### PR TITLE
fix(dust-hive): await zellij-switch to prevent stuck terminal on open

### DIFF
--- a/x/henry/dust-hive/src/commands/open.ts
+++ b/x/henry/dust-hive/src/commands/open.ts
@@ -271,9 +271,9 @@ export const openCommand = withEnvironment("open", async (env, options: OpenOpti
       await createSessionInBackground(sessionName, layoutPath);
     }
 
-    // Switch to target session using zellij-switch plugin (fire-and-forget)
+    // Switch to target session using zellij-switch plugin
     logger.info(`Switching to session '${sessionName}'...`);
-    Bun.spawn(
+    const switchProc = Bun.spawn(
       [
         "zellij",
         "pipe",
@@ -284,6 +284,7 @@ export const openCommand = withEnvironment("open", async (env, options: OpenOpti
       ],
       { stdin: "ignore", stdout: "ignore", stderr: "ignore" }
     );
+    await switchProc.exited;
 
     return Ok(undefined);
   }


### PR DESCRIPTION
## Description

When running `dust-hive open` without an argument inside zellij, the zellij-switch plugin was spawned fire-and-forget, causing the process to exit before the switch completed. This left the original terminal pane stuck displaying "Switching to session...". Now we await the zellij pipe command to ensure proper cleanup.


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
