### PR TITLE
Fix issue where new conversation would not immediately show up in the sidebar.

### DIFF
--- a/front/components/assistant/conversation/utils.ts
+++ b/front/components/assistant/conversation/utils.ts
@@ -17,33 +17,38 @@ export function getGroupConversationsByUnreadAndActionRequired(
   conversations: ConversationWithoutContentType[],
   titleFilter: string
 ) {
-  return conversations.reduce(
-    (acc, conversation) => {
-      if (
-        titleFilter &&
-        !subFilter(
-          removeDiacritics(titleFilter).toLowerCase(),
-          removeDiacritics(conversation.title ?? "").toLowerCase()
-        )
-      ) {
-        return acc;
-      }
+  return (
+    conversations
+      // Ensure that the conversations are always sorted by updated time as the list might have been manipulated client-side.
+      .toSorted((a, b) => b.updated - a.updated)
+      .reduce(
+        (acc, conversation) => {
+          if (
+            titleFilter &&
+            !subFilter(
+              removeDiacritics(titleFilter).toLowerCase(),
+              removeDiacritics(conversation.title ?? "").toLowerCase()
+            )
+          ) {
+            return acc;
+          }
 
-      if (conversation.unread || conversation.actionRequired) {
-        acc.inboxConversations.push(conversation);
-        return acc;
-      }
+          if (conversation.unread || conversation.actionRequired) {
+            acc.inboxConversations.push(conversation);
+            return acc;
+          }
 
-      acc.readConversations.push(conversation);
-      return acc;
-    },
-    {
-      readConversations: [],
-      inboxConversations: [],
-    } as {
-      readConversations: ConversationWithoutContentType[];
-      inboxConversations: ConversationWithoutContentType[];
-    }
+          acc.readConversations.push(conversation);
+          return acc;
+        },
+        {
+          readConversations: [],
+          inboxConversations: [],
+        } as {
+          readConversations: ConversationWithoutContentType[];
+          inboxConversations: ConversationWithoutContentType[];
+        }
+      )
   );
 }
 


### PR DESCRIPTION
## Description

Issue was that we appended the new conversation at the end of the list and it would be skipped by a .slice() that only take the first page of conversations client side.

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy front