### PR TITLE
feat(dust-hive): add multiplexer abstraction layer

### DIFF
--- a/x/henry/dust-hive/src/commands/doctor.ts
+++ b/x/henry/dust-hive/src/commands/doctor.ts
@@ -1,6 +1,7 @@
 import { configEnvExists } from "../lib/config";
 import { createConfigEnvTemplate } from "../lib/installer";
 import { logger } from "../lib/logger";
+import { getConfiguredMultiplexer } from "../lib/multiplexer";
 import { CONFIG_ENV_PATH, findRepoRoot } from "../lib/paths";
 import { getInstallInstructions } from "../lib/platform";
 import { confirm } from "../lib/prompt";
@@ -10,8 +11,8 @@ interface CheckResult {
   name: string;
   ok: boolean;
   message: string;
-  fix?: string;
-  optional?: boolean; // If true, failing this check doesn't fail the overall doctor
+  fix?: string | undefined;
+  optional?: boolean | undefined; // If true, failing this check doesn't fail the overall doctor
 }
 
 export interface SetupOptions {
@@ -68,13 +69,16 @@ async function checkLsof(): Promise<CheckResult> {
   };
 }
 
-async function checkZellij(): Promise<CheckResult> {
-  const version = await getCommandVersion("zellij");
+async function checkMultiplexer(): Promise<CheckResult> {
+  const multiplexer = await getConfiguredMultiplexer();
+  const result = await multiplexer.checkInstalled();
+  const name = multiplexer.type.charAt(0).toUpperCase() + multiplexer.type.slice(1); // Capitalize
+
   return {
-    name: "Zellij",
-    ok: version !== null,
-    message: version ?? "Not found",
-    fix: getInstallInstructions("zellij"),
+    name,
+    ok: result.ok,
+    message: result.ok ? (result.version ?? "Unknown version") : (result.error ?? "Not found"),
+    fix: result.ok ? undefined : multiplexer.getInstallInstructions(),
   };
 }
 
@@ -294,7 +298,7 @@ async function runAllChecks(): Promise<CheckResult[]> {
   return [
     await checkBun(),
     await checkLsof(),
-    await checkZellij(),
+    await checkMultiplexer(),
     await checkDocker(),
     await checkDockerCompose(),
     await checkTemporalCli(),

--- a/x/henry/dust-hive/src/commands/open.ts
+++ b/x/henry/dust-hive/src/commands/open.ts
@@ -1,147 +1,14 @@
-import { mkdir } from "node:fs/promises";
-import { join } from "node:path";
 import { withEnvironment } from "../lib/commands";
 import { logger } from "../lib/logger";
 import {
-  DUST_HIVE_ZELLIJ,
+  type LayoutConfig,
   MAIN_SESSION_NAME,
-  getEnvFilePath,
-  getWorktreeDir,
-  getZellijLayoutPath,
-} from "../lib/paths";
-import { restoreTerminal } from "../lib/prompt";
+  type MainLayoutConfig,
+  getConfiguredMultiplexer,
+  getSessionName,
+} from "../lib/multiplexer";
+import { getEnvFilePath, getWorktreeDir } from "../lib/paths";
 import { Ok } from "../lib/result";
-import { ALL_SERVICES, type ServiceName } from "../lib/services";
-import { shellQuote } from "../lib/shell";
-
-function kdlEscape(value: string): string {
-  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
-}
-
-function getUserShell(): string {
-  return process.env["SHELL"] ?? "/bin/bash";
-}
-
-// Shared tab template for all zellij layouts (ensures consistent tab bar)
-const TAB_TEMPLATE = `    default_tab_template {
-        pane size=1 borderless=true {
-            plugin location="zellij:compact-bar"
-        }
-        children
-    }`;
-
-// Compact tab template: bar at bottom with session name, mode, and tabs
-const TAB_TEMPLATE_COMPACT = `    default_tab_template {
-        children
-        pane size=1 borderless=true {
-            plugin location="zellij:compact-bar"
-        }
-    }`;
-
-// Tab display names (shorter names for better zellij tab bar)
-const TAB_NAMES: Record<ServiceName, string> = {
-  sdk: "sdk",
-  front: "front",
-  core: "core",
-  oauth: "oauth",
-  connectors: "connectors",
-  "front-workers": "workers",
-};
-
-interface LayoutOptions {
-  warmCommand?: string | undefined;
-  initialCommand?: string | undefined;
-  compact?: boolean | undefined;
-  unifiedLogs?: boolean | undefined;
-}
-
-// Generate a single service tab using dust-hive logs command
-function generateServiceTab(envName: string, service: ServiceName): string {
-  const tabName = TAB_NAMES[service];
-  return `    tab name="${tabName}" {
-        pane {
-            command "dust-hive"
-            args "logs" "${kdlEscape(envName)}" "${kdlEscape(service)}" "-f"
-            start_suspended true
-        }
-    }`;
-}
-
-// Generate zellij layout for an environment
-function generateLayout(
-  envName: string,
-  worktreePath: string,
-  envShPath: string,
-  options: LayoutOptions = {}
-): string {
-  const { warmCommand, initialCommand, compact, unifiedLogs } = options;
-  const shellPath = getUserShell();
-  // If initialCommand is provided, run it first then drop to shell on exit
-  const shellCommand = initialCommand
-    ? `source ${shellQuote(envShPath)} && ${initialCommand}; exec ${shellQuote(shellPath)}`
-    : `source ${shellQuote(envShPath)} && exec ${shellQuote(shellPath)}`;
-  const warmTab = warmCommand
-    ? `    tab name="warm" {
-        pane {
-            cwd "${kdlEscape(worktreePath)}"
-            command "bash"
-            args "-c" "${kdlEscape(warmCommand)}"
-            start_suspended false
-        }
-    }`
-    : "";
-
-  // Generate logs tabs based on mode
-  let logsTabs: string;
-  if (unifiedLogs) {
-    // Single unified logs tab using dust-hive logs -i
-    logsTabs = `    tab name="logs" {
-        pane {
-            command "dust-hive"
-            args "logs" "${kdlEscape(envName)}" "-i"
-            start_suspended true
-        }
-    }`;
-  } else {
-    // Individual service tabs (default)
-    logsTabs = ALL_SERVICES.map((service) => generateServiceTab(envName, service)).join("\n\n");
-  }
-
-  // When compact mode is enabled, use bottom bar; otherwise use top bar
-  const tabTemplate = compact ? TAB_TEMPLATE_COMPACT : TAB_TEMPLATE;
-
-  return `layout {
-${tabTemplate}
-
-    tab name="${kdlEscape(envName)}" focus=true {
-        pane {
-            cwd "${kdlEscape(worktreePath)}"
-            command "bash"
-            args "-c" "${kdlEscape(shellCommand)}"
-            start_suspended false
-        }
-    }
-
-${warmTab ? `${warmTab}\n\n` : ""}${logsTabs}
-}
-`;
-}
-
-// Write layout and return path
-async function writeLayout(
-  envName: string,
-  worktreePath: string,
-  envShPath: string,
-  options: LayoutOptions = {}
-): Promise<string> {
-  await mkdir(DUST_HIVE_ZELLIJ, { recursive: true });
-
-  const layoutPath = getZellijLayoutPath();
-  const content = generateLayout(envName, worktreePath, envShPath, options);
-  await Bun.write(layoutPath, content);
-
-  return layoutPath;
-}
 
 interface OpenOptions {
   warmCommand?: string | undefined;
@@ -151,62 +18,18 @@ interface OpenOptions {
   unifiedLogs?: boolean | undefined;
 }
 
-// Check if a zellij session exists
-async function checkSessionExists(sessionName: string): Promise<boolean> {
-  const checkProc = Bun.spawn(["zellij", "list-sessions"], {
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const sessions = await new Response(checkProc.stdout).text();
-  await checkProc.exited;
-
-  // Strip ANSI codes for comparison
-  // biome-ignore lint/suspicious/noControlCharactersInRegex: intentional for ANSI escape code stripping
-  const stripAnsi = (str: string) => str.replace(/\x1b\[[0-9;]*m/g, "");
-  return sessions
-    .split("\n")
-    .map((line) => stripAnsi(line).trim())
-    .filter((line) => line.length > 0)
-    .map((line) => line.split(/\s+/)[0])
-    .some((name) => name === sessionName);
-}
-
-// Create a zellij session in background (does not attach)
-async function createSessionInBackground(sessionName: string, layoutPath: string): Promise<void> {
-  logger.info(`Creating zellij session '${sessionName}' in background...`);
-
-  const proc = Bun.spawn(
-    [
-      "zellij",
-      "attach",
-      sessionName,
-      "--create-background",
-      "options",
-      "--default-layout",
-      layoutPath,
-    ],
-    {
-      stdin: "ignore",
-      stdout: "ignore",
-      stderr: "pipe",
-    }
-  );
-  await proc.exited;
-
-  logger.success(`Session '${sessionName}' created successfully.`);
-}
-
 export const openCommand = withEnvironment("open", async (env, options: OpenOptions = {}) => {
+  const multiplexer = await getConfiguredMultiplexer();
   const worktreePath = getWorktreeDir(env.name);
   const envShPath = getEnvFilePath(env.name);
-  const sessionName = `dust-hive-${env.name}`;
+  const sessionName = getSessionName(env.name);
 
-  // Detect if running inside zellij to avoid nesting
-  const inZellij = process.env["ZELLIJ"] !== undefined;
-  const currentSession = process.env["ZELLIJ_SESSION_NAME"];
+  // Detect if running inside the multiplexer to avoid nesting
+  const inMultiplexer = multiplexer.isInsideMultiplexer();
+  const currentSession = multiplexer.getCurrentSessionName();
 
-  // If inside zellij and trying to attach, use session manager instead
-  if (inZellij && !options.noAttach) {
+  // If inside multiplexer and trying to attach, use session switching instead
+  if (inMultiplexer && !options.noAttach) {
     // If already in the target session, nothing to do
     if (currentSession === sessionName) {
       logger.info(`Already in session '${sessionName}'`);
@@ -214,37 +37,30 @@ export const openCommand = withEnvironment("open", async (env, options: OpenOpti
     }
 
     // Ensure session exists (create in background if needed)
-    const sessionExists = await checkSessionExists(sessionName);
+    const sessionExists = await multiplexer.sessionExists(sessionName);
     if (!sessionExists) {
-      const layoutPath = await writeLayout(env.name, worktreePath, envShPath, {
+      const layoutConfig: LayoutConfig = {
+        envName: env.name,
+        worktreePath,
+        envShPath,
         warmCommand: options.warmCommand,
         initialCommand: options.initialCommand,
         compact: options.compact,
         unifiedLogs: options.unifiedLogs,
-      });
-      await createSessionInBackground(sessionName, layoutPath);
+      };
+      const layoutContent = multiplexer.generateLayout(layoutConfig);
+      const layoutPath = multiplexer.getLayoutPath("layout.kdl");
+      await multiplexer.writeLayout(layoutContent, layoutPath);
+      await multiplexer.createSessionInBackground(sessionName, layoutPath);
     }
 
-    // Switch to target session using zellij-switch plugin
-    logger.info(`Switching to session '${sessionName}'...`);
-    const switchProc = Bun.spawn(
-      [
-        "zellij",
-        "pipe",
-        "--plugin",
-        "https://github.com/mostafaqanbaryan/zellij-switch/releases/download/0.2.1/zellij-switch.wasm",
-        "--",
-        `--session ${sessionName}`,
-      ],
-      { stdin: "ignore", stdout: "ignore", stderr: "ignore" }
-    );
-    await switchProc.exited;
-
+    // Switch to target session
+    await multiplexer.switchToSession(sessionName);
     return Ok(undefined);
   }
 
   // Check if session already exists
-  const sessionExists = await checkSessionExists(sessionName);
+  const sessionExists = await multiplexer.sessionExists(sessionName);
 
   if (sessionExists) {
     if (options.noAttach) {
@@ -254,87 +70,33 @@ export const openCommand = withEnvironment("open", async (env, options: OpenOpti
     }
 
     // Attach to existing session
-    logger.info(`Attaching to existing session '${sessionName}'...`);
-
-    // Ensure terminal is fully restored before spawning zellij
-    restoreTerminal();
-
-    const proc = Bun.spawn(["zellij", "attach", sessionName], {
-      stdin: "inherit",
-      stdout: "inherit",
-      stderr: "inherit",
-    });
-
-    await proc.exited;
+    await multiplexer.attachSession(sessionName);
   } else {
     // Create new session with layout
-    const layoutPath = await writeLayout(env.name, worktreePath, envShPath, {
+    const layoutConfig: LayoutConfig = {
+      envName: env.name,
+      worktreePath,
+      envShPath,
       warmCommand: options.warmCommand,
       initialCommand: options.initialCommand,
       compact: options.compact,
       unifiedLogs: options.unifiedLogs,
-    });
+    };
+    const layoutContent = multiplexer.generateLayout(layoutConfig);
+    const layoutPath = multiplexer.getLayoutPath("layout.kdl");
+    await multiplexer.writeLayout(layoutContent, layoutPath);
 
     if (options.noAttach) {
-      await createSessionInBackground(sessionName, layoutPath);
+      await multiplexer.createSessionInBackground(sessionName, layoutPath);
       logger.info(`Use 'dust-hive open ${env.name}' to attach.`);
       return Ok(undefined);
     }
 
-    logger.info(`Creating new zellij session '${sessionName}'...`);
-
-    // Ensure terminal is fully restored before spawning zellij
-    restoreTerminal();
-
-    const proc = Bun.spawn(
-      ["zellij", "--session", sessionName, "--new-session-with-layout", layoutPath],
-      {
-        stdin: "inherit",
-        stdout: "inherit",
-        stderr: "inherit",
-      }
-    );
-
-    await proc.exited;
+    await multiplexer.createAndAttachSession(sessionName, layoutPath);
   }
 
   return Ok(undefined);
 });
-
-// Generate layout for main session (repo root + temporal logs)
-function generateMainLayout(repoRoot: string, compact?: boolean): string {
-  const shellPath = getUserShell();
-  const tabTemplate = compact ? TAB_TEMPLATE_COMPACT : TAB_TEMPLATE;
-
-  return `layout {
-${tabTemplate}
-
-    tab name="main" focus=true {
-        pane {
-            cwd "${kdlEscape(repoRoot)}"
-            command "${kdlEscape(shellPath)}"
-            start_suspended false
-        }
-    }
-
-    tab name="temporal" {
-        pane {
-            command "dust-hive"
-            args "temporal" "logs"
-            start_suspended true
-        }
-    }
-}
-`;
-}
-
-async function writeMainLayout(repoRoot: string, compact?: boolean): Promise<string> {
-  await mkdir(DUST_HIVE_ZELLIJ, { recursive: true });
-  const layoutPath = join(DUST_HIVE_ZELLIJ, "main-layout.kdl");
-  const content = generateMainLayout(repoRoot, compact);
-  await Bun.write(layoutPath, content);
-  return layoutPath;
-}
 
 interface MainSessionOptions {
   attach?: boolean;
@@ -346,39 +108,31 @@ export async function openMainSession(
   repoRoot: string,
   options: MainSessionOptions = {}
 ): Promise<void> {
+  const multiplexer = await getConfiguredMultiplexer();
   const sessionName = MAIN_SESSION_NAME;
 
-  const inZellij = process.env["ZELLIJ"] !== undefined;
-  const currentSession = process.env["ZELLIJ_SESSION_NAME"];
+  const inMultiplexer = multiplexer.isInsideMultiplexer();
+  const currentSession = multiplexer.getCurrentSessionName();
 
   // Check if session exists
-  const sessionExists = await checkSessionExists(sessionName);
+  const sessionExists = await multiplexer.sessionExists(sessionName);
 
-  if (inZellij && options.attach) {
+  if (inMultiplexer && options.attach) {
     if (currentSession === sessionName) {
       logger.info(`Already in session '${sessionName}'`);
       return;
     }
 
     if (!sessionExists) {
-      const layoutPath = await writeMainLayout(repoRoot, options.compact);
-      await createSessionInBackground(sessionName, layoutPath);
+      const layoutConfig: MainLayoutConfig = { repoRoot, compact: options.compact };
+      const layoutContent = multiplexer.generateMainLayout(layoutConfig);
+      const layoutPath = multiplexer.getLayoutPath("main-layout.kdl");
+      await multiplexer.writeLayout(layoutContent, layoutPath);
+      await multiplexer.createSessionInBackground(sessionName, layoutPath);
     }
 
-    // Switch to session using zellij-switch plugin
-    logger.info(`Switching to session '${sessionName}'...`);
-    const switchProc = Bun.spawn(
-      [
-        "zellij",
-        "pipe",
-        "--plugin",
-        "https://github.com/mostafaqanbaryan/zellij-switch/releases/download/0.2.1/zellij-switch.wasm",
-        "--",
-        `--session ${sessionName}`,
-      ],
-      { stdin: "ignore", stdout: "ignore", stderr: "ignore" }
-    );
-    await switchProc.exited;
+    // Switch to session
+    await multiplexer.switchToSession(sessionName);
     return;
   }
 
@@ -388,33 +142,19 @@ export async function openMainSession(
       return;
     }
 
-    logger.info(`Attaching to main session '${sessionName}'...`);
-    restoreTerminal();
-    const proc = Bun.spawn(["zellij", "attach", sessionName], {
-      stdin: "inherit",
-      stdout: "inherit",
-      stderr: "inherit",
-    });
-    await proc.exited;
+    await multiplexer.attachSession(sessionName);
   } else {
-    const layoutPath = await writeMainLayout(repoRoot, options.compact);
+    const layoutConfig: MainLayoutConfig = { repoRoot, compact: options.compact };
+    const layoutContent = multiplexer.generateMainLayout(layoutConfig);
+    const layoutPath = multiplexer.getLayoutPath("main-layout.kdl");
+    await multiplexer.writeLayout(layoutContent, layoutPath);
 
     if (!options.attach) {
-      await createSessionInBackground(sessionName, layoutPath);
+      await multiplexer.createSessionInBackground(sessionName, layoutPath);
       logger.info(`Main session '${sessionName}' created.`);
       return;
     }
 
-    logger.info(`Creating main session '${sessionName}'...`);
-    restoreTerminal();
-    const proc = Bun.spawn(
-      ["zellij", "--session", sessionName, "--new-session-with-layout", layoutPath],
-      {
-        stdin: "inherit",
-        stdout: "inherit",
-        stderr: "inherit",
-      }
-    );
-    await proc.exited;
+    await multiplexer.createAndAttachSession(sessionName, layoutPath);
   }
 }

--- a/x/henry/dust-hive/src/commands/spawn.ts
+++ b/x/henry/dust-hive/src/commands/spawn.ts
@@ -288,7 +288,7 @@ export async function spawnCommand(options: SpawnOptions): Promise<Result<void>>
   // Wait for SDK build if:
   // - --no-open is passed (forced, no UI to show progress)
   // - --wait is explicitly passed
-  // Otherwise, let the watch process run and show progress in zellij
+  // Otherwise, let the watch process run and show progress in terminal session
   const shouldWaitForSdk = options.noOpen || options.wait;
   const sdkResult = await startSdk(env, worktreePath, Boolean(shouldWaitForSdk), settings);
   if (!sdkResult.ok) return sdkResult;
@@ -301,10 +301,10 @@ export async function spawnCommand(options: SpawnOptions): Promise<Result<void>>
   console.log();
   console.log("Next steps:");
   console.log(`  dust-hive warm ${name}    # Start all services`);
-  console.log(`  dust-hive open ${name}    # Open zellij session`);
+  console.log(`  dust-hive open ${name}    # Open terminal session`);
   console.log();
 
-  // Open zellij unless --no-open
+  // Open terminal session unless --no-open
   if (!options.noOpen) {
     return openCommand(name, buildOpenOptions(name, options));
   }

--- a/x/henry/dust-hive/src/commands/start.ts
+++ b/x/henry/dust-hive/src/commands/start.ts
@@ -32,7 +32,7 @@ export const startCommand = withEnvironment("start", async (env) => {
   console.log();
   console.log("Next steps:");
   console.log(`  dust-hive warm ${env.name}    # Start all services`);
-  console.log(`  dust-hive open ${env.name}    # Open zellij session`);
+  console.log(`  dust-hive open ${env.name}    # Open terminal session`);
   console.log();
 
   return Ok(undefined);

--- a/x/henry/dust-hive/src/commands/warm.ts
+++ b/x/henry/dust-hive/src/commands/warm.ts
@@ -240,7 +240,7 @@ export const warmCommand = withEnvironment("warm", async (env, options: WarmOpti
   }
   console.log();
   console.log("Next steps:");
-  console.log(`  dust-hive open ${env.name}      # Open zellij session`);
+  console.log(`  dust-hive open ${env.name}      # Open terminal session`);
   console.log(`  dust-hive status ${env.name}    # Check service health`);
   console.log(`  dust-hive cool ${env.name}      # Stop services, keep SDK`);
   console.log();

--- a/x/henry/dust-hive/src/index.ts
+++ b/x/henry/dust-hive/src/index.ts
@@ -48,15 +48,15 @@ cli
   .alias("s")
   .option("-n, --name <name>", "Environment name")
   .option("-b, --branch-name <branch>", "Git branch name (default: [prefix]<name>)")
-  .option("-O, --no-open", "Do not open zellij session after spawn")
-  .option("-A, --no-attach", "Create zellij session but don't attach to it")
-  .option("-w, --warm", "Open zellij with a warm tab running dust-hive warm")
+  .option("-O, --no-open", "Do not open terminal session after spawn")
+  .option("-A, --no-attach", "Create terminal session but don't attach to it")
+  .option("-w, --warm", "Open with a warm tab running dust-hive warm")
   .option(
     "-W, --wait",
-    "Wait for SDK to build before opening zellij (cannot be used with --no-open)"
+    "Wait for SDK to build before opening session (cannot be used with --no-open)"
   )
   .option("-c, --command <cmd>", "Run command in shell tab after opening (drops to shell on exit)")
-  .option("-C, --compact", "Use compact zellij layout (no tab bar)")
+  .option("-C, --compact", "Use compact layout (no tab bar)")
   .option("-u, --unified-logs", "Use single unified logs tab instead of per-service tabs")
   .action(
     async (
@@ -123,9 +123,9 @@ cli
   );
 
 cli
-  .command("open [name]", "Open environment's zellij session")
+  .command("open [name]", "Open environment's terminal session")
   .alias("o")
-  .option("-C, --compact", "Use compact zellij layout (no tab bar)")
+  .option("-C, --compact", "Use compact layout (no tab bar)")
   .option("-u, --unified-logs", "Use single unified logs tab instead of per-service tabs")
   .action(
     async (name: string | undefined, options: { compact?: boolean; unifiedLogs?: boolean }) => {
@@ -136,7 +136,7 @@ cli
   );
 
 cli
-  .command("reload [name]", "Kill and reopen zellij session")
+  .command("reload [name]", "Kill and reopen terminal session")
   .option("-u, --unified-logs", "Use single unified logs tab instead of per-service tabs")
   .action(async (name: string | undefined, options: { unifiedLogs?: boolean }) => {
     await prepareAndRun(reloadCommand(name, { unifiedLogs: options.unifiedLogs }));
@@ -186,9 +186,9 @@ cli
 
 cli
   .command("up", "Start managed services (temporal + test postgres + test redis + main session)")
-  .option("-a, --attach", "Attach to main zellij session")
+  .option("-a, --attach", "Attach to main terminal session")
   .option("-f, --force", "Force rebuild even if no changes detected")
-  .option("-C, --compact", "Use compact zellij layout (bar at bottom)")
+  .option("-C, --compact", "Use compact layout (bar at bottom)")
   .action(async (options: { attach?: boolean; force?: boolean; compact?: boolean }) => {
     await prepareAndRun(
       upCommand({

--- a/x/henry/dust-hive/src/lib/config.ts
+++ b/x/henry/dust-hive/src/lib/config.ts
@@ -1,17 +1,11 @@
 import { mkdir } from "node:fs/promises";
-import {
-  CONFIG_ENV_PATH,
-  DUST_HIVE_ENVS,
-  DUST_HIVE_HOME,
-  DUST_HIVE_WORKTREES,
-  DUST_HIVE_ZELLIJ,
-} from "./paths";
+import { CONFIG_ENV_PATH, DUST_HIVE_ENVS, DUST_HIVE_HOME, DUST_HIVE_WORKTREES } from "./paths";
 
 // Ensure all required directories exist
+// Note: Multiplexer layout directories are created by the multiplexer adapter when needed
 export async function ensureDirectories(): Promise<void> {
   await mkdir(DUST_HIVE_HOME, { recursive: true });
   await mkdir(DUST_HIVE_ENVS, { recursive: true });
-  await mkdir(DUST_HIVE_ZELLIJ, { recursive: true });
   await mkdir(DUST_HIVE_WORKTREES, { recursive: true });
 }
 

--- a/x/henry/dust-hive/src/lib/multiplexer/index.ts
+++ b/x/henry/dust-hive/src/lib/multiplexer/index.ts
@@ -1,0 +1,107 @@
+/**
+ * Multiplexer abstraction module
+ *
+ * This module provides a unified interface for terminal multiplexers (zellij, tmux).
+ * Currently only zellij is implemented; tmux support can be added later.
+ */
+
+import { loadSettings } from "../settings";
+import type { MultiplexerAdapter, MultiplexerType } from "./types";
+import { ZellijAdapter } from "./zellij";
+
+// Re-export types for convenience
+export type { MultiplexerAdapter, MultiplexerType, LayoutConfig, MainLayoutConfig } from "./types";
+export { getSessionName, MAIN_SESSION_NAME, SESSION_PREFIX, TAB_NAMES } from "./types";
+
+/**
+ * Registry of available multiplexer adapters
+ */
+const adapters: Record<MultiplexerType, () => MultiplexerAdapter> = {
+  zellij: () => new ZellijAdapter(),
+  // tmux: () => new TmuxAdapter(), // Future implementation
+  tmux: () => {
+    throw new Error(
+      "tmux adapter not yet implemented. Please use zellij or contribute a tmux implementation."
+    );
+  },
+};
+
+/**
+ * Default multiplexer type (for backward compatibility)
+ */
+const DEFAULT_MULTIPLEXER: MultiplexerType = "zellij";
+
+/**
+ * Cached adapter instance (lazily initialized)
+ */
+let cachedAdapter: MultiplexerAdapter | null = null;
+let cachedAdapterType: MultiplexerType | null = null;
+
+/**
+ * Get a multiplexer adapter for the specified type.
+ * Use this when you need a specific multiplexer regardless of settings.
+ */
+export function getMultiplexerAdapter(type: MultiplexerType): MultiplexerAdapter {
+  const factory = adapters[type];
+  if (!factory) {
+    throw new Error(
+      `Unknown multiplexer type: ${type}. Available types: ${Object.keys(adapters).join(", ")}`
+    );
+  }
+  return factory();
+}
+
+/**
+ * Get the configured multiplexer adapter.
+ * Reads from settings.json, defaults to zellij for backward compatibility.
+ * The adapter is cached for the lifetime of the process.
+ */
+export async function getConfiguredMultiplexer(): Promise<MultiplexerAdapter> {
+  const settings = await loadSettings();
+  const type = settings.multiplexer ?? DEFAULT_MULTIPLEXER;
+
+  // Return cached adapter if it matches the configured type
+  if (cachedAdapter && cachedAdapterType === type) {
+    return cachedAdapter;
+  }
+
+  // Create and cache new adapter
+  cachedAdapter = getMultiplexerAdapter(type);
+  cachedAdapterType = type;
+  return cachedAdapter;
+}
+
+/**
+ * Get the configured multiplexer adapter synchronously.
+ * Uses cached adapter if available, otherwise returns default (zellij).
+ * Prefer getConfiguredMultiplexer() when possible.
+ */
+export function getMultiplexerSync(): MultiplexerAdapter {
+  if (cachedAdapter) {
+    return cachedAdapter;
+  }
+  // Fall back to default - this will be updated on first async call
+  return getMultiplexerAdapter(DEFAULT_MULTIPLEXER);
+}
+
+/**
+ * Clear the cached adapter (useful for testing)
+ */
+export function clearMultiplexerCache(): void {
+  cachedAdapter = null;
+  cachedAdapterType = null;
+}
+
+/**
+ * Check if a multiplexer type is supported
+ */
+export function isMultiplexerSupported(type: string): type is MultiplexerType {
+  return type in adapters;
+}
+
+/**
+ * Get list of supported multiplexer types
+ */
+export function getSupportedMultiplexers(): MultiplexerType[] {
+  return Object.keys(adapters) as MultiplexerType[];
+}

--- a/x/henry/dust-hive/src/lib/multiplexer/types.ts
+++ b/x/henry/dust-hive/src/lib/multiplexer/types.ts
@@ -1,0 +1,229 @@
+import type { ServiceName } from "../services";
+
+/**
+ * Multiplexer type - which terminal multiplexer to use
+ */
+export type MultiplexerType = "zellij" | "tmux";
+
+/**
+ * Configuration for a single tab/window in a multiplexer session
+ */
+export interface TabConfig {
+  /** Display name for the tab */
+  name: string;
+  /** Working directory for the tab */
+  cwd?: string;
+  /** Command to run in the tab */
+  command: string;
+  /** Arguments for the command */
+  args?: string[];
+  /** If true, don't start the command until the tab is focused (lazy loading) */
+  startSuspended?: boolean;
+  /** If true, this tab should have initial focus */
+  focus?: boolean;
+}
+
+/**
+ * Configuration for generating a session layout
+ */
+export interface LayoutConfig {
+  /** Environment name (used for session naming) */
+  envName: string;
+  /** Path to the git worktree */
+  worktreePath: string;
+  /** Path to the env.sh file to source */
+  envShPath: string;
+  /** Use compact layout (status bar at bottom instead of top) */
+  compact?: boolean | undefined;
+  /** Use unified logs tab instead of per-service tabs */
+  unifiedLogs?: boolean | undefined;
+  /** Optional command to run on warm (creates a dedicated "warm" tab) */
+  warmCommand?: string | undefined;
+  /** Optional initial command to run in the main shell before dropping to interactive shell */
+  initialCommand?: string | undefined;
+}
+
+/**
+ * Configuration for the main session layout (for managed services)
+ */
+export interface MainLayoutConfig {
+  /** Path to the main repository root */
+  repoRoot: string;
+  /** Use compact layout */
+  compact?: boolean | undefined;
+}
+
+/**
+ * Options for opening/attaching to a session
+ */
+export interface OpenSessionOptions {
+  /** Don't attach to the session after creating it */
+  noAttach?: boolean;
+}
+
+/**
+ * Result of checking if the multiplexer is installed
+ */
+export interface InstallCheckResult {
+  /** Whether the multiplexer is installed and working */
+  ok: boolean;
+  /** Version string if installed */
+  version?: string;
+  /** Error message if not ok */
+  error?: string;
+}
+
+/**
+ * Abstract interface for terminal multiplexer operations.
+ * Implementations exist for zellij and tmux.
+ */
+export interface MultiplexerAdapter {
+  /** The type of multiplexer this adapter handles */
+  readonly type: MultiplexerType;
+
+  // ============================================================
+  // Session Lifecycle
+  // ============================================================
+
+  /**
+   * List all dust-hive sessions (sessions with "dust-hive-" prefix)
+   */
+  listSessions(): Promise<string[]>;
+
+  /**
+   * Check if a session with the given name exists
+   */
+  sessionExists(sessionName: string): Promise<boolean>;
+
+  /**
+   * Create a new session in the background (does not attach)
+   * @param sessionName - Name for the session
+   * @param layoutPath - Path to the layout file
+   */
+  createSessionInBackground(sessionName: string, layoutPath: string): Promise<void>;
+
+  /**
+   * Create a new session and attach to it
+   * @param sessionName - Name for the session
+   * @param layoutPath - Path to the layout file
+   */
+  createAndAttachSession(sessionName: string, layoutPath: string): Promise<void>;
+
+  /**
+   * Attach to an existing session
+   * @param sessionName - Name of the session to attach to
+   */
+  attachSession(sessionName: string): Promise<void>;
+
+  /**
+   * Kill a session (stop it)
+   * @param sessionName - Name of the session to kill
+   */
+  killSession(sessionName: string): Promise<void>;
+
+  /**
+   * Delete a session (remove from session list)
+   * @param sessionName - Name of the session to delete
+   */
+  deleteSession(sessionName: string): Promise<void>;
+
+  // ============================================================
+  // Nested Session Handling
+  // ============================================================
+
+  /**
+   * Check if we're currently running inside this multiplexer
+   */
+  isInsideMultiplexer(): boolean;
+
+  /**
+   * Get the name of the current session (if inside the multiplexer)
+   */
+  getCurrentSessionName(): string | null;
+
+  /**
+   * Switch to a different session from within the multiplexer.
+   * This avoids nesting multiplexer sessions.
+   * @param sessionName - Name of the session to switch to
+   */
+  switchToSession(sessionName: string): Promise<void>;
+
+  // ============================================================
+  // Layout Generation
+  // ============================================================
+
+  /**
+   * Generate a layout file for an environment session
+   * @param config - Layout configuration
+   * @returns The generated layout content as a string
+   */
+  generateLayout(config: LayoutConfig): string;
+
+  /**
+   * Generate a layout file for the main session
+   * @param config - Main layout configuration
+   * @returns The generated layout content as a string
+   */
+  generateMainLayout(config: MainLayoutConfig): string;
+
+  /**
+   * Get the path where layouts should be stored for this multiplexer
+   */
+  getLayoutDirectory(): string;
+
+  /**
+   * Get the full path for a layout file
+   * @param filename - Name of the layout file (without directory)
+   */
+  getLayoutPath(filename: string): string;
+
+  /**
+   * Write a layout to disk
+   * @param content - Layout content
+   * @param path - Path to write to
+   */
+  writeLayout(content: string, path: string): Promise<void>;
+
+  // ============================================================
+  // Prerequisites
+  // ============================================================
+
+  /**
+   * Check if the multiplexer is installed
+   */
+  checkInstalled(): Promise<InstallCheckResult>;
+
+  /**
+   * Get installation instructions for this multiplexer
+   */
+  getInstallInstructions(): string;
+}
+
+/**
+ * Standard session name prefix for all dust-hive sessions
+ */
+export const SESSION_PREFIX = "dust-hive-";
+
+/**
+ * Get the session name for an environment
+ */
+export function getSessionName(envName: string): string {
+  return `${SESSION_PREFIX}${envName}`;
+}
+
+/**
+ * Main session name constant
+ */
+export const MAIN_SESSION_NAME = "dust-hive-main";
+
+/**
+ * Tab display names (shorter names for better display in tab bar)
+ */
+export const TAB_NAMES: Record<ServiceName, string> = {
+  sdk: "sdk",
+  front: "front",
+  core: "core",
+  oauth: "oauth",
+  connectors: "connectors",
+  "front-workers": "workers",
+};

--- a/x/henry/dust-hive/src/lib/multiplexer/zellij.ts
+++ b/x/henry/dust-hive/src/lib/multiplexer/zellij.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { logger } from "../logger";
 import { getInstallInstructions as getPlatformInstallInstructions } from "../platform";
 import { restoreTerminal } from "../prompt";
-import { ALL_SERVICES } from "../services";
+import { ALL_SERVICES, type ServiceName } from "../services";
 import { shellQuote } from "../shell";
 import type {
   InstallCheckResult,
@@ -296,8 +296,8 @@ ${tabTemplate}
 `;
   }
 
-  private generateServiceTab(envName: string, service: string): string {
-    const tabName = TAB_NAMES[service as keyof typeof TAB_NAMES] ?? service;
+  private generateServiceTab(envName: string, service: ServiceName): string {
+    const tabName = TAB_NAMES[service];
     return `    tab name="${tabName}" {
         pane {
             command "dust-hive"

--- a/x/henry/dust-hive/src/lib/multiplexer/zellij.ts
+++ b/x/henry/dust-hive/src/lib/multiplexer/zellij.ts
@@ -1,0 +1,355 @@
+import { mkdir } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { logger } from "../logger";
+import { getInstallInstructions as getPlatformInstallInstructions } from "../platform";
+import { restoreTerminal } from "../prompt";
+import { ALL_SERVICES } from "../services";
+import { shellQuote } from "../shell";
+import type {
+  InstallCheckResult,
+  LayoutConfig,
+  MainLayoutConfig,
+  MultiplexerAdapter,
+  MultiplexerType,
+} from "./types";
+import { MAIN_SESSION_NAME, SESSION_PREFIX, TAB_NAMES } from "./types";
+
+/**
+ * Base directory for zellij layouts
+ */
+const ZELLIJ_LAYOUT_DIR = join(homedir(), ".dust-hive", "zellij");
+
+/**
+ * URL for the zellij-switch plugin (used for session switching from within zellij)
+ */
+const ZELLIJ_SWITCH_PLUGIN_URL =
+  "https://github.com/mostafaqanbaryan/zellij-switch/releases/download/0.2.1/zellij-switch.wasm";
+
+/**
+ * Escape a string for use in KDL (Zellij's config format)
+ */
+function kdlEscape(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+/**
+ * Get the user's default shell
+ */
+function getUserShell(): string {
+  return process.env["SHELL"] ?? "/bin/bash";
+}
+
+/**
+ * Strip ANSI escape codes from a string
+ */
+function stripAnsi(str: string): string {
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: intentional for ANSI escape code stripping
+  return str.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+// Shared tab template for all zellij layouts (ensures consistent tab bar)
+const TAB_TEMPLATE = `    default_tab_template {
+        pane size=1 borderless=true {
+            plugin location="zellij:compact-bar"
+        }
+        children
+    }`;
+
+// Compact tab template: bar at bottom with session name, mode, and tabs
+const TAB_TEMPLATE_COMPACT = `    default_tab_template {
+        children
+        pane size=1 borderless=true {
+            plugin location="zellij:compact-bar"
+        }
+    }`;
+
+/**
+ * Zellij multiplexer adapter implementation
+ */
+export class ZellijAdapter implements MultiplexerAdapter {
+  readonly type: MultiplexerType = "zellij";
+
+  // ============================================================
+  // Session Lifecycle
+  // ============================================================
+
+  async listSessions(): Promise<string[]> {
+    const proc = Bun.spawn(["zellij", "list-sessions"], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const output = await new Response(proc.stdout).text();
+    await proc.exited;
+
+    if (proc.exitCode !== 0) {
+      return [];
+    }
+
+    return output
+      .split("\n")
+      .map((line) => stripAnsi(line).trim())
+      .filter((line) => line.length > 0)
+      .map((line) => line.split(/\s+/)[0])
+      .filter((name): name is string => name?.startsWith(SESSION_PREFIX) ?? false);
+  }
+
+  async sessionExists(sessionName: string): Promise<boolean> {
+    const proc = Bun.spawn(["zellij", "list-sessions"], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const sessions = await new Response(proc.stdout).text();
+    await proc.exited;
+
+    return sessions
+      .split("\n")
+      .map((line) => stripAnsi(line).trim())
+      .filter((line) => line.length > 0)
+      .map((line) => line.split(/\s+/)[0])
+      .some((name) => name === sessionName);
+  }
+
+  async createSessionInBackground(sessionName: string, layoutPath: string): Promise<void> {
+    logger.info(`Creating zellij session '${sessionName}' in background...`);
+
+    const proc = Bun.spawn(
+      [
+        "zellij",
+        "attach",
+        sessionName,
+        "--create-background",
+        "options",
+        "--default-layout",
+        layoutPath,
+      ],
+      {
+        stdin: "ignore",
+        stdout: "ignore",
+        stderr: "pipe",
+      }
+    );
+    await proc.exited;
+
+    logger.success(`Session '${sessionName}' created successfully.`);
+  }
+
+  async createAndAttachSession(sessionName: string, layoutPath: string): Promise<void> {
+    logger.info(`Creating new zellij session '${sessionName}'...`);
+
+    // Ensure terminal is fully restored before spawning zellij
+    restoreTerminal();
+
+    const proc = Bun.spawn(
+      ["zellij", "--session", sessionName, "--new-session-with-layout", layoutPath],
+      {
+        stdin: "inherit",
+        stdout: "inherit",
+        stderr: "inherit",
+      }
+    );
+
+    await proc.exited;
+  }
+
+  async attachSession(sessionName: string): Promise<void> {
+    logger.info(`Attaching to existing session '${sessionName}'...`);
+
+    // Ensure terminal is fully restored before spawning zellij
+    restoreTerminal();
+
+    const proc = Bun.spawn(["zellij", "attach", sessionName], {
+      stdin: "inherit",
+      stdout: "inherit",
+      stderr: "inherit",
+    });
+
+    await proc.exited;
+  }
+
+  async killSession(sessionName: string): Promise<void> {
+    const proc = Bun.spawn(["zellij", "kill-session", sessionName], {
+      stdout: "ignore",
+      stderr: "ignore",
+    });
+    await proc.exited;
+  }
+
+  async deleteSession(sessionName: string): Promise<void> {
+    const proc = Bun.spawn(["zellij", "delete-session", sessionName, "--force"], {
+      stdout: "ignore",
+      stderr: "ignore",
+    });
+    await proc.exited;
+  }
+
+  // ============================================================
+  // Nested Session Handling
+  // ============================================================
+
+  isInsideMultiplexer(): boolean {
+    return process.env["ZELLIJ"] !== undefined;
+  }
+
+  getCurrentSessionName(): string | null {
+    return process.env["ZELLIJ_SESSION_NAME"] ?? null;
+  }
+
+  async switchToSession(sessionName: string): Promise<void> {
+    logger.info(`Switching to session '${sessionName}'...`);
+
+    const proc = Bun.spawn(
+      ["zellij", "pipe", "--plugin", ZELLIJ_SWITCH_PLUGIN_URL, "--", `--session ${sessionName}`],
+      { stdin: "ignore", stdout: "ignore", stderr: "ignore" }
+    );
+    await proc.exited;
+  }
+
+  // ============================================================
+  // Layout Generation
+  // ============================================================
+
+  generateLayout(config: LayoutConfig): string {
+    const { envName, worktreePath, envShPath, compact, unifiedLogs, warmCommand, initialCommand } =
+      config;
+    const shellPath = getUserShell();
+
+    // Build the shell command that runs in the main tab
+    const shellCommand = initialCommand
+      ? `source ${shellQuote(envShPath)} && ${initialCommand}; exec ${shellQuote(shellPath)}`
+      : `source ${shellQuote(envShPath)} && exec ${shellQuote(shellPath)}`;
+
+    // Generate warm tab if requested
+    const warmTab = warmCommand
+      ? `    tab name="warm" {
+        pane {
+            cwd "${kdlEscape(worktreePath)}"
+            command "bash"
+            args "-c" "${kdlEscape(warmCommand)}"
+            start_suspended false
+        }
+    }`
+      : "";
+
+    // Generate logs tabs based on mode
+    let logsTabs: string;
+    if (unifiedLogs) {
+      // Single unified logs tab using dust-hive logs -i
+      logsTabs = `    tab name="logs" {
+        pane {
+            command "dust-hive"
+            args "logs" "${kdlEscape(envName)}" "-i"
+            start_suspended true
+        }
+    }`;
+    } else {
+      // Individual service tabs (default)
+      logsTabs = ALL_SERVICES.map((service) => this.generateServiceTab(envName, service)).join(
+        "\n\n"
+      );
+    }
+
+    // When compact mode is enabled, use bottom bar; otherwise use top bar
+    const tabTemplate = compact ? TAB_TEMPLATE_COMPACT : TAB_TEMPLATE;
+
+    return `layout {
+${tabTemplate}
+
+    tab name="${kdlEscape(envName)}" focus=true {
+        pane {
+            cwd "${kdlEscape(worktreePath)}"
+            command "bash"
+            args "-c" "${kdlEscape(shellCommand)}"
+            start_suspended false
+        }
+    }
+
+${warmTab ? `${warmTab}\n\n` : ""}${logsTabs}
+}
+`;
+  }
+
+  generateMainLayout(config: MainLayoutConfig): string {
+    const { repoRoot, compact } = config;
+    const shellPath = getUserShell();
+    const tabTemplate = compact ? TAB_TEMPLATE_COMPACT : TAB_TEMPLATE;
+
+    return `layout {
+${tabTemplate}
+
+    tab name="main" focus=true {
+        pane {
+            cwd "${kdlEscape(repoRoot)}"
+            command "${kdlEscape(shellPath)}"
+            start_suspended false
+        }
+    }
+
+    tab name="temporal" {
+        pane {
+            command "dust-hive"
+            args "temporal" "logs"
+            start_suspended true
+        }
+    }
+}
+`;
+  }
+
+  private generateServiceTab(envName: string, service: string): string {
+    const tabName = TAB_NAMES[service as keyof typeof TAB_NAMES] ?? service;
+    return `    tab name="${tabName}" {
+        pane {
+            command "dust-hive"
+            args "logs" "${kdlEscape(envName)}" "${kdlEscape(service)}" "-f"
+            start_suspended true
+        }
+    }`;
+  }
+
+  getLayoutDirectory(): string {
+    return ZELLIJ_LAYOUT_DIR;
+  }
+
+  getLayoutPath(filename: string): string {
+    return join(ZELLIJ_LAYOUT_DIR, filename);
+  }
+
+  async writeLayout(content: string, path: string): Promise<void> {
+    await mkdir(ZELLIJ_LAYOUT_DIR, { recursive: true });
+    await Bun.write(path, content);
+  }
+
+  // ============================================================
+  // Prerequisites
+  // ============================================================
+
+  async checkInstalled(): Promise<InstallCheckResult> {
+    try {
+      const proc = Bun.spawn(["zellij", "--version"], {
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const output = await new Response(proc.stdout).text();
+      await proc.exited;
+
+      if (proc.exitCode === 0) {
+        const version = output.trim().split("\n")[0] ?? "Unknown";
+        return { ok: true, version };
+      }
+      return { ok: false, error: "zellij command failed" };
+    } catch {
+      return { ok: false, error: "zellij not found" };
+    }
+  }
+
+  getInstallInstructions(): string {
+    return getPlatformInstallInstructions("zellij");
+  }
+}
+
+// Export singleton instance
+export const zellijAdapter = new ZellijAdapter();
+
+// Export the main session name for convenience
+export { MAIN_SESSION_NAME };

--- a/x/henry/dust-hive/src/lib/paths.ts
+++ b/x/henry/dust-hive/src/lib/paths.ts
@@ -9,9 +9,14 @@ export const DUST_HIVE_ROOT = resolve(dirname(import.meta.path), "../..");
 // Base directories
 export const DUST_HIVE_HOME = join(homedir(), ".dust-hive");
 export const DUST_HIVE_ENVS = join(DUST_HIVE_HOME, "envs");
-export const DUST_HIVE_ZELLIJ = join(DUST_HIVE_HOME, "zellij");
 export const DUST_HIVE_SCRIPTS = join(DUST_HIVE_HOME, "scripts");
 export const DUST_HIVE_WORKTREES = join(homedir(), "dust-hive");
+
+/**
+ * @deprecated Use multiplexer adapter's getLayoutDirectory() instead
+ * Kept for backward compatibility during migration
+ */
+export const DUST_HIVE_ZELLIJ = join(DUST_HIVE_HOME, "zellij");
 
 // Global config
 export const CONFIG_ENV_PATH = join(DUST_HIVE_HOME, "config.env");
@@ -41,7 +46,10 @@ export const TEST_POSTGRES_PASSWORD = "test";
 export const TEST_REDIS_CONTAINER_NAME = "dust-hive-test-redis";
 export const TEST_REDIS_PORT = 6479;
 
-// Main zellij session
+/**
+ * @deprecated Import MAIN_SESSION_NAME from "./multiplexer" instead
+ * Kept for backward compatibility during migration
+ */
 export const MAIN_SESSION_NAME = "dust-hive-main";
 
 // Seed user configuration
@@ -88,7 +96,10 @@ export function getLogPath(name: string, service: string): string {
   return join(getEnvDir(name), `${service}.log`);
 }
 
-// Zellij
+/**
+ * @deprecated Use multiplexer adapter's getLayoutPath() instead
+ * Kept for backward compatibility during migration
+ */
 export function getZellijLayoutPath(): string {
   return join(DUST_HIVE_ZELLIJ, "layout.kdl");
 }

--- a/x/henry/dust-hive/src/lib/settings.ts
+++ b/x/henry/dust-hive/src/lib/settings.ts
@@ -1,3 +1,4 @@
+import type { MultiplexerType } from "./multiplexer/types";
 import { SETTINGS_PATH } from "./paths";
 
 export interface Settings {
@@ -5,6 +6,8 @@ export interface Settings {
   branchPrefix?: string;
   // Enable git-spice for branch management (default: false)
   useGitSpice?: boolean;
+  // Terminal multiplexer to use (default: "zellij")
+  multiplexer?: MultiplexerType;
 }
 
 const DEFAULT_SETTINGS: Settings = {};


### PR DESCRIPTION
## Description

Add a multiplexer abstraction layer to dust-hive to enable future tmux support alongside the existing zellij implementation.

**New multiplexer module** (`src/lib/multiplexer/`):
- `types.ts`: Core interfaces (`MultiplexerAdapter`, `LayoutConfig`, `MainLayoutConfig`, etc.)
- `zellij.ts`: Zellij adapter implementation (logic extracted from `open.ts`)
- `index.ts`: Factory function with settings-based adapter selection

**Refactored commands** to use the abstraction:
- `open.ts`, `reload.ts`, `down.ts`, `destroy.ts`, `doctor.ts` now use `getConfiguredMultiplexer()` instead of direct zellij calls

**Configuration**:
- Added `multiplexer` setting to `settings.ts` (`"zellij" | "tmux"`)
- Defaults to `"zellij"` for backward compatibility
- tmux adapter throws "not implemented" error - placeholder for future work

**Updated CLI help text** to be multiplexer-agnostic (e.g., "terminal session" instead of "zellij session").

## Tests

- All 172 existing unit tests pass
- TypeScript strict mode passes with no errors
- Biome linting passes
- Manual testing: verified `dust-hive spawn`, `open`, `reload`, `destroy`, `down`, `doctor` commands work as before

## Risk

**Low risk** - This is a refactoring that maintains existing behavior:
- Zellij remains the default multiplexer
- No changes to runtime behavior for existing users
- All zellij-specific code is now encapsulated in the adapter

Safe to rollback if issues arise.

## Deploy Plan

No deployment needed - dust-hive is a local dev tool. Users will get the changes on next `git pull` and rebuild.