### PR TITLE
feat(mcp): per-argument approval ui

### DIFF
--- a/front/components/assistant/conversation/MCPToolValidationRequired.tsx
+++ b/front/components/assistant/conversation/MCPToolValidationRequired.tsx
@@ -124,16 +124,31 @@ export function MCPToolValidationRequired({
             </div>
           )}
           <div className="mt-3 flex flex-row items-center gap-3">
-            {blockedAction.stake === "low" && (
-              <div className="flex flex-row justify-end gap-2">
-                <Label className="flex w-fit cursor-pointer flex-row items-center gap-2 py-2 pr-2 text-xs">
+            {(blockedAction.stake === "low" ||
+              blockedAction.stake === "medium") && (
+              <div className="flex flex-col gap-0.5">
+                <Label className="flex w-fit cursor-pointer flex-row items-center gap-2 py-1 pr-2 text-xs">
                   <Checkbox
                     checked={neverAskAgain}
                     onCheckedChange={(check) => {
                       setNeverAskAgain(!!check);
                     }}
                   />
-                  <span>Always allow</span>
+                  <span>
+                    Always allow{" "}
+                    {blockedAction.stake === "medium" &&
+                      blockedAction.argumentsRequiringApproval &&
+                      blockedAction.argumentsRequiringApproval.length > 0 && (
+                        <span className="font-normal">
+                          @{blockedAction.metadata.agentName} to{" "}
+                          {asDisplayName(blockedAction.metadata.toolName)} using{" "}
+                          {blockedAction.argumentsRequiringApproval
+                            .filter((arg) => blockedAction.inputs[arg] != null)
+                            .map((arg) => `${blockedAction.inputs[arg]}`)
+                            .join(", ")}
+                        </span>
+                      )}
+                  </span>
                 </Label>
               </div>
             )}

--- a/front/components/assistant/conversation/MCPToolValidationRequired.tsx
+++ b/front/components/assistant/conversation/MCPToolValidationRequired.tsx
@@ -95,6 +95,28 @@ export function MCPToolValidationRequired({
     isTriggeredByCurrentUser,
   ]);
 
+  const alwaysAllowLabel = useMemo(() => {
+    if (blockedAction.stake !== "medium") {
+      return "Always allow";
+    }
+
+    const args = blockedAction.argumentsRequiringApproval ?? [];
+    const argValues = args
+      .filter((arg) => blockedAction.inputs[arg] != null)
+      .map((arg) => `${blockedAction.inputs[arg]}`);
+
+    return `Always allow @${blockedAction.metadata.agentName} to ${asDisplayName(blockedAction.metadata.toolName)}` +
+      argValues.length
+      ? ` using ${argValues.join(", ")}`
+      : "";
+  }, [
+    blockedAction.stake,
+    blockedAction.argumentsRequiringApproval,
+    blockedAction.inputs,
+    blockedAction.metadata.agentName,
+    blockedAction.metadata.toolName,
+  ]);
+
   return (
     <ContentMessage
       title={title}
@@ -126,31 +148,15 @@ export function MCPToolValidationRequired({
           <div className="mt-3 flex flex-row items-center gap-3">
             {(blockedAction.stake === "low" ||
               blockedAction.stake === "medium") && (
-              <div className="flex flex-col gap-0.5">
-                <Label className="flex w-fit cursor-pointer flex-row items-center gap-2 py-1 pr-2 text-xs">
-                  <Checkbox
-                    checked={neverAskAgain}
-                    onCheckedChange={(check) => {
-                      setNeverAskAgain(!!check);
-                    }}
-                  />
-                  <span>
-                    Always allow{" "}
-                    {blockedAction.stake === "medium" &&
-                      blockedAction.argumentsRequiringApproval &&
-                      blockedAction.argumentsRequiringApproval.length > 0 && (
-                        <span className="font-normal">
-                          @{blockedAction.metadata.agentName} to{" "}
-                          {asDisplayName(blockedAction.metadata.toolName)} using{" "}
-                          {blockedAction.argumentsRequiringApproval
-                            .filter((arg) => blockedAction.inputs[arg] != null)
-                            .map((arg) => `${blockedAction.inputs[arg]}`)
-                            .join(", ")}
-                        </span>
-                      )}
-                  </span>
-                </Label>
-              </div>
+              <Label className="flex w-fit cursor-pointer flex-row items-center gap-2 py-1 pr-2 text-xs">
+                <Checkbox
+                  checked={neverAskAgain}
+                  onCheckedChange={(check) => {
+                    setNeverAskAgain(!!check);
+                  }}
+                />
+                <span>{alwaysAllowLabel}</span>
+              </Label>
             )}
             <div className="flex-grow" />
             <Button

--- a/front/lib/actions/mcp_actions.test.ts
+++ b/front/lib/actions/mcp_actions.test.ts
@@ -294,7 +294,9 @@ describe("makeToolsWithStakesAndTimeout", () => {
         check_availability: "never_ask",
         get_user_timezones: "never_ask",
       },
+      toolsRetryPolicies: undefined,
       serverTimeoutMs: undefined,
+      toolsArgumentsRequiringApproval: undefined,
     });
   });
 
@@ -336,6 +338,7 @@ describe("makeToolsWithStakesAndTimeout", () => {
       },
       toolsRetryPolicies: undefined,
       serverTimeoutMs: undefined,
+      toolsArgumentsRequiringApproval: undefined,
     });
   });
 

