### PR TITLE
[front] feat: Add Workspace verification helpers

### DIFF
--- a/front/lib/api/workspace_verification/index.ts
+++ b/front/lib/api/workspace_verification/index.ts
@@ -1,0 +1,9 @@
+export {
+  startVerification,
+  type StartVerificationError,
+} from "./start_verification";
+export * from "./twilio";
+export {
+  validateVerification,
+  type ValidateVerificationError,
+} from "./validate_verification";

--- a/front/lib/api/workspace_verification/start_verification.ts
+++ b/front/lib/api/workspace_verification/start_verification.ts
@@ -1,0 +1,201 @@
+import {
+  lookupPhoneNumber,
+  sendOtp,
+} from "@app/lib/api/workspace_verification/twilio";
+import type { Authenticator } from "@app/lib/auth";
+import { WorkspaceVerificationAttemptResource } from "@app/lib/resources/workspace_verification_attempt_resource";
+import { rateLimiter } from "@app/lib/utils/rate_limiter";
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types";
+import { assertNever, Err, Ok } from "@app/types";
+import type { VerificationErrorType } from "@app/types/workspace_verification";
+
+const MAX_ATTEMPTS_PER_PHONE = 3;
+const MAX_DIFFERENT_PHONES_PER_WORKSPACE_PER_DAY = 3;
+const COOLDOWN_DURATION_SECONDS = 30 * 60; // 30 minutes.
+const DAY_IN_SECONDS = 24 * 60 * 60; // 24 hours.
+
+type RateLimitCheckResult =
+  | { allowed: true }
+  | { allowed: false; error: StartVerificationError };
+
+async function checkVerificationRateLimits(
+  phoneNumberHash: string,
+  workspaceModelId: number
+): Promise<RateLimitCheckResult> {
+  const phoneRemaining = await rateLimiter({
+    key: `verification:phone:${phoneNumberHash}`,
+    maxPerTimeframe: MAX_ATTEMPTS_PER_PHONE,
+    timeframeSeconds: COOLDOWN_DURATION_SECONDS,
+    logger,
+  });
+
+  if (phoneRemaining <= 0) {
+    const retryAfterSeconds =
+      Math.floor(Date.now() / 1000) + COOLDOWN_DURATION_SECONDS;
+    return {
+      allowed: false,
+      error: {
+        type: "rate_limit_error",
+        message: "Too many verification attempts for this phone number.",
+        retryAfterSeconds,
+      },
+    };
+  }
+
+  const workspaceRemaining = await rateLimiter({
+    key: `verification:workspace:${workspaceModelId}:phones`,
+    maxPerTimeframe: MAX_DIFFERENT_PHONES_PER_WORKSPACE_PER_DAY,
+    timeframeSeconds: DAY_IN_SECONDS,
+    logger,
+  });
+
+  if (workspaceRemaining <= 0) {
+    const retryAfterSeconds = Math.floor(Date.now() / 1000) + DAY_IN_SECONDS;
+    return {
+      allowed: false,
+      error: {
+        type: "rate_limit_error",
+        message:
+          "Too many different phone numbers attempted for this workspace today.",
+        retryAfterSeconds,
+      },
+    };
+  }
+
+  return { allowed: true };
+}
+
+export type StartVerificationError = {
+  type: VerificationErrorType;
+  message: string;
+  retryAfterSeconds?: number;
+};
+
+export async function startVerification(
+  auth: Authenticator,
+  phoneNumber: string
+): Promise<Result<void, StartVerificationError>> {
+  const workspace = auth.getNonNullableWorkspace();
+  const workspaceModelId = workspace.id;
+  const phoneNumberHash =
+    WorkspaceVerificationAttemptResource.hashPhoneNumber(phoneNumber);
+
+  const existingAttempt =
+    await WorkspaceVerificationAttemptResource.fetchByPhoneHash(
+      auth,
+      phoneNumberHash
+    );
+
+  if (existingAttempt) {
+    if (existingAttempt.status === "verified") {
+      return new Err({
+        type: "invalid_request_error",
+        message: "This workspace is already verified.",
+      });
+    }
+  } else {
+    const isPhoneUsedElsewhere =
+      await WorkspaceVerificationAttemptResource.isPhoneAlreadyUsed(
+        phoneNumberHash
+      );
+    if (isPhoneUsedElsewhere) {
+      return new Err({
+        type: "phone_already_used_error",
+        message:
+          "This phone number is already associated with another workspace.",
+      });
+    }
+  }
+
+  const lookupResult = await lookupPhoneNumber(phoneNumber);
+  if (lookupResult.isErr()) {
+    const error = lookupResult.error;
+    // for eng-oncall: you can defer this to growth / paywall owners
+    logger.error(
+      {
+        panic: true, // TODO(2026-03-01) - remove the panic:true
+        workspaceId: workspace.sId,
+        phoneNumberHash,
+        errorCode: error.code,
+      },
+      "Phone lookup validation failed"
+    );
+
+    let message: string;
+    switch (error.code) {
+      case "not_mobile":
+        message = "Only mobile phone numbers are accepted for verification.";
+        break;
+      case "high_sms_pumping_risk":
+        message = "This phone number cannot be used for verification.";
+        break;
+      case "invalid_phone_number":
+      case "lookup_failed":
+        message = error.message;
+        break;
+      default:
+        assertNever(error.code);
+    }
+
+    return new Err({
+      type: "invalid_request_error",
+      message,
+    });
+  }
+
+  const rateLimitResult = await checkVerificationRateLimits(
+    phoneNumberHash,
+    workspaceModelId
+  );
+  if (!rateLimitResult.allowed) {
+    return new Err(rateLimitResult.error);
+  }
+
+  const sendResult = await sendOtp(phoneNumber);
+  if (sendResult.isErr()) {
+    const error = sendResult.error;
+    logger.error(
+      {
+        workspaceId: workspace.sId,
+        phoneNumberHash,
+        error: error.message,
+      },
+      "Failed to send verification OTP"
+    );
+
+    return new Err({
+      type: "verification_error",
+      message: "Failed to send verification code. Please try again.",
+    });
+  }
+
+  const { verificationSid } = sendResult.value;
+
+  if (existingAttempt) {
+    await existingAttempt.recordNewAttempt(verificationSid);
+    logger.info(
+      {
+        workspaceId: workspace.sId,
+        phoneNumberHash,
+        attemptNumber: existingAttempt.attemptNumber + 1,
+      },
+      "Recorded new verification attempt"
+    );
+  } else {
+    await WorkspaceVerificationAttemptResource.makeNew(auth, {
+      phoneNumberHash,
+      twilioVerificationSid: verificationSid,
+    });
+    logger.info(
+      {
+        workspaceId: workspace.sId,
+        phoneNumberHash,
+        attemptNumber: 1,
+      },
+      "Created new verification attempt"
+    );
+  }
+
+  return new Ok(undefined);
+}

