### PR TITLE
[skills] Open editor when clicking on suggestion

### DIFF
--- a/front/components/skills/SuggestedSkillsSection.tsx
+++ b/front/components/skills/SuggestedSkillsSection.tsx
@@ -8,19 +8,38 @@ import {
   SparklesIcon,
   XMarkIcon,
 } from "@dust-tt/sparkle";
+import { useRouter } from "next/router";
 
 import { getSkillIcon } from "@app/lib/skill";
+import { useUpdateSkillEditors } from "@app/lib/swr/skill_editors";
+import { getSkillBuilderRoute } from "@app/lib/utils/router";
+import type { LightWorkspaceType, UserType } from "@app/types";
 import type { SkillWithRelationsType } from "@app/types/assistant/skill_configuration";
 
 type SuggestedSkillCardProps = {
   skill: SkillWithRelationsType;
   onMoreInfoClick: () => void;
+  owner: LightWorkspaceType;
+  user: UserType;
 };
 
 function SuggestedSkillCard({
   skill,
   onMoreInfoClick,
+  owner,
+  user,
 }: SuggestedSkillCardProps) {
+  const router = useRouter();
+  const updateSkillEditors = useUpdateSkillEditors({
+    owner,
+    skillId: skill.sId,
+  });
+
+  const handleAddSkillClick = async () => {
+    await updateSkillEditors({ addEditorIds: [user.sId], removeEditorIds: [] });
+    void router.push(getSkillBuilderRoute(owner.sId, skill.sId));
+  };
+
   return (
     <Card
       variant="primary"
@@ -52,8 +71,8 @@ function SuggestedSkillCard({
             icon={PlusIcon}
             label="Add skill" // TODO(skills): decide if this is the right label
             onClick={(e) => {
-              // TODO(skills): open the editor to customize the skill before adding
               e.stopPropagation();
+              void handleAddSkillClick();
             }}
           />
         </div>
@@ -65,11 +84,15 @@ function SuggestedSkillCard({
 type SuggestedSkillsSectionProps = {
   skills: SkillWithRelationsType[];
   onSkillClick: (skill: SkillWithRelationsType) => void;
+  owner: LightWorkspaceType;
+  user: UserType;
 };
 
 export function SuggestedSkillsSection({
   skills,
   onSkillClick,
+  owner,
+  user,
 }: SuggestedSkillsSectionProps) {
   if (skills.length === 0) {
     return null;
@@ -87,6 +110,8 @@ export function SuggestedSkillsSection({
             key={skill.sId}
             skill={skill}
             onMoreInfoClick={() => onSkillClick(skill)}
+            owner={owner}
+            user={user}
           />
         ))}
       </CardGrid>

--- a/front/lib/models/skill.ts
+++ b/front/lib/models/skill.ts
@@ -159,11 +159,11 @@ SkillConfigurationModel.belongsTo(UserModel, {
 
 // Skill version <> Author
 UserModel.hasMany(SkillVersionModel, {
-  foreignKey: { name: "authorId", allowNull: false },
+  foreignKey: { name: "authorId", allowNull: true },
   onDelete: "RESTRICT",
 });
 SkillVersionModel.belongsTo(UserModel, {
-  foreignKey: { name: "authorId", allowNull: false },
+  foreignKey: { name: "authorId", allowNull: true },
   as: "author",
 });
 

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1238,10 +1238,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
     await withTransaction(async (transaction) => {
       // Save the current version before updating.
-      // Skip version saving for suggested skills since they have no meaningful history.
-      if (this.status !== "suggested") {
-        await this.saveVersion(auth, { transaction });
-      }
+      await this.saveVersion(auth, { transaction });
 
       // Snapshot the previous requested space IDs before updating.
       const previousRequestedSpaceIds = [...this.requestedSpaceIds];

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1220,6 +1220,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       mcpServerViews,
       name,
       requestedSpaceIds,
+      status,
       userFacingDescription,
     }: {
       agentFacingDescription: string;
@@ -1229,6 +1230,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       mcpServerViews: MCPServerViewResource[];
       name: string;
       requestedSpaceIds: ModelId[];
+      status?: SkillStatus;
       userFacingDescription: string;
     }
   ): Promise<void> {
@@ -1236,7 +1238,10 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
     await withTransaction(async (transaction) => {
       // Save the current version before updating.
-      await this.saveVersion(auth, { transaction });
+      // Skip version saving for suggested skills since they have no meaningful history.
+      if (this.status !== "suggested") {
+        await this.saveVersion(auth, { transaction });
+      }
 
       // Snapshot the previous requested space IDs before updating.
       const previousRequestedSpaceIds = [...this.requestedSpaceIds];
@@ -1252,6 +1257,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
           icon,
           requestedSpaceIds,
           authorId,
+          ...(status ? { status } : {}),
         },
         transaction
       );

--- a/front/migrations/db/migration_468.sql
+++ b/front/migrations/db/migration_468.sql
@@ -1,0 +1,2 @@
+-- Migration created on Jan 08, 2026
+ALTER TABLE "skill_versions" ALTER COLUMN "authorId" DROP NOT NULL;

--- a/front/pages/api/w/[wId]/skills/[sId]/index.test.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.test.ts
@@ -1,7 +1,9 @@
 import type { RequestMethod } from "node-mocks-http";
+import type { WhereOptions } from "sequelize";
 import { describe, expect, it } from "vitest";
 
 import { Authenticator } from "@app/lib/auth";
+import { SkillVersionModel } from "@app/lib/models/skill";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
@@ -543,6 +545,16 @@ describe("PATCH /api/w/[wId]/skills/[sId] - Suggested skill activation", () => {
     expect(updatedSkill).not.toBeNull();
     expect(updatedSkill?.status).toBe("active");
     expect(updatedSkill?.authorId).toBe(requestUser.id);
+
+    const where: WhereOptions<SkillVersionModel> = {
+      workspaceId: workspace.id,
+      skillConfigurationId: updatedSkill!.id,
+    };
+    const versions = await SkillVersionModel.findAll({
+      where,
+    });
+    expect(versions).toHaveLength(1);
+    expect(versions[0].authorId).toBeNull();
   });
 });
 

--- a/front/pages/api/w/[wId]/skills/[sId]/index.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.ts
@@ -267,6 +267,9 @@ async function handler(
         })
       );
 
+      // When saving a suggested skill, automatically activate it.
+      const shouldActivate = skillResource.status === "suggested";
+
       await skillResource.updateSkill(auth, {
         agentFacingDescription: body.agentFacingDescription,
         attachedKnowledge: attachedKnowledgeWithDataSourceViews,
@@ -276,6 +279,7 @@ async function handler(
         name,
         requestedSpaceIds,
         userFacingDescription: body.userFacingDescription,
+        ...(shouldActivate ? { status: "active" as const } : {}),
       });
 
       return res.status(200).json({

--- a/front/pages/w/[wId]/builder/skills/index.tsx
+++ b/front/pages/w/[wId]/builder/skills/index.tsx
@@ -286,6 +286,8 @@ export default function WorkspaceSkills({
                     <SuggestedSkillsSection
                       skills={sortSkillsByName(suggestedSkills)}
                       onSkillClick={setSelectedSkill}
+                      owner={owner}
+                      user={user}
                     />
                   )}
                   <SkillsTable


### PR DESCRIPTION
## Description

closes https://github.com/dust-tt/tasks/issues/5872

clicking "add  skill" dd the current user as editor of the skill, then open the editor.
Saving this skill makes it active. 

https://github.com/user-attachments/assets/754ba06c-c95e-42e3-a141-495d9a5b123f

## Tests
 
Manual test
Unit test

## Risk

low

## Deploy Plan

block front
merge
apply migration
deploy front
unblock front