### PR TITLE
fix(dust-hive): reduce env name limit to 26 chars to avoid zellij hang

### DIFF
--- a/x/henry/dust-hive/src/lib/environment.ts
+++ b/x/henry/dust-hive/src/lib/environment.ts
@@ -42,8 +42,10 @@ export function validateEnvName(name: string): { valid: boolean; error?: string 
     };
   }
 
-  if (name.length > 32) {
-    return { valid: false, error: "Name must be 32 characters or less" };
+  // Zellij has a 36-character session name limit. Since session names are
+  // formatted as "dust-hive-{name}" (10-char prefix), env names must be ≤26 chars.
+  if (name.length > 26) {
+    return { valid: false, error: "Name must be 26 characters or less" };
   }
 
   return { valid: true };

--- a/x/henry/dust-hive/tests/lib/environment.test.ts
+++ b/x/henry/dust-hive/tests/lib/environment.test.ts
@@ -41,14 +41,14 @@ describe("environment", () => {
       expect(validateEnvName("test/feature").valid).toBe(false);
     });
 
-    it("rejects names longer than 32 characters", () => {
-      const longName = "a".repeat(33);
+    it("rejects names longer than 26 characters", () => {
+      const longName = "a".repeat(27);
       const result = validateEnvName(longName);
       expect(result.valid).toBe(false);
     });
 
-    it("accepts names exactly 32 characters", () => {
-      const maxName = "a".repeat(32);
+    it("accepts names exactly 26 characters", () => {
+      const maxName = "a".repeat(26);
       expect(validateEnvName(maxName).valid).toBe(true);
     });
   });


### PR DESCRIPTION
## Description

Zellij has a 36-character session name limit. Since session names are formatted as "dust-hive-{name}", environment names over 26 characters would cause Zellij to hang silently when creating sessions.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
