### PR TITLE
Fix: truncate index name to avoid overflow breaking the migration script

### DIFF
--- a/connectors/migrations/db/migration_110.sql
+++ b/connectors/migrations/db/migration_110.sql
@@ -1,14 +1,19 @@
 -- Migration created on Dec 19, 2025
 -- Replace URL-based indexes with MD5(url)-based indexes to handle long URLs
-
 -- webcrawler_pages: create new MD5 index, drop old index
-CREATE UNIQUE INDEX CONCURRENTLY "webcrawler_pages_url_md5_connector_id_webcrawler_configuration_id"
-  ON "webcrawler_pages" (md5("url"), "connectorId", "webcrawlerConfigurationId");
+CREATE UNIQUE INDEX CONCURRENTLY "webcrawler_pages_url_md5_connector_id_webcrawler_configuration_" ON "webcrawler_pages" (
+  md5 ("url"),
+  "connectorId",
+  "webcrawlerConfigurationId"
+);
 
 DROP INDEX CONCURRENTLY IF EXISTS "webcrawler_pages_url_connector_id_webcrawler_configuration_id";
 
 -- webcrawler_folders: create new MD5 index, drop old index
-CREATE UNIQUE INDEX CONCURRENTLY "webcrawler_folders_url_md5_connector_id_webcrawler_configuration_id"
-  ON "webcrawler_folders" (md5("url"), "connectorId", "webcrawlerConfigurationId");
+CREATE UNIQUE INDEX CONCURRENTLY "webcrawler_folders_url_md5_connector_id_webcrawler_configuratio" ON "webcrawler_folders" (
+  md5 ("url"),
+  "connectorId",
+  "webcrawlerConfigurationId"
+);
 
 DROP INDEX CONCURRENTLY IF EXISTS "webcrawler_folders_url_connector_id_webcrawler_configuration_id";

--- a/connectors/migrations/db/migration_111.sql
+++ b/connectors/migrations/db/migration_111.sql
@@ -1,10 +1,13 @@
 -- Migration created on Dec 19, 2025
 -- Drop indexes from migration_110, add urlMd5 columns (nullable for now)
-
 -- Drop the md5-based indexes created in migration_110
-DROP INDEX CONCURRENTLY IF EXISTS "webcrawler_pages_url_md5_connector_id_webcrawler_configuration_id";
-DROP INDEX CONCURRENTLY IF EXISTS "webcrawler_folders_url_md5_connector_id_webcrawler_configuration_id";
+DROP INDEX CONCURRENTLY IF EXISTS "webcrawler_pages_url_md5_connector_id_webcrawler_configuration_";
+
+DROP INDEX CONCURRENTLY IF EXISTS "webcrawler_folders_url_md5_connector_id_webcrawler_configuratio";
 
 -- Add urlMd5 columns (nullable)
-ALTER TABLE "webcrawler_pages" ADD COLUMN "urlMd5" VARCHAR(32);
-ALTER TABLE "webcrawler_folders" ADD COLUMN "urlMd5" VARCHAR(32);
+ALTER TABLE "webcrawler_pages"
+ADD COLUMN "urlMd5" VARCHAR(32);
+
+ALTER TABLE "webcrawler_folders"
+ADD COLUMN "urlMd5" VARCHAR(32);

--- a/connectors/migrations/db/migration_112.sql
+++ b/connectors/migrations/db/migration_112.sql
@@ -1,24 +1,45 @@
 -- Migration created on Dec 19, 2025
 -- Backfill urlMd5, add constraints, set NOT NULL
-
 -- Backfill urlMd5 for webcrawler_pages
-UPDATE "webcrawler_pages" SET "urlMd5" = md5("url") WHERE "urlMd5" IS NULL;
-ALTER TABLE "webcrawler_pages" ALTER COLUMN "urlMd5" SET NOT NULL;
+UPDATE "webcrawler_pages"
+SET
+  "urlMd5" = md5 ("url")
+WHERE
+  "urlMd5" IS NULL;
+
+ALTER TABLE "webcrawler_pages"
+ALTER COLUMN "urlMd5"
+SET
+  NOT NULL;
 
 -- Add new constraint, drop old constraint for webcrawler_pages
-ALTER TABLE "webcrawler_pages"
-  ADD CONSTRAINT "webcrawler_pages_url_md5_connector_id_webcrawler_configuration_id"
-  UNIQUE ("urlMd5", "connectorId", "webcrawlerConfigurationId");
+ALTER TABLE "webcrawler_pages" ADD CONSTRAINT "webcrawler_pages_url_md5_connector_id_webcrawler_configuration_" UNIQUE (
+  "urlMd5",
+  "connectorId",
+  "webcrawlerConfigurationId"
+);
 
-ALTER TABLE "webcrawler_pages" DROP CONSTRAINT IF EXISTS "webcrawler_pages_url_connector_id_webcrawler_configuration_id";
+ALTER TABLE "webcrawler_pages"
+DROP CONSTRAINT IF EXISTS "webcrawler_pages_url_connector_id_webcrawler_configuration_id";
 
 -- Backfill urlMd5 for webcrawler_folders
-UPDATE "webcrawler_folders" SET "urlMd5" = md5("url") WHERE "urlMd5" IS NULL;
-ALTER TABLE "webcrawler_folders" ALTER COLUMN "urlMd5" SET NOT NULL;
+UPDATE "webcrawler_folders"
+SET
+  "urlMd5" = md5 ("url")
+WHERE
+  "urlMd5" IS NULL;
+
+ALTER TABLE "webcrawler_folders"
+ALTER COLUMN "urlMd5"
+SET
+  NOT NULL;
 
 -- Add new constraint, drop old constraint for webcrawler_folders
-ALTER TABLE "webcrawler_folders"
-  ADD CONSTRAINT "webcrawler_folders_url_md5_connector_id_webcrawler_configuration_id"
-  UNIQUE ("urlMd5", "connectorId", "webcrawlerConfigurationId");
+ALTER TABLE "webcrawler_folders" ADD CONSTRAINT "webcrawler_folders_url_md5_connector_id_webcrawler_configuratio" UNIQUE (
+  "urlMd5",
+  "connectorId",
+  "webcrawlerConfigurationId"
+);
 
-ALTER TABLE "webcrawler_folders" DROP CONSTRAINT IF EXISTS "webcrawler_folders_url_connector_id_webcrawler_configuration_id";
+ALTER TABLE "webcrawler_folders"
+DROP CONSTRAINT IF EXISTS "webcrawler_folders_url_connector_id_webcrawler_configuration_id";

--- a/connectors/src/lib/models/webcrawler.ts
+++ b/connectors/src/lib/models/webcrawler.ts
@@ -183,6 +183,7 @@ WebCrawlerFolderModel.init(
       {
         unique: true,
         fields: ["urlMd5", "connectorId", "webcrawlerConfigurationId"],
+        name: "webcrawler_folders_url_md5_connector_id_webcrawler_configuratio",
       },
       {
         unique: true,
@@ -258,6 +259,7 @@ WebCrawlerPageModel.init(
       {
         unique: true,
         fields: ["urlMd5", "connectorId", "webcrawlerConfigurationId"],
+        name: "webcrawler_pages_url_md5_connector_id_webcrawler_configuration_",
       },
       {
         unique: true,


### PR DESCRIPTION
## Description

If the index name is too long, the migration script is stuck because the name in the DB do not match the name inferred by sequelize.

## Tests

Local

## Risk

Low

## Deploy Plan

Just merge