### PR TITLE
[front] fix(provisioning): fix email fallback on `rawAttributes.emails`

### DIFF
--- a/front/lib/api/workos/user.ts
+++ b/front/lib/api/workos/user.ts
@@ -277,9 +277,14 @@ export async function fetchOrCreateWorkOSUserWithEmail({
   let email = workOSUser.email;
   if (!email) {
     email =
-      workOSUser.emails.find(
-        (e): e is { address: string; primary: true } =>
-          e.primary === true && "address" in e && isString(e.address)
+      workOSUser.rawAttributes.emails.find(
+        (e: unknown): e is { address: string; primary: true } =>
+          typeof e === "object" &&
+          e !== null &&
+          "primary" in e &&
+          e.primary === true &&
+          "address" in e &&
+          isString(e.address)
       )?.address ?? null;
     if (!email) {
       return new Err(new Error("Missing email"));


### PR DESCRIPTION
## Description

- Fixed version of https://github.com/dust-tt/dust/pull/20315.
- Misread the payload, the emails are actually under `rawAttributes.emails`, `emails` is a deprecated field that is not supplied anymore.
- This is a short term fix, long term we need to consider enabling the emails as a predefined custom attribute https://workos.com/docs/directory-sync/attributes/standard-attributes

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
