### PR TITLE
fix(dust-hive): create log file in follow mode if missing

### DIFF
--- a/x/henry/dust-hive/src/commands/logs.ts
+++ b/x/henry/dust-hive/src/commands/logs.ts
@@ -1,6 +1,9 @@
+import { mkdir } from "node:fs/promises";
+import { dirname } from "node:path";
+
 import { withEnvironment } from "../lib/commands";
 import { getLogPath } from "../lib/paths";
-import { CommandError, Err, Ok } from "../lib/result";
+import { CommandError, Err, Ok, type Result } from "../lib/result";
 import { ensureServiceLogsTui } from "../lib/scripts";
 import { ALL_SERVICES, type ServiceName, isServiceName } from "../lib/services";
 
@@ -9,54 +12,72 @@ interface LogsOptions {
   interactive?: boolean;
 }
 
+function validateServiceArg(serviceArg: string): Result<ServiceName, CommandError> {
+  if (!isServiceName(serviceArg)) {
+    console.log(`\nServices: ${ALL_SERVICES.join(", ")}`);
+    return Err(new CommandError(`Unknown service '${serviceArg}'`));
+  }
+  return Ok(serviceArg);
+}
+
+async function runInteractiveMode(
+  envName: string,
+  serviceArg: string | undefined
+): Promise<Result<undefined, CommandError>> {
+  if (serviceArg) {
+    const result = validateServiceArg(serviceArg);
+    if (!result.ok) return result;
+  }
+  const scriptPath = await ensureServiceLogsTui();
+  const args = serviceArg ? [scriptPath, envName, serviceArg] : [scriptPath, envName];
+  const proc = Bun.spawn(args, {
+    stdin: "inherit",
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+  await proc.exited;
+  return Ok(undefined);
+}
+
+async function ensureLogFileExists(logPath: string): Promise<void> {
+  await mkdir(dirname(logPath), { recursive: true });
+  await Bun.write(logPath, "");
+}
+
 export const logsCommand = withEnvironment(
   "logs",
   async (env, serviceArg: string | undefined, options: LogsOptions) => {
     const follow = options.follow ?? false;
     const interactive = options.interactive ?? false;
 
-    // Interactive mode: launch the TUI
     if (interactive) {
-      // Validate service name if specified
-      if (serviceArg && !isServiceName(serviceArg)) {
-        console.log(`\nServices: ${ALL_SERVICES.join(", ")}`);
-        return Err(new CommandError(`Unknown service '${serviceArg}'`));
-      }
-      const scriptPath = await ensureServiceLogsTui();
-      // If a service is specified, start the TUI on that service
-      const args = serviceArg ? [scriptPath, env.name, serviceArg] : [scriptPath, env.name];
-      const proc = Bun.spawn(args, {
-        stdin: "inherit",
-        stdout: "inherit",
-        stderr: "inherit",
-      });
-      await proc.exited;
-      return Ok(undefined);
+      return runInteractiveMode(env.name, serviceArg);
     }
 
-    // If no service specified, show front by default
+    // Determine target service (default to front)
     let targetService: ServiceName = "front";
     if (serviceArg) {
-      if (!isServiceName(serviceArg)) {
-        console.log(`\nServices: ${ALL_SERVICES.join(", ")}`);
-        return Err(new CommandError(`Unknown service '${serviceArg}'`));
-      }
-      targetService = serviceArg;
+      const result = validateServiceArg(serviceArg);
+      if (!result.ok) return result;
+      targetService = result.value;
     }
-    const logPath = getLogPath(env.name, targetService);
 
-    const logFile = Bun.file(logPath);
-    if (!(await logFile.exists())) {
-      return Err(new CommandError(`No log file for ${targetService}`));
-    }
+    const logPath = getLogPath(env.name, targetService);
+    const exists = await Bun.file(logPath).exists();
 
     if (follow) {
+      if (!exists) {
+        await ensureLogFileExists(logPath);
+      }
       const proc = Bun.spawn(["tail", "-F", logPath], {
         stdout: "inherit",
         stderr: "inherit",
       });
       await proc.exited;
     } else {
+      if (!exists) {
+        return Err(new CommandError(`No log file for ${targetService}`));
+      }
       const proc = Bun.spawn(["tail", "-500", logPath], {
         stdout: "inherit",
         stderr: "inherit",


### PR DESCRIPTION
## Summary

Fixes individual service log tabs showing "No log file for X" errors when opening a new environment without unified logs.

## Problem

When spawning or opening a new environment, the zellij tabs run `dust-hive logs <env> <service> -f` for each service. If the service hasn't started writing logs yet, the command would error out with "No log file for X" and terminate - meaning once the service started logging, there was no process watching the logs.

## Solution

In follow mode (`-f`), if the log file doesn't exist, create an empty file first. This allows `tail -F` to wait for content to appear, matching the behavior of the interactive TUI which already handled this case.

Also refactored the logs command to extract helper functions, reducing cognitive complexity.

## Test plan

- [x] `bun run check` passes
- [x] Spawn a new environment without `-u` flag
- [x] Verify all service tabs start watching (no errors)
- [x] Verify logs appear once services start