### PR TITLE
fix(seed): use correct SkillResource method name

### DIFF
--- a/front/scripts/seed/basics/seed.test.ts
+++ b/front/scripts/seed/basics/seed.test.ts
@@ -65,7 +65,7 @@ describe("basics seed script integration test", () => {
     await seedConversations(ctx, assets.conversations, customAgentSId);
 
     // Verify skill was created
-    const skills = await SkillResource.listSkills(authenticator, {
+    const skills = await SkillResource.listByWorkspace(authenticator, {
       status: "active",
     });
     const createdSkill = skills.find((s) => s.name === assets.skill.name);

--- a/front/scripts/seed/basics/seedSkill.ts
+++ b/front/scripts/seed/basics/seedSkill.ts
@@ -9,7 +9,7 @@ export async function seedSkill(
 ): Promise<void> {
   const { auth, execute, logger } = ctx;
 
-  const existingSkills = await SkillResource.listSkills(auth, {
+  const existingSkills = await SkillResource.listByWorkspace(auth, {
     status: "active",
   });
   const existingSkill = existingSkills.find((s) => s.name === skillAsset.name);


### PR DESCRIPTION
## Description

Fixes the main branch CI failure by correcting the method call in the seed scripts.

The seed scripts introduced in #20059 were calling `SkillResource.listSkills` which doesn't exist on the `SkillResource` class. Changed to the correct method `listByWorkspace`.

## Tests

- TypeScript type checker passes
- CI should now pass

## Risk

Low risk - simple method name fix with no behavioral change.

## Deploy Plan

Standard merge to main.