### PR TITLE
Fix project homepage in Dark mode

### DIFF
--- a/front/components/assistant/conversation/space/conversations/SpaceConversationsActions.tsx
+++ b/front/components/assistant/conversation/space/conversations/SpaceConversationsActions.tsx
@@ -42,7 +42,7 @@ export function SpaceConversationsActions() {
             className="cursor-pointer"
           >
             <div className="flex w-full flex-col gap-2 text-sm">
-              <div className="flex w-full items-center gap-2 font-semibold text-foreground">
+              <div className="flex w-full items-center gap-2 font-semibold text-foreground dark:text-foreground-night">
                 <Icon visual={suggestion.icon} size="sm" />
                 <div className="w-full">{suggestion.label}</div>
               </div>

--- a/front/pages/w/[wId]/conversation/space/[spaceId]/index.tsx
+++ b/front/pages/w/[wId]/conversation/space/[spaceId]/index.tsx
@@ -294,7 +294,7 @@ export default function SpaceConversations({
   }
 
   return (
-    <div className="flex h-full w-full flex-col bg-background">
+    <div className="flex h-full w-full flex-col">
       <Tabs
         value={currentTab}
         onValueChange={(value) => handleTabChange(value as SpaceTab)}


### PR DESCRIPTION
## Description

This PR fixes the background color and the text color of the CTA buttons in the project homepage, in Dark mode.
<img width="811" height="596" alt="image" src="https://github.com/user-attachments/assets/7bb7483d-849e-4825-8ac0-d78b62d44be2" />


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

None

## Deploy Plan

Deploy front
