### PR TITLE
feat(dust-hive): Add shared test Postgres for cold environment testing

### DIFF
--- a/x/henry/dust-hive/.claude/skills/dust-hive/SKILL.md
+++ b/x/henry/dust-hive/.claude/skills/dust-hive/SKILL.md
@@ -149,9 +149,9 @@ curl -sf http://localhost:10000/api/healthz  # front
 curl -sf http://localhost:10001/             # core
 ```
 
-## Running Tests in Cold Environments
+## Running Front Tests in Cold Environments
 
-dust-hive provides a **shared test Postgres** container that allows running tests without warming up the full environment. This is especially useful for CI agents and quick test runs.
+The `front` project requires a Postgres database to run tests. dust-hive provides a **shared test Postgres** container that allows running front tests without warming up the full environment. This is useful for any agent making changes to front that needs to verify tests pass.
 
 ### How it works
 
@@ -160,13 +160,13 @@ dust-hive provides a **shared test Postgres** container that allows running test
 - The database is created automatically when you `spawn` an environment
 - `TEST_FRONT_DATABASE_URI` is set in each environment's `env.sh`
 
-### Running tests in a cold environment
+### Running front tests in a cold environment
 
 ```bash
 # Ensure dust-hive managed services are running (includes test postgres)
 dust-hive up
 
-# From any cold environment, just run tests directly
+# From any cold environment, run front tests directly
 cd front && npm test
 
 # Run specific test file
@@ -187,9 +187,9 @@ cd front && npm test --reporter verbose path/to/test.test.ts
 | `dust-hive up` | Shared Postgres started |
 | `dust-hive down` | Shared Postgres stopped |
 
-### Troubleshooting tests
+### Troubleshooting front tests
 
-If tests fail with database connection errors:
+If front tests fail with database connection errors:
 1. Check if test postgres is running: `docker ps | grep dust-hive-test-postgres`
 2. If not, run `dust-hive up` or start it manually: `docker start dust-hive-test-postgres`
 3. Verify the database exists: `docker exec dust-hive-test-postgres psql -U test -l`

--- a/x/henry/dust-hive/.claude/skills/dust-hive/SKILL.md
+++ b/x/henry/dust-hive/.claude/skills/dust-hive/SKILL.md
@@ -155,17 +155,13 @@ The `front` project requires a Postgres database to run tests. dust-hive provide
 
 ### How it works
 
-- `dust-hive up` starts a shared Postgres container on port **5433** (separate from per-env Postgres)
+- A shared Postgres container runs on port **5433** (started by `dust-hive up`)
 - Each environment gets its own test database: `dust_front_test_{env_name}`
-- The database is created automatically when you `spawn` an environment
-- `TEST_FRONT_DATABASE_URI` is set in each environment's `env.sh`
+- `TEST_FRONT_DATABASE_URI` is already set in each environment's `env.sh`
 
 ### Running front tests in a cold environment
 
 ```bash
-# Ensure dust-hive managed services are running (includes test postgres)
-dust-hive up
-
 # From any cold environment, run front tests directly
 cd front && npm test
 
@@ -176,7 +172,7 @@ cd front && npm test lib/resources/user_resource.test.ts
 cd front && npm test --reporter verbose path/to/test.test.ts
 ```
 
-**No need to warm the environment** - the shared test Postgres is always available when `dust-hive up` has been run.
+**No need to warm the environment** - the shared test Postgres is always available.
 
 ### Test database lifecycle
 
@@ -191,7 +187,7 @@ cd front && npm test --reporter verbose path/to/test.test.ts
 
 If front tests fail with database connection errors:
 1. Check if test postgres is running: `docker ps | grep dust-hive-test-postgres`
-2. If not, run `dust-hive up` or start it manually: `docker start dust-hive-test-postgres`
+2. If not running, start it: `docker start dust-hive-test-postgres`
 3. Verify the database exists: `docker exec dust-hive-test-postgres psql -U test -l`
 
 ## Services in Each Environment

