### PR TITLE
fix(dust-hive): add missing doctor checks for psql and fzf

### DIFF
--- a/x/henry/dust-hive/src/commands/doctor.ts
+++ b/x/henry/dust-hive/src/commands/doctor.ts
@@ -269,6 +269,26 @@ async function checkConfig(): Promise<CheckResult> {
   };
 }
 
+async function checkPsql(): Promise<CheckResult> {
+  const version = await getCommandVersion("psql");
+  return {
+    name: "psql",
+    ok: version !== null,
+    message: version ?? "Not found",
+    fix: getInstallInstructions("psql"),
+  };
+}
+
+async function checkFzf(): Promise<CheckResult> {
+  const version = await getCommandVersion("fzf");
+  return {
+    name: "fzf",
+    ok: version !== null,
+    message: version ?? "Not found",
+    fix: getInstallInstructions("fzf"),
+  };
+}
+
 function printResults(results: CheckResult[]): boolean {
   console.log("Prerequisites:");
   console.log();
@@ -302,6 +322,8 @@ async function runAllChecks(): Promise<CheckResult[]> {
     await checkDocker(),
     await checkDockerCompose(),
     await checkTemporalCli(),
+    await checkPsql(),
+    await checkFzf(),
     await checkNvm(),
     await checkCargo(),
     await checkCmake(),

--- a/x/henry/dust-hive/src/lib/platform.ts
+++ b/x/henry/dust-hive/src/lib/platform.ts
@@ -129,7 +129,9 @@ type InstallableTool =
   | "cargo"
   | "cmake"
   | "protobuf"
-  | "direnv";
+  | "direnv"
+  | "psql"
+  | "fzf";
 
 const INSTALL_INSTRUCTIONS: Record<PlatformName, Record<InstallableTool, string>> = {
   macos: {
@@ -144,6 +146,8 @@ const INSTALL_INSTRUCTIONS: Record<PlatformName, Record<InstallableTool, string>
     cmake: "brew install cmake",
     protobuf: "brew install protobuf",
     direnv: "brew install direnv && add shell hook (see README for setup)",
+    psql: "brew install postgresql (provides psql client)",
+    fzf: "brew install fzf",
   },
   linux: {
     zellij: "cargo install zellij (or download from https://github.com/zellij-org/zellij/releases)",
@@ -159,6 +163,8 @@ const INSTALL_INSTRUCTIONS: Record<PlatformName, Record<InstallableTool, string>
       "sudo apt install protobuf-compiler (Debian/Ubuntu) or sudo dnf install protobuf-compiler (Fedora)",
     direnv:
       "sudo apt install direnv (Debian/Ubuntu) or sudo dnf install direnv (Fedora) && add shell hook (see README)",
+    psql: "sudo apt install postgresql-client (Debian/Ubuntu) or sudo dnf install postgresql (Fedora)",
+    fzf: "sudo apt install fzf (Debian/Ubuntu) or sudo dnf install fzf (Fedora)",
   },
 };
 


### PR DESCRIPTION
## Description

The doctor command was missing checks for two required tools:

- **psql**: Required for DB initialization (`init.ts`) and `seed-config`
- **fzf**: Required for interactive environment selection in `open`

Without these checks, users could pass `doctor` but still hit runtime errors on first `warm` or when using interactive `open` selection.

## Changes

- Add `checkPsql()` and `checkFzf()` check functions in `doctor.ts`
- Add install instructions for both tools (macOS and Linux) in `platform.ts`

## Tests

- `bun run check` passes (typecheck, lint, 170 tests)

## Risk

Low - adds new prerequisite checks that provide earlier feedback to users.

## Deploy Plan

N/A - CLI tool, no deployment needed.