### PR TITLE
fix(dust-hive): correct lockfile path in sync change detection

### DIFF
--- a/x/henry/dust-hive/src/commands/sync.ts
+++ b/x/henry/dust-hive/src/commands/sync.ts
@@ -388,7 +388,7 @@ export async function syncCommand(options: SyncOptions = {}): Promise<Result<voi
         hash: await hashFile(`${path}/package-lock.json`),
       }))
     ),
-    hashFile(`${dustHiveDir}/bun.lockb`),
+    hashFile(`${dustHiveDir}/bun.lock`),
   ]);
 
   // Determine what needs updating


### PR DESCRIPTION
## Description

The sync command was hashing `bun.lockb` (binary lockfile format), but this repo uses `bun.lock` (JSON text format). Since `bun.lockb` doesn't exist, `hashFile()` returns `null`, causing sync to either:
- Always reinstall dust-hive deps (if no saved state)
- Never detect lockfile changes (comparing `null` to `null`)

This fix changes the path to hash `bun.lock` so change detection works correctly.

## Tests

- `bun run check` passes (typecheck, lint, 170 tests)
- Verified `bun.lock` exists and `bun.lockb` does not

## Risk

Low - single line change that fixes a bug, no behavior change for users who always run with `--force`.

## Deploy Plan

N/A - CLI tool, no deployment needed.