--- a/front/lib/actions/mcp_internal_actions/events.ts
+++ b/front/lib/actions/mcp_internal_actions/events.ts
@@ -20,6 +20,9 @@ export interface ToolExecution<
   metadata: T;
 
   inputs: Record<string, unknown>;
+
+  // For medium-stake tools: which arguments will be saved for future auto-approval.
+  argumentsRequiringApproval?: string[];
 }
 
 type ToolPersonalAuthError = {

--- a/front/lib/actions/tool_status.ts
+++ b/front/lib/actions/tool_status.ts
@@ -159,7 +159,7 @@ export async function hasUserAlwaysApprovedTool({
 
 // Extracts the values of the approval-requiring arguments from the tool inputs,
 // converting them to strings for storage. Skips any arguments that are not provided.
-function extractArgRequiringApprovalValues(
+export function extractArgRequiringApprovalValues(
   argumentsRequiringApproval: string[],
   toolInputs: Record<string, unknown>
 ): Record<string, string> {
@@ -176,8 +176,17 @@ function extractArgRequiringApprovalValues(
       result[argName] = value;
     } else if (typeof value === "number" || typeof value === "boolean") {
       result[argName] = String(value);
+    } else if (
+      Array.isArray(value) &&
+      value.length === 1 &&
+      (isString(value[0]) ||
+        typeof value[0] === "number" ||
+        typeof value[0] === "boolean")
+    ) {
+      // Handle single-element arrays (e.g., ["adrien@dust.tt"]).
+      result[argName] = String(value[0]);
     } else {
-      // For objects/arrays, we do not support approval. Skip them.
+      // For objects/arrays with multiple elements, we do not support approval. Skip them.
       // In fact, it's very unlikely the model will infer two times the same
       // object/array as identical, so storing the approval would be useless.
       continue;

--- a/front/lib/actions/tool_status.ts
+++ b/front/lib/actions/tool_status.ts
@@ -4,7 +4,7 @@ import { isServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards"
 import type { Authenticator } from "@app/lib/auth";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import type { AgentMessageType } from "@app/types";
-import { assertNever, isString } from "@app/types";
+import { assertNever, isNumberOrBoolean, isString } from "@app/types";
 
 export interface ToolInputContext {
   agentId: string;
@@ -174,17 +174,15 @@ export function extractArgRequiringApprovalValues(
 
     if (isString(value)) {
       result[argName] = value;
-    } else if (typeof value === "number" || typeof value === "boolean") {
+    } else if (isNumberOrBoolean(value)) {
       result[argName] = String(value);
     } else if (
       Array.isArray(value) &&
       value.length === 1 &&
-      (isString(value[0]) ||
-        typeof value[0] === "number" ||
-        typeof value[0] === "boolean")
+      (isString(value[0]) || isNumberOrBoolean(value[0]))
     ) {
       // Handle single-element arrays (e.g., ["adrien@dust.tt"]).
-      result[argName] = String(value[0]);
+      result[argName] = value[0].toString();
     } else {
       // For objects/arrays with multiple elements, we do not support approval. Skip them.
       // In fact, it's very unlikely the model will infer two times the same

--- a/front/lib/api/assistant/conversation/validate_actions.test.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.test.ts
@@ -44,6 +44,7 @@ import { AgentStepContentModel } from "@app/lib/models/agent/agent_step_content"
 import {
   AgentMessageModel,
   MentionModel,
+  MessageModel,
 } from "@app/lib/models/agent/conversation";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
@@ -1043,9 +1044,7 @@ describe("validateAction", () => {
         skipToolsValidation: false,
       });
 
-      const agentMessageMessage = await (
-        await import("@app/lib/models/agent/conversation")
-      ).MessageModel.create({
+      const agentMessageMessage = await MessageModel.create({
         workspaceId: workspace.id,
         sId: generateRandomModelSId(),
         conversationId: conversation.id,
@@ -1106,9 +1105,7 @@ describe("validateAction", () => {
         skipToolsValidation: false,
       });
 
-      const agentMessageMessage = await (
-        await import("@app/lib/models/agent/conversation")
-      ).MessageModel.create({
+      const agentMessageMessage = await MessageModel.create({
         workspaceId: workspace.id,
         sId: generateRandomModelSId(),
         conversationId: conversation.id,
@@ -1171,9 +1168,7 @@ describe("validateAction", () => {
         skipToolsValidation: false,
       });
 
-      const agentMessageMessage = await (
-        await import("@app/lib/models/agent/conversation")
-      ).MessageModel.create({
+      const agentMessageMessage = await MessageModel.create({
         workspaceId: workspace.id,
         sId: generateRandomModelSId(),
         conversationId: conversation.id,
@@ -1225,9 +1220,7 @@ describe("validateAction", () => {
         skipToolsValidation: false,
       });
 
-      const agentMessageMessage = await (
-        await import("@app/lib/models/agent/conversation")
-      ).MessageModel.create({
+      const agentMessageMessage = await MessageModel.create({
         workspaceId: workspace.id,
         sId: generateRandomModelSId(),
         conversationId: conversation.id,
@@ -1287,9 +1280,7 @@ describe("validateAction", () => {
         skipToolsValidation: false,
       });
 
-      const agentMessageMessage = await (
-        await import("@app/lib/models/agent/conversation")
-      ).MessageModel.create({
+      const agentMessageMessage = await MessageModel.create({
         workspaceId: workspace.id,
         sId: generateRandomModelSId(),
         conversationId: conversation.id,
@@ -1349,9 +1340,7 @@ describe("validateAction", () => {
         skipToolsValidation: false,
       });
 
-      const agentMessageMessage = await (
-        await import("@app/lib/models/agent/conversation")
-      ).MessageModel.create({
+      const agentMessageMessage = await MessageModel.create({
         workspaceId: workspace.id,
         sId: generateRandomModelSId(),
         conversationId: conversation.id,

--- a/front/lib/api/assistant/conversation/validate_actions.test.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.test.ts
@@ -1057,7 +1057,7 @@ describe("validateAction", () => {
       // Create a blocked action
       const { actionSId } = await createBlockedAction({
         agentMessageId: agentMessageRow.id,
-              });
+      });
 
       // Get the conversation resource
       const conversationResource = await ConversationResource.fetchById(
@@ -1120,7 +1120,7 @@ describe("validateAction", () => {
       // Create a blocked action
       const { action, actionSId } = await createBlockedAction({
         agentMessageId: agentMessageRow.id,
-              });
+      });
 
       // Get the conversation resource
       const conversationResource = await ConversationResource.fetchById(
@@ -1239,7 +1239,7 @@ describe("validateAction", () => {
       // Create an action that is NOT blocked (e.g., already succeeded)
       const { actionSId } = await createBlockedAction({
         agentMessageId: agentMessageRow.id,
-                status: "succeeded", // Not blocked
+        status: "succeeded", // Not blocked
       });
 
       // Get the conversation resource
@@ -1301,7 +1301,7 @@ describe("validateAction", () => {
       // Create a blocked action
       const { action, actionSId } = await createBlockedAction({
         agentMessageId: agentMessageRow.id,
-              });
+      });
 
       // Get the conversation resource
       const conversationResource = await ConversationResource.fetchById(
@@ -1363,10 +1363,10 @@ describe("validateAction", () => {
       // Create two blocked actions for the same message
       const { actionSId: actionSId1 } = await createBlockedAction({
         agentMessageId: agentMessageRow.id,
-              });
+      });
       await createBlockedAction({
         agentMessageId: agentMessageRow.id,
-              });
+      });
 
       // Get the conversation resource
       const conversationResource = await ConversationResource.fetchById(

--- a/front/lib/api/assistant/conversation/validate_actions.test.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.test.ts
@@ -11,6 +11,15 @@ vi.mock("@app/temporal/agent_loop/client", () => ({
   launchAgentLoopWorkflow: vi.fn().mockResolvedValue({ isOk: () => true }),
 }));
 
+// Mock Redis hybrid manager to prevent it from removing events
+vi.mock("@app/lib/api/redis-hybrid-manager", () => ({
+  getRedisHybridManager: vi.fn().mockReturnValue({
+    removeEvent: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+import type { LightMCPToolConfigurationType } from "@app/lib/actions/mcp";
+import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import {
   createConversation,
   postUserMessage,
@@ -20,16 +29,28 @@ import {
   createAgentMessages,
   createUserMentions,
 } from "@app/lib/api/assistant/conversation/mentions";
-import { dismissMention } from "@app/lib/api/assistant/conversation/validate_actions";
+import {
+  dismissMention,
+  validateAction,
+} from "@app/lib/api/assistant/conversation/validate_actions";
 import {
   publishAgentMessagesEvents,
   publishMessageEventsOnMessagePostOrEdit,
 } from "@app/lib/api/assistant/streaming/events";
 import { Authenticator } from "@app/lib/auth";
+import { AgentMCPActionModel } from "@app/lib/models/agent/actions/mcp";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
-import { MentionModel } from "@app/lib/models/agent/conversation";
+import { AgentStepContentModel } from "@app/lib/models/agent/agent_step_content";
+import {
+  AgentMessageModel,
+  MentionModel,
+} from "@app/lib/models/agent/conversation";
+import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
+import { launchAgentLoopWorkflow } from "@app/temporal/agent_loop/client";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
@@ -873,6 +894,498 @@ describe("dismissMention", () => {
       // a 400 error with "Invalid message type"
       // The actual test would require creating a content fragment, which is complex
       // so we're documenting that the error path exists in the implementation
+    });
+  });
+});
+
+describe("validateAction", () => {
+  let workspace: WorkspaceType;
+  let auth: Authenticator;
+  let conversation: ConversationType;
+
+  // Counter for unique step content indices
+  let stepContentIndex = 0;
+
+  beforeEach(async () => {
+    // Reset mocks before each test
+    vi.clearAllMocks();
+
+    // Reset counter for unique step content indices
+    stepContentIndex = 0;
+
+    // Create workspace, user, spaces, and groups using the helper
+    const setup = await createResourceTest({});
+    workspace = setup.workspace;
+    auth = setup.authenticator;
+
+    // Create a conversation using the factory
+    conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: "test-agent",
+      messagesCreatedAt: [],
+      visibility: "unlisted",
+    });
+  });
+
+  /**
+   * Helper to create a blocked MCP action for testing.
+   */
+  async function createBlockedAction({
+    agentMessageId,
+    status = "blocked_validation_required",
+  }: {
+    agentMessageId: number;
+    status?: ToolExecutionStatus;
+  }) {
+    const functionCallId = generateRandomModelSId();
+    const currentIndex = stepContentIndex++;
+
+    // Create step content (function_call type required for MCP actions)
+    const stepContent = await AgentStepContentModel.create({
+      workspaceId: workspace.id,
+      agentMessageId,
+      step: 1,
+      index: currentIndex,
+      version: 0,
+      type: "function_call",
+      value: {
+        type: "function_call",
+        value: {
+          id: functionCallId,
+          name: "test_tool",
+          arguments: "{}",
+        },
+      },
+    });
+
+    // Create a tool configuration
+    const toolConfiguration: LightMCPToolConfigurationType = {
+      id: 1,
+      sId: generateRandomModelSId(),
+      type: "mcp_configuration",
+      name: "test_tool",
+      dataSources: null,
+      tables: null,
+      childAgentId: null,
+      timeFrame: null,
+      jsonSchema: null,
+      additionalConfiguration: {},
+      mcpServerViewId: "test-server-view",
+      dustAppConfiguration: null,
+      secretName: null,
+      internalMCPServerId: null,
+      availability: "auto",
+      permission: "low",
+      toolServerId: "test-server",
+      retryPolicy: "no_retry",
+      originalName: "test_tool",
+      mcpServerName: "test_server",
+    };
+
+    // Create MCP action
+    const action = await AgentMCPActionModel.create({
+      workspaceId: workspace.id,
+      agentMessageId,
+      stepContentId: stepContent.id,
+      mcpServerConfigurationId: generateRandomModelSId(),
+      version: 0,
+      status,
+      citationsAllocated: 0,
+      augmentedInputs: {},
+      toolConfiguration,
+      stepContext: {
+        citationsCount: 0,
+        citationsOffset: 0,
+        resumeState: null,
+        retrievalTopK: 10,
+        websearchResultCount: 5,
+      },
+    });
+
+    const actionSId = AgentMCPActionResource.modelIdToSId({
+      id: action.id,
+      workspaceId: workspace.id,
+    });
+
+    return { action, actionSId, stepContent };
+  }
+
+  describe("authorization", () => {
+    it("should return error when user is not authorized to validate action", async () => {
+      // Create another user who will try to validate
+      const otherUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, otherUser, {
+        role: "user",
+      });
+      const otherUserAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        otherUser.sId,
+        workspace.sId
+      );
+
+      // Create a user message and agent message as the original user
+      const { messageRow } = await ConversationFactory.createUserMessage({
+        auth,
+        workspace,
+        conversation,
+        content: "Test message",
+      });
+
+      // Create an agent message as a response
+      const agentConfig = await AgentConfigurationFactory.createTestAgent(
+        auth,
+        { name: "Test Agent" }
+      );
+
+      const agentMessageRow = await AgentMessageModel.create({
+        workspaceId: workspace.id,
+        status: "created",
+        agentConfigurationId: agentConfig.sId,
+        agentConfigurationVersion: 0,
+        skipToolsValidation: false,
+      });
+
+      const agentMessageMessage = await (
+        await import("@app/lib/models/agent/conversation")
+      ).MessageModel.create({
+        workspaceId: workspace.id,
+        sId: generateRandomModelSId(),
+        conversationId: conversation.id,
+        rank: 1,
+        parentId: messageRow.id,
+        agentMessageId: agentMessageRow.id,
+      });
+
+      // Create a blocked action
+      const { actionSId } = await createBlockedAction({
+        agentMessageId: agentMessageRow.id,
+              });
+
+      // Get the conversation resource
+      const conversationResource = await ConversationResource.fetchById(
+        auth,
+        conversation.sId
+      );
+      expect(conversationResource).not.toBeNull();
+
+      // Try to validate as a different user (should fail)
+      const result = await validateAction(
+        otherUserAuth,
+        conversationResource!,
+        {
+          actionId: actionSId,
+          approvalState: "approved",
+          messageId: agentMessageMessage.sId,
+        }
+      );
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.code).toBe("unauthorized");
+      }
+    });
+
+    it("should successfully validate action when user is authorized", async () => {
+      // Create a user message and agent message
+      const { messageRow } = await ConversationFactory.createUserMessage({
+        auth,
+        workspace,
+        conversation,
+        content: "Test message",
+      });
+
+      // Create an agent message as a response
+      const agentConfig = await AgentConfigurationFactory.createTestAgent(
+        auth,
+        { name: "Test Agent" }
+      );
+
+      const agentMessageRow = await AgentMessageModel.create({
+        workspaceId: workspace.id,
+        status: "created",
+        agentConfigurationId: agentConfig.sId,
+        agentConfigurationVersion: 0,
+        skipToolsValidation: false,
+      });
+
+      const agentMessageMessage = await (
+        await import("@app/lib/models/agent/conversation")
+      ).MessageModel.create({
+        workspaceId: workspace.id,
+        sId: generateRandomModelSId(),
+        conversationId: conversation.id,
+        rank: 1,
+        parentId: messageRow.id,
+        agentMessageId: agentMessageRow.id,
+      });
+
+      // Create a blocked action
+      const { action, actionSId } = await createBlockedAction({
+        agentMessageId: agentMessageRow.id,
+              });
+
+      // Get the conversation resource
+      const conversationResource = await ConversationResource.fetchById(
+        auth,
+        conversation.sId
+      );
+      expect(conversationResource).not.toBeNull();
+
+      // Validate as the same user (should succeed)
+      const result = await validateAction(auth, conversationResource!, {
+        actionId: actionSId,
+        approvalState: "approved",
+        messageId: agentMessageMessage.sId,
+      });
+
+      expect(result.isOk()).toBe(true);
+
+      // Verify action status was updated
+      await action.reload();
+      expect(action.status).toBe("ready_allowed_explicitly");
+
+      // Verify agent loop was launched
+      expect(vi.mocked(launchAgentLoopWorkflow)).toHaveBeenCalled();
+    });
+  });
+
+  describe("error cases", () => {
+    it("should return error when action is not found", async () => {
+      // Create a user message and agent message
+      const { messageRow } = await ConversationFactory.createUserMessage({
+        auth,
+        workspace,
+        conversation,
+        content: "Test message",
+      });
+
+      // Create an agent message as a response
+      const agentConfig = await AgentConfigurationFactory.createTestAgent(
+        auth,
+        { name: "Test Agent" }
+      );
+
+      const agentMessageRow = await AgentMessageModel.create({
+        workspaceId: workspace.id,
+        status: "created",
+        agentConfigurationId: agentConfig.sId,
+        agentConfigurationVersion: 0,
+        skipToolsValidation: false,
+      });
+
+      const agentMessageMessage = await (
+        await import("@app/lib/models/agent/conversation")
+      ).MessageModel.create({
+        workspaceId: workspace.id,
+        sId: generateRandomModelSId(),
+        conversationId: conversation.id,
+        rank: 1,
+        parentId: messageRow.id,
+        agentMessageId: agentMessageRow.id,
+      });
+
+      // Get the conversation resource
+      const conversationResource = await ConversationResource.fetchById(
+        auth,
+        conversation.sId
+      );
+      expect(conversationResource).not.toBeNull();
+
+      // Try to validate a non-existent action
+      const result = await validateAction(auth, conversationResource!, {
+        actionId: "non-existent-action-id",
+        approvalState: "approved",
+        messageId: agentMessageMessage.sId,
+      });
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.code).toBe("action_not_found");
+      }
+    });
+
+    it("should return error when action is not in blocked state", async () => {
+      // Create a user message and agent message
+      const { messageRow } = await ConversationFactory.createUserMessage({
+        auth,
+        workspace,
+        conversation,
+        content: "Test message",
+      });
+
+      // Create an agent message as a response
+      const agentConfig = await AgentConfigurationFactory.createTestAgent(
+        auth,
+        { name: "Test Agent" }
+      );
+
+      const agentMessageRow = await AgentMessageModel.create({
+        workspaceId: workspace.id,
+        status: "created",
+        agentConfigurationId: agentConfig.sId,
+        agentConfigurationVersion: 0,
+        skipToolsValidation: false,
+      });
+
+      const agentMessageMessage = await (
+        await import("@app/lib/models/agent/conversation")
+      ).MessageModel.create({
+        workspaceId: workspace.id,
+        sId: generateRandomModelSId(),
+        conversationId: conversation.id,
+        rank: 1,
+        parentId: messageRow.id,
+        agentMessageId: agentMessageRow.id,
+      });
+
+      // Create an action that is NOT blocked (e.g., already succeeded)
+      const { actionSId } = await createBlockedAction({
+        agentMessageId: agentMessageRow.id,
+                status: "succeeded", // Not blocked
+      });
+
+      // Get the conversation resource
+      const conversationResource = await ConversationResource.fetchById(
+        auth,
+        conversation.sId
+      );
+      expect(conversationResource).not.toBeNull();
+
+      // Try to validate an action that is not blocked
+      const result = await validateAction(auth, conversationResource!, {
+        actionId: actionSId,
+        approvalState: "approved",
+        messageId: agentMessageMessage.sId,
+      });
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.code).toBe("action_not_blocked");
+      }
+    });
+  });
+
+  describe("approval states", () => {
+    it("should handle 'rejected' approval state", async () => {
+      // Create a user message and agent message
+      const { messageRow } = await ConversationFactory.createUserMessage({
+        auth,
+        workspace,
+        conversation,
+        content: "Test message",
+      });
+
+      // Create an agent message as a response
+      const agentConfig = await AgentConfigurationFactory.createTestAgent(
+        auth,
+        { name: "Test Agent" }
+      );
+
+      const agentMessageRow = await AgentMessageModel.create({
+        workspaceId: workspace.id,
+        status: "created",
+        agentConfigurationId: agentConfig.sId,
+        agentConfigurationVersion: 0,
+        skipToolsValidation: false,
+      });
+
+      const agentMessageMessage = await (
+        await import("@app/lib/models/agent/conversation")
+      ).MessageModel.create({
+        workspaceId: workspace.id,
+        sId: generateRandomModelSId(),
+        conversationId: conversation.id,
+        rank: 1,
+        parentId: messageRow.id,
+        agentMessageId: agentMessageRow.id,
+      });
+
+      // Create a blocked action
+      const { action, actionSId } = await createBlockedAction({
+        agentMessageId: agentMessageRow.id,
+              });
+
+      // Get the conversation resource
+      const conversationResource = await ConversationResource.fetchById(
+        auth,
+        conversation.sId
+      );
+      expect(conversationResource).not.toBeNull();
+
+      // Reject the action
+      const result = await validateAction(auth, conversationResource!, {
+        actionId: actionSId,
+        approvalState: "rejected",
+        messageId: agentMessageMessage.sId,
+      });
+
+      expect(result.isOk()).toBe(true);
+
+      // Verify action status was updated to denied
+      await action.reload();
+      expect(action.status).toBe("denied");
+    });
+  });
+
+  describe("agent loop launching", () => {
+    it("should not launch agent loop when there are remaining blocked actions", async () => {
+      // Create a user message and agent message
+      const { messageRow } = await ConversationFactory.createUserMessage({
+        auth,
+        workspace,
+        conversation,
+        content: "Test message",
+      });
+
+      // Create an agent message as a response
+      const agentConfig = await AgentConfigurationFactory.createTestAgent(
+        auth,
+        { name: "Test Agent" }
+      );
+
+      const agentMessageRow = await AgentMessageModel.create({
+        workspaceId: workspace.id,
+        status: "created",
+        agentConfigurationId: agentConfig.sId,
+        agentConfigurationVersion: 0,
+        skipToolsValidation: false,
+      });
+
+      const agentMessageMessage = await (
+        await import("@app/lib/models/agent/conversation")
+      ).MessageModel.create({
+        workspaceId: workspace.id,
+        sId: generateRandomModelSId(),
+        conversationId: conversation.id,
+        rank: 1,
+        parentId: messageRow.id,
+        agentMessageId: agentMessageRow.id,
+      });
+
+      // Create two blocked actions for the same message
+      const { actionSId: actionSId1 } = await createBlockedAction({
+        agentMessageId: agentMessageRow.id,
+              });
+      await createBlockedAction({
+        agentMessageId: agentMessageRow.id,
+              });
+
+      // Get the conversation resource
+      const conversationResource = await ConversationResource.fetchById(
+        auth,
+        conversation.sId
+      );
+      expect(conversationResource).not.toBeNull();
+
+      // Validate only the first action
+      const result = await validateAction(auth, conversationResource!, {
+        actionId: actionSId1,
+        approvalState: "approved",
+        messageId: agentMessageMessage.sId,
+      });
+
+      expect(result.isOk()).toBe(true);
+
+      // Agent loop should NOT be launched because there's still a blocked action
+      expect(vi.mocked(launchAgentLoopWorkflow)).not.toHaveBeenCalled();
     });
   });
 });

--- a/front/lib/api/assistant/conversation/validate_actions.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.ts
@@ -203,9 +203,12 @@ export async function validateAction(
         });
         break;
       case "medium":
-        const agentMessage = await AgentMessageModel.findByPk(
-          action.agentMessageId
-        );
+        const agentMessage = await AgentMessageModel.findOne({
+          where: {
+            workspaceId: owner.id,
+            id: action.agentMessageId,
+          },
+        });
         if (
           agentMessage &&
           isLightServerSideMCPToolConfiguration(action.toolConfiguration)

--- a/front/lib/api/assistant/conversation/validate_actions.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.ts
@@ -6,7 +6,11 @@ import {
   getMCPApprovalStateFromUserApprovalState,
   isMCPApproveExecutionEvent,
 } from "@app/lib/actions/mcp";
-import { setUserAlwaysApprovedTool } from "@app/lib/actions/tool_status";
+import {
+  extractArgRequiringApprovalValues,
+  setUserAlwaysApprovedTool,
+} from "@app/lib/actions/tool_status";
+import { isLightServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
 import { getRelatedContentFragments } from "@app/lib/api/assistant/conversation";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import {
@@ -19,6 +23,7 @@ import { getUserForWorkspace } from "@app/lib/api/user";
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import {
+  AgentMessageModel,
   MentionModel,
   MessageModel,
   UserMessageModel,
@@ -188,11 +193,41 @@ export async function validateAction(
   );
 
   if (approvalState === "always_approved" && user) {
-    await setUserAlwaysApprovedTool({
-      user,
-      mcpServerId: action.toolConfiguration.toolServerId,
-      functionCallName: action.functionCallName,
-    });
+    switch (action.toolConfiguration.permission) {
+      // TODO(adrien): move "low" to createToolApproval storage
+      case "low":
+        await setUserAlwaysApprovedTool({
+          user,
+          mcpServerId: action.toolConfiguration.toolServerId,
+          functionCallName: action.functionCallName,
+        });
+        break;
+      case "medium":
+        const agentMessage = await AgentMessageModel.findByPk(
+          action.agentMessageId
+        );
+        if (
+          agentMessage &&
+          isLightServerSideMCPToolConfiguration(action.toolConfiguration)
+        ) {
+          const argumentsRequiringApproval =
+            action.toolConfiguration.argumentsRequiringApproval ?? [];
+          const argsAndValues = extractArgRequiringApprovalValues(
+            argumentsRequiringApproval,
+            action.augmentedInputs
+          );
+
+          await user.createToolApproval(auth, {
+            mcpServerId: action.toolConfiguration.toolServerId,
+            toolName: action.functionCallName,
+            agentId: agentMessage.agentConfigurationId,
+            argsAndValues,
+          });
+        }
+        break;
+      default:
+        break;
+    }
   }
 
   if (updatedCount === 0) {

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -370,6 +370,11 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
           agentName: agentConfiguration.name,
           icon: action.toolConfiguration.icon,
         },
+        argumentsRequiringApproval: isLightServerSideMCPToolConfiguration(
+          action.toolConfiguration
+        )
+          ? action.toolConfiguration.argumentsRequiringApproval
+          : undefined,
       };
 
       if (action.status === "blocked_authentication_required") {

--- a/front/temporal/agent_loop/lib/create_tool_actions.ts
+++ b/front/temporal/agent_loop/lib/create_tool_actions.ts
@@ -1,8 +1,6 @@
 import assert from "assert";
 
-import type {
-  MCPToolConfigurationType,
-} from "@app/lib/actions/mcp";
+import type { MCPToolConfigurationType } from "@app/lib/actions/mcp";
 import { getAugmentedInputs } from "@app/lib/actions/mcp_execution";
 import type { MCPApproveExecutionEvent } from "@app/lib/actions/mcp_internal_actions/events";
 import { validateToolInputs } from "@app/lib/actions/mcp_utils";
@@ -253,10 +251,11 @@ async function createActionForTool(
               agentName: agentConfiguration.name,
               icon: actionConfiguration.icon,
             },
-            argumentsRequiringApproval:
-              isServerSideMCPToolConfiguration(actionConfiguration)
-                ? actionConfiguration.argumentsRequiringApproval
-                : undefined,
+            argumentsRequiringApproval: isServerSideMCPToolConfiguration(
+              actionConfiguration
+            )
+              ? actionConfiguration.argumentsRequiringApproval
+              : undefined,
           }
         : undefined,
   };

--- a/front/temporal/agent_loop/lib/create_tool_actions.ts
+++ b/front/temporal/agent_loop/lib/create_tool_actions.ts
@@ -2,9 +2,7 @@ import assert from "assert";
 
 import type {
   MCPToolConfigurationType,
-  ServerSideMCPToolConfigurationType,
 } from "@app/lib/actions/mcp";
-import { isServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
 import { getAugmentedInputs } from "@app/lib/actions/mcp_execution";
 import type { MCPApproveExecutionEvent } from "@app/lib/actions/mcp_internal_actions/events";
 import { validateToolInputs } from "@app/lib/actions/mcp_utils";
@@ -12,6 +10,7 @@ import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import type { ToolInputContext } from "@app/lib/actions/tool_status";
 import { getExecutionStatusFromConfig } from "@app/lib/actions/tool_status";
 import type { StepContext } from "@app/lib/actions/types";
+import { isServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
 import type { MCPToolRetryPolicyType } from "@app/lib/api/mcp";
 import { getRetryPolicyFromToolConfiguration } from "@app/lib/api/mcp";
 import { createMCPAction } from "@app/lib/api/mcp/create_mcp";

--- a/front/temporal/agent_loop/lib/create_tool_actions.ts
+++ b/front/temporal/agent_loop/lib/create_tool_actions.ts
@@ -1,6 +1,10 @@
 import assert from "assert";
 
-import type { MCPToolConfigurationType } from "@app/lib/actions/mcp";
+import type {
+  MCPToolConfigurationType,
+  ServerSideMCPToolConfigurationType,
+} from "@app/lib/actions/mcp";
+import { isServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
 import { getAugmentedInputs } from "@app/lib/actions/mcp_execution";
 import type { MCPApproveExecutionEvent } from "@app/lib/actions/mcp_internal_actions/events";
 import { validateToolInputs } from "@app/lib/actions/mcp_utils";
@@ -250,6 +254,10 @@ async function createActionForTool(
               agentName: agentConfiguration.name,
               icon: actionConfiguration.icon,
             },
+            argumentsRequiringApproval:
+              isServerSideMCPToolConfiguration(actionConfiguration)
+                ? actionConfiguration.argumentsRequiringApproval
+                : undefined,
           }
         : undefined,
   };

--- a/front/types/shared/utils/general.ts
+++ b/front/types/shared/utils/general.ts
@@ -9,6 +9,10 @@ export function isString(value: unknown): value is string {
   return typeof value === "string";
 }
 
+export function isNumberOrBoolean(value: unknown): value is number | boolean {
+  return typeof value === "number" || typeof value === "boolean";
+}
+
 export function isStringArray(value: unknown): value is string[] {
   return (
     Array.isArray(value) && value.every((item) => typeof item === "string")


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

This PR adds the UI, and hooks up the front to validate an action for medium stake tools.
  - Add per-argument approval UI for medium-stake MCP tools, allowing users to approve specific argument values (e.g., "Always allow @agent to query using table_name")
  - Store medium-stake tool approvals with argument values via the new createToolApproval method                                                                                                                                                                                               
  - Update the "Always allow" checkbox to display which arguments are being approved for medium-stake actions

<img width="539" height="205" alt="Capture d’écran 2026-01-13 à 13 57 34" src="https://github.com/user-attachments/assets/d7553382-59f6-43f1-94a1-132fe1070645" />

Next and last steps : 
- Migrate existing low stake validations to this DB table + Hook low stake tools to store/lookup this DB
- Define relevant medium stake tools

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested with several agents for several values. Behaves as expected.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low, unused yet, no medium stake tools defined.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front.