### PR TITLE
[front] - feat(obs): document outputs zoomed

### DIFF
--- a/front/components/agent_builder/observability/charts/DatasourceRetrievalTreemapChart.tsx
+++ b/front/components/agent_builder/observability/charts/DatasourceRetrievalTreemapChart.tsx
@@ -245,7 +245,8 @@ export function DatasourceRetrievalTreemapChart({
   const [zoomSelection, setZoomSelection] = useState<ZoomSelection | null>(
     null
   );
-  const version = mode === "version" ? selectedVersion?.version : undefined;
+  const version =
+    isCustomAgent && mode === "version" ? selectedVersion?.version : undefined;
 
   const {
     datasourceRetrieval,
@@ -256,10 +257,7 @@ export function DatasourceRetrievalTreemapChart({
     workspaceId,
     agentConfigurationId,
     days: period,
-    version:
-      isCustomAgent && mode === "version"
-        ? selectedVersion?.version
-        : undefined,
+    version,
   });
   const { treemapData, legendItems } = useMemo(() => {
     if (!datasourceRetrieval.length) {
@@ -378,68 +376,34 @@ export function DatasourceRetrievalTreemapChart({
     });
   }, []);
 
-  const renderDatasourceTooltip = useCallback(
-    (props: { payload?: { payload?: TreemapNode }[] }) => {
-      const { payload } = props;
-      if (!payload || !payload[0]) {
-        return null;
-      }
-
-      const data = payload[0].payload;
+  const makeTooltipRenderer = useCallback(
+    (total: number) => (props: { payload?: { payload?: TreemapNode }[] }) => {
+      const data = props.payload?.[0]?.payload;
       if (!data) {
         return null;
       }
 
       const size = data.size ?? 0;
-      const percent =
-        totalRetrievals > 0 ? Math.round((size / totalRetrievals) * 100) : 0;
+      const percent = total > 0 ? Math.round((size / total) * 100) : 0;
 
       return (
         <ChartTooltipCard
           title={data.name}
-          rows={[
-            {
-              label: "Retrievals",
-              value: size,
-              percent,
-            },
-          ]}
+          rows={[{ label: "Retrievals", value: size, percent }]}
         />
       );
     },
-    [totalRetrievals]
+    []
   );
 
-  const renderDocumentsTooltip = useCallback(
-    (props: { payload?: { payload?: TreemapNode }[] }) => {
-      const { payload } = props;
-      if (!payload || !payload[0]) {
-        return null;
-      }
+  const renderDatasourceTooltip = useMemo(
+    () => makeTooltipRenderer(totalRetrievals),
+    [makeTooltipRenderer, totalRetrievals]
+  );
 
-      const data = payload[0].payload;
-      if (!data) {
-        return null;
-      }
-
-      const size = data.size ?? 0;
-      const percent =
-        totalDocuments > 0 ? Math.round((size / totalDocuments) * 100) : 0;
-
-      return (
-        <ChartTooltipCard
-          title={data.name}
-          rows={[
-            {
-              label: "Retrievals",
-              value: size,
-              percent,
-            },
-          ]}
-        />
-      );
-    },
-    [totalDocuments]
+  const renderDocumentsTooltip = useMemo(
+    () => makeTooltipRenderer(totalDocuments),
+    [makeTooltipRenderer, totalDocuments]
   );
 
   const isDialogOpen = zoomSelection !== null;

--- a/front/components/agent_builder/observability/charts/DatasourceRetrievalTreemapChart.tsx
+++ b/front/components/agent_builder/observability/charts/DatasourceRetrievalTreemapChart.tsx
@@ -103,7 +103,6 @@ export function DatasourceRetrievalTreemapChart({
         ? selectedVersion?.version
         : undefined,
   });
-
   const { treemapData, legendItems } = useMemo(() => {
     if (!datasourceRetrieval.length) {
       return { treemapData: null, legendItems: [] };

--- a/front/components/agent_builder/observability/charts/DatasourceRetrievalTreemapChart.tsx
+++ b/front/components/agent_builder/observability/charts/DatasourceRetrievalTreemapChart.tsx
@@ -1,4 +1,13 @@
-import { useCallback, useMemo } from "react";
+import {
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  Spinner,
+} from "@dust-tt/sparkle";
+import { useCallback, useMemo, useState } from "react";
 import { ResponsiveContainer, Tooltip, Treemap } from "recharts";
 
 import {
@@ -9,15 +18,25 @@ import { useObservabilityContext } from "@app/components/agent_builder/observabi
 import { ChartContainer } from "@app/components/agent_builder/observability/shared/ChartContainer";
 import { ChartTooltipCard } from "@app/components/agent_builder/observability/shared/ChartTooltip";
 import { getIndexedColor } from "@app/components/agent_builder/observability/utils";
-import { useAgentDatasourceRetrieval } from "@app/lib/swr/assistants";
+import {
+  useAgentDatasourceRetrieval,
+  useAgentDatasourceRetrievalDocuments,
+} from "@app/lib/swr/assistants";
 import { asDisplayName } from "@app/types";
 
 interface TreemapNode {
   name: string;
   size: number;
   color: string;
+  mcpServerConfigId?: string;
+  mcpServerDisplayName?: string;
+  mcpServerName?: string;
+  dataSourceId?: string;
+  parentId?: string | null;
+  documentId?: string;
+  children?: TreemapNode[];
 
-  [key: string]: string | number;
+  [key: string]: unknown;
 }
 
 interface TreemapContentProps {
@@ -28,8 +47,37 @@ interface TreemapContentProps {
   name?: string;
   value?: number;
   depth?: number;
+  index?: number;
   color?: string;
+  mcpServerConfigId?: string;
+  mcpServerDisplayName?: string;
+  mcpServerName?: string;
+  dataSourceId?: string;
+  parentId?: string | null;
+  documentId?: string;
+  children?: TreemapNode[] | null;
+  root?: {
+    depth?: number;
+    name?: string;
+    x?: number;
+    y?: number;
+    width?: number;
+    height?: number;
+    children?: unknown[] | null;
+    value?: number;
+  };
+  onNodeClick?: (node: TreemapNode) => void;
 }
+
+const MIN_TILE_SIDE_FOR_VALUE = 14;
+const MIN_TILE_SIDE_FOR_NAME = 28;
+const GROUP_OUTLINE_INSET = 2;
+const GROUP_OUTLINE_STROKE_WIDTH = 2;
+const LEAF_STROKE_WIDTH = 1;
+const GROUP_LABEL_HEIGHT = 18;
+const MIN_GROUP_WIDTH_FOR_LABEL = 40;
+const MIN_GROUP_HEIGHT_FOR_LABEL = 24;
+const DOCUMENTS_LIMIT = 200;
 
 function TreemapContent({
   x = 0,
@@ -38,9 +86,56 @@ function TreemapContent({
   height = 0,
   name = "",
   value = 0,
+  depth = 0,
+  index,
   color = INDEXED_COLORS[0],
+  mcpServerConfigId,
+  mcpServerDisplayName,
+  mcpServerName,
+  dataSourceId,
+  parentId,
+  documentId,
+  children,
+  root,
+  onNodeClick,
 }: TreemapContentProps) {
-  const shouldShowText = width > 0 && height > 0;
+  if (depth === 0) {
+    return null;
+  }
+
+  if ((children?.length ?? 0) > 0) {
+    return null;
+  }
+
+  const minSide = Math.min(width, height);
+  const shouldShowValue = minSide >= MIN_TILE_SIDE_FOR_VALUE;
+  const shouldShowName = minSide >= MIN_TILE_SIDE_FOR_NAME;
+  const shouldShowText = shouldShowValue;
+  const isClickable = !!onNodeClick;
+  const leafClassName = isClickable ? `${color} cursor-pointer` : color;
+
+  const rootX = root?.x ?? 0;
+  const rootY = root?.y ?? 0;
+  const rootWidth = root?.width ?? 0;
+  const rootHeight = root?.height ?? 0;
+  const rootChildrenCount = root?.children?.length ?? 0;
+
+  const shouldShowGroupOutline =
+    root?.depth === 1 &&
+    typeof index === "number" &&
+    index === rootChildrenCount - 1;
+
+  const groupName = root?.name ?? "";
+  const groupValue = typeof root?.value === "number" ? root.value : null;
+  const groupLabel =
+    groupValue !== null ? `${groupName} — ${groupValue}` : groupName;
+  const shouldShowGroupLabel =
+    shouldShowGroupOutline &&
+    groupName.length > 0 &&
+    rootWidth >= MIN_GROUP_WIDTH_FOR_LABEL &&
+    rootHeight >= MIN_GROUP_HEIGHT_FOR_LABEL;
+
+  const nameTextClassName = documentId ? "text-[10px]" : "text-xs";
 
   return (
     <g>
@@ -50,9 +145,27 @@ function TreemapContent({
         width={width}
         height={height}
         fill="currentColor"
-        className={color}
+        className={leafClassName}
         stroke="white"
-        strokeWidth={2}
+        strokeWidth={LEAF_STROKE_WIDTH}
+        onClick={
+          onNodeClick
+            ? (e) => {
+                e.stopPropagation();
+                onNodeClick({
+                  name,
+                  size: value,
+                  color,
+                  mcpServerConfigId,
+                  mcpServerDisplayName,
+                  mcpServerName,
+                  dataSourceId,
+                  parentId,
+                  documentId,
+                });
+              }
+            : undefined
+        }
       />
       {shouldShowText && (
         <foreignObject
@@ -63,11 +176,43 @@ function TreemapContent({
           pointerEvents="none"
         >
           <div className="flex h-full w-full flex-col items-center justify-center gap-0.5 overflow-hidden p-1 text-center">
-            <div className="w-full truncate text-ellipsis text-xs font-medium text-foreground dark:text-foreground-night">
-              {name}
-            </div>
+            {shouldShowName && (
+              <div
+                className={`w-full truncate text-ellipsis ${nameTextClassName} font-medium text-foreground dark:text-foreground-night`}
+              >
+                {name}
+              </div>
+            )}
             <div className="text-xs text-muted-foreground dark:text-muted-foreground-night">
               {value}
+            </div>
+          </div>
+        </foreignObject>
+      )}
+      {shouldShowGroupOutline && (
+        <rect
+          x={rootX + GROUP_OUTLINE_INSET}
+          y={rootY + GROUP_OUTLINE_INSET}
+          width={Math.max(0, rootWidth - GROUP_OUTLINE_INSET * 2)}
+          height={Math.max(0, rootHeight - GROUP_OUTLINE_INSET * 2)}
+          rx={2}
+          fill="none"
+          stroke="white"
+          strokeWidth={GROUP_OUTLINE_STROKE_WIDTH}
+          pointerEvents="none"
+        />
+      )}
+      {shouldShowGroupLabel && (
+        <foreignObject
+          x={rootX}
+          y={rootY}
+          width={Math.max(0, rootWidth)}
+          height={GROUP_LABEL_HEIGHT}
+          pointerEvents="none"
+        >
+          <div className="flex h-full w-full items-center justify-center overflow-hidden">
+            <div className="w-full truncate text-ellipsis rounded bg-white/70 px-1 py-0.5 text-center text-[11px] font-medium text-foreground dark:bg-black/30 dark:text-foreground-night">
+              {groupLabel}
             </div>
           </div>
         </foreignObject>
@@ -82,12 +227,25 @@ interface DatasourceRetrievalTreemapChartProps {
   isCustomAgent: boolean;
 }
 
+type ZoomSelection = {
+  mcpServerConfigId: string;
+  mcpServerDisplayName: string;
+  mcpServerName: string;
+  dataSourceId: string;
+  dataSourceDisplayName: string;
+  color: string;
+};
+
 export function DatasourceRetrievalTreemapChart({
   workspaceId,
   agentConfigurationId,
   isCustomAgent,
 }: DatasourceRetrievalTreemapChartProps) {
   const { period, mode, selectedVersion } = useObservabilityContext();
+  const [zoomSelection, setZoomSelection] = useState<ZoomSelection | null>(
+    null
+  );
+  const version = mode === "version" ? selectedVersion?.version : undefined;
 
   const {
     datasourceRetrieval,
@@ -124,13 +282,13 @@ export function DatasourceRetrievalTreemapChart({
         mcp.mcpServerConfigId,
         mcpServerConfigIds
       );
-      const displayName =
+      const serverDisplayName =
         asDisplayName(mcp.mcpServerConfigName) || mcp.mcpServerName;
 
       if (!seenServers.has(mcp.mcpServerConfigId)) {
         legend.push({
           key: mcp.mcpServerConfigId,
-          label: displayName,
+          label: serverDisplayName,
           colorClassName: serverColor,
         });
         seenServers.add(mcp.mcpServerConfigId);
@@ -139,8 +297,12 @@ export function DatasourceRetrievalTreemapChart({
       mcp.datasources.forEach((ds) => {
         flattenedData.push({
           name: ds.displayName,
+          dataSourceId: ds.dataSourceId,
           size: ds.count,
           color: serverColor,
+          mcpServerConfigId: mcp.mcpServerConfigId,
+          mcpServerDisplayName: serverDisplayName,
+          mcpServerName: mcp.mcpServerName,
         });
       });
     });
@@ -148,7 +310,75 @@ export function DatasourceRetrievalTreemapChart({
     return { treemapData: flattenedData, legendItems: legend };
   }, [datasourceRetrieval]);
 
-  const renderTooltip = useCallback(
+  const {
+    documents,
+    groups,
+    total: totalDocuments,
+    isDatasourceRetrievalDocumentsLoading,
+    isDatasourceRetrievalDocumentsError,
+  } = useAgentDatasourceRetrievalDocuments({
+    workspaceId,
+    agentConfigurationId,
+    days: period,
+    version,
+    mcpServerConfigId: zoomSelection?.mcpServerConfigId ?? null,
+    dataSourceId: zoomSelection?.dataSourceId ?? null,
+    limit: DOCUMENTS_LIMIT,
+    disabled: !zoomSelection,
+  });
+
+  const zoomTreemapData = useMemo(() => {
+    if (!zoomSelection) {
+      return null;
+    }
+
+    const documentsByParentId = new Map<string | null, typeof documents>();
+    documents.forEach((d) => {
+      const key = d.parentId ?? null;
+      const bucket = documentsByParentId.get(key);
+      if (bucket) {
+        bucket.push(d);
+      } else {
+        documentsByParentId.set(key, [d]);
+      }
+    });
+
+    return groups.map((g) => ({
+      name: g.displayName,
+      parentId: g.parentId,
+      size: g.count,
+      color: zoomSelection.color,
+      children: (documentsByParentId.get(g.parentId) ?? []).map((d) => ({
+        name: d.displayName,
+        documentId: d.documentId,
+        parentId: d.parentId,
+        size: d.count,
+        color: zoomSelection.color,
+      })),
+    }));
+  }, [documents, groups, zoomSelection]);
+
+  const handleDatasourceClick = useCallback((node: TreemapNode) => {
+    if (
+      !node.mcpServerConfigId ||
+      !node.mcpServerDisplayName ||
+      !node.mcpServerName ||
+      !node.dataSourceId
+    ) {
+      return;
+    }
+
+    setZoomSelection({
+      mcpServerConfigId: node.mcpServerConfigId,
+      mcpServerDisplayName: node.mcpServerDisplayName,
+      mcpServerName: node.mcpServerName,
+      dataSourceId: node.dataSourceId,
+      dataSourceDisplayName: node.name,
+      color: node.color,
+    });
+  }, []);
+
+  const renderDatasourceTooltip = useCallback(
     (props: { payload?: { payload?: TreemapNode }[] }) => {
       const { payload } = props;
       if (!payload || !payload[0]) {
@@ -180,39 +410,137 @@ export function DatasourceRetrievalTreemapChart({
     [totalRetrievals]
   );
 
+  const renderDocumentsTooltip = useCallback(
+    (props: { payload?: { payload?: TreemapNode }[] }) => {
+      const { payload } = props;
+      if (!payload || !payload[0]) {
+        return null;
+      }
+
+      const data = payload[0].payload;
+      if (!data) {
+        return null;
+      }
+
+      const size = data.size ?? 0;
+      const percent =
+        totalDocuments > 0 ? Math.round((size / totalDocuments) * 100) : 0;
+
+      return (
+        <ChartTooltipCard
+          title={data.name}
+          rows={[
+            {
+              label: "Retrievals",
+              value: size,
+              percent,
+            },
+          ]}
+        />
+      );
+    },
+    [totalDocuments]
+  );
+
+  const isDialogOpen = zoomSelection !== null;
+  let dialogBody: JSX.Element | null = null;
+
+  if (isDialogOpen) {
+    if (isDatasourceRetrievalDocumentsLoading) {
+      dialogBody = (
+        <div className="flex h-48 w-full items-center justify-center">
+          <Spinner size="lg" />
+        </div>
+      );
+    } else if (isDatasourceRetrievalDocumentsError) {
+      dialogBody = (
+        <div className="flex h-48 w-full items-center justify-center text-sm text-muted-foreground dark:text-muted-foreground-night">
+          Failed to load document breakdown.
+        </div>
+      );
+    } else if (!zoomTreemapData || zoomTreemapData.length === 0) {
+      dialogBody = (
+        <div className="flex h-48 w-full items-center justify-center text-sm text-muted-foreground dark:text-muted-foreground-night">
+          No document data for this selection.
+        </div>
+      );
+    } else {
+      dialogBody = (
+        <div className="h-[60vh] w-full">
+          <ResponsiveContainer width="100%" height="100%">
+            <Treemap
+              data={zoomTreemapData}
+              dataKey="size"
+              aspectRatio={4 / 3}
+              isAnimationActive={false}
+              content={<TreemapContent />}
+            >
+              <Tooltip
+                cursor={false}
+                content={renderDocumentsTooltip}
+                wrapperStyle={{ outline: "none" }}
+              />
+            </Treemap>
+          </ResponsiveContainer>
+        </div>
+      );
+    }
+  }
+
   return (
-    <ChartContainer
-      title="Documents retrieved by data sources (BETA)"
-      description="Number of documents retrieved per searches, grouped by datasource."
-      isLoading={isDatasourceRetrievalLoading}
-      errorMessage={
-        isDatasourceRetrievalError
-          ? "Failed to load datasource retrieval data."
-          : undefined
-      }
-      emptyMessage={
-        !treemapData || treemapData.length === 0
-          ? "No retrieval data for this period."
-          : undefined
-      }
-      height={CHART_HEIGHT}
-      legendItems={legendItems}
-    >
-      <ResponsiveContainer width="100%" height={CHART_HEIGHT}>
+    <>
+      <ChartContainer
+        title="Documents retrieved by data sources (BETA)"
+        description="Number of documents retrieved per searches, grouped by datasource."
+        isLoading={isDatasourceRetrievalLoading}
+        errorMessage={
+          isDatasourceRetrievalError
+            ? "Failed to load datasource retrieval data."
+            : undefined
+        }
+        emptyMessage={
+          !treemapData || treemapData.length === 0
+            ? "No retrieval data for this period."
+            : undefined
+        }
+        height={CHART_HEIGHT}
+        legendItems={legendItems}
+      >
         <Treemap
           data={treemapData ?? []}
           dataKey="size"
           aspectRatio={4 / 3}
           isAnimationActive={false}
-          content={<TreemapContent />}
+          content={<TreemapContent onNodeClick={handleDatasourceClick} />}
         >
           <Tooltip
             cursor={false}
-            content={renderTooltip}
+            content={renderDatasourceTooltip}
             wrapperStyle={{ outline: "none" }}
           />
         </Treemap>
-      </ResponsiveContainer>
-    </ChartContainer>
+      </ChartContainer>
+
+      <Dialog
+        open={isDialogOpen}
+        onOpenChange={(open) => !open && setZoomSelection(null)}
+      >
+        <DialogContent size="2xl" height="2xl">
+          <DialogHeader>
+            <DialogTitle>
+              {zoomSelection
+                ? `Documents retrieved: ${zoomSelection.dataSourceDisplayName}`
+                : ""}
+            </DialogTitle>
+            {zoomSelection && (
+              <DialogDescription>
+                {`Top documents retrieved from ${zoomSelection.dataSourceDisplayName} via ${zoomSelection.mcpServerDisplayName}, grouped by parent.`}
+              </DialogDescription>
+            )}
+          </DialogHeader>
+          <DialogContainer>{dialogBody}</DialogContainer>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }

--- a/front/components/agent_builder/observability/charts/DatasourceRetrievalTreemapChart.tsx
+++ b/front/components/agent_builder/observability/charts/DatasourceRetrievalTreemapChart.tsx
@@ -69,8 +69,8 @@ interface TreemapContentProps {
   onNodeClick?: (node: TreemapNode) => void;
 }
 
-const MIN_TILE_SIDE_FOR_VALUE = 14;
-const MIN_TILE_SIDE_FOR_NAME = 28;
+const MIN_TILE_HEIGHT_FOR_VALUE = 24;
+const MIN_TILE_HEIGHT_FOR_NAME_AND_VALUE = 42;
 const GROUP_OUTLINE_INSET = 2;
 const GROUP_OUTLINE_STROKE_WIDTH = 2;
 const LEAF_STROKE_WIDTH = 1;
@@ -107,10 +107,8 @@ function TreemapContent({
     return null;
   }
 
-  const minSide = Math.min(width, height);
-  const shouldShowValue = minSide >= MIN_TILE_SIDE_FOR_VALUE;
-  const shouldShowName = minSide >= MIN_TILE_SIDE_FOR_NAME;
-  const shouldShowText = shouldShowValue;
+  const shouldShowValue = height >= MIN_TILE_HEIGHT_FOR_VALUE;
+  const shouldShowName = height >= MIN_TILE_HEIGHT_FOR_NAME_AND_VALUE;
   const isClickable = !!onNodeClick;
   const leafClassName = isClickable ? `${color} cursor-pointer` : color;
 
@@ -167,7 +165,7 @@ function TreemapContent({
             : undefined
         }
       />
-      {shouldShowText && (
+      {shouldShowValue && (
         <foreignObject
           x={x}
           y={y}

--- a/front/components/agent_builder/observability/charts/DatasourceRetrievalTreemapChart.tsx
+++ b/front/components/agent_builder/observability/charts/DatasourceRetrievalTreemapChart.tsx
@@ -328,6 +328,11 @@ export function DatasourceRetrievalTreemapChart({
       return null;
     }
 
+    // For Slack, only show channel-level blocks (no individual threads).
+    const isSlack =
+      zoomSelection.mcpServerName === "slack" ||
+      zoomSelection.mcpServerName === "slack_bot";
+
     const documentsByParentId = new Map<string | null, typeof documents>();
     documents.forEach((d) => {
       const key = d.parentId ?? null;
@@ -344,13 +349,15 @@ export function DatasourceRetrievalTreemapChart({
       parentId: g.parentId,
       size: g.count,
       color: zoomSelection.color,
-      children: (documentsByParentId.get(g.parentId) ?? []).map((d) => ({
-        name: d.displayName,
-        documentId: d.documentId,
-        parentId: d.parentId,
-        size: d.count,
-        color: zoomSelection.color,
-      })),
+      children: isSlack
+        ? undefined
+        : (documentsByParentId.get(g.parentId) ?? []).map((d) => ({
+            name: d.displayName,
+            documentId: d.documentId,
+            parentId: d.parentId,
+            size: d.count,
+            color: zoomSelection.color,
+          })),
     }));
   }, [documents, groups, zoomSelection]);
 

--- a/front/components/observability/AgentObservability.tsx
+++ b/front/components/observability/AgentObservability.tsx
@@ -242,6 +242,11 @@ export function AgentObservability({
           </>
         )}
         <Separator />
+        <DatasourceRetrievalTreemapChart
+          workspaceId={workspaceId}
+          agentConfigurationId={agentConfigurationId}
+        />
+        <Separator />
         <ToolUsageChart
           workspaceId={workspaceId}
           agentConfigurationId={agentConfigurationId}

--- a/front/components/observability/AgentObservability.tsx
+++ b/front/components/observability/AgentObservability.tsx
@@ -242,11 +242,6 @@ export function AgentObservability({
           </>
         )}
         <Separator />
-        <DatasourceRetrievalTreemapChart
-          workspaceId={workspaceId}
-          agentConfigurationId={agentConfigurationId}
-        />
-        <Separator />
         <ToolUsageChart
           workspaceId={workspaceId}
           agentConfigurationId={agentConfigurationId}

--- a/front/lib/api/assistant/observability/datasource_retrieval.ts
+++ b/front/lib/api/assistant/observability/datasource_retrieval.ts
@@ -147,7 +147,7 @@ export async function fetchDatasourceRetrievalMetrics(
   const serverConfigByModelId = new Map(
     serverConfigs.map((cfg) => [cfg.id, cfg])
   );
-  const dataSourceById = new Map(dataSources.map((ds) => [ds.sId, ds]));
+  const dataSourceBySId = new Map(dataSources.map((ds) => [ds.sId, ds]));
 
   const data: DatasourceRetrievalData[] = mcpServerConfigBuckets.map(
     (mcpConfigBucket) => {
@@ -168,7 +168,7 @@ export async function fetchDatasourceRetrievalMetrics(
         mcpServerName,
         count: mcpConfigBucket.doc_count,
         datasources: datasourceBuckets.map((dsBucket) => {
-          const dataSource = dataSourceById.get(dsBucket.key);
+          const dataSource = dataSourceBySId.get(dsBucket.key);
           return {
             dataSourceId: dsBucket.key,
             displayName: dataSource

--- a/front/lib/api/assistant/observability/datasource_retrieval_documents.ts
+++ b/front/lib/api/assistant/observability/datasource_retrieval_documents.ts
@@ -1,0 +1,332 @@
+import type { estypes } from "@elastic/elasticsearch";
+
+import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
+import { UNTITLED_TITLE } from "@app/lib/api/content_nodes";
+import config from "@app/lib/api/config";
+import {
+  AGENT_DOCUMENT_OUTPUTS_ALIAS_NAME,
+  bucketsToArray,
+  withEs,
+} from "@app/lib/api/elasticsearch";
+import type { Authenticator } from "@app/lib/auth";
+import { AgentMCPServerConfigurationResource } from "@app/lib/resources/agent_mcp_server_configuration_resource";
+import { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import logger from "@app/logger/logger";
+import type { CoreAPIContentNode } from "@app/types";
+import { CoreAPI } from "@app/types";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+type DatasourceRetrievalParentGroupData = {
+  parentId: string | null;
+  displayName: string;
+  count: number;
+};
+
+export type DatasourceRetrievalDocumentData = {
+  documentId: string;
+  displayName: string;
+  parentId: string | null;
+  parents: string[];
+  count: number;
+};
+
+export type DatasourceRetrievalDocuments = {
+  documents: DatasourceRetrievalDocumentData[];
+  groups: DatasourceRetrievalParentGroupData[];
+  total: number;
+};
+
+type DocumentBucket = {
+  key: string;
+  doc_count: number;
+};
+
+type DatasourceRetrievalDocumentsAggs = {
+  by_document?: estypes.AggregationsMultiBucketAggregateBase<DocumentBucket>;
+  total?: estypes.AggregationsValueCountAggregate;
+};
+
+const CORE_SEARCH_NODES_BATCH_SIZE = 200;
+
+function chunkArray<T>(items: T[], batchSize: number): T[][] {
+  if (batchSize <= 0) {
+    return [items];
+  }
+
+  const batches: T[][] = [];
+  for (let i = 0; i < items.length; i += batchSize) {
+    batches.push(items.slice(i, i + batchSize));
+  }
+  return batches;
+}
+
+function getNodeTitle(node: CoreAPIContentNode): string {
+  if (node.title === UNTITLED_TITLE) {
+    return node.node_id;
+  }
+
+  return node.title;
+}
+
+function isMeaningfulTitle(
+  title: string | null,
+  fallbackId: string
+): title is string {
+  return !!title && title !== UNTITLED_TITLE && title !== fallbackId;
+}
+
+async function fetchNodesById(
+  coreAPI: CoreAPI,
+  {
+    dustDataSourceId,
+    nodeIds,
+  }: {
+    dustDataSourceId: string;
+    nodeIds: string[];
+  }
+): Promise<Map<string, CoreAPIContentNode>> {
+  const nodesById = new Map<string, CoreAPIContentNode>();
+
+  if (nodeIds.length === 0) {
+    return nodesById;
+  }
+
+  const dataSourceViews = [
+    {
+      data_source_id: dustDataSourceId,
+      view_filter: [],
+    },
+  ];
+
+  const batches = chunkArray(nodeIds, CORE_SEARCH_NODES_BATCH_SIZE);
+  for (const batch of batches) {
+    const res = await coreAPI.searchNodes({
+      filter: {
+        data_source_views: dataSourceViews,
+        node_ids: batch,
+      },
+      options: {
+        limit: batch.length,
+      },
+    });
+
+    if (res.isErr()) {
+      continue;
+    }
+
+    for (const node of res.value.nodes) {
+      nodesById.set(node.node_id, node);
+    }
+  }
+
+  return nodesById;
+}
+
+export async function fetchDatasourceRetrievalDocumentsMetrics(
+  auth: Authenticator,
+  {
+    agentId,
+    days,
+    version,
+    mcpServerConfigId,
+    dataSourceId,
+    limit = 50,
+  }: {
+    agentId: string;
+    days?: number;
+    version?: string;
+    mcpServerConfigId: string;
+    dataSourceId: string;
+    limit?: number;
+  }
+): Promise<Result<DatasourceRetrievalDocuments, Error>> {
+  const workspace = auth.getNonNullableWorkspace();
+
+  const mcpServerConfig = await AgentMCPServerConfigurationResource.fetchBySId(
+    auth,
+    mcpServerConfigId
+  );
+
+  if (!mcpServerConfig) {
+    return new Ok({ documents: [], groups: [], total: 0 });
+  }
+
+  const baseQuery = buildAgentAnalyticsBaseQuery({
+    workspaceId: workspace.sId,
+    agentId,
+    days,
+    version,
+  });
+
+  const query: estypes.QueryDslQueryContainer = {
+    bool: {
+      filter: [
+        baseQuery,
+        {
+          term: {
+            mcp_server_configuration_id: mcpServerConfig.id,
+          },
+        },
+        {
+          term: {
+            data_source_id: dataSourceId,
+          },
+        },
+      ],
+    },
+  };
+
+  const aggs: Record<string, estypes.AggregationsAggregationContainer> = {
+    total: {
+      value_count: {
+        field: "document_id",
+      },
+    },
+    by_document: {
+      terms: {
+        field: "document_id",
+        size: limit,
+        order: { _count: "desc" },
+      },
+    },
+  };
+
+  const result = await withEs((client) =>
+    client.search({
+      index: AGENT_DOCUMENT_OUTPUTS_ALIAS_NAME,
+      query,
+      aggs,
+      size: 0,
+    })
+  );
+
+  if (result.isErr()) {
+    return new Err(
+      new Error(
+        `Failed to query datasource retrieval documents metrics: ${result.error.message}`
+      )
+    );
+  }
+
+  const response = result.value as estypes.SearchResponse<
+    never,
+    DatasourceRetrievalDocumentsAggs
+  >;
+
+  const documentBuckets = bucketsToArray<DocumentBucket>(
+    response.aggregations?.by_document?.buckets
+  );
+
+  const documents: DatasourceRetrievalDocumentData[] = documentBuckets.map(
+    (bucket) => ({
+      documentId: bucket.key,
+      displayName: bucket.key,
+      parentId: null,
+      parents: [bucket.key],
+      count: bucket.doc_count,
+    })
+  );
+
+  const total = response.aggregations?.total?.value ?? 0;
+
+  if (documents.length === 0) {
+    return new Ok({ documents: [], groups: [], total });
+  }
+
+  const dataSource = await DataSourceResource.fetchById(auth, dataSourceId);
+
+  const documentIds = documents.map((document) => document.documentId);
+  let coreAPI: CoreAPI | null = null;
+  let dustDataSourceId: string | null = null;
+  if (dataSource) {
+    coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
+    dustDataSourceId = dataSource.dustAPIDataSourceId;
+  }
+
+  let documentNodesById = new Map<string, CoreAPIContentNode>();
+  let enrichedDocuments: DatasourceRetrievalDocumentData[] = documents;
+
+  if (coreAPI && dustDataSourceId) {
+    documentNodesById = await fetchNodesById(coreAPI, {
+      dustDataSourceId,
+      nodeIds: documentIds,
+    });
+
+    enrichedDocuments = documents.map((documentData) => {
+      const node = documentNodesById.get(documentData.documentId);
+      if (!node) {
+        return documentData;
+      }
+
+      return {
+        ...documentData,
+        displayName: getNodeTitle(node),
+        parentId: node.parent_id,
+        parents: node.parents,
+      };
+    });
+  }
+
+  const countsByParentId = new Map<string | null, number>();
+  for (const document of enrichedDocuments) {
+    countsByParentId.set(
+      document.parentId,
+      (countsByParentId.get(document.parentId) ?? 0) + document.count
+    );
+  }
+
+  const parentIds = Array.from(countsByParentId.keys()).filter(
+    (parentId): parentId is string => parentId !== null
+  );
+
+  const parentDisplayNamesById = new Map<string, string>();
+  if (coreAPI && dustDataSourceId) {
+    for (const node of documentNodesById.values()) {
+      const parentId = node.parent_id;
+      if (!parentId) {
+        continue;
+      }
+
+      if (isMeaningfulTitle(node.parent_title, parentId)) {
+        parentDisplayNamesById.set(parentId, node.parent_title);
+      }
+    }
+
+    const unresolvedParentIds = parentIds.filter(
+      (parentId) => !parentDisplayNamesById.has(parentId)
+    );
+
+    if (unresolvedParentIds.length > 0) {
+      const parentNodesById = await fetchNodesById(coreAPI, {
+        dustDataSourceId,
+        nodeIds: unresolvedParentIds,
+      });
+
+      for (const parentNode of parentNodesById.values()) {
+        parentDisplayNamesById.set(
+          parentNode.node_id,
+          getNodeTitle(parentNode)
+        );
+      }
+    }
+  }
+
+  const groups: DatasourceRetrievalParentGroupData[] = Array.from(
+    countsByParentId.entries()
+  )
+    .map(([parentId, count]) => {
+      if (parentId === null) {
+        return { parentId, displayName: "Root", count };
+      }
+
+      return {
+        parentId,
+        displayName: parentDisplayNamesById.get(parentId) ?? parentId,
+        count,
+      };
+    })
+    .sort((a, b) => b.count - a.count);
+
+  return new Ok({ documents: enrichedDocuments, groups, total });
+}

--- a/front/lib/api/assistant/observability/datasource_retrieval_documents.ts
+++ b/front/lib/api/assistant/observability/datasource_retrieval_documents.ts
@@ -143,7 +143,7 @@ export async function fetchDatasourceRetrievalDocumentsMetrics(
 ): Promise<Result<DatasourceRetrievalDocuments, Error>> {
   const workspace = auth.getNonNullableWorkspace();
 
-  const mcpServerConfig = await AgentMCPServerConfigurationResource.fetchBySId(
+  const mcpServerConfig = await AgentMCPServerConfigurationResource.fetchById(
     auth,
     mcpServerConfigId
   );

--- a/front/lib/api/assistant/observability/datasource_retrieval_documents.ts
+++ b/front/lib/api/assistant/observability/datasource_retrieval_documents.ts
@@ -1,8 +1,8 @@
 import type { estypes } from "@elastic/elasticsearch";
 
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
-import { UNTITLED_TITLE } from "@app/lib/api/content_nodes";
 import config from "@app/lib/api/config";
+import { UNTITLED_TITLE } from "@app/lib/api/content_nodes";
 import {
   AGENT_DOCUMENT_OUTPUTS_ALIAS_NAME,
   bucketsToArray,

--- a/front/lib/resources/agent_mcp_server_configuration_resource.ts
+++ b/front/lib/resources/agent_mcp_server_configuration_resource.ts
@@ -46,7 +46,7 @@ export class AgentMCPServerConfigurationResource extends BaseResource<AgentMCPSe
     return configs.map((c) => new this(this.model, c.get()));
   }
 
-  static async fetchBySId(
+  static async fetchById(
     auth: Authenticator,
     sId: string
   ): Promise<AgentMCPServerConfigurationResource | null> {

--- a/front/lib/resources/agent_mcp_server_configuration_resource.ts
+++ b/front/lib/resources/agent_mcp_server_configuration_resource.ts
@@ -46,6 +46,22 @@ export class AgentMCPServerConfigurationResource extends BaseResource<AgentMCPSe
     return configs.map((c) => new this(this.model, c.get()));
   }
 
+  static async fetchBySId(
+    auth: Authenticator,
+    sId: string
+  ): Promise<AgentMCPServerConfigurationResource | null> {
+    const workspaceId = auth.getNonNullableWorkspace().id;
+
+    const config = await this.model.findOne({
+      where: {
+        workspaceId,
+        sId,
+      },
+    });
+
+    return config ? new this(this.model, config.get()) : null;
+  }
+
   async delete(
     auth: Authenticator,
     { transaction }: { transaction?: Transaction } = {}

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -21,6 +21,7 @@ import type { FetchAgentTemplateResponse } from "@app/pages/api/templates/[tId]"
 import type { GetAgentConfigurationsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations";
 import type { GetAgentMcpConfigurationsResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/mcp_configurations";
 import type { GetDatasourceRetrievalResponse } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/datasource-retrieval";
+import type { GetDatasourceRetrievalDocumentsResponse } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/datasource-retrieval-documents";
 import type { GetErrorRateResponse } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/error_rate";
 import type { GetFeedbackDistributionResponse } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/feedback-distribution";
 import type { GetLatencyResponse } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/latency";
@@ -1112,6 +1113,55 @@ export function useAgentDatasourceRetrieval({
     isDatasourceRetrievalLoading: !error && !data && !disabled,
     isDatasourceRetrievalError: error,
     isDatasourceRetrievalValidating: isValidating,
+  };
+}
+
+export function useAgentDatasourceRetrievalDocuments({
+  workspaceId,
+  agentConfigurationId,
+  days = DEFAULT_PERIOD_DAYS,
+  version,
+  mcpServerConfigId,
+  dataSourceId,
+  limit = 50,
+  disabled,
+}: {
+  workspaceId: string;
+  agentConfigurationId: string;
+  days?: number;
+  version?: string;
+  mcpServerConfigId: string | null;
+  dataSourceId: string | null;
+  limit?: number;
+  disabled?: boolean;
+}) {
+  const fetcherFn: Fetcher<GetDatasourceRetrievalDocumentsResponse> = fetcher;
+  const isDisabled = !!disabled || !mcpServerConfigId || !dataSourceId;
+  const params = new URLSearchParams({ days: days.toString() });
+  if (version) {
+    params.set("version", version);
+  }
+  if (mcpServerConfigId) {
+    params.set("mcpServerConfigId", mcpServerConfigId);
+  }
+  if (dataSourceId) {
+    params.set("dataSourceId", dataSourceId);
+  }
+  params.set("limit", limit.toString());
+
+  const key = isDisabled
+    ? null
+    : `/api/w/${workspaceId}/assistant/agent_configurations/${agentConfigurationId}/observability/datasource-retrieval-documents?${params.toString()}`;
+
+  const { data, error, isValidating } = useSWRWithDefaults(key, fetcherFn);
+
+  return {
+    documents: data?.documents ?? emptyArray(),
+    groups: data?.groups ?? emptyArray(),
+    total: data?.total ?? 0,
+    isDatasourceRetrievalDocumentsLoading: !error && !data && !isDisabled,
+    isDatasourceRetrievalDocumentsError: error,
+    isDatasourceRetrievalDocumentsValidating: isValidating,
   };
 }
 

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/datasource-retrieval-documents.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/datasource-retrieval-documents.ts
@@ -1,0 +1,119 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
+
+import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import type { DatasourceRetrievalDocuments } from "@app/lib/api/assistant/observability/datasource_retrieval_documents";
+import { fetchDatasourceRetrievalDocumentsMetrics } from "@app/lib/api/assistant/observability/datasource_retrieval_documents";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+import { isString } from "@app/types";
+
+const QuerySchema = z.object({
+  days: z.coerce.number().positive().default(DEFAULT_PERIOD_DAYS),
+  version: z.string().optional(),
+  mcpServerConfigId: z.string().min(1),
+  dataSourceId: z.string().min(1),
+  limit: z.coerce.number().positive().max(200).default(50),
+});
+
+export type GetDatasourceRetrievalDocumentsResponse =
+  DatasourceRetrievalDocuments;
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<GetDatasourceRetrievalDocumentsResponse>
+  >,
+  auth: Authenticator
+) {
+  const { aId } = req.query;
+  if (!isString(aId)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid agent configuration ID.",
+      },
+    });
+  }
+
+  const assistant = await getAgentConfiguration(auth, {
+    agentId: aId,
+    variant: "light",
+  });
+
+  if (!assistant || (!assistant.canRead && !auth.isAdmin())) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "agent_configuration_not_found",
+        message: "The agent you're trying to access was not found.",
+      },
+    });
+  }
+
+  if (!assistant.canEdit && !auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "app_auth_error",
+        message: "Only editors can get agent observability.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      const q = QuerySchema.safeParse(req.query);
+      if (!q.success) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid query parameters: ${fromError(q.error).toString()}`,
+          },
+        });
+      }
+
+      const { days, version, mcpServerConfigId, dataSourceId, limit } = q.data;
+
+      const documentsResult = await fetchDatasourceRetrievalDocumentsMetrics(
+        auth,
+        {
+          agentId: assistant.sId,
+          days,
+          version,
+          mcpServerConfigId,
+          dataSourceId,
+          limit,
+        }
+      );
+
+      if (documentsResult.isErr()) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: `Failed to retrieve datasource retrieval documents metrics: ${fromError(documentsResult.error).toString()}`,
+          },
+        });
+      }
+
+      return res.status(200).json(documentsResult.value);
+    }
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/datasource-retrieval.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/datasource-retrieval.ts
@@ -13,7 +13,7 @@ import type { WithAPIErrorResponse } from "@app/types";
 import { isString } from "@app/types";
 
 const QuerySchema = z.object({
-  days: z.coerce.number().positive().default(DEFAULT_PERIOD_DAYS),
+  days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
   version: z.string().optional(),
 });
 
@@ -70,7 +70,7 @@ async function handler(
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: `Invalid query parameters: ${fromError(q.error).toString()}`,
+            message: `Invalid query parameters: ${q.error.message}`,
           },
         });
       }

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/datasource-retrieval.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/datasource-retrieval.ts
@@ -70,7 +70,7 @@ async function handler(
           status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: `Invalid query parameters: ${q.error.message}`,
+            message: `Invalid query parameters: ${fromError(q.error).toString()}`,
           },
         });
       }


### PR DESCRIPTION
## Description

Adds drill-down capability to the datasource retrieval treemap chart. When clicking on a datasource tile, a dialog opens showing a detailed breakdown of the top documents retrieved from that source, grouped by parent container (e.g., Slack channels).

The implementation fetches document-level retrieval metrics from Elasticsearch and enriches them with display names from the Core API. For Slack datasources, the visualization shows only channel-level groups; for other sources, it displays both parent groups and individual documents.

## Risk

Low - feature is behind the `agent_tool_outputs_analytics` feature flag.

## Tests

Tested locally with various datasources (Slack, Google Drive, etc.) to verify drill-down behavior and document grouping.

## Deploy Plan

Deploy front
