### PR TITLE
feat(dust-hive): add --wait option to spawn command

### DIFF
--- a/x/henry/dust-hive/src/index.ts
+++ b/x/henry/dust-hive/src/index.ts
@@ -44,17 +44,25 @@ cli
   .option("--no-open", "Do not open zellij session after spawn")
   .option("--no-attach", "Create zellij session but don't attach to it")
   .option("--warm", "Open zellij with a warm tab running dust-hive warm")
+  .option("--wait", "Wait for SDK to build before opening zellij (cannot be used with --no-open)")
   .action(
     async (
       name: string | undefined,
-      options: { name?: string; open?: boolean; attach?: boolean; warm?: boolean }
+      options: { name?: string; open?: boolean; attach?: boolean; warm?: boolean; wait?: boolean }
     ) => {
+      // Validate --wait cannot be used with --no-open
+      if (options.wait && options.open === false) {
+        logger.error("--wait cannot be used with --no-open (--no-open always waits)");
+        process.exit(1);
+      }
+
       const resolvedName = name ?? options.name;
       const spawnOptions: {
         name?: string;
         noOpen?: boolean;
         noAttach?: boolean;
         warm?: boolean;
+        wait?: boolean;
       } = {};
       if (resolvedName !== undefined) {
         spawnOptions.name = resolvedName;
@@ -67,6 +75,9 @@ cli
       }
       if (options.warm) {
         spawnOptions.warm = true;
+      }
+      if (options.wait) {
+        spawnOptions.wait = true;
       }
       await prepareAndRun(spawnCommand(spawnOptions));
     }


### PR DESCRIPTION
## Description

By default, spawn no longer waits for SDK build when opening zellij, since the watch process shows progress in the UI. Add --wait flag to explicitly wait if needed. --no-open still forces waiting (no UI).

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
