### PR TITLE
feat(snowflake): implement Snowflake MCP server tools

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -54,7 +54,6 @@ import { default as slabServer } from "@app/lib/actions/mcp_internal_actions/ser
 import { default as slackBotServer } from "@app/lib/actions/mcp_internal_actions/servers/slack/slack_bot";
 import { default as slackServer } from "@app/lib/actions/mcp_internal_actions/servers/slack/slack_personal";
 import { default as slideshowServer } from "@app/lib/actions/mcp_internal_actions/servers/slideshow";
-import { default as snowflakeServer } from "@app/lib/actions/mcp_internal_actions/servers/snowflake";
 import { default as soundStudio } from "@app/lib/actions/mcp_internal_actions/servers/sound_studio";
 import { default as speechGenerator } from "@app/lib/actions/mcp_internal_actions/servers/speech_generator";
 import { default as tablesQueryServerV2 } from "@app/lib/actions/mcp_internal_actions/servers/tables_query";
@@ -69,6 +68,7 @@ import {
   isServerSideMCPServerConfiguration,
 } from "@app/lib/actions/types/guards";
 import { default as calendarServer } from "@app/lib/api/actions/servers/google_calendar";
+import { default as snowflakeServer } from "@app/lib/api/actions/servers/snowflake";
 import type { Authenticator } from "@app/lib/auth";
 import { assertNever } from "@app/types";
 

