### PR TITLE
[.gitignore] - feature: add exclusion pattern for .codex files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ core-api-keys.json
 oauth-api-keys.json
 /extension/build/
 **/.claude
+**/.codex
 **/.yalc
 yalc.lock
 front/public/sitemap.xml


### PR DESCRIPTION
## Description

 Include .codex files in the gitignore to prevent them from being tracked by git