### PR TITLE
feat(dust-hive): add --no-attach option to spawn command 

### DIFF
--- a/x/henry/dust-hive/CLAUDE.md
+++ b/x/henry/dust-hive/CLAUDE.md
@@ -121,7 +121,7 @@ tests/
 
 | Command | Description |
 |---------|-------------|
-| `spawn` | Create environment (worktree + symlinks + SDK watch); supports --warm to open a warm tab |
+| `spawn` | Create environment (worktree + symlinks + SDK watch); supports --warm to open a warm tab, --no-attach to run in background |
 | `warm` | Start docker + all services (auto-forwards port 3000, supports --no-forward/--force-ports) |
 | `cool` | Stop services, keep SDK watch |
 | `start` | Resume stopped env |

--- a/x/henry/dust-hive/README.md
+++ b/x/henry/dust-hive/README.md
@@ -90,7 +90,7 @@ open $(dust-hive url myenv)
 
 | Command | Description |
 |---------|-------------|
-| `spawn [--name NAME] [--base BRANCH] [--no-open] [--warm]` | Create new environment |
+| `spawn [--name NAME] [--base BRANCH] [--no-open] [--no-attach] [--warm]` | Create new environment |
 | `warm [NAME] [--no-forward] [--force-ports]` | Start docker + all services |
 | `cool [NAME]` | Stop services, keep SDK watch |
 | `start [NAME]` | Resume stopped environment |