--- a/front/lib/api/actions/servers/snowflake/client.ts
+++ b/front/lib/api/actions/servers/snowflake/client.ts
@@ -1,0 +1,474 @@
+import type {
+  Connection,
+  ConnectionOptions,
+  RowStatement,
+  SnowflakeError,
+} from "snowflake-sdk";
+import snowflake from "snowflake-sdk";
+
+import { escapeSnowflakeIdentifier } from "@app/lib/utils/snowflake";
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types";
+import { EnvironmentConfig, Err, normalizeError, Ok } from "@app/types";
+import { isString } from "@app/types/shared/utils/general";
+
+interface SnowflakeColumn {
+  name: string;
+  type: string;
+  nullable: boolean;
+}
+
+interface SnowflakeQueryResult {
+  columns: SnowflakeColumn[];
+  rows: Record<string, unknown>[];
+  rowCount: number;
+}
+
+/**
+ * Parse an optional string to an integer, returning undefined if not set or invalid.
+ */
+function parseOptionalInt(value: string | undefined): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const parsed = parseInt(value, 10);
+  return Number.isNaN(parsed) ? undefined : parsed;
+}
+
+/**
+ * Safely extract a string value from a row, checking multiple keys (for case sensitivity).
+ * Snowflake SDK may return column names in uppercase or lowercase depending on context.
+ */
+function getRowStringMultiKey(
+  row: Record<string, unknown>,
+  ...keys: string[]
+): string | undefined {
+  for (const key of keys) {
+    const value = row[key];
+    if (isString(value)) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+export class SnowflakeClient {
+  private account: string;
+  private accessToken: string;
+  private warehouse: string;
+
+  constructor(account: string, accessToken: string, warehouse: string) {
+    this.account = account.trim();
+    this.accessToken = accessToken;
+    this.warehouse = warehouse.trim();
+  }
+
+  /**
+   * Create a Snowflake connection using OAuth authentication.
+   * Uses proxy for static IP whitelisting support.
+   */
+  private async connect(): Promise<Result<Connection, Error>> {
+    // Configure SDK to suppress verbose logging
+    snowflake.configure({
+      logLevel: "OFF",
+    });
+
+    try {
+      const connectionOptions: ConnectionOptions = {
+        // Replace any `_` with `-` in the account name for nginx proxy
+        account: this.account.replace(/_/g, "-"),
+        authenticator: "OAUTH",
+        token: this.accessToken,
+        warehouse: this.warehouse,
+
+        // Use proxy if defined to have all requests coming from the same IP.
+        proxyHost: EnvironmentConfig.getOptionalEnvVariable("PROXY_HOST"),
+        proxyPort: parseOptionalInt(
+          EnvironmentConfig.getOptionalEnvVariable("PROXY_PORT")
+        ),
+        proxyUser: EnvironmentConfig.getOptionalEnvVariable("PROXY_USER_NAME"),
+        proxyPassword: EnvironmentConfig.getOptionalEnvVariable(
+          "PROXY_USER_PASSWORD"
+        ),
+      };
+
+      const connection = await new Promise<Connection>((resolve, reject) => {
+        const connectTimeoutMs = 15000;
+
+        const conn = snowflake.createConnection(connectionOptions);
+        let settled = false;
+
+        const timeout = setTimeout(() => {
+          if (settled) {
+            return;
+          }
+          settled = true;
+          try {
+            conn.destroy((err: SnowflakeError | undefined) => {
+              if (err) {
+                reject(err as unknown as Error);
+                return;
+              }
+              reject(
+                new Error(
+                  "Connection attempt timed out while contacting Snowflake. This often indicates an invalid account or region hostname."
+                )
+              );
+            });
+          } catch (e) {
+            reject(e instanceof Error ? e : new Error(String(e)));
+          }
+        }, connectTimeoutMs);
+
+        conn.connect((err: SnowflakeError | undefined, c: Connection) => {
+          if (settled) {
+            return;
+          }
+          settled = true;
+          clearTimeout(timeout);
+          if (err) {
+            reject(err);
+          } else {
+            resolve(c);
+          }
+        });
+      });
+
+      // Explicitly set the warehouse - the connectionOptions.warehouse isn't always respected
+      try {
+        await this.runSql(
+          connection,
+          `USE WAREHOUSE "${escapeSnowflakeIdentifier(this.warehouse)}"`
+        );
+      } catch (error) {
+        // Clean up connection on USE WAREHOUSE failure
+        await this.closeConnection(connection);
+        return new Err(normalizeError(error));
+      }
+
+      return new Ok(connection);
+    } catch (error) {
+      return new Err(normalizeError(error));
+    }
+  }
+
+  /**
+   * Run a SQL statement on a connection (no result returned).
+   */
+  private async runSql(connection: Connection, sql: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      connection.execute({
+        sqlText: sql,
+        complete: (err: SnowflakeError | undefined) => {
+          if (err) {
+            reject(err);
+          } else {
+            resolve();
+          }
+        },
+      });
+    });
+  }
+
+  /**
+   * Close a Snowflake connection.
+   */
+  private async closeConnection(conn: Connection): Promise<void> {
+    return new Promise((resolve) => {
+      conn.destroy((err: SnowflakeError | undefined) => {
+        if (err) {
+          logger.warn({ err }, "Snowflake connection close error");
+        }
+        resolve();
+      });
+    });
+  }
+
+  /**
+   * Execute a SQL query on a connection and return the result.
+   */
+  private async executeQuery(
+    conn: Connection,
+    sql: string
+  ): Promise<Result<SnowflakeQueryResult, Error>> {
+    try {
+      type SnowflakeRows = Record<string, unknown>[];
+
+      const result = await new Promise<{
+        rows: SnowflakeRows | undefined;
+        columns: SnowflakeColumn[];
+      }>((resolve, reject) => {
+        conn.execute({
+          sqlText: sql,
+          complete: (
+            err: SnowflakeError | undefined,
+            stmt: RowStatement,
+            rows: SnowflakeRows | undefined
+          ) => {
+            if (err) {
+              reject(err);
+            } else {
+              // Extract column metadata from statement
+              const cols = stmt.getColumns() ?? [];
+              const columns: SnowflakeColumn[] = cols.map((col) => ({
+                name: col.getName(),
+                type: col.getType(),
+                nullable: col.isNullable(),
+              }));
+              resolve({ rows, columns });
+            }
+          },
+        });
+      });
+
+      const rows = result.rows ?? [];
+
+      return new Ok({
+        columns: result.columns,
+        rows,
+        rowCount: rows.length,
+      });
+    } catch (error) {
+      return new Err(normalizeError(error));
+    }
+  }
+
+  /**
+   * Execute a statement with connection management.
+   */
+  private async executeStatement(
+    sql: string
+  ): Promise<Result<SnowflakeQueryResult, Error>> {
+    const connRes = await this.connect();
+    if (connRes.isErr()) {
+      return connRes;
+    }
+    const conn = connRes.value;
+
+    try {
+      return await this.executeQuery(conn, sql);
+    } finally {
+      await this.closeConnection(conn);
+    }
+  }
+
+  async listDatabases(): Promise<Result<string[], Error>> {
+    const result = await this.executeStatement("SHOW DATABASES");
+    if (result.isErr()) {
+      return result;
+    }
+
+    const databases = result.value.rows
+      .map((row) => getRowStringMultiKey(row, "name", "NAME"))
+      .filter((name): name is string => name !== undefined);
+    return new Ok(databases);
+  }
+
+  async listSchemas(database: string): Promise<Result<string[], Error>> {
+    const result = await this.executeStatement(
+      `SHOW SCHEMAS IN DATABASE "${escapeSnowflakeIdentifier(database)}"`
+    );
+    if (result.isErr()) {
+      return result;
+    }
+
+    const schemas = result.value.rows
+      .map((row) => getRowStringMultiKey(row, "name", "NAME"))
+      .filter((name): name is string => name !== undefined);
+    return new Ok(schemas);
+  }
+
+  async listTables(
+    database: string,
+    schema: string
+  ): Promise<Result<Array<{ name: string; kind: string }>, Error>> {
+    const result = await this.executeStatement(
+      `SHOW TABLES IN SCHEMA "${escapeSnowflakeIdentifier(database)}"."${escapeSnowflakeIdentifier(schema)}"`
+    );
+    if (result.isErr()) {
+      return result;
+    }
+
+    const tables = result.value.rows
+      .map((row) => {
+        const name = getRowStringMultiKey(row, "name", "NAME");
+        if (!name) {
+          return null;
+        }
+        return {
+          name,
+          kind: getRowStringMultiKey(row, "kind", "KIND") ?? "TABLE",
+        };
+      })
+      .filter((t): t is { name: string; kind: string } => t !== null);
+
+    // Also get views (failure is non-fatal - some schemas may not have view permissions)
+    const viewsResult = await this.executeStatement(
+      `SHOW VIEWS IN SCHEMA "${escapeSnowflakeIdentifier(database)}"."${escapeSnowflakeIdentifier(schema)}"`
+    );
+    if (viewsResult.isOk()) {
+      const views = viewsResult.value.rows
+        .map((row) => {
+          const name = getRowStringMultiKey(row, "name", "NAME");
+          if (!name) {
+            return null;
+          }
+          return { name, kind: "VIEW" };
+        })
+        .filter((v): v is { name: string; kind: string } => v !== null);
+      tables.push(...views);
+    }
+
+    return new Ok(tables);
+  }
+
+  async describeTable(
+    database: string,
+    schema: string,
+    table: string
+  ): Promise<Result<SnowflakeColumn[], Error>> {
+    const result = await this.executeStatement(
+      `DESCRIBE TABLE "${escapeSnowflakeIdentifier(database)}"."${escapeSnowflakeIdentifier(schema)}"."${escapeSnowflakeIdentifier(table)}"`
+    );
+    if (result.isErr()) {
+      return result;
+    }
+
+    const columns: SnowflakeColumn[] = result.value.rows.map((row) => ({
+      name: getRowStringMultiKey(row, "name", "NAME") ?? "",
+      type: getRowStringMultiKey(row, "type", "TYPE") ?? "",
+      // Snowflake DESCRIBE TABLE returns "null?" column (with question mark)
+      nullable:
+        getRowStringMultiKey(row, "null?", "NULL?", "null", "NULL") === "Y",
+    }));
+
+    return new Ok(columns);
+  }
+
+  /**
+   * Validate that a query is read-only using EXPLAIN.
+   *
+   * Uses a blocklist approach to reject known write operations, which is more
+   * robust than checking if the query starts with SELECT (easily bypassed with comments).
+   * EXPLAIN analyzes what the query actually does, not what it looks like.
+   */
+  private async validateReadOnlyWithExplain(
+    conn: Connection,
+    sql: string
+  ): Promise<Result<void, Error>> {
+    // Use EXPLAIN USING TABULAR to get the query plan as structured data.
+    const explainSql = `EXPLAIN USING TABULAR ${sql}`;
+
+    const result = await this.executeQuery(conn, explainSql);
+
+    if (result.isErr()) {
+      // If EXPLAIN fails, the query is likely invalid anyway
+      return new Err(
+        new Error(`Failed to validate query: ${result.error.message}`)
+      );
+    }
+
+    // Blocklist of write operations that appear in Snowflake EXPLAIN output.
+    // Based on Snowflake's GET_QUERY_OPERATOR_STATS documentation, these are
+    // the DML operators that modify data:
+    // - Insert: covers INSERT and COPY INTO table
+    // - Update: UPDATE statements
+    // - Delete: DELETE statements
+    // - Merge: MERGE statements
+    // - Copy: COPY INTO stage (data export/unload)
+    // DDL commands (CREATE, DROP, ALTER, etc.) don't produce query plans.
+    const blockedOperations = new Set([
+      "INSERT",
+      "UPDATE",
+      "DELETE",
+      "MERGE",
+      "COPY",
+    ]);
+
+    for (const row of result.value.rows) {
+      const operation = getRowStringMultiKey(row, "operation", "OPERATION");
+      if (operation && blockedOperations.has(operation.toUpperCase())) {
+        return new Err(
+          new Error(
+            `Write operation detected: ${operation}. Only SELECT queries are permitted.`
+          )
+        );
+      }
+    }
+
+    return new Ok(undefined);
+  }
+
+  async readOnlyQuery(
+    sql: string,
+    database?: string,
+    schema?: string,
+    warehouse?: string,
+    maxRows: number = 1000
+  ): Promise<Result<SnowflakeQueryResult, Error>> {
+    // Check for semicolons which could indicate multi-statement injection.
+    // EXPLAIN might only analyze the first statement, so we block this upfront.
+    if (sql.includes(";")) {
+      return new Err(
+        new Error(
+          "Multiple statements are not allowed. Please submit a single query."
+        )
+      );
+    }
+
+    const connRes = await this.connect();
+    if (connRes.isErr()) {
+      return connRes;
+    }
+    const conn = connRes.value;
+
+    try {
+      // Set context if provided
+      if (database) {
+        const useDbResult = await this.executeQuery(
+          conn,
+          `USE DATABASE "${escapeSnowflakeIdentifier(database)}"`
+        );
+        if (useDbResult.isErr()) {
+          return useDbResult;
+        }
+      }
+      if (schema) {
+        const useSchemaResult = await this.executeQuery(
+          conn,
+          `USE SCHEMA "${escapeSnowflakeIdentifier(schema)}"`
+        );
+        if (useSchemaResult.isErr()) {
+          return useSchemaResult;
+        }
+      }
+      if (warehouse) {
+        const useWhResult = await this.executeQuery(
+          conn,
+          `USE WAREHOUSE "${escapeSnowflakeIdentifier(warehouse)}"`
+        );
+        if (useWhResult.isErr()) {
+          return useWhResult;
+        }
+      }
+
+      // Validate query is read-only using EXPLAIN-based blocklist.
+      // This checks what the query actually does, not what it looks like.
+      const validationResult = await this.validateReadOnlyWithExplain(
+        conn,
+        sql
+      );
+
+      if (validationResult.isErr()) {
+        return validationResult;
+      }
+
+      // Wrap query to enforce row limit
+      const wrappedSql = `SELECT * FROM (${sql.trim()}) AS _limited_query LIMIT ${maxRows}`;
+
+      return await this.executeQuery(conn, wrappedSql);
+    } finally {
+      await this.closeConnection(conn);
+    }
+  }
+}

