### PR TITLE
Bypass workspace validation when reloading models.

### DIFF
--- a/front/lib/resources/storage/wrappers/workspace_models.ts
+++ b/front/lib/resources/storage/wrappers/workspace_models.ts
@@ -194,6 +194,17 @@ export class WorkspaceAwareModel<M extends Model = any> extends BaseModel<M> {
 
     return model;
   }
+
+  public override reload(options?: FindOptions<Attributes<M>>): Promise<this> {
+    const optionsWithBypass: WorkspaceTenantIsolationSecurityBypassOptions<
+      Attributes<M>
+    > = {
+      ...options,
+      // WORKSPACE_ISOLATION_BYPASS: Reloading an instance does not require workspace isolation.
+      dangerouslyBypassWorkspaceIsolationSecurity: true,
+    };
+    return super.reload(optionsWithBypass);
+  }
 }
 
 export type ModelStaticWorkspaceAware<M extends WorkspaceAwareModel> =


### PR DESCRIPTION
## Description

Sometimes we have an error in CI tests because .reload() ends up triggering the (very useful) workspace aware check.
However, when we reload something we already had, i believe it's okay to bypass the check.
This overrides the reload method to do that.

(I didn't expose the option to "reload" in general but simply do it implicitely)

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy front