### PR TITLE
copilot: Add table for storing suggestions

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -20,6 +20,7 @@ import {
 import { AgentDataRetentionModel } from "@app/lib/models/agent/agent_data_retention";
 import { AgentSkillModel } from "@app/lib/models/agent/agent_skill";
 import { AgentStepContentModel } from "@app/lib/models/agent/agent_step_content";
+import { AgentSuggestionModel } from "@app/lib/models/agent/agent_suggestion";
 import {
   AgentMessageFeedbackModel,
   AgentMessageModel,
@@ -208,6 +209,8 @@ async function main() {
   await AgentMessageSkillModel.sync({ alter: true });
   await SkillMCPServerConfigurationModel.sync({ alter: true });
   await WorkspaceVerificationAttemptModel.sync({ alter: true });
+
+  await AgentSuggestionModel.sync({ alter: true });
 
   process.exit(0);
 }

--- a/front/lib/models/agent/agent_suggestion.ts
+++ b/front/lib/models/agent/agent_suggestion.ts
@@ -1,0 +1,91 @@
+import type { CreationOptional } from "sequelize";
+import { DataTypes } from "sequelize";
+
+import { frontSequelize } from "@app/lib/resources/storage";
+import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
+import type {
+  AgentSuggestionKind,
+  AgentSuggestionSource,
+  AgentSuggestionState,
+  SuggestionPayload,
+} from "@app/types/suggestions/agent_suggestion";
+
+export class AgentSuggestionModel extends WorkspaceAwareModel<AgentSuggestionModel> {
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  // Reference agent by sId because sId cannot be inferred from id alone
+  declare agentConfigurationId: string;
+  declare agentConfigurationVersion: number;
+
+  declare kind: AgentSuggestionKind;
+  declare suggestion: SuggestionPayload;
+  declare analysis: string | null;
+
+  declare state: AgentSuggestionState;
+  declare source: AgentSuggestionSource;
+}
+
+AgentSuggestionModel.init(
+  {
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    agentConfigurationId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+    },
+    agentConfigurationVersion: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      comment:
+        "Version of the agent configuration when the suggestion was created",
+    },
+    kind: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      comment:
+        "Discriminator for the suggestion type (e.g., instructions, tools...)",
+    },
+    suggestion: {
+      type: DataTypes.JSONB,
+      allowNull: false,
+      comment:
+        "JSONB payload containing the suggestion details, structure depends on kind",
+    },
+    analysis: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      comment:
+        "Optional analysis/reasoning explaining why this suggestion was made",
+    },
+    state: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      comment:
+        "Current state of the suggestion (e.g., pending, accepted, rejected...)",
+    },
+    source: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      comment: "Origin of the suggestion such as reinforcement or copilot",
+    },
+  },
+  {
+    modelName: "agent_suggestion",
+    sequelize: frontSequelize,
+    indexes: [
+      {
+        fields: ["workspaceId", "agentConfigurationId"],
+        concurrently: true,
+      },
+    ],
+  }
+);

