### PR TITLE
[Front] chore(skills): cleanup todos + remove isGlobal getter

### DIFF
--- a/front/components/assistant/details/tabs/AgentInfoTab/AssistantToolsSection.tsx
+++ b/front/components/assistant/details/tabs/AgentInfoTab/AssistantToolsSection.tsx
@@ -156,7 +156,6 @@ export function AssistantToolsSection({
                     className="flex flex-row items-center gap-2"
                     key={skill.sId}
                   >
-                    {/* TODO(skills 2025-12-08): Add custom icon support (pictureUrl) */}
                     <SkillAvatar size="xs" />
                     <div>{skill.name}</div>
                   </div>

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -180,7 +180,6 @@ function getEnabledSkillInstructions(
   ].join("\n");
 }
 
-// TODO(skills): add detailed tools per skill
 function constructSkillsSection({
   enabledSkills,
   equippedSkills,

--- a/front/lib/models/agent/agent_skill.ts
+++ b/front/lib/models/agent/agent_skill.ts
@@ -1,9 +1,11 @@
-import isNil from "lodash/isNil";
 import type { CreationOptional, ForeignKey } from "sequelize";
 import { DataTypes } from "sequelize";
 
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
-import { SkillConfigurationModel } from "@app/lib/models/skill";
+import {
+  eitherGlobalOrCustomSkillValidation,
+  SkillConfigurationModel,
+} from "@app/lib/models/skill";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 
@@ -47,18 +49,7 @@ AgentSkillModel.init(
     sequelize: frontSequelize,
     indexes: [{ fields: ["workspaceId", "agentConfigurationId"] }],
     validate: {
-      // A skill link must reference either a custom skill (workspace-specific, stored in DB)
-      // or a global skill (code-defined, referenced by string ID), but never both or neither.
-      eitherGlobalOrCustomSkill() {
-        const hasCustomSkill = !isNil(this.customSkillId);
-        const hasGlobalSkill = !isNil(this.globalSkillId);
-        const hasExactlyOne = hasCustomSkill !== hasGlobalSkill;
-        if (!hasExactlyOne) {
-          throw new Error(
-            "Exactly one of customSkillId or globalSkillId must be set"
-          );
-        }
-      },
+      eitherGlobalOrCustomSkill: eitherGlobalOrCustomSkillValidation,
     },
   }
 );

--- a/front/lib/models/skill.ts
+++ b/front/lib/models/skill.ts
@@ -1,3 +1,4 @@
+import isNil from "lodash/isNil";
 import type { CreationOptional, ForeignKey, ModelAttributes } from "sequelize";
 import { DataTypes } from "sequelize";
 
@@ -51,6 +52,24 @@ const SKILL_MODEL_ATTRIBUTES = {
     allowNull: true,
   },
 } as const satisfies ModelAttributes;
+
+/**
+ * Shared validation for skill in conversation models.
+ * Ensures exactly one of customSkillId or globalSkillId is set.
+ */
+export function eitherGlobalOrCustomSkillValidation(this: {
+  customSkillId: unknown;
+  globalSkillId: unknown;
+}): void {
+  const hasCustomSkill = !isNil(this.customSkillId);
+  const hasGlobalSkill = !isNil(this.globalSkillId);
+  const hasExactlyOne = hasCustomSkill !== hasGlobalSkill;
+  if (!hasExactlyOne) {
+    throw new Error(
+      "Exactly one of customSkillId or globalSkillId must be set"
+    );
+  }
+}
 
 export class SkillConfigurationModel extends WorkspaceAwareModel<SkillConfigurationModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/models/skill/conversation_skill.ts
+++ b/front/lib/models/skill/conversation_skill.ts
@@ -5,7 +5,10 @@ import {
   AgentMessageModel,
   ConversationModel,
 } from "@app/lib/models/agent/conversation";
-import { SkillConfigurationModel } from "@app/lib/models/skill";
+import {
+  eitherGlobalOrCustomSkillValidation,
+  SkillConfigurationModel,
+} from "@app/lib/models/skill";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
@@ -59,23 +62,6 @@ const SKILL_IN_CONVERSATION_MODEL_ATTRIBUTES = {
     },
   },
 } as const satisfies ModelAttributes;
-
-/**
- * Shared validation for skill in conversation models.
- * Ensures exactly one of customSkillId or globalSkillId is set.
- */
-function eitherGlobalOrCustomSkillValidation(this: {
-  customSkillId: unknown;
-  globalSkillId: unknown;
-}) {
-  const hasCustomSkill = this.customSkillId !== null;
-  const hasGlobalSkill = this.globalSkillId !== null;
-  if (hasCustomSkill === hasGlobalSkill) {
-    throw new Error(
-      "Exactly one of customSkillId or globalSkillId must be set"
-    );
-  }
-}
 
 export class ConversationSkillModel extends WorkspaceAwareModel<ConversationSkillModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/resources/skill/global/frames.ts
