### PR TITLE
[dust-hive] feat: Add change detection to sync/up commands

### DIFF
--- a/x/henry/dust-hive/CLAUDE.md
+++ b/x/henry/dust-hive/CLAUDE.md
@@ -6,17 +6,24 @@ Follow all rules in **CODING_RULES.md** before making changes.
 
 **CRITICAL**: Always run `bun run check` before committing. This runs typecheck, lint, and tests. Never commit code that fails these checks.
 
+**IMPORTANT**: Always use `bun run` commands from within the `x/henry/dust-hive` directory. Do NOT run `tsc`, `biome`, or other tools directly - use the npm scripts which ensure correct configuration.
+
 ```bash
 # Before committing - run ALL checks (MANDATORY)
-bun run check
+bun run check        # Runs: typecheck → lint → test
 
-# Individual checks
-bun run typecheck    # TypeScript strict checks
-bun run lint         # Biome linting
-bun run lint:fix     # Auto-fix lint issues
-bun run format       # Code formatting
-bun run test         # All tests
+# Individual checks (use these, not direct tool invocations)
+bun run typecheck    # tsc --noEmit
+bun run lint         # biome check . (includes formatting + import sorting)
+bun run lint:fix     # biome check --write . (auto-fix issues)
+bun run format       # biome format --write .
+bun run test         # bun test
 ```
+
+**Why use `bun run` instead of direct commands?**
+- `bun run lint` runs `biome check` which enforces formatting, import sorting, AND linting
+- Running `biome lint` directly misses formatting and import organization errors
+- The scripts ensure you're using the project's biome/typescript config
 
 **Always fix lint/type errors immediately** - don't accumulate them.
 

--- a/x/henry/dust-hive/src/commands/up.ts
+++ b/x/henry/dust-hive/src/commands/up.ts
@@ -13,6 +13,7 @@ import { syncCommand } from "./sync";
 
 interface UpOptions {
   attach?: boolean;
+  force?: boolean;
 }
 
 // Check preconditions for managed services mode
@@ -69,7 +70,7 @@ export async function upCommand(options: UpOptions = {}): Promise<Result<void>> 
   // Run sync first
   logger.step("Running sync...");
   console.log();
-  const syncResult = await syncCommand();
+  const syncResult = await syncCommand(options.force ? { force: true } : {});
   if (!syncResult.ok) {
     return syncResult;
   }

--- a/x/henry/dust-hive/src/index.ts
+++ b/x/henry/dust-hive/src/index.ts
@@ -155,8 +155,11 @@ cli
 cli
   .command("up", "Start managed services (temporal + main session)")
   .option("-a, --attach", "Attach to main zellij session")
-  .action(async (options: { attach?: boolean }) => {
-    await prepareAndRun(upCommand({ attach: Boolean(options.attach) }));
+  .option("-f, --force", "Force rebuild even if no changes detected")
+  .action(async (options: { attach?: boolean; force?: boolean }) => {
+    await prepareAndRun(
+      upCommand({ attach: Boolean(options.attach), force: Boolean(options.force) })
+    );
   });
 
 cli
@@ -228,9 +231,12 @@ cli
     await prepareAndRun(forwardCommand(target));
   });
 
-cli.command("sync", "Pull latest main, rebuild binaries, refresh deps").action(async () => {
-  await prepareAndRun(syncCommand());
-});
+cli
+  .command("sync", "Pull latest main, rebuild binaries, refresh deps")
+  .option("-f, --force", "Force rebuild even if no changes detected")
+  .action(async (options: { force?: boolean }) => {
+    await prepareAndRun(syncCommand({ force: Boolean(options.force) }));
+  });
 
 // Temporal subcommands
 cli.command("temporal start", "Start Temporal server").action(async () => {


### PR DESCRIPTION
## Description

Skip npm install, cargo build, and bun install when no changes detected since last sync. Detection is based on:
- npm: package-lock.json hash comparison per directory
- cargo: git diff on core/ between last synced commit and current HEAD
- bun: bun.lockb hash comparison

Also checks for missing binaries and rebuilds if needed.

Add --force flag to both sync and up commands to bypass detection.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
