### PR TITLE
[dust-hive] Add --compact option to up command

### DIFF
--- a/x/henry/dust-hive/src/commands/open.ts
+++ b/x/henry/dust-hive/src/commands/open.ts
@@ -387,11 +387,12 @@ export const openCommand = withEnvironment("open", async (env, options: OpenOpti
 });
 
 // Generate layout for main session (repo root + temporal logs)
-function generateMainLayout(repoRoot: string, watchScriptPath: string): string {
+function generateMainLayout(repoRoot: string, watchScriptPath: string, compact?: boolean): string {
   const shellPath = getUserShell();
+  const tabTemplate = compact ? TAB_TEMPLATE_COMPACT : TAB_TEMPLATE;
 
   return `layout {
-${TAB_TEMPLATE}
+${tabTemplate}
 
     tab name="main" focus=true {
         pane {
@@ -412,16 +413,21 @@ ${TAB_TEMPLATE}
 `;
 }
 
-async function writeMainLayout(repoRoot: string, watchScriptPath: string): Promise<string> {
+async function writeMainLayout(
+  repoRoot: string,
+  watchScriptPath: string,
+  compact?: boolean
+): Promise<string> {
   await mkdir(DUST_HIVE_ZELLIJ, { recursive: true });
   const layoutPath = join(DUST_HIVE_ZELLIJ, "main-layout.kdl");
-  const content = generateMainLayout(repoRoot, watchScriptPath);
+  const content = generateMainLayout(repoRoot, watchScriptPath, compact);
   await Bun.write(layoutPath, content);
   return layoutPath;
 }
 
 interface MainSessionOptions {
   attach?: boolean;
+  compact?: boolean | undefined;
 }
 
 // Open the main session (for managed services mode)
@@ -447,7 +453,7 @@ export async function openMainSession(
     }
 
     if (!sessionExists) {
-      const layoutPath = await writeMainLayout(repoRoot, watchScriptPath);
+      const layoutPath = await writeMainLayout(repoRoot, watchScriptPath, options.compact);
       await createSessionInBackground(sessionName, layoutPath);
     }
 
@@ -483,7 +489,7 @@ export async function openMainSession(
     });
     await proc.exited;
   } else {
-    const layoutPath = await writeMainLayout(repoRoot, watchScriptPath);
+    const layoutPath = await writeMainLayout(repoRoot, watchScriptPath, options.compact);
 
     if (!options.attach) {
       await createSessionInBackground(sessionName, layoutPath);

--- a/x/henry/dust-hive/src/commands/up.ts
+++ b/x/henry/dust-hive/src/commands/up.ts
@@ -14,6 +14,7 @@ import { syncCommand } from "./sync";
 interface UpOptions {
   attach?: boolean;
   force?: boolean;
+  compact?: boolean;
 }
 
 // Check preconditions for managed services mode
@@ -101,10 +102,10 @@ export async function upCommand(options: UpOptions = {}): Promise<Result<void>> 
   // Create/attach main session
   if (options.attach) {
     console.log();
-    await openMainSession(repoRoot, { attach: true });
+    await openMainSession(repoRoot, { attach: true, compact: options.compact });
   } else {
     // Create session in background if it doesn't exist
-    await openMainSession(repoRoot, { attach: false });
+    await openMainSession(repoRoot, { attach: false, compact: options.compact });
     console.log();
     logger.success("Managed services started!");
     console.log();

--- a/x/henry/dust-hive/src/index.ts
+++ b/x/henry/dust-hive/src/index.ts
@@ -170,9 +170,14 @@ cli
   .command("up", "Start managed services (temporal + main session)")
   .option("-a, --attach", "Attach to main zellij session")
   .option("-f, --force", "Force rebuild even if no changes detected")
-  .action(async (options: { attach?: boolean; force?: boolean }) => {
+  .option("-C, --compact", "Use compact zellij layout (bar at bottom)")
+  .action(async (options: { attach?: boolean; force?: boolean; compact?: boolean }) => {
     await prepareAndRun(
-      upCommand({ attach: Boolean(options.attach), force: Boolean(options.force) })
+      upCommand({
+        attach: Boolean(options.attach),
+        force: Boolean(options.force),
+        compact: Boolean(options.compact),
+      })
     );
   });
 


### PR DESCRIPTION
## Summary
- Add `-C`/`--compact` option to `dust-hive up` command for consistency with `open` and `spawn` commands
- When enabled, the zellij layout uses a compact bar at the bottom instead of the top