### PR TITLE
[Conversation] Fix error type for rate limit errors

### DIFF
--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -317,7 +317,7 @@ describe("retryAgentMessage", () => {
     expect(result.isErr()).toBe(true);
     if (result.isErr()) {
       expect(result.error.status_code).toBe(403);
-      expect(result.error.api_error.type).toBe("plan_message_limit_exceeded");
+      expect(result.error.api_error.type).toBe("rate_limit_error");
     }
     expect(launchAgentLoopWorkflow).not.toHaveBeenCalled();
     expect(publishAgentMessagesEvents).not.toHaveBeenCalled();

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1583,7 +1583,7 @@ async function checkMessagesLimit(
     return new Err({
       status_code: 403,
       api_error: {
-        type: "plan_message_limit_exceeded",
+        type: messageLimit.limitType,
         message:
           messageLimit.limitType === "plan_message_limit_exceeded"
             ? "The message limit for this plan has been exceeded."


### PR DESCRIPTION
## Description

The API error type was hardcoded to `plan_message_limit_exceeded` even when the actual limit was a rate limit (`rate_limit_error`). Now uses the actual `limitType` value as the error type.

## Risks

Blast radius: Error responses for rate-limited conversation messages
Risk: low

## Deploy Plan
- pmrr
- deploy front