### PR TITLE
Fix project_metadata: use BIGINT for foreign key columns

### DIFF
--- a/front/migrations/db/migration_477.sql
+++ b/front/migrations/db/migration_477.sql
@@ -1,0 +1,3 @@
+-- Migration: Fix project_metadata foreign key columns to use BIGINT
+ALTER TABLE "project_metadata" ALTER COLUMN "workspaceId" TYPE BIGINT;
+ALTER TABLE "project_metadata" ALTER COLUMN "spaceId" TYPE BIGINT;


### PR DESCRIPTION
## Summary
- Fix migration to alter `workspaceId` and `spaceId` columns from INTEGER to BIGINT

## Context
The original migration_476 incorrectly defined foreign key columns as `INTEGER`:
```sql
"workspaceId" INTEGER NOT NULL REFERENCES "workspaces" ("id")
"spaceId" INTEGER NOT NULL REFERENCES "vaults" ("id")
```

But the referenced tables use bigint IDs, causing this error when running the backfill migration:
```
value "274877906944" is out of range for type integer
```

## Test plan
- [x] Apply migration_477 in production to fix the column types
- [x] Re-run the backfill migration