### PR TITLE
Scrub workspace workflow use workspace metadata to support custom  retention delay

### DIFF
--- a/front/lib/data_retention.ts
+++ b/front/lib/data_retention.ts
@@ -4,8 +4,7 @@ import isNumber from "lodash/isNumber";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentDataRetentionModel } from "@app/lib/models/agent/agent_data_retention";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
-
-export const WORKSPACE_DEFAULT_RETENTION_DAYS = 30;
+import { WORKSPACE_DEFAULT_RETENTION_DAYS } from "@app/temporal/scrub_workspace/config";
 
 export type DataRetentionConfig = {
   workspace: number;
@@ -48,7 +47,7 @@ export const getWorkspaceDataRetention = async (
 
   if (
     isNumber(customRetention) &&
-    customRetention >= 0 &&
+    customRetention >= 7 &&
     customRetention <= 1000
   ) {
     return customRetention;

--- a/front/lib/data_retention.ts
+++ b/front/lib/data_retention.ts
@@ -5,7 +5,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { AgentDataRetentionModel } from "@app/lib/models/agent/agent_data_retention";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 
-const WORKSPACE_DEFAULT_RETENTION_DAYS = 30;
+export const WORKSPACE_DEFAULT_RETENTION_DAYS = 30;
 
 export type DataRetentionConfig = {
   workspace: number;

--- a/front/migrations/20240515_scrub_workspaces.ts
+++ b/front/migrations/20240515_scrub_workspaces.ts
@@ -70,5 +70,8 @@ const scrubWorkspaces = async (execute: boolean) => {
 };
 
 makeScript({}, async ({ execute }) => {
-  await scrubWorkspaces(execute);
+  console.error(
+    "Not scrubbing workspaces: script needs to be adapted to use workspace data retention (in workspace metadata)."
+  );
+  // await scrubWorkspaces(execute);
 });

--- a/front/migrations/20240515_scrub_workspaces.ts
+++ b/front/migrations/20240515_scrub_workspaces.ts
@@ -7,17 +7,13 @@ import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import logger from "@app/logger/logger";
 import { makeScript } from "@app/scripts/helpers";
 import { launchImmediateWorkspaceScrubWorkflow } from "@app/temporal/scrub_workspace/client";
-import { DATA_RETENTION_PERIOD_IN_DAYS } from "@app/temporal/scrub_workspace/config";
 
 const scrubWorkspaces = async (execute: boolean) => {
   const endedSubs = await SubscriptionModel.findAll({
     where: {
       // end date at least 30 days ago
       endDate: {
-        [Op.lt]: new Date(
-          new Date().getTime() -
-            DATA_RETENTION_PERIOD_IN_DAYS * 24 * 60 * 60 * 1000
-        ),
+        [Op.lt]: new Date(new Date().getTime() - 30 * 24 * 60 * 60 * 1000),
       },
     },
   });
@@ -50,10 +46,7 @@ const scrubWorkspaces = async (execute: boolean) => {
             (s) =>
               !s.endDate ||
               s.endDate >
-                new Date(
-                  new Date().getTime() -
-                    DATA_RETENTION_PERIOD_IN_DAYS * 24 * 60 * 60 * 1000
-                )
+                new Date(new Date().getTime() - 30 * 24 * 60 * 60 * 1000)
           )
         ) {
           return;

--- a/front/temporal/scrub_workspace/activities.ts
+++ b/front/temporal/scrub_workspace/activities.ts
@@ -16,6 +16,7 @@ import {
   unsafeGetWorkspacesByModelId,
 } from "@app/lib/api/workspace";
 import { Authenticator } from "@app/lib/auth";
+import { getWorkspaceDataRetention } from "@app/lib/data_retention";
 import {
   FREE_NO_PLAN_CODE,
   FREE_TEST_PLAN_CODE,
@@ -72,6 +73,16 @@ export async function sendDataDeletionEmail({
     );
     throw e;
   }
+}
+
+export async function getWorkspaceRetentionDays({
+  workspaceId,
+}: {
+  workspaceId: string;
+}): Promise<number> {
+  const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
+  const retentionDays = await getWorkspaceDataRetention(auth);
+  return retentionDays;
 }
 
 export async function shouldStillScrubData({

--- a/front/temporal/scrub_workspace/config.ts
+++ b/front/temporal/scrub_workspace/config.ts
@@ -4,5 +4,4 @@ export const QUEUE_NAME = `scrub-workspace-queue-v${QUEUE_VERSION}`;
 export const DOWNGRADE_FREE_ENDED_WORKSPACES_WORKFLOW_ID =
   "downgrade-and-scrub-free-ended-workspaces";
 
-export const DATA_RETENTION_PERIOD_IN_DAYS = 30; // To be deprecated soon by calling getWorkspaceDataRetention
 export const LAST_EMAIL_BEFORE_SCRUB_IN_DAYS = 3;

--- a/front/temporal/scrub_workspace/config.ts
+++ b/front/temporal/scrub_workspace/config.ts
@@ -5,3 +5,4 @@ export const DOWNGRADE_FREE_ENDED_WORKSPACES_WORKFLOW_ID =
   "downgrade-and-scrub-free-ended-workspaces";
 
 export const LAST_EMAIL_BEFORE_SCRUB_IN_DAYS = 3;
+export const WORKSPACE_DEFAULT_RETENTION_DAYS = 30;

--- a/front/temporal/scrub_workspace/workflows.ts
+++ b/front/temporal/scrub_workspace/workflows.ts
@@ -7,13 +7,12 @@ import {
 } from "@temporalio/workflow";
 
 import type * as activities from "./activities";
-import {
-  DATA_RETENTION_PERIOD_IN_DAYS,
-  LAST_EMAIL_BEFORE_SCRUB_IN_DAYS,
-} from "./config";
+import { LAST_EMAIL_BEFORE_SCRUB_IN_DAYS } from "./config";
 import { runScrubFreeEndedWorkspacesSignal } from "./signals";
 
-const { shouldStillScrubData } = proxyActivities<typeof activities>({
+const { shouldStillScrubData, getWorkspaceRetentionDays } = proxyActivities<
+  typeof activities
+>({
   startToCloseTimeout: "1 minutes",
 });
 const { sendDataDeletionEmail } = proxyActivities<typeof activities>({
@@ -44,15 +43,19 @@ export async function scheduleWorkspaceScrubWorkflowV2({
     return false;
   }
 
+  const workspaceRetentionDays = await getWorkspaceRetentionDays({
+    workspaceId,
+  });
+
   await pauseAllConnectors({ workspaceId });
   await pauseAllTriggers({ workspaceId });
   await sendDataDeletionEmail({
-    remainingDays: DATA_RETENTION_PERIOD_IN_DAYS,
+    remainingDays: workspaceRetentionDays,
     workspaceId,
     isLast: false,
   });
   await sleep(
-    `${DATA_RETENTION_PERIOD_IN_DAYS - LAST_EMAIL_BEFORE_SCRUB_IN_DAYS} days`
+    `${workspaceRetentionDays - LAST_EMAIL_BEFORE_SCRUB_IN_DAYS} days`
   );
   if (!(await shouldStillScrubData({ workspaceId }))) {
     return false;

--- a/front/temporal/scrub_workspace/workflows.ts
+++ b/front/temporal/scrub_workspace/workflows.ts
@@ -7,10 +7,11 @@ import {
   startChild,
 } from "@temporalio/workflow";
 
-import { WORKSPACE_DEFAULT_RETENTION_DAYS } from "@app/lib/data_retention";
-
 import type * as activities from "./activities";
-import { LAST_EMAIL_BEFORE_SCRUB_IN_DAYS } from "./config";
+import {
+  LAST_EMAIL_BEFORE_SCRUB_IN_DAYS,
+  WORKSPACE_DEFAULT_RETENTION_DAYS,
+} from "./config";
 import { runScrubFreeEndedWorkspacesSignal } from "./signals";
 
 const { shouldStillScrubData, getWorkspaceRetentionDays } = proxyActivities<


### PR DESCRIPTION
## Description

Eng runner card: https://github.com/dust-tt/tasks/issues/5589

First PR https://github.com/dust-tt/dust/pull/19495 was focusing on Poké to fetch and display properly the custom workspace data retention (we're using workspace metadata). 

This PR updates the scrub workspace workflow to fetch this data and use it. 
I added Temporal patching to safely introduce getWorkspaceRetentionDays activity without causing non-determinism errors for workflows currently running in prod. 

Next PR is adding a Poké plugin to allow setting a custom retention period. 


## Tests

Will test locally before merging. 

## Risk

Break scrub workspace workflows. 

## Deploy Plan

Deploy front. 
Monitor for non deterministic errors 🤞🏻 