### PR TITLE
[Front] refactor(skills): rename extending to based on + improve UI

### DIFF
--- a/front/components/skill_builder/SkillBuilder.tsx
+++ b/front/components/skill_builder/SkillBuilder.tsx
@@ -170,7 +170,7 @@ export default function SkillBuilder({
                       Create new skill
                     </h2>
                     <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-                      Create a package of instructions, tools and knowledge that
+                      Create a package of instructions and tools that
                       agents can share.
                     </p>
                   </div>

--- a/front/components/skill_builder/SkillBuilder.tsx
+++ b/front/components/skill_builder/SkillBuilder.tsx
@@ -150,7 +150,7 @@ export default function SkillBuilder({
               className="mx-4"
               title={
                 (skill ? `Edit skill ${skill.name}` : "Create new skill") +
-                (extendedSkill ? ` - extending ${extendedSkill.name}` : "")
+                (extendedSkill ? ` - based on ${extendedSkill.name}` : "")
               }
               rightActions={
                 <Button
@@ -164,15 +164,17 @@ export default function SkillBuilder({
 
             <ScrollArea className="flex-1">
               <div className="mx-auto space-y-10 p-4 2xl:max-w-5xl">
-                <div>
-                  <h2 className="heading-lg text-foreground dark:text-foreground-night">
-                    Create new skill
-                  </h2>
-                  <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-                    Create a package of instructions, tools and knowledge that
-                    agents can share.
-                  </p>
-                </div>
+                {!extendedSkill && (
+                  <div>
+                    <h2 className="heading-lg text-foreground dark:text-foreground-night">
+                      Create new skill
+                    </h2>
+                    <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+                      Create a package of instructions, tools and knowledge that
+                      agents can share.
+                    </p>
+                  </div>
+                )}
                 <SkillBuilderRequestedSpacesSection />
                 <SkillBuilderAgentFacingDescriptionSection />
                 <SkillBuilderInstructionsSection skill={skill} />

--- a/front/components/skill_builder/SkillBuilder.tsx
+++ b/front/components/skill_builder/SkillBuilder.tsx
@@ -170,8 +170,8 @@ export default function SkillBuilder({
                       Create new skill
                     </h2>
                     <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-                      Create a package of instructions and tools that
-                      agents can share.
+                      Create a package of instructions and tools that agents can
+                      share.
                     </p>
                   </div>
                 )}

--- a/front/components/skills/SkillDetailsSheet.tsx
+++ b/front/components/skills/SkillDetailsSheet.tsx
@@ -2,6 +2,7 @@ import {
   ArrowPathIcon,
   Button,
   ContentMessage,
+  Icon,
   InformationCircleIcon,
   Sheet,
   SheetContainer,
@@ -158,9 +159,18 @@ const DescriptionSection = ({
           {skill.name}
         </h2>
         {skill.relations.extendedSkill && (
-          <p className="text-base text-muted-foreground dark:text-muted-foreground-night">
-            Extends {skill.relations.extendedSkill.name}
-          </p>
+          <div className="flex items-center gap-1 text-base">
+            <p className="text-muted-foreground dark:text-muted-foreground-night">
+              Based on
+            </p>
+            <Icon
+              visual={getSkillIcon(skill.relations.extendedSkill.icon)}
+              size="xs"
+            />
+            <p className="text-foreground dark:text-foreground-night">
+              {skill.relations.extendedSkill.name}
+            </p>
+          </div>
         )}
 
         {editedDate && (


### PR DESCRIPTION
First step to address https://github.com/dust-tt/tasks/issues/5778#issuecomment-3723799892

Change requested in skill builder would require BarHeader sparkle component to support subtitle with custom react component

## Description




- Rename "extends" to "based on" for extended skills in UI
- Hide "Create new skill" header when extending a skill (title bar already shows context)
- Add icon next to extended skill name in details sheet

## Tests

Manual.
<img width="1078" height="496" alt="image" src="https://github.com/user-attachments/assets/873a7b1f-eca7-46e5-91af-8a91805b6964" />

## Risk

Low.

## Deploy Plan

Deploy front.