### PR TITLE
[front] Optimize agent configuration save

### DIFF
--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/restore.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/restore.ts
@@ -68,10 +68,7 @@ async function handler(
         agentConfiguration.sId
       );
 
-      if (
-        restoredResult.isErr() ||
-        (restoredResult.isOk() && !restoredResult.value.restored)
-      ) {
+      if (!restoredResult.isOk() || !restoredResult.value.restored) {
         return apiError(req, res, {
           status_code: 500,
           api_error: {

--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/restore.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/restore.ts
@@ -63,12 +63,15 @@ async function handler(
         });
       }
 
-      const restored = await restoreAgentConfiguration(
+      const restoredResult = await restoreAgentConfiguration(
         auth,
         agentConfiguration.sId
       );
 
-      if (!restored) {
+      if (
+        restoredResult.isErr() ||
+        (restoredResult.isOk() && !restoredResult.value.restored)
+      ) {
         return apiError(req, res, {
           status_code: 500,
           api_error: {

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/restore.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/restore.ts
@@ -39,12 +39,15 @@ async function handler(
         });
       }
 
-      const restored = await restoreAgentConfiguration(
+      const restoredResult = await restoreAgentConfiguration(
         auth,
         agentConfiguration.sId
       );
 
-      if (!restored) {
+      if (
+        restoredResult.isErr() ||
+        (restoredResult.isOk() && !restoredResult.value.restored)
+      ) {
         return apiError(req, res, {
           status_code: 500,
           api_error: {

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/restore.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/restore.ts
@@ -44,10 +44,7 @@ async function handler(
         agentConfiguration.sId
       );
 
-      if (
-        restoredResult.isErr() ||
-        (restoredResult.isOk() && !restoredResult.value.restored)
-      ) {
+      if (!restoredResult.isOk() || !restoredResult.value.restored) {
         return apiError(req, res, {
           status_code: 500,
           api_error: {

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/index.ts
@@ -437,28 +437,26 @@ export async function createOrUpgradeAgentConfiguration({
       // the previous version back to `active` status so the agent remains
       // available.
       if (agentConfigurationId) {
-        try {
-          const restored = await restoreAgentConfiguration(
-            auth,
-            agentConfigurationRes.value.sId
-          );
-          if (!restored) {
-            logger.error(
-              {
-                workspaceId: auth.getNonNullableWorkspace().sId,
-                agentConfigurationId: agentConfigurationRes.value.sId,
-              },
-              "Failed to restore previous agent version after action creation error"
-            );
-          }
-        } catch (e) {
+        const restoredResult = await restoreAgentConfiguration(
+          auth,
+          agentConfigurationRes.value.sId
+        );
+        if (restoredResult.isErr()) {
           logger.error(
             {
-              error: e,
+              error: restoredResult.error,
               workspaceId: auth.getNonNullableWorkspace().sId,
               agentConfigurationId: agentConfigurationRes.value.sId,
             },
             "Error while restoring previous agent version after rollback"
+          );
+        } else if (!restoredResult.value.restored) {
+          logger.error(
+            {
+              workspaceId: auth.getNonNullableWorkspace().sId,
+              agentConfigurationId: agentConfigurationRes.value.sId,
+            },
+            "Failed to restore previous agent version after action creation error"
           );
         }
       }


### PR DESCRIPTION
## Description

- This PR optimizes the query done when saving agent configurations with data source or table configurations. We fetch all data source views in the workspace instead of only the ones in the configuration. Some workspaces have > 50k data source views.
- Also refactors `restoreAgentConfiguration` to return a `Result` instead of relying on the caller catching its errors.
- Looking at a few traces we're expecting a relatively minor speedup of ~70ms.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
