### PR TITLE
feat: Add configurable ports and OAuth redirect support

### DIFF
--- a/core/bin/core_api.rs
+++ b/core/bin/core_api.rs
@@ -340,8 +340,11 @@ fn main() {
         let (tx1, rx1) = tokio::sync::oneshot::channel::<()>();
         let (tx2, rx2) = tokio::sync::oneshot::channel::<()>();
 
+        let port = std::env::var("CORE_PORT").unwrap_or_else(|_| "3001".to_string());
+        let addr = format!("[::]:{}", port);
+
         let srv = axum::serve(
-            TcpListener::bind::<std::net::SocketAddr>("[::]:3001".parse().unwrap()).await?,
+            TcpListener::bind::<std::net::SocketAddr>(addr.parse().unwrap()).await?,
             app.into_make_service(),
         )
         .with_graceful_shutdown(async {
@@ -356,7 +359,7 @@ fn main() {
             tx2.send(()).ok();
         });
 
-        info!(pid = std::process::id() as u64, "dust_api server started");
+        info!(pid = std::process::id() as u64, port = %port, "dust_api server started");
 
         let mut stream = signal(SignalKind::terminate()).unwrap();
         stream.recv().await;

--- a/core/bin/oauth.rs
+++ b/core/bin/oauth.rs
@@ -21,8 +21,11 @@ fn main() {
         let (tx1, rx1) = tokio::sync::oneshot::channel::<()>();
         let (tx2, rx2) = tokio::sync::oneshot::channel::<()>();
 
+        let port = std::env::var("OAUTH_PORT").unwrap_or_else(|_| "3006".to_string());
+        let addr = format!("[::]:{}", port);
+
         let srv = axum::serve(
-            TcpListener::bind::<std::net::SocketAddr>("[::]:3006".parse().unwrap()).await?,
+            TcpListener::bind::<std::net::SocketAddr>(addr.parse().unwrap()).await?,
             app.into_make_service(),
         )
         .with_graceful_shutdown(async {
@@ -37,7 +40,7 @@ fn main() {
             tx2.send(()).ok();
         });
 
-        info!(pid = std::process::id() as u64, "oauth server started");
+        info!(pid = std::process::id() as u64, port = %port, "oauth server started");
 
         let mut stream = signal(SignalKind::terminate()).unwrap();
         stream.recv().await;

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -18,6 +18,14 @@ const config = {
       "NEXT_PUBLIC_DUST_CLIENT_FACING_URL"
     );
   },
+  // For OAuth/WorkOS redirects. Allows overriding the redirect base URL separately
+  // from NEXT_PUBLIC_DUST_CLIENT_FACING_URL. Falls back to getClientFacingUrl() when not set.
+  getAuthRedirectBaseUrl: (): string => {
+    return (
+      EnvironmentConfig.getOptionalEnvVariable("DUST_AUTH_REDIRECT_BASE_URL") ??
+      config.getClientFacingUrl()
+    );
+  },
   getDustApiAudience: (): string => {
     return EnvironmentConfig.getEnvVariable("DUST_API_AUDIENCE");
   },

--- a/front/lib/api/oauth/utils.ts
+++ b/front/lib/api/oauth/utils.ts
@@ -10,7 +10,8 @@ export function finalizeUriForProvider(provider: OAuthProvider): string {
   if (isDevelopment() && provider === "fathom") {
     return config.getDevOAuthFathomRedirectBaseUrl() + "/oauth/fathom/finalize";
   }
-  return config.getClientFacingUrl() + `/oauth/${provider}/finalize`;
+  // Use auth redirect base URL for OAuth callbacks
+  return config.getAuthRedirectBaseUrl() + `/oauth/${provider}/finalize`;
 }
 
 export function getStringFromQuery(

--- a/front/pages/api/workos/[action].ts
+++ b/front/pages/api/workos/[action].ts
@@ -91,7 +91,8 @@ async function handleLogin(req: NextApiRequest, res: NextApiResponse) {
     const authorizationUrl = getWorkOS().userManagement.getAuthorizationUrl({
       // Specify that we'd like AuthKit to handle the authentication flow
       provider: "authkit",
-      redirectUri: `${config.getClientFacingUrl()}/api/workos/callback`,
+      // Use auth redirect base URL for WorkOS callbacks
+      redirectUri: `${config.getAuthRedirectBaseUrl()}/api/workos/callback`,
       clientId: config.getWorkOSClientId(),
       ...enterpriseParams,
       state:

--- a/init_dev_container.sh
+++ b/init_dev_container.sh
@@ -1,28 +1,35 @@
 ## This is the init script used to initialize the development environment.
+## Supports parameterized PostgreSQL connection via environment variables:
+##   POSTGRES_PORT (default: 5432)
+##   POSTGRES_HOST (default: localhost)
+
+# Use environment variables with defaults
+POSTGRES_PORT="${POSTGRES_PORT:-5432}"
+POSTGRES_HOST="${POSTGRES_HOST:-localhost}"
+POSTGRES_URI="postgres://dev:dev@${POSTGRES_HOST}:${POSTGRES_PORT}/"
 
 ## Initializing PostgresSQL databases
 
-
 if [[ "$1" == "--reset-db" ]]; then
-    psql "postgres://dev:dev@localhost:5432/" -c "DROP DATABASE dust_api;"
-    psql "postgres://dev:dev@localhost:5432/" -c "DROP DATABASE dust_databases_store;"
-    psql "postgres://dev:dev@localhost:5432/" -c "DROP DATABASE dust_front;"
-    psql "postgres://dev:dev@localhost:5432/" -c "DROP DATABASE dust_front_test;"
-    psql "postgres://dev:dev@localhost:5432/" -c "DROP DATABASE dust_connectors;"
-    psql "postgres://dev:dev@localhost:5432/" -c "DROP DATABASE dust_connectors_test;"
-    psql "postgres://dev:dev@localhost:5432/" -c "DROP DATABASE dust_oauth;"
+    psql "$POSTGRES_URI" -c "DROP DATABASE dust_api;"
+    psql "$POSTGRES_URI" -c "DROP DATABASE dust_databases_store;"
+    psql "$POSTGRES_URI" -c "DROP DATABASE dust_front;"
+    psql "$POSTGRES_URI" -c "DROP DATABASE dust_front_test;"
+    psql "$POSTGRES_URI" -c "DROP DATABASE dust_connectors;"
+    psql "$POSTGRES_URI" -c "DROP DATABASE dust_connectors_test;"
+    psql "$POSTGRES_URI" -c "DROP DATABASE dust_oauth;"
 else
     echo "Skipping database reset. Use --reset-db to drop existing databases."
 fi
 
 
-psql "postgres://dev:dev@localhost:5432/" -c "CREATE DATABASE dust_api;";
-psql "postgres://dev:dev@localhost:5432/" -c "CREATE DATABASE dust_databases_store;";
-psql "postgres://dev:dev@localhost:5432/" -c "CREATE DATABASE dust_front;";
-psql "postgres://dev:dev@localhost:5432/" -c "CREATE DATABASE dust_front_test;";
-psql "postgres://dev:dev@localhost:5432/" -c "CREATE DATABASE dust_connectors;";
-psql "postgres://dev:dev@localhost:5432/" -c "CREATE DATABASE dust_connectors_test;";
-psql "postgres://dev:dev@localhost:5432/" -c "CREATE DATABASE dust_oauth;";
+psql "$POSTGRES_URI" -c "CREATE DATABASE dust_api;";
+psql "$POSTGRES_URI" -c "CREATE DATABASE dust_databases_store;";
+psql "$POSTGRES_URI" -c "CREATE DATABASE dust_front;";
+psql "$POSTGRES_URI" -c "CREATE DATABASE dust_front_test;";
+psql "$POSTGRES_URI" -c "CREATE DATABASE dust_connectors;";
+psql "$POSTGRES_URI" -c "CREATE DATABASE dust_connectors_test;";
+psql "$POSTGRES_URI" -c "CREATE DATABASE dust_oauth;";
 
 ## Initilizing Qdrant collections
 cd core/


### PR DESCRIPTION
## Description

support running multiple environments with different ports:

- **core/bin/core_api.rs, core/bin/oauth.rs**: Make server ports configurable via `CORE_PORT` and `OAUTH_PORT` environment variables (defaulting to 3001 and 3006)
- **front/lib/api/config.ts**: Add `getAuthRedirectBaseUrl()` to support OAuth callbacks through a fixed port (for dust-hive port forwarding)
- **front/lib/api/oauth/utils.ts, front/pages/api/workos/[action].ts**: Use auth redirect base URL for OAuth/WorkOS callbacks
- **init_dev_container.sh**: Parameterize PostgreSQL host/port via `POSTGRES_HOST` and `POSTGRES_PORT` env vars
- **tools/docker-compose.dust-hive.yml**: Base docker-compose configuration for dust-hive environments

## Tests

These are configuration-only changes with sensible defaults that match current behavior. Tested manually via dust-hive environment setup.

## Risk

Low - all changes use environment variables with defaults matching current hardcoded values, so existing setups are unaffected.

## Deploy Plan

No deployment needed - these are development infrastructure changes.
