### PR TITLE
fix(sheet): don't remove hashparams in url sheets

### DIFF
--- a/front/components/assistant/conversation/AgentHandle.tsx
+++ b/front/components/assistant/conversation/AgentHandle.tsx
@@ -21,6 +21,7 @@ export function AgentHandle({
   const href = {
     pathname: router.pathname,
     query: { ...router.query, agentDetails: agent.sId },
+    hash: router.asPath.split("#")[1] || undefined,
   };
 
   if (!canMention) {

--- a/front/components/assistant/details/AgentDetailsButtonBar.tsx
+++ b/front/components/assistant/details/AgentDetailsButtonBar.tsx
@@ -20,7 +20,6 @@ import { useState } from "react";
 
 import { DeleteAgentDialog } from "@app/components/assistant/DeleteAgentDialog";
 import { useSendNotification } from "@app/hooks/useNotification";
-import { useURLSheet } from "@app/hooks/useURLSheet";
 import { clientFetch } from "@app/lib/egress/client";
 import { useUpdateUserFavorite } from "@app/lib/swr/assistants";
 import { useUser } from "@app/lib/swr/user";
@@ -45,7 +44,6 @@ export function AgentDetailsButtonBar({
   owner,
 }: AgentDetailsButtonBarProps) {
   const { user } = useUser();
-  const { onOpenChange: onOpenChangeAgentModal } = useURLSheet("agentDetails");
 
   const { featureFlags } = useFeatureFlags({
     workspaceId: owner.sId,
@@ -142,7 +140,6 @@ export function AgentDetailsButtonBar({
           showTrigger
           agentConfiguration={agentConfiguration}
           owner={owner}
-          onClose={() => onOpenChangeAgentModal(false)}
         />
       )}
     </div>

--- a/front/hooks/useURLSheet.ts
+++ b/front/hooks/useURLSheet.ts
@@ -14,10 +14,13 @@ export function useURLSheet(paramName: string) {
   const onOpenChange = useCallback(
     (open: boolean) => {
       const { [paramName]: _, ...restQuery } = router.query;
+      const hash = router.asPath.split("#")[1] || undefined;
+
       void router.push(
         {
           pathname: router.pathname,
           query: open ? { ...restQuery, [paramName]: "true" } : restQuery,
+          hash,
         },
         undefined,
         { shallow: true }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Currently, when clicking on a button (and thus refreshing) a URL Sheet, we lose the hashparams, because we don't rebuild them into the URL.
Repro : go to dust.tt -> click on "editable by me" -> open the agent details of any agent -> perform any action in the menu at the top
Effect : the page behind the sheet is changed and hash params are removed

This PR fixes this

EDIT:
Also added a fix to add the hashparam when we open the agent details via the agent handle in a convo, previously, if we opened an agent details in a convo where a frame or a message breakdown was opened, it would close this frame/breakdown. This solves the problem

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front