### PR TITLE
[front] fix(provisioning): add fallback on `emails` in WorkOS events processing

### DIFF
--- a/front/lib/api/workos/user.ts
+++ b/front/lib/api/workos/user.ts
@@ -274,18 +274,22 @@ export async function fetchOrCreateWorkOSUserWithEmail({
     workspaceId: workspace.sId,
   });
 
-  if (workOSUser.email == null) {
-    return new Err(new Error("Missing email"));
+  let email = workOSUser.email;
+  if (!email) {
+    email = workOSUser.emails.find((e) => e.primary)?.value ?? null;
+    if (!email) {
+      return new Err(new Error("Missing email"));
+    }
   }
 
   const workOSUserResponse = await getWorkOS().userManagement.listUsers({
-    email: workOSUser.email,
+    email,
   });
 
   const [existingUser] = workOSUserResponse.data;
   if (!existingUser) {
     const createdUser = await getWorkOS().userManagement.createUser({
-      email: workOSUser.email,
+      email,
       firstName: workOSUser.firstName ?? undefined,
       lastName: workOSUser.lastName ?? undefined,
       metadata: {


### PR DESCRIPTION
## Description

- We currently have an event stuck ([workflow](https://cloud.temporal.io/namespaces/eu-dust-front-prod.gmnlm/workflows/workos-events-dsync.user.updated-event_01KFCH04T49Z94NS13556FVPX2-1768873299021/019bd910-8c5e-773b-9ad9-21ba60df784b/history)) with a missing `email` field.
- The payload has a list of emails in the `emails` field, the one with `primary: true` matches the actual user on WorkOS.
- This PR adds a fallback on the primary email when the `email` field is empty.

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
