### PR TITLE
[front] fix(skills): add deterministic order on global skills in `WorkspaceSkills`

### DIFF
--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -330,15 +330,11 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     }
 
     const globalSkillDefinitions = GlobalSkillsRegistry.findAll(where);
-    const globalSkills: SkillResource[] = [];
 
     // Fetch global skills with their MCP server configurations.
-    await concurrentExecutor(
+    const globalSkills = await concurrentExecutor(
       globalSkillDefinitions,
-      async (def) => {
-        const skill = await this.fromGlobalSkill(auth, def, context);
-        globalSkills.push(skill);
-      },
+      async (def) => this.fromGlobalSkill(auth, def, context),
       { concurrency: 5 }
     );
 


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/5788.
- Fixes random reorders of the rows for global skills in the `WorkspaceSkills` table.
- The order is now the one defined in `GLOBAL_SKILLS_ARRAY`. 

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
