### PR TITLE
[front] - refactor: reorganize skill settings layout

### DIFF
--- a/front/components/skill_builder/SkillBuilderNameSection.tsx
+++ b/front/components/skill_builder/SkillBuilderNameSection.tsx
@@ -1,7 +1,6 @@
 import { Input } from "@dust-tt/sparkle";
 
 import { BaseFormFieldSection } from "@app/components/shared/BaseFormFieldSection";
-import { SkillBuilderIconSection } from "@app/components/skill_builder/SkillBuilderIconSection";
 
 const NAME_FIELD_NAME = "name";
 
@@ -13,20 +12,15 @@ export function SkillBuilderNameSection() {
       triggerValidationOnChange={false}
     >
       {({ registerRef, registerProps, onChange, errorMessage, hasError }) => (
-        <div className="flex space-x-2">
-          <div className="flex-grow">
-            <Input
-              ref={registerRef}
-              placeholder="Enter skill name"
-              onChange={onChange}
-              message={errorMessage}
-              messageStatus={hasError ? "error" : "default"}
-              {...registerProps}
-            />
-          </div>
-          <div className="flex flex-col gap-2">
-            <SkillBuilderIconSection />
-          </div>
+        <div className="relative">
+          <Input
+            ref={registerRef}
+            placeholder="Enter skill name"
+            onChange={onChange}
+            message={errorMessage}
+            messageStatus={hasError ? "error" : "default"}
+            {...registerProps}
+          />
         </div>
       )}
     </BaseFormFieldSection>

--- a/front/components/skill_builder/SkillBuilderNameSection.tsx
+++ b/front/components/skill_builder/SkillBuilderNameSection.tsx
@@ -12,16 +12,14 @@ export function SkillBuilderNameSection() {
       triggerValidationOnChange={false}
     >
       {({ registerRef, registerProps, onChange, errorMessage, hasError }) => (
-        <div className="relative">
-          <Input
-            ref={registerRef}
-            placeholder="Enter skill name"
-            onChange={onChange}
-            message={errorMessage}
-            messageStatus={hasError ? "error" : "default"}
-            {...registerProps}
-          />
-        </div>
+        <Input
+          ref={registerRef}
+          placeholder="Enter skill name"
+          onChange={onChange}
+          message={errorMessage}
+          messageStatus={hasError ? "error" : "default"}
+          {...registerProps}
+        />
       )}
     </BaseFormFieldSection>
   );

--- a/front/components/skill_builder/SkillBuilderSettingsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderSettingsSection.tsx
@@ -1,5 +1,6 @@
 import { Label } from "@dust-tt/sparkle";
 
+import { SkillBuilderIconSection } from "@app/components/skill_builder/SkillBuilderIconSection";
 import { SkillBuilderNameSection } from "@app/components/skill_builder/SkillBuilderNameSection";
 import { SkillBuilderUserFacingDescriptionSection } from "@app/components/skill_builder/SkillBuilderUserFacingDescriptionSection";
 import { SkillEditorsSheet } from "@app/components/skill_builder/SkillEditorsSheet";
@@ -10,7 +11,12 @@ export function SkillBuilderSettingsSection() {
       <h2 className="heading-lg text-foreground dark:text-foreground-night">
         Skill settings
       </h2>
-      <SkillBuilderNameSection />
+      <div className="flex items-end gap-8">
+        <div className="flex-grow">
+          <SkillBuilderNameSection />
+        </div>
+        <SkillBuilderIconSection />
+      </div>
       <SkillBuilderUserFacingDescriptionSection />
       <div className="flex flex-col space-y-3">
         <Label className="text-sm font-semibold text-foreground dark:text-foreground-night">


### PR DESCRIPTION
## Description
Reorganizes the Skill Builder settings layout by moving `SkillBuilderIconSection` from within `SkillBuilderNameSection` to `SkillBuilderSettingsSection`, positioning it alongside the name input. This improves visual alignment and matches the pattern used in the Agent builder where the avatar picker is positioned next to the name input.

**References:**
- Fixes https://github.com/dust-tt/tasks/issues/5840

## Risk
No risk - purely visual/layout change with no functional modifications.

## Tests

Locally

## Deploy

Deploy front
