### PR TITLE
fix(mcp): use local API credentials for toolsets in dev mode

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/toolsets.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/toolsets.ts
@@ -40,7 +40,9 @@ function createServer(
 
         const owner = auth.getNonNullableWorkspace();
         const requestedGroupIds = auth.groups().map((g) => g.sId);
-        const prodCredentials = await prodAPICredentialsForOwner(owner);
+        const prodCredentials = await prodAPICredentialsForOwner(owner, {
+          useLocalInDev: true,
+        });
         const config = apiConfig.getDustAPIConfig();
         const api = new DustAPI(
           config,
@@ -115,7 +117,9 @@ function createServer(
         }
 
         const requestedGroupIds = auth.groups().map((g) => g.sId);
-        const prodCredentials = await prodAPICredentialsForOwner(owner);
+        const prodCredentials = await prodAPICredentialsForOwner(owner, {
+          useLocalInDev: true,
+        });
         const config = apiConfig.getDustAPIConfig();
 
         const api = new DustAPI(


### PR DESCRIPTION
## Description

Fix toolsets MCP server to use local API credentials in development mode.

The toolsets server was calling `prodAPICredentialsForOwner(owner)` without `{ useLocalInDev: true }`, causing it to use production API credentials when calling the local server. This resulted in `invalid_api_key_error` when trying to enable toolsets in local development.

## Changes

Add `{ useLocalInDev: true }` to both `prodAPICredentialsForOwner` calls in `toolsets.ts`.

## Testing

- Verified toolsets can now be enabled in local dev environment
- Production behavior unchanged (only affects localhost API URLs)

## Risk

Low risk. Only affects local development when API URL is localhost.