### PR TITLE
[Front] refactor(skills): move space requirements logic to MCPServerViewResource

### DIFF
--- a/front/lib/api/assistant/permissions.ts
+++ b/front/lib/api/assistant/permissions.ts
@@ -1,22 +1,19 @@
+import uniq from "lodash/uniq";
+
 import type { ServerSideMCPServerConfigurationType } from "@app/lib/actions/mcp";
-import { getAvailabilityOfInternalMCPServerById } from "@app/lib/actions/mcp_internal_actions/constants";
-import type {
-  UnsavedMCPServerConfigurationType,
-  UnsavedServerSideMCPServerConfigurationType,
-} from "@app/lib/actions/types/agent";
+import type { UnsavedMCPServerConfigurationType } from "@app/lib/actions/types/agent";
 import { isServerSideMCPServerConfiguration } from "@app/lib/actions/types/guards";
 import type { Authenticator } from "@app/lib/auth";
 import { AppResource } from "@app/lib/resources/app_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
-import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
 import type {
   CombinedResourcePermissions,
   ContentFragmentInputWithContentNode,
   ModelId,
 } from "@app/types";
-import { assertNever, removeNulls } from "@app/types";
+import { removeNulls } from "@app/types";
 
 export function getDataSourceViewIdsFromActions(
   actions: UnsavedMCPServerConfigurationType[]
@@ -67,61 +64,23 @@ export async function getAgentConfigurationRequirementsFromActions(
   }
 ): Promise<{ requestedSpaceIds: ModelId[] }> {
   const { actions, ignoreSpaces } = params;
-  const ignoreSpaceIds = new Set(ignoreSpaces?.map((space) => space.sId));
+  const ignoreSpaceModelIds = new Set(ignoreSpaces?.map((space) => space.id));
 
+  // Collect DataSourceView permissions by space.
   const dsViews = await DataSourceViewResource.fetchByIds(
     auth,
     getDataSourceViewIdsFromActions(actions)
   );
-  // Map spaceId to its group requirements.
-  const spacePermissions = new Set<string>();
-
-  // Collect DataSourceView permissions by space.
-  for (const view of dsViews) {
-    const { sId: spaceId } = view.space;
-    if (ignoreSpaceIds?.has(spaceId)) {
-      continue;
-    }
-
-    spacePermissions.add(spaceId);
-  }
+  const dsViewRequirements = dsViews.map((view) => view.space.id);
 
   // Collect MCPServerView permissions by space.
-  const mcpServerViews = await MCPServerViewResource.fetchByIds(
-    auth,
-    actions
-      .filter((action) => isServerSideMCPServerConfiguration(action))
-      .map(
-        (action) =>
-          (action as ServerSideMCPServerConfigurationType).mcpServerViewId
-      )
-  );
-
-  for (const view of mcpServerViews) {
-    const { sId: spaceId } = view.space;
-    if (ignoreSpaceIds?.has(spaceId)) {
-      continue;
-    }
-
-    // We skip the permissions for internal tools as they are automatically available to all users.
-    // This mimic the previous behavior of generic internal tools (search etc..).
-    if (view.serverType === "internal") {
-      const availability = getAvailabilityOfInternalMCPServerById(
-        view.mcpServerId
-      );
-      switch (availability) {
-        case "auto":
-        case "auto_hidden_builder":
-          continue;
-        case "manual":
-          break;
-        default:
-          assertNever(availability);
-      }
-    }
-
-    spacePermissions.add(spaceId);
-  }
+  const mcpServerViewRequirements =
+    await MCPServerViewResource.listSpaceRequirementsByIds(
+      auth,
+      actions
+        .filter(isServerSideMCPServerConfiguration)
+        .map((action) => action.mcpServerViewId)
+    );
 
   // Collect Dust App permissions by space.
   const dustAppIds = removeNulls(
@@ -129,52 +88,20 @@ export async function getAgentConfigurationRequirementsFromActions(
       .filter(isServerSideMCPServerConfiguration)
       .map((action) => action.dustAppConfiguration?.appId)
   );
+  let dustAppRequirements: ModelId[] = [];
 
   if (dustAppIds.length > 0) {
     const dustApps = await AppResource.fetchByIds(auth, dustAppIds);
-
-    for (const app of dustApps) {
-      const { sId: spaceId } = app.space;
-      if (ignoreSpaceIds?.has(spaceId)) {
-        continue;
-      }
-
-      spacePermissions.add(spaceId);
-    }
+    dustAppRequirements = dustApps.map((app) => app.space.id);
   }
 
-  // Convert Map to array of arrays, filtering out empty sets.
-  return {
-    requestedSpaceIds: removeNulls(
-      Array.from(spacePermissions).map(getResourceIdFromSId)
-    ),
-  };
-}
+  const requestedSpaceIds = uniq([
+    ...dsViewRequirements,
+    ...mcpServerViewRequirements,
+    ...dustAppRequirements,
+  ]).filter((id) => !ignoreSpaceModelIds.has(id));
 
-export async function getRequestedSpaceIdsFromMCPServerViewIds(
-  auth: Authenticator,
-  mcpServerViewIds: string[]
-): Promise<ModelId[]> {
-  // create dummy actions to reuse existing logic.
-  // we only need the space ids based on the MCP server views so other fields can be empty.
-  const actions: UnsavedServerSideMCPServerConfigurationType[] =
-    mcpServerViewIds.map((mcpServerViewId) => ({
-      type: "mcp_server_configuration" as const,
-      mcpServerViewId,
-      name: "",
-      description: "",
-      dataSources: null,
-      tables: null,
-      childAgentId: null,
-      timeFrame: null,
-      jsonSchema: null,
-      additionalConfiguration: {},
-      dustAppConfiguration: null,
-      secretName: null,
-    }));
-  const { requestedSpaceIds } =
-    await getAgentConfigurationRequirementsFromActions(auth, { actions });
-  return requestedSpaceIds;
+  return { requestedSpaceIds };
 }
 
 export async function getContentFragmentGroupIds(

--- a/front/pages/api/w/[wId]/skills/[sId]/index.test.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.test.ts
@@ -231,6 +231,30 @@ describe("PATCH /api/w/[wId]/skills/[sId]", () => {
     expect(res._getJSONData().error.message).toContain("Invalid MCP server");
   });
 
+  it("should return 404 when MCP server views not found", async () => {
+    const { req, res } = await setupTest({
+      requestUserRole: "admin",
+      method: "PATCH",
+    });
+
+    req.body = {
+      name: "Updated Skill",
+      agentFacingDescription: "Agent description",
+      userFacingDescription: "User description",
+      instructions: "Instructions",
+      icon: null,
+      tools: [{ mcpServerViewId: "msv_nonexistent123456" }],
+      attachedKnowledge: [],
+    };
+
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(404);
+    expect(res._getJSONData().error.type).toBe("invalid_request_error");
+    expect(res._getJSONData().error.message).toContain(
+      "MCP server views not all found"
+    );
+  });
+
   it("should return 400 for invalid request body", async () => {
     const { req, res } = await setupTest({
       requestUserRole: "admin",

--- a/front/pages/api/w/[wId]/skills/[sId]/index.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.ts
@@ -206,7 +206,7 @@ async function handler(
       }
 
       // Fetch MCP server views first to compute requestedSpaceIds.
-      const mcpServerViewIds = body.tools.map((t) => t.mcpServerViewId);
+      const mcpServerViewIds = uniq(body.tools.map((t) => t.mcpServerViewId));
       const mcpServerViews = await MCPServerViewResource.fetchByIds(
         auth,
         mcpServerViewIds

--- a/front/pages/api/w/[wId]/skills/[sId]/index.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.ts
@@ -4,7 +4,6 @@ import * as reporter from "io-ts-reporters";
 import uniq from "lodash/uniq";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { getRequestedSpaceIdsFromMCPServerViewIds } from "@app/lib/api/assistant/permissions";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
@@ -215,7 +214,7 @@ async function handler(
 
       if (mcpServerViewIds.length !== mcpServerViews.length) {
         return apiError(req, res, {
-          status_code: 400,
+          status_code: 404,
           api_error: {
             type: "invalid_request_error",
             message: `MCP server views not all found, ${mcpServerViews.length} found, ${mcpServerViewIds.length} requested`,
@@ -223,10 +222,11 @@ async function handler(
         });
       }
 
-      const requestedSpaceIds = await getRequestedSpaceIdsFromMCPServerViewIds(
-        auth,
-        mcpServerViewIds
-      );
+      const requestedSpaceIds =
+        await MCPServerViewResource.listSpaceRequirementsByIds(
+          auth,
+          mcpServerViewIds
+        );
 
       // Validate all data source views from attached knowledge exist and user has access.
       const { attachedKnowledge } = body;

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -189,7 +189,7 @@ async function handler(
       }
 
       // Validate all MCP server views exist before creating anything
-      const mcpServerViewIds = body.tools.map((t) => t.mcpServerViewId);
+      const mcpServerViewIds = uniq(body.tools.map((t) => t.mcpServerViewId));
       const mcpServerViews = await MCPServerViewResource.fetchByIds(
         auth,
         mcpServerViewIds


### PR DESCRIPTION
## Description

This PR extracts the `mcpserverview` space requirements logic to a shared function (adding a method in the resource seems appropriate).

This will allow in a later PR to change `getAgentConfigurationRequirementsFromActions` to also retrieve spaces from skills, fixing currently broken space deletion logic, simplifying agent configuration creation code and allowing to tackle this issue : https://github.com/dust-tt/dust/pull/19709#discussion_r2668193992

Main :
- Move `getRequestedSpaceIdsFromMCPServerViewIds` logic to `MCPServerViewResource.listSpaceRequirementsByIds`
- Simplify `getAgentConfigurationRequirementsFromActions` by delegating MCP space requirements to the resource

Misc :
- Batch MCP server view fetches in skills POST endpoint (was fetching one by one)
- Fix status code 400 -> 404 when MCP server views not found in skills PATCH (added missing test case too)

## Tests

Existing tests cover the refactored logic.

## Risk

Low.

## Deploy Plan

Deploy front.
