### PR TITLE
[front] chore: Make GC Gdrive plugin use \n as a separator

### DIFF
--- a/front/lib/api/poke/plugins/data_sources/garbage_collect_google_drive_document.ts
+++ b/front/lib/api/poke/plugins/data_sources/garbage_collect_google_drive_document.ts
@@ -40,14 +40,14 @@ export const garbageCollectGoogleDriveDocumentPlugin = createPlugin({
     id: "garbage-collect-google-drive-document",
     name: "GC Google Drive Document",
     description:
-      "Garbage collect Google Drive document(s). Accepts a single ID or a comma-separated list.",
+      "Garbage collect Google Drive document(s). Accepts a single ID or one per line.",
     resourceTypes: ["data_sources"],
     args: {
       documentId: {
-        type: "string",
+        type: "text",
         label: "Document ID(s)",
         description:
-          "Comma-separated list of document IDs to garbage collect, e.g. gdrive-abc, gdrive-def",
+          "One document ID per line to garbage collect, e.g. gdrive-abc",
       },
     },
   },
@@ -74,7 +74,7 @@ export const garbageCollectGoogleDriveDocumentPlugin = createPlugin({
     }
 
     const documentIds = rawDocumentIds
-      .split(",")
+      .split("\n")
       .map((d) => d.trim())
       .filter((d) => d.length > 0);
 

--- a/front/pages/poke/production-checks.tsx
+++ b/front/pages/poke/production-checks.tsx
@@ -134,7 +134,7 @@ function ActionLinksList({ payload, links, checkName }: ActionLinksListProps) {
       const notDeleted = item.notDeleted;
       if (Array.isArray(notDeleted)) {
         try {
-          await navigator.clipboard.writeText(notDeleted.join(","));
+          await navigator.clipboard.writeText(notDeleted.join("\n"));
           sendNotification({
             title: "Copied",
             description: "Document IDs copied to clipboard",


### PR DESCRIPTION
## Description

Update the google drive GC poke plugin to use \n as a separator, because `,` is a valid character in file names, and it breaks the plugin.

## Tests

Tested in front-edge

## Risk

Low

## Deploy Plan

- [ ] Deploy front