### PR TITLE
Implement Coordinated Connection Draining for Graceful Pod Shutdown

### DIFF
--- a/front/lib/constants/timeouts.ts
+++ b/front/lib/constants/timeouts.ts
@@ -9,6 +9,21 @@
 // DO NOT CHANGE THIS VALUE unless you update the deployment specification.
 export const PRESTOP_GRACE_PERIOD_MS = 130 * 1_000; // 130 seconds grace period.
 
+// PreStop phase durations for coordinated connection draining.
+// These work together to ensure graceful shutdown:
+// 1. Load balancer propagation (10s): Time for readiness=false to reach all LB backends
+// 2. Wake locks (up to 120s): Critical operations must complete
+// 3. Connection draining (min 60s): Existing connections gracefully close
+//
+// Total time: 10s + MAX(wakeLocks, 60s) ≤ 130s (grace period)
+// Examples:
+// - Wake locks clear in 20s: 10s + 60s = 70s total (waits extra 40s for draining)
+// - Wake locks clear in 80s: 10s + 80s = 90s total (draining requirement met)
+// - Wake locks take 120s: 10s + 120s = 130s total (at grace period limit)
+export const PRESTOP_LB_PROPAGATION_MS = 10 * 1_000; // Load balancer propagation.
+export const PRESTOP_WAKE_LOCK_MAX_WAIT_MS = 120 * 1_000; // Critical operations (max).
+export const PRESTOP_MIN_DRAINING_WAIT_MS = 60 * 1_000; // Connection draining (min).
+
 // Threshold for determining if tools should trigger async mode (2 minutes).
 // This is 10 seconds before the prestop grace period to ensure sufficient buffer time.
 export const LONG_RUNNING_TOOL_THRESHOLD_MS = PRESTOP_GRACE_PERIOD_MS - 10_000;

--- a/front/lib/shutdown_signal.ts
+++ b/front/lib/shutdown_signal.ts
@@ -1,0 +1,26 @@
+/**
+ * Global shutdown signal for coordinating graceful pod termination.
+ *
+ * This module tracks whether the pod is shutting down to coordinate between:
+ * - The prestop hook (which signals shutdown)
+ * - The readiness probe (which should fail when shutting down)
+ * - Connection draining (which needs the pod to stay alive)
+ */
+
+let isShuttingDown = false;
+
+/**
+ * Marks the pod as shutting down.
+ * This should be called by the prestop hook to signal that the pod is terminating.
+ */
+export function markShuttingDown(): void {
+  isShuttingDown = true;
+}
+
+/**
+ * Checks if the pod is currently in shutdown mode.
+ * Used by the readiness probe to determine if it should fail.
+ */
+export function isInShutdown(): boolean {
+  return isShuttingDown;
+}

--- a/front/pages/api/[preStopSecret]/prestop.ts
+++ b/front/pages/api/[preStopSecret]/prestop.ts
@@ -1,6 +1,12 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { PRESTOP_GRACE_PERIOD_MS } from "@app/lib/constants/timeouts";
+import {
+  PRESTOP_GRACE_PERIOD_MS,
+  PRESTOP_LB_PROPAGATION_MS,
+  PRESTOP_MIN_DRAINING_WAIT_MS,
+  PRESTOP_WAKE_LOCK_MAX_WAIT_MS,
+} from "@app/lib/constants/timeouts";
+import { markShuttingDown } from "@app/lib/shutdown_signal";
 import { setTimeoutAsync } from "@app/lib/utils/async_utils";
 import type { WakeLockEntry } from "@app/lib/wake_lock";
 import { getWakeLockDetails, wakeLockIsFree } from "@app/lib/wake_lock";
@@ -8,7 +14,6 @@ import logger from "@app/logger/logger";
 import { statsDClient } from "@app/logger/statsDClient";
 import { withLogging } from "@app/logger/withlogging";
 
-const PRESTOP_MAX_WAIT_MS = 120 * 1000; // 120 seconds max wait.
 const PRESTOP_LOG_INTERVAL_MS = 1000; // 1 second log interval.
 const PRESTOP_LOG_MAX_LOCKS = 3; // Show top 3 longest running wake locks.
 
@@ -39,15 +44,23 @@ async function handler(
     action: "preStop",
   });
 
-  childLogger.info("Received prestop request, waiting 10s");
-
   // Record pre-stop initiation.
   statsDClient.increment("prestop.requests");
 
-  // Wait 10s for load balancer propagation.
-  await setTimeoutAsync(10000);
+  // Phase 1: Signal shutdown immediately to fail readiness probe.
+  // This triggers the load balancer to stop sending new connections.
+  markShuttingDown();
+  childLogger.info("Shutdown initiated, readiness probe will now fail");
 
