### PR TITLE
Disable instruction block

### DIFF
--- a/front/components/assistant/AgentMessageMarkdown.integration.test.tsx
+++ b/front/components/assistant/AgentMessageMarkdown.integration.test.tsx
@@ -124,7 +124,7 @@ describe("AgentMessageMarkdown - Integration Tests", () => {
   });
 
   describe("Instruction Block Preprocessing", () => {
-    it("preprocesses and renders instruction blocks", () => {
+    it.skip("preprocesses and renders instruction blocks", () => {
       const content = "<instructions>Follow these steps</instructions>";
       const { container } = render(
         <AgentMessageMarkdown owner={mockOwner} content={content} />
@@ -134,7 +134,7 @@ describe("AgentMessageMarkdown - Integration Tests", () => {
       expect(container.textContent).toContain("Follow these steps");
     });
 
-    it("handles custom tag names in instruction blocks", () => {
+    it.skip("handles custom tag names in instruction blocks", () => {
       const content = "<my_custom_tag>Custom content</my_custom_tag>";
       const { container } = render(
         <AgentMessageMarkdown owner={mockOwner} content={content} />
@@ -143,7 +143,7 @@ describe("AgentMessageMarkdown - Integration Tests", () => {
       expect(container.textContent).toContain("Custom content");
     });
 
-    it("handles multiple instruction blocks", () => {
+    it.skip("handles multiple instruction blocks", () => {
       const content = "<tag1>Content 1</tag1>\n\n<tag2>Content 2</tag2>";
       const { container } = render(
         <AgentMessageMarkdown owner={mockOwner} content={content} />
@@ -154,7 +154,7 @@ describe("AgentMessageMarkdown - Integration Tests", () => {
       expect(container.textContent).toContain("Content 2");
     });
 
-    it("renders markdown inside instruction blocks", () => {
+    it.skip("renders markdown inside instruction blocks", () => {
       const content =
         "<instructions>**Bold** and *italic* content</instructions>";
       const { container } = render(
@@ -166,7 +166,7 @@ describe("AgentMessageMarkdown - Integration Tests", () => {
   });
 
   describe("Complex Content Scenarios", () => {
-    it("renders mixed markdown and instruction blocks", () => {
+    it.skip("renders mixed markdown and instruction blocks", () => {
       const content = `# Heading
 
 Regular paragraph with **bold** text.

--- a/front/components/assistant/AgentMessageMarkdown.tsx
+++ b/front/components/assistant/AgentMessageMarkdown.tsx
@@ -7,11 +7,6 @@ import {
   getCiteDirective,
 } from "@app/components/markdown/CiteBlock";
 import { getImgPlugin, imgDirective } from "@app/components/markdown/Image";
-import {
-  InstructionBlock,
-  instructionBlockDirective,
-  preprocessInstructionBlocks,
-} from "@app/components/markdown/InstructionBlock";
 import { quickReplyDirective } from "@app/components/markdown/QuickReplyBlock";
 import { toolDirective } from "@app/components/markdown/tool/tool";
 import { visualizationDirective } from "@app/components/markdown/VisualizationBlock";
@@ -44,12 +39,6 @@ export const AgentMessageMarkdown = ({
   forcedTextSize?: string;
   canCopyQuotes?: boolean;
 }) => {
-  // Preprocess content to handle instruction blocks
-  const processedContent = React.useMemo(
-    () => preprocessInstructionBlocks(content),
-    [content]
-  );
-
   const markdownComponents: Components = React.useMemo(
     () => ({
       sup: CiteBlock,
@@ -57,7 +46,6 @@ export const AgentMessageMarkdown = ({
       mention: getAgentMentionPlugin(owner),
       mention_user: getUserMentionPlugin(owner),
       dustimg: getImgPlugin(owner),
-      instruction_block: InstructionBlock,
       ...additionalMarkdownComponents,
     }),
     [owner, additionalMarkdownComponents]
@@ -72,14 +60,13 @@ export const AgentMessageMarkdown = ({
       imgDirective,
       toolDirective,
       quickReplyDirective,
-      instructionBlockDirective,
     ],
     []
   );
 
   return (
     <Markdown
-      content={processedContent}
+      content={content}
       additionalMarkdownComponents={markdownComponents}
       additionalMarkdownPlugins={additionalMarkdownPlugins}
       isLastMessage={isLastMessage}


### PR DESCRIPTION
## Description

Hotfix for https://dust4ai.slack.com/archives/C050SM8NSPK/p1767109691566489
This disables the instruction blocks on agent message markdown. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front.