### PR TITLE
[Front] fix(jira): render custom fields in issue output

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/jira/rendering.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/jira/rendering.ts
@@ -22,6 +22,22 @@ export function renderIssueWithEmbeddedComments(issue: JiraIssue): string {
 export function renderIssue(issue: JiraIssue, comments: JiraComment[]): string {
   const lines: string[] = [];
   const fields = issue.fields;
+  const renderedFields = new Set([
+    "summary",
+    "project",
+    "issuetype",
+    "status",
+    "priority",
+    "assignee",
+    "reporter",
+    "labels",
+    "duedate",
+    "parent",
+    "created",
+    "updated",
+    "description",
+    "comment",
+  ]);
 
   lines.push(`# ${issue.key}: ${fields?.summary ?? "No summary"}`);
   lines.push("");
@@ -76,6 +92,20 @@ export function renderIssue(issue: JiraIssue, comments: JiraComment[]): string {
 
   if (fields?.updated) {
     lines.push(`**Updated:** ${formatDateTime(fields.updated)}`);
+  }
+
+  // Additional fields (custom fields, fixVersions, etc.)
+  const additionalFields = Object.entries(fields ?? {})
+    .filter(([key]) => !renderedFields.has(key))
+    .filter(([, value]) => value != null);
+
+  if (additionalFields.length > 0) {
+    lines.push("");
+    lines.push("## Additional Fields");
+    lines.push("");
+    for (const [key, value] of additionalFields) {
+      lines.push(`**${key}:** ${JSON.stringify(value)}`);
+    }
   }
 
   lines.push("");


### PR DESCRIPTION
## Description

The `renderIssue` function was silently discarding custom fields (`customfield_XXXXX`) and non-default fields (`fixVersions`) even when explicitly requested via the `fields` parameter.

Added an "Additional Fields" section that renders any field not already handled by the standard rendering logic using `JSON.stringify`.

## Tests

Verified type check passes. No existing tests for Jira rendering module.

## Risk

Low - additive change only, existing rendering behavior unchanged.

## Deploy Plan

Standard deploy, no special considerations.