### PR TITLE
[front] - fix(InputBar): dropdowns

### DIFF
--- a/front/components/editor/input_bar/EmojiDropdown.test.tsx
+++ b/front/components/editor/input_bar/EmojiDropdown.test.tsx
@@ -27,9 +27,9 @@ describe("EmojiDropdown", () => {
     );
 
     // Should show curated popular emojis
-    const buttons = await screen.findAllByRole("button");
-    expect(buttons.length).toBeGreaterThan(0);
-    expect(buttons.length).toBeLessThanOrEqual(20);
+    const items = await screen.findAllByRole("menuitem");
+    expect(items.length).toBeGreaterThan(0);
+    expect(items.length).toBeLessThanOrEqual(20);
   });
 
   it("filters emojis based on query", async () => {
@@ -42,8 +42,8 @@ describe("EmojiDropdown", () => {
     );
 
     // Should show smile-related emojis
-    const buttons = await screen.findAllByRole("button");
-    expect(buttons.length).toBeGreaterThan(0);
+    const items = await screen.findAllByRole("menuitem");
+    expect(items.length).toBeGreaterThan(0);
 
     // Rerender with different query
     rerender(
@@ -55,8 +55,8 @@ describe("EmojiDropdown", () => {
     );
 
     // Should show different emojis
-    const heartButtons = await screen.findAllByRole("button");
-    expect(heartButtons.length).toBeGreaterThan(0);
+    const heartItems = await screen.findAllByRole("menuitem");
+    expect(heartItems.length).toBeGreaterThan(0);
   });
 
   it("shows no results message when no emojis match", () => {
@@ -81,9 +81,9 @@ describe("EmojiDropdown", () => {
       />
     );
 
-    const buttons = await screen.findAllByRole("button");
+    const items = await screen.findAllByRole("menuitem");
     // Should not exceed 20 results
-    expect(buttons.length).toBeLessThanOrEqual(20);
+    expect(items.length).toBeLessThanOrEqual(20);
   });
 
   it("returns null when clientRect is not provided", () => {

--- a/front/components/editor/input_bar/EmojiDropdown.tsx
+++ b/front/components/editor/input_bar/EmojiDropdown.tsx
@@ -1,5 +1,4 @@
 import {
-  Button,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -191,13 +190,7 @@ export const EmojiDropdown = forwardRef<
   return (
     <DropdownMenu open={true}>
       <DropdownMenuTrigger asChild>
-        <Button
-          size="xmini"
-          variant="ghost"
-          tabIndex={-1}
-          aria-hidden={true}
-          style={virtualTriggerStyle}
-        />
+        <div style={virtualTriggerStyle} />
       </DropdownMenuTrigger>
       <DropdownMenuContent
         key={contentKey}
@@ -215,7 +208,7 @@ export const EmojiDropdown = forwardRef<
         }}
       >
         {filteredEmojis.length > 0 ? (
-          <div className="flex max-h-60 flex-col overflow-y-auto">
+          <div className="max-h-60">
             {filteredEmojis.map((emoji, index) => (
               <DropdownMenuItem
                 key={emoji.id}

--- a/front/components/editor/input_bar/MentionDropdown.tsx
+++ b/front/components/editor/input_bar/MentionDropdown.tsx
@@ -1,14 +1,16 @@
 import {
   Avatar,
+  Button,
   Chip,
+  cn,
   DropdownMenu,
   DropdownMenuContent,
+  DropdownMenuItem,
   DropdownMenuTrigger,
   Spinner,
 } from "@dust-tt/sparkle";
 import React, {
   forwardRef,
-  useCallback,
   useEffect,
   useImperativeHandle,
   useRef,
@@ -20,7 +22,6 @@ import type {
   MentionDropdownProps,
 } from "@app/components/editor/input_bar/types";
 import { useMentionSuggestions } from "@app/lib/swr/mentions";
-import { classNames } from "@app/lib/utils";
 
 export const MentionDropdown = forwardRef<
   MentionDropdownOnKeyDown,
@@ -55,10 +56,7 @@ export const MentionDropdown = forwardRef<
       includeCurrentUser,
     });
 
-    const triggerRef = useRef<HTMLDivElement>(null);
-    const [virtualTriggerStyle, setVirtualTriggerStyle] =
-      useState<React.CSSProperties>({});
-    const selectedItemRef = useRef<HTMLButtonElement>(null);
+    const selectedItemRef = useRef<HTMLDivElement>(null);
 
     const selectItem = (index: number) => {
       const item = suggestions[index];
@@ -67,22 +65,6 @@ export const MentionDropdown = forwardRef<
         command(item);
       }
     };
-
-    const updateTriggerPosition = useCallback(() => {
-      if (triggerRect && triggerRef.current) {
-        setVirtualTriggerStyle({
-          position: "fixed",
-          left: triggerRect.left,
-          // On iOS based browsers, the position is not correct without adding the offsetTop.
-          // Something related to the position calculation when there is a scrollable area.
-          top: triggerRect.top + (window.visualViewport?.offsetTop ?? 0),
-          width: 1,
-          height: triggerRect.height || 1,
-          pointerEvents: "none",
-          zIndex: -1,
-        });
-      }
-    }, [triggerRect]);
 
     useImperativeHandle(ref, () => ({
       onKeyDown: ({ event }) => {
@@ -109,10 +91,6 @@ export const MentionDropdown = forwardRef<
         return false;
       },
     }));
-
-    useEffect(() => {
-      updateTriggerPosition();
-    }, [updateTriggerPosition]);
 
     // Reset the selected index when items change (e.g., when query changes).
     useEffect(() => {
@@ -147,10 +125,36 @@ export const MentionDropdown = forwardRef<
       return null;
     }
 
+    const virtualTriggerStyle: React.CSSProperties = {
+      position: "fixed",
+      left: triggerRect.left,
+      // On iOS based browsers, the position is not correct without adding the offsetTop.
+      // Something related to the position calculation when there is a scrollable area.
+      top:
+        triggerRect.top +
+        (typeof window === "undefined"
+          ? 0
+          : (window.visualViewport?.offsetTop ?? 0)),
+      width: 1,
+      height: triggerRect.height || 1,
+      pointerEvents: "none",
+      zIndex: -1,
+      padding: 0,
+      minWidth: 0,
+      border: "none",
+      background: "transparent",
+    };
+
     return (
       <DropdownMenu open={true}>
         <DropdownMenuTrigger asChild>
-          <div ref={triggerRef} style={virtualTriggerStyle} />
+          <Button
+            size="xmini"
+            variant="ghost"
+            tabIndex={-1}
+            aria-hidden={true}
+            style={virtualTriggerStyle}
+          />
         </DropdownMenuTrigger>
         <DropdownMenuContent
           key={contentKey}
@@ -172,48 +176,45 @@ export const MentionDropdown = forwardRef<
               <Spinner />
             </div>
           ) : suggestions.length > 0 ? (
-            <div className="flex max-h-60 flex-col gap-y-1 overflow-y-auto p-1">
+            <div className="flex max-h-60 flex-col overflow-y-auto">
               {suggestions.map((suggestion, index) => (
-                <div key={suggestion.id}>
-                  <button
-                    ref={index === selectedIndex ? selectedItemRef : null}
-                    className={classNames(
-                      "flex items-center px-2 py-1",
-                      "w-full flex-initial cursor-pointer text-left text-sm",
-                      index === selectedIndex
-                        ? "text-highlight-500"
-                        : "text-foreground dark:text-foreground-night"
-                    )}
-                    onClick={() => {
-                      selectItem(index);
-                    }}
-                    onMouseEnter={() => {
-                      setSelectedIndex(index);
-                    }}
-                  >
-                    <div className="flex min-w-0 flex-1 items-center gap-x-2">
-                      <Avatar
-                        size="xs"
-                        visual={suggestion.pictureUrl}
-                        isRounded={suggestion.type === "user"}
-                      />
-                      <span
-                        className="truncate font-semibold"
-                        title={suggestion.label}
-                      >
-                        {suggestion.label}
-                      </span>
-                    </div>
-                    {suggestion.type === "user" && (
-                      <Chip
-                        size="mini"
-                        color="primary"
-                        label="Member"
-                        className="ml-2 shrink-0"
-                      />
-                    )}
-                  </button>
-                </div>
+                <DropdownMenuItem
+                  key={suggestion.id}
+                  ref={index === selectedIndex ? selectedItemRef : null}
+                  className={cn(
+                    index === selectedIndex
+                      ? "text-highlight-500"
+                      : "text-foreground dark:text-foreground-night"
+                  )}
+                  onClick={() => {
+                    selectItem(index);
+                  }}
+                  onMouseEnter={() => {
+                    setSelectedIndex(index);
+                  }}
+                >
+                  <div className="flex min-w-0 flex-1 items-center gap-x-2">
+                    <Avatar
+                      size="xs"
+                      visual={suggestion.pictureUrl}
+                      isRounded={suggestion.type === "user"}
+                    />
+                    <span
+                      className="truncate font-semibold"
+                      title={suggestion.label}
+                    >
+                      {suggestion.label}
+                    </span>
+                  </div>
+                  {suggestion.type === "user" && (
+                    <Chip
+                      size="mini"
+                      color="primary"
+                      label="Member"
+                      className="ml-2 shrink-0"
+                    />
+                  )}
+                </DropdownMenuItem>
               ))}
             </div>
           ) : (

--- a/front/components/editor/input_bar/MentionDropdown.tsx
+++ b/front/components/editor/input_bar/MentionDropdown.tsx
@@ -1,6 +1,5 @@
 import {
   Avatar,
-  Button,
   Chip,
   cn,
   DropdownMenu,
@@ -148,13 +147,7 @@ export const MentionDropdown = forwardRef<
     return (
       <DropdownMenu open={true}>
         <DropdownMenuTrigger asChild>
-          <Button
-            size="xmini"
-            variant="ghost"
-            tabIndex={-1}
-            aria-hidden={true}
-            style={virtualTriggerStyle}
-          />
+          <div style={virtualTriggerStyle} />
         </DropdownMenuTrigger>
         <DropdownMenuContent
           key={contentKey}
@@ -176,7 +169,7 @@ export const MentionDropdown = forwardRef<
               <Spinner />
             </div>
           ) : suggestions.length > 0 ? (
-            <div className="flex max-h-60 flex-col overflow-y-auto">
+            <div className="max-h-60">
               {suggestions.map((suggestion, index) => (
                 <DropdownMenuItem
                   key={suggestion.id}


### PR DESCRIPTION
## Description

Simplifies the `EmojiDropdown` and `MentionDropdown` components by removing unnecessary complexity in virtual trigger positioning and list item rendering. Replaces manual `button` elements with the standardized `DropdownMenuItem` component from Sparkle for consistent styling and behavior. Removes `useCallback` and `useEffect` hooks that managed virtual trigger positioning in favor of inline style calculation.

## Risk

Medium - UI only but key components

## Tests

Locally

## Deploy Plan

Deploy front