### PR TITLE
[front] fix(skills): add descriptions in capabilities sheet

### DIFF
--- a/front/components/agent_builder/capabilities/capabilities_sheet/CapabilitiesSelectionPage.tsx
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/CapabilitiesSelectionPage.tsx
@@ -127,7 +127,13 @@ export function CapabilitiesSelectionPageContent({
         <>
           {showSkillsSection && hasSkills && (
             <>
-              <span className="text-lg font-semibold">Skills</span>
+              <div className="flex flex-col">
+                <span className="text-lg font-semibold">Skills</span>
+                <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+                  Reusable packages of instructions and tools that agents can
+                  share.
+                </span>
+              </div>
               <div className="grid grid-cols-2 gap-3">
                 {filteredSkills.map((skill) => (
                   <SkillCard
@@ -144,7 +150,12 @@ export function CapabilitiesSelectionPageContent({
 
           {showToolsSection && hasTools && (
             <>
-              <span className="text-lg font-semibold">Tools</span>
+              <div className="flex flex-col">
+                <span className="text-lg font-semibold">Tools</span>
+                <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+                  Capabilities that allow agents to take actions
+                </span>
+              </div>
               <div className="grid grid-cols-2 gap-3">
                 {sortedMCPServerViews.map((view) => (
                   <MCPServerCard


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/5841.
- This PR adds descriptions for skills and tools in the capabilities sheet in Agent Builder.

<img width="589" height="304" alt="Screenshot 2026-01-07 at 11 56 05 AM" src="https://github.com/user-attachments/assets/7e2ff918-ba02-4262-83a5-c890084f0747" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
