### PR TITLE
feat(dust-hive) add a script to seed the env

### DIFF
--- a/front/scripts/seed/README.md
+++ b/front/scripts/seed/README.md
@@ -1,0 +1,13 @@
+# Seed Scripts
+
+Scripts to populate the development environment with mock data.
+
+Each folder contains a `seed.ts` file. Run with:
+
+```bash
+npx tsx scripts/seed/<folder>/seed.ts --execute
+```
+
+## Folders
+
+- `basics/` - Creates a few basic things such as a custom agent and sample conversations

--- a/front/scripts/seed/basics/.gitignore
+++ b/front/scripts/seed/basics/.gitignore
@@ -1,0 +1,1 @@
+config.json

--- a/front/scripts/seed/basics/README.md
+++ b/front/scripts/seed/basics/README.md
@@ -1,0 +1,25 @@
+# Basics Seed
+
+Activates some feature flags and creates the following:
+
+- 1 skill (Poem Writer)
+- 1 custom agent (Haiku Poet)
+- 5 conversations (3 with custom agent, 2 with Dust global agent)
+- 1 restricted space (with the user added as member)
+- 2 MCP tools:
+  - Global Fake MCP Tool (available in global space)
+  - Restricted Fake MCP Tool (only available in restricted space)
+
+Uses data from `assets/` folder.
+
+## Setup
+
+You can setup your own feature flags by creating your own config.json file.
+
+## How to use ?
+
+Run
+
+```
+npx tsx scripts/seed/basics/seed.ts --execute
+```

--- a/front/scripts/seed/basics/assets/agent.json
+++ b/front/scripts/seed/basics/assets/agent.json
@@ -1,0 +1,6 @@
+{
+  "name": "Haiku Poet",
+  "description": "A creative agent that writes haikus based on your message topic",
+  "instructions": "You are a creative haiku poet. When the user sends you a message, identify the main topic or theme and respond with a beautiful haiku (5-7-5 syllable pattern) that captures the essence of that topic. Always explain briefly what inspired your haiku.",
+  "pictureUrl": "https://dust.tt/static/systemavatar/claude_avatar_full.png"
+}

