### PR TITLE
[front] - refactor(feedback): agent message feedback

### DIFF
--- a/extension/ui/components/conversation/AgentMessage.tsx
+++ b/extension/ui/components/conversation/AgentMessage.tsx
@@ -249,8 +249,6 @@ export function AgentMessage({
   >([]);
   const [isCopied, copy] = useCopyToClipboard();
 
-  const isGlobalAgent = message.configuration.id === -1;
-
   const { showValidationDialog } = useContext(ActionValidationContext);
 
   const [blockedAuthAction, setBlockedAuthAction] = useState<{
@@ -600,9 +598,8 @@ export function AgentMessage({
   const showFeedbackSection = useMemo(
     () =>
       showButtons &&
-      !isGlobalAgent &&
       agentMessageToRender.configuration.status !== "draft",
-    [showButtons, isGlobalAgent, agentMessageToRender.configuration.status]
+    [showButtons, agentMessageToRender.configuration.status]
   );
 
   const handleRetry = useCallback(() => {

--- a/extension/ui/components/conversation/AgentMessage.tsx
+++ b/extension/ui/components/conversation/AgentMessage.tsx
@@ -86,11 +86,17 @@ import type { Components } from "react-markdown";
 import type { PluggableList } from "react-markdown/lib/react-markdown";
 import { visit } from "unist-util-visit";
 
-export const FeedbackSelectorPopoverContent = () => {
+export const FeedbackSelectorPopoverContent = ({
+  isGlobalAgent,
+}: {
+  isGlobalAgent: boolean;
+}) => {
   return (
     <div className="mb-4 mt-2 flex flex-col gap-2">
       <Page.P variant="secondary">
-        Your feedback is available to editors of the agent.
+        {isGlobalAgent
+          ? "Submitting feedback will help Dust improve your global agents."
+          : "Your feedback is available to editors of the agent."}
       </Page.P>
     </div>
   );
@@ -483,9 +489,11 @@ export function AgentMessage({
     [activeReferences]
   );
 
+  const isGlobalAgent = message.configuration.id === -1;
+
   const PopoverContent = useCallback(
-    () => <FeedbackSelectorPopoverContent />,
-    []
+    () => <FeedbackSelectorPopoverContent isGlobalAgent={isGlobalAgent} />,
+    [isGlobalAgent]
   );
 
   async function handleCopyToClipboard() {

--- a/extension/ui/components/conversation/AgentMessage.tsx
+++ b/extension/ui/components/conversation/AgentMessage.tsx
@@ -9,7 +9,7 @@ import type {
 import { messageReducer } from "@app/ui/components/agents/state/messageReducer";
 import { ActionValidationContext } from "@app/ui/components/conversation/ActionValidationProvider";
 import { AgentMessageActions } from "@app/ui/components/conversation/AgentMessageActions";
-import type { FeedbackSelectorProps } from "@app/ui/components/conversation/FeedbackSelector";
+import type { FeedbackSelectorBaseProps } from "@app/ui/components/conversation/FeedbackSelector";
 import { FeedbackSelector } from "@app/ui/components/conversation/FeedbackSelector";
 import { GenerationContext } from "@app/ui/components/conversation/GenerationContextProvider";
 import { MCPServerAuthRequired } from "@app/ui/components/conversation/MCPServerAuthRequired";
@@ -67,7 +67,6 @@ import {
   FaviconIcon,
   InformationCircleIcon,
   Markdown,
-  Page,
   Popover,
   useCopyToClipboard,
   useSendNotification,
@@ -85,22 +84,6 @@ import {
 import type { Components } from "react-markdown";
 import type { PluggableList } from "react-markdown/lib/react-markdown";
 import { visit } from "unist-util-visit";
-
-export const FeedbackSelectorPopoverContent = ({
-  isGlobalAgent,
-}: {
-  isGlobalAgent: boolean;
-}) => {
-  return (
-    <div className="mb-4 mt-2 flex flex-col gap-2">
-      <Page.P variant="secondary">
-        {isGlobalAgent
-          ? "Submitting feedback will help Dust improve your global agents."
-          : "Your feedback is available to editors of the agent."}
-      </Page.P>
-    </div>
-  );
-};
 
 export function visualizationDirective() {
   return (tree: any) => {
@@ -192,7 +175,7 @@ interface AgentMessageProps {
   isLastMessage: boolean;
   message: AgentMessagePublicType;
   userAndAgentMessages: (UserMessageType | AgentMessagePublicType)[];
-  messageFeedback: FeedbackSelectorProps;
+  messageFeedback: FeedbackSelectorBaseProps;
   owner: LightWorkspaceType;
   user: StoredUser;
 }
@@ -491,11 +474,6 @@ export function AgentMessage({
 
   const isGlobalAgent = message.configuration.id === -1;
 
-  const PopoverContent = useCallback(
-    () => <FeedbackSelectorPopoverContent isGlobalAgent={isGlobalAgent} />,
-    [isGlobalAgent]
-  );
-
   async function handleCopyToClipboard() {
     const messageContent = agentMessageToRender.content || "";
     let footnotesMarkdown = "";
@@ -604,9 +582,7 @@ export function AgentMessage({
   );
 
   const showFeedbackSection = useMemo(
-    () =>
-      showButtons &&
-      agentMessageToRender.configuration.status !== "draft",
+    () => showButtons && agentMessageToRender.configuration.status !== "draft",
     [showButtons, agentMessageToRender.configuration.status]
   );
 
@@ -653,7 +629,7 @@ export function AgentMessage({
           <FeedbackSelector
             key="feedback-selector"
             {...messageFeedback}
-            getPopoverInfo={PopoverContent}
+            isGlobalAgent={isGlobalAgent}
           />
         );
       }
@@ -670,7 +646,7 @@ export function AgentMessage({
     isRetryHandlerProcessing,
     shouldStream,
     messageFeedback,
-    PopoverContent,
+    isGlobalAgent,
   ]);
 
   const renderName = useCallback(

--- a/extension/ui/components/conversation/FeedbackSelector.tsx
+++ b/extension/ui/components/conversation/FeedbackSelector.tsx
@@ -9,6 +9,7 @@ import {
   DialogTitle,
   HandThumbDownIcon,
   HandThumbUpIcon,
+  Label,
   Page,
   Spinner,
   TextArea,
@@ -38,14 +39,12 @@ export interface FeedbackSelectorProps extends FeedbackSelectorBaseProps {
 }
 
 const FEEDBACK_PREDEFINED_ANSWERS = [
-  "Didn't search company data",
-  "Should have searched the web",
-  "Response too verbose",
-  "Didn't follow instructions",
-  "Missing or incorrect citations",
-  "Didn't use available tools",
-  "Not factually correct",
-  "Should have spawned sub-agents",
+  "Factually incorrect",
+  "Didn't fully follow instructions",
+  "Don't like the tone",
+  "Wrong data sources",
+  "Took too long",
+  "Other (please explain below)",
 ] as const;
 
 type FeedbackPredefinedAnswerType =
@@ -150,7 +149,11 @@ export function FeedbackSelector({
       >
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Share feedback</DialogTitle>
+            <DialogTitle>
+              {thumbDirection === "down"
+                ? "What’s wrong with this answer?"
+                : "Glad you liked it! Tell us more?"}
+            </DialogTitle>
           </DialogHeader>
 
           <DialogContainer>
@@ -195,18 +198,17 @@ export function FeedbackSelector({
                   </Page.P>
                 </div>
 
-                <div className="bg-muted-background dark:bg-muted-background-night border-border dark:border-border-night rounded-lg border p-3">
-                  <div className="flex items-center gap-2">
-                    <Checkbox
-                      checked={isConversationShared}
-                      onCheckedChange={(value) => {
-                        setIsConversationShared(!!value);
-                      }}
-                    />
-                    <Page.P variant="secondary">
-                      Include my full conversation with this feedback.
-                    </Page.P>
-                  </div>
+                <div className="flex items-center gap-2">
+                  <Checkbox
+                    id="share-conversation"
+                    checked={isConversationShared}
+                    onCheckedChange={(value) => {
+                      setIsConversationShared(!!value);
+                    }}
+                  />
+                  <Label htmlFor="share-conversation">
+                    Include my full conversation with this feedback.
+                  </Label>
                 </div>
               </div>
             )}

--- a/extension/ui/components/conversation/FeedbackSelector.tsx
+++ b/extension/ui/components/conversation/FeedbackSelector.tsx
@@ -182,7 +182,7 @@ export function FeedbackSelector({
                       <Button
                         key={answer}
                         size="xs"
-                        color={isSelected ? "primary" : "outline"}
+                        variant={isSelected ? "primary" : "outline"}
                         label={answer}
                         onClick={
                           isSubmittingThumb

--- a/extension/ui/components/conversation/FeedbackSelector.tsx
+++ b/extension/ui/components/conversation/FeedbackSelector.tsx
@@ -1,7 +1,6 @@
 import {
   Button,
   Checkbox,
-  Chip,
   Dialog,
   DialogContainer,
   DialogContent,
@@ -180,10 +179,10 @@ export function FeedbackSelector({
                   {FEEDBACK_PREDEFINED_ANSWERS.map((answer) => {
                     const isSelected = selectedPredefinedAnswer === answer;
                     return (
-                      <Chip
+                      <Button
                         key={answer}
                         size="xs"
-                        color={isSelected ? "info" : "primary"}
+                        color={isSelected ? "primary" : "outline"}
                         label={answer}
                         onClick={
                           isSubmittingThumb

--- a/extension/ui/components/conversation/FeedbackSelector.tsx
+++ b/extension/ui/components/conversation/FeedbackSelector.tsx
@@ -1,16 +1,21 @@
 import {
   Button,
   Checkbox,
+  Chip,
+  cn,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
   HandThumbDownIcon,
   HandThumbUpIcon,
   Page,
-  PopoverContent,
-  PopoverRoot,
-  PopoverTrigger,
   Spinner,
   TextArea,
 } from "@dust-tt/sparkle";
-import React, { useCallback, useEffect, useRef } from "react";
+import React, { useCallback, useEffect } from "react";
 
 export type ThumbReaction = "up" | "down";
 
@@ -31,74 +36,46 @@ export interface FeedbackSelectorProps {
   getPopoverInfo?: () => JSX.Element | null;
 }
 
+const FEEDBACK_PREDEFINED_ANSWERS = [
+  "Didn't search company data",
+  "Should have searched the web",
+  "Response too verbose",
+  "Didn't follow instructions",
+  "Missing or incorrect citations",
+  "Didn't use available tools",
+  "Not factually correct",
+  "Should have spawned sub-agents",
+] as const;
+
+type FeedbackPredefinedAnswerType =
+  (typeof FEEDBACK_PREDEFINED_ANSWERS)[number];
+
 export function FeedbackSelector({
   feedback,
   onSubmitThumb,
   isSubmittingThumb,
   getPopoverInfo,
 }: FeedbackSelectorProps) {
-  const [isPopoverOpen, setIsPopoverOpen] = React.useState(false);
-  const containerRef = useRef<HTMLDivElement>(null);
+  const [isDialogOpen, setIsDialogOpen] = React.useState(false);
   const [localFeedbackContent, setLocalFeedbackContent] = React.useState<
     string | null
   >(null);
+  const [selectedPredefinedAnswer, setSelectedPredefinedAnswer] =
+    React.useState<FeedbackPredefinedAnswerType | null>(null);
   const [popOverInfo, setPopoverInfo] = React.useState<JSX.Element | null>(
     null
   );
   const [isConversationShared, setIsConversationShared] = React.useState(
     feedback?.isConversationShared ?? false
   );
-  // This is required to adjust the content of the popover even when feedback is null.
-  const [lastSelectedThumb, setLastSelectedThumb] =
-    React.useState<ThumbReaction | null>(feedback?.thumb ?? null);
 
   useEffect(() => {
-    if (isPopoverOpen) {
+    if (isDialogOpen) {
       if (getPopoverInfo) {
         setPopoverInfo(getPopoverInfo());
       }
-      if (feedback?.thumb === lastSelectedThumb) {
-        setLocalFeedbackContent(feedback?.feedbackContent ?? null);
-      }
     }
-  }, [
-    isPopoverOpen,
-    feedback?.feedbackContent,
-    getPopoverInfo,
-    lastSelectedThumb,
-    feedback?.thumb,
-  ]);
-
-  const selectThumb = useCallback(
-    async (thumb: ThumbReaction) => {
-      const shouldRemoveExistingFeedback = feedback?.thumb === thumb;
-      setIsPopoverOpen(!shouldRemoveExistingFeedback);
-      setLastSelectedThumb(shouldRemoveExistingFeedback ? null : thumb);
-      setIsConversationShared(thumb === "down");
-
-      // We enforce written feedback for thumbs down.
-      // -> Not saving the reaction until then.
-      if (thumb === "down" && !shouldRemoveExistingFeedback) {
-        return;
-      }
-
-      await onSubmitThumb({
-        feedbackContent: localFeedbackContent,
-        thumb,
-        shouldRemoveExistingFeedback,
-        isConversationShared: false,
-      });
-    },
-    [feedback?.thumb, localFeedbackContent, onSubmitThumb]
-  );
-
-  const handleThumbUp = useCallback(async () => {
-    await selectThumb("up");
-  }, [selectThumb]);
-
-  const handleThumbDown = useCallback(async () => {
-    await selectThumb("down");
-  }, [selectThumb]);
+  }, [isDialogOpen, getPopoverInfo]);
 
   const handleTextAreaChange = useCallback(
     (e: React.ChangeEvent<HTMLTextAreaElement>) => {
@@ -108,119 +85,190 @@ export function FeedbackSelector({
   );
 
   const closePopover = useCallback(() => {
-    setIsPopoverOpen(false);
+    setIsDialogOpen(false);
+    setSelectedPredefinedAnswer(null);
+    setLocalFeedbackContent(null);
+    setIsConversationShared(false);
   }, []);
 
   const handleSubmit = useCallback(async () => {
-    setIsPopoverOpen(false);
-    if (lastSelectedThumb) {
-      await onSubmitThumb({
-        thumb: lastSelectedThumb,
-        shouldRemoveExistingFeedback: false,
-        feedbackContent: localFeedbackContent,
-        isConversationShared,
-      });
-      setLocalFeedbackContent(null);
-    }
+    const details = localFeedbackContent?.trim() ?? "";
+    const predefinedAnswer = selectedPredefinedAnswer?.trim() ?? "";
+
+    const feedbackContent = [predefinedAnswer, details]
+      .filter(Boolean)
+      .join("\n\n");
+
+    await onSubmitThumb({
+      thumb: "down",
+      shouldRemoveExistingFeedback: false,
+      feedbackContent,
+      isConversationShared,
+    });
+    closePopover();
   }, [
+    closePopover,
     onSubmitThumb,
     localFeedbackContent,
     isConversationShared,
-    lastSelectedThumb,
+    selectedPredefinedAnswer,
   ]);
 
+  const handleThumbUp = useCallback(async () => {
+    const shouldRemoveExistingFeedback = feedback?.thumb === "up";
+    await onSubmitThumb({
+      thumb: "up",
+      shouldRemoveExistingFeedback,
+      feedbackContent: null,
+      isConversationShared: false,
+    });
+  }, [feedback?.thumb, onSubmitThumb]);
+
+  const handleThumbDown = useCallback(async () => {
+    const shouldRemoveExistingFeedback = feedback?.thumb === "down";
+    if (shouldRemoveExistingFeedback) {
+      await onSubmitThumb({
+        thumb: "down",
+        shouldRemoveExistingFeedback,
+        feedbackContent: null,
+        isConversationShared: false,
+      });
+      return;
+    }
+
+    setSelectedPredefinedAnswer(null);
+    setLocalFeedbackContent(null);
+    setIsConversationShared(true);
+    setIsDialogOpen(true);
+  }, [feedback?.thumb, onSubmitThumb]);
+
+  const canSubmit =
+    !!selectedPredefinedAnswer || (localFeedbackContent?.trim() ?? "") !== "";
+
   return (
-    <div ref={containerRef} className="flex items-center">
-      <PopoverRoot open={isPopoverOpen}>
-        <PopoverTrigger asChild>
-          <div className="flex items-center gap-2">
-            <Button
-              tooltip="I found this helpful"
-              variant={feedback?.thumb === "up" ? "primary" : "ghost"}
-              size="xs"
-              disabled={isSubmittingThumb}
-              onClick={handleThumbUp}
-              icon={HandThumbUpIcon}
-              // We enforce written feedback for thumbs down.
-              // -> Not saving the reaction until then.
-              className={
-                feedback?.thumb === "up"
-                  ? "text-muted-foreground dark:text-muted-foreground-night"
-                  : ""
-              }
-            />
-            <Button
-              tooltip="Report an issue with this answer"
-              variant={feedback?.thumb === "down" ? "primary" : "ghost"}
-              size="xs"
-              disabled={isSubmittingThumb}
-              onClick={handleThumbDown}
-              icon={HandThumbDownIcon}
-              // We enforce written feedback for thumbs down.
-              // -> Not saving the reaction until then.
-              className={
-                feedback?.thumb === "down"
-                  ? "text-muted-foreground dark:text-muted-foreground-night"
-                  : ""
-              }
-            />
-          </div>
-        </PopoverTrigger>
-        <PopoverContent
-          fullWidth={true}
-          onInteractOutside={closePopover}
-          onEscapeKeyDown={closePopover}
-        >
-          {isSubmittingThumb ? (
-            <div className="m-3 flex items-center justify-center">
-              <Spinner size="sm" />
-            </div>
-          ) : (
-            <div className="w-80 p-4">
-              <Page.H variant="h6">
-                {lastSelectedThumb === "up"
-                  ? "🎉 Glad you liked it! Tell us more?"
-                  : "🫠 Help make the answers better!"}
-              </Page.H>
-              <TextArea
-                placeholder={
-                  lastSelectedThumb === "up"
-                    ? "What did you like?"
-                    : "Tell us what went wrong so we can make this agent better."
-                }
-                className="mb-4 mt-4"
-                rows={3}
-                value={localFeedbackContent ?? ""}
-                onChange={handleTextAreaChange}
-              />
-              {popOverInfo}
-              <div className="mt-2 flex items-center gap-2">
-                <Checkbox
-                  checked={isConversationShared}
-                  onCheckedChange={(value) => {
-                    setIsConversationShared(!!value);
-                  }}
-                />
-                <Page.P variant="secondary">
-                  By clicking, you accept to share your full conversation
-                </Page.P>
+    <div className="flex items-center">
+      <div className="flex items-center gap-2">
+        <Button
+          tooltip="I found this helpful"
+          variant={feedback?.thumb === "up" ? "primary" : "ghost"}
+          size="xs"
+          disabled={isSubmittingThumb}
+          onClick={handleThumbUp}
+          icon={HandThumbUpIcon}
+          className={
+            feedback?.thumb === "up"
+              ? "text-muted-foreground dark:text-muted-foreground-night"
+              : ""
+          }
+        />
+        <Button
+          tooltip="Report an issue with this answer"
+          variant={feedback?.thumb === "down" ? "primary" : "ghost"}
+          size="xs"
+          disabled={isSubmittingThumb}
+          onClick={handleThumbDown}
+          icon={HandThumbDownIcon}
+          className={
+            feedback?.thumb === "down"
+              ? "text-muted-foreground dark:text-muted-foreground-night"
+              : ""
+          }
+        />
+      </div>
+
+      <Dialog
+        open={isDialogOpen}
+        onOpenChange={(open) => {
+          if (!open) {
+            closePopover();
+          }
+          setIsDialogOpen(open);
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Share feedback</DialogTitle>
+          </DialogHeader>
+
+          <DialogContainer>
+            {isSubmittingThumb ? (
+              <div className="m-3 flex items-center justify-center">
+                <Spinner size="sm" />
               </div>
-              <div className="mt-4 flex justify-end gap-2">
-                <Button
-                  variant="primary"
-                  label="Submit feedback"
-                  onClick={handleSubmit}
-                  disabled={
-                    !localFeedbackContent ||
-                    localFeedbackContent.trim() === "" ||
-                    isSubmittingThumb
-                  }
+            ) : (
+              <div className="flex flex-col gap-4">
+                <div className="flex flex-wrap gap-2">
+                  {FEEDBACK_PREDEFINED_ANSWERS.map((answer) => {
+                    const isSelected = selectedPredefinedAnswer === answer;
+                    return (
+                      <Chip
+                        key={answer}
+                        size="xs"
+                        color="primary"
+                        label={answer}
+                        className={cn(
+                          "s-whitespace-nowrap",
+                          isSubmittingThumb &&
+                            "s-cursor-not-allowed s-opacity-50",
+                          isSelected
+                            ? "s-border-transparent s-bg-foreground s-text-background dark:s-bg-foreground-night dark:s-text-background-night"
+                            : undefined
+                        )}
+                        onClick={
+                          isSubmittingThumb
+                            ? undefined
+                            : () =>
+                                setSelectedPredefinedAnswer(
+                                  isSelected ? null : answer
+                                )
+                        }
+                      />
+                    );
+                  })}
+                </div>
+                <TextArea
+                  placeholder="Share details (optional)"
+                  resize="vertical"
+                  rows={3}
+                  value={localFeedbackContent ?? ""}
+                  onChange={handleTextAreaChange}
                 />
+
+                {popOverInfo}
+
+                <div className="bg-muted-background dark:bg-muted-background-night border-border dark:border-border-night rounded-lg border p-3">
+                  <div className="flex items-center gap-2">
+                    <Checkbox
+                      checked={isConversationShared}
+                      onCheckedChange={(value) => {
+                        setIsConversationShared(!!value);
+                      }}
+                    />
+                    <Page.P variant="secondary">
+                      Include my full conversation with this feedback.
+                    </Page.P>
+                  </div>
+                </div>
               </div>
-            </div>
-          )}
-        </PopoverContent>
-      </PopoverRoot>
+            )}
+          </DialogContainer>
+
+          <DialogFooter
+            leftButtonProps={{
+              label: "Cancel",
+              variant: "outline",
+              disabled: isSubmittingThumb,
+              onClick: closePopover,
+            }}
+            rightButtonProps={{
+              label: "Submit",
+              variant: "primary",
+              onClick: handleSubmit,
+              disabled: isSubmittingThumb || !canSubmit,
+            }}
+          />
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/extension/ui/components/conversation/MessageItem.tsx
+++ b/extension/ui/components/conversation/MessageItem.tsx
@@ -7,7 +7,7 @@ import {
   AttachmentCitation,
   contentFragmentToAttachmentCitation,
 } from "@app/ui/components/conversation/AttachmentCitation";
-import type { FeedbackSelectorProps } from "@app/ui/components/conversation/FeedbackSelector";
+import type { FeedbackSelectorBaseProps } from "@app/ui/components/conversation/FeedbackSelector";
 import { UserMessage } from "@app/ui/components/conversation/UserMessage";
 import { useSubmitFunction } from "@app/ui/components/utils/useSubmitFunction";
 import type {
@@ -82,7 +82,7 @@ const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
       return null;
     }
 
-    const messageFeedbackWithSubmit: FeedbackSelectorProps = {
+    const messageFeedbackWithSubmit: FeedbackSelectorBaseProps = {
       feedback: messageFeedback
         ? {
             thumb: messageFeedback.thumbDirection,

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -82,7 +82,6 @@ import type {
 } from "@app/types";
 import {
   assertNever,
-  GLOBAL_AGENTS_SID,
   isInteractiveContentFileContentType,
   isSupportedImageContentType,
 } from "@app/types";
@@ -123,10 +122,6 @@ export function AgentMessage({
   const [isCopied, copy] = useCopyToClipboard();
   const sendNotification = useSendNotification();
   const confirm = useContext(ConfirmContext);
-
-  const isGlobalAgent = Object.values(GLOBAL_AGENTS_SID).includes(
-    agentMessage.configuration.sId as GLOBAL_AGENTS_SID
-  );
 
   const { enqueueBlockedAction, removeAllBlockedActionsForMessage } =
     useBlockedActionsContext();
@@ -452,7 +447,6 @@ export function AgentMessage({
     !isDeleted &&
     agentMessage.status !== "created" &&
     agentMessage.status !== "failed" &&
-    !isGlobalAgent &&
     agentMessage.configuration.status !== "draft";
 
   const retryMessage = useRetryMessage({ owner });

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -82,6 +82,7 @@ import type {
 } from "@app/types";
 import {
   assertNever,
+  isGlobalAgentId,
   isInteractiveContentFileContentType,
   isSupportedImageContentType,
 } from "@app/types";
@@ -272,6 +273,7 @@ export function AgentMessage({
       <FeedbackSelectorPopoverContent
         owner={owner}
         agentMessageToRender={agentMessage}
+        isGlobalAgent={isGlobalAgentId(agentMessage.configuration.sId)}
       />
     ),
     [owner, agentMessage]

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -30,9 +30,8 @@ import { markdownCitationToAttachmentCitation } from "@app/components/assistant/
 import { useBlockedActionsContext } from "@app/components/assistant/conversation/BlockedActionsProvider";
 import { DeletedMessage } from "@app/components/assistant/conversation/DeletedMessage";
 import { ErrorMessage } from "@app/components/assistant/conversation/ErrorMessage";
-import type { FeedbackSelectorProps } from "@app/components/assistant/conversation/FeedbackSelector";
+import type { FeedbackSelectorBaseProps } from "@app/components/assistant/conversation/FeedbackSelector";
 import { FeedbackSelector } from "@app/components/assistant/conversation/FeedbackSelector";
-import { FeedbackSelectorPopoverContent } from "@app/components/assistant/conversation/FeedbackSelectorPopoverContent";
 import { GenerationContext } from "@app/components/assistant/conversation/GenerationContextProvider";
 import { useAutoOpenInteractiveContent } from "@app/components/assistant/conversation/interactive_content/useAutoOpenInteractiveContent";
 import { MCPServerPersonalAuthenticationRequired } from "@app/components/assistant/conversation/MCPServerPersonalAuthenticationRequired";
@@ -91,7 +90,7 @@ interface AgentMessageProps {
   conversationId: string;
   isLastMessage: boolean;
   agentMessage: MessageTemporaryState;
-  messageFeedback: FeedbackSelectorProps;
+  messageFeedback: FeedbackSelectorBaseProps;
   owner: WorkspaceType;
   user: UserType;
   triggeringUser: UserType | null;
@@ -268,16 +267,7 @@ export function AgentMessage({
     }
   }, [shouldStream, generationContext, sId, conversationId]);
 
-  const PopoverContent = useCallback(
-    () => (
-      <FeedbackSelectorPopoverContent
-        owner={owner}
-        agentMessageToRender={agentMessage}
-        isGlobalAgent={isGlobalAgentId(agentMessage.configuration.sId)}
-      />
-    ),
-    [owner, agentMessage]
-  );
+  const isGlobalAgent = isGlobalAgentId(agentMessage.configuration.sId);
 
   async function handleCopyToClipboard() {
     const messageContent = agentMessage.content ?? "";
@@ -480,7 +470,9 @@ export function AgentMessage({
       <FeedbackSelector
         key="feedback-selector"
         {...messageFeedback}
-        getPopoverInfo={PopoverContent}
+        owner={owner}
+        agentConfigurationId={agentMessage.configuration.sId}
+        isGlobalAgent={isGlobalAgent}
       />
     );
   }

--- a/front/components/assistant/conversation/FeedbackSelector.tsx
+++ b/front/components/assistant/conversation/FeedbackSelector.tsx
@@ -1,17 +1,21 @@
 import {
-  Button,
   ButtonGroup,
   Checkbox,
+  Chip,
+  cn,
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
   HandThumbDownIcon,
   HandThumbUpIcon,
   Page,
-  PopoverContent,
-  PopoverRoot,
-  PopoverTrigger,
   Spinner,
   TextArea,
 } from "@dust-tt/sparkle";
-import React, { useCallback, useEffect, useRef } from "react";
+import React, { useCallback, useEffect } from "react";
 
 import type { WorkspaceType } from "@app/types";
 
@@ -35,71 +39,47 @@ export interface FeedbackSelectorProps {
   owner: WorkspaceType;
 }
 
+const FEEDBACK_PREDEFINED_ANSWERS = [
+  "Didn't search company data",
+  "Should have searched the web",
+  "Response too verbose",
+  "Didn't follow instructions",
+  "Missing or incorrect citations",
+  "Didn't use available tools",
+  "Not factually correct",
+  "Should have spawned sub-agents",
+  "Others",
+] as const;
+
+type FeedbackPredefinedAnswerType =
+  (typeof FEEDBACK_PREDEFINED_ANSWERS)[number];
+
 export function FeedbackSelector({
   feedback,
   onSubmitThumb,
   isSubmittingThumb,
   getPopoverInfo,
 }: FeedbackSelectorProps) {
-  const [isPopoverOpen, setIsPopoverOpen] = React.useState(false);
-  const containerRef = useRef<HTMLDivElement>(null);
+  const [isDialogOpen, setIsDialogOpen] = React.useState(false);
   const [localFeedbackContent, setLocalFeedbackContent] = React.useState<
     string | null
   >(null);
+  const [selectedPredefinedAnswer, setSelectedPredefinedAnswer] =
+    React.useState<FeedbackPredefinedAnswerType | null>(null);
   const [popOverInfo, setPopoverInfo] = React.useState<JSX.Element | null>(
     null
   );
   const [isConversationShared, setIsConversationShared] = React.useState(
     feedback?.isConversationShared ?? false
   );
-  // This is required to adjust the content of the popover even when feedback is null.
-  const [lastSelectedThumb, setLastSelectedThumb] =
-    React.useState<ThumbReaction | null>(feedback?.thumb ?? null);
 
   useEffect(() => {
-    if (isPopoverOpen) {
+    if (isDialogOpen) {
       if (getPopoverInfo) {
         setPopoverInfo(getPopoverInfo());
       }
-      if (feedback?.thumb === lastSelectedThumb) {
-        setLocalFeedbackContent(feedback?.feedbackContent ?? null);
-      }
     }
-  }, [
-    isPopoverOpen,
-    feedback?.feedbackContent,
-    getPopoverInfo,
-    lastSelectedThumb,
-    feedback?.thumb,
-  ]);
-
-  const selectThumb = async (thumb: ThumbReaction) => {
-    const shouldRemoveExistingFeedback = feedback?.thumb === thumb;
-    setIsPopoverOpen(!shouldRemoveExistingFeedback);
-    setLastSelectedThumb(shouldRemoveExistingFeedback ? null : thumb);
-    setIsConversationShared(thumb === "down");
-
-    // We enforce written feedback for thumbs down.
-    // -> Not saving the reaction until then.
-    if (thumb === "down" && !shouldRemoveExistingFeedback) {
-      return;
-    }
-
-    await onSubmitThumb({
-      feedbackContent: localFeedbackContent,
-      thumb,
-      shouldRemoveExistingFeedback,
-      isConversationShared: false,
-    });
-  };
-
-  const handleThumbUp = async () => {
-    await selectThumb("up");
-  };
-
-  const handleThumbDown = async () => {
-    await selectThumb("down");
-  };
+  }, [isDialogOpen, getPopoverInfo]);
 
   const handleTextAreaChange = useCallback(
     (e: React.ChangeEvent<HTMLTextAreaElement>) => {
@@ -109,116 +89,190 @@ export function FeedbackSelector({
   );
 
   const closePopover = () => {
-    setIsPopoverOpen(false);
+    setIsDialogOpen(false);
+    setSelectedPredefinedAnswer(null);
+    setLocalFeedbackContent(null);
+    setIsConversationShared(false);
   };
 
   const handleSubmit = async () => {
-    setIsPopoverOpen(false);
-    if (lastSelectedThumb) {
-      await onSubmitThumb({
-        thumb: lastSelectedThumb,
-        shouldRemoveExistingFeedback: false,
-        feedbackContent: localFeedbackContent,
-        isConversationShared,
-      });
-      setLocalFeedbackContent(null);
-    }
+    const details = localFeedbackContent?.trim() ?? "";
+    const predefinedAnswer = selectedPredefinedAnswer?.trim() ?? "";
+
+    const feedbackContent = [predefinedAnswer, details]
+      .filter(Boolean)
+      .join("\n\n");
+
+    await onSubmitThumb({
+      thumb: "down",
+      shouldRemoveExistingFeedback: false,
+      feedbackContent,
+      isConversationShared,
+    });
+    closePopover();
   };
 
+  const handleThumbUp = async () => {
+    const shouldRemoveExistingFeedback = feedback?.thumb === "up";
+    await onSubmitThumb({
+      thumb: "up",
+      shouldRemoveExistingFeedback,
+      feedbackContent: null,
+      isConversationShared: false,
+    });
+  };
+
+  const handleThumbDown = async () => {
+    const shouldRemoveExistingFeedback = feedback?.thumb === "down";
+    if (shouldRemoveExistingFeedback) {
+      await onSubmitThumb({
+        thumb: "down",
+        shouldRemoveExistingFeedback,
+        feedbackContent: null,
+        isConversationShared: false,
+      });
+      return;
+    }
+
+    setSelectedPredefinedAnswer(null);
+    setLocalFeedbackContent(null);
+    setIsConversationShared(true);
+    setIsDialogOpen(true);
+  };
+
+  const canSubmit =
+    !!selectedPredefinedAnswer || (localFeedbackContent?.trim() ?? "") !== "";
+
   return (
-    <div ref={containerRef} className="flex items-center">
-      <PopoverRoot open={isPopoverOpen}>
-        <PopoverTrigger asChild>
-          <ButtonGroup
-            variant="outline"
-            items={[
-              {
-                type: "button",
-                props: {
-                  tooltip: "I found this helpful",
-                  variant:
-                    feedback?.thumb === "up" ? "primary" : "ghost-secondary",
-                  size: "xs",
-                  disabled: isSubmittingThumb,
-                  onClick: handleThumbUp,
-                  icon: HandThumbUpIcon,
-                  className:
-                    feedback?.thumb === "up" ? "" : "text-muted-foreground",
-                },
-              },
-              {
-                type: "button",
-                props: {
-                  tooltip: "Report an issue with this answer",
-                  variant:
-                    feedback?.thumb === "down" ? "primary" : "ghost-secondary",
-                  size: "xs",
-                  disabled: isSubmittingThumb,
-                  onClick: handleThumbDown,
-                  icon: HandThumbDownIcon,
-                  className:
-                    feedback?.thumb === "down" ? "" : "text-muted-foreground",
-                },
-              },
-            ]}
+    <div className="flex items-center">
+      <ButtonGroup
+        variant="outline"
+        items={[
+          {
+            type: "button",
+            props: {
+              tooltip: "I found this helpful",
+              variant: feedback?.thumb === "up" ? "primary" : "ghost-secondary",
+              size: "xs",
+              disabled: isSubmittingThumb,
+              onClick: handleThumbUp,
+              icon: HandThumbUpIcon,
+              className:
+                feedback?.thumb === "up" ? "" : "text-muted-foreground",
+            },
+          },
+          {
+            type: "button",
+            props: {
+              tooltip: "Report an issue with this answer",
+              variant:
+                feedback?.thumb === "down" ? "primary" : "ghost-secondary",
+              size: "xs",
+              disabled: isSubmittingThumb,
+              onClick: handleThumbDown,
+              icon: HandThumbDownIcon,
+              className:
+                feedback?.thumb === "down" ? "" : "text-muted-foreground",
+            },
+          },
+        ]}
+      />
+
+      <Dialog
+        open={isDialogOpen}
+        onOpenChange={(open) => {
+          if (!open) {
+            closePopover();
+          }
+          setIsDialogOpen(open);
+        }}
+      >
+        <DialogContent height="md" size="lg">
+          <DialogHeader>
+            <DialogTitle>Share feedback</DialogTitle>
+          </DialogHeader>
+
+          <DialogContainer>
+            {isSubmittingThumb ? (
+              <div className="m-3 flex items-center justify-center">
+                <Spinner size="sm" />
+              </div>
+            ) : (
+              <div className="flex flex-col gap-4">
+                <div className="flex flex-wrap gap-2">
+                  {FEEDBACK_PREDEFINED_ANSWERS.map((answer) => {
+                    const isSelected = selectedPredefinedAnswer === answer;
+                    return (
+                      <Chip
+                        key={answer}
+                        size="xs"
+                        color="primary"
+                        label={answer}
+                        className={cn(
+                          isSubmittingThumb && "cursor-not-allowed opacity-50",
+                          isSelected
+                            ? "border-transparent bg-foreground text-background dark:bg-foreground-night dark:text-background-night"
+                            : undefined
+                        )}
+                        onClick={
+                          isSubmittingThumb
+                            ? undefined
+                            : () =>
+                                setSelectedPredefinedAnswer(
+                                  isSelected ? null : answer
+                                )
+                        }
+                      />
+                    );
+                  })}
+                </div>
+                <TextArea
+                  placeholder="Share details (optional)"
+                  resize="vertical"
+                  rows={3}
+                  value={localFeedbackContent ?? ""}
+                  onChange={handleTextAreaChange}
+                />
+                {popOverInfo}
+                <div
+                  className={cn(
+                    "rounded-lg border p-3",
+                    "border-border bg-muted-background",
+                    "dark:border-border-night dark:bg-muted-background-night"
+                  )}
+                >
+                  <div className="flex items-center gap-2">
+                    <Checkbox
+                      checked={isConversationShared}
+                      onCheckedChange={(value) => {
+                        setIsConversationShared(!!value);
+                      }}
+                    />
+                    <Page.P variant="secondary">
+                      Include my full conversation with this feedback.
+                    </Page.P>
+                  </div>
+                </div>
+              </div>
+            )}
+          </DialogContainer>
+
+          <DialogFooter
+            leftButtonProps={{
+              label: "Cancel",
+              variant: "outline",
+              disabled: isSubmittingThumb,
+              onClick: closePopover,
+            }}
+            rightButtonProps={{
+              label: "Submit",
+              variant: "primary",
+              onClick: handleSubmit,
+              disabled: isSubmittingThumb || !canSubmit,
+            }}
           />
-        </PopoverTrigger>
-        <PopoverContent
-          fullWidth={true}
-          onInteractOutside={closePopover}
-          onEscapeKeyDown={closePopover}
-        >
-          {isSubmittingThumb ? (
-            <div className="m-3 flex items-center justify-center">
-              <Spinner size="sm" />
-            </div>
-          ) : (
-            <div className="w-80 p-4">
-              <Page.H variant="h6">
-                {lastSelectedThumb === "up"
-                  ? "🎉 Glad you liked it! Tell us more?"
-                  : "🫠 Help make the answers better!"}
-              </Page.H>
-              <TextArea
-                placeholder={
-                  lastSelectedThumb === "up"
-                    ? "What did you like?"
-                    : "Tell us what went wrong so we can make this agent better."
-                }
-                className="mb-4 mt-4"
-                resize="vertical"
-                rows={3}
-                value={localFeedbackContent ?? ""}
-                onChange={handleTextAreaChange}
-              />
-              {popOverInfo}
-              <div className="mt-2 flex items-center gap-2">
-                <Checkbox
-                  checked={isConversationShared}
-                  onCheckedChange={(value) => {
-                    setIsConversationShared(!!value);
-                  }}
-                />
-                <Page.P variant="secondary">
-                  By clicking, you accept to share your full conversation
-                </Page.P>
-              </div>
-              <div className="mt-4 flex justify-end gap-2">
-                <Button
-                  variant="primary"
-                  label="Submit feedback"
-                  onClick={handleSubmit}
-                  disabled={
-                    !localFeedbackContent ||
-                    localFeedbackContent.trim() === "" ||
-                    isSubmittingThumb
-                  }
-                />
-              </div>
-            </div>
-          )}
-        </PopoverContent>
-      </PopoverRoot>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/front/components/assistant/conversation/FeedbackSelector.tsx
+++ b/front/components/assistant/conversation/FeedbackSelector.tsx
@@ -202,7 +202,7 @@ export function FeedbackSelector({
                       <Button
                         key={answer}
                         size="xs"
-                        color={isSelected ? "primary" : "outline"}
+                        variant={isSelected ? "primary" : "outline"}
                         label={answer}
                         onClick={
                           isSubmittingThumb

--- a/front/components/assistant/conversation/FeedbackSelector.tsx
+++ b/front/components/assistant/conversation/FeedbackSelector.tsx
@@ -2,7 +2,6 @@ import {
   Button,
   ButtonGroup,
   Checkbox,
-  cn,
   Dialog,
   DialogContainer,
   DialogContent,
@@ -11,7 +10,7 @@ import {
   DialogTitle,
   HandThumbDownIcon,
   HandThumbUpIcon,
-  Page,
+  Label,
   Spinner,
   TextArea,
 } from "@dust-tt/sparkle";
@@ -39,15 +38,12 @@ export interface FeedbackSelectorBaseProps {
 }
 
 const FEEDBACK_PREDEFINED_ANSWERS = [
-  "Didn't search company data",
-  "Should have searched the web",
-  "Response too verbose",
-  "Didn't follow instructions",
-  "Missing or incorrect citations",
-  "Didn't use available tools",
-  "Not factually correct",
-  "Should have spawned sub-agents",
-  "Other",
+  "Factually incorrect",
+  "Didn't fully follow instructions",
+  "Don't like the tone",
+  "Wrong data sources",
+  "Took too long",
+  "Other (please explain below)",
 ] as const;
 
 type FeedbackPredefinedAnswerType =
@@ -170,9 +166,13 @@ export function FeedbackSelector({
           }
         }}
       >
-        <DialogContent height="lg" size="lg">
+        <DialogContent size="lg">
           <DialogHeader>
-            <DialogTitle>Share feedback</DialogTitle>
+            <DialogTitle>
+              {thumbDirection === "down"
+                ? "What’s wrong with this answer?"
+                : "Glad you liked it! Tell us more?"}
+            </DialogTitle>
           </DialogHeader>
 
           <DialogContainer>
@@ -214,24 +214,18 @@ export function FeedbackSelector({
                   agentConfigurationId={agentConfigurationId}
                   isGlobalAgent={isGlobalAgent}
                 />
-                <div
-                  className={cn(
-                    "rounded-lg border p-3",
-                    "border-border bg-muted-background",
-                    "dark:border-border-night dark:bg-muted-background-night"
-                  )}
-                >
-                  <div className="flex items-center gap-2">
-                    <Checkbox
-                      checked={isConversationShared}
-                      onCheckedChange={(value) => {
-                        setIsConversationShared(!!value);
-                      }}
-                    />
-                    <Page.P variant="secondary">
-                      Include my full conversation with this feedback.
-                    </Page.P>
-                  </div>
+
+                <div className="flex items-center gap-2">
+                  <Checkbox
+                    id="share-conversation"
+                    checked={isConversationShared}
+                    onCheckedChange={(value) => {
+                      setIsConversationShared(!!value);
+                    }}
+                  />
+                  <Label htmlFor="share-conversation">
+                    Include my full conversation with this feedback.
+                  </Label>
                 </div>
               </div>
             )}

--- a/front/components/assistant/conversation/FeedbackSelector.tsx
+++ b/front/components/assistant/conversation/FeedbackSelector.tsx
@@ -1,7 +1,7 @@
 import {
+  Button,
   ButtonGroup,
   Checkbox,
-  Chip,
   cn,
   Dialog,
   DialogContainer,
@@ -199,10 +199,10 @@ export function FeedbackSelector({
                   {FEEDBACK_PREDEFINED_ANSWERS.map((answer) => {
                     const isSelected = selectedPredefinedAnswer === answer;
                     return (
-                      <Chip
+                      <Button
                         key={answer}
                         size="xs"
-                        color={isSelected ? "info" : "primary"}
+                        color={isSelected ? "primary" : "outline"}
                         label={answer}
                         onClick={
                           isSubmittingThumb
@@ -219,7 +219,7 @@ export function FeedbackSelector({
                 <TextArea
                   placeholder="Share details (optional)"
                   resize="vertical"
-                  rows={4}
+                  rows={5}
                   value={localFeedbackContent ?? ""}
                   onChange={(e) => {
                     setLocalFeedbackContent(e.target.value);

--- a/front/components/assistant/conversation/FeedbackSelectorPopoverContent.tsx
+++ b/front/components/assistant/conversation/FeedbackSelectorPopoverContent.tsx
@@ -1,4 +1,4 @@
-import { Page } from "@dust-tt/sparkle";
+import { Avatar, Page } from "@dust-tt/sparkle";
 
 import { useAgentConfigurationLastAuthor } from "@app/lib/swr/assistants";
 import type { LightWorkspaceType } from "@app/types";
@@ -39,11 +39,7 @@ export function FeedbackSelectorPopoverContent({
           </span>
           <span className="inline-flex items-center gap-2">
             {agentLastAuthor.image && (
-              <img
-                src={agentLastAuthor.image}
-                alt={agentLastAuthor.firstName}
-                className="h-8 w-8 rounded-full"
-              />
+              <Avatar visual={agentLastAuthor.image} size="sm" />
             )}
             <span className="font-medium text-foreground dark:text-foreground-night">
               {`${agentLastAuthor.firstName} ${agentLastAuthor.lastName}`}

--- a/front/components/assistant/conversation/FeedbackSelectorPopoverContent.tsx
+++ b/front/components/assistant/conversation/FeedbackSelectorPopoverContent.tsx
@@ -1,6 +1,6 @@
 import { Avatar, Page } from "@dust-tt/sparkle";
 
-import { useAgentConfigurationLastAuthor } from "@app/lib/swr/assistants";
+import { useEditors } from "@app/lib/swr/agent_editors";
 import type { LightWorkspaceType } from "@app/types";
 
 interface FeedbackSelectorPopoverContentProps {
@@ -14,39 +14,40 @@ export function FeedbackSelectorPopoverContent({
   agentConfigurationId,
   isGlobalAgent,
 }: FeedbackSelectorPopoverContentProps) {
-  const { agentLastAuthor } = useAgentConfigurationLastAuthor({
-    workspaceId: owner.sId,
+  const { editors } = useEditors({
+    owner,
     agentConfigurationId,
+    disabled: isGlobalAgent,
   });
 
   if (isGlobalAgent) {
     return (
       <div className="mb-4 mt-2 flex flex-col gap-2">
         <Page.P variant="secondary">
-          Submitting feedback will help Dust improve your global agents.
+          Your feedback will be available to Dust for future improvement to our
+          default agents.
         </Page.P>
       </div>
     );
   }
 
+  if (editors.length === 0) {
+    return null;
+  }
+
+  const avatarProps = editors.map((editor) => ({
+    name: `${editor.firstName} ${editor.lastName}`,
+    visual: editor.image ?? undefined,
+  }));
+
   return (
-    agentLastAuthor && (
-      <div className="mb-4 mt-2 flex flex-col gap-2">
+    <div className="mb-4 mt-2 flex flex-col gap-2">
+      <div className="flex items-center gap-2">
         <Page.P variant="secondary">
-          <span>
-            Your feedback is available to editors of the agent. The last agent
-            editor is:{" "}
-          </span>
-          <span className="inline-flex items-center gap-2">
-            {agentLastAuthor.image && (
-              <Avatar visual={agentLastAuthor.image} size="sm" />
-            )}
-            <span className="font-medium text-foreground dark:text-foreground-night">
-              {`${agentLastAuthor.firstName} ${agentLastAuthor.lastName}`}
-            </span>
-          </span>
+          Your feedback is available to editors of the agent:
         </Page.P>
+        <Avatar.Stack avatars={avatarProps} size="xs" nbVisibleItems={4} />
       </div>
-    )
+    </div>
   );
 }

--- a/front/components/assistant/conversation/FeedbackSelectorPopoverContent.tsx
+++ b/front/components/assistant/conversation/FeedbackSelectorPopoverContent.tsx
@@ -6,36 +6,50 @@ import type { LightAgentMessageType, LightWorkspaceType } from "@app/types";
 interface FeedbackSelectorPopoverContentProps {
   agentMessageToRender: LightAgentMessageType;
   owner: LightWorkspaceType;
+  isGlobalAgent: boolean;
 }
 
 export function FeedbackSelectorPopoverContent({
   owner,
   agentMessageToRender,
+  isGlobalAgent,
 }: FeedbackSelectorPopoverContentProps) {
   const { agentLastAuthor } = useAgentConfigurationLastAuthor({
     workspaceId: owner.sId,
     agentConfigurationId: agentMessageToRender.configuration.sId,
   });
 
+  if (isGlobalAgent) {
+    return (
+      <div className="mb-4 mt-2 flex flex-col gap-2">
+        <Page.P variant="secondary">
+          Submitting feedback will help Dust improve your global agents.
+        </Page.P>
+      </div>
+    );
+  }
+
   return (
     agentLastAuthor && (
       <div className="mb-4 mt-2 flex flex-col gap-2">
         <Page.P variant="secondary">
-          Your feedback is available to editors of the agent. The last agent
-          editor is:
+          <span>
+            Your feedback is available to editors of the agent. The last agent
+            editor is:{" "}
+          </span>
+          <span className="inline-flex items-center gap-2">
+            {agentLastAuthor.image && (
+              <img
+                src={agentLastAuthor.image}
+                alt={agentLastAuthor.firstName}
+                className="h-8 w-8 rounded-full"
+              />
+            )}
+            <span className="font-medium text-foreground dark:text-foreground-night">
+              {`${agentLastAuthor.firstName} ${agentLastAuthor.lastName}`}
+            </span>
+          </span>
         </Page.P>
-        <div className="flex flex-row items-center gap-2">
-          {agentLastAuthor.image && (
-            <img
-              src={agentLastAuthor.image}
-              alt={agentLastAuthor.firstName}
-              className="h-8 w-8 rounded-full"
-            />
-          )}
-          <Page.P variant="primary">
-            {agentLastAuthor.firstName} {agentLastAuthor.lastName}
-          </Page.P>
-        </div>
       </div>
     )
   );

--- a/front/components/assistant/conversation/FeedbackSelectorPopoverContent.tsx
+++ b/front/components/assistant/conversation/FeedbackSelectorPopoverContent.tsx
@@ -1,22 +1,22 @@
 import { Page } from "@dust-tt/sparkle";
 
 import { useAgentConfigurationLastAuthor } from "@app/lib/swr/assistants";
-import type { LightAgentMessageType, LightWorkspaceType } from "@app/types";
+import type { LightWorkspaceType } from "@app/types";
 
 interface FeedbackSelectorPopoverContentProps {
-  agentMessageToRender: LightAgentMessageType;
   owner: LightWorkspaceType;
+  agentConfigurationId: string;
   isGlobalAgent: boolean;
 }
 
 export function FeedbackSelectorPopoverContent({
   owner,
-  agentMessageToRender,
+  agentConfigurationId,
   isGlobalAgent,
 }: FeedbackSelectorPopoverContentProps) {
   const { agentLastAuthor } = useAgentConfigurationLastAuthor({
     workspaceId: owner.sId,
-    agentConfigurationId: agentMessageToRender.configuration.sId,
+    agentConfigurationId,
   });
 
   if (isGlobalAgent) {

--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -4,7 +4,7 @@ import React, { useMemo } from "react";
 import { AgentMessage } from "@app/components/assistant/conversation/AgentMessage";
 import { AttachmentCitation } from "@app/components/assistant/conversation/attachment/AttachmentCitation";
 import { contentFragmentToAttachmentCitation } from "@app/components/assistant/conversation/attachment/utils";
-import type { FeedbackSelectorProps } from "@app/components/assistant/conversation/FeedbackSelector";
+import type { FeedbackSelectorBaseProps } from "@app/components/assistant/conversation/FeedbackSelector";
 import { MentionInvalid } from "@app/components/assistant/conversation/MentionInvalid";
 import { MentionValidationRequired } from "@app/components/assistant/conversation/MentionValidationRequired";
 import { MessageDateIndicator } from "@app/components/assistant/conversation/MessageDateIndicator";
@@ -81,7 +81,7 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
 
     const messageFeedback = context.feedbacksByMessageId[sId];
 
-    const messageFeedbackWithSubmit: FeedbackSelectorProps = {
+    const messageFeedbackWithSubmit: FeedbackSelectorBaseProps = {
       feedback: messageFeedback
         ? {
             thumb: messageFeedback.thumbDirection,
@@ -91,7 +91,6 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
         : null,
       onSubmitThumb,
       isSubmittingThumb,
-      owner: context.owner,
     };
 
     const citations =


### PR DESCRIPTION
## Description

This PR refactors the agent message feedback UI to improve the user experience. The main changes include replacing the popover-based feedback interface with a dialog-based flow, introducing predefined answer options for quick feedback, and improving the feedback experience for global agents. The refactor simplifies the component structure by removing unnecessary state management and callbacks, and provides a more streamlined way for users to submit detailed feedback.

<img width="674" height="693" alt="Screenshot 2026-01-12 at 17 03 13" src="https://github.com/user-attachments/assets/19d2b8b8-4950-43c3-a370-0f3d57e656d0" />

## Risk

Low risk - this is primarily a UI/UX refactor. The feedback submission logic remains unchanged, only the interface is improved. Changes can be easily rolled back if needed.

## Tests

Tested locally in both the extension and front packages to ensure the dialog flows work correctly for both global and non-global agents, and that predefined answers are properly combined with optional text feedback.

## Deploy Plan
