### PR TITLE
[front] Add workspace isolation check on destroy

### DIFF
--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -753,6 +753,7 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
     try {
       await AgentMCPActionModel.destroy({
         where: {
+          workspaceId: auth.getNonNullableWorkspace().id,
           id: this.id,
         },
         transaction,

--- a/front/lib/resources/agent_message_feedback_resource.ts
+++ b/front/lib/resources/agent_message_feedback_resource.ts
@@ -119,6 +119,7 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
     await this.model.destroy({
       where: {
         id: this.id,
+        workspaceId: auth.getNonNullableWorkspace().id,
       },
       transaction,
     });

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -1515,11 +1515,17 @@ export class ConversationResource extends BaseResource<ConversationModel> {
 
     try {
       await ConversationMCPServerViewModel.destroy({
-        where: { workspaceId: owner.id, conversationId: this.id },
+        where: {
+          workspaceId: owner.id,
+          conversationId: this.id,
+        },
         transaction,
       });
       await ConversationParticipantModel.destroy({
-        where: { workspaceId: owner.id, conversationId: this.id },
+        where: {
+          workspaceId: owner.id,
+          conversationId: this.id,
+        },
         transaction,
       });
       await ConversationResource.model.destroy({

--- a/front/lib/resources/data_source_resource.ts
+++ b/front/lib/resources/data_source_resource.ts
@@ -543,6 +543,7 @@ export class DataSourceResource extends ResourceWithSpace<DataSourceModel> {
     const deletedCount = await DataSourceModel.destroy({
       where: {
         id: this.id,
+        workspaceId,
       },
       transaction,
       // Use 'hardDelete: true' to ensure the record is permanently deleted from the database,

--- a/front/lib/resources/extension.ts
+++ b/front/lib/resources/extension.ts
@@ -69,6 +69,7 @@ export class ExtensionConfigurationResource extends BaseResource<ExtensionConfig
       await this.model.destroy({
         where: {
           id: this.id,
+          workspaceId: auth.getNonNullableWorkspace().id,
         },
         transaction,
       });

--- a/front/lib/resources/feature_flag_resource.ts
+++ b/front/lib/resources/feature_flag_resource.ts
@@ -122,11 +122,14 @@ export class FeatureFlagResource extends BaseResource<FeatureFlagModel> {
   }
 
   async delete(
-    _auth: Authenticator,
+    auth: Authenticator,
     { transaction }: { transaction?: Transaction }
   ): Promise<Result<number | undefined, Error>> {
     await this.model.destroy({
-      where: { id: this.id },
+      where: {
+        id: this.id,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
       transaction,
     });
 

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -335,6 +335,7 @@ export class FileResource extends BaseResource<FileModel> {
       await this.model.destroy({
         where: {
           id: this.id,
+          workspaceId: this.workspaceId,
         },
       });
 

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -1330,11 +1330,12 @@ export class GroupResource extends BaseResource<GroupModel> {
     auth: Authenticator,
     { transaction }: { transaction?: Transaction } = {}
   ): Promise<Result<undefined, Error>> {
+    const owner = auth.getNonNullableWorkspace();
     try {
       await KeyModel.destroy({
         where: {
           groupId: this.id,
-          workspaceId: auth.getNonNullableWorkspace().id,
+          workspaceId: owner.id,
         },
         transaction,
       });
@@ -1342,6 +1343,7 @@ export class GroupResource extends BaseResource<GroupModel> {
       await GroupSpaceModel.destroy({
         where: {
           groupId: this.id,
+          workspaceId: owner.id,
         },
         transaction,
       });
@@ -1349,6 +1351,7 @@ export class GroupResource extends BaseResource<GroupModel> {
       await GroupAgentModel.destroy({
         where: {
           groupId: this.id,
+          workspaceId: owner.id,
         },
         transaction,
       });
@@ -1356,6 +1359,7 @@ export class GroupResource extends BaseResource<GroupModel> {
       await GroupMembershipModel.destroy({
         where: {
           groupId: this.id,
+          workspaceId: owner.id,
         },
         transaction,
       });
@@ -1363,6 +1367,7 @@ export class GroupResource extends BaseResource<GroupModel> {
       await this.model.destroy({
         where: {
           id: this.id,
+          workspaceId: owner.id,
         },
         transaction,
       });

--- a/front/lib/resources/mcp_server_connection_resource.ts
+++ b/front/lib/resources/mcp_server_connection_resource.ts
@@ -283,6 +283,7 @@ export class MCPServerConnectionResource extends BaseResource<MCPServerConnectio
       await this.model.destroy({
         where: {
           id: this.id,
+          workspaceId: auth.getNonNullableWorkspace().id,
         },
         transaction,
       });

--- a/front/lib/resources/project_metadata_resource.ts
+++ b/front/lib/resources/project_metadata_resource.ts
@@ -115,7 +115,10 @@ export class ProjectMetadataResource extends BaseResource<ProjectMetadataModel> 
     { transaction }: { transaction?: Transaction }
   ): Promise<Result<undefined, Error>> {
     await ProjectMetadataModel.destroy({
-      where: { id: this.id },
+      where: {
+        id: this.id,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
       transaction,
     });
     return new Ok(undefined);

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1312,6 +1312,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       await SkillMCPServerConfigurationModel.destroy({
         where: {
           id: { [Op.in]: idsToDelete },
+          workspaceId: workspace.id,
         },
         transaction,
       });

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -391,6 +391,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     await GroupSpaceModel.destroy({
       where: {
         vaultId: this.id,
+        workspaceId: auth.getNonNullableWorkspace().id,
       },
       transaction,
     });

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -531,12 +531,12 @@ export class SpaceResource extends BaseResource<SpaceModel> {
 
       // If the space should be restricted and was not restricted before, remove the global group.
       if (!wasRestricted && isRestricted) {
-        await this.removeGroup(globalGroup);
+        await this.removeGroup(auth, globalGroup);
       }
 
       // If the space should not be restricted and was restricted before, add the global group.
       if (wasRestricted && !isRestricted) {
-        await this.addGroup(globalGroup);
+        await this.addGroup(auth, globalGroup);
       }
 
       const previousManagementMode = this.managementMode;
@@ -582,6 +582,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
             where: {
               groupId: group.id,
               vaultId: this.id,
+              workspaceId: auth.getNonNullableWorkspace().id,
             },
             transaction: t,
           });
@@ -613,19 +614,20 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     });
   }
 
-  private async addGroup(group: GroupResource) {
+  private async addGroup(auth: Authenticator, group: GroupResource) {
     await GroupSpaceModel.create({
       groupId: group.id,
       vaultId: this.id,
-      workspaceId: this.workspaceId,
+      workspaceId: auth.getNonNullableWorkspace().id,
     });
   }
 
-  private async removeGroup(group: GroupResource) {
+  private async removeGroup(auth: Authenticator, group: GroupResource) {
     await GroupSpaceModel.destroy({
       where: {
         groupId: group.id,
         vaultId: this.id,
+        workspaceId: auth.getNonNullableWorkspace().id,
       },
     });
   }

--- a/front/lib/resources/storage/wrappers/workspace_models.ts
+++ b/front/lib/resources/storage/wrappers/workspace_models.ts
@@ -3,6 +3,7 @@ import type {
   CountWithOptions,
   CreationOptional,
   DestroyOptions,
+  Filterable,
   FindOptions,
   ForeignKey,
   GroupedCountResultItem,
@@ -16,6 +17,7 @@ import type {
   WhereOptions,
 } from "sequelize";
 import { DataTypes, Op } from "sequelize";
+import type { ModelHooks } from "sequelize/lib/hooks";
 
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import { BaseModel } from "@app/lib/resources/storage/wrappers/base";

--- a/front/lib/resources/storage/wrappers/workspace_models.ts
+++ b/front/lib/resources/storage/wrappers/workspace_models.ts
@@ -23,6 +23,9 @@ import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import { BaseModel } from "@app/lib/resources/storage/wrappers/base";
 import logger from "@app/logger/logger";
 
+// Log only 1 time out of 100 on average.
+const WORKSPACE_ISOLATION_SAMPLING_RATE = 0.99;
+
 // Helper type and type guard for workspaceId check.
 type WhereClauseWithNumericWorkspaceId<TAttributes> =
   WhereOptions<TAttributes> & {
@@ -95,8 +98,7 @@ function checkWorkspaceIsolation<MS extends ModelStatic<Model>>(
     return;
   }
 
-  // log only 1 time on 100 approximately
-  if (Math.random() < 0.99) {
+  if (Math.random() < WORKSPACE_ISOLATION_SAMPLING_RATE) {
     return;
   }
 

--- a/front/lib/resources/storage/wrappers/workspace_models.ts
+++ b/front/lib/resources/storage/wrappers/workspace_models.ts
@@ -89,8 +89,10 @@ function checkWorkspaceIsolation<MS extends ModelStatic<Model>>(
   options: Filterable<InferAttributes<InstanceType<MS>>>,
   {
     modelName,
+    queryType,
   }: {
     modelName: string;
+    queryType: "find" | "bulkDestroy";
   }
 ) {
   // Skip validation if specifically requested for this query.
@@ -114,7 +116,7 @@ function checkWorkspaceIsolation<MS extends ModelStatic<Model>>(
     logger.warn(
       {
         model: modelName,
-        query_type: "find",
+        query_type: queryType,
         stack_trace: stack,
         error: {
           message: "workspace_isolation_violation",
@@ -184,6 +186,7 @@ export class WorkspaceAwareModel<M extends Model = any> extends BaseModel<M> {
       beforeFind: (options: FindOptions<InferAttributes<InstanceType<MS>>>) => {
         checkWorkspaceIsolation(options, {
           modelName: this.name,
+          queryType: "find",
         });
       },
       beforeBulkDestroy: (
@@ -191,6 +194,7 @@ export class WorkspaceAwareModel<M extends Model = any> extends BaseModel<M> {
       ) => {
         checkWorkspaceIsolation(options, {
           modelName: this.name,
+          queryType: "bulkDestroy",
         });
       },
       ...(restOptions.hooks ?? {}),

--- a/front/lib/resources/storage/wrappers/workspace_models.ts
+++ b/front/lib/resources/storage/wrappers/workspace_models.ts
@@ -82,6 +82,64 @@ interface WorkspaceTenantIsolationSecurityBypassOptions<
   dangerouslyBypassWorkspaceIsolationSecurity?: boolean;
 }
 
+function checkWorkspaceIsolation<MS extends ModelStatic<Model>>(
+  options: Filterable<InferAttributes<InstanceType<MS>>>,
+  {
+    modelName,
+  }: {
+    modelName: string;
+  }
+) {
+  // Skip validation if specifically requested for this query.
+  if (isWorkspaceIsolationBypassEnabled(options)) {
+    return;
+  }
+
+  // log only 1 time on 100 approximately
+  if (Math.random() < 0.99) {
+    return;
+  }
+
+  const whereClause = options.where;
+
+  if (
+    !isWhereClauseWithNumericWorkspaceId<InferAttributes<InstanceType<MS>>>(
+      whereClause
+    )
+  ) {
+    const stack = new Error().stack;
+
+    logger.warn(
+      {
+        model: modelName,
+        query_type: "find",
+        stack_trace: stack,
+        error: {
+          message: "workspace_isolation_violation",
+          stack,
+        },
+        where: whereClause,
+      },
+      "workspace_isolation_violation"
+    );
+
+    if (
+      // Do not rely on `isDevelopment` since we want to run this check everywhere except
+      // production.
+      process.env.NODE_ENV !== "production" &&
+      !TEMPORARY_WHITELISTED_MODELS_FOR_WORKSPACE_ISOLATION_BYPASS.includes(
+        modelName
+      )
+    ) {
+      throw new Error(
+        `Query attempted without workspaceId on ${modelName}. All workspace-aware model ` +
+          "queries must be scoped to a specific workspaceId for query isolation. " +
+          "See Runbook https://www.notion.so/dust-tt/Runbook-WorkspaceAwareModel-Workspace-Isolation-Enforcement-2d128599d94180dbbbace7cffcd958f6"
+      );
+    }
+  }
+}
+
 function isWorkspaceIsolationBypassEnabled<T>(
   options: FindOptions<T>
 ): options is WorkspaceTenantIsolationSecurityBypassOptions<T> {
@@ -118,59 +176,22 @@ export class WorkspaceAwareModel<M extends Model = any> extends BaseModel<M> {
     const { relationship = "hasMany", ...restOptions } = options;
 
     // Define a hook to ensure all find queries are properly scoped to a workspace.
-    const hooks = {
+    const hooks: Partial<
+      ModelHooks<InstanceType<MS>, Attributes<InstanceType<MS>>>
+    > = {
       beforeFind: (options: FindOptions<InferAttributes<InstanceType<MS>>>) => {
-        // Skip validation if specifically requested for this query.
-        if (isWorkspaceIsolationBypassEnabled(options)) {
-          return;
-        }
-
-        // log only 1 time on 100 approximately
-        if (Math.random() < 0.99) {
-          return;
-        }
-
-        const whereClause = options.where;
-
-        if (
-          !isWhereClauseWithNumericWorkspaceId<
-            InferAttributes<InstanceType<MS>>
-          >(whereClause)
-        ) {
-          const stack = new Error().stack;
-
-          logger.warn(
-            {
-              model: this.name,
-              query_type: "find",
-              stack_trace: stack,
-              error: {
-                message: "workspace_isolation_violation",
-                stack,
-              },
-              where: whereClause,
-            },
-            "workspace_isolation_violation"
-          );
-
-          if (
-            // Do not rely on `isDevelopment` since we want to run this check everywhere except
-            // production.
-            process.env.NODE_ENV !== "production" &&
-            !TEMPORARY_WHITELISTED_MODELS_FOR_WORKSPACE_ISOLATION_BYPASS.includes(
-              this.name
-            )
-          ) {
-            throw new Error(
-              `Query attempted without workspaceId on ${this.name}. All workspace-aware model ` +
-                "queries must be scoped to a specific workspaceId for query isolation. " +
-                "See Runbook https://www.notion.so/dust-tt/Runbook-WorkspaceAwareModel-Workspace-Isolation-Enforcement-2d128599d94180dbbbace7cffcd958f6"
-            );
-          }
-        }
+        checkWorkspaceIsolation(options, {
+          modelName: this.name,
+        });
       },
-      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-      ...(restOptions.hooks || {}),
+      beforeBulkDestroy: (
+        options: DestroyOptions<InferAttributes<InstanceType<MS>>>
+      ) => {
+        checkWorkspaceIsolation(options, {
+          modelName: this.name,
+        });
+      },
+      ...(restOptions.hooks ?? {}),
     };
 
     const model = super.init(attrs, {

--- a/front/lib/resources/tags_resource.ts
+++ b/front/lib/resources/tags_resource.ts
@@ -244,6 +244,7 @@ export class TagResource extends BaseResource<TagModel> {
       await TagAgentModel.destroy({
         where: {
           tagId: this.id,
+          workspaceId: auth.getNonNullableWorkspace().id,
         },
         transaction,
       });

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -293,6 +293,7 @@ export class TriggerResource extends BaseResource<TriggerModel> {
         });
         await WebhookRequestModel.destroy({
           where: {
+            workspaceId: owner.id,
             id: { [Op.in]: webhookRequests.map((w) => w.id) },
           },
         });

--- a/front/lib/resources/user_resource.test.ts
+++ b/front/lib/resources/user_resource.test.ts
@@ -299,7 +299,7 @@ describe("UserResource", () => {
         await user.setMetadata("key2", "value2");
         await user.setMetadata("key3", "value3");
 
-        await user.deleteAllMetadata();
+        await user.deleteAllMetadata(auth);
 
         expect(await user.getMetadata("key1")).toBeNull();
         expect(await user.getMetadata("key2")).toBeNull();

--- a/front/lib/resources/user_resource.test.ts
+++ b/front/lib/resources/user_resource.test.ts
@@ -295,7 +295,7 @@ describe("UserResource", () => {
         await user.setMetadata("key2", "value2");
         await user.setMetadata("key3", "value3");
 
-        await user.deleteAllMetadata();
+        await user.deleteAllMetadata(auth);
 
         expect(await user.getMetadata("key1")).toBeNull();
         expect(await user.getMetadata("key2")).toBeNull();

--- a/front/lib/resources/user_resource.test.ts
+++ b/front/lib/resources/user_resource.test.ts
@@ -9,9 +9,13 @@ import type { WorkspaceType } from "@app/types";
 
 describe("UserResource", () => {
   let user: UserResource;
+  let workspace: WorkspaceType;
+  let auth: Authenticator;
 
   beforeEach(async () => {
+    workspace = await WorkspaceFactory.basic();
     user = await UserFactory.basic();
+    auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
   });
 
   describe("getMetadataAsArray", () => {

--- a/front/lib/resources/user_resource.test.ts
+++ b/front/lib/resources/user_resource.test.ts
@@ -299,7 +299,7 @@ describe("UserResource", () => {
         await user.setMetadata("key2", "value2");
         await user.setMetadata("key3", "value3");
 
-        await user.deleteAllMetadata(auth);
+        await user.deleteAllMetadata();
 
         expect(await user.getMetadata("key1")).toBeNull();
         expect(await user.getMetadata("key2")).toBeNull();

--- a/front/lib/resources/user_resource.ts
+++ b/front/lib/resources/user_resource.ts
@@ -356,7 +356,7 @@ export class UserResource extends BaseResource<UserModel> {
     auth: Authenticator,
     { transaction }: { transaction?: Transaction } = {}
   ): Promise<Result<undefined, Error>> {
-    await this.deleteAllMetadata(auth);
+    await this.deleteAllMetadata();
 
     try {
       await this.model.destroy({
@@ -473,18 +473,16 @@ export class UserResource extends BaseResource<UserModel> {
     });
   }
 
-  async deleteAllMetadata(auth: Authenticator) {
+  async deleteAllMetadata() {
     await UserMetadataModel.destroy({
       where: {
         userId: this.id,
-        workspaceId: auth.getNonNullableWorkspace().id,
       },
     });
 
     await UserToolApprovalModel.destroy({
       where: {
         userId: this.id,
-        workspaceId: auth.getNonNullableWorkspace().id,
       },
     });
 

--- a/front/lib/resources/user_resource.ts
+++ b/front/lib/resources/user_resource.ts
@@ -356,7 +356,7 @@ export class UserResource extends BaseResource<UserModel> {
     auth: Authenticator,
     { transaction }: { transaction?: Transaction } = {}
   ): Promise<Result<undefined, Error>> {
-    await this.deleteAllMetadata();
+    await this.deleteAllMetadata(auth);
 
     try {
       await this.model.destroy({
@@ -473,7 +473,7 @@ export class UserResource extends BaseResource<UserModel> {
     });
   }
 
-  async deleteAllMetadata() {
+  async deleteAllMetadata(auth: Authenticator) {
     await UserMetadataModel.destroy({
       where: {
         userId: this.id,
@@ -483,6 +483,7 @@ export class UserResource extends BaseResource<UserModel> {
     await UserToolApprovalModel.destroy({
       where: {
         userId: this.id,
+        workspaceId: auth.getNonNullableWorkspace().id,
       },
     });
 

--- a/front/lib/resources/user_resource.ts
+++ b/front/lib/resources/user_resource.ts
@@ -356,7 +356,7 @@ export class UserResource extends BaseResource<UserModel> {
     auth: Authenticator,
     { transaction }: { transaction?: Transaction } = {}
   ): Promise<Result<undefined, Error>> {
-    await this.deleteAllMetadata();
+    await this.deleteAllMetadata(auth);
 
     try {
       await this.model.destroy({
@@ -473,16 +473,18 @@ export class UserResource extends BaseResource<UserModel> {
     });
   }
 
-  async deleteAllMetadata() {
+  async deleteAllMetadata(auth: Authenticator) {
     await UserMetadataModel.destroy({
       where: {
         userId: this.id,
+        workspaceId: auth.getNonNullableWorkspace().id,
       },
     });
 
     await UserToolApprovalModel.destroy({
       where: {
         userId: this.id,
+        workspaceId: auth.getNonNullableWorkspace().id,
       },
     });
 


### PR DESCRIPTION
## Description

- This PR adds an `onBulkDestroy` hook on `WorkspaceAwareModel` to check for workspace isolation.
- This check crashes when outside of a production environment, and samples logs otherwise.

## Tests

- Tested locally.

## Risk

- Medium, wide scope but only logs in prod.

## Deploy Plan

- Deploy front.
