### PR TITLE
[front] - chore(LLM): include agent configuration ID in trace context

### DIFF
--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -419,6 +419,7 @@ export async function runModelActivity(
 
   const traceContext: LLMTraceContext = {
     operationType: "agent_conversation",
+    agentConfigurationId: agentConfiguration.sId,
     conversationId: conversation.sId,
     userId: auth.user()?.sId,
     workspaceId: conversation.owner.sId,


### PR DESCRIPTION

## Description

This PR adds the agent configuration ID to the trace context for better tracking of agent conversations

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front