### PR TITLE
feat(front): enable GPT 5.2 for EU users

### DIFF
--- a/front/components/workspace/ProviderManagementModal.tsx
+++ b/front/components/workspace/ProviderManagementModal.tsx
@@ -27,7 +27,6 @@ import {
 } from "@app/components/providers/types";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { useSendNotification } from "@app/hooks/useNotification";
-import type { RegionType } from "@app/lib/api/regions/config";
 import { canUseModel } from "@app/lib/assistant";
 import { clientFetch } from "@app/lib/egress/client";
 import { useFeatureFlags, useWorkspace } from "@app/lib/swr/workspaces";
@@ -51,13 +50,11 @@ const prettyfiedProviderNames: { [key in ModelProviderIdType]: string } = {
 interface ProviderManagementModalProps {
   owner: WorkspaceType;
   plan: PlanType;
-  region: RegionType;
 }
 
 export function ProviderManagementModal({
   owner,
   plan,
-  region,
 }: ProviderManagementModalProps) {
   const { isDark } = useTheme();
   const sendNotifications = useSendNotification();
@@ -85,7 +82,7 @@ export function ProviderManagementModal({
     (m) => m.modelId
   ).filter(
     (model) =>
-      !model.isLegacy && canUseModel(model, featureFlags, plan, owner, region)
+      !model.isLegacy && canUseModel(model, featureFlags, plan, owner)
   );
 
   const modelProviders = filteredModels.reduce(

--- a/front/components/workspace/ProviderManagementModal.tsx
+++ b/front/components/workspace/ProviderManagementModal.tsx
@@ -81,8 +81,7 @@ export function ProviderManagementModal({
     [...USED_MODEL_CONFIGS, ...REASONING_MODEL_CONFIGS],
     (m) => m.modelId
   ).filter(
-    (model) =>
-      !model.isLegacy && canUseModel(model, featureFlags, plan, owner)
+    (model) => !model.isLegacy && canUseModel(model, featureFlags, plan, owner)
   );
 
   const modelProviders = filteredModels.reduce(

--- a/front/components/workspace/settings/ModelSelectionSection.tsx
+++ b/front/components/workspace/settings/ModelSelectionSection.tsx
@@ -1,17 +1,14 @@
 import { Page } from "@dust-tt/sparkle";
 
 import { ProviderManagementModal } from "@app/components/workspace/ProviderManagementModal";
-import type { RegionType } from "@app/lib/api/regions/config";
 import type { PlanType, WorkspaceType } from "@app/types";
 
 export function ModelSelectionSection({
   owner,
   plan,
-  region,
 }: {
   owner: WorkspaceType;
   plan: PlanType;
-  region: RegionType;
 }) {
   return (
     <Page.Vertical align="stretch" gap="md">
@@ -22,7 +19,7 @@ export function ModelSelectionSection({
             Select the models you want available to your workspace.
           </Page.P>
         </div>
-        <ProviderManagementModal owner={owner} plan={plan} region={region} />
+        <ProviderManagementModal owner={owner} plan={plan} />
       </div>
     </Page.Vertical>
   );

--- a/front/lib/api/assistant/global_agents/configurations/openai.ts
+++ b/front/lib/api/assistant/global_agents/configurations/openai.ts
@@ -7,7 +7,6 @@ import {
   _getDefaultWebActionsForGlobalAgent,
   _getInteractiveContentToolConfiguration,
 } from "@app/lib/api/assistant/global_agents/tools";
-import { config as regionConfig } from "@app/lib/api/regions/config";
 import type { Authenticator } from "@app/lib/auth";
 import type { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";
 import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -19,7 +18,6 @@ import {
   GLOBAL_AGENTS_SID,
   GPT_3_5_TURBO_MODEL_CONFIG,
   GPT_4_1_MODEL_CONFIG,
-  GPT_5_1_MODEL_CONFIG,
   GPT_5_2_MODEL_CONFIG,
   GPT_5_MINI_MODEL_CONFIG,
   GPT_5_NANO_MODEL_CONFIG,
@@ -173,10 +171,6 @@ export function _getGPT5GlobalAgent({
   const sId = GLOBAL_AGENTS_SID.GPT5;
   const metadata = getGlobalAgentMetadata(sId);
 
-  // GPT 5.2 is only available in non-EU regions (US)
-  const isEuRegion = regionConfig.getCurrentRegion() === "europe-west1";
-  const modelConfig = isEuRegion ? GPT_5_1_MODEL_CONFIG : GPT_5_2_MODEL_CONFIG;
-
   return {
     id: -1,
     sId,
@@ -193,8 +187,8 @@ export function _getGPT5GlobalAgent({
     scope: "global",
     userFavorite: false,
     model: {
-      providerId: modelConfig.providerId,
-      modelId: modelConfig.modelId,
+      providerId: GPT_5_2_MODEL_CONFIG.providerId,
+      modelId: GPT_5_2_MODEL_CONFIG.modelId,
       temperature: 0.7,
       /**
        * WARNING: Because the default in ChatGPT is no reasoning, we do the same
@@ -248,10 +242,6 @@ export function _getGPT5ThinkingGlobalAgent({
   const sId = GLOBAL_AGENTS_SID.GPT5_THINKING;
   const metadata = getGlobalAgentMetadata(sId);
 
-  // GPT 5.2 is only available in non-EU regions (US)
-  const isEuRegion = regionConfig.getCurrentRegion() === "europe-west1";
-  const modelConfig = isEuRegion ? GPT_5_1_MODEL_CONFIG : GPT_5_2_MODEL_CONFIG;
-
   return {
     id: -1,
     sId,
@@ -269,10 +259,10 @@ export function _getGPT5ThinkingGlobalAgent({
     scope: "global",
     userFavorite: false,
     model: {
-      providerId: modelConfig.providerId,
-      modelId: modelConfig.modelId,
+      providerId: GPT_5_2_MODEL_CONFIG.providerId,
+      modelId: GPT_5_2_MODEL_CONFIG.modelId,
       temperature: 0.7,
-      reasoningEffort: modelConfig.defaultReasoningEffort,
+      reasoningEffort: GPT_5_2_MODEL_CONFIG.defaultReasoningEffort,
     },
     actions: [
       ..._getDefaultWebActionsForGlobalAgent({

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -1,4 +1,3 @@
-import type { RegionType } from "@app/lib/api/regions/config";
 import { isUpgraded } from "@app/lib/plans/plan_codes";
 import type {
   AgentModelConfigurationType,
@@ -39,8 +38,7 @@ export function canUseModel(
   m: ModelConfigurationType,
   featureFlags: WhitelistableFeature[],
   plan: PlanType | null,
-  owner: WorkspaceType,
-  _region: RegionType
+  owner: WorkspaceType
 ) {
   if (m.featureFlag && !featureFlags.includes(m.featureFlag)) {
     return false;

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -8,11 +8,7 @@ import type {
   WhitelistableFeature,
   WorkspaceType,
 } from "@app/types";
-import {
-  GPT_5_2_MODEL_ID,
-  isProviderWhitelisted,
-  SUPPORTED_MODEL_CONFIGS,
-} from "@app/types";
+import { isProviderWhitelisted, SUPPORTED_MODEL_CONFIGS } from "@app/types";
 
 export function isLargeModel(model: unknown): model is SupportedModel {
   const maybeSupportedModel = model as SupportedModel;
@@ -44,7 +40,7 @@ export function canUseModel(
   featureFlags: WhitelistableFeature[],
   plan: PlanType | null,
   owner: WorkspaceType,
-  region: RegionType
+  _region: RegionType
 ) {
   if (m.featureFlag && !featureFlags.includes(m.featureFlag)) {
     return false;
@@ -58,11 +54,6 @@ export function canUseModel(
   }
 
   if (m.largeModel && !isUpgraded(plan)) {
-    return false;
-  }
-
-  // GPT 5.2 is not available in EU region
-  if (m.modelId === GPT_5_2_MODEL_ID && region === "europe-west1") {
     return false;
   }
 

--- a/front/pages/api/w/[wId]/models.ts
+++ b/front/pages/api/w/[wId]/models.ts
@@ -5,7 +5,6 @@ import {
   USED_MODEL_CONFIGS,
 } from "@app/components/providers/types";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import { config as regionConfig } from "@app/lib/api/regions/config";
 import { canUseModel } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
@@ -28,13 +27,12 @@ async function handler(
   switch (req.method) {
     case "GET":
       const featureFlags = await getFeatureFlags(owner);
-      const region = regionConfig.getCurrentRegion();
       const models: ModelConfigurationType[] = USED_MODEL_CONFIGS.filter((m) =>
-        canUseModel(m, featureFlags, plan, owner, region)
+        canUseModel(m, featureFlags, plan, owner)
       );
       const reasoningModels: ModelConfigurationType[] =
         REASONING_MODEL_CONFIGS.filter((m) =>
-          canUseModel(m, featureFlags, plan, owner, region)
+          canUseModel(m, featureFlags, plan, owner)
         );
 
       return res.status(200).json({ models, reasoningModels });

--- a/front/pages/w/[wId]/workspace/index.tsx
+++ b/front/pages/w/[wId]/workspace/index.tsx
@@ -9,8 +9,6 @@ import { CapabilitiesSection } from "@app/components/workspace/settings/Capabili
 import { IntegrationsSection } from "@app/components/workspace/settings/IntegrationsSection";
 import { ModelSelectionSection } from "@app/components/workspace/settings/ModelSelectionSection";
 import { WorkspaceNameEditor } from "@app/components/workspace/settings/WorkspaceNameEditor";
-import type { RegionType } from "@app/lib/api/regions/config";
-import { config as regionConfig } from "@app/lib/api/regions/config";
 import { getFeatureFlags } from "@app/lib/auth";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
@@ -31,7 +29,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   microsoftBotDataSource: DataSourceType | null;
   discordBotDataSource: DataSourceType | null;
   systemSpace: SpaceType;
-  region: RegionType;
 }>(async (_, auth) => {
   const owner = auth.workspace();
   const subscription = auth.subscription();
@@ -65,7 +62,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
       microsoftBotDataSource: microsoftBotDataSource?.toJSON() ?? null,
       discordBotDataSource: discordBotDataSource?.toJSON() ?? null,
       systemSpace: systemSpace.toJSON(),
-      region: regionConfig.getCurrentRegion(),
     },
   };
 });
@@ -78,7 +74,6 @@ export default function WorkspaceAdmin({
   microsoftBotDataSource,
   discordBotDataSource,
   systemSpace,
-  region,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const { featureFlags } = useFeatureFlags({ workspaceId: owner.sId });
 
@@ -97,11 +92,7 @@ export default function WorkspaceAdmin({
         <Page.Vertical align="stretch" gap="md">
           <WorkspaceNameEditor owner={owner} />
         </Page.Vertical>
-        <ModelSelectionSection
-          owner={owner}
-          plan={subscription.plan}
-          region={region}
-        />
+        <ModelSelectionSection owner={owner} plan={subscription.plan} />
         <CapabilitiesSection
           owner={owner}
           showRestrictAgentsPublishing={featureFlags.includes(


### PR DESCRIPTION
## Description

GPT 5.2 is now available globally, so remove the region check that was falling back to GPT 5.1 for EU users.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
