### PR TITLE
Increase BigQuery MAX_TABLES_PER_SCHEMA limit to 1500

### DIFF
--- a/connectors/src/connectors/bigquery/lib/bigquery_api.ts
+++ b/connectors/src/connectors/bigquery/lib/bigquery_api.ts
@@ -13,7 +13,7 @@ import type { Logger } from "@connectors/logger/logger";
 import type { BigQueryCredentialsWithLocation } from "@connectors/types";
 import { isBigqueryPermissionsError } from "@connectors/types/bigquery";
 
-const MAX_TABLES_PER_SCHEMA = 1000;
+const MAX_TABLES_PER_SCHEMA = 1500;
 type TestConnectionErrorCode = "INVALID_CREDENTIALS" | "UNKNOWN";
 
 export class TestConnectionError extends Error {


### PR DESCRIPTION
## Description

Bumps the threshold for skipping large BigQuery schemas from 1000 to 1500 tables. This allows users to sync datasets with more tables that were previously being skipped.

## Tests

Manual review - the change is a simple constant value update.

## Risk

Low risk. This only increases the limit, allowing more tables to be synced. Worst case is slightly longer sync times for schemas with 1000-1500 tables.

## Deploy Plan

Standard deployment. No special considerations needed.