### PR TITLE
[front] fix(skills): update frames skill display name

### DIFF
--- a/front/lib/resources/skill/global/discover_tools.ts
+++ b/front/lib/resources/skill/global/discover_tools.ts
@@ -7,38 +7,6 @@ import type { Authenticator } from "@app/lib/auth";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import type { GlobalSkillDefinition } from "@app/lib/resources/skill/global/registry";
 
-export function buildDiscoverToolsInstructions(
-  availableToolsets: MCPServerViewResource[]
-): string {
-  const toolsetsList = availableToolsets
-    // Sort by display name to ensure consistent order for LLM cache optimization.
-    .sort((a, b) => {
-      const aView = a.toJSON();
-      const bView = b.toJSON();
-      return getMcpServerViewDisplayName(aView).localeCompare(
-        getMcpServerViewDisplayName(bView)
-      );
-    })
-    .map((toolset) => {
-      const mcpServerView = toolset.toJSON();
-      const sId = mcpServerView.sId;
-      const displayName = getMcpServerViewDisplayName(mcpServerView);
-      const description = getMcpServerViewDescription(mcpServerView);
-      return `- **${displayName}** (toolsetId: \`${sId}\`): ${description}`;
-    })
-    .join("\n");
-
-  return `The "toolsets" tools allow listing and enabling additional tools.
-
-<available_toolsets>
-${toolsetsList.length > 0 ? toolsetsList : "No additional toolsets are currently available."}
-</available_toolsets>
-
-When encountering any request that might benefit from specialized tools, review the available toolsets above.
-Enable relevant toolsets using \`toolsets__enable\` with the toolsetId (shown in backticks) before attempting to fulfill the request.
-Never assume or reply that you cannot do something before checking if there's a relevant toolset available.`;
-}
-
 export const discoverToolsSkill = {
   sId: "discover_tools",
   name: "Discover Tools",
@@ -68,3 +36,35 @@ export const discoverToolsSkill = {
   icon: "ToolsIcon",
   isAutoEnabled: true,
 } as const satisfies GlobalSkillDefinition;
+
+export function buildDiscoverToolsInstructions(
+  availableToolsets: MCPServerViewResource[]
+): string {
+  const toolsetsList = availableToolsets
+    // Sort by display name to ensure a consistent order for LLM cache optimization.
+    .sort((a, b) => {
+      const aView = a.toJSON();
+      const bView = b.toJSON();
+      return getMcpServerViewDisplayName(aView).localeCompare(
+        getMcpServerViewDisplayName(bView)
+      );
+    })
+    .map((toolset) => {
+      const mcpServerView = toolset.toJSON();
+      const sId = mcpServerView.sId;
+      const displayName = getMcpServerViewDisplayName(mcpServerView);
+      const description = getMcpServerViewDescription(mcpServerView);
+      return `- **${displayName}** (toolsetId: \`${sId}\`): ${description}`;
+    })
+    .join("\n");
+
+  return `The "toolsets" tools allow listing and enabling additional tools.
+
+<available_toolsets>
+${toolsetsList.length > 0 ? toolsetsList : "No additional toolsets are currently available."}
+</available_toolsets>
+
+When encountering any request that might benefit from specialized tools, review the available toolsets above.
+Enable relevant toolsets using \`toolsets__enable\` with the toolsetId (shown in backticks) before attempting to fulfill the request.
+Never assume or reply that you cannot do something before checking if there's a relevant toolset available.`;
+}

--- a/front/lib/resources/skill/global/frames.ts
+++ b/front/lib/resources/skill/global/frames.ts
@@ -3,7 +3,7 @@ import type { GlobalSkillDefinition } from "@app/lib/resources/skill/global/regi
 
 export const framesSkill = {
   sId: "frames",
-  name: "Frames",
+  name: "Create Frames",
   userFacingDescription:
     "Turn insights into interactive dashboards and presentations your team can explore, customize, and share. Living documents that adapt to different stakeholders.",
   agentFacingDescription:

--- a/front/lib/resources/skill/global/registry.ts
+++ b/front/lib/resources/skill/global/registry.ts
@@ -84,10 +84,6 @@ function matchesFilter<T>(value: T, filter: T | T[]): boolean {
 }
 
 export class GlobalSkillsRegistry {
-  static listAll(): readonly GlobalSkillDefinition[] {
-    return GLOBAL_SKILLS_ARRAY;
-  }
-
   static getById(sId: string): GlobalSkillDefinition | undefined {
     return GLOBAL_SKILLS_BY_ID.get(sId);
   }

--- a/front/types/shared/utils/string_utils.ts
+++ b/front/types/shared/utils/string_utils.ts
@@ -147,7 +147,7 @@ export function asDisplayToolName(name?: string | null) {
   }
 
   // TODO(skills-GA 2026-01-13): remove this renaming (all 3 below) once we GA.
-  // The tool will be named interactive content, Frames the the skill
+  // The tool will be named interactive content, Frames the skill
   // that wraps these tools with React client-side code generation.
 
   if (name === "interactive_content") {

--- a/front/types/shared/utils/string_utils.ts
+++ b/front/types/shared/utils/string_utils.ts
@@ -154,7 +154,8 @@ export function asDisplayToolName(name?: string | null) {
 
   // TODO(skills-GA 2026-01-13): remove this renaming once we GA.
   // The tool will be named interactive content, Frames the the skill
-  // wrapping it that makes is easy
+  // that wraps these tools with React client-side code generation.
+
   if (name === "interactive_content") {
     return "Create Frames";
   }
@@ -163,16 +164,16 @@ export function asDisplayToolName(name?: string | null) {
     return "Go deep";
   }
 
+  if (name === "slideshow") {
+    return "Create Slideshows";
+  }
+
   if (name === "image_generation") {
     return "Create Images";
   }
 
   if (name === "file_generation") {
     return "Create Files";
-  }
-
-  if (name === "slideshow") {
-    return "Create Slideshows";
   }
 
   // Override the name to avoids having "Query Tables V2" show up in the UI. Ideally, we would

--- a/front/types/shared/utils/string_utils.ts
+++ b/front/types/shared/utils/string_utils.ts
@@ -176,7 +176,7 @@ export function asDisplayToolName(name?: string | null) {
     return "Create Files";
   }
 
-  // Override the name to avoids having "Query Tables V2" show up in the UI. Ideally, we would
+  // Override the name to avoid having "Query Tables V2" show up in the UI. Ideally, we would
   // rename the tool internally to just "query_tables", but that raises more potential risks,
   // in particular with the Extension logic in extension/ui/components/actions/mcp/details/MCPActionDetails.tsx,
   // which has some hardcoded logic that could be affected.

--- a/front/types/shared/utils/string_utils.ts
+++ b/front/types/shared/utils/string_utils.ts
@@ -146,7 +146,7 @@ export function asDisplayToolName(name?: string | null) {
     return "";
   }
 
-  // TODO(skills-GA 2026-01-13): remove this renaming once we GA.
+  // TODO(skills-GA 2026-01-13): remove this renaming (all 3 below) once we GA.
   // The tool will be named interactive content, Frames the the skill
   // that wraps these tools with React client-side code generation.
 

--- a/front/types/shared/utils/string_utils.ts
+++ b/front/types/shared/utils/string_utils.ts
@@ -152,8 +152,15 @@ export function asDisplayToolName(name?: string | null) {
     return "";
   }
 
+  // TODO(skills-GA 2026-01-13): remove this renaming once we GA.
+  // The tool will be named interactive content, Frames the the skill
+  // wrapping it that makes is easy
   if (name === "interactive_content") {
     return "Create Frames";
+  }
+
+  if (name === "deep_dive") {
+    return "Go deep";
   }
 
   if (name === "image_generation") {
@@ -166,10 +173,6 @@ export function asDisplayToolName(name?: string | null) {
 
   if (name === "slideshow") {
     return "Create Slideshows";
-  }
-
-  if (name === "deep_dive") {
-    return "Go deep";
   }
 
   // Override the name to avoids having "Query Tables V2" show up in the UI. Ideally, we would

--- a/front/types/shared/utils/string_utils.ts
+++ b/front/types/shared/utils/string_utils.ts
@@ -123,8 +123,6 @@ const SPECIAL_CASES = {
   github: "GitHub",
   hubspot: "HubSpot",
   mcp: "MCP",
-  // TODO(cc): remove this once we have settled on a name.
-  "interactive content": "Frame",
 };
 
 // Create a single regex pattern for all special cases

--- a/front/types/shared/utils/string_utils.ts
+++ b/front/types/shared/utils/string_utils.ts
@@ -86,10 +86,6 @@ export function redactString(str: string, n: number) {
   return redacted;
 }
 
-export function isRedacted(str: string) {
-  return str.includes("•");
-}
-
 export function truncate(text: string, length: number, omission = "...") {
   return text.length > length
     ? `${text.substring(0, length - omission.length)}${omission}`


### PR DESCRIPTION
## Description

- This PR updates the display name of the Frames skill from "Frames" to "Create Frames".
- Every other change is purely cosmetic/todo additions (file reordering, unused functions cleanup).

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
