### PR TITLE
chore(dust-hive): remove dead code and unused exports

### DIFF
--- a/x/henry/dust-hive/README.md
+++ b/x/henry/dust-hive/README.md
@@ -465,7 +465,7 @@ dust-hive sync
 │       ├── *.pid              # Process IDs
 │       └── *.log              # Service logs
 ├── scripts/
-│   └── watch-logs.sh          # Log watcher (supports --temporal flag)
+│   └── service-logs-tui.sh    # Interactive service logs viewer
 └── zellij/
     ├── layout.kdl             # Environment zellij layout
     └── main-layout.kdl        # Main session layout

--- a/x/henry/dust-hive/src/lib/forward.ts
+++ b/x/henry/dust-hive/src/lib/forward.ts
@@ -86,12 +86,6 @@ async function writeForwarderState(state: ForwarderState): Promise<void> {
   await Bun.write(FORWARDER_STATE_PATH, JSON.stringify(state, null, 2));
 }
 
-// Check if forwarder is running
-export async function isForwarderRunning(): Promise<boolean> {
-  const pid = await readForwarderPid();
-  return pid !== null;
-}
-
 // Stop forwarder if running
 export async function stopForwarder(): Promise<boolean> {
   const pid = await readForwarderPid();

--- a/x/henry/dust-hive/src/lib/init.ts
+++ b/x/henry/dust-hive/src/lib/init.ts
@@ -4,15 +4,12 @@ import { type InitBinary, binaryExists, getBinaryPath, getCacheSource } from "./
 import { buildPostgresUri, loadEnvVars } from "./env-utils";
 import type { Environment } from "./environment";
 import { logger } from "./logger";
-import { SEED_USER_PATH, getEnvFilePath, getWorktreeDir } from "./paths";
+import { getEnvFilePath, getWorktreeDir } from "./paths";
 import { runSqlSeed } from "./seed";
 import { buildShell } from "./shell";
 import { SEARCH_ATTRIBUTES, TEMPORAL_NAMESPACE_CONFIG, getTemporalNamespaces } from "./temporal";
 
 export { getTemporalNamespaces } from "./temporal";
-
-// Re-export from paths.ts for backwards compatibility
-export { SEED_USER_PATH } from "./paths";
 
 // Run a binary directly or fall back to cargo run
 async function runBinary(
@@ -529,11 +526,6 @@ export async function createTemporalNamespaces(env: Environment): Promise<void> 
   }
 
   logger.success("Temporal search attributes created");
-}
-
-export async function hasSeedConfig(): Promise<boolean> {
-  const file = Bun.file(SEED_USER_PATH);
-  return file.exists();
 }
 
 export async function runSeedScript(env: Environment): Promise<boolean> {

--- a/x/henry/dust-hive/src/lib/multiplexer/tmux.ts
+++ b/x/henry/dust-hive/src/lib/multiplexer/tmux.ts
@@ -320,6 +320,3 @@ export class TmuxAdapter implements MultiplexerAdapter {
     return getPlatformInstallInstructions("tmux");
   }
 }
-
-// Export singleton instance
-export const tmuxAdapter = new TmuxAdapter();

--- a/x/henry/dust-hive/src/lib/multiplexer/zellij.ts
+++ b/x/henry/dust-hive/src/lib/multiplexer/zellij.ts
@@ -13,7 +13,7 @@ import type {
   MultiplexerAdapter,
   MultiplexerType,
 } from "./types";
