### PR TITLE
Add triggered conversations filter

### DIFF
--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -298,6 +298,11 @@ export function AgentSidebarMenu({ owner }: AgentSidebarMenuProps) {
     }
   }, [setSidebarOpen, router, setAnimate]);
 
+  const hasTriggeredConversations = useMemo(
+    () => conversations.some((c) => c.triggerId !== null),
+    [conversations]
+  );
+
   const filteredConversations = useMemo(() => {
     return filterTriggeredConversations(
       conversations,
@@ -540,7 +545,9 @@ export function AgentSidebarMenu({ owner }: AgentSidebarMenuProps) {
                           label="Hide triggered conversations"
                           checked={hideTriggeredConversations}
                           onCheckedChange={setHideTriggeredConversations}
-                          disabled={isHideTriggeredLoading}
+                          disabled={
+                            isHideTriggeredLoading || !hasTriggeredConversations
+                          }
                         />
                       </DropdownMenuContent>
                     </DropdownMenu>

--- a/front/components/assistant/conversation/utils.ts
+++ b/front/components/assistant/conversation/utils.ts
@@ -103,3 +103,13 @@ export function getGroupConversationsByDate({
 
   return groups;
 }
+
+export function filterTriggeredConversations(
+  conversations: ConversationWithoutContentType[],
+  hideTriggered: boolean
+): ConversationWithoutContentType[] {
+  if (!hideTriggered) {
+    return conversations;
+  }
+  return conversations.filter((c) => c.triggerId === null);
+}

--- a/front/hooks/useHideTriggeredConversations.ts
+++ b/front/hooks/useHideTriggeredConversations.ts
@@ -1,0 +1,31 @@
+import { useCallback } from "react";
+
+import { useUserMetadata } from "@app/lib/swr/user";
+import { setUserMetadataFromClient } from "@app/lib/user";
+
+const HIDE_TRIGGERED_CONVERSATIONS_KEY = "hideTriggeredConversations";
+
+export const useHideTriggeredConversations = () => {
+  const { metadata, isMetadataLoading, isMetadataError, mutateMetadata } =
+    useUserMetadata(HIDE_TRIGGERED_CONVERSATIONS_KEY);
+
+  const hideTriggeredConversations = metadata?.value === "true";
+
+  const setHideTriggeredConversations = useCallback(
+    async (hide: boolean) => {
+      await setUserMetadataFromClient({
+        key: HIDE_TRIGGERED_CONVERSATIONS_KEY,
+        value: hide ? "true" : "false",
+      });
+      void mutateMetadata();
+    },
+    [mutateMetadata]
+  );
+
+  return {
+    hideTriggeredConversations,
+    setHideTriggeredConversations,
+    isLoading: isMetadataLoading,
+    isError: isMetadataError,
+  };
+};

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -1566,6 +1566,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       created: this.createdAt.getTime(),
       updated: this.updatedAt.getTime(),
       spaceId: this.space?.sId ?? null,
+      triggerId: this.triggerSId,
       hasError: this.hasError,
       id: this.id,
       // TODO(REQUESTED_SPACE_IDS 2025-10-24): Stop exposing this once all logic is centralized

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -282,6 +282,7 @@ export type ConversationWithoutContentType = {
   sId: string;
   title: string | null;
   spaceId: string | null;
+  triggerId: string | null;
   depth: number;
 
   // Ideally, this property should be moved to the ConversationType.
@@ -293,7 +294,6 @@ export type ConversationWithoutContentType = {
  * messages).
  */
 export type ConversationType = ConversationWithoutContentType & {
-  triggerId: string | null;
   owner: WorkspaceType;
   visibility: ConversationVisibility;
   content: (UserMessageType[] | AgentMessageType[] | ContentFragmentType[])[];


### PR DESCRIPTION
## Description

Using agents with triggers can create a lot of noise in the conversation list, since every trigger will create a new conversation.

In this MR, we make it possible to hide triggered conversations from the conversation list. The preference is at the user level (same value across workspaces) and persisted in the user metadata, using the same pattern as in `hooks/usePersistedNavigationSelection.ts`.

## Tests

Locally

## Risk

Low. The filter is only available for users with the "projects" feature flag on.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
