### PR TITLE
[Front] fix(mcp): add resource parameter in OAuth flow to conform with RFC 8707

### DIFF
--- a/core/src/oauth/providers/mcp.rs
+++ b/core/src/oauth/providers/mcp.rs
@@ -25,6 +25,7 @@ pub struct MCPConnectionMetadata {
     pub code_verifier: String,
     pub code_challenge: String,
     pub scope: Option<String>,
+    pub resource: Option<String>,
 }
 
 pub struct MCPConnectionProvider {}

--- a/front/lib/actions/mcp_oauth_provider.ts
+++ b/front/lib/actions/mcp_oauth_provider.ts
@@ -1,3 +1,5 @@
+import url from "node:url";
+
 import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js";
 import type {
   OAuthClientInformationFull,
@@ -15,7 +17,7 @@ export class MCPOAuthProvider implements OAuthClientProvider {
   private token: OAuthTokens | undefined;
   private auth: Authenticator;
   private metadata: OAuthMetadata | undefined;
-  private resource: URL | undefined;
+  private resource: string | undefined;
 
   constructor(auth: Authenticator, tokens?: OAuthTokens) {
     this.auth = auth;
@@ -48,7 +50,9 @@ export class MCPOAuthProvider implements OAuthClientProvider {
   ): void | Promise<void> {
     // Save for a later step.
     this.metadata = metadata;
-    this.resource = resource;
+    if (resource) {
+      this.resource = url.format(resource, { fragment: false });
+    }
   }
 
   clientInformation(): OAuthClientInformationFull | undefined {
@@ -91,7 +95,7 @@ export class MCPOAuthProvider implements OAuthClientProvider {
       client_secret: clientInformation.client_secret || "",
       token_endpoint: this.metadata.token_endpoint,
       authorization_endpoint: this.metadata.authorization_endpoint,
-      resource: this.resource?.toString(),
+      resource: this.resource,
     });
   }
 

--- a/front/lib/actions/mcp_oauth_provider.ts
+++ b/front/lib/actions/mcp_oauth_provider.ts
@@ -15,6 +15,7 @@ export class MCPOAuthProvider implements OAuthClientProvider {
   private token: OAuthTokens | undefined;
   private auth: Authenticator;
   private metadata: OAuthMetadata | undefined;
+  private resource: URL | undefined;
 
   constructor(auth: Authenticator, tokens?: OAuthTokens) {
     this.auth = auth;
@@ -41,11 +42,13 @@ export class MCPOAuthProvider implements OAuthClientProvider {
     };
   }
 
-  saveAuthorizationServerMetadata(
-    metadata?: OAuthMetadata
+  saveAuthorizationServerMetadataAndResource(
+    metadata?: OAuthMetadata,
+    resource?: URL
   ): void | Promise<void> {
     // Save for a later step.
     this.metadata = metadata;
+    this.resource = resource;
   }
 
   clientInformation(): OAuthClientInformationFull | undefined {
@@ -88,6 +91,7 @@ export class MCPOAuthProvider implements OAuthClientProvider {
       client_secret: clientInformation.client_secret || "",
       token_endpoint: this.metadata.token_endpoint,
       authorization_endpoint: this.metadata.authorization_endpoint,
+      resource: this.resource?.toString(),
     });
   }
 

--- a/front/lib/api/oauth/providers/mcp.ts
+++ b/front/lib/api/oauth/providers/mcp.ts
@@ -34,6 +34,7 @@ const BaseMCPMetadataSchema = z.object({
 const MCPOAuthConnectionMetadataSchema = BaseMCPMetadataSchema.extend({
   client_secret: z.string().optional(),
   scope: z.string().optional(),
+  resource: z.string().optional(),
 });
 
 const MCPMetadataSchema = BaseMCPMetadataSchema.extend({
@@ -60,6 +61,7 @@ export class MCPOAuthProvider implements BaseOAuthStrategyProvider {
     const client_id = connection.metadata.client_id;
     const authorization_endpoint = connection.metadata.authorization_endpoint;
     const scope = connection.metadata.scope;
+    const resource = connection.metadata.resource;
 
     if (!code_challenge) {
       throw new Error("Missing code challenge");
@@ -88,6 +90,10 @@ export class MCPOAuthProvider implements BaseOAuthStrategyProvider {
 
     if (scope) {
       authUrl.searchParams.set("scope", scope);
+    }
+
+    if (resource) {
+      authUrl.searchParams.set("resource", resource);
     }
 
     return authUrl.toString();
@@ -235,6 +241,7 @@ export class MCPOAuthProvider implements BaseOAuthStrategyProvider {
           token_endpoint: connection.metadata.token_endpoint,
           authorization_endpoint: connection.metadata.authorization_endpoint,
           scope: connection.metadata.scope,
+          resource: connection.metadata.resource,
           code_verifier,
           code_challenge,
           ...restConfig,

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -28,7 +28,7 @@
         "@mendable/firecrawl-js": "^1.29.1",
         "@microsoft/microsoft-graph-client": "^3.0.7",
         "@mistralai/mistralai": "^1.10.0",
-        "@modelcontextprotocol/sdk": "git://github.com:dust-tt/typescript-sdk.git#4a3d6b942e3982c818acd529de9b574c92776a2e",
+        "@modelcontextprotocol/sdk": "git://github.com:dust-tt/typescript-sdk.git#77ce858cd0dd10025a068b897dc29c2c9303fe17",
         "@notionhq/client": "^2.3.0",
         "@novu/framework": "^2.7.1",
         "@novu/js": "^3.11.0",
@@ -5129,8 +5129,8 @@
     },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.20.1",
-      "resolved": "git+ssh://git@github.com/dust-tt/typescript-sdk.git#4a3d6b942e3982c818acd529de9b574c92776a2e",
-      "integrity": "sha512-VH2xjzEUtvyjE16Oni07beE1InChx5EZOAgSO3USqUroVs0LVvm9FMl/To4doW4ZF3a58EEg/tXxiMtCRkU5aQ==",
+      "resolved": "git+ssh://git@github.com/dust-tt/typescript-sdk.git#77ce858cd0dd10025a068b897dc29c2c9303fe17",
+      "integrity": "sha512-ApZarpFzkMf1u3uXVugLGq94Y+Rg4sJUEzQLMONRE/BJ3vWSiTl6JEh7rctCc2V/6Eh73840m7MR9NxmsdvSVg==",
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.6",

--- a/front/package.json
+++ b/front/package.json
@@ -54,7 +54,7 @@
     "@mendable/firecrawl-js": "^1.29.1",
     "@microsoft/microsoft-graph-client": "^3.0.7",
     "@mistralai/mistralai": "^1.10.0",
-    "@modelcontextprotocol/sdk": "git://github.com:dust-tt/typescript-sdk.git#4a3d6b942e3982c818acd529de9b574c92776a2e",
+    "@modelcontextprotocol/sdk": "git://github.com:dust-tt/typescript-sdk.git#77ce858cd0dd10025a068b897dc29c2c9303fe17",
     "@notionhq/client": "^2.3.0",
     "@novu/framework": "^2.7.1",
     "@novu/js": "^3.11.0",

--- a/front/types/oauth/lib.ts
+++ b/front/types/oauth/lib.ts
@@ -91,6 +91,7 @@ const SUPPORTED_OAUTH_CREDENTIALS = [
   "code_verifier",
   "code_challenge",
   "scope",
+  "resource",
   "token_endpoint",
   "authorization_endpoint",
   "freshservice_domain",


### PR DESCRIPTION
## Description

Followup of : https://github.com/dust-tt/typescript-sdk/pull/4
Should fix : https://github.com/dust-tt/tasks/issues/5741

Retrieves the `resource` parameter from the authorization server, save it in connection metadata in `oauth`, and finally pass it when building the mcp oauth setup URI 

## Tests

Tested locally with custom MCP:
- `resource` is correctly set in connection metadata jsonb in oauth db :
```
{
  "user_id": "Hg1ohlOslS",
  "resource": "https://disepalous-an-wineless.ngrok-free.dev/mcp",
  "use_case": "platform_actions",
  "client_id": "f4c39d13-4697-4a72-af32-df810428690a",
  "workspace_id": "JcByDeb8lg",
  "code_verifier": "20c4e2686378c52d992b470f2285309b54c0fbddc2b67793df3ea6841c659a2e",
  "code_challenge": "664JFc0ucN3HgXW_NMp2O91aWEI3LqLMlHtU7PAT_V4",
  "token_endpoint": "https://disepalous-an-wineless.ngrok-free.dev/oauth/token",
  "authorization_endpoint": "https://disepalous-an-wineless.ngrok-free.dev/oauth/authorize"
}
```

- `resource` is correctly set in setupURI :
```
https://disepalous-an-wineless.ngrok-free.dev/oauth/authorize?response_type=code

client_id=f4c39d13-4697-4a72-af32-df810428690a

code_challenge=664JFc0ucN3HgXW_NMp2O91aWEI3LqLMlHtU7PAT_V4

code_challenge_method=S256

redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Foauth%2Fmcp%2Ffinalize

state=con_ARsg16bH7i-38baf12e7ea6293047dd01460e44d77c799c8a497dc97cf62a1930c8c1b0e447

resource=https%3A%2F%2Fdisepalous-an-wineless.ngrok-free.dev%2Fmcp
```

## Risk

Low.

## Deploy Plan

Oauth, then Front.