### PR TITLE
[front] fix: Make inline generated image respect layout

### DIFF
--- a/front/components/actions/mcp/details/MCPActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPActionDetails.tsx
@@ -432,15 +432,18 @@ export function GenericActionDetails({
           {action.generatedFiles.filter((f) => !f.hidden).length > 0 && (
             <>
               <span className="heading-base">Generated Files</span>
-              <div className="flex flex-col gap-1">
+              <div className="flex flex-wrap gap-2">
                 {action.generatedFiles
                   .filter((file) => !file.hidden)
                   .map((file) => {
                     if (isSupportedImageContentType(file.contentType)) {
                       return (
-                        <div key={file.fileId} className="mr-5">
+                        <div
+                          key={file.fileId}
+                          className="h-24 w-24 flex-shrink-0"
+                        >
                           <img
-                            className="rounded-xl"
+                            className="h-full w-full rounded-xl object-cover"
                             src={`/api/w/${owner.sId}/files/${file.fileId}`}
                             alt={`${file.title}`}
                           />

--- a/front/components/assistant/conversation/attachment/AttachmentCitation.tsx
+++ b/front/components/assistant/conversation/attachment/AttachmentCitation.tsx
@@ -5,6 +5,7 @@ import {
   CitationIcons,
   CitationImage,
   CitationTitle,
+  cn,
   Icon,
   Tooltip,
 } from "@dust-tt/sparkle";
@@ -81,7 +82,7 @@ export function AttachmentCitation({
           <Citation
             {...dialogOrDownloadProps}
             isLoading={isLoading}
-            containerClassName="s-h-full"
+            containerClassName={cn("s-h-full", isImage && "s-aspect-square")}
             action={
               !isImage &&
               attachmentCitation.onRemove && (

--- a/sparkle/src/components/InteractiveImageGrid.tsx
+++ b/sparkle/src/components/InteractiveImageGrid.tsx
@@ -5,9 +5,9 @@ import { ImageZoomDialog } from "@sparkle/components/ImageZoomDialog";
 import { cn } from "@sparkle/lib/utils";
 
 const SIZE_CLASSES = {
-  sm: "s-h-24 s-w-24",
-  md: "s-h-48 s-w-48",
-  lg: "s-h-80 s-w-80",
+  sm: "s-relative s-h-24 s-w-24",
+  md: "s-relative s-h-48 s-w-48",
+  lg: "s-relative s-h-80 s-w-80",
 } as const;
 
 type InteractiveImageGridSize = keyof typeof SIZE_CLASSES;
@@ -101,7 +101,7 @@ function InteractiveImageGrid({
                 downloadUrl={image.downloadUrl}
                 isLoading={image.isLoading}
                 onClick={() => setCurrentImageIndex(idx)}
-                variant="embedded"
+                variant="standalone"
                 titlePosition="center"
                 manageZoomDialog={false}
               />


### PR DESCRIPTION
## Description

Currently generated image don't respect the layout 

<details><summary>Before</summary>
<p>

<img width="2225" height="694" alt="CleanShot 2026-01-20 at 09 08 35" src="https://github.com/user-attachments/assets/5f1268d6-9c93-437d-9cbd-1a20081de1f6" />


</p>
</details> 

<details><summary>After</summary>
<p>

<img width="1049" height="755" alt="CleanShot 2026-01-20 at 09 09 25" src="https://github.com/user-attachments/assets/1729284c-b9f7-4c0e-94f1-c5a5c5354df3" />

</p>
</details> 

## Tests

Tested manually

## Risk

Low

## Deploy Plan

- [ ] Deploy front