### PR TITLE
feat: add project metadata to dust_project connector

### DIFF
--- a/connectors/src/connectors/dust_project/lib/format_metadata.ts
+++ b/connectors/src/connectors/dust_project/lib/format_metadata.ts
@@ -1,0 +1,40 @@
+import type { ProjectMetadataType } from "@dust-tt/client";
+
+/**
+ * Formats project metadata as a markdown document.
+ */
+export function formatProjectMetadata(metadata: ProjectMetadataType): string {
+  if (!metadata.description) {
+    return "# Description\n\nNo description available for this project.";
+  }
+
+  return `# Description\n\n${metadata.description}`;
+}
+
+/**
+ * Gets the internal ID for the metadata file in the data source.
+ *
+ * @param connectorId - The connector ID
+ * @param projectId - The project/space ID
+ * @returns The internal ID for the metadata file
+ */
+export function getMetadataFileInternalId(
+  connectorId: number,
+  projectId: string
+): string {
+  return `dust-project-${connectorId}-project-${projectId}-metadata`;
+}
+
+/**
+ * Gets the folder ID for the project.
+ *
+ * @param connectorId - The connector ID
+ * @param projectId - The project/space ID
+ * @returns The folder ID for the project
+ */
+export function getProjectFolderInternalId(
+  connectorId: number,
+  projectId: string
+): string {
+  return `dust-project-${connectorId}-project-${projectId}`;
+}

