### PR TITLE
Improve image preview in conversations

### DIFF
--- a/sparkle/src/components/InteractiveImageGrid.tsx
+++ b/sparkle/src/components/InteractiveImageGrid.tsx
@@ -77,14 +77,27 @@ const ImagePreview = React.forwardRef<HTMLDivElement, ImagePreviewProps>(
               alt={image.alt}
               className="s-h-full s-w-full s-rounded-2xl s-object-cover"
             />
+            {/* Blur overlay with filename - hidden by default, shown on hover */}
             <div
               className={cn(
-                "s-absolute s-inset-0 s-bg-gradient-to-b",
-                "s-from-black/40 s-via-transparent s-to-black/40",
-                "s-opacity-0 s-transition-opacity s-duration-200",
+                "s-absolute s-inset-0 s-z-10",
+                "s-flex s-items-center s-justify-center",
+                "s-bg-primary-100/80 dark:s-bg-primary-100-night/80",
+                "s-backdrop-blur-sm",
+                "s-opacity-0 s-transition s-duration-200",
                 "group-hover/preview:s-opacity-100"
               )}
-            />
+            >
+              <span
+                className={cn(
+                  "s-max-w-[90%] s-truncate s-px-2 s-text-center",
+                  "s-text-sm s-font-medium",
+                  "s-text-foreground dark:s-text-foreground-night"
+                )}
+              >
+                {image.title}
+              </span>
+            </div>
             <div
               className={cn(
                 "s-absolute s-right-1 s-top-1 s-z-10 s-flex",
@@ -252,68 +265,74 @@ function InteractiveImageGrid({
           )}
         </div>
       </DialogTrigger>
-      <DialogContent className="s-w-auto s-max-w-[90vw] s-overflow-hidden s-p-0">
+      <DialogContent className="s-w-auto s-max-w-[90vw] s-overflow-hidden s-p-3">
         {currentImageIndex !== null && (
-          <div className="s-relative s-flex s-flex-col">
-            {/* Top bar with close button */}
-            <div className="s-flex s-h-10 s-flex-shrink-0 s-items-center s-justify-end s-px-3 s-pt-2">
-              <DialogClose asChild>
-                <Button variant="outline" size="sm" icon={XMarkIcon} />
-              </DialogClose>
-            </div>
+          <div className="s-relative s-flex s-items-center s-justify-center s-gap-2">
+            {/* Previous button */}
+            {images.length > 1 && (
+              <Button
+                variant="ghost"
+                size="sm"
+                icon={ChevronLeftIcon}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handlePrevious();
+                }}
+              />
+            )}
 
-            {/* Main content */}
-            <div className="s-flex s-items-center s-justify-center s-gap-2 s-px-3 s-pb-2">
-              {images.length > 1 && (
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  icon={ChevronLeftIcon}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    handlePrevious();
-                  }}
-                />
-              )}
+            {/* Image container with overlay buttons */}
+            <div className="s-relative">
               {images[currentImageIndex].isLoading ? (
                 <ImageLoadingState size="lg" />
               ) : (
-                <img
-                  src={images[currentImageIndex].imageUrl}
-                  alt={images[currentImageIndex].alt}
-                  className="s-max-h-[70vh] s-max-w-full s-rounded-lg s-object-contain"
-                  onLoad={() => setImageLoaded(true)}
-                />
-              )}
-              {images.length > 1 && (
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  icon={ChevronRightIcon}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    handleNext();
-                  }}
-                />
+                <>
+                  <img
+                    src={images[currentImageIndex].imageUrl}
+                    alt={images[currentImageIndex].alt}
+                    className="s-max-h-[70vh] s-max-w-full s-rounded-lg s-object-contain"
+                    onLoad={() => setImageLoaded(true)}
+                  />
+                  {/* Close button - top right of image */}
+                  <DialogClose asChild>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      icon={XMarkIcon}
+                      className="s-absolute s-right-2 s-top-2"
+                    />
+                  </DialogClose>
+                  {/* Download button - bottom right of image */}
+                  {imageLoaded && (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      icon={ArrowDownOnSquareIcon}
+                      tooltip="Download"
+                      className="s-absolute s-bottom-2 s-right-2"
+                      onClick={async () => {
+                        await handleDownload(
+                          images[currentImageIndex].downloadUrl,
+                          images[currentImageIndex].title
+                        );
+                      }}
+                    />
+                  )}
+                </>
               )}
             </div>
 
-            {/* Bottom controls */}
-            {!images[currentImageIndex].isLoading && imageLoaded && (
-              <div className="s-flex s-h-10 s-flex-shrink-0 s-items-center s-justify-end s-px-3 s-pb-2">
-                <Button
-                  variant="outline"
-                  size="sm"
-                  icon={ArrowDownOnSquareIcon}
-                  tooltip="Download"
-                  onClick={async () => {
-                    await handleDownload(
-                      images[currentImageIndex].downloadUrl,
-                      images[currentImageIndex].title
-                    );
-                  }}
-                />
-              </div>
+            {/* Next button */}
+            {images.length > 1 && (
+              <Button
+                variant="ghost"
+                size="sm"
+                icon={ChevronRightIcon}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleNext();
+                }}
+              />
             )}
           </div>
         )}

--- a/sparkle/src/components/InteractiveImageGrid.tsx
+++ b/sparkle/src/components/InteractiveImageGrid.tsx
@@ -51,11 +51,11 @@ interface ImagePreviewProps {
   };
   onClick: () => void;
   onDownload: (e: React.MouseEvent) => Promise<void>;
-  onRemove?: (e: React.MouseEvent) => void;
+  onClose?: (e: React.MouseEvent) => void;
 }
 
 const ImagePreview = React.forwardRef<HTMLDivElement, ImagePreviewProps>(
-  ({ image, onClick, onDownload, onRemove }, ref) => {
+  ({ image, onClick, onDownload, onClose }, ref) => {
     return (
       <div
         ref={ref}
@@ -105,17 +105,17 @@ const ImagePreview = React.forwardRef<HTMLDivElement, ImagePreviewProps>(
                 "group-hover/preview:s-opacity-100"
               )}
             >
-              {onRemove && (
+              {onClose && (
                 <Button
                   variant="ghost"
                   size="xs"
                   icon={XMarkIcon}
                   className="s-text-white dark:s-text-white"
                   tooltip="Remove"
-                  onClick={onRemove}
+                  onClick={onClose}
                 />
               )}
-              {!onRemove && (
+              {!onClose && (
                 <Button
                   variant="ghost"
                   size="xs"
@@ -152,14 +152,14 @@ interface InteractiveImageGridProps {
     isLoading?: boolean;
     title: string;
   }[];
-  onRemove?: () => void;
+  onClose?: () => void;
   size?: InteractiveImageGridSize;
 }
 
 function InteractiveImageGrid({
   className,
   images,
-  onRemove,
+  onClose,
   size = "lg",
 }: InteractiveImageGridProps) {
   const [currentImageIndex, setCurrentImageIndex] = React.useState<
@@ -236,11 +236,11 @@ function InteractiveImageGrid({
                   e.stopPropagation();
                   await handleDownload(images[0].downloadUrl, images[0].title);
                 }}
-                onRemove={
-                  onRemove
+                onClose={
+                  onClose
                     ? (e) => {
                         e.stopPropagation();
-                        onRemove();
+                        onClose();
                       }
                     : undefined
                 }
@@ -265,7 +265,7 @@ function InteractiveImageGrid({
           )}
         </div>
       </DialogTrigger>
-      <DialogContent className="s-w-auto s-max-w-[90vw] s-overflow-hidden s-p-3">
+      <DialogContent size="xl" className="s-max-w-[90vw] s-overflow-hidden s-p-3">
         {currentImageIndex !== null && (
           <div className="s-relative s-flex s-items-center s-justify-center s-gap-2">
             {/* Previous button */}
@@ -290,7 +290,7 @@ function InteractiveImageGrid({
                   <img
                     src={images[currentImageIndex].imageUrl}
                     alt={images[currentImageIndex].alt}
-                    className="s-max-h-[70vh] s-max-w-full s-rounded-lg s-object-contain"
+                    className="s-max-h-full s-max-w-full s-rounded-lg s-object-contain"
                     onLoad={() => setImageLoaded(true)}
                   />
                   {/* Close button - top right of image */}

--- a/sparkle/src/components/InteractiveImageGrid.tsx
+++ b/sparkle/src/components/InteractiveImageGrid.tsx
@@ -297,7 +297,7 @@ function InteractiveImageGrid({
                   <DialogClose asChild>
                     <Button
                       variant="outline"
-                      size="sm"
+                      size="xs"
                       icon={XMarkIcon}
                       className="s-absolute s-right-2 s-top-2"
                     />
@@ -306,7 +306,7 @@ function InteractiveImageGrid({
                   {imageLoaded && (
                     <Button
                       variant="outline"
-                      size="sm"
+                      size="xs"
                       icon={ArrowDownOnSquareIcon}
                       tooltip="Download"
                       className="s-absolute s-bottom-2 s-right-2"

--- a/sparkle/src/stories/InteractiveImageGrid.stories.tsx
+++ b/sparkle/src/stories/InteractiveImageGrid.stories.tsx
@@ -76,3 +76,38 @@ export const InteractiveImageExample = () => (
     </div>
   </div>
 );
+
+export const InteractiveImageWithRemove = () => {
+  const [removed, setRemoved] = React.useState(false);
+
+  return (
+    <div className="s-flex s-flex-col s-gap-8">
+      <div>
+        <h2 className="s-mb-2">
+          With onRemove callback (hover to see X button, no download button)
+        </h2>
+        {removed ? (
+          <div className="s-flex s-h-24 s-w-24 s-items-center s-justify-center s-rounded-2xl s-bg-muted s-text-muted-foreground">
+            Removed!
+            <button
+              className="s-ml-2 s-text-primary-600 s-underline"
+              onClick={() => setRemoved(false)}
+            >
+              Reset
+            </button>
+          </div>
+        ) : (
+          <InteractiveImageGrid
+            size="sm"
+            images={images.slice(1, 2)}
+            onRemove={() => setRemoved(true)}
+          />
+        )}
+      </div>
+      <div>
+        <h2 className="s-mb-2">Without onRemove (hover to see download button, no X button)</h2>
+        <InteractiveImageGrid size="sm" images={images.slice(1, 2)} />
+      </div>
+    </div>
+  );
+};

--- a/sparkle/src/stories/InteractiveImageGrid.stories.tsx
+++ b/sparkle/src/stories/InteractiveImageGrid.stories.tsx
@@ -98,7 +98,6 @@ export const InteractiveImageWithRemove = () => {
           </div>
         ) : (
           <InteractiveImageGrid
-            size="sm"
             images={images.slice(1, 2)}
             onRemove={() => setRemoved(true)}
           />
@@ -106,7 +105,7 @@ export const InteractiveImageWithRemove = () => {
       </div>
       <div>
         <h2 className="s-mb-2">Without onRemove (hover to see download button, no X button)</h2>
-        <InteractiveImageGrid size="sm" images={images.slice(1, 2)} />
+        <InteractiveImageGrid images={images.slice(1, 2)} />
       </div>
     </div>
   );

--- a/sparkle/src/stories/InteractiveImageGrid.stories.tsx
+++ b/sparkle/src/stories/InteractiveImageGrid.stories.tsx
@@ -84,7 +84,7 @@ export const InteractiveImageWithRemove = () => {
     <div className="s-flex s-flex-col s-gap-8">
       <div>
         <h2 className="s-mb-2">
-          With onRemove callback (hover to see X button, no download button)
+          With onClose callback (hover to see X button, no download button)
         </h2>
         {removed ? (
           <div className="s-flex s-h-24 s-w-24 s-items-center s-justify-center s-rounded-2xl s-bg-muted s-text-muted-foreground">
@@ -99,12 +99,12 @@ export const InteractiveImageWithRemove = () => {
         ) : (
           <InteractiveImageGrid
             images={images.slice(1, 2)}
-            onRemove={() => setRemoved(true)}
+            onClose={() => setRemoved(true)}
           />
         )}
       </div>
       <div>
-        <h2 className="s-mb-2">Without onRemove (hover to see download button, no X button)</h2>
+        <h2 className="s-mb-2">Without onClose (hover to see download button, no X button)</h2>
         <InteractiveImageGrid images={images.slice(1, 2)} />
       </div>
     </div>


### PR DESCRIPTION
## Description

First step of https://github.com/dust-tt/tasks/issues/5870, modifying the sparkle component, next will be to use it in front when this is merged.  

Change the visual of image attachments.  
* Image is clearly visible by default
* When hovering, it blurs and we see the filename
* Depending whether onRemove is set, user can either remove the image or download it from the preview
* When clicking on the preview, the dialog visual is improved compared to current state which open full-width  


### Default preview
<img width="834" height="354" alt="Screenshot 2026-01-09 at 11 32 17" src="https://github.com/user-attachments/assets/ffd7e27f-6615-4908-8f13-59861db2688e" />

### Hovering
<img width="836" height="348" alt="Screenshot 2026-01-09 at 11 32 26" src="https://github.com/user-attachments/assets/19fce8b7-ce07-47ed-a88c-59fc0c72c904" />
<img width="882" height="356" alt="Screenshot 2026-01-09 at 11 32 34" src="https://github.com/user-attachments/assets/7a96405f-583b-48d9-b6c2-889e3071b9f1" />

### Opening popover
<img width="1920" height="661" alt="Screenshot 2026-01-09 at 11 41 46" src="https://github.com/user-attachments/assets/2b471f55-d02e-48af-9f46-9f77705bd070" />




## Tests

Locally

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy Sparkle
