### PR TITLE
[dust-hive] Also copy AGENTS.override.md files when spawning

### DIFF
--- a/x/henry/dust-hive/src/lib/setup.ts
+++ b/x/henry/dust-hive/src/lib/setup.ts
@@ -88,9 +88,9 @@ async function symlinkCargoTarget(srcDir: string, destDir: string): Promise<void
   }
 }
 
-// Find all AGENTS.local.md files in the repo (excluding node_modules and other large dirs)
+// Find all files matching filename in the repo (excluding node_modules and other large dirs)
 // Uses -prune to skip entire directory trees rather than filtering after traversal
-async function findAgentsLocalFiles(srcDir: string): Promise<string[]> {
+async function findAgentsFiles(srcDir: string, filename: string): Promise<string[]> {
   const proc = Bun.spawn(
     [
       "find",
@@ -117,9 +117,8 @@ async function findAgentsLocalFiles(srcDir: string): Promise<string[]> {
       ")",
       "-prune",
       "-o",
-      // Find AGENTS.local.md files
       "-name",
-      "AGENTS.local.md",
+      filename,
       "-type",
       "f",
       "-print",
@@ -142,16 +141,19 @@ async function findAgentsLocalFiles(srcDir: string): Promise<string[]> {
     .filter((line) => line.length > 0);
 }
 
-// Copy user config files (AGENTS.local.md files, .claude/) from main repo to worktree
+// Copy user config files (AGENTS.local.md, AGENTS.override.md files, .claude/) from main repo to worktree
 async function copyUserConfigFiles(srcDir: string, destDir: string): Promise<void> {
-  // Find and copy all AGENTS.local.md files, preserving directory structure
-  const agentsFiles = await findAgentsLocalFiles(srcDir);
-  for (const srcPath of agentsFiles) {
-    // Get relative path from srcDir
-    const relativePath = srcPath.slice(srcDir.length + 1);
-    const destPath = `${destDir}/${relativePath}`;
-    await Bun.spawn(["cp", srcPath, destPath]).exited;
-    logger.success(`Copied ${relativePath}`);
+  // Find and copy all AGENTS.local.md and AGENTS.override.md files, preserving directory structure
+  const filenames = ["AGENTS.local.md", "AGENTS.override.md"];
+  for (const filename of filenames) {
+    const agentsFiles = await findAgentsFiles(srcDir, filename);
+    for (const srcPath of agentsFiles) {
+      // Get relative path from srcDir
+      const relativePath = srcPath.slice(srcDir.length + 1);
+      const destPath = `${destDir}/${relativePath}`;
+      await Bun.spawn(["cp", srcPath, destPath]).exited;
+      logger.success(`Copied ${relativePath}`);
+    }
   }
 
   // Copy directories recursively, merging with existing content
@@ -284,7 +286,7 @@ export async function installAllDependencies(
     throw new Error(`Failed to install dependencies for: ${failed.join(", ")}`);
   }
 
-  // Copy user config files (AGENTS.local.md, CLAUDE.md, .claude/) if they exist
+  // Copy user config files (AGENTS.local.md, AGENTS.override.md, .claude/) if they exist
   logger.step("Copying user config files...");
   await copyUserConfigFiles(repoRoot, worktreePath);
 }


### PR DESCRIPTION
## Description

Generalize `findAgentsLocalFiles` to `findAgentsFiles` with a filename parameter, then use it to copy both `AGENTS.local.md` and `AGENTS.override.md` files to worktrees during spawn.

## Risks

Blast radius: dust-hive spawn only
Risk: none

## Deploy Plan

N/A (internal tooling)