### PR TITLE
feat(projects): modify files API endpoints for project context files [Phase 2/3]

### DIFF
--- a/front/lib/api/files/upload.ts
+++ b/front/lib/api/files/upload.ts
@@ -465,7 +465,7 @@ const getProcessingFunction = ({
   }
 
   if (isSupportedImageContentType(contentType)) {
-    if (useCase === "conversation") {
+    if (useCase === "conversation" || useCase === "project_context") {
       return makeResizeAndUploadImageToFileStorage(
         CONVERSATION_IMG_MAX_SIZE_PIXELS
       );
@@ -491,6 +491,7 @@ const getProcessingFunction = ({
         "folders_document",
         "upsert_table",
         "tool_output",
+        "project_context",
       ].includes(useCase)
     ) {
       return storeRawText;
@@ -500,7 +501,7 @@ const getProcessingFunction = ({
 
   if (isSupportedAudioContentType(contentType)) {
     if (
-      useCase === "conversation" &&
+      (useCase === "conversation" || useCase === "project_context") &&
       // Only handle voice transcription if the workspace has enabled it.
       auth.getNonNullableWorkspace().metadata?.allowVoiceTranscription !== false
     ) {
@@ -518,9 +519,12 @@ const getProcessingFunction = ({
     case "application/vnd.google-apps.presentation":
     case "application/pdf":
       if (
-        ["conversation", "upsert_document", "folders_document"].includes(
-          useCase
-        )
+        [
+          "conversation",
+          "upsert_document",
+          "folders_document",
+          "project_context",
+        ].includes(useCase)
       ) {
         return extractTextFromFileAndUpload;
       }
@@ -564,18 +568,19 @@ const getProcessingFunction = ({
           "upsert_document",
           "tool_output",
           "folders_document",
+          "project_context",
         ].includes(useCase)
       ) {
         return storeRawText;
       }
       break;
     case "text/vnd.dust.attachment.slack.thread":
-      if (useCase === "conversation") {
+      if (useCase === "conversation" || useCase === "project_context") {
         return storeRawText;
       }
       break;
     case "text/vnd.dust.attachment.pasted":
-      if (useCase === "conversation") {
+      if (useCase === "conversation" || useCase === "project_context") {
         return storeRawText;
       }
       break;

--- a/front/lib/api/files/upsert.ts
+++ b/front/lib/api/files/upsert.ts
@@ -435,7 +435,8 @@ const getProcessingFunction = ({
       if (
         useCase === "conversation" ||
         useCase === "tool_output" ||
-        useCase === "upsert_table"
+        useCase === "upsert_table" ||
+        useCase === "project_context"
       ) {
         return upsertTableToDatasource;
       } else if (
@@ -454,7 +455,11 @@ const getProcessingFunction = ({
       }
     case "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet":
     case "application/vnd.ms-excel":
-      if (useCase === "conversation" || useCase === "upsert_table") {
+      if (
+        useCase === "conversation" ||
+        useCase === "upsert_table" ||
+        useCase === "project_context"
+      ) {
         return upsertExcelToDatasource;
       } else if (
         useCase === "upsert_document" ||
@@ -467,7 +472,11 @@ const getProcessingFunction = ({
   }
 
   if (isSupportedAudioContentType(contentType)) {
-    if (useCase === "conversation" || useCase === "upsert_document") {
+    if (
+      useCase === "conversation" ||
+      useCase === "upsert_document" ||
+      useCase === "project_context"
+    ) {
       return upsertDocumentToDatasource;
     }
     return undefined;
@@ -480,6 +489,7 @@ const getProcessingFunction = ({
       "tool_output",
       "upsert_document",
       "folders_document",
+      "project_context",
     ].includes(useCase)
   ) {
     return upsertDocumentToDatasource;

--- a/front/lib/api/tables.ts
+++ b/front/lib/api/tables.ts
@@ -135,7 +135,12 @@ export async function upsertTableFromCsv({
       });
     }
 
-    const VALID_USE_CASES = ["upsert_table", "conversation", "tool_output"];
+    const VALID_USE_CASES = [
+      "upsert_table",
+      "conversation",
+      "tool_output",
+      "project_context",
+    ];
     if (!VALID_USE_CASES.includes(file.useCase)) {
       return new Err({
         type: "invalid_request_error",

--- a/front/pages/api/w/[wId]/files/index.ts
+++ b/front/pages/api/w/[wId]/files/index.ts
@@ -56,6 +56,15 @@ const FileUploadUrlRequestSchema = t.union([
       t.undefined,
     ]),
   }),
+  t.type({
+    contentType: t.string,
+    fileName: t.string,
+    fileSize: t.number,
+    useCase: t.literal("project_context"),
+    useCaseMetadata: t.type({
+      spaceId: t.string,
+    }),
+  }),
 ]);
 
 export interface FileUploadRequestResponseBody {


### PR DESCRIPTION
## Description

Follow the JIT conversation datasource pattern but scope to spaces:

1. **Identification:** Use deterministic naming `__project_context__{spaceId}` (numeric ID) to find/create project
   context datasources
2. **Lazy Creation:** Create datasource on first file upload using distributed lock on space ID
3. **JIT Integration:** Modify `getJITServers()` to include project context datasource views for conversations in spaces
4. **Reuse Existing Code:** Leverage `createDataSourceWithoutProvider()`, `processAndUpsertToDataSource()`, and file upload APIs

It's split in 3 phases:
1. Core Infrastructure - Add the project_context file use case and create the core function to get/create project context datasources following the JIT conversation pattern.
2. Project Files API - Update files API endpoints for project context files under   ⬅️ this PR
3. JIT Tool Integration - Expose project context datasources to all conversations in a space through JIT tools (search, query_tables, conversation_files), enabling agents to access shared project files.


## Tests

Unit tests added

## Risk

None as it's a new endpoint

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
