### PR TITLE
Add Ephemeral cache control on Anthropic last user message

### DIFF
--- a/front/lib/api/llm/clients/anthropic/index.ts
+++ b/front/lib/api/llm/clients/anthropic/index.ts
@@ -50,7 +50,9 @@ export class AnthropicLLM extends LLM {
     forceToolCall,
   }: LLMStreamParameters): AsyncGenerator<LLMEvent> {
     try {
-      const messages = conversation.messages.map(toMessage);
+      const messages = conversation.messages.map((msg, index, array) =>
+        toMessage(msg, { isLast: index === array.length - 1 })
+      );
 
       const events = this.client.beta.messages.stream({
         model: this.modelId,

--- a/front/lib/api/llm/clients/anthropic/utils/conversation_to_anthropic.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/conversation_to_anthropic.ts
@@ -99,10 +99,20 @@ function functionMessage(message: FunctionMessageTypeModel): MessageParam {
   };
 }
 
-function userMessage(message: UserMessageTypeModel): MessageParam {
+function userMessage(
+  message: UserMessageTypeModel,
+  { isLast }: { isLast: boolean }
+): MessageParam {
+  const content = message.content.map(userContentToParam);
+
+  // Add cache_control to the last content block if this is the last message.
+  if (isLast && content.length > 0) {
+    content[content.length - 1].cache_control = { type: "ephemeral" };
+  }
+
   return {
     role: "user",
-    content: message.content.map(userContentToParam),
+    content,
   };
 }
 
@@ -120,11 +130,12 @@ function assistantMessage(
 }
 
 export function toMessage(
-  message: ModelMessageTypeMultiActionsWithoutContentFragment
+  message: ModelMessageTypeMultiActionsWithoutContentFragment,
+  { isLast }: { isLast: boolean } = { isLast: false }
 ): MessageParam {
   switch (message.role) {
     case "user":
-      return userMessage(message);
+      return userMessage(message, { isLast });
     case "function":
       return functionMessage(message);
     case "assistant":

--- a/front/lib/api/llm/clients/anthropic/utils/test/conversation_to_anthropic.test.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/test/conversation_to_anthropic.test.ts
@@ -56,7 +56,7 @@ describe("toMessage", () => {
       if (Array.isArray(result.content) && result.content.length > 0) {
         const lastBlock = result.content[result.content.length - 1];
         expect(lastBlock).toHaveProperty("cache_control");
-        expect(lastBlock.cache_control).toEqual({ type: "ephemeral" });
+        expect(lastBlock).toHaveProperty("cache_control.type", "ephemeral");
       } else {
         throw new Error("Expected content array with at least one element");
       }

--- a/front/lib/api/llm/clients/anthropic/utils/test/conversation_to_anthropic.test.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/test/conversation_to_anthropic.test.ts
@@ -9,15 +9,75 @@ import { reasoningInputMessages } from "@app/lib/api/llm/clients/anthropic/utils
 describe("toMessage", () => {
   describe("user messages", () => {
     it("should convert user message with text and function calls", () => {
-      const messages = conversationMessages.map(toMessage);
+      const messages = conversationMessages.map((msg) => toMessage(msg));
 
       expect(messages).toEqual(inputMessages);
     });
 
     it("should convert assistant message with reasoning/thinking content", () => {
-      const messages = reasoningConversationMessages.map(toMessage);
+      const messages = reasoningConversationMessages.map((msg) =>
+        toMessage(msg)
+      );
 
       expect(messages).toEqual(reasoningInputMessages);
+    });
+  });
+
+  describe("cache_control", () => {
+    it("should not add cache_control when isLast is false", () => {
+      const userMessage = conversationMessages.find(
+        (msg) => msg.role === "user"
+      );
+      if (!userMessage) {
+        throw new Error("No user message found in test fixtures");
+      }
+
+      const result = toMessage(userMessage, { isLast: false });
+
+      // Verify no cache_control is present
+      if (Array.isArray(result.content)) {
+        result.content.forEach((block) => {
+          expect(block).not.toHaveProperty("cache_control");
+        });
+      }
+    });
+
+    it("should add cache_control to last content block when isLast is true", () => {
+      const userMessage = conversationMessages.find(
+        (msg) => msg.role === "user"
+      );
+      if (!userMessage) {
+        throw new Error("No user message found in test fixtures");
+      }
+
+      const result = toMessage(userMessage, { isLast: true });
+
+      // Verify cache_control is added to the last content block
+      if (Array.isArray(result.content) && result.content.length > 0) {
+        const lastBlock = result.content[result.content.length - 1];
+        expect(lastBlock).toHaveProperty("cache_control");
+        expect(lastBlock.cache_control).toEqual({ type: "ephemeral" });
+      } else {
+        throw new Error("Expected content array with at least one element");
+      }
+    });
+
+    it("should not add cache_control to non-user messages", () => {
+      const assistantMessage = conversationMessages.find(
+        (msg) => msg.role === "assistant"
+      );
+      if (!assistantMessage) {
+        throw new Error("No assistant message found in test fixtures");
+      }
+
+      const result = toMessage(assistantMessage, { isLast: true });
+
+      // Assistant messages should not have cache_control even if isLast is true
+      if (Array.isArray(result.content)) {
+        result.content.forEach((block) => {
+          expect(block).not.toHaveProperty("cache_control");
+        });
+      }
     });
   });
 });


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Cache hit rates for Anthropic models (including Sonnet 4.5) dropped from ~40% to 25% around November 20-21, 2025.

### Root Cause

When we enabled the new LLM router for everyone on Nov 21 #18142, we introduced a different behavior that what we used to have in core.

Before Nov 21, the Core (Rust) implementation was handling Anthropic API calls and correctly implemented two
cache breakpoints:
- System prompt (instructions/meta-prompts)
- Conversation history (last user message)

When the LLM router was enabled on Nov 21, the TypeScript implementation was only caching the system prompt,
missing the conversation history cache breakpoint. This significantly impacted multi-turn conversations.

<img width="1058" height="476" alt="image" src="https://github.com/user-attachments/assets/df8aa7fc-e6c4-4fe1-a600-6cfc0341612c" />

### Solution

This PR adds `cache_control` to the last content block of the last user message in the Anthropic LLM client,
matching Core's previous behavior.

### Reference

Previous Core implementation (before it was removed):
- Full file: https://github.com/dust-tt/dust/blob/b779c50f04/core/src/providers/anthropic/anthropic.rs
- Specific cache logic:
https://github.com/dust-tt/dust/blob/b779c50f04/core/src/providers/anthropic/anthropic.rs#L407-L415

### Expected Impact

This should restore cache hit rates for Anthropic models, especially for multi-turn conversations where
conversation history represents a significant portion of the prompt.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
