### PR TITLE
[Front] feat(skills): enforce builders-only at skill editors API level

### DIFF
--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -1216,6 +1216,7 @@ export async function updateAgentPermissions(
       | "user_not_found"
       | "user_not_member"
       | "user_already_member"
+      | "group_requirements_not_met"
     >
   >
 > {

--- a/front/lib/error.ts
+++ b/front/lib/error.ts
@@ -31,6 +31,7 @@ export type DustErrorCode =
   | "user_already_member"
   | "user_not_found"
   | "user_not_member"
+  | "group_requirements_not_met"
   | "group_not_found"
   // MCP Server errors
   | "remote_server_not_found"

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -1024,6 +1024,7 @@ export class GroupResource extends BaseResource<GroupModel> {
         | "unauthorized"
         | "user_not_found"
         | "user_already_member"
+        | "group_requirements_not_met"
         | "system_or_global_group"
       >
     >
@@ -1081,6 +1082,20 @@ export class GroupResource extends BaseResource<GroupModel> {
         new DustError(
           "system_or_global_group",
           "Users can only be added to regular, agent_editors, skill_editors or provisioned groups."
+        )
+      );
+    }
+
+    if (
+      this.kind === "skill_editors" &&
+      workspaceMemberships.some((member) => !member.isBuilder)
+    ) {
+      return new Err(
+        new DustError(
+          "group_requirements_not_met",
+          userIds.length === 1
+            ? "Cannot add: user is not a builder in the workspace"
+            : "Cannot add: some users are not builders in the workspace"
         )
       );
     }
@@ -1248,6 +1263,7 @@ export class GroupResource extends BaseResource<GroupModel> {
         | "user_not_found"
         | "user_not_member"
         | "user_already_member"
+        | "group_requirements_not_met"
         | "system_or_global_group"
       >
     >

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -72,6 +72,18 @@ export class MembershipResource extends BaseResource<MembershipModel> {
     this.user = user;
   }
 
+  get isBuilder(): boolean {
+    switch (this.role) {
+      case "admin":
+      case "builder":
+        return true;
+      case "user":
+        return false;
+      default:
+        assertNever(this.role);
+    }
+  }
+
   static async getMembershipsForWorkspace({
     workspace,
     transaction,

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -471,6 +471,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
         | "user_not_found"
         | "user_not_member"
         | "user_already_member"
+        | "group_requirements_not_met"
         | "system_or_global_group"
         | "invalid_id"
       >
@@ -637,6 +638,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
         | "unauthorized"
         | "user_not_found"
         | "user_already_member"
+        | "group_requirements_not_met"
         | "system_or_global_group"
       >
     >

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/members/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/members/index.ts
@@ -142,6 +142,15 @@ async function handler(
                 message: "The user was not found in the workspace.",
               },
             });
+          case "group_requirements_not_met":
+            return apiError(req, res, {
+              status_code: 403,
+              api_error: {
+                type: "workspace_auth_error",
+                message:
+                  "Some users have insufficient role privilege to be added to the space.",
+              },
+            });
           case "system_or_global_group":
             return apiError(req, res, {
               status_code: 400,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/editors.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/editors.ts
@@ -238,6 +238,15 @@ async function handler(
                 message: "The user is not a member of the agent editors group.",
               },
             });
+          case "group_requirements_not_met":
+            return apiError(req, res, {
+              status_code: 403,
+              api_error: {
+                type: "workspace_auth_error",
+                message:
+                  "Some users have insufficient role privilege to be added to agent editors.",
+              },
+            });
           case "system_or_global_group":
             return apiError(req, res, {
               status_code: 403,

--- a/front/pages/api/w/[wId]/skills/[sId]/editors.test.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/editors.test.ts
@@ -105,8 +105,6 @@ describe("PATCH /api/w/[wId]/skills/[sId]/editors", () => {
     expect(res._getStatusCode()).toBe(403);
     const data = res._getJSONData();
     expect(data.error.type).toBe("workspace_auth_error");
-    expect(data.error.message).toContain("Only builders and admins");
-    expect(data.error.message).toContain(regularUser.sId);
   });
 
   it("rejects mixed batch (builder + user)", async () => {
@@ -143,9 +141,6 @@ describe("PATCH /api/w/[wId]/skills/[sId]/editors", () => {
     expect(res._getStatusCode()).toBe(403);
     const data = res._getJSONData();
     expect(data.error.type).toBe("workspace_auth_error");
-    expect(data.error.message).toContain("Only builders and admins");
-    expect(data.error.message).toContain(regularUser.sId);
-    expect(data.error.message).not.toContain(builderUser.sId);
   });
 
   it("allows removing any editor regardless of role", async () => {

--- a/front/pages/api/w/[wId]/skills/[sId]/editors.test.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/editors.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from "vitest";
+
+import { Authenticator } from "@app/lib/auth";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { SkillFactory } from "@app/tests/utils/SkillFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+
+import handler from "./editors";
+
+describe("PATCH /api/w/[wId]/skills/[sId]/editors", () => {
+  it("allows adding builder as editor", async () => {
+    const { req, res, workspace, user } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "admin",
+    });
+
+    const workspaceResource = await WorkspaceResource.fetchById(workspace.sId);
+    const auth = new Authenticator({
+      user,
+      role: "admin",
+      groups: [],
+      workspace: workspaceResource,
+      subscription: null,
+      authMethod: "internal",
+    });
+
+    const skill = await SkillFactory.create(auth);
+
+    const builderUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, builderUser, {
+      role: "builder",
+    });
+
+    req.query.sId = skill.sId;
+    req.body = { addEditorIds: [builderUser.sId] };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getJSONData();
+    expect(data.editors).toHaveLength(2); // admin + builder
+    expect(data.editors.map((e: any) => e.sId)).toContain(builderUser.sId);
+  });
+
+  it("allows adding admin as editor", async () => {
+    const { req, res, workspace, user } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "admin",
+    });
+
+    const workspaceResource = await WorkspaceResource.fetchById(workspace.sId);
+    const auth = new Authenticator({
+      user,
+      role: "admin",
+      groups: [],
+      workspace: workspaceResource,
+      subscription: null,
+      authMethod: "internal",
+    });
+
+    const skill = await SkillFactory.create(auth);
+
+    const adminUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, adminUser, { role: "admin" });
+
+    req.query.sId = skill.sId;
+    req.body = { addEditorIds: [adminUser.sId] };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getJSONData();
+    expect(data.editors).toHaveLength(2); // 2 admins
+    expect(data.editors.map((e: any) => e.sId)).toContain(adminUser.sId);
+  });
+
+  it("rejects adding regular user as editor", async () => {
+    const { req, res, workspace, user } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "admin",
+    });
+
+    const workspaceResource = await WorkspaceResource.fetchById(workspace.sId);
+    const auth = new Authenticator({
+      user,
+      role: "admin",
+      groups: [],
+      workspace: workspaceResource,
+      subscription: null,
+      authMethod: "internal",
+    });
+
+    const skill = await SkillFactory.create(auth);
+
+    const regularUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, regularUser, { role: "user" });
+
+    req.query.sId = skill.sId;
+    req.body = { addEditorIds: [regularUser.sId] };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(403);
+    const data = res._getJSONData();
+    expect(data.error.type).toBe("workspace_auth_error");
+    expect(data.error.message).toContain("Only builders and admins");
+    expect(data.error.message).toContain(regularUser.sId);
+  });
+
+  it("rejects mixed batch (builder + user)", async () => {
+    const { req, res, workspace, user } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "admin",
+    });
+
+    const workspaceResource = await WorkspaceResource.fetchById(workspace.sId);
+    const auth = new Authenticator({
+      user,
+      role: "admin",
+      groups: [],
+      workspace: workspaceResource,
+      subscription: null,
+      authMethod: "internal",
+    });
+
+    const skill = await SkillFactory.create(auth);
+
+    const builderUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, builderUser, {
+      role: "builder",
+    });
+
+    const regularUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, regularUser, { role: "user" });
+
+    req.query.sId = skill.sId;
+    req.body = { addEditorIds: [builderUser.sId, regularUser.sId] };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(403);
+    const data = res._getJSONData();
+    expect(data.error.type).toBe("workspace_auth_error");
+    expect(data.error.message).toContain("Only builders and admins");
+    expect(data.error.message).toContain(regularUser.sId);
+    expect(data.error.message).not.toContain(builderUser.sId);
+  });
+
+  it("allows removing any editor regardless of role", async () => {
+    const { req, res, workspace, user } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "admin",
+    });
+
+    const workspaceResource = await WorkspaceResource.fetchById(workspace.sId);
+    const auth = new Authenticator({
+      user,
+      role: "admin",
+      groups: [],
+      workspace: workspaceResource,
+      subscription: null,
+      authMethod: "internal",
+    });
+
+    const skill = await SkillFactory.create(auth);
+
+    // Remove the creator (admin user)
+    req.query.sId = skill.sId;
+    req.body = { removeEditorIds: [user.sId] };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getJSONData();
+    expect(data.editors).toHaveLength(0);
+  });
+
+  it("GET endpoint returns all editors", async () => {
+    const { req, res, workspace, user } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+
+    const workspaceResource = await WorkspaceResource.fetchById(workspace.sId);
+    const auth = new Authenticator({
+      user,
+      role: "admin",
+      groups: [],
+      workspace: workspaceResource,
+      subscription: null,
+      authMethod: "internal",
+    });
+
+    const skill = await SkillFactory.create(auth);
+
+    req.query.sId = skill.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getJSONData();
+    expect(data.editors).toHaveLength(1); // Creator is editor
+    expect(data.editors[0].sId).toBe(user.sId);
+  });
+});

