### PR TITLE
[sparkle] - refactor(AttachmentChip): streamline API

### DIFF
--- a/sparkle/src/components/AttachmentChip.tsx
+++ b/sparkle/src/components/AttachmentChip.tsx
@@ -12,38 +12,43 @@ const attachmentChipOverrides = cn(
   "dark:s-bg-background-night dark:s-text-foreground-night"
 );
 
-type AttachmentChipIconProps = IconProps | DoubleIconProps;
+export type AttachmentChipIconProps = IconProps;
+export type AttachmentChipDoubleIconProps = DoubleIconProps;
 
-function isDoubleIconProps(
-  props: AttachmentChipIconProps
-): props is DoubleIconProps {
-  return "mainIcon" in props;
-}
+type AttachmentChipIconOptions =
+  | { icon?: AttachmentChipIconProps; doubleIcon?: never }
+  | { icon?: never; doubleIcon?: AttachmentChipDoubleIconProps };
 
-interface AttachmentChipBaseProps {
+export type AttachmentChipBaseProps = AttachmentChipIconOptions & {
   label: string;
-  icon?: AttachmentChipIconProps;
   size?: (typeof CHIP_SIZES)[number];
   color?: (typeof CHIP_COLORS)[number];
   className?: string;
   isBusy?: boolean;
   onRemove?: () => void;
-  onClick?: () => void;
-}
+  children?: never;
+};
 
-type AttachmentChipButtonProps = AttachmentChipBaseProps & {
+export type AttachmentChipButtonProps = AttachmentChipBaseProps & {
   href?: never;
+  onClick?: () => void;
 } & {
   [K in keyof Omit<LinkWrapperProps, "children">]?: never;
 };
 
-type AttachmentChipLinkProps = AttachmentChipBaseProps &
-  Omit<LinkWrapperProps, "children">;
+export type AttachmentChipLinkProps = AttachmentChipBaseProps &
+  Omit<LinkWrapperProps, "children" | "href"> & {
+    href: string;
+    onClick?: never;
+  };
 
-type AttachmentChipProps = AttachmentChipButtonProps | AttachmentChipLinkProps;
+export type AttachmentChipProps =
+  | AttachmentChipButtonProps
+  | AttachmentChipLinkProps;
 
 export function AttachmentChip({
   icon,
+  doubleIcon,
   className,
   label,
   size,
@@ -53,13 +58,12 @@ export function AttachmentChip({
   onClick,
   ...linkProps
 }: AttachmentChipProps) {
-  const iconElement = icon && (
+  const chipClassName = cn(attachmentChipOverrides, className);
+  const iconElement = (icon || doubleIcon) && (
     <div className="s-shrink-0">
-      {isDoubleIconProps(icon) ? <DoubleIcon {...icon} /> : <Icon {...icon} />}
+      {doubleIcon ? <DoubleIcon {...doubleIcon} /> : <Icon {...icon} />}
     </div>
   );
-
-  const chipClassName = cn(attachmentChipOverrides, className);
 
   if ("href" in linkProps && linkProps.href) {
     return (

--- a/sparkle/src/stories/AttachmentChip.stories.tsx
+++ b/sparkle/src/stories/AttachmentChip.stories.tsx
@@ -85,7 +85,7 @@ export const LongLabel: Story = {
 export const WithDoubleIcon: Story = {
   args: {
     label: "My Drive Folder",
-    icon: { mainIcon: FolderIcon, secondaryIcon: DriveLogo, size: "sm" },
+    doubleIcon: { mainIcon: FolderIcon, secondaryIcon: DriveLogo, size: "sm" },
   },
   decorators: [
     (Story) => (
@@ -99,7 +99,11 @@ export const WithDoubleIcon: Story = {
 export const WithDoubleIconAndLink: Story = {
   args: {
     label: "Notion Document",
-    icon: { mainIcon: DocumentIcon, secondaryIcon: NotionLogo, size: "sm" },
+    doubleIcon: {
+      mainIcon: DocumentIcon,
+      secondaryIcon: NotionLogo,
+      size: "sm",
+    },
     href: "https://notion.so",
     target: "_blank",
   },


### PR DESCRIPTION
## Description
Refactors the `AttachmentChip` component to improve type safety and API clarity by explicitly separating single icon and double icon props. The icon prop now accepts only `IconProps`, while a new `doubleIcon` prop accepts `DoubleIconProps`. This eliminates the need for runtime type checking with the `isDoubleIconProps` function. All related types are exported for better reusability.

## Risk
Low - only affects the `AttachmentChip` component 

## Tests

Updated Storybook stories to use the new `doubleIcon` prop instead of passing `DoubleIconProps` through the `icon` prop.

## Deploy Plan
- Publish Sparkle RC
- Update front to use new API
- Publish Sparkle GR
