### PR TITLE
[Front] feat(skills): filter skill editor search to builders only

### DIFF
--- a/front/components/members/AddEditorsDropdown.tsx
+++ b/front/components/members/AddEditorsDropdown.tsx
@@ -20,11 +20,13 @@ export function AddEditorDropdown({
   editors,
   onAddEditor,
   trigger,
+  buildersOnly = false,
 }: {
   owner: WorkspaceType;
   editors: UserType[];
   onAddEditor: (member: UserType) => void;
   trigger: JSX.Element;
+  buildersOnly?: boolean;
 }) {
   const [isEditorPickerOpen, setIsEditorPickerOpen] = useState(false);
   const [searchTerm, setSearchTerm] = useState("");
@@ -35,6 +37,7 @@ export function AddEditorDropdown({
       searchTerm,
       pageIndex: 0,
       pageSize: 25,
+      buildersOnly,
     });
 
   return (

--- a/front/components/shared/EditorsSheet.tsx
+++ b/front/components/shared/EditorsSheet.tsx
@@ -49,6 +49,7 @@ type EditorsSheetProps = {
   editors: UserType[];
   onEditorsChange: (editors: UserType[]) => void;
   description: string;
+  buildersOnly?: boolean;
 };
 
 export function EditorsSheet({
@@ -56,6 +57,7 @@ export function EditorsSheet({
   editors,
   onEditorsChange,
   description,
+  buildersOnly = false,
 }: EditorsSheetProps) {
   const [pagination, setPagination] = useState<PaginationState>({
     pageIndex: 0,
@@ -87,6 +89,7 @@ export function EditorsSheet({
       searchTerm,
       pageIndex: 0,
       pageSize: 100,
+      buildersOnly,
     });
 
   const onRemoveEditor = useCallback((user: UserType) => {

--- a/front/components/skill_builder/SkillEditorsSheet.tsx
+++ b/front/components/skill_builder/SkillEditorsSheet.tsx
@@ -19,6 +19,7 @@ export function SkillEditorsSheet() {
       editors={editors || []}
       onEditorsChange={onChange}
       description="People who can use and edit the skill."
+      buildersOnly={true}
     />
   );
 }

--- a/front/components/skill_builder/SkillEditorsSheet.tsx
+++ b/front/components/skill_builder/SkillEditorsSheet.tsx
@@ -19,7 +19,7 @@ export function SkillEditorsSheet() {
       editors={editors || []}
       onEditorsChange={onChange}
       description="People who can use and edit the skill."
-      buildersOnly={true}
+      buildersOnly
     />
   );
 }

--- a/front/components/skills/SkillEditorsTab.tsx
+++ b/front/components/skills/SkillEditorsTab.tsx
@@ -71,6 +71,7 @@ export function SkillEditorsTab({ owner, user, skill }: AgentEditorsTabProps) {
             trigger={
               <Button label="Add editors" icon={PlusIcon} onClick={() => {}} />
             }
+            buildersOnly
           />
         </div>
       )}

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -38,6 +38,7 @@ import {
   ACTIVE_ROLES,
   assertNever,
   Err,
+  isBuilder,
   md5,
   Ok,
   removeNulls,
@@ -195,6 +196,7 @@ export async function searchMembers(
     searchTerm?: string;
     searchEmails?: string[];
     groupKind?: Omit<GroupKind, "system">;
+    buildersOnly?: boolean;
   },
   paginationParams: SearchMembersPaginationParams
 ): Promise<{ members: UserTypeWithWorkspace[]; total: number }> {
@@ -273,7 +275,15 @@ export async function searchMembers(
     })
   );
 
-  return { members: usersWithWorkspace, total };
+  let filteredUsers = usersWithWorkspace;
+  if (options.buildersOnly) {
+    filteredUsers = usersWithWorkspace.filter((u) => isBuilder(u.workspace));
+  }
+
+  return {
+    members: removeNulls(filteredUsers),
+    total: options.buildersOnly ? filteredUsers.length : total,
+  };
 }
 
 export async function getMembersCount(

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -94,6 +94,7 @@ export function useSearchMembers({
   pageIndex,
   pageSize,
   groupKind,
+  buildersOnly,
   disabled,
 }: {
   workspaceId: string;
@@ -101,6 +102,7 @@ export function useSearchMembers({
   pageIndex: number;
   pageSize: number;
   groupKind?: Omit<GroupKind, "system">;
+  buildersOnly?: boolean;
   disabled?: boolean;
 }) {
   const searchMembersFetcher: Fetcher<SearchMembersResponseBody> = fetcher;
@@ -123,6 +125,10 @@ export function useSearchMembers({
 
   if (groupKind && isGroupKind(groupKind)) {
     searchParams.set("groupKind", groupKind);
+  }
+
+  if (buildersOnly) {
+    searchParams.set("buildersOnly", "true");
   }
 
   const { data, error, mutate, mutateRegardlessOfQueryParams } =

--- a/front/pages/api/w/[wId]/members/search.test.ts
+++ b/front/pages/api/w/[wId]/members/search.test.ts
@@ -318,10 +318,7 @@ describe("GET /api/w/[wId]/members/search", () => {
       role: "admin",
     });
 
-    const users = await Promise.all([
-      UserFactory.basic(),
-      UserFactory.basic(),
-    ]);
+    const users = await Promise.all([UserFactory.basic(), UserFactory.basic()]);
 
     await Promise.all([
       MembershipFactory.associate(workspace, users[0], { role: "builder" }),
@@ -346,10 +343,7 @@ describe("GET /api/w/[wId]/members/search", () => {
       role: "admin",
     });
 
-    const users = await Promise.all([
-      UserFactory.basic(),
-      UserFactory.basic(),
-    ]);
+    const users = await Promise.all([UserFactory.basic(), UserFactory.basic()]);
 
     await Promise.all([
       MembershipFactory.associate(workspace, users[0], { role: "builder" }),

--- a/front/pages/api/w/[wId]/members/search.ts
+++ b/front/pages/api/w/[wId]/members/search.ts
@@ -1,7 +1,7 @@
 import { isLeft } from "fp-ts/lib/Either";
 import * as t from "io-ts";
 import { formatValidationErrors } from "io-ts-reporters";
-import { NumberFromString, withFallback } from "io-ts-types";
+import { BooleanFromString, NumberFromString, withFallback } from "io-ts-types";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
@@ -37,6 +37,7 @@ const SearchMembersQueryCodec = t.type({
   searchTerm: t.union([t.string, t.undefined]),
   searchEmails: t.union([t.string, t.undefined]),
   groupKind: t.union([GroupKindWithoutSystemCodec, t.undefined]),
+  buildersOnly: t.union([BooleanFromString, t.undefined]),
 });
 
 export type SearchMembersResponseBody = {
@@ -83,6 +84,7 @@ async function handler(
           searchTerm: query.searchTerm,
           searchEmails: emails,
           groupKind: query.groupKind,
+          buildersOnly: query.buildersOnly,
         },
         query
       );


### PR DESCRIPTION
First step of : https://github.com/dust-tt/tasks/issues/5894

Restrict skill editors to builders only in the UI. 

Next step is to enforce restriction at the skill API endpoints level

## Description

- Add `buildersOnly` filter to members search API endpoint
- Filter skill editor selection to only show builders/admins
- Agent editor selection unchanged (shows all members)

## Tests

- Manual
- Added 5 test cases covering buildersOnly filtering scenarios

## Risk

Low. 

## Deploy Plan

Front.