### PR TITLE
[front] Ignore rate limit errors from `run_agent` error tracking

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/run_agent/conversation.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_agent/conversation.ts
@@ -34,7 +34,8 @@ import { Err, isUserMessageType, Ok } from "@app/types";
 function isUserSideError(error: APIError): boolean {
   return (
     error.type === "invalid_request_error" ||
-    error.type === "plan_message_limit_exceeded"
+    error.type === "plan_message_limit_exceeded" ||
+    error.type === "rate_limit_error"
   );
 }
 


### PR DESCRIPTION
## Description

- Rate limits when creating conversations trigger a monitor on our side ([logs](https://app.datadoghq.eu/logs?query=region%3Aus-central1%20%40toolName%3Arun_agent%20%22Tool%20execution%20error%22%20status%3Aerror&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cworkspace.sId%2CtoolName%2Cerror&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1768639879000&to_ts=1768641079000&live=false)).
- This PR flags them as user-side errors, which untracks them.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
