### PR TITLE
fix: bug on hash location with next

### DIFF
--- a/front/hooks/useQueryParams.ts
+++ b/front/hooks/useQueryParams.ts
@@ -69,11 +69,22 @@ export function useQueryParams<T extends string[]>(
       );
 
       if (hasChanges) {
-        void router.push(
-          { pathname: router.pathname, query: updatedQuery },
-          undefined,
-          { shallow: true }
-        );
+        // Preserve the hash when updating query params
+        const hash = window.location.hash;
+        void router
+          .push({ pathname: router.pathname, query: updatedQuery }, undefined, {
+            shallow: true,
+          })
+          .then(() => {
+            // Restore hash after router.push (Next.js doesn't preserve it)
+            if (hash && window.location.hash !== hash) {
+              window.history.replaceState(
+                null,
+                "",
+                `${window.location.pathname}${window.location.search}${hash}`
+              );
+            }
+          });
       }
     },
     [router, paramNames]

--- a/front/lib/api/assistant/jit/common_utilities.ts
+++ b/front/lib/api/assistant/jit/common_utilities.ts
@@ -1,0 +1,60 @@
+import type { ServerSideMCPServerConfigurationType } from "@app/lib/actions/mcp";
+import type { Authenticator } from "@app/lib/auth";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids";
+import logger from "@app/logger/logger";
+import type {
+  ConversationWithoutContentType,
+  LightAgentConfigurationType,
+} from "@app/types";
+
+/**
+ * Get the common_utilities MCP server (random numbers, timers, etc.).
+ */
+export async function getCommonUtilitiesServer(
+  auth: Authenticator,
+  agentConfiguration: LightAgentConfigurationType,
+  conversation: ConversationWithoutContentType
+): Promise<ServerSideMCPServerConfigurationType | null> {
+  const commonUtilitiesView =
+    await MCPServerViewResource.getMCPServerViewForAutoInternalTool(
+      auth,
+      "common_utilities"
+    );
+
+  if (!commonUtilitiesView) {
+    logger.warn(
+      {
+        agentConfigurationId: agentConfiguration.sId,
+        conversationId: conversation.sId,
+      },
+      "MCP server view not found for common_utilities. Ensure auto tools are created."
+    );
+    return null;
+  }
+
+  const commonUtilitiesViewJSON = commonUtilitiesView.toJSON();
+  return {
+    id: -1,
+    sId: generateRandomModelSId(),
+    type: "mcp_server_configuration",
+    name:
+      commonUtilitiesViewJSON.name ??
+      commonUtilitiesViewJSON.server.name ??
+      "common_utilities",
+    description:
+      commonUtilitiesViewJSON.description ??
+      commonUtilitiesViewJSON.server.description ??
+      "Common utilities such as random numbers and timers.",
+    dataSources: null,
+    tables: null,
+    childAgentId: null,
+    timeFrame: null,
+    jsonSchema: null,
+    secretName: null,
+    additionalConfiguration: {},
+    mcpServerViewId: commonUtilitiesViewJSON.sId,
+    dustAppConfiguration: null,
+    internalMCPServerId: commonUtilitiesView.mcpServerId,
+  };
+}

