### PR TITLE
[Front] fix(agent-builder): reset local state on capabilities sheet save

### DIFF
--- a/front/components/agent_builder/capabilities/capabilities_sheet/hooks.ts
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/hooks.ts
@@ -52,8 +52,14 @@ export const useSkillSelection = ({
 
   // Draft state for space selection (only committed on save)
   const [draftSelectedSpaces, setDraftSelectedSpaces] = useState<string[]>(
-    localAdditionalSpaces
+    initialAdditionalSpaces
   );
+
+  const resetLocalState = useCallback(() => {
+    setLocalSelectedSkills([]);
+    setLocalAdditionalSpaces(initialAdditionalSpaces);
+    setDraftSelectedSpaces(initialAdditionalSpaces);
+  }, [initialAdditionalSpaces]);
 
   const { skills, isSkillsLoading } = useSkillsContext();
 
@@ -150,6 +156,7 @@ export const useSkillSelection = ({
     handleSpaceSelectionSave,
     draftSelectedSpaces,
     setDraftSelectedSpaces,
+    resetLocalState,
   };
 };
 
@@ -168,6 +175,10 @@ export const useToolSelection = ({
   const [localSelectedTools, setLocalSelectedTools] = useState<SelectedTool[]>(
     []
   );
+
+  const resetLocalState = useCallback(() => {
+    setLocalSelectedTools([]);
+  }, []);
 
   const selectedMCPServerViewIds = useMemo(() => {
     return new Set(localSelectedTools.map((t) => t.view.sId));
@@ -341,5 +352,6 @@ export const useToolSelection = ({
     selectedMCPServerViewIds,
     allMcpServerViews,
     handleToolConfigurationSave,
+    resetLocalState,
   };
 };

--- a/front/components/agent_builder/capabilities/capabilities_sheet/utils.tsx
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/utils.tsx
@@ -73,14 +73,10 @@ export function useCapabilitiesPageAndFooter({
       additionalSpaces: skillSelection.localAdditionalSpaces,
       tools: toolSelection.localSelectedTools,
     });
+    skillSelection.resetLocalState();
+    toolSelection.resetLocalState();
     onClose();
-  }, [
-    skillSelection.localSelectedSkills,
-    skillSelection.localAdditionalSpaces,
-    toolSelection.localSelectedTools,
-    onCapabilitiesSave,
-    onClose,
-  ]);
+  }, [skillSelection, toolSelection, onCapabilitiesSave, onClose]);
 
   const handleToolEditSave = useCallback(
     (mode: ToolEditMode) => (formData: MCPFormData) => {


### PR DESCRIPTION
## Description

Since the capabilities multi sheet is no longer unmounted when closed, the local state was not properly reset after saving changes. This PR fixes this by exposing reset local skill/tool selection state in hooks

## Tests

Local.

## Risk

Low.

## Deploy Plan

Deploy front.
