### PR TITLE
Convo creator is not well determined

### DIFF
--- a/front/lib/api/assistant/participants.ts
+++ b/front/lib/api/assistant/participants.ts
@@ -150,6 +150,7 @@ export async function fetchConversationParticipants(
     order: [["createdAt", "ASC"]],
   });
   const userIds = participants.map((p) => p.userId);
+  const creatorId = userIds[0]; // The current participant who was added first in the conversation is considered as the creator
 
   const [users, agents] = await Promise.all([
     fetchAllUsersById([...userIds]),
@@ -171,14 +172,14 @@ export async function fetchConversationParticipants(
       ...a,
       lastActivityAt: agentLastActivityMap.get(a.configurationId),
     })),
-    users: users.map((u, index) => ({
+    users: users.map((u) => ({
       sId: u.sId,
       fullName: u.fullName,
       pictureUrl: u.pictureUrl,
       username: u.username,
       action: userIdToAction.get(u.id) ?? "posted",
       lastActivityAt: userLastActivityMap.get(u.id),
-      isCreator: index === 0, // The current participant who was added first in the conversation is considered as the creator
+      isCreator: u.id === creatorId,
     })),
   });
 }


### PR DESCRIPTION
## Description

Fixes a bug in `fetchConversationParticipants` where the isCreator flag was incorrectly determined.
The `users` array (returned by `fetchAllUsersById`) doesn't guarantee the same order as the `participants` array (which is ordered by createdAt ASC). This caused the wrong user to be marked as the conversation creator.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

deploy front
