### PR TITLE
[front] chore(poke): Cleaned getServerSideProps for poke pages, use swr calls

### DIFF
--- a/front/components/poke/templates/TemplatesDataTable.tsx
+++ b/front/components/poke/templates/TemplatesDataTable.tsx
@@ -84,13 +84,12 @@ export function makeColumnsForTemplates() {
   ];
 }
 
-export function TemplatesDataTable({
-  dustRegionSyncEnabled,
-}: {
-  dustRegionSyncEnabled: boolean;
-}) {
-  const { assistantTemplates, isAssistantTemplatesLoading } =
-    usePokeAssistantTemplates();
+export function TemplatesDataTable() {
+  const {
+    assistantTemplates,
+    dustRegionSyncEnabled,
+    isAssistantTemplatesLoading,
+  } = usePokeAssistantTemplates();
   const { doPull, isPulling } = usePokePullTemplates();
   const [templateSearch, setTemplateSearch] = useState<string>("");
 

--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -355,6 +355,11 @@ const config = {
   getLangfuseUiBaseUrl: () => {
     return EnvironmentConfig.getOptionalEnvVariable("LANGFUSE_UI_BASE_URL");
   },
+  getTemporalConnectorsNamespace: () => {
+    return EnvironmentConfig.getOptionalEnvVariable(
+      "TEMPORAL_CONNECTORS_NAMESPACE"
+    );
+  },
 };
 
 export default config;

--- a/front/pages/api/poke/connectors/[connectorId]/redirect.ts
+++ b/front/pages/api/poke/connectors/[connectorId]/redirect.ts
@@ -53,7 +53,7 @@ async function handler(
         return apiError(req, res, {
           status_code: 404,
           api_error: {
-            type: "connector_not_found",
+            type: "connector_not_found_error",
             message: "Connector not found.",
           },
         });

--- a/front/pages/api/poke/connectors/[connectorId]/redirect.ts
+++ b/front/pages/api/poke/connectors/[connectorId]/redirect.ts
@@ -1,0 +1,79 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import config from "@app/lib/api/config";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
+import logger from "@app/logger/logger";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+import { ConnectorsAPI } from "@app/types";
+
+interface GetConnectorRedirectResponse {
+  redirectUrl: string;
+}
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetConnectorRedirectResponse>>,
+  session: SessionWithUser
+): Promise<void> {
+  const auth = await Authenticator.fromSuperUserSession(session, null);
+
+  if (!auth.isDustSuperUser()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "user_not_found",
+        message: "Could not find the user.",
+      },
+    });
+  }
+
+  const { connectorId } = req.query;
+  if (!connectorId || typeof connectorId !== "string") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid connector ID.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET":
+      const connectorsAPI = new ConnectorsAPI(
+        config.getConnectorsAPIConfig(),
+        logger
+      );
+      const cRes = await connectorsAPI.getConnector(connectorId);
+
+      if (cRes.isErr()) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "connector_not_found",
+            message: "Connector not found.",
+          },
+        });
+      }
+
+      const connector = cRes.value;
+
+      return res.status(200).json({
+        redirectUrl: `/poke/${connector.workspaceId}/data_sources/${connector.dataSourceId}`,
+      });
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForPoke(handler);

--- a/front/pages/api/poke/connectors/[connectorId]/redirect.ts
+++ b/front/pages/api/poke/connectors/[connectorId]/redirect.ts
@@ -7,6 +7,7 @@ import type { SessionWithUser } from "@app/lib/iam/provider";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
+import { isString } from "@app/types";
 import { ConnectorsAPI } from "@app/types";
 
 interface GetConnectorRedirectResponse {
@@ -31,7 +32,7 @@ async function handler(
   }
 
   const { connectorId } = req.query;
-  if (!connectorId || typeof connectorId !== "string") {
+  if (!isString(connectorId)) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {

--- a/front/pages/api/poke/templates/index.ts
+++ b/front/pages/api/poke/templates/index.ts
@@ -20,6 +20,7 @@ export interface CreateTemplateResponseBody {
 
 interface PokeFetchAssistantTemplatesResponse {
   templates: AssistantTemplateListType[];
+  dustRegionSyncEnabled: boolean;
 }
 
 async function handler(
@@ -47,9 +48,10 @@ async function handler(
     case "GET":
       const templates = await TemplateResource.listAll();
 
-      return res
-        .status(200)
-        .json({ templates: templates.map((t) => t.toListJSON()) });
+      return res.status(200).json({
+        templates: templates.map((t) => t.toListJSON()),
+        dustRegionSyncEnabled: regionConfig.getDustRegionSyncEnabled(),
+      });
 
     case "POST":
       const bodyValidation = CreateTemplateFormSchema.decode(req.body);

--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/details.ts
@@ -13,6 +13,7 @@ import type {
   UserType,
   WithAPIErrorResponse,
 } from "@app/types";
+import { isString } from "@app/types";
 
 export type PokeGetAgentDetails = {
   agentConfigurations: AgentConfigurationType[];
@@ -27,7 +28,7 @@ async function handler(
   session: SessionWithUser
 ): Promise<void> {
   const { wId, aId } = req.query;
-  if (typeof wId !== "string" || typeof aId !== "string") {
+  if (!isString(wId) || !isString(aId)) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {

--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/details.ts
@@ -74,10 +74,10 @@ async function handler(
         auth,
         latestAgentConfiguration.requestedSpaceIds
       );
-
+      const authors = await getAuthors(agentConfigurations);
       return res.status(200).json({
         agentConfigurations,
-        authors: await getAuthors(agentConfigurations),
+        authors,
         lastVersionEditors,
         spaces: spaces.map((s) => s.toJSON()),
       });

--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/details.ts
@@ -1,0 +1,96 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import { listsAgentConfigurationVersions } from "@app/lib/api/assistant/configuration/agent";
+import { getAuthors, getEditors } from "@app/lib/api/assistant/editors";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { apiError } from "@app/logger/withlogging";
+import type {
+  AgentConfigurationType,
+  SpaceType,
+  UserType,
+  WithAPIErrorResponse,
+} from "@app/types";
+
+export type PokeGetAgentDetails = {
+  agentConfigurations: AgentConfigurationType[];
+  authors: UserType[];
+  lastVersionEditors: UserType[];
+  spaces: SpaceType[];
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<PokeGetAgentDetails>>,
+  session: SessionWithUser
+): Promise<void> {
+  const { wId, aId } = req.query;
+  if (typeof wId !== "string" || typeof aId !== "string") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid workspace or agent ID.",
+      },
+    });
+  }
+
+  const auth = await Authenticator.fromSuperUserSession(session, wId);
+  const owner = auth.workspace();
+
+  if (!owner || !auth.isDustSuperUser()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_not_found",
+        message: "Workspace not found.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET":
+      const agentConfigurations = await listsAgentConfigurationVersions(auth, {
+        agentId: aId,
+        variant: "full",
+      });
+
+      if (agentConfigurations.length === 0) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "agent_configuration_not_found",
+            message: "Agent configuration not found.",
+          },
+        });
+      }
+
+      const lastVersionEditors = await getEditors(auth, agentConfigurations[0]);
+      const [latestAgentConfiguration] = agentConfigurations;
+
+      const spaces = await SpaceResource.fetchByIds(
+        auth,
+        latestAgentConfiguration.requestedSpaceIds
+      );
+
+      return res.status(200).json({
+        agentConfigurations,
+        authors: await getAuthors(agentConfigurations),
+        lastVersionEditors,
+        spaces: spaces.map((s) => s.toJSON()),
+      });
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForPoke(handler);

--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/details.ts
@@ -1,8 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { listsAgentConfigurationVersions } from "@app/lib/api/assistant/configuration/agent";
 import { getAuthors, getEditors } from "@app/lib/api/assistant/editors";
+import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { SpaceResource } from "@app/lib/resources/space_resource";

--- a/front/pages/api/poke/workspaces/[wId]/apps/[aId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/apps/[aId]/details.ts
@@ -1,0 +1,113 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import config from "@app/lib/api/config";
+import { cleanSpecificationFromCore, getSpecification } from "@app/lib/api/run";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
+import { AppResource } from "@app/lib/resources/app_resource";
+import { apiError } from "@app/logger/withlogging";
+import logger from "@app/logger/logger";
+import type {
+  AppType,
+  SpecificationType,
+  WithAPIErrorResponse,
+} from "@app/types";
+import { CoreAPI } from "@app/types";
+
+export type PokeGetAppDetails = {
+  app: AppType;
+  specification: SpecificationType;
+  specificationHashes: string[] | null;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<PokeGetAppDetails>>,
+  session: SessionWithUser
+): Promise<void> {
+  const { wId, aId, hash } = req.query;
+  if (typeof wId !== "string" || typeof aId !== "string") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid workspace or app ID.",
+      },
+    });
+  }
+
+  if (hash && typeof hash !== "string") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid hash parameter.",
+      },
+    });
+  }
+
+  const auth = await Authenticator.fromSuperUserSession(session, wId);
+  const owner = auth.workspace();
+
+  if (!owner || !auth.isDustSuperUser()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_not_found",
+        message: "Workspace not found.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET":
+      const app = await AppResource.fetchById(auth, aId);
+
+      if (!app) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "app_not_found",
+            message: "App not found.",
+          },
+        });
+      }
+
+      const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
+      const specificationHashes = await coreAPI.getSpecificationHashes({
+        projectId: app.dustAPIProjectId,
+      });
+
+      let specification = JSON.parse(app.savedSpecification ?? "{}");
+      if (hash && hash.length > 0) {
+        const specificationFromCore = await getSpecification(
+          app.toJSON(),
+          hash
+        );
+        if (specificationFromCore) {
+          cleanSpecificationFromCore(specificationFromCore);
+          specification = specificationFromCore;
+        }
+      }
+
+      return res.status(200).json({
+        app: app.toJSON(),
+        specification,
+        specificationHashes: specificationHashes.isOk()
+          ? specificationHashes.value.hashes.reverse()
+          : null,
+      });
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForPoke(handler);

--- a/front/pages/api/poke/workspaces/[wId]/apps/[aId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/apps/[aId]/details.ts
@@ -13,7 +13,7 @@ import type {
   SpecificationType,
   WithAPIErrorResponse,
 } from "@app/types";
-import { CoreAPI } from "@app/types";
+import { CoreAPI, isString } from "@app/types";
 
 export type PokeGetAppDetails = {
   app: AppType;
@@ -27,7 +27,7 @@ async function handler(
   session: SessionWithUser
 ): Promise<void> {
   const { wId, aId, hash } = req.query;
-  if (typeof wId !== "string" || typeof aId !== "string") {
+  if (!isString(wId) || !isString(aId)) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
@@ -37,7 +37,7 @@ async function handler(
     });
   }
 
-  if (hash && typeof hash !== "string") {
+  if (!isString(hash)) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {

--- a/front/pages/api/poke/workspaces/[wId]/apps/[aId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/apps/[aId]/details.ts
@@ -6,8 +6,8 @@ import { cleanSpecificationFromCore, getSpecification } from "@app/lib/api/run";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { AppResource } from "@app/lib/resources/app_resource";
-import { apiError } from "@app/logger/withlogging";
 import logger from "@app/logger/logger";
+import { apiError } from "@app/logger/withlogging";
 import type {
   AppType,
   SpecificationType,

--- a/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/config.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/config.ts
@@ -1,0 +1,85 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import config from "@app/lib/api/config";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+
+const { TEMPORAL_AGENT_NAMESPACE = "" } = process.env;
+
+export type PokeGetConversationConfig = {
+  conversationDataSourceId: string | null;
+  langfuseUiBaseUrl: string | null;
+  temporalWorkspace: string;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<PokeGetConversationConfig>>,
+  session: SessionWithUser
+): Promise<void> {
+  const { wId, cId } = req.query;
+  if (typeof wId !== "string" || typeof cId !== "string") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid workspace or conversation ID.",
+      },
+    });
+  }
+
+  const auth = await Authenticator.fromSuperUserSession(session, wId);
+  const owner = auth.workspace();
+
+  if (!owner || !auth.isDustSuperUser()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_not_found",
+        message: "Workspace not found.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET":
+      const cRes = await ConversationResource.fetchConversationWithoutContent(
+        auth,
+        cId
+      );
+      if (cRes.isErr()) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "conversation_not_found",
+            message: "Conversation not found.",
+          },
+        });
+      }
+
+      const conversationDataSource =
+        await DataSourceResource.fetchByConversation(auth, cRes.value);
+
+      return res.status(200).json({
+        conversationDataSourceId: conversationDataSource?.sId ?? null,
+        langfuseUiBaseUrl: config.getLangfuseUiBaseUrl() ?? null,
+        temporalWorkspace: TEMPORAL_AGENT_NAMESPACE,
+      });
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForPoke(handler);

