### PR TITLE
fix(dust-hive): follow symlinks when finding AGENTS.local.md files

### DIFF
--- a/x/henry/dust-hive/src/lib/setup.ts
+++ b/x/henry/dust-hive/src/lib/setup.ts
@@ -94,6 +94,7 @@ async function findAgentsLocalFiles(srcDir: string): Promise<string[]> {
   const proc = Bun.spawn(
     [
       "find",
+      "-L", // Follow symlinks so -type f matches symlinked files
       srcDir,
       // Prune large directories (skips traversal entirely, much faster than -not -path)
       "-type",


### PR DESCRIPTION
## Summary
- Fix `findAgentsLocalFiles` to follow symlinks when searching for AGENTS.local.md files
- The `find` command used `-type f` which only matches regular files, not symbolic links
- If AGENTS.local.md is a symlink in the main repo, it would not be found or copied to worktrees
- Adding `-L` makes find follow symlinks, so `-type f` will match symlinked files

## Test plan
- [x] `bun run check` passes (typecheck, lint, tests)
- [ ] Spawn a new env with a symlinked AGENTS.local.md in main repo and verify it gets copied