### PR TITLE
Fix: it's okay for a user message to not have a user linked to it.

### DIFF
--- a/front/lib/api/assistant/conversation/mentions.ts
+++ b/front/lib/api/assistant/conversation/mentions.ts
@@ -884,10 +884,8 @@ export async function getUserMessageIdFromMessageId(
   });
 
   assert(
-    parentMessage &&
-      parentMessage.userMessage &&
-      parentMessage.userMessage.userId,
-    "A user message with a linked user is expected for the agent message"
+    parentMessage && parentMessage.userMessage,
+    "A user message is expected for the agent message's parent"
   );
 
   return {


### PR DESCRIPTION
## Description

It's actually okay and the code using the function downstream was already expecting it.

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy front