### PR TITLE
[connectors] fix(projects): include `DustProjectConversation` in connector deletion

### DIFF
--- a/connectors/src/resources/connector/dust_project.ts
+++ b/connectors/src/resources/connector/dust_project.ts
@@ -1,6 +1,8 @@
 import type { Transaction } from "sequelize";
 
-import { DustProjectConfigurationModel } from "@connectors/lib/models/dust_project";
+import {
+  DustProjectConfigurationModel,
+} from "@connectors/lib/models/dust_project";
 import type {
   ConnectorProviderConfigurationType,
   ConnectorProviderModelResourceMapping,
@@ -9,6 +11,7 @@ import type {
 } from "@connectors/resources/connector/strategy";
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
 import { DustProjectConfigurationResource } from "@connectors/resources/dust_project_configuration_resource";
+import { DustProjectConversationResource } from "@connectors/resources/dust_project_conversation_resource";
 import type { ModelId } from "@connectors/types";
 
 export class DustProjectConnectorStrategy implements ConnectorProviderStrategy<"dust_project"> {
@@ -28,6 +31,10 @@ export class DustProjectConnectorStrategy implements ConnectorProviderStrategy<"
     connector: ConnectorResource,
     transaction: Transaction
   ): Promise<void> {
+    await DustProjectConversationResource.deleteByConnector(
+      connector,
+      transaction
+    );
     await DustProjectConfigurationModel.destroy({
       where: { connectorId: connector.id },
       transaction,

--- a/connectors/src/resources/connector/dust_project.ts
+++ b/connectors/src/resources/connector/dust_project.ts
@@ -1,8 +1,6 @@
 import type { Transaction } from "sequelize";
 
-import {
-  DustProjectConfigurationModel,
-} from "@connectors/lib/models/dust_project";
+import { DustProjectConfigurationModel } from "@connectors/lib/models/dust_project";
 import type {
   ConnectorProviderConfigurationType,
   ConnectorProviderModelResourceMapping,

--- a/connectors/src/resources/dust_project_conversation_resource.ts
+++ b/connectors/src/resources/dust_project_conversation_resource.ts
@@ -161,7 +161,9 @@ export class DustProjectConversationResource extends BaseResource<DustProjectCon
     transaction?: Transaction
   ): Promise<Result<undefined, Error>> {
     await this.model.destroy({
-      where: { connectorId: connector.id },
+      where: {
+        connectorId: connector.id,
+      },
       transaction,
     });
     return new Ok(undefined);

--- a/connectors/src/resources/dust_project_conversation_resource.ts
+++ b/connectors/src/resources/dust_project_conversation_resource.ts
@@ -160,7 +160,7 @@ export class DustProjectConversationResource extends BaseResource<DustProjectCon
     connector: ConnectorResource,
     transaction?: Transaction
   ): Promise<Result<undefined, Error>> {
-    await DustProjectConversationModel.destroy({
+    await this.model.destroy({
       where: { connectorId: connector.id },
       transaction,
     });

--- a/connectors/src/resources/dust_project_conversation_resource.ts
+++ b/connectors/src/resources/dust_project_conversation_resource.ts
@@ -5,6 +5,7 @@ import type { Attributes, ModelStatic, Transaction } from "sequelize";
 import { DustProjectConversationModel } from "@connectors/lib/models/dust_project";
 import logger from "@connectors/logger/logger";
 import { BaseResource } from "@connectors/resources/base_resource";
+import type { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { ReadonlyAttributesType } from "@connectors/resources/storage/types";
 import type { ModelId } from "@connectors/types";
 import { normalizeError } from "@connectors/types";
@@ -153,6 +154,17 @@ export class DustProjectConversationResource extends BaseResource<DustProjectCon
       );
       return new Err(normalizeError(err));
     }
+  }
+
+  static async deleteByConnector(
+    connector: ConnectorResource,
+    transaction?: Transaction
+  ): Promise<Result<undefined, Error>> {
+    await DustProjectConversationModel.destroy({
+      where: { connectorId: connector.id },
+      transaction,
+    });
+    return new Ok(undefined);
   }
 
   static async getMaxSourceUpdatedAt(


### PR DESCRIPTION
## Description

- A workflow is stuck while attempting to hard delete a project data source ([logs](https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40attempt%3A%3E14%20%40dd.service%3Afront-worker%20region%3Aus-central1&additional_filters=%5B%5D&cols=host%2Cservice&event=AwAAAZvGhSO2mZKT1AAAABhBWnZHaFRNekFBRHRRTDBLaEhOVHZnQUwAAAAkMDE5YmM2ODUtM2JkZC00MWMxLWJiYzktMDljOGJiNzBmNGQwAAAkTQ&fromUser=true&messageDisplay=inline&refresh_mode=sliding&saved-view-id=186561&storage=hot&stream_sort=desc&viz=stream&from_ts=1768558679708&to_ts=1768562279708&live=true)).
- The error comes from an FK constraint while deleting the connector, which is still referenced by rows in `dust_project_conversations`.
- This PR updates the deletion flow to first delete these rows in `dust_project_conversations`.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy connectors.
