### PR TITLE
[front] enh(skills): add space content messages to skill/agent builder

### DIFF
--- a/front/components/agent_builder/AgentBuilderSpacesBlock.tsx
+++ b/front/components/agent_builder/AgentBuilderSpacesBlock.tsx
@@ -172,8 +172,8 @@ export function AgentBuilderSpacesBlock() {
       {nonGlobalSpacesWithRestrictions.length > 0 && (
         <div className="mb-4 w-full">
           <ContentMessage variant="golden" size="lg">
-            Based on your selection, this agent can only be used by users with
-            access to space
+            Based on your selection of knowledge and capabilities, this agent
+            can only be used by users with access to space
             {pluralize(nonGlobalSpacesWithRestrictions.length)} :{" "}
             <strong>
               {nonGlobalSpacesWithRestrictions.map((v) => v.name).join(", ")}

--- a/front/components/agent_builder/AgentBuilderSpacesBlock.tsx
+++ b/front/components/agent_builder/AgentBuilderSpacesBlock.tsx
@@ -1,5 +1,6 @@
 import {
   Button,
+  ContentMessage,
   PlanetIcon,
   Sheet,
   SheetContainer,
@@ -20,7 +21,7 @@ import { useSkillsContext } from "@app/components/shared/skills/SkillsContext";
 import { SpaceChips } from "@app/components/shared/SpaceChips";
 import { useMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
 import type { SpaceType } from "@app/types";
-import { removeNulls } from "@app/types";
+import { pluralize, removeNulls } from "@app/types";
 
 export function AgentBuilderSpacesBlock() {
   const { setValue } = useFormContext<AgentBuilderFormData>();
@@ -168,6 +169,19 @@ export function AgentBuilderSpacesBlock() {
           onClick={handleOpenSheet}
         />
       </div>
+      {nonGlobalSpacesWithRestrictions.length > 0 && (
+        <div className="mb-4 w-full">
+          <ContentMessage variant="golden" size="lg">
+            Based on your selection, this agent can only be used by users with
+            access to space
+            {pluralize(nonGlobalSpacesWithRestrictions.length)} :{" "}
+            <strong>
+              {nonGlobalSpacesWithRestrictions.map((v) => v.name).join(", ")}
+            </strong>
+            .
+          </ContentMessage>
+        </div>
+      )}
       <SpaceChips spaces={spacesToDisplay} onRemoveSpace={handleRemoveSpace} />
 
       <Sheet open={isSheetOpen} onOpenChange={handleCloseSheet}>

--- a/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
@@ -70,8 +70,8 @@ export function SkillBuilderRequestedSpacesSection() {
       {nonGlobalSpacesUsedInActions.length > 0 && (
         <div className="mb-4 w-full">
           <ContentMessage variant="golden" size="lg">
-            Based on your selection, this skill can only be used by users with
-            access to space
+            Based on your selection of knowledge and tools, this skill can only
+            be used by users with access to space
             {pluralize(nonGlobalSpacesUsedInActions.length)} :{" "}
             <strong>
               {nonGlobalSpacesUsedInActions.map((v) => v.name).join(", ")}

--- a/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
@@ -1,3 +1,4 @@
+import { ContentMessage } from "@dust-tt/sparkle";
 import { useMemo } from "react";
 import { useFormContext } from "react-hook-form";
 
@@ -8,7 +9,7 @@ import { SpaceChips } from "@app/components/shared/SpaceChips";
 import { useMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
 import type { SkillBuilderFormData } from "@app/components/skill_builder/SkillBuilderFormContext";
 import type { SpaceType } from "@app/types";
-import { removeNulls } from "@app/types";
+import { pluralize, removeNulls } from "@app/types";
 
 export function SkillBuilderRequestedSpacesSection() {
   const { watch, setValue } = useFormContext<SkillBuilderFormData>();
@@ -66,6 +67,19 @@ export function SkillBuilderRequestedSpacesSection() {
           Set what data the skill can access and who can use it.
         </p>
       </div>
+      {nonGlobalSpacesUsedInActions.length > 0 && (
+        <div className="mb-4 w-full">
+          <ContentMessage variant="golden" size="lg">
+            Based on your selection, this skill can only be used by users with
+            access to space
+            {pluralize(nonGlobalSpacesUsedInActions.length)} :{" "}
+            <strong>
+              {nonGlobalSpacesUsedInActions.map((v) => v.name).join(", ")}
+            </strong>
+            .
+          </ContentMessage>
+        </div>
+      )}
       <SpaceChips spaces={spacesToDisplay} onRemoveSpace={handleRemoveSpace} />
     </div>
   );


### PR DESCRIPTION
## Description

- This PR adds back a content message relative to the space selection in both Agent Builder and Skill Builder, highlighting the restrictive aspect of spaces.
- Figma [here](https://www.figma.com/design/wJJMfVF6bluurSKfrEuysc/Product---WIP?node-id=2300-9865&t=A6xhoHyVYRvGrL8v-0).

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
