### PR TITLE
Add ProjectMetadata resource, API, and lifecycle (Part 2/3)

### DIFF
--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -444,8 +444,6 @@ export async function createSpaceAndGroup(
           description: null,
           urls: [],
           tags: [],
-          emoji: null,
-          color: null,
         },
         t
       );

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -17,6 +17,7 @@ import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { KeyResource } from "@app/lib/resources/key_resource";
+import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces";
@@ -268,6 +269,17 @@ export async function hardDeleteSpace(
   }
 
   await withTransaction(async (t) => {
+    // Delete project metadata if this is a project space
+    if (space.isProject()) {
+      const metadata = await ProjectMetadataResource.fetchBySpace(auth, space);
+      if (metadata) {
+        const metadataRes = await metadata.delete(auth, { transaction: t });
+        if (metadataRes.isErr()) {
+          throw metadataRes.error;
+        }
+      }
+    }
+
     // Delete all spaces groups.
     for (const group of space.groups) {
       // Skip deleting global groups for regular spaces.
@@ -421,6 +433,22 @@ export async function createSpaceAndGroup(
           { transaction: t }
         );
       }
+    }
+
+    // Create empty project metadata for project spaces
+    if (spaceKind === "project") {
+      await ProjectMetadataResource.makeNew(
+        auth,
+        space,
+        {
+          description: null,
+          urls: [],
+          tags: [],
+          emoji: null,
+          color: null,
+        },
+        t
+      );
     }
 
     return new Ok(space);

--- a/front/lib/resources/project_metadata_resource.test.ts
+++ b/front/lib/resources/project_metadata_resource.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { Authenticator } from "@app/lib/auth";
+import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import type { WorkspaceType } from "@app/types";
+
+describe("ProjectMetadataResource", () => {
+  let workspace: WorkspaceType;
+  let auth: Authenticator;
+  let projectSpace: SpaceResource;
+  let regularSpace: SpaceResource;
+
+  beforeEach(async () => {
+    workspace = await WorkspaceFactory.basic();
+    auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    projectSpace = await SpaceFactory.project(workspace);
+    regularSpace = await SpaceFactory.regular(workspace);
+  });
+
+  describe("fetchBySpace", () => {
+    it("returns null for non-project spaces", async () => {
+      const metadata = await ProjectMetadataResource.fetchBySpace(
+        auth,
+        regularSpace
+      );
+      expect(metadata).toBeNull();
+    });
+
+    it("returns metadata when it exists", async () => {
+      await ProjectMetadataResource.makeNew(auth, projectSpace, {
+        description: "Test",
+        urls: ["https://example.com"],
+        tags: ["tag1"],
+        emoji: "🚀",
+        color: "#FF0000",
+      });
+
+      const metadata = await ProjectMetadataResource.fetchBySpace(
+        auth,
+        projectSpace
+      );
+      expect(metadata).not.toBeNull();
+      expect(metadata!.description).toBe("Test");
+    });
+  });
+
+  describe("makeNew", () => {
+    it("creates metadata with provided values", async () => {
+      const metadata = await ProjectMetadataResource.makeNew(
+        auth,
+        projectSpace,
+        {
+          description: "Full metadata",
+          urls: ["https://github.com"],
+          tags: ["frontend"],
+          emoji: "✨",
+          color: "#00FF00",
+        }
+      );
+
+      expect(metadata.description).toBe("Full metadata");
+      expect(metadata.urls).toContain("https://github.com");
+      expect(metadata.sId).toMatch(/^pmd_/);
+    });
+  });
+
+  describe("updateMetadata", () => {
+    it("updates fields and persists changes", async () => {
+      const metadata = await ProjectMetadataResource.makeNew(
+        auth,
+        projectSpace,
+        {
+          description: "Initial",
+          urls: [],
+          tags: [],
+          emoji: null,
+          color: null,
+        }
+      );
+
+      await metadata.updateMetadata({
+        description: "Updated",
+        tags: ["new-tag"],
+      });
+
+      const updated = await ProjectMetadataResource.fetchBySpace(
+        auth,
+        projectSpace
+      );
+      expect(updated!.description).toBe("Updated");
+      expect(updated!.tags).toContain("new-tag");
+    });
+  });
+
+  describe("delete", () => {
+    it("removes metadata", async () => {
+      const metadata = await ProjectMetadataResource.makeNew(
+        auth,
+        projectSpace,
+        {
+          description: "To delete",
+          urls: [],
+          tags: [],
+          emoji: null,
+          color: null,
+        }
+      );
+
+      await metadata.delete(auth, {});
+
+      const deleted = await ProjectMetadataResource.fetchBySpace(
+        auth,
+        projectSpace
+      );
+      expect(deleted).toBeNull();
+    });
+  });
+
+  describe("toJSON", () => {
+    it("serializes correctly", async () => {
+      const metadata = await ProjectMetadataResource.makeNew(
+        auth,
+        projectSpace,
+        {
+          description: "JSON test",
+          urls: ["https://test.com"],
+          tags: ["test"],
+          emoji: "📋",
+          color: "#123456",
+        }
+      );
+
+      const json = metadata.toJSON();
+
+      expect(json.sId).toMatch(/^pmd_/);
+      expect(json.spaceId).toBe(projectSpace.sId);
+      expect(json.description).toBe("JSON test");
+      expect(typeof json.createdAt).toBe("number");
+    });
+  });
+});

--- a/front/lib/resources/project_metadata_resource.test.ts
+++ b/front/lib/resources/project_metadata_resource.test.ts
@@ -34,8 +34,6 @@ describe("ProjectMetadataResource", () => {
         description: "Test",
         urls: ["https://example.com"],
         tags: ["tag1"],
-        emoji: "🚀",
-        color: "#FF0000",
       });
 
       const metadata = await ProjectMetadataResource.fetchBySpace(
@@ -56,8 +54,6 @@ describe("ProjectMetadataResource", () => {
           description: "Full metadata",
           urls: ["https://github.com"],
           tags: ["frontend"],
-          emoji: "✨",
-          color: "#00FF00",
         }
       );
 
@@ -76,8 +72,6 @@ describe("ProjectMetadataResource", () => {
           description: "Initial",
           urls: [],
           tags: [],
-          emoji: null,
-          color: null,
         }
       );
 
@@ -104,8 +98,6 @@ describe("ProjectMetadataResource", () => {
           description: "To delete",
           urls: [],
           tags: [],
-          emoji: null,
-          color: null,
         }
       );
 
@@ -128,8 +120,6 @@ describe("ProjectMetadataResource", () => {
           description: "JSON test",
           urls: ["https://test.com"],
           tags: ["test"],
-          emoji: "📋",
-          color: "#123456",
         }
       );
 

--- a/front/lib/resources/project_metadata_resource.ts
+++ b/front/lib/resources/project_metadata_resource.ts
@@ -1,0 +1,139 @@
+import type { Attributes, CreationAttributes, Transaction } from "sequelize";
+
+import type { Authenticator } from "@app/lib/auth";
+import { BaseResource } from "@app/lib/resources/base_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { ProjectMetadataModel } from "@app/lib/resources/storage/models/project_metadata";
+import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
+import { makeSId } from "@app/lib/resources/string_ids";
+import type { ModelId, ProjectMetadataType, Result } from "@app/types";
+import { Ok } from "@app/types";
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export interface ProjectMetadataResource extends ReadonlyAttributesType<ProjectMetadataModel> {}
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export class ProjectMetadataResource extends BaseResource<ProjectMetadataModel> {
+  static model: typeof ProjectMetadataModel = ProjectMetadataModel;
+
+  constructor(
+    model: typeof ProjectMetadataModel,
+    blob: Attributes<ProjectMetadataModel>,
+    private readonly spaceSId: string
+  ) {
+    super(ProjectMetadataModel, blob);
+  }
+
+  static fromModel(
+    model: ProjectMetadataModel,
+    spaceSId: string
+  ): ProjectMetadataResource {
+    return new ProjectMetadataResource(
+      ProjectMetadataModel,
+      model.get(),
+      spaceSId
+    );
+  }
+
+  get sId(): string {
+    return ProjectMetadataResource.modelIdToSId({
+      id: this.id,
+      workspaceId: this.workspaceId,
+    });
+  }
+
+  static modelIdToSId({
+    id,
+    workspaceId,
+  }: {
+    id: ModelId;
+    workspaceId: ModelId;
+  }): string {
+    return makeSId("project_metadata", {
+      id,
+      workspaceId,
+    });
+  }
+
+  static async fetchBySpace(
+    auth: Authenticator,
+    space: SpaceResource
+  ): Promise<ProjectMetadataResource | null> {
+    if (!space.isProject()) {
+      return null;
+    }
+
+    const model = await ProjectMetadataModel.findOne({
+      where: {
+        spaceId: space.id,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+    });
+
+    if (!model) {
+      return null;
+    }
+
+    return ProjectMetadataResource.fromModel(model, space.sId);
+  }
+
+  static async makeNew(
+    auth: Authenticator,
+    space: SpaceResource,
+    blob: Omit<
+      CreationAttributes<ProjectMetadataModel>,
+      "workspaceId" | "spaceId"
+    >,
+    transaction?: Transaction
+  ): Promise<ProjectMetadataResource> {
+    const model = await ProjectMetadataModel.create(
+      {
+        ...blob,
+        workspaceId: auth.getNonNullableWorkspace().id,
+        spaceId: space.id,
+      },
+      { transaction }
+    );
+
+    return ProjectMetadataResource.fromModel(model, space.sId);
+  }
+
+  async updateMetadata(
+    blob: Partial<{
+      description: string | null;
+      urls: string[];
+      tags: string[];
+      emoji: string | null;
+      color: string | null;
+    }>,
+    transaction?: Transaction
+  ): Promise<Result<void, Error>> {
+    await this.update(blob, transaction);
+    return new Ok(undefined);
+  }
+
+  async delete(
+    auth: Authenticator,
+    { transaction }: { transaction?: Transaction }
+  ): Promise<Result<undefined, Error>> {
+    await ProjectMetadataModel.destroy({
+      where: { id: this.id },
+      transaction,
+    });
+    return new Ok(undefined);
+  }
+
+  toJSON(): ProjectMetadataType {
+    return {
+      sId: this.sId,
+      createdAt: this.createdAt.getTime(),
+      updatedAt: this.updatedAt.getTime(),
+      spaceId: this.spaceSId,
+      description: this.description,
+      urls: this.urls,
+      tags: this.tags,
+      emoji: this.emoji,
+      color: this.color,
+    };
+  }
+}

--- a/front/lib/resources/project_metadata_resource.ts
+++ b/front/lib/resources/project_metadata_resource.ts
@@ -103,8 +103,6 @@ export class ProjectMetadataResource extends BaseResource<ProjectMetadataModel> 
       description: string | null;
       urls: string[];
       tags: string[];
-      emoji: string | null;
-      color: string | null;
     }>,
     transaction?: Transaction
   ): Promise<Result<void, Error>> {
@@ -132,8 +130,6 @@ export class ProjectMetadataResource extends BaseResource<ProjectMetadataModel> 
       description: this.description,
       urls: this.urls,
       tags: this.tags,
-      emoji: this.emoji,
-      color: this.color,
     };
   }
 }

