### PR TITLE
docs(dust-hive): fix outdated/missing documentation

### DIFF
--- a/x/henry/dust-hive/.claude/skills/dust-hive/SKILL.md
+++ b/x/henry/dust-hive/.claude/skills/dust-hive/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dust-hive
-description: Information about dust-hive, a CLI tool for running multiple isolated Dust development environments. ALWAYS enable this skill when the working directory is under ~/dust-hive/. Use for environment status, Dust app commands, and understanding port allocation.
+description: Information about dust-hive, a CLI tool for running multiple isolated Dust development environments. ALWAYS enable this skill when the working directory is under ~/dust-hive/. Use for understanding port allocation, running tests, and working with the environment.
 ---
 
 # dust-hive
@@ -13,108 +13,45 @@ dust-hive is a CLI tool for running multiple isolated Dust development environme
 - Docker containers (isolated volumes)
 - Database instances (Postgres, Qdrant, Elasticsearch)
 
-## Code Location
-
-The dust-hive source code is located at `x/henry/dust-hive/` in the Dust monorepo:
-
-```
-x/henry/dust-hive/
-├── src/
-│   ├── index.ts           # CLI entry point
-│   ├── forward-daemon.ts  # TCP forwarder daemon
-│   ├── commands/          # Command implementations
-│   └── lib/               # Shared utilities
-├── tests/                 # Unit tests
-├── package.json
-└── CLAUDE.md              # Development context
-```
-
 ## Detecting a dust-hive Environment
 
 To check if you're currently running in a dust-hive environment:
 
 1. **Check working directory**: dust-hive worktrees are located at `~/dust-hive/{env-name}/`
 2. **Check for worktree**: The `.git` file (not directory) indicates a git worktree
-3. **Run status command**: `dust-hive status` shows environment info if you're in one
 
-Programmatically detect the current environment:
 ```bash
-# From the dust-hive CLI
-dust-hive status
-
 # Check if in worktree path
 pwd | grep -q "$HOME/dust-hive/" && echo "In dust-hive environment"
 ```
 
-The `detectEnvFromCwd()` function in `src/lib/paths.ts` detects the environment name from the current working directory.
+## Environment States
 
-## Automatic Environment Loading (direnv)
+Environments can be in one of three states:
 
