### PR TITLE
feat(dust-hive): add interactive setup command

### DIFF
--- a/x/henry/dust-hive/src/commands/doctor.ts
+++ b/x/henry/dust-hive/src/commands/doctor.ts
@@ -1,6 +1,8 @@
 import { configEnvExists } from "../lib/config";
+import { createConfigEnvTemplate, hasHomebrew, installers, tryInstall } from "../lib/installer";
 import { logger } from "../lib/logger";
 import { CONFIG_ENV_PATH, findRepoRoot } from "../lib/paths";
+import { confirm } from "../lib/prompt";
 import { CommandError, Err, Ok, type Result } from "../lib/result";
 
 interface CheckResult {
@@ -9,6 +11,11 @@ interface CheckResult {
   message: string;
   fix?: string;
   optional?: boolean; // If true, failing this check doesn't fail the overall doctor
+  installable?: boolean; // If true, we can offer to install this
+}
+
+export interface SetupOptions {
+  nonInteractive?: boolean;
 }
 
 async function checkCommand(command: string, args: string[] = []): Promise<boolean> {
@@ -41,6 +48,17 @@ async function getCommandVersion(command: string): Promise<string | null> {
   }
 }
 
+async function checkHomebrew(): Promise<CheckResult> {
+  const exists = await hasHomebrew();
+  return {
+    name: "Homebrew",
+    ok: exists,
+    message: exists ? "Available" : "Not found",
+    fix: "Install Homebrew: https://brew.sh",
+    installable: true,
+  };
+}
+
 async function checkBun(): Promise<CheckResult> {
   const version = await getCommandVersion("bun");
   return {
@@ -48,6 +66,7 @@ async function checkBun(): Promise<CheckResult> {
     ok: version !== null,
     message: version ?? "Not found",
     fix: "Install Bun: curl -fsSL https://bun.sh/install | bash",
+    installable: true,
   };
 }
 
@@ -58,6 +77,7 @@ async function checkZellij(): Promise<CheckResult> {
     ok: version !== null,
     message: version ?? "Not found",
     fix: "Install Zellij: brew install zellij",
+    installable: true,
   };
 }
 
@@ -70,6 +90,7 @@ async function checkDocker(): Promise<CheckResult> {
     ok: version !== null && running,
     message,
     fix: version ? "Start Docker Desktop" : "Install Docker Desktop",
+    installable: false,
   };
 }
 
@@ -80,6 +101,7 @@ async function checkDockerCompose(): Promise<CheckResult> {
     ok: available,
     message: available ? "Available" : "Not available",
     fix: "Docker Compose should be included with Docker Desktop",
+    installable: false,
   };
 }
 
@@ -93,12 +115,14 @@ async function checkTemporal(): Promise<{ cli: CheckResult; server: CheckResult 
       ok: version !== null,
       message: version ?? "Not found",
       fix: "Install Temporal: brew install temporal",
+      installable: true,
     },
     server: {
       name: "Temporal Server",
       ok: running,
       message: running ? "Running" : "Not running",
       fix: "Start Temporal: temporal server start-dev",
+      installable: false,
     },
   };
 }
@@ -110,6 +134,7 @@ async function checkNvm(): Promise<CheckResult> {
     ok: exists,
     message: exists ? "Available" : "Not found",
     fix: "Install nvm: https://github.com/nvm-sh/nvm",
+    installable: true,
   };
 }
 
@@ -120,6 +145,7 @@ async function checkCargo(): Promise<CheckResult> {
     ok: version !== null,
     message: version ?? "Not found",
     fix: "Install Rust: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh",
+    installable: true,
   };
 }
 
@@ -132,6 +158,7 @@ async function checkSccache(): Promise<CheckResult> {
       optional: true,
       message: "Not found (recommended for faster rebuilds)",
       fix: "Install sccache: brew install sccache",
+      installable: true,
     };
   }
 
@@ -149,6 +176,7 @@ async function checkSccache(): Promise<CheckResult> {
       optional: true,
       message: `${version} (not configured)`,
       fix: configFix,
+      installable: true,
     };
   }
 
@@ -169,6 +197,7 @@ async function checkSccache(): Promise<CheckResult> {
     optional: true,
     message: `${version} (not configured)`,
     fix: configFix,
+    installable: true,
   };
 }
 
@@ -179,6 +208,7 @@ async function checkRepo(): Promise<CheckResult> {
     ok: root !== null,
     message: root ?? "Not found",
     fix: "Run dust-hive from within the Dust repository",
+    installable: false,
   };
 }
 
