### PR TITLE
POC: Add AuthProvider for client-side auth context

### DIFF
--- a/front/.gitignore
+++ b/front/.gitignore
@@ -37,6 +37,8 @@ next-env.d.ts
 
 # build output
 dist/
+app/dist/
+public/spa/
 
 # cache
 .cache/

--- a/front/admin/build-spa.sh
+++ b/front/admin/build-spa.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Build the Vite SPA and copy to Next.js public folder
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FRONT_DIR="$(dirname "$SCRIPT_DIR")"
+
+echo "Building SPA..."
+cd "$FRONT_DIR"
+VITE_BASE_PATH=/spa VITE_DUST_CLIENT_FACING_URL="$DUST_CLIENT_FACING_URL" npx vite build --config vite.spa.config.ts
+
+echo "Copying build to public/spa..."
+rm -rf "$FRONT_DIR/public/spa"
+cp -r "$FRONT_DIR/app/dist" "$FRONT_DIR/public/spa"
+
+echo "Done! SPA available at /spa/"

--- a/front/app/index.html
+++ b/front/app/index.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Dust</title>
+    <script>
+      // Polyfills for Node.js globals (SPA only)
+      window.Buffer = window.Buffer || {
+        isBuffer: () => false,
+        from: () => new Uint8Array(),
+      };
+      window.process = window.process || { env: {} };
+    </script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/front/app/src/App.tsx
+++ b/front/app/src/App.tsx
@@ -1,0 +1,199 @@
+import { Notification } from "@dust-tt/sparkle";
+import {
+  createBrowserRouter,
+  Navigate,
+  RouterProvider,
+} from "react-router-dom";
+
+import { AppPage } from "@app/components/poke/pages/AppPage";
+import { AssistantDetailsPage } from "@app/components/poke/pages/AssistantDetailsPage";
+import { ConnectorRedirectPage } from "@app/components/poke/pages/ConnectorRedirectPage";
+import { ConversationPage } from "@app/components/poke/pages/ConversationPage";
+import { DashboardPage } from "@app/components/poke/pages/DashboardPage";
+import { DataSourcePage } from "@app/components/poke/pages/DataSourcePage";
+import { DataSourceQueryPage } from "@app/components/poke/pages/DataSourceQueryPage";
+import { DataSourceSearchPage } from "@app/components/poke/pages/DataSourceSearchPage";
+import { DataSourceViewPage } from "@app/components/poke/pages/DataSourceViewPage";
+import { EmailTemplatesPage } from "@app/components/poke/pages/EmailTemplatesPage";
+import { GroupPage } from "@app/components/poke/pages/GroupPage";
+import { KillPage } from "@app/components/poke/pages/KillPage";
+import { LLMTracePage } from "@app/components/poke/pages/LLMTracePage";
+import { MCPServerViewPage } from "@app/components/poke/pages/MCPServerViewPage";
+import { MembershipsPage } from "@app/components/poke/pages/MembershipsPage";
+import { NotionRequestsPage } from "@app/components/poke/pages/NotionRequestsPage";
+import { PlansPage } from "@app/components/poke/pages/PlansPage";
+import { PluginsPage } from "@app/components/poke/pages/PluginsPage";
+import { PokefyPage } from "@app/components/poke/pages/PokefyPage";
+import { ProductionChecksPage } from "@app/components/poke/pages/ProductionChecksPage";
+import { SkillDetailsPage } from "@app/components/poke/pages/SkillDetailsPage";
+import { SpaceDataSourceViewPage } from "@app/components/poke/pages/SpaceDataSourceViewPage";
+import { SpacePage } from "@app/components/poke/pages/SpacePage";
+import { TemplateDetailPage } from "@app/components/poke/pages/TemplateDetailPage";
+import { TemplatesListPage } from "@app/components/poke/pages/TemplatesListPage";
+import { TriggerDetailsPage } from "@app/components/poke/pages/TriggerDetailsPage";
+import { WorkspacePage } from "@app/components/poke/pages/WorkspacePage";
+
+import { PokeLayout } from "./layouts/PokeLayout";
+
+const router = createBrowserRouter(
+  [
+    {
+      path: "/poke",
+      element: <PokeLayout />,
+      children: [
+        // Static routes first
+        {
+          index: true,
+          element: <DashboardPage />,
+          handle: { title: "Home" },
+        },
+        {
+          path: "kill",
+          element: <KillPage />,
+          handle: { title: "Kill Switches" },
+        },
+        {
+          path: "plans",
+          element: <PlansPage />,
+          handle: { title: "Plans" },
+        },
+        {
+          path: "pokefy",
+          element: <PokefyPage />,
+          handle: { title: "Pokefy" },
+        },
+        {
+          path: "production-checks",
+          element: <ProductionChecksPage />,
+          handle: { title: "Production Checks" },
+        },
+        {
+          path: "email-templates",
+          element: <EmailTemplatesPage />,
+          handle: { title: "Email Templates" },
+        },
+        {
+          path: "templates",
+          element: <TemplatesListPage />,
+          handle: { title: "Templates" },
+        },
+        {
+          path: "templates/:tId",
+          element: <TemplateDetailPage />,
+          handle: { title: "Template" },
+        },
+        {
+          path: "plugins",
+          element: <PluginsPage />,
+          handle: { title: "Plugins" },
+        },
+        {
+          path: "connectors/:connectorId",
+          element: <ConnectorRedirectPage />,
+          handle: { title: "Connector Redirect" },
+        },
+        // Dynamic workspace routes
+        {
+          path: ":wId",
+          element: <WorkspacePage />,
+          handle: { title: "Workspace" },
+        },
+        {
+          path: ":wId/memberships",
+          element: <MembershipsPage />,
+          handle: { title: "Memberships" },
+        },
+        {
+          path: ":wId/llm-traces/:runId",
+          element: <LLMTracePage />,
+          handle: { title: "LLM Trace" },
+        },
+        {
+          path: ":wId/assistants/:aId",
+          element: <AssistantDetailsPage />,
+          handle: { title: "Assistant" },
+        },
+        {
+          path: ":wId/assistants/:aId/triggers/:triggerId",
+          element: <TriggerDetailsPage />,
+          handle: { title: "Trigger" },
+        },
+        {
+          path: ":wId/conversation/:cId",
+          element: <ConversationPage />,
+          handle: { title: "Conversation" },
+        },
+        {
+          path: ":wId/data_sources/:dsId",
+          element: <DataSourcePage />,
+          handle: { title: "Data Source" },
+        },
+        {
+          path: ":wId/data_sources/:dsId/notion-requests",
+          element: <NotionRequestsPage />,
+          handle: { title: "Notion Requests" },
+        },
+        {
+          path: ":wId/data_sources/:dsId/query",
+          element: <DataSourceQueryPage />,
+          handle: { title: "Query" },
+        },
+        {
+          path: ":wId/data_sources/:dsId/search",
+          element: <DataSourceSearchPage />,
+          handle: { title: "Search" },
+        },
+        {
+          path: ":wId/data_sources/:dsId/view",
+          element: <DataSourceViewPage />,
+          handle: { title: "View Document" },
+        },
+        {
+          path: ":wId/groups/:groupId",
+          element: <GroupPage />,
+          handle: { title: "Group" },
+        },
+        {
+          path: ":wId/skills/:sId",
+          element: <SkillDetailsPage />,
+          handle: { title: "Skill" },
+        },
+        {
+          path: ":wId/spaces/:spaceId",
+          element: <SpacePage />,
+          handle: { title: "Space" },
+        },
+        {
+          path: ":wId/spaces/:spaceId/apps/:appId",
+          element: <AppPage />,
+          handle: { title: "App" },
+        },
+        {
+          path: ":wId/spaces/:spaceId/data_source_views/:dsvId",
+          element: <SpaceDataSourceViewPage />,
+          handle: { title: "Data Source View" },
+        },
+        {
+          path: ":wId/spaces/:spaceId/mcp_server_views/:svId",
+          element: <MCPServerViewPage />,
+          handle: { title: "MCP Server View" },
+        },
+      ],
+    },
+    {
+      path: "*",
+      element: <Navigate to="/poke" replace />,
+    },
+  ],
+  {
+    basename: import.meta.env.VITE_BASE_PATH ?? "",
+  }
+);
+
+export default function App() {
+  return (
+    <Notification.Area>
+      <RouterProvider router={router} />
+    </Notification.Area>
+  );
+}

