### PR TITLE
[front] - refactor(AgentCreatedDialog): streamline functionality

### DIFF
--- a/front/components/agent_builder/AgentCreatedDialog.tsx
+++ b/front/components/agent_builder/AgentCreatedDialog.tsx
@@ -7,6 +7,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@dust-tt/sparkle";
+
 import { getConversationRoute } from "@app/lib/utils/router";
 import type { WorkspaceType } from "@app/types";
 

--- a/front/components/agent_builder/AgentCreatedDialog.tsx
+++ b/front/components/agent_builder/AgentCreatedDialog.tsx
@@ -1,18 +1,12 @@
 import {
   ChatBubbleBottomCenterTextIcon,
-  ClipboardCheckIcon,
-  ClipboardIcon,
   Dialog,
   DialogContent,
   DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
-  useCopyToClipboard,
 } from "@dust-tt/sparkle";
-import { useEffect } from "react";
-
-import { useSendNotification } from "@app/hooks/useNotification";
 import { getConversationRoute } from "@app/lib/utils/router";
 import type { WorkspaceType } from "@app/types";
 
@@ -31,18 +25,6 @@ export function AgentCreatedDialog({
   agentId,
   owner,
 }: AgentCreatedDialogProps) {
-  const [isCopied, copyToClipboard] = useCopyToClipboard();
-  const sendNotification = useSendNotification(true);
-
-  useEffect(() => {
-    if (isCopied) {
-      sendNotification({
-        type: "success",
-        title: "Link copied to clipboard",
-      });
-    }
-  }, [isCopied, sendNotification]);
-
   const agentHandle = `@${agentName}`;
   const conversationQuery = `agent=${agentId}`;
 
@@ -51,12 +33,6 @@ export function AgentCreatedDialog({
     "new",
     conversationQuery
   );
-  const shareLink = getConversationRoute(
-    owner.sId,
-    "new",
-    conversationQuery,
-    process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL
-  );
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -64,17 +40,16 @@ export function AgentCreatedDialog({
         <DialogHeader>
           <DialogTitle>Agent {agentHandle} has been created!</DialogTitle>
           <DialogDescription>
-            You can now use {agentHandle} in conversations. Start a chat or
-            share the link with your team.
+            You can now use {agentHandle} in conversations. Start a chat or keep
+            editing this agent.
           </DialogDescription>
         </DialogHeader>
         <DialogFooter
           leftButtonProps={{
-            label: isCopied ? "Link copied" : "Share",
+            label: "Keep editing",
             variant: "outline",
-            icon: isCopied ? ClipboardCheckIcon : ClipboardIcon,
             onClick: () => {
-              void copyToClipboard(shareLink);
+              onOpenChange(false);
             },
           }}
           rightButtonProps={{


### PR DESCRIPTION
## Description
Simplifies the `AgentCreatedDialog` by removing the copy-to-clipboard share functionality. Changes the left button from "Share" (which copied a conversation link) to "Keep editing" (which closes the dialog and returns to the agent builder). The right button remains "Start chat" to test the newly created agent.

This streamlines the post-creation flow to focus on the two primary user actions: continuing to edit the agent or immediately testing it in a conversation.
<img width="1202" height="499" alt="Screenshot 2026-01-20 at 14 27 07" src="https://github.com/user-attachments/assets/91f98aa8-0f86-490f-89d6-2cd160786c2b" />

## Risk
Low - UI-only change to a recently added dialog. The share functionality was redundant as users can share agents through other means.

## Tests
Manually tested agent creation flow.

## Deploy Plan

Deploy front