### PR TITLE
Fix project deletion

### DIFF
--- a/front/lib/api/spaces.test.ts
+++ b/front/lib/api/spaces.test.ts
@@ -1,7 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { getProjectConversationsDatasourceName } from "@app/lib/api/project_connectors";
-import { createSpaceAndGroup } from "@app/lib/api/spaces";
+import {
+  createSpaceAndGroup,
+  softDeleteSpaceAndLaunchScrubWorkflow,
+} from "@app/lib/api/spaces";
 import { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
@@ -14,7 +17,7 @@ import { KeyFactory } from "@app/tests/utils/KeyFactory";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
-import { ConnectorsAPI, CoreAPI, Ok } from "@app/types";
+import { ConnectorsAPI, CoreAPI, Ok, SPACE_KINDS } from "@app/types";
 
 // Mock config to avoid requiring environment variables
 vi.mock("@app/lib/api/config", () => ({
@@ -808,6 +811,303 @@ describe("createSpaceAndGroup", () => {
         const space = result.value;
         // When isRestricted is false, managementMode should be forced to "manual"
         expect(space.managementMode).toBe("manual");
+      }
+    });
+  });
+});
+
+describe("softDeleteSpaceAndLaunchScrubWorkflow", () => {
+  let workspace: Awaited<ReturnType<typeof WorkspaceFactory.basic>>;
+  let adminAuth: Authenticator;
+  let globalGroup: GroupResource;
+  let systemGroup: GroupResource;
+
+  beforeEach(async () => {
+    workspace = await WorkspaceFactory.basic();
+    const adminUser = await UserFactory.basic();
+
+    // Set up default groups and spaces FIRST (before creating authenticators)
+    const { globalGroup: gGroup, systemGroup: sGroup } =
+      await GroupFactory.defaults(workspace);
+    globalGroup = gGroup;
+    systemGroup = sGroup;
+
+    await MembershipFactory.associate(workspace, adminUser, {
+      role: "admin",
+    });
+
+    // Create internal admin auth to set up default spaces
+    const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    await SpaceResource.makeDefaultsForWorkspace(internalAdminAuth, {
+      globalGroup,
+      systemGroup,
+    });
+
+    // Now create admin authenticator (they will find the global group)
+    adminAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      adminUser.sId,
+      workspace.sId
+    );
+
+    // Mock launchScrubSpaceWorkflow to prevent actual workflow execution
+    vi.mock("@app/poke/temporal/client", () => ({
+      launchScrubSpaceWorkflow: vi.fn().mockResolvedValue(undefined),
+    }));
+  });
+
+  describe("space type validation", () => {
+    // This test ensures that if a new space kind is added to SPACE_KINDS,
+    // it will fail by default unless explicitly added to the allowed list
+    it("should only allow deleting 'regular' and 'project' space kinds", () => {
+      const allowedKinds = ["regular", "project"];
+      const allKinds = [...SPACE_KINDS];
+
+      // This assertion will fail if new space kinds are added to SPACE_KINDS
+      // without being explicitly handled in this test or in the deletion logic
+      const unhandledKinds = allKinds.filter(
+        (kind) => !allowedKinds.includes(kind)
+      );
+
+      // Document which kinds are NOT allowed to be deleted
+      const knownDisallowedKinds = [
+        "global",
+        "system",
+        "conversations",
+        "public",
+      ];
+
+      expect(unhandledKinds.sort()).toEqual(knownDisallowedKinds.sort());
+    });
+
+    it("should fail to delete a global space", async () => {
+      const spaces = await SpaceResource.listWorkspaceSpaces(adminAuth);
+      const globalSpace = spaces.find((s) => s.isGlobal());
+      expect(globalSpace).toBeDefined();
+
+      await expect(async () => {
+        await softDeleteSpaceAndLaunchScrubWorkflow(
+          adminAuth,
+          globalSpace!,
+          false
+        );
+      }).rejects.toThrow(
+        "Cannot delete spaces that are not regular or project"
+      );
+    });
+
+    it("should fail to delete a system space", async () => {
+      const spaces = await SpaceResource.listWorkspaceSpaces(adminAuth);
+      const systemSpace = spaces.find((s) => s.isSystem());
+      expect(systemSpace).toBeDefined();
+
+      await expect(async () => {
+        await softDeleteSpaceAndLaunchScrubWorkflow(
+          adminAuth,
+          systemSpace!,
+          false
+        );
+      }).rejects.toThrow(
+        "Cannot delete spaces that are not regular or project"
+      );
+    });
+
+    it("should fail to delete a conversations space", async () => {
+      const spaces = await SpaceResource.listWorkspaceSpaces(adminAuth, {
+        includeConversationsSpace: true,
+      });
+      const conversationsSpace = spaces.find((s) => s.isConversations());
+      expect(conversationsSpace).toBeDefined();
+
+      await expect(async () => {
+        await softDeleteSpaceAndLaunchScrubWorkflow(
+          adminAuth,
+          conversationsSpace!,
+          false
+        );
+      }).rejects.toThrow(
+        "Cannot delete spaces that are not regular or project"
+      );
+    });
+
+    it("should fail to delete a public space", async () => {
+      // Create a public space
+      const publicSpace = await SpaceResource.makeNew(
+        {
+          name: "Test Public Space",
+          kind: "public",
+          workspaceId: workspace.id,
+        },
+        [globalGroup]
+      );
+
+      await expect(async () => {
+        await softDeleteSpaceAndLaunchScrubWorkflow(
+          adminAuth,
+          publicSpace,
+          false
+        );
+      }).rejects.toThrow(
+        "Cannot delete spaces that are not regular or project"
+      );
+    });
+  });
+
+  describe("API key validation", () => {
+    it("should fail to delete a regular space with active API keys in non-global groups", async () => {
+      const result = await createSpaceAndGroup(adminAuth, {
+        name: "Test Regular Space With Keys",
+        isRestricted: true,
+        spaceKind: "regular",
+        managementMode: "manual",
+        memberIds: [],
+      });
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        const space = result.value;
+        // Get the space's non-global group
+        const spaceGroup = space.groups.find((g) => !g.isGlobal());
+        expect(spaceGroup).toBeDefined();
+
+        // Create an active API key for the space group
+        if (spaceGroup) {
+          await KeyFactory.regular(spaceGroup);
+
+          const deleteResult = await softDeleteSpaceAndLaunchScrubWorkflow(
+            adminAuth,
+            space,
+            false
+          );
+          expect(deleteResult.isErr()).toBe(true);
+          if (deleteResult.isErr()) {
+            expect(deleteResult.error.message).toContain(
+              "Cannot delete group with active API Keys"
+            );
+          }
+        }
+      }
+    });
+
+    it("should fail to delete a project space with active API keys in non-global groups", async () => {
+      const result = await createSpaceAndGroup(adminAuth, {
+        name: "Test Project Space With Keys",
+        isRestricted: true,
+        spaceKind: "project",
+        managementMode: "manual",
+        memberIds: [],
+      });
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        const space = result.value;
+        // Get the space's non-global group
+        const spaceGroup = space.groups.find((g) => !g.isGlobal());
+        expect(spaceGroup).toBeDefined();
+
+        // Create an active API key for the space group
+        if (spaceGroup) {
+          await KeyFactory.regular(spaceGroup);
+
+          const deleteResult = await softDeleteSpaceAndLaunchScrubWorkflow(
+            adminAuth,
+            space,
+            false
+          );
+          expect(deleteResult.isErr()).toBe(true);
+          if (deleteResult.isErr()) {
+            expect(deleteResult.error.message).toContain(
+              "Cannot delete group with active API Keys"
+            );
+          }
+        }
+      }
+    });
+
+    it("should allow deleting a regular space with disabled API keys", async () => {
+      const result = await createSpaceAndGroup(adminAuth, {
+        name: "Test Regular Space With Disabled Keys",
+        isRestricted: true,
+        spaceKind: "regular",
+        managementMode: "manual",
+        memberIds: [],
+      });
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        const space = result.value;
+        // Get the space's non-global group
+        const spaceGroup = space.groups.find((g) => !g.isGlobal());
+        expect(spaceGroup).toBeDefined();
+
+        // Create a disabled API key for the space group
+        if (spaceGroup) {
+          await KeyFactory.disabled(spaceGroup);
+
+          const deleteResult = await softDeleteSpaceAndLaunchScrubWorkflow(
+            adminAuth,
+            space,
+            false
+          );
+          expect(deleteResult.isOk()).toBe(true);
+        }
+      }
+    });
+
+    it("should allow deleting a regular space with active API keys in global group", async () => {
+      const result = await createSpaceAndGroup(adminAuth, {
+        name: "Test Regular Space With Global Keys",
+        isRestricted: false,
+        spaceKind: "regular",
+        managementMode: "manual",
+        memberIds: [],
+      });
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        const space = result.value;
+        // Verify the space has the global group
+        expect(space.groups.some((g) => g.isGlobal())).toBe(true);
+
+        // Create an active API key for the global group
+        await KeyFactory.regular(globalGroup);
+
+        // Should succeed because keys in global group are allowed for spaces
+        const deleteResult = await softDeleteSpaceAndLaunchScrubWorkflow(
+          adminAuth,
+          space,
+          false
+        );
+        expect(deleteResult.isOk()).toBe(true);
+      }
+    });
+
+    it("should allow deleting a project space with active API keys in global group", async () => {
+      const result = await createSpaceAndGroup(adminAuth, {
+        name: "Test Project Space With Global Keys",
+        isRestricted: false,
+        spaceKind: "project",
+        managementMode: "manual",
+        memberIds: [],
+      });
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        const space = result.value;
+        // Verify the space has the global group
+        expect(space.groups.some((g) => g.isGlobal())).toBe(true);
+
+        // Create an active API key for the global group
+        await KeyFactory.regular(globalGroup);
+
+        // Should succeed because keys in global group are allowed for unrestricted spaces
+        const deleteResult = await softDeleteSpaceAndLaunchScrubWorkflow(
+          adminAuth,
+          space,
+          false
+        );
+        expect(deleteResult.isOk()).toBe(true);
       }
     });
   });

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -87,7 +87,9 @@ export async function softDeleteSpaceAndLaunchScrubWorkflow(
 
   const groupHasKeys = await KeyResource.countActiveForGroups(
     auth,
-    space.groups.filter((g) => !space.isRegular() || !g.isGlobal())
+    space.groups.filter(
+      (g) => (!space.isRegular() && !space.isProject()) || !g.isGlobal()
+    )
   );
   if (groupHasKeys > 0) {
     return new Err(


### PR DESCRIPTION
## Description

Fixes project space deletion to properly check for active API keys. The previous logic incorrectly checked if the global group has active keys (which is very often true) when trying to delete a project.
<img width="360" height="204" alt="image" src="https://github.com/user-attachments/assets/229e71b9-c987-4f92-8c42-4312eb844cd3" />


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Deploy front
