### PR TITLE
[front] enh: ignore "Connector not stopped" errors when restoring workspace

### DIFF
--- a/front/lib/api/subscription.ts
+++ b/front/lib/api/subscription.ts
@@ -34,14 +34,14 @@ export async function restoreWorkspaceAfterSubscription(auth: Authenticator) {
   const dataSources = await getDataSources(auth);
   const connectorIds = removeNulls(dataSources.map((ds) => ds.connectorId));
 
-  const connectorsApi = new ConnectorsAPI(
+  const connectorsAPI = new ConnectorsAPI(
     apiConfig.getConnectorsAPIConfig(),
     logger
   );
 
   for (const connectorId of connectorIds) {
-    const r = await connectorsApi.unpauseConnector(connectorId);
-    if (r.isErr()) {
+    const r = await connectorsAPI.unpauseConnector(connectorId);
+    if (r.isErr() && r.error.message !== "Connector is not stopped") {
       logger.error(
         {
           connectorId,

--- a/front/lib/api/subscription.ts
+++ b/front/lib/api/subscription.ts
@@ -42,7 +42,12 @@ export async function restoreWorkspaceAfterSubscription(auth: Authenticator) {
     const r = await connectorsApi.unpauseConnector(connectorId);
     if (r.isErr()) {
       logger.error(
-        { connectorId, stripeError: true, error: r.error },
+        {
+          workspaceId: owner.sId,
+          connectorId,
+          stripeError: true,
+          error: r.error,
+        },
         "Error unpausing connector after subscription reactivation."
       );
     }

--- a/front/lib/api/subscription.ts
+++ b/front/lib/api/subscription.ts
@@ -18,10 +18,8 @@ import { ConnectorsAPI, removeNulls } from "@app/types";
  * - Re-enables all triggers that point to non-archived agents
  */
 export async function restoreWorkspaceAfterSubscription(auth: Authenticator) {
-  const owner = auth.workspace();
-  if (!owner) {
-    throw new Error("Missing workspace on auth.");
-  }
+  const owner = auth.getNonNullableWorkspace();
+
   const scrubCancelRes = await terminateScheduleWorkspaceScrubWorkflow({
     workspaceId: owner.sId,
     stopReason: "Workspace subscription activated/reactivated",
@@ -32,34 +30,41 @@ export async function restoreWorkspaceAfterSubscription(auth: Authenticator) {
       "Error terminating scrub workspace workflow."
     );
   }
+
   const dataSources = await getDataSources(auth);
   const connectorIds = removeNulls(dataSources.map((ds) => ds.connectorId));
+
   const connectorsApi = new ConnectorsAPI(
     apiConfig.getConnectorsAPIConfig(),
     logger
   );
+
   for (const connectorId of connectorIds) {
     const r = await connectorsApi.unpauseConnector(connectorId);
     if (r.isErr()) {
       logger.error(
         {
-          workspaceId: owner.sId,
           connectorId,
           stripeError: true,
           error: r.error,
+          workspaceId: owner.sId,
         },
         "Error unpausing connector after subscription reactivation."
       );
     }
   }
 
-  // Re-enable all triggers that point to non-archived agents
+  // Re-enable all triggers that point to non-archived agents.
   const enableTriggersRes = await TriggerResource.enableAllForWorkspace(auth);
   if (enableTriggersRes.isErr()) {
     logger.error(
-      { stripeError: true, error: enableTriggersRes.error },
+      {
+        stripeError: true,
+        error: enableTriggersRes.error,
+        workspaceId: owner.sId,
+      },
       "Error re-enabling workspace triggers on subscription reactivation"
     );
-    // Don't throw error here - we want the function to continue even if trigger re-enabling fails
+    // Don't throw an error here, we want the function to continue even if trigger re-enabling fails.
   }
 }


### PR DESCRIPTION
## Description

- We get this stripe error [log](https://app.datadoghq.eu/dashboard/i8e-twv-3vr/stripe-monitoring?fromUser=false&refresh_mode=sliding&from_ts=1768377514149&to_ts=1768463914149&live=true) when restoring a workspace once they resubscribed if their connector was already unpaused.
- This PR ignores this case and adds the workspace ID to the logs.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
