### PR TITLE
[front] fix(Ashby): hide candidate email and phone

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/ashby/rendering.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/ashby/rendering.ts
@@ -7,12 +7,6 @@ import type {
 function renderCandidate(candidate: AshbyCandidate): string {
   const lines = [`ID: ${candidate.id}`, `Name: ${candidate.name}`];
 
-  if (candidate.primaryEmailAddress) {
-    lines.push(
-      `Email: ${candidate.primaryEmailAddress.value} (${candidate.primaryEmailAddress.type})`
-    );
-  }
-
   if (candidate.primaryPhoneNumber) {
     lines.push(
       `Phone: ${candidate.primaryPhoneNumber.value} (${candidate.primaryPhoneNumber.type})`
@@ -113,10 +107,6 @@ export function renderInterviewFeedbackRecap(
     "",
     `**Candidate:** ${candidate.name}`,
   ];
-
-  if (candidate.primaryEmailAddress) {
-    header.push(`**Email:** ${candidate.primaryEmailAddress.value}`);
-  }
 
   header.push(
     "",

--- a/front/lib/actions/mcp_internal_actions/servers/ashby/rendering.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/ashby/rendering.ts
@@ -7,12 +7,6 @@ import type {
 function renderCandidate(candidate: AshbyCandidate): string {
   const lines = [`ID: ${candidate.id}`, `Name: ${candidate.name}`];
 
-  if (candidate.primaryPhoneNumber) {
-    lines.push(
-      `Phone: ${candidate.primaryPhoneNumber.value} (${candidate.primaryPhoneNumber.type})`
-    );
-  }
-
   if (candidate.createdAt) {
     lines.push(`Created: ${new Date(candidate.createdAt).toISOString()}`);
   }


### PR DESCRIPTION
## Description

- This PR prevents exposing the candidate emails and phone numbers to the model and potentially to the end user ultimately.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
