### PR TITLE
[front] fix(agent-loop): bump heartbeat timeout to 2 min

### DIFF
--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -31,10 +31,11 @@ import type {
 } from "@app/types/assistant/agent_run";
 
 const toolActivityStartToCloseTimeout = `${DEFAULT_MCP_REQUEST_TIMEOUT_MS / 1000 / 60 + 1} minutes`;
-export const TOOL_ACTIVITY_HEARTBEAT_TIMEOUT_MS = 60_000;
-const MODEL_ACTIVITY_HEARTBEAT_TIMEOUT_MS = 60_000;
 
-export const RUN_MODEL_MAX_RETRIES = 10;
+const TOOL_ACTIVITY_HEARTBEAT_TIMEOUT_MS = 60 * 1000;
+const MODEL_ACTIVITY_HEARTBEAT_TIMEOUT_MS = 2 * 60 * 1000;
+
+const RUN_MODEL_MAX_RETRIES = 10;
 
 import {
   OpenTelemetryInboundInterceptor,


### PR DESCRIPTION
## Description

- Context [here](https://dust4ai.slack.com/archives/C05B529FHV1/p1767092986068939).
- We hearbeat on each event in `getOutputFromLLMStream` but in some conversation we still do observe some heartbeat timeouts ([logs](https://app.datadoghq.eu/logs?query=%40dd.env%3Aprod%20%40dd.service%3Afront-agent-loop-worker%20%40workflowType%3AagentLoopWorkflow%20%22Heartbeat%20timeout%22&agg_m=count&agg_m_source=base&agg_q=%40workflowId&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&flat_group_bys=true&fromUser=true&messageDisplay=inline&refresh_mode=sliding&sort_m=count&sort_t=count&storage=hot&stream_sort=desc&top_n=10&top_o=top&viz=stream&x_missing=true&from_ts=1733653464474&to_ts=1733657064474&live=true)), specifically before running tools from Frame.
- This PR bumps the heartbeat timeout as a short-term solution, under the hypothesis that the model takes more than a minute to generate the inputs.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
