### PR TITLE
Protect `blocking: true` API calls during graceful shutdown

### DIFF
--- a/front/lib/api/assistant/streaming/blocking.ts
+++ b/front/lib/api/assistant/streaming/blocking.ts
@@ -188,7 +188,8 @@ export async function postUserMessageAndWaitForCompletion(
       }
 
       // Wait for all agent messages to complete.
-      const completedAgentMessages = await waitForAgentCompletion(agentMessages);
+      const completedAgentMessages =
+        await waitForAgentCompletion(agentMessages);
 
       return new Ok({
         userMessage,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Wraps `postUserMessageAndWaitForCompletion` with a wake lock to prevent server shutdown from interrupting
long-running blocking API requests. This go remove when we cleaned up the agent loop code.

### Problem

When users make API calls with `blocking=true` to `/v1/assistant/conversations` or `/v1/assistant/conversations/{cId}/messages`, the server waits up to 3 minutes for agent responses. If the
server starts shutting down during this wait, these requests could be interrupted, leaving clients with incomplete responses.

### Solution

Added wake lock protection. Now when `postUserMessageAndWaitForCompletion` is called:
1. A wake lock is acquired with context (workspaceId, conversationId, operation)
2. During graceful shutdown, the prestop hook waits up to 120s for these locks to clear
3. Active wake locks appear in prestop logs for visibility

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
