### PR TITLE
[Front] feat(skills): make globally available

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -47,7 +47,6 @@ import { useAgentTriggers } from "@app/lib/swr/agent_triggers";
 import { useSlackChannelsLinkedWithAgent } from "@app/lib/swr/assistants";
 import { useAgentConfigurationSkills } from "@app/lib/swr/skills";
 import { emptyArray } from "@app/lib/swr/swr";
-import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import datadogLogger from "@app/logger/datadogLogger";
 import type { LightAgentConfigurationType } from "@app/types";
 import { isBuilder, normalizeError, removeNulls } from "@app/types";
@@ -94,7 +93,6 @@ export default function AgentBuilder({
   const { owner, user, assistantTemplate } = useAgentBuilderContext();
   const { supportedDataSourceViews } = useDataSourceViewsContext();
   const { mcpServerViews } = useMCPServerViewsContext();
-  const { hasFeature } = useFeatureFlags({ workspaceId: owner.sId });
 
   const router = useRouter();
   const sendNotification = useSendNotification(true);
@@ -115,7 +113,7 @@ export default function AgentBuilder({
   const { skills, isSkillsLoading } = useAgentConfigurationSkills({
     owner,
     agentConfigurationSId: agentConfigurationSIdForSkills ?? "",
-    disabled: !hasFeature("skills") || !agentConfigurationSIdForSkills,
+    disabled: !agentConfigurationSIdForSkills,
   });
 
   const { editors } = useEditors({

--- a/front/components/agent_builder/AgentBuilderLeftPanel.tsx
+++ b/front/components/agent_builder/AgentBuilderLeftPanel.tsx
@@ -10,12 +10,10 @@ import React from "react";
 
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import { AgentBuilderSpacesBlock } from "@app/components/agent_builder/AgentBuilderSpacesBlock";
-import { AgentBuilderCapabilitiesBlock } from "@app/components/agent_builder/capabilities/AgentBuilderCapabilitiesBlock";
 import { AgentBuilderInstructionsBlock } from "@app/components/agent_builder/instructions/AgentBuilderInstructionsBlock";
 import { AgentBuilderSettingsBlock } from "@app/components/agent_builder/settings/AgentBuilderSettingsBlock";
 import { AgentBuilderSkillsBlock } from "@app/components/agent_builder/skills/AgentBuilderSkillsBlock";
 import { AgentBuilderTriggersBlock } from "@app/components/agent_builder/triggers/AgentBuilderTriggersBlock";
-import { useFeatureFlags } from "@app/lib/swr/workspaces";
 
 interface AgentBuilderLeftPanelProps {
   title: string;
@@ -31,12 +29,10 @@ export function AgentBuilderLeftPanel({
   onCancel,
   agentConfigurationId,
   saveButtonProps,
-  isActionsLoading,
+  isActionsLoading: _isActionsLoading,
   isTriggersLoading,
 }: AgentBuilderLeftPanelProps) {
   const { owner } = useAgentBuilderContext();
-
-  const { hasFeature } = useFeatureFlags({ workspaceId: owner.sId });
 
   const handleCancel = async () => {
     onCancel();
@@ -61,14 +57,8 @@ export function AgentBuilderLeftPanel({
           <AgentBuilderInstructionsBlock
             agentConfigurationId={agentConfigurationId}
           />
-          {hasFeature("skills") && <AgentBuilderSpacesBlock />}
-          {hasFeature("skills") ? (
-            <AgentBuilderSkillsBlock />
-          ) : (
-            <AgentBuilderCapabilitiesBlock
-              isActionsLoading={isActionsLoading}
-            />
-          )}
+          <AgentBuilderSpacesBlock />
+          <AgentBuilderSkillsBlock />
           <AgentBuilderTriggersBlock
             owner={owner}
             isTriggersLoading={isTriggersLoading}

--- a/front/components/assistant/AgentBrowser.tsx
+++ b/front/components/assistant/AgentBrowser.tsx
@@ -234,8 +234,6 @@ export function AgentBrowser({
     featureFlags.includes("disallow_agent_creation_to_users") &&
     !isBuilder(owner);
 
-  const hasSkills = featureFlags.includes("skills");
-
   const sortAgents = useCallback(
     (a: LightAgentConfigurationType, b: LightAgentConfigurationType) => {
       if (sortType === "popularity") {
@@ -476,7 +474,7 @@ export function AgentBrowser({
               </div>
             )}
 
-            {hasSkills && isBuilder(owner) ? (
+            {isBuilder(owner) ? (
               <ManageDropdownMenu owner={owner} />
             ) : (
               <Button

--- a/front/components/assistant/CreateDropdown.tsx
+++ b/front/components/assistant/CreateDropdown.tsx
@@ -58,7 +58,7 @@ export const CreateDropdown = ({
         />
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start">
-        {hasFeature("skills") && <DropdownMenuLabel label="Agents" />}
+        <DropdownMenuLabel label="Agents" />
         <DropdownMenuItem
           label="agent from scratch"
           icon={DocumentIcon}
@@ -91,23 +91,15 @@ export const CreateDropdown = ({
             onClick={triggerYAMLUpload}
           />
         )}
-        {hasFeature("skills") && (
-          <>
-            <DropdownMenuLabel label="Skills" />
-            <DropdownMenuItem
-              label="skill"
-              icon={PuzzleIcon}
-              onClick={withTracking(
-                TRACKING_AREAS.BUILDER,
-                "create_skill",
-                () => {
-                  setIsLoading(true);
-                  void router.push(getSkillBuilderRoute(owner.sId, "new"));
-                }
-              )}
-            />
-          </>
-        )}
+        <DropdownMenuLabel label="Skills" />
+        <DropdownMenuItem
+          label="skill"
+          icon={PuzzleIcon}
+          onClick={withTracking(TRACKING_AREAS.BUILDER, "create_skill", () => {
+            setIsLoading(true);
+            void router.push(getSkillBuilderRoute(owner.sId, "new"));
+          })}
+        />
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/front/components/assistant/ToolsPicker.tsx
+++ b/front/components/assistant/ToolsPicker.tsx
@@ -33,7 +33,6 @@ import {
 } from "@app/lib/swr/mcp_servers";
 import { useSkills } from "@app/lib/swr/skill_configurations";
 import { useSpaces } from "@app/lib/swr/spaces";
-import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import {
   trackEvent,
   TRACKING_ACTIONS,
@@ -145,9 +144,6 @@ export function ToolsPicker({
   const shouldFetchToolsData =
     isOpen || isSettingUpServer || !!pendingServerToAdd;
 
-  const { hasFeature } = useFeatureFlags({ workspaceId: owner.sId });
-  const hasSkillsFeature = hasFeature("skills");
-
   const { spaces } = useSpaces({
     workspaceId: owner.sId,
     disabled: !shouldFetchToolsData,
@@ -228,13 +224,11 @@ export function ToolsPicker({
     owner,
     status: "active",
     globalSpaceOnly: true,
-    disabled: !shouldFetchToolsData || !hasSkillsFeature,
+    disabled: !shouldFetchToolsData,
   });
 
   const isDataReady =
-    !isServerViewsLoading &&
-    !isAvailableMCPServersLoading &&
-    (!hasSkillsFeature || !isSkillsLoading);
+    !isServerViewsLoading && !isAvailableMCPServersLoading && !isSkillsLoading;
 
   const filteredSkillsUnselected = useMemo(() => {
     const selectedSkillIds = new Set(selectedSkills.map((s) => s.sId));
@@ -370,38 +364,36 @@ export function ToolsPicker({
         >
           {!isDataReady && <ToolsPickerLoading />}
 
-          {isDataReady &&
-            hasSkillsFeature &&
-            filteredSkillsUnselected.length > 0 && (
-              <>
-                <div className="text-element-700 px-4 py-2 text-xs font-semibold">
-                  Skills
-                </div>
-                {filteredSkillsUnselected.map((skill) => (
-                  <CapabilityItem
-                    key={`skills-picker-${skill.sId}`}
-                    id={skill.sId}
-                    icon={getSkillAvatarIcon(skill.icon)}
-                    label={skill.name}
-                    description={skill.userFacingDescription}
-                    keyPrefix="skills-picker"
-                    onClick={() => {
-                      trackEvent({
-                        area: TRACKING_AREAS.TOOLS,
-                        object: "skill_select",
-                        action: TRACKING_ACTIONS.SELECT,
-                        extra: {
-                          skill_id: skill.sId,
-                          skill_name: skill.name,
-                        },
-                      });
-                      onSkillSelect(skill);
-                      setIsOpen(false);
-                    }}
-                  />
-                ))}
-              </>
-            )}
+          {isDataReady && filteredSkillsUnselected.length > 0 && (
+            <>
+              <div className="text-element-700 px-4 py-2 text-xs font-semibold">
+                Skills
+              </div>
+              {filteredSkillsUnselected.map((skill) => (
+                <CapabilityItem
+                  key={`skills-picker-${skill.sId}`}
+                  id={skill.sId}
+                  icon={getSkillAvatarIcon(skill.icon)}
+                  label={skill.name}
+                  description={skill.userFacingDescription}
+                  keyPrefix="skills-picker"
+                  onClick={() => {
+                    trackEvent({
+                      area: TRACKING_AREAS.TOOLS,
+                      object: "skill_select",
+                      action: TRACKING_ACTIONS.SELECT,
+                      extra: {
+                        skill_id: skill.sId,
+                        skill_name: skill.name,
+                      },
+                    });
+                    onSkillSelect(skill);
+                    setIsOpen(false);
+                  }}
+                />
+              ))}
+            </>
+          )}
 
           {isDataReady && filteredServerViews.length > 0 && (
             <>
@@ -478,18 +470,12 @@ export function ToolsPicker({
                 label={
                   searchText.length > 0
                     ? "No result"
-                    : hasSkillsFeature
-                      ? "No more skills or tools to select"
-                      : "No more tools to select"
+                    : "No more skills or tools to select"
                 }
                 description={
                   searchText.length > 0
-                    ? hasSkillsFeature
-                      ? "No skills or tools found matching your search."
-                      : "No tools found matching your search."
-                    : hasSkillsFeature
-                      ? "All available skills and tools are already selected."
-                      : "All available tools are already selected."
+                    ? "No skills or tools found matching your search."
+                    : "All available skills and tools are already selected."
                 }
                 keyPrefix="tools-picker"
                 disabled

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -150,8 +150,6 @@ export function AgentSidebarMenu({ owner }: AgentSidebarMenuProps) {
     isLoading: isHideTriggeredLoading,
   } = useHideTriggeredConversations();
 
-  const hasSkills = hasFeature("skills");
-
   const isRestrictedFromAgentCreation =
     hasFeature("disallow_agent_creation_to_users") && !isBuilder(owner);
 
@@ -462,7 +460,7 @@ export function AgentSidebarMenu({ owner }: AgentSidebarMenuProps) {
                         />
                       </>
                     )}
-                    {hasSkills && isBuilder(owner) && (
+                    {isBuilder(owner) && (
                       <>
                         <DropdownMenuLabel>Skills</DropdownMenuLabel>
                         <DropdownMenuItem

--- a/front/components/assistant/details/tabs/AgentInfoTab/AssistantToolsSection.tsx
+++ b/front/components/assistant/details/tabs/AgentInfoTab/AssistantToolsSection.tsx
@@ -22,7 +22,6 @@ import { getSkillAvatarIcon } from "@app/lib/skill";
 import { useMCPServers, useMCPServerViews } from "@app/lib/swr/mcp_servers";
 import { useAgentConfigurationSkills } from "@app/lib/swr/skills";
 import { useSpaces } from "@app/lib/swr/spaces";
-import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import type { AgentConfigurationType, LightWorkspaceType } from "@app/types";
 import { asDisplayName, assertNever, removeNulls } from "@app/types";
 
@@ -59,14 +58,12 @@ export function AssistantToolsSection({
   owner,
   isDustAgent,
 }: AssistantToolsSectionProps) {
-  const { featureFlags } = useFeatureFlags({ workspaceId: owner.sId });
   const { mcpServers, isMCPServersLoading: isToolsLoading } = useMCPServers({
     owner,
   });
   const { skills, isSkillsLoading } = useAgentConfigurationSkills({
     owner,
     agentConfigurationSId: agentConfiguration.sId,
-    disabled: !featureFlags.includes("skills"),
   });
 
   const { availableToolsets, isLoading: isToolsetsLoading } =
@@ -87,7 +84,7 @@ export function AssistantToolsSection({
   const sortedSkills = useMemo(() => _.sortBy(skills, "name"), [skills]);
 
   const hasTools = sortedActions.length > 0 || availableToolsets.length > 0;
-  const hasSkills = featureFlags.includes("skills") && skills.length > 0;
+  const hasSkills = skills.length > 0;
 
   return (
     <div className="flex flex-col gap-5">

--- a/front/components/shared/skills/SkillsContext.tsx
+++ b/front/components/shared/skills/SkillsContext.tsx
@@ -2,7 +2,6 @@ import type { ReactNode } from "react";
 import { createContext, useContext, useMemo } from "react";
 
 import { useSkills } from "@app/lib/swr/skill_configurations";
-import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import type { LightWorkspaceType } from "@app/types";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 
@@ -28,13 +27,9 @@ interface SkillsProviderProps {
 }
 
 export const SkillsProvider = ({ owner, children }: SkillsProviderProps) => {
-  const { hasFeature } = useFeatureFlags({ workspaceId: owner.sId });
-  const hasSkillsFeature = hasFeature("skills");
-
   const { skills, isSkillsLoading, isSkillsError } = useSkills({
     owner,
     status: "active",
-    disabled: !hasSkillsFeature,
   });
 
   const value: SkillsContextType = useMemo(() => {

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1748,9 +1748,7 @@ export const INTERNAL_MCP_SERVERS = {
     availability: "auto_hidden_builder",
     allowMultipleInstances: false,
     isPreview: false,
-    isRestricted: ({ featureFlags }) => {
-      return !featureFlags.includes("skills");
-    },
+    isRestricted: undefined,
     tools_stakes: undefined,
     tools_approval_holding_arguments: undefined,
     tools_retry_policies: undefined,

--- a/front/lib/actions/mcp_internal_actions/servers/process/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/process/index.ts
@@ -35,7 +35,6 @@ import type { CoreDataSourceSearchCriteria } from "@app/lib/api/assistant/proces
 import { processDataSources } from "@app/lib/api/assistant/process_data_sources";
 import { getSupportedModelConfig } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
-import { getFeatureFlags } from "@app/lib/auth";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type {
   AgentConfigurationType,
@@ -398,8 +397,6 @@ async function getPromptForProcessDustApp({
   const userMessage: UserMessageType =
     lastUserMessageTuple[0] as UserMessageType;
 
-  const featureFlags = await getFeatureFlags(auth.getNonNullableWorkspace());
-
   return constructPromptMultiActions(auth, {
     userMessage,
     agentConfiguration,
@@ -410,7 +407,6 @@ async function getPromptForProcessDustApp({
     enabledSkills: [],
     equippedSkills: [],
     agentsList: null,
-    featureFlags,
   });
 }
 

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -26,7 +26,6 @@ import type {
   LightAgentConfigurationType,
   ModelConfigurationType,
   UserMessageType,
-  WhitelistableFeature,
   WorkspaceType,
 } from "@app/types";
 import { CHAIN_OF_THOUGHT_META_PROMPT } from "@app/types/assistant/chain_of_thought_meta_prompt";
@@ -86,7 +85,6 @@ function constructToolsSection({
   serverToolsAndInstructions,
   enabledSkills,
   equippedSkills,
-  featureFlags,
 }: {
   hasAvailableActions: boolean;
   model: ModelConfigurationType;
@@ -94,7 +92,6 @@ function constructToolsSection({
   serverToolsAndInstructions?: ServerToolsAndInstructions[];
   enabledSkills: (SkillResource & { extendedSkill: SkillResource | null })[];
   equippedSkills: SkillResource[];
-  featureFlags: WhitelistableFeature[];
 }): string {
   let toolsSection = "# TOOLS\n";
 
@@ -146,11 +143,8 @@ function constructToolsSection({
     toolServersPrompt +=
       "Each server provides a list of tools made available to the agent.\n";
     for (const serverData of serverToolsAndInstructions) {
-      if (
-        featureFlags.includes("skills") &&
-        areInstructionsAlreadyIncludedInSkillSection(serverData)
-      ) {
-        // When skills feature flag is enabled, prevent interactive_content and deep_dive server instructions
+      if (areInstructionsAlreadyIncludedInSkillSection(serverData)) {
+        // Prevent interactive_content and deep_dive server instructions
         // from being duplicated in the prompt if they are already included in the skills section.
         continue;
       }
@@ -201,16 +195,10 @@ function getEnabledSkillInstructions(
 function constructSkillsSection({
   enabledSkills,
   equippedSkills,
-  featureFlags,
 }: {
   enabledSkills: (SkillResource & { extendedSkill: SkillResource | null })[];
   equippedSkills: SkillResource[];
-  featureFlags: WhitelistableFeature[];
 }): string {
-  if (!featureFlags.includes("skills")) {
-    return "";
-  }
-
   let skillsSection =
     "\n## SKILLS\n" +
     "Skills are modular capabilities that extend your abilities for specific tasks. " +
@@ -419,7 +407,6 @@ export function constructPromptMultiActions(
     serverToolsAndInstructions,
     enabledSkills,
     equippedSkills,
-    featureFlags,
   }: {
     userMessage: UserMessageType;
     agentConfiguration: AgentConfigurationType;
@@ -432,7 +419,6 @@ export function constructPromptMultiActions(
     serverToolsAndInstructions?: ServerToolsAndInstructions[];
     enabledSkills: (SkillResource & { extendedSkill: SkillResource | null })[];
     equippedSkills: SkillResource[];
-    featureFlags: WhitelistableFeature[];
   }
 ) {
   const owner = auth.workspace();
@@ -453,12 +439,10 @@ export function constructPromptMultiActions(
       serverToolsAndInstructions,
       enabledSkills,
       equippedSkills,
-      featureFlags,
     }),
     constructSkillsSection({
       enabledSkills,
       equippedSkills,
-      featureFlags,
     }),
     constructAttachmentsSection(),
     constructPastedContentSection(),

--- a/front/lib/api/assistant/jit/skills.ts
+++ b/front/lib/api/assistant/jit/skills.ts
@@ -1,6 +1,5 @@
 import type { ServerSideMCPServerConfigurationType } from "@app/lib/actions/mcp";
 import type { Authenticator } from "@app/lib/auth";
-import { getFeatureFlags } from "@app/lib/auth";
 import { AgentSkillModel } from "@app/lib/models/agent/agent_skill";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
@@ -20,11 +19,6 @@ export async function getSkillManagementServer(
   conversation: ConversationWithoutContentType
 ): Promise<ServerSideMCPServerConfigurationType | null> {
   const owner = auth.getNonNullableWorkspace();
-  const featureFlags = await getFeatureFlags(owner);
-
-  if (!featureFlags.includes("skills")) {
-    return null;
-  }
 
   // Check if agent has any skills configured.
   const skillCount = await AgentSkillModel.count({

--- a/front/lib/api/assistant/jit_actions.test.ts
+++ b/front/lib/api/assistant/jit_actions.test.ts
@@ -116,7 +116,6 @@ describe("getJITServers", () => {
     // In the current test environment, this server may not be created by ensureAllAutoToolsAreCreated.
     it.skip("should include skill_management server when agent has skills and feature flag is enabled", async () => {
       // Enable skills feature flag.
-      await FeatureFlagFactory.basic("skills", workspace);
 
       // Create a skill and link it to the agent.
       const skill = await SkillFactory.create(auth, {
@@ -144,32 +143,8 @@ describe("getJITServers", () => {
       );
     });
 
-    it("should not include skill_management server when feature flag is disabled", async () => {
-      // Create a skill and link it to the agent.
-      const skill = await SkillFactory.create(auth, {
-        name: "Test Skill",
-      });
-      await SkillFactory.linkToAgent(auth, {
-        skillId: skill.id,
-        agentConfigurationId: agentConfig.id,
-      });
-
-      const jitServers = await getJITServers(auth, {
-        agentConfiguration: agentConfig,
-        conversation,
-        attachments: [],
-      });
-
-      const skillManagementServer = jitServers.find(
-        (server) => server.name === "skill_management"
-      );
-
-      expect(skillManagementServer).toBeUndefined();
-    });
-
     it("should not include skill_management server when agent has no skills", async () => {
       // Enable skills feature flag.
-      await FeatureFlagFactory.basic("skills", workspace);
 
       const jitServers = await getJITServers(auth, {
         agentConfiguration: agentConfig,

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -9,7 +9,6 @@ import {
 import { getAgentConfigurationRequirementsFromCapabilities } from "@app/lib/api/assistant/permissions";
 import { getWorkspaceAdministrationVersionLock } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
-import { getFeatureFlags } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { AppResource } from "@app/lib/resources/app_resource";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
@@ -156,16 +155,10 @@ export async function softDeleteSpaceAndLaunchScrubWorkflow(
           });
           const [agentConfig] = agentConfigs;
 
-          let skills: SkillResource[] = [];
-          const featureFlags = await getFeatureFlags(
-            auth.getNonNullableWorkspace()
+          const skills = await SkillResource.listByAgentConfiguration(
+            auth,
+            agentConfig
           );
-          if (featureFlags.includes("skills")) {
-            skills = await SkillResource.listByAgentConfiguration(
-              auth,
-              agentConfig
-            );
-          }
 
           // Get the required group IDs from the agent's actions
           const requirements =

--- a/front/lib/resources/internal_mcp_server_in_memory_resource.ts
+++ b/front/lib/resources/internal_mcp_server_in_memory_resource.ts
@@ -22,7 +22,6 @@ import { isEnabledForWorkspace } from "@app/lib/actions/mcp_internal_actions/ena
 import { extractMetadataFromServerVersion } from "@app/lib/actions/mcp_metadata_extraction";
 import type { MCPServerType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
-import { getFeatureFlags } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { InternalMCPServerCredentialModel } from "@app/lib/models/agent/actions/internal_mcp_server_credentials";
 import { MCPServerConnectionModel } from "@app/lib/models/agent/actions/mcp_server_connection";
@@ -59,16 +58,10 @@ export class InternalMCPServerInMemoryResource {
     let availability = getAvailabilityOfInternalMCPServerById(id);
 
     const name = r.value.name;
-    // TODO(skills-GA): Remove this check once skills are GA.
-    // When skills feature flag is enabled, treat interactive_content and deep_dive
-    // as auto_hidden_builder since they are exposed through skills instead.
+    // Treat interactive_content and deep_dive as auto_hidden_builder
+    // since they are exposed through skills instead.
     if (name === "interactive_content" || name === "deep_dive") {
-      const featureFlags = await getFeatureFlags(
-        auth.getNonNullableWorkspace()
-      );
-      if (featureFlags.includes("skills")) {
-        availability = "auto_hidden_builder";
-      }
+      availability = "auto_hidden_builder";
     }
 
     const isEnabled = await isEnabledForWorkspace(auth, name);

--- a/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
@@ -13,7 +13,7 @@ import { listAttachments } from "@app/lib/api/assistant/jit_utils";
 import { getSkillServers } from "@app/lib/api/assistant/skill_actions";
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { getSupportedModelConfig } from "@app/lib/assistant";
-import { Authenticator, getFeatureFlags } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
@@ -247,10 +247,6 @@ async function handler(
           })
         : null;
 
-      const featureFlags = await getFeatureFlags(
-        auth.getNonNullableWorkspace()
-      );
-
       const prompt = constructPromptMultiActions(auth, {
         userMessage,
         agentConfiguration,
@@ -263,7 +259,6 @@ async function handler(
         serverToolsAndInstructions,
         enabledSkills,
         equippedSkills,
-        featureFlags,
       });
 
       // Build tool specifications to estimate tokens for tool definitions (names + schemas only).

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/index.test.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/index.test.ts
@@ -5,7 +5,6 @@ import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { SkillConfigurationModel } from "@app/lib/models/skill";
 import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
-import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { GroupSpaceFactory } from "@app/tests/utils/GroupSpaceFactory";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
@@ -41,7 +40,6 @@ describe("PATCH /api/w/[wId]/assistant/agent_configurations/[aId] - Skills with 
     const { req, res, workspace, user, authenticator } = await setupTest();
 
     // Enable skills feature flag
-    await FeatureFlagFactory.basic("skills", workspace);
 
     const agent =
       await AgentConfigurationFactory.createTestAgent(authenticator);

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/skills.test.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/skills.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from "vitest";
 
 import { Authenticator } from "@app/lib/auth";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
-import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import type { MembershipRoleType } from "@app/types";
@@ -19,8 +18,6 @@ async function setupTest(
     method,
     role,
   });
-
-  await FeatureFlagFactory.basic("skills", mockRequest.workspace);
 
   return mockRequest;
 }

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/skills.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/skills.ts
@@ -3,7 +3,6 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
-import { getFeatureFlags } from "@app/lib/auth";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
@@ -19,19 +18,6 @@ async function handler(
   res: NextApiResponse<WithAPIErrorResponse<GetAgentSkillsResponseBody>>,
   auth: Authenticator
 ): Promise<void> {
-  const owner = auth.getNonNullableWorkspace();
-
-  const featureFlags = await getFeatureFlags(owner);
-  if (!featureFlags.includes("skills")) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "app_auth_error",
-        message: "Skill builder is not enabled for this workspace.",
-      },
-    });
-  }
-
   const { aId } = req.query;
   if (!isString(aId)) {
     return apiError(req, res, {

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.test.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.test.ts
@@ -8,7 +8,6 @@ import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
-import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { GroupSpaceFactory } from "@app/tests/utils/GroupSpaceFactory";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
@@ -235,7 +234,6 @@ describe("POST /api/w/[wId]/assistant/agent_configurations - Skills with restric
       });
 
     // Enable skills feature flag
-    await FeatureFlagFactory.basic("skills", workspace);
 
     await SpaceFactory.defaults(authenticator);
     const restrictedSpace = await SpaceFactory.regular(workspace);

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -24,7 +24,6 @@ import { getAgentsRecentAuthors } from "@app/lib/api/assistant/recent_authors";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { runOnRedis } from "@app/lib/api/redis";
 import type { Authenticator } from "@app/lib/auth";
-import { getFeatureFlags } from "@app/lib/auth";
 import { AgentMessageFeedbackResource } from "@app/lib/resources/agent_message_feedback_resource";
 import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
@@ -317,12 +316,7 @@ export async function createOrUpgradeAgentConfiguration({
   ).map((e) => e.toJSON());
 
   let skills: SkillResource[] = [];
-  const featureFlags = await getFeatureFlags(auth.getNonNullableWorkspace());
-  if (
-    featureFlags.includes("skills") &&
-    assistant.skills &&
-    assistant.skills.length > 0
-  ) {
+  if (assistant.skills && assistant.skills.length > 0) {
     skills = await SkillResource.fetchByIds(
       auth,
       assistant.skills.map((s) => s.sId)

--- a/front/pages/api/w/[wId]/skills/[sId]/index.test.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.test.ts
@@ -7,7 +7,6 @@ import { SkillVersionModel } from "@app/lib/models/skill";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
-import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
@@ -42,7 +41,6 @@ async function setupTest(
   });
 
   // Enable skills feature flag for the workspace
-  await FeatureFlagFactory.basic("skills", workspace);
 
   // Create default spaces (including system space required for PATCH operations)
   // We need an admin auth to create spaces, so create a temporary admin if needed
@@ -502,8 +500,6 @@ describe("PATCH /api/w/[wId]/skills/[sId] - Suggested skill activation", () => {
       role: "admin",
       method: "PATCH",
     });
-
-    await FeatureFlagFactory.basic("skills", workspace);
 
     const adminAuth = await Authenticator.fromUserIdAndWorkspaceId(
       requestUser.sId,

--- a/front/pages/api/w/[wId]/skills/[sId]/index.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.ts
@@ -6,7 +6,6 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
-import { getFeatureFlags } from "@app/lib/auth";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
@@ -75,17 +74,6 @@ async function handler(
   auth: Authenticator
 ): Promise<void> {
   const owner = auth.getNonNullableWorkspace();
-
-  const featureFlags = await getFeatureFlags(owner);
-  if (!featureFlags.includes("skills")) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "app_auth_error",
-        message: "Skill builder is not enabled for this workspace.",
-      },
-    });
-  }
 
   const { sId } = req.query;
   if (!isString(sId)) {

--- a/front/pages/api/w/[wId]/skills/[sId]/restore.test.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/restore.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from "vitest";
 
 import { Authenticator } from "@app/lib/auth";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
-import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
@@ -21,8 +20,6 @@ async function setupTest(
     role: "builder",
     method,
   });
-
-  await FeatureFlagFactory.basic("skills", workspace);
 
   let skillOwnerAuth: Authenticator;
   if (canWrite) {
@@ -71,24 +68,6 @@ describe("POST /api/w/[wId]/skills/[sId]/restore", () => {
       error: {
         type: "app_auth_error",
         message: "Only editors can restore this skill.",
-      },
-    });
-  });
-
-  it("should return 403 when skills feature flag is not enabled", async () => {
-    const { req, res, workspace } = await createPrivateApiMockRequest({
-      role: "builder",
-      method: "POST",
-    });
-    req.query = { ...req.query, wId: workspace.sId, sId: "some_skill_id" };
-
-    await handler(req, res);
-
-    expect(res._getStatusCode()).toBe(403);
-    expect(res._getJSONData()).toEqual({
-      error: {
-        type: "app_auth_error",
-        message: "Skill builder is not enabled for this workspace.",
       },
     });
   });

--- a/front/pages/api/w/[wId]/skills/[sId]/restore.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/restore.ts
@@ -2,7 +2,6 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
-import { getFeatureFlags } from "@app/lib/auth";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
@@ -19,19 +18,6 @@ async function handler(
   >,
   auth: Authenticator
 ): Promise<void> {
-  const owner = auth.getNonNullableWorkspace();
-
-  const featureFlags = await getFeatureFlags(owner);
-  if (!featureFlags.includes("skills")) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "app_auth_error",
-        message: "Skill builder is not enabled for this workspace.",
-      },
-    });
-  }
-
   if (!isString(req.query.sId)) {
     return apiError(req, res, {
       status_code: 400,

--- a/front/pages/api/w/[wId]/skills/index.test.ts
+++ b/front/pages/api/w/[wId]/skills/index.test.ts
@@ -10,7 +10,6 @@ import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resour
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
-import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
 import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
@@ -32,8 +31,6 @@ async function setupTest(
     method,
     role,
   });
-
-  await FeatureFlagFactory.basic("skills", mockRequest.workspace);
 
   return mockRequest;
 }
@@ -134,25 +131,6 @@ describe("GET /api/w/[wId]/skills", () => {
     expect(skillNames).toContain("Suggested Skill");
     expect(skillNames).not.toContain("Active Skill");
     expect(skillNames).not.toContain("Archived Skill");
-  });
-
-  it("should return 403 when skills feature flag is not enabled", async () => {
-    const { req, res, workspace } = await createPrivateApiMockRequest({
-      method: "GET",
-      role: "builder",
-    });
-
-    req.query = { ...req.query, wId: workspace.sId };
-
-    await handler(req, res);
-
-    expect(res._getStatusCode()).toBe(403);
-    expect(res._getJSONData()).toMatchObject({
-      error: {
-        type: "app_auth_error",
-        message: "Skills are not enabled for this workspace.",
-      },
-    });
   });
 
   it("should work for builder and admin roles", async () => {

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -6,7 +6,6 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
-import { getFeatureFlags } from "@app/lib/auth";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
@@ -77,17 +76,6 @@ async function handler(
   auth: Authenticator
 ): Promise<void> {
   const owner = auth.getNonNullableWorkspace();
-
-  const featureFlags = await getFeatureFlags(owner);
-  if (!featureFlags.includes("skills")) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "app_auth_error",
-        message: "Skills are not enabled for this workspace.",
-      },
-    });
-  }
 
   switch (req.method) {
     case "GET": {

--- a/front/pages/api/w/[wId]/skills/similar.test.ts
+++ b/front/pages/api/w/[wId]/skills/similar.test.ts
@@ -26,7 +26,6 @@ async function setupTest(
   req.query.wId = workspace.sId;
 
   if (withFeatureFlags) {
-    await FeatureFlagFactory.basic("skills", workspace);
     await FeatureFlagFactory.basic("skills_similar_display", workspace);
   }
 

--- a/front/pages/api/w/[wId]/skills/similar.ts
+++ b/front/pages/api/w/[wId]/skills/similar.ts
@@ -3,7 +3,6 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { getSimilarSkills } from "@app/lib/api/skills/existing_skill_checker";
 import type { Authenticator } from "@app/lib/auth";
-import { getFeatureFlags } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
@@ -19,17 +18,6 @@ async function handler(
   auth: Authenticator
 ): Promise<void> {
   const owner = auth.getNonNullableWorkspace();
-
-  const featureFlags = await getFeatureFlags(owner);
-  if (!featureFlags.includes("skills")) {
-    return apiError(req, res, {
-      status_code: 403,
-      api_error: {
-        type: "app_auth_error",
-        message: "Skills are not enabled for this workspace.",
-      },
-    });
-  }
 
   switch (req.method) {
     case "POST": {

--- a/front/pages/w/[wId]/builder/skills/[sId].tsx
+++ b/front/pages/w/[wId]/builder/skills/[sId].tsx
@@ -5,7 +5,6 @@ import React from "react";
 import SkillBuilder from "@app/components/skill_builder/SkillBuilder";
 import { SkillBuilderProvider } from "@app/components/skill_builder/SkillBuilderContext";
 import AppRootLayout from "@app/components/sparkle/AppRootLayout";
-import { getFeatureFlags } from "@app/lib/auth";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { SubscriptionType, UserType, WorkspaceType } from "@app/types";
@@ -23,13 +22,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
   const subscription = auth.subscription();
 
   if (!owner || !auth.isUser() || !subscription || !context.params?.sId) {
-    return {
-      notFound: true,
-    };
-  }
-
-  const featureFlags = await getFeatureFlags(owner);
-  if (!featureFlags.includes("skills")) {
     return {
       notFound: true,
     };

--- a/front/pages/w/[wId]/builder/skills/index.tsx
+++ b/front/pages/w/[wId]/builder/skills/index.tsx
@@ -21,7 +21,6 @@ import { SuggestedSkillsSection } from "@app/components/skills/SuggestedSkillsSe
 import AppRootLayout from "@app/components/sparkle/AppRootLayout";
 import { AppWideModeLayout } from "@app/components/sparkle/AppWideModeLayout";
 import { useHashParam } from "@app/hooks/useHashParams";
-import { getFeatureFlags } from "@app/lib/auth";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { SKILL_ICON } from "@app/lib/skill";
 import { useSkillsWithRelations } from "@app/lib/swr/skill_configurations";
@@ -91,8 +90,7 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     };
   }
 
-  const featureFlags = await getFeatureFlags(owner);
-  if (!featureFlags.includes("skills") || !isBuilder(owner)) {
+  if (!isBuilder(owner)) {
     return {
       notFound: true,
     };

--- a/front/pages/w/[wId]/builder/skills/new.tsx
+++ b/front/pages/w/[wId]/builder/skills/new.tsx
@@ -6,7 +6,6 @@ import { SpacesProvider } from "@app/components/agent_builder/SpacesContext";
 import SkillBuilder from "@app/components/skill_builder/SkillBuilder";
 import { SkillBuilderProvider } from "@app/components/skill_builder/SkillBuilderContext";
 import AppRootLayout from "@app/components/sparkle/AppRootLayout";
-import { getFeatureFlags } from "@app/lib/auth";
 import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { SubscriptionType, UserType, WorkspaceType } from "@app/types";
@@ -30,13 +29,6 @@ export const getServerSideProps = withDefaultUserAuthRequirements<{
     : null;
 
   if (!owner || !auth.isBuilder() || !subscription) {
-    return {
-      notFound: true,
-    };
-  }
-
-  const featureFlags = await getFeatureFlags(owner);
-  if (!featureFlags.includes("skills")) {
     return {
       notFound: true,
     };

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -264,8 +264,6 @@ export async function runModelActivity(
       })
     : null;
 
-  const featureFlags = await getFeatureFlags(auth.getNonNullableWorkspace());
-
   const prompt = constructPromptMultiActions(auth, {
     userMessage,
     agentConfiguration,
@@ -278,7 +276,6 @@ export async function runModelActivity(
     serverToolsAndInstructions: mcpActions,
     enabledSkills,
     equippedSkills,
-    featureFlags,
   });
 
   const specifications: AgentActionSpecification[] = [];

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -204,11 +204,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Discord bot integration for workspace-level Discord integration",
     stage: "dust_only",
   },
-  skills: {
-    description:
-      "Access to Skills, which are packaged sets of instructions and tools",
-    stage: "dust_only",
-  },
   skills_similar_display: {
     description:
       "Display similar skills when creating a new skill to avoid duplicates",


### PR DESCRIPTION
## Description

  - Remove `skills` feature flag, making skills globally available to all workspaces
  - Remove 403 guards from skills API endpoints (5 files)
  - Remove feature flag checks from frontend components (6 files) - always show skills UI
  - Remove feature flag checks from backend logic (5 files) - always enable skill_management MCP server, always treat interactive_content/deep_dive as auto_hidden
  - Remove `skills` from feature flag definition (keep `skills_similar_display` for separate GA)
  - Clean up obsolete tests checking for feature flag disabled state
  - Removed obsolete tests that checked for 403 when feature flag disabled


  ## Tests

🤞 

  ## Risk

  🤷 

  ## Deploy Plan

  Front.