### PR TITLE
Allow script init_plans to take a specific plan in param

### DIFF
--- a/front/admin/init_plans.sh
+++ b/front/admin/init_plans.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-npx tsx admin/init_plans.ts
+npx tsx admin/init_plans.ts "$@"
 

--- a/front/admin/init_plans.ts
+++ b/front/admin/init_plans.ts
@@ -2,9 +2,16 @@ import { upsertFreePlans } from "@app/lib/plans/free_plans";
 import { upsertProPlans } from "@app/lib/plans/pro_plans";
 
 async function main() {
-  await upsertFreePlans();
-  await upsertProPlans();
-  process.exit(0);
+  const planCode = process.argv[2];
+
+  if (planCode) {
+    console.log(`Upserting plan: ${planCode}`);
+  } else {
+    console.log("Upserting all plans");
+  }
+
+  await upsertFreePlans(planCode);
+  await upsertProPlans(planCode);
 }
 
 main()

--- a/front/lib/plans/free_plans.ts
+++ b/front/lib/plans/free_plans.ts
@@ -116,7 +116,10 @@ const FREE_PLANS_DATA: PlanAttributes[] = [
     code: FREE_TRIAL_PHONE_PLAN_CODE,
     name: "Free Trial",
     maxMessages: 100,
+<<<<<<< HEAD
     isDeepDiveAllowed: false,
+=======
+>>>>>>> 323f90f0db (Subscribe workspace to new FREE_TRIAL_PHONE_PLAN if phone number code successful)
     maxUsersInWorkspace: 5,
     maxVaultsInWorkspace: 5,
     maxImagesPerWeek: 10,

--- a/front/lib/plans/free_plans.ts
+++ b/front/lib/plans/free_plans.ts
@@ -116,10 +116,7 @@ const FREE_PLANS_DATA: PlanAttributes[] = [
     code: FREE_TRIAL_PHONE_PLAN_CODE,
     name: "Free Trial",
     maxMessages: 100,
-<<<<<<< HEAD
     isDeepDiveAllowed: false,
-=======
->>>>>>> 323f90f0db (Subscribe workspace to new FREE_TRIAL_PHONE_PLAN if phone number code successful)
     maxUsersInWorkspace: 5,
     maxVaultsInWorkspace: 5,
     maxImagesPerWeek: 10,
@@ -145,9 +142,14 @@ const FREE_PLANS_DATA: PlanAttributes[] = [
 
 /**
  * Function to call when we edit something in FREE_PLANS_DATA to update the database. It will create or update the plans.
+ * @param planCode - Optional plan code to upsert. If not provided, all plans are upserted.
  */
-export const upsertFreePlans = async () => {
-  for (const planData of FREE_PLANS_DATA) {
+export const upsertFreePlans = async (planCode?: string) => {
+  const plansToUpsert = planCode
+    ? FREE_PLANS_DATA.filter((p) => p.code === planCode)
+    : FREE_PLANS_DATA;
+
+  for (const planData of plansToUpsert) {
     const plan = await PlanModel.findOne({
       where: {
         code: planData.code,

--- a/front/lib/plans/pro_plans.ts
+++ b/front/lib/plans/pro_plans.ts
@@ -85,10 +85,15 @@ if (isDevelopment() || isTest()) {
 }
 
 /**
- * Function to call when we edit something in FREE_PLANS_DATA to update the database. It will create or update the plans.
+ * Function to call when we edit something in PRO_PLANS_DATA to update the database. It will create or update the plans.
+ * @param planCode - Optional plan code to upsert. If not provided, all plans are upserted.
  */
-export const upsertProPlans = async () => {
-  for (const planData of PRO_PLANS_DATA) {
+export const upsertProPlans = async (planCode?: string) => {
+  const plansToUpsert = planCode
+    ? PRO_PLANS_DATA.filter((p) => p.code === planCode)
+    : PRO_PLANS_DATA;
+
+  for (const planData of plansToUpsert) {
     const plan = await PlanModel.findOne({
       where: {
         code: planData.code,


### PR DESCRIPTION
## Description

Linked to https://github.com/dust-tt/dust/pull/19611

I want to run `./admin/init_plans.sh FREE_TRIAL_PHONE_PLAN` in prod db and have the script only upsert this plan. 

## Tests

Locally. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 