### PR TITLE
Stringify cachedTools jsonb column

### DIFF
--- a/front/temporal/relocation/lib/sql/insert.ts
+++ b/front/temporal/relocation/lib/sql/insert.ts
@@ -12,6 +12,11 @@ const JSONB_COLUMNS = [
     tableName: "agent_mcp_actions",
     columns: ["augmentedInputs", "toolConfiguration"],
   },
+  // cachedTools should be an array of objects, but we store it as JSONB
+  {
+    tableName: "remote_mcp_servers",
+    columns: ["cachedTools"],
+  },
 ];
 
 export function generateParameterizedInsertStatements(
@@ -54,8 +59,7 @@ export function generateParameterizedInsertStatements(
           JSONB_COLUMNS.some(
             (c) => c.tableName === tableName && c.columns.includes(col)
           ) &&
-          (typeof row[col] === "string" ||
-            (Array.isArray(row[col]) && row[col].length > 0))
+          (typeof row[col] === "string" || Array.isArray(row[col]))
         ) {
           params.push(JSON.stringify(row[col]));
           continue;

--- a/front/temporal/relocation/lib/sql/insert.ts
+++ b/front/temporal/relocation/lib/sql/insert.ts
@@ -12,10 +12,14 @@ const JSONB_COLUMNS = [
     tableName: "agent_mcp_actions",
     columns: ["augmentedInputs", "toolConfiguration"],
   },
-  // cachedTools should be an array of objects, but we store it as JSONB
+  // Following columns should be arrays of objects, but we store them as JSONB
   {
     tableName: "remote_mcp_servers",
     columns: ["cachedTools"],
+  },
+  {
+    tableName: "zendesk_configurations",
+    columns: ["customFieldsConfig"],
   },
 ];
 


### PR DESCRIPTION
## Description

Fixes a bug in the relocation workflow where **empty arrays** in JSONB columns were incorrectly interpreted as **empty objects** during insertion into the destination database. 
The root cause was improper stringification of empty arrays in JSONB columns. This affected: 
- the `cachedTools` column in the `remote_mcp_servers` table (front db)
- the `customFieldsConfig` column in the `zendesk_configurations` table (connectors db). 

This PR adds this column to the whitelisted columns (ie the columns to stringify).


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Deploy front
