### PR TITLE
Allow gcalendar to be a platfom action

### DIFF
--- a/front/lib/api/actions/servers/google_calendar/metadata.ts
+++ b/front/lib/api/actions/servers/google_calendar/metadata.ts
@@ -252,7 +252,10 @@ export const GOOGLE_CALENDAR_SERVER_INFO = {
   description: "Access calendar schedules and appointments.",
   authorization: {
     provider: "google_drive" as const,
-    supported_use_cases: ["personal_actions"] as MCPOAuthUseCase[],
+    supported_use_cases: [
+      "personal_actions",
+      "platform_actions",
+    ] as MCPOAuthUseCase[],
     scope:
       "https://www.googleapis.com/auth/calendar https://www.googleapis.com/auth/calendar.events" as const,
   },


### PR DESCRIPTION
## Description

* Adding ability to use platform action oauth type. We support this and we have a valid customer use case that it is blocking

## Tests

* Localhost

## Risk

* Low

## Deploy Plan

* Deploy front