### PR TITLE
Fix logged route when it contains escaped characters

### DIFF
--- a/front/logger/withlogging.ts
+++ b/front/logger/withlogging.ts
@@ -115,7 +115,7 @@ export function withLogging<T>(
 
         const value = req.query[key];
         if (typeof value === "string" && value.length > 0) {
-          route = route.replaceAll(value, `[${key}]`);
+          route = route.replaceAll(encodeURIComponent(value), `[${key}]`);
         }
       }
     }


### PR DESCRIPTION
## Description

Due to missing escaping, the route was showing up as `/api/user/metadata/onboarding%3Aconversation` when it should have been `/api/user/metadata/[key]`.

Side note: this code is fragile as it risks replacing random things if they key happens to match other parts of the path...

## Tests

Manual

## Risk

Low

## Deploy Plan

Front