--- a/front/lib/api/assistant/jit/conversation.ts
+++ b/front/lib/api/assistant/jit/conversation.ts
@@ -1,0 +1,196 @@
+import assert from "assert";
+
+import { DEFAULT_CONVERSATION_SEARCH_ACTION_NAME } from "@app/lib/actions/constants";
+import type { ServerSideMCPServerConfigurationType } from "@app/lib/actions/mcp";
+import type { DataSourceConfiguration } from "@app/lib/api/assistant/configuration/types";
+import type {
+  ContentNodeAttachmentType,
+  ConversationAttachmentType,
+} from "@app/lib/api/assistant/conversation/attachments";
+import { isContentNodeAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
+import { getConversationDataSourceViews } from "@app/lib/api/assistant/jit/utils";
+import type { Authenticator } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids";
+import type { ConversationWithoutContentType } from "@app/types";
+
+/**
+ * Get MCP server configurations for conversation-specific tools.
+ * These are tools explicitly attached to the conversation.
+ */
+export async function getConversationMCPServers(
+  auth: Authenticator,
+  conversation: ConversationWithoutContentType
+): Promise<ServerSideMCPServerConfigurationType[]> {
+  const servers: ServerSideMCPServerConfigurationType[] = [];
+
+  const conversationMCPServerViews =
+    await ConversationResource.fetchMCPServerViews(auth, conversation, true);
+
+  for (const conversationMCPServerView of conversationMCPServerViews) {
+    const mcpServerViewResource = await MCPServerViewResource.fetchByModelPk(
+      auth,
+      conversationMCPServerView.mcpServerViewId
+    );
+
+    if (!mcpServerViewResource) {
+      continue;
+    }
+
+    const mcpServerView = mcpServerViewResource.toJSON();
+
+    servers.push({
+      id: -1,
+      sId: generateRandomModelSId(),
+      type: "mcp_server_configuration",
+      name: mcpServerView.name ?? mcpServerView.server.name,
+      description:
+        mcpServerView.description ?? mcpServerView.server.description,
+      dataSources: null,
+      tables: null,
+      childAgentId: null,
+      timeFrame: null,
+      jsonSchema: null,
+      secretName: null,
+      additionalConfiguration: {},
+      mcpServerViewId: mcpServerView.sId,
+      dustAppConfiguration: null,
+      internalMCPServerId:
+        mcpServerView.serverType === "internal"
+          ? mcpServerView.server.sId
+          : null,
+    });
+  }
+
+  return servers;
+}
+
+/**
+ * Get the conversation_files MCP server for accessing conversation files.
+ * Only created if conversation has attachments.
+ */
+export async function getConversationFilesServer(
+  auth: Authenticator,
+  attachments: ConversationAttachmentType[]
+): Promise<ServerSideMCPServerConfigurationType | null> {
+  if (attachments.length === 0) {
+    return null;
+  }
+
+  const conversationFilesView =
+    await MCPServerViewResource.getMCPServerViewForAutoInternalTool(
+      auth,
+      "conversation_files"
+    );
+
+  assert(
+    conversationFilesView,
+    "MCP server view not found for conversation_files. Ensure auto tools are created."
+  );
+
+  return {
+    id: -1,
+    sId: generateRandomModelSId(),
+    type: "mcp_server_configuration",
+    name: "conversation_files",
+    description: "Access and include files from the conversation",
+    dataSources: null,
+    tables: null,
+    childAgentId: null,
+    timeFrame: null,
+    jsonSchema: null,
+    secretName: null,
+    additionalConfiguration: {},
+    mcpServerViewId: conversationFilesView.sId,
+    dustAppConfiguration: null,
+    internalMCPServerId: conversationFilesView.mcpServerId,
+  };
+}
+
+/**
+ * Get the conversation_search MCP server for semantic search over conversation files.
+ * Only created if conversation has searchable attachments.
+ */
+export async function getConversationSearchServer(
+  auth: Authenticator,
+  conversation: ConversationWithoutContentType,
+  attachments: ConversationAttachmentType[]
+): Promise<ServerSideMCPServerConfigurationType | null> {
+  const filesUsableAsRetrievalQuery = attachments.filter((f) => f.isSearchable);
+
+  if (filesUsableAsRetrievalQuery.length === 0) {
+    return null;
+  }
+
+  const retrievalView =
+    await MCPServerViewResource.getMCPServerViewForAutoInternalTool(
+      auth,
+      "search"
+    );
+
+  assert(
+    retrievalView,
+    "MCP server view not found for search. Ensure auto tools are created."
+  );
+
+  // Get datasource views for child conversations.
+  const fileIdToDataSourceViewMap = await getConversationDataSourceViews(
+    auth,
+    conversation,
+    attachments
+  );
+
+  const contentNodeAttachments: ContentNodeAttachmentType[] = [];
+  for (const f of filesUsableAsRetrievalQuery) {
+    if (isContentNodeAttachmentType(f)) {
+      contentNodeAttachments.push(f);
+    }
+  }
+
+  const dataSources: DataSourceConfiguration[] = contentNodeAttachments.map(
+    (f) => ({
+      workspaceId: auth.getNonNullableWorkspace().sId,
+      dataSourceViewId: f.nodeDataSourceViewId,
+      filter: {
+        parents: {
+          in: [f.nodeId],
+          not: [],
+        },
+        tags: null,
+      },
+    })
+  );
+
+  const dataSourceIds = new Set(
+    [...fileIdToDataSourceViewMap.values()].map(
+      (dataSourceView) => dataSourceView.sId
+    )
+  );
+
+  for (const dataSourceViewId of dataSourceIds.values()) {
+    dataSources.push({
+      workspaceId: auth.getNonNullableWorkspace().sId,
+      dataSourceViewId,
+      filter: { parents: null, tags: null },
+    });
+  }
+
+  return {
+    id: -1,
+    sId: generateRandomModelSId(),
+    type: "mcp_server_configuration",
+    name: DEFAULT_CONVERSATION_SEARCH_ACTION_NAME,
+    description: "Semantic search over all files from the conversation",
+    dataSources,
+    tables: null,
+    childAgentId: null,
+    timeFrame: null,
+    jsonSchema: null,
+    secretName: null,
+    additionalConfiguration: {},
+    mcpServerViewId: retrievalView.sId,
+    dustAppConfiguration: null,
+    internalMCPServerId: retrievalView.mcpServerId,
+  };
+}

--- a/front/lib/api/assistant/jit/folder.ts
+++ b/front/lib/api/assistant/jit/folder.ts
@@ -1,0 +1,86 @@
+import assert from "assert";
+
+import type { ServerSideMCPServerConfigurationType } from "@app/lib/actions/mcp";
+import type { DataSourceConfiguration } from "@app/lib/api/assistant/configuration/types";
+import type {
+  ContentNodeAttachmentType,
+  ConversationAttachmentType,
+} from "@app/lib/api/assistant/conversation/attachments";
+import {
+  isContentFragmentDataSourceNode,
+  isContentNodeAttachmentType,
+} from "@app/lib/api/assistant/conversation/attachments";
+import { isSearchableFolder } from "@app/lib/api/assistant/jit_utils";
+import type { Authenticator } from "@app/lib/auth";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids";
+
+/**
+ * Get folder search MCP servers for each searchable folder attachment.
+ * Creates one search server per folder.
+ */
+export async function getFolderSearchServers(
+  auth: Authenticator,
+  attachments: ConversationAttachmentType[]
+): Promise<ServerSideMCPServerConfigurationType[]> {
+  const retrievalView =
+    await MCPServerViewResource.getMCPServerViewForAutoInternalTool(
+      auth,
+      "search"
+    );
+
+  assert(
+    retrievalView,
+    "MCP server view not found for search. Ensure auto tools are created."
+  );
+
+  const searchableFolders: ContentNodeAttachmentType[] = [];
+  for (const attachment of attachments) {
+    if (
+      isContentNodeAttachmentType(attachment) &&
+      isSearchableFolder(attachment)
+    ) {
+      searchableFolders.push(attachment);
+    }
+  }
+
+  const servers: ServerSideMCPServerConfigurationType[] = [];
+
+  for (const [i, folder] of searchableFolders.entries()) {
+    const dataSources: DataSourceConfiguration[] = [
+      {
+        workspaceId: auth.getNonNullableWorkspace().sId,
+        dataSourceViewId: folder.nodeDataSourceViewId,
+        filter: {
+          parents: isContentFragmentDataSourceNode(folder)
+            ? null
+            : {
+                in: [folder.nodeId],
+                not: [],
+              },
+          tags: null,
+        },
+      },
+    ];
+
+    servers.push({
+      id: -1,
+      sId: generateRandomModelSId(),
+      type: "mcp_server_configuration",
+      name: `search_folder_${i}`,
+      description: `Search content within the documents inside "${folder.title}"`,
+      dataSources,
+      tables: null,
+      childAgentId: null,
+      timeFrame: null,
+      jsonSchema: null,
+      secretName: null,
+      additionalConfiguration: {},
+      mcpServerViewId: retrievalView.sId,
+      dustAppConfiguration: null,
+      internalMCPServerId: retrievalView.mcpServerId,
+    });
+  }
+
+  return servers;
+}

--- a/front/lib/api/assistant/jit/projects.ts
+++ b/front/lib/api/assistant/jit/projects.ts
@@ -1,0 +1,76 @@
+import assert from "assert";
+
+import { DEFAULT_PROJECT_SEARCH_ACTION_NAME } from "@app/lib/actions/constants";
+import type { ServerSideMCPServerConfigurationType } from "@app/lib/actions/mcp";
+import type { DataSourceConfiguration } from "@app/lib/api/assistant/configuration/types";
+import { getProjectContextDataSourceView } from "@app/lib/api/assistant/jit/utils";
+import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids";
+import type { ConversationWithoutContentType } from "@app/types";
+
+/**
+ * Get the project_search MCP server for searching project context files.
+ * Only available with "projects" feature flag and if conversation is in a project.
+ */
+export async function getProjectSearchServer(
+  auth: Authenticator,
+  conversation: ConversationWithoutContentType
+): Promise<ServerSideMCPServerConfigurationType | null> {
+  const owner = auth.getNonNullableWorkspace();
+  const featureFlags = await getFeatureFlags(owner);
+
+  if (!featureFlags.includes("projects") || !conversation.spaceId) {
+    return null;
+  }
+
+  const projectDatasourceView = await getProjectContextDataSourceView(
+    auth,
+    conversation
+  );
+
+  if (!projectDatasourceView) {
+    return null;
+  }
+
+  const retrievalView =
+    await MCPServerViewResource.getMCPServerViewForAutoInternalTool(
+      auth,
+      "search"
+    );
+
+  assert(
+    retrievalView,
+    "MCP server view not found for search. Ensure auto tools are created."
+  );
+
+  const dataSources: DataSourceConfiguration[] = [
+    {
+      workspaceId: owner.sId,
+      dataSourceViewId: projectDatasourceView.sId,
+      filter: {
+        parents: null,
+        tags: null,
+      },
+    },
+  ];
+
+  return {
+    id: -1,
+    sId: generateRandomModelSId(),
+    type: "mcp_server_configuration",
+    name: DEFAULT_PROJECT_SEARCH_ACTION_NAME,
+    description: `Semantic search over the project context`,
+    dataSources,
+    tables: null,
+    childAgentId: null,
+    timeFrame: null,
+    jsonSchema: null,
+    secretName: null,
+    additionalConfiguration: {},
+    mcpServerViewId: retrievalView.sId,
+    dustAppConfiguration: null,
+    internalMCPServerId: retrievalView.mcpServerId,
+  };
+}

--- a/front/lib/api/assistant/jit/query_tables_v2.ts
+++ b/front/lib/api/assistant/jit/query_tables_v2.ts
@@ -1,0 +1,127 @@
+import assert from "assert";
+
+import {
+  DEFAULT_CONVERSATION_LIST_FILES_ACTION_NAME,
+  DEFAULT_CONVERSATION_QUERY_TABLES_ACTION_NAME,
+} from "@app/lib/actions/constants";
+import type { ServerSideMCPServerConfigurationType } from "@app/lib/actions/mcp";
+import type { TableDataSourceConfiguration } from "@app/lib/api/assistant/configuration/types";
+import type { ConversationAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
+import {
+  isContentNodeAttachmentType,
+  isFileAttachmentType,
+} from "@app/lib/api/assistant/conversation/attachments";
+import { isMultiSheetSpreadsheetContentType } from "@app/lib/api/assistant/conversation/content_types";
+import {
+  getConversationDataSourceViews,
+  getTablesFromMultiSheetSpreadsheet,
+} from "@app/lib/api/assistant/jit/utils";
+import type { Authenticator } from "@app/lib/auth";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import logger from "@app/logger/logger";
+import type { ConversationWithoutContentType } from "@app/types";
+
+/**
+ * Get the query_tables_v2 MCP server for querying CSV/Excel files.
+ * Only created if conversation has queryable attachments (tables).
+ */
+export async function getQueryTablesServer(
+  auth: Authenticator,
+
+  conversation: ConversationWithoutContentType,
+  attachments: ConversationAttachmentType[]
+): Promise<ServerSideMCPServerConfigurationType | null> {
+  const filesUsableAsTableQuery = attachments.filter((f) => f.isQueryable);
+
+  if (filesUsableAsTableQuery.length === 0) {
+    return null;
+  }
+
+  // Get datasource views for child conversations that have generated files.
+  const fileIdToDataSourceViewMap = await getConversationDataSourceViews(
+    auth,
+    conversation,
+    attachments
+  );
+
+  // Assign tables to multi-sheet spreadsheets.
+  await concurrentExecutor(
+    filesUsableAsTableQuery.filter((f) =>
+      isMultiSheetSpreadsheetContentType(f.contentType)
+    ),
+    async (f) => {
+      assert(
+        isContentNodeAttachmentType(f),
+        "Unreachable: file should be a content node"
+      );
+      f.generatedTables = await getTablesFromMultiSheetSpreadsheet(auth, f);
+    },
+    { concurrency: 10 }
+  );
+
+  const queryTablesView =
+    await MCPServerViewResource.getMCPServerViewForAutoInternalTool(
+      auth,
+      "query_tables_v2"
+    );
+
+  assert(
+    queryTablesView,
+    "MCP server view not found for query_tables_v2. Ensure auto tools are created."
+  );
+
+  const tables: TableDataSourceConfiguration[] = [];
+
+  for (const f of filesUsableAsTableQuery) {
+    if (isFileAttachmentType(f)) {
+      const dataSourceView = fileIdToDataSourceViewMap.get(f.fileId);
+
+      if (!dataSourceView) {
+        logger.warn(
+          {
+            fileId: f.fileId,
+            conversationId: conversation.sId,
+          },
+          "Could not find datasource view for file in table query"
+        );
+        continue;
+      }
+
+      for (const tableId of f.generatedTables) {
+        tables.push({
+          workspaceId: auth.getNonNullableWorkspace().sId,
+          dataSourceViewId: dataSourceView.sId,
+          tableId,
+        });
+      }
+    } else if (isContentNodeAttachmentType(f)) {
+      for (const tableId of f.generatedTables) {
+        tables.push({
+          workspaceId: auth.getNonNullableWorkspace().sId,
+          dataSourceViewId: f.nodeDataSourceViewId,
+          tableId,
+        });
+      }
+    }
+  }
+
+  return {
+    id: -1,
+    sId: generateRandomModelSId(),
+    type: "mcp_server_configuration",
+    name: DEFAULT_CONVERSATION_QUERY_TABLES_ACTION_NAME,
+    description: `The tables associated with the 'queryable' conversation files as returned by \`${DEFAULT_CONVERSATION_LIST_FILES_ACTION_NAME}\``,
+    dataSources: null,
+    tables,
+    childAgentId: null,
+    timeFrame: null,
+    jsonSchema: null,
+    secretName: null,
+    additionalConfiguration: {},
+    mcpServerViewId: queryTablesView.sId,
+    dustAppConfiguration: null,
+    internalMCPServerId: queryTablesView.mcpServerId,
+  };
+}

--- a/front/lib/api/assistant/jit/schedules_management.ts
+++ b/front/lib/api/assistant/jit/schedules_management.ts
@@ -1,0 +1,78 @@
+import type { ServerSideMCPServerConfigurationType } from "@app/lib/actions/mcp";
+import type { Authenticator } from "@app/lib/auth";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids";
+import logger from "@app/logger/logger";
+import type {
+  ConversationWithoutContentType,
+  LightAgentConfigurationType,
+} from "@app/types";
+
+/**
+ * Get the schedules_management MCP server for onboarding conversations.
+ * Only available if this is the user's onboarding conversation.
+ */
+export async function getSchedulesManagementServer(
+  auth: Authenticator,
+  agentConfiguration: LightAgentConfigurationType,
+  conversation: ConversationWithoutContentType
+): Promise<ServerSideMCPServerConfigurationType | null> {
+  const owner = auth.getNonNullableWorkspace();
+  const userResource = auth.user();
+
+  if (!userResource || !owner) {
+    return null;
+  }
+
+  const onboardingMetadata = await userResource.getMetadata(
+    "onboarding:conversation",
+    owner.id
+  );
+
+  if (onboardingMetadata?.value !== conversation.sId) {
+    return null;
+  }
+
+  const schedulesManagementView =
+    await MCPServerViewResource.getMCPServerViewForAutoInternalTool(
+      auth,
+      "schedules_management"
+    );
+
+  if (!schedulesManagementView) {
+    logger.warn(
+      {
+        agentConfigurationId: agentConfiguration.sId,
+        conversationId: conversation.sId,
+      },
+      "MCP server view not found for schedules_management. Ensure auto tools are created."
+    );
+    return null;
+  }
+
+  const schedulesManagementViewJSON = schedulesManagementView.toJSON();
+
+  return {
+    id: -1,
+    sId: generateRandomModelSId(),
+    type: "mcp_server_configuration",
+    name:
+      schedulesManagementViewJSON.name ??
+      schedulesManagementViewJSON.server.name ??
+      "schedules_management",
+    description:
+      schedulesManagementViewJSON.description ??
+      schedulesManagementViewJSON.server.description ??
+      "Create schedules to automate recurring tasks.",
+    dataSources: null,
+    tables: null,
+    childAgentId: null,
+    timeFrame: null,
+    jsonSchema: null,
+    secretName: null,
+    additionalConfiguration: {},
+    mcpServerViewId: schedulesManagementViewJSON.sId,
+    dustAppConfiguration: null,
+    internalMCPServerId: schedulesManagementView.mcpServerId,
+  };
+}

--- a/front/lib/api/assistant/jit/skills.ts
+++ b/front/lib/api/assistant/jit/skills.ts
@@ -1,0 +1,75 @@
+import type { ServerSideMCPServerConfigurationType } from "@app/lib/actions/mcp";
+import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
+import { AgentSkillModel } from "@app/lib/models/agent/agent_skill";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids";
+import logger from "@app/logger/logger";
+import type {
+  ConversationWithoutContentType,
+  LightAgentConfigurationType,
+} from "@app/types";
+
+/**
+ * Get the skill_management MCP server if agent has configured skills.
+ * Only available with "skills" feature flag.
+ */
+export async function getSkillManagementServer(
+  auth: Authenticator,
+  agentConfiguration: LightAgentConfigurationType,
+  conversation: ConversationWithoutContentType
+): Promise<ServerSideMCPServerConfigurationType | null> {
+  const owner = auth.getNonNullableWorkspace();
+  const featureFlags = await getFeatureFlags(owner);
+
+  if (!featureFlags.includes("skills")) {
+    return null;
+  }
+
+  // Check if agent has any skills configured.
+  const skillCount = await AgentSkillModel.count({
+    where: {
+      agentConfigurationId: agentConfiguration.id,
+      workspaceId: owner.id,
+    },
+  });
+
+  if (skillCount === 0) {
+    return null;
+  }
+
+  const skillManagementView =
+    await MCPServerViewResource.getMCPServerViewForAutoInternalTool(
+      auth,
+      "skill_management"
+    );
+
+  if (!skillManagementView) {
+    logger.warn(
+      {
+        agentConfigurationId: agentConfiguration.sId,
+        conversationId: conversation.sId,
+      },
+      "MCP server view not found for skill_management. Ensure auto tools are created."
+    );
+    return null;
+  }
+
+  return {
+    id: -1,
+    sId: generateRandomModelSId(),
+    type: "mcp_server_configuration",
+    name: "skill_management",
+    description: "Enable skills for the conversation.",
+    dataSources: null,
+    tables: null,
+    childAgentId: null,
+    timeFrame: null,
+    jsonSchema: null,
+    secretName: null,
+    additionalConfiguration: {},
+    mcpServerViewId: skillManagementView.sId,
+    dustAppConfiguration: null,
+    internalMCPServerId: skillManagementView.mcpServerId,
+  };
+}

--- a/front/lib/api/assistant/jit/utils.test.ts
+++ b/front/lib/api/assistant/jit/utils.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { getProjectContextDataSourceView } from "@app/lib/api/assistant/jit/utils";
+import { getProjectContextDatasourceName } from "@app/lib/api/projects";
+import type { Authenticator } from "@app/lib/auth";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import type { ConversationType, WorkspaceType } from "@app/types";
+
+describe("getProjectContextDataSourceView", () => {
+  let auth: Authenticator;
+  let workspace: WorkspaceType;
+  let conversationsSpace: SpaceResource;
+  let conversation: ConversationType;
+
+  beforeEach(async () => {
+    const setup = await createResourceTest({ role: "admin" });
+    auth = setup.authenticator;
+    workspace = setup.workspace;
+    conversationsSpace = setup.conversationsSpace;
+
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Test Agent",
+      description: "Test Agent Description",
+    });
+
+    conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [],
+    });
+  });
+
+  it("should return null for conversation not in a space", async () => {
+    const result = await getProjectContextDataSourceView(auth, conversation);
+    expect(result).toBeNull();
+  });
+
+  it("should return null when space has no project context datasource", async () => {
+    const conversationInSpace = {
+      ...conversation,
+      spaceId: conversationsSpace.sId,
+    };
+
+    const result = await getProjectContextDataSourceView(
+      auth,
+      conversationInSpace
+    );
+    expect(result).toBeNull();
+  });
+
+  it("should return datasource view when space has project context", async () => {
+    // Create a data source view with the project context name.
+    const projectContextName = getProjectContextDatasourceName(
+      conversationsSpace.id
+    );
+    const dataSourceView = await DataSourceViewFactory.folder(
+      workspace,
+      conversationsSpace,
+      auth.user()
+    );
+
+    // Update the datasource name to match the project context name.
+    // @ts-expect-error -- access protected member for test
+    await dataSourceView.dataSource.update({
+      name: projectContextName,
+    });
+
+    const conversationInSpace = {
+      ...conversation,
+      spaceId: conversationsSpace.sId,
+    };
+
+    const result = await getProjectContextDataSourceView(
+      auth,
+      conversationInSpace
+    );
+
+    expect(result).toBeDefined();
+    expect(result?.sId).toBe(dataSourceView.sId);
+  });
+});