--- a/front/app/src/components/ReactRouterLinkWrapper.tsx
+++ b/front/app/src/components/ReactRouterLinkWrapper.tsx
@@ -1,0 +1,76 @@
+import type { MouseEvent, ReactNode } from "react";
+import { forwardRef } from "react";
+import { Link } from "react-router-dom";
+import type { UrlObject } from "url";
+import url from "url";
+
+// Link wrapper that uses React Router's Link for SPA navigation
+export const ReactRouterLinkWrapper = forwardRef<
+  HTMLAnchorElement,
+  {
+    href: string | UrlObject;
+    className?: string;
+    children: ReactNode;
+    ariaLabel?: string;
+    ariaCurrent?:
+      | boolean
+      | "time"
+      | "false"
+      | "true"
+      | "page"
+      | "step"
+      | "location"
+      | "date";
+    onClick?: (event: MouseEvent<HTMLAnchorElement>) => void;
+    target?: string;
+    rel?: string;
+  }
+>(function ReactRouterLinkWrapper(
+  {
+    href,
+    className,
+    children,
+    ariaCurrent,
+    ariaLabel,
+    onClick,
+    target = "_self",
+    rel,
+  },
+  ref
+) {
+  // Convert UrlObject to string if needed
+  const hrefString = typeof href !== "string" ? url.format(href) : href;
+
+  // For external links or API routes, use regular anchor
+  if (hrefString.startsWith("http") || hrefString.startsWith("/api/")) {
+    return (
+      <a
+        ref={ref}
+        href={hrefString}
+        className={className}
+        onClick={onClick}
+        aria-current={ariaCurrent}
+        aria-label={ariaLabel}
+        target={target}
+        rel={rel}
+      >
+        {children}
+      </a>
+    );
+  }
+
+  return (
+    <Link
+      ref={ref}
+      to={hrefString}
+      className={className}
+      onClick={onClick}
+      aria-current={ariaCurrent}
+      aria-label={ariaLabel}
+      target={target}
+      rel={rel}
+    >
+      {children}
+    </Link>
+  );
+});

--- a/front/app/src/index.css
+++ b/front/app/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/front/app/src/layouts/PokeLayout.tsx
+++ b/front/app/src/layouts/PokeLayout.tsx
@@ -1,0 +1,141 @@
+import { SparkleContext, Spinner } from "@dust-tt/sparkle";
+import type { ReactNode } from "react";
+import { useEffect, useState } from "react";
+import { Outlet, useMatches } from "react-router-dom";
+
+import { ReactRouterLinkWrapper } from "@app/app/src/components/ReactRouterLinkWrapper";
+import PokeNavbar from "@app/components/poke/PokeNavbar";
+import { ThemeProvider } from "@app/components/sparkle/ThemeContext";
+import type { RegionType } from "@app/lib/api/regions/config";
+import type { AuthContextValue } from "@app/lib/auth/AuthContext";
+import { AuthContext } from "@app/lib/auth/AuthContext";
+import { Head, usePathParams } from "@app/lib/platform";
+import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type {
+  LightWorkspaceType,
+  SubscriptionType,
+  UserType,
+} from "@app/types";
+
+// Define response types inline to avoid importing from API files (which have server-side dependencies)
+type GetPokeAuthContextResponseType =
+  | { user: UserType; isSuperUser: true }
+  | { user: null; isSuperUser: false };
+
+type GetPokeWorkspaceAuthContextResponseType = {
+  user: UserType;
+  workspace: LightWorkspaceType;
+  subscription: SubscriptionType;
+  isSuperUser: true;
+};
+
+type GetRegionResponseType = {
+  region: RegionType;
+  regionUrls: Record<RegionType, string>;
+};
+
+interface RouteHandle {
+  title?: string;
+}
+
+interface PokeLayoutProps {
+  children?: ReactNode;
+}
+
+export function PokeLayout({ children }: PokeLayoutProps) {
+  const params = usePathParams();
+  const wId = params.wId;
+  const [redirecting, setRedirecting] = useState(false);
+
+  // Get title from the deepest matched route's handle
+  const matches = useMatches();
+  const title = matches
+    .slice()
+    .reverse()
+    .find((match) => (match.handle as RouteHandle)?.title)?.handle as
+    | RouteHandle
+    | undefined;
+  const pageTitle = title?.title ?? "Poke";
+
+  // Fetch global poke auth (superuser check)
+  const { data: authData, isLoading: isAuthLoading } = useSWRWithDefaults<
+    string,
+    GetPokeAuthContextResponseType
+  >("/api/poke/auth-context", fetcher);
+
+  // Fetch workspace-specific auth when wId is present
+  const { data: workspaceAuthData, isLoading: isWorkspaceLoading } =
+    useSWRWithDefaults<string, GetPokeWorkspaceAuthContextResponseType>(
+      `/api/poke/workspaces/${wId}/auth-context`,
+      fetcher,
+      { disabled: !wId }
+    );
+
+  const { data: regionData } = useSWRWithDefaults<
+    string,
+    GetRegionResponseType
+  >("/api/poke/region", fetcher);
+
+  useEffect(() => {
+    if (
+      !isAuthLoading &&
+      (!authData || !authData.user || !authData.isSuperUser)
+    ) {
+      setRedirecting(true);
+      const baseUrl = import.meta.env.VITE_DUST_CLIENT_FACING_URL ?? "";
+      window.location.href = `${baseUrl}/api/workos/login?returnTo=${encodeURIComponent(
+        window.location.pathname + window.location.search
+      )}`;
+    }
+  }, [isAuthLoading, authData]);
+
+  const isLoading = isAuthLoading || (wId && isWorkspaceLoading);
+
+  if (isLoading || redirecting || !authData || !authData.user) {
+    return (
+      <div className="flex h-screen w-full items-center justify-center">
+        <Spinner size="xl" />
+      </div>
+    );
+  }
+
+  // If we have a wId but workspace auth failed, show error
+  if (wId && !workspaceAuthData) {
+    return (
+      <div className="flex h-screen w-full items-center justify-center">
+        <p className="text-red-500">Workspace not found</p>
+      </div>
+    );
+  }
+
+  const authContextValue: AuthContextValue = {
+    user: authData.user,
+    isSuperUser: authData.isSuperUser,
+    isAdmin: true, // Superusers have admin privileges
+    isBuilder: true, // Superusers have builder privileges
+    workspace: workspaceAuthData?.workspace,
+    subscription: workspaceAuthData?.subscription,
+  };
+
+  return (
+    <SparkleContext.Provider
+      value={{ components: { link: ReactRouterLinkWrapper } }}
+    >
+      <ThemeProvider>
+        <Head>
+          <title>{"Poke - " + pageTitle}</title>
+        </Head>
+        <AuthContext.Provider value={authContextValue}>
+          <div className="min-h-dvh bg-muted-background dark:bg-muted-background-night dark:text-white">
+            <PokeNavbar
+              currentRegion={regionData?.region}
+              regionUrls={regionData?.regionUrls}
+              title={pageTitle}
+            />
+            <div className="flex flex-col p-6">{children ?? <Outlet />}</div>
+          </div>
+        </AuthContext.Provider>
+      </ThemeProvider>
+    </SparkleContext.Provider>
+  );
+}

