### PR TITLE
[front] - fix(KnowledgeConfigurationSheet): simplify advanced settings toggle

### DIFF
--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
@@ -1,12 +1,9 @@
 import type { MultiPageSheetPage, RegularButtonProps } from "@dust-tt/sparkle";
 import {
   Avatar,
-  ChevronDownIcon,
-  ChevronRightIcon,
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
-  Icon,
   MultiPageSheet,
   MultiPageSheetContent,
 } from "@dust-tt/sparkle";
@@ -256,7 +253,6 @@ function KnowledgeConfigurationSheetContent({
   const { currentPageId, setSheetPageId } = useKnowledgePageContext();
   const { setValue, getValues, setFocus } =
     useFormContext<CapabilityFormData>();
-  const [isAdvancedSettingsOpen, setAdvancedSettingsOpen] = useState(false);
 
   const mcpServerView = useWatch<CapabilityFormData, "mcpServerView">({
     name: "mcpServerView",
@@ -411,19 +407,8 @@ function KnowledgeConfigurationSheetContent({
           {/* Advanced Settings collapsible section */}
           {mcpServerView?.serverType === "internal" &&
             mcpServerView.server.name === SEARCH_SERVER_NAME && (
-              <Collapsible
-                defaultOpen={isAdvancedSettingsOpen}
-                onOpenChange={setAdvancedSettingsOpen}
-              >
+              <Collapsible>
                 <CollapsibleTrigger>
-                  <Icon
-                    visual={
-                      isAdvancedSettingsOpen
-                        ? ChevronDownIcon
-                        : ChevronRightIcon
-                    }
-                    size="sm"
-                  />
                   <h3 className="heading-base font-semibold text-foreground dark:text-foreground-night">
                     Advanced Settings
                   </h3>


### PR DESCRIPTION
## Description

This PR:
- Removed icon and state handling for advanced settings collapsibility
- Changed the Collapsible component to be stateless without default open state control

This is all taken care of by the sparkle component now.

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front
