### PR TITLE
[connectors] enh(gdrive): Add parallelization option

### DIFF
--- a/connectors/migrations/20231109_2_create_gdrive_config.ts
+++ b/connectors/migrations/20231109_2_create_gdrive_config.ts
@@ -14,6 +14,7 @@ async function main() {
       pdfEnabled: false,
       csvEnabled: false,
       largeFilesEnabled: false,
+      useParallelSync: false,
     });
     console.log(
       `Created config for connector ${config.connectorId} with id ${config.id} and pdfEnabled ${config.pdfEnabled}`

--- a/connectors/migrations/db/migration_113.sql
+++ b/connectors/migrations/db/migration_113.sql
@@ -1,0 +1,7 @@
+-- Migration created on Jan 06, 2026
+-- Add parallel sync support for Google Drive connector
+
+-- Add useParallelSync flag to google_drive_configs table
+-- This enables gradual rollout of parallel folder sync feature
+ALTER TABLE "google_drive_configs"
+  ADD COLUMN "useParallelSync" BOOLEAN NOT NULL DEFAULT FALSE;

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -115,6 +115,7 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
       pdfEnabled: false,
       largeFilesEnabled: false,
       csvEnabled: false,
+      useParallelSync: false,
     };
 
     const connector = await ConnectorResource.makeNew(
@@ -683,6 +684,18 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
         }
         return new Ok(void 0);
       }
+      case "useParallelSync": {
+        await config.update({
+          useParallelSync: configValue === "true",
+        });
+        const workflowRes = await launchGoogleDriveIncrementalSyncWorkflow(
+          this.connectorId
+        );
+        if (workflowRes.isErr()) {
+          return workflowRes;
+        }
+        return new Ok(void 0);
+      }
 
       default: {
         return new Err(new Error(`Invalid config key ${configKey}`));
@@ -770,6 +783,9 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
       }
       case "csvEnabled": {
         return new Ok(config.csvEnabled ? "true" : "false");
+      }
+      case "useParallelSync": {
+        return new Ok(config.useParallelSync ? "true" : "false");
       }
       default:
         return new Err(new Error(`Invalid config key ${configKey}`));

--- a/connectors/src/lib/models/google_drive.ts
+++ b/connectors/src/lib/models/google_drive.ts
@@ -13,6 +13,7 @@ export class GoogleDriveConfigModel extends ConnectorBaseModel<GoogleDriveConfig
   declare pdfEnabled: boolean;
   declare csvEnabled: boolean;
   declare largeFilesEnabled: boolean;
+  declare useParallelSync: boolean;
 }
 GoogleDriveConfigModel.init(
   {
@@ -37,6 +38,11 @@ GoogleDriveConfigModel.init(
       defaultValue: false,
     },
     largeFilesEnabled: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    },
+    useParallelSync: {
       type: DataTypes.BOOLEAN,
       allowNull: false,
       defaultValue: false,

--- a/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
@@ -66,6 +66,7 @@ type FeaturesType = {
   slackBotEnabled: boolean;
   googleDrivePdfEnabled: boolean;
   googleDriveLargeFilesEnabled: boolean;
+  googleDriveParallelSyncEnabled: boolean;
   microsoftPdfEnabled: boolean;
   microsoftLargeFilesEnabled: boolean;
   googleDriveCsvEnabled: boolean;
@@ -157,6 +158,7 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
     slackBotEnabled: false,
     googleDrivePdfEnabled: false,
     googleDriveLargeFilesEnabled: false,
+    googleDriveParallelSyncEnabled: false,
     microsoftPdfEnabled: false,
     microsoftLargeFilesEnabled: false,
     googleDriveCsvEnabled: false,
@@ -242,6 +244,17 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
         }
         features.googleDriveLargeFilesEnabled =
           gdriveLargeFilesEnabledRes.value.configValue === "true";
+
+        const gdriveParallelSyncEnabledRes =
+          await connectorsAPI.getConnectorConfig(
+            dataSource.connectorId,
+            "useParallelSync"
+          );
+        if (gdriveParallelSyncEnabledRes.isErr()) {
+          throw gdriveParallelSyncEnabledRes.error;
+        }
+        features.googleDriveParallelSyncEnabled =
+          gdriveParallelSyncEnabledRes.value.configValue === "true";
         break;
 
       case "microsoft":
@@ -714,6 +727,14 @@ const DataSourcePage = ({
                   dataSource={dataSource}
                   configKey="largeFilesEnabled"
                   featureKey="googleDriveLargeFilesEnabled"
+                />
+                <ConfigToggle
+                  title="Parallel syncing enabled?"
+                  owner={owner}
+                  features={features}
+                  dataSource={dataSource}
+                  configKey="useParallelSync"
+                  featureKey="googleDriveParallelSyncEnabled"
                 />
               </>
             )}


### PR DESCRIPTION
## Description

Adds a new parallelized workflow for google_drive sync. 
Option will be used in following PRs. Config parameter can be enabled in poke.

Option to be removed once we're confident with new workflow : https://github.com/dust-tt/tasks/issues/5873

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

run migration

deploy connectors + front (poke)
