### PR TITLE
feat: allow instruction tags to be rendered on all levels in the agent instructions

### DIFF
--- a/front/components/editor/extensions/agent_builder/InstructionBlockExtension.test.ts
+++ b/front/components/editor/extensions/agent_builder/InstructionBlockExtension.test.ts
@@ -361,4 +361,36 @@ Toto:
 
 <br>`);
   });
+
+  it("should work on deep-nested instruction blocks with NBSP", () => {
+    editor.commands.setContent(
+      // Contains NBSP before the `1. something`
+      // eslint-disable-next-line no-irregular-whitespace
+      `<prompt>\n<instructions>\n<do>\n    1. something\n</do>\n</instructions>\n</prompt>`,
+      {
+        contentType: "markdown",
+      }
+    );
+
+    // check it doesn't fail
+    void editor.getJSON();
+
+    const markdown = editor.getMarkdown();
+    // We loose the <do> but at least the content can be displayed
+    expect(markdown).toEqual(`<prompt>
+
+<instructions>
+
+<do>
+
+1. something
+
+</do>
+
+</instructions>
+
+</prompt>
+
+<br>`);
+  });
 });

--- a/front/components/editor/extensions/agent_builder/InstructionBlockExtension.tsx
+++ b/front/components/editor/extensions/agent_builder/InstructionBlockExtension.tsx
@@ -288,10 +288,6 @@ export const InstructionBlockExtension =
             const type = match[1] ? match[1].toLowerCase() : "";
             const tagType = type || "instructions";
 
-            if (this.editor.isActive(this.name)) {
-              return;
-            }
-
             const content = {
               type: this.name,
               attrs: { type: tagType, isCollapsed: false },


### PR DESCRIPTION
## Description

Fix inconsistency in the instructions blocks.

We rendered them in agent details, when loading the instructions, but not when writing them

## Tests


### After

<img width="279" height="424" alt="image" src="https://github.com/user-attachments/assets/8169c41e-f0d4-4ec4-b976-1e5fa0aba35f" />


### Before

<img width="228" height="223" alt="image" src="https://github.com/user-attachments/assets/9656fe77-53a3-46ba-aa7c-7d3843a4bd60" />


## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
