### PR TITLE
Tweak the UI to match the design a bit better

### DIFF
--- a/front/components/navigation/NavigationSidebar.tsx
+++ b/front/components/navigation/NavigationSidebar.tsx
@@ -1,4 +1,5 @@
 import {
+  Button,
   classNames,
   cn,
   CollapseButton,
@@ -385,9 +386,7 @@ function SubscriptionEndBanner({
       footer={
         isFreePlan && (
           <Link href={`/w/${workspaceId}/subscribe`} className="no-underline">
-            <button className="rounded bg-foreground px-3 py-1.5 text-xs font-medium text-background">
-              Subscribe to Dust
-            </button>
+            <Button label="Subscribe to Dust" variant="primary" />
           </Link>
         )
       }
@@ -463,7 +462,7 @@ function TrialMessageUsage({ workspaceId }: TrialMessageUsageProps) {
       <div
         className={cn(
           "h-2 w-full overflow-hidden rounded-full",
-          "bg-structure-200 dark:bg-structure-200-night"
+          "bg-gray-100 dark:bg-gray-700"
         )}
       >
         <div
@@ -479,9 +478,7 @@ function TrialMessageUsage({ workspaceId }: TrialMessageUsageProps) {
       {isAtLimit && (
         <div className="mt-3">
           <Link href={`/w/${workspaceId}/subscribe`} className="no-underline">
-            <button className="rounded bg-foreground px-3 py-1.5 text-xs font-medium text-background dark:bg-foreground-night dark:text-background-night">
-              Subscribe to Dust
-            </button>
+            <Button label="Subscribe to Dust" variant="primary" />
           </Link>
         </div>
       )}

--- a/front/components/navigation/NavigationSidebar.tsx
+++ b/front/components/navigation/NavigationSidebar.tsx
@@ -445,7 +445,7 @@ function TrialMessageUsage({ workspaceId }: TrialMessageUsageProps) {
       className={cn(
         "mx-3 mb-3 rounded-lg border p-3",
         "border-border dark:border-border-night",
-        "bg-white dark:bg-background-night"
+        "bg-background dark:bg-background-night"
       )}
     >
       <div className="mb-2 flex items-center justify-between text-sm">

--- a/front/components/navigation/NavigationSidebar.tsx
+++ b/front/components/navigation/NavigationSidebar.tsx
@@ -462,7 +462,7 @@ function TrialMessageUsage({ workspaceId }: TrialMessageUsageProps) {
       <div
         className={cn(
           "h-2 w-full overflow-hidden rounded-full",
-          "bg-gray-100 dark:bg-gray-700"
+          "bg-gray-100 dark:bg-gray-800"
         )}
       >
         <div

--- a/front/components/navigation/NavigationSidebar.tsx
+++ b/front/components/navigation/NavigationSidebar.tsx
@@ -446,11 +446,11 @@ function TrialMessageUsage({ workspaceId }: TrialMessageUsageProps) {
       className={cn(
         "mx-3 mb-3 rounded-lg border p-3",
         "border-border dark:border-border-night",
-        "bg-muted-background dark:bg-muted-background-night"
+        "bg-white dark:bg-background-night"
       )}
     >
       <div className="mb-2 flex items-center justify-between text-sm">
-        <span className="text-muted-foreground dark:text-muted-foreground-night">
+        <span className="font-semibold text-foreground dark:text-foreground-night">
           Trial message used
         </span>
         <span className="font-medium text-foreground dark:text-foreground-night">
@@ -479,7 +479,7 @@ function TrialMessageUsage({ workspaceId }: TrialMessageUsageProps) {
       {isAtLimit && (
         <div className="mt-3">
           <Link href={`/w/${workspaceId}/subscribe`} className="no-underline">
-            <button className="w-full rounded bg-foreground px-3 py-1.5 text-xs font-medium text-background dark:bg-foreground-night dark:text-background-night">
+            <button className="rounded bg-foreground px-3 py-1.5 text-xs font-medium text-background dark:bg-foreground-night dark:text-background-night">
               Subscribe to Dust
             </button>
           </Link>

--- a/front/components/navigation/NavigationSidebar.tsx
+++ b/front/components/navigation/NavigationSidebar.tsx
@@ -462,14 +462,14 @@ function TrialMessageUsage({ workspaceId }: TrialMessageUsageProps) {
       <div
         className={cn(
           "h-2 w-full overflow-hidden rounded-full",
-          "bg-gray-100 dark:bg-gray-800"
+          "bg-gray-100 dark:bg-gray-100-night"
         )}
       >
         <div
           className={cn(
             "h-full rounded-full transition-all",
             isCritical
-              ? "bg-red-700 dark:bg-red-600"
+              ? "bg-red-700 dark:bg-red-700-night"
               : "bg-foreground dark:bg-foreground-night"
           )}
           style={{ width: `${Math.min(percentage * 100, 100)}%` }}

--- a/front/components/navigation/NavigationSidebar.tsx
+++ b/front/components/navigation/NavigationSidebar.tsx
@@ -451,7 +451,7 @@ function TrialMessageUsage({ workspaceId }: TrialMessageUsageProps) {
     >
       <div className="mb-2 flex items-center justify-between text-sm">
         <span className="font-semibold text-foreground dark:text-foreground-night">
-          Trial message used
+          Trial messages used
         </span>
         <span className="font-medium text-foreground dark:text-foreground-night">
           <span className={cn(isCritical && "text-red-600 dark:text-red-400")}>


### PR DESCRIPTION
## Description

Now looks like this:
<img width="314" height="79" alt="Screenshot 2026-01-07 at 15 38 12" src="https://github.com/user-attachments/assets/57bb9b9f-eb53-4eba-9bc8-4c706e655d86" />
<img width="315" height="127" alt="Screenshot 2026-01-07 at 15 37 58" src="https://github.com/user-attachments/assets/916d10ec-da0c-4dd5-a787-2bd6adcfef8c" />

## Tests

Manual

## Risk

None

## Deploy Plan

Front