### PR TITLE
fix(webhooks): allow listing private spaces webhooks

### DIFF
--- a/front/lib/resources/webhook_sources_view_resource.ts
+++ b/front/lib/resources/webhook_sources_view_resource.ts
@@ -274,6 +274,26 @@ export class WebhookSourcesViewResource extends ResourceWithSpace<WebhookSources
     );
   }
 
+  /**
+   * List all webhook source views for a webhook source without space permission filtering.
+   * This is used internally for webhook trigger processing where authorization
+   * is already established via the webhook URL secret.
+   *
+   * SECURITY: Only use this for internal webhook processing. The webhook secret
+   * in the URL serves as the authorization mechanism for these requests.
+   */
+  static async listByWebhookSourceForInternalProcessing(
+    auth: Authenticator,
+    webhookSourceId: ModelId
+  ): Promise<WebhookSourcesViewResource[]> {
+    // baseFetch already ensures we only return views from the same workspace.
+    // We skip the additional canReadOrAdministrate check since the webhook
+    // request was already authorized via the URL secret.
+    return this.baseFetch(auth, {
+      where: { webhookSourceId },
+    });
+  }
+
   static async getWebhookSourceViewForSystemSpace(
     auth: Authenticator,
     webhookSourceSId: string

--- a/front/lib/resources/webhook_sources_view_resource.ts
+++ b/front/lib/resources/webhook_sources_view_resource.ts
@@ -284,13 +284,13 @@ export class WebhookSourcesViewResource extends ResourceWithSpace<WebhookSources
    */
   static async listByWebhookSourceForInternalProcessing(
     auth: Authenticator,
-    webhookSourceId: ModelId
+    webhookSourceModelId: ModelId
   ): Promise<WebhookSourcesViewResource[]> {
     // baseFetch already ensures we only return views from the same workspace.
     // We skip the additional canReadOrAdministrate check since the webhook
     // request was already authorized via the URL secret.
     return this.baseFetch(auth, {
-      where: { webhookSourceId },
+      where: { webhookSourceId: webhookSourceModelId },
     });
   }
 

--- a/front/lib/triggers/webhook.ts
+++ b/front/lib/triggers/webhook.ts
@@ -402,11 +402,15 @@ export async function filterTriggers({
   const workspaceId = auth.getNonNullableWorkspace().sId;
   const webhookRequestId = webhookRequest.id;
   const { provider } = webhookSource;
-  // Fetch all triggers based on the webhook source id.
-  const views = await WebhookSourcesViewResource.listByWebhookSource(
-    auth,
-    webhookSource.id
-  );
+  // Fetch all webhook source views for this webhook source.
+  // We use the internal method that skips space permission filtering because:
+  // 1. The webhook request was already authorized via the URL secret.
+  // 2. Webhook source views in private spaces should still trigger their associated agents.
+  const views =
+    await WebhookSourcesViewResource.listByWebhookSourceForInternalProcessing(
+      auth,
+      webhookSource.id
+    );
 
   // Fetch all triggers based on the webhook source id and flatten the result.
   const triggers = (


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Closes https://github.com/dust-tt/tasks/issues/5887 and closes https://github.com/dust-tt/tasks/issues/5357

We don't trigger conversations when triggers are set up on private webhook sources.

Issue was that Authenticator.internalBuilderForWorkspace() only includes the global space, so it couldn't access webhook source views in private spaces. By using the new method that skips the canReadOrAdministrate check, we allow triggers in private spaces to fire.

1. front/lib/resources/webhook_sources_view_resource.ts (lines 277-295)
  - Added new method listByWebhookSourceForInternalProcessing that fetches webhook source views without the space permission filter
  - This is safe because webhook requests are already authorized via the URL secret
2. front/lib/triggers/webhook.ts (lines 405-413)
  - Updated filterTriggers to use the new internal method instead of listByWebhookSource
  - Added comments explaining why we skip space permission filtering

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand, created a private webhook :
- does not work without the fix
- does work and trigger convo as needed with the fix

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front