### PR TITLE
Update image attachment visuals

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "^1.2.3",
-        "@dust-tt/sparkle": "^0.5.19",
+        "@dust-tt/sparkle": "^0.5.20",
         "@frontapp/plugin-sdk": "^1.8.1",
         "@modelcontextprotocol/sdk": "^1.9.0",
         "@tailwindcss/forms": "^0.5.9",
@@ -1258,9 +1258,10 @@
       }
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.5.19.tgz",
-      "integrity": "sha512-JBCE8/2MG9wa3OxpnN5uh4WlTtLRiLTwETEqQkJnov1nv2M/dt2mPRookVx35V1Ga6srOifCKrQjFWAwc8UgiQ==",
+      "version": "0.5.20",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.5.20.tgz",
+      "integrity": "sha512-ScyDnulN7L6rEDVHsnUd5B1H7qn5vNls3Y1XlALOtygolRZIt8UydYutCdrw+4+S7M2YGssSUUmpO9B07RDwlw==",
+      "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/extension/package.json
+++ b/extension/package.json
@@ -62,7 +62,7 @@
   "dependencies": {
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "^1.2.3",
-    "@dust-tt/sparkle": "^0.5.19",
+    "@dust-tt/sparkle": "^0.5.20",
     "@frontapp/plugin-sdk": "^1.8.1",
     "@modelcontextprotocol/sdk": "^1.9.0",
     "@tailwindcss/forms": "^0.5.9",

--- a/front/components/assistant/conversation/attachment/AttachmentCitation.tsx
+++ b/front/components/assistant/conversation/attachment/AttachmentCitation.tsx
@@ -3,9 +3,9 @@ import {
   CitationClose,
   CitationDescription,
   CitationIcons,
-  CitationImage,
   CitationTitle,
   Icon,
+  InteractiveImageGrid,
   Tooltip,
 } from "@dust-tt/sparkle";
 import React, { useState } from "react";
@@ -48,11 +48,9 @@ export function AttachmentCitation({
       </div>
     );
 
-  const previewImageUrl =
+  const isImage =
     attachmentCitation.type === "file" &&
-    isSupportedImageContentType(attachmentCitation.contentType)
-      ? `${attachmentCitation.sourceUrl}?action=view`
-      : undefined;
+    isSupportedImageContentType(attachmentCitation.contentType);
 
   const isLoading =
     attachmentCitation.type === "file" && attachmentCitation.isUploading;
@@ -74,6 +72,29 @@ export function AttachmentCitation({
         href: attachmentCitation.sourceUrl ?? undefined,
       };
 
+  // For image attachments, use InteractiveImageGrid for better preview UX
+  if (isImage && attachmentCitation.type === "file") {
+    const imageUrl = `${attachmentCitation.sourceUrl}?action=view`;
+    const downloadUrl = `${attachmentCitation.sourceUrl}?action=download`;
+
+    return (
+      <InteractiveImageGrid
+        size="sm"
+        images={[
+          {
+            imageUrl,
+            downloadUrl,
+            alt: attachmentCitation.title,
+            title: attachmentCitation.title,
+            isLoading,
+          },
+        ]}
+        onClose={attachmentCitation.onRemove}
+      />
+    );
+  }
+
+  // For non-image attachments, use the standard Citation component
   return (
     <>
       <Tooltip
@@ -92,7 +113,6 @@ export function AttachmentCitation({
               )
             }
           >
-            {previewImageUrl && <CitationImage imgSrc={previewImageUrl} />}
             <CitationIcons>{attachmentCitation.visual}</CitationIcons>
             <CitationTitle className="truncate text-ellipsis">
               {attachmentCitation.title}

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -13,7 +13,7 @@
         "@contentful/rich-text-types": "^17.2.5",
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.5.19",
+        "@dust-tt/sparkle": "^0.5.20",
         "@elastic/elasticsearch": "^8.15.0",
         "@elevenlabs/elevenlabs-js": "^2.17.0",
         "@emoji-mart/data": "^1.2.1",
@@ -1324,9 +1324,10 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.5.19.tgz",
-      "integrity": "sha512-JBCE8/2MG9wa3OxpnN5uh4WlTtLRiLTwETEqQkJnov1nv2M/dt2mPRookVx35V1Ga6srOifCKrQjFWAwc8UgiQ==",
+      "version": "0.5.20",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.5.20.tgz",
+      "integrity": "sha512-ScyDnulN7L6rEDVHsnUd5B1H7qn5vNls3Y1XlALOtygolRZIt8UydYutCdrw+4+S7M2YGssSUUmpO9B07RDwlw==",
+      "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",
         "@emoji-mart/react": "^1.1.1",

--- a/front/package.json
+++ b/front/package.json
@@ -38,7 +38,7 @@
     "@contentful/rich-text-types": "^17.2.5",
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.5.19",
+    "@dust-tt/sparkle": "^0.5.20",
     "@elastic/elasticsearch": "^8.15.0",
     "@elevenlabs/elevenlabs-js": "^2.17.0",
     "@emoji-mart/data": "^1.2.1",


### PR DESCRIPTION
## Description

Second and final step of https://github.com/dust-tt/tasks/issues/5870. Integrate updated Sparkle component from https://github.com/dust-tt/dust/pull/19864.

### Preview
<img width="1823" height="539" alt="Screenshot 2026-01-09 at 16 05 13" src="https://github.com/user-attachments/assets/96764c39-6d66-42e5-887b-1143764c42c0" />

### Hover

Adds blur on the image + layer with the file title + download icon
<img width="1821" height="540" alt="Screenshot 2026-01-09 at 16 06 35" src="https://github.com/user-attachments/assets/c658b8b7-9f51-4a4b-9113-a668a7d44c8f" />


### Popover
<img width="1825" height="657" alt="Screenshot 2026-01-09 at 16 05 27" src="https://github.com/user-attachments/assets/b3621f16-9d27-42d7-bf0a-9f4be6dcb2c9" />


## Tests

Locally

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front
