### PR TITLE
[front/components/agent_builder/observability] - refactor: enhance ch…

### DIFF
--- a/front/components/agent_builder/observability/shared/ChartContainer.tsx
+++ b/front/components/agent_builder/observability/shared/ChartContainer.tsx
@@ -50,7 +50,7 @@ export function ChartContainer({
   const [isFullscreen, setIsFullscreen] = useState(false);
   return (
     <>
-      <div>
+      <div className="observability-chart-container">
         <div className="flex items-center justify-between">
           <div className="flex items-center justify-between gap-2">
             <h3 className="text-base font-medium text-foreground dark:text-foreground-night">
@@ -101,7 +101,10 @@ export function ChartContainer({
       </div>
       {isAllowFullScreen && (
         <Sheet open={isFullscreen} onOpenChange={setIsFullscreen}>
-          <SheetContent size="xl" className="max-w-[75%]">
+          <SheetContent
+            size="xl"
+            className="observability-chart-container max-w-[75%]"
+          >
             <SheetHeader>
               <SheetTitle>{title}</SheetTitle>
             </SheetHeader>

--- a/front/styles/global.css
+++ b/front/styles/global.css
@@ -179,3 +179,9 @@ body {
 .max-h-dvh {
   max-height: 100dvh;
 }
+
+/* Avoid the native focus outline border on Recharts surfaces when clicking charts. */
+.observability-chart-container svg:focus,
+.observability-chart-container svg:focus-visible {
+  outline: none;
+}


### PR DESCRIPTION
## Description

This PR implements a CSS rule to avoid the native focus outline on Recharts components within observability charts like:

<img width="1321" height="359" alt="Screenshot 2026-01-09 at 11 18 05" src="https://github.com/user-attachments/assets/dadd13e1-b5a6-4bf8-ab4e-457d34ede2ca" />

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front