### PR TITLE
[sparkle] - refacto(Collapsible): retire `CollapsibleComponent`

### DIFF
--- a/sparkle/src/components/Collapsible.tsx
+++ b/sparkle/src/components/Collapsible.tsx
@@ -67,7 +67,7 @@ export interface CollapsibleTriggerProps
     React.ComponentPropsWithoutRef<typeof CollapsiblePrimitive.Trigger>,
     Omit<VariantProps<typeof labelVariants>, "disabled"> {
   label?: string;
-  isOpen?: boolean;
+  hideChevron?: boolean;
 }
 
 const CollapsibleTrigger = React.forwardRef<
@@ -80,7 +80,7 @@ const CollapsibleTrigger = React.forwardRef<
       children,
       className,
       disabled = false,
-      isOpen = false,
+      hideChevron = false,
       variant = "primary",
       ...props
     },
@@ -97,25 +97,27 @@ const CollapsibleTrigger = React.forwardRef<
         )}
         {...props}
       >
-        {children ? (
-          children
-        ) : (
-          <>
-            <span
-              className={cn(
-                "s-transition-transform s-duration-200",
-                chevronVariants({ variant, disabled })
-              )}
-            >
-              <Icon
-                visual={isOpen ? ChevronDownIcon : ChevronRightIcon}
-                size="sm"
-              />
-            </span>
-            <span className={labelVariants({ variant, disabled })}>
-              {label}
-            </span>
-          </>
+        {!hideChevron && (
+          <span
+            className={cn(
+              "s-transition-transform s-duration-200",
+              chevronVariants({ variant, disabled })
+            )}
+          >
+            <Icon
+              visual={ChevronRightIcon}
+              size="sm"
+              className="s-block group-data-[state=open]/col:s-hidden"
+            />
+            <Icon
+              visual={ChevronDownIcon}
+              size="sm"
+              className="s-hidden group-data-[state=open]/col:s-block"
+            />
+          </span>
+        )}
+        {children ?? (
+          <span className={labelVariants({ variant, disabled })}>{label}</span>
         )}
       </CollapsiblePrimitive.Trigger>
     );
@@ -157,47 +159,4 @@ const CollapsibleContent = React.forwardRef<
 ));
 CollapsibleContent.displayName = "CollapsibleContent";
 
-export interface CollapsibleComponentProps {
-  rootProps?: Omit<CollapsibleProps, "children" | "open">;
-  triggerProps?: Omit<CollapsibleTriggerProps, "children" | "defaultOpen">;
-  triggerChildren?: React.ReactNode;
-  contentProps?: Omit<CollapsibleContentProps, "children">;
-  contentChildren?: React.ReactNode;
-}
-
-const CollapsibleComponent = React.forwardRef<
-  React.ElementRef<typeof CollapsiblePrimitive.Root>,
-  CollapsibleComponentProps
->(
-  (
-    { rootProps, triggerProps, triggerChildren, contentProps, contentChildren },
-    ref
-  ) => {
-    const [open, setOpen] = React.useState(!!rootProps?.defaultOpen);
-    return (
-      <Collapsible
-        ref={ref}
-        {...rootProps}
-        open={open}
-        onOpenChange={(open) => {
-          setOpen(open);
-          rootProps?.onOpenChange?.(open);
-        }}
-      >
-        <CollapsibleTrigger {...triggerProps} isOpen={open}>
-          {triggerChildren}
-        </CollapsibleTrigger>
-        <CollapsibleContent {...contentProps}>
-          {contentChildren}
-        </CollapsibleContent>
-      </Collapsible>
-    );
-  }
-);
-
-export {
-  Collapsible,
-  CollapsibleComponent,
-  CollapsibleContent,
-  CollapsibleTrigger,
-};
+export { Collapsible, CollapsibleContent, CollapsibleTrigger };