--- a/front/app/src/main.tsx
+++ b/front/app/src/main.tsx
@@ -1,0 +1,19 @@
+// Tailwind base globals
+import "@app/styles/global.css";
+// Use sparkle styles, override local globals
+import "@dust-tt/sparkle/dist/sparkle.css";
+// Local tailwind components override sparkle styles
+import "@app/styles/components.css";
+// Local index.css for any app-specific overrides
+import "./index.css";
+
+import React from "react";
+import ReactDOM from "react-dom/client";
+
+import App from "./App";
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/front/app/tsconfig.json
+++ b/front/app/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "baseUrl": ".",
+    "paths": {
+      "@app/*": ["../*"]
+    }
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/front/app/tsconfig.node.json
+++ b/front/app/tsconfig.node.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true,
+    "strict": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/front/knip.ts
+++ b/front/knip.ts
@@ -13,6 +13,11 @@ const config: KnipConfig = {
     "**/vite.config.js",
     "**/esbuild.worker.ts",
     "components/home/content/Product/BlogSection.tsx", // Temporarily disabled due to broken blog.dust.tt images
+    // SPA files - used by Vite build, not Next.js
+    "app/src/**/*.{ts,tsx}",
+    "vite.spa.config.ts",
+    "lib/platform/spa.ts",
+    "lib/auth/NextAuthContextProvider.tsx",
   ],
   project: ["**/*.{js,jsx,ts,tsx}"],
   rules: {
@@ -30,6 +35,8 @@ const config: KnipConfig = {
     "sqlite3", // used during the build process by sequelize
     "@dust-tt/client",
     "lefthook", // used as pre-commit hook
+    "event-source-polyfill", // used in SPA mode via Vite alias
+    "react-router-dom", // used in SPA mode via Vite alias
   ],
   ignoreBinaries: ["sleep"],
   paths: {

--- a/front/lib/auth/NextAuthContextProvider.tsx
+++ b/front/lib/auth/NextAuthContextProvider.tsx
@@ -1,0 +1,69 @@
+import { Spinner } from "@dust-tt/sparkle";
+import type { ComponentType, ReactNode } from "react";
+import { useEffect } from "react";
+
+import { useAppRouter } from "@app/lib/platform";
+import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { isString } from "@app/types";
+
+import type { AuthContextValue } from "./AuthContext";
+import { AuthContext } from "./AuthContext";
+
+interface AuthProviderProps {
+  children: ReactNode;
+  workspaceId: string;
+}
+
+function AuthProvider({ children, workspaceId }: AuthProviderProps) {
+  const { data, isLoading } = useSWRWithDefaults<
+    string,
+    AuthContextValue | { user: null }
+  >(`/api/w/${workspaceId}/auth-context`, fetcher);
+
+  useEffect(() => {
+    if (!isLoading && (!data || !("user" in data) || !data.user)) {
+      window.location.href = `/api/workos/login?returnTo=${encodeURIComponent(window.location.pathname + window.location.search)}`;
+    }
+  }, [isLoading, data]);
+
+  if (isLoading || !data || !("user" in data) || !data.user) {
+    return (
+      <div className="flex h-screen w-full items-center justify-center">
+        <Spinner size="xl" />
+      </div>
+    );
+  }
+
+  return (
+    <AuthContext.Provider value={data as AuthContextValue}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function withAuth<P extends object>(Component: ComponentType<P>) {
+  const displayName = Component.displayName ?? Component.name ?? "Component";
+
+  function WithAuth(props: P) {
+    const router = useAppRouter();
+    const { wId } = router.query;
+
+    if (!isString(wId)) {
+      return (
+        <div className="flex h-screen w-full items-center justify-center">
+          <Spinner size="xl" />
+        </div>
+      );
+    }
+
+    return (
+      <AuthProvider workspaceId={wId}>
+        <Component {...props} />
+      </AuthProvider>
+    );
+  }
+
+  WithAuth.displayName = `withAuth(${displayName})`;
+
+  return WithAuth;
+}

--- a/front/lib/egress/client.ts
+++ b/front/lib/egress/client.ts
@@ -1,3 +1,26 @@
+// Vite environment variables type declaration
+declare global {
+  interface ImportMeta {
+    env?: {
+      VITE_DUST_CLIENT_FACING_URL?: string;
+      VITE_BASE_PATH?: string;
+    };
+  }
+}
+
+// Get the API base URL from environment variables.
+// In Vite SPA: uses VITE_DUST_CLIENT_FACING_URL
+// In Next.js: uses relative URLs
+function getApiBaseUrl(): string | undefined {
+  // Check for Vite env var first (SPA mode)
+  if (
+    typeof import.meta !== "undefined" &&
+    import.meta.env?.VITE_DUST_CLIENT_FACING_URL
+  ) {
+    return import.meta.env.VITE_DUST_CLIENT_FACING_URL;
+  }
+}
+
 // Client-side fetch helper. This is a simple alias for the global fetch, used to satisfy
 // the linter rule that discourages direct use of `fetch`. On the client, we cannot route
 // through a proxy, so this is just a pass-through.
@@ -5,6 +28,17 @@ export function clientFetch(
   input: RequestInfo | URL,
   init?: RequestInit
 ): Promise<Response> {
+  const baseUrl = getApiBaseUrl();
+
+  // Only prepend base URL for relative paths (starting with /)
+  if (baseUrl && typeof input === "string" && input.startsWith("/")) {
+    input = `${baseUrl}${input}`;
+    init = {
+      ...init,
+      credentials: "include",
+    };
+  }
+
   // eslint-disable-next-line no-restricted-globals
   return fetch(input, init);
 }

--- a/front/lib/front.js
+++ b/front/lib/front.js
@@ -1,6 +1,7 @@
-import { useRouter } from "next/router";
 import { useEffect } from "react";
 import { useBeforeunload } from "react-beforeunload";
+
+import { useAppRouter } from "@app/lib/platform";
 
 export function useRegisterUnloadHandlers(
   editorDirty,
@@ -17,7 +18,7 @@ export function useRegisterUnloadHandlers(
   });
 
   // Add handler for next.js router events that don't load a new page in the browser.
-  const router = useRouter();
+  const router = useAppRouter();
   useEffect(() => {
     const confirmBrowseAway = () => {
       if (!editorDirty) {

--- a/front/lib/platform/spa.ts
+++ b/front/lib/platform/spa.ts
@@ -1,0 +1,333 @@
+/**
+ * SPA platform implementation
+ * Used when running in Vite SPA environment (React Router)
+ */
+import {
+  Children,
+  isValidElement,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import {
+  useLocation,
+  useNavigate,
+  useOutletContext,
+  useParams as useRouterParams,
+  useSearchParams as useRouterSearchParams,
+} from "react-router-dom";
+
+import type {
+  AppRouter,
+  HeadProps,
+  RouterEvents,
+  ScriptProps,
+  TransitionOptions,
+  UrlObject,
+} from "./types";
+
+/**
+ * Safe wrapper around useNavigate that handles the case where
+ * we're not inside a Router context (can happen during production build initialization)
+ */
+function useSafeNavigate() {
+  try {
+    return useNavigate();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Safe wrapper around useLocation that handles the case where
+ * we're not inside a Router context
+ */
+function useSafeLocation() {
+  try {
+    return useLocation();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Safe wrapper around useSearchParam that handles the case where
+ * we're not inside a Router context
+ */
+function useSafeSearchParams() {
+  try {
+    return useRouterSearchParams();
+  } catch {
+    return [new URLSearchParams(window.location.search), () => {}] as const;
+  }
+}
+
+/**
+ * Convert URL object to string
+ */
+function urlToString(url: string | UrlObject): string {
+  if (typeof url === "string") {
+    return url;
+  }
+  let result = url.pathname ?? "";
+  if (url.query && Object.keys(url.query).length > 0) {
+    const params = new URLSearchParams();
+    for (const [key, value] of Object.entries(url.query)) {
+      if (value !== undefined) {
+        if (Array.isArray(value)) {
+          value.forEach((v) => params.append(key, v));
+        } else {
+          params.append(key, value);
+        }
+      }
+    }
+    const queryString = params.toString();
+    if (queryString) {
+      result += "?" + queryString;
+    }
+  }
+  if (url.hash) {
+    result += url.hash;
+  }
+  return result;
+}
+
+/**
+ * Create a no-op events object for SPA
+ * In SPA mode, we don't have router events like Next.js
+ */
+function createNoopEvents(): RouterEvents {
+  return {
+    on: () => {},
+    off: () => {},
+    emit: () => {},
+  };
+}
+
+export function useAppRouter(): AppRouter {
+  const navigate = useSafeNavigate();
+  const location = useSafeLocation();
+  const [searchParams] = useSafeSearchParams();
+
+  // Force re-render when location changes via window (fallback mode)
+  const [, setForceUpdate] = useState(0);
+  useEffect(() => {
+    if (!location) {
+      // We're in fallback mode, listen to popstate to update
+      const handlePopState = () => setForceUpdate((n) => n + 1);
+      window.addEventListener("popstate", handlePopState);
+      return () => window.removeEventListener("popstate", handlePopState);
+    }
+  }, [location]);
+
+  const push = useCallback(
+    (url: string | UrlObject, _as?: string, _options?: TransitionOptions) => {
+      const urlString = urlToString(url);
+      if (navigate) {
+        navigate(urlString);
+      } else {
+        // Fallback to window.location if not in Router context
+        window.location.href = urlString;
+      }
+      return Promise.resolve(true);
+    },
+    [navigate]
+  );
+
+  const replace = useCallback(
+    (url: string | UrlObject, _as?: string, _options?: TransitionOptions) => {
+      const urlString = urlToString(url);
+      if (navigate) {
+        navigate(urlString, { replace: true });
+      } else {
+        // Fallback to window.location if not in Router context
+        window.location.replace(urlString);
+      }
+      return Promise.resolve(true);
+    },
+    [navigate]
+  );
+
+  const back = useCallback(() => {
+    if (navigate) {
+      navigate(-1);
+    } else {
+      window.history.back();
+    }
+  }, [navigate]);
+
+  const reload = useCallback(() => {
+    window.location.reload();
+  }, []);
+
+  const query = useMemo(() => {
+    const result: Record<string, string | string[] | undefined> = {};
+    searchParams.forEach((value: string, key: string) => {
+      const existing = result[key];
+      if (existing !== undefined) {
+        if (Array.isArray(existing)) {
+          existing.push(value);
+        } else {
+          result[key] = [existing, value];
+        }
+      } else {
+        result[key] = value;
+      }
+    });
+    return result;
+  }, [searchParams]);
+
+  const pathname = location?.pathname ?? window.location.pathname;
+  const search = location?.search ?? window.location.search;
+
+  // In SPA mode, router is always ready (no SSR hydration needed)
+  const isReady = true;
+
+  // No-op events for SPA
+  const events = useMemo(() => createNoopEvents(), []);
+
+  return {
+    push,
+    replace,
+    back,
+    reload,
+    pathname,
+    asPath: pathname + search,
+    query,
+    isReady,
+    events,
+    // beforePopState is a noop in SPA mode (not supported in React Router)
+    beforePopState: () => {},
+  };
+}
+
+/**
+ * Head component for SPA - manages document head elements
+ * This is a simplified implementation that extracts title and link elements
+ */
+export function Head({ children }: HeadProps) {
+  useEffect(() => {
+    const cleanupFns: (() => void)[] = [];
+
+    Children.forEach(children, (child) => {
+      if (!isValidElement(child)) {
+        return;
+      }
+
+      const props = child.props as Record<string, unknown>;
+
+      if (child.type === "title") {
+        const previousTitle = document.title;
+        document.title = String(props.children ?? "");
+        cleanupFns.push(() => {
+          document.title = previousTitle;
+        });
+      } else if (child.type === "link") {
+        const link = document.createElement("link");
+        Object.entries(props).forEach(([key, value]) => {
+          if (key !== "children" && value !== undefined) {
+            link.setAttribute(key, String(value));
+          }
+        });
+        document.head.appendChild(link);
+        cleanupFns.push(() => {
+          document.head.removeChild(link);
+        });
+      } else if (child.type === "meta") {
+        const meta = document.createElement("meta");
+        Object.entries(props).forEach(([key, value]) => {
+          if (key !== "children" && value !== undefined) {
+            meta.setAttribute(key, String(value));
+          }
+        });
+        document.head.appendChild(meta);
+        cleanupFns.push(() => {
+          document.head.removeChild(meta);
+        });
+      }
+    });
+
+    return () => {
+      cleanupFns.forEach((fn) => fn());
+    };
+  }, [children]);
+
+  return null;
+}
+
+/**
+ * Script component for SPA - loads external scripts
+ */
+export function Script({ id, src, children }: ScriptProps) {
+  useEffect(() => {
+    const script = document.createElement("script");
+
+    if (id) {
+      script.id = id;
+    }
+
+    if (src) {
+      script.src = src;
+      script.async = true;
+    } else if (children) {
+      script.textContent = children;
+    }
+
+    document.body.appendChild(script);
+
+    return () => {
+      document.body.removeChild(script);
+    };
+  }, [id, src, children]);
+
+  return null;
+}
+
+/**
+ * Hook to get page context (auth data) in SPA
+ * Uses React Router's outlet context
+ */
+export function usePageContext<T>(): T | null {
+  try {
+    return useOutletContext<T>();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Hook to get route params in SPA
+ * Returns route parameters from the URL (e.g., :wId, :aId)
+ */
+export function usePathParams(): Record<string, string | undefined> {
+  try {
+    return useRouterParams();
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Hook to get a required route param
+ * Throws an error if the param is missing
+ */
+export function useRequiredPathParam(name: string): string {
+  const params = usePathParams();
+  const value = params[name];
+  if (!value) {
+    throw new Error(`Required route parameter "${name}" is missing`);
+  }
+  return value;
+}
+
+/**
+ * Hook to get a search/query param in SPA
+ * Returns the value of the specified query parameter or null
+ */
+export function useSearchParam(name: string): string | null {
+  const [searchParams] = useSafeSearchParams();
+  return searchParams.get(name);
+}
+
+export type { AppRouter, HeadProps, ScriptProps };

--- a/front/lib/swr/poke.ts
+++ b/front/lib/swr/poke.ts
@@ -84,7 +84,7 @@ export function usePokeWorkspaces({
   }
 
   const { data, error } = useSWRWithDefaults(
-    `api/poke/workspaces${query}`,
+    `/api/poke/workspaces${query}`,
     workspacesFetcher,
     {
       disabled,

--- a/front/next.config.js
+++ b/front/next.config.js
@@ -407,35 +407,76 @@ const config = {
       });
     }
 
-    return [
+    const result = [
       {
         source: "/:path*", // Match all paths
         headers,
       },
     ];
+
+    // Add CORS headers for API routes in development (for Vite SPA on localhost:3010)
+    if (isDev) {
+      result.push({
+        source: "/api/:path*",
+        headers: [
+          {
+            key: "Access-Control-Allow-Origin",
+            value: "http://localhost:3010",
+          },
+          {
+            key: "Access-Control-Allow-Methods",
+            value: "GET, POST, PUT, PATCH, DELETE, OPTIONS",
+          },
+          {
+            key: "Access-Control-Allow-Headers",
+            value: "Content-Type, Authorization, X-Commit-Hash",
+          },
+          { key: "Access-Control-Allow-Credentials", value: "true" },
+        ],
+      });
+    }
+
+    return result;
   },
   async rewrites() {
-    return [
-      // Legacy endpoint rewrite to maintain compatibility for users still hitting `/vaults/`
-      // endpoints on the public API.
-      {
-        source: "/api/v1/w/:wId/vaults/:vId/:path*",
-        destination: "/api/v1/w/:wId/spaces/:vId/:path*",
-      },
-      {
-        source: "/api/v1/w/:wId/vaults",
-        destination: "/api/v1/w/:wId/spaces",
-      },
-      // Posthog tracking - endpoint name called "subtle1"
-      {
-        source: "/subtle1/static/:path*",
-        destination: "https://eu-assets.i.posthog.com/static/:path*",
-      },
-      {
-        source: "/subtle1/:path*",
-        destination: "https://eu.i.posthog.com/:path*",
-      },
-    ];
+    return {
+      beforeFiles: [
+        // SPA catch-all: serve index.html for all /spa/* routes (client-side routing)
+        // This must be beforeFiles to take precedence over static file serving
+        {
+          source: "/spa/:path*",
+          destination: "/spa/index.html",
+          has: [
+            {
+              type: "header",
+              key: "accept",
+              value: ".*text/html.*",
+            },
+          ],
+        },
+      ],
+      afterFiles: [
+        // Legacy endpoint rewrite to maintain compatibility for users still hitting `/vaults/`
+        // endpoints on the public API.
+        {
+          source: "/api/v1/w/:wId/vaults/:vId/:path*",
+          destination: "/api/v1/w/:wId/spaces/:vId/:path*",
+        },
+        {
+          source: "/api/v1/w/:wId/vaults",
+          destination: "/api/v1/w/:wId/spaces",
+        },
+        // Posthog tracking - endpoint name called "subtle1"
+        {
+          source: "/subtle1/static/:path*",
+          destination: "https://eu-assets.i.posthog.com/static/:path*",
+        },
+        {
+          source: "/subtle1/:path*",
+          destination: "https://eu.i.posthog.com/:path*",
+        },
+      ],
+    };
   },
   webpack(config, { dev, isServer }) {
     if (process.env.BUILD_WITH_SOURCE_MAPS === "true" && !dev) {
@@ -507,6 +548,20 @@ const config = {
       child_process: false,
       tls: false,
       dgram: false,
+    };
+
+    // Resolve SDK dependencies from front's node_modules
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      "eventsource-parser": path.resolve(
+        __dirname,
+        "node_modules/eventsource-parser"
+      ),
+      "event-source-polyfill": path.resolve(
+        __dirname,
+        "node_modules/event-source-polyfill"
+      ),
+      zod: path.resolve(__dirname, "node_modules/zod"),
     };
 
     // Use source-map-loader for transitively include source maps of dependencies.

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -108,6 +108,7 @@
         "dompurify": "^3.2.7",
         "embla-carousel-react": "^8.0.1",
         "emoji-mart": "^5.6.0",
+        "event-source-polyfill": "^1.0.31",
         "eventsource-parser": "^1.0.0",
         "fast-xml-parser": "^4.4.1",
         "fathom-typescript": "^0.0.36",
@@ -163,6 +164,7 @@
         "react-multi-select-component": "^4.3.4",
         "react-phone-number-input": "^3.4.14",
         "react-resizable-panels": "^2.1.7",
+        "react-router-dom": "^7.0.0",
         "react-textarea-autosize": "^8.4.0",
         "recharts": "3.2.1",
         "redis": "^4.6.8",
@@ -248,6 +250,7 @@
         "tsx": "^4.21.0",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.48.0",
+        "vite": "^5.4.0",
         "vitest": "^4.0.16",
         "vitest-canvas-mock": "^1.1.3",
         "webpack-stats-plugin": "^1.1.3",
@@ -3367,13 +3370,6 @@
       "engines": {
         "node": ">=20.11.0"
       }
-    },
-    "node_modules/@es-joy/jsdoccomment/node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@es-joy/resolve.exports": {
       "version": "1.2.0",
@@ -10815,259 +10811,349 @@
       "integrity": "sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg=="
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.40.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.40.2.tgz",
-      "integrity": "sha512-JkdNEq+DFxZfUwxvB58tHMHBHVgX23ew41g1OQinthJ+ryhdRk67O31S7sYw8u2lTjHUPFxwar07BBt1KHp/hg==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.55.1.tgz",
+      "integrity": "sha512-9R0DM/ykwfGIlNu6+2U09ga0WXeZ9MRC2Ter8jnz8415VbuIykVuc6bhdrbORFZANDmTDvq26mJrEVTl8TdnDg==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.40.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.40.2.tgz",
-      "integrity": "sha512-13unNoZ8NzUmnndhPTkWPWbX3vtHodYmy+I9kuLxN+F+l+x3LdVF7UCu8TWVMt1POHLh6oDHhnOA04n8oJZhBw==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.55.1.tgz",
+      "integrity": "sha512-eFZCb1YUqhTysgW3sj/55du5cG57S7UTNtdMjCW7LwVcj3dTTcowCsC8p7uBdzKsZYa8J7IDE8lhMI+HX1vQvg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.40.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.40.2.tgz",
-      "integrity": "sha512-Gzf1Hn2Aoe8VZzevHostPX23U7N5+4D36WJNHK88NZHCJr7aVMG4fadqkIf72eqVPGjGc0HJHNuUaUcxiR+N/w==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.55.1.tgz",
+      "integrity": "sha512-p3grE2PHcQm2e8PSGZdzIhCKbMCw/xi9XvMPErPhwO17vxtvCN5FEA2mSLgmKlCjHGMQTP6phuQTYWUnKewwGg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.40.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.40.2.tgz",
-      "integrity": "sha512-47N4hxa01a4x6XnJoskMKTS8XZ0CZMd8YTbINbi+w03A2w4j1RTlnGHOz/P0+Bg1LaVL6ufZyNprSg+fW5nYQQ==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.55.1.tgz",
+      "integrity": "sha512-rDUjG25C9qoTm+e02Esi+aqTKSBYwVTaoS1wxcN47/Luqef57Vgp96xNANwt5npq9GDxsH7kXxNkJVEsWEOEaQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.40.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.40.2.tgz",
-      "integrity": "sha512-8t6aL4MD+rXSHHZUR1z19+9OFJ2rl1wGKvckN47XFRVO+QL/dUSpKA2SLRo4vMg7ELA8pzGpC+W9OEd1Z/ZqoQ==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.55.1.tgz",
+      "integrity": "sha512-+JiU7Jbp5cdxekIgdte0jfcu5oqw4GCKr6i3PJTlXTCU5H5Fvtkpbs4XJHRmWNXF+hKmn4v7ogI5OQPaupJgOg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.40.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.40.2.tgz",
-      "integrity": "sha512-C+AyHBzfpsOEYRFjztcYUFsH4S7UsE9cDtHCtma5BK8+ydOZYgMmWg1d/4KBytQspJCld8ZIujFMAdKG1xyr4Q==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.55.1.tgz",
+      "integrity": "sha512-V5xC1tOVWtLLmr3YUk2f6EJK4qksksOYiz/TCsFHu/R+woubcLWdC9nZQmwjOAbmExBIVKsm1/wKmEy4z4u4Bw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.40.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.40.2.tgz",
-      "integrity": "sha512-de6TFZYIvJwRNjmW3+gaXiZ2DaWL5D5yGmSYzkdzjBDS3W+B9JQ48oZEsmMvemqjtAFzE16DIBLqd6IQQRuG9Q==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.55.1.tgz",
+      "integrity": "sha512-Rn3n+FUk2J5VWx+ywrG/HGPTD9jXNbicRtTM11e/uorplArnXZYsVifnPPqNNP5BsO3roI4n8332ukpY/zN7rQ==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.40.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.40.2.tgz",
-      "integrity": "sha512-urjaEZubdIkacKc930hUDOfQPysezKla/O9qV+O89enqsqUmQm8Xj8O/vh0gHg4LYfv7Y7UsE3QjzLQzDYN1qg==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.55.1.tgz",
+      "integrity": "sha512-grPNWydeKtc1aEdrJDWk4opD7nFtQbMmV7769hiAaYyUKCT1faPRm2av8CX1YJsZ4TLAZcg9gTR1KvEzoLjXkg==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.40.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.40.2.tgz",
-      "integrity": "sha512-KlE8IC0HFOC33taNt1zR8qNlBYHj31qGT1UqWqtvR/+NuCVhfufAq9fxO8BMFC22Wu0rxOwGVWxtCMvZVLmhQg==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.55.1.tgz",
+      "integrity": "sha512-a59mwd1k6x8tXKcUxSyISiquLwB5pX+fJW9TkWU46lCqD/GRDe9uDN31jrMmVP3feI3mhAdvcCClhV8V5MhJFQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.40.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.40.2.tgz",
-      "integrity": "sha512-j8CgxvfM0kbnhu4XgjnCWJQyyBOeBI1Zq91Z850aUddUmPeQvuAy6OiMdPS46gNFgy8gN1xkYyLgwLYZG3rBOg==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.55.1.tgz",
+      "integrity": "sha512-puS1MEgWX5GsHSoiAsF0TYrpomdvkaXm0CofIMG5uVkP6IBV+ZO9xhC5YEN49nsgYo1DuuMquF9+7EDBVYu4uA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-      "version": "4.40.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.40.2.tgz",
-      "integrity": "sha512-Ybc/1qUampKuRF4tQXc7G7QY9YRyeVSykfK36Y5Qc5dmrIxwFhrOzqaVTNoZygqZ1ZieSWTibfFhQ5qK8jpWxw==",
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.55.1.tgz",
+      "integrity": "sha512-r3Wv40in+lTsULSb6nnoudVbARdOwb2u5fpeoOAZjFLznp6tDU8kd+GTHmJoqZ9lt6/Sys33KdIHUaQihFcu7g==",
       "cpu": [
         "loong64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.40.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.40.2.tgz",
-      "integrity": "sha512-3FCIrnrt03CCsZqSYAOW/k9n625pjpuMzVfeI+ZBUSDT3MVIFDSPfSUgIl9FqUftxcUXInvFah79hE1c9abD+Q==",
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.55.1.tgz",
+      "integrity": "sha512-MR8c0+UxAlB22Fq4R+aQSPBayvYa3+9DrwG/i1TKQXFYEaoW3B5b/rkSRIypcZDdWjWnpcvxbNaAJDcSbJU3Lw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.55.1.tgz",
+      "integrity": "sha512-3KhoECe1BRlSYpMTeVrD4sh2Pw2xgt4jzNSZIIPLFEsnQn9gAnZagW9+VqDqAHgm1Xc77LzJOo2LdigS5qZ+gw==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.55.1.tgz",
+      "integrity": "sha512-ziR1OuZx0vdYZZ30vueNZTg73alF59DicYrPViG0NEgDVN8/Jl87zkAPu4u6VjZST2llgEUjaiNl9JM6HH1Vdw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.40.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.40.2.tgz",
-      "integrity": "sha512-QNU7BFHEvHMp2ESSY3SozIkBPaPBDTsfVNGx3Xhv+TdvWXFGOSH2NJvhD1zKAT6AyuuErJgbdvaJhYVhVqrWTg==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.55.1.tgz",
+      "integrity": "sha512-uW0Y12ih2XJRERZ4jAfKamTyIHVMPQnTZcQjme2HMVDAHY4amf5u414OqNYC+x+LzRdRcnIG1YodLrrtA8xsxw==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.40.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.40.2.tgz",
-      "integrity": "sha512-5W6vNYkhgfh7URiXTO1E9a0cy4fSgfE4+Hl5agb/U1sa0kjOLMLC1wObxwKxecE17j0URxuTrYZZME4/VH57Hg==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.55.1.tgz",
+      "integrity": "sha512-u9yZ0jUkOED1BFrqu3BwMQoixvGHGZ+JhJNkNKY/hyoEgOwlqKb62qu+7UjbPSHYjiVy8kKJHvXKv5coH4wDeg==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.40.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.40.2.tgz",
-      "integrity": "sha512-B7LKIz+0+p348JoAL4X/YxGx9zOx3sR+o6Hj15Y3aaApNfAshK8+mWZEf759DXfRLeL2vg5LYJBB7DdcleYCoQ==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.55.1.tgz",
+      "integrity": "sha512-/0PenBCmqM4ZUd0190j7J0UsQ/1nsi735iPRakO8iPciE7BQ495Y6msPzaOmvx0/pn+eJVVlZrNrSh4WSYLxNg==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.40.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.40.2.tgz",
-      "integrity": "sha512-lG7Xa+BmBNwpjmVUbmyKxdQJ3Q6whHjMjzQplOs5Z+Gj7mxPtWakGHqzMqNER68G67kmCX9qX57aRsW5V0VOng==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.55.1.tgz",
+      "integrity": "sha512-a8G4wiQxQG2BAvo+gU6XrReRRqj+pLS2NGXKm8io19goR+K8lw269eTrPkSdDTALwMmJp4th2Uh0D8J9bEV1vg==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.40.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.40.2.tgz",
-      "integrity": "sha512-tD46wKHd+KJvsmije4bUskNuvWKFcTOIM9tZ/RrmIvcXnbi0YK/cKS9FzFtAm7Oxi2EhV5N2OpfFB348vSQRXA==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.55.1.tgz",
+      "integrity": "sha512-bD+zjpFrMpP/hqkfEcnjXWHMw5BIghGisOKPj+2NaNDuVT+8Ds4mPf3XcPHuat1tz89WRL+1wbcxKY3WSbiT7w==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.40.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.40.2.tgz",
-      "integrity": "sha512-Bjv/HG8RRWLNkXwQQemdsWw4Mg+IJ29LK+bJPW2SCzPKOUaMmPEppQlu/Fqk1d7+DX3V7JbFdbkh/NMmurT6Pg==",
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.55.1.tgz",
+      "integrity": "sha512-eLXw0dOiqE4QmvikfQ6yjgkg/xDM+MdU9YJuP4ySTibXU0oAvnEWXt7UDJmD4UkYialMfOGFPJnIHSe/kdzPxg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.55.1.tgz",
+      "integrity": "sha512-xzm44KgEP11te3S2HCSyYf5zIzWmx3n8HDCc7EE59+lTcswEWNpvMLfd9uJvVX8LCg9QWG67Xt75AuHn4vgsXw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.55.1.tgz",
+      "integrity": "sha512-yR6Bl3tMC/gBok5cz/Qi0xYnVbIxGx5Fcf/ca0eB6/6JwOY+SRUcJfI0OpeTpPls7f194as62thCt/2BjxYN8g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.40.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.40.2.tgz",
-      "integrity": "sha512-dt1llVSGEsGKvzeIO76HToiYPNPYPkmjhMHhP00T9S4rDern8P2ZWvWAQUEJ+R1UdMWJ/42i/QqJ2WV765GZcA==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.55.1.tgz",
+      "integrity": "sha512-3fZBidchE0eY0oFZBnekYCfg+5wAB0mbpCBuofh5mZuzIU/4jIVkbESmd2dOsFNS78b53CYv3OAtwqkZZmU5nA==",
       "cpu": [
         "ia32"
       ],
       "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.55.1.tgz",
+      "integrity": "sha512-xGGY5pXj69IxKb4yv/POoocPy/qmEGhimy/FoTpTSVju3FYXUQQMFCaZZXJVidsmGxRioZAwpThl/4zX41gRKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.40.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.40.2.tgz",
-      "integrity": "sha512-bwspbWB04XJpeElvsp+DCylKfF4trJDa2Y9Go8O6A7YLX2LIKGcNK/CYImJN6ZP4DcuOHB4Utl3iCbnR62DudA==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.55.1.tgz",
+      "integrity": "sha512-SPEpaL6DX4rmcXtnhdrQYgzQ5W2uW3SCJch88lB2zImhJRhIIK44fkUrgIV/Q8yUNfw5oyZ5vkeQsZLhCb06lw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -14284,9 +14370,10 @@
       "dev": true
     },
     "node_modules/@types/estree": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
-      "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ=="
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "license": "MIT"
     },
     "node_modules/@types/express": {
       "version": "5.0.0",
@@ -15309,33 +15396,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/mocker": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.16.tgz",
-      "integrity": "sha512-yb6k4AZxJTB+q9ycAvsoxGn+j/po0UaPgajllBgt1PzoMAAmJGYFdDk0uCcRcxb3BrME34I6u8gHZTQlkqSZpg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/spy": "4.0.16",
-        "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.21"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      },
-      "peerDependencies": {
-        "msw": "^2.4.9",
-        "vite": "^6.0.0 || ^7.0.0-0"
-      },
-      "peerDependenciesMeta": {
-        "msw": {
-          "optional": true
-        },
-        "vite": {
-          "optional": true
-        }
       }
     },
     "node_modules/@vitest/pretty-format": {
@@ -20175,6 +20235,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/event-source-polyfill": {
+      "version": "1.0.31",
+      "resolved": "https://registry.npmjs.org/event-source-polyfill/-/event-source-polyfill-1.0.31.tgz",
+      "integrity": "sha512-4IJSItgS/41IxN5UVAVuAyczwZF7ZIEsM1XAoUzIHA6A+xzusEZUutdXz2Nr+MQPLxfTiCvqE79/C8HT8fKFvA==",
+      "license": "MIT"
     },
     "node_modules/event-target-polyfill": {
       "version": "0.0.4",
@@ -30429,6 +30495,57 @@
         "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.12.0.tgz",
+      "integrity": "sha512-kTPDYPFzDVGIIGNLS5VJykK0HfHLY5MF3b+xj0/tTyNYL1gF1qs7u67Z9jEhQk2sQ98SUaHxlG31g1JtF7IfVw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.12.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.12.0.tgz",
+      "integrity": "sha512-pfO9fiBcpEfX4Tx+iTYKDtPbrSLLCbwJ5EqP+SPYQu1VYCXdy79GSj0wttR0U4cikVdlImZuEZ/9ZNCgoaxwBA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.12.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-router/node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/react-style-singleton": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
@@ -31501,12 +31618,13 @@
       "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg=="
     },
     "node_modules/rollup": {
-      "version": "4.40.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.40.2.tgz",
-      "integrity": "sha512-tfUOg6DTP4rhQ3VjOO6B4wyrJnGOX85requAXvqYTHsOgb2TFJdZ3aWpT8W2kPoypSGP7dZUyzxJ9ee4buM5Fg==",
+      "version": "4.55.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.55.1.tgz",
+      "integrity": "sha512-wDv/Ht1BNHB4upNbK74s9usvl7hObDnvVzknxqY/E/O3X6rW1U1rV1aENEfJ54eFZDTNo7zv1f5N4edCluH7+A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.7"
+        "@types/estree": "1.0.8"
       },
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -31516,26 +31634,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.40.2",
-        "@rollup/rollup-android-arm64": "4.40.2",
-        "@rollup/rollup-darwin-arm64": "4.40.2",
-        "@rollup/rollup-darwin-x64": "4.40.2",
-        "@rollup/rollup-freebsd-arm64": "4.40.2",
-        "@rollup/rollup-freebsd-x64": "4.40.2",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.40.2",
-        "@rollup/rollup-linux-arm-musleabihf": "4.40.2",
-        "@rollup/rollup-linux-arm64-gnu": "4.40.2",
-        "@rollup/rollup-linux-arm64-musl": "4.40.2",
-        "@rollup/rollup-linux-loongarch64-gnu": "4.40.2",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.40.2",
-        "@rollup/rollup-linux-riscv64-gnu": "4.40.2",
-        "@rollup/rollup-linux-riscv64-musl": "4.40.2",
-        "@rollup/rollup-linux-s390x-gnu": "4.40.2",
-        "@rollup/rollup-linux-x64-gnu": "4.40.2",
-        "@rollup/rollup-linux-x64-musl": "4.40.2",
-        "@rollup/rollup-win32-arm64-msvc": "4.40.2",
-        "@rollup/rollup-win32-ia32-msvc": "4.40.2",
-        "@rollup/rollup-win32-x64-msvc": "4.40.2",
+        "@rollup/rollup-android-arm-eabi": "4.55.1",
+        "@rollup/rollup-android-arm64": "4.55.1",
+        "@rollup/rollup-darwin-arm64": "4.55.1",
+        "@rollup/rollup-darwin-x64": "4.55.1",
+        "@rollup/rollup-freebsd-arm64": "4.55.1",
+        "@rollup/rollup-freebsd-x64": "4.55.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.55.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.55.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.55.1",
+        "@rollup/rollup-linux-arm64-musl": "4.55.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.55.1",
+        "@rollup/rollup-linux-loong64-musl": "4.55.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.55.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.55.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.55.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.55.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.55.1",
+        "@rollup/rollup-linux-x64-gnu": "4.55.1",
+        "@rollup/rollup-linux-x64-musl": "4.55.1",
+        "@rollup/rollup-openbsd-x64": "4.55.1",
+        "@rollup/rollup-openharmony-arm64": "4.55.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.55.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.55.1",
+        "@rollup/rollup-win32-x64-gnu": "4.55.1",
+        "@rollup/rollup-win32-x64-msvc": "4.55.1",
         "fsevents": "~2.3.2"
       }
     },
@@ -32035,6 +32158,12 @@
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "license": "ISC",
       "optional": true
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -36077,24 +36206,21 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.25.0",
-        "fdir": "^6.4.4",
-        "picomatch": "^4.0.2",
-        "postcss": "^8.5.3",
-        "rollup": "^4.34.9",
-        "tinyglobby": "^0.2.13"
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
       },
       "bin": {
         "vite": "bin/vite.js"
       },
       "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+        "node": "^18.0.0 || >=20.0.0"
       },
       "funding": {
         "url": "https://github.com/vitejs/vite?sponsor=1"
@@ -36103,23 +36229,17 @@
         "fsevents": "~2.3.3"
       },
       "peerDependencies": {
-        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "jiti": ">=1.21.0",
+        "@types/node": "^18.0.0 || >=20.0.0",
         "less": "*",
         "lightningcss": "^1.21.0",
         "sass": "*",
         "sass-embedded": "*",
         "stylus": "*",
         "sugarss": "*",
-        "terser": "^5.16.0",
-        "tsx": "^4.8.1",
-        "yaml": "^2.4.2"
+        "terser": "^5.4.0"
       },
       "peerDependenciesMeta": {
         "@types/node": {
-          "optional": true
-        },
-        "jiti": {
           "optional": true
         },
         "less": {
@@ -36142,39 +36262,437 @@
         },
         "terser": {
           "optional": true
-        },
-        "tsx": {
-          "optional": true
-        },
-        "yaml": {
-          "optional": true
         }
       }
     },
-    "node_modules/vite/node_modules/fdir": {
-      "version": "6.4.4",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.4.tgz",
-      "integrity": "sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==",
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
       "dev": true,
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
       },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
       }
     },
     "node_modules/vitest": {
@@ -36269,6 +36787,535 @@
         "vitest": "^3.0.0 || ^4.0.0"
       }
     },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.2.tgz",
+      "integrity": "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.2.tgz",
+      "integrity": "sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.2.tgz",
+      "integrity": "sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.2.tgz",
+      "integrity": "sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.2.tgz",
+      "integrity": "sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.2.tgz",
+      "integrity": "sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.2.tgz",
+      "integrity": "sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.2.tgz",
+      "integrity": "sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.2.tgz",
+      "integrity": "sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.2.tgz",
+      "integrity": "sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.2.tgz",
+      "integrity": "sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.2.tgz",
+      "integrity": "sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.2.tgz",
+      "integrity": "sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.2.tgz",
+      "integrity": "sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.2.tgz",
+      "integrity": "sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.2.tgz",
+      "integrity": "sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.2.tgz",
+      "integrity": "sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.2.tgz",
+      "integrity": "sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.2.tgz",
+      "integrity": "sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.2.tgz",
+      "integrity": "sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.2.tgz",
+      "integrity": "sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.2.tgz",
+      "integrity": "sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.2.tgz",
+      "integrity": "sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.2.tgz",
+      "integrity": "sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.2.tgz",
+      "integrity": "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.2.tgz",
+      "integrity": "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "4.0.16",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.16.tgz",
+      "integrity": "sha512-yb6k4AZxJTB+q9ycAvsoxGn+j/po0UaPgajllBgt1PzoMAAmJGYFdDk0uCcRcxb3BrME34I6u8gHZTQlkqSZpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.16",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/esbuild": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
+      "integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.2",
+        "@esbuild/android-arm": "0.27.2",
+        "@esbuild/android-arm64": "0.27.2",
+        "@esbuild/android-x64": "0.27.2",
+        "@esbuild/darwin-arm64": "0.27.2",
+        "@esbuild/darwin-x64": "0.27.2",
+        "@esbuild/freebsd-arm64": "0.27.2",
+        "@esbuild/freebsd-x64": "0.27.2",
+        "@esbuild/linux-arm": "0.27.2",
+        "@esbuild/linux-arm64": "0.27.2",
+        "@esbuild/linux-ia32": "0.27.2",
+        "@esbuild/linux-loong64": "0.27.2",
+        "@esbuild/linux-mips64el": "0.27.2",
+        "@esbuild/linux-ppc64": "0.27.2",
+        "@esbuild/linux-riscv64": "0.27.2",
+        "@esbuild/linux-s390x": "0.27.2",
+        "@esbuild/linux-x64": "0.27.2",
+        "@esbuild/netbsd-arm64": "0.27.2",
+        "@esbuild/netbsd-x64": "0.27.2",
+        "@esbuild/openbsd-arm64": "0.27.2",
+        "@esbuild/openbsd-x64": "0.27.2",
+        "@esbuild/openharmony-arm64": "0.27.2",
+        "@esbuild/sunos-x64": "0.27.2",
+        "@esbuild/win32-arm64": "0.27.2",
+        "@esbuild/win32-ia32": "0.27.2",
+        "@esbuild/win32-x64": "0.27.2"
+      }
+    },
+    "node_modules/vitest/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/vitest/node_modules/picomatch": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
@@ -36290,6 +37337,81 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
       }
     },
     "node_modules/vscode-jsonrpc": {

--- a/front/package.json
+++ b/front/package.json
@@ -5,7 +5,7 @@
     "dev:all": "concurrently --kill-others \"cd ../types/ && npm run start\" \"sleep 20 && cd ../sdks/js/ && npm run start\" \"sleep 22 && next dev\" \"sleep 22 && tsx ./start_worker.ts\"",
     "dev": "next dev",
     "dev-datadog": "NODE_OPTIONS='-r dd-trace/init' DD_TAGS=service:front-edge DD_TAGS=env:dev-ben DD_GIT_COMMIT_SHA=`git rev-parse HEAD` DD_GIT_REPOSITORY_URL=https://github.com/dust-tt/dust/ npm run dev",
-    "build": "next build",
+    "build": "./admin/build-spa.sh && next build",
     "build:temporal-bundles": "tsx scripts/temporal-build/build-temporal-bundles.ts",
     "build:workers": "tsx esbuild.worker.ts",
     "start": "next start --keepAliveTimeout 5000",
@@ -31,6 +31,10 @@
     "analyze": "NODE_OPTIONS=--max-old-space-size=16384 ANALYZE=true npm run build",
     "knip": "knip",
     "generate:hubspot-forms": "tsx scripts/generate-hubspot-forms.ts"
+    "generate:contact-form": "tsx scripts/generate-contact-form-schema.ts",
+    "spa:dev": "VITE_DUST_CLIENT_FACING_URL=$DUST_CLIENT_FACING_URL vite --config vite.spa.config.ts",
+    "spa:build": "vite build --config vite.spa.config.ts",
+    "spa:preview": "vite preview --config vite.spa.config.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.71.0",
@@ -133,6 +137,7 @@
     "dompurify": "^3.2.7",
     "embla-carousel-react": "^8.0.1",
     "emoji-mart": "^5.6.0",
+    "event-source-polyfill": "^1.0.31",
     "eventsource-parser": "^1.0.0",
     "fast-xml-parser": "^4.4.1",
     "fathom-typescript": "^0.0.36",
@@ -188,6 +193,7 @@
     "react-multi-select-component": "^4.3.4",
     "react-phone-number-input": "^3.4.14",
     "react-resizable-panels": "^2.1.7",
+    "react-router-dom": "^7.0.0",
     "react-textarea-autosize": "^8.4.0",
     "recharts": "3.2.1",
     "redis": "^4.6.8",
@@ -273,6 +279,7 @@
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.48.0",
+    "vite": "^5.4.0",
     "vitest": "^4.0.16",
     "vitest-canvas-mock": "^1.1.3",
     "webpack-stats-plugin": "^1.1.3",

--- a/front/tsconfig.json
+++ b/front/tsconfig.json
@@ -33,7 +33,8 @@
     "**/*.jsx",
     "**/*.js",
     "**/*.mjs",
-    "./.eslintrc.js"
+    "./.eslintrc.js",
+    ".next/types/**/*.ts"
   ],
-  "exclude": ["node_modules", ".next", "dist"]
+  "exclude": ["node_modules", ".next", "dist", "app"]
 }

--- a/front/types/sparkle.d.ts
+++ b/front/types/sparkle.d.ts
@@ -1,0 +1,11 @@
+// Type augmentation for Sparkle components
+// TODO: Remove this once these props are properly supported in @dust-tt/sparkle
+import "@dust-tt/sparkle";
+
+declare module "@dust-tt/sparkle" {
+  interface LinkWrapperProps {
+    className?: string;
+    target?: string;
+    rel?: string;
+  }
+}

--- a/front/vite.spa.config.ts
+++ b/front/vite.spa.config.ts
@@ -1,0 +1,130 @@
+import react from "@vitejs/plugin-react";
+import path from "path";
+import type { Plugin } from "vite";
+import { defineConfig, loadEnv } from "vite";
+
+// Virtual module plugin to stub out server-side only modules
+function stubModulesPlugin(): Plugin {
+  const stubs: Record<string, string> = {
+    // Stream: minimal stub for Node.js stream module
+    stream:
+      "export class Readable { pipe() { return this; } on() { return this; } once() { return this; } destroy() {} } export class Writable { write() { return true; } end() {} on() { return this; } once() { return this; } } export class Transform extends Readable {} export class Duplex extends Readable { write() { return true; } end() {} } export default { Readable, Writable, Transform, Duplex };",
+  };
+
+  // Stubs for resolved file paths (after @app alias is applied)
+  const filePathStubs: Record<string, string> = {
+    // Logger
+    "logger/logger":
+      "const noop = () => {}; const logger = { info: noop, warn: noop, error: noop, debug: noop, trace: noop, fatal: noop, child: () => logger }; export default logger;",
+    // Text extraction
+    "types/shared/text_extraction/index":
+      "export const pagePrefixesPerMimeType = {}; export const isTextExtractionSupportedContentType = () => false; export class TextExtraction { constructor() {} fromStream() { throw new Error('Not available in browser'); } }",
+    // Structured data
+    "types/shared/utils/structured_data":
+      "export class InvalidStructuredDataHeaderError extends Error {} export const getSanitizedHeaders = () => { throw new Error('Not available in browser'); }; export const guessDelimiter = async () => undefined; export const parseAndStringifyCsv = async () => { throw new Error('Not available in browser'); };",
+  };
+
+  return {
+    name: "stub-server-modules",
+    enforce: "pre",
+    resolveId(id) {
+      if (id in stubs) {
+        return `\0virtual:${id}`;
+      }
+      return null;
+    },
+    load(id) {
+      // Handle virtual modules
+      if (id.startsWith("\0virtual:")) {
+        const moduleId = id.slice("\0virtual:".length);
+        return stubs[moduleId];
+      }
+      // Handle resolved file paths
+      for (const [pathSuffix, stub] of Object.entries(filePathStubs)) {
+        if (id.endsWith(pathSuffix + ".ts") || id.endsWith(pathSuffix)) {
+          return stub;
+        }
+      }
+      return null;
+    },
+  };
+}
+
+export default defineConfig(({ mode }) => {
+  // Load env file based on `mode` in the current working directory.
+  // Set the third parameter to '' to load all env regardless of the `VITE_` prefix.
+  const fileEnv = loadEnv(mode, process.cwd(), "");
+
+  // Merge with process.env to include shell environment variables (for build scripts)
+  const env = { ...fileEnv, ...process.env };
+
+  // Map NEXT_PUBLIC_* env vars to process.env.NEXT_PUBLIC_* for compatibility
+  const envVarDefines: Record<string, string> = {};
+  for (const key of Object.keys(env)) {
+    if (key.startsWith("NEXT_PUBLIC_")) {
+      envVarDefines[`process.env.${key}`] = JSON.stringify(env[key]);
+    }
+    // Also define VITE_* vars for import.meta.env (ensures shell vars are included)
+    if (key.startsWith("VITE_")) {
+      envVarDefines[`import.meta.env.${key}`] = JSON.stringify(env[key]);
+    }
+  }
+
+  // Base path for the app (e.g., "/prefix" to serve at localhost:3010/prefix/...)
+  const basePath = env.VITE_BASE_PATH ?? "/";
+
+  return {
+    base: basePath,
+    root: path.resolve(__dirname, "app"),
+    plugins: [stubModulesPlugin(), react()],
+    define: {
+      ...envVarDefines,
+      // Fallback for any remaining process.env access
+      "process.env": {},
+    },
+    server: {
+      port: 3010,
+      // No proxy - client calls API directly using VITE_DUST_CLIENT_FACING_URL
+      fs: {
+        // Allow serving files from the full front directory
+        allow: [path.resolve(__dirname, ".")],
+      },
+    },
+    resolve: {
+      // Use array format for aliases to ensure proper ordering (most specific first)
+      alias: [
+        // Platform abstraction: use SPA implementation instead of Next.js
+        {
+          find: "@app/lib/platform",
+          replacement: path.resolve(__dirname, "lib/platform/spa.ts"),
+        },
+        // General @app alias
+        { find: "@app", replacement: path.resolve(__dirname, "./") },
+        // Resolve SDK dependencies from front's node_modules
+        {
+          find: "eventsource-parser",
+          replacement: path.resolve(
+            __dirname,
+            "node_modules/eventsource-parser"
+          ),
+        },
+        {
+          find: "event-source-polyfill",
+          replacement: path.resolve(
+            __dirname,
+            "node_modules/event-source-polyfill"
+          ),
+        },
+        {
+          find: "zod",
+          replacement: path.resolve(__dirname, "node_modules/zod"),
+        },
+      ],
+      dedupe: ["react", "react-dom"],
+    },
+    build: {
+      outDir: path.resolve(__dirname, "app/dist"),
+      sourcemap: true,
+    },
+  };
+});


### PR DESCRIPTION
## Description

This is a proof-of-concept for moving away from `getServerSideProps` by introducing a client-side `AuthProvider` pattern. This is the first step towards migrating to React + Vite by eliminating SSR.

**Changes:**
- Add `AuthContext.tsx` with `AuthProvider` and `useAuth` hook
- Add `/api/w/[wId]/auth-context` endpoint that returns user, workspace, subscription, and role flags
- Convert `labs/index.tsx` as first example page using the new pattern

**How it works:**
```typescript
// Outer component extracts wId, wraps with AuthProvider
export default function MyPage() {
  const { wId } = useRouter().query;
  return (
    <AuthProvider workspaceId={wId}>
      <MyPageContent />
    </AuthProvider>
  );
}

// Inner component uses useAuth() - values guaranteed non-null
function MyPageContent() {
  const { workspace, subscription, isAdmin } = useAuth();
  // No loading checks needed, AuthProvider handles it
}
```

The AuthProvider handles:
- Fetching auth context via SWR
- Redirecting to login if not authenticated
- Showing loading spinner while auth is resolving

## Tests

Manual testing needed:
- Visit `/w/{wId}/labs` while logged in → should show labs page
- Visit `/w/{wId}/labs` while logged out → should redirect to login
- Refresh the page → should load correctly

## Risk

Low - this only changes one page (labs). If issues arise, we can revert easily.

## Deploy Plan

Standard deployment. No database changes, no migrations.