### PR TITLE
Fix conversation title when first message uses tools

### DIFF
--- a/front/lib/api/assistant/conversation_rendering/message_rendering.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/message_rendering.test.ts
@@ -309,9 +309,9 @@ describe("renderAllMessages", () => {
       expect(
         assistantMsg.contents.some((c) => c.type === "function_call")
       ).toBe(false);
-      expect(
-        assistantMsg.contents.some((c) => c.type === "text_content")
-      ).toBe(true);
+      expect(assistantMsg.contents.some((c) => c.type === "text_content")).toBe(
+        true
+      );
     });
 
     it("should include function_call contents when excludeActions is false", async () => {

--- a/front/lib/api/assistant/conversation_rendering/message_rendering.ts
+++ b/front/lib/api/assistant/conversation_rendering/message_rendering.ts
@@ -53,7 +53,7 @@ export function renderAgentSteps(
       // Filter out function_call contents since we're not including their outputs.
       // Including function_calls without outputs causes OpenAI's responses API to error.
       const filteredContents = lastStepWithContent.contents.filter(
-        (c) => c.type !== "function_call" || true
+        (c) => c.type !== "function_call"
       );
       messages.push({
         role: "assistant",

--- a/front/lib/api/assistant/conversation_rendering/message_rendering.ts
+++ b/front/lib/api/assistant/conversation_rendering/message_rendering.ts
@@ -50,11 +50,16 @@ export function renderAgentSteps(
           textContents.push(content);
         }
       }
+      // Filter out function_call contents since we're not including their outputs.
+      // Including function_calls without outputs causes OpenAI's responses API to error.
+      const filteredContents = lastStepWithContent.contents.filter(
+        (c) => c.type !== "function_call" || true
+      );
       messages.push({
         role: "assistant",
         name: message.configuration.name,
         content: textContents.map((c) => c.value).join("\n"),
-        contents: lastStepWithContent.contents,
+        contents: filteredContents,
       } satisfies AssistantContentMessageTypeModel);
     }
   } else {

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -137,10 +137,6 @@ export async function agentLoopWorkflow({
 }) {
   const { searchAttributes: parentSearchAttributes, memo } = workflowInfo();
 
-  let childWorkflowHandle: ChildWorkflowHandle<
-    typeof agentLoopConversationTitleWorkflow
-  > | null = null;
-
   // Allow cancellation of in-flight activities via signal-triggered scope cancellation.
   let cancelRequested = false;
   const executionScope = new CancellationScope();
@@ -157,6 +153,9 @@ export async function agentLoopWorkflow({
       const runIds: string[] = [];
       const syncStartTime = Date.now();
       let currentStep = startStep;
+      let childWorkflowHandle: ChildWorkflowHandle<
+        typeof agentLoopConversationTitleWorkflow
+      > | null = null;
 
       await logAgentLoopPhaseStartActivity({
         authType,
@@ -240,11 +239,11 @@ export async function agentLoopWorkflow({
       await CancellationScope.nonCancellable(async () => {
         await finalizeSuccessfulAgentLoopActivity(authType, agentLoopArgs);
       });
-    });
 
-    if (childWorkflowHandle) {
-      await childWorkflowHandle.result();
-    }
+      if (childWorkflowHandle) {
+        await childWorkflowHandle.result();
+      }
+    });
   } catch (err) {
     const workflowError = err instanceof Error ? err : new Error(String(err));
 


### PR DESCRIPTION
## Description

After fixing the context_exceeded errors on conversation_title, it is still failing in 2 ways, when there's a tool call on the first message: 

### [Invalid request to openai_responses. 400 No tool output found for function call](https://app.datadoghq.eu/logs?query=%40context.operationType%3Aconversation_title_suggestion%20status%3Aerror&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZuixNa9OKX1WAAAABhBWnVpeE4wRkFBQ1RpWkNaaktUbXVnQW4AAAAkMDE5YmEyYzYtOGJmNy00ZGJiLWIwODQtZjE0YTFhZGY3ZGQ2AANKag&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1767961826757&to_ts=1767962726757&live=true)

OpenAI API error: When conversations contained tool calls from Claude (with Anthropic-style IDs like toolu_01CoSjAuT14ES2RnS0up1n0u), the title generation request to OpenAI's responses API failed with "No tool output found for function call". This happened because excludeActions: true filtered out function results but still included function_call items in the contents array.

Solution: On `lib/api/assistant/conversation_rendering/message_rendering.ts`: When excludeActions is true, filter out function_call items from the contents array (not just from the text content). This prevents orphaned function calls from being sent to OpenAI.

I'm not 100% sure about this one, I see there was already an attempt to fix here: https://github.com/dust-tt/dust/pull/18147/changes


### [Error: No title found in LLM response](https://app.datadoghq.eu/logs?query=service%3Afront%20status%3Aerror%20%40dd.env%3Aprod%20-%40apiError.api_error.type%3A%28not_authenticated%20OR%20rate_limit_error%20OR%20invalid_api_key_error%20OR%20conversation_not_found%20OR%20message_not_found%20OR%20workspace_auth_error%20OR%20invalid_oauth_token_error%29%20-%22Session%20authentication%20error%22%20-%40statusCode%3A404%20%22No%20title%20found%20in%20LLM%20response%22&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZuiyse7YDcFlgAAABhBWnVpeXRmeUFBQjNuZzBqdmhmWTZ3QUYAAAAkMDE5YmEyY2EtZGFjNS00NTlkLWEzMDktNWI5YzdmZWQyOGYyAAAysQ&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1767453698297&to_ts=1767712898297&live=true)

Missing context: Title generation was started at the beginning of the agent loop workflow, before the agent had a chance to respond. The title model only saw the user's question without the agent's response, leading to confused outputs like "I currently don't have access to your email inbox" instead of generating a title.


Solution: In `temporal/agent_loop/workflows.ts`: Move title generation workflow start from the beginning of the agent loop to after the first step completes. This ensures the agent has at least one response in the database before title generation runs, giving the title model proper context.


## Tests

I did not reproduce the first issue locally. 

The second I did reproduce. I was sending this messsage "@/dust what are my latest 3 emails?" and I had this error log: 

```
[agent-loop]  No title found in LLM response: {
[agent-loop]   actions: [],
[agent-loop]   generation: "I currently don't have access to your email inbox. To help you with your 3 latest emails, please provide access or connect your email account through the appropriate service or app."
[agent-loop] }
```

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 