### PR TITLE
Throw error instead of returning null

### DIFF
--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -138,7 +138,7 @@ export async function getRootNodesToSyncFromResources(
               },
               "Failed to get item"
             );
-            return null;
+            throw error;
           }
         })
     )


### PR DESCRIPTION
## Description

Throw  error to retry activity if we something goes wrong. Avoid returning null (filtered out) when we get rate limit, for example - this is triggering GC and removing all drive content.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
