### PR TITLE
[front] fix opacity of tool name and description in `ToolsList`

### DIFF
--- a/front/components/actions/mcp/ToolsList.tsx
+++ b/front/components/actions/mcp/ToolsList.tsx
@@ -83,9 +83,7 @@ const ToolItem = memo(
     };
 
     return (
-      <div
-        className={`flex flex-col gap-1 pb-2 ${!toolEnabled ? "opacity-50" : ""}`}
-      >
+      <div className="flex flex-col gap-1 pb-2">
         <div className="flex items-center gap-2">
           {mayUpdate && (
             <Checkbox checked={toolEnabled} onClick={handleToggle} />
@@ -164,7 +162,7 @@ export const ToolsList = memo(
             <CollapsibleContent>
               <>
                 <ContentMessage
-                  className="mb-4 w-full"
+                  className="mb-4 mt-2 w-full"
                   variant="blue"
                   size="lg"
                   icon={InformationCircleIcon}


### PR DESCRIPTION
## Description

- Close https://github.com/dust-tt/tasks/issues/5925.
- This PR fixes the padding above the content message and removes the opacity change when disabling a tool.

<img width="459" height="858" alt="Screenshot 2026-01-14 at 6 45 52 PM" src="https://github.com/user-attachments/assets/d12b640d-7d9f-4a67-8bd6-59a9bc6bdca4" />

## Tests

- Checked locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
