### PR TITLE
[dust-hive] Add multi-convention AI config merge for skill directories

### DIFF
--- a/x/henry/dust-hive/src/lib/skills.ts
+++ b/x/henry/dust-hive/src/lib/skills.ts
@@ -1,0 +1,184 @@
+// AI assistant skill merging for multi-convention config directories
+// Handles .claude, .codex, and .agents directories with priority-based merging
+
+import { existsSync, lstatSync, readdirSync, rmSync } from "node:fs";
+import { copyFile, mkdir } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+import { logger } from "./logger";
+
+// AI assistant config directories in priority order (highest first)
+// When merging skills, .claude takes priority over .codex, which takes priority over .agents
+// Note: This only handles skills - other config files in these directories are NOT copied
+export const AI_CONFIG_DIRS = [".claude", ".codex", ".agents"] as const;
+export type AiConfigDir = (typeof AI_CONFIG_DIRS)[number];
+
+export interface SkillEntry {
+  name: string;
+  files: Map<string, string>; // relative path within skill -> absolute source path
+}
+
+// Recursively collect all files in a directory
+// Returns a map of relative path -> absolute path
+// Uses lstatSync to avoid following symlinks (prevents loops and unexpected behavior)
+export function collectFilesRecursively(dir: string, basePath = ""): Map<string, string> {
+  const files = new Map<string, string>();
+
+  if (!existsSync(dir)) {
+    return files;
+  }
+
+  const entries = readdirSync(dir);
+  for (const entry of entries) {
+    const fullPath = join(dir, entry);
+    const relativePath = basePath ? `${basePath}/${entry}` : entry;
+
+    const stat = lstatSync(fullPath);
+    // Skip symlinks to avoid loops and unexpected behavior
+    if (stat.isSymbolicLink()) {
+      continue;
+    }
+    if (stat.isDirectory()) {
+      // Recurse into subdirectories
+      const subFiles = collectFilesRecursively(fullPath, relativePath);
+      for (const [subRelPath, subAbsPath] of subFiles) {
+        files.set(subRelPath, subAbsPath);
+      }
+    } else if (stat.isFile()) {
+      files.set(relativePath, fullPath);
+    }
+  }
+
+  return files;
+}
+
+// Scan a config directory's skills folder and collect all skills with their files
+function collectSkillsFromDir(repoRoot: string, configDir: AiConfigDir): Map<string, SkillEntry> {
+  const skills = new Map<string, SkillEntry>();
+  const skillsPath = join(repoRoot, configDir, "skills");
+
+  if (!existsSync(skillsPath)) {
+    return skills;
+  }
+
+  const entries = readdirSync(skillsPath);
+  for (const entry of entries) {
+    const skillPath = join(skillsPath, entry);
+    const stat = lstatSync(skillPath);
+    // Skip symlinks and non-directories
+    if (stat.isSymbolicLink() || !stat.isDirectory()) {
+      continue;
+    }
+
+    const files = collectFilesRecursively(skillPath);
+    skills.set(entry, {
+      name: entry,
+      files,
+    });
+  }
+
+  return skills;
+}
+
+// Merge skill maps with whole-skill override semantics
+// When the same skill exists in multiple config dirs, the highest priority version wins entirely
+// (no per-file merging to avoid mixed/partial skill definitions)
+export function mergeSkills(
+  repoRoot: string,
+  configDirs: readonly AiConfigDir[]
+): Map<string, SkillEntry> {
+  const merged = new Map<string, SkillEntry>();
+
+  // Process in reverse order (lowest priority first: .agents → .codex → .claude)
+  // so that higher priority sources completely overwrite lower priority ones
+  const reversedDirs = [...configDirs].reverse();
+
+  for (const configDir of reversedDirs) {
+    const skills = collectSkillsFromDir(repoRoot, configDir);
+
+    for (const [skillName, skill] of skills) {
+      // Whole-skill override: higher priority completely replaces lower priority
+      merged.set(skillName, {
+        name: skill.name,
+        files: new Map(skill.files),
+      });
+    }
+  }
+
+  return merged;
+}
+
+// Load dust-hive skill from the dust-hive tool's own skills directory
+function getDustHiveSkill(dustHiveRoot: string): SkillEntry | null {
+  const skillPath = join(dustHiveRoot, ".claude", "skills", "dust-hive");
+
+  if (!existsSync(skillPath)) {
+    return null;
+  }
+
+  const files = collectFilesRecursively(skillPath);
+  return {
+    name: "dust-hive",
+    files,
+  };
+}
+
+// Write merged skills to one config directory
+// Cleans up each skill directory before writing to avoid stale files from previous runs
+async function writeSkillsToConfigDir(
+  skills: Map<string, SkillEntry>,
+  destRoot: string,
+  configDir: AiConfigDir
+): Promise<void> {
+  const skillsDir = join(destRoot, configDir, "skills");
+
+  for (const [skillName, skill] of skills) {
+    const skillDestDir = join(skillsDir, skillName);
+
+    // Clean up existing skill directory to avoid stale files
+    if (existsSync(skillDestDir)) {
+      rmSync(skillDestDir, { recursive: true, force: true });
+    }
+
+    for (const [relativePath, sourcePath] of skill.files) {
+      const destPath = join(skillDestDir, relativePath);
+      const destDir = dirname(destPath);
+
+      await mkdir(destDir, { recursive: true });
+      await copyFile(sourcePath, destPath);
+    }
+  }
+}
+
+// Main orchestration: collect skills from all AI config dirs, merge with priority,
+// inject dust-hive skill, and write to all three config directories in the target worktree
+export async function copyMergedSkills(
+  srcDir: string,
+  destDir: string,
+  dustHiveRoot: string
+): Promise<void> {
+  // Step 1: Collect and merge skills from all config dirs
+  const mergedSkills = mergeSkills(srcDir, AI_CONFIG_DIRS);
+
+  // Step 2: Inject dust-hive skill (always overwrites any existing)
+  const dustHiveSkill = getDustHiveSkill(dustHiveRoot);
+  if (dustHiveSkill) {
+    mergedSkills.set("dust-hive", dustHiveSkill);
+  } else {
+    logger.warn("dust-hive skill not found, skipping injection");
+  }
+
+  // Step 3: Write merged skills to all three config directories
+  const writePromises: Promise<void>[] = [];
+  for (const configDir of AI_CONFIG_DIRS) {
+    writePromises.push(writeSkillsToConfigDir(mergedSkills, destDir, configDir));
+  }
+  await Promise.all(writePromises);
+
+  // Log summary
+  const skillCount = mergedSkills.size;
+  if (skillCount > 0) {
+    const skillNames = [...mergedSkills.keys()].join(", ");
+    logger.success(`Merged ${skillCount} skill(s) to .claude/, .codex/, .agents/: ${skillNames}`);
+  }
+}

