### PR TITLE
fix: webhook sources index

### DIFF
--- a/front/pages/api/w/[wId]/webhook_sources/views/index.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/views/index.ts
@@ -46,7 +46,7 @@ async function handler(
 
       const normalizedQuery = {
         ...req.query,
-        spaceIds: spaceIds.split(","),
+        spaceIds: spaceIds ? spaceIds.split(",") : [],
       };
 
       const r = GetWebhookSourceViewsRequestSchema.safeParse(normalizedQuery);
@@ -60,10 +60,8 @@ async function handler(
         });
       }
 
-      const query = r.data;
-
       const webhookSourceViews = await concurrentExecutor(
-        query.spaceIds,
+        normalizedQuery.spaceIds,
         async (spaceId) => {
           const space = await SpaceResource.fetchById(auth, spaceId);
           if (!space || !space.canReadOrAdministrate(auth)) {


### PR DESCRIPTION
## Description

I had errors locally (at least on Safari), it was calling `/api/w/qhdewxMKT5/webhook_sources/views?spaceIds=` and it 500

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
