### PR TITLE
[Conversation] Add user message navigation arrows

### DIFF
--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -243,7 +243,7 @@ export const AgentInputBar = ({
   return (
     <div
       className={
-        "max-h-dvh relative z-20 mx-auto flex w-full flex-col py-2 sm:w-full sm:max-w-4xl sm:py-4"
+        "relative z-20 mx-auto flex max-h-dvh w-full flex-col py-2 sm:w-full sm:max-w-4xl sm:py-4"
       }
     >
       <div
@@ -289,7 +289,7 @@ export const AgentInputBar = ({
         <ContentMessageInline
           icon={InformationCircleIcon}
           variant="primary"
-          className="max-h-dvh mb-5 flex w-full"
+          className="mb-5 flex max-h-dvh w-full"
         >
           <span className="font-bold">
             {blockedActions.length} manual action

--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -5,6 +5,7 @@ import {
   Button,
   ContentMessageAction,
   ContentMessageInline,
+  IconButton,
   InformationCircleIcon,
   StopIcon,
 } from "@dust-tt/sparkle";
@@ -135,20 +136,20 @@ export const AgentInputBar = ({
     // Convert listOffset to positive scroll position.
     // listOffset is negative when scrolled down (distance from list top to viewport top).
     const viewportTop = -listOffset;
-    const viewportMiddle = viewportTop + visibleListHeight / 2;
+    const viewportTopQuarter = viewportTop + visibleListHeight / 4;
 
     // Find user messages fully above viewport (for arrow up).
     const fullyAboveIndices = userMessageIndices.filter(
       (idx) => positions[idx] && positions[idx].bottom <= viewportTop
     );
 
-    // Find user messages whose top is below viewport middle (for arrow down).
-    const belowMiddleIndices = userMessageIndices.filter(
-      (idx) => positions[idx] && positions[idx].top >= viewportMiddle
+    // Find user messages whose top is below the top quarter of viewport (for arrow down).
+    const belowTopQuarterIndices = userMessageIndices.filter(
+      (idx) => positions[idx] && positions[idx].top >= viewportTopQuarter
     );
 
     const canUp = fullyAboveIndices.length > 0;
-    const canDown = belowMiddleIndices.length > 0 || bottomOffset > 0;
+    const canDown = belowTopQuarterIndices.length > 0 || bottomOffset > 0;
 
     return {
       canScrollUp: canUp,
@@ -165,9 +166,9 @@ export const AgentInputBar = ({
         }
       },
       scrollToNextUserMessage: () => {
-        if (belowMiddleIndices.length > 0) {
-          // Scroll to the first user message below middle.
-          const targetIndex = belowMiddleIndices[0];
+        if (belowTopQuarterIndices.length > 0) {
+          // Scroll to the first user message below top quarter.
+          const targetIndex = belowTopQuarterIndices[0];
           methods.scrollToItem({
             index: targetIndex,
             align: "start",
@@ -253,18 +254,20 @@ export const AgentInputBar = ({
           top: "-2em",
         }}
       >
-        <Button
-          icon={ArrowUpIcon}
-          variant="outline"
-          onClick={scrollToPreviousUserMessage}
-          disabled={!canScrollUp}
-        />
-        <Button
-          icon={ArrowDownIcon}
-          variant="outline"
-          onClick={scrollToNextUserMessage}
-          disabled={!canScrollDown}
-        />
+        <div className="flex items-center gap-1 rounded-full border border-border bg-white px-1 py-0.5 dark:border-border-night dark:bg-muted-night">
+          <IconButton
+            icon={ArrowUpIcon}
+            onClick={scrollToPreviousUserMessage}
+            disabled={!canScrollUp}
+            size="xs"
+          />
+          <IconButton
+            icon={ArrowDownIcon}
+            onClick={scrollToNextUserMessage}
+            disabled={!canScrollDown}
+            size="xs"
+          />
+        </div>
 
         {showClearButton && (
           <Button


### PR DESCRIPTION
## Description

Replace the single "scroll to bottom" button with two navigation arrows (up/down) that allow navigating between user messages in conversations. Follows a WIP figma [here](https://www.figma.com/design/wJJMfVF6bluurSKfrEuysc/Product---WIP?node-id=643-4462&p=f&t=6h0FsC7pTVbFB0aY-0)

- **Arrow Up**: Scrolls to the previous user message that is completely above the viewport. Disabled when no user messages are fully above.
- **Arrow Down**: Scrolls to the next user message whose top is below the viewport top quarter. If at the last user message but more content exists below, scrolls to the end. Disabled when at bottom with no more content.
- Both arrows are always visible (disabled when using them makes no sense)


https://github.com/user-attachments/assets/900816ff-1ac7-4ec5-8870-5923a523e475

## Tests
Experimented locally on conversations with small and long messages

## Risks

Blast radius: Conversation scroll navigation in all conversations
Risk: low

## Deploy Plan

- deploy front