### PR TITLE
[feat] - sparkle(VoicePicker): new component

### DIFF
--- a/sparkle/playground/src/data/dataSources.ts
+++ b/sparkle/playground/src/data/dataSources.ts
@@ -176,7 +176,10 @@ function generateFileName(
 }
 
 // Generate file type distribution: 30% PDF, 20% docx, 15% xlsx, 10% pptx, 10% txt, 10% md, 5% doc
-function getFileTypeForIndex(index: number, seed: string): DataSource["fileType"] {
+function getFileTypeForIndex(
+  index: number,
+  seed: string
+): DataSource["fileType"] {
   const random = seededRandom(seed, index * 2);
   const value = random * 100;
 
@@ -190,7 +193,10 @@ function getFileTypeForIndex(index: number, seed: string): DataSource["fileType"
 }
 
 // Generate dates within the last year
-function generateDates(index: number, seed: string): { createdAt: Date; updatedAt: Date } {
+function generateDates(
+  index: number,
+  seed: string
+): { createdAt: Date; updatedAt: Date } {
   const now = new Date();
   const random = seededRandom(seed, index * 3);
   const random2 = seededRandom(seed, index * 3 + 1);
@@ -242,7 +248,10 @@ function getIconForFileType(
 }
 
 // Generate data sources for a space
-function generateDataSourcesForSpace(spaceId: string, count: number): DataSource[] {
+function generateDataSourcesForSpace(
+  spaceId: string,
+  count: number
+): DataSource[] {
   const dataSources: DataSource[] = [];
 
   for (let i = 0; i < count; i++) {
@@ -279,7 +288,7 @@ export function getDataSourcesBySpaceId(spaceId: string): DataSource[] {
     // 20% chance of 0 files, 80% chance of 3-80 files
     const randomValue = seededRandom(spaceId, 0);
     let fileCount: number;
-    
+
     if (randomValue < 0.2) {
       // 20% probability: 0 files
       fileCount = 0;
@@ -288,8 +297,11 @@ export function getDataSourcesBySpaceId(spaceId: string): DataSource[] {
       const countRandom = seededRandom(spaceId, 1);
       fileCount = Math.floor(countRandom * 78) + 3; // 78 possible values (3 to 80)
     }
-    
-    dataSourceCache.set(spaceId, generateDataSourcesForSpace(spaceId, fileCount));
+
+    dataSourceCache.set(
+      spaceId,
+      generateDataSourcesForSpace(spaceId, fileCount)
+    );
   }
   return dataSourceCache.get(spaceId)!;
 }

--- a/sparkle/src/components/NavigationList.tsx
+++ b/sparkle/src/components/NavigationList.tsx
@@ -167,7 +167,7 @@ const NavigationListItem = React.forwardRef<
             {icon && <Icon visual={icon} size="xs" className="s-m-0.5" />}
             {avatar}
             {label && (
-              <span className="s-grow s-overflow-hidden s-text-ellipsis s-whitespace-nowrap group-hover/menu-item:s-pr-8 group-focus-within/menu-item:s-pr-8 group-data-[selected=true]/menu-item:s-pr-8">
+              <span className="s-grow s-overflow-hidden s-text-ellipsis s-whitespace-nowrap group-focus-within/menu-item:s-pr-8 group-hover/menu-item:s-pr-8 group-data-[selected=true]/menu-item:s-pr-8">
                 {label}
               </span>
             )}
@@ -179,7 +179,7 @@ const NavigationListItem = React.forwardRef<
                 className={cn(
                   "s-flex-shrink-0 s-translate-x-0.5",
                   moreMenu &&
-                    "group-hover/menu-item:s-hidden group-focus-within/menu-item:s-hidden"
+                    "group-focus-within/menu-item:s-hidden group-hover/menu-item:s-hidden"
                 )}
               />
             )}
@@ -188,7 +188,7 @@ const NavigationListItem = React.forwardRef<
                 className={cn(
                   "s-heading-xs s-flex s-flex-shrink-0 s-items-center s-justify-center s-rounded-full",
                   moreMenu &&
-                    "group-hover/menu-item:s-hidden group-focus-within/menu-item:s-hidden",
+                    "group-focus-within/menu-item:s-hidden group-hover/menu-item:s-hidden",
                   getStatusDotColor()
                 )}
               />

--- a/sparkle/src/components/VoicePicker.tsx
+++ b/sparkle/src/components/VoicePicker.tsx
@@ -1,0 +1,267 @@
+import * as React from "react";
+
+import type { ButtonProps, ButtonSizeType } from "@sparkle/components/Button";
+import { Button } from "@sparkle/components/Button";
+import { MicIcon, SquareIcon } from "@sparkle/icons/app";
+import { cn } from "@sparkle/lib/utils";
+
+const DEFAULT_PRESS_DELAY_MS = 150;
+const VOICE_LEVEL_BASE_HEIGHTS = [
+  22, 33, 18, 64, 98, 56, 6, 34, 76, 46, 12, 22,
+];
+
+export type VoicePickerStatus =
+  | "idle"
+  | "authorizing_microphone"
+  | "recording"
+  | "transcribing";
+
+type VoicePickerInteractionMode = "hold" | "click";
+
+export interface VoicePickerProps {
+  status: VoicePickerStatus;
+  level: number;
+  elapsedSeconds: number;
+  onRecordStart: () => void | Promise<void>;
+  onRecordStop: () => void | Promise<void>;
+  size?: Exclude<ButtonSizeType, "xmini" | "mini">;
+  disabled?: boolean;
+  showStopLabel?: boolean;
+  pressDelayMs?: number;
+  buttonProps?: Omit<
+    ButtonProps,
+    "icon" | "label" | "variant" | "isLoading" | "disabled" | "size"
+  >;
+}
+
+export function VoicePicker({
+  status,
+  level,
+  elapsedSeconds,
+  onRecordStart,
+  onRecordStop,
+  size = "xs",
+  disabled = false,
+  showStopLabel = false,
+  pressDelayMs = DEFAULT_PRESS_DELAY_MS,
+  buttonProps,
+}: VoicePickerProps): React.ReactElement {
+  const [interactionMode, setInteractionMode] =
+    React.useState<VoicePickerInteractionMode>("hold");
+  const pressStartRef = React.useRef<number | null>(null);
+  const pressTimeoutRef = React.useRef<number | null>(null);
+
+  const isRecording = status === "recording";
+  const isTranscribing = status === "transcribing";
+  const isLoading =
+    status === "transcribing" || status === "authorizing_microphone";
+  const shouldShowStop = isRecording && interactionMode === "click";
+
+  function clearPressTimeout(): void {
+    if (pressTimeoutRef.current !== null) {
+      window.clearTimeout(pressTimeoutRef.current);
+      pressTimeoutRef.current = null;
+    }
+  }
+
+  function stopEvent(event: React.SyntheticEvent): void {
+    event.preventDefault();
+    event.stopPropagation();
+  }
+
+  async function handlePointerDown(
+    event: React.PointerEvent<HTMLButtonElement>
+  ): Promise<void> {
+    buttonProps?.onPointerDown?.(event);
+    if (event.defaultPrevented) {
+      return;
+    }
+
+    stopEvent(event);
+
+    if (disabled) {
+      return;
+    }
+
+    pressStartRef.current = Date.now();
+
+    clearPressTimeout();
+    pressTimeoutRef.current = window.setTimeout(async () => {
+      if (pressStartRef.current !== null) {
+        setInteractionMode("hold");
+        if (status === "idle") {
+          await onRecordStart();
+        }
+      }
+    }, pressDelayMs);
+  }
+
+  async function handlePointerUp(
+    event: React.PointerEvent<HTMLButtonElement>
+  ): Promise<void> {
+    buttonProps?.onPointerUp?.(event);
+    if (event.defaultPrevented) {
+      return;
+    }
+
+    stopEvent(event);
+
+    if (disabled) {
+      return;
+    }
+
+    const start = pressStartRef.current;
+    clearPressTimeout();
+    pressStartRef.current = null;
+
+    const duration =
+      start === null ? Number.POSITIVE_INFINITY : Date.now() - start;
+
+    if (duration < pressDelayMs) {
+      setInteractionMode("click");
+      if (status === "idle") {
+        await onRecordStart();
+        return;
+      }
+      await onRecordStop();
+      return;
+    }
+
+    if (status === "recording") {
+      await onRecordStop();
+    }
+  }
+
+  async function handlePointerLeave(
+    event: React.PointerEvent<HTMLButtonElement>
+  ): Promise<void> {
+    buttonProps?.onPointerLeave?.(event);
+    if (event.defaultPrevented) {
+      return;
+    }
+
+    stopEvent(event);
+
+    if (disabled || interactionMode !== "hold") {
+      return;
+    }
+    if (status === "recording") {
+      await onRecordStop();
+    }
+  }
+
+  async function handleClick(
+    event: React.MouseEvent<HTMLButtonElement>
+  ): Promise<void> {
+    buttonProps?.onClick?.(event);
+    if (event.defaultPrevented) {
+      return;
+    }
+
+    stopEvent(event);
+
+    if (disabled || interactionMode !== "click") {
+      return;
+    }
+    if (status === "recording") {
+      await onRecordStop();
+    }
+  }
+
+  const icon = shouldShowStop ? SquareIcon : MicIcon;
+  const variant = shouldShowStop ? "highlight" : "ghost-secondary";
+  const label = shouldShowStop && showStopLabel ? "Stop" : undefined;
+  const tooltip = computeTooltip(interactionMode, isRecording, isTranscribing);
+
+  return (
+    <>
+      <div
+        className={cn(
+          "s-duration-600 s-flex s-items-center s-justify-end s-gap-2 s-overflow-hidden s-px-2 s-transition-all s-ease-in-out",
+          isRecording ? "s-opacity-100" : "s-hidden"
+        )}
+      >
+        <div className="s-heading-xs s-font-mono">
+          {formatTime(elapsedSeconds)}
+        </div>
+        <VoiceLevelDisplay level={level} />
+      </div>
+      <Button
+        {...buttonProps}
+        size={size}
+        icon={icon}
+        isLoading={isLoading}
+        variant={variant}
+        tooltip={tooltip}
+        label={label}
+        disabled={disabled}
+        onPointerDown={handlePointerDown}
+        onPointerUp={handlePointerUp}
+        onPointerLeave={handlePointerLeave}
+        onClick={handleClick}
+      />
+    </>
+  );
+}
+
+interface VoiceLevelDisplayProps {
+  level: number;
+}
+
+function VoiceLevelDisplay({
+  level,
+}: VoiceLevelDisplayProps): React.ReactElement {
+  const clampedLevel = Math.max(0, Math.min(1, level * 1.2));
+  const easedLevel = Math.pow(clampedLevel, 0.8);
+
+  const minHeights = VOICE_LEVEL_BASE_HEIGHTS.map((height) =>
+    Math.max(6, Math.round(height * 0.3))
+  );
+
+  const heights = VOICE_LEVEL_BASE_HEIGHTS.map((height, index) =>
+    Math.max(
+      1,
+      Math.min(
+        100,
+        Math.round(
+          minHeights[index] + (height - minHeights[index]) * easedLevel
+        )
+      )
+    )
+  );
+
+  return (
+    <div className="s-flex s-h-5 s-items-center s-gap-0.5">
+      {heights.map((height, index) => (
+        <div
+          key={index}
+          className="s-min-h-1 s-w-0.5 s-rounded-full s-bg-muted-foreground s-transition-all s-duration-150 s-ease-out"
+          style={{ height: `${height}%` }}
+        />
+      ))}
+    </div>
+  );
+}
+
+function computeTooltip(
+  mode: VoicePickerInteractionMode,
+  isRecording: boolean,
+  isTranscribing: boolean
+): string {
+  if (isTranscribing) {
+    return "Transcribing...";
+  }
+  if (mode === "hold" && isRecording) {
+    return "Release to stop";
+  }
+  if (isRecording) {
+    return "Stop recording";
+  }
+  return "Click, or Press & Hold to record";
+}
+
+function formatTime(seconds: number): string {
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+  return `${minutes}:${remainingSeconds.toString().padStart(2, "0")}`;
+}

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -221,3 +221,5 @@ export {
 export { Tree } from "./Tree";
 export { TypingAnimation } from "./TypingAnimation";
 export { ValueCard } from "./ValueCard";
+export type { VoicePickerProps, VoicePickerStatus } from "./VoicePicker";
+export { VoicePicker } from "./VoicePicker";

--- a/sparkle/src/stories/InteractiveImageGrid.stories.tsx
+++ b/sparkle/src/stories/InteractiveImageGrid.stories.tsx
@@ -104,7 +104,9 @@ export const InteractiveImageWithRemove = () => {
         )}
       </div>
       <div>
-        <h2 className="s-mb-2">Without onClose (hover to see download button, no X button)</h2>
+        <h2 className="s-mb-2">
+          Without onClose (hover to see download button, no X button)
+        </h2>
         <InteractiveImageGrid images={images.slice(1, 2)} />
       </div>
     </div>

--- a/sparkle/src/stories/VoicePicker.stories.tsx
+++ b/sparkle/src/stories/VoicePicker.stories.tsx
@@ -1,0 +1,151 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import React from "react";
+
+import { BUTTON_SIZES } from "@sparkle/components/Button";
+import type {
+  VoicePickerProps,
+  VoicePickerStatus,
+} from "@sparkle/index_with_tw_base";
+import { VoicePicker } from "@sparkle/index_with_tw_base";
+
+const meta = {
+  title: "Primitives/VoicePicker",
+  component: VoicePicker,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "padded",
+  },
+  argTypes: {
+    status: { control: false },
+    level: { control: false },
+    elapsedSeconds: { control: false },
+    onRecordStart: { control: false },
+    onRecordStop: { control: false },
+    buttonProps: { control: false },
+    size: {
+      control: { type: "select" },
+      options: BUTTON_SIZES,
+    },
+    disabled: {
+      control: "boolean",
+    },
+    showStopLabel: {
+      control: "boolean",
+    },
+    pressDelayMs: {
+      control: "number",
+    },
+  },
+} satisfies Meta<typeof VoicePicker>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+type VoicePickerDemoProps = Pick<
+  VoicePickerProps,
+  "size" | "disabled" | "showStopLabel" | "pressDelayMs"
+>;
+
+export const Interactive: Story = {
+  args: {
+    size: "xs",
+    disabled: false,
+    showStopLabel: true,
+    pressDelayMs: 150,
+  },
+  render: function Render(args: VoicePickerDemoProps): React.ReactElement {
+    return <VoicePickerDemo {...args} />;
+  },
+};
+
+function VoicePickerDemo({
+  size,
+  disabled,
+  showStopLabel,
+  pressDelayMs,
+}: VoicePickerDemoProps): React.ReactElement {
+  const [status, setStatus] = React.useState<VoicePickerStatus>("idle");
+  const [level, setLevel] = React.useState(0);
+  const [elapsedSeconds, setElapsedSeconds] = React.useState(0);
+
+  const elapsedIntervalRef = React.useRef<number | null>(null);
+  const levelIntervalRef = React.useRef<number | null>(null);
+  const transcribeTimeoutRef = React.useRef<number | null>(null);
+
+  React.useEffect(() => {
+    return () => {
+      clearIntervalRef(elapsedIntervalRef);
+      clearIntervalRef(levelIntervalRef);
+      clearTimeoutRef(transcribeTimeoutRef);
+    };
+  }, []);
+
+  React.useEffect(() => {
+    if (status !== "recording") {
+      clearIntervalRef(elapsedIntervalRef);
+      clearIntervalRef(levelIntervalRef);
+      setElapsedSeconds(0);
+      setLevel(0);
+      return;
+    }
+
+    elapsedIntervalRef.current = window.setInterval(() => {
+      setElapsedSeconds((previous) => previous + 1);
+    }, 1000);
+
+    levelIntervalRef.current = window.setInterval(() => {
+      setLevel(Math.random());
+    }, 200);
+
+    return () => {
+      clearIntervalRef(elapsedIntervalRef);
+      clearIntervalRef(levelIntervalRef);
+    };
+  }, [status]);
+
+  async function handleRecordStart(): Promise<void> {
+    clearTimeoutRef(transcribeTimeoutRef);
+    setStatus("recording");
+  }
+
+  async function handleRecordStop(): Promise<void> {
+    if (status !== "recording") {
+      return;
+    }
+    setStatus("transcribing");
+    clearTimeoutRef(transcribeTimeoutRef);
+    transcribeTimeoutRef.current = window.setTimeout(() => {
+      setStatus("idle");
+    }, 1200);
+  }
+
+  return (
+    <div className="s-flex s-items-center s-gap-2">
+      <VoicePicker
+        status={status}
+        level={level}
+        elapsedSeconds={elapsedSeconds}
+        onRecordStart={handleRecordStart}
+        onRecordStop={handleRecordStop}
+        size={size}
+        disabled={disabled}
+        showStopLabel={showStopLabel}
+        pressDelayMs={pressDelayMs}
+      />
+    </div>
+  );
+}
+
+function clearIntervalRef(ref: React.MutableRefObject<number | null>): void {
+  if (ref.current !== null) {
+    window.clearInterval(ref.current);
+    ref.current = null;
+  }
+}
+
+function clearTimeoutRef(ref: React.MutableRefObject<number | null>): void {
+  if (ref.current !== null) {
+    window.clearTimeout(ref.current);
+    ref.current = null;
+  }
+}

--- a/sparkle/src/stories/VoicePicker.stories.tsx
+++ b/sparkle/src/stories/VoicePicker.stories.tsx
@@ -1,7 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import React from "react";
-
-import { BUTTON_SIZES } from "@sparkle/components/Button";
 import type {
   VoicePickerProps,
   VoicePickerStatus,
@@ -24,7 +22,7 @@ const meta = {
     buttonProps: { control: false },
     size: {
       control: { type: "select" },
-      options: BUTTON_SIZES,
+      options: ["xs", "sm", "md"],
     },
     disabled: {
       control: "boolean",
@@ -48,13 +46,25 @@ type VoicePickerDemoProps = Pick<
 
 export const Interactive: Story = {
   args: {
+    status: "idle",
+    level: 0,
+    elapsedSeconds: 0,
+    onRecordStart: async () => {},
+    onRecordStop: async () => {},
     size: "xs",
     disabled: false,
     showStopLabel: true,
     pressDelayMs: 150,
   },
-  render: function Render(args: VoicePickerDemoProps): React.ReactElement {
-    return <VoicePickerDemo {...args} />;
+  render: function Render(args: VoicePickerProps): React.ReactElement {
+    return (
+      <VoicePickerDemo
+        size={args.size}
+        disabled={args.disabled}
+        showStopLabel={args.showStopLabel}
+        pressDelayMs={args.pressDelayMs}
+      />
+    );
   },
 };
 

--- a/sparkle/src/styles/allotment.css
+++ b/sparkle/src/styles/allotment.css
@@ -17,28 +17,37 @@
   width: 100%;
 }
 
-.allotment-module_splitView__L-yRc > .allotment-module_sashContainer__fzwJF > .allotment-module_sash__QA-2t {
+.allotment-module_splitView__L-yRc
+  > .allotment-module_sashContainer__fzwJF
+  > .allotment-module_sash__QA-2t {
   pointer-events: auto;
 }
 
-.allotment-module_splitView__L-yRc > .allotment-module_splitViewContainer__rQnVa {
+.allotment-module_splitView__L-yRc
+  > .allotment-module_splitViewContainer__rQnVa {
   height: 100%;
   position: relative;
   white-space: nowrap;
   width: 100%;
 }
 
-.allotment-module_splitView__L-yRc > .allotment-module_splitViewContainer__rQnVa > .allotment-module_splitViewView__MGZ6O {
+.allotment-module_splitView__L-yRc
+  > .allotment-module_splitViewContainer__rQnVa
+  > .allotment-module_splitViewView__MGZ6O {
   overflow: hidden;
   position: absolute;
   white-space: initial;
 }
 
-.allotment-module_splitView__L-yRc.allotment-module_vertical__WSwwa > .allotment-module_splitViewContainer__rQnVa > .allotment-module_splitViewView__MGZ6O {
+.allotment-module_splitView__L-yRc.allotment-module_vertical__WSwwa
+  > .allotment-module_splitViewContainer__rQnVa
+  > .allotment-module_splitViewView__MGZ6O {
   width: 100%;
 }
 
-.allotment-module_splitView__L-yRc.allotment-module_horizontal__7doS8 > .allotment-module_splitViewContainer__rQnVa > .allotment-module_splitViewView__MGZ6O {
+.allotment-module_splitView__L-yRc.allotment-module_horizontal__7doS8
+  > .allotment-module_splitViewContainer__rQnVa
+  > .allotment-module_splitViewView__MGZ6O {
   height: 100%;
 }
 
@@ -129,7 +138,8 @@
   height: var(--sash-size);
 }
 
-.sash-module_sash__K-9lB:not(.sash-module_disabled__Hm-wx) > .sash-module_orthogonal-drag-handle__Yii2- {
+.sash-module_sash__K-9lB:not(.sash-module_disabled__Hm-wx)
+  > .sash-module_orthogonal-drag-handle__Yii2- {
   content: " ";
   height: calc(var(--sash-size) * 2);
   width: calc(var(--sash-size) * 2);
@@ -139,36 +149,48 @@
   position: absolute;
 }
 
-.sash-module_sash__K-9lB.sash-module_horizontal__kFbiw.sash-module_orthogonal-edge-north__f7Noe:not(.sash-module_disabled__Hm-wx)
+.sash-module_sash__K-9lB.sash-module_horizontal__kFbiw.sash-module_orthogonal-edge-north__f7Noe:not(
+    .sash-module_disabled__Hm-wx
+  )
   > .sash-module_orthogonal-drag-handle__Yii2-.sash-module_start__uZEDk,
-.sash-module_sash__K-9lB.sash-module_horizontal__kFbiw.sash-module_orthogonal-edge-south__6ZrFC:not(.sash-module_disabled__Hm-wx)
+.sash-module_sash__K-9lB.sash-module_horizontal__kFbiw.sash-module_orthogonal-edge-south__6ZrFC:not(
+    .sash-module_disabled__Hm-wx
+  )
   > .sash-module_orthogonal-drag-handle__Yii2-.sash-module_end__0TP-R {
   cursor: nwse-resize;
 }
 
-.sash-module_sash__K-9lB.sash-module_horizontal__kFbiw.sash-module_orthogonal-edge-north__f7Noe:not(.sash-module_disabled__Hm-wx)
+.sash-module_sash__K-9lB.sash-module_horizontal__kFbiw.sash-module_orthogonal-edge-north__f7Noe:not(
+    .sash-module_disabled__Hm-wx
+  )
   > .sash-module_orthogonal-drag-handle__Yii2-.sash-module_end__0TP-R,
-.sash-module_sash__K-9lB.sash-module_horizontal__kFbiw.sash-module_orthogonal-edge-south__6ZrFC:not(.sash-module_disabled__Hm-wx)
+.sash-module_sash__K-9lB.sash-module_horizontal__kFbiw.sash-module_orthogonal-edge-south__6ZrFC:not(
+    .sash-module_disabled__Hm-wx
+  )
   > .sash-module_orthogonal-drag-handle__Yii2-.sash-module_start__uZEDk {
   cursor: nesw-resize;
 }
 
-.sash-module_sash__K-9lB.sash-module_vertical__pB-rs > .sash-module_orthogonal-drag-handle__Yii2-.sash-module_start__uZEDk {
+.sash-module_sash__K-9lB.sash-module_vertical__pB-rs
+  > .sash-module_orthogonal-drag-handle__Yii2-.sash-module_start__uZEDk {
   left: calc(var(--sash-size) * -0.5);
   top: calc(var(--sash-size) * -1);
 }
 
-.sash-module_sash__K-9lB.sash-module_vertical__pB-rs > .sash-module_orthogonal-drag-handle__Yii2-.sash-module_end__0TP-R {
+.sash-module_sash__K-9lB.sash-module_vertical__pB-rs
+  > .sash-module_orthogonal-drag-handle__Yii2-.sash-module_end__0TP-R {
   left: calc(var(--sash-size) * -0.5);
   bottom: calc(var(--sash-size) * -1);
 }
 
-.sash-module_sash__K-9lB.sash-module_horizontal__kFbiw > .sash-module_orthogonal-drag-handle__Yii2-.sash-module_start__uZEDk {
+.sash-module_sash__K-9lB.sash-module_horizontal__kFbiw
+  > .sash-module_orthogonal-drag-handle__Yii2-.sash-module_start__uZEDk {
   top: calc(var(--sash-size) * -0.5);
   left: calc(var(--sash-size) * -1);
 }
 
-.sash-module_sash__K-9lB.sash-module_horizontal__kFbiw > .sash-module_orthogonal-drag-handle__Yii2-.sash-module_end__0TP-R {
+.sash-module_sash__K-9lB.sash-module_horizontal__kFbiw
+  > .sash-module_orthogonal-drag-handle__Yii2-.sash-module_end__0TP-R {
   top: calc(var(--sash-size) * -0.5);
   right: calc(var(--sash-size) * -1);
 }


### PR DESCRIPTION
## Description
Adds a new `VoicePicker` component to Sparkle as a stateless, reusable UI component for voice/audio input. This extraction follows the initiative to move shared components from front to Sparkle (#5980, #5977). The component accepts recording state, audio level, and callbacks as props, making it usable across both front and extension.

Features two interaction modes: "hold" (press and hold to record, release to stop) and "click" (click to start/stop). Includes visual feedback with animated voice level display bars and elapsed time counter during recording.

Also includes minor formatting improvements to NavigationList (CSS class ordering for consistency), playground data sources, and allotment CSS.

**References:**
- https://github.com/dust-tt/tasks/issues/5980

## Risk
Low

## Tests
Storybook story with interactive demo showing all states (idle, authorizing_microphone, recording, transcribing) and controls for size, disabled state, and press delay configuration.

## Deploy Plan

Publish Sparkle.
