### PR TITLE
Fix navigation labels on dark theme

### DIFF
--- a/sparkle/src/components/NavigationList.tsx
+++ b/sparkle/src/components/NavigationList.tsx
@@ -282,7 +282,7 @@ const NavigationListLabel = React.forwardRef<
 NavigationListLabel.displayName = "NavigationListLabel";
 
 const variantCompactStyles = cva(
-  "s-flex s-px-2 s-py-1 s-pl-3 s-text-[10px] s-font-semibold s-text-foreground s-pt-3 s-uppercase s-whitespace-nowrap s-overflow-hidden s-text-ellipsis",
+  "s-flex s-px-2 s-py-1 s-pl-3 s-text-[10px] s-font-semibold s-text-foreground dark:s-text-foreground-night s-pt-3 s-uppercase s-whitespace-nowrap s-overflow-hidden s-text-ellipsis",
   {
     variants: {
       isSticky: {


### PR DESCRIPTION
## Description

This fixes "YESTERDAY", "LAST WEEK", etc. color on dark themes

### Before
<img width="278" height="278" alt="Screenshot 2026-01-16 at 22 43 31" src="https://github.com/user-attachments/assets/0f29ca26-9518-49fd-a5bb-0440159c9a5e" />

### After
<img width="302" height="305" alt="Screenshot 2026-01-16 at 22 46 58" src="https://github.com/user-attachments/assets/892bc1d1-da92-4f7a-a7f1-88604d949655" />


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
