### PR TITLE
[front] fix(Ashby): block feedback searches on hired candidates

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/ashby/client.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/ashby/client.ts
@@ -3,6 +3,7 @@ import type { z } from "zod";
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type {
   AshbyApplicationFeedbackListRequest,
+  AshbyApplicationInfoRequest,
   AshbyCandidateCreateNoteRequest,
   AshbyCandidateSearchRequest,
   AshbyFeedbackSubmission,
@@ -10,6 +11,7 @@ import type {
 } from "@app/lib/actions/mcp_internal_actions/servers/ashby/types";
 import {
   AshbyApplicationFeedbackListResponseSchema,
+  AshbyApplicationInfoResponseSchema,
   AshbyCandidateCreateNoteResponseSchema,
   AshbyCandidateSearchResponseSchema,
   AshbyReportSynchronousResponseSchema,
@@ -160,6 +162,14 @@ export class AshbyClient {
       "candidate.createNote",
       request,
       AshbyCandidateCreateNoteResponseSchema
+    );
+  }
+
+  async getApplicationInfo(request: AshbyApplicationInfoRequest) {
+    return this.postRequest(
+      "application.info",
+      request,
+      AshbyApplicationInfoResponseSchema
     );
   }
 }

--- a/front/lib/actions/mcp_internal_actions/servers/ashby/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/ashby/index.ts
@@ -285,8 +285,8 @@ function createServer(
           if (appInfoResult.value.results.status === "Hired") {
             return new Err(
               new MCPError(
-                `Cannot retrieve interview feedback for ${candidate.name}: ` +
-                  "feedback is not available for hired candidates."
+                `Candidate ${candidate.name} was hired, ` +
+                  "retrieving feedback for hired candidates is not permitted."
               )
             );
           }

--- a/front/lib/actions/mcp_internal_actions/servers/ashby/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/ashby/index.ts
@@ -274,10 +274,15 @@ function createServer(
           const appInfoResult = await client.getApplicationInfo({
             applicationId,
           });
-          if (
-            appInfoResult.isOk() &&
-            appInfoResult.value.results.status === "Hired"
-          ) {
+          if (appInfoResult.isErr()) {
+            return new Err(
+              new MCPError(
+                `Failed to retrieve application info for candidate ${candidate.name}.`
+              )
+            );
+          }
+
+          if (appInfoResult.value.results.status === "Hired") {
             return new Err(
               new MCPError(
                 `Cannot retrieve interview feedback for ${candidate.name}: ` +

--- a/front/lib/actions/mcp_internal_actions/servers/ashby/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/ashby/index.ts
@@ -276,7 +276,7 @@ function createServer(
           });
           if (
             appInfoResult.isOk() &&
-            appInfoResult.value.results.status === "hired"
+            appInfoResult.value.results.status === "Hired"
           ) {
             return new Err(
               new MCPError(

--- a/front/lib/actions/mcp_internal_actions/servers/ashby/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/ashby/index.ts
@@ -269,6 +269,24 @@ function createServer(
           );
         }
 
+        // Check if any application is in "hired" status; feedback retrieval is then blocked.
+        for (const applicationId of candidate.applicationIds) {
+          const appInfoResult = await client.getApplicationInfo({
+            applicationId,
+          });
+          if (
+            appInfoResult.isOk() &&
+            appInfoResult.value.results.status === "hired"
+          ) {
+            return new Err(
+              new MCPError(
+                `Cannot retrieve interview feedback for ${candidate.name}: ` +
+                  "feedback is not available for hired candidates."
+              )
+            );
+          }
+        }
+
         let latestApplicationFeedback: AshbyFeedbackSubmission[] | null = null;
         let latestApplicationDate: Date | null = null;
 

--- a/front/lib/actions/mcp_internal_actions/servers/ashby/types.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/ashby/types.ts
@@ -188,9 +188,16 @@ export type AshbyApplicationInfoRequest = z.infer<
   typeof AshbyApplicationInfoRequestSchema
 >;
 
-export const AshbyApplicationStatusSchema = z.enum(["active", "hired", "archived"]);
+export const AshbyApplicationStatusSchema = z.enum([
+  "Hired",
+  "Archived",
+  "Active",
+  "Lead",
+]);
 
-export type AshbyApplicationStatus = z.infer<typeof AshbyApplicationStatusSchema>;
+export type AshbyApplicationStatus = z.infer<
+  typeof AshbyApplicationStatusSchema
+>;
 
 export const AshbyApplicationInfoResponseSchema = z.object({
   success: z.boolean(),

--- a/front/lib/actions/mcp_internal_actions/servers/ashby/types.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/ashby/types.ts
@@ -179,3 +179,30 @@ export const AshbyCandidateCreateNoteResponseSchema = z.object({
 export type AshbyCandidateCreateNoteResponse = z.infer<
   typeof AshbyCandidateCreateNoteResponseSchema
 >;
+
+export const AshbyApplicationInfoRequestSchema = z.object({
+  applicationId: z.string(),
+});
+
+export type AshbyApplicationInfoRequest = z.infer<
+  typeof AshbyApplicationInfoRequestSchema
+>;
+
+export const AshbyApplicationStatusSchema = z.enum(["active", "hired", "archived"]);
+
+export type AshbyApplicationStatus = z.infer<typeof AshbyApplicationStatusSchema>;
+
+export const AshbyApplicationInfoResponseSchema = z.object({
+  success: z.boolean(),
+  results: z
+    .object({
+      id: z.string(),
+      status: AshbyApplicationStatusSchema,
+      candidateId: z.string(),
+    })
+    .passthrough(),
+});
+
+export type AshbyApplicationInfoResponse = z.infer<
+  typeof AshbyApplicationInfoResponseSchema
+>;

--- a/front/lib/actions/mcp_internal_actions/servers/ashby/types.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/ashby/types.ts
@@ -205,7 +205,6 @@ export const AshbyApplicationInfoResponseSchema = z.object({
     .object({
       id: z.string(),
       status: AshbyApplicationStatusSchema,
-      candidateId: z.string(),
     })
     .passthrough(),
 });


### PR DESCRIPTION
## Description

- This PR adds an additional layer of security in the Ashby MCP server by blocking feedback searches on hired candidates.
- Surfaced [here](https://dust4ai.slack.com/archives/C066R3PMUAU/p1764087201722339?thread_ts=1764087192.905469&cid=C066R3PMUAU).

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
