### PR TITLE
Fix Jira create issue

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/jira/types.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/jira/types.ts
@@ -509,11 +509,15 @@ export const JiraSearchResultSchema = z.object({
 
 export const JiraCreateIssueRequestSchema = JiraIssueFieldsSchema.partial({
   description: true,
+  status: true,
   priority: true,
   assignee: true,
   reporter: true,
   labels: true,
   parent: true,
+  created: true,
+  updated: true,
+  duedate: true,
 })
   .extend({
     description: z.union([z.string(), ADFDocumentSchema]).optional(),


### PR DESCRIPTION
## Description

The JiraCreateIssueRequestSchema was missing several fields in its .partial() call, causing Zod validation to fail when these fields weren't provided:

- status - Read-only field (status changes must go through transitions)
- created - Read-only field (set automatically by Jira)
- updated - Read-only field (set automatically by Jira)
- duedate - Optional field

The status field is already stripped by processFieldsForJira() before sending to the API, but schema validation was failing before that processing could occur.

## Tests

Locally. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 