### PR TITLE
Some projects polishing

### DIFF
--- a/front/components/assistant/conversation/CreateProjectModal.tsx
+++ b/front/components/assistant/conversation/CreateProjectModal.tsx
@@ -8,15 +8,15 @@ import {
   DialogTitle,
   Input,
 } from "@dust-tt/sparkle";
+import { useRouter } from "next/router";
 import { useCallback, useEffect, useState } from "react";
 
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useSpaceConversationsSummary } from "@app/lib/swr/conversations";
 import { useCreateSpace } from "@app/lib/swr/spaces";
 import { useUser } from "@app/lib/swr/user";
-import type { LightWorkspaceType } from "@app/types";
 import { getSpaceConversationsRoute } from "@app/lib/utils/router";
-import { useRouter } from "next/router";
+import type { LightWorkspaceType } from "@app/types";
 
 interface CreateProjectModalProps {
   isOpen: boolean;

--- a/front/components/assistant/conversation/CreateProjectModal.tsx
+++ b/front/components/assistant/conversation/CreateProjectModal.tsx
@@ -93,6 +93,8 @@ export function CreateProjectModal({
     sendNotification,
     mutateSpaceSummary,
     user,
+    router,
+    owner.sId,
   ]);
 
   const handleKeyPress = useCallback(

--- a/front/components/assistant/conversation/CreateProjectModal.tsx
+++ b/front/components/assistant/conversation/CreateProjectModal.tsx
@@ -15,6 +15,8 @@ import { useSpaceConversationsSummary } from "@app/lib/swr/conversations";
 import { useCreateSpace } from "@app/lib/swr/spaces";
 import { useUser } from "@app/lib/swr/user";
 import type { LightWorkspaceType } from "@app/types";
+import { getSpaceConversationsRoute } from "@app/lib/utils/router";
+import { useRouter } from "next/router";
 
 interface CreateProjectModalProps {
   isOpen: boolean;
@@ -32,6 +34,7 @@ export function CreateProjectModal({
 
   const doCreate = useCreateSpace({ owner });
   const { user } = useUser();
+  const router = useRouter();
 
   const sendNotification = useSendNotification();
 
@@ -81,6 +84,7 @@ export function CreateProjectModal({
         description: `Project "${trimmedName}" has been created.`,
       });
       handleClose();
+      void router.push(getSpaceConversationsRoute(owner.sId, createdSpace.sId));
     }
   }, [
     projectName,

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -568,7 +568,17 @@ export function AgentSidebarMenu({ owner }: AgentSidebarMenuProps) {
                       ) : null
                     }
                   >
-                    <ProjectsList owner={owner} summary={summary} />
+                    <div className="mt-0.5 px-3 sm:flex sm:flex-col sm:gap-0.5">
+                      {summary.length > 0 ? (
+                        <ProjectsList owner={owner} summary={summary} />
+                      ) : (
+                        <NavigationListItem
+                          label="Create a Project"
+                          icon={PlusIcon}
+                          onClick={() => setIsCreateProjectModalOpen(true)}
+                        />
+                      )}
+                    </div>
                   </NavigationListCollapsibleSection>
 
                   <NavigationListCollapsibleSection

--- a/front/components/assistant/conversation/sidebar/ProjectsList.tsx
+++ b/front/components/assistant/conversation/sidebar/ProjectsList.tsx
@@ -68,7 +68,7 @@ export function ProjectsList({ owner, summary }: ProjectsListProps) {
   }
 
   return (
-    <div className="mt-0.5 px-3 sm:flex sm:flex-col sm:gap-0.5">
+    <>
       {summary.map(({ space, unreadConversations }) => (
         <ProjectListItem
           key={space.sId}
@@ -77,6 +77,6 @@ export function ProjectsList({ owner, summary }: ProjectsListProps) {
           owner={owner}
         />
       ))}
-    </div>
+    </>
   );
 }

--- a/front/components/assistant/conversation/space/about/DeleteSpaceDialog.tsx
+++ b/front/components/assistant/conversation/space/about/DeleteSpaceDialog.tsx
@@ -41,7 +41,7 @@ export function DeleteSpaceDialog({ owner, space }: DeleteSpaceDialogProps) {
       void mutateSpaceSummary();
     }
     setIsDeleting(false);
-  }, [doDelete, space, mutateSpaceSummary, owner.sId]);
+  }, [doDelete, space, mutateSpaceSummary, owner.sId, router]);
 
   return (
     <Dialog>

--- a/front/components/assistant/conversation/space/about/DeleteSpaceDialog.tsx
+++ b/front/components/assistant/conversation/space/about/DeleteSpaceDialog.tsx
@@ -1,0 +1,90 @@
+import {
+  Button,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+  Spinner,
+  TrashIcon,
+} from "@dust-tt/sparkle";
+import React, { useCallback, useState } from "react";
+
+import { getSpaceName } from "@app/lib/spaces";
+import { useSpaceConversationsSummary } from "@app/lib/swr/conversations";
+import { useDeleteSpace } from "@app/lib/swr/spaces";
+import type { LightWorkspaceType, SpaceType } from "@app/types";
+import { useRouter } from "next/router";
+import { getConversationRoute } from "@app/lib/utils/router";
+
+interface DeleteSpaceDialogProps {
+  owner: LightWorkspaceType;
+  space: SpaceType;
+}
+
+export function DeleteSpaceDialog({ owner, space }: DeleteSpaceDialogProps) {
+  const router = useRouter();
+  const [isDeleting, setIsDeleting] = useState(false);
+  const doDelete = useDeleteSpace({ owner, force: true });
+  const { mutate: mutateSpaceSummary } = useSpaceConversationsSummary({
+    workspaceId: owner.sId,
+    options: { disabled: true },
+  });
+
+  const onDelete = useCallback(async () => {
+    setIsDeleting(true);
+    const deleted = await doDelete(space);
+    if (deleted) {
+      void router.push(getConversationRoute(owner.sId));
+      void mutateSpaceSummary();
+    }
+    setIsDeleting(false);
+  }, [doDelete, space, mutateSpaceSummary, owner.sId]);
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <div className="flex w-full flex-col items-start">
+          <Button icon={TrashIcon} variant="warning" label="Delete project" />
+        </div>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{`Delete ${getSpaceName(space)}`}</DialogTitle>
+        </DialogHeader>
+        {isDeleting ? (
+          <div className="flex justify-center py-8">
+            <Spinner variant="dark" size="md" />
+          </div>
+        ) : (
+          <>
+            <DialogContainer className="space-y-4">
+              <div>
+                <p className="text-sm text-muted-foreground">
+                  Are you sure you want to permanently delete project{" "}
+                  <strong>{getSpaceName(space)}</strong>? This action cannot be
+                  undone.
+                </p>
+              </div>
+            </DialogContainer>
+            <DialogFooter
+              leftButtonProps={{
+                label: "Cancel",
+                variant: "outline",
+              }}
+              rightButtonProps={{
+                label: "Delete",
+                variant: "warning",
+                onClick: async () => {
+                  void onDelete();
+                },
+              }}
+            />
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/front/components/assistant/conversation/space/about/DeleteSpaceDialog.tsx
+++ b/front/components/assistant/conversation/space/about/DeleteSpaceDialog.tsx
@@ -10,14 +10,14 @@ import {
   Spinner,
   TrashIcon,
 } from "@dust-tt/sparkle";
+import { useRouter } from "next/router";
 import React, { useCallback, useState } from "react";
 
 import { getSpaceName } from "@app/lib/spaces";
 import { useSpaceConversationsSummary } from "@app/lib/swr/conversations";
 import { useDeleteSpace } from "@app/lib/swr/spaces";
-import type { LightWorkspaceType, SpaceType } from "@app/types";
-import { useRouter } from "next/router";
 import { getConversationRoute } from "@app/lib/utils/router";
+import type { LightWorkspaceType, SpaceType } from "@app/types";
 
 interface DeleteSpaceDialogProps {
   owner: LightWorkspaceType;

--- a/front/components/assistant/conversation/space/about/SpaceAboutTab.tsx
+++ b/front/components/assistant/conversation/space/about/SpaceAboutTab.tsx
@@ -1,6 +1,7 @@
-import { Button } from "@dust-tt/sparkle";
+import { Button, ContentMessage } from "@dust-tt/sparkle";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 
+import { DeleteSpaceDialog } from "@app/components/assistant/conversation/space/about/DeleteSpaceDialog";
 import { RestrictedAccessBody } from "@app/components/spaces/RestrictedAccessBody";
 import { useUpdateSpace } from "@app/lib/swr/spaces";
 import type {
@@ -122,7 +123,7 @@ export function SpaceAboutTab({
   ]);
 
   return (
-    <div className="flex w-full flex-col gap-y-4 p-8">
+    <div className="flex w-full flex-col gap-y-4 px-4 py-8">
       <RestrictedAccessBody
         isManual={isManual}
         planAllowsSCIM={planAllowsSCIM}
@@ -148,6 +149,24 @@ export function SpaceAboutTab({
           onClick={onSave}
           disabled={!canSave || isSaving}
         />
+      </div>
+
+      <div className="flex w-full flex-col items-center gap-y-4 border-t pt-8">
+        <ContentMessage
+          variant="warning"
+          title="Danger Zone"
+          className="flex w-full"
+        >
+          <div className="flex flex-col gap-y-4">
+            <p className="text-sm text-muted-foreground">
+              Deleting this project will permanently remove all its content,
+              including conversations, folders, websites, and data sources. This
+              action cannot be undone. All assistants using tools that depend on
+              this project will be impacted.
+            </p>
+            <DeleteSpaceDialog owner={owner} space={space} />
+          </div>
+        </ContentMessage>
       </div>
     </div>
   );

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -34,7 +34,10 @@ export async function softDeleteSpaceAndLaunchScrubWorkflow(
   force?: boolean
 ) {
   assert(auth.isAdmin(), "Only admins can delete spaces.");
-  assert(space.isRegular(), "Cannot delete non regular spaces.");
+  assert(
+    space.isRegular() || space.isProject(),
+    "Cannot delete spaces that are not regular or project."
+  );
 
   const usages: AgentsUsageType[] = [];
 

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -884,6 +884,9 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   isRegular() {
     return this.kind === "regular";
   }
+  isProject() {
+    return this.kind === "project";
+  }
 
   isRegularAndRestricted() {
     return this.isRegular() && !this.groups.some((group) => group.isGlobal());

--- a/front/lib/utils/router.ts
+++ b/front/lib/utils/router.ts
@@ -72,5 +72,5 @@ export const getSpaceConversationsRoute = (
   workspaceId: string,
   spaceId: string
 ) => {
-  return `/w/${workspaceId}/conversation/space/${spaceId}`;
+  return `/w/${workspaceId}/conversation/space/${spaceId}#conversations`;
 };

--- a/front/pages/w/[wId]/conversation/space/[spaceId]/index.tsx
+++ b/front/pages/w/[wId]/conversation/space/[spaceId]/index.tsx
@@ -19,7 +19,7 @@ import { useCallback, useState } from "react";
 import { ConversationContainerVirtuoso } from "@app/components/assistant/conversation/ConversationContainer";
 import type { ConversationLayoutProps } from "@app/components/assistant/conversation/ConversationLayout";
 import { ConversationLayout } from "@app/components/assistant/conversation/ConversationLayout";
-import { SpaceAboutTab } from "@app/components/assistant/conversation/space/SpaceAboutTab";
+import { SpaceAboutTab } from "@app/components/assistant/conversation/space/about/SpaceAboutTab";
 import { SpaceConversationsTab } from "@app/components/assistant/conversation/space/SpaceConversationsTab";
 import { SpaceKnowledgeTab } from "@app/components/assistant/conversation/space/SpaceKnowledgeTab";
 import { SpaceToolsTab } from "@app/components/assistant/conversation/space/SpaceToolsTab";
@@ -149,7 +149,7 @@ export default function SpaceConversations({
     // Listen for hash changes
     window.addEventListener("hashchange", updateTabFromHash);
     return () => window.removeEventListener("hashchange", updateTabFromHash);
-  }, []);
+  }, [router.asPath]);
 
   const handleTabChange = useCallback((tab: SpaceTab) => {
     window.location.hash = tab;


### PR DESCRIPTION
## Description

This PR:
- Adds a "Create a Project" CTA button in the sidebar when the user has no projects, 
<img width="319" height="90" alt="image" src="https://github.com/user-attachments/assets/ddb7d061-72d8-4686-8528-7b685486461a" />

- Implements project deletion in the About tab. The project deletion feature includes a danger zone with a confirmation dialog that redirects users to the main conversation view after deletion. Design to refined.
<img width="396" height="348" alt="image" src="https://github.com/user-attachments/assets/77f84501-2a9e-41dc-ae79-56626a9416f3" />

- When creating a project from the sidebar, the user is now automatically redirected to the new project's conversations view. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Deploy front
