### PR TITLE
Add permissionsToWrite parameter to GroupResource

### DIFF
--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -537,7 +537,7 @@ export async function createAgentConfiguration(
             { transaction: t }
           );
           await auth.refresh({ transaction: t });
-          await group.setMembers(auth, { users: editors }, { transaction: t });
+          await group.setMembers(auth, { users: editors, transaction: t });
         } else {
           const group = await GroupResource.fetchByAgentConfiguration({
             auth,
@@ -563,13 +563,10 @@ export async function createAgentConfiguration(
             );
             throw result.error;
           }
-          const setMembersRes = await group.setMembers(
-            auth,
-            { users: editors },
-            {
-              transaction: t,
-            }
-          );
+          const setMembersRes = await group.setMembers(auth, {
+            users: editors,
+            transaction: t,
+          });
           if (setMembersRes.isErr()) {
             logger.error(
               {
@@ -1237,26 +1234,20 @@ export async function updateAgentPermissions(
   try {
     const transactionResult = await withTransaction(async (t) => {
       if (usersToAdd.length > 0) {
-        const addRes = await editorGroupRes.value.addMembers(
-          auth,
-          { users: usersToAdd },
-          {
-            transaction: t,
-          }
-        );
+        const addRes = await editorGroupRes.value.addMembers(auth, {
+          users: usersToAdd,
+          transaction: t,
+        });
         if (addRes.isErr()) {
           return addRes;
         }
       }
 
       if (usersToRemove.length > 0) {
-        const removeRes = await editorGroupRes.value.removeMembers(
-          auth,
-          { users: usersToRemove },
-          {
-            transaction: t,
-          }
-        );
+        const removeRes = await editorGroupRes.value.removeMembers(auth, {
+          users: usersToRemove,
+          transaction: t,
+        });
         if (removeRes.isErr()) {
           return removeRes;
         }

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -537,7 +537,7 @@ export async function createAgentConfiguration(
             { transaction: t }
           );
           await auth.refresh({ transaction: t });
-          await group.setMembers(auth, editors, { transaction: t });
+          await group.setMembers(auth, { users: editors }, { transaction: t });
         } else {
           const group = await GroupResource.fetchByAgentConfiguration({
             auth,
@@ -563,9 +563,13 @@ export async function createAgentConfiguration(
             );
             throw result.error;
           }
-          const setMembersRes = await group.setMembers(auth, editors, {
-            transaction: t,
-          });
+          const setMembersRes = await group.setMembers(
+            auth,
+            { users: editors },
+            {
+              transaction: t,
+            }
+          );
           if (setMembersRes.isErr()) {
             logger.error(
               {
@@ -1233,9 +1237,13 @@ export async function updateAgentPermissions(
   try {
     const transactionResult = await withTransaction(async (t) => {
       if (usersToAdd.length > 0) {
-        const addRes = await editorGroupRes.value.addMembers(auth, usersToAdd, {
-          transaction: t,
-        });
+        const addRes = await editorGroupRes.value.addMembers(
+          auth,
+          { users: usersToAdd },
+          {
+            transaction: t,
+          }
+        );
         if (addRes.isErr()) {
           return addRes;
         }
@@ -1244,7 +1252,7 @@ export async function updateAgentPermissions(
       if (usersToRemove.length > 0) {
         const removeRes = await editorGroupRes.value.removeMembers(
           auth,
-          usersToRemove,
+          { users: usersToRemove },
           {
             transaction: t,
           }

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -388,13 +388,10 @@ export async function createSpaceAndGroup(
       const users = (await UserResource.fetchByIds(params.memberIds)).map(
         (user) => user.toJSON()
       );
-      const groupsResult = await group.addMembers(
-        auth,
-        { users },
-        {
-          transaction: t,
-        }
-      );
+      const groupsResult = await group.addMembers(auth, {
+        users,
+        transaction: t,
+      });
       if (groupsResult.isErr()) {
         logger.error(
           {

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -388,9 +388,13 @@ export async function createSpaceAndGroup(
       const users = (await UserResource.fetchByIds(params.memberIds)).map(
         (user) => user.toJSON()
       );
-      const groupsResult = await group.addMembers(auth, users, {
-        transaction: t,
-      });
+      const groupsResult = await group.addMembers(
+        auth,
+        { users },
+        {
+          transaction: t,
+        }
+      );
       if (groupsResult.isErr()) {
         logger.error(
           {

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -1054,7 +1054,13 @@ export class GroupResource extends BaseResource<GroupModel> {
       >
     >
   > {
-    if (!this.canWrite(auth, requestedPermissions)) {
+    if (
+      !auth.canWrite(
+        requestedPermissions
+          ? [requestedPermissions]
+          : this.requestedPermissions()
+      )
+    ) {
       return new Err(
         new DustError(
           "unauthorized",
@@ -1210,7 +1216,13 @@ export class GroupResource extends BaseResource<GroupModel> {
       >
     >
   > {
-    if (!this.canWrite(auth, requestedPermissions)) {
+    if (
+      !auth.canWrite(
+        requestedPermissions
+          ? [requestedPermissions]
+          : this.requestedPermissions()
+      )
+    ) {
       return new Err(
         new DustError(
           "unauthorized",
@@ -1350,7 +1362,13 @@ export class GroupResource extends BaseResource<GroupModel> {
       >
     >
   > {
-    if (!this.canWrite(auth, requestedPermissions)) {
+    if (
+      !auth.canWrite(
+        requestedPermissions
+          ? [requestedPermissions]
+          : this.requestedPermissions()
+      )
+    ) {
       return new Err(
         new DustError(
           "unauthorized",
@@ -1548,15 +1566,8 @@ export class GroupResource extends BaseResource<GroupModel> {
     return auth.canRead(this.requestedPermissions());
   }
 
-  canWrite(
-    auth: Authenticator,
-    requestedPermissions?: CombinedResourcePermissions
-  ): boolean {
-    return auth.canWrite(
-      requestedPermissions
-        ? [requestedPermissions]
-        : this.requestedPermissions()
-    );
+  canWrite(auth: Authenticator): boolean {
+    return auth.canWrite(this.requestedPermissions());
   }
 
   isSystem(): boolean {

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -1175,8 +1175,12 @@ export class GroupResource extends BaseResource<GroupModel> {
     {
       user,
       requestedPermissions,
-    }: { user: UserType; requestedPermissions?: CombinedResourcePermissions },
-    { transaction }: { transaction?: Transaction } = {}
+      transaction,
+    }: {
+      user: UserType;
+      requestedPermissions?: CombinedResourcePermissions;
+      transaction?: Transaction;
+    }
   ): Promise<
     Result<
       undefined,

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -1037,11 +1037,12 @@ export class GroupResource extends BaseResource<GroupModel> {
     {
       users,
       requestedPermissions,
+      transaction,
     }: {
       users: UserType[];
       requestedPermissions?: CombinedResourcePermissions;
-    },
-    { transaction }: { transaction?: Transaction } = {}
+      transaction?: Transaction;
+    }
   ): Promise<
     Result<
       undefined,
@@ -1188,11 +1189,11 @@ export class GroupResource extends BaseResource<GroupModel> {
       >
     >
   > {
-    return this.addMembers(
-      auth,
-      { users: [user], requestedPermissions },
-      { transaction }
-    );
+    return this.addMembers(auth, {
+      users: [user],
+      requestedPermissions,
+      transaction,
+    });
   }
 
   async removeMembers(
@@ -1200,11 +1201,12 @@ export class GroupResource extends BaseResource<GroupModel> {
     {
       users,
       requestedPermissions,
+      transaction,
     }: {
       users: UserType[];
       requestedPermissions?: CombinedResourcePermissions;
-    },
-    { transaction }: { transaction?: Transaction } = {}
+      transaction?: Transaction;
+    }
   ): Promise<
     Result<
       undefined,
@@ -1319,8 +1321,12 @@ export class GroupResource extends BaseResource<GroupModel> {
     {
       user,
       requestedPermissions,
-    }: { user: UserType; requestedPermissions?: CombinedResourcePermissions },
-    { transaction }: { transaction?: Transaction } = {}
+      transaction,
+    }: {
+      user: UserType;
+      requestedPermissions?: CombinedResourcePermissions;
+      transaction?: Transaction;
+    }
   ): Promise<
     Result<
       undefined,
@@ -1332,11 +1338,11 @@ export class GroupResource extends BaseResource<GroupModel> {
       >
     >
   > {
-    return this.removeMembers(
-      auth,
-      { users: [user], requestedPermissions },
-      { transaction }
-    );
+    return this.removeMembers(auth, {
+      users: [user],
+      requestedPermissions,
+      transaction,
+    });
   }
 
   async setMembers(
@@ -1344,11 +1350,12 @@ export class GroupResource extends BaseResource<GroupModel> {
     {
       users,
       requestedPermissions,
+      transaction,
     }: {
       users: UserType[];
       requestedPermissions?: CombinedResourcePermissions;
-    },
-    { transaction }: { transaction?: Transaction } = {}
+      transaction?: Transaction;
+    }
   ): Promise<
     Result<
       undefined,
@@ -1386,13 +1393,11 @@ export class GroupResource extends BaseResource<GroupModel> {
       (user) => !currentMemberIds.includes(user.sId)
     );
     if (usersToAdd.length > 0) {
-      const addResult = await this.addMembers(
-        auth,
-        { users: usersToAdd, requestedPermissions },
-        {
-          transaction,
-        }
-      );
+      const addResult = await this.addMembers(auth, {
+        users: usersToAdd,
+        requestedPermissions,
+        transaction,
+      });
       if (addResult.isErr()) {
         return addResult;
       }
@@ -1403,13 +1408,11 @@ export class GroupResource extends BaseResource<GroupModel> {
       .filter((currentMember) => !userIds.includes(currentMember.sId))
       .map((m) => m.toJSON());
     if (usersToRemove.length > 0) {
-      const removeResult = await this.removeMembers(
-        auth,
-        { users: usersToRemove, requestedPermissions },
-        {
-          transaction,
-        }
-      );
+      const removeResult = await this.removeMembers(auth, {
+        users: usersToRemove,
+        requestedPermissions,
+        transaction,
+      });
       if (removeResult.isErr()) {
         return removeResult;
       }

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -1036,8 +1036,11 @@ export class GroupResource extends BaseResource<GroupModel> {
     auth: Authenticator,
     {
       users,
-      permissionsToWrite,
-    }: { users: UserType[]; permissionsToWrite?: CombinedResourcePermissions },
+      requestedPermissions,
+    }: {
+      users: UserType[];
+      requestedPermissions?: CombinedResourcePermissions;
+    },
     { transaction }: { transaction?: Transaction } = {}
   ): Promise<
     Result<
@@ -1051,7 +1054,7 @@ export class GroupResource extends BaseResource<GroupModel> {
       >
     >
   > {
-    if (!this.canWrite(auth, permissionsToWrite)) {
+    if (!this.canWrite(auth, requestedPermissions)) {
       return new Err(
         new DustError(
           "unauthorized",
@@ -1164,8 +1167,8 @@ export class GroupResource extends BaseResource<GroupModel> {
     auth: Authenticator,
     {
       user,
-      permissionsToWrite,
-    }: { user: UserType; permissionsToWrite?: CombinedResourcePermissions },
+      requestedPermissions,
+    }: { user: UserType; requestedPermissions?: CombinedResourcePermissions },
     { transaction }: { transaction?: Transaction } = {}
   ): Promise<
     Result<
@@ -1181,7 +1184,7 @@ export class GroupResource extends BaseResource<GroupModel> {
   > {
     return this.addMembers(
       auth,
-      { users: [user], permissionsToWrite },
+      { users: [user], requestedPermissions },
       { transaction }
     );
   }
@@ -1190,8 +1193,11 @@ export class GroupResource extends BaseResource<GroupModel> {
     auth: Authenticator,
     {
       users,
-      permissionsToWrite,
-    }: { users: UserType[]; permissionsToWrite?: CombinedResourcePermissions },
+      requestedPermissions,
+    }: {
+      users: UserType[];
+      requestedPermissions?: CombinedResourcePermissions;
+    },
     { transaction }: { transaction?: Transaction } = {}
   ): Promise<
     Result<
@@ -1204,7 +1210,7 @@ export class GroupResource extends BaseResource<GroupModel> {
       >
     >
   > {
-    if (!this.canWrite(auth, permissionsToWrite)) {
+    if (!this.canWrite(auth, requestedPermissions)) {
       return new Err(
         new DustError(
           "unauthorized",
@@ -1300,8 +1306,8 @@ export class GroupResource extends BaseResource<GroupModel> {
     auth: Authenticator,
     {
       user,
-      permissionsToWrite,
-    }: { user: UserType; permissionsToWrite?: CombinedResourcePermissions },
+      requestedPermissions,
+    }: { user: UserType; requestedPermissions?: CombinedResourcePermissions },
     { transaction }: { transaction?: Transaction } = {}
   ): Promise<
     Result<
@@ -1316,7 +1322,7 @@ export class GroupResource extends BaseResource<GroupModel> {
   > {
     return this.removeMembers(
       auth,
-      { users: [user], permissionsToWrite },
+      { users: [user], requestedPermissions },
       { transaction }
     );
   }
@@ -1325,8 +1331,11 @@ export class GroupResource extends BaseResource<GroupModel> {
     auth: Authenticator,
     {
       users,
-      permissionsToWrite,
-    }: { users: UserType[]; permissionsToWrite?: CombinedResourcePermissions },
+      requestedPermissions,
+    }: {
+      users: UserType[];
+      requestedPermissions?: CombinedResourcePermissions;
+    },
     { transaction }: { transaction?: Transaction } = {}
   ): Promise<
     Result<
@@ -1341,7 +1350,7 @@ export class GroupResource extends BaseResource<GroupModel> {
       >
     >
   > {
-    if (!this.canWrite(auth, permissionsToWrite)) {
+    if (!this.canWrite(auth, requestedPermissions)) {
       return new Err(
         new DustError(
           "unauthorized",
@@ -1361,7 +1370,7 @@ export class GroupResource extends BaseResource<GroupModel> {
     if (usersToAdd.length > 0) {
       const addResult = await this.addMembers(
         auth,
-        { users: usersToAdd, permissionsToWrite },
+        { users: usersToAdd, requestedPermissions },
         {
           transaction,
         }
@@ -1378,7 +1387,7 @@ export class GroupResource extends BaseResource<GroupModel> {
     if (usersToRemove.length > 0) {
       const removeResult = await this.removeMembers(
         auth,
-        { users: usersToRemove, permissionsToWrite },
+        { users: usersToRemove, requestedPermissions },
         {
           transaction,
         }
@@ -1541,10 +1550,12 @@ export class GroupResource extends BaseResource<GroupModel> {
 
   canWrite(
     auth: Authenticator,
-    permissionsToWrite?: CombinedResourcePermissions
+    requestedPermissions?: CombinedResourcePermissions
   ): boolean {
     return auth.canWrite(
-      permissionsToWrite ? [permissionsToWrite] : this.requestedPermissions()
+      requestedPermissions
+        ? [requestedPermissions]
+        : this.requestedPermissions()
     );
   }
 

--- a/front/lib/resources/mcp_server_view_resource.test.ts
+++ b/front/lib/resources/mcp_server_view_resource.test.ts
@@ -186,7 +186,7 @@ describe("MCPServerViewResource", () => {
       // Add user to the group that accesses accessibleSpace
       const addMemberResult = await accessibleSpace.groups[0].addMember(
         adminAuth,
-        user.toJSON()
+        { user: user.toJSON() }
       );
       expect(addMemberResult.isOk()).toBe(true);
 
@@ -339,8 +339,8 @@ describe("MCPServerViewResource", () => {
       await MembershipFactory.associate(workspace, user, { role: "user" });
 
       // Add user to both groups
-      await space1.groups[0].addMember(adminAuth, user.toJSON());
-      await space2.groups[0].addMember(adminAuth, user.toJSON());
+      await space1.groups[0].addMember(adminAuth, { user: user.toJSON() });
+      await space2.groups[0].addMember(adminAuth, { user: user.toJSON() });
 
       // Create auth for the regular user
       const userAuth = await Authenticator.fromUserIdAndWorkspaceId(

--- a/front/lib/resources/space_resource.test.ts
+++ b/front/lib/resources/space_resource.test.ts
@@ -188,10 +188,9 @@ describe("SpaceResource", () => {
 
       it("should restore suspended members when switching from group to manual mode", async () => {
         // Add members first
-        await regularGroup.addMembers(adminAuth, [
-          user1.toJSON(),
-          user2.toJSON(),
-        ]);
+        await regularGroup.addMembers(adminAuth, {
+          users: [user1.toJSON(), user2.toJSON()],
+        });
 
         // Switch to group mode (this should suspend members)
         const provisionedGroup = await GroupResource.makeNew({
@@ -387,10 +386,9 @@ describe("SpaceResource", () => {
 
       it("should suspend active members when switching from manual to group mode", async () => {
         // Add members first
-        await regularGroup.addMembers(adminAuth, [
-          user1.toJSON(),
-          user2.toJSON(),
-        ]);
+        await regularGroup.addMembers(adminAuth, {
+          users: [user1.toJSON(), user2.toJSON()],
+        });
 
         // Set space to manual mode first
         await regularSpace.updatePermissions(adminAuth, {

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -572,11 +572,10 @@ export class SpaceResource extends BaseResource<SpaceModel> {
         // Handle member-based management
         const users = await UserResource.fetchByIds(memberIds);
 
-        const setMembersRes = await defaultSpaceGroup.setMembers(
-          auth,
-          { users: users.map((u) => u.toJSON()) },
-          { transaction: t }
-        );
+        const setMembersRes = await defaultSpaceGroup.setMembers(auth, {
+          users: users.map((u) => u.toJSON()),
+          transaction: t,
+        });
         if (setMembersRes.isErr()) {
           return setMembersRes;
         }

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -574,7 +574,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
 
         const setMembersRes = await defaultSpaceGroup.setMembers(
           auth,
-          users.map((u) => u.toJSON()),
+          { users: users.map((u) => u.toJSON()) },
           { transaction: t }
         );
         if (setMembersRes.isErr()) {
@@ -680,10 +680,9 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       return new Err(new DustError("user_not_found", "User not found."));
     }
 
-    const addMemberRes = await defaultSpaceGroup.addMembers(
-      auth,
-      users.map((user) => user.toJSON())
-    );
+    const addMemberRes = await defaultSpaceGroup.addMembers(auth, {
+      users: users.map((user) => user.toJSON()),
+    });
 
     if (addMemberRes.isErr()) {
       return addMemberRes;
@@ -726,10 +725,9 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       return new Err(new DustError("user_not_found", "User not found."));
     }
 
-    const removeMemberRes = await defaultSpaceGroup.removeMembers(
-      auth,
-      users.map((user) => user.toJSON())
-    );
+    const removeMemberRes = await defaultSpaceGroup.removeMembers(auth, {
+      users: users.map((user) => user.toJSON()),
+    });
 
     if (removeMemberRes.isErr()) {
       return removeMemberRes;

--- a/front/migrations/20250428_backfill_editor_groups.ts
+++ b/front/migrations/20250428_backfill_editor_groups.ts
@@ -126,10 +126,9 @@ async function backfillAgentEditorsGroup(
   );
 
   if (execute && editorGroup) {
-    const result = await editorGroup.setMembers(
-      auth,
-      usersToAdd.map((user) => user.toJSON())
-    );
+    const result = await editorGroup.setMembers(auth, {
+      users: usersToAdd.map((user) => user.toJSON()),
+    });
 
     if (result.isErr()) {
       throw result.error;

--- a/front/pages/api/w/[wId]/skills/[sId]/editors.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/editors.ts
@@ -152,7 +152,7 @@ async function handler(
         }
       }
 
-      const addRes = await editorGroup.addMembers(auth, usersToAdd);
+      const addRes = await editorGroup.addMembers(auth, { users: usersToAdd });
       if (addRes.isErr()) {
         switch (addRes.error.code) {
           case "unauthorized":
@@ -203,7 +203,9 @@ async function handler(
         }
       }
 
-      const removeRes = await editorGroup.removeMembers(auth, usersToRemove);
+      const removeRes = await editorGroup.removeMembers(auth, {
+        users: usersToRemove,
+      });
       if (removeRes.isErr()) {
         switch (removeRes.error.code) {
           case "unauthorized":

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/[svId]/index.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/mcp_views/[svId]/index.test.ts
@@ -84,7 +84,7 @@ describe("DELETE /api/w/[wId]/spaces/[spaceId]/mcp_views/[svId]", () => {
     const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
     const regularSpace = await SpaceFactory.regular(workspace);
-    await regularSpace.groups[0].addMember(auth, user.toJSON());
+    await regularSpace.groups[0].addMember(auth, { user: user.toJSON() });
 
     await FeatureFlagFactory.basic("dev_mcp_actions", workspace);
 

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_metadata.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_metadata.test.ts
@@ -80,7 +80,7 @@ describe("PATCH /api/w/[wId]/spaces/[spaceId]/project_metadata", () => {
       workspace.sId
     );
     const [spaceGroup] = projectSpace.groups.filter((g) => !g.isGlobal());
-    await spaceGroup.addMembers(adminAuth, [user.toJSON()]);
+    await spaceGroup.addMembers(adminAuth, { users: [user.toJSON()] });
 
     req.body = { description: "Should fail" };
 

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/webhook_source_views/[webhookSourceViewId]/index.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/webhook_source_views/[webhookSourceViewId]/index.test.ts
@@ -92,7 +92,9 @@ describe("DELETE /api/w/[wId]/spaces/[spaceId]/webhook_source_views/[webhookSour
     );
 
     const regularSpace = await SpaceFactory.regular(workspace);
-    await regularSpace.groups[0].addMember(authenticator, user.toJSON());
+    await regularSpace.groups[0].addMember(authenticator, {
+      user: user.toJSON(),
+    });
 
     const webhookSourceViewFactory = new WebhookSourceViewFactory(workspace);
     const webhookSourceView =

--- a/front/scripts/seed/basics/seedSpace.ts
+++ b/front/scripts/seed/basics/seedSpace.ts
@@ -42,7 +42,9 @@ export async function seedSpace(
     );
 
     // Add the user to the group so they can access the space
-    const addMemberResult = await group.addMember(auth, user.toJSON());
+    const addMemberResult = await group.addMember(auth, {
+      user: user.toJSON(),
+    });
     if (addMemberResult.isErr()) {
       throw new Error(
         `Failed to add user to group: ${addMemberResult.error.message}`

--- a/front/scripts/unrevoke_group_memberships.ts
+++ b/front/scripts/unrevoke_group_memberships.ts
@@ -107,7 +107,7 @@ makeScript(
       );
 
       if (execute) {
-        const result = await group.addMembers(auth, usersForGroup);
+        const result = await group.addMembers(auth, { users: usersForGroup });
         if (result.isErr()) {
           scriptLogger.error(
             { groupId: group.id, error: result.error },

--- a/front/temporal/workos_events_queue/activities.ts
+++ b/front/temporal/workos_events_queue/activities.ts
@@ -588,7 +588,7 @@ async function handleUserAddedToGroup(
 
   const isMember = await group.isMember(user);
   if (!isMember) {
-    const res = await group.addMember(auth, user.toJSON());
+    const res = await group.addMember(auth, { user: user.toJSON() });
     if (res.isErr()) {
       throw new Error(res.error.message);
     }
@@ -681,7 +681,7 @@ async function handleUserRemovedFromGroup(
     return;
   }
 
-  const res = await group.removeMember(auth, user.toJSON());
+  const res = await group.removeMember(auth, { user: user.toJSON() });
   if (res.isErr() && res.error.code !== "user_not_member") {
     throw new Error(res.error.message);
   }
@@ -824,7 +824,9 @@ async function handleDeleteWorkOSUser(
   });
 
   for (const group of groups) {
-    const removeResult = await group.removeMember(auth, user.toJSON());
+    const removeResult = await group.removeMember(auth, {
+      user: user.toJSON(),
+    });
     if (removeResult.isErr()) {
       logger.warn(
         {


### PR DESCRIPTION
## Description

This change enhances the GroupResource class by adding an optional `permissionsToWrite` parameter to member management methods (addMembers, addMember, removeMembers, removeMember, setMembers). This allows callers to specify custom permissions for write operations, enabling more flexible access control scenarios.

This PR moves us closer to proper project editor handling.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Deploy front
