### PR TITLE
fix(dust-hive): consume streams to prevent hang on destroy/reload

### DIFF
--- a/x/henry/dust-hive/src/commands/destroy.ts
+++ b/x/henry/dust-hive/src/commands/destroy.ts
@@ -20,6 +20,11 @@ async function cleanupZellijSession(envName: string): Promise<void> {
     stdout: "pipe",
     stderr: "pipe",
   });
+  // Consume pipes to prevent hanging the event loop
+  await Promise.all([
+    new Response(killProc.stdout).text(),
+    new Response(killProc.stderr).text(),
+  ]);
   await killProc.exited;
 
   // Then delete it (removes from list)
@@ -27,6 +32,11 @@ async function cleanupZellijSession(envName: string): Promise<void> {
     stdout: "pipe",
     stderr: "pipe",
   });
+  // Consume pipes to prevent hanging the event loop
+  await Promise.all([
+    new Response(deleteProc.stdout).text(),
+    new Response(deleteProc.stderr).text(),
+  ]);
   await deleteProc.exited;
 }
 

--- a/x/henry/dust-hive/src/commands/reload.ts
+++ b/x/henry/dust-hive/src/commands/reload.ts
@@ -18,6 +18,11 @@ export const reloadCommand = withEnvironment("reload", async (env) => {
     stdout: "pipe",
     stderr: "pipe",
   });
+  // Consume pipes to prevent hanging the event loop
+  await Promise.all([
+    new Response(killProc.stdout).text(),
+    new Response(killProc.stderr).text(),
+  ]);
   await killProc.exited;
 
   // Then delete it (removes from list)
@@ -25,6 +30,11 @@ export const reloadCommand = withEnvironment("reload", async (env) => {
     stdout: "pipe",
     stderr: "pipe",
   });
+  // Consume pipes to prevent hanging the event loop
+  await Promise.all([
+    new Response(deleteProc.stdout).text(),
+    new Response(deleteProc.stderr).text(),
+  ]);
   await deleteProc.exited;
 
   // Remove old layout


### PR DESCRIPTION
## Description

Spawned zellij processes used stdout/stderr pipes but never consumed them. Even after `await proc.exited`, unconsumed pipe handles keep the event loop alive indefinitely. Fix by consuming pipes before awaiting exit.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
