### PR TITLE
Add restricted/unrestricted toggle on projects 

### DIFF
--- a/front/components/assistant/conversation/CreateProjectModal.tsx
+++ b/front/components/assistant/conversation/CreateProjectModal.tsx
@@ -118,7 +118,8 @@ export function CreateProjectModal({
           <DialogTitle>Create a new Project</DialogTitle>
           <DialogDescription>
             Unrestricted projects are accessible to all the members of the
-            workspace.
+            workspace. Restricted projects allow you to control who can access
+            them.
           </DialogDescription>
         </DialogHeader>
         <DialogContainer>

--- a/front/components/assistant/conversation/CreateProjectModal.tsx
+++ b/front/components/assistant/conversation/CreateProjectModal.tsx
@@ -68,7 +68,7 @@ export function CreateProjectModal({
 
     const createdSpace = await doCreate({
       name: trimmedName,
-      isRestricted: false,
+      isRestricted: true,
       managementMode: "manual",
       memberIds: user?.sId ? [user.sId] : [],
       spaceKind: "project",

--- a/front/components/assistant/conversation/CreateProjectModal.tsx
+++ b/front/components/assistant/conversation/CreateProjectModal.tsx
@@ -3,10 +3,13 @@ import {
   Dialog,
   DialogContainer,
   DialogContent,
+  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
   Input,
+  Label,
+  SliderToggle,
 } from "@dust-tt/sparkle";
 import { useRouter } from "next/router";
 import { useCallback, useEffect, useState } from "react";
@@ -31,6 +34,7 @@ export function CreateProjectModal({
 }: CreateProjectModalProps) {
   const [projectName, setProjectName] = useState<string>("");
   const [isSaving, setIsSaving] = useState(false);
+  const [isRestricted, setIsRestricted] = useState(false);
 
   const doCreate = useCreateSpace({ owner });
   const { user } = useUser();
@@ -68,7 +72,7 @@ export function CreateProjectModal({
 
     const createdSpace = await doCreate({
       name: trimmedName,
-      isRestricted: true,
+      isRestricted,
       managementMode: "manual",
       memberIds: user?.sId ? [user.sId] : [],
       spaceKind: "project",
@@ -88,6 +92,7 @@ export function CreateProjectModal({
     }
   }, [
     projectName,
+    isRestricted,
     doCreate,
     handleClose,
     sendNotification,
@@ -111,6 +116,10 @@ export function CreateProjectModal({
       <DialogContent>
         <DialogHeader>
           <DialogTitle>Create a new Project</DialogTitle>
+          <DialogDescription>
+            Unrestricted projects are accessible to all the members of the
+            workspace.
+          </DialogDescription>
         </DialogHeader>
         <DialogContainer>
           <div className="flex w-full flex-col gap-y-4">
@@ -124,6 +133,13 @@ export function CreateProjectModal({
               onKeyDown={handleKeyPress}
               autoFocus
             />
+            <div className="flex w-full items-center justify-between">
+              <Label>Restricted Access</Label>
+              <SliderToggle
+                selected={isRestricted}
+                onClick={() => setIsRestricted(!isRestricted)}
+              />
+            </div>
           </div>
         </DialogContainer>
         <DialogFooter>

--- a/front/components/assistant/conversation/space/about/SpaceAboutTab.tsx
+++ b/front/components/assistant/conversation/space/about/SpaceAboutTab.tsx
@@ -3,6 +3,7 @@ import { useCallback, useMemo, useState } from "react";
 
 import { DeleteSpaceDialog } from "@app/components/assistant/conversation/space/about/DeleteSpaceDialog";
 import { RestrictedAccessBody } from "@app/components/spaces/RestrictedAccessBody";
+import { RestrictedAccessHeader } from "@app/components/spaces/RestrictedAccessHeader";
 import { useUpdateSpace } from "@app/lib/swr/spaces";
 import type {
   GroupType,
@@ -10,7 +11,6 @@ import type {
   SpaceType,
   UserType,
 } from "@app/types";
-import { RestrictedAccessHeader } from "@app/components/spaces/RestrictedAccessHeader";
 
 interface SpaceAboutTabProps {
   owner: LightWorkspaceType;

--- a/front/components/assistant/conversation/space/about/SpaceAboutTab.tsx
+++ b/front/components/assistant/conversation/space/about/SpaceAboutTab.tsx
@@ -49,6 +49,9 @@ export function SpaceAboutTab({
     if (managementType !== initialManagementMode) {
       return true;
     }
+    if (isRestricted !== initialIsRestricted) {
+      return true;
+    }
 
     if (managementType === "manual") {
       const currentMemberIds = selectedMembers.map((m) => m.sId).sort();
@@ -70,6 +73,8 @@ export function SpaceAboutTab({
     initialMembers,
     selectedGroups,
     initialGroups,
+    isRestricted,
+    initialIsRestricted,
   ]);
 
   const canSave = useMemo(() => {
@@ -116,6 +121,7 @@ export function SpaceAboutTab({
     planAllowsSCIM,
     selectedGroups,
     selectedMembers,
+    isRestricted,
     space,
   ]);
 

--- a/front/components/spaces/CreateOrEditSpaceModal.tsx
+++ b/front/components/spaces/CreateOrEditSpaceModal.tsx
@@ -8,7 +8,6 @@ import {
   SheetFooter,
   SheetHeader,
   SheetTitle,
-  SliderToggle,
 } from "@dust-tt/sparkle";
 import { useRouter } from "next/router";
 import * as React from "react";
@@ -17,6 +16,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { ConfirmContext } from "@app/components/Confirm";
 import { ConfirmDeleteSpaceDialog } from "@app/components/spaces/ConfirmDeleteSpaceDialog";
 import { RestrictedAccessBody } from "@app/components/spaces/RestrictedAccessBody";
+import { RestrictedAccessHeader } from "@app/components/spaces/RestrictedAccessHeader";
 import { useGroups } from "@app/lib/swr/groups";
 import {
   useCreateSpace,
@@ -33,7 +33,6 @@ import type {
   SpaceType,
   UserType,
 } from "@app/types";
-import { RestrictedAccessHeader } from "@app/components/spaces/RestrictedAccessHeader";
 
 type MembersManagementType = "manual" | "group";
 

--- a/front/components/spaces/CreateOrEditSpaceModal.tsx
+++ b/front/components/spaces/CreateOrEditSpaceModal.tsx
@@ -33,6 +33,7 @@ import type {
   SpaceType,
   UserType,
 } from "@app/types";
+import { RestrictedAccessHeader } from "@app/components/spaces/RestrictedAccessHeader";
 
 type MembersManagementType = "manual" | "group";
 
@@ -349,6 +350,8 @@ export function CreateOrEditSpaceModal({
                   setSelectedMembers([user, ...selectedMembers]);
                 }
               }}
+              unrestrictedDescription="Restricted access is disabled. The space is accessible to everyone in
+          the workspace."
             />
 
             {isRestricted && (
@@ -440,33 +443,6 @@ function SpaceDeleteSection({
         isDeleting={isDeleting}
       />
       <Separator />
-    </>
-  );
-}
-
-interface RestrictedAccessHeaderProps {
-  isRestricted: boolean;
-  onToggle: () => void;
-}
-
-function RestrictedAccessHeader({
-  isRestricted,
-  onToggle,
-}: RestrictedAccessHeaderProps) {
-  return (
-    <>
-      <div className="flex w-full items-center justify-between overflow-visible">
-        <Page.SectionHeader title="Restricted Access" />
-        <SliderToggle selected={isRestricted} onClick={onToggle} />
-      </div>
-      {isRestricted ? (
-        <span>Restricted access is active.</span>
-      ) : (
-        <span>
-          Restricted access is disabled. The space is accessible to everyone in
-          the workspace.
-        </span>
-      )}
     </>
   );
 }

--- a/front/components/spaces/RestrictedAccessHeader.tsx
+++ b/front/components/spaces/RestrictedAccessHeader.tsx
@@ -1,0 +1,27 @@
+import { Page, SliderToggle } from "@dust-tt/sparkle";
+
+interface RestrictedAccessHeaderProps {
+  isRestricted: boolean;
+  onToggle: () => void;
+  unrestrictedDescription: string;
+}
+
+export function RestrictedAccessHeader({
+  isRestricted,
+  onToggle,
+  unrestrictedDescription,
+}: RestrictedAccessHeaderProps) {
+  return (
+    <>
+      <div className="flex w-full items-center justify-between overflow-visible">
+        <Page.SectionHeader title="Restricted Access" />
+        <SliderToggle selected={isRestricted} onClick={onToggle} />
+      </div>
+      {isRestricted ? (
+        <span>Restricted access is active.</span>
+      ) : (
+        <span>{unrestrictedDescription}</span>
+      )}
+    </>
+  );
+}

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -895,6 +895,10 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     return this.isRegular() && !this.isOpen();
   }
 
+  isProjectAndRestricted() {
+    return this.isProject() && !this.groups.some((group) => group.isGlobal());
+  }
+
   isRegularAndOpen() {
     return this.isRegular() && this.isOpen();
   }
@@ -972,7 +976,8 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     return {
       createdAt: this.createdAt.getTime(),
       groupIds: this.groups.map((group) => group.sId),
-      isRestricted: this.isRegularAndRestricted(),
+      isRestricted:
+        this.isRegularAndRestricted() || this.isProjectAndRestricted(),
 
       kind: this.kind,
       managementMode: this.managementMode,

--- a/front/pages/w/[wId]/conversation/space/[spaceId]/index.tsx
+++ b/front/pages/w/[wId]/conversation/space/[spaceId]/index.tsx
@@ -391,6 +391,7 @@ export default function SpaceConversations({
                     : []
                 }
                 initialManagementMode={spaceInfo.managementMode}
+                initialIsRestricted={spaceInfo.isRestricted}
               />
             )}
           </TabsContent>

--- a/front/pages/w/[wId]/conversation/space/[spaceId]/index.tsx
+++ b/front/pages/w/[wId]/conversation/space/[spaceId]/index.tsx
@@ -378,7 +378,7 @@ export default function SpaceConversations({
               <SpaceAboutTab
                 owner={owner}
                 space={spaceInfo}
-                initialMembers={spaceInfo.members ?? []}
+                initialMembers={spaceInfo.members}
                 planAllowsSCIM={planAllowsSCIM}
                 initialGroups={
                   planAllowsSCIM &&


### PR DESCRIPTION
## Description

This PR allows users to set projects as restricted or unrestricted:
- on an existing project in the "About" tab:
<img width="396" height="269" alt="image" src="https://github.com/user-attachments/assets/5a5ca0ba-9330-4b1d-906f-3802450ed51e" />

- when creating a new project:
<img width="464" height="270" alt="image" src="https://github.com/user-attachments/assets/6b5422eb-b246-4221-b036-d50cff99f93b" />


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Deploy front
