### PR TITLE
dx: share specific dust skills

### DIFF
--- a/.claude/skills/dust-llm/SKILL.md
+++ b/.claude/skills/dust-llm/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dust-llm
-description: Step-by-step guide for adding support for a new LLM model in Dust. Use when adding a new AI model, supporting a new provider model, or updating model configurations.
+description: Step-by-step guide for adding support for a new LLM in Dust. Use when adding a new model, or updating a previous one.
 ---
 
 # Adding Support for a New LLM Model

--- a/.claude/skills/dust-llm/SKILL.md
+++ b/.claude/skills/dust-llm/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: dust-llm
+description: Step-by-step guide for adding support for a new LLM model in Dust. Use when adding a new AI model, supporting a new provider model, or updating model configurations.
+---
+
+# Adding Support for a New LLM Model
+
+This skill guides you through adding support for a newly released LLM.
+
+## Quick Reference
+
+### Files to Modify
+
+| File | Purpose |
+|------|---------|
+| `front/types/assistant/models/{provider}.ts` | Model ID + configuration |
+| `front/lib/api/assistant/token_pricing.ts` | Pricing per million tokens |
+| `front/types/assistant/models/models.ts` | Central registry |
+| `front/lib/api/llm/clients/{provider}/types.ts` | Router whitelist |
+| `sdks/js/src/types.ts` | SDK types |
+| `front/components/providers/types.ts` | UI availability (optional) |
+| `front/lib/api/llm/tests/llm.test.ts` | Integration tests |
+
+### Prerequisites
+
+Before adding, gather:
+- **Model ID**: Exact provider identifier (e.g., `gpt-4-turbo-2024-04-09`)
+- **Context size**: Total context window in tokens
+- **Pricing**: Input/output cost per million tokens
+- **Capabilities**: Vision, structured output, reasoning effort levels
+- **Tokenizer**: Compatible tokenizer for token counting
+
+## Step-by-Step: Adding an OpenAI Model
+
+### Step 1: Add Model Configuration
+
+Edit `front/types/assistant/models/openai.ts`:
+
+```typescript
+export const GPT_4_TURBO_2024_04_09_MODEL_ID = "gpt-4-turbo-2024-04-09" as const;
+
+export const GPT_4_TURBO_2024_04_09_MODEL_CONFIG: ModelConfigurationType = {
+  providerId: "openai",
+  modelId: GPT_4_TURBO_2024_04_09_MODEL_ID,
+  displayName: "GPT 4 turbo",
+  contextSize: 128_000,
+  recommendedTopK: 32,
+  recommendedExhaustiveTopK: 64,
+  largeModel: true,
+  description: "OpenAI's GPT 4 Turbo model for complex tasks (128k context).",
+  shortDescription: "OpenAI's second best model.",
+  isLegacy: false,
+  isLatest: false,
+  generationTokensCount: 2048,
+  supportsVision: true,
+  minimumReasoningEffort: "none",
+  maximumReasoningEffort: "none",
+  defaultReasoningEffort: "none",
+  supportsResponseFormat: false,
+  tokenizer: { type: "tiktoken", base: "cl100k_base" },
+};
+```
+
+### Step 2: Add Pricing
+
+Edit `front/lib/api/assistant/token_pricing.ts`:
+
+```typescript
+const CURRENT_MODEL_PRICING: Record<BaseModelIdType, PricingEntry> = {
+  // ... existing
+  "gpt-4-turbo-2024-04-09": {
+    input: 10.0,  // USD per million input tokens
+    output: 30.0, // USD per million output tokens
+    cache_read_input_tokens: 1.0,      // Optional: cached reads
+    cache_creation_input_tokens: 12.5, // Optional: cache creation
+  },
+};
+```
+
+### Step 3: Register in Central Registry
+
+Edit `front/types/assistant/models/models.ts`:
+
+```typescript
+export const MODEL_IDS = [
+  // ... existing
+  GPT_4_TURBO_2024_04_09_MODEL_ID,
+] as const;
+
+export const SUPPORTED_MODEL_CONFIGS: ModelConfigurationType[] = [
+  // ... existing
+  GPT_4_TURBO_2024_04_09_MODEL_CONFIG,
+];
+```
+
+### Step 4: Update Router Whitelist
+
+Edit `front/lib/api/llm/clients/openai/types.ts`:
+
+```typescript
+export const OPENAI_WHITELISTED_MODEL_IDS = [
+  // ... existing
+  GPT_4_TURBO_2024_04_09_MODEL_ID,
+] as const;
+```
+
+### Step 5: Update SDK Types
+
+Edit `sdks/js/src/types.ts`:
+
+```typescript
+const ModelLLMIdSchema = FlexibleEnumSchema<
+  // ... existing
+  | "gpt-4-turbo-2024-04-09"
+>();
+```
+
+### Step 6: Add to UI (Optional)
+
+Edit `front/components/providers/types.ts`:
+
+```typescript
+export const USED_MODEL_CONFIGS: readonly ModelConfig[] = [
+  // ... existing
+  GPT_4_TURBO_2024_04_09_MODEL_CONFIG,
+] as const;
+```
+
+### Step 7: Test (Mandatory)
+
+Edit `front/lib/api/llm/tests/llm.test.ts`:
+
+```typescript
+const MODELS = {
+  // ... existing
+  [GPT_4_TURBO_2024_04_09_MODEL_ID]: {
+    runTest: true,  // Enable for testing
+    providerId: "openai",
+  },
+};
+```
+
+Run test:
+```bash
+RUN_LLM_TEST=true npx vitest --config lib/api/llm/tests/vite.config.js lib/api/llm/tests/llm.test.ts --run
+```
+
+**After test passes**, set `runTest: false` to avoid expensive CI runs.
+
+## Adding Anthropic Models
+
+Same pattern with Anthropic-specific files:
+
+1. `front/types/assistant/models/anthropic.ts` - Add `CLAUDE_X_MODEL_ID` and config
+2. `front/lib/api/llm/clients/anthropic/types.ts` - Add to `ANTHROPIC_WHITELISTED_MODEL_IDS`
+3. `front/types/assistant/models/models.ts` - Register in central registry
+4. `front/lib/api/assistant/token_pricing.ts` - Add pricing
+5. `sdks/js/src/types.ts` - Update SDK types
+6. Test and validate
+
+## Model Configuration Properties
+
+| Property | Description |
+|----------|-------------|
+| `supportsVision` | Can process images |
+| `supportsResponseFormat` | Supports structured output (JSON) |
+| `minimumReasoningEffort` | Min reasoning level ("none", "low", "medium", "high") |
+| `maximumReasoningEffort` | Max reasoning level |
+| `defaultReasoningEffort` | Default reasoning level |
+| `tokenizer` | Tokenizer config for token counting |
+
+## Validation Checklist
+
+- [ ] Model config added to provider file
+- [ ] Pricing updated (input, output, cache if applicable)
+- [ ] Registered in central registry (`MODEL_IDS` + `SUPPORTED_MODEL_CONFIGS`)
+- [ ] Router whitelist updated
+- [ ] SDK types updated
+- [ ] UI config added (if needed)
+- [ ] Integration test passes
+- [ ] Test disabled after validation
+
+## Troubleshooting
+
+**Model not in UI**: Check `USED_MODEL_CONFIGS` in `front/components/providers/types.ts`
+
+**API calls failing**: Verify model ID matches provider's exact identifier, check router whitelist
+
+**Token counting errors**: Validate context size and tokenizer configuration
+
+**Pricing issues**: Ensure prices are per million tokens in USD
+
+## Reference
+
+- See `front/types/assistant/models/openai.ts` and `anthropic.ts` for examples
+- Provider docs: OpenAI, Anthropic, Google, Mistral

