### PR TITLE
Attempt to unstuck Github workflows

### DIFF
--- a/connectors/src/connectors/github/lib/code/tar_extraction.ts
+++ b/connectors/src/connectors/github/lib/code/tar_extraction.ts
@@ -61,6 +61,7 @@ function isRetryableStreamError(error: unknown): boolean {
     "other side closed",
     "ECONNRESET",
     "socket hang up",
+    "terminated", // undici fetch stream termination
   ];
 
   return retryableMessages.some((msg) =>


### PR DESCRIPTION
## Description

We have multiple stuck Github workflows: https://app.datadoghq.eu/dashboard/eza-jyh-pwy?fromUser=false&overlay=events&overlayQuery=%28%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40attempt%3A%3E19%20%40dd.service%3Aconnectors-worker%20region%3Aus-central1%29%20AND%20%40workflowId%3AgoogleDrive-IncrementalSync-17328&refresh_mode=sliding&from_ts=1767682264718&to_ts=1767696664718&live=true

Done on this PR: 
Add "terminated" to the list of retryable stream errors in GitHub tarball extraction to fix TypeError: terminated errors from Node's undici fetch that were causing githubExtractToGcsActivity failures without retry


**Context**
The existing retryable error list includes "other side closed", but this doesn't catch undici's TypeError: terminated errors. These are distinct failure modes:
- "other side closed": Remote server explicitly closes the connection
- "terminated": Node's undici fetch aborts the stream (timeout, network interruption, etc.)

The error matching checks if error.message contains any retryable string. Since "terminated" does not contain "other side closed", these errors were not being retried and caused workflow failures.

## Tests

/ 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy connectors. 