### PR TITLE
feat(dust-hive): improve sync/spawn for feature branch workflows

### DIFF
--- a/x/henry/dust-hive/src/commands/sync.ts
+++ b/x/henry/dust-hive/src/commands/sync.ts
@@ -4,6 +4,13 @@ import { ALL_BINARIES, buildBinaries, getCacheSource, setCacheSource } from "../
 import { logger } from "../lib/logger";
 import { findRepoRoot } from "../lib/paths";
 import { CommandError, Err, Ok, type Result } from "../lib/result";
+import { runNpmInstall } from "../lib/setup";
+import { getCurrentBranch } from "../lib/worktree";
+
+export interface SyncOptions {
+  targetBranch?: string;
+  switch?: boolean;
+}
 
 // Check if repo has uncommitted changes (ignores untracked files)
 async function hasUncommittedChanges(repoRoot: string): Promise<boolean> {
@@ -23,21 +30,6 @@ async function hasUncommittedChanges(repoRoot: string): Promise<boolean> {
   return lines.length > 0;
 }
 
-// Get current branch name
-async function getCurrentBranch(repoRoot: string): Promise<string | null> {
-  const proc = Bun.spawn(["git", "rev-parse", "--abbrev-ref", "HEAD"], {
-    cwd: repoRoot,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const output = await new Response(proc.stdout).text();
-  await proc.exited;
-  if (proc.exitCode !== 0) {
-    return null;
-  }
-  return output.trim();
-}
-
 // Run git fetch
 async function gitFetch(repoRoot: string): Promise<boolean> {
   const proc = Bun.spawn(["git", "fetch", "origin"], {
@@ -50,6 +42,40 @@ async function gitFetch(repoRoot: string): Promise<boolean> {
 }
 
 type RebaseResult = { success: true } | { success: false; conflict: boolean; error: string };
+
+// Checkout a branch and pull latest
+async function checkoutAndPull(
+  repoRoot: string,
+  branch: string
+): Promise<{ success: boolean; error?: string }> {
+  // Checkout the branch
+  const checkoutProc = Bun.spawn(["git", "checkout", branch], {
+    cwd: repoRoot,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const checkoutStderr = await new Response(checkoutProc.stderr).text();
+  await checkoutProc.exited;
+
+  if (checkoutProc.exitCode !== 0) {
+    return { success: false, error: checkoutStderr };
+  }
+
+  // Pull latest
+  const pullProc = Bun.spawn(["git", "pull", "--rebase"], {
+    cwd: repoRoot,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const pullStderr = await new Response(pullProc.stderr).text();
+  await pullProc.exited;
+
+  if (pullProc.exitCode !== 0) {
+    return { success: false, error: pullStderr };
+  }
+
+  return { success: true };
+}
 
 // Rebase current branch on origin/<branch>
 async function rebaseOnBranch(repoRoot: string, branch: string): Promise<RebaseResult> {
@@ -74,17 +100,6 @@ async function rebaseOnBranch(repoRoot: string, branch: string): Promise<RebaseR
   return { success: false, conflict: isConflict, error: stderr };
 }
 
-// Run npm install in a directory
-async function runNpmInstall(dir: string): Promise<boolean> {
-  const proc = Bun.spawn(["npm", "install", "--prefer-offline"], {
-    cwd: dir,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  await proc.exited;
-  return proc.exitCode === 0;
-}
-
 // Run bun install in a directory
 async function runBunInstall(dir: string): Promise<boolean> {
   const proc = Bun.spawn(["bun", "install"], {
@@ -107,9 +122,9 @@ async function runBunLink(dir: string): Promise<boolean> {
   return proc.exitCode === 0;
 }
 
-export async function syncCommand(targetBranch?: string): Promise<Result<void>> {
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: orchestration function with multiple steps
+export async function syncCommand(options: SyncOptions = {}): Promise<Result<void>> {
   const startTimeMs = Date.now();
-  const branch = targetBranch ?? "main";
 
   // Find repo root (or use existing cache source)
   let repoRoot = await getCacheSource();
@@ -139,10 +154,15 @@ export async function syncCommand(targetBranch?: string): Promise<Result<void>> 
   logger.success("Working directory clean");
 
   // Get current branch for reporting
-  const currentBranch = await getCurrentBranch(repoRoot);
-  if (!currentBranch) {
+  let currentBranch: string;
+  try {
+    currentBranch = await getCurrentBranch(repoRoot);
+  } catch {
     return Err(new CommandError("Could not determine current branch"));
   }
+
+  // Determine target branch (default to main)
+  const targetBranch = options.targetBranch ?? "main";
 
   // Fetch from origin
   logger.step("Fetching from origin...");
@@ -152,26 +172,37 @@ export async function syncCommand(targetBranch?: string): Promise<Result<void>> 
   }
   logger.success("Fetched latest changes");
 
-  // Rebase current branch on origin/<branch>
-  logger.step(`Rebasing '${currentBranch}' on origin/${branch}...`);
-  const rebaseResult = await rebaseOnBranch(repoRoot, branch);
-  if (!rebaseResult.success) {
-    if (rebaseResult.conflict) {
-      console.log();
-      logger.error("Rebase failed due to conflicts.");
-      console.log();
-      console.log("To resolve:");
-      console.log("  1. Fix the conflicts in the listed files");
-      console.log("  2. Stage your changes: git add <files>");
-      console.log("  3. Continue the rebase: git rebase --continue");
-      console.log("  4. Run dust-hive sync again");
-      console.log();
-      console.log("Or abort the rebase: git rebase --abort");
-      return Err(new CommandError("Rebase conflicts - resolve and run sync again"));
+  // Sync to target branch
+  if (options.switch) {
+    // --switch: checkout target branch and pull
+    logger.step(`Switching to '${targetBranch}' and pulling latest...`);
+    const switchResult = await checkoutAndPull(repoRoot, targetBranch);
+    if (!switchResult.success) {
+      return Err(new CommandError(`Failed to switch to ${targetBranch}: ${switchResult.error}`));
     }
-    return Err(new CommandError(`Rebase failed: ${rebaseResult.error}`));
+    logger.success(`Switched to '${targetBranch}' with latest changes`);
+  } else {
+    // Rebase current branch on origin/<targetBranch>
+    logger.step(`Rebasing '${currentBranch}' on origin/${targetBranch}...`);
+    const rebaseResult = await rebaseOnBranch(repoRoot, targetBranch);
+    if (!rebaseResult.success) {
+      if (rebaseResult.conflict) {
+        console.log();
+        logger.error("Rebase failed due to conflicts.");
+        console.log();
+        console.log("To resolve:");
+        console.log("  1. Fix the conflicts in the listed files");
+        console.log("  2. Stage your changes: git add <files>");
+        console.log("  3. Continue the rebase: git rebase --continue");
+        console.log("  4. Run dust-hive sync again");
+        console.log();
+        console.log("Or abort the rebase: git rebase --abort");
+        return Err(new CommandError("Rebase conflicts - resolve and run sync again"));
+      }
+      return Err(new CommandError(`Rebase failed: ${rebaseResult.error}`));
+    }
+    logger.success(`Rebased '${currentBranch}' on latest ${targetBranch}`);
   }
-  logger.success(`Rebased '${currentBranch}' on latest ${branch}`);
 
   // Update cache source
   await setCacheSource(repoRoot);
@@ -215,7 +246,7 @@ export async function syncCommand(targetBranch?: string): Promise<Result<void>> 
   }
   logger.success(`Built ${buildResult.built.length} binaries`);
 
-  // Install and link dust-hive globally
+  // Install and link dust-hive globally (only on main)
   logger.step(`Installing ${dustHiveDir.name} dependencies...`);
   const installSuccess = await runBunInstall(dustHiveDir.path);
   if (!installSuccess) {
@@ -223,18 +254,30 @@ export async function syncCommand(targetBranch?: string): Promise<Result<void>> 
   }
   logger.success(`${dustHiveDir.name} dependencies installed`);
 
-  logger.step(`Linking ${dustHiveDir.name}...`);
-  const linkSuccess = await runBunLink(dustHiveDir.path);
-  if (!linkSuccess) {
-    return Err(new CommandError("Failed to run bun link for dust-hive"));
+  // Only bun link when we're actually on main's code
+  // With --switch: we end up on targetBranch
+  // Without --switch: we stay on currentBranch (just rebased)
+  const finalBranch = options.switch ? targetBranch : currentBranch;
+  if (finalBranch === "main") {
+    logger.step(`Linking ${dustHiveDir.name}...`);
+    const linkSuccess = await runBunLink(dustHiveDir.path);
+    if (!linkSuccess) {
+      return Err(new CommandError("Failed to run bun link for dust-hive"));
+    }
+    logger.success("dust-hive linked globally");
+  } else {
+    logger.info("Skipping bun link (only done when on main branch)");
   }
-  logger.success("dust-hive linked globally");
 
   const elapsed = ((Date.now() - startTimeMs) / 1000).toFixed(1);
   console.log();
   logger.success(`Sync complete! (${elapsed}s)`);
   console.log();
-  console.log(`Branch '${currentBranch}' is now rebased on latest ${branch}.`);
+  if (options.switch) {
+    console.log(`Now on '${targetBranch}' with latest changes.`);
+  } else {
+    console.log(`Branch '${currentBranch}' is now rebased on latest ${targetBranch}.`);
+  }
   console.log("Dependencies and binaries are up to date.");
   console.log();
 

--- a/x/henry/dust-hive/src/index.ts
+++ b/x/henry/dust-hive/src/index.ts
@@ -199,8 +199,15 @@ cli
 
 cli
   .command("sync [branch]", "Rebase on branch (default: main), rebuild binaries, refresh deps")
-  .action(async (branch: string | undefined) => {
-    await prepareAndRun(syncCommand(branch));
+  .option("--switch", "Switch to target branch instead of rebasing onto it")
+  .action(async (branch: string | undefined, options: { switch?: boolean }) => {
+    const syncOptions: { targetBranch?: string; switch?: boolean } = {
+      switch: Boolean(options.switch),
+    };
+    if (branch !== undefined) {
+      syncOptions.targetBranch = branch;
+    }
+    await prepareAndRun(syncCommand(syncOptions));
   });
 
 cli

--- a/x/henry/dust-hive/src/lib/diff.ts
+++ b/x/henry/dust-hive/src/lib/diff.ts
@@ -1,0 +1,64 @@
+// Git diff utilities for cache validation
+// Used to determine if feature branch has diverged from main in specific areas
+
+// Check if a path has changes between main and current HEAD
+// Uses git diff --quiet which exits 0 for no changes, 1 for changes
+async function hasChanges(repoRoot: string, path: string): Promise<boolean> {
+  const proc = Bun.spawn(["git", "diff", "--quiet", "main...HEAD", "--", path], {
+    cwd: repoRoot,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  await proc.exited;
+  // exit code 0 = no changes, 1 = changes
+  return proc.exitCode !== 0;
+}
+
+// Check if core/ directory has changes between main and current HEAD
+// This indicates whether cached Rust binaries can be used
+export async function hasRustChanges(repoRoot: string): Promise<boolean> {
+  return hasChanges(repoRoot, "core/");
+}
+
+// Check if package-lock.json changed for a project between main and current HEAD
+// Projects: "sdks/js", "front", "connectors"
+export async function hasLockfileChanges(repoRoot: string, project: string): Promise<boolean> {
+  return hasChanges(repoRoot, `${project}/package-lock.json`);
+}
+
+// Result of comparing feature branch to main for cache purposes
+export interface CacheComparisonResult {
+  rust: { canUseCache: boolean; reason: string };
+  sdks: { canUseCache: boolean; reason: string };
+  front: { canUseCache: boolean; reason: string };
+  connectors: { canUseCache: boolean; reason: string };
+}
+
+// Compare current branch to main and determine what can use cache
+export async function compareBranchToMain(repoRoot: string): Promise<CacheComparisonResult> {
+  const [rustChanged, sdksChanged, frontChanged, connectorsChanged] = await Promise.all([
+    hasRustChanges(repoRoot),
+    hasLockfileChanges(repoRoot, "sdks/js"),
+    hasLockfileChanges(repoRoot, "front"),
+    hasLockfileChanges(repoRoot, "connectors"),
+  ]);
+
+  return {
+    rust: {
+      canUseCache: !rustChanged,
+      reason: rustChanged ? "core/ changed" : "core/ unchanged",
+    },
+    sdks: {
+      canUseCache: !sdksChanged,
+      reason: sdksChanged ? "lockfile changed" : "lockfile unchanged",
+    },
+    front: {
+      canUseCache: !frontChanged,
+      reason: frontChanged ? "lockfile changed" : "lockfile unchanged",
+    },
+    connectors: {
+      canUseCache: !connectorsChanged,
+      reason: connectorsChanged ? "lockfile changed" : "lockfile unchanged",
+    },
+  };
+}

--- a/x/henry/dust-hive/src/lib/prompt.ts
+++ b/x/henry/dust-hive/src/lib/prompt.ts
@@ -18,6 +18,50 @@ async function readLine(prompt: string): Promise<string | null> {
   return null;
 }
 
+// Simple y/n prompt - returns true for yes, false for no (no default)
+export async function promptYesNo(question: string): Promise<boolean> {
+  for (;;) {
+    const input = await readLine(`${question} (y/n): `);
+    if (input === null) {
+      throw new Error("No input received");
+    }
+    const normalized = input.toLowerCase();
+    if (normalized === "y" || normalized === "yes") {
+      return true;
+    }
+    if (normalized === "n" || normalized === "no") {
+      return false;
+    }
+    console.log("Please enter 'y' or 'n'");
+  }
+}
+
+// Choice prompt - returns the selected option
+export async function promptChoice<T extends string>(
+  question: string,
+  options: readonly T[]
+): Promise<T> {
+  console.log(question);
+  for (let i = 0; i < options.length; i++) {
+    console.log(`  ${i + 1}) ${options[i]}`);
+  }
+
+  for (;;) {
+    const input = await readLine("Enter choice (number): ");
+    if (input === null) {
+      throw new Error("No input received");
+    }
+    const num = Number.parseInt(input, 10);
+    if (num >= 1 && num <= options.length) {
+      const selected = options[num - 1];
+      if (selected !== undefined) {
+        return selected;
+      }
+    }
+    console.log(`Please enter a number between 1 and ${options.length}`);
+  }
+}
+
 // Prompt user for yes/no confirmation
 // Returns true for yes, false for no
 export async function confirm(message: string, defaultYes = true): Promise<boolean> {

--- a/x/henry/dust-hive/src/lib/setup.ts
+++ b/x/henry/dust-hive/src/lib/setup.ts
@@ -3,8 +3,17 @@
 // Running `npm install` in a worktree will modify the main repo's node_modules.
 // NOTE: cargo target is symlinked to share Rust compilation cache (including linked artifacts).
 
+import { ALL_BINARIES, buildBinaries } from "./cache";
 import { directoryExists } from "./fs";
 import { logger } from "./logger";
+
+// Configuration for how to install each dependency type
+export interface DependencyConfig {
+  rust: "symlink" | "build";
+  sdks: "symlink" | "install";
+  front: "symlink" | "install";
+  connectors: "symlink" | "install";
+}
 
 // Symlink node_modules from source to destination
 async function symlinkNodeModules(srcDir: string, destDir: string): Promise<boolean> {
@@ -37,37 +46,100 @@ async function symlinkCargoTarget(srcDir: string, destDir: string): Promise<void
   }
 }
 
-// Install all dependencies for a worktree by symlinking from main repo
+// Run npm install in a directory
+export async function runNpmInstall(dir: string): Promise<boolean> {
+  const proc = Bun.spawn(["npm", "install", "--prefer-offline"], {
+    cwd: dir,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  await proc.exited;
+  return proc.exitCode === 0;
+}
+
+// Build Rust binaries in worktree (no symlink from cache)
+async function buildRustInWorktree(worktreePath: string): Promise<boolean> {
+  const result = await buildBinaries(worktreePath, [...ALL_BINARIES]);
+  return result.success;
+}
+
+// Default config: symlink everything from cache
+const DEFAULT_CONFIG: DependencyConfig = {
+  rust: "symlink",
+  sdks: "symlink",
+  front: "symlink",
+  connectors: "symlink",
+};
+
+// Install all dependencies for a worktree
+// With config, can either symlink from cache or install/build in worktree
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: handles multiple dependency types with different modes
 export async function installAllDependencies(
   worktreePath: string,
-  repoRoot: string
+  repoRoot: string,
+  config: DependencyConfig = DEFAULT_CONFIG
 ): Promise<void> {
-  logger.step("Linking dependencies from main repo...");
-
-  // Symlink cargo target to share Rust compilation cache
-  await symlinkCargoTarget(repoRoot, worktreePath);
-
-  // Symlink node_modules for each project
-  const projects = [
-    { name: "sdks/js", src: `${repoRoot}/sdks/js`, dest: `${worktreePath}/sdks/js` },
-    { name: "front", src: `${repoRoot}/front`, dest: `${worktreePath}/front` },
-    { name: "connectors", src: `${repoRoot}/connectors`, dest: `${worktreePath}/connectors` },
-  ];
-
   const failed: string[] = [];
 
-  for (const { name, src, dest } of projects) {
-    const success = await symlinkNodeModules(src, dest);
+  // Handle Rust / cargo target
+  if (config.rust === "symlink") {
+    logger.step("Rust binaries: Linking from cache...");
+    await symlinkCargoTarget(repoRoot, worktreePath);
+    logger.success("Rust binaries: Linked");
+  } else {
+    logger.step("Rust binaries: Building from scratch...");
+    const success = await buildRustInWorktree(worktreePath);
     if (!success) {
-      failed.push(name);
+      failed.push("rust");
+    } else {
+      logger.success("Rust binaries: Built");
+    }
+  }
+
+  // Handle node_modules for each project
+  const projects = [
+    {
+      key: "sdks" as const,
+      name: "sdks/js",
+      src: `${repoRoot}/sdks/js`,
+      dest: `${worktreePath}/sdks/js`,
+    },
+    {
+      key: "front" as const,
+      name: "front",
+      src: `${repoRoot}/front`,
+      dest: `${worktreePath}/front`,
+    },
+    {
+      key: "connectors" as const,
+      name: "connectors",
+      src: `${repoRoot}/connectors`,
+      dest: `${worktreePath}/connectors`,
+    },
+  ];
+
+  for (const { key, name, src, dest } of projects) {
+    const mode = config[key];
+    if (mode === "symlink") {
+      logger.step(`${name}: Linking from cache...`);
+      const success = await symlinkNodeModules(src, dest);
+      if (!success) {
+        failed.push(name);
+      } else {
+        logger.success(`${name}: Linked`);
+      }
+    } else {
+      logger.step(`${name}: Installing dependencies...`);
+      const success = await runNpmInstall(dest);
+      if (!success) {
+        failed.push(name);
+      } else {
+        logger.success(`${name}: Installed`);
+      }
     }
   }
 
   if (failed.length > 0) {
-    throw new Error(
-      `Failed to symlink node_modules for: ${failed.join(", ")}. Make sure main repo has node_modules installed.`
-    );
+    throw new Error(`Failed to install dependencies for: ${failed.join(", ")}`);
   }
-
-  logger.success("Dependencies linked");
 }


### PR DESCRIPTION
## Description

- sync: prompt for target branch when not on main, add --switch flag
- sync: only run bun link when syncing to main
- spawn: prompt to base on feature branch instead of main
- spawn: compare feature branch to main for smart cache usage
- spawn: per-item cache status (rust bins, npm deps per directory)
- Add lib/diff.ts for git diff utilities
- Add promptYesNo/promptChoice helpers to lib/prompt.ts
- Extend lib/setup.ts with DependencyConfig for selective cache/build

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
