### PR TITLE
[Front] refactor(skills): sync local space selection with form state

### DIFF
--- a/front/components/agent_builder/AgentBuilderSpacesBlock.tsx
+++ b/front/components/agent_builder/AgentBuilderSpacesBlock.tsx
@@ -178,8 +178,8 @@ export function AgentBuilderSpacesBlock() {
           <SheetContainer>
             <SpaceSelectionPageContent
               alreadyRequestedSpaceIds={actionsAndSkillsRequestedSpaceIds}
-              draftSelectedSpaces={draftSelectedSpaces}
-              setDraftSelectedSpaces={setDraftSelectedSpaces}
+              selectedSpaces={draftSelectedSpaces}
+              setSelectedSpaces={setDraftSelectedSpaces}
             />
           </SheetContainer>
           <SheetFooter

--- a/front/components/agent_builder/capabilities/capabilities_sheet/SpaceSelectionPage.tsx
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/SpaceSelectionPage.tsx
@@ -18,14 +18,14 @@ type SpaceRowData = {
 
 interface SpaceSelectionPageProps {
   alreadyRequestedSpaceIds: Set<string>;
-  draftSelectedSpaces: string[];
-  setDraftSelectedSpaces: React.Dispatch<React.SetStateAction<string[]>>;
+  selectedSpaces: string[];
+  setSelectedSpaces: React.Dispatch<React.SetStateAction<string[]>>;
 }
 
 export function SpaceSelectionPageContent({
   alreadyRequestedSpaceIds,
-  draftSelectedSpaces,
-  setDraftSelectedSpaces,
+  selectedSpaces,
+  setSelectedSpaces,
 }: SpaceSelectionPageProps) {
   const { spaces } = useSpacesContext();
 
@@ -33,21 +33,21 @@ export function SpaceSelectionPageContent({
     return spaces.filter((s) => s.kind !== "global");
   }, [spaces]);
 
-  const localSelectedSpaceIds = useMemo(
-    () => new Set(draftSelectedSpaces),
-    [draftSelectedSpaces]
+  const selectedSpaceIds = useMemo(
+    () => new Set(selectedSpaces),
+    [selectedSpaces]
   );
 
   const handleSpaceToggle = useCallback(
     (space: SpaceType) => {
-      setDraftSelectedSpaces((prev) => {
+      setSelectedSpaces((prev) => {
         const newSpaces = prev.includes(space.sId)
           ? prev.filter((id) => id !== space.sId)
           : [...prev, space.sId];
         return newSpaces;
       });
     },
-    [setDraftSelectedSpaces]
+    [setSelectedSpaces]
   );
 
   const tableData: SpaceRowData[] = useMemo(() => {
@@ -57,7 +57,7 @@ export function SpaceSelectionPageContent({
         sId: space.sId,
         name: getSpaceName(space),
         space,
-        isSelected: localSelectedSpaceIds.has(space.sId) || isAlreadyRequested,
+        isSelected: selectedSpaceIds.has(space.sId) || isAlreadyRequested,
         isAlreadyRequested,
         onToggle: () => handleSpaceToggle(space),
       };
@@ -65,7 +65,7 @@ export function SpaceSelectionPageContent({
   }, [
     selectableSpaces,
     alreadyRequestedSpaceIds,
-    localSelectedSpaceIds,
+    selectedSpaceIds,
     handleSpaceToggle,
   ]);
 

--- a/front/components/agent_builder/capabilities/capabilities_sheet/types.ts
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/types.ts
@@ -37,7 +37,6 @@ export type CapabilitiesSheetContentProps = {
     tools: SelectedTool[];
   }) => void;
   onToolEditSave: (updatedAction: BuilderAction) => void;
-  initialAdditionalSpaces: string[];
   alreadyRequestedSpaceIds: Set<string>;
   alreadyAddedSkillIds: Set<string>;
   selectedActions: BuilderAction[];

--- a/front/components/agent_builder/skills/AgentBuilderSkillsBlock.tsx
+++ b/front/components/agent_builder/skills/AgentBuilderSkillsBlock.tsx
@@ -340,7 +340,6 @@ export function AgentBuilderSkillsBlock() {
         onCapabilitiesSave={handleCapabilitiesSave}
         onToolEditSave={handleToolEditSave}
         onStateChange={setSheetState}
-        initialAdditionalSpaces={additionalSpacesField.value}
         alreadyRequestedSpaceIds={alreadyRequestedSpaceIds}
         alreadyAddedSkillIds={alreadyAddedSkillIds}
         selectedActions={actionFields}


### PR DESCRIPTION
Fixes https://github.com/dust-tt/tasks/issues/5861
## Description

Fix space selection state in capabilities sheet to stay in sync with form state :
Previously, `initialAdditionalSpaces` was passed as prop and only read once, causing stale state when form changed

- New `useSkillSpaceSelection` hook uses `useWatch` to sync local state with form's `additionalSpaces`
- Removed unnecessary `draftSelectedSpaces` state
- Rename props from `draftSelectedSpaces` to `selectedSpaces` for clarity

## Tests

Manual - verified space selection reflects form state after opening/closing sheet

## Risk

Low.

## Deploy Plan

Deploy front.
