### PR TITLE
[doc-tracker] Phase 4: Drop tracker tables

### DIFF
--- a/front/migrations/db/migration_470.sql
+++ b/front/migrations/db/migration_470.sql
@@ -1,0 +1,8 @@
+-- Migration created on Jan 08, 2026
+-- Phase 4 of doc-tracker removal: Drop tracker tables
+-- This must run AFTER Phase 2 (data deletion) and Phase 3 (code removal)
+
+-- Drop tables in order respecting foreign key constraints
+DROP TABLE IF EXISTS tracker_generations;
+DROP TABLE IF EXISTS tracker_data_source_configurations;
+DROP TABLE IF EXISTS tracker_configurations;


### PR DESCRIPTION
## Description

Final phase of doc-tracker removal. This migration drops the now-empty tracker tables:
- `tracker_generations`
- `tracker_data_source_configurations`
- `tracker_configurations`

This PR should only be merged after:
1. Phase 1 (blocking creation) - merged
2. Phase 2 (data deletion migration) - run in production
3. Phase 3 (code removal) - merged and deployed

## Tests

No tests needed - this is a SQL schema migration that drops empty tables.

## Risk

**Low risk.** The tables are already empty (data was deleted in Phase 2) and all code references have been removed (Phase 3). Using `DROP TABLE IF EXISTS` for safety.

Rollback: Tables would need to be recreated, but since there's no code using them and no data, this is a non-issue.

## Deploy Plan

1. Ensure Phase 2 data deletion migration has been run in production (tables should be empty)
2. Ensure Phase 3 code removal is deployed (no code references remain)
3. Merge this PR - migration will run automatically and drop the empty tables