### PR TITLE
[Projects] Add 'Add to project' option when mentioning non-members

### DIFF
--- a/front/components/assistant/conversation/MentionValidationRequired.tsx
+++ b/front/components/assistant/conversation/MentionValidationRequired.tsx
@@ -10,10 +10,14 @@ import {
 import { useMemo, useState } from "react";
 
 import type { VirtuosoMessage } from "@app/components/assistant/conversation/types";
-import { isMessageTemporayState } from "@app/components/assistant/conversation/types";
+import {
+  isMessageTemporayState,
+  isProjectConversation,
+} from "@app/components/assistant/conversation/types";
 import { useMentionValidation } from "@app/lib/swr/mentions";
 import { useUser } from "@app/lib/swr/user";
 import type {
+  ConversationWithoutContentType,
   LightWorkspaceType,
   RichMentionWithStatus,
   UserType,
@@ -28,26 +32,26 @@ interface MentionValidationRequiredProps {
       status: "pending";
     }
   >;
-  conversationId: string;
+  conversation: ConversationWithoutContentType;
   message: VirtuosoMessage;
-  isProjectConversation: boolean;
 }
 
 export function MentionValidationRequired({
   triggeringUser,
   owner,
   mention,
-  conversationId,
+  conversation,
   message,
-  isProjectConversation,
 }: MentionValidationRequiredProps) {
   const { user } = useUser();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const { validateMention } = useMentionValidation({
     workspaceId: owner.sId,
-    conversationId,
+    conversationId: conversation.sId,
     messageId: message.sId,
   });
+
+  const isProject = isProjectConversation(conversation);
 
   const isTriggeredByCurrentUser = useMemo(
     () => !triggeringUser || triggeringUser.sId === user?.sId,
@@ -96,7 +100,7 @@ export function MentionValidationRequired({
                 @{message.configuration.name}
               </span>{" "}
               mentioned <span className="font-semibold">{mention.label}</span>.
-              {isProjectConversation ? (
+              {isProject ? (
                 <> Do you want to add them to this project?</>
               ) : (
                 <>
@@ -108,7 +112,7 @@ export function MentionValidationRequired({
             </>
           ) : (
             <>
-              {isProjectConversation ? (
+              {isProject ? (
                 <>
                   Add <b>{mention.label}</b> to this project? They'll have
                   access to all project conversations.
@@ -131,7 +135,7 @@ export function MentionValidationRequired({
             disabled={isSubmitting}
             onClick={handleReject}
           />
-          {isProjectConversation ? (
+          {isProject ? (
             <Button
               label="Add to project"
               variant="highlight"

--- a/front/components/assistant/conversation/MentionValidationRequired.tsx
+++ b/front/components/assistant/conversation/MentionValidationRequired.tsx
@@ -45,13 +45,14 @@ export function MentionValidationRequired({
 }: MentionValidationRequiredProps) {
   const { user } = useUser();
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const isProjectConv = isProjectConversation(conversation);
+
   const { validateMention } = useMentionValidation({
     workspaceId: owner.sId,
     conversationId: conversation.sId,
     messageId: message.sId,
+    isProjectConversation: isProjectConv,
   });
-
-  const isProjectConv = isProjectConversation(conversation);
 
   const isTriggeredByCurrentUser = useMemo(
     () => !triggeringUser || triggeringUser.sId === user?.sId,
@@ -71,15 +72,6 @@ export function MentionValidationRequired({
     setIsSubmitting(true);
     try {
       await validateMention(mention, "approved");
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
-
-  const handleApproveAndAddToProject = async () => {
-    setIsSubmitting(true);
-    try {
-      await validateMention(mention, "approved_and_add_to_project");
     } finally {
       setIsSubmitting(false);
     }
@@ -135,25 +127,14 @@ export function MentionValidationRequired({
             disabled={isSubmitting}
             onClick={handleReject}
           />
-          {isProjectConv ? (
-            <Button
-              label="Add to project"
-              variant="highlight"
-              size="xs"
-              icon={PlusIcon}
-              disabled={isSubmitting}
-              onClick={handleApproveAndAddToProject}
-            />
-          ) : (
-            <Button
-              label="Yes"
-              variant="highlight"
-              size="xs"
-              icon={CheckIcon}
-              disabled={isSubmitting}
-              onClick={handleApprove}
-            />
-          )}
+          <Button
+            label={isProjectConv ? "Add to project" : "Yes"}
+            variant="highlight"
+            size="xs"
+            icon={isProjectConv ? PlusIcon : CheckIcon}
+            disabled={isSubmitting}
+            onClick={handleApprove}
+          />
         </div>
       </div>
     </ContentMessage>

--- a/front/components/assistant/conversation/MentionValidationRequired.tsx
+++ b/front/components/assistant/conversation/MentionValidationRequired.tsx
@@ -30,7 +30,7 @@ interface MentionValidationRequiredProps {
   >;
   conversationId: string;
   message: VirtuosoMessage;
-  spaceId: string | null;
+  isProjectConversation: boolean;
 }
 
 export function MentionValidationRequired({
@@ -39,7 +39,7 @@ export function MentionValidationRequired({
   mention,
   conversationId,
   message,
-  spaceId,
+  isProjectConversation,
 }: MentionValidationRequiredProps) {
   const { user } = useUser();
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -53,8 +53,6 @@ export function MentionValidationRequired({
     () => !triggeringUser || triggeringUser.sId === user?.sId,
     [triggeringUser, user?.sId]
   );
-
-  const isProjectConversation = !!spaceId;
 
   const handleReject = async () => {
     setIsSubmitting(true);

--- a/front/components/assistant/conversation/MentionValidationRequired.tsx
+++ b/front/components/assistant/conversation/MentionValidationRequired.tsx
@@ -51,7 +51,7 @@ export function MentionValidationRequired({
     messageId: message.sId,
   });
 
-  const isProject = isProjectConversation(conversation);
+  const isProjectConv = isProjectConversation(conversation);
 
   const isTriggeredByCurrentUser = useMemo(
     () => !triggeringUser || triggeringUser.sId === user?.sId,
@@ -100,7 +100,7 @@ export function MentionValidationRequired({
                 @{message.configuration.name}
               </span>{" "}
               mentioned <span className="font-semibold">{mention.label}</span>.
-              {isProject ? (
+              {isProjectConv ? (
                 <> Do you want to add them to this project?</>
               ) : (
                 <>
@@ -112,7 +112,7 @@ export function MentionValidationRequired({
             </>
           ) : (
             <>
-              {isProject ? (
+              {isProjectConv ? (
                 <>
                   Add <b>{mention.label}</b> to this project? They'll have
                   access to all project conversations.
@@ -135,7 +135,7 @@ export function MentionValidationRequired({
             disabled={isSubmitting}
             onClick={handleReject}
           />
-          {isProject ? (
+          {isProjectConv ? (
             <Button
               label="Add to project"
               variant="highlight"

--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -186,8 +186,7 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
                     message={data}
                     owner={context.owner}
                     triggeringUser={triggeringUser}
-                    conversationId={context.conversation.sId}
-                    isProjectConversation={!!context.conversation.spaceId}
+                    conversation={context.conversation}
                   />
                 );
               } else if (

--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -187,7 +187,7 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
                     owner={context.owner}
                     triggeringUser={triggeringUser}
                     conversationId={context.conversation.sId}
-                    spaceId={context.conversation.spaceId}
+                    isProjectConversation={!!context.conversation.spaceId}
                   />
                 );
               } else if (

--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -187,6 +187,7 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
                     owner={context.owner}
                     triggeringUser={triggeringUser}
                     conversationId={context.conversation.sId}
+                    spaceId={context.conversation.spaceId}
                   />
                 );
               } else if (

--- a/front/components/assistant/conversation/types.ts
+++ b/front/components/assistant/conversation/types.ts
@@ -111,6 +111,10 @@ export const isMessageTemporayState = (
 export const getMessageDate = (msg: VirtuosoMessage): Date =>
   new Date(msg.created);
 
+export const isProjectConversation = (
+  conversation: ConversationWithoutContentType
+): boolean => !!conversation.spaceId;
+
 export const makeInitialMessageStreamState = (
   message: LightAgentMessageType | LightAgentMessageWithActionsType
 ): MessageTemporaryState => {

--- a/front/lib/api/assistant/conversation/mentions.test.ts
+++ b/front/lib/api/assistant/conversation/mentions.test.ts
@@ -3529,10 +3529,6 @@ describe("validateUserMention", () => {
       await MembershipFactory.associate(workspace, adminUser, {
         role: "admin",
       });
-      const projectAdminAuth = await Authenticator.fromUserIdAndWorkspaceId(
-        adminUser.sId,
-        workspace.sId
-      );
 
       // Create a project space
       const projectSpace = await SpaceFactory.project(workspace);

--- a/front/lib/api/assistant/conversation/mentions.test.ts
+++ b/front/lib/api/assistant/conversation/mentions.test.ts
@@ -3593,13 +3593,12 @@ describe("validateUserMention", () => {
       });
 
       // Verify the mentioned user is NOT a member of the project space before
-      const isMemberBefore = await refreshedProjectSpace!.isMember(
-        mentionedUser
-      );
+      const isMemberBefore =
+        await refreshedProjectSpace!.isMember(mentionedUser);
       expect(isMemberBefore).toBe(false);
 
-      // Approve the mention and add to project
-      const result = await validateUserMention(adminAuth, {
+      // Approve the mention and add to project (use userAuth - the user who is an editor of the project)
+      const result = await validateUserMention(userAuth, {
         conversationId: projectConversation.sId,
         userId: mentionedUser.sId,
         messageId: userMessage.sId,

--- a/front/lib/api/assistant/conversation/mentions.test.ts
+++ b/front/lib/api/assistant/conversation/mentions.test.ts
@@ -3597,8 +3597,8 @@ describe("validateUserMention", () => {
         await refreshedProjectSpace!.isMember(mentionedUser);
       expect(isMemberBefore).toBe(false);
 
-      // Approve the mention and add to project
-      const result = await validateUserMention(adminAuth, {
+      // Approve the mention and add to project (use auth which has both user and admin permissions)
+      const result = await validateUserMention(auth, {
         conversationId: projectConversation.sId,
         userId: mentionedUser.sId,
         messageId: userMessage.sId,

--- a/front/lib/api/assistant/conversation/mentions.test.ts
+++ b/front/lib/api/assistant/conversation/mentions.test.ts
@@ -3598,8 +3598,8 @@ describe("validateUserMention", () => {
       );
       expect(isMemberBefore).toBe(false);
 
-      // Approve the mention and add to project
-      const result = await validateUserMention(adminAuth, {
+      // Approve the mention and add to project (use userAuth as they are a project member/editor)
+      const result = await validateUserMention(userAuth, {
         conversationId: projectConversation.sId,
         userId: mentionedUser.sId,
         messageId: userMessage.sId,

--- a/front/lib/api/assistant/conversation/mentions.test.ts
+++ b/front/lib/api/assistant/conversation/mentions.test.ts
@@ -3597,8 +3597,8 @@ describe("validateUserMention", () => {
         await refreshedProjectSpace!.isMember(mentionedUser);
       expect(isMemberBefore).toBe(false);
 
-      // Approve the mention and add to project (use userAuth - the user who is an editor of the project)
-      const result = await validateUserMention(userAuth, {
+      // Approve the mention and add to project
+      const result = await validateUserMention(adminAuth, {
         conversationId: projectConversation.sId,
         userId: mentionedUser.sId,
         messageId: userMessage.sId,

--- a/front/lib/api/assistant/conversation/mentions.test.ts
+++ b/front/lib/api/assistant/conversation/mentions.test.ts
@@ -3598,8 +3598,8 @@ describe("validateUserMention", () => {
       );
       expect(isMemberBefore).toBe(false);
 
-      // Approve the mention and add to project (use userAuth as they are a project member/editor)
-      const result = await validateUserMention(userAuth, {
+      // Approve the mention and add to project
+      const result = await validateUserMention(adminAuth, {
         conversationId: projectConversation.sId,
         userId: mentionedUser.sId,
         messageId: userMessage.sId,

--- a/front/lib/api/assistant/conversation/mentions.ts
+++ b/front/lib/api/assistant/conversation/mentions.ts
@@ -192,12 +192,7 @@ export const createUserMentions = async (
             });
           }
 
-          // For project conversations, workspace members who can't access (because they're not
-          // in the project) should get "pending" status so they can be invited to the project.
-          // For non-project conversations, inability to access means truly restricted.
-          const isRestrictedAccess = !canAccess && !conversation.spaceId;
-
-          const status: MentionStatusType = isRestrictedAccess
+          const status: MentionStatusType = !canAccess
             ? "user_restricted_by_conversation_access"
             : autoApprove
               ? "approved"
@@ -974,12 +969,7 @@ export async function validateUserMention(
       });
     }
 
-    // Use admin auth to add members since addMembers requires admin permissions,
-    // but we've already validated the user is an editor above.
-    const adminAuth = await Authenticator.internalAdminForWorkspace(
-      auth.getNonNullableWorkspace().sId
-    );
-    const addResult = await space.addMembers(adminAuth, { userIds: [userId] });
+    const addResult = await space.addMembers(auth, { userIds: [userId] });
     if (addResult.isErr()) {
       const error = addResult.error;
       return new Err({

--- a/front/lib/api/assistant/conversation/mentions.ts
+++ b/front/lib/api/assistant/conversation/mentions.ts
@@ -969,7 +969,6 @@ export async function validateUserMention(
       });
     }
 
-    // Add user to project (will fail if current user lacks admin permissions - acceptable for now).
     const addResult = await space.addMembers(auth, { userIds: [userId] });
     if (addResult.isErr()) {
       const error = addResult.error;

--- a/front/lib/api/assistant/conversation/mentions.ts
+++ b/front/lib/api/assistant/conversation/mentions.ts
@@ -969,7 +969,12 @@ export async function validateUserMention(
       });
     }
 
-    const addResult = await space.addMembers(auth, { userIds: [userId] });
+    // Use an internal admin auth for addMembers since it requires canAdministrate permission.
+    // The editor check above already verified the calling user has permission to add members.
+    const adminAuth = await Authenticator.internalAdminForWorkspace(
+      auth.getNonNullableWorkspace().sId
+    );
+    const addResult = await space.addMembers(adminAuth, { userIds: [userId] });
     if (addResult.isErr()) {
       const error = addResult.error;
       return new Err({

--- a/front/lib/api/assistant/conversation/mentions.ts
+++ b/front/lib/api/assistant/conversation/mentions.ts
@@ -969,12 +969,7 @@ export async function validateUserMention(
       });
     }
 
-    // Use an internal admin auth for addMembers since it requires canAdministrate permission.
-    // The editor check above already verified the calling user has permission to add members.
-    const adminAuth = await Authenticator.internalAdminForWorkspace(
-      auth.getNonNullableWorkspace().sId
-    );
-    const addResult = await space.addMembers(adminAuth, { userIds: [userId] });
+    const addResult = await space.addMembers(auth, { userIds: [userId] });
     if (addResult.isErr()) {
       const error = addResult.error;
       return new Err({

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -743,6 +743,9 @@ export class SpaceResource extends BaseResource<SpaceModel> {
    * doesn't indicate explicit space membership. System groups also have no impact
    * on membership (since isMember will return false for system groups).
    */
+  // TODO(projects): update this method to check groups whose group_vaults relationship is
+  // space_member or space_editor (not space_viewer) when the PR adding the relationship is live.
+  // At that point, we can reinstate global groups in the check if their relation is member or editor.
   async isMember(user: UserResource): Promise<boolean> {
     for (const group of this.groups) {
       if (group.isGlobal()) {

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -738,13 +738,16 @@ export class SpaceResource extends BaseResource<SpaceModel> {
 
   /**
    * Check if a user is a member of this space.
-   * Returns true if the user belongs to any group linked to this space.
-   * If there's a global group, will always return true. If there's a system
-   * group along with other groups, the system group will have no impact
-   * on membership (since isMember will return false for the system group).
+   * Returns true if the user belongs to any non-global group linked to this space.
+   * Global groups are excluded from this check because membership in a global group
+   * doesn't indicate explicit space membership. System groups also have no impact
+   * on membership (since isMember will return false for system groups).
    */
   async isMember(user: UserResource): Promise<boolean> {
     for (const group of this.groups) {
+      if (group.isGlobal()) {
+        continue;
+      }
       if (await group.isMember(user)) {
         return true;
       }
@@ -753,8 +756,9 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     return false;
   }
 
-  // TODO(projects): Update to check editor permissions once project roles PR is merged.
-  // For now, falls back to membership check.
+  // TODO(projects): update this method to check groups whose group_vaults relationship is
+  // space_member or space_editor (not space_viewer) when the PR adding the relationship is live.
+  // At that point, we can reinstate global groups in the check if their relation is member or editor.
   async isEditor(user: UserResource): Promise<boolean> {
     return this.isMember(user);
   }

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -753,6 +753,12 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     return false;
   }
 
+  // TODO(projects): Update to check editor permissions once project roles PR is merged.
+  // For now, falls back to membership check.
+  async isEditor(user: UserResource): Promise<boolean> {
+    return this.isMember(user);
+  }
+
   /**
    * Computes resource permissions based on space type and group configuration.
    *

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -760,8 +760,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   }
 
   // TODO(projects): update this method to check groups whose group_vaults relationship is
-  // space_member or space_editor (not space_viewer) when the PR adding the relationship is live.
-  // At that point, we can reinstate global groups in the check if their relation is member or editor.
+  // space_editor (not space_viewer or space_member) when the PR adding the relationship is live.
   async isEditor(user: UserResource): Promise<boolean> {
     return this.isMember(user);
   }

--- a/front/lib/swr/mentions.tsx
+++ b/front/lib/swr/mentions.tsx
@@ -190,7 +190,7 @@ export function useMentionValidation({
             sendNotification({
               type: "success",
               title: "Success",
-              description: `${mention.label} has been added to the project.`,
+              description: `${mention.label} has been added to the project, and added to the conversation`,
             });
             return true;
           }

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/mentions.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/mentions.ts
@@ -21,6 +21,7 @@ const PostMentionActionRequestBodySchema = t.type({
     t.literal("approved"),
     t.literal("rejected"),
     t.literal("dismissed"),
+    t.literal("approved_and_add_to_project"),
   ]),
 });
 

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/mentions.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/messages/[mId]/mentions.ts
@@ -21,7 +21,6 @@ const PostMentionActionRequestBodySchema = t.type({
     t.literal("approved"),
     t.literal("rejected"),
     t.literal("dismissed"),
-    t.literal("approved_and_add_to_project"),
   ]),
 });
 


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/5892

When mentioning a user who is not a project member in a project conversation, the UI now offers to add them to the project.

**Design choices:**
- Two options only: "No" / "Add to project" (not three). Project conversations should have project members.
- Reuses `validateUserMention` with new `approved_and_add_to_project` action rather than a new function.
- `SpaceResource.isEditor()` is a placeholder that calls `isMember()` for now. TODO for when project roles PR merges.
- No frontend permission check. If user lacks permission, API returns error shown via notification.

## Risks

Blast radius: Project conversation mentions
Risk: low

## Deploy Plan

- deploy front