### PR TITLE
[front] fix(skills): update icon color in capabilities sheet

### DIFF
--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "^1.2.3",
-        "@dust-tt/sparkle": "^0.5.20",
+        "@dust-tt/sparkle": "^0.5.21",
         "@frontapp/plugin-sdk": "^1.8.1",
         "@modelcontextprotocol/sdk": "^1.9.0",
         "@tailwindcss/forms": "^0.5.9",
@@ -1258,9 +1258,9 @@
       }
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.5.20",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.5.20.tgz",
-      "integrity": "sha512-ScyDnulN7L6rEDVHsnUd5B1H7qn5vNls3Y1XlALOtygolRZIt8UydYutCdrw+4+S7M2YGssSUUmpO9B07RDwlw==",
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.5.21.tgz",
+      "integrity": "sha512-2v8HP0XV7pxLWHBeQZ8MCL1xp7egRG8JuscGk40EoGspGC2DMTn3EHzEex+DRG136Q2tA4pqfLmNgcWLiAfg6g==",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/extension/package.json
+++ b/extension/package.json
@@ -62,7 +62,7 @@
   "dependencies": {
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "^1.2.3",
-    "@dust-tt/sparkle": "^0.5.20",
+    "@dust-tt/sparkle": "^0.5.21",
     "@frontapp/plugin-sdk": "^1.8.1",
     "@modelcontextprotocol/sdk": "^1.9.0",
     "@tailwindcss/forms": "^0.5.9",

--- a/front/components/agent_builder/capabilities/capabilities_sheet/SkillCard.tsx
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/SkillCard.tsx
@@ -1,7 +1,11 @@
 import { ActionCard } from "@dust-tt/sparkle";
 import React from "react";
 
-import { getSkillIcon } from "@app/lib/skill";
+import {
+  getSkillIcon,
+  SKILL_AVATAR_BACKGROUND_COLOR,
+  SKILL_AVATAR_ICON_COLOR,
+} from "@app/lib/skill";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 
 interface SkillCardProps {
@@ -20,6 +24,8 @@ export function SkillCard({
   return (
     <ActionCard
       icon={getSkillIcon(skill.icon)}
+      iconBackgroundColor={SKILL_AVATAR_BACKGROUND_COLOR}
+      iconColor={SKILL_AVATAR_ICON_COLOR}
       label={skill.name}
       description={skill.userFacingDescription}
       isSelected={isSelected}

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -13,7 +13,7 @@
         "@contentful/rich-text-types": "^17.2.5",
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.5.20",
+        "@dust-tt/sparkle": "^0.5.21",
         "@elastic/elasticsearch": "^8.15.0",
         "@elevenlabs/elevenlabs-js": "^2.17.0",
         "@emoji-mart/data": "^1.2.1",
@@ -1325,9 +1325,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.5.20",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.5.20.tgz",
-      "integrity": "sha512-ScyDnulN7L6rEDVHsnUd5B1H7qn5vNls3Y1XlALOtygolRZIt8UydYutCdrw+4+S7M2YGssSUUmpO9B07RDwlw==",
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.5.21.tgz",
+      "integrity": "sha512-2v8HP0XV7pxLWHBeQZ8MCL1xp7egRG8JuscGk40EoGspGC2DMTn3EHzEex+DRG136Q2tA4pqfLmNgcWLiAfg6g==",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/front/package.json
+++ b/front/package.json
@@ -38,7 +38,7 @@
     "@contentful/rich-text-types": "^17.2.5",
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.5.20",
+    "@dust-tt/sparkle": "^0.5.21",
     "@elastic/elasticsearch": "^8.15.0",
     "@elevenlabs/elevenlabs-js": "^2.17.0",
     "@emoji-mart/data": "^1.2.1",


### PR DESCRIPTION
## Description

- front counterpart of https://github.com/dust-tt/dust/pull/19960
- This PR updates the avatar colors for skills in the capabilities sheet in Agent Builder.

<img width="685" height="990" alt="image" src="https://github.com/user-attachments/assets/12660f75-5961-4d24-839c-3c1beb30303c" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
