### PR TITLE
[front] enh: Handle granting free credit for yearly plans

### DIFF
--- a/front/lib/credits/free.test.ts
+++ b/front/lib/credits/free.test.ts
@@ -7,6 +7,7 @@ import {
   calculateFreeCreditAmountMicroUsd,
   countEligibleUsersForFreeCredits,
   getCustomerPaymentStatus,
+  grantFreeCreditFromSubscriptionStateChangeYearly,
   grantFreeCreditsFromSubscriptionStateChange,
 } from "@app/lib/credits/free";
 import {
@@ -37,6 +38,7 @@ vi.mock("@app/lib/auth", async () => {
 });
 
 const MONTH_SECONDS = 30 * 24 * 60 * 60;
+const YEAR_SECONDS = 365 * 24 * 60 * 60;
 const NOW = 1700000000; // Fixed timestamp for tests
 const NOW_MS = NOW * 1000;
 
@@ -466,6 +468,205 @@ describe("grantFreeCreditsOnSubscriptionRenewal", () => {
       stripeSubscription: subscription,
     });
 
+    expect(isEnterpriseSubscription).toHaveBeenCalledWith(subscription);
+  });
+});
+
+function makeYearlySubscription(
+  overrides: Partial<Stripe.Subscription> = {}
+): Stripe.Subscription {
+  return {
+    id: "sub_yearly_test",
+    current_period_start: NOW,
+    current_period_end: NOW + YEAR_SECONDS,
+    start_date: NOW - YEAR_SECONDS,
+    status: "active",
+    items: { data: [], has_more: false, object: "list", url: "" },
+    ...overrides,
+  } as Stripe.Subscription;
+}
+
+describe("grantFreeCreditFromSubscriptionStateChangeYearly", () => {
+  let auth: Authenticator;
+  let getMembersCountSpy: MockInstance;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW_MS);
+
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    auth = authenticator;
+
+    vi.mocked(isEnterpriseSubscription).mockReturnValue(false);
+    vi.mocked(getSubscriptionInvoices).mockResolvedValue([
+      makeInvoice(NOW - MONTH_SECONDS * 0.5),
+    ]);
+    getMembersCountSpy = vi
+      .spyOn(MembershipResource, "getMembersCountForWorkspace")
+      .mockResolvedValue(10);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    getMembersCountSpy.mockRestore();
+  });
+
+  it("should skip when credit already exists for billing cycle (idempotency)", async () => {
+    const subscription = makeYearlySubscription();
+    const idempotencyKey = `free-renewal-yearly-${subscription.id}-${subscription.current_period_start}`;
+
+    await CreditResource.makeNew(auth, {
+      type: "free",
+      initialAmountMicroUsd: 600_000_000,
+      consumedAmountMicroUsd: 0,
+      invoiceOrLineItemId: idempotencyKey,
+    });
+
+    const result = await grantFreeCreditFromSubscriptionStateChangeYearly({
+      auth,
+      stripeSubscription: subscription,
+    });
+
+    expect(result.isOk()).toBe(true);
+    const credits = await CreditResource.listAll(auth);
+    expect(credits.length).toBe(1);
+  });
+
+  it("should return error for non-paying subscription (no trials for yearly)", async () => {
+    vi.mocked(getSubscriptionInvoices).mockResolvedValue([]);
+    const subscription = makeYearlySubscription({
+      start_date: NOW - YEAR_SECONDS * 2,
+      status: "active",
+    });
+
+    const result = await grantFreeCreditFromSubscriptionStateChangeYearly({
+      auth,
+      stripeSubscription: subscription,
+    });
+
+    expect(result.isErr()).toBe(true);
+    expect(result.isErr() && result.error.message).toContain(
+      "Yearly subscription not eligible for free credits"
+    );
+  });
+
+  it("should return error for trialing subscription (no trials for yearly)", async () => {
+    vi.mocked(getSubscriptionInvoices).mockResolvedValue([]);
+    const subscription = makeYearlySubscription({
+      status: "trialing",
+      start_date: NOW,
+    });
+
+    const result = await grantFreeCreditFromSubscriptionStateChangeYearly({
+      auth,
+      stripeSubscription: subscription,
+    });
+
+    expect(result.isErr()).toBe(true);
+    expect(result.isErr() && result.error.message).toContain(
+      "Yearly subscription not eligible for free credits"
+    );
+  });
+
+  it("should use programmatic config override when freeCreditMicroUsd is set (yearly amount)", async () => {
+    const configResult = await ProgrammaticUsageConfigurationResource.makeNew(
+      auth,
+      {
+        freeCreditMicroUsd: 1_200_000_000, // $1200 yearly
+        defaultDiscountPercent: 0,
+        paygCapMicroUsd: null,
+      }
+    );
+    expect(configResult.isOk()).toBe(true);
+
+    const subscription = makeYearlySubscription();
+
+    const result = await grantFreeCreditFromSubscriptionStateChangeYearly({
+      auth,
+      stripeSubscription: subscription,
+    });
+
+    expect(result.isOk()).toBe(true);
+    const credits = await CreditResource.listAll(auth);
+    expect(credits[0].initialAmountMicroUsd).toBe(1_200_000_000);
+  });
+
+  it("should calculate bracket-based credits times 12 for paying customers", async () => {
+    getMembersCountSpy.mockResolvedValue(10);
+    // 10 users = $50/month -> $600/year
+
+    const subscription = makeYearlySubscription();
+
+    const result = await grantFreeCreditFromSubscriptionStateChangeYearly({
+      auth,
+      stripeSubscription: subscription,
+    });
+
+    expect(result.isOk()).toBe(true);
+    const credits = await CreditResource.listAll(auth);
+    expect(credits[0].initialAmountMicroUsd).toBe(50_000_000 * 12);
+  });
+
+  it("should calculate correct yearly amount for 25 users", async () => {
+    getMembersCountSpy.mockResolvedValue(25);
+    // 25 users = $50 (first 10) + $30 (15 users @ $2) = $80/month -> $960/year
+
+    const subscription = makeYearlySubscription();
+
+    const result = await grantFreeCreditFromSubscriptionStateChangeYearly({
+      auth,
+      stripeSubscription: subscription,
+    });
+
+    expect(result.isOk()).toBe(true);
+    const credits = await CreditResource.listAll(auth);
+    expect(credits[0].initialAmountMicroUsd).toBe(
+      (50_000_000 + 30_000_000) * 12
+    );
+  });
+
+  it("should create credit with correct expiration date (period end = 1 year)", async () => {
+    const subscription = makeYearlySubscription();
+
+    const result = await grantFreeCreditFromSubscriptionStateChangeYearly({
+      auth,
+      stripeSubscription: subscription,
+    });
+
+    expect(result.isOk()).toBe(true);
+    const credits = await CreditResource.listAll(auth);
+    expect(credits[0].expirationDate?.getTime()).toBe(
+      subscription.current_period_end * 1000
+    );
+  });
+
+  it("should use correct yearly idempotency key format", async () => {
+    const subscription = makeYearlySubscription({ id: "sub_yearly_abc123" });
+
+    await grantFreeCreditFromSubscriptionStateChangeYearly({
+      auth,
+      stripeSubscription: subscription,
+    });
+
+    const credits = await CreditResource.listAll(auth);
+    expect(credits[0].invoiceOrLineItemId).toBe(
+      `free-renewal-yearly-sub_yearly_abc123-${subscription.current_period_start}`
+    );
+  });
+
+  it("should always grant credits for enterprise subscriptions", async () => {
+    vi.mocked(isEnterpriseSubscription).mockReturnValue(true);
+    vi.mocked(getSubscriptionInvoices).mockResolvedValue([]);
+
+    const subscription = makeYearlySubscription();
+
+    const result = await grantFreeCreditFromSubscriptionStateChangeYearly({
+      auth,
+      stripeSubscription: subscription,
+    });
+
+    expect(result.isOk()).toBe(true);
     expect(isEnterpriseSubscription).toHaveBeenCalledWith(subscription);
   });
 });

