### PR TITLE
feat(oauth): allow users to override Snowflake role during personal auth

### DIFF
--- a/front/components/actions/mcp/MCPServerOAuthConnexion.tsx
+++ b/front/components/actions/mcp/MCPServerOAuthConnexion.tsx
@@ -96,27 +96,23 @@ export function MCPServerOAuthConnexion({
       return;
     }
 
-    // Fetch credential inputs for the selected provider/use case.
-    const fetchCredentialInputs = async () => {
-      const credentialInputs = await getProviderRequiredOAuthCredentialInputs({
-        provider: authorization.provider,
-        useCase: effectiveUseCase,
-      });
-      setInputs(credentialInputs);
+    // Get credential inputs for the selected provider/use case.
+    const credentialInputs = getProviderRequiredOAuthCredentialInputs({
+      provider: authorization.provider,
+      useCase: effectiveUseCase,
+    });
+    setInputs(credentialInputs);
 
-      // Pre-populate credentials with default values from the provider.
-      if (credentialInputs) {
-        const nextCredentials: OAuthCredentials = {};
-        for (const [key, inputData] of Object.entries(credentialInputs)) {
-          if (isSupportedOAuthCredential(key)) {
-            nextCredentials[key] = inputData.value ?? "";
-          }
+    // Pre-populate credentials with default values from the provider.
+    if (credentialInputs) {
+      const nextCredentials: OAuthCredentials = {};
+      for (const [key, inputData] of Object.entries(credentialInputs)) {
+        if (isSupportedOAuthCredential(key)) {
+          nextCredentials[key] = inputData.value ?? "";
         }
-        credentialsField.onChange(nextCredentials);
       }
-    };
-
-    void fetchCredentialInputs();
+      credentialsField.onChange(nextCredentials);
+    }
   }, [authorization, useCaseField, credentialsField, useCase]);
 
   // Validate credentials based on dynamic requirements.

--- a/front/components/agent_builder/PersonalConnectionRequiredDialog.tsx
+++ b/front/components/agent_builder/PersonalConnectionRequiredDialog.tsx
@@ -14,8 +14,12 @@ import {
   Icon,
   LockIcon,
 } from "@dust-tt/sparkle";
-import React, { useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 
+import {
+  areCredentialOverridesValid,
+  PersonalAuthCredentialOverrides,
+} from "@app/components/oauth/PersonalAuthCredentialOverrides";
 import { getIcon } from "@app/components/resources/resources_icons";
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
@@ -24,6 +28,7 @@ import {
   useMCPServerViewsWithPersonalConnections,
 } from "@app/lib/swr/mcp_servers";
 import type { LightWorkspaceType } from "@app/types";
+import { getOverridablePersonalAuthInputs } from "@app/types";
 
 interface DialogState {
   isOpen: boolean;
@@ -103,6 +108,29 @@ export function PersonalConnectionRequiredDialog({
 }) {
   const { createPersonalConnection } = useCreatePersonalConnection(owner);
   const [isConnecting, setIsConnecting] = useState(false);
+  const [credentialOverridesMap, setCredentialOverridesMap] = useState<
+    Record<string, Record<string, string>>
+  >({});
+
+  useEffect(() => {
+    if (!isOpen) {
+      setCredentialOverridesMap({});
+    }
+  }, [isOpen]);
+
+  const setOverrideValue = useCallback(
+    (serverId: string, key: string, value: string) => {
+      setCredentialOverridesMap((prev) => ({
+        ...prev,
+        [serverId]: {
+          ...prev[serverId],
+          [key]: value,
+        },
+      }));
+    },
+    []
+  );
+
   const disconnectedCount = useMemo(() => {
     return mcpServerViewsWithPersonalConnections.filter(
       ({ isAlreadyConnected }) => !isAlreadyConnected
@@ -147,50 +175,89 @@ export function PersonalConnectionRequiredDialog({
 
           <DialogDescription>
             {mcpServerViewsWithPersonalConnections.map(
-              ({ mcpServerView, isAlreadyConnected }) => (
-                <div key={mcpServerView.sId}>
-                  <div className="flex w-full items-center justify-between gap-2 py-2">
-                    <div className="flex items-center gap-2">
-                      <Icon
-                        visual={getIcon(mcpServerView.server.icon)}
-                        size="md"
-                      />
-                      <strong>
-                        {getMcpServerViewDisplayName(mcpServerView)}
-                      </strong>
-                    </div>
-                    <div>
-                      {isAlreadyConnected ? (
-                        <Chip color="green" label="Connected" />
-                      ) : (
-                        <Button
-                          icon={CloudArrowLeftRightIcon}
-                          size="xs"
-                          variant="outline"
-                          label="Connect"
-                          disabled={isConnecting}
-                          onClick={async () => {
-                            if (!mcpServerView.server.authorization) {
-                              return;
-                            }
-                            setIsConnecting(true);
-                            await createPersonalConnection({
-                              mcpServerId: mcpServerView.server.sId,
-                              mcpServerDisplayName:
-                                getMcpServerViewDisplayName(mcpServerView),
-                              provider:
-                                mcpServerView.server.authorization.provider,
-                              useCase: "personal_actions",
-                              scope: mcpServerView.server.authorization.scope,
-                            });
-                            setIsConnecting(false);
-                          }}
+              ({ mcpServerView, isAlreadyConnected }) => {
+                const provider = mcpServerView.server.authorization?.provider;
+                const serverOverridableInputs = provider
+                  ? getOverridablePersonalAuthInputs({ provider })
+                  : null;
+                const serverOverrides =
+                  credentialOverridesMap[mcpServerView.server.sId] ?? {};
+
+                return (
+                  <div key={mcpServerView.sId} className="py-2">
+                    <div className="flex w-full items-center justify-between gap-2">
+                      <div className="flex items-center gap-2">
+                        <Icon
+                          visual={getIcon(mcpServerView.server.icon)}
+                          size="md"
                         />
-                      )}
+                        <strong>
+                          {getMcpServerViewDisplayName(mcpServerView)}
+                        </strong>
+                      </div>
+                      <div>
+                        {isAlreadyConnected ? (
+                          <Chip color="green" label="Connected" />
+                        ) : (
+                          <Button
+                            icon={CloudArrowLeftRightIcon}
+                            size="xs"
+                            variant="outline"
+                            label="Connect"
+                            disabled={
+                              isConnecting ||
+                              !areCredentialOverridesValid(
+                                serverOverridableInputs,
+                                serverOverrides
+                              )
+                            }
+                            onClick={async () => {
+                              if (!mcpServerView.server.authorization) {
+                                return;
+                              }
+                              setIsConnecting(true);
+                              try {
+                                await createPersonalConnection({
+                                  mcpServerId: mcpServerView.server.sId,
+                                  mcpServerDisplayName:
+                                    getMcpServerViewDisplayName(mcpServerView),
+                                  provider:
+                                    mcpServerView.server.authorization.provider,
+                                  useCase: "personal_actions",
+                                  scope:
+                                    mcpServerView.server.authorization.scope,
+                                  credentialOverrides:
+                                    Object.keys(serverOverrides).length > 0
+                                      ? serverOverrides
+                                      : undefined,
+                                });
+                              } finally {
+                                setIsConnecting(false);
+                              }
+                            }}
+                          />
+                        )}
+                      </div>
                     </div>
+                    {!isAlreadyConnected && serverOverridableInputs && (
+                      <div className="mt-2 pl-8 pr-2">
+                        <PersonalAuthCredentialOverrides
+                          inputs={serverOverridableInputs}
+                          values={serverOverrides}
+                          idPrefix={mcpServerView.server.sId}
+                          onChange={(key, value) =>
+                            setOverrideValue(
+                              mcpServerView.server.sId,
+                              key,
+                              value
+                            )
+                          }
+                        />
+                      </div>
+                    )}
                   </div>
-                </div>
-              )
+                );
+              }
             )}
             <p className="mt-4">
               {disconnectedCount}{" "}

--- a/front/components/agent_builder/PersonalConnectionRequiredDialog.tsx
+++ b/front/components/agent_builder/PersonalConnectionRequiredDialog.tsx
@@ -108,7 +108,7 @@ export function PersonalConnectionRequiredDialog({
 }) {
   const { createPersonalConnection } = useCreatePersonalConnection(owner);
   const [isConnecting, setIsConnecting] = useState(false);
-  const [credentialOverridesMap, setCredentialOverridesMap] = useState<
+  const [overriddenCredentialsMap, setCredentialOverridesMap] = useState<
     Record<string, Record<string, string>>
   >({});
 
@@ -181,7 +181,7 @@ export function PersonalConnectionRequiredDialog({
                   ? getOverridablePersonalAuthInputs({ provider })
                   : null;
                 const serverOverrides =
-                  credentialOverridesMap[mcpServerView.server.sId] ?? {};
+                  overriddenCredentialsMap[mcpServerView.server.sId] ?? {};
 
                 return (
                   <div key={mcpServerView.sId} className="py-2">
@@ -226,7 +226,7 @@ export function PersonalConnectionRequiredDialog({
                                   useCase: "personal_actions",
                                   scope:
                                     mcpServerView.server.authorization.scope,
-                                  credentialOverrides:
+                                  overriddenCredentials:
                                     Object.keys(serverOverrides).length > 0
                                       ? serverOverrides
                                       : undefined,

--- a/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.tsx
+++ b/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.tsx
@@ -51,7 +51,7 @@ export function MCPServerPersonalAuthenticationRequired({
 
   const [isConnected, setIsConnected] = useState<boolean>(false);
   const [isConnecting, setIsConnecting] = useState<boolean>(false);
-  const [credentialOverrides, setCredentialOverrides] = useState<
+  const [overriddenCredentials, setCredentialOverrides] = useState<
     Record<string, string>
   >({});
 
@@ -71,9 +71,9 @@ export function MCPServerPersonalAuthenticationRequired({
         provider,
         useCase: "personal_actions",
         scope,
-        credentialOverrides:
-          Object.keys(credentialOverrides).length > 0
-            ? credentialOverrides
+        overriddenCredentials:
+          Object.keys(overriddenCredentials).length > 0
+            ? overriddenCredentials
             : undefined,
       });
 
@@ -124,7 +124,7 @@ export function MCPServerPersonalAuthenticationRequired({
                 <div className="mt-2">
                   <PersonalAuthCredentialOverrides
                     inputs={overridableInputs}
-                    values={credentialOverrides}
+                    values={overriddenCredentials}
                     idPrefix={mcpServerId}
                     onChange={(key, value) =>
                       setCredentialOverrides((prev) => ({
@@ -145,7 +145,7 @@ export function MCPServerPersonalAuthenticationRequired({
                     isConnecting ||
                     !areCredentialOverridesValid(
                       overridableInputs,
-                      credentialOverrides
+                      overriddenCredentials
                     )
                   }
                   onClick={() => void onConnectClick(mcpServer)}

--- a/front/components/oauth/PersonalAuthCredentialOverrides.tsx
+++ b/front/components/oauth/PersonalAuthCredentialOverrides.tsx
@@ -1,0 +1,96 @@
+import { Input, Label } from "@dust-tt/sparkle";
+
+import type { OAuthCredentialInputs } from "@app/types";
+import { isSupportedOAuthCredential } from "@app/types";
+
+interface PersonalAuthCredentialOverridesProps {
+  inputs: OAuthCredentialInputs;
+  values: Record<string, string>;
+  onChange: (key: string, value: string) => void;
+  idPrefix: string;
+}
+
+export function PersonalAuthCredentialOverrides({
+  inputs,
+  values,
+  onChange,
+  idPrefix,
+}: PersonalAuthCredentialOverridesProps) {
+  return (
+    <div className="flex flex-col gap-4">
+      {Object.entries(inputs).map(([key, inputData]) => {
+        if (!inputData || !isSupportedOAuthCredential(key)) {
+          return null;
+        }
+
+        const label = inputData.overridableAtPersonalAuth
+          ? inputData.personalAuthLabel
+          : inputData.label;
+        const helpText = inputData.overridableAtPersonalAuth
+          ? inputData.personalAuthHelpMessage
+          : inputData.helpMessage;
+        const inputId = `personal-auth-override-${idPrefix}-${key}`;
+        const value = values[key] ?? "";
+        const trimmedValue = value.trim();
+
+        const hasValidationError =
+          trimmedValue.length > 0 &&
+          inputData.validator &&
+          !inputData.validator(trimmedValue);
+
+        const message = hasValidationError
+          ? `Invalid ${label.toLowerCase()}. ${helpText ?? "Please check the format."}`
+          : helpText;
+
+        return (
+          <div key={key} className="flex flex-col gap-1">
+            <Label
+              htmlFor={inputId}
+              className="text-sm font-medium text-foreground dark:text-foreground-night"
+            >
+              {label}{" "}
+              <span className="font-normal text-muted-foreground dark:text-muted-foreground-night">
+                (optional)
+              </span>
+            </Label>
+            <Input
+              id={inputId}
+              name={key}
+              placeholder={label}
+              value={value}
+              onChange={(e) => onChange(key, e.target.value)}
+              message={message}
+              messageStatus={hasValidationError ? "error" : undefined}
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export function areCredentialOverridesValid(
+  inputs: OAuthCredentialInputs | null | undefined,
+  values: Record<string, string>
+): boolean {
+  if (!inputs) {
+    return true;
+  }
+
+  for (const [key, inputData] of Object.entries(inputs)) {
+    if (!inputData || !isSupportedOAuthCredential(key)) {
+      continue;
+    }
+    const value = values[key] ?? "";
+    const trimmedValue = value.trim();
+    if (
+      trimmedValue.length > 0 &&
+      inputData.validator &&
+      !inputData.validator(trimmedValue)
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/front/lib/api/oauth/providers/snowflake.ts
+++ b/front/lib/api/oauth/providers/snowflake.ts
@@ -23,6 +23,7 @@ import type { ExtraConfigType } from "@app/pages/w/[wId]/oauth/[provider]/setup"
 import type { Result } from "@app/types";
 import { Err, OAuthAPI, Ok } from "@app/types";
 import type { OAuthConnectionType, OAuthUseCase } from "@app/types/oauth/lib";
+import { isValidSnowflakeRole } from "@app/types/oauth/lib";
 import { isString } from "@app/types/shared/utils/general";
 
 /**
@@ -122,8 +123,7 @@ export class SnowflakeOAuthProvider implements BaseOAuthStrategyProvider {
 
   isExtraConfigValid(extraConfig: ExtraConfigType, useCase: OAuthUseCase) {
     if (useCase === "personal_actions" || useCase === "platform_actions") {
-      // If we have an mcp_server_id it means the admin already setup the connection and we have
-      // everything we need (role can be overridden via snowflake_role in extraConfig).
+      // If we have an mcp_server_id it means the admin already setup the connection.
       if (extraConfig.mcp_server_id) {
         return true;
       }
@@ -221,11 +221,7 @@ export class SnowflakeOAuthProvider implements BaseOAuthStrategyProvider {
       // For personal actions we reuse the existing connection credential id from the existing
       // workspace connection (setup by admin) if we have it, otherwise we fallback to assuming
       // we have client_secret (initial admin setup).
-      const {
-        mcp_server_id,
-        snowflake_role: userRole,
-        ...restConfig
-      } = extraConfig;
+      const { mcp_server_id, snowflake_role: userRole } = extraConfig;
 
       if (mcp_server_id && isString(mcp_server_id)) {
         const connection = await getWorkspaceConnectionForMCPServer(
@@ -233,15 +229,43 @@ export class SnowflakeOAuthProvider implements BaseOAuthStrategyProvider {
           mcp_server_id
         );
 
-        // Use user-provided role if specified, otherwise use the default role from workspace connection
-        const role = userRole || connection.metadata.snowflake_role;
+        const {
+          client_id: wsClientId,
+          snowflake_account: wsAccount,
+          snowflake_role: wsRole,
+          snowflake_warehouse: wsWarehouse,
+        } = connection.metadata;
+
+        if (
+          !isString(wsClientId) ||
+          !isString(wsAccount) ||
+          !isString(wsRole) ||
+          !isString(wsWarehouse)
+        ) {
+          throw new Error(
+            "Workspace connection is missing required Snowflake configuration. " +
+              "Please ask an admin to reconfigure the MCP server connection."
+          );
+        }
+
+        // Use user-provided role if specified, otherwise use the default from workspace connection.
+        let role = wsRole;
+        if (isString(userRole) && userRole.trim()) {
+          const trimmedUserRole = userRole.trim();
+          if (!isValidSnowflakeRole(trimmedUserRole)) {
+            throw new Error(
+              `Invalid Snowflake role format: "${trimmedUserRole}". ` +
+                "Role must start with a letter or underscore and contain only alphanumeric characters and underscores."
+            );
+          }
+          role = trimmedUserRole;
+        }
 
         return {
-          client_id: connection.metadata.client_id,
-          snowflake_account: connection.metadata.snowflake_account,
+          client_id: wsClientId,
+          snowflake_account: wsAccount,
           snowflake_role: role,
-          snowflake_warehouse: connection.metadata.snowflake_warehouse,
-          ...restConfig,
+          snowflake_warehouse: wsWarehouse,
         };
       }
     }

--- a/front/lib/api/oauth/providers/snowflake.ts
+++ b/front/lib/api/oauth/providers/snowflake.ts
@@ -250,8 +250,8 @@ export class SnowflakeOAuthProvider implements BaseOAuthStrategyProvider {
 
         // Use user-provided role if specified, otherwise use the default from workspace connection.
         let role = wsRole;
-        if (isString(userRole) && userRole.trim()) {
-          const trimmedUserRole = userRole.trim();
+        const trimmedUserRole = isString(userRole) ? userRole.trim() : "";
+        if (trimmedUserRole) {
           if (!isValidSnowflakeRole(trimmedUserRole)) {
             throw new Error(
               `Invalid Snowflake role format: "${trimmedUserRole}". ` +

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -859,14 +859,14 @@ export function useCreatePersonalConnection(owner: LightWorkspaceType) {
     provider,
     useCase,
     scope,
-    credentialOverrides,
+    overriddenCredentials,
   }: {
     mcpServerId: string;
     mcpServerDisplayName: string;
     provider: OAuthProvider;
     useCase: OAuthUseCase;
     scope?: string;
-    credentialOverrides?: Record<string, string>;
+    overriddenCredentials?: Record<string, string>;
   }): Promise<boolean> => {
     try {
       const extraConfig: Record<string, string> = {
@@ -877,8 +877,8 @@ export function useCreatePersonalConnection(owner: LightWorkspaceType) {
         extraConfig.scope = scope;
       }
 
-      if (credentialOverrides) {
-        for (const [key, value] of Object.entries(credentialOverrides)) {
+      if (overriddenCredentials) {
+        for (const [key, value] of Object.entries(overriddenCredentials)) {
           const trimmedValue = value.trim();
           if (trimmedValue && isSupportedOAuthCredential(key)) {
             extraConfig[key] = trimmedValue;

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -65,6 +65,7 @@ import {
   Err,
   isAdmin,
   isAPIErrorResponse,
+  isSupportedOAuthCredential,
   Ok,
   removeNulls,
   setupOAuthConnection,
@@ -858,12 +859,14 @@ export function useCreatePersonalConnection(owner: LightWorkspaceType) {
     provider,
     useCase,
     scope,
+    credentialOverrides,
   }: {
     mcpServerId: string;
     mcpServerDisplayName: string;
     provider: OAuthProvider;
     useCase: OAuthUseCase;
     scope?: string;
+    credentialOverrides?: Record<string, string>;
   }): Promise<boolean> => {
     try {
       const extraConfig: Record<string, string> = {
@@ -872,6 +875,15 @@ export function useCreatePersonalConnection(owner: LightWorkspaceType) {
 
       if (scope) {
         extraConfig.scope = scope;
+      }
+
+      if (credentialOverrides) {
+        for (const [key, value] of Object.entries(credentialOverrides)) {
+          const trimmedValue = value.trim();
+          if (trimmedValue && isSupportedOAuthCredential(key)) {
+            extraConfig[key] = trimmedValue;
+          }
+        }
       }
 
       const cRes = await setupOAuthConnection({

--- a/front/types/oauth/lib.ts
+++ b/front/types/oauth/lib.ts
@@ -116,7 +116,10 @@ export type OAuthCredentialInput = {
   value: string | undefined;
   helpMessage?: string;
   validator?: (value: string) => boolean;
-};
+} & (
+  | { overridableAtPersonalAuth: true; personalAuthLabel: string; personalAuthHelpMessage: string }
+  | { overridableAtPersonalAuth?: false }
+);
 
 export type OAuthCredentialInputs = Partial<
   Record<SupportedOAuthCredentials, OAuthCredentialInput>
@@ -126,6 +129,26 @@ export type OAuthCredentials = Partial<
   Record<SupportedOAuthCredentials, string>
 >;
 
+export function getOverridablePersonalAuthInputs({
+  provider,
+}: {
+  provider: OAuthProvider;
+}): OAuthCredentialInputs | null {
+  const allInputs = getProviderCredentialInputsImpl(provider, "personal_actions");
+  if (!allInputs) {
+    return null;
+  }
+
+  const filtered: OAuthCredentialInputs = {};
+  for (const [key, input] of Object.entries(allInputs)) {
+    if (input.overridableAtPersonalAuth && isSupportedOAuthCredential(key)) {
+      filtered[key] = input;
+    }
+  }
+
+  return Object.keys(filtered).length > 0 ? filtered : null;
+}
+
 export const getProviderRequiredOAuthCredentialInputs = async ({
   provider,
   useCase,
@@ -133,6 +156,13 @@ export const getProviderRequiredOAuthCredentialInputs = async ({
   provider: OAuthProvider;
   useCase: OAuthUseCase;
 }): Promise<OAuthCredentialInputs | null> => {
+  return getProviderCredentialInputsImpl(provider, useCase);
+};
+
+function getProviderCredentialInputsImpl(
+  provider: OAuthProvider,
+  useCase: OAuthUseCase
+): OAuthCredentialInputs | null {
   switch (provider) {
     case "salesforce":
       if (useCase === "personal_actions" || useCase === "platform_actions") {
@@ -344,6 +374,10 @@ export const getProviderRequiredOAuthCredentialInputs = async ({
             helpMessage:
               "The default role for users (e.g., ANALYST). Users can override this during their personal authentication.",
             validator: isValidSnowflakeRole,
+            overridableAtPersonalAuth: true,
+            personalAuthLabel: "Snowflake Role",
+            personalAuthHelpMessage:
+              "Enter a role to override the default, or leave empty to use the workspace default.",
           },
           snowflake_warehouse: {
             label: "Snowflake Warehouse",
@@ -358,7 +392,7 @@ export const getProviderRequiredOAuthCredentialInputs = async ({
     default:
       assertNever(provider);
   }
-};
+}
 
 export type OAuthProvider = (typeof OAUTH_PROVIDERS)[number];
 

--- a/front/types/oauth/lib.ts
+++ b/front/types/oauth/lib.ts
@@ -117,7 +117,11 @@ export type OAuthCredentialInput = {
   helpMessage?: string;
   validator?: (value: string) => boolean;
 } & (
-  | { overridableAtPersonalAuth: true; personalAuthLabel: string; personalAuthHelpMessage: string }
+  | {
+      overridableAtPersonalAuth: true;
+      personalAuthLabel: string;
+      personalAuthHelpMessage: string;
+    }
   | { overridableAtPersonalAuth?: false }
 );
 
@@ -134,7 +138,10 @@ export function getOverridablePersonalAuthInputs({
 }: {
   provider: OAuthProvider;
 }): OAuthCredentialInputs | null {
-  const allInputs = getProviderCredentialInputsImpl(provider, "personal_actions");
+  const allInputs = getProviderCredentialInputsImpl(
+    provider,
+    "personal_actions"
+  );
   if (!allInputs) {
     return null;
   }

--- a/front/types/oauth/lib.ts
+++ b/front/types/oauth/lib.ts
@@ -138,10 +138,10 @@ export function getOverridablePersonalAuthInputs({
 }: {
   provider: OAuthProvider;
 }): OAuthCredentialInputs | null {
-  const allInputs = getProviderCredentialInputsImpl(
+  const allInputs = getProviderRequiredOAuthCredentialInputs({
     provider,
-    "personal_actions"
-  );
+    useCase: "personal_actions",
+  });
   if (!allInputs) {
     return null;
   }
@@ -156,20 +156,13 @@ export function getOverridablePersonalAuthInputs({
   return Object.keys(filtered).length > 0 ? filtered : null;
 }
 
-export const getProviderRequiredOAuthCredentialInputs = async ({
+export function getProviderRequiredOAuthCredentialInputs({
   provider,
   useCase,
 }: {
   provider: OAuthProvider;
   useCase: OAuthUseCase;
-}): Promise<OAuthCredentialInputs | null> => {
-  return getProviderCredentialInputsImpl(provider, useCase);
-};
-
-function getProviderCredentialInputsImpl(
-  provider: OAuthProvider,
-  useCase: OAuthUseCase
-): OAuthCredentialInputs | null {
+}): OAuthCredentialInputs | null {
   switch (provider) {
     case "salesforce":
       if (useCase === "personal_actions" || useCase === "platform_actions") {


### PR DESCRIPTION
## Description

Allow users to override OAuth credentials (like Snowflake role) during personal authentication.

### Changes
- Add `overridableAtPersonalAuth` flag to credential inputs with dedicated labels/help text
- Add `PersonalAuthCredentialOverrides` component for override inputs
- `getOverridablePersonalAuthInputs()` helper to get overridable inputs for a provider
- Skip auto-creating admin's personal connection when provider has overridable inputs
- Pass credential overrides through the OAuth flow

**Note:** This PR provides the generic infrastructure. Snowflake-specific configuration is in #20222.

## Tests

- CI passes
- Manual testing with Snowflake role override

## Risk

**Low risk.** Additive changes to OAuth flow. Existing providers without overridable inputs are unaffected.

## Deploy Plan

1. Merge this PR
2. Deploy front
3. Merge #20222 (Snowflake boilerplate) and #20114 (Snowflake tools) to enable Snowflake