### PR TITLE
[front] Remove iron-session expiration

### DIFF
--- a/front/lib/api/workos/user.ts
+++ b/front/lib/api/workos/user.ts
@@ -99,6 +99,7 @@ export async function _getRefreshedCookie(
       },
       {
         password: config.getWorkOSCookiePassword(),
+        ttl: 0,
       }
     );
     return sealedCookie;

--- a/front/pages/api/workos/[action].ts
+++ b/front/pages/api/workos/[action].ts
@@ -191,6 +191,7 @@ async function handleCallback(req: NextApiRequest, res: NextApiResponse) {
 
     const sealedCookie = await sealData(sessionCookie, {
       password: config.getWorkOSCookiePassword(),
+      ttl: 0,
     });
 
     const currentRegion = multiRegionsConfig.getCurrentRegion();


### PR DESCRIPTION
## Description

Related to https://github.com/dust-tt/dust/pull/19657 - `unsealData()` returns an empty object in case of any error, which can be :
"Expired seal" - The seal has passed its TTL (time to live)
"Bad hmac value" - The seal was tampered with or encrypted with a different password
"Cannot find password" - The password used to encrypt the seal isn't in your current password map (relevant during password rotation)
"Incorrect number of sealed components" - The seal structure is malformed (e.g., if someone manually edits the cookie in DevTools)

We actually do not set a TTL when sealing the cookie, which sets it by default to 14 days - this is less than the default cookie expiration time we use (1 month). If the user returns between 14 and 30 days, they comes with an unexpired cookie contained expired seal, that can't be unsealed.

Setting TTL to 0 means no expiration, so we rely "only" on cookie expiration and workos refresh token expiration.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
