### PR TITLE
[Front] fix(mcp): deep clean strings in tool output before DB insert

### DIFF
--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -47,6 +47,7 @@ import {
   extensionsForContentType,
   isSupportedFileContentType,
   removeNulls,
+  sanitizeForJsonb,
   stripNullBytes,
   toWellFormed,
 } from "@app/types";
@@ -340,7 +341,7 @@ export async function processToolResults(
     cleanContent.map((c) => ({
       workspaceId: action.workspaceId,
       agentMCPActionId: action.id,
-      content: c.content,
+      content: sanitizeForJsonb(c.content),
       fileId: c.file?.id,
     }))
   );


### PR DESCRIPTION
## Description

Add `deepCleanStrings` helper to recursively sanitize all string fields in MCP tool output content before PostgreSQL JSONB insertion. Fixes "unsupported Unicode escape sequence" errors caused by null bytes in nested fields like `resource.html`, `resource.uri`, `resource.mimeType`.

## Tests

Manual - the existing individual string cleaning for `text` fields still works, and the deep clean now handles all other nested string fields.

## Risk

Low - the function preserves object structure and only cleans string content. Existing string cleaning for text fields is kept as defense in depth.

## Deploy Plan

Standard deploy, no migration needed.