### PR TITLE
fix(dust-hive): fix temporal restart command

### DIFF
--- a/x/henry/dust-hive/src/index.ts
+++ b/x/henry/dust-hive/src/index.ts
@@ -18,12 +18,7 @@ import { startCommand } from "./commands/start";
 import { statusCommand } from "./commands/status";
 import { stopCommand } from "./commands/stop";
 import { syncCommand } from "./commands/sync";
-import {
-  temporalRestartCommand,
-  temporalStartCommand,
-  temporalStatusCommand,
-  temporalStopCommand,
-} from "./commands/temporal";
+import { temporalCommand } from "./commands/temporal";
 import { upCommand } from "./commands/up";
 import { urlCommand } from "./commands/url";
 import { warmCommand } from "./commands/warm";
@@ -251,21 +246,11 @@ cli
   });
 
 // Temporal subcommands
-cli.command("temporal start", "Start Temporal server").action(async () => {
-  await prepareAndRun(temporalStartCommand());
-});
-
-cli.command("temporal stop", "Stop Temporal server").action(async () => {
-  await prepareAndRun(temporalStopCommand());
-});
-
-cli.command("temporal restart", "Restart Temporal server").action(async () => {
-  await prepareAndRun(temporalRestartCommand());
-});
-
-cli.command("temporal status", "Show Temporal server status").action(async () => {
-  await prepareAndRun(temporalStatusCommand());
-});
+cli
+  .command("temporal [subcommand]", "Manage Temporal server (start|stop|restart|status)")
+  .action(async (subcommand: string | undefined) => {
+    await prepareAndRun(temporalCommand(subcommand));
+  });
 
 cli
   .command(


### PR DESCRIPTION
## Description

- Fix race condition in restartTemporalServer() where the port could still be in use after stopping, causing "already running externally" error
- Add waitForPortFree() to wait for port release before starting new instance
- Fix CLI command structure: cac doesn't support "temporal start" style subcommands, changed to "temporal [subcommand]" with routing logic

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
