### PR TITLE
[front] fix: Handle partial Person report response

### DIFF
--- a/front/lib/api/workspace_verification/persona/lookup.ts
+++ b/front/lib/api/workspace_verification/persona/lookup.ts
@@ -20,6 +20,13 @@ import { getPersonaClient } from "./client";
 const POLL_INTERVAL_MS = 2000;
 const MAX_POLL_ATTEMPTS = 5;
 
+const PersonaCreateReportResponseSchema = z.object({
+  data: z.object({
+    type: z.string(),
+    id: z.string(),
+  }),
+});
+
 const PersonaReportResponseSchema = z.object({
   data: z.object({
     type: z.string(),
@@ -157,7 +164,7 @@ async function createReport(
   }
 
   const data = await response.json();
-  const parsed = PersonaReportResponseSchema.safeParse(data);
+  const parsed = PersonaCreateReportResponseSchema.safeParse(data);
 
   if (!parsed.success) {
     logger.error({ error: parsed.error }, "[Persona] Invalid response format");


### PR DESCRIPTION
## Description

Report return partial data when created. We used to parse expecting a full response. This PR fixes that

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
