### PR TITLE
test(dust-hive): Add integration test suite

### DIFF
--- a/x/henry/dust-hive/TEST_COVERAGE_PLAN.md
+++ b/x/henry/dust-hive/TEST_COVERAGE_PLAN.md
@@ -1,0 +1,296 @@
+# Plan: Comprehensive dust-hive Test Coverage
+
+## Problem Statement
+
+The current test suite has significant gaps:
+- **13/17 commands** have no integration tests
+- **E2E tests use mock services** (`sleep 300` instead of real SDK)
+- **Error handling** largely untested
+- **Critical features untested**: zellij, forward daemon, cache, doctor, sync
+
+## Test Categories
+
+We'll organize tests into 3 tiers based on speed and dependencies:
+
+| Tier | Location | Requires | Speed | Purpose |
+|------|----------|----------|-------|---------|
+| 1 | `tests/commands/*.test.ts` | Nothing | Fast | Command logic with mocked deps |
+| 2 | `tests/integration/*.test.ts` | Docker | Medium | Infrastructure integration |
+| 3 | `tests/e2e/*.test.ts` | Everything | Slow | Full workflows |
+
+---
+
+## Phase 1: Command Unit Tests (Tier 1)
+
+Create `tests/commands/` directory with unit tests for command logic.
+These mock external dependencies (Bun.spawn, file I/O) and test:
+- Input validation
+- Error conditions
+- Output formatting
+
+### Files to Create
+
+#### 1.1 `tests/commands/doctor.test.ts`
+Test the prerequisite checker:
+- All checks pass → success
+- Individual check failures → appropriate error messages
+- Version string parsing edge cases
+- Optional checks (sccache) vs required checks
+- Missing commands vs commands that error
+
+#### 1.2 `tests/commands/cache.test.ts`
+Test cache management:
+- Show status with no cache source configured
+- Show status with missing binaries
+- Rebuild with cargo failures
+- Partial rebuild (some succeed, some fail)
+
+#### 1.3 `tests/commands/forward.test.ts`
+Test port forwarding command:
+- Environment not found
+- Front service not running
+- Forwarder already running
+- Status display formatting
+- Stop when not running
+
+#### 1.4 `tests/commands/sync.test.ts`
+Test sync workflow:
+- Uncommitted changes blocks sync
+- Git fetch failure
+- Rebase conflicts detected
+- npm install failures (parallel)
+- Success path
+
+#### 1.5 `tests/commands/url.test.ts`
+Simple command:
+- Returns correct URL format
+- Handles missing environment
+
+#### 1.6 `tests/commands/logs.test.ts`
+Test log viewing:
+- Service not found
+- Log file doesn't exist
+- Correct path construction
+
+---
+
+## Phase 2: Missing Integration Tests (Tier 2)
+
+Extend existing integration test files and add new ones.
+
+### Files to Create/Modify
+
+#### 2.1 `tests/integration/commands.test.ts` (NEW)
+Integration tests for commands that need real file/process operations:
+
+```typescript
+describe("cool command", () => {
+  it("stops services but keeps SDK running");
+  it("errors when environment is not warm");
+});
+
+describe("start command", () => {
+  it("starts SDK from stopped state");
+  it("is idempotent when already running");
+});
+
+describe("stop command", () => {
+  it("stops all services including SDK");
+  it("is idempotent when already stopped");
+});
+
+describe("restart command", () => {
+  it("restarts a specific service");
+  it("errors for unknown service");
+});
+```
+
+#### 2.2 `tests/integration/forward.test.ts` (NEW)
+Test the forward daemon with real networking:
+
+```typescript
+describe("forward daemon", () => {
+  it("forwards TCP connections to target port");
+  it("handles upstream connection timeout");
+  it("handles client disconnect during connection");
+  it("respects buffer limits");
+  it("stops cleanly on SIGTERM");
+});
+
+describe("forward command integration", () => {
+  it("starts forwarder when front is running");
+  it("switches target when called with different env");
+  it("status shows correct forwarding state");
+});
+```
+
+#### 2.3 `tests/integration/zellij.test.ts` (NEW)
+Test zellij session management (auto-skips if zellij unavailable):
+
+```typescript
+describe("zellij sessions", () => {
+  it("creates session with correct layout");
+  it("open attaches to existing session");
+  it("reload kills and recreates session");
+  it("destroy cleans up session");
+});
+```
+
+#### 2.4 `tests/integration/cache.test.ts` (NEW)
+Test binary caching with real file operations:
+
+```typescript
+describe("cache system", () => {
+  it("detects missing binaries correctly");
+  it("symlinks work after cache setup");
+  it("rebuild creates expected binaries");
+});
+```
+
+---
+
+## Phase 3: Error Handling Tests
+
+Add error scenario tests across all tiers.
+
+### 3.1 Add to existing `e2e.test.ts`
+
+```typescript
+describe("error recovery", () => {
+  it("spawn fails gracefully with invalid name");
+  it("warm handles port conflicts");
+  it("destroy --force cleans up despite errors");
+  it("handles stale PID files");
+});
+```
+
+### 3.2 Add to `lifecycle.test.ts`
+
+```typescript
+describe("state inconsistencies", () => {
+  it("detects SDK running but Docker stopped");
+  it("handles orphaned processes on ports");
+  it("recovers from partial warm failure");
+});
+```
+
+### 3.3 Create `tests/integration/errors.test.ts`
+
+```typescript
+describe("error scenarios", () => {
+  it("handles corrupted metadata.json");
+  it("handles missing worktree directory");
+  it("handles docker compose syntax errors");
+  it("handles service crash during warm");
+});
+```
+
+---
+
+## Phase 4: Test Infrastructure Improvements
+
+### 4.1 Add test markers/tags
+
+Update `package.json` with granular test scripts:
+```json
+{
+  "test:unit": "bun test tests/lib tests/commands",
+  "test:integration:fast": "bun test tests/integration --grep 'filesystem|git|process'",
+  "test:integration:docker": "bun test tests/integration --grep 'docker|lifecycle'",
+  "test:e2e": "bun test tests/e2e",
+  "test:all": "bun test",
+  "test:coverage": "bun test --coverage"
+}
+```
+
+### 4.2 Add coverage reporting
+
+Add to `bunfig.toml`:
+```toml
+[test]
+coverage = true
+coverageDir = "./coverage"
+```
+
+Coverage will be informational only (no threshold enforcement).
+
+### 4.3 Add test documentation
+
+Create `tests/README.md` documenting:
+- Which tests require Docker
+- Which tests require zellij (auto-skipped if unavailable)
+- Expected timeouts
+- How to run subsets
+
+### 4.4 Zellij test skipping
+
+Tests in `zellij.test.ts` will auto-skip when zellij is not available:
+```typescript
+beforeAll(() => {
+  if (!isZellijAvailable()) {
+    console.log("Skipping zellij tests - zellij not found");
+    return; // Bun will skip the suite
+  }
+});
+```
+
+---
+
+## Implementation Order
+
+### Batch 1: Quick wins (command unit tests)
+1. `tests/commands/doctor.test.ts` - Easiest, pure mocking
+2. `tests/commands/url.test.ts` - Trivial
+3. `tests/commands/cache.test.ts` - Simple file mocking
+4. `tests/commands/logs.test.ts` - Simple
+
+### Batch 2: Medium effort (command tests with more logic)
+5. `tests/commands/forward.test.ts` - State management
+6. `tests/commands/sync.test.ts` - Git/npm mocking
+
+### Batch 3: Integration tests
+7. `tests/integration/commands.test.ts` - cool/start/stop/restart
+8. `tests/integration/errors.test.ts` - Error scenarios
+9. `tests/integration/forward.test.ts` - Real TCP forwarding
+
+### Batch 4: Infrastructure & optional
+10. `tests/integration/zellij.test.ts` - Auto-skips if zellij unavailable
+11. `tests/README.md` - Documentation
+12. Coverage setup in `bunfig.toml` and `package.json`
+
+---
+
+## Files to Create
+
+```
+tests/
+├── commands/           # NEW directory
+│   ├── doctor.test.ts
+│   ├── cache.test.ts
+│   ├── forward.test.ts
+│   ├── sync.test.ts
+│   ├── url.test.ts
+│   └── logs.test.ts
+├── integration/
+│   ├── commands.test.ts    # NEW - cool/start/stop/restart
+│   ├── errors.test.ts      # NEW - error scenarios
+│   ├── forward.test.ts     # NEW - TCP forwarding
+│   ├── zellij.test.ts      # NEW - session management (auto-skip)
+│   └── ... (existing files)
+└── README.md               # NEW - test documentation
+bunfig.toml                 # MODIFY - add coverage config
+package.json                # MODIFY - add test scripts
+```
+
+---
+
+## Success Criteria
+
+After implementation:
+- [ ] All 17 commands have at least basic test coverage
+- [ ] Error scenarios tested for spawn, warm, destroy, forward
+- [ ] Forward daemon TCP forwarding verified
+- [ ] Zellij tests auto-skip when zellij unavailable
+- [ ] Coverage reporting enabled (informational)
+- [ ] Test documentation explains how to run different suites
+- [ ] `bun run check` passes with all new tests

--- a/x/henry/dust-hive/package.json
+++ b/x/henry/dust-hive/package.json
@@ -11,8 +11,12 @@
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "format": "biome format --write .",
-    "test": "bun test",
+    "test": "bun test tests/lib",
     "test:watch": "bun test --watch",
