### PR TITLE
[PART 1] Fix deployment memory spikes caused by synchronized SSE reconnection bursts

### DIFF
--- a/front/hooks/useEventSource.ts
+++ b/front/hooks/useEventSource.ts
@@ -2,7 +2,8 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 import { COMMIT_HASH } from "@app/lib/commit-hash";
 
-const RECONNECT_DELAY = 5000; // 5 seconds.
+const RECONNECT_DELAY_BASE_MS = 3000; // 3 seconds base delay
+const RECONNECT_DELAY_JITTER_MS = 5000; // +0-5 seconds random jitter
 const MAX_RECONNECT_ATTEMPTS = 10;
 
 /**
@@ -149,14 +150,18 @@ export function useEventSource(
         return;
       }
 
+      // Add jitter to prevent synchronized reconnection bursts during deployment.
+      const reconnectDelayMs =
+        RECONNECT_DELAY_BASE_MS + Math.random() * RECONNECT_DELAY_JITTER_MS;
+
       console.error(
-        `Connection error. Attempting to reconnect in ${RECONNECT_DELAY}ms`
+        `Connection error. Attempting to reconnect in ${Math.round(reconnectDelayMs)}ms`
       );
 
-      // Set timeout to reconnect after a delay.
+      // Set timeout to reconnect after a jittered delay.
       reconnectTimeoutRef.current = setTimeout(() => {
         setReconnectCounter((c) => c + 1);
-      }, RECONNECT_DELAY);
+      }, reconnectDelayMs);
     };
 
     return source;


### PR DESCRIPTION
## Description

Production deployments cause significant memory spikes per pod, leading to high memory pressure/GC cycles and eventually leading to probes failures. Pods are being removed from the services, connections are being disrupted and it worsen this effect.

### Root Cause:
During deployment, all active SSE connections (conversation/message event streams) drop simultaneously. Clients reconnect with a fixed 5-second delay, creating a synchronized burst where many clients all reconnect at the exact same moment (T+5s). Each reconnection requests event replay from Redis, loading up to 256 cached events into memory per connection.

**Memory Impact:**
1000 clients × 256 events × 10KB average = 2.5GB raw event data
Without accounting for JSON parsing overhead!

This happens BEFORE any backpressure mechanisms can activate, as events are loaded from Redis into memory first, then streamed to clients (second PR to follow up to implement proper streaming here w/ back pressure).

### Solution

Two simple, high-impact changes to prevent the synchronized burst:

1. Add Reconnection Jitter (hooks/useEventSource.ts)

- Changed from fixed 5-second delay to randomized 3-8 second delay
- Impact: Spreads all reconnections over 5 seconds instead of all at once

2. Reduce Event Replay Batch Size (lib/api/redis-hybrid-manager.ts)

- Reduced `HISTORY_FETCH_COUNT` from 256 → 50 events
- Impact: Memory per reconnection should drops significantly
- Clients automatically paginate if more history is needed (fixed in https://github.com/dust-tt/dust/pull/19191).

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
i. Jitter: Minimal UX impact (reconnection spread over 3-8s vs fixed 5s)
ii. Reduced batch size: on very active conversations, clients will need several pages to retrieve the most recent events
I added some DD instrumentation, I'll monitor how often we need to replay more than 50 events. 

Safe to rollback.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
