### PR TITLE
refactor: Extract static IP proxy helper

### DIFF
--- a/front/lib/egress/server.ts
+++ b/front/lib/egress/server.ts
@@ -2,6 +2,7 @@ import type { RequestInfo, RequestInit, Response } from "undici";
 import { fetch as undiciFetch, ProxyAgent } from "undici";
 
 import config from "@app/lib/api/config";
+import { EnvironmentConfig } from "@app/types";
 
 export function getUntrustedEgressAgent(): ProxyAgent | undefined {
   const proxyHost = config.getUntrustedEgressProxyHost();
@@ -9,6 +10,26 @@ export function getUntrustedEgressAgent(): ProxyAgent | undefined {
 
   if (proxyHost && proxyPort) {
     const proxyUrl = `http://${proxyHost}:${proxyPort}`;
+    return new ProxyAgent(proxyUrl);
+  }
+
+  return undefined;
+}
+
+/**
+ * Get a proxy agent for static IP egress.
+ * Used for MCP requests to domains that require whitelisted IP addresses.
+ * Requires PROXY_USER_NAME, PROXY_USER_PASSWORD, PROXY_HOST, and PROXY_PORT
+ * environment variables to be configured.
+ */
+export function getStaticIPProxyAgent(): ProxyAgent | undefined {
+  const user = EnvironmentConfig.getEnvVariable("PROXY_USER_NAME");
+  const pass = EnvironmentConfig.getEnvVariable("PROXY_USER_PASSWORD");
+  const host = EnvironmentConfig.getEnvVariable("PROXY_HOST");
+  const port = EnvironmentConfig.getEnvVariable("PROXY_PORT");
+
+  if (user && pass && host && port) {
+    const proxyUrl = `http://${user}:${pass}@${host}:${port}`;
     return new ProxyAgent(proxyUrl);
   }
 


### PR DESCRIPTION
## Description

Extract static IP proxy agent creation into a centralized helper:
- Add `getStaticIPProxyAgent()` to `lib/egress/server.ts` for consistent proxy URL construction
- Refactor `github.ts` internal MCP server to use the new helper instead of inline proxy construction

This reduces code duplication and makes proxy configuration consistent across the codebase.

## Tests


## Risk

**Low risk** - Pure refactor with no behavior change. The proxy URL construction logic is identical.

## Deploy Plan

Standard deployment. No special considerations needed.