### PR TITLE
[connectors] chore(microsoft): flag invalid clients when connecting

### DIFF
--- a/connectors/src/lib/oauth.ts
+++ b/connectors/src/lib/oauth.ts
@@ -43,7 +43,8 @@ export async function getOAuthConnectionAccessTokenWithThrow({
         tokRes.error.message.includes("Token was globally revoked")) ||
       // Happens with microsoft
       (tokRes.error.code === "provider_access_token_refresh_error" &&
-        tokRes.error.message.includes("invalid_grant")) ||
+        (tokRes.error.message.includes("invalid_grant") ||
+          tokRes.error.message.includes("invalid_client"))) ||
       // Happens with google drive
       (tokRes.error.code === "provider_access_token_refresh_error" &&
         tokRes.error.message.includes("Account Restricted"))


### PR DESCRIPTION
## Description

- See [Slack thread](https://dust4ai.slack.com/archives/C050SM8NSPK/p1768816391229069).
- We don't correctly stop a Microsoft connector when the service principal is invalid in every cases.
- This PR handles the case where the client is invalid, and throws an `ExternalOAuthTokenError`.

## Tests


## Risk

## Deploy Plan

- Deploy connectors.
