### PR TITLE
add components for the academy

### DIFF
--- a/front/components/academy/AcademyComponents.tsx
+++ b/front/components/academy/AcademyComponents.tsx
@@ -1,0 +1,166 @@
+import { Button } from "@dust-tt/sparkle";
+import Image from "next/image";
+import Link from "next/link";
+
+import { Grid, H1, P } from "@app/components/home/ContentComponents";
+import { contentfulImageLoader } from "@app/lib/contentful/imageLoader";
+import type { CourseSummary } from "@app/lib/contentful/types";
+import { classNames } from "@app/lib/utils";
+
+export const ACADEMY_PAGE_SIZE = 12;
+
+export function AcademyHeader() {
+  return (
+    <div className="col-span-12 flex flex-col items-center gap-0 pt-1 text-center">
+      <Image
+        src="/static/landing/about/Dust_Fade.png"
+        alt="Dust"
+        width={112}
+        height={112}
+        className="h-28 w-28"
+        priority
+      />
+      <H1 className="text-5xl">Academy</H1>
+      <P className="max-w-2xl text-center text-muted-foreground">
+        Learn how to build and deploy AI agents with Dust through our
+        comprehensive courses.
+      </P>
+    </div>
+  );
+}
+
+interface CourseCardProps {
+  course: CourseSummary;
+}
+
+export function CourseCard({ course }: CourseCardProps) {
+  return (
+    <Link
+      href={`/academy/${course.slug}`}
+      className="flex h-full flex-col overflow-hidden rounded-2xl border border-gray-100 bg-white"
+    >
+      {course.image && (
+        <Image
+          src={course.image.url}
+          alt={course.image.alt}
+          width={640}
+          height={360}
+          loader={contentfulImageLoader}
+          sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+          className="aspect-video w-full object-cover"
+        />
+      )}
+      <div className="flex h-full flex-col gap-3 px-6 py-6">
+        <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+          {course.courseId && <span>Course {course.courseId}</span>}
+          {course.estimatedDurationMinutes && (
+            <>
+              {course.courseId && <span>•</span>}
+              <span>{course.estimatedDurationMinutes} min</span>
+            </>
+          )}
+        </div>
+        <h3 className="text-xl font-semibold text-foreground">
+          {course.title}
+        </h3>
+        {course.description && (
+          <p className="text-base text-muted-foreground">
+            {course.description}
+          </p>
+        )}
+      </div>
+    </Link>
+  );
+}
+
+interface CourseGridProps {
+  courses: CourseSummary[];
+  emptyMessage?: string;
+}
+
+export function CourseGrid({ courses, emptyMessage }: CourseGridProps) {
+  return (
+    <div
+      className={classNames(
+        "col-span-12 pt-4",
+        "grid gap-8 sm:grid-cols-2 lg:grid-cols-3"
+      )}
+    >
+      {courses.length > 0 ? (
+        courses.map((course) => <CourseCard key={course.id} course={course} />)
+      ) : (
+        <div className="col-span-full py-12 text-center">
+          <P size="md" className="text-muted-foreground">
+            {emptyMessage ?? "No courses available."}
+          </P>
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface FeaturedCourseProps {
+  course: CourseSummary;
+}
+
+export function FeaturedCourse({ course }: FeaturedCourseProps) {
+  return (
+    <div className="col-span-12 pt-4">
+      <div className="grid gap-6 rounded-2xl border border-gray-100 bg-white p-6 lg:grid-cols-12">
+        {course.image && (
+          <Link
+            href={`/academy/${course.slug}`}
+            className="cursor-pointer lg:col-span-7"
+          >
+            <Image
+              src={course.image.url}
+              alt={course.image.alt}
+              width={course.image.width}
+              height={course.image.height}
+              loader={contentfulImageLoader}
+              className="aspect-[16/9] w-full rounded-xl object-cover transition-opacity hover:opacity-90"
+              sizes="(max-width: 1024px) 100vw, 60vw"
+            />
+          </Link>
+        )}
+        <div className="flex h-full flex-col justify-center gap-4 lg:col-span-5">
+          <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+            {course.courseId && <span>Course {course.courseId}</span>}
+            {course.estimatedDurationMinutes && (
+              <>
+                {course.courseId && <span>•</span>}
+                <span>{course.estimatedDurationMinutes} min</span>
+              </>
+            )}
+          </div>
+          <Link
+            href={`/academy/${course.slug}`}
+            className="cursor-pointer transition-colors hover:text-highlight"
+          >
+            <h2 className="text-2xl font-semibold text-foreground md:text-3xl">
+              {course.title}
+            </h2>
+          </Link>
+          {course.description && (
+            <P className="text-muted-foreground">{course.description}</P>
+          )}
+          <div className="flex flex-wrap gap-3">
+            <Button
+              label="Start course"
+              href={`/academy/${course.slug}`}
+              size="sm"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface AcademyLayoutProps {
+  children: React.ReactNode;
+}
+
+export function AcademyLayout({ children }: AcademyLayoutProps) {
+  return <Grid>{children}</Grid>;
+}

--- a/front/components/academy/AcademyComponents.tsx
+++ b/front/components/academy/AcademyComponents.tsx
@@ -11,7 +11,7 @@ export const ACADEMY_PAGE_SIZE = 8;
 
 export function AcademyHeader() {
   return (
-    <div className="col-span-12 flex flex-col items-start gap-3 pb-8 pt-8">
+    <div className="col-span-12 flex flex-col items-start gap-3 pt-4">
       <H2>Dust Academy</H2>
       <P>
         Check out our courses, tutorials, and videos to learn everything about
@@ -80,7 +80,7 @@ export function CourseGrid({ courses, emptyMessage }: CourseGridProps) {
   return (
     <div
       className={classNames(
-        "col-span-12 pt-8",
+        "col-span-12",
         "grid gap-6 sm:grid-cols-1 lg:grid-cols-2"
       )}
     >

--- a/front/components/academy/AcademyComponents.tsx
+++ b/front/components/academy/AcademyComponents.tsx
@@ -2,28 +2,20 @@ import { Button } from "@dust-tt/sparkle";
 import Image from "next/image";
 import Link from "next/link";
 
-import { Grid, H1, P } from "@app/components/home/ContentComponents";
+import { Grid, H2, P } from "@app/components/home/ContentComponents";
 import { contentfulImageLoader } from "@app/lib/contentful/imageLoader";
 import type { CourseSummary } from "@app/lib/contentful/types";
 import { classNames } from "@app/lib/utils";
 
-export const ACADEMY_PAGE_SIZE = 12;
+export const ACADEMY_PAGE_SIZE = 8;
 
 export function AcademyHeader() {
   return (
-    <div className="col-span-12 flex flex-col items-center gap-0 pt-1 text-center">
-      <Image
-        src="/static/landing/about/Dust_Fade.png"
-        alt="Dust"
-        width={112}
-        height={112}
-        className="h-28 w-28"
-        priority
-      />
-      <H1 className="text-5xl">Academy</H1>
-      <P className="max-w-2xl text-center text-muted-foreground">
-        Learn how to build and deploy AI agents with Dust through our
-        comprehensive courses.
+    <div className="col-span-12 flex flex-col items-start gap-3 pb-8 pt-8">
+      <H2>Dust Academy</H2>
+      <P>
+        Check out our courses, tutorials, and videos to learn everything about
+        Dust
       </P>
     </div>
   );
@@ -37,21 +29,22 @@ export function CourseCard({ course }: CourseCardProps) {
   return (
     <Link
       href={`/academy/${course.slug}`}
-      className="flex h-full flex-col overflow-hidden rounded-2xl border border-gray-100 bg-white"
+      className="group flex h-full flex-col overflow-hidden rounded-2xl border border-gray-200 bg-white transition-all hover:shadow-lg"
     >
-      {course.image && (
+      <div className="relative aspect-video w-full overflow-hidden">
         <Image
-          src={course.image.url}
-          alt={course.image.alt}
+          src={course.image!.url}
+          alt={course.image!.alt}
           width={640}
           height={360}
           loader={contentfulImageLoader}
           sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
-          className="aspect-video w-full object-cover"
+          className="h-full w-full object-cover transition-transform group-hover:scale-105"
         />
-      )}
-      <div className="flex h-full flex-col gap-3 px-6 py-6">
-        <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+      </div>
+
+      <div className="flex flex-1 flex-col gap-3 p-6">
+        <div className="flex flex-wrap items-center gap-2 text-sm text-gray-500">
           {course.courseId && <span>Course {course.courseId}</span>}
           {course.estimatedDurationMinutes && (
             <>
@@ -60,11 +53,9 @@ export function CourseCard({ course }: CourseCardProps) {
             </>
           )}
         </div>
-        <h3 className="text-xl font-semibold text-foreground">
-          {course.title}
-        </h3>
+        <h3 className="text-2xl font-bold text-gray-900">{course.title}</h3>
         {course.description && (
-          <p className="text-base text-muted-foreground">
+          <p className="text-base leading-relaxed text-gray-600">
             {course.description}
           </p>
         )}
@@ -82,8 +73,8 @@ export function CourseGrid({ courses, emptyMessage }: CourseGridProps) {
   return (
     <div
       className={classNames(
-        "col-span-12 pt-4",
-        "grid gap-8 sm:grid-cols-2 lg:grid-cols-3"
+        "col-span-12 pt-8",
+        "grid gap-6 sm:grid-cols-1 lg:grid-cols-2"
       )}
     >
       {courses.length > 0 ? (
@@ -105,54 +96,47 @@ interface FeaturedCourseProps {
 
 export function FeaturedCourse({ course }: FeaturedCourseProps) {
   return (
-    <div className="col-span-12 pt-4">
-      <div className="grid gap-6 rounded-2xl border border-gray-100 bg-white p-6 lg:grid-cols-12">
-        {course.image && (
-          <Link
-            href={`/academy/${course.slug}`}
-            className="cursor-pointer lg:col-span-7"
-          >
-            <Image
-              src={course.image.url}
-              alt={course.image.alt}
-              width={course.image.width}
-              height={course.image.height}
-              loader={contentfulImageLoader}
-              className="aspect-[16/9] w-full rounded-xl object-cover transition-opacity hover:opacity-90"
-              sizes="(max-width: 1024px) 100vw, 60vw"
-            />
-          </Link>
-        )}
-        <div className="flex h-full flex-col justify-center gap-4 lg:col-span-5">
-          <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
-            {course.courseId && <span>Course {course.courseId}</span>}
-            {course.estimatedDurationMinutes && (
-              <>
-                {course.courseId && <span>•</span>}
-                <span>{course.estimatedDurationMinutes} min</span>
-              </>
-            )}
+    <div className="col-span-12 pt-8">
+      <Link
+        href={`/academy/${course.slug}`}
+        className="group flex flex-col overflow-hidden rounded-2xl border border-gray-200 bg-white transition-all hover:shadow-xl lg:flex-row"
+      >
+        <div className="relative w-full overflow-hidden lg:w-1/2">
+          <Image
+            src={course.image!.url}
+            alt={course.image!.alt}
+            width={800}
+            height={600}
+            loader={contentfulImageLoader}
+            sizes="(max-width: 1024px) 100vw, 50vw"
+            className="h-full w-full object-cover transition-transform group-hover:scale-105"
+          />
+        </div>
+
+        <div className="flex w-full flex-col justify-center gap-6 p-10 lg:w-1/2">
+          <div className="inline-block">
+            <span className="rounded-full bg-primary/10 px-4 py-1.5 text-sm font-medium text-primary">
+              Featured Course
+            </span>
           </div>
-          <Link
-            href={`/academy/${course.slug}`}
-            className="cursor-pointer transition-colors hover:text-highlight"
-          >
-            <h2 className="text-2xl font-semibold text-foreground md:text-3xl">
-              {course.title}
-            </h2>
-          </Link>
+          <h2 className="text-3xl font-bold text-gray-900 md:text-4xl">
+            {course.title}
+          </h2>
           {course.description && (
-            <P className="text-muted-foreground">{course.description}</P>
+            <p className="text-lg leading-relaxed text-gray-600">
+              {course.description}
+            </p>
           )}
-          <div className="flex flex-wrap gap-3">
+          <div>
             <Button
-              label="Start course"
+              label="Start learning"
               href={`/academy/${course.slug}`}
-              size="sm"
+              size="md"
+              variant="primary"
             />
           </div>
         </div>
-      </div>
+      </Link>
     </div>
   );
 }

--- a/front/components/academy/AcademyComponents.tsx
+++ b/front/components/academy/AcademyComponents.tsx
@@ -29,35 +29,42 @@ export function CourseCard({ course }: CourseCardProps) {
   return (
     <Link
       href={`/academy/${course.slug}`}
-      className="group flex h-full flex-col overflow-hidden rounded-2xl border border-gray-200 bg-white transition-all hover:shadow-lg"
+      className="group flex flex-col overflow-hidden rounded-xl border border-gray-200 bg-white transition-shadow duration-200 hover:shadow-md"
     >
-      <div className="relative aspect-video w-full overflow-hidden">
+      <div className="relative aspect-[2/1] w-full overflow-hidden">
         <Image
           src={course.image!.url}
           alt={course.image!.alt}
-          width={640}
-          height={360}
+          fill
           loader={contentfulImageLoader}
           sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
-          className="h-full w-full object-cover transition-transform group-hover:scale-105"
+          className="object-cover"
         />
       </div>
 
-      <div className="flex flex-1 flex-col gap-3 p-6">
-        <div className="flex flex-wrap items-center gap-2 text-sm text-gray-500">
-          {course.courseId && <span>Course {course.courseId}</span>}
-          {course.estimatedDurationMinutes && (
-            <>
-              {course.courseId && <span>•</span>}
-              <span>{course.estimatedDurationMinutes} min</span>
-            </>
-          )}
-        </div>
-        <h3 className="text-2xl font-bold text-gray-900">{course.title}</h3>
+      <div className="flex flex-1 flex-col p-4">
+        <h3 className="font-semibold text-gray-900 group-hover:text-primary">
+          {course.title}
+        </h3>
         {course.description && (
-          <p className="text-base leading-relaxed text-gray-600">
+          <p className="mt-1.5 line-clamp-2 text-sm leading-snug text-gray-500">
             {course.description}
           </p>
+        )}
+        {course.estimatedDurationMinutes && (
+          <div className="mt-3 flex items-center gap-1.5 text-xs text-gray-400">
+            <svg
+              className="h-3.5 w-3.5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <circle cx="12" cy="12" r="10" />
+              <path d="M12 6v6l4 2" />
+            </svg>
+            <span>{course.estimatedDurationMinutes} min</span>
+          </div>
         )}
       </div>
     </Link>
@@ -99,9 +106,9 @@ export function FeaturedCourse({ course }: FeaturedCourseProps) {
     <div className="col-span-12 pt-8">
       <Link
         href={`/academy/${course.slug}`}
-        className="group flex flex-col overflow-hidden rounded-2xl border border-gray-200 bg-white transition-all hover:shadow-xl lg:flex-row"
+        className="group flex flex-col overflow-hidden rounded-2xl border border-gray-200 bg-white transition-all duration-200 hover:border-gray-300 hover:shadow-lg lg:flex-row"
       >
-        <div className="relative w-full overflow-hidden lg:w-1/2">
+        <div className="relative w-full overflow-hidden bg-gray-100 lg:w-1/2">
           <Image
             src={course.image!.url}
             alt={course.image!.alt}
@@ -109,7 +116,7 @@ export function FeaturedCourse({ course }: FeaturedCourseProps) {
             height={600}
             loader={contentfulImageLoader}
             sizes="(max-width: 1024px) 100vw, 50vw"
-            className="h-full w-full object-cover transition-transform group-hover:scale-105"
+            className="h-full w-full object-cover transition-opacity duration-200 group-hover:opacity-90"
           />
         </div>
 
@@ -119,7 +126,7 @@ export function FeaturedCourse({ course }: FeaturedCourseProps) {
               Featured Course
             </span>
           </div>
-          <h2 className="text-3xl font-bold text-gray-900 md:text-4xl">
+          <h2 className="text-3xl font-semibold text-gray-900 transition-colors group-hover:text-primary md:text-4xl">
             {course.title}
           </h2>
           {course.description && (

--- a/front/components/academy/AcademyPagination.tsx
+++ b/front/components/academy/AcademyPagination.tsx
@@ -148,4 +148,3 @@ export function AcademyPagination({
     </nav>
   );
 }
-

--- a/front/components/academy/AcademyPagination.tsx
+++ b/front/components/academy/AcademyPagination.tsx
@@ -12,13 +12,12 @@ function buildPageUrl(page: number): string {
   return page === 1 ? "/academy" : `/academy/page/${page}`;
 }
 
-function PaginationLink({
-  page,
-  isCurrent,
-}: {
+interface PaginationLinkProps {
   page: number;
   isCurrent: boolean;
-}) {
+}
+
+function PaginationLink({ page, isCurrent }: PaginationLinkProps) {
   const href = buildPageUrl(page);
 
   if (isCurrent) {

--- a/front/components/academy/AcademyPagination.tsx
+++ b/front/components/academy/AcademyPagination.tsx
@@ -1,0 +1,151 @@
+import { ChevronLeftIcon, ChevronRightIcon } from "@dust-tt/sparkle";
+import Link from "next/link";
+
+interface AcademyPaginationProps {
+  currentPage: number;
+  totalPages: number;
+  rowCount: number;
+  pageSize: number;
+}
+
+function buildPageUrl(page: number): string {
+  return page === 1 ? "/academy" : `/academy/page/${page}`;
+}
+
+function PaginationLink({
+  page,
+  isCurrent,
+}: {
+  page: number;
+  isCurrent: boolean;
+}) {
+  const href = buildPageUrl(page);
+
+  if (isCurrent) {
+    return (
+      <span className="flex h-7 w-7 items-center justify-center rounded-md bg-primary-100 text-xs font-medium text-primary-800">
+        {page}
+      </span>
+    );
+  }
+
+  return (
+    <Link
+      href={href}
+      className="flex h-7 w-7 items-center justify-center rounded-md text-xs font-medium text-muted-foreground transition-colors hover:bg-gray-100 hover:text-foreground"
+    >
+      {page}
+    </Link>
+  );
+}
+
+export function AcademyPagination({
+  currentPage,
+  totalPages,
+  rowCount,
+  pageSize,
+}: AcademyPaginationProps) {
+  if (totalPages <= 1) {
+    return null;
+  }
+
+  const startItem = (currentPage - 1) * pageSize + 1;
+  const endItem = Math.min(currentPage * pageSize, rowCount);
+
+  // Generate page numbers to show
+  const getPageNumbers = () => {
+    const pages: (number | "ellipsis-start" | "ellipsis-end")[] = [];
+    const showEllipsisStart = currentPage > 3;
+    const showEllipsisEnd = currentPage < totalPages - 2;
+
+    // Always show first page
+    pages.push(1);
+
+    if (showEllipsisStart) {
+      pages.push("ellipsis-start");
+    }
+
+    // Show pages around current
+    for (
+      let i = Math.max(2, currentPage - 1);
+      i <= Math.min(totalPages - 1, currentPage + 1);
+      i++
+    ) {
+      if (!pages.includes(i)) {
+        pages.push(i);
+      }
+    }
+
+    if (showEllipsisEnd) {
+      pages.push("ellipsis-end");
+    }
+
+    // Always show last page if more than 1 page
+    if (totalPages > 1 && !pages.includes(totalPages)) {
+      pages.push(totalPages);
+    }
+
+    return pages;
+  };
+
+  const pageNumbers = getPageNumbers();
+  const canGoPrev = currentPage > 1;
+  const canGoNext = currentPage < totalPages;
+
+  return (
+    <nav
+      className="flex w-full items-center justify-between"
+      aria-label="Pagination"
+    >
+      <div className="flex items-center gap-1">
+        <Link
+          href={canGoPrev ? buildPageUrl(currentPage - 1) : "#"}
+          className={`flex h-7 w-7 items-center justify-center rounded-md transition-colors ${
+            canGoPrev
+              ? "text-muted-foreground hover:bg-gray-100 hover:text-foreground"
+              : "pointer-events-none text-gray-300"
+          }`}
+          aria-disabled={!canGoPrev}
+          tabIndex={canGoPrev ? undefined : -1}
+        >
+          <ChevronLeftIcon className="h-4 w-4" />
+        </Link>
+
+        {pageNumbers.map((pageNum) =>
+          pageNum === "ellipsis-start" || pageNum === "ellipsis-end" ? (
+            <span
+              key={pageNum}
+              className="flex h-7 w-7 items-center justify-center text-xs text-muted-foreground"
+            >
+              ...
+            </span>
+          ) : (
+            <PaginationLink
+              key={pageNum}
+              page={pageNum}
+              isCurrent={pageNum === currentPage}
+            />
+          )
+        )}
+
+        <Link
+          href={canGoNext ? buildPageUrl(currentPage + 1) : "#"}
+          className={`flex h-7 w-7 items-center justify-center rounded-md transition-colors ${
+            canGoNext
+              ? "text-muted-foreground hover:bg-gray-100 hover:text-foreground"
+              : "pointer-events-none text-gray-300"
+          }`}
+          aria-disabled={!canGoNext}
+          tabIndex={canGoNext ? undefined : -1}
+        >
+          <ChevronRightIcon className="h-4 w-4" />
+        </Link>
+      </div>
+
+      <span className="text-xs text-muted-foreground">
+        {startItem}-{endItem} of {rowCount}
+      </span>
+    </nav>
+  );
+}
+

--- a/front/components/academy/AcademySidebar.tsx
+++ b/front/components/academy/AcademySidebar.tsx
@@ -34,9 +34,9 @@ export function AcademySidebar({
   };
 
   return (
-    <div className="sticky top-0 h-screen w-64 border-r border-gray-200 bg-white">
+    <div className="sticky top-16 h-[calc(100vh-4rem)] w-64 border-r border-gray-200 bg-white">
       <div className="flex h-full flex-col">
-        <div className="flex-shrink-0 px-3 pb-2 pt-3">
+        <div className="flex-shrink-0 px-3 py-3">
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button
@@ -65,10 +65,10 @@ export function AcademySidebar({
         </div>
 
         {tocItems.length > 0 && (
-          <div className="flex-1 overflow-y-auto px-3 pb-4 pt-1">
+          <div className="flex-1 overflow-y-auto px-3 pb-4">
             <TableOfContents
               items={tocItems}
-              className="static top-0 [&>h3]:mb-2"
+              className="static max-h-none [&>h3]:mb-1 [&>h3]:text-xs"
             />
           </div>
         )}

--- a/front/components/academy/AcademySidebar.tsx
+++ b/front/components/academy/AcademySidebar.tsx
@@ -26,7 +26,7 @@ export function AcademySidebar({
   const currentCourse = courses.find((c) => c.slug === currentCourseSlug);
 
   const handleCourseChange = (slug: string) => {
-    router.push(`/academy/${slug}`);
+    void router.push(`/academy/${slug}`);
     setIsDropdownOpen(false);
   };
 

--- a/front/components/academy/AcademySidebar.tsx
+++ b/front/components/academy/AcademySidebar.tsx
@@ -4,17 +4,21 @@ import { ChevronDownIcon } from "@dust-tt/sparkle";
 import { useRouter } from "next/router";
 import { useState } from "react";
 
+import { TableOfContents } from "@app/components/blog/TableOfContents";
+import type { TocItem } from "@app/lib/contentful/tableOfContents";
 import type { CourseSummary } from "@app/lib/contentful/types";
 import { classNames } from "@app/lib/utils";
 
 interface AcademySidebarProps {
   courses: CourseSummary[];
   currentCourseSlug?: string;
+  tocItems?: TocItem[];
 }
 
 export function AcademySidebar({
   courses,
   currentCourseSlug,
+  tocItems = [],
 }: AcademySidebarProps) {
   const router = useRouter();
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
@@ -27,51 +31,61 @@ export function AcademySidebar({
   };
 
   return (
-    <div className="w-64 border-r border-gray-200 bg-white p-4">
-      <div className="relative">
-        <button
-          onClick={() => setIsDropdownOpen(!isDropdownOpen)}
-          className="flex w-full items-center justify-between rounded-lg border border-gray-200 bg-white px-4 py-2.5 text-left text-sm font-medium text-foreground transition-colors hover:bg-gray-50"
-        >
-          <span className="truncate">
-            {currentCourse ? currentCourse.title : "Select a course"}
-          </span>
-          <ChevronDownIcon
-            className={classNames(
-              "ml-2 h-4 w-4 flex-shrink-0 text-muted-foreground transition-transform",
-              isDropdownOpen && "rotate-180"
-            )}
-          />
-        </button>
+    <div className="sticky top-0 h-screen w-64 border-r border-gray-200 bg-white">
+      <div className="flex h-full flex-col">
+        <div className="flex-shrink-0 p-4">
+          <div className="relative">
+            <button
+              onClick={() => setIsDropdownOpen(!isDropdownOpen)}
+              className="flex w-full items-center justify-between rounded-lg border border-gray-200 bg-white px-4 py-2.5 text-left text-sm font-medium text-foreground transition-colors hover:bg-gray-50"
+            >
+              <span className="truncate">
+                {currentCourse ? currentCourse.title : "Select a course"}
+              </span>
+              <ChevronDownIcon
+                className={classNames(
+                  "ml-2 h-4 w-4 flex-shrink-0 text-muted-foreground transition-transform",
+                  isDropdownOpen && "rotate-180"
+                )}
+              />
+            </button>
 
-        {isDropdownOpen && (
-          <>
-            <div
-              className="fixed inset-0 z-10"
-              onClick={() => setIsDropdownOpen(false)}
-            />
-            <div className="absolute left-0 right-0 top-full z-20 mt-1 max-h-96 overflow-y-auto rounded-lg border border-gray-200 bg-white shadow-lg">
-              {courses.map((course) => (
-                <button
-                  key={course.id}
-                  onClick={() => handleCourseChange(course.slug)}
-                  className={classNames(
-                    "w-full px-4 py-2.5 text-left text-sm transition-colors hover:bg-gray-50",
-                    course.slug === currentCourseSlug
-                      ? "bg-gray-100 font-medium text-foreground"
-                      : "text-muted-foreground"
-                  )}
-                >
-                  <div className="truncate">{course.title}</div>
-                  {course.courseId && (
-                    <div className="mt-0.5 text-xs text-muted-foreground">
-                      Course {course.courseId}
-                    </div>
-                  )}
-                </button>
-              ))}
-            </div>
-          </>
+            {isDropdownOpen && (
+              <>
+                <div
+                  className="fixed inset-0 z-10"
+                  onClick={() => setIsDropdownOpen(false)}
+                />
+                <div className="absolute left-0 right-0 top-full z-20 mt-1 max-h-96 overflow-y-auto rounded-lg border border-gray-200 bg-white shadow-lg">
+                  {courses.map((course) => (
+                    <button
+                      key={course.id}
+                      onClick={() => handleCourseChange(course.slug)}
+                      className={classNames(
+                        "w-full px-4 py-2.5 text-left text-sm transition-colors hover:bg-gray-50",
+                        course.slug === currentCourseSlug
+                          ? "bg-gray-100 font-medium text-foreground"
+                          : "text-muted-foreground"
+                      )}
+                    >
+                      <div className="truncate">{course.title}</div>
+                      {course.courseId && (
+                        <div className="mt-0.5 text-xs text-muted-foreground">
+                          Course {course.courseId}
+                        </div>
+                      )}
+                    </button>
+                  ))}
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+
+        {tocItems.length > 0 && (
+          <div className="flex-1 overflow-y-auto px-4 pb-4">
+            <TableOfContents items={tocItems} />
+          </div>
         )}
       </div>
     </div>

--- a/front/components/academy/AcademySidebar.tsx
+++ b/front/components/academy/AcademySidebar.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { ChevronDownIcon } from "@dust-tt/sparkle";
+import { useRouter } from "next/router";
+import { useState } from "react";
+
+import type { CourseSummary } from "@app/lib/contentful/types";
+import { classNames } from "@app/lib/utils";
+
+interface AcademySidebarProps {
+  courses: CourseSummary[];
+  currentCourseSlug?: string;
+}
+
+export function AcademySidebar({
+  courses,
+  currentCourseSlug,
+}: AcademySidebarProps) {
+  const router = useRouter();
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+
+  const currentCourse = courses.find((c) => c.slug === currentCourseSlug);
+
+  const handleCourseChange = (slug: string) => {
+    router.push(`/academy/${slug}`);
+    setIsDropdownOpen(false);
+  };
+
+  return (
+    <div className="w-64 border-r border-gray-200 bg-white p-4">
+      <div className="relative">
+        <button
+          onClick={() => setIsDropdownOpen(!isDropdownOpen)}
+          className="flex w-full items-center justify-between rounded-lg border border-gray-200 bg-white px-4 py-2.5 text-left text-sm font-medium text-foreground transition-colors hover:bg-gray-50"
+        >
+          <span className="truncate">
+            {currentCourse ? currentCourse.title : "Select a course"}
+          </span>
+          <ChevronDownIcon
+            className={classNames(
+              "ml-2 h-4 w-4 flex-shrink-0 text-muted-foreground transition-transform",
+              isDropdownOpen && "rotate-180"
+            )}
+          />
+        </button>
+
+        {isDropdownOpen && (
+          <>
+            <div
+              className="fixed inset-0 z-10"
+              onClick={() => setIsDropdownOpen(false)}
+            />
+            <div className="absolute left-0 right-0 top-full z-20 mt-1 max-h-96 overflow-y-auto rounded-lg border border-gray-200 bg-white shadow-lg">
+              {courses.map((course) => (
+                <button
+                  key={course.id}
+                  onClick={() => handleCourseChange(course.slug)}
+                  className={classNames(
+                    "w-full px-4 py-2.5 text-left text-sm transition-colors hover:bg-gray-50",
+                    course.slug === currentCourseSlug
+                      ? "bg-gray-100 font-medium text-foreground"
+                      : "text-muted-foreground"
+                  )}
+                >
+                  <div className="truncate">{course.title}</div>
+                  {course.courseId && (
+                    <div className="mt-0.5 text-xs text-muted-foreground">
+                      Course {course.courseId}
+                    </div>
+                  )}
+                </button>
+              ))}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/front/components/academy/AcademySidebar.tsx
+++ b/front/components/academy/AcademySidebar.tsx
@@ -1,13 +1,18 @@
 "use client";
 
-import { ChevronDownIcon } from "@dust-tt/sparkle";
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "@dust-tt/sparkle";
 import { useRouter } from "next/router";
-import { useState } from "react";
 
 import { TableOfContents } from "@app/components/blog/TableOfContents";
 import type { TocItem } from "@app/lib/contentful/tableOfContents";
 import type { CourseSummary } from "@app/lib/contentful/types";
-import { classNames } from "@app/lib/utils";
 
 interface AcademySidebarProps {
   courses: CourseSummary[];
@@ -21,70 +26,50 @@ export function AcademySidebar({
   tocItems = [],
 }: AcademySidebarProps) {
   const router = useRouter();
-  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
   const currentCourse = courses.find((c) => c.slug === currentCourseSlug);
 
   const handleCourseChange = (slug: string) => {
     void router.push(`/academy/${slug}`);
-    setIsDropdownOpen(false);
   };
 
   return (
     <div className="sticky top-0 h-screen w-64 border-r border-gray-200 bg-white">
       <div className="flex h-full flex-col">
-        <div className="flex-shrink-0 p-4">
-          <div className="relative">
-            <button
-              onClick={() => setIsDropdownOpen(!isDropdownOpen)}
-              className="flex w-full items-center justify-between rounded-lg border border-gray-200 bg-white px-4 py-2.5 text-left text-sm font-medium text-foreground transition-colors hover:bg-gray-50"
-            >
-              <span className="truncate">
-                {currentCourse ? currentCourse.title : "Select a course"}
-              </span>
-              <ChevronDownIcon
-                className={classNames(
-                  "ml-2 h-4 w-4 flex-shrink-0 text-muted-foreground transition-transform",
-                  isDropdownOpen && "rotate-180"
-                )}
+        <div className="flex-shrink-0 px-3 pb-2 pt-3">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="outline"
+                size="sm"
+                className="w-full justify-between"
+                label={currentCourse?.title ?? "Select a course"}
+                isSelect
               />
-            </button>
-
-            {isDropdownOpen && (
-              <>
-                <div
-                  className="fixed inset-0 z-10"
-                  onClick={() => setIsDropdownOpen(false)}
-                />
-                <div className="absolute left-0 right-0 top-full z-20 mt-1 max-h-96 overflow-y-auto rounded-lg border border-gray-200 bg-white shadow-lg">
-                  {courses.map((course) => (
-                    <button
-                      key={course.id}
-                      onClick={() => handleCourseChange(course.slug)}
-                      className={classNames(
-                        "w-full px-4 py-2.5 text-left text-sm transition-colors hover:bg-gray-50",
-                        course.slug === currentCourseSlug
-                          ? "bg-gray-100 font-medium text-foreground"
-                          : "text-muted-foreground"
-                      )}
-                    >
-                      <div className="truncate">{course.title}</div>
-                      {course.courseId && (
-                        <div className="mt-0.5 text-xs text-muted-foreground">
-                          Course {course.courseId}
-                        </div>
-                      )}
-                    </button>
-                  ))}
-                </div>
-              </>
-            )}
-          </div>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent className="w-[var(--radix-dropdown-menu-trigger-width)]">
+              <DropdownMenuRadioGroup
+                value={currentCourseSlug ?? ""}
+                onValueChange={handleCourseChange}
+              >
+                {courses.map((course) => (
+                  <DropdownMenuRadioItem
+                    key={course.id}
+                    value={course.slug}
+                    label={course.title}
+                  />
+                ))}
+              </DropdownMenuRadioGroup>
+            </DropdownMenuContent>
+          </DropdownMenu>
         </div>
 
         {tocItems.length > 0 && (
-          <div className="flex-1 overflow-y-auto px-4 pb-4">
-            <TableOfContents items={tocItems} />
+          <div className="flex-1 overflow-y-auto px-3 pb-4 pt-1">
+            <TableOfContents
+              items={tocItems}
+              className="static top-0 [&>h3]:mb-2"
+            />
           </div>
         )}
       </div>

--- a/front/components/academy/LessonLink.tsx
+++ b/front/components/academy/LessonLink.tsx
@@ -9,6 +9,7 @@ interface LessonLinkProps {
   description?: string | null;
   lessonId?: string | null;
   estimatedDurationMinutes?: number | null;
+  complexity?: string | null;
 }
 
 export function LessonLink({
@@ -17,6 +18,7 @@ export function LessonLink({
   description,
   lessonId,
   estimatedDurationMinutes,
+  complexity,
 }: LessonLinkProps) {
   return (
     <div className="my-6 rounded-lg border border-gray-200 bg-gray-50 p-6">
@@ -27,6 +29,12 @@ export function LessonLink({
             <>
               {lessonId && <span>•</span>}
               <span>{estimatedDurationMinutes} min</span>
+            </>
+          )}
+          {complexity && (
+            <>
+              {(lessonId || estimatedDurationMinutes) && <span>•</span>}
+              <span>{complexity}</span>
             </>
           )}
         </div>

--- a/front/components/academy/LessonLink.tsx
+++ b/front/components/academy/LessonLink.tsx
@@ -2,7 +2,6 @@ import { Button } from "@dust-tt/sparkle";
 import Link from "next/link";
 
 import { P } from "@app/components/home/ContentComponents";
-import { classNames } from "@app/lib/utils";
 
 interface LessonLinkProps {
   title: string;
@@ -56,4 +55,3 @@ export function LessonLink({
     </div>
   );
 }
-

--- a/front/components/academy/LessonLink.tsx
+++ b/front/components/academy/LessonLink.tsx
@@ -1,0 +1,59 @@
+import { Button } from "@dust-tt/sparkle";
+import Link from "next/link";
+
+import { P } from "@app/components/home/ContentComponents";
+import { classNames } from "@app/lib/utils";
+
+interface LessonLinkProps {
+  title: string;
+  slug: string;
+  description?: string | null;
+  courseId?: string | null;
+  estimatedDurationMinutes?: number | null;
+}
+
+export function LessonLink({
+  title,
+  slug,
+  description,
+  courseId,
+  estimatedDurationMinutes,
+}: LessonLinkProps) {
+  return (
+    <div className="my-6 rounded-lg border border-gray-200 bg-gray-50 p-6 transition-colors hover:border-gray-300 hover:bg-gray-100">
+      <div className="flex flex-col gap-3">
+        <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+          {courseId && <span>Lesson {courseId}</span>}
+          {estimatedDurationMinutes && (
+            <>
+              {courseId && <span>•</span>}
+              <span>{estimatedDurationMinutes} min</span>
+            </>
+          )}
+        </div>
+        <Link
+          href={`/academy/lessons/${slug}`}
+          className="group flex flex-col gap-2"
+        >
+          <h3 className="text-lg font-semibold text-foreground transition-colors group-hover:text-highlight">
+            {title}
+          </h3>
+          {description && (
+            <P size="sm" className="text-muted-foreground">
+              {description}
+            </P>
+          )}
+        </Link>
+        <div className="mt-2">
+          <Button
+            label="View lesson"
+            href={`/academy/lessons/${slug}`}
+            size="sm"
+            variant="outline"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/front/components/academy/LessonLink.tsx
+++ b/front/components/academy/LessonLink.tsx
@@ -1,5 +1,4 @@
 import { Button } from "@dust-tt/sparkle";
-import Link from "next/link";
 
 import { P } from "@app/components/home/ContentComponents";
 
@@ -33,15 +32,13 @@ export function LessonLink({
           )}
           {complexity && (
             <>
-              {(lessonId || estimatedDurationMinutes) && <span>•</span>}
+              {(lessonId ?? estimatedDurationMinutes) && <span>•</span>}
               <span>{complexity}</span>
             </>
           )}
         </div>
         <div className="flex flex-col gap-2">
-          <h3 className="text-lg font-semibold text-foreground">
-            {title}
-          </h3>
+          <h3 className="text-lg font-semibold text-foreground">{title}</h3>
           {description && (
             <P size="sm" className="text-muted-foreground">
               {description}

--- a/front/components/academy/LessonLink.tsx
+++ b/front/components/academy/LessonLink.tsx
@@ -7,7 +7,7 @@ interface LessonLinkProps {
   title: string;
   slug: string;
   description?: string | null;
-  courseId?: string | null;
+  lessonId?: string | null;
   estimatedDurationMinutes?: number | null;
 }
 
@@ -15,26 +15,23 @@ export function LessonLink({
   title,
   slug,
   description,
-  courseId,
+  lessonId,
   estimatedDurationMinutes,
 }: LessonLinkProps) {
   return (
-    <div className="my-6 rounded-lg border border-gray-200 bg-gray-50 p-6 transition-colors hover:border-gray-300 hover:bg-gray-100">
+    <div className="my-6 rounded-lg border border-gray-200 bg-gray-50 p-6">
       <div className="flex flex-col gap-3">
         <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
-          {courseId && <span>Lesson {courseId}</span>}
+          {lessonId && <span>Lesson {lessonId}</span>}
           {estimatedDurationMinutes && (
             <>
-              {courseId && <span>•</span>}
+              {lessonId && <span>•</span>}
               <span>{estimatedDurationMinutes} min</span>
             </>
           )}
         </div>
-        <Link
-          href={`/academy/lessons/${slug}`}
-          className="group flex flex-col gap-2"
-        >
-          <h3 className="text-lg font-semibold text-foreground transition-colors group-hover:text-highlight">
+        <div className="flex flex-col gap-2">
+          <h3 className="text-lg font-semibold text-foreground">
             {title}
           </h3>
           {description && (
@@ -42,7 +39,7 @@ export function LessonLink({
               {description}
             </P>
           )}
-        </Link>
+        </div>
         <div className="mt-2">
           <Button
             label="View lesson"

--- a/front/components/blog/BlogPagination.tsx
+++ b/front/components/blog/BlogPagination.tsx
@@ -1,5 +1,4 @@
-import { ChevronLeftIcon, ChevronRightIcon } from "@dust-tt/sparkle";
-import Link from "next/link";
+import { Pagination } from "@app/components/shared/Pagination";
 
 interface BlogPaginationProps {
   currentPage: number;
@@ -9,7 +8,7 @@ interface BlogPaginationProps {
   tag?: string | null;
 }
 
-function buildPageUrl(page: number, tag?: string | null): string {
+function buildBlogPageUrl(page: number, tag?: string | null): string {
   if (tag) {
     // Tag filtering stays on index page (client-side filtering)
     const params = new URLSearchParams();
@@ -23,143 +22,14 @@ function buildPageUrl(page: number, tag?: string | null): string {
   return page === 1 ? "/blog" : `/blog/page/${page}`;
 }
 
-function PaginationLink({
-  page,
-  isCurrent,
-  tag,
-}: {
-  page: number;
-  isCurrent: boolean;
-  tag?: string | null;
-}) {
-  const href = buildPageUrl(page, tag);
-
-  if (isCurrent) {
-    return (
-      <span className="flex h-7 w-7 items-center justify-center rounded-md bg-primary-100 text-xs font-medium text-primary-800">
-        {page}
-      </span>
-    );
-  }
-
-  return (
-    <Link
-      href={href}
-      className="flex h-7 w-7 items-center justify-center rounded-md text-xs font-medium text-muted-foreground transition-colors hover:bg-gray-100 hover:text-foreground"
-    >
-      {page}
-    </Link>
-  );
-}
-
 export function BlogPagination({
-  currentPage,
-  totalPages,
-  rowCount,
-  pageSize,
   tag,
+  ...paginationProps
 }: BlogPaginationProps) {
-  if (totalPages <= 1) {
-    return null;
-  }
-
-  const startItem = (currentPage - 1) * pageSize + 1;
-  const endItem = Math.min(currentPage * pageSize, rowCount);
-
-  // Generate page numbers to show
-  const getPageNumbers = () => {
-    const pages: (number | "ellipsis-start" | "ellipsis-end")[] = [];
-    const showEllipsisStart = currentPage > 3;
-    const showEllipsisEnd = currentPage < totalPages - 2;
-
-    // Always show first page
-    pages.push(1);
-
-    if (showEllipsisStart) {
-      pages.push("ellipsis-start");
-    }
-
-    // Show pages around current
-    for (
-      let i = Math.max(2, currentPage - 1);
-      i <= Math.min(totalPages - 1, currentPage + 1);
-      i++
-    ) {
-      if (!pages.includes(i)) {
-        pages.push(i);
-      }
-    }
-
-    if (showEllipsisEnd) {
-      pages.push("ellipsis-end");
-    }
-
-    // Always show last page if more than 1 page
-    if (totalPages > 1 && !pages.includes(totalPages)) {
-      pages.push(totalPages);
-    }
-
-    return pages;
-  };
-
-  const pageNumbers = getPageNumbers();
-  const canGoPrev = currentPage > 1;
-  const canGoNext = currentPage < totalPages;
-
   return (
-    <nav
-      className="flex w-full items-center justify-between"
-      aria-label="Pagination"
-    >
-      <div className="flex items-center gap-1">
-        <Link
-          href={canGoPrev ? buildPageUrl(currentPage - 1, tag) : "#"}
-          className={`flex h-7 w-7 items-center justify-center rounded-md transition-colors ${
-            canGoPrev
-              ? "text-muted-foreground hover:bg-gray-100 hover:text-foreground"
-              : "pointer-events-none text-gray-300"
-          }`}
-          aria-disabled={!canGoPrev}
-          tabIndex={canGoPrev ? undefined : -1}
-        >
-          <ChevronLeftIcon className="h-4 w-4" />
-        </Link>
-
-        {pageNumbers.map((pageNum) =>
-          pageNum === "ellipsis-start" || pageNum === "ellipsis-end" ? (
-            <span
-              key={pageNum}
-              className="flex h-7 w-7 items-center justify-center text-xs text-muted-foreground"
-            >
-              ...
-            </span>
-          ) : (
-            <PaginationLink
-              key={pageNum}
-              page={pageNum}
-              isCurrent={pageNum === currentPage}
-              tag={tag}
-            />
-          )
-        )}
-
-        <Link
-          href={canGoNext ? buildPageUrl(currentPage + 1, tag) : "#"}
-          className={`flex h-7 w-7 items-center justify-center rounded-md transition-colors ${
-            canGoNext
-              ? "text-muted-foreground hover:bg-gray-100 hover:text-foreground"
-              : "pointer-events-none text-gray-300"
-          }`}
-          aria-disabled={!canGoNext}
-          tabIndex={canGoNext ? undefined : -1}
-        >
-          <ChevronRightIcon className="h-4 w-4" />
-        </Link>
-      </div>
-
-      <span className="text-xs text-muted-foreground">
-        {startItem}-{endItem} of {rowCount}
-      </span>
-    </nav>
+    <Pagination
+      {...paginationProps}
+      buildPageUrl={(page) => buildBlogPageUrl(page, tag)}
+    />
   );
 }

--- a/front/components/blog/TableOfContents.tsx
+++ b/front/components/blog/TableOfContents.tsx
@@ -112,7 +112,7 @@ export function TableOfContents({ items, className }: TableOfContentsProps) {
   return (
     <div
       className={classNames(
-        "sticky top-24 max-h-[calc(100vh-8rem)] overflow-y-auto",
+        "sticky top-5 max-h-[calc(100vh-8rem)] overflow-y-auto",
         className ?? null
       )}
     >

--- a/front/components/home/menu/config.ts
+++ b/front/components/home/menu/config.ts
@@ -243,6 +243,10 @@ const ExploreMenuConfig: MenuConfig = {
       href: "/blog",
     },
     {
+      title: "Academy",
+      href: "/academy",
+    },
+    {
       title: "Webinars",
       href: "https://app.getcontrast.io/dust",
       isExternal: true,

--- a/front/components/shared/Pagination.tsx
+++ b/front/components/shared/Pagination.tsx
@@ -49,8 +49,6 @@ function PaginationLink({
   isCurrent,
   buildPageUrl,
 }: PaginationLinkProps) {
-  const href = buildPageUrl(page);
-
   if (isCurrent) {
     return (
       <span className="flex h-7 w-7 items-center justify-center rounded-md bg-primary-100 text-xs font-medium text-primary-800">
@@ -61,7 +59,7 @@ function PaginationLink({
 
   return (
     <Link
-      href={href}
+      href={buildPageUrl(page)}
       className="flex h-7 w-7 items-center justify-center rounded-md text-xs font-medium text-muted-foreground transition-colors hover:bg-gray-100 hover:text-foreground"
     >
       {page}

--- a/front/components/shared/Pagination.tsx
+++ b/front/components/shared/Pagination.tsx
@@ -1,23 +1,54 @@
 import { ChevronLeftIcon, ChevronRightIcon } from "@dust-tt/sparkle";
 import Link from "next/link";
 
-interface AcademyPaginationProps {
-  currentPage: number;
-  totalPages: number;
-  rowCount: number;
-  pageSize: number;
-}
+type PageNumber = number | "ellipsis-start" | "ellipsis-end";
 
-function buildPageUrl(page: number): string {
-  return page === 1 ? "/academy" : `/academy/page/${page}`;
+function getPageNumbers(currentPage: number, totalPages: number): PageNumber[] {
+  const pages: PageNumber[] = [];
+  const showEllipsisStart = currentPage > 3;
+  const showEllipsisEnd = currentPage < totalPages - 2;
+
+  // Always show first page
+  pages.push(1);
+
+  if (showEllipsisStart) {
+    pages.push("ellipsis-start");
+  }
+
+  // Show pages around current
+  for (
+    let i = Math.max(2, currentPage - 1);
+    i <= Math.min(totalPages - 1, currentPage + 1);
+    i++
+  ) {
+    if (!pages.includes(i)) {
+      pages.push(i);
+    }
+  }
+
+  if (showEllipsisEnd) {
+    pages.push("ellipsis-end");
+  }
+
+  // Always show last page if more than 1 page
+  if (totalPages > 1 && !pages.includes(totalPages)) {
+    pages.push(totalPages);
+  }
+
+  return pages;
 }
 
 interface PaginationLinkProps {
   page: number;
   isCurrent: boolean;
+  buildPageUrl: (page: number) => string;
 }
 
-function PaginationLink({ page, isCurrent }: PaginationLinkProps) {
+function PaginationLink({
+  page,
+  isCurrent,
+  buildPageUrl,
+}: PaginationLinkProps) {
   const href = buildPageUrl(page);
 
   if (isCurrent) {
@@ -38,12 +69,21 @@ function PaginationLink({ page, isCurrent }: PaginationLinkProps) {
   );
 }
 
-export function AcademyPagination({
+export interface PaginationProps {
+  currentPage: number;
+  totalPages: number;
+  rowCount: number;
+  pageSize: number;
+  buildPageUrl: (page: number) => string;
+}
+
+export function Pagination({
   currentPage,
   totalPages,
   rowCount,
   pageSize,
-}: AcademyPaginationProps) {
+  buildPageUrl,
+}: PaginationProps) {
   if (totalPages <= 1) {
     return null;
   }
@@ -51,43 +91,7 @@ export function AcademyPagination({
   const startItem = (currentPage - 1) * pageSize + 1;
   const endItem = Math.min(currentPage * pageSize, rowCount);
 
-  // Generate page numbers to show
-  const getPageNumbers = () => {
-    const pages: (number | "ellipsis-start" | "ellipsis-end")[] = [];
-    const showEllipsisStart = currentPage > 3;
-    const showEllipsisEnd = currentPage < totalPages - 2;
-
-    // Always show first page
-    pages.push(1);
-
-    if (showEllipsisStart) {
-      pages.push("ellipsis-start");
-    }
-
-    // Show pages around current
-    for (
-      let i = Math.max(2, currentPage - 1);
-      i <= Math.min(totalPages - 1, currentPage + 1);
-      i++
-    ) {
-      if (!pages.includes(i)) {
-        pages.push(i);
-      }
-    }
-
-    if (showEllipsisEnd) {
-      pages.push("ellipsis-end");
-    }
-
-    // Always show last page if more than 1 page
-    if (totalPages > 1 && !pages.includes(totalPages)) {
-      pages.push(totalPages);
-    }
-
-    return pages;
-  };
-
-  const pageNumbers = getPageNumbers();
+  const pageNumbers = getPageNumbers(currentPage, totalPages);
   const canGoPrev = currentPage > 1;
   const canGoNext = currentPage < totalPages;
 
@@ -123,6 +127,7 @@ export function AcademyPagination({
               key={pageNum}
               page={pageNum}
               isCurrent={pageNum === currentPage}
+              buildPageUrl={buildPageUrl}
             />
           )
         )}

--- a/front/lib/contentful/client.ts
+++ b/front/lib/contentful/client.ts
@@ -203,15 +203,17 @@ function cleanDocumentEmbeddedEntries(document: Document): Document {
             : {};
 
         // Handle both course and lesson entries
-        const idField = "courseId" in entry.fields
-          ? { courseId: entry.fields.courseId }
-          : "lessonId" in entry.fields
-          ? { lessonId: entry.fields.lessonId }
-          : {};
+        const idField =
+          "courseId" in entry.fields
+            ? { courseId: entry.fields.courseId }
+            : "lessonId" in entry.fields
+              ? { lessonId: entry.fields.lessonId }
+              : {};
 
-        const complexityField = "complexity" in entry.fields
-          ? { complexity: entry.fields.complexity }
-          : {};
+        const complexityField =
+          "complexity" in entry.fields
+            ? { complexity: entry.fields.complexity }
+            : {};
 
         return {
           ...node,
@@ -1237,7 +1239,10 @@ function contentfulEntryToLesson(entry: Entry<LessonSkeleton>): Lesson | null {
 
   const parentCourseEntry = fields.parentCourse;
   let parentCourse: CourseSummary | null = null;
-  if (isContentfulEntryForCourse(parentCourseEntry)) {
+  if (
+    isContentfulContentEntry(parentCourseEntry) &&
+    isContentfulEntryForCourse(parentCourseEntry)
+  ) {
     parentCourse = contentfulEntryToCourseSummary(parentCourseEntry);
   }
 

--- a/front/lib/contentful/client.ts
+++ b/front/lib/contentful/client.ts
@@ -209,6 +209,10 @@ function cleanDocumentEmbeddedEntries(document: Document): Document {
           ? { lessonId: entry.fields.lessonId }
           : {};
 
+        const complexityField = "complexity" in entry.fields
+          ? { complexity: entry.fields.complexity }
+          : {};
+
         return {
           ...node,
           data: {
@@ -221,6 +225,7 @@ function cleanDocumentEmbeddedEntries(document: Document): Document {
                 description: entry.fields.description,
                 ...idField,
                 estimatedDurationMinutes: entry.fields.estimatedDurationMinutes,
+                ...complexityField,
               },
             },
           },

--- a/front/lib/contentful/client.ts
+++ b/front/lib/contentful/client.ts
@@ -957,7 +957,7 @@ function contentfulEntryToCourseSummary(
     : null;
 
   return {
-    kind: "course" as const,
+    kind: "course",
     id: entry.sys.id,
     slug,
     title,
@@ -1057,7 +1057,7 @@ export async function getAllCourses(
     });
 
     const courses = response.items
-      .map((entry) => contentfulEntryToCourse(entry))
+      .map((entry) => contentfulEntryToCourseSummary(entry))
       .filter(isNonNull)
       .sort((a, b) => {
         // Sort by courseId if available, otherwise by dateOfAddition or createdAt
@@ -1077,19 +1077,7 @@ export async function getAllCourses(
           ? new Date(b.dateOfAddition).getTime()
           : new Date(b.createdAt).getTime();
         return bDate - aDate;
-      })
-      .map((course) => ({
-        kind: "course" as const,
-        id: course.id,
-        slug: course.slug,
-        title: course.title,
-        description: course.description,
-        courseId: course.courseId,
-        dateOfAddition: course.dateOfAddition,
-        estimatedDurationMinutes: course.estimatedDurationMinutes,
-        image: course.image,
-        createdAt: course.createdAt,
-      }));
+      });
 
     return new Ok(courses);
   } catch (error) {
@@ -1157,7 +1145,7 @@ function contentfulEntryToLessonSummary(
         : null;
 
     return {
-      kind: "lesson" as const,
+      kind: "lesson",
       id: entry.sys.id,
       slug,
       title,

--- a/front/lib/contentful/richTextRenderer.tsx
+++ b/front/lib/contentful/richTextRenderer.tsx
@@ -7,6 +7,7 @@ import Image from "next/image";
 import type { ReactNode } from "react";
 import { useEffect, useState } from "react";
 
+import { LessonLink } from "@app/components/academy/LessonLink";
 import { A, H2, H3, H4, H5 } from "@app/components/home/ContentComponents";
 import { contentfulImageLoader } from "@app/lib/contentful/imageLoader";
 import {
@@ -251,6 +252,9 @@ const renderOptions: Options = {
       </blockquote>
     ),
     [BLOCKS.EMBEDDED_ASSET]: (node) => {
+      if (!node.data?.target?.fields) {
+        return null;
+      }
       const { file, title, description } = node.data.target.fields;
       if (!file) {
         return null;
@@ -306,6 +310,45 @@ const renderOptions: Options = {
         {children}
       </td>
     ),
+    [BLOCKS.EMBEDDED_ENTRY]: (node) => {
+      if (!node.data?.target) {
+        return null;
+      }
+      const entry = node.data.target;
+      const contentType = entry?.sys?.contentType?.sys?.id;
+
+      // Handle lesson entries
+      if (contentType === "lesson") {
+        const fields = entry.fields;
+        const title = isString(fields.title) ? fields.title : "";
+        const slug = isString(fields.slug) ? fields.slug : "";
+        const description = isString(fields.description)
+          ? fields.description
+          : null;
+        const courseId = isString(fields.courseId) ? fields.courseId : null;
+        const estimatedDurationMinutes =
+          typeof fields.estimatedDurationMinutes === "number"
+            ? fields.estimatedDurationMinutes
+            : null;
+
+        if (!title || !slug) {
+          return null;
+        }
+
+        return (
+          <LessonLink
+            title={title}
+            slug={slug}
+            description={description}
+            courseId={courseId}
+            estimatedDurationMinutes={estimatedDurationMinutes}
+          />
+        );
+      }
+
+      // Fallback for other embedded entry types
+      return null;
+    },
     [INLINES.HYPERLINK]: (node, children) => {
       const url = node.data.uri;
       // Check if it's a YouTube URL and embed it

--- a/front/lib/contentful/richTextRenderer.tsx
+++ b/front/lib/contentful/richTextRenderer.tsx
@@ -325,7 +325,7 @@ const renderOptions: Options = {
         const description = isString(fields.description)
           ? fields.description
           : null;
-        const courseId = isString(fields.courseId) ? fields.courseId : null;
+        const lessonId = isString(fields.lessonId) ? fields.lessonId : null;
         const estimatedDurationMinutes =
           typeof fields.estimatedDurationMinutes === "number"
             ? fields.estimatedDurationMinutes
@@ -340,7 +340,7 @@ const renderOptions: Options = {
             title={title}
             slug={slug}
             description={description}
-            courseId={courseId}
+            lessonId={lessonId}
             estimatedDurationMinutes={estimatedDurationMinutes}
           />
         );

--- a/front/lib/contentful/richTextRenderer.tsx
+++ b/front/lib/contentful/richTextRenderer.tsx
@@ -330,6 +330,9 @@ const renderOptions: Options = {
           typeof fields.estimatedDurationMinutes === "number"
             ? fields.estimatedDurationMinutes
             : null;
+        const complexity = isString(fields.complexity)
+          ? fields.complexity
+          : null;
 
         if (!title || !slug) {
           return null;
@@ -342,6 +345,7 @@ const renderOptions: Options = {
             description={description}
             lessonId={lessonId}
             estimatedDurationMinutes={estimatedDurationMinutes}
+            complexity={complexity}
           />
         );
       }

--- a/front/lib/contentful/types.ts
+++ b/front/lib/contentful/types.ts
@@ -251,6 +251,7 @@ export interface CourseListingPageProps {
 
 export interface CoursePageProps {
   course: Course;
+  courses: CourseSummary[];
   gtmTrackingId: string | null;
   preview?: boolean;
 }
@@ -312,6 +313,7 @@ export interface LessonSummary {
 
 export interface LessonPageProps {
   lesson: Lesson;
+  courses: CourseSummary[];
   gtmTrackingId: string | null;
   preview?: boolean;
 }

--- a/front/lib/contentful/types.ts
+++ b/front/lib/contentful/types.ts
@@ -262,13 +262,17 @@ export interface LessonFields {
   dateOfAddition: string;
   description: string;
   lessonObjectives?: string;
-  courseId: string;
+  lessonId: string;
   slug: string;
   estimatedDurationMinutes?: number;
   preRequisites?: Document;
   lessonContent: Document;
   previousContent?: Entry<CourseSkeleton | LessonSkeleton>;
   nextContent?: Entry<CourseSkeleton | LessonSkeleton>;
+  Category?: string;
+  tools?: string[];
+  complexity?: string;
+  parentCourse?: Entry<CourseSkeleton>;
 }
 
 export type LessonSkeleton = EntrySkeletonType<LessonFields, "lesson">;
@@ -280,7 +284,7 @@ export interface Lesson {
   slug: string;
   title: string;
   description: string | null;
-  courseId: string | null;
+  lessonId: string | null;
   dateOfAddition: string | null;
   estimatedDurationMinutes: number | null;
   lessonObjectives: string | null;
@@ -288,6 +292,10 @@ export interface Lesson {
   preRequisites: Document | null;
   previousContent: ContentSummary | null;
   nextContent: ContentSummary | null;
+  category: string | null;
+  tools: string[];
+  complexity: string | null;
+  parentCourse: CourseSummary | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -297,7 +305,7 @@ export interface LessonSummary {
   slug: string;
   title: string;
   description: string | null;
-  courseId: string | null;
+  lessonId: string | null;
   estimatedDurationMinutes: number | null;
   createdAt: string;
 }

--- a/front/lib/contentful/types.ts
+++ b/front/lib/contentful/types.ts
@@ -233,6 +233,7 @@ export interface Course {
 }
 
 export interface CourseSummary {
+  kind: "course";
   id: string;
   slug: string;
   title: string;
@@ -302,6 +303,7 @@ export interface Lesson {
 }
 
 export interface LessonSummary {
+  kind: "lesson";
   id: string;
   slug: string;
   title: string;
@@ -309,6 +311,18 @@ export interface LessonSummary {
   lessonId: string | null;
   estimatedDurationMinutes: number | null;
   createdAt: string;
+}
+
+export function isCourseSummary(
+  content: ContentSummary
+): content is CourseSummary {
+  return content.kind === "course";
+}
+
+export function isLessonSummary(
+  content: ContentSummary
+): content is LessonSummary {
+  return content.kind === "lesson";
 }
 
 export interface LessonPageProps {

--- a/front/lib/contentful/types.ts
+++ b/front/lib/contentful/types.ts
@@ -192,3 +192,118 @@ export interface CustomerStoryPageProps {
   gtmTrackingId: string | null;
   preview?: boolean;
 }
+
+// Course types
+
+export interface CourseFields {
+  title: string;
+  dateOfAddition: string;
+  courseImage: Asset;
+  description: string;
+  courseId: string;
+  slug: string;
+  tableOfContents?: string;
+  estimatedDurationMinutes?: number;
+  preRequisites?: Document;
+  courseContent: Document;
+  previousCourse?: Entry<CourseSkeleton>;
+  nextCourse?: Entry<CourseSkeleton>;
+  author?: Entry<AuthorSkeleton>;
+}
+
+export type CourseSkeleton = EntrySkeletonType<CourseFields, "course">;
+
+export interface Course {
+  id: string;
+  slug: string;
+  title: string;
+  description: string | null;
+  courseId: string | null;
+  dateOfAddition: string | null;
+  estimatedDurationMinutes: number | null;
+  courseContent: Document;
+  preRequisites: Document | null;
+  tableOfContents: string | null;
+  image: BlogImage | null;
+  author: BlogAuthor | null;
+  previousCourse: CourseSummary | null;
+  nextCourse: CourseSummary | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CourseSummary {
+  id: string;
+  slug: string;
+  title: string;
+  description: string | null;
+  courseId: string | null;
+  dateOfAddition: string | null;
+  estimatedDurationMinutes: number | null;
+  image: BlogImage | null;
+  createdAt: string;
+}
+
+export interface CourseListingPageProps {
+  courses: CourseSummary[];
+  gtmTrackingId: string | null;
+}
+
+export interface CoursePageProps {
+  course: Course;
+  gtmTrackingId: string | null;
+  preview?: boolean;
+}
+
+// Lesson types
+
+export interface LessonFields {
+  title: string;
+  dateOfAddition: string;
+  description: string;
+  lessonObjectives?: string;
+  courseId: string;
+  slug: string;
+  estimatedDurationMinutes?: number;
+  preRequisites?: Document;
+  lessonContent: Document;
+  previousContent?: Entry<CourseSkeleton | LessonSkeleton>;
+  nextContent?: Entry<CourseSkeleton | LessonSkeleton>;
+}
+
+export type LessonSkeleton = EntrySkeletonType<LessonFields, "lesson">;
+
+export type ContentSummary = CourseSummary | LessonSummary;
+
+export interface Lesson {
+  id: string;
+  slug: string;
+  title: string;
+  description: string | null;
+  courseId: string | null;
+  dateOfAddition: string | null;
+  estimatedDurationMinutes: number | null;
+  lessonObjectives: string | null;
+  lessonContent: Document;
+  preRequisites: Document | null;
+  previousContent: ContentSummary | null;
+  nextContent: ContentSummary | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface LessonSummary {
+  id: string;
+  slug: string;
+  title: string;
+  description: string | null;
+  courseId: string | null;
+  estimatedDurationMinutes: number | null;
+  createdAt: string;
+}
+
+export interface LessonPageProps {
+  lesson: Lesson;
+  gtmTrackingId: string | null;
+  preview?: boolean;
+}

--- a/front/pages/academy/[slug].tsx
+++ b/front/pages/academy/[slug].tsx
@@ -69,10 +69,7 @@ export const getStaticProps: GetStaticProps<CoursePageProps> = async (
 
 const WIDE_CLASSES = classNames("col-span-12", "lg:col-span-10 lg:col-start-2");
 
-export default function CoursePage({
-  course,
-  preview,
-}: CoursePageProps) {
+export default function CoursePage({ course, preview }: CoursePageProps) {
   const ogImageUrl = course.image?.url ?? "https://dust.tt/static/og_image.png";
   const canonicalUrl = `https://dust.tt/academy/${course.slug}`;
   const tocItems = extractTableOfContents(course.courseContent);
@@ -122,9 +119,7 @@ export default function CoursePage({
 
           <header className={WIDE_CLASSES}>
             <div className="mb-4 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
-              {course.courseId && (
-                <span>Course {course.courseId}</span>
-              )}
+              {course.courseId && <span>Course {course.courseId}</span>}
               {course.estimatedDurationMinutes && (
                 <>
                   {course.courseId && <span>•</span>}
@@ -135,7 +130,7 @@ export default function CoursePage({
 
             <H1 className="text-4xl md:text-5xl">{course.title}</H1>
 
-            {(course.author || course.dateOfAddition) && (
+            {(course.author ?? course.dateOfAddition) && (
               <div className="mt-4 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
                 {course.author && (
                   <>
@@ -222,8 +217,13 @@ export default function CoursePage({
             </div>
           </div>
 
-          {(course.previousCourse || course.nextCourse) && (
-            <div className={classNames(WIDE_CLASSES, "mt-12 border-t border-gray-200 pt-8")}>
+          {(course.previousCourse ?? course.nextCourse) && (
+            <div
+              className={classNames(
+                WIDE_CLASSES,
+                "mt-12 border-t border-gray-200 pt-8"
+              )}
+            >
               <div className="flex flex-col gap-4 sm:flex-row sm:justify-between">
                 {course.previousCourse && (
                   <Link
@@ -263,4 +263,3 @@ export default function CoursePage({
 CoursePage.getLayout = (page: ReactElement, pageProps: LandingLayoutProps) => {
   return <LandingLayout pageProps={pageProps}>{page}</LandingLayout>;
 };
-

--- a/front/pages/academy/[slug].tsx
+++ b/front/pages/academy/[slug].tsx
@@ -132,134 +132,134 @@ export default function CoursePage({
               </Link>
             </div>
 
-          <header className={WIDE_CLASSES}>
-            <div className="mb-4 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
-              {course.courseId && <span>Course {course.courseId}</span>}
-              {course.estimatedDurationMinutes && (
-                <>
-                  {course.courseId && <span>•</span>}
-                  <span>{course.estimatedDurationMinutes} min</span>
-                </>
-              )}
-            </div>
-
-            <H1 className="text-4xl md:text-5xl">{course.title}</H1>
-
-            {(course.author ?? course.dateOfAddition) && (
-              <div className="mt-4 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
-                {course.author && (
+            <header className={WIDE_CLASSES}>
+              <div className="mb-4 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+                {course.courseId && <span>Course {course.courseId}</span>}
+                {course.estimatedDurationMinutes && (
                   <>
-                    <div className="flex items-center gap-2">
-                      {course.author.image ? (
-                        <Image
-                          src={course.author.image.url}
-                          alt={course.author.name}
-                          width={24}
-                          height={24}
-                          loader={contentfulImageLoader}
-                          sizes="24px"
-                          className="rounded-full"
-                        />
-                      ) : (
-                        <div className="flex h-6 w-6 items-center justify-center rounded-full bg-gray-200 text-xs font-semibold text-gray-600">
-                          {course.author.name.charAt(0).toUpperCase()}
-                        </div>
-                      )}
-                      <span>{course.author.name}</span>
-                    </div>
-                    {course.dateOfAddition && <span>-</span>}
+                    {course.courseId && <span>•</span>}
+                    <span>{course.estimatedDurationMinutes} min</span>
                   </>
                 )}
-                {course.dateOfAddition && (
-                  <span>
-                    {formatTimestampToFriendlyDate(
-                      new Date(course.dateOfAddition).getTime(),
-                      "short"
-                    )}
-                  </span>
-                )}
+              </div>
+
+              <H1 className="text-4xl md:text-5xl">{course.title}</H1>
+
+              {(course.author ?? course.dateOfAddition) && (
+                <div className="mt-4 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+                  {course.author && (
+                    <>
+                      <div className="flex items-center gap-2">
+                        {course.author.image ? (
+                          <Image
+                            src={course.author.image.url}
+                            alt={course.author.name}
+                            width={24}
+                            height={24}
+                            loader={contentfulImageLoader}
+                            sizes="24px"
+                            className="rounded-full"
+                          />
+                        ) : (
+                          <div className="flex h-6 w-6 items-center justify-center rounded-full bg-gray-200 text-xs font-semibold text-gray-600">
+                            {course.author.name.charAt(0).toUpperCase()}
+                          </div>
+                        )}
+                        <span>{course.author.name}</span>
+                      </div>
+                      {course.dateOfAddition && <span>-</span>}
+                    </>
+                  )}
+                  {course.dateOfAddition && (
+                    <span>
+                      {formatTimestampToFriendlyDate(
+                        new Date(course.dateOfAddition).getTime(),
+                        "short"
+                      )}
+                    </span>
+                  )}
+                </div>
+              )}
+            </header>
+
+            {course.image && (
+              <div className={classNames(WIDE_CLASSES, "mt-2")}>
+                <div className="overflow-hidden rounded-2xl border border-gray-100 bg-white">
+                  <Image
+                    src={course.image.url}
+                    alt={course.image.alt}
+                    width={course.image.width}
+                    height={course.image.height}
+                    loader={contentfulImageLoader}
+                    className="h-full w-full object-cover"
+                    sizes="(min-width: 1536px) 1280px, (min-width: 1280px) 1067px, (min-width: 1024px) 853px, 100vw"
+                    priority
+                  />
+                </div>
               </div>
             )}
-          </header>
 
-          {course.image && (
-            <div className={classNames(WIDE_CLASSES, "mt-2")}>
-              <div className="overflow-hidden rounded-2xl border border-gray-100 bg-white">
-                <Image
-                  src={course.image.url}
-                  alt={course.image.alt}
-                  width={course.image.width}
-                  height={course.image.height}
-                  loader={contentfulImageLoader}
-                  className="h-full w-full object-cover"
-                  sizes="(min-width: 1536px) 1280px, (min-width: 1280px) 1067px, (min-width: 1024px) 853px, 100vw"
-                  priority
-                />
+            {course.tableOfContents && (
+              <div className={classNames(WIDE_CLASSES, "mt-6")}>
+                <H2 className="mb-4">Course Objectives</H2>
+                <div className="rounded-lg border border-gray-200 bg-gray-50 p-6">
+                  <P className="whitespace-pre-line text-muted-foreground">
+                    {course.tableOfContents}
+                  </P>
+                </div>
               </div>
-            </div>
-          )}
+            )}
 
-          {course.tableOfContents && (
-            <div className={classNames(WIDE_CLASSES, "mt-6")}>
-              <H2 className="mb-4">Course Objectives</H2>
-              <div className="rounded-lg border border-gray-200 bg-gray-50 p-6">
-                <P className="whitespace-pre-line text-muted-foreground">
-                  {course.tableOfContents}
-                </P>
+            {course.preRequisites && (
+              <div className={classNames(WIDE_CLASSES, "mt-6")}>
+                <H2 className="mb-4">Prerequisites</H2>
+                <div className="rounded-lg border border-gray-200 bg-gray-50 p-6">
+                  {renderRichTextFromContentful(course.preRequisites)}
+                </div>
               </div>
+            )}
+
+            <div className={classNames(WIDE_CLASSES, "mt-4")}>
+              {renderRichTextFromContentful(course.courseContent)}
             </div>
-          )}
 
-          {course.preRequisites && (
-            <div className={classNames(WIDE_CLASSES, "mt-6")}>
-              <H2 className="mb-4">Prerequisites</H2>
-              <div className="rounded-lg border border-gray-200 bg-gray-50 p-6">
-                {renderRichTextFromContentful(course.preRequisites)}
-              </div>
-            </div>
-          )}
-
-          <div className={classNames(WIDE_CLASSES, "mt-4")}>
-            {renderRichTextFromContentful(course.courseContent)}
-          </div>
-
-          {(course.previousCourse ?? course.nextCourse) && (
-            <div
-              className={classNames(
-                WIDE_CLASSES,
-                "mt-12 border-t border-gray-200 pt-8"
-              )}
-            >
-              <div className="flex flex-col gap-4 sm:flex-row sm:justify-between">
-                {course.previousCourse && (
-                  <Link
-                    href={`/academy/${course.previousCourse.slug}`}
-                    className="group flex flex-col"
-                  >
-                    <P size="sm" className="text-muted-foreground">
-                      Previous Course
-                    </P>
-                    <span className="mt-1 text-base font-medium text-foreground transition-colors group-hover:text-highlight">
-                      &larr; {course.previousCourse.title}
-                    </span>
-                  </Link>
+            {(course.previousCourse ?? course.nextCourse) && (
+              <div
+                className={classNames(
+                  WIDE_CLASSES,
+                  "mt-12 border-t border-gray-200 pt-8"
                 )}
-                {course.nextCourse && (
-                  <Link
-                    href={`/academy/${course.nextCourse.slug}`}
-                    className="group flex flex-col items-end sm:items-start"
-                  >
-                    <P size="sm" className="text-muted-foreground">
-                      Next Course
-                    </P>
-                    <span className="mt-1 text-base font-medium text-foreground transition-colors group-hover:text-highlight">
-                      {course.nextCourse.title} &rarr;
-                    </span>
-                  </Link>
-                )}
+              >
+                <div className="flex flex-col gap-4 sm:flex-row sm:justify-between">
+                  {course.previousCourse && (
+                    <Link
+                      href={`/academy/${course.previousCourse.slug}`}
+                      className="group flex flex-col"
+                    >
+                      <P size="sm" className="text-muted-foreground">
+                        Previous Course
+                      </P>
+                      <span className="mt-1 text-base font-medium text-foreground transition-colors group-hover:text-highlight">
+                        &larr; {course.previousCourse.title}
+                      </span>
+                    </Link>
+                  )}
+                  {course.nextCourse && (
+                    <Link
+                      href={`/academy/${course.nextCourse.slug}`}
+                      className="group flex flex-col items-end sm:items-start"
+                    >
+                      <P size="sm" className="text-muted-foreground">
+                        Next Course
+                      </P>
+                      <span className="mt-1 text-base font-medium text-foreground transition-colors group-hover:text-highlight">
+                        {course.nextCourse.title} &rarr;
+                      </span>
+                    </Link>
+                  )}
+                </div>
               </div>
-            </div>
-          )}
+            )}
           </Grid>
         </article>
       </div>

--- a/front/pages/academy/[slug].tsx
+++ b/front/pages/academy/[slug].tsx
@@ -1,0 +1,266 @@
+import type { GetStaticPaths, GetStaticProps } from "next";
+import Head from "next/head";
+import Image from "next/image";
+import Link from "next/link";
+import type { ReactElement } from "react";
+
+import { TableOfContents } from "@app/components/blog/TableOfContents";
+import { Grid, H1, H2, P } from "@app/components/home/ContentComponents";
+import type { LandingLayoutProps } from "@app/components/home/LandingLayout";
+import LandingLayout from "@app/components/home/LandingLayout";
+import {
+  buildPreviewQueryString,
+  CONTENTFUL_REVALIDATE_SECONDS,
+  getCourseBySlug,
+} from "@app/lib/contentful/client";
+import { contentfulImageLoader } from "@app/lib/contentful/imageLoader";
+import { renderRichTextFromContentful } from "@app/lib/contentful/richTextRenderer";
+import { extractTableOfContents } from "@app/lib/contentful/tableOfContents";
+import type { CoursePageProps } from "@app/lib/contentful/types";
+import { classNames, formatTimestampToFriendlyDate } from "@app/lib/utils";
+import logger from "@app/logger/logger";
+import { isString } from "@app/types";
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  // Don't pre-generate any paths at build time to minimize Contentful API calls.
+  // Pages are generated on-demand via fallback: "blocking" and cached with ISR.
+  return {
+    paths: [],
+    fallback: "blocking",
+  };
+};
+
+export const getStaticProps: GetStaticProps<CoursePageProps> = async (
+  context
+) => {
+  const { slug } = context.params ?? {};
+
+  if (!isString(slug)) {
+    return { notFound: true };
+  }
+
+  const resolvedUrl = buildPreviewQueryString(context.preview ?? false);
+
+  const courseResult = await getCourseBySlug(slug, resolvedUrl);
+
+  if (courseResult.isErr()) {
+    logger.error(
+      { slug, error: courseResult.error },
+      `Error fetching course "${slug}"`
+    );
+    return { notFound: true };
+  }
+
+  const course = courseResult.value;
+
+  if (!course) {
+    return { notFound: true };
+  }
+
+  return {
+    props: {
+      course,
+      gtmTrackingId: process.env.NEXT_PUBLIC_GTM_TRACKING_ID ?? null,
+      preview: context.preview ?? false,
+    },
+    revalidate: CONTENTFUL_REVALIDATE_SECONDS,
+  };
+};
+
+const WIDE_CLASSES = classNames("col-span-12", "lg:col-span-10 lg:col-start-2");
+
+export default function CoursePage({
+  course,
+  preview,
+}: CoursePageProps) {
+  const ogImageUrl = course.image?.url ?? "https://dust.tt/static/og_image.png";
+  const canonicalUrl = `https://dust.tt/academy/${course.slug}`;
+  const tocItems = extractTableOfContents(course.courseContent);
+
+  return (
+    <>
+      {preview && (
+        <div className="fixed left-0 right-0 top-0 z-50 bg-amber-100 px-4 py-2 text-center text-amber-800">
+          Preview Mode - This is a draft
+        </div>
+      )}
+      <Head>
+        <title>{course.title} | Dust Academy</title>
+        {preview && <meta name="robots" content="noindex, nofollow" />}
+        {course.description && (
+          <meta name="description" content={course.description} />
+        )}
+        <link rel="canonical" href={canonicalUrl} />
+
+        <meta property="og:title" content={course.title} />
+        {course.description && (
+          <meta property="og:description" content={course.description} />
+        )}
+        <meta property="og:type" content="article" />
+        <meta property="og:image" content={ogImageUrl} />
+        <meta property="og:url" content={canonicalUrl} />
+        <meta property="og:site_name" content="Dust" />
+
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={course.title} />
+        {course.description && (
+          <meta name="twitter:description" content={course.description} />
+        )}
+        <meta name="twitter:image" content={ogImageUrl} />
+      </Head>
+
+      <article>
+        <Grid>
+          <div className={classNames(WIDE_CLASSES, "pb-2 pt-6")}>
+            <Link
+              href="/academy"
+              className="inline-flex items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
+            >
+              <span>&larr;</span> Back to Academy
+            </Link>
+          </div>
+
+          <header className={WIDE_CLASSES}>
+            <div className="mb-4 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+              {course.courseId && (
+                <span>Course {course.courseId}</span>
+              )}
+              {course.estimatedDurationMinutes && (
+                <>
+                  {course.courseId && <span>•</span>}
+                  <span>{course.estimatedDurationMinutes} min</span>
+                </>
+              )}
+            </div>
+
+            <H1 className="text-4xl md:text-5xl">{course.title}</H1>
+
+            {(course.author || course.dateOfAddition) && (
+              <div className="mt-4 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+                {course.author && (
+                  <>
+                    <div className="flex items-center gap-2">
+                      {course.author.image ? (
+                        <Image
+                          src={course.author.image.url}
+                          alt={course.author.name}
+                          width={24}
+                          height={24}
+                          loader={contentfulImageLoader}
+                          sizes="24px"
+                          className="rounded-full"
+                        />
+                      ) : (
+                        <div className="flex h-6 w-6 items-center justify-center rounded-full bg-gray-200 text-xs font-semibold text-gray-600">
+                          {course.author.name.charAt(0).toUpperCase()}
+                        </div>
+                      )}
+                      <span>{course.author.name}</span>
+                    </div>
+                    {course.dateOfAddition && <span>-</span>}
+                  </>
+                )}
+                {course.dateOfAddition && (
+                  <span>
+                    {formatTimestampToFriendlyDate(
+                      new Date(course.dateOfAddition).getTime(),
+                      "short"
+                    )}
+                  </span>
+                )}
+              </div>
+            )}
+          </header>
+
+          {course.image && (
+            <div className={classNames(WIDE_CLASSES, "mt-2")}>
+              <div className="overflow-hidden rounded-2xl border border-gray-100 bg-white">
+                <Image
+                  src={course.image.url}
+                  alt={course.image.alt}
+                  width={course.image.width}
+                  height={course.image.height}
+                  loader={contentfulImageLoader}
+                  className="h-full w-full object-cover"
+                  sizes="(min-width: 1536px) 1280px, (min-width: 1280px) 1067px, (min-width: 1024px) 853px, 100vw"
+                  priority
+                />
+              </div>
+            </div>
+          )}
+
+          {course.tableOfContents && (
+            <div className={classNames(WIDE_CLASSES, "mt-6")}>
+              <H2 className="mb-4">Course Objectives</H2>
+              <div className="rounded-lg border border-gray-200 bg-gray-50 p-6">
+                <P className="whitespace-pre-line text-muted-foreground">
+                  {course.tableOfContents}
+                </P>
+              </div>
+            </div>
+          )}
+
+          {course.preRequisites && (
+            <div className={classNames(WIDE_CLASSES, "mt-6")}>
+              <H2 className="mb-4">Prerequisites</H2>
+              <div className="rounded-lg border border-gray-200 bg-gray-50 p-6">
+                {renderRichTextFromContentful(course.preRequisites)}
+              </div>
+            </div>
+          )}
+
+          <div className={classNames(WIDE_CLASSES, "mt-4")}>
+            <div className="grid gap-8 lg:grid-cols-12">
+              <div className="lg:col-span-9">
+                {renderRichTextFromContentful(course.courseContent)}
+              </div>
+              {tocItems.length > 0 && (
+                <div className="hidden lg:col-span-3 lg:block">
+                  <TableOfContents items={tocItems} />
+                </div>
+              )}
+            </div>
+          </div>
+
+          {(course.previousCourse || course.nextCourse) && (
+            <div className={classNames(WIDE_CLASSES, "mt-12 border-t border-gray-200 pt-8")}>
+              <div className="flex flex-col gap-4 sm:flex-row sm:justify-between">
+                {course.previousCourse && (
+                  <Link
+                    href={`/academy/${course.previousCourse.slug}`}
+                    className="group flex flex-col"
+                  >
+                    <P size="sm" className="text-muted-foreground">
+                      Previous Course
+                    </P>
+                    <span className="mt-1 text-base font-medium text-foreground transition-colors group-hover:text-highlight">
+                      &larr; {course.previousCourse.title}
+                    </span>
+                  </Link>
+                )}
+                {course.nextCourse && (
+                  <Link
+                    href={`/academy/${course.nextCourse.slug}`}
+                    className="group flex flex-col items-end sm:items-start"
+                  >
+                    <P size="sm" className="text-muted-foreground">
+                      Next Course
+                    </P>
+                    <span className="mt-1 text-base font-medium text-foreground transition-colors group-hover:text-highlight">
+                      {course.nextCourse.title} &rarr;
+                    </span>
+                  </Link>
+                )}
+              </div>
+            </div>
+          )}
+        </Grid>
+      </article>
+    </>
+  );
+}
+
+CoursePage.getLayout = (page: ReactElement, pageProps: LandingLayoutProps) => {
+  return <LandingLayout pageProps={pageProps}>{page}</LandingLayout>;
+};
+

--- a/front/pages/academy/[slug].tsx
+++ b/front/pages/academy/[slug].tsx
@@ -5,7 +5,6 @@ import Link from "next/link";
 import type { ReactElement } from "react";
 
 import { AcademySidebar } from "@app/components/academy/AcademySidebar";
-import { TableOfContents } from "@app/components/blog/TableOfContents";
 import { Grid, H1, H2, P } from "@app/components/home/ContentComponents";
 import type { LandingLayoutProps } from "@app/components/home/LandingLayout";
 import LandingLayout from "@app/components/home/LandingLayout";
@@ -117,7 +116,11 @@ export default function CoursePage({
       </Head>
 
       <div className="flex min-h-screen">
-        <AcademySidebar courses={courses} currentCourseSlug={course.slug} />
+        <AcademySidebar
+          courses={courses}
+          currentCourseSlug={course.slug}
+          tocItems={tocItems}
+        />
         <article className="flex-1">
           <Grid>
             <div className={classNames(WIDE_CLASSES, "pb-2 pt-6")}>
@@ -217,16 +220,7 @@ export default function CoursePage({
           )}
 
           <div className={classNames(WIDE_CLASSES, "mt-4")}>
-            <div className="grid gap-8 lg:grid-cols-12">
-              <div className="lg:col-span-9">
-                {renderRichTextFromContentful(course.courseContent)}
-              </div>
-              {tocItems.length > 0 && (
-                <div className="hidden lg:col-span-3 lg:block">
-                  <TableOfContents items={tocItems} />
-                </div>
-              )}
-            </div>
+            {renderRichTextFromContentful(course.courseContent)}
           </div>
 
           {(course.previousCourse ?? course.nextCourse) && (

--- a/front/pages/academy/index.tsx
+++ b/front/pages/academy/index.tsx
@@ -73,12 +73,12 @@ export default function AcademyListing({ courses }: CourseListingPageProps) {
         <title>Academy | Dust</title>
         <meta
           name="description"
-          content="Learn how to build and deploy AI agents with Dust through our comprehensive courses."
+          content="Courses, tutorials and videos to learn everything about Dust"
         />
         <meta property="og:title" content="Academy | Dust" />
         <meta
           property="og:description"
-          content="Learn how to build and deploy AI agents with Dust through our comprehensive courses."
+          content="Courses, tutorials and videos to learn everything about Dust"
         />
         <meta property="og:type" content="website" />
         <meta property="og:url" content="https://dust.tt/academy" />

--- a/front/pages/academy/index.tsx
+++ b/front/pages/academy/index.tsx
@@ -10,9 +10,9 @@ import {
   AcademyLayout,
   CourseGrid,
 } from "@app/components/academy/AcademyComponents";
-import { AcademyPagination } from "@app/components/academy/AcademyPagination";
 import type { LandingLayoutProps } from "@app/components/home/LandingLayout";
 import LandingLayout from "@app/components/home/LandingLayout";
+import { Pagination } from "@app/components/shared/Pagination";
 import {
   CONTENTFUL_REVALIDATE_SECONDS,
   getAllCourses,
@@ -99,11 +99,14 @@ export default function AcademyListing({ courses }: CourseListingPageProps) {
 
         {courses.length > ACADEMY_PAGE_SIZE && (
           <div className="col-span-12 mt-12 flex items-center justify-center pb-12">
-            <AcademyPagination
+            <Pagination
               currentPage={currentPage}
               totalPages={totalPages}
               rowCount={courses.length}
               pageSize={ACADEMY_PAGE_SIZE}
+              buildPageUrl={(p) =>
+                p === 1 ? "/academy" : `/academy/page/${p}`
+              }
             />
           </div>
         )}

--- a/front/pages/academy/index.tsx
+++ b/front/pages/academy/index.tsx
@@ -1,0 +1,120 @@
+import type { GetStaticProps } from "next";
+import Head from "next/head";
+import { useRouter } from "next/router";
+import type { ReactElement } from "react";
+import { useMemo } from "react";
+
+import {
+  ACADEMY_PAGE_SIZE,
+  AcademyHeader,
+  AcademyLayout,
+  CourseGrid,
+} from "@app/components/academy/AcademyComponents";
+import { AcademyPagination } from "@app/components/academy/AcademyPagination";
+import type { LandingLayoutProps } from "@app/components/home/LandingLayout";
+import LandingLayout from "@app/components/home/LandingLayout";
+import {
+  CONTENTFUL_REVALIDATE_SECONDS,
+  getAllCourses,
+} from "@app/lib/contentful/client";
+import type { CourseListingPageProps } from "@app/lib/contentful/types";
+import logger from "@app/logger/logger";
+import { isString } from "@app/types";
+
+export const getStaticProps: GetStaticProps<
+  CourseListingPageProps
+> = async () => {
+  const coursesResult = await getAllCourses();
+
+  if (coursesResult.isErr()) {
+    logger.error(
+      { error: coursesResult.error },
+      "Error fetching courses from Contentful"
+    );
+    return {
+      props: {
+        courses: [],
+        gtmTrackingId: process.env.NEXT_PUBLIC_GTM_TRACKING_ID ?? null,
+      },
+      revalidate: CONTENTFUL_REVALIDATE_SECONDS,
+    };
+  }
+
+  return {
+    props: {
+      courses: coursesResult.value,
+      gtmTrackingId: process.env.NEXT_PUBLIC_GTM_TRACKING_ID ?? null,
+    },
+    revalidate: CONTENTFUL_REVALIDATE_SECONDS,
+  };
+};
+
+export default function AcademyListing({ courses }: CourseListingPageProps) {
+  const router = useRouter();
+  const initialPage = useMemo(() => {
+    const queryPage = isString(router.query.page)
+      ? router.query.page
+      : undefined;
+    const parsed = parseInt(queryPage ?? "1", 10);
+    return parsed > 0 ? parsed : 1;
+  }, [router.query.page]);
+
+  const page = initialPage;
+
+  const totalPages = Math.max(1, Math.ceil(courses.length / ACADEMY_PAGE_SIZE));
+  const currentPage = Math.min(page, totalPages);
+  const startIndex = (currentPage - 1) * ACADEMY_PAGE_SIZE;
+  const endIndex = startIndex + ACADEMY_PAGE_SIZE;
+  const paginatedCourses = courses.slice(startIndex, endIndex);
+
+  return (
+    <>
+      <Head>
+        <title>Academy | Dust</title>
+        <meta
+          name="description"
+          content="Learn how to build and deploy AI agents with Dust through our comprehensive courses."
+        />
+        <meta property="og:title" content="Academy | Dust" />
+        <meta
+          property="og:description"
+          content="Learn how to build and deploy AI agents with Dust through our comprehensive courses."
+        />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content="https://dust.tt/academy" />
+        <meta property="og:image" content="/static/og_image.png" />
+        <link rel="canonical" href="https://dust.tt/academy" />
+        {totalPages > 1 && (
+          <link rel="next" href="https://dust.tt/academy/page/2" />
+        )}
+      </Head>
+
+      <AcademyLayout>
+        <AcademyHeader />
+
+        <CourseGrid
+          courses={paginatedCourses}
+          emptyMessage="No courses available yet. Check back soon!"
+        />
+
+        {courses.length > ACADEMY_PAGE_SIZE && (
+          <div className="col-span-12 mt-6 flex items-center justify-center">
+            <AcademyPagination
+              currentPage={currentPage}
+              totalPages={totalPages}
+              rowCount={courses.length}
+              pageSize={ACADEMY_PAGE_SIZE}
+            />
+          </div>
+        )}
+      </AcademyLayout>
+    </>
+  );
+}
+
+AcademyListing.getLayout = (
+  page: ReactElement,
+  pageProps: LandingLayoutProps
+) => {
+  return <LandingLayout pageProps={pageProps}>{page}</LandingLayout>;
+};

--- a/front/pages/academy/index.tsx
+++ b/front/pages/academy/index.tsx
@@ -51,15 +51,13 @@ export const getStaticProps: GetStaticProps<
 
 export default function AcademyListing({ courses }: CourseListingPageProps) {
   const router = useRouter();
-  const initialPage = useMemo(() => {
+  const page = useMemo(() => {
     const queryPage = isString(router.query.page)
       ? router.query.page
       : undefined;
     const parsed = parseInt(queryPage ?? "1", 10);
     return parsed > 0 ? parsed : 1;
   }, [router.query.page]);
-
-  const page = initialPage;
 
   const totalPages = Math.max(1, Math.ceil(courses.length / ACADEMY_PAGE_SIZE));
   const currentPage = Math.min(page, totalPages);

--- a/front/pages/academy/index.tsx
+++ b/front/pages/academy/index.tsx
@@ -70,15 +70,15 @@ export default function AcademyListing({ courses }: CourseListingPageProps) {
   return (
     <>
       <Head>
-        <title>Academy | Dust</title>
+        <title>Dust Academy</title>
         <meta
           name="description"
-          content="Courses, tutorials and videos to learn everything about Dust"
+          content="Master AI agents with Dust through hands-on courses and interactive lessons"
         />
-        <meta property="og:title" content="Academy | Dust" />
+        <meta property="og:title" content="Dust Academy" />
         <meta
           property="og:description"
-          content="Courses, tutorials and videos to learn everything about Dust"
+          content="Master AI agents with Dust through hands-on courses and interactive lessons"
         />
         <meta property="og:type" content="website" />
         <meta property="og:url" content="https://dust.tt/academy" />
@@ -98,7 +98,7 @@ export default function AcademyListing({ courses }: CourseListingPageProps) {
         />
 
         {courses.length > ACADEMY_PAGE_SIZE && (
-          <div className="col-span-12 mt-6 flex items-center justify-center">
+          <div className="col-span-12 mt-12 flex items-center justify-center pb-12">
             <AcademyPagination
               currentPage={currentPage}
               totalPages={totalPages}

--- a/front/pages/academy/lessons/[slug].tsx
+++ b/front/pages/academy/lessons/[slug].tsx
@@ -1,0 +1,225 @@
+import type { GetStaticPaths, GetStaticProps } from "next";
+import Head from "next/head";
+import Link from "next/link";
+import type { ReactElement } from "react";
+
+import { TableOfContents } from "@app/components/blog/TableOfContents";
+import { Grid, H1, H2, P } from "@app/components/home/ContentComponents";
+import type { LandingLayoutProps } from "@app/components/home/LandingLayout";
+import LandingLayout from "@app/components/home/LandingLayout";
+import {
+  buildPreviewQueryString,
+  CONTENTFUL_REVALIDATE_SECONDS,
+  getLessonBySlug,
+} from "@app/lib/contentful/client";
+import { renderRichTextFromContentful } from "@app/lib/contentful/richTextRenderer";
+import { extractTableOfContents } from "@app/lib/contentful/tableOfContents";
+import type { ContentSummary, LessonPageProps } from "@app/lib/contentful/types";
+import { classNames } from "@app/lib/utils";
+import logger from "@app/logger/logger";
+import { isString } from "@app/types";
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  // Don't pre-generate any paths at build time to minimize Contentful API calls.
+  // Pages are generated on-demand via fallback: "blocking" and cached with ISR.
+  return {
+    paths: [],
+    fallback: "blocking",
+  };
+};
+
+export const getStaticProps: GetStaticProps<LessonPageProps> = async (
+  context
+) => {
+  const { slug } = context.params ?? {};
+
+  if (!isString(slug)) {
+    return { notFound: true };
+  }
+
+  const resolvedUrl = buildPreviewQueryString(context.preview ?? false);
+
+  const lessonResult = await getLessonBySlug(slug, resolvedUrl);
+
+  if (lessonResult.isErr()) {
+    logger.error(
+      { slug, error: lessonResult.error },
+      `Error fetching lesson "${slug}"`
+    );
+    return { notFound: true };
+  }
+
+  const lesson = lessonResult.value;
+
+  if (!lesson) {
+    return { notFound: true };
+  }
+
+  return {
+    props: {
+      lesson,
+      gtmTrackingId: process.env.NEXT_PUBLIC_GTM_TRACKING_ID ?? null,
+      preview: context.preview ?? false,
+    },
+    revalidate: CONTENTFUL_REVALIDATE_SECONDS,
+  };
+};
+
+const WIDE_CLASSES = classNames("col-span-12", "lg:col-span-10 lg:col-start-2");
+
+function getContentUrl(content: ContentSummary): string {
+  // Check if it's a lesson by checking if it has the image field
+  // (courses have image, lessons don't in the summary)
+  if ("image" in content) {
+    return `/academy/${content.slug}`;
+  }
+  return `/academy/lessons/${content.slug}`;
+}
+
+function getContentTypeLabel(content: ContentSummary): string {
+  // Check if it's a course by checking if it has the image field
+  if ("image" in content) {
+    return "Course";
+  }
+  return "Lesson";
+}
+
+export default function LessonPage({
+  lesson,
+  preview,
+}: LessonPageProps) {
+  const canonicalUrl = `https://dust.tt/academy/lessons/${lesson.slug}`;
+  const tocItems = extractTableOfContents(lesson.lessonContent);
+
+  return (
+    <>
+      {preview && (
+        <div className="fixed left-0 right-0 top-0 z-50 bg-amber-100 px-4 py-2 text-center text-amber-800">
+          Preview Mode - This is a draft
+        </div>
+      )}
+      <Head>
+        <title>{lesson.title} | Dust Academy</title>
+        {preview && <meta name="robots" content="noindex, nofollow" />}
+        {lesson.description && (
+          <meta name="description" content={lesson.description} />
+        )}
+        <link rel="canonical" href={canonicalUrl} />
+
+        <meta property="og:title" content={lesson.title} />
+        {lesson.description && (
+          <meta property="og:description" content={lesson.description} />
+        )}
+        <meta property="og:type" content="article" />
+        <meta property="og:url" content={canonicalUrl} />
+        <meta property="og:site_name" content="Dust" />
+
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={lesson.title} />
+        {lesson.description && (
+          <meta name="twitter:description" content={lesson.description} />
+        )}
+      </Head>
+
+      <article>
+        <Grid>
+          <div className={classNames(WIDE_CLASSES, "pb-2 pt-6")}>
+            <Link
+              href="/academy"
+              className="inline-flex items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
+            >
+              <span>&larr;</span> Back to Academy
+            </Link>
+          </div>
+
+          <header className={WIDE_CLASSES}>
+            <div className="mb-4 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+              {lesson.courseId && (
+                <span>Lesson {lesson.courseId}</span>
+              )}
+              {lesson.estimatedDurationMinutes && (
+                <>
+                  {lesson.courseId && <span>•</span>}
+                  <span>{lesson.estimatedDurationMinutes} min</span>
+                </>
+              )}
+            </div>
+
+            <H1 className="text-4xl md:text-5xl">{lesson.title}</H1>
+          </header>
+
+          {lesson.lessonObjectives && (
+            <div className={classNames(WIDE_CLASSES, "mt-6")}>
+              <H2 className="mb-4">Lesson Objectives</H2>
+              <div className="rounded-lg border border-gray-200 bg-gray-50 p-6">
+                <P className="whitespace-pre-line text-muted-foreground">
+                  {lesson.lessonObjectives}
+                </P>
+              </div>
+            </div>
+          )}
+
+          {lesson.preRequisites && (
+            <div className={classNames(WIDE_CLASSES, "mt-6")}>
+              <H2 className="mb-4">Prerequisites</H2>
+              <div className="rounded-lg border border-gray-200 bg-gray-50 p-6">
+                {renderRichTextFromContentful(lesson.preRequisites)}
+              </div>
+            </div>
+          )}
+
+          <div className={classNames(WIDE_CLASSES, "mt-4")}>
+            <div className="grid gap-8 lg:grid-cols-12">
+              <div className="lg:col-span-9">
+                {renderRichTextFromContentful(lesson.lessonContent)}
+              </div>
+              {tocItems.length > 0 && (
+                <div className="hidden lg:col-span-3 lg:block">
+                  <TableOfContents items={tocItems} />
+                </div>
+              )}
+            </div>
+          </div>
+
+          {(lesson.previousContent || lesson.nextContent) && (
+            <div className={classNames(WIDE_CLASSES, "mt-12 border-t border-gray-200 pt-8")}>
+              <div className="flex flex-col gap-4 sm:flex-row sm:justify-between">
+                {lesson.previousContent && (
+                  <Link
+                    href={getContentUrl(lesson.previousContent)}
+                    className="group flex flex-col"
+                  >
+                    <P size="sm" className="text-muted-foreground">
+                      Previous {getContentTypeLabel(lesson.previousContent)}
+                    </P>
+                    <span className="mt-1 text-base font-medium text-foreground transition-colors group-hover:text-highlight">
+                      &larr; {lesson.previousContent.title}
+                    </span>
+                  </Link>
+                )}
+                {lesson.nextContent && (
+                  <Link
+                    href={getContentUrl(lesson.nextContent)}
+                    className="group flex flex-col items-end sm:items-start"
+                  >
+                    <P size="sm" className="text-muted-foreground">
+                      Next {getContentTypeLabel(lesson.nextContent)}
+                    </P>
+                    <span className="mt-1 text-base font-medium text-foreground transition-colors group-hover:text-highlight">
+                      {lesson.nextContent.title} &rarr;
+                    </span>
+                  </Link>
+                )}
+              </div>
+            </div>
+          )}
+        </Grid>
+      </article>
+    </>
+  );
+}
+
+LessonPage.getLayout = (page: ReactElement, pageProps: LandingLayoutProps) => {
+  return <LandingLayout pageProps={pageProps}>{page}</LandingLayout>;
+};
+

--- a/front/pages/academy/lessons/[slug].tsx
+++ b/front/pages/academy/lessons/[slug].tsx
@@ -145,118 +145,118 @@ export default function LessonPage({
                   className="inline-flex items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
                 >
                   <span>&larr;</span> Back to {lesson.parentCourse.title}
-              </Link>
-            ) : (
-              <Link
-                href="/academy"
-                className="inline-flex items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
-              >
-                <span>&larr;</span> Back to Academy
-              </Link>
-            )}
-          </div>
-
-          <header className={WIDE_CLASSES}>
-            <div className="mb-4 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
-              {lesson.lessonId && <span>Lesson {lesson.lessonId}</span>}
-              {lesson.estimatedDurationMinutes && (
-                <>
-                  {lesson.lessonId && <span>•</span>}
-                  <span>{lesson.estimatedDurationMinutes} min</span>
-                </>
+                </Link>
+              ) : (
+                <Link
+                  href="/academy"
+                  className="inline-flex items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
+                >
+                  <span>&larr;</span> Back to Academy
+                </Link>
               )}
-              {lesson.complexity && (
-                <>
-                  {(lesson.lessonId || lesson.estimatedDurationMinutes) && (
-                    <span>•</span>
+            </div>
+
+            <header className={WIDE_CLASSES}>
+              <div className="mb-4 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+                {lesson.lessonId && <span>Lesson {lesson.lessonId}</span>}
+                {lesson.estimatedDurationMinutes && (
+                  <>
+                    {lesson.lessonId && <span>•</span>}
+                    <span>{lesson.estimatedDurationMinutes} min</span>
+                  </>
+                )}
+                {lesson.complexity && (
+                  <>
+                    {(lesson.lessonId ?? lesson.estimatedDurationMinutes) && (
+                      <span>•</span>
+                    )}
+                    <span>{lesson.complexity}</span>
+                  </>
+                )}
+              </div>
+
+              <H1 className="text-4xl md:text-5xl">{lesson.title}</H1>
+
+              {(lesson.category ?? lesson.tools.length > 0) && (
+                <div className="mt-4 flex flex-wrap gap-2">
+                  {lesson.category && (
+                    <span className="rounded-full bg-blue-100 px-3 py-1 text-sm font-medium text-blue-800">
+                      {lesson.category}
+                    </span>
                   )}
-                  <span>{lesson.complexity}</span>
-                </>
+                  {lesson.tools.map((tool) => (
+                    <span
+                      key={tool}
+                      className="rounded-full bg-gray-100 px-3 py-1 text-sm font-medium text-gray-800"
+                    >
+                      {tool}
+                    </span>
+                  ))}
+                </div>
               )}
-            </div>
+            </header>
 
-            <H1 className="text-4xl md:text-5xl">{lesson.title}</H1>
-
-            {(lesson.category || lesson.tools.length > 0) && (
-              <div className="mt-4 flex flex-wrap gap-2">
-                {lesson.category && (
-                  <span className="rounded-full bg-blue-100 px-3 py-1 text-sm font-medium text-blue-800">
-                    {lesson.category}
-                  </span>
-                )}
-                {lesson.tools.map((tool) => (
-                  <span
-                    key={tool}
-                    className="rounded-full bg-gray-100 px-3 py-1 text-sm font-medium text-gray-800"
-                  >
-                    {tool}
-                  </span>
-                ))}
+            {lesson.lessonObjectives && (
+              <div className={classNames(WIDE_CLASSES, "mt-6")}>
+                <H2 className="mb-4">Lesson Objectives</H2>
+                <div className="rounded-lg border border-gray-200 bg-gray-50 p-6">
+                  <P className="whitespace-pre-line text-muted-foreground">
+                    {lesson.lessonObjectives}
+                  </P>
+                </div>
               </div>
             )}
-          </header>
 
-          {lesson.lessonObjectives && (
-            <div className={classNames(WIDE_CLASSES, "mt-6")}>
-              <H2 className="mb-4">Lesson Objectives</H2>
-              <div className="rounded-lg border border-gray-200 bg-gray-50 p-6">
-                <P className="whitespace-pre-line text-muted-foreground">
-                  {lesson.lessonObjectives}
-                </P>
+            {lesson.preRequisites && (
+              <div className={classNames(WIDE_CLASSES, "mt-6")}>
+                <H2 className="mb-4">Prerequisites</H2>
+                <div className="rounded-lg border border-gray-200 bg-gray-50 p-6">
+                  {renderRichTextFromContentful(lesson.preRequisites)}
+                </div>
               </div>
+            )}
+
+            <div className={classNames(WIDE_CLASSES, "mt-4")}>
+              {renderRichTextFromContentful(lesson.lessonContent)}
             </div>
-          )}
 
-          {lesson.preRequisites && (
-            <div className={classNames(WIDE_CLASSES, "mt-6")}>
-              <H2 className="mb-4">Prerequisites</H2>
-              <div className="rounded-lg border border-gray-200 bg-gray-50 p-6">
-                {renderRichTextFromContentful(lesson.preRequisites)}
-              </div>
-            </div>
-          )}
-
-          <div className={classNames(WIDE_CLASSES, "mt-4")}>
-            {renderRichTextFromContentful(lesson.lessonContent)}
-          </div>
-
-          {(lesson.previousContent ?? lesson.nextContent) && (
-            <div
-              className={classNames(
-                WIDE_CLASSES,
-                "mt-12 border-t border-gray-200 pt-8"
-              )}
-            >
-              <div className="flex flex-col gap-4 sm:flex-row sm:justify-between">
-                {lesson.previousContent && (
-                  <Link
-                    href={getContentUrl(lesson.previousContent)}
-                    className="group flex flex-col"
-                  >
-                    <P size="sm" className="text-muted-foreground">
-                      Previous {getContentTypeLabel(lesson.previousContent)}
-                    </P>
-                    <span className="mt-1 text-base font-medium text-foreground transition-colors group-hover:text-highlight">
-                      &larr; {lesson.previousContent.title}
-                    </span>
-                  </Link>
+            {(lesson.previousContent ?? lesson.nextContent) && (
+              <div
+                className={classNames(
+                  WIDE_CLASSES,
+                  "mt-12 border-t border-gray-200 pt-8"
                 )}
-                {lesson.nextContent && (
-                  <Link
-                    href={getContentUrl(lesson.nextContent)}
-                    className="group flex flex-col items-end sm:items-start"
-                  >
-                    <P size="sm" className="text-muted-foreground">
-                      Next {getContentTypeLabel(lesson.nextContent)}
-                    </P>
-                    <span className="mt-1 text-base font-medium text-foreground transition-colors group-hover:text-highlight">
-                      {lesson.nextContent.title} &rarr;
-                    </span>
-                  </Link>
-                )}
+              >
+                <div className="flex flex-col gap-4 sm:flex-row sm:justify-between">
+                  {lesson.previousContent && (
+                    <Link
+                      href={getContentUrl(lesson.previousContent)}
+                      className="group flex flex-col"
+                    >
+                      <P size="sm" className="text-muted-foreground">
+                        Previous {getContentTypeLabel(lesson.previousContent)}
+                      </P>
+                      <span className="mt-1 text-base font-medium text-foreground transition-colors group-hover:text-highlight">
+                        &larr; {lesson.previousContent.title}
+                      </span>
+                    </Link>
+                  )}
+                  {lesson.nextContent && (
+                    <Link
+                      href={getContentUrl(lesson.nextContent)}
+                      className="group flex flex-col items-end sm:items-start"
+                    >
+                      <P size="sm" className="text-muted-foreground">
+                        Next {getContentTypeLabel(lesson.nextContent)}
+                      </P>
+                      <span className="mt-1 text-base font-medium text-foreground transition-colors group-hover:text-highlight">
+                        {lesson.nextContent.title} &rarr;
+                      </span>
+                    </Link>
+                  )}
+                </div>
               </div>
-            </div>
-          )}
+            )}
           </Grid>
         </article>
       </div>

--- a/front/pages/academy/lessons/[slug].tsx
+++ b/front/pages/academy/lessons/[slug].tsx
@@ -19,6 +19,7 @@ import type {
   ContentSummary,
   LessonPageProps,
 } from "@app/lib/contentful/types";
+import { isCourseSummary } from "@app/lib/contentful/types";
 import { classNames } from "@app/lib/utils";
 import logger from "@app/logger/logger";
 import { isString } from "@app/types";
@@ -76,17 +77,14 @@ export const getStaticProps: GetStaticProps<LessonPageProps> = async (
 const WIDE_CLASSES = classNames("col-span-12", "lg:col-span-10 lg:col-start-2");
 
 function getContentUrl(content: ContentSummary): string {
-  // Check if it's a lesson by checking if it has the image field
-  // (courses have image, lessons don't in the summary)
-  if ("image" in content) {
+  if (isCourseSummary(content)) {
     return `/academy/${content.slug}`;
   }
   return `/academy/lessons/${content.slug}`;
 }
 
 function getContentTypeLabel(content: ContentSummary): string {
-  // Check if it's a course by checking if it has the image field
-  if ("image" in content) {
+  if (isCourseSummary(content)) {
     return "Course";
   }
   return "Lesson";

--- a/front/pages/academy/lessons/[slug].tsx
+++ b/front/pages/academy/lessons/[slug].tsx
@@ -124,20 +124,29 @@ export default function LessonPage({ lesson, preview }: LessonPageProps) {
       <article>
         <Grid>
           <div className={classNames(WIDE_CLASSES, "pb-2 pt-6")}>
-            <Link
-              href="/academy"
-              className="inline-flex items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
-            >
-              <span>&larr;</span> Back to Academy
-            </Link>
+            {lesson.parentCourse ? (
+              <Link
+                href={`/academy/${lesson.parentCourse.slug}`}
+                className="inline-flex items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
+              >
+                <span>&larr;</span> Back to {lesson.parentCourse.title}
+              </Link>
+            ) : (
+              <Link
+                href="/academy"
+                className="inline-flex items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
+              >
+                <span>&larr;</span> Back to Academy
+              </Link>
+            )}
           </div>
 
           <header className={WIDE_CLASSES}>
             <div className="mb-4 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
-              {lesson.courseId && <span>Lesson {lesson.courseId}</span>}
+              {lesson.lessonId && <span>Lesson {lesson.lessonId}</span>}
               {lesson.estimatedDurationMinutes && (
                 <>
-                  {lesson.courseId && <span>•</span>}
+                  {lesson.lessonId && <span>•</span>}
                   <span>{lesson.estimatedDurationMinutes} min</span>
                 </>
               )}

--- a/front/pages/academy/lessons/[slug].tsx
+++ b/front/pages/academy/lessons/[slug].tsx
@@ -14,7 +14,10 @@ import {
 } from "@app/lib/contentful/client";
 import { renderRichTextFromContentful } from "@app/lib/contentful/richTextRenderer";
 import { extractTableOfContents } from "@app/lib/contentful/tableOfContents";
-import type { ContentSummary, LessonPageProps } from "@app/lib/contentful/types";
+import type {
+  ContentSummary,
+  LessonPageProps,
+} from "@app/lib/contentful/types";
 import { classNames } from "@app/lib/utils";
 import logger from "@app/logger/logger";
 import { isString } from "@app/types";
@@ -84,10 +87,7 @@ function getContentTypeLabel(content: ContentSummary): string {
   return "Lesson";
 }
 
-export default function LessonPage({
-  lesson,
-  preview,
-}: LessonPageProps) {
+export default function LessonPage({ lesson, preview }: LessonPageProps) {
   const canonicalUrl = `https://dust.tt/academy/lessons/${lesson.slug}`;
   const tocItems = extractTableOfContents(lesson.lessonContent);
 
@@ -134,9 +134,7 @@ export default function LessonPage({
 
           <header className={WIDE_CLASSES}>
             <div className="mb-4 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
-              {lesson.courseId && (
-                <span>Lesson {lesson.courseId}</span>
-              )}
+              {lesson.courseId && <span>Lesson {lesson.courseId}</span>}
               {lesson.estimatedDurationMinutes && (
                 <>
                   {lesson.courseId && <span>•</span>}
@@ -181,8 +179,13 @@ export default function LessonPage({
             </div>
           </div>
 
-          {(lesson.previousContent || lesson.nextContent) && (
-            <div className={classNames(WIDE_CLASSES, "mt-12 border-t border-gray-200 pt-8")}>
+          {(lesson.previousContent ?? lesson.nextContent) && (
+            <div
+              className={classNames(
+                WIDE_CLASSES,
+                "mt-12 border-t border-gray-200 pt-8"
+              )}
+            >
               <div className="flex flex-col gap-4 sm:flex-row sm:justify-between">
                 {lesson.previousContent && (
                   <Link
@@ -222,4 +225,3 @@ export default function LessonPage({
 LessonPage.getLayout = (page: ReactElement, pageProps: LandingLayoutProps) => {
   return <LandingLayout pageProps={pageProps}>{page}</LandingLayout>;
 };
-

--- a/front/pages/academy/lessons/[slug].tsx
+++ b/front/pages/academy/lessons/[slug].tsx
@@ -4,7 +4,6 @@ import Link from "next/link";
 import type { ReactElement } from "react";
 
 import { AcademySidebar } from "@app/components/academy/AcademySidebar";
-import { TableOfContents } from "@app/components/blog/TableOfContents";
 import { Grid, H1, H2, P } from "@app/components/home/ContentComponents";
 import type { LandingLayoutProps } from "@app/components/home/LandingLayout";
 import LandingLayout from "@app/components/home/LandingLayout";
@@ -135,6 +134,7 @@ export default function LessonPage({
         <AcademySidebar
           courses={courses}
           currentCourseSlug={lesson.parentCourse?.slug}
+          tocItems={tocItems}
         />
         <article className="flex-1">
           <Grid>
@@ -217,16 +217,7 @@ export default function LessonPage({
           )}
 
           <div className={classNames(WIDE_CLASSES, "mt-4")}>
-            <div className="grid gap-8 lg:grid-cols-12">
-              <div className="lg:col-span-9">
-                {renderRichTextFromContentful(lesson.lessonContent)}
-              </div>
-              {tocItems.length > 0 && (
-                <div className="hidden lg:col-span-3 lg:block">
-                  <TableOfContents items={tocItems} />
-                </div>
-              )}
-            </div>
+            {renderRichTextFromContentful(lesson.lessonContent)}
           </div>
 
           {(lesson.previousContent ?? lesson.nextContent) && (


### PR DESCRIPTION
## Description

- Adds components for the /academy page, similarly to the /blog existing architecture
- Usage of Contentful as a CMS for the /academy content, similarly to the /blog architecture

Scope
- Content localization is EN only
- This PR will only be merged after copy and initial content in the CMS has been reviewed by @gcaplier (DRI for academy initative)

Academy homepage (images non-contractual)
<img width="1715" height="895" alt="image" src="https://github.com/user-attachments/assets/d1dfd0f2-ee12-4389-a300-994406e0dd51" />

---

Course page
<img width="367" height="980" alt="image" src="https://github.com/user-attachments/assets/fc520562-d13b-4ca5-b047-d0de162ab81e" />

---

Course page with link to lessons
<img width="354" height="412" alt="image" src="https://github.com/user-attachments/assets/c685e35d-c17a-476d-81ef-be09a556ab51" />

---

Lesson page
<img width="350" height="948" alt="image" src="https://github.com/user-attachments/assets/38e55ce3-3bbd-4808-a259-d6d933972ccc" />

---



## Tests

Locally and on front-edge

## Risk

low

## Deploy Plan

Front only
