### PR TITLE
New trial: trial & verify pages (Gated)

### DIFF
--- a/front/lib/iam/session.ts
+++ b/front/lib/iam/session.ts
@@ -16,7 +16,7 @@ import {
 } from "@app/lib/iam/users";
 import logger from "@app/logger/logger";
 import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
-import { isWorkspaceElligibleForTrial } from "@app/pages/api/auth/trial";
+import { isWorkspaceEligibleForTrial } from "@app/pages/api/auth/trial";
 import type { UserTypeWithWorkspaces } from "@app/types";
 import { isString } from "@app/types";
 
@@ -190,7 +190,7 @@ export function makeGetServerSidePropsRequirementsWrapper<
           );
         }
 
-        const redirectTrialPage = await isWorkspaceElligibleForTrial(auth!);
+        const redirectTrialPage = await isWorkspaceEligibleForTrial(auth!);
         if (redirectTrialPage) {
           return {
             redirect: {

--- a/front/lib/iam/session.ts
+++ b/front/lib/iam/session.ts
@@ -16,6 +16,7 @@ import {
 } from "@app/lib/iam/users";
 import logger from "@app/logger/logger";
 import { withGetServerSidePropsLogging } from "@app/logger/withlogging";
+import { isWorkspaceElligibleForTrial } from "@app/pages/api/auth/trial";
 import type { UserTypeWithWorkspaces } from "@app/types";
 import { isString } from "@app/types";
 
@@ -188,6 +189,17 @@ export function makeGetServerSidePropsRequirementsWrapper<
             "canUseProduct should never be true outside of a workspace context."
           );
         }
+
+        const redirectTrialPage = await isWorkspaceElligibleForTrial(auth!);
+        if (redirectTrialPage) {
+          return {
+            redirect: {
+              permanent: false,
+              destination: `/w/${context.query.wId}/trial`,
+            },
+          };
+        }
+
         return {
           redirect: {
             permanent: false,

--- a/front/pages/api/auth/trial.ts
+++ b/front/pages/api/auth/trial.ts
@@ -1,0 +1,42 @@
+import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
+import { isOldFreePlan } from "@app/lib/plans/plan_codes";
+import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
+
+/**
+ * Checks if a workspace is eligible for the trial page.
+ * A workspace is eligible if:
+ * - It has the "phone_trial_paywall" feature flag enabled.
+ * - It has never had another subscription before.
+ */
+export async function isWorkspaceElligibleForTrial(
+  auth: Authenticator
+): Promise<boolean> {
+  const owner = auth.getNonNullableWorkspace();
+
+  // If you're not admin it means the workspace had a subscription before.
+  // so no need to check further.
+  if (!auth.isAdmin()) {
+    return false;
+  }
+
+  const featureFlags = await getFeatureFlags(owner);
+  if (!featureFlags.includes("phone_trial_paywall")) {
+    return false;
+  }
+
+  const fetched = await SubscriptionResource.fetchByAuthenticator(auth);
+  const subscriptions = fetched.map((s) => s.toJSON());
+
+  // Current plan is either FREE_NO_PLAN or FREE_TEST_PLAN if you're on this paywall.
+  // FREE_NO_PLAN is not on the database, checking it comes down to having at least 1 subscription.
+  const noPreviousSubscription =
+    subscriptions.length === 0 ||
+    (subscriptions.length === 1 && isOldFreePlan(subscriptions[0].plan.code));
+
+  if (!noPreviousSubscription) {
+    return false;
+  }
+
+  return true;
+}

--- a/front/pages/api/auth/trial.ts
+++ b/front/pages/api/auth/trial.ts
@@ -9,7 +9,7 @@ import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
  * - It has the "phone_trial_paywall" feature flag enabled.
  * - It has never had another subscription before.
  */
-export async function isWorkspaceElligibleForTrial(
+export async function isWorkspaceEligibleForTrial(
   auth: Authenticator
 ): Promise<boolean> {
   const owner = auth.getNonNullableWorkspace();

--- a/front/pages/w/[wId]/trial.tsx
+++ b/front/pages/w/[wId]/trial.tsx
@@ -1,0 +1,95 @@
+import {
+  Button,
+  CheckIcon,
+  DustLogoSquare,
+  Icon,
+  Page,
+} from "@dust-tt/sparkle";
+import type { InferGetServerSidePropsType } from "next";
+import { useRouter } from "next/router";
+import React from "react";
+
+import { withDefaultUserAuthPaywallWhitelisted } from "@app/lib/iam/session";
+import type { WorkspaceType } from "@app/types";
+
+export const getServerSideProps = withDefaultUserAuthPaywallWhitelisted<{
+  owner: WorkspaceType;
+}>(async (context, auth) => {
+  const owner = auth.workspace();
+  if (!owner || !auth.isAdmin()) {
+    return {
+      notFound: true,
+    };
+  }
+
+  return {
+    props: {
+      owner,
+    },
+  };
+});
+
+export default function Trial({
+  owner,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  const router = useRouter();
+
+  const skip = async () => {
+    void router.push(`/w/${owner.sId}/subscribe`);
+  };
+
+  const startTrial = async () => {
+    void router.push(`/w/${owner.sId}/verify`);
+  };
+
+  const features = [
+    "Free 30-day trial",
+    "Advanced models (GPT-5, Claude..)",
+    "Custom agents which can execute actions",
+    "Connections (GitHub, Google Drive, Notion, Slack...)",
+    "Native integrations (Zendesk, Slack, Chrome Extension)",
+    "100 free messages",
+  ];
+
+  return (
+    <Page>
+      <div className="flex h-full flex-col justify-center">
+        <Page.Horizontal>
+          <Page.Vertical sizing="grow" gap="lg">
+            <Page.Header
+              title="Start your free trial"
+              icon={() => <DustLogoSquare className="-ml-11 h-10 w-32" />}
+            />
+            <p className="-mt-4 text-muted-foreground dark:text-muted-foreground-night">
+              No credit card required
+            </p>
+
+            <ul className="flex flex-col gap-4">
+              {features.map((feature, index) => (
+                <li key={index} className="flex items-center gap-3">
+                  <Icon
+                    visual={CheckIcon}
+                    size="sm"
+                    className="text-primary-500"
+                  />
+                  <span className="text-foreground dark:text-foreground-night">
+                    {feature}
+                  </span>
+                </li>
+              ))}
+            </ul>
+
+            <div className="flex flex-row gap-3">
+              <Button
+                onClick={startTrial}
+                variant="primary"
+                label="Start free trial"
+              />
+              <Button onClick={skip} variant="outline" label="Skip for now" />
+            </div>
+          </Page.Vertical>
+        </Page.Horizontal>
+      </div>
+    </Page>
+  );
+}

--- a/front/pages/w/[wId]/verify.tsx
+++ b/front/pages/w/[wId]/verify.tsx
@@ -14,7 +14,7 @@ import React, { useState } from "react";
 
 import { useSendNotification } from "@app/hooks/useNotification";
 import { withDefaultUserAuthPaywallWhitelisted } from "@app/lib/iam/session";
-import { isWorkspaceElligibleForTrial } from "@app/pages/api/auth/trial";
+import { isWorkspaceEligibleForTrial } from "@app/pages/api/auth/trial";
 import type { WorkspaceType } from "@app/types";
 
 // NOTE: This is a limited list of country codes for demonstration purposes.
@@ -42,7 +42,7 @@ export const getServerSideProps = withDefaultUserAuthPaywallWhitelisted<{
     };
   }
 
-  const isValidForTrial = await isWorkspaceElligibleForTrial(auth);
+  const isValidForTrial = await isWorkspaceEligibleForTrial(auth);
   if (!isValidForTrial) {
     return {
       notFound: true,

--- a/front/pages/w/[wId]/verify.tsx
+++ b/front/pages/w/[wId]/verify.tsx
@@ -1,0 +1,172 @@
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+  DustLogoSquare,
+  Input,
+  Page,
+} from "@dust-tt/sparkle";
+import type { InferGetServerSidePropsType } from "next";
+import React, { useState } from "react";
+
+import { useSendNotification } from "@app/hooks/useNotification";
+import { withDefaultUserAuthPaywallWhitelisted } from "@app/lib/iam/session";
+import { isWorkspaceElligibleForTrial } from "@app/pages/api/auth/trial";
+import type { WorkspaceType } from "@app/types";
+
+// NOTE: This is a limited list of country codes for demonstration purposes.
+// To refactor to have a complete list.
+const COUNTRY_CODES = [
+  { code: "+33", flag: "\u{1F1EB}\u{1F1F7}", country: "France" },
+  { code: "+1", flag: "\u{1F1FA}\u{1F1F8}", country: "United States" },
+  { code: "+44", flag: "\u{1F1EC}\u{1F1E7}", country: "United Kingdom" },
+  { code: "+49", flag: "\u{1F1E9}\u{1F1EA}", country: "Germany" },
+  { code: "+34", flag: "\u{1F1EA}\u{1F1F8}", country: "Spain" },
+  { code: "+39", flag: "\u{1F1EE}\u{1F1F9}", country: "Italy" },
+  { code: "+81", flag: "\u{1F1EF}\u{1F1F5}", country: "Japan" },
+  { code: "+86", flag: "\u{1F1E8}\u{1F1F3}", country: "China" },
+  { code: "+91", flag: "\u{1F1EE}\u{1F1F3}", country: "India" },
+  { code: "+61", flag: "\u{1F1E6}\u{1F1FA}", country: "Australia" },
+];
+
+export const getServerSideProps = withDefaultUserAuthPaywallWhitelisted<{
+  owner: WorkspaceType;
+}>(async (context, auth) => {
+  const owner = auth.workspace();
+  if (!owner || !auth.isAdmin()) {
+    return {
+      notFound: true,
+    };
+  }
+
+  const isValidForTrial = await isWorkspaceElligibleForTrial(auth);
+  if (!isValidForTrial) {
+    return {
+      notFound: true,
+    };
+  }
+
+  return {
+    props: {
+      owner,
+    },
+  };
+});
+
+// NOTE: This will change it's a placeholder implementation for now.
+// We will rework phone verification as part of the task implementing the phone validation service.
+function isValidPhoneNumber(phone: string): boolean {
+  const digitsOnly = phone.replace(/[\s\-().]/g, "");
+  return /^\d{6,15}$/.test(digitsOnly);
+}
+
+export default function Verify({
+  owner: _owner,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  const sendNotification = useSendNotification();
+
+  const [countryCode, setCountryCode] = useState("+33");
+  const [phoneNumber, setPhoneNumber] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const selectedCountry = COUNTRY_CODES.find((c) => c.code === countryCode);
+
+  const sendCode = async () => {
+    setError(null);
+
+    if (!phoneNumber.trim()) {
+      setError("Please enter your phone number.");
+      return;
+    }
+
+    if (!isValidPhoneNumber(phoneNumber)) {
+      setError("Please enter a valid phone number (digits only, 6-15 digits).");
+      return;
+    }
+
+    // TODO: Integrate with SMS service to send the code and redirect to a code verification page.
+    await sendNotification({
+      type: "success",
+      title: "SMS code sent",
+      description: `An SMS code has been sent to ${countryCode} ${phoneNumber}.`,
+    });
+  };
+
+  return (
+    <Page>
+      <div className="flex h-full flex-col justify-center">
+        <Page.Horizontal>
+          <Page.Vertical sizing="grow" gap="lg">
+            <Page.Header
+              title="Phone number"
+              icon={() => <DustLogoSquare className="-ml-11 h-10 w-32" />}
+            />
+            <p className="-mt-4 text-muted-foreground dark:text-muted-foreground-night">
+              To start your free trial, we need to verify your account with an
+              SMS code. <br />
+              Your number will only be used for this verification.
+            </p>
+
+            <div className="flex w-full max-w-xl flex-col gap-4">
+              <div className="flex w-full flex-col gap-2">
+                <label className="text-sm font-medium text-foreground dark:text-foreground-night">
+                  Phone number
+                </label>
+                <div className="flex w-full flex-row items-stretch">
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button
+                        variant="outline"
+                        className="rounded-r-none border-r-0"
+                        label={`${selectedCountry?.flag} ${countryCode}`}
+                        isSelect={true}
+                      />
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent>
+                      <DropdownMenuRadioGroup
+                        value={countryCode}
+                        onValueChange={setCountryCode}
+                      >
+                        {COUNTRY_CODES.map((country) => (
+                          <DropdownMenuRadioItem
+                            key={country.code}
+                            value={country.code}
+                            label={`${country.flag} ${country.code} ${country.country}`}
+                          />
+                        ))}
+                      </DropdownMenuRadioGroup>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                  <div className="min-w-0 flex-1">
+                    <Input
+                      name="phoneNumber"
+                      placeholder=""
+                      value={phoneNumber}
+                      onChange={(e) => {
+                        setPhoneNumber(e.target.value);
+                        setError(null);
+                      }}
+                      className="w-full rounded-l-none"
+                    />
+                  </div>
+                </div>
+                <p className="min-h-5 text-sm text-red-500">{error}</p>
+              </div>
+
+              <div className="flex justify-end">
+                <Button
+                  onClick={sendCode}
+                  variant="primary"
+                  label="Send code"
+                />
+              </div>
+            </div>
+          </Page.Vertical>
+        </Page.Horizontal>
+      </div>
+    </Page>
+  );
+}

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -235,6 +235,10 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Databricks MCP tool",
     stage: "on_demand",
   },
+  phone_trial_paywall: {
+    description: "Phone verification during trial sign-up",
+    stage: "dust_only",
+  },
 } as const satisfies Record<string, FeatureFlag>;
 
 export type FeatureFlagStage = "dust_only" | "rolling_out" | "on_demand";

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -675,6 +675,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "openai_o1_feature"
   | "openai_o1_high_reasoning_feature"
   | "openai_usage_mcp"
+  | "phone_trial_paywall"
   | "restrict_agents_publishing"
   | "salesforce_synced_queries"
   | "salesforce_tool_write"


### PR DESCRIPTION
## Description

This PR introduces two new pages for the trial onboarding flow:
- `/w/[wId]/trial`  → Landing page for users to start their free trial (or skip). 
- `/w/[wId]/verify` → Phone number verification page (with very basic validation for now - to be reworked).

***

This PR does not handle the phone verification flow, just the basics so that we can parralelize work on this project:
- Phone number input with country code selector (dropdown with flag emojis)
- Basic client-side phone number validation (6-15 digits)


I suggest that the /verify page should use internal state (step: "phone" | "code") to toggle between the two views. This approach:
  - Follows common UX patterns for verification flows (like 2FA)
  - Allows showing context: "We sent a code to +33 6XX..." while entering the code
  - Enables easy "Resend code" and "Change number" actions without navigation
  - Keeps tightly coupled steps feeling like one cohesive flow


So Proposal is the trial flow uses 2 URLs with /verify handling both phone entry and code verification:
```
/trial 
  → (Start free trial) → /verify (phone step)
        → /verify (code step, same page)
        → success → redirect to chat homepage with a sub on our new plan
  → (Skip for now) → /subscribe 
```


All of this is of course behind a Feature flag, so no changes for people subscribing on production. 


## Tests

Locally. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 