### PR TITLE
[front] refactor(skills): uniformize fetch methods on `SkillResource`

### DIFF
--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -215,29 +215,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     });
   }
 
-  private static fetchBySkillReferences(
-    auth: Authenticator,
-    refs: {
-      customSkillId: ModelId | null;
-      globalSkillId: string | null;
-    }[],
-    context: { agentConfiguration?: LightAgentConfigurationType } = {}
-  ): Promise<SkillResource[]> {
-    const customSkillModelIds = removeNulls(refs.map((r) => r.customSkillId));
-    const globalSkillIds = removeNulls(refs.map((r) => r.globalSkillId));
-
-    return this.baseFetch(
-      auth,
-      {
-        where: {
-          id: customSkillModelIds,
-          sId: globalSkillIds,
-        },
-      },
-      context
-    );
-  }
-
   private static async baseFetch(
     auth: Authenticator,
     options: SkillConfigurationFindOptions = {},
@@ -451,6 +428,29 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     }
 
     return resources[0];
+  }
+
+  private static fetchBySkillReferences(
+    auth: Authenticator,
+    refs: {
+      customSkillId: ModelId | null;
+      globalSkillId: string | null;
+    }[],
+    context: { agentConfiguration?: LightAgentConfigurationType } = {}
+  ): Promise<SkillResource[]> {
+    const customSkillModelIds = removeNulls(refs.map((r) => r.customSkillId));
+    const globalSkillIds = removeNulls(refs.map((r) => r.globalSkillId));
+
+    return this.baseFetch(
+      auth,
+      {
+        where: {
+          id: customSkillModelIds,
+          sId: globalSkillIds,
+        },
+      },
+      context
+    );
   }
 
   static async listByAgentConfiguration(

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -443,7 +443,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       },
     });
 
-    const customSkillIds = removeNulls(
+    const customSkillModelIds = removeNulls(
       agentSkills.map((as) => as.customSkillId)
     );
     const globalSkillIds = removeNulls(
@@ -452,7 +452,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
     return this.baseFetch(auth, {
       where: {
-        id: customSkillIds,
+        id: customSkillModelIds,
         sId: globalSkillIds,
       },
     });
@@ -526,28 +526,23 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       },
     });
 
