### PR TITLE
feat(mcp): add medium stake level to type system

### DIFF
--- a/front/components/actions/mcp/ToolsList.tsx
+++ b/front/components/actions/mcp/ToolsList.tsx
@@ -74,8 +74,9 @@ const ToolItem = memo(
     };
 
     const toolPermissionLabel: Record<MCPToolStakeLevelType, string> = {
-      high: "High (update data or send information)",
-      low: "Low (retrieve data or generate content)",
+      high: "High (always ask for confirmation)",
+      medium: "Medium (per-agent per-argument confirmation saves)",
+      low: "Low (per-tool confirmation saves)",
       never_ask: "Never ask (automatic execution)",
     };
 
@@ -114,14 +115,16 @@ const ToolItem = memo(
                   />
                 </DropdownMenuTrigger>
                 <DropdownMenuContent>
-                  {availableStakeLevels.map((permission) => (
-                    <DropdownMenuItem
-                      key={permission}
-                      onClick={() => handlePermissionChange(permission)}
-                      label={toolPermissionLabel[permission]}
-                      disabled={!toolEnabled}
-                    />
-                  ))}
+                  {availableStakeLevels
+                    .filter((v) => v !== "medium")
+                    .map((permission) => (
+                      <DropdownMenuItem
+                        key={permission}
+                        onClick={() => handlePermissionChange(permission)}
+                        label={toolPermissionLabel[permission]}
+                        disabled={!toolEnabled}
+                      />
+                    ))}
                 </DropdownMenuContent>
               </DropdownMenu>
             </div>

--- a/front/lib/actions/constants.ts
+++ b/front/lib/actions/constants.ts
@@ -49,7 +49,12 @@ export const DEFAULT_MCP_ACTION_VERSION = "1.0.0";
 export const DEFAULT_MCP_ACTION_DESCRIPTION =
   "Call a tool to answer a question.";
 
-export const MCP_TOOL_STAKE_LEVELS = ["high", "low", "never_ask"] as const;
+export const MCP_TOOL_STAKE_LEVELS = [
+  "high",
+  "medium",
+  "low",
+  "never_ask",
+] as const;
 export type MCPToolStakeLevelType = (typeof MCP_TOOL_STAKE_LEVELS)[number];
 
 export const FALLBACK_INTERNAL_AUTO_SERVERS_TOOL_STAKE_LEVEL =

--- a/front/lib/actions/mcp_actions.test.ts
+++ b/front/lib/actions/mcp_actions.test.ts
@@ -1,5 +1,6 @@
 import { assert, describe, expect, it } from "vitest";
 
+import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import type { ServerSideMCPServerConfigurationType } from "@app/lib/actions/mcp";
 import {
   getPrefixedToolName,
@@ -262,7 +263,7 @@ describe("makeToolsWithStakesAndTimeout", () => {
   it("should process internal MCP server with google_calendar", () => {
     const metadata: {
       toolName: string;
-      permission: "high" | "low" | "never_ask";
+      permission: MCPToolStakeLevelType;
       enabled: boolean;
     }[] = [
       {
@@ -300,7 +301,7 @@ describe("makeToolsWithStakesAndTimeout", () => {
   it("should process remote MCP server", () => {
     const metadata: {
       toolName: string;
-      permission: "high" | "low" | "never_ask";
+      permission: MCPToolStakeLevelType;
       enabled: boolean;
     }[] = [
       {

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -129,7 +129,7 @@ export function getToolExtraFields(
   mcpServerId: string,
   metadata: {
     toolName: string;
-    permission: "high" | "low" | "never_ask";
+    permission: MCPToolStakeLevelType;
     enabled: boolean;
   }[]
 ) {

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -183,6 +183,7 @@ export const INTERNAL_MCP_SERVERS = {
       search_advanced: "never_ask",
       get_issue: "never_ask",
     },
+    tools_approval_holding_arguments: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
@@ -205,6 +206,7 @@ export const INTERNAL_MCP_SERVERS = {
     isRestricted: undefined,
     isPreview: false,
     tools_stakes: undefined,
+    tools_approval_holding_arguments: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
@@ -225,6 +227,7 @@ export const INTERNAL_MCP_SERVERS = {
     isRestricted: undefined,
     isPreview: false,
     tools_stakes: undefined,
+    tools_approval_holding_arguments: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
@@ -244,6 +247,7 @@ export const INTERNAL_MCP_SERVERS = {
     isRestricted: undefined,
     isPreview: false,
     tools_stakes: undefined,
+    tools_approval_holding_arguments: undefined,
     tools_retry_policies: { default: "retry_on_interrupt" },
     timeoutMs: undefined,
     serverInfo: {
@@ -302,6 +306,7 @@ export const INTERNAL_MCP_SERVERS = {
       update_deal: "high",
       remove_association: "high",
     },
+    tools_approval_holding_arguments: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
@@ -324,6 +329,7 @@ export const INTERNAL_MCP_SERVERS = {
     isRestricted: undefined,
     isPreview: false,
     tools_stakes: undefined,
+    tools_approval_holding_arguments: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
@@ -343,6 +349,7 @@ export const INTERNAL_MCP_SERVERS = {
     isRestricted: undefined,
     isPreview: false,
     tools_stakes: undefined,
+    tools_approval_holding_arguments: undefined,
     tools_retry_policies: { default: "retry_on_interrupt" },
     timeoutMs: undefined,
     serverInfo: {
@@ -365,6 +372,7 @@ export const INTERNAL_MCP_SERVERS = {
     },
     isPreview: false,
     tools_stakes: undefined,
+    tools_approval_holding_arguments: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
@@ -406,6 +414,7 @@ export const INTERNAL_MCP_SERVERS = {
       update_row_database: "low",
       update_schema_database: "low",
     },
+    tools_approval_holding_arguments: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
@@ -428,6 +437,7 @@ export const INTERNAL_MCP_SERVERS = {
     isRestricted: undefined,
     isPreview: false,
     tools_stakes: undefined,
+    tools_approval_holding_arguments: undefined,
     tools_retry_policies: { default: "retry_on_interrupt" },
     timeoutMs: undefined,
     serverInfo: {
@@ -447,6 +457,7 @@ export const INTERNAL_MCP_SERVERS = {
     isRestricted: undefined,
     isPreview: false,
     tools_stakes: undefined,
+    tools_approval_holding_arguments: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
@@ -478,6 +489,7 @@ export const INTERNAL_MCP_SERVERS = {
       read_attachment: "never_ask",
       update_object: "high",
     },
+    tools_approval_holding_arguments: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
@@ -505,6 +517,7 @@ export const INTERNAL_MCP_SERVERS = {
       get_messages: "never_ask",
       create_reply_draft: "low",
     },
+    tools_approval_holding_arguments: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
@@ -538,6 +551,7 @@ export const INTERNAL_MCP_SERVERS = {
       check_availability: "never_ask",
       get_user_timezones: "never_ask",
     },
+    tools_approval_holding_arguments: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
@@ -563,6 +577,7 @@ export const INTERNAL_MCP_SERVERS = {
     isRestricted: undefined,
     isPreview: false,
     tools_stakes: undefined,
+    tools_approval_holding_arguments: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
@@ -600,6 +615,7 @@ export const INTERNAL_MCP_SERVERS = {
       add_reaction: "low",
       remove_reaction: "low",
     },
+    tools_approval_holding_arguments: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
@@ -642,6 +658,7 @@ export const INTERNAL_MCP_SERVERS = {
       rename_worksheet: "low",
       move_worksheet: "low",
     },
+    tools_approval_holding_arguments: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
@@ -697,6 +714,7 @@ export const INTERNAL_MCP_SERVERS = {
       delete_item: "high",
       delete_group: "high",
     },
+    tools_approval_holding_arguments: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
@@ -720,6 +738,7 @@ export const INTERNAL_MCP_SERVERS = {
     isRestricted: undefined,
     isPreview: false,
     tools_stakes: undefined,
+    tools_approval_holding_arguments: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
@@ -765,6 +784,7 @@ export const INTERNAL_MCP_SERVERS = {
       delete_issue_link: "low",
       upload_attachment: "low",
     },
+    tools_approval_holding_arguments: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
@@ -787,6 +807,7 @@ export const INTERNAL_MCP_SERVERS = {
     isRestricted: undefined,
     isPreview: false,
     tools_stakes: undefined,
+    tools_approval_holding_arguments: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
@@ -816,6 +837,7 @@ export const INTERNAL_MCP_SERVERS = {
       create_contact: "high",
       update_contact: "high",
     },
+    tools_approval_holding_arguments: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
@@ -850,6 +872,7 @@ export const INTERNAL_MCP_SERVERS = {
       check_availability: "never_ask",
       check_self_availability: "never_ask",
     },
+    tools_approval_holding_arguments: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
@@ -914,6 +937,7 @@ export const INTERNAL_MCP_SERVERS = {
       request_service_approval: "low",
       create_solution_article: "high",
     },
+    tools_approval_holding_arguments: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
@@ -942,6 +966,7 @@ export const INTERNAL_MCP_SERVERS = {
       get_spreadsheet: "never_ask",
       get_worksheet: "never_ask",
     },
+    tools_approval_holding_arguments: undefined,
     tools_retry_policies: { default: "retry_on_interrupt" },
     timeoutMs: undefined,
     serverInfo: {
@@ -967,6 +992,7 @@ export const INTERNAL_MCP_SERVERS = {
     },
     isPreview: true,
     tools_stakes: undefined,
+    tools_approval_holding_arguments: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
@@ -986,6 +1012,7 @@ export const INTERNAL_MCP_SERVERS = {
     allowMultipleInstances: false,
     isPreview: false,
     tools_stakes: undefined,
+    tools_approval_holding_arguments: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
@@ -1017,6 +1044,7 @@ export const INTERNAL_MCP_SERVERS = {
       add_reaction: "low" as const,
       remove_reaction: "low" as const,
     },
+    tools_approval_holding_arguments: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
@@ -1050,6 +1078,7 @@ export const INTERNAL_MCP_SERVERS = {
       get_completions_usage: "low",
       get_organization_costs: "low",
     },
+    tools_approval_holding_arguments: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
@@ -1082,6 +1111,7 @@ export const INTERNAL_MCP_SERVERS = {
       create_page: "low",
       update_page: "low",
     },
+    tools_approval_holding_arguments: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
@@ -1107,6 +1137,7 @@ export const INTERNAL_MCP_SERVERS = {
       text_to_speech: "low",
       text_to_dialogue: "low",
     },
+    tools_approval_holding_arguments: undefined,
     tools_retry_policies: { default: "retry_on_interrupt" },
     timeoutMs: undefined,
     serverInfo: {
@@ -1132,6 +1163,7 @@ export const INTERNAL_MCP_SERVERS = {
       get_file_content: "never_ask",
       upload_file: "high",
     },
+    tools_approval_holding_arguments: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
@@ -1164,6 +1196,7 @@ export const INTERNAL_MCP_SERVERS = {
       list_messages: "never_ask",
       post_message: "low",
     },
+    tools_approval_holding_arguments: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
@@ -1191,6 +1224,7 @@ export const INTERNAL_MCP_SERVERS = {
       generate_music: "low",
       generate_sound_effects: "low",
     },
+    tools_approval_holding_arguments: undefined,
     tools_retry_policies: { default: "retry_on_interrupt" },
     timeoutMs: undefined,
     serverInfo: {
@@ -1217,6 +1251,7 @@ export const INTERNAL_MCP_SERVERS = {
       create_worksheet: "low",
       clear_range: "high",
     },
+    tools_approval_holding_arguments: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
@@ -1247,6 +1282,7 @@ export const INTERNAL_MCP_SERVERS = {
       websearch: "never_ask",
       webbrowser: "never_ask",
     },
+    tools_approval_holding_arguments: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
@@ -1278,6 +1314,7 @@ export const INTERNAL_MCP_SERVERS = {
       get_candidate_notes: "never_ask",
       create_candidate_note: "high",
     },
+    tools_approval_holding_arguments: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
@@ -1305,6 +1342,7 @@ export const INTERNAL_MCP_SERVERS = {
       get_tasks: "never_ask",
       get_actions: "never_ask",
     },
+    tools_approval_holding_arguments: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
@@ -1329,6 +1367,7 @@ export const INTERNAL_MCP_SERVERS = {
       search_tickets: "never_ask",
       draft_reply: "low", // Low because it's a draft.
     },
+    tools_approval_holding_arguments: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
@@ -1360,6 +1399,7 @@ export const INTERNAL_MCP_SERVERS = {
       get_topics: "never_ask",
       get_post_metadata: "never_ask",
     },
+    tools_approval_holding_arguments: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
@@ -1396,6 +1436,7 @@ export const INTERNAL_MCP_SERVERS = {
       list_risks: "never_ask",
       list_vulnerabilities: "never_ask",
     },
+    tools_approval_holding_arguments: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
@@ -1421,6 +1462,7 @@ export const INTERNAL_MCP_SERVERS = {
       return !featureFlags.includes("dev_mcp_actions");
     },
     tools_stakes: undefined,
+    tools_approval_holding_arguments: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
@@ -1441,6 +1483,7 @@ export const INTERNAL_MCP_SERVERS = {
     isRestricted: undefined,
     isPreview: false,
     tools_stakes: undefined,
+    tools_approval_holding_arguments: undefined,
     tools_retry_policies: { default: "retry_on_interrupt" },
     timeoutMs: undefined,
     serverInfo: {
@@ -1460,6 +1503,7 @@ export const INTERNAL_MCP_SERVERS = {
     isRestricted: undefined,
     isPreview: false,
     tools_stakes: undefined,
+    tools_approval_holding_arguments: undefined,
     tools_retry_policies: { default: "retry_on_interrupt" },
     timeoutMs: DEFAULT_MCP_REQUEST_TIMEOUT_MS,
     serverInfo: {
@@ -1479,6 +1523,7 @@ export const INTERNAL_MCP_SERVERS = {
     isRestricted: undefined,
     isPreview: false,
     tools_stakes: undefined,
+    tools_approval_holding_arguments: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
@@ -1501,6 +1546,7 @@ export const INTERNAL_MCP_SERVERS = {
     isRestricted: undefined,
     isPreview: false,
     tools_stakes: undefined,
+    tools_approval_holding_arguments: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
@@ -1524,6 +1570,7 @@ export const INTERNAL_MCP_SERVERS = {
     tools_stakes: {
       create_agent: "high",
     },
+    tools_approval_holding_arguments: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
@@ -1543,6 +1590,7 @@ export const INTERNAL_MCP_SERVERS = {
     isPreview: false,
     isRestricted: undefined,
     tools_stakes: undefined,
+    tools_approval_holding_arguments: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
@@ -1562,6 +1610,7 @@ export const INTERNAL_MCP_SERVERS = {
     isPreview: false,
     isRestricted: undefined,
     tools_stakes: undefined,
+    tools_approval_holding_arguments: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
@@ -1593,6 +1642,7 @@ export const INTERNAL_MCP_SERVERS = {
       search_vals: "never_ask",
       list_val_files: "never_ask",
     },
+    tools_approval_holding_arguments: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
@@ -1615,6 +1665,7 @@ export const INTERNAL_MCP_SERVERS = {
       return !featureFlags.includes("dev_mcp_actions");
     },
     tools_stakes: undefined,
+    tools_approval_holding_arguments: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
@@ -1634,6 +1685,7 @@ export const INTERNAL_MCP_SERVERS = {
     isPreview: false,
     isRestricted: undefined,
     tools_stakes: undefined,
+    tools_approval_holding_arguments: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
@@ -1675,6 +1727,7 @@ export const INTERNAL_MCP_SERVERS = {
       update_conversation_status: "high",
       assign_conversation: "high",
     },
+    tools_approval_holding_arguments: undefined,
     tools_retry_policies: { default: "retry_on_interrupt" },
     timeoutMs: undefined,
     serverInfo: {
@@ -1704,6 +1757,7 @@ export const INTERNAL_MCP_SERVERS = {
       return !featureFlags.includes("skills");
     },
     tools_stakes: undefined,
+    tools_approval_holding_arguments: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
@@ -1730,6 +1784,7 @@ export const INTERNAL_MCP_SERVERS = {
       update_schedule: "high",
       delete_schedule: "high",
     },
+    tools_approval_holding_arguments: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
@@ -1756,6 +1811,7 @@ export const INTERNAL_MCP_SERVERS = {
     tools_stakes: {
       list_warehouses: "never_ask",
     },
+    tools_approval_holding_arguments: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     serverInfo: {
@@ -1787,6 +1843,10 @@ export const INTERNAL_MCP_SERVERS = {
       | undefined;
     isPreview: boolean;
     tools_stakes: Record<string, MCPToolStakeLevelType> | undefined;
+    // Defines which arguments require per-agent approval for "medium" stake tools.
+    // When a tool has "medium" stake, the user must approve the specific combination
+    // of (agent, tool, argument values) before the tool can execute.
+    tools_approval_holding_arguments: Record<string, string[]> | undefined;
     tools_retry_policies: Record<string, MCPToolRetryPolicyType> | undefined;
     timeoutMs: number | undefined;
     requiresBearerToken?: boolean;

--- a/front/lib/actions/tool_status.ts
+++ b/front/lib/actions/tool_status.ts
@@ -45,6 +45,8 @@ export async function getExecutionStatusFromConfig(
       }
       return { status: "blocked_validation_required" };
     }
+    // For now, "medium" is treated the same as "high".
+    case "medium":
     case "high":
       return { status: "blocked_validation_required" };
     default:

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -3312,11 +3312,12 @@ export type PostMCPResultsResponseType = z.infer<
   typeof PostMCPResultsResponseSchema
 >;
 
-const REMOTE_MCP_TOOL_STAKE_LEVELS = ["high", "medium", "low"] as const;
+const REMOTE_MCP_TOOL_STAKE_LEVELS = ["high", "low"] as const;
 export type RemoteMCPToolStakeLevelPublicType =
   (typeof REMOTE_MCP_TOOL_STAKE_LEVELS)[number];
 const MCP_TOOL_STAKE_LEVELS = [
   ...REMOTE_MCP_TOOL_STAKE_LEVELS,
+  "medium",
   "never_ask",
 ] as const;
 export type MCPToolStakeLevelPublicType =

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -1135,7 +1135,9 @@ export type ConversationMessageReactionsType = z.infer<
   typeof ConversationMessageReactionsSchema
 >;
 
-const MCPStakeLevelSchema = z.enum(["low", "high", "never_ask"]).optional();
+const MCPStakeLevelSchema = z
+  .enum(["low", "medium", "high", "never_ask"])
+  .optional();
 
 const MCPValidationMetadataSchema = z.object({
   agentName: z.string(),
@@ -3310,7 +3312,7 @@ export type PostMCPResultsResponseType = z.infer<
   typeof PostMCPResultsResponseSchema
 >;
 
-const REMOTE_MCP_TOOL_STAKE_LEVELS = ["high", "low"] as const;
+const REMOTE_MCP_TOOL_STAKE_LEVELS = ["high", "medium", "low"] as const;
 export type RemoteMCPToolStakeLevelPublicType =
   (typeof REMOTE_MCP_TOOL_STAKE_LEVELS)[number];
 const MCP_TOOL_STAKE_LEVELS = [


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

This PR
- Add \"medium\" stake level to \`MCP_TOOL_STAKE_LEVELS\` constant
- Update SDK types to include \"medium\" in Zod schemas. 
- Fix test type annotations to use `MCPToolStakeLevelType`.
- Add \`tools_approval_holding_arguments\` field to all internal MCP server configurations
- All servers have this set to \`undefined\` for now (groundwork for future per-argument approval)

This is the foundation for per-argument approval which will be added in follow-up PRs.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Unused

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front