### PR TITLE
[dust-hive] perf: exclude large directories from AGENTS.local.md search

### DIFF
--- a/x/henry/dust-hive/src/lib/setup.ts
+++ b/x/henry/dust-hive/src/lib/setup.ts
@@ -50,12 +50,38 @@ async function symlinkCargoTarget(srcDir: string, destDir: string): Promise<void
   }
 }
 
-// Find all AGENTS.local.md files in the repo
+// Find all AGENTS.local.md files in the repo (excluding node_modules and other large dirs)
 async function findAgentsLocalFiles(srcDir: string): Promise<string[]> {
-  const proc = Bun.spawn(["find", srcDir, "-name", "AGENTS.local.md", "-type", "f"], {
-    stdout: "pipe",
-    stderr: "pipe",
-  });
+  const proc = Bun.spawn(
+    [
+      "find",
+      srcDir,
+      "-name",
+      "AGENTS.local.md",
+      "-type",
+      "f",
+      // Exclude large directories that shouldn't contain user config files
+      "-not",
+      "-path",
+      "*/node_modules/*",
+      "-not",
+      "-path",
+      "*/.git/*",
+      "-not",
+      "-path",
+      "*/target/*",
+      "-not",
+      "-path",
+      "*/.next/*",
+      "-not",
+      "-path",
+      "*/.turbo/*",
+    ],
+    {
+      stdout: "pipe",
+      stderr: "pipe",
+    }
+  );
   const output = await new Response(proc.stdout).text();
   await proc.exited;
 


### PR DESCRIPTION


## Description

The findAgentsLocalFiles function was traversing the entire repo including node_modules, target, .git, .next, and .turbo directories, causing "Copying user config files..." to be very slow during spawn.
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
