### PR TITLE
[dust-hive] fix: update setup/doctor for new up/down workflow

### DIFF
--- a/x/henry/dust-hive/src/commands/doctor.ts
+++ b/x/henry/dust-hive/src/commands/doctor.ts
@@ -105,25 +105,14 @@ async function checkDockerCompose(): Promise<CheckResult> {
   };
 }
 
-async function checkTemporal(): Promise<{ cli: CheckResult; server: CheckResult }> {
+async function checkTemporalCli(): Promise<CheckResult> {
   const version = await getCommandVersion("temporal");
-  const running = await checkCommand("temporal", ["workflow", "list", "--limit", "1"]);
-
   return {
-    cli: {
-      name: "Temporal CLI",
-      ok: version !== null,
-      message: version ?? "Not found",
-      fix: "Install Temporal: brew install temporal",
-      installable: true,
-    },
-    server: {
-      name: "Temporal Server",
-      ok: running,
-      message: running ? "Running" : "Not running",
-      fix: "Start Temporal: temporal server start-dev",
-      installable: false,
-    },
+    name: "Temporal CLI",
+    ok: version !== null,
+    message: version ?? "Not found",
+    fix: "Install Temporal: brew install temporal",
+    installable: true,
   };
 }
 
@@ -249,16 +238,13 @@ function printResults(results: CheckResult[]): boolean {
 }
 
 async function runAllChecks(): Promise<CheckResult[]> {
-  const temporal = await checkTemporal();
-
   return [
     await checkHomebrew(),
     await checkBun(),
     await checkZellij(),
     await checkDocker(),
     await checkDockerCompose(),
-    temporal.cli,
-    temporal.server,
+    await checkTemporalCli(),
     await checkNvm(),
     await checkCargo(),
     await checkSccache(),
@@ -336,6 +322,11 @@ export async function setupCommand(options: SetupOptions = {}): Promise<Result<v
 
   if (allOk) {
     logger.success("All prerequisites met!");
+    console.log();
+    console.log("Next steps:");
+    console.log("  dust-hive up            # Start temporal server + sync main repo");
+    console.log("  dust-hive spawn <name>  # Create a new environment");
+    console.log();
     return Ok(undefined);
   }
 
@@ -360,6 +351,11 @@ export async function setupCommand(options: SetupOptions = {}): Promise<Result<v
 
   if (allOk) {
     logger.success("All prerequisites met!");
+    console.log();
+    console.log("Next steps:");
+    console.log("  dust-hive up            # Start temporal server + sync main repo");
+    console.log("  dust-hive spawn <name>  # Create a new environment");
+    console.log();
     return Ok(undefined);
   }
 
@@ -375,7 +371,7 @@ export async function setupCommand(options: SetupOptions = {}): Promise<Result<v
     console.log();
   }
 
-  logger.info("Ready to create environments once all prerequisites are met!");
+  logger.info("Once prerequisites are met, run: dust-hive up");
   return Err(new CommandError("Prerequisites check failed"));
 }
 

--- a/x/henry/dust-hive/src/index.ts
+++ b/x/henry/dust-hive/src/index.ts
@@ -211,7 +211,7 @@ cli.command("url [name]", "Print front URL").action(async (name: string | undefi
 });
 
 cli
-  .command("setup", "Interactive setup wizard for prerequisites")
+  .command("setup", "Check and install prerequisites (run this first!)")
   .option("-y, --non-interactive", "Run in non-interactive mode (same as doctor)")
   .action(async (options: { nonInteractive?: boolean }) => {
     await prepareAndRun(setupCommand({ nonInteractive: Boolean(options.nonInteractive) }));


### PR DESCRIPTION
## Description

- Remove Temporal Server running check from doctor (now managed by 'up')
- Add next steps guidance after successful setup
- Update final message to point users to 'dust-hive up'

The Temporal server is now started by 'dust-hive up', so checking if it's running during setup is no longer relevant and was confusing users.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
