### PR TITLE
[extension, front] - deps: update @dust-tt/sparkle to version 0.5.7

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "^1.2.3",
-        "@dust-tt/sparkle": "^0.5.5",
+        "@dust-tt/sparkle": "^0.5.7",
         "@frontapp/plugin-sdk": "^1.8.1",
         "@modelcontextprotocol/sdk": "^1.9.0",
         "@tailwindcss/forms": "^0.5.9",
@@ -1258,9 +1258,9 @@
       }
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.5.5.tgz",
-      "integrity": "sha512-E6NdJmmQ2YTTNgaOw75HqYddmEM4/bheuzRlT9gOO6wSZrKQ0QNQMQJXyDWuf9u7dhcMnj4nhCXgJC/2imhJmw==",
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.5.7.tgz",
+      "integrity": "sha512-ShgiELVq8es2oYfkLihyso5OXN2qoGHZK5jb8WkcDc+pXR9AA2qaADEtwFU7lCPV4HlPzD/k/Y3DQ4f8uAj3tw==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/extension/package.json
+++ b/extension/package.json
@@ -62,7 +62,7 @@
   "dependencies": {
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "^1.2.3",
-    "@dust-tt/sparkle": "^0.5.5",
+    "@dust-tt/sparkle": "^0.5.7",
     "@frontapp/plugin-sdk": "^1.8.1",
     "@modelcontextprotocol/sdk": "^1.9.0",
     "@tailwindcss/forms": "^0.5.9",

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -13,7 +13,7 @@
         "@contentful/rich-text-types": "^17.2.5",
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.5.5",
+        "@dust-tt/sparkle": "^0.5.7",
         "@elastic/elasticsearch": "^8.15.0",
         "@elevenlabs/elevenlabs-js": "^2.17.0",
         "@emoji-mart/data": "^1.2.1",
@@ -1323,10 +1323,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.5.5.tgz",
-      "integrity": "sha512-E6NdJmmQ2YTTNgaOw75HqYddmEM4/bheuzRlT9gOO6wSZrKQ0QNQMQJXyDWuf9u7dhcMnj4nhCXgJC/2imhJmw==",
-      "license": "ISC",
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.5.7.tgz",
+      "integrity": "sha512-ShgiELVq8es2oYfkLihyso5OXN2qoGHZK5jb8WkcDc+pXR9AA2qaADEtwFU7lCPV4HlPzD/k/Y3DQ4f8uAj3tw==",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -38,7 +38,7 @@
     "@contentful/rich-text-types": "^17.2.5",
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.5.5",
+    "@dust-tt/sparkle": "^0.5.7",
     "@elastic/elasticsearch": "^8.15.0",
     "@elevenlabs/elevenlabs-js": "^2.17.0",
     "@emoji-mart/data": "^1.2.1",


### PR DESCRIPTION
## Description

Bumps front and extension uses the latest features and fixes of the @dust-tt/sparkle library