### PR TITLE
[front] enh(fs-tools): validate mime types input by model

### DIFF
--- a/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/find.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/find.ts
@@ -1,3 +1,4 @@
+import { isDustMimeType } from "@dust-tt/client";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
@@ -93,6 +94,15 @@ async function findCallback(
     tagsNot,
   }: DataSourceFilesystemFindInputType & TagsInputType
 ): Promise<Result<CallToolResult["content"], MCPError>> {
+  const invalidMimeTypes = mimeTypes?.filter((m) => !isDustMimeType(m));
+  if (invalidMimeTypes && invalidMimeTypes.length > 0) {
+    return new Err(
+      new MCPError(`Invalid mime types: ${invalidMimeTypes.join(", ")}`, {
+        tracked: false,
+      })
+    );
+  }
+
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
 
   const fetchResult = await getAgentDataSourceConfigurations(auth, dataSources);

--- a/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/list.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/data_sources_file_system/list.ts
@@ -1,3 +1,4 @@
+import { isDustMimeType } from "@dust-tt/client";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 import { MCPError } from "@app/lib/actions/mcp_errors";
@@ -60,6 +61,15 @@ export function registerListTool(
         sortBy,
         nextPageCursor,
       }) => {
+        const invalidMimeTypes = mimeTypes?.filter((m) => !isDustMimeType(m));
+        if (invalidMimeTypes && invalidMimeTypes.length > 0) {
+          return new Err(
+            new MCPError(`Invalid mime types: ${invalidMimeTypes.join(", ")}`, {
+              tracked: false,
+            })
+          );
+        }
+
         const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
         const fetchResult = await getAgentDataSourceConfigurations(
           auth,


### PR DESCRIPTION
## Description

- The `ls` and `find` tools can take mime types in input to filter the results.
- If the model inputs an invalid mime type (typed as a string) the search won't return anything, which can lead the model to think there actually is no result instead of being aware that the mime type is actually invalid.
- Since we exhaustively define mime types this PR adds a validation with an explicit error message.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
