### PR TITLE
[Front] fix(qa-skill-lifecycle): fix conversation and agent enabled skills display

### DIFF
--- a/front/components/assistant/conversation/actions/AgentActionsPanel.tsx
+++ b/front/components/assistant/conversation/actions/AgentActionsPanel.tsx
@@ -44,7 +44,7 @@ function AgentActionsPanelContent({
 }: AgentActionsPanelContentProps) {
   const [currentStreamingStep, setCurrentStreamingStep] = useState(1);
 
-  const { skills } = useAgentMessageSkills({
+  const { skills, mutateSkills } = useAgentMessageSkills({
     conversation,
     owner,
     messageId,
@@ -72,14 +72,19 @@ function AgentActionsPanelContent({
 
   useEffect(() => {
     if (
-      fullAgentMessage?.type === "agent_message" &&
-      fullAgentMessage?.status === "created" &&
-      !!fullAgentMessage.chainOfThought
+      fullAgentMessage.type !== "agent_message" ||
+      !fullAgentMessage.chainOfThought
     ) {
+      return;
+    }
+
+    if (fullAgentMessage.status === "created") {
       // eslint-disable-next-line react-hooks/immutability
       isFreshMountWithContent.current = true;
+    } else if (fullAgentMessage.status === "succeeded") {
+      void mutateSkills();
     }
-  }, [fullAgentMessage, isFreshMountWithContent]);
+  }, [fullAgentMessage, isFreshMountWithContent, mutateSkills]);
 
   const steps =
     fullAgentMessage?.type === "agent_message"

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -46,6 +46,7 @@ import type {
   AgentConfigurationType,
   AgentsUsageType,
   ConversationType,
+  ConversationWithoutContentType,
   LightAgentConfigurationType,
   ModelId,
   Result,
@@ -540,30 +541,36 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   }
 
   /**
-   * List enabled skills for a given conversation and agent configuration.
-   * Returns only active skills.
+   * List enabled skills for a conversation.
+   *
+   * If agentConfiguration is provided, includes both agent enabled and conversation enabled skills.
+   *
+   * Otherwise, returns only conversation enabled skills (JIT).
    */
-  private static async listEnabledForConversation(
+  static async listEnabledByConversation(
     auth: Authenticator,
     {
-      agentConfiguration,
       conversation,
+      agentConfiguration,
     }: {
-      agentConfiguration: AgentConfigurationType;
-      conversation: ConversationType;
+      conversation: ConversationWithoutContentType;
+      agentConfiguration?: AgentConfigurationType;
     }
   ): Promise<SkillResource[]> {
     const workspace = auth.getNonNullableWorkspace();
 
-    // Fetch the conversation skills for this agent and the ones for all agents.
     const conversationSkills = await ConversationSkillModel.findAll({
       where: {
         workspaceId: workspace.id,
         conversationId: conversation.id,
-        [Op.or]: [
-          { agentConfigurationId: agentConfiguration.sId },
-          { agentConfigurationId: null },
-        ],
+        ...(agentConfiguration
+          ? {
+              [Op.or]: [
+                { agentConfigurationId: agentConfiguration.sId },
+                { agentConfigurationId: null },
+              ],
+            }
+          : { agentConfigurationId: null }),
       },
     });
 
@@ -588,11 +595,11 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     enabledSkills: (SkillResource & { extendedSkill: SkillResource | null })[];
     equippedSkills: SkillResource[];
   }> {
-    const conversationEnabledSkills = await this.listEnabledForConversation(
+    const conversationEnabledSkills = await this.listEnabledByConversation(
       auth,
       {
-        agentConfiguration,
         conversation,
+        agentConfiguration,
       }
     );
     const allAgentSkills = await this.listByAgentConfiguration(
@@ -645,20 +652,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           : null,
       })
     );
-  }
-
-  static async fetchConversationSkills(
-    auth: Authenticator,
-    conversationId: ModelId
-  ): Promise<SkillResource[]> {
-    const conversationSkills = await ConversationSkillModel.findAll({
-      where: {
-        workspaceId: auth.getNonNullableWorkspace().id,
-        conversationId,
-      },
-    });
-
-    return this.fetchBySkillReferences(auth, conversationSkills);
   }
 
   async upsertToConversation(
@@ -1166,7 +1159,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       where: {
         workspaceId: workspace.id,
         conversationId,
-        agentConfigurationId,
+        [Op.or]: [{ agentConfigurationId }, { agentConfigurationId: null }],
       },
     });
 

--- a/front/lib/swr/conversations.ts
+++ b/front/lib/swr/conversations.ts
@@ -309,7 +309,7 @@ export function useConversationSkills({
   const conversationSkillsFetcher: Fetcher<FetchConversationSkillsResponse> =
     fetcher;
 
-  const { data, error, mutate } = useSWRWithDefaults(
+  const { data, error, mutate, isLoading } = useSWRWithDefaults(
     conversationId
       ? `/api/w/${workspaceId}/assistant/conversations/${conversationId}/skills`
       : null,
@@ -318,11 +318,9 @@ export function useConversationSkills({
   );
 
   return {
-    conversationSkills: data
-      ? data.skills
-      : emptyArray<FetchConversationSkillsResponse["skills"][number]>(),
-    isConversationSkillsLoading: !error && !data,
-    isConversationSkillsError: error,
+    conversationSkills: data?.skills ?? emptyArray(),
+    isConversationSkillsLoading: !options?.disabled && isLoading,
+    isConversationSkillsError: !!error,
     mutateConversationSkills: mutate,
   };
 }
@@ -733,7 +731,7 @@ export function useAgentMessageSkills({
 }) {
   const skillsFetcher: Fetcher<GetAgentMessageSkillsResponseBody> = fetcher;
 
-  const { data, error, isLoading } = useSWRWithDefaults(
+  const { data, error, mutate, isLoading } = useSWRWithDefaults(
     conversation && messageId
       ? `/api/w/${owner.sId}/assistant/conversations/${conversation.sId}/messages/${messageId}/skills`
       : null,
@@ -744,7 +742,8 @@ export function useAgentMessageSkills({
   return {
     skills: data?.skills ?? emptyArray(),
     isSkillsLoading: !options?.disabled && isLoading,
-    isSkillsError: error,
+    isSkillsError: !!error,
+    mutateSkills: mutate,
   };
 }
 

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/skills.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/skills.ts
@@ -59,9 +59,9 @@ async function handler(
 
   switch (req.method) {
     case "GET":
-      const conversationSkills = await SkillResource.fetchConversationSkills(
+      const conversationSkills = await SkillResource.listEnabledByConversation(
         auth,
-        conversationWithoutContent.id
+        { conversation: conversationWithoutContent }
       );
 
       return res


### PR DESCRIPTION
Addresses issues raised in : https://github.com/dust-tt/tasks/issues/5734

## Description

- Don't display agent enabled skills in input bar
- Also snapshot JIT skills on agent loop completion
- Fix skills not revalidating after agent message completes
- Merged `fetchConversationSkills` and `listEnabledForConversation` into one single method

## Tests


https://github.com/user-attachments/assets/15cb0771-ce9b-4726-9beb-b87944069474




Manual

## Risk

Low.

## Deploy Plan

Deploy front.
