### PR TITLE
feat(front): add Snowflake OAuth provider

### DIFF
--- a/front/lib/api/oauth.ts
+++ b/front/lib/api/oauth.ts
@@ -29,6 +29,7 @@ import { ProductboardOAuthProvider } from "@app/lib/api/oauth/providers/productb
 import { SalesforceOAuthProvider } from "@app/lib/api/oauth/providers/salesforce";
 import { SlackOAuthProvider } from "@app/lib/api/oauth/providers/slack";
 import { SlackToolsOAuthProvider } from "@app/lib/api/oauth/providers/slack_tools";
+import { SnowflakeOAuthProvider } from "@app/lib/api/oauth/providers/snowflake";
 import { VantaOAuthProvider } from "@app/lib/api/oauth/providers/vanta";
 import { ZendeskOAuthProvider } from "@app/lib/api/oauth/providers/zendesk";
 import { finalizeUriForProvider } from "@app/lib/api/oauth/utils";
@@ -79,6 +80,7 @@ const _PROVIDER_STRATEGIES: Record<OAuthProvider, BaseOAuthStrategyProvider> = {
   salesforce: new SalesforceOAuthProvider(),
   slack: new SlackOAuthProvider(),
   slack_tools: new SlackToolsOAuthProvider(),
+  snowflake: new SnowflakeOAuthProvider(),
   zendesk: new ZendeskOAuthProvider(),
   vanta: new VantaOAuthProvider(),
 };

