### PR TITLE
[front] fix(skill): fix attach button position in Skill Builder

### DIFF
--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -16,6 +16,9 @@ import { SKILL_BUILDER_INSTRUCTIONS_BLUR_EVENT } from "@app/components/skill_bui
 import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 
+const INSTRUCTIONS_FIELD_NAME = "instructions";
+const ATTACHED_KNOWLEDGE_FIELD_NAME = "attachedKnowledge";
+
 const editorVariants = cva(
   [
     "overflow-auto border rounded-xl px-3 pt-2 pb-8 resize-y min-h-60 max-h-[1024px]",
@@ -56,15 +59,17 @@ export function SkillBuilderInstructionsEditor({
   isInstructionDiffMode = false,
 }: SkillBuilderInstructionsEditorProps) {
   const { field: instructionsField, fieldState: instructionsFieldState } =
-    useController<SkillBuilderFormData, "instructions">({
-      name: "instructions",
+    useController<SkillBuilderFormData, typeof INSTRUCTIONS_FIELD_NAME>({
+      name: INSTRUCTIONS_FIELD_NAME,
     });
   const {
     field: attachedKnowledgeField,
     fieldState: attachedKnowledgeFieldState,
-  } = useController<SkillBuilderFormData, "attachedKnowledge">({
-    name: "attachedKnowledge",
-  });
+  } = useController<SkillBuilderFormData, typeof ATTACHED_KNOWLEDGE_FIELD_NAME>(
+    {
+      name: ATTACHED_KNOWLEDGE_FIELD_NAME,
+    }
+  );
 
   const displayError =
     !!instructionsFieldState.error || !!attachedKnowledgeFieldState.error;
@@ -214,19 +219,21 @@ export function SkillBuilderInstructionsEditor({
   }, [isInstructionDiffMode, compareVersion, editor]);
 
   return (
-    <div className="relative space-y-1 p-px">
-      <SkillInstructionsEditorContent editor={editor} isReadOnly={false} />
+    <div className="space-y-1 p-px">
+      <div className="relative">
+        <SkillInstructionsEditorContent editor={editor} isReadOnly={false} />
 
-      {/* Floating Add Knowledge Button */}
-      <Button
-        size="xs"
-        variant="ghost"
-        icon={AttachmentIcon}
-        onClick={handleAddKnowledge}
-        className="absolute bottom-2 left-2"
-        tooltip="Add knowledge"
-        disabled={!editor}
-      />
+        {/* Floating Add Knowledge Button */}
+        <Button
+          size="xs"
+          variant="ghost"
+          icon={AttachmentIcon}
+          onClick={handleAddKnowledge}
+          className="absolute bottom-2 left-2"
+          tooltip="Add knowledge"
+          disabled={!editor}
+        />
+      </div>
 
       {instructionsFieldState.error && (
         <div className="dark:text-warning-night ml-2 text-xs text-warning">


### PR DESCRIPTION
## Description

- There is a button to attach knowledge in the instructions block of Skill Builder.
- If there is an error message for the block, this button gets misplaced.
- This PR fixes that.

Before

<img width="826" height="274" alt="Screenshot 2026-01-09 at 2 07 05 PM" src="https://github.com/user-attachments/assets/9e52f7ef-4f55-4109-ba03-e4b4adec7677" />

After

<img width="826" height="274" alt="Screenshot 2026-01-09 at 2 07 29 PM" src="https://github.com/user-attachments/assets/47952104-e792-404d-a2f8-f8d1f7d11f47" />


## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
