### PR TITLE
[front] fix: Accumulate report failures instead of overide them

### DIFF
--- a/front/types/production_checks.ts
+++ b/front/types/production_checks.ts
@@ -50,7 +50,11 @@ export interface CheckResult {
   checkName: string;
   status: CheckResultStatus;
   timestamp: string;
-  payload: CheckSuccessPayload | CheckFailurePayload | null;
+  payload:
+    | CheckSuccessPayload
+    | CheckFailurePayload
+    | CheckFailurePayload[]
+    | null;
   errorMessage: string | null;
   actionLinks: ActionLink[];
 }
@@ -61,7 +65,11 @@ export interface CheckActivityResult {
   checkName: string;
   status: CheckActivityResultStatus;
   timestamp: string;
-  payload: CheckSuccessPayload | CheckFailurePayload | null;
+  payload:
+    | CheckSuccessPayload
+    | CheckFailurePayload
+    | CheckFailurePayload[]
+    | null;
   errorMessage: string | null;
   actionLinks: ActionLink[];
 }


### PR DESCRIPTION
## Description

reportFailure can get called many times in some production checks (like `managedDataSourceGCGdriveCheck`) while the current code was assuming it should be called once. 
So failure flags and action links per check could be override, instead we now accumulate them.
This has the potential to increase the footprint (and cost) of production checks. I'm not too concerned given the low frequency and we have 1 activity.

This bug was not affecting datadog monitor, it's aimed at making poke/production-checks actually surface problems.

## Tests

Tested locally

## Risk

Low
Blast radius: Production check page

## Deploy Plan

- [ ] deploy front