### PR TITLE
[front] chore(agent-loop): add debug log on time before tool call event

### DIFF
--- a/front/temporal/agent_loop/lib/get_output_from_llm.ts
+++ b/front/temporal/agent_loop/lib/get_output_from_llm.ts
@@ -160,6 +160,7 @@ export async function getOutputFromLLMStream(
         metadata: { thoughtSignature },
       } = event;
 
+      // TODO(2025-12-30 aubin): temporary log to investigate heartbeat timeouts.
       logger.info(
         {
           conversationId: conversation.sId,


### PR DESCRIPTION
## Description

- Context [here](https://dust4ai.slack.com/archives/C05B529FHV1/p1767092986068939).
- This PR adds a debug log upon receiving a tool call event to analyze the time elapsed since the last event.
- This PR will be rolled back.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