--- a/x/henry/dust-hive/tests/lib/skills.test.ts
+++ b/x/henry/dust-hive/tests/lib/skills.test.ts
@@ -1,0 +1,156 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { AI_CONFIG_DIRS, collectFilesRecursively, mergeSkills } from "../../src/lib/skills";
+
+describe("skills", () => {
+  const testDir = "/tmp/dust-hive-test-skills";
+
+  beforeAll(() => {
+    // Clean up any previous test artifacts
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  afterAll(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  describe("collectFilesRecursively", () => {
+    const filesDir = join(testDir, "collect-files");
+
+    beforeAll(() => {
+      mkdirSync(join(filesDir, "subdir"), { recursive: true });
+      writeFileSync(join(filesDir, "file1.txt"), "content1");
+      writeFileSync(join(filesDir, "file2.md"), "content2");
+      writeFileSync(join(filesDir, "subdir", "nested.txt"), "nested content");
+    });
+
+    it("collects files from a directory", () => {
+      const files = collectFilesRecursively(filesDir);
+      expect(files.size).toBe(3);
+      expect(files.has("file1.txt")).toBe(true);
+      expect(files.has("file2.md")).toBe(true);
+      expect(files.has("subdir/nested.txt")).toBe(true);
+    });
+
+    it("returns absolute paths as values", () => {
+      const files = collectFilesRecursively(filesDir);
+      expect(files.get("file1.txt")).toBe(join(filesDir, "file1.txt"));
+      expect(files.get("subdir/nested.txt")).toBe(join(filesDir, "subdir", "nested.txt"));
+    });
+
+    it("returns empty map for non-existent directory", () => {
+      const files = collectFilesRecursively("/non/existent/path");
+      expect(files.size).toBe(0);
+    });
+
+    it("skips symlinks to avoid loops", () => {
+      const symlinkDir = join(testDir, "symlink-test");
+      mkdirSync(symlinkDir, { recursive: true });
+      writeFileSync(join(symlinkDir, "real-file.txt"), "real");
+
+      // Create a symlink that would cause a loop
+      symlinkSync(symlinkDir, join(symlinkDir, "loop-link"));
+
+      const files = collectFilesRecursively(symlinkDir);
+      expect(files.size).toBe(1);
+      expect(files.has("real-file.txt")).toBe(true);
+      expect(files.has("loop-link")).toBe(false);
+    });
+  });
+
+  describe("mergeSkills", () => {
+    const mergeDir = join(testDir, "merge-skills");
+
+    beforeAll(() => {
+      // Create skills in .claude (highest priority)
+      mkdirSync(join(mergeDir, ".claude", "skills", "skill-a"), { recursive: true });
+      writeFileSync(join(mergeDir, ".claude", "skills", "skill-a", "SKILL.md"), "from claude");
+
+      // Create skills in .codex (medium priority)
+      mkdirSync(join(mergeDir, ".codex", "skills", "skill-a"), { recursive: true });
+      writeFileSync(join(mergeDir, ".codex", "skills", "skill-a", "SKILL.md"), "from codex");
+      writeFileSync(join(mergeDir, ".codex", "skills", "skill-a", "extra.txt"), "codex extra");
+
+      mkdirSync(join(mergeDir, ".codex", "skills", "skill-b"), { recursive: true });
+      writeFileSync(join(mergeDir, ".codex", "skills", "skill-b", "SKILL.md"), "codex skill-b");
+
+      // Create skills in .agents (lowest priority)
+      mkdirSync(join(mergeDir, ".agents", "skills", "skill-a"), { recursive: true });
+      writeFileSync(join(mergeDir, ".agents", "skills", "skill-a", "SKILL.md"), "from agents");
+
+      mkdirSync(join(mergeDir, ".agents", "skills", "skill-c"), { recursive: true });
+      writeFileSync(join(mergeDir, ".agents", "skills", "skill-c", "SKILL.md"), "agents skill-c");
+    });
+
+    it("merges skills from all config directories", () => {
+      const skills = mergeSkills(mergeDir, AI_CONFIG_DIRS);
+      expect(skills.size).toBe(3);
+      expect(skills.has("skill-a")).toBe(true);
+      expect(skills.has("skill-b")).toBe(true);
+      expect(skills.has("skill-c")).toBe(true);
+    });
+
+    it("uses whole-skill override semantics (highest priority wins entirely)", () => {
+      const skills = mergeSkills(mergeDir, AI_CONFIG_DIRS);
+      const skillA = skills.get("skill-a");
+
+      // skill-a from .claude should completely replace lower priority versions
+      if (!skillA) {
+        throw new Error("skill-a should exist");
+      }
+      expect(skillA.files.size).toBe(1); // Only SKILL.md from claude, not extra.txt from codex
+      expect(skillA.files.has("SKILL.md")).toBe(true);
+      expect(skillA.files.has("extra.txt")).toBe(false); // codex's extra file not merged
+    });
+
+    it("preserves skills unique to lower priority directories", () => {
+      const skills = mergeSkills(mergeDir, AI_CONFIG_DIRS);
+
+      // skill-b only exists in .codex
+      const skillB = skills.get("skill-b");
+      if (!skillB) {
+        throw new Error("skill-b should exist");
+      }
+      expect(skillB.files.has("SKILL.md")).toBe(true);
+
+      // skill-c only exists in .agents
+      const skillC = skills.get("skill-c");
+      if (!skillC) {
+        throw new Error("skill-c should exist");
+      }
+      expect(skillC.files.has("SKILL.md")).toBe(true);
+    });
+
+    it("returns empty map when no config directories exist", () => {
+      const skills = mergeSkills("/non/existent/path", AI_CONFIG_DIRS);
+      expect(skills.size).toBe(0);
+    });
+
+    it("handles partial config directories (some missing)", () => {
+      const partialDir = join(testDir, "partial-merge");
+      mkdirSync(join(partialDir, ".claude", "skills", "only-claude"), { recursive: true });
+      writeFileSync(
+        join(partialDir, ".claude", "skills", "only-claude", "SKILL.md"),
+        "claude only"
+      );
+      // .codex and .agents don't exist
+
+      const skills = mergeSkills(partialDir, AI_CONFIG_DIRS);
+      expect(skills.size).toBe(1);
+      expect(skills.has("only-claude")).toBe(true);
+    });
+  });
+
+  describe("AI_CONFIG_DIRS", () => {
+    it("has correct priority order (highest first)", () => {
+      expect(AI_CONFIG_DIRS[0]).toBe(".claude");
+      expect(AI_CONFIG_DIRS[1]).toBe(".codex");
+      expect(AI_CONFIG_DIRS[2]).toBe(".agents");
+    });
+
+    it("has exactly 3 config directories", () => {
+      expect(AI_CONFIG_DIRS.length).toBe(3);
+    });
+  });
+});


### PR DESCRIPTION
## Description

Updates dust-hive's `spawn` command to merge skills from `.claude`, `.codex`, and `.agents` directories when creating new environments. Skills are merged with priority order (`.claude > .codex > .agents`), and the merged result is written to all three directories in the target worktree.

**Key changes:**
- Added `AI_CONFIG_DIRS` constant defining the three config directories in priority order
- Implemented recursive file collection for skill directories
- Added merge logic that processes lower-priority directories first so higher-priority ones overwrite
- The `dust-hive` skill is always injected from the dust-hive tool's own config
- Merged skills are written to `.claude/skills/`, `.codex/skills/`, and `.agents/skills/` in the worktree

**Why this matters:**
- Enables skill sharing across different AI coding assistants (Claude Code, Codex, etc.)
- Maintains clear precedence when the same skill exists in multiple config directories
- Ensures all AI assistants have access to the same skill definitions regardless of which config directory they use

## Tests

- [x] Ran `bun run check` (typecheck + lint + test) - all 170 tests pass

Manual verification:
```bash
# Create test fixtures in main repo
mkdir -p .claude/skills/skill-a && echo "from claude" > .claude/skills/skill-a/SKILL.md
mkdir -p .codex/skills/skill-a && echo "from codex" > .codex/skills/skill-a/SKILL.md
mkdir -p .codex/skills/skill-b && echo "codex only" > .codex/skills/skill-b/SKILL.md

# Spawn new env
dust-hive spawn test-merge

# Expected in worktree:
# - .claude/skills/, .codex/skills/, .agents/skills/ all exist
# - skill-a/SKILL.md contains "from claude" (not "from codex")
# - skill-b exists in all three
# - dust-hive skill exists in all three
```

## Risk

**Low** - Changes are isolated to the skill merging logic during spawn. Existing functionality for AGENTS.local.md copying remains unchanged. The merge algorithm gracefully handles missing directories.

## Deploy Plan

No deployment required - this is a local development tool (dust-hive). Users will get the update when they pull the latest code.