### PR TITLE
x(dust-hive): run bun link after sync

### DIFF
--- a/x/henry/dust-hive/src/commands/sync.ts
+++ b/x/henry/dust-hive/src/commands/sync.ts
@@ -97,7 +97,7 @@ async function runBunLink(dir: string): Promise<boolean> {
 }
 
 export async function syncCommand(targetBranch?: string): Promise<Result<void>> {
-  const startTime = Date.now();
+  const startTimeMs = Date.now();
   const branch = targetBranch ?? "main";
 
   // Find repo root (or use existing cache source)
@@ -169,14 +169,15 @@ export async function syncCommand(targetBranch?: string): Promise<Result<void>> 
   logger.step("Updating node dependencies...");
   console.log();
 
-  const dirs = [
+  const npmDirs = [
     { name: "sdks/js", path: `${repoRoot}/sdks/js` },
     { name: "front", path: `${repoRoot}/front` },
     { name: "connectors", path: `${repoRoot}/connectors` },
   ];
+  const dustHiveDir = { name: "x/henry/dust-hive", path: `${repoRoot}/x/henry/dust-hive` };
 
   const results = await Promise.all(
-    dirs.map(async ({ name, path }) => {
+    npmDirs.map(async ({ name, path }) => {
       logger.step(`  ${name}...`);
       const success = await runNpmInstall(path);
       if (success) {
@@ -204,15 +205,14 @@ export async function syncCommand(targetBranch?: string): Promise<Result<void>> 
   logger.success(`Built ${buildResult.built.length} binaries`);
 
   // Link dust-hive globally
-  logger.step("Linking dust-hive...");
-  const dustHiveDir = `${repoRoot}/x/henry/dust-hive`;
-  const linkSuccess = await runBunLink(dustHiveDir);
+  logger.step(`Linking ${dustHiveDir.name}...`);
+  const linkSuccess = await runBunLink(dustHiveDir.path);
   if (!linkSuccess) {
     return Err(new CommandError("Failed to run bun link for dust-hive"));
   }
   logger.success("dust-hive linked globally");
 
-  const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+  const elapsed = ((Date.now() - startTimeMs) / 1000).toFixed(1);
   console.log();
   logger.success(`Sync complete! (${elapsed}s)`);
   console.log();


### PR DESCRIPTION
## Description

Automatically run `bun link` for dust-hive at the end of the sync command to ensure the CLI stays globally available after rebasing.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
