### PR TITLE
[front] refactor(skills): add getter `skillReference`

### DIFF
--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -430,6 +430,9 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     return resources[0];
   }
 
+  /**
+   * Fetches skills from rows that reference them via customSkillId or globalSkillId.
+   */
   private static fetchBySkillReferences(
     auth: Authenticator,
     refs: {
@@ -453,6 +456,9 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     );
   }
 
+  /**
+   * Returns the fields to identify this skill in related tables (e.g., AgentSkillModel).
+   */
   private get skillReference():
     | { globalSkillId: string }
     | { customSkillId: ModelId } {


### PR DESCRIPTION
## Description

- On every table that references a skill we have a unifying way of referencing a skill: either a `globalSkillId`, which is a string, or a `customSkillId`, which is a model ID (FK on `skill_configurations`).
- This abstraction is bundled within the `SkillResource`, and this PR adds a helper that helps writing the corresponding Sequelize where clauses to go from the current instance to a reference to it.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
