### PR TITLE
[front] - fix(conversation): adjust scroll alignment

### DIFF
--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -162,7 +162,7 @@ export const AgentInputBar = ({
           const targetIndex = fullyAboveIndices[fullyAboveIndices.length - 1];
           methods.scrollToItem({
             index: targetIndex,
-            align: "start-no-overflow",
+            align: "start",
             behavior: "smooth",
           });
         }
@@ -173,7 +173,7 @@ export const AgentInputBar = ({
           const targetIndex = belowTopQuarterIndices[0];
           methods.scrollToItem({
             index: targetIndex,
-            align: "start-no-overflow",
+            align: "start",
             behavior: "smooth",
           });
         } else if (bottomOffset > 0) {

--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -162,7 +162,7 @@ export const AgentInputBar = ({
           const targetIndex = fullyAboveIndices[fullyAboveIndices.length - 1];
           methods.scrollToItem({
             index: targetIndex,
-            align: "start",
+            align: "start-no-overflow",
             behavior: "smooth",
           });
         }
@@ -173,7 +173,7 @@ export const AgentInputBar = ({
           const targetIndex = belowTopQuarterIndices[0];
           methods.scrollToItem({
             index: targetIndex,
-            align: "start",
+            align: "start-no-overflow",
             behavior: "smooth",
           });
         } else if (bottomOffset > 0) {

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -63,11 +63,12 @@ import type {
   WorkspaceType,
 } from "@app/types";
 import {
+  Err,
   isRichAgentMention,
   isUserMessageTypeWithContentFragments,
+  Ok,
   toMentionType,
 } from "@app/types";
-import { Err, Ok } from "@app/types";
 
 const DEFAULT_PAGE_LIMIT = 50;
 
@@ -92,6 +93,7 @@ function customSmoothScroll() {
     easing: easeOutQuint,
   };
 }
+
 /**
  *
  * @param isInModal is the conversation happening in a side modal, i.e. when testing an agent?
@@ -510,7 +512,7 @@ export const ConversationViewer = ({
           ? () => {
               return {
                 index: nbMessages, // Avoid jumping around when the agent message is generated.
-                align: "start",
+                align: "start-no-overflow",
                 behavior: customSmoothScroll,
               };
             }
@@ -708,7 +710,7 @@ export const ConversationViewer = ({
           EmptyPlaceholder={ConversationViewerEmptyState}
           // Large buffer to avoid manipulating the dom too much when the user scrolls a bit.
           increaseViewportBy={8192}
-          enforceStickyFooterAtBottom={true}
+          enforceStickyFooterAtBottom
         />
       </VirtuosoMessageListLicense>
     </>

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -328,7 +328,7 @@ export const InputBar = React.memo(function InputBar({
     <div className="flex w-full flex-col">
       <div
         className={classNames(
-          "relative flex w-full flex-1 flex-col items-stretch gap-0 self-stretch sm:flex-row",
+          "relative flex w-full flex-col items-stretch gap-0 self-stretch sm:flex-row",
           "rounded-2xl transition-all",
           "bg-muted-background dark:bg-muted-background-night",
           "border",
@@ -349,7 +349,7 @@ export const InputBar = React.memo(function InputBar({
           isAnimating ? "duration-600 animate-shake" : "duration-300"
         )}
       >
-        <div className="relative flex w-full flex-1 flex-col">
+        <div className="relative flex w-full flex-col">
           <InputBarAttachments
             owner={owner}
             files={{ service: fileUploaderService }}


### PR DESCRIPTION
## Description

Fixes scroll alignment issues in conversation view by changing from `"start"` to `"start-no-overflow"` alignment mode for Virtuoso scroll actions. This prevents content from overflowing the viewport during smooth scrolling when navigating between user messages or when an agent is mentioned. Also enforces sticky footer behavior by default and removes redundant `flex-1` CSS classes from InputBar components for cleaner layout structure.

## Risk

Low - refinement to existing scroll behavior introduced with navigation arrows feature.

## Tests

Locally

## Deploy Plan

Deploy front