### PR TITLE
Fix: show correct name after mcp server update.

### DIFF
--- a/front/components/actions/mcp/MCPServerDetails.tsx
+++ b/front/components/actions/mcp/MCPServerDetails.tsx
@@ -264,7 +264,7 @@ export function MCPServerDetails({
 
           sendNotification({
             type: "success",
-            title: `${getMcpServerDisplayName(mcpServerView.server)} updated`,
+            title: `${diff.serverView?.name ?? getMcpServerDisplayName(mcpServerView.server)} updated`,
             description: "Your changes have been saved.",
           });
 


### PR DESCRIPTION
## Description

Fix the name after updating MCP server.

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy front