### PR TITLE
run_agent: transient network error detection

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/run_agent/network_errors.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent/network_errors.ts
@@ -1,0 +1,56 @@
+import type { APIError } from "@dust-tt/client";
+
+import { normalizeError } from "@app/types";
+
+/**
+ * Patterns that indicate transient network errors.
+ * These errors are typically caused by infrastructure issues (load balancer timeouts,
+ * connection resets, network interruptions) and should not trigger alerts.
+ */
+const TRANSIENT_NETWORK_ERROR_PATTERNS = [
+  /terminated/i,
+  /aborted/i,
+  /socket hang up/i,
+  /ECONNRESET/i,
+  /ETIMEDOUT/i,
+  /ECONNREFUSED/i,
+  /exceeded maximum reconnection attempts/i,
+  /not connected/i,
+];
+
+/**
+ * Checks if an error message matches any known transient network error pattern.
+ */
+function matchesTransientPattern(message: string): boolean {
+  return TRANSIENT_NETWORK_ERROR_PATTERNS.some((pattern) =>
+    pattern.test(message)
+  );
+}
+
+/**
+ * Determines if an API error is a transient network error.
+ * Transient network errors are caused by infrastructure issues and should not
+ * trigger monitoring alerts as they are typically recoverable.
+ *
+ * Examples:
+ * - "TypeError: terminated" - TCP connection terminated unexpectedly
+ * - "Exceeded maximum reconnection attempts" - Stream reconnection exhausted
+ * - "ECONNRESET" - Connection reset by peer
+ */
+export function isTransientNetworkError(error: APIError): boolean {
+  const message = error.message || "";
+  return matchesTransientPattern(message);
+}
+
+/**
+ * Determines if a stream error is a transient network error.
+ * Used for errors thrown during agent stream processing.
+ *
+ * Also handles the "Not connected" error which indicates the stream
+ * was disconnected but the operation may have completed.
+ */
+export function isTransientStreamError(error: unknown): boolean {
+  const normalized = normalizeError(error);
+  const message = normalized.message || "";
+  return matchesTransientPattern(message);
+}


### PR DESCRIPTION
## Description

Detects network related errors and stop tracking them when calling `run_agent` MCP tool.

https://app.datadoghq.eu/logs?query=region%3Aeurope-west1%20%40toolName%3Arun_agent%20%22Tool%20execution%20error%22%20status%3Aerror&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cworkspace.sId%2CtoolName%2Cerror&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1766765555396&to_ts=1767370355396&live=true

These errors are retryable by the model and generally part of conversations that are making progress with other run agents.

## Tests

Tested locally

## Risk

Low

## Deploy Plan

- deploy `front`