### PR TITLE
[front] fix(skills): allow spaces in skill name

### DIFF
--- a/front/components/skill_builder/SkillBuilderFormContext.tsx
+++ b/front/components/skill_builder/SkillBuilderFormContext.tsx
@@ -13,7 +13,10 @@ export const attachedKnowledgeSchema = z.object({
 });
 
 export const skillBuilderFormSchema = z.object({
-  name: z.string().min(1, "Skill name is required"),
+  name: z
+    .string()
+    .transform((v) => v.trim())
+    .pipe(z.string().min(1, "Skill name is required")),
   agentFacingDescription: z
     .string()
     .min(1, "Description of when to use the skill is required"),

--- a/front/components/skill_builder/SkillBuilderFormContext.tsx
+++ b/front/components/skill_builder/SkillBuilderFormContext.tsx
@@ -13,10 +13,7 @@ export const attachedKnowledgeSchema = z.object({
 });
 
 export const skillBuilderFormSchema = z.object({
-  name: z
-    .string()
-    .min(1, "Skill name is required")
-    .refine((value) => !/\s/.test(value), "Skill name cannot contain spaces"),
+  name: z.string().min(1, "Skill name is required"),
   agentFacingDescription: z
     .string()
     .min(1, "Description of when to use the skill is required"),

--- a/front/pages/api/w/[wId]/skills/[sId]/index.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.ts
@@ -164,6 +164,17 @@ async function handler(
       }
 
       const body: PatchSkillRequestBody = bodyValidation.right;
+      const name = body.name.trim();
+
+      if (!name) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Skill name cannot be empty.",
+          },
+        });
+      }
 
       // Check if user can write.
       if (!skillResource.canWrite(auth)) {
@@ -177,17 +188,14 @@ async function handler(
       }
 
       // Check for existing active skill with the same name (excluding current skill).
-      const existingSkill = await SkillResource.fetchActiveByName(
-        auth,
-        body.name
-      );
+      const existingSkill = await SkillResource.fetchActiveByName(auth, name);
 
       if (existingSkill && existingSkill.id !== skillResource.id) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: `A skill with the name "${body.name}" already exists.`,
+            message: `A skill with the name "${name}" already exists.`,
           },
         });
       }
@@ -265,7 +273,7 @@ async function handler(
         icon: body.icon,
         instructions: body.instructions,
         mcpServerViews,
-        name: body.name,
+        name,
         requestedSpaceIds,
         userFacingDescription: body.userFacingDescription,
       });

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -171,18 +171,26 @@ async function handler(
       }
 
       const body: PostSkillRequestBody = bodyValidation.right;
+      const name = body.name.trim();
 
-      const existingSkill = await SkillResource.fetchActiveByName(
-        auth,
-        body.name
-      );
+      if (!name) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Skill name cannot be empty.",
+          },
+        });
+      }
+
+      const existingSkill = await SkillResource.fetchActiveByName(auth, name);
 
       if (existingSkill) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: `A skill with the name "${body.name}" already exists.`,
+            message: `A skill with the name "${name}" already exists.`,
           },
         });
       }
@@ -263,7 +271,7 @@ async function handler(
         auth,
         {
           status: "active",
-          name: body.name,
+          name,
           agentFacingDescription: body.agentFacingDescription,
           userFacingDescription: body.userFacingDescription,
           instructions: body.instructions,


### PR DESCRIPTION
## Description

- This PR allows whitespace characters in skill names.
- This condition comes from a copy from agent builder, where it makes sense because does not interact well with tagging them.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
