### PR TITLE
[front] - refacto(obs): charts

### DIFF
--- a/front/components/agent_builder/observability/charts/ChartsTooltip.tsx
+++ b/front/components/agent_builder/observability/charts/ChartsTooltip.tsx
@@ -51,6 +51,15 @@ export function ChartsTooltip({
     return null;
   }
 
+  const totalCount =
+    toolPayload.payload?.total ??
+    Object.values(toolPayload.payload?.values ?? {}).reduce(
+      (sum, d) => sum + (d?.count ?? 0),
+      0
+    );
+  const percentOfTotal =
+    totalCount > 0 ? Math.round((data.count / totalCount) * 100) : 0;
+
   const colorClassName = getIndexedColor(toolName, topTools);
 
   // If there's a breakdown, show the configurations as bullet points
@@ -90,7 +99,7 @@ export function ChartsTooltip({
           <LegendDot className={colorClassName} />
           <Label>{toolName}</Label>
           <span className="ml-1 text-muted-foreground dark:text-muted-foreground-night">
-            ({data.percent}%)
+            ({percentOfTotal}%)
           </span>
         </div>
         <div className="space-y-1.5">
@@ -121,7 +130,7 @@ export function ChartsTooltip({
         <LegendDot className={colorClassName} />
         <Label>{toolName}</Label>
         <span className="ml-1 text-muted-foreground dark:text-muted-foreground-night">
-          ({data.percent}%)
+          ({percentOfTotal}%)
         </span>
       </div>
       <div className="flex items-center gap-2">

--- a/front/components/agent_builder/observability/charts/ChartsTooltip.tsx
+++ b/front/components/agent_builder/observability/charts/ChartsTooltip.tsx
@@ -18,32 +18,23 @@ export interface ToolUsageTooltipProps extends TooltipContentProps<
   string
 > {
   topTools: string[];
-  hoveredTool?: string | null;
 }
 
 export function ChartsTooltip({
   active,
   payload,
   topTools,
-  hoveredTool,
 }: ToolUsageTooltipProps) {
   if (!active || !payload || payload.length === 0) {
     return null;
   }
 
-  // Only show a tooltip when a specific tool segment is hovered.
-  if (!hoveredTool) {
-    return null;
-  }
-
   const typed = payload.filter(isToolChartUsagePayload);
-  const filtered = typed.filter((p) => p.name === hoveredTool);
-
-  if (filtered.length === 0) {
+  if (typed.length === 0) {
     return null;
   }
 
-  const toolPayload = filtered[0];
+  const toolPayload = typed[0];
   const toolName = toolPayload.name ?? "";
   const data = toolPayload.payload?.values?.[toolName];
 
@@ -93,7 +84,7 @@ export function ChartsTooltip({
     return (
       <div
         role="tooltip"
-        className="min-w-32 rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl dark:border-border-night/50 dark:bg-background-night"
+        className="flex max-h-60 min-w-32 flex-col overflow-hidden rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl dark:border-border-night/50 dark:bg-background-night"
       >
         <div className="mb-2 flex items-center gap-2">
           <LegendDot className={colorClassName} />
@@ -102,20 +93,22 @@ export function ChartsTooltip({
             ({percentOfTotal}%)
           </span>
         </div>
-        <div className="space-y-1.5">
-          {breakdownRows.map((b) => (
-            <div key={b.label} className="flex items-center gap-2">
-              <span className="text-muted-foreground dark:text-muted-foreground-night">
-                {b.label}
-              </span>
-              <span className="ml-auto font-mono font-medium tabular-nums text-foreground dark:text-foreground-night">
-                {b.value}
-              </span>
-              <span className="text-muted-foreground dark:text-muted-foreground-night">
-                ({b.percent}%)
-              </span>
-            </div>
-          ))}
+        <div className="flex-1 overflow-y-auto pr-1">
+          <div className="space-y-1.5">
+            {breakdownRows.map((b) => (
+              <div key={b.label} className="flex items-center gap-2">
+                <span className="text-muted-foreground dark:text-muted-foreground-night">
+                  {b.label}
+                </span>
+                <span className="ml-auto font-mono font-medium tabular-nums text-foreground dark:text-foreground-night">
+                  {b.value}
+                </span>
+                <span className="text-muted-foreground dark:text-muted-foreground-night">
+                  ({b.percent}%)
+                </span>
+              </div>
+            ))}
+          </div>
         </div>
       </div>
     );
@@ -124,7 +117,7 @@ export function ChartsTooltip({
   return (
     <div
       role="tooltip"
-      className="min-w-32 rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl dark:border-border-night/50 dark:bg-background-night"
+      className="flex max-h-60 min-w-32 flex-col overflow-hidden rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl dark:border-border-night/50 dark:bg-background-night"
     >
       <div className="mb-1.5 flex items-center gap-2">
         <LegendDot className={colorClassName} />
@@ -133,13 +126,15 @@ export function ChartsTooltip({
           ({percentOfTotal}%)
         </span>
       </div>
-      <div className="flex items-center gap-2">
-        <span className="text-muted-foreground dark:text-muted-foreground-night">
-          {toolName}
-        </span>
-        <span className="ml-auto font-mono font-medium tabular-nums text-foreground dark:text-foreground-night">
-          {data.count}
-        </span>
+      <div className="flex-1 overflow-y-auto pr-1">
+        <div className="flex items-center gap-2">
+          <span className="text-muted-foreground dark:text-muted-foreground-night">
+            {toolName}
+          </span>
+          <span className="ml-auto font-mono font-medium tabular-nums text-foreground dark:text-foreground-night">
+            {data.count}
+          </span>
+        </div>
       </div>
     </div>
   );

--- a/front/components/agent_builder/observability/charts/ChartsTooltip.tsx
+++ b/front/components/agent_builder/observability/charts/ChartsTooltip.tsx
@@ -18,23 +18,30 @@ export interface ToolUsageTooltipProps extends TooltipContentProps<
   string
 > {
   topTools: string[];
+  hoveredTool?: string | null;
 }
 
 export function ChartsTooltip({
   active,
   payload,
   topTools,
+  hoveredTool,
 }: ToolUsageTooltipProps) {
   if (!active || !payload || payload.length === 0) {
     return null;
   }
 
-  const typed = payload.filter(isToolChartUsagePayload);
-  if (typed.length === 0) {
+  if (!hoveredTool) {
     return null;
   }
 
-  const toolPayload = typed[0];
+  const typed = payload.filter(isToolChartUsagePayload);
+  const filtered = typed.filter((p) => p.name === hoveredTool);
+  if (filtered.length === 0) {
+    return null;
+  }
+
+  const toolPayload = filtered[0];
   const toolName = toolPayload.name ?? "";
   const data = toolPayload.payload?.values?.[toolName];
 

--- a/front/components/agent_builder/observability/charts/FeedbackDistributionChart.tsx
+++ b/front/components/agent_builder/observability/charts/FeedbackDistributionChart.tsx
@@ -124,7 +124,7 @@ export function FeedbackDistributionChart({
         <Tooltip
           content={FeedbackDistributionTooltip}
           cursor={false}
-          wrapperStyle={{ outline: "none" }}
+          wrapperStyle={{ outline: "none", zIndex: 50 }}
           contentStyle={{
             background: "transparent",
             border: "none",

--- a/front/components/agent_builder/observability/charts/LatencyChart.tsx
+++ b/front/components/agent_builder/observability/charts/LatencyChart.tsx
@@ -181,7 +181,7 @@ export function LatencyChart({
             <LatencyTooltip {...props} versionMarkers={versionMarkers} />
           )}
           cursor={false}
-          wrapperStyle={{ outline: "none" }}
+          wrapperStyle={{ outline: "none", zIndex: 50 }}
           contentStyle={{
             background: "transparent",
             border: "none",

--- a/front/components/agent_builder/observability/charts/SourceChart.tsx
+++ b/front/components/agent_builder/observability/charts/SourceChart.tsx
@@ -63,7 +63,7 @@ export function SourceChart({
       <PieChart>
         <Tooltip
           cursor={false}
-          wrapperStyle={{ outline: "none" }}
+          wrapperStyle={{ outline: "none", zIndex: 50 }}
           content={({ active }) => {
             if (!active || data.length === 0) {
               return null;

--- a/front/components/agent_builder/observability/charts/ToolUsageChart.tsx
+++ b/front/components/agent_builder/observability/charts/ToolUsageChart.tsx
@@ -1,5 +1,5 @@
 import { ButtonsSwitch, ButtonsSwitchList } from "@dust-tt/sparkle";
-import { useCallback, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import {
   Bar,
   BarChart,
@@ -41,7 +41,6 @@ export function ToolUsageChart({
 }) {
   const { period, mode, selectedVersion } = useObservabilityContext();
   const [toolMode, setToolMode] = useState<ToolChartModeType>("version");
-  const [hoveredTool, setHoveredTool] = useState<string | null>(null);
 
   const { configurations: mcpConfigurations } = useAgentMcpConfigurations({
     workspaceId,
@@ -108,16 +107,9 @@ export function ToolUsageChart({
     });
   }, [bars, chartData]);
 
-  const renderToolUsageTooltip = useCallback(
-    (payload: TooltipContentProps<number, string>) => (
-      <ChartsTooltip
-        {...payload}
-        topTools={topTools}
-        hoveredTool={hoveredTool}
-      />
-    ),
-    [topTools, hoveredTool]
-  );
+  const renderToolUsageTooltip = (
+    props: TooltipContentProps<number, string>
+  ) => <ChartsTooltip {...props} topTools={topTools} />;
 
   return (
     <ChartContainer
@@ -147,6 +139,7 @@ export function ToolUsageChart({
         data={rechartsData}
         margin={{ top: 10, right: 30, left: 10, bottom: 20 }}
         stackOffset="expand"
+        style={{ zIndex: 10 }}
       >
         <CartesianGrid
           vertical={false}
@@ -177,7 +170,12 @@ export function ToolUsageChart({
         <Tooltip
           cursor={false}
           content={renderToolUsageTooltip}
-          wrapperStyle={{ outline: "none" }}
+          shared={false}
+          wrapperStyle={{
+            outline: "none",
+            zIndex: 50,
+            pointerEvents: "auto",
+          }}
           contentStyle={{
             background: "transparent",
             border: "none",
@@ -208,8 +206,6 @@ export function ToolUsageChart({
             shape={
               <RoundedTopBarShape toolName={toolName} stackOrder={topTools} />
             }
-            onMouseEnter={() => setHoveredTool(toolName)}
-            onMouseLeave={() => setHoveredTool(null)}
           />
         ))}
       </BarChart>

--- a/front/components/agent_builder/observability/charts/UsageMetricsChart.tsx
+++ b/front/components/agent_builder/observability/charts/UsageMetricsChart.tsx
@@ -221,7 +221,7 @@ export function UsageMetricsChart({
             <UsageMetricsTooltip {...props} versionMarkers={versionMarkers} />
           )}
           cursor={false}
-          wrapperStyle={{ outline: "none" }}
+          wrapperStyle={{ outline: "none", zIndex: 50 }}
           contentStyle={{
             background: "transparent",
             border: "none",

--- a/front/components/agent_builder/observability/shared/ChartShapes.tsx
+++ b/front/components/agent_builder/observability/shared/ChartShapes.tsx
@@ -1,5 +1,23 @@
 import type { ValuesPayload } from "@app/components/agent_builder/observability/utils";
 
+function getStackValue(payload: ValuesPayload, key: string): number {
+  const v = payload.values[key];
+  if (typeof v === "number") {
+    return v;
+  }
+
+  if (typeof v === "object" && v !== null) {
+    if (typeof v.count === "number") {
+      return v.count;
+    }
+    if (typeof v.percent === "number") {
+      return v.percent;
+    }
+  }
+
+  return 0;
+}
+
 export function RoundedTopBarShape({
   x,
   y,
@@ -29,15 +47,15 @@ export function RoundedTopBarShape({
     return <g />;
   }
 
-  const toolValue = payload.values[toolName] ?? 0;
-  if (toolValue === 0) {
+  const toolValue = getStackValue(payload, toolName);
+  if (toolValue <= 0) {
     return <rect x={x} y={y} width={width} height={height} fill={fill} />;
   }
 
   let topTool: string | undefined;
   for (let idx = stackOrder.length - 1; idx >= 0; idx--) {
     const candidate = stackOrder[idx];
-    const value = payload.values[candidate] ?? 0;
+    const value = getStackValue(payload, candidate);
 
     if (value > 0) {
       topTool = candidate;
@@ -49,7 +67,7 @@ export function RoundedTopBarShape({
     return <rect x={x} y={y} width={width} height={height} fill={fill} />;
   }
 
-  const r = 4;
+  const r = Math.max(0, Math.min(4, height, width / 2));
   const right = x + width;
   const bottom = y + height;
   const d = `M ${x} ${bottom} L ${x} ${y + r} A ${r} ${r} 0 0 1 ${x + r} ${y} L ${right - r} ${y} A ${r} ${r} 0 0 1 ${right} ${y + r} L ${right} ${bottom} Z`;

--- a/front/components/agent_builder/observability/shared/ChartShapes.tsx
+++ b/front/components/agent_builder/observability/shared/ChartShapes.tsx
@@ -1,21 +1,7 @@
 import type { ValuesPayload } from "@app/components/agent_builder/observability/utils";
 
 function getStackValue(payload: ValuesPayload, key: string): number {
-  const v = payload.values[key];
-  if (typeof v === "number") {
-    return v;
-  }
-
-  if (typeof v === "object" && v !== null) {
-    if (typeof v.count === "number") {
-      return v.count;
-    }
-    if (typeof v.percent === "number") {
-      return v.percent;
-    }
-  }
-
-  return 0;
+  return payload.values[key]?.count ?? 0;
 }
 
 export function RoundedTopBarShape({

--- a/front/components/agent_builder/observability/utils.ts
+++ b/front/components/agent_builder/observability/utils.ts
@@ -13,10 +13,7 @@ import type { UserMessageOrigin } from "@app/types";
 export type VersionMarker = { version: string; timestamp: number };
 
 export type ValuesPayload = {
-  values: Record<
-    string,
-    number | { count?: number; percent?: number } | undefined
-  >;
+  values: Record<string, { count: number; percent: number } | undefined>;
 };
 
 export type SourceBucket = { origin: string; count: number };

--- a/front/components/agent_builder/observability/utils.ts
+++ b/front/components/agent_builder/observability/utils.ts
@@ -12,7 +12,12 @@ import type { UserMessageOrigin } from "@app/types";
 
 export type VersionMarker = { version: string; timestamp: number };
 
-export type ValuesPayload = { values: Record<string, number> };
+export type ValuesPayload = {
+  values: Record<
+    string,
+    number | { count?: number; percent?: number } | undefined
+  >;
+};
 
 export type SourceBucket = { origin: string; count: number };
 


### PR DESCRIPTION
## Description

This PR fixes tooltip percentage calculations and rendering in the `ToolUsageChart` to ensure accurate data display. The tooltip now dynamically calculates percentages based on total counts rather than using pre-calculated values. Switches the stacked bar chart from using percentage values to count values with `stackOffset="expand"`, which properly normalizes the stack to 100%. Also adds z-index to all chart tooltips (ToolUsage, FeedbackDistribution, Latency, Source, UsageMetrics) to ensure they render above other elements, and adds overflow scrolling to tooltips to handle large breakdowns.

## Risk
Low

## Tests

- [x] Locally
- [x] Front-edge

## Deploy Plan
Deploy front