### PR TITLE
[front] enh: Do not resize image_generation outputs

### DIFF
--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -183,12 +183,17 @@ export async function processToolResults(
             ? block.name
             : `generated-image-${Date.now()}.${extensionsForContentType(block.mimeType as any)[0]}`;
 
+          const imageFileUseCase: FileUseCase =
+            toolConfiguration.mcpServerName === "image_generation"
+              ? "tool_output"
+              : fileUseCase;
+
           return handleBase64Upload(auth, {
             base64Data: block.data,
             mimeType: block.mimeType,
             fileName,
             block,
-            fileUseCase,
+            fileUseCase: imageFileUseCase,
             fileUseCaseMetadata,
           });
         }

--- a/front/lib/api/files/upload.ts
+++ b/front/lib/api/files/upload.ts
@@ -471,6 +471,8 @@ const getProcessingFunction = ({
       );
     } else if (useCase === "avatar") {
       return resizeAndUploadToPublicBucket;
+    } else if (useCase === "tool_output") {
+      return undefined;
     }
     return undefined;
   }


### PR DESCRIPTION
## Description

Do not resize images coming from image_generation tool.
Rationale: 
1. We are paying output tokens for certain resolutions that are orthogonal to our resize threshold
2. Both current inline display / download links use the original
=> Meaning we're resizing for nothing.


## Tests

Tested manually

## Risk

Low

## Deploy Plan

- [ ] Deploy front