### PR TITLE
[connector] enh: Start full sync from the created-at ascending

### DIFF
--- a/connectors/src/connectors/intercom/lib/intercom_api.ts
+++ b/connectors/src/connectors/intercom/lib/intercom_api.ts
@@ -40,6 +40,10 @@ async function queryIntercomAPI({
       per_page: number;
       starting_after: string | null;
     };
+    sort?: {
+      field: string;
+      order: "ascending" | "descending";
+    };
   };
 }) {
   // Intercom will route to the correct region based on the token.
@@ -385,6 +389,10 @@ export async function fetchIntercomConversations({
         pagination: {
           per_page: pageSize,
           starting_after: cursor,
+        },
+        sort: {
+          field: "created_at",
+          order: "ascending",
         },
       },
     });


### PR DESCRIPTION
## Description

Search intercom's api using sorting (createdAt asc) to start from the oldest conversation in the connector's window and go up from there.
Also add a gauge on the max age of the sync conversation per connector, to monitor the sync's health (eventually sync_max_age should be close to now(), not 100 days ago).

### Why not conversation list ? 
1. You cannot filter by created date
2. Despite returning a lot of fields (which will increase the time it takes), you still need to get conversation ONE BY ONE for the parts, which are not included in the list.

## Tests

Tested search with this in the past, even though we have some doubts on the stability, it's the best we have.
The sort by createdAt ascending worked well to fetch hundreds of thousands of conversations already. 

## Risk

Low
Blast radius: intercom connector

## Deploy Plan

- [ ] Deploy connector