### PR TITLE
Poké: Hide system message from convo view

### DIFF
--- a/front/pages/poke/[wId]/conversation/[cId]/index.tsx
+++ b/front/pages/poke/[wId]/conversation/[cId]/index.tsx
@@ -95,6 +95,9 @@ interface UserMessageViewProps {
 }
 
 const UserMessageView = ({ message, useMarkdown }: UserMessageViewProps) => {
+  const hasDustSystemTag = message.content.includes("<dust_system>");
+  const [isExpanded, setIsExpanded] = useState(!hasDustSystemTag);
+
   return (
     <div className="flex flex-grow flex-col">
       <div className="max-w-full self-end">
@@ -103,10 +106,31 @@ const UserMessageView = ({ message, useMarkdown }: UserMessageViewProps) => {
           name={message.user?.fullName ?? message.user?.username}
           type="user"
         >
-          {useMarkdown ? (
-            <Markdown content={message.content} />
+          {hasDustSystemTag && !isExpanded ? (
+            <button
+              onClick={() => setIsExpanded(true)}
+              className="flex cursor-pointer items-center gap-1 text-sm italic text-muted-foreground hover:text-foreground dark:text-muted-foreground-night dark:hover:text-foreground-night"
+            >
+              <ChevronDownIcon className="h-4 w-4" />
+              <span>Hidden System Message (click to expand)</span>
+            </button>
           ) : (
-            <div className="whitespace-pre-wrap">{message.content}</div>
+            <>
+              {hasDustSystemTag && (
+                <button
+                  onClick={() => setIsExpanded(false)}
+                  className="mb-2 flex cursor-pointer items-center gap-1 text-sm italic text-muted-foreground hover:text-foreground dark:text-muted-foreground-night dark:hover:text-foreground-night"
+                >
+                  <XMarkIcon className="h-4 w-4" />
+                  <span>Hide System Message</span>
+                </button>
+              )}
+              {useMarkdown ? (
+                <Markdown content={message.content} />
+              ) : (
+                <div className="whitespace-pre-wrap">{message.content}</div>
+              )}
+            </>
           )}
           <div className="mt-2 text-sm text-muted-foreground dark:text-muted-foreground-night">
             date: {new Date(message.created).toLocaleString()}


### PR DESCRIPTION
## Description

Short PR to by default hide a message on Poké if it contains <dust_system> tag. 
I went for the simple solution since it's internal only, and decided to not check that (it's only the first message / it's only the onboarding convo / the message contains only this tag). 

<kbd>
<img width="931" height="526" alt="Screenshot 2026-01-14 at 16 58 13" src="https://github.com/user-attachments/assets/50ff25ea-1483-4324-9f1b-a7adf2922a41" />
</kbd>


## Tests

Locally. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 