### PR TITLE
feat: add jit tool to handle project context

### DIFF
--- a/front/lib/api/assistant/jit/project_context_management.ts
+++ b/front/lib/api/assistant/jit/project_context_management.ts
@@ -1,0 +1,53 @@
+import assert from "assert";
+
+import type { ServerSideMCPServerConfigurationType } from "@app/lib/actions/mcp";
+import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids";
+import type { ConversationWithoutContentType } from "@app/types";
+
+/**
+ * Get the project_context_management MCP server for managing project files.
+ * Only available with "projects" feature flag and if conversation is in a project.
+ */
+export async function getProjectContextManagementServer(
+  auth: Authenticator,
+  conversation: ConversationWithoutContentType
+): Promise<ServerSideMCPServerConfigurationType | null> {
+  const owner = auth.getNonNullableWorkspace();
+  const featureFlags = await getFeatureFlags(owner);
+
+  if (!featureFlags.includes("projects") || !conversation.spaceId) {
+    return null;
+  }
+
+  const mcpServerView =
+    await MCPServerViewResource.getMCPServerViewForAutoInternalTool(
+      auth,
+      "project_context_management"
+    );
+
+  assert(
+    mcpServerView,
+    "MCP server view not found for project_context_management. Ensure auto tools are created."
+  );
+
+  return {
+    id: -1,
+    sId: generateRandomModelSId(),
+    type: "mcp_server_configuration",
+    name: "project_context_management",
+    description: "Manage files in the project context",
+    dataSources: null,
+    tables: null,
+    childAgentId: null,
+    timeFrame: null,
+    jsonSchema: null,
+    secretName: null,
+    additionalConfiguration: {},
+    mcpServerViewId: mcpServerView.sId,
+    dustAppConfiguration: null,
+    internalMCPServerId: mcpServerView.mcpServerId,
+  };
+}

--- a/front/lib/api/assistant/jit_actions.test.ts
+++ b/front/lib/api/assistant/jit_actions.test.ts
@@ -248,6 +248,68 @@ describe("getJITServers", () => {
 
       expect(projectSearchServer).toBeUndefined();
     });
+
+    it("should include project_context_management server when feature flag is enabled and conversation is in a project", async () => {
+      // Enable projects feature flag.
+      await FeatureFlagFactory.basic("projects", workspace);
+      await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
+
+      const jitServers = await getJITServers(auth, {
+        agentConfiguration: agentConfig,
+        conversation: {
+          ...conversation,
+          spaceId: conversationsSpace.sId,
+        },
+        attachments: [],
+      });
+
+      const projectContextManagementServer = jitServers.find(
+        (server) => server.name === "project_context_management"
+      );
+
+      expect(projectContextManagementServer).toBeDefined();
+      expect(projectContextManagementServer?.type).toBe(
+        "mcp_server_configuration"
+      );
+      expect(projectContextManagementServer?.description).toBe(
+        "Manage files in the project context"
+      );
+      expect(projectContextManagementServer?.mcpServerViewId).toBeDefined();
+    });
+
+    it("should not include project_context_management server when feature flag is disabled", async () => {
+      const jitServers = await getJITServers(auth, {
+        agentConfiguration: agentConfig,
+        conversation: {
+          ...conversation,
+          spaceId: conversationsSpace.sId,
+        },
+        attachments: [],
+      });
+
+      const projectContextManagementServer = jitServers.find(
+        (server) => server.name === "project_context_management"
+      );
+
+      expect(projectContextManagementServer).toBeUndefined();
+    });
+
+    it("should not include project_context_management server when conversation is not in a project", async () => {
+      // Enable projects feature flag.
+      await FeatureFlagFactory.basic("projects", workspace);
+
+      const jitServers = await getJITServers(auth, {
+        agentConfiguration: agentConfig,
+        conversation,
+        attachments: [],
+      });
+
+      const projectContextManagementServer = jitServers.find(
+        (server) => server.name === "project_context_management"
+      );
+
+      expect(projectContextManagementServer).toBeUndefined();
+    });
   });
 
   describe("schedules_management feature", () => {

--- a/front/lib/api/assistant/jit_actions.ts
+++ b/front/lib/api/assistant/jit_actions.ts
@@ -7,6 +7,7 @@ import {
   getConversationSearchServer,
 } from "@app/lib/api/assistant/jit/conversation";
 import { getFolderSearchServers } from "@app/lib/api/assistant/jit/folder";
+import { getProjectContextManagementServer } from "@app/lib/api/assistant/jit/project_context_management";
 import { getProjectSearchServer } from "@app/lib/api/assistant/jit/projects";
 import { getQueryTablesServer } from "@app/lib/api/assistant/jit/query_tables_v2";
 import { getSchedulesManagementServer } from "@app/lib/api/assistant/jit/schedules_management";
@@ -62,6 +63,13 @@ export async function getJITServers(
   const projectSearchServer = await getProjectSearchServer(auth, conversation);
   if (projectSearchServer) {
     jitServers.push(projectSearchServer);
+  }
+
+  // Get project context management server (if in a project).
+  const projectContextManagementServer =
+    await getProjectContextManagementServer(auth, conversation);
+  if (projectContextManagementServer) {
+    jitServers.push(projectContextManagementServer);
   }
 
   // Get schedules management server (if onboarding conversation).


### PR DESCRIPTION
## Description

Now that the MCP server is there we can add it as a JIT tool

⚠️ there is a limitation in the display of the knowledge, it only shows txt files. So if you add an image/PDF it's not displayed but visible nu by the MCP servers (search, this one)

## Tests

Locally


## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
