### PR TITLE
Add ProjectMetadata frontend hooks and UI (Part 3/3)

### DIFF
--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -35,10 +35,16 @@ import type { GetDataSourceViewResponseBody } from "@app/pages/api/w/[wId]/space
 import type { PostSpaceDataSourceResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/data_sources";
 import type { PatchSpaceMembersRequestBodyType } from "@app/pages/api/w/[wId]/spaces/[spaceId]/members";
 import type {
+  GetProjectMetadataResponseBody,
+  PatchProjectMetadataResponseBody,
+} from "@app/pages/api/w/[wId]/spaces/[spaceId]/project_metadata";
+import type {
   ContentNodesViewType,
   DataSourceViewCategoryWithoutApps,
   DataSourceViewType,
   LightWorkspaceType,
+  PatchProjectMetadataBodyType,
+  ProjectMetadataType,
   SearchWarningCode,
   SpaceType,
 } from "@app/types";
@@ -849,4 +855,79 @@ export function useSpacesSearchWithInfiniteScroll({
       await setSize((size) => size + 1);
     }, [setSize]),
   };
+}
+
+export function useProjectMetadata({
+  workspaceId,
+  spaceId,
+  disabled = false,
+}: {
+  workspaceId: string;
+  spaceId: string | null;
+  disabled?: boolean;
+}) {
+  const projectMetadataFetcher: Fetcher<GetProjectMetadataResponseBody> =
+    fetcher;
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    `/api/w/${workspaceId}/spaces/${spaceId}/project_metadata`,
+    projectMetadataFetcher,
+    { disabled: disabled || spaceId === null }
+  );
+
+  return {
+    projectMetadata: data?.projectMetadata ?? null,
+    isProjectMetadataLoading: !error && !data && !disabled,
+    isProjectMetadataError: error,
+    mutateProjectMetadata: mutate,
+  };
+}
+
+export function useUpdateProjectMetadata({
+  owner,
+  spaceId,
+}: {
+  owner: LightWorkspaceType;
+  spaceId: string;
+}) {
+  const sendNotification = useSendNotification();
+  const { mutateProjectMetadata } = useProjectMetadata({
+    workspaceId: owner.sId,
+    spaceId,
+    disabled: true, // Needed just to mutate
+  });
+
+  const doUpdate = async (
+    updates: PatchProjectMetadataBodyType
+  ): Promise<ProjectMetadataType | null> => {
+    const url = `/api/w/${owner.sId}/spaces/${spaceId}/project_metadata`;
+
+    const res = await clientFetch(url, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(updates),
+    });
+
+    if (!res.ok) {
+      const errorData = await getErrorFromResponse(res);
+      sendNotification({
+        type: "error",
+        title: "Error updating project metadata",
+        description: `Error: ${errorData.message}`,
+      });
+      return null;
+    }
+
+    void mutateProjectMetadata();
+    sendNotification({
+      type: "success",
+      title: "Project metadata updated",
+      description: "Project metadata was successfully updated.",
+    });
+
+    const response: PatchProjectMetadataResponseBody = await res.json();
+    return response.projectMetadata;
+  };
+
+  return doUpdate;
 }


### PR DESCRIPTION
## Description

Implements the frontend layer for project metadata.

This is **Part 3 of 3** in the project metadata feature:
- **Part 1 (#20067)**: Database model and migration
- **Part 2 (#20068)**: Resource, API endpoint, and lifecycle integration ← **depends on this**
- **Part 3 (this PR)**: Frontend SWR hooks and UI

**Changes in this PR:**
- `useProjectMetadata` SWR hook for fetching project metadata
- `useUpdateProjectMetadata` hook for updating metadata with notifications
- Description input field in `SpaceAboutTab` ("About this project" tab)

**How to test:**
1. Navigate to a project space
2. Click the "About this project" tab
3. Enter a description and click "Save description"
4. Refresh to verify persistence

## Tests

Manual testing only - this PR adds UI components.

## Risk

Low risk - additive UI changes with no impact on existing functionality.

## Deploy Plan

Deploy after Part 1 and Part 2 are merged.
