### PR TITLE
feat(dust-hive): move TUI status bar to bottom as sticky footer

### DIFF
--- a/x/henry/dust-hive/src/lib/scripts.ts
+++ b/x/henry/dust-hive/src/lib/scripts.ts
@@ -76,8 +76,21 @@ handle_resize() {
 trap cleanup EXIT
 trap handle_resize WINCH
 
-# Get terminal dimensions
+# Get terminal dimensions - try multiple methods for reliability
 get_term_height() {
+  local height
+  # Try stty first (most reliable for actual terminal)
+  height=$(stty size 2>/dev/null | cut -d' ' -f1)
+  if [[ -n "$height" && "$height" -gt 0 ]]; then
+    echo "$height"
+    return
+  fi
+  # Try LINES env var (set by bash)
+  if [[ -n "$LINES" && "$LINES" -gt 0 ]]; then
+    echo "$LINES"
+    return
+  fi
+  # Fall back to tput
   tput lines 2>/dev/null || echo 24
 }`;
 


### PR DESCRIPTION
## Description

Move the unified logs TUI status bar from top of terminal to bottom, creating a sticky footer that stays visible while logs stream naturally from the top. This matches the UX convention of tools like htop, vim, and less.

**Changes:**
- Rename `draw_header` → `draw_footer` and position at last terminal row
- Update scroll region from lines 2-bottom to lines 1-(bottom-1)
- Add `SIGWINCH` handler to redraw correctly on terminal resize

**Benefits:**
- Logs stream naturally from top like normal terminal output
- More consistent with standard CLI tools
- Better ergonomics with controls at bottom where your eye naturally rests

## Tests

- Ran `bun run check` (typecheck, lint, 170 tests pass)
- Manual testing needed: run `dust-hive logs` from a dust-hive environment and verify:
  - Footer appears at bottom of terminal
  - Logs stream from top and scroll up naturally
  - Footer remains visible as new logs arrive
  - All hotkeys work: n/p (switch), +/- (lines), r (restart), q (stop), x (exit)
  - Terminal resize redraws correctly

## Risk

Low risk - this is a UX improvement to the logs TUI that doesn't affect core functionality. The change is isolated to the generated bash script for the TUI.

## Deploy Plan

No deployment needed - this is a dust-hive CLI tool change. Users will get the update when they next run commands that use the TUI.