### PR TITLE
[front] - fix(AB): prevent re-selection of already selected skill

### DIFF
--- a/front/components/agent_builder/capabilities/capabilities_sheet/SkillCard.tsx
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/SkillCard.tsx
@@ -23,7 +23,7 @@ export function SkillCard({
       label={skill.name}
       description={skill.userFacingDescription}
       isSelected={isSelected}
-      canAdd
+      canAdd={!isSelected}
       onClick={onClick}
       cardContainerClassName="h-36"
       mountPortal


### PR DESCRIPTION

## Description

This PR modifies the `SkillCard` component to disable the add button when a skill is already selected, preventing redundant selections.

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front