### PR TITLE
[front] fix(skills): prevent name conflict on unarchiving

### DIFF
--- a/front/pages/api/w/[wId]/skills/[sId]/restore.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/restore.ts
@@ -67,6 +67,21 @@ async function handler(
         });
       }
 
+      // Check for existing active skill with the same name.
+      const existingSkill = await SkillResource.fetchActiveByName(
+        auth,
+        skillResource.name
+      );
+      if (existingSkill) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `A skill with the name "${skillResource.name}" already exists.`,
+          },
+        });
+      }
+
       await skillResource.restore(auth);
 
       return res.status(200).json({ success: true });


### PR DESCRIPTION
## Description

- This PR prevents name conflicts upon unarchiving a skill when another active skill of the same name was created since it was archived.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
