### PR TITLE
[front] - refactor(observability): standardize endpoints

### DIFF
--- a/front/lib/api/assistant/observability/utils.ts
+++ b/front/lib/api/assistant/observability/utils.ts
@@ -34,15 +34,3 @@ export function buildAgentAnalyticsBaseQuery({
     },
   };
 }
-
-export function buildFeedbackQuery({
-  dismissed,
-}: {
-  dismissed: boolean;
-}): estypes.QueryDslQueryContainer {
-  return {
-    bool: {
-      filter: [{ term: { "feedbacks.dismissed": dismissed } }],
-    },
-  };
-}

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/error_rate.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/error_rate.ts
@@ -1,5 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
+import { fromError } from "zod-validation-error";
 
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
@@ -10,9 +11,10 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
+import { isString } from "@app/types";
 
 const QuerySchema = z.object({
-  days: z.coerce.number().positive().optional(),
+  days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
   version: z.string().optional(),
 });
 
@@ -28,7 +30,7 @@ async function handler(
   res: NextApiResponse<WithAPIErrorResponse<GetErrorRateResponse>>,
   auth: Authenticator
 ) {
-  if (typeof req.query.aId !== "string") {
+  if (!isString(req.query.aId)) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
@@ -76,7 +78,7 @@ async function handler(
         });
       }
 
-      const days = q.data.days ?? DEFAULT_PERIOD_DAYS;
+      const days = q.data.days;
       const version = q.data.version;
 
       const owner = auth.getNonNullableWorkspace();
