### PR TITLE
refactor(mcp): extract exit_events.ts for server-only code

### DIFF
--- a/front/lib/actions/mcp_internal_actions/exit_events.ts
+++ b/front/lib/actions/mcp_internal_actions/exit_events.ts
@@ -1,0 +1,124 @@
+import type { MCPApproveExecutionEvent } from "@dust-tt/client";
+import { assertNever, isAgentPauseOutputResourceType } from "@dust-tt/client";
+
+import type {
+  ToolEarlyExitEvent,
+  ToolPersonalAuthRequiredEvent,
+} from "@app/lib/actions/mcp_internal_actions/events";
+import type { Authenticator } from "@app/lib/auth";
+import type { AgentMCPActionOutputItemModel } from "@app/lib/models/agent/actions/mcp";
+import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import type {
+  AgentConfigurationType,
+  AgentMessageType,
+  ConversationWithoutContentType,
+} from "@app/types";
+
+/**
+ * Server-only utility for processing exit/pause events from MCP tool outputs.
+ *
+ * Do NOT import this file from client-side code.
+ */
+export async function getExitOrPauseEvents(
+  auth: Authenticator,
+  {
+    outputItems,
+    action,
+    agentConfiguration,
+    agentMessage,
+    conversation,
+  }: {
+    outputItems: AgentMCPActionOutputItemModel[];
+    action: AgentMCPActionResource;
+    agentConfiguration: AgentConfigurationType;
+    agentMessage: AgentMessageType;
+    conversation: ConversationWithoutContentType;
+  }
+): Promise<
+  (
+    | MCPApproveExecutionEvent
+    | ToolPersonalAuthRequiredEvent
+    | ToolEarlyExitEvent
+  )[]
+> {
+  const exitOutputItem = outputItems
+    .map((item) => item.content)
+    .find(isAgentPauseOutputResourceType)?.resource;
+
+  if (exitOutputItem) {
+    switch (exitOutputItem.type) {
+      case "tool_early_exit": {
+        const { isError, text } = exitOutputItem;
+        return [
+          {
+            type: "tool_early_exit",
+            created: Date.now(),
+            configurationId: agentConfiguration.sId,
+            conversationId: conversation.sId,
+            messageId: agentMessage.sId,
+            text: text,
+            isError: isError,
+          },
+        ];
+      }
+      case "tool_blocked_awaiting_input": {
+        const { blockingEvents, state } = exitOutputItem;
+        // Update the action status to blocked_child_action_input_required to break the agent loop.
+        await action.updateStatus("blocked_child_action_input_required");
+
+        // Update the step context to save the resume state.
+        await action.updateStepContext({
+          ...action.stepContext,
+          resumeState: state,
+        });
+
+        // Yield the blocking events.
+        return blockingEvents;
+      }
+      case "tool_personal_auth_required": {
+        const { provider, scope } = exitOutputItem;
+
+        const authErrorMessage =
+          `The tool ${action.functionCallName} requires personal ` +
+          `authentication, please authenticate to use it.`;
+
+        // Update the action to mark it as blocked because of a personal authentication error.
+        await action.updateStatus("blocked_authentication_required");
+
+        return [
+          {
+            type: "tool_personal_auth_required",
+            created: Date.now(),
+            configurationId: agentConfiguration.sId,
+            userId: auth.user()?.sId,
+            messageId: agentMessage.sId,
+            conversationId: conversation.sId,
+            actionId: action.sId,
+            metadata: {
+              toolName: action.toolConfiguration.originalName,
+              mcpServerName: action.toolConfiguration.mcpServerName,
+              agentName: agentConfiguration.name,
+              mcpServerDisplayName: action.toolConfiguration.mcpServerName,
+              mcpServerId: action.toolConfiguration.toolServerId,
+            },
+            inputs: action.augmentedInputs,
+            authError: {
+              mcpServerId: action.toolConfiguration.toolServerId,
+              provider,
+              toolName: action.functionCallName ?? "unknown",
+              message: authErrorMessage,
+              ...(scope && {
+                scope,
+              }),
+            },
+          },
+        ];
+      }
+      default: {
+        assertNever(exitOutputItem);
+      }
+    }
+  }
+
+  return [];
+}

--- a/front/lib/actions/mcp_internal_actions/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils.ts
@@ -1,9 +1,4 @@
-import type { MCPApproveExecutionEvent } from "@dust-tt/client";
-import {
-  assertNever,
-  INTERNAL_MIME_TYPES,
-  isAgentPauseOutputResourceType,
-} from "@dust-tt/client";
+import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
@@ -12,21 +7,9 @@ import {
   getInternalMCPServerInfo,
   isInternalMCPServerOfName,
 } from "@app/lib/actions/mcp_internal_actions/constants";
