### PR TITLE
[front] - fix(MentionDropdown): member chip alignment

### DIFF
--- a/front/components/editor/input_bar/MentionDropdown.tsx
+++ b/front/components/editor/input_bar/MentionDropdown.tsx
@@ -186,27 +186,29 @@ export const MentionDropdown = forwardRef<
                     setSelectedIndex(index);
                   }}
                 >
-                  <div className="flex min-w-0 flex-1 items-center gap-x-2">
-                    <Avatar
-                      size="xs"
-                      visual={suggestion.pictureUrl}
-                      isRounded={suggestion.type === "user"}
-                    />
-                    <span
-                      className="truncate font-semibold"
-                      title={suggestion.label}
-                    >
-                      {suggestion.label}
-                    </span>
+                  <div className="flex w-full items-center">
+                    <div className="flex min-w-0 flex-1 items-center gap-x-2">
+                      <Avatar
+                        size="xs"
+                        visual={suggestion.pictureUrl}
+                        isRounded={suggestion.type === "user"}
+                      />
+                      <span
+                        className="truncate font-semibold"
+                        title={suggestion.label}
+                      >
+                        {suggestion.label}
+                      </span>
+                    </div>
+                    {suggestion.type === "user" && (
+                      <Chip
+                        size="mini"
+                        color="primary"
+                        label="Member"
+                        className="ml-2 shrink-0"
+                      />
+                    )}
                   </div>
-                  {suggestion.type === "user" && (
-                    <Chip
-                      size="mini"
-                      color="primary"
-                      label="Member"
-                      className="ml-2 shrink-0"
-                    />
-                  )}
                 </DropdownMenuItem>
               ))}
             </div>


### PR DESCRIPTION

## Description

This PR adjust styling to ensure full width alignment and prevent shrinking - the member chip used to be displayed below.

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front