### PR TITLE
[front] enh(skills): add icon generation

### DIFF
--- a/front/components/assistant/conversation/actions/AgentActionsPanel.tsx
+++ b/front/components/assistant/conversation/actions/AgentActionsPanel.tsx
@@ -256,7 +256,7 @@ function AgentActionsPanelContent({
       </div>
       {skills.length > 0 && (
         <div className="flex flex-col gap-4 border-t border-separator bg-background p-4 dark:border-separator-night dark:bg-background-night">
-          <span className="text-sm">Skills used</span>
+          <span className="text-semibold text-sm">Skills used</span>
           <div className="flex flex-wrap items-center gap-1">
             {skills.map((skill) => (
               <Chip

--- a/front/lib/api/llm/traces/types.ts
+++ b/front/lib/api/llm/traces/types.ts
@@ -23,6 +23,7 @@ interface LLMTraceContextBase {
     | "process_data_sources"
     | "process_schema_generator"
     | "skill_builder_description_suggestion"
+    | "skill_builder_icon_suggestion"
     | "skills_similarity_checker"
     | "trigger_cron_timezone_generator"
     | "trigger_webhook_filter_generator"

--- a/front/lib/api/skill/description_suggestion.ts
+++ b/front/lib/api/skill/description_suggestion.ts
@@ -1,0 +1,121 @@
+import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
+import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
+import type { Authenticator } from "@app/lib/auth";
+import type { ModelConversationTypeMultiActions, Result } from "@app/types";
+import { Err, getLargeWhitelistedModel, Ok } from "@app/types";
+
+const FUNCTION_NAME = "send_suggestion";
+
+const specifications: AgentActionSpecification[] = [
+  {
+    name: FUNCTION_NAME,
+    description: "Send a suggestion of description for the skill",
+    inputSchema: {
+      type: "object",
+      properties: {
+        suggestion: {
+          type: "string",
+          description:
+            "A description of the skill using 1 short sentence. Be factual, clear and concise. " +
+            "Do not use more than 15 words.",
+        },
+      },
+      required: ["suggestion"],
+    },
+  },
+];
+
+export interface SkillDescriptionSuggestionInputs {
+  instructions: string;
+  agentFacingDescription: string;
+  tools: { name: string; description: string }[];
+}
+
+function getConversationContext(
+  inputs: SkillDescriptionSuggestionInputs
+): ModelConversationTypeMultiActions {
+  const parts: string[] = [];
+
+  if (inputs.agentFacingDescription) {
+    parts.push(
+      `## Skill purpose (when to use)\n\n${inputs.agentFacingDescription}`
+    );
+  }
+
+  if (inputs.instructions) {
+    parts.push(`## Skill instructions (how to use)\n\n${inputs.instructions}`);
+  }
+
+  if (inputs.tools.length > 0) {
+    const toolsText = inputs.tools
+      .map((t) => `- **${t.name}**: ${t.description}`)
+      .join("\n");
+    parts.push(`## Available tools (what to use)\n\n${toolsText}`);
+  }
+
+  return {
+    messages: [
+      {
+        role: "user",
+        content: [{ type: "text", text: parts.join("\n\n") }],
+        name: "",
+      },
+    ],
+  };
+}
+
+export async function getSkillDescriptionSuggestion(
+  auth: Authenticator,
+  inputs: SkillDescriptionSuggestionInputs
+): Promise<Result<string, Error>> {
+  const owner = auth.getNonNullableWorkspace();
+  const model = getLargeWhitelistedModel(owner);
+
+  if (!model) {
+    return new Err(
+      new Error("No whitelisted models were found for the workspace.")
+    );
+  }
+
+  const res = await runMultiActionsAgent(
+    auth,
+    {
+      functionCall: FUNCTION_NAME,
+      modelId: model.modelId,
+      providerId: model.providerId,
+      temperature: 0.5,
+      useCache: false,
+    },
+    {
+      conversation: getConversationContext(inputs),
+      prompt:
+        "The user is creating a skill (reusable capability) for an AI assistant. " +
+        "Based on the provided purpose, instructions, and available tools, " +
+        "suggest a short user-facing description of the skill. " +
+        "Focus on what the skill does for the user.",
+      specifications,
+      forceToolCall: FUNCTION_NAME,
+    },
+    {
+      context: {
+        operationType: "skill_builder_description_suggestion",
+        userId: auth.user()?.sId,
+        workspaceId: owner.sId,
+      },
+    }
+  );
+
+  if (res.isErr()) {
+    return new Err(res.error);
+  }
+
+  if (res.value.actions?.[0]?.arguments?.suggestion) {
+    const { suggestion } = res.value.actions[0].arguments;
+
+    if (typeof suggestion === "string") {
+      return new Ok(suggestion);
+    }
+  }
+
+  return new Err(new Error("No suggestion found"));
+}

--- a/front/lib/api/skill/icon_suggestion.ts
+++ b/front/lib/api/skill/icon_suggestion.ts
@@ -90,11 +90,6 @@ function getConversationContext(
     parts.push(`## Skill instructions (how to use)\n\n${inputs.instructions}`);
   }
 
-  const iconList = SKILL_ICON_OPTIONS.map(
-    (i) => `- **${i.name}**: ${i.description}`
-  ).join("\n");
-  parts.push(`## Available icons\n\n${iconList}`);
-
   return {
     messages: [
       {
@@ -134,7 +129,11 @@ export async function getSkillIconSuggestion(
         "The user is creating a skill (reusable capability) for an AI assistant. " +
         "Based on the skill name, purpose, and instructions, " +
         "pick the most appropriate icon from the available options. " +
-        "Choose the icon that best represents what this skill does.",
+        "Choose the icon that best represents what this skill does." +
+        "## Available icons\n\n" +
+        SKILL_ICON_OPTIONS.map((i) => `- **${i.name}**: ${i.description}`).join(
+          "\n"
+        ),
       specifications,
       forceToolCall: FUNCTION_NAME,
     },

--- a/front/lib/api/skill/icon_suggestion.ts
+++ b/front/lib/api/skill/icon_suggestion.ts
@@ -3,125 +3,9 @@ import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
 import type { Authenticator } from "@app/lib/auth";
 import type { ModelConversationTypeMultiActions, Result } from "@app/types";
-import { isString } from "@app/types";
-import { Err, getLargeWhitelistedModel, Ok } from "@app/types";
+import { Err, getLargeWhitelistedModel, isString, Ok } from "@app/types";
 
-const DESCRIPTION_FUNCTION_NAME = "send_suggestion";
-const ICON_FUNCTION_NAME = "send_icon_suggestion";
-
-const descriptionSpecifications: AgentActionSpecification[] = [
-  {
-    name: DESCRIPTION_FUNCTION_NAME,
-    description: "Send a suggestion of description for the skill",
-    inputSchema: {
-      type: "object",
-      properties: {
-        suggestion: {
-          type: "string",
-          description:
-            "A description of the skill using 1 short sentence. Be factual, clear and concise. " +
-            "Do not use more than 15 words.",
-        },
-      },
-      required: ["suggestion"],
-    },
-  },
-];
-
-export interface SkillDescriptionSuggestionInputs {
-  instructions: string;
-  agentFacingDescription: string;
-  tools: { name: string; description: string }[];
-}
-
-function getConversationContext(
-  inputs: SkillDescriptionSuggestionInputs
-): ModelConversationTypeMultiActions {
-  const parts: string[] = [];
-
-  if (inputs.agentFacingDescription) {
-    parts.push(
-      `## Skill purpose (when to use)\n\n${inputs.agentFacingDescription}`
-    );
-  }
-
-  if (inputs.instructions) {
-    parts.push(`## Skill instructions (how to use)\n\n${inputs.instructions}`);
-  }
-
-  if (inputs.tools.length > 0) {
-    const toolsText = inputs.tools
-      .map((t) => `- **${t.name}**: ${t.description}`)
-      .join("\n");
-    parts.push(`## Available tools (what to use)\n\n${toolsText}`);
-  }
-
-  return {
-    messages: [
-      {
-        role: "user",
-        content: [{ type: "text", text: parts.join("\n\n") }],
-        name: "",
-      },
-    ],
-  };
-}
-
-export async function getSkillDescriptionSuggestion(
-  auth: Authenticator,
-  inputs: SkillDescriptionSuggestionInputs
-): Promise<Result<string, Error>> {
-  const owner = auth.getNonNullableWorkspace();
-  const model = getLargeWhitelistedModel(owner);
-
-  if (!model) {
-    return new Err(
-      new Error("No whitelisted models were found for the workspace.")
-    );
-  }
-
-  const res = await runMultiActionsAgent(
-    auth,
-    {
-      functionCall: DESCRIPTION_FUNCTION_NAME,
-      modelId: model.modelId,
-      providerId: model.providerId,
-      temperature: 0.5,
-      useCache: false,
-    },
-    {
-      conversation: getConversationContext(inputs),
-      prompt:
-        "The user is creating a skill (reusable capability) for an AI assistant. " +
-        "Based on the provided purpose, instructions, and available tools, " +
-        "suggest a short user-facing description of the skill. " +
-        "Focus on what the skill does for the user.",
-      specifications: descriptionSpecifications,
-      forceToolCall: DESCRIPTION_FUNCTION_NAME,
-    },
-    {
-      context: {
-        operationType: "skill_builder_description_suggestion",
-        userId: auth.user()?.sId,
-        workspaceId: owner.sId,
-      },
-    }
-  );
-
-  if (res.isErr()) {
-    return new Err(res.error);
-  }
-
-  if (res.value.actions?.[0]?.arguments?.suggestion) {
-    const { suggestion } = res.value.actions[0].arguments;
-
-    if (typeof suggestion === "string") {
-      return new Ok(suggestion);
-    }
-  }
-
-  return new Err(new Error("No suggestion found"));
-}
+const FUNCTION_NAME = "send_icon_suggestion";
 
 // Curated list of icons suitable for skills, with semantic descriptions.
 const SKILL_ICON_OPTIONS = [
@@ -163,9 +47,9 @@ const SKILL_ICON_OPTIONS = [
   description: string;
 }[];
 
-const iconSpecifications: AgentActionSpecification[] = [
+const specifications: AgentActionSpecification[] = [
   {
-    name: ICON_FUNCTION_NAME,
+    name: FUNCTION_NAME,
     description: "Select the most appropriate icon for the skill",
     inputSchema: {
       type: "object",
@@ -189,7 +73,7 @@ export interface SkillIconSuggestionInputs {
   agentFacingDescription: string;
 }
 
-function getIconConversationContext(
+function getConversationContext(
   inputs: SkillIconSuggestionInputs
 ): ModelConversationTypeMultiActions {
   const parts: string[] = [];
@@ -238,21 +122,21 @@ export async function getSkillIconSuggestion(
   const res = await runMultiActionsAgent(
     auth,
     {
-      functionCall: ICON_FUNCTION_NAME,
+      functionCall: FUNCTION_NAME,
       modelId: model.modelId,
       providerId: model.providerId,
       temperature: 0.2,
       useCache: false,
     },
     {
-      conversation: getIconConversationContext(inputs),
+      conversation: getConversationContext(inputs),
       prompt:
         "The user is creating a skill (reusable capability) for an AI assistant. " +
         "Based on the skill name, purpose, and instructions, " +
         "select the most appropriate icon from the available options. " +
         "Choose the icon that best represents what this skill does.",
-      specifications: iconSpecifications,
-      forceToolCall: ICON_FUNCTION_NAME,
+      specifications,
+      forceToolCall: FUNCTION_NAME,
     },
     {
       context: {

--- a/front/lib/api/skill/icon_suggestion.ts
+++ b/front/lib/api/skill/icon_suggestion.ts
@@ -133,7 +133,7 @@ export async function getSkillIconSuggestion(
       prompt:
         "The user is creating a skill (reusable capability) for an AI assistant. " +
         "Based on the skill name, purpose, and instructions, " +
-        "select the most appropriate icon from the available options. " +
+        "pick the most appropriate icon from the available options. " +
         "Choose the icon that best represents what this skill does.",
       specifications,
       forceToolCall: FUNCTION_NAME,

--- a/front/lib/api/skill/icon_suggestion.ts
+++ b/front/lib/api/skill/icon_suggestion.ts
@@ -126,10 +126,11 @@ export async function getSkillIconSuggestion(
     {
       conversation: getConversationContext(inputs),
       prompt:
-        "The user is creating a skill (reusable capability) for an AI assistant. " +
+        "The user is creating a skill (reusable capability) for an AI agent. " +
         "Based on the skill name, purpose, and instructions, " +
         "pick the most appropriate icon from the available options. " +
         "Choose the icon that best represents what this skill does." +
+        'The "icon" property of the `skill_builder_icon_suggestion` function must be set to exactly one of the available icon names.' +
         "## Available icons\n\n" +
         SKILL_ICON_OPTIONS.map((i) => `- **${i.name}**: ${i.description}`).join(
           "\n"

--- a/front/lib/api/skill/suggestions.ts
+++ b/front/lib/api/skill/suggestions.ts
@@ -1,9 +1,9 @@
-import type { ActionIcons } from "@dust-tt/sparkle";
-
+import type { InternalActionIcons } from "@app/components/resources/resources_icons";
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
 import type { Authenticator } from "@app/lib/auth";
 import type { ModelConversationTypeMultiActions, Result } from "@app/types";
+import { isString } from "@app/types";
 import { Err, getLargeWhitelistedModel, Ok } from "@app/types";
 
 const DESCRIPTION_FUNCTION_NAME = "send_suggestion";
@@ -34,7 +34,7 @@ export interface SkillDescriptionSuggestionInputs {
   tools: { name: string; description: string }[];
 }
 
-function getDescriptionConversationContext(
+function getConversationContext(
   inputs: SkillDescriptionSuggestionInputs
 ): ModelConversationTypeMultiActions {
   const parts: string[] = [];
@@ -90,7 +90,7 @@ export async function getSkillDescriptionSuggestion(
       useCache: false,
     },
     {
-      conversation: getDescriptionConversationContext(inputs),
+      conversation: getConversationContext(inputs),
       prompt:
         "The user is creating a skill (reusable capability) for an AI assistant. " +
         "Based on the provided purpose, instructions, and available tools, " +
@@ -126,55 +126,25 @@ export async function getSkillDescriptionSuggestion(
 // Curated list of icons suitable for skills, with semantic descriptions.
 const SKILL_ICON_OPTIONS = [
   { name: "ActionAtomIcon", description: "Science, research, deep analysis" },
-  {
-    name: "ActionBookOpenIcon",
-    description: "Knowledge, learning, documentation",
-  },
   { name: "ActionBrainIcon", description: "Thinking, AI, intelligence" },
-  { name: "ActionBriefcaseIcon", description: "Work, business, professional" },
-  { name: "ActionCalculatorIcon", description: "Math, calculations, numbers" },
-  { name: "ActionCalendarIcon", description: "Scheduling, events, planning" },
-  {
-    name: "ActionCheckCircleIcon",
-    description: "Tasks, completion, validation",
-  },
-  { name: "ActionClipboardIcon", description: "Notes, forms, checklists" },
-  {
-    name: "ActionCodeBlockIcon",
-    description: "Coding, programming, development",
-  },
-  { name: "ActionCommunityIcon", description: "People, team, collaboration" },
-  {
-    name: "ActionCustomerServiceIcon",
-    description: "Support, help, assistance",
-  },
-  { name: "ActionDashboardIcon", description: "Analytics, overview, metrics" },
-  { name: "ActionDatabaseIcon", description: "Data, storage, information" },
   { name: "ActionDocumentTextIcon", description: "Documents, text, writing" },
   {
     name: "ActionEmotionLaughIcon",
     description: "Fun, creative, entertainment",
   },
-  { name: "ActionFilterIcon", description: "Filtering, sorting, organizing" },
   { name: "ActionFrameIcon", description: "Structure, layout, design" },
   {
     name: "ActionGitBranchIcon",
     description: "Version control, branches, code",
   },
   { name: "ActionGlobeAltIcon", description: "Web, international, global" },
-  {
-    name: "ActionGraduationCapIcon",
-    description: "Education, training, learning",
-  },
   { name: "ActionImageIcon", description: "Images, visuals, graphics" },
   { name: "ActionLightbulbIcon", description: "Ideas, insights, suggestions" },
-  { name: "ActionListCheckIcon", description: "Todo lists, tasks, workflows" },
   { name: "ActionLockIcon", description: "Security, privacy, protection" },
   {
     name: "ActionMagnifyingGlassIcon",
     description: "Search, discovery, investigation",
   },
-  { name: "ActionMailIcon", description: "Email, messaging, communication" },
   {
     name: "ActionMegaphoneIcon",
     description: "Announcements, marketing, outreach",
@@ -182,20 +152,16 @@ const SKILL_ICON_OPTIONS = [
   { name: "ActionNoiseIcon", description: "Audio, sound, voice" },
   { name: "ActionPieChartIcon", description: "Charts, reports, visualization" },
   { name: "ActionRobotIcon", description: "Automation, bots, AI agents" },
-  { name: "ActionRocketIcon", description: "Launch, speed, growth" },
   { name: "ActionScanIcon", description: "Scanning, reading, extraction" },
-  { name: "ActionServerIcon", description: "Infrastructure, systems, backend" },
   { name: "ActionSlideshowIcon", description: "Presentations, slides, demos" },
   { name: "ActionSpeakIcon", description: "Speech, conversation, dialogue" },
   { name: "ActionTableIcon", description: "Tables, spreadsheets, data grids" },
   { name: "ActionTimeIcon", description: "Time, scheduling, deadlines" },
-  {
-    name: "ActionTranslateIcon",
-    description: "Translation, languages, localization",
-  },
-  { name: "ActionUserGroupIcon", description: "Team, groups, collaboration" },
   { name: "ToolsIcon", description: "Tools, utilities, configuration" },
-] as const satisfies { name: ActionIcons; description: string }[];
+] as const satisfies {
+  name: keyof typeof InternalActionIcons;
+  description: string;
+}[];
 
 const iconSpecifications: AgentActionSpecification[] = [
   {

--- a/front/pages/api/w/[wId]/builder/skills/suggestions.test.ts
+++ b/front/pages/api/w/[wId]/builder/skills/suggestions.test.ts
@@ -6,11 +6,11 @@ import { Err, Ok } from "@app/types";
 
 import handler from "./suggestions";
 
-vi.mock("@app/lib/api/skill/suggestions", () => ({
+vi.mock("@app/lib/api/skill/description_suggestion", () => ({
   getSkillDescriptionSuggestion: vi.fn(),
 }));
 
-import { getSkillDescriptionSuggestion } from "@app/lib/api/skill/suggestions";
+import { getSkillDescriptionSuggestion } from "@app/lib/api/skill/description_suggestion";
 
 async function setupTest(options: { method?: RequestMethod } = {}) {
   const method = options.method ?? "POST";

--- a/front/pages/api/w/[wId]/builder/skills/suggestions.ts
+++ b/front/pages/api/w/[wId]/builder/skills/suggestions.ts
@@ -4,8 +4,8 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import type { SkillDescriptionSuggestionInputs } from "@app/lib/api/skill/suggestions";
-import { getSkillDescriptionSuggestion } from "@app/lib/api/skill/suggestions";
+import type { SkillDescriptionSuggestionInputs } from "@app/lib/api/skill/description_suggestion";
+import { getSkillDescriptionSuggestion } from "@app/lib/api/skill/description_suggestion";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";

--- a/front/pages/api/w/[wId]/skills/index.test.ts
+++ b/front/pages/api/w/[wId]/skills/index.test.ts
@@ -453,7 +453,7 @@ describe("POST /api/w/[wId]/skills", () => {
       agentFacingDescription: "To use in various situations",
       userFacingDescription: "A simple skill without tools",
       instructions: "Simple instructions",
-      icon: null,
+      icon: "PuzzleIcon",
       tools: [],
       extendedSkillId: null,
       attachedKnowledge: [],
@@ -509,7 +509,7 @@ describe("POST /api/w/[wId]/skills", () => {
       agentFacingDescription: "Use this skill all the time",
       userFacingDescription: "A test skill description",
       instructions: "Test instructions for the skill",
-      icon: null,
+      icon: "PuzzleIcon",
       tools: [
         { mcpServerViewId: serverView1.sId },
         { mcpServerViewId: serverView2.sId },
@@ -590,7 +590,7 @@ describe("POST /api/w/[wId]/skills", () => {
       agentFacingDescription: "A skill restricted to specific spaces",
       userFacingDescription: "User description",
       instructions: "Instructions",
-      icon: null,
+      icon: "PuzzleIcon",
       tools: [{ mcpServerViewId: serverView.sId }],
       extendedSkillId: null,
       attachedKnowledge: [],
@@ -636,7 +636,7 @@ describe("POST /api/w/[wId]/skills", () => {
       agentFacingDescription: "A skill with knowledge attachments",
       userFacingDescription: "User description",
       instructions: "Instructions",
-      icon: null,
+      icon: "PuzzleIcon",
       tools: [],
       attachedKnowledge: [
         {

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -5,7 +5,7 @@ import uniq from "lodash/uniq";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import { getSkillIconSuggestion } from "@app/lib/api/skill/suggestions";
+import { getSkillIconSuggestion } from "@app/lib/api/skill/icon_suggestion";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";

--- a/front/tests/utils/SkillFactory.ts
+++ b/front/tests/utils/SkillFactory.ts
@@ -3,6 +3,7 @@ import assert from "assert";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentSkillModel } from "@app/lib/models/agent/agent_skill";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { SKILL_ICON } from "@app/lib/skill";
 import type { ModelId } from "@app/types";
 import type { SkillStatus } from "@app/types/assistant/skill_configuration";
 
@@ -42,6 +43,7 @@ export class SkillFactory {
         name,
         requestedSpaceIds,
         status,
+        icon: SKILL_ICON.name,
       },
       {
         mcpServerViews: [],


### PR DESCRIPTION
## Description

- This PR adds an icon generation upon saving a skill without one.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
