### PR TITLE
End key not working

### DIFF
--- a/front/components/editor/extensions/MentionExtension.tsx
+++ b/front/components/editor/extensions/MentionExtension.tsx
@@ -226,9 +226,6 @@ export const MentionExtension = Mention.extend<MentionExtensionOptions>({
     return parentPlugins ? [...parentPlugins, addedPlugin] : [addedPlugin];
   },
 
-  // Override Backspace behavior so it removes a single character from the
-  // mention label and converts the chip back to typed text (which re-triggers
-  // the @-suggestion dropdown).
   addKeyboardShortcuts() {
     // Shared command to jump to end of line
     const jumpToEndOfLine = () =>
@@ -251,6 +248,9 @@ export const MentionExtension = Mention.extend<MentionExtensionOptions>({
 
     return {
       ...this.parent?.(),
+      // Override Backspace behavior so it removes a single character from the
+      // mention label and converts the chip back to typed text (which re-triggers
+      // the @-suggestion dropdown).
       Backspace: () =>
         this.editor.commands.command(({ tr, state, dispatch }) => {
           const { selection } = state;

--- a/front/components/editor/extensions/MentionExtension.tsx
+++ b/front/components/editor/extensions/MentionExtension.tsx
@@ -230,6 +230,25 @@ export const MentionExtension = Mention.extend<MentionExtensionOptions>({
   // mention label and converts the chip back to typed text (which re-triggers
   // the @-suggestion dropdown).
   addKeyboardShortcuts() {
+    // Shared command to jump to end of line
+    const jumpToEndOfLine = () =>
+      this.editor.commands.command(({ state, dispatch }) => {
+        const { selection } = state;
+        const { $from } = selection;
+
+        // Find the end position of the current line
+        const endPos = $from.end();
+
+        if (dispatch) {
+          const tr = state.tr.setSelection(
+            TextSelection.create(state.doc, endPos)
+          );
+          dispatch(tr);
+        }
+
+        return true;
+      });
+
     return {
       ...this.parent?.(),
       Backspace: () =>
@@ -272,6 +291,9 @@ export const MentionExtension = Mention.extend<MentionExtensionOptions>({
 
           return handled;
         }),
+      // Handle Cmd+ArrowRight (Mac) / Ctrl+ArrowRight (Windows/Linux) and End key to jump to end of line
+      "Mod-ArrowRight": jumpToEndOfLine,
+      End: jumpToEndOfLine,
     };
   },
 });


### PR DESCRIPTION
## Description

Related to this [issue](https://github.com/dust-tt/tasks/issues/5665)

In the input bar, when a line starts with a mention, if the cursor is at the beginning of the line (so right before the mention), hitting End key or Cmd+ArrowRight doesn't make the cursor jump to the end of the line.
This PR fixes this issue by adding a keyboard shortcut in `MentionExtension`

## Tests

1. Open a new conversation and type `@dust hello`
2. Hit Home key or Cmd+ArrowLeft: the cursor should jump to the beginning of the line
3. Hit End key or Cmd+ArrowRight: the cursor should jump to the end of the line

## Risk

Low

## Deploy Plan

Deploy front