--- a/front/lib/api/workspace_verification/validate_verification.ts
+++ b/front/lib/api/workspace_verification/validate_verification.ts
@@ -1,0 +1,100 @@
+import { checkOtp } from "@app/lib/api/workspace_verification/twilio";
+import type { Authenticator } from "@app/lib/auth";
+import { WorkspaceVerificationAttemptResource } from "@app/lib/resources/workspace_verification_attempt_resource";
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types";
+import { Err, Ok } from "@app/types";
+import type { VerificationErrorType } from "@app/types/workspace_verification";
+
+export type ValidateVerificationError = {
+  type: VerificationErrorType;
+  message: string;
+};
+
+export async function validateVerification(
+  auth: Authenticator,
+  phoneNumber: string,
+  code: string
+): Promise<Result<{ verified: true }, ValidateVerificationError>> {
+  const workspace = auth.getNonNullableWorkspace();
+  const phoneNumberHash =
+    WorkspaceVerificationAttemptResource.hashPhoneNumber(phoneNumber);
+
+  const attempt = await WorkspaceVerificationAttemptResource.fetchByPhoneHash(
+    auth,
+    phoneNumberHash
+  );
+
+  if (!attempt) {
+    return new Err({
+      type: "verification_error",
+      message:
+        "No pending verification found. Please start a new verification.",
+    });
+  }
+
+  if (attempt.status === "verified") {
+    return new Err({
+      type: "invalid_request_error",
+      message: "This workspace is already verified.",
+    });
+  }
+
+  if (attempt.status === "expired") {
+    return new Err({
+      type: "verification_error",
+      message: "Verification code has expired. Please request a new code.",
+    });
+  }
+
+  if (attempt.status === "failed") {
+    return new Err({
+      type: "verification_error",
+      message: "Verification has failed. Please start a new verification.",
+    });
+  }
+
+  const verifyResult = await checkOtp(phoneNumber, code);
+  if (verifyResult.isErr()) {
+    const error = verifyResult.error;
+    logger.warn(
+      {
+        workspaceId: workspace.sId,
+        phoneNumberHash,
+        errorCode: error.code,
+      },
+      "OTP verification failed"
+    );
+
+    if (error.code === "expired") {
+      return new Err({
+        type: "verification_error",
+        message: "Verification code has expired. Please request a new code.",
+      });
+    }
+    if (error.code === "invalid_code") {
+      return new Err({
+        type: "verification_error",
+        message: "Invalid verification code. Please try again.",
+      });
+    }
+
+    return new Err({
+      type: "verification_error",
+      message: "Failed to verify code. Please try again.",
+    });
+  }
+
+  await attempt.markVerified();
+
+  logger.info(
+    {
+      workspaceId: workspace.sId,
+      phoneNumberHash,
+      attemptModelId: attempt.id,
+    },
+    "Workspace verification completed successfully"
+  );
+
+  return new Ok({ verified: true });
+}

--- a/front/lib/api/workspace_verification/validate_verification.ts
+++ b/front/lib/api/workspace_verification/validate_verification.ts
@@ -40,20 +40,6 @@ export async function validateVerification(
     });
   }
 