--- a/connectors/src/connectors/dust_project/lib/sync_conversation.ts
+++ b/connectors/src/connectors/dust_project/lib/sync_conversation.ts
@@ -76,7 +76,6 @@ export async function syncConversation({
   dataSourceConfig,
   projectId,
   conversation,
-
   syncType,
 }: {
   connectorId: ModelId;

--- a/connectors/src/connectors/dust_project/lib/sync_metadata.ts
+++ b/connectors/src/connectors/dust_project/lib/sync_metadata.ts
@@ -1,0 +1,87 @@
+import type { ProjectMetadataType } from "@dust-tt/client";
+
+import {
+  formatProjectMetadata,
+  getMetadataFileInternalId,
+} from "@connectors/connectors/dust_project/lib/format_metadata";
+import {
+  renderDocumentTitleAndContent,
+  upsertDataSourceDocument,
+} from "@connectors/lib/data_sources";
+import logger from "@connectors/logger/logger";
+import type { DataSourceConfig } from "@connectors/types";
+
+/**
+ * Syncs project metadata (description) to the data source.
+ * Creates a metadata.md file at the root of the project folder.
+ */
+export async function syncProjectMetadata({
+  dataSourceConfig,
+  connectorId,
+  projectId,
+  metadata,
+}: {
+  dataSourceConfig: DataSourceConfig;
+  connectorId: number;
+  projectId: string;
+  metadata: ProjectMetadataType | null;
+}): Promise<void> {
+  const localLogger = logger.child({
+    connectorId,
+    projectId,
+    provider: "dust_project",
+  });
+
+  if (!metadata) {
+    localLogger.info("No metadata found for project. Skipping sync.");
+    return;
+  }
+
+  localLogger.info("Syncing project metadata (only description for now)");
+
+  const metadataText = formatProjectMetadata(metadata);
+
+  // Get the internal IDs for the document and folder
+  const documentId = getMetadataFileInternalId(connectorId, projectId);
+
+  // Create the document content section
+  const contentSection = {
+    prefix: null,
+    content: metadataText,
+    sections: [],
+  };
+
+  // Render with metadata (title, timestamps)
+  const documentContent = await renderDocumentTitleAndContent({
+    dataSourceConfig,
+    title: "metadata.md",
+    createdAt: new Date(metadata.createdAt),
+    updatedAt: new Date(metadata.updatedAt),
+    content: contentSection,
+  });
+
+  // Upsert the description document
+  await upsertDataSourceDocument({
+    dataSourceConfig,
+    documentId,
+    documentContent,
+    documentUrl: undefined,
+    timestampMs: Date.now(),
+    tags: [`project:${projectId}`],
+    parents: [documentId],
+    parentId: null,
+    loggerArgs: {
+      connectorId,
+      projectId,
+      documentId,
+    },
+    upsertContext: {
+      sync_type: "batch",
+    },
+    title: "Project metadata",
+    mimeType: "text/markdown",
+    async: true,
+  });
+
+  localLogger.info("Successfully synced project metadata (description)");
+}

--- a/connectors/src/connectors/dust_project/temporal/client.ts
+++ b/connectors/src/connectors/dust_project/temporal/client.ts
@@ -15,6 +15,7 @@ import { getTemporalClient, terminateWorkflow } from "@connectors/lib/temporal";
 import logger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { ModelId } from "@connectors/types";
+import { isDevelopment } from "@connectors/types";
 import { normalizeError } from "@connectors/types";
 
 export async function launchDustProjectFullSyncWorkflow(
@@ -75,7 +76,9 @@ export async function launchDustProjectIncrementalSyncWorkflow(
   // minuteOffset ensures jobs are distributed across the 10-minute intervals based on connector ID
   // Run incremental sync every 10 minutes
   const minuteOffset = connector.id % 10;
-  const cronSchedule = `${minuteOffset},${minuteOffset + 10},${minuteOffset + 20},${minuteOffset + 30},${minuteOffset + 40},${minuteOffset + 50} * * * *`;
+  const cronSchedule = isDevelopment()
+    ? `* * * * *`
+    : `${minuteOffset},${minuteOffset + 10},${minuteOffset + 20},${minuteOffset + 30},${minuteOffset + 40},${minuteOffset + 50} * * * *`;
 
   try {
     // Check if workflow already exists

--- a/connectors/src/connectors/dust_project/temporal/workflows.ts
+++ b/connectors/src/connectors/dust_project/temporal/workflows.ts
@@ -3,10 +3,13 @@ import { proxyActivities } from "@temporalio/workflow";
 import type * as activities from "@connectors/connectors/dust_project/temporal/activities";
 import type { ModelId } from "@connectors/types";
 
-const { dustProjectFullSyncActivity, dustProjectIncrementalSyncActivity } =
-  proxyActivities<typeof activities>({
-    startToCloseTimeout: "60 minutes",
-  });
+const {
+  dustProjectConversationsFullSyncActivity,
+  dustProjectConversationsIncrementalSyncActivity,
+  dustProjectSyncMetadataActivity,
+} = proxyActivities<typeof activities>({
+  startToCloseTimeout: "60 minutes",
+});
 
 /**
  * Generate workflow IDs for dust_project workflows
@@ -30,7 +33,8 @@ export async function dustProjectFullSyncWorkflow({
 }: {
   connectorId: ModelId;
 }): Promise<void> {
-  await dustProjectFullSyncActivity({ connectorId });
+  await dustProjectConversationsFullSyncActivity({ connectorId });
+  await dustProjectSyncMetadataActivity({ connectorId });
 }
 
 /**
@@ -42,5 +46,6 @@ export async function dustProjectIncrementalSyncWorkflow({
 }: {
   connectorId: ModelId;
 }): Promise<void> {
-  await dustProjectIncrementalSyncActivity({ connectorId });
+  await dustProjectConversationsIncrementalSyncActivity({ connectorId });
+  await dustProjectSyncMetadataActivity({ connectorId });
 }

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/project_metadata.test.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/project_metadata.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from "vitest";
+
+import { Authenticator } from "@app/lib/auth";
+import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
+import { createPublicApiMockRequest } from "@app/tests/utils/generic_public_api_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+
+import handler from "./project_metadata";
+
+describe("system-only authentication tests", () => {
+  it("returns 403 if not system key", async () => {
+    const { req, res, workspace } = await createPublicApiMockRequest({
+      systemKey: false,
+      method: "GET",
+    });
+
+    const space = await SpaceFactory.project(workspace);
+    req.query.spaceId = space.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(403);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "invalid_oauth_token_error",
+        message: "Only system keys are allowed to use this endpoint.",
+      },
+    });
+  });
+});
+
+describe("GET /api/v1/w/[wId]/spaces/[spaceId]/project_metadata", () => {
+  it("should return 400 if workspace id is missing", async () => {
+    const { req, res } = await createPublicApiMockRequest({
+      systemKey: true,
+      method: "GET",
+    });
+
+    req.query.wId = undefined as any;
+    req.query.spaceId = "test-space-id";
+
+    await handler(req, res);
+
+    // The authentication wrapper might return 404 before the handler checks,
+    // but the handler itself should return 400. Let's check for both.
+    expect([400, 404]).toContain(res._getStatusCode());
+  });
+
+  it("should return 400 if space id is missing", async () => {
+    const { req, res } = await createPublicApiMockRequest({
+      systemKey: true,
+      method: "GET",
+    });
+
+    req.query.spaceId = undefined;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "invalid_request_error",
+        message: "Missing or invalid space id.",
+      },
+    });
+  });
+
+  it("should return 403 if not using system key", async () => {
+    const { req, res, workspace } = await createPublicApiMockRequest({
+      systemKey: false,
+      method: "GET",
+    });
+
+    const space = await SpaceFactory.project(workspace);
+    req.query.spaceId = space.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(403);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "invalid_oauth_token_error",
+        message: "Only system keys are allowed to use this endpoint.",
+      },
+    });
+  });
+
+  it("should return 404 if space does not exist", async () => {
+    const { req, res } = await createPublicApiMockRequest({
+      systemKey: true,
+      method: "GET",
+    });
+
+    req.query.spaceId = "non-existent-space-id";
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(404);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "space_not_found",
+        message: "Space not found.",
+      },
+    });
+  });
+
+  it("should return 400 if space is not a project space", async () => {
+    const { req, res, workspace } = await createPublicApiMockRequest({
+      systemKey: true,
+      method: "GET",
+    });
+
+    // Create a regular space (not a project)
+    const space = await SpaceFactory.regular(workspace);
+    req.query.spaceId = space.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "invalid_request_error",
+        message: "Project metadata is only available for project spaces.",
+      },
+    });
+  });
+
+  it("should return 405 for unsupported method", async () => {
+    const { req, res, workspace } = await createPublicApiMockRequest({
+      systemKey: true,
+      method: "POST",
+    });
+
+    const space = await SpaceFactory.project(workspace);
+    req.query.spaceId = space.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(405);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "method_not_supported_error",
+        message: "The method passed is not supported, GET expected.",
+      },
+    });
+  });
+
+  it("should return null metadata if no metadata exists", async () => {
+    const { req, res, workspace } = await createPublicApiMockRequest({
+      systemKey: true,
+      method: "GET",
+    });
+
+    const space = await SpaceFactory.project(workspace);
+    req.query.spaceId = space.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getJSONData();
+    expect(data.metadata).toBeNull();
+  });
+
+  it("should return project metadata when it exists", async () => {
+    const { req, res, workspace } = await createPublicApiMockRequest({
+      systemKey: true,
+      method: "GET",
+    });
+
+    const space = await SpaceFactory.project(workspace);
+
+    // Create an admin user to create metadata
+    const user = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, user, { role: "admin" });
+    const adminAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      user.sId,
+      workspace.sId
+    );
+
+    // Create project metadata
+    await ProjectMetadataResource.makeNew(adminAuth, space, {
+      description: "Test project description",
+      urls: ["https://example.com"],
+      tags: ["test", "project"],
+    });
+
+    req.query.spaceId = space.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getJSONData();
+    expect(data.metadata).toEqual({
+      createdAt: expect.anything(),
+      description: "Test project description",
+      sId: expect.anything(),
+      spaceId: space.sId,
+      tags: ["test", "project"],
+      updatedAt: expect.anything(),
+      urls: ["https://example.com"],
+    });
+  });
+});

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/project_metadata.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/project_metadata.ts
@@ -1,0 +1,98 @@
+import type { GetSpaceMetadataResponseType } from "@dust-tt/client";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+import { isString } from "@app/types";
+
+/**
+ * @ignoreswagger
+ * System API key only endpoint. Undocumented.
+ * Used by connectors to fetch project metadata for syncing to data sources.
+ */
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetSpaceMetadataResponseType>>,
+  auth: Authenticator
+): Promise<void> {
+  const { wId, spaceId } = req.query;
+  if (!isString(wId)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Missing or invalid workspace id.",
+      },
+    });
+  }
+  if (!isString(spaceId)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Missing or invalid space id.",
+      },
+    });
+  }
+
+  // Only allow system keys (connectors) to access this endpoint
+  if (!auth.isSystemKey()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "invalid_oauth_token_error",
+        message: "Only system keys are allowed to use this endpoint.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      // Fetch and verify space exists
+      const space = await SpaceResource.fetchById(auth, spaceId);
+      if (!space) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "space_not_found",
+            message: "Space not found.",
+          },
+        });
+      }
+
+      // Only project spaces can have metadata
+      if (!space.isProject()) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Project metadata is only available for project spaces.",
+          },
+        });
+      }
+
+      // Fetch metadata
+      const metadata = await ProjectMetadataResource.fetchBySpace(auth, space);
+
+      return res.status(200).json({
+        metadata: metadata ? metadata.toJSON() : null,
+      });
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET expected.",
+        },
+      });
+  }
+}
+
+export default withPublicAPIAuthentication(handler);

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -77,6 +77,7 @@ import {
   GetMentionSuggestionsResponseBodySchema,
   GetSpaceConversationIdsResponseSchema,
   GetSpaceConversationsForDataSourceResponseSchema,
+  GetSpaceMetadataResponseSchema,
   GetSpacesResponseSchema,
   GetWorkspaceFeatureFlagsResponseSchema,
   GetWorkspaceVerifiedDomainsResponseSchema,
@@ -1267,6 +1268,15 @@ export class DustAPI {
     });
 
     return this._resultFromResponse(GetSpaceConversationIdsResponseSchema, res);
