### PR TITLE
[Conversation] Fix unread status when adding participant via mention approval

### DIFF
--- a/front/lib/api/assistant/conversation/mentions.test.ts
+++ b/front/lib/api/assistant/conversation/mentions.test.ts
@@ -19,6 +19,7 @@ import {
   createAgentMessages,
   createUserMentions,
   createUserMessage,
+  validateUserMention,
 } from "@app/lib/api/assistant/conversation/mentions";
 import { Authenticator } from "@app/lib/auth";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
@@ -3519,5 +3520,158 @@ describe("createUserMessage", () => {
     const { userMessage: userMessageInDb } =
       await ConversationFactory.getMessage(auth, userMessage.id);
     expect(userMessageInDb?.userId).toBeNull();
+  });
+});
+
+describe("validateUserMention", () => {
+  let workspace: WorkspaceType;
+  let auth: Authenticator;
+  let conversation: ConversationType;
+
+  beforeEach(async () => {
+    const setup = await createResourceTest({});
+    workspace = setup.workspace;
+    auth = setup.authenticator;
+
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(auth, {
+      name: "Test Agent",
+      description: "Test agent",
+    });
+
+    conversation = await ConversationFactory.create(auth, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [new Date()],
+      visibility: "unlisted",
+    });
+  });
+
+  it("should add a participant with unread=true when approving a user mention", async () => {
+    // Create a second user who will be mentioned
+    const mentionedUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, mentionedUser, {
+      role: "user",
+    });
+
+    // Create a user message that mentions the second user
+    const userJson = auth.getNonNullableUser().toJSON();
+    const userMessage = await withTransaction(async (transaction) => {
+      return createUserMessage(auth, {
+        conversation,
+        content: `Hello @${mentionedUser.sId}`,
+        metadata: {
+          type: "create",
+          user: userJson,
+          rank: 1,
+          context: {
+            username: userJson.username,
+            timezone: "UTC",
+            fullName: userJson.fullName,
+            email: userJson.email,
+            profilePictureUrl: userJson.image,
+            origin: "web",
+          },
+        },
+        transaction,
+      });
+    });
+
+    // Create the mention with status "pending"
+    await MentionModel.create({
+      messageId: userMessage.id,
+      userId: mentionedUser.id,
+      workspaceId: workspace.id,
+      status: "pending",
+    });
+
+    // Verify the mentioned user is not a participant yet
+    const isParticipantBefore =
+      await ConversationResource.isConversationParticipant(auth, {
+        conversation,
+        user: mentionedUser.toJSON(),
+      });
+    expect(isParticipantBefore).toBe(false);
+
+    // Approve the mention
+    const result = await validateUserMention(auth, {
+      conversationId: conversation.sId,
+      userId: mentionedUser.sId,
+      messageId: userMessage.sId,
+      approvalState: "approved",
+    });
+
+    expect(result.isOk()).toBe(true);
+
+    // Verify the mentioned user is now a participant with unread=true
+    const participant = await ConversationParticipantModel.findOne({
+      where: {
+        workspaceId: workspace.id,
+        conversationId: conversation.id,
+        userId: mentionedUser.id,
+      },
+    });
+
+    expect(participant).not.toBeNull();
+    expect(participant?.unread).toBe(true);
+    expect(participant?.action).toBe("subscribed");
+  });
+
+  it("should not add a participant when rejecting a user mention", async () => {
+    // Create a second user who will be mentioned
+    const mentionedUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, mentionedUser, {
+      role: "user",
+    });
+
+    // Create a user message that mentions the second user
+    const userJson = auth.getNonNullableUser().toJSON();
+    const userMessage = await withTransaction(async (transaction) => {
+      return createUserMessage(auth, {
+        conversation,
+        content: `Hello @${mentionedUser.sId}`,
+        metadata: {
+          type: "create",
+          user: userJson,
+          rank: 1,
+          context: {
+            username: userJson.username,
+            timezone: "UTC",
+            fullName: userJson.fullName,
+            email: userJson.email,
+            profilePictureUrl: userJson.image,
+            origin: "web",
+          },
+        },
+        transaction,
+      });
+    });
+
+    // Create the mention with status "pending"
+    await MentionModel.create({
+      messageId: userMessage.id,
+      userId: mentionedUser.id,
+      workspaceId: workspace.id,
+      status: "pending",
+    });
+
+    // Reject the mention
+    const result = await validateUserMention(auth, {
+      conversationId: conversation.sId,
+      userId: mentionedUser.sId,
+      messageId: userMessage.sId,
+      approvalState: "rejected",
+    });
+
+    expect(result.isOk()).toBe(true);
+
+    // Verify the mentioned user is NOT a participant
+    const participant = await ConversationParticipantModel.findOne({
+      where: {
+        workspaceId: workspace.id,
+        conversationId: conversation.id,
+        userId: mentionedUser.id,
+      },
+    });
+
+    expect(participant).toBeNull();
   });
 });

