### PR TITLE
feat(front-mcp): add OAuth and file attachment support to Front MCP server

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1648,11 +1648,9 @@ export const INTERNAL_MCP_SERVERS = {
   front: {
     id: 1018,
     availability: "manual",
-    allowMultipleInstances: false,
-    isRestricted: ({ featureFlags }) => {
-      return !featureFlags.includes("front_tool");
-    },
-    isPreview: true,
+    allowMultipleInstances: true,
+    isRestricted: undefined,
+    isPreview: false,
     tools_stakes: {
       search_conversations: "never_ask",
       get_conversation: "never_ask",
@@ -1680,17 +1678,18 @@ export const INTERNAL_MCP_SERVERS = {
       version: "1.0.0",
       description:
         "Manage support conversations, messages, and customer interactions.",
-      authorization: null,
+      authorization: {
+        provider: "front" as const,
+        supported_use_cases: ["platform_actions", "personal_actions"] as const,
+      },
       icon: "FrontLogo",
       documentationUrl: "https://dev.frontapp.com/reference/introduction",
       instructions:
         "When handling support tickets:\n" +
         "- Always check customer history before replying using get_customer_history\n" +
         "- Auto-tag conversations based on issue type (bug, feature-request, billing)\n" +
-        "- Assign to teammate 'ilias' if T1 cannot resolve after three attempts\n" +
         "- Use LLM-friendly timeline format for conversation data\n" +
         "- Include full context (metadata, custom fields) in responses",
-      developerSecretSelection: "required",
     },
   },
   skill_management: {

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -208,6 +208,9 @@ const config = {
   getOAuthFreshserviceDomain: (): string => {
     return EnvironmentConfig.getEnvVariable("OAUTH_FRESHWORKS_DOMAIN");
   },
+  getOAuthFrontClientId: (): string => {
+    return EnvironmentConfig.getEnvVariable("OAUTH_FRONT_CLIENT_ID");
+  },
   getOAuthJiraClientId: (): string => {
     return EnvironmentConfig.getEnvVariable("OAUTH_JIRA_CLIENT_ID");
   },

--- a/front/lib/api/oauth.ts
+++ b/front/lib/api/oauth.ts
@@ -11,6 +11,7 @@ import { DatabricksOAuthProvider } from "@app/lib/api/oauth/providers/databricks
 import { DiscordOAuthProvider } from "@app/lib/api/oauth/providers/discord";
 import { FathomOAuthProvider } from "@app/lib/api/oauth/providers/fathom";
 import { FreshserviceOAuthProvider } from "@app/lib/api/oauth/providers/freshservice";
+import { FrontOAuthProvider } from "@app/lib/api/oauth/providers/front";
 import { GithubOAuthProvider } from "@app/lib/api/oauth/providers/github";
 import { GmailOAuthProvider } from "@app/lib/api/oauth/providers/gmail";
 import { GongOAuthProvider } from "@app/lib/api/oauth/providers/gong";
@@ -60,6 +61,7 @@ const _PROVIDER_STRATEGIES: Record<OAuthProvider, BaseOAuthStrategyProvider> = {
   discord: new DiscordOAuthProvider(),
   fathom: new FathomOAuthProvider(),
   freshservice: new FreshserviceOAuthProvider(),
+  front: new FrontOAuthProvider(),
   github: new GithubOAuthProvider(),
   gmail: new GmailOAuthProvider(),
   gong: new GongOAuthProvider(),

--- a/front/lib/api/oauth/providers/front.ts
+++ b/front/lib/api/oauth/providers/front.ts
@@ -1,0 +1,48 @@
+import type { ParsedUrlQuery } from "querystring";
+
+import config from "@app/lib/api/config";
+import type { BaseOAuthStrategyProvider } from "@app/lib/api/oauth/providers/base_oauth_stragegy_provider";
+import {
+  finalizeUriForProvider,
+  getStringFromQuery,
+} from "@app/lib/api/oauth/utils";
+import type { ExtraConfigType } from "@app/pages/w/[wId]/oauth/[provider]/setup";
+import type { OAuthConnectionType, OAuthUseCase } from "@app/types/oauth/lib";
+
+export class FrontOAuthProvider implements BaseOAuthStrategyProvider {
+  setupUri({
+    connection,
+  }: {
+    connection: OAuthConnectionType;
+    useCase: OAuthUseCase;
+  }) {
+    // Front OAuth scopes - see https://dev.frontapp.com/docs/oauth-overview
+    const scopes = ["shared:*"];
+
+    return (
+      `https://app.frontapp.com/oauth/authorize` +
+      `?client_id=${config.getOAuthFrontClientId()}` +
+      `&redirect_uri=${encodeURIComponent(finalizeUriForProvider("front"))}` +
+      `&response_type=code` +
+      `&scope=${encodeURIComponent(scopes.join(" "))}` +
+      `&state=${connection.connection_id}`
+    );
+  }
+
+  codeFromQuery(query: ParsedUrlQuery) {
+    return getStringFromQuery(query, "code");
+  }
+
+  connectionIdFromQuery(query: ParsedUrlQuery) {
+    return getStringFromQuery(query, "state");
+  }
+
+  isExtraConfigValid(extraConfig: ExtraConfigType, useCase: OAuthUseCase) {
+    if (useCase === "personal_actions" || useCase === "platform_actions") {
+      if (extraConfig.mcp_server_id) {
+        return true;
+      }
+    }
+    return Object.keys(extraConfig).length === 0;
+  }
+}

--- a/front/types/oauth/lib.ts
+++ b/front/types/oauth/lib.ts
@@ -31,6 +31,7 @@ export const OAUTH_PROVIDERS = [
   "discord",
   "fathom",
   "freshservice",
+  "front",
   "github",
   "google_drive",
   "gmail",
@@ -59,6 +60,7 @@ export const OAUTH_PROVIDER_NAMES: Record<OAuthProvider, string> = {
   discord: "Discord",
   fathom: "Fathom",
   freshservice: "Freshservice",
+  front: "Front",
   github: "GitHub",
   gmail: "Gmail",
   google_drive: "Google",
@@ -232,6 +234,7 @@ export const getProviderRequiredOAuthCredentialInputs = async ({
         return result;
       }
       return null;
+    case "front":
     case "hubspot":
     case "slack":
     case "slack_tools":


### PR DESCRIPTION
Replace manual API token configuration with standard OAuth 2.0 flow:
- Add "front" OAuth provider with shared:* scope
- Update Front MCP server constants to use OAuth authorization
- Update all tool implementations to use OAuth token via authInfo

Add file attachment support to messaging tools:
- send_message: support conversation_file and external_file attachments
- create_conversation: support file attachments for new outbound messages
- Use multipart/form-data for attachment uploads

This makes the Front MCP server a standard OAuth-enabled MCP for GA.