--- a/front/lib/api/assistant/jit/utils.ts
+++ b/front/lib/api/assistant/jit/utils.ts
@@ -1,0 +1,184 @@
+import assert from "assert";
+
+import type {
+  ContentNodeAttachmentType,
+  ConversationAttachmentType,
+} from "@app/lib/api/assistant/conversation/attachments";
+import { isFileAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
+import { isMultiSheetSpreadsheetContentType } from "@app/lib/api/assistant/conversation/content_types";
+import config from "@app/lib/api/config";
+import type { Authenticator } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import { FileResource } from "@app/lib/resources/file_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import logger from "@app/logger/logger";
+import type { ConversationWithoutContentType } from "@app/types";
+import { CoreAPI } from "@app/types";
+
+export async function getTablesFromMultiSheetSpreadsheet(
+  auth: Authenticator,
+  f: ContentNodeAttachmentType
+): Promise<string[]> {
+  assert(
+    isMultiSheetSpreadsheetContentType(f.contentType),
+    `Unexpected: ${f.title} is not a multi-sheet spreadsheet`
+  );
+
+  const dataSourceView = await DataSourceViewResource.fetchById(
+    auth,
+    f.nodeDataSourceViewId
+  );
+
+  assert(
+    dataSourceView,
+    `Unexpected: No datasource view found for datasource view id ${f.nodeDataSourceViewId}`
+  );
+
+  const coreApi = new CoreAPI(config.getCoreAPIConfig(), logger);
+  const searchResult = await coreApi.searchNodes({
+    filter: {
+      parent_id: f.nodeId,
+      data_source_views: [
+        {
+          data_source_id: dataSourceView.dataSource.dustAPIDataSourceId,
+          view_filter: [f.nodeId],
+        },
+      ],
+    },
+  });
+
+  if (searchResult.isErr()) {
+    throw new Error(
+      `Unexpected: Failed to get tables from multi-sheet spreadsheet: ${searchResult.error}`
+    );
+  }
+
+  // Children of multi-sheet spreadsheets are exclusively tables.
+  return searchResult.value.nodes.map((n) => n.node_id);
+}
+
+/**
+ * Get the project context datasource view for a conversation's space (if any).
+ * Returns null if the conversation not in a space or no project context datasource exists.
+ */
+export async function getProjectContextDataSourceView(
+  auth: Authenticator,
+  conversation: ConversationWithoutContentType
+): Promise<DataSourceViewResource | null> {
+  if (!conversation.spaceId) {
+    // Conversation not in a space (private conversation).
+    return null;
+  }
+
+  // Fetch space.
+  const space = await SpaceResource.fetchById(auth, conversation.spaceId);
+  if (!space) {
+    logger.warn(
+      {
+        conversationId: conversation.sId,
+        spaceId: conversation.spaceId,
+      },
+      "Space not found for conversation"
+    );
+    return null;
+  }
+
+  // Try to fetch the project context datasource.
+  const view = await DataSourceViewResource.fetchByProjectId(auth, space.id);
+
+  return view ?? null;
+}
+
+/**
+ * Get datasource views for child conversations that have generated files
+ * This allows JIT actions to access files from run_agent child conversations
+ */
+export async function getConversationDataSourceViews(
+  auth: Authenticator,
+  conversation: ConversationWithoutContentType,
+  attachments: ConversationAttachmentType[]
+): Promise<Map<string, DataSourceViewResource>> {
+  const conversationIdToDataSourceViewMap = new Map<
+    string,
+    DataSourceViewResource
+  >();
+
+  // Get the datasource view for the conversation.
+  const conversationDataSourceView =
+    await DataSourceViewResource.fetchByConversation(auth, conversation);
+  if (conversationDataSourceView) {
+    conversationIdToDataSourceViewMap.set(
+      conversation.sId,
+      conversationDataSourceView
+    );
+  }
+
+  const fileIdToDataSourceViewMap = new Map<string, DataSourceViewResource>();
+
+  // Check file attachments for their conversation metadata
+  for (const attachment of attachments) {
+    if (isFileAttachmentType(attachment)) {
+      try {
+        // Get the file resource to access its metadata
+        const fileResource = await FileResource.fetchById(
+          auth,
+          attachment.fileId
+        );
+        if (fileResource && fileResource.useCaseMetadata?.conversationId) {
+          const fileConversationId =
+            fileResource.useCaseMetadata.conversationId;
+
+          // First look in already fetched conversations
+          const cachedChildDataSourceView =
+            conversationIdToDataSourceViewMap.get(fileConversationId);
+          if (cachedChildDataSourceView) {
+            fileIdToDataSourceViewMap.set(
+              attachment.fileId,
+              cachedChildDataSourceView
+            );
+            continue;
+          }
+
+          // Fetch the datasource view for this conversation
+          const childConversation =
+            await ConversationResource.fetchConversationWithoutContent(
+              auth,
+              fileConversationId
+            );
+
+          if (childConversation.isErr()) {
+            logger.warn(
+              `Could not find child conversation with sId: ${fileConversationId}`
+            );
+            continue;
+          }
+
+          const childDataSourceView =
+            await DataSourceViewResource.fetchByConversation(
+              auth,
+              childConversation.value
+            );
+
+          if (childDataSourceView) {
+            conversationIdToDataSourceViewMap.set(
+              childConversation.value.sId,
+              childDataSourceView
+            );
+            // Map this file to its datasource view
+            fileIdToDataSourceViewMap.set(
+              attachment.fileId,
+              childDataSourceView
+            );
+          }
+        }
+      } catch (error) {
+        logger.warn(
+          `Failed to get file metadata for file ${attachment.fileId}: ${error instanceof Error ? error.message : String(error)}`
+        );
+      }
+    }
+  }
+
+  return fileIdToDataSourceViewMap;
+}

--- a/front/lib/api/assistant/jit_actions.test.ts
+++ b/front/lib/api/assistant/jit_actions.test.ts
@@ -7,10 +7,7 @@ import {
   DEFAULT_PROJECT_SEARCH_ACTION_NAME,
 } from "@app/lib/actions/constants";
 import type { ConversationAttachmentType } from "@app/lib/api/assistant/conversation/attachments";
-import {
-  getJITServers,
-  getProjectContextDataSourceView,
-} from "@app/lib/api/assistant/jit_actions";
+import { getJITServers } from "@app/lib/api/assistant/jit_actions";
 import { getProjectContextDatasourceName } from "@app/lib/api/projects";
 import type { Authenticator } from "@app/lib/auth";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -587,78 +584,5 @@ describe("getJITServers", () => {
       // All sIds should be unique.
       expect(sIds.length).toBe(uniqueSIds.size);
     });
-  });
-});
-
-describe("getProjectContextDataSourceView", () => {
-  let auth: Authenticator;
-  let workspace: WorkspaceType;
-  let conversationsSpace: SpaceResource;
-  let conversation: ConversationType;
-
-  beforeEach(async () => {
-    const setup = await createResourceTest({ role: "admin" });
-    auth = setup.authenticator;
-    workspace = setup.workspace;
-    conversationsSpace = setup.conversationsSpace;
-
-    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
-      name: "Test Agent",
-      description: "Test Agent Description",
-    });
-
-    conversation = await ConversationFactory.create(auth, {
-      agentConfigurationId: agentConfig.sId,
-      messagesCreatedAt: [],
-    });
-  });
-
-  it("should return null for conversation not in a space", async () => {
-    const result = await getProjectContextDataSourceView(auth, conversation);
-    expect(result).toBeNull();
-  });
-
-  it("should return null when space has no project context datasource", async () => {
-    const conversationInSpace = {
-      ...conversation,
-      spaceId: conversationsSpace.sId,
-    };
-
-    const result = await getProjectContextDataSourceView(
-      auth,
-      conversationInSpace
-    );
-    expect(result).toBeNull();
-  });
-
-  it("should return datasource view when space has project context", async () => {
-    // Create a data source view with the project context name.
-    const projectContextName = getProjectContextDatasourceName(
-      conversationsSpace.id
-    );
-    const dataSourceView = await DataSourceViewFactory.folder(
-      workspace,
-      conversationsSpace,
-      auth.user()
-    );
-
-    // Update the datasource name to match the project context name.
-    // @ts-expect-error -- access protected member for test
-    await dataSourceView.dataSource.update({
-      name: projectContextName,
-    });
-
-    const conversationInSpace = {
-      ...conversation,
-      spaceId: conversationsSpace.sId,
-    };
-
-    const result = await getProjectContextDataSourceView(
-      auth,
-      conversationInSpace
-    );
-
-    expect(result).toBeDefined();
-    expect(result?.sId).toBe(dataSourceView.sId);
   });
 });

--- a/front/lib/utils/router.ts
+++ b/front/lib/utils/router.ts
@@ -8,14 +8,28 @@ export const setQueryParam = (
   const q = router.query;
   q[key] = value;
 
-  void router.push(
-    {
-      pathname: router.pathname,
-      query: q,
-    },
-    undefined,
-    { shallow: true }
-  );
+  // Preserve the hash when updating query params
+  const hash = window.location.hash;
+
+  void router
+    .push(
+      {
+        pathname: router.pathname,
+        query: q,
+      },
+      undefined,
+      { shallow: true }
+    )
+    .then(() => {
+      // Restore hash after router.push (Next.js doesn't preserve it)
+      if (hash && window.location.hash !== hash) {
+        window.history.replaceState(
+          null,
+          "",
+          `${window.location.pathname}${window.location.search}${hash}`
+        );
+      }
+    });
 };
 
 export const parseQueryString = (url: string) => {


### PR DESCRIPTION
## Description

I had a bug when we were redirecting it didn't preserves the hash. 

In the project view, in the knowledge, when I'm changing the query params, the hash was not kept, hence it moved to another tab. It seems a next "bug" https://github.com/vercel/next.js/issues/18601


## Tests

Locally, it works for the knowledge tab in projects.


## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
