### PR TITLE
[dust-hive] Add direnv as a prerequisite with setup instructions

### DIFF
--- a/x/henry/dust-hive/.claude/skills/dust-hive/SKILL.md
+++ b/x/henry/dust-hive/.claude/skills/dust-hive/SKILL.md
@@ -48,6 +48,17 @@ pwd | grep -q "$HOME/dust-hive/" && echo "In dust-hive environment"
 
 The `detectEnvFromCwd()` function in `src/lib/paths.ts` detects the environment name from the current working directory.
 
+## Automatic Environment Loading (direnv)
+
+Each dust-hive worktree contains a `.envrc` file that automatically loads the environment variables when you `cd` into the directory. This is powered by [direnv](https://direnv.net/).
+
+**What this means:**
+- Environment variables (ports, database URIs, API keys, etc.) are automatically available in your shell
+- No need to manually source `env.sh` or set environment variables
+- Variables like `FRONT_DATABASE_URI`, `CORE_API`, `CONNECTORS_API` are pre-configured for the environment's port range
+
+**Prerequisites:** direnv must be installed and hooked into your shell. Run `dust-hive doctor` to verify.
+
 ## Environment States
 
 | State | Description | What's Running |
@@ -221,6 +232,7 @@ If front tests fail with database connection errors:
 └── zellij/              # Zellij layouts
 
 ~/dust-hive/{NAME}/      # Git worktrees
+└── .envrc               # direnv config (sources env.sh automatically)
 ```
 
 ## Troubleshooting

--- a/x/henry/dust-hive/.claude/skills/dust-hive/SKILL.md
+++ b/x/henry/dust-hive/.claude/skills/dust-hive/SKILL.md
@@ -57,7 +57,10 @@ Each dust-hive worktree contains a `.envrc` file that automatically loads the en
 - No need to manually source `env.sh` or set environment variables
 - Variables like `FRONT_DATABASE_URI`, `CORE_API`, `CONNECTORS_API` are pre-configured for the environment's port range
 
-**Prerequisites:** direnv must be installed and hooked into your shell. Run `dust-hive doctor` to verify.
+**Troubleshooting:** If you encounter errors about missing environment variables, the user may not have direnv configured. In that case, manually source the environment:
+```bash
+source ~/.dust-hive/envs/{ENV_NAME}/env.sh
+```
 
 ## Environment States
 

--- a/x/henry/dust-hive/README.md
+++ b/x/henry/dust-hive/README.md
@@ -13,8 +13,14 @@ Each environment gets its own:
 Install these before using dust-hive:
 
 ```bash
-# Bun (runtime)
+# Bun (runtime for dust-hive itself)
 curl -fsSL https://bun.sh/install | bash
+
+# nvm (Node version manager for front/connectors)
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
+
+# Rust toolchain (for core/oauth)
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 
 # Zellij (terminal multiplexer)
 brew install zellij
@@ -28,9 +34,14 @@ brew install temporal
 # direnv (auto-load environment variables)
 brew install direnv
 
-# sccache (Rust compilation cache - speeds up builds across worktrees)
+# Build dependencies
+brew install cmake protobuf
+
+# sccache (optional - Rust compilation cache, speeds up rebuilds)
 brew install sccache
 ```
+
+> **Linux users**: Also install `lsof` if not already available (`sudo apt install lsof`)
 
 ### direnv setup
 

--- a/x/henry/dust-hive/README.md
+++ b/x/henry/dust-hive/README.md
@@ -25,11 +25,43 @@ brew install --cask orbstack
 # Temporal CLI (workflow engine)
 brew install temporal
 
+# direnv (auto-load environment variables)
+brew install direnv
+
 # sccache (Rust compilation cache - speeds up builds across worktrees)
 brew install sccache
 ```
 
-Then configure cargo to use sccache by adding to `~/.cargo/config.toml`:
+### direnv setup
+
+1. **Add the shell hook** to your shell config:
+
+   **For zsh** (`~/.zshrc`):
+   ```bash
+   eval "$(direnv hook zsh)"
+   ```
+
+   **For bash** (`~/.bashrc`):
+   ```bash
+   eval "$(direnv hook bash)"
+   ```
+
+2. **Silence verbose output** by creating `~/.config/direnv/direnv.toml`:
+   ```bash
+   mkdir -p ~/.config/direnv
+   cat > ~/.config/direnv/direnv.toml << 'EOF'
+   [global]
+   hide_env_diff = true
+   EOF
+   ```
+
+This enables automatic environment loading when you `cd` into any dust-hive worktree. The `.envrc` file in each worktree sources the environment variables for that environment.
+
+After adding the hook, restart your shell or run `source ~/.zshrc` (or `~/.bashrc`).
+
+### sccache setup
+
+Configure cargo to use sccache by adding to `~/.cargo/config.toml`:
 
 ```toml
 [build]

--- a/x/henry/dust-hive/src/lib/platform.ts
+++ b/x/henry/dust-hive/src/lib/platform.ts
@@ -127,7 +127,8 @@ type InstallableTool =
   | "nvm"
   | "cargo"
   | "cmake"
-  | "protobuf";
+  | "protobuf"
+  | "direnv";
 
 const INSTALL_INSTRUCTIONS: Record<PlatformName, Record<InstallableTool, string>> = {
   macos: {
@@ -140,6 +141,7 @@ const INSTALL_INSTRUCTIONS: Record<PlatformName, Record<InstallableTool, string>
     cargo: 'curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs | sh',
     cmake: "brew install cmake",
     protobuf: "brew install protobuf",
+    direnv: "brew install direnv && add shell hook (see README for setup)",
   },
   linux: {
     zellij: "cargo install zellij (or download from https://github.com/zellij-org/zellij/releases)",
@@ -152,6 +154,8 @@ const INSTALL_INSTRUCTIONS: Record<PlatformName, Record<InstallableTool, string>
     cmake: "sudo apt install cmake (Debian/Ubuntu) or sudo dnf install cmake (Fedora)",
     protobuf:
       "sudo apt install protobuf-compiler (Debian/Ubuntu) or sudo dnf install protobuf-compiler (Fedora)",
+    direnv:
+      "sudo apt install direnv (Debian/Ubuntu) or sudo dnf install direnv (Fedora) && add shell hook (see README)",
   },
 };
 


### PR DESCRIPTION
## Description

Add direnv as a prerequisite for dust-hive and document all required tools to enable automatic environment loading when entering worktree directories.

Changes:
- Add `checkDirenv()` to doctor.ts that verifies direnv is installed and shell hook is configured
- Add direnv to platform.ts install instructions for macOS and Linux
- Update README with detailed direnv setup guide, including how to silence verbose output using `~/.config/direnv/direnv.toml`
- Document all prerequisites checked by `dust-hive doctor` in README (nvm, Rust, cmake, protobuf, lsof)
- Update SKILL.md with direnv documentation and troubleshooting guidance for agents

This improves the developer experience by automatically sourcing environment variables when cd'ing into a dust-hive worktree, eliminating the need to manually source env.sh.

Related to #19921 which added .envrc generation to dust-hive envs.

## Tests

- Ran `bun run check` (typecheck, lint, tests all pass)
- Verified `dust-hive doctor` shows direnv status correctly
- Tested direnv setup end-to-end on local machine

## Risk

Low risk - only affects dust-hive tooling, no production code changes.

## Deploy Plan

No deployment needed - this is developer tooling only.