### PR TITLE
Remove google sheets includeGridData flag

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/google_drive.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/google_drive.ts
@@ -364,10 +364,6 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
       spreadsheetId: z
         .string()
         .describe("The ID of the spreadsheet to retrieve."),
-      includeGridData: z
-        .boolean()
-        .default(false)
-        .describe("Whether to include grid data in the response."),
     },
     withToolLogging(
       auth,
@@ -375,7 +371,7 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
         toolNameForMonitoring: GOOGLE_DRIVE_TOOL_NAME,
         agentLoopContext,
       },
-      async ({ spreadsheetId, includeGridData }, { authInfo }) => {
+      async ({ spreadsheetId }, { authInfo }) => {
         const sheets = await getSheetsClient(authInfo);
         if (!sheets) {
           return new Err(
@@ -386,7 +382,6 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
         try {
           const res = await sheets.spreadsheets.get({
             spreadsheetId,
-            includeGridData,
           });
 
           return new Ok([

--- a/front/lib/actions/mcp_internal_actions/servers/google_sheets.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/google_sheets.ts
@@ -106,10 +106,6 @@ function createServer(
       spreadsheetId: z
         .string()
         .describe("The ID of the spreadsheet to retrieve."),
-      includeGridData: z
-        .boolean()
-        .default(false)
-        .describe("Whether to include grid data in the response."),
     },
     withToolLogging(
       auth,
@@ -117,7 +113,7 @@ function createServer(
         toolNameForMonitoring: GOOGLE_SHEET_TOOL_NAME,
         agentLoopContext,
       },
-      async ({ spreadsheetId, includeGridData }, { authInfo }) => {
+      async ({ spreadsheetId }, { authInfo }) => {
         const sheets = await getSheetsClient(authInfo);
         if (!sheets) {
           return new Err(
@@ -128,7 +124,6 @@ function createServer(
         try {
           const res = await sheets.spreadsheets.get({
             spreadsheetId,
-            includeGridData,
           });
 
           return new Ok([


### PR DESCRIPTION
## Description

* Removing includeGridData flag as this can lead to large data outputs. We already have a proper tool for exploring cells

## Tests
* Localhost

## Risk

* Low

## Deploy Plan

* Deploy front