### PR TITLE
[dust-hive] Use bash instead of sh for zellij pane commands

### DIFF
--- a/x/henry/dust-hive/src/commands/open.ts
+++ b/x/henry/dust-hive/src/commands/open.ts
@@ -180,7 +180,7 @@ function generateLayout(
     ? `    tab name="warm" {
         pane {
             cwd "${kdlEscape(worktreePath)}"
-            command "sh"
+            command "bash"
             args "-c" "${kdlEscape(warmCommand)}"
             start_suspended false
         }
@@ -199,7 +199,7 @@ ${tabTemplate}
     tab name="${kdlEscape(envName)}" focus=true {
         pane {
             cwd "${kdlEscape(worktreePath)}"
-            command "sh"
+            command "bash"
             args "-c" "${kdlEscape(shellCommand)}"
             start_suspended false
         }
@@ -457,7 +457,7 @@ export async function openMainSession(
       await createSessionInBackground(sessionName, layoutPath);
     }
 
-    // Switch to session
+    // Switch to session using zellij-switch plugin
     logger.info(`Switching to session '${sessionName}'...`);
     const switchProc = Bun.spawn(
       [


### PR DESCRIPTION
## Description

On Ubuntu/Debian, `/bin/sh` is `dash` which doesn't support the `source` builtin. This changes zellij layout commands from `sh -c` to `bash -c` so that `source env.sh` works correctly.

The user's preferred shell (`$SHELL`) is still used after sourcing the env file via `exec $SHELL`.

## Tests

- Ran `bun run check` (typecheck, lint, tests all pass)
- Issue discovered on Linux devbox where shell tab showed `sh: 1: source: not found`

## Risk

Low - simple change from `sh` to `bash` for running the initial source command. User ends up in their preferred shell regardless.

## Deploy Plan

N/A - dust-hive is a local development tool