### PR TITLE
[front] fix(agent-builder): align section title with button order

### DIFF
--- a/front/components/agent_builder/skills/AgentBuilderSkillsBlock.tsx
+++ b/front/components/agent_builder/skills/AgentBuilderSkillsBlock.tsx
@@ -261,10 +261,10 @@ export function AgentBuilderSkillsBlock() {
 
   return (
     <AgentBuilderSectionContainer
-      title="Knowledge and capabilities"
+      title="Capabilities and knowledge"
       description={
         <>
-          Add knowledge, tools and skills to enhance your agent's abilities.
+          Add skills, tools, and knowledge to enhance your agent's abilities.
           Need help? Check our{" "}
           <Hoverable
             variant="primary"


### PR DESCRIPTION
Fixes: https://github.com/dust-tt/tasks/issues/5968

## Description

Update "Knowledge and capabilities" section to "Capabilities and knowledge" to match the button order (Add capabilities, Add knowledge).

## Tests

<img width="1929" height="420" alt="image" src="https://github.com/user-attachments/assets/5b2c7ac7-d969-47c8-b682-f4b46e8125d9" />
<img width="1929" height="348" alt="image" src="https://github.com/user-attachments/assets/01b581f8-a6b3-4515-8cf3-a4593a08e4f8" />


## Risk

Low.

## Deploy Plan

Front.