-Each dust-hive worktree contains a `.envrc` file that automatically loads the environment variables when you `cd` into the directory. This is powered by [direnv](https://direnv.net/).
+| State | What's Running | Can Run Tests? |
+|-------|----------------|----------------|
+| **stopped** | Nothing | No |
+| **cold** | SDK watch only | Yes (front tests use shared test DB) |
+| **warm** | All services (front, core, connectors, oauth, workers) + Docker | Yes |
+
+Check the current state:
+```bash
+dust-hive status [ENV_NAME]
+```
+
+## Environment Variables (direnv)
+
+Each dust-hive worktree contains a `.envrc` file that automatically loads environment variables when you `cd` into the directory. This is powered by [direnv](https://direnv.net/).
 
 **What this means:**
-- Environment variables (ports, database URIs, API keys, etc.) are automatically available in your shell
-- No need to manually source `env.sh` or set environment variables
+- Environment variables (ports, database URIs, API keys, etc.) are automatically available
 - Variables like `FRONT_DATABASE_URI`, `CORE_API`, `CONNECTORS_API` are pre-configured for the environment's port range
 
-**Troubleshooting:** If you encounter errors about missing environment variables, the user may not have direnv configured. In that case, manually source the environment:
+**If environment variables are missing**, manually source the environment:
 ```bash
 source ~/.dust-hive/envs/{ENV_NAME}/env.sh
 ```
-
-## Environment States
-
-| State | Description | What's Running |
-|-------|-------------|----------------|
-| **stopped** | Nothing running | - |
-| **cold** | Minimal state | SDK watch only |
-| **warm** | Full development | All services (front, core, oauth, connectors, workers) + Docker |
-
-## Checking Environment Status
-
-```bash
-# Show full status (services, docker, health checks)
-dust-hive status [ENV_NAME]
-
-# List all environments with states
-dust-hive list
-
-# Check if temporal server is running
-dust-hive temporal status
-
-# Check port forwarding status
-dust-hive forward status
-```
-
-## Common Commands
-
-### Managed Services (Global)
-| Command | Description |
-|---------|-------------|
-| `dust-hive up [-a]` | Start temporal + test postgres + test redis + sync + main session |
-| `dust-hive down [-f]` | Stop everything (all envs, temporal, test postgres, test redis, sessions) |
-| `dust-hive temporal start/stop/status` | Control temporal server |
-
-### Environment Lifecycle
-| Command | Description |
-|---------|-------------|
-| `dust-hive spawn [--name NAME]` | Create new environment |
-| `dust-hive warm [NAME]` | Start docker + all services |
-| `dust-hive cool [NAME]` | Pause services + docker, keep SDK (fast restart) |
-| `dust-hive start [NAME]` | Resume stopped environment |
-| `dust-hive stop [NAME]` | Full stop + remove docker containers |
-| `dust-hive destroy NAME` | Remove environment completely |
-
-> **cool vs stop**: `cool` pauses Docker containers (faster re-warm), `stop` removes them (clean slate).
-
-### Development
-| Command | Description |
-|---------|-------------|
-| `dust-hive open [NAME]` | Open zellij terminal session |
-| `dust-hive logs [NAME] [SERVICE]` | View service logs |
-| `dust-hive restart [NAME] SERVICE` | Restart a single service |
-| `dust-hive url [NAME]` | Print the front URL |
-| `dust-hive forward [NAME\|status\|stop]` | Manage OAuth port forwarding |
 
 ## Port Allocation
 
@@ -167,7 +104,7 @@ curl -sf http://localhost:10001/             # core
 
 ## Running Front Tests in Cold Environments
 
-The `front` project requires a Postgres database and Redis to run tests. dust-hive provides **shared test containers** that allow running front tests without warming up the full environment. This is useful for any agent making changes to front that needs to verify tests pass.
+The `front` project requires a Postgres database and Redis to run tests. dust-hive provides **shared test containers** that allow running front tests without warming up the full environment.
 
 ### How it works
 
@@ -176,7 +113,7 @@ The `front` project requires a Postgres database and Redis to run tests. dust-hi
 - Each environment gets its own test database: `dust_front_test_{env_name}`
 - `TEST_FRONT_DATABASE_URI` and `TEST_REDIS_URI` are already set in each environment's `env.sh`
 
-### Running front tests in a cold environment
+### Running front tests
 
 **IMPORTANT**: You must set `NODE_ENV=test` when running front tests.
 
@@ -193,15 +130,6 @@ cd front && NODE_ENV=test npm test --reporter verbose path/to/test.test.ts
 
 **No need to warm the environment** - the shared test Postgres and Redis are always available.
 
-### Test infrastructure lifecycle
-
-| Action | Test Postgres | Test Redis |
-|--------|---------------|------------|
-| `dust-hive spawn` | Database created (`dust_front_test_{env_name}`) | N/A (shared) |
-| `dust-hive destroy` | Database dropped | N/A (shared) |
-| `dust-hive up` | Container started (port 5433) | Container started (port 6479) |
-| `dust-hive down` | Container stopped | Container stopped |
-
 ### Troubleshooting front tests
 
 If front tests fail with database connection errors:
@@ -209,79 +137,31 @@ If front tests fail with database connection errors:
 2. If not running, start it: `docker start dust-hive-test-postgres`
 3. Verify the database exists: `docker exec dust-hive-test-postgres psql -U test -l`
 
-## Services in Each Environment
-
-| Service | Description | Port Offset |
-|---------|-------------|-------------|
-| sdk | TypeScript SDK watcher | - |
-| front | Next.js frontend | +0 |
-| core | Rust core API | +1 |
-| connectors | TypeScript connectors | +2 |
-| oauth | Rust OAuth service | +6 |
-| front-workers | Temporal workers | - |
-
-## File Locations
-
-```
-~/.dust-hive/
-├── config.env           # Your secrets
-├── temporal.pid/log     # Temporal server
-├── forward.pid/log/json # Port forwarder
-├── envs/{NAME}/         # Per-environment state
-│   ├── metadata.json    # Environment info
-│   ├── ports.json       # Port allocation
-│   ├── env.sh           # Port overrides
-│   └── *.pid/*.log      # Service processes/logs
-└── zellij/              # Zellij layouts
-
-~/dust-hive/{NAME}/      # Git worktrees
-└── .envrc               # direnv config (sources env.sh automatically)
-```
-
-## Troubleshooting
-
-```bash
-# Check prerequisites
-dust-hive doctor
-
-# Reload zellij session if stuck
-dust-hive reload [NAME]
-
-# View specific service logs
-dust-hive logs [NAME] front -f
-
-# Check binary cache status
-dust-hive cache
-
-# Sync with main (pull, rebuild binaries, refresh deps)
-dust-hive sync
-```
-
 ## Known Issues
 
-### Node modules structure in dust-hive environments
+### Node modules structure
 
 In dust-hive environments, `node_modules` for `front` and `connectors` uses a **shallow copy** structure:
 - A real `node_modules` directory with symlinks to packages from the main repo
 - `@dust-tt/client` is overridden to point to the worktree's SDK (ensuring correct type resolution)
 
-**Running `npm install` requires manual cleanup**: The shallow copy structure is incompatible with npm's expectations. Before running `npm install`, you must delete `node_modules` first:
+**Running `npm install` requires manual cleanup**:
 ```bash
 rm -rf node_modules && npm install
 ```
 
 ### SDK watcher doesn't detect changes after git rebase
 
-The SDK watcher uses nodemon which relies on filesystem events. When running `git rebase`, `git pull`, or `git checkout`, nodemon may not detect the file changes due to how git updates files (fsevents on macOS can miss rapid file operations).
+The SDK watcher uses nodemon which relies on filesystem events. When running `git rebase`, `git pull`, or `git checkout`, nodemon may not detect file changes.
 
-**Symptoms**: Type errors in front about missing types that should exist in the SDK (e.g., new enum values, new fields).
+**Symptoms**: Type errors in front about missing types that should exist in the SDK.
 
 **Solution**: Restart the SDK watcher after git operations that change SDK files:
 ```bash
 dust-hive restart [ENV_NAME] sdk
 ```
 
-Alternatively, manually trigger a rebuild by touching the SDK source:
+Or manually trigger a rebuild:
 ```bash
 touch sdks/js/src/types.ts
 ```

--- a/x/henry/dust-hive/CLAUDE.md
+++ b/x/henry/dust-hive/CLAUDE.md
@@ -33,7 +33,7 @@ bun run test         # bun test
 - **Language**: TypeScript (strict mode)
 - **Linting/Formatting**: Biome (strict rules)
 - **Testing**: Bun test
-- **Terminal UI**: Zellij (viewer only)
+- **Terminal UI**: Zellij or tmux (viewer only, configurable via settings)
 - **Process Management**: CLI-managed daemons with PID files
 - **Infrastructure**: Docker Compose
 
@@ -131,20 +131,23 @@ tests/
 ## Key Architecture Decisions
 
 1. **No mprocs** - All services run as background daemons managed by the CLI
-2. **Zellij is passive** - Only shows logs via `tail -F`, closing it doesn't stop services
+2. **Multiplexer is passive** - Only shows logs via `tail -F`, closing it doesn't stop services
 3. **Port isolation** - Base port 10000, +1000 per environment
-4. **Git worktrees** - Each env gets a new branch: `NAME-workspace`
+4. **Git worktrees** - Each env gets a branch named `${branchPrefix}${envName}` (configurable via `--branch-name`)
 5. **Managed Temporal** - `dust-hive up` runs Temporal as a daemon, namespaces created per env
+6. **Multiplexer support** - Both zellij (default) and tmux are supported via `~/.dust-hive/settings.json`
 
 ## Commands Reference
+
+> **Tip**: Run `dust-hive <command> --help` for all available options (e.g., `--force`, `--compact`, `--unified-logs`).
 
 ### Managed Services (global)
 
 | Command | Description |
 |---------|-------------|
-| `up [-a]` | Start temporal + test postgres + test redis + sync + create main session (from main repo, requires clean main branch) |
+| `up [-a] [-f]` | Start temporal + test postgres + test redis + sync + create main session (from main repo, requires clean main branch) |
 | `down [-f]` | Stop all envs, temporal, test postgres, test redis, and sessions (requires confirmation or --force) |
-| `temporal start/stop/restart/status` | Direct temporal server control |
+| `temporal start\|stop\|restart\|status\|logs` | Direct temporal server control |
 
 ### Environment Commands
 
@@ -163,7 +166,8 @@ tests/
 | `status` | Show service health |
 | `logs` | View service logs |
 | `url` | Print front URL |
-| `doctor` | Check prerequisites |
+| `setup` | Check prerequisites and guide initial setup |
+| `doctor` | Check prerequisites (non-interactive) |
 | `cache` | Show binary cache status |
 | `forward` | Manage OAuth port forwarding (ports 3000,3001,3002,3006 → env) |
 | `sync` | Pull latest main, rebuild binaries, refresh deps |

--- a/x/henry/dust-hive/README.md
+++ b/x/henry/dust-hive/README.md
@@ -39,6 +39,12 @@ brew install cmake protobuf
 
 # sccache (optional - Rust compilation cache, speeds up rebuilds)
 brew install sccache
+
+# fzf (optional - used by `dust-hive open` when NAME is omitted)
+brew install fzf
+
+# psql (required for seed-config command)
+brew install postgresql
 ```
 
 > **Linux users**: Also install `lsof` if not already available (`sudo apt install lsof`)
@@ -101,7 +107,7 @@ mkdir -p ~/.dust-hive
 cp /path/to/your/.env ~/.dust-hive/config.env
 ```
 
-The `config.env` must use `export` statements (e.g., `export API_KEY=xxx`). It contains all the environment variables from your local dev setup (API keys, OAuth secrets, etc.). See `local-dev-setup.md` for the full list.
+The `config.env` must use `export` statements (e.g., `export API_KEY=xxx`). It contains all the environment variables from your local dev setup (API keys, OAuth secrets, etc.).
 
 2. **Start managed services** (temporal server + main zellij session):
 
@@ -143,16 +149,15 @@ dust-hive down
 
 ## Commands
 
+> **Tip**: Run `dust-hive <command> --help` for all available options.
+
 ### Managed Services
 
 | Command | Description |
 |---------|-------------|
-| `up [-a\|--attach]` | Start temporal + test postgres + test redis + sync + create main session (from main repo) |
-| `down [-f\|--force]` | Stop all envs, temporal, test postgres, test redis, and sessions |
-| `temporal start` | Start Temporal server only |
-| `temporal stop` | Stop Temporal server only |
-| `temporal restart` | Restart Temporal server |
-| `temporal status` | Show Temporal server status |
+| `up [-a] [-f]` | Start temporal + test postgres + test redis + sync + create main session (from main repo) |
+| `down [-f]` | Stop all envs, temporal, test postgres, test redis, and sessions |
+| `temporal start\|stop\|restart\|status\|logs` | Manage Temporal server |
 
 ### Environment Commands
 
@@ -163,7 +168,7 @@ dust-hive down
 | `cool [NAME]` | Pause services + docker, keep SDK (fast restart) |
 | `start [NAME]` | Resume stopped environment (when NAME provided) |
 | `stop [NAME]` | Full stop + remove docker containers |
-| `destroy NAME [--force]` | Remove environment completely |
+| `destroy [NAME] [--force]` | Remove environment completely (multi-select if NAME omitted) |
 | `restart [NAME] SERVICE` | Restart a single service |
 | `open [NAME]` | Open zellij terminal session |
 | `reload [NAME]` | Kill and reopen zellij session |
@@ -176,11 +181,14 @@ dust-hive down
 
 | Command | Description |
 |---------|-------------|
-| `doctor` | Check prerequisites |
+| `setup [-y]` | Check prerequisites and guide initial setup (run this first!) |
+| `doctor` | Check prerequisites (non-interactive) |
 | `cache` | Show binary cache status |
 | `forward [NAME\|status\|stop]` | Manage OAuth port forwarding |
-| `sync` | Pull latest main, rebuild binaries, refresh deps |
+| `sync [-f]` | Pull latest main, rebuild binaries, refresh deps |
 | `seed-config <postgres-uri>` | Extract user data from existing DB for seeding |
+
+**Aliases**: Most commands have short aliases (e.g., `s` for spawn, `o` for open, `w` for warm). Run `dust-hive --help` to see all aliases.
 
 > **Tip**: When `NAME` is omitted, you'll get an interactive picker to select an environment.
 > It pre-selects the current environment (if you're in a worktree) or the last one you used.
@@ -250,21 +258,44 @@ dust-hive forward env-b     # Switch OAuth to env-b
 If the ports are already owned by another dust-hive forwarder, `dust-hive forward NAME` will switch it automatically.
 If those ports are owned by a different process, the command will fail with details so you can stop it.
 
+## Preconditions
+
+### `dust-hive up` and `dust-hive sync`
+
+These commands must be run from the **main Dust repository** (not a worktree):
+
+1. **Not in a worktree**: Run from `~/path/to/dust` (the main clone)
+2. **On main branch**: Run `git checkout main` first
+3. **Clean working directory**: Commit or stash changes (untracked files OK)
+
+If you see errors about "cannot run from worktree" or "checkout main first", these preconditions aren't met.
+
 ## Configuration settings
 
-You can customize the behavior of `dust-hive` by editing `~/.dust-hive/settings.json`.
-Two options are available:
-* branchPrefix: Prefix to add to branch names (e.g., "tom-" creates branches like "tom-myenv")
-* useGitSpice: Use git-spice to manage stacks (requires git-spice installed and configured)
+You can customize the behavior of `dust-hive` by editing `~/.dust-hive/settings.json`:
 
-## Zellij Sessions
+```json
+{
+  "multiplexer": "zellij",
+  "branchPrefix": "tom-",
+  "useGitSpice": false
+}
+```
+
+* **multiplexer**: Terminal multiplexer to use (`"zellij"` or `"tmux"`, default: `"zellij"`)
+* **branchPrefix**: Prefix to add to branch names (e.g., `"tom-"` creates branches like `"tom-myenv"`)
+* **useGitSpice**: Use git-spice to manage stacks (requires git-spice installed and configured)
+
+## Terminal Sessions (zellij/tmux)
+
+> **Note**: The following describes the default zellij experience. If you set `"multiplexer": "tmux"` in settings, sessions use tmux instead (with different shortcuts).
 
 ### Main Session
 
 When you run `dust-hive up`, a main session (`dust-hive-main`) is created with:
 
 - **main** - Shell at the repo root
-- **temporal** - Temporal server logs with Ctrl+C menu (r=restart, c=clear, q=quit)
+- **temporal** - Temporal server logs (runs `dust-hive temporal logs`)
 
 Attach to it with `dust-hive up -a` or by running zellij directly: `zellij attach dust-hive-main`.
 
@@ -295,14 +326,6 @@ dust-hive spawn myenv --warm --no-attach
 ```
 
 This creates the zellij session and starts services, but leaves you in your current terminal. Use `dust-hive open myenv` to attach later.
-
-### Zellij Shortcuts
-
-- `Ctrl+o` then `d` - Detach (keeps services running)
-- `Ctrl+o` then `w` - Session manager
-- `Ctrl+o` then `[` - Scroll mode (arrow keys to scroll)
-- `Alt+n` - Next tab
-- `Alt+p` - Previous tab
 
 ## Workflow Examples
 
@@ -397,82 +420,13 @@ dust-hive logs myenv front
 dust-hive logs myenv front -f
 ```
 
-## Performance
+### Running `npm install`
 
-dust-hive uses aggressive caching and parallelization:
-
-| Operation | Time |
-|-----------|------|
-| `spawn` | ~7 seconds |
-| `warm` (first) | ~80 seconds |
-| `warm` (subsequent) | ~18 seconds |
-
-First warm is slower because it initializes databases (Postgres, Qdrant, Elasticsearch). Subsequent warms are fast because services just reconnect to existing data.
-
-### Cache System
-
-The cache uses your main Dust repo as source:
-
-1. **Node modules**: Shallow copy with symlinks from main repo (see below)
-2. **Cargo target**: Symlinked from main repo (shared compilation + linking cache)
-3. **Rust binaries**: Pre-compiled for init scripts (qdrant, elasticsearch, init_db)
-
-#### Node modules structure
-
-For `front` and `connectors`, dust-hive uses a **shallow copy** approach:
-- Creates a real `node_modules` directory in the worktree
-- Symlinks all packages from the main repo's node_modules
-- **Exception**: `@dust-tt/client` points to the worktree's SDK (not main repo's)
-
-This ensures TypeScript and runtime resolve `@dust-tt/client` from the worktree's SDK, preventing type mismatches when your branch has newer SDK types than main.
-
-For `sdks/js`, a simple symlink is used (it IS the SDK).
-
-> **Note**: To run `npm install` in a dust-hive worktree, you must first delete `node_modules`:
-> ```bash
-> rm -rf node_modules && npm install
-> ```
-> This is necessary because the shallow copy structure (symlinks) is incompatible with npm's expectations.
-
-> **sccache** (optional but recommended): When worktree code differs from main, cargo recompiles. sccache caches these compilations by content hash, so rebuilding after switching branches is faster.
-
+To run `npm install` in a dust-hive worktree, you must first delete `node_modules`:
 ```bash
-# Check cache status
-dust-hive cache
-
-# Update main repo with latest, rebuild binaries, refresh deps
-dust-hive sync
+rm -rf node_modules && npm install
 ```
-
-## File Locations
-
-```
-~/.dust-hive/
-├── config.env                 # Your secrets (create this)
-├── settings.json              # Your dust-hive settings
-├── temporal.pid               # Temporal server process ID
-├── temporal.log               # Temporal server logs
-├── forward.pid                # Forwarder process ID
-├── forward.log                # Forwarder logs
-├── forward.json               # Forwarder state (target env)
-├── cache/
-│   └── source.path            # Path to cache source repo
-├── envs/
-│   └── NAME/
-│       ├── env.sh             # Port overrides
-│       ├── ports.json         # Port allocation
-│       ├── metadata.json      # Environment info
-│       ├── *.pid              # Process IDs
-│       └── *.log              # Service logs
-├── scripts/
-│   └── service-logs-tui.sh    # Interactive service logs viewer
-└── zellij/
-    ├── layout.kdl             # Environment zellij layout
-    └── main-layout.kdl        # Main session layout
-
-~/dust-hive/
-└── NAME/                      # Git worktree
-```
+This is necessary because dust-hive uses a shallow copy structure (symlinks) that is incompatible with npm's expectations.
 
 ## Development
 

--- a/x/henry/dust-hive/src/index.ts
+++ b/x/henry/dust-hive/src/index.ts
@@ -254,13 +254,13 @@ cli.command("url [name]", "Print front URL").action(async (name: string | undefi
 });
 
 cli
-  .command("setup", "Check and install prerequisites (run this first!)")
-  .option("-y, --non-interactive", "Run in non-interactive mode (same as doctor)")
+  .command("setup", "Check prerequisites and guide initial setup (run this first!)")
+  .option("-y, --non-interactive", "Run without prompts (CI-friendly)")
   .action(async (options: { nonInteractive?: boolean }) => {
     await prepareAndRun(setupCommand({ nonInteractive: Boolean(options.nonInteractive) }));
   });
 
-cli.command("doctor", "Check prerequisites (alias for setup)").action(async () => {
+cli.command("doctor", "Check prerequisites (non-interactive)").action(async () => {
   await prepareAndRun(doctorCommand());
 });
 
@@ -295,7 +295,7 @@ cli
 
 // Temporal subcommands
 cli
-  .command("temporal [subcommand]", "Manage Temporal server (start|stop|restart|status)")
+  .command("temporal [subcommand]", "Manage Temporal server (start|stop|restart|status|logs)")
   .action(async (subcommand: string | undefined) => {
     await prepareAndRun(temporalCommand(subcommand));
   });


### PR DESCRIPTION
## Description

Comprehensive documentation update for dust-hive based on code review. Fixes inaccuracies, adds missing features, and streamlines verbose sections.

### Key fixes:
- **CLI help text**: Fixed misleading descriptions for `setup`, `doctor`, and `temporal` commands
- **Missing documentation**: Added `setup` command, `temporal logs`, `sync -f`, preconditions for `up`/`sync`
- **Incorrect content**: Fixed branch naming in CLAUDE.md, removed broken `local-dev-setup.md` reference
- **New features**: Documented `multiplexer` setting (tmux support), added missing prerequisites (fzf, psql)
- **Streamlined**: Removed verbose sections (File Locations, Performance timings, Zellij shortcuts) that added noise without value
- **SKILL.md**: Refocused for agent use - removed CLI command docs, kept only what agents need (environment detection, running tests, known issues)

## Tests

- Ran `bun run typecheck` on dust-hive - passes
- Verified CLI help output shows updated descriptions

## Risk

Low - documentation-only changes except for CLI help text strings in `src/index.ts`.

## Deploy Plan

No deployment needed - documentation changes only.