### PR TITLE
Create project from sidebar

### DIFF
--- a/front/components/assistant/conversation/CreateProjectModal.tsx
+++ b/front/components/assistant/conversation/CreateProjectModal.tsx
@@ -11,11 +11,11 @@ import {
 } from "@dust-tt/sparkle";
 import { useCallback, useEffect, useState } from "react";
 
+import { useSpaceConversationsSummary } from "@app/lib/swr/conversations";
 import { useCreateSpace } from "@app/lib/swr/spaces";
 import { useUser } from "@app/lib/swr/user";
-import type { LightWorkspaceType, SpaceType } from "@app/types";
-import { useSpaceConversationsSummary } from "@app/lib/swr/conversations";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
+import type { LightWorkspaceType } from "@app/types";
 
 interface CreateProjectModalProps {
   isOpen: boolean;

--- a/front/components/assistant/conversation/CreateProjectModal.tsx
+++ b/front/components/assistant/conversation/CreateProjectModal.tsx
@@ -11,8 +11,8 @@ import {
 import { useCallback, useEffect, useState } from "react";
 
 import { useCreateSpace } from "@app/lib/swr/spaces";
-import type { LightWorkspaceType, SpaceType } from "@app/types";
 import { useUser } from "@app/lib/swr/user";
+import type { LightWorkspaceType, SpaceType } from "@app/types";
 
 interface CreateProjectModalProps {
   isOpen: boolean;

--- a/front/components/assistant/conversation/CreateProjectModal.tsx
+++ b/front/components/assistant/conversation/CreateProjectModal.tsx
@@ -1,0 +1,116 @@
+import {
+  Button,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Input,
+} from "@dust-tt/sparkle";
+import { useCallback, useEffect, useState } from "react";
+
+import { useCreateSpace } from "@app/lib/swr/spaces";
+import type { LightWorkspaceType, SpaceType } from "@app/types";
+import { useUser } from "@app/lib/swr/user";
+
+interface CreateProjectModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onCreated?: (space: SpaceType) => void;
+  owner: LightWorkspaceType;
+}
+
+export function CreateProjectModal({
+  isOpen,
+  onClose,
+  onCreated,
+  owner,
+}: CreateProjectModalProps) {
+  const [projectName, setProjectName] = useState<string>("");
+  const [isSaving, setIsSaving] = useState(false);
+
+  const doCreate = useCreateSpace({ owner });
+  const { user } = useUser();
+
+  useEffect(() => {
+    if (isOpen) {
+      setProjectName("");
+      setIsSaving(false);
+    }
+  }, [isOpen]);
+
+  const handleClose = useCallback(() => {
+    onClose();
+    setTimeout(() => {
+      setProjectName("");
+      setIsSaving(false);
+    }, 500);
+  }, [onClose]);
+
+  const onSave = useCallback(async () => {
+    const trimmedName = projectName.trim();
+    if (!trimmedName) {
+      return;
+    }
+
+    setIsSaving(true);
+
+    const createdSpace = await doCreate({
+      name: trimmedName,
+      isRestricted: false,
+      managementMode: "manual",
+      memberIds: user?.sId ? [user.sId] : [],
+      conversationsEnabled: true,
+    });
+
+    setIsSaving(false);
+
+    if (createdSpace && onCreated) {
+      onCreated(createdSpace);
+    }
+
+    handleClose();
+  }, [projectName, doCreate, onCreated, handleClose]);
+
+  const handleKeyPress = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Enter" && projectName.trim()) {
+        void onSave();
+      }
+    },
+    [onSave, projectName]
+  );
+
+  return (
+    <Dialog open={isOpen} onOpenChange={handleClose}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Create a new Project</DialogTitle>
+        </DialogHeader>
+        <DialogContainer>
+          <div className="flex w-full flex-col gap-y-4">
+            <Input
+              placeholder="Project name"
+              value={projectName}
+              name="projectName"
+              onChange={(e) => {
+                setProjectName(e.target.value);
+              }}
+              onKeyDown={handleKeyPress}
+              autoFocus
+            />
+          </div>
+        </DialogContainer>
+        <DialogFooter>
+          <Button label="Cancel" variant="outline" onClick={handleClose} />
+          <Button
+            label={isSaving ? "Creating..." : "Create"}
+            onClick={onSave}
+            disabled={!projectName.trim() || isSaving}
+          />
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/front/components/assistant/conversation/CreateProjectModal.tsx
+++ b/front/components/assistant/conversation/CreateProjectModal.tsx
@@ -88,7 +88,14 @@ export function CreateProjectModal({
       });
       handleClose();
     }
-  }, [projectName, doCreate, handleClose]);
+  }, [
+    projectName,
+    doCreate,
+    handleClose,
+    sendNotification,
+    mutateSpaceSummary,
+    user,
+  ]);
 
   const handleKeyPress = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -52,6 +52,7 @@ import {
   ConversationMenu,
   useConversationMenu,
 } from "@app/components/assistant/conversation/ConversationMenu";
