### PR TITLE
[front] - refactor(SkillResource): optimize update tools

### DIFF
--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1029,8 +1029,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
     const workspace = auth.getNonNullableWorkspace();
 
-    // Delete existing tool associations.
-    await SkillMCPServerConfigurationModel.destroy({
+    const existingConfigs = await SkillMCPServerConfigurationModel.findAll({
       where: {
         workspaceId: workspace.id,
         skillConfigurationId: this.id,
@@ -1038,15 +1037,38 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       transaction,
     });
 
-    // Create new tool associations.
-    await SkillMCPServerConfigurationModel.bulkCreate(
-      mcpServerViews.map((mcpServerView) => ({
-        workspaceId: workspace.id,
-        skillConfigurationId: this.id,
-        mcpServerViewId: mcpServerView.id,
-      })),
-      { transaction }
+    const existingMcpServerViewIds = new Set(
+      existingConfigs.map((config) => config.mcpServerViewId)
     );
+    const mcpServerViewIds = new Set(mcpServerViews.map((msv) => msv.id));
+
+    // Delete removed tools
+    const idsToDelete = existingConfigs
+      .filter((config) => !mcpServerViewIds.has(config.mcpServerViewId))
+      .map((config) => config.id);
+    if (idsToDelete.length > 0) {
+      await SkillMCPServerConfigurationModel.destroy({
+        where: {
+          id: { [Op.in]: idsToDelete },
+        },
+        transaction,
+      });
+    }
+
+    // Create new tools
+    const toCreate = mcpServerViews.filter(
+      (msv) => !existingMcpServerViewIds.has(msv.id)
+    );
+    if (toCreate.length > 0) {
+      await SkillMCPServerConfigurationModel.bulkCreate(
+        toCreate.map((mcpServerView) => ({
+          workspaceId: workspace.id,
+          skillConfigurationId: this.id,
+          mcpServerViewId: mcpServerView.id,
+        })),
+        { transaction }
+      );
+    }
 
     // Update the current instance with the new tools to avoid stale data. (Similar to BaseResource update)
     Object.assign(this, { mcpServerViews });


### PR DESCRIPTION
## Description

Optimizes `SkillResource.updateTools` to avoid unnecessary database operations. Previously, the method deleted all existing MCP server configurations and recreated them from scratch. This change replaces the delete-and-recreate approach with selective updates: only removed configurations are deleted and only new ones are created, leaving unchanged configurations intact.

## Risk

Low

## Tests

Locally

## Deploy Plan

Deploy front