### PR TITLE
feat(mcp): generic personal auth inputs for OAuth providers

### DIFF
--- a/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.tsx
+++ b/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.tsx
@@ -49,8 +49,7 @@ export function MCPServerPersonalAuthenticationRequired({
   const [isConnecting, setIsConnecting] = useState<boolean>(false);
 
   // Generic state for additional auth inputs - keyed by extraConfigKey
-  const personalAuthInputs =
-    mcpServer?.authorization?.personalAuthInputs ?? [];
+  const personalAuthInputs = mcpServer?.authorization?.personalAuthInputs ?? [];
   const personalAuthDefaults =
     mcpServer?.authorization?.personalAuthDefaults ?? {};
   const [additionalInputs, setAdditionalInputs] = useState<

--- a/front/lib/actions/mcp_metadata_extraction.ts
+++ b/front/lib/actions/mcp_metadata_extraction.ts
@@ -14,10 +14,24 @@ import type {
 import type { MCPOAuthUseCase, OAuthProvider } from "@app/types";
 import { isOAuthProvider } from "@app/types";
 
+// Schema for personal auth input fields that OAuth providers may require
+export type PersonalAuthInputType = {
+  name: string; // Display name, e.g., "role"
+  extraConfigKey: string; // Key used in OAuth extraConfig, e.g., "snowflake_role"
+  label: string; // UI label, e.g., "Snowflake Role"
+  placeholder?: string; // e.g., "e.g., ANALYST"
+  description?: string; // Explanatory text
+  required: boolean; // Whether input is required (if false, default may exist)
+};
+
 export type AuthorizationInfo = {
   provider: OAuthProvider;
   supported_use_cases: MCPOAuthUseCase[];
   scope?: string;
+  // Generic personal auth inputs schema
+  personalAuthInputs?: PersonalAuthInputType[];
+  // Default values (populated from workspace connection metadata)
+  personalAuthDefaults?: Record<string, string>;
 };
 
 function isAuthorizationInfo(a: unknown): a is AuthorizationInfo {

--- a/front/lib/actions/mcp_metadata_extraction.ts
+++ b/front/lib/actions/mcp_metadata_extraction.ts
@@ -14,23 +14,19 @@ import type {
 import type { MCPOAuthUseCase, OAuthProvider } from "@app/types";
 import { isOAuthProvider } from "@app/types";
 
-// Schema for personal auth input fields that OAuth providers may require
 export type PersonalAuthInputType = {
-  name: string; // Display name, e.g., "role"
-  extraConfigKey: string; // Key used in OAuth extraConfig, e.g., "snowflake_role"
-  label: string; // UI label, e.g., "Snowflake Role"
-  placeholder?: string; // e.g., "e.g., ANALYST"
-  description?: string; // Explanatory text
-  required: boolean; // Whether input is required (if false, default may exist)
+  extraConfigKey: string;
+  label: string;
+  required: boolean;
+  placeholder?: string;
+  description?: string;
 };
 
 export type AuthorizationInfo = {
   provider: OAuthProvider;
   supported_use_cases: MCPOAuthUseCase[];
   scope?: string;
-  // Generic personal auth inputs schema
   personalAuthInputs?: PersonalAuthInputType[];
-  // Default values (populated from workspace connection metadata)
   personalAuthDefaults?: Record<string, string>;
 };
 

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -879,7 +879,9 @@ export function useCreatePersonalConnection(owner: LightWorkspaceType) {
 
       // Pass all additional inputs directly to extraConfig
       if (additionalInputs) {
-        for (const [extraConfigKey, value] of Object.entries(additionalInputs)) {
+        for (const [extraConfigKey, value] of Object.entries(
+          additionalInputs
+        )) {
           if (value) {
             extraConfig[extraConfigKey] = value;
           }

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -858,12 +858,15 @@ export function useCreatePersonalConnection(owner: LightWorkspaceType) {
     provider,
     useCase,
     scope,
+    additionalInputs,
   }: {
     mcpServerId: string;
     mcpServerDisplayName: string;
     provider: OAuthProvider;
     useCase: OAuthUseCase;
     scope?: string;
+    // Keys are extraConfigKey values from personalAuthInputs
+    additionalInputs?: Record<string, string>;
   }): Promise<boolean> => {
     try {
       const extraConfig: Record<string, string> = {
@@ -872,6 +875,15 @@ export function useCreatePersonalConnection(owner: LightWorkspaceType) {
 
       if (scope) {
         extraConfig.scope = scope;
+      }
+
+      // Pass all additional inputs directly to extraConfig
+      if (additionalInputs) {
+        for (const [extraConfigKey, value] of Object.entries(additionalInputs)) {
+          if (value) {
+            extraConfig[extraConfigKey] = value;
+          }
+        }
       }
 
       const cRes = await setupOAuthConnection({

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -877,13 +877,13 @@ export function useCreatePersonalConnection(owner: LightWorkspaceType) {
         extraConfig.scope = scope;
       }
 
-      // Pass all additional inputs directly to extraConfig
       if (additionalInputs) {
         for (const [extraConfigKey, value] of Object.entries(
           additionalInputs
         )) {
-          if (value) {
-            extraConfig[extraConfigKey] = value;
+          const trimmed = value.trim();
+          if (trimmed) {
+            extraConfig[extraConfigKey] = trimmed;
           }
         }
       }

--- a/front/pages/api/w/[wId]/mcp/[serverId]/index.ts
+++ b/front/pages/api/w/[wId]/mcp/[serverId]/index.ts
@@ -8,14 +8,20 @@ import {
   requiresBearerTokenConfiguration,
 } from "@app/lib/actions/mcp_helper";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import apiConfig from "@app/lib/api/config";
 import type { MCPServerType } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
+import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
 import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
+import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
-import { headersArrayToRecord } from "@app/types";
+import {
+  getOAuthConnectionAccessToken,
+  headersArrayToRecord,
+} from "@app/types";
 import { assertNever } from "@app/types";
 
 const PatchMCPServerBodySchema = z
@@ -112,7 +118,55 @@ async function handler(
             });
           }
 
-          return res.status(200).json({ server: server.toJSON() });
+          const serverJson = server.toJSON();
+
+          // For servers with personalAuthInputs, fetch defaults from workspace connection metadata
+          if (serverJson.authorization?.personalAuthInputs?.length) {
+            const workspaceConnectionRes =
+              await MCPServerConnectionResource.findByMCPServer(auth, {
+                mcpServerId: serverId,
+                connectionType: "workspace",
+              });
+
+            if (workspaceConnectionRes.isOk()) {
+              const tokenRes = await getOAuthConnectionAccessToken({
+                config: apiConfig.getOAuthAPIConfig(),
+                logger,
+                connectionId: workspaceConnectionRes.value.connectionId,
+              });
+
+              if (tokenRes.isOk()) {
+                const metadata = tokenRes.value.connection.metadata;
+                // Build defaults from metadata using extraConfigKey
+                const defaults: Record<string, string> = {};
+                for (const input of serverJson.authorization
+                  .personalAuthInputs) {
+                  const value = metadata[input.extraConfigKey];
+                  if (typeof value === "string" && value) {
+                    defaults[input.extraConfigKey] = value;
+                  }
+                }
+                if (Object.keys(defaults).length > 0) {
+                  serverJson.authorization = {
+                    ...serverJson.authorization,
+                    personalAuthDefaults: defaults,
+                  };
+                }
+              } else {
+                logger.warn(
+                  { serverId, error: tokenRes.error },
+                  "Failed to get OAuth token for personal auth defaults"
+                );
+              }
+            } else {
+              logger.warn(
+                { serverId, error: workspaceConnectionRes.error },
+                "No workspace connection found for server with personal auth inputs"
+              );
+            }
+          }
+
+          return res.status(200).json({ server: serverJson });
         }
         case "remote": {
           const server = await RemoteMCPServerResource.fetchById(


### PR DESCRIPTION
## Description

Adds a generic schema-driven approach for personal auth inputs in MCP servers. Instead of hardcoding provider-specific logic, servers can define `personalAuthInputs` in their authorization config:

```typescript
personalAuthInputs: [{
  extraConfigKey: "some_role",
  label: "Role",
  required: false,
  placeholder: "e.g., ADMIN",
  description: "Select your role",
}]
```

The UI components dynamically render input fields based on this schema. Defaults are populated from workspace connection metadata.

## Tests

- Type check passes
- No functional changes for existing MCP servers (none currently use `personalAuthInputs`)

## Risk

Low - pure additive change, only affects servers with `personalAuthInputs` defined.

## Deploy Plan

Standard deploy.