### PR TITLE
fix(dust-hive): detect missing subscription in SQL seed

### DIFF
--- a/front/admin/init_db.sh
+++ b/front/admin/init_db.sh
@@ -52,3 +52,5 @@ echo "Running initdb"
 
 npx tsx admin/db.ts
 
+echo "Done"
+


### PR DESCRIPTION
## Description

The SQL seed silently failed when FREE_UPGRADED_PLAN didn't exist in the plans table. The CROSS JOIN would return 0 rows, causing no subscription to be inserted while the query still succeeded.

Changes:
- Add required_plan CTE to explicitly select the plan
- Return subscription_id in the final SELECT
- Add verifySubscriptionCreated() in seed.ts to check the output
- Show clear error message when subscription wasn't created
- 
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