--- a/front/lib/api/oauth/providers/snowflake.ts
+++ b/front/lib/api/oauth/providers/snowflake.ts
@@ -1,0 +1,222 @@
+import type { ParsedUrlQuery } from "querystring";
+import querystring from "querystring";
+
+import config from "@app/lib/api/config";
+import type {
+  BaseOAuthStrategyProvider,
+  RelatedCredential,
+} from "@app/lib/api/oauth/providers/base_oauth_stragegy_provider";
+import {
+  finalizeUriForProvider,
+  getStringFromQuery,
+} from "@app/lib/api/oauth/utils";
+import type { Authenticator } from "@app/lib/auth";
+import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
+import logger from "@app/logger/logger";
+import type { ExtraConfigType } from "@app/pages/w/[wId]/oauth/[provider]/setup";
+import { OAuthAPI } from "@app/types";
+import type { OAuthConnectionType, OAuthUseCase } from "@app/types/oauth/lib";
+import { isString } from "@app/types/shared/utils/general";
+
+/**
+ * Snowflake OAuth provider for MCP server integration.
+ *
+ * Snowflake OAuth requires:
+ * 1. Account identifier (e.g., "abc123.us-east-1" or "myorg-myaccount")
+ * 2. Client ID and Client Secret from customer's security integration
+ *
+ * The OAuth endpoints are account-specific:
+ * - Authorization: https://<account>.snowflakecomputing.com/oauth/authorize
+ * - Token: https://<account>.snowflakecomputing.com/oauth/token-request
+ */
+/**
+ * Helper to fetch the workspace OAuth connection for an MCP server.
+ * Used to get credentials from an existing admin-configured connection.
+ */
+async function getWorkspaceConnectionForMCPServer(
+  auth: Authenticator,
+  mcpServerId: string
+): Promise<OAuthConnectionType> {
+  const mcpServerConnectionRes =
+    await MCPServerConnectionResource.findByMCPServer(auth, {
+      mcpServerId,
+      connectionType: "workspace",
+    });
+
+  if (mcpServerConnectionRes.isErr()) {
+    throw new Error(
+      "Failed to find MCP server connection: " +
+        mcpServerConnectionRes.error.message
+    );
+  }
+
+  const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
+  const connectionRes = await oauthApi.getAccessToken({
+    connectionId: mcpServerConnectionRes.value.connectionId,
+  });
+
+  if (connectionRes.isErr()) {
+    throw new Error(
+      "Failed to get connection metadata: " + connectionRes.error.message
+    );
+  }
+
+  return connectionRes.value.connection;
+}
+
+export class SnowflakeOAuthProvider implements BaseOAuthStrategyProvider {
+  setupUri({
+    connection,
+    clientId,
+    extraConfig,
+  }: {
+    connection: OAuthConnectionType;
+    useCase: OAuthUseCase;
+    clientId?: string;
+    extraConfig?: ExtraConfigType;
+  }) {
+    if (!extraConfig || !extraConfig.snowflake_account) {
+      throw new Error("Missing Snowflake account identifier");
+    }
+
+    if (!clientId) {
+      throw new Error("Missing client ID for Snowflake");
+    }
+
+    const account = extraConfig.snowflake_account;
+
+    // Use session:role-any to use the user's default role in Snowflake.
+    // This respects each user's own permissions - admins should configure
+    // appropriate default roles for users in Snowflake.
+    const qs = querystring.stringify({
+      response_type: "code",
+      client_id: clientId,
+      state: connection.connection_id,
+      redirect_uri: finalizeUriForProvider("snowflake"),
+      scope: "session:role-any",
+    });
+
+    // Build account-specific authorization URL
+    const authUrl = `https://${account.trim()}.snowflakecomputing.com/oauth/authorize?${qs}`;
+    return authUrl;
+  }
+
+  codeFromQuery(query: ParsedUrlQuery) {
+    return getStringFromQuery(query, "code");
+  }
+
+  connectionIdFromQuery(query: ParsedUrlQuery) {
+    return getStringFromQuery(query, "state");
+  }
+
+  isExtraConfigValid(extraConfig: ExtraConfigType, useCase: OAuthUseCase) {
+    if (useCase === "personal_actions") {
+      // If we have an mcp_server_id it means the admin already setup the connection and we have
+      // everything we need, otherwise we'll need the client_id, client_secret, and snowflake_account.
+      if (extraConfig.mcp_server_id) {
+        return true;
+      }
+      // Initial admin setup - requires full credentials
+      return !!(
+        extraConfig.client_id &&
+        extraConfig.client_secret &&
+        extraConfig.snowflake_account
+      );
+    }
+    return Object.keys(extraConfig).length === 0;
+  }
+
+  async getRelatedCredential(
+    auth: Authenticator,
+    {
+      extraConfig,
+      workspaceId,
+      userId,
+      useCase,
+    }: {
+      extraConfig: ExtraConfigType;
+      workspaceId: string;
+      userId: string;
+      useCase: OAuthUseCase;
+    }
+  ): Promise<RelatedCredential> {
+    if (useCase === "personal_actions") {
+      // For personal actions we reuse the existing connection credential id from the existing
+      // workspace connection (setup by admin) if we have it, otherwise we fallback to assuming
+      // we have client_secret (initial admin setup).
+      const { mcp_server_id } = extraConfig;
+
+      if (mcp_server_id && isString(mcp_server_id)) {
+        const connection = await getWorkspaceConnectionForMCPServer(
+          auth,
+          mcp_server_id
+        );
+
+        return {
+          content: {
+            from_connection_id: connection.connection_id,
+          },
+          metadata: { workspace_id: workspaceId, user_id: userId },
+        };
+      }
+    }
+
+    const { client_secret, client_id, snowflake_account } = extraConfig;
+
+    // Validate that all are strings before using them
+    if (
+      !isString(client_secret) ||
+      !isString(client_id) ||
+      !isString(snowflake_account)
+    ) {
+      throw new Error(
+        "Missing or invalid client_id, client_secret, or snowflake_account in extraConfig"
+      );
+    }
+
+    return {
+      content: {
+        client_secret,
+        client_id,
+        snowflake_account,
+      },
+      metadata: { workspace_id: workspaceId, user_id: userId },
+    };
+  }
+
+  async getUpdatedExtraConfig(
+    auth: Authenticator,
+    {
+      extraConfig,
+      useCase,
+    }: {
+      extraConfig: ExtraConfigType;
+      useCase: OAuthUseCase;
+    }
+  ): Promise<ExtraConfigType> {
+    if (useCase === "personal_actions") {
+      // For personal actions we reuse the existing connection credential id from the existing
+      // workspace connection (setup by admin) if we have it, otherwise we fallback to assuming
+      // we have client_secret (initial admin setup).
+      const { mcp_server_id, ...restConfig } = extraConfig;
+
+      if (mcp_server_id && isString(mcp_server_id)) {
+        const connection = await getWorkspaceConnectionForMCPServer(
+          auth,
+          mcp_server_id
+        );
+
+        return {
+          client_id: connection.metadata.client_id,
+          snowflake_account: connection.metadata.snowflake_account,
+          ...restConfig,
+        };
+      }
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- we filter out the client_secret from the extraConfig.
+    const { client_secret, ...restConfig } = extraConfig;
+
+    return restConfig;
+  }
+}

--- a/front/types/oauth/lib.test.ts
+++ b/front/types/oauth/lib.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import { isValidSnowflakeAccount } from "./lib";
+
+describe("isValidSnowflakeAccount", () => {
+  it("should accept valid account identifiers", () => {
+    // Legacy locator format
+    expect(isValidSnowflakeAccount("abc123")).toBe(true);
+    expect(isValidSnowflakeAccount("xy12345")).toBe(true);
+
+    // Locator with region
+    expect(isValidSnowflakeAccount("abc123.us-east-1")).toBe(true);
+    expect(isValidSnowflakeAccount("th19603.us-east4.gcp")).toBe(true);
+    expect(isValidSnowflakeAccount("abc123.eu-west-1.aws")).toBe(true);
+
+    // Organization name format
+    expect(isValidSnowflakeAccount("myorg-myaccount")).toBe(true);
+    expect(isValidSnowflakeAccount("company_name-prod")).toBe(true);
+
+    // Privatelink format
+    expect(isValidSnowflakeAccount("myorg-myaccount.privatelink")).toBe(true);
+  });
+
+  it("should reject invalid account identifiers", () => {
+    // Empty or whitespace
+    expect(isValidSnowflakeAccount("")).toBe(false);
+    expect(isValidSnowflakeAccount("   ")).toBe(false);
+
+    // Non-string types
+    expect(isValidSnowflakeAccount(null)).toBe(false);
+    expect(isValidSnowflakeAccount(undefined)).toBe(false);
+    expect(isValidSnowflakeAccount(123)).toBe(false);
+    expect(isValidSnowflakeAccount({})).toBe(false);
+
+    // Invalid characters
+    expect(isValidSnowflakeAccount("account@name")).toBe(false);
+    expect(isValidSnowflakeAccount("account/name")).toBe(false);
+    expect(isValidSnowflakeAccount("account:name")).toBe(false);
+
+    // Starting/ending with special chars
+    expect(isValidSnowflakeAccount("-abc")).toBe(false);
+    expect(isValidSnowflakeAccount("abc-")).toBe(false);
+    expect(isValidSnowflakeAccount(".abc")).toBe(false);
+    expect(isValidSnowflakeAccount("abc.")).toBe(false);
+  });
+
+  it("should handle edge cases", () => {
+    // Single character (might be valid, but our regex requires 2+)
+    expect(isValidSnowflakeAccount("a")).toBe(false);
+
+    // Two characters (minimum valid)
+    expect(isValidSnowflakeAccount("ab")).toBe(true);
+
+    // With whitespace (should be trimmed internally)
+    expect(isValidSnowflakeAccount(" abc123 ")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `SnowflakeOAuthProvider` with authorization code flow + PKCE support
- Add `SnowflakeLogo` component for UI
- Handle Snowflake connection type in `oauth/lib.ts`
- Register provider in the OAuth system

## Stack
This is PR 3/4 in the Snowflake MCP server stack:
1. Core OAuth provider (#20111)
2. SDK types (#20112)
3. **This PR** - Frontend OAuth provider
4. MCP server implementation

## Test plan
- [ ] CI passes
- [ ] Manual OAuth flow testing