### PR TITLE
[front] chore(skills): rename `SkillConfigurationFactory` into `SkillFactory`

### DIFF
--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -6,7 +6,7 @@ import type { SkillAttachedKnowledge } from "@app/lib/resources/skill/skill_reso
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
-import { SkillConfigurationFactory } from "@app/tests/utils/SkillConfigurationFactory";
+import { SkillFactory } from "@app/tests/utils/SkillFactory";
 
 describe("SkillResource", () => {
   let testContext: Awaited<ReturnType<typeof createResourceTest>>;
@@ -163,7 +163,7 @@ describe("SkillResource", () => {
     });
 
     it("should detect configurations that need deletion", async () => {
-      const skillResource = await SkillConfigurationFactory.create(
+      const skillResource = await SkillFactory.create(
         testContext.authenticator,
         {}
       );
@@ -208,7 +208,7 @@ describe("SkillResource", () => {
     });
 
     it("should detect when parentsIn has changed", async () => {
-      const skillResource = await SkillConfigurationFactory.create(
+      const skillResource = await SkillFactory.create(
         testContext.authenticator,
         {}
       );
@@ -253,7 +253,7 @@ describe("SkillResource", () => {
     });
 
     it("should not include unchanged configurations in toUpsert", async () => {
-      const skillResource = await SkillConfigurationFactory.create(
+      const skillResource = await SkillFactory.create(
         testContext.authenticator,
         {}
       );
@@ -295,7 +295,7 @@ describe("SkillResource", () => {
     });
 
     it("should handle mixed scenarios: add, update, delete", async () => {
-      const skillResource = await SkillConfigurationFactory.create(
+      const skillResource = await SkillFactory.create(
         testContext.authenticator,
         {}
       );
@@ -396,7 +396,7 @@ describe("SkillResource", () => {
     });
 
     it("should create unique configurations and handle updates properly", async () => {
-      const skillResource = await SkillConfigurationFactory.create(
+      const skillResource = await SkillFactory.create(
         testContext.authenticator,
         {}
       );

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/index.test.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/index.test.ts
@@ -8,7 +8,7 @@ import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFa
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { GroupSpaceFactory } from "@app/tests/utils/GroupSpaceFactory";
-import { SkillConfigurationFactory } from "@app/tests/utils/SkillConfigurationFactory";
+import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 
 import handler from "./index";
@@ -47,7 +47,7 @@ describe("PATCH /api/w/[wId]/assistant/agent_configurations/[aId] - Skills with 
       await AgentConfigurationFactory.createTestAgent(authenticator);
     const restrictedSpace = await SpaceFactory.regular(workspace);
     await restrictedSpace.addMembers(authenticator, { userIds: [user.sId] });
-    const skill = await SkillConfigurationFactory.create(authenticator, {
+    const skill = await SkillFactory.create(authenticator, {
       name: "Skill with restricted space",
     });
 

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/skills.test.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/skills.test.ts
@@ -5,7 +5,7 @@ import { Authenticator } from "@app/lib/auth";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
-import { SkillConfigurationFactory } from "@app/tests/utils/SkillConfigurationFactory";
+import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import type { MembershipRoleType } from "@app/types";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 
@@ -56,20 +56,20 @@ describe("GET /api/w/[wId]/assistant/agent_configurations/[aId]/skills", () => {
     const agent = await AgentConfigurationFactory.createTestAgent(auth);
 
     // Create skills and link them to the agent
-    const skill1 = await SkillConfigurationFactory.create(auth, {
+    const skill1 = await SkillFactory.create(auth, {
       name: "Test Skill 1",
       agentFacingDescription: "First test skill",
     });
-    const skill2 = await SkillConfigurationFactory.create(auth, {
+    const skill2 = await SkillFactory.create(auth, {
       name: "Test Skill 2",
       agentFacingDescription: "Second test skill",
     });
 
-    await SkillConfigurationFactory.linkToAgent(auth, {
+    await SkillFactory.linkToAgent(auth, {
       skillId: skill1.id,
       agentConfigurationId: agent.id,
     });
-    await SkillConfigurationFactory.linkToAgent(auth, {
+    await SkillFactory.linkToAgent(auth, {
       skillId: skill2.id,
       agentConfigurationId: agent.id,
     });
@@ -158,10 +158,10 @@ describe("GET /api/w/[wId]/assistant/agent_configurations/[aId]/skills", () => {
     const agent = await AgentConfigurationFactory.createTestAgent(auth);
 
     // Create skill and link it to agent
-    const skill = await SkillConfigurationFactory.create(auth, {
+    const skill = await SkillFactory.create(auth, {
       name: "Workspace Skill",
     });
-    await SkillConfigurationFactory.linkToAgent(auth, {
+    await SkillFactory.linkToAgent(auth, {
       skillId: skill.id,
       agentConfigurationId: agent.id,
     });
@@ -186,10 +186,10 @@ describe("GET /api/w/[wId]/assistant/agent_configurations/[aId]/skills", () => {
       );
 
       const agent = await AgentConfigurationFactory.createTestAgent(auth);
-      const skill = await SkillConfigurationFactory.create(auth, {
+      const skill = await SkillFactory.create(auth, {
         name: `Skill for ${role}`,
       });
-      await SkillConfigurationFactory.linkToAgent(auth, {
+      await SkillFactory.linkToAgent(auth, {
         skillId: skill.id,
         agentConfigurationId: agent.id,
       });

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.test.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.test.ts
@@ -13,7 +13,7 @@ import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_ap
 import { GroupSpaceFactory } from "@app/tests/utils/GroupSpaceFactory";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
-import { SkillConfigurationFactory } from "@app/tests/utils/SkillConfigurationFactory";
+import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import type {
@@ -242,7 +242,7 @@ describe("POST /api/w/[wId]/assistant/agent_configurations - Skills with restric
     await restrictedSpace.addMembers(authenticator, { userIds: [user.sId] });
     await authenticator.refresh();
 
-    const skill = await SkillConfigurationFactory.create(authenticator, {
+    const skill = await SkillFactory.create(authenticator, {
       name: "Skill with restricted space",
     });
     await SkillConfigurationModel.update(

--- a/front/pages/api/w/[wId]/skills/[sId]/index.test.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.test.ts
@@ -10,7 +10,7 @@ import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_ap
 import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
-import { SkillConfigurationFactory } from "@app/tests/utils/SkillConfigurationFactory";
+import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 
@@ -84,7 +84,7 @@ async function setupTest(
   }
 
   // Create skill owned by skillOwner
-  const skillModel = await SkillConfigurationFactory.create(skillOwnerAuth);
+  const skillModel = await SkillFactory.create(skillOwnerAuth);
   const skill = await SkillResource.fetchByModelIdWithAuth(
     skillOwnerAuth,
     skillModel.id
@@ -184,7 +184,7 @@ describe("PATCH /api/w/[wId]/skills/[sId]", () => {
     });
 
     // Create another skill with a different name
-    await SkillConfigurationFactory.create(requestUserAuth, {
+    await SkillFactory.create(requestUserAuth, {
       name: "Other Skill",
     });
 

--- a/front/pages/api/w/[wId]/skills/[sId]/restore.test.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/restore.test.ts
@@ -6,7 +6,7 @@ import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
-import { SkillConfigurationFactory } from "@app/tests/utils/SkillConfigurationFactory";
+import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 
 import handler from "./restore";
@@ -39,7 +39,7 @@ async function setupTest(
     );
   }
 
-  const skill = await SkillConfigurationFactory.create(skillOwnerAuth, {
+  const skill = await SkillFactory.create(skillOwnerAuth, {
     status: "archived",
   });
 

--- a/front/pages/api/w/[wId]/skills/index.test.ts
+++ b/front/pages/api/w/[wId]/skills/index.test.ts
@@ -14,7 +14,7 @@ import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
 import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
-import { SkillConfigurationFactory } from "@app/tests/utils/SkillConfigurationFactory";
+import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import type { MembershipRoleType } from "@app/types";
 import type {
@@ -47,11 +47,11 @@ describe("GET /api/w/[wId]/skills", () => {
       workspace.sId
     );
 
-    await SkillConfigurationFactory.create(auth, {
+    await SkillFactory.create(auth, {
       name: "Test Skill 1",
       agentFacingDescription: "First test skill",
     });
-    await SkillConfigurationFactory.create(auth, {
+    await SkillFactory.create(auth, {
       name: "Test Skill 2",
       agentFacingDescription: "Second test skill",
     });
@@ -77,15 +77,15 @@ describe("GET /api/w/[wId]/skills", () => {
       workspace.sId
     );
 
-    await SkillConfigurationFactory.create(auth, {
+    await SkillFactory.create(auth, {
       name: "Active Skill",
       status: "active",
     });
-    await SkillConfigurationFactory.create(auth, {
+    await SkillFactory.create(auth, {
       name: "Suggested Skill",
       status: "suggested",
     });
-    await SkillConfigurationFactory.create(auth, {
+    await SkillFactory.create(auth, {
       name: "Archived Skill",
       status: "archived",
     });
@@ -110,15 +110,15 @@ describe("GET /api/w/[wId]/skills", () => {
       workspace.sId
     );
 
-    await SkillConfigurationFactory.create(auth, {
+    await SkillFactory.create(auth, {
       name: "Active Skill",
       status: "active",
     });
-    await SkillConfigurationFactory.create(auth, {
+    await SkillFactory.create(auth, {
       name: "Suggested Skill",
       status: "suggested",
     });
-    await SkillConfigurationFactory.create(auth, {
+    await SkillFactory.create(auth, {
       name: "Archived Skill",
       status: "archived",
     });
@@ -180,7 +180,7 @@ describe("GET /api/w/[wId]/skills", () => {
         workspace.sId
       );
 
-      await SkillConfigurationFactory.create(auth, {
+      await SkillFactory.create(auth, {
         name: `Skill for ${role}`,
       });
 
@@ -200,7 +200,7 @@ describe("GET /api/w/[wId]/skills", () => {
     const { req, res, workspace, authenticator } = await setupTest();
 
     // Create a skill in global space (user has access)
-    await SkillConfigurationFactory.create(authenticator, {
+    await SkillFactory.create(authenticator, {
       name: "Accessible Skill",
     });
 
@@ -208,10 +208,9 @@ describe("GET /api/w/[wId]/skills", () => {
     const restrictedSpace = await SpaceFactory.regular(workspace);
 
     // Create a skill and manually set its requestedSpaceIds to the restricted space
-    const restrictedSkill = await SkillConfigurationFactory.create(
-      authenticator,
-      { name: "Restricted Skill" }
-    );
+    const restrictedSkill = await SkillFactory.create(authenticator, {
+      name: "Restricted Skill",
+    });
     await SkillConfigurationModel.update(
       { requestedSpaceIds: [restrictedSpace.id] },
       { where: { id: restrictedSkill.id } }
@@ -241,7 +240,7 @@ describe("GET /api/w/[wId]/skills", () => {
     await restrictedSpace.addMembers(authenticator, { userIds: [user.sId] });
 
     // Create a skill and set its requestedSpaceIds to the restricted space
-    const skill = await SkillConfigurationFactory.create(authenticator, {
+    const skill = await SkillFactory.create(authenticator, {
       name: "Skill In Restricted Space",
     });
     await SkillConfigurationModel.update(
@@ -268,7 +267,7 @@ describe("GET /api/w/[wId]/skills?withRelations=true", () => {
       workspace.sId
     );
 
-    const skill = await SkillConfigurationFactory.create(auth, {
+    const skill = await SkillFactory.create(auth, {
       name: "Skill With Usage",
     });
 
@@ -276,7 +275,7 @@ describe("GET /api/w/[wId]/skills?withRelations=true", () => {
       name: "Test Agent",
     });
 
-    await SkillConfigurationFactory.linkToAgent(auth, {
+    await SkillFactory.linkToAgent(auth, {
       skillId: skill.id,
       agentConfigurationId: agent.id,
     });
@@ -317,7 +316,7 @@ describe("GET /api/w/[wId]/skills?withRelations=true", () => {
       name: "Agent With Frames",
     });
 
-    await SkillConfigurationFactory.linkGlobalSkillToAgent(auth, {
+    await SkillFactory.linkGlobalSkillToAgent(auth, {
       globalSkillId: "frames",
       agentConfigurationId: agent.id,
     });
@@ -350,7 +349,7 @@ describe("GET /api/w/[wId]/skills?withRelations=true", () => {
       workspace.sId
     );
 
-    const skill = await SkillConfigurationFactory.create(auth, {
+    const skill = await SkillFactory.create(auth, {
       name: "Skill Without Agents",
     });
 
@@ -386,7 +385,7 @@ describe("GET /api/w/[wId]/skills?withRelations=true", () => {
       workspace.sId
     );
 
-    const skill = await SkillConfigurationFactory.create(auth, {
+    const skill = await SkillFactory.create(auth, {
       name: "Skill Without Relations",
     });
 
@@ -416,7 +415,7 @@ describe("GET /api/w/[wId]/skills?withRelations=true", () => {
       workspace.sId
     );
 
-    const skill = await SkillConfigurationFactory.create(auth, {
+    const skill = await SkillFactory.create(auth, {
       name: "Popular Skill",
     });
 
@@ -427,11 +426,11 @@ describe("GET /api/w/[wId]/skills?withRelations=true", () => {
       name: "Agent Beta",
     });
 
-    await SkillConfigurationFactory.linkToAgent(auth, {
+    await SkillFactory.linkToAgent(auth, {
       skillId: skill.id,
       agentConfigurationId: agent1.id,
     });
-    await SkillConfigurationFactory.linkToAgent(auth, {
+    await SkillFactory.linkToAgent(auth, {
       skillId: skill.id,
       agentConfigurationId: agent2.id,
     });

--- a/front/tests/utils/SkillFactory.ts
+++ b/front/tests/utils/SkillFactory.ts
@@ -6,8 +6,7 @@ import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { ModelId } from "@app/types";
 import type { SkillStatus } from "@app/types/assistant/skill_configuration";
 
-// TODO(SKILLS 2026-01-05) Rename to SkillFactory.
-export class SkillConfigurationFactory {
+export class SkillFactory {
   static async create(
     auth: Authenticator,
     overrides: Partial<{


### PR DESCRIPTION
## Description

- Contributes to https://github.com/dust-tt/tasks/issues/5767.
- This PR renames the factory `SkillConfigurationFactory` into `SkillFactory`.

## Tests

- This only affects the tests.

## Risk

- Low.

## Deploy Plan

- No deploy.