--- a/front/lib/resources/agent_suggestion_resource.test.ts
+++ b/front/lib/resources/agent_suggestion_resource.test.ts
@@ -1,0 +1,214 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import type { Authenticator } from "@app/lib/auth";
+import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { AgentSuggestionFactory } from "@app/tests/utils/AgentSuggestionFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import type { LightAgentConfigurationType, WorkspaceType } from "@app/types";
+
+describe("AgentSuggestionResource", () => {
+  let workspace: WorkspaceType;
+  let authenticator: Authenticator;
+  let agentConfiguration: LightAgentConfigurationType;
+
+  beforeEach(async () => {
+    const testSetup = await createResourceTest({ role: "builder" });
+    workspace = testSetup.workspace;
+    authenticator = testSetup.authenticator;
+
+    agentConfiguration =
+      await AgentConfigurationFactory.createTestAgent(authenticator);
+  });
+
+  describe("instructions suggestion", () => {
+    it("should create and fetch an instructions suggestion", async () => {
+      const suggestion = await AgentSuggestionFactory.createInstructions(
+        authenticator,
+        agentConfiguration.sId,
+        {
+          suggestion: {
+            oldString: "Be helpful",
+            newString: "Be extremely helpful and detailed",
+            expectedOccurrences: 1,
+          },
+          analysis: "Making the agent more helpful",
+        }
+      );
+
+      expect(suggestion).toBeDefined();
+      expect(suggestion.sId).toMatch(/^asu_/);
+      expect(suggestion.workspaceId).toBe(workspace.id);
+      expect(suggestion.agentConfigurationId).toBe(agentConfiguration.sId);
+      expect(suggestion.kind).toBe("instructions");
+      expect(suggestion.state).toBe("pending");
+      expect(suggestion.source).toBe("reinforcement");
+
+      const fetched = await AgentSuggestionResource.fetchById(
+        authenticator,
+        suggestion.sId
+      );
+      expect(fetched).toBeDefined();
+      expect(fetched?.sId).toBe(suggestion.sId);
+      expect(fetched?.kind).toBe("instructions");
+
+      const json = fetched!.toJSON();
+      expect(json.kind).toBe("instructions");
+      expect(json.suggestion).toEqual({
+        oldString: "Be helpful",
+        newString: "Be extremely helpful and detailed",
+        expectedOccurrences: 1,
+      });
+    });
+  });
+
+  describe("tools suggestion", () => {
+    it("should create and fetch a tools suggestion", async () => {
+      const suggestion = await AgentSuggestionFactory.createTools(
+        authenticator,
+        agentConfiguration.sId,
+        {
+          suggestion: {
+            additions: [
+              { id: "github", additionalConfiguration: { repo: "dust" } },
+              { id: "jira" },
+            ],
+            deletions: ["old_tool"],
+          },
+          analysis: "Adding project management tools",
+        }
+      );
+
+      expect(suggestion).toBeDefined();
+      expect(suggestion.kind).toBe("tools");
+
+      const fetched = await AgentSuggestionResource.fetchById(
+        authenticator,
+        suggestion.sId
+      );
+      expect(fetched).toBeDefined();
+
+      const json = fetched!.toJSON();
+      expect(json.kind).toBe("tools");
+      expect(json.suggestion).toEqual({
+        additions: [
+          { id: "github", additionalConfiguration: { repo: "dust" } },
+          { id: "jira" },
+        ],
+        deletions: ["old_tool"],
+      });
+    });
+  });
+
+  describe("skills suggestion", () => {
+    it("should create and fetch a skills suggestion", async () => {
+      const suggestion = await AgentSuggestionFactory.createSkills(
+        authenticator,
+        agentConfiguration.sId,
+        {
+          suggestion: {
+            additions: ["data_analysis"],
+          },
+          source: "copilot",
+        }
+      );
+
+      expect(suggestion).toBeDefined();
+      expect(suggestion.kind).toBe("skills");
+      expect(suggestion.source).toBe("copilot");
+
+      const fetched = await AgentSuggestionResource.fetchById(
+        authenticator,
+        suggestion.sId
+      );
+      expect(fetched).toBeDefined();
+
+      const json = fetched!.toJSON();
+      expect(json.kind).toBe("skills");
+      expect(json.suggestion).toEqual({
+        additions: ["data_analysis"],
+      });
+    });
+  });
+
+  describe("model suggestion", () => {
+    it("should create and fetch a model suggestion", async () => {
+      const suggestion = await AgentSuggestionFactory.createModel(
+        authenticator,
+        agentConfiguration.sId,
+        {
+          suggestion: {
+            modelId: "claude-haiku-4-5-20251001",
+            reasoningEffort: "high",
+          },
+          analysis: "Upgrading to a more capable model",
+        }
+      );
+
+      expect(suggestion).toBeDefined();
+      expect(suggestion.kind).toBe("model");
+
+      const fetched = await AgentSuggestionResource.fetchById(
+        authenticator,
+        suggestion.sId
+      );
+      expect(fetched).toBeDefined();
+
+      const json = fetched!.toJSON();
+      expect(json.kind).toBe("model");
+      expect(json.suggestion).toEqual({
+        modelId: "claude-haiku-4-5-20251001",
+        reasoningEffort: "high",
+      });
+    });
+  });
+
+  describe("delete", () => {
+    it("should delete a suggestion", async () => {
+      const suggestion = await AgentSuggestionFactory.createTools(
+        authenticator,
+        agentConfiguration.sId
+      );
+      const sId = suggestion.sId;
+
+      const result = await suggestion.delete(authenticator);
+      expect(result.isOk()).toBe(true);
+
+      const fetched = await AgentSuggestionResource.fetchById(
+        authenticator,
+        sId
+      );
+      expect(fetched).toBeNull();
+    });
+  });
+
+  describe("toJSON with discriminated union", () => {
+    it("should allow type narrowing based on kind", async () => {
+      const instructionsSuggestion =
+        await AgentSuggestionFactory.createInstructions(
+          authenticator,
+          agentConfiguration.sId,
+          {
+            suggestion: {
+              oldString: "old",
+              newString: "new",
+            },
+          }
+        );
+
+      const json = instructionsSuggestion.toJSON();
+
+      // Type narrowing based on kind
+      switch (json.kind) {
+        case "instructions":
+          expect(json.suggestion.oldString).toBe("old");
+          expect(json.suggestion.newString).toBe("new");
+          break;
+        case "tools":
+        case "skills":
+        case "model":
+          throw new Error("Unexpected kind");
+      }
+    });
+  });
+});

