### PR TITLE
feat(dust-hive): allow --no-open --warm to run warm in current terminal

### DIFF
--- a/x/henry/dust-hive/src/commands/spawn.ts
+++ b/x/henry/dust-hive/src/commands/spawn.ts
@@ -18,6 +18,7 @@ import { CommandError, Err, Ok, type Result } from "../lib/result";
 import { installAllDependencies } from "../lib/setup";
 import { cleanupPartialEnvironment, createWorktree, getCurrentBranch } from "../lib/worktree";
 import { openCommand } from "./open";
+import { warmCommand } from "./warm";
 
 interface SpawnOptions {
   name?: string;
@@ -223,18 +224,17 @@ export async function spawnCommand(options: SpawnOptions): Promise<Result<void>>
   console.log(`  dust-hive open ${name}    # Open zellij session`);
   console.log();
 
-  if (options.noOpen && options.warm) {
-    return Err(
-      new CommandError("Cannot use --warm with --no-open. Remove --no-open to open zellij.")
-    );
-  }
-
   // Open zellij unless --no-open
   if (!options.noOpen) {
     if (options.warm) {
       return openCommand(name, { warmCommand: `dust-hive warm ${name}` });
     }
     return openCommand(name);
+  }
+
+  // If --no-open and --warm, run warm command directly in current terminal
+  if (options.warm) {
+    return warmCommand(name, {});
   }
 
   return Ok(undefined);


### PR DESCRIPTION
## Description

Previously, using both --no-open and --warm flags together would error. Now this combination runs the warm command directly in the current terminal instead of opening a zellij session.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