--- a/front/lib/api/actions/servers/snowflake/index.ts
+++ b/front/lib/api/actions/servers/snowflake/index.ts
@@ -1,16 +1,21 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
+import { registerTool } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
+import { SNOWFLAKE_TOOL_NAME } from "@app/lib/api/actions/servers/snowflake/metadata";
+import { TOOLS } from "@app/lib/api/actions/servers/snowflake/tools";
 import type { Authenticator } from "@app/lib/auth";
 
 function createServer(
-  _auth: Authenticator,
-  _agentLoopContext?: AgentLoopContextType
+  auth: Authenticator,
+  agentLoopContext?: AgentLoopContextType
 ): McpServer {
   const server = makeInternalMCPServer("snowflake");
 
-  // Tools will be implemented in a follow-up PR
+  for (const tool of TOOLS) {
+    registerTool(auth, server, agentLoopContext, SNOWFLAKE_TOOL_NAME, tool);
+  }
 
   return server;
 }

--- a/front/lib/api/actions/servers/snowflake/metadata.ts
+++ b/front/lib/api/actions/servers/snowflake/metadata.ts
@@ -1,0 +1,119 @@
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
+
+import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { MCPToolType } from "@app/lib/api/mcp";
+import type { MCPOAuthUseCase } from "@app/types";
+
+export const SNOWFLAKE_TOOL_NAME = "snowflake" as const;
+export const MAX_QUERY_ROWS = 1000;
+
+export const listDatabasesMeta = {
+  name: "list_databases" as const,
+  description:
+    "List all databases accessible to the authenticated Snowflake user.",
+  schema: {},
+  stake: "never_ask" as MCPToolStakeLevelType,
+};
+
+export const listSchemasMeta = {
+  name: "list_schemas" as const,
+  description: "List all schemas within a specified Snowflake database.",
+  schema: {
+    database: z
+      .string()
+      .describe("The name of the database to list schemas from."),
+  },
+  stake: "never_ask" as MCPToolStakeLevelType,
+};
+
+export const listTablesMeta = {
+  name: "list_tables" as const,
+  description: "List all tables and views within a specified Snowflake schema.",
+  schema: {
+    database: z.string().describe("The name of the database."),
+    schema: z.string().describe("The name of the schema to list tables from."),
+  },
+  stake: "never_ask" as MCPToolStakeLevelType,
+};
+
+export const describeTableMeta = {
+  name: "describe_table" as const,
+  description:
+    "Get the schema (column names, types, and constraints) of a Snowflake table.",
+  schema: {
+    database: z.string().describe("The name of the database."),
+    schema: z.string().describe("The name of the schema."),
+    table: z.string().describe("The name of the table to describe."),
+  },
+  stake: "never_ask" as MCPToolStakeLevelType,
+};
+
+export const queryMeta = {
+  name: "query" as const,
+  description:
+    "Execute a read-only SQL query against Snowflake. Write operations are not allowed. Use the dedicated tools for listing databases, schemas, tables, and describing table structure.",
+  schema: {
+    sql: z
+      .string()
+      .describe("The SQL query to execute. Must be a read-only query."),
+    database: z
+      .string()
+      .optional()
+      .describe("The database context for the query."),
+    schema: z.string().optional().describe("The schema context for the query."),
+    warehouse: z
+      .string()
+      .optional()
+      .describe("The warehouse to use for query execution."),
+    max_rows: z
+      .number()
+      .int()
+      .min(1)
+      .max(MAX_QUERY_ROWS)
+      .optional()
+      .describe(
+        `Maximum number of rows to return. Defaults to ${MAX_QUERY_ROWS}.`
+      ),
+  },
+  stake: "never_ask" as MCPToolStakeLevelType,
+};
+
+export const TOOLS_META = [
+  listDatabasesMeta,
+  listSchemasMeta,
+  listTablesMeta,
+  describeTableMeta,
+  queryMeta,
+];
+
+export const SNOWFLAKE_TOOLS: MCPToolType[] = TOOLS_META.map((t) => ({
+  name: t.name,
+  description: t.description,
+  inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+}));
+
+export const SNOWFLAKE_TOOL_STAKES: Record<string, MCPToolStakeLevelType> =
+  Object.fromEntries(TOOLS_META.map((t) => [t.name, t.stake]));
+
+export const SNOWFLAKE_SERVER_INFO = {
+  name: "snowflake" as const,
+  version: "1.0.0",
+  description: "Execute read-only SQL queries and browse schema in Snowflake.",
+  authorization: {
+    provider: "snowflake" as const,
+    supported_use_cases: ["personal_actions"] as MCPOAuthUseCase[],
+  },
+  icon: "SnowflakeLogo" as const,
+  documentationUrl: "https://docs.dust.tt/docs/snowflake-tool",
+  instructions:
+    "Use list_databases, list_schemas, list_tables, and describe_table to explore the schema before writing queries. Only SELECT queries are allowed.",
+};
+
+export const SNOWFLAKE_SERVER = {
+  serverInfo: SNOWFLAKE_SERVER_INFO,
+  tools: SNOWFLAKE_TOOLS,
+  tools_stakes: SNOWFLAKE_TOOL_STAKES,
+} as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/snowflake/tools/index.ts
+++ b/front/lib/api/actions/servers/snowflake/tools/index.ts
@@ -1,0 +1,209 @@
+import { MCPError } from "@app/lib/actions/mcp_errors";
+import type { ToolDefinition } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { defineTool } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { SnowflakeClient } from "@app/lib/api/actions/servers/snowflake/client";
+import {
+  describeTableMeta,
+  listDatabasesMeta,
+  listSchemasMeta,
+  listTablesMeta,
+  MAX_QUERY_ROWS,
+  queryMeta,
+} from "@app/lib/api/actions/servers/snowflake/metadata";
+import type { Result } from "@app/types";
+import { Err, Ok } from "@app/types";
+
+const CONNECTION_ERROR = new MCPError(
+  "Snowflake connection not configured. Please connect your Snowflake account."
+);
+
+function getClientFromAuthInfo(
+  authInfo:
+    | {
+        extra?: Record<string, unknown>;
+        token?: string;
+      }
+    | null
+    | undefined
+): Result<SnowflakeClient, MCPError> {
+  const account = authInfo?.extra?.snowflake_account;
+  const warehouse = authInfo?.extra?.snowflake_warehouse;
+  const token = authInfo?.token;
+
+  if (typeof account !== "string" || typeof warehouse !== "string" || !token) {
+    return new Err(CONNECTION_ERROR);
+  }
+
+  return new Ok(new SnowflakeClient(account, token, warehouse));
+}
+
+const listDatabasesTool = defineTool({
+  ...listDatabasesMeta,
+  handler: async (_params, extra) => {
+    const clientRes = getClientFromAuthInfo(extra.authInfo);
+    if (clientRes.isErr()) {
+      return clientRes;
+    }
+
+    const result = await clientRes.value.listDatabases();
+    if (result.isErr()) {
+      return new Err(new MCPError(result.error.message));
+    }
+
+    const databases = result.value;
+    return new Ok([
+      {
+        type: "text" as const,
+        text: `Found ${databases.length} databases`,
+      },
+      {
+        type: "text" as const,
+        text: JSON.stringify({ databases }, null, 2),
+      },
+    ]);
+  },
+});
+
+const listSchemasTool = defineTool({
+  ...listSchemasMeta,
+  handler: async ({ database }, extra) => {
+    const clientRes = getClientFromAuthInfo(extra.authInfo);
+    if (clientRes.isErr()) {
+      return clientRes;
+    }
+
+    const result = await clientRes.value.listSchemas(database);
+    if (result.isErr()) {
+      return new Err(new MCPError(result.error.message));
+    }
+
+    const schemas = result.value;
+    return new Ok([
+      {
+        type: "text" as const,
+        text: `Found ${schemas.length} schemas in database "${database}"`,
+      },
+      {
+        type: "text" as const,
+        text: JSON.stringify({ database, schemas }, null, 2),
+      },
+    ]);
+  },
+});
+
+const listTablesTool = defineTool({
+  ...listTablesMeta,
+  handler: async ({ database, schema }, extra) => {
+    const clientRes = getClientFromAuthInfo(extra.authInfo);
+    if (clientRes.isErr()) {
+      return clientRes;
+    }
+
+    const result = await clientRes.value.listTables(database, schema);
+    if (result.isErr()) {
+      return new Err(new MCPError(result.error.message));
+    }
+
+    const tables = result.value;
+    return new Ok([
+      {
+        type: "text" as const,
+        text: `Found ${tables.length} tables/views in "${database}"."${schema}"`,
+      },
+      {
+        type: "text" as const,
+        text: JSON.stringify({ database, schema, tables }, null, 2),
+      },
+    ]);
+  },
+});
+
+const describeTableTool = defineTool({
+  ...describeTableMeta,
+  handler: async ({ database, schema, table }, extra) => {
+    const clientRes = getClientFromAuthInfo(extra.authInfo);
+    if (clientRes.isErr()) {
+      return clientRes;
+    }
+
+    const result = await clientRes.value.describeTable(database, schema, table);
+    if (result.isErr()) {
+      return new Err(new MCPError(result.error.message));
+    }
+
+    const columns = result.value;
+    return new Ok([
+      {
+        type: "text" as const,
+        text: `Table "${database}"."${schema}"."${table}" has ${columns.length} columns`,
+      },
+      {
+        type: "text" as const,
+        text: JSON.stringify(
+          {
+            database,
+            schema,
+            table,
+            columns,
+          },
+          null,
+          2
+        ),
+      },
+    ]);
+  },
+});
+
+const queryTool = defineTool({
+  ...queryMeta,
+  handler: async ({ sql, database, schema, warehouse, max_rows }, extra) => {
+    const clientRes = getClientFromAuthInfo(extra.authInfo);
+    if (clientRes.isErr()) {
+      return clientRes;
+    }
+
+    const result = await clientRes.value.readOnlyQuery(
+      sql,
+      database,
+      schema,
+      warehouse,
+      max_rows ?? MAX_QUERY_ROWS
+    );
+    if (result.isErr()) {
+      return new Err(new MCPError(result.error.message));
+    }
+
+    const { columns, rows, rowCount } = result.value;
+
+    // Format output for LLM consumption
+    const columnNames = columns.map((c) => c.name);
+    const columnTypes = columns.map((c) => `${c.name}: ${c.type}`);
+
+    return new Ok([
+      {
+        type: "text" as const,
+        text: `Query returned ${rowCount} rows with columns: ${columnNames.join(", ")}`,
+      },
+      {
+        type: "text" as const,
+        text: JSON.stringify(
+          {
+            columns: columnTypes,
+            rowCount,
+            data: rows,
+          },
+          null,
+          2
+        ),
+      },
+    ]);
+  },
+});
+
+export const TOOLS = [
+  listDatabasesTool,
+  listSchemasTool,
+  listTablesTool,
+  describeTableTool,
+  queryTool,
+] as ToolDefinition[];

