### PR TITLE
fix(dust-hive): tighten connectors init idempotency check

### DIFF
--- a/x/henry/dust-hive/src/lib/init.ts
+++ b/x/henry/dust-hive/src/lib/init.ts
@@ -423,11 +423,11 @@ async function runConnectorsDbInit(env: Environment): Promise<boolean> {
   const stderr = await new Response(proc.stderr).text();
   await proc.exited;
 
-  // Treat "already exists" or "relation already exists" as success (idempotent)
+  // Treat "already exists" or "No migrations" as success (idempotent)
+  // Note: Postgres outputs "relation X already exists" which is caught by "already exists"
   const alreadyExists =
     stderr.includes("already exists") ||
     stdout.includes("already exists") ||
-    stderr.includes("relation") ||
     stdout.includes("No migrations");
 
   if (proc.exitCode !== 0 && !alreadyExists) {


### PR DESCRIPTION
## Description

The idempotency check for connectors DB init was overly broad:
- It checked for `stderr.includes("relation")` which would match any error containing "relation" (e.g., "invalid relation type", "relation not found")
- This could hide real failures and leave environments half-initialized

The Postgres "already exists" error message is:
```
ERROR: relation "tablename" already exists
```

This is already caught by `stderr.includes("already exists")`, so the separate "relation" check is unnecessary and dangerous. Removed it.

## Tests

- `bun run check` passes (typecheck, lint, 170 tests)

## Risk

Low - removes an overly permissive check that could mask real errors.

## Deploy Plan

N/A - CLI tool, no deployment needed.