### PR TITLE
[front] - fix(AB): hide empty categories in data source views

### DIFF
--- a/front/components/agent_builder/capabilities/knowledge/DataSourceCategoryBrowser.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/DataSourceCategoryBrowser.tsx
@@ -126,6 +126,7 @@ function getCategoryRows(
     ? removeNulls(
         DATA_SOURCE_VIEW_CATEGORIES.map((category) =>
           spaceCategories[category] &&
+          spaceCategories[category].count > 0 &&
           hasFeature(CATEGORY_DETAILS[category].flag) &&
           isDataSourceViewCategoryWithoutApps(category)
             ? {

--- a/front/components/spaces/SpaceCategoriesList.tsx
+++ b/front/components/spaces/SpaceCategoriesList.tsx
@@ -105,6 +105,7 @@ export const SpaceCategoriesList = ({
     ? removeNulls(
         DATA_SOURCE_VIEW_CATEGORIES.map((category) =>
           spaceInfo.categories[category] &&
+          spaceInfo.categories[category].count > 0 &&
           hasFeature(CATEGORY_DETAILS[category].flag)
             ? {
                 category,


### PR DESCRIPTION

## Description

This PR:
- Ensures that categories with zero count are not displayed in the data source category browser
- Prevents showing empty categories in the space categories list, enhancing UI cleanliness and relevance

<img width="704" height="290" alt="Screenshot 2026-01-12 at 17 24 01" src="https://github.com/user-attachments/assets/71a7f119-ef78-4b48-87a8-c5b220ffb31d" />

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front
