### PR TITLE
feat(files): add project_context use case and datasource infrastructure [Phase 1/3]

### DIFF
--- a/front/lib/api/data_sources.test.ts
+++ b/front/lib/api/data_sources.test.ts
@@ -1,0 +1,298 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getOrCreateProjectContextDataSourceFromFile } from "@app/lib/api/data_sources";
+import { getProjectContextDatasourceName } from "@app/lib/api/projects";
+import { Authenticator } from "@app/lib/auth";
+import { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import { FileResource } from "@app/lib/resources/file_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import type { UserResource } from "@app/lib/resources/user_resource";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import type { LightWorkspaceType } from "@app/types";
+import { CoreAPI, Ok } from "@app/types";
+
+// Mock distributed lock to avoid Redis dependency
+vi.mock("@app/lib/lock", () => ({
+  executeWithLock: vi.fn(async (_lockName, fn) => {
+    // Simply execute the function without locking in tests
+    return fn();
+  }),
+}));
+
+// Mock config to avoid requiring environment variables
+vi.mock("@app/lib/api/config", () => ({
+  default: {
+    getCoreAPIConfig: () => ({
+      url: "http://localhost:3001",
+      logger: console,
+    }),
+  },
+}));
+
+// Mock CoreAPI methods to avoid requiring the Core service
+vi.spyOn(CoreAPI.prototype, "createProject").mockImplementation(async () => {
+  return new Ok({
+    project: {
+      project_id: Math.floor(Math.random() * 1000000),
+    },
+  });
+});
+
+vi.spyOn(CoreAPI.prototype, "createDataSource").mockImplementation(
+  async ({ name }) => {
+    return new Ok({
+      data_source: {
+        created: Date.now(),
+        data_source_id: `mock-datasource-${Math.random().toString(36).substring(7)}`,
+        data_source_internal_id: `internal-${Math.random().toString(36).substring(7)}`,
+        name,
+        config: {
+          embedder_config: {
+            embedder: {
+              provider_id: "openai",
+              model_id: "text-embedding-ada-002",
+              splitter_id: "base_v0",
+              max_chunk_size: 512,
+            },
+          },
+          qdrant_config: {
+            cluster: "cluster-0",
+            shadow_write_cluster: null,
+          },
+        },
+      },
+    });
+  }
+);
+
+describe("Project Context DataSource", () => {
+  let auth: Authenticator;
+  let workspace: LightWorkspaceType;
+  let user: UserResource;
+  let space: SpaceResource;
+
+  beforeEach(async () => {
+    workspace = await WorkspaceFactory.basic();
+    user = await UserFactory.basic();
+    auth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+
+    // Create a project space
+    space = await SpaceFactory.project(workspace);
+  });
+
+  afterEach(async () => {
+    // Clean up datasources created during tests
+    const dataSources = await DataSourceResource.listByWorkspace(auth);
+    for (const ds of dataSources) {
+      if (ds.name === getProjectContextDatasourceName(space.id)) {
+        await ds.delete(auth, { hardDelete: true });
+      }
+    }
+  });
+
+  describe("getOrCreateProjectContextDataSourceFromFile", () => {
+    it("should create a new datasource for a project context file", async () => {
+      const file = await FileResource.makeNew({
+        contentType: "text/plain",
+        fileName: "test-file.txt",
+        fileSize: 1024,
+        userId: user.id,
+        workspaceId: workspace.id,
+        useCase: "project_context",
+        useCaseMetadata: {
+          spaceId: space.sId,
+        },
+      });
+
+      const result = await getOrCreateProjectContextDataSourceFromFile(
+        auth,
+        file
+      );
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        const dataSource = result.value;
+        expect(dataSource.name).toBe(getProjectContextDatasourceName(space.id));
+        expect(dataSource.vaultId).toBe(space.id);
+      }
+
+      await file.delete(auth);
+    });
+
+    it("should return the same datasource when called twice", async () => {
+      // Create two files with the same space
+      const file1 = await FileResource.makeNew({
+        contentType: "text/plain",
+        fileName: "test-file-1.txt",
+        fileSize: 1024,
+        userId: user.id,
+        workspaceId: workspace.id,
+        useCase: "project_context",
+        useCaseMetadata: {
+          spaceId: space.sId,
+        },
+      });
+
+      const file2 = await FileResource.makeNew({
+        contentType: "text/plain",
+        fileName: "test-file-2.txt",
+        fileSize: 2048,
+        userId: user.id,
+        workspaceId: workspace.id,
+        useCase: "project_context",
+        useCaseMetadata: {
+          spaceId: space.sId,
+        },
+      });
+
+      // Get datasource for both files
+      const result1 = await getOrCreateProjectContextDataSourceFromFile(
+        auth,
+        file1
+      );
+      const result2 = await getOrCreateProjectContextDataSourceFromFile(
+        auth,
+        file2
+      );
+
+      expect(result1.isOk()).toBe(true);
+      expect(result2.isOk()).toBe(true);
+
+      if (result1.isOk() && result2.isOk()) {
+        expect(result1.value.id).toBe(result2.value.id);
+        expect(result1.value.name).toBe(result2.value.name);
+      }
+
+      // Clean up
+      await file1.delete(auth);
+      await file2.delete(auth);
+    });
+
+    it("should return an error if spaceId is missing from metadata", async () => {
+      // Create a file without spaceId in metadata
+      const file = await FileResource.makeNew({
+        contentType: "text/plain",
+        fileName: "test-file.txt",
+        fileSize: 1024,
+        userId: user.id,
+        workspaceId: workspace.id,
+        useCase: "project_context",
+        useCaseMetadata: {},
+      });
+
+      // Attempt to get datasource
+      const result = await getOrCreateProjectContextDataSourceFromFile(
+        auth,
+        file
+      );
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.code).toBe("invalid_request_error");
+        expect(result.error.message).toContain("spaceId");
+      }
+
+      await file.delete(auth);
+    });
+
+    it("should create different datasources for different spaces", async () => {
+      // Create a second project space
+      const space2 = await SpaceFactory.project(workspace);
+
+      // Create files in different spaces
+      const file1 = await FileResource.makeNew({
+        contentType: "text/plain",
+        fileName: "test-file-1.txt",
+        fileSize: 1024,
+        userId: user.id,
+        workspaceId: workspace.id,
+        useCase: "project_context",
+        useCaseMetadata: {
+          spaceId: space.sId,
+        },
+      });
+
+      const file2 = await FileResource.makeNew({
+        contentType: "text/plain",
+        fileName: "test-file-2.txt",
+        fileSize: 2048,
+        userId: user.id,
+        workspaceId: workspace.id,
+        useCase: "project_context",
+        useCaseMetadata: {
+          spaceId: space2.sId,
+        },
+      });
+
+      const result1 = await getOrCreateProjectContextDataSourceFromFile(
+        auth,
+        file1
+      );
+      const result2 = await getOrCreateProjectContextDataSourceFromFile(
+        auth,
+        file2
+      );
+
+      expect(result1.isOk()).toBe(true);
+      expect(result2.isOk()).toBe(true);
+
+      if (result1.isOk() && result2.isOk()) {
+        expect(result1.value.id).not.toBe(result2.value.id);
+        expect(result1.value.name).toBe(
+          getProjectContextDatasourceName(space.id)
+        );
+        expect(result1.value.space.sId).toBe(space.sId);
+        expect(result2.value.name).toBe(
+          getProjectContextDatasourceName(space2.id)
+        );
+        expect(result2.value.space.sId).toBe(space2.sId);
+      }
+
+      // Clean up
+      await file1.delete(auth);
+      await file2.delete(auth);
+    });
+  });
+
+  describe("DataSourceResource.fetchByName", () => {
+    it("should fetch a datasource by name", async () => {
+      const file = await FileResource.makeNew({
+        contentType: "text/plain",
+        fileName: "test-file.txt",
+        fileSize: 1024,
+        userId: user.id,
+        workspaceId: workspace.id,
+        useCase: "project_context",
+        useCaseMetadata: {
+          spaceId: space.sId,
+        },
+      });
+
+      const createResult = await getOrCreateProjectContextDataSourceFromFile(
+        auth,
+        file
+      );
+      expect(createResult.isOk()).toBe(true);
+
+      if (createResult.isOk()) {
+        const fetchedDataSource = await DataSourceResource.fetchByProjectId(
+          auth,
+          space.id
+        );
+
+        expect(fetchedDataSource?.name).toBe(
+          getProjectContextDatasourceName(space.id)
+        );
+        expect(fetchedDataSource?.id).toBe(createResult.value.id);
+      }
+
+      // Clean up
+      await file.delete(auth);
+    });
+  });
+});

