### PR TITLE
[Front] fix(skill-resource): add space restriction to base fetch

### DIFF
--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -264,14 +264,18 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     });
 
     // Check if user has access to skill requested spaces
-    const spaces = await SpaceResource.fetchByModelIds(
-      auth,
-      uniq(customSkills.flatMap((c) => c.requestedSpaceIds))
+    const uniqueRequestedSpaceIds = uniq(
+      customSkills.flatMap((c) => c.requestedSpaceIds)
     );
+    const spaces =
+      uniqueRequestedSpaceIds.length > 0
+        ? await SpaceResource.fetchByModelIds(auth, uniqueRequestedSpaceIds)
+        : [];
     const spaceIdToGroupsMap = createSpaceIdToGroupsMap(auth, spaces);
     const foundSpaceIds = new Set(spaces.map((s) => s.id));
 
     const validCustomSkills = customSkills.filter((skill) =>
+      // Parse as Number since Sequelize array of BigInts are returned as strings.
       skill.requestedSpaceIds.every((id) => foundSpaceIds.has(Number(id)))
     );
 

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -415,9 +415,9 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     auth: Authenticator,
     sId: string
   ): Promise<SkillResource | null> {
-    const [skill] = await this.fetchByIds(auth, [sId]);
+    const result = await this.fetchByIds(auth, [sId]);
 
-    return skill;
+    return result.at(0) ?? null;
   }
 
   static async fetchByIds(

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/index.test.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/index.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it, vi } from "vitest";
 
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { SkillConfigurationModel } from "@app/lib/models/skill";
-import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
@@ -47,6 +46,7 @@ describe("PATCH /api/w/[wId]/assistant/agent_configurations/[aId] - Skills with 
     const agent =
       await AgentConfigurationFactory.createTestAgent(authenticator);
     const restrictedSpace = await SpaceFactory.regular(workspace);
+    await restrictedSpace.addMembers(authenticator, { userIds: [user.sId] });
     const skill = await SkillConfigurationFactory.create(authenticator, {
       name: "Skill with restricted space",
     });
@@ -55,12 +55,6 @@ describe("PATCH /api/w/[wId]/assistant/agent_configurations/[aId] - Skills with 
       { requestedSpaceIds: [restrictedSpace.id] },
       { where: { id: skill.id } }
     );
-
-    const skillResource = await SkillResource.fetchByModelIdWithAuth(
-      authenticator,
-      skill.id
-    );
-    expect(skillResource).not.toBeNull();
 
     req.query = { ...req.query, wId: workspace.sId, aId: agent.sId };
     req.body = {
@@ -80,7 +74,7 @@ describe("PATCH /api/w/[wId]/assistant/agent_configurations/[aId] - Skills with 
         templateId: null,
         tags: [],
         editors: [{ sId: user.sId }],
-        skills: [{ sId: skillResource!.sId }],
+        skills: [{ sId: skill.sId }],
         additionalRequestedSpaceIds: [],
       },
     };

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.test.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.test.ts
@@ -239,6 +239,9 @@ describe("POST /api/w/[wId]/assistant/agent_configurations - Skills with restric
 
     await SpaceFactory.defaults(authenticator);
     const restrictedSpace = await SpaceFactory.regular(workspace);
+    await restrictedSpace.addMembers(authenticator, { userIds: [user.sId] });
+    await authenticator.refresh();
+
     const skill = await SkillConfigurationFactory.create(authenticator, {
       name: "Skill with restricted space",
     });

--- a/front/pages/api/w/[wId]/skills/[sId]/index.test.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.test.ts
@@ -276,14 +276,18 @@ describe("PATCH /api/w/[wId]/skills/[sId]", () => {
   });
 
   it("should update requestedSpaceIds when adding a tool from a new space", async () => {
-    const { req, res, skill, workspace, requestUserAuth } = await setupTest({
-      requestUserRole: "admin",
-      method: "PATCH",
-    });
+    const { req, res, skill, workspace, requestUser, requestUserAuth } =
+      await setupTest({
+        requestUserRole: "admin",
+        method: "PATCH",
+      });
 
     // Create two regular spaces
     const space1 = await SpaceFactory.regular(workspace);
+    await space1.addMembers(requestUserAuth, { userIds: [requestUser.sId] });
     const space2 = await SpaceFactory.regular(workspace);
+    await space2.addMembers(requestUserAuth, { userIds: [requestUser.sId] });
+    await requestUserAuth.refresh();
 
     // Create MCP servers and views in each space
     const server1 = await RemoteMCPServerFactory.create(workspace, {
@@ -337,13 +341,16 @@ describe("PATCH /api/w/[wId]/skills/[sId]", () => {
   });
 
   it("should correctly reflect updated tools in the response", async () => {
-    const { req, res, skill, workspace, requestUserAuth } = await setupTest({
-      requestUserRole: "admin",
-      method: "PATCH",
-    });
+    const { req, res, skill, workspace, requestUser, requestUserAuth } =
+      await setupTest({
+        requestUserRole: "admin",
+        method: "PATCH",
+      });
 
     // Create a regular space with an MCP server view
     const space = await SpaceFactory.regular(workspace);
+    await space.addMembers(requestUserAuth, { userIds: [requestUser.sId] });
+    await requestUserAuth.refresh();
     const server = await RemoteMCPServerFactory.create(workspace, {
       name: "Test Server",
     });

--- a/front/pages/api/w/[wId]/skills/index.test.ts
+++ b/front/pages/api/w/[wId]/skills/index.test.ts
@@ -194,6 +194,68 @@ describe("GET /api/w/[wId]/skills", () => {
       expect(skillNames).toContain(`Skill for ${role}`);
     }
   });
+
+  it("should not return skills with requestedSpaceIds user cannot access", async () => {
+    const { req, res, workspace, authenticator } = await setupTest();
+
+    // Create a skill in global space (user has access)
+    await SkillConfigurationFactory.create(authenticator, {
+      name: "Accessible Skill",
+    });
+
+    // Create a restricted space without adding user to it
+    const restrictedSpace = await SpaceFactory.regular(workspace);
+
+    // Create a skill and manually set its requestedSpaceIds to the restricted space
+    const restrictedSkill = await SkillConfigurationFactory.create(
+      authenticator,
+      { name: "Restricted Skill" }
+    );
+    await SkillConfigurationModel.update(
+      { requestedSpaceIds: [restrictedSpace.id] },
+      { where: { id: restrictedSkill.id } }
+    );
+
+    req.query = { ...req.query, wId: workspace.sId };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const skillNames = res._getJSONData().skills.map((s: SkillType) => s.name);
+    expect(skillNames).toContain("Accessible Skill");
+    expect(skillNames).not.toContain("Restricted Skill");
+  });
+
+  it("should return skills when user has access to requestedSpaceIds", async () => {
+    const { req, res, workspace, user, authenticator } = await setupTest(
+      "GET",
+      "admin"
+    );
+
+    // Required for proper group/space structure in permission checks.
+    await SpaceFactory.defaults(authenticator);
+
+    // Create a restricted space and add user to it
+    const restrictedSpace = await SpaceFactory.regular(workspace);
+    await restrictedSpace.addMembers(authenticator, { userIds: [user.sId] });
+
+    // Create a skill and set its requestedSpaceIds to the restricted space
+    const skill = await SkillConfigurationFactory.create(authenticator, {
+      name: "Skill In Restricted Space",
+    });
+    await SkillConfigurationModel.update(
+      { requestedSpaceIds: [restrictedSpace.id] },
+      { where: { id: skill.id } }
+    );
+
+    req.query = { ...req.query, wId: workspace.sId };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const skillNames = res._getJSONData().skills.map((s: SkillType) => s.name);
+    expect(skillNames).toContain("Skill In Restricted Space");
+  });
 });
 
 describe("GET /api/w/[wId]/skills?withRelations=true", () => {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Following [space restrictions QA](https://github.com/dust-tt/tasks/issues/5727), this PR adds the missing space restriction logic in the base fetch in the skill resource, to only return skills with requested spaces that the authenticated user has access to.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->
Local, with skill requesting spaces.
\+ added automated test cases

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
Low.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
Front.
