### PR TITLE
[Front] refactor(skills): move makeNewSkillEditorsGroup to SkillResource

### DIFF
--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -309,12 +309,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     const user = auth.getNonNullableUser();
     const workspace = auth.getNonNullableWorkspace();
 
-    if (skill.workspaceId !== workspace.id) {
-      throw new DustError(
-        "internal_error",
-        "Unexpected: skill and workspace mismatch"
-      );
-    }
+    assert(skill.workspaceId !== workspace.id, "Unexpected: skill and workspace mismatch");
 
     const defaultGroup = await GroupResource.makeNew(
       {

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -309,7 +309,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     const workspace = auth.getNonNullableWorkspace();
 
     assert(
-      skill.workspaceId !== workspace.id,
+      skill.workspaceId === workspace.id,
       "Unexpected: skill and workspace mismatch"
     );
 

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -19,7 +19,6 @@ import {
 import { getAgentConfigurationRequirementsFromCapabilities } from "@app/lib/api/assistant/permissions";
 import { hasSharedMembership } from "@app/lib/api/user";
 import type { Authenticator } from "@app/lib/auth";
-import { DustError } from "@app/lib/error";
 import { hasAll } from "@app/lib/matcher/operators/array";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { AgentSkillModel } from "@app/lib/models/agent/agent_skill";
@@ -309,7 +308,10 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     const user = auth.getNonNullableUser();
     const workspace = auth.getNonNullableWorkspace();
 
-    assert(skill.workspaceId !== workspace.id, "Unexpected: skill and workspace mismatch");
+    assert(
+      skill.workspaceId !== workspace.id,
+      "Unexpected: skill and workspace mismatch"
+    );
 
     const defaultGroup = await GroupResource.makeNew(
       {


### PR DESCRIPTION
Cleaning TODOs: https://github.com/dust-tt/tasks/issues/5767

## Description

- Move `makeNewSkillEditorsGroup` from `GroupResource` to `SkillResource` (resolves TODO)
- Method now private in `SkillResource` since only called from `makeNew`

## Tests

## Risk


## Deploy Plan

Deploy front.
