### PR TITLE
Fix fallback logic to properly distinguish token issues

### DIFF
--- a/front/lib/actions/mcp_authentication.ts
+++ b/front/lib/actions/mcp_authentication.ts
@@ -1,5 +1,6 @@
 import apiConfig from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
+import { DustError } from "@app/lib/error";
 import type { MCPServerConnectionConnectionType } from "@app/lib/resources/mcp_server_connection_resource";
 import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
 import logger from "@app/logger/logger";
@@ -25,7 +26,7 @@ export async function getConnectionForMCPServer(
       access_token_expiry: number | null;
       scrubbed_raw_json: unknown;
     },
-    Error
+    DustError<"mcp_access_token_error" | "connection_not_found">
   >
 > {
   const connection = await MCPServerConnectionResource.findByMCPServer(auth, {
@@ -50,7 +51,12 @@ export async function getConnectionForMCPServer(
         },
         "Failed to get access token for MCP server"
       );
-      return new Err(new Error("access_token_error"));
+      return new Err(
+        new DustError(
+          "mcp_access_token_error",
+          "Failed to get access token for MCP server"
+        )
+      );
     }
   } else {
     logger.info(
@@ -62,7 +68,12 @@ export async function getConnectionForMCPServer(
       },
       "No connection found for MCP server"
     );
-    return new Err(new Error("connection_not_found"));
+    return new Err(
+      new DustError(
+        "connection_not_found",
+        "No connection found for MCP server"
+      )
+    );
   }
 }
 

--- a/front/lib/actions/mcp_internal_actions/servers/slack/slack_personal.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack/slack_personal.ts
@@ -391,10 +391,9 @@ async function createServer(
     connectionType: "workspace", // Always get the admin token.
   });
 
