### PR TITLE
feat(skills): partial indexes on convo skills tables

### DIFF
--- a/front/lib/models/agent/agent_skill.ts
+++ b/front/lib/models/agent/agent_skill.ts
@@ -1,5 +1,5 @@
 import type { CreationOptional, ForeignKey } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes, Op } from "sequelize";
 
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import {
@@ -47,7 +47,19 @@ AgentSkillModel.init(
   {
     modelName: "agent_skills",
     sequelize: frontSequelize,
-    indexes: [{ fields: ["workspaceId", "agentConfigurationId"] }],
+    indexes: [
+      { fields: ["workspaceId", "agentConfigurationId"] },
+      {
+        fields: ["workspaceId", "customSkillId"],
+        where: { customSkillId: { [Op.ne]: null } },
+        name: "idx_agent_skills_workspace_custom_skill",
+      },
+      {
+        fields: ["workspaceId", "globalSkillId"],
+        where: { globalSkillId: { [Op.ne]: null } },
+        name: "idx_agent_skills_workspace_global_skill",
+      },
+    ],
     validate: {
       eitherGlobalOrCustomSkill: eitherGlobalOrCustomSkillValidation,
     },

--- a/front/lib/models/skill/conversation_skill.ts
+++ b/front/lib/models/skill/conversation_skill.ts
@@ -87,14 +87,24 @@ ConversationSkillModel.init(SKILL_IN_CONVERSATION_MODEL_ATTRIBUTES, {
       name: "idx_conversation_skills_workspace_conv_agent",
     },
     {
-      fields: ["workspaceId", "conversationId", "customSkillId"],
+      fields: [
+        "workspaceId",
+        "conversationId",
+        "agentConfigurationId",
+        "customSkillId",
+      ],
       where: { customSkillId: { [Op.ne]: null } },
-      name: "idx_conversation_skills_workspace_conv_custom_skill",
+      name: "idx_conversation_skills_workspace_conv_agent_custom_skill",
     },
     {
-      fields: ["workspaceId", "conversationId", "globalSkillId"],
+      fields: [
+        "workspaceId",
+        "conversationId",
+        "agentConfigurationId",
+        "globalSkillId",
+      ],
       where: { globalSkillId: { [Op.ne]: null } },
-      name: "idx_conversation_skills_workspace_conv_global_skill",
+      name: "idx_conversation_skills_workspace_conv_agent_global_skill",
     },
   ],
   validate: {

--- a/front/lib/models/skill/conversation_skill.ts
+++ b/front/lib/models/skill/conversation_skill.ts
@@ -1,5 +1,5 @@
 import type { CreationOptional, ForeignKey, ModelAttributes } from "sequelize";
-import { DataTypes } from "sequelize";
+import { DataTypes, Op } from "sequelize";
 
 import {
   AgentMessageModel,
@@ -85,6 +85,16 @@ ConversationSkillModel.init(SKILL_IN_CONVERSATION_MODEL_ATTRIBUTES, {
     {
       fields: ["workspaceId", "conversationId", "agentConfigurationId"],
       name: "idx_conversation_skills_workspace_conv_agent",
+    },
+    {
+      fields: ["workspaceId", "conversationId", "customSkillId"],
+      where: { customSkillId: { [Op.ne]: null } },
+      name: "idx_conversation_skills_workspace_conv_custom_skill",
+    },
+    {
+      fields: ["workspaceId", "conversationId", "globalSkillId"],
+      where: { globalSkillId: { [Op.ne]: null } },
+      name: "idx_conversation_skills_workspace_conv_global_skill",
     },
   ],
   validate: {

--- a/front/migrations/db/migration_459.sql
+++ b/front/migrations/db/migration_459.sql
@@ -1,0 +1,5 @@
+-- Migration created on Jan 02, 2026
+CREATE INDEX "idx_agent_skills_workspace_custom_skill" ON "agent_skills" ("workspaceId", "customSkillId") WHERE "customSkillId" IS NOT NULL;
+CREATE INDEX "idx_agent_skills_workspace_global_skill" ON "agent_skills" ("workspaceId", "globalSkillId") WHERE "globalSkillId" IS NOT NULL;
+CREATE INDEX "idx_conversation_skills_workspace_conv_custom_skill" ON "conversation_skills" ("workspaceId", "conversationId", "customSkillId") WHERE "customSkillId" IS NOT NULL;
+CREATE INDEX "idx_conversation_skills_workspace_conv_global_skill" ON "conversation_skills" ("workspaceId", "conversationId", "globalSkillId") WHERE "globalSkillId" IS NOT NULL;

--- a/front/migrations/db/migration_459.sql
+++ b/front/migrations/db/migration_459.sql
@@ -1,5 +1,0 @@
--- Migration created on Jan 02, 2026
-CREATE INDEX "idx_agent_skills_workspace_custom_skill" ON "agent_skills" ("workspaceId", "customSkillId") WHERE "customSkillId" IS NOT NULL;
-CREATE INDEX "idx_agent_skills_workspace_global_skill" ON "agent_skills" ("workspaceId", "globalSkillId") WHERE "globalSkillId" IS NOT NULL;
-CREATE INDEX "idx_conversation_skills_workspace_conv_custom_skill" ON "conversation_skills" ("workspaceId", "conversationId", "customSkillId") WHERE "customSkillId" IS NOT NULL;
-CREATE INDEX "idx_conversation_skills_workspace_conv_global_skill" ON "conversation_skills" ("workspaceId", "conversationId", "globalSkillId") WHERE "globalSkillId" IS NOT NULL;

--- a/front/migrations/db/migration_460.sql
+++ b/front/migrations/db/migration_460.sql
@@ -1,0 +1,5 @@
+-- Migration created on Jan 02, 2026
+CREATE INDEX "idx_agent_skills_workspace_custom_skill" ON "agent_skills" ("workspaceId", "customSkillId") WHERE "customSkillId" IS NOT NULL;
+CREATE INDEX "idx_agent_skills_workspace_global_skill" ON "agent_skills" ("workspaceId", "globalSkillId") WHERE "globalSkillId" IS NOT NULL;
+CREATE INDEX "idx_conversation_skills_workspace_conv_agent_custom_skill" ON "conversation_skills" ("workspaceId", "conversationId", "agentConfigurationId", "customSkillId") WHERE "customSkillId" IS NOT NULL;
+CREATE INDEX "idx_conversation_skills_workspace_conv_agent_global_skill" ON "conversation_skills" ("workspaceId", "conversationId", "agentConfigurationId", "globalSkillId") WHERE "globalSkillId" IS NOT NULL;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Adds partial indexes for skill lookups by skillId. These help with update/delete operations that need to find specific skills.

  ConversationSkillModel

  - [workspaceId, conversationId, customSkillId] (partial, WHERE customSkillId IS NOT NULL) — used by upsertToConversation() for lookups before insert/delete.
  - [workspaceId, conversationId, globalSkillId] (partial, WHERE globalSkillId IS NOT NULL) — same for global skills.

  AgentSkillModel

  - [workspaceId, customSkillId] (partial, WHERE customSkillId IS NOT NULL) — used by fetchUsage() for lookups and archive() when deleting skill links.
  - [workspaceId, globalSkillId] (partial, WHERE globalSkillId IS NOT NULL) — same for global skills.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

Apply migration 459
Deploy front