### PR TITLE
[front] fix(skills): update copy, remove header, add link

### DIFF
--- a/front/components/agent_builder/AgentBuilderSpacesBlock.tsx
+++ b/front/components/agent_builder/AgentBuilderSpacesBlock.tsx
@@ -158,7 +158,7 @@ export function AgentBuilderSpacesBlock() {
             Spaces
           </h2>
           <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-            Set what data the agent can access and who can use it.
+            Set what data and tools the agent can access and who can use it.
           </p>
         </div>
         <Button

--- a/front/components/editor/extensions/skill_builder/KnowledgeChip.tsx
+++ b/front/components/editor/extensions/skill_builder/KnowledgeChip.tsx
@@ -40,6 +40,7 @@ export function KnowledgeChip({ node, title, onRemove }: KnowledgeChipProps) {
       label={title}
       icon={{ visual: icon }}
       target="_blank"
+      href={node.sourceUrl ?? undefined}
       color="white"
       onRemove={onRemove}
       size="xs"

--- a/front/components/skill_builder/SkillBuilder.tsx
+++ b/front/components/skill_builder/SkillBuilder.tsx
@@ -158,17 +158,6 @@ export default function SkillBuilder({
 
             <ScrollArea className="flex-1">
               <div className="mx-auto space-y-10 p-4 2xl:max-w-5xl">
-                {!extendedSkill && (
-                  <div>
-                    <h2 className="heading-lg text-foreground dark:text-foreground-night">
-                      Create new skill
-                    </h2>
-                    <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-                      Create a package of instructions and tools that agents can
-                      share.
-                    </p>
-                  </div>
-                )}
                 <SkillBuilderRequestedSpacesSection />
                 <SkillBuilderAgentFacingDescriptionSection />
                 <SkillBuilderInstructionsSection skill={skill} />

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -137,8 +137,8 @@ const getTableColumns = (onAgentClick: (agentId: string) => void) => {
 
   return [
     nameColumn,
-    editorsColumn,
     usedByColumn(onAgentClick),
+    editorsColumn,
     lastEditedColumn,
     menuColumn,
   ];


### PR DESCRIPTION
## Description

This PR is a collection of a few small fixes.
- Update the copy for the Agent Builder spaces block.
- Add a clickable link in `KnowledgeChip`.
- Remove the header in Skill Builder.
- Fix the order of the columns in `SkillsTable`.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
