### PR TITLE
[front] enh: Add programmatic usage configuration to enterprise upgrade

### DIFF
--- a/front/components/poke/shadcn/ui/form/fields.tsx
+++ b/front/components/poke/shadcn/ui/form/fields.tsx
@@ -94,6 +94,16 @@ export function InputField<T extends FieldValues>({
               type={type}
               {...field}
               value={field.value}
+              onChange={
+                type === "number"
+                  ? (e) => {
+                      const parsed = Number(e.target.value);
+                      if (isFinite(parsed)) {
+                        field.onChange(parsed);
+                      }
+                    }
+                  : field.onChange
+              }
             />
           </PokeFormControl>
           <PokeFormMessage />

--- a/front/components/poke/subscriptions/table.tsx
+++ b/front/components/poke/subscriptions/table.tsx
@@ -498,10 +498,7 @@ function UpgradeDowngradeModal({
               description="Go to the Enterprise billing form page to upgrade this workspace to a new Enterprise plan ."
             />
             <div>
-              <EnterpriseUpgradeDialog
-                owner={owner}
-                programmaticUsageConfig={programmaticUsageConfig}
-              />
+              <EnterpriseUpgradeDialog owner={owner} />
             </div>
             {isProPlanPrefix(subscription.plan.code) && (
               <>

--- a/front/components/poke/subscriptions/table.tsx
+++ b/front/components/poke/subscriptions/table.tsx
@@ -498,7 +498,11 @@ function UpgradeDowngradeModal({
               description="Go to the Enterprise billing form page to upgrade this workspace to a new Enterprise plan ."
             />
             <div>
-              <EnterpriseUpgradeDialog owner={owner} />
+              <EnterpriseUpgradeDialog
+                owner={owner}
+                subscription={subscription}
+                programmaticUsageConfig={programmaticUsageConfig}
+              />
             </div>
             {isProPlanPrefix(subscription.plan.code) && (
               <>

--- a/front/lib/api/poke/plugins/workspaces/manage_programmatic_usage_configuration.ts
+++ b/front/lib/api/poke/plugins/workspaces/manage_programmatic_usage_configuration.ts
@@ -200,8 +200,7 @@ export const manageProgrammaticUsageConfigurationPlugin = createPlugin({
   },
 
   execute: async (auth, _, args) => {
-    const parseResult =
-      ProgrammaticUsageConfigurationSchema.safeParse(args);
+    const parseResult = ProgrammaticUsageConfigurationSchema.safeParse(args);
 
     if (!parseResult.success) {
       return new Err(

--- a/front/lib/api/poke/plugins/workspaces/upgrade_downgrade.ts
+++ b/front/lib/api/poke/plugins/workspaces/upgrade_downgrade.ts
@@ -8,7 +8,7 @@ export const upgradeEnterprisePlan = createPlugin({
   manifest: {
     id: "upgrade-enterprise-plan",
     name: "Upgrade Enterprise Plan",
-    description: "Upgrade enterprise plan",
+    description: "Upgrade enterprise plan with programmatic usage configuration",
     resourceTypes: ["workspaces"],
     isHidden: true,
     args: {
@@ -25,6 +25,36 @@ export const upgradeEnterprisePlan = createPlugin({
         description: "The stripe subscription id to upgrade to",
         placeholder: "e.g., sub_1234567890",
         required: true,
+      },
+      freeCreditsOverrideEnabled: {
+        type: "boolean",
+        label: "Negotiated Free Credits",
+        description: "Enable negotiated free monthly credits",
+        required: true,
+      },
+      freeCreditsDollars: {
+        type: "number",
+        label: "Free Credits (USD)",
+        description: "Negotiated monthly free credits amount",
+        required: false,
+      },
+      defaultDiscountPercent: {
+        type: "number",
+        label: "Default Discount (%)",
+        description: "Discount applied to programmatic credit purchases",
+        required: false,
+      },
+      paygEnabled: {
+        type: "boolean",
+        label: "Pay-as-you-go",
+        description: "Enable pay-as-you-go billing",
+        required: true,
+      },
+      paygCapDollars: {
+        type: "number",
+        label: "PAYG Spending Cap (USD)",
+        description: "Maximum monthly PAYG spending",
+        required: false,
       },
     },
   },

--- a/front/lib/api/poke/plugins/workspaces/upgrade_downgrade.ts
+++ b/front/lib/api/poke/plugins/workspaces/upgrade_downgrade.ts
@@ -8,7 +8,8 @@ export const upgradeEnterprisePlan = createPlugin({
   manifest: {
     id: "upgrade-enterprise-plan",
     name: "Upgrade Enterprise Plan",
-    description: "Upgrade enterprise plan with programmatic usage configuration",
+    description:
+      "Upgrade enterprise plan with programmatic usage configuration",
     resourceTypes: ["workspaces"],
     isHidden: true,
     args: {

--- a/front/pages/api/poke/workspaces/[wId]/upgrade_enterprise.ts
+++ b/front/pages/api/poke/workspaces/[wId]/upgrade_enterprise.ts
@@ -4,8 +4,13 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { pluginManager } from "@app/lib/api/poke/plugin_manager";
+import {
+  ProgrammaticUsageConfigurationSchema,
+  upsertProgrammaticUsageConfiguration,
+} from "@app/lib/api/poke/plugins/workspaces/manage_programmatic_usage_configuration";
 import { restoreWorkspaceAfterSubscription } from "@app/lib/api/subscription";
 import { Authenticator } from "@app/lib/auth";
+import { startOrResumeEnterprisePAYG } from "@app/lib/credits/payg";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import {
   assertStripeSubscriptionIsValid,
@@ -13,7 +18,6 @@ import {
   isEnterpriseSubscription,
 } from "@app/lib/plans/stripe";
 import { PluginRunResource } from "@app/lib/resources/plugin_run_resource";
-import { ProgrammaticUsageConfigurationResource } from "@app/lib/resources/programmatic_usage_configuration_resource";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
@@ -87,7 +91,6 @@ async function handler(
       }
       const body = bodyValidation.right;
 
-      // We validate that the stripe subscription exists and is correctly configured.
       const stripeSubscription = await getStripeSubscription(
         body.stripeSubscriptionId
       );
@@ -154,11 +157,12 @@ async function handler(
         });
       }
 
-      const programmaticUsageConfig =
-        await ProgrammaticUsageConfigurationResource.fetchByWorkspaceId(auth);
-      if (!programmaticUsageConfig) {
-        const errorMessage =
-          "Programmatic usage configuration must be set before upgrading to enterprise.";
+      const programmaticConfigValidation =
+        ProgrammaticUsageConfigurationSchema.safeParse(body);
+      if (!programmaticConfigValidation.success) {
+        const errorMessage = programmaticConfigValidation.error.errors
+          .map((e) => `${e.path.join(".")}: ${e.message}`)
+          .join(", ");
         await pluginRun.recordError(errorMessage);
         return apiError(req, res, {
           status_code: 400,
@@ -169,11 +173,67 @@ async function handler(
         });
       }
 
-      // If yes, we will create the new plan and attach it to the workspace with a new subscription
+      const {
+        freeCreditsOverrideEnabled,
+        freeCreditsDollars,
+        defaultDiscountPercent,
+        paygEnabled,
+        paygCapDollars,
+      } = programmaticConfigValidation.data;
+
+      const freeCreditMicroUsd =
+        freeCreditsOverrideEnabled && freeCreditsDollars
+          ? Math.round(freeCreditsDollars * 1_000_000)
+          : null;
+
+      const paygCapMicroUsd =
+        paygEnabled && paygCapDollars
+          ? Math.round(paygCapDollars * 1_000_000)
+          : null;
+
+      const upsertResult = await upsertProgrammaticUsageConfiguration(auth, {
+        freeCreditMicroUsd,
+        defaultDiscountPercent: defaultDiscountPercent ?? 0,
+        paygCapMicroUsd,
+      });
+      if (upsertResult.isErr()) {
+        const errorMessage = upsertResult.error.message;
+        await pluginRun.recordError(errorMessage);
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: errorMessage,
+          },
+        });
+      }
+
       try {
         await SubscriptionResource.pokeUpgradeWorkspaceToEnterprise(auth, body);
         // Restore workspace functionality after subscription upgrade
         await restoreWorkspaceAfterSubscription(auth);
+
+        // If PAYG is enabled, create the PAYG credit for the current billing period
+        if (paygEnabled && paygCapMicroUsd !== null) {
+          const paygResult = await startOrResumeEnterprisePAYG({
+            auth,
+            stripeSubscription,
+            paygCapMicroUsd,
+          });
+          if (paygResult.isErr()) {
+            const errorMessage = paygResult.error.message;
+            await pluginRun.recordError(
+              `Workspace upgraded but PAYG credit creation failed: ${errorMessage}`
+            );
+            return apiError(req, res, {
+              status_code: 400,
+              api_error: {
+                type: "invalid_request_error",
+                message: `Workspace upgraded but PAYG credit creation failed: ${errorMessage}`,
+              },
+            });
+          }
+        }
       } catch (error) {
         const errorString =
           error instanceof Error
@@ -190,9 +250,12 @@ async function handler(
         });
       }
 
+      const paygStatus = paygEnabled
+        ? `PAYG enabled with $${paygCapDollars} cap.`
+        : "PAYG disabled.";
       await pluginRun.recordResult({
         display: "text",
-        value: `Workspace ${owner.name} upgraded to enterprise.`,
+        value: `Workspace ${owner.name} upgraded to enterprise. ${paygStatus}`,
       });
 
       res.status(200).json({

--- a/front/types/plan.ts
+++ b/front/types/plan.ts
@@ -121,10 +121,19 @@ export const CreatePlanFormSchema = t.type({
 
 export type CreatePlanFormType = t.TypeOf<typeof CreatePlanFormSchema>;
 
-export const EnterpriseUpgradeFormSchema = t.type({
-  stripeSubscriptionId: NonEmptyString,
-  planCode: NonEmptyString,
-});
+export const EnterpriseUpgradeFormSchema = t.intersection([
+  t.type({
+    stripeSubscriptionId: NonEmptyString,
+    planCode: NonEmptyString,
+    freeCreditsOverrideEnabled: t.boolean,
+    paygEnabled: t.boolean,
+  }),
+  t.partial({
+    freeCreditsDollars: t.number,
+    defaultDiscountPercent: t.number,
+    paygCapDollars: t.number,
+  }),
+]);
 
 export type EnterpriseUpgradeFormType = t.TypeOf<
   typeof EnterpriseUpgradeFormSchema


### PR DESCRIPTION
## Description

When opening the Upgrade to enterprise modal, we now offer to configure the programmatic usage (including payg) in one go, instead of the (sometime) confusing back and forth.

<img width="543" height="665" alt="CleanShot 2026-01-13 at 18 29 14" src="https://github.com/user-attachments/assets/c2d26814-c9c3-4156-bd3b-99b389cda618" />


## Tests

Tested manually

## Risk

Low

## Deploy Plan

- [ ] Deploy front