### PR TITLE
[front] feat(skills): add support for skills in Poke

### DIFF
--- a/front/components/poke/skills/columns.tsx
+++ b/front/components/poke/skills/columns.tsx
@@ -7,11 +7,10 @@ import type { SkillType } from "@app/types/assistant/skill_configuration";
 
 type SkillDisplayType = Pick<
   SkillType,
-  "sId" | "name" | "status" | "userFacingDescription" | "createdAt"
+  "sId" | "name" | "status" | "createdAt" | "updatedAt"
 >;
 
-export function makeColumnsForSkills(
-): ColumnDef<SkillDisplayType>[] {
+export function makeColumnsForSkills(): ColumnDef<SkillDisplayType>[] {
   return [
     {
       accessorKey: "sId",
@@ -59,7 +58,6 @@ export function makeColumnsForSkills(
       header: "Created at",
       cell: ({ row }) => {
         const createdAt: number | null = row.getValue("createdAt");
-
         return createdAt ? formatTimestampToFriendlyDate(createdAt) : null;
       },
     },
@@ -68,7 +66,6 @@ export function makeColumnsForSkills(
       header: "Updated at",
       cell: ({ row }) => {
         const updatedAt: number | null = row.getValue("updatedAt");
-
         return updatedAt ? formatTimestampToFriendlyDate(updatedAt) : null;
       },
     },

--- a/front/components/poke/skills/columns.tsx
+++ b/front/components/poke/skills/columns.tsx
@@ -14,9 +14,6 @@ export function makeColumnsForSkills(): ColumnDef<SkillDisplayType>[] {
   return [
     {
       accessorKey: "sId",
-      cell: ({ row }) => {
-        return row.getValue("sId");
-      },
       header: ({ column }) => {
         return (
           <div className="flex space-x-2">

--- a/front/components/poke/skills/columns.tsx
+++ b/front/components/poke/skills/columns.tsx
@@ -1,0 +1,76 @@
+import { IconButton } from "@dust-tt/sparkle";
+import { ArrowsUpDownIcon } from "@heroicons/react/20/solid";
+import type { ColumnDef } from "@tanstack/react-table";
+
+import { formatTimestampToFriendlyDate } from "@app/lib/utils";
+import type { SkillType } from "@app/types/assistant/skill_configuration";
+
+type SkillDisplayType = Pick<
+  SkillType,
+  "sId" | "name" | "status" | "userFacingDescription" | "createdAt"
+>;
+
+export function makeColumnsForSkills(
+): ColumnDef<SkillDisplayType>[] {
+  return [
+    {
+      accessorKey: "sId",
+      cell: ({ row }) => {
+        return row.getValue("sId");
+      },
+      header: ({ column }) => {
+        return (
+          <div className="flex space-x-2">
+            <p>Id</p>
+            <IconButton
+              variant="outline"
+              icon={ArrowsUpDownIcon}
+              onClick={() =>
+                column.toggleSorting(column.getIsSorted() === "asc")
+              }
+            />
+          </div>
+        );
+      },
+    },
+    {
+      accessorKey: "name",
+      header: ({ column }) => {
+        return (
+          <div className="flex space-x-2">
+            <p>Name</p>
+            <IconButton
+              variant="outline"
+              icon={ArrowsUpDownIcon}
+              onClick={() =>
+                column.toggleSorting(column.getIsSorted() === "asc")
+              }
+            />
+          </div>
+        );
+      },
+    },
+    {
+      accessorKey: "status",
+      header: "Status",
+    },
+    {
+      accessorKey: "createdAt",
+      header: "Created at",
+      cell: ({ row }) => {
+        const createdAt: number | null = row.getValue("createdAt");
+
+        return createdAt ? formatTimestampToFriendlyDate(createdAt) : null;
+      },
+    },
+    {
+      accessorKey: "updatedAt",
+      header: "Updated at",
+      cell: ({ row }) => {
+        const updatedAt: number | null = row.getValue("updatedAt");
+
+        return updatedAt ? formatTimestampToFriendlyDate(updatedAt) : null;
+      },
+    },
+  ];
+}

--- a/front/components/poke/skills/columns.tsx
+++ b/front/components/poke/skills/columns.tsx
@@ -1,4 +1,4 @@
-import { IconButton } from "@dust-tt/sparkle";
+import { Button } from "@dust-tt/sparkle";
 import { ArrowsUpDownIcon } from "@heroicons/react/20/solid";
 import type { ColumnDef } from "@tanstack/react-table";
 
@@ -18,8 +18,8 @@ export function makeColumnsForSkills(): ColumnDef<SkillDisplayType>[] {
         return (
           <div className="flex space-x-2">
             <p>Id</p>
-            <IconButton
-              variant="outline"
+            <Button
+              variant="ghost"
               icon={ArrowsUpDownIcon}
               onClick={() =>
                 column.toggleSorting(column.getIsSorted() === "asc")
@@ -35,8 +35,8 @@ export function makeColumnsForSkills(): ColumnDef<SkillDisplayType>[] {
         return (
           <div className="flex space-x-2">
             <p>Name</p>
-            <IconButton
-              variant="outline"
+            <Button
+              variant="ghost"
               icon={ArrowsUpDownIcon}
               onClick={() =>
                 column.toggleSorting(column.getIsSorted() === "asc")

--- a/front/components/poke/skills/table.tsx
+++ b/front/components/poke/skills/table.tsx
@@ -17,9 +17,7 @@ export function SkillsDataTable({ owner, loadOnInit }: SkillsDataTableProps) {
       loadOnInit={loadOnInit}
       useSWRHook={usePokeSkills}
     >
-      {(data) => (
-        <PokeDataTable columns={makeColumnsForSkills(owner)} data={data} />
-      )}
+      {(data) => <PokeDataTable columns={makeColumnsForSkills()} data={data} />}
     </PokeDataTableConditionalFetch>
   );
 }

--- a/front/components/poke/skills/table.tsx
+++ b/front/components/poke/skills/table.tsx
@@ -1,0 +1,25 @@
+import { PokeDataTableConditionalFetch } from "@app/components/poke/PokeConditionalDataTables";
+import { PokeDataTable } from "@app/components/poke/shadcn/ui/data_table";
+import { makeColumnsForSkills } from "@app/components/poke/skills/columns";
+import { usePokeSkills } from "@app/poke/swr/skills";
+import type { LightWorkspaceType } from "@app/types";
+
+interface SkillsDataTableProps {
+  owner: LightWorkspaceType;
+  loadOnInit?: boolean;
+}
+
+export function SkillsDataTable({ owner, loadOnInit }: SkillsDataTableProps) {
+  return (
+    <PokeDataTableConditionalFetch
+      header="Skills"
+      owner={owner}
+      loadOnInit={loadOnInit}
+      useSWRHook={usePokeSkills}
+    >
+      {(data) => (
+        <PokeDataTable columns={makeColumnsForSkills(owner)} data={data} />
+      )}
+    </PokeDataTableConditionalFetch>
+  );
+}

--- a/front/pages/api/poke/workspaces/[wId]/apps/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/apps/index.ts
@@ -54,7 +54,7 @@ async function handler(
         status_code: 405,
         api_error: {
           type: "method_not_supported_error",
-          message: "The method passed is not supported, POST is expected.",
+          message: "The method passed is not supported, GET is expected.",
         },
       });
   }

--- a/front/pages/api/poke/workspaces/[wId]/data_source_views/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_source_views/index.ts
@@ -82,7 +82,7 @@ async function handler(
         status_code: 405,
         api_error: {
           type: "method_not_supported_error",
-          message: "The method passed is not supported, POST is expected.",
+          message: "The method passed is not supported, GET is expected.",
         },
       });
   }

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/index.ts
@@ -56,7 +56,7 @@ async function handler(
         status_code: 405,
         api_error: {
           type: "method_not_supported_error",
-          message: "The method passed is not supported, POST is expected.",
+          message: "The method passed is not supported, GET is expected.",
         },
       });
   }

--- a/front/pages/api/poke/workspaces/[wId]/skills/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/skills/index.ts
@@ -1,0 +1,63 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+import type { SkillType } from "@app/types/assistant/skill_configuration";
+
+export type GetPokeSkillsResponseBody = {
+  skills: SkillType[];
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetPokeSkillsResponseBody | void>>,
+  session: SessionWithUser
+): Promise<void> {
+  const { wId } = req.query;
+  if (typeof wId !== "string") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "workspace_not_found",
+        message: "The workspace you're trying to access was not found.",
+      },
+    });
+  }
+
+  const auth = await Authenticator.fromSuperUserSession(session, wId);
+  const owner = auth.workspace();
+  if (!owner || !auth.isDustSuperUser()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_not_found",
+        message: "The workspace you're trying to access was not found.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      const skills = await SkillResource.listSkills(auth);
+
+      return res.status(200).json({
+        skills: skills.map((skill) => skill.toJSON(auth)),
+      });
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForPoke(handler);

--- a/front/pages/api/poke/workspaces/[wId]/skills/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/skills/index.ts
@@ -6,6 +6,7 @@ import type { SessionWithUser } from "@app/lib/iam/provider";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
+import { isString } from "@app/types";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 
 export type GetPokeSkillsResponseBody = {
@@ -18,7 +19,7 @@ async function handler(
   session: SessionWithUser
 ): Promise<void> {
   const { wId } = req.query;
-  if (typeof wId !== "string") {
+  if (!isString(wId)) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {

--- a/front/pages/api/poke/workspaces/[wId]/spaces/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/spaces/index.ts
@@ -54,7 +54,7 @@ async function handler(
         status_code: 405,
         api_error: {
           type: "method_not_supported_error",
-          message: "The method passed is not supported, POST is expected.",
+          message: "The method passed is not supported, GET is expected.",
         },
       });
   }

--- a/front/pages/poke/[wId]/index.tsx
+++ b/front/pages/poke/[wId]/index.tsx
@@ -37,6 +37,7 @@ import {
   PokeAlertDescription,
   PokeAlertTitle,
 } from "@app/components/poke/shadcn/ui/alert";
+import { SkillsDataTable } from "@app/components/poke/skills/table";
 import { SpaceDataTable } from "@app/components/poke/spaces/table";
 import {
   ActiveSubscriptionTable,
@@ -317,6 +318,7 @@ const WorkspacePage = ({
               <TabsTrigger value="featureflags" label="Feature Flags" />
               <TabsTrigger value="groups" label="Groups" />
               <TabsTrigger value="mcpviews" label="MCP Server Views" />
+              <TabsTrigger value="skills" label="Skills" />
               <TabsTrigger value="spaces" label="Spaces" />
 
               <TabsTrigger value="triggers" label="Triggers" />
@@ -344,6 +346,9 @@ const WorkspacePage = ({
                 agentsRetention={agentsRetention}
                 loadOnInit
               />
+            </TabsContent>
+            <TabsContent value="skills">
+              <SkillsDataTable owner={owner} loadOnInit />
             </TabsContent>
             <TabsContent value="apps">
               <AppDataTable owner={owner} loadOnInit />

--- a/front/poke/swr/skills.ts
+++ b/front/poke/swr/skills.ts
@@ -1,0 +1,22 @@
+import type { Fetcher } from "swr";
+
+import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { GetPokeSkillsResponseBody } from "@app/pages/api/poke/workspaces/[wId]/skills";
+import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
+
+export function usePokeSkills({ disabled, owner }: PokeConditionalFetchProps) {
+  const skillsFetcher: Fetcher<GetPokeSkillsResponseBody> = fetcher;
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    `/api/poke/workspaces/${owner.sId}/skills`,
+    skillsFetcher,
+    { disabled }
+  );
+
+  return {
+    data: data?.skills ?? emptyArray(),
+    isLoading: !error && !data,
+    isError: error,
+    mutate,
+  };
+}


### PR DESCRIPTION
## Description

- This PR adds a data table on the poke page for a workspace that lists the skills for the workspace.
- This data table is behind the tab "Skills".

<img width="1811" height="542" alt="Screenshot 2026-01-03 at 11 26 59 PM" src="https://github.com/user-attachments/assets/2c6ab8a4-b6f3-4adb-96cf-00a373d354d7" />


## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.	
