### PR TITLE
fix(dust-hive): Skip invalid .git directories when finding repo root

### DIFF
--- a/x/henry/dust-hive/src/lib/paths.ts
+++ b/x/henry/dust-hive/src/lib/paths.ts
@@ -87,7 +87,33 @@ export function getWatchScriptPath(): string {
   return join(DUST_HIVE_SCRIPTS, "watch-logs.sh");
 }
 
-// Find repo root by looking for .git directory
+// Check if a .git path represents a valid git repository
+// Returns true for: real git repos (.git/HEAD exists) or worktrees (.git is a file)
+async function isValidGitDir(gitPath: string): Promise<boolean> {
+  try {
+    const gitStat = await stat(gitPath);
+    if (gitStat.isFile()) {
+      // Worktree: .git is a file pointing to the main repo
+      return true;
+    }
+    if (gitStat.isDirectory()) {
+      // Real repo: must have .git/HEAD
+      try {
+        await stat(join(gitPath, "HEAD"));
+        return true;
+      } catch {
+        // .git directory exists but no HEAD - not a valid repo
+        // (e.g., just .git/info/exclude for local ignores)
+        return false;
+      }
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+// Find repo root by looking for valid .git directory or file
 export async function findRepoRoot(startPath?: string): Promise<string | null> {
   let current = resolve(startPath ?? process.cwd());
 
@@ -95,7 +121,12 @@ export async function findRepoRoot(startPath?: string): Promise<string | null> {
     const gitPath = join(current, ".git");
     try {
       await stat(gitPath);
-      return current;
+      // Found .git, but verify it's a real git repo
+      if (await isValidGitDir(gitPath)) {
+        return current;
+      }
+      // Not a valid git repo, continue traversing up
+      current = dirname(current);
     } catch (error) {
       if (!isErrnoException(error) || error.code !== "ENOENT") {
         throw error;


### PR DESCRIPTION
## Description

Fixes an issue where `dust-hive spawn` would fail when run from a subdirectory of the main repo that contains a `.git/info/exclude` file (for local ignores).

The `findRepoRoot()` function now validates that a `.git` path is a real git repository by checking for `.git/HEAD` (for directories) or treating `.git` files as valid worktrees. This prevents false positives from directories that only contain `.git/info/exclude`.

## Tests

- Added 3 unit tests for `findRepoRoot()` covering:
  - Skipping `.git` directories without HEAD file
  - Finding real git repos with HEAD file
  - Finding real git repos from repo root
- All existing tests pass (`bun run check`)

## Risk

Low - this change only affects the repo detection logic in dust-hive. The validation is additive (checking for HEAD) and won't affect valid git repositories.

## Deploy Plan

No deployment needed - this is a local development tool.