### PR TITLE
[sparkle] chore(ActionCard): allow passing colors

### DIFF
--- a/front/components/agent_builder/capabilities/capabilities_sheet/SkillCard.tsx
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/SkillCard.tsx
@@ -1,7 +1,11 @@
 import { ActionCard } from "@dust-tt/sparkle";
 import React from "react";
 
-import { getSkillIcon } from "@app/lib/skill";
+import {
+  getSkillIcon,
+  SKILL_AVATAR_BACKGROUND_COLOR,
+  SKILL_AVATAR_ICON_COLOR,
+} from "@app/lib/skill";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 
 interface SkillCardProps {
@@ -20,6 +24,8 @@ export function SkillCard({
   return (
     <ActionCard
       icon={getSkillIcon(skill.icon)}
+      iconBackgroundColor={SKILL_AVATAR_BACKGROUND_COLOR}
+      iconColor={SKILL_AVATAR_ICON_COLOR}
       label={skill.name}
       description={skill.userFacingDescription}
       isSelected={isSelected}

--- a/front/components/agent_builder/capabilities/capabilities_sheet/SkillCard.tsx
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/SkillCard.tsx
@@ -1,11 +1,7 @@
 import { ActionCard } from "@dust-tt/sparkle";
 import React from "react";
 
-import {
-  getSkillIcon,
-  SKILL_AVATAR_BACKGROUND_COLOR,
-  SKILL_AVATAR_ICON_COLOR,
-} from "@app/lib/skill";
+import { getSkillIcon } from "@app/lib/skill";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 
 interface SkillCardProps {
@@ -24,8 +20,6 @@ export function SkillCard({
   return (
     <ActionCard
       icon={getSkillIcon(skill.icon)}
-      iconBackgroundColor={SKILL_AVATAR_BACKGROUND_COLOR}
-      iconColor={SKILL_AVATAR_ICON_COLOR}
       label={skill.name}
       description={skill.userFacingDescription}
       isSelected={isSelected}

--- a/sparkle/src/components/ActionCard.tsx
+++ b/sparkle/src/components/ActionCard.tsx
@@ -10,6 +10,8 @@ const FADE_TRANSITION_CLASSES =
 
 export interface ActionCardProps {
   icon: React.ComponentType;
+  iconBackgroundColor?: string;
+  iconColor?: string;
   label: string;
   description: string | React.ReactNode;
   isSelected: boolean;
@@ -28,6 +30,8 @@ export const ActionCard = React.forwardRef<HTMLDivElement, ActionCardProps>(
   (
     {
       icon,
+      iconBackgroundColor,
+      iconColor,
       label,
       description,
       isSelected,
@@ -56,7 +60,12 @@ export const ActionCard = React.forwardRef<HTMLDivElement, ActionCardProps>(
           <div className="s-flex s-flex-col">
             <div className="s-mb-2 s-flex s-items-center s-justify-between s-gap-2">
               <div className="s-flex s-items-center s-gap-2">
-                <Avatar icon={icon} size="sm" />
+                <Avatar
+                  icon={icon}
+                  size="sm"
+                  backgroundColor={iconBackgroundColor}
+                  iconColor={iconColor}
+                />
                 <span className="s-text-sm s-font-medium">{label}</span>
                 {isSelected && (
                   <Chip


### PR DESCRIPTION
## Description

- Follow up on https://github.com/dust-tt/dust/pull/19933.
- This PR allows passing a background and line colors to an `ActionCard`. 
- The goal is to update the background color for skills in the Agent Builder capabilities sheet like so:

<img width="685" height="990" alt="image" src="https://github.com/user-attachments/assets/12660f75-5961-4d24-839c-3c1beb30303c" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Publish sparkle.
