### PR TITLE
x(dust-hive): add Temporal search attributes on namespace creation

### DIFF
--- a/x/henry/dust-hive/src/lib/temporal.ts
+++ b/x/henry/dust-hive/src/lib/temporal.ts
@@ -1,8 +1,34 @@
+// Search attribute definitions for Temporal namespaces
+// These must be registered before workflows can use them
+export const SEARCH_ATTRIBUTES = {
+  conversationId: "Text",
+  workspaceId: "Text",
+  connectorId: "Int",
+} as const;
+
+export type SearchAttributeName = keyof typeof SEARCH_ATTRIBUTES;
+
 export const TEMPORAL_NAMESPACE_CONFIG = [
-  { suffix: "", envVar: "TEMPORAL_NAMESPACE" },
-  { suffix: "-agent", envVar: "TEMPORAL_AGENT_NAMESPACE" },
-  { suffix: "-connectors", envVar: "TEMPORAL_CONNECTORS_NAMESPACE" },
-  { suffix: "-relocation", envVar: "TEMPORAL_RELOCATION_NAMESPACE" },
+  {
+    suffix: "",
+    envVar: "TEMPORAL_NAMESPACE",
+    searchAttributes: ["conversationId", "workspaceId"] satisfies SearchAttributeName[],
+  },
+  {
+    suffix: "-agent",
+    envVar: "TEMPORAL_AGENT_NAMESPACE",
+    searchAttributes: ["conversationId", "workspaceId"] satisfies SearchAttributeName[],
+  },
+  {
+    suffix: "-connectors",
+    envVar: "TEMPORAL_CONNECTORS_NAMESPACE",
+    searchAttributes: ["connectorId"] satisfies SearchAttributeName[],
+  },
+  {
+    suffix: "-relocation",
+    envVar: "TEMPORAL_RELOCATION_NAMESPACE",
+    searchAttributes: [] satisfies SearchAttributeName[],
+  },
 ] as const;
 
 export function getTemporalNamespaces(envName: string): string[] {


### PR DESCRIPTION
## Description


When creating Temporal namespaces during `dust-hive warm`, now also registers the required custom search attributes for each namespace:
- Front and Agent namespaces: conversationId, workspaceId
- Connectors namespace: connectorId

This fixes agent loop workflows failing with "no mapping defined for search attribute conversationId" errors in newly created environments.


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
