### PR TITLE
[front] enh(skills): add archived and suggested skills in poke

### DIFF
--- a/front/lib/resources/skill/global/registry.ts
+++ b/front/lib/resources/skill/global/registry.ts
@@ -104,7 +104,7 @@ export class GlobalSkillsRegistry {
         return false;
       }
 
-      if (where.status && where.status !== "active") {
+      if (where.status && !matchesFilter("active", where.status)) {
         return false; // Global skills are always active.
       }
 

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -673,7 +673,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       limit,
       globalSpaceOnly,
     }: {
-      status?: SkillStatus;
+      status?: SkillStatus | SkillStatus[];
       limit?: number;
       globalSpaceOnly?: boolean;
     } = {}

--- a/front/lib/resources/skill/types.ts
+++ b/front/lib/resources/skill/types.ts
@@ -11,7 +11,7 @@ export type AllSkillConfigurationFindOptions = Omit<
     name?: string | string[];
     sId?: string | string[];
     id?: number | number[];
-    status?: SkillStatus;
+    status?: SkillStatus | SkillStatus[];
   };
   onlyCustom?: false; // Default: include global skills.
 };

--- a/front/pages/api/poke/workspaces/[wId]/skills/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/skills/index.ts
@@ -43,7 +43,9 @@ async function handler(
 
   switch (req.method) {
     case "GET": {
-      const skills = await SkillResource.listSkills(auth);
+      const skills = await SkillResource.listSkills(auth, {
+        status: ["active", "archived", "suggested"],
+      });
 
       return res.status(200).json({
         skills: skills.map((skill) => skill.toJSON(auth)),


### PR DESCRIPTION
## Description

- This PR adds the archived and suggested skills to the poke data table.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
