### PR TITLE
[connectors] enh(google_drive): rework CLI arguments

### DIFF
--- a/connectors/migrations/20231109_incident_gdrive_non_deleted_files.ts
+++ b/connectors/migrations/20231109_incident_gdrive_non_deleted_files.ts
@@ -1,135 +1,135 @@
-import { Sequelize } from "sequelize";
-
-import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
-import { deleteDataSourceDocument } from "@connectors/lib/data_sources";
-import { GoogleDriveFilesModel } from "@connectors/lib/models/google_drive";
-import { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
-
-// To be run from connectors with `CORE_DATABASE_URI` and `FRONT_DATABASE_URI` set.
-const { CORE_DATABASE_URI, FRONT_DATABASE_URI, LIVE = false } = process.env;
-
-async function main() {
-  const core_sequelize = new Sequelize(CORE_DATABASE_URI as string, {
-    logging: false,
-  });
-  const front_sequelize = new Sequelize(FRONT_DATABASE_URI as string, {
-    logging: false,
-  });
-
-  const gDriveConnectors = await ConnectorModel.findAll({
-    where: {
-      type: "google_drive",
-    },
-  });
-
-  console.log(`Processing ${gDriveConnectors.length} google drive connectors`);
-
-  for (const c of gDriveConnectors) {
-    const files = await GoogleDriveFilesModel.findAll({
-      where: {
-        connectorId: c.id,
-      },
-      attributes: ["id", "driveFileId", "dustFileId"],
-    });
-
-    console.log(`Connector ${c.id}: found ${files.length} files`);
-
-    const fileHash = files.reduce(
-      (acc, f) => {
-        acc[f.dustFileId] = f.id;
-        return acc;
-      },
-      {} as { [key: string]: number }
-    );
-
-    // find dustProjectId from front based on workspaceId and connectorName
-    const dsData = await front_sequelize.query(
-      'SELECT * FROM data_sources WHERE "connectorId" = :connectorId',
-      {
-        replacements: {
-          connectorId: c.id.toString(),
-        },
-      }
-    );
-
-    if (dsData[0].length === 0) {
-      throw new Error(`No data source found for connector ${c.id}`);
-    }
-    const ds = dsData[0][0] as { dustAPIProjectId: string };
-    const dustAPIProjectId = parseInt(ds.dustAPIProjectId);
-
-    console.log(`Found dustAPIProjectId: ${dustAPIProjectId}`);
-
-    const coreDsData = await core_sequelize.query(
-      `SELECT * FROM data_sources WHERE "project" = :dustAPIProjectId`,
-      {
-        replacements: {
-          dustAPIProjectId: dustAPIProjectId,
-        },
-      }
-    );
-
-    if (coreDsData[0].length === 0) {
-      throw new Error(
-        `No core data source found for dustAPIProjectId ${dustAPIProjectId}`
-      );
-    }
-    const coreDs = coreDsData[0][0] as { data_source_id: string; id: number };
-    const coreDsId = coreDs.id;
-
-    console.log(
-      `Found core DustDataSource: ${coreDsId} ${coreDs.data_source_id}`
-    );
-
-    const coreDocumentsData = await core_sequelize.query(
-      `SELECT * FROM data_sources_documents WHERE "data_source" = :coreDsId AND status = 'latest'`,
-      {
-        replacements: {
-          coreDsId: coreDsId,
-        },
-      }
-    );
-
-    const documents = coreDocumentsData[0] as {
-      id: number;
-      document_id: string;
-      tags_array: string[];
-    }[];
-
-    console.log(`Found ${documents.length} core documents`);
-
-    const documentsToDelete = documents.filter((d) => {
-      return fileHash[d.document_id] === undefined;
-    });
-
-    for (const d of documentsToDelete) {
-      console.log(
-        `Deleting document ${d.id} ${d.document_id}, tags #${d.tags_array.join(
-          ", #"
-        )}`
-      );
-      if (LIVE) {
-        await deleteDocument(c, d.document_id);
-      }
-    }
-
-    console.log(
-      `>>> Found ${documentsToDelete.length} documents to delete for workspace ${c.workspaceId}`
-    );
-  }
-}
-
-async function deleteDocument(connector: ConnectorModel, fileId: string) {
-  const dataSourceConfig = dataSourceConfigFromConnector(connector);
-  await deleteDataSourceDocument(dataSourceConfig, fileId);
-}
-
-main()
-  .then(() => {
-    console.log("Done");
-    process.exit(0);
-  })
-  .catch((err) => {
-    console.error(err);
-    process.exit(1);
-  });
+// import { Sequelize } from "sequelize";
+//
+// import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
+// import { deleteDataSourceDocument } from "@connectors/lib/data_sources";
+// import { GoogleDriveFilesModel } from "@connectors/lib/models/google_drive";
+// import { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
+//
+// // To be run from connectors with `CORE_DATABASE_URI` and `FRONT_DATABASE_URI` set.
+// const { CORE_DATABASE_URI, FRONT_DATABASE_URI, LIVE = false } = process.env;
+//
+// async function main() {
+//   const core_sequelize = new Sequelize(CORE_DATABASE_URI as string, {
+//     logging: false,
+//   });
+//   const front_sequelize = new Sequelize(FRONT_DATABASE_URI as string, {
+//     logging: false,
+//   });
+//
+//   const gDriveConnectors = await ConnectorModel.findAll({
+//     where: {
+//       type: "google_drive",
+//     },
+//   });
+//
+//   console.log(`Processing ${gDriveConnectors.length} google drive connectors`);
+//
+//   for (const c of gDriveConnectors) {
+//     const files = await GoogleDriveFilesModel.findAll({
+//       where: {
+//         connectorId: c.id,
+//       },
+//       attributes: ["id", "driveFileId", "dustFileId"],
+//     });
+//
+//     console.log(`Connector ${c.id}: found ${files.length} files`);
+//
+//     const fileHash = files.reduce(
+//       (acc, f) => {
+//         acc[f.dustFileId] = f.id;
+//         return acc;
+//       },
+//       {} as { [key: string]: number }
+//     );
+//
+//     // find dustProjectId from front based on workspaceId and connectorName
+//     const dsData = await front_sequelize.query(
+//       'SELECT * FROM data_sources WHERE "connectorId" = :connectorId',
+//       {
+//         replacements: {
+//           connectorId: c.id.toString(),
+//         },
+//       }
+//     );
+//
+//     if (dsData[0].length === 0) {
+//       throw new Error(`No data source found for connector ${c.id}`);
+//     }
+//     const ds = dsData[0][0] as { dustAPIProjectId: string };
+//     const dustAPIProjectId = parseInt(ds.dustAPIProjectId);
+//
+//     console.log(`Found dustAPIProjectId: ${dustAPIProjectId}`);
+//
+//     const coreDsData = await core_sequelize.query(
+//       `SELECT * FROM data_sources WHERE "project" = :dustAPIProjectId`,
+//       {
+//         replacements: {
+//           dustAPIProjectId: dustAPIProjectId,
+//         },
+//       }
+//     );
+//
+//     if (coreDsData[0].length === 0) {
+//       throw new Error(
+//         `No core data source found for dustAPIProjectId ${dustAPIProjectId}`
+//       );
+//     }
+//     const coreDs = coreDsData[0][0] as { data_source_id: string; id: number };
+//     const coreDsId = coreDs.id;
+//
+//     console.log(
+//       `Found core DustDataSource: ${coreDsId} ${coreDs.data_source_id}`
+//     );
+//
+//     const coreDocumentsData = await core_sequelize.query(
+//       `SELECT * FROM data_sources_documents WHERE "data_source" = :coreDsId AND status = 'latest'`,
+//       {
+//         replacements: {
+//           coreDsId: coreDsId,
+//         },
+//       }
+//     );
+//
+//     const documents = coreDocumentsData[0] as {
+//       id: number;
+//       document_id: string;
+//       tags_array: string[];
+//     }[];
+//
+//     console.log(`Found ${documents.length} core documents`);
+//
+//     const documentsToDelete = documents.filter((d) => {
+//       return fileHash[d.document_id] === undefined;
+//     });
+//
+//     for (const d of documentsToDelete) {
+//       console.log(
+//         `Deleting document ${d.id} ${d.document_id}, tags #${d.tags_array.join(
+//           ", #"
+//         )}`
+//       );
+//       if (LIVE) {
+//         await deleteDocument(c, d.document_id);
+//       }
+//     }
+//
+//     console.log(
+//       `>>> Found ${documentsToDelete.length} documents to delete for workspace ${c.workspaceId}`
+//     );
+//   }
+// }
+//
+// async function deleteDocument(connector: ConnectorModel, fileId: string) {
+//   const dataSourceConfig = dataSourceConfigFromConnector(connector);
+//   await deleteDataSourceDocument(dataSourceConfig, fileId);
+// }
+//
+// main()
+//   .then(() => {
+//     console.log("Done");
+//     process.exit(0);
+//   })
+//   .catch((err) => {
+//     console.error(err);
+//     process.exit(1);
+//   });

--- a/connectors/migrations/20241211_fix_gdrive_parents.ts
+++ b/connectors/migrations/20241211_fix_gdrive_parents.ts
@@ -1,266 +1,266 @@
-import { makeScript } from "scripts/helpers";
-import { Op } from "sequelize";
-
-import { getInternalId } from "@connectors/connectors/google_drive/temporal/utils";
-import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
-import {
-  getDataSourceFolder,
-  getDataSourceTable,
-  updateDataSourceTableParents,
-  upsertDataSourceFolder,
-} from "@connectors/lib/data_sources";
-import {
-  GoogleDriveFilesModel,
-  GoogleDriveSheetModel,
-} from "@connectors/lib/models/google_drive";
-import type { Logger } from "@connectors/logger/logger";
-import logger from "@connectors/logger/logger";
-import { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
-import { concurrentExecutor, getGoogleSheetTableId } from "@connectors/types";
-
-const QUERY_BATCH_SIZE = 1024;
-const DOCUMENT_CONCURRENCY = 16;
-const TABLE_CONCURRENCY = 16;
-
-function getParents(
-  fileId: string | null,
-  parentsMap: Record<string, string | null>,
-  logger: Logger
-) {
-  const parents = [];
-  let current: string | null = fileId;
-  while (current) {
-    parents.push(current);
-    if (typeof parentsMap[current] === "undefined") {
-      logger.error({ fileId: current }, "Parent not found");
-      return null;
-    }
-    current = parentsMap[current] || null;
-  }
-  return parents;
-}
-
-async function migrate({
-  connector,
-  execute,
-}: {
-  connector: ConnectorModel;
-  execute: boolean;
-}) {
-  const childLogger = logger.child({ connectorId: connector.id });
-  childLogger.info(`Processing connector ${connector.id}...`);
-
-  const dataSourceConfig = dataSourceConfigFromConnector(connector);
-  const parentsMap: Record<string, string | null> = {};
-  let nextId: number | undefined = 0;
-  do {
-    const googleDriveFiles: GoogleDriveFilesModel[] =
-      await GoogleDriveFilesModel.findAll({
-        where: {
-          connectorId: connector.id,
-          id: {
-            [Op.gt]: nextId,
-          },
-        },
-      });
-
-    googleDriveFiles.forEach((file) => {
-      parentsMap[file.driveFileId] = file.parentId;
-    });
-
-    nextId = googleDriveFiles[googleDriveFiles.length - 1]?.id;
-  } while (nextId);
-
-  nextId = 0;
-  do {
-    const googleDriveFiles: GoogleDriveFilesModel[] =
-      await GoogleDriveFilesModel.findAll({
-        where: {
-          connectorId: connector.id,
-          id: {
-            [Op.gt]: nextId,
-          },
-          mimeType: {
-            [Op.or]: ["application/vnd.google-apps.folder", "text/csv"],
-          },
-        },
-        order: [["id", "ASC"]],
-        limit: QUERY_BATCH_SIZE,
-      });
-
-    await concurrentExecutor(
-      googleDriveFiles,
-      async (file) => {
-        const internalId = file.dustFileId;
-        const driveFileId = file.driveFileId;
-        const parents = getParents(
-          file.parentId,
-          parentsMap,
-          childLogger.child({ nodeId: driveFileId })
-        );
-        if (!parents) {
-          return;
-        }
-        parents.unshift(driveFileId);
-
-        if (file.mimeType === "application/vnd.google-apps.folder") {
-          const folder = await getDataSourceFolder({
-            dataSourceConfig,
-            folderId: internalId,
-          });
-          const newParents = parents.map((id) => getInternalId(id));
-          if (!folder || folder.parents.join("/") !== newParents.join("/")) {
-            childLogger.info(
-              { folderId: file.driveFileId, parents: newParents },
-              "Upsert folder"
-            );
-
-            if (execute) {
-              // upsert repository as folder
-              await upsertDataSourceFolder({
-                dataSourceConfig,
-                folderId: file.dustFileId,
-                parents: newParents,
-                parentId: file.parentId ? getInternalId(file.parentId) : null,
-                title: file.name,
-                mimeType: "application/vnd.dust.googledrive.folder",
-              });
-            }
-          }
-        } else if (file.mimeType === "text/csv") {
-          const tableId = internalId;
-          parents.unshift(...parents.map((id) => getInternalId(id)));
-          const table = await getDataSourceTable({ dataSourceConfig, tableId });
-          if (table) {
-            if (table.parents.join("/") !== parents.join("/")) {
-              childLogger.info(
-                {
-                  tableId,
-                  parents,
-                  previousParents: table.parents,
-                },
-                "Update parents for table"
-              );
-              if (execute) {
-                await updateDataSourceTableParents({
-                  dataSourceConfig,
-                  tableId,
-                  parents,
-                  parentId: parents[1] || null,
-                });
-              }
-            }
-          }
-        }
-      },
-      { concurrency: DOCUMENT_CONCURRENCY }
-    );
-
-    nextId = googleDriveFiles[googleDriveFiles.length - 1]?.id;
-  } while (nextId);
-
-  nextId = 0;
-  do {
-    const googleDriveSheets: GoogleDriveSheetModel[] =
-      await GoogleDriveSheetModel.findAll({
-        where: {
-          connectorId: connector.id,
-          id: {
-            [Op.gt]: nextId,
-          },
-        },
-        order: [["id", "ASC"]],
-        limit: QUERY_BATCH_SIZE,
-      });
-
-    await concurrentExecutor(
-      googleDriveSheets,
-      async (sheet) => {
-        const tableId = getGoogleSheetTableId(
-          sheet.driveFileId,
-          sheet.driveSheetId
-        );
-
-        const parents = getParents(
-          sheet.driveFileId,
-          parentsMap,
-          childLogger.child({ nodeId: tableId })
-        );
-        if (!parents) {
-          return;
-        }
-
-        parents.unshift(...parents.map((id) => getInternalId(id)));
-        parents.unshift(tableId);
-
-        const table = await getDataSourceTable({ dataSourceConfig, tableId });
-        if (table) {
-          if (table.parents.join("/") !== parents.join("/")) {
-            childLogger.info(
-              {
-                tableId,
-                parents,
-                previousParents: table.parents,
-              },
-              "Update parents for table"
-            );
-            if (execute) {
-              await updateDataSourceTableParents({
-                dataSourceConfig,
-                tableId,
-                parents,
-                parentId: parents[1] || null,
-              });
-            }
-          }
-        }
-      },
-      { concurrency: TABLE_CONCURRENCY }
-    );
-
-    nextId = googleDriveSheets[googleDriveSheets.length - 1]?.id;
-  } while (nextId);
-}
-
-makeScript(
-  {
-    nextConnectorId: {
-      type: "number",
-      required: false,
-      default: 0,
-    },
-    connectorId: {
-      type: "number",
-      required: false,
-      default: 0,
-    },
-  },
-  async ({ nextConnectorId, connectorId, execute }) => {
-    if (connectorId) {
-      const connector = await ConnectorModel.findByPk(connectorId);
-      if (connector) {
-        await migrate({
-          connector,
-          execute,
-        });
-      }
-    } else {
-      const connectors = await ConnectorModel.findAll({
-        where: {
-          type: "google_drive",
-          id: {
-            [Op.gt]: nextConnectorId,
-          },
-        },
-        order: [["id", "ASC"]],
-      });
-
-      for (const connector of connectors) {
-        await migrate({
-          connector,
-          execute,
-        });
-      }
-    }
-  }
-);
+// import { makeScript } from "scripts/helpers";
+// import { Op } from "sequelize";
+//
+// import { getInternalId } from "@connectors/connectors/google_drive/temporal/utils";
+// import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
+// import {
+//   getDataSourceFolder,
+//   getDataSourceTable,
+//   updateDataSourceTableParents,
+//   upsertDataSourceFolder,
+// } from "@connectors/lib/data_sources";
+// import {
+//   GoogleDriveFilesModel,
+//   GoogleDriveSheetModel,
+// } from "@connectors/lib/models/google_drive";
+// import type { Logger } from "@connectors/logger/logger";
+// import logger from "@connectors/logger/logger";
+// import { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
+// import { concurrentExecutor, getGoogleSheetTableId } from "@connectors/types";
+//
+// const QUERY_BATCH_SIZE = 1024;
+// const DOCUMENT_CONCURRENCY = 16;
+// const TABLE_CONCURRENCY = 16;
+//
+// function getParents(
+//   fileId: string | null,
+//   parentsMap: Record<string, string | null>,
+//   logger: Logger
+// ) {
+//   const parents = [];
+//   let current: string | null = fileId;
+//   while (current) {
+//     parents.push(current);
+//     if (typeof parentsMap[current] === "undefined") {
+//       logger.error({ fileId: current }, "Parent not found");
+//       return null;
+//     }
+//     current = parentsMap[current] || null;
+//   }
+//   return parents;
+// }
+//
+// async function migrate({
+//   connector,
+//   execute,
+// }: {
+//   connector: ConnectorModel;
+//   execute: boolean;
+// }) {
+//   const childLogger = logger.child({ connectorId: connector.id });
+//   childLogger.info(`Processing connector ${connector.id}...`);
+//
+//   const dataSourceConfig = dataSourceConfigFromConnector(connector);
+//   const parentsMap: Record<string, string | null> = {};
+//   let nextId: number | undefined = 0;
+//   do {
+//     const googleDriveFiles: GoogleDriveFilesModel[] =
+//       await GoogleDriveFilesModel.findAll({
+//         where: {
+//           connectorId: connector.id,
+//           id: {
+//             [Op.gt]: nextId,
+//           },
+//         },
+//       });
+//
+//     googleDriveFiles.forEach((file) => {
+//       parentsMap[file.driveFileId] = file.parentId;
+//     });
+//
+//     nextId = googleDriveFiles[googleDriveFiles.length - 1]?.id;
+//   } while (nextId);
+//
+//   nextId = 0;
+//   do {
+//     const googleDriveFiles: GoogleDriveFilesModel[] =
+//       await GoogleDriveFilesModel.findAll({
+//         where: {
+//           connectorId: connector.id,
+//           id: {
+//             [Op.gt]: nextId,
+//           },
+//           mimeType: {
+//             [Op.or]: ["application/vnd.google-apps.folder", "text/csv"],
+//           },
+//         },
+//         order: [["id", "ASC"]],
+//         limit: QUERY_BATCH_SIZE,
+//       });
+//
+//     await concurrentExecutor(
+//       googleDriveFiles,
+//       async (file) => {
+//         const internalId = file.dustFileId;
+//         const driveFileId = file.driveFileId;
+//         const parents = getParents(
+//           file.parentId,
+//           parentsMap,
+//           childLogger.child({ nodeId: driveFileId })
+//         );
+//         if (!parents) {
+//           return;
+//         }
+//         parents.unshift(driveFileId);
+//
+//         if (file.mimeType === "application/vnd.google-apps.folder") {
+//           const folder = await getDataSourceFolder({
+//             dataSourceConfig,
+//             folderId: internalId,
+//           });
+//           const newParents = parents.map((id) => getInternalId(id));
+//           if (!folder || folder.parents.join("/") !== newParents.join("/")) {
+//             childLogger.info(
+//               { folderId: file.driveFileId, parents: newParents },
+//               "Upsert folder"
+//             );
+//
+//             if (execute) {
+//               // upsert repository as folder
+//               await upsertDataSourceFolder({
+//                 dataSourceConfig,
+//                 folderId: file.dustFileId,
+//                 parents: newParents,
+//                 parentId: file.parentId ? getInternalId(file.parentId) : null,
+//                 title: file.name,
+//                 mimeType: "application/vnd.dust.googledrive.folder",
+//               });
+//             }
+//           }
+//         } else if (file.mimeType === "text/csv") {
+//           const tableId = internalId;
+//           parents.unshift(...parents.map((id) => getInternalId(id)));
+//           const table = await getDataSourceTable({ dataSourceConfig, tableId });
+//           if (table) {
+//             if (table.parents.join("/") !== parents.join("/")) {
+//               childLogger.info(
+//                 {
+//                   tableId,
+//                   parents,
+//                   previousParents: table.parents,
+//                 },
+//                 "Update parents for table"
+//               );
+//               if (execute) {
+//                 await updateDataSourceTableParents({
+//                   dataSourceConfig,
+//                   tableId,
+//                   parents,
+//                   parentId: parents[1] || null,
+//                 });
+//               }
+//             }
+//           }
+//         }
+//       },
+//       { concurrency: DOCUMENT_CONCURRENCY }
+//     );
+//
+//     nextId = googleDriveFiles[googleDriveFiles.length - 1]?.id;
+//   } while (nextId);
+//
+//   nextId = 0;
+//   do {
+//     const googleDriveSheets: GoogleDriveSheetModel[] =
+//       await GoogleDriveSheetModel.findAll({
+//         where: {
+//           connectorId: connector.id,
+//           id: {
+//             [Op.gt]: nextId,
+//           },
+//         },
+//         order: [["id", "ASC"]],
+//         limit: QUERY_BATCH_SIZE,
+//       });
+//
+//     await concurrentExecutor(
+//       googleDriveSheets,
+//       async (sheet) => {
+//         const tableId = getGoogleSheetTableId(
+//           sheet.driveFileId,
+//           sheet.driveSheetId
+//         );
+//
+//         const parents = getParents(
+//           sheet.driveFileId,
+//           parentsMap,
+//           childLogger.child({ nodeId: tableId })
+//         );
+//         if (!parents) {
+//           return;
+//         }
+//
+//         parents.unshift(...parents.map((id) => getInternalId(id)));
+//         parents.unshift(tableId);
+//
+//         const table = await getDataSourceTable({ dataSourceConfig, tableId });
+//         if (table) {
+//           if (table.parents.join("/") !== parents.join("/")) {
+//             childLogger.info(
+//               {
+//                 tableId,
+//                 parents,
+//                 previousParents: table.parents,
+//               },
+//               "Update parents for table"
+//             );
+//             if (execute) {
+//               await updateDataSourceTableParents({
+//                 dataSourceConfig,
+//                 tableId,
+//                 parents,
+//                 parentId: parents[1] || null,
+//               });
+//             }
+//           }
+//         }
+//       },
+//       { concurrency: TABLE_CONCURRENCY }
+//     );
+//
+//     nextId = googleDriveSheets[googleDriveSheets.length - 1]?.id;
+//   } while (nextId);
+// }
+//
+// makeScript(
+//   {
+//     nextConnectorId: {
+//       type: "number",
+//       required: false,
+//       default: 0,
+//     },
+//     connectorId: {
+//       type: "number",
+//       required: false,
+//       default: 0,
+//     },
+//   },
+//   async ({ nextConnectorId, connectorId, execute }) => {
+//     if (connectorId) {
+//       const connector = await ConnectorModel.findByPk(connectorId);
+//       if (connector) {
+//         await migrate({
+//           connector,
+//           execute,
+//         });
+//       }
+//     } else {
+//       const connectors = await ConnectorModel.findAll({
+//         where: {
+//           type: "google_drive",
+//           id: {
+//             [Op.gt]: nextConnectorId,
+//           },
+//         },
+//         order: [["id", "ASC"]],
+//       });
+//
+//       for (const connector of connectors) {
+//         await migrate({
+//           connector,
+//           execute,
+//         });
+//       }
+//     }
+//   }
+// );

--- a/connectors/migrations/20241212_restore_gdrive_parents.ts
+++ b/connectors/migrations/20241212_restore_gdrive_parents.ts
@@ -1,65 +1,65 @@
-import * as fs from "fs";
-import * as readline from "readline";
-import { makeScript } from "scripts/helpers";
-
-import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
-import { updateDataSourceDocumentParents } from "@connectors/lib/data_sources";
-import logger from "@connectors/logger/logger";
-import { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
-
-interface LogEntry {
-  msg: string;
-  documentId: string;
-  parents: string[];
-  previousParents: string[];
-}
-
-async function processLogFile(
-  connector: ConnectorModel,
-  filePath: string,
-  execute: boolean
-) {
-  const fileStream = fs.createReadStream(filePath);
-  const rl = readline.createInterface({
-    input: fileStream,
-    crlfDelay: Infinity,
-  });
-
-  const dataSourceConfig = dataSourceConfigFromConnector(connector);
-
-  for await (const line of rl) {
-    const entry = JSON.parse(line) as LogEntry;
-    const { msg, documentId, previousParents } = entry;
-    if (
-      msg === "Update parents for document" &&
-      documentId &&
-      previousParents
-    ) {
-      logger.info(
-        { documentId, previousParents },
-        "Restoring parent for document"
-      );
-      if (execute) {
-        await updateDataSourceDocumentParents({
-          dataSourceConfig,
-          documentId: documentId,
-          parents: previousParents,
-          parentId: previousParents[1] || null,
-        });
-      }
-    }
-  }
-}
-
-makeScript(
-  {
-    connectorId: { type: "number", required: true },
-    file: { type: "string", required: true },
-  },
-  async ({ connectorId, file, execute }) => {
-    const connector = await ConnectorModel.findByPk(connectorId);
-    if (connector) {
-      await processLogFile(connector, file, execute);
-    }
-  }
-);
+// import * as fs from "fs";
+// import * as readline from "readline";
+// import { makeScript } from "scripts/helpers";
+//
+// import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
+// import { updateDataSourceDocumentParents } from "@connectors/lib/data_sources";
+// import logger from "@connectors/logger/logger";
+// import { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
+//
+// interface LogEntry {
+//   msg: string;
+//   documentId: string;
+//   parents: string[];
+//   previousParents: string[];
+// }
+//
+// async function processLogFile(
+//   connector: ConnectorModel,
+//   filePath: string,
+//   execute: boolean
+// ) {
+//   const fileStream = fs.createReadStream(filePath);
+//   const rl = readline.createInterface({
+//     input: fileStream,
+//     crlfDelay: Infinity,
+//   });
+//
+//   const dataSourceConfig = dataSourceConfigFromConnector(connector);
+//
+//   for await (const line of rl) {
+//     const entry = JSON.parse(line) as LogEntry;
+//     const { msg, documentId, previousParents } = entry;
+//     if (
+//       msg === "Update parents for document" &&
+//       documentId &&
+//       previousParents
+//     ) {
+//       logger.info(
+//         { documentId, previousParents },
+//         "Restoring parent for document"
+//       );
+//       if (execute) {
+//         await updateDataSourceDocumentParents({
+//           dataSourceConfig,
+//           documentId: documentId,
+//           parents: previousParents,
+//           parentId: previousParents[1] || null,
+//         });
+//       }
+//     }
+//   }
+// }
+//
+// makeScript(
+//   {
+//     connectorId: { type: "number", required: true },
+//     file: { type: "string", required: true },
+//   },
+//   async ({ connectorId, file, execute }) => {
+//     const connector = await ConnectorModel.findByPk(connectorId);
+//     if (connector) {
+//       await processLogFile(connector, file, execute);
+//     }
+//   }
+// );

--- a/connectors/migrations/20241216_backfill_ms_folders.ts
+++ b/connectors/migrations/20241216_backfill_ms_folders.ts
@@ -1,166 +1,166 @@
-import { makeScript } from "scripts/helpers";
-import { Op } from "sequelize";
-
-import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
-import {
-  getDataSourceFolder,
-  upsertDataSourceFolder,
-} from "@connectors/lib/data_sources";
-import {} from "@connectors/lib/models/google_drive";
-import { MicrosoftNodeModel } from "@connectors/lib/models/microsoft";
-import type { Logger } from "@connectors/logger/logger";
-import logger from "@connectors/logger/logger";
-import { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
-import { concurrentExecutor } from "@connectors/types";
-
-const QUERY_BATCH_SIZE = 1024;
-
-function getParents(
-  fileId: string | null,
-  parentsMap: Record<string, string | null>,
-  logger: Logger
-) {
-  const parents = [];
-  let current: string | null = fileId;
-  while (current) {
-    parents.push(current);
-    if (typeof parentsMap[current] === "undefined") {
-      logger.error({ fileId: current }, "Parent not found");
-      return null;
-    }
-    current = parentsMap[current] || null;
-  }
-  return parents;
-}
-
-async function backfillFolder({
-  connector,
-  execute,
-}: {
-  connector: ConnectorModel;
-  execute: boolean;
-}) {
-  const childLogger = logger.child({ connectorId: connector.id });
-  childLogger.info(`Processing connector ${connector.id}...`);
-
-  const dataSourceConfig = dataSourceConfigFromConnector(connector);
-  const parentsMap: Record<string, string | null> = {};
-  let nextId: number | undefined = 0;
-  do {
-    const msFolders: MicrosoftNodeModel[] = await MicrosoftNodeModel.findAll({
-      where: {
-        connectorId: connector.id,
-        id: {
-          [Op.gt]: nextId,
-        },
-        nodeType: { [Op.or]: ["folder", "drive"] },
-      },
-    });
-
-    msFolders.forEach((file) => {
-      parentsMap[file.internalId] = file.parentInternalId;
-    });
-
-    nextId = msFolders[msFolders.length - 1]?.id;
-  } while (nextId);
-
-  nextId = 0;
-  do {
-    const msFolders: MicrosoftNodeModel[] = await MicrosoftNodeModel.findAll({
-      where: {
-        connectorId: connector.id,
-        id: {
-          [Op.gt]: nextId,
-        },
-        nodeType: { [Op.or]: ["folder", "drive"] },
-      },
-      order: [["id", "ASC"]],
-      limit: QUERY_BATCH_SIZE,
-    });
-
-    await concurrentExecutor(
-      msFolders,
-      async (file) => {
-        const internalId = file.internalId;
-        const parents = getParents(
-          file.parentInternalId,
-          parentsMap,
-          childLogger.child({ nodeId: internalId })
-        );
-        if (!parents) {
-          return;
-        }
-        parents.unshift(internalId);
-
-        const folder = await getDataSourceFolder({
-          dataSourceConfig,
-          folderId: internalId,
-        });
-        if (!folder || folder.parents.join("/") !== parents.join("/")) {
-          childLogger.info(
-            { folderId: file.internalId, parents },
-            "Upsert folder"
-          );
-
-          if (execute) {
-            // upsert repository as folder
-            await upsertDataSourceFolder({
-              dataSourceConfig,
-              folderId: file.internalId,
-              parents,
-              parentId: file.parentInternalId,
-              title: file.name || "",
-              mimeType: "application/vnd.dust.microsoft.folder",
-            });
-          }
-        }
-      },
-      { concurrency: 16 }
-    );
-
-    nextId = msFolders[msFolders.length - 1]?.id;
-  } while (nextId);
-}
-
-makeScript(
-  {
-    nextConnectorId: {
-      type: "number",
-      required: false,
-      default: 0,
-    },
-    connectorId: {
-      type: "number",
-      required: false,
-      default: 0,
-    },
-  },
-  async ({ nextConnectorId, connectorId, execute }) => {
-    if (connectorId) {
-      const connector = await ConnectorModel.findByPk(connectorId);
-      if (connector) {
-        await backfillFolder({
-          connector,
-          execute,
-        });
-      }
-    } else {
-      const connectors = await ConnectorModel.findAll({
-        where: {
-          type: "microsoft",
-          id: {
-            [Op.gt]: nextConnectorId,
-          },
-        },
-        order: [["id", "ASC"]],
-      });
-
-      for (const connector of connectors) {
-        await backfillFolder({
-          connector,
-          execute,
-        });
-      }
-    }
-  }
-);
+// import { makeScript } from "scripts/helpers";
+// import { Op } from "sequelize";
+//
+// import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
+// import {
+//   getDataSourceFolder,
+//   upsertDataSourceFolder,
+// } from "@connectors/lib/data_sources";
+// import {} from "@connectors/lib/models/google_drive";
+// import { MicrosoftNodeModel } from "@connectors/lib/models/microsoft";
+// import type { Logger } from "@connectors/logger/logger";
+// import logger from "@connectors/logger/logger";
+// import { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
+// import { concurrentExecutor } from "@connectors/types";
+//
+// const QUERY_BATCH_SIZE = 1024;
+//
+// function getParents(
+//   fileId: string | null,
+//   parentsMap: Record<string, string | null>,
+//   logger: Logger
+// ) {
+//   const parents = [];
+//   let current: string | null = fileId;
+//   while (current) {
+//     parents.push(current);
+//     if (typeof parentsMap[current] === "undefined") {
+//       logger.error({ fileId: current }, "Parent not found");
+//       return null;
+//     }
+//     current = parentsMap[current] || null;
+//   }
+//   return parents;
+// }
+//
+// async function backfillFolder({
+//   connector,
+//   execute,
+// }: {
+//   connector: ConnectorModel;
+//   execute: boolean;
+// }) {
+//   const childLogger = logger.child({ connectorId: connector.id });
+//   childLogger.info(`Processing connector ${connector.id}...`);
+//
+//   const dataSourceConfig = dataSourceConfigFromConnector(connector);
+//   const parentsMap: Record<string, string | null> = {};
+//   let nextId: number | undefined = 0;
+//   do {
+//     const msFolders: MicrosoftNodeModel[] = await MicrosoftNodeModel.findAll({
+//       where: {
+//         connectorId: connector.id,
+//         id: {
+//           [Op.gt]: nextId,
+//         },
+//         nodeType: { [Op.or]: ["folder", "drive"] },
+//       },
+//     });
+//
+//     msFolders.forEach((file) => {
+//       parentsMap[file.internalId] = file.parentInternalId;
+//     });
+//
+//     nextId = msFolders[msFolders.length - 1]?.id;
+//   } while (nextId);
+//
+//   nextId = 0;
+//   do {
+//     const msFolders: MicrosoftNodeModel[] = await MicrosoftNodeModel.findAll({
+//       where: {
+//         connectorId: connector.id,
+//         id: {
+//           [Op.gt]: nextId,
+//         },
+//         nodeType: { [Op.or]: ["folder", "drive"] },
+//       },
+//       order: [["id", "ASC"]],
+//       limit: QUERY_BATCH_SIZE,
+//     });
+//
+//     await concurrentExecutor(
+//       msFolders,
+//       async (file) => {
+//         const internalId = file.internalId;
+//         const parents = getParents(
+//           file.parentInternalId,
+//           parentsMap,
+//           childLogger.child({ nodeId: internalId })
+//         );
+//         if (!parents) {
+//           return;
+//         }
+//         parents.unshift(internalId);
+//
+//         const folder = await getDataSourceFolder({
+//           dataSourceConfig,
+//           folderId: internalId,
+//         });
+//         if (!folder || folder.parents.join("/") !== parents.join("/")) {
+//           childLogger.info(
+//             { folderId: file.internalId, parents },
+//             "Upsert folder"
+//           );
+//
+//           if (execute) {
+//             // upsert repository as folder
+//             await upsertDataSourceFolder({
+//               dataSourceConfig,
+//               folderId: file.internalId,
+//               parents,
+//               parentId: file.parentInternalId,
+//               title: file.name || "",
+//               mimeType: "application/vnd.dust.microsoft.folder",
+//             });
+//           }
+//         }
+//       },
+//       { concurrency: 16 }
+//     );
+//
+//     nextId = msFolders[msFolders.length - 1]?.id;
+//   } while (nextId);
+// }
+//
+// makeScript(
+//   {
+//     nextConnectorId: {
+//       type: "number",
+//       required: false,
+//       default: 0,
+//     },
+//     connectorId: {
+//       type: "number",
+//       required: false,
+//       default: 0,
+//     },
+//   },
+//   async ({ nextConnectorId, connectorId, execute }) => {
+//     if (connectorId) {
+//       const connector = await ConnectorModel.findByPk(connectorId);
+//       if (connector) {
+//         await backfillFolder({
+//           connector,
+//           execute,
+//         });
+//       }
+//     } else {
+//       const connectors = await ConnectorModel.findAll({
+//         where: {
+//           type: "microsoft",
+//           id: {
+//             [Op.gt]: nextConnectorId,
+//           },
+//         },
+//         order: [["id", "ASC"]],
+//       });
+//
+//       for (const connector of connectors) {
+//         await backfillFolder({
+//           connector,
+//           execute,
+//         });
+//       }
+//     }
+//   }
+// );

--- a/connectors/src/connectors/gong/lib/upserts.ts
+++ b/connectors/src/connectors/gong/lib/upserts.ts
@@ -6,6 +6,7 @@ import {
   makeGongTranscriptFolderInternalId,
   makeGongTranscriptInternalId,
 } from "@connectors/connectors/gong/lib/internal_ids";
+import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import {
   renderDocumentTitleAndContent,
   renderMarkdownSection,
@@ -14,7 +15,6 @@ import {
 import logger from "@connectors/logger/logger";
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
 import { GongTranscriptResource } from "@connectors/resources/gong_resources";
-import type { DataSourceConfig } from "@connectors/types";
 import { INTERNAL_MIME_TYPES } from "@connectors/types";
 
 function formatDateNicely(date: Date) {
@@ -33,7 +33,6 @@ export async function syncGongTranscript({
   participantEmails,
   speakerToEmailMap,
   connector,
-  dataSourceConfig,
   loggerArgs,
   forceResync,
 }: {
@@ -42,10 +41,11 @@ export async function syncGongTranscript({
   participantEmails: string[];
   speakerToEmailMap: Record<string, string>;
   connector: ConnectorResource;
-  dataSourceConfig: DataSourceConfig;
   loggerArgs: Record<string, string | number | null>;
   forceResync: boolean;
 }) {
+  const dataSourceConfig = dataSourceConfigFromConnector(connector);
+
   const { callId } = transcript;
   const createdAtDate = new Date(transcriptMetadata.metaData.started);
   const title = `${formatDateNicely(createdAtDate)} - ${transcriptMetadata.metaData.title || "Untitled transcript"}`;

--- a/connectors/src/connectors/gong/temporal/activities.ts
+++ b/connectors/src/connectors/gong/temporal/activities.ts
@@ -158,7 +158,7 @@ export async function gongSyncTranscriptsActivity({
   const processedRecords = transcripts.length;
 
   if (totalRecords > 0) {
-    const progressMessage = `${processedRecords + currentRecordCount + 1}/${totalRecords} transcripts`;
+    const progressMessage = `${processedRecords + currentRecordCount}/${totalRecords} transcripts`;
     await reportInitialSyncProgress(connectorId, progressMessage);
   }
 

--- a/connectors/src/connectors/gong/temporal/activities.ts
+++ b/connectors/src/connectors/gong/temporal/activities.ts
@@ -110,13 +110,12 @@ export async function gongSyncTranscriptsActivity({
 }) {
   const connector = await fetchGongConnector({ connectorId });
   const configuration = await fetchGongConfiguration(connector);
-  const dataSourceConfig = dataSourceConfigFromConnector(connector);
   const loggerArgs = {
     connectorId: connector.id,
-    dataSourceId: dataSourceConfig.dataSourceId,
+    dataSourceId: connector.dataSourceId,
     provider: "gong",
     startTimestamp: configuration.lastSyncTimestamp,
-    workspaceId: dataSourceConfig.workspaceId,
+    workspaceId: connector.workspaceId,
   };
 
   const gongClient = await getGongClient(connector);
@@ -243,7 +242,6 @@ export async function gongSyncTranscriptsActivity({
       await syncGongTranscript({
         transcript,
         transcriptMetadata,
-        dataSourceConfig,
         speakerToEmailMap,
         loggerArgs,
         participantEmails,

--- a/connectors/src/connectors/google_drive/lib.ts
+++ b/connectors/src/connectors/google_drive/lib.ts
@@ -31,9 +31,7 @@ import {
 } from "@connectors/lib/models/google_drive";
 import { getLoggerArgs } from "@connectors/logger/logger";
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
-import type { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
-import type { ContentNodesViewType } from "@connectors/types";
-import type { ModelId } from "@connectors/types";
+import type { ContentNodesViewType, ModelId } from "@connectors/types";
 import {
   cacheWithRedis,
   concurrentExecutor,
@@ -184,7 +182,7 @@ export async function internalDeleteFile(
 }
 
 export async function updateParentsField(
-  connector: ConnectorResource | ConnectorModel,
+  connector: ConnectorResource,
   file: GoogleDriveFilesModel,
   parentIds: string[],
   logger: Logger

--- a/connectors/src/connectors/slack/lib/cli.ts
+++ b/connectors/src/connectors/slack/lib/cli.ts
@@ -490,9 +490,10 @@ export const slack = async ({
       if (!args.channelId) {
         throw new Error("Missing --channelId argument");
       }
-      const connector = await ConnectorModel.findOne({
-        where: { workspaceId: `${args.wId}`, type: "slack" },
-      });
+      const connector = await ConnectorResource.findByWorkspaceIdAndType(
+        args.wId,
+        "slack"
+      );
       if (!connector) {
         throw new Error(`Could not find connector for workspace ${args.wId}`);
       }

--- a/connectors/src/lib/api/data_source_config.ts
+++ b/connectors/src/lib/api/data_source_config.ts
@@ -1,10 +1,8 @@
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
-import type { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
 import type { DataSourceConfig, DataSourceInfo } from "@connectors/types";
 
 export function dataSourceConfigFromConnector(
-  // TODO(2024-02-14 flav) Remove ConnectorModel once fully bundled in `ConnectorResource`.
-  connector: ConnectorResource | ConnectorModel
+  connector: ConnectorResource
 ): DataSourceConfig {
   return {
     workspaceAPIKey: connector.workspaceAPIKey,
@@ -14,8 +12,7 @@ export function dataSourceConfigFromConnector(
 }
 
 export function dataSourceInfoFromConnector(
-  // TODO(2024-02-14 flav) Remove ConnectorModel once fully bundled in `ConnectorResource`.
-  connector: ConnectorResource | ConnectorModel
+  connector: ConnectorResource
 ): DataSourceInfo {
   return {
     dataSourceId: connector.dataSourceId,

--- a/connectors/src/logger/logger.ts
+++ b/connectors/src/logger/logger.ts
@@ -5,7 +5,6 @@ import pino from "pino";
 
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
-import type { ConnectorModel } from "@connectors/resources/storage/models/connector_model";
 
 function sanitizeError(error: Error) {
   // Override default pino error serializer to handle Axios errors.
@@ -78,10 +77,10 @@ const logger = pino(pinoOptions);
 export default logger;
 export type { Logger } from "pino";
 
-export const getLoggerArgs = (
-  connector: ConnectorResource | ConnectorModel,
+export function getLoggerArgs(
+  connector: ConnectorResource,
   loggerArgs?: Record<string, string | number | null>
-) => {
+) {
   const dataSourceConfig = dataSourceConfigFromConnector(connector);
   const effectiveArgs: Record<string, string | number | null> = {
     workspaceId: dataSourceConfig.workspaceId,
@@ -104,11 +103,11 @@ export const getLoggerArgs = (
     // Cannot read context, ignore
   }
   return effectiveArgs;
-};
+}
 
-export const getActivityLogger = (
-  connector: ConnectorResource | ConnectorModel,
+export function getActivityLogger(
+  connector: ConnectorResource,
   loggerArgs?: Record<string, string | number | null>
-) => {
+) {
   return logger.child(getLoggerArgs(connector, loggerArgs));
-};
+}


### PR DESCRIPTION
## Description

- We currently have to pass a workspace ID to the google drive CLI even if we only use the connector ID.
- This PR allows passing only the connector ID.
- Also updates the typing of `dataSourceConfigFromConnector` (this is the change that makes the PR blow up in size).
- Unrelated but also bundles a 1-liner fix on the progress displayed in [poke](https://dust.tt/poke/LQvKvnXeCt/data_sources/dts_se8GjY4YCX7Y8) and in the admin page for Gong connectors (off by one).

## Tests

- Checked locally.

## Risk

- Low.

## Deploy Plan

- Deploy connectors.