--- a/front/lib/resources/agent_suggestion_resource.ts
+++ b/front/lib/resources/agent_suggestion_resource.ts
@@ -1,0 +1,140 @@
+import type {
+  Attributes,
+  CreationAttributes,
+  ModelStatic,
+  Transaction,
+} from "sequelize";
+
+import type { Authenticator } from "@app/lib/auth";
+import { AgentSuggestionModel } from "@app/lib/models/agent/agent_suggestion";
+import { BaseResource } from "@app/lib/resources/base_resource";
+import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
+import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
+import type { ResourceFindOptions } from "@app/lib/resources/types";
+import type { ModelId, Result } from "@app/types";
+import { Err, normalizeError, Ok, removeNulls } from "@app/types";
+import type { AgentSuggestionType } from "@app/types/suggestions/agent_suggestion";
+import { parseAgentSuggestionData } from "@app/types/suggestions/agent_suggestion";
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export interface AgentSuggestionResource extends ReadonlyAttributesType<AgentSuggestionModel> {}
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export class AgentSuggestionResource extends BaseResource<AgentSuggestionModel> {
+  static model: ModelStatic<AgentSuggestionModel> = AgentSuggestionModel;
+
+  constructor(
+    model: ModelStatic<AgentSuggestionModel>,
+    blob: Attributes<AgentSuggestionModel>
+  ) {
+    super(AgentSuggestionModel, blob);
+  }
+
+  static async makeNew(
+    auth: Authenticator,
+    blob: Omit<CreationAttributes<AgentSuggestionModel>, "workspaceId">
+  ) {
+    const suggestion = await AgentSuggestionModel.create({
+      ...blob,
+      workspaceId: auth.getNonNullableWorkspace().id,
+    });
+
+    return new this(AgentSuggestionModel, suggestion.get());
+  }
+
+  private static async baseFetch(
+    auth: Authenticator,
+    options?: ResourceFindOptions<AgentSuggestionModel>
+  ) {
+    const { where, ...otherOptions } = options ?? {};
+
+    const suggestions = await AgentSuggestionModel.findAll({
+      where: {
+        ...where,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+      ...otherOptions,
+    });
+
+    return suggestions.map(
+      (suggestion) => new this(AgentSuggestionModel, suggestion.get())
+    );
+  }
+
+  static async fetchByIds(
+    auth: Authenticator,
+    ids: string[]
+  ): Promise<AgentSuggestionResource[]> {
+    return this.baseFetch(auth, {
+      where: {
+        id: removeNulls(ids.map(getResourceIdFromSId)),
+      },
+    });
+  }
+
+  static async fetchById(
+    auth: Authenticator,
+    id: string
+  ): Promise<AgentSuggestionResource | null> {
+    const [suggestion] = await this.fetchByIds(auth, [id]);
+    return suggestion ?? null;
+  }
+
+  async delete(
+    auth: Authenticator,
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<Result<undefined, Error>> {
+    try {
+      await this.model.destroy({
+        where: {
+          workspaceId: auth.getNonNullableWorkspace().id,
+          id: this.id,
+        },
+        transaction,
+      });
+
+      return new Ok(undefined);
+    } catch (err) {
+      return new Err(normalizeError(err));
+    }
+  }
+
+  get sId(): string {
+    return AgentSuggestionResource.modelIdToSId({
+      id: this.id,
+      workspaceId: this.workspaceId,
+    });
+  }
+
+  static modelIdToSId({
+    id,
+    workspaceId,
+  }: {
+    id: ModelId;
+    workspaceId: ModelId;
+  }): string {
+    return makeSId("agent_suggestion", {
+      id,
+      workspaceId,
+    });
+  }
+
+  toJSON(): AgentSuggestionType {
+    const suggestionData = parseAgentSuggestionData({
+      kind: this.kind,
+      suggestion: this.suggestion,
+    });
+
+    return {
+      id: this.id,
+      sId: this.sId,
+      createdAt: this.createdAt.getTime(),
+      updatedAt: this.updatedAt.getTime(),
+      agentConfigurationId: this.agentConfigurationId,
+      agentConfigurationVersion: this.agentConfigurationVersion,
+      analysis: this.analysis,
+      state: this.state,
+      source: this.source,
+      ...suggestionData,
+    };
+  }
+}

--- a/front/lib/resources/string_ids.ts
+++ b/front/lib/resources/string_ids.ts
@@ -59,6 +59,9 @@ export const RESOURCES_PREFIX = {
   // Skills.
   skill: "skl",
 
+  // Agent suggestions.
+  agent_suggestion: "asu",
+
   // Workspace verification.
   workspace_verification_attempt: "wva",
 

--- a/front/migrations/db/migration_485.sql
+++ b/front/migrations/db/migration_485.sql
@@ -1,0 +1,22 @@
+-- Migration created on Jan 20, 2026
+CREATE TABLE IF NOT EXISTS "agent_suggestions" (
+    "id" BIGSERIAL PRIMARY KEY,
+    "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+    "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+    "workspaceId" BIGINT NOT NULL REFERENCES "workspaces" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    "agentConfigurationId" VARCHAR(255) NOT NULL,
+    "agentConfigurationVersion" INTEGER NOT NULL,
+    "kind" VARCHAR(255) NOT NULL,
+    "suggestion" JSONB NOT NULL,
+    "analysis" TEXT,
+    "state" VARCHAR(255) NOT NULL,
+    "source" VARCHAR(255) NOT NULL
+);
+COMMENT ON COLUMN "agent_suggestions"."agentConfigurationVersion" IS 'Version of the agent configuration when the suggestion was created';
+COMMENT ON COLUMN "agent_suggestions"."kind" IS 'Discriminator for the suggestion type: instructions, tools, skills, model';
+COMMENT ON COLUMN "agent_suggestions"."suggestion" IS 'JSONB payload containing the suggestion details, structure depends on kind';
+COMMENT ON COLUMN "agent_suggestions"."analysis" IS 'Optional analysis/reasoning explaining why this suggestion was made';
+COMMENT ON COLUMN "agent_suggestions"."source" IS 'Origin of the suggestion such as reinforcement or copilot';
+COMMENT ON COLUMN "agent_suggestions"."state" IS 'Current state of the suggestion (e.g., pending, accepted, rejected...)';
+COMMENT ON TABLE "agent_suggestions" IS 'AI-generated suggestions to improve agent configurations.';
+CREATE INDEX CONCURRENTLY "agent_suggestions_workspace_agent_config" ON "agent_suggestions" ("workspaceId", "agentConfigurationId");

--- a/front/tests/utils/AgentSuggestionFactory.ts
+++ b/front/tests/utils/AgentSuggestionFactory.ts
@@ -1,0 +1,116 @@
+import type { Authenticator } from "@app/lib/auth";
+import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
+import type {
+  AgentSuggestionSource,
+  AgentSuggestionState,
+  InstructionsSuggestionType,
+  ModelSuggestionType,
+  SkillsSuggestionType,
+  ToolsSuggestionType,
+} from "@app/types/suggestions/agent_suggestion";
+
+export class AgentSuggestionFactory {
+  static async createInstructions(
+    auth: Authenticator,
+    agentConfigurationId: string,
+    overrides: Partial<{
+      agentConfigurationVersion: number;
+      suggestion: InstructionsSuggestionType;
+      analysis: string | null;
+      state: AgentSuggestionState;
+      source: AgentSuggestionSource;
+    }> = {}
+  ): Promise<AgentSuggestionResource> {
+    return AgentSuggestionResource.makeNew(auth, {
+      agentConfigurationId,
+      agentConfigurationVersion: overrides.agentConfigurationVersion ?? 1,
+      kind: "instructions",
+      suggestion: overrides.suggestion ?? {
+        oldString: "You are a helpful assistant.",
+        newString: "You are an expert assistant specialized in coding.",
+        expectedOccurrences: 1,
+      },
+      analysis:
+        overrides.analysis ?? "Improved instructions for better coding help",
+      state: overrides.state ?? "pending",
+      source: overrides.source ?? "reinforcement",
+    });
+  }
+
+  static async createTools(
+    auth: Authenticator,
+    agentConfigurationId: string,
+    overrides: Partial<{
+      agentConfigurationVersion: number;
+      suggestion: ToolsSuggestionType;
+      analysis: string | null;
+      state: AgentSuggestionState;
+      source: AgentSuggestionSource;
+    }> = {}
+  ): Promise<AgentSuggestionResource> {
+    return AgentSuggestionResource.makeNew(auth, {
+      agentConfigurationId,
+      agentConfigurationVersion: overrides.agentConfigurationVersion ?? 1,
+      kind: "tools",
+      suggestion: overrides.suggestion ?? {
+        additions: [
+          { id: "notion", additionalConfiguration: { database: "tasks" } },
+          { id: "slack" },
+        ],
+        deletions: ["deprecated_tool"],
+      },
+      analysis: overrides.analysis ?? "Added useful integrations",
+      state: overrides.state ?? "pending",
+      source: overrides.source ?? "reinforcement",
+    });
+  }
+
+  static async createSkills(
+    auth: Authenticator,
+    agentConfigurationId: string,
+    overrides: Partial<{
+      agentConfigurationVersion: number;
+      suggestion: SkillsSuggestionType;
+      analysis: string | null;
+      state: AgentSuggestionState;
+      source: AgentSuggestionSource;
+    }> = {}
+  ): Promise<AgentSuggestionResource> {
+    return AgentSuggestionResource.makeNew(auth, {
+      agentConfigurationId,
+      agentConfigurationVersion: overrides.agentConfigurationVersion ?? 1,
+      kind: "skills",
+      suggestion: overrides.suggestion ?? {
+        additions: ["code_review", "summarization"],
+      },
+      analysis: overrides.analysis ?? "Added skills for better assistance",
+      state: overrides.state ?? "pending",
+      source: overrides.source ?? "copilot",
+    });
+  }
+
+  static async createModel(
+    auth: Authenticator,
+    agentConfigurationId: string,
+    overrides: Partial<{
+      agentConfigurationVersion: number;
+      suggestion: ModelSuggestionType;
+      analysis: string | null;
+      state: AgentSuggestionState;
+      source: AgentSuggestionSource;
+    }> = {}
+  ): Promise<AgentSuggestionResource> {
+    return AgentSuggestionResource.makeNew(auth, {
+      agentConfigurationId,
+      agentConfigurationVersion: overrides.agentConfigurationVersion ?? 1,
+      kind: "model",
+      suggestion: overrides.suggestion ?? {
+        modelId: "claude-haiku-4-5-20251001",
+        reasoningEffort: "medium",
+      },
+      analysis: overrides.analysis ?? "Suggested a more capable model",
+      state: overrides.state ?? "pending",
+      source: overrides.source ?? "reinforcement",
+    });
+  }
+}

--- a/front/types/index.ts
+++ b/front/types/index.ts
@@ -97,6 +97,7 @@ export * from "./shared/utils/time_frame";
 export * from "./shared/utils/url_utils";
 export * from "./sheets";
 export * from "./space";
+export * from "./suggestions/agent_suggestion";
 export * from "./tokenizer";
 export * from "./user";
 export * from "./website";

--- a/front/types/suggestions/agent_suggestion.ts
+++ b/front/types/suggestions/agent_suggestion.ts
@@ -1,0 +1,106 @@
+import { z } from "zod";
+
+import { MODEL_IDS } from "@app/types/assistant/models/models";
+import { REASONING_EFFORTS } from "@app/types/assistant/models/reasoning";
+import type { ModelId } from "@app/types/shared/model_id";
+
+export const AGENT_SUGGESTION_KINDS = [
+  "instructions",
+  "tools",
+  "skills",
+  "model",
+] as const;
+
+export type AgentSuggestionKind = (typeof AGENT_SUGGESTION_KINDS)[number];
+
+export const AGENT_SUGGESTION_STATES = [
+  "pending",
+  "approved",
+  "declined",
+  "outdated",
+] as const;
+
+export type AgentSuggestionState = (typeof AGENT_SUGGESTION_STATES)[number];
+
+export const AGENT_SUGGESTION_SOURCES = ["reinforcement", "copilot"] as const;
+
+export type AgentSuggestionSource = (typeof AGENT_SUGGESTION_SOURCES)[number];
+
+const ToolAdditionSchema = z.object({
+  id: z.string(),
+  additionalConfiguration: z.record(z.unknown()).optional(),
+});
+
+const ToolsSuggestionSchema = z.object({
+  additions: z.array(ToolAdditionSchema).optional(),
+  deletions: z.array(z.string()).optional(),
+});
+
+const SkillsSuggestionSchema = z.object({
+  additions: z.array(z.string()).optional(),
+  deletions: z.array(z.string()).optional(),
+});
+
+const InstructionsSuggestionSchema = z.object({
+  oldString: z
+    .string()
+    .describe("The exact text to find (including surrounding context)"),
+  newString: z.string().describe("The exact replacement text"),
+  expectedOccurrences: z
+    .number()
+    .optional()
+    .describe("Number of occurrences to replace."),
+});
+
+const ModelSuggestionSchema = z.object({
+  modelId: z.enum(MODEL_IDS),
+  reasoningEffort: z.enum(REASONING_EFFORTS).optional(),
+});
+
+export type ToolAdditionType = z.infer<typeof ToolAdditionSchema>;
+export type ToolsSuggestionType = z.infer<typeof ToolsSuggestionSchema>;
+export type SkillsSuggestionType = z.infer<typeof SkillsSuggestionSchema>;
+export type InstructionsSuggestionType = z.infer<
+  typeof InstructionsSuggestionSchema
+>;
+export type ModelSuggestionType = z.infer<typeof ModelSuggestionSchema>;
+
+export type SuggestionPayload =
+  | ToolsSuggestionType
+  | SkillsSuggestionType
+  | InstructionsSuggestionType
+  | ModelSuggestionType;
+
+const AgentSuggestionDataSchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("tools"), suggestion: ToolsSuggestionSchema }),
+  z.object({ kind: z.literal("skills"), suggestion: SkillsSuggestionSchema }),
+  z.object({
+    kind: z.literal("instructions"),
+    suggestion: InstructionsSuggestionSchema,
+  }),
+  z.object({ kind: z.literal("model"), suggestion: ModelSuggestionSchema }),
+]);
+
+export type AgentSuggestionData = z.infer<typeof AgentSuggestionDataSchema>;
+
+export function parseAgentSuggestionData(data: unknown): AgentSuggestionData {
+  return AgentSuggestionDataSchema.parse(data);
+}
+
+type BaseAgentSuggestionType = {
+  id: ModelId;
+  sId: string;
+  createdAt: number;
+  updatedAt: number;
+  agentConfigurationId: string;
+  agentConfigurationVersion: number;
+  analysis: string | null;
+  state: AgentSuggestionState;
+  source: AgentSuggestionSource;
+};
+
+/**
+ * Discriminated union for agent suggestions based on "kind" field.
+ * Use switch(suggestion.kind) to narrow the suggestion type.
+ */
+export type AgentSuggestionType = BaseAgentSuggestionType & AgentSuggestionData;


### PR DESCRIPTION
## Description

 - Add the agent_suggestions table
 - Add the model and resource
 - Add the types for AgentSuggestion
 - Add the sId creation method

## Tests

 - Unit test added inserting all type of suggestions

## Risk

low, not exposed

## Deploy Plan
block front
merge PR
run migration
deploy front
unblock front

