### PR TITLE
[front] enh: Dynamic rendering of Jira issues fields & relationships

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/jira/jira_api_helper.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/jira/jira_api_helper.ts
@@ -53,6 +53,8 @@ import { isTextExtractionSupportedContentType } from "@app/types/shared/text_ext
 
 import { sanitizeFilename } from "../../utils/file_utils";
 
+const DEFAULT_ISSUE_FIELDS = ["*navigable"];
+
 // Type guard to check if a value is an ADFDocument
 function isADFDocument(value: unknown): value is ADFDocument {
   return ADFDocumentSchema.safeParse(value).success;
@@ -227,24 +229,10 @@ export async function getIssue({
   issueKey: string;
   fields?: string[];
 }): Promise<Result<z.infer<typeof JiraIssueSchema> | null, JiraErrorResult>> {
-  // Use a minimal default field set to reduce payload size while keeping key metadata
-  const defaultFields = [
-    "summary",
-    "issuetype",
-    "priority",
-    "assignee",
-    "reporter",
-    "labels",
-    "duedate",
-    "parent",
-    "project",
-    "status",
-  ];
-
   const params = new URLSearchParams();
-  const fieldList = (fields && fields.length > 0 ? fields : defaultFields).join(
-    ","
-  );
+  const fieldList = (
+    fields && fields.length > 0 ? fields : DEFAULT_ISSUE_FIELDS
+  ).join(",");
   params.set("fields", fieldList);
 
   const result = await jiraApiCall(
@@ -514,7 +502,7 @@ export async function searchIssues(
   const requestBody: z.infer<typeof JiraSearchRequestSchema> = {
     jql,
     maxResults,
-    fields: ["summary"],
+    fields: DEFAULT_ISSUE_FIELDS,
   };
 
   if (nextPageToken) {
@@ -568,7 +556,7 @@ export async function searchJiraIssuesUsingJql(
   const {
     nextPageToken,
     maxResults = SEARCH_ISSUES_MAX_RESULTS,
-    fields = ["summary"],
+    fields = DEFAULT_ISSUE_FIELDS,
     // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   } = options || {};
 

--- a/front/lib/actions/mcp_internal_actions/servers/jira/jira_api_helper.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/jira/jira_api_helper.ts
@@ -23,7 +23,7 @@ import type {
   SortDirection,
 } from "@app/lib/actions/mcp_internal_actions/servers/jira/types";
 import {
-  ADFDocumentSchema,
+  isADFDocument,
   JiraAttachmentsResultSchema,
   JiraCommentSchema,
   JiraCommentsListSchema,
@@ -54,11 +54,6 @@ import { isTextExtractionSupportedContentType } from "@app/types/shared/text_ext
 import { sanitizeFilename } from "../../utils/file_utils";
 
 const DEFAULT_ISSUE_FIELDS = ["*navigable"];
-
-// Type guard to check if a value is an ADFDocument
-function isADFDocument(value: unknown): value is ADFDocument {
-  return ADFDocumentSchema.safeParse(value).success;
-}
 
 // Generic helper to handle errors consistently
 function handleResults<T>(

--- a/front/lib/actions/mcp_internal_actions/servers/jira/rendering.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/jira/rendering.ts
@@ -4,7 +4,7 @@ import { jsonToMarkdown } from "@app/lib/actions/mcp_internal_actions/utils";
 import { isStringArray } from "@app/types/shared/utils/general";
 
 import type { ADFContentNode, JiraComment, JiraIssue } from "./types";
-import { JiraCommentsListSchema } from "./types";
+import { isADFDocument, JiraCommentsListSchema } from "./types";
 
 function formatDateTime(dateString: string): string {
   return format(new Date(dateString), "yyyy-MM-dd HH:mm");
@@ -25,17 +25,6 @@ const PRIORITY_FIELD_ORDER = [
   "created",
   "updated",
 ];
-
-function isADFDocument(
-  value: object
-): value is { type: "doc"; version: 1; content?: ADFContentNode[] } {
-  return (
-    "type" in value &&
-    value.type === "doc" &&
-    "version" in value &&
-    value.version === 1
-  );
-}
 
 function formatFieldName(fieldName: string): string {
   const mappings: Record<string, string> = {

--- a/front/lib/actions/mcp_internal_actions/servers/jira/rendering.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/jira/rendering.ts
@@ -1,10 +1,165 @@
 import { format } from "date-fns";
 
+import { jsonToMarkdown } from "@app/lib/actions/mcp_internal_actions/utils";
+import { isStringArray } from "@app/types/shared/utils/general";
+
 import type { ADFContentNode, JiraComment, JiraIssue } from "./types";
 import { JiraCommentsListSchema } from "./types";
 
 function formatDateTime(dateString: string): string {
   return format(new Date(dateString), "yyyy-MM-dd HH:mm");
+}
+
+const SKIPPED_FIELDS = new Set(["summary", "description", "comment"]);
+const DATETIME_FIELDS = new Set(["created", "updated"]);
+const PRIORITY_FIELD_ORDER = [
+  "project",
+  "issuetype",
+  "status",
+  "priority",
+  "assignee",
+  "reporter",
+  "labels",
+  "duedate",
+  "parent",
+  "created",
+  "updated",
+];
+
+function isADFDocument(
+  value: object
+): value is { type: "doc"; version: 1; content?: ADFContentNode[] } {
+  return (
+    "type" in value &&
+    value.type === "doc" &&
+    "version" in value &&
+    value.version === 1
+  );
+}
+
+function formatFieldName(fieldName: string): string {
+  const mappings: Record<string, string> = {
+    issuetype: "Type",
+    duedate: "Due Date",
+  };
+  if (fieldName in mappings) {
+    return mappings[fieldName];
+  }
+  if (fieldName.startsWith("customfield_")) {
+    return fieldName.replace(/_/g, " ").replace(/^./, (s) => s.toUpperCase());
+  }
+  return fieldName
+    .replace(/([A-Z])/g, " $1")
+    .replace(/^./, (s) => s.toUpperCase())
+    .trim();
+}
+
+function renderIssueLink(link: object): string | null {
+  if (!("type" in link) || !("outwardIssue" in link || "inwardIssue" in link)) {
+    return null;
+  }
+
+  const outward = "outwardIssue" in link ? link.outwardIssue : null;
+  const inward = "inwardIssue" in link ? link.inwardIssue : null;
+  const linkedIssue = outward ?? inward;
+
+  if (
+    typeof linkedIssue !== "object" ||
+    linkedIssue === null ||
+    !("key" in linkedIssue)
+  ) {
+    return null;
+  }
+
+  const issueKey = typeof linkedIssue.key === "string" ? linkedIssue.key : null;
+  if (!issueKey) {
+    return null;
+  }
+
+  const type =
+    typeof link.type === "object" && link.type !== null ? link.type : null;
+  if (!type) {
+    return issueKey;
+  }
+
+  const relationship = outward
+    ? "outward" in type && typeof type.outward === "string"
+      ? type.outward
+      : null
+    : "inward" in type && typeof type.inward === "string"
+      ? type.inward
+      : null;
+
+  return relationship ? `${relationship} ${issueKey}` : issueKey;
+}
+
+function renderObjectValue(obj: unknown): string | null {
+  if (typeof obj !== "object" || obj === null) {
+    return null;
+  }
+
+  if ("type" in obj && ("outwardIssue" in obj || "inwardIssue" in obj)) {
+    return renderIssueLink(obj);
+  }
+
+  if ("name" in obj && typeof obj.name === "string") {
+    return obj.name;
+  }
+  if ("displayName" in obj && typeof obj.displayName === "string") {
+    return obj.displayName;
+  }
+  if ("accountId" in obj && typeof obj.accountId === "string") {
+    return obj.accountId;
+  }
+  if ("key" in obj && typeof obj.key === "string") {
+    return obj.key;
+  }
+  if ("value" in obj && typeof obj.value === "string") {
+    return obj.value;
+  }
+  if ("id" in obj && typeof obj.id === "string") {
+    return obj.id;
+  }
+
+  return null;
+}
+
+function renderFieldValue(value: unknown, isDateTime: boolean): string | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  if (typeof value === "string") {
+    if (value.trim() === "") {
+      return null;
+    }
+    return isDateTime ? formatDateTime(value) : value;
+  }
+
+  if (typeof value === "number") {
+    return String(value);
+  }
+
+  if (typeof value === "boolean") {
+    return value ? "Yes" : "No";
+  }
+
+  if (isStringArray(value)) {
+    return value.length > 0 ? value.join(", ") : null;
+  }
+
+  if (Array.isArray(value)) {
+    const rendered = value
+      .map((item) => renderObjectValue(item))
+      .filter((item): item is string => item !== null);
+    return rendered.length > 0 ? rendered.join(", ") : null;
+  }
+
+  if (typeof value === "object") {
+    return renderObjectValue(value);
+  }
+
+  return null;
 }
 
 function extractEmbeddedComments(issue: JiraIssue): JiraComment[] {
@@ -21,69 +176,76 @@ export function renderIssueWithEmbeddedComments(issue: JiraIssue): string {
 
 export function renderIssue(issue: JiraIssue, comments: JiraComment[]): string {
   const lines: string[] = [];
-  const fields = issue.fields;
+  const fields = issue.fields ?? {};
 
-  lines.push(`# ${issue.key}: ${fields?.summary ?? "No summary"}`);
+  const summary =
+    typeof fields.summary === "string" ? fields.summary : "No summary";
+  lines.push(`# ${issue.key}: ${summary}`);
   lines.push("");
 
   if (issue.browseUrl) {
     lines.push(`**URL:** ${issue.browseUrl}`);
   }
 
-  if (fields?.project?.key) {
-    lines.push(`**Project:** ${fields.project.key}`);
-  }
+  const fieldEntries = Object.entries(fields).filter(
+    ([key]) => !SKIPPED_FIELDS.has(key)
+  );
+  const priorityEntries = fieldEntries.filter(([key]) =>
+    PRIORITY_FIELD_ORDER.includes(key)
+  );
+  const remainingEntries = fieldEntries.filter(
+    ([key]) => !PRIORITY_FIELD_ORDER.includes(key)
+  );
 
-  if (fields?.issuetype?.name) {
-    lines.push(`**Type:** ${fields.issuetype.name}`);
-  }
+  priorityEntries.sort(
+    (a, b) =>
+      PRIORITY_FIELD_ORDER.indexOf(a[0]) - PRIORITY_FIELD_ORDER.indexOf(b[0])
+  );
+  remainingEntries.sort((a, b) => a[0].localeCompare(b[0]));
 
-  if (fields?.status?.name) {
-    lines.push(`**Status:** ${fields.status.name}`);
-  }
+  const complexFields: Array<[string, unknown]> = [];
 
-  if (fields?.priority?.name) {
-    lines.push(`**Priority:** ${fields.priority.name}`);
-  }
+  for (const [name, value] of [...priorityEntries, ...remainingEntries]) {
+    if (value === null || value === undefined) {
+      continue;
+    }
 
-  if (fields?.assignee) {
-    const assigneeName =
-      fields.assignee.displayName ?? fields.assignee.accountId ?? "Unknown";
-    lines.push(`**Assignee:** ${assigneeName}`);
-  }
+    if (typeof value === "object" && !Array.isArray(value)) {
+      if (isADFDocument(value)) {
+        complexFields.push([name, value]);
+        continue;
+      }
+    }
 
-  if (fields?.reporter) {
-    const reporterName =
-      fields.reporter.displayName ?? fields.reporter.accountId ?? "Unknown";
-    lines.push(`**Reporter:** ${reporterName}`);
-  }
-
-  if (fields?.labels && fields.labels.length > 0) {
-    lines.push(`**Labels:** ${fields.labels.join(", ")}`);
-  }
-
-  if (fields?.duedate) {
-    lines.push(`**Due Date:** ${fields.duedate}`);
-  }
-
-  if (fields?.parent?.key) {
-    lines.push(`**Parent:** ${fields.parent.key}`);
-  }
-
-  if (fields?.created) {
-    lines.push(`**Created:** ${formatDateTime(fields.created)}`);
-  }
-
-  if (fields?.updated) {
-    lines.push(`**Updated:** ${formatDateTime(fields.updated)}`);
+    const rendered = renderFieldValue(value, DATETIME_FIELDS.has(name));
+    if (rendered !== null) {
+      lines.push(`**${formatFieldName(name)}:** ${rendered}`);
+    } else if (
+      typeof value === "object" &&
+      value !== null &&
+      !Array.isArray(value)
+    ) {
+      complexFields.push([name, value]);
+    }
   }
 
   lines.push("");
 
-  if (fields?.description) {
+  if (fields.description) {
     lines.push("## Description");
     lines.push("");
     lines.push(renderADFToMarkdown(fields.description));
+    lines.push("");
+  }
+
+  for (const [name, value] of complexFields) {
+    lines.push(`## ${formatFieldName(name)}`);
+    lines.push("");
+    if (typeof value === "object" && value !== null && isADFDocument(value)) {
+      lines.push(renderADFToMarkdown(value));
+    } else {
+      lines.push(jsonToMarkdown(value));
+    }
     lines.push("");
   }
 

--- a/front/lib/actions/mcp_internal_actions/servers/jira/types.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/jira/types.ts
@@ -549,3 +549,7 @@ export type JiraAttachmentsResult = z.infer<typeof JiraAttachmentsResultSchema>;
 export type JiraIssueWithAttachments = z.infer<
   typeof JiraIssueWithAttachmentsSchema
 >;
+
+export function isADFDocument(value: unknown): value is ADFDocument {
+  return ADFDocumentSchema.safeParse(value).success;
+}


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/5922
Fixes https://github.com/dust-tt/tasks/issues/5898

Add markdown, dynamic rendering of Jira issue fields, with a focus on issue relationships, (blocked by, related to, blocking, etc) which were missing completely.


## Tests

Tested locally with our jira test space ([eng space](https://dust-team-acceleration.atlassian.net/jira/software/projects/ENG/boards/67))

<img width="1063" height="1140" alt="CleanShot 2026-01-14 at 19 58 32" src="https://github.com/user-attachments/assets/f61d0702-d487-4c73-990e-44bf5d7a9dae" />

<details><summary>Raw</summary>
<p>

````
{
  "params": {
    "filters": [
      {
        "field": "project",
        "value": "ENG"
      },
      {
        "field": "status",
        "value": "In Progress"
      }
    ]
  },
  "output": [
    {
      "text": "Found 3 issue(s)",
      "type": "text"
    },
    {
      "text": "Found 3 issue(s)\n\n# ENG-36: Buy a Smoothy machine\n\n**URL:** https://dust-team-acceleration.atlassian.net/browse/ENG-36\n**Project:** ENG\n**Type:** Task\n**Status:** In Progress\n**Priority:** Medium\n**Assignee:** Frank Aloia\n**Reporter:** Accounts Dust\n**Created:** 2026-01-14 18:38\n**Updated:** 2026-01-14 19:07\n**Creator:** Accounts Dust\n**Customfield 10019:** 0|i000z3:\n**Issuelinks:** blocks ENG-30\n**Last Viewed:** 2026-01-14T18:57:51.815+0100\n**Status Category:** In Progress\n**Statuscategorychangedate:** 2026-01-14T18:38:42.025+0100\n**Subtasks:** ENG-37, ENG-38, ENG-39, ENG-40\n**Workratio:** -1\n\n## Aggregateprogress\n\n- **progress:** 0\n- **total:** 0\n\n## Progress\n\n- **progress:** 0\n- **total:** 0\n\n## Votes\n\n- **self:** https://api.atlassian.com/ex/jira/38aabb32-c150-4b4c-a360-294d04be2f43/rest/api/3/issue/ENG-36/votes\n- **votes:** 0\n- **hasVoted:** false\n\n## Watches\n\n- **self:** https://api.atlassian.com/ex/jira/38aabb32-c150-4b4c-a360-294d04be2f43/rest/api/3/issue/ENG-36/watchers\n- **watchCount:** 1\n- **isWatching:** true\n\n\n--------------------------------------------------------------------------------\n\n# ENG-30: perf issues\n\n**URL:** https://dust-team-acceleration.atlassian.net/browse/ENG-30\n**Project:** ENG\n**Type:** Task\n**Status:** In Progress\n**Priority:** High\n**Reporter:** Dora Marques\n**Labels:** performance, potential-outage\n**Created:** 2025-11-20 10:26\n**Updated:** 2026-01-14 19:08\n**Creator:** Dora Marques\n**Customfield 10019:** 0|i000vr:\n**Issuelinks:** is blocked by ENG-36, relates to ENG-29\n**Last Viewed:** 2026-01-14T19:22:14.606+0100\n**Status Category:** In Progress\n**Statuscategorychangedate:** 2025-11-20T10:35:20.118+0100\n**Workratio:** -1\n\n## Aggregateprogress\n\n- **progress:** 0\n- **total:** 0\n\n## Progress\n\n- **progress:** 0\n- **total:** 0\n\n## Votes\n\n- **self:** https://api.atlassian.com/ex/jira/38aabb32-c150-4b4c-a360-294d04be2f43/rest/api/3/issue/ENG-30/votes\n- **votes:** 0\n- **hasVoted:** false\n\n## Watches\n\n- **self:** https://api.atlassian.com/ex/jira/38aabb32-c150-4b4c-a360-294d04be2f43/rest/api/3/issue/ENG-30/watchers\n- **watchCount:** 3\n- **isWatching:** false\n\n\n--------------------------------------------------------------------------------\n\n# ENG-29: app is slow\n\n**URL:** https://dust-team-acceleration.atlassian.net/browse/ENG-29\n**Project:** ENG\n**Type:** Task\n**Status:** In Progress\n**Priority:** High\n**Reporter:** Dora Marques\n**Labels:** performance, potential-outage\n**Created:** 2025-11-20 10:26\n**Updated:** 2026-01-14 19:08\n**Creator:** Dora Marques\n**Customfield 10019:** 0|i000vj:\n**Issuelinks:** relates to ENG-30\n**Last Viewed:** 2026-01-14T19:08:03.531+0100\n**Status Category:** In Progress\n**Statuscategorychangedate:** 2025-11-20T10:38:01.137+0100\n**Workratio:** -1\n\n## Aggregateprogress\n\n- **progress:** 0\n- **total:** 0\n\n## Progress\n\n- **progress:** 0\n- **total:** 0\n\n## Votes\n\n- **self:** https://api.atlassian.com/ex/jira/38aabb32-c150-4b4c-a360-294d04be2f43/rest/api/3/issue/ENG-29/votes\n- **votes:** 0\n- **hasVoted:** false\n\n## Watches\n\n- **self:** https://api.atlassian.com/ex/jira/38aabb32-c150-4b4c-a360-294d04be2f43/rest/api/3/issue/ENG-29/watchers\n- **watchCount:** 3\n- **isWatching:** false\n",
      "type": "text"
    }
  ],
  "generatedFiles": []
}
````

</p>
</details> 

## Risk

Low - we change rendering, adding more fields available, but potentially some edge cases not covered
Blast radius: Jira tool users

## Deploy Plan

- [ ] Deploy front