### PR TITLE
[front] Re-enable system space check on webhook source deletion

### DIFF
--- a/front/lib/resources/webhook_source_resource.ts
+++ b/front/lib/resources/webhook_source_resource.ts
@@ -168,13 +168,12 @@ export class WebhookSourceResource extends BaseResource<WebhookSourceModel> {
     auth: Authenticator,
     { transaction }: { transaction?: Transaction | undefined } = {}
   ): Promise<Result<undefined, Error>> {
-    // TODO(2026-01-15 aubin): add this check back once the workflow are unstuck.
-    // const canAdministrate =
-    //   await SpaceResource.canAdministrateSystemSpace(auth);
-    // assert(
-    //   canAdministrate,
-    //   "The user is not authorized to delete a webhook source"
-    // );
+    const canAdministrate =
+      await SpaceResource.canAdministrateSystemSpace(auth);
+    assert(
+      canAdministrate,
+      "The user is not authorized to delete a webhook source"
+    );
 
     const owner = auth.getNonNullableWorkspace();
 


### PR DESCRIPTION
## Description

- Cleanup following https://github.com/dust-tt/dust/pull/20092.
- This check was removed to unstuck a scrub workflow.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
