### PR TITLE
Add visual feedback when clicking review actions

### DIFF
--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -107,6 +107,18 @@ export const AgentInputBar = ({
   const showStopButton = generatingMessages.length > 0;
   const blockedActions = getBlockedActions(context.user.sId);
 
+  // Keep blockedActionIndex in sync when blockedActions array changes
+  useEffect(() => {
+    if (
+      blockedActionIndex >= blockedActions.length &&
+      blockedActions.length > 0
+    ) {
+      setBlockedActionIndex(blockedActions.length - 1);
+    } else if (blockedActions.length === 0) {
+      setBlockedActionIndex(0);
+    }
+  }, [blockedActionIndex, blockedActions.length]);
+
   const scrollToBottom = useCallback(() => {
     methods.scrollToItem({
       index: "LAST",

--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -109,13 +109,9 @@ export const AgentInputBar = ({
 
   // Keep blockedActionIndex in sync when blockedActions array changes
   useEffect(() => {
-    if (
-      blockedActionIndex >= blockedActions.length &&
-      blockedActions.length > 0
-    ) {
-      setBlockedActionIndex(blockedActions.length - 1);
-    } else if (blockedActions.length === 0) {
-      setBlockedActionIndex(0);
+    // Clamp index to valid range: [0, length-1] when non-empty, or 0 when empty
+    if (blockedActionIndex >= blockedActions.length) {
+      setBlockedActionIndex(Math.max(0, blockedActions.length - 1));
     }
   }, [blockedActionIndex, blockedActions.length]);
 

--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -42,7 +42,7 @@ export const AgentInputBar = ({
 }) => {
   const [blockedActionIndex, setBlockedActionIndex] = useState<number>(0);
   const generationContext = useContext(GenerationContext);
-  const { getBlockedActions, hasPendingValidations } =
+  const { getBlockedActions, hasPendingValidations, startPulsingAction } =
     useBlockedActionsContext();
 
   if (!generationContext) {
@@ -212,8 +212,10 @@ export const AgentInputBar = ({
               variant="outline"
               size="xs"
               onClick={() => {
-                const blockedActionTargetMessageId =
-                  blockedActions[blockedActionIndex].messageId;
+                const blockedAction = blockedActions[blockedActionIndex];
+                const blockedActionTargetMessageId = blockedAction.messageId;
+
+                startPulsingAction(blockedAction.actionId);
 
                 const blockedActionMessageIndex = methods.data.findIndex(
                   (m) =>

--- a/front/components/assistant/conversation/BlockedActionsProvider.tsx
+++ b/front/components/assistant/conversation/BlockedActionsProvider.tsx
@@ -22,7 +22,7 @@ type BlockedActionQueueItem = {
 };
 
 const EMPTY_BLOCKED_ACTIONS_QUEUE: BlockedActionQueueItem[] = [];
-const PULSE_DURATION_MS = 3000;
+const pulseDurationMs = 3000;
 
 type BlockedActionsContextType = {
   enqueueBlockedAction: (params: {
@@ -150,7 +150,7 @@ export function BlockedActionsProvider({
         return newSet;
       });
       pulseTimersRef.current.delete(actionId);
-    }, PULSE_DURATION_MS);
+    }, pulseDurationMs);
 
     pulseTimersRef.current.set(actionId, timer);
   }, []);

--- a/front/components/assistant/conversation/MCPToolValidationRequired.tsx
+++ b/front/components/assistant/conversation/MCPToolValidationRequired.tsx
@@ -38,7 +38,8 @@ export function MCPToolValidationRequired({
   const [neverAskAgain, setNeverAskAgain] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
-  const { removeCompletedAction } = useBlockedActionsContext();
+  const { removeCompletedAction, isActionPulsing, stopPulsingAction } =
+    useBlockedActionsContext();
   const { validateAction, isValidating } = useValidateAction({
     owner,
     conversationId,
@@ -50,6 +51,8 @@ export function MCPToolValidationRequired({
     [blockedAction.userId, user?.sId]
   );
 
+  const isPulsing = isActionPulsing(blockedAction.actionId);
+
   const icon = blockedAction.metadata.icon
     ? getIcon(blockedAction.metadata.icon)
     : undefined;
@@ -58,6 +61,9 @@ export function MCPToolValidationRequired({
     blockedAction?.inputs && Object.keys(blockedAction.inputs).length > 0;
 
   const handleValidation = async (approved: MCPValidationOutputType) => {
+    // Stop pulsing immediately when user takes action
+    stopPulsingAction(blockedAction.actionId);
+
     setErrorMessage(null);
 
     const result = await validateAction({
@@ -136,6 +142,7 @@ export function MCPToolValidationRequired({
               size="xs"
               icon={XMarkIcon}
               disabled={isValidating}
+              isPulsing={isPulsing}
               onClick={() => void handleValidation("rejected")}
             />
             <Button
@@ -144,6 +151,7 @@ export function MCPToolValidationRequired({
               size="xs"
               icon={CheckIcon}
               disabled={isValidating}
+              isPulsing={isPulsing}
               onClick={() => void handleValidation("approved")}
             />
           </div>


### PR DESCRIPTION
## Description

When user clicks on the "review" button because he currently has required manual actions on the conversation, we currently scroll to the message with manual action required. Which means that if the message is already visible, clicking "review" does nothing, which feels odd.

In this PR, we make the action buttons blink for 3 seconds when the user clicks on "review". If there are multiple actions required (say within messages A, B and C), clicking review will make A blink, then if the user click again it will make B blink, then C, then back to A.

## Tests

Manual

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
