### PR TITLE
Fix Single Content Fragment Rendering

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1316,7 +1316,7 @@ export async function postNewContentFragment(
     }
   }
 
-  const { messageRow } = await withTransaction(async (t) => {
+  const { contentFragment, messageRow } = await withTransaction(async (t) => {
     await getConversationRankVersionLock(auth, conversation, t);
 
     const fullBlob = {
@@ -1371,14 +1371,16 @@ export async function postNewContentFragment(
 
     await ConversationResource.markAsUpdated(auth, { conversation, t });
 
-    return { messageRow };
+    return { contentFragment, messageRow };
   });
 
   // Use batch method even for single message to ensure optimized file fetching.
-  const [render] = await ContentFragmentResource.batchRenderFromMessages(auth, {
+  const render = await contentFragment.renderFromMessage(auth, {
     conversationId: conversation.sId,
-    messages: [messageRow],
+    message: messageRow,
   });
+
+  console.log(">> render:", render);
 
   return new Ok(render);
 }

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1380,8 +1380,6 @@ export async function postNewContentFragment(
     message: messageRow,
   });
 
-  console.log(">> render:", render);
-
   return new Ok(render);
 }
 

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1374,7 +1374,6 @@ export async function postNewContentFragment(
     return { contentFragment, messageRow };
   });
 
-  // Use batch method even for single message to ensure optimized file fetching.
   const render = await contentFragment.renderFromMessage(auth, {
     conversationId: conversation.sId,
     message: messageRow,

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -237,8 +237,7 @@ export class ContentFragmentResource extends BaseResource<ContentFragmentModel> 
           ? filesByModelId.get(contentFragment.fileId)
           : undefined;
 
-        return contentFragment._renderFromMessage({
-          auth,
+        return contentFragment.renderFromMessage(auth, {
           conversationId,
           message,
           file,
@@ -303,20 +302,20 @@ export class ContentFragmentResource extends BaseResource<ContentFragmentModel> 
   }
 
   /**
-   * Internal method to render a content fragment from a message.
    * Use batchRenderFromMessages instead to avoid N+1 queries.
    */
-  private async _renderFromMessage({
-    auth,
-    conversationId,
-    message,
-    file,
-  }: {
-    auth: Authenticator;
-    conversationId: string;
-    message: MessageModel;
-    file?: FileResource;
-  }): Promise<ContentFragmentType> {
+  async renderFromMessage(
+    auth: Authenticator,
+    {
+      conversationId,
+      message,
+      file,
+    }: {
+      conversationId: string;
+      message: MessageModel;
+      file?: FileResource;
+    }
+  ): Promise<ContentFragmentType> {
     const owner = auth.workspace();
     if (!owner) {
       throw new Error(


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
A regression was introduced in https://github.com/dust-tt/dust/pull/20304 that broke the single content fragment rendering. Assuming the `contentFragment` was properly populated through the Sequelize relationship. This was inaccurate.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
