### PR TITLE
Add Startup Probe To Prevent Traffic Before Dependencies Ready

### DIFF
--- a/front/lib/api/redis-hybrid-manager.ts
+++ b/front/lib/api/redis-hybrid-manager.ts
@@ -574,6 +574,15 @@ class RedisHybridManager {
       },
     };
   }
+
+  /**
+   * Ping Redis to check connectivity.
+   * Used by startup probe to verify Redis is accessible before accepting traffic.
+   */
+  public async ping(): Promise<void> {
+    const client = await this.getStreamAndPublishClient();
+    await client.ping();
+  }
 }
 
 export const getRedisHybridManager = () => {

--- a/front/pages/api/healthz.ts
+++ b/front/pages/api/healthz.ts
@@ -3,6 +3,8 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 export const statsDClient = new StatsD();
 
+// TODO(2026-01-12): Delete once helm chart has been updated to use /api/healthz/ready.
+
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse

--- a/front/pages/api/healthz/ready.ts
+++ b/front/pages/api/healthz/ready.ts
@@ -1,0 +1,27 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { getStatsDClient } from "@app/lib/utils/statsd";
+
+const statsDClient = getStatsDClient();
+
+/**
+ * Readiness probe endpoint.
+ *
+ * This endpoint is checked continuously by Kubernetes to determine if the pod should receive
+ * traffic. It's kept simple and doesn't check dependencies to avoid marking all pods unready if
+ * Redis/DB have transient issues.
+ *
+ * The startup probe (/api/healthz/startup) handles dependency checking at pod startup.
+ */
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const startMs = performance.now();
+
+  // Simple check, just verify process is responsive.
+  res.status(200).json({ status: "ready" });
+
+  const durationMs = performance.now() - startMs;
+  statsDClient.distribution("healthz.ready.duration_ms", durationMs);
+}

--- a/front/pages/api/healthz/startup.ts
+++ b/front/pages/api/healthz/startup.ts
@@ -1,0 +1,74 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { getRedisHybridManager } from "@app/lib/api/redis-hybrid-manager";
+import { frontSequelize } from "@app/lib/resources/storage";
+import { getStatsDClient } from "@app/lib/utils/statsd";
+import logger from "@app/logger/logger";
+import { normalizeError } from "@app/types";
+
+const DEPENDENCY_CHECK_TIMEOUT_MS = 2000;
+
+const statsDClient = getStatsDClient();
+
+/**
+ * Startup probe endpoint.
+ *
+ * This endpoint checks that critical dependencies (Redis, DB) are connected before the pod starts
+ * accepting traffic. It's called during pod startup only.
+ *
+ * Unlike readiness probes, this doesn't continuously check dependencies. It just ensures
+ * connections are established at startup to prevent traffic from hitting pods that aren't ready.
+ */
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const startMs = performance.now();
+
+  try {
+    // Check both Redis and DB with a timeout.
+    await Promise.race([
+      Promise.all([
+        // Check Redis connectivity.
+        getRedisHybridManager().ping(),
+        // Check DB connectivity.
+        frontSequelize.authenticate(),
+      ]),
+
+      new Promise<never>((_, reject) =>
+        setTimeout(
+          () => reject(new Error("Dependency check timeout")),
+          DEPENDENCY_CHECK_TIMEOUT_MS
+        )
+      ),
+    ]);
+
+    const durationMs = performance.now() - startMs;
+    logger.info(
+      { durationMs },
+      "Startup probe succeeded - dependencies connected"
+    );
+
+    statsDClient.distribution("healthz.startup.duration_ms", durationMs, [
+      "status:success",
+    ]);
+
+    res.status(200).json({ status: "ready", durationMs });
+  } catch (error) {
+    const durationMs = performance.now() - startMs;
+    logger.warn(
+      { error, durationMs },
+      "Startup probe failed - dependencies not ready"
+    );
+
+    res.status(503).json({
+      status: "not ready",
+      error: normalizeError(error),
+      durationMs,
+    });
+
+    statsDClient.distribution("healthz.startup.duration_ms", durationMs, [
+      "status:failure",
+    ]);
+  }
+}


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
### Problem:

During deployments, new pods receive traffic immediately after container starts, we suspect that Redis/DB connections are not yet established. This causes event loop blocking, health check timeouts, and SSE subscription floods.

### Solution:
Add Kubernetes startup probe that checks dependency connectivity before marking pod ready.

### Expected impact:
Pods won't receive traffic until warm and ready, preventing deployment spikes.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
