### PR TITLE
feat(dust-hive): add --db-from flag to clone postgres from existing env

### DIFF
--- a/x/henry/dust-hive/src/index.ts
+++ b/x/henry/dust-hive/src/index.ts
@@ -57,6 +57,7 @@ cli
   )
   .option("-c, --command <cmd>", "Run command in shell tab after opening (drops to shell on exit)")
   .option("-C, --compact", "Use compact zellij layout (no tab bar)")
+  .option("-d, --db-from <env>", "Clone Postgres database from existing environment")
   .action(
     async (
       name: string | undefined,
@@ -69,6 +70,7 @@ cli
         wait?: boolean;
         command?: string;
         compact?: boolean;
+        dbFrom?: string;
       }
     ) => {
       // Validate --wait cannot be used with --no-open
@@ -87,6 +89,7 @@ cli
         wait?: boolean;
         command?: string;
         compact?: boolean;
+        dbFrom?: string;
       } = {};
       if (resolvedName !== undefined) {
         spawnOptions.name = resolvedName;
@@ -111,6 +114,9 @@ cli
       }
       if (options.compact) {
         spawnOptions.compact = true;
+      }
+      if (options.dbFrom) {
+        spawnOptions.dbFrom = options.dbFrom;
       }
       await prepareAndRun(spawnCommand(spawnOptions));
     }

--- a/x/henry/dust-hive/src/lib/test-postgres.ts
+++ b/x/henry/dust-hive/src/lib/test-postgres.ts
@@ -1,6 +1,7 @@
 // Shared test Postgres management (global container, not per-environment)
 // Each environment gets its own database within this container.
 
+import { isContainerRunning } from "./docker";
 import {
   TEST_POSTGRES_CONTAINER_NAME,
   TEST_POSTGRES_PASSWORD,
@@ -10,17 +11,7 @@ import {
 
 // Check if the test postgres container is running
 export async function isTestPostgresRunning(): Promise<boolean> {
-  const proc = Bun.spawn(
-    ["docker", "inspect", "-f", "{{.State.Running}}", TEST_POSTGRES_CONTAINER_NAME],
-    {
-      stdout: "pipe",
-      stderr: "pipe",
-    }
-  );
-  const output = await new Response(proc.stdout).text();
-  await proc.exited;
-
-  return proc.exitCode === 0 && output.trim() === "true";
+  return isContainerRunning(TEST_POSTGRES_CONTAINER_NAME);
 }
 
 // Check if the test postgres container exists (running or stopped)

--- a/x/henry/dust-hive/src/lib/test-redis.ts
+++ b/x/henry/dust-hive/src/lib/test-redis.ts
@@ -1,21 +1,12 @@
 // Shared test Redis management (global container, not per-environment)
 // All environments share the same Redis instance for testing.
 
+import { isContainerRunning } from "./docker";
 import { TEST_REDIS_CONTAINER_NAME, TEST_REDIS_PORT } from "./paths";
 
 // Check if the test Redis container is running
 export async function isTestRedisRunning(): Promise<boolean> {
-  const proc = Bun.spawn(
-    ["docker", "inspect", "-f", "{{.State.Running}}", TEST_REDIS_CONTAINER_NAME],
-    {
-      stdout: "pipe",
-      stderr: "pipe",
-    }
-  );
-  const output = await new Response(proc.stdout).text();
-  await proc.exited;
-
-  return proc.exitCode === 0 && output.trim() === "true";
+  return isContainerRunning(TEST_REDIS_CONTAINER_NAME);
 }
 
 // Check if the test Redis container exists (running or stopped)


### PR DESCRIPTION
## Description

Add ability to clone the Postgres database volume from an existing dust-hive environment when spawning a new one. This is useful when you want to start with existing data instead of a fresh database.

**Usage:**
```bash
dust-hive spawn --name my-feature --db-from existing-env
# or short form:
dust-hive spawn -n my-feature -d existing-env
```

**Implementation details:**
- Validates source environment exists before spawning
- Pauses source postgres container during copy if running (ensures data consistency)
- Uses docker volume copy via alpine container
- Resumes source container after copy completes
- On first warm, postgres init no-ops (DBs already exist), qdrant/ES initialize fresh

## Tests

- Ran `bun run check` (typecheck, lint, tests) - all pass
- Manual testing with existing dust-hive environments

## Risk

**Low** - This is an additive feature that only runs when `--db-from` flag is explicitly provided. Normal spawn behavior is unchanged.

## Deploy Plan

No deployment needed - this is a local development tool (dust-hive).