### PR TITLE
fix(dust-hive): extend stop command to support single service

### DIFF
--- a/x/henry/dust-hive/src/index.ts
+++ b/x/henry/dust-hive/src/index.ts
@@ -178,10 +178,10 @@ cli
   });
 
 cli
-  .command("stop [name]", "Stop all services in environment")
+  .command("stop [name] [service]", "Stop all services (or a single service) in environment")
   .alias("x")
-  .action(async (name: string | undefined) => {
-    await prepareAndRun(stopCommand(name));
+  .action(async (name: string | undefined, service: string | undefined) => {
+    await prepareAndRun(stopCommand(name, service));
   });
 
 cli

--- a/x/henry/dust-hive/src/lib/scripts.ts
+++ b/x/henry/dust-hive/src/lib/scripts.ts
@@ -164,9 +164,7 @@ quit_service() {
   stop_tail
   echo ""
   echo -e "\\033[33m[Stopping $service...]\\033[0m"
-  dust-hive restart "$ENV_NAME" "$service" --stop 2>/dev/null || \\
-    pkill -f "dust-hive.*$service" 2>/dev/null || true
-  echo -e "\\033[31m[$service stopped]\\033[0m"
+  dust-hive stop "$ENV_NAME" "$service"
   sleep 1
   switch_service
 }


### PR DESCRIPTION
## Description

Extends the `stop` command to support stopping a single service:
- `dust-hive stop <env>` - stops all services (existing behavior)
- `dust-hive stop <env> <service>` - stops just that service (new)

This allows the logs TUI to use the CLI instead of reimplementing process management logic in bash. The TUI's `quit_service()` now simply calls `dust-hive stop "$ENV_NAME" "$service"`.

**Before:** The TUI had 26 lines of bash duplicating the PID file handling from `lib/process.ts`, plus a dangerous `pkill` fallback.

**After:** The TUI calls the CLI, which uses the existing `stopService()` function. Single source of truth.

## Tests

- `bun run check` passes (typecheck, lint, 170 tests)
- Manual: `dust-hive stop <env> front` stops only the front service

## Risk

Low - extends existing command with backward-compatible optional argument. The single-service stop uses the same `stopService()` function that `restart` already uses.

## Deploy Plan

N/A - CLI tool, no deployment needed.