### PR TITLE
Use storage for temporal

### DIFF
--- a/x/henry/dust-hive/src/lib/paths.ts
+++ b/x/henry/dust-hive/src/lib/paths.ts
@@ -28,6 +28,7 @@ export const ACTIVITY_PATH = join(DUST_HIVE_HOME, "activity.json");
 // Temporal server paths (global, not per-env)
 export const TEMPORAL_PID_PATH = join(DUST_HIVE_HOME, "temporal.pid");
 export const TEMPORAL_LOG_PATH = join(DUST_HIVE_HOME, "temporal.log");
+export const TEMPORAL_DB_PATH = join(DUST_HIVE_HOME, "temporal.db");
 export const TEMPORAL_PORT = 7233;
 
 // Shared test Postgres paths (global, not per-env)

--- a/x/henry/dust-hive/src/lib/temporal-server.ts
+++ b/x/henry/dust-hive/src/lib/temporal-server.ts
@@ -3,7 +3,7 @@
 import { open, rename, unlink } from "node:fs/promises";
 import { createConnection } from "node:net";
 import { isErrnoException } from "./errors";
-import { TEMPORAL_LOG_PATH, TEMPORAL_PID_PATH, TEMPORAL_PORT } from "./paths";
+import { TEMPORAL_DB_PATH, TEMPORAL_LOG_PATH, TEMPORAL_PID_PATH, TEMPORAL_PORT } from "./paths";
 import { isProcessRunning, killProcess } from "./process";
 
 // Check if something is listening on the temporal port
@@ -143,7 +143,7 @@ export async function startTemporalServer(): Promise<{
   await rotateLogIfNeeded();
   const logHandle = await open(TEMPORAL_LOG_PATH, "a");
 
-  const proc = Bun.spawn(["temporal", "server", "start-dev"], {
+  const proc = Bun.spawn(["temporal", "server", "start-dev", "--db-filename", TEMPORAL_DB_PATH], {
     stdout: logHandle.fd,
     stderr: logHandle.fd,
     detached: true,


### PR DESCRIPTION
## Description

When we stop temporal (dh down) , all data is lost, including namespaces and search attribute , which makes environment already spawned/warmed unusable anymore. This stores temporal db to avoid loosing all data on every restart


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
