### PR TITLE
[sparkle] - refactor(AttachmentChip): enhance component

### DIFF
--- a/sparkle/src/components/AttachmentChip.tsx
+++ b/sparkle/src/components/AttachmentChip.tsx
@@ -1,25 +1,34 @@
-import { cva } from "class-variance-authority";
 import React from "react";
 
 import { cn } from "@sparkle/lib/utils";
 
-import { Icon } from "./Icon";
-import { LinkWrapper, LinkWrapperProps } from "./LinkWrapper";
+import { Chip, CHIP_COLORS, CHIP_SIZES } from "./Chip";
+import { DoubleIcon, DoubleIconProps, Icon, IconProps } from "./Icon";
+import { LinkWrapperProps } from "./LinkWrapper";
 
-const attachmentChipVariants = cva(
-  cn(
-    "s-box-border s-inline-flex s-items-center s-gap-1.5 s-rounded-lg s-px-2 s-py-1 s-heading-sm",
-    "s-border-border s-bg-background",
-    "dark:s-border-border-night dark:s-bg-background-night",
-    "s-text-foreground dark:s-text-foreground-night",
-    "s-max-w-44"
-  )
+const attachmentChipOverrides = cn(
+  "s-rounded-lg s-px-2 s-py-1 s-heading-sm s-gap-1.5",
+  "s-bg-background s-text-foreground s-max-w-44",
+  "dark:s-bg-background-night dark:s-text-foreground-night"
 );
+
+type AttachmentChipIconProps = IconProps | DoubleIconProps;
+
+function isDoubleIconProps(
+  props: AttachmentChipIconProps
+): props is DoubleIconProps {
+  return "mainIcon" in props;
+}
 
 interface AttachmentChipBaseProps {
   label: string;
-  icon?: React.ComponentType;
+  icon?: AttachmentChipIconProps;
+  size?: (typeof CHIP_SIZES)[number];
+  color?: (typeof CHIP_COLORS)[number];
   className?: string;
+  isBusy?: boolean;
+  onRemove?: () => void;
+  onClick?: () => void;
 }
 
 type AttachmentChipButtonProps = AttachmentChipBaseProps & {
@@ -34,21 +43,51 @@ type AttachmentChipLinkProps = AttachmentChipBaseProps &
 type AttachmentChipProps = AttachmentChipButtonProps | AttachmentChipLinkProps;
 
 export function AttachmentChip({
-  label,
   icon,
   className,
-  ...props
+  label,
+  size,
+  color,
+  isBusy,
+  onRemove,
+  onClick,
+  ...linkProps
 }: AttachmentChipProps) {
-  const chipContent = (
-    <div className={cn(attachmentChipVariants({}), className)}>
-      <Icon visual={icon} size="xs" className="s-shrink-0" />
-      <span className="s-pointer s-grow s-truncate">{label}</span>
+  const iconElement = icon && (
+    <div className="s-shrink-0">
+      {isDoubleIconProps(icon) ? <DoubleIcon {...icon} /> : <Icon {...icon} />}
     </div>
   );
 
-  return "href" in props && props.href ? (
-    <LinkWrapper {...props}>{chipContent}</LinkWrapper>
-  ) : (
-    chipContent
+  const chipClassName = cn(attachmentChipOverrides, className);
+
+  if ("href" in linkProps && linkProps.href) {
+    return (
+      <Chip
+        className={chipClassName}
+        label={label}
+        size={size}
+        color={color}
+        isBusy={isBusy}
+        onRemove={onRemove}
+        {...linkProps}
+      >
+        {iconElement}
+      </Chip>
+    );
+  }
+
+  return (
+    <Chip
+      className={chipClassName}
+      label={label}
+      size={size}
+      color={color}
+      isBusy={isBusy}
+      onRemove={onRemove}
+      onClick={onClick}
+    >
+      {iconElement}
+    </Chip>
   );
 }

--- a/sparkle/src/components/Card.tsx
+++ b/sparkle/src/components/Card.tsx
@@ -212,7 +212,7 @@ const CardActions = React.forwardRef<
     <div
       ref={ref}
       className={cn(
-        "s-absolute s-right-2 s-top-2 sm:s-opacity-0 s-transition-opacity",
+        "s-absolute s-right-2 s-top-2 s-transition-opacity sm:s-opacity-0",
         "group-focus-within/card:s-opacity-100 group-hover/card:s-opacity-100"
       )}
       {...props}

--- a/sparkle/src/components/Chip.tsx
+++ b/sparkle/src/components/Chip.tsx
@@ -160,7 +160,7 @@ type ChipLinkProps = ChipBaseProps &
     onClick?: never;
   };
 
-type ChipProps = ChipLinkProps | ChipButtonProps;
+export type ChipProps = ChipLinkProps | ChipButtonProps;
 
 // TODO(yuka: 1606): we should update this component so that you cannot have both
 // onClick and onRemove at the same time. We should use div when there is no onClick,

--- a/sparkle/src/stories/AttachmentChip.stories.tsx
+++ b/sparkle/src/stories/AttachmentChip.stories.tsx
@@ -2,8 +2,8 @@ import type { Meta, StoryObj } from "@storybook/react";
 import React from "react";
 
 import { AttachmentChip } from "@sparkle/components";
-import { DocumentIcon, DocumentTextIcon } from "@sparkle/icons/app";
-import { NotionLogo } from "@sparkle/logo";
+import { DocumentIcon, DocumentTextIcon, FolderIcon } from "@sparkle/icons/app";
+import { DriveLogo, NotionLogo } from "@sparkle/logo";
 
 const meta = {
   title: "Components/AttachmentChip",
@@ -29,7 +29,7 @@ const ParagraphWrapper = ({ children }: { children: React.ReactNode }) => (
 export const Document: Story = {
   args: {
     label: "document.pdf",
-    icon: NotionLogo,
+    icon: { visual: NotionLogo },
   },
   decorators: [
     (Story) => (
@@ -43,7 +43,7 @@ export const Document: Story = {
 export const Image: Story = {
   args: {
     label: "image.jpg",
-    icon: NotionLogo,
+    icon: { visual: NotionLogo },
   },
   decorators: [
     (Story) => (
@@ -57,7 +57,7 @@ export const Image: Story = {
 export const Text: Story = {
   args: {
     label: "text.txt",
-    icon: DocumentTextIcon,
+    icon: { visual: DocumentTextIcon },
   },
   decorators: [
     (Story) => (
@@ -71,7 +71,52 @@ export const Text: Story = {
 export const LongLabel: Story = {
   args: {
     label: "very_long_document_name_that_will_be_truncated.pdf",
-    icon: DocumentIcon,
+    icon: { visual: DocumentIcon },
+  },
+  decorators: [
+    (Story) => (
+      <ParagraphWrapper>
+        <Story />
+      </ParagraphWrapper>
+    ),
+  ],
+};
+
+export const WithDoubleIcon: Story = {
+  args: {
+    label: "My Drive Folder",
+    icon: { mainIcon: FolderIcon, secondaryIcon: DriveLogo, size: "sm" },
+  },
+  decorators: [
+    (Story) => (
+      <ParagraphWrapper>
+        <Story />
+      </ParagraphWrapper>
+    ),
+  ],
+};
+
+export const WithDoubleIconAndLink: Story = {
+  args: {
+    label: "Notion Document",
+    icon: { mainIcon: DocumentIcon, secondaryIcon: NotionLogo, size: "sm" },
+    href: "https://notion.so",
+    target: "_blank",
+  },
+  decorators: [
+    (Story) => (
+      <ParagraphWrapper>
+        <Story />
+      </ParagraphWrapper>
+    ),
+  ],
+};
+
+export const WithChipColor: Story = {
+  args: {
+    label: "Success chip",
+    icon: { visual: DocumentIcon },
+    color: "success",
   },
   decorators: [
     (Story) => (


### PR DESCRIPTION
## Description
Refactors `AttachmentChip` to use the `Chip` component internally, unifying styling and behavior across the design system. The component now supports rendering either a single icon or a combination of icons using `DoubleIcon`, and introduces new props for customization including size, color, isBusy state, onRemove and onClick handlers. Also exports `ChipProps` type to enable reuse in other components.

## Risk

Low - only affects `AttachmentChip`

## Tests

Updated storybook stories to demonstrate new functionality with DoubleIcon support and color variants.

## Deploy Plan

- Publish rc
- Create front PR
- Publish gr
- Update front
