### PR TITLE
[connectors] enh(logging): add fine-grained stop reasons logged to Temporal

### DIFF
--- a/connectors/scripts/20250621_mark_as_error_and_unistall_slack_app.ts
+++ b/connectors/scripts/20250621_mark_as_error_and_unistall_slack_app.ts
@@ -35,7 +35,9 @@ async function markConnectorAsErrorAndUninstall({
 
   if (execute) {
     // Stop the workflows.
-    await connectorManager.pauseAndStop();
+    await connectorManager.pauseAndStop({
+      reason: "Stopped to uninstall Slack app (script)",
+    });
 
     // Mark the connector as error so it's not picked up by monitors.
     await connector.markAsError("third_party_internal_error");

--- a/connectors/src/api/delete_connector.ts
+++ b/connectors/src/api/delete_connector.ts
@@ -29,7 +29,9 @@ const _deleteConnectorAPIHandler = async (
     connectorId: connector.id,
   });
 
-  const stopRes = await connectorManager.stop();
+  const stopRes = await connectorManager.stop({
+    reason: "Connector deleted via API",
+  });
 
   if (stopRes.isErr() && !force) {
     return apiError(req, res, {

--- a/connectors/src/api/pause_connector.ts
+++ b/connectors/src/api/pause_connector.ts
@@ -32,7 +32,7 @@ const _pauseConnectorAPIHandler = async (
     const pauseRes = await getConnectorManager({
       connectorProvider: connector.type,
       connectorId: connector.id,
-    }).pauseAndStop();
+    }).pauseAndStop({ reason: "Paused via connector PAUSE API" });
 
     if (pauseRes.isErr()) {
       return apiError(req, res, {

--- a/connectors/src/api/stop_connector.ts
+++ b/connectors/src/api/stop_connector.ts
@@ -32,7 +32,7 @@ const _stopConnectorAPIHandler = async (
     const stopRes = await getConnectorManager({
       connectorProvider: connector.type,
       connectorId: connector.id,
-    }).stop();
+    }).stop({ reason: "Stopped via connector STOP API" });
 
     if (stopRes.isErr()) {
       return apiError(req, res, {

--- a/connectors/src/connectors/bigquery/index.ts
+++ b/connectors/src/connectors/bigquery/index.ts
@@ -179,10 +179,14 @@ export class BigQueryConnectorManager extends BaseConnectorManager<null> {
     return new Ok(undefined);
   }
 
-  async stop(): Promise<Result<undefined, Error>> {
+  async stop({
+    reason,
+  }: {
+    reason: string;
+  }): Promise<Result<undefined, Error>> {
     const stopRes = await stopBigQuerySyncWorkflow({
       connectorId: this.connectorId,
-      stopReason: "Stopped via connector STOP command",
+      stopReason: reason,
     });
     if (stopRes.isErr()) {
       return stopRes;

--- a/connectors/src/connectors/confluence/index.ts
+++ b/connectors/src/connectors/confluence/index.ts
@@ -190,10 +190,14 @@ export class ConfluenceConnectorManager extends BaseConnectorManager<null> {
     return new Ok(undefined);
   }
 
-  async stop(): Promise<Result<undefined, Error>> {
+  async stop({
+    reason,
+  }: {
+    reason: string;
+  }): Promise<Result<undefined, Error>> {
     const res = await stopConfluenceSyncWorkflow({
       connectorId: this.connectorId,
-      stopReason: "Stopped via connector STOP command",
+      stopReason: reason,
     });
     if (res.isErr()) {
       return res;

--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -147,7 +147,11 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
     return new Ok(c.id.toString());
   }
 
-  async stop(): Promise<Result<undefined, Error>> {
+  async stop({
+    reason,
+  }: {
+    reason: string;
+  }): Promise<Result<undefined, Error>> {
     try {
       const connector = await ConnectorResource.fetchById(this.connectorId);
 
@@ -171,7 +175,7 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
 
       await terminateAllWorkflowsForConnectorId({
         connectorId: this.connectorId,
-        stopReason: "Stopped via connector STOP command",
+        stopReason: reason,
       });
 
       return new Ok(undefined);

--- a/connectors/src/connectors/gong/index.ts
+++ b/connectors/src/connectors/gong/index.ts
@@ -198,14 +198,18 @@ export class GongConnectorManager extends BaseConnectorManager<null> {
     return new Ok(undefined);
   }
 
-  async stop(): Promise<Result<undefined, Error>> {
+  async stop({
+    reason,
+  }: {
+    reason: string;
+  }): Promise<Result<undefined, Error>> {
     const connector = await fetchGongConnector({
       connectorId: this.connectorId,
     });
     const result = await pauseSchedule({
       connector,
       scheduleId: makeGongSyncScheduleId(connector),
-      stopReason: "Stopped via connector STOP command",
+      stopReason: reason,
     });
     if (result.isErr()) {
       return result;

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -787,10 +787,14 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
     return launchGoogleGarbageCollector(this.connectorId);
   }
 
-  async stop(): Promise<Result<undefined, Error>> {
+  async stop({
+    reason,
+  }: {
+    reason: string;
+  }): Promise<Result<undefined, Error>> {
     await terminateAllWorkflowsForConnectorId({
       connectorId: this.connectorId,
-      stopReason: "Stopped via connector STOP command",
+      stopReason: reason,
     });
     return new Ok(undefined);
   }

--- a/connectors/src/connectors/intercom/index.ts
+++ b/connectors/src/connectors/intercom/index.ts
@@ -234,14 +234,18 @@ export class IntercomConnectorManager extends BaseConnectorManager<null> {
     return new Ok(undefined);
   }
 
-  async stop(): Promise<Result<undefined, Error>> {
+  async stop({
+    reason,
+  }: {
+    reason: string;
+  }): Promise<Result<undefined, Error>> {
     const connector = await ConnectorResource.fetchById(this.connectorId);
     if (!connector) {
       return new Err(new Error("Connector not found"));
     }
 
     const res = await stopIntercomSchedulesAndWorkflows(connector, {
-      stopReason: "Stopped via connector STOP command",
+      stopReason: reason,
     });
     if (res.isErr()) {
       return res;

--- a/connectors/src/connectors/interface.ts
+++ b/connectors/src/connectors/interface.ts
@@ -58,7 +58,7 @@ export abstract class BaseConnectorManager<T extends ConnectorConfiguration> {
 
   abstract clean(params: { force: boolean }): Promise<Result<undefined, Error>>;
 
-  abstract stop(): Promise<Result<undefined, Error>>;
+  abstract stop(params: { reason: string }): Promise<Result<undefined, Error>>;
 
   abstract resume(): Promise<Result<undefined, Error>>;
 
@@ -98,7 +98,11 @@ export abstract class BaseConnectorManager<T extends ConnectorConfiguration> {
 
   abstract garbageCollect(): Promise<Result<string, Error>>;
 
-  async pauseAndStop(): Promise<Result<undefined, Error>> {
+  async pauseAndStop({
+    reason,
+  }: {
+    reason: string;
+  }): Promise<Result<undefined, Error>> {
     const connector = await ConnectorResource.fetchById(this.connectorId);
     if (!connector) {
       throw new Error(
@@ -106,7 +110,7 @@ export abstract class BaseConnectorManager<T extends ConnectorConfiguration> {
       );
     }
     await connector.markAsPaused();
-    return this.stop();
+    return this.stop({ reason });
   }
 
   async unpauseAndResume(): Promise<Result<undefined, Error>> {

--- a/connectors/src/connectors/microsoft/index.ts
+++ b/connectors/src/connectors/microsoft/index.ts
@@ -462,10 +462,14 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
     return new Ok(undefined);
   }
 
-  async stop(): Promise<Result<undefined, Error>> {
+  async stop({
+    reason,
+  }: {
+    reason: string;
+  }): Promise<Result<undefined, Error>> {
     await terminateAllWorkflowsForConnectorId({
       connectorId: this.connectorId,
-      stopReason: "Stopped via connector STOP command",
+      stopReason: reason,
     });
     return new Ok(undefined);
   }

--- a/connectors/src/connectors/notion/index.ts
+++ b/connectors/src/connectors/notion/index.ts
@@ -242,7 +242,11 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
     return new Ok(c.id.toString());
   }
 
-  async stop(): Promise<Result<undefined, Error>> {
+  async stop({
+    reason,
+  }: {
+    reason: string;
+  }): Promise<Result<undefined, Error>> {
     const connector = await ConnectorResource.fetchById(this.connectorId);
 
     if (!connector) {
@@ -259,7 +263,7 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
     try {
       await stopNotionSyncWorkflow({
         connectorId: connector.id,
-        stopReason: "Stopped via connector STOP command",
+        stopReason: reason,
       });
     } catch (e) {
       logger.error(
@@ -362,7 +366,7 @@ export class NotionConnectorManager extends BaseConnectorManager<null> {
     }
 
     try {
-      await this.stop();
+      await this.stop({ reason: "Stopped for full resync" });
     } catch (e) {
       logger.error(
         {

--- a/connectors/src/connectors/salesforce/index.ts
+++ b/connectors/src/connectors/salesforce/index.ts
@@ -135,7 +135,11 @@ export class SalesforceConnectorManager extends BaseConnectorManager<null> {
     return new Ok(undefined);
   }
 
-  async stop(): Promise<Result<undefined, Error>> {
+  async stop({
+    reason,
+  }: {
+    reason: string;
+  }): Promise<Result<undefined, Error>> {
     const connector = await ConnectorResource.fetchById(this.connectorId);
     if (!connector) {
       throw new Error(`Connector ${this.connectorId} not found`);
@@ -149,13 +153,13 @@ export class SalesforceConnectorManager extends BaseConnectorManager<null> {
         stopSalesforceSyncQueryWorkflow({
           connectorId: connector.id,
           queryId: query.id,
-          stopReason: "Stopped via connector STOP command",
+          stopReason: reason,
         })
       )
     );
     const stopRes = await stopSalesforceSyncWorkflow({
       connectorId: this.connectorId,
-      stopReason: "Stopped via connector STOP command",
+      stopReason: reason,
     });
     if (stopRes.isErr()) {
       return stopRes;

--- a/connectors/src/connectors/slack/index.ts
+++ b/connectors/src/connectors/slack/index.ts
@@ -712,7 +712,11 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
     }
   }
 
-  async stop(): Promise<Result<undefined, Error>> {
+  async stop({
+    reason,
+  }: {
+    reason: string;
+  }): Promise<Result<undefined, Error>> {
     const connector = await ConnectorResource.fetchById(this.connectorId);
     if (!connector) {
       return new Err(
@@ -722,7 +726,7 @@ export class SlackConnectorManager extends BaseConnectorManager<SlackConfigurati
 
     await terminateAllWorkflowsForConnectorId({
       connectorId: this.connectorId,
-      stopReason: "Stopped via connector STOP command",
+      stopReason: reason,
     });
 
     return new Ok(undefined);

--- a/connectors/src/connectors/snowflake/index.ts
+++ b/connectors/src/connectors/snowflake/index.ts
@@ -190,10 +190,14 @@ export class SnowflakeConnectorManager extends BaseConnectorManager<null> {
     return new Ok(undefined);
   }
 
-  async stop(): Promise<Result<undefined, Error>> {
+  async stop({
+    reason,
+  }: {
+    reason: string;
+  }): Promise<Result<undefined, Error>> {
     const stopRes = await stopSnowflakeSyncWorkflow({
       connectorId: this.connectorId,
-      stopReason: "Stopped via connector STOP command",
+      stopReason: reason,
     });
     if (stopRes.isErr()) {
       return stopRes;

--- a/connectors/src/connectors/webcrawler/index.ts
+++ b/connectors/src/connectors/webcrawler/index.ts
@@ -120,7 +120,11 @@ export class WebcrawlerConnectorManager extends BaseConnectorManager<WebCrawlerC
     return new Ok(undefined);
   }
 
-  async stop(): Promise<Result<undefined, Error>> {
+  async stop({
+    reason,
+  }: {
+    reason: string;
+  }): Promise<Result<undefined, Error>> {
     const webConfig = await WebCrawlerConfigurationResource.fetchByConnectorId(
       this.connectorId
     );
@@ -159,7 +163,7 @@ export class WebcrawlerConnectorManager extends BaseConnectorManager<WebCrawlerC
     } else {
       const res = await stopCrawlWebsiteWorkflow({
         connectorId: this.connectorId,
-        stopReason: "Stopped via connector STOP command",
+        stopReason: reason,
       });
       if (res.isErr()) {
         return res;

--- a/connectors/src/connectors/zendesk/index.ts
+++ b/connectors/src/connectors/zendesk/index.ts
@@ -229,7 +229,11 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
   /**
    * Stops all workflows related to the connector (sync and garbage collection).
    */
-  async stop(): Promise<Result<undefined, Error>> {
+  async stop({
+    reason,
+  }: {
+    reason: string;
+  }): Promise<Result<undefined, Error>> {
     const { connectorId } = this;
     const connector = await ConnectorResource.fetchById(connectorId);
     if (!connector) {
@@ -237,7 +241,7 @@ export class ZendeskConnectorManager extends BaseConnectorManager<null> {
       throw new Error("[Zendesk] Connector not found.");
     }
     return stopZendeskWorkflows(connector, {
-      stopReason: "Stopped via connector STOP command",
+      stopReason: reason,
     });
   }
 

--- a/connectors/src/lib/cli.ts
+++ b/connectors/src/lib/cli.ts
@@ -159,11 +159,11 @@ export const connectors = async ({
   });
   switch (command) {
     case "stop": {
-      await throwOnError(manager.stop());
+      await throwOnError(manager.stop({ reason: "Stopped via CLI" }));
       return { success: true };
     }
     case "pause": {
-      await throwOnError(manager.pauseAndStop());
+      await throwOnError(manager.pauseAndStop({ reason: "Paused via CLI" }));
       return { success: true };
     }
     case "unpause": {
@@ -210,7 +210,7 @@ export const connectors = async ({
         throw new Error("Cannot restart a paused connector");
       }
 
-      await throwOnError(manager.stop());
+      await throwOnError(manager.stop({ reason: "Restart via CLI" }));
       await throwOnError(manager.resume());
       return { success: true };
     }
@@ -392,7 +392,7 @@ export const batch = async ({
                 getConnectorManager({
                   connectorId: connector.id,
                   connectorProvider: connector.type,
-                }).stop()
+                }).stop({ reason: "Stopped via CLI batch operation" })
               );
             }
             if (["restart-all", "resume-all"].includes(command)) {

--- a/connectors/src/lib/temporal_monitoring.ts
+++ b/connectors/src/lib/temporal_monitoring.ts
@@ -237,7 +237,9 @@ export class ActivityInboundLogInterceptor implements ActivityInboundCallsInterc
           });
 
           if (connectorManager) {
-            await connectorManager.pauseAndStop();
+            await connectorManager.pauseAndStop({
+              reason: "Stopped due to workspace quota exceeded"
+            });
           } else {
             this.logger.error(
               {

--- a/connectors/src/lib/temporal_monitoring.ts
+++ b/connectors/src/lib/temporal_monitoring.ts
@@ -47,9 +47,7 @@ export interface ContextWithLogger extends Context {
   logger: typeof logger;
 }
 
-export class ActivityInboundLogInterceptor
-  implements ActivityInboundCallsInterceptor
-{
+export class ActivityInboundLogInterceptor implements ActivityInboundCallsInterceptor {
   public readonly logger: Logger;
   private readonly context: Context;
   private readonly provider: ConnectorProvider;

--- a/connectors/src/lib/temporal_monitoring.ts
+++ b/connectors/src/lib/temporal_monitoring.ts
@@ -13,7 +13,7 @@ import type { Logger } from "@connectors/logger/logger";
 import type logger from "@connectors/logger/logger";
 import { statsDClient } from "@connectors/logger/withlogging";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
-import { type ConnectorErrorType, WithRetriesError } from "@connectors/types";
+import { WithRetriesError } from "@connectors/types";
 
 import {
   DustConnectorWorkflowError,


### PR DESCRIPTION
## Description

- Follow up on https://github.com/dust-tt/dust/pull/19568
- This PR adds more finegrained stop reasons passed through the `stop` method of connector managers.
- These stop reasons are logged by Temporal on workflows terminations.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy connectors.
