### PR TITLE
[front] fix(skills): invert order of search bar and buttons in capabilities sheet

### DIFF
--- a/front/components/agent_builder/capabilities/capabilities_sheet/CapabilitiesSelectionPage.tsx
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/CapabilitiesSelectionPage.tsx
@@ -75,7 +75,14 @@ export function CapabilitiesSelectionPageContent({
     (showSkillsSection && hasSkills) || (showToolsSection && hasTools);
 
   return (
-    <div className="flex flex-col gap-4">
+    <div className="flex flex-col gap-4 pt-1">
+      <SearchInput
+        placeholder="Search capabilities..."
+        value={searchQuery}
+        onChange={setSearchQuery}
+        name="capability-search"
+      />
+
       <div className="flex gap-2">
         <Button
           label="All"
@@ -96,13 +103,6 @@ export function CapabilitiesSelectionPageContent({
           onClick={() => setFilter("tools")}
         />
       </div>
-
-      <SearchInput
-        placeholder="Search capabilities..."
-        value={searchQuery}
-        onChange={setSearchQuery}
-        name="capability-search"
-      />
 
       {isCapabilitiesLoading ? (
         <div className="flex h-40 items-center justify-center">


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/5784.
<img width="631" height="430" alt="Screenshot 2026-01-05 at 10 28 21 PM" src="https://github.com/user-attachments/assets/66383576-df10-48ae-86a4-c7c4231b31f8" />


## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
