### PR TITLE
fix(dust-hive): correct qdrant port expectations in tests

### DIFF
--- a/x/henry/dust-hive/tests/lib/docker.test.ts
+++ b/x/henry/dust-hive/tests/lib/docker.test.ts
@@ -14,7 +14,7 @@ describe("docker", () => {
 
       expect(override.services.db.ports).toEqual(["10432:5432"]);
       expect(override.services.redis.ports).toEqual(["10379:6379"]);
-      expect(override.services.qdrant_primary.ports).toEqual(["10334:6334", "10333:6333"]);
+      expect(override.services.qdrant_primary.ports).toEqual(["10333:6333", "10334:6334"]);
       expect(override.services.elasticsearch.ports).toEqual(["10200:9200"]);
       expect(override.services["apache-tika"].ports).toEqual(["10998:9998"]);
     });

--- a/x/henry/dust-hive/tests/lib/envgen.test.ts
+++ b/x/henry/dust-hive/tests/lib/envgen.test.ts
@@ -43,7 +43,7 @@ describe("envgen", () => {
       const content = generateEnvSh("test", ports);
       expect(content).toContain("export POSTGRES_PORT=10432");
       expect(content).toContain("export POSTGRES_HOST=localhost");
-      expect(content).toContain("export QDRANT_URL=http://localhost:10334");
+      expect(content).toContain("export QDRANT_URL=http://localhost:10333");
       expect(content).toContain("export ELASTICSEARCH_INIT_URL=http://localhost:10200");
     });
 

--- a/x/henry/dust-hive/tests/lib/ports.test.ts
+++ b/x/henry/dust-hive/tests/lib/ports.test.ts
@@ -13,8 +13,8 @@ describe("ports", () => {
       expect(ports.oauth).toBe(10006);
       expect(ports.postgres).toBe(10432);
       expect(ports.redis).toBe(10379);
-      expect(ports.qdrantHttp).toBe(10334);
-      expect(ports.qdrantGrpc).toBe(10333);
+      expect(ports.qdrantHttp).toBe(10333);
+      expect(ports.qdrantGrpc).toBe(10334);
       expect(ports.elasticsearch).toBe(10200);
       expect(ports.apacheTika).toBe(10998);
     });


### PR DESCRIPTION
## Description

Test expectations had qdrantHttp and qdrantGrpc ports swapped. The implementation uses offset 333 for HTTP (resembling 6333) and 334 for GRPC (resembling 6334), but tests expected the opposite.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
