### PR TITLE
Make sure we incremental sync based on max date of synced data, not max sync date.

### DIFF
--- a/connectors/migrations/db/migration_115.sql
+++ b/connectors/migrations/db/migration_115.sql
@@ -1,0 +1,24 @@
+-- Migration created on Jan 14, 2026
+ALTER TABLE "public"."dust_project_conversations"
+ADD COLUMN "sourceUpdatedAt" TIMESTAMP
+WITH
+    TIME ZONE;
+
+ALTER TABLE "dust_project_conversations"
+ALTER COLUMN "lastMessageAt"
+DROP NOT NULL;
+
+ALTER TABLE "dust_project_conversations"
+ALTER COLUMN "lastMessageAt"
+DROP DEFAULT;
+
+ALTER TABLE "dust_project_conversations"
+ALTER COLUMN "lastMessageAt" TYPE TIMESTAMP
+WITH
+    TIME ZONE;
+
+UPDATE "dust_project_conversations"
+SET
+    "sourceUpdatedAt" = "lastMessageAt";
+
+CREATE INDEX "dust_project_conversations_connector_id_source_updated_at" ON "dust_project_conversations" ("connectorId", "sourceUpdatedAt");

--- a/connectors/src/connectors/dust_project/lib/conversation_formatting.ts
+++ b/connectors/src/connectors/dust_project/lib/conversation_formatting.ts
@@ -58,9 +58,7 @@ export async function formatConversationForUpsert({
       messageSections.push({
         prefix,
         content:
-          msg.visibility === "deleted"
-            ? "Deleted message\n"
-            : content.trimStart().trimEnd(),
+          msg.visibility === "deleted" ? "Deleted message\n" : content.trim(),
         sections: [],
       });
     }

--- a/connectors/src/connectors/dust_project/lib/sync_conversation.ts
+++ b/connectors/src/connectors/dust_project/lib/sync_conversation.ts
@@ -102,7 +102,9 @@ export async function syncConversation({
     return;
   }
 
-  const lastMessageAt = new Date(conversation.updated ?? conversation.created);
+  const sourceUpdatedAt = new Date(
+    conversation.updated ?? conversation.created
+  );
 
   try {
     // Format conversation for upsert (converts raw content to plain text)
@@ -165,14 +167,14 @@ export async function syncConversation({
     if (existingConversation) {
       await existingConversation.update({
         lastSyncedAt: new Date(),
-        lastMessageAt,
+        sourceUpdatedAt,
       });
     } else {
       await DustProjectConversationResource.makeNew({
         connectorId,
         conversationId: conversation.sId,
         projectId,
-        lastMessageAt,
+        sourceUpdatedAt,
       });
     }
 

--- a/connectors/src/lib/models/dust_project.ts
+++ b/connectors/src/lib/models/dust_project.ts
@@ -50,7 +50,7 @@ export class DustProjectConversationModel extends ConnectorBaseModel<DustProject
   declare conversationId: string;
   declare projectId: string;
   declare lastSyncedAt: CreationOptional<Date | null>;
-  declare lastMessageAt: Date;
+  declare sourceUpdatedAt: CreationOptional<Date | null>;
 }
 
 DustProjectConversationModel.init(
@@ -80,7 +80,11 @@ DustProjectConversationModel.init(
     },
     lastMessageAt: {
       type: DataTypes.DATE,
-      allowNull: false,
+      allowNull: true,
+    },
+    sourceUpdatedAt: {
+      type: DataTypes.DATE,
+      allowNull: true,
     },
   },
   {
@@ -88,7 +92,7 @@ DustProjectConversationModel.init(
     indexes: [
       { fields: ["conversationId"], unique: true },
       { fields: ["connectorId", "conversationId"], unique: true },
-      { fields: ["connectorId", "lastMessageAt"] },
+      { fields: ["connectorId", "sourceUpdatedAt"] },
       {
         fields: ["connectorId", "projectId", "conversationId"],
         name: "dust_project_conversations_connector_id_project_id_conversation",


### PR DESCRIPTION
## Description

Handle properly the last time we need to sync from during incremental sync.
fix naming: lastMessageUpdatedAt => sourceUpdatedAt 

## Tests

Local

## Risk

Low

## Deploy Plan

Run migration THEN deploy connectors