### PR TITLE
Refactor to pass conversation instead of conversationId in virtuoso context.

### DIFF
--- a/front/components/agent_builder/AgentBuilderPreview.tsx
+++ b/front/components/agent_builder/AgentBuilderPreview.tsx
@@ -119,7 +119,7 @@ function PreviewContent({
               stickyMentions={
                 draftAgent ? [toRichAgentMentionType(draftAgent)] : []
               }
-              conversationId={null}
+              conversation={null}
               actions={["attachment"]}
               disableAutoFocus
               isFloating={false}

--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -55,17 +55,19 @@ export const AgentInputBar = ({
   }
 
   const { mutateConversation } = useConversation({
-    conversationId: context.conversationId,
+    conversationId: context.conversation?.sId,
     workspaceId: context.owner.sId,
     options: { disabled: true }, // We just want to get the mutation function
   });
   const cancelMessage = useCancelMessage({
     owner: context.owner,
-    conversationId: context.conversationId,
+    conversationId: context.conversation?.sId,
   });
 
   const generatingMessages =
-    generationContext.getConversationGeneratingMessages(context.conversationId);
+    generationContext.getConversationGeneratingMessages(
+      context.conversation?.sId ?? ""
+    );
 
   const isMobile = useIsMobile();
   const methods = useVirtuosoMethods<VirtuosoMessage>();
@@ -214,13 +216,13 @@ export const AgentInputBar = ({
   };
 
   const handleStopGeneration = async () => {
-    if (!context.conversationId) {
+    if (!context.conversation) {
       return;
     }
     setIsStopping(true); // we don't set it back to false immediately cause it takes a bit of time to cancel
     await cancelMessage(
       generationContext.generatingMessages
-        .filter((m) => m.conversationId === context.conversationId)
+        .filter((m) => m.conversationId === context.conversation?.sId)
         .map((m) => m.messageId)
     );
     void mutateConversation();
@@ -230,16 +232,12 @@ export const AgentInputBar = ({
     if (
       isStopping &&
       !generationContext.generatingMessages.some(
-        (m) => m.conversationId === context.conversationId
+        (m) => m.conversationId === context.conversation?.sId
       )
     ) {
       setIsStopping(false);
     }
-  }, [
-    isStopping,
-    generationContext.generatingMessages,
-    context.conversationId,
-  ]);
+  }, [isStopping, generationContext.generatingMessages, context.conversation]);
 
   return (
     <div
@@ -345,7 +343,7 @@ export const AgentInputBar = ({
         user={context.user}
         onSubmit={context.handleSubmit}
         stickyMentions={autoMentions}
-        conversationId={context.conversationId}
+        conversation={context.conversation}
         disableAutoFocus={isMobile}
         actions={context.agentBuilderContext?.actionsToShow}
         isSubmitting={context.agentBuilderContext?.isSavingDraftAgent === true}

--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -187,7 +187,7 @@ export function ConversationContainerVirtuoso({
               owner={owner}
               user={user}
               onSubmit={handleConversationCreation}
-              conversationId={null}
+              conversation={null}
               disableAutoFocus={false}
             />
           </div>

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -621,7 +621,7 @@ export const ConversationViewer = ({
       data: VirtuosoMessage;
       context: VirtuosoMessageListContext;
     }) => {
-      return `conversation-${context.conversationId}-message-rank-${data.rank}`;
+      return `conversation-${context.conversation?.sId}-message-rank-${data.rank}`;
     },
     []
   );
@@ -640,12 +640,12 @@ export const ConversationViewer = ({
     );
   }, [feedbacks]);
 
-  const context = useMemo(() => {
+  const context: VirtuosoMessageListContext = useMemo(() => {
     return {
       user,
       owner,
       handleSubmit,
-      conversationId,
+      conversation,
       enableReactions: !!conversation?.spaceId,
       agentBuilderContext,
       feedbacksByMessageId,
@@ -654,8 +654,7 @@ export const ConversationViewer = ({
     user,
     owner,
     handleSubmit,
-    conversationId,
-    conversation?.spaceId,
+    conversation,
     agentBuilderContext,
     feedbacksByMessageId,
   ]);

--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -47,7 +47,7 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
 
     const submitFeedback = useMessageFeedback({
       owner: context.owner,
-      conversationId: context.conversationId,
+      conversationId: context.conversation?.sId,
     });
 
     const { submit: onSubmitThumb, isSubmitting: isSubmittingThumb } =
@@ -75,7 +75,7 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
 
     const { onReactionToggle } = useReaction({
       owner: context.owner,
-      conversationId: context.conversationId,
+      conversationId: context.conversation?.sId,
       message: data,
     });
 
@@ -104,7 +104,7 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
                 owner={context.owner}
                 key={index}
                 attachmentCitation={attachmentCitation}
-                conversationId={context.conversationId}
+                conversationId={context.conversation?.sId}
               />
             );
           })
@@ -134,6 +134,11 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
       return null;
     }
 
+    // No message without a conversation
+    if (!context.conversation) {
+      return null;
+    }
+
     return (
       <>
         {!areSameDate && <MessageDateIndicator message={data} />}
@@ -145,7 +150,7 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
           {isUserMessage(data) && (
             <UserMessage
               citations={citations}
-              conversationId={context.conversationId}
+              conversationId={context.conversation.sId}
               enableReactions={context.enableReactions}
               currentUserId={context.user.sId}
               isLastMessage={!nextData}
@@ -158,7 +163,7 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
             <AgentMessage
               user={context.user}
               triggeringUser={triggeringUser}
-              conversationId={context.conversationId}
+              conversationId={context.conversation.sId}
               isLastMessage={!nextData}
               agentMessage={data}
               messageFeedback={messageFeedbackWithSubmit}
@@ -168,6 +173,11 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
           )}
           {data.visibility !== "deleted" &&
             data.richMentions.map((mention) => {
+              // To please the type checker
+              if (!context.conversation) {
+                return null;
+              }
+
               if (mention.status === "pending") {
                 return (
                   <MentionValidationRequired
@@ -176,7 +186,7 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
                     message={data}
                     owner={context.owner}
                     triggeringUser={triggeringUser}
-                    conversationId={context.conversationId}
+                    conversationId={context.conversation.sId}
                   />
                 );
               } else if (
@@ -190,7 +200,7 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
                     message={data}
                     owner={context.owner}
                     triggeringUser={triggeringUser}
-                    conversationId={context.conversationId}
+                    conversationId={context.conversation.sId}
                   />
                 );
               }

--- a/front/components/assistant/conversation/attachment/AttachmentCitation.tsx
+++ b/front/components/assistant/conversation/attachment/AttachmentCitation.tsx
@@ -22,7 +22,7 @@ import { getFileFormat, isSupportedImageContentType } from "@app/types";
 interface AttachmentCitationProps {
   owner: LightWorkspaceType;
   attachmentCitation: AttachmentCitation;
-  conversationId: string | null;
+  conversationId?: string | null;
 }
 
 export function AttachmentCitation({

--- a/front/components/assistant/conversation/attachment/AttachmentViewer.tsx
+++ b/front/components/assistant/conversation/attachment/AttachmentViewer.tsx
@@ -42,7 +42,7 @@ export const AttachmentViewer = ({
   viewerOpen: boolean;
   setViewerOpen: (open: boolean) => void;
   attachmentCitation: FileAttachmentCitation | MCPAttachmentCitation;
-  conversationId: string | null;
+  conversationId?: string | null;
   owner: LightWorkspaceType;
 }) => {
   const fileUploaderService = useFileUploaderService({

--- a/front/components/assistant/conversation/input_bar/InputBarAttachments.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachments.tsx
@@ -43,7 +43,7 @@ interface InputBarAttachmentsProps {
   owner: LightWorkspaceType;
   files: FileAttachmentsProps;
   nodes?: NodeAttachmentsProps;
-  conversationId: string | null;
+  conversationId?: string | null;
   disable?: boolean;
 }
 

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -68,7 +68,7 @@ export interface InputBarContainerProps {
   actions: InputBarAction[];
   allAgents: LightAgentConfigurationType[];
   attachedNodes: DataSourceViewContentNode[];
-  conversationId: string | null;
+  conversationId?: string | null;
   disableAutoFocus: boolean;
   disableInput: boolean;
   fileUploaderService: FileUploaderService;

--- a/front/components/assistant/conversation/input_bar/useConversationDrafts.ts
+++ b/front/components/assistant/conversation/input_bar/useConversationDrafts.ts
@@ -35,7 +35,7 @@ export function useConversationDrafts({
 }: {
   workspaceId: string;
   userId: string | null;
-  conversationId: string | null;
+  conversationId?: string | null;
   shouldUseDraft?: boolean;
 }) {
   const internalConversationId = conversationId ?? "new";

--- a/front/components/assistant/conversation/space/SpaceConversationsTab.tsx
+++ b/front/components/assistant/conversation/space/SpaceConversationsTab.tsx
@@ -245,7 +245,7 @@ export function SpaceConversationsTab({
                 owner={owner}
                 user={user}
                 onSubmit={onSubmit}
-                conversationId={null}
+                conversation={null}
                 disableAutoFocus={false}
               />
             </div>

--- a/front/components/assistant/conversation/types.ts
+++ b/front/components/assistant/conversation/types.ts
@@ -8,6 +8,7 @@ import type { AgentMessageEvents } from "@app/lib/api/assistant/streaming/types"
 import type { DustError } from "@app/lib/error";
 import type {
   ContentFragmentsType,
+  ConversationWithoutContentType,
   LightAgentConfigurationType,
   LightAgentMessageType,
   LightAgentMessageWithActionsType,
@@ -68,7 +69,7 @@ export type VirtuosoMessageListContext = {
     mentions: RichMention[],
     contentFragments: ContentFragmentsType
   ) => Promise<Result<undefined, DustError>>;
-  conversationId: string;
+  conversation: ConversationWithoutContentType | null;
   enableReactions: boolean;
   agentBuilderContext?: {
     draftAgent?: LightAgentConfigurationType;

--- a/front/components/editor/input_bar/mentionSuggestion.tsx
+++ b/front/components/editor/input_bar/mentionSuggestion.tsx
@@ -22,7 +22,7 @@ export function createMentionSuggestion({
   includeCurrentUser = false,
 }: {
   owner: WorkspaceType;
-  conversationId: string | null;
+  conversationId?: string | null;
   includeCurrentUser?: boolean;
   select: {
     agents: boolean;

--- a/front/components/editor/input_bar/useCustomEditor.tsx
+++ b/front/components/editor/input_bar/useCustomEditor.tsx
@@ -174,7 +174,7 @@ export interface CustomEditorProps {
   disableAutoFocus: boolean;
   onUrlDetected?: (candidate: UrlCandidate | NodeCandidate | null) => void;
   owner: WorkspaceType;
-  conversationId: string | null;
+  conversationId?: string | null;
   // If provided, large pasted text will be routed to this callback along with selection bounds
   onLongTextPaste?: (payload: {
     text: string;
@@ -192,7 +192,7 @@ export const buildEditorExtensions = ({
   onUrlDetected,
 }: {
   owner: WorkspaceType;
-  conversationId: string | null;
+  conversationId?: string | null;
   onInlineText?: (fileId: string, textContent: string) => void;
   onUrlDetected?: (candidate: UrlCandidate | NodeCandidate | null) => void;
 }) => {

--- a/front/hooks/useMessageFeedback.ts
+++ b/front/hooks/useMessageFeedback.ts
@@ -10,7 +10,7 @@ export function useMessageFeedback({
   conversationId,
 }: {
   owner: LightWorkspaceType;
-  conversationId: string | null;
+  conversationId?: string | null;
 }) {
   const sendNotification = useSendNotification();
   const { mutateReactions } = useConversationFeedbacks({

--- a/front/hooks/useReaction.ts
+++ b/front/hooks/useReaction.ts
@@ -13,7 +13,7 @@ export function useReaction({
   message,
 }: {
   owner: { sId: string };
-  conversationId: string;
+  conversationId?: string | null;
   message: VirtuosoMessage;
 }) {
   const { user } = useUser();
@@ -21,6 +21,10 @@ export function useReaction({
   const { submit: onReactionToggle } = useSubmitFunction(
     async ({ emoji }: { emoji: string }) => {
       if (!isUserMessage(message) && !isMessageTemporayState(message)) {
+        return;
+      }
+
+      if (!conversationId) {
         return;
       }
 

--- a/front/lib/swr/conversations.ts
+++ b/front/lib/swr/conversations.ts
@@ -46,7 +46,7 @@ export function useConversation({
   workspaceId,
   options,
 }: {
-  conversationId: string | null;
+  conversationId?: string | null;
   workspaceId: string;
   options?: { disabled: boolean };
 }): {
@@ -184,7 +184,7 @@ export function useConversationMessages({
   workspaceId,
   limit,
 }: {
-  conversationId: string | null;
+  conversationId?: string | null;
   workspaceId: string;
   limit: number;
   startAtRank?: number;
@@ -237,7 +237,7 @@ export function useConversationParticipants({
   workspaceId,
   options,
 }: {
-  conversationId: string | null;
+  conversationId?: string | null;
   workspaceId: string;
   options?: { disabled: boolean };
 }) {
@@ -268,7 +268,7 @@ export function useConversationTools({
   workspaceId,
   options,
 }: {
-  conversationId: string | null;
+  conversationId?: string | null;
   workspaceId: string;
   options?: { disabled: boolean };
 }) {
@@ -302,7 +302,7 @@ export function useConversationSkills({
   workspaceId,
   options,
 }: {
-  conversationId: string | null;
+  conversationId?: string | null;
   workspaceId: string;
   options?: { disabled: boolean };
 }) {
@@ -332,7 +332,7 @@ export function useCancelMessage({
   conversationId,
 }: {
   owner: LightWorkspaceType;
-  conversationId: string | null;
+  conversationId?: string | null;
 }) {
   const sendNotification = useSendNotification();
 
@@ -363,7 +363,7 @@ export function useAddDeleteConversationTool({
   conversationId,
   workspaceId,
 }: {
-  conversationId: string | null;
+  conversationId?: string | null;
   workspaceId: string;
 }) {
   const { mutateConversationTools } = useConversationTools({
@@ -463,7 +463,7 @@ export function useAddDeleteConversationSkill({
   conversationId,
   workspaceId,
 }: {
-  conversationId: string | null;
+  conversationId?: string | null;
   workspaceId: string;
 }) {
   const sendNotification = useSendNotification();
@@ -572,7 +572,7 @@ export function useVisualizationRevert({
   conversationId,
 }: {
   workspaceId: string | null;
-  conversationId: string | null;
+  conversationId?: string | null;
 }) {
   const handleVisualizationRevert = useCallback(
     async ({
@@ -630,7 +630,7 @@ export function useVisualizationRetry({
   isPublic,
 }: {
   workspaceId: string | null;
-  conversationId: string | null;
+  conversationId?: string | null;
   agentConfigurationId: string | null;
   isPublic: boolean;
 }) {
@@ -752,7 +752,7 @@ export function useConversationFiles({
   options,
   owner,
 }: {
-  conversationId: string | null;
+  conversationId?: string | null;
   options?: { disabled?: boolean };
   owner: LightWorkspaceType;
 }) {
@@ -872,7 +872,7 @@ export const useConversationParticipationOptions = ({
   disabled,
 }: {
   ownerId: string;
-  conversationId: string | null;
+  conversationId?: string | null;
   userId: string | null;
   disabled: boolean;
 }) => {
@@ -922,7 +922,7 @@ export const useJoinConversation = ({
   conversationId,
 }: {
   ownerId: string;
-  conversationId: string | null;
+  conversationId?: string | null;
 }): (() => Promise<boolean>) => {
   const sendNotification = useSendNotification();
 
@@ -999,7 +999,7 @@ export function usePostOnboardingFollowUp({
   conversationId,
 }: {
   workspaceId: string;
-  conversationId: string | null;
+  conversationId?: string | null;
 }) {
   const sendNotification = useSendNotification();
 


### PR DESCRIPTION
## Description

Pass `conversation:ConversationWithoutContentType` instead of `conversationId` in virtuoso context to make more information available to sub-components.

Next PR will leverage it to adapt the input bar attachment so we can filter in case of project conversations.

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy front