### PR TITLE
[Front] fix(skills): correct topViews/nonTopViews filter logic

### DIFF
--- a/front/components/agent_builder/capabilities/capabilities_sheet/CapabilitiesFooter.tsx
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/CapabilitiesFooter.tsx
@@ -1,11 +1,11 @@
 import { Chip } from "@dust-tt/sparkle";
 
 import type { AgentBuilderSkillsType } from "@app/components/agent_builder/AgentBuilderFormContext";
-import type { SelectedTool } from "@app/components/agent_builder/capabilities/mcp/MCPServerViewsSheet";
 import {
   getSelectedToolIcon,
   getSelectedToolLabel,
 } from "@app/components/agent_builder/capabilities/mcp/utils/toolDisplayUtils";
+import type { SelectedTool } from "@app/components/agent_builder/capabilities/shared/types";
 import { getSkillIcon } from "@app/lib/skill";
 
 interface CapabilitiesFooterProps {

--- a/front/components/agent_builder/capabilities/capabilities_sheet/hooks.ts
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/hooks.ts
@@ -6,12 +6,12 @@ import type {
   AgentBuilderSkillsType,
   MCPFormData,
 } from "@app/components/agent_builder/AgentBuilderFormContext";
-import type { SelectedTool } from "@app/components/agent_builder/capabilities/capabilities_sheet/types";
-import { TOP_MCP_SERVER_VIEWS } from "@app/components/agent_builder/capabilities/capabilities_sheet/types";
 import {
   generateUniqueActionName,
   nameToStorageFormat,
 } from "@app/components/agent_builder/capabilities/mcp/utils/actionNameUtils";
+import type { SelectedTool } from "@app/components/agent_builder/capabilities/shared/types";
+import { TOP_MCP_SERVER_VIEWS } from "@app/components/agent_builder/capabilities/shared/types";
 import type {
   ConfigurationState,
   SheetState,
@@ -228,11 +228,11 @@ export const useToolSelection = ({
           );
         });
 
-    const topViews = mcpServerViewsWithoutKnowledge.filter(
-      (view) => !TOP_MCP_SERVER_VIEWS.includes(view.server.name)
-    );
-    const nonTopViews = mcpServerViewsWithoutKnowledge.filter((view) =>
+    const topViews = mcpServerViewsWithoutKnowledge.filter((view) =>
       TOP_MCP_SERVER_VIEWS.includes(view.server.name)
+    );
+    const nonTopViews = mcpServerViewsWithoutKnowledge.filter(
+      (view) => !TOP_MCP_SERVER_VIEWS.includes(view.server.name)
     );
 
     return {

--- a/front/components/agent_builder/capabilities/capabilities_sheet/types.ts
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/types.ts
@@ -1,28 +1,10 @@
 import type { AgentBuilderSkillsType } from "@app/components/agent_builder/AgentBuilderFormContext";
+import type { SelectedTool } from "@app/components/agent_builder/capabilities/shared/types";
 import type {
   CapabilitiesSheetState,
   SheetState,
 } from "@app/components/agent_builder/skills/types";
-import type { MCPServerViewTypeWithLabel } from "@app/components/shared/tools_picker/MCPServerViewsContext";
 import type { BuilderAction } from "@app/components/shared/tools_picker/types";
-import { AGENT_MEMORY_SERVER_NAME } from "@app/lib/actions/mcp_internal_actions/constants";
-
-// TODO(skills 2025-12-18): duplicated from MCPServerViewsSheet, to cleanup later
-export const TOP_MCP_SERVER_VIEWS = [
-  "web_search_&_browse",
-  "image_generation",
-  AGENT_MEMORY_SERVER_NAME,
-  "deep_dive",
-  "interactive_content",
-  "slack",
-  "gmail",
-  "google_calendar",
-];
-
-export type SelectedTool = {
-  view: MCPServerViewTypeWithLabel;
-  configuredAction?: BuilderAction;
-};
 
 export type CapabilityFilterType = "all" | "tools" | "skills";
 

--- a/front/components/agent_builder/capabilities/mcp/MCPServerSelectionPage.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerSelectionPage.tsx
@@ -6,7 +6,7 @@ import {
 } from "@dust-tt/sparkle";
 import React, { useMemo } from "react";
 
-import type { SelectedTool } from "@app/components/agent_builder/capabilities/mcp/MCPServerViewsSheet";
+import type { SelectedTool } from "@app/components/agent_builder/capabilities/shared/types";
 import {
   InternalActionIcons,
   isCustomResourceIconType,

--- a/front/components/agent_builder/capabilities/mcp/MCPServerViewsFooter.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerViewsFooter.tsx
@@ -1,11 +1,11 @@
 import { Chip } from "@dust-tt/sparkle";
 import React from "react";
 
-import type { SelectedTool } from "@app/components/agent_builder/capabilities/mcp/MCPServerViewsSheet";
 import {
   getSelectedToolIcon,
   getSelectedToolLabel,
 } from "@app/components/agent_builder/capabilities/mcp/utils/toolDisplayUtils";
+import type { SelectedTool } from "@app/components/agent_builder/capabilities/shared/types";
 
 interface MCPServerViewsFooterProps {
   selectedToolsInSheet: SelectedTool[];

--- a/front/components/agent_builder/capabilities/mcp/MCPServerViewsSheet.tsx
+++ b/front/components/agent_builder/capabilities/mcp/MCPServerViewsSheet.tsx
@@ -48,6 +48,8 @@ import { JsonSchemaSection } from "@app/components/agent_builder/capabilities/sh
 import { NameSection } from "@app/components/agent_builder/capabilities/shared/NameSection";
 import { SecretSection } from "@app/components/agent_builder/capabilities/shared/SecretSection";
 import { TimeFrameSection } from "@app/components/agent_builder/capabilities/shared/TimeFrameSection";
+import type { SelectedTool } from "@app/components/agent_builder/capabilities/shared/types";
+import { TOP_MCP_SERVER_VIEWS } from "@app/components/agent_builder/capabilities/shared/types";
 import type { ConfigurationPagePageId } from "@app/components/agent_builder/types";
 import {
   getDefaultMCPAction,
@@ -63,25 +65,8 @@ import type {
 import { FormProvider } from "@app/components/sparkle/FormProvider";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { getAvatar } from "@app/lib/actions/mcp_icons";
-import { AGENT_MEMORY_SERVER_NAME } from "@app/lib/actions/mcp_internal_actions/constants";
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
-
-const TOP_MCP_SERVER_VIEWS = [
-  "web_search_&_browse",
-  "image_generation",
-  AGENT_MEMORY_SERVER_NAME,
-  "deep_dive",
-  "interactive_content",
-  "slack",
-  "gmail",
-  "google_calendar",
-];
-
-export type SelectedTool = {
-  view: MCPServerViewTypeWithLabel;
-  configuredAction?: BuilderAction;
-};
 
 export type SheetMode =
   | { type: "add" }

--- a/front/components/agent_builder/capabilities/mcp/utils/actionNameUtils.ts
+++ b/front/components/agent_builder/capabilities/mcp/utils/actionNameUtils.ts
@@ -1,4 +1,4 @@
-import type { SelectedTool } from "@app/components/agent_builder/capabilities/mcp/MCPServerViewsSheet";
+import type { SelectedTool } from "@app/components/agent_builder/capabilities/shared/types";
 import type { BuilderAction } from "@app/components/shared/tools_picker/types";
 
 interface GenerateUniqueActionNameParams {

--- a/front/components/agent_builder/capabilities/mcp/utils/sheetUtils.ts
+++ b/front/components/agent_builder/capabilities/mcp/utils/sheetUtils.ts
@@ -3,10 +3,8 @@ import type { Dispatch, SetStateAction } from "react";
 import type { UseFormReturn } from "react-hook-form";
 
 import type { MCPFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
-import type {
-  SelectedTool,
-  SheetMode,
-} from "@app/components/agent_builder/capabilities/mcp/MCPServerViewsSheet";
+import type { SheetMode } from "@app/components/agent_builder/capabilities/mcp/MCPServerViewsSheet";
+import type { SelectedTool } from "@app/components/agent_builder/capabilities/shared/types";
 import type { ConfigurationPagePageId } from "@app/components/agent_builder/types";
 import { TOOLS_SHEET_PAGE_IDS } from "@app/components/agent_builder/types";
 import type { MCPServerViewTypeWithLabel } from "@app/components/shared/tools_picker/MCPServerViewsContext";

--- a/front/components/agent_builder/capabilities/mcp/utils/toolDisplayUtils.ts
+++ b/front/components/agent_builder/capabilities/mcp/utils/toolDisplayUtils.ts
@@ -1,7 +1,7 @@
 import { ActionIcons, BookOpenIcon } from "@dust-tt/sparkle";
 import type { ComponentType } from "react";
 
-import type { SelectedTool } from "@app/components/agent_builder/capabilities/mcp/MCPServerViewsSheet";
+import type { SelectedTool } from "@app/components/agent_builder/capabilities/shared/types";
 import {
   InternalActionIcons,
   isCustomResourceIconType,

--- a/front/components/agent_builder/capabilities/shared/types.ts
+++ b/front/components/agent_builder/capabilities/shared/types.ts
@@ -1,0 +1,19 @@
+import type { MCPServerViewTypeWithLabel } from "@app/components/shared/tools_picker/MCPServerViewsContext";
+import type { BuilderAction } from "@app/components/shared/tools_picker/types";
+import { AGENT_MEMORY_SERVER_NAME } from "@app/lib/actions/mcp_internal_actions/constants";
+
+export type SelectedTool = {
+  view: MCPServerViewTypeWithLabel;
+  configuredAction?: BuilderAction;
+};
+
+export const TOP_MCP_SERVER_VIEWS = [
+  "web_search_&_browse",
+  "image_generation",
+  AGENT_MEMORY_SERVER_NAME,
+  "deep_dive",
+  "interactive_content",
+  "slack",
+  "gmail",
+  "google_calendar",
+];

--- a/front/components/agent_builder/skills/AgentBuilderSkillsBlock.tsx
+++ b/front/components/agent_builder/skills/AgentBuilderSkillsBlock.tsx
@@ -20,9 +20,9 @@ import type {
 } from "@app/components/agent_builder/AgentBuilderFormContext";
 import { AgentBuilderSectionContainer } from "@app/components/agent_builder/AgentBuilderSectionContainer";
 import { CapabilitiesSheet } from "@app/components/agent_builder/capabilities/capabilities_sheet/CapabilitiesSheet";
-import type { SelectedTool } from "@app/components/agent_builder/capabilities/capabilities_sheet/types";
 import { KnowledgeConfigurationSheet } from "@app/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet";
 import { validateMCPActionConfiguration } from "@app/components/agent_builder/capabilities/mcp/utils/formValidation";
+import type { SelectedTool } from "@app/components/agent_builder/capabilities/shared/types";
 import { getSheetStateForActionEdit } from "@app/components/agent_builder/skills/sheetRouting";
 import { useSkillsAndActionsState } from "@app/components/agent_builder/skills/skillsAndActionsState";
 import type { SheetState } from "@app/components/agent_builder/skills/types";


### PR DESCRIPTION
## Description

- Fix inverted `topViews`/`nonTopViews` filter logic in `useToolSelection` hook
- Extract `SelectedTool` type and `TOP_MCP_SERVER_VIEWS` constant to shared location (`capabilities/shared/types.ts`) (clear todo)

_(cleaning up todo while there https://github.com/dust-tt/tasks/issues/5767)_

## Tests

Manual

## Risk

Low.

## Deploy Plan

Deploy front.