--- a/front/lib/resources/string_ids.ts
+++ b/front/lib/resources/string_ids.ts
@@ -61,6 +61,9 @@ export const RESOURCES_PREFIX = {
 
   // Workspace verification.
   workspace_verification_attempt: "wva",
+
+  // Project metadata.
+  project_metadata: "pmd",
 } as const;
 
 export const CROSS_WORKSPACE_RESOURCES_WORKSPACE_ID: ModelId = 0;

--- a/front/migrations/20260114_backfill_project_metadata.ts
+++ b/front/migrations/20260114_backfill_project_metadata.ts
@@ -1,0 +1,130 @@
+import type { Logger } from "pino";
+import { Op } from "sequelize";
+
+import { ProjectMetadataModel } from "@app/lib/resources/storage/models/project_metadata";
+import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
+import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
+import { makeScript } from "@app/scripts/helpers";
+import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
+import type { LightWorkspaceType } from "@app/types";
+
+/**
+ * This migration creates project_metadata records for existing project spaces
+ * that were created before the project metadata feature was implemented.
+ */
+
+async function backfillProjectMetadata(
+  execute: boolean,
+  logger: Logger,
+  workspace: LightWorkspaceType
+): Promise<void> {
+  // Find all project spaces for this workspace
+  const projectSpaces = await SpaceModel.findAll({
+    where: {
+      workspaceId: workspace.id,
+      kind: "project",
+      deletedAt: null,
+    },
+  });
+
+  if (projectSpaces.length === 0) {
+    logger.info(
+      { workspaceId: workspace.sId },
+      "No project spaces found, skipping"
+    );
+    return;
+  }
+
+  // Find which project spaces already have metadata
+  const existingMetadata = await ProjectMetadataModel.findAll({
+    where: {
+      spaceId: { [Op.in]: projectSpaces.map((s) => s.id) },
+    },
+    attributes: ["spaceId"],
+  });
+
+  const existingSpaceIds = new Set(existingMetadata.map((m) => m.spaceId));
+
+  // Filter to spaces that don't have metadata yet
+  const spacesNeedingMetadata = projectSpaces.filter(
+    (space) => !existingSpaceIds.has(space.id)
+  );
+
+  if (spacesNeedingMetadata.length === 0) {
+    logger.info(
+      { workspaceId: workspace.sId },
+      "All project spaces already have metadata, skipping"
+    );
+    return;
+  }
+
+  logger.info(
+    {
+      workspaceId: workspace.sId,
+      spaceCount: spacesNeedingMetadata.length,
+    },
+    `Found ${spacesNeedingMetadata.length} project spaces needing metadata`
+  );
+
+  await concurrentExecutor(
+    spacesNeedingMetadata,
+    async (space) => {
+      logger.info(
+        {
+          workspaceId: workspace.sId,
+          spaceId: space.id,
+          spaceName: space.name,
+        },
+        "Creating project metadata for space"
+      );
+
+      if (execute) {
+        await ProjectMetadataModel.create({
+          workspaceId: workspace.id,
+          spaceId: space.id,
+          description: null,
+          urls: [],
+          tags: [],
+        });
+      }
+    },
+    { concurrency: 4 }
+  );
+
+  logger.info(
+    { workspaceId: workspace.sId },
+    `Project metadata backfill completed for workspace`
+  );
+}
+
+makeScript(
+  {
+    wId: { type: "string", required: false },
+  },
+  async ({ wId, execute }, logger) => {
+    logger.info("Starting project metadata backfill");
+
+    if (wId) {
+      const ws = await WorkspaceModel.findOne({ where: { sId: wId } });
+      if (!ws) {
+        throw new Error(`Workspace not found: ${wId}`);
+      }
+      await backfillProjectMetadata(
+        execute,
+        logger,
+        renderLightWorkspaceType({ workspace: ws })
+      );
+    } else {
+      await runOnAllWorkspaces(
+        async (workspace) => {
+          await backfillProjectMetadata(execute, logger, workspace);
+        },
+        { concurrency: 4 }
+      );
+    }
+
+    logger.info("Project metadata backfill completed");
+  }
+);

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_metadata.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_metadata.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+
+import { Authenticator } from "@app/lib/auth";
+import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+
+import handler from "./project_metadata";
+
+describe("GET /api/w/[wId]/spaces/[spaceId]/project_metadata", () => {
+  it("returns metadata for project spaces", async () => {
+    const { req, res, workspace, authenticator } =
+      await createPrivateApiMockRequest({ role: "admin" });
+
+    const projectSpace = await SpaceFactory.project(workspace);
+    req.query.spaceId = projectSpace.sId;
+
+    await ProjectMetadataResource.makeNew(authenticator, projectSpace, {
+      description: "Test description",
+      urls: ["https://github.com/test"],
+      tags: ["frontend"],
+      emoji: "🚀",
+      color: "#FF0000",
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData().projectMetadata.description).toBe(
+      "Test description"
+    );
+  });
+
+  it("returns 400 for non-project spaces", async () => {
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      role: "admin",
+    });
+
+    const regularSpace = await SpaceFactory.regular(workspace);
+    req.query.spaceId = regularSpace.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData().error.type).toBe("invalid_request_error");
+  });
+});
+
+describe("PATCH /api/w/[wId]/spaces/[spaceId]/project_metadata", () => {
+  it("creates and updates metadata", async () => {
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "admin",
+    });
+
+    const projectSpace = await SpaceFactory.project(workspace);
+    req.query.spaceId = projectSpace.sId;
+    req.body = {
+      description: "New description",
+      tags: ["backend", "api"],
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData().projectMetadata.description).toBe(
+      "New description"
+    );
+    expect(res._getJSONData().projectMetadata.tags).toContain("backend");
+  });
+
+  it("denies non-admin users", async () => {
+    const { req, res, workspace, user } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "user",
+    });
+
+    const projectSpace = await SpaceFactory.project(workspace);
+    req.query.spaceId = projectSpace.sId;
+
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const [spaceGroup] = projectSpace.groups.filter((g) => !g.isGlobal());
+    await spaceGroup.addMembers(adminAuth, [user.toJSON()]);
+
+    req.body = { description: "Should fail" };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(403);
+  });
+
+  it("rejects invalid body", async () => {
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "admin",
+    });
+
+    const projectSpace = await SpaceFactory.project(workspace);
+    req.query.spaceId = projectSpace.sId;
+    req.body = { urls: "not-an-array" };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+  });
+});
+
+describe("unsupported methods", () => {
+  it("returns 405 for DELETE/POST/PUT", async () => {
+    for (const method of ["DELETE", "POST", "PUT"] as const) {
+      const { req, res, workspace } = await createPrivateApiMockRequest({
+        method,
+        role: "admin",
+      });
+
+      const projectSpace = await SpaceFactory.project(workspace);
+      req.query.spaceId = projectSpace.sId;
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(405);
+    }
+  });
+});

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_metadata.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_metadata.test.ts
@@ -19,8 +19,6 @@ describe("GET /api/w/[wId]/spaces/[spaceId]/project_metadata", () => {
       description: "Test description",
       urls: ["https://github.com/test"],
       tags: ["frontend"],
-      emoji: "🚀",
-      color: "#FF0000",
     });
 
     await handler(req, res);

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_metadata.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_metadata.ts
@@ -81,8 +81,6 @@ async function handler(
           description: body.description ?? null,
           urls: body.urls ?? [],
           tags: body.tags ?? [],
-          emoji: body.emoji ?? null,
-          color: body.color ?? null,
         });
       } else {
         // Update existing metadata

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_metadata.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_metadata.ts
@@ -54,7 +54,7 @@ async function handler(
           status_code: 403,
           api_error: {
             type: "workspace_auth_error",
-            message: "Only admins can update project metadata.",
+            message: "Only project members can update project metadata.",
           },
         });
       }

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_metadata.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_metadata.ts
@@ -1,0 +1,112 @@
+import { isLeft } from "fp-ts/lib/Either";
+import * as reporter from "io-ts-reporters";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { ProjectMetadataType, WithAPIErrorResponse } from "@app/types";
+import { PatchProjectMetadataBodySchema } from "@app/types";
+
+export type GetProjectMetadataResponseBody = {
+  projectMetadata: ProjectMetadataType | null;
+};
+
+export type PatchProjectMetadataResponseBody = {
+  projectMetadata: ProjectMetadataType;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<
+      GetProjectMetadataResponseBody | PatchProjectMetadataResponseBody
+    >
+  >,
+  auth: Authenticator,
+  { space }: { space: SpaceResource }
+): Promise<void> {
+  // Only project spaces can have metadata
+  if (!space.isProject()) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Project metadata is only available for project spaces.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      const metadata = await ProjectMetadataResource.fetchBySpace(auth, space);
+      return res.status(200).json({
+        projectMetadata: metadata ? metadata.toJSON() : null,
+      });
+    }
+
+    case "PATCH": {
+      if (!space.canAdministrate(auth)) {
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "workspace_auth_error",
+            message: "Only admins can update project metadata.",
+          },
+        });
+      }
+
+      const bodyValidation = PatchProjectMetadataBodySchema.decode(req.body);
+      if (isLeft(bodyValidation)) {
+        const pathError = reporter.formatValidationErrors(bodyValidation.left);
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid request body: ${pathError}`,
+          },
+        });
+      }
+
+      const body = bodyValidation.right;
+
+      let metadata = await ProjectMetadataResource.fetchBySpace(auth, space);
+
+      if (!metadata) {
+        // Create new metadata
+        metadata = await ProjectMetadataResource.makeNew(auth, space, {
+          description: body.description ?? null,
+          urls: body.urls ?? [],
+          tags: body.tags ?? [],
+          emoji: body.emoji ?? null,
+          color: body.color ?? null,
+        });
+      } else {
+        // Update existing metadata
+        await metadata.updateMetadata(body);
+      }
+
+      return res.status(200).json({
+        projectMetadata: metadata.toJSON(),
+      });
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET or PATCH expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(
+  withResourceFetchingFromRoute(handler, {
+    space: { requireCanReadOrAdministrate: true },
+  })
+);

--- a/front/types/api/internal/spaces.ts
+++ b/front/types/api/internal/spaces.ts
@@ -41,8 +41,6 @@ export const PatchProjectMetadataBodySchema = t.partial({
   description: t.union([t.string, t.null]),
   urls: t.array(t.string),
   tags: t.array(t.string),
-  emoji: t.union([t.string, t.null]),
-  color: t.union([t.string, t.null]),
 });
 
 export type PatchProjectMetadataBodyType = t.TypeOf<

--- a/front/types/api/internal/spaces.ts
+++ b/front/types/api/internal/spaces.ts
@@ -36,3 +36,15 @@ export const GetPostNotionSyncResponseBodySchema = t.type({
 export type GetPostNotionSyncResponseBody = t.TypeOf<
   typeof GetPostNotionSyncResponseBodySchema
 >;
+
+export const PatchProjectMetadataBodySchema = t.partial({
+  description: t.union([t.string, t.null]),
+  urls: t.array(t.string),
+  tags: t.array(t.string),
+  emoji: t.union([t.string, t.null]),
+  color: t.union([t.string, t.null]),
+});
+
+export type PatchProjectMetadataBodyType = t.TypeOf<
+  typeof PatchProjectMetadataBodySchema
+>;

--- a/front/types/index.ts
+++ b/front/types/index.ts
@@ -68,6 +68,7 @@ export * from "./poke/plugins";
 export * from "./production_checks";
 export * from "./programmatic_usage";
 export * from "./project";
+export * from "./project_metadata";
 export * from "./provider";
 export * from "./resource_permissions";
 export * from "./run";

--- a/front/types/project_metadata.ts
+++ b/front/types/project_metadata.ts
@@ -6,6 +6,4 @@ export interface ProjectMetadataType {
   description: string | null;
   urls: string[];
   tags: string[];
-  emoji: string | null;
-  color: string | null;
 }

--- a/front/types/project_metadata.ts
+++ b/front/types/project_metadata.ts
@@ -1,0 +1,11 @@
+export interface ProjectMetadataType {
+  sId: string;
+  createdAt: number;
+  updatedAt: number;
+  spaceId: string;
+  description: string | null;
+  urls: string[];
+  tags: string[];
+  emoji: string | null;
+  color: string | null;
+}


### PR DESCRIPTION
## Description

Implements the business logic layer for project metadata.

This is **Part 2 of 3** in the project metadata feature:
- **Part 1 (#20067)**: Database model and migration ← **depends on this**
- **Part 2 (this PR)**: Resource, API endpoint, and lifecycle integration
- **Part 3**: Frontend SWR hooks and UI

**Changes in this PR:**
- `ProjectMetadataResource` with CRUD operations (fetch, create, update, delete)
- `GET/PATCH /api/w/[wId]/spaces/[spaceId]/project_metadata` API endpoint
- Auto-create empty metadata when a project space is created
- Explicit metadata deletion in `hardDeleteSpace` before space deletion (RESTRICT FK)
- Type definitions for `ProjectMetadataType` and `PatchProjectMetadataBodyType`

**Tests included:**
- Resource unit tests (CRUD, serialization)
- API endpoint tests (GET, PATCH, authorization, validation)
- Lifecycle integration tests (auto-create on project space creation)

## Tests

```bash
NODE_ENV=test npm test -- project_metadata lib/api/spaces.test.ts
```

## Risk

Low risk:
- New resource with no impact on existing code paths
- New API endpoint isolated from existing endpoints
- Lifecycle hooks are additive (create) or explicit (delete)

## Deploy Plan

Deploy after Part 1 is merged and migration_475 has been run.
