### PR TITLE
[front] Speed up queries in `getConversationDataSourceViews` 2 

### DIFF
--- a/front/lib/api/assistant/jit/utils.ts
+++ b/front/lib/api/assistant/jit/utils.ts
@@ -14,7 +14,7 @@ import { DataSourceViewResource } from "@app/lib/resources/data_source_view_reso
 import { FileResource } from "@app/lib/resources/file_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
-import type { ConversationWithoutContentType } from "@app/types";
+import type { ConversationWithoutContentType, ModelId } from "@app/types";
 import { CoreAPI } from "@app/types";
 
 export async function getTablesFromMultiSheetSpreadsheet(
@@ -100,85 +100,75 @@ export async function getConversationDataSourceViews(
   conversation: ConversationWithoutContentType,
   attachments: ConversationAttachmentType[]
 ): Promise<Map<string, DataSourceViewResource>> {
-  const conversationIdToDataSourceViewMap = new Map<
+  const fileIdToDataSourceViewMap = new Map<string, DataSourceViewResource>();
+
+  // Filter to get only file attachments.
+  const fileAttachments = attachments.filter(isFileAttachmentType);
+  if (fileAttachments.length === 0) {
+    return fileIdToDataSourceViewMap;
+  }
+
+  const fileIds = fileAttachments.map((a) => a.fileId);
+  const fileResources = await FileResource.fetchByIds(auth, fileIds);
+  const fileResourceById = new Map(fileResources.map((f) => [f.sId, f]));
+
+  const conversationIds = new Set<string>();
+  // Add the current conversation.
+  conversationIds.add(conversation.sId);
+  // Add conversations from files.
+  for (const file of fileResources) {
+    if (file.useCaseMetadata?.conversationId) {
+      conversationIds.add(file.useCaseMetadata.conversationId);
+    }
+  }
+
+  const conversations = await ConversationResource.fetchByIds(auth, [
+    ...conversationIds,
+  ]);
+
+  const dataSourceViews =
+    await DataSourceViewResource.fetchByConversationModelIds(
+      auth,
+      conversations.map((c) => c.id)
+    );
+
+  // Going from the data source view to conversation Model ID.
+  const conversationModelIdToDataSourceView = new Map<
+    ModelId,
+    DataSourceViewResource
+  >();
+  for (const dsv of dataSourceViews) {
+    const conversationId = dsv.dataSource.conversationId;
+    if (conversationId) {
+      conversationModelIdToDataSourceView.set(conversationId, dsv);
+    }
+  }
+
+  // Going from the conversation to the data source view via the conversation Model ID.
+  const conversationIdToDataSourceView = new Map<
     string,
     DataSourceViewResource
   >();
-
-  // Get the datasource view for the conversation.
-  const conversationDataSourceView =
-    await DataSourceViewResource.fetchByConversation(auth, conversation);
-  if (conversationDataSourceView) {
-    conversationIdToDataSourceViewMap.set(
-      conversation.sId,
-      conversationDataSourceView
-    );
+  for (const { sId, id: modelId } of conversations) {
+    const dsv = conversationModelIdToDataSourceView.get(modelId);
+    if (dsv) {
+      conversationIdToDataSourceView.set(sId, dsv);
+    }
   }
-  const files = await FileResource.fetchByIds(
-    auth,
-    attachments.filter(isFileAttachmentType).map((f) => f.fileId)
-  );
-  const filesById = new Map(files.map((f) => [f.sId, f]));
 
-  const fileIdToDataSourceViewMap = new Map<string, DataSourceViewResource>();
+  // Build the result map from file ID to DataSourceView.
+  // Only add files that have a conversationId in their metadata.
+  for (const attachment of fileAttachments) {
+    const fileResource = fileResourceById.get(attachment.fileId);
+    if (!fileResource?.useCaseMetadata?.conversationId) {
+      continue;
+    }
 
-  // Check file attachments for their conversation metadata
-  for (const attachment of attachments) {
-    if (isFileAttachmentType(attachment)) {
-      try {
-        // Get the file resource to access its metadata
-        const file = filesById.get(attachment.fileId);
-        if (file && file.useCaseMetadata?.conversationId) {
-          const fileConversationId = file.useCaseMetadata.conversationId;
-
-          // First look in already fetched conversations
-          const cachedChildDataSourceView =
-            conversationIdToDataSourceViewMap.get(fileConversationId);
-          if (cachedChildDataSourceView) {
-            fileIdToDataSourceViewMap.set(
-              attachment.fileId,
-              cachedChildDataSourceView
-            );
-            continue;
-          }
-
-          // Fetch the datasource view for this conversation
-          const childConversation =
-            await ConversationResource.fetchConversationWithoutContent(
-              auth,
-              fileConversationId
-            );
-
-          if (childConversation.isErr()) {
-            logger.warn(
-              `Could not find child conversation with sId: ${fileConversationId}`
-            );
-            continue;
-          }
-
-          const childDataSourceView =
-            await DataSourceViewResource.fetchByConversation(
-              auth,
-              childConversation.value
-            );
-
-          if (childDataSourceView) {
-            conversationIdToDataSourceViewMap.set(
-              childConversation.value.sId,
-              childDataSourceView
-            );
-            // Map this file to its datasource view
-            fileIdToDataSourceViewMap.set(
-              attachment.fileId,
-              childDataSourceView
-            );
-          }
-        }
-      } catch (error) {
-        logger.warn(
-          `Failed to get file metadata for file ${attachment.fileId}: ${error instanceof Error ? error.message : String(error)}`
-        );
-      }
+    const dsv = conversationIdToDataSourceView.get(
+      fileResource.useCaseMetadata.conversationId
+    );
+    if (dsv) {
+      fileIdToDataSourceViewMap.set(attachment.fileId, dsv);
     }
   }
 

--- a/front/lib/models/agent/agent_step_content.ts
+++ b/front/lib/models/agent/agent_step_content.ts
@@ -80,6 +80,10 @@ AgentStepContentModel.init(
       },
       {
         concurrently: true,
+        fields: ["agentMessageId"],
+      },
+      {
+        concurrently: true,
         fields: ["workspaceId", "agentMessageId"],
       },
       {

--- a/front/lib/resources/data_source_resource.ts
+++ b/front/lib/resources/data_source_resource.ts
@@ -284,6 +284,23 @@ export class DataSourceResource extends ResourceWithSpace<DataSourceModel> {
     return dataSource ?? null;
   }
 
+  static async fetchByConversationModelIds(
+    auth: Authenticator,
+    conversationModelIds: ModelId[],
+    options?: FetchDataSourceOptions
+  ): Promise<DataSourceResource[]> {
+    if (conversationModelIds.length === 0) {
+      return [];
+    }
+
+    return this.baseFetch(auth, options, {
+      where: {
+        conversationId: { [Op.in]: conversationModelIds },
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+    });
+  }
+
   // TODO(DATASOURCE_SID): remove
   static async fetchByNames(
     auth: Authenticator,

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -38,7 +38,6 @@ import type { ResourceFindOptions } from "@app/lib/resources/types";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import logger from "@app/logger/logger";
 import type {
-  ConversationWithoutContentType,
   DataSourceViewCategory,
   DataSourceViewType,
   ModelId,
@@ -483,34 +482,6 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
     );
 
     return dataSourceViews ?? [];
-  }
-
-  static async fetchByConversation(
-    auth: Authenticator,
-    conversation: ConversationWithoutContentType
-  ): Promise<DataSourceViewResource | null> {
-    // Fetch the data source view associated with the datasource that is associated with the conversation.
-    const dataSource = await DataSourceResource.fetchByConversation(
-      auth,
-      conversation
-    );
-    if (!dataSource) {
-      return null;
-    }
-
-    const dataSourceViews = await this.baseFetch(
-      auth,
-      {},
-      {
-        where: {
-          workspaceId: auth.getNonNullableWorkspace().id,
-          kind: "default",
-          dataSourceId: dataSource.id,
-        },
-      }
-    );
-
-    return dataSourceViews[0] ?? null;
   }
 
   static async fetchByConversationModelIds(

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -513,6 +513,35 @@ export class DataSourceViewResource extends ResourceWithSpace<DataSourceViewMode
     return dataSourceViews[0] ?? null;
   }
 
+  static async fetchByConversationModelIds(
+    auth: Authenticator,
+    conversationModelIds: ModelId[]
+  ): Promise<DataSourceViewResource[]> {
+    if (conversationModelIds.length === 0) {
+      return [];
+    }
+
+    const dataSources = await DataSourceResource.fetchByConversationModelIds(
+      auth,
+      conversationModelIds
+    );
+    if (dataSources.length === 0) {
+      return [];
+    }
+
+    return this.baseFetch(
+      auth,
+      {},
+      {
+        where: {
+          workspaceId: auth.getNonNullableWorkspace().id,
+          kind: "default",
+          dataSourceId: { [Op.in]: dataSources.map((ds) => ds.id) },
+        },
+      }
+    );
+  }
+
   static async search(
     auth: Authenticator,
     searchParams: {

--- a/front/migrations/db/migration_478.sql
+++ b/front/migrations/db/migration_478.sql
@@ -3,7 +3,6 @@ CREATE UNIQUE INDEX CONCURRENTLY "agent_step_contents_workspace_agent_message_st
 CREATE INDEX CONCURRENTLY "agent_step_contents_workspace_id_agent_message_id" ON "agent_step_contents" ("workspaceId", "agentMessageId");
 CREATE INDEX CONCURRENTLY "agent_step_contents_workspace_id_step_content_id_function_call" ON "agent_step_contents" ("workspaceId", "agentMessageId") WHERE "type"='functionCall';
 
-DROP INDEX CONCURRENTLY "agent_step_contents_agent_message_id_idx";
 DROP INDEX CONCURRENTLY "agent_step_contents_type_idx";
 DROP INDEX CONCURRENTLY "agent_step_contents_workspace_id_idx";
 DROP INDEX CONCURRENTLY "agent_step_contents_agent_message_id_step_index_versioned";


### PR DESCRIPTION
## Description

- Follow up on https://github.com/dust-tt/dust/pull/20241.
- This PR batches the fetches on data source views and conversations for conversations files (currently individual fetches for each file attachment + unused fetches through `ConversationResource.getActionRequiredAndUnreadForUser`).

## Tests

- Tested locally and on front-edge.

## Risk

- Medium.

## Deploy Plan

- Deploy front.
