### PR TITLE
fix(dust-hive): use -n flag for temporal namespace create command

### DIFF
--- a/x/henry/dust-hive/src/lib/init.ts
+++ b/x/henry/dust-hive/src/lib/init.ts
@@ -485,7 +485,7 @@ export async function createTemporalNamespaces(env: Environment): Promise<void> 
   const namespaces = getTemporalNamespaces(env.name);
 
   for (const ns of namespaces) {
-    const proc = Bun.spawn(["temporal", "operator", "namespace", "create", ns], {
+    const proc = Bun.spawn(["temporal", "operator", "namespace", "create", "-n", ns], {
       stdout: "pipe",
       stderr: "pipe",
     });


### PR DESCRIPTION
## Description

Fixes compatibility with temporal CLI 0.12.0 which changed the syntax for namespace creation.

The `temporal operator namespace create` command now requires the namespace to be passed with the `-n` flag instead of as a positional argument. Without this fix, users with temporal 0.12.0+ see this error when running `dust-hive warm`:

```
level=ERROR msg="namespace was provided as both an argument (dust-hive-xxx) and a flag (-n dust-hive-xxx); please specify namespace only with -n"
```

## Tests

Tested manually with temporal CLI 0.12.0.

## Risk

Low - this is a simple syntax change that maintains backwards compatibility with the expected behavior.

## Deploy Plan

N/A - dust-hive is a local development tool.