### PR TITLE
[Slack MCP] post msg + file for private DM fixed

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/slack/helpers.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack/helpers.ts
@@ -251,7 +251,8 @@ export async function resolveChannelId({
   const searchString = channelNameOrId
     .trim()
     .replace(/^#/, "")
-    .replace(/^@/, "");
+    .replace(/^@/, "")
+    .replace(/^U/, "D");
 
   // If searchString looks like a Slack channel/DM ID (starts with C, G, or D), try direct lookup first.
   if (searchString.match(/^[CGD][A-Z0-9]+$/)) {
@@ -686,8 +687,7 @@ export async function executePostMessage(
     message: string;
     threadTs: string | undefined;
     fileId: string | undefined;
-  },
-  mcpServerId: string
+  }
 ) {
   const slackClient = await getSlackClient(accessToken);
   const originalMessage = message;
@@ -715,47 +715,20 @@ export async function executePostMessage(
       );
     }
 
-    // Resolve channel id - optimize by trying conversations.info first if it looks like an ID.
-    const searchString = to.trim().replace(/^#/, "");
-    let channelId: string | undefined;
-
-    // If searchString looks like a Slack channel ID (starts with C or G), try direct lookup first.
-    if (searchString.match(/^[CG][A-Z0-9]+$/)) {
-      try {
-        const infoResp = await slackClient.conversations.info({
-          channel: searchString,
-        });
-        if (infoResp.ok && infoResp.channel?.id) {
-          channelId = infoResp.channel.id;
-        }
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      } catch (error) {
-        // Fall through to list-based search.
-      }
-    }
-
-    // If not found via direct lookup, search through cached channels list.
+    // Resolve channel id using the shared helper function.
+    const channelId = await resolveChannelId({
+      channelNameOrId: to,
+      accessToken,
+    });
     if (!channelId) {
-      const conversationsList = await getCachedPublicChannels({
-        mcpServerId,
-        slackClient,
-      });
-      const channel = conversationsList.find(
-        (c) =>
-          c.name?.toLowerCase() === searchString.toLowerCase() ||
-          c.id?.toLowerCase() === searchString.toLowerCase()
+      return new Err(
+        new MCPError(
+          `Unable to resolve channel id for "${to}". Please use a channel id, user id, or a valid channel name.`,
+          {
+            tracked: false,
+          }
+        )
       );
-      if (!channel) {
-        return new Err(
-          new MCPError(
-            `Unable to resolve channel id for "${to}". Please use a channel id or a valid channel name.`,
-            {
-              tracked: false,
-            }
-          )
-        );
-      }
-      channelId = channel.id;
     }
 
     const signedUrl = await file.getSignedUrlForDownload(auth, "original");

--- a/front/lib/actions/mcp_internal_actions/servers/slack/slack_bot.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack/slack_bot.ts
@@ -69,17 +69,13 @@ async function createServer(
         }
 
         try {
-          return await executePostMessage(
-            auth,
-            agentLoopContext,
-            {
-              to,
-              message,
-              threadTs,
-              fileId,
-              accessToken,
-            }
-          );
+          return await executePostMessage(auth, agentLoopContext, {
+            to,
+            message,
+            threadTs,
+            fileId,
+            accessToken,
+          });
         } catch (error) {
           return new Err(
             new MCPError(`Error posting message: ${normalizeError(error)}`)

--- a/front/lib/actions/mcp_internal_actions/servers/slack/slack_bot.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack/slack_bot.ts
@@ -78,8 +78,7 @@ async function createServer(
               threadTs,
               fileId,
               accessToken,
-            },
-            mcpServerId
+            }
           );
         } catch (error) {
           return new Err(

--- a/front/lib/actions/mcp_internal_actions/servers/slack/slack_personal.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack/slack_personal.ts
@@ -680,17 +680,13 @@ async function createServer(
         }
 
         try {
-          return await executePostMessage(
-            auth,
-            agentLoopContext,
-            {
-              to,
-              message,
-              threadTs,
-              fileId,
-              accessToken,
-            }
-          );
+          return await executePostMessage(auth, agentLoopContext, {
+            to,
+            message,
+            threadTs,
+            fileId,
+            accessToken,
+          });
         } catch (error) {
           const authError = handleSlackAuthError(error);
           if (authError) {

--- a/front/lib/actions/mcp_internal_actions/servers/slack/slack_personal.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack/slack_personal.ts
@@ -689,8 +689,7 @@ async function createServer(
               threadTs,
               fileId,
               accessToken,
-            },
-            mcpServerId
+            }
           );
         } catch (error) {
           const authError = handleSlackAuthError(error);


### PR DESCRIPTION
## Description

Fixes posting Slack messages with file attachments to DMs. The issue occurred because `executePostMessage` was attempting to resolve the channel ID using a helper function designed for channel lookups when a file was present, but this helper didn't properly handle user IDs for DMs. Additionally, user IDs starting with 'U' need to be converted to their DM channel ID equivalent starting with 'D'. The fix consolidates the channel resolution logic to use the shared `resolveChannelId` helper function for both file and non-file message paths, and adds a simple string replacement to convert user IDs ('U') to DM channel IDs ('D'). This eliminates the duplicate channel resolution code that was only used for file attachments and removes the unnecessary `mcpServerId` parameter from `executePostMessage`.
https://github.com/dust-tt/tasks/issues/5927

## Tests

Tested manually by posting messages with file attachments to DMs using user IDs.

## Risk

Low - simplifies code by removing duplicate logic and reusing existing helper function. The user ID to DM ID conversion is a simple string replacement that follows Slack's convention.

## Deploy Plan

Run front