### PR TITLE
Remove `getDustProdActionRegistry` usage

### DIFF
--- a/front/migrations/20240906_registry_apps_to_public_vault.ts
+++ b/front/migrations/20240906_registry_apps_to_public_vault.ts
@@ -1,58 +1,58 @@
-import config from "@app/lib/api/config";
-import { getDustProdActionRegistry } from "@app/lib/registry";
-import { AppModel } from "@app/lib/resources/storage/models/apps";
-import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
-import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
-import { makeScript } from "@app/scripts/helpers";
-
-makeScript({}, async ({ execute }, logger) => {
-  const publicVaultSqid = config.getDustAppsSpaceId();
-  const vaultId = getResourceIdFromSId(publicVaultSqid);
-  const dustAppsWorkspace = await WorkspaceModel.findOne({
-    where: { sId: config.getDustAppsWorkspaceId() },
-  });
-  if (!dustAppsWorkspace) {
-    throw new Error(
-      `Could not find workspace with sId ${config.getDustAppsWorkspaceId()}`
-    );
-  }
-  if (!vaultId) {
-    throw new Error(`Could not find vault with SQID ${publicVaultSqid}`);
-  }
-
-  for (const [
-    appName,
-    {
-      app: { appId },
-    },
-  ] of Object.entries(getDustProdActionRegistry())) {
-    console.log(
-      execute ? "" : "[DRY RUN] ",
-      `Updating app ${appName} (sId=${appId}) in ${dustAppsWorkspace.name} workspace ` +
-        `(sId=${dustAppsWorkspace.sId}) with vaultId ${vaultId}`
-    );
-    if (execute) {
-      await AppModel.update(
-        {
-          vaultId,
-        },
-        {
-          where: {
-            sId: appId,
-            workspaceId: dustAppsWorkspace.id,
-          },
-        }
-      );
-      logger.info(
-        {
-          appName,
-          appId,
-          workspaceId: config.getDustAppsWorkspaceId(),
-          vaultId,
-          execute,
-        },
-        "Updated app"
-      );
-    }
-  }
-});
+// import config from "@app/lib/api/config";
+// import { getDustProdActionRegistry } from "@app/lib/registry";
+// import { AppModel } from "@app/lib/resources/storage/models/apps";
+// import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
+// import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
+// import { makeScript } from "@app/scripts/helpers";
+//
+// makeScript({}, async ({ execute }, logger) => {
+//   const publicVaultSqid = config.getDustAppsSpaceId();
+//   const vaultId = getResourceIdFromSId(publicVaultSqid);
+//   const dustAppsWorkspace = await WorkspaceModel.findOne({
+//     where: { sId: config.getDustAppsWorkspaceId() },
+//   });
+//   if (!dustAppsWorkspace) {
+//     throw new Error(
+//       `Could not find workspace with sId ${config.getDustAppsWorkspaceId()}`
+//     );
+//   }
+//   if (!vaultId) {
+//     throw new Error(`Could not find vault with SQID ${publicVaultSqid}`);
+//   }
+//
+//   for (const [
+//     appName,
+//     {
+//       app: { appId },
+//     },
+//   ] of Object.entries(getDustProdActionRegistry())) {
+//     console.log(
+//       execute ? "" : "[DRY RUN] ",
+//       `Updating app ${appName} (sId=${appId}) in ${dustAppsWorkspace.name} workspace ` +
+//         `(sId=${dustAppsWorkspace.sId}) with vaultId ${vaultId}`
+//     );
+//     if (execute) {
+//       await AppModel.update(
+//         {
+//           vaultId,
+//         },
+//         {
+//           where: {
+//             sId: appId,
+//             workspaceId: dustAppsWorkspace.id,
+//           },
+//         }
+//       );
+//       logger.info(
+//         {
+//           appName,
+//           appId,
+//           workspaceId: config.getDustAppsWorkspaceId(),
+//           vaultId,
+//           execute,
+//         },
+//         "Updated app"
+//       );
+//     }
+//   }
+// });

