### PR TITLE
Fix project_metadata migration: use BIGSERIAL for id

### DIFF
--- a/front/migrations/db/migration_476.sql
+++ b/front/migrations/db/migration_476.sql
@@ -1,6 +1,6 @@
 -- Migration: Create project_metadata table
 CREATE TABLE "project_metadata" (
-    "id" SERIAL PRIMARY KEY,
+    "id" BIGSERIAL PRIMARY KEY,
     "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
     "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
     "workspaceId" INTEGER NOT NULL REFERENCES "workspaces" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,


### PR DESCRIPTION
## Summary
- Fix migration_476 to use `BIGSERIAL` instead of `SERIAL` for the id column
- This fixes the production deployment error where the sequence shard range function requires bigint sequences

## Context
When applying migration_476 in production (EU env), it failed with:
```
ERROR: MAXVALUE (549755813887) is out of range for sequence data type integer
```

The database has a `set_sequence_shard_range()` function that sets sequence ranges beyond integer limits, so all new tables must use `BIGSERIAL` (bigint) instead of `SERIAL` (integer) for their id columns.

## Test plan
- [x] Verify the migration applies successfully in production