### PR TITLE
[front] perf: update db indexes on agent step contents

### DIFF
--- a/front/lib/models/agent/agent_step_content.ts
+++ b/front/lib/models/agent/agent_step_content.ts
@@ -78,18 +78,6 @@ AgentStepContentModel.init(
         name: "agent_step_contents_agent_message_id_step_index_versioned",
       },
       {
-        fields: ["agentMessageId"],
-        name: "agent_step_contents_agent_message_id_idx",
-      },
-      {
-        fields: ["workspaceId"],
-        name: "agent_step_contents_workspace_id_idx",
-      },
-      {
-        fields: ["type"],
-        name: "agent_step_contents_type_idx",
-      },
-      {
         fields: ["workspaceId", "agentMessageId"],
         name: "agent_step_contents_workspace_id_idx",
       },

--- a/front/lib/models/agent/agent_step_content.ts
+++ b/front/lib/models/agent/agent_step_content.ts
@@ -74,7 +74,7 @@ AgentStepContentModel.init(
     indexes: [
       {
         unique: true,
-        fields: ["agentMessageId", "step", "index", "version"],
+        fields: ["workspaceId", "agentMessageId", "step", "index", "version"],
         name: "agent_step_contents_agent_message_id_step_index_versioned",
       },
       {
@@ -88,6 +88,17 @@ AgentStepContentModel.init(
       {
         fields: ["type"],
         name: "agent_step_contents_type_idx",
+      },
+      {
+        fields: ["workspaceId", "agentMessageId"],
+        name: "agent_step_contents_workspace_id_idx",
+      },
+      {
+        fields: ["workspaceId", "agentMessageId"],
+        name: "agent_step_contents_workspace_id_idx",
+        where: {
+          type: "function_call",
+        },
       },
     ],
   }

--- a/front/lib/models/agent/agent_step_content.ts
+++ b/front/lib/models/agent/agent_step_content.ts
@@ -76,7 +76,7 @@ AgentStepContentModel.init(
         unique: true,
         concurrently: true,
         fields: ["workspaceId", "agentMessageId", "step", "index", "version"],
-        name: "agent_step_contents_agent_message_id_step_index_versioned",
+        name: "agent_step_contents_workspace_agent_message_step_index_version",
       },
       {
         concurrently: true,

--- a/front/lib/models/agent/agent_step_content.ts
+++ b/front/lib/models/agent/agent_step_content.ts
@@ -74,14 +74,16 @@ AgentStepContentModel.init(
     indexes: [
       {
         unique: true,
+        concurrently: true,
         fields: ["workspaceId", "agentMessageId", "step", "index", "version"],
         name: "agent_step_contents_agent_message_id_step_index_versioned",
       },
       {
+        concurrently: true,
         fields: ["workspaceId", "agentMessageId"],
-        name: "agent_step_contents_workspace_id_idx",
       },
       {
+        concurrently: true,
         fields: ["workspaceId", "agentMessageId"],
         name: "agent_step_contents_workspace_id_idx",
         where: {

--- a/front/lib/resources/agent_step_content_resource.ts
+++ b/front/lib/resources/agent_step_content_resource.ts
@@ -271,15 +271,18 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
       AgentStepContentModel.findAll({
         include: includeClause,
         where: whereClause,
-        order: [["createdAt", "DESC"]],
         limit: limit + 1,
       }),
     ]);
 
-    const hasMore = stepContents.length > limit;
+    const sortedStepContents = stepContents.toSorted(
+      (a, b) => b.createdAt.getTime() - a.createdAt.getTime()
+    );
+
+    const hasMore = sortedStepContents.length > limit;
     const actualStepContents = hasMore
-      ? stepContents.slice(0, limit)
-      : stepContents;
+      ? sortedStepContents.slice(0, limit)
+      : sortedStepContents;
 
     const nextCursor = hasMore
       ? actualStepContents[

--- a/front/lib/resources/agent_step_content_resource.ts
+++ b/front/lib/resources/agent_step_content_resource.ts
@@ -102,14 +102,11 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
     blob: CreationAttributes<AgentStepContentModel>,
     transaction?: Transaction
   ): Promise<AgentStepContentResource> {
-    const agentStepContent = await AgentStepContentModel.create(blob, {
+    const agentStepContent = await this.model.create(blob, {
       transaction,
     });
 
-    return new AgentStepContentResource(
-      AgentStepContentModel,
-      agentStepContent.get()
-    );
+    return new AgentStepContentResource(this.model, agentStepContent.get());
   }
 
   public static async fetchByModelIds(
@@ -172,7 +169,7 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
       agentMessageIds
     );
 
-    let contents = await AgentStepContentModel.findAll({
+    let contents = await this.model.findAll({
       where: {
         workspaceId: owner.id,
         agentMessageId: {
@@ -196,8 +193,7 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
     }
 
     return contents.map(
-      (content) =>
-        new AgentStepContentResource(AgentStepContentModel, content.get())
+      (content) => new AgentStepContentResource(this.model, content.get())
     );
   }
 
@@ -263,12 +259,12 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
     ];
 
     const [totalCount, stepContents] = await Promise.all([
-      AgentStepContentModel.count({
+      this.model.count({
         include: includeClause,
         where: whereClause,
         distinct: true,
       }),
-      AgentStepContentModel.findAll({
+      this.model.findAll({
         include: includeClause,
         where: whereClause,
         limit: limit + 1,
@@ -337,7 +333,7 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
       return new Err(new Error("User does not have access to agents"));
     }
 
-    const deletedCount = await AgentStepContentModel.destroy({
+    const deletedCount = await this.model.destroy({
       where: {
         id: this.id,
         workspaceId: owner.id,

--- a/front/migrations/db/migration_478.sql
+++ b/front/migrations/db/migration_478.sql
@@ -1,0 +1,9 @@
+-- Migration created on Jan 15, 2026
+CREATE UNIQUE INDEX CONCURRENTLY "agent_step_contents_workspace_agent_message_step_index_version" ON "agent_step_contents" ("workspaceId", "agentMessageId", "step", "index", "version");
+CREATE INDEX CONCURRENTLY "agent_step_contents_workspace_id_agent_message_id" ON "agent_step_contents" ("workspaceId", "agentMessageId");
+CREATE INDEX CONCURRENTLY "agent_step_contents_workspace_id_step_content_id_function_call" ON "agent_step_contents" ("workspaceId", "agentMessageId") WHERE "type"='functionCall';
+
+DROP INDEX CONCURRENTLY "agent_step_contents_agent_message_id_idx";
+DROP INDEX CONCURRENTLY "agent_step_contents_type_idx";
+DROP INDEX CONCURRENTLY "agent_step_contents_workspace_id_idx";
+DROP INDEX CONCURRENTLY "agent_step_contents_agent_message_id_step_index_versioned";


### PR DESCRIPTION
## Description

- This PR goes through the queries done on table `agent_step_contents` and changes the indexes we have to speed up more efficiently the queries we do run.

## Tests

- Tested locally.

## Risk

- Low, will monitor db perfs

## Deploy Plan

- Run migration.
- Deploy front.
