### PR TITLE
[front] fix(provisioning): fix email fallback on workos events

### DIFF
--- a/front/lib/api/workos/user.ts
+++ b/front/lib/api/workos/user.ts
@@ -24,7 +24,7 @@ import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { cacheWithRedis } from "@app/lib/utils/cache";
 import logger from "@app/logger/logger";
 import type { LightWorkspaceType, Result } from "@app/types";
-import { Err, Ok, sha256 } from "@app/types";
+import { Err, isString, Ok, sha256 } from "@app/types";
 import { isDevelopment } from "@app/types/shared/env";
 
 export type SessionCookie = {
@@ -276,7 +276,11 @@ export async function fetchOrCreateWorkOSUserWithEmail({
 
   let email = workOSUser.email;
   if (!email) {
-    email = workOSUser.emails.find((e) => e.primary)?.value ?? null;
+    email =
+      workOSUser.emails.find(
+        (e): e is { address: string; primary: true } =>
+          e.primary === true && "address" in e && isString(e.address)
+      )?.address ?? null;
     if (!email) {
       return new Err(new Error("Missing email"));
     }


### PR DESCRIPTION
## Description

- Follow up on https://github.com/dust-tt/dust/pull/20292.
- The type we receive from WorkOS' SDK is actually incorrect, there's no value field in the object, the email is in the address field instead ([workflow](https://cloud.temporal.io/namespaces/eu-dust-front-prod.gmnlm/workflows/workos-events-dsync.user.updated-event_01KFCPNAWNRTSVQR4XDMQEJADP-1768879205578/019bd96a-ad4a-7e81-ac7c-fed15be704fc/history)).

## Tests

## Risk

## Deploy Plan

- Deploy front.
