### PR TITLE
feat: add a way to copy a file

### DIFF
--- a/front/lib/resources/file_resource.test.ts
+++ b/front/lib/resources/file_resource.test.ts
@@ -10,8 +10,14 @@ import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
+import { Ok } from "@app/types";
 import { GLOBAL_AGENTS_SID } from "@app/types";
 import { frameContentType } from "@app/types/files";
+
+// Mock the upload module.
+vi.mock("@app/lib/api/files/upload", () => ({
+  processAndStoreFile: vi.fn(),
+}));
 
 describe("FileResource", () => {
   beforeEach(() => {
@@ -173,6 +179,231 @@ describe("FileResource", () => {
       expect(result?.file.id).toBe(frameFile.id);
       expect(result?.content).toEqual(expectedContent);
       expect(result?.shareScope).toBe("workspace");
+    });
+  });
+
+  describe("copy", () => {
+    const testFileContent = "test file content for copying";
+
+    it("should successfully copy a file with new useCase and metadata", async () => {
+      const { authenticator: auth, workspace } = await createResourceTest({
+        role: "admin",
+      });
+
+      // Create source file.
+      const sourceFile = await FileFactory.create(workspace, null, {
+        contentType: "text/plain",
+        fileName: "source.txt",
+        fileSize: testFileContent.length,
+        status: "ready",
+        useCase: "conversation",
+        useCaseMetadata: { conversationId: "original-conv-id" },
+      });
+
+      // Mock processAndStoreFile to return success.
+      const { processAndStoreFile } = await import("@app/lib/api/files/upload");
+      const mockProcessAndStoreFile = vi.mocked(processAndStoreFile);
+      mockProcessAndStoreFile.mockImplementation(async (_auth, { file }) => {
+        await file.markAsReady();
+        return new Ok(file);
+      });
+
+      // Mock getReadStream on the FileResource prototype.
+      const getReadStreamSpy = vi
+        .spyOn(FileResource.prototype, "getReadStream")
+        .mockReturnValue(
+          new Readable({
+            read() {
+              this.push(testFileContent);
+              this.push(null); // End the stream.
+            },
+          })
+        );
+
+      // Copy the file.
+      const result = await FileResource.copy(auth, {
+        sourceId: sourceFile.sId,
+        useCase: "project_context",
+        useCaseMetadata: { conversationId: "new-conv-id" },
+      });
+
+      // Verify success.
+      assert(result.isOk(), "Copy should succeed");
+      const copiedFile = result.value;
+
+      // Verify the copied file has correct properties.
+      expect(copiedFile.contentType).toBe(sourceFile.contentType);
+      expect(copiedFile.fileName).toBe(sourceFile.fileName);
+      expect(copiedFile.fileSize).toBe(sourceFile.fileSize);
+      expect(copiedFile.useCase).toBe("project_context");
+      expect(copiedFile.useCaseMetadata?.conversationId).toBe("new-conv-id");
+      expect(copiedFile.isReady).toBe(true);
+
+      // Verify processAndStoreFile was called.
+      expect(mockProcessAndStoreFile).toHaveBeenCalledOnce();
+      expect(getReadStreamSpy).toHaveBeenCalledOnce();
+    });
+
+    it("should return error when source file not found", async () => {
+      const { authenticator: auth } = await createResourceTest({
+        role: "admin",
+      });
+
+      const result = await FileResource.copy(auth, {
+        sourceId: "non-existent-file-id",
+        useCase: "conversation",
+      });
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.message).toContain("Source file not found");
+      }
+    });
+
+    it("should return error when source file is not ready", async () => {
+      const { authenticator: auth, workspace } = await createResourceTest({
+        role: "admin",
+      });
+
+      // Create a file that is not ready.
+      const sourceFile = await FileFactory.create(workspace, null, {
+        contentType: "text/plain",
+        fileName: "not-ready.txt",
+        fileSize: 100,
+        status: "created",
+        useCase: "conversation",
+      });
+
+      const result = await FileResource.copy(auth, {
+        sourceId: sourceFile.sId,
+        useCase: "project_context",
+      });
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.message).toContain("not ready for copying");
+        expect(result.error.message).toContain("created");
+      }
+    });
+
+    it("should return error when source file has failed status", async () => {
+      const { authenticator: auth, workspace } = await createResourceTest({
+        role: "admin",
+      });
+
+      // Create a failed file.
+      const sourceFile = await FileFactory.create(workspace, null, {
+        contentType: "text/plain",
+        fileName: "failed.txt",
+        fileSize: 100,
+        status: "failed",
+        useCase: "conversation",
+      });
+
+      const result = await FileResource.copy(auth, {
+        sourceId: sourceFile.sId,
+        useCase: "project_context",
+      });
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.message).toContain("not ready for copying");
+      }
+    });
+
+    it("should handle processAndStoreFile errors", async () => {
+      const { authenticator: auth, workspace } = await createResourceTest({
+        role: "admin",
+      });
+
+      const sourceFile = await FileFactory.create(workspace, null, {
+        contentType: "text/plain",
+        fileName: "source.txt",
+        fileSize: 100,
+        status: "ready",
+        useCase: "conversation",
+      });
+
+      // Mock processAndStoreFile to return an error.
+      const { processAndStoreFile } = await import("@app/lib/api/files/upload");
+      const { Err } = await import("@app/types");
+      const mockProcessAndStoreFile = vi.mocked(processAndStoreFile);
+      mockProcessAndStoreFile.mockResolvedValue(
+        new Err({
+          name: "dust_error",
+          code: "internal_server_error",
+          message: "Processing failed",
+        })
+      );
+
+      // Mock getReadStream.
+      vi.spyOn(FileResource.prototype, "getReadStream").mockReturnValue(
+        new Readable({
+          read() {
+            this.push("content");
+            this.push(null);
+          },
+        })
+      );
+
+      const result = await FileResource.copy(auth, {
+        sourceId: sourceFile.sId,
+        useCase: "project_context",
+      });
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error).toMatchObject({
+          name: "dust_error",
+          code: "internal_server_error",
+          message: "Processing failed",
+        });
+      }
+    });
+
+    it("should copy file with different use case but same content type", async () => {
+      const { authenticator: auth, workspace } = await createResourceTest({
+        role: "admin",
+      });
+
+      const sourceFile = await FileFactory.create(workspace, null, {
+        contentType: "application/pdf",
+        fileName: "document.pdf",
+        fileSize: 5000,
+        status: "ready",
+        useCase: "conversation",
+        useCaseMetadata: { conversationId: "conv-1" },
+      });
+
+      const { processAndStoreFile } = await import("@app/lib/api/files/upload");
+      const mockProcessAndStoreFile = vi.mocked(processAndStoreFile);
+      mockProcessAndStoreFile.mockImplementation(async (_auth, { file }) => {
+        await file.markAsReady();
+        return new Ok(file);
+      });
+
+      vi.spyOn(FileResource.prototype, "getReadStream").mockReturnValue(
+        new Readable({
+          read() {
+            this.push("PDF content");
+            this.push(null);
+          },
+        })
+      );
+
+      const result = await FileResource.copy(auth, {
+        sourceId: sourceFile.sId,
+        useCase: "upsert_document",
+        useCaseMetadata: { spaceId: "space-1" },
+      });
+
+      assert(result.isOk(), "Copy should succeed");
+      const copiedFile = result.value;
+
+      expect(copiedFile.contentType).toBe("application/pdf");
+      expect(copiedFile.useCase).toBe("upsert_document");
+      expect(copiedFile.useCaseMetadata?.spaceId).toBe("space-1");
+      expect(copiedFile.useCaseMetadata?.conversationId).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
## Description

Add a way to copy a file. This will be useful for the context tool for projects: agent will be able to copy their output to their context.

On purpose - and challengable - this `copy` function **doesn't do any checks**, hence it can move a file from a conversation to a space or the other way around. And it works on any kind of files. On purpose, as it's a low level functiopn

The checks must be done by the caller

## Tests

Unit tests
## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
