### PR TITLE
[front] refactor(skills): drop `configuration` suffix in props relative to skills (front-end)

### DIFF
--- a/front/components/agent_builder/capabilities/capabilities_sheet/SkillInfoPage.tsx
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/SkillInfoPage.tsx
@@ -71,7 +71,7 @@ export function SkillInfoPage({
             <TabsContent value="editors">
               {hasRelations(skill) && (
                 <SkillEditorsTab
-                  skillConfiguration={skill}
+                  skill={skill}
                   owner={owner}
                   user={user}
                 />

--- a/front/components/agent_builder/capabilities/capabilities_sheet/SkillInfoPage.tsx
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/SkillInfoPage.tsx
@@ -70,11 +70,7 @@ export function SkillInfoPage({
             </TabsContent>
             <TabsContent value="editors">
               {hasRelations(skill) && (
-                <SkillEditorsTab
-                  skill={skill}
-                  owner={owner}
-                  user={user}
-                />
+                <SkillEditorsTab skill={skill} owner={owner} user={user} />
               )}
             </TabsContent>
           </div>

--- a/front/components/skill_builder/SkillBuilder.tsx
+++ b/front/components/skill_builder/SkillBuilder.tsx
@@ -25,7 +25,7 @@ import { SkillBuilderToolsSection } from "@app/components/skill_builder/SkillBui
 import { submitSkillBuilderForm } from "@app/components/skill_builder/submitSkillBuilderForm";
 import {
   getDefaultSkillFormData,
-  transformSkillConfigurationToFormData,
+  transformSkillTypeToFormData,
 } from "@app/components/skill_builder/transformSkillConfiguration";
 import { appLayoutBack } from "@app/components/sparkle/AppContentLayout";
 import { FormProvider } from "@app/components/sparkle/FormProvider";
@@ -35,12 +35,12 @@ import { useSkillEditors } from "@app/lib/swr/skill_editors";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 
 interface SkillBuilderProps {
-  skillConfiguration?: SkillType;
+  skill?: SkillType;
   extendedSkill?: SkillType;
 }
 
 export default function SkillBuilder({
-  skillConfiguration,
+  skill,
   extendedSkill,
 }: SkillBuilderProps) {
   const { owner, user } = useSkillBuilderContext();
@@ -50,19 +50,19 @@ export default function SkillBuilder({
 
   const { editors } = useSkillEditors({
     owner,
-    skillConfigurationId: skillConfiguration?.sId ?? null,
+    skillId: skill?.sId ?? null,
   });
 
   const defaultValues = useMemo(() => {
-    if (skillConfiguration) {
-      return transformSkillConfigurationToFormData(skillConfiguration);
+    if (skill) {
+      return transformSkillTypeToFormData(skill);
     }
 
     return getDefaultSkillFormData({
       user,
       extendedSkillId: extendedSkill?.sId ?? null,
     });
-  }, [skillConfiguration, user, extendedSkill]);
+  }, [skill, user, extendedSkill]);
 
   const form = useForm<SkillBuilderFormData>({
     resolver: zodResolver(skillBuilderFormSchema),
@@ -79,11 +79,11 @@ export default function SkillBuilder({
 
     form.reset({
       ...currentValues,
-      editors: skillConfiguration || editors.length > 0 ? editors : [user],
+      editors: skill || editors.length > 0 ? editors : [user],
     });
-  }, [editors, form, user, skillConfiguration]);
+  }, [editors, form, user, skill]);
 
-  const isCreatingNew = !skillConfiguration;
+  const isCreatingNew = !skill;
   const { isDirty } = form.formState;
 
   useNavigationLock(isDirty && !isSaving);
@@ -94,9 +94,7 @@ export default function SkillBuilder({
     const result = await submitSkillBuilderForm({
       formData: data,
       owner,
-      skillConfigurationId: !isCreatingNew
-        ? skillConfiguration?.sId
-        : undefined,
+      skillId: !isCreatingNew ? skill?.sId : undefined,
       currentEditors: editors,
     });
 
@@ -151,9 +149,7 @@ export default function SkillBuilder({
               variant="default"
               className="mx-4"
               title={
-                (skillConfiguration
-                  ? `Edit skill ${skillConfiguration.name}`
-                  : "Create new skill") +
+                (skill ? `Edit skill ${skill.name}` : "Create new skill") +
                 (extendedSkill ? ` - extending ${extendedSkill.name}` : "")
               }
               rightActions={
@@ -178,9 +174,7 @@ export default function SkillBuilder({
                 </div>
                 <SkillBuilderRequestedSpacesSection />
                 <SkillBuilderAgentFacingDescriptionSection />
-                <SkillBuilderInstructionsSection
-                  skillConfiguration={skillConfiguration}
-                />
+                <SkillBuilderInstructionsSection skill={skill} />
                 <SkillBuilderToolsSection />
                 <SkillBuilderSettingsSection />
               </div>

--- a/front/components/skill_builder/SkillBuilderAgentFacingDescriptionSection.tsx
+++ b/front/components/skill_builder/SkillBuilderAgentFacingDescriptionSection.tsx
@@ -16,7 +16,7 @@ const DEBOUNCE_DELAY_MS = 250;
 const MIN_DESCRIPTION_LENGTH = 10;
 
 export function SkillBuilderAgentFacingDescriptionSection() {
-  const { owner, skillConfigurationId } = useSkillBuilderContext();
+  const { owner, skillId } = useSkillBuilderContext();
   const { hasFeature } = useFeatureFlags({ workspaceId: owner.sId });
   const isSimilarSkillsEnabled = hasFeature("skills_similar_display");
 
@@ -52,13 +52,13 @@ export function SkillBuilderAgentFacingDescriptionSection() {
           const matchedSkills = skills.filter(
             (skill) =>
               similarSkillIdsSet.has(skill.sId) &&
-              skill.sId !== skillConfigurationId
+              skill.sId !== skillId
           );
           setSimilarSkills(matchedSkills);
         }
       }
     },
-    [getSimilarSkills, isSimilarSkillsEnabled, skillConfigurationId, skills]
+    [getSimilarSkills, isSimilarSkillsEnabled, skillId, skills]
   );
 
   const triggerSimilarSkillsFetch = useDebounceWithAbort(fetchSimilarSkills, {

--- a/front/components/skill_builder/SkillBuilderAgentFacingDescriptionSection.tsx
+++ b/front/components/skill_builder/SkillBuilderAgentFacingDescriptionSection.tsx
@@ -51,8 +51,7 @@ export function SkillBuilderAgentFacingDescriptionSection() {
           const similarSkillIdsSet = new Set(similarSkillIds);
           const matchedSkills = skills.filter(
             (skill) =>
-              similarSkillIdsSet.has(skill.sId) &&
-              skill.sId !== skillId
+              similarSkillIdsSet.has(skill.sId) && skill.sId !== skillId
           );
           setSimilarSkills(matchedSkills);
         }

--- a/front/components/skill_builder/SkillBuilderContext.tsx
+++ b/front/components/skill_builder/SkillBuilderContext.tsx
@@ -9,7 +9,7 @@ export type SkillBuilderContextType = {
   owner: WorkspaceType;
   user: UserType;
   /** Id of the current skill being edited, or null if the skill is not yet created. */
-  skillConfigurationId: string | null;
+  skillId: string | null;
 };
 
 export const SkillBuilderContext =
@@ -18,18 +18,18 @@ export const SkillBuilderContext =
 interface SkillBuilderProviderProps {
   owner: WorkspaceType;
   user: UserType;
-  skillConfigurationId: string | null;
+  skillId: string | null;
   children: ReactNode;
 }
 
 export function SkillBuilderProvider({
   owner,
   user,
-  skillConfigurationId,
+  skillId,
   children,
 }: SkillBuilderProviderProps) {
   return (
-    <SkillBuilderContext.Provider value={{ owner, user, skillConfigurationId }}>
+    <SkillBuilderContext.Provider value={{ owner, user, skillId }}>
       <SpacesProvider owner={owner}>
         <MCPServerViewsProvider owner={owner}>
           {children}

--- a/front/components/skill_builder/SkillBuilderInstructionsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsSection.tsx
@@ -19,11 +19,11 @@ import type { SkillType } from "@app/types/assistant/skill_configuration";
 const INSTRUCTIONS_FIELD_NAME = "instructions";
 
 interface SkillBuilderInstructionsSectionProps {
-  skillConfiguration?: SkillType;
+  skill?: SkillType;
 }
 
 export function SkillBuilderInstructionsSection({
-  skillConfiguration,
+  skill,
 }: SkillBuilderInstructionsSectionProps) {
   const { owner } = useSkillBuilderContext();
   const { setValue } = useFormContext<SkillBuilderFormData>();
@@ -32,8 +32,8 @@ export function SkillBuilderInstructionsSection({
 
   const { skillHistory } = useSkillHistory({
     owner,
-    skillConfiguration,
-    disabled: !skillConfiguration,
+    skill,
+    disabled: !skill,
     limit: 30,
   });
 

--- a/front/components/skill_builder/submitSkillBuilderForm.ts
+++ b/front/components/skill_builder/submitSkillBuilderForm.ts
@@ -8,12 +8,12 @@ import { Err, normalizeError, Ok } from "@app/types";
 export async function submitSkillBuilderForm({
   formData,
   owner,
-  skillConfigurationId,
+  skillId,
   currentEditors = [],
 }: {
   formData: SkillBuilderFormData;
   owner: WorkspaceType;
-  skillConfigurationId?: string;
+  skillId?: string;
   currentEditors?: UserType[];
 }): Promise<
   Result<
@@ -23,11 +23,11 @@ export async function submitSkillBuilderForm({
   >
 > {
   try {
-    const endpoint = skillConfigurationId
-      ? `/api/w/${owner.sId}/skills/${skillConfigurationId}`
+    const endpoint = skillId
+      ? `/api/w/${owner.sId}/skills/${skillId}`
       : `/api/w/${owner.sId}/skills`;
 
-    const method = skillConfigurationId ? "PATCH" : "POST";
+    const method = skillId ? "PATCH" : "POST";
 
     const response = await clientFetch(endpoint, {
       method,
@@ -52,9 +52,7 @@ export async function submitSkillBuilderForm({
       return new Err(
         new Error(
           errorData.error?.message ??
-            (skillConfigurationId
-              ? "Failed to update skill"
-              : "Failed to create skill")
+            (skillId ? "Failed to update skill" : "Failed to create skill")
         )
       );
     }
@@ -67,7 +65,7 @@ export async function submitSkillBuilderForm({
 
     // Only sync editors for existing skills (updates), not for newly created skills
     // When creating a skill, the backend automatically adds the creator to the editors group
-    if (skillConfigurationId) {
+    if (skillId) {
       const desiredEditorIds = new Set(formData.editors.map((e) => e.sId));
       const currentEditorIds = new Set(currentEditors.map((e) => e.sId));
 
@@ -119,7 +117,7 @@ export async function submitSkillBuilderForm({
     const normalizedError = normalizeError(error);
     return new Err(
       new Error(
-        `Unexpected error ${skillConfigurationId ? "updating" : "creating"} skill: ${normalizedError.message}`
+        `Unexpected error ${skillId ? "updating" : "creating"} skill: ${normalizedError.message}`
       )
     );
   }

--- a/front/components/skill_builder/transformSkillConfiguration.ts
+++ b/front/components/skill_builder/transformSkillConfiguration.ts
@@ -7,7 +7,7 @@ import type { SkillType } from "@app/types/assistant/skill_configuration";
  * Transforms a skill configuration (server-side) into skill builder form data (client-side).
  * Editors are intentionally set to empty defaults as they will be populated reactively.
  */
-export function transformSkillConfigurationToFormData(
+export function transformSkillTypeToFormData(
   skillConfiguration: SkillType
 ): SkillBuilderFormData {
   return {

--- a/front/components/skills/ArchiveSkillDialog.tsx
+++ b/front/components/skills/ArchiveSkillDialog.tsx
@@ -15,20 +15,20 @@ import { pluralize } from "@app/types";
 import type { SkillWithRelationsType } from "@app/types/assistant/skill_configuration";
 
 interface DeleteSkillDialogProps {
-  skillConfiguration: SkillWithRelationsType;
+  skill: SkillWithRelationsType;
   isOpen: boolean;
   onClose: () => void;
   owner: LightWorkspaceType;
 }
 
 export function ArchiveSkillDialog({
-  skillConfiguration,
+  skill,
   isOpen,
   onClose,
   owner,
 }: DeleteSkillDialogProps) {
   const [isArchiving, setIsArchiving] = useState(false);
-  const doArchive = useArchiveSkill({ owner, skillConfiguration });
+  const doArchive = useArchiveSkill({ owner, skill: skill });
 
   return (
     <Dialog
@@ -45,10 +45,10 @@ export function ArchiveSkillDialog({
           <DialogDescription>
             <div>
               This will archive the skill{" "}
-              <span className="font-bold">{skillConfiguration?.name}</span>{" "}
-              {skillConfiguration.relations.usage.count === 0
+              <span className="font-bold">{skill?.name}</span>{" "}
+              {skill.relations.usage.count === 0
                 ? "for everyone."
-                : `used by ${skillConfiguration.relations.usage.count} agent${pluralize(skillConfiguration.relations.usage.count)}.`}
+                : `used by ${skill.relations.usage.count} agent${pluralize(skill.relations.usage.count)}.`}
             </div>
           </DialogDescription>
         </DialogHeader>

--- a/front/components/skills/SkillDetailsButtonBar.tsx
+++ b/front/components/skills/SkillDetailsButtonBar.tsx
@@ -40,7 +40,7 @@ export function SkillDetailsButtonBar({
       <ArchiveSkillDialog
         owner={owner}
         isOpen={showArchiveDialog}
-        skillConfiguration={skill}
+        skill={skill}
         onClose={() => {
           setShowArchiveDialog(false);
           onClose();

--- a/front/components/skills/SkillDetailsSheet.tsx
+++ b/front/components/skills/SkillDetailsSheet.tsx
@@ -110,11 +110,7 @@ export function SkillDetailsSheetContent({
           </TabsContent>
           <TabsContent value="editors">
             {hasRelations(skill) && (
-              <SkillEditorsTab
-                skill={skill}
-                owner={owner}
-                user={user}
-              />
+              <SkillEditorsTab skill={skill} owner={owner} user={user} />
             )}
           </TabsContent>
         </div>

--- a/front/components/skills/SkillDetailsSheet.tsx
+++ b/front/components/skills/SkillDetailsSheet.tsx
@@ -111,7 +111,7 @@ export function SkillDetailsSheetContent({
           <TabsContent value="editors">
             {hasRelations(skill) && (
               <SkillEditorsTab
-                skillConfiguration={skill}
+                skill={skill}
                 owner={owner}
                 user={user}
               />

--- a/front/components/skills/SkillEditorsTab.tsx
+++ b/front/components/skills/SkillEditorsTab.tsx
@@ -16,21 +16,17 @@ import type { SkillWithRelationsType } from "@app/types/assistant/skill_configur
 type AgentEditorsTabProps = {
   owner: WorkspaceType;
   user: UserType;
-  skillConfiguration: SkillWithRelationsType;
+  skill: SkillWithRelationsType;
 };
 
-export function SkillEditorsTab({
-  owner,
-  user,
-  skillConfiguration,
-}: AgentEditorsTabProps) {
+export function SkillEditorsTab({ owner, user, skill }: AgentEditorsTabProps) {
   const updateEditors = useUpdateSkillEditors({
     owner,
-    skillConfigurationId: skillConfiguration.sId,
+    skillId: skill.sId,
   });
   const { editors, isEditorsLoading } = useSkillEditors({
     owner,
-    skillConfigurationId: skillConfiguration.sId,
+    skillId: skill.sId,
   });
 
   const isCurrentUserEditor =

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -268,7 +268,7 @@ export function SkillsTable({
         <ArchiveSkillDialog
           owner={owner}
           isOpen={true}
-          skillConfiguration={skillToArchive}
+          skill={skillToArchive}
           onClose={() => {
             setSkillToArchive(null);
           }}

--- a/front/lib/skill.ts
+++ b/front/lib/skill.ts
@@ -61,7 +61,8 @@ const IDS_OF_SKILLS_TRIGGERING_SELECT_SPACES_OPTIONS: string[] = [
 export function doesSkillTriggerSelectSpaces(sId: string): boolean {
   return IDS_OF_SKILLS_TRIGGERING_SELECT_SPACES_OPTIONS.includes(sId);
 }
-export const hasRelations = (
-  skillConfiguration: SkillType & { relations?: SkillRelations }
-): skillConfiguration is SkillWithRelationsType =>
-  skillConfiguration.relations !== undefined;
+export function hasRelations(
+  skill: SkillType & { relations?: SkillRelations }
+): skill is SkillWithRelationsType {
+  return skill.relations !== undefined;
+}

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -110,10 +110,10 @@ export function useSimilarSkills({ owner }: { owner: LightWorkspaceType }) {
 
 export function useArchiveSkill({
   owner,
-  skillConfiguration,
+  skill,
 }: {
   owner: LightWorkspaceType;
-  skillConfiguration: SkillType;
+  skill: SkillType;
 }) {
   const sendNotification = useSendNotification();
   const { mutateSkillsWithRelations: mutateArchivedSkills } =
@@ -130,15 +130,12 @@ export function useArchiveSkill({
     });
 
   const doArchive = async () => {
-    if (!skillConfiguration.sId) {
+    if (!skill.sId) {
       return;
     }
-    const res = await clientFetch(
-      `/api/w/${owner.sId}/skills/${skillConfiguration.sId}`,
-      {
-        method: "DELETE",
-      }
-    );
+    const res = await clientFetch(`/api/w/${owner.sId}/skills/${skill.sId}`, {
+      method: "DELETE",
+    });
 
     if (res.ok) {
       void mutateArchivedSkills();
@@ -146,15 +143,15 @@ export function useArchiveSkill({
 
       sendNotification({
         type: "success",
-        title: `Successfully archived ${skillConfiguration.name}`,
-        description: `${skillConfiguration.name} was successfully archived.`,
+        title: `Successfully archived ${skill.name}`,
+        description: `${skill.name} was successfully archived.`,
       });
     } else {
       const errorData = await getErrorFromResponse(res);
 
       sendNotification({
         type: "error",
-        title: `Error archiving ${skillConfiguration.name}`,
+        title: `Error archiving ${skill.name}`,
         description: `Error: ${errorData.message}`,
       });
     }
@@ -222,12 +219,12 @@ export function useRestoreSkill({
 
 export function useSkillHistory({
   owner,
-  skillConfiguration,
+  skill,
   limit,
   disabled,
 }: {
   owner: LightWorkspaceType;
-  skillConfiguration?: SkillType;
+  skill?: SkillType;
   limit?: number;
   disabled?: boolean;
 }) {
@@ -236,8 +233,8 @@ export function useSkillHistory({
 
   const queryParams = limit ? `?limit=${limit}` : "";
   const { data, error, mutate } = useSWRWithDefaults(
-    skillConfiguration
-      ? `/api/w/${owner.sId}/skills/${skillConfiguration.sId}/history${queryParams}`
+    skill
+      ? `/api/w/${owner.sId}/skills/${skill.sId}/history${queryParams}`
       : null,
     skillHistoryFetcher,
     { disabled }

--- a/front/lib/swr/skill_editors.ts
+++ b/front/lib/swr/skill_editors.ts
@@ -13,19 +13,17 @@ import { pluralize } from "@app/types";
 
 export function useSkillEditors({
   owner,
-  skillConfigurationId,
+  skillId,
   disabled,
 }: {
   owner: LightWorkspaceType;
-  skillConfigurationId: string | null;
+  skillId: string | null;
   disabled?: boolean;
 }) {
   const editorsFetcher: Fetcher<GetSkillEditorsResponseBody> = fetcher;
 
   const { data, error, mutate } = useSWRWithDefaults(
-    skillConfigurationId
-      ? `/api/w/${owner.sId}/skills/${skillConfigurationId}/editors`
-      : null,
+    skillId ? `/api/w/${owner.sId}/skills/${skillId}/editors` : null,
 
     editorsFetcher,
     {
@@ -43,22 +41,22 @@ export function useSkillEditors({
 
 export function useUpdateSkillEditors({
   owner,
-  skillConfigurationId,
+  skillId,
 }: {
   owner: LightWorkspaceType;
-  skillConfigurationId: string;
+  skillId: string;
 }) {
   const sendNotification = useSendNotification();
   const { mutateEditors } = useSkillEditors({
     owner,
-    skillConfigurationId,
+    skillId,
     disabled: true,
   });
 
   const updateSkillEditors = useCallback(
     async (body: PatchSkillEditorsRequestBody) => {
       const res = await clientFetch(
-        `/api/w/${owner.sId}/skills/${skillConfigurationId}/editors`,
+        `/api/w/${owner.sId}/skills/${skillId}/editors`,
         {
           method: "PATCH",
           headers: {
@@ -71,7 +69,7 @@ export function useUpdateSkillEditors({
       if (res.ok) {
         void mutateEditors();
 
-        let title = "";
+        let title;
         let description: string | undefined = undefined;
         if (
           body.addEditorIds != null &&
@@ -98,7 +96,7 @@ export function useUpdateSkillEditors({
         });
       }
     },
-    [owner, skillConfigurationId, mutateEditors, sendNotification]
+    [owner, skillId, mutateEditors, sendNotification]
   );
 
   return updateSkillEditors;

--- a/front/pages/w/[wId]/builder/skills/[sId].tsx
+++ b/front/pages/w/[wId]/builder/skills/[sId].tsx
@@ -12,7 +12,7 @@ import type { SubscriptionType, UserType, WorkspaceType } from "@app/types";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 
 export const getServerSideProps = withDefaultUserAuthRequirements<{
-  skillConfiguration: SkillType;
+  skill: SkillType;
   extendedSkill: SkillType | null;
   owner: WorkspaceType;
   user: UserType;
@@ -59,7 +59,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
 
   return {
     props: {
-      skillConfiguration: skillResource.toJSON(auth),
+      skill: skillResource.toJSON(auth),
       extendedSkill: extendedSkillResource
         ? extendedSkillResource.toJSON(auth)
         : null,
@@ -71,12 +71,12 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
 });
 
 export default function EditSkill({
-  skillConfiguration,
+  skill,
   extendedSkill,
   owner,
   user,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
-  if (skillConfiguration.status === "archived") {
+  if (skill.status === "archived") {
     throw new Error("Cannot edit archived skill");
   }
 
@@ -84,14 +84,14 @@ export default function EditSkill({
     <SkillBuilderProvider
       owner={owner}
       user={user}
-      skillConfigurationId={skillConfiguration.sId}
+      skillId={skill.sId}
     >
       <>
         <Head>
-          <title>{`Dust - ${skillConfiguration.name}`}</title>
+          <title>{`Dust - ${skill.name}`}</title>
         </Head>
         <SkillBuilder
-          skillConfiguration={skillConfiguration}
+          skill={skill}
           extendedSkill={extendedSkill ?? undefined}
         />
       </>

--- a/front/pages/w/[wId]/builder/skills/[sId].tsx
+++ b/front/pages/w/[wId]/builder/skills/[sId].tsx
@@ -81,11 +81,7 @@ export default function EditSkill({
   }
 
   return (
-    <SkillBuilderProvider
-      owner={owner}
-      user={user}
-      skillId={skill.sId}
-    >
+    <SkillBuilderProvider owner={owner} user={user} skillId={skill.sId}>
       <>
         <Head>
           <title>{`Dust - ${skill.name}`}</title>

--- a/front/pages/w/[wId]/builder/skills/new.tsx
+++ b/front/pages/w/[wId]/builder/skills/new.tsx
@@ -60,7 +60,7 @@ export default function CreateSkill({
   extendedSkill,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   return (
-    <SkillBuilderProvider owner={owner} user={user} skillConfigurationId={null}>
+    <SkillBuilderProvider owner={owner} user={user} skillId={null}>
       <SpacesProvider owner={owner}>
         <Head>
           <title>Dust - New Skill</title>


### PR DESCRIPTION
## Description

- This PR renames the props named `skillConfiguration` (resp. `skillConfigurationId`) into `skill` (resp. `skillId`).
- The goal is to make `skillConfiguration` a backend-only concept as it is actually very close to the data model.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
