### PR TITLE
Add form data to GTM form submission events

### DIFF
--- a/front/components/home/ContactForm.tsx
+++ b/front/components/home/ContactForm.tsx
@@ -99,12 +99,19 @@ function useContactFormSubmit() {
         action: "submit_success",
       });
 
-      // Push GTM event with actual qualification status
+      // Push GTM event with actual qualification status and form details
       if (typeof window !== "undefined") {
         window.dataLayer = window.dataLayer ?? [];
         window.dataLayer.push({
           event: "contact_form_submitted",
           is_qualified: result.isQualified,
+          user_email: data.email,
+          user_phone: data.mobilephone,
+          user_first_name: data.firstname,
+          user_last_name: data.lastname,
+          user_language: data.language,
+          user_headquarters_region: data.headquarters_region,
+          user_company_headcount: data.company_headcount_form,
         });
       }
 

--- a/front/components/home/ContactFormThankYou.tsx
+++ b/front/components/home/ContactFormThankYou.tsx
@@ -83,6 +83,13 @@ export function ContactFormThankYou({ isQualified }: ContactFormThankYouProps) {
         window.dataLayer = window.dataLayer ?? [];
         window.dataLayer.push({
           event: "contact_form_qualified_lead",
+          user_email: email,
+          user_phone: phone,
+          user_first_name: firstName,
+          user_last_name: lastName,
+          user_language: language,
+          user_headquarters_region: headquartersRegion,
+          user_company_headcount: companyHeadcount,
         });
       }
     }

--- a/front/components/home/ContactFormThankYou.tsx
+++ b/front/components/home/ContactFormThankYou.tsx
@@ -64,6 +64,7 @@ export function ContactFormThankYou({ isQualified }: ContactFormThankYouProps) {
   const headquartersRegion = formValues.headquarters_region ?? "";
   const companyHeadcount = formValues.company_headcount_form ?? "";
   const howToUseDust = formValues.landing_use_cases ?? "";
+  const consentMarketing = formValues.consent_marketing ?? false;
 
   const hasTrackedRef = useRef(false);
   const defaultTriggeredRef = useRef(false);
@@ -79,17 +80,19 @@ export function ContactFormThankYou({ isQualified }: ContactFormThankYouProps) {
         action: "qualified_lead",
       });
 
+      // Only include PII if user has consented to marketing
       if (typeof window !== "undefined") {
         window.dataLayer = window.dataLayer ?? [];
         window.dataLayer.push({
           event: "contact_form_qualified_lead",
-          user_email: email,
-          user_phone: phone,
-          user_first_name: firstName,
-          user_last_name: lastName,
+          user_email: consentMarketing ? email : undefined,
+          user_phone: consentMarketing ? phone : undefined,
+          user_first_name: consentMarketing ? firstName : undefined,
+          user_last_name: consentMarketing ? lastName : undefined,
           user_language: language,
           user_headquarters_region: headquartersRegion,
           user_company_headcount: companyHeadcount,
+          consent_marketing: consentMarketing,
         });
       }
     }
@@ -102,6 +105,7 @@ export function ContactFormThankYou({ isQualified }: ContactFormThankYouProps) {
     language,
     headquartersRegion,
     companyHeadcount,
+    consentMarketing,
   ]);
 
   // Load Default.com SDK and submit form data for all leads

--- a/front/components/home/ContactFormThankYou.tsx
+++ b/front/components/home/ContactFormThankYou.tsx
@@ -93,7 +93,16 @@ export function ContactFormThankYou({ isQualified }: ContactFormThankYouProps) {
         });
       }
     }
-  }, [isQualified]);
+  }, [
+    isQualified,
+    email,
+    phone,
+    firstName,
+    lastName,
+    language,
+    headquartersRegion,
+    companyHeadcount,
+  ]);
 
   // Load Default.com SDK and submit form data for all leads
   useEffect(() => {

--- a/front/global.d.ts
+++ b/front/global.d.ts
@@ -1,3 +1,13 @@
+type ContactFormEventData = {
+  user_email: string;
+  user_phone: string | undefined;
+  user_first_name: string | undefined;
+  user_last_name: string | undefined;
+  user_language: string;
+  user_headquarters_region: string | undefined;
+  user_company_headcount: string;
+};
+
 type DataLayer =
   | {
       event: "userIdentified";
@@ -9,27 +19,13 @@ type DataLayer =
       company_name: string;
       gclid: string | null;
     }
-  | {
+  | ({
       event: "contact_form_submitted";
       is_qualified: boolean;
-      user_email: string;
-      user_phone: string | undefined;
-      user_first_name: string | undefined;
-      user_last_name: string | undefined;
-      user_language: string;
-      user_headquarters_region: string | undefined;
-      user_company_headcount: string;
-    }
-  | {
+    } & ContactFormEventData)
+  | ({
       event: "contact_form_qualified_lead";
-      user_email: string;
-      user_phone: string | undefined;
-      user_first_name: string | undefined;
-      user_last_name: string | undefined;
-      user_language: string;
-      user_headquarters_region: string | undefined;
-      user_company_headcount: string;
-    };
+    } & ContactFormEventData);
 
 interface Signals {
   identify: (data: { email: string; name: string }) => void;

--- a/front/global.d.ts
+++ b/front/global.d.ts
@@ -12,9 +12,23 @@ type DataLayer =
   | {
       event: "contact_form_submitted";
       is_qualified: boolean;
+      user_email: string;
+      user_phone: string | undefined;
+      user_first_name: string | undefined;
+      user_last_name: string | undefined;
+      user_language: string;
+      user_headquarters_region: string | undefined;
+      user_company_headcount: string;
     }
   | {
       event: "contact_form_qualified_lead";
+      user_email: string;
+      user_phone: string | undefined;
+      user_first_name: string | undefined;
+      user_last_name: string | undefined;
+      user_language: string;
+      user_headquarters_region: string | undefined;
+      user_company_headcount: string;
     };
 
 interface Signals {

--- a/front/global.d.ts
+++ b/front/global.d.ts
@@ -1,11 +1,12 @@
 type ContactFormEventData = {
-  user_email: string;
+  user_email: string | undefined;
   user_phone: string | undefined;
   user_first_name: string | undefined;
   user_last_name: string | undefined;
   user_language: string;
   user_headquarters_region: string | undefined;
   user_company_headcount: string;
+  consent_marketing: boolean;
 };
 
 type DataLayer =

--- a/front/lib/api/hubspot/contactFormSchema.ts
+++ b/front/lib/api/hubspot/contactFormSchema.ts
@@ -109,6 +109,7 @@ export const ContactFormSchema = z.object({
   headquarters_region: z.string().optional(),
   company_headcount_form: z.string().min(1, "Company headcount is required"),
   landing_use_cases: z.string().optional(),
+  consent_marketing: z.boolean().optional(),
 });
 
 export type ContactFormData = z.infer<typeof ContactFormSchema>;


### PR DESCRIPTION





## Description

Adds a marketing consent checkbox to the contact form to enable more comprehensive GTM tracking while remaining GDPR compliant. The checkbox defaults to checked for non-GDPR regions and unchecked for GDPR regions based on geolocation. When users consent, GTM events (`contact_form_submitted` and `contact_form_qualified_lead`) include additional form data (email, phone, first name, last name, language, headquarters region, and company headcount). Without consent, only non-PII fields are sent to GTM.

## Risk

PII is now conditionally sent to Google Tag Manager based on user consent. The geolocation-based default could fail silently if the geo endpoint is unavailable, though this only affects the checkbox default state (users can still manually opt in/out).

## Tests

Manual testing on contact form.

## Deploy Plan
