### PR TITLE
[front] - chore(SkillInfoTab): knowledge node view in sheet

### DIFF
--- a/front/components/agent_builder/SpacesContext.tsx
+++ b/front/components/agent_builder/SpacesContext.tsx
@@ -6,6 +6,7 @@ import { useSpaces } from "@app/lib/swr/spaces";
 import type { LightWorkspaceType, SpaceType } from "@app/types";
 
 interface SpacesContextType {
+  owner: LightWorkspaceType;
   spaces: SpaceType[];
   isSpacesLoading: boolean;
   isSpacesError: boolean;
@@ -44,11 +45,12 @@ export const SpacesProvider = ({ owner, children }: SpacesProviderProps) => {
 
   const value: SpacesContextType = useMemo(
     () => ({
+      owner,
       spaces,
       isSpacesLoading,
       isSpacesError,
     }),
-    [spaces, isSpacesLoading, isSpacesError]
+    [owner, spaces, isSpacesLoading, isSpacesError]
   );
 
   return (

--- a/front/components/editor/SkillInstructionsEditor.tsx
+++ b/front/components/editor/SkillInstructionsEditor.tsx
@@ -157,10 +157,8 @@ export function useSkillInstructionsEditor({
       extensions,
       editable: !isReadOnly,
       immediatelyRender: false,
-      onUpdate: onUpdate
-        ? ({ editor, transaction }) => onUpdate({ editor, transaction })
-        : undefined,
-      onBlur: onBlur ? () => onBlur() : undefined,
+      onUpdate,
+      onBlur,
       onDelete: onDelete ? ({ editor }) => onDelete(editor) : undefined,
     },
     [extensions, isReadOnly]

--- a/front/components/editor/SkillInstructionsEditor.tsx
+++ b/front/components/editor/SkillInstructionsEditor.tsx
@@ -4,6 +4,7 @@ import { Markdown } from "@tiptap/markdown";
 import type { Editor, Extensions } from "@tiptap/react";
 import { EditorContent, useEditor } from "@tiptap/react";
 import { StarterKit } from "@tiptap/starter-kit";
+import type { Transaction } from "@tiptap/pm/state";
 import { useEffect, useMemo, useRef } from "react";
 
 import { AgentInstructionDiffExtension } from "@app/components/editor/extensions/agent_builder/AgentInstructionDiffExtension";
@@ -131,7 +132,7 @@ function useEditorService(editor: Editor | null) {
 interface UseSkillInstructionsEditorProps {
   content: string;
   isReadOnly: boolean;
-  onUpdate?: (editor: Editor) => void;
+  onUpdate?: (props: { editor: Editor; transaction: Transaction }) => void;
   onBlur?: () => void;
   onDelete?: (editor: Editor) => void;
 }
@@ -157,11 +158,7 @@ export function useSkillInstructionsEditor({
       editable: !isReadOnly,
       immediatelyRender: false,
       onUpdate: onUpdate
-        ? ({ editor, transaction }) => {
-            if (transaction.docChanged) {
-              onUpdate(editor);
-            }
-          }
+        ? ({ editor, transaction }) => onUpdate({ editor, transaction })
         : undefined,
       onBlur: onBlur ? () => onBlur() : undefined,
       onDelete: onDelete ? ({ editor }) => onDelete(editor) : undefined,

--- a/front/components/editor/SkillInstructionsEditor.tsx
+++ b/front/components/editor/SkillInstructionsEditor.tsx
@@ -4,7 +4,7 @@ import { Markdown } from "@tiptap/markdown";
 import type { Editor, Extensions } from "@tiptap/react";
 import { EditorContent, useEditor } from "@tiptap/react";
 import { StarterKit } from "@tiptap/starter-kit";
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 
 import { AgentInstructionDiffExtension } from "@app/components/editor/extensions/agent_builder/AgentInstructionDiffExtension";
 import { ListItemExtension } from "@app/components/editor/extensions/ListItemExtension";
@@ -14,101 +14,146 @@ import { SlashCommandExtension } from "@app/components/editor/extensions/skill_b
 
 export const INSTRUCTIONS_MAXIMUM_CHARACTER_COUNT = 120_000;
 
-interface SkillInstructionsEditorProps {
+export function buildSkillInstructionsExtensions(
+  isReadOnly: boolean
+): Extensions {
+  const baseExtensions: Extensions = [
+    Markdown,
+    StarterKit.configure({
+      orderedList: false,
+      listItem: false,
+      bulletList: {
+        HTMLAttributes: {
+          class: markdownStyles.unorderedList(),
+        },
+      },
+      blockquote: false,
+      horizontalRule: false,
+      strike: false,
+      code: {
+        HTMLAttributes: {
+          class: markdownStyles.codeBlock(),
+        },
+      },
+      codeBlock: {
+        HTMLAttributes: {
+          class: markdownStyles.codeBlock(),
+        },
+      },
+      paragraph: {
+        HTMLAttributes: {
+          class: markdownStyles.paragraph(),
+        },
+      },
+    }),
+    KnowledgeNode,
+    OrderedListExtension.configure({
+      HTMLAttributes: {
+        class: markdownStyles.orderedList(),
+      },
+    }),
+    ListItemExtension.configure({
+      HTMLAttributes: {
+        class: markdownStyles.list(),
+      },
+    }),
+  ];
+
+  if (!isReadOnly) {
+    baseExtensions.push(
+      SlashCommandExtension,
+      AgentInstructionDiffExtension,
+      Placeholder.configure({
+        placeholder: "What does this skill do? How should it behave?",
+        emptyNodeClass:
+          "first:before:text-gray-400 first:before:italic first:before:content-[attr(data-placeholder)] first:before:pointer-events-none first:before:absolute",
+      }),
+      CharacterCount.configure({
+        limit: INSTRUCTIONS_MAXIMUM_CHARACTER_COUNT,
+      })
+    );
+  }
+
+  return baseExtensions;
+}
+
+function useEditorService(editor: Editor | null) {
+  return useMemo(() => {
+    return {
+      getMarkdown() {
+        return editor?.getMarkdown() ?? "";
+      },
+
+      setContent(content: string) {
+        editor?.commands.setContent(content, {
+          emitUpdate: false,
+          contentType: "markdown",
+        });
+      },
+
+      setEditable(editable: boolean) {
+        editor?.setEditable(editable);
+      },
+
+      setClass(className: string) {
+        editor?.setOptions({
+          editorProps: {
+            attributes: {
+              class: className,
+            },
+          },
+        });
+      },
+
+      applyDiff(oldText: string, newText: string) {
+        editor?.commands.applyDiff(oldText, newText);
+      },
+
+      exitDiff() {
+        editor?.commands.exitDiff();
+      },
+
+      isDiffMode() {
+        return editor?.storage.agentInstructionDiff?.isDiffMode ?? false;
+      },
+
+      isFocused() {
+        return editor?.isFocused ?? false;
+      },
+
+      isDestroyed() {
+        return editor?.isDestroyed ?? true;
+      },
+    };
+  }, [editor]);
+}
+
+interface UseSkillInstructionsEditorProps {
   content: string;
   isReadOnly: boolean;
-  className?: string;
   onUpdate?: (editor: Editor) => void;
   onBlur?: () => void;
   onDelete?: (editor: Editor) => void;
 }
 
-export function useSkillInstructionsExtensions(
-  isReadOnly: boolean
-): Extensions {
-  return useMemo(() => {
-    const baseExtensions: Extensions = [
-      Markdown,
-      StarterKit.configure({
-        orderedList: false,
-        listItem: false,
-        bulletList: {
-          HTMLAttributes: {
-            class: markdownStyles.unorderedList(),
-          },
-        },
-        blockquote: false,
-        horizontalRule: false,
-        strike: false,
-        code: {
-          HTMLAttributes: {
-            class: markdownStyles.codeBlock(),
-          },
-        },
-        codeBlock: {
-          HTMLAttributes: {
-            class: markdownStyles.codeBlock(),
-          },
-        },
-        paragraph: {
-          HTMLAttributes: {
-            class: markdownStyles.paragraph(),
-          },
-        },
-      }),
-      KnowledgeNode,
-      OrderedListExtension.configure({
-        HTMLAttributes: {
-          class: markdownStyles.orderedList(),
-        },
-      }),
-      ListItemExtension.configure({
-        HTMLAttributes: {
-          class: markdownStyles.list(),
-        },
-      }),
-    ];
-
-    if (!isReadOnly) {
-      baseExtensions.push(
-        SlashCommandExtension,
-        AgentInstructionDiffExtension,
-        Placeholder.configure({
-          placeholder: "What does this skill do? How should it behave?",
-          emptyNodeClass:
-            "first:before:text-gray-400 first:before:italic first:before:content-[attr(data-placeholder)] first:before:pointer-events-none first:before:absolute",
-        }),
-        CharacterCount.configure({
-          limit: INSTRUCTIONS_MAXIMUM_CHARACTER_COUNT,
-        })
-      );
-    }
-
-    return baseExtensions;
-  }, [isReadOnly]);
-}
-
-const readOnlyStyles = cn(
-  "min-h-60 w-full min-w-0 rounded-xl border p-3",
-  "border-border bg-muted-background",
-  "dark:border-border-night dark:bg-muted-background-night"
-);
-
-export function SkillInstructionsEditor({
+export function useSkillInstructionsEditor({
   content,
   isReadOnly,
-  className,
   onUpdate,
   onBlur,
   onDelete,
-}: SkillInstructionsEditorProps) {
-  const extensions = useSkillInstructionsExtensions(isReadOnly);
+}: UseSkillInstructionsEditorProps) {
+  const extensions = useMemo(
+    () => buildSkillInstructionsExtensions(isReadOnly),
+    [isReadOnly]
+  );
+
+  // Track if initial content has been set
+  const initialContentSetRef = useRef(false);
 
   const editor = useEditor(
     {
       extensions,
-      content: content || undefined,
-      contentType: "markdown",
       editable: !isReadOnly,
       immediatelyRender: false,
       onUpdate: onUpdate
@@ -124,13 +169,48 @@ export function SkillInstructionsEditor({
     [extensions, isReadOnly]
   );
 
-  if (isReadOnly) {
-    return (
-      <div className={className ?? readOnlyStyles}>
-        <EditorContent editor={editor} />
-      </div>
-    );
-  }
+  const editorService = useEditorService(editor);
 
-  return <EditorContent editor={editor} className={className} />;
+  // Set initial content after editor is created (markdown must be set via setContent)
+  useEffect(() => {
+    if (editor && content && !initialContentSetRef.current) {
+      editor.commands.setContent(content, {
+        emitUpdate: false,
+        contentType: "markdown",
+      });
+      initialContentSetRef.current = true;
+    }
+  }, [editor, content]);
+
+  return { editor, editorService };
+}
+
+const readOnlyStyles = cn(
+  "min-h-60 w-full min-w-0 rounded-xl border p-3",
+  "border-border bg-muted-background",
+  "dark:border-border-night dark:bg-muted-background-night"
+);
+
+interface SkillInstructionsEditorContentProps {
+  editor: Editor | null;
+  isReadOnly: boolean;
+  className?: string;
+}
+
+export function SkillInstructionsEditorContent({
+  editor,
+  isReadOnly,
+  className,
+}: SkillInstructionsEditorContentProps) {
+  return (
+    <>
+      {isReadOnly ? (
+        <div className={cn(className, readOnlyStyles)}>
+          <EditorContent editor={editor} />
+        </div>
+      ) : (
+        <EditorContent editor={editor} className={className} />
+      )}
+    </>
+  );
 }

--- a/front/components/editor/SkillInstructionsEditor.tsx
+++ b/front/components/editor/SkillInstructionsEditor.tsx
@@ -1,0 +1,136 @@
+import { cn, markdownStyles } from "@dust-tt/sparkle";
+import { CharacterCount, Placeholder } from "@tiptap/extensions";
+import { Markdown } from "@tiptap/markdown";
+import type { Editor, Extensions } from "@tiptap/react";
+import { EditorContent, useEditor } from "@tiptap/react";
+import { StarterKit } from "@tiptap/starter-kit";
+import { useMemo } from "react";
+
+import { AgentInstructionDiffExtension } from "@app/components/editor/extensions/agent_builder/AgentInstructionDiffExtension";
+import { ListItemExtension } from "@app/components/editor/extensions/ListItemExtension";
+import { OrderedListExtension } from "@app/components/editor/extensions/OrderedListExtension";
+import { KnowledgeNode } from "@app/components/editor/extensions/skill_builder/KnowledgeNode";
+import { SlashCommandExtension } from "@app/components/editor/extensions/skill_builder/SlashCommandExtension";
+
+export const INSTRUCTIONS_MAXIMUM_CHARACTER_COUNT = 120_000;
+
+interface SkillInstructionsEditorProps {
+  content: string;
+  isReadOnly: boolean;
+  className?: string;
+  onUpdate?: (editor: Editor) => void;
+  onBlur?: () => void;
+  onDelete?: (editor: Editor) => void;
+}
+
+export function useSkillInstructionsExtensions(
+  isReadOnly: boolean
+): Extensions {
+  return useMemo(() => {
+    const baseExtensions: Extensions = [
+      Markdown,
+      StarterKit.configure({
+        orderedList: false,
+        listItem: false,
+        bulletList: {
+          HTMLAttributes: {
+            class: markdownStyles.unorderedList(),
+          },
+        },
+        blockquote: false,
+        horizontalRule: false,
+        strike: false,
+        code: {
+          HTMLAttributes: {
+            class: markdownStyles.codeBlock(),
+          },
+        },
+        codeBlock: {
+          HTMLAttributes: {
+            class: markdownStyles.codeBlock(),
+          },
+        },
+        paragraph: {
+          HTMLAttributes: {
+            class: markdownStyles.paragraph(),
+          },
+        },
+      }),
+      KnowledgeNode,
+      OrderedListExtension.configure({
+        HTMLAttributes: {
+          class: markdownStyles.orderedList(),
+        },
+      }),
+      ListItemExtension.configure({
+        HTMLAttributes: {
+          class: markdownStyles.list(),
+        },
+      }),
+    ];
+
+    if (!isReadOnly) {
+      baseExtensions.push(
+        SlashCommandExtension,
+        AgentInstructionDiffExtension,
+        Placeholder.configure({
+          placeholder: "What does this skill do? How should it behave?",
+          emptyNodeClass:
+            "first:before:text-gray-400 first:before:italic first:before:content-[attr(data-placeholder)] first:before:pointer-events-none first:before:absolute",
+        }),
+        CharacterCount.configure({
+          limit: INSTRUCTIONS_MAXIMUM_CHARACTER_COUNT,
+        })
+      );
+    }
+
+    return baseExtensions;
+  }, [isReadOnly]);
+}
+
+const readOnlyStyles = cn(
+  "min-h-60 w-full min-w-0 rounded-xl border p-3",
+  "border-border bg-muted-background",
+  "dark:border-border-night dark:bg-muted-background-night"
+);
+
+export function SkillInstructionsEditor({
+  content,
+  isReadOnly,
+  className,
+  onUpdate,
+  onBlur,
+  onDelete,
+}: SkillInstructionsEditorProps) {
+  const extensions = useSkillInstructionsExtensions(isReadOnly);
+
+  const editor = useEditor(
+    {
+      extensions,
+      content: content || undefined,
+      contentType: "markdown",
+      editable: !isReadOnly,
+      immediatelyRender: false,
+      onUpdate: onUpdate
+        ? ({ editor, transaction }) => {
+            if (transaction.docChanged) {
+              onUpdate(editor);
+            }
+          }
+        : undefined,
+      onBlur: onBlur ? () => onBlur() : undefined,
+      onDelete: onDelete ? ({ editor }) => onDelete(editor) : undefined,
+    },
+    [extensions, isReadOnly]
+  );
+
+  if (isReadOnly) {
+    return (
+      <div className={className ?? readOnlyStyles}>
+        <EditorContent editor={editor} />
+      </div>
+    );
+  }
+
+  return <EditorContent editor={editor} className={className} />;
+}

--- a/front/components/editor/SkillInstructionsEditor.tsx
+++ b/front/components/editor/SkillInstructionsEditor.tsx
@@ -1,10 +1,10 @@
 import { cn, markdownStyles } from "@dust-tt/sparkle";
 import { CharacterCount, Placeholder } from "@tiptap/extensions";
 import { Markdown } from "@tiptap/markdown";
+import type { Transaction } from "@tiptap/pm/state";
 import type { Editor, Extensions } from "@tiptap/react";
 import { EditorContent, useEditor } from "@tiptap/react";
 import { StarterKit } from "@tiptap/starter-kit";
-import type { Transaction } from "@tiptap/pm/state";
 import { useEffect, useMemo, useRef } from "react";
 
 import { AgentInstructionDiffExtension } from "@app/components/editor/extensions/agent_builder/AgentInstructionDiffExtension";

--- a/front/components/editor/extensions/skill_builder/KnowledgeChip.tsx
+++ b/front/components/editor/extensions/skill_builder/KnowledgeChip.tsx
@@ -49,7 +49,7 @@ export function KnowledgeChip({ node, title, onRemove }: KnowledgeChipProps) {
 
 interface KnowledgeErrorChipProps {
   errorMessage?: string;
-  onRemove: () => void;
+  onRemove?: () => void;
   title: string;
 }
 

--- a/front/components/editor/extensions/skill_builder/KnowledgeNodeView.tsx
+++ b/front/components/editor/extensions/skill_builder/KnowledgeNodeView.tsx
@@ -79,7 +79,6 @@ export function KnowledgeDisplayComponent({
   // Update the item with fetched node data.
   useEffect(() => {
     if (
-      updateAttributes &&
       needsFetch &&
       fetchedNodes &&
       fetchedNodes.length > 0 &&

--- a/front/components/editor/extensions/skill_builder/KnowledgeNodeView.tsx
+++ b/front/components/editor/extensions/skill_builder/KnowledgeNodeView.tsx
@@ -41,21 +41,22 @@ import { isFolder, isWebsite } from "@app/lib/data_sources";
 import { useDataSourceViewContentNodes } from "@app/lib/swr/data_source_views";
 import { useUnifiedSearch } from "@app/lib/swr/search";
 import { useSpaceDataSourceView, useSpaces } from "@app/lib/swr/spaces";
+import type { LightWorkspaceType } from "@app/types";
 import { removeNulls } from "@app/types";
 
 interface KnowledgeDisplayProps {
   item: KnowledgeItem;
-  onRemove: () => void;
-  updateAttributes: (attrs: Partial<KnowledgeNodeAttributes>) => void;
+  owner: LightWorkspaceType;
+  onRemove?: () => void;
+  updateAttributes?: (attrs: Partial<KnowledgeNodeAttributes>) => void;
 }
 
-function KnowledgeDisplayComponent({
+export function KnowledgeDisplayComponent({
   item,
+  owner,
   onRemove,
   updateAttributes,
 }: KnowledgeDisplayProps) {
-  const { owner } = useSkillBuilderContext();
-
   // Check if we need to fetch full node data.
   const needsFetch = !isFullKnowledgeItem(item);
 
@@ -78,6 +79,7 @@ function KnowledgeDisplayComponent({
   // Update the item with fetched node data.
   useEffect(() => {
     if (
+      updateAttributes &&
       needsFetch &&
       fetchedNodes &&
       fetchedNodes.length > 0 &&
@@ -466,6 +468,7 @@ export const KnowledgeNodeView: React.FC<ExtendedNodeViewProps> = ({
   node,
   updateAttributes,
 }) => {
+  const { owner } = useSkillBuilderContext();
   const { selectedItems } = node.attrs as KnowledgeNodeAttributes;
 
   const handleRemove = useCallback(
@@ -498,8 +501,9 @@ export const KnowledgeNodeView: React.FC<ExtendedNodeViewProps> = ({
       <NodeViewWrapper className="inline">
         <KnowledgeDisplayComponent
           item={selectedItems[0]}
-          onRemove={handleRemove}
-          updateAttributes={updateAttributes}
+          owner={owner}
+          onRemove={editor.isEditable ? handleRemove : undefined}
+          updateAttributes={editor.isEditable ? updateAttributes : undefined}
         />
       </NodeViewWrapper>
     );

--- a/front/components/editor/extensions/skill_builder/KnowledgeNodeView.tsx
+++ b/front/components/editor/extensions/skill_builder/KnowledgeNodeView.tsx
@@ -48,7 +48,7 @@ interface KnowledgeDisplayProps {
   item: KnowledgeItem;
   owner: LightWorkspaceType;
   onRemove?: () => void;
-  updateAttributes?: (attrs: Partial<KnowledgeNodeAttributes>) => void;
+  updateAttributes: (attrs: Partial<KnowledgeNodeAttributes>) => void;
 }
 
 export function KnowledgeDisplayComponent({
@@ -503,7 +503,7 @@ export const KnowledgeNodeView: React.FC<ExtendedNodeViewProps> = ({
           item={selectedItems[0]}
           owner={owner}
           onRemove={editor.isEditable ? handleRemove : undefined}
-          updateAttributes={editor.isEditable ? updateAttributes : undefined}
+          updateAttributes={updateAttributes}
         />
       </NodeViewWrapper>
     );

--- a/front/components/editor/extensions/skill_builder/KnowledgeNodeView.tsx
+++ b/front/components/editor/extensions/skill_builder/KnowledgeNodeView.tsx
@@ -18,6 +18,7 @@ import React, {
   useState,
 } from "react";
 
+import { useSpacesContext } from "@app/components/agent_builder/SpacesContext";
 import {
   KnowledgeChip,
   KnowledgeErrorChip,
@@ -31,7 +32,6 @@ import {
   computeHasChildren,
   isFullKnowledgeItem,
 } from "@app/components/editor/extensions/skill_builder/KnowledgeNode";
-import { useSkillBuilderContext } from "@app/components/skill_builder/SkillBuilderContext";
 import { getConnectorProviderLogoWithFallback } from "@app/lib/connector_providers_ui";
 import {
   getLocationForDataSourceViewContentNodeWithSpace,
@@ -157,7 +157,7 @@ function KnowledgeSearchComponent({
   onCancel,
   clientRect,
 }: KnowledgeSearchProps) {
-  const { owner } = useSkillBuilderContext();
+  const { owner } = useSpacesContext();
   const [isOpen, setIsOpen] = useState(false);
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [searchQuery, setSearchQuery] = useState("");
@@ -468,7 +468,7 @@ export const KnowledgeNodeView: React.FC<ExtendedNodeViewProps> = ({
   node,
   updateAttributes,
 }) => {
-  const { owner } = useSkillBuilderContext();
+  const { owner } = useSpacesContext();
   const { selectedItems } = node.attrs as KnowledgeNodeAttributes;
 
   const handleRemove = useCallback(

--- a/front/components/skill_builder/SkillBuilderContext.tsx
+++ b/front/components/skill_builder/SkillBuilderContext.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import { createContext, useContext } from "react";
 
 import { SpacesProvider } from "@app/components/agent_builder/SpacesContext";
+import { KnowledgeOwnerProvider } from "@app/components/editor/extensions/skill_builder/KnowledgeOwnerContext";
 import { MCPServerViewsProvider } from "@app/components/shared/tools_picker/MCPServerViewsContext";
 import type { UserType, WorkspaceType } from "@app/types";
 
@@ -30,11 +31,13 @@ export function SkillBuilderProvider({
 }: SkillBuilderProviderProps) {
   return (
     <SkillBuilderContext.Provider value={{ owner, user, skillId }}>
-      <SpacesProvider owner={owner}>
-        <MCPServerViewsProvider owner={owner}>
-          {children}
-        </MCPServerViewsProvider>
-      </SpacesProvider>
+      <KnowledgeOwnerProvider owner={owner}>
+        <SpacesProvider owner={owner}>
+          <MCPServerViewsProvider owner={owner}>
+            {children}
+          </MCPServerViewsProvider>
+        </SpacesProvider>
+      </KnowledgeOwnerProvider>
     </SkillBuilderContext.Provider>
   );
 }

--- a/front/components/skill_builder/SkillBuilderContext.tsx
+++ b/front/components/skill_builder/SkillBuilderContext.tsx
@@ -2,7 +2,6 @@ import type { ReactNode } from "react";
 import { createContext, useContext } from "react";
 
 import { SpacesProvider } from "@app/components/agent_builder/SpacesContext";
-import { KnowledgeOwnerProvider } from "@app/components/editor/extensions/skill_builder/KnowledgeOwnerContext";
 import { MCPServerViewsProvider } from "@app/components/shared/tools_picker/MCPServerViewsContext";
 import type { UserType, WorkspaceType } from "@app/types";
 
@@ -31,13 +30,11 @@ export function SkillBuilderProvider({
 }: SkillBuilderProviderProps) {
   return (
     <SkillBuilderContext.Provider value={{ owner, user, skillId }}>
-      <KnowledgeOwnerProvider owner={owner}>
-        <SpacesProvider owner={owner}>
-          <MCPServerViewsProvider owner={owner}>
-            {children}
-          </MCPServerViewsProvider>
-        </SpacesProvider>
-      </KnowledgeOwnerProvider>
+      <SpacesProvider owner={owner}>
+        <MCPServerViewsProvider owner={owner}>
+          {children}
+        </MCPServerViewsProvider>
+      </SpacesProvider>
     </SkillBuilderContext.Provider>
   );
 }

--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -1,3 +1,4 @@
+import { AttachmentIcon, Button } from "@dust-tt/sparkle";
 import type { Editor } from "@tiptap/react";
 import { cva } from "class-variance-authority";
 import debounce from "lodash/debounce";
@@ -67,8 +68,12 @@ export function SkillBuilderInstructionsEditor({
   const displayError =
     !!instructionsFieldState.error || !!attachedKnowledgeFieldState.error;
 
+  // Helper function to extract attached knowledge and update form.
   const extractAttachedKnowledge = useCallback((editorInstance: Editor) => {
     const knowledgeItems: KnowledgeItem[] = [];
+
+    // Use TipTap's document traversal API to recursively find all knowledge nodes.
+    // Note: $nodes() only searches top-level nodes, not nested inline nodes.
     const { state } = editorInstance;
     const { doc } = state;
 
@@ -134,6 +139,12 @@ export function SkillBuilderInstructionsEditor({
     onBlur: handleBlur,
     onDelete: handleDelete,
   });
+
+  const handleAddKnowledge = useCallback(() => {
+    if (editor) {
+      editor.chain().focus().insertKnowledgeNode().run();
+    }
+  }, [editor]);
 
   useEffect(() => {
     return () => {
@@ -201,6 +212,16 @@ export function SkillBuilderInstructionsEditor({
   return (
     <div className="relative space-y-1 p-px">
       <SkillInstructionsEditorContent editor={editor} isReadOnly={false} />
+      <Button
+        size="xs"
+        variant="ghost"
+        icon={AttachmentIcon}
+        onClick={handleAddKnowledge}
+        className="absolute bottom-2 left-2"
+        tooltip="Add knowledge"
+        disabled={!editor}
+      />
+
       {instructionsFieldState.error && (
         <div className="dark:text-warning-night ml-2 text-xs text-warning">
           {instructionsFieldState.error.message}

--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -1,4 +1,5 @@
 import { AttachmentIcon, Button } from "@dust-tt/sparkle";
+import type { Transaction } from "@tiptap/pm/state";
 import type { Editor } from "@tiptap/react";
 import { cva } from "class-variance-authority";
 import debounce from "lodash/debounce";
@@ -90,6 +91,7 @@ export function SkillBuilderInstructionsEditor({
   const updateAttachedKnowledge = useCallback(
     (editor: Editor) => {
       const attachedKnowledge = extractAttachedKnowledge(editor);
+      // Transform for form storage.
       const transformedAttachments = attachedKnowledge.map((item) => ({
         dataSourceViewId: item.dataSourceViewId,
         nodeId: item.nodeId, // This is the node ID from the data source view content node.
@@ -113,8 +115,10 @@ export function SkillBuilderInstructionsEditor({
   );
 
   const handleUpdate = useCallback(
-    (editor: Editor) => {
-      debouncedUpdate(editor);
+    ({ editor, transaction }: { editor: Editor; transaction: Transaction }) => {
+      if (transaction.docChanged) {
+        debouncedUpdate(editor);
+      }
     },
     [debouncedUpdate]
   );

--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -1,28 +1,17 @@
-import { AttachmentIcon, Button, markdownStyles } from "@dust-tt/sparkle";
-import { CharacterCount, Placeholder } from "@tiptap/extensions";
-import { Markdown } from "@tiptap/markdown";
+import { AttachmentIcon, Button } from "@dust-tt/sparkle";
 import type { Editor } from "@tiptap/react";
 import { EditorContent, useEditor } from "@tiptap/react";
-import { StarterKit } from "@tiptap/starter-kit";
 import { cva } from "class-variance-authority";
 import debounce from "lodash/debounce";
-import React, { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { useController } from "react-hook-form";
 
-import { AgentInstructionDiffExtension } from "@app/components/editor/extensions/agent_builder/AgentInstructionDiffExtension";
-import { ListItemExtension } from "@app/components/editor/extensions/ListItemExtension";
-import { OrderedListExtension } from "@app/components/editor/extensions/OrderedListExtension";
 import type { KnowledgeItem } from "@app/components/editor/extensions/skill_builder/KnowledgeNode";
-import {
-  KNOWLEDGE_NODE_TYPE,
-  KnowledgeNode,
-} from "@app/components/editor/extensions/skill_builder/KnowledgeNode";
-import { SlashCommandExtension } from "@app/components/editor/extensions/skill_builder/SlashCommandExtension";
+import { KNOWLEDGE_NODE_TYPE } from "@app/components/editor/extensions/skill_builder/KnowledgeNode";
+import { useSkillInstructionsExtensions } from "@app/components/editor/SkillInstructionsEditor";
 import { SKILL_BUILDER_INSTRUCTIONS_BLUR_EVENT } from "@app/components/skill_builder/events";
 import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
-
-export const INSTRUCTIONS_MAXIMUM_CHARACTER_COUNT = 120_000;
 
 const editorVariants = cva(
   [
@@ -114,61 +103,7 @@ export function SkillBuilderInstructionsEditor({
     [extractAttachedKnowledge, attachedKnowledgeField]
   );
 
-  const extensions = useMemo(() => {
-    return [
-      Markdown,
-      StarterKit.configure({
-        orderedList: false, // we use custom OrderedListExtension instead
-        listItem: false, // we use custom ListItemExtension instead
-        bulletList: {
-          HTMLAttributes: {
-            class: markdownStyles.unorderedList(),
-          },
-        },
-        blockquote: false,
-        horizontalRule: false,
-        strike: false,
-        code: {
-          HTMLAttributes: {
-            class: markdownStyles.codeBlock(),
-          },
-        },
-        codeBlock: {
-          HTMLAttributes: {
-            class: markdownStyles.codeBlock(),
-          },
-        },
-        paragraph: {
-          HTMLAttributes: {
-            class: markdownStyles.paragraph(),
-          },
-        },
-      }),
-      SlashCommandExtension,
-      KnowledgeNode,
-      // Custom ordered list and list item extensions to preserve start attribute
-      OrderedListExtension.configure({
-        HTMLAttributes: {
-          class: markdownStyles.orderedList(),
-        },
-      }),
-      ListItemExtension.configure({
-        HTMLAttributes: {
-          class: markdownStyles.list(),
-        },
-      }),
-      AgentInstructionDiffExtension,
-      Placeholder.configure({
-        placeholder:
-          "How should this work? What company-specific knowledge applies here?",
-        emptyNodeClass:
-          "first:before:text-gray-400 first:before:italic first:before:content-[attr(data-placeholder)] first:before:pointer-events-none first:before:absolute",
-      }),
-      CharacterCount.configure({
-        limit: INSTRUCTIONS_MAXIMUM_CHARACTER_COUNT,
-      }),
-    ];
-  }, []);
+  const extensions = useSkillInstructionsExtensions(false);
 
   const debouncedUpdate = useMemo(
     () =>

--- a/front/components/skills/SkillInfoTab.tsx
+++ b/front/components/skills/SkillInfoTab.tsx
@@ -1,13 +1,8 @@
-import {
-  Chip,
-  ReadOnlyTextArea,
-  Separator,
-  Spinner,
-  Tooltip,
-} from "@dust-tt/sparkle";
+import { Chip, Separator, Spinner, Tooltip } from "@dust-tt/sparkle";
 import sortBy from "lodash/sortBy";
 import { useMemo } from "react";
 
+import { SkillInstructionsReadOnlyEditor } from "@app/components/skills/SkillInstructionsReadOnlyEditor";
 import {
   getMcpServerViewDescription,
   getMcpServerViewDisplayName,
@@ -80,7 +75,10 @@ export function SkillInfoTab({
           <div className="heading-lg text-foreground dark:text-foreground-night">
             Instructions
           </div>
-          <ReadOnlyTextArea content={skill.instructions} />
+          <SkillInstructionsReadOnlyEditor
+            content={skill.instructions}
+            owner={owner}
+          />
         </div>
       )}
       {sortedMCPServerViews.length > 0 && (

--- a/front/components/skills/SkillInstructionsReadOnlyEditor.tsx
+++ b/front/components/skills/SkillInstructionsReadOnlyEditor.tsx
@@ -1,0 +1,90 @@
+import { cn, markdownStyles } from "@dust-tt/sparkle";
+import { Markdown } from "@tiptap/markdown";
+import { EditorContent, useEditor } from "@tiptap/react";
+import { StarterKit } from "@tiptap/starter-kit";
+import { useMemo } from "react";
+
+import { KnowledgeOwnerProvider } from "@app/components/editor/extensions/skill_builder/KnowledgeOwnerContext";
+import { ListItemExtension } from "@app/components/editor/extensions/ListItemExtension";
+import { OrderedListExtension } from "@app/components/editor/extensions/OrderedListExtension";
+import { KnowledgeNode } from "@app/components/editor/extensions/skill_builder/KnowledgeNode";
+import type { LightWorkspaceType } from "@app/types";
+
+interface SkillInstructionsReadOnlyEditorProps {
+  content: string;
+  owner: LightWorkspaceType;
+}
+
+export function SkillInstructionsReadOnlyEditor({
+  content,
+  owner,
+}: SkillInstructionsReadOnlyEditorProps) {
+  const extensions = useMemo(() => {
+    return [
+      Markdown,
+      StarterKit.configure({
+        orderedList: false,
+        listItem: false,
+        bulletList: {
+          HTMLAttributes: {
+            class: markdownStyles.unorderedList(),
+          },
+        },
+        blockquote: false,
+        horizontalRule: false,
+        strike: false,
+        code: {
+          HTMLAttributes: {
+            class: markdownStyles.codeBlock(),
+          },
+        },
+        codeBlock: {
+          HTMLAttributes: {
+            class: markdownStyles.codeBlock(),
+          },
+        },
+        paragraph: {
+          HTMLAttributes: {
+            class: markdownStyles.paragraph(),
+          },
+        },
+      }),
+      KnowledgeNode,
+      OrderedListExtension.configure({
+        HTMLAttributes: {
+          class: markdownStyles.orderedList(),
+        },
+      }),
+      ListItemExtension.configure({
+        HTMLAttributes: {
+          class: markdownStyles.list(),
+        },
+      }),
+    ];
+  }, []);
+
+  const editor = useEditor(
+    {
+      extensions,
+      content,
+      contentType: "markdown",
+      editable: false,
+      immediatelyRender: false,
+    },
+    [extensions, content]
+  );
+
+  return (
+    <KnowledgeOwnerProvider owner={owner}>
+      <div
+        className={cn(
+          "min-h-60 w-full min-w-0 rounded-xl border p-3",
+          "border-border bg-muted-background",
+          "dark:border-border-night dark:bg-muted-background-night"
+        )}
+      >
+        <EditorContent editor={editor} />
+      </div>
+    </KnowledgeOwnerProvider>
+  );
+}

--- a/front/components/skills/SkillInstructionsReadOnlyEditor.tsx
+++ b/front/components/skills/SkillInstructionsReadOnlyEditor.tsx
@@ -4,7 +4,7 @@ import { EditorContent, useEditor } from "@tiptap/react";
 import { StarterKit } from "@tiptap/starter-kit";
 import { useMemo } from "react";
 
-import { KnowledgeOwnerProvider } from "@app/components/editor/extensions/skill_builder/KnowledgeOwnerContext";
+import { SpacesProvider } from "@app/components/agent_builder/SpacesContext";
 import { ListItemExtension } from "@app/components/editor/extensions/ListItemExtension";
 import { OrderedListExtension } from "@app/components/editor/extensions/OrderedListExtension";
 import { KnowledgeNode } from "@app/components/editor/extensions/skill_builder/KnowledgeNode";
@@ -75,7 +75,7 @@ export function SkillInstructionsReadOnlyEditor({
   );
 
   return (
-    <KnowledgeOwnerProvider owner={owner}>
+    <SpacesProvider owner={owner}>
       <div
         className={cn(
           "min-h-60 w-full min-w-0 rounded-xl border p-3",
@@ -85,6 +85,6 @@ export function SkillInstructionsReadOnlyEditor({
       >
         <EditorContent editor={editor} />
       </div>
-    </KnowledgeOwnerProvider>
+    </SpacesProvider>
   );
 }

--- a/front/components/skills/SkillInstructionsReadOnlyEditor.tsx
+++ b/front/components/skills/SkillInstructionsReadOnlyEditor.tsx
@@ -1,13 +1,5 @@
-import { cn, markdownStyles } from "@dust-tt/sparkle";
-import { Markdown } from "@tiptap/markdown";
-import { EditorContent, useEditor } from "@tiptap/react";
-import { StarterKit } from "@tiptap/starter-kit";
-import { useMemo } from "react";
-
 import { SpacesProvider } from "@app/components/agent_builder/SpacesContext";
-import { ListItemExtension } from "@app/components/editor/extensions/ListItemExtension";
-import { OrderedListExtension } from "@app/components/editor/extensions/OrderedListExtension";
-import { KnowledgeNode } from "@app/components/editor/extensions/skill_builder/KnowledgeNode";
+import { SkillInstructionsEditor } from "@app/components/editor/SkillInstructionsEditor";
 import type { LightWorkspaceType } from "@app/types";
 
 interface SkillInstructionsReadOnlyEditorProps {
@@ -19,72 +11,9 @@ export function SkillInstructionsReadOnlyEditor({
   content,
   owner,
 }: SkillInstructionsReadOnlyEditorProps) {
-  const extensions = useMemo(() => {
-    return [
-      Markdown,
-      StarterKit.configure({
-        orderedList: false,
-        listItem: false,
-        bulletList: {
-          HTMLAttributes: {
-            class: markdownStyles.unorderedList(),
-          },
-        },
-        blockquote: false,
-        horizontalRule: false,
-        strike: false,
-        code: {
-          HTMLAttributes: {
-            class: markdownStyles.codeBlock(),
-          },
-        },
-        codeBlock: {
-          HTMLAttributes: {
-            class: markdownStyles.codeBlock(),
-          },
-        },
-        paragraph: {
-          HTMLAttributes: {
-            class: markdownStyles.paragraph(),
-          },
-        },
-      }),
-      KnowledgeNode,
-      OrderedListExtension.configure({
-        HTMLAttributes: {
-          class: markdownStyles.orderedList(),
-        },
-      }),
-      ListItemExtension.configure({
-        HTMLAttributes: {
-          class: markdownStyles.list(),
-        },
-      }),
-    ];
-  }, []);
-
-  const editor = useEditor(
-    {
-      extensions,
-      content,
-      contentType: "markdown",
-      editable: false,
-      immediatelyRender: false,
-    },
-    [extensions, content]
-  );
-
   return (
     <SpacesProvider owner={owner}>
-      <div
-        className={cn(
-          "min-h-60 w-full min-w-0 rounded-xl border p-3",
-          "border-border bg-muted-background",
-          "dark:border-border-night dark:bg-muted-background-night"
-        )}
-      >
-        <EditorContent editor={editor} />
-      </div>
+      <SkillInstructionsEditor content={content} isReadOnly />
     </SpacesProvider>
   );
 }

--- a/front/components/skills/SkillInstructionsReadOnlyEditor.tsx
+++ b/front/components/skills/SkillInstructionsReadOnlyEditor.tsx
@@ -1,5 +1,8 @@
 import { SpacesProvider } from "@app/components/agent_builder/SpacesContext";
-import { SkillInstructionsEditor } from "@app/components/editor/SkillInstructionsEditor";
+import {
+  SkillInstructionsEditorContent,
+  useSkillInstructionsEditor,
+} from "@app/components/editor/SkillInstructionsEditor";
 import type { LightWorkspaceType } from "@app/types";
 
 interface SkillInstructionsReadOnlyEditorProps {
@@ -11,9 +14,14 @@ export function SkillInstructionsReadOnlyEditor({
   content,
   owner,
 }: SkillInstructionsReadOnlyEditorProps) {
+  const { editor } = useSkillInstructionsEditor({
+    content,
+    isReadOnly: true,
+  });
+
   return (
     <SpacesProvider owner={owner}>
-      <SkillInstructionsEditor content={content} isReadOnly />
+      <SkillInstructionsEditorContent editor={editor} isReadOnly />
     </SpacesProvider>
   );
 }


### PR DESCRIPTION
## Description

Implements a read-only TipTap editor to properly display skill instructions with knowledge nodes in the `SkillInfoTab`. Previously, knowledge node attachments were not rendered correctly in the skill details sheet - only as plain text. 

This adds a new `SkillInstructionsReadOnlyEditor` component that uses TipTap with the `KnowledgeNode` extension in read-only mode to correctly display knowledge chips.

The implementation refactors the context architecture by centralizing owner state in `SpacesContext` instead of relying on `SkillBuilderContext`, making `KnowledgeNodeView` reusable across both editable and read-only contexts.

**References:**
- Close https://github.com/dust-tt/tasks/issues/5830

## Risk

Low

## Tests

Locally on skill builder and skill management screens

## Deploy Plan

Deploy front