### PR TITLE
Model error classification tweaks

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/run_agent/network_errors.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent/network_errors.ts
@@ -3,9 +3,14 @@ import type { APIError } from "@dust-tt/client";
 import { normalizeError } from "@app/types";
 
 /**
- * Patterns that indicate transient network errors.
- * These errors are typically caused by infrastructure issues (load balancer timeouts,
- * connection resets, network interruptions) and should not trigger alerts.
+ * Patterns that indicate transient network errors. These errors are typically caused by
+ * infrastructure issues (load balancer timeouts, connection resets, network interruptions) and
+ * should not trigger alerts.
+ *
+ * Examples:
+ * - "TypeError: terminated" - TCP connection terminated unexpectedly
+ * - "Exceeded maximum reconnection attempts" - Stream reconnection exhausted
+ * - "ECONNRESET" - Connection reset by peer
  */
 const TRANSIENT_NETWORK_ERROR_PATTERNS = [
   /terminated/i,
@@ -29,13 +34,6 @@ function matchesTransientPattern(message: string): boolean {
 
 /**
  * Determines if an API error is a transient network error.
- * Transient network errors are caused by infrastructure issues and should not
- * trigger monitoring alerts as they are typically recoverable.
- *
- * Examples:
- * - "TypeError: terminated" - TCP connection terminated unexpectedly
- * - "Exceeded maximum reconnection attempts" - Stream reconnection exhausted
- * - "ECONNRESET" - Connection reset by peer
  */
 export function isTransientNetworkError(error: APIError): boolean {
   const message = error.message || "";
@@ -43,11 +41,8 @@ export function isTransientNetworkError(error: APIError): boolean {
 }
 
 /**
- * Determines if a stream error is a transient network error.
- * Used for errors thrown during agent stream processing.
- *
- * Also handles the "Not connected" error which indicates the stream
- * was disconnected but the operation may have completed.
+ * Determines if a stream error is a transient network error. Used for errors thrown during agent
+ * stream processing.
  */
 export function isTransientStreamError(error: unknown): boolean {
   const normalized = normalizeError(error);

--- a/front/lib/api/assistant/errors.ts
+++ b/front/lib/api/assistant/errors.ts
@@ -110,6 +110,23 @@ export const categorizeAgentErrorMessage = (error: {
         publicMessage:
           "Connection interrupted while receiving your answer. Please try again.",
       };
+    } else if (
+      error.message.includes("Server error from anthropic") &&
+      error.message.includes("api_error")
+    ) {
+      return {
+        category: "provider_internal_error",
+        errorTitle: "Anthropic server error",
+        publicMessage:
+          "Anthropic (Claude's provider) encountered an error. Please try again.",
+      };
+    } else if (error.message.includes("Terminated error for")) {
+      return {
+        category: "retryable_model_error",
+        errorTitle: "Connection interrupted",
+        publicMessage:
+          "The connection to the model was interrupted. Please try again.",
+      };
     }
   }
   // The original message is used as a fallback.


### PR DESCRIPTION
## Description

- Removes a few extraneous comments in mcp run_agent error handling code
- Few tweaks in `categorizeAgentErrorMessage` to add retryability to some cases happening in production esp in the case of run_agent which triggers a monitor.

https://app.datadoghq.eu/logs?query=region%3Aeurope-west1%20%40toolName%3Arun_agent%20%22Tool%20execution%20error%22%20status%3Aerror&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cworkspace.sId%2CtoolName%2Cerror&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1767464647934&to_ts=1767572459148&live=false

## Tests

N/A

## Risk

Low

## Deploy Plan

- deploy `front`