### PR TITLE
Create onboarding convo in user's language

### DIFF
--- a/front/lib/api/poke/plugins/workspaces/send_onboarding_conversation.ts
+++ b/front/lib/api/poke/plugins/workspaces/send_onboarding_conversation.ts
@@ -22,6 +22,12 @@ export const sendOnboardingConversationPlugin = createPlugin({
         description:
           "Target user stable id (e.g., usr_xxx) belonging to this workspace.",
       },
+      language: {
+        type: "string",
+        label: "Language",
+        description:
+          "Language code for the onboarding conversation (e.g., 'en', 'fr', 'de'). Defaults to English if not specified.",
+      },
     },
   },
   execute: async (auth, _resource, args) => {
@@ -51,6 +57,7 @@ export const sendOnboardingConversationPlugin = createPlugin({
 
     const convoRes = await createOnboardingConversationIfNeeded(targetAuth, {
       force: true,
+      language: args.language || null,
     });
 
     if (convoRes.isErr()) {

--- a/front/lib/swr/conversations.ts
+++ b/front/lib/swr/conversations.ts
@@ -1009,18 +1009,12 @@ export function usePostOnboardingFollowUp({
         return false;
       }
       try {
-        // Get user's preferred language from browser settings.
-        const language =
-          typeof navigator !== "undefined"
-            ? navigator.language?.split("-")[0]
-            : null;
-
         const response = await clientFetch(
           `/api/w/${workspaceId}/assistant/conversations/${conversationId}/onboarding-followup`,
           {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ toolId, language }),
+            body: JSON.stringify({ toolId }),
           }
         );
 

--- a/front/lib/swr/conversations.ts
+++ b/front/lib/swr/conversations.ts
@@ -1009,12 +1009,18 @@ export function usePostOnboardingFollowUp({
         return false;
       }
       try {
+        // Get user's preferred language from browser settings.
+        const language =
+          typeof navigator !== "undefined"
+            ? navigator.language?.split("-")[0]
+            : null;
+
         const response = await clientFetch(
           `/api/w/${workspaceId}/assistant/conversations/${conversationId}/onboarding-followup`,
           {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({ toolId }),
+            body: JSON.stringify({ toolId, language }),
           }
         );
 

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/onboarding-followup.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/onboarding-followup.ts
@@ -45,7 +45,7 @@ async function handler(
     });
   }
 
-  const { toolId, language } = req.body;
+  const { toolId } = req.body;
 
   if (!isString(toolId) || !isInternalMCPServerName(toolId)) {
     return apiError(req, res, {
@@ -65,10 +65,11 @@ async function handler(
 
   const conversation = conversationRes.value;
 
-  const followUpPrompt = buildOnboardingFollowUpPrompt(
-    toolId,
-    isString(language) ? language : null
-  );
+  // Extract user's preferred language from Accept-Language header.
+  const acceptLanguage = req.headers["accept-language"];
+  const language = acceptLanguage?.split(",")[0]?.split("-")[0] ?? null;
+
+  const followUpPrompt = buildOnboardingFollowUpPrompt(toolId, language);
 
   const messageRes = await postUserMessage(auth, {
     conversation,

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/onboarding-followup.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/onboarding-followup.ts
@@ -45,7 +45,7 @@ async function handler(
     });
   }
 
-  const { toolId } = req.body;
+  const { toolId, language } = req.body;
 
   if (!isString(toolId) || !isInternalMCPServerName(toolId)) {
     return apiError(req, res, {
@@ -65,7 +65,10 @@ async function handler(
 
   const conversation = conversationRes.value;
 
-  const followUpPrompt = buildOnboardingFollowUpPrompt(toolId);
+  const followUpPrompt = buildOnboardingFollowUpPrompt(
+    toolId,
+    isString(language) ? language : null
+  );
 
   const messageRes = await postUserMessage(auth, {
     conversation,

--- a/front/pages/api/w/[wId]/assistant/conversations/send-onboarding.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/send-onboarding.ts
@@ -5,6 +5,7 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
+import { isString } from "@app/types";
 
 export type PostSendOnboardingResponseBody = {
   conversationSId: string;
@@ -29,8 +30,16 @@ async function handler(
 
   switch (req.method) {
     case "POST":
+      // Accept language from body or fall back to Accept-Language header.
+      const bodyLanguage = req.body?.language;
+      const acceptLanguage = req.headers["accept-language"];
+      const language = isString(bodyLanguage)
+        ? bodyLanguage
+        : (acceptLanguage?.split(",")[0]?.split("-")[0] ?? null);
+
       const result = await createOnboardingConversationIfNeeded(auth, {
         force: true,
+        language,
       });
 
       if (result.isErr()) {

--- a/front/pages/api/w/[wId]/assistant/conversations/send-onboarding.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/send-onboarding.ts
@@ -30,7 +30,7 @@ async function handler(
 
   switch (req.method) {
     case "POST":
-      // Accept language from body or fall back to Accept-Language header.
+      // Accept language from body (for testing) or fall back to Accept-Language header.
       const bodyLanguage = req.body?.language;
       const acceptLanguage = req.headers["accept-language"];
       const language = isString(bodyLanguage)

--- a/front/pages/w/[wId]/conversation/[cId]/index.tsx
+++ b/front/pages/w/[wId]/conversation/[cId]/index.tsx
@@ -77,7 +77,11 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
     cId === "new" &&
     context.query.welcome === "true"
   ) {
-    await createOnboardingConversationIfNeeded(auth);
+    // Extract user's preferred language from Accept-Language header.
+    const acceptLanguage = context.req.headers["accept-language"];
+    const language = acceptLanguage?.split(",")[0]?.split("-")[0] ?? null;
+
+    await createOnboardingConversationIfNeeded(auth, { language });
 
     const userResource = auth.user();
     const metadata = userResource


### PR DESCRIPTION
## Description

Use the accept-language header to get the language for the onboarding conversation. We have 3 scenarios that create onboarding convos, which all have to account for this:
- The real one users go through
- The poke plugin, which now lets you choose a language for testing
- The dev tools menu item

Fixes https://github.com/dust-tt/tasks/issues/5891

## Tests

Manual

## Risk

Low, only affects onboarding convo.

## Deploy Plan

Front