### PR TITLE
fix(dust-hive): don't pass --unsafe to init_plans.sh

### DIFF
--- a/x/henry/dust-hive/src/lib/init.ts
+++ b/x/henry/dust-hive/src/lib/init.ts
@@ -320,7 +320,7 @@ async function runFrontDbInit(env: Environment): Promise<boolean> {
   // Both init_db.sh and init_plans.sh print "Done" when they complete successfully
   const commands = [
     { cmd: "./admin/init_db.sh --unsafe", name: "init_db", expectDone: true },
-    { cmd: "./admin/init_plans.sh --unsafe", name: "init_plans", expectDone: true },
+    { cmd: "./admin/init_plans.sh", name: "init_plans", expectDone: true },
   ];
 
   for (const { cmd, name, expectDone } of commands) {


### PR DESCRIPTION
## Description

The --unsafe flag was being passed to init_plans.sh, which doesn't handle it (unlike init_db.sh). The flag was passed through to init_plans.ts where it was misinterpreted as a plan code filter, causing upsertFreePlans("--unsafe") to filter to an empty array and create zero plans.

This caused the SQL seed to fail because FREE_UPGRADED_PLAN didn't exist in the plans table.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
