### PR TITLE
[front] - chore(AB): tweak preview display

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -13,10 +13,10 @@ import {
   AgentBuilderFormContext,
   agentBuilderFormSchema,
 } from "@app/components/agent_builder/AgentBuilderFormContext";
-import { AgentCreatedDialog } from "@app/components/agent_builder/AgentCreatedDialog";
 import { AgentBuilderLayout } from "@app/components/agent_builder/AgentBuilderLayout";
 import { AgentBuilderLeftPanel } from "@app/components/agent_builder/AgentBuilderLeftPanel";
 import { AgentBuilderRightPanel } from "@app/components/agent_builder/AgentBuilderRightPanel";
+import { AgentCreatedDialog } from "@app/components/agent_builder/AgentCreatedDialog";
 import { useDataSourceViewsContext } from "@app/components/agent_builder/DataSourceViewsContext";
 import {
   PersonalConnectionRequiredDialog,

--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -13,6 +13,7 @@ import {
   AgentBuilderFormContext,
   agentBuilderFormSchema,
 } from "@app/components/agent_builder/AgentBuilderFormContext";
+import { AgentCreatedDialog } from "@app/components/agent_builder/AgentCreatedDialog";
 import { AgentBuilderLayout } from "@app/components/agent_builder/AgentBuilderLayout";
 import { AgentBuilderLeftPanel } from "@app/components/agent_builder/AgentBuilderLeftPanel";
 import { AgentBuilderRightPanel } from "@app/components/agent_builder/AgentBuilderRightPanel";
@@ -48,26 +49,23 @@ import { useSlackChannelsLinkedWithAgent } from "@app/lib/swr/assistants";
 import { useAgentConfigurationSkills } from "@app/lib/swr/skills";
 import { emptyArray } from "@app/lib/swr/swr";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
+import { removeParamFromRouter } from "@app/lib/utils/router_util";
 import datadogLogger from "@app/logger/datadogLogger";
 import type { LightAgentConfigurationType } from "@app/types";
-import { isBuilder, normalizeError, removeNulls } from "@app/types";
+import { isBuilder, isString, normalizeError, removeNulls } from "@app/types";
 
 function processActionsFromStorage(
   actions: AgentBuilderMCPConfigurationWithId[]
 ): BuilderAction[] {
-  return [
-    ...actions.map((action) => {
-      return {
-        ...action,
-        configuration: {
-          ...action.configuration,
-          additionalConfiguration: processAdditionalConfigurationFromStorage(
-            action.configuration.additionalConfiguration
-          ),
-        },
-      };
-    }),
-  ];
+  return actions.map((action) => ({
+    ...action,
+    configuration: {
+      ...action.configuration,
+      additionalConfiguration: processAdditionalConfigurationFromStorage(
+        action.configuration.additionalConfiguration
+      ),
+    },
+  }));
 }
 
 function processAdditionalConfigurationFromStorage(
@@ -99,6 +97,7 @@ export default function AgentBuilder({
   const router = useRouter();
   const sendNotification = useSendNotification(true);
   const [isSaving, setIsSaving] = useState(false);
+  const [isCreatedDialogOpen, setIsCreatedDialogOpen] = useState(false);
 
   const { actions, isActionsLoading } = useAgentConfigurationActions(
     owner.sId,
@@ -281,6 +280,21 @@ export default function AgentBuilder({
     mcpServerViews,
   });
 
+  useEffect(() => {
+    const createdParam = router.query.showCreatedDialog;
+    const shouldOpenDialog =
+      Boolean(agentConfiguration) &&
+      isString(createdParam) &&
+      (createdParam === "1" || createdParam === "true");
+
+    if (!shouldOpenDialog) {
+      return;
+    }
+
+    setIsCreatedDialogOpen(true);
+    void removeParamFromRouter(router, "showCreatedDialog");
+  }, [agentConfiguration, router, router.query.showCreatedDialog]);
+
   const handleSubmit = async (formData: AgentBuilderFormData) => {
     try {
       setIsSaving(true);
@@ -345,7 +359,7 @@ export default function AgentBuilder({
       await mutateTriggers();
 
       if (isCreatingNew && createdAgent.sId) {
-        const newUrl = `/w/${owner.sId}/builder/agents/${createdAgent.sId}`;
+        const newUrl = `/w/${owner.sId}/builder/agents/${createdAgent.sId}?showCreatedDialog=1`;
         await router.replace(newUrl, undefined, { shallow: true });
       } else {
         // For existing agents, just reset form state
@@ -436,6 +450,15 @@ export default function AgentBuilder({
           onCancel={dialogProps.onCancel}
           onClose={dialogProps.onClose}
         />
+        {agentConfiguration && (
+          <AgentCreatedDialog
+            open={isCreatedDialogOpen}
+            onOpenChange={setIsCreatedDialogOpen}
+            agentName={agentConfiguration.name}
+            agentId={agentConfiguration.sId}
+            owner={owner}
+          />
+        )}
         <AgentBuilderLayout
           leftPanel={
             <AgentBuilderLeftPanel

--- a/front/components/agent_builder/AgentBuilderPreview.tsx
+++ b/front/components/agent_builder/AgentBuilderPreview.tsx
@@ -1,4 +1,4 @@
-import { Spinner, TestTubeIcon } from "@dust-tt/sparkle";
+import { Spinner } from "@dust-tt/sparkle";
 import { useEffect, useMemo, useRef } from "react";
 import { useWatch } from "react-hook-form";
 
@@ -7,8 +7,6 @@ import {
   useDraftAgent,
   useDraftConversation,
 } from "@app/components/agent_builder/hooks/useAgentPreview";
-import { EmptyPlaceholder } from "@app/components/agent_builder/observability/shared/EmptyPlaceholder";
-import { TabContentLayout } from "@app/components/agent_builder/observability/TabContentLayout";
 import { usePreviewPanelContext } from "@app/components/agent_builder/PreviewPanelContext";
 import { BlockedActionsProvider } from "@app/components/assistant/conversation/BlockedActionsProvider";
 import ConversationSidePanelContent from "@app/components/assistant/conversation/ConversationSidePanelContent";
@@ -107,6 +105,13 @@ function PreviewContent({
               key={conversation.sId}
             />
           )}
+          {!conversation && (
+            <div className="flex h-full items-center justify-center px-6 text-center">
+              <div className="text-base font-medium text-muted-foreground">
+                Preview your agent here
+              </div>
+            </div>
+          )}
         </div>
 
         {!conversation && (
@@ -154,9 +159,10 @@ export function AgentBuilderPreview() {
 
   const [instructions, actions, agentName] = watchedFields;
 
-  const hasContent = useMemo(() => {
-    return !!instructions?.trim() || (actions?.length ?? 0) > 0;
-  }, [instructions, actions]);
+  const hasContent = useMemo(
+    () => !!instructions?.trim() || !!actions?.length,
+    [instructions, actions]
+  );
 
   const {
     draftAgent,
@@ -245,13 +251,11 @@ export function AgentBuilderPreview() {
   const renderContent = () => {
     if (!hasContent) {
       return (
-        <TabContentLayout title="Testing">
-          <EmptyPlaceholder
-            icon={TestTubeIcon}
-            title="Ready to test your agent?"
-            description="Add some instructions or actions to your agent to start testing it here."
-          />
-        </TabContentLayout>
+        <div className="flex h-full flex-1 items-center justify-center px-6 text-center">
+          <div className="text-base font-medium text-muted-foreground">
+            Preview your agent here
+          </div>
+        </div>
       );
     }
 

--- a/front/components/agent_builder/AgentBuilderRightPanel.tsx
+++ b/front/components/agent_builder/AgentBuilderRightPanel.tsx
@@ -24,7 +24,7 @@ import { TabContentLayout } from "@app/components/agent_builder/observability/Ta
 import { usePreviewPanelContext } from "@app/components/agent_builder/PreviewPanelContext";
 
 type AgentBuilderRightPanelTabType =
-  | "testing"
+  | "preview"
   | "feedback"
   | "template"
   | "insights";
@@ -59,10 +59,10 @@ function PanelHeader({
                   onClick={onTogglePanel}
                 />
                 <TabsTrigger
-                  value="testing"
-                  label="Testing"
+                  value="preview"
+                  label="Preview"
                   icon={TestTubeIcon}
-                  onClick={() => onTabChange("testing")}
+                  onClick={() => onTabChange("preview")}
                 />
                 <TabsTrigger
                   value="insights"
@@ -115,8 +115,8 @@ function CollapsedTabs({ onTabSelect, hasTemplate }: CollapsedTabsProps) {
         icon={TestTubeIcon}
         variant="ghost"
         size="sm"
-        tooltip="Testing"
-        onClick={() => onTabSelect("testing")}
+        tooltip="Preview"
+        onClick={() => onTabSelect("preview")}
       />
       <Button
         icon={BarChartIcon}
@@ -164,7 +164,7 @@ function ExpandedContent({
           onAddPresetAction={setPresetActionToAdd}
         />
       )}
-      {selectedTab === "testing" && (
+      {selectedTab === "preview" && (
         <div className="min-h-0 flex-1">
           <AgentBuilderPreview />
         </div>
@@ -173,7 +173,7 @@ function ExpandedContent({
         {selectedTab === "insights" &&
           (agentConfigurationSId ? (
             <AgentBuilderObservability
-              agentConfigurationSId={agentConfigurationSId ?? ""}
+              agentConfigurationSId={agentConfigurationSId}
             />
           ) : (
             <TabContentLayout title="Insights">
@@ -217,11 +217,11 @@ export function AgentBuilderRightPanel({
   const hasTemplate = !!assistantTemplate;
 
   const [selectedTab, setSelectedTab] = useState<AgentBuilderRightPanelTabType>(
-    hasTemplate ? "template" : "testing"
+    hasTemplate ? "template" : "preview"
   );
 
   const handleTogglePanel = () => {
-    setIsPreviewPanelOpen(!isPreviewPanelOpen);
+    setIsPreviewPanelOpen((prev) => !prev);
   };
 
   const handleTabChange = (tab: AgentBuilderRightPanelTabType) => {

--- a/front/components/agent_builder/AgentCreatedDialog.tsx
+++ b/front/components/agent_builder/AgentCreatedDialog.tsx
@@ -1,0 +1,86 @@
+import {
+  ChatBubbleBottomCenterTextIcon,
+  ClipboardCheckIcon,
+  ClipboardIcon,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  useCopyToClipboard,
+} from "@dust-tt/sparkle";
+import { useEffect } from "react";
+
+import { useSendNotification } from "@app/hooks/useNotification";
+import { getConversationRoute } from "@app/lib/utils/router";
+import type { WorkspaceType } from "@app/types";
+
+interface AgentCreatedDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  agentName: string;
+  agentId: string;
+  owner: WorkspaceType;
+}
+
+export function AgentCreatedDialog({
+  open,
+  onOpenChange,
+  agentName,
+  agentId,
+  owner,
+}: AgentCreatedDialogProps) {
+  const [isCopied, copyToClipboard] = useCopyToClipboard();
+  const sendNotification = useSendNotification(true);
+
+  useEffect(() => {
+    if (isCopied) {
+      sendNotification({
+        type: "success",
+        title: "Link copied to clipboard",
+      });
+    }
+  }, [isCopied, sendNotification]);
+
+  const conversationRoute = getConversationRoute(
+    owner.sId,
+    "new",
+    `agent=${agentId}`
+  );
+  const shareLink = getConversationRoute(
+    owner.sId,
+    "new",
+    `agent=${agentId}`,
+    process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Agent @{agentName} has been created!</DialogTitle>
+          <DialogDescription>
+            You can now use @{agentName} in conversations. Start a chat or share
+            the link with your team.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter
+          leftButtonProps={{
+            label: isCopied ? "Link copied" : "Share",
+            variant: "outline",
+            icon: isCopied ? ClipboardCheckIcon : ClipboardIcon,
+            onClick: () => {
+              void copyToClipboard(shareLink);
+            },
+          }}
+          rightButtonProps={{
+            label: "Start chat",
+            icon: ChatBubbleBottomCenterTextIcon,
+            href: conversationRoute,
+          }}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/front/components/agent_builder/AgentCreatedDialog.tsx
+++ b/front/components/agent_builder/AgentCreatedDialog.tsx
@@ -43,15 +43,18 @@ export function AgentCreatedDialog({
     }
   }, [isCopied, sendNotification]);
 
+  const agentHandle = `@${agentName}`;
+  const conversationQuery = `agent=${agentId}`;
+
   const conversationRoute = getConversationRoute(
     owner.sId,
     "new",
-    `agent=${agentId}`
+    conversationQuery
   );
   const shareLink = getConversationRoute(
     owner.sId,
     "new",
-    `agent=${agentId}`,
+    conversationQuery,
     process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL
   );
 
@@ -59,10 +62,10 @@ export function AgentCreatedDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Agent @{agentName} has been created!</DialogTitle>
+          <DialogTitle>Agent {agentHandle} has been created!</DialogTitle>
           <DialogDescription>
-            You can now use @{agentName} in conversations. Start a chat or share
-            the link with your team.
+            You can now use {agentHandle} in conversations. Start a chat or
+            share the link with your team.
           </DialogDescription>
         </DialogHeader>
         <DialogFooter


### PR DESCRIPTION



## Description
This PR improves the agent builder preview experience by:
- Renaming the "Testing" tab to "Preview" for clarity
- Adding a confirmation dialog when an agent is successfully created, with options to share the agent or start a conversation
- Simplifying the preview empty state with cleaner placeholder text

<img width="1920" height="964" alt="Screenshot 2026-01-18 at 17 22 12" src="https://github.com/user-attachments/assets/c804b6ed-54fb-4106-b2e3-aeb112b2f783" />

## Risk
Low 

## Tests
Tested locally

## Deploy Plan

Deploy front
