### PR TITLE
[dust-hive] Add cmake and protobuf to prerequisites

### DIFF
--- a/x/henry/dust-hive/src/commands/doctor.ts
+++ b/x/henry/dust-hive/src/commands/doctor.ts
@@ -132,6 +132,26 @@ async function checkCargo(): Promise<CheckResult> {
   };
 }
 
+async function checkCmake(): Promise<CheckResult> {
+  const version = await getCommandVersion("cmake");
+  return {
+    name: "CMake",
+    ok: version !== null,
+    message: version ?? "Not found",
+    fix: getInstallInstructions("cmake"),
+  };
+}
+
+async function checkProtobuf(): Promise<CheckResult> {
+  const version = await getCommandVersion("protoc");
+  return {
+    name: "Protobuf",
+    ok: version !== null,
+    message: version ?? "Not found",
+    fix: getInstallInstructions("protobuf"),
+  };
+}
+
 async function checkSccache(): Promise<CheckResult> {
   const version = await getCommandVersion("sccache");
   if (!version) {
@@ -236,6 +256,8 @@ async function runAllChecks(): Promise<CheckResult[]> {
     await checkTemporalCli(),
     await checkNvm(),
     await checkCargo(),
+    await checkCmake(),
+    await checkProtobuf(),
     await checkSccache(),
     await checkRepo(),
     await checkConfig(),

--- a/x/henry/dust-hive/src/lib/platform.ts
+++ b/x/henry/dust-hive/src/lib/platform.ts
@@ -118,7 +118,16 @@ export function getPidsOnPort(port: number): number[] {
 // Installation Instructions
 // ============================================================================
 
-type InstallableTool = "zellij" | "temporal" | "sccache" | "lsof" | "bun" | "nvm" | "cargo";
+type InstallableTool =
+  | "zellij"
+  | "temporal"
+  | "sccache"
+  | "lsof"
+  | "bun"
+  | "nvm"
+  | "cargo"
+  | "cmake"
+  | "protobuf";
 
 const INSTALL_INSTRUCTIONS: Record<PlatformName, Record<InstallableTool, string>> = {
   macos: {
@@ -129,6 +138,8 @@ const INSTALL_INSTRUCTIONS: Record<PlatformName, Record<InstallableTool, string>
     bun: "curl -fsSL https://bun.sh/install | bash",
     nvm: "curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash",
     cargo: 'curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs | sh',
+    cmake: "brew install cmake",
+    protobuf: "brew install protobuf",
   },
   linux: {
     zellij: "cargo install zellij (or download from https://github.com/zellij-org/zellij/releases)",
@@ -138,6 +149,9 @@ const INSTALL_INSTRUCTIONS: Record<PlatformName, Record<InstallableTool, string>
     bun: "curl -fsSL https://bun.sh/install | bash",
     nvm: "curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash",
     cargo: 'curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs | sh',
+    cmake: "sudo apt install cmake (Debian/Ubuntu) or sudo dnf install cmake (Fedora)",
+    protobuf:
+      "sudo apt install protobuf-compiler (Debian/Ubuntu) or sudo dnf install protobuf-compiler (Fedora)",
   },
 };
 


### PR DESCRIPTION
## Description

Rust crate builds (e.g., sentencepiece-sys) require cmake and protobuf compiler to be installed. Without these, `dust-hive up` fails when building Rust binaries on a fresh Linux machine.

This PR adds:
- `checkCmake()` and `checkProtobuf()` functions in `doctor.ts`
- Platform-specific install instructions in `platform.ts`
- Both checks are included in `runAllChecks()`

## Tests

- Ran `bun run check` (typecheck, lint, tests all pass)
- Verified manually that the new checks work on a Linux devbox

## Risk

Low - adds new prerequisite checks without modifying existing functionality. Users missing cmake/protobuf will now see clear install instructions instead of cryptic cargo build errors.

## Deploy Plan

N/A - dust-hive is a local development tool