--- a/front/lib/api/projects.ts
+++ b/front/lib/api/projects.ts
@@ -1,0 +1,7 @@
+import type { ModelId } from "@app/types";
+
+const PROJECT_CONTEXT_DATASOURCE_NAME = "__project_context__";
+
+export const getProjectContextDatasourceName = (spaceId: ModelId) => {
+  return `${PROJECT_CONTEXT_DATASOURCE_NAME}_${spaceId}`;
+};

--- a/front/lib/resources/data_source_resource.ts
+++ b/front/lib/resources/data_source_resource.ts
@@ -8,6 +8,7 @@ import type {
 import { Op } from "sequelize";
 
 import { getDataSourceUsage } from "@app/lib/api/agent_data_sources";
+import { getProjectContextDatasourceName } from "@app/lib/api/projects";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentDataSourceConfigurationModel } from "@app/lib/models/agent/actions/data_sources";
 import { AgentTablesQueryConfigurationTableModel } from "@app/lib/models/agent/actions/tables_query";
@@ -294,6 +295,22 @@ export class DataSourceResource extends ResourceWithSpace<DataSourceModel> {
     });
 
     return dataSources;
+  }
+
+  static async fetchByProjectId(
+    auth: Authenticator,
+    spaceId: ModelId,
+    options?: FetchDataSourceOptions
+  ): Promise<DataSourceResource | null> {
+    const [dataSource] = await this.baseFetch(auth, options, {
+      where: {
+        name: getProjectContextDatasourceName(spaceId),
+        vaultId: spaceId,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+    });
+
+    return dataSource ?? null;
   }
 
   static async fetchByModelIds(

--- a/front/tests/utils/SpaceFactory.ts
+++ b/front/tests/utils/SpaceFactory.ts
@@ -77,4 +77,22 @@ export class SpaceFactory {
       []
     );
   }
+
+  static async project(workspace: WorkspaceType) {
+    const name = "project " + faker.string.alphanumeric(8);
+    const group = await GroupResource.makeNew({
+      name: `Group for space ${name}`,
+      workspaceId: workspace.id,
+      kind: "regular",
+    });
+
+    return SpaceResource.makeNew(
+      {
+        name,
+        kind: "project",
+        workspaceId: workspace.id,
+      },
+      [group]
+    );
+  }
 }

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -22,7 +22,10 @@ export type FileUseCase =
   // via the UI in a Folder). In that case, it will be stored permanently as a file
   // resource even for the upsert (no need to transit via upsert queue).
   | "folders_document"