--- a/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/config.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/config.ts
@@ -8,6 +8,7 @@ import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
+import { isString } from "@app/types";
 
 export type PokeGetConversationConfig = {
   conversationDataSourceId: string | null;
@@ -21,7 +22,7 @@ async function handler(
   session: SessionWithUser
 ): Promise<void> {
   const { wId, cId } = req.query;
-  if (typeof wId !== "string" || typeof cId !== "string") {
+  if (!isString(wId) || !isString(cId)) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {

--- a/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/config.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/config.ts
@@ -9,8 +9,6 @@ import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
 
-const { TEMPORAL_AGENT_NAMESPACE = "" } = process.env;
-
 export type PokeGetConversationConfig = {
   conversationDataSourceId: string | null;
   langfuseUiBaseUrl: string | null;
@@ -65,10 +63,11 @@ async function handler(
       const conversationDataSource =
         await DataSourceResource.fetchByConversation(auth, cRes.value);
 
+      const temporalWorkspace = config.getTemporalConnectorsNamespace() ?? "";
       return res.status(200).json({
         conversationDataSourceId: conversationDataSource?.sId ?? null,
         langfuseUiBaseUrl: config.getLangfuseUiBaseUrl() ?? null,
-        temporalWorkspace: TEMPORAL_AGENT_NAMESPACE,
+        temporalWorkspace,
       });
 
     default:

--- a/front/pages/api/poke/workspaces/[wId]/data_source_views/[dsvId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_source_views/[dsvId]/details.ts
@@ -61,8 +61,9 @@ async function handler(
         });
       }
 
+      const dataSourceViewJSON = await dataSourceViewToPokeJSON(dataSourceView);
       return res.status(200).json({
-        dataSourceView: await dataSourceViewToPokeJSON(dataSourceView),
+        dataSourceView: dataSourceViewJSON,
       });
 
     default:

--- a/front/pages/api/poke/workspaces/[wId]/data_source_views/[dsvId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_source_views/[dsvId]/details.ts
@@ -7,6 +7,7 @@ import { dataSourceViewToPokeJSON } from "@app/lib/poke/utils";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { PokeDataSourceViewType, WithAPIErrorResponse } from "@app/types";
+import { isString } from "@app/types";
 
 export type PokeGetDataSourceViewDetails = {
   dataSourceView: PokeDataSourceViewType;
@@ -18,7 +19,7 @@ async function handler(
   session: SessionWithUser
 ): Promise<void> {
   const { wId, dsvId } = req.query;
-  if (typeof wId !== "string" || typeof dsvId !== "string") {
+  if (!isString(wId) || !isString(dsvId)) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {

--- a/front/pages/api/poke/workspaces/[wId]/data_source_views/[dsvId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_source_views/[dsvId]/details.ts
@@ -1,0 +1,79 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
+import { dataSourceViewToPokeJSON } from "@app/lib/poke/utils";
+import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { PokeDataSourceViewType, WithAPIErrorResponse } from "@app/types";
+
+export type PokeGetDataSourceViewDetails = {
+  dataSourceView: PokeDataSourceViewType;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<PokeGetDataSourceViewDetails>>,
+  session: SessionWithUser
+): Promise<void> {
+  const { wId, dsvId } = req.query;
+  if (typeof wId !== "string" || typeof dsvId !== "string") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid workspace or data source view ID.",
+      },
+    });
+  }
+
+  const auth = await Authenticator.fromSuperUserSession(session, wId);
+  const owner = auth.workspace();
+
+  if (!owner || !auth.isDustSuperUser()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_not_found",
+        message: "Workspace not found.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET":
+      const dataSourceView = await DataSourceViewResource.fetchById(
+        auth,
+        dsvId,
+        {
+          includeEditedBy: true,
+        }
+      );
+
+      if (!dataSourceView) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "data_source_view_not_found",
+            message: "Data source view not found.",
+          },
+        });
+      }
+
+      return res.status(200).json({
+        dataSourceView: await dataSourceViewToPokeJSON(dataSourceView),
+      });
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForPoke(handler);

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/details.ts
@@ -23,9 +23,6 @@ import {
   safeParseJSON,
 } from "@app/types";
 import type { InternalConnectorType } from "@app/types/connectors/connectors_api";
-
-const { TEMPORAL_CONNECTORS_NAMESPACE = "" } = process.env;
-
 export type FeaturesType = {
   slackBotEnabled: boolean;
   googleDrivePdfEnabled: boolean;
@@ -322,14 +319,14 @@ async function handler(
             break;
         }
       }
-
+      const temporalWorkspace = config.getTemporalConnectorsNamespace() ?? "";
       return res.status(200).json({
         dataSource: dataSource.toJSON(),
         dataSourceViews: dataSourceViews.map((view) => view.toJSON()),
         coreDataSource: coreDataSourceRes.value.data_source,
         connector,
         features,
-        temporalWorkspace: TEMPORAL_CONNECTORS_NAMESPACE,
+        temporalWorkspace,
         temporalRunningWorkflows: workflowInfos,
       });
 

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/details.ts
@@ -1,0 +1,347 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import config from "@app/lib/api/config";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
+import { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import { getTemporalClientForConnectorsNamespace } from "@app/lib/temporal";
+import logger from "@app/logger/logger";
+import { apiError } from "@app/logger/withlogging";
+import type {
+  CoreAPIDataSource,
+  DataSourceType,
+  DataSourceViewType,
+  SlackAutoReadPattern,
+  WithAPIErrorResponse,
+} from "@app/types";
+import {
+  ConnectorsAPI,
+  CoreAPI,
+  isSlackAutoReadPatterns,
+  safeParseJSON,
+} from "@app/types";
+import type { InternalConnectorType } from "@app/types/connectors/connectors_api";
+
+const { TEMPORAL_CONNECTORS_NAMESPACE = "" } = process.env;
+
+export type FeaturesType = {
+  slackBotEnabled: boolean;
+  googleDrivePdfEnabled: boolean;
+  googleDriveLargeFilesEnabled: boolean;
+  googleDriveParallelSyncEnabled: boolean;
+  microsoftPdfEnabled: boolean;
+  microsoftLargeFilesEnabled: boolean;
+  googleDriveCsvEnabled: boolean;
+  microsoftCsvEnabled: boolean;
+  githubCodeSyncEnabled: boolean;
+  githubUseProxyEnabled: boolean;
+  autoReadChannelPatterns: SlackAutoReadPattern[];
+};
+
+export type PokeGetDataSourceDetails = {
+  dataSource: DataSourceType;
+  dataSourceViews: DataSourceViewType[];
+  coreDataSource: CoreAPIDataSource;
+  connector: InternalConnectorType | null;
+  features: FeaturesType;
+  temporalWorkspace: string;
+  temporalRunningWorkflows: {
+    workflowId: string;
+    runId: string;
+    status: string;
+  }[];
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<PokeGetDataSourceDetails>>,
+  session: SessionWithUser
+): Promise<void> {
+  const { wId, dsId } = req.query;
+  if (typeof wId !== "string" || typeof dsId !== "string") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid workspace or data source ID.",
+      },
+    });
+  }
+
+  const auth = await Authenticator.fromSuperUserSession(session, wId);
+  const owner = auth.workspace();
+
+  if (!owner || !auth.isDustSuperUser()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_not_found",
+        message: "Workspace not found.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET":
+      const dataSource = await DataSourceResource.fetchById(auth, dsId, {
+        includeEditedBy: true,
+      });
+      if (!dataSource) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "data_source_not_found",
+            message: "Data source not found.",
+          },
+        });
+      }
+
+      const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
+      const coreDataSourceRes = await coreAPI.getDataSource({
+        projectId: dataSource.dustAPIProjectId,
+        dataSourceId: dataSource.dustAPIDataSourceId,
+      });
+
+      if (coreDataSourceRes.isErr()) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "data_source_not_found",
+            message: "Core data source not found.",
+          },
+        });
+      }
+
+      const dataSourceViews = await DataSourceViewResource.listForDataSources(
+        auth,
+        [dataSource]
+      );
+
+      let connector: InternalConnectorType | null = null;
+      const workflowInfos: {
+        workflowId: string;
+        runId: string;
+        status: string;
+      }[] = [];
+
+      if (dataSource.connectorId) {
+        const connectorsAPI = new ConnectorsAPI(
+          config.getConnectorsAPIConfig(),
+          logger
+        );
+        const connectorRes = await connectorsAPI.getConnector(
+          dataSource.connectorId
+        );
+        if (connectorRes.isOk()) {
+          connector = connectorRes.value;
+          const temporalClient =
+            await getTemporalClientForConnectorsNamespace();
+
+          const workflowsIter = temporalClient.workflow.list({
+            query: `ExecutionStatus = 'Running' AND connectorId = ${connector.id}`,
+          });
+
+          for await (const infos of workflowsIter) {
+            workflowInfos.push({
+              workflowId: infos.workflowId,
+              runId: infos.runId,
+              status: infos.status.name,
+            });
+          }
+        } else {
+          logger.error(
+            { connectorId: dataSource.connectorId },
+            "Failed to get connector"
+          );
+        }
+      }
+
+      const features: FeaturesType = {
+        slackBotEnabled: false,
+        googleDrivePdfEnabled: false,
+        googleDriveLargeFilesEnabled: false,
+        googleDriveParallelSyncEnabled: false,
+        microsoftPdfEnabled: false,
+        microsoftLargeFilesEnabled: false,
+        googleDriveCsvEnabled: false,
+        microsoftCsvEnabled: false,
+        githubCodeSyncEnabled: false,
+        githubUseProxyEnabled: false,
+        autoReadChannelPatterns: [],
+      };
+
+      const connectorsAPI = new ConnectorsAPI(
+        config.getConnectorsAPIConfig(),
+        logger
+      );
+
+      if (dataSource.connectorId) {
+        switch (dataSource.connectorProvider) {
+          case "slack_bot":
+          case "slack":
+            const botEnabledRes = await connectorsAPI.getConnectorConfig(
+              dataSource.connectorId,
+              "botEnabled"
+            );
+            if (botEnabledRes.isErr()) {
+              throw botEnabledRes.error;
+            }
+            features.slackBotEnabled =
+              botEnabledRes.value.configValue === "true";
+
+            const autoReadChannelPatternsRes =
+              await connectorsAPI.getConnectorConfig(
+                dataSource.connectorId,
+                "autoReadChannelPatterns"
+              );
+            if (autoReadChannelPatternsRes.isErr()) {
+              throw autoReadChannelPatternsRes.error;
+            }
+
+            const parsedAutoReadChannelPatternsRes = safeParseJSON(
+              autoReadChannelPatternsRes.value.configValue
+            );
+            if (parsedAutoReadChannelPatternsRes.isErr()) {
+              throw parsedAutoReadChannelPatternsRes.error;
+            }
+
+            if (
+              !parsedAutoReadChannelPatternsRes.value ||
+              !Array.isArray(parsedAutoReadChannelPatternsRes.value) ||
+              !isSlackAutoReadPatterns(parsedAutoReadChannelPatternsRes.value)
+            ) {
+              throw new Error("Invalid auto read channel patterns");
+            }
+
+            features.autoReadChannelPatterns =
+              parsedAutoReadChannelPatternsRes.value;
+            break;
+
+          case "google_drive":
+            const gdrivePdfEnabledRes = await connectorsAPI.getConnectorConfig(
+              dataSource.connectorId,
+              "pdfEnabled"
+            );
+            if (gdrivePdfEnabledRes.isErr()) {
+              throw gdrivePdfEnabledRes.error;
+            }
+            features.googleDrivePdfEnabled =
+              gdrivePdfEnabledRes.value.configValue === "true";
+
+            const gdriveCsvEnabledRes = await connectorsAPI.getConnectorConfig(
+              dataSource.connectorId,
+              "csvEnabled"
+            );
+            if (gdriveCsvEnabledRes.isErr()) {
+              throw gdriveCsvEnabledRes.error;
+            }
+            features.googleDriveCsvEnabled =
+              gdriveCsvEnabledRes.value.configValue === "true";
+
+            const gdriveLargeFilesEnabledRes =
+              await connectorsAPI.getConnectorConfig(
+                dataSource.connectorId,
+                "largeFilesEnabled"
+              );
+            if (gdriveLargeFilesEnabledRes.isErr()) {
+              throw gdriveLargeFilesEnabledRes.error;
+            }
+            features.googleDriveLargeFilesEnabled =
+              gdriveLargeFilesEnabledRes.value.configValue === "true";
+
+            const gdriveParallelSyncEnabledRes =
+              await connectorsAPI.getConnectorConfig(
+                dataSource.connectorId,
+                "useParallelSync"
+              );
+            if (gdriveParallelSyncEnabledRes.isErr()) {
+              throw gdriveParallelSyncEnabledRes.error;
+            }
+            features.googleDriveParallelSyncEnabled =
+              gdriveParallelSyncEnabledRes.value.configValue === "true";
+            break;
+
+          case "microsoft":
+            const microsoftPdfEnabledRes =
+              await connectorsAPI.getConnectorConfig(
+                dataSource.connectorId,
+                "pdfEnabled"
+              );
+            if (microsoftPdfEnabledRes.isErr()) {
+              throw microsoftPdfEnabledRes.error;
+            }
+            features.microsoftPdfEnabled =
+              microsoftPdfEnabledRes.value.configValue === "true";
+
+            const microsoftCsvEnabledRes =
+              await connectorsAPI.getConnectorConfig(
+                dataSource.connectorId,
+                "csvEnabled"
+              );
+            if (microsoftCsvEnabledRes.isErr()) {
+              throw microsoftCsvEnabledRes.error;
+            }
+            features.microsoftCsvEnabled =
+              microsoftCsvEnabledRes.value.configValue === "true";
+
+            const microsoftLargeFilesEnabledRes =
+              await connectorsAPI.getConnectorConfig(
+                dataSource.connectorId,
+                "largeFilesEnabled"
+              );
+            if (microsoftLargeFilesEnabledRes.isErr()) {
+              throw microsoftLargeFilesEnabledRes.error;
+            }
+            features.microsoftLargeFilesEnabled =
+              microsoftLargeFilesEnabledRes.value.configValue === "true";
+            break;
+
+          case "github":
+            const githubConnectorEnabledRes =
+              await connectorsAPI.getConnectorConfig(
+                dataSource.connectorId,
+                "codeSyncEnabled"
+              );
+            if (githubConnectorEnabledRes.isErr()) {
+              throw githubConnectorEnabledRes.error;
+            }
+            features.githubCodeSyncEnabled =
+              githubConnectorEnabledRes.value.configValue === "true";
+
+            const githubUseProxyRes = await connectorsAPI.getConnectorConfig(
+              dataSource.connectorId,
+              "useProxy"
+            );
+            if (githubUseProxyRes.isErr()) {
+              throw githubUseProxyRes.error;
+            }
+            features.githubUseProxyEnabled =
+              githubUseProxyRes.value.configValue === "true";
+            break;
+        }
+      }
+
+      return res.status(200).json({
+        dataSource: dataSource.toJSON(),
+        dataSourceViews: dataSourceViews.map((view) => view.toJSON()),
+        coreDataSource: coreDataSourceRes.value.data_source,
+        connector,
+        features,
+        temporalWorkspace: TEMPORAL_CONNECTORS_NAMESPACE,
+        temporalRunningWorkflows: workflowInfos,
+      });
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForPoke(handler);

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/document.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/document.ts
@@ -1,0 +1,98 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import config from "@app/lib/api/config";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
+import { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import logger from "@app/logger/logger";
+import { apiError } from "@app/logger/withlogging";
+import type { CoreAPIDocument, WithAPIErrorResponse } from "@app/types";
+import { CoreAPI } from "@app/types";
+
+export type PokeGetDocument = {
+  document: CoreAPIDocument;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<PokeGetDocument>>,
+  session: SessionWithUser
+): Promise<void> {
+  const { wId, dsId, documentId } = req.query;
+  if (
+    typeof wId !== "string" ||
+    typeof dsId !== "string" ||
+    typeof documentId !== "string"
+  ) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid workspace, data source, or document ID.",
+      },
+    });
+  }
+
+  const auth = await Authenticator.fromSuperUserSession(session, wId);
+  const owner = auth.workspace();
+
+  if (!owner || !auth.isDustSuperUser()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_not_found",
+        message: "Workspace not found.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET":
+      const dataSource = await DataSourceResource.fetchById(auth, dsId, {
+        includeEditedBy: true,
+      });
+
+      if (!dataSource) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "data_source_not_found",
+            message: "Data source not found.",
+          },
+        });
+      }
+
+      const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
+      const documentResult = await coreAPI.getDataSourceDocument({
+        projectId: dataSource.dustAPIProjectId,
+        dataSourceId: dataSource.dustAPIDataSourceId,
+        documentId,
+      });
+
+      if (documentResult.isErr()) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "data_source_document_not_found",
+            message: "Document not found.",
+          },
+        });
+      }
+
+      return res.status(200).json({
+        document: documentResult.value.document,
+      });
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForPoke(handler);

