### PR TITLE
[front] feat: Add WorkspaceVerificationAttempt resource

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -96,9 +96,9 @@ import {
 } from "@app/lib/resources/storage/models/user";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import { WorkspaceHasDomainModel } from "@app/lib/resources/storage/models/workspace_has_domain";
+import { WorkspaceVerificationAttemptModel } from "@app/lib/resources/storage/models/workspace_verification_attempt";
 import logger from "@app/logger/logger";
 import { sendInitDbMessage } from "@app/types";
-import { WorkspaceVerificationAttemptModel } from "@app/lib/resources/storage/models/workspace_verification_attempt";
 
 async function main() {
   await sendInitDbMessage({

--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -98,6 +98,7 @@ import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import { WorkspaceHasDomainModel } from "@app/lib/resources/storage/models/workspace_has_domain";
 import logger from "@app/logger/logger";
 import { sendInitDbMessage } from "@app/types";
+import { WorkspaceVerificationAttemptModel } from "@app/lib/resources/storage/models/workspace_verification_attempt";
 
 async function main() {
   await sendInitDbMessage({
@@ -201,6 +202,7 @@ async function main() {
   await ConversationSkillModel.sync({ alter: true });
   await AgentMessageSkillModel.sync({ alter: true });
   await SkillMCPServerConfigurationModel.sync({ alter: true });
+  await WorkspaceVerificationAttemptModel.sync({ alter: true });
 
   process.exit(0);
 }

--- a/front/lib/resources/storage/models/workspace_verification_attempt.ts
+++ b/front/lib/resources/storage/models/workspace_verification_attempt.ts
@@ -1,0 +1,71 @@
+import type { CreationOptional } from "sequelize";
+import { DataTypes, Op } from "sequelize";
+
+import { frontSequelize } from "@app/lib/resources/storage";
+import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
+
+export class WorkspaceVerificationAttemptModel extends WorkspaceAwareModel<WorkspaceVerificationAttemptModel> {
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+  declare phoneNumberHash: string;
+  declare twilioVerificationSid: string | null;
+  declare attemptNumber: number;
+  declare verifiedAt: Date | null;
+  declare failedAt: Date | null;
+}
+
+WorkspaceVerificationAttemptModel.init(
+  {
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    phoneNumberHash: {
+      type: DataTypes.STRING(64),
+      allowNull: false,
+    },
+    twilioVerificationSid: {
+      type: DataTypes.STRING(64),
+      allowNull: true,
+      defaultValue: null,
+    },
+    attemptNumber: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      defaultValue: 1,
+    },
+    verifiedAt: {
+      type: DataTypes.DATE,
+      allowNull: true,
+      defaultValue: null,
+    },
+    failedAt: {
+      type: DataTypes.DATE,
+      allowNull: true,
+      defaultValue: null,
+    },
+  },
+  {
+    modelName: "workspace_verification_attempt",
+    sequelize: frontSequelize,
+    indexes: [
+      { fields: ["workspaceId"] },
+      {
+        fields: ["phoneNumberHash"],
+        unique: true,
+        name: "workspace_verification_attempts_phone_hash_unique_idx",
+      },
+      {
+        fields: ["twilioVerificationSid"],
+        name: "workspace_verification_attempts_twilio_sid_idx",
+        where: { twilioVerificationSid: { [Op.ne]: null } },
+      },
+    ],
+  }
+);

--- a/front/lib/resources/storage/models/workspace_verification_attempt.ts
+++ b/front/lib/resources/storage/models/workspace_verification_attempt.ts
@@ -11,7 +11,6 @@ export class WorkspaceVerificationAttemptModel extends WorkspaceAwareModel<Works
   declare twilioVerificationSid: string | null;
   declare attemptNumber: number;
   declare verifiedAt: Date | null;
-  declare failedAt: Date | null;
 }
 
 WorkspaceVerificationAttemptModel.init(
@@ -45,11 +44,6 @@ WorkspaceVerificationAttemptModel.init(
       allowNull: true,
       defaultValue: null,
     },
-    failedAt: {
-      type: DataTypes.DATE,
-      allowNull: true,
-      defaultValue: null,
-    },
   },
   {
     modelName: "workspace_verification_attempt",
@@ -60,6 +54,7 @@ WorkspaceVerificationAttemptModel.init(
         fields: ["phoneNumberHash"],
         unique: true,
         name: "workspace_verification_attempts_phone_hash_unique_idx",
+        where: { verifiedAt: { [Op.ne]: null } },
       },
       {
         fields: ["twilioVerificationSid"],

--- a/front/lib/resources/string_ids.ts
+++ b/front/lib/resources/string_ids.ts
@@ -58,6 +58,9 @@ export const RESOURCES_PREFIX = {
 
   // Skills.
   skill: "skl",
+
+  // Workspace verification.
+  workspace_verification_attempt: "wva",
 } as const;
 
 export const CROSS_WORKSPACE_RESOURCES_WORKSPACE_ID: ModelId = 0;

--- a/front/lib/resources/workspace_verification_attempt_resource.ts
+++ b/front/lib/resources/workspace_verification_attempt_resource.ts
@@ -1,0 +1,184 @@
+import { createHash } from "crypto";
+import type { Attributes, Transaction } from "sequelize";
+import { Op } from "sequelize";
+
+import type { Authenticator } from "@app/lib/auth";
+import { BaseResource } from "@app/lib/resources/base_resource";
+import { WorkspaceVerificationAttemptModel } from "@app/lib/resources/storage/models/workspace_verification_attempt";
+import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
+import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
+import { makeSId } from "@app/lib/resources/string_ids";
+import type { ResourceFindOptions } from "@app/lib/resources/types";
+import type { Result } from "@app/types";
+import { Ok } from "@app/types";
+import type { VerificationStatus } from "@app/types/workspace_verification";
+
+const VERIFICATION_EXPIRY_SECONDS = 10 * 60; // 10 minutes.
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export interface WorkspaceVerificationAttemptResource extends ReadonlyAttributesType<WorkspaceVerificationAttemptModel> {}
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export class WorkspaceVerificationAttemptResource extends BaseResource<WorkspaceVerificationAttemptModel> {
+  static model: ModelStaticWorkspaceAware<WorkspaceVerificationAttemptModel> =
+    WorkspaceVerificationAttemptModel;
+
+  constructor(
+    model: ModelStaticWorkspaceAware<WorkspaceVerificationAttemptModel>,
+    blob: Attributes<WorkspaceVerificationAttemptModel>
+  ) {
+    super(WorkspaceVerificationAttemptModel, blob);
+  }
+
+  get sId(): string {
+    return makeSId("workspace_verification_attempt", {
+      id: this.id,
+      workspaceId: this.workspaceId,
+    });
+  }
+
+  get status(): VerificationStatus {
+    if (this.verifiedAt) {
+      return "verified";
+    }
+    if (this.failedAt) {
+      return "failed";
+    }
+    const expiryTime =
+      this.createdAt.getTime() + VERIFICATION_EXPIRY_SECONDS * 1000;
+    if (Date.now() > expiryTime) {
+      return "expired";
+    }
+    return "pending";
+  }
+
+  static hashPhoneNumber(phoneNumber: string): string {
+    return createHash("sha256").update(phoneNumber).digest("hex");
+  }
+
+  static async isPhoneAlreadyUsed(phoneNumberHash: string): Promise<boolean> {
+    const existing = await this.model.findOne({
+      where: { phoneNumberHash },
+      // WORKSPACE_ISOLATION_BYPASS: Global uniqueness check - a phone can only be used by one workspace.
+      dangerouslyBypassWorkspaceIsolationSecurity: true,
+    });
+    return existing !== null;
+  }
+
+  static async makeNew(
+    auth: Authenticator,
+    {
+      phoneNumberHash,
+      twilioVerificationSid,
+    }: {
+      phoneNumberHash: string;
+      twilioVerificationSid: string;
+    },
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<WorkspaceVerificationAttemptResource> {
+    const attempt = await this.model.create(
+      {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        phoneNumberHash,
+        twilioVerificationSid,
+        attemptNumber: 1,
+      },
+      { transaction }
+    );
+
+    return new this(this.model, attempt.get());
+  }
+
+  private static async baseFetch(
+    auth: Authenticator,
+    options?: ResourceFindOptions<WorkspaceVerificationAttemptModel>
+  ): Promise<WorkspaceVerificationAttemptResource[]> {
+    const { where, ...rest } = options ?? {};
+    const rows = await this.model.findAll({
+      where: {
+        ...where,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+      ...rest,
+    });
+
+    return rows.map((r) => new this(this.model, r.get()));
+  }
+
+  static async fetchByPhoneHash(
+    auth: Authenticator,
+    phoneNumberHash: string
+  ): Promise<WorkspaceVerificationAttemptResource | null> {
+    const [row] = await this.baseFetch(auth, {
+      where: { phoneNumberHash },
+    });
+    return row ?? null;
+  }
+
+  static async hasVerifiedPhone(auth: Authenticator): Promise<boolean> {
+    const rows = await this.baseFetch(auth, {
+      where: { verifiedAt: { [Op.ne]: null } },
+      limit: 1,
+    });
+    return rows.length > 0;
+  }
+
+  async recordNewAttempt(
+    twilioVerificationSid: string,
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<void> {
+    await this.update(
+      {
+        twilioVerificationSid,
+        attemptNumber: this.attemptNumber + 1,
+      },
+      transaction
+    );
+  }
+
+  async markVerified({
+    transaction,
+  }: { transaction?: Transaction } = {}): Promise<void> {
+    await this.update({ verifiedAt: new Date() }, transaction);
+  }
+
+  async markFailed({
+    transaction,
+  }: { transaction?: Transaction } = {}): Promise<void> {
+    await this.update({ failedAt: new Date() }, transaction);
+  }
+
+  toLogJSON() {
+    return {
+      id: this.id,
+      workspaceId: this.workspaceId,
+      phoneNumberHash: this.phoneNumberHash,
+      attemptNumber: this.attemptNumber,
+      status: this.status,
+      verifiedAt: this.verifiedAt?.toISOString() ?? null,
+      failedAt: this.failedAt?.toISOString() ?? null,
+    };
+  }
+
+  async delete(
+    auth: Authenticator,
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<Result<number, Error>> {
+    const deletedCount = await WorkspaceVerificationAttemptModel.destroy({
+      where: {
+        id: this.id,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+      transaction,
+    });
+
+    return new Ok(deletedCount);
+  }
+
+  static async deleteAllForWorkspace(auth: Authenticator): Promise<void> {
+    await WorkspaceVerificationAttemptModel.destroy({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+    });
+  }
+}

--- a/front/lib/resources/workspace_verification_attempt_resource.ts
+++ b/front/lib/resources/workspace_verification_attempt_resource.ts
@@ -138,12 +138,22 @@ export class WorkspaceVerificationAttemptResource extends BaseResource<Workspace
   async markVerified({
     transaction,
   }: { transaction?: Transaction } = {}): Promise<void> {
+    if (this.verifiedAt || this.failedAt) {
+      throw new Error(
+        "Verification attempt already marked as verified or failed"
+      );
+    }
     await this.update({ verifiedAt: new Date() }, transaction);
   }
 
   async markFailed({
     transaction,
   }: { transaction?: Transaction } = {}): Promise<void> {
+    if (this.verifiedAt || this.failedAt) {
+      throw new Error(
+        "Verification attempt already marked as verified or failed"
+      );
+    }
     await this.update({ failedAt: new Date() }, transaction);
   }
 

--- a/front/migrations/db/migration_461.sql
+++ b/front/migrations/db/migration_461.sql
@@ -1,3 +1,2 @@
 -- Migration created on Jan 05, 2026
 ALTER TABLE "public"."plans" ADD COLUMN "isDeepDiveAllowed" BOOLEAN NOT NULL DEFAULT true;
-||||||| parent of 1a9adba4a5 ([front] feat: Add WorkspaceVerificationAttempt resource)

--- a/front/migrations/db/migration_461.sql
+++ b/front/migrations/db/migration_461.sql
@@ -1,2 +1,3 @@
 -- Migration created on Jan 05, 2026
 ALTER TABLE "public"."plans" ADD COLUMN "isDeepDiveAllowed" BOOLEAN NOT NULL DEFAULT true;
+||||||| parent of 1a9adba4a5 ([front] feat: Add WorkspaceVerificationAttempt resource)

--- a/front/migrations/db/migration_469.sql
+++ b/front/migrations/db/migration_469.sql
@@ -5,7 +5,7 @@ CREATE TABLE "workspace_verification_attempts" (
     "id" BIGSERIAL PRIMARY KEY,
     "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
     "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
-    "workspaceId" BIGINT NOT NULL REFERENCES "workspaces"("id") ON DELETE RESTRICT,
+    "workspaceId" BIGINT NOT NULL REFERENCES "workspaces" ("id") ON DELETE RESTRICT,
     "phoneNumberHash" VARCHAR(64) NOT NULL,
     "twilioVerificationSid" VARCHAR(64),
     "attemptNumber" INTEGER NOT NULL DEFAULT 1,
@@ -14,15 +14,15 @@ CREATE TABLE "workspace_verification_attempts" (
 );
 
 -- Index for workspace queries
-CREATE INDEX "workspace_verification_attempts_workspace_id_idx"
-    ON "workspace_verification_attempts"("workspaceId");
+CREATE INDEX "workspace_verification_attempts_workspace_id_idx" ON "workspace_verification_attempts" ("workspaceId");
 
 -- Unique index: one phone number globally (phone can only be used by one workspace)
-CREATE UNIQUE INDEX "workspace_verification_attempts_phone_hash_unique_idx"
-    ON "workspace_verification_attempts"("phoneNumberHash");
+CREATE UNIQUE INDEX "workspace_verification_attempts_phone_hash_unique_idx" ON "workspace_verification_attempts" ("phoneNumberHash")
+WHERE
+    "verifiedAt" IS NOT NULL;
 
 -- Index for webhook lookups by Twilio SID
-CREATE INDEX "workspace_verification_attempts_twilio_sid_idx"
-    ON "workspace_verification_attempts"("twilioVerificationSid")
-    WHERE "twilioVerificationSid" IS NOT NULL;
+CREATE INDEX "workspace_verification_attempts_twilio_sid_idx" ON "workspace_verification_attempts" ("twilioVerificationSid")
+WHERE
+    "twilioVerificationSid" IS NOT NULL;
 

--- a/front/migrations/db/migration_469.sql
+++ b/front/migrations/db/migration_469.sql
@@ -9,8 +9,7 @@ CREATE TABLE "workspace_verification_attempts" (
     "phoneNumberHash" VARCHAR(64) NOT NULL,
     "twilioVerificationSid" VARCHAR(64),
     "attemptNumber" INTEGER NOT NULL DEFAULT 1,
-    "verifiedAt" TIMESTAMP WITH TIME ZONE,
-    "failedAt" TIMESTAMP WITH TIME ZONE
+    "verifiedAt" TIMESTAMP WITH TIME ZONE
 );
 
 -- Index for workspace queries

--- a/front/migrations/db/migration_469.sql
+++ b/front/migrations/db/migration_469.sql
@@ -1,0 +1,28 @@
+-- Migration: Create workspace_verification_attempts table
+-- Purpose: Store phone verification attempts for workspace verification
+
+CREATE TABLE "workspace_verification_attempts" (
+    "id" BIGSERIAL PRIMARY KEY,
+    "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    "workspaceId" BIGINT NOT NULL REFERENCES "workspaces"("id") ON DELETE RESTRICT,
+    "phoneNumberHash" VARCHAR(64) NOT NULL,
+    "twilioVerificationSid" VARCHAR(64),
+    "attemptNumber" INTEGER NOT NULL DEFAULT 1,
+    "verifiedAt" TIMESTAMP WITH TIME ZONE,
+    "failedAt" TIMESTAMP WITH TIME ZONE
+);
+
+-- Index for workspace queries
+CREATE INDEX "workspace_verification_attempts_workspace_id_idx"
+    ON "workspace_verification_attempts"("workspaceId");
+
+-- Unique index: one phone number globally (phone can only be used by one workspace)
+CREATE UNIQUE INDEX "workspace_verification_attempts_phone_hash_unique_idx"
+    ON "workspace_verification_attempts"("phoneNumberHash");
+
+-- Index for webhook lookups by Twilio SID
+CREATE INDEX "workspace_verification_attempts_twilio_sid_idx"
+    ON "workspace_verification_attempts"("twilioVerificationSid")
+    WHERE "twilioVerificationSid" IS NOT NULL;
+

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -62,6 +62,7 @@ import { UserResource } from "@app/lib/resources/user_resource";
 import { WebhookRequestResource } from "@app/lib/resources/webhook_request_resource";
 import { WebhookSourceResource } from "@app/lib/resources/webhook_source_resource";
 import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_view_resource";
+import { WorkspaceVerificationAttemptResource } from "@app/lib/resources/workspace_verification_attempt_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
@@ -652,6 +653,7 @@ export async function deleteWorkspaceActivity({
   });
   await CreditResource.deleteAllForWorkspace(auth);
   await ProgrammaticUsageConfigurationResource.deleteAllForWorkspace(auth);
+  await WorkspaceVerificationAttemptResource.deleteAllForWorkspace(auth);
 
   hardDeleteLogger.info({ workspaceId }, "Deleting Workspace");
 

--- a/front/types/workspace_verification.ts
+++ b/front/types/workspace_verification.ts
@@ -1,9 +1,7 @@
-// Computed status (derived from verifiedAt/failedAt/createdAt).
+// Computed status (derived from verifiedAt).
 export const VERIFICATION_STATUSES = [
   "pending",
   "verified",
-  "failed",
-  "expired",
 ] as const;
 export type VerificationStatus = (typeof VERIFICATION_STATUSES)[number];
 

--- a/front/types/workspace_verification.ts
+++ b/front/types/workspace_verification.ts
@@ -38,7 +38,7 @@ export type VerificationErrorResponse = {
   error: {
     type: VerificationErrorType;
     message: string;
-    retryAfter?: number; // Unix timestamp (seconds).
+    retryAfterSeconds?: number; // Unix timestamp (seconds).
   };
 };
 

--- a/front/types/workspace_verification.ts
+++ b/front/types/workspace_verification.ts
@@ -1,0 +1,64 @@
+// Computed status (derived from verifiedAt/failedAt/createdAt).
+export const VERIFICATION_STATUSES = [
+  "pending",
+  "verified",
+  "failed",
+  "expired",
+] as const;
+export type VerificationStatus = (typeof VERIFICATION_STATUSES)[number];
+
+// API request/response types.
+export type StartVerificationRequest = {
+  phoneNumber: string;
+};
+
+export type StartVerificationResponse = {
+  success: true;
+  message: string;
+};
+
+export type VerifyCodeRequest = {
+  phoneNumber: string;
+  code: string;
+};
+
+export type VerifyCodeResponse = {
+  success: true;
+  verified: true;
+};
+
+// Error response.
+export type VerificationErrorType =
+  | "rate_limit_error"
+  | "invalid_request_error"
+  | "verification_error"
+  | "phone_already_used_error";
+
+export type VerificationErrorResponse = {
+  error: {
+    type: VerificationErrorType;
+    message: string;
+    retryAfter?: number; // Unix timestamp (seconds).
+  };
+};
+
+// Twilio Lookup API types.
+export const LINE_TYPES = [
+  "mobile",
+  "landline",
+  "fixedVoip",
+  "nonFixedVoip",
+  "personal",
+  "tollFree",
+  "premium",
+  "sharedCost",
+  "uan",
+  "voicemail",
+  "pager",
+  "unknown",
+] as const;
+export type LineType = (typeof LINE_TYPES)[number];
+
+export const SMS_PUMPING_RISK_CATEGORIES = ["low", "medium", "high"] as const;
+export type SmsPumpingRiskCategory =
+  (typeof SMS_PUMPING_RISK_CATEGORIES)[number];

--- a/front/types/workspace_verification.ts
+++ b/front/types/workspace_verification.ts
@@ -1,8 +1,5 @@
 // Computed status (derived from verifiedAt).
-export const VERIFICATION_STATUSES = [
-  "pending",
-  "verified",
-] as const;
+export const VERIFICATION_STATUSES = ["pending", "verified"] as const;
 export type VerificationStatus = (typeof VERIFICATION_STATUSES)[number];
 
 // API request/response types.


### PR DESCRIPTION
## Description

Add workspace verification attempt resource.

This is the first PR of many, with some code not used _yet_ but still interesting to discuss now

fixes https://github.com/dust-tt/tasks/issues/5793

This is to support sending otp via sms, enforcing that:
- A phone number can be used by only one workspace
- We don't store phone numbers (only hashes)

The PR assumes choosing twilio as the provider, but can be easily switched over / columns renamed.

## Tests

N/A

## Risk

Low
Blast radius: none, dead code for now

## Deploy Plan

- [ ] Run migration
- [ ] Deploy front