-import { MAIN_SESSION_NAME, SESSION_PREFIX, TAB_NAMES } from "./types";
+import { SESSION_PREFIX, TAB_NAMES } from "./types";
 
 /**
  * Base directory for zellij layouts
@@ -347,9 +347,3 @@ ${tabTemplate}
     return getPlatformInstallInstructions("zellij");
   }
 }
-
-// Export singleton instance
-export const zellijAdapter = new ZellijAdapter();
-
-// Export the main session name for convenience
-export { MAIN_SESSION_NAME };

--- a/x/henry/dust-hive/src/lib/paths.ts
+++ b/x/henry/dust-hive/src/lib/paths.ts
@@ -12,12 +12,6 @@ export const DUST_HIVE_ENVS = join(DUST_HIVE_HOME, "envs");
 export const DUST_HIVE_SCRIPTS = join(DUST_HIVE_HOME, "scripts");
 export const DUST_HIVE_WORKTREES = join(homedir(), "dust-hive");
 
-/**
- * @deprecated Use multiplexer adapter's getLayoutDirectory() instead
- * Kept for backward compatibility during migration
- */
-export const DUST_HIVE_ZELLIJ = join(DUST_HIVE_HOME, "zellij");
-
 // Global config
 export const CONFIG_ENV_PATH = join(DUST_HIVE_HOME, "config.env");
 export const SETTINGS_PATH = join(DUST_HIVE_HOME, "settings.json");
@@ -45,12 +39,6 @@ export const TEST_POSTGRES_PASSWORD = "test";
 // Shared test Redis paths (global, not per-env)
 export const TEST_REDIS_CONTAINER_NAME = "dust-hive-test-redis";
 export const TEST_REDIS_PORT = 6479;
-
-/**
- * @deprecated Import MAIN_SESSION_NAME from "./multiplexer" instead
- * Kept for backward compatibility during migration
- */
-export const MAIN_SESSION_NAME = "dust-hive-main";
 
 // Seed user configuration
 export const SEED_USER_PATH = join(DUST_HIVE_HOME, "seed-user.json");
@@ -96,19 +84,7 @@ export function getLogPath(name: string, service: string): string {
   return join(getEnvDir(name), `${service}.log`);
 }
 
-/**
- * @deprecated Use multiplexer adapter's getLayoutPath() instead
- * Kept for backward compatibility during migration
- */
-export function getZellijLayoutPath(): string {
-  return join(DUST_HIVE_ZELLIJ, "layout.kdl");
-}
-
 // Scripts
-export function getWatchScriptPath(): string {
-  return join(DUST_HIVE_SCRIPTS, "watch-logs.sh");
-}
-
 export function getServiceLogsTuiPath(): string {
   return join(DUST_HIVE_SCRIPTS, "service-logs-tui.sh");
 }

--- a/x/henry/dust-hive/src/lib/settings.ts
+++ b/x/henry/dust-hive/src/lib/settings.ts
@@ -27,11 +27,6 @@ export async function loadSettings(): Promise<Settings> {
   }
 }
 
