### PR TITLE
 Reduce streaming backpressure with token event coalescing

### DIFF
--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -200,21 +200,14 @@ export async function updateResourceAndPublishEvent(
     processEventForUnreadState(auth, { event, conversation }),
   ]);
 
-  // All events go through the coalescer, which handles batching logic internally
+  // All events go through the coalescer, which handles batching logic internally.
   const key = `${conversation.sId}-${event.messageId}-${step}`;
-  await globalCoalescer.handleEvent(
-    key,
-    conversation.sId,
-    step,
+  await globalCoalescer.handleEvent({
+    conversationId: conversation.sId,
     event,
-    async (coalescedEvent) => {
-      await publishConversationRelatedEvent({
-        conversationId: conversation.sId,
-        event: coalescedEvent,
-        step,
-      });
-    }
-  );
+    key,
+    step,
+  });
 }
 
 export async function notifyWorkflowError(

--- a/front/temporal/agent_loop/lib/event_coalescer.test.ts
+++ b/front/temporal/agent_loop/lib/event_coalescer.test.ts
@@ -1,0 +1,932 @@
+import type { MockInstance } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as streamingEvents from "@app/lib/api/assistant/streaming/events";
+import type { AgentMessageEvents } from "@app/lib/api/assistant/streaming/types";
+import { globalCoalescer } from "@app/temporal/agent_loop/lib/event_coalescer";
+import type { GenerationTokensEvent } from "@app/types";
+
+describe("EventCoalescer", () => {
+  let publishMock: MockInstance;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    publishMock = vi
+      .spyOn(streamingEvents, "publishConversationRelatedEvent")
+      .mockResolvedValue();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    publishMock.mockRestore();
+  });
+
+  const createTokenEvent = (
+    text: string,
+    classification: "tokens" | "chain_of_thought" = "tokens"
+  ): GenerationTokensEvent => ({
+    type: "generation_tokens",
+    created: Date.now(),
+    configurationId: "config123",
+    messageId: "msg123",
+    text,
+    classification,
+  });
+
+  const createActionEvent = (): AgentMessageEvents => ({
+    type: "agent_action_success",
+    created: Date.now(),
+    configurationId: "config123",
+    messageId: "msg123",
+    action: {
+      id: 123,
+      sId: "action123",
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      agentMessageId: 456,
+      internalMCPServerName: null,
+      toolName: "test_tool",
+      mcpServerId: "mcp123",
+      functionCallName: "test_function",
+      functionCallId: "fc123",
+      params: {},
+      citationsAllocated: 0,
+      status: "succeeded",
+      step: 0,
+      executionDurationMs: null,
+      generatedFiles: [],
+      output: null,
+    },
+  });
+
+  const createErrorEvent = (): AgentMessageEvents => ({
+    type: "agent_error",
+    created: Date.now(),
+    configurationId: "config123",
+    messageId: "msg123",
+    error: {
+      code: "test_error",
+      message: "Test error",
+      metadata: {},
+    },
+  });
+
+  describe("Token Batching", () => {
+    it("batches multiple tokens within 100ms", async () => {
+      const key = "conv123-msg123-0";
+      const conversationId = "conv123";
+      const step = 0;
+
+      // Send 5 tokens rapidly
+      await globalCoalescer.handleEvent({
+        key,
+        conversationId,
+        step,
+        event: createTokenEvent("token1"),
+      });
+      await globalCoalescer.handleEvent({
+        key,
+        conversationId,
+        step,
+        event: createTokenEvent("token2"),
+      });
+      await globalCoalescer.handleEvent({
+        key,
+        conversationId,
+        step,
+        event: createTokenEvent("token3"),
+      });
+      await globalCoalescer.handleEvent({
+        key,
+        conversationId,
+        step,
+        event: createTokenEvent("token4"),
+      });
+      await globalCoalescer.handleEvent({
+        key,
+        conversationId,
+        step,
+        event: createTokenEvent("token5"),
+      });
+
+      // No publishes yet
+      expect(publishMock).toHaveBeenCalledTimes(0);
+
+      // Advance timer by 100ms
+      await vi.advanceTimersByTimeAsync(100);
+
+      // Should have published once with concatenated text
+      expect(publishMock).toHaveBeenCalledTimes(1);
+      expect(publishMock).toHaveBeenCalledWith({
+        conversationId: "conv123",
+        event: expect.objectContaining({
+          type: "generation_tokens",
+          text: "token1token2token3token4token5",
+        }),
+        step: 0,
+      });
+    });
+
+    it("starts new batch after flush completes", async () => {
+      const key = "conv123-msg123-0";
+      const conversationId = "conv123";
+      const step = 0;
+
+      // First batch
+      await globalCoalescer.handleEvent({
+        key,
+        conversationId,
+        step,
+        event: createTokenEvent("batch1token1"),
+      });
+      await globalCoalescer.handleEvent({
+        key,
+        conversationId,
+        step,
+        event: createTokenEvent("batch1token2"),
+      });
+
+      await vi.advanceTimersByTimeAsync(100);
+      expect(publishMock).toHaveBeenCalledTimes(1);
+      expect(publishMock).toHaveBeenCalledWith({
+        conversationId: "conv123",
+        event: expect.objectContaining({
+          text: "batch1token1batch1token2",
+        }),
+        step: 0,
+      });
+
+      publishMock.mockClear();
+
+      // Second batch
+      await globalCoalescer.handleEvent({
+        key,
+        conversationId,
+        step,
+        event: createTokenEvent("batch2token1"),
+      });
+      await globalCoalescer.handleEvent({
+        key,
+        conversationId,
+        step,
+        event: createTokenEvent("batch2token2"),
+      });
+
+      await vi.advanceTimersByTimeAsync(100);
+      expect(publishMock).toHaveBeenCalledTimes(1);
+      expect(publishMock).toHaveBeenCalledWith({
+        conversationId: "conv123",
+        event: expect.objectContaining({
+          text: "batch2token1batch2token2",
+        }),
+        step: 0,
+      });
+    });
+  });
+
+  describe("Event Ordering", () => {
+    it("flushes pending tokens before non-token events", async () => {
+      const key = "conv123-msg123-0";
+      const conversationId = "conv123";
+      const step = 0; // Send 3 tokens
+      await globalCoalescer.handleEvent({
+        key,
+        conversationId,
+        step,
+        event: createTokenEvent("token1"),
+      });
+      await globalCoalescer.handleEvent({
+        key,
+        conversationId,
+        step,
+        event: createTokenEvent("token2"),
+      });
+      await globalCoalescer.handleEvent({
+        key,
+        conversationId,
+        step,
+        event: createTokenEvent("token3"),
+      });
+
+      // Before timer expires, send an action event
+      await globalCoalescer.handleEvent({
+        key,
+        conversationId,
+        step,
+        event: createActionEvent(),
+      });
+
+      // Should have flushed tokens and published action (2 calls)
+      expect(publishMock).toHaveBeenCalledTimes(2);
+
+      // First call: batched tokens
+      expect(publishMock).toHaveBeenNthCalledWith(1, {
+        conversationId: "conv123",
+        event: expect.objectContaining({
+          type: "generation_tokens",
+          text: "token1token2token3",
+        }),
+        step: 0,
+      });
+
+      // Second call: action event
+      expect(publishMock).toHaveBeenNthCalledWith(2, {
+        conversationId: "conv123",
+        event: expect.objectContaining({
+          type: "agent_action_success",
+        }),
+        step: 0,
+      });
+    });
+
+    it("preserves event order with mixed event sequence", async () => {
+      const key = "conv123-msg123-0";
+      const conversationId = "conv123";
+      const step = 0; // token1, token2
+      await globalCoalescer.handleEvent({
+        key,
+        conversationId,
+        step,
+        event: createTokenEvent("token1"),
+      });
+      await globalCoalescer.handleEvent({
+        key,
+        conversationId,
+        step,
+        event: createTokenEvent("token2"),
+      });
+
+      // action (should flush token1+token2)
+      await globalCoalescer.handleEvent({
+        key,
+        conversationId,
+        step,
+        event: createActionEvent(),
+      });
+
+      // token3, token4
+      await globalCoalescer.handleEvent({
+        key,
+        conversationId,
+        step,
+        event: createTokenEvent("token3"),
+      });
+      await globalCoalescer.handleEvent({
+        key,
+        conversationId,
+        step,
+        event: createTokenEvent("token4"),
+      });
+
+      // error (should flush token3+token4)
+      await globalCoalescer.handleEvent({
+        key,
+        conversationId,
+        step,
+        event: createErrorEvent(),
+      });
+
+      // Should have 4 publish calls in correct order
+      expect(publishMock).toHaveBeenCalledTimes(4);
+
+      // 1. Batched token1+token2 (flushed by action)
+      expect(publishMock).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          event: expect.objectContaining({
+            type: "generation_tokens",
+            text: "token1token2",
+          }),
+        })
+      );
+
+      // 2. Action event
+      expect(publishMock).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          event: expect.objectContaining({
+            type: "agent_action_success",
+          }),
+        })
+      );
+
+      // 3. Batched token3+token4 (flushed by error)
+      expect(publishMock).toHaveBeenNthCalledWith(
+        3,
+        expect.objectContaining({
+          event: expect.objectContaining({
+            type: "generation_tokens",
+            text: "token3token4",
+          }),
+        })
+      );
+
+      // 4. Error event
+      expect(publishMock).toHaveBeenNthCalledWith(
+        4,
+        expect.objectContaining({
+          event: expect.objectContaining({
+            type: "agent_error",
+          }),
+        })
+      );
+    });
+  });
+
+  describe("Multiple Buffers", () => {
+    it("batches independently for different keys", async () => {
+      const key1 = "conv123-msg123-0";
+      const key2 = "conv456-msg456-1";
+      const conversationId1 = "conv123";
+      const conversationId2 = "conv456";
+
+      // Send tokens to key1
+      await globalCoalescer.handleEvent({
+        key: key1,
+        conversationId: conversationId1,
+        step: 0,
+        event: createTokenEvent("key1token1"),
+      });
+      await globalCoalescer.handleEvent({
+        key: key1,
+        conversationId: conversationId1,
+        step: 0,
+        event: createTokenEvent("key1token2"),
+      });
+
+      // Send tokens to key2
+      await globalCoalescer.handleEvent({
+        key: key2,
+        conversationId: conversationId2,
+        step: 1,
+        event: createTokenEvent("key2token1"),
+      });
+      await globalCoalescer.handleEvent({
+        key: key2,
+        conversationId: conversationId2,
+        step: 1,
+        event: createTokenEvent("key2token2"),
+      });
+
+      // Advance timer
+      await vi.advanceTimersByTimeAsync(100);
+
+      // Should have published both keys independently
+      expect(publishMock).toHaveBeenCalledTimes(2);
+      expect(publishMock).toHaveBeenCalledWith({
+        conversationId: "conv123",
+        event: expect.objectContaining({
+          text: "key1token1key1token2",
+        }),
+        step: 0,
+      });
+      expect(publishMock).toHaveBeenCalledWith({
+        conversationId: "conv456",
+        event: expect.objectContaining({
+          text: "key2token1key2token2",
+        }),
+        step: 1,
+      });
+    });
+  });
+
+  describe("Safety Mechanisms", () => {
+    it("forces flush after max buffer age", async () => {
+      const key = "conv123-msg123-0";
+      const conversationId = "conv123";
+      const step = 0;
+
+      // Send first token
+      await globalCoalescer.handleEvent({
+        key,
+        conversationId,
+        step,
+        event: createTokenEvent("token1"),
+      });
+
+      // Advance time by 61 seconds (exceeds MAX_BUFFER_AGE_MS of 60s)
+      await vi.advanceTimersByTimeAsync(61_000);
+
+      // Should have force-flushed
+      expect(publishMock).toHaveBeenCalledTimes(1);
+      expect(publishMock).toHaveBeenCalledWith({
+        conversationId: "conv123",
+        event: expect.objectContaining({
+          text: "token1",
+        }),
+        step: 0,
+      });
+
+      publishMock.mockClear();
+
+      // Send another token (should start new buffer)
+      await globalCoalescer.handleEvent({
+        key,
+        conversationId,
+        step,
+        event: createTokenEvent("token2"),
+      });
+
+      // Should not have published yet
+      expect(publishMock).toHaveBeenCalledTimes(0);
+
+      // Advance by 100ms
+      await vi.advanceTimersByTimeAsync(100);
+
+      // Should publish token2 separately
+      expect(publishMock).toHaveBeenCalledTimes(1);
+      expect(publishMock).toHaveBeenCalledWith({
+        conversationId: "conv123",
+        event: expect.objectContaining({
+          text: "token2",
+        }),
+        step: 0,
+      });
+    });
+
+    it("periodic cleanup flushes stale buffers", async () => {
+      const key = "conv123-msg123-0";
+      const conversationId = "conv123";
+      const step = 0;
+
+      // Send token to create buffer
+      await globalCoalescer.handleEvent({
+        key,
+        conversationId,
+        step,
+        event: createTokenEvent("staletoken"),
+      });
+
+      // Advance time to make buffer stale (61 seconds)
+      await vi.advanceTimersByTimeAsync(61_000);
+
+      // The max buffer age check in handleEvent won't trigger since we're not sending more events
+      // So we need to call cleanup() directly to test the cleanup mechanism
+      await globalCoalescer.cleanup();
+
+      // Should have flushed the stale buffer
+      expect(publishMock).toHaveBeenCalledTimes(1);
+      expect(publishMock).toHaveBeenCalledWith({
+        conversationId: "conv123",
+        event: expect.objectContaining({
+          text: "staletoken",
+        }),
+        step: 0,
+      });
+    });
+
+    it("cleanup flushes accumulated data before deleting", async () => {
+      const key = "conv123-msg123-0";
+      const conversationId = "conv123";
+      const step = 0;
+
+      // Create buffer with multiple tokens
+      await globalCoalescer.handleEvent({
+        key,
+        conversationId,
+        step,
+        event: createTokenEvent("token1"),
+      });
+      await globalCoalescer.handleEvent({
+        key,
+        conversationId,
+        step,
+        event: createTokenEvent("token2"),
+      });
+      await globalCoalescer.handleEvent({
+        key,
+        conversationId,
+        step,
+        event: createTokenEvent("token3"),
+      });
+
+      // Make buffer stale
+      await vi.advanceTimersByTimeAsync(61_000);
+
+      // Cleanup
+      await globalCoalescer.cleanup();
+
+      // Should have published all accumulated tokens
+      expect(publishMock).toHaveBeenCalledTimes(1);
+      expect(publishMock).toHaveBeenCalledWith({
+        conversationId: "conv123",
+        event: expect.objectContaining({
+          text: "token1token2token3",
+        }),
+        step: 0,
+      });
+    });
+  });
+
+  describe("Real-world Event Patterns", () => {
+    it("handles complete real event sequence with delimiters", async () => {
+      const key = "conv123-msg123-0";
+      const conversationId = "conv123";
+      const step = 0; // 1. Opening delimiter - should publish immediately
+      const openingDelimiter: GenerationTokensEvent = {
+        type: "generation_tokens",
+        created: Date.now(),
+        configurationId: "dust",
+        messageId: "msg123",
+        text: "<thinking>",
+        classification: "opening_delimiter",
+        delimiterClassification: "chain_of_thought",
+      };
+      await globalCoalescer.handleEvent({
+        key,
+        conversationId,
+        step,
+        event: openingDelimiter,
+      });
+
+      // 2. Multiple chain_of_thought tokens - should batch
+      await globalCoalescer.handleEvent({
+        key,
+        conversationId,
+        step,
+        event: createTokenEvent("\nThe user is", "chain_of_thought"),
+      });
+      await globalCoalescer.handleEvent({
+        key,
+        conversationId,
+        step,
+        event: createTokenEvent(" asking for", "chain_of_thought"),
+      });
+      await globalCoalescer.handleEvent({
+        key,
+        conversationId,
+        step,
+        event: createTokenEvent(" a poem", "chain_of_thought"),
+      });
+
+      // 3. Closing delimiter - should flush pending chain_of_thought and publish immediately
+      const closingDelimiter: GenerationTokensEvent = {
+        type: "generation_tokens",
+        created: Date.now(),
+        configurationId: "dust",
+        messageId: "msg123",
+        text: "</thinking>",
+        classification: "closing_delimiter",
+        delimiterClassification: "chain_of_thought",
+      };
+      await globalCoalescer.handleEvent({
+        key,
+        conversationId,
+        step,
+        event: closingDelimiter,
+      });
+
+      // 4. Regular tokens after delimiter - should batch separately
+      await globalCoalescer.handleEvent({
+        key,
+        conversationId,
+        step,
+        event: createTokenEvent("\n\n", "tokens"),
+      });
+      await globalCoalescer.handleEvent({
+        key,
+        conversationId,
+        step,
+        event: createTokenEvent("A poem about", "tokens"),
+      });
+
+      // Advance timer to flush regular tokens
+      await vi.advanceTimersByTimeAsync(100);
+
+      // Verify the order:
+      // Verify the order: 4 publish calls
+      expect(publishMock).toHaveBeenCalledTimes(4);
+
+      // 1. Opening delimiter published immediately
+      expect(publishMock).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          event: expect.objectContaining({
+            type: "generation_tokens",
+            classification: "opening_delimiter",
+            text: "<thinking>",
+          }),
+        })
+      );
+
+      // 2. Batched chain_of_thought tokens (flushed by closing delimiter)
+      expect(publishMock).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          event: expect.objectContaining({
+            type: "generation_tokens",
+            classification: "chain_of_thought",
+            text: "\nThe user is asking for a poem",
+          }),
+        })
+      );
+
+      // 3. Closing delimiter published immediately
+      expect(publishMock).toHaveBeenNthCalledWith(
+        3,
+        expect.objectContaining({
+          event: expect.objectContaining({
+            type: "generation_tokens",
+            classification: "closing_delimiter",
+            text: "</thinking>",
+          }),
+        })
+      );
+
+      // 4. Batched regular tokens (flushed by timer)
+      expect(publishMock).toHaveBeenNthCalledWith(
+        4,
+        expect.objectContaining({
+          event: expect.objectContaining({
+            type: "generation_tokens",
+            classification: "tokens",
+            text: "\n\nA poem about",
+          }),
+        })
+      );
+    });
+
+    it("handles opening_delimiter flushing pending tokens", async () => {
+      const key = "conv123-msg123-0";
+      const conversationId = "conv123";
+      const step = 0; // Send regular tokens
+      await globalCoalescer.handleEvent({
+        key,
+        conversationId,
+        step,
+        event: createTokenEvent("token1"),
+      });
+      await globalCoalescer.handleEvent({
+        key,
+        conversationId,
+        step,
+        event: createTokenEvent("token2"),
+      });
+
+      // Send opening_delimiter (should flush pending tokens first)
+      const openingDelimiterEvent: GenerationTokensEvent = {
+        type: "generation_tokens",
+        created: Date.now(),
+        configurationId: "config123",
+        messageId: "msg123",
+        text: "<thinking>",
+        classification: "opening_delimiter",
+        delimiterClassification: "chain_of_thought",
+      };
+      await globalCoalescer.handleEvent({
+        key,
+        conversationId,
+        step,
+        event: openingDelimiterEvent,
+      });
+
+      // Should have flushed batched tokens, then published delimiter
+      expect(publishMock).toHaveBeenCalledTimes(2);
+
+      // First: batched tokens
+      expect(publishMock).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          event: expect.objectContaining({
+            type: "generation_tokens",
+            classification: "tokens",
+            text: "token1token2",
+          }),
+        })
+      );
+
+      // Second: opening delimiter
+      expect(publishMock).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          event: expect.objectContaining({
+            type: "generation_tokens",
+            classification: "opening_delimiter",
+            text: "<thinking>",
+          }),
+        })
+      );
+    });
+
+    it("handles closing_delimiter flushing pending tokens", async () => {
+      const key = "conv123-msg123-0";
+      const conversationId = "conv123";
+      const step = 0; // Send chain_of_thought tokens
+      await globalCoalescer.handleEvent({
+        key,
+        conversationId,
+        step,
+        event: createTokenEvent("thought1", "chain_of_thought"),
+      });
+      await globalCoalescer.handleEvent({
+        key,
+        conversationId,
+        step,
+        event: createTokenEvent("thought2", "chain_of_thought"),
+      });
+
+      // Send closing_delimiter (should flush pending chain_of_thought tokens first)
+      const closingDelimiterEvent: GenerationTokensEvent = {
+        type: "generation_tokens",
+        created: Date.now(),
+        configurationId: "config123",
+        messageId: "msg123",
+        text: "</thinking>",
+        classification: "closing_delimiter",
+        delimiterClassification: "chain_of_thought",
+      };
+      await globalCoalescer.handleEvent({
+        key,
+        conversationId,
+        step,
+        event: closingDelimiterEvent,
+      });
+
+      // Should have flushed batched chain_of_thought tokens, then published delimiter
+      expect(publishMock).toHaveBeenCalledTimes(2);
+
+      // First: batched chain_of_thought tokens
+      expect(publishMock).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          event: expect.objectContaining({
+            type: "generation_tokens",
+            classification: "chain_of_thought",
+            text: "thought1thought2",
+          }),
+        })
+      );
+
+      // Second: closing delimiter
+      expect(publishMock).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          event: expect.objectContaining({
+            type: "generation_tokens",
+            classification: "closing_delimiter",
+            text: "</thinking>",
+          }),
+        })
+      );
+    });
+
+    it("flushes buffer when classification changes from tokens to chain_of_thought", async () => {
+      const key = "conv123-msg123-0";
+      const conversationId = "conv123";
+      const step = 0;
+
+      // Send regular tokens
+      await globalCoalescer.handleEvent({
+        key,
+        conversationId,
+        step,
+        event: createTokenEvent("regular ", "tokens"),
+      });
+      await globalCoalescer.handleEvent({
+        key,
+        conversationId,
+        step,
+        event: createTokenEvent("tokens", "tokens"),
+      });
+
+      // Send chain_of_thought token (should flush regular tokens first)
+      await globalCoalescer.handleEvent({
+        key,
+        conversationId,
+        step,
+        event: createTokenEvent("thought", "chain_of_thought"),
+      });
+
+      // Should have published regular tokens when classification changed
+      expect(publishMock).toHaveBeenCalledTimes(1);
+      expect(publishMock).toHaveBeenCalledWith({
+        conversationId: "conv123",
+        event: expect.objectContaining({
+          text: "regular tokens",
+          classification: "tokens",
+        }),
+        step: 0,
+      });
+
+      publishMock.mockClear();
+
+      // Advance timer to flush chain_of_thought tokens
+      await vi.advanceTimersByTimeAsync(100);
+
+      // Should have published chain_of_thought separately
+      expect(publishMock).toHaveBeenCalledTimes(1);
+      expect(publishMock).toHaveBeenCalledWith({
+        conversationId: "conv123",
+        event: expect.objectContaining({
+          text: "thought",
+          classification: "chain_of_thought",
+        }),
+        step: 0,
+      });
+    });
+
+    it("flushes buffer when classification changes from chain_of_thought to tokens", async () => {
+      const key = "conv123-msg123-0";
+      const conversationId = "conv123";
+      const step = 0;
+
+      // Send chain_of_thought tokens
+      await globalCoalescer.handleEvent({
+        key,
+        conversationId,
+        step,
+        event: createTokenEvent("thinking ", "chain_of_thought"),
+      });
+      await globalCoalescer.handleEvent({
+        key,
+        conversationId,
+        step,
+        event: createTokenEvent("hard", "chain_of_thought"),
+      });
+
+      // Send regular token (should flush chain_of_thought first)
+      await globalCoalescer.handleEvent({
+        key,
+        conversationId,
+        step,
+        event: createTokenEvent("output", "tokens"),
+      });
+
+      // Should have published chain_of_thought tokens when classification changed
+      expect(publishMock).toHaveBeenCalledTimes(1);
+      expect(publishMock).toHaveBeenCalledWith({
+        conversationId: "conv123",
+        event: expect.objectContaining({
+          text: "thinking hard",
+          classification: "chain_of_thought",
+        }),
+        step: 0,
+      });
+    });
+
+    it("batches same-classification tokens after different classification", async () => {
+      // This test verifies that after a classification change, tokens with the
+      // same classification still batch correctly in the new buffer
+      // Use unique key to avoid state pollution from previous tests
+      const key = "conv-batch-test-msg123-0";
+      const conversationId = "conv-batch-test";
+      const step = 0;
+
+      // First send regular tokens
+      await globalCoalescer.handleEvent({
+        key,
+        conversationId,
+        step,
+        event: createTokenEvent("regular", "tokens"),
+      });
+
+      // Switch to chain_of_thought (flushes previous buffer)
+      await globalCoalescer.handleEvent({
+        key,
+        conversationId,
+        step,
+        event: createTokenEvent("thought1", "chain_of_thought"),
+      });
+
+      // Verify first buffer was flushed
+      expect(publishMock).toHaveBeenCalledTimes(1);
+      expect(publishMock).toHaveBeenCalledWith({
+        conversationId: "conv-batch-test",
+        event: expect.objectContaining({
+          text: "regular",
+          classification: "tokens",
+        }),
+        step: 0,
+      });
+
+      publishMock.mockClear();
+
+      // Continue adding chain_of_thought tokens - these should batch together
+      await globalCoalescer.handleEvent({
+        key,
+        conversationId,
+        step,
+        event: createTokenEvent("thought2", "chain_of_thought"),
+      });
+      await globalCoalescer.handleEvent({
+        key,
+        conversationId,
+        step,
+        event: createTokenEvent("thought3", "chain_of_thought"),
+      });
+
+      await vi.advanceTimersByTimeAsync(100);
+
+      // Should batch all chain_of_thought tokens together
+      expect(publishMock).toHaveBeenCalledTimes(1);
+      expect(publishMock).toHaveBeenCalledWith({
+        conversationId: "conv-batch-test",
+        event: expect.objectContaining({
+          text: "thought1thought2thought3",
+          classification: "chain_of_thought",
+        }),
+        step: 0,
+      });
+    });
+  });
+});

