### PR TITLE
fix(dust-hive): Use docker stop instead of down when cooling

### DIFF
--- a/x/henry/dust-hive/.claude/skills/dust-hive/SKILL.md
+++ b/x/henry/dust-hive/.claude/skills/dust-hive/SKILL.md
@@ -86,10 +86,12 @@ dust-hive forward status
 |---------|-------------|
 | `dust-hive spawn [--name NAME]` | Create new environment |
 | `dust-hive warm [NAME]` | Start docker + all services |
-| `dust-hive cool [NAME]` | Stop services, keep SDK |
+| `dust-hive cool [NAME]` | Pause services + docker, keep SDK (fast restart) |
 | `dust-hive start [NAME]` | Resume stopped environment |
-| `dust-hive stop [NAME]` | Full stop of environment |
+| `dust-hive stop [NAME]` | Full stop + remove docker containers |
 | `dust-hive destroy NAME` | Remove environment completely |
+
+> **cool vs stop**: `cool` pauses Docker containers (faster re-warm), `stop` removes them (clean slate).
 
 ### Development
 | Command | Description |

--- a/x/henry/dust-hive/CLAUDE.md
+++ b/x/henry/dust-hive/CLAUDE.md
@@ -56,7 +56,7 @@ src/
 ├── forward-daemon.ts  # TCP forwarder daemon (ports 3000,3001,3002,3006 → env)
 ├── commands/          # Command implementations (all MVP commands complete)
 │   ├── cache.ts       # Cache management (show cache status)
-│   ├── cool.ts        # Stop services, keep SDK
+│   ├── cool.ts        # Pause services + docker, keep SDK
 │   ├── destroy.ts     # Remove environment
 │   ├── doctor.ts      # Prerequisite checking
 │   ├── forward.ts     # OAuth port forwarding management
@@ -152,9 +152,9 @@ tests/
 |---------|-------------|
 | `spawn` | Create environment (worktree + symlinks + SDK watch); supports --warm, --no-attach, --wait |
 | `warm` | Start docker + all services (auto-forwards port 3000, supports --no-forward/--force-ports) |
-| `cool` | Stop services, keep SDK watch |
+| `cool` | Pause services + docker, keep SDK (fast restart) |
 | `start [NAME]` | Resume stopped env (start SDK watch) |
-| `stop [NAME]` | Full stop of env (stop all services + docker) |
+| `stop [NAME]` | Full stop + remove docker containers |
 | `destroy` | Remove environment |
 | `open` | Attach to zellij session |
 | `reload` | Kill and reopen zellij session |

--- a/x/henry/dust-hive/README.md
+++ b/x/henry/dust-hive/README.md
@@ -117,9 +117,9 @@ dust-hive down
 |---------|-------------|
 | `spawn [NAME] [--no-open] [--no-attach] [--warm] [--wait]` | Create new environment |
 | `warm [NAME] [--no-forward] [--force-ports]` | Start docker + all services |
-| `cool [NAME]` | Stop services, keep SDK watch |
+| `cool [NAME]` | Pause services + docker, keep SDK (fast restart) |
 | `start [NAME]` | Resume stopped environment (when NAME provided) |
-| `stop [NAME]` | Full stop of environment (when NAME provided) |
+| `stop [NAME]` | Full stop + remove docker containers |
 | `destroy NAME [--force]` | Remove environment completely |
 | `restart [NAME] SERVICE` | Restart a single service |
 | `open [NAME]` | Open zellij terminal session |

--- a/x/henry/dust-hive/src/commands/cool.ts
+++ b/x/henry/dust-hive/src/commands/cool.ts
@@ -1,5 +1,5 @@
 import { withEnvironment } from "../lib/commands";
-import { stopDocker } from "../lib/docker";
+import { pauseDocker } from "../lib/docker";
 import { logger } from "../lib/logger";
 import { stopService } from "../lib/process";
 import { CommandError, Err, Ok } from "../lib/result";
@@ -26,9 +26,9 @@ export const coolCommand = withEnvironment("cool", async (env) => {
   }
   logger.success("Services stopped");
 
-  // Stop Docker
-  const dockerStopped = await stopDocker(env.name);
-  if (!dockerStopped) {
+  // Pause Docker (stop without removing containers for faster restart)
+  const dockerPaused = await pauseDocker(env.name);
+  if (!dockerPaused) {
     logger.warn("Docker containers may need manual cleanup");
   }
 


### PR DESCRIPTION
## Description

Change the `cool` command to use `docker compose stop` instead of `docker compose down`. This preserves containers (only stops them) rather than removing them, which provides two benefits:

- **Faster re-warming**: Containers don't need to be recreated on next `warm`
- **Safer for stateful services**: Avoids potential issues with services like qdrant during container removal/recreation

The `stop` command continues to use `docker compose down` for full cleanup.

## Tests

- Ran `bun run check` (typecheck, lint, tests) - all pass

## Risk

Low risk. The change only affects the `cool` command. If containers somehow get into a bad state, users can use `dust-hive stop` followed by `dust-hive warm` to do a full container recreation.

## Deploy Plan

N/A - dust-hive is a local development tool, no deployment needed.