### PR TITLE
[front] fix(layout): prevent trial banner from clipping chat input

### DIFF
--- a/front/components/sparkle/AppContentLayout.tsx
+++ b/front/components/sparkle/AppContentLayout.tsx
@@ -97,7 +97,7 @@ export default function AppContentLayout({
       />
       <div
         className={cn(
-          "relative h-full w-full flex-1 overflow-hidden",
+          "relative flex h-full w-full flex-1 flex-col overflow-hidden",
           "bg-background text-foreground",
           "dark:bg-background-night dark:text-foreground-night"
         )}
@@ -111,12 +111,14 @@ export default function AppContentLayout({
         {/* Temporary measure to preserve title existence on smaller screens.
          * Page has no title, prepend empty AppLayoutTitle. */}
         {loaded && !hasTitle && (
-          <>
+          <div className="flex min-h-0 flex-1 flex-col">
             <AppLayoutTitle />
             {children}
-          </>
+          </div>
         )}
-        {loaded && hasTitle && children}
+        {loaded && hasTitle && (
+          <div className="flex min-h-0 flex-1 flex-col">{children}</div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
Fixes: https://github.com/dust-tt/tasks/issues/5932

## Description

Chat input was being clipped when the trial/subscription banner was displayed. The banner took space in the layout but children tried to fill `h-full`, causing the input to extend beyond the visible area.

Fixed by making the content area use flex column layout so the banner takes its natural height and children get the remaining space via `flex-1` with `min-h-0` (required for proper overflow handling in nested flex).

## Tests

<img width="2541" height="1350" alt="image" src="https://github.com/user-attachments/assets/4720f65d-b2b7-4ff8-9d36-0520366de328" />

## Risk

Low.

## Deploy Plan

Front.