### PR TITLE
fix(dust-hive): make unified logs header sticky when scrolling

### DIFF
--- a/x/henry/dust-hive/src/lib/scripts.ts
+++ b/x/henry/dust-hive/src/lib/scripts.ts
@@ -129,9 +129,12 @@ stop_tail() {
   const serviceFunctions = `
 switch_service() {
   stop_tail
-  clear
-  draw_header
-  setup_scroll_region
+  # Reset scroll region, clear screen properly, then set up header
+  printf "\\033[r"                    # Reset scroll region to full screen
+  printf "\\033[2J\\033[H"            # Clear screen and move cursor to home
+  setup_scroll_region                 # Set scroll region FIRST (lines 2+)
+  draw_header                         # Draw header at line 1 (outside scroll region)
+  printf "\\033[2;1H"                 # Move cursor to line 2 for tail output
   start_tail
 }
 
@@ -184,10 +187,11 @@ decrease_lines() {
 
   // Main loop
   const mainLoop = `
-# Initial draw
-clear
-draw_header
-setup_scroll_region
+# Initial draw - set scroll region FIRST to protect header line
+printf "\\033[2J\\033[H"            # Clear screen and move cursor to home
+setup_scroll_region                 # Set scroll region (lines 2+)
+draw_header                         # Draw header at line 1 (protected)
+printf "\\033[2;1H"                 # Move cursor to line 2 for tail output
 start_tail
 
 # Main input loop - read single chars


### PR DESCRIPTION
## Summary

Fixes the unified logs TUI header (showing service name and keyboard shortcuts) scrolling off screen when log output overflows.

## Changes

- Set up scroll region before drawing the header, not after
- Replace `clear` command with explicit ANSI escape sequences (`\033[2J\033[H`)
- Explicitly position cursor at line 2 after header is drawn

The scroll region now properly protects line 1, keeping the header visible regardless of how much log output is displayed.

## Test plan

- [x] `bun run check` passes (typecheck, lint, tests)
- [ ] Open unified logs with `dust-hive logs <env> -i` or `dust-hive reload <env> -u`
- [ ] Generate lots of log output and verify header stays pinned at top
- [ ] Switch services with n/p keys and verify header remains sticky