### PR TITLE
Avoid filtering unread or action required triggered conversations

### DIFF
--- a/front/components/assistant/conversation/utils.ts
+++ b/front/components/assistant/conversation/utils.ts
@@ -111,5 +111,8 @@ export function filterTriggeredConversations(
   if (!hideTriggered) {
     return conversations;
   }
-  return conversations.filter((c) => c.triggerId === null);
+
+  return conversations.filter(
+    (c) => c.triggerId === null || c.unread || c.actionRequired
+  );
 }


### PR DESCRIPTION
## Description

We want to avoid filtering unread conversations or conversations with actions required.  

Currently if we toggle "hide triggered conversations", all of them are hidden.  

This PR updates this behaviour to keep showing unread/action required conversations even when the filter is toggled.

## Tests

Local

## Risk

Low, only available to users with "projects" feature flag enabled.

## Deploy Plan

Deploy front