-  const preStopStartTime = Date.now();
+  // Phase 2: Wait for load balancer to propagate readiness=false.
+  childLogger.info(
+    { propagationMs: PRESTOP_LB_PROPAGATION_MS },
+    "Waiting for load balancer propagation"
+  );
+  await setTimeoutAsync(PRESTOP_LB_PROPAGATION_MS);
+
+  // Phase 3: Wait for wake locks (critical operations), max 120s.
+  const wakeLockStartTime = Date.now();
   let initialWakeLockCount: number | null = null;
 
   while (!wakeLockIsFree()) {
@@ -85,8 +98,8 @@ async function handler(
       });
     }
 
-    const elapsedMs = Date.now() - preStopStartTime;
-    const remainingMs = PRESTOP_MAX_WAIT_MS - elapsedMs;
+    const elapsedMs = Date.now() - wakeLockStartTime;
+    const remainingMs = PRESTOP_WAKE_LOCK_MAX_WAIT_MS - elapsedMs;
 
     // Show progress of longest-running wake locks.
     const longestRunning = wakeLockDetails
@@ -112,13 +125,14 @@ async function handler(
     );
 
     // Safety timeout to avoid exceeding grace period.
-    if (elapsedMs >= PRESTOP_MAX_WAIT_MS) {
+    if (elapsedMs >= PRESTOP_WAKE_LOCK_MAX_WAIT_MS) {
       childLogger.warn(
         {
-          timeoutMs: PRESTOP_MAX_WAIT_MS,
+          timeoutMs: PRESTOP_WAKE_LOCK_MAX_WAIT_MS,
           currentWakeLockCount,
           graceSecondsRemaining: Math.round(
-            (PRESTOP_GRACE_PERIOD_MS - elapsedMs) / 1000
+            (PRESTOP_GRACE_PERIOD_MS - PRESTOP_LB_PROPAGATION_MS - elapsedMs) /
+              1000
           ),
           activeWakeLocks: wakeLockDetails.map((lock) => ({
             context: lock.context,
@@ -126,7 +140,7 @@ async function handler(
             lockId: getLockShortId(lock),
           })),
         },
-        "Pre-stop timeout reached, terminating with active wake locks"
+        "Pre-stop wake lock timeout reached, terminating with active wake locks"
       );
 
       // Record timeout metrics.
@@ -140,24 +154,90 @@ async function handler(
     await setTimeoutAsync(PRESTOP_LOG_INTERVAL_MS);
   }
 
-  const totalWaitMs = Date.now() - preStopStartTime;
+  const wakeLockDurationMs = Date.now() - wakeLockStartTime;
 
   if (wakeLockIsFree()) {
     childLogger.info(
       {
-        totalWaitSeconds: Math.round(totalWaitMs / 1000),
+        wakeLockDurationMs,
+        wakeLockDurationSeconds: Math.round(wakeLockDurationMs / 1000),
       },
       "All wake locks cleared successfully"
     );
 
     // Record successful completion metrics.
-    statsDClient.increment("prestop.completions");
-    statsDClient.distribution("prestop.wait_duration_ms", totalWaitMs);
+    statsDClient.increment("prestop.wake_locks_cleared");
+    statsDClient.distribution(
+      "prestop.wake_lock_duration_ms",
+      wakeLockDurationMs
+    );
   } else {
     // Record forced termination metrics.
-    statsDClient.increment("prestop.forced_terminations");
-    statsDClient.distribution("prestop.forced_duration_ms", totalWaitMs);
+    statsDClient.increment("prestop.wake_locks_forced");
+    statsDClient.distribution(
+      "prestop.wake_lock_forced_duration_ms",
+      wakeLockDurationMs
+    );
   }
+
+  // Phase 4: Ensure we wait at least 60s total for connection draining.
+  // This allows existing SSE connections and HTTP requests to complete gracefully.
+  // Wait for MAX(wakeLockDuration, 60s).
+  const remainingDrainingWaitMs = Math.max(
+    0,
+    PRESTOP_MIN_DRAINING_WAIT_MS - wakeLockDurationMs
+  );
+
+  if (remainingDrainingWaitMs > 0) {
+    childLogger.info(
+      {
+        wakeLockDurationMs,
+        additionalDrainingWaitMs: remainingDrainingWaitMs,
+        totalDrainingTimeMs: PRESTOP_MIN_DRAINING_WAIT_MS,
+      },
+      "Waiting additional time for connection draining"
+    );
+
+    statsDClient.increment("prestop.draining_wait_additional");
+    statsDClient.distribution(
+      "prestop.draining_additional_wait_ms",
+      remainingDrainingWaitMs
+    );
+
+    await setTimeoutAsync(remainingDrainingWaitMs);
+  } else {
+    childLogger.info(
+      {
+        wakeLockDurationMs,
+        drainingRequirementMet: true,
+      },
+      "Connection draining period already satisfied by wake lock wait"
+    );
+
+    statsDClient.increment("prestop.draining_wait_satisfied_by_wake_locks");
+  }
+
+  const totalDurationMs =
+    PRESTOP_LB_PROPAGATION_MS +
+    Math.max(wakeLockDurationMs, PRESTOP_MIN_DRAINING_WAIT_MS);
+
+  childLogger.info(
+    {
+      totalDurationMs,
+      totalDurationSeconds: Math.round(totalDurationMs / 1000),
+      phaseLbPropagationMs: PRESTOP_LB_PROPAGATION_MS,
+      phaseWakeLockMs: wakeLockDurationMs,
+      phaseDrainingWaitMs: Math.max(
+        wakeLockDurationMs,
+        PRESTOP_MIN_DRAINING_WAIT_MS
+      ),
+    },
+    "PreStop complete, process can now exit"
+  );
+
+  // Record total prestop duration.
+  statsDClient.increment("prestop.completions");
+  statsDClient.distribution("prestop.total_duration_ms", totalDurationMs);
 
   res.status(200).end();
 }

--- a/front/pages/api/healthz/ready.ts
+++ b/front/pages/api/healthz/ready.ts
@@ -1,5 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
+import { isInShutdown } from "@app/lib/shutdown_signal";
 import { getStatsDClient } from "@app/lib/utils/statsd";
 
 const statsDClient = getStatsDClient();
@@ -11,6 +12,9 @@ const statsDClient = getStatsDClient();
  * traffic. It's kept simple and doesn't check dependencies to avoid marking all pods unready if
  * Redis/DB have transient issues.
  *
+ * During pod shutdown, this probe fails immediately to signal the load balancer to stop
+ * sending new connections and begin connection draining.
+ *
  * The startup probe (/api/healthz/startup) handles dependency checking at pod startup.
  */
 export default async function handler(
@@ -18,6 +22,16 @@ export default async function handler(
   res: NextApiResponse
 ) {
   const startMs = performance.now();
+
+  // Check if pod is shutting down.
+  if (isInShutdown()) {
+    const durationMs = performance.now() - startMs;
+    statsDClient.distribution("healthz.ready.duration_ms", durationMs);
+    statsDClient.increment("healthz.ready.shutdown");
+
+    res.status(503).json({ status: "shutting_down" });
+    return;
+  }
 
   // Simple check, just verify process is responsive.
   res.status(200).json({ status: "ready" });


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

### Problem

During deployments, pods terminate before existing connections can drain gracefully, causing:
- Abrupt SSE connection drops
- ~6-minute traffic bursts as clients rapidly reconnect
- Poor user experience during deployments

**Root Cause:** The prestop hook completes after 10-120s (waiting for wake locks), then immediately returns, causing the Node.js process to exit. This prevents GCP Load Balancer connection draining from working because the pod dies before the draining period can complete.

### Solution

This PR implements the application-side changes needed to support coordinated connection draining. The actual connection draining will be enabled in a separate infrastructure change on the `BackendConfig`.

_Key Insight:_ Connection draining only works if the pod stays alive for the full draining period. These changes ensure the prestop hook coordinates with the load balancer by:
1. Failing readiness probe immediately (signals LB to start draining)
2. Staying alive for the full draining period (allowing connections to close gracefully // Events on SSE will still be sent)

### Changes

1. New Global Shutdown Signal
- Tracks pod shutdown state
- Allows coordination between prestop hook and readiness probe

2. Updated Readiness Probe 
- Returns 503 immediately when pod enters shutdown
- Triggers load balancer to stop routing new traffic instantly
- Backward compatible: No impact without connectionDraining enabled

3. New Timing Constants
- PRESTOP_LB_PROPAGATION_MS = 10s - Load balancer propagation time
- PRESTOP_WAKE_LOCK_MAX_WAIT_MS = 120s - Maximum wait for critical operations
- PRESTOP_MIN_DRAINING_WAIT_MS = 60s - Minimum connection draining period

4. Restructured Prestop Handler
- Phase 1: Signal shutdown immediately (readiness fails)
- Phase 2: Wait 10s for load balancer propagation
- Phase 3: Wait for wake locks (up to 120s)
- Phase 4: Ensure minimum 60s wait for connection draining

**Logic:** Waits for MAX(wakeLockDuration, 60s) to satisfy both critical operations and connection draining requirements.

### Future State (After BackendConfig Update)

Once connectionDraining: `{ drainingTimeoutSec: 60 }` is added to BackendConfig (see PR: https://github.com/dust-tt/dust-infra/pull/607):
- Load balancer will actively drain connections for 60s
- Existing SSE connections remain ACTIVE and continue receiving events
- Backend processes requests normally on existing connections
- Connections close gracefully after 60s
- Clients auto-reconnect with jitter (3-8s) to healthy pods

Expected Impact:
- Deployment burst should reduce
- Graceful connection closes instead of abrupt drops
- Smooth user experience during deployments

### References

- https://cloud.google.com/load-balancing/docs/enabling-connection-draining
- https://medium.com/niveus-solutions/handling-session-affinity-and-backend-settings-in-gke-with-ingress-and-backendconfig-6be84f51a552
- https://cloud.google.com/load-balancing/docs/health-check-concepts

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
This will add a small overhead to all deploys as we need to wait at least 70 seconds. We might revisit this 60 seconds draining period later. It's safe to rollback. 

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
