### PR TITLE
[front] - fix(AB): preview conversation

### DIFF
--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -192,8 +192,7 @@ export const AgentInputBar = ({
   }, [methods, listOffset, visibleListHeight, bottomOffset]);
 
   const showStopButton = generatingMessages.length > 0;
-  const showClearButton =
-    context.agentBuilderContext?.resetConversation && !showStopButton;
+  const resetConversation = context.agentBuilderContext?.resetConversation;
   const showMessageNavigation = !context.agentBuilderContext;
   const showNavigationContainer = showStopButton || showMessageNavigation;
   const blockedActions = getBlockedActions(context.user.sId);
@@ -291,11 +290,11 @@ export const AgentInputBar = ({
           </div>
         )}
 
-        {showClearButton && (
+        {resetConversation && !showStopButton && (
           <Button
             variant="outline"
             icon={ArrowPathIcon}
-            onClick={context.agentBuilderContext?.resetConversation}
+            onClick={resetConversation}
             label="Clear"
             style={{
               position: "absolute",

--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -191,10 +191,11 @@ export const AgentInputBar = ({
     };
   }, [methods, listOffset, visibleListHeight, bottomOffset]);
 
-  const showClearButton =
-    context.agentBuilderContext?.resetConversation &&
-    generatingMessages.length > 0;
   const showStopButton = generatingMessages.length > 0;
+  const showClearButton =
+    context.agentBuilderContext?.resetConversation && !showStopButton;
+  const showMessageNavigation = !context.agentBuilderContext;
+  const showNavigationContainer = showStopButton || showMessageNavigation;
   const blockedActions = getBlockedActions(context.user.sId);
 
   // Keep blockedActionIndex in sync when blockedActions array changes.
@@ -246,41 +247,49 @@ export const AgentInputBar = ({
       }
     >
       <div className="flex w-full justify-center gap-2">
-        <div
-          className="flex items-center gap-1 rounded-xl border border-border bg-white p-1 dark:border-border-night dark:bg-muted-night"
-          style={{
-            position: "absolute",
-            top: "-2em",
-          }}
-        >
-          {showStopButton && (
-            <>
-              <Button
-                variant="ghost"
-                label={getStopButtonLabel()}
-                icon={StopIcon}
-                onClick={handleStopGeneration}
-                disabled={isStopping}
-                size="xs"
-              />
-              <div className="h-4 w-px bg-border dark:bg-border-night" />
-            </>
-          )}
-          <IconButton
-            icon={ArrowUpIcon}
-            onClick={scrollToPreviousUserMessage}
-            disabled={!canScrollUp}
-            size="xs"
-            tooltip="Previous message"
-          />
-          <IconButton
-            icon={ArrowDownIcon}
-            onClick={scrollToNextUserMessage}
-            disabled={!canScrollDown}
-            size="xs"
-            tooltip="Next message"
-          />
-        </div>
+        {showNavigationContainer && (
+          <div
+            className="flex items-center gap-1 rounded-xl border border-border bg-white p-1 dark:border-border-night dark:bg-muted-night"
+            style={{
+              position: "absolute",
+              top: "-2em",
+            }}
+          >
+            {showStopButton && (
+              <>
+                <Button
+                  variant="ghost"
+                  label={getStopButtonLabel()}
+                  icon={StopIcon}
+                  onClick={handleStopGeneration}
+                  disabled={isStopping}
+                  size="xs"
+                />
+                {showMessageNavigation && (
+                  <div className="h-4 w-px bg-border dark:bg-border-night" />
+                )}
+              </>
+            )}
+            {showMessageNavigation && (
+              <>
+                <IconButton
+                  icon={ArrowUpIcon}
+                  onClick={scrollToPreviousUserMessage}
+                  disabled={!canScrollUp}
+                  size="xs"
+                  tooltip="Previous message"
+                />
+                <IconButton
+                  icon={ArrowDownIcon}
+                  onClick={scrollToNextUserMessage}
+                  disabled={!canScrollDown}
+                  size="xs"
+                  tooltip="Next message"
+                />
+              </>
+            )}
+          </div>
+        )}
 
         {showClearButton && (
           <Button

--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -192,7 +192,6 @@ export const AgentInputBar = ({
   }, [methods, listOffset, visibleListHeight, bottomOffset]);
 
   const showStopButton = generatingMessages.length > 0;
-  const resetConversation = context.agentBuilderContext?.resetConversation;
   const showMessageNavigation = !context.agentBuilderContext;
   const showNavigationContainer = showStopButton || showMessageNavigation;
   const blockedActions = getBlockedActions(context.user.sId);
@@ -290,11 +289,11 @@ export const AgentInputBar = ({
           </div>
         )}
 
-        {resetConversation && !showStopButton && (
+        {context.agentBuilderContext?.resetConversation && !showStopButton && (
           <Button
             variant="outline"
             icon={ArrowPathIcon}
-            onClick={resetConversation}
+            onClick={context.agentBuilderContext.resetConversation}
             label="Clear"
             style={{
               position: "absolute",


### PR DESCRIPTION
## Description

Fixes the visibility logic for conversation controls in the agent builder preview. The message navigation arrows (previous/next message) are now properly hidden in the agent builder context, and the clear button is only shown when appropriate (when `resetConversation` is available and stop button is not visible)

## Risk

Low. The changes only affect conditional rendering logic for UI controls in the agent builder preview.

## Tests

Locally

## Deploy Plan

Deploy front