### PR TITLE
Push SEO articles to the bottom of their blog page

### DIFF
--- a/front/lib/contentful/client.ts
+++ b/front/lib/contentful/client.ts
@@ -354,16 +354,10 @@ export async function getAllBlogPosts(
 
     const posts = response.items
       .map((entry) => contentfulEntryToBlogPost(entry, tagNameMap))
-      .sort((a, b) => {
-        // SEO articles go to the end.
-        if (a.isSeoArticle !== b.isSeoArticle) {
-          return a.isSeoArticle ? 1 : -1;
-        }
-        // Within each group, sort by date (newest first).
-        return (
+      .sort(
+        (a, b) =>
           new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
-        );
-      })
+      )
       .map(contentfulEntryToBlogPostSummary);
 
     return new Ok(posts);

--- a/front/lib/contentful/types.ts
+++ b/front/lib/contentful/types.ts
@@ -16,6 +16,7 @@ export interface BlogPageFields {
   image?: Asset;
   publishedAt?: string;
   authors?: Entry<AuthorSkeleton>[];
+  isSeoArticle?: boolean;
 }
 
 export type BlogPageSkeleton = EntrySkeletonType<BlogPageFields, "blogPage">;
@@ -43,6 +44,7 @@ export interface BlogPost {
   authors: BlogAuthor[];
   createdAt: string;
   updatedAt: string;
+  isSeoArticle: boolean;
 }
 
 export interface BlogPostSummary {
@@ -53,6 +55,7 @@ export interface BlogPostSummary {
   tags: string[];
   image: BlogImage | null;
   createdAt: string;
+  isSeoArticle: boolean;
 }
 
 export interface BlogListingPageProps {

--- a/front/pages/blog/page/[page].tsx
+++ b/front/pages/blog/page/[page].tsx
@@ -76,9 +76,13 @@ export const getStaticProps: GetStaticProps<BlogPageProps> = async ({
   allPosts.forEach((post) => post.tags.forEach((tag) => tagSet.add(tag)));
   const allTags = Array.from(tagSet).sort();
 
-  // Paginate: skip featured post (index 0) and previous pages
-  const FEATURED_POST_OFFSET = 1;
-  const remainingPosts = allPosts.slice(FEATURED_POST_OFFSET);
+  // Featured post is the first non-SEO post (shown on page 1 at /blog).
+  const featuredPost = allPosts.find((post) => !post.isSeoArticle);
+
+  // Remaining posts exclude the featured post.
+  const remainingPosts = featuredPost
+    ? allPosts.filter((post) => post.id !== featuredPost.id)
+    : allPosts;
   const totalPages = Math.ceil(remainingPosts.length / BLOG_PAGE_SIZE);
 
   // If page is beyond available pages, 404
@@ -87,7 +91,15 @@ export const getStaticProps: GetStaticProps<BlogPageProps> = async ({
   }
 
   const startIndex = (page - 1) * BLOG_PAGE_SIZE;
-  const posts = remainingPosts.slice(startIndex, startIndex + BLOG_PAGE_SIZE);
+  // Sort within each page: regular articles first, SEO articles at the bottom.
+  const posts = remainingPosts
+    .slice(startIndex, startIndex + BLOG_PAGE_SIZE)
+    .sort((a, b) => {
+      if (a.isSeoArticle !== b.isSeoArticle) {
+        return a.isSeoArticle ? 1 : -1;
+      }
+      return 0;
+    });
 
   return {
     props: {


### PR DESCRIPTION





## Description

Adds support for an `isSeoArticle` boolean field in Contentful blog posts to control their display priority. SEO articles are now sorted to the bottom of each blog page and excluded from being featured. The featured post selection now picks the first non-SEO article instead of simply the first article in the list.

