### PR TITLE
[front] fix(skills): update space restrictions on tagged knowledge

### DIFF
--- a/front/components/Confirm.tsx
+++ b/front/components/Confirm.tsx
@@ -14,6 +14,7 @@ export type ConfirmDataType = {
   message: string | ReactNode;
   validateLabel?: string;
   validateVariant?: "primary" | "warning";
+  validateDisabled?: boolean;
   cancelLabel?: string;
 };
 
@@ -97,6 +98,7 @@ export function ConfirmDialog({
           rightButtonProps={{
             label: confirmData?.validateLabel ?? "OK",
             variant: confirmData?.validateVariant ?? "warning",
+            disabled: confirmData?.validateDisabled ?? false,
             onClick: () => resolveConfirm(true),
           }}
         />

--- a/front/components/agent_builder/AgentBuilderSpacesBlock.tsx
+++ b/front/components/agent_builder/AgentBuilderSpacesBlock.tsx
@@ -92,15 +92,15 @@ export function AgentBuilderSpacesBlock() {
         ?.requestedSpaceIds.includes(space.sId)
     );
 
-    // Only show confirmation dialog if there are resources to remove
+    // Only show the confirmation dialog if there are resources to remove.
     if (actionsToRemove.length > 0 || skillsToRemove.length > 0) {
-      const confirmed = await confirmRemoveSpace(
+      const confirmed = await confirmRemoveSpace({
         space,
-        actionsToRemove,
-        allSkills.filter((skill) =>
+        actions: actionsToRemove,
+        skills: allSkills.filter((skill) =>
           skillsToRemove.some((s) => s.sId === skill.sId)
-        )
-      );
+        ),
+      });
 
       if (!confirmed) {
         return;

--- a/front/components/editor/extensions/skill_builder/KnowledgeNodeView.tsx
+++ b/front/components/editor/extensions/skill_builder/KnowledgeNodeView.tsx
@@ -47,6 +47,7 @@ import { removeNulls } from "@app/types";
 interface KnowledgeDisplayProps {
   item: KnowledgeItem;
   owner: LightWorkspaceType;
+  isSpacesLoading?: boolean;
   onRemove?: () => void;
   updateAttributes: (attrs: Partial<KnowledgeNodeAttributes>) => void;
 }
@@ -54,6 +55,7 @@ interface KnowledgeDisplayProps {
 export function KnowledgeDisplayComponent({
   item,
   owner,
+  isSpacesLoading = false,
   onRemove,
   updateAttributes,
 }: KnowledgeDisplayProps) {
@@ -62,7 +64,7 @@ export function KnowledgeDisplayComponent({
 
   const { dataSourceView, isDataSourceViewError } = useSpaceDataSourceView({
     dataSourceViewId: item.dataSourceViewId,
-    disabled: !needsFetch,
+    disabled: !needsFetch || isSpacesLoading,
     owner,
     spaceId: item.spaceId,
   });
@@ -466,7 +468,7 @@ export const KnowledgeNodeView: React.FC<ExtendedNodeViewProps> = ({
   node,
   updateAttributes,
 }) => {
-  const { owner } = useSpacesContext();
+  const { owner, isSpacesLoading } = useSpacesContext();
   const { selectedItems } = node.attrs as KnowledgeNodeAttributes;
 
   const handleRemove = useCallback(
@@ -512,6 +514,7 @@ export const KnowledgeNodeView: React.FC<ExtendedNodeViewProps> = ({
         <KnowledgeDisplayComponent
           item={selectedItems[0]}
           owner={owner}
+          isSpacesLoading={isSpacesLoading}
           onRemove={editor.isEditable ? handleRemove : undefined}
           updateAttributes={updateAttributes}
         />

--- a/front/components/shared/RemoveSpaceDialog.tsx
+++ b/front/components/shared/RemoveSpaceDialog.tsx
@@ -101,12 +101,18 @@ export function useRemoveSpaceConfirm({
       })),
     ];
 
+    const hasKnowledge = knowledgeItems.length > 0;
+
     return confirm({
       title: `Remove ${getSpaceName(space)} space`,
       message: (
-        <p className="text-sm">
-          This will remove the following elements from the {entityName}:
-          <span className="mt-4 flex flex-wrap items-center gap-1">
+        <div className="space-y-3">
+          <p className="text-sm">
+            {hasKnowledge
+              ? `The following elements from this space are used in the ${entityName}:`
+              : `This will remove the following elements from the ${entityName}:`}
+          </p>
+          <span className="flex flex-wrap items-center gap-1">
             {allItems.map((item, index) => (
               <span key={item.id} className="inline-flex items-center gap-1">
                 {item.icon}
@@ -121,10 +127,17 @@ export function useRemoveSpaceConfirm({
               </span>
             ))}
           </span>
-        </p>
+          {hasKnowledge && (
+            <p className="dark:text-warning-night text-sm text-warning">
+              To remove this space, first update your instructions to remove the
+              knowledge references.
+            </p>
+          )}
+        </div>
       ),
       validateLabel: "OK",
       validateVariant: "warning",
+      validateDisabled: hasKnowledge,
     });
   };
 }

--- a/front/components/shared/RemoveSpaceDialog.tsx
+++ b/front/components/shared/RemoveSpaceDialog.tsx
@@ -1,3 +1,4 @@
+import { Icon, InboxIcon } from "@dust-tt/sparkle";
 import React, { useContext } from "react";
 
 import { ConfirmContext } from "@app/components/Confirm";
@@ -51,6 +52,11 @@ interface SkillToRemove {
   icon: string | null;
 }
 
+interface KnowledgeToRemove {
+  nodeId: string;
+  title: string;
+}
+
 interface UseRemoveSpaceConfirmParams {
   entityName: "agent" | "skill";
   mcpServerViews: MCPServerViewType[];
@@ -65,10 +71,25 @@ export function useRemoveSpaceConfirm({
   return async (
     space: SpaceType,
     actions: BuilderAction[],
-    skills: SkillToRemove[] = []
+    knowledgeOrSkills: KnowledgeToRemove[] | SkillToRemove[] = []
   ): Promise<boolean> => {
+    // Determine if we're dealing with knowledge items or skills based on the shape.
+    const isKnowledge = (
+      item: KnowledgeToRemove | SkillToRemove
+    ): item is KnowledgeToRemove => "nodeId" in item;
+
+    const knowledgeItems = knowledgeOrSkills.filter(isKnowledge);
+    const skillItems = knowledgeOrSkills.filter(
+      (item): item is SkillToRemove => !isKnowledge(item)
+    );
+
     const allItems: ItemToRemove[] = [
-      ...skills.map((skill) => ({
+      ...knowledgeItems.map((k) => ({
+        id: k.nodeId,
+        name: k.title,
+        icon: <Icon visual={InboxIcon} size="xs" />,
+      })),
+      ...skillItems.map((skill) => ({
         id: skill.sId,
         name: skill.name,
         icon: getSkillIcon(skill),

--- a/front/components/shared/RemoveSpaceDialog.tsx
+++ b/front/components/shared/RemoveSpaceDialog.tsx
@@ -1,4 +1,4 @@
-import { Icon, InboxIcon } from "@dust-tt/sparkle";
+import { DocumentIcon, Icon } from "@dust-tt/sparkle";
 import React, { useContext } from "react";
 
 import { ConfirmContext } from "@app/components/Confirm";
@@ -87,7 +87,7 @@ export function useRemoveSpaceConfirm({
       ...knowledgeItems.map((k) => ({
         id: k.nodeId,
         name: k.title,
-        icon: <Icon visual={InboxIcon} size="xs" />,
+        icon: <Icon visual={DocumentIcon} size="xs" />,
       })),
       ...skillItems.map((skill) => ({
         id: skill.sId,

--- a/front/components/shared/RemoveSpaceDialog.tsx
+++ b/front/components/shared/RemoveSpaceDialog.tsx
@@ -65,7 +65,7 @@ interface UseRemoveSpaceConfirmParams {
 interface ConfirmRemoveSpaceParams {
   space: SpaceType;
   actions: BuilderAction[];
-  knowledge?: KnowledgeToRemove[];
+  knowledgeInInstructions?: KnowledgeToRemove[];
   skills?: SkillToRemove[];
 }
 
@@ -78,11 +78,11 @@ export function useRemoveSpaceConfirm({
   return async ({
     space,
     actions,
-    knowledge = [],
+    knowledgeInInstructions = [],
     skills = [],
   }: ConfirmRemoveSpaceParams): Promise<boolean> => {
     const allItems: ItemToRemove[] = [
-      ...knowledge.map((k) => ({
+      ...knowledgeInInstructions.map((k) => ({
         id: k.nodeId,
         name: k.title,
         icon: <Icon visual={DocumentIcon} size="xs" />,
@@ -99,7 +99,7 @@ export function useRemoveSpaceConfirm({
       })),
     ];
 
-    const hasKnowledge = knowledge.length > 0;
+    const hasKnowledge = knowledgeInInstructions.length > 0;
 
     return confirm({
       title: `Remove ${getSpaceName(space)} space`,

--- a/front/components/shared/RemoveSpaceDialog.tsx
+++ b/front/components/shared/RemoveSpaceDialog.tsx
@@ -126,7 +126,7 @@ export function useRemoveSpaceConfirm({
             ))}
           </span>
           {hasKnowledge && (
-            <p className="dark:text-warning-night text-sm text-warning">
+            <p className="dark:text-warning-night text-sm">
               To remove this space, first update your instructions to remove the
               knowledge references.
             </p>

--- a/front/components/shared/RemoveSpaceDialog.tsx
+++ b/front/components/shared/RemoveSpaceDialog.tsx
@@ -62,34 +62,32 @@ interface UseRemoveSpaceConfirmParams {
   mcpServerViews: MCPServerViewType[];
 }
 
+interface ConfirmRemoveSpaceParams {
+  space: SpaceType;
+  actions: BuilderAction[];
+  knowledge?: KnowledgeToRemove[];
+  skills?: SkillToRemove[];
+}
+
 export function useRemoveSpaceConfirm({
   entityName,
   mcpServerViews,
 }: UseRemoveSpaceConfirmParams) {
   const confirm = useContext(ConfirmContext);
 
-  return async (
-    space: SpaceType,
-    actions: BuilderAction[],
-    knowledgeOrSkills: KnowledgeToRemove[] | SkillToRemove[] = []
-  ): Promise<boolean> => {
-    // Determine if we're dealing with knowledge items or skills based on the shape.
-    const isKnowledge = (
-      item: KnowledgeToRemove | SkillToRemove
-    ): item is KnowledgeToRemove => "nodeId" in item;
-
-    const knowledgeItems = knowledgeOrSkills.filter(isKnowledge);
-    const skillItems = knowledgeOrSkills.filter(
-      (item): item is SkillToRemove => !isKnowledge(item)
-    );
-
+  return async ({
+    space,
+    actions,
+    knowledge = [],
+    skills = [],
+  }: ConfirmRemoveSpaceParams): Promise<boolean> => {
     const allItems: ItemToRemove[] = [
-      ...knowledgeItems.map((k) => ({
+      ...knowledge.map((k) => ({
         id: k.nodeId,
         name: k.title,
         icon: <Icon visual={DocumentIcon} size="xs" />,
       })),
-      ...skillItems.map((skill) => ({
+      ...skills.map((skill) => ({
         id: skill.sId,
         name: skill.name,
         icon: getSkillIcon(skill),
@@ -101,7 +99,7 @@ export function useRemoveSpaceConfirm({
       })),
     ];
 
-    const hasKnowledge = knowledgeItems.length > 0;
+    const hasKnowledge = knowledge.length > 0;
 
     return confirm({
       title: `Remove ${getSpaceName(space)} space`,

--- a/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
@@ -55,17 +55,17 @@ export function SkillBuilderRequestedSpacesSection() {
 
   const handleRemoveSpace = async (space: SpaceType) => {
     const actionsToRemove = spaceIdToActions[space.sId] || [];
-    const knowledgeToRemove = knowledgeToRemoveBySpaceId[space.sId] || [];
+    const knowledgeInSpace = knowledgeToRemoveBySpaceId[space.sId] || [];
 
     // Don't show confirmation if nothing to remove.
-    if (actionsToRemove.length === 0 && knowledgeToRemove.length === 0) {
+    if (actionsToRemove.length === 0 && knowledgeInSpace.length === 0) {
       return;
     }
 
     const confirmed = await confirmRemoveSpace(
       space,
       actionsToRemove,
-      knowledgeToRemove
+      knowledgeInSpace
     );
 
     if (!confirmed) {
@@ -73,19 +73,10 @@ export function SkillBuilderRequestedSpacesSection() {
     }
 
     const actionIdsToRemove = new Set(actionsToRemove.map((a) => a.id));
-    const knowledgeNodeIdsToRemove = new Set(
-      knowledgeToRemove.map((k) => k.nodeId)
-    );
 
     // Filter out the tools to remove and set the new value.
     const newTools = tools.filter((t) => !actionIdsToRemove.has(t.id));
     setValue("tools", newTools, { shouldDirty: true });
-
-    // Filter out the attached knowledge to remove and set the new value.
-    const newAttachedKnowledge = (attachedKnowledge ?? []).filter(
-      (k) => !knowledgeNodeIdsToRemove.has(k.nodeId)
-    );
-    setValue("attachedKnowledge", newAttachedKnowledge, { shouldDirty: true });
   };
 
   const globalSpace = useMemo(() => {

--- a/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
@@ -62,11 +62,11 @@ export function SkillBuilderRequestedSpacesSection() {
       return;
     }
 
-    const confirmed = await confirmRemoveSpace(
+    const confirmed = await confirmRemoveSpace({
       space,
-      actionsToRemove,
-      knowledgeInSpace
-    );
+      actions: actionsToRemove,
+      knowledge: knowledgeInSpace,
+    });
 
     if (!confirmed) {
       return;

--- a/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
@@ -37,7 +37,8 @@ export function SkillBuilderRequestedSpacesSection() {
     return spaces.filter(
       (s) =>
         s.kind !== "global" &&
-        (spaceIdToActions[s.sId]?.length > 0 || spaceIdsFromKnowledge.has(s.sId))
+        (spaceIdToActions[s.sId]?.length > 0 ||
+          spaceIdsFromKnowledge.has(s.sId))
     );
   }, [spaceIdToActions, spaceIdsFromKnowledge, spaces]);
 

--- a/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
@@ -15,6 +15,7 @@ export function SkillBuilderRequestedSpacesSection() {
   const { watch, setValue } = useFormContext<SkillBuilderFormData>();
 
   const tools = watch("tools");
+  const attachedKnowledge = watch("attachedKnowledge");
 
   const { mcpServerViews } = useMCPServerViewsContext();
   const { spaces } = useSpacesContext();
@@ -28,11 +29,17 @@ export function SkillBuilderRequestedSpacesSection() {
     return getSpaceIdToActionsMap(tools, mcpServerViews);
   }, [tools, mcpServerViews]);
 
+  const spaceIdsFromKnowledge = useMemo(() => {
+    return new Set(attachedKnowledge?.map((k) => k.spaceId) ?? []);
+  }, [attachedKnowledge]);
+
   const nonGlobalSpacesUsedInActions = useMemo(() => {
     return spaces.filter(
-      (s) => s.kind !== "global" && spaceIdToActions[s.sId]?.length > 0
+      (s) =>
+        s.kind !== "global" &&
+        (spaceIdToActions[s.sId]?.length > 0 || spaceIdsFromKnowledge.has(s.sId))
     );
-  }, [spaceIdToActions, spaces]);
+  }, [spaceIdToActions, spaceIdsFromKnowledge, spaces]);
 
   const handleRemoveSpace = async (space: SpaceType) => {
     const actionsToRemove = spaceIdToActions[space.sId] || [];

--- a/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
+++ b/front/components/skill_builder/SkillBuilderRequestedSpacesSection.tsx
@@ -65,7 +65,7 @@ export function SkillBuilderRequestedSpacesSection() {
     const confirmed = await confirmRemoveSpace({
       space,
       actions: actionsToRemove,
-      knowledge: knowledgeInSpace,
+      knowledgeInInstructions: knowledgeInSpace,
     });
 
     if (!confirmed) {

--- a/front/pages/api/w/[wId]/skills/[sId]/index.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.ts
@@ -221,7 +221,7 @@ async function handler(
         });
       }
 
-      const requestedSpaceIds =
+      const spaceIdsFromMcpServerViews =
         await MCPServerViewResource.listSpaceRequirementsByIds(
           auth,
           mcpServerViewIds
@@ -257,6 +257,15 @@ async function handler(
           nodeId: attachment.nodeId,
         })
       );
+
+      const spaceIdsFromAttachedKnowledge = dataSourceViews.map(
+        (dsv) => dsv.space.id
+      );
+
+      const requestedSpaceIds = uniq([
+        ...spaceIdsFromMcpServerViews,
+        ...spaceIdsFromAttachedKnowledge,
+      ]);
 
       // When saving a suggested skill, automatically activate it.
       const shouldActivate = skillResource.status === "suggested";

--- a/front/pages/api/w/[wId]/skills/index.ts
+++ b/front/pages/api/w/[wId]/skills/index.ts
@@ -245,11 +245,20 @@ async function handler(
         })
       );
 
-      const requestedSpaceIds =
+      const spaceIdsFromMcpServerViews =
         await MCPServerViewResource.listSpaceRequirementsByIds(
           auth,
           mcpServerViewIds
         );
+
+      const spaceIdsFromAttachedKnowledge = dataSourceViews.map(
+        (dsv) => dsv.space.id
+      );
+
+      const requestedSpaceIds = uniq([
+        ...spaceIdsFromMcpServerViews,
+        ...spaceIdsFromAttachedKnowledge,
+      ]);
 
       const extendedSkill = body.extendedSkillId
         ? await SkillResource.fetchById(auth, body.extendedSkillId)


### PR DESCRIPTION
## Description

- This PR fixes a bug in Skill Builder occurring when tagging content nodes from private spaces where requested spaces would not be updated, causing no leak but leading to the knowledge references not loading upon loading.
- This PR updates the space update in the backend (directly reading the space from the data source view) and also in the front-end for an immediate visual feedback. Also updates the space removal flow to take knowledge in account.

## Tests

- Tested locally.

## Risk

- Low, behind FF.

## Deploy Plan

- Deploy front.
