### PR TITLE
[Front] fix(qa-skill-builder): improve error display and action card click handling

### DIFF
--- a/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
+++ b/front/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock.tsx
@@ -212,7 +212,7 @@ export function AgentBuilderCapabilitiesBlock({
                   key={field.id}
                   action={field}
                   onRemove={() => remove(index)}
-                  onEdit={() => handleActionEdit(field, index)}
+                  onClick={() => handleActionEdit(field, index)}
                 />
               ))}
             </CardGrid>

--- a/front/components/agent_builder/skills/AgentBuilderSkillsBlock.tsx
+++ b/front/components/agent_builder/skills/AgentBuilderSkillsBlock.tsx
@@ -317,7 +317,7 @@ export function AgentBuilderSkillsBlock() {
                   key={field.id}
                   action={field}
                   onRemove={() => removeAction(index)}
-                  onEdit={() => handleActionEdit(field, index)}
+                  onClick={() => handleActionEdit(field, index)}
                 />
               ))}
             </CardGrid>

--- a/front/components/shared/tools_picker/ActionCard.tsx
+++ b/front/components/shared/tools_picker/ActionCard.tsx
@@ -30,10 +30,10 @@ function actionDisplayName(
 export interface ActionCardProps {
   action: BuilderAction;
   onRemove: () => void;
-  onEdit?: () => void;
+  onClick?: () => void;
 }
 
-export function ActionCard({ action, onRemove, onEdit }: ActionCardProps) {
+export function ActionCard({ action, onRemove, onClick }: ActionCardProps) {
   const { mcpServerViews, isMCPServerViewsLoading } =
     useMCPServerViewsContext();
 
@@ -51,7 +51,7 @@ export function ActionCard({ action, onRemove, onEdit }: ActionCardProps) {
     <Card
       variant="primary"
       className="h-28"
-      onClick={onEdit}
+      onClick={onClick}
       action={
         <CardActionButton
           size="mini"

--- a/front/components/skill_builder/SkillBuilderAgentFacingDescriptionSection.tsx
+++ b/front/components/skill_builder/SkillBuilderAgentFacingDescriptionSection.tsx
@@ -92,6 +92,7 @@ export function SkillBuilderAgentFacingDescriptionSection() {
             ref={registerRef}
             placeholder="When should this skill be used? What is this skill good for?"
             className="min-h-24 text-base placeholder:italic placeholder:text-gray-400"
+            resize="vertical"
             onChange={(e) => handleDescriptionChange(e, onChange)}
             error={hasError ? errorMessage : undefined}
             showErrorLabel={hasError}

--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -21,7 +21,7 @@ export const INSTRUCTIONS_MAXIMUM_CHARACTER_COUNT = 120_000;
 
 const editorVariants = cva(
   [
-    "overflow-auto border rounded-xl p-2 resize-y min-h-60 max-h-[1024px]",
+    "overflow-auto border rounded-xl px-3 py-2 resize-y min-h-60 max-h-[1024px]",
     "transition-all duration-200",
     "bg-muted-background dark:bg-muted-background-night",
   ],
@@ -29,10 +29,11 @@ const editorVariants = cva(
     variants: {
       error: {
         true: [
-          "border-warning-500 dark:border-warning-500-night",
-          "focus:ring-warning-500 dark:focus:ring-warning-500-night",
-          "focus:outline-warning-500 dark:focus:outline-warning-500-night",
-          "focus:border-warning-500 dark:focus:border-warning-500-night",
+          "border-border-warning/30 dark:border-border-warning-night/60",
+          "ring-warning/0 dark:ring-warning-night/0",
+          "focus-visible:border-border-warning dark:focus-visible:border-border-warning-night",
+          "focus-visible:outline-none focus-visible:ring-2",
+          "focus-visible:ring-warning/10 dark:focus-visible:ring-warning/30",
         ],
         false: [
           "border-border dark:border-border-night",
@@ -217,8 +218,13 @@ export function SkillBuilderInstructionsEditor({
   }, [isInstructionDiffMode, compareVersion, editor]);
 
   return (
-    <div className="relative p-px">
+    <div className="relative space-y-1 p-px">
       <EditorContent editor={editor} />
+      {fieldState.error && (
+        <div className="dark:text-warning-night ml-2 text-xs text-warning">
+          {fieldState.error.message}
+        </div>
+      )}
     </div>
   );
 }

--- a/front/components/skill_builder/SkillBuilderToolsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderToolsSection.tsx
@@ -13,6 +13,7 @@ import { MCPServerViewsSheet } from "@app/components/agent_builder/capabilities/
 import { ActionCard } from "@app/components/shared/tools_picker/ActionCard";
 import type { MCPServerViewTypeWithLabel } from "@app/components/shared/tools_picker/MCPServerViewsContext";
 import { useMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
+import type { BuilderAction } from "@app/components/shared/tools_picker/types";
 import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 
@@ -41,6 +42,10 @@ export function SkillBuilderToolsSection() {
 
   const handleOpenSheet = () => {
     setSheetMode({ type: "add" });
+  };
+
+  const handleClickActionCard = (action: BuilderAction) => {
+    setSheetMode({ type: "info", action, source: "addedTool" });
   };
 
   const headerActions = fields.length > 0 && (
@@ -87,6 +92,7 @@ export function SkillBuilderToolsSection() {
                 key={field.id}
                 action={field}
                 onRemove={() => remove(index)}
+                onClick={() => handleClickActionCard(field)}
               />
             ))}
           </CardGrid>

--- a/front/components/skill_builder/SkillBuilderUserFacingDescriptionSection.tsx
+++ b/front/components/skill_builder/SkillBuilderUserFacingDescriptionSection.tsx
@@ -113,29 +113,35 @@ export function SkillBuilderUserFacingDescriptionSection() {
       triggerValidationOnChange={false}
     >
       {({ registerRef, registerProps, onChange, errorMessage, hasError }) => (
-        <div className="relative">
-          <Input
-            ref={registerRef}
-            placeholder="Enter skill description"
-            onChange={(e) => {
-              markAsUserEdited();
-              onChange(e);
-            }}
-            message={errorMessage}
-            messageStatus={hasError ? "error" : "default"}
-            className="pr-10"
-            {...registerProps}
-          />
-          <Button
-            icon={isGenerating ? () => <Spinner size="xs" /> : SparklesIcon}
-            variant="outline"
-            size="xs"
-            className="absolute right-0 top-1/2 mr-1 h-7 w-7 -translate-y-1/2 rounded-lg p-0"
-            disabled={isGenerating || !canGenerate}
-            onClick={generate}
-            tooltip={getTooltip()}
-          />
-        </div>
+        <>
+          <div className="relative">
+            <Input
+              ref={registerRef}
+              placeholder="Enter skill description"
+              onChange={(e) => {
+                markAsUserEdited();
+                onChange(e);
+              }}
+              isError={hasError}
+              className="pr-10"
+              {...registerProps}
+            />
+            <Button
+              icon={isGenerating ? () => <Spinner size="xs" /> : SparklesIcon}
+              variant="outline"
+              size="xs"
+              className="absolute right-0 top-1/2 mr-1 h-7 w-7 -translate-y-1/2 rounded-lg p-0"
+              disabled={isGenerating || !canGenerate}
+              onClick={generate}
+              tooltip={getTooltip()}
+            />
+          </div>
+          {errorMessage && (
+            <div className="dark:text-warning-night mt-1 text-xs text-warning">
+              {errorMessage}
+            </div>
+          )}
+        </>
       )}
     </BaseFormFieldSection>
   );


### PR DESCRIPTION
Addressing issues raised in : https://github.com/dust-tt/tasks/issues/5729

## Description

- Fix error display in skill builder forms (instructions editor, user-facing description)
- Rename `onEdit` to `onClick` in ActionCard for clarity
- Add click handler on ActionCard in skill builder to show tool info sheet
- Minor styling tweaks (padding, resize behavior)

## Tests

https://github.com/user-attachments/assets/e0c55d3c-227f-4a8f-9161-29b67e809553


Manual testing of skill builder form validation and tool info sheet.

## Risk

Low.

## Deploy Plan

Deploy front.
