### PR TITLE
[front] fix(workspace-deletion): fix order of deletions for webhook sources

### DIFF
--- a/front/lib/resources/webhook_source_resource.ts
+++ b/front/lib/resources/webhook_source_resource.ts
@@ -168,8 +168,10 @@ export class WebhookSourceResource extends BaseResource<WebhookSourceModel> {
     auth: Authenticator,
     { transaction }: { transaction?: Transaction | undefined } = {}
   ): Promise<Result<undefined, Error>> {
+    const canAdministrate =
+      await SpaceResource.canAdministrateSystemSpace(auth);
     assert(
-      await SpaceResource.canAdministrateSystemSpace(auth),
+      canAdministrate,
       "The user is not authorized to delete a webhook source"
     );
 

--- a/front/lib/resources/webhook_source_resource.ts
+++ b/front/lib/resources/webhook_source_resource.ts
@@ -168,6 +168,7 @@ export class WebhookSourceResource extends BaseResource<WebhookSourceModel> {
     auth: Authenticator,
     { transaction }: { transaction?: Transaction | undefined } = {}
   ): Promise<Result<undefined, Error>> {
+    // TODO(2026-01-15 aubin): add this check back once the workflow are unstuck.
     // const canAdministrate =
     //   await SpaceResource.canAdministrateSystemSpace(auth);
     // assert(

--- a/front/lib/resources/webhook_source_resource.ts
+++ b/front/lib/resources/webhook_source_resource.ts
@@ -94,7 +94,6 @@ export class WebhookSourceResource extends BaseResource<WebhookSourceModel> {
         workspaceId: workspace.id,
       },
       limit: options.limit,
-      order: options.order,
     });
 
     return res.map((c) => new this(this.model, c.get()));
@@ -145,9 +144,7 @@ export class WebhookSourceResource extends BaseResource<WebhookSourceModel> {
   }
 
   static async listByWorkspace(auth: Authenticator) {
-    return this.baseFetch(auth, {
-      order: [["createdAt", "DESC"]],
-    });
+    return this.baseFetch(auth);
   }
 
   async updateRemoteMetadata(

--- a/front/lib/resources/webhook_source_resource.ts
+++ b/front/lib/resources/webhook_source_resource.ts
@@ -168,12 +168,12 @@ export class WebhookSourceResource extends BaseResource<WebhookSourceModel> {
     auth: Authenticator,
     { transaction }: { transaction?: Transaction | undefined } = {}
   ): Promise<Result<undefined, Error>> {
-    const canAdministrate =
-      await SpaceResource.canAdministrateSystemSpace(auth);
-    assert(
-      canAdministrate,
-      "The user is not authorized to delete a webhook source"
-    );
+    // const canAdministrate =
+    //   await SpaceResource.canAdministrateSystemSpace(auth);
+    // assert(
+    //   canAdministrate,
+    //   "The user is not authorized to delete a webhook source"
+    // );
 
     const owner = auth.getNonNullableWorkspace();
 

--- a/front/poke/temporal/workflows.ts
+++ b/front/poke/temporal/workflows.ts
@@ -78,8 +78,8 @@ export async function deleteWorkspaceWorkflow({
   await deleteMembersActivity({ workspaceId });
   await deleteWorkspaceUserMetadataActivity({ workspaceId });
   await deleteTagsActivity({ workspaceId });
-  await deleteSpacesActivity({ workspaceId });
   await deleteWebhookSourcesActivity({ workspaceId });
+  await deleteSpacesActivity({ workspaceId });
   await deleteTranscriptsActivity({ workspaceId });
   await deletePluginRunsActivity({ workspaceId });
   await deleteWorkspaceActivity({ workspaceId });


### PR DESCRIPTION
## Description

- In the workspace deletion we currently delete the spaces before the webhook sources, which fails because we assert that we have a system space in the webhook source deletion.
- This PR fixes the order and temporarily comments out this check to allow the workflow to get unstuck.
- Also contains some unrelated clean ups: no order by without an index, no transaction that leak outside of the resource.

## Tests
## Risk

- Low.

## Deploy Plan

- Deploy front.
