### PR TITLE
Do a mutate to refresh the message UX whenever an agent message is done

### DIFF
--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -14,6 +14,7 @@ import React, {
   useRef,
   useState,
 } from "react";
+import { useSWRConfig } from "swr";
 
 import { AgentInputBar } from "@app/components/assistant/conversation/AgentInputBar";
 import { ConversationErrorDisplay } from "@app/components/assistant/conversation/ConversationError";
@@ -108,6 +109,7 @@ export const ConversationViewer = ({
       VirtuosoMessageListMethods<VirtuosoMessage, VirtuosoMessageListContext>
     >(null);
   const sendNotification = useSendNotification();
+  const { mutate: globalMutate } = useSWRConfig();
 
   const {
     conversation,
@@ -414,6 +416,9 @@ export const ConversationViewer = ({
               },
               { revalidate: false }
             );
+
+            // Refresh trial message usage count after an agent message completes.
+            void globalMutate(`/api/w/${owner.sId}/trial-message-usage`);
             break;
           default:
             ((t: never) => {
@@ -425,10 +430,12 @@ export const ConversationViewer = ({
     [
       conversationId,
       debouncedMarkAsRead,
+      globalMutate,
       mutateConversation,
       mutateConversationParticipants,
       mutateConversations,
       mutateMessages,
+      owner.sId,
       user.sId,
     ]
   );

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -14,7 +14,6 @@ import React, {
   useRef,
   useState,
 } from "react";
-import { useSWRConfig } from "swr";
 
 import { AgentInputBar } from "@app/components/assistant/conversation/AgentInputBar";
 import { ConversationErrorDisplay } from "@app/components/assistant/conversation/ConversationError";
@@ -40,6 +39,7 @@ import { getLightAgentMessageFromAgentMessage } from "@app/lib/api/assistant/cit
 import type { AgentMessageFeedbackType } from "@app/lib/api/assistant/feedback";
 import { getUpdatedParticipantsFromEvent } from "@app/lib/client/conversation/event_handlers";
 import type { DustError } from "@app/lib/error";
+import { AgentMessageCompletedEvent } from "@app/lib/notifications/events";
 import {
   useConversation,
   useConversationFeedbacks,
@@ -109,7 +109,6 @@ export const ConversationViewer = ({
       VirtuosoMessageListMethods<VirtuosoMessage, VirtuosoMessageListContext>
     >(null);
   const sendNotification = useSendNotification();
-  const { mutate: globalMutate } = useSWRConfig();
 
   const {
     conversation,
@@ -417,8 +416,7 @@ export const ConversationViewer = ({
               { revalidate: false }
             );
 
-            // Refresh trial message usage count after an agent message completes.
-            void globalMutate(`/api/w/${owner.sId}/trial-message-usage`);
+            window.dispatchEvent(new AgentMessageCompletedEvent());
             break;
           default:
             ((t: never) => {
@@ -430,12 +428,10 @@ export const ConversationViewer = ({
     [
       conversationId,
       debouncedMarkAsRead,
-      globalMutate,
       mutateConversation,
       mutateConversationParticipants,
       mutateConversations,
       mutateMessages,
-      owner.sId,
       user.sId,
     ]
   );

--- a/front/lib/notifications/events.ts
+++ b/front/lib/notifications/events.ts
@@ -5,3 +5,11 @@ export class ConversationsUpdatedEvent extends CustomEvent<void> {
     super(CONVERSATIONS_UPDATED_EVENT);
   }
 }
+
+export const AGENT_MESSAGE_COMPLETED_EVENT = "agent-message-completed";
+
+export class AgentMessageCompletedEvent extends CustomEvent<void> {
+  constructor() {
+    super(AGENT_MESSAGE_COMPLETED_EVENT);
+  }
+}


### PR DESCRIPTION
## Description

Do a mutate on the message limit UI when an agent message completes to make sure that UI is refreshed and showing the latest message count.

## Tests

Manual. I made sure that this doesn't result in any requests when the trial message count UI is not showing.

## Risk

Low

## Deploy Plan

Front