### PR TITLE
Attempt to unstuck Slack ratelimited syncOneMessageDebounced

### DIFF
--- a/connectors/src/connectors/slack/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/slack/temporal/cast_known_errors.ts
@@ -1,3 +1,4 @@
+import type { Context } from "@temporalio/activity";
 import { ApplicationFailure } from "@temporalio/common";
 import type {
   ActivityExecuteInput,
@@ -7,7 +8,16 @@ import type {
 
 import { ProviderRateLimitError } from "@connectors/lib/error";
 
+// After this many attempts, start adding extra delay on top of the rate limit header.
+const RATE_LIMIT_BACKOFF_ATTEMPT_THRESHOLD = 50;
+// Extra delay added per attempt over the threshold (10 seconds).
+const RATE_LIMIT_EXTRA_DELAY_PER_ATTEMPT_MS = 10_000;
+// Maximum extra delay to add (5 minutes).
+const RATE_LIMIT_MAX_EXTRA_DELAY_MS = 300_000;
+
 export class SlackCastKnownErrorsInterceptor implements ActivityInboundCallsInterceptor {
+  constructor(private readonly ctx: Context) {}
+
   async execute(
     input: ActivityExecuteInput,
     next: Next<ActivityInboundCallsInterceptor, "execute">
@@ -16,14 +26,26 @@ export class SlackCastKnownErrorsInterceptor implements ActivityInboundCallsInte
       return await next(input);
     } catch (err: unknown) {
       // Ensure rate limit errors with retryAfterMs are honored.
-      if (err instanceof ProviderRateLimitError) {
-        if (err.retryAfter) {
-          throw ApplicationFailure.create({
-            message: `${err.message}. Retry after ${err.retryAfter / 1000}s`,
-            nextRetryDelay: err.retryAfter,
-            cause: err,
-          });
+      if (err instanceof ProviderRateLimitError && err.retryAfter) {
+        let delayMs = err.retryAfter;
+
+        // Slack's rate limit header often returns a fixed 10s value which isn't
+        // always sufficient. After many retries, add progressive backoff.
+        const attempt = this.ctx.info.attempt;
+        if (attempt > RATE_LIMIT_BACKOFF_ATTEMPT_THRESHOLD) {
+          const extraDelayMs = Math.min(
+            (attempt - RATE_LIMIT_BACKOFF_ATTEMPT_THRESHOLD) *
+              RATE_LIMIT_EXTRA_DELAY_PER_ATTEMPT_MS,
+            RATE_LIMIT_MAX_EXTRA_DELAY_MS
+          );
+          delayMs += extraDelayMs;
         }
+
+        throw ApplicationFailure.create({
+          message: `${err.message}. Retry after ${delayMs / 1000}s (attempt ${attempt})`,
+          nextRetryDelay: delayMs,
+          cause: err,
+        });
       }
 
       throw err;

--- a/connectors/src/connectors/slack/temporal/worker.ts
+++ b/connectors/src/connectors/slack/temporal/worker.ts
@@ -28,8 +28,8 @@ export async function runSlackWorker() {
         (ctx: Context) => ({
           inbound: new ActivityInboundLogInterceptor(ctx, logger, "slack"),
         }),
-        () => ({
-          inbound: new SlackCastKnownErrorsInterceptor(),
+        (ctx: Context) => ({
+          inbound: new SlackCastKnownErrorsInterceptor(ctx),
         }),
       ],
     },


### PR DESCRIPTION
## Description

Add progressive backoff for Slack rate limit retries after many attempts.

Slack's `x-rate-limit` header often returns a fixed 10s value which isn't always sufficient when hitting sustained rate limits. After 50+ retries with 10s delays, the system would hot-loop indefinitely.

**Changes**

  - **`cast_known_errors.ts`**: Modified `SlackCastKnownErrorsInterceptor` to accept the activity context and add progressive backoff after 50 attempts
  - **`worker.ts`**: Pass context to the interceptor

**Behavior**

  | Attempt | Base delay | Extra delay | Total |
  |---------|------------|-------------|-------|
  | 1-50    | 10s        | 0           | 10s   |
  | 51      | 10s        | 10s         | 20s   |
  | 52      | 10s        | 20s         | 30s   |
  | ...     | ...        | ...         | ...   |
  | 80+     | 10s        | 300s (cap)  | 310s  |

**Configuration**

  - `RATE_LIMIT_BACKOFF_ATTEMPT_THRESHOLD`: 50 attempts before adding extra delay
  - `RATE_LIMIT_EXTRA_DELAY_PER_ATTEMPT_MS`: 10s added per attempt over threshold
  - `RATE_LIMIT_MAX_EXTRA_DELAY_MS`: 5 minute cap on extra delay

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
