### PR TITLE
Improve conversation rendering for content fragments

### DIFF
--- a/front/lib/api/assistant/conversation_rendering/helpers.ts
+++ b/front/lib/api/assistant/conversation_rendering/helpers.ts
@@ -15,7 +15,6 @@ import { renderLightContentFragmentForModel } from "@app/lib/resources/content_f
 import logger from "@app/logger/logger";
 import type {
   AgentMessageType,
-  ConversationType,
   FunctionCallType,
   FunctionMessageTypeModel,
   ModelConfigurationType,
@@ -342,14 +341,12 @@ export function renderUserMessage(m: UserMessageType): UserMessageTypeModel {
 export async function renderContentFragment(
   auth: Authenticator,
   m: any, // ContentFragmentType
-  conversation: ConversationType,
   model: ModelConfigurationType,
   excludeImages: boolean
 ): Promise<ModelMessageTypeMultiActions | null> {
   const renderedContentFragment = await renderLightContentFragmentForModel(
     auth,
     m,
-    conversation,
     model,
     {
       excludeImages: Boolean(excludeImages),

--- a/front/lib/api/assistant/conversation_rendering/message_rendering.ts
+++ b/front/lib/api/assistant/conversation_rendering/message_rendering.ts
@@ -195,7 +195,6 @@ export async function renderAllMessages(
         const renderedContentFragment = await renderContentFragment(
           auth,
           m,
-          conversation,
           model,
           !!excludeImages
         );

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -21,7 +21,7 @@ import appConfig from "@app/lib/api/config";
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
 import { getPrivateUploadBucket } from "@app/lib/file_storage";
-import { MessageModel } from "@app/lib/models/agent/conversation";
+import type { MessageModel } from "@app/lib/models/agent/conversation";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
@@ -180,22 +180,6 @@ export class ContentFragmentResource extends BaseResource<ContentFragmentModel> 
       ContentFragmentResource.model,
       contentFragment.get()
     );
-  }
-
-  static async fromMessageId(auth: Authenticator, id: ModelId) {
-    const message = await MessageModel.findOne({
-      where: {
-        id,
-        workspaceId: auth.getNonNullableWorkspace().id,
-      },
-      include: [{ model: ContentFragmentModel, as: "contentFragment" }],
-    });
-    if (!message) {
-      throw new Error(
-        "No message found for the given id when trying to create a ContentFragmentResource"
-      );
-    }
-    return ContentFragmentResource.fromMessage(message);
   }
 
   static async fetchManyByModelIds(auth: Authenticator, ids: Array<ModelId>) {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
### Problem
`renderConversationForModel` was executing an N+1 query pattern when rendering content fragments. For each content
fragment in a conversation, the function would make an individual database query via
`ContentFragmentResource.fromMessageId()` which led to a query on the `messages` table.

For a conversation with 50 content fragments, this resulted in 50 individual database queries.

![InneficientRendering](https://github.com/user-attachments/assets/9d4facf8-c339-4e9c-93a1-e40a3ea49b7e)

### Solution

The `ContentFragmentType` object already contains all the necessary data:
- `expiredReason`
- `fileId` (for file fragments)
- `nodeId`, `nodeDataSourceViewId` (for content node fragments)

Removed the unnecessary database call in `renderLightContentFragmentForModel` and now directly use data from the message parameter. This function still need to remains async to get the signed url.

### Impact

- Before: N database queries for N content fragments
- After: 0 database queries. All data comes from the already-loaded conversation.
- Significantly improves performance for conversations with many attachments

⚠️ **DISCLAIMER:** We have no tests on `renderConversationForModel` yet, I might add some in a follow up PR. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