+    "test:integration": "bun test tests/integration",
+    "test:integration:fast": "bun test tests/integration/filesystem.test.ts tests/integration/git.test.ts tests/integration/process.test.ts",
+    "test:e2e": "bun test tests/integration/e2e.test.ts",
+    "test:all": "bun test",
     "check": "bun run typecheck && bun run lint && bun run test"
   },
   "devDependencies": {

--- a/x/henry/dust-hive/tests/integration/cleanup.ts
+++ b/x/henry/dust-hive/tests/integration/cleanup.ts
@@ -1,0 +1,214 @@
+/**
+ * Cleanup utilities for integration tests
+ *
+ * Provides guaranteed cleanup even on test failure.
+ */
+
+import { rm } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+// Track PIDs spawned during tests for cleanup on exit
+const trackedPids: Set<number> = new Set();
+
+// Track cleanup tasks to run after each test
+const cleanupTasks: Array<() => Promise<void>> = [];
+
+/**
+ * Register a cleanup task to run after the test
+ */
+export function registerCleanup(task: () => Promise<void>): void {
+  cleanupTasks.push(task);
+}
+
+/**
+ * Run all registered cleanup tasks (call in afterEach)
+ */
+export async function runAllCleanups(): Promise<void> {
+  // Run in reverse order (LIFO)
+  for (const task of cleanupTasks.reverse()) {
+    try {
+      await task();
+    } catch (error) {
+      // Log but don't throw - we want all cleanups to run
+      console.warn("Cleanup task failed:", error);
+    }
+  }
+  cleanupTasks.length = 0;
+}
+
+/**
+ * Track a PID for cleanup on process exit
+ */
+export function trackPid(pid: number): void {
+  trackedPids.add(pid);
+}
+
+/**
+ * Remove a PID from tracking (after it's been cleaned up)
+ */
+export function untrackPid(pid: number): void {
+  trackedPids.delete(pid);
+}
+
+/**
+ * Kill all tracked PIDs
+ */
+export function killAllTrackedPids(): void {
+  for (const pid of trackedPids) {
+    try {
+      process.kill(pid, "SIGKILL");
+    } catch {
+      // Process may have already exited
+    }
+  }
+  trackedPids.clear();
+}
+
+/**
+ * Kill a process by PID (tries process group first, then individual)
+ */
+function killPid(pid: number): void {
+  try {
+    process.kill(-pid, "SIGKILL"); // Kill process group
+  } catch {
+    try {
+      process.kill(pid, "SIGKILL");
+    } catch {
+      // Process already dead
+    }
+  }
+}
+
+/**
+ * Stop a service by reading its PID file and killing the process
+ */
+async function stopServiceByPid(envDir: string, service: string): Promise<void> {
+  const pidPath = join(envDir, `${service}.pid`);
+  const pidFile = Bun.file(pidPath);
+
+  if (!(await pidFile.exists())) {
+    return;
+  }
+
+  const pid = Number.parseInt(await pidFile.text(), 10);
+  if (!Number.isNaN(pid)) {
+    killPid(pid);
+  }
+}
+
+/**
+ * Stop all services for an environment
+ */
+async function stopAllServicesByPid(envDir: string): Promise<void> {
+  const services = ["sdk", "front", "core", "oauth", "connectors", "front-workers"];
+
+  for (const service of services) {
+    await stopServiceByPid(envDir, service).catch(() => {});
+  }
+}
+
+/**
+ * Stop Docker containers and remove volumes
+ */
+async function cleanupDocker(envName: string): Promise<void> {
+  const dockerProject = `dust-hive-${envName}`;
+
+  // Stop containers
+  const dockerProc = Bun.spawn(
+    ["docker", "compose", "-p", dockerProject, "down", "-v", "--remove-orphans"],
+    { stdout: "pipe", stderr: "pipe" }
+  );
+  await dockerProc.exited;
+
+  // Remove volumes (force)
+  const volumes = [
+    `${dockerProject}-pgsql`,
+    `${dockerProject}-qdrant-primary`,
+    `${dockerProject}-qdrant-secondary`,
+    `${dockerProject}-elasticsearch`,
+  ];
+
+  for (const vol of volumes) {
+    const volProc = Bun.spawn(["docker", "volume", "rm", "-f", vol], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    await volProc.exited;
+  }
+}
+
+/**
+ * Remove git worktree and branch
+ */
+async function cleanupGitWorktree(envName: string): Promise<void> {
+  const DUST_HIVE_WORKTREES = join(homedir(), "dust-hive");
+  const worktreePath = join(DUST_HIVE_WORKTREES, envName);
+  const branchName = `${envName}-workspace`;
+
+  // Remove worktree
+  const wtProc = Bun.spawn(["git", "worktree", "remove", worktreePath, "--force"], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  await wtProc.exited;
+
+  // Delete branch
+  const branchProc = Bun.spawn(["git", "branch", "-D", branchName], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  await branchProc.exited;
+
+  // Remove directory if still exists
+  await rm(worktreePath, { recursive: true, force: true }).catch(() => {});
+}
+
+/**
+ * Clean up a test environment completely
+ */
+export async function cleanupTestEnvironment(envName: string): Promise<void> {
+  const DUST_HIVE_HOME = join(homedir(), ".dust-hive");
+  const envDir = join(DUST_HIVE_HOME, "envs", envName);
+
+  // Stop all services
+  await stopAllServicesByPid(envDir);
+
+  // Clean up Docker
+  await cleanupDocker(envName);
+
+  // Clean up git worktree
+  await cleanupGitWorktree(envName);
+
+  // Remove environment directory
+  await rm(envDir, { recursive: true, force: true }).catch(() => {});
+}
+
+/**
+ * Clean up forwarder process
+ */
+export async function cleanupForwarder(): Promise<void> {
+  const DUST_HIVE_HOME = join(homedir(), ".dust-hive");
+  const pidPath = join(DUST_HIVE_HOME, "forward.pid");
+
+  const pidFile = Bun.file(pidPath);
+  if (!(await pidFile.exists())) {
+    return;
+  }
+
+  const pid = Number.parseInt(await pidFile.text(), 10);
+  if (!Number.isNaN(pid)) {
+    killPid(pid);
+  }
+}
+
+// Register cleanup on process exit
+process.on("exit", killAllTrackedPids);
+process.on("SIGINT", () => {
+  killAllTrackedPids();
+  process.exit(1);
+});
+process.on("SIGTERM", () => {
+  killAllTrackedPids();
+  process.exit(1);
+});

--- a/x/henry/dust-hive/tests/integration/docker.test.ts
+++ b/x/henry/dust-hive/tests/integration/docker.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Integration tests for Docker operations
+ *
+ * Tests Docker Compose file generation, container management, and volumes.
+ * Requires Docker to be running.
+ */
+
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import YAML from "yaml";
+import { cleanupTestEnvironment, registerCleanup, runAllCleanups } from "./cleanup";
+import {
+  type TestContext,
+  createTestContext,
+  createTestGitRepo,
+  getTestPortBase,
+  requireDocker,
+} from "./setup";
+
+// Import the modules we're testing
+import {
+  generateDockerComposeOverride,
+  getDockerProjectName,
+  getVolumeNames,
+  removeDockerVolumes,
+  startDocker,
+  stopDocker,
+  writeDockerComposeOverride,
+} from "../../src/lib/docker";
+import {
+  type EnvironmentMetadata,
+  createEnvironment,
+  deleteEnvironmentDir,
+} from "../../src/lib/environment";
+import { DUST_HIVE_ENVS, getDockerOverridePath } from "../../src/lib/paths";
+import { calculatePorts } from "../../src/lib/ports";
+
+// Check Docker availability before running tests
+beforeAll(async () => {
+  await requireDocker();
+});
+
+describe("docker integration", () => {
+  let ctx: TestContext;
+  let repoPath: string;
+
+  beforeEach(async () => {
+    ctx = await createTestContext("docker");
+    repoPath = join(ctx.tempDir, "repo");
+    await createTestGitRepo(repoPath);
+    await mkdir(DUST_HIVE_ENVS, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await runAllCleanups();
+    await ctx.cleanup();
+  });
+
+  describe("generateDockerComposeOverride", () => {
+    it("generates correct port mappings", () => {
+      const ports = calculatePorts(50000);
+      const override = generateDockerComposeOverride(ctx.envName, ports);
+
+      expect(override.services.db.ports).toEqual(["50432:5432"]);
+      expect(override.services.redis.ports).toEqual(["50379:6379"]);
+      expect(override.services.qdrant_primary.ports).toEqual(["50334:6334", "50333:6333"]);
+      expect(override.services.elasticsearch.ports).toEqual(["50200:9200"]);
+      expect(override.services["apache-tika"].ports).toEqual(["50998:9998"]);
+    });
+
+    it("generates correct volume names", () => {
+      const ports = calculatePorts(50000);
+      const override = generateDockerComposeOverride(ctx.envName, ports);
+
+      expect(override.services.db.volumes).toEqual([
+        `dust-hive-${ctx.envName}-pgsql:/var/lib/postgresql/data`,
+      ]);
+      expect(override.services.qdrant_primary.volumes).toEqual([
+        `dust-hive-${ctx.envName}-qdrant-primary:/qdrant/storage`,
+      ]);
+      expect(override.services.elasticsearch.volumes).toEqual([
+        `dust-hive-${ctx.envName}-elasticsearch:/usr/share/elasticsearch/data`,
+      ]);
+
+      // Verify volume declarations
+      expect(override.volumes).toHaveProperty(`dust-hive-${ctx.envName}-pgsql`);
+      expect(override.volumes).toHaveProperty(`dust-hive-${ctx.envName}-qdrant-primary`);
+      expect(override.volumes).toHaveProperty(`dust-hive-${ctx.envName}-qdrant-secondary`);
+      expect(override.volumes).toHaveProperty(`dust-hive-${ctx.envName}-elasticsearch`);
+    });
+  });
+
+  describe("writeDockerComposeOverride", () => {
+    it("writes valid YAML file", async () => {
+      const ports = calculatePorts(50000);
+
+      const metadata: EnvironmentMetadata = {
+        name: ctx.envName,
+        baseBranch: "main",
+        workspaceBranch: `${ctx.envName}-workspace`,
+        createdAt: new Date().toISOString(),
+        repoRoot: repoPath,
+      };
+
+      registerCleanup(async () => {
+        await deleteEnvironmentDir(ctx.envName);
+      });
+
+      await createEnvironment(metadata);
+      await writeDockerComposeOverride(ctx.envName, ports);
+
+      // Read and parse the file
+      const overridePath = getDockerOverridePath(ctx.envName);
+      const content = await Bun.file(overridePath).text();
+      const parsed = YAML.parse(content);
+
+      expect(parsed.services).toBeDefined();
+      expect(parsed.services.db).toBeDefined();
+      expect(parsed.services.db.ports[0]).toBe("50432:5432");
+    });
+  });
+
+  describe("getDockerProjectName", () => {
+    it("returns prefixed project name", () => {
+      expect(getDockerProjectName("myenv")).toBe("dust-hive-myenv");
+      expect(getDockerProjectName("test-feature")).toBe("dust-hive-test-feature");
+    });
+  });
+
+  describe("getVolumeNames", () => {
+    it("returns all volume names", () => {
+      const volumes = getVolumeNames("myenv");
+      expect(volumes).toEqual([
+        "dust-hive-myenv-pgsql",
+        "dust-hive-myenv-qdrant-primary",
+        "dust-hive-myenv-qdrant-secondary",
+        "dust-hive-myenv-elasticsearch",
+      ]);
+    });
+  });
+
+  describe("startDocker / stopDocker", () => {
+    it("starts and stops containers", async () => {
+      // Use unique port base to avoid conflicts
+      const portBase = getTestPortBase();
+      const ports = calculatePorts(portBase);
+
+      const metadata: EnvironmentMetadata = {
+        name: ctx.envName,
+        baseBranch: "main",
+        workspaceBranch: `${ctx.envName}-workspace`,
+        createdAt: new Date().toISOString(),
+        repoRoot: repoPath,
+      };
+
+      // Create the docker-compose base file with all required services
+      const dockerComposeBase = `
+services:
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_PASSWORD: test
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 2s
+      timeout: 5s
+      retries: 5
+  redis:
+    image: redis:7
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 2s
+      timeout: 5s
+      retries: 5
+  qdrant_primary:
+    image: qdrant/qdrant:latest
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:6334/health"]
+      interval: 2s
+      timeout: 5s
+      retries: 5
+  qdrant_secondary:
+    image: qdrant/qdrant:latest
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:6334/health"]
+      interval: 2s
+      timeout: 5s
+      retries: 5
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.11.1
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:9200 || exit 1"]
+      interval: 2s
+      timeout: 5s
+      retries: 10
+  apache-tika:
+    image: apache/tika:latest
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9998/tika"]
+      interval: 2s
+      timeout: 5s
+      retries: 5
+`;
+      await mkdir(join(repoPath, "tools"), { recursive: true });
+      await Bun.write(join(repoPath, "tools/docker-compose.dust-hive.yml"), dockerComposeBase);
+
+      registerCleanup(async () => {
+        await cleanupTestEnvironment(ctx.envName);
+      });
+
+      await createEnvironment(metadata);
+      await writeDockerComposeOverride(ctx.envName, ports);
+
+      const env = {
+        name: ctx.envName,
+        metadata,
+        ports,
+        initialized: false,
+      };
+
+      // Start Docker
+      await startDocker(env);
+
+      // Give containers a moment to start
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+
+      // Check containers are running
+      const projectName = getDockerProjectName(ctx.envName);
+      const psProc = Bun.spawn(["docker", "compose", "-p", projectName, "ps", "--format", "json"], {
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const psOutput = await new Response(psProc.stdout).text();
+      await psProc.exited;
+
+      // Should have at least some containers
+      expect(psOutput.length).toBeGreaterThan(0);
+
+      // Stop Docker
+      const stopped = await stopDocker(ctx.envName, repoPath);
+      expect(stopped).toBe(true);
+
+      // Verify containers are stopped
+      const psProc2 = Bun.spawn(
+        ["docker", "compose", "-p", projectName, "ps", "--format", "json"],
+        { stdout: "pipe", stderr: "pipe" }
+      );
+      const psOutput2 = await new Response(psProc2.stdout).text();
+      await psProc2.exited;
+
+      // Should have no running containers (empty or no output)
+      expect(psOutput2.trim()).toBe("");
+    }, 60000); // 60 second timeout for Docker operations
+  });
+
+  describe("removeDockerVolumes", () => {
+    it("removes volumes by name", async () => {
+      // Create a test volume
+      const volumeName = `dust-hive-${ctx.envName}-test-volume`;
+
+      const createProc = Bun.spawn(["docker", "volume", "create", volumeName], {
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      await createProc.exited;
+
+      registerCleanup(async () => {
+        // Ensure volume is removed
+        const rmProc = Bun.spawn(["docker", "volume", "rm", "-f", volumeName], {
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        await rmProc.exited;
+      });
+
+      // Verify volume exists
+      const lsProc = Bun.spawn(["docker", "volume", "ls", "--format", "{{.Name}}"], {
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const lsOutput = await new Response(lsProc.stdout).text();
+      await lsProc.exited;
+      expect(lsOutput).toContain(volumeName);
+
+      // Remove volumes (will fail for non-existent ones, that's ok)
+      const failed = await removeDockerVolumes(ctx.envName);
+      // The test volume won't be in the standard list, but removeDockerVolumes
+      // should handle non-existent volumes gracefully
+      expect(Array.isArray(failed)).toBe(true);
+    });
+
+    it("handles non-existent volumes gracefully", async () => {
+      const failed = await removeDockerVolumes("nonexistent-env-12345");
+      // Should return the failed volumes (all of them since they don't exist)
+      // But should not throw
+      expect(Array.isArray(failed)).toBe(true);
+    });
+  });
+});

--- a/x/henry/dust-hive/tests/integration/e2e.test.ts
+++ b/x/henry/dust-hive/tests/integration/e2e.test.ts
@@ -1,0 +1,405 @@
+/**
+ * End-to-end integration tests
+ *
+ * Tests full environment lifecycle with real Docker containers.
+ * These are the slowest tests (~60-180s each).
+ */
+
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import {
+  cleanupTestEnvironment,
+  registerCleanup,
+  runAllCleanups,
+  trackPid,
+  untrackPid,
+} from "./cleanup";
+import {
+  type TestContext,
+  createTestContext,
+  createTestGitRepo,
+  getTestPortBase,
+  requireDocker,
+  waitFor,
+} from "./setup";
+
+import { startDocker, stopDocker, writeDockerComposeOverride } from "../../src/lib/docker";
+import { generateEnvSh } from "../../src/lib/envgen";
+// Import modules
+import {
+  type EnvironmentMetadata,
+  createEnvironment,
+  deleteEnvironmentDir,
+  getEnvironment,
+  isInitialized,
+  listEnvironments,
+  markInitialized,
+} from "../../src/lib/environment";
+import { DUST_HIVE_ENVS, getEnvFilePath } from "../../src/lib/paths";
+import { calculatePorts, savePortAllocation } from "../../src/lib/ports";
+import { isServiceRunning, spawnDaemon, stopService } from "../../src/lib/process";
+import { getStateInfo, isDockerRunning } from "../../src/lib/state";
+import {
+  createWorktree,
+  deleteBranch,
+  hasUncommittedChanges,
+  removeWorktree,
+} from "../../src/lib/worktree";
+
+// Check Docker availability before running tests
+beforeAll(async () => {
+  await requireDocker();
+});
+
+describe("e2e integration", () => {
+  let ctx: TestContext;
+  let repoPath: string;
+
+  beforeEach(async () => {
+    ctx = await createTestContext("e2e");
+    repoPath = join(ctx.tempDir, "repo");
+    await createTestGitRepo(repoPath);
+    await mkdir(DUST_HIVE_ENVS, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await runAllCleanups();
+    await ctx.cleanup();
+  });
+
+  describe("full lifecycle", () => {
+    it("spawn -> warm -> cool -> warm -> stop -> start -> destroy", async () => {
+      const portBase = getTestPortBase();
+      const ports = calculatePorts(portBase);
+      const worktreePath = join(ctx.tempDir, "worktree");
+      const branchName = `${ctx.envName}-workspace`;
+
+      const metadata: EnvironmentMetadata = {
+        name: ctx.envName,
+        baseBranch: "main",
+        workspaceBranch: branchName,
+        createdAt: new Date().toISOString(),
+        repoRoot: repoPath,
+      };
+
+      // Create docker-compose with all required services
+      const dockerComposeBase = `
+services:
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_PASSWORD: test
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 2s
+      timeout: 5s
+      retries: 10
+  redis:
+    image: redis:7
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 2s
+      timeout: 5s
+      retries: 10
+  qdrant_primary:
+    image: qdrant/qdrant:latest
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:6334/health"]
+      interval: 2s
+      timeout: 5s
+      retries: 5
+  qdrant_secondary:
+    image: qdrant/qdrant:latest
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:6334/health"]
+      interval: 2s
+      timeout: 5s
+      retries: 5
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.11.1
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:9200 || exit 1"]
+      interval: 2s
+      timeout: 5s
+      retries: 10
+  apache-tika:
+    image: apache/tika:latest
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9998/tika"]
+      interval: 2s
+      timeout: 5s
+      retries: 5
+`;
+      await mkdir(join(repoPath, "tools"), { recursive: true });
+      await Bun.write(join(repoPath, "tools/docker-compose.dust-hive.yml"), dockerComposeBase);
+
+      registerCleanup(async () => {
+        await cleanupTestEnvironment(ctx.envName);
+        await removeWorktree(repoPath, worktreePath);
+        await deleteBranch(repoPath, branchName);
+      });
+
+      // === SPAWN PHASE ===
+      // Create environment files
+      await createEnvironment(metadata);
+      await savePortAllocation(ctx.envName, ports);
+
+      // Generate env.sh
+      const envSh = generateEnvSh(ctx.envName, ports);
+      await Bun.write(getEnvFilePath(ctx.envName), envSh);
+
+      // Write docker-compose override
+      await writeDockerComposeOverride(ctx.envName, ports);
+
+      // Create worktree
+      await createWorktree(repoPath, worktreePath, branchName, "main");
+
+      // Verify worktree exists
+      expect(await Bun.file(join(worktreePath, ".git")).exists()).toBe(true);
+
+      // Start SDK (simulated)
+      const sdkPid = await spawnDaemon(ctx.envName, "sdk", ["sleep", "300"], {
+        cwd: worktreePath,
+      });
+      trackPid(sdkPid);
+
+      // Verify cold state
+      const env = await getEnvironment(ctx.envName);
+      if (!env) {
+        throw new Error("Environment should exist");
+      }
+      let stateInfo = await getStateInfo(env);
+      expect(stateInfo.state).toBe("cold");
+
+      // === FIRST WARM PHASE ===
+      // Start Docker
+      await startDocker(env);
+
+      // Wait for Docker to be running
+      await waitFor(async () => await isDockerRunning(ctx.envName), {
+        timeout: 30000,
+        message: "Docker containers did not start",
+      });
+
+      // Start a mock app service
+      const frontPid = await spawnDaemon(ctx.envName, "front", ["sleep", "300"], {
+        cwd: worktreePath,
+      });
+      trackPid(frontPid);
+
+      // Mark initialized (simulating DB init)
+      await markInitialized(ctx.envName);
+
+      // Verify warm state
+      stateInfo = await getStateInfo(env);
+      expect(stateInfo.state).toBe("warm");
+      expect(stateInfo.sdkRunning).toBe(true);
+      expect(stateInfo.dockerRunning).toBe(true);
+      expect(stateInfo.appServicesRunning).toBe(true);
+
+      // Verify initialized
+      expect(await isInitialized(ctx.envName)).toBe(true);
+
+      // === COOL PHASE ===
+      // Stop app services (but not SDK)
+      await stopService(ctx.envName, "front");
+      untrackPid(frontPid);
+
+      // Stop Docker
+      await stopDocker(ctx.envName, repoPath);
+
+      // Verify cold state (SDK still running)
+      stateInfo = await getStateInfo(env);
+      expect(stateInfo.state).toBe("cold");
+      expect(stateInfo.sdkRunning).toBe(true);
+      expect(stateInfo.dockerRunning).toBe(false);
+
+      // === SECOND WARM PHASE ===
+      // Start Docker again
+      await startDocker(env);
+
+      // Wait for Docker
+      await waitFor(async () => await isDockerRunning(ctx.envName), {
+        timeout: 30000,
+        message: "Docker containers did not start on second warm",
+      });
+
+      // Start app service again
+      const frontPid2 = await spawnDaemon(ctx.envName, "front", ["sleep", "300"], {
+        cwd: worktreePath,
+      });
+      trackPid(frontPid2);
+
+      // Should still be initialized (no re-init)
+      expect(await isInitialized(ctx.envName)).toBe(true);
+
+      // Verify warm again
+      stateInfo = await getStateInfo(env);
+      expect(stateInfo.state).toBe("warm");
+
+      // === STOP PHASE ===
+      // Stop everything
+      await stopService(ctx.envName, "front");
+      untrackPid(frontPid2);
+
+      await stopService(ctx.envName, "sdk");
+      untrackPid(sdkPid);
+
+      await stopDocker(ctx.envName, repoPath);
+
+      // Verify stopped
+      stateInfo = await getStateInfo(env);
+      expect(stateInfo.state).toBe("stopped");
+
+      // === START PHASE ===
+      // Restart SDK only
+      const sdkPid2 = await spawnDaemon(ctx.envName, "sdk", ["sleep", "300"], {
+        cwd: worktreePath,
+      });
+      trackPid(sdkPid2);
+
+      // Verify cold
+      stateInfo = await getStateInfo(env);
+      expect(stateInfo.state).toBe("cold");
+
+      // Clean up SDK
+      await stopService(ctx.envName, "sdk");
+      untrackPid(sdkPid2);
+
+      // === DESTROY PHASE ===
+      // Verify no uncommitted changes
+      expect(await hasUncommittedChanges(worktreePath)).toBe(false);
+
+      // Remove worktree and branch
+      await removeWorktree(repoPath, worktreePath);
+      await deleteBranch(repoPath, branchName);
+
+      // Remove Docker volumes
+      await stopDocker(ctx.envName, repoPath, { removeVolumes: true });
+
+      // Delete environment directory
+      await deleteEnvironmentDir(ctx.envName);
+
+      // Verify environment is gone
+      expect(await getEnvironment(ctx.envName)).toBeNull();
+      const envs = await listEnvironments();
+      expect(envs).not.toContain(ctx.envName);
+    }, 180000); // 3 minute timeout
+
+    it("handles multiple concurrent environments", async () => {
+      const env1Name = `${ctx.envName}-1`;
+      const env2Name = `${ctx.envName}-2`;
+
+      const port1 = getTestPortBase();
+      const port2 = port1 + 1000; // Next port range
+
+      const ports1 = calculatePorts(port1);
+      const ports2 = calculatePorts(port2);
+
+      const metadata1: EnvironmentMetadata = {
+        name: env1Name,
+        baseBranch: "main",
+        workspaceBranch: `${env1Name}-workspace`,
+        createdAt: new Date().toISOString(),
+        repoRoot: repoPath,
+      };
+
+      const metadata2: EnvironmentMetadata = {
+        name: env2Name,
+        baseBranch: "main",
+        workspaceBranch: `${env2Name}-workspace`,
+        createdAt: new Date().toISOString(),
+        repoRoot: repoPath,
+      };
+
+      registerCleanup(async () => {
+        await cleanupTestEnvironment(env1Name);
+        await cleanupTestEnvironment(env2Name);
+      });
+
+      // Create both environments
+      await createEnvironment(metadata1);
+      await savePortAllocation(env1Name, ports1);
+
+      await createEnvironment(metadata2);
+      await savePortAllocation(env2Name, ports2);
+
+      // Start SDK in both
+      const sdk1Pid = await spawnDaemon(env1Name, "sdk", ["sleep", "60"], {
+        cwd: ctx.tempDir,
+      });
+      trackPid(sdk1Pid);
+
+      const sdk2Pid = await spawnDaemon(env2Name, "sdk", ["sleep", "60"], {
+        cwd: ctx.tempDir,
+      });
+      trackPid(sdk2Pid);
+
+      // Both should be running independently
+      expect(await isServiceRunning(env1Name, "sdk")).toBe(true);
+      expect(await isServiceRunning(env2Name, "sdk")).toBe(true);
+
+      // Both should be listed
+      const envs = await listEnvironments();
+      expect(envs).toContain(env1Name);
+      expect(envs).toContain(env2Name);
+
+      // Stop env1 SDK
+      await stopService(env1Name, "sdk");
+      untrackPid(sdk1Pid);
+
+      // env1 stopped, env2 still running
+      expect(await isServiceRunning(env1Name, "sdk")).toBe(false);
+      expect(await isServiceRunning(env2Name, "sdk")).toBe(true);
+
+      // Clean up env2
+      await stopService(env2Name, "sdk");
+      untrackPid(sdk2Pid);
+
+      // Destroy both
+      await deleteEnvironmentDir(env1Name);
+      await deleteEnvironmentDir(env2Name);
+
+      // Both gone
+      const envsAfter = await listEnvironments();
+      expect(envsAfter).not.toContain(env1Name);
+      expect(envsAfter).not.toContain(env2Name);
+    }, 60000); // 1 minute timeout
+
+    it("destroy blocks on uncommitted changes", async () => {
+      const worktreePath = join(ctx.tempDir, "worktree");
+      const branchName = `${ctx.envName}-workspace`;
+
+      const metadata: EnvironmentMetadata = {
+        name: ctx.envName,
+        baseBranch: "main",
+        workspaceBranch: branchName,
+        createdAt: new Date().toISOString(),
+        repoRoot: repoPath,
+      };
+
+      registerCleanup(async () => {
+        await cleanupTestEnvironment(ctx.envName);
+        await removeWorktree(repoPath, worktreePath);
+        await deleteBranch(repoPath, branchName);
+      });
+
+      // Create environment with worktree
+      await createEnvironment(metadata);
+      await createWorktree(repoPath, worktreePath, branchName, "main");
+
+      // Make uncommitted changes
+      await Bun.write(join(worktreePath, "new-file.txt"), "uncommitted content");
+
+      // Verify uncommitted changes detected
+      expect(await hasUncommittedChanges(worktreePath)).toBe(true);
+
+      // This is where the destroy command would check and fail
+      // We're testing the detection mechanism here
+    }, 30000);
+  });
+});

--- a/x/henry/dust-hive/tests/integration/filesystem.test.ts
+++ b/x/henry/dust-hive/tests/integration/filesystem.test.ts
@@ -1,0 +1,348 @@
+/**
+ * Integration tests for filesystem operations
+ *
+ * Tests environment CRUD operations with real filesystem.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdir, readdir } from "node:fs/promises";
+import { join } from "node:path";
+import { registerCleanup, runAllCleanups } from "./cleanup";
+import { type TestContext, createTestContext } from "./setup";
+
+// Import the modules we're testing
+import {
+  type EnvironmentMetadata,
+  createEnvironment,
+  deleteEnvironmentDir,
+  environmentExists,
+  getEnvironment,
+  isInitialized,
+  listEnvironments,
+  loadMetadata,
+  markInitialized,
+} from "../../src/lib/environment";
+import { DUST_HIVE_ENVS, getEnvDir, getMetadataPath } from "../../src/lib/paths";
+import { type PortAllocation, savePortAllocation } from "../../src/lib/ports";
+
+describe("filesystem integration", () => {
+  let ctx: TestContext;
+
+  beforeEach(async () => {
+    ctx = await createTestContext("fs");
+    // Ensure envs directory exists for real operations
+    await mkdir(DUST_HIVE_ENVS, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await runAllCleanups();
+    await ctx.cleanup();
+  });
+
+  describe("createEnvironment", () => {
+    it("creates environment directory with metadata.json", async () => {
+      const metadata: EnvironmentMetadata = {
+        name: ctx.envName,
+        baseBranch: "main",
+        workspaceBranch: `${ctx.envName}-workspace`,
+        createdAt: new Date().toISOString(),
+        repoRoot: ctx.tempDir,
+      };
+
+      // Register cleanup first
+      registerCleanup(async () => {
+        await deleteEnvironmentDir(ctx.envName);
+      });
+
+      await createEnvironment(metadata);
+
+      // Verify directory exists
+      const envDir = getEnvDir(ctx.envName);
+      const entries = await readdir(envDir);
+      expect(entries).toContain("metadata.json");
+
+      // Verify metadata content
+      const loaded = await loadMetadata(ctx.envName);
+      expect(loaded).not.toBeNull();
+      expect(loaded?.name).toBe(ctx.envName);
+      expect(loaded?.baseBranch).toBe("main");
+    });
+
+    it("creates nested directory structure", async () => {
+      const deepName = `${ctx.envName}-nested`;
+      const metadata: EnvironmentMetadata = {
+        name: deepName,
+        baseBranch: "main",
+        workspaceBranch: `${deepName}-workspace`,
+        createdAt: new Date().toISOString(),
+        repoRoot: ctx.tempDir,
+      };
+
+      registerCleanup(async () => {
+        await deleteEnvironmentDir(deepName);
+      });
+
+      await createEnvironment(metadata);
+      expect(await environmentExists(deepName)).toBe(true);
+    });
+  });
+
+  describe("environmentExists", () => {
+    it("returns false for non-existent environment", async () => {
+      expect(await environmentExists("nonexistent-env-12345")).toBe(false);
+    });
+
+    it("returns true for existing environment", async () => {
+      const metadata: EnvironmentMetadata = {
+        name: ctx.envName,
+        baseBranch: "main",
+        workspaceBranch: `${ctx.envName}-workspace`,
+        createdAt: new Date().toISOString(),
+        repoRoot: ctx.tempDir,
+      };
+
+      registerCleanup(async () => {
+        await deleteEnvironmentDir(ctx.envName);
+      });
+
+      await createEnvironment(metadata);
+      expect(await environmentExists(ctx.envName)).toBe(true);
+    });
+  });
+
+  describe("loadMetadata", () => {
+    it("returns null for non-existent environment", async () => {
+      expect(await loadMetadata("nonexistent-env-12345")).toBeNull();
+    });
+
+    it("returns metadata for existing environment", async () => {
+      const metadata: EnvironmentMetadata = {
+        name: ctx.envName,
+        baseBranch: "develop",
+        workspaceBranch: `${ctx.envName}-workspace`,
+        createdAt: "2024-01-01T00:00:00Z",
+        repoRoot: "/path/to/repo",
+      };
+
+      registerCleanup(async () => {
+        await deleteEnvironmentDir(ctx.envName);
+      });
+
+      await createEnvironment(metadata);
+      const loaded = await loadMetadata(ctx.envName);
+
+      expect(loaded).not.toBeNull();
+      expect(loaded?.name).toBe(ctx.envName);
+      expect(loaded?.baseBranch).toBe("develop");
+      expect(loaded?.createdAt).toBe("2024-01-01T00:00:00Z");
+    });
+
+    it("returns null for corrupted metadata", async () => {
+      registerCleanup(async () => {
+        await deleteEnvironmentDir(ctx.envName);
+      });
+
+      // Create directory with invalid JSON
+      const envDir = getEnvDir(ctx.envName);
+      await mkdir(envDir, { recursive: true });
+      await Bun.write(getMetadataPath(ctx.envName), "not valid json");
+
+      // Should throw or return null (depends on implementation)
+      try {
+        const result = await loadMetadata(ctx.envName);
+        expect(result).toBeNull();
+      } catch {
+        // Also acceptable - invalid JSON throws
+      }
+    });
+  });
+
+  describe("getEnvironment", () => {
+    it("returns null when metadata missing", async () => {
+      expect(await getEnvironment("nonexistent-env-12345")).toBeNull();
+    });
+
+    it("returns null when ports missing", async () => {
+      const metadata: EnvironmentMetadata = {
+        name: ctx.envName,
+        baseBranch: "main",
+        workspaceBranch: `${ctx.envName}-workspace`,
+        createdAt: new Date().toISOString(),
+        repoRoot: ctx.tempDir,
+      };
+
+      registerCleanup(async () => {
+        await deleteEnvironmentDir(ctx.envName);
+      });
+
+      await createEnvironment(metadata);
+      // Don't save ports
+
+      const env = await getEnvironment(ctx.envName);
+      expect(env).toBeNull();
+    });
+
+    it("returns full environment when metadata and ports exist", async () => {
+      const metadata: EnvironmentMetadata = {
+        name: ctx.envName,
+        baseBranch: "main",
+        workspaceBranch: `${ctx.envName}-workspace`,
+        createdAt: new Date().toISOString(),
+        repoRoot: ctx.tempDir,
+      };
+
+      const ports: PortAllocation = {
+        base: 10000,
+        front: 10000,
+        core: 10001,
+        connectors: 10002,
+        oauth: 10006,
+        postgres: 10432,
+        redis: 10379,
+        qdrantHttp: 10334,
+        qdrantGrpc: 10333,
+        elasticsearch: 10200,
+        apacheTika: 10998,
+      };
+
+      registerCleanup(async () => {
+        await deleteEnvironmentDir(ctx.envName);
+      });
+
+      await createEnvironment(metadata);
+      await savePortAllocation(ctx.envName, ports);
+
+      const env = await getEnvironment(ctx.envName);
+      expect(env).not.toBeNull();
+      expect(env?.name).toBe(ctx.envName);
+      expect(env?.ports.base).toBe(10000);
+      expect(env?.initialized).toBe(false);
+    });
+  });
+
+  describe("markInitialized / isInitialized", () => {
+    it("returns false before marking", async () => {
+      const metadata: EnvironmentMetadata = {
+        name: ctx.envName,
+        baseBranch: "main",
+        workspaceBranch: `${ctx.envName}-workspace`,
+        createdAt: new Date().toISOString(),
+        repoRoot: ctx.tempDir,
+      };
+
+      registerCleanup(async () => {
+        await deleteEnvironmentDir(ctx.envName);
+      });
+
+      await createEnvironment(metadata);
+      expect(await isInitialized(ctx.envName)).toBe(false);
+    });
+
+    it("returns true after marking", async () => {
+      const metadata: EnvironmentMetadata = {
+        name: ctx.envName,
+        baseBranch: "main",
+        workspaceBranch: `${ctx.envName}-workspace`,
+        createdAt: new Date().toISOString(),
+        repoRoot: ctx.tempDir,
+      };
+
+      registerCleanup(async () => {
+        await deleteEnvironmentDir(ctx.envName);
+      });
+
+      await createEnvironment(metadata);
+      await markInitialized(ctx.envName);
+      expect(await isInitialized(ctx.envName)).toBe(true);
+    });
+  });
+
+  describe("listEnvironments", () => {
+    it("returns empty array when no environments exist", async () => {
+      // This might have environments from other tests, so we check the specific one
+      const envs = await listEnvironments();
+      expect(envs).not.toContain("nonexistent-env-12345");
+    });
+
+    it("includes newly created environment", async () => {
+      const metadata: EnvironmentMetadata = {
+        name: ctx.envName,
+        baseBranch: "main",
+        workspaceBranch: `${ctx.envName}-workspace`,
+        createdAt: new Date().toISOString(),
+        repoRoot: ctx.tempDir,
+      };
+
+      registerCleanup(async () => {
+        await deleteEnvironmentDir(ctx.envName);
+      });
+
+      await createEnvironment(metadata);
+      const envs = await listEnvironments();
+      expect(envs).toContain(ctx.envName);
+    });
+
+    it("ignores directories without metadata.json", async () => {
+      const invalidName = `${ctx.envName}-invalid`;
+      const invalidDir = getEnvDir(invalidName);
+
+      registerCleanup(async () => {
+        await deleteEnvironmentDir(invalidName);
+      });
+
+      // Create directory without metadata
+      await mkdir(invalidDir, { recursive: true });
+      await Bun.write(join(invalidDir, "some-file.txt"), "not metadata");
+
+      const envs = await listEnvironments();
+      expect(envs).not.toContain(invalidName);
+    });
+  });
+
+  describe("deleteEnvironmentDir", () => {
+    it("removes environment directory completely", async () => {
+      const metadata: EnvironmentMetadata = {
+        name: ctx.envName,
+        baseBranch: "main",
+        workspaceBranch: `${ctx.envName}-workspace`,
+        createdAt: new Date().toISOString(),
+        repoRoot: ctx.tempDir,
+      };
+
+      await createEnvironment(metadata);
+      expect(await environmentExists(ctx.envName)).toBe(true);
+
+      await deleteEnvironmentDir(ctx.envName);
+      expect(await environmentExists(ctx.envName)).toBe(false);
+    });
+
+    it("handles non-existent directory gracefully", async () => {
+      // Should not throw
+      await deleteEnvironmentDir("nonexistent-env-12345");
+    });
+
+    it("removes all files in directory", async () => {
+      const metadata: EnvironmentMetadata = {
+        name: ctx.envName,
+        baseBranch: "main",
+        workspaceBranch: `${ctx.envName}-workspace`,
+        createdAt: new Date().toISOString(),
+        repoRoot: ctx.tempDir,
+      };
+
+      await createEnvironment(metadata);
+
+      // Add some extra files
+      const envDir = getEnvDir(ctx.envName);
+      await Bun.write(join(envDir, "sdk.pid"), "12345");
+      await Bun.write(join(envDir, "sdk.log"), "some logs");
+
+      await deleteEnvironmentDir(ctx.envName);
+
+      // Directory should be completely gone
+      // Check parent directory doesn't contain our env
+      const envs = await listEnvironments();
+      expect(envs).not.toContain(ctx.envName);
+    });
+  });
+});

--- a/x/henry/dust-hive/tests/integration/git.test.ts
+++ b/x/henry/dust-hive/tests/integration/git.test.ts
@@ -1,0 +1,318 @@
+/**
+ * Integration tests for git worktree operations
+ *
+ * Tests worktree creation, branch management, and cleanup.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { rm } from "node:fs/promises";
+import { join } from "node:path";
+import { registerCleanup, runAllCleanups } from "./cleanup";
+import { type TestContext, createTestContext, createTestGitRepo } from "./setup";
+
+// Import the modules we're testing
+import {
+  cleanupPartialEnvironment,
+  createWorktree,
+  deleteBranch,
+  getCurrentBranch,
+  hasUncommittedChanges,
+  removeWorktree,
+} from "../../src/lib/worktree";
+
+describe("git integration", () => {
+  let ctx: TestContext;
+  let repoPath: string;
+
+  beforeEach(async () => {
+    ctx = await createTestContext("git");
+    repoPath = join(ctx.tempDir, "repo");
+    await createTestGitRepo(repoPath);
+  });
+
+  afterEach(async () => {
+    await runAllCleanups();
+    await ctx.cleanup();
+  });
+
+  describe("getCurrentBranch", () => {
+    it("returns the current branch name", async () => {
+      // Default branch after init is usually 'main' or 'master'
+      const branch = await getCurrentBranch(repoPath);
+      expect(["main", "master"]).toContain(branch);
+    });
+
+    it("returns branch name in worktree", async () => {
+      const worktreePath = join(ctx.tempDir, "worktree");
+      const branchName = `${ctx.envName}-workspace`;
+
+      registerCleanup(async () => {
+        await removeWorktree(repoPath, worktreePath);
+        await deleteBranch(repoPath, branchName);
+      });
+
+      await createWorktree(repoPath, worktreePath, branchName, "main");
+
+      const branch = await getCurrentBranch(worktreePath);
+      expect(branch).toBe(branchName);
+    });
+  });
+
+  describe("createWorktree", () => {
+    it("creates worktree at specified path", async () => {
+      const worktreePath = join(ctx.tempDir, "worktree");
+      const branchName = `${ctx.envName}-workspace`;
+
+      registerCleanup(async () => {
+        await removeWorktree(repoPath, worktreePath);
+        await deleteBranch(repoPath, branchName);
+      });
+
+      await createWorktree(repoPath, worktreePath, branchName, "main");
+
+      // Verify worktree exists (has .git file or directory)
+      const gitPath = join(worktreePath, ".git");
+      const gitFile = Bun.file(gitPath);
+      expect(await gitFile.exists()).toBe(true);
+    });
+
+    it("creates new branch from base branch", async () => {
+      const worktreePath = join(ctx.tempDir, "worktree");
+      const branchName = `${ctx.envName}-feature`;
+
+      registerCleanup(async () => {
+        await removeWorktree(repoPath, worktreePath);
+        await deleteBranch(repoPath, branchName);
+      });
+
+      await createWorktree(repoPath, worktreePath, branchName, "main");
+
+      // Verify branch was created
+      const branch = await getCurrentBranch(worktreePath);
+      expect(branch).toBe(branchName);
+    });
+
+    it("throws when branch already exists", async () => {
+      const worktreePath = join(ctx.tempDir, "worktree");
+      const branchName = `${ctx.envName}-existing`;
+
+      // Create the branch first via git
+      const proc = Bun.spawn(["git", "branch", branchName], {
+        cwd: repoPath,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      await proc.exited;
+
+      registerCleanup(async () => {
+        await rm(worktreePath, { recursive: true, force: true });
+        await deleteBranch(repoPath, branchName);
+      });
+
+      // Now try to create worktree with same branch name
+      await expect(createWorktree(repoPath, worktreePath, branchName, "main")).rejects.toThrow();
+    });
+
+    it("copies files from base branch", async () => {
+      const worktreePath = join(ctx.tempDir, "worktree");
+      const branchName = `${ctx.envName}-workspace`;
+
+      registerCleanup(async () => {
+        await removeWorktree(repoPath, worktreePath);
+        await deleteBranch(repoPath, branchName);
+      });
+
+      await createWorktree(repoPath, worktreePath, branchName, "main");
+
+      // Verify files from base branch exist
+      const packageJson = Bun.file(join(worktreePath, "package.json"));
+      expect(await packageJson.exists()).toBe(true);
+
+      const sdkPackage = Bun.file(join(worktreePath, "sdks/js/package.json"));
+      expect(await sdkPackage.exists()).toBe(true);
+    });
+  });
+
+  describe("removeWorktree", () => {
+    it("removes an existing worktree", async () => {
+      const worktreePath = join(ctx.tempDir, "worktree");
+      const branchName = `${ctx.envName}-workspace`;
+
+      await createWorktree(repoPath, worktreePath, branchName, "main");
+
+      // Verify it exists
+      expect(await Bun.file(join(worktreePath, ".git")).exists()).toBe(true);
+
+      await removeWorktree(repoPath, worktreePath);
+
+      // Branch still exists (removeWorktree doesn't delete branch)
+      // But worktree should be gone
+      const wtFile = Bun.file(join(worktreePath, ".git"));
+      expect(await wtFile.exists()).toBe(false);
+
+      // Clean up branch
+      await deleteBranch(repoPath, branchName);
+    });
+
+    it("handles non-existent worktree gracefully", async () => {
+      // Should not throw
+      await removeWorktree(repoPath, join(ctx.tempDir, "nonexistent"));
+    });
+  });
+
+  describe("deleteBranch", () => {
+    it("deletes an existing branch", async () => {
+      const branchName = `${ctx.envName}-to-delete`;
+
+      // Create branch
+      const createProc = Bun.spawn(["git", "branch", branchName], {
+        cwd: repoPath,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      await createProc.exited;
+
+      // Verify branch exists
+      const listProc = Bun.spawn(["git", "branch", "--list", branchName], {
+        cwd: repoPath,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const output = await new Response(listProc.stdout).text();
+      await listProc.exited;
+      expect(output.trim()).toContain(branchName);
+
+      // Delete branch
+      await deleteBranch(repoPath, branchName);
+
+      // Verify branch is gone
+      const listProc2 = Bun.spawn(["git", "branch", "--list", branchName], {
+        cwd: repoPath,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const output2 = await new Response(listProc2.stdout).text();
+      await listProc2.exited;
+      expect(output2.trim()).toBe("");
+    });
+
+    it("handles non-existent branch gracefully", async () => {
+      // Should not throw
+      await deleteBranch(repoPath, "nonexistent-branch-12345");
+    });
+  });
+
+  describe("hasUncommittedChanges", () => {
+    it("returns false for clean worktree", async () => {
+      const worktreePath = join(ctx.tempDir, "worktree");
+      const branchName = `${ctx.envName}-workspace`;
+
+      registerCleanup(async () => {
+        await removeWorktree(repoPath, worktreePath);
+        await deleteBranch(repoPath, branchName);
+      });
+
+      await createWorktree(repoPath, worktreePath, branchName, "main");
+
+      const hasChanges = await hasUncommittedChanges(worktreePath);
+      expect(hasChanges).toBe(false);
+    });
+
+    it("returns true when files are modified", async () => {
+      const worktreePath = join(ctx.tempDir, "worktree");
+      const branchName = `${ctx.envName}-workspace`;
+
+      registerCleanup(async () => {
+        await removeWorktree(repoPath, worktreePath);
+        await deleteBranch(repoPath, branchName);
+      });
+
+      await createWorktree(repoPath, worktreePath, branchName, "main");
+
+      // Modify a file
+      await Bun.write(join(worktreePath, "package.json"), '{"modified": true}');
+
+      const hasChanges = await hasUncommittedChanges(worktreePath);
+      expect(hasChanges).toBe(true);
+    });
+
+    it("returns true when new files are added", async () => {
+      const worktreePath = join(ctx.tempDir, "worktree");
+      const branchName = `${ctx.envName}-workspace`;
+
+      registerCleanup(async () => {
+        await removeWorktree(repoPath, worktreePath);
+        await deleteBranch(repoPath, branchName);
+      });
+
+      await createWorktree(repoPath, worktreePath, branchName, "main");
+
+      // Add a new file
+      await Bun.write(join(worktreePath, "new-file.txt"), "new content");
+
+      const hasChanges = await hasUncommittedChanges(worktreePath);
+      expect(hasChanges).toBe(true);
+    });
+
+    it("returns true when files are staged", async () => {
+      const worktreePath = join(ctx.tempDir, "worktree");
+      const branchName = `${ctx.envName}-workspace`;
+
+      registerCleanup(async () => {
+        await removeWorktree(repoPath, worktreePath);
+        await deleteBranch(repoPath, branchName);
+      });
+
+      await createWorktree(repoPath, worktreePath, branchName, "main");
+
+      // Add and stage a file
+      await Bun.write(join(worktreePath, "staged.txt"), "staged content");
+      const stageProc = Bun.spawn(["git", "add", "staged.txt"], {
+        cwd: worktreePath,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      await stageProc.exited;
+
+      const hasChanges = await hasUncommittedChanges(worktreePath);
+      expect(hasChanges).toBe(true);
+    });
+  });
+
+  describe("cleanupPartialEnvironment", () => {
+    it("removes worktree and deletes branch", async () => {
+      const worktreePath = join(ctx.tempDir, "worktree");
+      const branchName = `${ctx.envName}-partial`;
+
+      // Create worktree
+      await createWorktree(repoPath, worktreePath, branchName, "main");
+
+      // Verify it exists
+      expect(await Bun.file(join(worktreePath, ".git")).exists()).toBe(true);
+
+      // Cleanup
+      await cleanupPartialEnvironment(repoPath, worktreePath, branchName);
+
+      // Verify worktree is gone
+      expect(await Bun.file(join(worktreePath, ".git")).exists()).toBe(false);
+
+      // Verify branch is gone
+      const listProc = Bun.spawn(["git", "branch", "--list", branchName], {
+        cwd: repoPath,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const output = await new Response(listProc.stdout).text();
+      await listProc.exited;
+      expect(output.trim()).toBe("");
+    });
+
+    it("handles partial state gracefully", async () => {
+      const worktreePath = join(ctx.tempDir, "nonexistent-worktree");
+      const branchName = `${ctx.envName}-nonexistent`;
+
+      // Should not throw even if nothing exists
+      await cleanupPartialEnvironment(repoPath, worktreePath, branchName);
+    });
+  });
+});

--- a/x/henry/dust-hive/tests/integration/lifecycle.test.ts
+++ b/x/henry/dust-hive/tests/integration/lifecycle.test.ts
@@ -1,0 +1,382 @@
+/**
+ * Integration tests for environment lifecycle
+ *
+ * Tests state transitions and command workflows.
+ * Requires Docker.
+ */
+
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import {
+  cleanupTestEnvironment,
+  registerCleanup,
+  runAllCleanups,
+  trackPid,
+  untrackPid,
+} from "./cleanup";
+import {
+  type TestContext,
+  createTestContext,
+  createTestGitRepo,
+  getTestPortBase,
+  requireDocker,
+} from "./setup";
+
+import { writeDockerComposeOverride } from "../../src/lib/docker";
+import { generateEnvSh } from "../../src/lib/envgen";
+// Import modules for testing
+import {
+  type EnvironmentMetadata,
+  createEnvironment,
+  getEnvironment,
+  markInitialized,
+} from "../../src/lib/environment";
+import { DUST_HIVE_ENVS, getEnvDir, getEnvFilePath } from "../../src/lib/paths";
+import { calculatePorts, savePortAllocation } from "../../src/lib/ports";
+import {
+  isServiceRunning,
+  readPid,
+  spawnDaemon,
+  stopAllServices,
+  stopService,
+} from "../../src/lib/process";
+import { determineState, getStateInfo } from "../../src/lib/state";
+
+// Check Docker availability before running tests
+beforeAll(async () => {
+  await requireDocker();
+});
+
+describe("lifecycle integration", () => {
+  let ctx: TestContext;
+  let repoPath: string;
+
+  beforeEach(async () => {
+    ctx = await createTestContext("life");
+    repoPath = join(ctx.tempDir, "repo");
+    await createTestGitRepo(repoPath);
+    await mkdir(DUST_HIVE_ENVS, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await runAllCleanups();
+    await ctx.cleanup();
+  });
+
+  describe("environment creation", () => {
+    it("creates all expected artifacts", async () => {
+      const portBase = getTestPortBase();
+      const ports = calculatePorts(portBase);
+
+      const metadata: EnvironmentMetadata = {
+        name: ctx.envName,
+        baseBranch: "main",
+        workspaceBranch: `${ctx.envName}-workspace`,
+        createdAt: new Date().toISOString(),
+        repoRoot: repoPath,
+      };
+
+      registerCleanup(async () => {
+        await cleanupTestEnvironment(ctx.envName);
+      });
+
+      // Create environment
+      await createEnvironment(metadata);
+      await savePortAllocation(ctx.envName, ports);
+
+      // Generate env.sh
+      const envSh = generateEnvSh(ctx.envName, ports);
+      await Bun.write(getEnvFilePath(ctx.envName), envSh);
+
+      // Write docker-compose override
+      await writeDockerComposeOverride(ctx.envName, ports);
+
+      // Verify all files exist
+      const envDir = getEnvDir(ctx.envName);
+      expect(await Bun.file(join(envDir, "metadata.json")).exists()).toBe(true);
+      expect(await Bun.file(join(envDir, "ports.json")).exists()).toBe(true);
+      expect(await Bun.file(join(envDir, "env.sh")).exists()).toBe(true);
+      expect(await Bun.file(join(envDir, "docker-compose.override.yml")).exists()).toBe(true);
+
+      // Verify environment loads correctly
+      const env = await getEnvironment(ctx.envName);
+      expect(env).not.toBeNull();
+      expect(env?.name).toBe(ctx.envName);
+      expect(env?.ports.base).toBe(portBase);
+    });
+  });
+
+  describe("state detection", () => {
+    it("detects stopped state correctly", async () => {
+      const portBase = getTestPortBase();
+      const ports = calculatePorts(portBase);
+
+      const metadata: EnvironmentMetadata = {
+        name: ctx.envName,
+        baseBranch: "main",
+        workspaceBranch: `${ctx.envName}-workspace`,
+        createdAt: new Date().toISOString(),
+        repoRoot: repoPath,
+      };
+
+      registerCleanup(async () => {
+        await cleanupTestEnvironment(ctx.envName);
+      });
+
+      await createEnvironment(metadata);
+      await savePortAllocation(ctx.envName, ports);
+
+      const env = await getEnvironment(ctx.envName);
+      if (!env) {
+        throw new Error("Environment should exist");
+      }
+
+      const stateInfo = await getStateInfo(env);
+      expect(stateInfo.state).toBe("stopped");
+      expect(stateInfo.sdkRunning).toBe(false);
+      expect(stateInfo.dockerRunning).toBe(false);
+      expect(stateInfo.appServicesRunning).toBe(false);
+    });
+
+    it("detects cold state when only SDK running", async () => {
+      const portBase = getTestPortBase();
+      const ports = calculatePorts(portBase);
+
+      const metadata: EnvironmentMetadata = {
+        name: ctx.envName,
+        baseBranch: "main",
+        workspaceBranch: `${ctx.envName}-workspace`,
+        createdAt: new Date().toISOString(),
+        repoRoot: repoPath,
+      };
+
+      registerCleanup(async () => {
+        const pid = await readPid(ctx.envName, "sdk");
+        if (pid) {
+          try {
+            process.kill(pid, "SIGKILL");
+          } catch {}
+        }
+        await cleanupTestEnvironment(ctx.envName);
+      });
+
+      await createEnvironment(metadata);
+      await savePortAllocation(ctx.envName, ports);
+
+      // Start SDK (simulated with sleep)
+      const pid = await spawnDaemon(ctx.envName, "sdk", ["sleep", "60"], {
+        cwd: ctx.tempDir,
+      });
+      trackPid(pid);
+
+      const env = await getEnvironment(ctx.envName);
+      if (!env) {
+        throw new Error("Environment should exist");
+      }
+
+      const stateInfo = await getStateInfo(env);
+      expect(stateInfo.state).toBe("cold");
+      expect(stateInfo.sdkRunning).toBe(true);
+      expect(stateInfo.dockerRunning).toBe(false);
+      expect(stateInfo.appServicesRunning).toBe(false);
+
+      // Clean up
+      try {
+        process.kill(pid, "SIGKILL");
+      } catch {}
+      untrackPid(pid);
+    });
+  });
+
+  describe("state transitions", () => {
+    it("stopped -> cold: starting SDK", async () => {
+      const portBase = getTestPortBase();
+      const ports = calculatePorts(portBase);
+
+      const metadata: EnvironmentMetadata = {
+        name: ctx.envName,
+        baseBranch: "main",
+        workspaceBranch: `${ctx.envName}-workspace`,
+        createdAt: new Date().toISOString(),
+        repoRoot: repoPath,
+      };
+
+      registerCleanup(async () => {
+        await cleanupTestEnvironment(ctx.envName);
+      });
+
+      await createEnvironment(metadata);
+      await savePortAllocation(ctx.envName, ports);
+
+      const env = await getEnvironment(ctx.envName);
+      if (!env) {
+        throw new Error("Environment should exist");
+      }
+
+      // Verify stopped
+      let stateInfo = await getStateInfo(env);
+      expect(stateInfo.state).toBe("stopped");
+
+      // Start SDK
+      const pid = await spawnDaemon(ctx.envName, "sdk", ["sleep", "60"], {
+        cwd: ctx.tempDir,
+      });
+      trackPid(pid);
+
+      // Verify cold
+      stateInfo = await getStateInfo(env);
+      expect(stateInfo.state).toBe("cold");
+
+      // Clean up
+      try {
+        process.kill(pid, "SIGKILL");
+      } catch {}
+      untrackPid(pid);
+    });
+
+    it("cold -> stopped: stopping SDK", async () => {
+      const portBase = getTestPortBase();
+      const ports = calculatePorts(portBase);
+
+      const metadata: EnvironmentMetadata = {
+        name: ctx.envName,
+        baseBranch: "main",
+        workspaceBranch: `${ctx.envName}-workspace`,
+        createdAt: new Date().toISOString(),
+        repoRoot: repoPath,
+      };
+
+      registerCleanup(async () => {
+        await cleanupTestEnvironment(ctx.envName);
+      });
+
+      await createEnvironment(metadata);
+      await savePortAllocation(ctx.envName, ports);
+
+      // Start SDK
+      const pid = await spawnDaemon(ctx.envName, "sdk", ["sleep", "60"], {
+        cwd: ctx.tempDir,
+      });
+      trackPid(pid);
+
+      const env = await getEnvironment(ctx.envName);
+      if (!env) {
+        throw new Error("Environment should exist");
+      }
+
+      // Verify cold
+      let stateInfo = await getStateInfo(env);
+      expect(stateInfo.state).toBe("cold");
+
+      // Stop SDK
+      await stopService(ctx.envName, "sdk");
+      untrackPid(pid);
+
+      // Verify stopped
+      stateInfo = await getStateInfo(env);
+      expect(stateInfo.state).toBe("stopped");
+    });
+  });
+
+  describe("stopAllServices", () => {
+    it("stops all running services", async () => {
+      const portBase = getTestPortBase();
+      const ports = calculatePorts(portBase);
+
+      const metadata: EnvironmentMetadata = {
+        name: ctx.envName,
+        baseBranch: "main",
+        workspaceBranch: `${ctx.envName}-workspace`,
+        createdAt: new Date().toISOString(),
+        repoRoot: repoPath,
+      };
+
+      registerCleanup(async () => {
+        await cleanupTestEnvironment(ctx.envName);
+      });
+
+      await createEnvironment(metadata);
+      await savePortAllocation(ctx.envName, ports);
+
+      // Start multiple services
+      const sdkPid = await spawnDaemon(ctx.envName, "sdk", ["sleep", "60"], {
+        cwd: ctx.tempDir,
+      });
+      trackPid(sdkPid);
+
+      const frontPid = await spawnDaemon(ctx.envName, "front", ["sleep", "60"], {
+        cwd: ctx.tempDir,
+      });
+      trackPid(frontPid);
+
+      // Verify running
+      expect(await isServiceRunning(ctx.envName, "sdk")).toBe(true);
+      expect(await isServiceRunning(ctx.envName, "front")).toBe(true);
+
+      // Stop all
+      await stopAllServices(ctx.envName);
+      untrackPid(sdkPid);
+      untrackPid(frontPid);
+
+      // Verify stopped
+      expect(await isServiceRunning(ctx.envName, "sdk")).toBe(false);
+      expect(await isServiceRunning(ctx.envName, "front")).toBe(false);
+    });
+  });
+
+  describe("initialization marker", () => {
+    it("tracks initialized state", async () => {
+      const portBase = getTestPortBase();
+      const ports = calculatePorts(portBase);
+
+      const metadata: EnvironmentMetadata = {
+        name: ctx.envName,
+        baseBranch: "main",
+        workspaceBranch: `${ctx.envName}-workspace`,
+        createdAt: new Date().toISOString(),
+        repoRoot: repoPath,
+      };
+
+      registerCleanup(async () => {
+        await cleanupTestEnvironment(ctx.envName);
+      });
+
+      await createEnvironment(metadata);
+      await savePortAllocation(ctx.envName, ports);
+
+      // Initially not initialized
+      let env = await getEnvironment(ctx.envName);
+      expect(env).not.toBeNull();
+      expect(env?.initialized).toBe(false);
+
+      // Mark initialized
+      await markInitialized(ctx.envName);
+
+      // Now initialized
+      env = await getEnvironment(ctx.envName);
+      expect(env?.initialized).toBe(true);
+    });
+  });
+
+  describe("determineState", () => {
+    it("returns stopped when nothing running", () => {
+      expect(determineState(false, false, false)).toBe("stopped");
+    });
+
+    it("returns cold when only SDK running", () => {
+      expect(determineState(true, false, false)).toBe("cold");
+    });
+
+    it("returns warm when all running", () => {
+      expect(determineState(true, true, true)).toBe("warm");
+    });
+
+    it("returns warm when docker or app services running (inconsistent)", () => {
+      // Docker running, no SDK, no app services
+      expect(determineState(false, true, false)).toBe("warm");
+      // App services running, no SDK, no docker
+      expect(determineState(false, false, true)).toBe("warm");
+    });
+  });
+});

--- a/x/henry/dust-hive/tests/integration/process.test.ts
+++ b/x/henry/dust-hive/tests/integration/process.test.ts
@@ -1,0 +1,526 @@
+/**
+ * Integration tests for process management
+ *
+ * Tests daemon spawning, PID file management, and process lifecycle.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdir } from "node:fs/promises";
+import { registerCleanup, runAllCleanups, trackPid, untrackPid } from "./cleanup";
+import { type TestContext, createTestContext } from "./setup";
+
+import {
+  type EnvironmentMetadata,
+  createEnvironment,
+  deleteEnvironmentDir,
+} from "../../src/lib/environment";
+import { DUST_HIVE_ENVS, getLogPath, getPidPath } from "../../src/lib/paths";
+// Import the modules we're testing
+import {
+  cleanupPidFile,
+  getRunningServices,
+  isProcessRunning,
+  isServiceRunning,
+  readPid,
+  spawnDaemon,
+  spawnShellDaemon,
+  stopService,
+  writePid,
+} from "../../src/lib/process";
+
+describe("process integration", () => {
+  let ctx: TestContext;
+
+  beforeEach(async () => {
+    ctx = await createTestContext("proc");
+    await mkdir(DUST_HIVE_ENVS, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await runAllCleanups();
+    await ctx.cleanup();
+  });
+
+  describe("isProcessRunning", () => {
+    it("returns true for running process", () => {
+      // Current process is definitely running
+      expect(isProcessRunning(process.pid)).toBe(true);
+    });
+
+    it("returns false for non-existent PID", () => {
+      // Use a very high PID that's unlikely to exist
+      expect(isProcessRunning(999999)).toBe(false);
+    });
+  });
+
+  describe("writePid / readPid", () => {
+    it("writes and reads PID correctly", async () => {
+      const metadata: EnvironmentMetadata = {
+        name: ctx.envName,
+        baseBranch: "main",
+        workspaceBranch: `${ctx.envName}-workspace`,
+        createdAt: new Date().toISOString(),
+        repoRoot: ctx.tempDir,
+      };
+
+      registerCleanup(async () => {
+        await deleteEnvironmentDir(ctx.envName);
+      });
+
+      await createEnvironment(metadata);
+
+      // Write a PID (use current process as it's definitely running)
+      await writePid(ctx.envName, "sdk", process.pid);
+
+      // Read it back
+      const pid = await readPid(ctx.envName, "sdk");
+      expect(pid).toBe(process.pid);
+    });
+
+    it("returns null for non-existent PID file", async () => {
+      const metadata: EnvironmentMetadata = {
+        name: ctx.envName,
+        baseBranch: "main",
+        workspaceBranch: `${ctx.envName}-workspace`,
+        createdAt: new Date().toISOString(),
+        repoRoot: ctx.tempDir,
+      };
+
+      registerCleanup(async () => {
+        await deleteEnvironmentDir(ctx.envName);
+      });
+
+      await createEnvironment(metadata);
+
+      const pid = await readPid(ctx.envName, "sdk");
+      expect(pid).toBeNull();
+    });
+
+    it("cleans up stale PID file", async () => {
+      const metadata: EnvironmentMetadata = {
+        name: ctx.envName,
+        baseBranch: "main",
+        workspaceBranch: `${ctx.envName}-workspace`,
+        createdAt: new Date().toISOString(),
+        repoRoot: ctx.tempDir,
+      };
+
+      registerCleanup(async () => {
+        await deleteEnvironmentDir(ctx.envName);
+      });
+
+      await createEnvironment(metadata);
+
+      // Write a stale PID (process that doesn't exist)
+      await writePid(ctx.envName, "sdk", 999999);
+
+      // Reading should return null and clean up the file
+      const pid = await readPid(ctx.envName, "sdk");
+      expect(pid).toBeNull();
+
+      // PID file should be gone
+      const pidPath = getPidPath(ctx.envName, "sdk");
+      expect(await Bun.file(pidPath).exists()).toBe(false);
+    });
+  });
+
+  describe("cleanupPidFile", () => {
+    it("removes PID file", async () => {
+      const metadata: EnvironmentMetadata = {
+        name: ctx.envName,
+        baseBranch: "main",
+        workspaceBranch: `${ctx.envName}-workspace`,
+        createdAt: new Date().toISOString(),
+        repoRoot: ctx.tempDir,
+      };
+
+      registerCleanup(async () => {
+        await deleteEnvironmentDir(ctx.envName);
+      });
+
+      await createEnvironment(metadata);
+      await writePid(ctx.envName, "sdk", 12345);
+
+      const pidPath = getPidPath(ctx.envName, "sdk");
+      expect(await Bun.file(pidPath).exists()).toBe(true);
+
+      await cleanupPidFile(ctx.envName, "sdk");
+      expect(await Bun.file(pidPath).exists()).toBe(false);
+    });
+
+    it("handles non-existent file gracefully", async () => {
+      const metadata: EnvironmentMetadata = {
+        name: ctx.envName,
+        baseBranch: "main",
+        workspaceBranch: `${ctx.envName}-workspace`,
+        createdAt: new Date().toISOString(),
+        repoRoot: ctx.tempDir,
+      };
+
+      registerCleanup(async () => {
+        await deleteEnvironmentDir(ctx.envName);
+      });
+
+      await createEnvironment(metadata);
+
+      // Should not throw
+      await cleanupPidFile(ctx.envName, "sdk");
+    });
+  });
+
+  describe("spawnDaemon", () => {
+    it("spawns process and creates PID file", async () => {
+      const metadata: EnvironmentMetadata = {
+        name: ctx.envName,
+        baseBranch: "main",
+        workspaceBranch: `${ctx.envName}-workspace`,
+        createdAt: new Date().toISOString(),
+        repoRoot: ctx.tempDir,
+      };
+
+      registerCleanup(async () => {
+        // Kill the process first
+        const pid = await readPid(ctx.envName, "sdk");
+        if (pid) {
+          try {
+            process.kill(pid, "SIGKILL");
+          } catch {
+            // May have already exited
+          }
+        }
+        await deleteEnvironmentDir(ctx.envName);
+      });
+
+      await createEnvironment(metadata);
+
+      // Spawn a simple process that stays alive
+      const pid = await spawnDaemon(ctx.envName, "sdk", ["sleep", "30"], {
+        cwd: ctx.tempDir,
+      });
+
+      trackPid(pid);
+
+      // Verify PID file exists
+      const pidPath = getPidPath(ctx.envName, "sdk");
+      expect(await Bun.file(pidPath).exists()).toBe(true);
+
+      // Verify process is running
+      expect(isProcessRunning(pid)).toBe(true);
+
+      // Verify log file exists
+      const logPath = getLogPath(ctx.envName, "sdk");
+      expect(await Bun.file(logPath).exists()).toBe(true);
+
+      // Clean up
+      try {
+        process.kill(pid, "SIGKILL");
+      } catch {
+        // May have already exited
+      }
+      untrackPid(pid);
+    });
+
+    it("throws when process exits immediately", async () => {
+      const metadata: EnvironmentMetadata = {
+        name: ctx.envName,
+        baseBranch: "main",
+        workspaceBranch: `${ctx.envName}-workspace`,
+        createdAt: new Date().toISOString(),
+        repoRoot: ctx.tempDir,
+      };
+
+      registerCleanup(async () => {
+        await deleteEnvironmentDir(ctx.envName);
+      });
+
+      await createEnvironment(metadata);
+
+      // Spawn a process that exits immediately
+      await expect(
+        spawnDaemon(ctx.envName, "sdk", ["false"], {
+          cwd: ctx.tempDir,
+        })
+      ).rejects.toThrow(/exited immediately/);
+    });
+  });
+
+  describe("spawnShellDaemon", () => {
+    it("spawns shell command as daemon", async () => {
+      const metadata: EnvironmentMetadata = {
+        name: ctx.envName,
+        baseBranch: "main",
+        workspaceBranch: `${ctx.envName}-workspace`,
+        createdAt: new Date().toISOString(),
+        repoRoot: ctx.tempDir,
+      };
+
+      registerCleanup(async () => {
+        const pid = await readPid(ctx.envName, "sdk");
+        if (pid) {
+          try {
+            process.kill(pid, "SIGKILL");
+          } catch {
+            // May have already exited
+          }
+        }
+        await deleteEnvironmentDir(ctx.envName);
+      });
+
+      await createEnvironment(metadata);
+
+      // Spawn a shell command
+      const pid = await spawnShellDaemon(ctx.envName, "sdk", "sleep 30", {
+        cwd: ctx.tempDir,
+      });
+
+      trackPid(pid);
+
+      // Verify running
+      expect(isProcessRunning(pid)).toBe(true);
+
+      // Clean up
+      try {
+        process.kill(pid, "SIGKILL");
+      } catch {
+        // May have already exited
+      }
+      untrackPid(pid);
+    });
+
+    it("captures output to log file", async () => {
+      const metadata: EnvironmentMetadata = {
+        name: ctx.envName,
+        baseBranch: "main",
+        workspaceBranch: `${ctx.envName}-workspace`,
+        createdAt: new Date().toISOString(),
+        repoRoot: ctx.tempDir,
+      };
+
+      registerCleanup(async () => {
+        const pid = await readPid(ctx.envName, "sdk");
+        if (pid) {
+          try {
+            process.kill(pid, "SIGKILL");
+          } catch {
+            // May have already exited
+          }
+        }
+        await deleteEnvironmentDir(ctx.envName);
+      });
+
+      await createEnvironment(metadata);
+
+      // Spawn a command that outputs something then sleeps
+      const pid = await spawnShellDaemon(ctx.envName, "sdk", "echo 'test output' && sleep 30", {
+        cwd: ctx.tempDir,
+      });
+
+      trackPid(pid);
+
+      // Wait a moment for output
+      await new Promise((resolve) => setTimeout(resolve, 500));
+
+      // Check log file
+      const logPath = getLogPath(ctx.envName, "sdk");
+      const logContent = await Bun.file(logPath).text();
+      expect(logContent).toContain("test output");
+
+      // Clean up
+      try {
+        process.kill(pid, "SIGKILL");
+      } catch {
+        // May have already exited
+      }
+      untrackPid(pid);
+    });
+  });
+
+  describe("isServiceRunning", () => {
+    it("returns true when service is running", async () => {
+      const metadata: EnvironmentMetadata = {
+        name: ctx.envName,
+        baseBranch: "main",
+        workspaceBranch: `${ctx.envName}-workspace`,
+        createdAt: new Date().toISOString(),
+        repoRoot: ctx.tempDir,
+      };
+
+      registerCleanup(async () => {
+        const pid = await readPid(ctx.envName, "sdk");
+        if (pid) {
+          try {
+            process.kill(pid, "SIGKILL");
+          } catch {
+            // May have already exited
+          }
+        }
+        await deleteEnvironmentDir(ctx.envName);
+      });
+
+      await createEnvironment(metadata);
+
+      const pid = await spawnDaemon(ctx.envName, "sdk", ["sleep", "30"], {
+        cwd: ctx.tempDir,
+      });
+      trackPid(pid);
+
+      expect(await isServiceRunning(ctx.envName, "sdk")).toBe(true);
+
+      // Clean up
+      try {
+        process.kill(pid, "SIGKILL");
+      } catch {
+        // May have already exited
+      }
+      untrackPid(pid);
+    });
+
+    it("returns false when service is not running", async () => {
+      const metadata: EnvironmentMetadata = {
+        name: ctx.envName,
+        baseBranch: "main",
+        workspaceBranch: `${ctx.envName}-workspace`,
+        createdAt: new Date().toISOString(),
+        repoRoot: ctx.tempDir,
+      };
+
+      registerCleanup(async () => {
+        await deleteEnvironmentDir(ctx.envName);
+      });
+
+      await createEnvironment(metadata);
+
+      expect(await isServiceRunning(ctx.envName, "sdk")).toBe(false);
+    });
+  });
+
+  describe("stopService", () => {
+    it("stops a running service", async () => {
+      const metadata: EnvironmentMetadata = {
+        name: ctx.envName,
+        baseBranch: "main",
+        workspaceBranch: `${ctx.envName}-workspace`,
+        createdAt: new Date().toISOString(),
+        repoRoot: ctx.tempDir,
+      };
+
+      registerCleanup(async () => {
+        await deleteEnvironmentDir(ctx.envName);
+      });
+
+      await createEnvironment(metadata);
+
+      const pid = await spawnDaemon(ctx.envName, "sdk", ["sleep", "30"], {
+        cwd: ctx.tempDir,
+      });
+      trackPid(pid);
+
+      expect(await isServiceRunning(ctx.envName, "sdk")).toBe(true);
+
+      const stopped = await stopService(ctx.envName, "sdk");
+      expect(stopped).toBe(true);
+
+      // Verify process is gone
+      expect(isProcessRunning(pid)).toBe(false);
+
+      // Verify PID file is cleaned up
+      const pidPath = getPidPath(ctx.envName, "sdk");
+      expect(await Bun.file(pidPath).exists()).toBe(false);
+
+      untrackPid(pid);
+    });
+
+    it("returns false when service not running", async () => {
+      const metadata: EnvironmentMetadata = {
+        name: ctx.envName,
+        baseBranch: "main",
+        workspaceBranch: `${ctx.envName}-workspace`,
+        createdAt: new Date().toISOString(),
+        repoRoot: ctx.tempDir,
+      };
+
+      registerCleanup(async () => {
+        await deleteEnvironmentDir(ctx.envName);
+      });
+
+      await createEnvironment(metadata);
+
+      const stopped = await stopService(ctx.envName, "sdk");
+      expect(stopped).toBe(false);
+    });
+  });
+
+  describe("getRunningServices", () => {
+    it("returns list of running services", async () => {
+      const metadata: EnvironmentMetadata = {
+        name: ctx.envName,
+        baseBranch: "main",
+        workspaceBranch: `${ctx.envName}-workspace`,
+        createdAt: new Date().toISOString(),
+        repoRoot: ctx.tempDir,
+      };
+
+      registerCleanup(async () => {
+        // Stop all services
+        for (const service of ["sdk", "front"] as const) {
+          const pid = await readPid(ctx.envName, service);
+          if (pid) {
+            try {
+              process.kill(pid, "SIGKILL");
+            } catch {
+              // May have already exited
+            }
+          }
+        }
+        await deleteEnvironmentDir(ctx.envName);
+      });
+
+      await createEnvironment(metadata);
+
+      // Start two services
+      const sdkPid = await spawnDaemon(ctx.envName, "sdk", ["sleep", "30"], {
+        cwd: ctx.tempDir,
+      });
+      trackPid(sdkPid);
+
+      const frontPid = await spawnDaemon(ctx.envName, "front", ["sleep", "30"], {
+        cwd: ctx.tempDir,
+      });
+      trackPid(frontPid);
+
+      const running = await getRunningServices(ctx.envName);
+      expect(running).toContain("sdk");
+      expect(running).toContain("front");
+      expect(running).not.toContain("core");
+
+      // Clean up
+      try {
+        process.kill(sdkPid, "SIGKILL");
+        process.kill(frontPid, "SIGKILL");
+      } catch {
+        // May have already exited
+      }
+      untrackPid(sdkPid);
+      untrackPid(frontPid);
+    });
+
+    it("returns empty array when no services running", async () => {
+      const metadata: EnvironmentMetadata = {
+        name: ctx.envName,
+        baseBranch: "main",
+        workspaceBranch: `${ctx.envName}-workspace`,
+        createdAt: new Date().toISOString(),
+        repoRoot: ctx.tempDir,
+      };
+
+      registerCleanup(async () => {
+        await deleteEnvironmentDir(ctx.envName);
+      });
+
+      await createEnvironment(metadata);
+
+      const running = await getRunningServices(ctx.envName);
+      expect(running).toEqual([]);
+    });
+  });
+});

--- a/x/henry/dust-hive/tests/integration/setup.ts
+++ b/x/henry/dust-hive/tests/integration/setup.ts
@@ -1,0 +1,168 @@
+/**
+ * Integration test infrastructure
+ *
+ * Provides isolated test contexts with guaranteed cleanup.
+ */
+
+import { mkdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Counter for unique test names
+let testCounter = 0;
+
+/**
+ * Test context providing isolated directories for each test
+ */
+export interface TestContext {
+  /** Unique name for this test environment */
+  envName: string;
+  /** Temp directory for test files */
+  tempDir: string;
+  /** Cleanup function - call in afterEach */
+  cleanup: () => Promise<void>;
+}
+
+/**
+ * Create an isolated test context
+ */
+export async function createTestContext(prefix = "int"): Promise<TestContext> {
+  const timestamp = Date.now();
+  const counter = ++testCounter;
+  const envName = `${prefix}-${timestamp}-${counter}`;
+  const tempDir = join(tmpdir(), `dust-hive-test-${envName}`);
+
+  await mkdir(tempDir, { recursive: true });
+
+  return {
+    envName,
+    tempDir,
+    cleanup: async () => {
+      await rm(tempDir, { recursive: true, force: true }).catch(() => {});
+    },
+  };
+}
+
+/**
+ * Check if Docker is available
+ */
+export async function isDockerAvailable(): Promise<boolean> {
+  const proc = Bun.spawn(["docker", "info"], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  await proc.exited;
+  return proc.exitCode === 0;
+}
+
+/**
+ * Require Docker to be available, fail test if not
+ */
+export async function requireDocker(): Promise<void> {
+  if (!(await isDockerAvailable())) {
+    throw new Error("Docker is required for integration tests. Please start Docker and try again.");
+  }
+}
+
+/**
+ * Check if we're in a git repo
+ */
+export async function isInGitRepo(path: string): Promise<boolean> {
+  const proc = Bun.spawn(["git", "rev-parse", "--git-dir"], {
+    cwd: path,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  await proc.exited;
+  return proc.exitCode === 0;
+}
+
+/**
+ * Create a minimal git repo for testing
+ */
+export async function createTestGitRepo(path: string): Promise<void> {
+  await mkdir(path, { recursive: true });
+
+  // Initialize git repo
+  await runGit(path, ["init"]);
+  await runGit(path, ["config", "user.email", "test@test.local"]);
+  await runGit(path, ["config", "user.name", "Test User"]);
+
+  // Create minimal dust-hive structure
+  await mkdir(join(path, "sdks/js/dist"), { recursive: true });
+  await mkdir(join(path, "front"), { recursive: true });
+  await mkdir(join(path, "core"), { recursive: true });
+  await mkdir(join(path, "connectors"), { recursive: true });
+  await mkdir(join(path, "tools"), { recursive: true });
+
+  // Create package.json files
+  await Bun.write(
+    join(path, "sdks/js/package.json"),
+    JSON.stringify({ name: "@dust/client", version: "0.0.1" })
+  );
+  await Bun.write(
+    join(path, "front/package.json"),
+    JSON.stringify({ name: "front", version: "0.0.1" })
+  );
+  await Bun.write(
+    join(path, "connectors/package.json"),
+    JSON.stringify({ name: "connectors", version: "0.0.1" })
+  );
+  await Bun.write(join(path, "package.json"), JSON.stringify({ name: "dust", version: "0.0.1" }));
+
+  // Create placeholder SDK dist file (so build check passes)
+  await Bun.write(join(path, "sdks/js/dist/client.esm.js"), "// placeholder");
+
+  // Initial commit
+  await runGit(path, ["add", "."]);
+  await runGit(path, ["commit", "-m", "Initial commit"]);
+}
+
+/**
+ * Run a git command and throw on failure
+ */
+async function runGit(cwd: string, args: string[]): Promise<string> {
+  const proc = Bun.spawn(["git", ...args], {
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const stdout = await new Response(proc.stdout).text();
+  const stderr = await new Response(proc.stderr).text();
+  await proc.exited;
+
+  if (proc.exitCode !== 0) {
+    throw new Error(`git ${args.join(" ")} failed: ${stderr}`);
+  }
+
+  return stdout.trim();
+}
+
+/**
+ * Wait for a condition with timeout
+ */
+export async function waitFor(
+  condition: () => Promise<boolean>,
+  options: { timeout?: number; interval?: number; message?: string } = {}
+): Promise<void> {
+  const { timeout = 5000, interval = 100, message = "Condition not met" } = options;
+  const start = Date.now();
+
+  while (Date.now() - start < timeout) {
+    if (await condition()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, interval));
+  }
+
+  throw new Error(`${message} (timeout after ${timeout}ms)`);
+}
+
+/**
+ * Generate unique port base for test (to avoid conflicts)
+ * Uses ports in 50000-59000 range
+ */
+export function getTestPortBase(): number {
+  return 50000 + ((testCounter * 1000) % 9000);
+}


### PR DESCRIPTION
Add comprehensive integration tests covering the full environment lifecycle:
- filesystem.test.ts: Environment CRUD operations (18 tests)
- git.test.ts: Git worktree operations (16 tests)
- docker.test.ts: Docker compose management (8 tests)
- process.test.ts: Daemon process management (17 tests)
- lifecycle.test.ts: State transitions (11 tests)
- e2e.test.ts: Full spawn→warm→cool→destroy cycle (3 tests)

Also adds test infrastructure (setup.ts, cleanup.ts) for isolated test contexts with guaranteed cleanup, and new npm scripts for running tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
