### PR TITLE
[dust-hive] Follow symlinks when finding AGENTS.local.md files

### DIFF
--- a/x/henry/dust-hive/src/lib/setup.ts
+++ b/x/henry/dust-hive/src/lib/setup.ts
@@ -94,6 +94,7 @@ async function findAgentsLocalFiles(srcDir: string): Promise<string[]> {
   const proc = Bun.spawn(
     [
       "find",
+      "-L", // Follow symlinks so -type f matches symlinked files
       srcDir,
       // Prune large directories (skips traversal entirely, much faster than -not -path)
       "-type",


### PR DESCRIPTION
## Description
The `find` command in `findAgentsLocalFiles` used `-type f` which only matches regular files, not symbolic links. If AGENTS.local.md is a symlink in the main repo, it would not be found or copied to worktrees.

Adding `-L` makes find follow symlinks, so `-type f` will match symlinked files and copy their content.

## Risks
Blast radius: dust-hive warmup only
Risk: none

## Deploy Plan
- pmrr
- N/A (dust-hive CLI tool, no deployment)