-    const customSkillIds = removeNulls(
-      conversationSkills.map((cs) =>
-        cs.customSkillId
-          ? SkillResource.modelIdToSId({
-              id: cs.customSkillId,
-              workspaceId: workspace.id,
-            })
-          : null
-      )
+    const customSkillModelIds = removeNulls(
+      conversationSkills.map((cs) => cs.customSkillId)
     );
-
     const globalSkillIds = removeNulls(
       conversationSkills.map((cs) => cs.globalSkillId)
     );
 
-    const allSkillIds = [...customSkillIds, ...globalSkillIds];
-
-    if (allSkillIds.length === 0) {
-      return [];
-    }
-
-    return SkillResource.fetchByIds(auth, allSkillIds, { agentConfiguration });
+    return this.baseFetch(
+      auth,
+      {
+        where: {
+          id: customSkillModelIds,
+          sId: globalSkillIds,
+        },
+      },
+      { agentConfiguration }
+    );
   }
 
   /**
@@ -1205,17 +1200,19 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       where,
     });
 
-    const customSkills = await this.fetchByModelIds(
-      auth,
-      removeNulls(agentMessageSkills.map((ams) => ams.customSkillId))
+    const customSkillModelIds = removeNulls(
+      agentMessageSkills.map((ams) => ams.customSkillId)
+    );
+    const globalSkillIds = removeNulls(
+      agentMessageSkills.map((ams) => ams.globalSkillId)
     );
 
-    const globalSkills = await this.fetchByIds(
-      auth,
-      removeNulls(agentMessageSkills.map((ams) => ams.globalSkillId))
-    );
-
-    return [...customSkills, ...globalSkills];
+    return this.baseFetch(auth, {
+      where: {
+        id: customSkillModelIds,
+        sId: globalSkillIds,
+      },
+    });
   }
 
   static async deleteAllForWorkspace(auth: Authenticator): Promise<void> {

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -604,7 +604,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     const extendedSkillIds = removeNulls(
       uniq(skills.map((skill) => skill.extendedSkillId))
     );
-    const extendedSkills = await SkillResource.fetchByIds(
+    const extendedSkills = await this.fetchByIds(
       auth,
       extendedSkillIds
     );

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -215,6 +215,29 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     });
   }
 
+  private static fetchBySkillReferences(
+    auth: Authenticator,
+    refs: {
+      customSkillId: ModelId | null;
+      globalSkillId: string | null;
+    }[],
+    context: { agentConfiguration?: LightAgentConfigurationType } = {}
+  ): Promise<SkillResource[]> {
+    const customSkillModelIds = removeNulls(refs.map((r) => r.customSkillId));
+    const globalSkillIds = removeNulls(refs.map((r) => r.globalSkillId));
+
+    return this.baseFetch(
+      auth,
+      {
+        where: {
+          id: customSkillModelIds,
+          sId: globalSkillIds,
+        },
+      },
+      context
+    );
+  }
+
   private static async baseFetch(
     auth: Authenticator,
     options: SkillConfigurationFindOptions = {},
@@ -443,19 +466,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       },
     });
 
-    const customSkillModelIds = removeNulls(
-      agentSkills.map((as) => as.customSkillId)
-    );
-    const globalSkillIds = removeNulls(
-      agentSkills.map((as) => as.globalSkillId)
-    );
-
-    return this.baseFetch(auth, {
-      where: {
-        id: customSkillModelIds,
-        sId: globalSkillIds,
-      },
-    });
+    return this.fetchBySkillReferences(auth, agentSkills);
   }
 
   static modelIdToSId({
@@ -526,23 +537,9 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       },
     });
 
-    const customSkillModelIds = removeNulls(
-      conversationSkills.map((cs) => cs.customSkillId)
-    );
-    const globalSkillIds = removeNulls(
-      conversationSkills.map((cs) => cs.globalSkillId)
-    );
-
-    return this.baseFetch(
-      auth,
-      {
-        where: {
-          id: customSkillModelIds,
-          sId: globalSkillIds,
-        },
-      },
-      { agentConfiguration }
-    );
+    return this.fetchBySkillReferences(auth, conversationSkills, {
+      agentConfiguration,
+    });
   }
 
   /**
@@ -604,10 +601,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     const extendedSkillIds = removeNulls(
       uniq(skills.map((skill) => skill.extendedSkillId))
     );
-    const extendedSkills = await this.fetchByIds(
-      auth,
-      extendedSkillIds
-    );
+    const extendedSkills = await this.fetchByIds(auth, extendedSkillIds);
 
     // Create a map for quick lookup of extended skills.
     const extendedSkillsMap = new Map(
@@ -634,19 +628,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       },
     });
 
-    const customSkillModelIds = removeNulls(
-      conversationSkills.map((cs) => cs.customSkillId)
-    );
-    const globalSkillIds = removeNulls(
-      conversationSkills.map((cs) => cs.globalSkillId)
-    );
-
-    return this.baseFetch(auth, {
-      where: {
-        id: customSkillModelIds,
-        sId: globalSkillIds,
-      },
-    });
+    return this.fetchBySkillReferences(auth, conversationSkills);
   }
 
   async upsertToConversation(
@@ -1200,19 +1182,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       where,
     });
 
-    const customSkillModelIds = removeNulls(
-      agentMessageSkills.map((ams) => ams.customSkillId)
-    );
-    const globalSkillIds = removeNulls(
-      agentMessageSkills.map((ams) => ams.globalSkillId)
-    );
-
-    return this.baseFetch(auth, {
-      where: {
-        id: customSkillModelIds,
-        sId: globalSkillIds,
-      },
-    });
+    return this.fetchBySkillReferences(auth, agentMessageSkills);
   }
 
   static async deleteAllForWorkspace(auth: Authenticator): Promise<void> {


### PR DESCRIPTION
## Description

- On `SkillResource` we have to fetch custom and global skills at a few places.
- We currently have a mix of different approaches: `fetchByModelIds` for custom and `fetchByIds` for global, turn model IDs into `sId` and `fetchByIds`, or `baseFetch`.
- This PR uniformizes on a direct call to `baseFetch`, which supports this out of the box, and adds a method `fetchBySkillReferences`.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
