### PR TITLE
Add: system only rendering endpoint (crude) for conversations as datasource, methods and type to sdk.

### DIFF
--- a/connectors/knip.ts
+++ b/connectors/knip.ts
@@ -5,6 +5,7 @@ const config: KnipConfig = {
   ignoreFiles: [
     "src/resources/dust_project_configuration_resource.ts",
     "src/resources/dust_project_conversation_resource.ts",
+    "src/lib/conversation_rendering.ts",
   ],
   project: ["**/*.{js,jsx,ts,tsx}"],
   rules: {

--- a/connectors/src/connectors/slack/lib/workspace_limits.ts
+++ b/connectors/src/connectors/slack/lib/workspace_limits.ts
@@ -1,5 +1,5 @@
 import type { Result, WorkspaceDomainType } from "@dust-tt/client";
-import { DustAPI, Err, Ok } from "@dust-tt/client";
+import { Err, Ok } from "@dust-tt/client";
 import type { WebClient } from "@slack/web-api";
 import type {} from "@slack/web-api/dist/types/response/UsersInfoResponse";
 
@@ -9,27 +9,13 @@ import {
   getSlackConversationInfo,
   reportSlackUsage,
 } from "@connectors/connectors/slack/lib/slack_client";
-import { apiConfig } from "@connectors/lib/api/config";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
+import { getDustAPI } from "@connectors/lib/api/dust_api";
 import { isActiveMemberOfWorkspace } from "@connectors/lib/bot/user_validation";
 import logger from "@connectors/logger/logger";
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
 import { SlackConfigurationResource } from "@connectors/resources/slack_configuration_resource";
-import type { DataSourceConfig } from "@connectors/types";
 import { cacheWithRedis } from "@connectors/types";
-
-function getDustAPI(dataSourceConfig: DataSourceConfig) {
-  return new DustAPI(
-    {
-      url: apiConfig.getDustFrontAPIUrl(),
-    },
-    {
-      apiKey: dataSourceConfig.workspaceAPIKey,
-      workspaceId: dataSourceConfig.workspaceId,
-    },
-    logger
-  );
-}
 
 async function getVerifiedDomainsForWorkspace(
   connector: ConnectorResource

--- a/connectors/src/lib/api/dust_api.ts
+++ b/connectors/src/lib/api/dust_api.ts
@@ -1,0 +1,31 @@
+import { DustAPI } from "@dust-tt/client";
+
+import { apiConfig } from "@connectors/lib/api/config";
+import logger from "@connectors/logger/logger";
+import type { DataSourceConfig } from "@connectors/types";
+
+/**
+ * Creates a DustAPI instance for the given data source configuration.
+ * Uses the public Front API URL by default.
+ *
+ * @param dataSourceConfig - The data source configuration
+ * @param useInternalAPI - If true, uses the internal API URL instead of the public one
+ * @returns A configured DustAPI instance
+ */
+export function getDustAPI(
+  dataSourceConfig: DataSourceConfig,
+  useInternalAPI = false
+): DustAPI {
+  return new DustAPI(
+    {
+      url: useInternalAPI
+        ? apiConfig.getDustFrontInternalAPIUrl()
+        : apiConfig.getDustFrontAPIUrl(),
+    },
+    {
+      apiKey: dataSourceConfig.workspaceAPIKey,
+      workspaceId: dataSourceConfig.workspaceId,
+    },
+    logger
+  );
+}

--- a/connectors/src/lib/bot/user_validation.ts
+++ b/connectors/src/lib/bot/user_validation.ts
@@ -1,24 +1,8 @@
-import { DustAPI } from "@dust-tt/client";
-
-import { apiConfig } from "@connectors/lib/api/config";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
+import { getDustAPI } from "@connectors/lib/api/dust_api";
 import logger from "@connectors/logger/logger";
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
-import type { DataSourceConfig } from "@connectors/types";
 import { cacheWithRedis } from "@connectors/types";
-
-function getDustAPI(dataSourceConfig: DataSourceConfig) {
-  return new DustAPI(
-    {
-      url: apiConfig.getDustFrontAPIUrl(),
-    },
-    {
-      apiKey: dataSourceConfig.workspaceAPIKey,
-      workspaceId: dataSourceConfig.workspaceId,
-    },
-    logger
-  );
-}
 
 async function getActiveMemberEmails(
   connector: ConnectorResource

--- a/connectors/src/lib/conversation_rendering.ts
+++ b/connectors/src/lib/conversation_rendering.ts
@@ -1,0 +1,95 @@
+import type { PostRenderConversationForDataSourceResponseType } from "@dust-tt/client";
+import tracer from "dd-trace";
+
+import { getDustAPI } from "@connectors/lib/api/dust_api";
+import logger from "@connectors/logger/logger";
+import type { DataSourceConfig } from "@connectors/types";
+import { withRetries } from "@connectors/types";
+
+export type RenderConversationForDataSourceParams = {
+  dataSourceConfig: DataSourceConfig;
+  conversationId: string;
+  excludeActions?: boolean;
+  excludeImages?: boolean;
+};
+
+/**
+ * Renders a conversation for data source syncing by calling the Front API.
+ * This function calls the system-only endpoint that renders conversations
+ * in a format suitable for indexing in data sources.
+ */
+export const renderConversationForDataSource = withRetries(
+  logger,
+  _renderConversationForDataSource,
+  {
+    retries: 3,
+    delayBetweenRetriesMs: 1000,
+  }
+);
+
+async function _renderConversationForDataSource({
+  dataSourceConfig,
+  conversationId,
+  excludeActions,
+  excludeImages,
+}: RenderConversationForDataSourceParams): Promise<PostRenderConversationForDataSourceResponseType> {
+  return tracer.trace(
+    `connectors`,
+    {
+      resource: `renderConversationForDataSource`,
+    },
+    async (span) => {
+      span?.setTag("conversationId", conversationId);
+      span?.setTag("workspaceId", dataSourceConfig.workspaceId);
+
+      const dustAPI = getDustAPI(dataSourceConfig);
+
+      const result = await dustAPI.renderConversationForDataSource({
+        conversationId,
+        excludeActions,
+        excludeImages,
+      });
+
+      if (result.isErr()) {
+        logger.error(
+          {
+            workspaceId: dataSourceConfig.workspaceId,
+            conversationId,
+            error: result.error.message,
+            errorType: result.error.type,
+          },
+          "[renderConversationForDataSource] Failed to render conversation"
+        );
+
+        if (result.error.type === "conversation_not_found") {
+          throw new Error(
+            `Conversation ${conversationId} not found in workspace ${dataSourceConfig.workspaceId}`
+          );
+        }
+        if (result.error.type === "invalid_oauth_token_error") {
+          throw new Error(
+            `Access denied: Only system API keys can render conversations for data source syncing`
+          );
+        }
+
+        throw new Error(
+          `Failed to render conversation: ${result.error.message}`
+        );
+      }
+
+      const response = result.value;
+
+      logger.info(
+        {
+          workspaceId: dataSourceConfig.workspaceId,
+          conversationId,
+          tokensUsed: response.tokensUsed,
+          messageCount: response.messages.length,
+        },
+        "[renderConversationForDataSource] Successfully rendered conversation"
+      );
+
+      return response;
+    }
+  );
+}

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -8,7 +8,6 @@ import type {
   UpsertDatabaseTableRequestType,
   UpsertTableFromCsvRequestType,
 } from "@dust-tt/client";
-import { DustAPI } from "@dust-tt/client";
 import type { AxiosRequestConfig, AxiosResponse } from "axios";
 import type { AxiosError } from "axios";
 import axios from "axios";
@@ -22,6 +21,7 @@ import { toMarkdown } from "mdast-util-to-markdown";
 import { gfm } from "micromark-extension-gfm";
 
 import { apiConfig } from "@connectors/lib/api/config";
+import { getDustAPI } from "@connectors/lib/api/dust_api";
 import { DustConnectorWorkflowError, TablesError } from "@connectors/lib/error";
 import logger from "@connectors/logger/logger";
 import { statsDClient } from "@connectors/logger/withlogging";
@@ -80,19 +80,6 @@ export type UpsertDataSourceDocumentParams = {
   mimeType: string;
   async: boolean;
 };
-
-function getDustAPI(dataSourceConfig: DataSourceConfig) {
-  return new DustAPI(
-    {
-      url: apiConfig.getDustFrontInternalAPIUrl(),
-    },
-    {
-      apiKey: dataSourceConfig.workspaceAPIKey,
-      workspaceId: dataSourceConfig.workspaceId,
-    },
-    logger
-  );
-}
 
 export const upsertDataSourceDocument = withRetries(
   logger,
@@ -1083,7 +1070,7 @@ export async function upsertDataSourceTableFromCsv({
     );
   }
 
-  const dustAPI = getDustAPI(dataSourceConfig);
+  const dustAPI = getDustAPI(dataSourceConfig, true);
 
   const fileRes = await dustAPI.uploadFile({
     contentType: "text/csv",
@@ -1552,7 +1539,7 @@ export async function _upsertDataSourceFolder({
 }) {
   const now = new Date();
 
-  const r = await getDustAPI(dataSourceConfig).upsertFolder({
+  const r = await getDustAPI(dataSourceConfig, true).upsertFolder({
     dataSourceId: dataSourceConfig.dataSourceId,
     folderId,
     timestamp: timestampMs ? timestampMs : now.getTime(),
@@ -1577,7 +1564,7 @@ export async function deleteDataSourceFolder({
   folderId: string;
   loggerArgs?: Record<string, string | number>;
 }) {
-  const r = await getDustAPI(dataSourceConfig).deleteFolder({
+  const r = await getDustAPI(dataSourceConfig, true).deleteFolder({
     dataSourceId: dataSourceConfig.dataSourceId,
     folderId,
   });

--- a/front/pages/api/v1/w/[wId]/conversations/[cId]/render_for_data_source.ts
+++ b/front/pages/api/v1/w/[wId]/conversations/[cId]/render_for_data_source.ts
@@ -1,0 +1,147 @@
+import type { PostRenderConversationForDataSourceResponseType } from "@dust-tt/client";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
+import { renderConversationForModel } from "@app/lib/api/assistant/conversation_rendering";
+import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import logger from "@app/logger/logger";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+import { GPT_4_TURBO_MODEL_CONFIG, isString } from "@app/types";
+
+/**
+ * @ignoreswagger
+ * System API key only endpoint. Undocumented.
+ */
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<PostRenderConversationForDataSourceResponseType>
+  >,
+  auth: Authenticator
+): Promise<void> {
+  const { wId, cId } = req.query;
+  if (!isString(wId)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Missing or invalid workspace id.",
+      },
+    });
+  }
+  if (!isString(cId)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Missing or invalid conversation id.",
+      },
+    });
+  }
+
+  // Only allow system keys (connectors) to access this endpoint
+  if (!auth.isSystemKey()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "invalid_oauth_token_error",
+        message: "Only system keys are allowed to use this endpoint.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "POST": {
+      const { excludeActions, excludeImages } = req.body as {
+        excludeActions?: boolean;
+        excludeImages?: boolean;
+      };
+
+      const conversationRes = await getConversation(auth, cId, true);
+      if (conversationRes.isErr()) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "conversation_not_found",
+            message: conversationRes.error.message,
+          },
+        });
+      }
+      const conversation = conversationRes.value;
+
+      // Use GPT-4 Turbo as default model for rendering (large context window)
+      const model = GPT_4_TURBO_MODEL_CONFIG;
+
+      // For data source syncing, we want to render the full conversation
+      // Use a large token budget to include as much as possible
+      const MIN_GENERATION_TOKENS = 2048;
+      const allowedTokenCount = model.contextSize - MIN_GENERATION_TOKENS;
+
+      // Empty prompt and tools since we're just rendering for indexing, not generation
+      const prompt = "";
+      const tools = "";
+
+      const convoRes = await renderConversationForModel(auth, {
+        conversation,
+        model,
+        prompt,
+        tools,
+        allowedTokenCount,
+        excludeActions,
+        excludeImages,
+        onMissingAction: "skip",
+      });
+
+      //TODO(project): transform & filter the json to something more appropriate as a data source document
+
+      if (convoRes.isErr()) {
+        logger.error(
+          {
+            workspaceId: wId,
+            conversationId: cId,
+            error: convoRes.error,
+          },
+          "[RenderConversationForDataSource] Failed to render conversation"
+        );
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: `Failed to render conversation: ${convoRes.error.message}`,
+          },
+        });
+      }
+
+      const { modelConversation, tokensUsed } = convoRes.value;
+
+      logger.info(
+        {
+          workspaceId: wId,
+          conversationId: cId,
+          tokensUsed,
+          messageCount: modelConversation.messages.length,
+        },
+        "[RenderConversationForDataSource] Successfully rendered conversation"
+      );
+
+      return res.status(200).json({
+        messages: modelConversation.messages,
+        tokensUsed,
+      });
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, POST is expected.",
+        },
+      });
+  }
+}
+
+export default withPublicAPIAuthentication(handler);

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -87,6 +87,7 @@ import {
   PostContentFragmentResponseSchema,
   PostMCPResultsResponseSchema,
   PostMessageFeedbackResponseSchema,
+  PostRenderConversationForDataSourceResponseSchema,
   PostUserMessageResponseSchema,
   PostWorkspaceSearchResponseBodySchema,
   RegisterMCPResponseSchema,
@@ -1225,6 +1226,30 @@ export class DustAPI {
       return r;
     }
     return new Ok(r.value.feedbacks);
+  }
+
+  async renderConversationForDataSource({
+    conversationId,
+    excludeActions,
+    excludeImages,
+  }: {
+    conversationId: string;
+    excludeActions?: boolean;
+    excludeImages?: boolean;
+  }) {
+    const res = await this.request({
+      method: "POST",
+      path: `conversations/${conversationId}/render_for_data_source`,
+      body: {
+        ...(excludeActions !== undefined ? { excludeActions } : {}),
+        ...(excludeImages !== undefined ? { excludeImages } : {}),
+      },
+    });
+
+    return this._resultFromResponse(
+      PostRenderConversationForDataSourceResponseSchema,
+      res
+    );
   }
 
   async postFeedback(

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -2392,6 +2392,23 @@ export type CheckUpsertQueueResponseType = z.infer<
   typeof CheckUpsertQueueResponseSchema
 >;
 
+const PostRenderConversationForDataSourceRequestBodySchema = z.object({
+  excludeActions: z.boolean().optional(),
+  excludeImages: z.boolean().optional(),
+});
+export type PostRenderConversationForDataSourceRequestBody = z.infer<
+  typeof PostRenderConversationForDataSourceRequestBodySchema
+>;
+
+export const PostRenderConversationForDataSourceResponseSchema = z.object({
+  //TODO(project): add the proper schema for the messages
+  messages: z.array(z.unknown()),
+  tokensUsed: z.number(),
+});
+export type PostRenderConversationForDataSourceResponseType = z.infer<
+  typeof PostRenderConversationForDataSourceResponseSchema
+>;
+
 const GetDocumentsResponseSchema = z.object({
   documents: z.array(CoreAPIDocumentSchema),
   total: z.number(),


### PR DESCRIPTION
## Description

Add a "system only" endpoint to return a "rendered conversation" for data source ingestion purpose.
Update the sdk to expose a function to call that endpoint.
The endpoint is super crude, will refine in follow up PR.

## Tests

Local
Will add more in follow up PRs.

## Risk

Medium because I did a small refactor to avoid 4 definitions of getDustAPI() in connectors.

## Deploy Plan

Deploy connectors.