### PR TITLE
fix: copy/pasting of instruction blocks

### DIFF
--- a/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
+++ b/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
@@ -26,6 +26,7 @@ import { KeyboardShortcutsExtension } from "@app/components/editor/extensions/in
 import { ListItemExtension } from "@app/components/editor/extensions/ListItemExtension";
 import { MentionExtension } from "@app/components/editor/extensions/MentionExtension";
 import { OrderedListExtension } from "@app/components/editor/extensions/OrderedListExtension";
+import { cleanupPastedHTML } from "@app/components/editor/input_bar/cleanupPastedHTML";
 import { createMentionSuggestion } from "@app/components/editor/input_bar/mentionSuggestion";
 import type { LightAgentConfigurationType } from "@app/types";
 
@@ -214,6 +215,13 @@ export function AgentBuilderInstructionsEditor({
         window.dispatchEvent(new CustomEvent(BLUR_EVENT_NAME));
         return false;
       },
+      editorProps: {
+        // Cleans up incoming HTML to remove Chrome-specific wrapper tags (e.g., <b style="font-weight:normal">)
+        // that interfere with instruction block parsing
+        transformPastedHTML(html: string) {
+          return cleanupPastedHTML(html);
+        },
+      },
       immediatelyRender: false,
     },
     [extensions]
@@ -277,6 +285,10 @@ export function AgentBuilderInstructionsEditor({
       editorProps: {
         attributes: {
           class: editorVariants({ error: displayError }),
+        },
+        // Preserve the transformPastedHTML handler when updating editorProps
+        transformPastedHTML(html: string) {
+          return cleanupPastedHTML(html);
         },
       },
     });


### PR DESCRIPTION
## Description

Fix copy/pasting in the agent builder from chrome, fixes https://github.com/dust-tt/tasks/issues/5973#issuecomment-3769585098

The root cause is chrome is adding `<b>` tags when copy/pasting. That was putting the copied instruction blocks as bold, hence it was not recognize as such. 

## Tests

Locally on chrome and firefox

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
