### PR TITLE
[front] feat(skills): add poke page to inspect single skill

### DIFF
--- a/front/components/poke/skills/SkillOverviewTable.tsx
+++ b/front/components/poke/skills/SkillOverviewTable.tsx
@@ -1,0 +1,93 @@
+import { Chip } from "@dust-tt/sparkle";
+
+import {
+  PokeTable,
+  PokeTableBody,
+  PokeTableCell,
+  PokeTableRow,
+} from "@app/components/poke/shadcn/ui/table";
+import { formatTimestampToFriendlyDate } from "@app/lib/utils";
+import type { SpaceType, UserType } from "@app/types";
+import type { SkillType } from "@app/types/assistant/skill_configuration";
+
+interface SkillOverviewTableProps {
+  skill: SkillType;
+  author: UserType | null;
+  spaces: SpaceType[];
+}
+
+export function SkillOverviewTable({
+  skill,
+  author,
+  spaces,
+}: SkillOverviewTableProps) {
+  return (
+    <div className="border-material-200 flex flex-grow flex-col rounded-lg border p-4">
+      <div className="flex items-center justify-between gap-3">
+        <h2 className="text-md flex-grow pb-4 font-bold">Overview</h2>
+      </div>
+      <PokeTable>
+        <PokeTableBody>
+          <PokeTableRow>
+            <PokeTableCell>Name</PokeTableCell>
+            <PokeTableCell>{skill.name}</PokeTableCell>
+          </PokeTableRow>
+          <PokeTableRow>
+            <PokeTableCell>sId</PokeTableCell>
+            <PokeTableCell>{skill.sId}</PokeTableCell>
+          </PokeTableRow>
+          <PokeTableRow>
+            <PokeTableCell>Status</PokeTableCell>
+            <PokeTableCell>
+              <span className="capitalize">{skill.status}</span>
+            </PokeTableCell>
+          </PokeTableRow>
+          <PokeTableRow>
+            <PokeTableCell>Spaces</PokeTableCell>
+            <PokeTableCell className="flex flex-row space-x-2">
+              {spaces.map((s) => (
+                <Chip
+                  key={s.sId}
+                  size="sm"
+                  color={s.isRestricted ? "warning" : "blue"}
+                >
+                  {s.name}
+                </Chip>
+              ))}
+            </PokeTableCell>
+          </PokeTableRow>
+          <PokeTableRow>
+            <PokeTableCell>Extended skill</PokeTableCell>
+            <PokeTableCell>{skill.extendedSkillId ?? "None"}</PokeTableCell>
+          </PokeTableRow>
+          <PokeTableRow>
+            <PokeTableCell>Tools count</PokeTableCell>
+            <PokeTableCell>{skill.tools.length}</PokeTableCell>
+          </PokeTableRow>
+          <PokeTableRow>
+            <PokeTableCell>Created at</PokeTableCell>
+            <PokeTableCell>
+              {skill.createdAt
+                ? formatTimestampToFriendlyDate(skill.createdAt)
+                : "N/A"}
+            </PokeTableCell>
+          </PokeTableRow>
+          <PokeTableRow>
+            <PokeTableCell>Updated at</PokeTableCell>
+            <PokeTableCell>
+              {skill.updatedAt
+                ? formatTimestampToFriendlyDate(skill.updatedAt)
+                : "N/A"}
+            </PokeTableCell>
+          </PokeTableRow>
+          <PokeTableRow>
+            <PokeTableCell>Created by</PokeTableCell>
+            <PokeTableCell>
+              {author ? `${author.fullName} (${author.email})` : "N/A"}
+            </PokeTableCell>
+          </PokeTableRow>
+        </PokeTableBody>
+      </PokeTable>
+    </div>
+  );
+}

