### PR TITLE
fix(dust-hive): fix Qdrant port mapping and make init idempotent

### DIFF
--- a/x/henry/dust-hive/src/lib/docker.ts
+++ b/x/henry/dust-hive/src/lib/docker.ts
@@ -58,7 +58,7 @@ export function generateDockerComposeOverride(
         ports: [`${ports.redis}:6379`],
       },
       qdrant_primary: {
-        ports: [`${ports.qdrantHttp}:6334`, `${ports.qdrantGrpc}:6333`],
+        ports: [`${ports.qdrantHttp}:6333`, `${ports.qdrantGrpc}:6334`],
         volumes: [`${getVolumeName(name, "qdrant-primary")}:/qdrant/storage`],
       },
       qdrant_secondary: {

--- a/x/henry/dust-hive/src/lib/envgen.ts
+++ b/x/henry/dust-hive/src/lib/envgen.ts
@@ -49,7 +49,7 @@ export OAUTH_DATABASE_URI=postgres://dev:dev@localhost:${ports.postgres}/dust_oa
 # === Service URIs ===
 export REDIS_URI=redis://localhost:${ports.redis}
 export REDIS_CACHE_URI=redis://localhost:${ports.redis}
-export QDRANT_CLUSTER_0_URL=http://127.0.0.1:${ports.qdrantHttp}
+export QDRANT_CLUSTER_0_URL=http://127.0.0.1:${ports.qdrantGrpc}
 export ELASTICSEARCH_URL=http://localhost:${ports.elasticsearch}
 export TEXT_EXTRACTION_URL=http://localhost:${ports.apacheTika}
 `;

--- a/x/henry/dust-hive/src/lib/ports.ts
+++ b/x/henry/dust-hive/src/lib/ports.ts
@@ -9,7 +9,7 @@ import { isProcessRunning, killProcess } from "./process";
 // Port offsets from base (spec-defined).
 // Offsets chosen so base_port + offset resembles standard ports:
 // postgres: 432 -> 10432 (resembles 5432), redis: 379 -> 10379 (resembles 6379),
-// qdrant: 334 -> 10334 (resembles 6334), elasticsearch: 200 -> 10200 (resembles 9200)
+// qdrant: 333 -> 10333 (resembles 6333 HTTP), elasticsearch: 200 -> 10200 (resembles 9200)
 export const PORT_OFFSETS = {
   front: 0,
   core: 1,
@@ -17,8 +17,8 @@ export const PORT_OFFSETS = {
   oauth: 6,
   postgres: 432,
   redis: 379,
-  qdrantHttp: 334,
-  qdrantGrpc: 333,
+  qdrantHttp: 333,
+  qdrantGrpc: 334,
   elasticsearch: 200,
   apacheTika: 998,
 } as const;


### PR DESCRIPTION
## Description

- Fix swapped port mappings in docker.ts: qdrantHttp now correctly maps to container port 6333 (HTTP) and qdrantGrpc to 6334 (gRPC)
- Fix port offsets in ports.ts to match naming convention
- Fix envgen.ts to use gRPC port for QDRANT_CLUSTER_0_URL (used by Rust client)
- Make all init functions idempotent by handling "already exists" errors:
  - initQdrant, initElasticsearchRust, initElasticsearchTS
  - runCoreDbInit, runFrontDbInit, runConnectorsDbInit

The port mapping bug was latent until waitForQdrantReady was added, which exposed the issue by trying to hit the HTTP API on the gRPC port.
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
