### PR TITLE
[front] refactor(skills): replace custom `Avatar` with `getSkillAvatarIcon`

### DIFF
--- a/front/components/skill_builder/SimilarSkillsDisplay.tsx
+++ b/front/components/skill_builder/SimilarSkillsDisplay.tsx
@@ -1,11 +1,10 @@
 import {
-  Avatar,
   ContentMessage,
   InformationCircleIcon,
   Spinner,
 } from "@dust-tt/sparkle";
 
-import { getSkillIcon } from "@app/lib/skill";
+import { getSkillAvatarIcon } from "@app/lib/skill";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 
 type SimilarSkillsDisplayProps = {
@@ -38,23 +37,23 @@ export function SimilarSkillsDisplay({
       icon={InformationCircleIcon}
     >
       <div className="mt-2 space-y-3">
-        {similarSkills.map((skill) => (
-          <div key={skill.sId} className="flex items-start gap-2">
-            <Avatar
-              name={skill.name}
-              icon={getSkillIcon(skill.icon)}
-              size="xs"
-            />
-            <div className="flex flex-col">
-              <span className="text-sm font-medium text-foreground dark:text-foreground-night">
-                {skill.name}
-              </span>
-              <span className="text-xs text-muted-foreground dark:text-muted-foreground-night">
-                {skill.agentFacingDescription}
-              </span>
+        {similarSkills.map((skill) => {
+          const SkillAvatar = getSkillAvatarIcon(skill.icon);
+
+          return (
+            <div key={skill.sId} className="flex items-start gap-2">
+              <SkillAvatar name={skill.name} size="xs" />
+              <div className="flex flex-col">
+                <span className="text-sm font-medium text-foreground dark:text-foreground-night">
+                  {skill.name}
+                </span>
+                <span className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+                  {skill.agentFacingDescription}
+                </span>
+              </div>
             </div>
-          </div>
-        ))}
+          );
+        })}
         {isLoading && (
           <div className="flex items-center gap-2 text-sm text-muted-foreground dark:text-muted-foreground-night">
             <Spinner size="xs" />

--- a/front/components/skills/SkillDetailsSheet.tsx
+++ b/front/components/skills/SkillDetailsSheet.tsx
@@ -17,13 +17,12 @@ import {
 import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
 import { useState } from "react";
 
-import { ResourceAvatar } from "@app/components/resources/resources_icons";
 import { ExtendedSkillBadge } from "@app/components/skills/ExtendedSkillBadge";
 import { RestoreSkillDialog } from "@app/components/skills/RestoreSkillDialog";
 import { SkillDetailsButtonBar } from "@app/components/skills/SkillDetailsButtonBar";
 import { SkillEditorsTab } from "@app/components/skills/SkillEditorsTab";
 import { SkillInfoTab } from "@app/components/skills/SkillInfoTab";
-import { getSkillIcon, hasRelations } from "@app/lib/skill";
+import { getSkillAvatarIcon, hasRelations } from "@app/lib/skill";
 import type { UserType, WorkspaceType } from "@app/types";
 import type {
   SkillRelations,
@@ -143,14 +142,13 @@ const DescriptionSection = ({
       day: "2-digit",
     });
 
+  const SkillAvatar = getSkillAvatarIcon(skill.icon);
+
   return (
     <div className="flex flex-col items-center gap-4 pt-4">
       <div className="relative flex items-center justify-center">
-        <ResourceAvatar
-          icon={getSkillIcon(skill.icon)}
-          name="Skill avatar"
-          size="xl"
-        />
+        {/* eslint-disable-next-line react-hooks/static-components */}
+        <SkillAvatar name="Skill avatar" size="xl" />
       </div>
 
       {/* Title and edit info */}

--- a/front/components/skills/SuggestedSkillsSection.tsx
+++ b/front/components/skills/SuggestedSkillsSection.tsx
@@ -9,13 +9,8 @@ import {
 import { useRouter } from "next/router";
 import { useState } from "react";
 
-import { ResourceAvatar } from "@app/components/resources/resources_icons";
 import { ArchiveSkillDialog } from "@app/components/skills/ArchiveSkillDialog";
-import {
-  getSkillIcon,
-  SKILL_AVATAR_BACKGROUND_COLOR,
-  SKILL_AVATAR_ICON_COLOR,
-} from "@app/lib/skill";
+import { getSkillAvatarIcon } from "@app/lib/skill";
 import { useUpdateSkillEditors } from "@app/lib/swr/skill_editors";
 import { getSkillBuilderRoute } from "@app/lib/utils/router";
 import type { LightWorkspaceType, UserType } from "@app/types";
@@ -36,6 +31,7 @@ function SuggestedSkillCard({
 }: SuggestedSkillCardProps) {
   const router = useRouter();
   const [isArchiveDialogOpen, setIsArchiveDialogOpen] = useState(false);
+  const SkillAvatar = getSkillAvatarIcon(skill.icon);
   const updateSkillEditors = useUpdateSkillEditors({
     owner,
     skillId: skill.sId,
@@ -71,12 +67,8 @@ function SuggestedSkillCard({
         <div className="flex h-full w-full flex-col justify-between gap-3">
           <div className="flex flex-col">
             <div className="mb-2 flex items-center gap-2">
-              <ResourceAvatar
-                icon={getSkillIcon(skill.icon)}
-                size="sm"
-                backgroundColor={SKILL_AVATAR_BACKGROUND_COLOR}
-                iconColor={SKILL_AVATAR_ICON_COLOR}
-              />
+              {/* eslint-disable-next-line react-hooks/static-components */}
+              <SkillAvatar size="sm" />
               <span className="truncate text-sm font-medium">{skill.name}</span>
             </div>
             <p className="line-clamp-2 text-sm text-muted-foreground dark:text-muted-foreground-night">

--- a/front/lib/resources/skill/global/frames.ts
+++ b/front/lib/resources/skill/global/frames.ts
@@ -3,7 +3,7 @@ import type { GlobalSkillDefinition } from "@app/lib/resources/skill/global/regi
 
 export const framesSkill = {
   sId: "frames",
-  name: "Create Frames",
+  name: "Frames",
   userFacingDescription:
     "Turn insights into interactive dashboards and presentations your team can explore, customize, and share. Living documents that adapt to different stakeholders.",
   agentFacingDescription:

--- a/front/lib/resources/skill/global/frames.ts
+++ b/front/lib/resources/skill/global/frames.ts
@@ -3,7 +3,7 @@ import type { GlobalSkillDefinition } from "@app/lib/resources/skill/global/regi
 
 export const framesSkill = {
   sId: "frames",
-  name: "Frames",
+  name: "Create Frames",
   userFacingDescription:
     "Turn insights into interactive dashboards and presentations your team can explore, customize, and share. Living documents that adapt to different stakeholders.",
   agentFacingDescription:


### PR DESCRIPTION
## Description

- This PR unifies the code paths for generating an avatar for a skill with `getSkillAvatarIcon`.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