--- a/sparkle/src/components/Dropdown.tsx
+++ b/sparkle/src/components/Dropdown.tsx
@@ -243,8 +243,9 @@ const DropdownMenuSubContent = React.forwardRef<
 DropdownMenuSubContent.displayName =
   DropdownMenuPrimitive.SubContent.displayName;
 
-interface DropdownMenuContentProps
-  extends React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content> {
+interface DropdownMenuContentProps extends React.ComponentPropsWithoutRef<
+  typeof DropdownMenuPrimitive.Content
+> {
   mountPortal?: boolean;
   mountPortalContainer?: HTMLElement;
   dropdownHeaders?: React.ReactNode;
@@ -487,8 +488,10 @@ const DropdownMenuRadioItem = React.forwardRef<
 ));
 DropdownMenuRadioItem.displayName = DropdownMenuPrimitive.RadioItem.displayName;
 
-interface DropdownMenuTagItemProps
-  extends Omit<DropdownMenuItemProps, "label" | "icon" | "onClick"> {
+interface DropdownMenuTagItemProps extends Omit<
+  DropdownMenuItemProps,
+  "label" | "icon" | "onClick"
+> {
   label: string;
   size?: React.ComponentProps<typeof Chip>["size"];
   color?: React.ComponentProps<typeof Chip>["color"];

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -33,7 +33,6 @@ export * from "./Citation";
 export { default as CollapseButton } from "./CollapseButton";
 export {
   Collapsible,
-  CollapsibleComponent,
   CollapsibleContent,
   CollapsibleTrigger,
 } from "./Collapsible";

--- a/sparkle/src/stories/Collapsible.stories.tsx
+++ b/sparkle/src/stories/Collapsible.stories.tsx
@@ -4,7 +4,6 @@ import React from "react";
 import {
   Chip,
   Collapsible,
-  CollapsibleComponent,
   CollapsibleContent,
   CollapsibleTrigger,
 } from "../index_with_tw_base";
@@ -45,25 +44,34 @@ export const CollapsibleExample = () => (
     </Collapsible>
     <Collapsible>
       <CollapsibleTrigger>
-        <Chip>Click me custom</Chip>
+        <Chip>Click me custom (with chevron)</Chip>
       </CollapsibleTrigger>
       <CollapsibleContent>
         <div className="mt-1 s-flex s-h-16 s-w-full s-items-center s-justify-center s-bg-muted-background">
-          Anything goes for the Collapsible button
+          Custom trigger content with chevron shown by default
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+    <Collapsible>
+      <CollapsibleTrigger hideChevron>
+        <Chip>Click me custom (no chevron)</Chip>
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        <div className="mt-1 s-flex s-h-16 s-w-full s-items-center s-justify-center s-bg-muted-background">
+          Custom trigger content with chevron hidden
         </div>
       </CollapsibleContent>
     </Collapsible>
     <div className="s-rounded-md s-border s-border-gray-200 s-p-4">
       <h3 className="s-mb-2 s-font-medium">Default Open</h3>
-      <CollapsibleComponent
-        rootProps={{ defaultOpen: true }}
-        triggerProps={{ label: "Open by default" }}
-        contentChildren={
+      <Collapsible defaultOpen>
+        <CollapsibleTrigger label="Open by default" />
+        <CollapsibleContent>
           <div className="s-flex s-h-16 s-w-full s-items-center s-justify-center s-bg-muted-background">
             This collapsible is open by default
           </div>
-        }
-      />
+        </CollapsibleContent>
+      </Collapsible>
     </div>
   </div>
 );

--- a/sparkle/src/stories/MultiPageDialog.stories.tsx
+++ b/sparkle/src/stories/MultiPageDialog.stories.tsx
@@ -4,7 +4,11 @@ import React, { useState } from "react";
 import { SearchInput } from "@sparkle/components";
 import { Button } from "@sparkle/components/Button";
 import { Checkbox } from "@sparkle/components/Checkbox";
-import { CollapsibleComponent } from "@sparkle/components/Collapsible";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@sparkle/components/Collapsible";
 import {
   MultiPageDialog,
   MultiPageDialogContent,
@@ -920,13 +924,13 @@ export const ActionValidation: Story = {
               </p>
 
               <div className="s-space-y-3">
-                <CollapsibleComponent
-                  triggerChildren={
+                <Collapsible>
+                  <CollapsibleTrigger>
                     <span className="s-text-sm s-font-medium s-text-muted-foreground dark:s-text-muted-foreground-night">
                       Details
                     </span>
-                  }
-                  contentChildren={
+                  </CollapsibleTrigger>
+                  <CollapsibleContent>
                     <div className="s-mt-2 s-rounded-md s-border s-bg-muted s-p-3">
                       <h4 className="s-mb-2 s-text-sm s-font-medium">
                         Email Details
@@ -946,8 +950,8 @@ export const ActionValidation: Story = {
                         </div>
                       </div>
                     </div>
-                  }
-                />
+                  </CollapsibleContent>
+                </Collapsible>
 
                 {errorMessage && (
                   <div className="s-flex s-items-center s-gap-2 s-text-sm s-font-medium s-text-warning-800">
@@ -989,13 +993,13 @@ export const ActionValidation: Story = {
               </p>
 
               <div className="s-space-y-3">
-                <CollapsibleComponent
-                  triggerChildren={
+                <Collapsible>
+                  <CollapsibleTrigger>
                     <span className="s-text-sm s-font-medium s-text-muted-foreground dark:s-text-muted-foreground-night">
                       Details
                     </span>
-                  }
-                  contentChildren={
+                  </CollapsibleTrigger>
+                  <CollapsibleContent>
                     <div className="s-mt-2 s-rounded-md s-border s-bg-muted s-p-3">
                       <h4 className="s-mb-2 s-text-sm s-font-medium">
                         Campaign Details
@@ -1015,8 +1019,8 @@ export const ActionValidation: Story = {
                         </div>
                       </div>
                     </div>
-                  }
-                />
+                  </CollapsibleContent>
+                </Collapsible>
 
                 <div className="s-rounded-md s-border s-bg-blue-50 s-p-3">
                   <h4 className="s-mb-1 s-text-sm s-font-medium s-text-blue-900">
@@ -1048,13 +1052,13 @@ export const ActionValidation: Story = {
               </p>
 
               <div className="s-space-y-3">
-                <CollapsibleComponent
-                  triggerChildren={
+                <Collapsible>
+                  <CollapsibleTrigger>
                     <span className="s-text-sm s-font-medium s-text-muted-foreground dark:s-text-muted-foreground-night">
                       Details
                     </span>
-                  }
-                  contentChildren={
+                  </CollapsibleTrigger>
+                  <CollapsibleContent>
                     <div className="s-mt-2 s-rounded-md s-border s-bg-muted s-p-3">
                       <h4 className="s-mb-2 s-text-sm s-font-medium">
                         Template Details
@@ -1074,8 +1078,8 @@ export const ActionValidation: Story = {
                         </div>
                       </div>
                     </div>
-                  }
-                />
+                  </CollapsibleContent>
+                </Collapsible>
 
                 <div className="s-rounded-md s-border s-bg-green-50 s-p-3">
                   <h4 className="s-mb-1 s-text-sm s-font-medium s-text-green-900">


### PR DESCRIPTION
## Description

Removes the `CollapsibleComponent` wrapper in favor of direct composition using `Collapsible`, `CollapsibleTrigger`, and `CollapsibleContent`. Replaces the `isOpen` prop in `CollapsibleTrigger` with `hideChevron` to better express intent and simplify the API. The chevron now uses CSS state classes (`group-data-[state=open]/col`) for conditional rendering instead of relying on external state management, making the component more self-contained.

## Risk
Medium - not backward compatible

## Tests

Storybook stories updated to demonstrate both default chevron behavior and the new `hideChevron` prop option.

## Deploy plan

- Publish RC
- Update front
- Publish GR