--- a/front/temporal/agent_loop/lib/event_coalescer.ts
+++ b/front/temporal/agent_loop/lib/event_coalescer.ts
@@ -1,0 +1,140 @@
+import { publishConversationRelatedEvent } from "@app/lib/api/assistant/streaming/events";
+import type { AgentMessageEvents } from "@app/lib/api/assistant/streaming/types";
+import logger from "@app/logger/logger";
+import type { GenerationTokensEvent } from "@app/types";
+
+const FLUSH_INTERVAL_MS = 100;
+const MAX_BUFFER_AGE_MS = 60_000; // 1 minute
+const CLEANUP_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+
+interface BufferedEvent {
+  latestEvent: GenerationTokensEvent;
+  accumulatedText: string;
+  firstTokenAt: number;
+  timer: NodeJS.Timeout;
+  // Store metadata to avoid parsing key
+  conversationId: string;
+  step: number;
+}
+
+/**
+ * EventCoalescer batches generation_tokens events to reduce Redis writes
+ * and function call overhead. Buffers tokens for 100ms before publishing.
+ *
+ * Safety mechanisms:
+ * - maxBufferAge: Forces flush after 60s
+ * - Periodic cleanup: Flushes and removes stale buffers every 5 minutes
+ * - Terminal events: Bypass coalescing and flush immediately
+ */
+class EventCoalescer {
+  private buffers = new Map<string, BufferedEvent>();
+
+  /**
+   * Handle an event. generation_tokens are batched, other events are passed through immediately to
+   * the publishFn callback.
+   */
+  async handleEvent(
+    key: string,
+    conversationId: string,
+    step: number,
+    event: AgentMessageEvents,
+    publishFn: (coalescedEvent: AgentMessageEvents) => Promise<void>
+  ): Promise<void> {
+    // Non-token events: flush any pending tokens for this key, then publish immediately.
+    if (event.type !== "generation_tokens") {
+      await this.flush(key);
+      await publishFn(event);
+      return;
+    }
+
+    // Token event: accumulate.
+    const existing = this.buffers.get(key);
+    if (!existing) {
+      // First token in window, start new buffer.
+      const timer = setTimeout(() => {
+        void this.flush(key);
+      }, FLUSH_INTERVAL_MS);
+
+      this.buffers.set(key, {
+        latestEvent: event,
+        accumulatedText: event.text,
+        firstTokenAt: Date.now(),
+        timer,
+        conversationId,
+        step,
+      });
+    } else {
+      // Accumulate tokens.
+      existing.accumulatedText += event.text;
+      existing.latestEvent = event; // Keep latest metadata (classification, etc.)
+
+      // Safety: if buffer is too old, force flush.
+      if (Date.now() - existing.firstTokenAt > MAX_BUFFER_AGE_MS) {
+        clearTimeout(existing.timer);
+        await this.flush(key);
+      }
+    }
+  }
+
+  /**
+   * Flush a specific buffer, publishes the accumulated tokens.
+   */
+  private async flush(key: string): Promise<void> {
+    const buffered = this.buffers.get(key);
+    if (!buffered) {
+      return;
+    }
+
+    this.buffers.delete(key);
+    clearTimeout(buffered.timer);
+
+    // Publish single coalesced event with all accumulated text
+    const coalescedEvent: GenerationTokensEvent = {
+      ...buffered.latestEvent,
+      text: buffered.accumulatedText,
+      created: Date.now(), // Update timestamp.
+    };
+
+    await publishConversationRelatedEvent({
+      conversationId: buffered.conversationId,
+      event: coalescedEvent,
+      step: buffered.step,
+    });
+  }
+
+  /**
+   * Cleanup stale buffers, flushes and removes buffers older than maxBufferAge.
+   * Called periodically to prevent memory leaks.
+   */
+  async cleanup(): Promise<void> {
+    const now = Date.now();
+    const staleKeys: string[] = [];
+
+    for (const [key, buffer] of this.buffers.entries()) {
+      if (now - buffer.firstTokenAt > MAX_BUFFER_AGE_MS) {
+        staleKeys.push(key);
+      }
+    }
+
+    if (staleKeys.length > 0) {
+      logger.info(
+        { count: staleKeys.length },
+        "Cleaning up stale event coalescer buffers"
+      );
+
+      for (const key of staleKeys) {
+        await this.flush(key);
+      }
+    }
+  }
+}
+
+// Singleton instance.
+const globalCoalescer = new EventCoalescer();
+
+// Periodic cleanup every 5 minutes.
+setInterval(() => {
+  void globalCoalescer.cleanup();
+}, CLEANUP_INTERVAL_MS);
+
+export { globalCoalescer };