--- a/front/scripts/seed/basics/assets/conversations.json
+++ b/front/scripts/seed/basics/assets/conversations.json
@@ -1,0 +1,86 @@
+{
+  "customAgentConversations": [
+    {
+      "sId": "seed_conv_01",
+      "title": "Haiku about coding",
+      "exchanges": [
+        {
+          "user": {
+            "sId": "seed_umsg_01",
+            "content": ":mention[Haiku Poet]{sId=__CUSTOM_AGENT_SID__} Write me a haiku about programming"
+          },
+          "agent": {
+            "sId": "seed_amsg_01",
+            "content": "Lines of code cascade\nBugs hide in the syntax deep\nDebug, compile, breathe\n\nThis haiku captures the meditative yet challenging nature of programming - the flow of writing code, the hunt for bugs, and the patience required."
+          }
+        }
+      ]
+    },
+    {
+      "sId": "seed_conv_02",
+      "title": "Haiku about nature",
+      "exchanges": [
+        {
+          "user": {
+            "sId": "seed_umsg_02",
+            "content": ":mention[Haiku Poet]{sId=__CUSTOM_AGENT_SID__} I love watching the sunset over the ocean"
+          },
+          "agent": {
+            "sId": "seed_amsg_02",
+            "content": "Gold melts into waves\nHorizon drinks the sun whole\nNight waits, patient, still\n\nYour love for ocean sunsets inspired this haiku - the way light transforms the water and the peaceful transition from day to night."
+          }
+        }
+      ]
+    },
+    {
+      "sId": "seed_conv_03",
+      "title": "Haiku about coffee",
+      "exchanges": [
+        {
+          "user": {
+            "sId": "seed_umsg_03",
+            "content": ":mention[Haiku Poet]{sId=__CUSTOM_AGENT_SID__} My morning coffee ritual is sacred"
+          },
+          "agent": {
+            "sId": "seed_amsg_03",
+            "content": "Steam curls like prayers\nBitter warmth, a daily grace\nFirst sip: world begins\n\nYour sacred morning ritual deserves this haiku honoring the quiet reverence of that first cup."
+          }
+        }
+      ]
+    }
+  ],
+  "dustAgentConversations": [
+    {
+      "sId": "seed_conv_04",
+      "title": "Help with documentation",
+      "exchanges": [
+        {
+          "user": {
+            "sId": "seed_umsg_04",
+            "content": ":mention[Dust]{sId=dust} Can you help me understand how to use this tool?"
+          },
+          "agent": {
+            "sId": "seed_amsg_04",
+            "content": "Of course! I'd be happy to help you understand how to use this tool. Could you tell me which specific tool or feature you're trying to learn about? That way I can provide you with the most relevant guidance and documentation."
+          }
+        }
+      ]
+    },
+    {
+      "sId": "seed_conv_05",
+      "title": "General question",
+      "exchanges": [
+        {
+          "user": {
+            "sId": "seed_umsg_05",
+            "content": ":mention[Dust]{sId=dust} What can you help me with today?"
+          },
+          "agent": {
+            "sId": "seed_amsg_05",
+            "content": "I can help you with many things! Here are some examples:\n\n- Answer questions about your company's knowledge base\n- Help draft documents, emails, or messages\n- Explain complex concepts or processes\n- Search through your connected data sources\n- Assist with analysis and summarization\n\nWhat would you like to work on?"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/front/scripts/seed/basics/assets/conversations.json
+++ b/front/scripts/seed/basics/assets/conversations.json
@@ -1,48 +1,48 @@
 {
   "customAgentConversations": [
     {
-      "sId": "seed_conv_01",
+      "sId": "SeedConv01",
       "title": "Haiku about coding",
       "exchanges": [
         {
           "user": {
-            "sId": "seed_umsg_01",
+            "sId": "SeedUMsg01",
             "content": ":mention[Haiku Poet]{sId=__CUSTOM_AGENT_SID__} Write me a haiku about programming"
           },
           "agent": {
-            "sId": "seed_amsg_01",
+            "sId": "SeedAMsg01",
             "content": "Lines of code cascade\nBugs hide in the syntax deep\nDebug, compile, breathe\n\nThis haiku captures the meditative yet challenging nature of programming - the flow of writing code, the hunt for bugs, and the patience required."
           }
         }
       ]
     },
     {
-      "sId": "seed_conv_02",
+      "sId": "SeedConv02",
       "title": "Haiku about nature",
       "exchanges": [
         {
           "user": {
-            "sId": "seed_umsg_02",
+            "sId": "SeedUMsg02",
             "content": ":mention[Haiku Poet]{sId=__CUSTOM_AGENT_SID__} I love watching the sunset over the ocean"
           },
           "agent": {
-            "sId": "seed_amsg_02",
+            "sId": "SeedAMsg02",
             "content": "Gold melts into waves\nHorizon drinks the sun whole\nNight waits, patient, still\n\nYour love for ocean sunsets inspired this haiku - the way light transforms the water and the peaceful transition from day to night."
           }
         }
       ]
     },
     {
-      "sId": "seed_conv_03",
+      "sId": "SeedConv03",
       "title": "Haiku about coffee",
       "exchanges": [
         {
           "user": {
-            "sId": "seed_umsg_03",
+            "sId": "SeedUMsg03",
             "content": ":mention[Haiku Poet]{sId=__CUSTOM_AGENT_SID__} My morning coffee ritual is sacred"
           },
           "agent": {
-            "sId": "seed_amsg_03",
+            "sId": "SeedAMsg03",
             "content": "Steam curls like prayers\nBitter warmth, a daily grace\nFirst sip: world begins\n\nYour sacred morning ritual deserves this haiku honoring the quiet reverence of that first cup."
           }
         }
@@ -51,32 +51,32 @@
   ],
   "dustAgentConversations": [
     {
-      "sId": "seed_conv_04",
+      "sId": "SeedConv04",
       "title": "Help with documentation",
       "exchanges": [
         {
           "user": {
-            "sId": "seed_umsg_04",
+            "sId": "SeedUMsg04",
             "content": ":mention[Dust]{sId=dust} Can you help me understand how to use this tool?"
           },
           "agent": {
-            "sId": "seed_amsg_04",
+            "sId": "SeedAMsg04",
             "content": "Of course! I'd be happy to help you understand how to use this tool. Could you tell me which specific tool or feature you're trying to learn about? That way I can provide you with the most relevant guidance and documentation."
           }
         }
       ]
     },
     {
-      "sId": "seed_conv_05",
+      "sId": "SeedConv05",
       "title": "General question",
       "exchanges": [
         {
           "user": {
-            "sId": "seed_umsg_05",
+            "sId": "SeedUMsg05",
             "content": ":mention[Dust]{sId=dust} What can you help me with today?"
           },
           "agent": {
-            "sId": "seed_amsg_05",
+            "sId": "SeedAMsg05",
             "content": "I can help you with many things! Here are some examples:\n\n- Answer questions about your company's knowledge base\n- Help draft documents, emails, or messages\n- Explain complex concepts or processes\n- Search through your connected data sources\n- Assist with analysis and summarization\n\nWhat would you like to work on?"
           }
         }

--- a/front/scripts/seed/basics/assets/skill.json
+++ b/front/scripts/seed/basics/assets/skill.json
@@ -1,0 +1,6 @@
+{
+  "name": "Poem Writer",
+  "agentFacingDescription": "Guidelines and techniques for writing various types of poems including haikus, sonnets, free verse, and more.",
+  "userFacingDescription": "Learn how to write beautiful poems with this skill that covers different poetry styles and techniques.",
+  "instructions": "# Poem Writing Guide\n\nWhen helping users write poems, follow these guidelines:\n\n## Haiku (5-7-5)\n- First line: 5 syllables\n- Second line: 7 syllables\n- Third line: 5 syllables\n- Focus on nature or a single moment\n- Include a seasonal reference (kigo)\n\n## Sonnet (14 lines)\n- Shakespearean: ABAB CDCD EFEF GG rhyme scheme\n- Petrarchan: ABBAABBA CDECDE rhyme scheme\n- Use iambic pentameter (10 syllables per line)\n\n## Free Verse\n- No required rhyme scheme or meter\n- Focus on imagery and emotion\n- Use line breaks intentionally\n\n## General Tips\n1. Show, don't tell - use sensory details\n2. Choose words carefully for sound and meaning\n3. Read the poem aloud to check rhythm\n4. Revise and refine multiple times"
+}

--- a/front/scripts/seed/basics/config.json.example
+++ b/front/scripts/seed/basics/config.json.example
@@ -1,0 +1,3 @@
+{
+  "featureFlags": []
+}

--- a/front/scripts/seed/basics/seed.test.ts
+++ b/front/scripts/seed/basics/seed.test.ts
@@ -1,0 +1,131 @@
+import * as fs from "fs";
+import * as path from "path";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import type { Authenticator } from "@app/lib/auth";
+import { AgentStepContentModel } from "@app/lib/models/agent/agent_step_content";
+import {
+  AgentMessageModel,
+  ConversationModel,
+  MessageModel,
+  UserMessageModel,
+} from "@app/lib/models/agent/conversation";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import type { UserResource } from "@app/lib/resources/user_resource";
+import logger from "@app/logger/logger";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import type { LightWorkspaceType } from "@app/types";
+
+import { seedAgent } from "./seedAgent";
+import { seedConversations } from "./seedConversations";
+import { seedSkill } from "./seedSkill";
+import type { Assets, SeedContext } from "./types";
+
+// Load assets from JSON files (same as seed.ts)
+function loadAssets(): Assets {
+  const assetsDir = path.join(__dirname, "assets");
+  const agent = JSON.parse(
+    fs.readFileSync(path.join(assetsDir, "agent.json"), "utf-8")
+  );
+  const skill = JSON.parse(
+    fs.readFileSync(path.join(assetsDir, "skill.json"), "utf-8")
+  );
+  const conversations = JSON.parse(
+    fs.readFileSync(path.join(assetsDir, "conversations.json"), "utf-8")
+  );
+  return { agent, skill, conversations };
+}
+
+describe("basics seed script integration test", () => {
+  let workspace: LightWorkspaceType;
+  let user: UserResource;
+  let authenticator: Authenticator;
+
+  const assets = loadAssets();
+
+  beforeEach(async () => {
+    const testResources = await createResourceTest({ role: "admin" });
+    workspace = testResources.workspace;
+    user = testResources.user;
+    authenticator = testResources.authenticator;
+  });
+
+  it("should run the full seed and create all expected resources", async () => {
+    const ctx: SeedContext = {
+      auth: authenticator,
+      workspace,
+      user,
+      execute: true,
+      logger,
+    };
+
+    // Run the seed flow (same order as seed.ts)
+    await seedSkill(ctx, assets.skill);
+    const customAgentSId = await seedAgent(ctx, assets.agent);
+    await seedConversations(ctx, assets.conversations, customAgentSId);
+
+    // Verify skill was created
+    const skills = await SkillResource.listSkills(authenticator, {
+      status: "active",
+    });
+    const createdSkill = skills.find((s) => s.name === assets.skill.name);
+    expect(createdSkill).toBeDefined();
+    expect(createdSkill?.name).toBe(assets.skill.name);
+
+    // Verify agent was created
+    expect(customAgentSId).toBeDefined();
+
+    // Verify all conversations were created
+    const allConversations = [
+      ...assets.conversations.customAgentConversations,
+      ...assets.conversations.dustAgentConversations,
+    ];
+
+    for (const convAsset of allConversations) {
+      const conversation = await ConversationModel.findOne({
+        where: { sId: convAsset.sId, workspaceId: workspace.id },
+      });
+      expect(conversation).toBeDefined();
+      expect(conversation?.title).toBe(convAsset.title);
+
+      // Verify messages exist
+      const messages = await MessageModel.findAll({
+        where: { conversationId: conversation!.id },
+        order: [["rank", "ASC"]],
+      });
+      expect(messages.length).toBe(convAsset.exchanges.length * 2);
+
+      // Verify user message content
+      const userMessageRow = messages[0];
+      const userMessage = await UserMessageModel.findByPk(
+        userMessageRow.userMessageId!
+      );
+      expect(userMessage?.content).toBeDefined();
+
+      // Verify agent message and step content
+      const agentMessageRow = messages[1];
+      const agentMessage = await AgentMessageModel.findByPk(
+        agentMessageRow.agentMessageId!
+      );
+      expect(agentMessage?.status).toBe("succeeded");
+
+      const stepContent = await AgentStepContentModel.findOne({
+        where: { agentMessageId: agentMessage!.id },
+      });
+      expect(stepContent).toBeDefined();
+      expect((stepContent?.value as { value: string }).value).toBe(
+        convAsset.exchanges[0].agent.content
+      );
+    }
+
+    // Verify idempotency - running again should not create duplicates
+    await seedSkill(ctx, assets.skill);
+
+    for (const convAsset of allConversations) {
+      const count = await ConversationModel.count({
+        where: { sId: convAsset.sId, workspaceId: workspace.id },
+      });
+      expect(count).toBe(1);
+    }
+  });
+});

--- a/front/scripts/seed/basics/seed.ts
+++ b/front/scripts/seed/basics/seed.ts
@@ -1,0 +1,120 @@
+import * as fs from "fs";
+import * as path from "path";
+
+import { Authenticator } from "@app/lib/auth";
+import { FeatureFlagResource } from "@app/lib/resources/feature_flag_resource";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
+import { makeScript } from "@app/scripts/helpers";
+import type { WhitelistableFeature } from "@app/types";
+
+import { seedAgent } from "./seedAgent";
+import { seedConversations } from "./seedConversations";
+import { seedMCPTools } from "./seedMCPTools";
+import { seedSkill } from "./seedSkill";
+import { seedSpace } from "./seedSpace";
+import type { Assets, SeedContext } from "./types";
+
+// The workspace sId created by dust-hive seed
+const WORKSPACE_SID = "DevWkSpace";
+
+// Load assets from JSON files
+function loadAssets(): Assets {
+  const assetsDir = path.join(__dirname, "assets");
+  const agent = JSON.parse(
+    fs.readFileSync(path.join(assetsDir, "agent.json"), "utf-8")
+  );
+  const skill = JSON.parse(
+    fs.readFileSync(path.join(assetsDir, "skill.json"), "utf-8")
+  );
+  const conversations = JSON.parse(
+    fs.readFileSync(path.join(assetsDir, "conversations.json"), "utf-8")
+  );
+  return { agent, skill, conversations };
+}
+
+interface SeedConfig {
+  featureFlags: WhitelistableFeature[];
+}
+
+// Load config from JSON file if it exists
+function loadConfig(): SeedConfig {
+  const configPath = path.join(__dirname, "config.json");
+  if (!fs.existsSync(configPath)) {
+    return { featureFlags: [] };
+  }
+
+  return JSON.parse(fs.readFileSync(configPath, "utf-8"));
+}
+
+makeScript({}, async ({ execute }, logger) => {
+  const {
+    agent: agentAsset,
+    skill: skillAsset,
+    conversations: conversationsAsset,
+  } = loadAssets();
+
+  logger.info("Loading workspace...");
+  const workspace = await WorkspaceResource.fetchById(WORKSPACE_SID);
+  if (!workspace) {
+    throw new Error(
+      `Workspace ${WORKSPACE_SID} not found. Make sure dust-hive seed has run first.`
+    );
+  }
+
+  // Get the first admin user from the workspace
+  const { memberships } = await MembershipResource.getActiveMemberships({
+    workspace: renderLightWorkspaceType({ workspace }),
+    roles: ["admin"],
+  });
+  if (memberships.length === 0) {
+    throw new Error(
+      `No admin user found in workspace ${WORKSPACE_SID}. Make sure dust-hive seed has run first.`
+    );
+  }
+  const membershipUser = memberships[0].user;
+  if (!membershipUser) {
+    throw new Error("Membership has no associated user");
+  }
+
+  // Fetch the full UserResource
+  const user = await UserResource.fetchById(membershipUser.sId);
+  if (!user) {
+    throw new Error("User not found");
+  }
+
+  // Create authenticator with the user
+  const auth = await Authenticator.fromUserIdAndWorkspaceId(
+    user.sId,
+    WORKSPACE_SID
+  );
+
+  // Create seed context
+  const ctx: SeedContext = {
+    auth,
+    workspace,
+    user,
+    execute,
+    logger,
+  };
+
+  // Load config and apply feature flags
+  const config = loadConfig();
+  if (config.featureFlags.length > 0) {
+    logger.info({ flags: config.featureFlags }, "Feature flags to enable");
+    if (execute) {
+      await FeatureFlagResource.enableMany(workspace, config.featureFlags);
+      logger.info("Feature flags enabled");
+    }
+  }
+
+  await seedSkill(ctx, skillAsset);
+  const customAgentSId = await seedAgent(ctx, agentAsset);
+  await seedConversations(ctx, conversationsAsset, customAgentSId);
+  const restrictedSpace = await seedSpace(ctx);
+  await seedMCPTools(ctx, restrictedSpace);
+
+  logger.info("Basics seed completed");
+});

--- a/front/scripts/seed/basics/seed.ts
+++ b/front/scripts/seed/basics/seed.ts
@@ -94,7 +94,7 @@ makeScript({}, async ({ execute }, logger) => {
   // Create seed context
   const ctx: SeedContext = {
     auth,
-    workspace,
+    workspace: renderLightWorkspaceType({ workspace }),
     user,
     execute,
     logger,

--- a/front/scripts/seed/basics/seedAgent.ts
+++ b/front/scripts/seed/basics/seedAgent.ts
@@ -1,0 +1,57 @@
+import {
+  createAgentConfiguration,
+  searchAgentConfigurationsByName,
+} from "@app/lib/api/assistant/configuration/agent";
+
+import type { AgentAsset, SeedContext } from "./types";
+
+export async function seedAgent(
+  ctx: SeedContext,
+  agentAsset: AgentAsset
+): Promise<string | null> {
+  const { auth, user, execute, logger } = ctx;
+
+  const existingAgents = await searchAgentConfigurationsByName(
+    auth,
+    agentAsset.name
+  );
+  const existingAgent = existingAgents.find((a) => a.name === agentAsset.name);
+
+  if (existingAgent) {
+    logger.info(
+      { sId: existingAgent.sId, name: agentAsset.name },
+      "Agent already exists, skipping"
+    );
+    return existingAgent.sId;
+  }
+
+  if (execute) {
+    const result = await createAgentConfiguration(auth, {
+      name: agentAsset.name,
+      description: agentAsset.description,
+      instructions: agentAsset.instructions,
+      pictureUrl: agentAsset.pictureUrl,
+      status: "active",
+      scope: "visible",
+      model: {
+        providerId: "anthropic",
+        modelId: "claude-4-sonnet-20250514",
+        temperature: 0.7,
+      },
+      templateId: null,
+      requestedSpaceIds: [],
+      tags: [],
+      editors: [user.toJSON()],
+    });
+
+    if (result.isErr()) {
+      throw result.error;
+    }
+
+    const customAgentSId = result.value.sId;
+    logger.info({ sId: customAgentSId }, "Custom agent created");
+    return customAgentSId;
+  }
+
+  return null;
+}

--- a/front/scripts/seed/basics/seedConversations.ts
+++ b/front/scripts/seed/basics/seedConversations.ts
@@ -1,0 +1,158 @@
+import { AgentStepContentModel } from "@app/lib/models/agent/agent_step_content";
+import {
+  AgentMessageModel,
+  ConversationModel,
+  ConversationParticipantModel,
+  MessageModel,
+  UserMessageModel,
+} from "@app/lib/models/agent/conversation";
+import { GLOBAL_AGENTS_SID } from "@app/types";
+
+import type {
+  ConversationAsset,
+  ConversationsAsset,
+  SeedContext,
+} from "./types";
+
+interface ConversationWithAgent extends ConversationAsset {
+  agentId: string;
+  isCustomAgent: boolean;
+}
+
+export async function seedConversations(
+  ctx: SeedContext,
+  conversationsAsset: ConversationsAsset,
+  customAgentSId: string | null
+): Promise<void> {
+  const { workspace, user, execute, logger } = ctx;
+
+  // Merge all conversations for processing
+  const allConversations: ConversationWithAgent[] = [
+    ...conversationsAsset.customAgentConversations.map((c) => ({
+      ...c,
+      agentId: customAgentSId ?? "",
+      isCustomAgent: true,
+    })),
+    ...conversationsAsset.dustAgentConversations.map((c) => ({
+      ...c,
+      agentId: GLOBAL_AGENTS_SID.DUST,
+      isCustomAgent: false,
+    })),
+  ];
+
+  for (const conv of allConversations) {
+    const agentLabel = conv.isCustomAgent
+      ? "custom agent"
+      : "Dust global agent";
+    logger.info(
+      { title: conv.title },
+      `Creating conversation with ${agentLabel}`
+    );
+
+    // Skip custom agent conversations if we don't have the agent ID
+    if (conv.isCustomAgent && !customAgentSId) {
+      continue;
+    }
+
+    if (execute) {
+      // Check if conversation already exists
+      const existingConversation = await ConversationModel.findOne({
+        where: { sId: conv.sId, workspaceId: workspace.id },
+      });
+
+      if (existingConversation) {
+        logger.info({ sId: conv.sId }, "Conversation already exists, skipping");
+        continue;
+      }
+
+      // Create conversation directly with the model for deterministic sId
+      const conversation = await ConversationModel.create({
+        sId: conv.sId,
+        workspaceId: workspace.id,
+        title: conv.title,
+        visibility: "unlisted",
+        depth: 0,
+        requestedSpaceIds: [],
+      });
+
+      // Add user as participant so they can see the conversation
+      await ConversationParticipantModel.create({
+        conversationId: conversation.id,
+        action: "posted",
+        userId: user.id,
+        workspaceId: workspace.id,
+        unread: false,
+        actionRequired: false,
+      });
+
+      // Create user message and agent message for each exchange
+      for (let i = 0; i < conv.exchanges.length; i++) {
+        const exchange = conv.exchanges[i];
+        const agentIdToUse = conv.agentId;
+
+        // Replace placeholder with actual agent sId in user message
+        const userContent = exchange.user.content.replace(
+          /__CUSTOM_AGENT_SID__/g,
+          customAgentSId ?? ""
+        );
+
+        // Create user message
+        const userMessageRow = await UserMessageModel.create({
+          userId: user.id,
+          workspaceId: workspace.id,
+          content: userContent,
+          userContextUsername: user.username ?? "dev-user",
+          userContextTimezone: "UTC",
+          userContextFullName: user.fullName() ?? "Dev User",
+          userContextEmail: user.email ?? "dev@dust.tt",
+          userContextProfilePictureUrl: null,
+          userContextOrigin: "web",
+          clientSideMCPServerIds: [],
+        });
+
+        const userMsgRow = await MessageModel.create({
+          sId: exchange.user.sId,
+          rank: i * 2,
+          conversationId: conversation.id,
+          parentId: null,
+          userMessageId: userMessageRow.id,
+          workspaceId: workspace.id,
+        });
+
+        // Create agent message with "succeeded" status since it has content
+        const agentMessageRow = await AgentMessageModel.create({
+          status: "succeeded",
+          agentConfigurationId: agentIdToUse,
+          agentConfigurationVersion: 0,
+          workspaceId: workspace.id,
+          skipToolsValidation: false,
+        });
+
+        // Create agent step content with the response
+        await AgentStepContentModel.create({
+          agentMessageId: agentMessageRow.id,
+          workspaceId: workspace.id,
+          step: 0,
+          index: 0,
+          version: 0,
+          type: "text_content",
+          value: {
+            type: "text_content",
+            value: exchange.agent.content,
+          },
+        });
+
+        await MessageModel.create({
+          sId: exchange.agent.sId,
+          rank: i * 2 + 1,
+          conversationId: conversation.id,
+          parentId: userMsgRow.id,
+          agentMessageId: agentMessageRow.id,
+          workspaceId: workspace.id,
+        });
+      }
+
+      logger.info({ sId: conv.sId }, "Conversation created");
+    }
+  }
+}

--- a/front/scripts/seed/basics/seedMCPTools.ts
+++ b/front/scripts/seed/basics/seedMCPTools.ts
@@ -1,0 +1,124 @@
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { SpaceResource as SpaceResourceClass } from "@app/lib/resources/space_resource";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
+import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
+
+import type { SeedContext } from "./types";
+
+const GLOBAL_MCP_NAME = "Global Fake MCP Tool";
+const RESTRICTED_MCP_NAME = "Restricted Fake MCP Tool";
+const FAKE_MCP_URL = "https://fake-mcp-endpoint.example.com";
+
+export async function seedMCPTools(
+  ctx: SeedContext,
+  restrictedSpace: SpaceResource | undefined
+): Promise<void> {
+  const { auth, workspace, execute, logger } = ctx;
+
+  // Check for existing MCP servers
+  const existingMCPServers =
+    await RemoteMCPServerResource.listByWorkspace(auth);
+  const existingGlobalMCP = existingMCPServers.find(
+    (s) => s.cachedName === GLOBAL_MCP_NAME
+  );
+  const existingRestrictedMCP = existingMCPServers.find(
+    (s) => s.cachedName === RESTRICTED_MCP_NAME
+  );
+
+  // Create global MCP tool (available in global space)
+  if (existingGlobalMCP) {
+    logger.info(
+      { sId: existingGlobalMCP.sId },
+      "Global MCP tool already exists, skipping"
+    );
+  } else if (execute) {
+    logger.info({ name: GLOBAL_MCP_NAME }, "Creating global MCP tool");
+
+    // Create the remote MCP server using factory
+    const globalMCPServer = await RemoteMCPServerFactory.create(
+      renderLightWorkspaceType({ workspace }),
+      {
+        name: GLOBAL_MCP_NAME,
+        url: `${FAKE_MCP_URL}/global`,
+        description: "A fake MCP tool available globally to all users",
+        tools: [
+          {
+            name: "global_action",
+            description: "A fake global action for testing",
+            inputSchema: undefined,
+          },
+        ],
+      }
+    );
+
+    // Get the system view that was automatically created
+    const systemView =
+      await MCPServerViewResource.getMCPServerViewForSystemSpace(
+        auth,
+        globalMCPServer.sId
+      );
+
+    if (systemView) {
+      // Create a view in the global space to make it available to everyone
+      const globalSpace =
+        await SpaceResourceClass.fetchWorkspaceGlobalSpace(auth);
+      await MCPServerViewResource.create(auth, {
+        systemView,
+        space: globalSpace,
+      });
+      logger.info({ sId: globalMCPServer.sId }, "Global MCP tool created");
+    } else {
+      logger.error("Failed to get system view for global MCP server");
+    }
+  }
+
+  // Create restricted MCP tool (only available in restricted space)
+  if (existingRestrictedMCP) {
+    logger.info(
+      { sId: existingRestrictedMCP.sId },
+      "Restricted MCP tool already exists, skipping"
+    );
+  } else if (execute && restrictedSpace) {
+    logger.info({ name: RESTRICTED_MCP_NAME }, "Creating restricted MCP tool");
+
+    // Create the remote MCP server using factory
+    const restrictedMCPServer = await RemoteMCPServerFactory.create(
+      renderLightWorkspaceType({ workspace }),
+      {
+        name: RESTRICTED_MCP_NAME,
+        url: `${FAKE_MCP_URL}/restricted`,
+        description: "A fake MCP tool only available in the restricted space",
+        tools: [
+          {
+            name: "restricted_action",
+            description: "A fake restricted action for testing",
+            inputSchema: undefined,
+          },
+        ],
+      }
+    );
+
+    // Get the system view that was automatically created
+    const systemView =
+      await MCPServerViewResource.getMCPServerViewForSystemSpace(
+        auth,
+        restrictedMCPServer.sId
+      );
+
+    if (systemView) {
+      // Create a view only in the restricted space
+      await MCPServerViewResource.create(auth, {
+        systemView,
+        space: restrictedSpace,
+      });
+      logger.info(
+        { sId: restrictedMCPServer.sId },
+        "Restricted MCP tool created"
+      );
+    } else {
+      logger.error("Failed to get system view for restricted MCP server");
+    }
+  }
+}

--- a/front/scripts/seed/basics/seedSkill.ts
+++ b/front/scripts/seed/basics/seedSkill.ts
@@ -1,0 +1,35 @@
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { SkillFactory } from "@app/tests/utils/SkillFactory";
+
+import type { SeedContext, SkillAsset } from "./types";
+
+export async function seedSkill(
+  ctx: SeedContext,
+  skillAsset: SkillAsset
+): Promise<void> {
+  const { auth, execute, logger } = ctx;
+
+  const existingSkills = await SkillResource.listSkills(auth, {
+    status: "active",
+  });
+  const existingSkill = existingSkills.find((s) => s.name === skillAsset.name);
+
+  if (existingSkill) {
+    logger.info(
+      { sId: existingSkill.sId, name: skillAsset.name },
+      "Skill already exists, skipping"
+    );
+    return;
+  }
+
+  if (execute) {
+    const skill = await SkillFactory.create(auth, {
+      name: skillAsset.name,
+      agentFacingDescription: skillAsset.agentFacingDescription,
+      userFacingDescription: skillAsset.userFacingDescription,
+      instructions: skillAsset.instructions,
+      status: "active",
+    });
+    logger.info({ sId: skill.sId }, "Skill created");
+  }
+}

--- a/front/scripts/seed/basics/seedSpace.ts
+++ b/front/scripts/seed/basics/seedSpace.ts
@@ -1,0 +1,57 @@
+import { GroupResource } from "@app/lib/resources/group_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+
+import type { SeedContext } from "./types";
+
+const RESTRICTED_SPACE_NAME = "Restricted Space";
+
+export async function seedSpace(
+  ctx: SeedContext
+): Promise<SpaceResource | undefined> {
+  const { auth, workspace, user, execute, logger } = ctx;
+
+  const existingSpaces = await SpaceResource.listWorkspaceSpaces(auth);
+  const existingRestrictedSpace = existingSpaces.find(
+    (s) => s.name === RESTRICTED_SPACE_NAME
+  );
+
+  if (existingRestrictedSpace) {
+    logger.info(
+      { sId: existingRestrictedSpace.sId, name: RESTRICTED_SPACE_NAME },
+      "Restricted space already exists, skipping"
+    );
+    return existingRestrictedSpace;
+  }
+
+  if (execute) {
+    // Create a group for the restricted space
+    const group = await GroupResource.makeNew({
+      name: `Group for ${RESTRICTED_SPACE_NAME}`,
+      workspaceId: workspace.id,
+      kind: "regular",
+    });
+
+    // Create the restricted space
+    const restrictedSpace = await SpaceResource.makeNew(
+      {
+        name: RESTRICTED_SPACE_NAME,
+        kind: "regular",
+        workspaceId: workspace.id,
+      },
+      [group]
+    );
+
+    // Add the user to the group so they can access the space
+    const addMemberResult = await group.addMember(auth, user.toJSON());
+    if (addMemberResult.isErr()) {
+      throw new Error(
+        `Failed to add user to group: ${addMemberResult.error.message}`
+      );
+    }
+
+    logger.info({ sId: restrictedSpace.sId }, "Restricted space created");
+    return restrictedSpace;
+  }
+
+  return undefined;
+}

--- a/front/scripts/seed/basics/types.ts
+++ b/front/scripts/seed/basics/types.ts
@@ -1,0 +1,59 @@
+import type { Authenticator } from "@app/lib/auth";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import type { UserResource } from "@app/lib/resources/user_resource";
+import type { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import type { Logger } from "@app/logger/logger";
+
+// Seed context shared across all seed functions
+export interface SeedContext {
+  auth: Authenticator;
+  workspace: WorkspaceResource;
+  user: UserResource;
+  execute: boolean;
+  logger: Logger;
+}
+
+export interface AgentAsset {
+  name: string;
+  description: string;
+  instructions: string;
+  pictureUrl: string;
+}
+
+export interface SkillAsset {
+  name: string;
+  agentFacingDescription: string;
+  userFacingDescription: string;
+  instructions: string;
+}
+
+export interface MessageAsset {
+  sId: string;
+  content: string;
+}
+
+export interface Exchange {
+  user: MessageAsset;
+  agent: MessageAsset;
+}
+
+export interface ConversationAsset {
+  sId: string;
+  title: string;
+  exchanges: Exchange[];
+}
+
+export interface ConversationsAsset {
+  customAgentConversations: ConversationAsset[];
+  dustAgentConversations: ConversationAsset[];
+}
+
+export interface Assets {
+  agent: AgentAsset;
+  skill: SkillAsset;
+  conversations: ConversationsAsset;
+}
+
+export interface SeedSpaceResult {
+  restrictedSpace: SpaceResource | undefined;
+}

--- a/front/scripts/seed/basics/types.ts
+++ b/front/scripts/seed/basics/types.ts
@@ -1,13 +1,13 @@
 import type { Authenticator } from "@app/lib/auth";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
-import type { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import type { Logger } from "@app/logger/logger";
+import type { LightWorkspaceType } from "@app/types";
 
 // Seed context shared across all seed functions
 export interface SeedContext {
   auth: Authenticator;
-  workspace: WorkspaceResource;
+  workspace: LightWorkspaceType;
   user: UserResource;
   execute: boolean;
   logger: Logger;


### PR DESCRIPTION
## Description

Allow to seed an env with a bit of fake data.
Activates some feature flags and creates the following:

- 1 skill (Poem Writer)
- 1 custom agent (Haiku Poet)
- 5 conversations (3 with custom agent, 2 with Dust global agent)
- 1 restricted space (with the user added as member)
- 2 MCP tools:
  - Global Fake MCP Tool (available in global space)
  - Restricted Fake MCP Tool (only available in restricted space)

<img width="3438" height="1752" alt="image" src="https://github.com/user-attachments/assets/143cd580-c653-4dbc-97c5-5a51750693c0" />

<img width="3440" height="1756" alt="image" src="https://github.com/user-attachments/assets/91248c31-a387-486d-b0a9-afabd6638957" />


## Tests

Manual tests

## Risk

low

## Deploy Plan

no
