### PR TITLE
[Front] fix(skills): propagate skill space requirements to agents on update

### DIFF
--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -462,7 +462,7 @@ describe("SkillResource", () => {
       const restrictedSpace = await SpaceFactory.regular(testContext.workspace);
 
       // Create a skill without space restrictions.
-      const skillResource = await SkillConfigurationFactory.create(
+      const skillResource = await SkillFactory.create(
         testContext.authenticator,
         { name: "Test Skill For Update" }
       );
@@ -472,7 +472,7 @@ describe("SkillResource", () => {
         testContext.authenticator,
         { name: "Test Agent With Skill" }
       );
-      await SkillConfigurationFactory.linkToAgent(testContext.authenticator, {
+      await SkillFactory.linkToAgent(testContext.authenticator, {
         skillId: skillResource.id,
         agentConfigurationId: agent.id,
       });

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -956,7 +956,9 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       async (agent) => {
         const spaceIdsToRemoveFromAgent = new Set<ModelId>();
 
-        // Some spaces were removed from the skill: we must check if they need to be removed from the agent. In order to achieve this, we check if the agent has any other capabilities that require the removed spaces.
+        // Some spaces were removed from the skill: we must check if they need to be
+        // removed from the agent. In order to achieve this, we check if the agent has
+        // any other capabilities that require the removed spaces.
         if (spaceIdsRemovedFromThisSkill.length > 0) {
           const agentConfig = await getAgentConfiguration(auth, {
             agentId: agent.sId,
@@ -984,7 +986,8 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
           for (const spaceId of spaceIdsRemovedFromThisSkill) {
             if (!otherCapabilitiesRequestedSpaceIds.has(spaceId)) {
-              // This space is not required by any other capabilities of the agent, so we must remove it from the config.
+              // This space is not required by any other capabilities of the agent, so
+              // we must remove it from the config.
               spaceIdsToRemoveFromAgent.add(spaceId);
             }
           }

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -932,16 +932,16 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       return;
     }
 
-    const skillSpaceIds = this.requestedSpaceIds.map((id) => Number(id));
-
     await concurrentExecutor(
       agents,
       async (agent) => {
-        const currentSpaceIds = agent.requestedSpaceIds.map((id) => Number(id));
-        const newSpaceIds = uniq([...currentSpaceIds, ...skillSpaceIds]);
+        const newSpaceIds = uniq([
+          ...agent.requestedSpaceIds,
+          ...this.requestedSpaceIds,
+        ]);
 
         // Only update if there are new spaces to add.
-        if (newSpaceIds.length > currentSpaceIds.length) {
+        if (newSpaceIds.length > agent.requestedSpaceIds.length) {
           await updateAgentRequirements(
             auth,
             {

--- a/front/migrations/20250725_backfill_agent_configurations.ts
+++ b/front/migrations/20250725_backfill_agent_configurations.ts
@@ -3,7 +3,7 @@ import { Op } from "sequelize";
 
 import { isServerSideMCPServerConfiguration } from "@app/lib/actions/types/guards";
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
-import { getAgentConfigurationRequirementsFromActions } from "@app/lib/api/assistant/permissions";
+import { getAgentConfigurationRequirementsFromCapabilities } from "@app/lib/api/assistant/permissions";
 import { Authenticator } from "@app/lib/auth";
 import { AgentMCPServerConfigurationModel } from "@app/lib/models/agent/actions/mcp";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
@@ -56,10 +56,11 @@ async function updateAgentConfigurationGroupIds(
     }
 
     // Calculate the correct group IDs using the updated function
-    const newRequirements = await getAgentConfigurationRequirementsFromActions(
-      auth,
-      { actions: ac.actions }
-    );
+    const newRequirements =
+      await getAgentConfigurationRequirementsFromCapabilities(auth, {
+        actions: ac.actions,
+        skills: [],
+      });
 
     // Check if the group IDs have changed
     if (_.isEqual(newRequirements.requestedSpaceIds, agent.requestedSpaceIds)) {

--- a/front/migrations/20251017_backfill_agent_requested_space_ids.ts
+++ b/front/migrations/20251017_backfill_agent_requested_space_ids.ts
@@ -2,7 +2,7 @@ import * as _ from "lodash";
 import { Op } from "sequelize";
 
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
-import { getAgentConfigurationRequirementsFromActions } from "@app/lib/api/assistant/permissions";
+import { getAgentConfigurationRequirementsFromCapabilities } from "@app/lib/api/assistant/permissions";
 import { Authenticator } from "@app/lib/auth";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
@@ -45,9 +45,9 @@ async function updateAgentRequestedSpaceIds(
   }
 
   // Calculate the correct space IDs from actions
-  const requirements = await getAgentConfigurationRequirementsFromActions(
+  const requirements = await getAgentConfigurationRequirementsFromCapabilities(
     auth,
-    { actions: agentConfiguration.actions }
+    { actions: agentConfiguration.actions, skills: [] }
   );
 
   // Skip if no space IDs are required

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -1,6 +1,8 @@
 import { isLeft } from "fp-ts/lib/Either";
 import * as reporter from "io-ts-reporters";
-import _ from "lodash";
+import keyBy from "lodash/keyBy";
+import omit from "lodash/omit";
+import uniq from "lodash/uniq";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { DEFAULT_MCP_ACTION_DESCRIPTION } from "@app/lib/actions/constants";
@@ -17,7 +19,7 @@ import {
 } from "@app/lib/api/assistant/configuration/agent";
 import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
 import { getAgentsEditors } from "@app/lib/api/assistant/editors";
-import { getAgentConfigurationRequirementsFromActions } from "@app/lib/api/assistant/permissions";
+import { getAgentConfigurationRequirementsFromCapabilities } from "@app/lib/api/assistant/permissions";
 import { getAgentsRecentAuthors } from "@app/lib/api/assistant/recent_authors";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { runOnRedis } from "@app/lib/api/redis";
@@ -135,12 +137,12 @@ async function handler(
             });
           }
         );
-        const usageMap = _.keyBy(mentionCounts, "agentId");
+        const usageMap = keyBy(mentionCounts, "agentId");
         agentConfigurations = agentConfigurations.map((agentConfiguration) =>
           usageMap[agentConfiguration.sId]
             ? {
                 ...agentConfiguration,
-                usage: _.omit(usageMap[agentConfiguration.sId], ["agentId"]),
+                usage: omit(usageMap[agentConfiguration.sId], ["agentId"]),
               }
             : agentConfiguration
         );
@@ -314,38 +316,28 @@ export async function createOrUpgradeAgentConfiguration({
     await UserResource.fetchByIds(assistant.editors.map((e) => e.sId))
   ).map((e) => e.toJSON());
 
-  const requirements = await getAgentConfigurationRequirementsFromActions(
+  let skills: SkillResource[] = [];
+  const featureFlags = await getFeatureFlags(auth.getNonNullableWorkspace());
+  if (
+    featureFlags.includes("skills") &&
+    assistant.skills &&
+    assistant.skills.length > 0
+  ) {
+    skills = await SkillResource.fetchByIds(
+      auth,
+      assistant.skills.map((s) => s.sId)
+    );
+  }
+
+  const requirements = await getAgentConfigurationRequirementsFromCapabilities(
     auth,
     {
       actions,
+      skills,
     }
   );
 
   let allRequestedSpaceIds = requirements.requestedSpaceIds;
-
-  // Collect requestedSpaceIds from skills (only when feature flag is enabled)
-  const featureFlags = await getFeatureFlags(auth.getNonNullableWorkspace());
-  if (featureFlags.includes("skills")) {
-    const skillResources = await SkillResource.fetchByIds(
-      auth,
-      (assistant.skills ?? []).map((s) => s.sId)
-    );
-
-    const skillRequestedSpaceIds = new Set<number>();
-    for (const skillResource of skillResources) {
-      for (const spaceId of skillResource.requestedSpaceIds) {
-        skillRequestedSpaceIds.add(spaceId);
-      }
-    }
-
-    // Merge action and skill requestedSpaceIds
-    allRequestedSpaceIds = [
-      ...new Set([
-        ...requirements.requestedSpaceIds,
-        ...skillRequestedSpaceIds,
-      ]),
-    ];
-  }
 
   // Collect additional requestedSpaceIds
   if (
@@ -376,9 +368,9 @@ export async function createOrUpgradeAgentConfiguration({
       additionalSpaces.map((s) => getResourceIdFromSId(s.sId))
     );
 
-    allRequestedSpaceIds = [
-      ...new Set([...allRequestedSpaceIds, ...additionalSpaceModelIds]),
-    ];
+    allRequestedSpaceIds = uniq(
+      allRequestedSpaceIds.concat(additionalSpaceModelIds)
+    );
   }
 
   const agentConfigurationRes = await createAgentConfiguration(auth, {

--- a/front/scripts/update_agent_requested_group_and_space_ids.ts
+++ b/front/scripts/update_agent_requested_group_and_space_ids.ts
@@ -2,7 +2,7 @@ import isEqual from "lodash/isEqual";
 import type { WhereOptions } from "sequelize";
 
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
-import { getAgentConfigurationRequirementsFromActions } from "@app/lib/api/assistant/permissions";
+import { getAgentConfigurationRequirementsFromCapabilities } from "@app/lib/api/assistant/permissions";
 import { Authenticator } from "@app/lib/auth";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
@@ -93,12 +93,11 @@ async function updateAgentRequestedSpaceIds(
     // Calculate the correct group IDs from actions
     // Note: You may see workspace_isolation_violation warnings in logs - these are benign
     // monitoring warnings, not actual errors. The auth parameter ensures proper scoping.
-    const newRequirements = await getAgentConfigurationRequirementsFromActions(
-      auth,
-      {
+    const newRequirements =
+      await getAgentConfigurationRequirementsFromCapabilities(auth, {
         actions: agentConfiguration.actions,
-      }
-    );
+        skills: [],
+      });
 
     const currentRequestedSpaceIds = agentConfiguration.requestedSpaceIds.map(
       (spaceSId) => {

--- a/front/tests/utils/SkillFactory.ts
+++ b/front/tests/utils/SkillFactory.ts
@@ -16,6 +16,7 @@ export class SkillFactory {
       instructions: string;
       status: SkillStatus;
       version: number;
+      requestedSpaceIds: ModelId[];
     }> = {}
   ): Promise<SkillResource> {
     const user = auth.user();
@@ -29,6 +30,7 @@ export class SkillFactory {
     const instructions = overrides.instructions ?? "Test skill instructions";
     const status = overrides.status ?? "active";
     const authorId = overrides.status === "suggested" ? null : user.id;
+    const requestedSpaceIds = overrides.requestedSpaceIds ?? [];
 
     return SkillResource.makeNew(
       auth,
@@ -38,7 +40,7 @@ export class SkillFactory {
         userFacingDescription,
         instructions,
         name,
-        requestedSpaceIds: [],
+        requestedSpaceIds,
         status,
       },
       {


### PR DESCRIPTION
Addresses issue raised in https://github.com/dust-tt/tasks/issues/5727#issuecomment-3715618943

## Description

- When a skill is updated with new `requestedSpaceIds`, propagate those spaces to all active agents using the skill
- **When spaces are removed from a skill, remove them from agent configs (unless another capability still requires them)**
- Fixes edge case: skill already equipped on agent, then updated with tools requiring restricted spaces → agent config wasn't updated
- Added `listActiveAgents()` private method (reused by `fetchUsage()`)
- Added `updateActiveAgentsRequirements()` private method called from `updateSkill()`

## Tests

Local + Added 4 tests for `updateSkill` space propagation (add, no-duplicate, remove, keep-if-shared)

## Risk

Low.

## Deploy Plan

Deploy front.