### PR TITLE
fix: clear draft when sending not when success

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -256,6 +256,10 @@ export const InputBar = React.memo(function InputBar({
       setLoading(true);
       setIsLocalSubmitting(true);
 
+      // Clear draft immediately before async operation to prevent it from persisting
+      // if the component unmounts during the await (e.g., due to navigation).
+      clearDraft();
+
       const r = await onSubmit(
         markdown,
         mentions,
@@ -281,7 +285,6 @@ export const InputBar = React.memo(function InputBar({
       setIsLocalSubmitting(false);
       if (r.isOk()) {
         resetEditorText();
-        clearDraft();
         fileUploaderService.resetUpload();
       }
     } else {


### PR DESCRIPTION
## Description

Fix clearing the draft when we send the message, not when the send is successfull. 

This fixes this bug => https://www.loom.com/share/65db62feaa574c21b7a322ffa830c5bb

## Tests

Locally
## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