--- a/.claude/skills/dust-mcp-server/SKILL.md
+++ b/.claude/skills/dust-mcp-server/SKILL.md
@@ -1,0 +1,240 @@
+---
+name: dust-mcp-server
+description: Step-by-step guide for creating new internal MCP server integrations in Dust that connect to remote platforms (Jira, HubSpot, Salesforce, etc.). Use when adding a new MCP server, implementing a platform integration, or connecting Dust to a new external service.
+---
+
+# Adding Internal MCP Server Integrations
+
+This skill guides you through creating new internal MCP server integrations in Dust that connect to remote platforms.
+
+## Quick Reference
+
+### Minimal Files Needed
+
+1. `front/lib/actions/mcp_internal_actions/constants.ts` - Add server to `AVAILABLE_INTERNAL_MCP_SERVER_NAMES` and `INTERNAL_MCP_SERVERS`
+2. `front/lib/actions/mcp_internal_actions/servers/{provider}.ts` - Server implementation with tools
+3. `front/lib/actions/mcp_internal_actions/servers/index.ts` - Register server in switch statement
+
+If the server code does not fit in one file, split into a folder with `index.ts` default-exporting `createServer`.
+
+### OAuth Requirements (if needed)
+
+- OAuth provider must exist in `front/lib/api/oauth/providers/{provider}.ts`
+- OAuth core implementation must exist in `core/src/oauth/providers/{provider}.rs`
+- Server's `authorization` field must reference the OAuth provider
+
+### Common Gotchas
+
+- Add server to `AVAILABLE_INTERNAL_MCP_SERVER_NAMES` array
+- Server IDs must be stable and unique - never change after deployment
+- Configure tool stakes appropriately (never_ask, low, high)
+- Always implement proper error handling with Result types
+
+## Prerequisites
+
+### OAuth Configuration Check
+
+If the platform requires OAuth:
+
+1. Check if OAuth provider exists: `core/src/oauth/providers/{provider}.rs`
+2. Check if front OAuth provider exists: `front/lib/api/oauth/providers/{provider}.ts`
+
+If OAuth provider does NOT exist, implement it first in `core` or ask the user if they want to proceed with that first.
+
+### Research Phase
+
+Before implementing, research:
+
+1. **API Documentation** - REST vs GraphQL vs SDK, rate limits, pagination
+2. **Authentication** - OAuth 2.0 (preferred) or API Key/Bearer Token
+3. **Operations** - Read (list, get, search), Write (create, update, delete), Special operations
+
+## Step-by-Step Implementation
+
+### Step 1: Add Server to Constants
+
+Edit `front/lib/actions/mcp_internal_actions/constants.ts`:
+
+```typescript
+// 1. Add to AVAILABLE_INTERNAL_MCP_SERVER_NAMES array
+export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
+  // ... existing servers
+  "your_provider", // <- Add here (alphabetically sorted)
+] as const;
+
+// 2. Add to INTERNAL_MCP_SERVERS object
+export const INTERNAL_MCP_SERVERS = {
+  your_provider: {
+    id: 99, // Use next available unique ID
+    availability: "manual", // or "auto"
+    allowMultipleInstances: true, // true for OAuth-based
+    isRestricted: undefined,
+    isPreview: false,
+    tools_stakes: {
+      get_item: "never_ask",
+      list_items: "never_ask",
+      create_item: "low",
+      delete_item: "high",
+    },
+    tools_retry_policies: undefined,
+    timeoutMs: undefined,
+    serverInfo: {
+      name: "your_provider",
+      version: "1.0.0",
+      description: "Short description.",
+      authorization: {
+        provider: "your_provider" as const,
+        supported_use_cases: ["platform_actions", "personal_actions"] as const,
+      },
+      icon: "YourProviderLogo",
+      documentationUrl: "https://docs.dust.tt/docs/your-provider",
+      instructions: null,
+    },
+  },
+};
+```
+
+### Step 2: Create API Helper
+
+Create `front/lib/actions/mcp_internal_actions/servers/{provider}/{provider}_api_helper.ts`:
+
+- Define TypeScript interfaces for API responses
+- Export async functions for each API operation
+- Use `Result<T, Error>` return types from `@app/types`
+- Accept `accessToken` as first parameter for OAuth APIs
+
+See `servers/jira/jira_api_helper.ts` or `servers/hubspot/hubspot_api_helper.ts` for examples.
+
+### Step 3: Create Utility Functions (Optional)
+
+Create `front/lib/actions/mcp_internal_actions/servers/{provider}/{provider}_utils.ts`:
+
+- `withAuth` helper to extract OAuth token and handle errors
+- Error message constants
+- Response formatting helpers
+
+See `servers/hubspot/hubspot_utils.ts` for reference.
+
+### Step 4: Create Server Implementation
+
+Create `front/lib/actions/mcp_internal_actions/servers/{provider}/index.ts`:
+
+1. Export default function creating McpServer
+2. Use `makeInternalMCPServer("your_provider")`
+3. Register tools with `server.tool()`:
+   - Tool name (must match `tools_stakes` key)
+   - Description
+   - Zod schema with `.describe()` for each field
+   - Async handler using `withAuth` wrapper
+
+See `servers/jira/index.ts` or `servers/notion.ts` for examples.
+
+### Step 5: Register Server in Index
+
+Edit `front/lib/actions/mcp_internal_actions/servers/index.ts`:
+
+1. Add import at top
+2. Add case in `getInternalMCPServer` switch statement
+
+### Step 6: Icon
+
+Use an existing similar icon temporarily. Request final icon from designer for Sparkle.
+
+## Tool Stakes Guide
+
+| Stake Level | When to Use | Examples |
+|-------------|-------------|----------|
+| `never_ask` | Read-only, no side effects | list_items, get_item, search |
+| `low` | Write with minimal impact | create_comment, add_tag |
+| `high` | Destructive/high-impact | delete_item, send_email |
+
+## Best Practices
+
+### Error Handling
+
+Use Result types. Translate API errors into actionable messages.
+
+### Response Rendering (Important for Token Efficiency)
+
+Implement functions converting API output to clean, focused, Markdown text. See `servers/zendesk/rendering.ts`.
+
+**Do:**
+- Select only relevant fields
+- Start with brief summary
+- Use consistent formats
+
+**Don't:**
+- Return raw `JSON.stringify(apiResponse)`
+- Include pagination metadata, rate limit info
+
+### Tool Descriptions
+
+Write clear descriptions including:
+- What the tool does
+- Required vs optional parameters
+- What it returns
+- Limitations/prerequisites
+
+### Validate External API Responses
+
+Use Zod schemas to validate external API responses:
+
+```typescript
+const ItemSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+}).passthrough();
+
+const parseResult = schema.safeParse(rawData);
+if (!parseResult.success) {
+  return new Err(new Error(`Invalid API response: ${parseResult.error.message}`));
+}
+```
+
+See `servers/zendesk/types.ts` and `servers/zendesk/client.ts` for examples.
+
+## Validation Checklist
+
+- [ ] Server added to `AVAILABLE_INTERNAL_MCP_SERVER_NAMES`
+- [ ] Server configuration added to `INTERNAL_MCP_SERVERS`
+- [ ] Server registered in `servers/index.ts` switch statement
+- [ ] API helper functions with proper error handling
+- [ ] All tools defined with appropriate stakes
+- [ ] Response pruning implemented
+- [ ] OAuth provider configured (if needed)
+- [ ] Temporary icon set
+- [ ] Feature flag configured (if preview)
+- [ ] Manual testing completed
+
+## Troubleshooting
+
+### Server Not Appearing in Builder
+
+- Check `availability` setting
+- Check `isRestricted` function
+- Verify server is in `AVAILABLE_INTERNAL_MCP_SERVER_NAMES`
+
+### OAuth Connection Failing
+
+- Verify OAuth provider exists in both `core` and `front`
+- Check client ID/secret environment variables
+- Verify redirect URI whitelisted
+- Check OAuth scopes
+
+### Tools Not Working
+
+- Verify tool registered in server
+- Check `tools_stakes` includes tool name
+- Test API helpers directly
+- Check authInfo.token passed correctly
+
+### Type Errors
+
+- Ensure server name in `AVAILABLE_INTERNAL_MCP_SERVER_NAMES`
+- Run `npm run type-check`
+
+## Reference Implementations
+
+- **Simple OAuth**: `servers/hubspot/`
+- **Complex with pagination**: `servers/jira/`
+- **Multiple auth use cases**: `servers/github/`