-  const slackAIStatus: SlackAIStatus =
-    c.status === "success"
-      ? await getSlackAIEnablementStatus({ accessToken: c.access_token })
-      : "disconnected";
+  const slackAIStatus: SlackAIStatus = c.isOk()
+    ? await getSlackAIEnablementStatus({ accessToken: c.value.access_token })
+    : "disconnected";
 
   localLogger.info(
     {

--- a/front/lib/actions/mcp_internal_actions/servers/slack/slack_personal.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack/slack_personal.ts
@@ -391,9 +391,10 @@ async function createServer(
     connectionType: "workspace", // Always get the admin token.
   });
 
-  const slackAIStatus: SlackAIStatus = c
-    ? await getSlackAIEnablementStatus({ accessToken: c.access_token })
-    : "disconnected";
+  const slackAIStatus: SlackAIStatus =
+    c.status === "success"
+      ? await getSlackAIEnablementStatus({ accessToken: c.access_token })
+      : "disconnected";
 
   localLogger.info(
     {

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -182,7 +182,7 @@ export const connectToMCPServer = async (
                     ? "personal"
                     : "workspace",
               });
-              if (c) {
+              if (c.status === "success") {
                 const authInfo: AuthInfo = {
                   token: c.access_token,
                   expiresAt: c.access_token_expiry ?? undefined,
@@ -206,6 +206,7 @@ export const connectToMCPServer = async (
                     workspaceId: auth.getNonNullableWorkspace().sId,
                     mcpServerId: params.mcpServerId,
                     oAuthUseCase: params.oAuthUseCase,
+                    error: c.error,
                   },
                   "Internal server requires workspace authentication but no connection found"
                 );
@@ -219,7 +220,10 @@ export const connectToMCPServer = async (
                     }
                   );
                   // If no admin connection exists, return an error to display a message to the user saying that the server requires the admin to setup the connection.
-                  if (!adminConnection) {
+                  if (
+                    adminConnection.status === "error" &&
+                    adminConnection.error === "connection_not_found"
+                  ) {
                     return new Err(
                       new MCPServerRequiresAdminAuthenticationError(
                         params.mcpServerId,
@@ -291,7 +295,7 @@ export const connectToMCPServer = async (
               mcpServerId: params.mcpServerId,
               connectionType: connectionType,
             });
-            if (c) {
+            if (c.status === "success") {
               token = {
                 access_token: c.access_token,
                 token_type: "bearer",
@@ -306,7 +310,7 @@ export const connectToMCPServer = async (
                   connectionType: "workspace",
                 });
                 // If no admin connection exists, return an error to display a message to the user saying that the server requires the admin to setup the connection.
-                if (!adminConnection) {
+                if (adminConnection.status === "error") {
                   return new Err(
                     new MCPServerRequiresAdminAuthenticationError(
                       params.mcpServerId,

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -182,14 +182,14 @@ export const connectToMCPServer = async (
                     ? "personal"
                     : "workspace",
               });
-              if (c.status === "success") {
+              if (c.isOk()) {
                 const authInfo: AuthInfo = {
-                  token: c.access_token,
-                  expiresAt: c.access_token_expiry ?? undefined,
+                  token: c.value.access_token,
+                  expiresAt: c.value.access_token_expiry ?? undefined,
                   clientId: "",
                   scopes: [],
                   extra: {
-                    ...c.connection.metadata,
+                    ...c.value.connection.metadata,
                     connectionType:
                       params.oAuthUseCase === "personal_actions"
                         ? "personal"
@@ -221,8 +221,8 @@ export const connectToMCPServer = async (
                   );
                   // If no admin connection exists, return an error to display a message to the user saying that the server requires the admin to setup the connection.
                   if (
-                    adminConnection.status === "error" &&
-                    adminConnection.error === "connection_not_found"
+                    adminConnection.isErr() &&
+                    adminConnection.error.message === "connection_not_found"
                   ) {
                     return new Err(
                       new MCPServerRequiresAdminAuthenticationError(
@@ -295,12 +295,12 @@ export const connectToMCPServer = async (
               mcpServerId: params.mcpServerId,
               connectionType: connectionType,
             });
-            if (c.status === "success") {
+            if (c.isOk()) {
               token = {
-                access_token: c.access_token,
+                access_token: c.value.access_token,
                 token_type: "bearer",
-                expires_in: c.access_token_expiry ?? undefined,
-                scope: c.connection.metadata.scope,
+                expires_in: c.value.access_token_expiry ?? undefined,
+                scope: c.value.connection.metadata.scope,
               };
             } else {
               if (connectionType === "personal") {
@@ -310,7 +310,7 @@ export const connectToMCPServer = async (
                   connectionType: "workspace",
                 });
                 // If no admin connection exists, return an error to display a message to the user saying that the server requires the admin to setup the connection.
-                if (adminConnection.status === "error") {
+                if (adminConnection.isErr()) {
                   return new Err(
                     new MCPServerRequiresAdminAuthenticationError(
                       params.mcpServerId,

--- a/front/lib/error.ts
+++ b/front/lib/error.ts
@@ -39,6 +39,7 @@ export type DustErrorCode =
   | "mcp_server_view_not_found"
   | "action_not_found"
   | "action_not_blocked"
+  | "mcp_access_token_error"
   // Triggers errors
   | "webhook_source_not_found"
   // Space errors

--- a/front/lib/search/tools/search.ts
+++ b/front/lib/search/tools/search.ts
@@ -91,14 +91,14 @@ async function _getToolAndAccessTokenForView(
     connectionType,
   });
 
-  if (connectionResult.status === "error") {
+  if (connectionResult.isErr()) {
     return null;
   }
 
   return {
     tool: SEARCHABLE_TOOLS[r.value.name],
-    accessToken: connectionResult.access_token,
-    metadata: connectionResult.connection.metadata,
+    accessToken: connectionResult.value.access_token,
+    metadata: connectionResult.value.connection.metadata,
   };
 }
 

--- a/front/lib/search/tools/search.ts
+++ b/front/lib/search/tools/search.ts
@@ -91,7 +91,7 @@ async function _getToolAndAccessTokenForView(
     connectionType,
   });
 
-  if (!connectionResult) {
+  if (connectionResult.status === "error") {
     return null;
   }
 


### PR DESCRIPTION
## Description

This PR fixes the fallback logic in MCP authentication to properly distinguish between connection not found errors and access token retrieval errors. Previously, `getConnectionForMCPServer()` returned null for both cases, making it impossible to determine whether a connection didn't exist or the token refresh failed. 

This caused the system to incorrectly show "admin setup required" errors when the admin token was invalid, whereas we should ask the user to reconnect his personal tool.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Deploy front
