### PR TITLE
[Slack MCP] meta-prompt post_message tools

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/slack/helpers.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack/helpers.ts
@@ -428,7 +428,9 @@ function buildFilteredListResponse<T, U = T>(
     {
       type: "text" as const,
       text:
-        contextMessage(items.length, true, nameFilter) + " but none matching",
+        `No items match the filter "${nameFilter}". ` +
+        contextMessage(items.length, false) +
+        " Showing all available items instead:",
     },
     {
       type: "text" as const,

--- a/front/lib/actions/mcp_internal_actions/servers/slack/slack_bot.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack/slack_bot.ts
@@ -27,7 +27,7 @@ async function createServer(
 
   server.tool(
     "post_message",
-    "Post a message to a Slack channel. The slack bot must be added to the channel before it can post messages. Direct messages are not supported.",
+    "Post a message to a Slack channel. The slack bot must be added to the channel before it can post messages. Direct messages are not supported. You MUST ONLY post to channels that were explicitly specified by the user in their request. NEVER post to alternative channels if the requested channel is not found. If you cannot find the exact channel requested by the user, you MUST ask the user for clarification instead of choosing a different channel.",
     {
       to: z
         .string()

--- a/front/lib/actions/mcp_internal_actions/servers/slack/slack_personal.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack/slack_personal.ts
@@ -635,7 +635,7 @@ async function createServer(
 
   server.tool(
     "post_message",
-    "Post a message to a public channel, private channel, or DM",
+    "Post a message to a public channel, private channel, or DM. You MUST ONLY post to channels or users that were explicitly specified by the user in their request. NEVER post to alternative channels if the requested channel is not found. If you cannot find the exact channel requested by the user, you MUST ask the user for clarification instead of choosing a different channel.",
     {
       to: z
         .string()
@@ -705,7 +705,7 @@ async function createServer(
 
   server.tool(
     "schedule_message",
-    "Schedule a message to be posted to a channel at a future time. Messages can be scheduled up to 120 days in advance. Maximum of 30 scheduled messages per 5 minutes per channel.",
+    "Schedule a message to be posted to a channel at a future time. Messages can be scheduled up to 120 days in advance. Maximum of 30 scheduled messages per 5 minutes per channel. You MUST ONLY schedule messages to channels or users that were explicitly specified by the user in their request. NEVER schedule messages to alternative channels if the requested channel is not found. If you cannot find the exact channel requested by the user, you MUST ask the user for clarification instead of choosing a different channel.",
     {
       to: z
         .string()


### PR DESCRIPTION
## Description

Adds explicit instructions to the `post_message` and `schedule_message` tool descriptions to prevent agents from posting to alternative channels when the user-requested channel cannot be found. This meta-prompt layer prevents agents from taking initiative and choosing alternative channels, requiring them to ask the user for clarification instead. Also improves the filter feedback message when no channels match a search filter.

## Tests

Manual testing locally

## Risk

None - this is a prompt-only change that adds safety guardrails. Existing functionality remains unchanged.

## Deploy Plan

Run front