### PR DESCRIPTION
## Description

Implement token event coalescing to reduce Redis backpressure on streaming endpoints.

A small local test shows 3x less tokens for a simple task (no tool calls).

### Context

We observed bursts of memory usage and high CPU with backpressure on `/events` streaming endpoints.

<img width="1055" height="338" alt="image" src="https://github.com/user-attachments/assets/9579d434-a084-43f5-b8d7-1557daded35f" />

Datadog dashboard: [here](https://app.datadoghq.eu/notebook/284787/flavien-jan-12-2026-13-49?fullscreen_end_ts=1768319789443&fullscreen_paused=false&fullscreen_refresh_mode=sliding&fullscreen_start_ts=1768318889443&fullscreen_widget=60q8cnoe&refresh_mode=sliding&from_ts=1768310324946&to_ts=1768311224946).

Analysis showed that `generation_tokens` events were generating excessive Redis publishes. One for each token received from the LLM. They are being debounced in the client-side already, see below:

https://github.com/dust-tt/dust/blob/f5db1a476a76598d1f661af0c00320f3128a68b6/front/hooks/useAgentMessageStream.ts#L23C7-L23C29

## Changes

### 1. Implemented `EventCoalescer`

Created `EventCoalescer` class to batch `generation_tokens` events before publishing to Redis:

**Key Features:**
- **100ms debounce window**: Batches tokens within 100ms before publishing
- **Classification-aware batching**: Only batches tokens with the same classification (`tokens`, `chain_of_thought`)
- **Delimiter handling**: Opening/closing delimiters bypass batching and flush pending tokens immediately
- **Safety mechanisms**:
  - Max buffer age (60s): Forces flush for stale buffers
  - Periodic cleanup (5min): Prevents memory leaks
  - Classification change: Flushes buffer when classification changes

**❓ Why not using a FF?**
The backpressure is spread through so many workspaces that FF will make the whole release phase slightly more complex.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->
Added some tests, and heavily tested locally. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
While this is a pure optimization that maintains the same external behavior. It's could not send all events, or change the order of events leading to weird streaming state on the client-side. Once streaming is done, client-side re-fetch the whole agent message anyway. It's safe to rollback.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