@@ -195,6 +195,14 @@ dust-hive spawn myenv --warm
 ```
 
 This opens zellij with an extra **warm** tab that runs `dust-hive warm myenv`.
+
+To create the session in the background without attaching (useful for scripts or CI):
+
+```bash
+dust-hive spawn myenv --warm --no-attach
+```
+
+This creates the zellij session and starts services, but leaves you in your current terminal. Use `dust-hive open myenv` to attach later.
 
 ### Zellij Shortcuts
 

--- a/x/henry/dust-hive/src/commands/open.ts
+++ b/x/henry/dust-hive/src/commands/open.ts
@@ -246,42 +246,44 @@ export const openCommand = withEnvironment("open", async (env, options: OpenOpti
     );
 
     if (options.noAttach) {
-      // Create session in background without attaching
-      // Use 'script' to provide a pseudo-TTY so zellij can run properly
+      // Create session in background using zellij's native --create-background
       logger.info(`Creating zellij session '${sessionName}' in background...`);
 
-      const shellCmd = `script -q /dev/null zellij --session ${shellQuote(sessionName)} --new-session-with-layout ${shellQuote(layoutPath)} &`;
-      const proc = Bun.spawn(["sh", "-c", shellCmd], {
+      // Step 1: Create a detached background session
+      const createProc = Bun.spawn(["zellij", "attach", sessionName, "--create-background"], {
+        stdin: "ignore",
+        stdout: "ignore",
+        stderr: "pipe",
+      });
+      await createProc.exited;
+
+      // Step 2: Add our layout tabs to the session
+      const addTabsProc = Bun.spawn(
+        ["zellij", "--session", sessionName, "action", "new-tab", "--layout", layoutPath],
+        {
+          stdin: "ignore",
+          stdout: "ignore",
+          stderr: "pipe",
+        }
+      );
+      await addTabsProc.exited;
+
+      // Step 3: Close the default first tab and focus shell tab
+      const closeDefaultProc = Bun.spawn(
+        ["zellij", "--session", sessionName, "action", "go-to-tab", "1"],
+        { stdin: "ignore", stdout: "ignore", stderr: "ignore" }
+      );
+      await closeDefaultProc.exited;
+
+      const closeTabProc = Bun.spawn(["zellij", "--session", sessionName, "action", "close-tab"], {
         stdin: "ignore",
         stdout: "ignore",
         stderr: "ignore",
       });
-      await proc.exited;
+      await closeTabProc.exited;
 
-      // Give zellij a moment to start
-      await Bun.sleep(1000);
-
-      // Verify session was created
-      const checkProc = Bun.spawn(["zellij", "list-sessions"], {
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      const sessionsAfter = await new Response(checkProc.stdout).text();
-      await checkProc.exited;
-
-      const sessionCreated = sessionsAfter
-        .split("\n")
-        .map((line) => stripAnsi(line).trim())
-        .filter((line) => line.length > 0)
-        .map((line) => line.split(/\s+/)[0])
-        .some((name) => name === sessionName);
-
-      if (sessionCreated) {
-        logger.success(`Session '${sessionName}' created successfully.`);
-        logger.info(`Use 'dust-hive open ${env.name}' to attach.`);
-      } else {
-        logger.warn(`Session may not have started. Try 'dust-hive open ${env.name}'.`);
-      }
+      logger.success(`Session '${sessionName}' created successfully.`);
+      logger.info(`Use 'dust-hive open ${env.name}' to attach.`);
 
       return Ok(undefined);
     }

--- a/x/henry/dust-hive/src/commands/open.ts
+++ b/x/henry/dust-hive/src/commands/open.ts
@@ -246,34 +246,26 @@ export const openCommand = withEnvironment("open", async (env, options: OpenOpti
     );
 
     if (options.noAttach) {
-      // Create session in background using zellij's native --create-background
+      // Create session in background with our layout using zellij's native options
       logger.info(`Creating zellij session '${sessionName}' in background...`);
 
-      // Step 1: Create a detached background session
-      const createProc = Bun.spawn(["zellij", "attach", sessionName, "--create-background"], {
-        stdin: "ignore",
-        stdout: "ignore",
-        stderr: "pipe",
-      });
-      await createProc.exited;
-
-      // Step 2: Add our layout tabs to the session
-      const addTabsProc = Bun.spawn(
-        ["zellij", "--session", sessionName, "action", "new-tab", "--layout", layoutPath],
+      const proc = Bun.spawn(
+        [
+          "zellij",
+          "attach",
+          sessionName,
+          "--create-background",
+          "options",
+          "--default-layout",
+          layoutPath,
+        ],
         {
           stdin: "ignore",
           stdout: "ignore",
           stderr: "pipe",
         }
       );
-      await addTabsProc.exited;
-
-      // Step 3: Focus the shell tab (skip closing the default tab as it hangs on running panes)
-      const focusProc = Bun.spawn(
-        ["zellij", "--session", sessionName, "action", "go-to-tab-name", "shell"],
-        { stdin: "ignore", stdout: "ignore", stderr: "ignore" }
-      );
-      await focusProc.exited;
+      await proc.exited;
 
       logger.success(`Session '${sessionName}' created successfully.`);
       logger.info(`Use 'dust-hive open ${env.name}' to attach.`);

--- a/x/henry/dust-hive/src/commands/open.ts
+++ b/x/henry/dust-hive/src/commands/open.ts
@@ -268,19 +268,12 @@ export const openCommand = withEnvironment("open", async (env, options: OpenOpti
       );
       await addTabsProc.exited;
 
-      // Step 3: Close the default first tab and focus shell tab
-      const closeDefaultProc = Bun.spawn(
-        ["zellij", "--session", sessionName, "action", "go-to-tab", "1"],
+      // Step 3: Focus the shell tab (skip closing the default tab as it hangs on running panes)
+      const focusProc = Bun.spawn(
+        ["zellij", "--session", sessionName, "action", "go-to-tab-name", "shell"],
         { stdin: "ignore", stdout: "ignore", stderr: "ignore" }
       );
-      await closeDefaultProc.exited;
-
-      const closeTabProc = Bun.spawn(["zellij", "--session", sessionName, "action", "close-tab"], {
-        stdin: "ignore",
-        stdout: "ignore",
-        stderr: "ignore",
-      });
-      await closeTabProc.exited;
+      await focusProc.exited;
 
       logger.success(`Session '${sessionName}' created successfully.`);
       logger.info(`Use 'dust-hive open ${env.name}' to attach.`);

--- a/x/henry/dust-hive/src/commands/spawn.ts
+++ b/x/henry/dust-hive/src/commands/spawn.ts
@@ -24,6 +24,7 @@ interface SpawnOptions {
   name?: string;
   base?: string;
   noOpen?: boolean;
+  noAttach?: boolean;
   warm?: boolean;
 }
 
@@ -226,10 +227,10 @@ export async function spawnCommand(options: SpawnOptions): Promise<Result<void>>
 
   // Open zellij unless --no-open
   if (!options.noOpen) {
-    if (options.warm) {
-      return openCommand(name, { warmCommand: `dust-hive warm ${name}` });
-    }
-    return openCommand(name);
+    const openOpts: { warmCommand?: string; noAttach?: boolean } = {};
+    if (options.warm) openOpts.warmCommand = `dust-hive warm ${name}`;
+    if (options.noAttach) openOpts.noAttach = true;
+    return openCommand(name, openOpts);
   }
 
   // If --no-open and --warm, run warm command directly in current terminal

--- a/x/henry/dust-hive/src/index.ts
+++ b/x/henry/dust-hive/src/index.ts
@@ -43,14 +43,21 @@ cli
   .option("--name <name>", "Environment name")
   .option("--base <branch>", "Base branch")
   .option("--no-open", "Do not open zellij session after spawn")
+  .option("--no-attach", "Create zellij session but don't attach to it")
   .option("--warm", "Open zellij with a warm tab running dust-hive warm")
   .action(
     async (
       name: string | undefined,
-      options: { name?: string; base?: string; open?: boolean; warm?: boolean }
+      options: { name?: string; base?: string; open?: boolean; attach?: boolean; warm?: boolean }
     ) => {
       const resolvedName = name ?? options.name;
-      const spawnOptions: { name?: string; base?: string; noOpen?: boolean; warm?: boolean } = {};
+      const spawnOptions: {
+        name?: string;
+        base?: string;
+        noOpen?: boolean;
+        noAttach?: boolean;
+        warm?: boolean;
+      } = {};
       if (resolvedName !== undefined) {
         spawnOptions.name = resolvedName;
       }
@@ -59,6 +66,9 @@ cli
       }
       if (options.open === false) {
         spawnOptions.noOpen = true;
+      }
+      if (options.attach === false) {
+        spawnOptions.noAttach = true;
       }
       if (options.warm) {
         spawnOptions.warm = true;


### PR DESCRIPTION
## Description

Spawn a session (warm or cool), and create the corresponding zellij window without attaching it.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
