### PR TITLE
Add CI workflow for dust-hive

### DIFF
--- a/.github/workflows/build-and-lint-dust-hive.yml
+++ b/.github/workflows/build-and-lint-dust-hive.yml
@@ -1,0 +1,51 @@
+name: Build and lint dust-hive
+
+on:
+  pull_request:
+    paths:
+      - x/henry/dust-hive/**
+      - .github/workflows/build-and-lint-dust-hive.yml
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - name: Install dependencies
+        working-directory: x/henry/dust-hive
+        run: bun install --frozen-lockfile
+      - name: Typecheck
+        working-directory: x/henry/dust-hive
+        run: bun run typecheck
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - name: Install dependencies
+        working-directory: x/henry/dust-hive
+        run: bun install --frozen-lockfile
+      - name: Lint
+        working-directory: x/henry/dust-hive
+        run: bun run lint
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - name: Install dependencies
+        working-directory: x/henry/dust-hive
+        run: bun install --frozen-lockfile
+      - name: Test
+        working-directory: x/henry/dust-hive
+        run: bun run test


### PR DESCRIPTION
## Description

Adds GitHub Actions workflow that runs on PRs affecting x/henry/dust-hive:
- Typecheck (bun run typecheck)
- Lint with Biome (bun run lint)
- Tests with Bun test runner (bun run test)

Jobs run in parallel for faster feedback.


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
