### PR TITLE
[connectors] Add stop reasons to Temporal workflow terminations

### DIFF
--- a/connectors/src/api/delete_connector.ts
+++ b/connectors/src/api/delete_connector.ts
@@ -53,7 +53,7 @@ const _deleteConnectorAPIHandler = async (
   }
   await terminateAllWorkflowsForConnectorId({
     connectorId: connector.id,
-    stopReason: "Connector deletion via API",
+    stopReason: "Connector deleted via API",
   });
   return res.json({
     success: true,

--- a/connectors/src/api/delete_connector.ts
+++ b/connectors/src/api/delete_connector.ts
@@ -51,7 +51,10 @@ const _deleteConnectorAPIHandler = async (
       },
     });
   }
-  await terminateAllWorkflowsForConnectorId(connector.id);
+  await terminateAllWorkflowsForConnectorId({
+    connectorId: connector.id,
+    stopReason: "Connector deletion via API",
+  });
   return res.json({
     success: true,
   });

--- a/connectors/src/connectors/bigquery/index.ts
+++ b/connectors/src/connectors/bigquery/index.ts
@@ -141,7 +141,10 @@ export class BigQueryConnectorManager extends BaseConnectorManager<null> {
         )
       );
     }
-    await stopBigQuerySyncWorkflow(c.id);
+    await stopBigQuerySyncWorkflow({
+      connectorId: c.id,
+      stopReason: "Stopped to update connector configuration",
+    });
     await c.update({ connectionId });
     // We reset all the remote tables "lastUpsertedAt" to null, to force the tables to be
     // upserted again (to update their remoteDatabaseSecret).
@@ -177,7 +180,10 @@ export class BigQueryConnectorManager extends BaseConnectorManager<null> {
   }
 
   async stop(): Promise<Result<undefined, Error>> {
-    const stopRes = await stopBigQuerySyncWorkflow(this.connectorId);
+    const stopRes = await stopBigQuerySyncWorkflow({
+      connectorId: this.connectorId,
+      stopReason: "Stopped via connector STOP command",
+    });
     if (stopRes.isErr()) {
       return stopRes;
     }

--- a/connectors/src/connectors/bigquery/temporal/client.ts
+++ b/connectors/src/connectors/bigquery/temporal/client.ts
@@ -60,9 +60,13 @@ export async function launchBigQuerySyncWorkflow(
   return new Ok(workflowId);
 }
 
-export async function stopBigQuerySyncWorkflow(
-  connectorId: ModelId
-): Promise<Result<void, Error>> {
+export async function stopBigQuerySyncWorkflow({
+  connectorId,
+  stopReason,
+}: {
+  connectorId: ModelId;
+  stopReason: string;
+}): Promise<Result<void, Error>> {
   const client = await getTemporalClient();
   const connector = await ConnectorResource.fetchById(connectorId);
   if (!connector) {
@@ -77,7 +81,7 @@ export async function stopBigQuerySyncWorkflow(
     const handle: WorkflowHandle<typeof bigquerySyncWorkflow> =
       client.workflow.getHandle(workflowId);
     try {
-      await handle.terminate();
+      await handle.terminate(stopReason);
     } catch (e) {
       if (!(e instanceof WorkflowNotFoundError)) {
         throw e;

--- a/connectors/src/connectors/confluence/index.ts
+++ b/connectors/src/connectors/confluence/index.ts
@@ -191,7 +191,10 @@ export class ConfluenceConnectorManager extends BaseConnectorManager<null> {
   }
 
   async stop(): Promise<Result<undefined, Error>> {
-    const res = await stopConfluenceSyncWorkflow(this.connectorId);
+    const res = await stopConfluenceSyncWorkflow({
+      connectorId: this.connectorId,
+      stopReason: "Stopped via connector STOP command",
+    });
     if (res.isErr()) {
       return res;
     }

--- a/connectors/src/connectors/confluence/temporal/client.ts
+++ b/connectors/src/connectors/confluence/temporal/client.ts
@@ -131,9 +131,13 @@ export async function launchConfluenceRemoveSpacesSyncWorkflow(
   return new Ok(workflowId);
 }
 
-export async function stopConfluenceSyncWorkflow(
-  connectorId: ModelId
-): Promise<Result<void, Error>> {
+export async function stopConfluenceSyncWorkflow({
+  connectorId,
+  stopReason,
+}: {
+  connectorId: ModelId;
+  stopReason: string;
+}): Promise<Result<void, Error>> {
   const client = await getTemporalClient();
   const connector = await ConnectorResource.fetchById(connectorId);
   if (!connector) {
@@ -148,7 +152,7 @@ export async function stopConfluenceSyncWorkflow(
     const handle: WorkflowHandle<typeof confluenceSyncWorkflow> =
       client.workflow.getHandle(workflowId);
     try {
-      await handle.terminate();
+      await handle.terminate(stopReason);
     } catch (e) {
       if (!(e instanceof WorkflowNotFoundError)) {
         throw e;

--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -169,7 +169,10 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
         webhooksEnabledAt: null,
       });
 
-      await terminateAllWorkflowsForConnectorId(this.connectorId);
+      await terminateAllWorkflowsForConnectorId({
+        connectorId: this.connectorId,
+        stopReason: "Stopped via connector STOP command",
+      });
 
       return new Ok(undefined);
     } catch (err) {

--- a/connectors/src/connectors/gong/index.ts
+++ b/connectors/src/connectors/gong/index.ts
@@ -205,6 +205,7 @@ export class GongConnectorManager extends BaseConnectorManager<null> {
     const result = await pauseSchedule({
       connector,
       scheduleId: makeGongSyncScheduleId(connector),
+      stopReason: "Stopped via connector STOP command",
     });
     if (result.isErr()) {
       return result;

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -788,7 +788,10 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
   }
 
   async stop(): Promise<Result<undefined, Error>> {
-    await terminateAllWorkflowsForConnectorId(this.connectorId);
+    await terminateAllWorkflowsForConnectorId({
+      connectorId: this.connectorId,
+      stopReason: "Stopped via connector STOP command",
+    });
     return new Ok(undefined);
   }
 

--- a/connectors/src/connectors/google_drive/temporal/client.ts
+++ b/connectors/src/connectors/google_drive/temporal/client.ts
@@ -168,7 +168,7 @@ export async function launchGoogleGarbageCollector(
     const handle: WorkflowHandle<typeof googleDriveGarbageCollectorWorkflow> =
       client.workflow.getHandle(workflowId);
     try {
-      await handle.terminate();
+      await handle.terminate("Terminating before restarting workflow");
     } catch (e) {
       if (!(e instanceof WorkflowNotFoundError)) {
         throw e;
@@ -221,7 +221,7 @@ export async function launchGoogleFixParentsConsistencyWorkflow(
       typeof googleDriveFixParentsConsistencyWorkflow
     > = client.workflow.getHandle(workflowId);
     try {
-      await handle.terminate();
+      await handle.terminate("Terminating before restarting workflow");
     } catch (e) {
       if (!(e instanceof WorkflowNotFoundError)) {
         throw e;

--- a/connectors/src/connectors/intercom/index.ts
+++ b/connectors/src/connectors/intercom/index.ts
@@ -240,7 +240,9 @@ export class IntercomConnectorManager extends BaseConnectorManager<null> {
       return new Err(new Error("Connector not found"));
     }
 
-    const res = await stopIntercomSchedulesAndWorkflows(connector);
+    const res = await stopIntercomSchedulesAndWorkflows(connector, {
+      stopReason: "Stopped via connector STOP command",
+    });
     if (res.isErr()) {
       return res;
     }

--- a/connectors/src/connectors/intercom/temporal/client.ts
+++ b/connectors/src/connectors/intercom/temporal/client.ts
@@ -251,7 +251,7 @@ export async function deleteIntercomSchedules(
   connector: ConnectorResource
 ): Promise<Result<void, Error>> {
   await stopIntercomSchedulesAndWorkflows(connector, {
-    stopReason: "Connector deleted.",
+    stopReason: "Connector deleted",
   });
 
   const helpCenterResult = await deleteSchedule({

--- a/connectors/src/connectors/microsoft/index.ts
+++ b/connectors/src/connectors/microsoft/index.ts
@@ -463,7 +463,10 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
   }
 
   async stop(): Promise<Result<undefined, Error>> {
-    await terminateAllWorkflowsForConnectorId(this.connectorId);
+    await terminateAllWorkflowsForConnectorId({
+      connectorId: this.connectorId,
+      stopReason: "Stopped via connector STOP command",
+    });
     return new Ok(undefined);
   }
 

--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -257,7 +257,10 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
     }
 
     try {
-      await stopNotionSyncWorkflow(connector.id);
+      await stopNotionSyncWorkflow({
+        connectorId: connector.id,
+        stopReason: "Stopped via connector STOP command",
+      });
     } catch (e) {
       logger.error(
         {

--- a/connectors/src/connectors/notion/lib/cli.ts
+++ b/connectors/src/connectors/notion/lib/cli.ts
@@ -682,7 +682,10 @@ export const notion = async ({
           { connectorId: connector.id },
           "[Admin] Stopping notion garbage collector"
         );
-        await stopNotionGarbageCollectorWorkflow(connector.id);
+        await stopNotionGarbageCollectorWorkflow({
+          connectorId: connector.id,
+          stopReason: "Stopped via CLI",
+        });
       }
       return { success: true };
     }

--- a/connectors/src/connectors/notion/temporal/client.ts
+++ b/connectors/src/connectors/notion/temporal/client.ts
@@ -12,8 +12,10 @@ import {
   QUEUE_NAME,
 } from "@connectors/connectors/notion/temporal/config";
 import { notionDeletionCrawlSignal } from "@connectors/connectors/notion/temporal/signals";
-import { notionSyncWorkflow } from "@connectors/connectors/notion/temporal/workflows/";
-import { updateOrphanedResourcesParentsWorkflow } from "@connectors/connectors/notion/temporal/workflows/";
+import {
+  notionSyncWorkflow,
+  updateOrphanedResourcesParentsWorkflow,
+} from "@connectors/connectors/notion/temporal/workflows/";
 import { notionDeletionCrawlWorkflow } from "@connectors/connectors/notion/temporal/workflows/deletion_crawl";
 import { notionGarbageCollectionWorkflow } from "@connectors/connectors/notion/temporal/workflows/garbage_collection";
 import { processDatabaseUpsertQueueWorkflow } from "@connectors/connectors/notion/temporal/workflows/upsert_database_queue";
@@ -172,9 +174,13 @@ export async function launchNotionGarbageCollectorWorkflow(
   );
 }
 
-export async function stopNotionSyncWorkflow(
-  connectorId: ModelId
-): Promise<void> {
+export async function stopNotionSyncWorkflow({
+  connectorId,
+  stopReason,
+}: {
+  connectorId: ModelId;
+  stopReason: string;
+}): Promise<void> {
   const connector = await ConnectorResource.fetchById(connectorId);
   if (!connector) {
     throw new Error(`Connector not found. ConnectorId: ${connectorId}`);
@@ -221,21 +227,25 @@ export async function stopNotionSyncWorkflow(
     "Terminating existing Notion sync workflow."
   );
 
-  await handle.terminate();
+  await handle.terminate(stopReason);
 
   logger.info(
     { workspaceId: dataSourceConfig.workspaceId, provider: "notion" },
     "Terminated Notion sync workflow."
   );
 
-  await stopNotionGarbageCollectorWorkflow(connectorId);
-  await stopProcessDatabaseUpsertQueueWorkflow(connectorId);
-  await stopNotionDeletionCrawlWorkflow(connectorId);
+  await stopNotionGarbageCollectorWorkflow({ connectorId, stopReason });
+  await stopProcessDatabaseUpsertQueueWorkflow({ connectorId, stopReason });
+  await stopNotionDeletionCrawlWorkflow({ connectorId, stopReason });
 }
 
-export async function stopNotionGarbageCollectorWorkflow(
-  connectorId: ModelId
-): Promise<void> {
+export async function stopNotionGarbageCollectorWorkflow({
+  connectorId,
+  stopReason,
+}: {
+  connectorId: ModelId;
+  stopReason: string;
+}): Promise<void> {
   const connector = await ConnectorResource.fetchById(connectorId);
   if (!connector) {
     throw new Error(`Connector not found. ConnectorId: ${connectorId}`);
@@ -270,7 +280,7 @@ export async function stopNotionGarbageCollectorWorkflow(
     "Terminating existing Notion garbage collector workflow."
   );
 
-  await handle.terminate();
+  await handle.terminate(stopReason);
 
   logger.info(
     { workspaceId: dataSourceConfig.workspaceId, provider: "notion" },
@@ -278,9 +288,13 @@ export async function stopNotionGarbageCollectorWorkflow(
   );
 }
 
-export async function stopProcessDatabaseUpsertQueueWorkflow(
-  connectorId: ModelId
-): Promise<void> {
+export async function stopProcessDatabaseUpsertQueueWorkflow({
+  connectorId,
+  stopReason,
+}: {
+  connectorId: ModelId;
+  stopReason: string;
+}): Promise<void> {
   const connector = await ConnectorResource.fetchById(connectorId);
   if (!connector) {
     throw new Error(`Connector not found. ConnectorId: ${connectorId}`);
@@ -315,7 +329,7 @@ export async function stopProcessDatabaseUpsertQueueWorkflow(
     "Terminating existing Process database upsert queue workflow."
   );
 
-  await handle.terminate();
+  await handle.terminate(stopReason);
 
   logger.info(
     { connectorId },
@@ -323,9 +337,13 @@ export async function stopProcessDatabaseUpsertQueueWorkflow(
   );
 }
 
-export async function stopNotionDeletionCrawlWorkflow(
-  connectorId: ModelId
-): Promise<void> {
+export async function stopNotionDeletionCrawlWorkflow({
+  connectorId,
+  stopReason,
+}: {
+  connectorId: ModelId;
+  stopReason: string;
+}): Promise<void> {
   const connector = await ConnectorResource.fetchById(connectorId);
   if (!connector) {
     throw new Error(`Connector not found. ConnectorId: ${connectorId}`);
@@ -360,7 +378,7 @@ export async function stopNotionDeletionCrawlWorkflow(
     "Terminating existing Notion deletion crawl workflow."
   );
 
-  await handle.terminate();
+  await handle.terminate(stopReason);
 
   logger.info(
     { workspaceId: dataSourceConfig.workspaceId, provider: "notion" },

--- a/connectors/src/connectors/salesforce/index.ts
+++ b/connectors/src/connectors/salesforce/index.ts
@@ -105,7 +105,11 @@ export class SalesforceConnectorManager extends BaseConnectorManager<null> {
       await SalesforceSyncedQueryResource.fetchByConnector(connector);
     await Promise.all(
       queries.map((query) =>
-        stopSalesforceSyncQueryWorkflow(connector.id, query.id)
+        stopSalesforceSyncQueryWorkflow({
+          connectorId: connector.id,
+          queryId: query.id,
+          stopReason: "Stopped to update connector configuration",
+        })
       )
     );
     await connector.update({ connectionId });
@@ -142,10 +146,17 @@ export class SalesforceConnectorManager extends BaseConnectorManager<null> {
 
     await Promise.all(
       queries.map((query) =>
-        stopSalesforceSyncQueryWorkflow(connector.id, query.id)
+        stopSalesforceSyncQueryWorkflow({
+          connectorId: connector.id,
+          queryId: query.id,
+          stopReason: "Stopped via connector STOP command",
+        })
       )
     );
-    const stopRes = await stopSalesforceSyncWorkflow(this.connectorId);
+    const stopRes = await stopSalesforceSyncWorkflow({
+      connectorId: this.connectorId,
+      stopReason: "Stopped via connector STOP command",
+    });
     if (stopRes.isErr()) {
       return stopRes;
     }

--- a/connectors/src/connectors/salesforce/temporal/client.ts
+++ b/connectors/src/connectors/salesforce/temporal/client.ts
@@ -61,9 +61,13 @@ export async function launchSalesforceSyncWorkflow(
   return new Ok(workflowId);
 }
 
-export async function stopSalesforceSyncWorkflow(
-  connectorId: ModelId
-): Promise<Result<void, Error>> {
+export async function stopSalesforceSyncWorkflow({
+  connectorId,
+  stopReason,
+}: {
+  connectorId: ModelId;
+  stopReason: string;
+}): Promise<Result<void, Error>> {
   const client = await getTemporalClient();
   const connector = await ConnectorResource.fetchById(connectorId);
   if (!connector) {
@@ -78,7 +82,7 @@ export async function stopSalesforceSyncWorkflow(
     const handle: WorkflowHandle<typeof salesforceSyncWorkflow> =
       client.workflow.getHandle(workflowId);
     try {
-      await handle.terminate();
+      await handle.terminate(stopReason);
     } catch (e) {
       if (!(e instanceof WorkflowNotFoundError)) {
         throw e;
@@ -134,10 +138,15 @@ export async function launchSalesforceSyncQueryWorkflow(
   return new Ok(workflowId);
 }
 
-export async function stopSalesforceSyncQueryWorkflow(
-  connectorId: ModelId,
-  queryId: ModelId
-): Promise<Result<void, Error>> {
+export async function stopSalesforceSyncQueryWorkflow({
+  connectorId,
+  queryId,
+  stopReason,
+}: {
+  connectorId: ModelId;
+  queryId: ModelId;
+  stopReason: string;
+}): Promise<Result<void, Error>> {
   const client = await getTemporalClient();
   const connector = await ConnectorResource.fetchById(connectorId);
   if (!connector) {
@@ -156,7 +165,7 @@ export async function stopSalesforceSyncQueryWorkflow(
     const handle: WorkflowHandle<typeof salesforceSyncQueryWorkflow> =
       client.workflow.getHandle(workflowId);
     try {
-      await handle.terminate();
+      await handle.terminate(stopReason);
     } catch (e) {
       if (!(e instanceof WorkflowNotFoundError)) {
         throw e;

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -720,7 +720,10 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
       );
     }
 
-    await terminateAllWorkflowsForConnectorId(this.connectorId);
+    await terminateAllWorkflowsForConnectorId({
+      connectorId: this.connectorId,
+      stopReason: "Stopped via connector STOP command",
+    });
 
     return new Ok(undefined);
   }

--- a/connectors/src/connectors/snowflake/index.ts
+++ b/connectors/src/connectors/snowflake/index.ts
@@ -151,7 +151,10 @@ export class SnowflakeConnectorManager extends BaseConnectorManager<null> {
         )
       );
     }
-    await stopSnowflakeSyncWorkflow(c.id);
+    await stopSnowflakeSyncWorkflow({
+      connectorId: c.id,
+      stopReason: "Stopped to update connector configuration",
+    });
     await c.update({ connectionId });
     // We reset all the remote tables "lastUpsertedAt" to null, to force the tables to be
     // upserted again (to update their remoteDatabaseSecret).
@@ -188,7 +191,10 @@ export class SnowflakeConnectorManager extends BaseConnectorManager<null> {
   }
 
   async stop(): Promise<Result<undefined, Error>> {
-    const stopRes = await stopSnowflakeSyncWorkflow(this.connectorId);
+    const stopRes = await stopSnowflakeSyncWorkflow({
+      connectorId: this.connectorId,
+      stopReason: "Stopped via connector STOP command",
+    });
     if (stopRes.isErr()) {
       return stopRes;
     }

--- a/connectors/src/connectors/snowflake/temporal/client.ts
+++ b/connectors/src/connectors/snowflake/temporal/client.ts
@@ -80,9 +80,13 @@ export async function launchSnowflakeSyncWorkflow(
   }
 }
 
-export async function stopSnowflakeSyncWorkflow(
-  connectorId: ModelId
-): Promise<Result<void, Error>> {
+export async function stopSnowflakeSyncWorkflow({
+  connectorId,
+  stopReason,
+}: {
+  connectorId: ModelId;
+  stopReason: string;
+}): Promise<Result<void, Error>> {
   const client = await getTemporalClient();
   const connector = await ConnectorResource.fetchById(connectorId);
   if (!connector) {
@@ -97,7 +101,7 @@ export async function stopSnowflakeSyncWorkflow(
     const handle: WorkflowHandle<typeof snowflakeSyncWorkflow> =
       client.workflow.getHandle(workflowId);
     try {
-      await handle.terminate();
+      await handle.terminate(stopReason);
     } catch (e) {
       if (!(e instanceof WorkflowNotFoundError)) {
         throw e;

--- a/connectors/src/connectors/webcrawler/index.ts
+++ b/connectors/src/connectors/webcrawler/index.ts
@@ -157,7 +157,10 @@ export class WebcrawlerConnectorManager extends BaseConnectorManager<WebCrawlerC
         }
       }
     } else {
-      const res = await stopCrawlWebsiteWorkflow(this.connectorId);
+      const res = await stopCrawlWebsiteWorkflow({
+        connectorId: this.connectorId,
+        stopReason: "Stopped via connector STOP command",
+      });
       if (res.isErr()) {
         return res;
       }
@@ -372,7 +375,10 @@ export class WebcrawlerConnectorManager extends BaseConnectorManager<WebCrawlerC
 
     await webcrawlerConfig.setCustomHeaders(headersForUpdate);
 
-    const stopRes = await stopCrawlWebsiteWorkflow(connector.id);
+    const stopRes = await stopCrawlWebsiteWorkflow({
+      connectorId: connector.id,
+      stopReason: "Stopped to update connector configuration",
+    });
     if (stopRes.isErr()) {
       return new Err(stopRes.error);
     }

--- a/connectors/src/connectors/webcrawler/temporal/client.ts
+++ b/connectors/src/connectors/webcrawler/temporal/client.ts
@@ -58,7 +58,7 @@ export async function launchCrawlWebsiteWorkflow(
     const handle: WorkflowHandle<typeof crawlWebsiteWorkflow> =
       client.workflow.getHandle(workflowId);
     try {
-      await handle.terminate();
+      await handle.terminate("Terminating before restarting workflow");
     } catch (e) {
       if (!(e instanceof WorkflowNotFoundError)) {
         throw e;
@@ -95,9 +95,13 @@ export async function launchCrawlWebsiteWorkflow(
   }
 }
 
-export async function stopCrawlWebsiteWorkflow(
-  connectorId: ModelId
-): Promise<Result<void, Error>> {
+export async function stopCrawlWebsiteWorkflow({
+  connectorId,
+  stopReason,
+}: {
+  connectorId: ModelId;
+  stopReason: string;
+}): Promise<Result<void, Error>> {
   const client = await getTemporalClient();
 
   const workflowId = crawlWebsiteWorkflowId(connectorId);
@@ -105,7 +109,7 @@ export async function stopCrawlWebsiteWorkflow(
     const handle: WorkflowHandle<typeof crawlWebsiteWorkflow> =
       client.workflow.getHandle(workflowId);
     try {
-      await handle.terminate();
+      await handle.terminate(stopReason);
     } catch (e) {
       if (!(e instanceof WorkflowNotFoundError)) {
         throw e;

--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -236,7 +236,9 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
       logger.error({ connectorId }, "[Zendesk] Connector not found.");
       throw new Error("[Zendesk] Connector not found.");
     }
-    return stopZendeskWorkflows(connector);
+    return stopZendeskWorkflows(connector, {
+      stopReason: "Stopped via connector STOP command",
+    });
   }
 
   /**

--- a/connectors/src/connectors/zendesk/temporal/client.ts
+++ b/connectors/src/connectors/zendesk/temporal/client.ts
@@ -101,7 +101,12 @@ export async function launchZendeskSyncWorkflow(
 }
 
 export async function stopZendeskWorkflows(
-  connector: ConnectorResource
+  connector: ConnectorResource,
+  {
+    stopReason,
+  }: {
+    stopReason: string;
+  }
 ): Promise<Result<undefined, Error>> {
   const client = await getTemporalClient();
 
@@ -114,7 +119,7 @@ export async function stopZendeskWorkflows(
       const handle: WorkflowHandle<typeof zendeskSyncWorkflow> =
         client.workflow.getHandle(workflowId);
       try {
-        await handle.terminate();
+        await handle.terminate(stopReason);
       } catch (e) {
         if (!(e instanceof WorkflowNotFoundError)) {
           throw e;

--- a/connectors/src/lib/temporal.ts
+++ b/connectors/src/lib/temporal.ts
@@ -128,9 +128,13 @@ export async function terminateWorkflow(workflowId: string, reason?: string) {
   return false;
 }
 
-export async function terminateAllWorkflowsForConnectorId(
-  connectorId: ModelId
-) {
+export async function terminateAllWorkflowsForConnectorId({
+  connectorId,
+  stopReason,
+}: {
+  connectorId: ModelId;
+  stopReason: string;
+}) {
   const client = await getTemporalClient();
 
   const workflowInfos = client.workflow.list({
@@ -152,7 +156,7 @@ export async function terminateAllWorkflowsForConnectorId(
 
     const workflowHandle = client.workflow.getHandle(handle.workflowId);
     try {
-      await workflowHandle.terminate();
+      await workflowHandle.terminate(stopReason);
     } catch (err) {
       // Intentionally ignore errors that indicate the workflow no longer exists.
       if (err instanceof WorkflowNotFoundError) {


### PR DESCRIPTION
## Description

- This PR adds a reason on most if not all programmatic workflow terminations from within connectors' code.
- This reason will be logged within Temporal Cloud to help with the debugging.
- No reason currently appears as `terminated by user via frontend` (the backend in this sentence being Temporal Cloud and the front-end the API user).
- Will refine the `Stopped via connector STOP command` in a follow up PR to differentiate pauses on `ExternalOAuthTokenError`, pauses via API, etc...

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy connectors.
