### PR TITLE
feat(snowflake): change snowflake_tool feature flag to on_demand

### DIFF
--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -188,7 +188,7 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
   },
   snowflake_tool: {
     description: "Snowflake MCP tool for read-only SQL queries",
-    stage: "dust_only",
+    stage: "on_demand",
   },
   slack_message_splitting: {
     description:


### PR DESCRIPTION
## Description

Change the `snowflake_tool` feature flag from `dust_only` to `on_demand`, making the Snowflake MCP tool available to customers who request it.

## Tests

No tests needed - this is a simple feature flag stage change.

## Risk

Low risk. The Snowflake MCP server code is already merged. This only affects visibility/availability of the feature to workspaces.

## Deploy Plan

Standard deploy. The feature will become available on-demand after deployment.