### PR TITLE
fix(dust-hive): simplify sync/spawn/cache commands

### DIFF
--- a/x/henry/dust-hive/src/commands/spawn.ts
+++ b/x/henry/dust-hive/src/commands/spawn.ts
@@ -1,5 +1,4 @@
 import { setCacheSource } from "../lib/cache";
-import { compareBranchToMain } from "../lib/diff";
 import { writeDockerComposeOverride } from "../lib/docker";
 import { writeEnvSh } from "../lib/envgen";
 import {
@@ -14,17 +13,15 @@ import { logger } from "../lib/logger";
 import { findRepoRoot, getWorktreeDir } from "../lib/paths";
 import type { PortAllocation } from "../lib/ports";
 import { allocateNextPort, calculatePorts, savePortAllocation } from "../lib/ports";
-import { promptYesNo } from "../lib/prompt";
 import { startService, waitForServiceReady } from "../lib/registry";
 import { CommandError, Err, Ok, type Result } from "../lib/result";
-import { type DependencyConfig, installAllDependencies } from "../lib/setup";
-import { cleanupPartialEnvironment, createWorktree, getCurrentBranch } from "../lib/worktree";
+import { installAllDependencies } from "../lib/setup";
+import { cleanupPartialEnvironment, createWorktree, getMainRepoPath } from "../lib/worktree";
 import { openCommand } from "./open";
 import { warmCommand } from "./warm";
 
 interface SpawnOptions {
   name?: string;
-  base?: string;
   noOpen?: boolean;
   noAttach?: boolean;
   warm?: boolean;
@@ -97,8 +94,7 @@ async function setupEnvironmentFiles(
 async function setupWorktree(
   metadata: EnvironmentMetadata,
   worktreePath: string,
-  workspaceBranch: string,
-  depConfig?: DependencyConfig
+  workspaceBranch: string
 ): Promise<Result<void, CommandError>> {
   try {
     await createWorktree(metadata.repoRoot, worktreePath, workspaceBranch, metadata.baseBranch);
@@ -110,7 +106,7 @@ async function setupWorktree(
   }
 
   try {
-    await installAllDependencies(worktreePath, metadata.repoRoot, depConfig);
+    await installAllDependencies(worktreePath, metadata.repoRoot);
   } catch (error) {
     logger.error("Spawn failed during dependency linking, cleaning up...");
     await cleanupPartialEnvironment(metadata.repoRoot, worktreePath, workspaceBranch).catch((e) =>
@@ -150,16 +146,18 @@ async function startSdk(
   return Ok(undefined);
 }
 
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: orchestration function with multiple phases
 export async function spawnCommand(options: SpawnOptions): Promise<Result<void>> {
-  // Find repo root
-  const repoRoot = await findRepoRoot();
-  if (!repoRoot) {
+  // Find repo root (could be main repo or worktree)
+  const currentRepoRoot = await findRepoRoot();
+  if (!currentRepoRoot) {
     return Err(new CommandError("Not in a git repository. Please run from within the Dust repo."));
   }
 
+  // Always use the main repo for cache and worktree creation
+  const mainRepoRoot = await getMainRepoPath(currentRepoRoot);
+
   // Set cache source to use binaries from main repo
-  await setCacheSource(repoRoot);
+  await setCacheSource(mainRepoRoot);
 
   // Get or prompt for name
   let name = options.name;
@@ -178,58 +176,8 @@ export async function spawnCommand(options: SpawnOptions): Promise<Result<void>>
     return Err(new CommandError(`Environment '${name}' already exists`));
   }
 
-  // Determine base branch and dependency config
-  const currentBranch = await getCurrentBranch(repoRoot);
-  let baseBranch: string;
-  let depConfig: DependencyConfig | undefined;
-
-  if (options.base) {
-    // Explicit base branch provided
-    baseBranch = options.base;
-  } else if (currentBranch === "main") {
-    // On main, use main with full cache
-    baseBranch = "main";
-  } else {
-    // Not on main - prompt user
-    console.log();
-    const useFeatureBranch = await promptYesNo(`Base on '${currentBranch}' instead of main?`);
-    console.log();
-
-    if (useFeatureBranch) {
-      baseBranch = currentBranch;
-      // Compare feature branch to main to determine cache usage
-      logger.step("Comparing branch to main for cache usage...");
-      const comparison = await compareBranchToMain(repoRoot);
-
-      depConfig = {
-        rust: comparison.rust.canUseCache ? "symlink" : "build",
-        sdks: comparison.sdks.canUseCache ? "symlink" : "install",
-        front: comparison.front.canUseCache ? "symlink" : "install",
-        connectors: comparison.connectors.canUseCache ? "symlink" : "install",
-      };
-
-      // Show comparison summary
-      console.log();
-      console.log("Cache comparison:");
-      console.log(
-        `  Rust binaries: ${comparison.rust.canUseCache ? "Using cache" : "Will build"} (${comparison.rust.reason})`
-      );
-      console.log(
-        `  sdks/js: ${comparison.sdks.canUseCache ? "Using cache" : "Will install"} (${comparison.sdks.reason})`
-      );
-      console.log(
-        `  front: ${comparison.front.canUseCache ? "Using cache" : "Will install"} (${comparison.front.reason})`
-      );
-      console.log(
-        `  connectors: ${comparison.connectors.canUseCache ? "Using cache" : "Will install"} (${comparison.connectors.reason})`
-      );
-      console.log();
-    } else {
-      // User chose main
-      baseBranch = "main";
-    }
-  }
-
+  // Always base on main branch
+  const baseBranch = "main";
   const workspaceBranch = `${name}-workspace`;
   const worktreePath = getWorktreeDir(name);
 
@@ -246,7 +194,7 @@ export async function spawnCommand(options: SpawnOptions): Promise<Result<void>>
     baseBranch,
     workspaceBranch,
     createdAt: new Date().toISOString(),
-    repoRoot,
+    repoRoot: mainRepoRoot,
   };
 
   // Phase 1: Setup environment files
@@ -254,7 +202,7 @@ export async function spawnCommand(options: SpawnOptions): Promise<Result<void>>
   if (!filesResult.ok) return filesResult;
 
   // Phase 2: Setup worktree
-  const worktreeResult = await setupWorktree(metadata, worktreePath, workspaceBranch, depConfig);
+  const worktreeResult = await setupWorktree(metadata, worktreePath, workspaceBranch);
   if (!worktreeResult.ok) return worktreeResult;
 
   // Phase 3: Start SDK

--- a/x/henry/dust-hive/src/commands/sync.ts
+++ b/x/henry/dust-hive/src/commands/sync.ts
@@ -1,16 +1,11 @@
-// Sync command - rebase current branch on latest main, rebuild binaries, refresh node_modules
+// Sync command - pull latest main, rebuild binaries, refresh node_modules
 
-import { ALL_BINARIES, buildBinaries, getCacheSource, setCacheSource } from "../lib/cache";
+import { ALL_BINARIES, buildBinaries, setCacheSource } from "../lib/cache";
 import { logger } from "../lib/logger";
 import { findRepoRoot } from "../lib/paths";
 import { CommandError, Err, Ok, type Result } from "../lib/result";
 import { runNpmInstall } from "../lib/setup";
-import { getCurrentBranch } from "../lib/worktree";
-
-export interface SyncOptions {
-  targetBranch?: string;
-  switch?: boolean;
-}
+import { getCurrentBranch, getMainRepoPath, isWorktree } from "../lib/worktree";
 
 // Check if repo has uncommitted changes (ignores untracked files)
 async function hasUncommittedChanges(repoRoot: string): Promise<boolean> {
@@ -30,56 +25,9 @@ async function hasUncommittedChanges(repoRoot: string): Promise<boolean> {
   return lines.length > 0;
 }
 
-// Run git fetch
-async function gitFetch(repoRoot: string): Promise<boolean> {
-  const proc = Bun.spawn(["git", "fetch", "origin"], {
-    cwd: repoRoot,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  await proc.exited;
-  return proc.exitCode === 0;
-}
-
-type RebaseResult = { success: true } | { success: false; conflict: boolean; error: string };
-
-// Checkout a branch and pull latest
-async function checkoutAndPull(
-  repoRoot: string,
-  branch: string
-): Promise<{ success: boolean; error?: string }> {
-  // Checkout the branch
-  const checkoutProc = Bun.spawn(["git", "checkout", branch], {
-    cwd: repoRoot,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const checkoutStderr = await new Response(checkoutProc.stderr).text();
-  await checkoutProc.exited;
-
-  if (checkoutProc.exitCode !== 0) {
-    return { success: false, error: checkoutStderr };
-  }
-
-  // Pull latest
-  const pullProc = Bun.spawn(["git", "pull", "--rebase"], {
-    cwd: repoRoot,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const pullStderr = await new Response(pullProc.stderr).text();
-  await pullProc.exited;
-
-  if (pullProc.exitCode !== 0) {
-    return { success: false, error: pullStderr };
-  }
-
-  return { success: true };
-}
-
-// Rebase current branch on origin/<branch>
-async function rebaseOnBranch(repoRoot: string, branch: string): Promise<RebaseResult> {
-  const proc = Bun.spawn(["git", "rebase", `origin/${branch}`], {
+// Pull latest from origin (with rebase)
+async function gitPull(repoRoot: string): Promise<{ success: boolean; error?: string }> {
+  const proc = Bun.spawn(["git", "pull", "--rebase"], {
     cwd: repoRoot,
     stdout: "pipe",
     stderr: "pipe",
@@ -87,17 +35,10 @@ async function rebaseOnBranch(repoRoot: string, branch: string): Promise<RebaseR
   const stderr = await new Response(proc.stderr).text();
   await proc.exited;
 
-  if (proc.exitCode === 0) {
-    return { success: true };
+  if (proc.exitCode !== 0) {
+    return { success: false, error: stderr.trim() };
   }
-
-  // Check if it's a conflict
-  const isConflict =
-    stderr.includes("CONFLICT") ||
-    stderr.includes("could not apply") ||
-    stderr.includes("Resolve all conflicts");
-
-  return { success: false, conflict: isConflict, error: stderr };
+  return { success: true };
 }
 
 // Run bun install in a directory
@@ -122,28 +63,35 @@ async function runBunLink(dir: string): Promise<boolean> {
   return proc.exitCode === 0;
 }
 
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: orchestration function with multiple steps
-export async function syncCommand(options: SyncOptions = {}): Promise<Result<void>> {
+export async function syncCommand(): Promise<Result<void>> {
   const startTimeMs = Date.now();
 
-  // Find repo root (or use existing cache source)
-  let repoRoot = await getCacheSource();
+  // Find repo root
+  const repoRoot = await findRepoRoot();
   if (!repoRoot) {
-    repoRoot = await findRepoRoot();
+    return Err(new CommandError("Not in a git repository. Run from within the Dust repo."));
   }
 
-  if (!repoRoot) {
+  // Precondition: Must be run from main repo, not a worktree
+  const inWorktree = await isWorktree(repoRoot);
+  if (inWorktree) {
+    const mainRepo = await getMainRepoPath(repoRoot);
+    return Err(
+      new CommandError(`Cannot sync from a worktree. Run sync from the main repo: cd ${mainRepo}`)
+    );
+  }
+
+  // Precondition: Must be on main branch
+  const currentBranch = await getCurrentBranch(repoRoot);
+  if (currentBranch !== "main") {
     return Err(
       new CommandError(
-        "Not in a git repository and no cache source configured. Run from within the Dust repo."
+        `Cannot sync from branch '${currentBranch}'. Checkout main first: git checkout main`
       )
     );
   }
 
-  logger.info(`Syncing cache source: ${repoRoot}`);
-  console.log();
-
-  // Check for uncommitted changes
+  // Precondition: Must have clean working directory
   logger.step("Checking for uncommitted changes...");
   const hasChanges = await hasUncommittedChanges(repoRoot);
   if (hasChanges) {
@@ -153,56 +101,16 @@ export async function syncCommand(options: SyncOptions = {}): Promise<Result<voi
   }
   logger.success("Working directory clean");
 
-  // Get current branch for reporting
-  let currentBranch: string;
-  try {
-    currentBranch = await getCurrentBranch(repoRoot);
-  } catch {
-    return Err(new CommandError("Could not determine current branch"));
-  }
+  logger.info(`Syncing: ${repoRoot}`);
+  console.log();
 
-  // Determine target branch (default to main)
-  const targetBranch = options.targetBranch ?? "main";
-
-  // Fetch from origin
-  logger.step("Fetching from origin...");
-  const fetched = await gitFetch(repoRoot);
-  if (!fetched) {
-    return Err(new CommandError("Failed to fetch from origin"));
+  // Pull latest main
+  logger.step("Pulling latest main...");
+  const pullResult = await gitPull(repoRoot);
+  if (!pullResult.success) {
+    return Err(new CommandError(`Failed to pull: ${pullResult.error}`));
   }
-  logger.success("Fetched latest changes");
-
-  // Sync to target branch
-  if (options.switch) {
-    // --switch: checkout target branch and pull
-    logger.step(`Switching to '${targetBranch}' and pulling latest...`);
-    const switchResult = await checkoutAndPull(repoRoot, targetBranch);
-    if (!switchResult.success) {
-      return Err(new CommandError(`Failed to switch to ${targetBranch}: ${switchResult.error}`));
-    }
-    logger.success(`Switched to '${targetBranch}' with latest changes`);
-  } else {
-    // Rebase current branch on origin/<targetBranch>
-    logger.step(`Rebasing '${currentBranch}' on origin/${targetBranch}...`);
-    const rebaseResult = await rebaseOnBranch(repoRoot, targetBranch);
-    if (!rebaseResult.success) {
-      if (rebaseResult.conflict) {
-        console.log();
-        logger.error("Rebase failed due to conflicts.");
-        console.log();
-        console.log("To resolve:");
-        console.log("  1. Fix the conflicts in the listed files");
-        console.log("  2. Stage your changes: git add <files>");
-        console.log("  3. Continue the rebase: git rebase --continue");
-        console.log("  4. Run dust-hive sync again");
-        console.log();
-        console.log("Or abort the rebase: git rebase --abort");
-        return Err(new CommandError("Rebase conflicts - resolve and run sync again"));
-      }
-      return Err(new CommandError(`Rebase failed: ${rebaseResult.error}`));
-    }
-    logger.success(`Rebased '${currentBranch}' on latest ${targetBranch}`);
-  }
+  logger.success("Pulled latest changes");
 
   // Update cache source
   await setCacheSource(repoRoot);
@@ -246,7 +154,7 @@ export async function syncCommand(options: SyncOptions = {}): Promise<Result<voi
   }
   logger.success(`Built ${buildResult.built.length} binaries`);
 
-  // Install and link dust-hive globally (only on main)
+  // Install and link dust-hive globally
   logger.step(`Installing ${dustHiveDir.name} dependencies...`);
   const installSuccess = await runBunInstall(dustHiveDir.path);
   if (!installSuccess) {
@@ -254,30 +162,17 @@ export async function syncCommand(options: SyncOptions = {}): Promise<Result<voi
   }
   logger.success(`${dustHiveDir.name} dependencies installed`);
 
-  // Only bun link when we're actually on main's code
-  // With --switch: we end up on targetBranch
-  // Without --switch: we stay on currentBranch (just rebased)
-  const finalBranch = options.switch ? targetBranch : currentBranch;
-  if (finalBranch === "main") {
-    logger.step(`Linking ${dustHiveDir.name}...`);
-    const linkSuccess = await runBunLink(dustHiveDir.path);
-    if (!linkSuccess) {
-      return Err(new CommandError("Failed to run bun link for dust-hive"));
-    }
-    logger.success("dust-hive linked globally");
-  } else {
-    logger.info("Skipping bun link (only done when on main branch)");
+  logger.step(`Linking ${dustHiveDir.name}...`);
+  const linkSuccess = await runBunLink(dustHiveDir.path);
+  if (!linkSuccess) {
+    return Err(new CommandError("Failed to run bun link for dust-hive"));
   }
+  logger.success("dust-hive linked globally");
 
   const elapsed = ((Date.now() - startTimeMs) / 1000).toFixed(1);
   console.log();
   logger.success(`Sync complete! (${elapsed}s)`);
   console.log();
-  if (options.switch) {
-    console.log(`Now on '${targetBranch}' with latest changes.`);
-  } else {
-    console.log(`Branch '${currentBranch}' is now rebased on latest ${targetBranch}.`);
-  }
   console.log("Dependencies and binaries are up to date.");
   console.log();
 

--- a/x/henry/dust-hive/src/index.ts
+++ b/x/henry/dust-hive/src/index.ts
@@ -41,28 +41,23 @@ const cli = cac("dust-hive");
 cli
   .command("spawn [name]", "Create a new environment")
   .option("--name <name>", "Environment name")
-  .option("--base <branch>", "Base branch")
   .option("--no-open", "Do not open zellij session after spawn")
   .option("--no-attach", "Create zellij session but don't attach to it")
   .option("--warm", "Open zellij with a warm tab running dust-hive warm")
   .action(
     async (
       name: string | undefined,
-      options: { name?: string; base?: string; open?: boolean; attach?: boolean; warm?: boolean }
+      options: { name?: string; open?: boolean; attach?: boolean; warm?: boolean }
     ) => {
       const resolvedName = name ?? options.name;
       const spawnOptions: {
         name?: string;
-        base?: string;
         noOpen?: boolean;
         noAttach?: boolean;
         warm?: boolean;
       } = {};
       if (resolvedName !== undefined) {
         spawnOptions.name = resolvedName;
-      }
-      if (options.base !== undefined) {
-        spawnOptions.base = options.base;
       }
       if (options.open === false) {
         spawnOptions.noOpen = true;
@@ -169,27 +164,9 @@ cli.command("doctor", "Check prerequisites (alias for setup)").action(async () =
   await prepareAndRun(doctorCommand());
 });
 
-cli
-  .command("cache [action]", "Show or rebuild binary cache")
-  .option("--rebuild", "Rebuild cache")
-  .option("--status", "Show cache status")
-  .action(async (action: string | undefined, options: { rebuild?: boolean; status?: boolean }) => {
-    const resolved = {
-      rebuild: options.rebuild ?? false,
-      status: options.status ?? false,
-    };
-
-    if (action === "rebuild") {
-      resolved.rebuild = true;
-    } else if (action === "status") {
-      resolved.status = true;
-    } else if (action !== undefined) {
-      logger.error(`Unknown cache action: ${action}`);
-      process.exit(1);
-    }
-
-    await prepareAndRun(cacheCommand(resolved));
-  });
+cli.command("cache", "Show binary cache status").action(async () => {
+  await prepareAndRun(cacheCommand());
+});
 
 cli
   .command("forward [target]", "Manage OAuth port forwarding")
@@ -197,18 +174,9 @@ cli
     await prepareAndRun(forwardCommand(target));
   });
 
-cli
-  .command("sync [branch]", "Rebase on branch (default: main), rebuild binaries, refresh deps")
-  .option("--switch", "Switch to target branch instead of rebasing onto it")
-  .action(async (branch: string | undefined, options: { switch?: boolean }) => {
-    const syncOptions: { targetBranch?: string; switch?: boolean } = {
-      switch: Boolean(options.switch),
-    };
-    if (branch !== undefined) {
-      syncOptions.targetBranch = branch;
-    }
-    await prepareAndRun(syncCommand(syncOptions));
-  });
+cli.command("sync", "Pull latest main, rebuild binaries, refresh deps").action(async () => {
+  await prepareAndRun(syncCommand());
+});
 
 cli
   .command(


### PR DESCRIPTION
## Description

- sync: must run from main repo on main branch with clean working dir
- spawn: always uses main repo as cache source, always bases on main
- cache: status only (removed --rebuild, use sync instead)
- Added isWorktree() and getMainRepoPath() helpers

Removed features:
- sync --switch and sync [BRANCH] options
- spawn --base option and branch prompting
- cache --rebuild option

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
