### PR TITLE
Use a blue banner for end trial message

### DIFF
--- a/front/components/app/ReachedLimitPopup.tsx
+++ b/front/components/app/ReachedLimitPopup.tsx
@@ -109,7 +109,7 @@ function getLimitPromptForCode(
           title: "Dust trial message limit reached",
           validateLabel: "Subscribe to Dust",
           onValidate: () => {
-            void router.push(`/w/${owner.sId}/subscribe`);
+            void router.push(`/w/${owner.sId}/subscription`);
           },
           children: (
             <>

--- a/front/components/app/ReachedLimitPopup.tsx
+++ b/front/components/app/ReachedLimitPopup.tsx
@@ -28,7 +28,8 @@ function getLimitPromptForCode(
   owner: WorkspaceType,
   code: WorkspaceLimit,
   subscription: SubscriptionType,
-  displayFairUseModal: () => void
+  displayFairUseModal: () => void,
+  isAdmin: boolean
 ) {
   switch (code) {
     case "cant_invite_no_seats_available": {
@@ -107,10 +108,12 @@ function getLimitPromptForCode(
       if (isFreeTrialPhonePlan(subscription.plan.code)) {
         return {
           title: "Dust trial message limit reached",
-          validateLabel: "Subscribe to Dust",
-          onValidate: () => {
-            void router.push(`/w/${owner.sId}/subscription`);
-          },
+          validateLabel: isAdmin ? "Subscribe to Dust" : "Ok",
+          onValidate: isAdmin
+            ? () => {
+                void router.push(`/w/${owner.sId}/subscription`);
+              }
+            : undefined,
           children: (
             <>
               <Page.P>
@@ -123,10 +126,12 @@ function getLimitPromptForCode(
       } else if (subscription.trialing) {
         return {
           title: "Fair usage limit reached",
-          validateLabel: "Manage your subscription",
-          onValidate: () => {
-            void router.push(`/w/${owner.sId}/subscription`);
-          },
+          validateLabel: isAdmin ? "Manage your subscription" : "Ok",
+          onValidate: isAdmin
+            ? () => {
+                void router.push(`/w/${owner.sId}/subscription`);
+              }
+            : undefined,
           children: (
             <>
               <Page.P>
@@ -171,12 +176,14 @@ function getLimitPromptForCode(
 }
 
 export function ReachedLimitPopup({
+  isAdmin,
   isOpened,
   onClose,
   subscription,
   owner,
   code,
 }: {
+  isAdmin: boolean;
   isOpened: boolean;
   onClose: () => void;
   subscription: SubscriptionType;
@@ -191,7 +198,8 @@ export function ReachedLimitPopup({
     owner,
     code,
     subscription,
-    () => setIsFairUsageModalOpened(true)
+    () => setIsFairUsageModalOpened(true),
+    isAdmin
   );
 
   return (

--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -25,7 +25,13 @@ import type {
   UserType,
   WorkspaceType,
 } from "@app/types";
-import { Err, Ok, toMentionType, toRichAgentMentionType } from "@app/types";
+import {
+  Err,
+  isAdmin,
+  Ok,
+  toMentionType,
+  toRichAgentMentionType,
+} from "@app/types";
 interface ConversationContainerProps {
   owner: WorkspaceType;
   subscription: SubscriptionType;
@@ -195,6 +201,7 @@ export function ConversationContainerVirtuoso({
         </>
       )}
       <ReachedLimitPopup
+        isAdmin={isAdmin(owner)}
         isOpened={planLimitReached}
         onClose={() => setPlanLimitReached(false)}
         subscription={subscription}

--- a/front/components/navigation/NavigationSidebar.tsx
+++ b/front/components/navigation/NavigationSidebar.tsx
@@ -14,13 +14,7 @@ import {
 } from "@dust-tt/sparkle";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import React, {
-  useCallback,
-  useContext,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import React, { useCallback, useContext, useMemo, useState } from "react";
 
 import { useWelcomeTourGuide } from "@app/components/assistant/WelcomeTourGuideProvider";
 import type { SidebarNavigation } from "@app/components/navigation/config";
@@ -30,10 +24,7 @@ import { useNavigationLoading } from "@app/components/sparkle/NavigationLoadingC
 import { SidebarContext } from "@app/components/sparkle/SidebarContext";
 import { UserMenu } from "@app/components/UserMenu";
 import type { AppStatus } from "@app/lib/api/status";
-import {
-  FREE_TRIAL_PHONE_PLAN_CODE,
-  isFreePlan,
-} from "@app/lib/plans/plan_codes";
+import { FREE_TRIAL_PHONE_PLAN_CODE } from "@app/lib/plans/plan_codes";
 import { useTrialMessageUsage } from "@app/lib/swr/trial_message_usage";
 import { useAppStatus } from "@app/lib/swr/useAppStatus";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
@@ -103,27 +94,10 @@ export const NavigationSidebar = React.forwardRef<
 
   const { appStatus } = useAppStatus();
 
-  const hasIncidentBanner =
-    appStatus?.dustStatus !== null || appStatus?.providersStatus !== null;
-  const endDate = subscription.endDate;
-  const thresholdMs = 30 * 24 * 60 * 60 * 1000;
-  // Capture initial timestamp in a ref to avoid re-computation on re-renders.
-  // eslint-disable-next-line react-hooks/purity
-  const nowRef = useRef(Date.now());
-  // Show subscription end banner for paid plans only (free plans use the new TrialBanner).
-  const showSubscriptionEndBanner =
-    !hasIncidentBanner &&
-    endDate !== null &&
-    endDate < nowRef.current + thresholdMs &&
-    !isFreePlan(subscription.plan.code);
-
   return (
     <div ref={ref} className="flex min-w-0 grow flex-col">
       <div className="flex flex-col gap-2 pt-3">
         {appStatus && <AppStatusBanner appStatus={appStatus} />}
-        {showSubscriptionEndBanner && (
-          <SubscriptionEndBanner endDate={endDate} />
-        )}
         {subscription.paymentFailingSince && isAdmin(owner) && (
           <SubscriptionPastDueBanner />
         )}
@@ -323,35 +297,6 @@ function AppStatusBanner({ appStatus }: AppStatusBannerProps) {
   }
 
   return null;
-}
-
-function SubscriptionEndBanner({ endDate }: { endDate: number }) {
-  const formattedEndDate = new Date(endDate).toLocaleDateString("en-US", {
-    year: "numeric",
-    month: "long",
-    day: "numeric",
-  });
-
-  return (
-    <StatusBanner
-      variant="info"
-      title={`Subscription ending on ${formattedEndDate}`}
-      description={
-        <>
-          Your connections and member access will be removed after this date.
-          Details{" "}
-          <Link
-            href="https://docs.dust.tt/docs/subscriptions#what-happens-when-we-cancel-our-dust-subscription"
-            target="_blank"
-            className="underline"
-          >
-            here
-          </Link>
-          .
-        </>
-      }
-    />
-  );
 }
 
 function SubscriptionPastDueBanner() {

--- a/front/components/navigation/NavigationSidebar.tsx
+++ b/front/components/navigation/NavigationSidebar.tsx
@@ -382,7 +382,10 @@ function TrialMessageUsage({ workspaceId }: TrialMessageUsageProps) {
       </div>
       {isAtLimit && (
         <div className="mt-3">
-          <Link href={`/w/${workspaceId}/subscribe`} className="no-underline">
+          <Link
+            href={`/w/${workspaceId}/subscription`}
+            className="no-underline"
+          >
             <Button label="Subscribe to Dust" variant="primary" />
           </Link>
         </div>

--- a/front/components/navigation/NavigationSidebar.tsx
+++ b/front/components/navigation/NavigationSidebar.tsx
@@ -194,7 +194,7 @@ export const NavigationSidebar = React.forwardRef<
       </div>
       <div className="flex grow flex-col">{children}</div>
       {subscription.plan.code === FREE_TRIAL_PHONE_PLAN_CODE && (
-        <TrialMessageUsage workspaceId={owner.sId} />
+        <TrialMessageUsage isAdmin={isAdmin(owner)} workspaceId={owner.sId} />
       )}
       {user && (
         <div
@@ -330,10 +330,11 @@ function SubscriptionPastDueBanner() {
 const MESSAGE_USAGE_CRITICAL_THRESHOLD = 0.9;
 
 interface TrialMessageUsageProps {
+  isAdmin: boolean;
   workspaceId: string;
 }
 
-function TrialMessageUsage({ workspaceId }: TrialMessageUsageProps) {
+function TrialMessageUsage({ isAdmin, workspaceId }: TrialMessageUsageProps) {
   const { messageUsage } = useTrialMessageUsage({ workspaceId });
 
   if (!messageUsage || messageUsage.limit === -1) {
@@ -380,7 +381,7 @@ function TrialMessageUsage({ workspaceId }: TrialMessageUsageProps) {
           style={{ width: `${Math.min(percentage * 100, 100)}%` }}
         />
       </div>
-      {isAtLimit && (
+      {isAtLimit && isAdmin && (
         <div className="mt-3">
           <Link
             href={`/w/${workspaceId}/subscription`}

--- a/front/components/navigation/TrialBanner.tsx
+++ b/front/components/navigation/TrialBanner.tsx
@@ -11,11 +11,13 @@ const THRESHOLD_MS =
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 interface SubscriptionEndBannerProps {
+  isAdmin: boolean;
   owner: { sId: string };
   subscription: SubscriptionType;
 }
 
 export function SubscriptionEndBanner({
+  isAdmin,
   owner,
   subscription,
 }: SubscriptionEndBannerProps) {
@@ -83,20 +85,22 @@ export function SubscriptionEndBanner({
           keep everything.
         </span>
       </div>
-      <Link
-        href={`/w/${owner.sId}/subscribe`}
-        className="shrink-0 no-underline"
-      >
-        <Button
-          label="Subscribe to Dust"
-          className={cn(
-            "bg-sky-600 dark:bg-sky-600-night",
-            "dark:text-white-night text-white",
-            "hover:bg-sky-700 dark:hover:bg-sky-700-night"
-          )}
-          size="sm"
-        />
-      </Link>
+      {isAdmin && (
+        <Link
+          href={`/w/${owner.sId}/subscription`}
+          className="shrink-0 no-underline"
+        >
+          <Button
+            label="Subscribe to Dust"
+            className={cn(
+              "bg-sky-600 dark:bg-sky-600-night",
+              "dark:text-white-night text-white",
+              "hover:bg-sky-700 dark:hover:bg-sky-700-night"
+            )}
+            size="sm"
+          />
+        </Link>
+      )}
     </div>
   );
 }

--- a/front/components/navigation/TrialBanner.tsx
+++ b/front/components/navigation/TrialBanner.tsx
@@ -5,17 +5,22 @@ import { useMemo, useRef } from "react";
 import { isFreePlan } from "@app/lib/plans/plan_codes";
 import type { SubscriptionType } from "@app/types";
 
-const TRIAL_BANNER_DISPLAY_THRESHOLD_DAYS = 30;
-const THRESHOLD_MS = TRIAL_BANNER_DISPLAY_THRESHOLD_DAYS * 24 * 60 * 60 * 1000;
+const SUBSCRIPTION_BANNER_DISPLAY_THRESHOLD_DAYS = 30;
+const THRESHOLD_MS =
+  SUBSCRIPTION_BANNER_DISPLAY_THRESHOLD_DAYS * 24 * 60 * 60 * 1000;
 const DAY_MS = 24 * 60 * 60 * 1000;
 
-interface TrialBannerProps {
+interface SubscriptionEndBannerProps {
   owner: { sId: string };
   subscription: SubscriptionType;
 }
 
-export function TrialBanner({ owner, subscription }: TrialBannerProps) {
+export function SubscriptionEndBanner({
+  owner,
+  subscription,
+}: SubscriptionEndBannerProps) {
   const endDate = subscription.endDate;
+  const isTrial = isFreePlan(subscription.plan.code);
 
   // Capture initial timestamp in a ref to avoid re-computation on re-renders.
   // This is intentionally not reactive - the banner state is stable for the session.
@@ -27,53 +32,70 @@ export function TrialBanner({ owner, subscription }: TrialBannerProps) {
       return null;
     }
 
-    if (!isFreePlan(subscription.plan.code)) {
-      return null;
-    }
-
     const now = nowRef.current;
 
     if (endDate > now + THRESHOLD_MS) {
       return null;
     }
 
-    const hasTrialEnded = endDate < now;
+    const hasEnded = endDate < now;
     const daysRemaining = Math.max(0, Math.ceil((endDate - now) / DAY_MS));
 
-    return { hasTrialEnded, daysRemaining };
-  }, [endDate, subscription.plan.code]);
+    return { hasEnded, daysRemaining };
+  }, [endDate]);
 
   if (!bannerState) {
     return null;
   }
 
-  const { hasTrialEnded, daysRemaining } = bannerState;
+  const { hasEnded, daysRemaining } = bannerState;
 
-  const title = hasTrialEnded
-    ? "Heads up, your trial has ended"
-    : `Heads up, your trial ends in ${daysRemaining} day${daysRemaining !== 1 ? "s" : ""}`;
+  let title: string;
+  if (isTrial) {
+    title = hasEnded
+      ? "Heads up, your trial has ended"
+      : `Heads up, your trial ends in ${daysRemaining} day${daysRemaining !== 1 ? "s" : ""}`;
+  } else {
+    title = hasEnded
+      ? "Heads up, your subscription has ended"
+      : `Heads up, your subscription ends in ${daysRemaining} day${daysRemaining !== 1 ? "s" : ""}`;
+  }
 
   return (
     <div
       className={cn(
         "flex items-center justify-between gap-4 px-4 py-2",
-        "bg-sky-50 dark:bg-sky-950"
+        "bg-sky-50 dark:bg-sky-50-night"
       )}
     >
       <div className="flex flex-col text-sm">
-        <span className="font-semibold text-sky-900 dark:text-sky-100">
+        <span
+          className={cn(
+            "font-semibold",
+            "text-sky-900 dark:text-sky-900-night"
+          )}
+        >
           {title}
         </span>
-        <span className="text-sky-800 dark:text-sky-200">
-          When your trial wraps up, your connections and team member access will
-          be removed. Subscribe now to keep everything.
+        <span className="text-sky-800 dark:text-sky-800-night">
+          When your {isTrial ? "trial" : "subscription"} wraps up, your
+          connections and team member access will be removed. Subscribe now to
+          keep everything.
         </span>
       </div>
       <Link
         href={`/w/${owner.sId}/subscribe`}
         className="shrink-0 no-underline"
       >
-        <Button label="Subscribe to Dust" variant="primary" size="sm" />
+        <Button
+          label="Subscribe to Dust"
+          className={cn(
+            "bg-sky-600 dark:bg-sky-600-night",
+            "dark:text-white-night text-white",
+            "hover:bg-sky-700 dark:hover:bg-sky-700-night"
+          )}
+          size="sm"
+        />
       </Link>
     </div>
   );

--- a/front/components/navigation/TrialBanner.tsx
+++ b/front/components/navigation/TrialBanner.tsx
@@ -2,7 +2,7 @@ import { Button, cn } from "@dust-tt/sparkle";
 import Link from "next/link";
 import { useMemo, useRef } from "react";
 
-import { isFreePlan } from "@app/lib/plans/plan_codes";
+import { isFreeTrialPhonePlan } from "@app/lib/plans/plan_codes";
 import type { SubscriptionType } from "@app/types";
 
 const SUBSCRIPTION_BANNER_DISPLAY_THRESHOLD_DAYS = 30;
@@ -20,7 +20,7 @@ export function SubscriptionEndBanner({
   subscription,
 }: SubscriptionEndBannerProps) {
   const endDate = subscription.endDate;
-  const isTrial = isFreePlan(subscription.plan.code);
+  const isTrial = isFreeTrialPhonePlan(subscription.plan.code);
 
   // Capture initial timestamp in a ref to avoid re-computation on re-renders.
   // This is intentionally not reactive - the banner state is stable for the session.

--- a/front/components/navigation/TrialBanner.tsx
+++ b/front/components/navigation/TrialBanner.tsx
@@ -1,0 +1,80 @@
+import { Button, cn } from "@dust-tt/sparkle";
+import Link from "next/link";
+import { useMemo, useRef } from "react";
+
+import { isFreePlan } from "@app/lib/plans/plan_codes";
+import type { SubscriptionType } from "@app/types";
+
+const TRIAL_BANNER_DISPLAY_THRESHOLD_DAYS = 30;
+const THRESHOLD_MS = TRIAL_BANNER_DISPLAY_THRESHOLD_DAYS * 24 * 60 * 60 * 1000;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+interface TrialBannerProps {
+  owner: { sId: string };
+  subscription: SubscriptionType;
+}
+
+export function TrialBanner({ owner, subscription }: TrialBannerProps) {
+  const endDate = subscription.endDate;
+
+  // Capture initial timestamp in a ref to avoid re-computation on re-renders.
+  // This is intentionally not reactive - the banner state is stable for the session.
+  // eslint-disable-next-line react-hooks/purity
+  const nowRef = useRef(Date.now());
+
+  const bannerState = useMemo(() => {
+    if (!endDate) {
+      return null;
+    }
+
+    if (!isFreePlan(subscription.plan.code)) {
+      return null;
+    }
+
+    const now = nowRef.current;
+
+    if (endDate > now + THRESHOLD_MS) {
+      return null;
+    }
+
+    const hasTrialEnded = endDate < now;
+    const daysRemaining = Math.max(0, Math.ceil((endDate - now) / DAY_MS));
+
+    return { hasTrialEnded, daysRemaining };
+  }, [endDate, subscription.plan.code]);
+
+  if (!bannerState) {
+    return null;
+  }
+
+  const { hasTrialEnded, daysRemaining } = bannerState;
+
+  const title = hasTrialEnded
+    ? "Heads up, your trial has ended"
+    : `Heads up, your trial ends in ${daysRemaining} day${daysRemaining !== 1 ? "s" : ""}`;
+
+  return (
+    <div
+      className={cn(
+        "flex items-center justify-between gap-4 px-4 py-2",
+        "bg-sky-50 dark:bg-sky-950"
+      )}
+    >
+      <div className="flex flex-col text-sm">
+        <span className="font-semibold text-sky-900 dark:text-sky-100">
+          {title}
+        </span>
+        <span className="text-sky-800 dark:text-sky-200">
+          When your trial wraps up, your connections and team member access will
+          be removed. Subscribe now to keep everything.
+        </span>
+      </div>
+      <Link
+        href={`/w/${owner.sId}/subscribe`}
+        className="shrink-0 no-underline"
+      >
+        <Button label="Subscribe to Dust" variant="primary" size="sm" />
+      </Link>
+    </div>
+  );
+}

--- a/front/components/navigation/TrialBanner.tsx
+++ b/front/components/navigation/TrialBanner.tsx
@@ -64,7 +64,7 @@ export function SubscriptionEndBanner({
   return (
     <div
       className={cn(
-        "flex items-center justify-between gap-4 px-4 py-2",
+        "flex items-center justify-between gap-4 px-4 py-3",
         "bg-sky-50 dark:bg-sky-50-night"
       )}
     >

--- a/front/components/sparkle/AppContentLayout.tsx
+++ b/front/components/sparkle/AppContentLayout.tsx
@@ -102,18 +102,16 @@ export default function AppContentLayout({
         )}
       >
         <SubscriptionEndBanner owner={owner} subscription={subscription} />
-        <div className="relative flex-1 overflow-hidden">
-          <NavigationLoadingOverlay />
-          {/* Temporary measure to preserve title existence on smaller screens.
-           * Page has no title, prepend empty AppLayoutTitle. */}
-          {loaded && !hasTitle && (
-            <>
-              <AppLayoutTitle />
-              {children}
-            </>
-          )}
-          {loaded && hasTitle && children}
-        </div>
+        <NavigationLoadingOverlay />
+        {/* Temporary measure to preserve title existence on smaller screens.
+         * Page has no title, prepend empty AppLayoutTitle. */}
+        {loaded && !hasTitle && (
+          <>
+            <AppLayoutTitle />
+            {children}
+          </>
+        )}
+        {loaded && hasTitle && children}
       </div>
     </div>
   );

--- a/front/components/sparkle/AppContentLayout.tsx
+++ b/front/components/sparkle/AppContentLayout.tsx
@@ -6,7 +6,7 @@ import React from "react";
 import type { SidebarNavigation } from "@app/components/navigation/config";
 import { useDesktopNavigation } from "@app/components/navigation/DesktopNavigationContext";
 import { Navigation } from "@app/components/navigation/Navigation";
-import { TrialBanner } from "@app/components/navigation/TrialBanner";
+import { SubscriptionEndBanner } from "@app/components/navigation/TrialBanner";
 import { AppLayoutTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { NavigationLoadingOverlay } from "@app/components/sparkle/NavigationLoadingOverlay";
 import { useAppKeyboardShortcuts } from "@app/hooks/useAppKeyboardShortcuts";
@@ -101,7 +101,7 @@ export default function AppContentLayout({
           "dark:bg-background-night dark:text-foreground-night"
         )}
       >
-        <TrialBanner owner={owner} subscription={subscription} />
+        <SubscriptionEndBanner owner={owner} subscription={subscription} />
         <div className="relative flex-1 overflow-hidden">
           <NavigationLoadingOverlay />
           {/* Temporary measure to preserve title existence on smaller screens.

--- a/front/components/sparkle/AppContentLayout.tsx
+++ b/front/components/sparkle/AppContentLayout.tsx
@@ -6,6 +6,7 @@ import React from "react";
 import type { SidebarNavigation } from "@app/components/navigation/config";
 import { useDesktopNavigation } from "@app/components/navigation/DesktopNavigationContext";
 import { Navigation } from "@app/components/navigation/Navigation";
+import { TrialBanner } from "@app/components/navigation/TrialBanner";
 import { AppLayoutTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { NavigationLoadingOverlay } from "@app/components/sparkle/NavigationLoadingOverlay";
 import { useAppKeyboardShortcuts } from "@app/hooks/useAppKeyboardShortcuts";
@@ -95,21 +96,24 @@ export default function AppContentLayout({
       />
       <div
         className={cn(
-          "relative h-full w-full flex-1 overflow-hidden",
+          "relative flex h-full w-full flex-1 flex-col overflow-hidden",
           "bg-background text-foreground",
           "dark:bg-background-night dark:text-foreground-night"
         )}
       >
-        <NavigationLoadingOverlay />
-        {/* Temporary measure to preserve title existence on smaller screens.
-         * Page has no title, prepend empty AppLayoutTitle. */}
-        {loaded && !hasTitle && (
-          <>
-            <AppLayoutTitle />
-            {children}
-          </>
-        )}
-        {loaded && hasTitle && children}
+        <TrialBanner owner={owner} subscription={subscription} />
+        <div className="relative flex-1 overflow-hidden">
+          <NavigationLoadingOverlay />
+          {/* Temporary measure to preserve title existence on smaller screens.
+           * Page has no title, prepend empty AppLayoutTitle. */}
+          {loaded && !hasTitle && (
+            <>
+              <AppLayoutTitle />
+              {children}
+            </>
+          )}
+          {loaded && hasTitle && children}
+        </div>
       </div>
     </div>
   );

--- a/front/components/sparkle/AppContentLayout.tsx
+++ b/front/components/sparkle/AppContentLayout.tsx
@@ -96,7 +96,7 @@ export default function AppContentLayout({
       />
       <div
         className={cn(
-          "relative flex h-full w-full flex-1 flex-col overflow-hidden",
+          "relative h-full w-full flex-1 overflow-hidden",
           "bg-background text-foreground",
           "dark:bg-background-night dark:text-foreground-night"
         )}

--- a/front/components/sparkle/AppContentLayout.tsx
+++ b/front/components/sparkle/AppContentLayout.tsx
@@ -12,6 +12,7 @@ import { NavigationLoadingOverlay } from "@app/components/sparkle/NavigationLoad
 import { useAppKeyboardShortcuts } from "@app/hooks/useAppKeyboardShortcuts";
 import { getConversationRoute } from "@app/lib/utils/router";
 import type { SubscriptionType, WorkspaceType } from "@app/types";
+import { isAdmin } from "@app/types";
 
 // This function is used to navigate back to the previous page (eg modal like page close) and
 // fallback to the landing if we linked directly to that modal.
@@ -101,7 +102,11 @@ export default function AppContentLayout({
           "dark:bg-background-night dark:text-foreground-night"
         )}
       >
-        <SubscriptionEndBanner owner={owner} subscription={subscription} />
+        <SubscriptionEndBanner
+          isAdmin={isAdmin(owner)}
+          owner={owner}
+          subscription={subscription}
+        />
         <NavigationLoadingOverlay />
         {/* Temporary measure to preserve title existence on smaller screens.
          * Page has no title, prepend empty AppLayoutTitle. */}

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -38,6 +38,7 @@ import type {
   WorkspaceDomain,
   WorkspaceType,
 } from "@app/types";
+import { isAdmin } from "@app/types";
 
 export const getServerSideProps = withDefaultUserAuthRequirements<{
   user: UserType;
@@ -168,6 +169,7 @@ export default function WorkspaceAdmin({
           </WorkspaceSection>
           {inviteBlockedPopupReason && (
             <ReachedLimitPopup
+              isAdmin={isAdmin(owner)}
               isOpened={!!inviteBlockedPopupReason}
               onClose={() => setInviteBlockedPopupReason(null)}
               subscription={subscription}


### PR DESCRIPTION
## Description

Move the message usage box to a blue banner at the top, per https://github.com/dust-tt/tasks/issues/5838.

## Tests

Manual

## Risk

Low, although it affects both the free trial and regular subs that have an end date

## Deploy Plan

Front