### PR TITLE
 fix(onboarding): make onboarding conversation less directive and more welcoming

### DIFF
--- a/front/lib/api/assistant/onboarding.ts
+++ b/front/lib/api/assistant/onboarding.ts
@@ -288,6 +288,17 @@ ${firstMessageSection}
 
 ## HANDLING SUBSEQUENT MESSAGES
 
+### When user already has something in mind
+If the user says they already have an idea of what they want to do with Dust (e.g., "I already have an idea", "I know what I want to do"):
+1. Acknowledge enthusiastically (one line)
+2. Ask them what they'd like to accomplish - be genuinely curious and helpful
+3. End with a quick reply to go back to tool setup if they change their mind
+
+Example ending:
+:quickReply[Actually, let's connect tools first]{message="I'd like to connect some tools first"}
+
+Once they share their goal, help them achieve it. If their goal would benefit from connecting a specific tool, mention it naturally as part of helping them (e.g., "To help you with that, connecting Gmail would let me access your emails directly").
+
 ### When user wants to skip initial tool setup
 1. Acknowledge briefly (one line)
 2. List available tools by category:
@@ -345,20 +356,21 @@ ${toolsWithDescriptions}
 
 Write a SHORT welcome message (3-4 lines max):
 1. "# Welcome to Dust 👋" (or similar short greeting)
-2. One sentence inviting them to connect their tools
-3. Briefly mention the recommended tool(s) above
-4. End with the tool setup cards and skip option
+2. One sentence offering to help - either by connecting tools OR by helping with whatever they want to achieve
+3. Briefly mention the recommended tool(s) as a suggestion, not a requirement
+4. End with the tool setup cards AND an option for users who already know what they want to do
 
 You MUST end your message EXACTLY like this:
 ${toolSetupDirectives}
-:quickReply[Skip for now]{message="I'd like to skip connecting tools for now"}
+:quickReply[I have something in mind]{message="I already have an idea of what I want to do with Dust"} :quickReply[Skip for now]{message="I'd like to skip connecting tools for now"}
 
 **DO NOT:**
 - Explain what Dust is at length
 - List features or capabilities beyond the tools
 - Invent use cases or scenarios specific to their role
 - Promise cross-tool functionality
-- Write more than 4 lines before the buttons`;
+- Write more than 4 lines before the buttons
+- Be pushy about connecting tools - present it as an option, not a requirement`;
 }
 
 function buildFirstMessageWithConfiguredTool(


### PR DESCRIPTION
## Description

  ## Summary
  - Updated the onboarding conversation prompt to offer users a choice: connect tools OR share what they want to
  accomplish
  - Added "I have something in mind" quick reply option alongside tool setup buttons
  - Added handling for when users already have a goal, guiding the agent to help them directly

  ## Context
  The previous onboarding flow was too pushy about connecting tools ("Let's get you started by connecting your tools").
  This change makes it more welcoming by giving users agency to either connect tools or dive straight into what they want
  to achieve with Dust.

<kbd>
<img width="975" height="559" alt="Screenshot 2026-01-15 at 17 02 18" src="https://github.com/user-attachments/assets/8a304bf7-b7c0-49bd-9ec2-32875a5bb42d" />
</kbd>



## Tests

Locally. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 