### PR TITLE
feat: improve instruction blocks in agent details

### DIFF
--- a/front/components/assistant/AgentMessageMarkdown.integration.test.tsx
+++ b/front/components/assistant/AgentMessageMarkdown.integration.test.tsx
@@ -124,49 +124,77 @@ describe("AgentMessageMarkdown - Integration Tests", () => {
   });
 
   describe("Instruction Block Preprocessing", () => {
-    it.skip("preprocesses and renders instruction blocks", () => {
+    it("does not process instructions block when not enabled", () => {
       const content = "<instructions>Follow these steps</instructions>";
       const { container } = render(
         <AgentMessageMarkdown owner={mockOwner} content={content} />
       );
-      // Check that the instruction block was preprocessed and rendered
-      expect(container.textContent).toContain("INSTRUCTIONS");
-      expect(container.textContent).toContain("Follow these steps");
+      // no processing
+      expect(container.textContent).toBe(
+        "<instructions>Follow these steps</instructions>"
+      );
     });
 
-    it.skip("handles custom tag names in instruction blocks", () => {
-      const content = "<my_custom_tag>Custom content</my_custom_tag>";
-      const { container } = render(
-        <AgentMessageMarkdown owner={mockOwner} content={content} />
-      );
-      expect(container.textContent).toContain("MY_CUSTOM_TAG");
-      expect(container.textContent).toContain("Custom content");
-    });
+    describe("when isInstructions enabled", () => {
+      it("preprocesses and renders instruction blocks", () => {
+        const content = "<instructions>Follow these steps</instructions>";
+        const { container } = render(
+          <AgentMessageMarkdown
+            owner={mockOwner}
+            content={content}
+            isInstructions={true}
+          />
+        );
+        expect(container.textContent).toContain("INSTRUCTIONS");
+        expect(container.textContent).toContain("Follow these steps");
+      });
 
-    it.skip("handles multiple instruction blocks", () => {
-      const content = "<tag1>Content 1</tag1>\n\n<tag2>Content 2</tag2>";
-      const { container } = render(
-        <AgentMessageMarkdown owner={mockOwner} content={content} />
-      );
-      expect(container.textContent).toContain("TAG1");
-      expect(container.textContent).toContain("Content 1");
-      expect(container.textContent).toContain("TAG2");
-      expect(container.textContent).toContain("Content 2");
-    });
+      it("handles custom tag names in instruction blocks", () => {
+        const content = "<my_custom_tag>Custom content</my_custom_tag>";
+        const { container } = render(
+          <AgentMessageMarkdown
+            owner={mockOwner}
+            content={content}
+            isInstructions={true}
+          />
+        );
+        expect(container.textContent).toContain("MY_CUSTOM_TAG");
+        expect(container.textContent).toContain("Custom content");
+      });
 
-    it.skip("renders markdown inside instruction blocks", () => {
-      const content =
-        "<instructions>**Bold** and *italic* content</instructions>";
-      const { container } = render(
-        <AgentMessageMarkdown owner={mockOwner} content={content} />
-      );
-      expect(container.querySelector("strong")).toBeInTheDocument();
-      expect(container.querySelector("em")).toBeInTheDocument();
+      it("handles multiple instruction blocks", () => {
+        const content = "<tag1>Content 1</tag1>\n\n<tag2>Content 2</tag2>";
+        const { container } = render(
+          <AgentMessageMarkdown
+            owner={mockOwner}
+            content={content}
+            isInstructions={true}
+          />
+        );
+        expect(container.textContent).toContain("TAG1");
+        expect(container.textContent).toContain("Content 1");
+        expect(container.textContent).toContain("TAG2");
+        expect(container.textContent).toContain("Content 2");
+      });
+
+      it("renders markdown inside instruction blocks", () => {
+        const content =
+          "<instructions>**Bold** and *italic* content</instructions>";
+        const { container } = render(
+          <AgentMessageMarkdown
+            owner={mockOwner}
+            content={content}
+            isInstructions={true}
+          />
+        );
+        expect(container.querySelector("strong")).toBeInTheDocument();
+        expect(container.querySelector("em")).toBeInTheDocument();
+      });
     });
   });
 
   describe("Complex Content Scenarios", () => {
-    it.skip("renders mixed markdown and instruction blocks", () => {
+    it("renders mixed markdown and instruction blocks", () => {
       const content = `# Heading
 
 Regular paragraph with **bold** text.
@@ -178,7 +206,11 @@ Regular paragraph with **bold** text.
 
 More content after.`;
       const { container } = render(
-        <AgentMessageMarkdown owner={mockOwner} content={content} />
+        <AgentMessageMarkdown
+          owner={mockOwner}
+          content={content}
+          isInstructions={true}
+        />
       );
       expect(container.querySelector("h1")).toBeInTheDocument();
       expect(container.querySelector("strong")).toBeInTheDocument();

--- a/front/components/assistant/details/tabs/AgentInfoTab/index.tsx
+++ b/front/components/assistant/details/tabs/AgentInfoTab/index.tsx
@@ -79,6 +79,7 @@ export function AgentInfoTab({
               content={agentConfiguration.instructions}
               owner={owner}
               compactSpacing={true}
+              isInstructions={true}
             />
           </div>
         </div>


### PR DESCRIPTION
## Description

Display instructions blocks correctly only in the agent details. 

As we use the same component for agent messages, we need the `if`


## Tests

<img width="1045" height="303" alt="image" src="https://github.com/user-attachments/assets/54c8520c-c1d5-41d3-9db8-6e95717328ab" />

<img width="562" height="307" alt="image" src="https://github.com/user-attachments/assets/7ea4b218-2c61-4e77-b1ff-51728dad76c4" />


<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
