### PR TITLE
refactor(cli): integrate forward command with cac help system

### DIFF
--- a/x/henry/dust-hive/src/index.ts
+++ b/x/henry/dust-hive/src/index.ts
@@ -6,7 +6,7 @@ import { coolCommand } from "./commands/cool";
 import { destroyCommand } from "./commands/destroy";
 import { doctorCommand, setupCommand } from "./commands/doctor";
 import { downCommand } from "./commands/down";
-import { forwardCommand } from "./commands/forward";
+import { forwardCommand, forwardStatusCommand, forwardStopCommand } from "./commands/forward";
 import { listCommand } from "./commands/list";
 import { logsCommand } from "./commands/logs";
 import { openCommand } from "./commands/open";
@@ -250,10 +250,22 @@ cli.command("cache", "Show binary cache status").action(async () => {
   await prepareAndRun(cacheCommand());
 });
 
+cli.command("forward status", "Show current forwarding status").action(async () => {
+  await prepareAndRun(forwardStatusCommand());
+});
+
+cli.command("forward stop", "Stop the port forwarder").action(async () => {
+  await prepareAndRun(forwardStopCommand());
+});
+
 cli
-  .command("forward [target]", "Manage OAuth port forwarding")
-  .action(async (target: string | undefined) => {
-    await prepareAndRun(forwardCommand(target));
+  .command("forward [name]", "Forward OAuth ports to environment")
+  .example("dust-hive forward          # Forward to last warmed env")
+  .example("dust-hive forward my-env   # Forward to specific env")
+  .example("dust-hive forward status   # Show forwarding status")
+  .example("dust-hive forward stop     # Stop port forwarding")
+  .action(async (name: string | undefined) => {
+    await prepareAndRun(forwardCommand(name));
   });
 
 cli


### PR DESCRIPTION
## Description

This PR refactors the `dust-hive forward` command to properly integrate with cac's help system instead of using manual argument parsing.

**Problem**: The forward command previously implemented custom argument parsing with manual string checks for `--help`, `-h`, `help`, `status`, and `stop`. This prevented the command from properly integrating with cac's native help generation, making `dust-hive forward --help` work only through custom logic rather than cac's built-in system.


## Tests

- Manual verification of all command variations:
  - `dust-hive forward --help` displays proper help text
  - `dust-hive forward status` shows current forwarding status
  - `dust-hive forward stop` stops the forwarder
  - `dust-hive --help` correctly lists all three forward commands

## Risk

don't affect any production systems or user-facing features.

## Deploy Plan


