### PR TITLE
[Mentions] Fix project space membership check

### DIFF
--- a/front/lib/api/assistant/conversation/mentions.test.ts
+++ b/front/lib/api/assistant/conversation/mentions.test.ts
@@ -49,7 +49,6 @@ import { UserFactory } from "@app/tests/utils/UserFactory";
 import type {
   AgenticMessageData,
   AgentMention,
-  AgentMessageTypeWithoutMentions,
   ConversationType,
   ConversationWithoutContentType,
   LightAgentConfigurationType,

--- a/front/lib/api/assistant/conversation/mentions.ts
+++ b/front/lib/api/assistant/conversation/mentions.ts
@@ -185,9 +185,8 @@ export const createUserMentions = async (
           }
 
           // Auto approve mentions for users who are members of the conversation's project space.
-          let userInProject = false;
           if (!autoApprove && conversation.spaceId) {
-            userInProject = await isUserMemberOfSpace(auth, {
+            autoApprove = await isUserMemberOfSpace(auth, {
               userId: user.sId,
               spaceId: conversation.spaceId,
             });
@@ -195,7 +194,7 @@ export const createUserMentions = async (
 
           const status: MentionStatusType = !canAccess
             ? "user_restricted_by_conversation_access"
-            : autoApprove || userInProject
+            : autoApprove
               ? "approved"
               : "pending";
 

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -736,6 +736,9 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   /**
    * Check if a user is a member of this space.
    * Returns true if the user belongs to any group linked to this space.
+   * If there's a global group, will always return true. If there's a system
+   * group along with other groups, the system group will have no impact
+   * on membership (since isMember will return false for the system group).
    */
   async isMember(user: UserResource): Promise<boolean> {
     for (const group of this.groups) {

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -733,9 +733,18 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     return regularGroups[0];
   }
 
+  /**
+   * Check if a user is a member of this space.
+   * Returns true if the user belongs to any group linked to this space.
+   */
   async isMember(user: UserResource): Promise<boolean> {
-    const defaultGroup = this.getDefaultSpaceGroup();
-    return defaultGroup.isMember(user);
+    for (const group of this.groups) {
+      if (await group.isMember(user)) {
+        return true;
+      }
+    }
+
+    return false;
   }
 
   /**


### PR DESCRIPTION
## Description

Follow-up fixes to #20095 based on review feedback:

1. **Remove extra flag**: Instead of creating a separate `userInProject` flag, directly set `autoApprove = true` when the user is a project member

2. **Fix `isMember` implementation**: Check membership against ALL groups linked to the space (not just the default group). This handles:
   - Provisioned groups (SCIM/SAML sync)
   - Future multi-group scenarios

3. **Refactor tests**: Replace 6 occurrences of manual `AgentMessageModel`/`MessageModel` creation with `ConversationFactory.createAgentMessage()`, removing ~300 lines of boilerplate code

## Risks

Blast radius: User mentions approval flow in project space conversations
Risk: low

## Deploy Plan

- deploy front