### PR TITLE
fix: agent builder display error

### DIFF
--- a/front/components/editor/extensions/agent_builder/InstructionBlockExtension.test.ts
+++ b/front/components/editor/extensions/agent_builder/InstructionBlockExtension.test.ts
@@ -361,4 +361,36 @@ Toto:
 
 <br>`);
   });
+
+  it("should work on deep-nested instruction blocks with NBSP", () => {
+    editor.commands.setContent(
+      // Contains NBSP before the `1. something`
+      // eslint-disable-next-line no-irregular-whitespace
+      `<prompt>\n<instructions>\n<do>\n    1. something\n</do>\n</instructions>\n</prompt>`,
+      {
+        contentType: "markdown",
+      }
+    );
+
+    // check it doesn't fail
+    void editor.getJSON();
+
+    const markdown = editor.getMarkdown();
+    // We loose the <do> but at least the content can be displayed
+    expect(markdown).toEqual(`<prompt>
+
+<instructions>
+
+<do>
+
+1. something
+
+</do>
+
+</instructions>
+
+</prompt>
+
+<br>`);
+  });
 });


### PR DESCRIPTION
## Description

A customer couldn't display their instructions. The reason was a bug in the parsing of the markdown. 

I tried various approaches:
* Understand the bug, but it was deep in marked.js
* Upgrade of marked.js => nothing

So I went to this fix

## Tests

Added a unit test, and tested on the instructions locally

## Risk

None
## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
