### PR TITLE
[front] Drop domain in other region if dropExistingDomain is set

### DIFF
--- a/front/lib/api/workos/organization.ts
+++ b/front/lib/api/workos/organization.ts
@@ -178,6 +178,15 @@ export async function removeWorkOSOrganizationDomain(
     );
   }
 
+  return removeWorkOSOrganizationDomainFromOrganization(organization, {
+    domain,
+  });
+}
+
+export async function removeWorkOSOrganizationDomainFromOrganization(
+  organization: Organization,
+  { domain }: { domain: string }
+): Promise<Result<void, Error>> {
   await getWorkOS().organizations.updateOrganization({
     organization: organization.id,
     domainData: organization.domains


### PR DESCRIPTION
## Description

If dropExistingDomain is set, we clear the existing domain in workos instead of throwing an error. dropExistingDomain is set when we get event from workos, from a verified DNS record. It happens that domain is already taken by old outdated workspaces in US region (as they were automatically set by email check without dns verification)
 
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

low

## Deploy Plan

deploy front
