### PR TITLE
fix(dust-hive): fix seed-config failing with NULL trailing columns

### DIFF
--- a/x/henry/dust-hive/src/commands/seed-config.ts
+++ b/x/henry/dust-hive/src/commands/seed-config.ts
@@ -35,10 +35,28 @@ async function runPsqlQuery(uri: string, query: string): Promise<Result<string, 
   return Ok(stdout.trim());
 }
 
+// Sentinel value for NULL fields - ensures psql outputs all columns even when NULL.
+// Without this, trailing NULLs get trimmed and field count becomes unpredictable.
+const NULL_SENTINEL = "__NULL__";
+
+function nullableField(value: string | undefined): string | null {
+  if (!value || value === NULL_SENTINEL) {
+    return null;
+  }
+  return value;
+}
+
 async function extractUser(postgresUri: string): Promise<Result<string[], CommandError>> {
+  // Use COALESCE with sentinel value to ensure all 10 fields are always present.
+  // psql doesn't output trailing tabs for NULL columns, and .trim() removes any
+  // remaining trailing whitespace, making field count unreliable without this.
   const query = `
-    SELECT u."sId", u.username, u.email, u.name, u."firstName", u."lastName",
-           u."workOSUserId", u.provider, u."providerId", u."imageUrl"
+    SELECT u."sId", u.username, u.email, u.name, u."firstName",
+           COALESCE(u."lastName", '${NULL_SENTINEL}'),
+           COALESCE(u."workOSUserId", '${NULL_SENTINEL}'),
+           COALESCE(u.provider, '${NULL_SENTINEL}'),
+           COALESCE(u."providerId", '${NULL_SENTINEL}'),
+           COALESCE(u."imageUrl", '${NULL_SENTINEL}')
     FROM users u
     WHERE u."workOSUserId" IS NOT NULL
     ORDER BY u."lastLoginAt" DESC NULLS LAST, u."createdAt" DESC
@@ -59,9 +77,7 @@ async function extractUser(postgresUri: string): Promise<Result<string[], Comman
   }
 
   const fields = result.value.split("\t");
-  // Require at least 7 fields (sId through workOSUserId). The last 3 fields (provider,
-  // providerId, imageUrl) may be trimmed when NULL due to psql output + .trim() behavior.
-  if (fields.length < 7) {
+  if (fields.length !== 10) {
     return Err(new CommandError(`Unexpected user data format: ${result.value}`));
   }
 
@@ -142,11 +158,11 @@ export async function seedConfigCommand(postgresUri?: string): Promise<Result<vo
     email: f[2] ?? "",
     name: f[3] ?? "",
     firstName,
-    lastName: f[5] || null,
-    workOSUserId: f[6] || null,
-    provider: f[7] || null,
-    providerId: f[8] || null,
-    imageUrl: f[9] || null,
+    lastName: nullableField(f[5]),
+    workOSUserId: nullableField(f[6]),
+    provider: nullableField(f[7]),
+    providerId: nullableField(f[8]),
+    imageUrl: nullableField(f[9]),
     workspaceSId: workspace.sId,
     workspaceName: workspace.name,
     extractedAt: new Date().toISOString(),

--- a/x/henry/dust-hive/src/commands/seed-config.ts
+++ b/x/henry/dust-hive/src/commands/seed-config.ts
@@ -59,7 +59,9 @@ async function extractUser(postgresUri: string): Promise<Result<string[], Comman
   }
 
   const fields = result.value.split("\t");
-  if (fields.length < 10) {
+  // Require at least 7 fields (sId through workOSUserId). The last 3 fields (provider,
+  // providerId, imageUrl) may be trimmed when NULL due to psql output + .trim() behavior.
+  if (fields.length < 7) {
     return Err(new CommandError(`Unexpected user data format: ${result.value}`));
   }
 


### PR DESCRIPTION
## Description

Use COALESCE with sentinel value to ensure psql always outputs all 10
fields. The sentinel is converted back to null when building the config.

This avoids relying on field count heuristics which break when psql
doesn't output trailing tabs for NULL columns and .trim() removes them.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