-// Save settings to disk
-export async function saveSettings(settings: Settings): Promise<void> {
-  await Bun.write(SETTINGS_PATH, `${JSON.stringify(settings, null, 2)}\n`);
-}
-
 // Get the branch name for an environment
 export function getBranchName(envName: string, settings: Settings): string {
   const prefix = settings.branchPrefix ?? "";

--- a/x/henry/dust-hive/src/lib/test-postgres.ts
+++ b/x/henry/dust-hive/src/lib/test-postgres.ts
@@ -136,22 +136,6 @@ export async function stopTestPostgres(): Promise<{ success: boolean; wasRunning
   return { success: proc.exitCode === 0, wasRunning: true };
 }
 
-// Remove the shared test postgres container (including volumes)
-export async function removeTestPostgres(): Promise<{ success: boolean }> {
-  // Stop first if running
-  await stopTestPostgres();
-
-  // Remove container
-  const proc = Bun.spawn(["docker", "rm", "-v", TEST_POSTGRES_CONTAINER_NAME], {
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  await proc.exited;
-
-  // Success even if container didn't exist
-  return { success: true };
-}
-
 // Get the test database name for an environment
 export function getTestDatabaseName(envName: string): string {
   // Sanitize env name for postgres (replace dashes with underscores)

--- a/x/henry/dust-hive/src/lib/test-redis.ts
+++ b/x/henry/dust-hive/src/lib/test-redis.ts
@@ -124,22 +124,6 @@ export async function stopTestRedis(): Promise<{ success: boolean; wasRunning: b
   return { success: proc.exitCode === 0, wasRunning: true };
 }
 
-// Remove the shared test Redis container
-export async function removeTestRedis(): Promise<{ success: boolean }> {
-  // Stop first if running
-  await stopTestRedis();
-
-  // Remove container
-  const proc = Bun.spawn(["docker", "rm", "-v", TEST_REDIS_CONTAINER_NAME], {
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  await proc.exited;
-
-  // Success even if container didn't exist
-  return { success: true };
-}
-
 // Get the connection URI for the test Redis
 export function getTestRedisUri(): string {
   return `redis://localhost:${TEST_REDIS_PORT}`;

--- a/x/henry/dust-hive/tests/lib/paths.test.ts
+++ b/x/henry/dust-hive/tests/lib/paths.test.ts
@@ -7,7 +7,6 @@ import {
   DUST_HIVE_ENVS,
   DUST_HIVE_HOME,
   DUST_HIVE_WORKTREES,
-  DUST_HIVE_ZELLIJ,
   findRepoRoot,
   getDockerOverridePath,
   getEnvDir,
@@ -18,7 +17,6 @@ import {
   getPidPath,
   getPortsPath,
   getWorktreeDir,
-  getZellijLayoutPath,
 } from "../../src/lib/paths";
 
 describe("paths", () => {
@@ -31,10 +29,6 @@ describe("paths", () => {
 
     it("sets DUST_HIVE_ENVS to ~/.dust-hive/envs", () => {
       expect(DUST_HIVE_ENVS).toBe(join(home, ".dust-hive", "envs"));
-    });
-
-    it("sets DUST_HIVE_ZELLIJ to ~/.dust-hive/zellij", () => {
-      expect(DUST_HIVE_ZELLIJ).toBe(join(home, ".dust-hive", "zellij"));
     });
 
     it("sets DUST_HIVE_WORKTREES to ~/dust-hive", () => {
@@ -130,12 +124,6 @@ describe("paths", () => {
       expect(getLogPath("test", "front-workers")).toBe(
         join(home, ".dust-hive", "envs", "test", "front-workers.log")
       );
-    });
-  });
-
-  describe("getZellijLayoutPath", () => {
-    it("returns path to zellij layout.kdl", () => {
-      expect(getZellijLayoutPath()).toBe(join(home, ".dust-hive", "zellij", "layout.kdl"));
     });
   });
 


### PR DESCRIPTION
## Description

Removes unused functions, singleton exports, and deprecated exports from dust-hive that were identified during a comprehensive code review.

**Removed dead functions:**
- `saveSettings` in settings.ts (no command uses it)
- `getWatchScriptPath` in paths.ts (watch-logs.sh script not generated)
- `isForwarderRunning` in forward.ts (unused wrapper around readForwarderPid)
- `hasSeedConfig` in init.ts (never called)
- `removeTestPostgres` in test-postgres.ts (cleanup function never invoked)
- `removeTestRedis` in test-redis.ts (cleanup function never invoked)

**Removed unused singleton exports:**
- `zellijAdapter` in multiplexer/zellij.ts (code uses factory pattern via getConfiguredMultiplexer)
- `tmuxAdapter` in multiplexer/tmux.ts (same reason)

**Removed deprecated exports:**
- `DUST_HIVE_ZELLIJ` constant (superseded by multiplexer adapter's getLayoutDirectory)
- `MAIN_SESSION_NAME` from paths.ts (canonical export moved to multiplexer/types.ts)
- `getZellijLayoutPath` function (superseded by multiplexer adapter's getLayoutPath)
- Dead `SEED_USER_PATH` re-export from init.ts (consumers import directly from paths.ts)

## Tests

- All 170 existing tests pass
- TypeScript type checking passes
- Biome linting passes
- Ran full `bun run check` suite

## Risk

**Low risk**. These are purely dead code removals:
- Functions removed were never called in the codebase
- Singleton exports removed were never imported (factory pattern used instead)
- Deprecated exports were only referenced by tests (now removed) - actual consumers use new locations

No behavioral changes. Safe to rollback if any external consumers are discovered.

## Deploy Plan

Standard deployment. No runtime impact as removed code was never executed.