### PR TITLE
[Rate Limit] Lower programmatic usage rate limit to 1 message per $3

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -91,6 +91,9 @@ import {
 } from "@app/types";
 import { isAgentMessageType } from "@app/types/assistant/conversation";
 
+// Rate limit for programmatic usage: 1 message per this amount of dollars per minute.
+const PROGRAMMATIC_RATE_LIMIT_DOLLARS_PER_MESSAGE = 3;
+
 /**
  * Conversation Creation, update and deletion
  */
@@ -1585,11 +1588,12 @@ async function isMessagesLimitReached(
         0
       ) / 1_000_000;
 
-    // Rate limit: creditDollarAmount messages per minute.
     // Minimum of 1 to allow at least some messages even with very low credits.
     const maxMessagesPerMinute = Math.max(
       1,
-      Math.floor(totalRemainingCreditsDollars)
+      Math.floor(
+        totalRemainingCreditsDollars / PROGRAMMATIC_RATE_LIMIT_DOLLARS_PER_MESSAGE
+      )
     );
 
     const remainingMessages = await rateLimiter({

--- a/front/lib/production_checks/checks/check_excess_credits.ts
+++ b/front/lib/production_checks/checks/check_excess_credits.ts
@@ -1,10 +1,14 @@
 import { QueryTypes } from "sequelize";
 
+import { Authenticator } from "@app/lib/auth";
 import { getFrontReplicaDbConnection } from "@app/lib/production_checks/utils";
+import { CreditResource } from "@app/lib/resources/credit_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { ActionLink, CheckFunction } from "@app/types";
 
-const FIFTY_DOLLARS_MICRO_USD = 50_000_000;
+const EXCESS_ABSOLUTE_THRESHOLD_MICRO_USD = 10_000_000;
 const DAYS_30_MS = 30 * 24 * 60 * 60 * 1000;
+const EXCESS_PERCENTAGE_THRESHOLD = 2;
 
 interface WorkspaceExcessCredits {
   workspaceId: number;
@@ -22,7 +26,7 @@ export const checkExcessCredits: CheckFunction = async (
   const frontDb = getFrontReplicaDbConnection();
   const thirtyDaysAgo = new Date(Date.now() - DAYS_30_MS);
 
-  // Query for workspaces with excess credits > $50 in the last 30 days.
+  // Query for workspaces with excess credits above the absolute threshold in the last 30 days.
   const workspacesWithExcessCredits: WorkspaceExcessCredits[] =
     // eslint-disable-next-line dust/no-raw-sql -- Production check using read replica
     await frontDb.query(
@@ -44,32 +48,71 @@ export const checkExcessCredits: CheckFunction = async (
         type: QueryTypes.SELECT,
         replacements: {
           thirtyDaysAgo: thirtyDaysAgo.toISOString(),
-          threshold: FIFTY_DOLLARS_MICRO_USD,
+          threshold: EXCESS_ABSOLUTE_THRESHOLD_MICRO_USD,
         },
       }
     );
 
-  if (workspacesWithExcessCredits.length > 0) {
-    const formattedWorkspaces = workspacesWithExcessCredits.map((w) => ({
+  if (workspacesWithExcessCredits.length === 0) {
+    reportSuccess();
+    return;
+  }
+
+  // Fetch active credits for workspaces that exceeded the absolute threshold.
+  const activeCreditsByWorkspaceSId = new Map<string, number>();
+  await concurrentExecutor(
+    workspacesWithExcessCredits,
+    async (workspace) => {
+      const auth = await Authenticator.internalAdminForWorkspace(
+        workspace.workspaceSId
+      );
+      const activeCredits = await CreditResource.listActive(auth);
+      const totalActiveCreditsMicroUsd = activeCredits.reduce(
+        (sum, c) => sum + c.initialAmountMicroUsd,
+        0
+      );
+      activeCreditsByWorkspaceSId.set(
+        workspace.workspaceSId,
+        totalActiveCreditsMicroUsd
+      );
+    },
+    { concurrency: 10 }
+  );
+
+  // Filter to only include workspaces where excess exceeds the percentage threshold of active credits.
+  const significantExcessWorkspaces = workspacesWithExcessCredits.filter(
+    (w) => {
+      const totalActiveCreditsMicroUsd =
+        activeCreditsByWorkspaceSId.get(w.workspaceSId) ?? 0;
+      if (totalActiveCreditsMicroUsd === 0) {
+        return true;
+      }
+      const excessPercentage =
+        (Number(w.totalExcessMicroUsd) / totalActiveCreditsMicroUsd) * 100;
+      return excessPercentage > EXCESS_PERCENTAGE_THRESHOLD;
+    }
+  );
+
+  if (significantExcessWorkspaces.length > 0) {
+    const formattedWorkspaces = significantExcessWorkspaces.map((w) => ({
       workspaceSId: w.workspaceSId,
       workspaceName: w.workspaceName,
       totalExcessUsd: (Number(w.totalExcessMicroUsd) / 1_000_000).toFixed(2),
     }));
 
-    const actionLinks: ActionLink[] = workspacesWithExcessCredits.map((w) => ({
+    const actionLinks: ActionLink[] = significantExcessWorkspaces.map((w) => ({
       label: `${w.workspaceName} ($${(Number(w.totalExcessMicroUsd) / 1_000_000).toFixed(2)})`,
       url: `/poke/${w.workspaceSId}`,
     }));
 
-    logger.warn(
-      { workspaces: formattedWorkspaces },
-      `Found ${workspacesWithExcessCredits.length} workspace(s) with excess credits > $50 in the last 30 days`
-    );
+    const thresholdDollars = EXCESS_ABSOLUTE_THRESHOLD_MICRO_USD / 1_000_000;
+    const message =
+      `${significantExcessWorkspaces.length} workspace(s) have excess credits > $${thresholdDollars} ` +
+      `(and > ${EXCESS_PERCENTAGE_THRESHOLD}% of active credits) in the last 30 days`;
 
-    reportFailure(
-      { workspaces: formattedWorkspaces, actionLinks },
-      `${workspacesWithExcessCredits.length} workspace(s) have excess credits > $50 in the last 30 days`
-    );
+    logger.warn({ workspaces: formattedWorkspaces }, message);
+
+    reportFailure({ workspaces: formattedWorkspaces, actionLinks }, message);
   } else {
     reportSuccess();
   }


### PR DESCRIPTION
## Description

Context: [Slack thread](https://dust4ai.slack.com/archives/C05B529FHV1/p1767690717271849)

Lower the programmatic usage rate limit from 1 message per dollar to 1 message per $3 of remaining credits per minute.

This helps prevent scenarios where customers with low credits ($2-$3) can start many concurrent messages (~30) before token usage is computed. Note: this does not prevent using up all credits - customers can smooth out their API calls.

## Risks

Blast radius: Programmatic API usage rate limiting
Risk: low

## Deploy Plan

- deploy front