### PR TITLE
Google drive parallelization

### DIFF
--- a/connectors/migrations/20231109_2_create_gdrive_config.ts
+++ b/connectors/migrations/20231109_2_create_gdrive_config.ts
@@ -14,6 +14,7 @@ async function main() {
       pdfEnabled: false,
       csvEnabled: false,
       largeFilesEnabled: false,
+      useParallelSync: false,
     });
     console.log(
       `Created config for connector ${config.connectorId} with id ${config.id} and pdfEnabled ${config.pdfEnabled}`

--- a/connectors/migrations/db/migration_113.sql
+++ b/connectors/migrations/db/migration_113.sql
@@ -1,0 +1,7 @@
+-- Migration created on Jan 06, 2026
+-- Add parallel sync support for Google Drive connector
+
+-- Add useParallelSync flag to google_drive_configs table
+-- This enables gradual rollout of parallel folder sync feature
+ALTER TABLE "google_drive_configs"
+  ADD COLUMN "useParallelSync" BOOLEAN NOT NULL DEFAULT FALSE;

--- a/connectors/src/connectors/google_drive/temporal/activities/cancel_child_workflow.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities/cancel_child_workflow.ts
@@ -1,0 +1,19 @@
+import { getTemporalClient } from "@connectors/lib/temporal";
+import logger from "@connectors/logger/logger";
+
+/**
+ * Activity to cancel a child workflow by workflow ID.
+ * This is needed because workflows cannot directly cancel child workflows -
+ * they need to use the Temporal client which is only available in activities.
+ */
+export async function cancelChildWorkflow(workflowId: string): Promise<void> {
+  const client = await getTemporalClient();
+
+  try {
+    const handle = client.workflow.getHandle(workflowId);
+    await handle.cancel();
+  } catch (e) {
+    // Workflow may not exist or already completed, which is fine
+    logger.info(`Failed to cancel workflow ${workflowId}: ${e}`);
+  }
+}

--- a/connectors/src/connectors/google_drive/temporal/activities/get_files_count_for_sync.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities/get_files_count_for_sync.ts
@@ -1,0 +1,24 @@
+import { Op } from "sequelize";
+
+import { GoogleDriveFilesModel } from "@connectors/lib/models/google_drive";
+import type { ModelId } from "@connectors/types";
+
+/**
+ * Count the number of files that were synced (upserted) during this sync run.
+ * Uses lastSeenTs to identify files touched in this sync.
+ */
+export async function getFilesCountForSync(
+  connectorId: ModelId,
+  startSyncTs: number
+): Promise<number> {
+  const count = await GoogleDriveFilesModel.count({
+    where: {
+      connectorId,
+      lastSeenTs: {
+        [Op.gte]: new Date(startSyncTs),
+      },
+    },
+  });
+
+  return count;
+}

--- a/connectors/src/connectors/google_drive/temporal/activities/incremental_sync.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities/incremental_sync.ts
@@ -53,7 +53,16 @@ export async function incrementalSync(
     driveId: driveId,
     runInstance: uuid4(),
   });
-
+  localLogger.info(
+    {
+      connectorId,
+      driveId,
+      isSharedDrive,
+      startSyncTs,
+      nextPageToken,
+    },
+    "Starting incremental sync"
+  );
   const redisCli = await redisClient({
     origin: "google_drive_incremental_sync",
   });

--- a/connectors/src/connectors/google_drive/temporal/activities/index.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities/index.ts
@@ -1,7 +1,9 @@
+export { cancelChildWorkflow } from "./cancel_child_workflow";
 export { fixParentsConsistencyActivity } from "./fix_parents_consistency_activity";
 export { garbageCollector } from "./garbage_collector";
 export { garbageCollectorFinished } from "./garbage_collector_finished";
 export { getDrivesToSync } from "./get_drives_to_sync";
+export { getFilesCountForSync } from "./get_files_count_for_sync";
 export { getFoldersToSync } from "./get_folders_to_sync";
 export { incrementalSync } from "./incremental_sync";
 export { markFolderAsVisited } from "./mark_folder_as_visited";

--- a/connectors/src/connectors/google_drive/temporal/client.ts
+++ b/connectors/src/connectors/google_drive/temporal/client.ts
@@ -10,6 +10,7 @@ import {
 import type { FolderUpdatesSignal } from "@connectors/connectors/google_drive/temporal/signals";
 import { folderUpdatesSignal } from "@connectors/connectors/google_drive/temporal/signals";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
+import { GoogleDriveConfigModel } from "@connectors/lib/models/google_drive";
 import { getTemporalClient, terminateWorkflow } from "@connectors/lib/temporal";
 import { getActivityLogger } from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
@@ -23,16 +24,35 @@ import {
   googleDriveFixParentsConsistencyWorkflow,
   googleDriveFixParentsConsistencyWorkflowId,
   googleDriveFullSync,
+  googleDriveFullSyncV2,
+  googleDriveFullSyncV2WorkflowId,
   googleDriveFullSyncWorkflowId,
   googleDriveGarbageCollectorWorkflow,
   googleDriveGarbageCollectorWorkflowId,
   googleDriveIncrementalSync,
+  googleDriveIncrementalSyncV2,
+  googleDriveIncrementalSyncV2WorkflowId,
 } from "./workflows";
+
+const isWorkflowRunning = async (handle: WorkflowHandle): Promise<boolean> => {
+  try {
+    const description = await handle.describe();
+    // Workflow is running if it's in one of these states
+    return description.status.name === "RUNNING";
+  } catch (e) {
+    if (!(e instanceof WorkflowNotFoundError)) {
+      throw e;
+    }
+
+    return false;
+  }
+};
 
 export async function launchGoogleDriveFullSyncWorkflow(
   connectorId: ModelId,
   fromTs: number | null,
   addedFolderIds: string[],
+  removedFolderIds: string[] = [],
   mimeTypeFilter?: string[]
 ): Promise<Result<string, Error>> {
   const connector = await ConnectorResource.fetchById(connectorId);
@@ -48,47 +68,114 @@ export async function launchGoogleDriveFullSyncWorkflow(
     );
   }
 
-  const client = await getTemporalClient();
+  // Check feature flag to determine which workflow version to use
+  const config = await GoogleDriveConfigModel.findOne({
+    where: { connectorId },
+  });
+  const useParallelSync = config?.useParallelSync ?? false;
 
+  const client = await getTemporalClient();
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
 
-  const signalArgs: FolderUpdatesSignal[] =
-    addedFolderIds.map((sId) => ({
-      action: "added",
+  // Create signals for both added and removed folders
+  const signalArgs: FolderUpdatesSignal[] = [
+    ...addedFolderIds.map((sId) => ({
+      action: "added" as const,
       folderId: sId,
-    })) ?? [];
+    })),
+    ...removedFolderIds.map((sId) => ({
+      action: "removed" as const,
+      folderId: sId,
+    })),
+  ];
 
-  const workflowId = googleDriveFullSyncWorkflowId(connectorId);
+  // Route to appropriate workflow based on feature flag
+  const workflowId = useParallelSync
+    ? googleDriveFullSyncV2WorkflowId(connectorId)
+    : googleDriveFullSyncWorkflowId(connectorId);
+
   try {
-    await client.workflow.signalWithStart(googleDriveFullSync, {
-      args: [
+    const handle = client.workflow.getHandle(workflowId);
+    const workflowRunning = await isWorkflowRunning(handle);
+
+    if (workflowRunning) {
+      await handle.signal(folderUpdatesSignal, signalArgs);
+      localLogger.info(
         {
-          connectorId: connectorId,
-          garbageCollect: true,
-          startSyncTs: undefined,
-          foldersToBrowse: addedFolderIds,
-          totalCount: 0,
-          mimeTypeFilter: mimeTypeFilter,
+          workspaceId: dataSourceConfig.workspaceId,
+          workflowId,
+          useParallelSync,
+          foldersAdded: addedFolderIds.length,
+          foldersRemoved: removedFolderIds.length,
         },
-      ],
-      taskQueue: GDRIVE_FULL_SYNC_QUEUE_NAME,
-      workflowId: workflowId,
-      searchAttributes: {
-        connectorId: [connectorId],
-      },
-      memo: {
-        connectorId: connectorId,
-      },
-      signal: folderUpdatesSignal,
-      signalArgs: [signalArgs],
-    });
-    localLogger.info(
-      {
-        workspaceId: dataSourceConfig.workspaceId,
-        workflowId,
-      },
-      `Started workflow.`
-    );
+        `Sent signal to running workflow.`
+      );
+    } else {
+      if (addedFolderIds.length > 0) {
+        if (useParallelSync) {
+          await client.workflow.start(googleDriveFullSyncV2, {
+            args: [
+              {
+                connectorId,
+                garbageCollect: true,
+                startSyncTs: undefined,
+                mimeTypeFilter,
+                runningFolderWorkflows: {},
+                folderWorkflowCounters: {},
+                initialFolderIds: addedFolderIds,
+              },
+            ],
+            taskQueue: GDRIVE_FULL_SYNC_QUEUE_NAME,
+            workflowId,
+            searchAttributes: {
+              connectorId: [connectorId],
+            },
+            memo: {
+              connectorId,
+            },
+          });
+        } else {
+          await client.workflow.start(googleDriveFullSync, {
+            args: [
+              {
+                connectorId,
+                garbageCollect: true,
+                startSyncTs: undefined,
+                foldersToBrowse: addedFolderIds,
+                totalCount: 0,
+                mimeTypeFilter,
+              },
+            ],
+            taskQueue: GDRIVE_FULL_SYNC_QUEUE_NAME,
+            workflowId,
+            searchAttributes: {
+              connectorId: [connectorId],
+            },
+            memo: {
+              connectorId,
+            },
+          });
+        }
+        localLogger.info(
+          {
+            workspaceId: dataSourceConfig.workspaceId,
+            workflowId,
+            useParallelSync,
+          },
+          `Started workflow.`
+        );
+      } else if (removedFolderIds.length > 0) {
+        // Only removals, launch garbage collector
+        localLogger.info(
+          {
+            workspaceId: dataSourceConfig.workspaceId,
+            foldersRemoved: removedFolderIds.length,
+          },
+          `Folders removed but workflow not running, will launch GC.`
+        );
+        return await launchGoogleGarbageCollector(connectorId);
+      }
+    }
     return new Ok(workflowId);
   } catch (e) {
     localLogger.error(
@@ -112,24 +199,42 @@ export async function launchGoogleDriveIncrementalSyncWorkflow(
   }
   const localLogger = getActivityLogger(connector);
 
+  // Check feature flag to determine which workflow version to use
+  const config = await GoogleDriveConfigModel.findOne({
+    where: { connectorId },
+  });
+  const useParallelSync = config?.useParallelSync ?? false;
+
   const client = await getTemporalClient();
 
-  const workflowId = googleDriveIncrementalSyncWorkflowId(connectorId);
+  // Route to appropriate workflow based on feature flag
+  const workflowId = useParallelSync
+    ? googleDriveIncrementalSyncV2WorkflowId(connectorId)
+    : googleDriveIncrementalSyncWorkflowId(connectorId);
+
+  const workflowFn = useParallelSync
+    ? googleDriveIncrementalSyncV2
+    : googleDriveIncrementalSync;
 
   // Randomize the delay to avoid all incremental syncs starting at the same time, especially when restarting all via cli.
   const delay = Math.floor(Math.random() * 5);
 
   try {
-    await terminateWorkflow(workflowId);
-    await client.workflow.start(googleDriveIncrementalSync, {
+    // Terminate both versions of the workflows in case we changed the flag
+    await terminateWorkflow(
+      googleDriveIncrementalSyncV2WorkflowId(connectorId)
+    );
+    await terminateWorkflow(googleDriveIncrementalSyncWorkflowId(connectorId));
+
+    await client.workflow.start(workflowFn, {
       args: [connectorId],
       taskQueue: GDRIVE_INCREMENTAL_SYNC_QUEUE_NAME,
-      workflowId: workflowId,
+      workflowId,
       searchAttributes: {
         connectorId: [connectorId],
       },
       memo: {
-        connectorId: connectorId,
+        connectorId,
       },
       startDelay: `${delay} minutes`,
     });
@@ -137,6 +242,7 @@ export async function launchGoogleDriveIncrementalSyncWorkflow(
       {
         workspaceId: connector.workspaceId,
         workflowId,
+        useParallelSync,
       },
       `Started workflow.`
     );
@@ -149,6 +255,79 @@ export async function launchGoogleDriveIncrementalSyncWorkflow(
         error: e,
       },
       `Failed starting workflow.`
+    );
+    return new Err(normalizeError(e));
+  }
+}
+
+/**
+ * Signal folder removal to a running workflow, or launch GC if workflow is not running.
+ * This function is used when folders are removed without any additions.
+ */
+export async function signalFolderRemoval(
+  connectorId: ModelId,
+  removedFolderIds: string[]
+): Promise<Result<string, Error>> {
+  const connector = await ConnectorResource.fetchById(connectorId);
+  if (!connector) {
+    return new Err(new Error(`Connector ${connectorId} not found`));
+  }
+  const localLogger = getActivityLogger(connector);
+
+  const config = await GoogleDriveConfigModel.findOne({
+    where: { connectorId },
+  });
+  const useParallelSync = config?.useParallelSync ?? false;
+
+  const client = await getTemporalClient();
+  const dataSourceConfig = dataSourceConfigFromConnector(connector);
+
+  const workflowId = useParallelSync
+    ? googleDriveFullSyncV2WorkflowId(connectorId)
+    : googleDriveFullSyncWorkflowId(connectorId);
+
+  const signalArgs: FolderUpdatesSignal[] = removedFolderIds.map((sId) => ({
+    action: "removed" as const,
+    folderId: sId,
+  }));
+
+  try {
+    // Try to get handle to existing workflow
+    const handle = client.workflow.getHandle(workflowId);
+    const workflowRunning = await isWorkflowRunning(handle);
+
+    if (workflowRunning) {
+      // Workflow is running, send signal to stop tracking these folders
+      await handle.signal(folderUpdatesSignal, signalArgs);
+      localLogger.info(
+        {
+          workspaceId: dataSourceConfig.workspaceId,
+          workflowId,
+          useParallelSync,
+          foldersRemoved: removedFolderIds.length,
+        },
+        `Sent removal signal to running workflow.`
+      );
+      return new Ok(workflowId);
+    } else {
+      // Workflow not running, just launch GC to clean up removed folders
+      localLogger.info(
+        {
+          workspaceId: dataSourceConfig.workspaceId,
+          foldersRemoved: removedFolderIds.length,
+        },
+        `Workflow not running, launching GC for removed folders.`
+      );
+      return await launchGoogleGarbageCollector(connectorId);
+    }
+  } catch (e) {
+    localLogger.error(
+      {
+        workspaceId: dataSourceConfig.workspaceId,
+        workflowId,
+        error: e,
+      },
+      `Failed to signal folder removal.`
     );
     return new Err(normalizeError(e));
   }

--- a/connectors/src/connectors/google_drive/temporal/config.ts
+++ b/connectors/src/connectors/google_drive/temporal/config.ts
@@ -2,3 +2,7 @@ const GDRIVE_FULL_SYNC_QUEUE_VERSION = 6;
 const GDRIVE_INCREMENTAL_SYNC_QUEUE_VERSION = 9;
 export const GDRIVE_FULL_SYNC_QUEUE_NAME = `google-queue-fullsync-v${GDRIVE_FULL_SYNC_QUEUE_VERSION}`;
 export const GDRIVE_INCREMENTAL_SYNC_QUEUE_NAME = `google-queue-incremental-v${GDRIVE_INCREMENTAL_SYNC_QUEUE_VERSION}`;
+
+// Maximum number of folders to sync in parallel for parallel sync workflows.
+// Can be overridden via GDRIVE_MAX_CONCURRENT_FOLDER_SYNCS environment variable.
+export const GDRIVE_MAX_CONCURRENT_FOLDER_SYNCS = 5;

--- a/connectors/src/connectors/google_drive/temporal/workflows.ts
+++ b/connectors/src/connectors/google_drive/temporal/workflows.ts
@@ -1,13 +1,16 @@
 import { assertNever } from "@temporalio/common/lib/type-helpers";
+import type { ChildWorkflowHandle } from "@temporalio/workflow";
 import {
   continueAsNew,
   executeChild,
   proxyActivities,
   setHandler,
   sleep,
+  startChild,
   workflowInfo,
 } from "@temporalio/workflow";
 import { uniq } from "lodash";
+import PQueue from "p-queue";
 
 import type * as activities from "@connectors/connectors/google_drive/temporal/activities";
 import type { FolderUpdatesSignal } from "@connectors/connectors/google_drive/temporal/signals";
@@ -15,11 +18,14 @@ import type * as sync_status from "@connectors/lib/sync_status";
 import type { ModelId } from "@connectors/types";
 
 import { GOOGLE_DRIVE_USER_SPACE_VIRTUAL_DRIVE_ID } from "../lib/consts";
+import { GDRIVE_MAX_CONCURRENT_FOLDER_SYNCS } from "./config";
 import { folderUpdatesSignal } from "./signals";
 
 const {
+  cancelChildWorkflow,
   getDrivesToSync,
   garbageCollector,
+  getFilesCountForSync,
   getFoldersToSync,
   populateSyncTokens,
   garbageCollectorFinished,
@@ -317,4 +323,476 @@ export async function googleDriveFixParentsConsistencyWorkflow(
       startTs,
     });
   } while (fromId > 0);
+}
+
+/**
+ * Child workflow that syncs a single root folder and all its subfolders (subtree).
+ */
+export async function googleDriveFolderSync({
+  connectorId,
+  rootFolderId,
+  startSyncTs,
+  mimeTypeFilter,
+  foldersToBrowse = [],
+  totalCount = 0,
+}: {
+  connectorId: ModelId;
+  rootFolderId: string;
+  startSyncTs: number;
+  mimeTypeFilter?: string[];
+  foldersToBrowse?: string[];
+  totalCount?: number;
+}) {
+  // Initialize with root folder if not resuming
+  if (foldersToBrowse.length === 0) {
+    foldersToBrowse = [rootFolderId];
+  }
+
+  let nextPageToken: string | undefined = undefined;
+
+  // Process all folders in this subtree
+  while (foldersToBrowse.length > 0) {
+    const folder = foldersToBrowse.pop();
+    if (!folder) {
+      throw new Error("folderId should be defined");
+    }
+
+    // Sync all files in this folder (with pagination)
+    do {
+      const res = await syncFiles(
+        connectorId,
+        folder,
+        startSyncTs,
+        nextPageToken,
+        mimeTypeFilter
+      );
+      nextPageToken = res.nextPageToken ? res.nextPageToken : undefined;
+      totalCount += res.count;
+      // Add discovered subfolders to the queue
+      foldersToBrowse = foldersToBrowse.concat(res.subfolders);
+    } while (nextPageToken);
+
+    // Mark folder as visited
+    await markFolderAsVisited(connectorId, folder, startSyncTs);
+
+    // Continue as new if history is getting too large
+    if (workflowInfo().historyLength > 4000) {
+      await continueAsNew<typeof googleDriveFolderSync>({
+        connectorId,
+        rootFolderId,
+        startSyncTs,
+        mimeTypeFilter,
+        foldersToBrowse,
+        totalCount,
+      });
+    }
+
+    // Deduplicate folders
+    foldersToBrowse = uniq(foldersToBrowse);
+  }
+}
+
+export function googleDriveFolderSyncWorkflowId(
+  connectorId: ModelId,
+  folderId: string,
+  folderWorkflowCounters: Record<string, number>
+): string {
+  // Increment counter for this folder to get a unique workflow ID.
+  // This is to avoid conflicts when starting/stopping workflow multiple times.
+  const counter = (folderWorkflowCounters[folderId] || 0) + 1;
+  folderWorkflowCounters[folderId] = counter;
+
+  return `googleDrive-fullSync-${connectorId}-folder-${folderId}-${counter}`;
+}
+
+/**
+ * V2 Full Sync Coordinator Workflow - launches child workflows for each selected folder
+ * to enable parallel processing. This is the gradual migration version that runs
+ * alongside the legacy googleDriveFullSync workflow.
+ */
+export async function googleDriveFullSyncV2({
+  connectorId,
+  garbageCollect = true,
+  startSyncTs = undefined,
+  mimeTypeFilter,
+  runningFolderWorkflows = {},
+  folderWorkflowCounters = {},
+  initialFolderIds = [],
+}: {
+  connectorId: ModelId;
+  garbageCollect: boolean;
+  startSyncTs: number | undefined;
+  mimeTypeFilter?: string[];
+  runningFolderWorkflows?: Record<
+    string,
+    {
+      handle: ChildWorkflowHandle<typeof googleDriveFolderSync>;
+      workflowId: string;
+    }
+  >;
+  folderWorkflowCounters?: Record<string, number>;
+  initialFolderIds?: string[];
+}) {
+  // Initialize sync timestamp
+  if (!startSyncTs) {
+    await syncStarted(connectorId);
+    startSyncTs = new Date().getTime();
+  }
+
+  // Populate sync tokens before starting
+  await populateSyncTokens(connectorId);
+
+  // Get folders to sync - use initialFolderIds if provided, otherwise fetch all from DB
+  const folderIds =
+    initialFolderIds.length > 0
+      ? initialFolderIds
+      : await getFoldersToSync(connectorId);
+
+  // Upsert shared with me folder
+  await upsertSharedWithMeFolder(connectorId);
+
+  // Track pending folder changes that arrive after sync completes
+  const pendingAddedFolders: string[] = [];
+  const pendingRemovedFolders: string[] = [];
+  let syncCompleted = false;
+
+  // Create queue for bounded concurrency
+  const queue = new PQueue({ concurrency: GDRIVE_MAX_CONCURRENT_FOLDER_SYNCS });
+
+  // Helper function to start a child workflow with concurrency control
+  const startFolderWorkflow = async (folderId: string) => {
+    if (folderId in runningFolderWorkflows) {
+      return; // Already running
+    }
+
+    await queue.add(async () => {
+      const childWorkflowId = googleDriveFolderSyncWorkflowId(
+        connectorId,
+        folderId,
+        folderWorkflowCounters
+      );
+
+      const handle = await startChild(googleDriveFolderSync, {
+        workflowId: childWorkflowId,
+        searchAttributes: { connectorId: [connectorId] },
+        args: [
+          {
+            connectorId,
+            rootFolderId: folderId,
+            startSyncTs,
+            mimeTypeFilter,
+          },
+        ],
+        memo: workflowInfo().memo,
+      });
+
+      runningFolderWorkflows[folderId] = {
+        handle,
+        workflowId: childWorkflowId,
+      };
+    });
+  };
+
+  // Set up signal handler for folder additions/removals
+  setHandler(
+    folderUpdatesSignal,
+    async (folderUpdates: FolderUpdatesSignal[]) => {
+      for (const { action, folderId } of folderUpdates) {
+        switch (action) {
+          case "added": {
+            if (syncCompleted) {
+              // Sync already done, queue for next run
+              const idx = pendingRemovedFolders.indexOf(folderId);
+              if (idx !== -1) {
+                pendingRemovedFolders.splice(idx, 1);
+              } else if (!pendingAddedFolders.includes(folderId)) {
+                pendingAddedFolders.push(folderId);
+              }
+            } else {
+              // Start child workflow with concurrency control
+              await startFolderWorkflow(folderId);
+            }
+            break;
+          }
+          case "removed": {
+            if (syncCompleted) {
+              // Sync already done, queue for next run
+              const idx = pendingAddedFolders.indexOf(folderId);
+              if (idx !== -1) {
+                pendingAddedFolders.splice(idx, 1);
+              } else if (!pendingRemovedFolders.includes(folderId)) {
+                pendingRemovedFolders.push(folderId);
+              }
+            } else {
+              // Cancel the running child workflow
+              const folderWorkflow = runningFolderWorkflows[folderId];
+              if (folderWorkflow) {
+                try {
+                  await cancelChildWorkflow(folderWorkflow.workflowId);
+                } catch (e) {
+                  // Workflow may have already completed, that's fine
+                }
+                delete runningFolderWorkflows[folderId];
+              }
+            }
+            break;
+          }
+          default: {
+            assertNever(
+              `Unexpected signal action ${action} received for Google Drive full sync V2 workflow.`,
+              action
+            );
+          }
+        }
+      }
+    }
+  );
+
+  // Start all initial child workflows with bounded concurrency
+  for (const folderId of folderIds) {
+    await startFolderWorkflow(folderId);
+  }
+
+  // Start progress reporting task (runs in parallel with child workflows)
+  const progressReporting = async () => {
+    while (!syncCompleted) {
+      await sleep("30 seconds");
+      if (syncCompleted) break;
+
+      // Count total files synced so far in this run
+      const totalFilesSynced = await getFilesCountForSync(
+        connectorId,
+        startSyncTs
+      );
+      if (totalFilesSynced > 0) {
+        await reportInitialSyncProgress(
+          connectorId,
+          `Synced ${totalFilesSynced} files`
+        );
+      }
+    }
+  };
+
+  const progressReportingTask = progressReporting();
+
+  // Wait for all child workflows to complete
+  while (Object.keys(runningFolderWorkflows).length > 0) {
+    const snapshot = { ...runningFolderWorkflows };
+
+    // Wait for each workflow and remove it as it completes
+    await Promise.allSettled(
+      Object.entries(snapshot).map(async ([folderId, wf]) => {
+        try {
+          await wf.handle.result();
+        } finally {
+          // Remove if it's still the same workflow (not replaced by signal)
+          if (runningFolderWorkflows[folderId]?.workflowId === wf.workflowId) {
+            delete runningFolderWorkflows[folderId];
+          }
+        }
+      })
+    );
+  }
+
+  // Mark sync as completed - any signals from now on will be queued for next run
+  syncCompleted = true;
+
+  await progressReportingTask;
+
+  const finalFilesSynced = await getFilesCountForSync(connectorId, startSyncTs);
+  await reportInitialSyncProgress(
+    connectorId,
+    `Synced ${finalFilesSynced} files`
+  );
+
+  await syncSucceeded(connectorId);
+
+  if (garbageCollect) {
+    await executeChild(googleDriveGarbageCollectorWorkflow, {
+      workflowId: googleDriveGarbageCollectorWorkflowId(connectorId),
+      searchAttributes: {
+        connectorId: [connectorId],
+      },
+      args: [connectorId, startSyncTs],
+      memo: workflowInfo().memo,
+    });
+  }
+
+  // If folders were added during sync or GC, restart workflow to handle them
+  if (pendingAddedFolders.length > 0) {
+    // Restart workflow to sync newly added folders
+    // GC will automatically clean up removed folders based on lastSeenTs
+    await continueAsNew<typeof googleDriveFullSyncV2>({
+      connectorId,
+      garbageCollect: true,
+      startSyncTs: undefined,
+      mimeTypeFilter,
+      runningFolderWorkflows: {},
+      folderWorkflowCounters: {},
+      initialFolderIds: pendingAddedFolders,
+    });
+  } else if (pendingRemovedFolders.length > 0) {
+    // Only removals, just re-launch GC to clean them up
+    await executeChild(googleDriveGarbageCollectorWorkflow, {
+      workflowId: googleDriveGarbageCollectorWorkflowId(connectorId),
+      searchAttributes: {
+        connectorId: [connectorId],
+      },
+      args: [connectorId, new Date().getTime()],
+      memo: workflowInfo().memo,
+    });
+  }
+}
+
+export function googleDriveFullSyncV2WorkflowId(connectorId: ModelId): string {
+  return `googleDrive-fullSyncV2-${connectorId}`;
+}
+
+/**
+ * Child workflow that handles incremental sync for a single drive.
+ * Processes all changes for the drive with pagination, and launches full sync for new folders.
+ */
+export async function googleDriveIncrementalSyncPerDrive({
+  connectorId,
+  driveId,
+  isShared,
+  startSyncTs,
+}: {
+  connectorId: ModelId;
+  driveId: string;
+  isShared: boolean;
+  startSyncTs: number;
+}) {
+  let nextPageToken: string | undefined = undefined;
+  const discoveredFolders: string[] = [];
+
+  // Process all changes for this drive with pagination
+  do {
+    const syncRes = await incrementalSync(
+      connectorId,
+      driveId,
+      isShared,
+      startSyncTs,
+      nextPageToken
+    );
+
+    if (syncRes) {
+      discoveredFolders.push(...syncRes.newFolders);
+      nextPageToken = syncRes.nextPageToken;
+    }
+  } while (nextPageToken);
+
+  // If new folders discovered from this drive, launch child workflow
+  if (discoveredFolders.length > 0) {
+    await executeChild(googleDriveFullSync, {
+      workflowId: `googleDrive-newFolders-${connectorId}-drive-${driveId}-${startSyncTs}`,
+      searchAttributes: {
+        connectorId: [connectorId],
+      },
+      args: [
+        {
+          connectorId,
+          garbageCollect: false,
+          foldersToBrowse: discoveredFolders,
+          totalCount: 0,
+          startSyncTs,
+          mimeTypeFilter: undefined,
+        },
+      ],
+      memo: workflowInfo().memo,
+    });
+  }
+}
+
+export function googleDriveIncrementalSyncPerDriveWorkflowId(
+  connectorId: ModelId,
+  driveId: string
+): string {
+  return `googleDrive-incrementalSync-${connectorId}-drive-${driveId}`;
+}
+
+/**
+ * V2 Incremental Sync Coordinator Workflow - launches one child workflow per drive for parallel processing.
+ * Each child workflow handles its drive's incremental sync and new folder discovery.
+ */
+export async function googleDriveIncrementalSyncV2(
+  connectorId: ModelId,
+  startSyncTs: number | undefined = undefined
+) {
+  if (!startSyncTs) {
+    await syncStarted(connectorId);
+    startSyncTs = new Date().getTime();
+  }
+
+  // Get drives to sync
+  const drives = await getDrivesToSync(connectorId);
+  const drivesToSync = drives
+    .map((drive) => ({
+      id: drive.id,
+      isShared: drive.isSharedDrive,
+    }))
+    // Include userspace (non-shared drives)
+    .concat({
+      id: GOOGLE_DRIVE_USER_SPACE_VIRTUAL_DRIVE_ID,
+      isShared: false,
+    });
+
+  // Launch child workflows in parallel - one per drive
+  const queue = new PQueue({ concurrency: GDRIVE_MAX_CONCURRENT_FOLDER_SYNCS });
+  const childHandles: ChildWorkflowHandle<
+    typeof googleDriveIncrementalSyncPerDrive
+  >[] = [];
+
+  // Start all child workflows
+  for (const googleDrive of drivesToSync) {
+    await queue.add(async () => {
+      const handle = await startChild(googleDriveIncrementalSyncPerDrive, {
+        workflowId: googleDriveIncrementalSyncPerDriveWorkflowId(
+          connectorId,
+          googleDrive.id
+        ),
+        searchAttributes: {
+          connectorId: [connectorId],
+        },
+        args: [
+          {
+            connectorId,
+            driveId: googleDrive.id,
+            isShared: googleDrive.isShared,
+            startSyncTs,
+          },
+        ],
+        memo: workflowInfo().memo,
+      });
+      childHandles.push(handle);
+    });
+  }
+
+  // Wait for all drive syncs to complete
+  await Promise.all(childHandles.map((handle) => handle.result()));
+
+  // Check if garbage collection is needed
+  const shouldGc = await shouldGarbageCollect(connectorId);
+  if (shouldGc) {
+    await executeChild(googleDriveGarbageCollectorWorkflow, {
+      workflowId: googleDriveGarbageCollectorWorkflowId(connectorId),
+      searchAttributes: {
+        connectorId: [connectorId],
+      },
+      args: [connectorId, startSyncTs],
+      memo: workflowInfo().memo,
+    });
+  }
+
+  await syncSucceeded(connectorId);
+
+  // Sleep and continue
+  await sleep("5 minutes");
+  await continueAsNew<typeof googleDriveIncrementalSyncV2>(connectorId);
+}
+
+export function googleDriveIncrementalSyncV2WorkflowId(
+  connectorId: ModelId
+): string {
+  return `googleDrive-incrementalSyncV2-${connectorId}`;
 }

--- a/connectors/src/lib/models/google_drive.ts
+++ b/connectors/src/lib/models/google_drive.ts
@@ -13,6 +13,7 @@ export class GoogleDriveConfigModel extends ConnectorBaseModel<GoogleDriveConfig
   declare pdfEnabled: boolean;
   declare csvEnabled: boolean;
   declare largeFilesEnabled: boolean;
+  declare useParallelSync: boolean;
 }
 GoogleDriveConfigModel.init(
   {
@@ -37,6 +38,11 @@ GoogleDriveConfigModel.init(
       defaultValue: false,
     },
     largeFilesEnabled: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    },
+    useParallelSync: {
       type: DataTypes.BOOLEAN,
       allowNull: false,
       defaultValue: false,

--- a/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
@@ -66,6 +66,7 @@ type FeaturesType = {
   slackBotEnabled: boolean;
   googleDrivePdfEnabled: boolean;
   googleDriveLargeFilesEnabled: boolean;
+  googleDriveParallelSyncEnabled: boolean;
   microsoftPdfEnabled: boolean;
   microsoftLargeFilesEnabled: boolean;
   googleDriveCsvEnabled: boolean;
@@ -157,6 +158,7 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
     slackBotEnabled: false,
     googleDrivePdfEnabled: false,
     googleDriveLargeFilesEnabled: false,
+    googleDriveParallelSyncEnabled: false,
     microsoftPdfEnabled: false,
     microsoftLargeFilesEnabled: false,
     googleDriveCsvEnabled: false,
@@ -242,6 +244,17 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
         }
         features.googleDriveLargeFilesEnabled =
           gdriveLargeFilesEnabledRes.value.configValue === "true";
+
+        const gdriveParallelSyncEnabledRes =
+          await connectorsAPI.getConnectorConfig(
+            dataSource.connectorId,
+            "useParallelSync"
+          );
+        if (gdriveParallelSyncEnabledRes.isErr()) {
+          throw gdriveParallelSyncEnabledRes.error;
+        }
+        features.googleDriveParallelSyncEnabled =
+          gdriveParallelSyncEnabledRes.value.configValue === "true";
         break;
 
       case "microsoft":
@@ -714,6 +727,14 @@ const DataSourcePage = ({
                   dataSource={dataSource}
                   configKey="largeFilesEnabled"
                   featureKey="googleDriveLargeFilesEnabled"
+                />
+                <ConfigToggle
+                  title="Parallel syncing enabled?"
+                  owner={owner}
+                  features={features}
+                  dataSource={dataSource}
+                  configKey="useParallelSync"
+                  featureKey="googleDriveParallelSyncEnabled"
                 />
               </>
             )}


### PR DESCRIPTION
## Description

Adds a new parallelized workflow for google_drive sync, for both full and incremental. This are different workflows (suffxied with V2), gated with config parameter, that can be enabled in poke.

The full sync workflow creates a child workflow for every root folder added. We limit the concurrency to 5 parallel workflow, and handle added/removed folders with signals, enqueing new workflow or cancelling the one that are running (when removing a folder that was just added). Once all workflows are done we continue with the GC - all new signals are then enqueued for a "continueAsNew" workflow. This is to avoid running GC in parallel with sync, as GC relies on lastSeen value, set by the sync.
Progress is updated in parallel through a dedicated activity.

The incremental sync parallelize per drive, as the delta are fetched per drive. Changes here are more simple - we just start one googleDriveIncrementalSyncPerDrive for each drive (also limited to 5 in parallel).

Activities are unchanged.

## Tests

Tested locally :
- setup new config
- add/remove folder/drives multiple times (same or differnet folders) while initial sync is running
- check incremental sync by adding files/folders in drive once initial sync is over
- switch from v1 to v2 and the opposite

## Risk

New workflow is gated, not enabled by default - we can still go back to previous version by changing the flag.

## Deploy Plan

run migration
deploy connectors + front (poke)
