### PR TITLE
[front] fix(reactions): close `MessageEmojiPicker` on clicks outside of it

### DIFF
--- a/front/components/assistant/conversation/MessageEmojiPicker.tsx
+++ b/front/components/assistant/conversation/MessageEmojiPicker.tsx
@@ -23,7 +23,7 @@ export function MessageEmojiPicker({ onEmojiSelect }: MessageEmojiPickerProps) {
   const theme = useTheme();
 
   return (
-    <PopoverRoot open={isOpen}>
+    <PopoverRoot open={isOpen} onOpenChange={setIsOpen}>
       <PopoverTrigger asChild>
         <Button
           key="emoji-picker-button"


### PR DESCRIPTION
## Description

If the `MessageEmojiPicker` is opened, clicks outside of it do not close it.
This PR fixes that.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
