### PR TITLE
[Sparkle] chore(skills): support subtitle props in bar header component

### DIFF
--- a/sparkle/src/components/Bar.tsx
+++ b/sparkle/src/components/Bar.tsx
@@ -47,6 +47,7 @@ const barVariants = cva(
 
 interface BarProps extends VariantProps<typeof barVariants> {
   title?: string;
+  subtitle?: React.ReactNode;
   tooltip?: string;
   leftActions?: React.ReactNode;
   rightActions?: React.ReactNode;
@@ -55,6 +56,7 @@ interface BarProps extends VariantProps<typeof barVariants> {
 
 export function Bar({
   title,
+  subtitle,
   tooltip,
   leftActions,
   rightActions,
@@ -75,11 +77,19 @@ export function Bar({
           {tooltip ? (
             <Tooltip
               tooltipTriggerAsChild
-              trigger={<span>{title}</span>}
+              trigger={
+                <>
+                  <span>{title}</span>
+                  {subtitle}
+                </>
+              }
               label={tooltip}
             />
           ) : (
-            title
+            <>
+              <span>{title}</span>
+              {subtitle}
+            </>
           )}
         </div>
       )}
@@ -173,6 +183,7 @@ Bar.ButtonBar = function (props: BarButtonBarProps) {
 // BarHeader component - convenience wrapper for top-positioned Bar
 interface BarHeaderProps {
   title: string;
+  subtitle?: React.ReactNode;
   tooltip?: string;
   leftActions?: React.ReactNode;
   rightActions?: React.ReactNode;
@@ -182,6 +193,7 @@ interface BarHeaderProps {
 
 export function BarHeader({
   title,
+  subtitle,
   tooltip,
   leftActions,
   rightActions,
@@ -192,6 +204,7 @@ export function BarHeader({
     <Bar
       position="top"
       title={title}
+      subtitle={subtitle}
       tooltip={tooltip}
       leftActions={leftActions}
       rightActions={rightActions}

--- a/sparkle/src/components/Bar.tsx
+++ b/sparkle/src/components/Bar.tsx
@@ -47,7 +47,7 @@ const barVariants = cva(
 
 interface BarProps extends VariantProps<typeof barVariants> {
   title?: string;
-  subtitle?: React.ReactNode;
+  description?: React.ReactNode;
   tooltip?: string;
   leftActions?: React.ReactNode;
   rightActions?: React.ReactNode;
@@ -56,7 +56,7 @@ interface BarProps extends VariantProps<typeof barVariants> {
 
 export function Bar({
   title,
-  subtitle,
+  description,
   tooltip,
   leftActions,
   rightActions,
@@ -80,7 +80,7 @@ export function Bar({
               trigger={
                 <>
                   <span>{title}</span>
-                  {subtitle}
+                  {description}
                 </>
               }
               label={tooltip}
@@ -88,7 +88,7 @@ export function Bar({
           ) : (
             <>
               <span>{title}</span>
-              {subtitle}
+              {description}
             </>
           )}
         </div>
@@ -183,7 +183,7 @@ Bar.ButtonBar = function (props: BarButtonBarProps) {
 // BarHeader component - convenience wrapper for top-positioned Bar
 interface BarHeaderProps {
   title: string;
-  subtitle?: React.ReactNode;
+  description?: React.ReactNode;
   tooltip?: string;
   leftActions?: React.ReactNode;
   rightActions?: React.ReactNode;
@@ -193,7 +193,7 @@ interface BarHeaderProps {
 
 export function BarHeader({
   title,
-  subtitle,
+  description,
   tooltip,
   leftActions,
   rightActions,
@@ -204,7 +204,7 @@ export function BarHeader({
     <Bar
       position="top"
       title={title}
-      subtitle={subtitle}
+      description={description}
       tooltip={tooltip}
       leftActions={leftActions}
       rightActions={rightActions}

--- a/sparkle/src/stories/Bar.stories.tsx
+++ b/sparkle/src/stories/Bar.stories.tsx
@@ -1,12 +1,13 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import React from "react";
 
-import { ChatBubbleBottomCenterTextIcon } from "@sparkle/icons/app";
+import { ChatBubbleBottomCenterTextIcon, RobotIcon } from "@sparkle/icons/app";
 
 import {
   Bar,
   BarFooter,
   Button,
+  Icon,
   Page,
   ResizableHandle,
   ResizablePanel,
@@ -26,6 +27,26 @@ export const BasicBarHeader: Story = {
     position: "top",
     title: "Knowledge Base",
   },
+};
+
+export const BarHeaderWithSubtitle = () => {
+  return (
+    <Bar
+      position="top"
+      title="My Custom Skill"
+      subtitle={
+        <div className="s-flex s-items-center s-gap-1 s-text-sm">
+          <p className="s-text-muted-foreground dark:s-text-muted-foreground-night">
+            Based on
+          </p>
+          <Icon visual={RobotIcon} size="xs" />
+          <p className="s-text-foreground dark:s-text-foreground-night">
+            Research Assistant
+          </p>
+        </div>
+      }
+    />
+  );
 };
 
 export const BasicBarFooter: Story = {

--- a/sparkle/src/stories/Bar.stories.tsx
+++ b/sparkle/src/stories/Bar.stories.tsx
@@ -29,12 +29,12 @@ export const BasicBarHeader: Story = {
   },
 };
 
-export const BarHeaderWithSubtitle = () => {
+export const BarHeaderWithDescription = () => {
   return (
     <Bar
       position="top"
       title="My Custom Skill"
-      subtitle={
+      description={
         <div className="s-flex s-items-center s-gap-1 s-text-sm">
           <p className="s-text-muted-foreground dark:s-text-muted-foreground-night">
             Based on


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PRs adds an optional subtitle props to the bar header component to allow displaying extended skill in the skill builder
(for ref: https://github.com/dust-tt/tasks/issues/5778#issuecomment-3723799892)

## Tests

<img width="2030" height="298" alt="image" src="https://github.com/user-attachments/assets/79985e71-bffd-4d7e-85cd-b9dfc4ee579b" />

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