--- a/front/pages/api/poke/workspaces/[wId]/groups/[groupId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/groups/[groupId]/details.ts
@@ -1,0 +1,96 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import { getMembers } from "@app/lib/api/workspace";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import { apiError } from "@app/logger/withlogging";
+import type {
+  GroupType,
+  UserTypeWithWorkspaces,
+  WithAPIErrorResponse,
+} from "@app/types";
+
+export type PokeGetGroupDetails = {
+  members: UserTypeWithWorkspaces[];
+  group: GroupType;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<PokeGetGroupDetails>>,
+  session: SessionWithUser
+): Promise<void> {
+  const { wId, groupId } = req.query;
+  if (typeof wId !== "string" || typeof groupId !== "string") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid workspace or group ID.",
+      },
+    });
+  }
+
+  const auth = await Authenticator.fromSuperUserSession(session, wId);
+  const owner = auth.workspace();
+
+  if (!owner || !auth.isDustSuperUser()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_not_found",
+        message: "Workspace not found.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET":
+      const groupRes = await GroupResource.fetchById(auth, groupId);
+      if (groupRes.isErr()) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "group_not_found",
+            message: "Group not found.",
+          },
+        });
+      }
+
+      const group = groupRes.value;
+
+      const groupMembers = await group.getActiveMembers(auth);
+      const memberships = await getMembers(auth);
+
+      const userWithWorkspaces = groupMembers.reduce<UserTypeWithWorkspaces[]>(
+        (acc, user) => {
+          const member = memberships.members.find((m) => m.sId === user.sId);
+
+          if (member) {
+            acc.push(member);
+          }
+
+          return acc;
+        },
+        []
+      );
+
+      return res.status(200).json({
+        members: userWithWorkspaces,
+        group: group.toJSON(),
+      });
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForPoke(handler);

--- a/front/pages/api/poke/workspaces/[wId]/mcp_server_views/[svId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/mcp_server_views/[svId]/details.ts
@@ -1,0 +1,73 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
+import { mcpServerViewToPokeJSON } from "@app/lib/poke/utils";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { PokeMCPServerViewType, WithAPIErrorResponse } from "@app/types";
+
+export type PokeGetMCPServerViewDetails = {
+  mcpServerView: PokeMCPServerViewType;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<PokeGetMCPServerViewDetails>>,
+  session: SessionWithUser
+): Promise<void> {
+  const { wId, svId } = req.query;
+  if (typeof wId !== "string" || typeof svId !== "string") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid workspace or MCP server view ID.",
+      },
+    });
+  }
+
+  const auth = await Authenticator.fromSuperUserSession(session, wId);
+  const owner = auth.workspace();
+
+  if (!owner || !auth.isDustSuperUser()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_not_found",
+        message: "Workspace not found.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET":
+      const mcpServerView = await MCPServerViewResource.fetchById(auth, svId);
+
+      if (!mcpServerView) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "mcp_server_view_not_found",
+            message: "MCP server view not found.",
+          },
+        });
+      }
+
+      return res.status(200).json({
+        mcpServerView: await mcpServerViewToPokeJSON(mcpServerView, auth),
+      });
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForPoke(handler);

--- a/front/pages/api/poke/workspaces/[wId]/mcp_server_views/[svId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/mcp_server_views/[svId]/details.ts
@@ -54,9 +54,12 @@ async function handler(
           },
         });
       }
-
+      const mcpServerViewJSON = await mcpServerViewToPokeJSON(
+        mcpServerView,
+        auth
+      );
       return res.status(200).json({
-        mcpServerView: await mcpServerViewToPokeJSON(mcpServerView, auth),
+        mcpServerView: mcpServerViewJSON,
       });
 
     default:

--- a/front/pages/api/poke/workspaces/[wId]/memberships.ts
+++ b/front/pages/api/poke/workspaces/[wId]/memberships.ts
@@ -1,0 +1,81 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import { getMembershipInvitationUrl } from "@app/lib/api/invitation";
+import { getMembers } from "@app/lib/api/workspace";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
+import { MembershipInvitationResource } from "@app/lib/resources/membership_invitation_resource";
+import { apiError } from "@app/logger/withlogging";
+import type {
+  MembershipInvitationTypeWithLink,
+  UserTypeWithWorkspaces,
+  WithAPIErrorResponse,
+} from "@app/types";
+
+export type PokeGetMemberships = {
+  members: UserTypeWithWorkspaces[];
+  pendingInvitations: MembershipInvitationTypeWithLink[];
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<PokeGetMemberships>>,
+  session: SessionWithUser
+): Promise<void> {
+  const { wId } = req.query;
+  if (typeof wId !== "string") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid workspace ID.",
+      },
+    });
+  }
+
+  const auth = await Authenticator.fromSuperUserSession(session, wId);
+  const owner = auth.workspace();
+
+  if (!owner || !auth.isDustSuperUser()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_not_found",
+        message: "Workspace not found.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET":
+      const [{ members }, pendingInvitations] = await Promise.all([
+        getMembers(auth),
+        MembershipInvitationResource.getPendingInvitations(auth, {
+          includeExpired: true,
+        }),
+      ]);
+
+      return res.status(200).json({
+        members,
+        pendingInvitations: pendingInvitations.map((invite) => {
+          const i = invite.toJSON();
+          return {
+            ...i,
+            inviteLink: getMembershipInvitationUrl(owner, i),
+          };
+        }),
+      });
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForPoke(handler);

--- a/front/pages/api/poke/workspaces/[wId]/skills/[sId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/skills/[sId]/details.ts
@@ -1,0 +1,85 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { SpaceType, UserType, WithAPIErrorResponse } from "@app/types";
+import type { SkillType } from "@app/types/assistant/skill_configuration";
+
+export type PokeGetSkillDetails = {
+  skill: SkillType;
+  editedByUser: UserType | null;
+  spaces: SpaceType[];
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<PokeGetSkillDetails>>,
+  session: SessionWithUser
+): Promise<void> {
+  const { wId, sId } = req.query;
+  if (typeof wId !== "string" || typeof sId !== "string") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid workspace or skill ID.",
+      },
+    });
+  }
+
+  const auth = await Authenticator.fromSuperUserSession(session, wId);
+  const owner = auth.workspace();
+
+  if (!owner || !auth.isDustSuperUser()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_not_found",
+        message: "Workspace not found.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET":
+      const skill = await SkillResource.fetchById(auth, sId);
+
+      if (!skill) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "skill_not_found",
+            message: "Skill not found.",
+          },
+        });
+      }
+
+      const serializedSkill = skill.toJSON(auth);
+      const editedByUser = await skill.fetchEditedByUser(auth);
+      const spaces = await SpaceResource.fetchByIds(
+        auth,
+        serializedSkill.requestedSpaceIds
+      );
+
+      return res.status(200).json({
+        skill: serializedSkill,
+        editedByUser: editedByUser ? editedByUser.toJSON() : null,
+        spaces: spaces.map((s) => s.toJSON()),
+      });
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForPoke(handler);

--- a/front/pages/api/poke/workspaces/[wId]/spaces/[spaceId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/spaces/[spaceId]/details.ts
@@ -1,0 +1,105 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import { getMembers } from "@app/lib/api/workspace";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
+import { spaceToPokeJSON } from "@app/lib/poke/utils";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { apiError } from "@app/logger/withlogging";
+import type {
+  PokeSpaceType,
+  UserTypeWithWorkspaces,
+  WithAPIErrorResponse,
+} from "@app/types";
+
+export type PokeGetSpaceDetails = {
+  members: Record<string, UserTypeWithWorkspaces[]>;
+  space: PokeSpaceType;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<PokeGetSpaceDetails>>,
+  session: SessionWithUser
+): Promise<void> {
+  const { wId, spaceId } = req.query;
+  if (typeof wId !== "string" || typeof spaceId !== "string") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid workspace or space ID.",
+      },
+    });
+  }
+
+  const auth = await Authenticator.fromSuperUserSession(session, wId);
+  const owner = auth.workspace();
+
+  if (!owner || !auth.isDustSuperUser()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_not_found",
+        message: "Workspace not found.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET":
+      const space = await SpaceResource.fetchById(auth, spaceId);
+      if (!space) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "space_not_found",
+            message: "Space not found.",
+          },
+        });
+      }
+
+      const members: Record<string, UserTypeWithWorkspaces[]> = {};
+
+      const allGroups = space.groups.filter((g) =>
+        space.managementMode === "manual"
+          ? g.kind === "regular" || g.kind === "space_editors"
+          : g.kind === "provisioned"
+      );
+
+      const memberships = await getMembers(auth);
+
+      for (const group of allGroups) {
+        const groupMembers = await group.getActiveMembers(auth);
+        members[group.name] = groupMembers.reduce<UserTypeWithWorkspaces[]>(
+          (acc, user) => {
+            const member = memberships.members.find((m) => m.sId === user.sId);
+
+            if (member) {
+              acc.push(member);
+            }
+
+            return acc;
+          },
+          []
+        );
+      }
+
+      return res.status(200).json({
+        members,
+        space: spaceToPokeJSON(space),
+      });
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForPoke(handler);

--- a/front/pages/api/poke/workspaces/[wId]/triggers/[tId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/triggers/[tId]/details.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";

--- a/front/pages/api/poke/workspaces/[wId]/triggers/[tId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/triggers/[tId]/details.ts
@@ -1,0 +1,103 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
+import { TriggerResource } from "@app/lib/resources/trigger_resource";
+import { UserResource } from "@app/lib/resources/user_resource";
+import { apiError } from "@app/logger/withlogging";
+import type {
+  LightAgentConfigurationType,
+  UserType,
+  WithAPIErrorResponse,
+} from "@app/types";
+import type { TriggerType } from "@app/types/assistant/triggers";
+
+export type PokeGetTriggerDetails = {
+  trigger: TriggerType;
+  agent: LightAgentConfigurationType;
+  editorUser: UserType | null;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<PokeGetTriggerDetails>>,
+  session: SessionWithUser
+): Promise<void> {
+  const { wId, tId } = req.query;
+  if (typeof wId !== "string" || typeof tId !== "string") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid workspace or trigger ID.",
+      },
+    });
+  }
+
+  const auth = await Authenticator.fromSuperUserSession(session, wId);
+  const owner = auth.workspace();
+
+  if (!owner || !auth.isDustSuperUser()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_not_found",
+        message: "Workspace not found.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET":
+      const trigger = await TriggerResource.fetchById(auth, tId);
+      if (!trigger) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "trigger_not_found",
+            message: "Trigger not found.",
+          },
+        });
+      }
+
+      const agentConfiguration = await getAgentConfiguration(auth, {
+        agentId: trigger.agentConfigurationId,
+        variant: "full",
+      });
+      if (!agentConfiguration) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "agent_configuration_not_found",
+            message: "Agent configuration not found.",
+          },
+        });
+      }
+
+      // Fetch editor user
+      const editorUsers = trigger.editor
+        ? await UserResource.fetchByModelIds([trigger.editor])
+        : [];
+      const editorUser =
+        editorUsers.length > 0 ? editorUsers[0].toJSON() : null;
+
+      return res.status(200).json({
+        trigger: trigger.toJSON(),
+        agent: agentConfiguration,
+        editorUser,
+      });
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForPoke(handler);

