### PR TITLE
[front] - feat(obs): treemap search

### DIFF
--- a/front/components/agent_builder/observability/charts/DatasourceRetrievalTreemapChart.tsx
+++ b/front/components/agent_builder/observability/charts/DatasourceRetrievalTreemapChart.tsx
@@ -48,6 +48,8 @@ interface TreemapContentProps {
   color?: string;
 }
 
+const RECTANGLE_LABEL_OFFSET = 8;
+
 function TreemapContent({
   x = 0,
   y = 0,
@@ -75,7 +77,7 @@ function TreemapContent({
         <>
           <text
             x={x + width / 2}
-            y={y + height / 2 - 8}
+            y={y + height / 2 - RECTANGLE_LABEL_OFFSET}
             textAnchor="middle"
             className="pointer-events-none truncate text-ellipsis fill-foreground text-xs font-medium dark:fill-foreground-night"
           >
@@ -83,7 +85,7 @@ function TreemapContent({
           </text>
           <text
             x={x + width / 2}
-            y={y + height / 2 + 8}
+            y={y + height / 2 + RECTANGLE_LABEL_OFFSET}
             textAnchor="middle"
             className="pointer-events-none fill-muted-foreground text-xs dark:fill-muted-foreground-night"
           >

--- a/front/components/agent_builder/observability/charts/DatasourceRetrievalTreemapChart.tsx
+++ b/front/components/agent_builder/observability/charts/DatasourceRetrievalTreemapChart.tsx
@@ -9,9 +9,8 @@ import { useObservabilityContext } from "@app/components/agent_builder/observabi
 import { ChartContainer } from "@app/components/agent_builder/observability/shared/ChartContainer";
 import { ChartTooltipCard } from "@app/components/agent_builder/observability/shared/ChartTooltip";
 import { getIndexedColor } from "@app/components/agent_builder/observability/utils";
-import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
 import { useAgentDatasourceRetrieval } from "@app/lib/swr/assistants";
-import { asDisplayName, isConnectorProvider } from "@app/types";
+import { asDisplayName } from "@app/types";
 
 interface TreemapNode {
   name: string;
@@ -19,18 +18,6 @@ interface TreemapNode {
   color: string;
 
   [key: string]: string | number;
-}
-
-function getDisplayNameForDataSourceName(dataSourceName: string): string {
-  if (dataSourceName.startsWith("managed-")) {
-    const parts = dataSourceName.slice("managed-".length).split("-");
-    const provider = parts[0];
-
-    if (isConnectorProvider(provider)) {
-      return CONNECTOR_CONFIGURATIONS[provider].name;
-    }
-  }
-  return dataSourceName;
 }
 
 interface TreemapContentProps {
@@ -147,7 +134,7 @@ export function DatasourceRetrievalTreemapChart({
 
       mcp.datasources.forEach((ds) => {
         flattenedData.push({
-          name: getDisplayNameForDataSourceName(ds.name),
+          name: ds.displayName,
           size: ds.count,
           color: serverColor,
         });

--- a/front/components/agent_builder/observability/charts/DatasourceRetrievalTreemapChart.tsx
+++ b/front/components/agent_builder/observability/charts/DatasourceRetrievalTreemapChart.tsx
@@ -9,11 +9,13 @@ import { useObservabilityContext } from "@app/components/agent_builder/observabi
 import { ChartContainer } from "@app/components/agent_builder/observability/shared/ChartContainer";
 import { ChartTooltipCard } from "@app/components/agent_builder/observability/shared/ChartTooltip";
 import { getIndexedColor } from "@app/components/agent_builder/observability/utils";
+import { isMCPServerConfiguration } from "@app/lib/actions/types/guards";
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
 import {
   useAgentConfiguration,
   useAgentDatasourceRetrieval,
 } from "@app/lib/swr/assistants";
+import type { WorkspaceType } from "@app/types";
 import { isConnectorProvider } from "@app/types";
 
 interface TreemapNode {
@@ -47,7 +49,7 @@ interface TreemapContentProps {
   color?: string;
 }
 
-function CustomizedContent({
+function TreemapContent({
   x = 0,
   y = 0,
   width = 0,
@@ -94,13 +96,15 @@ function CustomizedContent({
   );
 }
 
-export function DatasourceRetrievalTreemapChart({
-  workspaceId,
-  agentConfigurationId,
-}: {
-  workspaceId: string;
+interface DatasourceRetrievalTreemapChartProps {
+  owner: WorkspaceType;
   agentConfigurationId: string;
-}) {
+}
+
+export function DatasourceRetrievalTreemapChart({
+  owner,
+  agentConfigurationId,
+}: DatasourceRetrievalTreemapChartProps) {
   const { period, mode, selectedVersion } = useObservabilityContext();
 
   const {
@@ -109,14 +113,14 @@ export function DatasourceRetrievalTreemapChart({
     isDatasourceRetrievalLoading,
     isDatasourceRetrievalError,
   } = useAgentDatasourceRetrieval({
-    workspaceId,
+    workspaceId: owner.sId,
     agentConfigurationId,
     days: period,
     version: mode === "version" ? selectedVersion?.version : undefined,
   });
 
   const { agentConfiguration } = useAgentConfiguration({
-    workspaceId,
+    workspaceId: owner.sId,
     agentConfigurationId,
   });
 
@@ -126,7 +130,7 @@ export function DatasourceRetrievalTreemapChart({
     }
     const map = new Map<string, string>();
     agentConfiguration.actions.forEach((action) => {
-      if (action.type === "mcp_server_configuration" && action.name) {
+      if (isMCPServerConfiguration(action) && action.name) {
         map.set(action.id.toString(), action.name);
       }
     });
@@ -235,7 +239,7 @@ export function DatasourceRetrievalTreemapChart({
           dataKey="size"
           aspectRatio={4 / 3}
           isAnimationActive={false}
-          content={<CustomizedContent />}
+          content={<TreemapContent />}
         >
           <Tooltip
             cursor={false}

--- a/front/components/agent_builder/observability/charts/DatasourceRetrievalTreemapChart.tsx
+++ b/front/components/agent_builder/observability/charts/DatasourceRetrievalTreemapChart.tsx
@@ -9,10 +9,12 @@ import { useObservabilityContext } from "@app/components/agent_builder/observabi
 import { ChartContainer } from "@app/components/agent_builder/observability/shared/ChartContainer";
 import { ChartTooltipCard } from "@app/components/agent_builder/observability/shared/ChartTooltip";
 import { getIndexedColor } from "@app/components/agent_builder/observability/utils";
+import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
 import {
   useAgentConfiguration,
   useAgentDatasourceRetrieval,
 } from "@app/lib/swr/assistants";
+import { isConnectorProvider } from "@app/types";
 
 interface TreemapNode {
   name: string;
@@ -20,6 +22,18 @@ interface TreemapNode {
   color: string;
 
   [key: string]: string | number;
+}
+
+function getDisplayNameForDataSourceName(dataSourceName: string): string {
+  if (dataSourceName.startsWith("managed-")) {
+    const parts = dataSourceName.slice("managed-".length).split("-");
+    const provider = parts[0];
+
+    if (isConnectorProvider(provider)) {
+      return CONNECTOR_CONFIGURATIONS[provider].name;
+    }
+  }
+  return dataSourceName;
 }
 
 interface TreemapContentProps {
@@ -155,7 +169,7 @@ export function DatasourceRetrievalTreemapChart({
 
       mcp.datasources.forEach((ds) => {
         flattenedData.push({
-          name: ds.name,
+          name: getDisplayNameForDataSourceName(ds.name),
           size: ds.count,
           color: serverColor,
         });

--- a/front/components/agent_builder/observability/charts/DatasourceRetrievalTreemapChart.tsx
+++ b/front/components/agent_builder/observability/charts/DatasourceRetrievalTreemapChart.tsx
@@ -77,9 +77,9 @@ function TreemapContent({
             x={x + width / 2}
             y={y + height / 2 - 8}
             textAnchor="middle"
-            className="pointer-events-none fill-foreground text-xs font-medium dark:fill-foreground-night"
+            className="pointer-events-none truncate text-ellipsis fill-foreground text-xs font-medium dark:fill-foreground-night"
           >
-            {name.length > 20 ? `${name.slice(0, 17)}...` : name}
+            {name}
           </text>
           <text
             x={x + width / 2}
@@ -124,11 +124,12 @@ export function DatasourceRetrievalTreemapChart({
   });
 
   const mcpConfigNameMap = useMemo(() => {
+    const map = new Map<string, string>();
+
     if (!agentConfiguration) {
-      return new Map<string, string>();
+      return map;
     }
 
-    const map = new Map<string, string>();
     agentConfiguration.actions.forEach((action) => {
       if (isMCPServerConfiguration(action) && action.name) {
         map.set(action.id.toString(), asDisplayName(action.name));

--- a/front/components/agent_builder/observability/charts/DatasourceRetrievalTreemapChart.tsx
+++ b/front/components/agent_builder/observability/charts/DatasourceRetrievalTreemapChart.tsx
@@ -18,6 +18,8 @@ interface TreemapNode {
   name: string;
   size: number;
   color: string;
+
+  [key: string]: string | number;
 }
 
 interface TreemapContentProps {
@@ -38,7 +40,6 @@ function CustomizedContent({
   height = 0,
   name = "",
   value = 0,
-  depth = 0,
   color = INDEXED_COLORS[0],
 }: TreemapContentProps) {
   const shouldShowText = width > 50 && height > 30;
@@ -109,17 +110,12 @@ export function DatasourceRetrievalTreemapChart({
     if (!agentConfiguration) {
       return new Map<string, string>();
     }
-    console.log(">>>>> agentConfiguration.actions", agentConfiguration.actions);
     const map = new Map<string, string>();
     agentConfiguration.actions.forEach((action) => {
       if (action.type === "mcp_server_configuration" && action.name) {
-        console.log(
-          `>>>>> Mapping action ID ${action.id} -> name "${action.name}"`
-        );
         map.set(action.id.toString(), action.name);
       }
     });
-    console.log(">>>>> mcpConfigNameMap", map);
     return map;
   }, [agentConfiguration]);
 
@@ -128,7 +124,6 @@ export function DatasourceRetrievalTreemapChart({
       return { treemapData: null, legendItems: [] };
     }
 
-    console.log(">>>>> datasourceRetrieval", datasourceRetrieval);
     const mcpServerConfigIds = datasourceRetrieval.map(
       (mcp) => mcp.mcpServerConfigId
     );
@@ -148,10 +143,6 @@ export function DatasourceRetrievalTreemapChart({
       const displayName =
         mcpConfigNameMap.get(mcp.mcpServerConfigId.toString()) ??
         mcp.mcpServerName;
-
-      console.log(
-        `>>>>> Matching mcpServerConfigId "${mcp.mcpServerConfigId}" -> displayName "${displayName}" (found in map: ${mcpConfigNameMap.has(mcp.mcpServerConfigId)})`
-      );
 
       if (!seenServers.has(mcp.mcpServerConfigId)) {
         legend.push({

--- a/front/components/agent_builder/observability/charts/DatasourceRetrievalTreemapChart.tsx
+++ b/front/components/agent_builder/observability/charts/DatasourceRetrievalTreemapChart.tsx
@@ -15,7 +15,7 @@ import {
   useAgentConfiguration,
   useAgentDatasourceRetrieval,
 } from "@app/lib/swr/assistants";
-import { isConnectorProvider } from "@app/types";
+import { asDisplayName, isConnectorProvider } from "@app/types";
 
 interface TreemapNode {
   name: string;
@@ -127,10 +127,11 @@ export function DatasourceRetrievalTreemapChart({
     if (!agentConfiguration) {
       return new Map<string, string>();
     }
+
     const map = new Map<string, string>();
     agentConfiguration.actions.forEach((action) => {
       if (isMCPServerConfiguration(action) && action.name) {
-        map.set(action.id.toString(), action.name);
+        map.set(action.id.toString(), asDisplayName(action.name));
       }
     });
     return map;

--- a/front/components/agent_builder/observability/charts/DatasourceRetrievalTreemapChart.tsx
+++ b/front/components/agent_builder/observability/charts/DatasourceRetrievalTreemapChart.tsx
@@ -9,12 +9,8 @@ import { useObservabilityContext } from "@app/components/agent_builder/observabi
 import { ChartContainer } from "@app/components/agent_builder/observability/shared/ChartContainer";
 import { ChartTooltipCard } from "@app/components/agent_builder/observability/shared/ChartTooltip";
 import { getIndexedColor } from "@app/components/agent_builder/observability/utils";
-import { isMCPServerConfiguration } from "@app/lib/actions/types/guards";
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
-import {
-  useAgentConfiguration,
-  useAgentDatasourceRetrieval,
-} from "@app/lib/swr/assistants";
+import { useAgentDatasourceRetrieval } from "@app/lib/swr/assistants";
 import { asDisplayName, isConnectorProvider } from "@app/types";
 
 interface TreemapNode {
@@ -120,26 +116,6 @@ export function DatasourceRetrievalTreemapChart({
     version: mode === "version" ? selectedVersion?.version : undefined,
   });
 
-  const { agentConfiguration } = useAgentConfiguration({
-    workspaceId,
-    agentConfigurationId,
-  });
-
-  const mcpConfigNameMap = useMemo(() => {
-    const map = new Map<string, string>();
-
-    if (!agentConfiguration) {
-      return map;
-    }
-
-    agentConfiguration.actions.forEach((action) => {
-      if (isMCPServerConfiguration(action) && action.name) {
-        map.set(action.id.toString(), asDisplayName(action.name));
-      }
-    });
-    return map;
-  }, [agentConfiguration]);
-
   const { treemapData, legendItems } = useMemo(() => {
     if (!datasourceRetrieval.length) {
       return { treemapData: null, legendItems: [] };
@@ -162,8 +138,7 @@ export function DatasourceRetrievalTreemapChart({
         mcpServerConfigIds
       );
       const displayName =
-        mcpConfigNameMap.get(mcp.mcpServerConfigId.toString()) ??
-        mcp.mcpServerName;
+        asDisplayName(mcp.mcpServerConfigName) || mcp.mcpServerName;
 
       if (!seenServers.has(mcp.mcpServerConfigId)) {
         legend.push({
@@ -184,7 +159,7 @@ export function DatasourceRetrievalTreemapChart({
     });
 
     return { treemapData: flattenedData, legendItems: legend };
-  }, [datasourceRetrieval, mcpConfigNameMap]);
+  }, [datasourceRetrieval]);
 
   const renderTooltip = useCallback(
     (props: { payload?: { payload?: TreemapNode }[] }) => {

--- a/front/components/agent_builder/observability/charts/DatasourceRetrievalTreemapChart.tsx
+++ b/front/components/agent_builder/observability/charts/DatasourceRetrievalTreemapChart.tsx
@@ -213,8 +213,8 @@ export function DatasourceRetrievalTreemapChart({
 
   return (
     <ChartContainer
-      title="MCP Servers"
-      description="Number of documents retrieved per MCP server, grouped by datasource."
+      title="Documents retrieved by data sources (BETA)"
+      description="Number of documents retrieved per searches, grouped by datasource."
       isLoading={isDatasourceRetrievalLoading}
       errorMessage={
         isDatasourceRetrievalError

--- a/front/components/agent_builder/observability/charts/DatasourceRetrievalTreemapChart.tsx
+++ b/front/components/agent_builder/observability/charts/DatasourceRetrievalTreemapChart.tsx
@@ -44,8 +44,6 @@ interface TreemapContentProps {
   color?: string;
 }
 
-const RECTANGLE_LABEL_OFFSET = 8;
-
 function TreemapContent({
   x = 0,
   y = 0,
@@ -55,7 +53,7 @@ function TreemapContent({
   value = 0,
   color = INDEXED_COLORS[0],
 }: TreemapContentProps) {
-  const shouldShowText = width > 50 && height > 30;
+  const shouldShowText = width > 0 && height > 0;
 
   return (
     <g>
@@ -70,24 +68,22 @@ function TreemapContent({
         strokeWidth={2}
       />
       {shouldShowText && (
-        <>
-          <text
-            x={x + width / 2}
-            y={y + height / 2 - RECTANGLE_LABEL_OFFSET}
-            textAnchor="middle"
-            className="pointer-events-none truncate text-ellipsis fill-foreground text-xs font-medium dark:fill-foreground-night"
-          >
-            {name}
-          </text>
-          <text
-            x={x + width / 2}
-            y={y + height / 2 + RECTANGLE_LABEL_OFFSET}
-            textAnchor="middle"
-            className="pointer-events-none fill-muted-foreground text-xs dark:fill-muted-foreground-night"
-          >
-            {value}
-          </text>
-        </>
+        <foreignObject
+          x={x}
+          y={y}
+          width={width}
+          height={height}
+          pointerEvents="none"
+        >
+          <div className="flex h-full w-full flex-col items-center justify-center gap-0.5 overflow-hidden p-1 text-center">
+            <div className="w-full truncate text-ellipsis text-xs font-medium text-foreground dark:text-foreground-night">
+              {name}
+            </div>
+            <div className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+              {value}
+            </div>
+          </div>
+        </foreignObject>
       )}
     </g>
   );

--- a/front/components/agent_builder/observability/charts/DatasourceRetrievalTreemapChart.tsx
+++ b/front/components/agent_builder/observability/charts/DatasourceRetrievalTreemapChart.tsx
@@ -1,0 +1,244 @@
+import { useCallback, useMemo } from "react";
+import { ResponsiveContainer, Tooltip, Treemap } from "recharts";
+
+import {
+  CHART_HEIGHT,
+  INDEXED_COLORS,
+} from "@app/components/agent_builder/observability/constants";
+import { useObservabilityContext } from "@app/components/agent_builder/observability/ObservabilityContext";
+import { ChartContainer } from "@app/components/agent_builder/observability/shared/ChartContainer";
+import { ChartTooltipCard } from "@app/components/agent_builder/observability/shared/ChartTooltip";
+import { getIndexedColor } from "@app/components/agent_builder/observability/utils";
+import {
+  useAgentConfiguration,
+  useAgentDatasourceRetrieval,
+} from "@app/lib/swr/assistants";
+
+interface TreemapNode {
+  name: string;
+  size: number;
+  color: string;
+}
+
+interface TreemapContentProps {
+  x?: number;
+  y?: number;
+  width?: number;
+  height?: number;
+  name?: string;
+  value?: number;
+  depth?: number;
+  color?: string;
+}
+
+function CustomizedContent({
+  x = 0,
+  y = 0,
+  width = 0,
+  height = 0,
+  name = "",
+  value = 0,
+  depth = 0,
+  color = INDEXED_COLORS[0],
+}: TreemapContentProps) {
+  const shouldShowText = width > 50 && height > 30;
+
+  return (
+    <g>
+      <rect
+        x={x}
+        y={y}
+        width={width}
+        height={height}
+        fill="currentColor"
+        className={color}
+        stroke="white"
+        strokeWidth={2}
+      />
+      {shouldShowText && (
+        <>
+          <text
+            x={x + width / 2}
+            y={y + height / 2 - 8}
+            textAnchor="middle"
+            className="pointer-events-none fill-foreground text-xs font-medium dark:fill-foreground-night"
+          >
+            {name.length > 20 ? `${name.slice(0, 17)}...` : name}
+          </text>
+          <text
+            x={x + width / 2}
+            y={y + height / 2 + 8}
+            textAnchor="middle"
+            className="pointer-events-none fill-muted-foreground text-xs dark:fill-muted-foreground-night"
+          >
+            {value}
+          </text>
+        </>
+      )}
+    </g>
+  );
+}
+
+export function DatasourceRetrievalTreemapChart({
+  workspaceId,
+  agentConfigurationId,
+}: {
+  workspaceId: string;
+  agentConfigurationId: string;
+}) {
+  const { period, mode, selectedVersion } = useObservabilityContext();
+
+  const {
+    datasourceRetrieval,
+    totalRetrievals,
+    isDatasourceRetrievalLoading,
+    isDatasourceRetrievalError,
+  } = useAgentDatasourceRetrieval({
+    workspaceId,
+    agentConfigurationId,
+    days: period,
+    version: mode === "version" ? selectedVersion?.version : undefined,
+  });
+
+  const { agentConfiguration } = useAgentConfiguration({
+    workspaceId,
+    agentConfigurationId,
+  });
+
+  const mcpConfigNameMap = useMemo(() => {
+    if (!agentConfiguration) {
+      return new Map<string, string>();
+    }
+    console.log(">>>>> agentConfiguration.actions", agentConfiguration.actions);
+    const map = new Map<string, string>();
+    agentConfiguration.actions.forEach((action) => {
+      if (action.type === "mcp_server_configuration" && action.name) {
+        console.log(
+          `>>>>> Mapping action ID ${action.id} -> name "${action.name}"`
+        );
+        map.set(action.id.toString(), action.name);
+      }
+    });
+    console.log(">>>>> mcpConfigNameMap", map);
+    return map;
+  }, [agentConfiguration]);
+
+  const { treemapData, legendItems } = useMemo(() => {
+    if (!datasourceRetrieval.length) {
+      return { treemapData: null, legendItems: [] };
+    }
+
+    console.log(">>>>> datasourceRetrieval", datasourceRetrieval);
+    const mcpServerConfigIds = datasourceRetrieval.map(
+      (mcp) => mcp.mcpServerConfigId
+    );
+    const flattenedData: TreemapNode[] = [];
+    const legend: Array<{
+      key: string;
+      label: string;
+      colorClassName: string;
+    }> = [];
+    const seenServers = new Set<string>();
+
+    datasourceRetrieval.forEach((mcp) => {
+      const serverColor = getIndexedColor(
+        mcp.mcpServerConfigId,
+        mcpServerConfigIds
+      );
+      const displayName =
+        mcpConfigNameMap.get(mcp.mcpServerConfigId.toString()) ??
+        mcp.mcpServerName;
+
+      console.log(
+        `>>>>> Matching mcpServerConfigId "${mcp.mcpServerConfigId}" -> displayName "${displayName}" (found in map: ${mcpConfigNameMap.has(mcp.mcpServerConfigId)})`
+      );
+
+      if (!seenServers.has(mcp.mcpServerConfigId)) {
+        legend.push({
+          key: mcp.mcpServerConfigId,
+          label: displayName,
+          colorClassName: serverColor,
+        });
+        seenServers.add(mcp.mcpServerConfigId);
+      }
+
+      mcp.datasources.forEach((ds) => {
+        flattenedData.push({
+          name: ds.name,
+          size: ds.count,
+          color: serverColor,
+        });
+      });
+    });
+
+    return { treemapData: flattenedData, legendItems: legend };
+  }, [datasourceRetrieval, mcpConfigNameMap]);
+
+  const renderTooltip = useCallback(
+    (props: { payload?: { payload?: TreemapNode }[] }) => {
+      const { payload } = props;
+      if (!payload || !payload[0]) {
+        return null;
+      }
+
+      const data = payload[0].payload;
+      if (!data) {
+        return null;
+      }
+
+      const size = data.size ?? 0;
+      const percent =
+        totalRetrievals > 0 ? Math.round((size / totalRetrievals) * 100) : 0;
+
+      return (
+        <ChartTooltipCard
+          title={data.name}
+          rows={[
+            {
+              label: "Retrievals",
+              value: size,
+              percent,
+            },
+          ]}
+        />
+      );
+    },
+    [totalRetrievals]
+  );
+
+  return (
+    <ChartContainer
+      title="MCP Servers"
+      description="Number of documents retrieved per MCP server, grouped by datasource."
+      isLoading={isDatasourceRetrievalLoading}
+      errorMessage={
+        isDatasourceRetrievalError
+          ? "Failed to load datasource retrieval data."
+          : undefined
+      }
+      emptyMessage={
+        !treemapData || treemapData.length === 0
+          ? "No retrieval data for this period."
+          : undefined
+      }
+      height={CHART_HEIGHT}
+      legendItems={legendItems}
+    >
+      <ResponsiveContainer width="100%" height={CHART_HEIGHT}>
+        <Treemap
+          data={treemapData ?? []}
+          dataKey="size"
+          aspectRatio={4 / 3}
+          isAnimationActive={false}
+          content={<CustomizedContent />}
+        >
+          <Tooltip
+            cursor={false}
+            content={renderTooltip}
+            wrapperStyle={{ outline: "none" }}
+          />
+        </Treemap>
+      </ResponsiveContainer>
+    </ChartContainer>
+  );
+}

--- a/front/components/agent_builder/observability/charts/DatasourceRetrievalTreemapChart.tsx
+++ b/front/components/agent_builder/observability/charts/DatasourceRetrievalTreemapChart.tsx
@@ -15,7 +15,6 @@ import {
   useAgentConfiguration,
   useAgentDatasourceRetrieval,
 } from "@app/lib/swr/assistants";
-import type { WorkspaceType } from "@app/types";
 import { isConnectorProvider } from "@app/types";
 
 interface TreemapNode {
@@ -97,12 +96,12 @@ function TreemapContent({
 }
 
 interface DatasourceRetrievalTreemapChartProps {
-  owner: WorkspaceType;
+  workspaceId: string;
   agentConfigurationId: string;
 }
 
 export function DatasourceRetrievalTreemapChart({
-  owner,
+  workspaceId,
   agentConfigurationId,
 }: DatasourceRetrievalTreemapChartProps) {
   const { period, mode, selectedVersion } = useObservabilityContext();
@@ -113,14 +112,14 @@ export function DatasourceRetrievalTreemapChart({
     isDatasourceRetrievalLoading,
     isDatasourceRetrievalError,
   } = useAgentDatasourceRetrieval({
-    workspaceId: owner.sId,
+    workspaceId,
     agentConfigurationId,
     days: period,
     version: mode === "version" ? selectedVersion?.version : undefined,
   });
 
   const { agentConfiguration } = useAgentConfiguration({
-    workspaceId: owner.sId,
+    workspaceId,
     agentConfigurationId,
   });
 

--- a/front/components/observability/AgentObservability.tsx
+++ b/front/components/observability/AgentObservability.tsx
@@ -10,6 +10,7 @@ import {
   ValueCard,
 } from "@dust-tt/sparkle";
 
+import { DatasourceRetrievalTreemapChart } from "@app/components/agent_builder/observability/charts/DatasourceRetrievalTreemapChart";
 import { LatencyChart } from "@app/components/agent_builder/observability/charts/LatencyChart";
 import { SourceChart } from "@app/components/agent_builder/observability/charts/SourceChart";
 import { ToolUsageChart } from "@app/components/agent_builder/observability/charts/ToolUsageChart";
@@ -186,6 +187,11 @@ export function AgentObservability({
         />
         <Separator />
         <SourceChart
+          workspaceId={workspaceId}
+          agentConfigurationId={agentConfigurationId}
+        />
+        <Separator />
+        <DatasourceRetrievalTreemapChart
           workspaceId={workspaceId}
           agentConfigurationId={agentConfigurationId}
         />

--- a/front/components/observability/AgentObservability.tsx
+++ b/front/components/observability/AgentObservability.tsx
@@ -23,6 +23,7 @@ import {
   useAgentAnalytics,
   useAgentObservabilitySummary,
 } from "@app/lib/swr/assistants";
+import { useFeatureFlags } from "@app/lib/swr/workspaces";
 
 interface AgentObservabilityProps {
   workspaceId: string;
@@ -36,6 +37,7 @@ export function AgentObservability({
   isCustomAgent,
 }: AgentObservabilityProps) {
   const { period, mode, selectedVersion } = useObservabilityContext();
+  const { featureFlags } = useFeatureFlags({ workspaceId });
 
   const isTimeRangeMode = mode === "timeRange";
 
@@ -190,11 +192,15 @@ export function AgentObservability({
           workspaceId={workspaceId}
           agentConfigurationId={agentConfigurationId}
         />
-        <Separator />
-        <DatasourceRetrievalTreemapChart
-          workspaceId={workspaceId}
-          agentConfigurationId={agentConfigurationId}
-        />
+        {featureFlags.includes("agent_tool_outputs_analytics") && (
+          <>
+            <Separator />
+            <DatasourceRetrievalTreemapChart
+              workspaceId={workspaceId}
+              agentConfigurationId={agentConfigurationId}
+            />
+          </>
+        )}
         <Separator />
         <ToolUsageChart
           workspaceId={workspaceId}

--- a/front/lib/api/assistant/observability/datasource_retrieval.ts
+++ b/front/lib/api/assistant/observability/datasource_retrieval.ts
@@ -1,5 +1,6 @@
 import type { estypes } from "@elastic/elasticsearch";
 
+import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import {
   AGENT_DOCUMENT_OUTPUTS_ALIAS_NAME,
   bucketsToArray,
@@ -34,9 +35,24 @@ type DatasourceRetrievalAggs = {
   by_mcp_server_config?: estypes.AggregationsMultiBucketAggregateBase<McpServerConfigBucket>;
 };
 
-export async function fetchDatasourceRetrievalMetrics(
-  baseQuery: estypes.QueryDslQueryContainer
-): Promise<Result<DatasourceRetrievalData[], Error>> {
+export async function fetchDatasourceRetrievalMetrics({
+  workspaceId,
+  agentId,
+  days,
+  version,
+}: {
+  workspaceId: string;
+  agentId: string;
+  days?: number;
+  version?: string;
+}): Promise<Result<DatasourceRetrievalData[], Error>> {
+  const baseQuery = buildAgentAnalyticsBaseQuery({
+    workspaceId,
+    agentId,
+    days,
+    version,
+  });
+
   const aggs: Record<string, estypes.AggregationsAggregationContainer> = {
     by_mcp_server_config: {
       terms: {

--- a/front/lib/api/assistant/observability/datasource_retrieval.ts
+++ b/front/lib/api/assistant/observability/datasource_retrieval.ts
@@ -1,0 +1,115 @@
+import type { estypes } from "@elastic/elasticsearch";
+
+import {
+  AGENT_DOCUMENT_OUTPUTS_ALIAS_NAME,
+  bucketsToArray,
+  withEs,
+} from "@app/lib/api/elasticsearch";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+export type DatasourceRetrievalData = {
+  mcpServerConfigId: string;
+  mcpServerName: string;
+  count: number;
+  datasources: {
+    name: string;
+    count: number;
+  }[];
+};
+
+type TermBucket = {
+  key: string;
+  doc_count: number;
+};
+
+type DatasourceBucket = TermBucket;
+
+type McpServerConfigBucket = TermBucket & {
+  by_datasource?: estypes.AggregationsMultiBucketAggregateBase<DatasourceBucket>;
+  by_mcp_server_name?: estypes.AggregationsMultiBucketAggregateBase<TermBucket>;
+};
+
+type DatasourceRetrievalAggs = {
+  by_mcp_server_config?: estypes.AggregationsMultiBucketAggregateBase<McpServerConfigBucket>;
+};
+
+export async function fetchDatasourceRetrievalMetrics(
+  baseQuery: estypes.QueryDslQueryContainer
+): Promise<Result<DatasourceRetrievalData[], Error>> {
+  const aggs: Record<string, estypes.AggregationsAggregationContainer> = {
+    by_mcp_server_config: {
+      terms: {
+        field: "mcp_server_configuration_id",
+        size: 20,
+        order: { _count: "desc" },
+      },
+      aggs: {
+        by_mcp_server_name: {
+          terms: {
+            field: "mcp_server_name",
+            size: 1,
+          },
+        },
+        by_datasource: {
+          terms: {
+            field: "data_source_name",
+            size: 50,
+          },
+        },
+      },
+    },
+  };
+
+  const result = await withEs((client) =>
+    client.search({
+      index: AGENT_DOCUMENT_OUTPUTS_ALIAS_NAME,
+      query: baseQuery,
+      aggs,
+      size: 0,
+    })
+  );
+
+  if (result.isErr()) {
+    return new Err(
+      new Error(
+        `Failed to query datasource retrieval metrics: ${result.error.message}`
+      )
+    );
+  }
+
+  const response = result.value as estypes.SearchResponse<
+    never,
+    DatasourceRetrievalAggs
+  >;
+  const mcpServerConfigBuckets = bucketsToArray<McpServerConfigBucket>(
+    response.aggregations?.by_mcp_server_config?.buckets
+  );
+
+  const data: DatasourceRetrievalData[] = mcpServerConfigBuckets.map(
+    (mcpConfigBucket) => {
+      const datasourceBuckets = bucketsToArray<DatasourceBucket>(
+        mcpConfigBucket.by_datasource?.buckets
+      );
+
+      const mcpServerNameBuckets = bucketsToArray<TermBucket>(
+        mcpConfigBucket.by_mcp_server_name?.buckets
+      );
+
+      return {
+        mcpServerConfigId: mcpConfigBucket.key,
+        mcpServerName:
+          mcpServerNameBuckets.length > 0
+            ? mcpServerNameBuckets[0].key
+            : mcpConfigBucket.key,
+        count: mcpConfigBucket.doc_count,
+        datasources: datasourceBuckets.map((dsBucket) => ({
+          name: dsBucket.key,
+          count: dsBucket.doc_count,
+        })),
+      };
+    }
+  );
+
+  return new Ok(data);
+}

--- a/front/lib/api/assistant/observability/datasource_retrieval.ts
+++ b/front/lib/api/assistant/observability/datasource_retrieval.ts
@@ -6,6 +6,7 @@ import {
   bucketsToArray,
   withEs,
 } from "@app/lib/api/elasticsearch";
+import type { Authenticator } from "@app/lib/auth";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
@@ -35,19 +36,21 @@ type DatasourceRetrievalAggs = {
   by_mcp_server_config?: estypes.AggregationsMultiBucketAggregateBase<McpServerConfigBucket>;
 };
 
-export async function fetchDatasourceRetrievalMetrics({
-  workspaceId,
-  agentId,
-  days,
-  version,
-}: {
-  workspaceId: string;
-  agentId: string;
-  days?: number;
-  version?: string;
-}): Promise<Result<DatasourceRetrievalData[], Error>> {
+export async function fetchDatasourceRetrievalMetrics(
+  auth: Authenticator,
+  {
+    agentId,
+    days,
+    version,
+  }: {
+    agentId: string;
+    days?: number;
+    version?: string;
+  }
+): Promise<Result<DatasourceRetrievalData[], Error>> {
+  const workspace = auth.getNonNullableWorkspace();
   const baseQuery = buildAgentAnalyticsBaseQuery({
-    workspaceId,
+    workspaceId: workspace.sId,
     agentId,
     days,
     version,

--- a/front/lib/api/assistant/observability/datasource_retrieval.ts
+++ b/front/lib/api/assistant/observability/datasource_retrieval.ts
@@ -115,6 +115,7 @@ export async function fetchDatasourceRetrievalMetrics(
     response.aggregations?.by_mcp_server_config?.buckets
   );
 
+  // Filtering out JIT MCP servers
   const configModelIds = Array.from(
     new Set(mcpServerConfigBuckets.map((b) => b.key))
   ).filter((id) => Number.isFinite(id) && id > 0);
@@ -146,7 +147,7 @@ export async function fetchDatasourceRetrievalMetrics(
   const serverConfigByModelId = new Map(
     serverConfigs.map((cfg) => [cfg.id, cfg])
   );
-  const dataSourceBySId = new Map(dataSources.map((ds) => [ds.sId, ds]));
+  const dataSourceById = new Map(dataSources.map((ds) => [ds.sId, ds]));
 
   const data: DatasourceRetrievalData[] = mcpServerConfigBuckets.map(
     (mcpConfigBucket) => {
@@ -167,7 +168,7 @@ export async function fetchDatasourceRetrievalMetrics(
         mcpServerName,
         count: mcpConfigBucket.doc_count,
         datasources: datasourceBuckets.map((dsBucket) => {
-          const dataSource = dataSourceBySId.get(dsBucket.key);
+          const dataSource = dataSourceById.get(dsBucket.key);
           return {
             dataSourceId: dsBucket.key,
             displayName: dataSource

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -1095,8 +1095,11 @@ export function useAgentDatasourceRetrieval({
   disabled?: boolean;
 }) {
   const fetcherFn: Fetcher<GetDatasourceRetrievalResponse> = fetcher;
-  const versionParam = version ? `&version=${encodeURIComponent(version)}` : "";
-  const key = `/api/w/${workspaceId}/assistant/agent_configurations/${agentConfigurationId}/observability/datasource-retrieval?days=${days}${versionParam}`;
+  const params = new URLSearchParams({ days: days.toString() });
+  if (version) {
+    params.set("version", version);
+  }
+  const key = `/api/w/${workspaceId}/assistant/agent_configurations/${agentConfigurationId}/observability/datasource-retrieval?${params.toString()}`;
 
   const { data, error, isValidating } = useSWRWithDefaults(
     disabled ? null : key,

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -20,6 +20,7 @@ import type { FetchAssistantTemplatesResponse } from "@app/pages/api/templates";
 import type { FetchAgentTemplateResponse } from "@app/pages/api/templates/[tId]";
 import type { GetAgentConfigurationsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
 import type { GetAgentMcpConfigurationsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/mcp_configurations";
+import type { GetDatasourceRetrievalResponse } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/datasource-retrieval";
 import type { GetErrorRateResponse } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/error_rate";
 import type { GetFeedbackDistributionResponse } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/feedback-distribution";
 import type { GetLatencyResponse } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/latency";
@@ -1077,6 +1078,37 @@ export function useAgentToolStepIndex({
     isToolStepIndexLoading: !error && !data && !disabled,
     isToolStepIndexError: error,
     isToolStepIndexValidating: isValidating,
+  };
+}
+
+export function useAgentDatasourceRetrieval({
+  workspaceId,
+  agentConfigurationId,
+  days = DEFAULT_PERIOD_DAYS,
+  version,
+  disabled,
+}: {
+  workspaceId: string;
+  agentConfigurationId: string;
+  days?: number;
+  version?: string;
+  disabled?: boolean;
+}) {
+  const fetcherFn: Fetcher<GetDatasourceRetrievalResponse> = fetcher;
+  const versionParam = version ? `&version=${encodeURIComponent(version)}` : "";
+  const key = `/api/w/${workspaceId}/assistant/agent_configurations/${agentConfigurationId}/observability/datasource-retrieval?days=${days}${versionParam}`;
+
+  const { data, error, isValidating } = useSWRWithDefaults(
+    disabled ? null : key,
+    fetcherFn
+  );
+
+  return {
+    datasourceRetrieval: data?.datasources ?? emptyArray(),
+    totalRetrievals: data?.total ?? 0,
+    isDatasourceRetrievalLoading: !error && !data && !disabled,
+    isDatasourceRetrievalError: error,
+    isDatasourceRetrievalValidating: isValidating,
   };
 }
 

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/datasource-retrieval.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/datasource-retrieval.ts
@@ -77,14 +77,15 @@ async function handler(
 
       const days = q.data.days;
       const version = q.data.version;
-      const owner = auth.getNonNullableWorkspace();
 
-      const datasourceRetrievalResult = await fetchDatasourceRetrievalMetrics({
-        workspaceId: owner.sId,
-        agentId: assistant.sId,
-        days,
-        version,
-      });
+      const datasourceRetrievalResult = await fetchDatasourceRetrievalMetrics(
+        auth,
+        {
+          agentId: assistant.sId,
+          days,
+          version,
+        }
+      );
 
       if (datasourceRetrievalResult.isErr()) {
         return apiError(req, res, {

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/datasource-retrieval.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/datasource-retrieval.ts
@@ -1,0 +1,121 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+
+import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import type { DatasourceRetrievalData } from "@app/lib/api/assistant/observability/datasource_retrieval";
+import { fetchDatasourceRetrievalMetrics } from "@app/lib/api/assistant/observability/datasource_retrieval";
+import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+
+const QuerySchema = z.object({
+  days: z.coerce.number().positive().optional(),
+  version: z.string().optional(),
+});
+
+export type GetDatasourceRetrievalResponse = {
+  datasources: DatasourceRetrievalData[];
+  total: number;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetDatasourceRetrievalResponse>>,
+  auth: Authenticator
+) {
+  if (typeof req.query.aId !== "string") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid agent configuration ID.",
+      },
+    });
+  }
+
+  const assistant = await getAgentConfiguration(auth, {
+    agentId: req.query.aId,
+    variant: "light",
+  });
+
+  if (!assistant || (!assistant.canRead && !auth.isAdmin())) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "agent_configuration_not_found",
+        message: "The agent you're trying to access was not found.",
+      },
+    });
+  }
+
+  if (!assistant.canEdit && !auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "app_auth_error",
+        message: "Only editors can get agent observability.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      const q = QuerySchema.safeParse(req.query);
+      if (!q.success) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid query parameters: ${q.error.message}`,
+          },
+        });
+      }
+
+      const days = q.data.days ?? DEFAULT_PERIOD_DAYS;
+      const version = q.data.version;
+      const owner = auth.getNonNullableWorkspace();
+
+      const baseQuery = buildAgentAnalyticsBaseQuery({
+        workspaceId: owner.sId,
+        agentId: assistant.sId,
+        days,
+        version,
+      });
+
+      const datasourceRetrievalResult =
+        await fetchDatasourceRetrievalMetrics(baseQuery);
+
+      if (datasourceRetrievalResult.isErr()) {
+        const e = datasourceRetrievalResult.error;
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: `Failed to retrieve datasource retrieval metrics: ${e.message}`,
+          },
+        });
+      }
+
+      const datasources = datasourceRetrievalResult.value;
+      const total = datasources.reduce((sum, ds) => sum + ds.count, 0);
+
+      return res.status(200).json({
+        datasources,
+        total,
+      });
+    }
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);


### PR DESCRIPTION
## Description

This PR adds a treemap visualization to the agent observability dashboard to show document retrieval patterns by datasource. The chart aggregates Elasticsearch data showing how many documents are retrieved per search, grouped by datasource and organized by MCP server configuration. The feature is gated behind the `agent_tool_outputs_analytics` feature flag and builds on the analytics infrastructure introduced in PR #19311.

The treemap displays user-friendly names for managed datasources by mapping internal naming conventions to connector provider names, and uses custom names for MCP server configurations when available.

## Risk

Low - feature is behind the `agent_tool_outputs_analytics` feature flag.

## Tests

- [x] Locally
- [x] Front-edge

## Deploy Plan

Deploy front
