### PR TITLE
Conversation and AgentMessage FK indexes

### DIFF
--- a/front/lib/models/agent/actions/conversation_mcp_server_view.ts
+++ b/front/lib/models/agent/actions/conversation_mcp_server_view.ts
@@ -77,6 +77,11 @@ ConversationMCPServerViewModel.init(
         fields: ["workspaceId", "conversationId"],
         name: "conversation_mcp_server_views_workspace_conversation_idx",
       },
+      {
+        fields: ["conversationId"],
+        name: "conversation_mcp_server_views_conversation_id",
+        concurrently: true,
+      },
     ],
   }
 );

--- a/front/lib/models/agent/actions/mcp.ts
+++ b/front/lib/models/agent/actions/mcp.ts
@@ -299,6 +299,11 @@ AgentMCPActionModel.init(
         name: "agent_mcp_action_workspace_agent_message_status",
         concurrently: true,
       },
+      {
+        fields: ["agentMessageId"],
+        name: "agent_mcp_actions_agent_message_id",
+        concurrently: true,
+      },
     ],
   }
 );

--- a/front/lib/models/agent/conversation.ts
+++ b/front/lib/models/agent/conversation.ts
@@ -180,6 +180,11 @@ ConversationParticipantModel.init(
       {
         fields: ["workspaceId", "userId", "action"],
       },
+      {
+        fields: ["conversationId"],
+        name: "conversation_participants_conversation_id",
+        concurrently: true,
+      },
     ],
   }
 );

--- a/front/lib/models/skill/conversation_skill.ts
+++ b/front/lib/models/skill/conversation_skill.ts
@@ -106,6 +106,11 @@ ConversationSkillModel.init(SKILL_IN_CONVERSATION_MODEL_ATTRIBUTES, {
       where: { globalSkillId: { [Op.ne]: null } },
       name: "idx_conversation_skills_workspace_conv_agent_global_skill",
     },
+    {
+      fields: ["conversationId"],
+      name: "idx_conversation_skills_conversation_id",
+      concurrently: true,
+    },
   ],
   validate: {
     eitherGlobalOrCustomSkill: eitherGlobalOrCustomSkillValidation,
@@ -165,6 +170,16 @@ AgentMessageSkillModel.init(
       {
         fields: ["workspaceId", "agentMessageId"],
         name: "idx_agent_message_skills_workspace_message",
+      },
+      {
+        fields: ["conversationId"],
+        name: "idx_agent_message_skills_conversation_id",
+        concurrently: true,
+      },
+      {
+        fields: ["agentMessageId"],
+        name: "idx_agent_message_skills_agent_message_id",
+        concurrently: true,
       },
     ],
     validate: {

--- a/front/lib/resources/storage/models/data_source.ts
+++ b/front/lib/resources/storage/models/data_source.ts
@@ -87,6 +87,11 @@ DataSourceModel.init(
       { fields: ["workspaceId", "vaultId"] },
       { fields: ["workspaceId", "conversationId"], unique: true },
       { fields: ["dustAPIProjectId"] },
+      {
+        fields: ["conversationId"],
+        name: "data_sources_conversation_id",
+        concurrently: true,
+      },
     ],
   }
 );

--- a/front/migrations/db/migration_462.sql
+++ b/front/migrations/db/migration_462.sql
@@ -1,0 +1,7 @@
+-- Migration created on Jan 05, 2026
+CREATE INDEX CONCURRENTLY "data_sources_conversation_id" ON "data_sources" ("conversationId");
+CREATE INDEX CONCURRENTLY "conversation_mcp_server_views_conversation_id" ON "conversation_mcp_server_views" ("conversationId");
+CREATE INDEX CONCURRENTLY "agent_mcp_actions_agent_message_id" ON "agent_mcp_actions" ("agentMessageId");
+CREATE INDEX CONCURRENTLY "idx_conversation_skills_conversation_id" ON "conversation_skills" ("conversationId");
+CREATE INDEX CONCURRENTLY "idx_agent_message_skills_conversation_id" ON "agent_message_skills" ("conversationId");
+CREATE INDEX CONCURRENTLY "idx_agent_message_skills_agent_message_id" ON "agent_message_skills" ("agentMessageId");


### PR DESCRIPTION
## Description

Adds FK indexes to Conversation and AgentMessage which trigger high CPU on delete.

Context: https://dust4ai.slack.com/archives/C050SM8NSPK/p1767631897988819

```
  For DELETE FROM conversations (7 indexes):

  | Table                        | New Index Name                                |
  |------------------------------|-----------------------------------------------|
  | conversation_participant     | conversation_participants_conversation_id     |
  | conversation_skills          | idx_conversation_skills_conversation_id       |
  | agent_message_skills         | idx_agent_message_skills_conversation_id      |
  | conversation_mcp_server_view | conversation_mcp_server_views_conversation_id |
  | data_sources                 | data_sources_conversation_id                  |

  For DELETE FROM agent_messages (2 indexes):

  | Table                | New Index Name                            |
  |----------------------|-------------------------------------------|
  | agent_message_skills | idx_agent_message_skills_agent_message_id |
  | agent_mcp_actions    | agent_mcp_actions_agent_message_id        |
```

## Tests

N/A

## Risk

Low

## Deploy Plan

- run migration
- no deploy required