### PR TITLE
fix(dust-hive): exit explicitly after command completion to prevent hang

### DIFF
--- a/x/henry/dust-hive/src/commands/destroy.ts
+++ b/x/henry/dust-hive/src/commands/destroy.ts
@@ -6,7 +6,6 @@ import { logger } from "../lib/logger";
 import { getWorktreeDir } from "../lib/paths";
 import { cleanupServicePorts } from "../lib/ports";
 import { readPid, stopAllServices } from "../lib/process";
-import { confirm, restoreTerminal } from "../lib/prompt";
 import { CommandError, Err, Ok, type Result } from "../lib/result";
 import type { ServiceName } from "../lib/services";
 import { isDockerRunning } from "../lib/state";
@@ -17,26 +16,16 @@ async function cleanupZellijSession(envName: string): Promise<void> {
 
   // Kill session first (stops it)
   const killProc = Bun.spawn(["zellij", "kill-session", sessionName], {
-    stdout: "pipe",
-    stderr: "pipe",
+    stdout: "ignore",
+    stderr: "ignore",
   });
-  // Consume pipes to prevent hanging the event loop
-  await Promise.all([
-    new Response(killProc.stdout).text(),
-    new Response(killProc.stderr).text(),
-  ]);
   await killProc.exited;
 
   // Then delete it (removes from list)
   const deleteProc = Bun.spawn(["zellij", "delete-session", sessionName], {
-    stdout: "pipe",
-    stderr: "pipe",
+    stdout: "ignore",
+    stderr: "ignore",
   });
-  // Consume pipes to prevent hanging the event loop
-  await Promise.all([
-    new Response(deleteProc.stdout).text(),
-    new Response(deleteProc.stderr).text(),
-  ]);
   await deleteProc.exited;
 }
 

--- a/x/henry/dust-hive/src/commands/reload.ts
+++ b/x/henry/dust-hive/src/commands/reload.ts
@@ -15,26 +15,16 @@ export const reloadCommand = withEnvironment("reload", async (env) => {
 
   // Kill session first (stops it)
   const killProc = Bun.spawn(["zellij", "kill-session", sessionName], {
-    stdout: "pipe",
-    stderr: "pipe",
+    stdout: "ignore",
+    stderr: "ignore",
   });
-  // Consume pipes to prevent hanging the event loop
-  await Promise.all([
-    new Response(killProc.stdout).text(),
-    new Response(killProc.stderr).text(),
-  ]);
   await killProc.exited;
 
   // Then delete it (removes from list)
   const deleteProc = Bun.spawn(["zellij", "delete-session", sessionName], {
-    stdout: "pipe",
-    stderr: "pipe",
+    stdout: "ignore",
+    stderr: "ignore",
   });
-  // Consume pipes to prevent hanging the event loop
-  await Promise.all([
-    new Response(deleteProc.stdout).text(),
-    new Response(deleteProc.stderr).text(),
-  ]);
   await deleteProc.exited;
 
   // Remove old layout

--- a/x/henry/dust-hive/src/index.ts
+++ b/x/henry/dust-hive/src/index.ts
@@ -29,6 +29,8 @@ async function runCommand(resultPromise: Promise<Result<void>>): Promise<void> {
     logger.error(result.error.message);
     process.exit(1);
   }
+  // Exit explicitly to avoid hanging on unconsumed Bun.spawn pipe handles
+  process.exit(0);
 }
 
 async function prepareAndRun(resultPromise: Promise<Result<void>>): Promise<void> {

--- a/x/henry/dust-hive/src/lib/prompt.ts
+++ b/x/henry/dust-hive/src/lib/prompt.ts
@@ -19,11 +19,10 @@ export interface SelectEnvironmentOptions {
  * IMPORTANT: Call this before spawning any subprocess that takes over the terminal
  * (like zellij) to prevent terminal corruption.
  *
- * This does four things:
+ * This does three things:
  * 1. Exits raw mode (restores cooked mode)
  * 2. Pauses stdin to stop reading
  * 3. Removes all listeners that clack may have attached
- * 4. Unrefs stdin so it doesn't keep the event loop alive
  */
 export function restoreTerminal(): void {
   try {
@@ -41,10 +40,6 @@ export function restoreTerminal(): void {
     process.stdin.removeAllListeners("data");
     process.stdin.removeAllListeners("keypress");
     process.stdin.removeAllListeners("readable");
-
-    // Unref stdin so it doesn't keep the event loop alive
-    // This allows the process to exit naturally after interactive prompts
-    process.stdin.unref();
   } catch {
     // Ignore errors - best effort cleanup
   }


### PR DESCRIPTION
## Description

Previous PRs tried to fix the hang by consuming Bun.spawn pipe streams and unreffing stdin. However, multiple spawn calls throughout the codebase still had unconsumed pipes (docker.ts, worktree.ts, state.ts).

Instead of chasing every spawn call, we now call process.exit(0) after successful command completion. This is standard practice for CLI tools and matches the error path (which already calls process.exit(1)).

This commit also cleans up the now-redundant workarounds:
- Remove pipe consumption in destroy.ts and reload.ts (use "ignore")
- Remove stdin.unref() from prompt.ts
- Remove unused imports from destroy.ts
- 
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
