### PR TITLE
[front] enh(skills): exclude global skills from similar skills detection

### DIFF
--- a/front/lib/api/skills/existing_skill_checker.ts
+++ b/front/lib/api/skills/existing_skill_checker.ts
@@ -111,6 +111,7 @@ export async function getSimilarSkills(
   // Retrieve existing skills
   const skills: SkillResource[] = await SkillResource.listByWorkspace(auth, {
     limit: MAX_SKILLS_SENT_TO_LLM,
+    onlyCustom: true,
   });
   if (skills.length === MAX_SKILLS_SENT_TO_LLM) {
     logger.warn(

--- a/front/lib/api/skills/existing_skill_checker.ts
+++ b/front/lib/api/skills/existing_skill_checker.ts
@@ -109,7 +109,7 @@ export async function getSimilarSkills(
   }
 
   // Retrieve existing skills
-  const skills: SkillResource[] = await SkillResource.listSkills(auth, {
+  const skills: SkillResource[] = await SkillResource.listByWorkspace(auth, {
     limit: MAX_SKILLS_SENT_TO_LLM,
   });
   if (skills.length === MAX_SKILLS_SENT_TO_LLM) {

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -666,7 +666,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     });
   }
 
-  static async listSkills(
+  static async listByWorkspace(
     auth: Authenticator,
     {
       status = "active",

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -672,15 +672,18 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       status = "active",
       limit,
       globalSpaceOnly,
+      onlyCustom,
     }: {
       status?: SkillStatus | SkillStatus[];
       limit?: number;
       globalSpaceOnly?: boolean;
+      onlyCustom?: boolean;
     } = {}
   ): Promise<SkillResource[]> {
     const skills = await this.baseFetch(auth, {
       where: { status },
       ...(limit ? { limit } : {}),
+      onlyCustom,
     });
 
     if (globalSpaceOnly) {

--- a/front/pages/api/poke/workspaces/[wId]/skills/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/skills/index.ts
@@ -43,7 +43,7 @@ async function handler(
 
   switch (req.method) {
     case "GET": {
-      const skills = await SkillResource.listSkills(auth, {
+      const skills = await SkillResource.listByWorkspace(auth, {
         status: ["active", "archived", "suggested"],
       });
 

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -107,7 +107,7 @@ async function handler(
       }
       const skillStatus = statusValidation.right;
 
-      const skills = await SkillResource.listSkills(auth, {
+      const skills = await SkillResource.listByWorkspace(auth, {
         status: skillStatus,
         globalSpaceOnly: globalSpaceOnly === "true",
       });


### PR DESCRIPTION
## Description

- This PR excludes the global skills from the similar skill detection to avoid flagging a skill as overlapping a global one.
- These matches can occur very often when extending a global skill, which may create many false positives, and the risk of a true positive is non existent (the underlying tools for global skills are not exposed as is, or configured programatically).

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
