### PR TITLE
[front] fix: do not stop unpause connector cli for connectors running

### DIFF
--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -175,7 +175,11 @@ const workspace = async (command: string, args: parseArgs.ParsedArgs) => {
           console.log(`Unpausing connectorId=${connectorId}`);
           const res = await connectorsAPI.unpauseConnector(connectorId);
           if (res.isErr()) {
-            throw new Error(res.error.message);
+            if (res.error.message == "Connector is not stopped") {
+              logger.error(res.error.message);
+            } else {
+              throw new Error(res.error.message);
+            }
           }
         }
       }

--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -175,7 +175,7 @@ const workspace = async (command: string, args: parseArgs.ParsedArgs) => {
           console.log(`Unpausing connectorId=${connectorId}`);
           const res = await connectorsAPI.unpauseConnector(connectorId);
           if (res.isErr()) {
-            if (res.error.message == "Connector is not stopped") {
+            if (res.error.message === "Connector is not stopped") {
               logger.error(res.error.message);
             } else {
               throw new Error(res.error.message);

--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -172,7 +172,7 @@ const workspace = async (command: string, args: parseArgs.ParsedArgs) => {
           logger
         );
         for (const connectorId of connectorIds) {
-          console.log(`Unpausing connectorId=${connectorId}`);
+            logger.info(`Unpausing connectorId=${connectorId}`);
           const res = await connectorsAPI.unpauseConnector(connectorId);
           if (res.isErr()) {
             if (res.error.message === "Connector is not stopped") {

--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -172,7 +172,7 @@ const workspace = async (command: string, args: parseArgs.ParsedArgs) => {
           logger
         );
         for (const connectorId of connectorIds) {
-            logger.info(`Unpausing connectorId=${connectorId}`);
+          logger.info(`Unpausing connectorId=${connectorId}`);
           const res = await connectorsAPI.unpauseConnector(connectorId);
           if (res.isErr()) {
             if (res.error.message === "Connector is not stopped") {


### PR DESCRIPTION
## Description

To be consistent with https://github.com/dust-tt/dust/blob/main/front/lib/api/subscription.ts#L20-L20 (and also make the command actually usable) we don't stop the execution if a connector is not paused, we log it and continue.

## Tests

Tested in prodbox.

## Risk

Low

## Deploy Plan

- no deploy required