@@ -189,6 +219,7 @@ async function checkConfig(): Promise<CheckResult> {
     ok: exists,
     message: exists ? CONFIG_ENV_PATH : "Not found",
     fix: `Create ${CONFIG_ENV_PATH} with required environment variables`,
+    installable: true,
   };
 }
 
@@ -217,12 +248,11 @@ function printResults(results: CheckResult[]): boolean {
   return allOk;
 }
 
-export async function doctorCommand(): Promise<Result<void>> {
-  logger.info("Checking prerequisites...\n");
-
+async function runAllChecks(): Promise<CheckResult[]> {
   const temporal = await checkTemporal();
 
-  const results: CheckResult[] = [
+  return [
+    await checkHomebrew(),
     await checkBun(),
     await checkZellij(),
     await checkDocker(),
@@ -235,9 +265,61 @@ export async function doctorCommand(): Promise<Result<void>> {
     await checkRepo(),
     await checkConfig(),
   ];
+}
+
+function getInstallableFailures(results: CheckResult[]): CheckResult[] {
+  return results.filter((r) => !r.ok && r.installable);
+}
+
+function getManualFailures(results: CheckResult[]): CheckResult[] {
+  return results.filter((r) => !(r.ok || r.installable || r.optional));
+}
+
+async function interactiveInstall(results: CheckResult[]): Promise<boolean> {
+  const installable = getInstallableFailures(results);
+  if (installable.length === 0) {
+    return false;
+  }
 
   console.log();
-  const allOk = printResults(results);
+  logger.info("Some prerequisites can be installed automatically.\n");
+
+  // Check if we have homebrew (needed for some installs)
+  const hasBrew = await hasHomebrew();
+  let anyInstalled = false;
+
+  for (const check of installable) {
+    // Special case: config.env
+    if (check.name === "config.env") {
+      const shouldCreate = await confirm("Create config.env template?", true);
+      if (shouldCreate) {
+        await createConfigEnvTemplate(CONFIG_ENV_PATH);
+        anyInstalled = true;
+      } else {
+        logger.info("→ Skipped");
+      }
+      continue;
+    }
+
+    // Check if this prerequisite has an installer
+    if (installers[check.name]) {
+      const installed = await tryInstall(check.name, check.optional ?? false, hasBrew);
+      if (installed) {
+        anyInstalled = true;
+      }
+    }
+  }
+
+  return anyInstalled;
+}
+
+export async function setupCommand(options: SetupOptions = {}): Promise<Result<void>> {
+  logger.info("Checking prerequisites...\n");
+
+  let results = await runAllChecks();
+
+  console.log();
+  let allOk = printResults(results);
   console.log();
 
   if (allOk) {
@@ -245,6 +327,47 @@ export async function doctorCommand(): Promise<Result<void>> {
     return Ok(undefined);
   }
 
-  logger.warn("Some prerequisites are missing. Please install them to use dust-hive.");
+  // In non-interactive mode, just report and exit
+  if (options.nonInteractive) {
+    logger.warn("Some prerequisites are missing. Please install them to use dust-hive.");
+    return Err(new CommandError("Prerequisites check failed"));
+  }
+
+  // Interactive mode: offer to install what we can
+  const anyInstalled = await interactiveInstall(results);
+
+  if (anyInstalled) {
+    // Re-run checks after installations
+    console.log();
+    logger.info("Re-checking prerequisites...\n");
+    results = await runAllChecks();
+    console.log();
+    allOk = printResults(results);
+    console.log();
+  }
+
+  if (allOk) {
+    logger.success("All prerequisites met!");
+    return Ok(undefined);
+  }
+
+  // Report remaining manual fixes needed
+  const manualFixes = getManualFailures(results);
+  if (manualFixes.length > 0) {
+    logger.warn("Some prerequisites require manual action:");
+    for (const fix of manualFixes) {
+      if (fix.fix) {
+        console.log(`  • ${fix.name}: ${fix.fix}`);
+      }
+    }
+    console.log();
+  }
+
+  logger.info("Ready to create environments once all prerequisites are met!");
   return Err(new CommandError("Prerequisites check failed"));
+}
+
+// Alias for backwards compatibility
+export async function doctorCommand(): Promise<Result<void>> {
+  return setupCommand({ nonInteractive: false });
 }

--- a/x/henry/dust-hive/src/index.ts
+++ b/x/henry/dust-hive/src/index.ts
@@ -4,7 +4,7 @@ import { cac } from "cac";
 import { cacheCommand } from "./commands/cache";
 import { coolCommand } from "./commands/cool";
 import { destroyCommand } from "./commands/destroy";
-import { doctorCommand } from "./commands/doctor";
+import { doctorCommand, setupCommand } from "./commands/doctor";
 import { forwardCommand } from "./commands/forward";
 import { listCommand } from "./commands/list";
 import { logsCommand } from "./commands/logs";
@@ -147,7 +147,14 @@ cli.command("url [name]", "Print front URL").action(async (name: string | undefi
   await prepareAndRun(urlCommand(name));
 });
 
-cli.command("doctor", "Check prerequisites").action(async () => {
+cli
+  .command("setup", "Interactive setup wizard for prerequisites")
+  .option("-y, --non-interactive", "Run in non-interactive mode (same as doctor)")
+  .action(async (options: { nonInteractive?: boolean }) => {
+    await prepareAndRun(setupCommand({ nonInteractive: Boolean(options.nonInteractive) }));
+  });
+
+cli.command("doctor", "Check prerequisites (alias for setup)").action(async () => {
   await prepareAndRun(doctorCommand());
 });
 

--- a/x/henry/dust-hive/src/lib/installer.ts
+++ b/x/henry/dust-hive/src/lib/installer.ts
@@ -1,0 +1,243 @@
+// Installation helpers for dust-hive setup
+// Handles automatic installation of prerequisites
+
+import { logger } from "./logger";
+import { confirm } from "./prompt";
+
+export interface InstallResult {
+  success: boolean;
+  message: string;
+}
+
+// Check if a command exists and is executable
+async function commandExists(command: string): Promise<boolean> {
+  try {
+    const proc = Bun.spawn(["which", command], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    await proc.exited;
+    return proc.exitCode === 0;
+  } catch {
+    return false;
+  }
+}
+
+// Check if homebrew is available
+export async function hasHomebrew(): Promise<boolean> {
+  return commandExists("brew");
+}
+
+// Run an installation command with progress output
+export async function runInstall(
+  name: string,
+  command: string[],
+  options?: { shell?: boolean }
+): Promise<InstallResult> {
+  const displayCommand = command.join(" ");
+  logger.info(`→ Running: ${displayCommand}`);
+
+  try {
+    let proc: ReturnType<typeof Bun.spawn>;
+
+    if (options?.shell) {
+      // For commands that need shell execution (pipes, etc.)
+      proc = Bun.spawn(["bash", "-c", command.join(" ")], {
+        stdout: "inherit",
+        stderr: "inherit",
+        stdin: "inherit",
+      });
+    } else {
+      proc = Bun.spawn(command, {
+        stdout: "inherit",
+        stderr: "inherit",
+        stdin: "inherit",
+      });
+    }
+
+    await proc.exited;
+
+    if (proc.exitCode === 0) {
+      logger.success(`${name} installed`);
+      return { success: true, message: `${name} installed successfully` };
+    }
+    return { success: false, message: `Installation failed with exit code ${proc.exitCode}` };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { success: false, message };
+  }
+}
+
+// Install homebrew if not present
+export async function installHomebrew(): Promise<InstallResult> {
+  const script =
+    '/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"';
+  return runInstall("Homebrew", [script], { shell: true });
+}
+
+// Install bun
+export async function installBun(): Promise<InstallResult> {
+  return runInstall("Bun", ["curl", "-fsSL", "https://bun.sh/install", "|", "bash"], {
+    shell: true,
+  });
+}
+
+// Install zellij via homebrew
+export async function installZellij(): Promise<InstallResult> {
+  return runInstall("Zellij", ["brew", "install", "zellij"]);
+}
+
+// Install temporal CLI via homebrew
+export async function installTemporal(): Promise<InstallResult> {
+  return runInstall("Temporal CLI", ["brew", "install", "temporal"]);
+}
+
+// Install nvm
+export async function installNvm(): Promise<InstallResult> {
+  const script = "curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash";
+  return runInstall("nvm", [script], { shell: true });
+}
+
+// Install cargo (rustup)
+export async function installCargo(): Promise<InstallResult> {
+  const script = 'curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y';
+  return runInstall("Cargo", [script], { shell: true });
+}
+
+// Install sccache via homebrew
+export async function installSccache(): Promise<InstallResult> {
+  const result = await runInstall("sccache", ["brew", "install", "sccache"]);
+  if (!result.success) {
+    return result;
+  }
+
+  // Configure sccache in cargo config
+  const { HOME: home = "" } = process.env;
+  const configPath = `${home}/.cargo/config.toml`;
+  const file = Bun.file(configPath);
+
+  try {
+    let content = "";
+    if (await file.exists()) {
+      content = await file.text();
+    }
+
+    if (!content.includes("sccache")) {
+      const sccacheConfig = '\n[build]\nrustc-wrapper = "sccache"\n';
+      await Bun.write(configPath, content + sccacheConfig);
+      logger.info("→ Configured sccache in ~/.cargo/config.toml");
+    }
+  } catch {
+    logger.warn("Could not configure sccache in cargo config");
+  }
+
+  return result;
+}
+
+// Create config.env template
+export async function createConfigEnvTemplate(configPath: string): Promise<InstallResult> {
+  const template = `# dust-hive configuration
+# Fill in the required values below
+
+# Required: Your Dust API credentials
+DUST_CLIENT_ID=
+DUST_CLIENT_SECRET=
+
+# Required: OpenAI API key for embeddings
+OPENAI_API_KEY=
+
+# Optional: Anthropic API key
+ANTHROPIC_API_KEY=
+
+# Optional: Other API keys as needed
+# GITHUB_TOKEN=
+# GOOGLE_CLIENT_ID=
+# GOOGLE_CLIENT_SECRET=
+`;
+
+  try {
+    await Bun.write(configPath, template);
+    logger.success(`Created config template at ${configPath}`);
+    logger.info("→ Please edit the file and add your credentials");
+    return { success: true, message: "Config template created" };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { success: false, message };
+  }
+}
+
+// Installer registry - maps check names to their installers
+export interface Installer {
+  name: string;
+  requiresBrew: boolean;
+  install: () => Promise<InstallResult>;
+}
+
+export const installers: Record<string, Installer> = {
+  Homebrew: {
+    name: "Homebrew",
+    requiresBrew: false,
+    install: installHomebrew,
+  },
+  Bun: {
+    name: "Bun",
+    requiresBrew: false,
+    install: installBun,
+  },
+  Zellij: {
+    name: "Zellij",
+    requiresBrew: true,
+    install: installZellij,
+  },
+  "Temporal CLI": {
+    name: "Temporal CLI",
+    requiresBrew: true,
+    install: installTemporal,
+  },
+  nvm: {
+    name: "nvm",
+    requiresBrew: false,
+    install: installNvm,
+  },
+  Cargo: {
+    name: "Cargo",
+    requiresBrew: false,
+    install: installCargo,
+  },
+  "sccache (optional)": {
+    name: "sccache",
+    requiresBrew: true,
+    install: installSccache,
+  },
+};
+
+// Attempt to install a prerequisite interactively
+export async function tryInstall(
+  name: string,
+  optional: boolean,
+  hasBrew: boolean
+): Promise<boolean> {
+  const installer = installers[name];
+  if (!installer) {
+    return false;
+  }
+
+  // Check if homebrew is needed but missing
+  if (installer.requiresBrew && !hasBrew) {
+    logger.warn(`${name} requires Homebrew, which is not installed`);
+    return false;
+  }
+
+  // Ask for confirmation
+  const defaultYes = !optional;
+  const suffix = optional ? " (optional)" : "";
+  const confirmed = await confirm(`Install ${installer.name}${suffix}?`, defaultYes);
+
+  if (!confirmed) {
+    logger.info("→ Skipped");
+    return false;
+  }
+
+  const result = await installer.install();
+  return result.success;
+}

--- a/x/henry/dust-hive/src/lib/prompt.ts
+++ b/x/henry/dust-hive/src/lib/prompt.ts
@@ -1,4 +1,4 @@
-// Interactive prompts for environment selection
+// Interactive prompts for environment selection and confirmations
 // Uses simple line input (no raw mode) for compatibility with terminal multiplexers
 
 import { getLastActiveEnv } from "./activity";
@@ -16,6 +16,23 @@ async function readLine(prompt: string): Promise<string | null> {
     return line.trim();
   }
   return null;
+}
+
+// Prompt user for yes/no confirmation
+// Returns true for yes, false for no
+export async function confirm(message: string, defaultYes = true): Promise<boolean> {
+  const hint = defaultYes ? "[Y/n]" : "[y/N]";
+  const input = await readLine(`${message} ${hint} `);
+
+  if (input === null) {
+    return false;
+  }
+
+  const normalized = input.toLowerCase();
+  if (normalized === "") {
+    return defaultYes;
+  }
+  return normalized === "y" || normalized === "yes";
 }
 
 function sortEnvs(


### PR DESCRIPTION
## Description

Transform `dust-hive doctor` into an interactive setup wizard that can automatically install missing prerequisites.

Changes:
- Add `setup` command with interactive installation prompts
- Keep `doctor` as alias for backwards compatibility
- Add `--non-interactive` / `-y` flag for CI usage
- Add Homebrew check (required for brew-based installs)
- Support auto-installation of: Homebrew, Bun, Zellij, Temporal CLI, nvm, Cargo, sccache
- Create config.env template when missing
- Re-run checks after installations to verify success


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
