### PR TITLE
[front] chore(skills): rename column `mcpServerConfigurationIds` into `mcpServerViewIds`

### DIFF
--- a/front/lib/models/skill.ts
+++ b/front/lib/models/skill.ts
@@ -103,7 +103,7 @@ SkillConfigurationModel.init(SKILL_MODEL_ATTRIBUTES, {
 
 export class SkillVersionModel extends SkillConfigurationModel {
   declare skillConfigurationId: ForeignKey<SkillConfigurationModel["id"]>;
-  declare mcpServerConfigurationIds: number[];
+  declare mcpServerViewIds: number[];
   declare version: number;
 }
 
@@ -114,7 +114,7 @@ SkillVersionModel.init(
       type: DataTypes.BIGINT,
       allowNull: false,
     },
-    mcpServerConfigurationIds: {
+    mcpServerViewIds: {
       type: DataTypes.ARRAY(DataTypes.BIGINT),
       allowNull: false,
     },

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -70,9 +70,9 @@ type SkillResourceConstructorOptions =
 
 type SkillVersionCreationAttributes =
   CreationAttributes<SkillConfigurationModel> & {
-    skillConfigurationId: number;
+    skillConfigurationId: ModelId;
     version: number;
-    mcpServerConfigurationIds: number[];
+    mcpServerViewIds: ModelId[];
   };
 
 type ConversationSkillCreationAttributes =
@@ -842,7 +842,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         // TODO(skills 2025-12-23): add caching on the MCP server views across versions.
         const mcpServerViews = await MCPServerViewResource.fetchByModelIds(
           auth,
-          versionModel.mcpServerConfigurationIds
+          versionModel.mcpServerViewIds
         );
 
         return new SkillResource(
@@ -1269,7 +1269,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         transaction,
       });
 
-    const mcpServerConfigurationIds = mcpServerConfigurations.map(
+    const mcpServerViewIds = mcpServerConfigurations.map(
       (config) => config.mcpServerViewId
     );
 
@@ -1298,8 +1298,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       instructions: this.instructions,
       requestedSpaceIds: this.requestedSpaceIds,
       authorId: this.authorId,
-      // TODO(skills 2025-12-23): rename into mcpServerViewIds.
-      mcpServerConfigurationIds,
+      mcpServerViewIds,
       createdAt: this.createdAt,
       updatedAt: this.updatedAt,
     };

--- a/front/migrations/db/migration_459.sql
+++ b/front/migrations/db/migration_459.sql
@@ -1,0 +1,2 @@
+-- Migration created on Jan 02, 2026
+ALTER TABLE "public"."skill_versions" RENAME COLUMN "mcpServerConfigurationIds" TO "mcpServerViewIds";


### PR DESCRIPTION
## Description

- This PR renames the column `"mcpServerConfigurationIds"` on table `skill_versions` into `"mcpServerViewIds"`.
- The rename will temporarily crash queries on this table, but the feature is not GA and there is only one code path that queries it (list versions, triggered by clicks on the history button in Skill Builder).

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Run migration.
- Deploy front.
