### PR TITLE
fix(front): only show trial message usage for phone trial plan in agent builder

### DIFF
--- a/front/components/agent_builder/AgentBuilderPreview.tsx
+++ b/front/components/agent_builder/AgentBuilderPreview.tsx
@@ -8,10 +8,9 @@ import {
   useDraftConversation,
 } from "@app/components/agent_builder/hooks/useAgentPreview";
 import { usePreviewPanelContext } from "@app/components/agent_builder/PreviewPanelContext";
-import {
-  TrialMessageUsage,
-  useIsTrialPlanWithMessageLimit,
-} from "@app/components/app/TrialMessageUsage";
+import { TrialMessageUsage } from "@app/components/app/TrialMessageUsage";
+import { isFreeTrialPhonePlan } from "@app/lib/plans/plan_codes";
+import { useWorkspaceActiveSubscription } from "@app/lib/swr/workspaces";
 import { BlockedActionsProvider } from "@app/components/assistant/conversation/BlockedActionsProvider";
 import ConversationSidePanelContent from "@app/components/assistant/conversation/ConversationSidePanelContent";
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
@@ -161,7 +160,9 @@ function PreviewContent({
 export function AgentBuilderPreview() {
   const { owner, isAdmin } = useAgentBuilderContext();
   const { user } = useUser();
-  const { isTrialPlan } = useIsTrialPlanWithMessageLimit(owner.sId);
+  const { activeSubscription } = useWorkspaceActiveSubscription({ owner });
+  const isTrialPlan =
+    activeSubscription && isFreeTrialPhonePlan(activeSubscription.plan.code);
   const { isMCPServerViewsLoading } = useMCPServerViewsContext();
   const { isPreviewPanelOpen } = usePreviewPanelContext();
 
@@ -296,7 +297,7 @@ export function AgentBuilderPreview() {
         createConversation={createConversation}
         draftAgent={draftAgent}
         isSavingDraftAgent={isSavingDraftAgent}
-        isTrialPlan={isTrialPlan}
+        isTrialPlan={!!isTrialPlan}
         isAdmin={isAdmin}
       />
     );

--- a/front/components/agent_builder/AgentBuilderPreview.tsx
+++ b/front/components/agent_builder/AgentBuilderPreview.tsx
@@ -9,8 +9,6 @@ import {
 } from "@app/components/agent_builder/hooks/useAgentPreview";
 import { usePreviewPanelContext } from "@app/components/agent_builder/PreviewPanelContext";
 import { TrialMessageUsage } from "@app/components/app/TrialMessageUsage";
-import { isFreeTrialPhonePlan } from "@app/lib/plans/plan_codes";
-import { useWorkspaceActiveSubscription } from "@app/lib/swr/workspaces";
 import { BlockedActionsProvider } from "@app/components/assistant/conversation/BlockedActionsProvider";
 import ConversationSidePanelContent from "@app/components/assistant/conversation/ConversationSidePanelContent";
 import { useConversationSidePanelContext } from "@app/components/assistant/conversation/ConversationSidePanelContext";
@@ -19,7 +17,9 @@ import { GenerationContextProvider } from "@app/components/assistant/conversatio
 import { InputBar } from "@app/components/assistant/conversation/input_bar/InputBar";
 import { useMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
 import type { DustError } from "@app/lib/error";
+import { isFreeTrialPhonePlan } from "@app/lib/plans/plan_codes";
 import { useUser } from "@app/lib/swr/user";
+import { useWorkspaceActiveSubscription } from "@app/lib/swr/workspaces";
 import type {
   ContentFragmentsType,
   ConversationWithoutContentType,

--- a/front/components/app/TrialMessageUsage.tsx
+++ b/front/components/app/TrialMessageUsage.tsx
@@ -93,21 +93,3 @@ export function TrialMessageUsage({
     </div>
   );
 }
-
-/**
- * Hook to check if the workspace is on a trial plan with message limits.
- * Returns true if the workspace has a message limit (trial plan), false otherwise.
- */
-export function useIsTrialPlanWithMessageLimit(workspaceId: string): {
-  isTrialPlan: boolean;
-  isLoading: boolean;
-} {
-  const { messageUsage, isMessageUsageLoading } = useTrialMessageUsage({
-    workspaceId,
-  });
-
-  return {
-    isTrialPlan: !!messageUsage && messageUsage.limit !== -1,
-    isLoading: isMessageUsageLoading,
-  };
-}


### PR DESCRIPTION
## Description

The trial message usage component in the agent builder testing tab was being shown to all users with any message limit, not just users on the phone trial plan. This was because `useIsTrialPlanWithMessageLimit` only checked if `messageUsage.limit !== -1`, which is true for any plan with message limits.

**Changes:**
- Changed to use `useWorkspaceActiveSubscription` combined with `isFreeTrialPhonePlan()` - the same approach used in `NavigationSidebar.tsx`
- Removed the misleading `useIsTrialPlanWithMessageLimit` hook

Fixes visibility issue from #20253.

## Tests

- Type check passes
- Manual verification that the logic now matches `NavigationSidebar.tsx`

## Risk

**Low risk** - This is a targeted fix that aligns the agent builder's trial detection with the established pattern in NavigationSidebar.

Rollback: Safe to rollback, no data migrations involved.

## Deploy Plan

Standard deployment, no special considerations needed.