### PR TITLE
[front] enh(skills): show search results immediately in Knowledge Dropdown

### DIFF
--- a/front/components/editor/extensions/skill_builder/KnowledgeNodeView.tsx
+++ b/front/components/editor/extensions/skill_builder/KnowledgeNodeView.tsx
@@ -175,14 +175,11 @@ function KnowledgeSearchComponent({
 
   const spaceIds = useMemo(() => spaces.map((s) => s.sId), [spaces]);
 
-  const isDisabled = !searchQuery || searchQuery.length < 2;
-
   const { knowledgeResults: searchResults, isSearchLoading } = useUnifiedSearch(
     {
       owner,
       query: searchQuery,
       pageSize: 10,
-      disabled: isDisabled,
       spaceIds,
       // Tables can't be attached to a skill.
       viewType: "document",
@@ -281,7 +278,9 @@ function KnowledgeSearchComponent({
   const handleInput = useCallback((e: React.FormEvent<HTMLSpanElement>) => {
     const text = e.currentTarget.textContent ?? "";
     setSearchQuery(text);
-    setIsOpen(text.trim().length > 0);
+    if (text.trim().length > 0) {
+      setIsOpen(true);
+    }
   }, []);
 
   // Auto-focus when component mounts.
@@ -308,6 +307,9 @@ function KnowledgeSearchComponent({
   // Reset selected index when items change.
   useEffect(() => {
     setSelectedIndex(0);
+    if (knowledgeItems.length > 0) {
+      setIsOpen(true);
+    }
   }, [knowledgeItems.length]);
 
   // Delete empty node helper.

--- a/front/components/editor/extensions/skill_builder/KnowledgeNodeView.tsx
+++ b/front/components/editor/extensions/skill_builder/KnowledgeNodeView.tsx
@@ -357,10 +357,6 @@ function KnowledgeSearchComponent({
     [isOpen, selectedIndex, knowledgeItems.length, handleItemSelect, onCancel]
   );
 
-  const handleBlur = useCallback(() => {
-    deleteIfEmpty(50);
-  }, [deleteIfEmpty]);
-
   const handleInteractOutside = useCallback(() => {
     setIsOpen(false);
     deleteIfEmpty(50);
@@ -381,7 +377,6 @@ function KnowledgeSearchComponent({
         ref={contentRef}
         onKeyDown={handleKeyDown}
         onInput={handleInput}
-        onBlur={handleBlur}
         data-placeholder="Search for knowledge..."
       />
 

--- a/front/lib/swr/search.ts
+++ b/front/lib/swr/search.ts
@@ -63,7 +63,7 @@ export function useUnifiedSearch({
 
   const loadPage = useCallback(
     (cursor?: string | null, appendResults = false) => {
-      if (disabled || !query || query.length < 3) {
+      if (disabled) {
         setIsSearchLoading(false);
         setIsLoadingNextPage(false);
         return;


### PR DESCRIPTION
## Description

- This PR updates the behavior of the Knowledge Dropdown in the instructions of the Skill Builder to immediately show results upon opening, even without a query.
- There's a known limitation on the fact that typing a first character yields empty results, will improve in a follow up PR.

https://github.com/user-attachments/assets/95d759a8-d004-4609-bd20-972c22239fe6

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
