### PR TITLE
[front] feat: Make Dust smarter with connected tools at onboarding

### DIFF
--- a/front/hooks/useSubmitMessage.ts
+++ b/front/hooks/useSubmitMessage.ts
@@ -59,7 +59,8 @@ export function useSubmitMessage({
                   url: contentFragment.url,
                   context: {
                     timezone:
-                      Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC",
+                      Intl.DateTimeFormat().resolvedOptions().timeZone ||
+                      "Etc/UTC",
                     profilePictureUrl: user.image,
                   },
                 }),
@@ -80,7 +81,8 @@ export function useSubmitMessage({
                   nodeDataSourceViewId: contentFragment.dataSourceView.sId,
                   context: {
                     timezone:
-                      Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC",
+                      Intl.DateTimeFormat().resolvedOptions().timeZone ||
+                      "Etc/UTC",
                     profilePictureUrl: user.image,
                   },
                 }),
@@ -115,7 +117,7 @@ export function useSubmitMessage({
             content: input,
             context: {
               timezone:
-                Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC",
+                Intl.DateTimeFormat().resolvedOptions().timeZone || "Etc/UTC",
               profilePictureUrl: user.image,
               clientSideMCPServerIds,
             },

--- a/front/lib/api/assistant/onboarding.ts
+++ b/front/lib/api/assistant/onboarding.ts
@@ -154,10 +154,9 @@ function buildOnboardingPrompt(options: {
     options.userJobType as JobType | null
   );
 
-  // Build the tool setup directives for the first message (max 2, on same line).
+  // We want to display on the best 2 tools maximum
   const topTools = tools.slice(0, 2);
 
-  // Check if any of the initial tools are already configured
   const alreadyConfiguredTopTool = topTools.find((tool) =>
     options.configuredTools.includes(tool)
   );
@@ -190,18 +189,15 @@ function buildOnboardingPrompt(options: {
     }
   }
 
-  // Build suggested tool names for reference
   const suggestedTopToolNames = topTools
     .map((sId) => asDisplayName(sId))
     .join(", ");
 
-  // Build toolSetup directives for "connect more tools" flow
   const otherTools = tools.slice(2);
   const otherToolSetupDirectives = otherTools
     .map((sId) => `:toolSetup[Connect ${asDisplayName(sId)}]{sId=${sId}}`)
     .join(" ");
 
-  // Build the first message section based on whether a tool is already configured
   const firstMessageSection = alreadyConfiguredTopTool
     ? buildFirstMessageWithConfiguredTool(alreadyConfiguredTopTool)
     : buildFirstMessageWithToolSetup(
@@ -241,7 +237,7 @@ ${userContext}
 - Keep task suggestions universal - they should work for ANY user of that tool
 - When describing tools, use only their official descriptions provided below
 
-## Quick replies must match the data found
+### Quick replies must match the data found
 
 After showing results from any tool use:
 1. Present the results with specific names/titles/dates
@@ -249,7 +245,7 @@ After showing results from any tool use:
 3. Include "Automate this" as ONE option among the actions - not the main focus
 
 **Quick replies should be specific to what you found:**
-- Found emails from Sarah and Mike → :quickReply[Reply to Sarah]{...} :quickReply[Summarize Mike's email]{...}
+- Found emails from Sarah and Mike → :quickReply[Draft a reply to Sarah]{...} :quickReply[Summarize Mike's email]{...}
 - Found PR reviews pending → :quickReply[Show PR details]{...} :quickReply[List my open PRs]{...}
 - Found Notion pages → :quickReply[Open recent page]{...} :quickReply[Search for...]{...}
 
@@ -258,13 +254,10 @@ After showing results from any tool use:
 ## Automation flow
 
 When user wants to automate (clicks "Automate this" or asks for it):
-1. Ask for timezone:
-   :quickReply[Eastern US]{message="My timezone is America/New_York"} :quickReply[Pacific US]{message="My timezone is America/Los_Angeles"} :quickReply[Europe/Paris]{message="My timezone is Europe/Paris"} :quickReply[Other]{message="My timezone is different"}
-2. Call create_schedule_trigger with:
-   - name: Short description (e.g., "Daily email summary")
-   - schedule: Natural language (e.g., "every weekday at 9am")
-   - prompt: Start with @${options.username} so user gets pinged
-   - timezone: The IANA timezone provided
+Call create_schedule_trigger with:
+- name: Short description (e.g., "Daily email summary")
+- schedule: Natural language (e.g., "every weekday at 9am")
+- prompt: Start with @${options.username} so user gets pinged
 
 ## Directive reference
 
@@ -378,11 +371,11 @@ Query guidance: ${queryGuidance}
 1. Welcome the user to Dust and mention you noticed ${toolName} was already connected, so you went ahead and checked it
    (e.g., "Welcome to Dust! 👋 I noticed you already have ${toolName} connected, so I took a look...")
 2. Share what you found in a conversational way (e.g., "I see you have an email from Roger 2 days ago...")
-3. End with **actionable quick replies based on the actual data found** (e.g., "Reply to Roger", "Summarize this email")
+3. End with **actionable quick replies based on the actual data found** (e.g., "Draft a reply to Roger", "Summarize this email")
 4. Include "Automate this" as one option among the quick replies
 
 Example quick replies for Gmail with emails from Sarah and a Datadog digest:
-:quickReply[Reply to Sarah]{message="Help me reply to Sarah's email"} :quickReply[Summarize Datadog digest]{message="Summarize the Datadog digest"} :quickReply[Automate daily summary]{message="Send me a daily email summary every morning"}
+:quickReply[Draft a reply to Sarah]{message="Draft a reply to Sarah's email"} :quickReply[Summarize Datadog digest]{message="Summarize the Datadog digest"} :quickReply[Automate daily summary]{message="Send me a daily email summary every morning"}
 
 If you don't find relevant data:
 - Still welcome the user and mention the tool is connected

--- a/front/lib/api/assistant/onboarding.ts
+++ b/front/lib/api/assistant/onboarding.ts
@@ -154,7 +154,6 @@ function buildOnboardingPrompt(options: {
     options.userJobType as JobType | null
   );
 
-  // We want to display on the best 2 tools maximum
   const topTools = tools.slice(0, 2);
 
   const alreadyConfiguredTopTool = topTools.find((tool) =>
@@ -213,10 +212,8 @@ ${userContext}
 ## CRITICAL RULES
 
 1. EVERY message MUST end with at least one interactive element (toolSetup or quickReply)
-2. Keep messages SHORT - 3-4 lines maximum
-3. Be direct and action-focused - get to the tool connection quickly
-
-### Do not hallucinate
+2. Be direct and action-focused - get to the tool connection quickly
+3. You MUST NOT hallucinate:
 - NEVER suggest cross-tool queries like "get answers from multiple sources"
 - NEVER assume what data the user has (no "find your design docs", "search your specs", etc.)
 - NEVER invent role-specific scenarios (no "as a designer, you can search design feedback...")

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/onboarding-followup.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/onboarding-followup.ts
@@ -65,9 +65,7 @@ async function handler(
 
   const conversation = conversationRes.value;
 
-  const followUpPrompt = buildOnboardingFollowUpPrompt(toolId, {
-    username: user.username,
-  });
+  const followUpPrompt = buildOnboardingFollowUpPrompt(toolId);
 
   const messageRes = await postUserMessage(auth, {
     conversation,


### PR DESCRIPTION
Fixes https://github.com/dust-tt/tasks/issues/5754

## Description

This PR aims at making Dust agent better with tools during onboarding by adjusting its prompting. 
Specifically, it aims at 
- Make it more consistent with quickReplies for tools connections, sometimes it will just list tools _without_ offering the nice quick reply.
- Suggest more often to automate (i.e create schedule) but make it less of a focus, more a subtle nudge.
- Handle cases when the user has already a high priority tool connected (e.g gmail) - this is supposed to be super rare, but right now the model is a bit "stuck" in this situation.

Not related improvement: we are removing the "timezone" step as it's no longer necessary, we can get the timezone after a user has posted its first message.

## Tests

<details><summary>Tool already connected after onboarding conversation was created</summary>
<p>

<img width="936" height="958" alt="CleanShot 2025-12-31 at 08 07 16" src="https://github.com/user-attachments/assets/ca5b7dfd-5b3c-4438-83fe-6de1fd339503" />

</p>
</details> 

<details><summary>Tool already connected before onboarding conversation was created</summary>
<p>

<img width="667" height="761" alt="CleanShot 2025-12-30 at 10 16 42" src="https://github.com/user-attachments/assets/31b8b136-77ba-4847-8cc7-6e71904bf28a" />

</p>
</details> 

<details><summary>Happy path (clicked on "automate this")</summary>
<p>

<img width="660" height="1207" alt="image" src="https://github.com/user-attachments/assets/ba54bee7-58e8-4bb2-a827-b2da6dd2c3b1" />


</p>
</details> 

<details><summary>Connect more tools</summary>
<p>

<img width="834" height="1123" alt="image" src="https://github.com/user-attachments/assets/eac48398-84ae-4109-93dd-e11c909842f0" />


</p>
</details> 

## Risk

Standard
Blast radius: all new onboarding conversations

## Deploy Plan

- [ ] Deploy front