### PR TITLE
feat(toolsets): check personal OAuth before enabling toolset

### DIFF
--- a/front/lib/actions/mcp_internal_actions/output_schemas.ts
+++ b/front/lib/actions/mcp_internal_actions/output_schemas.ts
@@ -1020,6 +1020,8 @@ export const AuthRequiredOutputResourceSchema = z.object({
   scope: z.string().optional(),
   text: z.string(),
   uri: z.string(),
+  // Optional: the MCP server that requires auth (used when a tool triggers auth for another server).
+  mcpServerId: z.string().optional(),
 });
 
 export const BlockedAwaitingInputOutputResourceSchema = z.object({

--- a/front/lib/actions/mcp_internal_actions/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils.ts
@@ -45,7 +45,8 @@ export function makeInternalMCPServer(
 
 export function makePersonalAuthenticationError(
   provider: OAuthProvider,
-  scope?: string
+  scope?: string,
+  mcpServerId?: string
 ) {
   return {
     content: [
@@ -58,6 +59,7 @@ export function makePersonalAuthenticationError(
           provider,
           text: "Personal authentication required",
           uri: "",
+          ...(mcpServerId && { mcpServerId }),
         },
       },
     ],


### PR DESCRIPTION
## Description

When enabling a toolset via the toolsets MCP server, check if the target server requires personal OAuth authentication before enabling it. This provides a better UX by:

1. Verifying admin has set up workspace connection first - if not, shows clear error message
2. Checking if user has completed personal authentication
3. If not authenticated, returning auth prompt with the correct MCP server ID so UI shows the right server name (e.g., "Snowflake" instead of "Toolsets")

Changes:
- Add `mcpServerId` optional field to `AuthRequiredOutputResourceSchema` 
- Add `mcpServerId` parameter to `makePersonalAuthenticationError` helper
- Add personal OAuth validation in toolsets `enable` handler

## Tests

- Manual testing: Enable OAuth-requiring toolset without personal auth → should show auth prompt with correct server name
- Manual testing: Enable OAuth-requiring toolset with personal auth → should enable successfully
- Manual testing: Enable toolset that doesn't require OAuth → should work as before

## Risk

Low risk. Adds validation before enabling toolsets - if validation fails, user sees appropriate error/auth prompt. Existing flows for non-OAuth toolsets unaffected.

## Deploy Plan

Standard deployment. No special considerations needed.