### PR TITLE
[front] fix: replace 'assistant' with 'agent' in builder suggestions

### DIFF
--- a/front/components/agent_builder/settings/AgentBuilderDescriptionSection.tsx
+++ b/front/components/agent_builder/settings/AgentBuilderDescriptionSection.tsx
@@ -49,7 +49,7 @@ export function AgentBuilderDescriptionSection({
     const result = await getDescriptionSuggestion({
       owner,
       instructions,
-      name: name || "Assistant",
+      name: name || "Agent",
     });
 
     if (result.isErr()) {

--- a/front/lib/api/assistant/suggestions/description.ts
+++ b/front/lib/api/assistant/suggestions/description.ts
@@ -14,7 +14,7 @@ const FUNCTION_NAME = "send_suggestion";
 const specifications: AgentActionSpecification[] = [
   {
     name: FUNCTION_NAME,
-    description: "Send a suggestion of description for the assistant",
+    description: "Send a suggestion of description for the agent",
     inputSchema: {
       type: "object",
       properties: {
@@ -36,7 +36,7 @@ function getConversationContext(
   const instructions = "instructions" in inputs ? inputs.instructions : "";
 
   const instructionsText = instructions
-    ? "\nAssistant instructions\n======\n" + JSON.stringify(instructions)
+    ? "\nAgent instructions\n======\n" + JSON.stringify(instructions)
     : "";
 
   return {
@@ -66,9 +66,9 @@ export async function getBuilderDescriptionSuggestions(
     {
       conversation: getConversationContext(inputs),
       prompt:
-        "The user is currently creating an assistant based on a large language model. " +
-        "The assistant has been given instructions by the user. Based on the provided " +
-        "instructions suggest a short description of the assistant.",
+        "The user is currently creating an agent based on a large language model. " +
+        "The agent has been given instructions by the user. Based on the provided " +
+        "instructions suggest a short description of the agent.",
       specifications,
       forceToolCall: FUNCTION_NAME,
     },

--- a/front/lib/api/assistant/suggestions/emoji.ts
+++ b/front/lib/api/assistant/suggestions/emoji.ts
@@ -21,7 +21,7 @@ const FUNCTION_NAME = "send_suggestions";
 const specifications: AgentActionSpecification[] = [
   {
     name: FUNCTION_NAME,
-    description: "Send suggestions of names for the assistants",
+    description: "Send suggestions of names for the agents",
     inputSchema: {
       type: "object",
       properties: {
@@ -56,7 +56,7 @@ const specifications: AgentActionSpecification[] = [
             required: ["emoji", "backgroundColor"],
             additionalProperties: false,
           },
-          description: "Suggest one to three emojis for the assistant",
+          description: "Suggest one to three emojis for the agent",
         },
       },
       required: ["suggestions"],
@@ -70,7 +70,7 @@ function getConversationContext(
   const instructions = "instructions" in inputs ? inputs.instructions : "";
 
   const instructionsText = instructions
-    ? "\nAssistant instructions\n======\n" + JSON.stringify(instructions)
+    ? "\nAgent instructions\n======\n" + JSON.stringify(instructions)
     : "";
 
   const initialPrompt =
@@ -104,7 +104,7 @@ export async function getBuilderEmojiSuggestions(
     {
       conversation: getConversationContext(inputs),
       prompt:
-        "Task Overview: Assist in the customization of a virtual assistant’s visual identity by selecting an emoji for its avatar. The assistant's design and purpose will be described in each message you receive.\n\nObjective: Your main responsibility is to choose an emoji that captures the essence of the assistant, reflecting its unique functions, personality, or the context in which it will be used.\n\nGuidelines:\n- Broaden Your Choices: Consider a wide range of emojis to find one that uniquely represents the assistant's qualities or use case. Avoid defaulting to common choices unless they are the best fit. Try to avoid the generic 🤖 that could work for all assistants, unless the topic is truly about robots.\n- Relevance is Key: Select emojis that directly relate to the assistant’s described characteristics or intended environment. For instance, a 🎨 might suit a creative design tool, while a 📚 could represent a learning aid.\n- Compatibility Consideration: Ensure that your choices adhere to the Unicode standard to guarantee that the emoji displays correctly across all platforms.",
+        "Task Overview: Assist in the customization of a virtual agent’s visual identity by selecting an emoji for its avatar. The agent's design and purpose will be described in each message you receive.\n\nObjective: Your main responsibility is to choose an emoji that captures the essence of the agent, reflecting its unique functions, personality, or the context in which it will be used.\n\nGuidelines:\n- Broaden Your Choices: Consider a wide range of emojis to find one that uniquely represents the agent's qualities or use case. Avoid defaulting to common choices unless they are the best fit. Try to avoid the generic 🤖 that could work for all agents, unless the topic is truly about robots.\n- Relevance is Key: Select emojis that directly relate to the agent’s described characteristics or intended environment. For instance, a 🎨 might suit a creative design tool, while a 📚 could represent a learning aid.\n- Compatibility Consideration: Ensure that your choices adhere to the Unicode standard to guarantee that the emoji displays correctly across all platforms.",
       specifications,
       forceToolCall: FUNCTION_NAME,
     },

--- a/front/lib/api/assistant/suggestions/instructions.ts
+++ b/front/lib/api/assistant/suggestions/instructions.ts
@@ -30,7 +30,7 @@ const specifications: AgentActionSpecification[] = [
           items: {
             type: "string",
             description:
-              "A suggestion to improve the user's instructions to the assistant, phrased nicely, as a short question. It should not be more than thirty words.",
+              "A suggestion to improve the user's instructions to the agent, phrased nicely, as a short question. It should not be more than thirty words.",
           },
           description:
             "Array of two new suggestions that would improve the instructions.",
@@ -40,7 +40,7 @@ const specifications: AgentActionSpecification[] = [
           items: {
             type: "string",
             description:
-              "A suggestion to improve the user's instructions to the assistant.",
+              "A suggestion to improve the user's instructions to the agent.",
           },
           description:
             "Array of already existing, user provided suggestions that would improve the instructions",
@@ -50,7 +50,7 @@ const specifications: AgentActionSpecification[] = [
           items: {
             type: "string",
             description:
-              "A suggestion to improve the user's instructions to the assistant.",
+              "A suggestion to improve the user's instructions to the agent.",
           },
           description:
             "Array of the suggestions taken from new_suggestions and former_suggestions, ranked by most important first. That is, the suggestion that will improve the instructions for the LLM best should come first.",
@@ -75,7 +75,7 @@ function getConversationContext(
     "former_suggestions" in inputs ? inputs.former_suggestions : [];
 
   const currentInstructionsText = currentInstructions
-    ? "Instructions I wrote for my assistant:\n" + currentInstructions
+    ? "Instructions I wrote for my agent:\n" + currentInstructions
     : "";
 
   const messages: ModelMessageTypeMultiActionsWithoutContentFragment[] = [
@@ -120,7 +120,7 @@ export async function getBuilderInstructionsSuggestions(
     {
       conversation: getConversationContext(inputs),
       prompt:
-        'A user is working on a Saas product called Dust, a tool for creating custom assistants based on large language models, to help employees to be more productive. \n\nContext\n---\nA few elements to bear in mind:\n- On Dust, users can give assistants access to company data (on slack, notion, google drive, github, intercom, confluence). Assistants that are configured to use company data can do semantic searches before answering the user, and use the retrieved data to reply;\n- some companies have created "Dust apps" and for some advanced use cases assistants can execute those dust apps before answering;\n- advanced use cases also include allowing assistants to query structured data from Notion Databases or Google Spreadsheets, that is, treating those documents as SQL databases and running sql queries on them;\n- however, in the majority of cases, custom assistants are either asked to reply only (i.e. without searching data, acting or querying structured data), or to perform retrieval-augmented-generation, that is to do semantic search on data and add the result to the LLM\'s context before generating the reply.\n\nThe user is currently writing instructions for the large language model prompt that will be the basis of a custom assistant they are creating for a specific purpose.\n\nYour task\n---\nBased on the instructions the user has written, propose two new suggestions to improve them, different from the already-existing former suggestions the user provided. Indicate if the instructions are already very good as they are. Rank all suggestions (former and new) by most important first.\nYou MUST answer by calling ' +
+        'A user is working on a Saas product called Dust, a tool for creating custom agents based on large language models, to help employees to be more productive. \n\nContext\n---\nA few elements to bear in mind:\n- On Dust, users can give agents access to company data (on slack, notion, google drive, github, intercom, confluence). Agents that are configured to use company data can do semantic searches before answering the user, and use the retrieved data to reply;\n- some companies have created "Dust apps" and for some advanced use cases agents can execute those dust apps before answering;\n- advanced use cases also include allowing agents to query structured data from Notion Databases or Google Spreadsheets, that is, treating those documents as SQL databases and running sql queries on them;\n- however, in the majority of cases, custom agents are either asked to reply only (i.e. without searching data, acting or querying structured data), or to perform retrieval-augmented-generation, that is to do semantic search on data and add the result to the LLM\'s context before generating the reply.\n\nThe user is currently writing instructions for the large language model prompt that will be the basis of a custom agent they are creating for a specific purpose.\n\nYour task\n---\nBased on the instructions the user has written, propose two new suggestions to improve them, different from the already-existing former suggestions the user provided. Indicate if the instructions are already very good as they are. Rank all suggestions (former and new) by most important first.\nYou MUST answer by calling ' +
         FUNCTION_NAME,
       specifications,
       forceToolCall: FUNCTION_NAME,


### PR DESCRIPTION
Fixes: https://github.com/dust-tt/tasks/issues/5971

## Description

Replace "assistant" with "agent" terminology in the agent builder suggestion prompts (description, emoji, instructions). This aligns with the product terminology.

## Tests

Front.

## Risk

Low.

## Deploy Plan

Front.