+++ b/front/lib/resources/skill/global/frames.ts
@@ -6,8 +6,8 @@ export const framesSkill = {
   name: "Frames",
   userFacingDescription:
     "Create dashboards, presentations, or any interactive content.",
-  // TODO(skills 2025-12-12): add an appropriate description.
-  agentFacingDescription: "",
+  agentFacingDescription:
+    "Create interactive visualizations, charts, dashboards, and presentations as executable React components.",
   instructions: INTERACTIVE_CONTENT_INSTRUCTIONS,
   internalMCPServerNames: ["interactive_content"],
   version: 1,

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -169,11 +169,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     });
   }
 
-  // TODO(SKILLS 2025-12-11): Remove and hide behind canWrite.
-  get isGlobal(): boolean {
-    return this.globalSId !== null;
-  }
-
   static async makeNew(
     auth: Authenticator,
     blob: Omit<CreationAttributes<SkillConfigurationModel>, "workspaceId">,
@@ -694,8 +689,8 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         workspaceId: workspace.id,
         conversationId,
         agentConfigurationId: null,
-        ...(this.isGlobal
-          ? { globalSkillId: this.sId }
+        ...(this.globalSId
+          ? { globalSkillId: this.globalSId }
           : { customSkillId: this.id }),
       },
     });
@@ -710,8 +705,9 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         conversationId,
         workspaceId: workspace.id,
         agentConfigurationId: null,
-        customSkillId: this.globalSId ? null : this.id,
-        globalSkillId: this.globalSId ?? null,
+        ...(this.globalSId
+          ? { globalSkillId: this.globalSId }
+          : { customSkillId: this.id }),
         source: "conversation",
         addedByUserId: user.id,
       } satisfies ConversationSkillCreationAttributes);
@@ -809,7 +805,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   }
 
   isExtendable(): boolean {
-    return this.isGlobal;
+    return this.globalSId !== null;
   }
 
   async fetchUsage(auth: Authenticator): Promise<AgentsUsageType> {
@@ -1120,8 +1116,9 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     await AgentSkillModel.create({
       workspaceId: workspace.id,
       agentConfigurationId: agentConfiguration.id,
-      customSkillId: this.globalSId ? null : this.id,
-      globalSkillId: this.globalSId,
+      ...(this.globalSId
+        ? { globalSkillId: this.globalSId }
+        : { customSkillId: this.id }),
     });
   }
 
@@ -1157,8 +1154,9 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
     const conversationSkillBlob: ConversationSkillCreationAttributes = {
       workspaceId: workspace.id,
-      customSkillId: this.isGlobal ? null : this.id,
-      globalSkillId: this.isGlobal ? this.globalSId : null,
+      ...(this.globalSId
+        ? { globalSkillId: this.globalSId }
+        : { customSkillId: this.id }),
       conversationId: conversation.id,
       addedByUserId: null,
       source: "agent_enabled",

--- a/front/pages/api/w/[wId]/skills/[sId]/index.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.ts
@@ -240,8 +240,7 @@ async function handler(
           {
             name: body.name,
             agentFacingDescription: body.agentFacingDescription,
-            // TODO(skills 2025-12-12): insert an LLM-generated description if missing.
-            userFacingDescription: body.userFacingDescription ?? "",
+            userFacingDescription: body.userFacingDescription,
             instructions: body.instructions,
             icon: body.icon,
             requestedSpaceIds,

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -232,8 +232,7 @@ async function handler(
           status: "active",
           name: body.name,
           agentFacingDescription: body.agentFacingDescription,
-          // TODO(skills 2025-12-12): insert an LLM-generated description if missing.
-          userFacingDescription: body.userFacingDescription ?? "",
+          userFacingDescription: body.userFacingDescription,
           instructions: body.instructions,
           authorId: user.id,
           requestedSpaceIds,


### PR DESCRIPTION
Contributes to : https://github.com/dust-tt/tasks/issues/5767

## Description

- Remove outdated TODOs (custom icon support, detailed tools per skill)
- Add agent-facing description for Frames skill
- Dedupe `eitherGlobalOrCustomSkillValidation` - move to shared location in `lib/models/skill.ts`
- Remove unused `isGlobal` getter, use `globalSId !== null` directly

## Tests

## Risk

Low.

## Deploy Plan

Deploy front.
