### PR TITLE
fix(github): use correct body text for child comments in GitHub discussions

### DIFF
--- a/connectors/src/connectors/github/temporal/activities.ts
+++ b/connectors/src/connectors/github/temporal/activities.ts
@@ -441,7 +441,7 @@ async function renderDiscussion(
             prefix: `>> ${childComment.author?.login || "Unknown author"}:\n`,
             content: null,
             sections: [
-              await renderMarkdownSection(dataSourceConfig, comment.bodyText, {
+              await renderMarkdownSection(dataSourceConfig, childComment.bodyText, {
                 flavor: "gfm",
               }),
             ],


### PR DESCRIPTION
## Description

When rendering child comments (replies) in GitHub discussions, the code was incorrectly using the parent comment's `bodyText` instead of the child comment's `bodyText`. This caused all child comments to display the same content as the parent comment.

**Fix:** Changed `comment.bodyText` to `childComment.bodyText` in the `renderDiscussion` function at `connectors/src/connectors/github/temporal/activities.ts:444`.

## Tests

Manual code review - the fix is straightforward and clearly correct. The loop iterates over `childComments` but was using `comment.bodyText` from the outer scope instead of `childComment.bodyText`.

## Risk

**Low risk.** This is a one-line bug fix that uses the correct variable in an existing loop. The change is isolated and only affects the rendering of GitHub discussion child comments. Safe to rollback if needed.

## Deploy Plan

Standard deployment - no special steps required. The fix will take effect for any new GitHub discussion syncs.