### PR TITLE
[front] Add stop reasons to Temporal workflow terminations

### DIFF
--- a/front/lib/api/subscription.ts
+++ b/front/lib/api/subscription.ts
@@ -24,6 +24,7 @@ export async function restoreWorkspaceAfterSubscription(auth: Authenticator) {
   }
   const scrubCancelRes = await terminateScheduleWorkspaceScrubWorkflow({
     workspaceId: owner.sId,
+    stopReason: "Workspace subscription activated/reactivated",
   });
   if (scrubCancelRes.isErr()) {
     logger.error(

--- a/front/scripts/replay-upsert-document-queue-tasks.ts
+++ b/front/scripts/replay-upsert-document-queue-tasks.ts
@@ -12,7 +12,7 @@ async function terminateWorkflow(workflowId: string, logger: Logger) {
   const client = await getTemporalClientForFrontNamespace();
   try {
     const workflowHandle = client.workflow.getHandle(workflowId);
-    await workflowHandle.terminate();
+    await workflowHandle.terminate("Terminated via script for replay");
     logger.info({ workflowId }, "Workflow successfully terminated.");
     return true;
   } catch (e) {

--- a/front/temporal/data_retention/admin/cli.ts
+++ b/front/temporal/data_retention/admin/cli.ts
@@ -19,7 +19,7 @@ const main = async () => {
       await launchDataRetentionWorkflow();
       return;
     case "stop":
-      await stopDataRetentionWorkflow();
+      await stopDataRetentionWorkflow({ stopReason: "Stopped via CLI" });
       return;
     case "run-now":
       const client = await getTemporalClientForFrontNamespace();

--- a/front/temporal/data_retention/client.ts
+++ b/front/temporal/data_retention/client.ts
@@ -25,13 +25,17 @@ export async function launchDataRetentionWorkflow(): Promise<
   return new Ok(undefined);
 }
 
-export async function stopDataRetentionWorkflow() {
+export async function stopDataRetentionWorkflow({
+  stopReason,
+}: {
+  stopReason: string;
+}) {
   const client = await getTemporalClientForFrontNamespace();
 
   try {
     const handle: WorkflowHandle<typeof dataRetentionWorkflow> =
       client.workflow.getHandle("data-retention-workflow");
-    await handle.terminate();
+    await handle.terminate(stopReason);
   } catch (e) {
     logger.error(
       {

--- a/front/temporal/production_checks/client.ts
+++ b/front/temporal/production_checks/client.ts
@@ -17,7 +17,7 @@ export async function launchProductionChecksWorkflow(): Promise<
   const workflowId = "production_checks";
   try {
     const handle = client.workflow.getHandle(workflowId);
-    await handle.terminate();
+    await handle.terminate("Terminating before restarting workflow");
   } catch (e) {
     if (!(e instanceof WorkflowNotFoundError)) {
       throw e;

--- a/front/temporal/remote_tools/client.ts
+++ b/front/temporal/remote_tools/client.ts
@@ -16,7 +16,7 @@ export async function createRemoteMCPServersSyncSchedule(): Promise<
   try {
     try {
       const handle = client.workflow.getHandle(workflowId);
-      await handle.terminate();
+      await handle.terminate("Terminating before creating schedule");
     } catch (e) {
       if (!(e instanceof WorkflowNotFoundError)) {
         throw e;

--- a/front/temporal/scrub_workspace/admin/cli.ts
+++ b/front/temporal/scrub_workspace/admin/cli.ts
@@ -18,7 +18,7 @@ const main = async () => {
       console.log(`Found ${workspaces.length} free ended workspaces:`);
       console.log(workspaces.map((w) => w.sId));
       return;
-    case "lauch-workflow-to-downgrade-free-ended-workspaces":
+    case "launch-workflow-to-downgrade-free-ended-workspaces":
       await launchDowngradeFreeEndedWorkspacesWorkflow();
       return;
     case "stop-workflow-to-downgrade-free-ended-workspaces":

--- a/front/temporal/scrub_workspace/admin/cli.ts
+++ b/front/temporal/scrub_workspace/admin/cli.ts
@@ -22,7 +22,7 @@ const main = async () => {
       await launchDowngradeFreeEndedWorkspacesWorkflow();
       return;
     case "stop-workflow-to-downgrade-free-ended-workspaces":
-      await stopDowngradeFreeEndedWorkspacesWorkflow();
+      await stopDowngradeFreeEndedWorkspacesWorkflow({ stopReason: "Stopped via CLI" });
       return;
     default:
       console.error("\x1b[31m%s\x1b[0m", `Error: Unknown command`);

--- a/front/temporal/scrub_workspace/admin/cli.ts
+++ b/front/temporal/scrub_workspace/admin/cli.ts
@@ -22,7 +22,9 @@ const main = async () => {
       await launchDowngradeFreeEndedWorkspacesWorkflow();
       return;
     case "stop-workflow-to-downgrade-free-ended-workspaces":
-      await stopDowngradeFreeEndedWorkspacesWorkflow({ stopReason: "Stopped via CLI" });
+      await stopDowngradeFreeEndedWorkspacesWorkflow({
+        stopReason: "Stopped via CLI",
+      });
       return;
     default:
       console.error("\x1b[31m%s\x1b[0m", `Error: Unknown command`);

--- a/front/temporal/scrub_workspace/client.ts
+++ b/front/temporal/scrub_workspace/client.ts
@@ -91,15 +91,17 @@ export async function launchImmediateWorkspaceScrubWorkflow({
 
 export async function terminateScheduleWorkspaceScrubWorkflow({
   workspaceId,
+  stopReason,
 }: {
   workspaceId: string;
+  stopReason: string;
 }): Promise<Result<void, Error>> {
   const client = await getTemporalClientForFrontNamespace();
   const workflowId = getWorkflowId(workspaceId);
   try {
     const handle: WorkflowHandle<typeof scheduleWorkspaceScrubWorkflowV2> =
       client.workflow.getHandle(workflowId);
-    await handle.terminate();
+    await handle.terminate(stopReason);
     logger.info(
       {
         workflowId,
@@ -142,13 +144,17 @@ export async function launchDowngradeFreeEndedWorkspacesWorkflow(): Promise<
   return new Ok(undefined);
 }
 
-export async function stopDowngradeFreeEndedWorkspacesWorkflow() {
+export async function stopDowngradeFreeEndedWorkspacesWorkflow({
+  stopReason,
+}: {
+  stopReason: string;
+}) {
   const client = await getTemporalClientForFrontNamespace();
 
   try {
     const handle: WorkflowHandle<typeof downgradeFreeEndedWorkspacesWorkflow> =
       client.workflow.getHandle(DOWNGRADE_FREE_ENDED_WORKSPACES_WORKFLOW_ID);
-    await handle.terminate();
+    await handle.terminate(stopReason);
   } catch (e) {
     logger.error(
       {

--- a/front/temporal/tracker/admin/cli.ts
+++ b/front/temporal/tracker/admin/cli.ts
@@ -20,7 +20,7 @@ const main = async () => {
       await launchTrackerNotificationWorkflow();
       return;
     case "stop":
-      await stopTrackerNotificationWorkflow();
+      await stopTrackerNotificationWorkflow({ stopReason: "Stopped via CLI" });
       return;
     case "run-workflow-for-tracker":
       // This is a debug command to run the tracker notification workflow for a specific tracker.

--- a/front/temporal/tracker/client.ts
+++ b/front/temporal/tracker/client.ts
@@ -58,13 +58,17 @@ export async function launchTrackerNotificationWorkflow(
   });
 }
 
-export async function stopTrackerNotificationWorkflow() {
+export async function stopTrackerNotificationWorkflow({
+  stopReason,
+}: {
+  stopReason: string;
+}) {
   const client = await getTemporalClientForFrontNamespace();
 
   try {
     const handle: WorkflowHandle<typeof trackersNotificationsWorkflow> =
       client.workflow.getHandle("tracker-notify-workflow");
-    await handle.terminate();
+    await handle.terminate(stopReason);
   } catch (e) {
     logger.error(
       {


### PR DESCRIPTION
## Description

- This PR adds a reason on programmatic workflow terminations from within front's code.
- This reason will be logged within Temporal Cloud to help with the debugging.
- No reason currently appears as terminated by user via frontend (the backend in this sentence being Temporal Cloud and the front-end the API user).

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
