### PR TITLE
Fix: bulk create notification returns a 201 now.

### DIFF
--- a/front/lib/notifications/workflows/conversation-unread.ts
+++ b/front/lib/notifications/workflows/conversation-unread.ts
@@ -48,13 +48,13 @@ export const shouldSendNotificationForAgentAnswer = (
   switch (userMessageOrigin) {
     case "web":
     case "extension":
+    case "cli":
+    case "cli_programmatic":
       return true;
     case "onboarding_conversation":
       // Internal bootstrap conversations shouldn't trigger unread notifications.
       return false;
     case "api":
-    case "cli":
-    case "cli_programmatic":
     case "email":
     case "excel":
     case "gsheet":
@@ -475,11 +475,11 @@ export const triggerConversationUnreadNotifications = async (
           };
         })
       );
-      if (r.status !== 200) {
+      if (r.status <= 200 && r.status >= 300) {
         return new Err({
           name: "dust_error",
           code: "internal_server_error",
-          message: `Failed to trigger conversation unread notification due to network error: ${r.statusText}`,
+          message: `Failed to trigger conversation unread notification due to network error: ${r.status} ${r.statusText}`,
         });
       }
       return new Ok(undefined);


### PR DESCRIPTION
## Description

From the log I understood that after fixing the problem of missing env vars, we also had a second issue as bulkTrigger now returns a 201 instead of a 200.
Also made it so the cli supports notifications.

## Tests

Discovered via logs.

## Risk

Low

## Deploy Plan

Deploy front