### PR TITLE
[connectors] enh(gdrive): Parallelize incremental workflow

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/activities/incremental_sync.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities/incremental_sync.ts
@@ -53,7 +53,16 @@ export async function incrementalSync(
     driveId: driveId,
     runInstance: uuid4(),
   });
-
+  localLogger.info(
+    {
+      connectorId,
+      driveId,
+      isSharedDrive,
+      startSyncTs,
+      nextPageToken,
+    },
+    "Starting incremental sync"
+  );
   const redisCli = await redisClient({
     origin: "google_drive_incremental_sync",
   });

--- a/connectors/src/connectors/google_drive/temporal/client.ts
+++ b/connectors/src/connectors/google_drive/temporal/client.ts
@@ -133,7 +133,7 @@ export async function launchGoogleDriveIncrementalSyncWorkflow(
     : googleDriveIncrementalSync;
 
   // Randomize the delay to avoid all incremental syncs starting at the same time, especially when restarting all via cli.
-  const delay = Math.floor(Math.random() * 5);
+  const delayMinutes = Math.floor(Math.random() * 5);
 
   try {
     // Terminate both versions of the workflows in case we changed the flag
@@ -152,7 +152,7 @@ export async function launchGoogleDriveIncrementalSyncWorkflow(
       memo: {
         connectorId,
       },
-      startDelay: `${delay} minutes`,
+      startDelay: `${delayMinutes} minutes`,
     });
     localLogger.info(
       {

--- a/connectors/src/connectors/google_drive/temporal/config.ts
+++ b/connectors/src/connectors/google_drive/temporal/config.ts
@@ -2,3 +2,7 @@ const GDRIVE_FULL_SYNC_QUEUE_VERSION = 6;
 const GDRIVE_INCREMENTAL_SYNC_QUEUE_VERSION = 9;
 export const GDRIVE_FULL_SYNC_QUEUE_NAME = `google-queue-fullsync-v${GDRIVE_FULL_SYNC_QUEUE_VERSION}`;
 export const GDRIVE_INCREMENTAL_SYNC_QUEUE_NAME = `google-queue-incremental-v${GDRIVE_INCREMENTAL_SYNC_QUEUE_VERSION}`;
+
+// Maximum number of folders to sync in parallel for parallel sync workflows.
+// Can be overridden via GDRIVE_MAX_CONCURRENT_FOLDER_SYNCS environment variable.
+export const GDRIVE_MAX_CONCURRENT_FOLDER_SYNCS = 5;

--- a/connectors/src/connectors/google_drive/temporal/config.ts
+++ b/connectors/src/connectors/google_drive/temporal/config.ts
@@ -4,5 +4,4 @@ export const GDRIVE_FULL_SYNC_QUEUE_NAME = `google-queue-fullsync-v${GDRIVE_FULL
 export const GDRIVE_INCREMENTAL_SYNC_QUEUE_NAME = `google-queue-incremental-v${GDRIVE_INCREMENTAL_SYNC_QUEUE_VERSION}`;
 
 // Maximum number of folders to sync in parallel for parallel sync workflows.
-// Can be overridden via GDRIVE_MAX_CONCURRENT_FOLDER_SYNCS environment variable.
 export const GDRIVE_MAX_CONCURRENT_FOLDER_SYNCS = 5;

--- a/connectors/src/connectors/google_drive/temporal/workflows.ts
+++ b/connectors/src/connectors/google_drive/temporal/workflows.ts
@@ -1,5 +1,4 @@
 import { assertNever } from "@temporalio/common/lib/type-helpers";
-import type { ChildWorkflowHandle } from "@temporalio/workflow";
 import {
   continueAsNew,
   executeChild,

--- a/connectors/src/connectors/google_drive/temporal/workflows.ts
+++ b/connectors/src/connectors/google_drive/temporal/workflows.ts
@@ -1,13 +1,16 @@
 import { assertNever } from "@temporalio/common/lib/type-helpers";
+import type { ChildWorkflowHandle } from "@temporalio/workflow";
 import {
   continueAsNew,
   executeChild,
   proxyActivities,
   setHandler,
   sleep,
+  startChild,
   workflowInfo,
 } from "@temporalio/workflow";
 import { uniq } from "lodash";
+import PQueue from "p-queue";
 
 import type * as activities from "@connectors/connectors/google_drive/temporal/activities";
 import type { FolderUpdatesSignal } from "@connectors/connectors/google_drive/temporal/signals";
@@ -15,6 +18,7 @@ import type * as sync_status from "@connectors/lib/sync_status";
 import type { ModelId } from "@connectors/types";
 
 import { GOOGLE_DRIVE_USER_SPACE_VIRTUAL_DRIVE_ID } from "../lib/consts";
+import { GDRIVE_MAX_CONCURRENT_FOLDER_SYNCS } from "./config";
 import { folderUpdatesSignal } from "./signals";
 
 const {
@@ -317,4 +321,153 @@ export async function googleDriveFixParentsConsistencyWorkflow(
       startTs,
     });
   } while (fromId > 0);
+}
+
+/**
+ * Child workflow that handles incremental sync for a single drive.
+ * Processes all changes for the drive with pagination, and launches full sync for new folders.
+ */
+export async function googleDriveIncrementalSyncPerDrive({
+  connectorId,
+  driveId,
+  isShared,
+  startSyncTs,
+}: {
+  connectorId: ModelId;
+  driveId: string;
+  isShared: boolean;
+  startSyncTs: number;
+}) {
+  let nextPageToken: string | undefined = undefined;
+  const discoveredFolders: string[] = [];
+
+  // Process all changes for this drive with pagination
+  do {
+    const syncRes = await incrementalSync(
+      connectorId,
+      driveId,
+      isShared,
+      startSyncTs,
+      nextPageToken
+    );
+
+    if (syncRes) {
+      discoveredFolders.push(...syncRes.newFolders);
+      nextPageToken = syncRes.nextPageToken;
+    }
+  } while (nextPageToken);
+
+  // If new folders discovered from this drive, launch child workflow
+  if (discoveredFolders.length > 0) {
+    await executeChild(googleDriveFullSync, {
+      workflowId: `googleDrive-newFolders-${connectorId}-drive-${driveId}-${startSyncTs}`,
+      searchAttributes: {
+        connectorId: [connectorId],
+      },
+      args: [
+        {
+          connectorId,
+          garbageCollect: false,
+          foldersToBrowse: discoveredFolders,
+          totalCount: 0,
+          startSyncTs,
+          mimeTypeFilter: undefined,
+        },
+      ],
+      memo: workflowInfo().memo,
+    });
+  }
+}
+
+export function googleDriveIncrementalSyncPerDriveWorkflowId(
+  connectorId: ModelId,
+  driveId: string
+): string {
+  return `googleDrive-incrementalSync-${connectorId}-drive-${driveId}`;
+}
+
+/**
+ * V2 Incremental Sync Coordinator Workflow - launches one child workflow per drive for parallel processing.
+ * Each child workflow handles its drive's incremental sync and new folder discovery.
+ */
+export async function googleDriveIncrementalSyncV2(
+  connectorId: ModelId,
+  startSyncTs: number | undefined = undefined
+) {
+  if (!startSyncTs) {
+    await syncStarted(connectorId);
+    startSyncTs = new Date().getTime();
+  }
+
+  // Get drives to sync
+  const drives = await getDrivesToSync(connectorId);
+  const drivesToSync = drives
+    .map((drive) => ({
+      id: drive.id,
+      isShared: drive.isSharedDrive,
+    }))
+    // Include userspace (non-shared drives)
+    .concat({
+      id: GOOGLE_DRIVE_USER_SPACE_VIRTUAL_DRIVE_ID,
+      isShared: false,
+    });
+
+  // Launch child workflows in parallel - one per drive
+  const queue = new PQueue({ concurrency: GDRIVE_MAX_CONCURRENT_FOLDER_SYNCS });
+  const childHandles: ChildWorkflowHandle<
+    typeof googleDriveIncrementalSyncPerDrive
+  >[] = [];
+
+  // Start all child workflows
+  for (const googleDrive of drivesToSync) {
+    await queue.add(async () => {
+      const handle = await startChild(googleDriveIncrementalSyncPerDrive, {
+        workflowId: googleDriveIncrementalSyncPerDriveWorkflowId(
+          connectorId,
+          googleDrive.id
+        ),
+        searchAttributes: {
+          connectorId: [connectorId],
+        },
+        args: [
+          {
+            connectorId,
+            driveId: googleDrive.id,
+            isShared: googleDrive.isShared,
+            startSyncTs,
+          },
+        ],
+        memo: workflowInfo().memo,
+      });
+      childHandles.push(handle);
+    });
+  }
+
+  // Wait for all drive syncs to complete
+  await Promise.all(childHandles.map((handle) => handle.result()));
+
+  // Check if garbage collection is needed
+  const shouldGc = await shouldGarbageCollect(connectorId);
+  if (shouldGc) {
+    await executeChild(googleDriveGarbageCollectorWorkflow, {
+      workflowId: googleDriveGarbageCollectorWorkflowId(connectorId),
+      searchAttributes: {
+        connectorId: [connectorId],
+      },
+      args: [connectorId, startSyncTs],
+      memo: workflowInfo().memo,
+    });
+  }
+
+  await syncSucceeded(connectorId);
+
+  // Sleep and continue
+  await sleep("5 minutes");
+  await continueAsNew<typeof googleDriveIncrementalSyncV2>(connectorId);
+}
+
+export function googleDriveIncrementalSyncV2WorkflowId(
+  connectorId: ModelId
+): string {
+  return `googleDrive-incrementalSyncV2-${connectorId}`;
 }

--- a/connectors/src/connectors/google_drive/temporal/workflows.ts
+++ b/connectors/src/connectors/google_drive/temporal/workflows.ts
@@ -438,13 +438,10 @@ export async function googleDriveIncrementalSyncV2(
         ],
         memo: workflowInfo().memo,
       });
-      childHandles.push(handle);
+      return handle.result();
     },
     { concurrency: GDRIVE_MAX_CONCURRENT_FOLDER_SYNCS }
   );
-
-  // Wait for all drive syncs to complete
-  await Promise.all(childHandles.map((handle) => handle.result()));
 
   // Check if garbage collection is needed
   const shouldGc = await shouldGarbageCollect(connectorId);


### PR DESCRIPTION
## Description

The incremental sync parallelize per drive, as the delta are fetched per drive. 
We start one googleDriveIncrementalSyncPerDrive child workflow for each drive (limited to 5 in parallel).

## Tests

Tested locally :

- setup new config
- check incremental sync by adding files/folders in drive once initial sync is over
- switch from v1 to v2 and the opposite : incremental sync is switched from one version to the other


## Risk

gated with option

## Deploy Plan

deploy connectors