--- a/front/lib/credits/free.ts
+++ b/front/lib/credits/free.ts
@@ -369,13 +369,13 @@ export async function grantFreeCreditFromSubscriptionStateChangeYearly({
   } else {
     // Calculate monthly amount and multiply by 12 for yearly
     const userCount = await countEligibleUsersForFreeCredits(workspace);
-    const monthlyAmount = calculateFreeCreditAmountMicroUsd(userCount);
-    creditAmountMicroUsd = monthlyAmount * YEARLY_MULTIPLIER;
+    const monthlyAmountMicroUsd = calculateFreeCreditAmountMicroUsd(userCount);
+    creditAmountMicroUsd = monthlyAmountMicroUsd * YEARLY_MULTIPLIER;
     logger.info(
       {
         workspaceId: workspaceSId,
         userCount,
-        monthlyAmount,
+        monthlyAmountMicroUsd,
         creditAmountMicroUsd,
       },
       "[Free Credits Yearly] Calculated credit amount using brackets system x 12"

--- a/front/lib/credits/free.ts
+++ b/front/lib/credits/free.ts
@@ -192,7 +192,7 @@ export async function grantFreeCreditsFromSubscriptionStateChange({
   } else {
     switch (customerPaymentStatus) {
       case "not_paying":
-        logger.info(
+        logger.warn(
           {
             workspaceId: workspaceSId,
             subscriptionId: stripeSubscription.id,
@@ -287,6 +287,165 @@ export async function grantFreeCreditsFromSubscriptionStateChange({
       periodEnd,
     },
     "[Free Credits] Successfully granted and activated free credit on renewal"
+  );
+
+  return new Ok(undefined);
+}
+
+const YEARLY_MULTIPLIER = 12;
+
+export async function grantFreeCreditFromSubscriptionStateChangeYearly({
+  auth,
+  stripeSubscription,
+}: {
+  auth: Authenticator;
+  stripeSubscription: Stripe.Subscription;
+}): Promise<Result<undefined, Error>> {
+  const workspace = auth.getNonNullableWorkspace();
+  const workspaceSId = workspace.sId;
+
+  // Check if credit already exists for this billing cycle (idempotency)
+  const idempotencyKey = `free-renewal-yearly-${stripeSubscription.id}-${stripeSubscription.current_period_start}`;
+  const existingCredit = await CreditResource.fetchByInvoiceOrLineItemId(
+    auth,
+    idempotencyKey
+  );
+
+  if (existingCredit) {
+    logger.info(
+      {
+        workspaceId: workspaceSId,
+        creditId: existingCredit.id,
+        subscriptionId: stripeSubscription.id,
+      },
+      "[Free Credits Yearly] Credit already exists for this billing cycle, skipping"
+    );
+    return new Ok(undefined);
+  }
+
+  const isEnterprise = isEnterpriseSubscription(stripeSubscription);
+  const customerPaymentStatus: CustomerPaymentStatus =
+    await getCustomerPaymentStatus(stripeSubscription);
+
+  logger.info(
+    {
+      workspaceId: workspaceSId,
+      subscriptionId: stripeSubscription.id,
+      isEnterprise,
+    },
+    "[Free Credits Yearly] Processing free credit grant on yearly subscription renewal"
+  );
+
+  // Yearly subscriptions don't have trials - must be paying
+  if (customerPaymentStatus !== "paying") {
+    logger.warn(
+      {
+        workspaceId: workspaceSId,
+        subscriptionId: stripeSubscription.id,
+        customerPaymentStatus,
+      },
+      "[Free Credits Yearly] Yearly subscription not eligible for free credits (not paying)"
+    );
+    return new Err(
+      new Error("Yearly subscription not eligible for free credits")
+    );
+  }
+
+  let creditAmountMicroUsd: number;
+
+  const programmaticConfig =
+    await ProgrammaticUsageConfigurationResource.fetchByWorkspaceId(auth);
+
+  if (programmaticConfig && programmaticConfig.freeCreditMicroUsd !== null) {
+    // For yearly subscriptions, the configured amount is assumed to be yearly
+    creditAmountMicroUsd = programmaticConfig.freeCreditMicroUsd;
+    logger.info(
+      {
+        workspaceId: workspaceSId,
+        creditAmountMicroUsd,
+      },
+      "[Free Credits Yearly] Using ProgrammaticUsageConfiguration override amount (yearly)"
+    );
+  } else {
+    // Calculate monthly amount and multiply by 12 for yearly
+    const userCount = await countEligibleUsersForFreeCredits(workspace);
+    const monthlyAmount = calculateFreeCreditAmountMicroUsd(userCount);
+    creditAmountMicroUsd = monthlyAmount * YEARLY_MULTIPLIER;
+    logger.info(
+      {
+        workspaceId: workspaceSId,
+        userCount,
+        monthlyAmount,
+        creditAmountMicroUsd,
+      },
+      "[Free Credits Yearly] Calculated credit amount using brackets system x 12"
+    );
+  }
+
+  assert(
+    creditAmountMicroUsd > 0,
+    "Unexpected programmatic usage free credit amount equal to zero"
+  );
+
+  const periodStart = new Date(stripeSubscription.current_period_start * 1000);
+  const periodEnd = new Date(stripeSubscription.current_period_end * 1000);
+
+  const credit = await CreditResource.makeNew(auth, {
+    type: "free",
+    initialAmountMicroUsd: creditAmountMicroUsd,
+    consumedAmountMicroUsd: 0,
+    discount: null,
+    invoiceOrLineItemId: idempotencyKey,
+  });
+
+  logger.info(
+    {
+      workspaceId: workspaceSId,
+      creditId: credit.id,
+      creditAmountMicroUsd,
+      periodStart,
+      periodEnd,
+    },
+    "[Free Credits Yearly] Created credit, now starting"
+  );
+
+  // Start the credit at beginning of billing cycle (spans the full year).
+  const startResult = await credit.start(auth, {
+    startDate: periodStart,
+    expirationDate: periodEnd,
+  });
+  if (startResult.isErr()) {
+    logger.error(
+      {
+        panic: true,
+        workspaceId: workspaceSId,
+        creditId: credit.id,
+        error: startResult.error,
+      },
+      "[Free Credits Yearly] Error starting credit"
+    );
+    statsDClient.increment("credits.top_up.error", 1, [
+      `workspace_id:${workspaceSId}`,
+      "type:free_yearly",
+      `customer:${isEnterprise ? "enterprise" : "pro"}`,
+    ]);
+    return new Err(startResult.error);
+  }
+
+  statsDClient.increment("credits.top_up.success", 1, [
+    `workspace_id:${workspaceSId}`,
+    "type:free_yearly",
+    `customer:${isEnterprise ? "enterprise" : "pro"}`,
+  ]);
+  logger.info(
+    {
+      workspaceId: workspaceSId,
+      creditId: credit.id,
+      creditAmountMicroUsd,
+      periodStart,
+      periodEnd,
+    },
+    "[Free Credits Yearly] Successfully granted and activated free credit on yearly renewal"
   );
 
   return new Ok(undefined);


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/5721

- Downgrade general panic at webhook level to more fine-grained one (cc @PopDaph )
- Handle yearly plans's free credit (by granting 12 months worth of free credit on cycle renewal, Tl;Dr same logic x12 )
- Slightly better warning when we deny free credits

## Tests

Tested locally with test clock on sub creation + 1 year forward

## Risk

Low
Blast Radius: Stripe webhooks + yearly plan customers' programmatic usage (latter is currently NOT working anyway)

## Deploy Plan

- Deploy front