### PR TITLE
[front] enh(skills): add Knowledge section to `SkillsDetails`

### DIFF
--- a/front/components/editor/SkillInstructionsEditor.tsx
+++ b/front/components/editor/SkillInstructionsEditor.tsx
@@ -10,7 +10,11 @@ import { useEffect, useMemo, useRef } from "react";
 import { AgentInstructionDiffExtension } from "@app/components/editor/extensions/agent_builder/AgentInstructionDiffExtension";
 import { ListItemExtension } from "@app/components/editor/extensions/ListItemExtension";
 import { OrderedListExtension } from "@app/components/editor/extensions/OrderedListExtension";
-import { KnowledgeNode } from "@app/components/editor/extensions/skill_builder/KnowledgeNode";
+import type { KnowledgeItem } from "@app/components/editor/extensions/skill_builder/KnowledgeNode";
+import {
+  KNOWLEDGE_NODE_TYPE,
+  KnowledgeNode,
+} from "@app/components/editor/extensions/skill_builder/KnowledgeNode";
 import { SlashCommandExtension } from "@app/components/editor/extensions/skill_builder/SlashCommandExtension";
 
 export const INSTRUCTIONS_MAXIMUM_CHARACTER_COUNT = 120_000;
@@ -83,6 +87,23 @@ function useEditorService(editor: Editor | null) {
     return {
       getMarkdown() {
         return editor?.getMarkdown() ?? "";
+      },
+
+      getKnowledgeItems(): KnowledgeItem[] {
+        if (!editor) {
+          return [];
+        }
+
+        const items: KnowledgeItem[] = [];
+        editor.state.doc.descendants((node) => {
+          if (node.type.name === KNOWLEDGE_NODE_TYPE) {
+            const selectedItems = node.attrs.selectedItems as KnowledgeItem[];
+            if (selectedItems && selectedItems.length > 0) {
+              items.push(...selectedItems);
+            }
+          }
+        });
+        return items;
       },
 
       setContent(content: string) {

--- a/front/components/editor/extensions/skill_builder/KnowledgeChip.tsx
+++ b/front/components/editor/extensions/skill_builder/KnowledgeChip.tsx
@@ -15,12 +15,18 @@ type KnowledgeNode = Omit<DataSourceViewContentNode, "dataSourceViews"> & {
 };
 
 interface KnowledgeChipProps {
+  color?: React.ComponentProps<typeof AttachmentChip>["color"];
   node: KnowledgeNode;
   onRemove?: () => void;
   title: string;
 }
 
-export function KnowledgeChip({ node, title, onRemove }: KnowledgeChipProps) {
+export function KnowledgeChip({
+  color = "white",
+  node,
+  title,
+  onRemove,
+}: KnowledgeChipProps) {
   const icon =
     isWebsite(node.dataSourceView.dataSource) ||
     isFolder(node.dataSourceView.dataSource)
@@ -41,7 +47,7 @@ export function KnowledgeChip({ node, title, onRemove }: KnowledgeChipProps) {
       icon={{ visual: icon }}
       target="_blank"
       href={node.sourceUrl ?? undefined}
-      color="white"
+      color={color}
       onRemove={onRemove}
       size="xs"
     />

--- a/front/components/editor/extensions/skill_builder/KnowledgeChip.tsx
+++ b/front/components/editor/extensions/skill_builder/KnowledgeChip.tsx
@@ -10,8 +10,11 @@ import { getVisualForDataSourceViewContentNode } from "@app/lib/content_nodes";
 import { isFolder, isWebsite } from "@app/lib/data_sources";
 import type { DataSourceViewContentNode } from "@app/lib/swr/search";
 
-type KnowledgeNode = Omit<DataSourceViewContentNode, "dataSourceViews"> & {
-  dataSourceView: DataSourceViewContentNode["dataSourceViews"][0];
+type KnowledgeNode = Omit<
+  DataSourceViewContentNode,
+  "dataSourceViews" | "dataSource"
+> & {
+  dataSourceView: DataSourceViewContentNode["dataSourceViews"][number];
 };
 
 interface KnowledgeChipProps {

--- a/front/components/editor/extensions/skill_builder/KnowledgeNodeView.tsx
+++ b/front/components/editor/extensions/skill_builder/KnowledgeNodeView.tsx
@@ -134,14 +134,7 @@ export function KnowledgeDisplayComponent({
 
   // At this point we must have a full item with node data.
   return (
-    <KnowledgeChip
-      node={{
-        ...item.node,
-        dataSource: item.node.dataSourceView.dataSource,
-      }}
-      onRemove={onRemove}
-      title={item.label}
-    />
+    <KnowledgeChip node={item.node} onRemove={onRemove} title={item.label} />
   );
 }
 

--- a/front/components/skills/SkillInfoTab.tsx
+++ b/front/components/skills/SkillInfoTab.tsx
@@ -1,7 +1,10 @@
 import { Chip, Separator, Spinner, Tooltip } from "@dust-tt/sparkle";
 import sortBy from "lodash/sortBy";
-import { useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 
+import { KnowledgeChip } from "@app/components/editor/extensions/skill_builder/KnowledgeChip";
+import type { KnowledgeItem } from "@app/components/editor/extensions/skill_builder/KnowledgeNode";
+import { isFullKnowledgeItem } from "@app/components/editor/extensions/skill_builder/KnowledgeNode";
 import { SkillInstructionsReadOnlyEditor } from "@app/components/skills/SkillInstructionsReadOnlyEditor";
 import {
   getMcpServerViewDescription,
@@ -27,6 +30,8 @@ export function SkillInfoTab({
   spaces,
   showDescription = true,
 }: SkillInfoTabProps) {
+  const [knowledgeItems, setKnowledgeItems] = useState<KnowledgeItem[]>([]);
+
   const shouldLoadSpaces = skill.requestedSpaceIds.length > 0;
   const { spaces: spacesFromHook, isSpacesLoading } = useSpaces({
     workspaceId: owner.sId,
@@ -57,8 +62,15 @@ export function SkillInfoTab({
     [requestedSpaces]
   );
 
+  const handleKnowledgeItemsChange = useCallback((items: KnowledgeItem[]) => {
+    setKnowledgeItems(items);
+  }, []);
+
   const showSeparator =
-    !!skill.instructions || sortedMCPServerViews.length > 0 || shouldLoadSpaces;
+    !!skill.instructions ||
+    knowledgeItems.length > 0 ||
+    sortedMCPServerViews.length > 0 ||
+    shouldLoadSpaces;
 
   return (
     <div className="flex flex-col gap-4">
@@ -78,7 +90,25 @@ export function SkillInfoTab({
           <SkillInstructionsReadOnlyEditor
             content={skill.instructions}
             owner={owner}
+            onKnowledgeItemsChange={handleKnowledgeItemsChange}
           />
+        </div>
+      )}
+      {knowledgeItems.length > 0 && (
+        <div className="flex flex-col gap-5">
+          <div className="heading-lg text-foreground dark:text-foreground-night">
+            Knowledge
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {knowledgeItems.filter(isFullKnowledgeItem).map((item) => (
+              <KnowledgeChip
+                key={item.nodeId}
+                node={item.node}
+                title={item.label}
+                color="primary"
+              />
+            ))}
+          </div>
         </div>
       )}
       {sortedMCPServerViews.length > 0 && (

--- a/front/components/skills/SkillInstructionsReadOnlyEditor.tsx
+++ b/front/components/skills/SkillInstructionsReadOnlyEditor.tsx
@@ -1,4 +1,7 @@
+import { useEffect } from "react";
+
 import { SpacesProvider } from "@app/components/agent_builder/SpacesContext";
+import type { KnowledgeItem } from "@app/components/editor/extensions/skill_builder/KnowledgeNode";
 import {
   SkillInstructionsEditorContent,
   useSkillInstructionsEditor,
@@ -8,16 +11,25 @@ import type { LightWorkspaceType } from "@app/types";
 interface SkillInstructionsReadOnlyEditorProps {
   content: string;
   owner: LightWorkspaceType;
+  onKnowledgeItemsChange?: (items: KnowledgeItem[]) => void;
 }
 
 export function SkillInstructionsReadOnlyEditor({
   content,
   owner,
+  onKnowledgeItemsChange,
 }: SkillInstructionsReadOnlyEditorProps) {
-  const { editor } = useSkillInstructionsEditor({
+  const { editor, editorService } = useSkillInstructionsEditor({
     content,
     isReadOnly: true,
   });
+
+  useEffect(() => {
+    if (editor && onKnowledgeItemsChange) {
+      const items = editorService.getKnowledgeItems();
+      onKnowledgeItemsChange(items);
+    }
+  }, [editor, editorService, onKnowledgeItemsChange]);
 
   return (
     <SpacesProvider owner={owner}>

--- a/front/components/skills/SkillInstructionsReadOnlyEditor.tsx
+++ b/front/components/skills/SkillInstructionsReadOnlyEditor.tsx
@@ -25,10 +25,21 @@ export function SkillInstructionsReadOnlyEditor({
   });
 
   useEffect(() => {
-    if (editor && onKnowledgeItemsChange) {
+    if (!editor || !onKnowledgeItemsChange) {
+      return;
+    }
+
+    const updateItems = () => {
       const items = editorService.getKnowledgeItems();
       onKnowledgeItemsChange(items);
-    }
+    };
+
+    updateItems();
+    editor.on("update", updateItems);
+
+    return () => {
+      editor.off("update", updateItems);
+    };
   }, [editor, editorService, onKnowledgeItemsChange]);
 
   return (


### PR DESCRIPTION
## Description

- Figma [here](https://www.figma.com/design/wJJMfVF6bluurSKfrEuysc/Product---WIP?node-id=860-53446&t=A6xhoHyVYRvGrL8v-0).
- This PR adds a Knowledge section to the Skills detail sheet.
- This section shows the nodes that were references in the skill's instructions.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
