### PR TITLE
[Front] chore(skills): add ExtendedSkillBadge component and use it in skill builder header

### DIFF
--- a/front/components/skill_builder/SkillBuilder.tsx
+++ b/front/components/skill_builder/SkillBuilder.tsx
@@ -1,11 +1,4 @@
-import {
-  BarFooter,
-  BarHeader,
-  Button,
-  cn,
-  ScrollArea,
-  XMarkIcon,
-} from "@dust-tt/sparkle";
+import { BarFooter, BarHeader, Button, cn, ScrollArea } from "@dust-tt/sparkle";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useRouter } from "next/router";
 import { useEffect, useMemo, useState } from "react";
@@ -27,6 +20,7 @@ import {
   transformSkillTypeToFormData,
 } from "@app/components/skill_builder/skillFormData";
 import { submitSkillBuilderForm } from "@app/components/skill_builder/submitSkillBuilderForm";
+import { ExtendedSkillBadge } from "@app/components/skills/ExtendedSkillBadge";
 import { appLayoutBack } from "@app/components/sparkle/AppContentLayout";
 import { FormProvider } from "@app/components/sparkle/FormProvider";
 import { useNavigationLock } from "@app/hooks/useNavigationLock";
@@ -148,17 +142,17 @@ export default function SkillBuilder({
             <BarHeader
               variant="default"
               className="mx-4"
-              title={
-                (skill ? `Edit skill ${skill.name}` : "Create new skill") +
-                (extendedSkill ? ` - based on ${extendedSkill.name}` : "")
+              title={skill ? `Edit skill ${skill.name}` : "Create new skill"}
+              description={
+                extendedSkill ? (
+                  <ExtendedSkillBadge
+                    extendedSkill={extendedSkill}
+                    className="text-sm"
+                  />
+                ) : undefined
               }
               rightActions={
-                <Button
-                  icon={XMarkIcon}
-                  onClick={handleCancel}
-                  variant="ghost"
-                  type="button"
-                />
+                <BarHeader.ButtonBar variant="close" onClose={handleCancel} />
               }
             />
 

--- a/front/components/skills/ExtendedSkillBadge.tsx
+++ b/front/components/skills/ExtendedSkillBadge.tsx
@@ -1,0 +1,28 @@
+import { cn, Icon } from "@dust-tt/sparkle";
+
+import { getSkillIcon } from "@app/lib/skill";
+import type { SkillType } from "@app/types/assistant/skill_configuration";
+
+type ExtendedSkillInfo = Pick<SkillType, "name" | "icon">;
+
+interface ExtendedSkillBadgeProps {
+  extendedSkill: ExtendedSkillInfo;
+  className?: string;
+}
+
+export function ExtendedSkillBadge({
+  extendedSkill,
+  className,
+}: ExtendedSkillBadgeProps) {
+  return (
+    <div className={cn("flex items-center gap-1 font-normal", className)}>
+      <p className="text-muted-foreground dark:text-muted-foreground-night">
+        Based on
+      </p>
+      <Icon visual={getSkillIcon(extendedSkill.icon)} size="xs" />
+      <p className="text-foreground dark:text-foreground-night">
+        {extendedSkill.name}
+      </p>
+    </div>
+  );
+}

--- a/front/components/skills/SkillDetailsSheet.tsx
+++ b/front/components/skills/SkillDetailsSheet.tsx
@@ -2,7 +2,6 @@ import {
   ArrowPathIcon,
   Button,
   ContentMessage,
-  Icon,
   InformationCircleIcon,
   Sheet,
   SheetContainer,
@@ -19,6 +18,7 @@ import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
 import { useState } from "react";
 
 import { ResourceAvatar } from "@app/components/resources/resources_icons";
+import { ExtendedSkillBadge } from "@app/components/skills/ExtendedSkillBadge";
 import { RestoreSkillDialog } from "@app/components/skills/RestoreSkillDialog";
 import { SkillDetailsButtonBar } from "@app/components/skills/SkillDetailsButtonBar";
 import { SkillEditorsTab } from "@app/components/skills/SkillEditorsTab";
@@ -52,7 +52,7 @@ export function SkillDetailsSheet({
         </VisuallyHidden>
         {skill && (
           <>
-            <SheetHeader className="flex flex-col gap-5 text-sm text-foreground dark:text-foreground-night">
+            <SheetHeader>
               <DescriptionSection
                 skill={skill}
                 owner={owner}
@@ -159,18 +159,7 @@ const DescriptionSection = ({
           {skill.name}
         </h2>
         {skill.relations.extendedSkill && (
-          <div className="flex items-center gap-1 text-base">
-            <p className="text-muted-foreground dark:text-muted-foreground-night">
-              Based on
-            </p>
-            <Icon
-              visual={getSkillIcon(skill.relations.extendedSkill.icon)}
-              size="xs"
-            />
-            <p className="text-foreground dark:text-foreground-night">
-              {skill.relations.extendedSkill.name}
-            </p>
-          </div>
+          <ExtendedSkillBadge extendedSkill={skill.relations.extendedSkill} />
         )}
 
         {editedDate && (


### PR DESCRIPTION
## Description

- Extract `ExtendedSkillBadge` component for reuse between SkillBuilder header and SkillDetailsSheet
- In SkillBuilder: move "Based on X" from title to description prop, use `BarHeader.ButtonBar` for close button
- Bump sparkle to 0.5.17

## Tests

Manual
<img width="3371" height="838" alt="image" src="https://github.com/user-attachments/assets/7db39de6-4cb6-4d3c-9715-df74b95e5691" />


## Risk

Low.

## Deploy Plan

Deploy front.