--- a/front/components/poke/skills/columns.tsx
+++ b/front/components/poke/skills/columns.tsx
@@ -1,8 +1,9 @@
-import { Button } from "@dust-tt/sparkle";
+import { Button, LinkWrapper } from "@dust-tt/sparkle";
 import { ArrowsUpDownIcon } from "@heroicons/react/20/solid";
 import type { ColumnDef } from "@tanstack/react-table";
 
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
+import type { LightWorkspaceType } from "@app/types";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 
 type SkillDisplayType = Pick<
@@ -10,10 +11,20 @@ type SkillDisplayType = Pick<
   "sId" | "name" | "status" | "createdAt" | "updatedAt"
 >;
 
-export function makeColumnsForSkills(): ColumnDef<SkillDisplayType>[] {
+export function makeColumnsForSkills(owner: LightWorkspaceType
+): ColumnDef<SkillDisplayType>[] {
   return [
     {
       accessorKey: "sId",
+      cell: ({ row }) => {
+        const sId: string = row.getValue("sId");
+
+        return (
+          <LinkWrapper href={`/poke/${owner.sId}/skills/${sId}`}>
+            {sId}
+          </LinkWrapper>
+        );
+      },
       header: ({ column }) => {
         return (
           <div className="flex space-x-2">

--- a/front/components/poke/skills/columns.tsx
+++ b/front/components/poke/skills/columns.tsx
@@ -11,7 +11,8 @@ type SkillDisplayType = Pick<
   "sId" | "name" | "status" | "createdAt" | "updatedAt"
 >;
 
-export function makeColumnsForSkills(owner: LightWorkspaceType
+export function makeColumnsForSkills(
+  owner: LightWorkspaceType
 ): ColumnDef<SkillDisplayType>[] {
   return [
     {

--- a/front/components/poke/skills/table.tsx
+++ b/front/components/poke/skills/table.tsx
@@ -17,7 +17,9 @@ export function SkillsDataTable({ owner, loadOnInit }: SkillsDataTableProps) {
       loadOnInit={loadOnInit}
       useSWRHook={usePokeSkills}
     >
-      {(data) => <PokeDataTable columns={makeColumnsForSkills()} data={data} />}
+      {(data) => (
+        <PokeDataTable columns={makeColumnsForSkills(owner)} data={data} />
+      )}
     </PokeDataTableConditionalFetch>
   );
 }

--- a/front/pages/poke/[wId]/skills/[sId]/index.tsx
+++ b/front/pages/poke/[wId]/skills/[sId]/index.tsx
@@ -1,6 +1,7 @@
 import { TextArea } from "@dust-tt/sparkle";
 import { JsonViewer } from "@textea/json-viewer";
 import type { InferGetServerSidePropsType } from "next";
+import Link from "next/link";
 import type { ReactElement } from "react";
 
 import PokeLayout from "@app/components/poke/PokeLayout";
@@ -63,9 +64,9 @@ const SkillDetailsPage = ({
     <div>
       <h3 className="text-xl font-bold">
         Skill {skill.name} from workspace&nbsp;
-        <a href={`/poke/${owner.sId}`} className="text-highlight-500">
+        <Link href={`/poke/${owner.sId}`} className="text-highlight-500">
           {owner.name}
-        </a>
+        </Link>
       </h3>
 
       <div className="mt-4 flex flex-row items-stretch space-x-3">

--- a/front/pages/poke/[wId]/skills/[sId]/index.tsx
+++ b/front/pages/poke/[wId]/skills/[sId]/index.tsx
@@ -1,0 +1,141 @@
+import { TextArea } from "@dust-tt/sparkle";
+import { JsonViewer } from "@textea/json-viewer";
+import type { InferGetServerSidePropsType } from "next";
+import type { ReactElement } from "react";
+
+import PokeLayout from "@app/components/poke/PokeLayout";
+import { SkillOverviewTable } from "@app/components/poke/skills/SkillOverviewTable";
+import { useTheme } from "@app/components/sparkle/ThemeContext";
+import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import type { SpaceType, UserType, WorkspaceType } from "@app/types";
+import { isString } from "@app/types";
+import type { SkillType } from "@app/types/assistant/skill_configuration";
+
+export const getServerSideProps = withSuperUserAuthRequirements<{
+  skill: SkillType;
+  author: UserType | null;
+  spaces: SpaceType[];
+  owner: WorkspaceType;
+}>(async (context, auth) => {
+  const sId = context.params?.sId;
+  if (!isString(sId)) {
+    return {
+      notFound: true,
+    };
+  }
+
+  const skill = await SkillResource.fetchById(auth, sId);
+
+  if (!skill) {
+    return {
+      notFound: true,
+    };
+  }
+
+  const serializedSkill = skill.toJSON(auth);
+  const author = await skill.fetchAuthor(auth);
+  const spaces = await SpaceResource.fetchByIds(
+    auth,
+    serializedSkill.requestedSpaceIds
+  );
+
+  return {
+    props: {
+      owner: auth.getNonNullableWorkspace(),
+      skill: serializedSkill,
+      author: author ? author.toJSON() : null,
+      spaces: spaces.map((s) => s.toJSON()),
+    },
+  };
+});
+
+const SkillDetailsPage = ({
+  owner,
+  skill,
+  author,
+  spaces,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) => {
+  const { isDark } = useTheme();
+
+  return (
+    <div>
+      <h3 className="text-xl font-bold">
+        Skill {skill.name} from workspace&nbsp;
+        <a href={`/poke/${owner.sId}`} className="text-highlight-500">
+          {owner.name}
+        </a>
+      </h3>
+
+      <div className="mt-4 flex flex-row items-stretch space-x-3">
+        <SkillOverviewTable skill={skill} author={author} spaces={spaces} />
+      </div>
+
+      <div className="mt-4 flex flex-row gap-4">
+        <div className="border-material-200 flex-1 rounded-lg border p-4">
+          <h2 className="text-md pb-4 font-bold">User-facing description</h2>
+          <TextArea
+            value={skill.userFacingDescription}
+            readOnly
+            minRows={4}
+            resize="none"
+            isDisplay
+          />
+        </div>
+        <div className="border-material-200 flex-1 rounded-lg border p-4">
+          <h2 className="text-md pb-4 font-bold">Agent-facing description</h2>
+          <TextArea
+            value={skill.agentFacingDescription}
+            readOnly
+            minRows={4}
+            resize="none"
+            isDisplay
+          />
+        </div>
+      </div>
+
+      <div className="mt-4">
+        <div className="border-material-200 rounded-lg border p-4">
+          <h2 className="text-md pb-4 font-bold">Instructions</h2>
+          <TextArea
+            value={skill.instructions ?? ""}
+            readOnly
+            resize="none"
+            isDisplay
+          />
+        </div>
+      </div>
+
+      <div className="mt-4">
+        <div className="border-material-200 rounded-lg border p-4">
+          <h2 className="text-md pb-4 font-bold">
+            Tools ({skill.tools.length})
+          </h2>
+          {skill.tools.map((tool, index) => (
+            <div key={index} className="mb-4">
+              <div className="text-sm font-medium">{tool.name}</div>
+              <JsonViewer
+                theme={isDark ? "dark" : "light"}
+                value={tool}
+                rootName={false}
+                defaultInspectDepth={1}
+              />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+SkillDetailsPage.getLayout = (
+  page: ReactElement,
+  { owner, skill }: { owner: WorkspaceType; skill: SkillType }
+) => {
+  return (
+    <PokeLayout title={`${owner.name} - ${skill.name}`}>{page}</PokeLayout>
+  );
+};
+
+export default SkillDetailsPage;


### PR DESCRIPTION
## Description

- This PR adds a page to inspect a single skill in poke, under `poke/[wId]/skills/[sId]`.
- Clicking on the id of a skill in the data table leads to this page.

<img width="699" alt="Screenshot 2026-01-05 at 9 56 45 AM" src="https://github.com/user-attachments/assets/fabe226f-3b26-46b9-be35-59def35d848b" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
