### PR TITLE
[Rate Limit] Lower programmatic usage rate limit to 1 message per $3

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -91,6 +91,9 @@ import {
 } from "@app/types";
 import { isAgentMessageType } from "@app/types/assistant/conversation";
 
+// Rate limit for programmatic usage: 1 message per this amount of dollars per minute.
+const PROGRAMMATIC_RATE_LIMIT_DOLLARS_PER_MESSAGE = 3;
+
 /**
  * Conversation Creation, update and deletion
  */
@@ -1585,11 +1588,13 @@ async function isMessagesLimitReached(
         0
       ) / 1_000_000;
 
-    // Rate limit: creditDollarAmount messages per minute.
     // Minimum of 1 to allow at least some messages even with very low credits.
     const maxMessagesPerMinute = Math.max(
       1,
-      Math.floor(totalRemainingCreditsDollars)
+      Math.floor(
+        totalRemainingCreditsDollars /
+          PROGRAMMATIC_RATE_LIMIT_DOLLARS_PER_MESSAGE
+      )
     );
 
     const remainingMessages = await rateLimiter({


### PR DESCRIPTION
## Description

Context: [Slack thread](https://dust4ai.slack.com/archives/C05B529FHV1/p1767690717271849)

Lower the programmatic usage rate limit from 1 message per dollar to 1 message per $3 of remaining credits per minute.

This helps prevent scenarios where customer can start many heavy concurrent message (~30 at $3 each with only $30 remaining => $60 overage) before token usage is computed. Note: this does not prevent using up all credits - customers can smooth out their API calls. Related slack thread https://dust4ai.slack.com/archives/C05B529FHV1/p1767690717271849

## Risks

Blast radius: Programmatic API usage rate limiting
Risk: low

## Deploy Plan
- pmrr
- deploy front