### PR TITLE
[UI] Hide status dot when navigation item is selected

### DIFF
--- a/sparkle/src/components/NavigationList.tsx
+++ b/sparkle/src/components/NavigationList.tsx
@@ -177,7 +177,8 @@ const NavigationListItem = React.forwardRef<
                 variant="outline"
                 className={cn(
                   "s-flex-shrink-0 s-translate-x-0.5",
-                  moreMenu && "group-hover/menu-item:s-hidden"
+                  moreMenu &&
+                    "group-hover/menu-item:s-hidden group-data-[selected=true]/menu-item:s-hidden"
                 )}
               />
             )}
@@ -185,7 +186,8 @@ const NavigationListItem = React.forwardRef<
               <div
                 className={cn(
                   "s-heading-xs s-flex s-flex-shrink-0 s-items-center s-justify-center s-rounded-full",
-                  moreMenu && "group-hover/menu-item:s-hidden",
+                  moreMenu &&
+                    "group-hover/menu-item:s-hidden group-data-[selected=true]/menu-item:s-hidden",
                   getStatusDotColor()
                 )}
               />

--- a/sparkle/src/components/NavigationList.tsx
+++ b/sparkle/src/components/NavigationList.tsx
@@ -166,7 +166,7 @@ const NavigationListItem = React.forwardRef<
             {icon && <Icon visual={icon} size="xs" className="s-m-0.5" />}
             {avatar}
             {label && (
-              <span className="s-grow s-overflow-hidden s-text-ellipsis s-whitespace-nowrap group-hover/menu-item:s-pr-8 group-data-[selected=true]/menu-item:s-pr-8">
+              <span className="s-grow s-overflow-hidden s-text-ellipsis s-whitespace-nowrap group-hover/menu-item:s-pr-8 group-focus-within/menu-item:s-pr-8 group-data-[selected=true]/menu-item:s-pr-8">
                 {label}
               </span>
             )}
@@ -178,7 +178,7 @@ const NavigationListItem = React.forwardRef<
                 className={cn(
                   "s-flex-shrink-0 s-translate-x-0.5",
                   moreMenu &&
-                    "group-hover/menu-item:s-hidden group-data-[selected=true]/menu-item:s-hidden"
+                    "group-hover/menu-item:s-hidden group-focus-within/menu-item:s-hidden group-data-[selected=true]/menu-item:s-hidden"
                 )}
               />
             )}
@@ -187,7 +187,7 @@ const NavigationListItem = React.forwardRef<
                 className={cn(
                   "s-heading-xs s-flex s-flex-shrink-0 s-items-center s-justify-center s-rounded-full",
                   moreMenu &&
-                    "group-hover/menu-item:s-hidden group-data-[selected=true]/menu-item:s-hidden",
+                    "group-hover/menu-item:s-hidden group-focus-within/menu-item:s-hidden group-data-[selected=true]/menu-item:s-hidden",
                   getStatusDotColor()
                 )}
               />

--- a/sparkle/src/components/NavigationList.tsx
+++ b/sparkle/src/components/NavigationList.tsx
@@ -130,6 +130,7 @@ const NavigationListItem = React.forwardRef<
 
     const shouldShowStatusDot = status !== "idle";
     const counterValue = count && count > 0 ? count : undefined;
+    const shouldHideStatusIndicators = Boolean(moreMenu && selected);
 
     return (
       <div
@@ -170,7 +171,7 @@ const NavigationListItem = React.forwardRef<
                 {label}
               </span>
             )}
-            {counterValue && (
+            {counterValue !== undefined && !shouldHideStatusIndicators && (
               <Counter
                 value={counterValue}
                 size="xs"
@@ -178,16 +179,16 @@ const NavigationListItem = React.forwardRef<
                 className={cn(
                   "s-flex-shrink-0 s-translate-x-0.5",
                   moreMenu &&
-                    "group-hover/menu-item:s-hidden group-focus-within/menu-item:s-hidden group-data-[selected=true]/menu-item:s-hidden"
+                    "group-hover/menu-item:s-hidden group-focus-within/menu-item:s-hidden"
                 )}
               />
             )}
-            {shouldShowStatusDot && (
+            {shouldShowStatusDot && !shouldHideStatusIndicators && (
               <div
                 className={cn(
                   "s-heading-xs s-flex s-flex-shrink-0 s-items-center s-justify-center s-rounded-full",
                   moreMenu &&
-                    "group-hover/menu-item:s-hidden group-focus-within/menu-item:s-hidden group-data-[selected=true]/menu-item:s-hidden",
+                    "group-hover/menu-item:s-hidden group-focus-within/menu-item:s-hidden",
                   getStatusDotColor()
                 )}
               />


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/5886

When a navigation item is selected, the more menu button is visible. In that state we should never show the status dot/counter (regardless of hover/focus), otherwise they overlap in responsive and desktop views. This change hides those indicators whenever the item is selected and has a `moreMenu`, while keeping the hover/focus hide behavior for other states.

## Risks

Blast radius: Navigation list item styling (sidebar conversation list)
Risk: low

## Deploy Plan
- pmrr
- deploy sparkle
- deploy front
