### PR TITLE
remove 'Select spaces'

### DIFF
--- a/front/components/agent_builder/capabilities/capabilities_sheet/SpaceSelectionPage.tsx
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/SpaceSelectionPage.tsx
@@ -127,9 +127,6 @@ export function SpaceSelectionPageContent({
 
   return (
     <div className="flex flex-col gap-4">
-      <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-        Select spaces
-      </p>
       {selectableSpaces.length > 0 ? (
         <DataTable
           data={tableData}


### PR DESCRIPTION
## Description
Remove redundant "Select spaces" text in Add spaces modal

## Tests


## Risk

Very low

## Deploy Plan


