### PR TITLE
[dust-hive] perf: use -prune instead of -not -path for find command

### DIFF
--- a/x/henry/dust-hive/src/lib/setup.ts
+++ b/x/henry/dust-hive/src/lib/setup.ts
@@ -51,31 +51,39 @@ async function symlinkCargoTarget(srcDir: string, destDir: string): Promise<void
 }
 
 // Find all AGENTS.local.md files in the repo (excluding node_modules and other large dirs)
+// Uses -prune to skip entire directory trees rather than filtering after traversal
 async function findAgentsLocalFiles(srcDir: string): Promise<string[]> {
   const proc = Bun.spawn(
     [
       "find",
       srcDir,
+      // Prune large directories (skips traversal entirely, much faster than -not -path)
+      "-type",
+      "d",
+      "(",
+      "-name",
+      "node_modules",
+      "-o",
+      "-name",
+      ".git",
+      "-o",
+      "-name",
+      "target",
+      "-o",
+      "-name",
+      ".next",
+      "-o",
+      "-name",
+      ".turbo",
+      ")",
+      "-prune",
+      "-o",
+      // Find AGENTS.local.md files
       "-name",
       "AGENTS.local.md",
       "-type",
       "f",
-      // Exclude large directories that shouldn't contain user config files
-      "-not",
-      "-path",
-      "*/node_modules/*",
-      "-not",
-      "-path",
-      "*/.git/*",
-      "-not",
-      "-path",
-      "*/target/*",
-      "-not",
-      "-path",
-      "*/.next/*",
-      "-not",
-      "-path",
-      "*/.turbo/*",
+      "-print",
     ],
     {
       stdout: "pipe",


### PR DESCRIPTION
## Description

The previous fix used `-not -path` which still traverses into excluded directories before filtering. Using `-prune` skips entire directory trees, reducing search time from ~15s to ~0.4s (36x faster).

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