--- a/.claude/skills/dust-temporal/SKILL.md
+++ b/.claude/skills/dust-temporal/SKILL.md
@@ -1,0 +1,237 @@
+---
+name: dust-temporal
+description: Step-by-step guide for creating Temporal workflows in Dust. Use when adding background jobs, async processing, durable workflows, or task queues.
+---
+
+# Creating Temporal Workflows
+
+This skill guides you through creating Temporal workflows for durable background processing.
+
+## Quick Reference
+
+### Files Structure (per queue)
+
+```
+temporal/your_queue/
+├── config.ts          # Queue name and version
+├── helpers.ts         # Workflow ID generators
+├── activities.ts      # Activity implementations (DB, API calls)
+├── workflows.ts       # Workflow orchestration
+├── worker.ts          # Worker setup
+└── client.ts          # Workflow launcher functions
+```
+
+### Key Concepts
+
+- **Workflow**: Durable, deterministic function that orchestrates activities
+- **Activity**: Non-deterministic function with side effects (DB, API calls)
+- **Task Queue**: Named queue where workflows/activities execute
+- **Workflow ID**: Unique identifier for idempotency
+
+## Step-by-Step Implementation
+
+### Step 1: Create Queue Configuration
+
+Create `temporal/your_queue/config.ts`:
+
+```typescript
+const QUEUE_VERSION = 1;
+export const QUEUE_NAME = `your-queue-v${QUEUE_VERSION}`;
+```
+
+### Step 2: Create Workflow ID Helper
+
+Create `temporal/your_queue/helpers.ts`:
+
+```typescript
+export function makeYourWorkflowId({ entityId }: { entityId: string }): string {
+  return `your-workflow-${entityId}`;
+}
+```
+
+**Important:** Workflow IDs must be deterministic (same inputs = same ID) for idempotency.
+
+### Step 3: Create Activities
+
+Create `temporal/your_queue/activities.ts`:
+
+```typescript
+import { YourResource } from "@app/lib/resources/your_resource";
+import logger from "@app/logger/logger";
+
+export async function yourActivity({
+  entityId,
+  workspaceId,
+}: {
+  entityId: string;
+  workspaceId: number;
+}): Promise<void> {
+  const entity = await YourResource.fetchById(entityId);
+  if (!entity) {
+    throw new Error(`Entity not found: ${entityId}`);
+  }
+
+  const result = await entity.doSomething();
+  if (result.isErr()) {
+    logger.error({ entityId, error: result.error }, "Failed to process entity");
+    throw new Error(`Failed to process: ${result.error.message}`);
+  }
+}
+```
+
+**Guidelines:** Activities perform side effects, can throw (Temporal retries), should be idempotent.
+
+### Step 4: Create Workflow
+
+Create `temporal/your_queue/workflows.ts`:
+
+```typescript
+import { proxyActivities } from "@temporalio/workflow";
+import type * as activities from "@app/temporal/your_queue/activities";
+
+const { yourActivity } = proxyActivities<typeof activities>({
+  startToCloseTimeout: "5 minutes",
+});
+
+export async function yourWorkflow({
+  entityId,
+  workspaceId,
+}: {
+  entityId: string;
+  workspaceId: number;
+}): Promise<void> {
+  await yourActivity({ entityId, workspaceId });
+}
+```
+
+**Guidelines:** Workflows are deterministic - no `Math.random()`, `Date.now()`, etc.
+
+### Step 5: Create Client Launcher
+
+Create `temporal/your_queue/client.ts`:
+
+```typescript
+import { WorkflowExecutionAlreadyStartedError } from "@temporalio/client";
+import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
+import logger from "@app/logger/logger";
+import { QUEUE_NAME } from "@app/temporal/your_queue/config";
+import { makeYourWorkflowId } from "@app/temporal/your_queue/helpers";
+import { yourWorkflow } from "@app/temporal/your_queue/workflows";
+import type { Result } from "@app/types";
+import { Err, normalizeError, Ok } from "@app/types";
+
+export async function launchYourWorkflow({
+  entityId,
+  workspaceId,
+}: {
+  entityId: string;
+  workspaceId: number;
+}): Promise<Result<undefined, Error>> {
+  const client = await getTemporalClientForFrontNamespace();
+  const workflowId = makeYourWorkflowId({ entityId });
+
+  try {
+    await client.workflow.start(yourWorkflow, {
+      args: [{ entityId, workspaceId }],
+      taskQueue: QUEUE_NAME,
+      workflowId,
+      memo: { entityId, workspaceId },
+    });
+    return new Ok(undefined);
+  } catch (e) {
+    if (!(e instanceof WorkflowExecutionAlreadyStartedError)) {
+      logger.error({ workflowId, entityId, workspaceId, error: e }, "Failed starting workflow");
+    }
+    return new Err(normalizeError(e));
+  }
+}
+```
+
+### Step 6: Create Worker
+
+Create `temporal/your_queue/worker.ts`:
+
+```typescript
+import type { Context } from "@temporalio/activity";
+import { Worker } from "@temporalio/worker";
+import { getTemporalWorkerConnection, TEMPORAL_MAXED_CACHED_WORKFLOWS } from "@app/lib/temporal";
+import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
+import logger from "@app/logger/logger";
+import * as activities from "@app/temporal/your_queue/activities";
+import { getWorkflowConfig } from "@app/temporal/bundle_helper";
+import { QUEUE_NAME } from "./config";
+
+export async function runYourQueueWorker() {
+  const { connection, namespace } = await getTemporalWorkerConnection();
+
+  const worker = await Worker.create({
+    ...getWorkflowConfig({
+      workerName: "your_queue",
+      getWorkflowsPath: () => require.resolve("./workflows"),
+    }),
+    activities,
+    taskQueue: QUEUE_NAME,
+    maxCachedWorkflows: TEMPORAL_MAXED_CACHED_WORKFLOWS,
+    maxConcurrentActivityTaskExecutions: 16,
+    connection,
+    namespace,
+    interceptors: {
+      activityInbound: [(ctx: Context) => new ActivityInboundLogInterceptor(ctx, logger)],
+    },
+  });
+
+  await worker.run();
+}
+```
+
+### Step 7: Register Worker (Critical!)
+
+Edit `temporal/worker_registry.ts`:
+
+```typescript
+// 1. Add import
+import { runYourQueueWorker } from "@app/temporal/your_queue/worker";
+
+// 2. Add to WorkerName type
+export type WorkerName =
+  | "agent_loop"
+  // ... existing workers
+  | "your_queue"; // <- Add this
+
+// 3. Add to workerFunctions mapping
+export const workerFunctions: Record<WorkerName, () => Promise<void>> = {
+  // ... existing workers
+  your_queue: runYourQueueWorker, // <- Add this
+};
+```
+
+**Without registration, workflows will never execute!**
+
+## Timeout & Retry Configuration
+
+```typescript
+const { yourActivity } = proxyActivities<typeof activities>({
+  startToCloseTimeout: "5 minutes",
+  retry: {
+    maximumAttempts: 3,
+    initialInterval: "1s",
+    backoffCoefficient: 2,
+    maximumInterval: "1m",
+    nonRetryableErrorTypes: ["ValidationError"],
+  },
+});
+```
+
+## Validation Checklist
+
+- [ ] Queue config created with versioned name
+- [ ] Workflow ID helper is deterministic
+- [ ] Activities handle errors properly
+- [ ] Workflow uses `proxyActivities` with appropriate timeouts
+- [ ] Client returns `Result<>` and handles `WorkflowExecutionAlreadyStartedError`
+- [ ] Worker registered in `worker_registry.ts`
+- [ ] Tested locally
+
+## Reference Examples
+
+See `temporal/` directory for existing implementations.

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,11 @@ qdrant_storage
 core-api-keys.json
 oauth-api-keys.json
 /extension/build/
-**/.claude
+**/.claude/*
+!**/.claude/skills/
+**/.claude/skills/*
+!**/.claude/skills/dust-*/
+**/.claude/skills/dust-hive/
 **/.codex
 **/.yalc
 yalc.lock


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

This PR adds shared Claude skills for every Dust engineer.

Started with 3 basic skills, directly generated from @ front/runbooks. They obviously can be iterated on. 
Settle on the rule that :
- any skill starting by "dust-" is committed
- dust-hive is ignored
- any other skill is ignored

This way we can keep personal skills private, and dust-created ones shared with the team.
We could also say that if you want a private skill you'd better put it in ~./claude and that all of dust/.claude/skills is committed. Happy to revisit, we'd get rid of the "dust-" prefix requirement.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Used those locally, you can trigger and discover them.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Merge