--- a/front/pages/w/[wId]/spaces/[spaceId]/categories/[category]/index.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/categories/[category]/index.tsx
@@ -7,7 +7,6 @@ import type { SpaceLayoutPageProps } from "@app/components/spaces/SpaceLayout";
 import { SpaceLayout } from "@app/components/spaces/SpaceLayout";
 import { SpaceResourcesList } from "@app/components/spaces/SpaceResourcesList";
 import AppRootLayout from "@app/components/sparkle/AppRootLayout";
-import config from "@app/lib/api/config";
 import {
   augmentDataSourceWithConnectorDetails,
   getDataSources,
@@ -15,8 +14,6 @@ import {
 import { isManaged } from "@app/lib/data_sources";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { countActiveSeatsInWorkspaceCached } from "@app/lib/plans/usage/seats";
-import type { ActionApp } from "@app/lib/registry";
-import { getDustProdActionRegistry } from "@app/lib/registry";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import type {
   ConnectorProvider,
@@ -40,7 +37,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
     space: SpaceType;
     systemSpace: SpaceType;
     integrations: DataSourceIntegration[];
-    registryApps: ActionApp[] | null;
     user: UserType;
     activeSeats: number;
   }
@@ -133,14 +129,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
     }
   }
 
-  const isDustAppsSpace =
-    owner.sId === config.getDustAppsWorkspaceId() &&
-    space.sId === config.getDustAppsSpaceId();
-
-  const registryApps = isDustAppsSpace
-    ? Object.values(getDustProdActionRegistry()).map((action) => action.app)
-    : null;
-
   const activeSeats = await countActiveSeatsInWorkspaceCached(owner.sId);
 
   return {
@@ -154,7 +142,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
       owner,
       user: user.toJSON(),
       plan,
-      registryApps,
       space: space.toJSON(),
       subscription,
       systemSpace: systemSpace.toJSON(),

--- a/front/pages/w/[wId]/spaces/[spaceId]/categories/apps/index.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/categories/apps/index.tsx
@@ -6,10 +6,7 @@ import { SpaceAppsList } from "@app/components/spaces/SpaceAppsList";
 import type { SpaceLayoutPageProps } from "@app/components/spaces/SpaceLayout";
 import { SpaceLayout } from "@app/components/spaces/SpaceLayout";
 import AppRootLayout from "@app/components/sparkle/AppRootLayout";
-import config from "@app/lib/api/config";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
-import type { ActionApp } from "@app/lib/registry";
-import { getDustProdActionRegistry } from "@app/lib/registry";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import type { DataSourceViewCategory, SpaceType } from "@app/types";
 
@@ -17,7 +14,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
   SpaceLayoutPageProps & {
     isBuilder: boolean;
     category: DataSourceViewCategory;
-    registryApps: ActionApp[] | null;
     space: SpaceType;
   }
 >(async (context, auth) => {
@@ -45,14 +41,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
   const isBuilder = auth.isBuilder();
   const canWriteInSpace = space.canWrite(auth);
 
-  const isDustAppsSpace =
-    owner.sId === config.getDustAppsWorkspaceId() &&
-    space.sId === config.getDustAppsSpaceId();
-
-  const registryApps = isDustAppsSpace
-    ? Object.values(getDustProdActionRegistry()).map((action) => action.app)
-    : null;
-
   return {
     props: {
       canReadInSpace: space.canRead(auth),
@@ -62,7 +50,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
       isBuilder,
       owner,
       plan,
-      registryApps,
       space: space.toJSON(),
       subscription,
     },
@@ -73,7 +60,6 @@ export default function Space({
   isBuilder,
   owner,
   space,
-  registryApps,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const router = useRouter();
 

--- a/front/pages/w/[wId]/spaces/[spaceId]/categories/apps/index.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/categories/apps/index.tsx
@@ -71,7 +71,6 @@ export default function Space({
       onSelect={(sId) => {
         void router.push(`/w/${owner.sId}/spaces/${space.sId}/apps/${sId}`);
       }}
-      registryApps={registryApps}
     />
   );
 }


### PR DESCRIPTION
## Description

Various removal of `getDustProdActionRegistry`. They were ~all dead or not useful anymore code.

## Tests

N/A

## Risk

None

## Deploy Plan

- deploy `front`