### PR TITLE
fix(dust-hive): use docker compose to get container IDs

### DIFF
--- a/x/henry/dust-hive/src/commands/warm.ts
+++ b/x/henry/dust-hive/src/commands/warm.ts
@@ -1,6 +1,6 @@
 import { setCacheSource } from "../lib/cache";
 import { withEnvironment } from "../lib/commands";
-import { getDockerProjectName, startDocker } from "../lib/docker";
+import { startDocker } from "../lib/docker";
 import { isInitialized, markInitialized } from "../lib/environment";
 import { startForwarder } from "../lib/forward";
 import { FORWARDER_PORTS } from "../lib/forwarderConfig";
@@ -130,7 +130,6 @@ export const warmCommand = withEnvironment("warm", async (env, options: WarmOpti
 
   // Check if first warm (needs initialization)
   const needsInit = !(await isInitialized(env.name));
-  const projectName = getDockerProjectName(env.name);
 
   // Start Docker + front + pre-warming all in parallel
   // Front can compile pages while Docker starts and init runs
@@ -157,7 +156,7 @@ export const warmCommand = withEnvironment("warm", async (env, options: WarmOpti
     console.log();
 
     // Run all init tasks in parallel with Rust service compilation
-    const dbInitPromise = runAllDbInits(env, projectName);
+    const dbInitPromise = runAllDbInits(env);
     const temporalRunningPromise = isTemporalRunning();
     const [, , temporalRunning] = await Promise.all([
       // Start Rust services - they'll compile while init runs


### PR DESCRIPTION
## Description

The init code was constructing container names as `${projectName}-${service}-1` which relies on Docker Compose's internal naming convention. This is brittle:
- Can change across Compose versions  
- Changes with scaling
- Can be affected by `--compatibility` flag

Instead, use `docker compose ps -q <service>` to reliably get the container ID, then inspect that ID for health status.

## Changes

- Add `getServiceContainerId()` helper to `docker.ts`
- Update `waitForContainer()` to use the helper instead of constructing names
- Remove unused `projectName` parameter from `runAllDbInits()`

## Tests

- `bun run check` passes (typecheck, lint, 170 tests)

## Risk

Low - improves reliability by using official docker compose API instead of relying on internal naming conventions.

## Deploy Plan

N/A - CLI tool, no deployment needed.