### PR TITLE
[skills] Add a groups kind 'skill_editors' to not wrongly use "agent_editors"

### DIFF
--- a/front/components/poke/groups/columns.tsx
+++ b/front/components/poke/groups/columns.tsx
@@ -13,6 +13,7 @@ export const getPokeGroupKindChipColor = (kind: GroupKind) => {
     case "system":
       return "warning";
     case "agent_editors":
+    case "skill_editors":
       return "rose";
     default:
       return "primary";

--- a/front/components/workspace/api-keys/utils.ts
+++ b/front/components/workspace/api-keys/utils.ts
@@ -2,6 +2,7 @@ import type { GroupType } from "@app/types";
 import {
   AGENT_GROUP_PREFIX,
   GLOBAL_SPACE_NAME,
+  SKILL_GROUP_PREFIX,
   SPACE_GROUP_PREFIX,
 } from "@app/types";
 
@@ -10,7 +11,13 @@ export const prettifyGroupName = (group: GroupType) => {
     return GLOBAL_SPACE_NAME;
   }
 
-  return group.kind === "agent_editors"
-    ? group.name.replace(AGENT_GROUP_PREFIX, "")
-    : group.name.replace(SPACE_GROUP_PREFIX, "");
+  if (group.kind === "agent_editors") {
+    return group.name.replace(AGENT_GROUP_PREFIX, "");
+  }
+
+  if (group.kind === "skill_editors") {
+    return group.name.replace(SKILL_GROUP_PREFIX, "");
+  }
+
+  return group.name.replace(SPACE_GROUP_PREFIX, "");
 };

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -1065,12 +1065,16 @@ export class GroupResource extends BaseResource<GroupModel> {
       );
     }
 
-    // Users can only be added to regular, agent_editors or provisioned groups.
-    if (!["regular", "agent_editors", "provisioned"].includes(this.kind)) {
+    // Users can only be added to regular, agent_editors, skill_editors or provisioned groups.
+    if (
+      !["regular", "agent_editors", "skill_editors", "provisioned"].includes(
+        this.kind
+      )
+    ) {
       return new Err(
         new DustError(
           "system_or_global_group",
-          "Users can only be added to regular, agent_editors or provisioned groups."
+          "Users can only be added to regular, agent_editors, skill_editors or provisioned groups."
         )
       );
     }
@@ -1169,12 +1173,16 @@ export class GroupResource extends BaseResource<GroupModel> {
       );
     }
 
