### PR TITLE
Debug log for run_agent errors

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent/index.ts
@@ -666,6 +666,19 @@ export default async function createServer(
         });
 
         if (streamRes.isErr()) {
+          // TODO(spolu): remove once `Failed to retrieve agent message` error is understood
+          logger.info(
+            {
+              error: streamRes.error,
+              conversationId: conversation.sId,
+              userMessageId,
+              isNewConversation,
+              hasResumeState:
+                !!agentLoopContext.runContext.stepContext.resumeState,
+            },
+            "[DEBUG] Failed to stream agent answer in run_agent"
+          );
+
           const errorMessage = `Failed to stream agent answer: ${streamRes.error.message}`;
           return finalizeAndReturn(new Err(new MCPError(errorMessage)));
         }


### PR DESCRIPTION
## Description

Debug log for 

https://app.datadoghq.eu/logs?query=region%3Aeurope-west1%20%40toolName%3Arun_agent%20%22Tool%20execution%20error%22%20status%3Aerror&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cworkspace.sId%2CtoolName%2Cerror&event=AwAAAZuPX2Ze5oFfLgAAABhBWnVQWDNFa0FBRGJlQVlhTi0zSGF3QUkAAAAkMDE5YjhmNzMtMzdjMC00OGIwLTgyOWUtYWMwMGIwN2U0OGQ5AAILng&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1767631825432&to_ts=1767646225432&live=true

Which is causing flaky monitor and seems unexpected

## Tests

Tested locally 

## Risk

Low

## Deploy Plan

- deploy `front`