+import { CreateProjectModal } from "@app/components/assistant/conversation/CreateProjectModal";
 import { DeleteConversationsDialog } from "@app/components/assistant/conversation/DeleteConversationsDialog";
 import { StackedInAppBanners } from "@app/components/assistant/conversation/InAppBanner";
 import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
@@ -61,7 +62,6 @@ import {
   getGroupConversationsByUnreadAndActionRequired,
 } from "@app/components/assistant/conversation/utils";
 import { SidebarContext } from "@app/components/sparkle/SidebarContext";
-import { CreateProjectModal } from "@app/components/assistant/conversation/CreateProjectModal";
 import { useDeleteConversation } from "@app/hooks/useDeleteConversation";
 import { useMarkAllConversationsAsRead } from "@app/hooks/useMarkAllConversationsAsRead";
 import { useSendNotification } from "@app/hooks/useNotification";

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -164,7 +164,7 @@ export function AgentSidebarMenu({ owner }: AgentSidebarMenuProps) {
 
   const hasSpaceConversations = hasFeature("projects");
 
-  const { summary, mutate: mutateSpaceSummary } = useSpaceConversationsSummary({
+  const { summary } = useSpaceConversationsSummary({
     workspaceId: owner.sId,
     options: { disabled: !hasSpaceConversations },
   });
@@ -355,15 +355,6 @@ export function AgentSidebarMenu({ owner }: AgentSidebarMenuProps) {
         isOpen={isCreateProjectModalOpen}
         onClose={() => setIsCreateProjectModalOpen(false)}
         owner={owner}
-        onCreated={(space) => {
-          setIsCreateProjectModalOpen(false);
-          void mutateSpaceSummary();
-          sendNotification({
-            type: "success",
-            title: "Project created",
-            description: `Project "${space.name}" has been created.`,
-          });
-        }}
       />
       <div className="relative flex grow flex-col">
         <div className="flex h-0 min-h-full w-full">

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -274,7 +274,11 @@ export async function hardDeleteSpace(
 
 export async function createRegularSpaceAndGroup(
   auth: Authenticator,
-  params: { name: string; isRestricted: boolean } & (
+  params: {
+    name: string;
+    isRestricted: boolean;
+    conversationsEnabled?: boolean;
+  } & (
     | { memberIds: string[]; managementMode: "manual" }
     | { groupIds: string[]; managementMode: "group" }
   ),
@@ -306,7 +310,7 @@ export async function createRegularSpaceAndGroup(
       );
     }
 
-    const { name, isRestricted } = params;
+    const { name, isRestricted, conversationsEnabled } = params;
     const managementMode = isRestricted ? params.managementMode : "manual";
     const nameAvailable = await SpaceResource.isNameAvailable(auth, name, t);
     if (!nameAvailable) {
@@ -342,6 +346,7 @@ export async function createRegularSpaceAndGroup(
         kind: "regular",
         managementMode,
         workspaceId: owner.id,
+        conversationsEnabled: conversationsEnabled ?? false,
       },
       groups,
       t

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -394,7 +394,7 @@ export function useCreateSpace({ owner }: { owner: LightWorkspaceType }) {
   });
 
   const doCreate = async (params: PostSpaceRequestBodyType) => {
-    const { name, managementMode, isRestricted } = params;
+    const { name, managementMode, isRestricted, conversationsEnabled } = params;
 
     if (!name) {
       return null;
@@ -421,6 +421,7 @@ export function useCreateSpace({ owner }: { owner: LightWorkspaceType }) {
           memberIds,
           managementMode,
           isRestricted,
+          conversationsEnabled: conversationsEnabled ?? false,
         }),
       });
     } else if (managementMode === "group") {

--- a/front/pages/api/w/[wId]/spaces/index.ts
+++ b/front/pages/api/w/[wId]/spaces/index.ts
@@ -12,10 +12,15 @@ import type { SpaceType, WithAPIErrorResponse } from "@app/types";
 import { assertNever } from "@app/types";
 
 const PostSpaceRequestBodySchema = t.intersection([
-  t.type({
-    isRestricted: t.boolean,
-    name: t.string,
-  }),
+  t.intersection([
+    t.type({
+      isRestricted: t.boolean,
+      name: t.string,
+    }),
+    t.partial({
+      conversationsEnabled: t.boolean,
+    }),
+  ]),
   t.union([
     t.type({
       memberIds: t.array(t.string),


### PR DESCRIPTION
## Description

Adds the ability to create projects directly from the Chat sidebar. A "New" button appears next to the "Projects" section label (visible to admins only), which opens a modal to create a new project with conversations enabled. The new project is created with the current user as a member and immediately shows up in the sidebar after creation.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Depoloy front
