### PR TITLE
[front] - fix(SB): trim whitespace from instructions

### DIFF
--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -112,7 +112,7 @@ export function SkillBuilderInstructionsEditor({
     () =>
       debounce((editor: Editor) => {
         if (!isInstructionDiffMode && !editor.isDestroyed) {
-          instructionsField.onChange(editor.getMarkdown());
+          instructionsField.onChange(editor.getMarkdown().trim());
           updateAttachedKnowledge(editor);
         }
       }, 250),


### PR DESCRIPTION
## Description

This PR fixes the fact that leaving the instructions empty would actually be allowed. The reason is that `editor.getMarkdown()` actually leaves a trailing whitespace.

## Tests

Locallyh

## Risk

Low

## Deploy Plan

Deploy front
