### PR TITLE
[front] fix(skills): remove background for tools in `SkillInfoTab`

### DIFF
--- a/front/components/assistant/details/tabs/AgentInfoTab/AssistantToolsSection.tsx
+++ b/front/components/assistant/details/tabs/AgentInfoTab/AssistantToolsSection.tsx
@@ -107,8 +107,8 @@ export function AssistantToolsSection({
                   key={action.title}
                   label={action.description ?? action.title}
                   trigger={
-                    <div className="flex min-w-0 flex-row items-center gap-2">
-                      <div className="flex-shrink-0">{action.avatar}</div>
+                    <div className="flex flex-row items-center gap-2">
+                      {action.avatar}
                       <div className="truncate">{action.title}</div>
                     </div>
                   }
@@ -125,8 +125,8 @@ export function AssistantToolsSection({
                   key={view.sId}
                   label={description ?? displayName}
                   trigger={
-                    <div className="flex min-w-0 flex-row items-center gap-2">
-                      <div className="flex-shrink-0">{avatar}</div>
+                    <div className="flex flex-row items-center gap-2">
+                      {avatar}
                       <div className="truncate">{displayName}</div>
                     </div>
                   }

--- a/front/components/skills/SkillInfoTab.tsx
+++ b/front/components/skills/SkillInfoTab.tsx
@@ -94,8 +94,8 @@ export function SkillInfoTab({
                 key={view.title}
                 label={view.description ?? view.title}
                 trigger={
-                  <div className="flex min-w-0 flex-row items-center gap-2">
-                    <div className="flex-shrink-0">{view.avatar}</div>
+                  <div className="flex flex-row items-center gap-2">
+                    {view.avatar}
                     <div className="truncate">{view.title}</div>
                   </div>
                 }

--- a/front/components/skills/SkillInfoTab.tsx
+++ b/front/components/skills/SkillInfoTab.tsx
@@ -1,8 +1,17 @@
-import { Chip, ReadOnlyTextArea, Separator, Spinner } from "@dust-tt/sparkle";
+import {
+  Chip,
+  ReadOnlyTextArea,
+  Separator,
+  Spinner,
+  Tooltip,
+} from "@dust-tt/sparkle";
 import sortBy from "lodash/sortBy";
 import { useMemo } from "react";
 
-import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
+import {
+  getMcpServerViewDescription,
+  getMcpServerViewDisplayName,
+} from "@app/lib/actions/mcp_helper";
 import { getAvatar } from "@app/lib/actions/mcp_icons";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { getSpaceIcon, getSpaceName } from "@app/lib/spaces";
@@ -79,11 +88,19 @@ export function SkillInfoTab({
           <div className="heading-lg text-foreground dark:text-foreground-night">
             Tools
           </div>
-          <div className="flex flex-wrap gap-2">
+          <div className="grid grid-cols-2 gap-2">
             {sortedMCPServerViews.map((view) => (
-              <Chip key={view.title} label={view.title} size="sm">
-                {view.avatar}
-              </Chip>
+              <Tooltip
+                key={view.title}
+                label={view.description ?? view.title}
+                trigger={
+                  <div className="flex min-w-0 flex-row items-center gap-2">
+                    <div className="flex-shrink-0">{view.avatar}</div>
+                    <div className="truncate">{view.title}</div>
+                  </div>
+                }
+                tooltipTriggerAsChild
+              />
             ))}
           </div>
         </div>
@@ -115,5 +132,6 @@ export function SkillInfoTab({
 
 const renderMCPServerView = (view: MCPServerViewType) => ({
   title: getMcpServerViewDisplayName(view),
+  description: getMcpServerViewDescription(view),
   avatar: getAvatar(view.server, "xs"),
 });


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/5839.
- This PR removes the background behind tools in `SkillInfoTab`.
- Matches agents https://github.com/dust-tt/dust/blob/main/front/components/assistant/details/tabs/AgentInfoTab/AssistantToolsSection.tsx#L124

Before
<img width="589" height="168" alt="Screenshot 2026-01-07 at 11 54 29 AM" src="https://github.com/user-attachments/assets/25ec4a4e-7c97-4d68-a7ac-14f64150fec8" />

After
<img width="589" height="168" alt="Screenshot 2026-01-07 at 11 52 02 AM" src="https://github.com/user-attachments/assets/0a562efb-5ae7-4ee7-a2b2-a9d28a744209" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
