### PR TITLE
[Notifications] Include conversation name in email subject

### DIFF
--- a/front/lib/notifications/workflows/conversation-added-as-participant.ts
+++ b/front/lib/notifications/workflows/conversation-added-as-participant.ts
@@ -163,7 +163,7 @@ export const conversationAddedAsParticipantWorkflow = workflow(
           },
         });
         return {
-          subject: `[Dust] You were mentioned in a conversation`,
+          subject: `[Dust] ${details.subject}`,
           body,
         };
       },

--- a/front/lib/notifications/workflows/conversation-added-as-participant.ts
+++ b/front/lib/notifications/workflows/conversation-added-as-participant.ts
@@ -163,7 +163,7 @@ export const conversationAddedAsParticipantWorkflow = workflow(
           },
         });
         return {
-          subject: `[Dust] ${details.subject}`,
+          subject: `[Dust] You were mentioned in '${details.subject}'`,
           body,
         };
       },

--- a/front/lib/notifications/workflows/conversation-unread.ts
+++ b/front/lib/notifications/workflows/conversation-unread.ts
@@ -490,11 +490,12 @@ export const conversationUnreadWorkflow = workflow(
           },
           conversations,
         });
+        const subject =
+          conversations.length > 1
+            ? `[Dust] New unread message(s) in ${conversations.length} conversations`
+            : `[Dust] ${conversations[0]?.title ?? "New unread message(s) in conversation"}`;
         return {
-          subject:
-            conversations.length > 1
-              ? `[Dust] new unread message(s) in ${conversations.length} conversations`
-              : `[Dust] new unread message(s) in conversation`,
+          subject,
           body,
         };
       },


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/5903

Context: https://dust4ai.slack.com/archives/C050A0S2Z7F/p1768282065917559

When a mention notification email includes only one conversation, the email subject now displays the conversation title instead of a generic message. This helps users manage their inbox more effectively by seeing at a glance which conversation needs attention.

Changes:
- `conversation-unread.ts`: Single conversation emails now show `[Dust] {title}` instead of `[Dust] new unread message(s) in conversation`
- `conversation-added-as-participant.ts`: Emails now show `[Dust] {title}` instead of `[Dust] You were mentioned in a conversation`

## Risks

Blast radius: Email notification subjects for mentions
Risk: low

## Deploy Plan

- deploy front