### PR TITLE
chore(instructions): nudge model to nest code blocks

### DIFF
--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -302,6 +302,11 @@ export function constructGuidelinesSection({
     "parentheses are not sufficient to denote mathematical formulas:\nBAD: \\( \\Delta \\)\nGOOD: $$ \\Delta $$.\n";
 
   guidelinesSection +=
+    "\n## RENDERING MARKDOWN CODE BLOCKS\n" +
+    "When rendering code blocks, always use quadruple backticks (````). " +
+    "To render nested code blocks, always use triple backticks (```) for the inner code blocks.";
+
+  guidelinesSection +=
     "\n## RENDERING MARKDOWN IMAGES\n" +
     'When rendering markdown images, always use the file id of the image, which can be extracted from the corresponding `<attachment id="{FILE_ID}" type... title...>` tag in the conversation history.' +
     'Also always use the file title which can similarly be extracted from the same `<attachment id... type... title="{TITLE}">` tag in the conversation history.' +


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Closes https://github.com/dust-tt/tasks/issues/5735

This PR changes the instructions generation by adding a new section regarding code blocks rendering.

It nudges the model to render the outer code block using quadruple backticks instead of triple, and render the inner ones with triple.

<img width="997" height="630" alt="Capture d’écran 2026-01-02 à 11 52 02" src="https://github.com/user-attachments/assets/6b9fa927-b72a-4781-bd88-f3007dc7d46a" />


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand, see screenshot.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front