### PR TITLE
[Programmatic Usage] Fix discount percent calculation

### DIFF
--- a/front/lib/api/assistant/token_pricing.ts
+++ b/front/lib/api/assistant/token_pricing.ts
@@ -19,7 +19,7 @@ export const DUST_MARKUP_PERCENT = 30;
 // A discount above this threshold would result in selling below cost.
 // Formula: (1 - 1 / (1 + MARKUP/100)) * 100
 // With 30% markup: (1 - 1/1.30) * 100 ≈ 23.08%
-export const MAX_DISCOUNT_PERCENT = Math.floor(
+export const MAX_DISCOUNT_PERCENT = Math.ceil(
   (1 - 1 / (1 + DUST_MARKUP_PERCENT / 100)) * 100
 );
 


### PR DESCRIPTION
Description
---
This commit fixes the discount percent calculation to ensure it is always rounded up to the nearest integer.

The previous calculation was rounding down to the nearest integer, while we want to be nice to customers.

We had previously decided that and some customers do have 24% which caused a validation issue.

Risks
---
none

Deploy
---
pmrr
front
