### PR TITLE
Chrisjow/project editors

### DIFF
--- a/front/components/assistant/conversation/CreateProjectModal.tsx
+++ b/front/components/assistant/conversation/CreateProjectModal.tsx
@@ -75,7 +75,7 @@ export function CreateProjectModal({
       isRestricted,
       managementMode: "manual",
       memberIds: [],
-      editorIds: user?.sId ? [user.sId] : [],
+      editorIds: user?.sId ? [user.sId] : [], // add the project creator as editor
       spaceKind: "project",
     });
 

--- a/front/components/assistant/conversation/CreateProjectModal.tsx
+++ b/front/components/assistant/conversation/CreateProjectModal.tsx
@@ -74,7 +74,8 @@ export function CreateProjectModal({
       name: trimmedName,
       isRestricted,
       managementMode: "manual",
-      memberIds: user?.sId ? [user.sId] : [],
+      memberIds: [],
+      editorIds: user?.sId ? [user.sId] : [],
       spaceKind: "project",
     });
 

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -83,7 +83,7 @@ import {
   getSkillBuilderRoute,
 } from "@app/lib/utils/router";
 import type { ConversationWithoutContentType, WorkspaceType } from "@app/types";
-import { isAdmin, isBuilder } from "@app/types";
+import { isBuilder } from "@app/types";
 
 type AgentSidebarMenuProps = {
   owner: WorkspaceType;
@@ -566,7 +566,7 @@ export function AgentSidebarMenu({ owner }: AgentSidebarMenuProps) {
                   label="Projects"
                   defaultOpen
                   action={
-                    isAdmin(owner) ? (
+                    summary.length > 0 && (
                       <Button
                         size="xs"
                         icon={PlusIcon}
@@ -579,7 +579,7 @@ export function AgentSidebarMenu({ owner }: AgentSidebarMenuProps) {
                           setIsCreateProjectModalOpen(true);
                         }}
                       />
-                    ) : null
+                    )
                   }
                 >
                   <div className="mt-0.5 px-3 sm:flex sm:flex-col sm:gap-0.5">

--- a/front/components/assistant/conversation/space/about/SpaceAboutTab.tsx
+++ b/front/components/assistant/conversation/space/about/SpaceAboutTab.tsx
@@ -144,7 +144,13 @@ export function SpaceAboutTab({
       return false;
     }
     return true;
-  }, [hasChanges, managementType, selectedMembers, selectedGroups]);
+  }, [
+    hasChanges,
+    managementType,
+    selectedMembers,
+    selectedGroups,
+    isSpaceEditor,
+  ]);
 
   const onSave = useCallback(async () => {
     if (!canSave) {
@@ -154,7 +160,7 @@ export function SpaceAboutTab({
     setIsSaving(true);
 
     if (planAllowsSCIM && managementType === "group") {
-      const updatedtedSpace = await doUpdate(space, {
+      const updatedSpace = await doUpdate(space, {
         isRestricted,
         groupIds: selectedGroups
           .filter((group) => !group.isEditor)
@@ -165,13 +171,14 @@ export function SpaceAboutTab({
         managementMode: "group",
         name: space.name,
       });
-      if (updatedtedSpace) {
+      if (updatedSpace) {
+        // reset only if the update was successful
         setSavedGroups(selectedGroups);
         setSavedManagementType("group");
         setSavedIsRestricted(isRestricted);
       }
     } else {
-      const updatedtedSpace = await doUpdate(space, {
+      const updatedSpace = await doUpdate(space, {
         isRestricted,
         memberIds: selectedMembers
           .filter((m) => !m.isEditor)
@@ -180,7 +187,8 @@ export function SpaceAboutTab({
         managementMode: "manual",
         name: space.name,
       });
-      if (updatedtedSpace) {
+      if (updatedSpace) {
+        // reset only if the update was successful
         setSavedMembers(selectedMembers);
         setSavedManagementType("manual");
         setSavedIsRestricted(isRestricted);

--- a/front/components/assistant/conversation/space/about/SpaceAboutTab.tsx
+++ b/front/components/assistant/conversation/space/about/SpaceAboutTab.tsx
@@ -158,6 +158,7 @@ export function SpaceAboutTab({
         onToggle={() => setIsRestricted(!isRestricted)}
         restrictedDescription="The project is only accessible to selected members."
         unrestrictedDescription="The project is accessible to everyone in the workspace."
+        disabled={!isSpaceEditor}
       />
       <RestrictedAccessBody
         isManual={isManual}

--- a/front/components/assistant/conversation/space/about/SpaceAboutTab.tsx
+++ b/front/components/assistant/conversation/space/about/SpaceAboutTab.tsx
@@ -115,22 +115,28 @@ export function SpaceAboutTab({
     setIsSaving(true);
 
     if (planAllowsSCIM && managementType === "group") {
-      await doUpdate(space, {
+      const updatedtedSpace = await doUpdate(space, {
         isRestricted,
         groupIds: selectedGroups.map((group) => group.sId),
         managementMode: "group",
         name: space.name,
       });
-      setSavedGroups(selectedGroups);
+      if (updatedtedSpace) {
+        setSavedGroups(selectedGroups);
+      }
     } else {
-      await doUpdate(space, {
+      const updatedtedSpace = await doUpdate(space, {
         isRestricted,
-        memberIds: selectedMembers.map((member) => member.sId),
+        memberIds: selectedMembers
+          .filter((m) => !m.isEditor)
+          .map((member) => member.sId),
         editorIds: selectedMembers.filter((m) => m.isEditor).map((m) => m.sId),
         managementMode: "manual",
         name: space.name,
       });
-      setSavedMembers(selectedMembers);
+      if (updatedtedSpace) {
+        setSavedMembers(selectedMembers);
+      }
     }
 
     setIsSaving(false);

--- a/front/components/groups/GroupsList.tsx
+++ b/front/components/groups/GroupsList.tsx
@@ -28,7 +28,7 @@ export type GroupsListProps = {
   isLoading?: boolean;
   groups: SpaceGroupType[];
   showColumns: ("name" | "memberCount" | "isEditor" | "action")[];
-  onToggleEditor: (groupId: string) => void;
+  onToggleEditor?: (groupId: string) => void;
   onRemoveGroupClick?: (group: SpaceGroupType) => void;
   pagination?: PaginationState;
   setPagination?: (pagination: PaginationState) => void;
@@ -58,14 +58,6 @@ export function GroupsList({
       onRemoveGroupClick: () => onRemoveGroupClick?.(group),
     }));
   }, [groups, onRemoveGroupClick]);
-
-  if (isLoading) {
-    return (
-      <div className="flex items-center justify-center py-8">
-        <Spinner size="lg" />
-      </div>
-    );
-  }
 
   const getTableColumns = useCallback(() => {
     return [
@@ -105,7 +97,9 @@ export function GroupsList({
           <DataTable.CellContent>
             <Checkbox
               checked={info.row.original.isEditor ?? false}
-              onCheckedChange={() => onToggleEditor(info.row.original.groupId)}
+              onCheckedChange={() =>
+                onToggleEditor?.(info.row.original.groupId)
+              }
               disabled={disabled}
             />
           </DataTable.CellContent>
@@ -131,9 +125,17 @@ export function GroupsList({
         },
       },
     ].filter((column) => showColumns.includes(column.id));
-  }, [showColumns]);
+  }, [showColumns, onToggleEditor, disabled]);
 
   const columns = useMemo(() => getTableColumns(), [getTableColumns]);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-8">
+        <Spinner size="lg" />
+      </div>
+    );
+  }
 
   return (
     <DataTable

--- a/front/components/groups/GroupsList.tsx
+++ b/front/components/groups/GroupsList.tsx
@@ -1,5 +1,6 @@
 import {
   Button,
+  Checkbox,
   DataTable,
   Spinner,
   UserGroupIcon,
@@ -7,87 +8,40 @@ import {
 } from "@dust-tt/sparkle";
 import type { CellContext, PaginationState } from "@tanstack/react-table";
 import assert from "assert";
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 
-import type { GroupType } from "@app/types";
+import type { SpaceGroupType } from "@app/types";
 
 type GroupRowData = {
   groupId: string;
   name: string;
   memberCount: number;
+  isEditor?: boolean;
   onClick?: () => void;
   onRemoveGroupClick?: () => void;
 };
 
 type GroupInfo = CellContext<GroupRowData, unknown>;
 
-const groupColumns = [
-  {
-    id: "name" as const,
-    accessorKey: "name",
-    header: "Group name",
-    cell: (info: GroupInfo) => (
-      <DataTable.CellContent icon={UserGroupIcon} className="capitalize">
-        {info.row.original.name}
-      </DataTable.CellContent>
-    ),
-    enableSorting: true,
-  },
-  {
-    id: "memberCount" as const,
-    accessorKey: "memberCount",
-    header: "Members",
-    meta: {
-      className: "w-[120px]",
-    },
-    cell: (info: GroupInfo) => (
-      <DataTable.BasicCellContent label={`${info.row.original.memberCount}`} />
-    ),
-    enableSorting: true,
-  },
-  {
-    id: "action" as const,
-    meta: {
-      className: "w-[44px]",
-    },
-    cell: (info: GroupInfo) => {
-      return (
-        <DataTable.CellContent>
-          <Button
-            icon={XMarkIcon}
-            size="xs"
-            variant="ghost-secondary"
-            onClick={info.row.original.onRemoveGroupClick}
-          />
-        </DataTable.CellContent>
-      );
-    },
-  },
-];
-
-type GroupColumnIDs = (typeof groupColumns)[number]["id"][];
-
-const filterColumn = (shownColumns: GroupColumnIDs) => {
-  return (column: (typeof groupColumns)[number]) => {
-    return shownColumns.includes(column.id);
-  };
-};
-
 export type GroupsListProps = {
   searchTerm?: string;
   isLoading?: boolean;
-  groups: GroupType[];
-  showColumns: GroupColumnIDs;
-  onRemoveGroupClick?: (group: GroupType) => void;
+  groups: SpaceGroupType[];
+  showColumns: ("name" | "memberCount" | "isEditor" | "action")[];
+  onToggleEditor: (groupId: string) => void;
+  onRemoveGroupClick?: (group: SpaceGroupType) => void;
   pagination?: PaginationState;
   setPagination?: (pagination: PaginationState) => void;
+  disabled?: boolean;
 };
 
 export function GroupsList({
   isLoading,
   groups,
   showColumns,
+  onToggleEditor,
   onRemoveGroupClick,
+  disabled,
   ...tableProps
 }: GroupsListProps) {
   assert(
@@ -100,6 +54,7 @@ export function GroupsList({
       groupId: group.sId,
       name: group.name,
       memberCount: group.memberCount,
+      isEditor: group.isEditor,
       onRemoveGroupClick: () => onRemoveGroupClick?.(group),
     }));
   }, [groups, onRemoveGroupClick]);
@@ -112,11 +67,79 @@ export function GroupsList({
     );
   }
 
+  const getTableColumns = useCallback(() => {
+    return [
+      {
+        id: "name" as const,
+        accessorKey: "name",
+        header: "Group name",
+        cell: (info: GroupInfo) => (
+          <DataTable.CellContent icon={UserGroupIcon} className="capitalize">
+            {info.row.original.name}
+          </DataTable.CellContent>
+        ),
+        enableSorting: true,
+      },
+      {
+        id: "memberCount" as const,
+        accessorKey: "memberCount",
+        header: "Members",
+        meta: {
+          className: "w-[120px]",
+        },
+        cell: (info: GroupInfo) => (
+          <DataTable.BasicCellContent
+            label={`${info.row.original.memberCount}`}
+          />
+        ),
+        enableSorting: true,
+      },
+      {
+        id: "isEditor" as const,
+        accessorKey: "isEditor",
+        header: "Editor",
+        meta: {
+          className: "w-20",
+        },
+        cell: (info: GroupInfo) => (
+          <DataTable.CellContent>
+            <Checkbox
+              checked={info.row.original.isEditor ?? false}
+              onCheckedChange={() => onToggleEditor(info.row.original.groupId)}
+              disabled={disabled}
+            />
+          </DataTable.CellContent>
+        ),
+        enableSorting: false,
+      },
+      {
+        id: "action" as const,
+        meta: {
+          className: "w-[44px]",
+        },
+        cell: (info: GroupInfo) => {
+          return (
+            <DataTable.CellContent>
+              <Button
+                icon={XMarkIcon}
+                size="xs"
+                variant="ghost-secondary"
+                onClick={info.row.original.onRemoveGroupClick}
+              />
+            </DataTable.CellContent>
+          );
+        },
+      },
+    ].filter((column) => showColumns.includes(column.id));
+  }, [showColumns]);
+
+  const columns = useMemo(() => getTableColumns(), [getTableColumns]);
+
   return (
     <DataTable
       filterColumn="name"
       data={rows}
-      columns={groupColumns.filter(filterColumn(showColumns))}
+      columns={columns}
       columnsBreakpoints={{
         name: "md",
       }}

--- a/front/components/spaces/CreateOrEditSpaceModal.tsx
+++ b/front/components/spaces/CreateOrEditSpaceModal.tsx
@@ -31,7 +31,7 @@ import type {
   LightWorkspaceType,
   PlanType,
   SpaceType,
-  UserType,
+  SpaceUserType,
 } from "@app/types";
 
 type MembersManagementType = "manual" | "group";
@@ -59,7 +59,7 @@ export function CreateOrEditSpaceModal({
 }: CreateOrEditSpaceModalProps) {
   const confirm = React.useContext(ConfirmContext);
   const [spaceName, setSpaceName] = useState<string>(space?.name ?? "");
-  const [selectedMembers, setSelectedMembers] = useState<UserType[]>([]);
+  const [selectedMembers, setSelectedMembers] = useState<SpaceUserType[]>([]);
   const [selectedGroups, setSelectedGroups] = useState<GroupType[]>([]);
 
   const [isSaving, setIsSaving] = useState(false);
@@ -129,7 +129,7 @@ export function CreateOrEditSpaceModal({
         : (defaultRestricted ?? false);
       setIsRestricted(isRestricted);
 
-      let initialMembers: UserType[] = [];
+      let initialMembers: SpaceUserType[] = [];
       if (spaceMembers && space) {
         initialMembers = spaceMembers;
       } else if (!space) {

--- a/front/components/spaces/RestrictedAccessBody.tsx
+++ b/front/components/spaces/RestrictedAccessBody.tsx
@@ -409,7 +409,14 @@ function MembersTable({
         },
       },
     ];
-  }, [onMembersUpdated, selectedMembers, sendNotifications, disabled]);
+  }, [
+    onMembersUpdated,
+    selectedMembers,
+    sendNotifications,
+    disabled,
+    canSetEditors,
+    editorIds,
+  ]);
 
   const rows = useMemo(
     () => getMemberTableRows(selectedMembers),

--- a/front/components/spaces/RestrictedAccessHeader.tsx
+++ b/front/components/spaces/RestrictedAccessHeader.tsx
@@ -5,6 +5,7 @@ interface RestrictedAccessHeaderProps {
   onToggle: () => void;
   restrictedDescription: string;
   unrestrictedDescription: string;
+  disabled?: boolean;
 }
 
 export function RestrictedAccessHeader({
@@ -12,12 +13,17 @@ export function RestrictedAccessHeader({
   onToggle,
   restrictedDescription,
   unrestrictedDescription,
+  disabled,
 }: RestrictedAccessHeaderProps) {
   return (
     <>
       <div className="flex w-full items-center justify-between overflow-visible">
         <Page.SectionHeader title="Restricted Access" />
-        <SliderToggle selected={isRestricted} onClick={onToggle} />
+        <SliderToggle
+          selected={isRestricted}
+          onClick={onToggle}
+          disabled={disabled}
+        />
       </div>
       {isRestricted ? (
         <span>{restrictedDescription}</span>

--- a/front/components/spaces/SearchGroupsDropdown.tsx
+++ b/front/components/spaces/SearchGroupsDropdown.tsx
@@ -17,12 +17,14 @@ interface SearchGroupsDropdownProps {
   owner: LightWorkspaceType;
   selectedGroups: GroupType[];
   onGroupsUpdated: (groups: GroupType[]) => void;
+  disabled?: boolean;
 }
 
 export function SearchGroupsDropdown({
   owner,
   selectedGroups,
   onGroupsUpdated,
+  disabled = false,
 }: SearchGroupsDropdownProps) {
   const [searchTerm, setSearchTerm] = useState("");
 
@@ -52,9 +54,11 @@ export function SearchGroupsDropdown({
 
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button label="Add groups" icon={PlusIcon} size="sm" />
-      </DropdownMenuTrigger>
+      {!disabled && (
+        <DropdownMenuTrigger asChild>
+          <Button label="Add groups" icon={PlusIcon} size="sm" />
+        </DropdownMenuTrigger>
+      )}
       <DropdownMenuContent
         className="w-80"
         dropdownHeaders={

--- a/front/components/spaces/SearchMembersDropdown.tsx
+++ b/front/components/spaces/SearchMembersDropdown.tsx
@@ -18,6 +18,7 @@ interface SearchMembersDropdownProps {
   owner: LightWorkspaceType;
   selectedMembers: UserType[];
   onMembersUpdated: (members: UserType[]) => void;
+  disabled?: boolean;
 }
 
 const DefaultPagination = { pageIndex: 0, pageSize: 25 };
@@ -26,6 +27,7 @@ export function SearchMembersDropdown({
   owner,
   selectedMembers,
   onMembersUpdated,
+  disabled = false,
 }: SearchMembersDropdownProps) {
   const [searchTerm, setSearchTerm] = useState("");
   const [pagination, setPagination] = useState(DefaultPagination);
@@ -83,9 +85,11 @@ export function SearchMembersDropdown({
 
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button label="Add members" icon={PlusIcon} size="sm" />
-      </DropdownMenuTrigger>
+      {!disabled && (
+        <DropdownMenuTrigger asChild>
+          <Button label="Add members" icon={PlusIcon} size="sm" />
+        </DropdownMenuTrigger>
+      )}
       <DropdownMenuContent
         className="w-80"
         dropdownHeaders={

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -537,7 +537,7 @@ export async function createAgentConfiguration(
             { transaction: t }
           );
           await auth.refresh({ transaction: t });
-          await group.setMembers(auth, editors, { transaction: t });
+          await group.setMembers(auth, { users: editors }, { transaction: t });
         } else {
           const group = await GroupResource.fetchByAgentConfiguration({
             auth,
@@ -563,9 +563,13 @@ export async function createAgentConfiguration(
             );
             throw result.error;
           }
-          const setMembersRes = await group.setMembers(auth, editors, {
-            transaction: t,
-          });
+          const setMembersRes = await group.setMembers(
+            auth,
+            { users: editors },
+            {
+              transaction: t,
+            }
+          );
           if (setMembersRes.isErr()) {
             logger.error(
               {
@@ -1233,9 +1237,13 @@ export async function updateAgentPermissions(
   try {
     const transactionResult = await withTransaction(async (t) => {
       if (usersToAdd.length > 0) {
-        const addRes = await editorGroupRes.value.addMembers(auth, usersToAdd, {
-          transaction: t,
-        });
+        const addRes = await editorGroupRes.value.addMembers(
+          auth,
+          { users: usersToAdd },
+          {
+            transaction: t,
+          }
+        );
         if (addRes.isErr()) {
           return addRes;
         }
@@ -1244,7 +1252,7 @@ export async function updateAgentPermissions(
       if (usersToRemove.length > 0) {
         const removeRes = await editorGroupRes.value.removeMembers(
           auth,
-          usersToRemove,
+          { users: usersToRemove },
           {
             transaction: t,
           }

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -22,7 +22,7 @@ import { GroupResource } from "@app/lib/resources/group_resource";
 import { KeyResource } from "@app/lib/resources/key_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
-import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces";
+import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_view_resource";
@@ -33,7 +33,6 @@ import logger from "@app/logger/logger";
 import { launchScrubSpaceWorkflow } from "@app/poke/temporal/client";
 import type { AgentsUsageType, Result } from "@app/types";
 import { Err, Ok, removeNulls, SPACE_GROUP_PREFIX } from "@app/types";
-import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
 
 export async function softDeleteSpaceAndLaunchScrubWorkflow(
   auth: Authenticator,

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -383,7 +383,7 @@ export async function createSpaceAndGroup(
         {
           name: `${SPACE_GROUP_PREFIX} ${name}`,
           workspaceId: owner.id,
-          kind: "regular",
+          kind: "space_members",
         },
         { transaction: t }
       );
@@ -417,7 +417,7 @@ export async function createSpaceAndGroup(
           {
             name: `Editors for space ${name}`,
             workspaceId: owner.id,
-            kind: "regular",
+            kind: "space_editors",
           },
           { transaction: t }
         );

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -39,11 +39,18 @@ export async function softDeleteSpaceAndLaunchScrubWorkflow(
   space: SpaceResource,
   force?: boolean
 ) {
-  assert(auth.isAdmin(), "Only admins can delete spaces.");
   assert(
     space.isRegular() || space.isProject(),
     "Cannot delete spaces that are not regular or project."
   );
+  if (space.isProject()) {
+    assert(
+      space.canAdministrate(auth),
+      "Only project admins can delete project spaces."
+    );
+  } else {
+    assert(auth.isAdmin(), "Only super admins can delete regular spaces.");
+  }
 
   const usages: AgentsUsageType[] = [];
 

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -395,7 +395,7 @@ export async function createSpaceAndGroup(
         // Create editor group
         editorGroup = await GroupResource.makeNew(
           {
-            name: `Editors for space ${name}`,
+            name: `Editors for ${spaceKind === "project" ? "project" : "space"} ${name}`,
             workspaceId: owner.id,
             kind: "space_editors",
           },
@@ -440,7 +440,7 @@ export async function createSpaceAndGroup(
                 groups: [
                   {
                     id: editorGroup.id,
-                    permissions: ["read", "write"],
+                    permissions: ["admin", "read", "write"],
                   },
                 ],
                 workspaceId: owner.id,

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -431,26 +431,22 @@ export async function createSpaceAndGroup(
       );
       const groupsResult = await memberGroup.addMembers(
         auth,
-        // Editors can add members to the space
+        // Space creators can add members to the space
         {
           users,
-          permissionsToWrite: {
-            roles: [
-              {
-                role: "admin",
-                permissions: ["read", "write", "admin"],
-              },
-            ],
-            groups: editorGroup
-              ? [
-                  {
-                    id: editorGroup.id,
-                    permissions: ["read", "write"],
-                  },
-                ]
-              : [],
-            workspaceId: owner.id,
-          },
+          permissionsToWrite:
+            memberGroup.isSpaceMemberGroup() && editorGroup
+              ? {
+                  roles: [],
+                  groups: [
+                    {
+                      id: editorGroup.id,
+                      permissions: ["read", "write"],
+                    },
+                  ],
+                  workspaceId: owner.id,
+                }
+              : undefined,
         },
         {
           transaction: t,

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -1478,7 +1478,7 @@ export class GroupResource extends BaseResource<GroupModel> {
       ];
     }
 
-    if (this.isSpaceEditorGroup()) {
+    if (this.kind === "space_editors") {
       return [
         {
           groups: [
@@ -1526,14 +1526,6 @@ export class GroupResource extends BaseResource<GroupModel> {
 
   isGlobal(): boolean {
     return this.kind === "global";
-  }
-
-  isSpaceMemberGroup(): boolean {
-    return this.kind === "space_members";
-  }
-
-  isSpaceEditorGroup(): boolean {
-    return this.kind === "space_editors";
   }
 
   isProvisioned(): boolean {

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -1484,7 +1484,7 @@ export class GroupResource extends BaseResource<GroupModel> {
           groups: [
             {
               id: this.id,
-              permissions: ["read", "write"],
+              permissions: ["admin", "read", "write"],
             },
           ],
           roles: [{ role: "admin", permissions: ["read", "write", "admin"] }],

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -37,7 +37,6 @@ import type {
   ModelId,
   ResourcePermission,
   Result,
-  RolePermission,
   UserType,
 } from "@app/types";
 import {

--- a/front/lib/resources/mcp_server_view_resource.test.ts
+++ b/front/lib/resources/mcp_server_view_resource.test.ts
@@ -186,7 +186,7 @@ describe("MCPServerViewResource", () => {
       // Add user to the group that accesses accessibleSpace
       const addMemberResult = await accessibleSpace.groups[0].addMember(
         adminAuth,
-        user.toJSON()
+        { user: user.toJSON() }
       );
       expect(addMemberResult.isOk()).toBe(true);
 
@@ -339,8 +339,8 @@ describe("MCPServerViewResource", () => {
       await MembershipFactory.associate(workspace, user, { role: "user" });
 
       // Add user to both groups
-      await space1.groups[0].addMember(adminAuth, user.toJSON());
-      await space2.groups[0].addMember(adminAuth, user.toJSON());
+      await space1.groups[0].addMember(adminAuth, { user: user.toJSON() });
+      await space2.groups[0].addMember(adminAuth, { user: user.toJSON() });
 
       // Create auth for the regular user
       const userAuth = await Authenticator.fromUserIdAndWorkspaceId(

--- a/front/lib/resources/space_resource.test.ts
+++ b/front/lib/resources/space_resource.test.ts
@@ -606,5 +606,329 @@ describe("SpaceResource", () => {
         expect(updatedSpace2?.managementMode).toBe("manual");
       });
     });
+
+    describe("project space editor and member permissions", () => {
+      let projectSpace: SpaceResource;
+      let projectMemberGroup: GroupResource;
+      let projectEditorGroup: GroupResource;
+      let editorUser: UserResource;
+      let memberUser: UserResource;
+      let nonMemberUser: UserResource;
+
+      beforeEach(async () => {
+        // Create users for testing
+        editorUser = await UserFactory.basic();
+        memberUser = await UserFactory.basic();
+        nonMemberUser = await UserFactory.basic();
+
+        await MembershipFactory.associate(workspace, editorUser, {
+          role: "user",
+        });
+        await MembershipFactory.associate(workspace, memberUser, {
+          role: "user",
+        });
+        await MembershipFactory.associate(workspace, nonMemberUser, {
+          role: "user",
+        });
+
+        // Create a project space with member and editor groups
+        projectMemberGroup = await GroupResource.makeNew({
+          name: "Project Members Group",
+          workspaceId: workspace.id,
+          kind: "space_members",
+        });
+      });
+
+      describe("with manual groups", () => {
+        beforeEach(async () => {
+          projectEditorGroup = await GroupResource.makeNew({
+            name: "Project Editors Group",
+            workspaceId: workspace.id,
+            kind: "space_editors",
+          });
+
+          projectSpace = await SpaceResource.makeNew(
+            {
+              name: "Test Project Space",
+              kind: "project",
+              workspaceId: workspace.id,
+              managementMode: "manual",
+            },
+            [projectMemberGroup]
+          );
+
+          // Link the editor group to the project space with kind="editor"
+          await GroupSpaceModel.create({
+            groupId: projectEditorGroup.id,
+            vaultId: projectSpace.id,
+            workspaceId: workspace.id,
+            kind: "editor",
+          });
+        });
+
+        it("should not allow simple members to update space permissions", async () => {
+          // Add user as a simple member
+          await projectMemberGroup.addMember(adminAuth, {
+            user: memberUser.toJSON(),
+          });
+
+          // Create an authenticator for the member user
+          const memberAuth = await Authenticator.fromUserIdAndWorkspaceId(
+            memberUser.sId,
+            workspace.sId
+          );
+
+          // Reload space to get updated groups
+          const reloadedSpace = await SpaceResource.fetchById(
+            adminAuth,
+            projectSpace.sId
+          );
+
+          // Member should NOT be able to update space permissions
+          const result = await reloadedSpace!.updatePermissions(memberAuth, {
+            name: "Test Project Space",
+            isRestricted: true,
+            managementMode: "manual",
+            memberIds: [user1.sId],
+          });
+
+          expect(result.isErr()).toBe(true);
+          if (result.isErr()) {
+            expect(result.error.code).toBe("unauthorized");
+          }
+        });
+
+        it("should not allow non-members to update space permissions", async () => {
+          // Create an authenticator for a non-member user
+          const nonMemberAuth = await Authenticator.fromUserIdAndWorkspaceId(
+            nonMemberUser.sId,
+            workspace.sId
+          );
+
+          // Reload space to get updated groups
+          const reloadedSpace = await SpaceResource.fetchById(
+            adminAuth,
+            projectSpace.sId
+          );
+
+          // Non-member should NOT be able to update space permissions
+          const result = await reloadedSpace!.updatePermissions(nonMemberAuth, {
+            name: "Test Project Space",
+            isRestricted: true,
+            managementMode: "manual",
+            memberIds: [user1.sId],
+          });
+
+          expect(result.isErr()).toBe(true);
+          if (result.isErr()) {
+            expect(result.error.code).toBe("unauthorized");
+          }
+        });
+
+        it("should allow editors to manage members through updatePermissions", async () => {
+          // Add editor to the editor group
+          await projectEditorGroup.addMember(adminAuth, {
+            user: editorUser.toJSON(),
+          });
+
+          // Create an authenticator for the editor user
+          const editorAuth = await Authenticator.fromUserIdAndWorkspaceId(
+            editorUser.sId,
+            workspace.sId
+          );
+
+          // Reload space to get updated groups
+          const reloadedSpace = await SpaceResource.fetchById(
+            editorAuth,
+            projectSpace.sId
+          );
+
+          // Editor should be able to manage members through updatePermissions
+          const result = await reloadedSpace!.updatePermissions(editorAuth, {
+            name: "Test Project Space",
+            isRestricted: true,
+            managementMode: "manual",
+            memberIds: [user1.sId, user2.sId],
+            editorIds: [editorUser.sId], // Keep the editor
+          });
+
+          expect(result.isOk()).toBe(true);
+
+          // Verify members were added
+          const members = await projectMemberGroup.getActiveMembers(adminAuth);
+          const memberSIds = members.map((m) => m.sId);
+          expect(memberSIds).toContain(user1.sId);
+          expect(memberSIds).toContain(user2.sId);
+
+          // Verify editor is still in the editor group
+          const editors = await projectEditorGroup.getActiveMembers(adminAuth);
+          const editorSIds = editors.map((m) => m.sId);
+          expect(editorSIds).toContain(editorUser.sId);
+        });
+      });
+
+      describe("with provisioned groups", () => {
+        let provisionedMemberGroup: GroupResource;
+        let provisionedEditorGroup: GroupResource;
+
+        beforeEach(async () => {
+          // Create provisioned groups
+          provisionedMemberGroup = await GroupResource.makeNew({
+            name: "Provisioned Members Group",
+            workspaceId: workspace.id,
+            kind: "provisioned",
+          });
+
+          provisionedEditorGroup = await GroupResource.makeNew({
+            name: "Provisioned Editors Group",
+            workspaceId: workspace.id,
+            kind: "provisioned",
+          });
+
+          projectSpace = await SpaceResource.makeNew(
+            {
+              name: "Test Project Space",
+              kind: "project",
+              workspaceId: workspace.id,
+              managementMode: "group",
+            },
+            [projectMemberGroup, provisionedMemberGroup]
+          );
+
+          // Link the editor group to the project space with kind="editor"
+          await GroupSpaceModel.create({
+            groupId: provisionedEditorGroup.id,
+            vaultId: projectSpace.id,
+            workspaceId: workspace.id,
+            kind: "editor",
+          });
+        });
+
+        it("should not allow simple members to update space permissions", async () => {
+          // Add user as a simple member to the provisioned group
+          await provisionedMemberGroup.addMember(adminAuth, {
+            user: memberUser.toJSON(),
+          });
+
+          // Create an authenticator for the member user
+          const memberAuth = await Authenticator.fromUserIdAndWorkspaceId(
+            memberUser.sId,
+            workspace.sId
+          );
+
+          // Reload space to get updated groups
+          const reloadedSpace = await SpaceResource.fetchById(
+            adminAuth,
+            projectSpace.sId
+          );
+
+          // Member should NOT be able to update space permissions
+          const result = await reloadedSpace!.updatePermissions(memberAuth, {
+            name: "Test Project Space",
+            isRestricted: true,
+            managementMode: "group",
+            groupIds: [provisionedMemberGroup.sId],
+          });
+
+          expect(result.isErr()).toBe(true);
+          if (result.isErr()) {
+            expect(result.error.code).toBe("unauthorized");
+          }
+        });
+
+        it("should not allow non-members to update space permissions", async () => {
+          // Create an authenticator for a non-member user
+          const nonMemberAuth = await Authenticator.fromUserIdAndWorkspaceId(
+            nonMemberUser.sId,
+            workspace.sId
+          );
+
+          // Reload space to get updated groups
+          const reloadedSpace = await SpaceResource.fetchById(
+            adminAuth,
+            projectSpace.sId
+          );
+
+          // Non-member should NOT be able to update space permissions
+          const result = await reloadedSpace!.updatePermissions(nonMemberAuth, {
+            name: "Test Project Space",
+            isRestricted: true,
+            managementMode: "group",
+            groupIds: [provisionedMemberGroup.sId],
+          });
+
+          expect(result.isErr()).toBe(true);
+          if (result.isErr()) {
+            expect(result.error.code).toBe("unauthorized");
+          }
+        });
+
+        it("should allow editors to manage members through updatePermissions", async () => {
+          // Add editor to the provisioned editor group
+          await provisionedEditorGroup.addMember(adminAuth, {
+            user: editorUser.toJSON(),
+          });
+
+          // Create another provisioned group for the new members
+          const newProvisionedMemberGroup = await GroupResource.makeNew({
+            name: "New Provisioned Members Group",
+            workspaceId: workspace.id,
+            kind: "provisioned",
+          });
+
+          // Add members to the new provisioned group
+          await newProvisionedMemberGroup.addMembers(adminAuth, {
+            users: [user1.toJSON(), user2.toJSON(), editorUser.toJSON()],
+          });
+
+          // Create an authenticator for the editor user
+          const editorAuth = await Authenticator.fromUserIdAndWorkspaceId(
+            editorUser.sId,
+            workspace.sId
+          );
+
+          // Reload space to get updated groups
+          const reloadedSpace = await SpaceResource.fetchById(
+            editorAuth,
+            projectSpace.sId
+          );
+
+          expect(newProvisionedMemberGroup.canRead(editorAuth)).toBe(true);
+
+          // Editor should be able to manage members through updatePermissions
+          const result = await reloadedSpace!.updatePermissions(editorAuth, {
+            name: "Test Project Space",
+            isRestricted: true,
+            managementMode: "group",
+            groupIds: [newProvisionedMemberGroup.sId],
+            editorGroupIds: [provisionedEditorGroup.sId], // Keep the editor group
+          });
+
+          expect(result.isOk()).toBe(true);
+
+          // Verify the new provisioned group is associated
+          const groupSpaces = await GroupSpaceModel.findAll({
+            where: {
+              vaultId: projectSpace.id,
+              workspaceId: workspace.id,
+              kind: "member",
+            },
+          });
+          const associatedGroupIds = groupSpaces.map((gs) => gs.groupId);
+          expect(associatedGroupIds).toContain(newProvisionedMemberGroup.id);
+
+          // Verify editor group is still associated
+          const editorGroupSpaces = await GroupSpaceModel.findAll({
+            where: {
+              vaultId: projectSpace.id,
+              workspaceId: workspace.id,
+              kind: "editor",
+            },
+          });
+          const editorGroupIds = editorGroupSpaces.map((gs) => gs.groupId);
+          expect(editorGroupIds).toContain(provisionedEditorGroup.id);
+        });
+      });
+    });
   });
 });

--- a/front/lib/resources/space_resource.test.ts
+++ b/front/lib/resources/space_resource.test.ts
@@ -64,7 +64,7 @@ describe("SpaceResource", () => {
       regularGroup = await GroupResource.makeNew({
         name: "Test Regular Group",
         workspaceId: workspace.id,
-        kind: "regular",
+        kind: "space_members",
       });
 
       regularSpace = await SpaceResource.makeNew(
@@ -188,10 +188,9 @@ describe("SpaceResource", () => {
 
       it("should restore suspended members when switching from group to manual mode", async () => {
         // Add members first
-        await regularGroup.addMembers(adminAuth, [
-          user1.toJSON(),
-          user2.toJSON(),
-        ]);
+        await regularGroup.addMembers(adminAuth, {
+          users: [user1.toJSON(), user2.toJSON()],
+        });
 
         // Switch to group mode (this should suspend members)
         const provisionedGroup = await GroupResource.makeNew({
@@ -387,10 +386,9 @@ describe("SpaceResource", () => {
 
       it("should suspend active members when switching from manual to group mode", async () => {
         // Add members first
-        await regularGroup.addMembers(adminAuth, [
-          user1.toJSON(),
-          user2.toJSON(),
-        ]);
+        await regularGroup.addMembers(adminAuth, {
+          users: [user1.toJSON(), user2.toJSON()],
+        });
 
         // Set space to manual mode first
         await regularSpace.updatePermissions(adminAuth, {
@@ -472,6 +470,7 @@ describe("SpaceResource", () => {
           groupId: globalGroup.id,
           vaultId: regularSpace.id,
           workspaceId: workspace.id,
+          kind: "member",
         });
 
         // Reload space to get updated groups

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -33,7 +33,6 @@ import type {
   SpaceType,
 } from "@app/types";
 import { Err, GLOBAL_SPACE_NAME, Ok, removeNulls } from "@app/types";
-import { cons } from "fp-ts/lib/ReadonlyNonEmptyArray";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -868,7 +868,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
 
   private getDefaultSpaceGroup(): GroupResource {
     const spaceMembersGroups = this.groups.filter(
-      (group) => group.group_vaults?.kind === "member"
+      (group) => group.kind === "space_members"
     );
     assert(
       spaceMembersGroups.length === 1,

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -456,7 +456,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
         `Group for ${this.isProject() ? "project" : "space"} ${newName}`
       );
     }
-    let spaceEditorGroup = this.getDefaultSpaceEditorGroup();
+    const spaceEditorGroup = this.getDefaultSpaceEditorGroup();
     if (spaceEditorGroup && (this.isRegular() || this.isPublic())) {
       await spaceEditorGroup.updateName(
         auth,

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -696,6 +696,22 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     });
   }
 
+  async linkGroup(
+    group: GroupResource,
+    kind: "member" | "editor" = "member",
+    t: Transaction
+  ) {
+    await GroupSpaceModel.create(
+      {
+        groupId: group.id,
+        vaultId: this.id,
+        workspaceId: this.workspaceId,
+        kind,
+      },
+      { transaction: t }
+    );
+  }
+
   private async addGroup(group: GroupResource) {
     await GroupSpaceModel.create({
       groupId: group.id,

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -33,7 +33,6 @@ import type {
   SpaceType,
 } from "@app/types";
 import { Err, GLOBAL_SPACE_NAME, Ok, removeNulls } from "@app/types";
-import { log } from "console";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
@@ -576,8 +575,6 @@ export class SpaceResource extends BaseResource<SpaceModel> {
         }
       }
 
-      console.log("========= updatePermissions params =========", params);
-
       if (managementMode === "manual") {
         const memberIds = params.memberIds;
         const editorIds = params.editorIds ?? [];
@@ -608,11 +605,6 @@ export class SpaceResource extends BaseResource<SpaceModel> {
               { transaction: t }
             );
           }
-
-          console.log(
-            "========= updatePermissions editorGroup =========",
-            editorGroup
-          );
 
           // Set members of the editor group
           const setEditorsRes = await editorGroup.setMembers(
@@ -669,10 +661,9 @@ export class SpaceResource extends BaseResource<SpaceModel> {
           return setMembersRes;
         }
       } else if (managementMode === "group") {
-        console.log("========= updatePermissions group mode =========");
         // Handle group-based management
         const groupIds = params.groupIds;
-        const editorGroupIds = params.editorGroupIds || [];
+        const editorGroupIds = params.editorGroupIds ?? [];
 
         // Remove existing external groups
         const existingExternalGroups = this.groups.filter(

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -631,16 +631,25 @@ export class SpaceResource extends BaseResource<SpaceModel> {
           auth,
           {
             users: users.map((u) => u.toJSON()),
-            permissionsToWrite: {
-              groups: [
-                {
-                  id: editorGroup.id,
-                  permissions: ["admin", "write", "read"],
-                },
-              ],
-              roles: [],
-              workspaceId: this.workspaceId,
-            },
+            // Editors and admins can add members to the space
+            permissionsToWrite:
+              memberGroup.isSpaceMemberGroup() && editorGroup
+                ? {
+                    groups: [
+                      {
+                        id: editorGroup.id,
+                        permissions: ["admin", "write", "read"],
+                      },
+                    ],
+                    roles: [
+                      {
+                        role: "admin",
+                        permissions: ["read", "write", "admin"],
+                      },
+                    ],
+                    workspaceId: this.workspaceId,
+                  }
+                : undefined,
           },
           { transaction: t }
         );

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -1127,19 +1127,21 @@ export class SpaceResource extends BaseResource<SpaceModel> {
         transaction,
       }
     );
-    await GroupMembershipModel.update(
-      { status: "suspended" },
-      {
-        where: {
-          groupId: defaultSpaceEditorGroup.id,
-          workspaceId: this.workspaceId,
-          status: "active",
-          startAt: { [Op.lte]: new Date() },
-          [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: new Date() } }],
-        },
-        transaction,
-      }
-    );
+    if (defaultSpaceEditorGroup) {
+      await GroupMembershipModel.update(
+        { status: "suspended" },
+        {
+          where: {
+            groupId: defaultSpaceEditorGroup.id,
+            workspaceId: this.workspaceId,
+            status: "active",
+            startAt: { [Op.lte]: new Date() },
+            [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: new Date() } }],
+          },
+          transaction,
+        }
+      );
+    }
   }
 
   /**
@@ -1166,19 +1168,21 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       }
     );
 
-    await GroupMembershipModel.update(
-      { status: "active" },
-      {
-        where: {
-          groupId: defaultSpaceEditorGroup.id,
-          workspaceId: this.workspaceId,
-          status: "suspended",
-          startAt: { [Op.lte]: new Date() },
-          [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: new Date() } }],
-        },
-        transaction,
-      }
-    );
+    if (defaultSpaceEditorGroup) {
+      await GroupMembershipModel.update(
+        { status: "active" },
+        {
+          where: {
+            groupId: defaultSpaceEditorGroup.id,
+            workspaceId: this.workspaceId,
+            status: "suspended",
+            startAt: { [Op.lte]: new Date() },
+            [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: new Date() } }],
+          },
+          transaction,
+        }
+      );
+    }
   }
 
   toJSON(): SpaceType {

--- a/front/lib/resources/storage/models/group_spaces.ts
+++ b/front/lib/resources/storage/models/group_spaces.ts
@@ -5,11 +5,13 @@ import { frontSequelize } from "@app/lib/resources/storage";
 import { GroupModel } from "@app/lib/resources/storage/models/groups";
 import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
+import type { GroupSpaceKind } from "@app/types";
 
 export class GroupSpaceModel extends WorkspaceAwareModel<GroupSpaceModel> {
   declare createdAt: CreationOptional<Date>;
   declare groupId: ForeignKey<GroupModel["id"]>;
   declare vaultId: ForeignKey<SpaceModel["id"]>;
+  declare kind: GroupSpaceKind;
 }
 GroupSpaceModel.init(
   {
@@ -17,6 +19,14 @@ GroupSpaceModel.init(
       type: DataTypes.DATE,
       allowNull: false,
       defaultValue: DataTypes.NOW,
+    },
+    kind: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      defaultValue: "member",
+      validate: {
+        isIn: [["member", "editor"]],
+      },
     },
   },
   {

--- a/front/lib/swr/groups.ts
+++ b/front/lib/swr/groups.ts
@@ -3,7 +3,7 @@ import type { Fetcher } from "swr";
 
 import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetGroupsResponseBody } from "@app/pages/api/w/[wId]/groups";
-import type { GroupKind, GroupType, LightWorkspaceType } from "@app/types";
+import type { GroupKind, LightWorkspaceType, SpaceGroupType } from "@app/types";
 
 export function useGroups({
   owner,
@@ -35,7 +35,7 @@ export function useGroups({
   });
 
   return {
-    groups: data ? data.groups : emptyArray<GroupType>(),
+    groups: data ? data.groups : emptyArray<SpaceGroupType>(),
     isGroupsLoading: !error && !data && !disabled,
     isGroupsError: !!error,
     mutateGroups: mutate,

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -545,6 +545,7 @@ export function useUpdateSpace({ owner }: { owner: LightWorkspaceType }) {
             isRestricted,
             managementMode,
             groupIds: params.groupIds,
+            editorGroupIds: params.editorGroupIds,
           }),
         })
       );

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -404,7 +404,7 @@ export function useCreateSpace({ owner }: { owner: LightWorkspaceType }) {
     let res;
 
     if (managementMode === "manual") {
-      const { memberIds } = params;
+      const { memberIds, editorIds } = params;
 
       // Must have memberIds for manual management mode
       if (isRestricted && (!memberIds || memberIds.length < 1)) {
@@ -419,6 +419,7 @@ export function useCreateSpace({ owner }: { owner: LightWorkspaceType }) {
         body: JSON.stringify({
           name,
           memberIds,
+          editorIds,
           managementMode,
           isRestricted,
           spaceKind,
@@ -524,6 +525,7 @@ export function useUpdateSpace({ owner }: { owner: LightWorkspaceType }) {
             isRestricted,
             managementMode,
             memberIds: params.memberIds,
+            editorIds: params.editorIds,
           }),
         })
       );

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -406,8 +406,12 @@ export function useCreateSpace({ owner }: { owner: LightWorkspaceType }) {
     if (managementMode === "manual") {
       const { memberIds, editorIds } = params;
 
-      // Must have memberIds for manual management mode
-      if (isRestricted && (!memberIds || memberIds.length < 1)) {
+      // Must have memberIds or editorIds for manual management mode
+      if (
+        isRestricted &&
+        (!memberIds || memberIds.length < 1) &&
+        (!editorIds || editorIds.length < 1)
+      ) {
         return null;
       }
 

--- a/front/migrations/20241205_update_space_group_names.ts
+++ b/front/migrations/20241205_update_space_group_names.ts
@@ -13,8 +13,8 @@ makeScript({}, async ({ execute }) => {
       `Found ${regularSpaces.length} regular spaces for workspace ${w.name}`
     );
     for (const space of regularSpaces) {
-      const spaceMembersGroups = space.groups.filter((g) =>
-        g.isSpaceMemberGroup()
+      const spaceMembersGroups = space.groups.filter(
+        (g) => g.kind === "space_members"
       );
       if (spaceMembersGroups.length === 1) {
         const group = spaceMembersGroups[0];
@@ -23,6 +23,19 @@ makeScript({}, async ({ execute }) => {
         }
         console.log(
           `[Execute: ${execute}] Updating group ${group.id} to "Group for space ${space.name}"`
+        );
+      }
+
+      const spaceEditorsGroups = space.groups.filter(
+        (g) => g.kind === "space_editors"
+      );
+      if (spaceEditorsGroups.length === 1) {
+        const group = spaceEditorsGroups[0];
+        if (execute) {
+          await group.updateName(auth, `Editors for space ${space.name}`);
+        }
+        console.log(
+          `[Execute: ${execute}] Updating group ${group.id} to "Editors for space ${space.name}"`
         );
       }
     }

--- a/front/migrations/20241205_update_space_group_names.ts
+++ b/front/migrations/20241205_update_space_group_names.ts
@@ -13,7 +13,7 @@ makeScript({}, async ({ execute }) => {
       `Found ${regularSpaces.length} regular spaces for workspace ${w.name}`
     );
     for (const space of regularSpaces) {
-      const regularGroups = space.groups.filter((g) => g.isRegular());
+      const regularGroups = space.groups.filter((g) => g.isSpaceMemberGroup());
       if (regularGroups.length === 1) {
         const group = regularGroups[0];
         if (execute) {

--- a/front/migrations/20241205_update_space_group_names.ts
+++ b/front/migrations/20241205_update_space_group_names.ts
@@ -13,9 +13,11 @@ makeScript({}, async ({ execute }) => {
       `Found ${regularSpaces.length} regular spaces for workspace ${w.name}`
     );
     for (const space of regularSpaces) {
-      const regularGroups = space.groups.filter((g) => g.isSpaceMemberGroup());
-      if (regularGroups.length === 1) {
-        const group = regularGroups[0];
+      const spaceMembersGroups = space.groups.filter((g) =>
+        g.isSpaceMemberGroup()
+      );
+      if (spaceMembersGroups.length === 1) {
+        const group = spaceMembersGroups[0];
         if (execute) {
           await group.updateName(auth, `Group for space ${space.name}`);
         }

--- a/front/migrations/20250428_backfill_editor_groups.ts
+++ b/front/migrations/20250428_backfill_editor_groups.ts
@@ -126,10 +126,9 @@ async function backfillAgentEditorsGroup(
   );
 
   if (execute && editorGroup) {
-    const result = await editorGroup.setMembers(
-      auth,
-      usersToAdd.map((user) => user.toJSON())
-    );
+    const result = await editorGroup.setMembers(auth, {
+      users: usersToAdd.map((user) => user.toJSON()),
+    });
 
     if (result.isErr()) {
       throw result.error;

--- a/front/migrations/20251013_suspend_group_mode_members.ts
+++ b/front/migrations/20251013_suspend_group_mode_members.ts
@@ -44,29 +44,29 @@ async function suspendGroupModeMembers(
     const groupIds = groupSpaceJunctions.map((gs) => gs.groupId);
 
     // Find regular groups among those associated with the space
-    const regularGroups = await GroupModel.findAll({
+    const spaceMemberGroups = await GroupModel.findAll({
       where: {
         id: {
           [Op.in]: groupIds,
         },
-        kind: "regular",
+        kind: "space_members",
         workspaceId: space.workspaceId,
       },
     });
 
-    if (regularGroups.length !== 1) {
+    if (spaceMemberGroups.length !== 1) {
       logger.warn(
         {
           spaceId: space.id,
           spaceName: space.name,
-          regularGroupsCount: regularGroups.length,
+          spaceMembersGroupsCount: spaceMemberGroups.length,
         },
-        "Space has unexpected number of regular groups, expected exactly 1. Skipping..."
+        "Space has unexpected number of space_members groups, expected exactly 1. Skipping..."
       );
       continue;
     }
 
-    const defaultGroup = regularGroups[0];
+    const defaultGroup = spaceMemberGroups[0];
 
     // Find all active memberships in this group
     const activeMemberships = await GroupMembershipModel.findAll({

--- a/front/pages/api/poke/workspaces/[wId]/groups/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/groups/index.ts
@@ -44,7 +44,7 @@ async function handler(
   switch (req.method) {
     case "GET":
       const groups = await GroupResource.listAllWorkspaceGroups(auth, {
-        groupKinds: ["global", "regular", "provisioned"],
+        groupKinds: ["global", "space_members", "provisioned"],
       });
 
       return res.status(200).json({

--- a/front/pages/api/poke/workspaces/[wId]/groups/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/groups/index.ts
@@ -44,7 +44,7 @@ async function handler(
   switch (req.method) {
     case "GET":
       const groups = await GroupResource.listAllWorkspaceGroups(auth, {
-        groupKinds: ["global", "space_members", "provisioned"],
+        groupKinds: ["global", "space_members", "space_editors", "provisioned"],
       });
 
       return res.status(200).json({

--- a/front/pages/api/w/[wId]/assistant/conversations/spaces/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/spaces/index.ts
@@ -27,14 +27,9 @@ async function handler(
     case "GET":
       const workspace = auth.getNonNullableWorkspace();
 
-      // Filter out non-space_member and non-space_editors groups as we only want to allow conversations in project spaces (that are linked to space_members/space_editors groups)
       const allGroups = auth
         .groups()
-        .filter(
-          (g) =>
-            (g.kind === "space_members" || g.kind === "space_editors") &&
-            g.workspaceId === workspace.id
-        );
+        .filter((g) => g.workspaceId === workspace.id);
 
       const spaces = await SpaceResource.listForGroups(auth, allGroups);
 

--- a/front/pages/api/w/[wId]/assistant/conversations/spaces/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/spaces/index.ts
@@ -27,7 +27,7 @@ async function handler(
     case "GET":
       const workspace = auth.getNonNullableWorkspace();
 
-      // Filter out non-space_member groups as we only want to allow conversations in project spaces (that are linked to space_members groups)
+      // Filter out non-space_member and non-space_editors groups as we only want to allow conversations in project spaces (that are linked to space_members/space_editors groups)
       const allGroups = auth
         .groups()
         .filter(

--- a/front/pages/api/w/[wId]/assistant/conversations/spaces/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/spaces/index.ts
@@ -27,10 +27,14 @@ async function handler(
     case "GET":
       const workspace = auth.getNonNullableWorkspace();
 
-      // Filter out non-regular groups as we only want to allow conversations in project spaces (that are linked to regular groups)
+      // Filter out non-space_member groups as we only want to allow conversations in project spaces (that are linked to space_members groups)
       const allGroups = auth
         .groups()
-        .filter((g) => g.kind === "regular" && g.workspaceId === workspace.id);
+        .filter(
+          (g) =>
+            (g.kind === "space_members" || g.kind === "space_editors") &&
+            g.workspaceId === workspace.id
+        );
 
       const spaces = await SpaceResource.listForGroups(auth, allGroups);
 

--- a/front/pages/api/w/[wId]/groups.ts
+++ b/front/pages/api/w/[wId]/groups.ts
@@ -43,7 +43,7 @@ async function handler(
         ? Array.isArray(kind)
           ? kind
           : [kind]
-        : ["global", "regular"];
+        : ["global", "space_members"];
 
       let groups: GroupResource[];
       if (spaceId) {

--- a/front/pages/api/w/[wId]/groups.ts
+++ b/front/pages/api/w/[wId]/groups.ts
@@ -43,7 +43,7 @@ async function handler(
         ? Array.isArray(kind)
           ? kind
           : [kind]
-        : ["global", "space_members"];
+        : ["global", "space_members", "space_editors"];
 
       let groups: GroupResource[];
       if (spaceId) {

--- a/front/pages/api/w/[wId]/groups.ts
+++ b/front/pages/api/w/[wId]/groups.ts
@@ -6,8 +6,6 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { GroupResource } from "@app/lib/resources/group_resource";
-import { SpaceResource } from "@app/lib/resources/space_resource";
-import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces";
 import { apiError } from "@app/logger/withlogging";
 import type {
   GroupKind,

--- a/front/pages/api/w/[wId]/groups.ts
+++ b/front/pages/api/w/[wId]/groups.ts
@@ -6,6 +6,8 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { GroupResource } from "@app/lib/resources/group_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces";
 import { apiError } from "@app/logger/withlogging";
 import type {
   GroupKind,
@@ -13,8 +15,6 @@ import type {
   WithAPIErrorResponse,
 } from "@app/types";
 import { GroupKindCodec } from "@app/types";
-import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces";
-import { SpaceResource } from "@app/lib/resources/space_resource";
 
 export type GetGroupsResponseBody = {
   groups: SpaceGroupType[];

--- a/front/pages/api/w/[wId]/skills/[sId]/editors.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/editors.ts
@@ -152,7 +152,7 @@ async function handler(
         }
       }
 
-      const addRes = await editorGroup.addMembers(auth, usersToAdd);
+      const addRes = await editorGroup.addMembers(auth, { users: usersToAdd });
       if (addRes.isErr()) {
         switch (addRes.error.code) {
           case "unauthorized":
@@ -203,7 +203,9 @@ async function handler(
         }
       }
 
-      const removeRes = await editorGroup.removeMembers(auth, usersToRemove);
+      const removeRes = await editorGroup.removeMembers(auth, {
+        users: usersToRemove,
+      });
       if (removeRes.isErr()) {
         switch (removeRes.error.code) {
           case "unauthorized":

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/index.ts
@@ -116,7 +116,10 @@ async function handler(
           await concurrentExecutor(
             // Get members from the space_member group only.
             space.groups.filter((g) => {
-              return g.isSpaceMemberGroup() || g.isSpaceEditorGroup();
+              return (
+                g.group_vaults?.kind === "member" ||
+                g.group_vaults?.kind === "editor"
+              );
             }),
             async (group) => {
               const members = includeAllMembers
@@ -124,7 +127,7 @@ async function handler(
                 : await group.getActiveMembers(auth);
               return members.map((member) => ({
                 ...member.toJSON(),
-                isEditor: group.isSpaceEditorGroup(),
+                isEditor: group.group_vaults?.kind === "editor",
               }));
             },
             { concurrency: 10 }

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/index.ts
@@ -118,7 +118,7 @@ async function handler(
           await concurrentExecutor(
             // Get members from the space_member group only.
             space.groups.filter((g) => {
-              return g.kind === "space_members" || g.kind === "space_editors";
+              return g.isSpaceMemberGroup() || g.isSpaceEditorGroup();
             }),
             async (group) => {
               const members = includeAllMembers
@@ -126,7 +126,7 @@ async function handler(
                 : await group.getActiveMembers(auth);
               return members.map((member) => ({
                 ...member.toJSON(),
-                isEditor: group.kind === "space_editors",
+                isEditor: group.isSpaceEditorGroup(),
               }));
             },
             { concurrency: 10 }

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/index.ts
@@ -114,9 +114,9 @@ async function handler(
       const currentMembers = uniqBy(
         (
           await concurrentExecutor(
-            // Get members from the regular group only.
+            // Get members from the space_member group only.
             space.groups.filter((g) => {
-              return g.kind === "regular";
+              return g.kind === "space_members";
             }),
             (group) =>
               includeAllMembers

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/index.ts
@@ -1,4 +1,3 @@
-import assert from "assert";
 import { isLeft } from "fp-ts/lib/Either";
 import * as reporter from "io-ts-reporters";
 import uniqBy from "lodash/uniqBy";
@@ -14,7 +13,6 @@ import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
-import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { apiError } from "@app/logger/withlogging";
 import type {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/index.ts
@@ -114,12 +114,9 @@ async function handler(
       })[] = uniqBy(
         (
           await concurrentExecutor(
-            // Get members from the space_member group only.
+            // Get members and editors from manual groups only.
             space.groups.filter((g) => {
-              return (
-                g.group_vaults?.kind === "member" ||
-                g.group_vaults?.kind === "editor"
-              );
+              return g.kind === "space_members" || g.kind === "space_editors";
             }),
             async (group) => {
               const members = includeAllMembers
@@ -127,7 +124,7 @@ async function handler(
                 : await group.getActiveMembers(auth);
               return members.map((member) => ({
                 ...member.toJSON(),
-                isEditor: group.group_vaults?.kind === "editor",
+                isEditor: group.group_vaults?.kind === "editor", // we rely on the information stored in group_vaults to know if the group is an editor group
               }));
             },
             { concurrency: 10 }

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/[svId]/index.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/[svId]/index.test.ts
@@ -84,7 +84,7 @@ describe("DELETE /api/w/[wId]/spaces/[spaceId]/mcp_views/[svId]", () => {
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
     const regularSpace = await SpaceFactory.regular(workspace);
-    await regularSpace.groups[0].addMember(auth, user.toJSON());
+    await regularSpace.groups[0].addMember(auth, { user: user.toJSON() });
 
     await FeatureFlagFactory.basic("dev_mcp_actions", workspace);
 

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/members.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/members.ts
@@ -31,10 +31,15 @@ const PatchSpaceMembersRequestBodySchema = t.intersection([
         editorIds: t.array(t.string),
       }),
     ]),
-    t.type({
-      groupIds: t.array(t.string),
-      managementMode: t.literal("group"),
-    }),
+    t.intersection([
+      t.type({
+        groupIds: t.array(t.string),
+        managementMode: t.literal("group"),
+      }),
+      t.partial({
+        editorGroupIds: t.array(t.string),
+      }),
+    ]),
   ]),
 ]);
 

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/members.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/members.ts
@@ -22,10 +22,15 @@ const PatchSpaceMembersRequestBodySchema = t.intersection([
     name: t.string,
   }),
   t.union([
-    t.type({
-      memberIds: t.array(t.string),
-      managementMode: t.literal("manual"),
-    }),
+    t.intersection([
+      t.type({
+        memberIds: t.array(t.string),
+        managementMode: t.literal("manual"),
+      }),
+      t.partial({
+        editorIds: t.array(t.string),
+      }),
+    ]),
     t.type({
       groupIds: t.array(t.string),
       managementMode: t.literal("group"),

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/webhook_source_views/[webhookSourceViewId]/index.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/webhook_source_views/[webhookSourceViewId]/index.test.ts
@@ -92,7 +92,9 @@ describe("DELETE /api/w/[wId]/spaces/[spaceId]/webhook_source_views/[webhookSour
     );
 
     const regularSpace = await SpaceFactory.regular(workspace);
-    await regularSpace.groups[0].addMember(authenticator, user.toJSON());
+    await regularSpace.groups[0].addMember(authenticator, {
+      user: user.toJSON(),
+    });
 
     const webhookSourceViewFactory = new WebhookSourceViewFactory(workspace);
     const webhookSourceView =

--- a/front/pages/api/w/[wId]/spaces/index.ts
+++ b/front/pages/api/w/[wId]/spaces/index.ts
@@ -27,10 +27,15 @@ const PostSpaceRequestBodySchema = t.intersection([
         editorIds: t.array(t.string),
       }),
     ]),
-    t.type({
-      groupIds: t.array(t.string),
-      managementMode: t.literal("group"),
-    }),
+    t.intersection([
+      t.type({
+        groupIds: t.array(t.string),
+        managementMode: t.literal("group"),
+      }),
+      t.partial({
+        editorGroupIds: t.array(t.string),
+      }),
+    ]),
   ]),
 ]);
 

--- a/front/pages/poke/[wId]/spaces/[spaceId]/index.tsx
+++ b/front/pages/poke/[wId]/spaces/[spaceId]/index.tsx
@@ -44,7 +44,7 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
 
   const allGroups = space.groups.filter((g) =>
     space.managementMode === "manual"
-      ? g.kind === "space_members" || g.kind === "space_editors"
+      ? g.isSpaceMemberGroup() || g.isSpaceEditorGroup()
       : g.kind === "provisioned"
   );
 

--- a/front/pages/poke/[wId]/spaces/[spaceId]/index.tsx
+++ b/front/pages/poke/[wId]/spaces/[spaceId]/index.tsx
@@ -44,7 +44,7 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
 
   const allGroups = space.groups.filter((g) =>
     space.managementMode === "manual"
-      ? g.isSpaceMemberGroup() || g.isSpaceEditorGroup()
+      ? g.group_vaults?.kind === "member" || g.group_vaults?.kind === "editor"
       : g.kind === "provisioned"
   );
 

--- a/front/pages/poke/[wId]/spaces/[spaceId]/index.tsx
+++ b/front/pages/poke/[wId]/spaces/[spaceId]/index.tsx
@@ -44,7 +44,7 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
 
   const allGroups = space.groups.filter((g) =>
     space.managementMode === "manual"
-      ? g.group_vaults?.kind === "member" || g.group_vaults?.kind === "editor"
+      ? g.kind === "space_members" || g.kind === "space_editors"
       : g.kind === "provisioned"
   );
 

--- a/front/pages/poke/[wId]/spaces/[spaceId]/index.tsx
+++ b/front/pages/poke/[wId]/spaces/[spaceId]/index.tsx
@@ -44,7 +44,7 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
 
   const allGroups = space.groups.filter((g) =>
     space.managementMode === "manual"
-      ? g.kind === "regular"
+      ? g.kind === "space_members" || g.kind === "space_editors"
       : g.kind === "provisioned"
   );
 

--- a/front/pages/w/[wId]/conversation/space/[spaceId]/index.tsx
+++ b/front/pages/w/[wId]/conversation/space/[spaceId]/index.tsx
@@ -12,7 +12,7 @@ import type { InferGetServerSidePropsType } from "next";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import type { ReactElement } from "react";
-import React, { useMemo } from "react";
+import React, { useEffect, useMemo } from "react";
 import { useCallback, useState } from "react";
 
 import { ConversationContainerVirtuoso } from "@app/components/assistant/conversation/ConversationContainer";
@@ -175,8 +175,30 @@ export default function SpaceConversations({
 
   const [currentTab, setCurrentTab] = useState<SpaceTab>(getCurrentTabFromHash);
 
+  const initialGroups = useMemo(() => {
+    if (!planAllowsSCIM || !spaceInfo || !groups) {
+      return [];
+    }
+    if (
+      (spaceInfo.groupIds && spaceInfo.groupIds.length > 0) ||
+      (spaceInfo.editorGroupIds && spaceInfo.editorGroupIds.length > 0)
+    ) {
+      return groups
+        .filter(
+          (group) =>
+            spaceInfo?.groupIds.includes(group.sId) ||
+            spaceInfo?.editorGroupIds?.includes(group.sId)
+        )
+        .map((group) => ({
+          ...group,
+          isEditor: !!spaceInfo.editorGroupIds?.includes(group.sId),
+        }));
+    }
+    return [];
+  }, [planAllowsSCIM, spaceInfo, groups]);
+
   // Sync current tab with URL hash
-  React.useEffect(() => {
+  useEffect(() => {
     const updateTabFromHash = () => {
       const newTab = getCurrentTabFromHash();
       setCurrentTab(newTab);
@@ -301,28 +323,6 @@ export default function SpaceConversations({
       />
     );
   }
-
-  const initialGroups = useMemo(() => {
-    if (!planAllowsSCIM || !spaceInfo || !groups) {
-      return [];
-    }
-    if (
-      (spaceInfo.groupIds && spaceInfo.groupIds.length > 0) ||
-      (spaceInfo.editorGroupIds && spaceInfo.editorGroupIds.length > 0)
-    ) {
-      return groups
-        .filter(
-          (group) =>
-            spaceInfo?.groupIds.includes(group.sId) ||
-            spaceInfo?.editorGroupIds?.includes(group.sId)
-        )
-        .map((group) => ({
-          ...group,
-          isEditor: !!spaceInfo.editorGroupIds?.includes(group.sId),
-        }));
-    }
-    return [];
-  }, [planAllowsSCIM, spaceInfo, groups]);
 
   return (
     <div className="flex w-full items-center justify-center overflow-auto">

--- a/front/pages/w/[wId]/conversation/space/[spaceId]/index.tsx
+++ b/front/pages/w/[wId]/conversation/space/[spaceId]/index.tsx
@@ -392,6 +392,7 @@ export default function SpaceConversations({
                 }
                 initialManagementMode={spaceInfo.managementMode}
                 initialIsRestricted={spaceInfo.isRestricted}
+                isSpaceEditor={spaceInfo.isEditor}
               />
             )}
           </TabsContent>

--- a/front/scripts/unrevoke_group_memberships.ts
+++ b/front/scripts/unrevoke_group_memberships.ts
@@ -107,7 +107,7 @@ makeScript(
       );
 
       if (execute) {
-        const result = await group.addMembers(auth, usersForGroup);
+        const result = await group.addMembers(auth, { users: usersForGroup });
         if (result.isErr()) {
           scriptLogger.error(
             { groupId: group.id, error: result.error },

--- a/front/temporal/workos_events_queue/activities.ts
+++ b/front/temporal/workos_events_queue/activities.ts
@@ -588,7 +588,7 @@ async function handleUserAddedToGroup(
 
   const isMember = await group.isMember(user);
   if (!isMember) {
-    const res = await group.addMember(auth, user.toJSON());
+    const res = await group.addMember(auth, { user: user.toJSON() });
     if (res.isErr()) {
       throw new Error(res.error.message);
     }
@@ -681,7 +681,7 @@ async function handleUserRemovedFromGroup(
     return;
   }
 
-  const res = await group.removeMember(auth, user.toJSON());
+  const res = await group.removeMember(auth, { user: user.toJSON() });
   if (res.isErr()) {
     throw new Error(res.error.message);
   }
@@ -824,7 +824,9 @@ async function handleDeleteWorkOSUser(
   });
 
   for (const group of groups) {
-    const removeResult = await group.removeMember(auth, user.toJSON());
+    const removeResult = await group.removeMember(auth, {
+      user: user.toJSON(),
+    });
     if (removeResult.isErr()) {
       logger.warn(
         {

--- a/front/tests/utils/GroupSpaceFactory.ts
+++ b/front/tests/utils/GroupSpaceFactory.ts
@@ -8,6 +8,7 @@ export class GroupSpaceFactory {
       groupId: group.id,
       vaultId: space.id,
       workspaceId: space.workspaceId,
+      kind: "member",
     });
   }
 }

--- a/front/tests/utils/GroupSpaceFactory.ts
+++ b/front/tests/utils/GroupSpaceFactory.ts
@@ -3,12 +3,16 @@ import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces";
 
 export class GroupSpaceFactory {
-  static async associate(space: SpaceResource, group: GroupResource) {
+  static async associate(
+    space: SpaceResource,
+    group: GroupResource,
+    kind: "member" | "editor" = "member"
+  ): Promise<GroupSpaceModel> {
     return GroupSpaceModel.create({
       groupId: group.id,
       vaultId: space.id,
       workspaceId: space.workspaceId,
-      kind: "member",
+      kind,
     });
   }
 }

--- a/front/tests/utils/SpaceFactory.ts
+++ b/front/tests/utils/SpaceFactory.ts
@@ -54,7 +54,7 @@ export class SpaceFactory {
     const group = await GroupResource.makeNew({
       name: `Group for space ${name}`,
       workspaceId: workspace.id,
-      kind: "regular",
+      kind: "space_members",
     });
 
     return SpaceResource.makeNew(
@@ -83,7 +83,7 @@ export class SpaceFactory {
     const group = await GroupResource.makeNew({
       name: `Group for space ${name}`,
       workspaceId: workspace.id,
-      kind: "regular",
+      kind: "space_members",
     });
 
     return SpaceResource.makeNew(

--- a/front/types/groups.ts
+++ b/front/types/groups.ts
@@ -11,7 +11,7 @@ import { isRoleType } from "./user";
  * global group: Contains all users from the workspace. Has access to the global
  * Space which holds all existing datasource created before spaces.
  *
- * regular group: Contains specific users added by workspace admins. Has access
+ * space_members group: Contains specific users added by workspace admins. Has access
  * to the list of spaces configured by workspace admins.
  *
  * agent_editors group: Group specific to represent agent editors, tied to an
@@ -25,7 +25,8 @@ import { isRoleType } from "./user";
  *  provisioned group: Contains all users from a provisioned group.
  */
 export const GROUP_KINDS = [
-  "regular",
+  "space_members",
+  "space_editors",
   "global",
   "system",
   "agent_editors",
@@ -63,7 +64,8 @@ export type GroupType = {
 
 export const GroupKindCodec = t.keyof({
   global: null,
-  regular: null,
+  space_members: null,
+  space_editors: null,
   agent_editors: null,
   skill_editors: null,
   system: null,

--- a/front/types/groups.ts
+++ b/front/types/groups.ts
@@ -25,6 +25,7 @@ import { isRoleType } from "./user";
  *  provisioned group: Contains all users from a provisioned group.
  */
 export const GROUP_KINDS = [
+  // space_members and space_editors are only used to know if a member of a manual group can edit the group
   "space_members",
   "space_editors",
   "global",

--- a/front/types/groups.ts
+++ b/front/types/groups.ts
@@ -62,6 +62,10 @@ export type GroupType = {
   memberCount: number;
 };
 
+export type SpaceGroupType = GroupType & {
+  isEditor?: boolean;
+};
+
 export const GroupKindCodec = t.keyof({
   global: null,
   space_members: null,

--- a/front/types/space.ts
+++ b/front/types/space.ts
@@ -17,6 +17,7 @@ export type UniqueSpaceKind = (typeof UNIQUE_SPACE_KINDS)[number];
 export type SpaceType = {
   createdAt: number;
   groupIds: string[];
+  editorGroupIds?: string[];
   isRestricted: boolean;
   kind: SpaceKind;
   managementMode: "manual" | "group";

--- a/front/types/space.ts
+++ b/front/types/space.ts
@@ -28,3 +28,10 @@ export type SpaceType = {
 export function isUniqueSpaceKind(kind: SpaceKind): kind is UniqueSpaceKind {
   return UNIQUE_SPACE_KINDS.includes(kind as UniqueSpaceKind);
 }
+
+// It's used only by projects
+export const GROUP_SPACE_KINDS = [
+  "member", // can access the space
+  "editor", // can manage the space
+] as const;
+export type GroupSpaceKind = (typeof GROUP_SPACE_KINDS)[number];

--- a/front/types/user.ts
+++ b/front/types/user.ts
@@ -120,6 +120,10 @@ export type UserTypeWithExtensionWorkspaces = UserType & {
   selectedWorkspace?: string;
 };
 
+export type SpaceUserType = UserType & {
+  isEditor?: boolean;
+};
+
 export type UserMetadataType = {
   key: string;
   value: string;


### PR DESCRIPTION
## Description

This PR implements editor roles for projects, allowing project creators and designated editors to manage project membership and metadata without requiring admin permissions. 
When creating a project, the creator is automatically added as an editor. Editors can then add/remove members and designate other editors.

Key changes include:
- introducing new group kinds (`space_members` and `space_editors` replacing the generic `regular` kind), 
- adding a kind field to the `group_vaults` junction table to distinguish member groups from editor groups (especially used for provisioned groups), 
- and updating permissions logic so editor groups have admin permissions on their projects. 

The UI now includes editor checkboxes in member/group management interfaces.

## Tests

Add Unit tests

## Risk

Medium. 
Regular spaces should not be impacted but the logic has been touched so a risk of regression exists.

## Deploy Plan

Deploy front
