### PR TITLE
x(dust-hive): add service restart shortcut via Ctrl+C menu

### DIFF
--- a/x/henry/dust-hive/src/lib/paths.ts
+++ b/x/henry/dust-hive/src/lib/paths.ts
@@ -9,6 +9,7 @@ export const DUST_HIVE_ROOT = resolve(dirname(import.meta.path), "../..");
 export const DUST_HIVE_HOME = join(homedir(), ".dust-hive");
 export const DUST_HIVE_ENVS = join(DUST_HIVE_HOME, "envs");
 export const DUST_HIVE_ZELLIJ = join(DUST_HIVE_HOME, "zellij");
+export const DUST_HIVE_SCRIPTS = join(DUST_HIVE_HOME, "scripts");
 export const DUST_HIVE_WORKTREES = join(homedir(), "dust-hive");
 
 // Global config
@@ -66,6 +67,11 @@ export function getLogPath(name: string, service: string): string {
 // Zellij
 export function getZellijLayoutPath(): string {
   return join(DUST_HIVE_ZELLIJ, "layout.kdl");
+}
+
+// Scripts
+export function getWatchScriptPath(): string {
+  return join(DUST_HIVE_SCRIPTS, "watch-logs.sh");
 }
 
 function isErrnoException(error: unknown): error is NodeJS.ErrnoException {


### PR DESCRIPTION
## Description

Add a watch script that provides an interactive menu for service management:
- Press Ctrl+C while viewing logs to open menu
- r: restart service
- c: clear screen
- q: quit
- Enter: resume log viewing

The script is written to ~/.dust-hive/scripts/watch-logs.sh and used by zellij service tabs instead of plain tail -F.


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
