### PR TITLE
fix(ui): extend hover area to include emoji picker and action buttons

### DIFF
--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -247,14 +247,14 @@ export const AgentInputBar = ({
         "relative z-20 mx-auto flex max-h-dvh w-full flex-col py-2 sm:w-full sm:max-w-4xl sm:py-4"
       }
     >
-      <div
-        className="flex w-full justify-center gap-2"
-        style={{
-          position: "absolute",
-          top: "-2em",
-        }}
-      >
-        <div className="flex items-center gap-1 rounded-xl border border-border bg-white p-1 dark:border-border-night dark:bg-muted-night">
+      <div className="flex w-full justify-center gap-2">
+        <div
+          className="flex items-center gap-1 rounded-xl border border-border bg-white p-1 dark:border-border-night dark:bg-muted-night"
+          style={{
+            position: "absolute",
+            top: "-2em",
+          }}
+        >
           {showStopButton && (
             <>
               <Button
@@ -290,6 +290,10 @@ export const AgentInputBar = ({
             icon={ArrowPathIcon}
             onClick={context.agentBuilderContext?.resetConversation}
             label="Clear"
+            style={{
+              position: "absolute",
+              top: "-2em",
+            }}
           />
         )}
       </div>


### PR DESCRIPTION
## Description

Fixes emoji picker and action menu buttons being unclickable when messages are at the bottom of the screen, just above the input bar.

**Root Cause:**

In AgentInputBar.tsx, the navigation buttons wrapper div had position absolute and top -2em styling. This caused the parent wrapper to create an absolutely positioned layer that extended across the full width, blocking clicks on any elements above it (including the emoji picker and action menu buttons on the last message).

Even though the buttons appeared visually clickable, clicks were being intercepted by this absolutely positioned parent div layer.


## Tests

Tested manually
## Risk

Very low risk - minimal change
## Deploy Plan

Standard deployment - no special steps required