--- a/x/henry/dust-hive/src/commands/destroy.ts
+++ b/x/henry/dust-hive/src/commands/destroy.ts
@@ -10,6 +10,7 @@ import { restoreTerminal, selectMultipleEnvironments } from "../lib/prompt";
 import { CommandError, Err, Ok, type Result } from "../lib/result";
 import type { ServiceName } from "../lib/services";
 import { isDockerRunning } from "../lib/state";
+import { dropTestDatabase } from "../lib/test-postgres";
 import { deleteBranch, hasUncommittedChanges, removeWorktree } from "../lib/worktree";
 
 async function cleanupZellijSession(envName: string): Promise<void> {
@@ -115,6 +116,15 @@ async function destroySingleEnvironment(
 
   // Stop Docker and remove volumes
   await cleanupDocker(env.name);
+
+  // Drop test database
+  logger.step("Dropping test database...");
+  const testDbResult = await dropTestDatabase(env.name);
+  if (testDbResult.success) {
+    logger.success("Test database dropped");
+  } else {
+    logger.warn(`Could not drop test database: ${testDbResult.error}`);
+  }
 
   // Remove git worktree
   logger.step("Removing git worktree...");

--- a/x/henry/dust-hive/src/lib/envgen.ts
+++ b/x/henry/dust-hive/src/lib/envgen.ts
@@ -1,6 +1,7 @@
 import { CONFIG_ENV_PATH, getEnvFilePath } from "./paths";
 import type { PortAllocation } from "./ports";
 import { getTemporalEnvExports } from "./temporal";
+import { getTestDatabaseUri } from "./test-postgres";
 
 // Generate env.sh content for an environment
 export function generateEnvSh(name: string, ports: PortAllocation): string {
@@ -45,6 +46,9 @@ export CORE_DATABASE_READ_REPLICA_URI=postgres://dev:dev@localhost:${ports.postg
 export CONNECTORS_DATABASE_URI=postgres://dev:dev@localhost:${ports.postgres}/dust_connectors
 export CONNECTORS_DATABASE_READ_REPLICA_URI=postgres://dev:dev@localhost:${ports.postgres}/dust_connectors
 export OAUTH_DATABASE_URI=postgres://dev:dev@localhost:${ports.postgres}/dust_oauth
+
+# === Test Database URI (shared test postgres on port 5433) ===
+export TEST_FRONT_DATABASE_URI=${getTestDatabaseUri(name)}
 
 # === Service URIs ===
 export REDIS_URI=redis://localhost:${ports.redis}

--- a/x/henry/dust-hive/src/lib/paths.ts
+++ b/x/henry/dust-hive/src/lib/paths.ts
@@ -30,6 +30,12 @@ export const TEMPORAL_PID_PATH = join(DUST_HIVE_HOME, "temporal.pid");
 export const TEMPORAL_LOG_PATH = join(DUST_HIVE_HOME, "temporal.log");
 export const TEMPORAL_PORT = 7233;
 
+// Shared test Postgres paths (global, not per-env)
+export const TEST_POSTGRES_CONTAINER_NAME = "dust-hive-test-postgres";
+export const TEST_POSTGRES_PORT = 5433;
+export const TEST_POSTGRES_USER = "test";
+export const TEST_POSTGRES_PASSWORD = "test";
+
 // Main zellij session
 export const MAIN_SESSION_NAME = "dust-hive-main";
 

--- a/x/henry/dust-hive/src/lib/test-postgres.ts
+++ b/x/henry/dust-hive/src/lib/test-postgres.ts
@@ -1,0 +1,241 @@
+// Shared test Postgres management (global container, not per-environment)
+// Each environment gets its own database within this container.
+
+import {
+  TEST_POSTGRES_CONTAINER_NAME,
+  TEST_POSTGRES_PASSWORD,
+  TEST_POSTGRES_PORT,
+  TEST_POSTGRES_USER,
+} from "./paths";
+
+// Check if the test postgres container is running
+export async function isTestPostgresRunning(): Promise<boolean> {
+  const proc = Bun.spawn(
+    ["docker", "inspect", "-f", "{{.State.Running}}", TEST_POSTGRES_CONTAINER_NAME],
+    {
+      stdout: "pipe",
+      stderr: "pipe",
+    }
+  );
+  const output = await new Response(proc.stdout).text();
+  await proc.exited;
+
+  return proc.exitCode === 0 && output.trim() === "true";
+}
+
+// Check if the test postgres container exists (running or stopped)
+async function containerExists(): Promise<boolean> {
+  const proc = Bun.spawn(["docker", "inspect", TEST_POSTGRES_CONTAINER_NAME], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  await proc.exited;
+  return proc.exitCode === 0;
+}
+
+// Wait for postgres to be ready to accept connections
+async function waitForPostgresReady(timeoutMs = 30000): Promise<boolean> {
+  const start = Date.now();
+
+  while (Date.now() - start < timeoutMs) {
+    const proc = Bun.spawn(
+      ["docker", "exec", TEST_POSTGRES_CONTAINER_NAME, "pg_isready", "-U", TEST_POSTGRES_USER],
+      {
+        stdout: "pipe",
+        stderr: "pipe",
+      }
+    );
+    await proc.exited;
+
+    if (proc.exitCode === 0) {
+      return true;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+
+  return false;
+}
+
+// Start the shared test postgres container
+export async function startTestPostgres(): Promise<{
+  success: boolean;
+  error?: string;
+  alreadyRunning?: boolean;
+}> {
+  // Check if already running
+  if (await isTestPostgresRunning()) {
+    return { success: true, alreadyRunning: true };
+  }
+
+  // Check if container exists but is stopped
+  if (await containerExists()) {
+    const proc = Bun.spawn(["docker", "start", TEST_POSTGRES_CONTAINER_NAME], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    await proc.exited;
+
+    if (proc.exitCode !== 0) {
+      const stderr = await new Response(proc.stderr).text();
+      return { success: false, error: `Failed to start existing container: ${stderr}` };
+    }
+  } else {
+    // Create new container
+    const proc = Bun.spawn(
+      [
+        "docker",
+        "run",
+        "-d",
+        "--name",
+        TEST_POSTGRES_CONTAINER_NAME,
+        "-e",
+        `POSTGRES_USER=${TEST_POSTGRES_USER}`,
+        "-e",
+        `POSTGRES_PASSWORD=${TEST_POSTGRES_PASSWORD}`,
+        "-e",
+        "POSTGRES_DB=postgres",
+        "-p",
+        `${TEST_POSTGRES_PORT}:5432`,
+        "postgres:15",
+      ],
+      {
+        stdout: "pipe",
+        stderr: "pipe",
+      }
+    );
+    await proc.exited;
+
+    if (proc.exitCode !== 0) {
+      const stderr = await new Response(proc.stderr).text();
+      return { success: false, error: `Failed to create container: ${stderr}` };
+    }
+  }
+
+  // Wait for postgres to be ready
+  const ready = await waitForPostgresReady();
+  if (!ready) {
+    return { success: false, error: "Postgres container started but not responding" };
+  }
+
+  return { success: true, alreadyRunning: false };
+}
+
+// Stop the shared test postgres container
+export async function stopTestPostgres(): Promise<{ success: boolean; wasRunning: boolean }> {
+  if (!(await isTestPostgresRunning())) {
+    return { success: true, wasRunning: false };
+  }
+
+  const proc = Bun.spawn(["docker", "stop", TEST_POSTGRES_CONTAINER_NAME], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  await proc.exited;
+
+  return { success: proc.exitCode === 0, wasRunning: true };
+}
+
+// Remove the shared test postgres container (including volumes)
+export async function removeTestPostgres(): Promise<{ success: boolean }> {
+  // Stop first if running
+  await stopTestPostgres();
+
+  // Remove container
+  const proc = Bun.spawn(["docker", "rm", "-v", TEST_POSTGRES_CONTAINER_NAME], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  await proc.exited;
+
+  // Success even if container didn't exist
+  return { success: true };
+}
+
+// Get the test database name for an environment
+export function getTestDatabaseName(envName: string): string {
+  // Sanitize env name for postgres (replace dashes with underscores)
+  const sanitized = envName.replace(/-/g, "_");
+  return `dust_front_test_${sanitized}`;
+}
+
+// Get the connection URI for a test database
+export function getTestDatabaseUri(envName: string): string {
+  const dbName = getTestDatabaseName(envName);
+  return `postgres://${TEST_POSTGRES_USER}:${TEST_POSTGRES_PASSWORD}@localhost:${TEST_POSTGRES_PORT}/${dbName}`;
+}
+
+// Create a test database for an environment
+export async function createTestDatabase(envName: string): Promise<{
+  success: boolean;
+  error?: string;
+}> {
+  const dbName = getTestDatabaseName(envName);
+
+  // Check if postgres is running
+  if (!(await isTestPostgresRunning())) {
+    return { success: false, error: "Test postgres is not running. Run 'dust-hive up' first." };
+  }
+
+  // Create database if it doesn't exist
+  const proc = Bun.spawn(
+    [
+      "docker",
+      "exec",
+      TEST_POSTGRES_CONTAINER_NAME,
+      "psql",
+      "-U",
+      TEST_POSTGRES_USER,
+      "-c",
+      `CREATE DATABASE ${dbName};`,
+    ],
+    {
+      stdout: "pipe",
+      stderr: "pipe",
+    }
+  );
+  const stderr = await new Response(proc.stderr).text();
+  await proc.exited;
+
+  // Success if created or already exists
+  if (proc.exitCode === 0 || stderr.includes("already exists")) {
+    return { success: true };
+  }
+
+  return { success: false, error: stderr };
+}
+
+// Drop a test database for an environment
+export async function dropTestDatabase(envName: string): Promise<{
+  success: boolean;
+  error?: string;
+}> {
+  const dbName = getTestDatabaseName(envName);
+
+  // Check if postgres is running
+  if (!(await isTestPostgresRunning())) {
+    // If postgres is not running, we can't drop the DB but that's okay
+    return { success: true };
+  }
+
+  // Terminate existing connections and drop
+  const proc = Bun.spawn(
+    [
+      "docker",
+      "exec",
+      TEST_POSTGRES_CONTAINER_NAME,
+      "psql",
+      "-U",
+      TEST_POSTGRES_USER,
+      "-c",
+      `DROP DATABASE IF EXISTS ${dbName};`,
+    ],
+    {
+      stdout: "pipe",
+      stderr: "pipe",
+    }
+  );
+  await proc.exited;
+
+  return { success: proc.exitCode === 0 };
+}


### PR DESCRIPTION
## Description

The `front` project requires a Postgres database to run tests. This PR adds a shared test Postgres container that enables running front tests without warming the full dust-hive environment. This is useful for any agent making changes to front that needs to verify tests pass.

### How it works

- A shared Postgres container runs on port **5433** (started by `dust-hive up`)
- Each environment gets its own test database: `dust_front_test_{env_name}`
- `TEST_FRONT_DATABASE_URI` is already set in each environment's `env.sh`

### Usage

```bash
# From any cold environment, run front tests directly
cd front && npm test
```

### Changes

- New `lib/test-postgres.ts` for Docker container lifecycle management
- Updated `up.ts` to start test Postgres alongside Temporal
- Updated `down.ts` to stop test Postgres
- Updated `spawn.ts` to create per-env test database
- Updated `destroy.ts` to drop per-env test database
- Updated `envgen.ts` to include `TEST_FRONT_DATABASE_URI` in env.sh
- Added documentation in SKILL.md

## Tests

- Ran `bun run check` (typecheck + lint + tests) - all pass
- Manual testing of the container lifecycle will be done after merge

## Risk

Low risk - this is an additive feature that doesn't affect existing warm environment flows. The test Postgres runs on a separate port (5433) so there's no conflict with per-environment databases.

## Deploy Plan

No deployment needed - this is a local development tool only.