--- a/front/pages/api/poke/workspaces/[wId]/workspace-info.ts
+++ b/front/pages/api/poke/workspaces/[wId]/workspace-info.ts
@@ -1,0 +1,145 @@
+import { format } from "date-fns/format";
+import keyBy from "lodash/keyBy";
+import type { NextApiRequest, NextApiResponse } from "next";
+import type Stripe from "stripe";
+
+import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import config from "@app/lib/api/config";
+import { getWorkspaceCreationDate } from "@app/lib/api/workspace";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
+import { PlanModel, SubscriptionModel } from "@app/lib/models/plan";
+import { renderSubscriptionFromModels } from "@app/lib/plans/renderers";
+import { getStripeSubscription } from "@app/lib/plans/stripe";
+import { ExtensionConfigurationResource } from "@app/lib/resources/extension";
+import { ProgrammaticUsageConfigurationResource } from "@app/lib/resources/programmatic_usage_configuration_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { apiError } from "@app/logger/withlogging";
+import type {
+  ExtensionConfigurationType,
+  ProgrammaticUsageConfigurationType,
+  SubscriptionType,
+  WhitelistableFeature,
+  WithAPIErrorResponse,
+  WorkspaceDomain,
+} from "@app/types";
+import { WHITELISTABLE_FEATURES } from "@app/types";
+
+export type PokeGetWorkspaceInfo = {
+  activeSubscription: SubscriptionType;
+  baseUrl: string;
+  extensionConfig: ExtensionConfigurationType | null;
+  programmaticUsageConfig: ProgrammaticUsageConfigurationType | null;
+  stripeSubscription: Stripe.Subscription | null;
+  subscriptions: SubscriptionType[];
+  whitelistableFeatures: WhitelistableFeature[];
+  workspaceCreationDay: string;
+  workspaceVerifiedDomains: WorkspaceDomain[];
+  workosEnvironmentId: string;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<PokeGetWorkspaceInfo>>,
+  session: SessionWithUser
+): Promise<void> {
+  const { wId } = req.query;
+  if (typeof wId !== "string") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid workspace ID.",
+      },
+    });
+  }
+
+  const auth = await Authenticator.fromSuperUserSession(session, wId);
+  const owner = auth.workspace();
+  const activeSubscription = auth.subscription();
+
+  if (!owner || !activeSubscription || !auth.isDustSuperUser()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_not_found",
+        message: "Workspace not found.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET":
+      const subscriptionModels = await SubscriptionModel.findAll({
+        where: { workspaceId: owner.id },
+      });
+
+      const plans = keyBy(
+        await PlanModel.findAll({
+          where: {
+            id: subscriptionModels.map((s) => s.planId),
+          },
+        }),
+        "id"
+      );
+
+      const subscriptions = subscriptionModels.map((s) =>
+        renderSubscriptionFromModels({
+          plan: plans[s.planId],
+          activeSubscription: s,
+        })
+      );
+
+      const workspaceResource = await WorkspaceResource.fetchById(owner.sId);
+      if (!workspaceResource) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "workspace_not_found",
+            message: "Workspace not found.",
+          },
+        });
+      }
+      const workspaceVerifiedDomains =
+        await workspaceResource.getVerifiedDomains();
+
+      const workspaceCreationDay = await getWorkspaceCreationDate(owner.sId);
+
+      const extensionConfig =
+        await ExtensionConfigurationResource.fetchForWorkspace(auth);
+
+      const programmaticUsageConfig =
+        await ProgrammaticUsageConfigurationResource.fetchByWorkspaceId(auth);
+
+      let stripeSubscription: Stripe.Subscription | null = null;
+      if (activeSubscription.stripeSubscriptionId) {
+        stripeSubscription = await getStripeSubscription(
+          activeSubscription.stripeSubscriptionId
+        );
+      }
+
+      return res.status(200).json({
+        activeSubscription,
+        stripeSubscription,
+        subscriptions,
+        whitelistableFeatures: WHITELISTABLE_FEATURES,
+        workspaceVerifiedDomains,
+        workspaceCreationDay: format(workspaceCreationDay, "yyyy-MM-dd"),
+        extensionConfig: extensionConfig?.toJSON() ?? null,
+        programmaticUsageConfig: programmaticUsageConfig?.toJSON() ?? null,
+        baseUrl: config.getClientFacingUrl(),
+        workosEnvironmentId: config.getWorkOSEnvironmentId(),
+      });
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForPoke(handler);

--- a/front/pages/poke/[wId]/assistants/[aId]/index.tsx
+++ b/front/pages/poke/[wId]/assistants/[aId]/index.tsx
@@ -24,14 +24,14 @@ import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 import { decodeSqids } from "@app/lib/utils";
 import { usePokeAgentDetails } from "@app/poke/swr/agent_details";
 import type { WorkspaceType } from "@app/types";
