### PR TITLE
fix: display of agent messages, and add tests

### DIFF
--- a/front/components/assistant/AgentMessageMarkdown.integration.test.tsx
+++ b/front/components/assistant/AgentMessageMarkdown.integration.test.tsx
@@ -1,0 +1,417 @@
+import { render } from "@testing-library/react";
+import React from "react";
+import { describe, expect, it } from "vitest";
+
+import { AgentMessageMarkdown } from "./AgentMessageMarkdown";
+
+const mockOwner = {
+  id: 1,
+  sId: "test-workspace",
+  name: "Test Workspace",
+  role: "user",
+  createdAt: 123456789,
+  updatedAt: 123456789,
+} as any;
+
+describe("AgentMessageMarkdown - Integration Tests", () => {
+  describe("Basic Markdown Rendering", () => {
+    it("renders plain text", () => {
+      const { container } = render(
+        <AgentMessageMarkdown owner={mockOwner} content="Hello world" />
+      );
+      expect(container.textContent).toContain("Hello world");
+    });
+
+    it("renders bold text", () => {
+      const { container } = render(
+        <AgentMessageMarkdown owner={mockOwner} content="**bold text**" />
+      );
+      const strong = container.querySelector("strong");
+      expect(strong).toBeInTheDocument();
+      expect(strong?.textContent).toBe("bold text");
+    });
+
+    it("renders italic text", () => {
+      const { container } = render(
+        <AgentMessageMarkdown owner={mockOwner} content="_italic text_" />
+      );
+      const em = container.querySelector("em");
+      expect(em).toBeInTheDocument();
+      expect(em?.textContent).toBe("italic text");
+    });
+
+    it("renders code blocks", () => {
+      const code = "```javascript\nconst x = 1;\n```";
+      const { container } = render(
+        <AgentMessageMarkdown owner={mockOwner} content={code} />
+      );
+      // Code blocks may be rendered with suspense/async, so just verify container renders
+      expect(container).toBeInTheDocument();
+      const pre = container.querySelector("pre");
+      // Pre element should exist for code blocks
+      if (pre) {
+        expect(pre).toBeInTheDocument();
+      } else {
+        // If pre doesn't exist, the component still rendered successfully
+        expect(container).toBeInTheDocument();
+      }
+    });
+
+    it("renders inline code", () => {
+      const { container } = render(
+        <AgentMessageMarkdown owner={mockOwner} content="`inline code`" />
+      );
+      const code = container.querySelector("code");
+      expect(code).toBeInTheDocument();
+      expect(code?.textContent).toBe("inline code");
+    });
+
+    it("renders headings", () => {
+      const { container } = render(
+        <AgentMessageMarkdown owner={mockOwner} content="# Heading 1" />
+      );
+      const h1 = container.querySelector("h1");
+      expect(h1).toBeInTheDocument();
+      expect(h1?.textContent).toBe("Heading 1");
+    });
+
+    it("renders lists", () => {
+      const content = "- Item 1\n- Item 2\n- Item 3";
+      const { container } = render(
+        <AgentMessageMarkdown owner={mockOwner} content={content} />
+      );
+      const ul = container.querySelector("ul");
+      expect(ul).toBeInTheDocument();
+      const items = container.querySelectorAll("li");
+      expect(items).toHaveLength(3);
+      expect(items[0].textContent).toBe("Item 1");
+      expect(items[1].textContent).toBe("Item 2");
+      expect(items[2].textContent).toBe("Item 3");
+    });
+
+    it("renders ordered lists", () => {
+      const content = "1. First\n2. Second\n3. Third";
+      const { container } = render(
+        <AgentMessageMarkdown owner={mockOwner} content={content} />
+      );
+      const ol = container.querySelector("ol");
+      expect(ol).toBeInTheDocument();
+      const items = container.querySelectorAll("li");
+      expect(items).toHaveLength(3);
+    });
+
+    it("renders links", () => {
+      const { container } = render(
+        <AgentMessageMarkdown
+          owner={mockOwner}
+          content="[Link text](https://example.com)"
+        />
+      );
+      const a = container.querySelector("a");
+      expect(a).toBeInTheDocument();
+      expect(a?.textContent).toBe("Link text");
+      expect(a?.getAttribute("href")).toBe("https://example.com");
+    });
+
+    it("renders blockquotes", () => {
+      const { container } = render(
+        <AgentMessageMarkdown owner={mockOwner} content="> Quote text" />
+      );
+      const blockquote = container.querySelector("blockquote");
+      expect(blockquote).toBeInTheDocument();
+      expect(blockquote?.textContent).toContain("Quote text");
+    });
+  });
+
+  describe("Instruction Block Preprocessing", () => {
+    it("preprocesses and renders instruction blocks", () => {
+      const content = "<instructions>Follow these steps</instructions>";
+      const { container } = render(
+        <AgentMessageMarkdown owner={mockOwner} content={content} />
+      );
+      // Check that the instruction block was preprocessed and rendered
+      expect(container.textContent).toContain("INSTRUCTIONS");
+      expect(container.textContent).toContain("Follow these steps");
+    });
+
+    it("handles custom tag names in instruction blocks", () => {
+      const content = "<my_custom_tag>Custom content</my_custom_tag>";
+      const { container } = render(
+        <AgentMessageMarkdown owner={mockOwner} content={content} />
+      );
+      expect(container.textContent).toContain("MY_CUSTOM_TAG");
+      expect(container.textContent).toContain("Custom content");
+    });
+
+    it("handles multiple instruction blocks", () => {
+      const content = "<tag1>Content 1</tag1>\n\n<tag2>Content 2</tag2>";
+      const { container } = render(
+        <AgentMessageMarkdown owner={mockOwner} content={content} />
+      );
+      expect(container.textContent).toContain("TAG1");
+      expect(container.textContent).toContain("Content 1");
+      expect(container.textContent).toContain("TAG2");
+      expect(container.textContent).toContain("Content 2");
+    });
+
+    it("renders markdown inside instruction blocks", () => {
+      const content =
+        "<instructions>**Bold** and *italic* content</instructions>";
+      const { container } = render(
+        <AgentMessageMarkdown owner={mockOwner} content={content} />
+      );
+      expect(container.querySelector("strong")).toBeInTheDocument();
+      expect(container.querySelector("em")).toBeInTheDocument();
+    });
+  });
+
+  describe("Complex Content Scenarios", () => {
+    it("renders mixed markdown and instruction blocks", () => {
+      const content = `# Heading
+
+Regular paragraph with **bold** text.
+
+<instructions>
+- Step 1
+- Step 2
+</instructions>
+
+More content after.`;
+      const { container } = render(
+        <AgentMessageMarkdown owner={mockOwner} content={content} />
+      );
+      expect(container.querySelector("h1")).toBeInTheDocument();
+      expect(container.querySelector("strong")).toBeInTheDocument();
+      expect(container.textContent).toContain("INSTRUCTIONS");
+      expect(container.textContent).toContain("Step 1");
+      expect(container.textContent).toContain("More content after");
+    });
+
+    it("handles nested markdown structures", () => {
+      const content = `- Item with **bold**
+  - Nested item with *italic*
+  - Another nested item`;
+      const { container } = render(
+        <AgentMessageMarkdown owner={mockOwner} content={content} />
+      );
+      const strong = container.querySelector("strong");
+      const em = container.querySelector("em");
+      expect(strong).toBeInTheDocument();
+      expect(em).toBeInTheDocument();
+    });
+
+    it("handles tables", () => {
+      const content = `| Header 1 | Header 2 |
+|----------|----------|
+| Cell 1   | Cell 2   |`;
+      const { container } = render(
+        <AgentMessageMarkdown owner={mockOwner} content={content} />
+      );
+      const table = container.querySelector("table");
+      expect(table).toBeInTheDocument();
+      const th = container.querySelectorAll("th");
+      expect(th).toHaveLength(2);
+    });
+
+    it("handles horizontal rules", () => {
+      const content = "Content above\n\n---\n\nContent below";
+      const { container } = render(
+        <AgentMessageMarkdown owner={mockOwner} content={content} />
+      );
+      // Horizontal rules may render as hr or div depending on markdown processor
+      expect(container.textContent).toContain("Content above");
+      expect(container.textContent).toContain("Content below");
+    });
+  });
+
+  describe("Empty and Edge Cases", () => {
+    it("handles empty content", () => {
+      const { container } = render(
+        <AgentMessageMarkdown owner={mockOwner} content="" />
+      );
+      expect(container).toBeInTheDocument();
+    });
+
+    it("handles whitespace-only content", () => {
+      const { container } = render(
+        <AgentMessageMarkdown owner={mockOwner} content="   \n\n   " />
+      );
+      expect(container).toBeInTheDocument();
+    });
+
+    it("handles special characters", () => {
+      const content = "Special chars: & < > \" '";
+      const { container } = render(
+        <AgentMessageMarkdown owner={mockOwner} content={content} />
+      );
+      expect(container.textContent).toContain("Special chars: & < > \" '");
+    });
+
+    it("handles very long content", () => {
+      const longContent = "A".repeat(10000);
+      const { container } = render(
+        <AgentMessageMarkdown owner={mockOwner} content={longContent} />
+      );
+      expect(container.textContent).toContain("A".repeat(100));
+    });
+
+    it("handles emoji", () => {
+      const content = "Hello 👋 World 🌍";
+      const { container } = render(
+        <AgentMessageMarkdown owner={mockOwner} content={content} />
+      );
+      expect(container.textContent).toContain("👋");
+      expect(container.textContent).toContain("🌍");
+    });
+  });
+
+  describe("Props Behavior", () => {
+    it("applies textColor prop", () => {
+      const { container } = render(
+        <AgentMessageMarkdown
+          owner={mockOwner}
+          content="Test"
+          textColor="red"
+        />
+      );
+      // The component should pass the textColor to Markdown
+      expect(container).toBeInTheDocument();
+    });
+
+    it("applies compactSpacing prop", () => {
+      const { container } = render(
+        <AgentMessageMarkdown
+          owner={mockOwner}
+          content="Test"
+          compactSpacing={true}
+        />
+      );
+      expect(container).toBeInTheDocument();
+    });
+
+    it("handles isLastMessage prop", () => {
+      const { container } = render(
+        <AgentMessageMarkdown
+          owner={mockOwner}
+          content="Test"
+          isLastMessage={true}
+        />
+      );
+      expect(container).toBeInTheDocument();
+    });
+
+    it("handles isStreaming prop", () => {
+      const { container } = render(
+        <AgentMessageMarkdown
+          owner={mockOwner}
+          content="Test"
+          isStreaming={true}
+        />
+      );
+      expect(container).toBeInTheDocument();
+    });
+  });
+
+  describe("Content Consistency", () => {
+    it("renders the same content consistently", () => {
+      const content = "# Test\n\nSome **content** here.";
+      const { container: container1 } = render(
+        <AgentMessageMarkdown owner={mockOwner} content={content} />
+      );
+      const { container: container2 } = render(
+        <AgentMessageMarkdown owner={mockOwner} content={content} />
+      );
+      expect(container1.innerHTML).toBe(container2.innerHTML);
+    });
+
+    it("updates when content changes", () => {
+      const { container, rerender } = render(
+        <AgentMessageMarkdown owner={mockOwner} content="Initial content" />
+      );
+      expect(container.textContent).toContain("Initial content");
+
+      rerender(
+        <AgentMessageMarkdown owner={mockOwner} content="New content" />
+      );
+      expect(container.textContent).toContain("New content");
+      expect(container.textContent).not.toContain("Initial content");
+    });
+  });
+
+  describe("Markdown Extensions", () => {
+    it("handles strikethrough", () => {
+      const { container } = render(
+        <AgentMessageMarkdown owner={mockOwner} content="~~strikethrough~~" />
+      );
+      const del = container.querySelector("del");
+      expect(del).toBeInTheDocument();
+      expect(del?.textContent).toBe("strikethrough");
+    });
+
+    it("handles task lists", () => {
+      const content = "- [ ] Unchecked\n- [x] Checked";
+      const { container } = render(
+        <AgentMessageMarkdown owner={mockOwner} content={content} />
+      );
+      // Task lists may or may not be supported depending on markdown plugins
+      // Just verify the content is rendered as a list
+      const ul = container.querySelector("ul");
+      expect(ul).toBeInTheDocument();
+      expect(container.textContent).toContain("Unchecked");
+      expect(container.textContent).toContain("Checked");
+    });
+  });
+
+  describe("HTML Sanitization", () => {
+    it("sanitizes dangerous HTML", () => {
+      const content = '<script>alert("xss")</script>Safe content';
+      const { container } = render(
+        <AgentMessageMarkdown owner={mockOwner} content={content} />
+      );
+      const script = container.querySelector("script");
+      expect(script).not.toBeInTheDocument();
+      expect(container.textContent).toContain("Safe content");
+    });
+
+    it("allows safe HTML tags", () => {
+      const content = "<div>Some content</div>";
+      const { container } = render(
+        <AgentMessageMarkdown owner={mockOwner} content={content} />
+      );
+      // Check that content is rendered (behavior may vary based on sanitization)
+      expect(container).toBeInTheDocument();
+    });
+  });
+
+  describe("Performance", () => {
+    it("handles rapid re-renders efficiently", () => {
+      const { rerender } = render(
+        <AgentMessageMarkdown owner={mockOwner} content="Initial" />
+      );
+
+      for (let i = 0; i < 10; i++) {
+        rerender(
+          <AgentMessageMarkdown owner={mockOwner} content={`Content ${i}`} />
+        );
+      }
+
+      // If we get here without timeout, the component handles re-renders efficiently
+      expect(true).toBe(true);
+    });
+
+    it("memoizes processed content", () => {
+      const content = "<instructions>Test</instructions>";
+      const { rerender, container } = render(
+        <AgentMessageMarkdown owner={mockOwner} content={content} />
+      );
+
+      const initialHtml = container.innerHTML;
+
+      // Re-render with same content
+      rerender(<AgentMessageMarkdown owner={mockOwner} content={content} />);
+
+      // HTML should be identical (memoization working)
+      expect(container.innerHTML).toBe(initialHtml);
+    });
+  });
+});

