### PR TITLE
[front] Prevent web and slack origins

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -485,7 +485,6 @@ export function isUserMessageContextValid(
     case "powerpoint":
     case "zapier":
       return authMethod === "api_key";
-
     case "zendesk":
       return (
         (authMethod === "api_key" || authMethod === "oauth") && !!zendeskUserId

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -477,8 +477,6 @@ export function isUserMessageContextValid(
 
   switch (context.origin) {
     case "api":
-    case "slack": // TODO: should not be allowed
-    case "web": // TODO: should not be allowed
       return true;
     case "excel":
     case "gsheet":
@@ -487,6 +485,7 @@ export function isUserMessageContextValid(
     case "powerpoint":
     case "zapier":
       return authMethod === "api_key";
+
     case "zendesk":
       return (
         (authMethod === "api_key" || authMethod === "oauth") && !!zendeskUserId
@@ -499,12 +498,14 @@ export function isUserMessageContextValid(
     case "raycast":
       return authMethod === "oauth" && userAgent === "undici";
     case "email":
+    case "slack":
     case "slack_workflow":
     case "teams":
     case "transcript":
     case "triggered":
     case "triggered_programmatic":
     case "onboarding_conversation":
+    case "web":
       return false;
     default:
       assertNever(context.origin);

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -234,7 +234,7 @@ async function handler(
           api_error: {
             type: "invalid_request_error",
             message:
-              "This origin is not allowed. See documentation to fix to an allowed origin.",
+              "This origin is not allowed. Remove the origin from the context property.",
           },
         });
       }

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -429,7 +429,7 @@ async function handler(
             api_error: {
               type: "invalid_request_error",
               message:
-                "This origin is not allowed. See documentation to fix to an allowed origin.",
+                "This origin is not allowed. Remove the origin from the context property.",
             },
           });
         }


### PR DESCRIPTION
## Description

"web" and "slack" can't be used anymore as origins in public api calls. "slack" is only allowed with system key, while "web" should only be used in internal api.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

API calls being rejected. Communication has been done.

## Deploy Plan

deploy front
