### PR TITLE
feat: Use static IP proxy for MCP servers on verified domains

### DIFF
--- a/front/components/workspace/WorkspaceAccessPanel.tsx
+++ b/front/components/workspace/WorkspaceAccessPanel.tsx
@@ -85,9 +85,9 @@ function DomainVerification({
   return (
     <WorkspaceSection icon={ActionGlobeAltIcon} title="Domain Verification">
       <Page.P variant="secondary">
-        Verify one or multiple company domains to enable Single Sign-On (SSO)
-        and allow team members to automatically join your workspace when they
-        sign up with their work email address.
+        Verify your company domains to enable Single Sign-On (SSO), automatic
+        workspace enrollment for team members, and secure connections to your
+        internal MCP servers.
       </Page.P>
       {isDomainsLoading ? (
         <LoadingBlock className="h-32 w-full rounded-xl" />
@@ -193,7 +193,7 @@ function DomainVerificationTable({
       {
         header: "",
         accessorKey: "actions",
-        meta: { className: "w-14" },
+        meta: { className: "w-12" },
         cell: ({ row }: CellContext<DomainRowData, string>) => {
           return (
             <IconButton
@@ -229,7 +229,6 @@ function DomainVerificationTable({
             label="Add Domain"
             variant="primary"
             href={addDomainLink}
-            target="_blank"
             icon={PlusIcon}
           />
         </div>

--- a/front/lib/api/workspace_has_domains.ts
+++ b/front/lib/api/workspace_has_domains.ts
@@ -1,5 +1,5 @@
 import type { Authenticator } from "@app/lib/auth";
-import { WorkspaceHasDomainModel } from "@app/lib/resources/storage/models/workspace_has_domain";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { isHostUnderDomain, isIpAddress } from "@app/types";
 
 /**
@@ -15,10 +15,14 @@ export async function isHostUnderVerifiedDomain(
     return false;
   }
 
-  const verifiedDomains = await WorkspaceHasDomainModel.findAll({
-    attributes: ["domain"],
-    where: { workspaceId: auth.getNonNullableWorkspace().id },
-  });
+  const workspace = await WorkspaceResource.fetchById(
+    auth.getNonNullableWorkspace().sId
+  );
+  if (!workspace) {
+    return false;
+  }
+
+  const verifiedDomains = await workspace.getVerifiedDomains();
 
   return verifiedDomains.some((d) => isHostUnderDomain(host, d.domain));
 }

--- a/front/lib/api/workspace_has_domains.ts
+++ b/front/lib/api/workspace_has_domains.ts
@@ -1,0 +1,24 @@
+import type { Authenticator } from "@app/lib/auth";
+import { WorkspaceHasDomainModel } from "@app/lib/resources/storage/models/workspace_has_domain";
+import { isHostUnderDomain, isIpAddress } from "@app/types";
+
+/**
+ * Check if a host is under any verified domain for the workspace.
+ * Used for MCP static IP egress routing.
+ * Rejects IP address literals for security (only domain names are matched).
+ */
+export async function isHostUnderVerifiedDomain(
+  auth: Authenticator,
+  host: string
+): Promise<boolean> {
+  if (isIpAddress(host)) {
+    return false;
+  }
+
+  const verifiedDomains = await WorkspaceHasDomainModel.findAll({
+    attributes: ["domain"],
+    where: { workspaceId: auth.getNonNullableWorkspace().id },
+  });
+
+  return verifiedDomains.some((d) => isHostUnderDomain(host, d.domain));
+}

--- a/front/lib/resources/workspace_resource.ts
+++ b/front/lib/resources/workspace_resource.ts
@@ -22,13 +22,7 @@ import type {
   WorkspaceDomain,
   WorkspaceSegmentationType,
 } from "@app/types";
-import {
-  Err,
-  isHostUnderDomain,
-  isIpAddress,
-  normalizeError,
-  Ok,
-} from "@app/types";
+import { Err, normalizeError, Ok } from "@app/types";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
@@ -129,34 +123,6 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
   static async listAll(): Promise<WorkspaceResource[]> {
     const workspaces = await this.model.findAll();
     return workspaces.map((workspace) => new this(this.model, workspace.get()));
-  }
-
-  /**
-   * Check if a host is under any verified domain for this workspace.
-   * Used for MCP static IP egress - requests to hosts under verified domains
-   * are routed through the static IP proxy.
-   *
-   * Rejects IP address literals for security (only domain names are matched).
-   */
-  static async isHostUnderVerifiedDomain(
-    workspaceId: ModelId,
-    host: string
-  ): Promise<boolean> {
-    // Reject IP addresses - only domain names should be matched
-    if (isIpAddress(host)) {
-      return false;
-    }
-
-    // Fetch all verified domains for the workspace
-    const verifiedDomains = await this.workspaceDomainModel.findAll({
-      attributes: ["domain"],
-      where: { workspaceId },
-      // WORKSPACE_ISOLATION_BYPASS: Need to bypass for workspace-level domain lookup.
-      dangerouslyBypassWorkspaceIsolationSecurity: true,
-    });
-
-    // Check if host matches any verified domain (exact or subdomain)
-    return verifiedDomains.some((d) => isHostUnderDomain(host, d.domain));
   }
 
   async updateSegmentation(segmentation: WorkspaceSegmentationType) {

--- a/front/types/shared/utils/url_utils.test.ts
+++ b/front/types/shared/utils/url_utils.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+
+import { isHostUnderDomain, isIpAddress } from "./url_utils";
+
+describe("isIpAddress", () => {
+  describe("IPv4 addresses", () => {
+    it("should accept valid IPv4 addresses", () => {
+      expect(isIpAddress("192.168.1.1")).toBe(true);
+      expect(isIpAddress("10.0.0.1")).toBe(true);
+      expect(isIpAddress("0.0.0.0")).toBe(true);
+      expect(isIpAddress("255.255.255.255")).toBe(true);
+      expect(isIpAddress("127.0.0.1")).toBe(true);
+      expect(isIpAddress("1.1.1.1")).toBe(true);
+    });
+
+    it("should reject invalid IPv4 addresses", () => {
+      // Octets out of range
+      expect(isIpAddress("256.1.1.1")).toBe(false);
+      expect(isIpAddress("1.256.1.1")).toBe(false);
+      expect(isIpAddress("1.1.256.1")).toBe(false);
+      expect(isIpAddress("1.1.1.256")).toBe(false);
+      expect(isIpAddress("999.999.999.999")).toBe(false);
+
+      // Wrong number of octets
+      expect(isIpAddress("1.2.3")).toBe(false);
+      expect(isIpAddress("1.2")).toBe(false);
+      expect(isIpAddress("1")).toBe(false);
+      expect(isIpAddress("1.2.3.4.5")).toBe(false);
+
+      // Invalid formats
+      expect(isIpAddress("")).toBe(false);
+      expect(isIpAddress("...")).toBe(false);
+      expect(isIpAddress("1...1")).toBe(false);
+      expect(isIpAddress(".1.1.1.1")).toBe(false);
+      expect(isIpAddress("1.1.1.1.")).toBe(false);
+    });
+  });
+
+  describe("IPv6 addresses", () => {
+    it("should accept valid IPv6 addresses with brackets", () => {
+      expect(isIpAddress("[::1]")).toBe(true);
+      expect(isIpAddress("[2001:db8::1]")).toBe(true);
+      expect(isIpAddress("[::ffff:192.168.1.1]")).toBe(true);
+      expect(isIpAddress("[2001:0db8:85a3:0000:0000:8a2e:0370:7334]")).toBe(
+        true
+      );
+      expect(isIpAddress("[fe80::1]")).toBe(true);
+    });
+
+    it("should accept valid raw IPv6 addresses without brackets", () => {
+      expect(isIpAddress("::1")).toBe(true);
+      expect(isIpAddress("2001:db8::1")).toBe(true);
+      expect(isIpAddress("fe80::1")).toBe(true);
+      expect(isIpAddress("::ffff:192.168.1.1")).toBe(true);
+    });
+
+    it("should reject invalid IPv6 addresses", () => {
+      expect(isIpAddress("[invalid]")).toBe(false);
+      expect(isIpAddress("[::gggg]")).toBe(false);
+      expect(isIpAddress("[]")).toBe(false);
+      expect(isIpAddress("[")).toBe(false);
+      expect(isIpAddress("]")).toBe(false);
+    });
+  });
+
+  describe("non-IP hostnames", () => {
+    it("should reject domain names", () => {
+      expect(isIpAddress("example.com")).toBe(false);
+      expect(isIpAddress("sub.example.com")).toBe(false);
+      expect(isIpAddress("localhost")).toBe(false);
+      expect(isIpAddress("my-server.local")).toBe(false);
+    });
+
+    it("should reject mixed/invalid formats", () => {
+      expect(isIpAddress("192.168.1.1:8080")).toBe(false);
+      expect(isIpAddress("http://192.168.1.1")).toBe(false);
+      expect(isIpAddress("192.168.1.1/24")).toBe(false);
+      expect(isIpAddress("abc123")).toBe(false);
+      expect(isIpAddress("0")).toBe(false);
+    });
+  });
+});
+
+describe("isHostUnderDomain", () => {
+  describe("exact matches", () => {
+    it("should match identical domains", () => {
+      expect(isHostUnderDomain("example.com", "example.com")).toBe(true);
+      expect(isHostUnderDomain("sub.example.com", "sub.example.com")).toBe(
+        true
+      );
+    });
+
+    it("should match case-insensitively", () => {
+      expect(isHostUnderDomain("EXAMPLE.COM", "example.com")).toBe(true);
+      expect(isHostUnderDomain("example.com", "EXAMPLE.COM")).toBe(true);
+      expect(isHostUnderDomain("Example.Com", "example.com")).toBe(true);
+    });
+
+    it("should handle trailing dots", () => {
+      expect(isHostUnderDomain("example.com.", "example.com")).toBe(true);
+      expect(isHostUnderDomain("example.com", "example.com.")).toBe(true);
+      expect(isHostUnderDomain("example.com.", "example.com.")).toBe(true);
+    });
+  });
+
+  describe("subdomain matches", () => {
+    it("should match subdomains", () => {
+      expect(isHostUnderDomain("sub.example.com", "example.com")).toBe(true);
+      expect(isHostUnderDomain("deep.sub.example.com", "example.com")).toBe(
+        true
+      );
+      expect(isHostUnderDomain("a.b.c.example.com", "example.com")).toBe(true);
+    });
+
+    it("should match subdomains case-insensitively", () => {
+      expect(isHostUnderDomain("SUB.EXAMPLE.COM", "example.com")).toBe(true);
+      expect(isHostUnderDomain("sub.example.com", "EXAMPLE.COM")).toBe(true);
+    });
+
+    it("should match subdomains with trailing dots", () => {
+      expect(isHostUnderDomain("sub.example.com.", "example.com")).toBe(true);
+      expect(isHostUnderDomain("sub.example.com", "example.com.")).toBe(true);
+    });
+  });
+
+  describe("non-matches", () => {
+    it("should not match unrelated domains", () => {
+      expect(isHostUnderDomain("other.com", "example.com")).toBe(false);
+      expect(isHostUnderDomain("example.org", "example.com")).toBe(false);
+    });
+
+    it("should not match partial suffix matches", () => {
+      // "notexample.com" ends with "example.com" but is not a subdomain
+      expect(isHostUnderDomain("notexample.com", "example.com")).toBe(false);
+      expect(isHostUnderDomain("fakeexample.com", "example.com")).toBe(false);
+      expect(isHostUnderDomain("myexample.com", "example.com")).toBe(false);
+    });
+
+    it("should not match when host is shorter than domain", () => {
+      expect(isHostUnderDomain("com", "example.com")).toBe(false);
+      expect(isHostUnderDomain("example", "example.com")).toBe(false);
+    });
+
+    it("should not match reversed relationship", () => {
+      expect(isHostUnderDomain("example.com", "sub.example.com")).toBe(false);
+    });
+  });
+});

--- a/front/types/shared/utils/url_utils.ts
+++ b/front/types/shared/utils/url_utils.ts
@@ -95,3 +95,50 @@ export const validateRelativePath = (
     return { valid: false, sanitizedPath: null };
   }
 };
+
+/**
+ * Check if a string is an IP address (IPv4 or IPv6).
+ * Used to reject IP addresses when matching against domain names.
+ */
+export function isIpAddress(host: string): boolean {
+  // IPv4: four groups of 1-3 digits separated by dots, each 0-255
+  const ipv4Match = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host);
+  if (ipv4Match) {
+    const octets = [ipv4Match[1], ipv4Match[2], ipv4Match[3], ipv4Match[4]];
+    const allValid = octets.every((octet) => {
+      const num = parseInt(octet, 10);
+      return num >= 0 && num <= 255;
+    });
+    if (allValid) {
+      return true;
+    }
+  }
+
+  // IPv6: contains colons and only hex digits, colons, dots (for IPv4-mapped)
+  if (host.includes(":")) {
+    if (/^[0-9a-f:.]+$/i.test(host)) {
+      const parts = host.split(":");
+      if (parts.length <= 9) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Check if a host is under a domain.
+ * - Exact match: host === domain
+ * - Subdomain match: host ends with '.' + domain
+ * Both are normalized to lowercase and trailing dots are removed.
+ */
+export function isHostUnderDomain(host: string, domain: string): boolean {
+  const normalizedHost = host.toLowerCase().replace(/\.$/, "");
+  const normalizedDomain = domain.toLowerCase().replace(/\.$/, "");
+
+  return (
+    normalizedHost === normalizedDomain ||
+    normalizedHost.endsWith("." + normalizedDomain)
+  );
+}


### PR DESCRIPTION
## Description

Enable domain-based static IP proxy routing for MCP requests. Workspaces can now connect to internal MCP servers by verifying their domain - Dust will automatically route requests through a static IP that can be whitelisted.

**Changes:**

**`types/shared/utils/url_utils.ts`**
- Add `isIpAddress()` - detects IPv4/IPv6 addresses to reject them from domain matching
- Add `isHostUnderDomain()` - checks if a host matches a domain (exact or subdomain)

**`lib/api/workspace_has_domains.ts`** (new file)
- Add `isHostUnderVerifiedDomain()` helper that checks if a host matches any verified domain for a workspace

**`lib/actions/mcp_metadata.ts`**
- Update `createMCPDispatcher()` to be async and accept host parameter
- Use domain-based check in addition to legacy hardcoded workspace check
- Use shared `getStaticIPProxyAgent()` helper instead of inline proxy creation

**`components/workspace/WorkspaceAccessPanel.tsx`**
- Update domain verification description to mention MCP server connections
- Minor UX fixes (button opens in same tab, column width adjustment)

**How it works:**
1. Workspace admin verifies their domain (e.g., `example.com`)
2. When connecting to an MCP server, we check if the server's hostname is under any verified domain
3. If yes, the request is routed through our static IP proxy so the workspace can whitelist our IP
4. IP address literals are rejected (only domain names are matched)

## Tests


## Risk

Limited blast radius

## Deploy Plan

Standard deployment. No migration needed - uses existing verified domains data.