### PR TITLE
[LLM_ROUTER] Force tool call in title suggestion

### DIFF
--- a/front/lib/api/assistant/conversation/title.ts
+++ b/front/lib/api/assistant/conversation/title.ts
@@ -186,6 +186,7 @@ async function generateConversationTitle(
       conversation: conv,
       prompt: prompt,
       specifications,
+      forceToolCall: FUNCTION_NAME,
     },
     {
       context: {


### PR DESCRIPTION
## Description

We keep getting "No title found in LLM response" because for long conversation, the system prompt asking to generate a title based on the conversation content gets lost in the model context.

This PR forces to call the update title tool

## Tests

local

## Risk

no

## Deploy Plan

front