-    // Users can only be added to regular, agent_editors or provisioned groups.
-    if (!["regular", "agent_editors", "provisioned"].includes(this.kind)) {
+    // Users can only be removed from regular, agent_editors, skill_editors or provisioned groups.
+    if (
+      !["regular", "agent_editors", "skill_editors", "provisioned"].includes(
+        this.kind
+      )
+    ) {
       return new Err(
         new DustError(
           "system_or_global_group",
-          "Users can only be removed from regular, agent_editors or provisioned groups."
+          "Users can only be removed from regular, agent_editors, skill_editors or provisioned groups."
         )
       );
     }
@@ -1352,10 +1360,10 @@ export class GroupResource extends BaseResource<GroupModel> {
    * 1. Group-based: The group's members get read access
    * 2. Role-based: Workspace admins get read and write access
    *
-   * For agent_editors groups, the permissions are:
+   * For agent_editors and skill_editors groups, the permissions are:
    * 1. Group-based: The group's members get read and write access
    * 2. Role-based: Workspace admins get read and write access. All users can
-   *    read "agent_editors" groups.
+   *    read "agent_editors" and "skill_editors" groups.
    *
    * CAUTION: if / when editing, note that for role permissions, permissions are
    * NOT inherited, i.e. if you set a permission for role "user", an "admin"
@@ -1376,18 +1384,20 @@ export class GroupResource extends BaseResource<GroupModel> {
       },
     ];
 
+    const isEditorGroup =
+      this.kind === "agent_editors" || this.kind === "skill_editors";
+
     return [
       {
         groups: [
           {
             id: this.id,
-            permissions:
-              this.kind === "agent_editors" ? ["read", "write"] : ["read"],
+            permissions: isEditorGroup ? ["read", "write"] : ["read"],
           },
         ],
         roles: [
           { role: "admin", permissions: ["read", "write", "admin"] },
-          ...(this.kind === "agent_editors" ? userReadPermissions : []),
+          ...(isEditorGroup ? userReadPermissions : []),
         ],
         workspaceId: this.workspaceId,
       },

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -791,7 +791,13 @@ export class GroupResource extends BaseResource<GroupModel> {
   static async listUserGroupsInWorkspace({
     user,
     workspace,
-    groupKinds = ["global", "regular", "provisioned", "agent_editors"],
+    groupKinds = [
+      "global",
+      "regular",
+      "provisioned",
+      "agent_editors",
+      "skill_editors",
+    ],
     transaction,
   }: {
     user: UserResource;

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -66,11 +66,11 @@ import type {
   Result,
 } from "@app/types";
 import {
-  AGENT_GROUP_PREFIX,
   Err,
   normalizeError,
   Ok,
   removeNulls,
+  SKILL_GROUP_PREFIX,
 } from "@app/types";
 import type {
   SkillStatus,
@@ -316,8 +316,8 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     const defaultGroup = await GroupResource.makeNew(
       {
         workspaceId: workspace.id,
-        name: `${AGENT_GROUP_PREFIX} ${skill.name} (skill:${skill.id})`,
-        kind: "agent_editors",
+        name: `${SKILL_GROUP_PREFIX} ${skill.name} (skill:${skill.id})`,
+        kind: "skill_editors",
       },
       { transaction }
     );

--- a/front/migrations/20260112_migrate_skill_editor_groups.ts
+++ b/front/migrations/20260112_migrate_skill_editor_groups.ts
@@ -1,0 +1,131 @@
+import type { Logger } from "pino";
+import { Op } from "sequelize";
+
+import { GroupSkillModel } from "@app/lib/models/skill/group_skill";
+import { GroupModel } from "@app/lib/resources/storage/models/groups";
+import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
+import { makeScript } from "@app/scripts/helpers";
+import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
+import type { LightWorkspaceType } from "@app/types";
+import { AGENT_GROUP_PREFIX, SKILL_GROUP_PREFIX } from "@app/types";
+
+/**
+ * This migration changes all groups that are associated with skills from
+ * kind "agent_editors" to "skill_editors". It also updates their names
+ * to use SKILL_GROUP_PREFIX instead of AGENT_GROUP_PREFIX.
+ */
+
+async function migrateSkillEditorGroups(
+  execute: boolean,
+  logger: Logger,
+  workspace: LightWorkspaceType
+): Promise<void> {
+  // Find all group-skill associations for this workspace.
+  const groupSkillAssociations = await GroupSkillModel.findAll({
+    where: {
+      workspaceId: workspace.id,
+    },
+    attributes: ["groupId"],
+  });
+
+  if (groupSkillAssociations.length === 0) {
+    logger.info(
+      { workspaceId: workspace.sId },
+      "No skill-group associations found, skipping"
+    );
+    return;
+  }
+
+  const groupIds = [...new Set(groupSkillAssociations.map((gs) => gs.groupId))];
+
+  // Find groups that are of kind "agent_editors" (not already "skill_editors").
+  const groupsToMigrate = await GroupModel.findAll({
+    where: {
+      id: { [Op.in]: groupIds },
+      workspaceId: workspace.id,
+      kind: "agent_editors",
+    },
+  });
+
+  if (groupsToMigrate.length === 0) {
+    logger.info(
+      { workspaceId: workspace.sId },
+      "No groups to migrate (all already skill_editors or no agent_editors groups found)"
+    );
+    return;
+  }
+
+  logger.info(
+    {
+      workspaceId: workspace.sId,
+      groupCount: groupsToMigrate.length,
+    },
+    `Found ${groupsToMigrate.length} groups to migrate from agent_editors to skill_editors`
+  );
+
+  await concurrentExecutor(
+    groupsToMigrate,
+    async (group) => {
+      const oldName = group.name;
+      // Replace AGENT_GROUP_PREFIX with SKILL_GROUP_PREFIX in the name
+      const newName = oldName.replace(AGENT_GROUP_PREFIX, SKILL_GROUP_PREFIX);
+
+      logger.info(
+        {
+          workspaceId: workspace.sId,
+          groupId: group.id,
+          oldKind: group.kind,
+          newKind: "skill_editors",
+          oldName,
+          newName,
+        },
+        "Migrating group"
+      );
+
+      if (execute) {
+        await group.update({
+          kind: "skill_editors",
+          name: newName,
+        });
+      }
+    },
+    { concurrency: 4 }
+  );
+
+  logger.info(
+    { workspaceId: workspace.sId },
+    `Skill editor groups migration completed for workspace`
+  );
+}
+
+makeScript(
+  {
+    wId: { type: "string", required: false },
+  },
+  async ({ wId, execute }, logger) => {
+    logger.info("Starting skill editor groups migration");
+
+    if (wId) {
+      const ws = await WorkspaceModel.findOne({ where: { sId: wId } });
+      if (!ws) {
+        throw new Error(`Workspace not found: ${wId}`);
+      }
+      await migrateSkillEditorGroups(
+        execute,
+        logger,
+        renderLightWorkspaceType({ workspace: ws })
+      );
+    } else {
+      await runOnAllWorkspaces(
+        async (workspace) => {
+          await migrateSkillEditorGroups(execute, logger, workspace);
+        },
+        { concurrency: 4 }
+      );
+    }
+
+    logger.info("Skill editor groups migration completed");
+  }
+);

--- a/front/types/groups.ts
+++ b/front/types/groups.ts
@@ -18,6 +18,10 @@ import { isRoleType } from "./user";
  *  agent. Has special permissions: not restricted only to admins. Users can
  *  create, and members of the group can update it.
  *
+ * skill_editors group: Group specific to represent skill editors, tied to a
+ *  skill. Has special permissions: not restricted only to admins. Users can
+ *  create, and members of the group can update it.
+ *
  *  provisioned group: Contains all users from a provisioned group.
  */
 export const GROUP_KINDS = [
@@ -25,6 +29,7 @@ export const GROUP_KINDS = [
   "global",
   "system",
   "agent_editors",
+  "skill_editors",
   "provisioned",
 ] as const;
 export type GroupKind = (typeof GROUP_KINDS)[number];
@@ -43,6 +48,10 @@ export function isAgentEditorGroupKind(value: GroupKind): boolean {
   return value === "agent_editors";
 }
 
+export function isSkillEditorGroupKind(value: GroupKind): boolean {
+  return value === "skill_editors";
+}
+
 export type GroupType = {
   id: ModelId;
   name: string;
@@ -56,6 +65,7 @@ export const GroupKindCodec = t.keyof({
   global: null,
   regular: null,
   agent_editors: null,
+  skill_editors: null,
   system: null,
   provisioned: null,
 });
@@ -112,5 +122,6 @@ export function getHeaderFromRole(role: RoleType | undefined) {
 }
 
 export const AGENT_GROUP_PREFIX = "Group for Agent";
+export const SKILL_GROUP_PREFIX = "Group for Skill";
 export const SPACE_GROUP_PREFIX = "Group for space";
 export const GLOBAL_SPACE_NAME = "Company Data";


### PR DESCRIPTION
## Description

We currently use the kind "agent_editors" for skill editors.
This PR Introduces another kind of group,  which I think it makes things clearer

## Tests



## Risk

low
## Deploy Plan

I think it is OK to merge then apply the migration script 
There is nothing really relying on this value being "skill_editors" so nothing should break
