### PR TITLE
feat: remove assistant-builder-autocompletion-suggestions

### DIFF
--- a/front/lib/registry.ts
+++ b/front/lib/registry.ts
@@ -114,20 +114,6 @@ export const BaseDustProdActionRegistry = {
       },
     },
   },
-  "assistant-builder-autocompletion-suggestions": {
-    app: {
-      appId: "eDoafmNqwn",
-      appHash:
-        "7dd7f4522a818a5ccbd076972563acf897941752c15616b6135d53ed19195dee",
-    },
-    config: {
-      CREATE_SUGGESTIONS: {
-        // `provider_id` and `model_id` must be set by caller.
-        function_call: "autocomplete_instructions",
-        use_cache: false,
-      },
-    },
-  },
   "assistant-v2-visualization": {
     app: {
       appId: "tWcuYDj1OE",

--- a/front/types/api/internal/assistant.ts
+++ b/front/types/api/internal/assistant.ts
@@ -209,15 +209,6 @@ export const InternalPostBuilderSuggestionsRequestBodySchema = t.union([
     inputs: t.type({ instructions: t.string }),
   }),
   t.type({
-    type: t.literal("autocompletion"),
-    inputs: t.type({
-      description: t.union([t.null, t.string]),
-      instructions: t.string,
-      name: t.union([t.null, t.string]),
-      tools: t.string, // Stringified array of {name: string, description: string}.
-    }),
-  }),
-  t.type({
     type: t.literal("instructions"),
     inputs: t.type({
       current_instructions: t.string,


### PR DESCRIPTION
## Description

There are two remaining dust apps supported in Dust codebase:
- `assistant-builder-autocompletion-suggestions`
- `conversation-file-summarizer`

However `assistant-builder-autocompletion-suggestions` is never reached: 
`getBuilderSuggestions` is called from `/api/w/[wId]/assistant/builder/suggestions` endpoint, which is itself called only with these type parameters:
- instructions
- name
- description
- tags
- emoji

And all of the above have been refactored to use the LLM Router already

This PR cleans code related to `assistant-builder-autocompletion-suggestions`

## Tests

No

## Risk

Low

## Deploy Plan

not needed
