### PR TITLE
fix(dust-hive): unref stdin after interactive prompt to allow exit

### DIFF
--- a/x/henry/dust-hive/src/lib/prompt.ts
+++ b/x/henry/dust-hive/src/lib/prompt.ts
@@ -19,10 +19,11 @@ export interface SelectEnvironmentOptions {
  * IMPORTANT: Call this before spawning any subprocess that takes over the terminal
  * (like zellij) to prevent terminal corruption.
  *
- * This does three things:
+ * This does four things:
  * 1. Exits raw mode (restores cooked mode)
  * 2. Pauses stdin to stop reading
  * 3. Removes all listeners that clack may have attached
+ * 4. Unrefs stdin so it doesn't keep the event loop alive
  */
 export function restoreTerminal(): void {
   try {
@@ -40,6 +41,10 @@ export function restoreTerminal(): void {
     process.stdin.removeAllListeners("data");
     process.stdin.removeAllListeners("keypress");
     process.stdin.removeAllListeners("readable");
+
+    // Unref stdin so it doesn't keep the event loop alive
+    // This allows the process to exit naturally after interactive prompts
+    process.stdin.unref();
   } catch {
     // Ignore errors - best effort cleanup
   }


### PR DESCRIPTION
## Description

After interactive selection with @clack/prompts, stdin remains in the event loop even after pausing and removing listeners. This prevented commands like `dust-hive destroy` from exiting after completion when using interactive mode.

Adding process.stdin.unref() tells the runtime not to keep the process alive just for stdin, allowing natural exit after all work completes.
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
