### PR TITLE
fix: vitest warning upgrade

### DIFF
--- a/connectors/vite.config.mjs
+++ b/connectors/vite.config.mjs
@@ -27,21 +27,13 @@ export default defineConfig({
       if (isDebug) {
         return {
           pool: "threads",
-          poolOptions: {
-            threads: {
-              singleThread: true, // Run everything in a single worker to allow debugger attach.
-            },
-          },
+          maxWorkers: 1, // Run everything in a single worker to allow debugger attach.
+          isolate: false,
         };
       }
       return {
         pool: "forks",
-        poolOptions: {
-          forks: {
-            singleFork: false, // Use multiple forks for parallelism
-            isolate: true, // Each test file gets its own process
-          },
-        },
+        isolate: true, // Each test file gets its own process
       };
     })(),
   },

--- a/front/vite.config.mjs
+++ b/front/vite.config.mjs
@@ -31,21 +31,13 @@ export default defineConfig({
       if (isDebug) {
         return {
           pool: "threads",
-          poolOptions: {
-            threads: {
-              singleThread: true, // Run everything in a single worker to allow debugger attach.
-            },
-          },
+          maxWorkers: 1, // Run everything in a single worker to allow debugger attach.
+          isolate: false,
         };
       }
       return {
         pool: "forks",
-        poolOptions: {
-          forks: {
-            singleFork: false, // Use multiple forks for parallelism
-            isolate: true, // Each test file gets its own process
-          },
-        },
+        isolate: true, // Each test file gets its own process
       };
     })(),
   },


### PR DESCRIPTION
## Description

Fix the warning we have

```
DEPRECATED  `test.poolOptions` was removed in Vitest 4. All previous `poolOptions` are now top-level options. Please, refer to the migration guide: https://vitest.dev/guide/migration#pool-rework
```

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