--- a/front/lib/api/oauth/providers/snowflake.ts
+++ b/front/lib/api/oauth/providers/snowflake.ts
@@ -18,6 +18,7 @@ import {
 } from "@app/lib/api/oauth/utils";
 import type { Authenticator } from "@app/lib/auth";
 import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
+import { escapeSnowflakeIdentifier } from "@app/lib/utils/snowflake";
 import logger from "@app/logger/logger";
 import type { ExtraConfigType } from "@app/pages/w/[wId]/oauth/[provider]/setup";
 import type { Result } from "@app/types";
@@ -353,7 +354,7 @@ export class SnowflakeOAuthProvider implements BaseOAuthStrategyProvider {
       try {
         await new Promise<void>((resolve, reject) => {
           connection.execute({
-            sqlText: `USE WAREHOUSE "${warehouse}"`,
+            sqlText: `USE WAREHOUSE "${escapeSnowflakeIdentifier(warehouse)}"`,
             complete: (err: SnowflakeError | undefined) => {
               if (err) {
                 reject(err);

--- a/front/lib/utils/snowflake.ts
+++ b/front/lib/utils/snowflake.ts
@@ -1,0 +1,7 @@
+/**
+ * Escape a Snowflake identifier for use in double-quoted SQL.
+ * Doubles any internal double-quote characters to prevent SQL injection.
+ */
+export function escapeSnowflakeIdentifier(identifier: string): string {
+  return identifier.replace(/"/g, '""');
+}


### PR DESCRIPTION
## Description

Implement the actual Snowflake MCP server tools on top of the boilerplate (#20222).

### Tools
- `list_databases` - List accessible databases
- `list_schemas` - List schemas in a database
- `list_tables` - List tables/views in a schema
- `describe_table` - Get table column info
- `query` - Execute SELECT/WITH queries with EXPLAIN validation

### Implementation
- `SnowflakeClient` using official `snowflake-sdk` with OAuth authentication
- Read-only query validation using EXPLAIN
- Static IP proxy support for Snowflake IP whitelisting

## Tests

- CI passes
- Manual e2e testing with Snowflake account
- Verify read-only query validation rejects write operations
- Verify personal auth flow with role override

## Risk

**Low risk.** New MCP server behind `snowflake_tool` feature flag, isolated from existing functionality. Safe to rollback by disabling feature flag.

## Deploy Plan

1. Merge this PR
2. Deploy front
3. Enable `snowflake_tool` feature flag for test workspaces
4. Roll out to broader audience after validation