-import { SUPPORTED_MODEL_CONFIGS } from "@app/types";
+import { isString, SUPPORTED_MODEL_CONFIGS } from "@app/types";
 
 export const getServerSideProps = withSuperUserAuthRequirements<{
   owner: WorkspaceType;
   params: { wId: string; aId: string };
 }>(async (context, auth) => {
-  const aId = context.params?.aId;
-  if (!aId || typeof aId !== "string") {
+  const { wId, aId } = context.params ?? {};
+  if (!isString(wId) || !isString(aId)) {
     return {
       notFound: true,
     };
@@ -40,7 +40,7 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
   return {
     props: {
       owner: auth.getNonNullableWorkspace(),
-      params: context.params as { wId: string; aId: string },
+      params: { wId, aId },
     },
   };
 });

--- a/front/pages/poke/[wId]/assistants/[aId]/triggers/[triggerId]/index.tsx
+++ b/front/pages/poke/[wId]/assistants/[aId]/triggers/[triggerId]/index.tsx
@@ -10,6 +10,7 @@ import { ViewTriggerTable } from "@app/components/poke/triggers/view";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 import { usePokeTriggerDetails } from "@app/poke/swr/trigger_details";
 import type { LightWorkspaceType, WorkspaceType } from "@app/types";
+import { isString } from "@app/types";
 
 export const getServerSideProps = withSuperUserAuthRequirements<{
   owner: LightWorkspaceType;
@@ -17,9 +18,8 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
 }>(async (context, auth) => {
   const owner = auth.getNonNullableWorkspace();
 
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-  const { aId, triggerId } = context.params || {};
-  if (typeof aId !== "string" || typeof triggerId !== "string") {
+  const { wId, aId, triggerId } = context.params ?? {};
+  if (!isString(wId) || !isString(aId) || !isString(triggerId)) {
     return {
       notFound: true,
     };
@@ -28,7 +28,7 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
   return {
     props: {
       owner,
-      params: context.params as { wId: string; aId: string; triggerId: string },
+      params: { wId, aId, triggerId },
     },
   };
 });

--- a/front/pages/poke/[wId]/conversation/[cId]/index.tsx
+++ b/front/pages/poke/[wId]/conversation/[cId]/index.tsx
@@ -36,7 +36,7 @@ import type {
   PokeAgentMessageType,
   UserMessageType,
 } from "@app/types";
-import { assertNever, isFileContentFragment } from "@app/types";
+import { assertNever, isFileContentFragment, isString } from "@app/types";
 
 export const getServerSideProps = withSuperUserAuthRequirements<{
   owner: LightWorkspaceType;
@@ -44,8 +44,8 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
 }>(async (context, auth) => {
   const owner = auth.getNonNullableWorkspace();
 
-  const cId = context.params?.cId;
-  if (!cId || typeof cId !== "string") {
+  const { wId, cId } = context.params ?? {};
+  if (!isString(wId) || !isString(cId)) {
     return {
       notFound: true,
     };
@@ -54,7 +54,7 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
   return {
     props: {
       owner,
-      params: context.params as { wId: string; cId: string },
+      params: { wId, cId },
     },
   };
 });

--- a/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
@@ -44,7 +44,7 @@ import type {
   WorkspaceType,
   ZendeskFetchTicketResponseType,
 } from "@app/types";
-import { normalizeError } from "@app/types";
+import { isString, normalizeError } from "@app/types";
 
 const maxNotionParentChainDepth = 20;
 
@@ -54,8 +54,8 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
 }>(async (context, auth) => {
   const owner = auth.getNonNullableWorkspace();
 
-  const { dsId } = context.params ?? {};
-  if (typeof dsId !== "string") {
+  const { wId, dsId } = context.params ?? {};
+  if (!isString(wId) || !isString(dsId)) {
     return {
       notFound: true,
     };
@@ -64,7 +64,7 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
   return {
     props: {
       owner,
-      params: context.params as { wId: string; dsId: string },
+      params: { wId, dsId },
     },
   };
 });

--- a/front/pages/poke/[wId]/data_sources/[dsId]/notion-requests.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/notion-requests.tsx
@@ -1,5 +1,6 @@
 import { Button, Input, Spinner, TextArea } from "@dust-tt/sparkle";
 import { JsonViewer } from "@textea/json-viewer";
+import type { InferGetServerSidePropsType } from "next";
 import type { ReactElement } from "react";
 import { useState } from "react";
 
@@ -7,12 +8,12 @@ import PokeLayout from "@app/components/poke/PokeLayout";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { clientFetch } from "@app/lib/egress/client";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
-import { DataSourceResource } from "@app/lib/resources/data_source_resource";
-import type { DataSourceType, WorkspaceType } from "@app/types";
+import { usePokeDataSourceDetails } from "@app/poke/swr/data_source_details";
+import type { LightWorkspaceType } from "@app/types";
 
 export const getServerSideProps = withSuperUserAuthRequirements<{
-  owner: WorkspaceType;
-  dataSource: DataSourceType;
+  owner: LightWorkspaceType;
+  params: { wId: string; dsId: string };
 }>(async (context, auth) => {
   const owner = auth.getNonNullableWorkspace();
 
@@ -24,41 +25,21 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
     };
   }
 
-  const dataSource = await DataSourceResource.fetchById(auth, dsId, {
-    includeEditedBy: true,
-  });
-  if (!dataSource) {
-    return {
-      notFound: true,
-    };
-  }
-
-  // Only allow for Notion datasources
-  if (dataSource.connectorProvider !== "notion") {
-    return {
-      notFound: true,
-    };
-  }
-
   return {
     props: {
       owner,
-      dataSource: dataSource.toJSON(),
+      params: context.params as { wId: string; dsId: string },
     },
   };
 });
 
 type HttpMethod = "GET" | "POST";
 
-interface NotionRequestsPageProps {
-  owner: WorkspaceType;
-  dataSource: DataSourceType;
-}
-
 export default function NotionRequestsPage({
   owner,
-  dataSource,
-}: NotionRequestsPageProps) {
+  params,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  const { dsId } = params;
   const { isDark } = useTheme();
   const [url, setUrl] = useState("");
   const [method, setMethod] = useState<HttpMethod>("GET");
@@ -69,6 +50,43 @@ export default function NotionRequestsPage({
     status: number;
     data: unknown;
   } | null>(null);
+
+  const {
+    data: dataSourceDetails,
+    isLoading,
+    isError,
+  } = usePokeDataSourceDetails({
+    owner,
+    dsId,
+    disabled: false,
+  });
+
+  if (isLoading) {
+    return (
+      <div className="flex h-64 items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (isError || !dataSourceDetails) {
+    return (
+      <div className="flex h-64 items-center justify-center">
+        <p>Error loading data source details.</p>
+      </div>
+    );
+  }
+
+  const { dataSource } = dataSourceDetails;
+
+  // Only allow for Notion datasources
+  if (dataSource.connectorProvider !== "notion") {
+    return (
+      <div className="flex h-64 items-center justify-center">
+        <p>This page is only available for Notion data sources.</p>
+      </div>
+    );
+  }
 
   const handleExecuteRequest = async () => {
     if (!url.trim()) {
@@ -259,11 +277,9 @@ export default function NotionRequestsPage({
 
 NotionRequestsPage.getLayout = (
   page: ReactElement,
-  { owner, dataSource }: { owner: WorkspaceType; dataSource: DataSourceType }
+  { owner }: { owner: LightWorkspaceType }
 ) => {
   return (
-    <PokeLayout title={`${owner.name} - Notion Requests - ${dataSource.name}`}>
-      {page}
-    </PokeLayout>
+    <PokeLayout title={`${owner.name} - Notion Requests`}>{page}</PokeLayout>
   );
 };

--- a/front/pages/poke/[wId]/data_sources/[dsId]/notion-requests.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/notion-requests.tsx
@@ -10,6 +10,7 @@ import { clientFetch } from "@app/lib/egress/client";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 import { usePokeDataSourceDetails } from "@app/poke/swr/data_source_details";
 import type { LightWorkspaceType } from "@app/types";
+import { isString } from "@app/types";
 
 export const getServerSideProps = withSuperUserAuthRequirements<{
   owner: LightWorkspaceType;
@@ -17,9 +18,8 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
 }>(async (context, auth) => {
   const owner = auth.getNonNullableWorkspace();
 
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-  const { dsId } = context.params || {};
-  if (typeof dsId !== "string") {
+  const { wId, dsId } = context.params ?? {};
+  if (!isString(wId) || !isString(dsId)) {
     return {
       notFound: true,
     };
@@ -28,7 +28,7 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
   return {
     props: {
       owner,
-      params: context.params as { wId: string; dsId: string },
+      params: { wId, dsId },
     },
   };
 });

--- a/front/pages/poke/[wId]/data_sources/[dsId]/query.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/query.tsx
@@ -9,6 +9,7 @@ import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 import { usePokeTables } from "@app/poke/swr";
 import { usePokeDataSourceDetails } from "@app/poke/swr/data_source_details";
 import type { DataSourceType, LightWorkspaceType } from "@app/types";
+import { isString } from "@app/types";
 
 export const getServerSideProps = withSuperUserAuthRequirements<{
   owner: LightWorkspaceType;
@@ -16,9 +17,8 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
 }>(async (context, auth) => {
   const owner = auth.getNonNullableWorkspace();
 
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-  const { dsId } = context.params || {};
-  if (typeof dsId !== "string") {
+  const { wId, dsId } = context.params ?? {};
+  if (!isString(wId) || !isString(dsId)) {
     return {
       notFound: true,
     };
@@ -27,7 +27,7 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
   return {
     props: {
       owner,
-      params: context.params as { wId: string; dsId: string },
+      params: { wId, dsId },
     },
   };
 });

--- a/front/pages/poke/[wId]/data_sources/[dsId]/query.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/query.tsx
@@ -6,13 +6,13 @@ import { useState } from "react";
 import PokeLayout from "@app/components/poke/PokeLayout";
 import { clientFetch } from "@app/lib/egress/client";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
-import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { usePokeTables } from "@app/poke/swr";
-import type { DataSourceType, WorkspaceType } from "@app/types";
+import { usePokeDataSourceDetails } from "@app/poke/swr/data_source_details";
+import type { DataSourceType, LightWorkspaceType } from "@app/types";
 
 export const getServerSideProps = withSuperUserAuthRequirements<{
-  owner: WorkspaceType;
-  dataSource: DataSourceType;
+  owner: LightWorkspaceType;
+  params: { wId: string; dsId: string };
 }>(async (context, auth) => {
   const owner = auth.getNonNullableWorkspace();
 
@@ -24,19 +24,10 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
     };
   }
 
-  const dataSource = await DataSourceResource.fetchById(auth, dsId, {
-    includeEditedBy: true,
-  });
-  if (!dataSource) {
-    return {
-      notFound: true,
-    };
-  }
-
   return {
     props: {
       owner,
-      dataSource: dataSource.toJSON(),
+      params: context.params as { wId: string; dsId: string },
     },
   };
 });
@@ -49,10 +40,12 @@ type QueryResult = {
   results: Array<Record<string, string | number | boolean | null | undefined>>;
 };
 
-export default function DataSourceQueryPage({
-  owner,
-  dataSource,
-}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+interface QueryContentProps {
+  owner: LightWorkspaceType;
+  dataSource: DataSourceType;
+}
+
+function QueryContent({ owner, dataSource }: QueryContentProps) {
   const [query, setQuery] = useState("");
   const [selectedTables, setSelectedTables] = useState<Set<string>>(new Set());
   const [isExecuting, setIsExecuting] = useState(false);
@@ -269,13 +262,46 @@ export default function DataSourceQueryPage({
   );
 }
 
+export default function DataSourceQueryPage({
+  owner,
+  params,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  const { dsId } = params;
+
+  const {
+    data: dataSourceDetails,
+    isLoading,
+    isError,
+  } = usePokeDataSourceDetails({
+    owner,
+    dsId,
+    disabled: false,
+  });
+
+  if (isLoading) {
+    return (
+      <div className="flex h-64 items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (isError || !dataSourceDetails) {
+    return (
+      <div className="flex h-64 items-center justify-center">
+        <p>Error loading data source details.</p>
+      </div>
+    );
+  }
+
+  return (
+    <QueryContent owner={owner} dataSource={dataSourceDetails.dataSource} />
+  );
+}
+
 DataSourceQueryPage.getLayout = (
   page: ReactElement,
-  { owner, dataSource }: { owner: WorkspaceType; dataSource: DataSourceType }
+  { owner }: { owner: LightWorkspaceType }
 ) => {
-  return (
-    <PokeLayout title={`${owner.name} - Query ${dataSource.name}`}>
-      {page}
-    </PokeLayout>
-  );
+  return <PokeLayout title={`${owner.name} - Query`}>{page}</PokeLayout>;
 };

--- a/front/pages/poke/[wId]/data_sources/[dsId]/search.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/search.tsx
@@ -10,6 +10,7 @@ import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 import { classNames, timeAgoFrom } from "@app/lib/utils";
 import { usePokeDataSourceDetails } from "@app/poke/swr/data_source_details";
 import type { DocumentType, LightWorkspaceType } from "@app/types";
+import { isString } from "@app/types";
 
 export const getServerSideProps = withSuperUserAuthRequirements<{
   owner: LightWorkspaceType;
@@ -17,9 +18,8 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
 }>(async (context, auth) => {
   const owner = auth.getNonNullableWorkspace();
 
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-  const { dsId } = context.params || {};
-  if (typeof dsId !== "string") {
+  const { wId, dsId } = context.params ?? {};
+  if (!isString(wId) || !isString(dsId)) {
     return {
       notFound: true,
     };
@@ -28,7 +28,7 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
   return {
     props: {
       owner,
-      params: context.params as { wId: string; dsId: string },
+      params: { wId, dsId },
     },
   };
 });

--- a/front/pages/poke/[wId]/data_sources/[dsId]/search.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/search.tsx
@@ -1,4 +1,4 @@
-import { Input } from "@dust-tt/sparkle";
+import { Input, Spinner } from "@dust-tt/sparkle";
 import type { InferGetServerSidePropsType } from "next";
 import type { ReactElement } from "react";
 import { useEffect, useState } from "react";
@@ -7,13 +7,13 @@ import PokeLayout from "@app/components/poke/PokeLayout";
 import { getDisplayNameForDocument } from "@app/lib/data_sources";
 import { clientFetch } from "@app/lib/egress/client";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
-import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { classNames, timeAgoFrom } from "@app/lib/utils";
-import type { DataSourceType, DocumentType, WorkspaceType } from "@app/types";
+import { usePokeDataSourceDetails } from "@app/poke/swr/data_source_details";
+import type { DocumentType, LightWorkspaceType } from "@app/types";
 
 export const getServerSideProps = withSuperUserAuthRequirements<{
-  owner: WorkspaceType;
-  dataSource: DataSourceType;
+  owner: LightWorkspaceType;
+  params: { wId: string; dsId: string };
 }>(async (context, auth) => {
   const owner = auth.getNonNullableWorkspace();
 
@@ -25,37 +25,39 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
     };
   }
 
-  const dataSource = await DataSourceResource.fetchById(auth, dsId, {
-    includeEditedBy: true,
-  });
-  if (!dataSource) {
-    return {
-      notFound: true,
-    };
-  }
-
   return {
     props: {
       owner,
-      dataSource: dataSource.toJSON(),
+      params: context.params as { wId: string; dsId: string },
     },
   };
 });
 
-export default function DataSourceView({
+export default function DataSourceSearchPage({
   owner,
-  dataSource,
+  params,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  const { dsId } = params;
   const [searchQuery, setSearchQuery] = useState("");
   const [tagsIn, setTagsIn] = useState("");
   const [tagsNotIn, setTagsNotIn] = useState("");
   const [documents, setDocuments] = useState<DocumentType[]>([]);
   const [expandedChunkId, setExpandedChunkId] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState<boolean>(false);
-  const [error, setError] = useState<boolean>(false);
+  const [isSearching, setIsSearching] = useState<boolean>(false);
+  const [searchError, setSearchError] = useState<boolean>(false);
   const [displayNameByDocId, setDisplayNameByDocId] = useState<
     Record<string, string>
   >({});
+
+  const {
+    data: dataSourceDetails,
+    isLoading,
+    isError,
+  } = usePokeDataSourceDetails({
+    owner,
+    dsId,
+    disabled: false,
+  });
 
   useEffect(
     () =>
@@ -72,7 +74,13 @@ export default function DataSourceView({
   );
 
   useEffect(() => {
-    setError(false);
+    if (!dataSourceDetails) {
+      return;
+    }
+
+    const { dataSource } = dataSourceDetails;
+
+    setSearchError(false);
     let isCancelled = false;
     void (async () => {
       if (
@@ -84,7 +92,7 @@ export default function DataSourceView({
 
         return;
       }
-      setIsLoading(true);
+      setIsSearching(true);
       const searchParams = new URLSearchParams();
       if (searchQuery.trim().length > 0) {
         searchParams.append("query", searchQuery);
@@ -108,17 +116,17 @@ export default function DataSourceView({
           },
         }
       );
-      setIsLoading(false);
+      setIsSearching(false);
       if (isCancelled) {
         return;
       }
 
       if (searchRes.ok) {
-        setError(false);
-        const documents = await searchRes.json();
-        setDocuments(documents.documents);
+        setSearchError(false);
+        const documentsResult = await searchRes.json();
+        setDocuments(documentsResult.documents);
       } else {
-        setError(true);
+        setSearchError(true);
         setDocuments([]);
       }
     })();
@@ -126,7 +134,25 @@ export default function DataSourceView({
     return () => {
       isCancelled = true;
     };
-  }, [dataSource.sId, owner.sId, searchQuery, tagsIn, tagsNotIn]);
+  }, [dataSourceDetails, owner.sId, searchQuery, tagsIn, tagsNotIn]);
+
+  if (isLoading) {
+    return (
+      <div className="flex h-64 items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (isError || !dataSourceDetails) {
+    return (
+      <div className="flex h-64 items-center justify-center">
+        <p>Error loading data source details.</p>
+      </div>
+    );
+  }
+
+  const { dataSource } = dataSourceDetails;
 
   const onDisplayDocumentSource = (documentId: string) => {
     if (
@@ -196,7 +222,7 @@ export default function DataSourceView({
         </div>
         <div className="mt-8 overflow-hidden">
           <ul role="list" className="space-y-4">
-            {!isLoading &&
+            {!isSearching &&
               documents.map((d: DocumentType) => (
                 <li
                   key={d.document_id}
@@ -276,18 +302,18 @@ export default function DataSourceView({
               ))}
             <div className="mt-4 flex flex-col items-center justify-center text-sm text-gray-500">
               {(() => {
-                if (error) {
+                if (searchError) {
                   return (
                     <p className="copy-sm font-semibold text-warning">
                       Something went wrong...
                     </p>
                   );
                 }
-                if (isLoading) {
+                if (isSearching) {
                   return <p>Searching...</p>;
                 }
                 if (
-                  !isLoading &&
+                  !isSearching &&
                   searchQuery.length == 0 &&
                   tagsIn.length == 0 &&
                   tagsNotIn.length == 0 &&
@@ -296,7 +322,7 @@ export default function DataSourceView({
                   return null;
                 }
                 if (
-                  !isLoading &&
+                  !isSearching &&
                   (searchQuery.length > 0 ||
                     tagsIn.length > 0 ||
                     tagsNotIn.length > 0) &&
@@ -315,13 +341,9 @@ export default function DataSourceView({
   );
 }
 
-DataSourceView.getLayout = (
+DataSourceSearchPage.getLayout = (
   page: ReactElement,
-  { owner, dataSource }: { owner: WorkspaceType; dataSource: DataSourceType }
+  { owner }: { owner: LightWorkspaceType }
 ) => {
-  return (
-    <PokeLayout title={`${owner.name} - Search ${dataSource.name}`}>
-      {page}
-    </PokeLayout>
-  );
+  return <PokeLayout title={`${owner.name} - Search`}>{page}</PokeLayout>;
 };

--- a/front/pages/poke/[wId]/data_sources/[dsId]/view.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/view.tsx
@@ -8,6 +8,7 @@ import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 import { classNames } from "@app/lib/utils";
 import { usePokeDocument } from "@app/poke/swr/document";
 import type { LightWorkspaceType } from "@app/types";
+import { isString } from "@app/types";
 
 export const getServerSideProps = withSuperUserAuthRequirements<{
   owner: LightWorkspaceType;
@@ -15,9 +16,8 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
 }>(async (context, auth) => {
   const owner = auth.getNonNullableWorkspace();
 
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-  const { dsId } = context.params || {};
-  if (typeof dsId !== "string") {
+  const { wId, dsId } = context.params ?? {};
+  if (!isString(wId) || !isString(dsId)) {
     return {
       notFound: true,
     };
@@ -26,7 +26,7 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
   return {
     props: {
       owner,
-      params: context.params as { wId: string; dsId: string },
+      params: { wId, dsId },
     },
   };
 });

--- a/front/pages/poke/[wId]/data_sources/[dsId]/view.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/view.tsx
@@ -1,19 +1,20 @@
-import { Input, Page, TextArea } from "@dust-tt/sparkle";
+import { Input, Page, Spinner, TextArea } from "@dust-tt/sparkle";
 import type { InferGetServerSidePropsType } from "next";
+import { useSearchParams } from "next/navigation";
 import type { ReactElement } from "react";
 
 import PokeLayout from "@app/components/poke/PokeLayout";
-import config from "@app/lib/api/config";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
-import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { classNames } from "@app/lib/utils";
-import logger from "@app/logger/logger";
-import type { CoreAPIDocument } from "@app/types";
-import { CoreAPI } from "@app/types";
+import { usePokeDocument } from "@app/poke/swr/document";
+import type { LightWorkspaceType } from "@app/types";
 
 export const getServerSideProps = withSuperUserAuthRequirements<{
-  document: CoreAPIDocument;
+  owner: LightWorkspaceType;
+  params: { wId: string; dsId: string };
 }>(async (context, auth) => {
+  const owner = auth.getNonNullableWorkspace();
+
   // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const { dsId } = context.params || {};
   if (typeof dsId !== "string") {
@@ -22,38 +23,59 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
     };
   }
 
-  const dataSource = await DataSourceResource.fetchById(auth, dsId, {
-    includeEditedBy: true,
-  });
-  if (!dataSource) {
-    return {
-      notFound: true,
-    };
-  }
-
-  const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
-  const document = await coreAPI.getDataSourceDocument({
-    projectId: dataSource.dustAPIProjectId,
-    dataSourceId: dataSource.dustAPIDataSourceId,
-    documentId: context.query.documentId as string,
-  });
-
-  if (document.isErr()) {
-    return {
-      notFound: true,
-    };
-  }
-
   return {
     props: {
-      document: document.value.document,
+      owner,
+      params: context.params as { wId: string; dsId: string },
     },
   };
 });
 
 export default function DataSourceDocumentView({
-  document,
+  owner,
+  params,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  const { dsId } = params;
+  const searchParams = useSearchParams();
+  const documentId = searchParams?.get("documentId") ?? null;
+
+  const {
+    data: documentData,
+    isLoading,
+    isError,
+  } = usePokeDocument({
+    owner,
+    dsId,
+    documentId,
+    disabled: false,
+  });
+
+  if (!documentId) {
+    return (
+      <div className="flex h-64 items-center justify-center">
+        <p>No document ID provided.</p>
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex h-64 items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (isError || !documentData) {
+    return (
+      <div className="flex h-64 items-center justify-center">
+        <p>Error loading document.</p>
+      </div>
+    );
+  }
+
+  const { document } = documentData;
+
   return (
     <div className="max-w-4xl">
       <div className="pt-6">
@@ -141,6 +163,11 @@ export default function DataSourceDocumentView({
   );
 }
 
-DataSourceDocumentView.getLayout = (page: ReactElement) => {
-  return <PokeLayout title="View Document">{page}</PokeLayout>;
+DataSourceDocumentView.getLayout = (
+  page: ReactElement,
+  { owner }: { owner: LightWorkspaceType }
+) => {
+  return (
+    <PokeLayout title={`${owner.name} - View Document`}>{page}</PokeLayout>
+  );
 };

--- a/front/pages/poke/[wId]/groups/[groupId]/index.tsx
+++ b/front/pages/poke/[wId]/groups/[groupId]/index.tsx
@@ -8,6 +8,7 @@ import PokeLayout from "@app/components/poke/PokeLayout";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 import { usePokeGroupDetails } from "@app/poke/swr/group_details";
 import type { LightWorkspaceType } from "@app/types";
+import { isString } from "@app/types";
 
 export const getServerSideProps = withSuperUserAuthRequirements<{
   owner: LightWorkspaceType;
@@ -15,9 +16,8 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
 }>(async (context, auth) => {
   const owner = auth.getNonNullableWorkspace();
 
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-  const { groupId } = context.params || {};
-  if (typeof groupId !== "string") {
+  const { wId, groupId } = context.params ?? {};
+  if (!isString(wId) || !isString(groupId)) {
     return {
       notFound: true,
     };
@@ -26,7 +26,7 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
   return {
     props: {
       owner,
-      params: context.params as { wId: string; groupId: string },
+      params: { wId, groupId },
     },
   };
 });

--- a/front/pages/poke/[wId]/groups/[groupId]/index.tsx
+++ b/front/pages/poke/[wId]/groups/[groupId]/index.tsx
@@ -1,29 +1,19 @@
+import { Spinner } from "@dust-tt/sparkle";
 import type { InferGetServerSidePropsType } from "next";
 import type { ReactElement } from "react";
 
 import { ViewGroupTable } from "@app/components/poke/groups/view";
 import { MembersDataTable } from "@app/components/poke/members/table";
 import PokeLayout from "@app/components/poke/PokeLayout";
-import { getMembers } from "@app/lib/api/workspace";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
-import { GroupResource } from "@app/lib/resources/group_resource";
-import type {
-  GroupType,
-  LightWorkspaceType,
-  UserTypeWithWorkspaces,
-} from "@app/types";
+import { usePokeGroupDetails } from "@app/poke/swr/group_details";
+import type { LightWorkspaceType } from "@app/types";
 
 export const getServerSideProps = withSuperUserAuthRequirements<{
-  members: UserTypeWithWorkspaces[];
   owner: LightWorkspaceType;
-  group: GroupType;
+  params: { wId: string; groupId: string };
 }>(async (context, auth) => {
-  const owner = auth.workspace();
-  if (!owner) {
-    return {
-      notFound: true,
-    };
-  }
+  const owner = auth.getNonNullableWorkspace();
 
   // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const { groupId } = context.params || {};
@@ -33,45 +23,48 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
     };
   }
 
-  const groupRes = await GroupResource.fetchById(auth, groupId);
-  if (groupRes.isErr()) {
-    return {
-      notFound: true,
-    };
-  }
-
-  const group = groupRes.value;
-
-  const groupMembers = await group.getActiveMembers(auth);
-  const memberships = await getMembers(auth);
-
-  const userWithWorkspaces = groupMembers.reduce<UserTypeWithWorkspaces[]>(
-    (acc, user) => {
-      const member = memberships.members.find((m) => m.sId === user.sId);
-
-      if (member) {
-        acc.push(member);
-      }
-
-      return acc;
-    },
-    []
-  );
-
   return {
     props: {
-      members: userWithWorkspaces,
       owner,
-      group: group.toJSON(),
+      params: context.params as { wId: string; groupId: string },
     },
   };
 });
 
 export default function GroupPage({
-  members,
   owner,
-  group,
+  params,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  const { groupId } = params;
+
+  const {
+    data: groupDetails,
+    isLoading,
+    isError,
+  } = usePokeGroupDetails({
+    owner,
+    groupId,
+    disabled: false,
+  });
+
+  if (isLoading) {
+    return (
+      <div className="flex h-64 items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (isError || !groupDetails) {
+    return (
+      <div className="flex h-64 items-center justify-center">
+        <p>Error loading group details.</p>
+      </div>
+    );
+  }
+
+  const { members, group } = groupDetails;
+
   return (
     <>
       <h3 className="text-xl font-bold">

--- a/front/pages/poke/[wId]/index.tsx
+++ b/front/pages/poke/[wId]/index.tsx
@@ -102,7 +102,7 @@ const WorkspacePage = ({
           throw new Error("Failed to update workspace.");
         }
         router.reload();
-      } catch (e) {
+      } catch {
         window.alert("An error occurred while updating the workspace.");
       }
     }

--- a/front/pages/poke/[wId]/llm-traces/[runId].tsx
+++ b/front/pages/poke/[wId]/llm-traces/[runId].tsx
@@ -24,8 +24,8 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
 }>(async (context, auth) => {
   const owner = auth.getNonNullableWorkspace();
 
-  const runId = context.params?.runId;
-  if (!runId || !isString(runId) || !isLLMTraceId(runId)) {
+  const { wId, runId } = context.params ?? {};
+  if (!isString(wId) || !isString(runId) || !isLLMTraceId(runId)) {
     return {
       notFound: true,
     };
@@ -34,7 +34,7 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
   return {
     props: {
       owner,
-      params: context.params as { wId: string; runId: string },
+      params: { wId, runId },
     },
   };
 });

--- a/front/pages/poke/[wId]/llm-traces/[runId].tsx
+++ b/front/pages/poke/[wId]/llm-traces/[runId].tsx
@@ -20,21 +20,9 @@ import { isString } from "@app/types";
 
 export const getServerSideProps = withSuperUserAuthRequirements<{
   owner: LightWorkspaceType;
-  runId: string;
+  params: { wId: string; runId: string };
 }>(async (context, auth) => {
-  const owner = auth.workspace();
-  if (!owner) {
-    return {
-      notFound: true,
-    };
-  }
-
-  const wId = context.params?.wId;
-  if (!wId || !isString(wId)) {
-    return {
-      notFound: true,
-    };
-  }
+  const owner = auth.getNonNullableWorkspace();
 
   const runId = context.params?.runId;
   if (!runId || !isString(runId) || !isLLMTraceId(runId)) {
@@ -46,16 +34,16 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
   return {
     props: {
       owner,
-      runId,
+      params: context.params as { wId: string; runId: string },
     },
   };
 });
 
-interface LLMTracePageProps extends InferGetServerSidePropsType<
-  typeof getServerSideProps
-> {}
-
-const LLMTracePage = ({ owner, runId }: LLMTracePageProps) => {
+const LLMTracePage = ({
+  owner,
+  params,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) => {
+  const { runId } = params;
   const { trace, isLLMTraceLoading, isLLMTraceError } = usePokeLLMTrace({
     workspace: owner,
     runId,

--- a/front/pages/poke/[wId]/skills/[sId]/index.tsx
+++ b/front/pages/poke/[wId]/skills/[sId]/index.tsx
@@ -16,8 +16,8 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
   owner: WorkspaceType;
   params: { wId: string; sId: string };
 }>(async (context, auth) => {
-  const sId = context.params?.sId;
-  if (!isString(sId)) {
+  const { wId, sId } = context.params ?? {};
+  if (!isString(wId) || !isString(sId)) {
     return {
       notFound: true,
     };
@@ -26,7 +26,7 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
   return {
     props: {
       owner: auth.getNonNullableWorkspace(),
-      params: context.params as { wId: string; sId: string },
+      params: { wId, sId },
     },
   };
 });

--- a/front/pages/poke/[wId]/spaces/[spaceId]/apps/[appId]/index.tsx
+++ b/front/pages/poke/[wId]/spaces/[spaceId]/apps/[appId]/index.tsx
@@ -25,6 +25,7 @@ import type {
   LightWorkspaceType,
   SpecificationType,
 } from "@app/types";
+import { isString } from "@app/types";
 
 export const getServerSideProps = withSuperUserAuthRequirements<{
   owner: LightWorkspaceType;
@@ -32,9 +33,8 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
 }>(async (context, auth) => {
   const owner = auth.getNonNullableWorkspace();
 
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-  const { appId, spaceId } = context.params || {};
-  if (typeof spaceId !== "string" || typeof appId !== "string") {
+  const { wId, spaceId, appId } = context.params ?? {};
+  if (!isString(wId) || !isString(spaceId) || !isString(appId)) {
     return {
       notFound: true,
     };
@@ -43,7 +43,7 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
   return {
     props: {
       owner,
-      params: context.params as { wId: string; spaceId: string; appId: string },
+      params: { wId, spaceId, appId },
     },
   };
 });

--- a/front/pages/poke/[wId]/spaces/[spaceId]/apps/[appId]/index.tsx
+++ b/front/pages/poke/[wId]/spaces/[spaceId]/apps/[appId]/index.tsx
@@ -4,6 +4,7 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
+  Spinner,
 } from "@dust-tt/sparkle";
 import { JsonViewer } from "@textea/json-viewer";
 import type { InferGetServerSidePropsType } from "next";
@@ -15,91 +16,75 @@ import { ViewAppTable } from "@app/components/poke/apps/view";
 import { PluginList } from "@app/components/poke/plugins/PluginList";
 import PokeLayout from "@app/components/poke/PokeLayout";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
-import config from "@app/lib/api/config";
-import { cleanSpecificationFromCore, getSpecification } from "@app/lib/api/run";
 import { clientFetch } from "@app/lib/egress/client";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
-import { AppResource } from "@app/lib/resources/app_resource";
-import { SpaceResource } from "@app/lib/resources/space_resource";
 import { decodeSqids } from "@app/lib/utils";
-import logger from "@app/logger/logger";
+import { usePokeAppDetails } from "@app/poke/swr/app_details";
 import type {
   AppType,
   LightWorkspaceType,
   SpecificationType,
-  WorkspaceType,
 } from "@app/types";
-import { CoreAPI } from "@app/types";
 
 export const getServerSideProps = withSuperUserAuthRequirements<{
-  app: AppType;
-  specification: SpecificationType;
-  specificationHashes: string[] | null;
   owner: LightWorkspaceType;
+  params: { wId: string; spaceId: string; appId: string };
 }>(async (context, auth) => {
   const owner = auth.getNonNullableWorkspace();
 
   // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const { appId, spaceId } = context.params || {};
-  if (typeof spaceId !== "string") {
+  if (typeof spaceId !== "string" || typeof appId !== "string") {
     return {
       notFound: true,
     };
-  }
-
-  const { hash } = context.query;
-  if (hash && typeof hash !== "string") {
-    return {
-      notFound: true,
-    };
-  }
-
-  const space = await SpaceResource.fetchById(auth, spaceId);
-  if (!space) {
-    return {
-      notFound: true,
-    };
-  }
-
-  const app = await AppResource.fetchById(auth, appId);
-  if (!app) {
-    return {
-      notFound: true,
-    };
-  }
-  const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
-
-  const specificationHashes = await coreAPI.getSpecificationHashes({
-    projectId: app.dustAPIProjectId,
-  });
-
-  let specification = JSON.parse(app.savedSpecification ?? "{}");
-  if (hash && hash.length > 0) {
-    const specificationFromCore = await getSpecification(app.toJSON(), hash);
-    if (specificationFromCore) {
-      cleanSpecificationFromCore(specificationFromCore);
-      specification = specificationFromCore;
-    }
   }
 
   return {
     props: {
-      app: app.toJSON(),
-      specification,
-      specificationHashes: specificationHashes.isOk()
-        ? specificationHashes.value.hashes.reverse()
-        : null,
       owner,
+      params: context.params as { wId: string; spaceId: string; appId: string },
     },
   };
 });
 
 export default function AppPage({
-  app,
-  specification,
-  specificationHashes,
   owner,
+  params,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  const { appId } = params;
+  const searchParams = useSearchParams();
+  const hash = searchParams?.get("hash") ?? null;
+
+  const {
+    data: appDetails,
+    isLoading,
+    isError,
+  } = usePokeAppDetails({
+    owner,
+    appId,
+    hash,
+    disabled: false,
+  });
+
+  if (isLoading) {
+    return (
+      <div className="flex h-64 items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (isError || !appDetails) {
+    return (
+      <div className="flex h-64 items-center justify-center">
+        <p>Error loading app details.</p>
+      </div>
+    );
+  }
+
+  const { app, specification, specificationHashes } = appDetails;
+
   return (
     <div className="flex flex-row gap-x-6">
       <ViewAppTable app={app} owner={owner} />
@@ -136,8 +121,8 @@ function AppSpecification({
   const { isDark } = useTheme();
   const router = useRouter();
   const pathname = usePathname();
-  const params = useSearchParams();
-  const hash = params.get("hash");
+  const searchParamsInner = useSearchParams();
+  const hash = searchParamsInner?.get("hash") ?? null;
 
   const submit = async () => {
     try {
@@ -230,7 +215,7 @@ function AppSpecification({
 
 AppPage.getLayout = (
   page: ReactElement,
-  { owner, app }: { owner: WorkspaceType; app: AppType }
+  { owner }: { owner: LightWorkspaceType }
 ) => {
-  return <PokeLayout title={`${owner.name} - ${app.name}`}>{page}</PokeLayout>;
+  return <PokeLayout title={`${owner.name} - App`}>{page}</PokeLayout>;
 };

--- a/front/pages/poke/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.tsx
+++ b/front/pages/poke/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.tsx
@@ -11,7 +11,7 @@ import { usePokeDataSourceViewDetails } from "@app/poke/swr/data_source_view_det
 import type { DataSourceViewContentNodesProps } from "@app/poke/swr/data_source_views";
 import { usePokeDataSourceViewContentNodes } from "@app/poke/swr/data_source_views";
 import type { LightWorkspaceType } from "@app/types";
-import { defaultSelectionConfiguration } from "@app/types";
+import { defaultSelectionConfiguration, isString } from "@app/types";
 
 export const getServerSideProps = withSuperUserAuthRequirements<{
   owner: LightWorkspaceType;
@@ -19,9 +19,8 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
 }>(async (context, auth) => {
   const owner = auth.getNonNullableWorkspace();
 
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-  const { dsvId } = context.params || {};
-  if (typeof dsvId !== "string") {
+  const { wId, spaceId, dsvId } = context.params ?? {};
+  if (!isString(wId) || !isString(spaceId) || !isString(dsvId)) {
     return {
       notFound: true,
     };
@@ -30,7 +29,7 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
   return {
     props: {
       owner,
-      params: context.params as { wId: string; spaceId: string; dsvId: string },
+      params: { wId, spaceId, dsvId },
     },
   };
 });

--- a/front/pages/poke/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.tsx
+++ b/front/pages/poke/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.tsx
@@ -7,9 +7,9 @@ import { ViewDataSourceViewTable } from "@app/components/poke/data_source_views/
 import { PluginList } from "@app/components/poke/plugins/PluginList";
 import PokeLayout from "@app/components/poke/PokeLayout";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
+import { usePokeDataSourceViewDetails } from "@app/poke/swr/data_source_view_details";
 import type { DataSourceViewContentNodesProps } from "@app/poke/swr/data_source_views";
 import { usePokeDataSourceViewContentNodes } from "@app/poke/swr/data_source_views";
-import { usePokeDataSourceViewDetails } from "@app/poke/swr/data_source_view_details";
 import type { LightWorkspaceType } from "@app/types";
 import { defaultSelectionConfiguration } from "@app/types";
 

--- a/front/pages/poke/[wId]/spaces/[spaceId]/index.tsx
+++ b/front/pages/poke/[wId]/spaces/[spaceId]/index.tsx
@@ -11,6 +11,7 @@ import { ViewSpaceViewTable } from "@app/components/poke/spaces/view";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 import { usePokeSpaceDetails } from "@app/poke/swr/space_details";
 import type { LightWorkspaceType } from "@app/types";
+import { isString } from "@app/types";
 
 export const getServerSideProps = withSuperUserAuthRequirements<{
   owner: LightWorkspaceType;
@@ -18,9 +19,8 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
 }>(async (context, auth) => {
   const owner = auth.getNonNullableWorkspace();
 
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-  const { spaceId } = context.params || {};
-  if (typeof spaceId !== "string") {
+  const { wId, spaceId } = context.params ?? {};
+  if (!isString(wId) || !isString(spaceId)) {
     return {
       notFound: true,
     };
@@ -29,7 +29,7 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
   return {
     props: {
       owner,
-      params: context.params as { wId: string; spaceId: string },
+      params: { wId, spaceId },
     },
   };
 });

--- a/front/pages/poke/[wId]/spaces/[spaceId]/mcp_server_views/[svId]/index.tsx
+++ b/front/pages/poke/[wId]/spaces/[spaceId]/mcp_server_views/[svId]/index.tsx
@@ -1,3 +1,4 @@
+import { Spinner } from "@dust-tt/sparkle";
 import type { InferGetServerSidePropsType } from "next";
 import type { ReactElement } from "react";
 
@@ -6,13 +7,12 @@ import { PluginList } from "@app/components/poke/plugins/PluginList";
 import PokeLayout from "@app/components/poke/PokeLayout";
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
-import { mcpServerViewToPokeJSON } from "@app/lib/poke/utils";
-import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
-import type { PokeMCPServerViewType, WorkspaceType } from "@app/types";
+import { usePokeMCPServerViewDetails } from "@app/poke/swr/mcp_server_view_details";
+import type { LightWorkspaceType } from "@app/types";
 
 export const getServerSideProps = withSuperUserAuthRequirements<{
-  mcpServerView: PokeMCPServerViewType;
-  owner: WorkspaceType;
+  owner: LightWorkspaceType;
+  params: { wId: string; spaceId: string; svId: string };
 }>(async (context, auth) => {
   const owner = auth.getNonNullableWorkspace();
 
@@ -24,27 +24,48 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
     };
   }
 
-  const mcpServerView = await MCPServerViewResource.fetchById(auth, svId);
-  if (!mcpServerView) {
-    return {
-      notFound: true,
-    };
-  }
-
-  const pokeMCPServerView = await mcpServerViewToPokeJSON(mcpServerView, auth);
-
   return {
     props: {
-      mcpServerView: pokeMCPServerView,
       owner,
+      params: context.params as { wId: string; spaceId: string; svId: string },
     },
   };
 });
 
 export default function MCPServerViewPage({
-  mcpServerView,
   owner,
+  params,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  const { svId } = params;
+
+  const {
+    data: mcpServerViewDetails,
+    isLoading,
+    isError,
+  } = usePokeMCPServerViewDetails({
+    owner,
+    mcpServerViewId: svId,
+    disabled: false,
+  });
+
+  if (isLoading) {
+    return (
+      <div className="flex h-64 items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (isError || !mcpServerViewDetails) {
+    return (
+      <div className="flex h-64 items-center justify-center">
+        <p>Error loading MCP server view details.</p>
+      </div>
+    );
+  }
+
+  const { mcpServerView } = mcpServerViewDetails;
+
   return (
     <>
       <h3 className="text-xl font-bold">
@@ -78,18 +99,9 @@ export default function MCPServerViewPage({
 
 MCPServerViewPage.getLayout = (
   page: ReactElement,
-  {
-    owner,
-    mcpServerView,
-  }: { owner: WorkspaceType; mcpServerView: PokeMCPServerViewType }
+  { owner }: { owner: LightWorkspaceType }
 ) => {
   return (
-    <PokeLayout
-      title={`${owner.name} - ${getMcpServerViewDisplayName(mcpServerView)} in ${
-        mcpServerView.space?.name || mcpServerView.spaceId
-      }`}
-    >
-      {page}
-    </PokeLayout>
+    <PokeLayout title={`${owner.name} - MCP Server View`}>{page}</PokeLayout>
   );
 };

--- a/front/pages/poke/[wId]/spaces/[spaceId]/mcp_server_views/[svId]/index.tsx
+++ b/front/pages/poke/[wId]/spaces/[spaceId]/mcp_server_views/[svId]/index.tsx
@@ -9,6 +9,7 @@ import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 import { usePokeMCPServerViewDetails } from "@app/poke/swr/mcp_server_view_details";
 import type { LightWorkspaceType } from "@app/types";
+import { isString } from "@app/types";
 
 export const getServerSideProps = withSuperUserAuthRequirements<{
   owner: LightWorkspaceType;
@@ -16,9 +17,8 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
 }>(async (context, auth) => {
   const owner = auth.getNonNullableWorkspace();
 
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-  const { svId } = context.params || {};
-  if (typeof svId !== "string") {
+  const { wId, spaceId, svId } = context.params ?? {};
+  if (!isString(wId) || !isString(spaceId) || !isString(svId)) {
     return {
       notFound: true,
     };
@@ -27,7 +27,7 @@ export const getServerSideProps = withSuperUserAuthRequirements<{
   return {
     props: {
       owner,
-      params: context.params as { wId: string; spaceId: string; svId: string },
+      params: { wId, spaceId, svId },
     },
   };
 });

--- a/front/pages/poke/connectors/[connectorId]/index.tsx
+++ b/front/pages/poke/connectors/[connectorId]/index.tsx
@@ -1,44 +1,54 @@
-import config from "@app/lib/api/config";
+import { Spinner } from "@dust-tt/sparkle";
+import { useRouter } from "next/router";
+import type { ReactElement } from "react";
+import { useEffect } from "react";
+import useSWR from "swr";
+
+import PokeLayout from "@app/components/poke/PokeLayout";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
-import logger from "@app/logger/logger";
-import type { ConnectorType } from "@app/types";
-import { ConnectorsAPI } from "@app/types";
+import { fetcher } from "@app/lib/swr/swr";
 
 export const getServerSideProps = withSuperUserAuthRequirements<object>(
-  async (context) => {
-    const connectorId = context.params?.connectorId;
-
-    if (!connectorId || typeof connectorId !== "string") {
-      return {
-        notFound: true,
-      };
-    }
-
-    const connectorsAPI = new ConnectorsAPI(
-      config.getConnectorsAPIConfig(),
-      logger
-    );
-    const cRes = await connectorsAPI.getConnector(connectorId);
-    if (cRes.isErr()) {
-      return {
-        notFound: true,
-      };
-    }
-
-    const connector: ConnectorType = {
-      ...cRes.value,
-      connectionId: null,
-    };
-
+  async () => {
     return {
-      redirect: {
-        destination: `/poke/${connector.workspaceId}/data_sources/${connector.dataSourceId}`,
-        permanent: false,
-      },
+      props: {},
     };
   }
 );
 
-export default function Redirect() {
-  return <></>;
+export default function ConnectorRedirect() {
+  const router = useRouter();
+  const connectorId =
+    typeof router.query.connectorId === "string"
+      ? router.query.connectorId
+      : null;
+
+  const { data, error } = useSWR<{ redirectUrl: string }>(
+    connectorId ? `/api/poke/connectors/${connectorId}/redirect` : null,
+    fetcher
+  );
+
+  useEffect(() => {
+    if (data?.redirectUrl) {
+      void router.replace(data.redirectUrl);
+    }
+  }, [data, router]);
+
+  if (error) {
+    return (
+      <div className="flex h-64 items-center justify-center">
+        <p>Connector not found.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-64 items-center justify-center">
+      <Spinner />
+    </div>
+  );
 }
+
+ConnectorRedirect.getLayout = (page: ReactElement) => {
+  return <PokeLayout title="Connector Redirect">{page}</PokeLayout>;
+};

--- a/front/pages/poke/templates/[tId].tsx
+++ b/front/pages/poke/templates/[tId].tsx
@@ -17,7 +17,6 @@ import {
 } from "@dust-tt/sparkle";
 import { ioTsResolver } from "@hookform/resolvers/io-ts";
 import _ from "lodash";
-import type { InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
 import type { ReactElement } from "react";
 import React, { useCallback, useEffect, useRef, useState } from "react";
@@ -60,22 +59,13 @@ import {
   TEMPLATES_TAGS_CONFIG,
 } from "@app/types";
 
-export const getServerSideProps = withSuperUserAuthRequirements<{
-  templateId: string;
-}>(async (context) => {
-  const { tId: templateId } = context.query;
-  if (!templateId || typeof templateId !== "string") {
+export const getServerSideProps = withSuperUserAuthRequirements<object>(
+  async () => {
     return {
-      notFound: true,
+      props: {},
     };
   }
-
-  return {
-    props: {
-      templateId,
-    },
-  };
-});
+);
 
 function InputField({
   control,
@@ -442,16 +432,16 @@ function PreviewDialog({ form }: { form: any }) {
   );
 }
 
-function TemplatesPage({
-  templateId,
-}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+function TemplatesPage() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const router = useRouter();
+  const templateId =
+    typeof router.query.tId === "string" ? router.query.tId : null;
 
   const sendNotification = useSendNotification();
 
   const { assistantTemplate } = usePokeAssistantTemplate({
-    templateId: templateId === "new" ? null : templateId,
+    templateId: templateId === "new" || templateId === null ? null : templateId,
   });
 
   const onSubmit = useCallback(
@@ -576,6 +566,14 @@ function TemplatesPage({
       });
     }
   }, [assistantTemplate, form]);
+
+  if (!templateId) {
+    return (
+      <div className="flex min-h-dvh items-center justify-center bg-primary-50 dark:bg-primary-50-night">
+        <div className="text-primary-900">Loading...</div>
+      </div>
+    );
+  }
 
   if (isSubmitting) {
     return (
@@ -758,11 +756,8 @@ function TemplatesPage({
   );
 }
 
-TemplatesPage.getLayout = (
-  page: ReactElement,
-  { templateId }: { templateId: string }
-) => {
-  return <PokeLayout title={`Templates ${templateId}`}>{page}</PokeLayout>;
+TemplatesPage.getLayout = (page: ReactElement) => {
+  return <PokeLayout title="Template">{page}</PokeLayout>;
 };
 
 export default TemplatesPage;

--- a/front/pages/poke/templates/index.tsx
+++ b/front/pages/poke/templates/index.tsx
@@ -2,28 +2,20 @@ import type { ReactElement } from "react";
 
 import PokeLayout from "@app/components/poke/PokeLayout";
 import { TemplatesDataTable } from "@app/components/poke/templates/TemplatesDataTable";
-import { config } from "@app/lib/api/regions/config";
 import { withSuperUserAuthRequirements } from "@app/lib/iam/session";
 
 export const getServerSideProps = withSuperUserAuthRequirements<object>(
   async () => {
-    const dustRegionSyncEnabled = config.getDustRegionSyncEnabled();
     return {
-      props: {
-        dustRegionSyncEnabled,
-      },
+      props: {},
     };
   }
 );
 
-export default function ListTemplates({
-  dustRegionSyncEnabled,
-}: {
-  dustRegionSyncEnabled: boolean;
-}) {
+export default function ListTemplates() {
   return (
     <div className="mx-auto h-full w-full max-w-7xl flex-grow flex-col items-center justify-center p-8 pt-8">
-      <TemplatesDataTable dustRegionSyncEnabled={dustRegionSyncEnabled} />
+      <TemplatesDataTable />
     </div>
   );
 }

--- a/front/poke/swr/agent_details.ts
+++ b/front/poke/swr/agent_details.ts
@@ -1,0 +1,31 @@
+import type { Fetcher } from "swr";
+
+import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { PokeGetAgentDetails } from "@app/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/details";
+import type { LightWorkspaceType } from "@app/types";
+
+interface UsePokeAgentDetailsProps {
+  disabled?: boolean;
+  owner: LightWorkspaceType;
+  aId: string;
+}
+
+export function usePokeAgentDetails({
+  disabled,
+  owner,
+  aId,
+}: UsePokeAgentDetailsProps) {
+  const agentDetailsFetcher: Fetcher<PokeGetAgentDetails> = fetcher;
+  const { data, error, mutate } = useSWRWithDefaults(
+    `/api/poke/workspaces/${owner.sId}/agent_configurations/${aId}/details`,
+    agentDetailsFetcher,
+    { disabled }
+  );
+
+  return {
+    data: data ?? null,
+    isLoading: !error && !data && !disabled,
+    isError: error,
+    mutate,
+  };
+}

--- a/front/poke/swr/app_details.ts
+++ b/front/poke/swr/app_details.ts
@@ -1,0 +1,34 @@
+import type { Fetcher } from "swr";
+
+import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { PokeGetAppDetails } from "@app/pages/api/poke/workspaces/[wId]/apps/[aId]/details";
+import type { LightWorkspaceType } from "@app/types";
+
+interface UsePokeAppDetailsProps {
+  disabled?: boolean;
+  owner: LightWorkspaceType;
+  appId: string;
+  hash?: string | null;
+}
+
+export function usePokeAppDetails({
+  disabled,
+  owner,
+  appId,
+  hash,
+}: UsePokeAppDetailsProps) {
+  const detailsFetcher: Fetcher<PokeGetAppDetails> = fetcher;
+  const hashParam = hash ? `?hash=${hash}` : "";
+  const { data, error, mutate } = useSWRWithDefaults(
+    `/api/poke/workspaces/${owner.sId}/apps/${appId}/details${hashParam}`,
+    detailsFetcher,
+    { disabled }
+  );
+
+  return {
+    data: data ?? null,
+    isLoading: !error && !data && !disabled,
+    isError: error,
+    mutate,
+  };
+}

--- a/front/poke/swr/conversation_config.ts
+++ b/front/poke/swr/conversation_config.ts
@@ -1,0 +1,31 @@
+import type { Fetcher } from "swr";
+
+import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { PokeGetConversationConfig } from "@app/pages/api/poke/workspaces/[wId]/conversations/[cId]/config";
+import type { LightWorkspaceType } from "@app/types";
+
+interface UsePokeConversationConfigProps {
+  disabled?: boolean;
+  owner: LightWorkspaceType;
+  conversationId: string;
+}
+
+export function usePokeConversationConfig({
+  disabled,
+  owner,
+  conversationId,
+}: UsePokeConversationConfigProps) {
+  const configFetcher: Fetcher<PokeGetConversationConfig> = fetcher;
+  const { data, error, mutate } = useSWRWithDefaults(
+    `/api/poke/workspaces/${owner.sId}/conversations/${conversationId}/config`,
+    configFetcher,
+    { disabled }
+  );
+
+  return {
+    data: data ?? null,
+    isLoading: !error && !data && !disabled,
+    isError: error,
+    mutate,
+  };
+}

--- a/front/poke/swr/data_source_details.ts
+++ b/front/poke/swr/data_source_details.ts
@@ -1,0 +1,31 @@
+import type { Fetcher } from "swr";
+
+import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { PokeGetDataSourceDetails } from "@app/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/details";
+import type { LightWorkspaceType } from "@app/types";
+
+interface UsePokeDataSourceDetailsProps {
+  disabled?: boolean;
+  owner: LightWorkspaceType;
+  dsId: string;
+}
+
+export function usePokeDataSourceDetails({
+  disabled,
+  owner,
+  dsId,
+}: UsePokeDataSourceDetailsProps) {
+  const dataSourceDetailsFetcher: Fetcher<PokeGetDataSourceDetails> = fetcher;
+  const { data, error, mutate } = useSWRWithDefaults(
+    `/api/poke/workspaces/${owner.sId}/data_sources/${dsId}/details`,
+    dataSourceDetailsFetcher,
+    { disabled }
+  );
+
+  return {
+    data: data ?? null,
+    isLoading: !error && !data && !disabled,
+    isError: error,
+    mutate,
+  };
+}

--- a/front/poke/swr/data_source_view_details.ts
+++ b/front/poke/swr/data_source_view_details.ts
@@ -1,0 +1,31 @@
+import type { Fetcher } from "swr";
+
+import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { PokeGetDataSourceViewDetails } from "@app/pages/api/poke/workspaces/[wId]/data_source_views/[dsvId]/details";
+import type { LightWorkspaceType } from "@app/types";
+
+interface UsePokeDataSourceViewDetailsProps {
+  disabled?: boolean;
+  owner: LightWorkspaceType;
+  dataSourceViewId: string;
+}
+
+export function usePokeDataSourceViewDetails({
+  disabled,
+  owner,
+  dataSourceViewId,
+}: UsePokeDataSourceViewDetailsProps) {
+  const detailsFetcher: Fetcher<PokeGetDataSourceViewDetails> = fetcher;
+  const { data, error, mutate } = useSWRWithDefaults(
+    `/api/poke/workspaces/${owner.sId}/data_source_views/${dataSourceViewId}/details`,
+    detailsFetcher,
+    { disabled }
+  );
+
+  return {
+    data: data ?? null,
+    isLoading: !error && !data && !disabled,
+    isError: error,
+    mutate,
+  };
+}

--- a/front/poke/swr/document.ts
+++ b/front/poke/swr/document.ts
@@ -1,0 +1,35 @@
+import type { Fetcher } from "swr";
+
+import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { PokeGetDocument } from "@app/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/document";
+import type { LightWorkspaceType } from "@app/types";
+
+interface UsePokeDocumentProps {
+  disabled?: boolean;
+  owner: LightWorkspaceType;
+  dsId: string;
+  documentId: string | null;
+}
+
+export function usePokeDocument({
+  disabled,
+  owner,
+  dsId,
+  documentId,
+}: UsePokeDocumentProps) {
+  const documentFetcher: Fetcher<PokeGetDocument> = fetcher;
+  const { data, error, mutate } = useSWRWithDefaults(
+    documentId
+      ? `/api/poke/workspaces/${owner.sId}/data_sources/${dsId}/document?documentId=${encodeURIComponent(documentId)}`
+      : null,
+    documentFetcher,
+    { disabled: disabled || !documentId }
+  );
+
+  return {
+    data: data ?? null,
+    isLoading: !error && !data && !disabled && !!documentId,
+    isError: error,
+    mutate,
+  };
+}

--- a/front/poke/swr/document.ts
+++ b/front/poke/swr/document.ts
@@ -23,7 +23,7 @@ export function usePokeDocument({
       ? `/api/poke/workspaces/${owner.sId}/data_sources/${dsId}/document?documentId=${encodeURIComponent(documentId)}`
       : null,
     documentFetcher,
-    { disabled: disabled || !documentId }
+    { disabled: disabled ?? !documentId }
   );
 
   return {

--- a/front/poke/swr/group_details.ts
+++ b/front/poke/swr/group_details.ts
@@ -1,0 +1,31 @@
+import type { Fetcher } from "swr";
+
+import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { PokeGetGroupDetails } from "@app/pages/api/poke/workspaces/[wId]/groups/[groupId]/details";
+import type { LightWorkspaceType } from "@app/types";
+
+interface UsePokeGroupDetailsProps {
+  disabled?: boolean;
+  owner: LightWorkspaceType;
+  groupId: string;
+}
+
+export function usePokeGroupDetails({
+  disabled,
+  owner,
+  groupId,
+}: UsePokeGroupDetailsProps) {
+  const groupDetailsFetcher: Fetcher<PokeGetGroupDetails> = fetcher;
+  const { data, error, mutate } = useSWRWithDefaults(
+    `/api/poke/workspaces/${owner.sId}/groups/${groupId}/details`,
+    groupDetailsFetcher,
+    { disabled }
+  );
+
+  return {
+    data: data ?? null,
+    isLoading: !error && !data && !disabled,
+    isError: error,
+    mutate,
+  };
+}

--- a/front/poke/swr/index.ts
+++ b/front/poke/swr/index.ts
@@ -10,6 +10,10 @@ import type { PullTemplatesResponseBody } from "@app/pages/api/poke/templates/pu
 import type { GetDocumentsResponseBody } from "@app/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/documents";
 import type { GetTablesResponseBody } from "@app/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/tables";
 import type { FetchAssistantTemplatesResponse } from "@app/pages/api/templates";
+
+interface PokeAssistantTemplatesResponse extends FetchAssistantTemplatesResponse {
+  dustRegionSyncEnabled: boolean;
+}
 import type {
   ConversationType,
   DataSourceType,
@@ -46,11 +50,10 @@ export function usePokePullTemplates() {
 }
 
 export function usePokeAssistantTemplates() {
-  const assistantTemplatesFetcher: Fetcher<FetchAssistantTemplatesResponse> =
+  const assistantTemplatesFetcher: Fetcher<PokeAssistantTemplatesResponse> =
     fetcher;
 
   // Templates are shared across workspaces, not specific to a single one.
-  // Use the same endpoint as the front-end to fetch templates.
   const { data, error, mutate } = useSWR(
     "/api/poke/templates",
     assistantTemplatesFetcher
@@ -58,6 +61,7 @@ export function usePokeAssistantTemplates() {
 
   return {
     assistantTemplates: data?.templates ?? emptyArray(),
+    dustRegionSyncEnabled: data?.dustRegionSyncEnabled ?? false,
     isAssistantTemplatesLoading: !error && !data,
     isAssistantTemplatesError: error,
     mutateAssistantTemplates: mutate,

--- a/front/poke/swr/mcp_server_view_details.ts
+++ b/front/poke/swr/mcp_server_view_details.ts
@@ -1,0 +1,31 @@
+import type { Fetcher } from "swr";
+
+import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { PokeGetMCPServerViewDetails } from "@app/pages/api/poke/workspaces/[wId]/mcp_server_views/[svId]/details";
+import type { LightWorkspaceType } from "@app/types";
+
+interface UsePokeMCPServerViewDetailsProps {
+  disabled?: boolean;
+  owner: LightWorkspaceType;
+  mcpServerViewId: string;
+}
+
+export function usePokeMCPServerViewDetails({
+  disabled,
+  owner,
+  mcpServerViewId,
+}: UsePokeMCPServerViewDetailsProps) {
+  const detailsFetcher: Fetcher<PokeGetMCPServerViewDetails> = fetcher;
+  const { data, error, mutate } = useSWRWithDefaults(
+    `/api/poke/workspaces/${owner.sId}/mcp_server_views/${mcpServerViewId}/details`,
+    detailsFetcher,
+    { disabled }
+  );
+
+  return {
+    data: data ?? null,
+    isLoading: !error && !data && !disabled,
+    isError: error,
+    mutate,
+  };
+}

--- a/front/poke/swr/memberships.ts
+++ b/front/poke/swr/memberships.ts
@@ -1,0 +1,24 @@
+import type { Fetcher } from "swr";
+
+import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { PokeGetMemberships } from "@app/pages/api/poke/workspaces/[wId]/memberships";
+import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
+
+export function usePokeMemberships({
+  disabled,
+  owner,
+}: PokeConditionalFetchProps) {
+  const membershipsFetcher: Fetcher<PokeGetMemberships> = fetcher;
+  const { data, error, mutate } = useSWRWithDefaults(
+    `/api/poke/workspaces/${owner.sId}/memberships`,
+    membershipsFetcher,
+    { disabled }
+  );
+
+  return {
+    data: data ?? null,
+    isLoading: !error && !data && !disabled,
+    isError: error,
+    mutate,
+  };
+}

--- a/front/poke/swr/skill_details.ts
+++ b/front/poke/swr/skill_details.ts
@@ -1,0 +1,31 @@
+import type { Fetcher } from "swr";
+
+import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { PokeGetSkillDetails } from "@app/pages/api/poke/workspaces/[wId]/skills/[sId]/details";
+import type { LightWorkspaceType } from "@app/types";
+
+interface UsePokeSkillDetailsProps {
+  disabled?: boolean;
+  owner: LightWorkspaceType;
+  skillId: string;
+}
+
+export function usePokeSkillDetails({
+  disabled,
+  owner,
+  skillId,
+}: UsePokeSkillDetailsProps) {
+  const skillDetailsFetcher: Fetcher<PokeGetSkillDetails> = fetcher;
+  const { data, error, mutate } = useSWRWithDefaults(
+    `/api/poke/workspaces/${owner.sId}/skills/${skillId}/details`,
+    skillDetailsFetcher,
+    { disabled }
+  );
+
+  return {
+    data: data ?? null,
+    isLoading: !error && !data && !disabled,
+    isError: error,
+    mutate,
+  };
+}

--- a/front/poke/swr/space_details.ts
+++ b/front/poke/swr/space_details.ts
@@ -1,0 +1,31 @@
+import type { Fetcher } from "swr";
+
+import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { PokeGetSpaceDetails } from "@app/pages/api/poke/workspaces/[wId]/spaces/[spaceId]/details";
+import type { LightWorkspaceType } from "@app/types";
+
+interface UsePokeSpaceDetailsProps {
+  disabled?: boolean;
+  owner: LightWorkspaceType;
+  spaceId: string;
+}
+
+export function usePokeSpaceDetails({
+  disabled,
+  owner,
+  spaceId,
+}: UsePokeSpaceDetailsProps) {
+  const spaceDetailsFetcher: Fetcher<PokeGetSpaceDetails> = fetcher;
+  const { data, error, mutate } = useSWRWithDefaults(
+    `/api/poke/workspaces/${owner.sId}/spaces/${spaceId}/details`,
+    spaceDetailsFetcher,
+    { disabled }
+  );
+
+  return {
+    data: data ?? null,
+    isLoading: !error && !data && !disabled,
+    isError: error,
+    mutate,
+  };
+}

--- a/front/poke/swr/trigger_details.ts
+++ b/front/poke/swr/trigger_details.ts
@@ -1,0 +1,31 @@
+import type { Fetcher } from "swr";
+
+import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { PokeGetTriggerDetails } from "@app/pages/api/poke/workspaces/[wId]/triggers/[tId]/details";
+import type { LightWorkspaceType } from "@app/types";
+
+interface UsePokeTriggerDetailsProps {
+  disabled?: boolean;
+  owner: LightWorkspaceType;
+  triggerId: string;
+}
+
+export function usePokeTriggerDetails({
+  disabled,
+  owner,
+  triggerId,
+}: UsePokeTriggerDetailsProps) {
+  const triggerDetailsFetcher: Fetcher<PokeGetTriggerDetails> = fetcher;
+  const { data, error, mutate } = useSWRWithDefaults(
+    `/api/poke/workspaces/${owner.sId}/triggers/${triggerId}/details`,
+    triggerDetailsFetcher,
+    { disabled }
+  );
+
+  return {
+    data: data ?? null,
+    isLoading: !error && !data && !disabled,
+    isError: error,
+    mutate,
+  };
+}

--- a/front/poke/swr/workspace_info.ts
+++ b/front/poke/swr/workspace_info.ts
@@ -1,0 +1,24 @@
+import type { Fetcher } from "swr";
+
+import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { PokeGetWorkspaceInfo } from "@app/pages/api/poke/workspaces/[wId]/workspace-info";
+import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
+
+export function usePokeWorkspaceInfo({
+  disabled,
+  owner,
+}: PokeConditionalFetchProps) {
+  const workspaceInfoFetcher: Fetcher<PokeGetWorkspaceInfo> = fetcher;
+  const { data, error, mutate } = useSWRWithDefaults(
+    `/api/poke/workspaces/${owner.sId}/workspace-info`,
+    workspaceInfoFetcher,
+    { disabled }
+  );
+
+  return {
+    data: data ?? null,
+    isLoading: !error && !data && !disabled,
+    isError: error,
+    mutate,
+  };
+}


### PR DESCRIPTION
## Description

This cleans up the getServerSideProps of all poke pages to just return the minimal props :`owner` when there is one, user if needed and path params in `params`.
Main changes are addition of swr (in `poke/swr`) and poke api endpoint ( in `pages/api/poke` ) to fetch the data that were in GSSP.
In the following PR : https://github.com/dust-tt/dust/pull/20217 , page file are split between next route file and react component.

## Tests

Deployed on front-edge

## Risk

Might break some data fetching in poke - no user facing

## Deploy Plan

deploy front