@@ -94,12 +96,11 @@ async function handler(
       ] as const);
 
       if (errorRateResult.isErr()) {
-        const e = errorRateResult.error;
         return apiError(req, res, {
           status_code: 500,
           api_error: {
             type: "internal_server_error",
-            message: `Failed to retrieve error rate: ${e.message}`,
+            message: `Failed to retrieve error rate: ${fromError(errorRateResult.error).toString()}`,
           },
         });
       }

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/feedback-distribution.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/feedback-distribution.ts
@@ -1,5 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
+import { fromError } from "zod-validation-error";
 
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
@@ -10,9 +11,10 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
+import { isString } from "@app/types";
 
 const QuerySchema = z.object({
-  days: z.coerce.number().positive().optional(),
+  days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
 });
 
 export type GetFeedbackDistributionResponse = {
@@ -24,7 +26,7 @@ async function handler(
   res: NextApiResponse<WithAPIErrorResponse<GetFeedbackDistributionResponse>>,
   auth: Authenticator
 ) {
-  if (typeof req.query.aId !== "string") {
+  if (!isString(req.query.aId)) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
@@ -72,7 +74,7 @@ async function handler(
         });
       }
 
-      const days = q.data.days ?? DEFAULT_PERIOD_DAYS;
+      const days = q.data.days;
 
       const owner = auth.getNonNullableWorkspace();
 
@@ -88,12 +90,11 @@ async function handler(
       );
 
       if (feedbackDistributionResult.isErr()) {
-        const error = feedbackDistributionResult.error;
         return apiError(req, res, {
           status_code: 500,
           api_error: {
             type: "internal_server_error",
-            message: `Failed to retrieve feedback distribution: ${error.message}`,
+            message: `Failed to retrieve feedback distribution: ${fromError(feedbackDistributionResult.error).toString()}`,
           },
         });
       }

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/latency.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/latency.ts
@@ -1,5 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
+import { fromError } from "zod-validation-error";
 
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
@@ -10,9 +11,10 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
+import { isString } from "@app/types";
 
 const QuerySchema = z.object({
-  days: z.coerce.number().positive().optional(),
+  days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
   version: z.string().optional(),
 });
 
@@ -28,7 +30,7 @@ async function handler(
   res: NextApiResponse<WithAPIErrorResponse<GetLatencyResponse>>,
   auth: Authenticator
 ) {
-  if (typeof req.query.aId !== "string") {
+  if (!isString(req.query.aId)) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
@@ -76,7 +78,7 @@ async function handler(
         });
       }
 
-      const days = q.data.days ?? DEFAULT_PERIOD_DAYS;
+      const days = q.data.days;
 
       const owner = auth.getNonNullableWorkspace();
 
@@ -93,12 +95,11 @@ async function handler(
       ] as const);
 
       if (latencyResult.isErr()) {
-        const e = latencyResult.error;
         return apiError(req, res, {
           status_code: 500,
           api_error: {
             type: "internal_server_error",
-            message: `Failed to retrieve usage metrics: ${e.message}`,
+            message: `Failed to retrieve usage metrics: ${fromError(latencyResult.error).toString()}`,
           },
         });
       }

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/overview.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/overview.ts
@@ -1,5 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
+import { fromError } from "zod-validation-error";
 
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
@@ -9,6 +10,7 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
+import { isString } from "@app/types";
 
 export type GetAgentOverviewResponseBody = {
   activeUsers: number;
@@ -25,7 +27,7 @@ export type GetAgentOverviewResponseBody = {
 };
 
 const QuerySchema = z.object({
-  days: z.coerce.number().positive().optional(),
+  days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
   version: z.string().optional(),
 });
 
@@ -34,7 +36,7 @@ async function handler(
   res: NextApiResponse<WithAPIErrorResponse<GetAgentOverviewResponseBody>>,
   auth: Authenticator
 ) {
-  if (typeof req.query.aId !== "string") {
+  if (!isString(req.query.aId)) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
@@ -95,12 +97,11 @@ async function handler(
 
       const overview = await fetchAgentOverview(baseQuery, days);
       if (overview.isErr()) {
-        const e = overview.error;
         return apiError(req, res, {
           status_code: 500,
           api_error: {
             type: "internal_server_error",
-            message: `Failed to retrieve agent overview: ${e.message}`,
+            message: `Failed to retrieve agent overview: ${fromError(overview.error).toString()}`,
           },
         });
       }

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/tool-execution.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/tool-execution.ts
@@ -1,5 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
+import { fromError } from "zod-validation-error";
 
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
@@ -10,9 +11,10 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
+import { isString } from "@app/types";
 
 const QuerySchema = z.object({
-  days: z.coerce.number().positive().optional(),
+  days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
   version: z.string().optional(),
 });
 
@@ -25,7 +27,7 @@ async function handler(
   res: NextApiResponse<WithAPIErrorResponse<GetToolExecutionResponse>>,
   auth: Authenticator
 ) {
-  if (typeof req.query.aId !== "string") {
+  if (!isString(req.query.aId)) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
@@ -87,12 +89,11 @@ async function handler(
       const toolExecutionResult = await fetchToolExecutionMetrics(baseQuery);
 
       if (toolExecutionResult.isErr()) {
-        const e = toolExecutionResult.error;
         return apiError(req, res, {
           status_code: 500,
           api_error: {
             type: "internal_server_error",
-            message: `Failed to retrieve tool execution metrics: ${e.message}`,
+            message: `Failed to retrieve tool execution metrics: ${fromError(toolExecutionResult.error).toString()}`,
           },
         });
       }

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/tool-step-index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/tool-step-index.ts
@@ -1,5 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
+import { fromError } from "zod-validation-error";
 
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
@@ -10,9 +11,10 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
+import { isString } from "@app/types";
 
 const QuerySchema = z.object({
-  days: z.coerce.number().positive().optional(),
+  days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
   version: z.string().optional(),
 });
 
@@ -25,7 +27,7 @@ async function handler(
   res: NextApiResponse<WithAPIErrorResponse<GetToolStepIndexResponse>>,
   auth: Authenticator
 ) {
-  if (typeof req.query.aId !== "string") {
+  if (!isString(req.query.aId)) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
@@ -73,7 +75,7 @@ async function handler(
         });
       }
 
-      const days = q.data.days ?? DEFAULT_PERIOD_DAYS;
+      const days = q.data.days;
       const version = q.data.version;
       const owner = auth.getNonNullableWorkspace();
 
@@ -87,12 +89,11 @@ async function handler(
       const result = await fetchToolStepIndexDistribution(baseQuery);
 
       if (result.isErr()) {
-        const e = result.error;
         return apiError(req, res, {
           status_code: 500,
           api_error: {
             type: "internal_server_error",
-            message: `Failed to retrieve tool step index distribution: ${e.message}`,
+            message: `Failed to retrieve tool step index distribution: ${fromError(result.error).toString()}`,
           },
         });
       }

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/usage-metrics.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/usage-metrics.ts
@@ -1,5 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
+import { fromError } from "zod-validation-error";
 
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
@@ -13,10 +14,11 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
+import { isString } from "@app/types";
 
 const QuerySchema = z.object({
-  days: z.coerce.number().positive().optional(),
-  interval: z.enum(["day", "week"]).optional(),
+  days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
+  interval: z.enum(["day", "week"]).optional().default("day"),
 });
 
 export type GetUsageMetricsResponse = {
@@ -32,7 +34,7 @@ async function handler(
   res: NextApiResponse<WithAPIErrorResponse<GetUsageMetricsResponse>>,
   auth: Authenticator
 ) {
-  if (typeof req.query.aId !== "string") {
+  if (!isString(req.query.aId)) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
@@ -80,8 +82,8 @@ async function handler(
         });
       }
 
-      const days = q.data.days ?? DEFAULT_PERIOD_DAYS;
-      const interval = q.data.interval ?? "day";
+      const days = q.data.days;
+      const interval = q.data.interval;
 
       const owner = auth.getNonNullableWorkspace();
 
@@ -98,12 +100,11 @@ async function handler(
       );
 
       if (usageMetricsResult.isErr()) {
-        const e = usageMetricsResult.error;
         return apiError(req, res, {
           status_code: 500,
           api_error: {
             type: "internal_server_error",
-            message: `Failed to retrieve usage metrics: ${e.message}`,
+            message: `Failed to retrieve usage metrics: ${fromError(usageMetricsResult.error).toString()}`,
           },
         });
       }

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/version-markers.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/version-markers.ts
@@ -10,9 +10,10 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
+import { isString } from "@app/types";
 
 const QuerySchema = z.object({
-  days: z.coerce.number().positive().optional(),
+  days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
 });
 
 export type GetVersionMarkersResponse = {
@@ -24,7 +25,7 @@ async function handler(
   res: NextApiResponse<WithAPIErrorResponse<GetVersionMarkersResponse>>,
   auth: Authenticator
 ) {
-  if (typeof req.query.aId !== "string") {
+  if (!isString(req.query.aId)) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
@@ -72,7 +73,7 @@ async function handler(
         });
       }
 
-      const days = q.data.days ?? DEFAULT_PERIOD_DAYS;
+      const days = q.data.days;
 
       const owner = auth.getNonNullableWorkspace();
 


### PR DESCRIPTION
## Description

This refactoring standardizes error handling and query parameter processing across all observability endpoints. The changes introduce the `fromError` utility from `zod-validation-error` to format error messages consistently, set default values directly in Zod schemas using `.default()` instead of manual fallbacks, and replace direct type checks with the existing `isString` utility function. The unused `buildFeedbackQuery` function is removed from the observability utils module.

## Risk

Low

## Tests

Locally
