### PR TITLE
[front] chore: remove `useSummary` setting on web browse

### DIFF
--- a/front/components/agent_builder/capabilities/capabilities_sheet/CapabilitiesSelectionPage.tsx
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/CapabilitiesSelectionPage.tsx
@@ -8,7 +8,6 @@ import { MCPServerCard } from "@app/components/agent_builder/capabilities/mcp/MC
 import type { SheetState } from "@app/components/agent_builder/skills/types";
 import type { MCPServerViewTypeWithLabel } from "@app/components/shared/tools_picker/MCPServerViewsContext";
 import { useSkillWithRelations } from "@app/lib/swr/skill_configurations";
-import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 
 type CapabilitiesSelectionPageProps = {
@@ -42,7 +41,6 @@ export function CapabilitiesSelectionPageContent({
   onStateChange,
 }: CapabilitiesSelectionPageProps) {
   const { owner } = useAgentBuilderContext();
-  const { featureFlags } = useFeatureFlags({ workspaceId: owner.sId });
   const [filter, setFilter] = useState<CapabilityFilterType>("all");
 
   const { fetchSkillWithRelations } = useSkillWithRelations(owner, {
@@ -113,7 +111,7 @@ export function CapabilitiesSelectionPageContent({
           <div className="px-4 text-center">
             <div className="mb-2 text-lg font-medium text-foreground dark:text-foreground-night">
               {searchQuery
-                ? "No capability match your search"
+                ? "No capability matches your search"
                 : "No capabilities available"}
             </div>
             <div className="max-w-sm text-muted-foreground dark:text-muted-foreground-night">
@@ -153,7 +151,6 @@ export function CapabilitiesSelectionPageContent({
                     isSelected={selectedMCPServerViewIds.has(view.sId)}
                     onClick={() => handleToolToggle(view)}
                     onToolInfoClick={() => handleToolInfoClick(view)}
-                    featureFlags={featureFlags}
                   />
                 ))}
               </div>

--- a/front/components/agent_builder/capabilities/capabilities_sheet/hooks.ts
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/hooks.ts
@@ -254,10 +254,7 @@ export const useToolSelection = ({
   const handleToolToggle = useCallback(
     (mcpServerView: MCPServerViewTypeWithLabel) => {
       const tool = { view: mcpServerView } satisfies SelectedTool;
-      const requirements = getMCPServerRequirements(
-        mcpServerView,
-        featureFlags
-      );
+      const requirements = getMCPServerRequirements(mcpServerView);
 
       if (!requirements.noRequirement) {
         const action = getDefaultMCPAction(mcpServerView);

--- a/front/components/agent_builder/capabilities/mcp/MCPServerConfigurationPage.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerConfigurationPage.tsx
@@ -1,7 +1,6 @@
 import { useMemo } from "react";
 import type { UseFormReturn } from "react-hook-form";
 
-import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import type { MCPFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
 import { AdditionalConfigurationSection } from "@app/components/agent_builder/capabilities/shared/AdditionalConfigurationSection";
 import { ChildAgentSection } from "@app/components/agent_builder/capabilities/shared/ChildAgentSection";
@@ -14,7 +13,6 @@ import type { MCPServerViewTypeWithLabel } from "@app/components/shared/tools_pi
 import type { BuilderAction } from "@app/components/shared/tools_picker/types";
 import { FormProvider } from "@app/components/sparkle/FormProvider";
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
-import { useFeatureFlags } from "@app/lib/swr/workspaces";
 
 export interface MCPServerConfigurationPageProps {
   form: UseFormReturn<MCPFormData>;
@@ -29,12 +27,9 @@ export function MCPServerConfigurationPage({
   mcpServerView,
   getAgentInstructions,
 }: MCPServerConfigurationPageProps) {
-  const { owner } = useAgentBuilderContext();
-  const { featureFlags } = useFeatureFlags({ workspaceId: owner.sId });
-
   const requirements = useMemo(() => {
-    return getMCPServerRequirements(mcpServerView, featureFlags);
-  }, [mcpServerView, featureFlags]);
+    return getMCPServerRequirements(mcpServerView);
+  }, [mcpServerView]);
 
   return (
     <FormProvider form={form} className="h-full">

--- a/front/components/agent_builder/capabilities/mcp/MCPServerSelectionPage.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerSelectionPage.tsx
@@ -14,14 +14,12 @@ import {
 import type { MCPServerViewTypeWithLabel } from "@app/components/shared/tools_picker/MCPServerViewsContext";
 import { getMcpServerViewDescription } from "@app/lib/actions/mcp_helper";
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
-import type { WhitelistableFeature } from "@app/types";
 
 export interface MCPServerCardProps {
   view: MCPServerViewTypeWithLabel;
   isSelected: boolean;
   onClick: () => void;
   onToolInfoClick: () => void;
-  featureFlags?: WhitelistableFeature[];
 }
 
 export function MCPServerCard({
@@ -29,9 +27,8 @@ export function MCPServerCard({
   isSelected,
   onClick,
   onToolInfoClick,
-  featureFlags,
 }: MCPServerCardProps) {
-  const requirements = getMCPServerRequirements(view, featureFlags);
+  const requirements = getMCPServerRequirements(view);
   const canAdd = requirements.noRequirement ? !isSelected : true;
 
   const icon = isCustomResourceIconType(view.server.icon)
@@ -90,7 +87,6 @@ interface MCPServerSelectionPageProps {
   onItemClick: (mcpServerView: MCPServerViewTypeWithLabel) => void;
   selectedToolsInSheet?: SelectedTool[];
   onToolDetailsClick?: (tool: SelectedTool) => void;
-  featureFlags?: WhitelistableFeature[];
 }
 
 export function MCPServerSelectionPage({
@@ -99,7 +95,6 @@ export function MCPServerSelectionPage({
   onItemClick,
   selectedToolsInSheet = [],
   onToolDetailsClick,
-  featureFlags,
 }: MCPServerSelectionPageProps) {
   // Optimize selection lookup with Set-based approach
   const selectedMCPIds = useMemo(() => {
@@ -146,7 +141,6 @@ export function MCPServerSelectionPage({
                 onToolDetailsClick({ view });
               }
             }}
-            featureFlags={featureFlags}
           />
         ))}
       </div>
@@ -165,7 +159,6 @@ export function MCPServerSelectionPage({
                 onToolDetailsClick({ view });
               }
             }}
-            featureFlags={featureFlags}
           />
         ))}
       </div>

--- a/front/components/agent_builder/capabilities/mcp/MCPServerViewsSheet.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerViewsSheet.tsx
@@ -60,14 +60,12 @@ import type {
   BuilderAction,
   MCPServerConfigurationType,
 } from "@app/components/shared/tools_picker/types";
-import { useBuilderContext } from "@app/components/shared/useBuilderContext";
 import { FormProvider } from "@app/components/sparkle/FormProvider";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { getAvatar } from "@app/lib/actions/mcp_icons";
 import { AGENT_MEMORY_SERVER_NAME } from "@app/lib/actions/mcp_internal_actions/constants";
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
-import { useFeatureFlags } from "@app/lib/swr/workspaces";
 
 const TOP_MCP_SERVER_VIEWS = [
   "web_search_&_browse",
@@ -135,10 +133,8 @@ export function MCPServerViewsSheet({
   getAgentInstructions,
   filterMCPServerViews,
 }: MCPServerViewsSheetProps) {
-  const { owner } = useBuilderContext();
   const confirm = React.useContext(ConfirmContext);
   const sendNotification = useSendNotification();
-  const { featureFlags } = useFeatureFlags({ workspaceId: owner.sId });
   const {
     mcpServerViews: allMcpServerViews,
     mcpServerViewsWithKnowledge,
@@ -203,11 +199,9 @@ export function MCPServerViewsSheet({
   }, [mcpServerViewsWithoutKnowledge, filterMCPServerViews]);
 
   const selectableTopMCPServerViews = useMemo(() => {
-    const filteredList = topMCPServerViews.filter(
+    return topMCPServerViews.filter(
       (view) => !shouldFilterServerView(view, selectedActions)
     );
-
-    return filteredList;
   }, [topMCPServerViews, selectedActions, shouldFilterServerView]);
 
   const selectableNonTopMCPServerViews = useMemo(
@@ -319,7 +313,7 @@ export function MCPServerViewsSheet({
 
   function onClickMCPServer(mcpServerView: MCPServerViewTypeWithLabel) {
     const tool = { view: mcpServerView } satisfies SelectedTool;
-    const requirements = getMCPServerRequirements(mcpServerView, featureFlags);
+    const requirements = getMCPServerRequirements(mcpServerView);
 
     if (!requirements.noRequirement) {
       const action = getDefaultMCPAction(mcpServerView);
@@ -409,11 +403,8 @@ export function MCPServerViewsSheet({
   });
 
   const requirements = useMemo(
-    () =>
-      mcpServerView
-        ? getMCPServerRequirements(mcpServerView, featureFlags)
-        : null,
-    [mcpServerView, featureFlags]
+    () => (mcpServerView ? getMCPServerRequirements(mcpServerView) : null),
+    [mcpServerView]
   );
 
   // Stable form reset handler - no form dependency to prevent re-renders
@@ -468,7 +459,6 @@ export function MCPServerViewsSheet({
             onToolDetailsClick={(tool) => {
               handleToolInfoClick(tool.view);
             }}
-            featureFlags={featureFlags}
           />
         </>
       ),

--- a/front/components/agent_builder/capabilities/shared/AdditionalConfigurationSection.tsx
+++ b/front/components/agent_builder/capabilities/shared/AdditionalConfigurationSection.tsx
@@ -15,11 +15,9 @@ import { InformationCircleIcon } from "@heroicons/react/20/solid";
 import React, { useMemo, useState } from "react";
 import { useController } from "react-hook-form";
 
-import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import type { MCPFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
 import { ConfigurationSectionContainer } from "@app/components/agent_builder/capabilities/shared/ConfigurationSectionContainer";
 import type { MCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
-import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import { asDisplayName } from "@app/types";
 
 function formatKeyForDisplay(key: string): string {
@@ -542,20 +540,6 @@ export function AdditionalConfigurationSection({
   requiredEnums,
   requiredLists,
 }: AdditionalConfigurationSectionProps) {
-  const { owner } = useAgentBuilderContext();
-  const { featureFlags } = useFeatureFlags({
-    workspaceId: owner.sId,
-  });
-  const hasWebSummarizationFlag = featureFlags.includes("web_summarization");
-
-  const filteredBooleanConfigurations = useMemo(
-    () =>
-      requiredBooleans.filter(
-        ({ key }) => !(key === "useSummary" && !hasWebSummarizationFlag)
-      ),
-    [requiredBooleans, hasWebSummarizationFlag]
-  );
-
   // Group configuration fields by prefix.
   const groupedStrings = useMemo(
     () => groupKeysByPrefix(requiredStrings),
@@ -566,8 +550,8 @@ export function AdditionalConfigurationSection({
     [requiredNumbers]
   );
   const groupedBooleans = useMemo(
-    () => groupKeysByPrefix(filteredBooleanConfigurations),
-    [filteredBooleanConfigurations]
+    () => groupKeysByPrefix(requiredBooleans),
+    [requiredBooleans]
   );
   const groupedEnums = useMemo(() => {
     const groups: Record<string, MCPServerRequirements["requiredEnums"]> = {};
@@ -619,7 +603,7 @@ export function AdditionalConfigurationSection({
   const hasConfiguration =
     requiredStrings.length > 0 ||
     requiredNumbers.length > 0 ||
-    filteredBooleanConfigurations.length > 0 ||
+    requiredBooleans.length > 0 ||
     Object.keys(requiredEnums).length > 0 ||
     Object.keys(requiredLists).length > 0;
 

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -33,6 +33,7 @@ import type {
 import { Err, Ok } from "@app/types";
 
 export const ADVANCED_SEARCH_SWITCH = "advanced_search";
+export const USE_SUMMARY_SWITCH = "useSummary";
 
 export const SEARCH_TOOL_NAME = "semantic_search";
 export const INCLUDE_TOOL_NAME = "retrieve_recent_documents";

--- a/front/lib/actions/mcp_internal_actions/input_configuration.ts
+++ b/front/lib/actions/mcp_internal_actions/input_configuration.ts
@@ -32,7 +32,7 @@ import {
   iterateOverSchemaPropertiesRecursive,
   setValueAtPath,
 } from "@app/lib/utils/json_schemas";
-import type { WhitelistableFeature, WorkspaceType } from "@app/types";
+import type { WorkspaceType } from "@app/types";
 import { assertNever, isString, removeNulls } from "@app/types";
 
 function getDataSourceURI(config: DataSourceConfiguration): string {
@@ -492,8 +492,7 @@ export interface MCPServerRequirements {
 }
 
 export function getMCPServerRequirements(
-  mcpServerView: MCPServerViewType | null | undefined,
-  featureFlags?: WhitelistableFeature[]
+  mcpServerView: MCPServerViewType | null | undefined
 ): MCPServerRequirements {
   if (!mcpServerView) {
     return {
@@ -607,24 +606,18 @@ export function getMCPServerRequirements(
       mcpServerView,
       mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.BOOLEAN,
     })
-  )
-    .map(([key, schema]) => {
-      const defaultValue = extractSchemaDefault(schema);
-      assert(
-        defaultValue === null || typeof defaultValue === "boolean",
-        `Value stored does not have the correct type, expected boolean, got ${typeof defaultValue}.`
-      );
-      return {
-        key,
-        description: schema.description,
-        default: defaultValue,
-      };
-    })
-    // Exclude useSummary if the user doesn't have the web_summarization feature flag.
-    .filter(
-      ({ key }) =>
-        key !== "useSummary" || featureFlags?.includes("web_summarization")
+  ).map(([key, schema]) => {
+    const defaultValue = extractSchemaDefault(schema);
+    assert(
+      defaultValue === null || typeof defaultValue === "boolean",
+      `Value stored does not have the correct type, expected boolean, got ${typeof defaultValue}.`
     );
+    return {
+      key,
+      description: schema.description,
+      default: defaultValue,
+    };
+  });
 
   const requiredEnums: MCPServerRequirements["requiredEnums"] =
     Object.fromEntries(

--- a/front/lib/actions/mcp_internal_actions/tools/web_browser/web_browser_tools.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/web_browser/web_browser_tools.ts
@@ -9,6 +9,7 @@ import {
 import { MAXED_OUTPUT_FILE_SNIPPET_LENGTH } from "@app/lib/actions/action_output_limits";
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import {
+  USE_SUMMARY_SWITCH,
   WEBBROWSER_TOOL_NAME,
   WEBSEARCH_TOOL_NAME,
 } from "@app/lib/actions/mcp_internal_actions/constants";
@@ -129,7 +130,8 @@ export function registerWebBrowserTool(
         const { toolConfiguration } = agentLoopContext.runContext;
         const useSummarization =
           isLightServerSideMCPToolConfiguration(toolConfiguration) &&
-          toolConfiguration.additionalConfiguration.useSummary === true;
+          toolConfiguration.additionalConfiguration[USE_SUMMARY_SWITCH] ===
+            true;
 
         const summaryAgentId = useSummarization
           ? GLOBAL_AGENTS_SID.DUST_BROWSER_SUMMARY

--- a/front/lib/actions/mcp_internal_actions/tools/web_browser/web_browser_tools.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/web_browser/web_browser_tools.ts
@@ -23,6 +23,7 @@ import {
 import { summarizeWithAgent } from "@app/lib/actions/mcp_internal_actions/utils/web_summarization";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
+import { isLightServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
 import { getRefs } from "@app/lib/api/assistant/citations";
 import type { Authenticator } from "@app/lib/auth";
 import { tokenCountForTexts } from "@app/lib/tokenization";
@@ -120,20 +121,15 @@ export function registerWebBrowserTool(
         agentLoopContext,
         enableAlerting: true,
       },
-      async ({
-        urls,
-        format = "markdown",
-        screenshotMode = "none",
-        links,
-        useSummary,
-      }) => {
-        const useSummarization = useSummary?.value === true;
-
-        if (useSummarization && !agentLoopContext?.runContext) {
-          return new Err(
-            new MCPError("agentLoopContext is required for summarization")
-          );
+      async ({ urls, format = "markdown", screenshotMode = "none", links }) => {
+        if (!agentLoopContext?.runContext) {
+          return new Err(new MCPError("No conversation context available"));
         }
+
+        const { toolConfiguration } = agentLoopContext.runContext;
+        const useSummarization =
+          isLightServerSideMCPToolConfiguration(toolConfiguration) &&
+          toolConfiguration.additionalConfiguration.useSummarization === true;
 
         const summaryAgentId = useSummarization
           ? GLOBAL_AGENTS_SID.DUST_BROWSER_SUMMARY
@@ -144,11 +140,7 @@ export function registerWebBrowserTool(
           links,
         });
 
-        if (
-          useSummarization &&
-          summaryAgentId &&
-          agentLoopContext?.runContext
-        ) {
+        if (useSummarization && summaryAgentId) {
           const runCtx = agentLoopContext.runContext;
           const conversationId = runCtx.conversation.sId;
           const { citationsOffset, websearchResultCount } = runCtx.stepContext;

--- a/front/lib/actions/mcp_internal_actions/tools/web_browser/web_browser_tools.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/web_browser/web_browser_tools.ts
@@ -129,7 +129,7 @@ export function registerWebBrowserTool(
         const { toolConfiguration } = agentLoopContext.runContext;
         const useSummarization =
           isLightServerSideMCPToolConfiguration(toolConfiguration) &&
-          toolConfiguration.additionalConfiguration.useSummarization === true;
+          toolConfiguration.additionalConfiguration.useSummary === true;
 
         const summaryAgentId = useSummarization
           ? GLOBAL_AGENTS_SID.DUST_BROWSER_SUMMARY

--- a/front/lib/actions/mcp_internal_actions/types.ts
+++ b/front/lib/actions/mcp_internal_actions/types.ts
@@ -125,16 +125,6 @@ export const WebbrowseInputSchema = z.object({
     .boolean()
     .optional()
     .describe("If true, also retrieve outgoing links from the page."),
-  useSummary: ConfigurableToolInputSchemas[
-    INTERNAL_MIME_TYPES.TOOL_INPUT.BOOLEAN
-  ]
-    .describe(
-      "Summarize web pages using an AI agent before returning content. When enabled, provides concise summaries instead of full page content."
-    )
-    .default({
-      value: false,
-      mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.BOOLEAN,
-    }),
 });
 
 export type WebbrowseInputType = z.infer<typeof WebbrowseInputSchema>;

--- a/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
@@ -1,6 +1,7 @@
 import { DEFAULT_WEBSEARCH_ACTION_DESCRIPTION } from "@app/lib/actions/constants";
 import type { MCPServerConfigurationType } from "@app/lib/actions/mcp";
 import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
+import { USE_SUMMARY_SWITCH } from "@app/lib/actions/mcp_internal_actions/constants";
 import {
   DEEP_DIVE_DESC,
   DEEP_DIVE_NAME,
@@ -706,7 +707,7 @@ export function _getDustTaskGlobalAgent(
       tables: null,
       childAgentId: null,
       additionalConfiguration: {
-        useSummary: true,
+        [USE_SUMMARY_SWITCH]: true,
       },
       timeFrame: null,
       dustAppConfiguration: null,

--- a/front/lib/api/search.ts
+++ b/front/lib/api/search.ts
@@ -122,7 +122,20 @@ const NodeIdSearchBody = t.intersection([
   }),
 ]);
 
-export const SearchRequestBody = t.union([TextSearchBody, NodeIdSearchBody]);
+const BrowseSearchBody = t.intersection([
+  BaseSearchBody,
+  t.partial({
+    query: t.undefined,
+    nodeIds: t.undefined,
+    searchSourceUrls: t.boolean,
+  }),
+]);
+
+export const SearchRequestBody = t.union([
+  TextSearchBody,
+  NodeIdSearchBody,
+  BrowseSearchBody,
+]);
 
 export type SearchRequestBodyType = t.TypeOf<typeof SearchRequestBody>;
 


### PR DESCRIPTION
## Description

- The webbrowsing tool has a setting that enables summarization.
- This feature is used by dust-task and by user who have a certain feature flag.
- The flow that lets user configure this setting has been broken for a while.
- This PR removes it, keeping it for dust-task.
- Note: behavior is maintained for users who already had it.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
