### PR TITLE
[Front] fix(migrations): filter by active agents in tool-to-skill migration

### DIFF
--- a/front/migrations/20251229_add_global_skill_to_agents_with_tool.ts
+++ b/front/migrations/20251229_add_global_skill_to_agents_with_tool.ts
@@ -9,6 +9,7 @@ import {
 } from "@app/lib/actions/mcp_internal_actions/constants";
 import { Authenticator } from "@app/lib/auth";
 import { AgentMCPServerConfigurationModel } from "@app/lib/models/agent/actions/mcp";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { AgentSkillModel } from "@app/lib/models/agent/agent_skill";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { GlobalSkillId } from "@app/lib/resources/skill/global/registry";
@@ -61,12 +62,20 @@ async function migrateToolToSkill(
     return "";
   }
 
-  // 2. Find all agent configs using this MCP server view.
+  // 2. Find all agent configs using this MCP server view (only active agents).
   const agentsWithTool = await AgentMCPServerConfigurationModel.findAll({
     where: {
       workspaceId: workspace.id,
       mcpServerViewId: mcpServerView.id,
     },
+    include: [
+      {
+        model: AgentConfigurationModel,
+        required: true,
+        where: { status: "active" },
+        attributes: [],
+      },
+    ],
   });
 
   if (agentsWithTool.length === 0) {


### PR DESCRIPTION
## Description

Fix `add_global_skill_to_agents_with_tool` migration to only fetch MCP server configs for active agent configurations. Previously it could migrate tools for archived/inactive agents.

## Tests

Migration script dry-run on local workspace.

## Risk

Low - only affects migration script behavior, no production code changes.

## Deploy Plan

Run migration after deploy.