### PR TITLE
[Front] fix(skills): show placeholder in instructions editor + match font styles

### DIFF
--- a/front/components/skill_builder/SkillBuilderAgentFacingDescriptionSection.tsx
+++ b/front/components/skill_builder/SkillBuilderAgentFacingDescriptionSection.tsx
@@ -92,7 +92,7 @@ export function SkillBuilderAgentFacingDescriptionSection() {
           <TextArea
             ref={registerRef}
             placeholder="When should this skill be used? What is this skill good for?"
-            className="min-h-24"
+            className="min-h-24 text-base placeholder:italic placeholder:text-gray-400"
             onChange={(e) => handleDescriptionChange(e, onChange)}
             error={hasError ? errorMessage : undefined}
             showErrorLabel={hasError}

--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -133,7 +133,7 @@ export function SkillBuilderInstructionsEditor({
   const editor = useEditor(
     {
       extensions,
-      content: field.value,
+      content: field.value || undefined, // display placeholder if instructions are empty
       contentType: "markdown",
       onUpdate: ({ editor, transaction }) => {
         if (transaction.docChanged) {


### PR DESCRIPTION
Closes : https://github.com/dust-tt/tasks/issues/5768

## Description

- Fix instructions editor placeholder not showing when empty (TipTap needs `undefined` not empty string to create paragraph node)
- Match font size and placeholder styling between agent description textarea and instructions editor

## Tests

Local.

https://github.com/user-attachments/assets/95a4eefe-a9b0-4dcb-808b-52826f02f452



## Risk

Low.

## Deploy Plan

Deploy front.

