### PR TITLE
Move `/tokenize` calls to front-internal

### DIFF
--- a/connectors/src/lib/api/dust_api.ts
+++ b/connectors/src/lib/api/dust_api.ts
@@ -14,7 +14,7 @@ import type { DataSourceConfig } from "@connectors/types";
  */
 export function getDustAPI(
   dataSourceConfig: DataSourceConfig,
-  useInternalAPI = false
+  { useInternalAPI }: { useInternalAPI?: boolean } = { useInternalAPI: false }
 ): DustAPI {
   return new DustAPI(
     {

--- a/connectors/src/lib/data_sources.ts
+++ b/connectors/src/lib/data_sources.ts
@@ -531,7 +531,7 @@ async function tokenize(text: string, ds: DataSourceConfig) {
 
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), TOKENIZE_TIMEOUT_MS);
-  const tokensRes = await getDustAPI(ds).tokenize(
+  const tokensRes = await getDustAPI(ds, { useInternalAPI: true }).tokenize(
     sanitizedText,
     ds.dataSourceId,
     { signal: controller.signal }
@@ -1070,7 +1070,7 @@ export async function upsertDataSourceTableFromCsv({
     );
   }
 
-  const dustAPI = getDustAPI(dataSourceConfig, true);
+  const dustAPI = getDustAPI(dataSourceConfig, { useInternalAPI: true });
 
   const fileRes = await dustAPI.uploadFile({
     contentType: "text/csv",
@@ -1539,7 +1539,9 @@ export async function _upsertDataSourceFolder({
 }) {
   const now = new Date();
 
-  const r = await getDustAPI(dataSourceConfig, true).upsertFolder({
+  const r = await getDustAPI(dataSourceConfig, {
+    useInternalAPI: true,
+  }).upsertFolder({
     dataSourceId: dataSourceConfig.dataSourceId,
     folderId,
     timestamp: timestampMs ? timestampMs : now.getTime(),
@@ -1564,7 +1566,9 @@ export async function deleteDataSourceFolder({
   folderId: string;
   loggerArgs?: Record<string, string | number>;
 }) {
-  const r = await getDustAPI(dataSourceConfig, true).deleteFolder({
+  const r = await getDustAPI(dataSourceConfig, {
+    useInternalAPI: true,
+  }).deleteFolder({
     dataSourceId: dataSourceConfig.dataSourceId,
     folderId,
   });


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Looking at the most used endpoints on our front API, `/tokenize` is by far number 1. Debugging the bursts of CPU and memory, this PR redirects connectors calls to `/tokenize` to our front-internal deployment.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
Worst case, we observe resource contention on `front-internal` connectors will be slower. I'll keep an eye out. Safe to rollback.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
