### PR TITLE
Remove rollup config check from Sparkle dev

### DIFF
--- a/front/admin/sparkle_dev.sh
+++ b/front/admin/sparkle_dev.sh
@@ -23,7 +23,6 @@ RESET='\033[0m'
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SPARKLE_DIR="$(cd "$SCRIPT_DIR/../../sparkle" && pwd)"
 FRONT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-ROLLUP_CONFIG="$SPARKLE_DIR/rollup.config.mjs"
 
 log() {
     local message="$1"
@@ -107,8 +106,8 @@ main() {
     fi
     
     # Check if we're in the right directory structure
-    if [[ ! -d "$SPARKLE_DIR" ]] || [[ ! -f "$ROLLUP_CONFIG" ]]; then
-        log "❌ Cannot find Sparkle directory or rollup config" "$RED"
+    if [[ ! -d "$SPARKLE_DIR" ]]; then
+        log "❌ Cannot find Sparkle directory" "$RED"
         log "   Expected: $SPARKLE_DIR" "$DIM"
         exit 1
     fi


### PR DESCRIPTION
## Description

This PR fixes the `npm run spakle:dev` script, by fixing `admin/dev.sh`.
The script was still checking if the rollup.config file exists. This file was deleted in this [PR](https://github.com/dust-tt/dust/pull/19331)

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Deploy front
