### PR TITLE
Conditionally Add File System Server for Skills with Attached Knowledge

### DIFF
--- a/front/lib/actions/configuration/helpers.ts
+++ b/front/lib/actions/configuration/helpers.ts
@@ -79,9 +79,11 @@ export function renderTableConfiguration(
 export function buildServerSideMCPServerConfiguration({
   mcpServerView,
   dataSources = null,
+  serverNameOverride,
 }: {
   mcpServerView: MCPServerViewResource;
   dataSources?: DataSourceConfiguration[] | null;
+  serverNameOverride?: string;
 }): ServerSideMCPServerConfigurationType {
   const { server } = mcpServerView.toJSON();
 
@@ -89,7 +91,7 @@ export function buildServerSideMCPServerConfiguration({
     id: -1,
     sId: `mcp_${server.sId}`,
     type: "mcp_server_configuration",
-    name: mcpServerView.name ?? server.name,
+    name: serverNameOverride ?? mcpServerView.name ?? server.name,
     description: mcpServerView.description ?? server.description,
     icon: server.icon,
     mcpServerViewId: mcpServerView.sId,

--- a/front/lib/api/assistant/skill_actions.ts
+++ b/front/lib/api/assistant/skill_actions.ts
@@ -2,10 +2,14 @@ import { buildServerSideMCPServerConfiguration } from "@app/lib/actions/configur
 import type { MCPServerConfigurationType } from "@app/lib/actions/mcp";
 import type { DataSourceConfiguration } from "@app/lib/api/assistant/configuration/types";
 import type { Authenticator } from "@app/lib/auth";
+import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import type { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { LightAgentConfigurationType } from "@app/types";
 import { removeNulls } from "@app/types";
+
+const SKIL_KNOWLEDGE_FILE_SYSTEM_SERVER_NAME = "skill_knowledge_file_system";
 
 export async function getSkillServers(
   auth: Authenticator,
@@ -41,4 +45,129 @@ export async function getSkillServers(
       });
     })
   );
+}
+
+/**
+ * Extracts and deduplicates data source configurations from skills with attached knowledge.
+ * Returns an array of merged configurations, or empty array if no skills have knowledge.
+ */
+export async function getSkillDataSourceConfigurations(
+  auth: Authenticator,
+  {
+    skills,
+  }: {
+    skills: SkillResource[];
+  }
+): Promise<DataSourceConfiguration[]> {
+  // Filter skills that have attached knowledge.
+  const skillsWithKnowledge = skills.filter(
+    (skill) => skill.dataSourceConfigurations.length > 0
+  );
+
+  if (skillsWithKnowledge.length === 0) {
+    return [];
+  }
+
+  // Extract all unique dataSourceViewIds from skill configurations.
+  const dataSourceViewModelIds = Array.from(
+    new Set(
+      skillsWithKnowledge.flatMap((skill) =>
+        skill.dataSourceConfigurations.map((config) => config.dataSourceViewId)
+      )
+    )
+  );
+
+  const dataSourceViews = await DataSourceViewResource.fetchByModelIds(
+    auth,
+    dataSourceViewModelIds
+  );
+
+  // Create a map for efficient lookup: ModelId -> DataSourceViewResource.
+  const viewsByModelId = new Map(
+    dataSourceViews.map((view) => [view.id, view])
+  );
+
+  // Build configurations with parentsIn filters, grouped by dataSourceViewId (sId).
+  const configsByViewId = new Map<string, DataSourceConfiguration>();
+
+  for (const skill of skillsWithKnowledge) {
+    for (const config of skill.dataSourceConfigurations) {
+      const view = viewsByModelId.get(config.dataSourceViewId);
+
+      if (!view) {
+        // Skip configurations where the data source view doesn't exist or user has no access.
+        continue;
+      }
+
+      const existingConfig = configsByViewId.get(view.sId);
+      if (existingConfig) {
+        // Merge parentsIn arrays for duplicate data source views.
+        const mergedParentsIn = Array.from(
+          new Set([
+            ...(existingConfig.filter.parents?.in ?? []),
+            ...config.parentsIn,
+          ])
+        );
+
+        configsByViewId.set(view.sId, {
+          ...existingConfig,
+          filter: {
+            ...existingConfig.filter,
+            parents: {
+              in: mergedParentsIn,
+              not: null,
+            },
+          },
+        });
+      } else {
+        // Create new configuration.
+        configsByViewId.set(view.sId, {
+          dataSourceViewId: view.sId,
+          workspaceId: auth.getNonNullableWorkspace().sId,
+          filter: {
+            parents: {
+              in: config.parentsIn,
+              not: null,
+            },
+            tags: null,
+          },
+        });
+      }
+    }
+  }
+
+  return Array.from(configsByViewId.values());
+}
+
+/**
+ * Creates a file system server configuration scoped to the provided data source configurations.
+ * Returns null if no configurations are provided or the server view doesn't exist.
+ */
+export async function createSkillKnowledgeFileSystemServer(
+  auth: Authenticator,
+  {
+    dataSourceConfigurations,
+  }: {
+    dataSourceConfigurations: DataSourceConfiguration[];
+  }
+): Promise<MCPServerConfigurationType | null> {
+  if (dataSourceConfigurations.length === 0) {
+    return null;
+  }
+
+  const mcpServerView =
+    await MCPServerViewResource.getMCPServerViewForAutoInternalTool(
+      auth,
+      "data_sources_file_system"
+    );
+
+  if (!mcpServerView) {
+    return null;
+  }
+
+  return buildServerSideMCPServerConfiguration({
+    mcpServerView,
+    dataSources: dataSourceConfigurations,
+    serverNameOverride: SKIL_KNOWLEDGE_FILE_SYSTEM_SERVER_NAME,
+  });
 }

--- a/front/lib/api/assistant/skill_actions.ts
+++ b/front/lib/api/assistant/skill_actions.ts
@@ -9,7 +9,7 @@ import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { LightAgentConfigurationType } from "@app/types";
 import { removeNulls } from "@app/types";
 
-const SKIL_KNOWLEDGE_FILE_SYSTEM_SERVER_NAME = "skill_knowledge_file_system";
+const SKILL_KNOWLEDGE_FILE_SYSTEM_SERVER_NAME = "skill_knowledge_file_system";
 
 export async function getSkillServers(
   auth: Authenticator,
@@ -168,6 +168,6 @@ export async function createSkillKnowledgeFileSystemServer(
   return buildServerSideMCPServerConfiguration({
     mcpServerView,
     dataSources: dataSourceConfigurations,
-    serverNameOverride: SKIL_KNOWLEDGE_FILE_SYSTEM_SERVER_NAME,
+    serverNameOverride: SKILL_KNOWLEDGE_FILE_SYSTEM_SERVER_NAME,
   });
 }

--- a/front/lib/resources/storage/index.test.ts
+++ b/front/lib/resources/storage/index.test.ts
@@ -16,7 +16,9 @@ describe("PostgreSQL BIGINT type parser", () => {
       requestedSpaceIds: [],
     });
 
-    const fetched = await ConversationModel.findByPk(conversation.id);
+    const fetched = await ConversationModel.findOne({
+      where: { id: conversation.id, workspaceId: workspace.id },
+    });
 
     expect(fetched).not.toBeNull();
     expect(fetched!.spaceId).toBe(space.id);
@@ -36,7 +38,9 @@ describe("PostgreSQL BIGINT type parser", () => {
       requestedSpaceIds: spaceIds,
     });
 
-    const fetched = await ConversationModel.findByPk(conversation.id);
+    const fetched = await ConversationModel.findOne({
+      where: { id: conversation.id, workspaceId: workspace.id },
+    });
 
     expect(fetched).not.toBeNull();
     expect(fetched!.requestedSpaceIds).toEqual(spaceIds);

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -209,13 +209,12 @@ export async function runModelActivity(
       skills: enabledSkills,
     }
   );
-  if (dataSourceConfigurations.length > 0) {
-    const fileSystemServer = await createSkillKnowledgeFileSystemServer(auth, {
-      dataSourceConfigurations,
-    });
-    if (fileSystemServer) {
-      skillServers.push(fileSystemServer);
-    }
+
+  const fileSystemServer = await createSkillKnowledgeFileSystemServer(auth, {
+    dataSourceConfigurations,
+  });
+  if (fileSystemServer) {
+    skillServers.push(fileSystemServer);
   }
 
   const {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
1. Single scoped server for all skills
- Creates one `skill_knowledge_file_system` server with access to all data source views from enabled skills with attached knowledge
- The `data_sources_file_system` server natively supports an array of `DataSourceConfiguration[]`, so one server handles multiple skills efficiently
- Server name override: `skill_knowledge_file_system` (distinct from agent-level data_sources_file_system)

2. Conditional enablement
- Only added when `enabledSkills` have attached knowledge (non-empty dataSourceConfigurations)

3. Scoped access
- Restricted to ONLY data source views attached to skills via SkillDataSourceConfigurationModel
- Uses parentsIn filters from skill configurations to limit access to specific folders/documents
- Does NOT include agent-level data sources (independent from "advanced search" toggle)

4. Deduplication
- When multiple skills reference the same data source view, configurations are merged
- `parentsIn` arrays are combined

### Server Name

Uses serverNameOverride: "skill_knowledge_file_system" to distinguish from agent-level file system server, preventing collisions and making it clear in logs/UI which server is serving which scope.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
Low risk, this part is still gated behind a FF. Safe to rollback.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
