### PR TITLE
feat(triggers): remove deprecated enabled field

### DIFF
--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -727,7 +727,6 @@ export class TriggerResource extends BaseResource<TriggerModel> {
       editor: this.editor,
       customPrompt: this.customPrompt,
       status: this.status,
-      enabled: this.status === "enabled", // deprecated, for backward compatibility (BACK12)
       naturalLanguageDescription: this.naturalLanguageDescription,
       createdAt: this.createdAt.getTime(),
       origin: this.origin,

--- a/front/migrations/db/migration_475.sql
+++ b/front/migrations/db/migration_475.sql
@@ -1,0 +1,3 @@
+-- Migration created on Jan 13, 2026
+
+ALTER TABLE "triggers" DROP COLUMN "enabled";

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/triggers/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/triggers/index.ts
@@ -12,22 +12,8 @@ import { UserResource } from "@app/lib/resources/user_resource";
 import logger from "@app/logger/logger";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
-import type { TriggerStatus, TriggerType } from "@app/types/assistant/triggers";
+import type { TriggerType } from "@app/types/assistant/triggers";
 import { TriggerSchema } from "@app/types/assistant/triggers";
-
-// Resolve status from either new `status` field or deprecated `enabled` field (BACK12 backward compatibility)
-function resolveStatus(trigger: {
-  status?: TriggerStatus;
-  enabled?: boolean;
-}): TriggerStatus {
-  if (trigger.status) {
-    return trigger.status;
-  }
-  if (trigger.enabled !== undefined) {
-    return trigger.enabled ? "enabled" : "disabled";
-  }
-  return "enabled";
-}
 
 export interface GetTriggersResponseBody {
   triggers: (TriggerType & {
@@ -252,7 +238,7 @@ async function handler(
           triggerData.sId,
           {
             ...validatedTrigger,
-            status: resolveStatus(validatedTrigger),
+            status: validatedTrigger.status ?? "enabled",
             webhookSourceViewId,
           }
         );
@@ -342,7 +328,7 @@ async function handler(
           agentConfigurationId,
           name: validatedTrigger.name,
           kind: validatedTrigger.kind,
-          status: resolveStatus(validatedTrigger),
+          status: validatedTrigger.status ?? "enabled",
           configuration: validatedTrigger.configuration,
           naturalLanguageDescription:
             validatedTrigger.naturalLanguageDescription,

--- a/front/types/assistant/triggers.ts
+++ b/front/types/assistant/triggers.ts
@@ -40,7 +40,6 @@ export type TriggerType = {
   editor: UserType["id"];
   customPrompt: string | null;
   status: TriggerStatus;
-  enabled: boolean; // deprecated, for backward compatibility (BACK12)
   createdAt: number;
   naturalLanguageDescription: string | null;
   origin: TriggerOrigin;
@@ -118,9 +117,6 @@ const TriggerStatusSchema = t.union([
   t.literal("downgraded"),
 ]);
 
-// Note: Both enabled and status are optional for backward compatibility (BACK12).
-// Old clients send enabled: boolean, new clients send status: TriggerStatus.
-// The API handler should convert enabled to status using: status ?? (enabled ? "enabled" : "disabled") ?? "enabled"
 export const TriggerSchema = t.union([
   t.intersection([
     t.type({
@@ -133,7 +129,6 @@ export const TriggerSchema = t.union([
     }),
     t.partial({
       status: TriggerStatusSchema,
-      enabled: t.boolean, // deprecated, for backward compatibility
     }),
   ]),
   t.intersection([
@@ -149,7 +144,6 @@ export const TriggerSchema = t.union([
     }),
     t.partial({
       status: TriggerStatusSchema,
-      enabled: t.boolean, // deprecated, for backward compatibility
     }),
   ]),
 ]);


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Finish migration of enabled to status field on triggers.
This PR completely removes enabled boolean from the code, to base everything off of the new status field introduced in a previous PR.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

Deploy front
Apply Migration 475 afterwards