### PR TITLE
[connectors] fix(google_drive): Prevent error if workflow was already started

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/workflows.ts
+++ b/connectors/src/connectors/google_drive/temporal/workflows.ts
@@ -3,7 +3,6 @@ import type { ChildWorkflowHandle } from "@temporalio/workflow";
 import {
   continueAsNew,
   executeChild,
-  getExternalWorkflowHandle,
   isCancellation,
   proxyActivities,
   setHandler,

--- a/connectors/src/connectors/google_drive/temporal/workflows.ts
+++ b/connectors/src/connectors/google_drive/temporal/workflows.ts
@@ -678,9 +678,8 @@ export async function googleDriveIncrementalSyncPerDrive({
                 err instanceof Error &&
                 err.name === "WorkflowExecutionAlreadyStartedError"
               ) {
-                // Workflow already running, wait for it to complete
-                const existing = getExternalWorkflowHandle(workflowId);
-                await existing.result();
+                // Workflow already running, folder will be synced by that execution
+                return;
               } else {
                 throw err;
               }


### PR DESCRIPTION
## Description

I had a case where the incremental sync of "userspace" and another drive lead to the same new folders, both trying to create the same full sync workflow. This prevent the error and skip if workflow is already running.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy connectors
