### PR TITLE
feat(dust-hive): use @clack/prompts for interactive selection

### DIFF
--- a/x/henry/dust-hive/bun.lock
+++ b/x/henry/dust-hive/bun.lock
@@ -4,6 +4,7 @@
     "": {
       "name": "dust-hive",
       "dependencies": {
+        "@clack/prompts": "^0.11.0",
         "cac": "^6.7.14",
         "yaml": "^2.3.0",
         "zod": "^4.3.5",
@@ -34,6 +35,10 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@1.9.4", "", { "os": "win32", "cpu": "x64" }, "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA=="],
 
+    "@clack/core": ["@clack/core@0.5.0", "", { "dependencies": { "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-p3y0FIOwaYRUPRcMO7+dlmLh8PSRcrjuTndsiA0WAFbWES0mLZlrjVoBRZ9DzkPFJZG6KGkJmoEAY0ZcVWTkow=="],
+
+    "@clack/prompts": ["@clack/prompts@0.11.0", "", { "dependencies": { "@clack/core": "0.5.0", "picocolors": "^1.0.0", "sisteransi": "^1.0.5" } }, "sha512-pMN5FcrEw9hUkZA4f+zLlzivQSeQf5dRGJjSUbvVYDLvpKCdQx5OaknvKzgbtXOizhP+SJJJjqEbOe55uKKfAw=="],
+
     "@types/bun": ["@types/bun@1.3.5", "", { "dependencies": { "bun-types": "1.3.5" } }, "sha512-RnygCqNrd3srIPEWBd5LFeUYG7plCoH2Yw9WaZGyNmdTEei+gWaHqydbaIRkIkcbXwhBT94q78QljxN0Sk838w=="],
 
     "@types/node": ["@types/node@25.0.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA=="],
@@ -41,6 +46,10 @@
     "bun-types": ["bun-types@1.3.5", "", { "dependencies": { "@types/node": "*" } }, "sha512-inmAYe2PFLs0SUbFOWSVD24sg1jFlMPxOjOSSCYqUgn4Hsc3rDc7dFvfVYjFPNHtov6kgUeulV4SxbuIV/stPw=="],
 
     "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 

--- a/x/henry/dust-hive/package.json
+++ b/x/henry/dust-hive/package.json
@@ -21,6 +21,7 @@
     "typescript": "^5.0.0"
   },
   "dependencies": {
+    "@clack/prompts": "^0.11.0",
     "cac": "^6.7.14",
     "yaml": "^2.3.0",
     "zod": "^4.3.5"

--- a/x/henry/dust-hive/src/commands/open.ts
+++ b/x/henry/dust-hive/src/commands/open.ts
@@ -9,6 +9,7 @@ import {
   getWorktreeDir,
   getZellijLayoutPath,
 } from "../lib/paths";
+import { restoreTerminal } from "../lib/prompt";
 import { Ok } from "../lib/result";
 import { ALL_SERVICES, type ServiceName } from "../lib/services";
 
@@ -303,6 +304,9 @@ export const openCommand = withEnvironment("open", async (env, options: OpenOpti
     // Attach to existing session
     logger.info(`Attaching to existing session '${sessionName}'...`);
 
+    // Ensure terminal is fully restored before spawning zellij
+    restoreTerminal();
+
     const proc = Bun.spawn(["zellij", "attach", sessionName], {
       stdin: "inherit",
       stdout: "inherit",
@@ -327,6 +331,9 @@ export const openCommand = withEnvironment("open", async (env, options: OpenOpti
     }
 
     logger.info(`Creating new zellij session '${sessionName}'...`);
+
+    // Ensure terminal is fully restored before spawning zellij
+    restoreTerminal();
 
     const proc = Bun.spawn(
       ["zellij", "--session", sessionName, "--new-session-with-layout", layoutPath],

--- a/x/henry/dust-hive/src/lib/commands.ts
+++ b/x/henry/dust-hive/src/lib/commands.ts
@@ -2,7 +2,7 @@
 
 import { setLastActiveEnv } from "./activity";
 import { type Environment, getEnvironment } from "./environment";
-import { selectEnvironment } from "./prompt";
+import { restoreTerminal, selectEnvironment } from "./prompt";
 import { CommandError, Err, Ok, type Result, envNotFoundError } from "./result";
 
 // Require an environment to exist, returning error if not found
@@ -18,6 +18,10 @@ export async function requireEnvironment(
     const selected = await selectEnvironment({
       message: `Select environment for ${commandName}`,
     });
+
+    // Restore terminal to cooked mode after interactive prompt
+    // This prevents terminal corruption when spawning subprocesses like zellij
+    restoreTerminal();
 
     if (!selected) {
       return Err(new CommandError("No environment selected"));

--- a/x/henry/dust-hive/src/lib/prompt.ts
+++ b/x/henry/dust-hive/src/lib/prompt.ts
@@ -1,6 +1,7 @@
 // Interactive prompts for environment selection and confirmations
-// Uses simple line input (no raw mode) for compatibility with terminal multiplexers
+// Uses @clack/prompts for beautiful arrow-key navigation
 
+import * as p from "@clack/prompts";
 import { getLastActiveEnv } from "./activity";
 import { listEnvironments } from "./environment";
 import { detectEnvFromCwd } from "./paths";
@@ -9,31 +10,48 @@ export interface SelectEnvironmentOptions {
   message?: string;
 }
 
-// Simple line reader using Bun's console async iterator (same as spawn.ts)
-async function readLine(prompt: string): Promise<string | null> {
-  process.stdout.write(prompt);
-  for await (const line of console) {
-    return line.trim();
+/**
+ * Restore terminal to cooked mode and clean up stdin.
+ * IMPORTANT: Call this before spawning any subprocess that takes over the terminal
+ * (like zellij) to prevent terminal corruption.
+ *
+ * This does three things:
+ * 1. Exits raw mode (restores cooked mode)
+ * 2. Pauses stdin to stop reading
+ * 3. Removes all listeners that clack may have attached
+ */
+export function restoreTerminal(): void {
+  try {
+    // Exit raw mode if we're in a TTY
+    if (process.stdin.isTTY) {
+      process.stdin.setRawMode(false);
+    }
+
+    // Pause stdin to stop it from reading
+    process.stdin.pause();
+
+    // Remove all listeners that clack may have attached
+    // This is critical - without this, clack's listeners will interfere
+    // with child processes that inherit stdin
+    process.stdin.removeAllListeners("data");
+    process.stdin.removeAllListeners("keypress");
+    process.stdin.removeAllListeners("readable");
+  } catch {
+    // Ignore errors - best effort cleanup
   }
-  return null;
 }
 
 // Simple y/n prompt - returns true for yes, false for no (no default)
 export async function promptYesNo(question: string): Promise<boolean> {
-  for (;;) {
-    const input = await readLine(`${question} (y/n): `);
-    if (input === null) {
-      throw new Error("No input received");
-    }
-    const normalized = input.toLowerCase();
-    if (normalized === "y" || normalized === "yes") {
-      return true;
-    }
-    if (normalized === "n" || normalized === "no") {
-      return false;
-    }
-    console.log("Please enter 'y' or 'n'");
+  const result = await p.confirm({
+    message: question,
+  });
+
+  if (p.isCancel(result)) {
+    throw new Error("Prompt cancelled");
   }
+
+  return result;
 }
 
 // Choice prompt - returns the selected option
@@ -41,42 +59,30 @@ export async function promptChoice<T extends string>(
   question: string,
   options: readonly T[]
 ): Promise<T> {
-  console.log(question);
-  for (let i = 0; i < options.length; i++) {
-    console.log(`  ${i + 1}) ${options[i]}`);
+  const result = await p.select({
+    message: question,
+    options: options.map((opt) => ({ value: opt as string, label: opt })),
+  });
+
+  if (p.isCancel(result)) {
+    throw new Error("Prompt cancelled");
   }
 
-  for (;;) {
-    const input = await readLine("Enter choice (number): ");
-    if (input === null) {
-      throw new Error("No input received");
-    }
-    const num = Number.parseInt(input, 10);
-    if (num >= 1 && num <= options.length) {
-      const selected = options[num - 1];
-      if (selected !== undefined) {
-        return selected;
-      }
-    }
-    console.log(`Please enter a number between 1 and ${options.length}`);
-  }
+  return result as T;
 }
 
-// Prompt user for yes/no confirmation
-// Returns true for yes, false for no
+// Prompt user for yes/no confirmation with default
 export async function confirm(message: string, defaultYes = true): Promise<boolean> {
-  const hint = defaultYes ? "[Y/n]" : "[y/N]";
-  const input = await readLine(`${message} ${hint} `);
+  const result = await p.confirm({
+    message,
+    initialValue: defaultYes,
+  });
 
-  if (input === null) {
+  if (p.isCancel(result)) {
     return false;
   }
 
-  const normalized = input.toLowerCase();
-  if (normalized === "") {
-    return defaultYes;
-  }
-  return normalized === "y" || normalized === "yes";
+  return result;
 }
 
 function sortEnvs(
@@ -93,56 +99,22 @@ function sortEnvs(
   });
 }
 
-function findDefault(
+function findInitialValue(
   sortedEnvs: string[],
   envs: string[],
   currentEnv: string | null,
   lastActiveEnv: string | null
-): number {
+): string | undefined {
   if (currentEnv && envs.includes(currentEnv)) {
-    return sortedEnvs.indexOf(currentEnv);
+    return currentEnv;
   }
   if (lastActiveEnv && envs.includes(lastActiveEnv)) {
-    return sortedEnvs.indexOf(lastActiveEnv);
+    return lastActiveEnv;
   }
-  return 0;
+  return sortedEnvs[0];
 }
 
-function printList(
-  sortedEnvs: string[],
-  defaultIndex: number,
-  currentEnv: string | null,
-  lastActiveEnv: string | null,
-  message: string
-): void {
-  console.log();
-  console.log(message);
-  for (let i = 0; i < sortedEnvs.length; i++) {
-    const name = sortedEnvs[i];
-    let suffix = "";
-    if (name === currentEnv) {
-      suffix = " (current)";
-    } else if (name === lastActiveEnv) {
-      suffix = " (last)";
-    }
-    const marker = i === defaultIndex ? ">" : " ";
-    console.log(`  ${marker} ${i + 1}. ${name}${suffix}`);
-  }
-}
-
-function parseInput(input: string, count: number, defaultIndex: number): number | null {
-  if (input === "") {
-    return defaultIndex;
-  }
-  const num = Number.parseInt(input, 10);
-  if (Number.isNaN(num) || num < 1 || num > count) {
-    console.log("Invalid selection");
-    return null;
-  }
-  return num - 1;
-}
-
-// Interactively select an environment using simple numbered list
+// Interactively select an environment using arrow keys
 export async function selectEnvironment(
   options?: SelectEnvironmentOptions
 ): Promise<string | null> {
@@ -154,25 +126,25 @@ export async function selectEnvironment(
   const currentEnv = detectEnvFromCwd();
   const lastActiveEnv = await getLastActiveEnv();
   const sortedEnvs = sortEnvs(envs, currentEnv, lastActiveEnv);
-  const defaultIndex = findDefault(sortedEnvs, envs, currentEnv, lastActiveEnv);
+  const initialValue = findInitialValue(sortedEnvs, envs, currentEnv, lastActiveEnv);
 
-  printList(
-    sortedEnvs,
-    defaultIndex,
-    currentEnv,
-    lastActiveEnv,
-    options?.message ?? "Select environment:"
-  );
+  const result = await p.select({
+    message: options?.message ?? "Select environment",
+    initialValue,
+    options: sortedEnvs.map((name) => {
+      if (name === currentEnv) {
+        return { value: name, label: name, hint: "current" };
+      }
+      if (name === lastActiveEnv) {
+        return { value: name, label: name, hint: "last" };
+      }
+      return { value: name, label: name };
+    }),
+  });
 
-  const input = await readLine(`[${defaultIndex + 1}]: `);
-  if (input === null) {
+  if (p.isCancel(result)) {
     return null;
   }
 
-  const selected = parseInput(input, sortedEnvs.length, defaultIndex);
-  if (selected === null) {
-    return null;
-  }
-
-  return sortedEnvs[selected] ?? null;
+  return result as string;
 }


### PR DESCRIPTION
## Description

Replace custom numbered prompts with @clack/prompts for proper arrow-key navigation. Adds terminal restoration to prevent corruption when spawning Zellij after interactive prompts.

- Add @clack/prompts dependency for beautiful CLI prompts
- Rewrite prompt.ts with clack's select/confirm components
- Add restoreTerminal() to clean up stdin before subprocess spawn
- Re-enable interactive selection for destroy command with confirmation

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
