### PR TITLE
Fix N+1 Queries In Conversation Rendering For Content Fragment

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1316,7 +1316,7 @@ export async function postNewContentFragment(
     }
   }
 
-  const { contentFragment, messageRow } = await withTransaction(async (t) => {
+  const { messageRow } = await withTransaction(async (t) => {
     await getConversationRankVersionLock(auth, conversation, t);
 
     const fullBlob = {
@@ -1371,7 +1371,7 @@ export async function postNewContentFragment(
 
     await ConversationResource.markAsUpdated(auth, { conversation, t });
 
-    return { contentFragment, messageRow };
+    return { messageRow };
   });
 
   // Use batch method even for single message to ensure optimized file fetching.

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1374,12 +1374,11 @@ export async function postNewContentFragment(
     return { contentFragment, messageRow };
   });
 
-  // Use batch method even for single message to ensure optimized file fetching
-  const [render] = await ContentFragmentResource.batchRenderFromMessages(
-    auth,
-    conversation.sId,
-    [messageRow]
-  );
+  // Use batch method even for single message to ensure optimized file fetching.
+  const [render] = await ContentFragmentResource.batchRenderFromMessages(auth, {
+    conversationId: conversation.sId,
+    messages: [messageRow],
+  });
 
   return new Ok(render);
 }

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1373,11 +1373,13 @@ export async function postNewContentFragment(
 
     return { contentFragment, messageRow };
   });
-  const render = await contentFragment.renderFromMessage({
+
+  // Use batch method even for single message to ensure optimized file fetching
+  const [render] = await ContentFragmentResource.batchRenderFromMessages(
     auth,
-    conversationId: conversation.sId,
-    message: messageRow,
-  });
+    conversation.sId,
+    [messageRow]
+  );
 
   return new Ok(render);
 }

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -670,26 +670,10 @@ async function batchRenderContentFragment(
   conversationId: string,
   messages: MessageModel[]
 ): Promise<ContentFragmentType[]> {
-  const messagesWithContentFragment = messages.filter(
-    (m) => !!m.contentFragment
-  );
-  if (messagesWithContentFragment.find((m) => !m.contentFragment)) {
-    throw new Error(
-      "Unreachable: batchRenderContentFragment must be called with only content fragments"
-    );
-  }
-
-  return Promise.all(
-    messagesWithContentFragment.map(async (message: MessageModel) => {
-      const contentFragment = ContentFragmentResource.fromMessage(message);
-      const render = await contentFragment.renderFromMessage({
-        auth,
-        conversationId,
-        message,
-      });
-
-      return render;
-    })
+  return ContentFragmentResource.batchRenderFromMessages(
+    auth,
+    conversationId,
+    messages
   );
 }
 

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -670,11 +670,10 @@ async function batchRenderContentFragment(
   conversationId: string,
   messages: MessageModel[]
 ): Promise<ContentFragmentType[]> {
-  return ContentFragmentResource.batchRenderFromMessages(
-    auth,
+  return ContentFragmentResource.batchRenderFromMessages(auth, {
     conversationId,
-    messages
-  );
+    messages,
+  });
 }
 
 type RenderMessageVariant = "legacy-light" | "full" | "light";

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -206,8 +206,13 @@ export class ContentFragmentResource extends BaseResource<ContentFragmentModel> 
    */
   static async batchRenderFromMessages(
     auth: Authenticator,
-    conversationId: string,
-    messages: MessageModel[]
+    {
+      conversationId,
+      messages,
+    }: {
+      conversationId: string;
+      messages: MessageModel[];
+    }
   ): Promise<ContentFragmentType[]> {
     const messagesWithContentFragment = messages.filter(
       (m) => !!m.contentFragment
@@ -300,9 +305,8 @@ export class ContentFragmentResource extends BaseResource<ContentFragmentModel> 
   /**
    * Internal method to render a content fragment from a message.
    * Use batchRenderFromMessages instead to avoid N+1 queries.
-   * @private
    */
-  async _renderFromMessage({
+  private async _renderFromMessage({
     auth,
     conversationId,
     message,

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -9,6 +9,7 @@ import type {
   Transaction,
   WhereOptions,
 } from "sequelize";
+import { Op } from "sequelize";
 import type { Readable, Writable } from "stream";
 import { validate } from "uuid";
 
@@ -121,20 +122,32 @@ export class FileResource extends BaseResource<FileModel> {
     );
   }
 
-  static async fetchByModelIdWithAuth(
+  static async fetchByModelIdsWithAuth(
     auth: Authenticator,
-    id: ModelId,
+    ids: ModelId[],
     transaction?: Transaction
-  ): Promise<FileResource | null> {
-    const file = await this.model.findOne({
+  ): Promise<FileResource[]> {
+    const files = await this.model.findAll({
       where: {
-        id,
+        id: {
+          [Op.in]: ids,
+        },
         workspaceId: auth.getNonNullableWorkspace().id,
       },
       transaction,
     });
 
-    return file ? new this(this.model, file.get()) : null;
+    return files.map((f) => new this(this.model, f.get()));
+  }
+
+  static async fetchByModelIdWithAuth(
+    auth: Authenticator,
+    id: ModelId,
+    transaction?: Transaction
+  ): Promise<FileResource | null> {
+    const [file] = await this.fetchByModelIdsWithAuth(auth, [id], transaction);
+
+    return file || null;
   }
 
   static async fetchByShareTokenWithContent(token: string): Promise<{

--- a/front/lib/resources/file_resource.ts
+++ b/front/lib/resources/file_resource.ts
@@ -147,7 +147,7 @@ export class FileResource extends BaseResource<FileModel> {
   ): Promise<FileResource | null> {
     const [file] = await this.fetchByModelIdsWithAuth(auth, [id], transaction);
 
-    return file || null;
+    return file ?? null;
   }
 
   static async fetchByShareTokenWithContent(token: string): Promise<{


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
### Problems

1. File Fetching Queries (Second N+1)

`batchRenderContentFragment` was executing N+1 queries when rendering file content fragments. For each file
attachment, it called `FileResource.fetchByModelIdWithAuth()`:

Root cause: Each content fragment's `renderFromMessage` method was individually fetching its associated file
instead of batch fetching.

### Solutions

Implemented Batch File Fetching Pattern

- Added FileResource.fetchByModelIdsWithAuth() to fetch multiple files in one query
- Created ContentFragmentResource.batchRenderFromMessages() that:
  - Collects all fileIds from content fragments
  - Batch fetches all files in a single query
  - Maps files to their content fragments for rendering
- Made _renderFromMessage() private to enforce batch usage
- Updated all call sites to use the optimized batch method

Impact

For a conversation with 50 content fragments (40 with file attachments):
- Before: 50 content fragment queries + 40 file queries = 90 database queries
- After: 0 content fragment queries + 1 file query = 1 database query

Significant performance improvement for conversations with many attachments, especially in the agent loop.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
