### PR TITLE
[front] refactor(resources): move step content deletion into existing resource

### DIFF
--- a/front/lib/api/assistant/conversation/destroy.ts
+++ b/front/lib/api/assistant/conversation/destroy.ts
@@ -4,7 +4,6 @@ import type { WhereOptions } from "sequelize";
 import { hardDeleteDataSource } from "@app/lib/api/data_sources";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentMCPActionOutputItemModel } from "@app/lib/models/agent/actions/mcp";
-import { AgentStepContentModel } from "@app/lib/models/agent/agent_step_content";
 import {
   AgentMessageFeedbackModel,
   AgentMessageModel,
@@ -18,6 +17,7 @@ import {
   ConversationSkillModel,
 } from "@app/lib/models/skill/conversation_skill";
 import { AgentMCPActionResource } from "@app/lib/resources/agent_mcp_action_resource";
+import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import { ContentFragmentResource } from "@app/lib/resources/content_fragment_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
@@ -213,11 +213,8 @@ export async function destroyConversation(
         workspaceId: owner.id,
       },
     });
-    await AgentStepContentModel.destroy({
-      where: {
-        agentMessageId: agentMessageIds,
-        workspaceId: owner.id,
-      },
+    await AgentStepContentResource.deleteByAgentMessageIds(auth, {
+      agentMessageIds,
     });
     await AgentMessageFeedbackModel.destroy({
       where: {

--- a/front/lib/resources/agent_step_content_resource.ts
+++ b/front/lib/resources/agent_step_content_resource.ts
@@ -344,6 +344,18 @@ export class AgentStepContentResource extends BaseResource<AgentStepContentModel
     return new Ok(deletedCount);
   }
 
+  static async deleteByAgentMessageIds(
+    auth: Authenticator,
+    { agentMessageIds }: { agentMessageIds: ModelId[] }
+  ): Promise<number> {
+    return this.model.destroy({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        agentMessageId: { [Op.in]: agentMessageIds },
+      },
+    });
+  }
+
   toJSON(): AgentStepContentType {
     let value = this.value;
     if (this.type === "reasoning" && value.type === "reasoning") {


### PR DESCRIPTION
## Description

- This PR moves the deletion of `agent_step_contents` into the existing resources instead of relying on the raw Sequelize model.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
