### PR TITLE
[Front] feat(agent-builder): add capabilities footer for selected items

### DIFF
--- a/front/components/agent_builder/capabilities/capabilities_sheet/CapabilitiesFooter.tsx
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/CapabilitiesFooter.tsx
@@ -1,0 +1,58 @@
+import { Chip } from "@dust-tt/sparkle";
+
+import type { AgentBuilderSkillsType } from "@app/components/agent_builder/AgentBuilderFormContext";
+import type { SelectedTool } from "@app/components/agent_builder/capabilities/mcp/MCPServerViewsSheet";
+import {
+  getSelectedToolIcon,
+  getSelectedToolLabel,
+} from "@app/components/agent_builder/capabilities/mcp/utils/toolDisplayUtils";
+import { getSkillIcon } from "@app/lib/skill";
+
+interface CapabilitiesFooterProps {
+  localSelectedTools: SelectedTool[];
+  localSelectedSkills: AgentBuilderSkillsType[];
+  onRemoveSelectedTool: (tool: SelectedTool) => void;
+  onRemoveSelectedSkill: (skill: AgentBuilderSkillsType) => void;
+}
+
+export function CapabilitiesFooter({
+  localSelectedTools,
+  localSelectedSkills,
+  onRemoveSelectedTool,
+  onRemoveSelectedSkill,
+}: CapabilitiesFooterProps) {
+  const hasCapabilities =
+    localSelectedTools.length > 0 || localSelectedSkills.length > 0;
+
+  return (
+    <>
+      {hasCapabilities && (
+        <div className="space-y-3">
+          <h2 className="text-lg font-semibold">Selected capabilities</h2>
+          <div className="flex flex-wrap gap-2">
+            {localSelectedSkills.map((skill, index) => (
+              <Chip
+                key={index}
+                icon={getSkillIcon(skill.icon)}
+                label={skill.name}
+                onRemove={() => onRemoveSelectedSkill(skill)}
+                size="xs"
+                color="green"
+              />
+            ))}
+            {localSelectedTools.map((tool, index) => (
+              <Chip
+                key={index}
+                icon={getSelectedToolIcon(tool)}
+                label={getSelectedToolLabel(tool)}
+                onRemove={() => onRemoveSelectedTool(tool)}
+                size="xs"
+                color="green"
+              />
+            ))}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/front/components/agent_builder/capabilities/capabilities_sheet/hooks.ts
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/hooks.ts
@@ -78,6 +78,12 @@ export const useSkillSelection = ({
     );
   }, [skills, searchQuery, alreadyAddedSkillIds]);
 
+  const unselectSkill = useCallback((skill: AgentBuilderSkillsType) => {
+    setLocalSelectedSkills((prev) =>
+      prev.filter((selected) => skill.sId !== selected.sId)
+    );
+  }, []);
+
   const handleSkillToggle = useCallback(
     (skill: SkillType) => {
       if (selectedSkillIds.has(skill.sId)) {
@@ -136,6 +142,7 @@ export const useSkillSelection = ({
   return {
     localSelectedSkills,
     localAdditionalSpaces,
+    unselectSkill,
     handleSkillToggle,
     filteredSkills,
     isSkillsLoading,
@@ -227,6 +234,12 @@ export const useToolSelection = ({
     selectedActions,
     isSelectedMCPServerView,
   ]);
+
+  const unselectTool = useCallback((tool: SelectedTool) => {
+    setLocalSelectedTools((prev) =>
+      prev.filter((selected) => tool.view.sId !== selected.view.sId)
+    );
+  }, []);
 
   const handleToolToggle = useCallback(
     (mcpServerView: MCPServerViewTypeWithLabel) => {
@@ -320,6 +333,7 @@ export const useToolSelection = ({
 
   return {
     localSelectedTools,
+    unselectTool,
     handleToolToggle,
     handleToolInfoClick,
     filteredMCPServerViews,

--- a/front/components/agent_builder/capabilities/capabilities_sheet/utils.tsx
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/utils.tsx
@@ -165,14 +165,15 @@ export function useCapabilitiesPageAndFooter({
               onModeChange={onModeChange}
             />
           ),
-          footerContent: (
-            <CapabilitiesFooter
-              localSelectedTools={toolSelection.localSelectedTools}
-              localSelectedSkills={skillSelection.localSelectedSkills}
-              onRemoveSelectedTool={toolSelection.unselectTool}
-              onRemoveSelectedSkill={skillSelection.unselectSkill}
-            />
-          ),
+          footerContent:
+            selectedCapabilitiesCount > 0 ? (
+              <CapabilitiesFooter
+                localSelectedTools={toolSelection.localSelectedTools}
+                localSelectedSkills={skillSelection.localSelectedSkills}
+                onRemoveSelectedTool={toolSelection.unselectTool}
+                onRemoveSelectedSkill={skillSelection.unselectSkill}
+              />
+            ) : null,
         },
         leftButton: {
           label: "Cancel",

--- a/front/components/agent_builder/capabilities/capabilities_sheet/utils.tsx
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/utils.tsx
@@ -6,6 +6,7 @@ import { useForm } from "react-hook-form";
 
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import type { MCPFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
+import { CapabilitiesFooter } from "@app/components/agent_builder/capabilities/capabilities_sheet/CapabilitiesFooter";
 import { CapabilitiesSelectionPageContent } from "@app/components/agent_builder/capabilities/capabilities_sheet/CapabilitiesSelectionPage";
 import {
   useSkillSelection,
@@ -162,6 +163,14 @@ export function useCapabilitiesPageAndFooter({
               {...skillSelection}
               {...toolSelection}
               onModeChange={onModeChange}
+            />
+          ),
+          footerContent: (
+            <CapabilitiesFooter
+              localSelectedTools={toolSelection.localSelectedTools}
+              localSelectedSkills={skillSelection.localSelectedSkills}
+              onRemoveSelectedTool={toolSelection.unselectTool}
+              onRemoveSelectedSkill={skillSelection.unselectSkill}
             />
           ),
         },


### PR DESCRIPTION
Closes: https://github.com/dust-tt/tasks/issues/5769

## Description

- Add footer to capabilities selection sheet showing selected skills/tools as chips
- Allow removing items directly from the footer via chip remove button
- Add `unselectSkill` and `unselectTool` helpers to selection hooks

## Tests

Local.

https://github.com/user-attachments/assets/a03b94c1-80ca-4d25-9b22-a7dc385f61c1


## Risk

Low.

## Deploy Plan

Deploy front.
