### PR TITLE
[Front] fix(editor): allow space key when mention dropdown has no results

### DIFF
--- a/front/components/editor/input_bar/MentionDropdown.tsx
+++ b/front/components/editor/input_bar/MentionDropdown.tsx
@@ -83,6 +83,9 @@ export const MentionDropdown = forwardRef<
         }
 
         if (event.key === "Enter" || event.key === "Tab" || event.key === " ") {
+          if (suggestions.length === 0) {
+            return false;
+          }
           selectItem(selectedIndex);
           return true;
         }


### PR DESCRIPTION
Fixes: https://github.com/dust-tt/tasks/issues/5969

## Description

The `onKeyDown` handler in `MentionDropdown.tsx` was returning `true` for space/enter/tab keys even when `suggestions.length === 0`, blocking the space character from being inserted into the editor.

Added a check for `suggestions.length > 0` before calling `selectItem()`, matching the existing pattern used for the ArrowDown handler.

## Tests

Manual: typed `@invalidquery` then pressed space — space character now inserts correctly instead of being blocked.

## Risk

Low.

## Deploy Plan

Front.