### PR TITLE
fix(dust-hive): make destroy command name argument optional

### DIFF
--- a/x/henry/dust-hive/src/index.ts
+++ b/x/henry/dust-hive/src/index.ts
@@ -133,9 +133,9 @@ cli.command("stop [name]", "Full stop of all services").action(async (name: stri
 });
 
 cli
-  .command("destroy <name>", "Remove environment")
+  .command("destroy [name]", "Remove environment")
   .option("-f, --force", "Force destroy even with uncommitted changes")
-  .action(async (name: string, options: { force?: boolean }) => {
+  .action(async (name: string | undefined, options: { force?: boolean }) => {
     await prepareAndRun(destroyCommand(name, { force: Boolean(options.force) }));
   });
 


### PR DESCRIPTION
## Description

The destroy command was using <name> (required) instead of [name] (optional), which prevented interactive environment selection from working when no argument was provided.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
