### PR TITLE
[front-worker] - fix(Langfuse): input/output traces

### DIFF
--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -1,6 +1,7 @@
 import { startObservation } from "@langfuse/tracing";
 import { randomUUID } from "crypto";
 import pickBy from "lodash/pickBy";
+import startCase from "lodash/startCase";
 
 import type { LLMTraceId } from "@app/lib/api/llm/traces/buffer";
 import {
@@ -142,7 +143,7 @@ export abstract class LLM {
         : [{ role: "system", content: prompt }, ...conversation.messages];
 
     generation.updateTrace({
-      name: this.context.operationType,
+      name: startCase(this.context.operationType),
       input: traceInput,
       metadata: {
         dustTraceId: this.traceId,

--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -142,6 +142,7 @@ export abstract class LLM {
         : [{ role: "system", content: prompt }, ...conversation.messages];
 
     generation.updateTrace({
+      name: this.context.operationType,
       input: traceInput,
       metadata: {
         dustTraceId: this.traceId,
@@ -184,7 +185,6 @@ export abstract class LLM {
     ];
     statsDClient.increment("llm_interaction.count", 1, metricTags);
 
-    // TODO(LLM-Router 13/11/2025): Temporary logs, TBRemoved
     let currentEvent: LLMEvent | null = null;
     let timeToFirstEventMs: number | undefined = undefined;
 

--- a/front/lib/api/llm/traces/types.ts
+++ b/front/lib/api/llm/traces/types.ts
@@ -39,23 +39,10 @@ export type LLMTraceContext = LLMTraceContextBase & {
   [key: string]: string | undefined;
 };
 
-/**
- * Optional trace customization for input/output display.
- * Passed separately from context to keep tagging fields type-safe.
- */
 export interface LLMTraceCustomization {
-  /**
-   * Transform the conversation for trace input display.
-   * Return the value to set as trace input, or undefined to use default (full conversation).
-   */
   getTraceInput?: (
     conversation: ModelConversationTypeMultiActions
   ) => string | undefined;
-
-  /**
-   * Transform the LLM output for trace display.
-   * Return the value to set as trace output, or undefined to skip.
-   */
   getTraceOutput?: (
     output: LLMTraceOutput
   ) => LLMTraceOutput | string | undefined;

--- a/front/lib/api/llm/traces/types.ts
+++ b/front/lib/api/llm/traces/types.ts
@@ -40,6 +40,28 @@ export type LLMTraceContext = LLMTraceContextBase & {
 };
 
 /**
+ * Optional trace customization for input/output display.
+ * Passed separately from context to keep tagging fields type-safe.
+ */
+export interface LLMTraceCustomization {
+  /**
+   * Transform the conversation for trace input display.
+   * Return the value to set as trace input, or undefined to use default (full conversation).
+   */
+  getTraceInput?: (
+    conversation: ModelConversationTypeMultiActions
+  ) => string | undefined;
+
+  /**
+   * Transform the LLM output for trace display.
+   * Return the value to set as trace output, or undefined to skip.
+   */
+  getTraceOutput?: (
+    output: LLMTraceOutput
+  ) => LLMTraceOutput | string | undefined;
+}
+
+/**
  * Input parameters for an LLM call
  */
 export interface LLMTraceInput {

--- a/front/lib/api/llm/types/options.ts
+++ b/front/lib/api/llm/types/options.ts
@@ -1,5 +1,8 @@
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
-import type { LLMTraceContext } from "@app/lib/api/llm/traces/types";
+import type {
+  LLMTraceContext,
+  LLMTraceCustomization,
+} from "@app/lib/api/llm/traces/types";
 import type {
   ModelConversationTypeMultiActions,
   ModelIdType,
@@ -13,7 +16,7 @@ export type LLMParameters = {
   reasoningEffort?: ReasoningEffort | null;
   responseFormat?: string | null;
   temperature?: number | null;
-};
+} & LLMTraceCustomization;
 
 export type LLMClientMetadata = {
   clientId: string;


### PR DESCRIPTION
## Description

This PR improves Langfuse tracing for agent conversations by refining the input and output data captured. For `agent_conversation` operations, the trace input now only includes the last user message text (instead of the full conversation), and the trace output only shows the final agent answer (excluding intermediate tool calls).

<img width="1068" height="573" alt="Screenshot 2026-01-13 at 16 31 48" src="https://github.com/user-attachments/assets/92509672-217a-42a2-8ccf-a3df74339688" />
-----
<img width="2049" height="327" alt="Screenshot 2026-01-13 at 16 31 39" src="https://github.com/user-attachments/assets/46511da1-0221-4d94-854c-4925a404a157" />

## Risk

Medium. Changes only affect observability tracing data sent to Langfuse and do not alter the actual agent conversation behavior.

## Tests

Tested manually by reviewing Langfuse traces for agent conversations to verify improved input/output clarity.

## Deploy Plan

Deploy front