### PR TITLE
[Connectors] fix(slack): handle slack webhook of private channels

### DIFF
--- a/connectors/src/api/webhooks/slack/utils.ts
+++ b/connectors/src/api/webhooks/slack/utils.ts
@@ -64,7 +64,7 @@ export interface SlackWebhookEvent<T = string> {
   ts?: string; // slack message id
   thread_ts?: string; // slack thread id
   type?: string; // event type (eg: message)
-  channel_type?: "channel" | "im" | "mpim";
+  channel_type?: "channel" | "group" | "im" | "mpim";
   text: string; // content of the message
   old_name?: string; // when renaming channel: old channel name
   name?: string; // when renaming channel: new channel name

--- a/connectors/src/api/webhooks/webhook_slack.ts
+++ b/connectors/src/api/webhooks/webhook_slack.ts
@@ -162,7 +162,10 @@ const _webhookSlackAPIHandler = async (
             // Message from an actual user (a human)
             await handleDeprecatedChatBot(req, res, logger);
             break;
-          } else if (event.channel_type === "channel") {
+          } else if (
+            event.channel_type === "channel" ||
+            event.channel_type === "group"
+          ) {
             if (!event.channel) {
               return apiError(req, res, {
                 api_error: {

--- a/connectors/src/api/webhooks/webhook_slack_bot.ts
+++ b/connectors/src/api/webhooks/webhook_slack_bot.ts
@@ -167,7 +167,10 @@ const _webhookSlackBotAPIHandler = async (
               "slack.team_id": teamId,
               "slack.app": "slack_bot",
             })(handleChatBot)(req, res, logger);
-          } else if (event.channel_type === "channel") {
+          } else if (
+            event.channel_type === "channel" ||
+            event.channel_type === "group"
+          ) {
             if (
               !event.bot_id &&
               event.channel &&


### PR DESCRIPTION
Tries to fix : https://github.com/dust-tt/tasks/issues/5907

## Description

Fixes handling of private Slack channel webhook events. 

**Context**: Slack's Events API sends `channel_type: "group"` for all private channels ([doc](https://docs.slack.dev/reference/events/message.groups/)), while public channels use `channel_type: "channel"`.

The webhook handler was only checking for `"channel"` and `"im"`, causing private channel events to fall through without being processed.

Related incident: https://dust4ai.slack.com/archives/C05B529FHV1/p1766491319590099

I think the bug went undetected because of initial sync and backfill script

## Tests

Local. The private messages are indeed not synced, the events are ignored

## Risk

Low.

## Deploy Plan

Connectors.