### PR TITLE
[front] - chore(CreateDropdown): add skills and rename

### DIFF
--- a/front/components/assistant/AgentBrowser.tsx
+++ b/front/components/assistant/AgentBrowser.tsx
@@ -30,7 +30,7 @@ import React, {
 } from "react";
 import { useInView } from "react-intersection-observer";
 
-import { CreateAgentButton } from "@app/components/assistant/CreateAgentButton";
+import { CreateDropdown } from "@app/components/assistant/CreateDropdown";
 import { AgentDetails } from "@app/components/assistant/details/AgentDetails";
 import { AgentDetailsDropdownMenu } from "@app/components/assistant/details/AgentDetailsButtonBar";
 import { rankAgentsByPopularity } from "@app/components/assistant/helpers/agents";
@@ -472,7 +472,7 @@ export function AgentBrowser({
           <div className="flex gap-2">
             {!isRestrictedFromAgentCreation && (
               <div ref={createAgentButtonRef}>
-                <CreateAgentButton owner={owner} dataGtmLocation="homepage" />
+                <CreateDropdown owner={owner} dataGtmLocation="homepage" />
               </div>
             )}
 

--- a/front/components/assistant/AgentPicker.tsx
+++ b/front/components/assistant/AgentPicker.tsx
@@ -11,7 +11,7 @@ import {
 } from "@dust-tt/sparkle";
 import { useState } from "react";
 
-import { CreateAgentButton } from "@app/components/assistant/CreateAgentButton";
+import { CreateDropdown } from "@app/components/assistant/CreateDropdown";
 import { filterAndSortAgents } from "@app/lib/utils";
 import type { LightAgentConfigurationType, WorkspaceType } from "@app/types";
 
@@ -89,7 +89,7 @@ export function AgentPicker({
               }}
               button={
                 showFooterButtons && (
-                  <CreateAgentButton owner={owner} dataGtmLocation="homepage" />
+                  <CreateDropdown owner={owner} dataGtmLocation="homepage" />
                 )
               }
             />

--- a/front/components/assistant/CreateAgentButton.tsx
+++ b/front/components/assistant/CreateAgentButton.tsx
@@ -4,10 +4,12 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
   DropdownMenuTrigger,
   FolderOpenIcon,
   MagicIcon,
   PlusIcon,
+  PuzzleIcon,
   Spinner,
 } from "@dust-tt/sparkle";
 import { useRouter } from "next/router";
@@ -16,7 +18,10 @@ import { useState } from "react";
 import { useYAMLUpload } from "@app/hooks/useYAMLUpload";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
-import { getAgentBuilderRoute } from "@app/lib/utils/router";
+import {
+  getAgentBuilderRoute,
+  getSkillBuilderRoute,
+} from "@app/lib/utils/router";
 import type { LightWorkspaceType } from "@app/types";
 
 interface CreateAgentButtonProps {
@@ -53,6 +58,7 @@ export const CreateAgentButton = ({
         />
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start">
+        {hasFeature("skills") && <DropdownMenuLabel label="Agents" />}
         <DropdownMenuItem
           label="agent from scratch"
           icon={DocumentIcon}
@@ -84,6 +90,23 @@ export const CreateAgentButton = ({
             disabled={isUploadingYAML}
             onClick={triggerYAMLUpload}
           />
+        )}
+        {hasFeature("skills") && (
+          <>
+            <DropdownMenuLabel label="Skills" />
+            <DropdownMenuItem
+              label="skill"
+              icon={PuzzleIcon}
+              onClick={withTracking(
+                TRACKING_AREAS.BUILDER,
+                "create_skill",
+                () => {
+                  setIsLoading(true);
+                  void router.push(getSkillBuilderRoute(owner.sId, "new"));
+                }
+              )}
+            />
+          </>
         )}
       </DropdownMenuContent>
     </DropdownMenu>

--- a/front/components/assistant/CreateDropdown.tsx
+++ b/front/components/assistant/CreateDropdown.tsx
@@ -24,15 +24,15 @@ import {
 } from "@app/lib/utils/router";
 import type { LightWorkspaceType } from "@app/types";
 
-interface CreateAgentButtonProps {
+interface CreateDropdownProps {
   owner: LightWorkspaceType;
   dataGtmLocation: string;
 }
 
-export const CreateAgentButton = ({
+export const CreateDropdown = ({
   owner,
   dataGtmLocation,
-}: CreateAgentButtonProps) => {
+}: CreateDropdownProps) => {
   const router = useRouter();
   const [isLoading, setIsLoading] = useState(false);
   const { isUploading: isUploadingYAML, triggerYAMLUpload } = useYAMLUpload({

--- a/front/pages/w/[wId]/builder/agents/index.tsx
+++ b/front/pages/w/[wId]/builder/agents/index.tsx
@@ -18,7 +18,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 
 import { AgentEditBar } from "@app/components/assistant/AgentEditBar";
 import { AgentSidebarMenu } from "@app/components/assistant/conversation/SidebarMenu";
-import { CreateAgentButton } from "@app/components/assistant/CreateAgentButton";
+import { CreateDropdown } from "@app/components/assistant/CreateDropdown";
 import { AgentDetails } from "@app/components/assistant/details/AgentDetails";
 import { AssistantsTable } from "@app/components/assistant/manager/AssistantsTable";
 import { TagsFilterMenu } from "@app/components/assistant/TagsFilterMenu";
@@ -343,7 +343,7 @@ export default function WorkspaceAssistants({
                   owner={owner}
                 />
                 {!isRestrictedFromAgentCreation && (
-                  <CreateAgentButton
+                  <CreateDropdown
                     owner={owner}
                     dataGtmLocation="assistantsWorkspace"
                   />


### PR DESCRIPTION



## Description
Renames `CreateAgentButton` component to `CreateDropdown` to better reflect its purpose, and adds skill creation functionality to the dropdown menu when the `skills` feature flag is enabled. The dropdown now includes a "Skills" section with an option to create a new skill, routing users to the skill builder page.

## Risk
No risk - the changes are purely cosmetic (component rename) and additive (new menu items behind a feature flag). The dropdown behavior and existing agent creation flows remain unchanged.

## Tests
Manual testing of the dropdown menu with and without the `skills` feature flag enabled.

## Deploy Plan
Deploy front