### PR TITLE
Add debug log for 2 errors I'd like to investigate

### DIFF
--- a/front/lib/api/assistant/conversation/title.ts
+++ b/front/lib/api/assistant/conversation/title.ts
@@ -217,5 +217,10 @@ async function generateConversationTitle(
     return new Ok(title);
   }
 
+  logger.error(
+    { arguments: res.value.actions?.[0]?.arguments },
+    "No title found in LLM response (log with response)"
+  );
+
   return new Err(new Error("No title found in LLM response"));
 }

--- a/front/lib/resources/string_ids.ts
+++ b/front/lib/resources/string_ids.ts
@@ -156,6 +156,10 @@ export function getIdsFromSId(sId: string): Result<
   const [resourcePrefix, sIdWithoutPrefix] = sId.split("_");
 
   if (!ALL_RESOURCES_PREFIXES.includes(resourcePrefix)) {
+    logger.error(
+      { sId, resourcePrefix },
+      "Invalid resource prefix in string Id (log with prefix)"
+    );
     return new Err(new Error("Invalid resource prefix in string Id"));
   }
 


### PR DESCRIPTION
## Description

I would just like to know what causes those 2 errors: 

[No title found in LLM response
](https://app.datadoghq.eu/logs?query=service%3Afront%20status%3Aerror%20%40dd.env%3Aprod%20-%40apiError.api_error.type%3A%28not_authenticated%20OR%20rate_limit_error%20OR%20invalid_api_key_error%20OR%20conversation_not_found%20OR%20message_not_found%20OR%20workspace_auth_error%20OR%20invalid_oauth_token_error%29%20-%22Session%20authentication%20error%22%20-%40statusCode%3A404%20%22Conversation%20title%20generation%20error%20%20%20%20%22&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1767453698297&to_ts=1767712898297&live=true)
[Invalid resource prefix in string Id](https://app.datadoghq.eu/logs?query=service%3Afront%20status%3Aerror%20%40dd.env%3Aprod%20-%40apiError.api_error.type%3A%28not_authenticated%20OR%20rate_limit_error%20OR%20invalid_api_key_error%20OR%20conversation_not_found%20OR%20message_not_found%20OR%20workspace_auth_error%20OR%20invalid_oauth_token_error%29%20-%22Session%20authentication%20error%22%20-%40statusCode%3A404%20%22Failed%20to%20get%20IDs%20from%20string%20Id%22&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1766418345257&to_ts=1767714345257&live=true)

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 