### PR TITLE
[Conversation] Navigation arrows: tooltips and design improvements

### DIFF
--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -103,41 +103,36 @@ export const AgentInputBar = ({
 
   const { bottomOffset, listOffset, visibleListHeight } = useVirtuosoLocation();
 
-  // Memoize message positions separately - only recalculate when messages change, not on scroll.
-  const { userMessageIndices, positions } = useMemo(() => {
-    const allMessages = methods.data.get();
-
-    // Find indices of visible (non-hidden) user messages.
-    const userIndices: number[] = [];
-    for (let i = 0; i < allMessages.length; i++) {
-      const msg = allMessages[i];
-      if (isUserMessage(msg) && !isHiddenMessage(msg)) {
-        userIndices.push(i);
-      }
-    }
-
-    // Calculate positions by accumulating heights.
-    const pos: { top: number; bottom: number }[] = [];
-    let accumulatedHeight = 0;
-    for (const msg of allMessages) {
-      const height = methods.height(msg);
-      pos.push({
-        top: accumulatedHeight,
-        bottom: accumulatedHeight + height,
-      });
-      accumulatedHeight += height;
-    }
-
-    return { userMessageIndices: userIndices, positions: pos };
-  }, [methods]);
-
-  // Determine navigable messages based on viewport position.
+  // Calculate positions and determine which user messages are navigable.
   const {
     canScrollUp,
     canScrollDown,
     scrollToPreviousUserMessage,
     scrollToNextUserMessage,
   } = useMemo(() => {
+    const allMessages = methods.data.get();
+
+    // Find indices of visible (non-hidden) user messages.
+    const userMessageIndices: number[] = [];
+    for (let i = 0; i < allMessages.length; i++) {
+      const msg = allMessages[i];
+      if (isUserMessage(msg) && !isHiddenMessage(msg)) {
+        userMessageIndices.push(i);
+      }
+    }
+
+    // Calculate positions by accumulating heights.
+    const positions: { top: number; bottom: number }[] = [];
+    let accumulatedHeight = 0;
+    for (const msg of allMessages) {
+      const height = methods.height(msg);
+      positions.push({
+        top: accumulatedHeight,
+        bottom: accumulatedHeight + height,
+      });
+      accumulatedHeight += height;
+    }
+
     // Convert listOffset to positive scroll position.
     // listOffset is negative when scrolled down (distance from list top to viewport top).
     const viewportTop = -listOffset;
@@ -192,14 +187,7 @@ export const AgentInputBar = ({
         }
       },
     };
-  }, [
-    userMessageIndices,
-    positions,
-    listOffset,
-    visibleListHeight,
-    bottomOffset,
-    methods,
-  ]);
+  }, [methods, listOffset, visibleListHeight, bottomOffset]);
 
   const showClearButton =
     context.agentBuilderContext?.resetConversation &&

--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -266,7 +266,20 @@ export const AgentInputBar = ({
           top: "-2em",
         }}
       >
-        <div className="flex items-center gap-1 rounded-full border border-border bg-white px-1 py-0.5 dark:border-border-night dark:bg-muted-night">
+        <div className="flex items-center gap-1 rounded-full border border-border bg-white px-2 py-1 dark:border-border-night dark:bg-muted-night">
+          {showStopButton && (
+            <>
+              <Button
+                variant="ghost"
+                label={getStopButtonLabel()}
+                icon={StopIcon}
+                onClick={handleStopGeneration}
+                disabled={isStopping}
+                size="xs"
+              />
+              <div className="h-4 w-px bg-border dark:bg-border-night" />
+            </>
+          )}
           <IconButton
             icon={ArrowUpIcon}
             onClick={scrollToPreviousUserMessage}
@@ -289,16 +302,6 @@ export const AgentInputBar = ({
             icon={ArrowPathIcon}
             onClick={context.agentBuilderContext?.resetConversation}
             label="Clear"
-          />
-        )}
-
-        {showStopButton && (
-          <Button
-            variant="outline"
-            label={getStopButtonLabel()}
-            icon={StopIcon}
-            onClick={handleStopGeneration}
-            disabled={isStopping}
           />
         )}
       </div>


### PR DESCRIPTION
## Description

Several improvements to the conversation navigation arrows:

1. **UX**: Add tooltips to navigation arrows ("Previous message" / "Next message").

2. **Design**: 
   - Increase padding in the pill container so button edges are not too close to the border
   - Move the Stop button inside the pill on the left with a vertical separator
 
 
<img width="1025" height="315" alt="image" src="https://github.com/user-attachments/assets/02738b39-a953-4bb1-ba2d-a96871ccaac4" />

## Risks

Blast radius: Conversation navigation arrows and stop button
Risk: low

## Deploy Plan
- pmrr
- deploy front