### PR TITLE
[front] - refactor(MCPServerOAuthConnexion): tweak RHF 

### DIFF
--- a/front/components/actions/mcp/MCPServerOAuthConnexion.tsx
+++ b/front/components/actions/mcp/MCPServerOAuthConnexion.tsx
@@ -160,6 +160,7 @@ export function MCPServerOAuthConnexion({
     }
   }, [authCredentials, inputs, setError, clearErrors]);
 
+  // User interaction handlers use field.onChange for proper lifecycle integration.
   const handleCredentialChange = (key: string, value: string) => {
     if (!isSupportedOAuthCredential(key)) {
       return;

--- a/front/components/actions/mcp/MCPServerOAuthConnexion.tsx
+++ b/front/components/actions/mcp/MCPServerOAuthConnexion.tsx
@@ -14,7 +14,7 @@ import {
 } from "@dust-tt/sparkle";
 import { ChevronDownIcon, ChevronRightIcon } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
-import { useFormContext } from "react-hook-form";
+import { useController, useFormContext } from "react-hook-form";
 
 import type { MCPServerOAuthFormValues } from "@app/components/actions/mcp/forms/types";
 import type { AuthorizationInfo } from "@app/lib/actions/mcp_metadata_extraction";
@@ -56,11 +56,21 @@ export function MCPServerOAuthConnexion({
   authorization,
   documentationUrl,
 }: MCPServerOAuthConnexionProps) {
-  const { setError, clearErrors, setValue, watch } =
+  const { setError, clearErrors, setValue, control } =
     useFormContext<MCPServerOAuthFormValues>();
 
-  const useCase = watch("useCase");
-  const authCredentials = watch("authCredentials");
+  const { field: useCaseField } = useController({
+    name: "useCase",
+    control,
+  });
+
+  const { field: authCredentialsField } = useController({
+    name: "authCredentials",
+    control,
+  });
+
+  const useCase = useCaseField.value;
+  const authCredentials = authCredentialsField.value;
 
   // Dynamically fetched credential inputs based on provider and use case.
   const [inputs, setInputs] = useState<OAuthCredentialInputs | null>(null);
@@ -164,11 +174,11 @@ export function MCPServerOAuthConnexion({
     if (!isSupportedOAuthCredential(key)) {
       return;
     }
-    setValue("authCredentials", { ...(authCredentials ?? {}), [key]: value });
+    authCredentialsField.onChange({ ...(authCredentials ?? {}), [key]: value });
   };
 
   const handleUseCaseSelect = (selectedUseCase: MCPOAuthUseCase) => {
-    setValue("useCase", selectedUseCase);
+    useCaseField.onChange(selectedUseCase);
   };
 
   const supportsPersonalActions =

--- a/front/components/actions/mcp/MCPServerOAuthConnexion.tsx
+++ b/front/components/actions/mcp/MCPServerOAuthConnexion.tsx
@@ -160,7 +160,6 @@ export function MCPServerOAuthConnexion({
     }
   }, [authCredentials, inputs, setError, clearErrors]);
 
-  // User interaction handlers use field.onChange for proper lifecycle integration.
   const handleCredentialChange = (key: string, value: string) => {
     if (!isSupportedOAuthCredential(key)) {
       return;


### PR DESCRIPTION
## Description

Using useController with field.onChange for user interactions (clicks, typing) instead of setValue is the recommended pattern because:

  1. Proper controller lifecycle - field.onChange integrates with react-hook-form's internal state management, ensuring proper dirty/touched state tracking and validation triggers.
  2. Clearer separation of concerns - The code now clearly distinguishes between:
    - User interactions → field.onChange (in event handlers)
    - Programmatic updates → setValue (in useEffect for initialization)
  3. Consistency with controlled components - useController is designed for controlled components (like the UseCaseCard selection and credential Input fields). Using its field.onChange keeps the component in sync with how react-hook-form expects controlled inputs to behave.
  4. Avoids subtle bugs - Using setValue for user interactions can bypass certain internal react-hook-form updates (like isDirty calculation based on user input vs programmatic changes), potentially causing inconsistent form state.

**References:**
- Closes https://github.com/dust-tt/tasks/issues/5967

## Test

Locally

## Deploy plan

Deploy front
