### PR TITLE
feat(dust-hive): add tmux multiplexer adapter

### DIFF
--- a/x/henry/dust-hive/src/lib/multiplexer/index.ts
+++ b/x/henry/dust-hive/src/lib/multiplexer/index.ts
@@ -6,6 +6,7 @@
  */
 
 import { loadSettings } from "../settings";
+import { TmuxAdapter } from "./tmux";
 import type { MultiplexerAdapter, MultiplexerType } from "./types";
 import { ZellijAdapter } from "./zellij";
 
@@ -18,12 +19,7 @@ export { getSessionName, MAIN_SESSION_NAME, SESSION_PREFIX, TAB_NAMES } from "./
  */
 const adapters: Record<MultiplexerType, () => MultiplexerAdapter> = {
   zellij: () => new ZellijAdapter(),
-  // tmux: () => new TmuxAdapter(), // Future implementation
-  tmux: () => {
-    throw new Error(
-      "tmux adapter not yet implemented. Please use zellij or contribute a tmux implementation."
-    );
-  },
+  tmux: () => new TmuxAdapter(),
 };
 
 /**

--- a/x/henry/dust-hive/src/lib/multiplexer/tmux.ts
+++ b/x/henry/dust-hive/src/lib/multiplexer/tmux.ts
@@ -1,0 +1,328 @@
+import { mkdir } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { logger } from "../logger";
+import { getInstallInstructions as getPlatformInstallInstructions } from "../platform";
+import { restoreTerminal } from "../prompt";
+import { ALL_SERVICES } from "../services";
+import { shellQuote } from "../shell";
+import type {
+  InstallCheckResult,
+  LayoutConfig,
+  MainLayoutConfig,
+  MultiplexerAdapter,
+  MultiplexerType,
+} from "./types";
+import { SESSION_PREFIX, TAB_NAMES } from "./types";
+
+/**
+ * Base directory for tmux layout scripts
+ */
+const TMUX_LAYOUT_DIR = join(homedir(), ".dust-hive", "tmux");
+
+/**
+ * Get the user's default shell
+ */
+function getUserShell(): string {
+  return process.env["SHELL"] ?? "/bin/bash";
+}
+
+/**
+ * Tmux multiplexer adapter implementation
+ *
+ * Tmux uses shell scripts for "layouts" since it doesn't have a declarative
+ * layout format like Zellij's KDL. The script creates windows and sends
+ * commands to them.
+ */
+export class TmuxAdapter implements MultiplexerAdapter {
+  readonly type: MultiplexerType = "tmux";
+
+  // ============================================================
+  // Session Lifecycle
+  // ============================================================
+
+  async listSessions(): Promise<string[]> {
+    const proc = Bun.spawn(["tmux", "list-sessions", "-F", "#{session_name}"], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const output = await new Response(proc.stdout).text();
+    await proc.exited;
+
+    if (proc.exitCode !== 0) {
+      return [];
+    }
+
+    return output
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0)
+      .filter((name) => name.startsWith(SESSION_PREFIX));
+  }
+
+  async sessionExists(sessionName: string): Promise<boolean> {
+    const proc = Bun.spawn(["tmux", "has-session", "-t", sessionName], {
+      stdout: "ignore",
+      stderr: "ignore",
+    });
+    await proc.exited;
+    return proc.exitCode === 0;
+  }
+
+  async createSessionInBackground(sessionName: string, layoutPath: string): Promise<void> {
+    logger.info(`Creating tmux session '${sessionName}' in background...`);
+
+    // Run the layout script which creates the session and windows
+    const proc = Bun.spawn(["bash", layoutPath], {
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const stderr = await new Response(proc.stderr).text();
+    await proc.exited;
+
+    if (proc.exitCode !== 0) {
+      throw new Error(`Failed to create tmux session: ${stderr}`);
+    }
+
+    logger.success(`Session '${sessionName}' created successfully.`);
+  }
+
+  async createAndAttachSession(sessionName: string, layoutPath: string): Promise<void> {
+    logger.info(`Creating new tmux session '${sessionName}'...`);
+
+    // First create the session in background
+    await this.createSessionInBackground(sessionName, layoutPath);
+
+    // Ensure terminal is fully restored before attaching
+    restoreTerminal();
+
+    // Then attach to it
+    const proc = Bun.spawn(["tmux", "attach-session", "-t", sessionName], {
+      stdin: "inherit",
+      stdout: "inherit",
+      stderr: "inherit",
+    });
+
+    await proc.exited;
+  }
+
+  async attachSession(sessionName: string): Promise<void> {
+    logger.info(`Attaching to existing session '${sessionName}'...`);
+
+    // Ensure terminal is fully restored before attaching
+    restoreTerminal();
+
+    const proc = Bun.spawn(["tmux", "attach-session", "-t", sessionName], {
+      stdin: "inherit",
+      stdout: "inherit",
+      stderr: "inherit",
+    });
+
+    await proc.exited;
+  }
+
+  async killSession(sessionName: string): Promise<void> {
+    const proc = Bun.spawn(["tmux", "kill-session", "-t", sessionName], {
+      stdout: "ignore",
+      stderr: "ignore",
+    });
+    await proc.exited;
+  }
+
+  async deleteSession(sessionName: string): Promise<void> {
+    // tmux doesn't have a separate delete concept - killing is enough
+    await this.killSession(sessionName);
+  }
+
+  // ============================================================
+  // Nested Session Handling
+  // ============================================================
+
+  isInsideMultiplexer(): boolean {
+    return process.env["TMUX"] !== undefined;
+  }
+
+  getCurrentSessionName(): string | null {
+    // When inside tmux, we need to query for the current session name
+    if (!this.isInsideMultiplexer()) {
+      return null;
+    }
+
+    // Use synchronous approach - spawn and wait
+    const proc = Bun.spawnSync(["tmux", "display-message", "-p", "#{session_name}"], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    if (proc.exitCode === 0) {
+      return proc.stdout.toString().trim() || null;
+    }
+    return null;
+  }
+
+  async switchToSession(sessionName: string): Promise<void> {
+    logger.info(`Switching to session '${sessionName}'...`);
+
+    const proc = Bun.spawn(["tmux", "switch-client", "-t", sessionName], {
+      stdin: "ignore",
+      stdout: "ignore",
+      stderr: "ignore",
+    });
+    await proc.exited;
+  }
+
+  // ============================================================
+  // Layout Generation
+  // ============================================================
+
+  generateLayout(config: LayoutConfig): string {
+    const { envName, worktreePath, envShPath, unifiedLogs, warmCommand, initialCommand } = config;
+    const shellPath = getUserShell();
+    const sessionName = `${SESSION_PREFIX}${envName}`;
+
+    // Build the shell command that runs in the main window
+    const shellCommand = initialCommand
+      ? `source ${shellQuote(envShPath)} && ${initialCommand}; exec ${shellQuote(shellPath)}`
+      : `source ${shellQuote(envShPath)} && exec ${shellQuote(shellPath)}`;
+
+    const lines: string[] = [
+      "#!/bin/bash",
+      "# Auto-generated tmux layout script for dust-hive",
+      "set -e",
+      "",
+      `SESSION_NAME=${shellQuote(sessionName)}`,
+      `WORKTREE_PATH=${shellQuote(worktreePath)}`,
+      "",
+      "# Create the session with the main window",
+      `tmux new-session -d -s "$SESSION_NAME" -n ${shellQuote(envName)} -c "$WORKTREE_PATH"`,
+      "",
+      "# Run the shell command in the main window",
+      `tmux send-keys -t "$SESSION_NAME:0" ${shellQuote(shellCommand)} Enter`,
+      "",
+    ];
+
+    let windowIndex = 1;
+
+    // Generate warm window if requested
+    if (warmCommand) {
+      lines.push(
+        "# Create warm window",
+        `tmux new-window -t "$SESSION_NAME" -n "warm" -c "$WORKTREE_PATH"`,
+        `tmux send-keys -t "$SESSION_NAME:${windowIndex}" ${shellQuote(warmCommand)} Enter`,
+        ""
+      );
+      windowIndex++;
+    }
+
+    // Generate logs windows based on mode
+    if (unifiedLogs) {
+      // Single unified logs window
+      lines.push(
+        "# Create unified logs window",
+        `tmux new-window -t "$SESSION_NAME" -n "logs"`,
+        `tmux send-keys -t "$SESSION_NAME:${windowIndex}" "dust-hive logs ${shellQuote(envName)} -i" Enter`,
+        ""
+      );
+    } else {
+      // Individual service windows
+      for (const service of ALL_SERVICES) {
+        const tabName = TAB_NAMES[service];
+        lines.push(
+          `# Create ${service} logs window`,
+          `tmux new-window -t "$SESSION_NAME" -n ${shellQuote(tabName)}`,
+          `tmux send-keys -t "$SESSION_NAME:${windowIndex}" "dust-hive logs ${shellQuote(envName)} ${shellQuote(service)} -f" Enter`,
+          ""
+        );
+        windowIndex++;
+      }
+    }
+
+    // Select the first window (main)
+    lines.push("# Select the main window", `tmux select-window -t "$SESSION_NAME:0"`, "");
+
+    return lines.join("\n");
+  }
+
+  generateMainLayout(config: MainLayoutConfig): string {
+    const { repoRoot } = config;
+    const shellPath = getUserShell();
+    const sessionName = `${SESSION_PREFIX}main`;
+
+    const lines: string[] = [
+      "#!/bin/bash",
+      "# Auto-generated tmux layout script for dust-hive main session",
+      "set -e",
+      "",
+      `SESSION_NAME=${shellQuote(sessionName)}`,
+      `REPO_ROOT=${shellQuote(repoRoot)}`,
+      "",
+      "# Create the session with the main window",
+      `tmux new-session -d -s "$SESSION_NAME" -n "main" -c "$REPO_ROOT"`,
+      "",
+      "# Start the user's shell in the main window",
+      `tmux send-keys -t "$SESSION_NAME:0" ${shellQuote(`exec ${shellPath}`)} Enter`,
+      "",
+      "# Create temporal logs window",
+      `tmux new-window -t "$SESSION_NAME" -n "temporal"`,
+      `tmux send-keys -t "$SESSION_NAME:1" "dust-hive temporal logs" Enter`,
+      "",
+      "# Select the main window",
+      `tmux select-window -t "$SESSION_NAME:0"`,
+      "",
+    ];
+
+    return lines.join("\n");
+  }
+
+  getLayoutDirectory(): string {
+    return TMUX_LAYOUT_DIR;
+  }
+
+  getLayoutPath(filename: string): string {
+    // Replace .kdl extension with .sh for tmux
+    const baseName = filename.replace(/\.kdl$/, ".sh");
+    return join(TMUX_LAYOUT_DIR, baseName);
+  }
+
+  async writeLayout(content: string, path: string): Promise<void> {
+    await mkdir(TMUX_LAYOUT_DIR, { recursive: true });
+    await Bun.write(path, content);
+    // Make the script executable
+    const proc = Bun.spawn(["chmod", "+x", path], {
+      stdout: "ignore",
+      stderr: "ignore",
+    });
+    await proc.exited;
+  }
+
+  // ============================================================
+  // Prerequisites
+  // ============================================================
+
+  async checkInstalled(): Promise<InstallCheckResult> {
+    try {
+      const proc = Bun.spawn(["tmux", "-V"], {
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const output = await new Response(proc.stdout).text();
+      await proc.exited;
+
+      if (proc.exitCode === 0) {
+        const version = output.trim().split("\n")[0] ?? "Unknown";
+        return { ok: true, version };
+      }
+      return { ok: false, error: "tmux command failed" };
+    } catch {
+      return { ok: false, error: "tmux not found" };
+    }
+  }
+
+  getInstallInstructions(): string {
+    return getPlatformInstallInstructions("tmux");
+  }
+}
+
+// Export singleton instance
+export const tmuxAdapter = new TmuxAdapter();

--- a/x/henry/dust-hive/src/lib/platform.ts
+++ b/x/henry/dust-hive/src/lib/platform.ts
@@ -120,6 +120,7 @@ export function getPidsOnPort(port: number): number[] {
 
 type InstallableTool =
   | "zellij"
+  | "tmux"
   | "temporal"
   | "sccache"
   | "lsof"
@@ -133,6 +134,7 @@ type InstallableTool =
 const INSTALL_INSTRUCTIONS: Record<PlatformName, Record<InstallableTool, string>> = {
   macos: {
     zellij: "brew install zellij",
+    tmux: "brew install tmux",
     temporal: "brew install temporal",
     sccache: "brew install sccache",
     lsof: "lsof is included with macOS",
@@ -145,6 +147,7 @@ const INSTALL_INSTRUCTIONS: Record<PlatformName, Record<InstallableTool, string>
   },
   linux: {
     zellij: "cargo install zellij (or download from https://github.com/zellij-org/zellij/releases)",
+    tmux: "sudo apt install tmux (Debian/Ubuntu) or sudo dnf install tmux (Fedora)",
     temporal: "curl -sSf https://temporal.download/cli.sh | sh",
     sccache: "cargo install sccache",
     lsof: "sudo apt install lsof (Debian/Ubuntu) or sudo dnf install lsof (Fedora)",


### PR DESCRIPTION
## Summary
- Implements `TmuxAdapter` class as a full tmux alternative to zellij
- Uses shell scripts for layouts (tmux has no declarative layout format)
- Adds `tmux` to platform install instructions for macOS/Linux

## Details
**Stacked on #20174** (multiplexer abstraction layer)

The adapter implements:
- Session lifecycle: create, attach, kill, delete, list
- Nested session detection via `$TMUX` env var
- Session switching with `tmux switch-client` (bound to Alt+w in your config)
- Script-based layouts that create windows and send commands

Users can switch to tmux by adding to `~/.dust-hive/settings.json`:
```json
{
  "multiplexer": "tmux"
}
```

## Test plan
- [ ] Verify `bun run check` passes (typecheck, lint, tests)
- [ ] Test creating session with `dust-hive spawn` using tmux
- [ ] Test `dust-hive open` attaching to existing session
- [ ] Test session switching from within tmux
- [ ] Test `dust-hive destroy` cleaning up tmux sessions