### PR TITLE
Create and edit permissions on projects

### DIFF
--- a/front/components/assistant/conversation/space/about/SpaceAboutTab.tsx
+++ b/front/components/assistant/conversation/space/about/SpaceAboutTab.tsx
@@ -290,7 +290,7 @@ export function SpaceAboutTab({
       await doUpdate(space, {
         isRestricted,
         groupIds: selectedGroups.map((group) => group.sId),
-        editorGroupIds: [],
+        editorGroupIds: [], // todo(projects): handle editor groups in the UI
         managementMode: "group",
         name: space.name,
       });
@@ -298,7 +298,7 @@ export function SpaceAboutTab({
       await doUpdate(space, {
         isRestricted,
         memberIds: selectedMembers.map((member) => member.sId),
-        editorIds: [],
+        editorIds: [], // todo(projects): handle editors in the UI
         managementMode: "manual",
         name: space.name,
       });

--- a/front/components/assistant/conversation/space/about/SpaceAboutTab.tsx
+++ b/front/components/assistant/conversation/space/about/SpaceAboutTab.tsx
@@ -290,6 +290,7 @@ export function SpaceAboutTab({
       await doUpdate(space, {
         isRestricted,
         groupIds: selectedGroups.map((group) => group.sId),
+        editorGroupIds: [],
         managementMode: "group",
         name: space.name,
       });
@@ -297,6 +298,7 @@ export function SpaceAboutTab({
       await doUpdate(space, {
         isRestricted,
         memberIds: selectedMembers.map((member) => member.sId),
+        editorIds: [],
         managementMode: "manual",
         name: space.name,
       });

--- a/front/components/spaces/CreateOrEditSpaceModal.tsx
+++ b/front/components/spaces/CreateOrEditSpaceModal.tsx
@@ -200,6 +200,7 @@ export function CreateOrEditSpaceModal({
         await doUpdate(space, {
           isRestricted,
           groupIds: selectedGroups.map((group) => group.sId),
+          editorGroupIds: [],
           managementMode: "group",
           name: trimmedName,
         });
@@ -207,6 +208,7 @@ export function CreateOrEditSpaceModal({
         await doUpdate(space, {
           isRestricted,
           memberIds: selectedMembers.map((vm) => vm.sId),
+          editorIds: [],
           managementMode: "manual",
           name: trimmedName,
         });

--- a/front/lib/api/spaces.test.ts
+++ b/front/lib/api/spaces.test.ts
@@ -614,7 +614,7 @@ describe("createSpaceAndGroup", () => {
       expect(result.isOk()).toBe(true);
       if (result.isOk()) {
         const space = result.value;
-        expect(space.isRegularAndRestricted()).toBe(false);
+        expect(space.isOpen()).toBe(true);
 
         // Verify global group was added with kind "member"
         const groupSpace = await GroupSpaceModel.findOne({
@@ -647,6 +647,7 @@ describe("createSpaceAndGroup", () => {
       if (result.isOk()) {
         const space = result.value;
         expect(space.kind).toBe("project");
+        expect(space.isOpen()).toBe(true);
 
         // Verify global group was added with kind "project_viewer"
         const groupSpace = await GroupSpaceModel.findOne({

--- a/front/lib/api/spaces.test.ts
+++ b/front/lib/api/spaces.test.ts
@@ -9,6 +9,7 @@ import { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
+import { GroupSpaceMemberResource } from "@app/lib/resources/group_space_resource";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces";
@@ -617,15 +618,11 @@ describe("createSpaceAndGroup", () => {
         expect(space.isOpen()).toBe(true);
 
         // Verify global group was added with kind "member"
-        const groupSpace = await GroupSpaceModel.findOne({
-          where: {
-            vaultId: space.id,
-            workspaceId: workspace.id,
-            groupId: globalGroup.id,
-          },
+        const groupSpaces = await GroupSpaceMemberResource.fetchBySpace({
+          space,
         });
-        expect(groupSpace).toBeDefined();
-        expect(groupSpace?.kind).toBe("member");
+        expect(groupSpaces.length).toBeGreaterThan(0);
+        expect(groupSpaces.some((gs) => gs.group.kind === "global")).toBe(true);
       }
     });
 

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -17,7 +17,6 @@ import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import {
-  GroupSpaceEditorResource,
   GroupSpaceMemberResource,
 } from "@app/lib/resources/group_space_resource";
 import { KeyResource } from "@app/lib/resources/key_resource";

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -466,7 +466,7 @@ export async function createSpaceAndGroup(
     // Handle member-based space creation
     if (params.managementMode === "manual") {
       let editorGroup: GroupResource | undefined;
-      // Handle editor group if editorIds are provided
+      // Handle editor group if editorIds are provided (for project spaces only)
       if (
         space.isProject() &&
         params.editorIds &&

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -21,6 +21,7 @@ import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_res
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
+import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_view_resource";
@@ -37,7 +38,6 @@ import {
   removeNulls,
   SPACE_GROUP_PREFIX,
 } from "@app/types";
-import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces";
 
 export async function softDeleteSpaceAndLaunchScrubWorkflow(
   auth: Authenticator,

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -20,7 +20,7 @@ import { KeyResource } from "@app/lib/resources/key_resource";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
-import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces";
+import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_view_resource";
@@ -43,11 +43,18 @@ export async function softDeleteSpaceAndLaunchScrubWorkflow(
   space: SpaceResource,
   force?: boolean
 ) {
-  assert(auth.isAdmin(), "Only admins can delete spaces.");
   assert(
     space.isRegular() || space.isProject(),
     "Cannot delete spaces that are not regular or project."
   );
+  if (space.isProject()) {
+    assert(
+      space.canAdministrate(auth),
+      "Only project admins can delete project spaces."
+    );
+  } else {
+    assert(auth.isAdmin(), "Only super admins can delete regular spaces.");
+  }
 
   const usages: AgentsUsageType[] = [];
 
@@ -332,8 +339,8 @@ export async function createSpaceAndGroup(
     isRestricted: boolean;
     spaceKind: "regular" | "project";
   } & (
-    | { memberIds: string[]; managementMode: "manual" }
-    | { groupIds: string[]; managementMode: "group" }
+    | { memberIds: string[]; editorIds?: string[]; managementMode: "manual" }
+    | { groupIds: string[]; editorGroupIds?: string[]; managementMode: "group" }
   ),
   { ignoreWorkspaceLimit = false }: { ignoreWorkspaceLimit?: boolean } = {}
 ): Promise<
@@ -420,14 +427,67 @@ export async function createSpaceAndGroup(
     );
 
     // Handle member-based space creation
-    if ("memberIds" in params && params.memberIds) {
+    if (params.managementMode === "manual") {
+      let editorGroup: GroupResource | undefined;
+      // Handle editor group if editorIds are provided
+      if (params.editorIds && params.editorIds.length > 0) {
+        // Create editor group
+        editorGroup = await GroupResource.makeNew(
+          {
+            name: `Editors for ${spaceKind === "project" ? "project" : "space"} ${name}`,
+            workspaceId: owner.id,
+            kind: "space_editors",
+          },
+          { transaction: t }
+        );
+
+        // Add editor group to space with kind="project_editor"
+        await space.linkGroup(auth, editorGroup, "project_editor", t);
+
+        const editorUsers = (
+          await UserResource.fetchByIds(params.editorIds)
+        ).map((user) => user.toJSON());
+
+        // Add user to the newly created group. For the specific purpose of
+        // space_editors group creation, we don't use addMembers, since only admins
+        // can add/remove members this way. We create the relation directly.
+        await GroupMembershipModel.create(
+          {
+            groupId: editorGroup.id,
+            userId: editorUsers[0].id,
+            workspaceId: owner.id,
+            startAt: new Date(),
+            status: "active" as const,
+          },
+          { transaction: t }
+        );
+      }
+
+      // Add members to the member group
       const users = (await UserResource.fetchByIds(params.memberIds)).map(
         (user) => user.toJSON()
       );
-      const groupsResult = await membersGroup.addMembers(auth, {
-        users,
-        transaction: t,
-      });
+
+      const groupsResult = await membersGroup.addMembers(
+        auth,
+        // Space creators can add members to the space
+        {
+          users,
+          requestedPermissions: editorGroup
+            ? {
+                roles: [],
+                groups: [
+                  {
+                    id: editorGroup.id,
+                    permissions: ["admin", "read", "write"],
+                  },
+                ],
+                workspaceId: owner.id,
+              }
+            : undefined,
+          transaction: t,
+        }
+      );
       if (groupsResult.isErr()) {
         logger.error(
           {
@@ -443,35 +503,53 @@ export async function createSpaceAndGroup(
     }
 
     // Handle group-based space creation
-    if ("groupIds" in params && params.groupIds.length > 0) {
+    if (params.managementMode === "group") {
       // For group-based spaces, we need to associate the selected groups with the space
-      const selectedGroupsResult = await GroupResource.fetchByIds(
-        auth,
-        params.groupIds
-      );
-      if (selectedGroupsResult.isErr()) {
-        logger.error(
-          {
-            error: selectedGroupsResult.error,
-          },
-          "The space cannot be created - failed to fetch groups"
+      if (params.groupIds.length > 0) {
+        const selectedGroupsResult = await GroupResource.fetchByIds(
+          auth,
+          params.groupIds
         );
-        return new Err(
-          new DustError("internal_error", "The space cannot be created.")
-        );
+        if (selectedGroupsResult.isErr()) {
+          logger.error(
+            {
+              error: selectedGroupsResult.error,
+            },
+            "The space cannot be created - failed to fetch groups"
+          );
+          return new Err(
+            new DustError("internal_error", "The space cannot be created.")
+          );
+        }
+
+        const selectedGroups = selectedGroupsResult.value;
+        for (const selectedGroup of selectedGroups) {
+          await space.linkGroup(auth, selectedGroup, "member", t);
+        }
       }
 
-      const selectedGroups = selectedGroupsResult.value;
-      for (const selectedGroup of selectedGroups) {
-        await GroupSpaceModel.create(
-          {
-            groupId: selectedGroup.id,
-            vaultId: space.id,
-            workspaceId: space.workspaceId,
-            kind: "member",
-          },
-          { transaction: t }
+      if (params.editorGroupIds && params.editorGroupIds.length > 0) {
+        // This section is not used for the moment, since we can't add editor groups on creation yet from the front-end
+        const selectedEditorGroupsResult = await GroupResource.fetchByIds(
+          auth,
+          params.editorGroupIds
         );
+        if (selectedEditorGroupsResult.isErr()) {
+          logger.error(
+            {
+              error: selectedEditorGroupsResult.error,
+            },
+            "The space cannot be created - failed to fetch groups"
+          );
+          return new Err(
+            new DustError("internal_error", "The space cannot be created.")
+          );
+        }
+
+        const selectedEditorGroups = selectedEditorGroupsResult.value;
+        for (const selectedGroup of selectedEditorGroups) {
+          await space.linkGroup(auth, selectedGroup, "project_editor", t);
+        }
       }
     }
 

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -426,6 +426,16 @@ export async function createSpaceAndGroup(
       t
     );
 
+    if (globalGroupRes?.isOk()) {
+      space.linkGroup(
+        auth,
+        globalGroupRes.value,
+        // add the global group as viewer for project spaces (member otherwise)
+        spaceKind === "project" ? "project_viewer" : "member",
+        t
+      );
+    }
+
     // Handle member-based space creation
     if (params.managementMode === "manual") {
       let editorGroup: GroupResource | undefined;
@@ -448,7 +458,7 @@ export async function createSpaceAndGroup(
           await UserResource.fetchByIds(params.editorIds)
         ).map((user) => user.toJSON());
 
-        // Add user to the newly created group. For the specific purpose of
+        // Add users to the newly created group. For the specific purpose of
         // space_editors group creation, we don't use addMembers, since only admins
         // can add/remove members this way. We create the relation directly.
         await GroupMembershipModel.create(
@@ -539,7 +549,7 @@ export async function createSpaceAndGroup(
             {
               error: selectedEditorGroupsResult.error,
             },
-            "The space cannot be created - failed to fetch groups"
+            "The space cannot be created - failed to fetch editor groups"
           );
           return new Err(
             new DustError("internal_error", "The space cannot be created.")

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -466,26 +466,6 @@ export async function createSpaceAndGroup(
 
     // Handle member-based space creation
     if (params.managementMode === "manual") {
-      if (space.isProject()) {
-        // Create an editor group, add the project creator, and link it to the project
-        const creator = auth.getNonNullableUser();
-        const editorGroup = await GroupResource.makeNew(
-          {
-            name: `${PROJECT_EDITOR_GROUP_PREFIX} ${name}`,
-            workspaceId: owner.id,
-            kind: "space_editors",
-          },
-          { memberIds: [creator.id], transaction: t }
-        );
-
-        // Add editor group to space with kind="project_editor"
-        await GroupSpaceEditorResource.makeNew(auth, {
-          group: editorGroup,
-          space,
-          transaction: t,
-        });
-      }
-
       // Add members to the member group
       const users = (await UserResource.fetchByIds(params.memberIds)).map(
         (user) => user.toJSON()

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -16,6 +16,10 @@ import { AppResource } from "@app/lib/resources/app_resource";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
+import {
+  GroupSpaceEditorResource,
+  GroupSpaceMemberResource,
+} from "@app/lib/resources/group_space_resource";
 import { KeyResource } from "@app/lib/resources/key_resource";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
@@ -38,7 +42,6 @@ import {
   removeNulls,
   SPACE_GROUP_PREFIX,
 } from "@app/types";
-import { GroupSpaceEditorResource } from "@app/lib/resources/group_space_resource";
 
 export async function softDeleteSpaceAndLaunchScrubWorkflow(
   auth: Authenticator,
@@ -464,11 +467,15 @@ export async function createSpaceAndGroup(
     if (params.managementMode === "manual") {
       let editorGroup: GroupResource | undefined;
       // Handle editor group if editorIds are provided
-      if (params.editorIds && params.editorIds.length > 0) {
+      if (
+        space.isProject() &&
+        params.editorIds &&
+        params.editorIds.length > 0
+      ) {
         // Create editor group
         editorGroup = await GroupResource.makeNew(
           {
-            name: `Editors for ${space.isProject() ? "project" : "space"} ${name}`,
+            name: `Editors for project ${name}`,
             workspaceId: owner.id,
             kind: "space_editors",
           },

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -37,6 +37,7 @@ import {
   removeNulls,
   SPACE_GROUP_PREFIX,
 } from "@app/types";
+import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces";
 
 export async function softDeleteSpaceAndLaunchScrubWorkflow(
   auth: Authenticator,
@@ -426,13 +427,19 @@ export async function createSpaceAndGroup(
       t
     );
 
-    if (globalGroupRes?.isOk()) {
-      space.linkGroup(
-        auth,
-        globalGroupRes.value,
-        // add the global group as viewer for project spaces (member otherwise)
-        spaceKind === "project" ? "project_viewer" : "member",
-        t
+    if (spaceKind === "project" && globalGroupRes?.isOk()) {
+      // Set the global group as viewer for project spaces
+      GroupSpaceModel.update(
+        {
+          kind: "project_viewer",
+        },
+        {
+          where: {
+            groupId: globalGroupRes.value.id,
+            vaultId: space.id,
+          },
+          transaction: t,
+        }
       );
     }
 

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -16,9 +16,7 @@ import { AppResource } from "@app/lib/resources/app_resource";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
-import {
-  GroupSpaceMemberResource,
-} from "@app/lib/resources/group_space_resource";
+import { GroupSpaceMemberResource } from "@app/lib/resources/group_space_resource";
 import { KeyResource } from "@app/lib/resources/key_resource";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -1609,6 +1609,10 @@ export class GroupResource extends BaseResource<GroupModel> {
     return this.kind === "regular";
   }
 
+  isSpaceEditor(): boolean {
+    return this.kind === "space_editors";
+  }
+
   isProvisioned(): boolean {
     return this.kind === "provisioned";
   }

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -1078,7 +1078,7 @@ export class GroupResource extends BaseResource<GroupModel> {
       transaction,
     }: {
       users: UserType[];
-      requestedPermissions?: CombinedResourcePermissions;
+      requestedPermissions?: CombinedResourcePermissions[];
       transaction?: Transaction;
     }
   ): Promise<
@@ -1093,13 +1093,7 @@ export class GroupResource extends BaseResource<GroupModel> {
       >
     >
   > {
-    if (
-      !auth.canWrite(
-        requestedPermissions
-          ? [requestedPermissions]
-          : this.requestedPermissions()
-      )
-    ) {
+    if (!auth.canWrite(requestedPermissions ?? this.requestedPermissions())) {
       return new Err(
         new DustError(
           "unauthorized",
@@ -1216,7 +1210,7 @@ export class GroupResource extends BaseResource<GroupModel> {
       transaction,
     }: {
       user: UserType;
-      requestedPermissions?: CombinedResourcePermissions;
+      requestedPermissions?: CombinedResourcePermissions[];
       transaction?: Transaction;
     }
   ): Promise<
@@ -1246,7 +1240,7 @@ export class GroupResource extends BaseResource<GroupModel> {
       transaction,
     }: {
       users: UserType[];
-      requestedPermissions?: CombinedResourcePermissions;
+      requestedPermissions?: CombinedResourcePermissions[];
       transaction?: Transaction;
     }
   ): Promise<
@@ -1260,13 +1254,7 @@ export class GroupResource extends BaseResource<GroupModel> {
       >
     >
   > {
-    if (
-      !auth.canWrite(
-        requestedPermissions
-          ? [requestedPermissions]
-          : this.requestedPermissions()
-      )
-    ) {
+    if (!auth.canWrite(requestedPermissions ?? this.requestedPermissions())) {
       return new Err(
         new DustError(
           "unauthorized",
@@ -1366,7 +1354,7 @@ export class GroupResource extends BaseResource<GroupModel> {
       transaction,
     }: {
       user: UserType;
-      requestedPermissions?: CombinedResourcePermissions;
+      requestedPermissions?: CombinedResourcePermissions[];
       transaction?: Transaction;
     }
   ): Promise<
@@ -1395,7 +1383,7 @@ export class GroupResource extends BaseResource<GroupModel> {
       transaction,
     }: {
       users: UserType[];
-      requestedPermissions?: CombinedResourcePermissions;
+      requestedPermissions?: CombinedResourcePermissions[];
       transaction?: Transaction;
     }
   ): Promise<
@@ -1411,13 +1399,7 @@ export class GroupResource extends BaseResource<GroupModel> {
       >
     >
   > {
-    if (
-      !auth.canWrite(
-        requestedPermissions
-          ? [requestedPermissions]
-          : this.requestedPermissions()
-      )
-    ) {
+    if (!auth.canWrite(requestedPermissions ?? this.requestedPermissions())) {
       return new Err(
         new DustError(
           "unauthorized",

--- a/front/lib/resources/group_space_resource.test.ts
+++ b/front/lib/resources/group_space_resource.test.ts
@@ -1,13 +1,13 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
 import { Authenticator } from "@app/lib/auth";
+import { GroupResource } from "@app/lib/resources/group_resource";
 import {
   GroupSpaceEditorResource,
   GroupSpaceMemberResource,
   GroupSpaceViewerResource,
 } from "@app/lib/resources/group_space_resource";
-import { GroupResource } from "@app/lib/resources/group_resource";
-import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
 import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
@@ -61,9 +61,6 @@ describe("GroupSpaceMemberResource", () => {
   describe("fetchBySpace", () => {
     it("should return null when no member GroupSpace exists for the space", async () => {
       // Create a space without any member groups
-      const { SpaceResource } = await import(
-        "@app/lib/resources/space_resource"
-      );
       const emptySpace = await SpaceResource.makeNew(
         {
           name: "Empty Space",

--- a/front/lib/resources/group_space_resource.test.ts
+++ b/front/lib/resources/group_space_resource.test.ts
@@ -1,0 +1,372 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { Authenticator } from "@app/lib/auth";
+import {
+  GroupSpaceEditorResource,
+  GroupSpaceMemberResource,
+  GroupSpaceViewerResource,
+} from "@app/lib/resources/group_space_resource";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces";
+import { GroupFactory } from "@app/tests/utils/GroupFactory";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+
+describe("GroupSpaceMemberResource", () => {
+  let workspace: Awaited<ReturnType<typeof WorkspaceFactory.basic>>;
+  let auth: Authenticator;
+  let regularSpace: SpaceResource;
+
+  beforeEach(async () => {
+    workspace = await WorkspaceFactory.basic();
+    const adminUser = await UserFactory.basic();
+
+    // Create default groups (including global group)
+    await GroupFactory.defaults(workspace);
+
+    await MembershipFactory.associate(workspace, adminUser, { role: "admin" });
+
+    auth = await Authenticator.fromUserIdAndWorkspaceId(
+      adminUser.sId,
+      workspace.sId
+    );
+
+    regularSpace = await SpaceFactory.regular(workspace);
+  });
+
+  describe("makeNew", () => {
+    it("should create a new GroupSpaceMemberResource with correct properties", async () => {
+      const testGroup = await GroupResource.makeNew({
+        name: "Test Group",
+        workspaceId: workspace.id,
+        kind: "regular",
+      });
+
+      const groupSpaceMember = await GroupSpaceMemberResource.makeNew(auth, {
+        group: testGroup,
+        space: regularSpace,
+      });
+
+      expect(groupSpaceMember).toBeInstanceOf(GroupSpaceMemberResource);
+      expect(groupSpaceMember.groupId).toBe(testGroup.id);
+      expect(groupSpaceMember.vaultId).toBe(regularSpace.id);
+      expect(groupSpaceMember.workspaceId).toBe(workspace.id);
+      expect(groupSpaceMember.kind).toBe("member");
+    });
+  });
+
+  describe("fetchBySpace", () => {
+    it("should return null when no member GroupSpace exists for the space", async () => {
+      // Create a space without any member groups
+      const { SpaceResource } = await import(
+        "@app/lib/resources/space_resource"
+      );
+      const emptySpace = await SpaceResource.makeNew(
+        {
+          name: "Empty Space",
+          kind: "regular",
+          workspaceId: workspace.id,
+        },
+        { members: [] }
+      );
+
+      const result = await GroupSpaceMemberResource.fetchBySpace(auth, {
+        space: emptySpace,
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it("should fetch an existing GroupSpaceMemberResource by space", async () => {
+      // regularSpace already has a member group from SpaceFactory.regular
+      // Let's fetch it
+      const result = await GroupSpaceMemberResource.fetchBySpace(auth, {
+        space: regularSpace,
+      });
+
+      expect(result).toBeInstanceOf(GroupSpaceMemberResource);
+      expect(result?.vaultId).toBe(regularSpace.id);
+      expect(result?.kind).toBe("member");
+      // The group should be the one created by SpaceFactory
+      expect(result?.groupId).toBeDefined();
+    });
+
+    // Note: Testing the assertion "Group must exist for member group space" is not possible
+    // in this test environment due to database foreign key constraints that prevent
+    // creating orphaned GroupSpace records. The assertion is still valid in production
+    // if data integrity issues occur.
+  });
+});
+
+describe("GroupSpaceEditorResource", () => {
+  let workspace: Awaited<ReturnType<typeof WorkspaceFactory.basic>>;
+  let auth: Authenticator;
+  let projectSpace: SpaceResource;
+  let editorGroup: GroupResource;
+
+  beforeEach(async () => {
+    workspace = await WorkspaceFactory.basic();
+    const adminUser = await UserFactory.basic();
+
+    // Create default groups (including global group)
+    await GroupFactory.defaults(workspace);
+
+    await MembershipFactory.associate(workspace, adminUser, { role: "admin" });
+
+    auth = await Authenticator.fromUserIdAndWorkspaceId(
+      adminUser.sId,
+      workspace.sId
+    );
+
+    // Create a project space
+    projectSpace = await SpaceFactory.project(workspace);
+
+    // Create an editor group
+    editorGroup = await GroupResource.makeNew({
+      name: "Test Editor Group",
+      workspaceId: workspace.id,
+      kind: "space_editors",
+    });
+  });
+
+  describe("makeNew", () => {
+    it("should throw an assertion error when space is not a project space", async () => {
+      const regularSpace = await SpaceFactory.regular(workspace);
+
+      await expect(
+        GroupSpaceEditorResource.makeNew(auth, {
+          group: editorGroup,
+          space: regularSpace,
+        })
+      ).rejects.toThrow("Editor groups only apply to project spaces");
+    });
+
+    it("should throw an assertion error when group is not a space editor or provisioned group", async () => {
+      const regularGroup = await GroupResource.makeNew({
+        name: "Regular Group",
+        workspaceId: workspace.id,
+        kind: "regular",
+      });
+
+      await expect(
+        GroupSpaceEditorResource.makeNew(auth, {
+          group: regularGroup,
+          space: projectSpace,
+        })
+      ).rejects.toThrow(
+        "Only space editor or provisioned groups can be an editor group"
+      );
+    });
+
+    it("should allow creating editor resource with provisioned group", async () => {
+      const provisionedGroup = await GroupResource.makeNew({
+        name: "Provisioned Group",
+        workspaceId: workspace.id,
+        kind: "provisioned",
+      });
+
+      const groupSpaceEditor = await GroupSpaceEditorResource.makeNew(auth, {
+        group: provisionedGroup,
+        space: projectSpace,
+      });
+
+      expect(groupSpaceEditor).toBeInstanceOf(GroupSpaceEditorResource);
+      expect(groupSpaceEditor.kind).toBe("project_editor");
+    });
+  });
+
+  describe("fetchBySpace", () => {
+    it("should return the existing editor group space for a project", async () => {
+      const result = await GroupSpaceEditorResource.fetchBySpace(
+        workspace.id,
+        projectSpace
+      );
+
+      expect(result).toBeInstanceOf(GroupSpaceEditorResource);
+      expect(result?.vaultId).toBe(projectSpace.id);
+      expect(result?.kind).toBe("project_editor");
+    });
+
+    it("should return null when no editor GroupSpace exists for the project", async () => {
+      // Delete existing editor group spaces
+      await GroupSpaceModel.destroy({
+        where: {
+          vaultId: projectSpace.id,
+          kind: "project_editor",
+          workspaceId: workspace.id,
+        },
+      });
+
+      const result = await GroupSpaceEditorResource.fetchBySpace(
+        workspace.id,
+        projectSpace
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it("should throw an assertion error when space is not a project space", async () => {
+      const regularSpace = await SpaceFactory.regular(workspace);
+
+      await expect(
+        GroupSpaceEditorResource.fetchBySpace(workspace.id, regularSpace)
+      ).rejects.toThrow("Editor groups only apply to project spaces");
+    });
+
+    // Note: Testing the assertion "Group must exist for editor group space" is not possible
+    // in this test environment due to database foreign key constraints that prevent
+    // creating orphaned GroupSpace records. The assertion is still valid in production
+    // if data integrity issues occur.
+
+    it("should throw an assertion error when group is not a space editor or provisioned group", async () => {
+      const regularGroup = await GroupResource.makeNew({
+        name: "Regular Group",
+        workspaceId: workspace.id,
+        kind: "regular",
+      });
+
+      // Delete existing editor groups
+      await GroupSpaceModel.destroy({
+        where: {
+          vaultId: projectSpace.id,
+          kind: "project_editor",
+          workspaceId: workspace.id,
+        },
+      });
+
+      // Create a GroupSpaceModel with a non-editor group
+      await GroupSpaceModel.create({
+        groupId: regularGroup.id,
+        vaultId: projectSpace.id,
+        workspaceId: workspace.id,
+        kind: "project_editor",
+      });
+
+      await expect(
+        GroupSpaceEditorResource.fetchBySpace(workspace.id, projectSpace)
+      ).rejects.toThrow(
+        "Only space editors or provisioned groups can be an editor group"
+      );
+    });
+  });
+});
+
+describe("GroupSpaceViewerResource", () => {
+  let workspace: Awaited<ReturnType<typeof WorkspaceFactory.basic>>;
+  let auth: Authenticator;
+  let projectSpace: SpaceResource;
+  let globalGroup: GroupResource;
+
+  beforeEach(async () => {
+    workspace = await WorkspaceFactory.basic();
+    const adminUser = await UserFactory.basic();
+
+    // Create default groups (including global group)
+    const { globalGroup: gGroup } = await GroupFactory.defaults(workspace);
+    globalGroup = gGroup;
+
+    await MembershipFactory.associate(workspace, adminUser, { role: "admin" });
+
+    auth = await Authenticator.fromUserIdAndWorkspaceId(
+      adminUser.sId,
+      workspace.sId
+    );
+
+    // Create a project space
+    projectSpace = await SpaceFactory.project(workspace);
+  });
+
+  describe("makeNew", () => {
+    it("should throw an assertion error when space is not a project space", async () => {
+      const regularSpace = await SpaceFactory.regular(workspace);
+
+      await expect(
+        GroupSpaceViewerResource.makeNew(auth, {
+          group: globalGroup,
+          space: regularSpace,
+        })
+      ).rejects.toThrow("Viewer groups only apply to project spaces");
+    });
+
+    it("should throw an assertion error when group is not the global group", async () => {
+      const regularGroup = await GroupResource.makeNew({
+        name: "Regular Group",
+        workspaceId: workspace.id,
+        kind: "regular",
+      });
+
+      await expect(
+        GroupSpaceViewerResource.makeNew(auth, {
+          group: regularGroup,
+          space: projectSpace,
+        })
+      ).rejects.toThrow("Only the global group can be a viewer group");
+    });
+  });
+
+  describe("fetchBySpace", () => {
+    it("should return null when no viewer GroupSpace exists for the project", async () => {
+      const result = await GroupSpaceViewerResource.fetchBySpace(auth, {
+        space: projectSpace,
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it("should fetch an existing GroupSpaceViewerResource by space", async () => {
+      await GroupSpaceViewerResource.makeNew(auth, {
+        group: globalGroup,
+        space: projectSpace,
+      });
+
+      const result = await GroupSpaceViewerResource.fetchBySpace(auth, {
+        space: projectSpace,
+      });
+
+      expect(result).toBeInstanceOf(GroupSpaceViewerResource);
+      expect(result?.groupId).toBe(globalGroup.id);
+      expect(result?.vaultId).toBe(projectSpace.id);
+      expect(result?.kind).toBe("project_viewer");
+    });
+
+    it("should throw an assertion error when space is not a project space", async () => {
+      const regularSpace = await SpaceFactory.regular(workspace);
+
+      await expect(
+        GroupSpaceViewerResource.fetchBySpace(auth, {
+          space: regularSpace,
+        })
+      ).rejects.toThrow("Viewer groups only apply to project spaces");
+    });
+
+    // Note: Testing the assertion "Group must exist for viewer group space" is not possible
+    // in this test environment due to database foreign key constraints that prevent
+    // creating orphaned GroupSpace records. The assertion is still valid in production
+    // if data integrity issues occur.
+
+    it("should throw an assertion error when group is not the global group", async () => {
+      const regularGroup = await GroupResource.makeNew({
+        name: "Regular Group",
+        workspaceId: workspace.id,
+        kind: "regular",
+      });
+
+      // Create a GroupSpaceModel with a non-global group
+      await GroupSpaceModel.create({
+        groupId: regularGroup.id,
+        vaultId: projectSpace.id,
+        workspaceId: workspace.id,
+        kind: "project_viewer",
+      });
+
+      await expect(
+        GroupSpaceViewerResource.fetchBySpace(auth, {
+          space: projectSpace,
+        })
+      ).rejects.toThrow("Only the global group can be a viewer group");
+    });
+  });
+});

--- a/front/lib/resources/group_space_resource.ts
+++ b/front/lib/resources/group_space_resource.ts
@@ -78,11 +78,15 @@ export class GroupSpaceBaseResource extends BaseResource<GroupSpaceModel> {
     >
   > {
     const requestedPermissions = await this.requestedPermissions();
-    return this.group.addMembers(auth, {
+    const addMembersRes = await this.group.addMembers(auth, {
       users,
       requestedPermissions,
       transaction,
     });
+    if (addMembersRes.isErr()) {
+      return new Err(addMembersRes.error);
+    }
+    return new Ok(addMembersRes.value);
   }
 
   /**
@@ -109,11 +113,15 @@ export class GroupSpaceBaseResource extends BaseResource<GroupSpaceModel> {
     >
   > {
     const requestedPermissions = await this.requestedPermissions();
-    return this.group.removeMembers(auth, {
+    const removeMembersRes = await this.group.removeMembers(auth, {
       users,
       requestedPermissions,
       transaction,
     });
+    if (removeMembersRes.isErr()) {
+      return new Err(removeMembersRes.error);
+    }
+    return new Ok(removeMembersRes.value);
   }
 
   /**
@@ -143,11 +151,15 @@ export class GroupSpaceBaseResource extends BaseResource<GroupSpaceModel> {
     >
   > {
     const requestedPermissions = await this.requestedPermissions();
-    return this.group.setMembers(auth, {
+    const setMembersRes = await this.group.setMembers(auth, {
       users,
       requestedPermissions,
       transaction,
     });
+    if (setMembersRes.isErr()) {
+      return new Err(setMembersRes.error);
+    }
+    return new Ok(setMembersRes.value);
   }
 
   /**

--- a/front/lib/resources/group_space_resource.ts
+++ b/front/lib/resources/group_space_resource.ts
@@ -1,0 +1,533 @@
+import type { Attributes, ModelStatic, Transaction } from "sequelize";
+
+import type { Authenticator } from "@app/lib/auth";
+import { DustError } from "@app/lib/error";
+import { BaseResource } from "@app/lib/resources/base_resource";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces";
+import { GroupModel } from "@app/lib/resources/storage/models/groups";
+import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
+import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
+import type {
+  CombinedResourcePermissions,
+  GroupPermission,
+  ModelId,
+  Result,
+  UserType,
+} from "@app/types";
+import { Err, Ok } from "@app/types";
+
+// Base class for group-space junction resources
+// Attributes are marked as read-only to reflect the stateless nature of our Resource.
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export interface GroupSpaceBaseResource extends ReadonlyAttributesType<GroupSpaceModel> {}
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export class GroupSpaceBaseResource extends BaseResource<GroupSpaceModel> {
+  static model: ModelStatic<GroupSpaceModel> = GroupSpaceModel;
+
+  constructor(
+    model: ModelStatic<GroupSpaceModel>,
+    blob: Attributes<GroupSpaceModel>,
+    readonly space: SpaceResource,
+    readonly group: GroupResource
+  ) {
+    super(GroupSpaceModel, blob);
+  }
+
+  /**
+   * Create a new group-space relationship and return the appropriate resource type.
+   */
+  static async makeNew(
+    auth: Authenticator,
+    {
+      group,
+      space,
+      kind,
+      transaction,
+    }: {
+      group: GroupResource;
+      space: SpaceResource;
+      kind: "member" | "project_editor" | "project_viewer";
+      transaction?: Transaction;
+    }
+  ): Promise<
+    | GroupSpaceMemberResource
+    | GroupSpaceEditorResource
+    | GroupSpaceViewerResource
+  > {
+    const groupSpace = await GroupSpaceModel.create(
+      {
+        groupId: group.id,
+        vaultId: space.id,
+        workspaceId: auth.getNonNullableWorkspace().id,
+        kind,
+      },
+      { transaction }
+    );
+
+    switch (kind) {
+      case "member":
+        return new GroupSpaceMemberResource(
+          GroupSpaceModel,
+          groupSpace.get(),
+          space,
+          group
+        );
+      case "project_editor":
+        return new GroupSpaceEditorResource(
+          GroupSpaceModel,
+          groupSpace.get(),
+          space,
+          group
+        );
+      case "project_viewer":
+        return new GroupSpaceViewerResource(
+          GroupSpaceModel,
+          groupSpace.get(),
+          space,
+          group
+        );
+    }
+  }
+
+  static async fetchByGroupAndSpace(
+    auth: Authenticator,
+    {
+      groupId,
+      spaceId,
+      transaction,
+    }: {
+      groupId: ModelId;
+      spaceId: ModelId;
+      transaction?: Transaction;
+    }
+  ): Promise<
+    | GroupSpaceMemberResource
+    | GroupSpaceEditorResource
+    | GroupSpaceViewerResource
+    | null
+  > {
+    const groupSpace = await GroupSpaceModel.findOne({
+      where: {
+        groupId,
+        vaultId: spaceId,
+        workspaceId: auth.getNonNullableWorkspace().id,
+      },
+      include: [
+        {
+          model: SpaceModel,
+          as: "space",
+          include: [
+            {
+              model: GroupModel,
+            },
+          ],
+        },
+        {
+          model: GroupModel,
+          as: "group",
+        },
+      ],
+      transaction,
+    });
+
+    if (!groupSpace) {
+      return null;
+    }
+
+    const space = SpaceResource.fromModel(
+      groupSpace.get("space") as SpaceModel
+    );
+    const group = new GroupResource(
+      GroupModel,
+      (groupSpace.get("group") as GroupModel).get()
+    );
+
+    switch (groupSpace.kind) {
+      case "member":
+        return new GroupSpaceMemberResource(
+          GroupSpaceModel,
+          groupSpace.get(),
+          space,
+          group
+        );
+      case "project_editor":
+        return new GroupSpaceEditorResource(
+          GroupSpaceModel,
+          groupSpace.get(),
+          space,
+          group
+        );
+      case "project_viewer":
+        return new GroupSpaceViewerResource(
+          GroupSpaceModel,
+          groupSpace.get(),
+          space,
+          group
+        );
+    }
+  }
+
+  /**
+   * Helper method to find the editor group for a space.
+   * Returns the group with kind "project_editor" if it exists.
+   */
+  protected getEditorGroup(): GroupResource | undefined {
+    return this.space.groups.find(
+      (g) => g.group_vaults?.kind === "project_editor"
+    );
+  }
+
+  /**
+   * Placeholder for requestedPermissions to be defined in subclasses.
+   * Each subclass will implement its own permission logic.
+   */
+  requestedPermissions(): CombinedResourcePermissions[] {
+    throw new Error("requestedPermissions must be implemented in subclass");
+  }
+
+  /**
+   * Add multiple members to the group with permissions from this group-space relationship.
+   */
+  async addMembers(
+    auth: Authenticator,
+    {
+      users,
+      transaction,
+    }: {
+      users: UserType[];
+      transaction?: Transaction;
+    }
+  ): Promise<
+    Result<
+      undefined,
+      DustError<
+        | "unauthorized"
+        | "user_not_found"
+        | "user_already_member"
+        | "group_requirements_not_met"
+        | "system_or_global_group"
+      >
+    >
+  > {
+    // Get the permissions for this specific group-space relationship.
+    // We use the first permission set since our permission model returns an array
+    // but each group-space relationship has a single permission configuration.
+    const permissions = this.requestedPermissions();
+    const requestedPermissions =
+      permissions.length > 0 ? permissions[0] : undefined;
+
+    return this.group.addMembers(auth, {
+      users,
+      requestedPermissions,
+      transaction,
+    });
+  }
+
+  /**
+   * Add a single member to the group with permissions from this group-space relationship.
+   */
+  async addMember(
+    auth: Authenticator,
+    {
+      user,
+      transaction,
+    }: {
+      user: UserType;
+      transaction?: Transaction;
+    }
+  ): Promise<
+    Result<
+      undefined,
+      DustError<
+        | "unauthorized"
+        | "user_not_found"
+        | "user_already_member"
+        | "group_requirements_not_met"
+        | "system_or_global_group"
+      >
+    >
+  > {
+    return this.addMembers(auth, {
+      users: [user],
+      transaction,
+    });
+  }
+
+  /**
+   * Remove multiple members from the group with permissions from this group-space relationship.
+   */
+  async removeMembers(
+    auth: Authenticator,
+    {
+      users,
+      transaction,
+    }: {
+      users: UserType[];
+      transaction?: Transaction;
+    }
+  ): Promise<
+    Result<
+      undefined,
+      DustError<
+        | "unauthorized"
+        | "user_not_found"
+        | "user_not_member"
+        | "system_or_global_group"
+      >
+    >
+  > {
+    // Get the permissions for this specific group-space relationship.
+    // We use the first permission set since our permission model returns an array
+    // but each group-space relationship has a single permission configuration.
+    const permissions = this.requestedPermissions();
+    const requestedPermissions =
+      permissions.length > 0 ? permissions[0] : undefined;
+
+    return this.group.removeMembers(auth, {
+      users,
+      requestedPermissions,
+      transaction,
+    });
+  }
+
+  /**
+   * Remove a single member from the group with permissions from this group-space relationship.
+   */
+  async removeMember(
+    auth: Authenticator,
+    {
+      user,
+      transaction,
+    }: {
+      user: UserType;
+      transaction?: Transaction;
+    }
+  ): Promise<
+    Result<
+      undefined,
+      DustError<
+        | "unauthorized"
+        | "user_not_found"
+        | "user_not_member"
+        | "system_or_global_group"
+      >
+    >
+  > {
+    return this.removeMembers(auth, {
+      users: [user],
+      transaction,
+    });
+  }
+
+  /**
+   * Set the exact list of members for the group with permissions from this group-space relationship.
+   * This will add new members and remove members not in the list.
+   */
+  async setMembers(
+    auth: Authenticator,
+    {
+      users,
+      transaction,
+    }: {
+      users: UserType[];
+      transaction?: Transaction;
+    }
+  ): Promise<
+    Result<
+      undefined,
+      DustError<
+        | "unauthorized"
+        | "user_not_found"
+        | "user_not_member"
+        | "user_already_member"
+        | "group_requirements_not_met"
+        | "system_or_global_group"
+      >
+    >
+  > {
+    // Get the permissions for this specific group-space relationship.
+    // We use the first permission set since our permission model returns an array
+    // but each group-space relationship has a single permission configuration.
+    const permissions = this.requestedPermissions();
+    const requestedPermissions =
+      permissions.length > 0 ? permissions[0] : undefined;
+
+    return this.group.setMembers(auth, {
+      users,
+      requestedPermissions,
+      transaction,
+    });
+  }
+
+  /**
+   * Delete the group-space relationship.
+   */
+  async delete(
+    auth: Authenticator,
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<Result<undefined, Error>> {
+    try {
+      await GroupSpaceModel.destroy({
+        where: {
+          groupId: this.groupId,
+          vaultId: this.vaultId,
+          workspaceId: auth.getNonNullableWorkspace().id,
+          kind: this.kind,
+        },
+        transaction,
+      });
+
+      return new Ok(undefined);
+    } catch (error) {
+      return new Err(error instanceof Error ? error : new Error(String(error)));
+    }
+  }
+}
+
+// GroupSpaceMemberResource - represents member permission (kind=member)
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export interface GroupSpaceMemberResource extends ReadonlyAttributesType<GroupSpaceModel> {}
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export class GroupSpaceMemberResource extends GroupSpaceBaseResource {
+  constructor(
+    model: ModelStatic<GroupSpaceModel>,
+    blob: Attributes<GroupSpaceModel>,
+    space: SpaceResource,
+    group: GroupResource
+  ) {
+    super(model, blob, space, group);
+  }
+
+  requestedPermissions(): CombinedResourcePermissions[] {
+    if (this.space.isProject()) {
+      const editorGroup = this.getEditorGroup();
+      return [
+        {
+          groups: [
+            {
+              id: this.group.id,
+              permissions: ["read", "write"],
+            },
+            ...((editorGroup
+              ? [
+                  {
+                    id: editorGroup.id,
+                    permissions: ["admin", "read", "write"],
+                  },
+                ]
+              : []) as GroupPermission[]),
+          ],
+          roles: [
+            {
+              role: "admin",
+              permissions: ["admin", "read", "write"],
+            },
+          ],
+          workspaceId: this.space.workspaceId,
+        },
+      ];
+    }
+    return [
+      {
+        groups: [
+          {
+            id: this.group.id,
+            permissions: ["read"],
+          },
+        ],
+        roles: [
+          {
+            role: "admin",
+            permissions: ["admin", "read", "write"],
+          },
+        ],
+        workspaceId: this.space.workspaceId,
+      },
+    ];
+  }
+}
+
+// GroupSpaceEditorResource - represents editor permission (kind=project_editor)
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export interface GroupSpaceEditorResource extends ReadonlyAttributesType<GroupSpaceModel> {}
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export class GroupSpaceEditorResource extends GroupSpaceBaseResource {
+  constructor(
+    model: ModelStatic<GroupSpaceModel>,
+    blob: Attributes<GroupSpaceModel>,
+    space: SpaceResource,
+    group: GroupResource
+  ) {
+    super(model, blob, space, group);
+  }
+
+  requestedPermissions(): CombinedResourcePermissions[] {
+    if (this.space.isProject()) {
+      const editorGroup = this.getEditorGroup();
+      return [
+        {
+          groups: editorGroup
+            ? [
+                {
+                  id: editorGroup.id,
+                  permissions: ["admin", "read", "write"],
+                },
+              ]
+            : [],
+          roles: [],
+          workspaceId: this.space.workspaceId,
+        },
+      ];
+    }
+    return [];
+  }
+}
+
+// GroupSpaceViewerResource - represents viewer permission (kind=project_viewer)
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export interface GroupSpaceViewerResource extends ReadonlyAttributesType<GroupSpaceModel> {}
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export class GroupSpaceViewerResource extends GroupSpaceBaseResource {
+  constructor(
+    model: ModelStatic<GroupSpaceModel>,
+    blob: Attributes<GroupSpaceModel>,
+    space: SpaceResource,
+    group: GroupResource
+  ) {
+    super(model, blob, space, group);
+  }
+
+  requestedPermissions(): CombinedResourcePermissions[] {
+    if (this.space.isProject()) {
+      const editorGroup = this.getEditorGroup();
+      return [
+        {
+          groups: [
+            {
+              id: this.group.id,
+              permissions: ["read"],
+            },
+            ...((editorGroup
+              ? [
+                  {
+                    id: editorGroup.id,
+                    permissions: ["admin", "read", "write"],
+                  },
+                ]
+              : []) as GroupPermission[]),
+          ],
+          roles: [
+            {
+              role: "admin",
+              permissions: ["admin", "read", "write"],
+            },
+          ],
+          workspaceId: this.space.workspaceId,
+        },
+      ];
+    }
+    return [];
+  }
+}

--- a/front/lib/resources/group_space_resource.ts
+++ b/front/lib/resources/group_space_resource.ts
@@ -262,6 +262,10 @@ export class GroupSpaceMemberResource extends GroupSpaceBaseResource {
       transaction,
     });
     assert(groupModel, "Group must exist for member group space");
+    assert(
+      groupModel.kind === "regular",
+      "Group kind must be regular for member group space"
+    );
     const group = new GroupResource(GroupModel, groupModel.get());
 
     return new GroupSpaceMemberResource(
@@ -402,6 +406,8 @@ export class GroupSpaceEditorResource extends GroupSpaceBaseResource {
     }
   ): Promise<GroupSpaceEditorResource> {
     assert(space.isProject(), "Editor groups only apply to project spaces");
+    assert(group.isSpaceEditor(), "space_editors groups can be editor groups");
+
     const groupSpace = await GroupSpaceModel.create(
       {
         groupId: group.id,
@@ -446,6 +452,10 @@ export class GroupSpaceEditorResource extends GroupSpaceBaseResource {
       transaction,
     });
     assert(groupModel, "Group must exist for editor group space");
+    assert(
+      groupModel.kind === "space_editors",
+      "Group kind must be space_editors for editor group space"
+    );
     const group = new GroupResource(GroupModel, groupModel.get());
 
     return new GroupSpaceEditorResource(
@@ -505,6 +515,7 @@ export class GroupSpaceViewerResource extends GroupSpaceBaseResource {
     }
   ): Promise<GroupSpaceViewerResource> {
     assert(space.isProject(), "Viewer groups only apply to project spaces");
+    assert(group.isGlobal(), "Only the global group can be a viewer group");
     const groupSpace = await GroupSpaceModel.create(
       {
         groupId: group.id,
@@ -555,6 +566,10 @@ export class GroupSpaceViewerResource extends GroupSpaceBaseResource {
       transaction,
     });
     assert(groupModel, "Group must exist for viewer group space");
+    assert(
+      groupModel.kind === "global",
+      "Only the global group can be a viewer group"
+    );
 
     const group = new GroupResource(GroupModel, groupModel.get());
 

--- a/front/lib/resources/group_space_resource.ts
+++ b/front/lib/resources/group_space_resource.ts
@@ -78,13 +78,7 @@ export class GroupSpaceBaseResource extends BaseResource<GroupSpaceModel> {
       >
     >
   > {
-    // Get the permissions for this specific group-space relationship.
-    // We use the first permission set since our permission model returns an array
-    // but each group-space relationship has a single permission configuration.
-    const permissions = await this.requestedPermissions();
-    const requestedPermissions =
-      permissions.length > 0 ? permissions[0] : undefined;
-
+    const requestedPermissions = await this.requestedPermissions();
     return this.group.addMembers(auth, {
       users,
       requestedPermissions,
@@ -145,13 +139,7 @@ export class GroupSpaceBaseResource extends BaseResource<GroupSpaceModel> {
       >
     >
   > {
-    // Get the permissions for this specific group-space relationship.
-    // We use the first permission set since our permission model returns an array
-    // but each group-space relationship has a single permission configuration.
-    const permissions = await this.requestedPermissions();
-    const requestedPermissions =
-      permissions.length > 0 ? permissions[0] : undefined;
-
+    const requestedPermissions = await this.requestedPermissions();
     return this.group.removeMembers(auth, {
       users,
       requestedPermissions,
@@ -214,13 +202,7 @@ export class GroupSpaceBaseResource extends BaseResource<GroupSpaceModel> {
       >
     >
   > {
-    // Get the permissions for this specific group-space relationship.
-    // We use the first permission set since our permission model returns an array
-    // but each group-space relationship has a single permission configuration.
-    const permissions = await this.requestedPermissions();
-    const requestedPermissions =
-      permissions.length > 0 ? permissions[0] : undefined;
-
+    const requestedPermissions = await this.requestedPermissions();
     return this.group.setMembers(auth, {
       users,
       requestedPermissions,

--- a/front/lib/resources/group_space_resource.ts
+++ b/front/lib/resources/group_space_resource.ts
@@ -39,7 +39,7 @@ export class GroupSpaceBaseResource extends BaseResource<GroupSpaceModel> {
    * Helper method to find the editor group for a space.
    * Returns the group with kind "project_editor" if it exists.
    */
-  async getEditorGroup(): Promise<GroupSpaceEditorResource | null> {
+  async getEditorGroupSpace(): Promise<GroupSpaceEditorResource | null> {
     return GroupSpaceEditorResource.fetchBySpace(
       this.space.workspaceId,
       this.space.id
@@ -341,7 +341,7 @@ export class GroupSpaceMemberResource extends GroupSpaceBaseResource {
 
   async requestedPermissions(): Promise<CombinedResourcePermissions[]> {
     if (this.space.isProject()) {
-      const editorGroup = await this.getEditorGroup();
+      const editorGroupSpace = await this.getEditorGroupSpace();
       return [
         {
           groups: [
@@ -349,10 +349,10 @@ export class GroupSpaceMemberResource extends GroupSpaceBaseResource {
               id: this.group.id,
               permissions: ["read", "write"],
             },
-            ...((editorGroup
+            ...((editorGroupSpace
               ? [
                   {
-                    id: editorGroup.id,
+                    id: editorGroupSpace.groupId,
                     permissions: ["admin", "read", "write"],
                   },
                 ]
@@ -488,13 +488,13 @@ export class GroupSpaceEditorResource extends GroupSpaceBaseResource {
 
   async requestedPermissions(): Promise<CombinedResourcePermissions[]> {
     if (this.space.isProject()) {
-      const editorGroup = await this.getEditorGroup();
+      const editorGroupSpace = await this.getEditorGroupSpace();
       return [
         {
-          groups: editorGroup
+          groups: editorGroupSpace
             ? [
                 {
-                  id: editorGroup.id,
+                  id: editorGroupSpace.groupId,
                   permissions: ["admin", "read", "write"],
                 },
               ]
@@ -614,7 +614,7 @@ export class GroupSpaceViewerResource extends GroupSpaceBaseResource {
 
   async requestedPermissions(): Promise<CombinedResourcePermissions[]> {
     if (this.space.isProject()) {
-      const editorGroup = await this.getEditorGroup();
+      const editorGroupSpace = await this.getEditorGroupSpace();
       return [
         {
           groups: [
@@ -622,10 +622,10 @@ export class GroupSpaceViewerResource extends GroupSpaceBaseResource {
               id: this.group.id,
               permissions: ["read"],
             },
-            ...((editorGroup
+            ...((editorGroupSpace
               ? [
                   {
-                    id: editorGroup.id,
+                    id: editorGroupSpace.groupId,
                     permissions: ["admin", "read", "write"],
                   },
                 ]

--- a/front/lib/resources/group_space_resource.ts
+++ b/front/lib/resources/group_space_resource.ts
@@ -262,10 +262,6 @@ export class GroupSpaceMemberResource extends GroupSpaceBaseResource {
       transaction,
     });
     assert(groupModel, "Group must exist for member group space");
-    assert(
-      groupModel.kind === "regular",
-      "Group kind must be regular for member group space"
-    );
     const group = new GroupResource(GroupModel, groupModel.get());
 
     return new GroupSpaceMemberResource(
@@ -406,8 +402,10 @@ export class GroupSpaceEditorResource extends GroupSpaceBaseResource {
     }
   ): Promise<GroupSpaceEditorResource> {
     assert(space.isProject(), "Editor groups only apply to project spaces");
-    assert(group.isSpaceEditor(), "space_editors groups can be editor groups");
-
+    assert(
+      group.isSpaceEditor() || group.isProvisioned(),
+      "Only space editor or provisioned groups can be an editor group"
+    );
     const groupSpace = await GroupSpaceModel.create(
       {
         groupId: group.id,
@@ -452,11 +450,11 @@ export class GroupSpaceEditorResource extends GroupSpaceBaseResource {
       transaction,
     });
     assert(groupModel, "Group must exist for editor group space");
-    assert(
-      groupModel.kind === "space_editors",
-      "Group kind must be space_editors for editor group space"
-    );
     const group = new GroupResource(GroupModel, groupModel.get());
+    assert(
+      group.isSpaceEditor() || group.isProvisioned(),
+      "Only space editors or provisioned groups can be an editor group"
+    );
 
     return new GroupSpaceEditorResource(
       GroupSpaceModel,
@@ -572,6 +570,7 @@ export class GroupSpaceViewerResource extends GroupSpaceBaseResource {
     );
 
     const group = new GroupResource(GroupModel, groupModel.get());
+    assert(group.isGlobal(), "Only the global group can be a viewer group");
 
     return new GroupSpaceViewerResource(
       GroupSpaceModel,

--- a/front/lib/resources/space_resource.test.ts
+++ b/front/lib/resources/space_resource.test.ts
@@ -774,7 +774,7 @@ describe("SpaceResource", () => {
             isRestricted: true,
             managementMode: "manual",
             memberIds: [user1.sId, user2.sId],
-            editorIds: [editorUser.sId], // Keep the editor
+            editorIds: [editorUser.sId],
           });
 
           expect(result.isOk()).toBe(true);

--- a/front/lib/resources/space_resource.test.ts
+++ b/front/lib/resources/space_resource.test.ts
@@ -12,6 +12,10 @@ import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import {
+  GroupSpaceEditorResource,
+  GroupSpaceMemberResource,
+} from "@app/lib/resources/group_space_resource";
 
 describe("SpaceResource", () => {
   describe("updatePermissions", () => {
@@ -482,7 +486,10 @@ describe("SpaceResource", () => {
 
       it("should remove global group when changing from open to restricted", async () => {
         // First add global group to make it open
-        await regularSpace.linkGroup(adminAuth, globalGroup, "member");
+        await GroupSpaceMemberResource.makeNew(adminAuth, {
+          group: globalGroup,
+          space: regularSpace,
+        });
 
         // Reload space to get updated groups
         const spaceWithGlobalGroup = await SpaceResource.fetchById(
@@ -676,11 +683,10 @@ describe("SpaceResource", () => {
           );
 
           // Link the editor group to the project space with kind="project_editor"
-          await projectSpace.linkGroup(
-            adminAuth,
-            projectEditorGroup,
-            "project_editor"
-          );
+          await GroupSpaceEditorResource.makeNew(adminAuth, {
+            group: projectEditorGroup,
+            space: projectSpace,
+          });
         });
 
         it("should not allow simple members to update space permissions", async () => {
@@ -815,11 +821,10 @@ describe("SpaceResource", () => {
           );
 
           // Link the editor group to the project space with kind="project_editor"
-          await projectSpace.linkGroup(
-            adminAuth,
-            provisionedEditorGroup,
-            "project_editor"
-          );
+          await GroupSpaceEditorResource.makeNew(adminAuth, {
+            group: provisionedEditorGroup,
+            space: projectSpace,
+          });
         });
 
         it("should not allow simple members to update space permissions", async () => {

--- a/front/lib/resources/space_resource.test.ts
+++ b/front/lib/resources/space_resource.test.ts
@@ -932,12 +932,8 @@ describe("SpaceResource", () => {
           expect(result.isOk()).toBe(true);
 
           // Verify the new provisioned group is associated
-          const groupSpaces = await GroupSpaceModel.findAll({
-            where: {
-              vaultId: projectSpace.id,
-              workspaceId: workspace.id,
-              kind: "member",
-            },
+          const groupSpaces = await GroupSpaceMemberResource.fetchBySpace({
+            space: projectSpace,
           });
           const associatedGroupIds = groupSpaces.map((gs) => gs.groupId);
           expect(associatedGroupIds).toContain(newProvisionedMemberGroup.id);

--- a/front/lib/resources/space_resource.test.ts
+++ b/front/lib/resources/space_resource.test.ts
@@ -3,6 +3,10 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { GroupResource } from "@app/lib/resources/group_resource";
+import {
+  GroupSpaceEditorResource,
+  GroupSpaceMemberResource,
+} from "@app/lib/resources/group_space_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
 import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces";
@@ -12,10 +16,6 @@ import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
-import {
-  GroupSpaceEditorResource,
-  GroupSpaceMemberResource,
-} from "@app/lib/resources/group_space_resource";
 
 describe("SpaceResource", () => {
   describe("updatePermissions", () => {

--- a/front/lib/resources/space_resource.test.ts
+++ b/front/lib/resources/space_resource.test.ts
@@ -679,7 +679,7 @@ describe("SpaceResource", () => {
               workspaceId: workspace.id,
               managementMode: "manual",
             },
-            [projectMemberGroup]
+            { members: [projectMemberGroup] }
           );
 
           // Link the editor group to the project space with kind="project_editor"
@@ -817,7 +817,7 @@ describe("SpaceResource", () => {
               workspaceId: workspace.id,
               managementMode: "group",
             },
-            [projectMemberGroup, provisionedMemberGroup]
+            { members: [projectMemberGroup, provisionedMemberGroup] }
           );
 
           // Link the editor group to the project space with kind="project_editor"

--- a/front/lib/resources/space_resource.test.ts
+++ b/front/lib/resources/space_resource.test.ts
@@ -607,6 +607,330 @@ describe("SpaceResource", () => {
         expect(updatedSpace2?.managementMode).toBe("manual");
       });
     });
+
+    describe("project space editor and member permissions", () => {
+      let projectSpace: SpaceResource;
+      let projectMemberGroup: GroupResource;
+      let projectEditorGroup: GroupResource;
+      let editorUser: UserResource;
+      let memberUser: UserResource;
+      let nonMemberUser: UserResource;
+
+      beforeEach(async () => {
+        // Create users for testing
+        editorUser = await UserFactory.basic();
+        memberUser = await UserFactory.basic();
+        nonMemberUser = await UserFactory.basic();
+
+        await MembershipFactory.associate(workspace, editorUser, {
+          role: "user",
+        });
+        await MembershipFactory.associate(workspace, memberUser, {
+          role: "user",
+        });
+        await MembershipFactory.associate(workspace, nonMemberUser, {
+          role: "user",
+        });
+
+        // Create a project space with member and editor groups
+        projectMemberGroup = await GroupResource.makeNew({
+          name: "Project Members Group",
+          workspaceId: workspace.id,
+          kind: "regular",
+        });
+      });
+
+      describe("with manual groups", () => {
+        beforeEach(async () => {
+          projectEditorGroup = await GroupResource.makeNew({
+            name: "Project Editors Group",
+            workspaceId: workspace.id,
+            kind: "space_editors",
+          });
+
+          projectSpace = await SpaceResource.makeNew(
+            {
+              name: "Test Project Space",
+              kind: "project",
+              workspaceId: workspace.id,
+              managementMode: "manual",
+            },
+            [projectMemberGroup]
+          );
+
+          // Link the editor group to the project space with kind="project_editor"
+          await GroupSpaceModel.create({
+            groupId: projectEditorGroup.id,
+            vaultId: projectSpace.id,
+            workspaceId: workspace.id,
+            kind: "project_editor",
+          });
+        });
+
+        it("should not allow simple members to update space permissions", async () => {
+          // Add user as a simple member
+          await projectMemberGroup.addMember(adminAuth, {
+            user: memberUser.toJSON(),
+          });
+
+          // Create an authenticator for the member user
+          const memberAuth = await Authenticator.fromUserIdAndWorkspaceId(
+            memberUser.sId,
+            workspace.sId
+          );
+
+          // Reload space to get updated groups
+          const reloadedSpace = await SpaceResource.fetchById(
+            adminAuth,
+            projectSpace.sId
+          );
+
+          // Member should NOT be able to update space permissions
+          const result = await reloadedSpace!.updatePermissions(memberAuth, {
+            name: "Test Project Space",
+            isRestricted: true,
+            managementMode: "manual",
+            memberIds: [user1.sId],
+          });
+
+          expect(result.isErr()).toBe(true);
+          if (result.isErr()) {
+            expect(result.error.code).toBe("unauthorized");
+          }
+        });
+
+        it("should not allow non-members to update space permissions", async () => {
+          // Create an authenticator for a non-member user
+          const nonMemberAuth = await Authenticator.fromUserIdAndWorkspaceId(
+            nonMemberUser.sId,
+            workspace.sId
+          );
+
+          // Reload space to get updated groups
+          const reloadedSpace = await SpaceResource.fetchById(
+            adminAuth,
+            projectSpace.sId
+          );
+
+          // Non-member should NOT be able to update space permissions
+          const result = await reloadedSpace!.updatePermissions(nonMemberAuth, {
+            name: "Test Project Space",
+            isRestricted: true,
+            managementMode: "manual",
+            memberIds: [user1.sId],
+          });
+
+          expect(result.isErr()).toBe(true);
+          if (result.isErr()) {
+            expect(result.error.code).toBe("unauthorized");
+          }
+        });
+
+        it("should allow editors to manage members through updatePermissions", async () => {
+          // Add editor to the editor group
+          await projectEditorGroup.addMember(adminAuth, {
+            user: editorUser.toJSON(),
+          });
+
+          // Create an authenticator for the editor user
+          const editorAuth = await Authenticator.fromUserIdAndWorkspaceId(
+            editorUser.sId,
+            workspace.sId
+          );
+
+          // Reload space to get updated groups
+          const reloadedSpace = await SpaceResource.fetchById(
+            editorAuth,
+            projectSpace.sId
+          );
+
+          // Editor should be able to manage members through updatePermissions
+          const result = await reloadedSpace!.updatePermissions(editorAuth, {
+            name: "Test Project Space",
+            isRestricted: true,
+            managementMode: "manual",
+            memberIds: [user1.sId, user2.sId],
+            editorIds: [editorUser.sId], // Keep the editor
+          });
+
+          expect(result.isOk()).toBe(true);
+
+          // Verify members were added
+          const members = await projectMemberGroup.getActiveMembers(adminAuth);
+          const memberSIds = members.map((m) => m.sId);
+          expect(memberSIds).toContain(user1.sId);
+          expect(memberSIds).toContain(user2.sId);
+
+          // Verify editor is still in the editor group
+          const editors = await projectEditorGroup.getActiveMembers(adminAuth);
+          const editorSIds = editors.map((m) => m.sId);
+          expect(editorSIds).toContain(editorUser.sId);
+        });
+      });
+
+      describe("with provisioned groups", () => {
+        let provisionedMemberGroup: GroupResource;
+        let provisionedEditorGroup: GroupResource;
+
+        beforeEach(async () => {
+          // Create provisioned groups
+          provisionedMemberGroup = await GroupResource.makeNew({
+            name: "Provisioned Members Group",
+            workspaceId: workspace.id,
+            kind: "provisioned",
+          });
+
+          provisionedEditorGroup = await GroupResource.makeNew({
+            name: "Provisioned Editors Group",
+            workspaceId: workspace.id,
+            kind: "provisioned",
+          });
+
+          projectSpace = await SpaceResource.makeNew(
+            {
+              name: "Test Project Space",
+              kind: "project",
+              workspaceId: workspace.id,
+              managementMode: "group",
+            },
+            [projectMemberGroup, provisionedMemberGroup]
+          );
+
+          // Link the editor group to the project space with kind="project_editor"
+          await GroupSpaceModel.create({
+            groupId: provisionedEditorGroup.id,
+            vaultId: projectSpace.id,
+            workspaceId: workspace.id,
+            kind: "project_editor",
+          });
+        });
+
+        it("should not allow simple members to update space permissions", async () => {
+          // Add user as a simple member to the provisioned group
+          await provisionedMemberGroup.addMember(adminAuth, {
+            user: memberUser.toJSON(),
+          });
+
+          // Create an authenticator for the member user
+          const memberAuth = await Authenticator.fromUserIdAndWorkspaceId(
+            memberUser.sId,
+            workspace.sId
+          );
+
+          // Reload space to get updated groups
+          const reloadedSpace = await SpaceResource.fetchById(
+            adminAuth,
+            projectSpace.sId
+          );
+
+          // Member should NOT be able to update space permissions
+          const result = await reloadedSpace!.updatePermissions(memberAuth, {
+            name: "Test Project Space",
+            isRestricted: true,
+            managementMode: "group",
+            groupIds: [provisionedMemberGroup.sId],
+          });
+
+          expect(result.isErr()).toBe(true);
+          if (result.isErr()) {
+            expect(result.error.code).toBe("unauthorized");
+          }
+        });
+
+        it("should not allow non-members to update space permissions", async () => {
+          // Create an authenticator for a non-member user
+          const nonMemberAuth = await Authenticator.fromUserIdAndWorkspaceId(
+            nonMemberUser.sId,
+            workspace.sId
+          );
+
+          // Reload space to get updated groups
+          const reloadedSpace = await SpaceResource.fetchById(
+            adminAuth,
+            projectSpace.sId
+          );
+
+          // Non-member should NOT be able to update space permissions
+          const result = await reloadedSpace!.updatePermissions(nonMemberAuth, {
+            name: "Test Project Space",
+            isRestricted: true,
+            managementMode: "group",
+            groupIds: [provisionedMemberGroup.sId],
+          });
+
+          expect(result.isErr()).toBe(true);
+          if (result.isErr()) {
+            expect(result.error.code).toBe("unauthorized");
+          }
+        });
+
+        it("should allow editors to manage members through updatePermissions", async () => {
+          // Add editor to the provisioned editor group
+          await provisionedEditorGroup.addMember(adminAuth, {
+            user: editorUser.toJSON(),
+          });
+
+          // Create another provisioned group for the new members
+          const newProvisionedMemberGroup = await GroupResource.makeNew({
+            name: "New Provisioned Members Group",
+            workspaceId: workspace.id,
+            kind: "provisioned",
+          });
+
+          // Add members to the new provisioned group
+          await newProvisionedMemberGroup.addMembers(adminAuth, {
+            users: [user1.toJSON(), user2.toJSON(), editorUser.toJSON()],
+          });
+
+          // Create an authenticator for the editor user
+          const editorAuth = await Authenticator.fromUserIdAndWorkspaceId(
+            editorUser.sId,
+            workspace.sId
+          );
+
+          // Reload space to get updated groups
+          const reloadedSpace = await SpaceResource.fetchById(
+            editorAuth,
+            projectSpace.sId
+          );
+
+          expect(newProvisionedMemberGroup.canRead(editorAuth)).toBe(true);
+
+          // Editor should be able to manage members through updatePermissions
+          const result = await reloadedSpace!.updatePermissions(editorAuth, {
+            name: "Test Project Space",
+            isRestricted: true,
+            managementMode: "group",
+            groupIds: [newProvisionedMemberGroup.sId],
+            editorGroupIds: [provisionedEditorGroup.sId], // Keep the editor group
+          });
+
+          expect(result.isOk()).toBe(true);
+
+          // Verify the new provisioned group is associated
+          const groupSpaces = await GroupSpaceModel.findAll({
+            where: {
+              vaultId: projectSpace.id,
+              workspaceId: workspace.id,
+              kind: "member",
+            },
+          });
+          const associatedGroupIds = groupSpaces.map((gs) => gs.groupId);
+          expect(associatedGroupIds).toContain(newProvisionedMemberGroup.id);
+
+          // Verify editor group is still associated
+          const editorGroupSpaces = await GroupSpaceModel.findAll({
+            where: {
+              vaultId: projectSpace.id,
+              workspaceId: workspace.id,
+              kind: "editor",
+            },
+          });
+          const editorGroupIds = editorGroupSpaces.map((gs) => gs.groupId);
+          expect(editorGroupIds).toContain(provisionedEditorGroup.id);
+        });
+      });
+    });
   });
 
   describe("listWorkspaceSpaces", () => {

--- a/front/lib/resources/space_resource.test.ts
+++ b/front/lib/resources/space_resource.test.ts
@@ -482,7 +482,7 @@ describe("SpaceResource", () => {
 
       it("should remove global group when changing from open to restricted", async () => {
         // First add global group to make it open
-        regularSpace.linkGroup(adminAuth, globalGroup, "member");
+        await regularSpace.linkGroup(adminAuth, globalGroup, "member");
 
         // Reload space to get updated groups
         const spaceWithGlobalGroup = await SpaceResource.fetchById(
@@ -676,7 +676,7 @@ describe("SpaceResource", () => {
           );
 
           // Link the editor group to the project space with kind="project_editor"
-          projectSpace.linkGroup(
+          await projectSpace.linkGroup(
             adminAuth,
             projectEditorGroup,
             "project_editor"
@@ -815,7 +815,7 @@ describe("SpaceResource", () => {
           );
 
           // Link the editor group to the project space with kind="project_editor"
-          projectSpace.linkGroup(
+          await projectSpace.linkGroup(
             adminAuth,
             provisionedEditorGroup,
             "project_editor"

--- a/front/lib/resources/space_resource.test.ts
+++ b/front/lib/resources/space_resource.test.ts
@@ -95,6 +95,7 @@ describe("SpaceResource", () => {
           isRestricted: false,
           managementMode: "manual",
           memberIds: [user1.sId],
+          editorIds: [],
         });
 
         expect(result.isErr()).toBe(true);
@@ -113,6 +114,7 @@ describe("SpaceResource", () => {
           isRestricted: false,
           managementMode: "manual",
           memberIds: [user1.sId],
+          editorIds: [],
         });
 
         expect(result.isErr()).toBe(true);
@@ -130,6 +132,7 @@ describe("SpaceResource", () => {
           isRestricted: true,
           managementMode: "manual",
           memberIds: [user1.sId, user2.sId],
+          editorIds: [],
         });
 
         expect(result.isOk()).toBe(true);
@@ -159,6 +162,7 @@ describe("SpaceResource", () => {
           isRestricted: true,
           managementMode: "group",
           groupIds: [provisionedGroup.sId],
+          editorGroupIds: [],
         });
         expect(groupResult.isOk()).toBe(true);
 
@@ -175,6 +179,7 @@ describe("SpaceResource", () => {
           isRestricted: true,
           managementMode: "manual",
           memberIds: [user1.sId],
+          editorIds: [],
         });
 
         expect(result.isOk()).toBe(true);
@@ -205,6 +210,7 @@ describe("SpaceResource", () => {
           isRestricted: true,
           managementMode: "group",
           groupIds: [provisionedGroup.sId],
+          editorGroupIds: [],
         });
         expect(groupResult.isOk()).toBe(true);
 
@@ -234,6 +240,7 @@ describe("SpaceResource", () => {
             isRestricted: true,
             managementMode: "manual",
             memberIds: [user1.sId, user2.sId],
+            editorIds: [],
           }
         );
         expect(manualResult.isOk()).toBe(true);
@@ -269,6 +276,7 @@ describe("SpaceResource", () => {
           isRestricted: true,
           managementMode: "group",
           groupIds: [provisionedGroup1.sId, provisionedGroup2.sId],
+          editorGroupIds: [],
         });
 
         expect(result.isOk()).toBe(true);
@@ -309,6 +317,7 @@ describe("SpaceResource", () => {
           isRestricted: true,
           managementMode: "group",
           groupIds: [provisionedGroup1.sId],
+          editorGroupIds: [],
         });
         expect(firstResult.isOk()).toBe(true);
 
@@ -326,6 +335,7 @@ describe("SpaceResource", () => {
             isRestricted: true,
             managementMode: "group",
             groupIds: [provisionedGroup2.sId],
+            editorGroupIds: [],
           }
         );
 
@@ -351,6 +361,7 @@ describe("SpaceResource", () => {
           isRestricted: true,
           managementMode: "manual",
           memberIds: [user1.sId],
+          editorIds: [],
         });
         expect(manualResult.isOk()).toBe(true);
 
@@ -373,6 +384,7 @@ describe("SpaceResource", () => {
           isRestricted: true,
           managementMode: "group",
           groupIds: [provisionedGroup.sId],
+          editorGroupIds: [],
         });
 
         expect(result.isOk()).toBe(true);
@@ -397,6 +409,7 @@ describe("SpaceResource", () => {
           isRestricted: true,
           managementMode: "manual",
           memberIds: [user1.sId, user2.sId],
+          editorIds: [],
         });
 
         // Verify members are active
@@ -427,6 +440,7 @@ describe("SpaceResource", () => {
           isRestricted: true,
           managementMode: "group",
           groupIds: [provisionedGroup.sId],
+          editorGroupIds: [],
         });
         expect(result.isOk()).toBe(true);
 
@@ -450,6 +464,7 @@ describe("SpaceResource", () => {
           isRestricted: false,
           managementMode: "manual",
           memberIds: [user1.sId],
+          editorIds: [],
         });
 
         expect(result.isOk()).toBe(true);
@@ -467,12 +482,7 @@ describe("SpaceResource", () => {
 
       it("should remove global group when changing from open to restricted", async () => {
         // First add global group to make it open
-        await GroupSpaceModel.create({
-          groupId: globalGroup.id,
-          vaultId: regularSpace.id,
-          workspaceId: workspace.id,
-          kind: "member",
-        });
+        regularSpace.linkGroup(adminAuth, globalGroup, "member");
 
         // Reload space to get updated groups
         const spaceWithGlobalGroup = await SpaceResource.fetchById(
@@ -488,6 +498,7 @@ describe("SpaceResource", () => {
             isRestricted: true,
             managementMode: "manual",
             memberIds: [user1.sId],
+            editorIds: [],
           }
         );
 
@@ -511,6 +522,7 @@ describe("SpaceResource", () => {
           isRestricted: true,
           managementMode: "manual",
           memberIds: [user1.sId],
+          editorIds: [],
         });
 
         const groupSpacesBefore = await GroupSpaceModel.findAll({
@@ -529,6 +541,7 @@ describe("SpaceResource", () => {
           isRestricted: true,
           managementMode: "manual",
           memberIds: [user2.sId],
+          editorIds: [],
         });
 
         const groupSpacesAfter = await GroupSpaceModel.findAll({
@@ -552,6 +565,7 @@ describe("SpaceResource", () => {
           isRestricted: true,
           managementMode: "group",
           groupIds: ["invalid-group-id"],
+          editorGroupIds: [],
         });
 
         expect(result.isErr()).toBe(true);
@@ -568,6 +582,7 @@ describe("SpaceResource", () => {
           isRestricted: true,
           managementMode: "manual",
           memberIds: ["invalid-user-id"],
+          editorIds: [],
         });
 
         // The method should handle this gracefully
@@ -583,6 +598,7 @@ describe("SpaceResource", () => {
           isRestricted: true,
           managementMode: "group",
           groupIds: [],
+          editorGroupIds: [],
         });
         expect(groupResult.isOk()).toBe(true);
 
@@ -597,6 +613,7 @@ describe("SpaceResource", () => {
           isRestricted: true,
           managementMode: "manual",
           memberIds: [user1.sId],
+          editorIds: [],
         });
         expect(manualResult.isOk()).toBe(true);
 
@@ -659,12 +676,11 @@ describe("SpaceResource", () => {
           );
 
           // Link the editor group to the project space with kind="project_editor"
-          await GroupSpaceModel.create({
-            groupId: projectEditorGroup.id,
-            vaultId: projectSpace.id,
-            workspaceId: workspace.id,
-            kind: "project_editor",
-          });
+          projectSpace.linkGroup(
+            adminAuth,
+            projectEditorGroup,
+            "project_editor"
+          );
         });
 
         it("should not allow simple members to update space permissions", async () => {
@@ -691,6 +707,7 @@ describe("SpaceResource", () => {
             isRestricted: true,
             managementMode: "manual",
             memberIds: [user1.sId],
+            editorIds: [],
           });
 
           expect(result.isErr()).toBe(true);
@@ -718,6 +735,7 @@ describe("SpaceResource", () => {
             isRestricted: true,
             managementMode: "manual",
             memberIds: [user1.sId],
+            editorIds: [],
           });
 
           expect(result.isErr()).toBe(true);
@@ -797,12 +815,11 @@ describe("SpaceResource", () => {
           );
 
           // Link the editor group to the project space with kind="project_editor"
-          await GroupSpaceModel.create({
-            groupId: provisionedEditorGroup.id,
-            vaultId: projectSpace.id,
-            workspaceId: workspace.id,
-            kind: "project_editor",
-          });
+          projectSpace.linkGroup(
+            adminAuth,
+            provisionedEditorGroup,
+            "project_editor"
+          );
         });
 
         it("should not allow simple members to update space permissions", async () => {
@@ -829,6 +846,7 @@ describe("SpaceResource", () => {
             isRestricted: true,
             managementMode: "group",
             groupIds: [provisionedMemberGroup.sId],
+            editorGroupIds: [],
           });
 
           expect(result.isErr()).toBe(true);
@@ -856,6 +874,7 @@ describe("SpaceResource", () => {
             isRestricted: true,
             managementMode: "group",
             groupIds: [provisionedMemberGroup.sId],
+            editorGroupIds: [],
           });
 
           expect(result.isErr()).toBe(true);

--- a/front/lib/resources/space_resource.test.ts
+++ b/front/lib/resources/space_resource.test.ts
@@ -923,7 +923,7 @@ describe("SpaceResource", () => {
             where: {
               vaultId: projectSpace.id,
               workspaceId: workspace.id,
-              kind: "editor",
+              kind: "project_editor",
             },
           });
           const editorGroupIds = editorGroupSpaces.map((gs) => gs.groupId);

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -623,7 +623,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
         const memberGroupSpace = await GroupSpaceMemberResource.fetchBySpace(
           auth,
           {
-            spaceId: this.id,
+            space: this,
             transaction: t,
           }
         );
@@ -672,7 +672,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
             // Fetch existing editor group-space relationship
             editorGroupSpace = await GroupSpaceEditorResource.fetchBySpace(
               this.workspaceId,
-              this.id,
+              this,
               t
             );
 
@@ -698,7 +698,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
           // No editors specified, clear the editor group
           const editorGroupSpace = await GroupSpaceEditorResource.fetchBySpace(
             this.workspaceId,
-            this.id,
+            this,
             t
           );
 
@@ -817,7 +817,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
 
     // Get the GroupSpaceMemberResource for the member group
     const memberGroupSpace = await GroupSpaceMemberResource.fetchBySpace(auth, {
-      spaceId: this.id,
+      space: this,
     });
 
     if (!memberGroupSpace) {
@@ -876,7 +876,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
 
     // Get the GroupSpaceMemberResource for the member group
     const memberGroupSpace = await GroupSpaceMemberResource.fetchBySpace(auth, {
-      spaceId: this.id,
+      space: this,
     });
 
     if (!memberGroupSpace) {

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -652,11 +652,6 @@ export class SpaceResource extends BaseResource<SpaceModel> {
 
         // Handle editor group - create if needed and update members
         if (this.isProject()) {
-          assert(
-            editorIds.length > 0,
-            "Projects must have at least one editor."
-          );
-
           let editorGroupSpace = await GroupSpaceEditorResource.fetchBySpace(
             this.workspaceId,
             this,
@@ -684,6 +679,10 @@ export class SpaceResource extends BaseResource<SpaceModel> {
 
           // Set members of the editor group using the GroupSpaceEditorResource
           const editorUsers = await UserResource.fetchByIds(editorIds);
+          assert(
+            editorUsers.length > 0,
+            "Projects must have at least one editor."
+          );
           const setEditorsRes = await editorGroupSpace.setMembers(auth, {
             users: editorUsers.map((u) => u.toJSON()),
             transaction: t,
@@ -722,7 +721,12 @@ export class SpaceResource extends BaseResource<SpaceModel> {
           });
         }
 
-        if (editorGroupIds.length > 0) {
+        if (this.isProject()) {
+          assert(
+            editorGroupIds.length > 0,
+            "Projects must have at least one editor group."
+          );
+          // Add the new editor groups
           const editorGroupsResult = await GroupResource.fetchByIds(
             auth,
             editorGroupIds
@@ -1082,7 +1086,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
                   permissions: ["admin", "read", "write"],
                 });
               } else {
-                // Members get read permissions in restricted projects
+                // Members get read permissions in restricted projects (the unrestricted case is handled by the roles above)
                 acc.push({
                   id: group.id,
                   permissions: ["read"],

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -37,12 +37,7 @@ import type {
   SpaceKind,
   SpaceType,
 } from "@app/types";
-import {
-  Err,
-  GLOBAL_SPACE_NAME,
-  Ok,
-  removeNulls,
-} from "@app/types";
+import { Err, GLOBAL_SPACE_NAME, Ok, removeNulls } from "@app/types";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -1130,7 +1130,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   }
 
   isProjectAndRestricted() {
-    return this.isProject() && !this.groups.some((group) => group.isGlobal());
+    return this.isProject() && !this.isOpen();
   }
 
   isRegularAndOpen() {

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -38,13 +38,11 @@ import type {
   SpaceType,
 } from "@app/types";
 import {
-  assertNever,
   Err,
   GLOBAL_SPACE_NAME,
   Ok,
   removeNulls,
 } from "@app/types";
-import { Group } from "lucide-react";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -737,6 +737,10 @@ export class SpaceResource extends BaseResource<SpaceModel> {
             return editorGroupsResult;
           }
           const selectedEditorGroups = editorGroupsResult.value;
+          assert(
+            selectedEditorGroups.length > 0,
+            "Projects must have at least one editor group."
+          );
           for (const selectedEditorGroup of selectedEditorGroups) {
             await GroupSpaceEditorResource.makeNew(auth, {
               group: selectedEditorGroup,

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -1242,12 +1242,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   toJSON(): SpaceType {
     return {
       createdAt: this.createdAt.getTime(),
-      groupIds: this.groups
-        .filter((group) => group.group_vaults?.kind === "member")
-        .map((group) => group.sId),
-      editorGroupIds: this.groups
-        .filter((group) => group.group_vaults?.kind === "project_editor")
-        .map((group) => group.sId),
+      groupIds: this.groups.map((group) => group.sId),
       isRestricted:
         this.isRegularAndRestricted() || this.isProjectAndRestricted(),
 

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -37,7 +37,13 @@ import type {
   SpaceKind,
   SpaceType,
 } from "@app/types";
-import { Err, GLOBAL_SPACE_NAME, Ok, removeNulls } from "@app/types";
+import {
+  assertNever,
+  Err,
+  GLOBAL_SPACE_NAME,
+  Ok,
+  removeNulls,
+} from "@app/types";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -1097,7 +1097,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
                 // Members get read permissions in restricted projects (the unrestricted case is handled by the roles above)
                 acc.push({
                   id: group.id,
-                  permissions: ["read"],
+                  permissions: ["read", "write"],
                 });
               }
             }

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -654,23 +654,19 @@ export class SpaceResource extends BaseResource<SpaceModel> {
           }
 
           // Set members of the editor group
-          const setEditorsRes = await editorGroup.setMembers(
-            auth,
-            { users: editorUsers.map((u) => u.toJSON()) },
-            { transaction: t }
-          );
+          const setEditorsRes = await editorGroup.setMembers(auth, {
+            users: editorUsers.map((u) => u.toJSON()),
+            transaction: t,
+          });
           if (setEditorsRes.isErr()) {
             return setEditorsRes;
           }
         } else if (editorGroup) {
           // No editors specified, clear the editor group
-          const setEditorsRes = await editorGroup.setMembers(
-            auth,
-            { users: [] },
-            {
-              transaction: t,
-            }
-          );
+          const setEditorsRes = await editorGroup.setMembers(auth, {
+            users: [],
+            transaction: t,
+          });
           if (setEditorsRes.isErr()) {
             return setEditorsRes;
           }

--- a/front/migrations/20241205_update_space_group_names.ts
+++ b/front/migrations/20241205_update_space_group_names.ts
@@ -3,6 +3,11 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
 import { makeScript } from "@app/scripts/helpers";
 import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
+import {
+  PROJECT_EDITOR_GROUP_PREFIX,
+  PROJECT_GROUP_PREFIX,
+  SPACE_GROUP_PREFIX,
+} from "@app/types";
 
 makeScript({}, async ({ execute }) => {
   await runOnAllWorkspaces(async (w) => {
@@ -19,10 +24,13 @@ makeScript({}, async ({ execute }) => {
       if (regularGroups.length === 1) {
         const group = regularGroups[0];
         if (execute) {
-          await group.updateName(auth, `Group for space ${space.name}`);
+          await group.updateName(
+            auth,
+            `${space.isProject() ? PROJECT_GROUP_PREFIX : SPACE_GROUP_PREFIX} ${space.name}`
+          );
         }
         logger.info(
-          `[Execute: ${execute}] Updating group ${group.id} to "Group for space ${space.name}"`
+          `[Execute: ${execute}] Updating group ${group.id} to "${space.isProject() ? PROJECT_GROUP_PREFIX : SPACE_GROUP_PREFIX} ${space.name}"`
         );
       }
 
@@ -32,10 +40,13 @@ makeScript({}, async ({ execute }) => {
       if (spaceEditorsGroups.length === 1) {
         const group = spaceEditorsGroups[0];
         if (execute) {
-          await group.updateName(auth, `Editors for space ${space.name}`);
+          await group.updateName(
+            auth,
+            `${PROJECT_EDITOR_GROUP_PREFIX} ${space.name}`
+          );
         }
         logger.info(
-          `[Execute: ${execute}] Updating group ${group.id} to "Editors for space ${space.name}"`
+          `[Execute: ${execute}] Updating group ${group.id} to "${PROJECT_EDITOR_GROUP_PREFIX} ${space.name}"`
         );
       }
     }

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/members/[userId].ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/members/[userId].ts
@@ -116,6 +116,14 @@ async function handler(
                   "Users cannot be removed from system or global groups.",
               },
             });
+          case "group_not_found":
+            return apiError(req, res, {
+              status_code: 404,
+              api_error: {
+                type: "group_not_found",
+                message: "The group was not found in the workspace.",
+              },
+            });
           default:
             assertNever(updateRes.error.code);
         }

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/members/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/members/index.ts
@@ -160,6 +160,14 @@ async function handler(
                   "Users cannot be removed from system or global groups.",
               },
             });
+          case "group_not_found":
+            return apiError(req, res, {
+              status_code: 404,
+              api_error: {
+                type: "group_not_found",
+                message: "The group was not found in the workspace.",
+              },
+            });
           default:
             assertNever(updateRes.error.code);
         }

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/members.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/members.ts
@@ -25,10 +25,12 @@ const PatchSpaceMembersRequestBodySchema = t.intersection([
     t.type({
       memberIds: t.array(t.string),
       managementMode: t.literal("manual"),
+      editorIds: t.array(t.string),
     }),
     t.type({
       groupIds: t.array(t.string),
       managementMode: t.literal("group"),
+      editorGroupIds: t.array(t.string),
     }),
   ]),
 ]);

--- a/front/pages/api/w/[wId]/spaces/index.ts
+++ b/front/pages/api/w/[wId]/spaces/index.ts
@@ -97,15 +97,6 @@ async function handler(
       });
 
     case "POST":
-      if (!auth.isAdmin()) {
-        return apiError(req, res, {
-          status_code: 403,
-          api_error: {
-            type: "workspace_auth_error",
-            message: "Only users that are `admins` can administrate spaces.",
-          },
-        });
-      }
       const bodyValidation = PostSpaceRequestBodySchema.decode(req.body);
 
       if (isLeft(bodyValidation)) {
@@ -120,7 +111,22 @@ async function handler(
         });
       }
 
-      const spaceRes = await createSpaceAndGroup(auth, bodyValidation.right);
+      const requestBody = bodyValidation.right;
+
+      // Check permissions based on space kind
+      // Projects can be created by any workspace member
+      // Regular spaces require admin permissions
+      if (requestBody.spaceKind !== "project" && !auth.isAdmin()) {
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "workspace_auth_error",
+            message: "Only users that are `admins` can create regular spaces.",
+          },
+        });
+      }
+
+      const spaceRes = await createSpaceAndGroup(auth, requestBody);
       if (spaceRes.isErr()) {
         switch (spaceRes.error.code) {
           case "limit_reached":

--- a/front/pages/api/w/[wId]/spaces/index.ts
+++ b/front/pages/api/w/[wId]/spaces/index.ts
@@ -113,19 +113,6 @@ async function handler(
 
       const requestBody = bodyValidation.right;
 
-      // Check permissions based on space kind
-      // Projects can be created by any workspace member
-      // Regular spaces require admin permissions
-      if (requestBody.spaceKind !== "project" && !auth.isAdmin()) {
-        return apiError(req, res, {
-          status_code: 403,
-          api_error: {
-            type: "workspace_auth_error",
-            message: "Only users that are `admins` can create regular spaces.",
-          },
-        });
-      }
-
       const spaceRes = await createSpaceAndGroup(auth, requestBody);
       if (spaceRes.isErr()) {
         switch (spaceRes.error.code) {
@@ -152,6 +139,15 @@ async function handler(
               api_error: {
                 type: "internal_server_error",
                 message: spaceRes.error.message,
+              },
+            });
+          case "unauthorized":
+            return apiError(req, res, {
+              status_code: 403,
+              api_error: {
+                type: "workspace_auth_error",
+                message:
+                  "Only users that are `admins` can create regular spaces.",
               },
             });
           default:

--- a/front/tests/utils/SpaceFactory.ts
+++ b/front/tests/utils/SpaceFactory.ts
@@ -6,7 +6,12 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import type { WorkspaceType } from "@app/types";
-import { removeNulls, SPACE_GROUP_PREFIX } from "@app/types";
+import {
+  PROJECT_EDITOR_GROUP_PREFIX,
+  PROJECT_GROUP_PREFIX,
+  removeNulls,
+  SPACE_GROUP_PREFIX,
+} from "@app/types";
 
 export class SpaceFactory {
   static async defaults(auth: Authenticator) {
@@ -82,7 +87,7 @@ export class SpaceFactory {
   static async project(workspace: WorkspaceType, creatorId?: number) {
     const name = "project " + faker.string.alphanumeric(8);
     const group = await GroupResource.makeNew({
-      name: `Group for project ${name}`,
+      name: `${PROJECT_GROUP_PREFIX} ${name}`,
       workspaceId: workspace.id,
       kind: "regular",
     });
@@ -91,7 +96,7 @@ export class SpaceFactory {
     const defaultCreator = await UserFactory.basic();
     const editorGroup = await GroupResource.makeNew(
       {
-        name: `Editors for project ${name}`,
+        name: `${PROJECT_EDITOR_GROUP_PREFIX} ${name}`,
         workspaceId: workspace.id,
         kind: "space_editors",
       },

--- a/front/tests/utils/SpaceFactory.ts
+++ b/front/tests/utils/SpaceFactory.ts
@@ -1,12 +1,12 @@
 import { faker } from "@faker-js/faker";
 
-import { Authenticator } from "@app/lib/auth";
+import type { Authenticator } from "@app/lib/auth";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
 import type { WorkspaceType } from "@app/types";
 import { removeNulls } from "@app/types";
-import { UserFactory } from "@app/tests/utils/UserFactory";
 
 export class SpaceFactory {
   static async defaults(auth: Authenticator) {

--- a/front/tests/utils/SpaceFactory.ts
+++ b/front/tests/utils/SpaceFactory.ts
@@ -6,7 +6,7 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import type { WorkspaceType } from "@app/types";
-import { removeNulls } from "@app/types";
+import { removeNulls, SPACE_GROUP_PREFIX } from "@app/types";
 
 export class SpaceFactory {
   static async defaults(auth: Authenticator) {
@@ -53,7 +53,7 @@ export class SpaceFactory {
   static async regular(workspace: WorkspaceType) {
     const name = "space " + faker.string.alphanumeric(8);
     const group = await GroupResource.makeNew({
-      name: `Group for space ${name}`,
+      name: `${SPACE_GROUP_PREFIX} ${name}`,
       workspaceId: workspace.id,
       kind: "regular",
     });

--- a/front/types/groups.ts
+++ b/front/types/groups.ts
@@ -127,4 +127,5 @@ export const AGENT_GROUP_PREFIX = "Group for Agent";
 export const SKILL_GROUP_PREFIX = "Group for Skill";
 export const SPACE_GROUP_PREFIX = "Group for space";
 export const PROJECT_GROUP_PREFIX = "Group for project";
+export const PROJECT_EDITOR_GROUP_PREFIX = "Editors for project";
 export const GLOBAL_SPACE_NAME = "Company Data";

--- a/front/types/space.ts
+++ b/front/types/space.ts
@@ -17,6 +17,7 @@ export type UniqueSpaceKind = (typeof UNIQUE_SPACE_KINDS)[number];
 export type SpaceType = {
   createdAt: number;
   groupIds: string[];
+  editorGroupIds?: string[];
   isRestricted: boolean;
   kind: SpaceKind;
   managementMode: "manual" | "group";

--- a/front/types/space.ts
+++ b/front/types/space.ts
@@ -17,7 +17,6 @@ export type UniqueSpaceKind = (typeof UNIQUE_SPACE_KINDS)[number];
 export type SpaceType = {
   createdAt: number;
   groupIds: string[];
-  editorGroupIds?: string[];
   isRestricted: boolean;
   kind: SpaceKind;
   managementMode: "manual" | "group";


### PR DESCRIPTION
## Description

This PR sets the permission in projects.
- Create a project: anyone can create projects
- Update a project: project editors can manage the project

Projects have several layers of permissions: 
1. viewers (can be everyone or nobody, base on if the project is restricted or not), 
2. members (can see the project) 
3. and editors (manage project members and settings without requiring workspace admin privileges). Project creators are editors by default. 

## Tests

Added unit tests

## Risk

Medium. The code is shared with the regular spaces. A risk of breaking regular spaces permissions exist.

## Deploy Plan

Deploy fron
