### PR TITLE
[connectors] enh(gdrive): Parallelize full sync workflow

### DIFF
--- a/connectors/migrations/20240702_gdrive_fullsync_pptx_docx.ts
+++ b/connectors/migrations/20240702_gdrive_fullsync_pptx_docx.ts
@@ -25,6 +25,8 @@ export async function main() {
         await launchGoogleDriveFullSyncWorkflow(
           connector.id,
           null,
+          null,
+          [],
           mimeTypeFilter
         );
       }

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -17,6 +17,7 @@ import {
   launchGoogleDriveFullSyncWorkflow,
   launchGoogleDriveIncrementalSyncWorkflow,
   launchGoogleGarbageCollector,
+  signalFolderRemoval,
 } from "@connectors/connectors/google_drive/temporal/client";
 import {
   isGoogleDriveFolder,
@@ -588,15 +589,16 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
       const res = await launchGoogleDriveFullSyncWorkflow(
         this.connectorId,
         null,
-        addedFolderIds
+        addedFolderIds,
+        removedFolderIds
       );
       if (res.isErr()) {
         return res;
       }
     } else if (removedFolderIds.length > 0) {
       // If we have added folders, the garbage collector will be automatically at the end of the full sync,
-      // but if we only removed folders, we need launch it manually.
-      const res = await launchGoogleGarbageCollector(this.connectorId);
+      // but if we only removed folders, check if workflow is running to signal it
+      const res = await signalFolderRemoval(this.connectorId, removedFolderIds);
       if (res.isErr()) {
         return res;
       }

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -830,7 +830,7 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
   }: {
     fromTs: number | null;
   }): Promise<Result<string, Error>> {
-    return launchGoogleDriveFullSyncWorkflow(this.connectorId, fromTs, null);
+    return launchGoogleDriveFullSyncWorkflow(this.connectorId, fromTs);
   }
 
   async configure(): Promise<Result<void, Error>> {

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -650,8 +650,7 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
         });
         const workflowRes = await launchGoogleDriveFullSyncWorkflow(
           this.connectorId,
-          null,
-          []
+          null
         );
         if (workflowRes.isErr()) {
           return workflowRes;
@@ -664,8 +663,7 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
         });
         const workflowRes = await launchGoogleDriveFullSyncWorkflow(
           this.connectorId,
-          null,
-          []
+          null
         );
         if (workflowRes.isErr()) {
           return workflowRes;
@@ -678,8 +676,7 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
         });
         const workflowRes = await launchGoogleDriveFullSyncWorkflow(
           this.connectorId,
-          null,
-          []
+          null
         );
         if (workflowRes.isErr()) {
           return workflowRes;
@@ -833,7 +830,7 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
   }: {
     fromTs: number | null;
   }): Promise<Result<string, Error>> {
-    return launchGoogleDriveFullSyncWorkflow(this.connectorId, fromTs, []);
+    return launchGoogleDriveFullSyncWorkflow(this.connectorId, fromTs, null);
   }
 
   async configure(): Promise<Result<void, Error>> {

--- a/connectors/src/connectors/google_drive/index.ts
+++ b/connectors/src/connectors/google_drive/index.ts
@@ -17,7 +17,6 @@ import {
   launchGoogleDriveFullSyncWorkflow,
   launchGoogleDriveIncrementalSyncWorkflow,
   launchGoogleGarbageCollector,
-  signalFolderRemoval,
 } from "@connectors/connectors/google_drive/temporal/client";
 import {
   isGoogleDriveFolder,
@@ -585,20 +584,13 @@ export class GoogleDriveConnectorManager extends BaseConnectorManager<null> {
       }
     }
 
-    if (addedFolderIds.length > 0) {
+    if (addedFolderIds.length > 0 || removedFolderIds.length > 0) {
       const res = await launchGoogleDriveFullSyncWorkflow(
         this.connectorId,
         null,
         addedFolderIds,
         removedFolderIds
       );
-      if (res.isErr()) {
-        return res;
-      }
-    } else if (removedFolderIds.length > 0) {
-      // If we have added folders, the garbage collector will be automatically at the end of the full sync,
-      // but if we only removed folders, check if workflow is running to signal it
-      const res = await signalFolderRemoval(this.connectorId, removedFolderIds);
       if (res.isErr()) {
         return res;
       }

--- a/connectors/src/connectors/google_drive/temporal/activities/cancel_child_workflow.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities/cancel_child_workflow.ts
@@ -1,0 +1,19 @@
+import { getTemporalClient } from "@connectors/lib/temporal";
+import logger from "@connectors/logger/logger";
+
+/**
+ * Activity to cancel a child workflow by workflow ID.
+ * This is needed because workflows cannot directly cancel child workflows -
+ * they need to use the Temporal client which is only available in activities.
+ */
+export async function cancelChildWorkflow(workflowId: string): Promise<void> {
+  const client = await getTemporalClient();
+
+  try {
+    const handle = client.workflow.getHandle(workflowId);
+    await handle.cancel();
+  } catch (e) {
+    // Workflow may not exist or already completed, which is fine
+    logger.info(`Failed to cancel workflow ${workflowId}: ${e}`);
+  }
+}

--- a/connectors/src/connectors/google_drive/temporal/activities/get_files_count_for_sync.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities/get_files_count_for_sync.ts
@@ -1,0 +1,24 @@
+import { Op } from "sequelize";
+
+import { GoogleDriveFilesModel } from "@connectors/lib/models/google_drive";
+import type { ModelId } from "@connectors/types";
+
+/**
+ * Count the number of files that were synced (upserted) during this sync run.
+ * Uses lastSeenTs to identify files touched in this sync.
+ */
+export async function getFilesCountForSync(
+  connectorId: ModelId,
+  startSyncTs: number
+): Promise<number> {
+  const count = await GoogleDriveFilesModel.count({
+    where: {
+      connectorId,
+      lastSeenTs: {
+        [Op.gte]: new Date(startSyncTs),
+      },
+    },
+  });
+
+  return count;
+}

--- a/connectors/src/connectors/google_drive/temporal/activities/index.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities/index.ts
@@ -1,7 +1,9 @@
+export { cancelChildWorkflow } from "./cancel_child_workflow";
 export { fixParentsConsistencyActivity } from "./fix_parents_consistency_activity";
 export { garbageCollector } from "./garbage_collector";
 export { garbageCollectorFinished } from "./garbage_collector_finished";
 export { getDrivesToSync } from "./get_drives_to_sync";
+export { getFilesCountForSync } from "./get_files_count_for_sync";
 export { getFoldersToSync } from "./get_folders_to_sync";
 export { incrementalSync } from "./incremental_sync";
 export { markFolderAsVisited } from "./mark_folder_as_visited";

--- a/connectors/src/connectors/google_drive/temporal/client.ts
+++ b/connectors/src/connectors/google_drive/temporal/client.ts
@@ -37,7 +37,6 @@ import {
 const isWorkflowRunning = async (handle: WorkflowHandle): Promise<boolean> => {
   try {
     const description = await handle.describe();
-    // Workflow is running if it's in one of these states
     return description.status.name === "RUNNING";
   } catch (e) {
     if (!(e instanceof WorkflowNotFoundError)) {
@@ -108,7 +107,6 @@ export async function launchGoogleDriveFullSyncWorkflow(
             garbageCollect: true,
             startSyncTs: undefined,
             mimeTypeFilter,
-            folderWorkflowCounters: {},
             initialFolderIds: addedFolderIds,
           },
         ],

--- a/connectors/src/connectors/google_drive/temporal/client.ts
+++ b/connectors/src/connectors/google_drive/temporal/client.ts
@@ -99,48 +99,29 @@ export async function launchGoogleDriveFullSyncWorkflow(
 
   // Helper to start the workflow
   const startWorkflow = async () => {
-    if (useParallelSync) {
-      await client.workflow.start(googleDriveFullSyncV2, {
-        args: [
-          {
-            connectorId,
-            garbageCollect: true,
-            startSyncTs: undefined,
-            mimeTypeFilter,
-            initialFolderIds: addedFolderIds,
-          },
-        ],
-        taskQueue: GDRIVE_FULL_SYNC_QUEUE_NAME,
-        workflowId,
-        searchAttributes: {
-          connectorId: [connectorId],
-        },
-        memo: {
+    const workflowFn = useParallelSync
+      ? googleDriveFullSyncV2
+      : googleDriveFullSync;
+    await client.workflow.start(workflowFn, {
+      args: [
+        {
           connectorId,
+          garbageCollect: true,
+          startSyncTs: undefined,
+          foldersToBrowse: addedFolderIds,
+          totalCount: 0,
+          mimeTypeFilter,
         },
-      });
-    } else {
-      await client.workflow.start(googleDriveFullSync, {
-        args: [
-          {
-            connectorId,
-            garbageCollect: true,
-            startSyncTs: undefined,
-            foldersToBrowse: addedFolderIds,
-            totalCount: 0,
-            mimeTypeFilter,
-          },
-        ],
-        taskQueue: GDRIVE_FULL_SYNC_QUEUE_NAME,
-        workflowId,
-        searchAttributes: {
-          connectorId: [connectorId],
-        },
-        memo: {
-          connectorId,
-        },
-      });
-    }
+      ],
+      taskQueue: GDRIVE_FULL_SYNC_QUEUE_NAME,
+      workflowId,
+      searchAttributes: {
+        connectorId: [connectorId],
+      },
+      memo: {
+        connectorId,
+      },
+    });
   };
 
   try {

--- a/connectors/src/connectors/google_drive/temporal/client.ts
+++ b/connectors/src/connectors/google_drive/temporal/client.ts
@@ -120,7 +120,6 @@ export async function launchGoogleDriveFullSyncWorkflow(
                 garbageCollect: true,
                 startSyncTs: undefined,
                 mimeTypeFilter,
-                runningFolderWorkflows: {},
                 folderWorkflowCounters: {},
                 initialFolderIds: addedFolderIds,
               },

--- a/connectors/src/connectors/google_drive/temporal/client.ts
+++ b/connectors/src/connectors/google_drive/temporal/client.ts
@@ -24,6 +24,8 @@ import {
   googleDriveFixParentsConsistencyWorkflow,
   googleDriveFixParentsConsistencyWorkflowId,
   googleDriveFullSync,
+  googleDriveFullSyncV2,
+  googleDriveFullSyncV2WorkflowId,
   googleDriveFullSyncWorkflowId,
   googleDriveGarbageCollectorWorkflow,
   googleDriveGarbageCollectorWorkflowId,
@@ -32,10 +34,25 @@ import {
   googleDriveIncrementalSyncV2WorkflowId,
 } from "./workflows";
 
+const isWorkflowRunning = async (handle: WorkflowHandle): Promise<boolean> => {
+  try {
+    const description = await handle.describe();
+    // Workflow is running if it's in one of these states
+    return description.status.name === "RUNNING";
+  } catch (e) {
+    if (!(e instanceof WorkflowNotFoundError)) {
+      throw e;
+    }
+
+    return false;
+  }
+};
+
 export async function launchGoogleDriveFullSyncWorkflow(
   connectorId: ModelId,
   fromTs: number | null,
   addedFolderIds: string[],
+  removedFolderIds: string[] = [],
   mimeTypeFilter?: string[]
 ): Promise<Result<string, Error>> {
   const connector = await ConnectorResource.fetchById(connectorId);
@@ -51,47 +68,114 @@ export async function launchGoogleDriveFullSyncWorkflow(
     );
   }
 
-  const client = await getTemporalClient();
+  // Check feature flag to determine which workflow version to use
+  const config = await GoogleDriveConfigModel.findOne({
+    where: { connectorId },
+  });
+  const useParallelSync = config?.useParallelSync ?? false;
 
+  const client = await getTemporalClient();
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
 
-  const signalArgs: FolderUpdatesSignal[] =
-    addedFolderIds.map((sId) => ({
-      action: "added",
+  // Create signals for both added and removed folders
+  const signalArgs: FolderUpdatesSignal[] = [
+    ...addedFolderIds.map((sId) => ({
+      action: "added" as const,
       folderId: sId,
-    })) ?? [];
+    })),
+    ...removedFolderIds.map((sId) => ({
+      action: "removed" as const,
+      folderId: sId,
+    })),
+  ];
 
-  const workflowId = googleDriveFullSyncWorkflowId(connectorId);
+  // Route to appropriate workflow based on feature flag
+  const workflowId = useParallelSync
+    ? googleDriveFullSyncV2WorkflowId(connectorId)
+    : googleDriveFullSyncWorkflowId(connectorId);
+
   try {
-    await client.workflow.signalWithStart(googleDriveFullSync, {
-      args: [
+    const handle = client.workflow.getHandle(workflowId);
+    const workflowRunning = await isWorkflowRunning(handle);
+
+    if (workflowRunning) {
+      await handle.signal(folderUpdatesSignal, signalArgs);
+      localLogger.info(
         {
-          connectorId: connectorId,
-          garbageCollect: true,
-          startSyncTs: undefined,
-          foldersToBrowse: addedFolderIds,
-          totalCount: 0,
-          mimeTypeFilter: mimeTypeFilter,
+          workspaceId: dataSourceConfig.workspaceId,
+          workflowId,
+          useParallelSync,
+          foldersAdded: addedFolderIds.length,
+          foldersRemoved: removedFolderIds.length,
         },
-      ],
-      taskQueue: GDRIVE_FULL_SYNC_QUEUE_NAME,
-      workflowId: workflowId,
-      searchAttributes: {
-        connectorId: [connectorId],
-      },
-      memo: {
-        connectorId: connectorId,
-      },
-      signal: folderUpdatesSignal,
-      signalArgs: [signalArgs],
-    });
-    localLogger.info(
-      {
-        workspaceId: dataSourceConfig.workspaceId,
-        workflowId,
-      },
-      `Started workflow.`
-    );
+        `Sent signal to running workflow.`
+      );
+    } else {
+      if (addedFolderIds.length > 0) {
+        if (useParallelSync) {
+          await client.workflow.start(googleDriveFullSyncV2, {
+            args: [
+              {
+                connectorId,
+                garbageCollect: true,
+                startSyncTs: undefined,
+                mimeTypeFilter,
+                runningFolderWorkflows: {},
+                folderWorkflowCounters: {},
+                initialFolderIds: addedFolderIds,
+              },
+            ],
+            taskQueue: GDRIVE_FULL_SYNC_QUEUE_NAME,
+            workflowId,
+            searchAttributes: {
+              connectorId: [connectorId],
+            },
+            memo: {
+              connectorId,
+            },
+          });
+        } else {
+          await client.workflow.start(googleDriveFullSync, {
+            args: [
+              {
+                connectorId,
+                garbageCollect: true,
+                startSyncTs: undefined,
+                foldersToBrowse: addedFolderIds,
+                totalCount: 0,
+                mimeTypeFilter,
+              },
+            ],
+            taskQueue: GDRIVE_FULL_SYNC_QUEUE_NAME,
+            workflowId,
+            searchAttributes: {
+              connectorId: [connectorId],
+            },
+            memo: {
+              connectorId,
+            },
+          });
+        }
+        localLogger.info(
+          {
+            workspaceId: dataSourceConfig.workspaceId,
+            workflowId,
+            useParallelSync,
+          },
+          `Started workflow.`
+        );
+      } else if (removedFolderIds.length > 0) {
+        // Only removals, launch garbage collector
+        localLogger.info(
+          {
+            workspaceId: dataSourceConfig.workspaceId,
+            foldersRemoved: removedFolderIds.length,
+          },
+          `Folders removed but workflow not running, will launch GC.`
+        );
+        return await launchGoogleGarbageCollector(connectorId);
+      }
+    }
     return new Ok(workflowId);
   } catch (e) {
     localLogger.error(
@@ -171,6 +255,79 @@ export async function launchGoogleDriveIncrementalSyncWorkflow(
         error: e,
       },
       `Failed starting workflow.`
+    );
+    return new Err(normalizeError(e));
+  }
+}
+
+/**
+ * Signal folder removal to a running workflow, or launch GC if workflow is not running.
+ * This function is used when folders are removed without any additions.
+ */
+export async function signalFolderRemoval(
+  connectorId: ModelId,
+  removedFolderIds: string[]
+): Promise<Result<string, Error>> {
+  const connector = await ConnectorResource.fetchById(connectorId);
+  if (!connector) {
+    return new Err(new Error(`Connector ${connectorId} not found`));
+  }
+  const localLogger = getActivityLogger(connector);
+
+  const config = await GoogleDriveConfigModel.findOne({
+    where: { connectorId },
+  });
+  const useParallelSync = config?.useParallelSync ?? false;
+
+  const client = await getTemporalClient();
+  const dataSourceConfig = dataSourceConfigFromConnector(connector);
+
+  const workflowId = useParallelSync
+    ? googleDriveFullSyncV2WorkflowId(connectorId)
+    : googleDriveFullSyncWorkflowId(connectorId);
+
+  const signalArgs: FolderUpdatesSignal[] = removedFolderIds.map((sId) => ({
+    action: "removed" as const,
+    folderId: sId,
+  }));
+
+  try {
+    // Try to get handle to existing workflow
+    const handle = client.workflow.getHandle(workflowId);
+    const workflowRunning = await isWorkflowRunning(handle);
+
+    if (workflowRunning) {
+      // Workflow is running, send signal to stop tracking these folders
+      await handle.signal(folderUpdatesSignal, signalArgs);
+      localLogger.info(
+        {
+          workspaceId: dataSourceConfig.workspaceId,
+          workflowId,
+          useParallelSync,
+          foldersRemoved: removedFolderIds.length,
+        },
+        `Sent removal signal to running workflow.`
+      );
+      return new Ok(workflowId);
+    } else {
+      // Workflow not running, just launch GC to clean up removed folders
+      localLogger.info(
+        {
+          workspaceId: dataSourceConfig.workspaceId,
+          foldersRemoved: removedFolderIds.length,
+        },
+        `Workflow not running, launching GC for removed folders.`
+      );
+      return await launchGoogleGarbageCollector(connectorId);
+    }
+  } catch (e) {
+    localLogger.error(
+      {
+        workspaceId: dataSourceConfig.workspaceId,
+        workflowId,
+        error: e,
+      },
+      `Failed to signal folder removal.`
     );
     return new Err(normalizeError(e));
   }

--- a/connectors/src/connectors/google_drive/temporal/client.ts
+++ b/connectors/src/connectors/google_drive/temporal/client.ts
@@ -316,7 +316,6 @@ export async function signalFolderRemoval(
   }));
 
   try {
-    // Try to get handle to existing workflow
     const handle = client.workflow.getHandle(workflowId);
     const workflowRunning = await isWorkflowRunning(handle);
 

--- a/connectors/src/connectors/google_drive/temporal/workflows.ts
+++ b/connectors/src/connectors/google_drive/temporal/workflows.ts
@@ -92,9 +92,7 @@ export async function googleDriveFullSync({
 
   // Initialize foldersToBrowse from DB if null, otherwise use provided list
   let foldersQueue: string[] =
-    foldersToBrowse !== null
-      ? foldersToBrowse
-      : await getFoldersToSync(connectorId);
+    foldersToBrowse ?? (await getFoldersToSync(connectorId));
 
   setHandler(folderUpdatesSignal, (folderUpdates: FolderUpdatesSignal[]) => {
     // If we get a signal, update the workflow state by adding/removing folder ids.
@@ -570,6 +568,10 @@ export async function googleDriveFullSyncV2({
 
   // Start progress reporting task (runs in parallel with child workflows)
   const progressReporting = async () => {
+    if (folderIds.length === 0) {
+      return;
+    }
+
     while (!syncCompleted) {
       await sleep("30 seconds");
       if (syncCompleted) break;

--- a/connectors/src/connectors/google_drive/temporal/workflows.ts
+++ b/connectors/src/connectors/google_drive/temporal/workflows.ts
@@ -444,7 +444,7 @@ export async function googleDriveFullSyncV2({
   // Upsert shared with me folder
   await upsertSharedWithMeFolder(connectorId);
 
-  // Track pending folder changes that arrive after sync completes (Sets for O(1) lookup)
+  // Track pending folder changes that arrive after sync completes.
   const addedFoldersForNextRun = new Set<string>();
   const removedFoldersForNextRun = new Set<string>();
   let syncCompleted = false;
@@ -644,7 +644,7 @@ export async function googleDriveFullSyncV2({
     });
   }
 
-  // If folders were added during sync or GC, restart workflow to handle them
+  // If folders were added during GC, restart a new workflow to handle them
   if (addedFoldersForNextRun.size > 0) {
     // Restart workflow to sync newly added folders
     // GC will automatically clean up removed folders based on lastSeenTs

--- a/connectors/src/connectors/google_drive/temporal/workflows.ts
+++ b/connectors/src/connectors/google_drive/temporal/workflows.ts
@@ -673,7 +673,10 @@ export async function googleDriveIncrementalSyncPerDrive({
           newFolders,
           async (folderId) => {
             await startChild(googleDriveFolderSync, {
-              workflowId: googleDriveFolderSyncWorkflowId(connectorId, folderId),
+              workflowId: googleDriveFolderSyncWorkflowId(
+                connectorId,
+                folderId
+              ),
               searchAttributes: { connectorId: [connectorId] },
               args: [
                 {

--- a/connectors/src/connectors/google_drive/temporal/workflows.ts
+++ b/connectors/src/connectors/google_drive/temporal/workflows.ts
@@ -467,29 +467,20 @@ export async function googleDriveFullSyncV2({
     for (const { action, folderId } of folderUpdates) {
       switch (action) {
         case "added": {
-          if (syncCompleted) {
-            if (removedFoldersForNextRun.has(folderId)) {
-              removedFoldersForNextRun.delete(folderId);
-            } else {
-              addedFoldersForNextRun.add(folderId);
-            }
+          if (syncCompleted && removedFoldersForNextRun.has(folderId)) {
+            removedFoldersForNextRun.delete(folderId);
           } else {
-            // During sync, new folders go directly to next run
             addedFoldersForNextRun.add(folderId);
           }
           break;
         }
         case "removed": {
-          if (syncCompleted) {
-            if (addedFoldersForNextRun.has(folderId)) {
-              addedFoldersForNextRun.delete(folderId);
-            } else {
-              removedFoldersForNextRun.add(folderId);
-            }
+          if (syncCompleted && addedFoldersForNextRun.has(folderId)) {
+            addedFoldersForNextRun.delete(folderId);
+          } else if (syncCompleted) {
+            removedFoldersForNextRun.add(folderId);
           } else {
-            // Mark as removed - prevents starting new workflows
             removedFolderIds.add(folderId);
-            // Cancel running workflow if present
             const folderWorkflow = runningFolderWorkflows[folderId];
             if (folderWorkflow) {
               void cancelChildWorkflow(folderWorkflow.workflowId);

--- a/connectors/src/connectors/google_drive/temporal/workflows.ts
+++ b/connectors/src/connectors/google_drive/temporal/workflows.ts
@@ -103,9 +103,13 @@ export async function googleDriveFullSync({
             foldersQueue.push(folderId);
           }
           break;
-        case "removed":
-          foldersQueue.splice(foldersQueue.indexOf(folderId), 1);
+        case "removed": {
+          const index = foldersQueue.indexOf(folderId);
+          if (index !== -1) {
+            foldersQueue.splice(index, 1);
+          }
           break;
+        }
         default:
           assertNever(
             `Unexpected signal action ${action} received for Google Drive full sync workflow.`,

--- a/connectors/src/connectors/google_drive/temporal/workflows.ts
+++ b/connectors/src/connectors/google_drive/temporal/workflows.ts
@@ -538,7 +538,6 @@ export async function googleDriveFullSyncV2({
 
       const handle = await startChild(googleDriveFolderSync, {
         workflowId: childWorkflowId,
-        workflowIdReusePolicy: "TERMINATE_IF_RUNNING",
         searchAttributes: { connectorId: [connectorId] },
         args: [
           {

--- a/connectors/src/connectors/google_drive/temporal/workflows.ts
+++ b/connectors/src/connectors/google_drive/temporal/workflows.ts
@@ -489,9 +489,7 @@ export async function googleDriveFullSyncV2({
             // Cancel running workflow if present
             const folderWorkflow = runningFolderWorkflows[folderId];
             if (folderWorkflow) {
-              cancelChildWorkflow(folderWorkflow.workflowId).catch(() => {
-                // Workflow may have already completed, ignore
-              });
+              void cancelChildWorkflow(folderWorkflow.workflowId);
               delete runningFolderWorkflows[folderId];
             }
           }
@@ -569,7 +567,7 @@ export async function googleDriveFullSyncV2({
 
       // Check again in case a removal signal arrived while starting
       if (removedFolderIds.has(folderId)) {
-        cancelChildWorkflow(childWorkflowId).catch(() => {});
+        void cancelChildWorkflow(childWorkflowId);
         delete runningFolderWorkflows[folderId];
         return;
       }


### PR DESCRIPTION
## Description

The full sync workflow creates a child workflow for every root folder added. We limit the concurrency to 5 parallel workflow, and handle added/removed folders with signals, enqueing new workflow or cancelling the one that are running (when removing a folder that was just added). Once all workflows are done we continue with the GC - all new signals are then enqueued for a "continueAsNew" workflow. This is to avoid running GC in parallel with sync, as GC relies on lastSeen value, set by the sync.
Progress is updated in parallel through a dedicated activity.

## Tests

Tested locally :

- setup new config : check sync
- add/remove folder/drives multiple times (same or different folders) while initial sync is running
- switch from v1 to v2 and the opposite - current sync if it exists continues, but next sync will use the other version

## Risk

gated

## Deploy Plan

deploy connectors