### PR TITLE
refactor(dust-hive): reduce code duplication with shared helpers

### DIFF
--- a/x/henry/dust-hive/src/commands/destroy.ts
+++ b/x/henry/dust-hive/src/commands/destroy.ts
@@ -5,7 +5,7 @@ import { directoryExists } from "../lib/fs";
 import { logger } from "../lib/logger";
 import { getConfiguredMultiplexer, getSessionName } from "../lib/multiplexer";
 import { getWorktreeDir } from "../lib/paths";
-import { cleanupServicePorts } from "../lib/ports";
+import { cleanupServicePorts, formatBlockedPorts } from "../lib/ports";
 import { readPid, stopAllServices } from "../lib/process";
 import { restoreTerminal, selectMultipleEnvironments } from "../lib/prompt";
 import { CommandError, Err, Ok, type Result } from "../lib/result";
@@ -91,14 +91,7 @@ async function destroySingleEnvironment(
     force: options.force,
   });
   if (blockedPorts.length > 0) {
-    const details = blockedPorts
-      .map(({ port, processes }) => {
-        const procInfo = processes
-          .map((proc) => `${proc.pid}${proc.command ? ` (${proc.command})` : ""}`)
-          .join(", ");
-        return `${port}: ${procInfo}`;
-      })
-      .join("; ");
+    const details = formatBlockedPorts(blockedPorts);
     return Err(
       new CommandError(
         `Ports in use by other processes: ${details}. Stop them or rerun destroy with --force to terminate.`

--- a/x/henry/dust-hive/src/commands/warm.ts
+++ b/x/henry/dust-hive/src/commands/warm.ts
@@ -6,7 +6,7 @@ import { startForwarder } from "../lib/forward";
 import { FORWARDER_PORTS } from "../lib/forwarderConfig";
 import { createTemporalNamespaces, runAllDbInits, runSeedScript } from "../lib/init";
 import { logger } from "../lib/logger";
-import { cleanupServicePorts } from "../lib/ports";
+import { cleanupServicePorts, formatBlockedPorts } from "../lib/ports";
 import { isServiceRunning, readPid } from "../lib/process";
 import { startService, waitForServiceReady } from "../lib/registry";
 import { CommandError, Err, Ok } from "../lib/result";
@@ -109,14 +109,7 @@ export const warmCommand = withEnvironment("warm", async (env, options: WarmOpti
   });
 
   if (blockedPorts.length > 0) {
-    const details = blockedPorts
-      .map(({ port, processes }) => {
-        const procInfo = processes
-          .map((proc) => `${proc.pid}${proc.command ? ` (${proc.command})` : ""}`)
-          .join(", ");
-        return `${port}: ${procInfo}`;
-      })
-      .join("; ");
+    const details = formatBlockedPorts(blockedPorts);
     return Err(
       new CommandError(
         `Ports in use by other processes: ${details}. Stop them or rerun with --force-ports to terminate.`

--- a/x/henry/dust-hive/src/lib/docker-container.ts
+++ b/x/henry/dust-hive/src/lib/docker-container.ts
@@ -1,0 +1,156 @@
+// Shared Docker container management utilities
+
+export interface ContainerConfig {
+  name: string;
+  image: string;
+  port: { host: number; container: number };
+  env?: Record<string, string>;
+  readinessCheck: (containerName: string) => Promise<boolean>;
+}
+
+// Check if a container is running
+export async function isContainerRunning(containerName: string): Promise<boolean> {
+  const proc = Bun.spawn(["docker", "inspect", "-f", "{{.State.Running}}", containerName], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const output = await new Response(proc.stdout).text();
+  await proc.exited;
+
+  return proc.exitCode === 0 && output.trim() === "true";
+}
+
+// Check if a container exists (running or stopped)
+export async function containerExists(containerName: string): Promise<boolean> {
+  const proc = Bun.spawn(["docker", "inspect", containerName], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  await proc.exited;
+  return proc.exitCode === 0;
+}
+
+// Wait for a container to be ready using the provided readiness check
+export async function waitForContainerReady(
+  containerName: string,
+  readinessCheck: (name: string) => Promise<boolean>,
+  timeoutMs = 30000
+): Promise<boolean> {
+  const start = Date.now();
+  const pollIntervalMs = 500;
+
+  while (Date.now() - start < timeoutMs) {
+    if (await readinessCheck(containerName)) {
+      return true;
+    }
+    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+  }
+
+  return false;
+}
+
+// Start a container (creates if doesn't exist, starts if stopped)
+export async function startContainer(config: ContainerConfig): Promise<{
+  success: boolean;
+  error?: string;
+  alreadyRunning?: boolean;
+}> {
+  // Check if already running
+  if (await isContainerRunning(config.name)) {
+    return { success: true, alreadyRunning: true };
+  }
+
+  // Check if container exists but is stopped
+  if (await containerExists(config.name)) {
+    const proc = Bun.spawn(["docker", "start", config.name], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    await proc.exited;
+
+    if (proc.exitCode !== 0) {
+      const stderr = await new Response(proc.stderr).text();
+      return { success: false, error: `Failed to start existing container: ${stderr}` };
+    }
+  } else {
+    // Create new container
+    const args = [
+      "docker",
+      "run",
+      "-d",
+      "--name",
+      config.name,
+      "-p",
+      `${config.port.host}:${config.port.container}`,
+    ];
+
+    // Add environment variables
+    if (config.env) {
+      for (const [key, value] of Object.entries(config.env)) {
+        args.push("-e", `${key}=${value}`);
+      }
+    }
+
+    args.push(config.image);
+
+    const proc = Bun.spawn(args, {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    await proc.exited;
+
+    if (proc.exitCode !== 0) {
+      const stderr = await new Response(proc.stderr).text();
+      return { success: false, error: `Failed to create container: ${stderr}` };
+    }
+  }
+
+  // Wait for container to be ready
+  const ready = await waitForContainerReady(config.name, config.readinessCheck);
+  if (!ready) {
+    return { success: false, error: `${config.name} container started but not responding` };
+  }
+
+  return { success: true, alreadyRunning: false };
+}
+
+// Stop a container
+export async function stopContainer(
+  containerName: string
+): Promise<{ success: boolean; wasRunning: boolean }> {
+  if (!(await isContainerRunning(containerName))) {
+    return { success: true, wasRunning: false };
+  }
+
+  const proc = Bun.spawn(["docker", "stop", containerName], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  await proc.exited;
+
+  return { success: proc.exitCode === 0, wasRunning: true };
+}
+
+// Readiness check for Postgres
+export async function postgresReadinessCheck(
+  containerName: string,
+  user: string
+): Promise<boolean> {
+  const proc = Bun.spawn(["docker", "exec", containerName, "pg_isready", "-U", user], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  await proc.exited;
+  return proc.exitCode === 0;
+}
+
+// Readiness check for Redis
+export async function redisReadinessCheck(containerName: string): Promise<boolean> {
+  const proc = Bun.spawn(["docker", "exec", containerName, "redis-cli", "ping"], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const output = await new Response(proc.stdout).text();
+  await proc.exited;
+  return proc.exitCode === 0 && output.trim() === "PONG";
+}

--- a/x/henry/dust-hive/src/lib/ports.ts
+++ b/x/henry/dust-hive/src/lib/ports.ts
@@ -275,3 +275,17 @@ export async function cleanupServicePorts(
 
   return { killedPorts, blockedPorts };
 }
+
+// Format blocked ports for display in error messages
+export function formatBlockedPorts(
+  blockedPorts: Array<{ port: number; processes: PortProcessInfo[] }>
+): string {
+  return blockedPorts
+    .map(({ port, processes }) => {
+      const procInfo = processes
+        .map((proc) => `${proc.pid}${proc.command ? ` (${proc.command})` : ""}`)
+        .join(", ");
+      return `${port}: ${procInfo}`;
+    })
+    .join("; ");
+}

--- a/x/henry/dust-hive/src/lib/repo-preconditions.ts
+++ b/x/henry/dust-hive/src/lib/repo-preconditions.ts
@@ -1,0 +1,56 @@
+// Shared precondition checks for commands that operate on the main repo
+
+import { CommandError, Err, Ok, type Result } from "./result";
+import { getCurrentBranch, getMainRepoPath, hasUncommittedChanges, isWorktree } from "./worktree";
+
+export interface PreconditionOptions {
+  /** The command name to use in error messages (e.g., "dust-hive up", "sync") */
+  commandName: string;
+}
+
+/**
+ * Check preconditions for commands that must run from the main repo on main branch.
+ * Validates:
+ * - Not in a worktree
+ * - On main branch
+ * - Clean working directory (ignoring untracked files)
+ */
+export async function checkMainRepoPreconditions(
+  repoRoot: string,
+  options: PreconditionOptions
+): Promise<Result<void>> {
+  const { commandName } = options;
+
+  // Must not be in a worktree
+  const inWorktree = await isWorktree(repoRoot);
+  if (inWorktree) {
+    const mainRepo = await getMainRepoPath(repoRoot);
+    return Err(
+      new CommandError(
+        `Cannot run '${commandName}' from a worktree. Run from the main repo: cd ${mainRepo}`
+      )
+    );
+  }
+
+  // Must be on main branch
+  const currentBranch = await getCurrentBranch(repoRoot);
+  if (currentBranch !== "main") {
+    return Err(
+      new CommandError(
+        `Cannot run '${commandName}' from branch '${currentBranch}'. Checkout main first: git checkout main`
+      )
+    );
+  }
+
+  // Must have clean working directory (ignoring untracked files)
+  const hasChanges = await hasUncommittedChanges(repoRoot, { ignoreUntracked: true });
+  if (hasChanges) {
+    return Err(
+      new CommandError(
+        `Repository has uncommitted changes. Commit or stash them before running '${commandName}'.`
+      )
+    );
+  }
+
+  return Ok(undefined);
+}

--- a/x/henry/dust-hive/src/lib/test-postgres.ts
+++ b/x/henry/dust-hive/src/lib/test-postgres.ts
@@ -2,59 +2,34 @@
 // Each environment gets its own database within this container.
 
 import {
+  type ContainerConfig,
+  isContainerRunning,
+  postgresReadinessCheck,
+  startContainer,
+  stopContainer,
+} from "./docker-container";
+import {
   TEST_POSTGRES_CONTAINER_NAME,
   TEST_POSTGRES_PASSWORD,
   TEST_POSTGRES_PORT,
   TEST_POSTGRES_USER,
 } from "./paths";
 
+const TEST_POSTGRES_CONFIG: ContainerConfig = {
+  name: TEST_POSTGRES_CONTAINER_NAME,
+  image: "postgres:15",
+  port: { host: TEST_POSTGRES_PORT, container: 5432 },
+  env: {
+    POSTGRES_USER: TEST_POSTGRES_USER,
+    POSTGRES_PASSWORD: TEST_POSTGRES_PASSWORD,
+    POSTGRES_DB: "postgres",
+  },
+  readinessCheck: (name) => postgresReadinessCheck(name, TEST_POSTGRES_USER),
+};
+
 // Check if the test postgres container is running
 export async function isTestPostgresRunning(): Promise<boolean> {
-  const proc = Bun.spawn(
-    ["docker", "inspect", "-f", "{{.State.Running}}", TEST_POSTGRES_CONTAINER_NAME],
-    {
-      stdout: "pipe",
-      stderr: "pipe",
-    }
-  );
-  const output = await new Response(proc.stdout).text();
-  await proc.exited;
-
-  return proc.exitCode === 0 && output.trim() === "true";
-}
-
-// Check if the test postgres container exists (running or stopped)
-async function containerExists(): Promise<boolean> {
-  const proc = Bun.spawn(["docker", "inspect", TEST_POSTGRES_CONTAINER_NAME], {
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  await proc.exited;
-  return proc.exitCode === 0;
-}
-
-// Wait for postgres to be ready to accept connections
-async function waitForPostgresReady(timeoutMs = 30000): Promise<boolean> {
-  const start = Date.now();
-
-  while (Date.now() - start < timeoutMs) {
-    const proc = Bun.spawn(
-      ["docker", "exec", TEST_POSTGRES_CONTAINER_NAME, "pg_isready", "-U", TEST_POSTGRES_USER],
-      {
-        stdout: "pipe",
-        stderr: "pipe",
-      }
-    );
-    await proc.exited;
-
-    if (proc.exitCode === 0) {
-      return true;
-    }
-
-    await new Promise((resolve) => setTimeout(resolve, 500));
-  }
-
-  return false;
+  return isContainerRunning(TEST_POSTGRES_CONTAINER_NAME);
 }
 
 // Start the shared test postgres container
@@ -63,77 +38,12 @@ export async function startTestPostgres(): Promise<{
   error?: string;
   alreadyRunning?: boolean;
 }> {
-  // Check if already running
-  if (await isTestPostgresRunning()) {
-    return { success: true, alreadyRunning: true };
-  }
-
-  // Check if container exists but is stopped
-  if (await containerExists()) {
-    const proc = Bun.spawn(["docker", "start", TEST_POSTGRES_CONTAINER_NAME], {
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    await proc.exited;
-
-    if (proc.exitCode !== 0) {
-      const stderr = await new Response(proc.stderr).text();
-      return { success: false, error: `Failed to start existing container: ${stderr}` };
-    }
-  } else {
-    // Create new container
-    const proc = Bun.spawn(
-      [
-        "docker",
-        "run",
-        "-d",
-        "--name",
-        TEST_POSTGRES_CONTAINER_NAME,
-        "-e",
-        `POSTGRES_USER=${TEST_POSTGRES_USER}`,
-        "-e",
-        `POSTGRES_PASSWORD=${TEST_POSTGRES_PASSWORD}`,
-        "-e",
-        "POSTGRES_DB=postgres",
-        "-p",
-        `${TEST_POSTGRES_PORT}:5432`,
-        "postgres:15",
-      ],
-      {
-        stdout: "pipe",
-        stderr: "pipe",
-      }
-    );
-    await proc.exited;
-
-    if (proc.exitCode !== 0) {
-      const stderr = await new Response(proc.stderr).text();
-      return { success: false, error: `Failed to create container: ${stderr}` };
-    }
-  }
-
-  // Wait for postgres to be ready
-  const ready = await waitForPostgresReady();
-  if (!ready) {
-    return { success: false, error: "Postgres container started but not responding" };
-  }
-
-  return { success: true, alreadyRunning: false };
+  return startContainer(TEST_POSTGRES_CONFIG);
 }
 
 // Stop the shared test postgres container
 export async function stopTestPostgres(): Promise<{ success: boolean; wasRunning: boolean }> {
-  if (!(await isTestPostgresRunning())) {
-    return { success: true, wasRunning: false };
-  }
-
-  const proc = Bun.spawn(["docker", "stop", TEST_POSTGRES_CONTAINER_NAME], {
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  await proc.exited;
-
-  return { success: proc.exitCode === 0, wasRunning: true };
+  return stopContainer(TEST_POSTGRES_CONTAINER_NAME);
 }
 
 // Get the test database name for an environment

--- a/x/henry/dust-hive/src/lib/test-redis.ts
+++ b/x/henry/dust-hive/src/lib/test-redis.ts
@@ -1,54 +1,25 @@
 // Shared test Redis management (global container, not per-environment)
 // All environments share the same Redis instance for testing.
 
+import {
+  type ContainerConfig,
+  isContainerRunning,
+  redisReadinessCheck,
+  startContainer,
+  stopContainer,
+} from "./docker-container";
 import { TEST_REDIS_CONTAINER_NAME, TEST_REDIS_PORT } from "./paths";
+
+const TEST_REDIS_CONFIG: ContainerConfig = {
+  name: TEST_REDIS_CONTAINER_NAME,
+  image: "redis:7-alpine",
+  port: { host: TEST_REDIS_PORT, container: 6379 },
+  readinessCheck: redisReadinessCheck,
+};
 
 // Check if the test Redis container is running
 export async function isTestRedisRunning(): Promise<boolean> {
-  const proc = Bun.spawn(
-    ["docker", "inspect", "-f", "{{.State.Running}}", TEST_REDIS_CONTAINER_NAME],
-    {
-      stdout: "pipe",
-      stderr: "pipe",
-    }
-  );
-  const output = await new Response(proc.stdout).text();
-  await proc.exited;
-
-  return proc.exitCode === 0 && output.trim() === "true";
-}
-
-// Check if the test Redis container exists (running or stopped)
-async function containerExists(): Promise<boolean> {
-  const proc = Bun.spawn(["docker", "inspect", TEST_REDIS_CONTAINER_NAME], {
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  await proc.exited;
-  return proc.exitCode === 0;
-}
-
-// Wait for Redis to be ready to accept connections
-async function waitForRedisReady(timeoutMs = 30000): Promise<boolean> {
-  const start = Date.now();
-
-  while (Date.now() - start < timeoutMs) {
-    const proc = Bun.spawn(["docker", "exec", TEST_REDIS_CONTAINER_NAME, "redis-cli", "ping"], {
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const output = await new Response(proc.stdout).text();
-    await proc.exited;
-
-    if (proc.exitCode === 0 && output.trim() === "PONG") {
-      return true;
-    }
-
-    const pollIntervalMs = 500;
-    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
-  }
-
-  return false;
+  return isContainerRunning(TEST_REDIS_CONTAINER_NAME);
 }
 
 // Start the shared test Redis container
@@ -57,71 +28,12 @@ export async function startTestRedis(): Promise<{
   error?: string;
   alreadyRunning?: boolean;
 }> {
-  // Check if already running
-  if (await isTestRedisRunning()) {
-    return { success: true, alreadyRunning: true };
-  }
-
-  // Check if container exists but is stopped
-  if (await containerExists()) {
-    const proc = Bun.spawn(["docker", "start", TEST_REDIS_CONTAINER_NAME], {
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    await proc.exited;
-
-    if (proc.exitCode !== 0) {
-      const stderr = await new Response(proc.stderr).text();
-      return { success: false, error: `Failed to start existing container: ${stderr}` };
-    }
-  } else {
-    // Create new container
-    const proc = Bun.spawn(
-      [
-        "docker",
-        "run",
-        "-d",
-        "--name",
-        TEST_REDIS_CONTAINER_NAME,
-        "-p",
-        `${TEST_REDIS_PORT}:6379`,
-        "redis:7-alpine",
-      ],
-      {
-        stdout: "pipe",
-        stderr: "pipe",
-      }
-    );
-    await proc.exited;
-
-    if (proc.exitCode !== 0) {
-      const stderr = await new Response(proc.stderr).text();
-      return { success: false, error: `Failed to create container: ${stderr}` };
-    }
-  }
-
-  // Wait for Redis to be ready
-  const ready = await waitForRedisReady();
-  if (!ready) {
-    return { success: false, error: "Redis container started but not responding" };
-  }
-
-  return { success: true, alreadyRunning: false };
+  return startContainer(TEST_REDIS_CONFIG);
 }
 
 // Stop the shared test Redis container
 export async function stopTestRedis(): Promise<{ success: boolean; wasRunning: boolean }> {
-  if (!(await isTestRedisRunning())) {
-    return { success: true, wasRunning: false };
-  }
-
-  const proc = Bun.spawn(["docker", "stop", TEST_REDIS_CONTAINER_NAME], {
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  await proc.exited;
-
-  return { success: proc.exitCode === 0, wasRunning: true };
+  return stopContainer(TEST_REDIS_CONTAINER_NAME);
 }
 
 // Get the connection URI for the test Redis


### PR DESCRIPTION
## Description

Extracts common patterns from dust-hive into reusable modules to reduce code duplication and improve maintainability.

**New shared modules:**

1. **docker-container.ts** - Unified Docker container lifecycle management
   - `isContainerRunning()`, `containerExists()`, `startContainer()`, `stopContainer()`
   - Configurable readiness checks (Postgres uses `pg_isready`, Redis uses `redis-cli ping`)
   - Reduces test-postgres.ts from 232 to 142 lines (-39%)
   - Reduces test-redis.ts from 131 to 43 lines (-67%)

2. **repo-preconditions.ts** - Shared main repo validation
   - `checkMainRepoPreconditions()` validates: not in worktree, on main branch, clean working directory
   - Used by both `up` and `sync` commands (previously had nearly identical validation code)
   - Removes ~60 lines of duplicated logic

3. **ports.ts: formatBlockedPorts()** - Error message formatting
   - Extracted identical port formatting code from warm.ts and destroy.ts
   - Single source of truth for blocked port error messages

**Net change:** -46 lines overall (273 added, 319 removed), with better organization.

## Minor Output Changes

This refactor includes minor changes to CLI output strings:

- **sync command:** Error messages now use "Cannot run 'sync'..." instead of "Cannot sync...". The "Checking for uncommitted changes..." and "Working directory clean" log lines are no longer emitted.
- **Container timeout errors:** Now show the container name (e.g., "dust-hive-test-postgres container started but not responding") instead of the friendly name ("Postgres container started...").

These are cosmetic differences only; the underlying validation and container logic is functionally identical.

## Tests

- All 170 existing tests pass
- TypeScript type checking passes  
- Biome linting passes
- Ran full `bun run check` suite

## Risk

**Low risk.** The core logic is unchanged:
- Container lifecycle behavior is identical (same Docker commands, same readiness checks, same timeouts)
- Precondition validation is identical (same checks in same order)
- Port formatting is identical (extracted verbatim)

The only differences are the cosmetic output string changes noted above.

## Deploy Plan

Standard deployment. No runtime impact - this is internal code organization only.