### PR TITLE
Implements agent mentions rejections in Space's conversations.

### DIFF
--- a/front/components/assistant/conversation/MentionInvalid.tsx
+++ b/front/components/assistant/conversation/MentionInvalid.tsx
@@ -1,0 +1,112 @@
+import {
+  Button,
+  ContentMessage,
+  ExclamationCircleIcon,
+  Icon,
+  XMarkIcon,
+} from "@dust-tt/sparkle";
+import { useMemo, useState } from "react";
+
+import type { VirtuosoMessage } from "@app/components/assistant/conversation/types";
+import { useUser } from "@app/lib/swr/user";
+import type {
+  LightWorkspaceType,
+  RichMentionWithStatus,
+  UserType,
+} from "@app/types";
+
+interface MentionInvalidProps {
+  triggeringUser: UserType | null;
+  owner: LightWorkspaceType;
+  mention: Extract<
+    RichMentionWithStatus,
+    {
+      status:
+        | "user_restricted_by_conversation_access"
+        | "agent_restricted_by_space_usage";
+    }
+  >;
+  conversationId: string;
+  message: VirtuosoMessage;
+}
+
+export function MentionInvalid({
+  triggeringUser,
+  mention,
+}: MentionInvalidProps) {
+  const { user } = useUser();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const isTriggeredByCurrentUser = useMemo(
+    () => !triggeringUser || triggeringUser.sId === user?.sId,
+    [triggeringUser, user?.sId]
+  );
+
+  const handleDismiss = async () => {
+    setIsSubmitting(true);
+    try {
+      //TODO: Implement dismiss action
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (!isTriggeredByCurrentUser) {
+    return null;
+  }
+
+  switch (mention.status) {
+    case "user_restricted_by_conversation_access": {
+      // Show warning message without approve/reject buttons
+      return (
+        <ContentMessage variant="warning" className="my-3 w-full max-w-full">
+          <div className="flex items-center gap-2">
+            <Icon visual={ExclamationCircleIcon} className="hidden sm:block" />
+            <div>
+              <span className="font-semibold">{mention.label}</span> doesn't
+              have access to this conversation's spaces and won't be able to
+              view it nor be invited.
+            </div>
+            <div className="ml-auto">
+              <Button
+                label="Dismiss"
+                variant="outline"
+                size="xs"
+                icon={XMarkIcon}
+                disabled={isSubmitting}
+                onClick={handleDismiss}
+              />
+            </div>
+          </div>
+        </ContentMessage>
+      );
+      break;
+    }
+    case "agent_restricted_by_space_usage": {
+      return (
+        <ContentMessage variant="warning" className="my-3 w-full max-w-full">
+          <div className="flex items-center gap-2">
+            <Icon visual={ExclamationCircleIcon} className="hidden sm:block" />
+            <div>
+              <span className="font-semibold">{mention.label}</span> can't be
+              invoked as it is configured to use at least one space that the
+              conversation cannot use. Projects conversations cannot use private
+              spaces.
+            </div>
+            <div className="ml-auto">
+              <Button
+                label="Dismiss"
+                variant="outline"
+                size="xs"
+                icon={XMarkIcon}
+                disabled={isSubmitting}
+                onClick={handleDismiss}
+              />
+            </div>
+          </div>
+        </ContentMessage>
+      );
+      break;
+    }
+  }
+}

--- a/front/components/assistant/conversation/MentionValidationRequired.tsx
+++ b/front/components/assistant/conversation/MentionValidationRequired.tsx
@@ -2,7 +2,6 @@ import {
   Button,
   CheckIcon,
   ContentMessage,
-  ExclamationCircleIcon,
   Icon,
   InformationCircleIcon,
   XMarkIcon,
@@ -22,7 +21,12 @@ import type {
 interface MentionValidationRequired {
   triggeringUser: UserType | null;
   owner: LightWorkspaceType;
-  pendingMention: RichMentionWithStatus;
+  mention: Extract<
+    RichMentionWithStatus,
+    {
+      status: "pending";
+    }
+  >;
   conversationId: string;
   message: VirtuosoMessage;
 }
@@ -30,7 +34,7 @@ interface MentionValidationRequired {
 export function MentionValidationRequired({
   triggeringUser,
   owner,
-  pendingMention,
+  mention,
   conversationId,
   message,
 }: MentionValidationRequired) {
@@ -50,7 +54,7 @@ export function MentionValidationRequired({
   const handleReject = async () => {
     setIsSubmitting(true);
     try {
-      await validateMention(pendingMention, "rejected");
+      await validateMention(mention, "rejected");
     } finally {
       setIsSubmitting(false);
     }
@@ -59,7 +63,7 @@ export function MentionValidationRequired({
   const handleApprove = async () => {
     setIsSubmitting(true);
     try {
-      await validateMention(pendingMention, "approved");
+      await validateMention(mention, "approved");
     } finally {
       setIsSubmitting(false);
     }
@@ -67,37 +71,6 @@ export function MentionValidationRequired({
 
   if (!isTriggeredByCurrentUser) {
     return null;
-  }
-
-  // Check if this is a user mention without conversation access
-  const cannotAccessConversation =
-    pendingMention.type === "user" &&
-    pendingMention.userConversationAccessStatus !== "accessible";
-
-  if (cannotAccessConversation) {
-    // Show warning message without approve/reject buttons
-    return (
-      <ContentMessage variant="warning" className="my-3 w-full max-w-full">
-        <div className="flex items-center gap-2">
-          <Icon visual={ExclamationCircleIcon} className="hidden sm:block" />
-          <div>
-            <span className="font-semibold">{pendingMention.label}</span>{" "}
-            doesn't have access to this conversation's spaces and won't be able
-            to view it nor be invited.
-          </div>
-          <div className="ml-auto">
-            <Button
-              label="Dismiss"
-              variant="outline"
-              size="xs"
-              icon={XMarkIcon}
-              disabled={isSubmitting}
-              onClick={handleReject}
-            />
-          </div>
-        </div>
-      </ContentMessage>
-    );
   }
 
   // Original behavior for users who can access
@@ -111,15 +84,14 @@ export function MentionValidationRequired({
               <span className="font-semibold">
                 @{message.configuration.name}
               </span>{" "}
-              mentioned{" "}
-              <span className="font-semibold">{pendingMention.label}</span>. Do
-              you want to invite them? They'll see the full history and be able
-              to reply.
+              mentioned <span className="font-semibold">{mention.label}</span>.
+              Do you want to invite them? They'll see the full history and be
+              able to reply.
             </>
           ) : (
             <>
-              Invite <b>{pendingMention.label}</b> to this conversation? They'll
-              see the full history and be able to reply.
+              Invite <b>{mention.label}</b> to this conversation? They'll see
+              the full history and be able to reply.
             </>
           )}
         </div>

--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -5,6 +5,7 @@ import { AgentMessage } from "@app/components/assistant/conversation/AgentMessag
 import { AttachmentCitation } from "@app/components/assistant/conversation/attachment/AttachmentCitation";
 import { contentFragmentToAttachmentCitation } from "@app/components/assistant/conversation/attachment/utils";
 import type { FeedbackSelectorProps } from "@app/components/assistant/conversation/FeedbackSelector";
+import { MentionInvalid } from "@app/components/assistant/conversation/MentionInvalid";
 import { MentionValidationRequired } from "@app/components/assistant/conversation/MentionValidationRequired";
 import { MessageDateIndicator } from "@app/components/assistant/conversation/MessageDateIndicator";
 import type {
@@ -167,18 +168,34 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
             />
           )}
           {data.visibility !== "deleted" &&
-            data.richMentions
-              .filter((mention) => mention.status === "pending")
-              .map((mention) => (
-                <MentionValidationRequired
-                  key={mention.id}
-                  pendingMention={mention}
-                  message={data}
-                  owner={context.owner}
-                  triggeringUser={triggeringUser}
-                  conversationId={context.conversationId}
-                />
-              ))}
+            data.richMentions.map((mention) => {
+              if (mention.status === "pending") {
+                return (
+                  <MentionValidationRequired
+                    key={mention.id}
+                    mention={mention}
+                    message={data}
+                    owner={context.owner}
+                    triggeringUser={triggeringUser}
+                    conversationId={context.conversationId}
+                  />
+                );
+              } else if (
+                mention.status === "user_restricted_by_conversation_access" ||
+                mention.status === "agent_restricted_by_space_usage"
+              ) {
+                return (
+                  <MentionInvalid
+                    key={mention.id}
+                    mention={mention}
+                    message={data}
+                    owner={context.owner}
+                    triggeringUser={triggeringUser}
+                    conversationId={context.conversationId}
+                  />
+                );
+              }
+            })}
         </div>
       </>
     );

--- a/front/lib/api/assistant/conversation/mentions.test.ts
+++ b/front/lib/api/assistant/conversation/mentions.test.ts
@@ -12,6 +12,7 @@ vi.mock("@app/lib/api/assistant/conversation/agent_loop", () => ({
 
 import { signalAgentUsage } from "@app/lib/api/assistant/agent_usage";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import { createConversation } from "@app/lib/api/assistant/conversation";
 import { runAgentLoopWorkflow } from "@app/lib/api/assistant/conversation/agent_loop";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import {
@@ -30,6 +31,8 @@ import {
 } from "@app/lib/models/agent/conversation";
 import { TriggerModel } from "@app/lib/models/agent/triggers/triggers";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
 import {
   generateRandomModelSId,
   getResourceIdFromSId,
@@ -38,6 +41,7 @@ import { withTransaction } from "@app/lib/utils/sql_utils";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { GroupSpaceFactory } from "@app/tests/utils/GroupSpaceFactory";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
@@ -52,7 +56,10 @@ import type {
   UserMessageContext,
   WorkspaceType,
 } from "@app/types";
-import { isRichUserMention } from "@app/types/assistant/mentions";
+import {
+  isRichAgentMention,
+  isRichUserMention,
+} from "@app/types/assistant/mentions";
 
 describe("createAgentMessages", () => {
   let workspace: WorkspaceType;
@@ -104,7 +111,7 @@ describe("createAgentMessages", () => {
       } satisfies AgentMention,
     ];
 
-    const result = await createAgentMessages(auth, {
+    const { agentMessages, richMentions } = await createAgentMessages(auth, {
       conversation,
       metadata: {
         type: "create",
@@ -116,10 +123,22 @@ describe("createAgentMessages", () => {
       },
     });
 
-    expect(result).toHaveLength(1);
-    expect(result[0].configuration.sId).toBe(agentConfig1.sId);
-    expect(result[0].status).toBe("created");
-    expect(result[0].skipToolsValidation).toBe(false);
+    expect(agentMessages).toHaveLength(1);
+    expect(agentMessages[0].configuration.sId).toBe(agentConfig1.sId);
+    expect(agentMessages[0].status).toBe("created");
+    expect(agentMessages[0].skipToolsValidation).toBe(false);
+
+    // Verify richMentions are returned correctly
+    expect(richMentions).toHaveLength(1);
+    expect(isRichAgentMention(richMentions[0])).toBe(true);
+    if (isRichAgentMention(richMentions[0])) {
+      expect(richMentions[0].id).toBe(agentConfig1.sId);
+      expect(richMentions[0].type).toBe("agent");
+      expect(richMentions[0].label).toBe(agentConfig1.name);
+      expect(richMentions[0].status).toBe("approved");
+      expect(richMentions[0].pictureUrl).toBe(agentConfig1.pictureUrl);
+      expect(richMentions[0].description).toBe(agentConfig1.description);
+    }
 
     // Verify database records were created
     const mentionInDb = await MentionModel.findOne({
@@ -132,14 +151,14 @@ describe("createAgentMessages", () => {
     expect(mentionInDb).not.toBeNull();
 
     const { agentMessage: agentMessageInDb, message: messageInDb } =
-      await ConversationFactory.getMessage(auth, result[0].id);
+      await ConversationFactory.getMessage(auth, agentMessages[0].id);
     expect(agentMessageInDb).not.toBeNull();
     expect(agentMessageInDb?.status).toBe("created");
 
     expect(messageInDb).not.toBeNull();
     expect(messageInDb?.rank).toBe(1);
     expect(messageInDb?.parentId).toBe(messageRow.id);
-    expect(messageInDb?.agentMessageId).toBe(result[0].agentMessageId);
+    expect(messageInDb?.agentMessageId).toBe(agentMessages[0].agentMessageId);
     expect(messageInDb?.workspaceId).toBe(workspace.id);
     expect(messageInDb?.visibility).toBe("visible");
     expect(messageInDb?.version).toBe(0);
@@ -171,7 +190,7 @@ describe("createAgentMessages", () => {
       } as AgentMention,
     ];
 
-    const result = await createAgentMessages(auth, {
+    const { agentMessages, richMentions } = await createAgentMessages(auth, {
       conversation,
       metadata: {
         type: "create",
@@ -183,9 +202,26 @@ describe("createAgentMessages", () => {
       },
     });
 
-    expect(result).toHaveLength(2);
-    expect(result[0].configuration.sId).toBe(agentConfig1.sId);
-    expect(result[1].configuration.sId).toBe(agentConfig2.sId);
+    expect(agentMessages).toHaveLength(2);
+    expect(agentMessages[0].configuration.sId).toBe(agentConfig1.sId);
+    expect(agentMessages[1].configuration.sId).toBe(agentConfig2.sId);
+
+    // Verify richMentions are returned correctly
+    expect(richMentions).toHaveLength(2);
+    const agent1Mention = richMentions.find((m) => m.id === agentConfig1.sId);
+    const agent2Mention = richMentions.find((m) => m.id === agentConfig2.sId);
+    expect(agent1Mention).toBeDefined();
+    expect(agent2Mention).toBeDefined();
+    if (agent1Mention && isRichAgentMention(agent1Mention)) {
+      expect(agent1Mention.type).toBe("agent");
+      expect(agent1Mention.label).toBe(agentConfig1.name);
+      expect(agent1Mention.status).toBe("approved");
+    }
+    if (agent2Mention && isRichAgentMention(agent2Mention)) {
+      expect(agent2Mention.type).toBe("agent");
+      expect(agent2Mention.label).toBe(agentConfig2.name);
+      expect(agent2Mention.status).toBe("approved");
+    }
 
     // Verify both mentions were created
     const mentionsInDb = await MentionModel.findAll({
@@ -226,7 +262,7 @@ describe("createAgentMessages", () => {
     ];
 
     // Only pass agentConfig1, not the non-existent one
-    const result = await createAgentMessages(auth, {
+    const { agentMessages, richMentions } = await createAgentMessages(auth, {
       conversation,
       metadata: {
         type: "create",
@@ -239,8 +275,15 @@ describe("createAgentMessages", () => {
     });
 
     // Should only create one agent message for the valid configuration
-    expect(result).toHaveLength(1);
-    expect(result[0].configuration.sId).toBe(agentConfig1.sId);
+    expect(agentMessages).toHaveLength(1);
+    expect(agentMessages[0].configuration.sId).toBe(agentConfig1.sId);
+
+    // Verify richMentions only contains the valid agent mention
+    expect(richMentions).toHaveLength(1);
+    if (isRichAgentMention(richMentions[0])) {
+      expect(richMentions[0].id).toBe(agentConfig1.sId);
+      expect(richMentions[0].status).toBe("approved");
+    }
 
     // Verify signalAgentUsage was called only for the valid configuration
     expect(signalAgentUsage).toHaveBeenCalledTimes(1);
@@ -253,7 +296,7 @@ describe("createAgentMessages", () => {
     expect(runAgentLoopWorkflow).toHaveBeenCalledTimes(1);
     expect(runAgentLoopWorkflow).toHaveBeenCalledWith({
       auth,
-      agentMessages: result,
+      agentMessages,
       conversation,
       userMessage,
     });
@@ -267,7 +310,7 @@ describe("createAgentMessages", () => {
       content: "Hello",
     });
 
-    const result = await createAgentMessages(auth, {
+    const { agentMessages, richMentions } = await createAgentMessages(auth, {
       conversation,
       metadata: {
         type: "create",
@@ -279,7 +322,10 @@ describe("createAgentMessages", () => {
       },
     });
 
-    expect(result).toHaveLength(0);
+    expect(agentMessages).toHaveLength(0);
+
+    // Verify richMentions is empty when no agent mentions are provided
+    expect(richMentions).toHaveLength(0);
 
     // Verify signalAgentUsage was not called when no agent mentions are provided
     expect(signalAgentUsage).not.toHaveBeenCalled();
@@ -302,7 +348,7 @@ describe("createAgentMessages", () => {
       } as AgentMention,
     ];
 
-    const result = await createAgentMessages(auth, {
+    const { agentMessages, richMentions } = await createAgentMessages(auth, {
       conversation,
       metadata: {
         type: "create",
@@ -314,8 +360,15 @@ describe("createAgentMessages", () => {
       },
     });
 
-    expect(result).toHaveLength(1);
-    expect(result[0].skipToolsValidation).toBe(true);
+    expect(agentMessages).toHaveLength(1);
+    expect(agentMessages[0].skipToolsValidation).toBe(true);
+
+    // Verify richMentions are returned correctly
+    expect(richMentions).toHaveLength(1);
+    if (isRichAgentMention(richMentions[0])) {
+      expect(richMentions[0].id).toBe(agentConfig1.sId);
+      expect(richMentions[0].status).toBe("approved");
+    }
 
     // Verify signalAgentUsage was called with correct arguments
     expect(signalAgentUsage).toHaveBeenCalledTimes(1);
@@ -328,7 +381,7 @@ describe("createAgentMessages", () => {
     expect(runAgentLoopWorkflow).toHaveBeenCalledTimes(1);
     expect(runAgentLoopWorkflow).toHaveBeenCalledWith({
       auth,
-      agentMessages: result,
+      agentMessages,
       conversation,
       userMessage,
     });
@@ -353,7 +406,7 @@ describe("createAgentMessages", () => {
       } as AgentMention,
     ];
 
-    const result = await createAgentMessages(auth, {
+    const { agentMessages, richMentions } = await createAgentMessages(auth, {
       conversation,
       metadata: {
         type: "create",
@@ -365,8 +418,15 @@ describe("createAgentMessages", () => {
       },
     });
 
-    expect(result).toHaveLength(1);
-    expect(result[0].parentAgentMessageId).toBe(originMessageId);
+    expect(agentMessages).toHaveLength(1);
+    expect(agentMessages[0].parentAgentMessageId).toBe(originMessageId);
+
+    // Verify richMentions are returned correctly
+    expect(richMentions).toHaveLength(1);
+    if (isRichAgentMention(richMentions[0])) {
+      expect(richMentions[0].id).toBe(agentConfig1.sId);
+      expect(richMentions[0].status).toBe("approved");
+    }
 
     // Verify signalAgentUsage was called with correct arguments
     expect(signalAgentUsage).toHaveBeenCalledTimes(1);
@@ -379,7 +439,7 @@ describe("createAgentMessages", () => {
     expect(runAgentLoopWorkflow).toHaveBeenCalledTimes(1);
     expect(runAgentLoopWorkflow).toHaveBeenCalledWith({
       auth,
-      agentMessages: result,
+      agentMessages,
       conversation,
       userMessage,
     });
@@ -400,7 +460,7 @@ describe("createAgentMessages", () => {
       } as AgentMention,
     ];
 
-    const result = await createAgentMessages(auth, {
+    const { agentMessages, richMentions } = await createAgentMessages(auth, {
       conversation,
       metadata: {
         type: "create",
@@ -412,8 +472,15 @@ describe("createAgentMessages", () => {
       },
     });
 
-    expect(result).toHaveLength(1);
-    expect(result[0].parentAgentMessageId).toBeNull();
+    expect(agentMessages).toHaveLength(1);
+    expect(agentMessages[0].parentAgentMessageId).toBeNull();
+
+    // Verify richMentions are returned correctly
+    expect(richMentions).toHaveLength(1);
+    if (isRichAgentMention(richMentions[0])) {
+      expect(richMentions[0].id).toBe(agentConfig1.sId);
+      expect(richMentions[0].status).toBe("approved");
+    }
 
     // Verify signalAgentUsage was called with correct arguments
     expect(signalAgentUsage).toHaveBeenCalledTimes(1);
@@ -426,7 +493,7 @@ describe("createAgentMessages", () => {
     expect(runAgentLoopWorkflow).toHaveBeenCalledTimes(1);
     expect(runAgentLoopWorkflow).toHaveBeenCalledWith({
       auth,
-      agentMessages: result,
+      agentMessages,
       conversation,
       userMessage,
     });
@@ -451,7 +518,7 @@ describe("createAgentMessages", () => {
 
     const nextMessageRank = 10;
 
-    const result = await createAgentMessages(auth, {
+    const { agentMessages, richMentions } = await createAgentMessages(auth, {
       conversation,
       metadata: {
         type: "create",
@@ -463,10 +530,23 @@ describe("createAgentMessages", () => {
       },
     });
 
-    expect(result).toHaveLength(2);
+    expect(agentMessages).toHaveLength(2);
     // Note: The function increments nextMessageRank internally, so ranks should be 10 and 11
-    expect(result[0].rank).toBe(nextMessageRank);
-    expect(result[1].rank).toBe(nextMessageRank + 1);
+    expect(agentMessages[0].rank).toBe(nextMessageRank);
+    expect(agentMessages[1].rank).toBe(nextMessageRank + 1);
+
+    // Verify richMentions are returned correctly
+    expect(richMentions).toHaveLength(2);
+    const agent1Mention = richMentions.find((m) => m.id === agentConfig1.sId);
+    const agent2Mention = richMentions.find((m) => m.id === agentConfig2.sId);
+    expect(agent1Mention).toBeDefined();
+    expect(agent2Mention).toBeDefined();
+    if (agent1Mention && isRichAgentMention(agent1Mention)) {
+      expect(agent1Mention.status).toBe("approved");
+    }
+    if (agent2Mention && isRichAgentMention(agent2Mention)) {
+      expect(agent2Mention.status).toBe("approved");
+    }
 
     // Verify signalAgentUsage was called for each agent configuration
     expect(signalAgentUsage).toHaveBeenCalledTimes(2);
@@ -483,7 +563,7 @@ describe("createAgentMessages", () => {
     expect(runAgentLoopWorkflow).toHaveBeenCalledTimes(1);
     expect(runAgentLoopWorkflow).toHaveBeenCalledWith({
       auth,
-      agentMessages: result,
+      agentMessages,
       conversation,
       userMessage,
     });
@@ -586,20 +666,29 @@ describe("createAgentMessages", () => {
     expect(agentConfigWithSpaces?.requestedSpaceIds).toContain(space2.sId);
 
     // Call createAgentMessages
-    const agentMessages = await withTransaction(async (transaction) => {
-      return createAgentMessages(auth, {
-        conversation: testConversation,
-        metadata: {
-          type: "create",
-          mentions,
-          agentConfigurations: [agentConfigWithSpaces!],
-          skipToolsValidation: false,
-          nextMessageRank: 1,
-          userMessage,
-        },
-        transaction,
-      });
-    });
+    const { agentMessages, richMentions } = await withTransaction(
+      async (transaction) => {
+        return createAgentMessages(auth, {
+          conversation: testConversation,
+          metadata: {
+            type: "create",
+            mentions,
+            agentConfigurations: [agentConfigWithSpaces!],
+            skipToolsValidation: false,
+            nextMessageRank: 1,
+            userMessage,
+          },
+          transaction,
+        });
+      }
+    );
+
+    // Verify richMentions are returned correctly
+    expect(richMentions).toHaveLength(1);
+    if (isRichAgentMention(richMentions[0])) {
+      expect(richMentions[0].id).toBe(agentConfig.sId);
+      expect(richMentions[0].status).toBe("approved");
+    }
 
     // Verify runAgentLoopWorkflow was called with correct arguments
     expect(runAgentLoopWorkflow).toHaveBeenCalledTimes(1);
@@ -715,20 +804,29 @@ describe("createAgentMessages", () => {
     expect(agentConfigWithSpaces?.requestedSpaceIds).toContain(space2.sId);
 
     // Call createAgentMessages
-    const agentMessages = await withTransaction(async (transaction) => {
-      return createAgentMessages(auth, {
-        conversation: testConversation,
-        metadata: {
-          type: "create",
-          mentions,
-          agentConfigurations: [agentConfigWithSpaces!],
-          skipToolsValidation: false,
-          nextMessageRank: 1,
-          userMessage,
-        },
-        transaction,
-      });
-    });
+    const { agentMessages, richMentions } = await withTransaction(
+      async (transaction) => {
+        return createAgentMessages(auth, {
+          conversation: testConversation,
+          metadata: {
+            type: "create",
+            mentions,
+            agentConfigurations: [agentConfigWithSpaces!],
+            skipToolsValidation: false,
+            nextMessageRank: 1,
+            userMessage,
+          },
+          transaction,
+        });
+      }
+    );
+
+    // Verify richMentions are returned correctly
+    expect(richMentions).toHaveLength(1);
+    if (isRichAgentMention(richMentions[0])) {
+      expect(richMentions[0].id).toBe(agentConfig.sId);
+      expect(richMentions[0].status).toBe("approved");
+    }
 
     // Verify runAgentLoopWorkflow was called with correct arguments
     expect(runAgentLoopWorkflow).toHaveBeenCalledTimes(1);
@@ -844,20 +942,29 @@ describe("createAgentMessages", () => {
     expect(agentConfigWithSpaces?.requestedSpaceIds).toContain(space2.sId);
 
     // Call createAgentMessages
-    const agentMessages = await withTransaction(async (transaction) => {
-      return createAgentMessages(auth, {
-        conversation: testConversation,
-        metadata: {
-          type: "create",
-          mentions,
-          agentConfigurations: [agentConfigWithSpaces!],
-          skipToolsValidation: false,
-          nextMessageRank: 1,
-          userMessage,
-        },
-        transaction,
-      });
-    });
+    const { agentMessages, richMentions } = await withTransaction(
+      async (transaction) => {
+        return createAgentMessages(auth, {
+          conversation: testConversation,
+          metadata: {
+            type: "create",
+            mentions,
+            agentConfigurations: [agentConfigWithSpaces!],
+            skipToolsValidation: false,
+            nextMessageRank: 1,
+            userMessage,
+          },
+          transaction,
+        });
+      }
+    );
+
+    // Verify richMentions are returned correctly
+    expect(richMentions).toHaveLength(1);
+    if (isRichAgentMention(richMentions[0])) {
+      expect(richMentions[0].id).toBe(agentConfig.sId);
+      expect(richMentions[0].status).toBe("approved");
+    }
 
     // Verify runAgentLoopWorkflow was called with correct arguments
     expect(runAgentLoopWorkflow).toHaveBeenCalledTimes(1);
@@ -881,6 +988,407 @@ describe("createAgentMessages", () => {
     expect(requestedSpaceIdsAfter).toHaveLength(2);
     expect(requestedSpaceIdsAfter).toContain(space1.sId);
     expect(requestedSpaceIdsAfter).toContain(space2.sId);
+  });
+
+  describe("conversations that belong to a space", () => {
+    it("should create agent messages when agent only uses the conversation's space", async () => {
+      // Create a space for the conversation
+      const conversationSpace = await SpaceFactory.regular(workspace);
+      const user = auth.getNonNullableUser();
+      const adminAuth = await Authenticator.internalAdminForWorkspace(
+        workspace.sId
+      );
+      // Add user to the space so they can create conversations in it
+      const addMembersRes = await conversationSpace.addMembers(adminAuth, {
+        userIds: [user.sId],
+      });
+      expect(addMembersRes.isOk()).toBe(true);
+
+      // Create a fresh authenticator after adding user to space to refresh permissions
+      const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        user.sId,
+        workspace.sId
+      );
+
+      // Refresh the space to get updated permissions
+      const refreshedConversationSpace = await SpaceResource.fetchById(
+        userAuth,
+        conversationSpace.sId
+      );
+      expect(refreshedConversationSpace).not.toBeNull();
+
+      // Create conversation in the space
+      const spaceConversation = await createConversation(userAuth, {
+        title: "Space Conversation",
+        visibility: "unlisted",
+        spaceId: refreshedConversationSpace!.id,
+      });
+
+      // Create agent configuration that only uses the conversation's space
+      const agentConfig = await AgentConfigurationFactory.createTestAgent(
+        auth,
+        {
+          name: "Space Agent",
+        }
+      );
+
+      const spaceModelId = getResourceIdFromSId(conversationSpace.sId);
+      expect(spaceModelId).not.toBeNull();
+
+      await AgentConfigurationModel.update(
+        {
+          requestedSpaceIds: [spaceModelId!],
+        },
+        {
+          where: {
+            workspaceId: workspace.id,
+            sId: agentConfig.sId,
+            version: agentConfig.version,
+          },
+        }
+      );
+
+      const updatedAgentConfig = await getAgentConfiguration(auth, {
+        agentId: agentConfig.sId,
+        agentVersion: agentConfig.version,
+        variant: "light",
+      });
+      expect(updatedAgentConfig).not.toBeNull();
+
+      const { userMessage } = await ConversationFactory.createUserMessage({
+        auth,
+        workspace,
+        conversation: spaceConversation,
+        content: `Hello @${agentConfig.name}`,
+      });
+
+      const mentions: MentionType[] = [
+        {
+          configurationId: agentConfig.sId,
+        } satisfies AgentMention,
+      ];
+
+      const { agentMessages, richMentions } = await createAgentMessages(auth, {
+        conversation: spaceConversation,
+        metadata: {
+          type: "create",
+          mentions,
+          agentConfigurations: [updatedAgentConfig!],
+          skipToolsValidation: false,
+          nextMessageRank: 1,
+          userMessage,
+        },
+      });
+
+      // Should create agent message successfully
+      expect(agentMessages).toHaveLength(1);
+      expect(agentMessages[0].configuration.sId).toBe(agentConfig.sId);
+
+      // Verify richMentions are returned correctly
+      expect(richMentions).toHaveLength(1);
+      if (isRichAgentMention(richMentions[0])) {
+        expect(richMentions[0].id).toBe(agentConfig.sId);
+        expect(richMentions[0].status).toBe("approved");
+      }
+
+      // Verify mention was created with approved status
+      const mentionInDb = await MentionModel.findOne({
+        where: {
+          workspaceId: workspace.id,
+          messageId: userMessage.id,
+          agentConfigurationId: agentConfig.sId,
+        },
+      });
+      expect(mentionInDb).not.toBeNull();
+      expect(mentionInDb?.status).toBe("approved");
+    });
+
+    it("should reject agent mentions when agent uses restricted spaces other than conversation's space", async () => {
+      // Create a space for the conversation
+      const conversationSpace = await SpaceFactory.regular(workspace);
+      const user = auth.getNonNullableUser();
+      const adminAuth = await Authenticator.internalAdminForWorkspace(
+        workspace.sId
+      );
+      await conversationSpace.addMembers(adminAuth, {
+        userIds: [user.sId],
+      });
+
+      // Create a fresh authenticator after adding user to space to refresh permissions
+      const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        user.sId,
+        workspace.sId
+      );
+
+      // Create a restricted space (regular space without global group)
+      // SpaceFactory.regular creates a space with a regular group, which is restricted by default
+      const restrictedSpace = await SpaceFactory.regular(workspace);
+      // Refresh to get updated groups
+      const refreshedRestrictedSpace = await SpaceResource.fetchById(
+        adminAuth,
+        restrictedSpace.sId
+      );
+      expect(refreshedRestrictedSpace).not.toBeNull();
+      // Regular spaces created by SpaceFactory.regular are restricted (no global group)
+      expect(refreshedRestrictedSpace?.isOpen()).toBe(false);
+
+      // Refresh the conversation space to get updated permissions
+      const refreshedConversationSpace = await SpaceResource.fetchById(
+        userAuth,
+        conversationSpace.sId
+      );
+      expect(refreshedConversationSpace).not.toBeNull();
+
+      // Create conversation in the conversationSpace
+      const spaceConversation = await createConversation(userAuth, {
+        title: "Space Conversation",
+        visibility: "unlisted",
+        spaceId: conversationSpace.id,
+      });
+
+      // Create agent configuration that uses both the conversation's space and a restricted space
+      const agentConfig = await AgentConfigurationFactory.createTestAgent(
+        auth,
+        {
+          name: "Restricted Space Agent",
+        }
+      );
+
+      const conversationSpaceModelId = getResourceIdFromSId(
+        conversationSpace.sId
+      );
+      const restrictedSpaceModelId = getResourceIdFromSId(
+        refreshedRestrictedSpace!.sId
+      );
+      expect(conversationSpaceModelId).not.toBeNull();
+      expect(restrictedSpaceModelId).not.toBeNull();
+
+      await AgentConfigurationModel.update(
+        {
+          requestedSpaceIds: [
+            conversationSpaceModelId!,
+            restrictedSpaceModelId!,
+          ],
+        },
+        {
+          where: {
+            workspaceId: workspace.id,
+            sId: agentConfig.sId,
+            version: agentConfig.version,
+          },
+        }
+      );
+
+      // Manually construct the updated agent config with requestedSpaceIds as sIds
+      // We can't use getAgentConfiguration because it filters by space access,
+      // and the agent now has restricted space requirements
+      const updatedAgentConfig: LightAgentConfigurationType = {
+        ...agentConfig,
+        requestedSpaceIds: [
+          conversationSpace.sId,
+          refreshedRestrictedSpace!.sId,
+        ],
+      };
+
+      const { userMessage } = await ConversationFactory.createUserMessage({
+        auth: userAuth,
+        workspace,
+        conversation: spaceConversation,
+        content: `Hello @${agentConfig.name}`,
+      });
+
+      const mentions: MentionType[] = [
+        {
+          configurationId: agentConfig.sId,
+        } satisfies AgentMention,
+      ];
+
+      const { agentMessages, richMentions } = await createAgentMessages(
+        userAuth,
+        {
+          conversation: spaceConversation,
+          metadata: {
+            type: "create",
+            mentions,
+            agentConfigurations: [updatedAgentConfig],
+            skipToolsValidation: false,
+            nextMessageRank: 1,
+            userMessage,
+          },
+        }
+      );
+
+      // Should NOT create agent message because agent uses restricted space
+      expect(agentMessages).toHaveLength(0);
+
+      // Verify richMentions shows the restriction
+      expect(richMentions).toHaveLength(1);
+      if (isRichAgentMention(richMentions[0])) {
+        expect(richMentions[0].id).toBe(agentConfig.sId);
+        expect(richMentions[0].status).toBe("agent_restricted_by_space_usage");
+      }
+
+      // Verify mention was created with restricted status
+      const mentionInDb = await MentionModel.findOne({
+        where: {
+          workspaceId: workspace.id,
+          messageId: userMessage.id,
+          agentConfigurationId: agentConfig.sId,
+        },
+      });
+      expect(mentionInDb).not.toBeNull();
+      expect(mentionInDb?.status).toBe("agent_restricted_by_space_usage");
+    });
+
+    it("should allow agent mentions when agent uses open spaces other than conversation's space", async () => {
+      // Create a space for the conversation
+      const conversationSpace = await SpaceFactory.regular(workspace);
+      const user = auth.getNonNullableUser();
+      const adminAuth = await Authenticator.internalAdminForWorkspace(
+        workspace.sId
+      );
+      await conversationSpace.addMembers(adminAuth, {
+        userIds: [user.sId],
+      });
+
+      // Create a fresh authenticator after adding user to space to refresh permissions
+      const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        user.sId,
+        workspace.sId
+      );
+
+      // Create an open space (regular space with global group)
+      const openSpace = await SpaceFactory.regular(workspace);
+      // Add global group to make it open
+      const globalGroupRes =
+        await GroupResource.fetchWorkspaceGlobalGroup(adminAuth);
+      expect(globalGroupRes.isOk()).toBe(true);
+      if (!globalGroupRes.isOk()) {
+        throw new Error("Failed to fetch global group");
+      }
+      const globalGroup = globalGroupRes.value;
+
+      // Add global group directly to make it open (if not already there)
+      const existingGroupIds = openSpace.groups.map((g) => g.sId);
+      const hasGlobalGroup = existingGroupIds.includes(globalGroup.sId);
+
+      // If global group is not already there, associate it directly
+      if (!hasGlobalGroup) {
+        await GroupSpaceFactory.associate(openSpace, globalGroup);
+      }
+
+      // Refresh to get updated groups
+      const refreshedOpenSpace = await SpaceResource.fetchById(
+        adminAuth,
+        openSpace.sId
+      );
+      expect(refreshedOpenSpace).not.toBeNull();
+      expect(refreshedOpenSpace?.isOpen()).toBe(true);
+
+      // Refresh the conversation space to get updated permissions
+      const refreshedConversationSpace = await SpaceResource.fetchById(
+        userAuth,
+        conversationSpace.sId
+      );
+      expect(refreshedConversationSpace).not.toBeNull();
+
+      // Create conversation in the conversationSpace
+      const spaceConversation = await createConversation(userAuth, {
+        title: "Space Conversation",
+        visibility: "unlisted",
+        spaceId: refreshedConversationSpace!.id,
+      });
+
+      // Create agent configuration that uses both the conversation's space and an open space
+      const agentConfig = await AgentConfigurationFactory.createTestAgent(
+        userAuth,
+        {
+          name: "Open Space Agent",
+        }
+      );
+
+      const conversationSpaceModelId = getResourceIdFromSId(
+        refreshedConversationSpace!.sId
+      );
+      const openSpaceModelId = getResourceIdFromSId(refreshedOpenSpace!.sId);
+      expect(conversationSpaceModelId).not.toBeNull();
+      expect(openSpaceModelId).not.toBeNull();
+
+      await AgentConfigurationModel.update(
+        {
+          requestedSpaceIds: [conversationSpaceModelId!, openSpaceModelId!],
+        },
+        {
+          where: {
+            workspaceId: workspace.id,
+            sId: agentConfig.sId,
+            version: agentConfig.version,
+          },
+        }
+      );
+
+      // Refresh agent config to get updated requestedSpaceIds
+      const updatedAgentConfigRes = await getAgentConfiguration(userAuth, {
+        agentId: agentConfig.sId,
+        agentVersion: agentConfig.version,
+        variant: "light",
+      });
+      expect(updatedAgentConfigRes).not.toBeNull();
+      if (!updatedAgentConfigRes) {
+        throw new Error("Failed to fetch updated agent configuration");
+      }
+      const updatedAgentConfig = updatedAgentConfigRes;
+
+      const { userMessage } = await ConversationFactory.createUserMessage({
+        auth: userAuth,
+        workspace,
+        conversation: spaceConversation,
+        content: `Hello @${agentConfig.name}`,
+      });
+
+      const mentions: MentionType[] = [
+        {
+          configurationId: agentConfig.sId,
+        } satisfies AgentMention,
+      ];
+
+      const { agentMessages, richMentions } = await createAgentMessages(
+        userAuth,
+        {
+          conversation: spaceConversation,
+          metadata: {
+            type: "create",
+            mentions,
+            agentConfigurations: [updatedAgentConfig],
+            skipToolsValidation: false,
+            nextMessageRank: 1,
+            userMessage,
+          },
+        }
+      );
+
+      // Should create agent message successfully because open spaces are allowed
+      expect(agentMessages).toHaveLength(1);
+      expect(agentMessages[0].configuration.sId).toBe(agentConfig.sId);
+
+      // Verify richMentions are returned correctly
+      expect(richMentions).toHaveLength(1);
+      if (isRichAgentMention(richMentions[0])) {
+        expect(richMentions[0].id).toBe(agentConfig.sId);
+        expect(richMentions[0].status).toBe("approved");
+      }
+
+      // Verify mention was created with approved status
+      const mentionInDb = await MentionModel.findOne({
+        where: {
+          workspaceId: workspace.id,
+          messageId: userMessage.id,
+          agentConfigurationId: agentConfig.sId,
+        },
+      });
+      expect(mentionInDb).not.toBeNull();
+      expect(mentionInDb?.status).toBe("approved");
+    });
   });
 });
 
@@ -1860,6 +2368,332 @@ describe("createUserMentions", () => {
       });
       expect(mentionInDb).not.toBeNull();
       expect(mentionInDb?.status).toBe("pending");
+    });
+  });
+
+  describe("users that cannot access the conversation", () => {
+    it("should set status to user_restricted_by_conversation_access when user cannot access conversation", async () => {
+      // Create a restricted space
+      // SpaceFactory.regular creates a space with a regular group, which is restricted by default
+      const restrictedSpace = await SpaceFactory.regular(workspace);
+      const adminAuth = await Authenticator.internalAdminForWorkspace(
+        workspace.sId
+      );
+      // Refresh to get updated groups
+      const refreshedRestrictedSpace = await SpaceResource.fetchById(
+        adminAuth,
+        restrictedSpace.sId
+      );
+      expect(refreshedRestrictedSpace).not.toBeNull();
+      // Regular spaces created by SpaceFactory.regular are restricted (no global group)
+      expect(refreshedRestrictedSpace?.isOpen()).toBe(false);
+
+      // Create a user who is NOT a member of the restricted space
+      const mentionedUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, mentionedUser, {
+        role: "user",
+      });
+
+      // Create a conversation with requestedSpaceIds that includes the restricted space
+      const restrictedSpaceModelId = getResourceIdFromSId(
+        refreshedRestrictedSpace!.sId
+      );
+      expect(restrictedSpaceModelId).not.toBeNull();
+
+      const restrictedConversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: "test-agent",
+        messagesCreatedAt: [],
+        visibility: "unlisted",
+        requestedSpaceIds: [restrictedSpaceModelId!],
+      });
+
+      // Verify the mentioned user cannot access the conversation
+      const canAccess = await ConversationResource.canAccess(
+        await Authenticator.fromUserIdAndWorkspaceId(
+          mentionedUser.sId,
+          workspace.sId
+        ),
+        restrictedConversation.sId
+      );
+      expect(canAccess).toBe("conversation_access_restricted");
+
+      const { userMessage } = await ConversationFactory.createUserMessage({
+        auth,
+        workspace,
+        conversation: restrictedConversation,
+        content: `Hello @${mentionedUser.username}`,
+      });
+
+      const mentions: MentionType[] = [
+        {
+          type: "user",
+          userId: mentionedUser.sId.toString(),
+        },
+      ];
+
+      const result = await createUserMentions(auth, {
+        mentions,
+        message: userMessage,
+        conversation: restrictedConversation,
+      });
+
+      // Verify return value shows restricted status
+      expect(result).toBeInstanceOf(Array);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        id: mentionedUser.sId,
+        type: "user",
+        status: "user_restricted_by_conversation_access",
+      });
+      expect(isRichUserMention(result[0])).toBe(true);
+
+      // Verify mention was stored with restricted status
+      const mentionInDb = await MentionModel.findOne({
+        where: {
+          workspaceId: workspace.id,
+          messageId: userMessage.id,
+          userId: mentionedUser.id,
+        },
+      });
+      expect(mentionInDb).not.toBeNull();
+      expect(mentionInDb?.status).toBe(
+        "user_restricted_by_conversation_access"
+      );
+    });
+
+    it("should set status to approved when user can access conversation even if not a participant", async () => {
+      const adminAuth = await Authenticator.internalAdminForWorkspace(
+        workspace.sId
+      );
+      // Create an open space (regular space with global group)
+      const openSpace = await SpaceFactory.regular(workspace);
+      // Add global group to make it open
+      const globalGroupRes =
+        await GroupResource.fetchWorkspaceGlobalGroup(adminAuth);
+      expect(globalGroupRes.isOk()).toBe(true);
+      if (!globalGroupRes.isOk()) {
+        throw new Error("Failed to fetch global group");
+      }
+      const globalGroup = globalGroupRes.value;
+
+      // Add global group directly to make it open (if not already there)
+      const existingGroupIds = openSpace.groups.map((g) => g.sId);
+      const hasGlobalGroup = existingGroupIds.includes(globalGroup.sId);
+
+      // If global group is not already there, associate it directly
+      if (!hasGlobalGroup) {
+        await GroupSpaceFactory.associate(openSpace, globalGroup);
+      }
+
+      // Refresh to get updated groups
+      const refreshedOpenSpace = await SpaceResource.fetchById(
+        adminAuth,
+        openSpace.sId
+      );
+      expect(refreshedOpenSpace).not.toBeNull();
+      expect(refreshedOpenSpace?.isOpen()).toBe(true);
+
+      // Create a user who can access the space (all users can access open spaces)
+      const mentionedUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, mentionedUser, {
+        role: "user",
+      });
+
+      // Create a conversation with requestedSpaceIds that includes the open space
+      const openSpaceModelId = getResourceIdFromSId(refreshedOpenSpace!.sId);
+      expect(openSpaceModelId).not.toBeNull();
+
+      const openConversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: "test-agent",
+        messagesCreatedAt: [],
+        visibility: "unlisted",
+        requestedSpaceIds: [openSpaceModelId!],
+      });
+
+      // Verify the mentioned user can access the conversation
+      const canAccess = await ConversationResource.canAccess(
+        await Authenticator.fromUserIdAndWorkspaceId(
+          mentionedUser.sId,
+          workspace.sId
+        ),
+        openConversation.sId
+      );
+      expect(canAccess).toBe("allowed");
+
+      const { userMessage } = await ConversationFactory.createUserMessage({
+        auth,
+        workspace,
+        conversation: openConversation,
+        content: `Hello @${mentionedUser.username}`,
+      });
+
+      const mentions: MentionType[] = [
+        {
+          type: "user",
+          userId: mentionedUser.sId.toString(),
+        },
+      ];
+
+      const result = await createUserMentions(auth, {
+        mentions,
+        message: userMessage,
+        conversation: openConversation,
+      });
+
+      // Verify return value shows pending status (not restricted, but requires approval for user messages)
+      expect(result).toBeInstanceOf(Array);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        id: mentionedUser.sId,
+        type: "user",
+        status: "pending",
+      });
+      expect(isRichUserMention(result[0])).toBe(true);
+
+      // Verify mention was stored with pending status (not restricted)
+      const mentionInDb = await MentionModel.findOne({
+        where: {
+          workspaceId: workspace.id,
+          messageId: userMessage.id,
+          userId: mentionedUser.id,
+        },
+      });
+      expect(mentionInDb).not.toBeNull();
+      expect(mentionInDb?.status).toBe("pending");
+      expect(mentionInDb?.status).not.toBe(
+        "user_restricted_by_conversation_access"
+      );
+    });
+
+    it("should prioritize user_restricted_by_conversation_access over auto-approval", async () => {
+      // Create a restricted space
+      // SpaceFactory.regular creates a space with a regular group, which is restricted by default
+      const restrictedSpace = await SpaceFactory.regular(workspace);
+      const adminAuth = await Authenticator.internalAdminForWorkspace(
+        workspace.sId
+      );
+      // Refresh to get updated groups
+      const refreshedRestrictedSpace = await SpaceResource.fetchById(
+        adminAuth,
+        restrictedSpace.sId
+      );
+      expect(refreshedRestrictedSpace).not.toBeNull();
+      // Regular spaces created by SpaceFactory.regular are restricted (no global group)
+      expect(refreshedRestrictedSpace?.isOpen()).toBe(false);
+
+      // Create a user who is NOT a member of the restricted space
+      const mentionedUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, mentionedUser, {
+        role: "user",
+      });
+
+      // Create a conversation with requestedSpaceIds that includes the restricted space
+      const restrictedSpaceModelId = getResourceIdFromSId(
+        refreshedRestrictedSpace!.sId
+      );
+      expect(restrictedSpaceModelId).not.toBeNull();
+
+      const restrictedConversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: "test-agent",
+        messagesCreatedAt: [],
+        visibility: "unlisted",
+        requestedSpaceIds: [restrictedSpaceModelId!],
+      });
+
+      // Add user as participant first (which would normally auto-approve)
+      await ConversationResource.upsertParticipation(auth, {
+        conversation: restrictedConversation,
+        action: "subscribed",
+        user: mentionedUser.toJSON(),
+      });
+
+      // Create an agent message
+      const agentConfig = await AgentConfigurationFactory.createTestAgent(
+        auth,
+        {
+          name: "Test Agent",
+        }
+      );
+
+      const agentMessageRow = await AgentMessageModel.create({
+        status: "created",
+        agentConfigurationId: agentConfig.sId,
+        agentConfigurationVersion: agentConfig.version,
+        workspaceId: workspace.id,
+        skipToolsValidation: false,
+      });
+
+      const messageRow = await MessageModel.create({
+        sId: generateRandomModelSId(),
+        rank: 0,
+        conversationId: restrictedConversation.id,
+        parentId: null,
+        agentMessageId: agentMessageRow.id,
+        workspaceId: workspace.id,
+      });
+
+      const agentMessage: AgentMessageTypeWithoutMentions = {
+        id: messageRow.id,
+        agentMessageId: agentMessageRow.id,
+        created: agentMessageRow.createdAt.getTime(),
+        completedTs: null,
+        sId: messageRow.sId,
+        type: "agent_message",
+        visibility: messageRow.visibility,
+        version: messageRow.version,
+        parentMessageId: "",
+        parentAgentMessageId: null,
+        status: agentMessageRow.status,
+        content: null,
+        chainOfThought: null,
+        error: null,
+        configuration: agentConfig,
+        skipToolsValidation: false,
+        actions: [],
+        rawContents: [],
+        contents: [],
+        parsedContents: {},
+        reactions: [],
+        modelInteractionDurationMs: null,
+        completionDurationMs: null,
+        rank: messageRow.rank,
+      };
+
+      const mentions: MentionType[] = [
+        {
+          type: "user",
+          userId: mentionedUser.sId.toString(),
+        },
+      ];
+
+      const result = await createUserMentions(auth, {
+        mentions,
+        message: agentMessage,
+        conversation: restrictedConversation,
+      });
+
+      // Verify return value shows restricted status (access restriction takes priority over auto-approval)
+      expect(result).toBeInstanceOf(Array);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        id: mentionedUser.sId,
+        type: "user",
+        status: "user_restricted_by_conversation_access",
+      });
+      expect(isRichUserMention(result[0])).toBe(true);
+
+      // Verify mention was stored with restricted status (not approved despite being a participant)
+      const mentionInDb = await MentionModel.findOne({
+        where: {
+          workspaceId: workspace.id,
+          messageId: messageRow.id,
+          userId: mentionedUser.id,
+        },
+      });
+      expect(mentionInDb).not.toBeNull();
+      expect(mentionInDb?.status).toBe(
+        "user_restricted_by_conversation_access"
+      );
     });
   });
 });

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -111,7 +111,6 @@ export function getRichMentionsWithStatusForMessage(
             return {
               ...toRichUserMentionType(mentionedUser),
               status: m.status,
-              userConversationAccessStatus: "accessible",
             };
           }
         } else {

--- a/front/lib/models/agent/conversation.ts
+++ b/front/lib/models/agent/conversation.ts
@@ -774,7 +774,12 @@ MessageReactionModel.belongsTo(UserModel, {
   foreignKey: { name: "userId", allowNull: true }, // null = mention is not a user using a Slackbot
 });
 
-export type MentionStatusType = "pending" | "approved" | "rejected";
+export type MentionStatusType =
+  | "pending" // Waiting for user input
+  | "approved" // Auto or manually approved
+  | "rejected" // Auto or manually rejected
+  | "user_restricted_by_conversation_access" // The conversation access is restricted to the user (the conversation uses at least one space that the user doesn't have access to)
+  | "agent_restricted_by_space_usage"; // The agent uses at least one space that the conversation doesn't have access to (eg: projects conversations cannot use private spaces).
 
 export class MentionModel extends WorkspaceAwareModel<MentionModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -892,11 +892,15 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   }
 
   isRegularAndRestricted() {
-    return this.isRegular() && !this.groups.some((group) => group.isGlobal());
+    return this.isRegular() && !this.isOpen();
   }
 
   isRegularAndOpen() {
-    return this.isRegular() && this.groups.some((group) => group.isGlobal());
+    return this.isRegular() && this.isOpen();
+  }
+
+  isOpen() {
+    return this.groups.some((group) => group.isGlobal());
   }
 
   isPublic() {

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -1,6 +1,5 @@
 import type { MCPApproveExecutionEvent } from "@app/lib/actions/mcp_internal_actions/events";
 import type { ActionGeneratedFileType } from "@app/lib/actions/types";
-import type { MentionStatusType } from "@app/lib/models/agent/conversation";
 import type {
   AllSupportedWithDustSpecificFileContentType,
   ContentFragmentType,
@@ -116,9 +115,12 @@ export type AgenticMessageData = {
   originMessageId: string;
 };
 
-export type RichMentionWithStatus = RichMention & {
-  status: MentionStatusType;
-};
+export type RichMentionWithStatus =
+  | (RichMention & { status: "pending" })
+  | (RichMention & { status: "approved" })
+  | (RichMention & { status: "rejected" })
+  | (RichMention & { status: "user_restricted_by_conversation_access" })
+  | (RichMention & { status: "agent_restricted_by_space_usage" });
 
 export type UserMessageType = {
   id: ModelId;

--- a/front/types/assistant/mentions.ts
+++ b/front/types/assistant/mentions.ts
@@ -63,7 +63,6 @@ export interface RichAgentMentionInConversation extends RichAgentMention {
  */
 export interface RichUserMention extends BaseRichMention {
   type: "user";
-  userConversationAccessStatus?: "accessible" | "restricted";
 }
 
 export interface RichUserMentionInConversation extends RichUserMention {


### PR DESCRIPTION
## Description

Handle invalid users and agents mention at the mention's status level with 2 new statuses.
Remove extra query in bathRenderMessages.
Another PR soon with the ability to dimiss the mention (I don't want to reject otherwise we lose the information on the mention state that is useful for data analysis).

## Tests

Added

## Risk

Medium

## Deploy Plan

Deploy front