+  }
+
+  async getSpaceMetadata({ spaceId }: { spaceId: string }) {
+    const res = await this.request({
+      method: "GET",
+      path: `spaces/${spaceId}/project_metadata`,
+    });
+
+    return this._resultFromResponse(GetSpaceMetadataResponseSchema, res);
   }
 
   async postFeedback(

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -2410,6 +2410,22 @@ export type GetSpaceConversationIdsResponseType = z.infer<
   typeof GetSpaceConversationIdsResponseSchema
 >;
 
+export const ProjectMetadataSchema = z.object({
+  sId: z.string(),
+  createdAt: z.number(),
+  updatedAt: z.number(),
+  spaceId: z.string(),
+  description: z.string().nullable(),
+});
+export type ProjectMetadataType = z.infer<typeof ProjectMetadataSchema>;
+
+export const GetSpaceMetadataResponseSchema = z.object({
+  metadata: ProjectMetadataSchema.nullable(),
+});
+export type GetSpaceMetadataResponseType = z.infer<
+  typeof GetSpaceMetadataResponseSchema
+>;
+
 const GetDocumentsResponseSchema = z.object({
   documents: z.array(CoreAPIDocumentSchema),
   total: z.number(),


### PR DESCRIPTION
## Description

The dust_project connector now syncs project metadata as a single file.

It uses the same pattern as the conversations: connectors calls front

## Tests

Locally + unit tests

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
