### PR TITLE
[dust-hive] Add --sync flag to spawn command

### DIFF
--- a/x/henry/dust-hive/src/commands/spawn.ts
+++ b/x/henry/dust-hive/src/commands/spawn.ts
@@ -21,6 +21,7 @@ import { installAllDependencies } from "../lib/setup";
 import { createTestDatabase, isTestPostgresRunning } from "../lib/test-postgres";
 import { cleanupPartialEnvironment, createWorktree, getMainRepoPath } from "../lib/worktree";
 import { openCommand } from "./open";
+import { syncCommand } from "./sync";
 import { warmCommand } from "./warm";
 
 interface SpawnOptions {
@@ -33,6 +34,7 @@ interface SpawnOptions {
   command?: string;
   compact?: boolean;
   unifiedLogs?: boolean;
+  sync?: boolean;
 }
 
 async function promptForName(): Promise<string> {
@@ -213,6 +215,17 @@ async function startSdk(
 }
 
 export async function spawnCommand(options: SpawnOptions): Promise<Result<void>> {
+  // Run sync first if requested
+  if (options.sync) {
+    logger.info("Running sync before spawn...");
+    console.log();
+    const syncResult = await syncCommand({});
+    if (!syncResult.ok) {
+      return syncResult;
+    }
+    console.log();
+  }
+
   // Find repo root (could be main repo or worktree)
   const currentRepoRoot = await findRepoRoot();
   if (!currentRepoRoot) {

--- a/x/henry/dust-hive/src/index.ts
+++ b/x/henry/dust-hive/src/index.ts
@@ -58,6 +58,7 @@ cli
   .option("-c, --command <cmd>", "Run command in shell tab after opening (drops to shell on exit)")
   .option("-C, --compact", "Use compact layout (no tab bar)")
   .option("-u, --unified-logs", "Use single unified logs tab instead of per-service tabs")
+  .option("-S, --sync", "Run dust-hive sync before spawning")
   .action(
     async (
       name: string | undefined,
@@ -71,6 +72,7 @@ cli
         command?: string;
         compact?: boolean;
         unifiedLogs?: boolean;
+        sync?: boolean;
       }
     ) => {
       // Validate --wait cannot be used with --no-open
@@ -90,6 +92,7 @@ cli
         command?: string;
         compact?: boolean;
         unifiedLogs?: boolean;
+        sync?: boolean;
       } = {};
       if (resolvedName !== undefined) {
         spawnOptions.name = resolvedName;
@@ -117,6 +120,9 @@ cli
       }
       if (options.unifiedLogs) {
         spawnOptions.unifiedLogs = true;
+      }
+      if (options.sync) {
+        spawnOptions.sync = true;
       }
       await prepareAndRun(spawnCommand(spawnOptions));
     }


### PR DESCRIPTION
## Description

Adds a `--sync` / `-S` flag to the `dust-hive spawn` command that automatically runs `dust-hive sync` before creating a new environment.

This is useful when you want to ensure you have the latest main, rebuilt binaries, and refreshed dependencies before spawning a new environment, without having to run two separate commands.

**Usage:**
```bash
dust-hive spawn my-env --sync    # Sync then create environment
dust-hive spawn my-env -S        # Short form
dust-hive s my-env -S -w         # Combine with other flags like --warm
```

## Tests

- Ran `bun run check` which runs typecheck, lint, and all 170 tests - all passing

## Risk

Low - This is an additive feature that only runs sync when explicitly requested via the flag. No changes to existing spawn behavior.

## Deploy Plan

No deploy needed - dust-hive is a local CLI tool. Users will get the update on next `dust-hive sync`.