### PR TITLE
[Front] enh(pg-type-parser): handle array of bigint conversion

### DIFF
--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -1425,15 +1425,14 @@ export async function filterAgentsByRequestedSpaces(
   // When a space is deleted, mcp actions are removed, and requestedSpaceIds are updated.
   const foundSpaceIds = new Set(spaces.map((s) => s.id));
   const validAgents = agents.filter((c) =>
-    c.requestedSpaceIds.every((id) => foundSpaceIds.has(Number(id)))
+    c.requestedSpaceIds.every((id) => foundSpaceIds.has(id))
   );
 
   const allowedBySpaceIds = validAgents.filter((agent) =>
     auth.canRead(
       createResourcePermissionsFromSpacesWithMap(
         spaceIdToGroupsMap,
-        // Parse as Number since Sequelize array of BigInts are returned as strings.
-        agent.requestedSpaceIds.map((id) => Number(id))
+        agent.requestedSpaceIds
       )
     )
   );

--- a/front/lib/api/assistant/conversation/mentions.test.ts
+++ b/front/lib/api/assistant/conversation/mentions.test.ts
@@ -541,12 +541,8 @@ describe("createAgentMessages", () => {
       },
     });
     expect(updatedAgentConfig).not.toBeNull();
-    expect(updatedAgentConfig?.requestedSpaceIds).toContain(
-      space1ModelId?.toString()
-    );
-    expect(updatedAgentConfig?.requestedSpaceIds).toContain(
-      space2ModelId?.toString()
-    );
+    expect(updatedAgentConfig?.requestedSpaceIds).toContain(space1ModelId);
+    expect(updatedAgentConfig?.requestedSpaceIds).toContain(space2ModelId);
 
     // Create conversation
     const testConversation = await ConversationFactory.create(auth, {

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -208,9 +208,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     // We should probably only filter out conversations where the spaceId is deleted but keep the one that referenced a deleted space.
     const foundSpaceIds = new Set(spaces.map((s) => s.id));
     const validConversations = conversations
-      .filter((c) =>
-        c.requestedSpaceIds.every((id) => foundSpaceIds.has(Number(id)))
-      )
+      .filter((c) => c.requestedSpaceIds.every((id) => foundSpaceIds.has(id)))
       .map(
         (c) =>
           new this(
@@ -227,8 +225,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       auth.canRead(
         createResourcePermissionsFromSpacesWithMap(
           spaceIdToGroupsMap,
-          // Parse as Number since Sequelize array of BigInts are returned as strings.
-          c.requestedSpaceIds.map((id) => Number(id))
+          c.requestedSpaceIds
         )
       )
     );
@@ -339,7 +336,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
         !auth.canRead(
           createResourcePermissionsFromSpacesWithMap(
             spaceIdToGroupsMap,
-            conversation.requestedSpaceIds.map((id) => Number(id))
+            conversation.requestedSpaceIds
           )
         )
       ) {

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -307,16 +307,14 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     const foundSpaceIds = new Set(spaces.map((s) => s.id));
 
     const validCustomSkills = customSkills.filter((skill) =>
-      // Parse as Number since Sequelize array of BigInts are returned as strings.
-      skill.requestedSpaceIds.every((id) => foundSpaceIds.has(Number(id)))
+      skill.requestedSpaceIds.every((id) => foundSpaceIds.has(id))
     );
 
     const allowedCustomSkills = validCustomSkills.filter((skill) =>
       auth.canRead(
         createResourcePermissionsFromSpacesWithMap(
           spaceIdToGroupsMap,
-          // Parse as Number since Sequelize array of BigInts are returned as strings.
-          skill.requestedSpaceIds.map((id) => Number(id))
+          skill.requestedSpaceIds
         )
       )
     );
@@ -1475,7 +1473,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
   toJSON(auth: Authenticator): SkillType {
     const requestedSpaceIds = this.requestedSpaceIds.map((spaceId) =>
       SpaceResource.modelIdToSId({
-        id: Number(spaceId), // Note: Sequelize returns BIGINT arrays as strings
+        id: spaceId,
         workspaceId: this.workspaceId,
       })
     );

--- a/front/lib/resources/storage/index.test.ts
+++ b/front/lib/resources/storage/index.test.ts
@@ -1,0 +1,44 @@
+/* eslint-disable dust/no-raw-sql */
+import { QueryTypes } from "sequelize";
+import { describe, expect, it } from "vitest";
+
+import { frontSequelize } from "@app/lib/resources/storage";
+
+describe("PostgreSQL BIGINT type parser", () => {
+  it("parses single BIGINT values as numbers", async () => {
+    const result = await frontSequelize.query<{ val: number }>(
+      `SELECT 9007199254740991::BIGINT as val`,
+      { type: QueryTypes.SELECT }
+    );
+
+    expect(result[0].val).toBe(9007199254740991);
+    expect(typeof result[0].val).toBe("number");
+  });
+
+  it("parses BIGINT arrays as number arrays", async () => {
+    const result = await frontSequelize.query<{ vals: number[] }>(
+      `SELECT ARRAY[1, 2, 3]::BIGINT[] as vals`,
+      { type: QueryTypes.SELECT }
+    );
+
+    expect(result[0].vals).toEqual([1, 2, 3]);
+    expect(result[0].vals.every((v) => typeof v === "number")).toBe(true);
+  });
+
+  it("throws for unsafe BIGINT values", async () => {
+    await expect(
+      frontSequelize.query(`SELECT 9007199254740992::BIGINT as val`, {
+        type: QueryTypes.SELECT,
+      })
+    ).rejects.toThrow("not a safe integer");
+  });
+
+  it("throws for unsafe values in BIGINT arrays", async () => {
+    await expect(
+      frontSequelize.query(
+        `SELECT ARRAY[1, 9007199254740992]::BIGINT[] as vals`,
+        { type: QueryTypes.SELECT }
+      )
+    ).rejects.toThrow("not a safe integer");
+  });
+});

--- a/front/lib/resources/storage/index.test.ts
+++ b/front/lib/resources/storage/index.test.ts
@@ -1,44 +1,47 @@
-/* eslint-disable dust/no-raw-sql */
-import { QueryTypes } from "sequelize";
 import { describe, expect, it } from "vitest";
 
-import { frontSequelize } from "@app/lib/resources/storage";
+import { ConversationModel } from "@app/lib/models/agent/conversation";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 
 describe("PostgreSQL BIGINT type parser", () => {
-  it("parses single BIGINT values as numbers", async () => {
-    const result = await frontSequelize.query<{ val: number }>(
-      `SELECT 9007199254740991::BIGINT as val`,
-      { type: QueryTypes.SELECT }
+  it("parses spaceId as number from ConversationModel", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const space = await SpaceFactory.regular(workspace);
+
+    const conversation = await ConversationModel.create({
+      workspaceId: workspace.id,
+      sId: "test-conversation-bigint-single",
+      spaceId: space.id,
+      requestedSpaceIds: [],
+    });
+
+    const fetched = await ConversationModel.findByPk(conversation.id);
+
+    expect(fetched).not.toBeNull();
+    expect(fetched!.spaceId).toBe(space.id);
+    expect(typeof fetched!.spaceId).toBe("number");
+  });
+
+  it("parses requestedSpaceIds as number array from ConversationModel", async () => {
+    const workspace = await WorkspaceFactory.basic();
+    const space1 = await SpaceFactory.regular(workspace);
+    const space2 = await SpaceFactory.regular(workspace);
+    const spaceIds = [space1.id, space2.id];
+
+    const conversation = await ConversationModel.create({
+      workspaceId: workspace.id,
+      sId: "test-conversation-bigint-array",
+      spaceId: null,
+      requestedSpaceIds: spaceIds,
+    });
+
+    const fetched = await ConversationModel.findByPk(conversation.id);
+
+    expect(fetched).not.toBeNull();
+    expect(fetched!.requestedSpaceIds).toEqual(spaceIds);
+    expect(fetched!.requestedSpaceIds.every((v) => typeof v === "number")).toBe(
+      true
     );
-
-    expect(result[0].val).toBe(9007199254740991);
-    expect(typeof result[0].val).toBe("number");
-  });
-
-  it("parses BIGINT arrays as number arrays", async () => {
-    const result = await frontSequelize.query<{ vals: number[] }>(
-      `SELECT ARRAY[1, 2, 3]::BIGINT[] as vals`,
-      { type: QueryTypes.SELECT }
-    );
-
-    expect(result[0].vals).toEqual([1, 2, 3]);
-    expect(result[0].vals.every((v) => typeof v === "number")).toBe(true);
-  });
-
-  it("throws for unsafe BIGINT values", async () => {
-    await expect(
-      frontSequelize.query(`SELECT 9007199254740992::BIGINT as val`, {
-        type: QueryTypes.SELECT,
-      })
-    ).rejects.toThrow("not a safe integer");
-  });
-
-  it("throws for unsafe values in BIGINT arrays", async () => {
-    await expect(
-      frontSequelize.query(
-        `SELECT ARRAY[1, 9007199254740992]::BIGINT[] as vals`,
-        { type: QueryTypes.SELECT }
-      )
-    ).rejects.toThrow("not a safe integer");
   });
 });

--- a/front/lib/resources/storage/index.ts
+++ b/front/lib/resources/storage/index.ts
@@ -42,7 +42,8 @@ types.setTypeParser(INT8_OID, parseBigIntToSafeNumber);
 
 // Override parser for BIGINT arrays.
 // By default, pg-types returns arrays of strings for BIGINT[].
-// We get the default array parser, then map each element through our safe number parser to ensure all values are validated and converted to JavaScript numbers.
+// We get the default array parser, then map each element through our safe
+// number parser to ensure all values are validated and converted to JavaScript numbers.
 const parseBigIntegerArray = types.getTypeParser(INT8_ARRAY_OID);
 types.setTypeParser(INT8_ARRAY_OID, (val: string) =>
   parseBigIntegerArray(val).map(parseBigIntToSafeNumber)

--- a/front/lib/resources/storage/index.ts
+++ b/front/lib/resources/storage/index.ts
@@ -25,13 +25,28 @@ function sequelizeLogger(message: string) {
 // prevents silent precision loss when handling large integers from the database.
 // Throws an assertion error if a BIGINT value exceeds JavaScript's safe integer
 // limits.
-types.setTypeParser(types.builtins.INT8, function (val: unknown) {
+function parseBigIntToSafeNumber(val: string): number {
   assert(
     Number.isSafeInteger(Number(val)),
     `Found a value stored as a BIGINT that is not a safe integer: ${val}`
   );
   return Number(val);
-});
+}
+
+// Reference: https://github.com/postgres/postgres/blob/master/src/include/catalog/pg_type.dat#L55
+const INT8_OID = 20;
+const INT8_ARRAY_OID = 1016;
+
+// Override parser for single BIGINT values.
+types.setTypeParser(INT8_OID, parseBigIntToSafeNumber);
+
+// Override parser for BIGINT arrays.
+// By default, pg-types returns arrays of strings for BIGINT[].
+// We get the default array parser, then map each element through our safe number parser to ensure all values are validated and converted to JavaScript numbers.
+const parseBigIntegerArray = types.getTypeParser(INT8_ARRAY_OID);
+types.setTypeParser(INT8_ARRAY_OID, (val: string) =>
+  parseBigIntegerArray(val).map(parseBigIntToSafeNumber)
+);
 
 export const statsDClient = getStatsDClient();
 

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/index.test.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/index.test.ts
@@ -148,7 +148,7 @@ describe("PATCH /api/w/[wId]/assistant/agent_configurations/[aId] - additionalRe
     expect(agentConfigurationModel).not.toBeNull();
     const openSpaceModelId = getResourceIdFromSId(openSpace.sId);
     expect(agentConfigurationModel?.requestedSpaceIds).toContain(
-      openSpaceModelId?.toString()
+      openSpaceModelId
     );
   });
 });

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.test.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.test.ts
@@ -317,7 +317,7 @@ describe("POST /api/w/[wId]/assistant/agent_configurations - additionalRequested
     expect(agentConfigurationModel).not.toBeNull();
     const openSpaceModelId = getResourceIdFromSId(openSpace.sId);
     expect(agentConfigurationModel?.requestedSpaceIds).toContain(
-      openSpaceModelId?.toString()
+      openSpaceModelId
     );
   });
 

--- a/front/pages/api/w/[wId]/skills/index.test.ts
+++ b/front/pages/api/w/[wId]/skills/index.test.ts
@@ -629,9 +629,7 @@ describe("POST /api/w/[wId]/skills", () => {
       },
     });
     expect(skillConfiguration).not.toBeNull();
-    expect(skillConfiguration!.requestedSpaceIds).toEqual([
-      String(regularSpace.id), // BigInt array returned as string
-    ]);
+    expect(skillConfiguration!.requestedSpaceIds).toEqual([regularSpace.id]);
   });
 
   it("creates a skill with attached knowledge", async () => {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR aims at parsing postgres bigint arrays in safe js numbers, similarly to how we do it today for single bigints.
I'm using [node-pg-types](https://github.com/brianc/node-pg-types/blob/master/lib/textParsers.js) bigIntegerArray parser to achieve this.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->
Automated + regression test locally.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
Medium, touching skills, conversation, and agent requested space filtering code paths.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
Front.
