### PR TITLE
[Front] fix(agent): use ModelId param in updateAgentRequirements

### DIFF
--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -1387,11 +1387,12 @@ export async function updateAgentConfigurationScope(
 
 export async function updateAgentRequirements(
   auth: Authenticator,
-  params: { agentId: string; newSpaceIds: number[] },
-  options?: { transaction?: Transaction }
+  {
+    agentModelId,
+    newSpaceIds,
+  }: { agentModelId: ModelId; newSpaceIds: ModelId[] },
+  { transaction }: { transaction?: Transaction }
 ): Promise<Result<boolean, Error>> {
-  const { agentId, newSpaceIds } = params;
-
   const owner = auth.getNonNullableWorkspace();
 
   const updated = await AgentConfigurationModel.update(
@@ -1401,9 +1402,9 @@ export async function updateAgentRequirements(
     {
       where: {
         workspaceId: owner.id,
-        sId: agentId,
+        id: agentModelId,
       },
-      transaction: options?.transaction,
+      transaction,
     }
   );
 

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -178,7 +178,7 @@ export async function softDeleteSpaceAndLaunchScrubWorkflow(
           const res = await updateAgentRequirements(
             auth,
             {
-              agentId,
+              agentModelId: agentConfig.id,
               newSpaceIds: requirements.requestedSpaceIds,
             },
             { transaction: t }

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1000,7 +1000,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         await updateAgentRequirements(
           auth,
           {
-            agentId: agent.sId,
+            agentModelId: agent.id,
             newSpaceIds,
           },
           { transaction }


### PR DESCRIPTION
## Description

- Fix `updateAgentRequirements` to use `ModelId` instead of `sId` for agent identification, avoiding updating previous versions of the agent.

## Tests

Existing tests cover this code path

## Risk

Low.

## Deploy Plan

Deploy front.
