### PR TITLE
[Front] feat(skills): make userFacingDescription mandatory in API

### DIFF
--- a/front/pages/api/w/[wId]/skills/[sId]/index.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.ts
@@ -47,7 +47,7 @@ export type DeleteSkillConfigurationResponseBody = {
 const PatchSkillConfigurationRequestBodySchema = t.type({
   name: t.string,
   agentFacingDescription: t.string,
-  userFacingDescription: t.union([t.string, t.null]),
+  userFacingDescription: t.string,
   instructions: t.string,
   icon: t.union([t.string, t.null]),
   tools: t.array(

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -42,7 +42,7 @@ const SkillStatusSchema = t.union([
 const PostSkillConfigurationRequestBodySchema = t.type({
   name: t.string,
   agentFacingDescription: t.string,
-  userFacingDescription: t.union([t.string, t.null]),
+  userFacingDescription: t.string,
   instructions: t.string,
   icon: t.union([t.string, t.null]),
   tools: t.array(


### PR DESCRIPTION
## Description

This PR is a small follow-up of https://github.com/dust-tt/dust/pull/19473

Now that `userFacingDescription` is required on the frontend side, we can enforce it at API endpoint level.

## Tests

## Risk

Low.

## Deploy Plan

Deploy front.
