### PR TITLE
registry: get rid of getDustProdAction

### DIFF
--- a/front/lib/poke/conversation.ts
+++ b/front/lib/poke/conversation.ts
@@ -2,7 +2,6 @@ import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { isLLMTraceId } from "@app/lib/api/llm/traces/buffer";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentMessageModel } from "@app/lib/models/agent/conversation";
-import { getDustProdAction } from "@app/lib/registry";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import type {
   ConversationError,
@@ -29,9 +28,6 @@ export async function getPokeConversation(
   // and I still wanted to use the existing getConversation code for rendering.
   if (conversation.isOk()) {
     const pokeConversation = conversation.value as PokeConversationType;
-    const multiActionsApp = getDustProdAction(
-      "assistant-v2-multi-actions-agent"
-    );
 
     // Cycle through the message and actions and enrich them with the runId(s) and timestamps
     for (const messages of pokeConversation.content) {
@@ -54,10 +50,7 @@ export async function getPokeConversation(
           if (runIds) {
             m.runUrls = runIds.map((runId) => {
               const isLLM = isLLMTraceId(runId);
-              const url = isLLM
-                ? `/poke/${owner.sId}/llm-traces/${runId}`
-                : `/w/${multiActionsApp.app.workspaceId}/spaces/${multiActionsApp.app.appSpaceId}/apps/${multiActionsApp.app.appId}/runs/${runId}`;
-
+              const url = `/poke/${owner.sId}/llm-traces/${runId}`;
               return { runId, url, isLLM };
             });
           }

--- a/front/pages/poke/[wId]/conversation/[cId]/index.tsx
+++ b/front/pages/poke/[wId]/conversation/[cId]/index.tsx
@@ -26,8 +26,6 @@ import { useEffect, useState } from "react";
 import PokeLayout from "@app/components/poke/PokeLayout";
 import { clientFetch } from "@app/lib/egress/client";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
-import type { Action } from "@app/lib/registry";
-import { getDustProdAction } from "@app/lib/registry";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { classNames } from "@app/lib/utils";
@@ -48,7 +46,6 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
   workspaceId: string;
   conversationId: string;
   conversationDataSourceId: string | null;
-  multiActionsApp: Action;
   temporalWorkspace: string;
 }>(async (context, auth) => {
   const cId = context.params?.cId;
@@ -80,14 +77,11 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
     cRes.value
   );
 
-  const multiActionsApp = getDustProdAction("assistant-v2-multi-actions-agent");
-
   return {
     props: {
       workspaceId: wId,
       conversationId: cId,
       conversationDataSourceId: conversationDataSource?.sId ?? null,
-      multiActionsApp,
       workspace: auth.getNonNullableWorkspace(),
       temporalWorkspace: TEMPORAL_AGENT_NAMESPACE,
     },
@@ -124,7 +118,6 @@ const UserMessageView = ({ message, useMarkdown }: UserMessageViewProps) => {
 
 interface AgentMessageViewProps {
   message: PokeAgentMessageType;
-  multiActionsApp: Action;
   useMarkdown: boolean;
   workspaceId: string;
 }
@@ -318,7 +311,6 @@ const ConversationPage = ({
   workspace,
   conversationId,
   conversationDataSourceId,
-  multiActionsApp,
   temporalWorkspace,
 }: ConversationPageProps) => {
   const { conversation } = usePokeConversation({ workspaceId, conversationId });
@@ -564,7 +556,6 @@ const ConversationPage = ({
                         return (
                           <AgentMessageView
                             key={`message-${i}-${j}`}
-                            multiActionsApp={multiActionsApp}
                             message={m}
                             useMarkdown={useMarkdown}
                             workspaceId={workspaceId}


### PR DESCRIPTION
## Description

Was dead code mostly. Removed the ability to link from poke conversation view to dust-apps logs (old convo only).

## Tests

N/A, covered by typechecker

## Risk

Low, poke

## Deploy Plan

- deploy `front`