--- a/front/pages/api/w/[wId]/skills/[sId]/editors.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/editors.ts
@@ -138,7 +138,7 @@ async function handler(
             status_code: 403,
             api_error: {
               type: "workspace_auth_error",
-              message: `Only builders and admins can be added as skill editors.`,
+              message: "Only builders can be added as skill editors.",
             },
           });
         }

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/members.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/members.ts
@@ -137,6 +137,15 @@ export async function handler(
                 message: "Some of the passed ids are invalid.",
               },
             });
+          case "group_requirements_not_met":
+            return apiError(req, res, {
+              status_code: 403,
+              api_error: {
+                type: "workspace_auth_error",
+                message:
+                  "Some users have insufficient role privilege to be added to the space.",
+              },
+            });
           case "system_or_global_group":
             return apiError(req, res, {
               status_code: 400,


### PR DESCRIPTION
Closes : https://github.com/dust-tt/tasks/issues/5894

## Description

- Enforce builders-only restriction when adding editors to skill_editors groups
- Add `isBuilder` computed property to `MembershipResource`
- Add new `group_requirements_not_met` error code
- Propagate error handling through group, space, and agent configuration endpoints

## Tests

Added functional tests for skill editors endpoint covering:
- Adding builder/admin as editor (allowed)
- Adding regular user as editor (rejected)
- Mixed batch with builder + user (rejected)
- Removing editors (always allowed)


## Risk
Low.

## Deploy Plan

Deploy front.