### PR TITLE
feat(dust-hive): remove -workspace suffix from branch names

### DIFF
--- a/x/henry/dust-hive/src/commands/spawn.ts
+++ b/x/henry/dust-hive/src/commands/spawn.ts
@@ -15,6 +15,7 @@ import type { PortAllocation } from "../lib/ports";
 import { allocateNextPort, calculatePorts, savePortAllocation } from "../lib/ports";
 import { startService, waitForServiceReady } from "../lib/registry";
 import { CommandError, Err, Ok, type Result } from "../lib/result";
+import { getBranchName, loadSettings } from "../lib/settings";
 import { installAllDependencies } from "../lib/setup";
 import { cleanupPartialEnvironment, createWorktree, getMainRepoPath } from "../lib/worktree";
 import { openCommand } from "./open";
@@ -181,9 +182,12 @@ export async function spawnCommand(options: SpawnOptions): Promise<Result<void>>
     return Err(new CommandError(`Environment '${name}' already exists`));
   }
 
+  // Load settings for branch prefix
+  const settings = await loadSettings();
+
   // Always base on main branch
   const baseBranch = "main";
-  const workspaceBranch = `${name}-workspace`;
+  const workspaceBranch = getBranchName(name, settings);
   const worktreePath = getWorktreeDir(name);
 
   logger.info(`Creating environment '${name}' from branch '${baseBranch}'`);

--- a/x/henry/dust-hive/src/lib/paths.ts
+++ b/x/henry/dust-hive/src/lib/paths.ts
@@ -15,6 +15,7 @@ export const DUST_HIVE_WORKTREES = join(homedir(), "dust-hive");
 
 // Global config
 export const CONFIG_ENV_PATH = join(DUST_HIVE_HOME, "config.env");
+export const SETTINGS_PATH = join(DUST_HIVE_HOME, "settings.json");
 
 // Global forwarder paths (not per-env, since forwarding is global)
 export const FORWARDER_PID_PATH = join(DUST_HIVE_HOME, "forward.pid");

--- a/x/henry/dust-hive/src/lib/settings.ts
+++ b/x/henry/dust-hive/src/lib/settings.ts
@@ -1,0 +1,34 @@
+import { SETTINGS_PATH } from "./paths";
+
+export interface Settings {
+  // Prefix to add to branch names (e.g., "tom-" creates branches like "tom-myenv")
+  branchPrefix?: string;
+}
+
+const DEFAULT_SETTINGS: Settings = {};
+
+// Load settings from disk, returns defaults if file doesn't exist
+export async function loadSettings(): Promise<Settings> {
+  const file = Bun.file(SETTINGS_PATH);
+  if (!(await file.exists())) {
+    return DEFAULT_SETTINGS;
+  }
+
+  try {
+    const content = await file.json();
+    return { ...DEFAULT_SETTINGS, ...content };
+  } catch {
+    return DEFAULT_SETTINGS;
+  }
+}
+
+// Save settings to disk
+export async function saveSettings(settings: Settings): Promise<void> {
+  await Bun.write(SETTINGS_PATH, `${JSON.stringify(settings, null, 2)}\n`);
+}
+
+// Get the branch name for an environment
+export function getBranchName(envName: string, settings: Settings): string {
+  const prefix = settings.branchPrefix ?? "";
+  return `${prefix}${envName}`;
+}


### PR DESCRIPTION
## Description

Branch names now match the environment name directly (e.g., "myenv" instead of "myenv-workspace"). Added optional branchPrefix setting in ~/.dust-hive/settings.json for users who want a prefix (e.g., "tom-myenv").

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