--- a/front/lib/api/assistant/conversation/mentions.test.ts
+++ b/front/lib/api/assistant/conversation/mentions.test.ts
@@ -3030,7 +3030,7 @@ describe("createUserMessage", () => {
         metadata: {
           type: "create",
           user: userJson,
-          rank: 1,
+          rank: 0,
           context: {
             username: userJson.username,
             timezone: "UTC",
@@ -3473,7 +3473,7 @@ describe("createUserMessage", () => {
         metadata: {
           type: "create",
           user: userJson,
-          rank: 1,
+          rank: 0,
           context,
         },
         transaction,
@@ -3540,7 +3540,7 @@ describe("validateUserMention", () => {
 
     conversation = await ConversationFactory.create(auth, {
       agentConfigurationId: agentConfig.sId,
-      messagesCreatedAt: [new Date()],
+      messagesCreatedAt: [],
       visibility: "unlisted",
     });
   });
@@ -3561,7 +3561,7 @@ describe("validateUserMention", () => {
         metadata: {
           type: "create",
           user: userJson,
-          rank: 1,
+          rank: 0,
           context: {
             username: userJson.username,
             timezone: "UTC",
@@ -3631,7 +3631,7 @@ describe("validateUserMention", () => {
         metadata: {
           type: "create",
           user: userJson,
-          rank: 1,
+          rank: 0,
           context: {
             username: userJson.username,
             timezone: "UTC",

--- a/front/lib/api/assistant/conversation/mentions.test.ts
+++ b/front/lib/api/assistant/conversation/mentions.test.ts
@@ -3030,7 +3030,7 @@ describe("createUserMessage", () => {
         metadata: {
           type: "create",
           user: userJson,
-          rank: 0,
+          rank: 1,
           context: {
             username: userJson.username,
             timezone: "UTC",
@@ -3473,7 +3473,7 @@ describe("createUserMessage", () => {
         metadata: {
           type: "create",
           user: userJson,
-          rank: 0,
+          rank: 1,
           context,
         },
         transaction,

--- a/front/lib/api/assistant/conversation/mentions.ts
+++ b/front/lib/api/assistant/conversation/mentions.ts
@@ -1047,3 +1047,181 @@ export async function validateUserMention(
 
   return new Ok(undefined);
 }
+
+export async function dismissMention(
+  auth: Authenticator,
+  {
+    messageId,
+    conversationId,
+    type,
+    id,
+  }: {
+    messageId: string;
+    conversationId: string;
+    type: "user" | "agent";
+    id: string;
+  }
+): Promise<Result<void, APIErrorWithStatusCode>> {
+  const conversationRes = await getConversation(auth, conversationId);
+  if (conversationRes.isErr()) {
+    return new Err({
+      status_code: 404,
+      api_error: {
+        type: "conversation_not_found",
+        message: "Conversation not found",
+      },
+    });
+  }
+
+  const conversation = conversationRes.value;
+
+  // Verify the message exists
+  const message = conversation.content.flat().find((m) => m.sId === messageId);
+
+  if (!message) {
+    return new Err({
+      status_code: 404,
+      api_error: {
+        type: "message_not_found",
+        message: "Message not found",
+      },
+    });
+  }
+
+  if (isUserMessageType(message)) {
+    // Verify user is authorized to edit the message by checking the message user.
+    if (message.user && message.user.id !== auth.getNonNullableUser().id) {
+      return new Err({
+        status_code: 403,
+        api_error: {
+          type: "invalid_request_error",
+          message: "User is not authorized to dismiss this mention",
+        },
+      });
+    }
+  } else if (isAgentMessageType(message)) {
+    // Verify user is authorized to edit the message by going back to the user message.
+    const { userMessageUserId } = await getUserMessageIdFromMessageId(auth, {
+      messageId,
+    });
+    if (
+      userMessageUserId !== null &&
+      userMessageUserId !== auth.getNonNullableUser().id
+    ) {
+      return new Err({
+        status_code: 403,
+        api_error: {
+          type: "invalid_request_error",
+          message: "User is not authorized to dismiss this mention",
+        },
+      });
+    }
+  } else if (isContentFragmentType(message)) {
+    return new Err({
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid message type",
+      },
+    });
+  } else {
+    assertNever(message);
+  }
+
+  const updatedMessages: {
+    userMessages: UserMessageType[];
+    agentMessages: AgentMessageType[];
+  } = {
+    userMessages: [],
+    agentMessages: [],
+  };
+
+  // For user mentions, convert sId to database ID
+  let userIdForQuery: number | undefined;
+  if (type === "user") {
+    const user = await getUserForWorkspace(auth, {
+      userId: id,
+    });
+    if (!user) {
+      return new Err({
+        status_code: 404,
+        api_error: {
+          type: "user_not_found",
+          message: "User not found",
+        },
+      });
+    }
+    userIdForQuery = user.id;
+  }
+
+  const predicate = (m: RichMentionWithStatus) =>
+    (m.status === "agent_restricted_by_space_usage" ||
+      m.status === "user_restricted_by_conversation_access") &&
+    m.type === type &&
+    m.id === id;
+
+  // Find all restricted mentions for the same user/agent on conversation messages latest versions.
+  for (const messageVersions of conversation.content) {
+    const latestMessage = messageVersions[messageVersions.length - 1];
+
+    if (
+      latestMessage.visibility !== "deleted" &&
+      !isContentFragmentType(latestMessage) &&
+      latestMessage.richMentions.some(predicate)
+    ) {
+      const mentionModel = await MentionModel.findOne({
+        where: {
+          workspaceId: conversation.owner.id,
+          messageId: latestMessage.id,
+          ...(type === "user"
+            ? { userId: userIdForQuery }
+            : { agentConfigurationId: id }),
+        },
+      });
+      if (!mentionModel) {
+        continue;
+      }
+      await mentionModel.update({ dismissed: true });
+      const newRichMentions = latestMessage.richMentions.map((m) =>
+        predicate(m)
+          ? {
+              ...m,
+              dismissed: true,
+            }
+          : m
+      );
+      if (isUserMessageType(latestMessage)) {
+        updatedMessages.userMessages.push({
+          ...latestMessage,
+          richMentions: newRichMentions,
+          mentions: newRichMentions.map(toMentionType),
+        });
+      } else if (isAgentMessageType(latestMessage)) {
+        updatedMessages.agentMessages.push({
+          ...latestMessage,
+          richMentions: newRichMentions,
+        });
+      }
+    }
+  }
+
+  for (const userMessage of updatedMessages.userMessages) {
+    await publishMessageEventsOnMessagePostOrEdit(
+      conversation,
+      {
+        ...userMessage,
+        contentFragments: getRelatedContentFragments(conversation, userMessage),
+      },
+      []
+    );
+  }
+
+  if (updatedMessages.agentMessages.length > 0) {
+    await publishAgentMessagesEvents(
+      conversation,
+      updatedMessages.agentMessages
+    );
+  }
+
+  return new Ok(undefined);
+}

--- a/front/lib/api/assistant/conversation/mentions.ts
+++ b/front/lib/api/assistant/conversation/mentions.ts
@@ -1,5 +1,4 @@
 import assert from "assert";
-
 import uniq from "lodash/uniq";
 import type { Transaction } from "sequelize";
 import { Op } from "sequelize";

--- a/front/lib/api/assistant/conversation/validate_actions.test.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.test.ts
@@ -28,11 +28,9 @@ import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import {
   createAgentMessages,
   createUserMentions,
-} from "@app/lib/api/assistant/conversation/mentions";
-import {
   dismissMention,
-  validateAction,
-} from "@app/lib/api/assistant/conversation/validate_actions";
+} from "@app/lib/api/assistant/conversation/mentions";
+import { validateAction } from "@app/lib/api/assistant/conversation/validate_actions";
 import {
   publishAgentMessagesEvents,
   publishMessageEventsOnMessagePostOrEdit,

--- a/front/lib/api/assistant/conversation/validate_actions.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.ts
@@ -19,7 +19,7 @@ import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_
 import type { ConversationResource } from "@app/lib/resources/conversation_resource";
 import logger from "@app/logger/logger";
 import { launchAgentLoopWorkflow } from "@app/temporal/agent_loop/client";
-import type { APIErrorWithStatusCode, Result } from "@app/types";
+import type { Result } from "@app/types";
 import { Err, Ok } from "@app/types";
 
 export async function validateAction(

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -930,11 +930,13 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       action,
       user,
       transaction,
+      unread = false,
     }: {
       conversation: ConversationWithoutContentType;
       action: ParticipantActionType;
       user: UserType | null;
       transaction?: Transaction;
+      unread?: boolean;
     }
   ): Promise<"added" | "updated" | "none"> {
     if (!user) {
@@ -976,7 +978,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
             action,
             userId: user.id,
             workspaceId: auth.getNonNullableWorkspace().id,
-            unread: false,
+            unread,
             actionRequired: false,
           },
           { transaction: t }

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/mentions.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/mentions.ts
@@ -3,8 +3,10 @@ import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { validateUserMention } from "@app/lib/api/assistant/conversation/mentions";
-import { dismissMention } from "@app/lib/api/assistant/conversation/validate_actions";
+import {
+  dismissMention,
+  validateUserMention,
+} from "@app/lib/api/assistant/conversation/mentions";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/mentions.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/mentions.ts
@@ -3,10 +3,8 @@ import * as t from "io-ts";
 import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import {
-  dismissMention,
-  validateUserMention,
-} from "@app/lib/api/assistant/conversation/validate_actions";
+import { validateUserMention } from "@app/lib/api/assistant/conversation/mentions";
+import { dismissMention } from "@app/lib/api/assistant/conversation/validate_actions";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/5924

When a user approves a mention of another user who is not already a participant, the mentioned user was added as a participant with `unread: false`. This caused the conversation to appear in their sidebar but not in their inbox with the unread indicator.

Changes:
- Added optional `unread` parameter to `ConversationResource.upsertParticipation()` (default: `false`)
- Moved `validateUserMention` from `validate_actions.ts` to `mentions.ts` (per fraggle's suggestion)
- When approving a mention, now passes `unread: true` to add the participant with the conversation marked as unread

## Risks

Blast radius: User mention approval in conversations
Risk: low

## Deploy Plan

- deploy front
