### PR TITLE
[front] fix(skills): reduce size of input for description

### DIFF
--- a/front/components/skill_builder/SkillBuilderAgentFacingDescriptionSection.tsx
+++ b/front/components/skill_builder/SkillBuilderAgentFacingDescriptionSection.tsx
@@ -91,7 +91,7 @@ export function SkillBuilderAgentFacingDescriptionSection() {
           <TextArea
             ref={registerRef}
             placeholder="When should this skill be used? What is this skill good for?"
-            className="min-h-24 text-base placeholder:italic placeholder:text-gray-400"
+            className="h-40 text-base placeholder:italic placeholder:text-gray-400"
             resize="vertical"
             onChange={(e) => handleDescriptionChange(e, onChange)}
             error={hasError ? errorMessage : undefined}


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/5785
- This PR reduces the height of the text area for the agent facing description.

<img width="826" height="451" alt="Screenshot 2026-01-06 at 6 09 01 PM" src="https://github.com/user-attachments/assets/18e8d621-8213-440d-abb6-a902625b8cc2" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
