### PR TITLE
[front] - chore(obs): tweak charts for global agents

### DIFF
--- a/front/components/agent_builder/observability/charts/DatasourceRetrievalTreemapChart.tsx
+++ b/front/components/agent_builder/observability/charts/DatasourceRetrievalTreemapChart.tsx
@@ -79,11 +79,13 @@ function TreemapContent({
 interface DatasourceRetrievalTreemapChartProps {
   workspaceId: string;
   agentConfigurationId: string;
+  isCustomAgent: boolean;
 }
 
 export function DatasourceRetrievalTreemapChart({
   workspaceId,
   agentConfigurationId,
+  isCustomAgent,
 }: DatasourceRetrievalTreemapChartProps) {
   const { period, mode, selectedVersion } = useObservabilityContext();
 
@@ -96,7 +98,10 @@ export function DatasourceRetrievalTreemapChart({
     workspaceId,
     agentConfigurationId,
     days: period,
-    version: mode === "version" ? selectedVersion?.version : undefined,
+    version:
+      isCustomAgent && mode === "version"
+        ? selectedVersion?.version
+        : undefined,
   });
 
   const { treemapData, legendItems } = useMemo(() => {

--- a/front/components/agent_builder/observability/charts/FeedbackDistributionChart.tsx
+++ b/front/components/agent_builder/observability/charts/FeedbackDistributionChart.tsx
@@ -30,6 +30,7 @@ import { formatShortDate } from "@app/lib/utils/timestamps";
 interface FeedbackDistributionChartProps {
   workspaceId: string;
   agentConfigurationId: string;
+  isCustomAgent: boolean;
 }
 
 function zeroFactory(timestamp: number) {
@@ -44,6 +45,7 @@ function zeroFactory(timestamp: number) {
 export function FeedbackDistributionChart({
   workspaceId,
   agentConfigurationId,
+  isCustomAgent,
 }: FeedbackDistributionChartProps) {
   const { period, mode, selectedVersion } = useObservabilityContext();
   const {
@@ -60,20 +62,21 @@ export function FeedbackDistributionChart({
     workspaceId,
     agentConfigurationId,
     days: period,
-    disabled: !workspaceId || !agentConfigurationId,
+    disabled: !workspaceId || !agentConfigurationId || !isCustomAgent,
   });
 
   const legendItems = legendFromConstant(
     FEEDBACK_DISTRIBUTION_LEGEND,
     FEEDBACK_DISTRIBUTION_PALETTE,
     {
-      includeVersionMarker: mode === "timeRange" && versionMarkers.length > 0,
+      includeVersionMarker:
+        isCustomAgent && mode === "timeRange" && versionMarkers.length > 0,
     }
   );
 
   const filteredData = filterTimeSeriesByVersionWindow(
     feedbackDistribution,
-    mode,
+    isCustomAgent ? mode : "timeRange",
     selectedVersion,
     versionMarkers
   );
@@ -150,7 +153,9 @@ export function FeedbackDistributionChart({
           strokeWidth={2}
           dot={false}
         />
-        <VersionMarkersDots mode={mode} versionMarkers={versionMarkers} />
+        {isCustomAgent && (
+          <VersionMarkersDots mode={mode} versionMarkers={versionMarkers} />
+        )}
       </LineChart>
     </ChartContainer>
   );

--- a/front/components/agent_builder/observability/charts/LatencyChart.tsx
+++ b/front/components/agent_builder/observability/charts/LatencyChart.tsx
@@ -83,13 +83,17 @@ function LatencyTooltip(
   );
 }
 
+interface LatencyChartProps {
+  workspaceId: string;
+  agentConfigurationId: string;
+  isCustomAgent: boolean;
+}
+
 export function LatencyChart({
   workspaceId,
   agentConfigurationId,
-}: {
-  workspaceId: string;
-  agentConfigurationId: string;
-}) {
+  isCustomAgent,
+}: LatencyChartProps) {
   const { period, mode, selectedVersion } = useObservabilityContext();
 
   const {
@@ -100,15 +104,15 @@ export function LatencyChart({
     workspaceId,
     agentConfigurationId,
     period,
-    mode,
-    filterVersion: selectedVersion?.version,
+    mode: isCustomAgent ? mode : "timeRange",
+    filterVersion: isCustomAgent ? selectedVersion?.version : undefined,
   });
 
   const { versionMarkers } = useAgentVersionMarkers({
     workspaceId,
     agentConfigurationId,
     days: period,
-    disabled: !workspaceId || !agentConfigurationId,
+    disabled: !workspaceId || !agentConfigurationId || !isCustomAgent,
   });
 
   const data = useMemo(() => {
@@ -123,7 +127,8 @@ export function LatencyChart({
   }, [rawData, mode, period]);
 
   const legendItems = legendFromConstant(LATENCY_LEGEND, LATENCY_PALETTE, {
-    includeVersionMarker: mode === "timeRange" && versionMarkers.length > 0,
+    includeVersionMarker:
+      isCustomAgent && mode === "timeRange" && versionMarkers.length > 0,
   });
 
   return (
@@ -206,7 +211,9 @@ export function LatencyChart({
           stroke="currentColor"
           dot={false}
         />
-        <VersionMarkersDots mode={mode} versionMarkers={versionMarkers} />
+        {isCustomAgent && (
+          <VersionMarkersDots mode={mode} versionMarkers={versionMarkers} />
+        )}
       </LineChart>
     </ChartContainer>
   );

--- a/front/components/agent_builder/observability/charts/LatencyChart.tsx
+++ b/front/components/agent_builder/observability/charts/LatencyChart.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import { useMemo } from "react";
 import {
   CartesianGrid,
   Line,

--- a/front/components/agent_builder/observability/charts/SourceChart.tsx
+++ b/front/components/agent_builder/observability/charts/SourceChart.tsx
@@ -13,11 +13,13 @@ import { useAgentContextOrigin } from "@app/lib/swr/assistants";
 interface SourceChartProps {
   workspaceId: string;
   agentConfigurationId: string;
+  isCustomAgent: boolean;
 }
 
 export function SourceChart({
   workspaceId,
   agentConfigurationId,
+  isCustomAgent,
 }: SourceChartProps) {
   const { period, mode, selectedVersion } = useObservabilityContext();
 
@@ -27,13 +29,13 @@ export function SourceChart({
       agentConfigurationId,
       days: period,
       version:
-        mode === "version" && selectedVersion
+        isCustomAgent && mode === "version" && selectedVersion
           ? selectedVersion.version
           : undefined,
       disabled:
         !workspaceId ||
         !agentConfigurationId ||
-        (mode === "version" && !selectedVersion),
+        (isCustomAgent && mode === "version" && !selectedVersion),
     });
 
   const total = contextOrigin.total;

--- a/front/components/agent_builder/observability/charts/ToolUsageChart.tsx
+++ b/front/components/agent_builder/observability/charts/ToolUsageChart.tsx
@@ -24,15 +24,21 @@ import type {
 import { getIndexedColor } from "@app/components/agent_builder/observability/utils";
 import { useAgentMcpConfigurations } from "@app/lib/swr/assistants";
 
+interface ToolUsageChartProps {
+  workspaceId: string;
+  agentConfigurationId: string;
+  isCustomAgent: boolean;
+}
+
 export function ToolUsageChart({
   workspaceId,
   agentConfigurationId,
-}: {
-  workspaceId: string;
-  agentConfigurationId: string;
-}) {
+  isCustomAgent,
+}: ToolUsageChartProps) {
   const { period, mode, selectedVersion } = useObservabilityContext();
-  const [toolMode, setToolMode] = useState<ToolChartModeType>("version");
+  const [toolMode, setToolMode] = useState<ToolChartModeType>(
+    isCustomAgent ? "version" : "step"
+  );
   const [hoveredTool, setHoveredTool] = useState<string | null>(null);
 
   const { configurations: mcpConfigurations } = useAgentMcpConfigurations({
@@ -95,18 +101,20 @@ export function ToolUsageChart({
       errorMessage={errorMessage}
       emptyMessage={chartData.length === 0 ? emptyMessage : undefined}
       additionalControls={
-        <ButtonsSwitchList defaultValue={toolMode} size="xs">
-          <ButtonsSwitch
-            value="version"
-            label="By version"
-            onClick={() => setToolMode("version")}
-          />
-          <ButtonsSwitch
-            value="step"
-            label="By step"
-            onClick={() => setToolMode("step")}
-          />
-        </ButtonsSwitchList>
+        isCustomAgent ? (
+          <ButtonsSwitchList defaultValue={toolMode} size="xs">
+            <ButtonsSwitch
+              value="version"
+              label="By version"
+              onClick={() => setToolMode("version")}
+            />
+            <ButtonsSwitch
+              value="step"
+              label="By step"
+              onClick={() => setToolMode("step")}
+            />
+          </ButtonsSwitchList>
+        ) : undefined
       }
       height={CHART_HEIGHT}
       legendItems={legendItems}
@@ -153,7 +161,8 @@ export function ToolUsageChart({
             boxShadow: "none",
           }}
         />
-        {mode === "version" &&
+        {isCustomAgent &&
+          mode === "version" &&
           toolMode === "version" &&
           selectedVersion &&
           chartData.length > 0 && (

--- a/front/components/agent_builder/observability/charts/ToolUsageChart.tsx
+++ b/front/components/agent_builder/observability/charts/ToolUsageChart.tsx
@@ -101,7 +101,7 @@ export function ToolUsageChart({
       errorMessage={errorMessage}
       emptyMessage={chartData.length === 0 ? emptyMessage : undefined}
       additionalControls={
-        isCustomAgent ? (
+        isCustomAgent && (
           <ButtonsSwitchList defaultValue={toolMode} size="xs">
             <ButtonsSwitch
               value="version"
@@ -114,7 +114,7 @@ export function ToolUsageChart({
               onClick={() => setToolMode("step")}
             />
           </ButtonsSwitchList>
-        ) : undefined
+        )
       }
       height={CHART_HEIGHT}
       legendItems={legendItems}

--- a/front/components/agent_builder/observability/charts/UsageMetricsChart.tsx
+++ b/front/components/agent_builder/observability/charts/UsageMetricsChart.tsx
@@ -96,13 +96,17 @@ function UsageMetricsTooltip(
   );
 }
 
+interface UsageMetricsChartProps {
+  workspaceId: string;
+  agentConfigurationId: string;
+  isCustomAgent: boolean;
+}
+
 export function UsageMetricsChart({
   workspaceId,
   agentConfigurationId,
-}: {
-  workspaceId: string;
-  agentConfigurationId: string;
-}) {
+  isCustomAgent,
+}: UsageMetricsChartProps) {
   const { period, mode, selectedVersion } = useObservabilityContext();
   const { usageMetrics, isUsageMetricsLoading, isUsageMetricsError } =
     useAgentUsageMetrics({
@@ -116,20 +120,21 @@ export function UsageMetricsChart({
     workspaceId,
     agentConfigurationId,
     days: period,
-    disabled: !workspaceId || !agentConfigurationId,
+    disabled: !workspaceId || !agentConfigurationId || !isCustomAgent,
   });
 
   const legendItems = legendFromConstant(
     USAGE_METRICS_LEGEND,
     USAGE_METRICS_PALETTE,
     {
-      includeVersionMarker: mode === "timeRange" && versionMarkers.length > 0,
+      includeVersionMarker:
+        isCustomAgent && mode === "timeRange" && versionMarkers.length > 0,
     }
   );
 
   const filteredData = filterTimeSeriesByVersionWindow(
     usageMetrics,
-    mode,
+    isCustomAgent ? mode : "timeRange",
     selectedVersion,
     versionMarkers
   );
@@ -266,7 +271,9 @@ export function UsageMetricsChart({
           stroke="currentColor"
           dot={false}
         />
-        <VersionMarkersDots mode={mode} versionMarkers={versionMarkers} />
+        {isCustomAgent && (
+          <VersionMarkersDots mode={mode} versionMarkers={versionMarkers} />
+        )}
       </LineChart>
     </ChartContainer>
   );

--- a/front/components/observability/AgentFeedback.tsx
+++ b/front/components/observability/AgentFeedback.tsx
@@ -31,7 +31,10 @@ export function AgentFeedback({
     workspaceId: owner.sId,
     agentConfigurationId,
     period,
-    version: mode === "version" ? selectedVersion?.version : undefined,
+    version:
+      allowReactions && mode === "version"
+        ? selectedVersion?.version
+        : undefined,
   });
 
   return (
@@ -74,6 +77,7 @@ export function AgentFeedback({
         <FeedbackDistributionChart
           workspaceId={owner.sId}
           agentConfigurationId={agentConfigurationId}
+          isCustomAgent={allowReactions}
         />
       </TabContentChildSectionLayout>
 

--- a/front/components/observability/AgentFeedback.tsx
+++ b/front/components/observability/AgentFeedback.tsx
@@ -41,6 +41,7 @@ export function AgentFeedback({
         <SharedObservabilityFilterSelector
           workspaceId={owner.sId}
           agentConfigurationId={agentConfigurationId}
+          isCustomAgent={allowReactions}
         />
       }
     >

--- a/front/components/observability/AgentObservability.tsx
+++ b/front/components/observability/AgentObservability.tsx
@@ -68,6 +68,7 @@ export function AgentObservability({
         <SharedObservabilityFilterSelector
           workspaceId={workspaceId}
           agentConfigurationId={agentConfigurationId}
+          isCustomAgent={isCustomAgent}
         />
       }
     >

--- a/front/components/observability/AgentObservability.tsx
+++ b/front/components/observability/AgentObservability.tsx
@@ -206,6 +206,7 @@ export function AgentObservability({
         <ToolUsageChart
           workspaceId={workspaceId}
           agentConfigurationId={agentConfigurationId}
+          isCustomAgent={isCustomAgent}
         />
         <Separator />
         <LatencyChart

--- a/front/components/observability/AgentObservability.tsx
+++ b/front/components/observability/AgentObservability.tsx
@@ -45,7 +45,10 @@ export function AgentObservability({
     workspaceId,
     agentConfigurationId,
     period,
-    version: mode === "version" ? selectedVersion?.version : undefined,
+    version:
+      isCustomAgent && mode === "version"
+        ? selectedVersion?.version
+        : undefined,
   });
 
   const shouldShowMessagesPerActiveUser =
@@ -187,11 +190,13 @@ export function AgentObservability({
         <UsageMetricsChart
           workspaceId={workspaceId}
           agentConfigurationId={agentConfigurationId}
+          isCustomAgent={isCustomAgent}
         />
         <Separator />
         <SourceChart
           workspaceId={workspaceId}
           agentConfigurationId={agentConfigurationId}
+          isCustomAgent={isCustomAgent}
         />
         {featureFlags.includes("agent_tool_outputs_analytics") && (
           <>
@@ -199,6 +204,7 @@ export function AgentObservability({
             <DatasourceRetrievalTreemapChart
               workspaceId={workspaceId}
               agentConfigurationId={agentConfigurationId}
+              isCustomAgent={isCustomAgent}
             />
           </>
         )}
@@ -212,6 +218,7 @@ export function AgentObservability({
         <LatencyChart
           workspaceId={workspaceId}
           agentConfigurationId={agentConfigurationId}
+          isCustomAgent={isCustomAgent}
         />
       </TabContentChildSectionLayout>
     </TabContentLayout>

--- a/front/components/observability/SharedObservabilityFilterSelector.tsx
+++ b/front/components/observability/SharedObservabilityFilterSelector.tsx
@@ -18,6 +18,7 @@ import { useAgentVersionMarkers } from "@app/lib/swr/assistants";
 interface SharedObservabilityFilterSelectorProps {
   workspaceId: string;
   agentConfigurationId: string;
+  isCustomAgent: boolean;
 }
 
 function getVersionValue(versionMarker: AgentVersionMarker) {
@@ -36,6 +37,7 @@ function getVersionValue(versionMarker: AgentVersionMarker) {
 export function SharedObservabilityFilterSelector({
   workspaceId,
   agentConfigurationId,
+  isCustomAgent,
 }: SharedObservabilityFilterSelectorProps) {
   const {
     mode,
@@ -50,7 +52,7 @@ export function SharedObservabilityFilterSelector({
     workspaceId,
     agentConfigurationId,
     days: period,
-    disabled: false,
+    disabled: !isCustomAgent,
   });
 
   useEffect(() => {
@@ -66,20 +68,22 @@ export function SharedObservabilityFilterSelector({
 
   return (
     <div className="flex items-center gap-3">
-      <ButtonsSwitchList defaultValue={mode} size="xs">
-        <ButtonsSwitch
-          value="timeRange"
-          label="Time range"
-          onClick={() => setMode("timeRange")}
-        />
-        <ButtonsSwitch
-          value="version"
-          label="Version"
-          onClick={() => setMode("version")}
-        />
-      </ButtonsSwitchList>
+      {isCustomAgent && (
+        <ButtonsSwitchList defaultValue={mode} size="xs">
+          <ButtonsSwitch
+            value="timeRange"
+            label="Time range"
+            onClick={() => setMode("timeRange")}
+          />
+          <ButtonsSwitch
+            value="version"
+            label="Version"
+            onClick={() => setMode("version")}
+          />
+        </ButtonsSwitchList>
+      )}
 
-      {mode === "timeRange" ? (
+      {mode === "timeRange" || !isCustomAgent ? (
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button

--- a/front/components/observability/SharedObservabilityFilterSelector.tsx
+++ b/front/components/observability/SharedObservabilityFilterSelector.tsx
@@ -83,27 +83,7 @@ export function SharedObservabilityFilterSelector({
         </ButtonsSwitchList>
       )}
 
-      {mode === "timeRange" || !isCustomAgent ? (
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button
-              label={`${period} days`}
-              size="xs"
-              variant="outline"
-              isSelect
-            />
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            {OBSERVABILITY_TIME_RANGE.map((p) => (
-              <DropdownMenuItem
-                key={p}
-                label={`${p} days`}
-                onClick={() => setPeriod(p)}
-              />
-            ))}
-          </DropdownMenuContent>
-        </DropdownMenu>
-      ) : (
+      {isCustomAgent && mode === "version" ? (
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button
@@ -127,6 +107,26 @@ export function SharedObservabilityFilterSelector({
                 key={marker.version}
                 label={getVersionValue(marker)}
                 onClick={() => setSelectedVersion(marker)}
+              />
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      ) : (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              label={`${period} days`}
+              size="xs"
+              variant="outline"
+              isSelect
+            />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            {OBSERVABILITY_TIME_RANGE.map((p) => (
+              <DropdownMenuItem
+                key={p}
+                label={`${p} days`}
+                onClick={() => setPeriod(p)}
               />
             ))}
           </DropdownMenuContent>


### PR DESCRIPTION
## Description

This PR conditionally disables version-specific filtering and controls for global agents in observability charts. Global agents  now default to time range filtering mode only, while custom agents retain full version filtering capabilities including version markers, version selection dropdowns, and tool chart mode switches.

The changes ensure that:
- Version markers are only displayed and fetched for custom agents
- Filter selectors conditionally render time range vs version mode switches based on agent type
- Charts apply version filters only when the agent is custom
- Tool usage chart defaults to "by step" mode for global agents instead of "by version"

## Risk

Low - this only affects the observability UI for global agents by simplifying the available filtering options

## Tests

- [x] Locally
- [x] front-edge

## Deploy Plan

Deploy front