### PR TITLE
[front] fix(agent-loop): add periodic heartbeat around router event stream

### DIFF
--- a/front/temporal/agent_loop/lib/get_output_from_llm.ts
+++ b/front/temporal/agent_loop/lib/get_output_from_llm.ts
@@ -30,8 +30,9 @@ async function* withPeriodicHeartbeat<T>(
       ),
     ]);
 
+    heartbeat();
+
     if (result === LLM_HEARTBEAT) {
-      heartbeat();
       continue;
     }
 
@@ -93,12 +94,7 @@ export async function getOutputFromLLMStream(
       });
     }
 
-    // Heartbeat & sleep allow the activity to be cancelled, e.g. on a "Stop
-    // agent" request. Upon experimentation, both are needed to ensure the
-    // activity receives the cancellation signal. The delay until which is the
-    // signal is received is governed by heartbeat
-    // [throttling](https://docs.temporal.io/encyclopedia/detecting-activity-failures#throttling).
-    heartbeat();
+    // Sleep allows the activity to be cancelled, e.g. on a "Stop agent" request.
     try {
       await sleep(1);
     } catch (err) {


### PR DESCRIPTION
## Description

- Context [here](https://dust4ai.slack.com/archives/C05B529FHV1/p1767092986068939).
- This PR wraps the async generator coming from the LLM router (`llm.stream`) to ensure we hearbeat at least every 10s.
- We already had a heartbeat on each event, but we observed that sometimes two events can be separated by more than a minute, specifically before tool calls (model takes time generating the inputs, which is not streamed).

## Tests

- Tested locally.

## Risk

- Medium but well tested.

## Deploy Plan

- Deploy front.
