### PR TITLE
[front] feat: Improve production check display and failure collection

### DIFF
--- a/front/lib/production_checks/checks/managed_data_source_gdrive_gc.ts
+++ b/front/lib/production_checks/checks/managed_data_source_gdrive_gc.ts
@@ -114,7 +114,7 @@ export const managedDataSourceGCGdriveCheck: CheckFunction = async (
           "Google Drive documents not properly Garbage collected"
         );
       } else {
-        reportSuccess({ connectorId: ds.connectorId });
+        reportSuccess();
       }
     },
     { concurrency: CONCURRENCY }

--- a/front/temporal/production_checks/activities.ts
+++ b/front/temporal/production_checks/activities.ts
@@ -127,7 +127,7 @@ async function runAllChecks(checks: Check[]): Promise<CheckActivityResult[]> {
             "Production check failed"
           );
           checkSucceeded = false;
-          allFailurePayloads.push(payload);
+          allFailurePayloads.push({ ...payload, errorMessage: message });
           errorMessages.push(message);
           allActionLinks.push(...(payload.actionLinks ?? []));
         };
@@ -164,7 +164,9 @@ async function runAllChecks(checks: Check[]): Promise<CheckActivityResult[]> {
               ? allFailurePayloads
               : null,
           errorMessage:
-            errorMessages.length > 0 ? errorMessages.join("; ") : null,
+            errorMessages.length > 0
+              ? [...new Set(errorMessages)].join("; ")
+              : null,
           actionLinks: allActionLinks,
         });
 
@@ -217,7 +219,7 @@ export async function runSingleCheckActivity(
   const reportFailure = (payload: CheckFailurePayload, message: string) => {
     logger.error({ payload, errorMessage: message }, "Production check failed");
     checkSucceeded = false;
-    allFailurePayloads.push(payload);
+    allFailurePayloads.push({ ...payload, errorMessage: message });
     errorMessages.push(message);
     allActionLinks.push(...(payload.actionLinks ?? []));
   };
@@ -258,7 +260,8 @@ export async function runSingleCheckActivity(
       : allFailurePayloads.length > 0
         ? allFailurePayloads
         : null,
-    errorMessage: errorMessages.length > 0 ? errorMessages.join("; ") : null,
+    errorMessage:
+      errorMessages.length > 0 ? [...new Set(errorMessages)].join("; ") : null,
     actionLinks: allActionLinks,
   };
 }

--- a/front/types/production_checks.ts
+++ b/front/types/production_checks.ts
@@ -9,6 +9,7 @@ export interface ActionLink {
 // Payload types for check functions
 export interface CheckFailurePayload {
   actionLinks: ActionLink[];
+  errorMessage?: string;
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
## Description

- Add a copy to clipboard button on gdrive gc production check (useful when you have 2k+ docs to gc)
<details><summary>preview</summary>
<p>

<img width="552" height="583" alt="image" src="https://github.com/user-attachments/assets/11cf2331-d283-4954-b50d-2e24cb0aec76" />


</p>
</details> 

- Add a "running" status to give some feedback to the user.
- Improve errors displaying in runs history
- Misc UX improvements.

## Tests

Tested on front-edge


## Risk

Low
Blast radius: production check poke page

## Deploy Plan

- [ ] Deploy front