### PR TITLE
[sparkle] allow mini & xmini for button with label

### DIFF
--- a/front/components/agent_builder/FeedbacksSection.tsx
+++ b/front/components/agent_builder/FeedbacksSection.tsx
@@ -288,7 +288,7 @@ function FeedbackCard({
       action={
         <div className="flex gap-1">
           <CardActionButton
-            size="mini"
+            size="icon"
             icon={feedback.dismissed ? EyeIcon : EyeSlashIcon}
             onClick={() => toggleDismiss(!feedback.dismissed)}
             disabled={isDismissing}
@@ -296,7 +296,7 @@ function FeedbackCard({
           />
           {conversationUrl && (
             <CardActionButton
-              size="mini"
+              size="icon"
               icon={ExternalLinkIcon}
               href={conversationUrl ?? ""}
               disabled={!conversationUrl}

--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeFooter.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeFooter.tsx
@@ -85,7 +85,7 @@ function KnowledgeFooterItem({
       visual={<Icon size="sm" visual={VisualComponent} />}
       action={
         <Button
-          size="mini"
+          size="icon"
           variant="ghost"
           icon={XMarkIcon}
           onClick={() => removeNodeWithPath(item)}

--- a/front/components/agent_builder/skills/AgentBuilderSkillsBlock.tsx
+++ b/front/components/agent_builder/skills/AgentBuilderSkillsBlock.tsx
@@ -59,7 +59,7 @@ function SkillCard({ skill, onRemove, onClick }: SkillCardProps) {
       onClick={onClick}
       action={
         <CardActionButton
-          size="mini"
+          size="icon"
           icon={XMarkIcon}
           onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
             onRemove();

--- a/front/components/agent_builder/triggers/TriggerCard.tsx
+++ b/front/components/agent_builder/triggers/TriggerCard.tsx
@@ -90,7 +90,7 @@ export const TriggerCard = ({
       action={
         (isEditor || isAdmin) && (
           <CardActionButton
-            size="mini"
+            size="icon"
             icon={XMarkIcon}
             onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
               e.stopPropagation();

--- a/front/components/app/DatasetView.tsx
+++ b/front/components/app/DatasetView.tsx
@@ -618,7 +618,7 @@ export default function DatasetView({
                             {datasetKeys.length > 1 ? (
                               <>
                                 <Button
-                                  size="mini"
+                                  size="icon"
                                   variant="ghost"
                                   className="text-muted-foreground"
                                   icon={XCircleIcon}
@@ -629,7 +629,7 @@ export default function DatasetView({
                                 />
 
                                 <Button
-                                  size="mini"
+                                  size="icon"
                                   variant="ghost"
                                   className="text-muted-foreground"
                                   icon={PlusCircleIcon}
@@ -798,7 +798,7 @@ export default function DatasetView({
                         {datasetData.length > 1 ? (
                           <Button
                             icon={XCircleIcon}
-                            size="mini"
+                            size="icon"
                             variant="ghost"
                             onClick={() => {
                               handleDeleteEntry(i);
@@ -807,7 +807,7 @@ export default function DatasetView({
                         ) : null}
                         <Button
                           icon={PlusCircleIcon}
-                          size="mini"
+                          size="icon"
                           variant="ghost"
                           onClick={() => {
                             handleNewEntry(i);

--- a/front/components/app/NewBlock.tsx
+++ b/front/components/app/NewBlock.tsx
@@ -130,7 +130,7 @@ export default function NewBlock({
             icon={PlusIcon}
             disabled={disabled}
             variant="ghost-secondary"
-            size="mini"
+            size="icon"
           />
         ) : (
           <Button

--- a/front/components/app/blocks/Block.tsx
+++ b/front/components/app/blocks/Block.tsx
@@ -123,7 +123,7 @@ export default function Block({
                     : "Results are computed at each run"
                 }
                 variant="ghost-secondary"
-                size="mini"
+                size="icon"
                 icon={
                   block.config && block.config.use_cache
                     ? Square3Stack3DIcon
@@ -145,19 +145,19 @@ export default function Block({
                   variant="ghost-secondary"
                   icon={ChevronUpIcon}
                   onClick={onBlockUp}
-                  size="mini"
+                  size="icon"
                 />
                 <Button
                   variant="ghost-secondary"
                   icon={ChevronDownIcon}
                   onClick={onBlockDown}
-                  size="mini"
+                  size="icon"
                 />
                 <Button
                   variant="ghost-secondary"
                   icon={TrashIcon}
                   onClick={onBlockDelete}
-                  size="mini"
+                  size="icon"
                 />
               </>
             )}

--- a/front/components/app/blocks/Output.tsx
+++ b/front/components/app/blocks/Output.tsx
@@ -353,7 +353,7 @@ const JsonCopyLink = ({ value }: { value: string }) => {
           onClick={handleClick}
           tooltip="Copy JSON to clipboard"
           icon={ClipboardIcon}
-          size="mini"
+          size="icon"
           variant="ghost-secondary"
         />
       )}

--- a/front/components/assistant/conversation/ConversationTitle.tsx
+++ b/front/components/assistant/conversation/ConversationTitle.tsx
@@ -47,7 +47,7 @@ export function ConversationTitle({ owner }: { owner: WorkspaceType }) {
         <div className="flex min-w-0">
           {conversation?.spaceId && (
             <IconButton
-              size="xmini"
+              size="xs"
               variant="outline"
               icon={ArrowLeftIcon}
               aria-label={`Back to ${spaceInfo?.name}`}

--- a/front/components/assistant/conversation/MessageEmojiPicker.tsx
+++ b/front/components/assistant/conversation/MessageEmojiPicker.tsx
@@ -32,9 +32,9 @@ export function MessageEmojiPicker({
           key="emoji-picker-button"
           tooltip="Add reaction"
           variant="outline"
-          size="xs"
+          size="xmini"
           icon={EmotionLaughIcon}
-          isSelect={true}
+          isSelect
           className={cn("text-muted-foreground", className)}
         />
       </PopoverTrigger>

--- a/front/components/assistant/conversation/MessageReactions.tsx
+++ b/front/components/assistant/conversation/MessageReactions.tsx
@@ -64,7 +64,7 @@ export function MessageReactions({
           trigger={
             <Button
               label={`+${hiddenReactions.length}`}
-              size="xs"
+              size="xmini"
               variant="outline"
               aria-label="More reactions"
             />

--- a/front/components/assistant/conversation/ReactionPill.tsx
+++ b/front/components/assistant/conversation/ReactionPill.tsx
@@ -1,4 +1,4 @@
-import { Button, Tooltip } from "@dust-tt/sparkle";
+import { Button, cn, Tooltip } from "@dust-tt/sparkle";
 
 interface ReactionPillProps {
   emoji: string;
@@ -36,9 +36,13 @@ export function ReactionPill({
       trigger={
         <Button
           label={`${emoji} ${count}`}
-          size="xs"
-          variant={hasCurrentUserReacted ? "primary" : "outline"}
+          size="xmini"
+          variant="outline"
           onClick={onClick}
+          className={cn(
+            hasCurrentUserReacted &&
+              "border-blue-200 bg-blue-50 hover:border-blue-200 hover:bg-blue-100 dark:border-blue-700 dark:bg-blue-900 hover:dark:border-blue-700 dark:hover:bg-blue-800"
+          )}
         />
       }
     />

--- a/front/components/assistant/conversation/UserMessage.tsx
+++ b/front/components/assistant/conversation/UserMessage.tsx
@@ -437,7 +437,12 @@ function ActionMenu({
     : [];
 
   return (
-    <div className="absolute -bottom-3.5 left-2.5 flex flex-wrap items-center gap-1">
+    <div
+      className={cn(
+        "absolute top-[80%] flex flex-wrap items-center gap-1",
+        reactionsEnabled ? "left-2.5" : "right-2.5"
+      )}
+    >
       {!isDeleted && reactionsEnabled && (
         <>
           <MessageReactions
@@ -462,7 +467,7 @@ function ActionMenu({
           <DropdownMenuTrigger asChild>
             <Button
               icon={MoreIcon}
-              size="xs"
+              size="icon-xs"
               variant="outline"
               aria-label="Message actions"
               className={cn(

--- a/front/components/assistant/conversation/input_bar/toolbar/MobileToolbar.tsx
+++ b/front/components/assistant/conversation/input_bar/toolbar/MobileToolbar.tsx
@@ -22,7 +22,7 @@ export function MobileToolbar({ editor, className, onClose }: ToolbarProps) {
       )}
     >
       <Button
-        size="mini"
+        size="icon"
         variant="outline"
         icon={XMarkIcon}
         onClick={onClose}

--- a/front/components/assistant/conversation/input_bar/toolbar/ToolbarIcon.tsx
+++ b/front/components/assistant/conversation/input_bar/toolbar/ToolbarIcon.tsx
@@ -21,7 +21,7 @@ export function ToolbarIcon({
 }: ToolbarIconProps) {
   const isMobile = useIsMobile();
   const shortcutLabel = useKeyboardShortcutLabel(shortcut);
-  const buttonSize = isMobile ? "xs" : "mini";
+  const buttonSize = isMobile ? "xs" : "icon";
 
   let tooltipText = tooltip;
   if (isMobile) {

--- a/front/components/assistant/details/tabs/AgentMemoryTab.tsx
+++ b/front/components/assistant/details/tabs/AgentMemoryTab.tsx
@@ -137,7 +137,7 @@ export function AgentMemoryTab({
                     className="flex flex-col gap-2"
                     action={
                       <CardActionButton
-                        size="mini"
+                        size="icon"
                         icon={TrashIcon}
                         onClick={() => {
                           setMemoryToDelete(memory.sId);

--- a/front/components/assistant/manager/TableTagSelector.tsx
+++ b/front/components/assistant/manager/TableTagSelector.tsx
@@ -59,7 +59,7 @@ export const TableTagSelector = ({
           <Button
             variant="ghost"
             icon={ChevronDownIcon}
-            size="xmini"
+            size="icon-xs"
             className="invisible text-muted-foreground group-hover:visible dark:text-muted-foreground-night"
           />
         )}

--- a/front/components/shared/tools_picker/ActionCard.tsx
+++ b/front/components/shared/tools_picker/ActionCard.tsx
@@ -54,7 +54,7 @@ export function ActionCard({ action, onRemove, onClick }: ActionCardProps) {
       onClick={onClick}
       action={
         <CardActionButton
-          size="mini"
+          size="icon"
           icon={XMarkIcon}
           onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
             onRemove();

--- a/front/components/skills/SuggestedSkillsSection.tsx
+++ b/front/components/skills/SuggestedSkillsSection.tsx
@@ -64,7 +64,7 @@ function SuggestedSkillCard({
         onClick={onMoreInfoClick}
         action={
           <CardActionButton
-            size="mini"
+            size="icon"
             icon={XMarkIcon}
             onClick={(e) => {
               e.stopPropagation();

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -13,7 +13,7 @@
         "@contentful/rich-text-types": "^17.2.5",
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.7.2",
+        "@dust-tt/sparkle": "^0.7.8-rc-1",
         "@elastic/elasticsearch": "^8.15.0",
         "@elevenlabs/elevenlabs-js": "^2.17.0",
         "@emoji-mart/data": "^1.2.1",
@@ -2624,9 +2624,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.7.2.tgz",
-      "integrity": "sha512-1eh125pKkINb3Ei0ThEzy1LmDdgg9Oi3+MR0I69Rt8OCJVA6QZTEwy8koqytTjiKCkOLvaIhayUX7QQzu1B5sw==",
+      "version": "0.7.8-rc-1",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.7.8-rc-1.tgz",
+      "integrity": "sha512-I42AoC7Mw0cZEA5kBbbucku+JHWSigoe7I0pDpRxDH0AYM1VltOAqgi6+ZJUGhPF2xRM4hc7ZzoG3EilVe8OlA==",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/front/package.json
+++ b/front/package.json
@@ -39,7 +39,7 @@
     "@contentful/rich-text-types": "^17.2.5",
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.7.2",
+    "@dust-tt/sparkle": "^0.7.8-rc-1",
     "@elastic/elasticsearch": "^8.15.0",
     "@elevenlabs/elevenlabs-js": "^2.17.0",
     "@emoji-mart/data": "^1.2.1",

--- a/sparkle/src/components/AssistantCard.tsx
+++ b/sparkle/src/components/AssistantCard.tsx
@@ -22,7 +22,7 @@ interface BaseAssistantCardProps {
   variant?: CardVariantType;
 }
 
-type AssistantCardMore = Omit<IconOnlyButtonProps, "icon">;
+type AssistantCardMore = IconOnlyButtonProps;
 
 export const AssistantCardMore = React.forwardRef<
   HTMLButtonElement,

--- a/sparkle/src/components/AssistantCard.tsx
+++ b/sparkle/src/components/AssistantCard.tsx
@@ -1,10 +1,6 @@
 import React from "react";
 
-import {
-  Avatar,
-  Card,
-  CardActionButton,
-} from "@sparkle/components/";
+import { Avatar, Card, CardActionButton } from "@sparkle/components/";
 import { CardVariantType } from "@sparkle/components/Card";
 import { MoreIcon } from "@sparkle/icons/app/";
 import { cn } from "@sparkle/lib/utils";

--- a/sparkle/src/components/AssistantCard.tsx
+++ b/sparkle/src/components/AssistantCard.tsx
@@ -4,11 +4,12 @@ import {
   Avatar,
   Card,
   CardActionButton,
-  MiniButtonProps,
 } from "@sparkle/components/";
 import { CardVariantType } from "@sparkle/components/Card";
 import { MoreIcon } from "@sparkle/icons/app/";
 import { cn } from "@sparkle/lib/utils";
+
+import { IconOnlyButtonProps } from "./Button";
 
 interface BaseAssistantCardProps {
   description: string;
@@ -21,7 +22,7 @@ interface BaseAssistantCardProps {
   variant?: CardVariantType;
 }
 
-type AssistantCardMore = Omit<MiniButtonProps, "icon" | "size">;
+type AssistantCardMore = Omit<IconOnlyButtonProps, "icon">;
 
 export const AssistantCardMore = React.forwardRef<
   HTMLButtonElement,

--- a/sparkle/src/components/AssistantCard.tsx
+++ b/sparkle/src/components/AssistantCard.tsx
@@ -27,7 +27,7 @@ export const AssistantCardMore = React.forwardRef<
   HTMLButtonElement,
   AssistantCardMore
 >(({ ...props }, ref) => {
-  return <CardActionButton size="mini" ref={ref} icon={MoreIcon} {...props} />;
+  return <CardActionButton ref={ref} icon={MoreIcon} {...props} />;
 });
 AssistantCardMore.displayName = "AssistantCardMore";
 

--- a/sparkle/src/components/AssistantCard.tsx
+++ b/sparkle/src/components/AssistantCard.tsx
@@ -18,13 +18,13 @@ interface BaseAssistantCardProps {
   variant?: CardVariantType;
 }
 
-type AssistantCardMore = IconOnlyButtonProps;
+type AssistantCardMore = Omit<IconOnlyButtonProps, "icon">;
 
 export const AssistantCardMore = React.forwardRef<
   HTMLButtonElement,
   AssistantCardMore
->(({ ...props }, ref) => {
-  return <CardActionButton ref={ref} icon={MoreIcon} {...props} />;
+>(({ size = "icon", ...props }, ref) => {
+  return <CardActionButton ref={ref} icon={MoreIcon} size={size} {...props} />;
 });
 AssistantCardMore.displayName = "AssistantCardMore";
 

--- a/sparkle/src/components/AssistantCard.tsx
+++ b/sparkle/src/components/AssistantCard.tsx
@@ -5,7 +5,7 @@ import { CardVariantType } from "@sparkle/components/Card";
 import { MoreIcon } from "@sparkle/icons/app/";
 import { cn } from "@sparkle/lib/utils";
 
-import { IconOnlyButtonProps } from "./Button";
+import { IconOnlyButtonProps, IconOnlySize } from "./Button";
 
 interface BaseAssistantCardProps {
   description: string;
@@ -18,7 +18,7 @@ interface BaseAssistantCardProps {
   variant?: CardVariantType;
 }
 
-type AssistantCardMore = Omit<IconOnlyButtonProps, "icon">;
+type AssistantCardMore = Omit<IconOnlyButtonProps, "icon" | "size"> & { size?: IconOnlySize };
 
 export const AssistantCardMore = React.forwardRef<
   HTMLButtonElement,

--- a/sparkle/src/components/Button.tsx
+++ b/sparkle/src/components/Button.tsx
@@ -43,6 +43,12 @@ export const ICON_ONLY_SIZES = ["icon-xs", "icon"] as const;
 // Small button sizes that use xs spinner size
 export const SMALL_BUTTON_SIZES = ["icon-xs", "icon", "xmini", "mini"] as const;
 
+function isSmallButtonSize(
+  size: ButtonSizeType | undefined
+): size is typeof SMALL_BUTTON_SIZES[number] {
+  return size !== undefined && SMALL_BUTTON_SIZES.includes(size as typeof SMALL_BUTTON_SIZES[number]);
+}
+
 // Define button styling with cva
 const buttonVariants = cva(
   cn(
@@ -380,11 +386,11 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
           <div
             className={cn(
               "-s-mx-0.5",
-              SMALL_BUTTON_SIZES.includes(size as typeof SMALL_BUTTON_SIZES[number]) && "s-w-5 s-px-0.5"
+              isSmallButtonSize(size) && "s-w-5 s-px-0.5"
             )}
           >
             <Spinner
-              size={SMALL_BUTTON_SIZES.includes(size as typeof SMALL_BUTTON_SIZES[number]) ? "xs" : iconSize}
+            size={isSmallButtonSize(size) ? "xs" : iconSize}
               variant={(variant && spinnerVariantsMap[variant]) || "gray400"}
             />
           </div>

--- a/sparkle/src/components/Button.tsx
+++ b/sparkle/src/components/Button.tsx
@@ -34,7 +34,13 @@ export const BUTTON_VARIANTS = [
 
 export type ButtonVariantType = (typeof BUTTON_VARIANTS)[number];
 
-export const REGULAR_BUTTON_SIZES = ["xmini", "mini", "xs", "sm", "md"] as const;
+export const REGULAR_BUTTON_SIZES = [
+  "xmini",
+  "mini",
+  "xs",
+  "sm",
+  "md",
+] as const;
 export const ICON_ONLY_SIZES = ["icon-xs", "icon"] as const;
 export const SMALL_BUTTON_SIZES = ["icon-xs", "icon", "xmini", "mini"] as const;
 
@@ -42,11 +48,13 @@ export type RegularButtonSize = (typeof REGULAR_BUTTON_SIZES)[number];
 export type IconOnlySize = (typeof ICON_ONLY_SIZES)[number];
 export type ButtonSize = RegularButtonSize | IconOnlySize;
 
-
 function isSmallButtonSize(
   size: ButtonSize | undefined
-): size is typeof SMALL_BUTTON_SIZES[number] {
-  return size !== undefined && SMALL_BUTTON_SIZES.includes(size as typeof SMALL_BUTTON_SIZES[number]);
+): size is (typeof SMALL_BUTTON_SIZES)[number] {
+  return (
+    size !== undefined &&
+    SMALL_BUTTON_SIZES.includes(size as (typeof SMALL_BUTTON_SIZES)[number])
+  );
 }
 
 // Define button styling with cva
@@ -223,8 +231,8 @@ const chevronVariantMap = {
 
 export interface MetaButtonProps
   extends
-  React.ButtonHTMLAttributes<HTMLButtonElement>,
-  VariantProps<typeof buttonVariants> {
+    React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
   asChild?: boolean;
   isRounded?: boolean;
 }

--- a/sparkle/src/components/Button.tsx
+++ b/sparkle/src/components/Button.tsx
@@ -289,19 +289,31 @@ type CommonButtonProps = Omit<MetaButtonProps, "children"> &
     isRounded?: boolean;
   };
 
-export type ButtonProps = CommonButtonProps & {
-  size?: ButtonSizeType;
-  icon?: React.ComponentType;
-  label?: string;
-};
-
-export type MiniButtonProps = CommonButtonProps & {
-  size: "mini";
+/**
+ * Icon-only button sizes (fixed width).
+ * When using these sizes, an icon is required and labels are not allowed.
+ */
+export type IconOnlyButtonProps = CommonButtonProps & {
+  size: "icon-xs" | "icon";
   icon: React.ComponentType;
   label?: never;
 };
 
-export type RegularButtonProps = ButtonProps;
+/**
+ * Default button props (all non-icon-only sizes).
+ */
+export type RegularButtonProps = CommonButtonProps & {
+  size?: Exclude<ButtonSizeType, "icon" | "icon-xs">;
+  icon?: React.ComponentType;
+  label?: string;
+};
+
+/**
+ * Main Button props.
+ * - If `size` is `"icon"` or `"icon-xs"`, `icon` is required and `label` is not allowed.
+ * - Otherwise, `icon` is optional and `label` is allowed.
+ */
+export type ButtonProps = IconOnlyButtonProps | RegularButtonProps;
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   (

--- a/sparkle/src/components/Button.tsx
+++ b/sparkle/src/components/Button.tsx
@@ -34,8 +34,14 @@ export const BUTTON_VARIANTS = [
 
 export type ButtonVariantType = (typeof BUTTON_VARIANTS)[number];
 
-export const BUTTON_SIZES = ["xmini", "mini", "xs", "sm", "md"] as const;
+export const BUTTON_SIZES = ["icon-xs", "icon", "xmini", "mini", "xs", "sm", "md"] as const;
 export type ButtonSizeType = (typeof BUTTON_SIZES)[number];
+
+// Icon-only button sizes (fixed width, labels hidden)
+export const ICON_ONLY_SIZES = ["icon-xs", "icon"] as const;
+
+// Small button sizes that use xs spinner size
+export const SMALL_BUTTON_SIZES = ["icon-xs", "icon", "xmini", "mini"] as const;
 
 // Define button styling with cva
 const buttonVariants = cva(
@@ -141,13 +147,17 @@ const buttonVariants = cva(
         ),
       },
       size: {
-        xmini: "s-h-6 s-w-6 s-label-xs s-gap-1 s-shrink-0",
-        mini: "s-h-7 s-w-7 s-label-xs s-gap-1.5 s-shrink-0",
+        "icon-xs": "s-h-6 s-w-6 s-label-xs s-gap-1 s-shrink-0",
+        icon: "s-h-7 s-w-7 s-label-xs s-gap-1.5 s-shrink-0",
+        xmini: "s-h-6 s-px-1.5 s-label-xs s-gap-1 s-shrink-0",
+        mini: "s-h-7 s-px-2 s-label-xs s-gap-1.5 s-shrink-0",
         xs: "s-h-7 s-px-2.5 s-label-xs s-gap-1.5 s-shrink-0",
         sm: "s-h-9 s-px-3 s-label-sm s-gap-2 s-shrink-0",
         md: "s-h-12 s-px-4 s-py-2 s-label-base s-gap-2.5 s-shrink-0",
       },
       rounded: {
+        "icon-xs": "s-rounded-lg",
+        icon: "s-rounded-lg",
         xmini: "s-rounded-lg",
         mini: "s-rounded-lg",
         xs: "s-rounded-lg",
@@ -167,8 +177,10 @@ const buttonVariants = cva(
 const labelVariants = cva("", {
   variants: {
     size: {
-      xmini: "s-label-xs s-hidden",
-      mini: "s-label-xs s-hidden",
+      "icon-xs": "s-label-xs s-hidden",
+      icon: "s-label-xs s-hidden",
+      xmini: "s-label-xs",
+      mini: "s-label-xs",
       xs: "s-label-xs",
       sm: "s-label-sm",
       md: "s-label-base",
@@ -246,6 +258,8 @@ type IconSizeType = "xs" | "sm" | "md";
 type CounterSizeType = "xs" | "sm" | "md";
 
 export const ICON_SIZE_MAP: Record<ButtonSizeType, IconSizeType> = {
+  "icon-xs": "xs",
+  icon: "sm",
   xmini: "xs",
   mini: "sm",
   xs: "xs",
@@ -254,6 +268,8 @@ export const ICON_SIZE_MAP: Record<ButtonSizeType, IconSizeType> = {
 };
 
 const COUNTER_SIZE_MAP: Record<ButtonSizeType, CounterSizeType> = {
+  "icon-xs": "xs",
+  icon: "xs",
   xmini: "xs",
   mini: "xs",
   xs: "xs",
@@ -273,19 +289,19 @@ type CommonButtonProps = Omit<MetaButtonProps, "children"> &
     isRounded?: boolean;
   };
 
+export type ButtonProps = CommonButtonProps & {
+  size?: ButtonSizeType;
+  icon?: React.ComponentType;
+  label?: string;
+};
+
 export type MiniButtonProps = CommonButtonProps & {
   size: "mini";
   icon: React.ComponentType;
   label?: never;
 };
 
-export type RegularButtonProps = CommonButtonProps & {
-  size?: Exclude<ButtonSizeType, "mini">;
-  icon?: React.ComponentType;
-  label?: string;
-};
-
-export type ButtonProps = MiniButtonProps | RegularButtonProps;
+export type RegularButtonProps = ButtonProps;
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   (
@@ -352,12 +368,11 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
           <div
             className={cn(
               "-s-mx-0.5",
-              size === "mini" && "s-w-5 s-px-0.5",
-              size === "xmini" && "s-w-5 s-px-0.5"
+              SMALL_BUTTON_SIZES.includes(size as typeof SMALL_BUTTON_SIZES[number]) && "s-w-5 s-px-0.5"
             )}
           >
             <Spinner
-              size={size === "mini" || size === "xmini" ? "xs" : iconSize}
+              size={SMALL_BUTTON_SIZES.includes(size as typeof SMALL_BUTTON_SIZES[number]) ? "xs" : iconSize}
               variant={(variant && spinnerVariantsMap[variant]) || "gray400"}
             />
           </div>

--- a/sparkle/src/components/Button.tsx
+++ b/sparkle/src/components/Button.tsx
@@ -35,19 +35,16 @@ export const BUTTON_VARIANTS = [
 export type ButtonVariantType = (typeof BUTTON_VARIANTS)[number];
 
 export const REGULAR_BUTTON_SIZES = ["xmini", "mini", "xs", "sm", "md"] as const;
-
-// Icon-only button sizes (fixed width, labels hidden)
 export const ICON_ONLY_SIZES = ["icon-xs", "icon"] as const;
-
-// All button sizes (union of regular and icon-only)
-export const BUTTON_SIZES = [...REGULAR_BUTTON_SIZES, ...ICON_ONLY_SIZES] as const;
-export type ButtonSizeType = (typeof REGULAR_BUTTON_SIZES)[number] | (typeof ICON_ONLY_SIZES)[number];
-
-// Small button sizes that use xs spinner size
 export const SMALL_BUTTON_SIZES = ["icon-xs", "icon", "xmini", "mini"] as const;
 
+export type RegularButtonSize = (typeof REGULAR_BUTTON_SIZES)[number];
+export type IconOnlySize = (typeof ICON_ONLY_SIZES)[number];
+export type ButtonSize = RegularButtonSize | IconOnlySize;
+
+
 function isSmallButtonSize(
-  size: ButtonSizeType | undefined
+  size: ButtonSize | undefined
 ): size is typeof SMALL_BUTTON_SIZES[number] {
   return size !== undefined && SMALL_BUTTON_SIZES.includes(size as typeof SMALL_BUTTON_SIZES[number]);
 }
@@ -226,8 +223,8 @@ const chevronVariantMap = {
 
 export interface MetaButtonProps
   extends
-    React.ButtonHTMLAttributes<HTMLButtonElement>,
-    VariantProps<typeof buttonVariants> {
+  React.ButtonHTMLAttributes<HTMLButtonElement>,
+  VariantProps<typeof buttonVariants> {
   asChild?: boolean;
   isRounded?: boolean;
 }
@@ -266,7 +263,7 @@ MetaButton.displayName = "MetaButton";
 type IconSizeType = "xs" | "sm" | "md";
 type CounterSizeType = "xs" | "sm" | "md";
 
-export const ICON_SIZE_MAP: Record<ButtonSizeType, IconSizeType> = {
+export const ICON_SIZE_MAP: Record<ButtonSize, IconSizeType> = {
   "icon-xs": "xs",
   icon: "sm",
   xmini: "xs",
@@ -276,7 +273,7 @@ export const ICON_SIZE_MAP: Record<ButtonSizeType, IconSizeType> = {
   md: "md",
 };
 
-const COUNTER_SIZE_MAP: Record<ButtonSizeType, CounterSizeType> = {
+const COUNTER_SIZE_MAP: Record<ButtonSize, CounterSizeType> = {
   "icon-xs": "xs",
   icon: "xs",
   xmini: "xs",
@@ -303,13 +300,13 @@ type CommonButtonProps = Omit<MetaButtonProps, "children"> &
  * When using these sizes, an icon is required and labels are not allowed.
  */
 export type IconOnlyButtonProps = CommonButtonProps & {
-  size: (typeof ICON_ONLY_SIZES)[number];
+  size: IconOnlySize;
   icon: React.ComponentType;
   label?: never;
 };
 
 export type RegularButtonProps = CommonButtonProps & {
-  size?: (typeof REGULAR_BUTTON_SIZES)[number];
+  size?: RegularButtonSize;
   icon?: React.ComponentType;
   label?: string;
 };
@@ -385,7 +382,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
             )}
           >
             <Spinner
-            size={isSmallButtonSize(size) ? "xs" : iconSize}
+              size={isSmallButtonSize(size) ? "xs" : iconSize}
               variant={(variant && spinnerVariantsMap[variant]) || "gray400"}
             />
           </div>

--- a/sparkle/src/components/Button.tsx
+++ b/sparkle/src/components/Button.tsx
@@ -34,11 +34,14 @@ export const BUTTON_VARIANTS = [
 
 export type ButtonVariantType = (typeof BUTTON_VARIANTS)[number];
 
-export const BUTTON_SIZES = ["icon-xs", "icon", "xmini", "mini", "xs", "sm", "md"] as const;
-export type ButtonSizeType = (typeof BUTTON_SIZES)[number];
+export const REGULAR_BUTTON_SIZES = ["xmini", "mini", "xs", "sm", "md"] as const;
 
 // Icon-only button sizes (fixed width, labels hidden)
 export const ICON_ONLY_SIZES = ["icon-xs", "icon"] as const;
+
+// All button sizes (union of regular and icon-only)
+export const BUTTON_SIZES = [...REGULAR_BUTTON_SIZES, ...ICON_ONLY_SIZES] as const;
+export type ButtonSizeType = (typeof REGULAR_BUTTON_SIZES)[number] | (typeof ICON_ONLY_SIZES)[number];
 
 // Small button sizes that use xs spinner size
 export const SMALL_BUTTON_SIZES = ["icon-xs", "icon", "xmini", "mini"] as const;
@@ -300,13 +303,13 @@ type CommonButtonProps = Omit<MetaButtonProps, "children"> &
  * When using these sizes, an icon is required and labels are not allowed.
  */
 export type IconOnlyButtonProps = CommonButtonProps & {
-  size: "icon-xs" | "icon";
+  size: (typeof ICON_ONLY_SIZES)[number];
   icon: React.ComponentType;
   label?: never;
 };
 
 export type RegularButtonProps = CommonButtonProps & {
-  size?: Exclude<ButtonSizeType, "icon" | "icon-xs">;
+  size?: (typeof REGULAR_BUTTON_SIZES)[number];
   icon?: React.ComponentType;
   label?: string;
 };

--- a/sparkle/src/components/Button.tsx
+++ b/sparkle/src/components/Button.tsx
@@ -305,20 +305,12 @@ export type IconOnlyButtonProps = CommonButtonProps & {
   label?: never;
 };
 
-/**
- * Default button props (all non-icon-only sizes).
- */
 export type RegularButtonProps = CommonButtonProps & {
   size?: Exclude<ButtonSizeType, "icon" | "icon-xs">;
   icon?: React.ComponentType;
   label?: string;
 };
 
-/**
- * Main Button props.
- * - If `size` is `"icon"` or `"icon-xs"`, `icon` is required and `label` is not allowed.
- * - Otherwise, `icon` is optional and `label` is allowed.
- */
 export type ButtonProps = IconOnlyButtonProps | RegularButtonProps;
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(

--- a/sparkle/src/components/ButtonGroup.tsx
+++ b/sparkle/src/components/ButtonGroup.tsx
@@ -4,10 +4,7 @@ import * as React from "react";
 import { cn } from "@sparkle/lib/utils";
 
 import type { ButtonProps, ButtonSizeType, ButtonVariantType } from "./Button";
-import { Button, ICON_ONLY_SIZES } from "./Button";
-
-// Sizes that must be set per-item in ButtonGroup (not at group level)
-const PER_ITEM_SIZES = ["mini", ...ICON_ONLY_SIZES] as const;
+import { Button } from "./Button";
 import type { DropdownMenuItemProps } from "./Dropdown";
 import {
   DropdownMenu,
@@ -95,9 +92,10 @@ export interface ButtonGroupProps
    */
   variant?: ButtonGroupVariantType;
   /**
-   * Size to apply to all buttons in the group. Icon-only buttons and mini must opt-in per item.
+   * Size to apply to all buttons in the group. Icon-only buttons must opt-in per item 
+   * TODO(yuka 2026-01-22): it's because I couldn't type it properly, ideally we should allow to have icon size at group level
    */
-  size?: Exclude<ButtonSizeType, "mini" | "icon" | "icon-xs">;
+  size?: Exclude<ButtonSizeType, "icon" | "icon-xs">;
   /**
    * Whether every button should be disabled.
    */
@@ -195,10 +193,10 @@ const ButtonGroup = React.forwardRef<HTMLDivElement, ButtonGroupProps>(
 
       const nextVariant = sanitizeVariant(variant ?? item.triggerProps.variant);
       const rawSize = size ?? item.triggerProps.size;
-      const nextSize: Exclude<ButtonSizeType, "mini"> | undefined =
-        rawSize === "mini"
+      const nextSize: Exclude<ButtonSizeType, "icon" | "icon-xs"> | undefined =
+        rawSize === "icon" || rawSize === "icon-xs"
           ? undefined
-          : (rawSize as Exclude<ButtonSizeType, "mini"> | undefined);
+          : (rawSize as Exclude<ButtonSizeType, "icon" | "icon-xs"> | undefined);
 
       return (
         <DropdownMenu key={index}>

--- a/sparkle/src/components/ButtonGroup.tsx
+++ b/sparkle/src/components/ButtonGroup.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 
 import { cn } from "@sparkle/lib/utils";
 
-import type { ButtonProps, ButtonSizeType, ButtonVariantType } from "./Button";
+import type { ButtonProps, ButtonSizeType, ButtonVariantType,REGULAR_BUTTON_SIZES,RegularButtonProps } from "./Button";
 import { Button } from "./Button";
 import type { DropdownMenuItemProps } from "./Dropdown";
 import {
@@ -15,7 +15,7 @@ import {
 
 type ButtonGroupButtonItem = {
   type: "button";
-  props: ButtonProps;
+  props: RegularButtonProps;
 };
 
 type ButtonGroupDropdownItem = {
@@ -98,10 +98,10 @@ export interface ButtonGroupProps
    */
   variant?: ButtonGroupVariantType;
   /**
-   * Size to apply to all buttons in the group. Icon-only buttons must opt-in per item 
-   * TODO(yuka 2026-01-22): it's because I couldn't type it properly, ideally we should allow to have icon size at group level
+   * Size to apply to all buttons in the group.
+   * TODO(yuka 2026-01-22): allow to have icon only button size.
    */
-  size?: Exclude<ButtonSizeType, "icon" | "icon-xs">;
+  size?: (typeof REGULAR_BUTTON_SIZES)[number];
   /**
    * Whether every button should be disabled.
    */

--- a/sparkle/src/components/ButtonGroup.tsx
+++ b/sparkle/src/components/ButtonGroup.tsx
@@ -4,7 +4,10 @@ import * as React from "react";
 import { cn } from "@sparkle/lib/utils";
 
 import type { ButtonProps, ButtonSizeType, ButtonVariantType } from "./Button";
-import { Button } from "./Button";
+import { Button, ICON_ONLY_SIZES } from "./Button";
+
+// Sizes that must be set per-item in ButtonGroup (not at group level)
+const PER_ITEM_SIZES = ["mini", ...ICON_ONLY_SIZES] as const;
 import type { DropdownMenuItemProps } from "./Dropdown";
 import {
   DropdownMenu,
@@ -92,9 +95,9 @@ export interface ButtonGroupProps
    */
   variant?: ButtonGroupVariantType;
   /**
-   * Size to apply to all buttons in the group. Mini buttons must opt-in per item.
+   * Size to apply to all buttons in the group. Icon-only buttons and mini must opt-in per item.
    */
-  size?: Exclude<ButtonSizeType, "mini">;
+  size?: Exclude<ButtonSizeType, "mini" | "icon" | "icon-xs">;
   /**
    * Whether every button should be disabled.
    */
@@ -168,10 +171,10 @@ const ButtonGroup = React.forwardRef<HTMLDivElement, ButtonGroupProps>(
       if (item.type === "button") {
         const nextVariant = sanitizeVariant(variant ?? item.props.variant);
         const rawSize = size ?? item.props.size;
-        const nextSize: Exclude<ButtonSizeType, "mini"> | undefined =
-          rawSize === "mini"
+        const nextSize: Exclude<ButtonSizeType, "mini" | "icon" | "icon-xs"> | undefined =
+          PER_ITEM_SIZES.includes(rawSize as typeof PER_ITEM_SIZES[number])
             ? undefined
-            : (rawSize as Exclude<ButtonSizeType, "mini"> | undefined);
+            : (rawSize as Exclude<ButtonSizeType, "mini" | "icon" | "icon-xs"> | undefined);
 
         return (
           <Button

--- a/sparkle/src/components/ButtonGroup.tsx
+++ b/sparkle/src/components/ButtonGroup.tsx
@@ -67,6 +67,12 @@ const sanitizeVariant = (
   return variant as ButtonGroupVariantType;
 };
 
+const isNonIconSize = (
+  size: ButtonSizeType | undefined
+): size is Exclude<ButtonSizeType, "icon" | "icon-xs"> | undefined => {
+  return size === undefined || (size !== "icon" && size !== "icon-xs");
+};
+
 const buttonGroupVariants = cva("s-inline-flex", {
   variants: {
     orientation: {
@@ -169,10 +175,8 @@ const ButtonGroup = React.forwardRef<HTMLDivElement, ButtonGroupProps>(
       if (item.type === "button") {
         const nextVariant = sanitizeVariant(variant ?? item.props.variant);
         const rawSize = size ?? item.props.size;
-        const nextSize: Exclude<ButtonSizeType, "mini" | "icon" | "icon-xs"> | undefined =
-          PER_ITEM_SIZES.includes(rawSize as typeof PER_ITEM_SIZES[number])
-            ? undefined
-            : (rawSize as Exclude<ButtonSizeType, "mini" | "icon" | "icon-xs"> | undefined);
+        const nextSize =
+          isNonIconSize(rawSize) ? rawSize : undefined;
 
         return (
           <Button
@@ -193,10 +197,8 @@ const ButtonGroup = React.forwardRef<HTMLDivElement, ButtonGroupProps>(
 
       const nextVariant = sanitizeVariant(variant ?? item.triggerProps.variant);
       const rawSize = size ?? item.triggerProps.size;
-      const nextSize: Exclude<ButtonSizeType, "icon" | "icon-xs"> | undefined =
-        rawSize === "icon" || rawSize === "icon-xs"
-          ? undefined
-          : (rawSize as Exclude<ButtonSizeType, "icon" | "icon-xs"> | undefined);
+      const nextSize =
+        isNonIconSize(rawSize) ? rawSize : undefined;
 
       return (
         <DropdownMenu key={index}>

--- a/sparkle/src/components/ButtonGroup.tsx
+++ b/sparkle/src/components/ButtonGroup.tsx
@@ -81,8 +81,8 @@ const buttonGroupVariants = cva("s-inline-flex", {
 
 export interface ButtonGroupProps
   extends
-  Omit<React.HTMLAttributes<HTMLDivElement>, "children">,
-  VariantProps<typeof buttonGroupVariants> {
+    Omit<React.HTMLAttributes<HTMLDivElement>, "children">,
+    VariantProps<typeof buttonGroupVariants> {
   /**
    * Array of button or dropdown items to render in the group.
    */
@@ -93,7 +93,6 @@ export interface ButtonGroupProps
   variant?: ButtonGroupVariantType;
   /**
    * Size to apply to all buttons in the group.
-   * TODO(yuka 2026-01-22): allow to have icon only button size.
    */
   size?: ButtonSize;
   /**
@@ -172,9 +171,7 @@ const ButtonGroup = React.forwardRef<HTMLDivElement, ButtonGroupProps>(
 
         if (buttonSize === "icon" || buttonSize === "icon-xs") {
           if (!item.props.icon) {
-            throw new Error(
-              "Icon is required for icon-only buttons"
-            );
+            throw new Error("Icon is required for icon-only buttons");
           }
 
           return (
@@ -220,9 +217,7 @@ const ButtonGroup = React.forwardRef<HTMLDivElement, ButtonGroupProps>(
 
       if (buttonSize === "icon" || buttonSize === "icon-xs") {
         if (!item.triggerProps.icon) {
-          throw new Error(
-            "Icon is required for icon-only buttons"
-          );
+          throw new Error("Icon is required for icon-only buttons");
         }
 
         return (

--- a/sparkle/src/components/Card.tsx
+++ b/sparkle/src/components/Card.tsx
@@ -225,11 +225,10 @@ const CardActions = React.forwardRef<
 
 CardActions.displayName = "CardActions";
 
-
 export const CardActionButton = React.forwardRef<
   HTMLButtonElement,
   IconOnlyButtonProps
->(({ className, variant = "outline", icon = XMarkIcon, ...props }, ref) => {
+>(({ className, variant = "outline", icon = XMarkIcon, size = "icon", ...props }, ref) => {
   return (
     <Button
       ref={ref}

--- a/sparkle/src/components/Card.tsx
+++ b/sparkle/src/components/Card.tsx
@@ -225,15 +225,20 @@ const CardActions = React.forwardRef<
 
 CardActions.displayName = "CardActions";
 
+export type CardActionButtonProps = Omit<MiniButtonProps, "size"> & {
+  size?: "icon" | "icon-xs";
+};
+
 export const CardActionButton = React.forwardRef<
   HTMLButtonElement,
-  MiniButtonProps
->(({ className, variant = "outline", icon = XMarkIcon, ...props }, ref) => {
+  CardActionButtonProps
+>(({ className, variant = "outline", icon = XMarkIcon, size = "icon", ...props }, ref) => {
   return (
     <Button
       ref={ref}
       variant={variant}
       icon={icon}
+      size={size}
       className={className}
       {...props}
     />

--- a/sparkle/src/components/Card.tsx
+++ b/sparkle/src/components/Card.tsx
@@ -229,7 +229,7 @@ CardActions.displayName = "CardActions";
 export const CardActionButton = React.forwardRef<
   HTMLButtonElement,
   IconOnlyButtonProps
->(({ className, variant = "outline", icon = XMarkIcon, size = "icon", ...props }, ref) => {
+>(({ className, variant = "outline", icon = XMarkIcon, ...props }, ref) => {
   return (
     <Button
       ref={ref}

--- a/sparkle/src/components/Card.tsx
+++ b/sparkle/src/components/Card.tsx
@@ -1,7 +1,7 @@
 import { cva } from "class-variance-authority";
 import React from "react";
 
-import { Button, MiniButtonProps } from "@sparkle/components/Button";
+import { Button, IconOnlyButtonProps } from "@sparkle/components/Button";
 import { LinkWrapperProps } from "@sparkle/components/LinkWrapper";
 import {
   noHrefLink,
@@ -225,13 +225,10 @@ const CardActions = React.forwardRef<
 
 CardActions.displayName = "CardActions";
 
-export type CardActionButtonProps = Omit<MiniButtonProps, "size"> & {
-  size?: "icon" | "icon-xs";
-};
 
 export const CardActionButton = React.forwardRef<
   HTMLButtonElement,
-  CardActionButtonProps
+  IconOnlyButtonProps
 >(({ className, variant = "outline", icon = XMarkIcon, size = "icon", ...props }, ref) => {
   return (
     <Button

--- a/sparkle/src/components/Card.tsx
+++ b/sparkle/src/components/Card.tsx
@@ -228,18 +228,29 @@ CardActions.displayName = "CardActions";
 export const CardActionButton = React.forwardRef<
   HTMLButtonElement,
   IconOnlyButtonProps
->(({ className, variant = "outline", icon = XMarkIcon, size = "icon", ...props }, ref) => {
-  return (
-    <Button
-      ref={ref}
-      variant={variant}
-      icon={icon}
-      size={size}
-      className={className}
-      {...props}
-    />
-  );
-});
+>(
+  (
+    {
+      className,
+      variant = "outline",
+      icon = XMarkIcon,
+      size = "icon",
+      ...props
+    },
+    ref
+  ) => {
+    return (
+      <Button
+        ref={ref}
+        variant={variant}
+        icon={icon}
+        size={size}
+        className={className}
+        {...props}
+      />
+    );
+  }
+);
 
 CardActionButton.displayName = "CardActionButton";
 

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -13,7 +13,6 @@ export type { BreadcrumbItem } from "./Breadcrumbs";
 export { Breadcrumbs } from "./Breadcrumbs";
 export type {
   ButtonProps,
-  MiniButtonProps,
   RegularButtonProps,
 } from "./Button";
 export { Button } from "./Button";

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -11,10 +11,7 @@ export { Avatar } from "./Avatar";
 export { Bar, BarFooter, BarHeader } from "./Bar";
 export type { BreadcrumbItem } from "./Breadcrumbs";
 export { Breadcrumbs } from "./Breadcrumbs";
-export type {
-  ButtonProps,
-  RegularButtonProps,
-} from "./Button";
+export type { ButtonProps, RegularButtonProps } from "./Button";
 export { Button } from "./Button";
 export type { ButtonGroupItem, ButtonGroupProps } from "./ButtonGroup";
 export { ButtonGroup } from "./ButtonGroup";

--- a/sparkle/src/stories/Button.stories.tsx
+++ b/sparkle/src/stories/Button.stories.tsx
@@ -1,7 +1,12 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import React from "react";
 
-import { BUTTON_VARIANTS, ICON_ONLY_SIZES, REGULAR_BUTTON_SIZES, RegularButtonSize } from "@sparkle/components/Button";
+import {
+  BUTTON_VARIANTS,
+  ICON_ONLY_SIZES,
+  REGULAR_BUTTON_SIZES,
+  RegularButtonSize,
+} from "@sparkle/components/Button";
 
 import { Button, PlusIcon, RobotIcon, Separator } from "../index_with_tw_base";
 
@@ -113,11 +118,7 @@ export const IconOnlyButtons: Story = {
   ),
 };
 
-const ButtonBySize = ({
-  size,
-}: {
-  size: RegularButtonSize;
-}) => (
+const ButtonBySize = ({ size }: { size: RegularButtonSize }) => (
   <>
     <Separator />
     <h3 className="s-text-primary dark:s-text-primary-50">

--- a/sparkle/src/stories/Button.stories.tsx
+++ b/sparkle/src/stories/Button.stories.tsx
@@ -22,22 +22,19 @@ const meta = {
       control: { type: "select" },
     },
     size: {
-      description:
-        "The size of the button (Note: 'mini' size requires an icon and cannot have a label)",
+      description: `The size of the button. Use "icon" or "icon-xs" for icon-only buttons`,
       options: BUTTON_SIZES,
       control: { type: "select" },
     },
     icon: {
-      description: "Icon to display in the button (Required for mini size)",
+      description: "Icon to display in the button",
       options: Object.keys(ICONS),
       mapping: ICONS,
       control: { type: "select" },
-      if: { arg: "size", neq: "mini" },
     },
     label: {
-      description: "Button label (Not available for mini size)",
+      description: "Button label",
       control: { type: "text" },
-      if: { arg: "size", neq: "mini" },
     },
     disabled: {
       description: "Whether the button should be disabled",
@@ -100,14 +97,26 @@ export const ExampleButton: Story = {
   },
 };
 
-export const MiniButton: Story = {
-  render: () => <Button size="mini" icon={PlusIcon} />,
+export const IconOnlyButtons: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: `Use "icon" or "icon-xs" for icon-only buttons. Labels are automatically hidden for these sizes.`,
+      },
+    },
+  },
+  render: () => (
+    <div className="s-flex s-items-center s-gap-4">
+      <Button size="icon-xs" icon={PlusIcon} />
+      <Button size="icon" icon={PlusIcon} />
+    </div>
+  ),
 };
 
 const ButtonBySize = ({
   size,
 }: {
-  size: Exclude<React.ComponentProps<typeof Button>["size"], "mini">;
+  size: React.ComponentProps<typeof Button>["size"];
 }) => (
   <>
     <Separator />
@@ -140,6 +149,7 @@ const ButtonBySize = ({
 export const Gallery: Story = {
   render: () => (
     <div className="s-flex s-flex-col s-gap-4">
+      <ButtonBySize size="mini" />
       <ButtonBySize size="xs" />
       <ButtonBySize size="sm" />
       <ButtonBySize size="md" />

--- a/sparkle/src/stories/Button.stories.tsx
+++ b/sparkle/src/stories/Button.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import React from "react";
 
-import { BUTTON_SIZES, BUTTON_VARIANTS } from "@sparkle/components/Button";
+import { BUTTON_VARIANTS, ICON_ONLY_SIZES, REGULAR_BUTTON_SIZES, RegularButtonSize } from "@sparkle/components/Button";
 
 import { Button, PlusIcon, RobotIcon, Separator } from "../index_with_tw_base";
 
@@ -23,7 +23,7 @@ const meta = {
     },
     size: {
       description: `The size of the button. Use "icon" or "icon-xs" for icon-only buttons`,
-      options: BUTTON_SIZES,
+      options: [...REGULAR_BUTTON_SIZES, ...ICON_ONLY_SIZES],
       control: { type: "select" },
     },
     icon: {
@@ -116,7 +116,7 @@ export const IconOnlyButtons: Story = {
 const ButtonBySize = ({
   size,
 }: {
-  size: React.ComponentProps<typeof Button>["size"];
+  size: RegularButtonSize;
 }) => (
   <>
     <Separator />

--- a/sparkle/src/stories/ButtonGroup.stories.tsx
+++ b/sparkle/src/stories/ButtonGroup.stories.tsx
@@ -52,7 +52,7 @@ const meta = {
     size: {
       description: "Size applied to every button",
       control: { type: "select" },
-      options: BUTTON_SIZES.filter((size) => size !== "mini"),
+      options: BUTTON_SIZES.filter((size) => size !== "icon" && size !== "icon-xs"),
     },
     orientation: {
       description: "Stack buttons horizontally or vertically",

--- a/sparkle/src/stories/ButtonGroup.stories.tsx
+++ b/sparkle/src/stories/ButtonGroup.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import React from "react";
 
 import {
-  BUTTON_SIZES,
+  REGULAR_BUTTON_SIZES,
   BUTTON_VARIANTS,
   type ButtonVariantType,
 } from "@sparkle/components/Button";
@@ -52,7 +52,7 @@ const meta = {
     size: {
       description: "Size applied to every button",
       control: { type: "select" },
-      options: BUTTON_SIZES.filter((size) => size !== "icon" && size !== "icon-xs"),
+      options: REGULAR_BUTTON_SIZES,
     },
     orientation: {
       description: "Stack buttons horizontally or vertically",
@@ -94,6 +94,17 @@ export const WithIcons: Story = {
       { type: "button", props: { icon: PlusIcon, label: "Add" } },
       { type: "button", props: { icon: RobotIcon, label: "Agent" } },
       { type: "button", props: { label: "More" } },
+    ],
+  },
+};
+
+export const IconOnly: Story = {
+  args: {
+    size: "icon",
+    items: [
+      { type: "button", props: { icon: PlusIcon, tooltip: "Add" } },
+      { type: "button", props: { icon: RobotIcon, tooltip: "Agent" } },
+      { type: "button", props: { icon: ClipboardIcon, tooltip: "Copy" } },
     ],
   },
 };

--- a/sparkle/src/stories/Card.stories.tsx
+++ b/sparkle/src/stories/Card.stories.tsx
@@ -219,7 +219,7 @@ export const WithActions: Story = {
           onClick={() => {
             alert(`You clicked on ${card.title}`);
           }}
-          action={<CardActionButton size="mini" icon={XMarkIcon} />}
+          action={<CardActionButton icon={XMarkIcon} />}
         >
           <div className="s-flex s-w-full s-flex-col s-gap-1 s-text-sm">
             <div className="s-flex s-w-full s-gap-1 s-font-semibold s-text-foreground">
@@ -249,7 +249,7 @@ export const SelectableGrid: Story = {
             size="md"
             selected={selected === index}
             onClick={() => setSelected(index)}
-            action={<CardActionButton size="mini" icon={XMarkIcon} />}
+            action={<CardActionButton icon={XMarkIcon} />}
           >
             <div className="s-flex s-w-full s-flex-col s-gap-1 s-text-sm">
               <div className="s-flex s-w-full s-gap-1 s-font-semibold s-text-foreground">

--- a/sparkle/src/stories/Card.stories.tsx
+++ b/sparkle/src/stories/Card.stories.tsx
@@ -219,7 +219,7 @@ export const WithActions: Story = {
           onClick={() => {
             alert(`You clicked on ${card.title}`);
           }}
-          action={<CardActionButton icon={XMarkIcon} />}
+          action={<CardActionButton icon={XMarkIcon} size="icon" />}
         >
           <div className="s-flex s-w-full s-flex-col s-gap-1 s-text-sm">
             <div className="s-flex s-w-full s-gap-1 s-font-semibold s-text-foreground">
@@ -249,7 +249,7 @@ export const SelectableGrid: Story = {
             size="md"
             selected={selected === index}
             onClick={() => setSelected(index)}
-            action={<CardActionButton icon={XMarkIcon} />}
+            action={<CardActionButton icon={XMarkIcon} size="icon" />}
           >
             <div className="s-flex s-w-full s-flex-col s-gap-1 s-text-sm">
               <div className="s-flex s-w-full s-gap-1 s-font-semibold s-text-foreground">


### PR DESCRIPTION
## Description
This PR is to allow to have "mini" and "xmini" for button with labels. We want to keep fixed width for icon only button so it adds new variants "icon" and "icon-xs". The changes in front is done in https://github.com/dust-tt/dust/pull/20331
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
