### PR TITLE
[front] fix citation/generated files update during streaming

### DIFF
--- a/front/hooks/useAgentMessageStream.ts
+++ b/front/hooks/useAgentMessageStream.ts
@@ -281,8 +281,9 @@ export function useAgentMessageStream({
             isMessageTemporayState(m) && m.sId === sId
               ? {
                   ...m,
-                  ...getLightAgentMessageFromAgentMessage(messageSuccess.message),
-                  actions: m.actions,
+                  ...getLightAgentMessageFromAgentMessage(
+                    messageSuccess.message
+                  ),
                   status: "succeeded",
                   streaming: {
                     ...m.streaming,

--- a/front/hooks/useAgentMessageStream.ts
+++ b/front/hooks/useAgentMessageStream.ts
@@ -12,6 +12,7 @@ import type {
 import { isMessageTemporayState } from "@app/components/assistant/conversation/types";
 import { useEventSource } from "@app/hooks/useEventSource";
 import type { ToolNotificationEvent } from "@app/lib/actions/mcp";
+import { getLightAgentMessageFromAgentMessage } from "@app/lib/api/assistant/citations";
 import type {
   LightAgentMessageWithActionsType,
   LightWorkspaceType,
@@ -280,7 +281,8 @@ export function useAgentMessageStream({
             isMessageTemporayState(m) && m.sId === sId
               ? {
                   ...m,
-                  ...messageSuccess.message,
+                  ...getLightAgentMessageFromAgentMessage(messageSuccess.message),
+                  actions: m.actions,
                   status: "succeeded",
                   streaming: {
                     ...m.streaming,


### PR DESCRIPTION
## Description

- Reported [here](https://dust4ai.slack.com/archives/C066R3PMUAU/p1768255285871839).
- While streaming the UI does not reflect new `generatedFiles` in the conversation.
- This PR fixes that: `getLightAgentMessageFromAgentMessage` actually processes the input agent message to extract citations and generated files.

## Tests

- Tested locally and on front-edge.

## Risk

- Low to medium.

## Deploy Plan

- Deploy front.
