### PR TITLE
Add StatsD metrics for streaming backpressure monitoring

### DIFF
--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/events.ts
@@ -7,6 +7,8 @@ import { getMessagesEvents } from "@app/lib/api/assistant/pubsub";
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import logger from "@app/logger/logger";
+import { statsDClient } from "@app/logger/statsDClient";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
 
@@ -166,8 +168,17 @@ async function handler(
       const eventStream: AsyncGenerator<AgentMessageEventType> =
         getMessagesEvents(auth, { messageId: mId, lastEventId, signal });
 
+      let backpressureCount = 0;
+
       for await (const event of eventStream) {
-        res.write(`data: ${JSON.stringify(event)}\n\n`);
+        const writeSuccessful = res.write(`data: ${JSON.stringify(event)}\n\n`);
+        if (!writeSuccessful) {
+          backpressureCount++;
+          statsDClient.increment("streaming.backpressure.count", 1, [
+            "endpoint_type:v1",
+            "endpoint:message_events",
+          ]);
+        }
         // @ts-expect-error - We need it for streaming but it does not exists in the types.
         res.flush();
 
@@ -175,6 +186,18 @@ async function handler(
         if (signal.aborted) {
           break;
         }
+      }
+
+      if (backpressureCount > 10) {
+        logger.warn(
+          {
+            conversationId: conversation.sId,
+            messageId: mId,
+            backpressureCount,
+            endpointType: "v1",
+          },
+          "High streaming backpressure detected during message events"
+        );
       }
 
       res.status(200).end();

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/events.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/events.ts
@@ -5,6 +5,8 @@ import { getConversationEvents } from "@app/lib/api/assistant/pubsub";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import logger from "@app/logger/logger";
+import { statsDClient } from "@app/logger/statsDClient";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
 
@@ -72,8 +74,17 @@ async function handler(
         signal,
       });
 
+      let backpressureCount = 0;
+
       for await (const event of eventStream) {
-        res.write(`data: ${JSON.stringify(event)}\n\n`);
+        const writeSuccessful = res.write(`data: ${JSON.stringify(event)}\n\n`);
+        if (!writeSuccessful) {
+          backpressureCount++;
+          statsDClient.increment("streaming.backpressure.count", 1, [
+            "endpoint_type:internal",
+            "endpoint:conversation_events",
+          ]);
+        }
         // @ts-expect-error - We need it for streaming but it does not exists in the types.
         res.flush();
 
@@ -82,9 +93,27 @@ async function handler(
           break;
         }
       }
-      res.write("data: done\n\n");
+      const doneWriteSuccessful = res.write("data: done\n\n");
+      if (!doneWriteSuccessful) {
+        backpressureCount++;
+        statsDClient.increment("streaming.backpressure.count", 1, [
+          "endpoint_type:internal",
+          "endpoint:conversation_events",
+        ]);
+      }
       // @ts-expect-error - We need it for streaming but it does not exists in the types.
       res.flush();
+
+      if (backpressureCount > 10) {
+        logger.warn(
+          {
+            conversationId: conversation.sId,
+            backpressureCount,
+            endpointType: "internal",
+          },
+          "High streaming backpressure detected during conversation events"
+        );
+      }
 
       res.status(200).end();
       return;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Add instrumentation to track backpressure on streaming `/events` endpoints to help investigate memory and CPU spikes.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
