### PR TITLE
feat(conversations): add message deep-linking with URL anchors (#5821)

### DIFF
--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -181,6 +181,10 @@ export const ConversationViewer = ({
     VirtuosoMessage[] | undefined
   >(undefined);
 
+  const [messageIdToScrollTo, setMessageIdToScrollTo] = useState<number | null>(
+    null
+  );
+
   // Setup the initial list data when the conversation is loaded.
   useEffect(() => {
     // We also wait in case of revalidation because otherwise we might use stale data from the swr cache.
@@ -194,6 +198,28 @@ export const ConversationViewer = ({
       const messagesToRender = convertLightMessageTypeToVirtuosoMessages(raw);
 
       setInitialListData(messagesToRender);
+
+      // Fetch the message to scroll to from the URL hash.
+      const hash = window.location.hash;
+      if (!hash || !hash.startsWith("#")) {
+        return;
+      }
+
+      const messageId = hash.substring(1); // Remove the '#' prefix.
+      if (!messageId) {
+        return;
+      }
+
+      // Find the message index in the current data.
+      const messageIndex = messagesToRender.findIndex(
+        (m) => m.sId === messageId
+      );
+
+      if (messageIndex === -1) {
+        // nothing found to scroll to.
+        return;
+      }
+      setMessageIdToScrollTo(messageIndex);
     }
   }, [initialListData, messages, setInitialListData, isValidating]);
 
@@ -650,7 +676,7 @@ export const ConversationViewer = ({
       handleSubmit,
       conversation,
       draftKey: `conversation-${conversationId}`,
-      enableReactions: !!conversation?.spaceId,
+      enableExtendedActions: !!conversation?.spaceId,
       agentBuilderContext,
       feedbacksByMessageId,
     };
@@ -680,17 +706,12 @@ export const ConversationViewer = ({
             scrollModifier: {
               type: "item-location",
               location: {
-                index: "LAST",
-                align: "end",
+                index: messageIdToScrollTo ?? "LAST",
+                align: messageIdToScrollTo ? "start" : "end",
                 behavior: "instant",
               },
               purgeItemSizes: true,
             },
-          }}
-          initialLocation={{
-            index: "LAST",
-            align: "end",
-            behavior: "instant",
           }}
           ref={ref}
           ItemContent={MessageItem}

--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -151,7 +151,7 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
             <UserMessage
               citations={citations}
               conversationId={context.conversation.sId}
-              enableReactions={context.enableReactions}
+              enableExtendedActions={context.enableExtendedActions}
               currentUserId={context.user.sId}
               isLastMessage={!nextData}
               message={data}
@@ -169,6 +169,7 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
               messageFeedback={messageFeedbackWithSubmit}
               owner={context.owner}
               handleSubmit={context.handleSubmit}
+              enableExtendedActions={context.enableExtendedActions}
             />
           )}
           {data.visibility !== "deleted" &&

--- a/front/components/assistant/conversation/types.ts
+++ b/front/components/assistant/conversation/types.ts
@@ -71,7 +71,7 @@ export type VirtuosoMessageListContext = {
   ) => Promise<Result<undefined, DustError>>;
   conversation: ConversationWithoutContentType | null;
   draftKey: string;
-  enableReactions: boolean;
+  enableExtendedActions: boolean;
   agentBuilderContext?: {
     draftAgent?: LightAgentConfigurationType;
     isSavingDraftAgent: boolean;


### PR DESCRIPTION
## Description

This PR implements message deep-linking functionality for conversations, enabling users to share direct links to specific messages within conversation, only in **projects**

**Key features:**
- **Copy message link**: Added "Copy message link" action to both user and agent message context menus (three-dot menu). The action generates a shareable URL with a hash fragment pointing to the specific message.
- **Automatic navigation**: When users open a conversation URL with a message hash (e.g., `https://dust.tt/w/{workspace}/conversation/{conversationId}#{messageId}`), the page automatically scrolls to the target message once all messages are loaded.

**Limitations**
- We don't update the has in the URL when scrolling in a conversation

## Tests

<img width="286" height="269" alt="image" src="https://github.com/user-attachments/assets/3682d06d-fe1e-45ac-8f0e-7c88048c1c82" />



## Risk



## Deploy Plan

