### PR TITLE
fix(dust-hive): remove preinstall script injection approach

### DIFF
--- a/x/henry/dust-hive/.claude/skills/dust-hive/SKILL.md
+++ b/x/henry/dust-hive/.claude/skills/dust-hive/SKILL.md
@@ -265,7 +265,10 @@ In dust-hive environments, `node_modules` for `front` and `connectors` uses a **
 - A real `node_modules` directory with symlinks to packages from the main repo
 - `@dust-tt/client` is overridden to point to the worktree's SDK (ensuring correct type resolution)
 
-**Running `npm install` works automatically**: dust-hive injects a `preinstall` script into package.json and creates a `.dust-hive-shallow-copy` marker file. When npm runs, the preinstall detects the marker and cleans up the shallow copy before proceeding. After install, you'll have a standard npm-managed node_modules.
+**Running `npm install` requires manual cleanup**: The shallow copy structure is incompatible with npm's expectations. Before running `npm install`, you must delete `node_modules` first:
+```bash
+rm -rf node_modules && npm install
+```
 
 ### SDK watcher doesn't detect changes after git rebase
 

--- a/x/henry/dust-hive/CLAUDE.md
+++ b/x/henry/dust-hive/CLAUDE.md
@@ -197,9 +197,10 @@ For `front` and `connectors`, dust-hive creates a **shallow copy** of node_modul
 
 This ensures correct SDK type resolution when your branch has newer types than main.
 
-**Note**: Running `npm install` works automatically. dust-hive injects a `preinstall` script into
-package.json and creates a `.dust-hive-shallow-copy` marker file. The preinstall detects the marker
-and cleans up the shallow copy before npm proceeds.
+**Note**: To run `npm install` in a dust-hive worktree, you must first delete `node_modules`:
+```bash
+rm -rf node_modules && npm install
+```
 
 **sccache** (optional): When worktree code differs from main, cargo recompiles. sccache
 caches compilations by content hash, making rebuilds after branch switches faster.

--- a/x/henry/dust-hive/README.md
+++ b/x/henry/dust-hive/README.md
@@ -428,7 +428,11 @@ This ensures TypeScript and runtime resolve `@dust-tt/client` from the worktree'
 
 For `sdks/js`, a simple symlink is used (it IS the SDK).
 
-> **Note**: Running `npm install` in a worktree works automatically. dust-hive injects a `preinstall` script into package.json and creates a `.dust-hive-shallow-copy` marker file. When npm runs, the preinstall detects the marker and cleans up the shallow copy before proceeding. After install, you'll have a standard npm-managed node_modules.
+> **Note**: To run `npm install` in a dust-hive worktree, you must first delete `node_modules`:
+> ```bash
+> rm -rf node_modules && npm install
+> ```
+> This is necessary because the shallow copy structure (symlinks) is incompatible with npm's expectations.
 
 > **sccache** (optional but recommended): When worktree code differs from main, cargo recompiles. sccache caches these compilations by content hash, so rebuilding after switching branches is faster.
 


### PR DESCRIPTION
## Description

Removes the preinstall script injection approach for cleaning up shallow node_modules before npm install. The approach was causing ENOTEMPTY errors because npm would start processing node_modules before the `rm -rf` completed.

Instead, documentation now states that users need to manually delete node_modules before running npm install in dust-hive environments:

```bash
rm -rf node_modules && npm install
```

This is simpler and more reliable than trying to intercept npm.

## Changes

- Remove `PREINSTALL_SCRIPT` constant and `injectPreinstallScript()` function from setup.ts
- Remove marker file (`.dust-hive-shallow-copy`) creation
- Remove unused imports (`readFileSync`, `writeFileSync`)
- Update README.md, CLAUDE.md, and SKILL.md with manual cleanup instructions

## Tests

- All dust-hive tests pass (172 tests)
- Typecheck and lint pass

## Risk

Low - this simplifies the approach and removes code that was causing issues.

## Deploy Plan

No deployment needed - dust-hive is a local development tool.