### PR TITLE
dust-apps: migrate file-summarization

### DIFF
--- a/front/lib/api/files/snippet.ts
+++ b/front/lib/api/files/snippet.ts
@@ -2,28 +2,46 @@
 import { isSupportedPlainTextContentType } from "@dust-tt/client";
 
 import { isPastedFile } from "@app/components/assistant/conversation/input_bar/pasted_utils";
-import { runAction } from "@app/lib/actions/server";
+import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
+import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
 import config from "@app/lib/api/config";
 import { getFileContent } from "@app/lib/api/files/utils";
 import type { Authenticator } from "@app/lib/auth";
-import { cloneBaseConfig, getDustProdAction } from "@app/lib/registry";
 import type { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import type { FileResource } from "@app/lib/resources/file_resource";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types";
 import { isSupportedAudioContentType } from "@app/types";
 import {
-  assertNever,
   CoreAPI,
   Err,
   getSmallWhitelistedModel,
   isSupportedDelimitedTextContentType,
   isSupportedImageContentType,
   Ok,
-  removeNulls,
 } from "@app/types";
 
 const ENABLE_LLM_SNIPPETS = false;
+
+const SET_SNIPPET_FUNCTION_NAME = "set_snippet";
+
+const specifications: AgentActionSpecification[] = [
+  {
+    name: SET_SNIPPET_FUNCTION_NAME,
+    description: "Set the generated snippet for the file",
+    inputSchema: {
+      type: "object",
+      properties: {
+        snippet: {
+          type: "string",
+          description:
+            "A concise summary of the file content (max 256 characters)",
+        },
+      },
+      required: ["snippet"],
+    },
+  },
+];
 
 export async function generateSnippet(
   auth: Authenticator,
@@ -90,15 +108,9 @@ export async function generateSnippet(
     const model = getSmallWhitelistedModel(owner);
     if (!model) {
       return new Err(
-        new Error(`Failed to find a whitelisted model to generate title`)
+        new Error(`Failed to find a whitelisted model to generate snippet`)
       );
     }
-
-    const appConfig = cloneBaseConfig(
-      getDustProdAction("conversation-file-summarizer").config
-    );
-    appConfig.MODEL.provider_id = model.providerId;
-    appConfig.MODEL.model_id = model.modelId;
 
     const resTokenize = await coreAPI.tokenize({
       text: content,
@@ -135,63 +147,70 @@ export async function generateSnippet(
       content = content.slice(0, truncateLength);
     }
 
-    const res = await runAction(
+    const res = await runMultiActionsAgent(
       auth,
-      "conversation-file-summarizer",
-      appConfig,
-      [
-        {
-          content: content,
+      {
+        modelId: model.modelId,
+        providerId: model.providerId,
+        temperature: 0,
+        useCache: false,
+      },
+      {
+        conversation: {
+          messages: [
+            {
+              role: "user",
+              content: [{ type: "text", text: content }],
+              name: "",
+            },
+          ],
         },
-      ]
+        prompt: `Generate a concise snippet (max 256 characters) that describes the content of the file provided by the user. Focus on what the file contains or does. Call the \`set_snippet\` function with your summary.`,
+        specifications,
+      },
+      {
+        context: {
+          operationType: "file_snippet_generator",
+          userId: auth.user()?.sId,
+          workspaceId: owner.sId,
+        },
+      }
     );
 
     if (res.isErr()) {
       return new Err(
-        new Error(
-          `Error generating snippet: ${res.error.type} ${res.error.message}`
-        )
+        new Error(`Error generating snippet: ${res.error.message}`)
       );
     }
 
-    const {
-      status: { run },
-      traces,
-      results,
-    } = res.value;
+    let snippet: string | null = null;
 
-    switch (run) {
-      case "errored":
-        const error = removeNulls(traces.map((t) => t[1][0][0].error)).join(
-          ", "
-        );
-        return new Err(new Error(`Error generating snippet: ${error}`));
-      case "succeeded":
-        if (!results || results.length === 0) {
-          return new Err(
-            new Error(
-              `Error generating snippet: no results returned while run was successful`
-            )
-          );
+    if (res.value.actions) {
+      for (const action of res.value.actions) {
+        if (action.name === SET_SNIPPET_FUNCTION_NAME) {
+          snippet = action.arguments.snippet;
         }
-        const snippet = results[0][0].value as string;
-        const endTime = Date.now();
-        logger.info(
-          {
-            workspaceId: owner.sId,
-            fileId: file.sId,
-          },
-          `Snippet generation took ${endTime - startTime}ms`
-        );
-
-        return new Ok(snippet);
-      case "running":
-        return new Err(
-          new Error(`Snippet generation is still running, should never happen.`)
-        );
-      default:
-        assertNever(run);
+      }
     }
+
+    if (!snippet) {
+      return new Err(new Error("No snippet generated"));
+    }
+
+    if (snippet.length > 256) {
+      snippet = snippet.slice(0, 242) + "... (truncated)";
+    }
+
+    const endTime = Date.now();
+    logger.info(
+      {
+        workspaceId: owner.sId,
+        fileId: file.sId,
+      },
+      `Snippet generation took ${endTime - startTime}ms`
+    );
+
+    return new Ok(snippet);
   }
 
   if (isSupportedAudioContentType(file.contentType)) {

--- a/front/lib/api/files/snippet.ts
+++ b/front/lib/api/files/snippet.ts
@@ -2,8 +2,6 @@
 import { isSupportedPlainTextContentType } from "@dust-tt/client";
 
 import { isPastedFile } from "@app/components/assistant/conversation/input_bar/pasted_utils";
-import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
-import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
 import config from "@app/lib/api/config";
 import { getFileContent } from "@app/lib/api/files/utils";
 import type { Authenticator } from "@app/lib/auth";
@@ -15,33 +13,10 @@ import { isSupportedAudioContentType } from "@app/types";
 import {
   CoreAPI,
   Err,
-  getSmallWhitelistedModel,
   isSupportedDelimitedTextContentType,
   isSupportedImageContentType,
   Ok,
 } from "@app/types";
-
-const ENABLE_LLM_SNIPPETS = false;
-
-const SET_SNIPPET_FUNCTION_NAME = "set_snippet";
-
-const specifications: AgentActionSpecification[] = [
-  {
-    name: SET_SNIPPET_FUNCTION_NAME,
-    description: "Set the generated snippet for the file",
-    inputSchema: {
-      type: "object",
-      properties: {
-        snippet: {
-          type: "string",
-          description:
-            "A concise summary of the file content (max 256 characters)",
-        },
-      },
-      required: ["snippet"],
-    },
-  },
-];
 
 export async function generateSnippet(
   auth: Authenticator,
@@ -53,8 +28,6 @@ export async function generateSnippet(
     dataSource: DataSourceResource;
   }
 ): Promise<Result<string, Error>> {
-  const startTime = Date.now();
-  const owner = auth.getNonNullableWorkspace();
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
 
   if (isSupportedImageContentType(file.contentType)) {
@@ -86,7 +59,7 @@ export async function generateSnippet(
   }
 
   if (isSupportedPlainTextContentType(file.contentType)) {
-    let content = await getFileContent(auth, file);
+    const content = await getFileContent(auth, file);
     if (!content) {
       return new Err(new Error("Failed to get file content"));
     }
@@ -96,121 +69,12 @@ export async function generateSnippet(
       return new Ok(content);
     }
 
-    if (!ENABLE_LLM_SNIPPETS) {
-      // Take the first 256 characters
-      if (content.length > 256) {
-        return new Ok(content.slice(0, 242) + "... (truncated)");
-      } else {
-        return new Ok(content);
-      }
+    // Take the first 256 characters
+    if (content.length > 256) {
+      return new Ok(content.slice(0, 242) + "... (truncated)");
+    } else {
+      return new Ok(content);
     }
-
-    const model = getSmallWhitelistedModel(owner);
-    if (!model) {
-      return new Err(
-        new Error(`Failed to find a whitelisted model to generate snippet`)
-      );
-    }
-
-    const resTokenize = await coreAPI.tokenize({
-      text: content,
-      providerId: model.providerId,
-      modelId: model.modelId,
-      tokenizer: model.tokenizer,
-    });
-
-    if (resTokenize.isErr()) {
-      return new Err(
-        new Error(
-          `Error tokenizing content: ${resTokenize.error.code} ${resTokenize.error.message}`
-        )
-      );
-    }
-
-    const tokensCount = resTokenize.value.tokens.length;
-    const allowedTokens = model.contextSize * 0.9;
-    if (tokensCount > allowedTokens) {
-      // Truncate the content to the context size * 0.9 using cross product
-      const truncateLength = Math.floor(
-        (allowedTokens * content.length) / tokensCount
-      );
-
-      logger.warn(
-        {
-          tokensCount,
-          contentLength: content.length,
-          contextSize: model.contextSize,
-        },
-        `Truncating content to ${truncateLength} characters`
-      );
-
-      content = content.slice(0, truncateLength);
-    }
-
-    const res = await runMultiActionsAgent(
-      auth,
-      {
-        modelId: model.modelId,
-        providerId: model.providerId,
-        temperature: 0,
-        useCache: false,
-      },
-      {
-        conversation: {
-          messages: [
-            {
-              role: "user",
-              content: [{ type: "text", text: content }],
-              name: "",
-            },
-          ],
-        },
-        prompt: `Generate a concise snippet (max 256 characters) that describes the content of the file provided by the user. Focus on what the file contains or does. Call the \`set_snippet\` function with your summary.`,
-        specifications,
-      },
-      {
-        context: {
-          operationType: "file_snippet_generator",
-          userId: auth.user()?.sId,
-          workspaceId: owner.sId,
-        },
-      }
-    );
-
-    if (res.isErr()) {
-      return new Err(
-        new Error(`Error generating snippet: ${res.error.message}`)
-      );
-    }
-
-    let snippet: string | null = null;
-
-    if (res.value.actions) {
-      for (const action of res.value.actions) {
-        if (action.name === SET_SNIPPET_FUNCTION_NAME) {
-          snippet = action.arguments.snippet;
-        }
-      }
-    }
-
-    if (!snippet) {
-      return new Err(new Error("No snippet generated"));
-    }
-
-    if (snippet.length > 256) {
-      snippet = snippet.slice(0, 242) + "... (truncated)";
-    }
-
-    const endTime = Date.now();
-    logger.info(
-      {
-        workspaceId: owner.sId,
-        fileId: file.sId,
-      },
-      `Snippet generation took ${endTime - startTime}ms`
-    );
-
-    return new Ok(snippet);
   }
 
   if (isSupportedAudioContentType(file.contentType)) {

--- a/front/lib/api/llm/traces/types.ts
+++ b/front/lib/api/llm/traces/types.ts
@@ -20,7 +20,6 @@ interface LLMTraceContextBase {
     | "agent_observability_summary"
     | "agent_suggestion"
     | "conversation_title_suggestion"
-    | "file_snippet_generator"
     | "process_data_sources"
     | "process_schema_generator"
     | "skill_builder_description_suggestion"

--- a/front/lib/api/llm/traces/types.ts
+++ b/front/lib/api/llm/traces/types.ts
@@ -17,17 +17,18 @@ interface LLMTraceContextBase {
     | "agent_builder_name_suggestion"
     | "agent_builder_tags_suggestion"
     | "agent_conversation"
+    | "agent_observability_summary"
     | "agent_suggestion"
     | "conversation_title_suggestion"
+    | "file_snippet_generator"
     | "process_data_sources"
     | "process_schema_generator"
     | "skill_builder_description_suggestion"
+    | "skills_similarity_checker"
     | "trigger_cron_timezone_generator"
     | "trigger_webhook_filter_generator"
     | "voice_agent_finder"
-    | "workspace_tags_suggestion"
-    | "agent_observability_summary"
-    | "skills_similarity_checker";
+    | "workspace_tags_suggestion";
 
   workspaceId?: string;
   /** User who triggered the operation */


### PR DESCRIPTION
## Description

Migrates `conversation-file-summarizer` use of dust-apps to direct LLM.

@pmilliotte you confirm `context.operationType: "file_snippet_generator"` forces the model to use the function?

## Tests

Pending local test

## Risk

Low (not sure it's really used)

## Deploy Plan

- deploy `front`