### PR TITLE
HubSpot tool: do not error the tool if there's no result on search endpoint

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/hubspot/hubspot_api_helper.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/hubspot/hubspot_api_helper.ts
@@ -1465,6 +1465,13 @@ export const searchCrmObjects = async ({
       paging: searchResponse.paging,
     };
   } catch (error: any) {
+    if (error.code === 404) {
+      localLogger.warn(
+        { objectType, filters, query },
+        `Error 404 when searching ${objectType}. Returning empty results.`
+      );
+      return { results: [], paging: undefined };
+    }
     localLogger.error({ error }, `Error searching ${objectType}:`);
     throw normalizeError(error);
   }

--- a/front/lib/actions/mcp_internal_actions/servers/hubspot/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/hubspot/index.ts
@@ -1043,12 +1043,16 @@ function createServer(): McpServer {
             limit: input.limit,
             after: input.after,
           });
-          if (!result || result.results.length === 0) {
+          if (!result) {
             return {
               isError: true,
-              content: [
-                { type: "text", text: "Search failed or returned no results." },
-              ],
+              content: [{ type: "text", text: "Search failed." }],
+            };
+          }
+          if (result.results.length === 0) {
+            return {
+              isError: false,
+              content: [{ type: "text", text: "No results found." }],
             };
           }
 
@@ -1145,7 +1149,7 @@ function createServer(): McpServer {
       }
       if (!allResults.length) {
         return {
-          isError: true,
+          isError: false,
           content: [{ type: "text", text: "No objects found for export." }],
         };
       }


### PR DESCRIPTION
## Description

Do not error the Hubspot tool if there's no result on search endpoint. 
It was already the case on the getter tools. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 