### PR TITLE
Relocation: es_indexation user search rebuild

### DIFF
--- a/front/runbooks/ELASTICSEARCH.md
+++ b/front/runbooks/ELASTICSEARCH.md
@@ -871,3 +871,115 @@ async function handler(
 
 export default withSessionAuthentication(handler);
 ```
+
+---
+
+## Workspace Relocation Support
+
+When a workspace is relocated to a different region, Elasticsearch indices need to be recreated in the destination region.
+
+### Step 1: Create a Relocation Activity
+
+Add an activity function in `temporal/relocation/activities/destination_region/front/es_indexation.ts` that recreates your index for a given workspace:
+
+```typescript
+import { YourResource } from "@app/lib/resources/your_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { indexYourDocument } from "@app/lib/your_feature";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
+import logger from "@app/logger/logger";
+
+export async function recreateYourIndex({
+  workspaceId,
+}: {
+  workspaceId: string;
+}) {
+  const localLogger = logger.child({ workspaceId });
+
+  localLogger.info("[Your Index] Recreating index for workspace.");
+
+  const workspace = await WorkspaceResource.fetchById(workspaceId);
+  if (!workspace) {
+    throw new Error(`Workspace not found: ${workspaceId}`);
+  }
+
+  const lightWorkspace = renderLightWorkspaceType({ workspace });
+
+  // Fetch all entities that need to be indexed for this workspace
+  const entities = await YourResource.listForWorkspace(lightWorkspace);
+
+  localLogger.info(
+    { entityCount: entities.length },
+    "[Your Index] Found entities to index"
+  );
+
+  let successCount = 0;
+  let errorCount = 0;
+
+  await concurrentExecutor(
+    entities,
+    async (entity) => {
+      const document = entity.toSearchDocument(lightWorkspace);
+      const result = await indexYourDocument(document);
+
+      if (result.isErr()) {
+        localLogger.error(
+          { entityId: entity.sId, error: result.error },
+          "[Your Index] Failed to index document"
+        );
+        errorCount++;
+      } else {
+        successCount++;
+      }
+    },
+    { concurrency: 10 }
+  );
+
+  localLogger.info(
+    { successCount, errorCount },
+    "[Your Index] Completed index recreation for workspace"
+  );
+
+  if (errorCount > 0) {
+    throw new Error(
+      `Failed to index ${errorCount} entities for workspace ${workspaceId}`
+    );
+  }
+}
+```
+
+### Step 2: Export the Activity
+
+Ensure your activity is exported from `temporal/relocation/activities/destination_region/front/index.ts`:
+
+```typescript
+export * from "./es_indexation";
+export * from "./file_storage";
+export * from "./sql";
+```
+
+### Step 3: Call the Activity from the Relocation Workflow
+
+Add a call to your activity in `temporal/relocation/workflows.ts` within the `workspaceRelocateFrontWorkflow` function. The activity should be called after the front tables have been relocated (so the data exists in the destination region's database):
+
+```typescript
+export async function workspaceRelocateFrontWorkflow({
+  sourceRegion,
+  destRegion,
+  workspaceId,
+}: RelocationWorkflowBase) {
+  // ...
+
+  // 4) Recreate Elasticsearch indices in the destination region.
+  await destinationRegionActivities.recreateUserSearchIndex({ workspaceId });
+  await destinationRegionActivities.recreateYourIndex({ workspaceId }); // Add your index here
+}
+```
+
+### Example: User Search Index
+
+The user search index (`front.user_search`) is recreated during relocation using this pattern. See:
+
+- **Activity:** `temporal/relocation/activities/destination_region/front/es_indexation.ts` - `recreateUserSearchIndex`
+- **Workflow call:** `temporal/relocation/workflows.ts` - Called in `workspaceRelocateFrontWorkflow`

--- a/front/temporal/relocation/activities/destination_region/front/es_indexation.ts
+++ b/front/temporal/relocation/activities/destination_region/front/es_indexation.ts
@@ -1,0 +1,95 @@
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { indexUserDocument } from "@app/lib/user_search";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
+import logger from "@app/logger/logger";
+
+export async function recreateUserSearchIndex({
+  workspaceId,
+}: {
+  workspaceId: string;
+}) {
+  const localLogger = logger.child({
+    workspaceId,
+  });
+
+  localLogger.info("[User Search] Recreating user search index for workspace.");
+
+  const workspace = await WorkspaceResource.fetchById(workspaceId);
+  if (!workspace) {
+    throw new Error(`Workspace not found: ${workspaceId}`);
+  }
+
+  const lightWorkspace = renderLightWorkspaceType({ workspace });
+
+  // Get all memberships for this workspace.
+  const { memberships } = await MembershipResource.getLatestMemberships({
+    workspace: lightWorkspace,
+  });
+
+  // Filter out revoked memberships - only index active members.
+  const activeMemberships = memberships.filter((m) => !m.isRevoked());
+
+  localLogger.info(
+    {
+      totalMemberships: memberships.length,
+      activeMemberships: activeMemberships.length,
+    },
+    "[User Search] Found memberships to index"
+  );
+
+  let successCount = 0;
+  let errorCount = 0;
+
+  await concurrentExecutor(
+    activeMemberships,
+    async (membership) => {
+      const user = await UserResource.fetchByModelId(membership.userId);
+      if (!user) {
+        localLogger.warn(
+          {
+            membershipId: membership.id,
+            userId: membership.userId,
+          },
+          "[User Search] User not found for membership"
+        );
+        errorCount++;
+        return;
+      }
+
+      const document = user.toUserSearchDocument(lightWorkspace);
+      const result = await indexUserDocument(document);
+
+      if (result.isErr()) {
+        localLogger.error(
+          {
+            userId: user.sId,
+            error: result.error,
+          },
+          "[User Search] Failed to index user document"
+        );
+        errorCount++;
+      } else {
+        successCount++;
+      }
+    },
+    { concurrency: 10 }
+  );
+
+  localLogger.info(
+    {
+      successCount,
+      errorCount,
+      totalIndexed: activeMemberships.length,
+    },
+    "[User Search] Completed user search index recreation for workspace"
+  );
+
+  if (errorCount > 0) {
+    throw new Error(
+      `Failed to index ${errorCount} users for workspace ${workspaceId}`
+    );
+  }
+}

--- a/front/temporal/relocation/activities/destination_region/front/index.ts
+++ b/front/temporal/relocation/activities/destination_region/front/index.ts
@@ -1,2 +1,3 @@
+export * from "./es_indexation";
 export * from "./file_storage";
 export * from "./sql";

--- a/front/temporal/relocation/workflows.ts
+++ b/front/temporal/relocation/workflows.ts
@@ -165,6 +165,9 @@ export async function workspaceRelocateFrontWorkflow({
       },
     ],
   });
+
+  // 4) Recreate the user search index in the destination region.
+  await destinationRegionActivities.recreateUserSearchIndex({ workspaceId });
 }
 
 export async function workspaceRelocateFrontTableWorkflow({

--- a/front/temporal/relocation/workflows.ts
+++ b/front/temporal/relocation/workflows.ts
@@ -166,8 +166,19 @@ export async function workspaceRelocateFrontWorkflow({
     ],
   });
 
-  // 4) Recreate the user search index in the destination region.
-  await destinationRegionActivities.recreateUserSearchIndex({ workspaceId });
+  // 4) Recreate Elasticsearch indices in the destination region.
+  await executeChild(workspaceRelocateFrontEsIndexationWorkflow, {
+    workflowId: `workspaceRelocateFrontEsIndexationWorkflow-${workspaceId}`,
+    searchAttributes: parentSearchAttributes,
+    args: [
+      {
+        sourceRegion,
+        destRegion,
+        workspaceId,
+      },
+    ],
+    memo,
+  });
 }
 
 export async function workspaceRelocateFrontTableWorkflow({
@@ -287,6 +298,17 @@ export async function workspaceRelocateFrontFileStorageWorkflow({
       await sleep("1m");
     }
   }
+}
+
+export async function workspaceRelocateFrontEsIndexationWorkflow({
+  destRegion,
+  workspaceId,
+}: RelocationWorkflowBase) {
+  const destinationRegionActivities =
+    getFrontDestinationRegionActivities(destRegion);
+
+  // Recreate user search index.
+  await destinationRegionActivities.recreateUserSearchIndex({ workspaceId });
 }
 
 /**


### PR DESCRIPTION
## Description

For: https://github.com/dust-tt/tasks/issues/5643

Adds an activity to rebuild `es_indexation/user_search` index upon relocation of a workspace.

cc @davidebbo 

## Tests

N/A

## Risk

Low

## Deploy Plan

N/A