### PR TITLE
fix(dust-hive): Connect to postgres db when creating/dropping test databases

### DIFF
--- a/x/henry/dust-hive/src/lib/test-postgres.ts
+++ b/x/henry/dust-hive/src/lib/test-postgres.ts
@@ -178,6 +178,7 @@ export async function createTestDatabase(envName: string): Promise<{
   }
 
   // Create database if it doesn't exist
+  // Must connect to 'postgres' db since the default db (username) doesn't exist
   const proc = Bun.spawn(
     [
       "docker",
@@ -186,6 +187,8 @@ export async function createTestDatabase(envName: string): Promise<{
       "psql",
       "-U",
       TEST_POSTGRES_USER,
+      "-d",
+      "postgres",
       "-c",
       `CREATE DATABASE ${dbName};`,
     ],
@@ -219,6 +222,7 @@ export async function dropTestDatabase(envName: string): Promise<{
   }
 
   // Terminate existing connections and drop
+  // Must connect to 'postgres' db since the default db (username) doesn't exist
   const proc = Bun.spawn(
     [
       "docker",
@@ -227,6 +231,8 @@ export async function dropTestDatabase(envName: string): Promise<{
       "psql",
       "-U",
       TEST_POSTGRES_USER,
+      "-d",
+      "postgres",
       "-c",
       `DROP DATABASE IF EXISTS ${dbName};`,
     ],


### PR DESCRIPTION
## Description

Fixes test database creation failing during `dust-hive spawn` with error:
```
psql: error: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed: FATAL:  database "test" does not exist
```

The issue is that `psql` defaults to connecting to a database named after the user. Since the test postgres container uses `test` as the user but creates a `postgres` database, we need to explicitly specify `-d postgres` when running CREATE DATABASE and DROP DATABASE commands.

## Tests

- Ran `bun run check` (typecheck, lint, tests all pass)
- Manually verified the fix by successfully creating a test database:
  ```
  docker exec dust-hive-test-postgres psql -U test -d postgres -c "CREATE DATABASE dust_front_test_run_front_tests;"
  CREATE DATABASE
  ```

## Risk

Low - this is a simple fix that adds an explicit database connection parameter to psql commands. The previous behavior was broken, so this can only improve things.

## Deploy Plan

Merge and pull into main repo. Users running `dust-hive sync` will get the fix.