### PR TITLE
Add ProjectMetadata database model and migration (Part 1/3)

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -84,6 +84,7 @@ import { MembershipModel } from "@app/lib/resources/storage/models/membership";
 import { OnboardingTaskModel } from "@app/lib/resources/storage/models/onboarding_tasks";
 import { PluginRunModel } from "@app/lib/resources/storage/models/plugin_runs";
 import { ProgrammaticUsageConfigurationModel } from "@app/lib/resources/storage/models/programmatic_usage_configurations";
+import { ProjectMetadataModel } from "@app/lib/resources/storage/models/project_metadata";
 import {
   RunModel,
   RunUsageModel,
@@ -117,6 +118,7 @@ async function main() {
   await TagModel.sync({ alter: true });
 
   await SpaceModel.sync({ alter: true });
+  await ProjectMetadataModel.sync({ alter: true });
   await AppModel.sync({ alter: true });
   await DatasetModel.sync({ alter: true });
   await ProviderModel.sync({ alter: true });

--- a/front/lib/resources/storage/models/project_metadata.ts
+++ b/front/lib/resources/storage/models/project_metadata.ts
@@ -1,0 +1,67 @@
+import type { CreationOptional, ForeignKey } from "sequelize";
+import { DataTypes } from "sequelize";
+
+import { frontSequelize } from "@app/lib/resources/storage";
+import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
+import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
+
+export class ProjectMetadataModel extends WorkspaceAwareModel<ProjectMetadataModel> {
+  declare id: CreationOptional<number>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare spaceId: ForeignKey<SpaceModel["id"]>;
+
+  declare description: string | null;
+  declare urls: string[];
+  declare tags: string[];
+}
+
+ProjectMetadataModel.init(
+  {
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    description: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+    },
+    urls: {
+      type: DataTypes.JSONB,
+      allowNull: false,
+      defaultValue: [],
+    },
+    tags: {
+      type: DataTypes.JSONB,
+      allowNull: false,
+      defaultValue: [],
+    },
+  },
+  {
+    modelName: "project_metadata",
+    sequelize: frontSequelize,
+    indexes: [
+      { unique: true, fields: ["spaceId"], concurrently: true },
+      { fields: ["workspaceId"], concurrently: true },
+    ],
+  }
+);
+
+// Define the relationship: ProjectMetadata belongs to Space
+ProjectMetadataModel.belongsTo(SpaceModel, {
+  foreignKey: { name: "spaceId", allowNull: false },
+  onDelete: "RESTRICT",
+});
+
+// Define the reverse relationship: Space has one ProjectMetadata
+SpaceModel.hasOne(ProjectMetadataModel, {
+  foreignKey: { name: "spaceId", allowNull: false },
+  as: "projectMetadata",
+});

--- a/front/migrations/db/migration_476.sql
+++ b/front/migrations/db/migration_476.sql
@@ -1,0 +1,14 @@
+-- Migration: Create project_metadata table
+CREATE TABLE "project_metadata" (
+    "id" SERIAL PRIMARY KEY,
+    "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    "workspaceId" INTEGER NOT NULL REFERENCES "workspaces" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    "spaceId" INTEGER NOT NULL REFERENCES "vaults" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    "description" TEXT,
+    "urls" JSONB NOT NULL DEFAULT '[]',
+    "tags" JSONB NOT NULL DEFAULT '[]'
+);
+
+CREATE UNIQUE INDEX CONCURRENTLY "project_metadata_space_id_unique" ON "project_metadata" ("spaceId");
+CREATE INDEX CONCURRENTLY "project_metadata_workspace_id" ON "project_metadata" ("workspaceId");


### PR DESCRIPTION
## Description

Introduces the database layer for storing structured metadata on project spaces.

This is **Part 1 of 3** in the project metadata feature:
- **Part 1 (this PR)**: Database model and migration
- **Part 2 (#20068)**: Resource, API endpoint, and lifecycle integration
- **Part 3 (#20069)**: Frontend SWR hooks and UI

**Changes in this PR:**
- New `project_metadata` table via `migration_475.sql`
- New `ProjectMetadataModel` with 1:1 relationship to `SpaceModel`
- Model registration in `admin/db.ts`

**Table schema:**
- `description` (TEXT) - Project description
- `urls` (JSONB) - Array of related URLs
- `tags` (JSONB) - Array of tags
- `emoji` (VARCHAR) - Project emoji
- `color` (VARCHAR) - Project color

**Workspace/Space deletion handling:**
The `ProjectMetadataModel` uses `onDelete: RESTRICT` on the `spaceId` FK. Explicit deletion is implemented in Part 2 (#20068) in the `hardDeleteSpace` function, which deletes project metadata before the space is deleted. This ensures proper cleanup during workspace/space deletion workflows.

## Tests

No tests in this PR - tests will be added in Part 2 with the resource and API.

## Risk

Low risk - adds a new table with no existing data dependencies.

## Deploy Plan

Run migration_475 to create the project_metadata table, then deploy front.
