### PR TITLE
[front] - feat(AB): skill info sheet

### DIFF
--- a/front/components/agent_builder/capabilities/capabilities_sheet/SkillInfoPage.tsx
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/SkillInfoPage.tsx
@@ -1,0 +1,159 @@
+import {
+  Avatar,
+  InformationCircleIcon,
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+  UserGroupIcon,
+} from "@dust-tt/sparkle";
+import React, { useMemo, useState } from "react";
+
+import { useDataSourceViewsContext } from "@app/components/agent_builder/DataSourceViewsContext";
+import { useSpacesContext } from "@app/components/agent_builder/SpacesContext";
+import { SkillDetailsButtonBar } from "@app/components/skills/SkillDetailsButtonBar";
+import { SkillEditorsTab } from "@app/components/skills/SkillEditorsTab";
+import { SkillInfoTab } from "@app/components/skills/SkillInfoTab";
+import { hasRelations } from "@app/lib/skill";
+import type { UserType, WorkspaceType } from "@app/types";
+import type { SkillWithRelationsType } from "@app/types/assistant/skill_configuration";
+
+type SkillTabType = "info" | "editors";
+
+interface SkillInfoPageProps {
+  skill: SkillWithRelationsType;
+  owner: WorkspaceType;
+  user: UserType;
+  onClose: () => void;
+}
+
+export function SkillInfoPage({
+  skill,
+  owner,
+  user,
+  onClose,
+}: SkillInfoPageProps) {
+  const [selectedTab, setSelectedTab] = useState<SkillTabType>("info");
+  const showEditorsTabs = skill.canWrite;
+
+  return (
+    <div className="flex h-full flex-col gap-4">
+      {skill.status !== "archived" && (
+        <div className="-ml-1.5">
+          <SkillDetailsButtonBar
+            owner={owner}
+            skill={skill}
+            onClose={onClose}
+          />
+        </div>
+      )}
+
+      {showEditorsTabs ? (
+        <Tabs value={selectedTab}>
+          <TabsList border={false}>
+            <TabsTrigger
+              value="info"
+              label="Info"
+              icon={InformationCircleIcon}
+              onClick={() => setSelectedTab("info")}
+            />
+            <TabsTrigger
+              value="editors"
+              label="Editors"
+              icon={UserGroupIcon}
+              onClick={() => setSelectedTab("editors")}
+            />
+          </TabsList>
+          <div className="mt-4">
+            <TabsContent value="info">
+              <SkillInfoContent owner={owner} skill={skill} />
+            </TabsContent>
+            <TabsContent value="editors">
+              {hasRelations(skill) && (
+                <SkillEditorsTab
+                  skillConfiguration={skill}
+                  owner={owner}
+                  user={user}
+                />
+              )}
+            </TabsContent>
+          </div>
+        </Tabs>
+      ) : (
+        <SkillInfoContent owner={owner} skill={skill} />
+      )}
+    </div>
+  );
+}
+
+function SkillInfoContent({
+  owner,
+  skill,
+}: {
+  owner: WorkspaceType;
+  skill: SkillWithRelationsType;
+}) {
+  const { spaces } = useSpacesContext();
+  const { supportedDataSourceViews, isDataSourceViewsLoading } =
+    useDataSourceViewsContext();
+
+  const editedAt = useMemo(() => {
+    if (!skill.updatedAt) {
+      return null;
+    }
+    return new Date(skill.updatedAt).toLocaleDateString("en-US", {
+      year: "2-digit",
+      month: "2-digit",
+      day: "2-digit",
+    });
+  }, [skill.updatedAt]);
+
+  const editedBy = useMemo(
+    () => skill.relations.author?.fullName ?? null,
+    [skill.relations.author?.fullName]
+  );
+
+  const editorsForAvatars = useMemo(() => {
+    const seen = new Set<string>();
+    const users: UserType[] = [];
+    const maybePush = (u: UserType | null | undefined) => {
+      if (!u || seen.has(u.sId)) {
+        return;
+      }
+      seen.add(u.sId);
+      users.push(u);
+    };
+    maybePush(skill.relations.author);
+    for (const editor of skill.relations.editors ?? []) {
+      maybePush(editor);
+    }
+    return users.slice(0, 3);
+  }, [skill.relations.author, skill.relations.editors]);
+
+  return (
+    <div className="flex flex-col gap-4">
+      {editedBy && editedAt && (
+        <div className="flex items-center justify-between gap-3 text-sm text-muted-foreground dark:text-muted-foreground-night">
+          <div>
+            Edited by {editedBy}, {editedAt}
+          </div>
+          {editorsForAvatars.length > 0 && (
+            <div className="flex items-center -space-x-2">
+              {editorsForAvatars.map((u) => (
+                <Avatar key={u.sId} size="sm" visual={u.image} isRounded />
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+      <SkillInfoTab
+        owner={owner}
+        skill={skill}
+        showDescription
+        spaces={spaces}
+        dataSourceViews={supportedDataSourceViews}
+        isDataSourceViewsLoading={isDataSourceViewsLoading}
+      />
+    </div>
+  );
+}

--- a/front/components/agent_builder/capabilities/capabilities_sheet/utils.tsx
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/utils.tsx
@@ -12,6 +12,7 @@ import {
   useSkillSelection,
   useToolSelection,
 } from "@app/components/agent_builder/capabilities/capabilities_sheet/hooks";
+import { SkillInfoPage } from "@app/components/agent_builder/capabilities/capabilities_sheet/SkillInfoPage";
 import { SpaceSelectionPageContent } from "@app/components/agent_builder/capabilities/capabilities_sheet/SpaceSelectionPage";
 import type { CapabilitiesSheetContentProps } from "@app/components/agent_builder/capabilities/capabilities_sheet/types";
 import { MCPServerConfigurationPage } from "@app/components/agent_builder/capabilities/mcp/MCPServerConfigurationPage";
@@ -29,7 +30,6 @@ import {
 } from "@app/components/agent_builder/capabilities/mcp/utils/infoPageUtils";
 import type { ConfigurationState } from "@app/components/agent_builder/skills/types";
 import { isConfigurationState } from "@app/components/agent_builder/skills/types";
-import { SkillDetailsSheetContent } from "@app/components/skills/SkillDetailsSheet";
 import { getAvatar } from "@app/lib/actions/mcp_icons";
 import { getSkillIcon } from "@app/lib/skill";
 import { assertNever } from "@app/types";
@@ -191,6 +191,10 @@ export function useCapabilitiesPageAndFooter({
           ? `${sheetState.capability.name} (extends ${sheetState.capability.relations.extendedSkill.name})`
           : sheetState.capability.name;
 
+        const handleClose = sheetState.hasPreviousPage
+          ? () => onStateChange({ state: "selection" })
+          : onClose;
+
         return {
           page: {
             title,
@@ -198,10 +202,11 @@ export function useCapabilitiesPageAndFooter({
             id: sheetState.state,
             icon: getSkillIcon(sheetState.capability.icon),
             content: (
-              <SkillDetailsSheetContent
+              <SkillInfoPage
                 skill={sheetState.capability}
                 owner={owner}
                 user={user}
+                onClose={handleClose}
               />
             ),
           },

--- a/front/components/skills/SkillDetailsSheet.tsx
+++ b/front/components/skills/SkillDetailsSheet.tsx
@@ -106,7 +106,7 @@ export function SkillDetailsSheetContent({
         </TabsList>
         <div className="mt-4">
           <TabsContent value="info">
-            <SkillInfoTab skill={skill} />
+            <SkillInfoTab skill={skill} owner={owner} />
           </TabsContent>
           <TabsContent value="editors">
             {hasRelations(skill) && (
@@ -122,7 +122,7 @@ export function SkillDetailsSheetContent({
     );
   }
 
-  return <SkillInfoTab skill={skill} />;
+  return <SkillInfoTab skill={skill} owner={owner} />;
 }
 
 type DescriptionSectionProps = {

--- a/front/components/skills/SkillInfoTab.tsx
+++ b/front/components/skills/SkillInfoTab.tsx
@@ -1,27 +1,117 @@
-import { Page, ReadOnlyTextArea } from "@dust-tt/sparkle";
+import { Chip, ReadOnlyTextArea, Separator, Spinner } from "@dust-tt/sparkle";
 import sortBy from "lodash/sortBy";
 import { useMemo } from "react";
 
+import { ResourceAvatar } from "@app/components/resources/resources_icons";
+import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import { getAvatar } from "@app/lib/actions/mcp_icons";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
+import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers_ui";
+import { getDisplayNameForDataSource } from "@app/lib/data_sources";
+import { getSpaceIcon, getSpaceName } from "@app/lib/spaces";
+import { useDataSourceViews } from "@app/lib/swr/data_source_views";
+import { useSpaces } from "@app/lib/swr/spaces";
+import type {
+  DataSourceViewType,
+  LightWorkspaceType,
+  SpaceType,
+} from "@app/types";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 
-export function SkillInfoTab({ skill }: { skill: SkillType }) {
+interface SkillInfoTabProps {
+  skill: SkillType;
+  owner: LightWorkspaceType;
+  spaces?: SpaceType[];
+  dataSourceViews?: DataSourceViewType[];
+  isDataSourceViewsLoading?: boolean;
+  showDescription?: boolean;
+}
+
+export function SkillInfoTab({
+  skill,
+  owner,
+  spaces,
+  dataSourceViews,
+  isDataSourceViewsLoading,
+  showDescription = true,
+}: SkillInfoTabProps) {
+  const { isDark } = useTheme();
+
+  const shouldLoadKnowledgeAndSpaces = skill.requestedSpaceIds.length > 0;
+  const { spaces: spacesFromHook, isSpacesLoading } = useSpaces({
+    workspaceId: owner.sId,
+    disabled: !shouldLoadKnowledgeAndSpaces || !!spaces,
+  });
+  const {
+    dataSourceViews: dataSourceViewsFromHook,
+    isDataSourceViewsLoading: isDataSourceViewsLoadingFromHook,
+  } = useDataSourceViews(owner, {
+    disabled: !shouldLoadKnowledgeAndSpaces || !!dataSourceViews,
+  });
+
+  const resolvedSpaces = spaces ?? spacesFromHook;
+  const resolvedDataSourceViews = dataSourceViews ?? dataSourceViewsFromHook;
+  const resolvedIsDataSourceViewsLoading =
+    isDataSourceViewsLoading ?? isDataSourceViewsLoadingFromHook;
+
   const sortedMCPServerViews = useMemo(
     () => sortBy(skill.tools.map(renderMCPServerView), "title"),
     [skill.tools]
   );
 
+  const requestedSpaces = useMemo(
+    () =>
+      resolvedSpaces
+        .filter((s) => skill.requestedSpaceIds.includes(s.sId))
+        .map((space) => ({
+          space,
+          name: getSpaceName(space),
+          Icon: getSpaceIcon(space),
+        })),
+    [resolvedSpaces, skill.requestedSpaceIds]
+  );
+
+  const sortedSpaces = useMemo(
+    () => sortBy(requestedSpaces, "name"),
+    [requestedSpaces]
+  );
+
+  const knowledgeViews = useMemo(() => {
+    if (!shouldLoadKnowledgeAndSpaces) {
+      return [];
+    }
+    return resolvedDataSourceViews.filter((dsv) =>
+      skill.requestedSpaceIds.includes(dsv.spaceId)
+    );
+  }, [
+    resolvedDataSourceViews,
+    shouldLoadKnowledgeAndSpaces,
+    skill.requestedSpaceIds,
+  ]);
+
+  const sortedKnowledgeViews = useMemo(
+    () =>
+      sortBy(knowledgeViews, (dsv) =>
+        getDisplayNameForDataSource(dsv.dataSource)
+      ),
+    [knowledgeViews]
+  );
+
+  const showSeparator =
+    !!skill.instructions ||
+    sortedMCPServerViews.length > 0 ||
+    shouldLoadKnowledgeAndSpaces;
+
   return (
     <div className="flex flex-col gap-4">
-      {skill.userFacingDescription && (
+      {showDescription && skill.userFacingDescription ? (
         <div className="text-sm text-foreground dark:text-foreground-night">
           {skill.userFacingDescription}
         </div>
-      )}
+      ) : null}
 
-      <Page.Separator />
+      {showSeparator ? <Separator /> : null}
 
       {skill.instructions && (
         <div className="dd-privacy-mask flex flex-col gap-5">
@@ -32,26 +122,73 @@ export function SkillInfoTab({ skill }: { skill: SkillType }) {
         </div>
       )}
 
+      {shouldLoadKnowledgeAndSpaces ? (
+        <div className="flex flex-col gap-5">
+          <div className="heading-lg text-foreground dark:text-foreground-night">
+            Knowledge
+          </div>
+          {resolvedIsDataSourceViewsLoading ? (
+            <div className="flex flex-row items-center gap-2">
+              <Spinner size="xs" />
+            </div>
+          ) : sortedKnowledgeViews.length > 0 ? (
+            <div className="flex flex-wrap gap-2">
+              {sortedKnowledgeViews.map((dsv) => {
+                const Logo = getConnectorProviderLogoWithFallback({
+                  provider: dsv.dataSource.connectorProvider,
+                  isDark,
+                });
+                const title = getDisplayNameForDataSource(dsv.dataSource);
+                return (
+                  <Chip key={dsv.sId} label={title} size="sm">
+                    <ResourceAvatar icon={Logo} size="xs" />
+                  </Chip>
+                );
+              })}
+            </div>
+          ) : (
+            <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+              No knowledge sources found in the required spaces.
+            </div>
+          )}
+        </div>
+      ) : null}
+
       {sortedMCPServerViews.length > 0 && (
         <div className="flex flex-col gap-5">
           <div className="heading-lg text-foreground dark:text-foreground-night">
             Tools
           </div>
-          <div className="grid grid-cols-2 gap-2">
+          <div className="flex flex-wrap gap-2">
             {sortedMCPServerViews.map((view) => (
-              <div
-                className="flex min-w-0 flex-row items-center gap-2"
-                key={view.title}
-              >
+              <Chip key={view.title} label={view.title} size="sm">
                 {view.avatar}
-                <div className="truncate" title={view.title}>
-                  {view.title}
-                </div>
-              </div>
+              </Chip>
             ))}
           </div>
         </div>
       )}
+
+      {shouldLoadKnowledgeAndSpaces ? (
+        <div className="flex flex-col gap-5">
+          <div className="heading-lg text-foreground dark:text-foreground-night">
+            Spaces
+          </div>
+          {isSpacesLoading ? (
+            <div className="flex flex-row items-center gap-2">
+              <Spinner size="xs" />
+            </div>
+          ) : sortedSpaces.length > 0 ? (
+            <div className="flex flex-wrap gap-2">
+              {sortedSpaces.map(({ space, name, Icon }) => (
+                <Chip key={space.sId} label={name} size="sm">
+                  <Icon className="h-4 w-4 text-muted-foreground dark:text-muted-foreground-night" />
+                </Chip>
+              ))}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## Description

Creates a new `SkillInfoPage` component to display skill information in the capabilities sheet within the agent builder. This replaces the previous `SkillDetailsSheetContent` usage and provides a more consistent experience when viewing skill details from the capabilities selection flow. The component shows skill metadata (last edited by/date), tabs for info and editors (if user has write permission), and integrates the `SkillDetailsButtonBar` for actions.

<img width="716" height="1018" alt="Screenshot 2025-12-31 at 13 12 14" src="https://github.com/user-attachments/assets/7f547ead-f543-4389-b31a-0d898986d4d4" />

**References:**
- https://github.com/dust-tt/tasks/issues/5772

## Risk

Low - behind FF

## Tests

Locally

## Deploy Plan


Deploy front