-import type {
-  ToolEarlyExitEvent,
-  ToolPersonalAuthRequiredEvent,
-} from "@app/lib/actions/mcp_internal_actions/events";
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
-import type { Authenticator } from "@app/lib/auth";
-import type { AgentMCPActionOutputItemModel } from "@app/lib/models/agent/actions/mcp";
-import type { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
-import type {
-  AgentConfigurationType,
-  AgentMessageType,
-  ConversationWithoutContentType,
-  OAuthProvider,
-} from "@app/types";
+import type { OAuthProvider } from "@app/types";
 
 export function makeInternalMCPServer(
   serverName: InternalMCPServerNameType,
@@ -85,110 +68,6 @@ export function makeMCPToolExit({
       },
     ],
   };
-}
-
-export async function getExitOrPauseEvents(
-  auth: Authenticator,
-  {
-    outputItems,
-    action,
-    agentConfiguration,
-    agentMessage,
-    conversation,
-  }: {
-    outputItems: AgentMCPActionOutputItemModel[];
-    action: AgentMCPActionResource;
-    agentConfiguration: AgentConfigurationType;
-    agentMessage: AgentMessageType;
-    conversation: ConversationWithoutContentType;
-  }
-): Promise<
-  (
-    | MCPApproveExecutionEvent
-    | ToolPersonalAuthRequiredEvent
-    | ToolEarlyExitEvent
-  )[]
-> {
-  const exitOutputItem = outputItems
-    .map((item) => item.content)
-    .find(isAgentPauseOutputResourceType)?.resource;
-
-  if (exitOutputItem) {
-    switch (exitOutputItem.type) {
-      case "tool_early_exit": {
-        const { isError, text } = exitOutputItem;
-        return [
-          {
-            type: "tool_early_exit",
-            created: Date.now(),
-            configurationId: agentConfiguration.sId,
-            conversationId: conversation.sId,
-            messageId: agentMessage.sId,
-            text: text,
-            isError: isError,
-          },
-        ];
-      }
-      case "tool_blocked_awaiting_input": {
-        const { blockingEvents, state } = exitOutputItem;
-        // Update the action status to blocked_child_action_input_required to break the agent loop.
-        await action.updateStatus("blocked_child_action_input_required");
-
-        // Update the step context to save the resume state.
-        await action.updateStepContext({
-          ...action.stepContext,
-          resumeState: state,
-        });
-
-        // Yield the blocking events.
-        return blockingEvents;
-      }
-      case "tool_personal_auth_required": {
-        const { provider, scope } = exitOutputItem;
-
-        const authErrorMessage =
-          `The tool ${action.functionCallName} requires personal ` +
-          `authentication, please authenticate to use it.`;
-
-        // Update the action to mark it as blocked because of a personal authentication error.
-        await action.updateStatus("blocked_authentication_required");
-
-        return [
-          {
-            type: "tool_personal_auth_required",
-            created: Date.now(),
-            configurationId: agentConfiguration.sId,
-            userId: auth.user()?.sId,
-            messageId: agentMessage.sId,
-            conversationId: conversation.sId,
-            actionId: action.sId,
-            metadata: {
-              toolName: action.toolConfiguration.originalName,
-              mcpServerName: action.toolConfiguration.mcpServerName,
-              agentName: agentConfiguration.name,
-              mcpServerDisplayName: action.toolConfiguration.mcpServerName,
-              mcpServerId: action.toolConfiguration.toolServerId,
-            },
-            inputs: action.augmentedInputs,
-            authError: {
-              mcpServerId: action.toolConfiguration.toolServerId,
-              provider,
-              toolName: action.functionCallName ?? "unknown",
-              message: authErrorMessage,
-              ...(scope && {
-                scope,
-              }),
-            },
-          },
-        ];
-      }
-      default: {
-        assertNever(exitOutputItem);
-      }
-    }
-  }
-
-  return [];
 }
 
 export function isJITMCPServerView(view: MCPServerViewType): boolean {

--- a/front/lib/api/mcp/run_tool.ts
+++ b/front/lib/api/mcp/run_tool.ts
@@ -14,7 +14,7 @@ import type {
   ToolEarlyExitEvent,
   ToolPersonalAuthRequiredEvent,
 } from "@app/lib/actions/mcp_internal_actions/events";
-import { getExitOrPauseEvents } from "@app/lib/actions/mcp_internal_actions/utils";
+import { getExitOrPauseEvents } from "@app/lib/actions/mcp_internal_actions/exit_events";
 import { hideFileFromActionOutput } from "@app/lib/actions/mcp_utils";
 import type { AgentLoopRunContextType } from "@app/lib/actions/types";
 import { handleMCPActionError } from "@app/lib/api/mcp/error";


### PR DESCRIPTION
## Description

Extract `getExitOrPauseEvents` to a separate `exit_events.ts` file to isolate server-only code that depends on resources.

This is a pure refactor with no functional changes - just moving code to a new file and updating imports.

**Context:** This is a preparatory refactor extracted from #20114 (Snowflake MCP server).

## Tests

- CI passes
- No new tests needed - pure code movement with no behavior change

## Risk

**Low risk.**
- Pure code movement: extracting a function to a new file
- No behavior changes
- No database changes
- No API changes

## Deploy Plan

1. Merge PR
2. Deploy front
3. No feature flags or gradual rollout needed