### PR TITLE
[front] - fix(AB): adjust alignment in agent builder sections

### DIFF
--- a/front/components/agent_builder/AgentBuilderSectionContainer.tsx
+++ b/front/components/agent_builder/AgentBuilderSectionContainer.tsx
@@ -16,7 +16,7 @@ export function AgentBuilderSectionContainer({
 }: AgentBuilderSectionContainerProps) {
   return (
     <section className="flex flex-col gap-3 px-6">
-      <div className="flex flex-col items-end justify-between gap-2 sm:flex-row">
+      <div className="flex flex-col items-start justify-between gap-2 sm:flex-row sm:items-end">
         <div>
           <div className="flex flex-row items-center gap-2">
             <h2 className="heading-lg text-foreground dark:text-foreground-night">

--- a/front/components/shared/BaseFormFieldSection.tsx
+++ b/front/components/shared/BaseFormFieldSection.tsx
@@ -52,7 +52,7 @@ export function BaseFormFieldSection<
   return (
     <div className="space-y-4">
       {(!!title || !!description || !!headerActions) && (
-        <div className="flex flex-col items-end justify-between gap-2 sm:flex-row">
+        <div className="flex flex-col items-start justify-between gap-2 sm:flex-row sm:items-end">
           <div>
             {title && (
               <h3


### PR DESCRIPTION
## Description

This PR changes alignment of items in `AgentBuilderSectionContainer` and `BaseFormFieldSection` for consistency at small and large screen sizes

**References:**
- Fixes https://github.com/dust-tt/dust/issues/20003

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front