### PR TITLE
[front] enh(agent-loop): optimize transport fallback, add hearbeat

### DIFF
--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -363,6 +363,8 @@ export async function* tryCallMCPTool(
     }
     mcpClient = connectionResult.value;
 
+    heartbeat();
+
     const emitter = new EventEmitter();
 
     // Convert the emitter to an async generator.

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -306,6 +306,7 @@ export async function* tryCallMCPTool(
     conversationId,
     messageId,
     toolName: toolConfiguration.originalName,
+    toolConfigurationId: toolConfiguration.sId,
     workspaceId,
   };
 

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -50,11 +50,11 @@ interface ConnectViaMCPServerId {
   oAuthUseCase: MCPOAuthUseCase | null;
 }
 
-export const isConnectViaMCPServerId = (
+export function isConnectViaMCPServerId(
   params: MCPConnectionParams
-): params is ConnectViaMCPServerId => {
+): params is ConnectViaMCPServerId {
   return params.type === "mcpServerId";
-};
+}
 
 interface ConnectViaRemoteMCPServerUrl {
   type: "remoteMCPServerUrl";
@@ -69,11 +69,11 @@ interface ConnectViaClientSideMCPServer {
   mcpServerId: string;
 }
 
-export const isConnectViaClientSideMCPServer = (
+export function isConnectViaClientSideMCPServer(
   params: MCPConnectionParams
-): params is ConnectViaClientSideMCPServer => {
+): params is ConnectViaClientSideMCPServer {
   return params.type === "clientSideMCPServerId";
-};
+}
 
 export type ServerSideMCPConnectionParams =
   | ConnectViaMCPServerId
@@ -103,7 +103,7 @@ function createMCPDispatcher(auth: Authenticator): ProxyAgent | undefined {
   return getUntrustedEgressAgent();
 }
 
-export const connectToMCPServer = async (
+export async function connectToMCPServer(
   auth: Authenticator,
   {
     params,
@@ -114,7 +114,7 @@ export const connectToMCPServer = async (
   }
 ): Promise<
   Result<Client, Error | MCPServerPersonalAuthenticationRequiredError>
-> => {
+> {
   // This is where we route the MCP client to the right server.
   const mcpClient = new Client({
     name: "dust-mcp-client",
@@ -436,7 +436,7 @@ export const connectToMCPServer = async (
   }
 
   return new Ok(mcpClient);
-};
+}
 
 // Try to connect via streamableHttpTransport first, and if that fails, fall back to sseTransport.
 // If the URL path ends with /sse, skip HTTP streaming and use SSE directly.

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -6,7 +6,6 @@ import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/
 import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import type { OAuthTokens } from "@modelcontextprotocol/sdk/shared/auth.js";
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
-import { heartbeat } from "@temporalio/activity";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { ProxyAgent } from "undici";
 
@@ -459,8 +458,6 @@ async function connectToRemoteMCPServer(
       timeout: DEFAULT_MCP_CLIENT_CONNECT_TIMEOUT_MS,
     });
   } catch (error) {
-    // Heartbeat here, which prevents timing out in the case where we timed out above.
-    heartbeat();
     // Check if the error message contains "HTTP 4xx" as suggested by the official doc.
     // Doc is here https://github.com/modelcontextprotocol/typescript-sdk?tab=readme-ov-file#client-side-compatibility.
     if (

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -43,7 +43,7 @@ import {
   Ok,
 } from "@app/types";
 
-const DEFAULT_MCP_CLIENT_CONNECT_TIMEOUT_MS = 15_000;
+const DEFAULT_MCP_CLIENT_CONNECT_TIMEOUT_MS = 25_000;
 
 interface ConnectViaMCPServerId {
   type: "mcpServerId";
@@ -476,7 +476,9 @@ async function connectToRemoteMCPServer(
         "Error establishing connection to remote MCP server via streamableHttpTransport, falling back to sseTransport."
       );
       const sseTransport = new SSEClientTransport(url, req);
-      return mcpClient.connect(sseTransport);
+      return mcpClient.connect(sseTransport, {
+        timeout: DEFAULT_MCP_CLIENT_CONNECT_TIMEOUT_MS,
+      });
     }
     throw error;
   }

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -1,4 +1,4 @@
-import { Context } from "@temporalio/activity";
+import { Context, heartbeat } from "@temporalio/activity";
 import assert from "assert";
 
 import { runToolWithStreaming } from "@app/lib/api/mcp/run_tool";
@@ -68,6 +68,9 @@ export async function runToolActivity(
     }
     throw runAgentDataRes.error;
   }
+
+  // Heartbeating here as retrieving the agent loop data takes some time.
+  heartbeat();
 
   const {
     agentConfiguration,


### PR DESCRIPTION
## Description

- This PR contains 4 changes:
	- Reduces the default timeout when connecting to an MCP server from 60s to 15s to avoid heartbeat-timing out. 
	- Heartbeats to Temporal before falling back to SSE.
	- Skips the fallback on 429.
	- Improves logging on heartbeating by adding the tool configuration ID.
- Example studied [here](https://app.datadoghq.eu/logs?query=%40conversationId%3AOb2c5Cy4BE&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=host%2Casc&viz=stream&from_ts=1733653464474&to_ts=1733657064474&live=true) and [here](https://cloud.temporal.io/namespaces/dust-agent-prod.gmnlm/workflows/agent-loop-workflow-aBYzD8sCOU-8VJt6tAJ6t-P19HwoDtIz/019bc2c1-20fe-7457-b7e4-78d9d4621811/history).

## Tests

- Tested locally.

## Risk

- Medium.

## Deploy Plan

- Deploy front.