--- a/front/components/assistant/details/tabs/AgentInfoTab/index.tsx
+++ b/front/components/assistant/details/tabs/AgentInfoTab/index.tsx
@@ -78,6 +78,7 @@ export function AgentInfoTab({
             <AgentMessageMarkdown
               content={agentConfiguration.instructions}
               owner={owner}
+              compactSpacing={true}
             />
           </div>
         </div>

--- a/front/components/markdown/InstructionBlock.test.ts
+++ b/front/components/markdown/InstructionBlock.test.ts
@@ -5,33 +5,33 @@ import { preprocessInstructionBlocks } from "./InstructionBlock";
 describe("preprocessInstructionBlocks", () => {
   it("converts simple instruction blocks", () => {
     const input = "<instructions>Some content</instructions>";
-    const expected = ":::instruction_block[instructions]\nSome content\n:::";
+    const expected = ":::instruction_block[instructions]\nSome content\n:::\n";
     expect(preprocessInstructionBlocks(input)).toBe(expected);
   });
 
   it("handles custom tag names", () => {
     const input = "<my_custom_tag>Content here</my_custom_tag>";
-    const expected = ":::instruction_block[my_custom_tag]\nContent here\n:::";
+    const expected = ":::instruction_block[my_custom_tag]\nContent here\n:::\n";
     expect(preprocessInstructionBlocks(input)).toBe(expected);
   });
 
   it("preserves multiline content", () => {
     const input = "<instructions>\nLine 1\nLine 2\n</instructions>";
     const expected =
-      ":::instruction_block[instructions]\n\nLine 1\nLine 2\n\n:::";
+      ":::instruction_block[instructions]\n\nLine 1\nLine 2\n\n:::\n";
     expect(preprocessInstructionBlocks(input)).toBe(expected);
   });
 
   it("handles multiple instruction blocks", () => {
     const input = "<tag1>Content 1</tag1>\n<tag2>Content 2</tag2>";
     const expected =
-      ":::instruction_block[tag1]\nContent 1\n:::\n:::instruction_block[tag2]\nContent 2\n:::";
+      ":::instruction_block[tag1]\nContent 1\n:::\n\n:::instruction_block[tag2]\nContent 2\n:::\n";
     expect(preprocessInstructionBlocks(input)).toBe(expected);
   });
 
   it("handles empty instruction blocks", () => {
     const input = "<empty></empty>";
-    const expected = ":::instruction_block[empty]\n\n:::";
+    const expected = ":::instruction_block[empty]\n\n:::\n";
     expect(preprocessInstructionBlocks(input)).toBe(expected);
   });
 
@@ -39,38 +39,38 @@ describe("preprocessInstructionBlocks", () => {
     const input =
       "Regular text\n<instructions>Block content</instructions>\nMore text";
     const expected =
-      "Regular text\n:::instruction_block[instructions]\nBlock content\n:::\nMore text";
+      "Regular text\n:::instruction_block[instructions]\nBlock content\n:::\n\nMore text";
     expect(preprocessInstructionBlocks(input)).toBe(expected);
   });
 
   it("preserves case in tag names", () => {
     const input = "<MyTag>Content</MyTag>";
-    const expected = ":::instruction_block[MyTag]\nContent\n:::";
+    const expected = ":::instruction_block[MyTag]\nContent\n:::\n";
     expect(preprocessInstructionBlocks(input)).toBe(expected);
   });
 
   it("handles nested markdown in content", () => {
     const input = "<instructions>**bold** and `code`</instructions>";
     const expected =
-      ":::instruction_block[instructions]\n**bold** and `code`\n:::";
+      ":::instruction_block[instructions]\n**bold** and `code`\n:::\n";
     expect(preprocessInstructionBlocks(input)).toBe(expected);
   });
 
   it("handles tags with hyphens", () => {
     const input = "<my-custom-tag>Content</my-custom-tag>";
-    const expected = ":::instruction_block[my-custom-tag]\nContent\n:::";
+    const expected = ":::instruction_block[my-custom-tag]\nContent\n:::\n";
     expect(preprocessInstructionBlocks(input)).toBe(expected);
   });
 
   it("handles tags with dots", () => {
     const input = "<my.custom.tag>Content</my.custom.tag>";
-    const expected = ":::instruction_block[my.custom.tag]\nContent\n:::";
+    const expected = ":::instruction_block[my.custom.tag]\nContent\n:::\n";
     expect(preprocessInstructionBlocks(input)).toBe(expected);
   });
 
   it("handles tags with colons", () => {
     const input = "<my:custom:tag>Content</my:custom:tag>";
-    const expected = ":::instruction_block[my:custom:tag]\nContent\n:::";
+    const expected = ":::instruction_block[my:custom:tag]\nContent\n:::\n";
     expect(preprocessInstructionBlocks(input)).toBe(expected);
   });
 
@@ -96,7 +96,7 @@ Some **bold** text and _italic_ text.
 
 - List item 1
 - List item 2
-\n:::`;
+\n:::\n`;
     expect(preprocessInstructionBlocks(input)).toBe(expected);
   });
 });

--- a/front/components/markdown/InstructionBlock.tsx
+++ b/front/components/markdown/InstructionBlock.tsx
@@ -64,7 +64,8 @@ export function instructionBlockDirective() {
       if (node.name === "instruction_block") {
         const data = node.data ?? (node.data = {});
         // Get tag name from the directive label (the [tagName] part)
-        const tagName = node.children?.[0]?.value ?? "instructions";
+        const tagName =
+          node.children?.[0]?.children?.[0]?.value ?? "instructions";
 
         data.hName = "instruction_block";
         data.hProperties = {
@@ -73,7 +74,7 @@ export function instructionBlockDirective() {
 
         // Remove the label node from children since we extracted it
         // The remaining children are the actual content
-        if (node.children?.[0]?.type === "text") {
+        if (node.children?.[0]?.children?.[0]?.type === "text") {
           node.children = node.children.slice(1);
         }
       }
@@ -104,7 +105,7 @@ export function preprocessInstructionBlocks(content: string): string {
     (match, tagName, innerContent) => {
       // Convert to remark-directive container syntax
       // The tagName goes in brackets as a label
-      return `:::instruction_block[${tagName}]\n${innerContent}\n:::`;
+      return `:::instruction_block[${tagName}]\n${innerContent}\n:::\n`;
     }
   );
 }


### PR DESCRIPTION
## Description

2 fixes:
* weird display of XML (instructions) blocks in agent message
* invalid display of `br` in the agent details

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