-  if (attempt.status === "expired") {
-    return new Err({
-      type: "verification_error",
-      message: "Verification code has expired. Please request a new code.",
-    });
-  }
-
-  if (attempt.status === "failed") {
-    return new Err({
-      type: "verification_error",
-      message: "Verification has failed. Please start a new verification.",
-    });
-  }
-
   const verifyResult = await checkOtp(phoneNumber, code);
   if (verifyResult.isErr()) {
     const error = verifyResult.error;

--- a/front/pages/api/w/[wId]/verification/start.ts
+++ b/front/pages/api/w/[wId]/verification/start.ts
@@ -1,0 +1,116 @@
+import { isLeft } from "fp-ts/lib/Either";
+import * as t from "io-ts";
+import * as reporter from "io-ts-reporters";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { startVerification } from "@app/lib/api/workspace_verification";
+import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+import { assertNever } from "@app/types";
+import type {
+  StartVerificationResponse,
+  VerificationErrorResponse,
+  VerificationErrorType,
+} from "@app/types/workspace_verification";
+
+export const E164PhoneNumber = t.refinement(
+  t.string,
+  (s) => /^\+[1-9]\d{1,14}$/.test(s),
+  "E164PhoneNumber"
+);
+
+export const OtpCode = t.refinement(
+  t.string,
+  (s) => /^\d{6}$/.test(s),
+  "OtpCode"
+);
+
+export function getStatusCodeForError(type: VerificationErrorType): number {
+  switch (type) {
+    case "rate_limit_error":
+      return 429;
+    case "invalid_request_error":
+    case "verification_error":
+      return 400;
+    case "phone_already_used_error":
+      return 403;
+    default:
+      assertNever(type);
+  }
+}
+
+const PostStartVerificationRequestBody = t.type({
+  phoneNumber: E164PhoneNumber,
+});
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<StartVerificationResponse | VerificationErrorResponse>
+  >,
+  auth: Authenticator
+): Promise<void> {
+  if (!auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message:
+          "Only users that are `admins` for the current workspace can start verification.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "POST": {
+      const bodyValidation = PostStartVerificationRequestBody.decode(req.body);
+      if (isLeft(bodyValidation)) {
+        const pathError = reporter.formatValidationErrors(bodyValidation.left);
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid request body: ${pathError}`,
+          },
+        });
+      }
+
+      const { phoneNumber } = bodyValidation.right;
+
+      const result = await startVerification(auth, phoneNumber);
+
+      if (result.isErr()) {
+        const error = result.error;
+        return res.status(getStatusCodeForError(error.type)).json({
+          error: {
+            type: error.type,
+            message: error.message,
+            ...(error.retryAfterSeconds !== undefined && {
+              retryAfterSeconds: error.retryAfterSeconds,
+            }),
+          },
+        });
+      }
+
+      return res.status(200).json({
+        success: true,
+        message: "Verification code sent successfully.",
+      });
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler, {
+  doesNotRequireCanUseProduct: true,
+});

--- a/front/pages/api/w/[wId]/verification/validate.ts
+++ b/front/pages/api/w/[wId]/verification/validate.ts
@@ -1,0 +1,93 @@
+import { isLeft } from "fp-ts/lib/Either";
+import * as t from "io-ts";
+import * as reporter from "io-ts-reporters";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { validateVerification } from "@app/lib/api/workspace_verification";
+import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
+import {
+  E164PhoneNumber,
+  getStatusCodeForError,
+  OtpCode,
+} from "@app/pages/api/w/[wId]/verification/start";
+import type { WithAPIErrorResponse } from "@app/types";
+import type {
+  VerificationErrorResponse,
+  VerifyCodeResponse,
+} from "@app/types/workspace_verification";
+
+const PostValidateVerificationRequestBody = t.type({
+  phoneNumber: E164PhoneNumber,
+  code: OtpCode,
+});
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<VerifyCodeResponse | VerificationErrorResponse>
+  >,
+  auth: Authenticator
+): Promise<void> {
+  if (!auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message:
+          "Only users that are `admins` for the current workspace can validate verification.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "POST": {
+      const bodyValidation = PostValidateVerificationRequestBody.decode(
+        req.body
+      );
+      if (isLeft(bodyValidation)) {
+        const pathError = reporter.formatValidationErrors(bodyValidation.left);
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid request body: ${pathError}`,
+          },
+        });
+      }
+
+      const { phoneNumber, code } = bodyValidation.right;
+
+      const result = await validateVerification(auth, phoneNumber, code);
+
+      if (result.isErr()) {
+        const error = result.error;
+        return res.status(getStatusCodeForError(error.type)).json({
+          error: {
+            type: error.type,
+            message: error.message,
+          },
+        });
+      }
+
+      return res.status(200).json({
+        success: true,
+        verified: true,
+      });
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler, {
+  doesNotRequireCanUseProduct: true,
+});


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/5796

- Add helpers to send an otp code and validate the given code.
- Otp sending also wraps phone number looks legit through vendor's (assumed twilio but can be switched easily) lookup api
- Add some rate limiting at helper level.

## Tests

Tested end to end with new frontend.

## Risk

Low
Blast radius: Dead code for now

## Deploy Plan

 - No deploy required