### PR TITLE
[front] - refacto(skills): skill routing

### DIFF
--- a/front/components/agent_builder/skills/AgentBuilderSkillsBlock.tsx
+++ b/front/components/agent_builder/skills/AgentBuilderSkillsBlock.tsx
@@ -24,6 +24,7 @@ import { CapabilitiesSheet } from "@app/components/agent_builder/capabilities/ca
 import type { SelectedTool } from "@app/components/agent_builder/capabilities/capabilities_sheet/types";
 import { KnowledgeConfigurationSheet } from "@app/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet";
 import { validateMCPActionConfiguration } from "@app/components/agent_builder/capabilities/mcp/utils/formValidation";
+import { getSheetStateForActionEdit } from "@app/components/agent_builder/skills/sheetRouting";
 import type { SheetState } from "@app/components/agent_builder/skills/types";
 import { isCapabilitiesSheetOpen } from "@app/components/agent_builder/skills/types";
 import { useSpacesContext } from "@app/components/agent_builder/SpacesContext";
@@ -213,34 +214,13 @@ export function AgentBuilderSkillsBlock() {
   };
 
   const handleActionEdit = (action: BuilderAction, index: number) => {
-    const mcpServerViewWithKnowledge = mcpServerViewsWithKnowledge.find(
-      (view) => view.sId === action.configuration?.mcpServerViewId
-    );
-    const isDataSourceSelectionRequired = Boolean(mcpServerViewWithKnowledge);
-
-    if (isDataSourceSelectionRequired) {
-      setSheetState({ state: "knowledge", action, index });
-      return;
-    }
-
-    const mcpServerViewWithoutKnowledge = mcpServerViewsWithoutKnowledge.find(
-      (view) => view.sId === action.configuration?.mcpServerViewId
-    );
-
     setSheetState(
-      action.configurationRequired && mcpServerViewWithoutKnowledge
-        ? {
-            state: "configuration",
-            capability: action,
-            mcpServerView: mcpServerViewWithoutKnowledge,
-            index,
-          }
-        : {
-            state: "info",
-            kind: "tool",
-            capability: action,
-            hasPreviousPage: false,
-          }
+      getSheetStateForActionEdit({
+        action,
+        index,
+        mcpServerViewsWithKnowledge,
+        mcpServerViewsWithoutKnowledge,
+      })
     );
   };
 

--- a/front/components/agent_builder/skills/sheetRouting.ts
+++ b/front/components/agent_builder/skills/sheetRouting.ts
@@ -1,7 +1,10 @@
+import type {
+  ConfigurationState,
+  InfoState,
+  KnowledgeState,
+} from "@app/components/agent_builder/skills/types";
 import type { MCPServerViewTypeWithLabel } from "@app/components/shared/tools_picker/MCPServerViewsContext";
 import type { BuilderAction } from "@app/components/shared/tools_picker/types";
-
-import type { ConfigurationState, InfoState, KnowledgeState } from "./types";
 
 export function getKnowledgeMCPServerViewForAction(
   action: BuilderAction,

--- a/front/components/agent_builder/skills/sheetRouting.ts
+++ b/front/components/agent_builder/skills/sheetRouting.ts
@@ -25,6 +25,11 @@ export function getNonKnowledgeMCPServerViewForAction(
   );
 }
 
+type ActionEditState =
+  | KnowledgeState
+  | ConfigurationState
+  | InfoState<"tool", BuilderAction>;
+
 export function getSheetStateForActionEdit({
   action,
   index,
@@ -35,7 +40,7 @@ export function getSheetStateForActionEdit({
   index: number;
   mcpServerViewsWithKnowledge: MCPServerViewTypeWithLabel[];
   mcpServerViewsWithoutKnowledge: MCPServerViewTypeWithLabel[];
-}): KnowledgeState | ConfigurationState | InfoState<"tool", BuilderAction> {
+}): ActionEditState {
   const knowledgeView = getKnowledgeMCPServerViewForAction(
     action,
     mcpServerViewsWithKnowledge

--- a/front/components/agent_builder/skills/sheetRouting.ts
+++ b/front/components/agent_builder/skills/sheetRouting.ts
@@ -1,0 +1,68 @@
+import type { MCPServerViewTypeWithLabel } from "@app/components/shared/tools_picker/MCPServerViewsContext";
+import type { BuilderAction } from "@app/components/shared/tools_picker/types";
+
+import type { ConfigurationState, InfoState, KnowledgeState } from "./types";
+
+export function getKnowledgeMCPServerViewForAction(
+  action: BuilderAction,
+  mcpServerViewsWithKnowledge: MCPServerViewTypeWithLabel[]
+): MCPServerViewTypeWithLabel | null {
+  return (
+    mcpServerViewsWithKnowledge.find(
+      (view) => view.sId === action.configuration?.mcpServerViewId
+    ) ?? null
+  );
+}
+
+export function getNonKnowledgeMCPServerViewForAction(
+  action: BuilderAction,
+  mcpServerViewsWithoutKnowledge: MCPServerViewTypeWithLabel[]
+): MCPServerViewTypeWithLabel | null {
+  return (
+    mcpServerViewsWithoutKnowledge.find(
+      (view) => view.sId === action.configuration?.mcpServerViewId
+    ) ?? null
+  );
+}
+
+export function getSheetStateForActionEdit({
+  action,
+  index,
+  mcpServerViewsWithKnowledge,
+  mcpServerViewsWithoutKnowledge,
+}: {
+  action: BuilderAction;
+  index: number;
+  mcpServerViewsWithKnowledge: MCPServerViewTypeWithLabel[];
+  mcpServerViewsWithoutKnowledge: MCPServerViewTypeWithLabel[];
+}): KnowledgeState | ConfigurationState | InfoState<"tool", BuilderAction> {
+  const knowledgeView = getKnowledgeMCPServerViewForAction(
+    action,
+    mcpServerViewsWithKnowledge
+  );
+
+  if (knowledgeView) {
+    return { state: "knowledge", action, index };
+  }
+
+  const toolView = getNonKnowledgeMCPServerViewForAction(
+    action,
+    mcpServerViewsWithoutKnowledge
+  );
+
+  if (action.configurationRequired && toolView) {
+    return {
+      state: "configuration",
+      capability: action,
+      mcpServerView: toolView,
+      index,
+    };
+  }
+
+  return {
+    state: "info",
+    kind: "tool",
+    capability: action,
+    hasPreviousPage: false,
+  };
+}


### PR DESCRIPTION
## Description

Extracts complex conditional logic for determining sheet state during action editing into dedicated utility functions in `sheetRouting.ts`. The refactor improves code readability and maintainability by moving the logic that determines whether to show knowledge configuration, tool configuration, or info sheets based on MCP server view properties out of the main component.

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front