### PR TITLE
feat(front): improve space context page with card-based file display

### DIFF
--- a/front/components/assistant/conversation/space/SpaceContextFileList.tsx
+++ b/front/components/assistant/conversation/space/SpaceContextFileList.tsx
@@ -1,0 +1,167 @@
+import { Spinner } from "@dust-tt/sparkle";
+import { useMemo } from "react";
+
+import { AttachmentCitation } from "@app/components/assistant/conversation/attachment/AttachmentCitation";
+import { markdownCitationToAttachmentCitation } from "@app/components/assistant/conversation/attachment/utils";
+import type { ActionGeneratedFileType } from "@app/lib/actions/types";
+import { useProjectFiles } from "@app/lib/swr/projects";
+import type { LightWorkspaceType, WorkspaceType } from "@app/types";
+
+interface SpaceContextFileListProps {
+  owner: WorkspaceType;
+  spaceId: string;
+}
+
+interface FileGroup {
+  files: ActionGeneratedFileType[];
+  key: string;
+  title: string;
+}
+
+function groupFilesByContentType(
+  files: ActionGeneratedFileType[]
+): FileGroup[] {
+  const textFiles: ActionGeneratedFileType[] = [];
+  const imageFiles: ActionGeneratedFileType[] = [];
+  const otherFiles: ActionGeneratedFileType[] = [];
+
+  for (const file of files) {
+    if (file.contentType.startsWith("image/")) {
+      imageFiles.push(file);
+    } else if (
+      file.contentType.startsWith("text/") ||
+      file.contentType === "application/json"
+    ) {
+      textFiles.push(file);
+    } else {
+      otherFiles.push(file);
+    }
+  }
+
+  const groups: FileGroup[] = [];
+
+  if (textFiles.length > 0) {
+    groups.push({
+      key: "text",
+      title: "Text",
+      files: textFiles,
+    });
+  }
+
+  if (imageFiles.length > 0) {
+    groups.push({
+      key: "images",
+      title: "Images",
+      files: imageFiles,
+    });
+  }
+
+  if (otherFiles.length > 0) {
+    groups.push({
+      key: "others",
+      title: "Others",
+      files: otherFiles,
+    });
+  }
+
+  return groups;
+}
+
+interface FileRendererProps {
+  files: ActionGeneratedFileType[];
+  owner: LightWorkspaceType;
+}
+
+const FileRenderer = ({ files, owner }: FileRendererProps) => (
+  <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 md:grid-cols-3">
+    {files.map((file, index) => {
+      const attachmentCitation = markdownCitationToAttachmentCitation({
+        href: `/api/w/${owner.sId}/files/${file.fileId}`,
+        title: file.title,
+        contentType: file.contentType,
+        fileId: file.fileId,
+      });
+
+      return (
+        <AttachmentCitation
+          key={index}
+          attachmentCitation={attachmentCitation}
+          owner={owner}
+          conversationId={null}
+        />
+      );
+    })}
+  </div>
+);
+
+interface FileGroupSectionProps {
+  group: FileGroup;
+  owner: LightWorkspaceType;
+}
+
+const FileGroupSection = ({ group, owner }: FileGroupSectionProps) => {
+  return (
+    <div className="space-y-3">
+      <div className="text-element-900 text-sm font-medium">{group.title}</div>
+      <div className="flex flex-col gap-4">
+        <FileRenderer files={group.files} owner={owner} />
+      </div>
+    </div>
+  );
+};
+
+export function SpaceContextFileList({
+  owner,
+  spaceId,
+}: SpaceContextFileListProps) {
+  const { projectFiles, isProjectFilesLoading, isProjectFilesError } =
+    useProjectFiles({
+      owner,
+      projectId: spaceId,
+    });
+
+  // Convert project files to ActionGeneratedFileType format
+  const actionFiles: ActionGeneratedFileType[] = useMemo(
+    () =>
+      projectFiles.map((file) => ({
+        fileId: file.sId,
+        title: file.fileName,
+        contentType: file.contentType,
+        snippet: null,
+        createdAt: file.createdAt,
+        updatedAt: file.updatedAt,
+      })),
+    [projectFiles]
+  );
+
+  const fileGroups = useMemo(
+    () => groupFilesByContentType(actionFiles),
+    [actionFiles]
+  );
+
+  if (isProjectFilesLoading) {
+    return (
+      <div className="flex w-full items-center justify-center p-8">
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (isProjectFilesError) {
+    return (
+      <div className="flex w-full items-center justify-center p-8">
+        <div className="text-center text-warning">
+          Failed to load project files. Please try again.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      {fileGroups.map((group) => (
+        <FileGroupSection key={group.key} group={group} owner={owner} />
+      ))}
+    </div>
+  );
+}

--- a/front/lib/swr/projects.ts
+++ b/front/lib/swr/projects.ts
@@ -1,0 +1,87 @@
+import type { Fetcher } from "swr";
+
+import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress/client";
+import {
+  fetcher,
+  getErrorFromResponse,
+  useSWRWithDefaults,
+} from "@app/lib/swr/swr";
+import type { GetProjectFilesResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/project_files";
+import type {
+  FileTypeWithMetadata,
+  LightWorkspaceType,
+  Result,
+} from "@app/types";
+import { normalizeError } from "@app/types";
+import { Err, Ok } from "@app/types";
+
+export type ProjectFileType = FileTypeWithMetadata & {
+  createdAt: number;
+  updatedAt: number;
+  user: {
+    sId: string;
+    name: string | null;
+  } | null;
+};
+
+export function useProjectFiles({
+  owner,
+  projectId,
+  disabled,
+}: {
+  owner: LightWorkspaceType;
+  projectId: string;
+  disabled?: boolean;
+}) {
+  const projectFilesFetcher: Fetcher<GetProjectFilesResponseBody> = fetcher;
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    disabled ? null : `/api/w/${owner.sId}/spaces/${projectId}/project_files`,
+    projectFilesFetcher
+  );
+
+  return {
+    projectFiles: data?.files ?? [],
+    isProjectFilesLoading: !disabled && !error && !data,
+    isProjectFilesError: !!error,
+    mutateProjectFiles: mutate,
+  };
+}
+
+export function useDeleteProjectFile({ owner }: { owner: LightWorkspaceType }) {
+  const sendNotification = useSendNotification();
+
+  return async (fileId: string): Promise<Result<void, Error>> => {
+    try {
+      const res = await clientFetch(`/api/w/${owner.sId}/files/${fileId}`, {
+        method: "DELETE",
+      });
+
+      if (!res.ok) {
+        const errorData = await getErrorFromResponse(res);
+        sendNotification({
+          type: "error",
+          title: "Failed to delete file",
+          description: errorData.message,
+        });
+        return new Err(new Error(errorData.message));
+      }
+
+      sendNotification({
+        type: "success",
+        title: "File deleted",
+      });
+
+      return new Ok(undefined);
+    } catch (e) {
+      const errorMessage = normalizeError(e).message;
+      sendNotification({
+        type: "error",
+        title: "Failed to delete file",
+        description: errorMessage,
+      });
+      return new Err(new Error(errorMessage));
+    }
+  };
+}

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_files/index.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_files/index.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, it } from "vitest";
+
+import { Authenticator } from "@app/lib/auth";
+import { FileFactory } from "@app/tests/utils/FileFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+
+import handler from "./index";
+
+describe("GET /api/w/[wId]/spaces/[spaceId]/project_files", () => {
+  it("should return project files for a valid space", async () => {
+    const { req, res, workspace, user, globalSpace } =
+      await createPrivateApiMockRequest({
+        method: "GET",
+        role: "user",
+      });
+
+    // Use the global space (user already has access)
+    const space = globalSpace;
+
+    // Create some project files
+    await FileFactory.create(workspace, user, {
+      contentType: "text/plain",
+      fileName: "test1.txt",
+      fileSize: 100,
+      status: "ready",
+      useCase: "project_context",
+      useCaseMetadata: { spaceId: space.sId },
+    });
+
+    await FileFactory.create(workspace, user, {
+      contentType: "image/png",
+      fileName: "test2.png",
+      fileSize: 200,
+      status: "ready",
+      useCase: "project_context",
+      useCaseMetadata: { spaceId: space.sId },
+    });
+
+    req.query.spaceId = space.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const responseData = res._getJSONData();
+    expect(responseData.files).toHaveLength(2);
+    expect(responseData.files[0].fileName).toBeDefined();
+    expect(responseData.files[0].user).toBeDefined();
+    expect(responseData.files[0].user?.sId).toBe(user.sId);
+  });
+
+  it("should return empty array when space has no files", async () => {
+    const { req, res, globalSpace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+    });
+
+    req.query.spaceId = globalSpace.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const responseData = res._getJSONData();
+    expect(responseData.files).toHaveLength(0);
+  });
+
+  it("should return 404 for non-existent space", async () => {
+    const { req, res } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+    });
+
+    req.query.spaceId = "non_existent_space_id";
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(404);
+    const responseData = res._getJSONData();
+    expect(responseData.error.type).toBe("space_not_found");
+  });
+
+  it("should return 404 when user cannot read space", async () => {
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+    });
+
+    // Create a space that the user is not a member of
+    const space = await SpaceFactory.regular(workspace);
+
+    // Create another user who owns the space
+    const otherUser = await UserFactory.basic();
+    await Authenticator.fromUserIdAndWorkspaceId(otherUser.sId, workspace.sId);
+
+    req.query.spaceId = space.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(404);
+    const responseData = res._getJSONData();
+    expect(responseData.error.type).toBe("space_not_found");
+  });
+
+  it("should include user information for files with uploaders", async () => {
+    const { req, res, workspace, user, globalSpace } =
+      await createPrivateApiMockRequest({
+        method: "GET",
+        role: "user",
+      });
+
+    const space = globalSpace;
+
+    // Create file with user
+    await FileFactory.create(workspace, user, {
+      contentType: "text/csv",
+      fileName: "data.csv",
+      fileSize: 500,
+      status: "ready",
+      useCase: "project_context",
+      useCaseMetadata: { spaceId: space.sId },
+    });
+
+    // Create file without user
+    await FileFactory.create(workspace, null, {
+      contentType: "application/json",
+      fileName: "data.json",
+      fileSize: 300,
+      status: "ready",
+      useCase: "project_context",
+      useCaseMetadata: { spaceId: space.sId },
+    });
+
+    req.query.spaceId = space.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const responseData = res._getJSONData();
+    expect(responseData.files).toHaveLength(2);
+
+    // Find the files in response
+    const fileWithUserResponse = responseData.files.find(
+      (f: any) => f.fileName === "data.csv"
+    );
+    const fileWithoutUserResponse = responseData.files.find(
+      (f: any) => f.fileName === "data.json"
+    );
+
+    // File with user should have user info
+    expect(fileWithUserResponse.user).toBeDefined();
+    expect(fileWithUserResponse.user.sId).toBe(user.sId);
+    expect(fileWithUserResponse.user.name).toBeDefined();
+
+    // File without user should have null user
+    expect(fileWithoutUserResponse.user).toBeNull();
+  });
+
+  it("should return 400 for invalid spaceId parameter", async () => {
+    const { req, res } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "user",
+    });
+
+    // Set spaceId to an array to make it invalid
+    req.query.spaceId = ["invalid", "array"];
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    const responseData = res._getJSONData();
+    expect(responseData.error.type).toBe("invalid_request_error");
+  });
+
+  it("should return 405 for unsupported methods", async () => {
+    const { req, res, globalSpace } = await createPrivateApiMockRequest({
+      method: "POST",
+      role: "user",
+    });
+
+    req.query.spaceId = globalSpace.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(405);
+    const responseData = res._getJSONData();
+    expect(responseData.error.type).toBe("method_not_supported_error");
+  });
+
+  it("should return files with correct metadata format", async () => {
+    const { req, res, workspace, user, globalSpace } =
+      await createPrivateApiMockRequest({
+        method: "GET",
+        role: "user",
+      });
+
+    const space = globalSpace;
+
+    await FileFactory.create(workspace, user, {
+      contentType: "text/markdown",
+      fileName: "readme.md",
+      fileSize: 1024,
+      status: "ready",
+      useCase: "project_context",
+      useCaseMetadata: { spaceId: space.sId },
+    });
+
+    req.query.spaceId = space.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const responseData = res._getJSONData();
+    expect(responseData.files).toHaveLength(1);
+
+    const file = responseData.files[0];
+
+    // Check all required fields are present
+    expect(file.sId).toBeDefined();
+    expect(file.id).toBe(file.sId); // id should equal sId
+    expect(file.fileName).toBe("readme.md");
+    expect(file.fileSize).toBe(1024);
+    expect(file.contentType).toBe("text/markdown");
+    expect(file.status).toBe("ready");
+    expect(file.version).toBeDefined();
+    expect(file.useCase).toBe("project_context");
+    expect(file.useCaseMetadata).toBeDefined();
+    expect(typeof file.createdAt).toBe("number");
+    expect(typeof file.updatedAt).toBe("number");
+  });
+});

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_files/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_files/index.ts
@@ -1,0 +1,104 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { FileResource } from "@app/lib/resources/file_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { FileTypeWithMetadata, WithAPIErrorResponse } from "@app/types";
+import { isString } from "@app/types";
+
+export type ProjectFileType = FileTypeWithMetadata & {
+  createdAt: number;
+  updatedAt: number;
+  user: {
+    sId: string;
+    name: string | null;
+  } | null;
+};
+
+export type GetProjectFilesResponseBody = {
+  files: ProjectFileType[];
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetProjectFilesResponseBody>>,
+  auth: Authenticator
+): Promise<void> {
+  const { spaceId } = req.query;
+  if (!isString(spaceId)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid spaceId query parameter.",
+      },
+    });
+  }
+
+  const space = await SpaceResource.fetchById(auth, spaceId);
+  if (!space || !space.canRead(auth)) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "space_not_found",
+        message: "Space not found.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      const files = await FileResource.listByProject(auth, {
+        projectId: spaceId,
+      });
+
+      // Fetch user information for all files
+      const userIds = files
+        .map((f) => f.userId)
+        .filter((id): id is number => id !== null);
+      const uniqueUserIds = Array.from(new Set(userIds));
+      const users = await UserResource.fetchByModelIds(uniqueUserIds);
+      const userMap = new Map(users.map((u) => [u.id, u]));
+
+      const filesWithMetadata: ProjectFileType[] = files.map((f) => {
+        const user = f.userId ? userMap.get(f.userId) : null;
+        return {
+          sId: f.sId,
+          id: f.sId, // For FileType compatibility
+          fileName: f.fileName,
+          fileSize: f.fileSize,
+          contentType: f.contentType,
+          status: f.status,
+          version: f.version,
+          useCase: f.useCase,
+          useCaseMetadata: f.useCaseMetadata ?? {},
+          createdAt: f.createdAt.getTime(),
+          updatedAt: f.updatedAt.getTime(),
+          user: user
+            ? {
+                sId: user.sId,
+                name: user.fullName() || user.username,
+              }
+            : null,
+        };
+      });
+
+      res.status(200).json({ files: filesWithMetadata });
+      return;
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "Method not supported.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);


### PR DESCRIPTION
## Description

This PR redesigns the Space Context page file list UI to provide a more visual and user-friendly experience. The changes replace the previous DataTable-based interface with a modern card-based grid layout that groups files by type and provides inline previews.

<img width="1017" height="964" alt="image" src="https://github.com/user-attachments/assets/45d047f9-9de0-4611-afee-05f624c9a5c0" />


## Tests

*Manual testing performed:*

## Risk



## Deploy Plan
