### PR TITLE
Support Almost-Concurrent File Edits with Distributed Locking

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/interactive_content/instructions.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/interactive_content/instructions.ts
@@ -41,7 +41,7 @@ Validation is performed automatically when you create or edit files.
 receive warnings in the tool response, they include the exact \`old_string\` and
 \`expected_replacements\` count. You MUST fix these warnings using
 \`${EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME}\` with the provided values. If you receive
-multiple warnings, fix them sequentially with separate tool calls (not all in one message).
+multiple warnings, fix all of them in a single response using multiple edit tool calls.
 Common warning: "Forbidden Tailwind arbitrary value 'h-[600px]'" means you should replace with
 predefined classes like h-96 or use inline styles. Do NOT regenerate the entire file; use
 targeted edits only.

--- a/front/lib/lock.ts
+++ b/front/lib/lock.ts
@@ -54,7 +54,7 @@ const WAIT_BETWEEN_RETRIES = 100;
 export const executeWithLock = async <T>(
   lockName: string,
   callback: () => Promise<T>,
-  timeoutMs: number = 30000
+  timeoutMs: number = 30_000
 ): Promise<T> => {
   const client = await getRedisClient({ origin: "lock" });
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Follow up of https://github.com/dust-tt/dust/pull/20198.

Enables LLMs to make multiple file edits in a single response without conflicts. File-level locking ensures edits are applied sequentially even when tool calls are made in parallel, preventing race conditions and lost updates.

### Behavior

**Before:** Multiple edits in one response could cause race conditions or conflicts
**After:** Multiple edits are safely serialized through distributed locking

Example - LLM can now do this in one message:
```javascript
editFile({ file_id: "fil_123", old_string: "className=\"h-[600px]\"", new_string: "className=\"h-96\"" })
editFile({ file_id: "fil_123", old_string: "className=\"w-[800px]\"", new_string: "className=\"w-full\"" })
editFile({ file_id: "fil_123", old_string: "className=\"text-[14px]\"", new_string: "className=\"text-sm\"" })
```

All three edits will be applied sequentially in the order received, with proper locking preventing conflicts.

## Future Work

Replace Redis locks with YJS/CRDT for true concurrent multi-agent editing where multiple edits can be merged intelligently rather than serialized.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