-  | "upsert_table";
+  | "upsert_table"
+  // Project context: case in which a file is uploaded to a project's shared
+  // context datasource. Accessible to all conversations within the project.
+  | "project_context";
 
 export type FileUseCaseMetadata = {
   conversationId?: string;

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -2690,6 +2690,7 @@ const FileTypeUseCaseSchema = FlexibleEnumSchema<
   | "upsert_table"
   // See also front/types/files.ts.
   | "folders_document"
+  | "project_context"
 >();
 
 export const FileTypeSchema = z.object({


### PR DESCRIPTION
## Description

Follow the JIT conversation datasource pattern but scope to spaces:

1. **Identification:** Use deterministic naming `__project_context__{spaceId}` (numeric ID) to find/create project
   context datasources
2. **Lazy Creation:** Create datasource on first file upload using distributed lock on space ID
3. **JIT Integration:** Modify `getJITServers()` to include project context datasource views for conversations in spaces
4. **Reuse Existing Code:** Leverage `createDataSourceWithoutProvider()`, `processAndUpsertToDataSource()`, and file upload APIs

It's split in 3 phases:
1. Core Infrastructure - Add the project_context file use case and create the core function to get/create project context datasources following the JIT conversation pattern. ⬅️ this PR
2. Project Files API - Create dedicated API endpoints for project context files under `/api/w/[wId]/projects/[projectId]/files`. This provides a clean, explicit API surface separate from the generic file upload API.
3. JIT Tool Integration - Expose project context datasources to all conversations in a space through JIT tools (search, query_tables, conversation_files), enabling agents to access shared project files.


## Tests

Unit tests added

## Risk

None as it's a new endpoint

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
