### PR TITLE
Add day of week reference to util + calendar tool

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/common_utilities.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/common_utilities.ts
@@ -152,7 +152,10 @@ async function createServer(
           parts.push(`UNIX (ms): ${now.getTime()}`);
         }
         if (formats.has("locale")) {
-          parts.push(`Locale: ${now.toLocaleString()}`);
+          const dayOfWeek = now.toLocaleDateString("en-US", {
+            weekday: "long",
+          });
+          parts.push(`Locale: ${now.toLocaleString()} (${dayOfWeek})`);
         }
 
         return new Ok([

--- a/front/lib/api/actions/servers/google_calendar/metadata.ts
+++ b/front/lib/api/actions/servers/google_calendar/metadata.ts
@@ -259,7 +259,7 @@ export const GOOGLE_CALENDAR_SERVER_INFO = {
   icon: "GcalLogo" as const,
   documentationUrl: "https://docs.dust.tt/docs/google-calendar",
   instructions:
-    "By default when creating a meeting, (1) set the calling user as the organizer and an attendee (2) check availability for attendees using the check_availability tool (3) use get_user_timezones to check attendee timezones for better scheduling.",
+    "By default when creating a meeting, (1) set the calling user as the organizer and an attendee (2) check availability for attendees using the check_availability tool (3) use get_user_timezones to check attendee timezones for better scheduling. Always call get_current_time when users reference relative dates or days of the week (e.g., 'monday', 'tomorrow', 'next week') to accurately resolve the date before creating or scheduling events.",
 };
 
 export const GOOGLE_CALENDAR_SERVER = {


### PR DESCRIPTION
## Description

* Adding day of week return from get current time
* Adding info to obtain that as reference in calendar tool instructions

## Tests

```
Locale: 1/16/2026, 2:26:23 PM (Friday)
```

## Risk

* low

## Deploy Plan

* deploy front