### PR TITLE
fix(agent-builder): prevent Safari/iOS race conditions in instructions editor

### DIFF
--- a/front/components/editor/extensions/MentionExtension.tsx
+++ b/front/components/editor/extensions/MentionExtension.tsx
@@ -187,8 +187,11 @@ export const MentionExtension = Mention.extend<MentionExtensionOptions>({
 
           // If we're in inline code, just paste as plain text with the code mark
           if (isInInlineCode) {
-            const transaction = state.tr.insertText(text, from, to);
-            view.dispatch(transaction);
+            // Safety check for Safari: ensure editor is not destroyed before dispatch
+            if (!editor.isDestroyed) {
+              const transaction = state.tr.insertText(text, from, to);
+              view.dispatch(transaction);
+            }
             return true;
           }
 
@@ -214,8 +217,11 @@ export const MentionExtension = Mention.extend<MentionExtensionOptions>({
             .catch((error: unknown) => {
               logger.error("Failed to parse mentions:", error);
               // Fallback to the default paste behavior.
-              const transaction = state.tr.replaceRange(from, to, slice);
-              view.dispatch(transaction);
+              // Safety check for Safari: ensure editor is not destroyed before dispatch
+              if (!editor.isDestroyed) {
+                const transaction = state.tr.replaceRange(from, to, slice);
+                view.dispatch(transaction);
+              }
             });
 
           return true;

--- a/front/components/editor/extensions/agent_builder/InstructionBlockExtension.tsx
+++ b/front/components/editor/extensions/agent_builder/InstructionBlockExtension.tsx
@@ -374,6 +374,11 @@ export const InstructionBlockExtension =
             return false;
           }
 
+          // Safety check for Safari: ensure editor is not destroyed before dispatch
+          if (this.editor.isDestroyed) {
+            return false;
+          }
+
           const tr = state.tr;
           const fromPos = $from.before(blockDepth);
           const toPos = fromPos + blockNode.nodeSize;
@@ -391,7 +396,7 @@ export const InstructionBlockExtension =
           }
 
           this.editor.view.dispatch(tr);
-          // Safety check for Safari: ensure editor and docView are available
+          // Focus after dispatch
           if (!this.editor.isDestroyed) {
             this.editor.commands.focus();
           }
@@ -455,6 +460,11 @@ export const InstructionBlockExtension =
             return false;
           }
 
+          // Safety check for Safari: ensure editor is not destroyed before dispatch
+          if (this.editor.isDestroyed) {
+            return false;
+          }
+
           // Exit the block by creating a new paragraph after it
           const tr = state.tr;
           const posBeforeBlock = $from.before(blockDepth);
@@ -468,7 +478,7 @@ export const InstructionBlockExtension =
           tr.setSelection(TextSelection.create(tr.doc, posAfterBlock + 1));
 
           this.editor.view.dispatch(tr);
-          // Safety check for Safari: ensure editor and docView are available
+          // Focus after dispatch
           if (!this.editor.isDestroyed) {
             this.editor.commands.focus();
           }


### PR DESCRIPTION
## Description

Fixes Safari/iOS race conditions in the TipTap editor within the agent builder instructions editor that could cause "Applying a mismatched transaction" RangeErrors.

The issue occurred because:
- Content was being set synchronously in `useEditor()` before the DOM was fully ready
- Transaction dispatches weren't checking if the editor was destroyed
- Timing issues between content setting and editor initialization

**Changes:**
- Added `initialContentSetRef` to track initial content setting and prevent duplicate initialization
- Moved content initialization out of `useEditor` config to a separate useEffect
- Used `requestAnimationFrame` to ensure DOM is fully ready before editor operations
- Added `editor.isDestroyed` safety checks before dispatching transactions in MentionExtension and InstructionBlockExtension
- Replaced `setTimeout` with `requestAnimationFrame` for better timing guarantees

## Tests

Tested manually on Safari/iOS

## Risk

**Low risk** - Changes are defensive safety improvements

## Deploy Plan

Standard deployment:
