### PR TITLE
[front] refactor(skills): drop `configuration` suffix in endpoint responses

### DIFF
--- a/front/components/skill_builder/submitSkillBuilderForm.ts
+++ b/front/components/skill_builder/submitSkillBuilderForm.ts
@@ -17,8 +17,7 @@ export async function submitSkillBuilderForm({
   currentEditors?: UserType[];
 }): Promise<
   Result<
-    | PostSkillResponseBody["skill"]
-    | PatchSkillResponseBody["skill"],
+    PostSkillResponseBody["skill"] | PatchSkillResponseBody["skill"],
     Error
   >
 > {
@@ -57,9 +56,8 @@ export async function submitSkillBuilderForm({
       );
     }
 
-    const result:
-      | PostSkillResponseBody
-      | PatchSkillResponseBody = await response.json();
+    const result: PostSkillResponseBody | PatchSkillResponseBody =
+      await response.json();
 
     const { skill } = result;
 

--- a/front/components/skill_builder/submitSkillBuilderForm.ts
+++ b/front/components/skill_builder/submitSkillBuilderForm.ts
@@ -1,7 +1,7 @@
 import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
 import { clientFetch } from "@app/lib/egress/client";
-import type { PostSkillConfigurationResponseBody } from "@app/pages/api/w/[wId]/skills";
-import type { PatchSkillConfigurationResponseBody } from "@app/pages/api/w/[wId]/skills/[sId]";
+import type { PostSkillResponseBody } from "@app/pages/api/w/[wId]/skills";
+import type { PatchSkillResponseBody } from "@app/pages/api/w/[wId]/skills/[sId]";
 import type { Result, UserType, WorkspaceType } from "@app/types";
 import { Err, normalizeError, Ok } from "@app/types";
 
@@ -17,8 +17,8 @@ export async function submitSkillBuilderForm({
   currentEditors?: UserType[];
 }): Promise<
   Result<
-    | PostSkillConfigurationResponseBody["skillConfiguration"]
-    | PatchSkillConfigurationResponseBody["skillConfiguration"],
+    | PostSkillResponseBody["skill"]
+    | PatchSkillResponseBody["skill"],
     Error
   >
 > {
@@ -58,10 +58,10 @@ export async function submitSkillBuilderForm({
     }
 
     const result:
-      | PostSkillConfigurationResponseBody
-      | PatchSkillConfigurationResponseBody = await response.json();
+      | PostSkillResponseBody
+      | PatchSkillResponseBody = await response.json();
 
-    const skillConfiguration = result.skillConfiguration;
+    const { skill } = result;
 
     // Only sync editors for existing skills (updates), not for newly created skills
     // When creating a skill, the backend automatically adds the creator to the editors group
@@ -88,7 +88,7 @@ export async function submitSkillBuilderForm({
 
       if (addEditorIds.length > 0 || removeEditorIds.length > 0) {
         const editorsResponse = await clientFetch(
-          `/api/w/${owner.sId}/skills/${skillConfiguration.sId}/editors`,
+          `/api/w/${owner.sId}/skills/${skill.sId}/editors`,
           {
             method: "PATCH",
             headers: {
@@ -112,7 +112,7 @@ export async function submitSkillBuilderForm({
       }
     }
 
-    return new Ok(skillConfiguration);
+    return new Ok(skill);
   } catch (error) {
     const normalizedError = normalizeError(error);
     return new Err(

--- a/front/components/skill_builder/transformSkillConfiguration.ts
+++ b/front/components/skill_builder/transformSkillConfiguration.ts
@@ -8,17 +8,17 @@ import type { SkillType } from "@app/types/assistant/skill_configuration";
  * Editors are intentionally set to empty defaults as they will be populated reactively.
  */
 export function transformSkillTypeToFormData(
-  skillConfiguration: SkillType
+  skill: SkillType
 ): SkillBuilderFormData {
   return {
-    name: skillConfiguration.name,
-    agentFacingDescription: skillConfiguration.agentFacingDescription,
-    userFacingDescription: skillConfiguration.userFacingDescription,
-    instructions: skillConfiguration.instructions ?? "",
+    name: skill.name,
+    agentFacingDescription: skill.agentFacingDescription,
+    userFacingDescription: skill.userFacingDescription,
+    instructions: skill.instructions ?? "",
     editors: [], // Will be populated reactively from useEditors hook
-    tools: skillConfiguration.tools.map(getDefaultMCPAction),
-    icon: skillConfiguration.icon ?? null,
-    extendedSkillId: skillConfiguration.extendedSkillId,
+    tools: skill.tools.map(getDefaultMCPAction),
+    icon: skill.icon ?? null,
+    extendedSkillId: skill.extendedSkillId,
   };
 }
 

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -70,8 +70,7 @@ export function useSkillsWithRelations({
   disabled?: boolean;
   status: SkillStatus;
 }) {
-  const skillsFetcher: Fetcher<GetSkillsWithRelationsResponseBody> =
-    fetcher;
+  const skillsFetcher: Fetcher<GetSkillsWithRelationsResponseBody> = fetcher;
 
   const { data, isLoading, mutate } = useSWRWithDefaults(
     `/api/w/${owner.sId}/skills?withRelations=true&status=${status}`,
@@ -228,8 +227,7 @@ export function useSkillHistory({
   limit?: number;
   disabled?: boolean;
 }) {
-  const skillHistoryFetcher: Fetcher<GetSkillHistoryResponseBody> =
-    fetcher;
+  const skillHistoryFetcher: Fetcher<GetSkillHistoryResponseBody> = fetcher;
 
   const queryParams = limit ? `?limit=${limit}` : "";
   const { data, error, mutate } = useSWRWithDefaults(

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -12,11 +12,11 @@ import {
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
 import type {
-  GetSkillConfigurationsResponseBody,
-  GetSkillConfigurationsWithRelationsResponseBody,
+  GetSkillsResponseBody,
+  GetSkillsWithRelationsResponseBody,
 } from "@app/pages/api/w/[wId]/skills";
 import type { GetSkillWithRelationsResponseBody } from "@app/pages/api/w/[wId]/skills/[sId]";
-import type { GetSkillConfigurationsHistoryResponseBody } from "@app/pages/api/w/[wId]/skills/[sId]/history";
+import type { GetSkillHistoryResponseBody } from "@app/pages/api/w/[wId]/skills/[sId]/history";
 import type { GetSimilarSkillsResponseBody } from "@app/pages/api/w/[wId]/skills/similar";
 import type { LightWorkspaceType } from "@app/types";
 import { Ok } from "@app/types";
@@ -36,7 +36,7 @@ export function useSkills({
   status?: SkillStatus;
   globalSpaceOnly?: boolean;
 }) {
-  const skillsFetcher: Fetcher<GetSkillConfigurationsResponseBody> = fetcher;
+  const skillsFetcher: Fetcher<GetSkillsResponseBody> = fetcher;
 
   const queryParams = new URLSearchParams();
   if (status) {
@@ -54,7 +54,7 @@ export function useSkills({
   );
 
   return {
-    skills: data?.skillConfigurations ?? emptyArray(),
+    skills: data?.skills ?? emptyArray(),
     isSkillsError: !!error,
     isSkillsLoading: isLoading,
     mutateSkills: mutate,
@@ -70,7 +70,7 @@ export function useSkillsWithRelations({
   disabled?: boolean;
   status: SkillStatus;
 }) {
-  const skillsFetcher: Fetcher<GetSkillConfigurationsWithRelationsResponseBody> =
+  const skillsFetcher: Fetcher<GetSkillsWithRelationsResponseBody> =
     fetcher;
 
   const { data, isLoading, mutate } = useSWRWithDefaults(
@@ -80,7 +80,7 @@ export function useSkillsWithRelations({
   );
 
   return {
-    skillsWithRelations: data?.skillConfigurations ?? emptyArray(),
+    skillsWithRelations: data?.skills ?? emptyArray(),
     isSkillsWithRelationsLoading: isLoading,
     mutateSkillsWithRelations: mutate,
   };
@@ -228,7 +228,7 @@ export function useSkillHistory({
   limit?: number;
   disabled?: boolean;
 }) {
-  const skillHistoryFetcher: Fetcher<GetSkillConfigurationsHistoryResponseBody> =
+  const skillHistoryFetcher: Fetcher<GetSkillHistoryResponseBody> =
     fetcher;
 
   const queryParams = limit ? `?limit=${limit}` : "";

--- a/front/pages/api/w/[wId]/skills/[sId]/history/index.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/history/index.ts
@@ -8,17 +8,17 @@ import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
 import { isString } from "@app/types";
-import { GetSkillConfigurationsHistoryQuerySchema } from "@app/types/api/internal/skill";
+import { GetSkillHistoryQuerySchema } from "@app/types/api/internal/skill";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 
-export type GetSkillConfigurationsHistoryResponseBody = {
+export type GetSkillHistoryResponseBody = {
   history: SkillType[];
 };
 
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<
-    WithAPIErrorResponse<GetSkillConfigurationsHistoryResponseBody | void>
+    WithAPIErrorResponse<GetSkillHistoryResponseBody | void>
   >,
   auth: Authenticator
 ): Promise<void> {
@@ -49,7 +49,7 @@ async function handler(
 
   switch (req.method) {
     case "GET":
-      const queryValidation = GetSkillConfigurationsHistoryQuerySchema.decode({
+      const queryValidation = GetSkillHistoryQuerySchema.decode({
         ...req.query,
         limit:
           typeof req.query.limit === "string"

--- a/front/pages/api/w/[wId]/skills/[sId]/index.test.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.test.ts
@@ -126,9 +126,9 @@ describe("GET /api/w/[wId]/skills/[sId]", () => {
     await handler(req, res);
     expect(res._getStatusCode()).toBe(200);
     const data = res._getJSONData();
-    expect(data).toHaveProperty("skillConfiguration");
-    expect(data.skillConfiguration.sId).toBe(skill.sId);
-    expect(data.skillConfiguration.name).toBe("Test Skill");
+    expect(data).toHaveProperty("skill");
+    expect(data.skill.sId).toBe(skill.sId);
+    expect(data.skill.name).toBe("Test Skill");
   });
 
   it("should return 404 for non-existent skill", async () => {
@@ -262,9 +262,9 @@ describe("PATCH /api/w/[wId]/skills/[sId]", () => {
     const data = res._getJSONData();
     expect(data).not.toHaveProperty("error");
     expect(res._getStatusCode()).toBe(200);
-    expect(data).toHaveProperty("skillConfiguration");
-    expect(data.skillConfiguration.sId).toBe(skill.sId);
-    expect(data.skillConfiguration.agentFacingDescription).toBe(newDescription);
+    expect(data).toHaveProperty("skill");
+    expect(data.skill.sId).toBe(skill.sId);
+    expect(data.skill.agentFacingDescription).toBe(newDescription);
 
     // Verify the update persisted by fetching the resource
     const updatedSkill = await SkillResource.fetchById(
@@ -322,10 +322,10 @@ describe("PATCH /api/w/[wId]/skills/[sId]", () => {
     const data = res._getJSONData();
     expect(data).not.toHaveProperty("error");
     expect(res._getStatusCode()).toBe(200);
-    expect(data.skillConfiguration.tools).toHaveLength(2);
-    expect(data.skillConfiguration.requestedSpaceIds).toHaveLength(2);
-    expect(data.skillConfiguration.requestedSpaceIds).toContain(space1.sId);
-    expect(data.skillConfiguration.requestedSpaceIds).toContain(space2.sId);
+    expect(data.skill.tools).toHaveLength(2);
+    expect(data.skill.requestedSpaceIds).toHaveLength(2);
+    expect(data.skill.requestedSpaceIds).toContain(space1.sId);
+    expect(data.skill.requestedSpaceIds).toContain(space2.sId);
 
     // Verify the update persisted in the database
     const updatedSkill = await SkillResource.fetchById(
@@ -370,8 +370,8 @@ describe("PATCH /api/w/[wId]/skills/[sId]", () => {
     expect(res._getStatusCode()).toBe(200);
 
     // Verify the response contains the updated tools
-    expect(data.skillConfiguration.tools).toHaveLength(1);
-    expect(data.skillConfiguration.tools[0].sId).toBe(serverView.sId);
+    expect(data.skill.tools).toHaveLength(1);
+    expect(data.skill.tools[0].sId).toBe(serverView.sId);
 
     // Verify fetching the skill also shows the tool
     const updatedSkill = await SkillResource.fetchById(

--- a/front/pages/api/w/[wId]/skills/index.test.ts
+++ b/front/pages/api/w/[wId]/skills/index.test.ts
@@ -230,9 +230,7 @@ describe("GET /api/w/[wId]/skills?withRelations=true", () => {
     });
     const skillResult = res
       ._getJSONData()
-      .skills.find(
-        (s: SkillWithRelationsType) => s.sId === skillSId
-      );
+      .skills.find((s: SkillWithRelationsType) => s.sId === skillSId);
 
     expect(skillResult).toMatchObject({
       relations: {
@@ -269,9 +267,7 @@ describe("GET /api/w/[wId]/skills?withRelations=true", () => {
 
     const skillResult = res
       ._getJSONData()
-      .skills.find(
-        (s: SkillWithRelationsType) => s.sId === "frames"
-      );
+      .skills.find((s: SkillWithRelationsType) => s.sId === "frames");
 
     expect(skillResult).toMatchObject({
       relations: {
@@ -307,9 +303,7 @@ describe("GET /api/w/[wId]/skills?withRelations=true", () => {
     });
     const skillResult = res
       ._getJSONData()
-      .skills.find(
-        (s: SkillWithRelationsType) => s.sId === skillSId
-      );
+      .skills.find((s: SkillWithRelationsType) => s.sId === skillSId);
 
     expect(skillResult).toMatchObject({
       relations: {
@@ -391,9 +385,7 @@ describe("GET /api/w/[wId]/skills?withRelations=true", () => {
     });
     const skillResult = res
       ._getJSONData()
-      .skills.find(
-        (s: SkillWithRelationsType) => s.sId === skillSId
-      );
+      .skills.find((s: SkillWithRelationsType) => s.sId === skillSId);
 
     expect(skillResult).toMatchObject({
       relations: {

--- a/front/pages/api/w/[wId]/skills/index.test.ts
+++ b/front/pages/api/w/[wId]/skills/index.test.ts
@@ -61,9 +61,9 @@ describe("GET /api/w/[wId]/skills", () => {
 
     expect(res._getStatusCode()).toBe(200);
     const data = res._getJSONData();
-    expect(data).toHaveProperty("skillConfigurations");
+    expect(data).toHaveProperty("skills");
 
-    const skillNames = data.skillConfigurations.map((s: SkillType) => s.name);
+    const skillNames = data.skills.map((s: SkillType) => s.name);
     expect(skillNames).toContain("Test Skill 1");
     expect(skillNames).toContain("Test Skill 2");
   });
@@ -96,7 +96,7 @@ describe("GET /api/w/[wId]/skills", () => {
     expect(res._getStatusCode()).toBe(200);
     const data = res._getJSONData();
 
-    const skillNames = data.skillConfigurations.map((s: SkillType) => s.name);
+    const skillNames = data.skills.map((s: SkillType) => s.name);
     expect(skillNames).toContain("Active Skill");
     expect(skillNames).not.toContain("Archived Skill");
   });
@@ -129,7 +129,7 @@ describe("GET /api/w/[wId]/skills", () => {
     expect(res._getStatusCode()).toBe(200);
     const data = res._getJSONData();
 
-    const skillNames = data.skillConfigurations.map((s: SkillType) => s.name);
+    const skillNames = data.skills.map((s: SkillType) => s.name);
     expect(skillNames).toContain("Suggested Skill");
     expect(skillNames).not.toContain("Active Skill");
     expect(skillNames).not.toContain("Archived Skill");
@@ -190,7 +190,7 @@ describe("GET /api/w/[wId]/skills", () => {
       expect(res._getStatusCode()).toBe(200);
       const skillNames = res
         ._getJSONData()
-        .skillConfigurations.map((s: SkillType) => s.name);
+        .skills.map((s: SkillType) => s.name);
       expect(skillNames).toContain(`Skill for ${role}`);
     }
   });
@@ -230,7 +230,7 @@ describe("GET /api/w/[wId]/skills?withRelations=true", () => {
     });
     const skillResult = res
       ._getJSONData()
-      .skillConfigurations.find(
+      .skills.find(
         (s: SkillWithRelationsType) => s.sId === skillSId
       );
 
@@ -269,7 +269,7 @@ describe("GET /api/w/[wId]/skills?withRelations=true", () => {
 
     const skillResult = res
       ._getJSONData()
-      .skillConfigurations.find(
+      .skills.find(
         (s: SkillWithRelationsType) => s.sId === "frames"
       );
 
@@ -307,7 +307,7 @@ describe("GET /api/w/[wId]/skills?withRelations=true", () => {
     });
     const skillResult = res
       ._getJSONData()
-      .skillConfigurations.find(
+      .skills.find(
         (s: SkillWithRelationsType) => s.sId === skillSId
       );
 
@@ -345,7 +345,7 @@ describe("GET /api/w/[wId]/skills?withRelations=true", () => {
     });
     const skillResult = res
       ._getJSONData()
-      .skillConfigurations.find((s: SkillType) => s.sId === skillSId);
+      .skills.find((s: SkillType) => s.sId === skillSId);
 
     expect(skillResult).toBeDefined();
     expect(skillResult).not.toHaveProperty("usage");
@@ -391,7 +391,7 @@ describe("GET /api/w/[wId]/skills?withRelations=true", () => {
     });
     const skillResult = res
       ._getJSONData()
-      .skillConfigurations.find(
+      .skills.find(
         (s: SkillWithRelationsType) => s.sId === skillSId
       );
 
@@ -424,7 +424,7 @@ describe("POST /api/w/[wId]/skills", () => {
     expect(res._getStatusCode()).toBe(200);
 
     const responseData = res._getJSONData();
-    expect(responseData.skillConfiguration).toMatchObject({
+    expect(responseData.skill).toMatchObject({
       name: "Simple Skill",
       agentFacingDescription: "To use in various situations",
       userFacingDescription: "A simple skill without tools",
@@ -482,7 +482,7 @@ describe("POST /api/w/[wId]/skills", () => {
     expect(res._getStatusCode()).toBe(200);
 
     const responseData = res._getJSONData();
-    expect(responseData.skillConfiguration).toMatchObject({
+    expect(responseData.skill).toMatchObject({
       name: "Test Skill",
       agentFacingDescription: "Use this skill all the time",
       userFacingDescription: "A test skill description",
@@ -559,7 +559,7 @@ describe("POST /api/w/[wId]/skills", () => {
     expect(res._getStatusCode()).toBe(200);
 
     const responseData = res._getJSONData();
-    expect(responseData.skillConfiguration).toMatchObject({
+    expect(responseData.skill).toMatchObject({
       name: "Skill With Space Restrictions",
       requestedSpaceIds: [regularSpace.sId],
     });

--- a/front/types/api/internal/skill.ts
+++ b/front/types/api/internal/skill.ts
@@ -4,6 +4,6 @@ import { createRangeCodec } from "@app/types/shared/utils/iots_utils";
 
 const LimitCodec = createRangeCodec(0, 100);
 
-export const GetSkillConfigurationsHistoryQuerySchema = t.type({
+export const GetSkillHistoryQuerySchema = t.type({
   limit: t.union([LimitCodec, t.undefined]),
 });


### PR DESCRIPTION
## Description

- Follow up on https://github.com/dust-tt/dust/pull/19553.
- This PR renames the fields named `skillConfiguration(s)` in endpoint responses for skills into `skill(s)`.
- The goal is to not expose the name `skillConfiguration` to the front-end and make it a backend-only concept as it is actually very close to the data model.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
