### PR TITLE
[front] enh(skills): update avatar color and copy

### DIFF
--- a/front/components/agent_builder/AgentBuilderSpacesBlock.tsx
+++ b/front/components/agent_builder/AgentBuilderSpacesBlock.tsx
@@ -159,7 +159,7 @@ export function AgentBuilderSpacesBlock() {
             Spaces
           </h2>
           <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-            Set what data and tools the agent can access and who can use it.
+            Set what knowledge and capabilities the agent can access.
           </p>
         </div>
         <Button

--- a/front/components/agent_builder/skills/AgentBuilderSkillsBlock.tsx
+++ b/front/components/agent_builder/skills/AgentBuilderSkillsBlock.tsx
@@ -36,7 +36,11 @@ import { useMCPServerViewsContext } from "@app/components/shared/tools_picker/MC
 import type { BuilderAction } from "@app/components/shared/tools_picker/types";
 import { BACKGROUND_IMAGE_STYLE_PROPS } from "@app/components/shared/tools_picker/util";
 import { useSendNotification } from "@app/hooks/useNotification";
-import { getSkillIcon } from "@app/lib/skill";
+import {
+  getSkillIcon,
+  SKILL_AVATAR_BACKGROUND_COLOR,
+  SKILL_AVATAR_ICON_COLOR,
+} from "@app/lib/skill";
 import { useSkillWithRelations } from "@app/lib/swr/skill_configurations";
 
 interface SkillCardProps {
@@ -66,7 +70,12 @@ function SkillCard({ skill, onRemove, onClick }: SkillCardProps) {
     >
       <div className="flex w-full flex-col gap-2 text-sm">
         <div className="flex w-full items-center gap-2 font-medium text-foreground dark:text-foreground-night">
-          <ResourceAvatar icon={SkillIcon} size="xs" />
+          <ResourceAvatar
+            icon={SkillIcon}
+            size="xs"
+            backgroundColor={SKILL_AVATAR_BACKGROUND_COLOR}
+            iconColor={SKILL_AVATAR_ICON_COLOR}
+          />
           <span className="truncate">{skill.name}</span>
         </div>
 

--- a/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
@@ -64,7 +64,7 @@ export function SkillBuilderRequestedSpacesSection() {
           Spaces
         </h3>
         <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-          Set what data the skill can access and who can use it.
+          Sets what knowledge and tools the skill can access.
         </p>
       </div>
       {nonGlobalSpacesUsedInActions.length > 0 && (

--- a/front/components/skills/SuggestedSkillsSection.tsx
+++ b/front/components/skills/SuggestedSkillsSection.tsx
@@ -1,5 +1,4 @@
 import {
-  Avatar,
   Button,
   Card,
   CardActionButton,
@@ -10,8 +9,13 @@ import {
 import { useRouter } from "next/router";
 import { useState } from "react";
 
+import { ResourceAvatar } from "@app/components/resources/resources_icons";
 import { ArchiveSkillDialog } from "@app/components/skills/ArchiveSkillDialog";
-import { getSkillIcon } from "@app/lib/skill";
+import {
+  getSkillIcon,
+  SKILL_AVATAR_BACKGROUND_COLOR,
+  SKILL_AVATAR_ICON_COLOR,
+} from "@app/lib/skill";
 import { useUpdateSkillEditors } from "@app/lib/swr/skill_editors";
 import { getSkillBuilderRoute } from "@app/lib/utils/router";
 import type { LightWorkspaceType, UserType } from "@app/types";
@@ -67,7 +71,12 @@ function SuggestedSkillCard({
         <div className="flex h-full w-full flex-col justify-between gap-3">
           <div className="flex flex-col">
             <div className="mb-2 flex items-center gap-2">
-              <Avatar icon={getSkillIcon(skill.icon)} size="sm" />
+              <ResourceAvatar
+                icon={getSkillIcon(skill.icon)}
+                size="sm"
+                backgroundColor={SKILL_AVATAR_BACKGROUND_COLOR}
+                iconColor={SKILL_AVATAR_ICON_COLOR}
+              />
               <span className="truncate text-sm font-medium">{skill.name}</span>
             </div>
             <p className="line-clamp-2 text-sm text-muted-foreground dark:text-muted-foreground-night">

--- a/front/lib/skill.ts
+++ b/front/lib/skill.ts
@@ -16,6 +16,11 @@ import type {
 
 export const SKILL_ICON = PuzzleIcon;
 
+export const SKILL_AVATAR_BACKGROUND_COLOR =
+  "bg-highlight-50 dark:bg-highlight-50-night";
+export const SKILL_AVATAR_ICON_COLOR =
+  "text-highlight dark:text-highlight-night";
+
 export function getSkillAvatarIcon(
   iconString: string | null
 ): React.ComponentType<{
@@ -29,13 +34,21 @@ export function getSkillAvatarIcon(
   ) {
     const icon = getIcon(iconString);
     return (props) =>
-      React.createElement(ResourceAvatar, { icon, size: "sm", ...props });
+      React.createElement(ResourceAvatar, {
+        icon,
+        size: "sm",
+        backgroundColor: SKILL_AVATAR_BACKGROUND_COLOR,
+        iconColor: SKILL_AVATAR_ICON_COLOR,
+        ...props,
+      });
   }
 
   return (props) =>
     React.createElement(ResourceAvatar, {
       icon: SKILL_ICON,
       size: "sm",
+      backgroundColor: SKILL_AVATAR_BACKGROUND_COLOR,
+      iconColor: SKILL_AVATAR_ICON_COLOR,
       ...props,
     });
 }


### PR DESCRIPTION
## Description

- This PR updates the text and background color for skill avatars + updates the copy for the spaces section.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
