### PR TITLE
feat(dust-hive): add -c/--command option to spawn

### DIFF
--- a/x/henry/dust-hive/src/commands/spawn.ts
+++ b/x/henry/dust-hive/src/commands/spawn.ts
@@ -26,6 +26,7 @@ interface SpawnOptions {
   noAttach?: boolean;
   warm?: boolean;
   wait?: boolean;
+  command?: string;
 }
 
 async function promptForName(): Promise<string> {
@@ -238,16 +239,20 @@ export async function spawnCommand(options: SpawnOptions): Promise<Result<void>>
 
   // Open zellij unless --no-open
   if (!options.noOpen) {
-    const openOpts: { warmCommand?: string; noAttach?: boolean } = {};
-    if (options.warm) openOpts.warmCommand = `dust-hive warm ${name}`;
-    if (options.noAttach) openOpts.noAttach = true;
-    return openCommand(name, openOpts);
+    return openCommand(name, buildOpenOptions(name, options));
   }
 
   // If --no-open and --warm, run warm command directly in current terminal
-  if (options.warm) {
-    return warmCommand(name, {});
-  }
+  return options.warm ? warmCommand(name, {}) : Ok(undefined);
+}
 
-  return Ok(undefined);
+function buildOpenOptions(
+  name: string,
+  options: SpawnOptions
+): { warmCommand?: string; noAttach?: boolean; initialCommand?: string } {
+  const openOpts: { warmCommand?: string; noAttach?: boolean; initialCommand?: string } = {};
+  if (options.warm) openOpts.warmCommand = `dust-hive warm ${name}`;
+  if (options.noAttach) openOpts.noAttach = true;
+  if (options.command) openOpts.initialCommand = options.command;
+  return openOpts;
 }

--- a/x/henry/dust-hive/src/index.ts
+++ b/x/henry/dust-hive/src/index.ts
@@ -59,10 +59,18 @@ cli
     "-W, --wait",
     "Wait for SDK to build before opening zellij (cannot be used with --no-open)"
   )
+  .option("-c, --command <cmd>", "Run command in shell tab after opening (drops to shell on exit)")
   .action(
     async (
       name: string | undefined,
-      options: { name?: string; open?: boolean; attach?: boolean; warm?: boolean; wait?: boolean }
+      options: {
+        name?: string;
+        open?: boolean;
+        attach?: boolean;
+        warm?: boolean;
+        wait?: boolean;
+        command?: string;
+      }
     ) => {
       // Validate --wait cannot be used with --no-open
       if (options.wait && options.open === false) {
@@ -77,6 +85,7 @@ cli
         noAttach?: boolean;
         warm?: boolean;
         wait?: boolean;
+        command?: string;
       } = {};
       if (resolvedName !== undefined) {
         spawnOptions.name = resolvedName;
@@ -92,6 +101,9 @@ cli
       }
       if (options.wait) {
         spawnOptions.wait = true;
+      }
+      if (options.command) {
+        spawnOptions.command = options.command;
       }
       await prepareAndRun(spawnCommand(spawnOptions));
     }


### PR DESCRIPTION
## Description

Run a command in the shell tab after spawn opens zellij. When the command exits (e.g., ctrl+c), the user drops back into their shell instead of closing the tab.

Usage: dust-hive spawn -c claude

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
