### PR TITLE
fix(assistant): count retries toward message limit

### DIFF
--- a/front/lib/api/assistant/conversation/mentions.ts
+++ b/front/lib/api/assistant/conversation/mentions.ts
@@ -532,6 +532,12 @@ export const createAgentMessages = async (
           }
         );
 
+        // Track agent usage when retrying an agent message.
+        void signalAgentUsage({
+          agentConfigurationId: agentConfiguration.sId,
+          workspaceId: owner.sId,
+        });
+
         results.push({
           agentMessageRow,
           messageRow,


### PR DESCRIPTION
## Description

Retrying a message was not counted toward the workspace message limit, allowing users to bypass billing limits by modifying attached file content and repeatedly hitting retry.

This fix:
- Adds limit checking in `retryAgentMessage()` before allowing retry
- Calls `signalAgentUsage()` in the retry case to track usage
- Extracts `checkMessagesLimit()` helper to DRY limit checking between `postUserMessage` and `retryAgentMessage`
- Uses the parent user message's original context to preserve web vs programmatic origin for correct rate limiting

## Tests

Added tests in `conversation.test.ts`:
- `should return error when message limit is reached` - verifies retry fails with 403 when rate limiter returns 0
- `should succeed when under the message limit` - verifies retry works when rate limiter returns positive value
- `should return error when parent user message is not found` - verifies error handling for invalid parent message
- `should use the parent user message context for rate limiting` - verifies the original context (web vs programmatic origin) is preserved

## Risk

Low risk. The change adds a limit check before an existing operation. If the limit check fails unexpectedly, users would see a "limit exceeded" error but no data loss or corruption would occur. Safe to rollback.

## Deploy Plan

Standard deployment, no special steps required.