### PR TITLE
[front] - fix(AB): edit XML tag

### DIFF
--- a/front/components/editor/extensions/agent_builder/InstructionBlockExtension.tsx
+++ b/front/components/editor/extensions/agent_builder/InstructionBlockExtension.tsx
@@ -105,10 +105,6 @@ const InstructionBlockComponent: React.FC<NodeViewProps> = ({
     }
   };
 
-  const handleTypeBlur = () => {
-    handleTypeSubmit();
-  };
-
   const ChevronIcon = isCollapsed ? ChevronRightIcon : ChevronDownIcon;
 
   const handleBlockClick = (e: React.MouseEvent) => {
@@ -147,7 +143,6 @@ const InstructionBlockComponent: React.FC<NodeViewProps> = ({
               ref={editableRef}
               contentEditable
               suppressContentEditableWarning
-              onMouseDown={(e) => e.stopPropagation()}
               onKeyDown={(e) => {
                 e.stopPropagation();
                 if (e.key === "Enter") {
@@ -162,7 +157,7 @@ const InstructionBlockComponent: React.FC<NodeViewProps> = ({
                   setIsEditingType(false);
                 }
               }}
-              onBlur={handleTypeBlur}
+              onBlur={handleTypeSubmit}
               className="outline-none"
             >
               {(node.attrs.type ?? "instructions").toUpperCase()}

--- a/front/components/editor/extensions/agent_builder/InstructionBlockExtension.tsx
+++ b/front/components/editor/extensions/agent_builder/InstructionBlockExtension.tsx
@@ -123,61 +123,53 @@ const InstructionBlockComponent: React.FC<NodeViewProps> = ({
       : ""
   }`;
 
-  const renderTagChip = (isOpening: boolean) => {
-    const prefix = isOpening ? "<" : "</";
-    const suffix = ">";
-
-    if (isEditingType && isOpening && !isCollapsed) {
-      return (
-        <span
-          contentEditable={false}
-          onMouseDown={(e) => e.stopPropagation()}
-          onClick={(e) => e.stopPropagation()}
-        >
-          <Chip
-            size="mini"
-            className="bg-gray-100 transition-colors hover:bg-gray-200 dark:bg-gray-800 dark:hover:bg-gray-700"
-          >
-            {prefix}
-            <span
-              ref={editableRef}
-              contentEditable
-              suppressContentEditableWarning
-              onKeyDown={(e) => {
-                e.stopPropagation();
-                if (e.key === "Enter") {
-                  e.preventDefault();
-                  handleTypeSubmit();
-                } else if (e.key === "Escape") {
-                  e.preventDefault();
-                  if (editableRef.current) {
-                    editableRef.current.textContent =
-                      (node.attrs.type ?? "instructions").toUpperCase();
-                  }
-                  setIsEditingType(false);
-                }
-              }}
-              onBlur={handleTypeSubmit}
-              className="outline-none"
-            >
-              {(node.attrs.type ?? "instructions").toUpperCase()}
-            </span>
-            {suffix}
-          </Chip>
-        </span>
-      );
-    }
-
-    return (
-      <span
-        contentEditable={false}
-        onClick={isOpening ? handleChipClick : undefined}
-        className={isOpening && !isCollapsed ? "cursor-pointer" : undefined}
+  const openingTagChip = isEditingType ? (
+    <span
+      contentEditable={false}
+      onMouseDown={(e) => e.stopPropagation()}
+      onClick={(e) => e.stopPropagation()}
+    >
+      <Chip
+        size="mini"
+        className="bg-gray-100 transition-colors hover:bg-gray-200 dark:bg-gray-800 dark:hover:bg-gray-700"
       >
-        <InstructionBlockChip text={`${prefix}${displayType}${suffix}`} />
-      </span>
-    );
-  };
+        {"<"}
+        <span
+          ref={editableRef}
+          contentEditable
+          suppressContentEditableWarning
+          onKeyDown={(e) => {
+            e.stopPropagation();
+            if (e.key === "Enter") {
+              e.preventDefault();
+              handleTypeSubmit();
+            } else if (e.key === "Escape") {
+              e.preventDefault();
+              if (editableRef.current) {
+                editableRef.current.textContent = (
+                  node.attrs.type ?? "instructions"
+                ).toUpperCase();
+              }
+              setIsEditingType(false);
+            }
+          }}
+          onBlur={handleTypeSubmit}
+          className="outline-none"
+        >
+          {(node.attrs.type ?? "instructions").toUpperCase()}
+        </span>
+        {">"}
+      </Chip>
+    </span>
+  ) : (
+    <span
+      contentEditable={false}
+      onClick={handleChipClick}
+      className="cursor-pointer"
+    >
+      <InstructionBlockChip text={`<${displayType}>`} />
+    </span>
+  );
 
   return (
     <NodeViewWrapper className="my-2">
@@ -197,16 +189,16 @@ const InstructionBlockComponent: React.FC<NodeViewProps> = ({
               className="mt-[0.5px] cursor-pointer"
               onClick={handleToggle}
             >
-              {renderTagChip(true)}
+              <InstructionBlockChip text={`<${displayType}>`} />
             </div>
           ) : (
             <div className="mt-0.5 w-full">
-              {renderTagChip(true)}
+              {openingTagChip}
               <NodeViewContent
                 className={instructionBlockContentStyles}
                 as="div"
               />
-              {renderTagChip(false)}
+              <InstructionBlockChip text={`</${displayType}>`} />
             </div>
           )}
         </div>


### PR DESCRIPTION
## Description

Fixes a regression introduced during mentions cleanup work where users could no longer edit the XML tag names in instruction blocks within the agent builder (e.g., `<INSTRUCTIONS>`). This PR restores the ability to click on and inline-edit the tag type while preserving the improved code structure. When clicking on an instruction block chip in edit mode, the tag name becomes contentEditable, auto-selects its text, and sanitizes input to only allow valid XML tag characters.

**References:**
- https://github.com/dust-tt/tasks/issues/5770


## Risk
Low

## Tests

Locally

## Deploy Plan

Deploy front