### PR TITLE
user index: ignore scrubbed users

### DIFF
--- a/front/temporal/es_indexation/activities.ts
+++ b/front/temporal/es_indexation/activities.ts
@@ -12,7 +12,8 @@ export async function indexUserSearchActivity({
 }): Promise<void> {
   const user = await UserResource.fetchById(userId);
   if (!user) {
-    throw new Error(`User not found: ${userId}`);
+    logger.warn({ userId }, `[user_search] User not found (likely scrubbed)`);
+    return;
   }
 
   // Get all memberships for this user


### PR DESCRIPTION
## Description

Logs: https://app.datadoghq.eu/dashboard/zms-vrt-9zr/stuck-front-worker?fromUser=false&refresh_mode=sliding&from_ts=1767878817331&to_ts=1767893217331&live=true

Due to users being deleted as part of workspace scrub when they solely belong to it.

## Tests

N/A

## Risk

Low

## Deploy Plan

- deploy `front`