### PR TITLE
[front] fix(Slack): handle `message_not_found` errors in chat updates

### DIFF
--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -639,14 +639,14 @@ async function postSlackMessageUpdate({
           ts: mainMessage.ts as string,
           // Note: file_ids is not supported by chat.update API, so we need to delete and repost the message
         });
-      } catch (e) {
+      } catch (error) {
         if (
-          isSlackWebAPIPlatformError(e) &&
-          e.data.error === "message_not_found"
+          isSlackWebAPIPlatformError(error) &&
+          error.data.error === "message_not_found"
         ) {
           return undefined;
         }
-        throw e;
+        throw error;
       }
     },
     extraLogs


### PR DESCRIPTION
## Description

- Attempt to fix this [error](https://app.datadoghq.eu/logs?query=%40panic%3Atrue%20region%3Aus-central1&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZu7ZXweQ7Ya9AAAABhBWnU3WlljMUFBQnA0aGpDTlVQQ193QW0AAAAkMDE5YmJiNjUtYjFlNi00MTlkLWI3OGQtNGIwNjU5ZDQ2MTNiAAAFFg&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1768373806000&to_ts=1768375606000&live=false).
- This PR catches `message_not_found` errors when doing updates on a message.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy connectors.
