### PR TITLE
feat(snowflake): add Snowflake MCP server boilerplate

### DIFF
--- a/front/components/actions/mcp/MCPServerOAuthConnexion.tsx
+++ b/front/components/actions/mcp/MCPServerOAuthConnexion.tsx
@@ -18,6 +18,7 @@ import { useController, useFormContext } from "react-hook-form";
 
 import type { MCPServerOAuthFormValues } from "@app/components/actions/mcp/forms/types";
 import type { AuthorizationInfo } from "@app/lib/actions/mcp_metadata_extraction";
+import config from "@app/lib/api/config";
 import type {
   MCPOAuthUseCase,
   OAuthCredentialInputs,
@@ -325,7 +326,7 @@ function UseCaseCard({
 function SnowflakeSetupInstructions() {
   const [isOpen, setIsOpen] = useState(false);
 
-  const redirectUri = `${process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL}/oauth/snowflake/finalize`;
+  const redirectUri = `${config.getClientFacingUrl()}/oauth/snowflake/finalize`;
 
   return (
     <div className="w-full pt-4">

--- a/front/components/actions/mcp/MCPServerOAuthConnexion.tsx
+++ b/front/components/actions/mcp/MCPServerOAuthConnexion.tsx
@@ -1,6 +1,9 @@
 import {
   Card,
   cn,
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
   Hoverable,
   Icon,
   Input,
@@ -9,6 +12,7 @@ import {
   Tooltip,
   UserIcon,
 } from "@dust-tt/sparkle";
+import { ChevronDownIcon, ChevronRightIcon } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useController, useFormContext } from "react-hook-form";
 
@@ -201,6 +205,8 @@ export function MCPServerOAuthConnexion({
         </div>
       </div>
 
+      {authorization.provider === "snowflake" && <SnowflakeSetupInstructions />}
+
       {inputs && (
         <div className="w-full space-y-4 pt-4">
           {Object.entries(inputs).map(([key, inputData]) => {
@@ -314,4 +320,89 @@ function UseCaseCard({
   }
 
   return card;
+}
+
+function SnowflakeSetupInstructions() {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const redirectUri = `${process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL}/oauth/snowflake/finalize`;
+
+  return (
+    <div className="w-full pt-4">
+      <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+        <CollapsibleTrigger hideChevron>
+          <div className="flex w-full items-center gap-2 rounded-lg border border-border bg-muted/50 p-3 text-left text-sm font-medium text-foreground transition-colors hover:bg-muted dark:border-border-night dark:bg-muted-night/50 dark:text-foreground-night dark:hover:bg-muted-night">
+            {isOpen ? (
+              <ChevronDownIcon className="h-4 w-4 shrink-0" />
+            ) : (
+              <ChevronRightIcon className="h-4 w-4 shrink-0" />
+            )}
+            <span>Snowflake Custom OAuth Setup Guide</span>
+          </div>
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <div className="mt-3 space-y-4 rounded-lg border border-border bg-background p-4 text-sm dark:border-border-night dark:bg-background-night">
+            <p className="text-muted-foreground dark:text-muted-foreground-night">
+              Before connecting, you need to create a Custom OAuth Security
+              Integration in your Snowflake account. Run the following SQL
+              commands as an <strong>ACCOUNTADMIN</strong>:
+            </p>
+
+            <div className="space-y-3">
+              <div>
+                <p className="mb-2 font-medium text-foreground dark:text-foreground-night">
+                  1. Create the OAuth Security Integration:
+                </p>
+                <pre className="overflow-x-auto whitespace-pre-wrap rounded-md bg-muted p-3 text-xs dark:bg-muted-night">
+                  {`CREATE SECURITY INTEGRATION dust_oauth
+  TYPE = OAUTH
+  ENABLED = TRUE
+  OAUTH_CLIENT = CUSTOM
+  OAUTH_CLIENT_TYPE = 'CONFIDENTIAL'
+  OAUTH_REDIRECT_URI = '${redirectUri}'
+  OAUTH_ISSUE_REFRESH_TOKENS = TRUE
+  OAUTH_REFRESH_TOKEN_VALIDITY = 7776000;`}
+                </pre>
+              </div>
+
+              <div>
+                <p className="mb-2 font-medium text-foreground dark:text-foreground-night">
+                  2. Get the Client ID and Client Secret:
+                </p>
+                <pre className="overflow-x-auto whitespace-pre-wrap rounded-md bg-muted p-3 text-xs dark:bg-muted-night">
+                  {`SELECT SYSTEM$SHOW_OAUTH_CLIENT_SECRETS('DUST_OAUTH');`}
+                </pre>
+                <p className="mt-2 text-muted-foreground dark:text-muted-foreground-night">
+                  This returns a JSON object with{" "}
+                  <code className="rounded bg-muted px-1 dark:bg-muted-night">
+                    OAUTH_CLIENT_ID
+                  </code>{" "}
+                  and{" "}
+                  <code className="rounded bg-muted px-1 dark:bg-muted-night">
+                    OAUTH_CLIENT_SECRET
+                  </code>
+                  . Copy these values into the form below.
+                </p>
+              </div>
+
+              <div>
+                <p className="mb-2 font-medium text-foreground dark:text-foreground-night">
+                  3. (Optional) Grant the integration to specific roles:
+                </p>
+                <pre className="overflow-x-auto whitespace-pre-wrap rounded-md bg-muted p-3 text-xs dark:bg-muted-night">
+                  {`GRANT USAGE ON INTEGRATION dust_oauth TO ROLE <role_name>;`}
+                </pre>
+              </div>
+            </div>
+
+            <p className="text-muted-foreground dark:text-muted-foreground-night">
+              <strong>Note:</strong> The warehouse you specify below will be
+              used for all users. The default role can be overridden by
+              individual users during their personal authentication.
+            </p>
+          </div>
+        </CollapsibleContent>
+      </Collapsible>
+    </div>
+  );
 }

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -137,6 +137,7 @@ export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   "slab",
   "slack",
   "slack_bot",
+  "snowflake",
   "sound_studio",
   "speech_generator",
   "toolsets",
@@ -1876,6 +1877,38 @@ export const INTERNAL_MCP_SERVERS = {
       icon: "ProductboardLogo",
       documentationUrl: "https://docs.dust.tt/docs/productboard",
       instructions: PRODUCTBOARD_SERVER_INSTRUCTIONS,
+    },
+  },
+  snowflake: {
+    id: 47,
+    availability: "manual",
+    allowMultipleInstances: true,
+    isRestricted: ({ featureFlags }) => {
+      return !featureFlags.includes("snowflake_tool");
+    },
+    isPreview: false,
+    tools_stakes: {
+      list_databases: "never_ask",
+      list_schemas: "never_ask",
+      list_tables: "never_ask",
+      describe_table: "never_ask",
+      query: "low",
+    },
+    tools_arguments_requiring_approval: undefined,
+    tools_retry_policies: undefined,
+    timeoutMs: undefined,
+    serverInfo: {
+      name: "snowflake",
+      version: "1.0.0",
+      description:
+        "Execute read-only SQL queries and browse schema in Snowflake.",
+      authorization: {
+        provider: "snowflake" as const,
+        supported_use_cases: ["personal_actions"] as const,
+      },
+      icon: "SnowflakeLogo",
+      documentationUrl: "https://docs.dust.tt/docs/snowflake-tool",
+      instructions: null,
     },
   },
   // Using satisfies here instead of: type to avoid TypeScript widening the type and breaking the type inference for AutoInternalMCPServerNameType.

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -54,6 +54,7 @@ import { default as slabServer } from "@app/lib/actions/mcp_internal_actions/ser
 import { default as slackBotServer } from "@app/lib/actions/mcp_internal_actions/servers/slack/slack_bot";
 import { default as slackServer } from "@app/lib/actions/mcp_internal_actions/servers/slack/slack_personal";
 import { default as slideshowServer } from "@app/lib/actions/mcp_internal_actions/servers/slideshow";
+import { default as snowflakeServer } from "@app/lib/actions/mcp_internal_actions/servers/snowflake";
 import { default as soundStudio } from "@app/lib/actions/mcp_internal_actions/servers/sound_studio";
 import { default as speechGenerator } from "@app/lib/actions/mcp_internal_actions/servers/speech_generator";
 import { default as tablesQueryServerV2 } from "@app/lib/actions/mcp_internal_actions/servers/tables_query";
@@ -162,6 +163,8 @@ export async function getInternalMCPServer(
       return salesloftServer(auth, agentLoopContext);
     case "slab":
       return slabServer(auth, agentLoopContext);
+    case "snowflake":
+      return snowflakeServer(auth, agentLoopContext);
     case "gmail":
       return gmailServer(auth, agentLoopContext);
     case "google_calendar":

--- a/front/lib/actions/mcp_internal_actions/servers/snowflake/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/snowflake/index.ts
@@ -1,0 +1,18 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { Authenticator } from "@app/lib/auth";
+
+function createServer(
+  _auth: Authenticator,
+  _agentLoopContext?: AgentLoopContextType
+): McpServer {
+  const server = makeInternalMCPServer("snowflake");
+
+  // Tools will be implemented in a follow-up PR
+
+  return server;
+}
+
+export default createServer;

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -186,6 +186,10 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Slideshow MCP tool",
     stage: "dust_only",
   },
+  snowflake_tool: {
+    description: "Snowflake MCP tool for read-only SQL queries",
+    stage: "dust_only",
+  },
   slack_message_splitting: {
     description:
       "Enable splitting agent responses into multiple Slack messages for Slack (instead of truncation)",


### PR DESCRIPTION
## Description

Add the basic structure for the Snowflake MCP server:

### MCP Server Boilerplate
- Feature flag: `snowflake_tool` (dust_only)
- Server registration in constants.ts (id: 47, manual availability)
- Stub server implementation (tools to follow in next PR)

### OAuth Setup
- Snowflake setup instructions UI (collapsible guide showing SQL commands)
- Optimize admin connection check in mcp_metadata.ts

**Stack:** This PR is based on #20211 (feat: allow users to override Snowflake role during personal auth)

## Tests

- CI passes
- Manual verification of setup instructions UI

## Risk

**Low risk.** This is boilerplate + OAuth UI improvements. Server has no tools until next PR.

## Deploy Plan

1. Merge #20211 first (credential override PR)
2. Merge this PR
3. Deploy front
4. Server is hidden behind feature flag (dust_only), no user impact