### PR TITLE
[front] update button variants

### DIFF
--- a/front/components/agent_builder/FeedbacksSection.tsx
+++ b/front/components/agent_builder/FeedbacksSection.tsx
@@ -288,7 +288,7 @@ function FeedbackCard({
       action={
         <div className="flex gap-1">
           <CardActionButton
-            size="mini"
+            size="icon"
             icon={feedback.dismissed ? EyeIcon : EyeSlashIcon}
             onClick={() => toggleDismiss(!feedback.dismissed)}
             disabled={isDismissing}
@@ -296,7 +296,7 @@ function FeedbackCard({
           />
           {conversationUrl && (
             <CardActionButton
-              size="mini"
+              size="icon"
               icon={ExternalLinkIcon}
               href={conversationUrl ?? ""}
               disabled={!conversationUrl}

--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeFooter.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeFooter.tsx
@@ -85,7 +85,7 @@ function KnowledgeFooterItem({
       visual={<Icon size="sm" visual={VisualComponent} />}
       action={
         <Button
-          size="mini"
+          size="icon"
           variant="ghost"
           icon={XMarkIcon}
           onClick={() => removeNodeWithPath(item)}

--- a/front/components/agent_builder/skills/AgentBuilderSkillsBlock.tsx
+++ b/front/components/agent_builder/skills/AgentBuilderSkillsBlock.tsx
@@ -59,7 +59,7 @@ function SkillCard({ skill, onRemove, onClick }: SkillCardProps) {
       onClick={onClick}
       action={
         <CardActionButton
-          size="mini"
+          size="icon"
           icon={XMarkIcon}
           onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
             onRemove();

--- a/front/components/agent_builder/triggers/TriggerCard.tsx
+++ b/front/components/agent_builder/triggers/TriggerCard.tsx
@@ -90,7 +90,7 @@ export const TriggerCard = ({
       action={
         (isEditor || isAdmin) && (
           <CardActionButton
-            size="mini"
+            size="icon"
             icon={XMarkIcon}
             onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
               e.stopPropagation();

--- a/front/components/app/DatasetView.tsx
+++ b/front/components/app/DatasetView.tsx
@@ -618,7 +618,7 @@ export default function DatasetView({
                             {datasetKeys.length > 1 ? (
                               <>
                                 <Button
-                                  size="mini"
+                                  size="icon"
                                   variant="ghost"
                                   className="text-muted-foreground"
                                   icon={XCircleIcon}
@@ -629,7 +629,7 @@ export default function DatasetView({
                                 />
 
                                 <Button
-                                  size="mini"
+                                  size="icon"
                                   variant="ghost"
                                   className="text-muted-foreground"
                                   icon={PlusCircleIcon}
@@ -798,7 +798,7 @@ export default function DatasetView({
                         {datasetData.length > 1 ? (
                           <Button
                             icon={XCircleIcon}
-                            size="mini"
+                            size="icon"
                             variant="ghost"
                             onClick={() => {
                               handleDeleteEntry(i);
@@ -807,7 +807,7 @@ export default function DatasetView({
                         ) : null}
                         <Button
                           icon={PlusCircleIcon}
-                          size="mini"
+                          size="icon"
                           variant="ghost"
                           onClick={() => {
                             handleNewEntry(i);

--- a/front/components/app/NewBlock.tsx
+++ b/front/components/app/NewBlock.tsx
@@ -130,7 +130,7 @@ export default function NewBlock({
             icon={PlusIcon}
             disabled={disabled}
             variant="ghost-secondary"
-            size="mini"
+            size="icon"
           />
         ) : (
           <Button

--- a/front/components/app/blocks/Block.tsx
+++ b/front/components/app/blocks/Block.tsx
@@ -123,7 +123,7 @@ export default function Block({
                     : "Results are computed at each run"
                 }
                 variant="ghost-secondary"
-                size="mini"
+                size="icon"
                 icon={
                   block.config && block.config.use_cache
                     ? Square3Stack3DIcon
@@ -145,19 +145,19 @@ export default function Block({
                   variant="ghost-secondary"
                   icon={ChevronUpIcon}
                   onClick={onBlockUp}
-                  size="mini"
+                  size="icon"
                 />
                 <Button
                   variant="ghost-secondary"
                   icon={ChevronDownIcon}
                   onClick={onBlockDown}
-                  size="mini"
+                  size="icon"
                 />
                 <Button
                   variant="ghost-secondary"
                   icon={TrashIcon}
                   onClick={onBlockDelete}
-                  size="mini"
+                  size="icon"
                 />
               </>
             )}

--- a/front/components/app/blocks/Output.tsx
+++ b/front/components/app/blocks/Output.tsx
@@ -353,7 +353,7 @@ const JsonCopyLink = ({ value }: { value: string }) => {
           onClick={handleClick}
           tooltip="Copy JSON to clipboard"
           icon={ClipboardIcon}
-          size="mini"
+          size="icon"
           variant="ghost-secondary"
         />
       )}

--- a/front/components/assistant/conversation/ConversationTitle.tsx
+++ b/front/components/assistant/conversation/ConversationTitle.tsx
@@ -47,7 +47,7 @@ export function ConversationTitle({ owner }: { owner: WorkspaceType }) {
         <div className="flex min-w-0">
           {conversation?.spaceId && (
             <IconButton
-              size="xmini"
+              size="icon-xs"
               variant="outline"
               icon={ArrowLeftIcon}
               aria-label={`Back to ${spaceInfo?.name}`}

--- a/front/components/assistant/conversation/ConversationTitle.tsx
+++ b/front/components/assistant/conversation/ConversationTitle.tsx
@@ -47,7 +47,7 @@ export function ConversationTitle({ owner }: { owner: WorkspaceType }) {
         <div className="flex min-w-0">
           {conversation?.spaceId && (
             <IconButton
-              size="icon-xs"
+              size="xs"
               variant="outline"
               icon={ArrowLeftIcon}
               aria-label={`Back to ${spaceInfo?.name}`}

--- a/front/components/assistant/conversation/MessageEmojiPicker.tsx
+++ b/front/components/assistant/conversation/MessageEmojiPicker.tsx
@@ -32,9 +32,9 @@ export function MessageEmojiPicker({
           key="emoji-picker-button"
           tooltip="Add reaction"
           variant="outline"
-          size="xs"
+          size="icon-xs"
           icon={EmotionLaughIcon}
-          isSelect={true}
+          isSelect
           className={cn("text-muted-foreground", className)}
         />
       </PopoverTrigger>

--- a/front/components/assistant/conversation/MessageEmojiPicker.tsx
+++ b/front/components/assistant/conversation/MessageEmojiPicker.tsx
@@ -32,7 +32,7 @@ export function MessageEmojiPicker({
           key="emoji-picker-button"
           tooltip="Add reaction"
           variant="outline"
-          size="icon-xs"
+          size="xmini"
           icon={EmotionLaughIcon}
           isSelect
           className={cn("text-muted-foreground", className)}

--- a/front/components/assistant/conversation/MessageReactions.tsx
+++ b/front/components/assistant/conversation/MessageReactions.tsx
@@ -64,7 +64,7 @@ export function MessageReactions({
           trigger={
             <Button
               label={`+${hiddenReactions.length}`}
-              size="xs"
+              size="xmini"
               variant="outline"
               aria-label="More reactions"
             />

--- a/front/components/assistant/conversation/ReactionPill.tsx
+++ b/front/components/assistant/conversation/ReactionPill.tsx
@@ -1,4 +1,4 @@
-import { Button, Tooltip } from "@dust-tt/sparkle";
+import { Button, cn, Tooltip } from "@dust-tt/sparkle";
 
 interface ReactionPillProps {
   emoji: string;
@@ -36,8 +36,11 @@ export function ReactionPill({
       trigger={
         <Button
           label={`${emoji} ${count}`}
-          size="xs"
-          variant={hasCurrentUserReacted ? "primary" : "outline"}
+          size="xmini"
+          variant="outline"
+          className={cn(
+            hasCurrentUserReacted && "bg-blue-50 hover:bg-blue-100 border-blue-200 hover:border-blue-200 dark:bg-blue-900 dark:hover:bg-blue-800 dark:border-blue-700 hover:dark:border-blue-700"
+          )}
           onClick={onClick}
         />
       }

--- a/front/components/assistant/conversation/ReactionPill.tsx
+++ b/front/components/assistant/conversation/ReactionPill.tsx
@@ -1,4 +1,4 @@
-import { Button, Tooltip } from "@dust-tt/sparkle";
+import { Button, cn, Tooltip } from "@dust-tt/sparkle";
 
 interface ReactionPillProps {
   emoji: string;
@@ -37,8 +37,12 @@ export function ReactionPill({
         <Button
           label={`${emoji} ${count}`}
           size="xmini"
-          variant={hasCurrentUserReacted ? "primary" : "outline"}
+          variant="outline"
           onClick={onClick}
+          className={cn(
+            hasCurrentUserReacted &&
+              "border-blue-200 bg-blue-50 hover:border-blue-200 hover:bg-blue-100 dark:border-blue-700 dark:bg-blue-900 hover:dark:border-blue-700 dark:hover:bg-blue-800"
+          )}
         />
       }
     />

--- a/front/components/assistant/conversation/ReactionPill.tsx
+++ b/front/components/assistant/conversation/ReactionPill.tsx
@@ -1,4 +1,4 @@
-import { Button, cn, Tooltip } from "@dust-tt/sparkle";
+import { Button, Tooltip } from "@dust-tt/sparkle";
 
 interface ReactionPillProps {
   emoji: string;
@@ -37,10 +37,7 @@ export function ReactionPill({
         <Button
           label={`${emoji} ${count}`}
           size="xmini"
-          variant="outline"
-          className={cn(
-            hasCurrentUserReacted && "bg-blue-50 hover:bg-blue-100 border-blue-200 hover:border-blue-200 dark:bg-blue-900 dark:hover:bg-blue-800 dark:border-blue-700 hover:dark:border-blue-700"
-          )}
+          variant={hasCurrentUserReacted ? "primary" : "outline"}
           onClick={onClick}
         />
       }

--- a/front/components/assistant/conversation/UserMessage.tsx
+++ b/front/components/assistant/conversation/UserMessage.tsx
@@ -437,7 +437,7 @@ function ActionMenu({
     : [];
 
   return (
-    <div className="absolute -bottom-3.5 left-2.5 flex flex-wrap items-center gap-1">
+    <div className="absolute top-[80%] left-2.5 flex flex-wrap items-center gap-1">
       {!isDeleted && reactionsEnabled && (
         <>
           <MessageReactions
@@ -462,7 +462,7 @@ function ActionMenu({
           <DropdownMenuTrigger asChild>
             <Button
               icon={MoreIcon}
-              size="xs"
+              size="icon-xs"
               variant="outline"
               aria-label="Message actions"
               className={cn(
@@ -475,7 +475,7 @@ function ActionMenu({
             {actions.map((action, index) => (
               <DropdownMenuItem
                 key={index}
-                icon={action.icon}
+                icon={action.icon} 
                 label={action.label}
                 onClick={action.onClick}
               />

--- a/front/components/assistant/conversation/UserMessage.tsx
+++ b/front/components/assistant/conversation/UserMessage.tsx
@@ -437,7 +437,12 @@ function ActionMenu({
     : [];
 
   return (
-    <div className="absolute left-2.5 top-[80%] flex flex-wrap items-center gap-1">
+    <div
+      className={cn(
+        "absolute top-[80%] flex flex-wrap items-center gap-1",
+        reactionsEnabled ? "left-2.5" : "right-2.5"
+      )}
+    >
       {!isDeleted && reactionsEnabled && (
         <>
           <MessageReactions

--- a/front/components/assistant/conversation/UserMessage.tsx
+++ b/front/components/assistant/conversation/UserMessage.tsx
@@ -437,7 +437,7 @@ function ActionMenu({
     : [];
 
   return (
-    <div className="absolute top-[80%] left-2.5 flex flex-wrap items-center gap-1">
+    <div className="absolute left-2.5 top-[80%] flex flex-wrap items-center gap-1">
       {!isDeleted && reactionsEnabled && (
         <>
           <MessageReactions

--- a/front/components/assistant/conversation/UserMessage.tsx
+++ b/front/components/assistant/conversation/UserMessage.tsx
@@ -475,7 +475,7 @@ function ActionMenu({
             {actions.map((action, index) => (
               <DropdownMenuItem
                 key={index}
-                icon={action.icon} 
+                icon={action.icon}
                 label={action.label}
                 onClick={action.onClick}
               />

--- a/front/components/assistant/conversation/input_bar/toolbar/MobileToolbar.tsx
+++ b/front/components/assistant/conversation/input_bar/toolbar/MobileToolbar.tsx
@@ -22,7 +22,7 @@ export function MobileToolbar({ editor, className, onClose }: ToolbarProps) {
       )}
     >
       <Button
-        size="mini"
+        size="icon"
         variant="outline"
         icon={XMarkIcon}
         onClick={onClose}

--- a/front/components/assistant/conversation/input_bar/toolbar/ToolbarIcon.tsx
+++ b/front/components/assistant/conversation/input_bar/toolbar/ToolbarIcon.tsx
@@ -21,7 +21,7 @@ export function ToolbarIcon({
 }: ToolbarIconProps) {
   const isMobile = useIsMobile();
   const shortcutLabel = useKeyboardShortcutLabel(shortcut);
-  const buttonSize = isMobile ? "xs" : "mini";
+  const buttonSize = isMobile ? "xs" : "icon";
 
   let tooltipText = tooltip;
   if (isMobile) {

--- a/front/components/assistant/details/tabs/AgentMemoryTab.tsx
+++ b/front/components/assistant/details/tabs/AgentMemoryTab.tsx
@@ -137,7 +137,7 @@ export function AgentMemoryTab({
                     className="flex flex-col gap-2"
                     action={
                       <CardActionButton
-                        size="mini"
+                        size="icon"
                         icon={TrashIcon}
                         onClick={() => {
                           setMemoryToDelete(memory.sId);

--- a/front/components/assistant/manager/TableTagSelector.tsx
+++ b/front/components/assistant/manager/TableTagSelector.tsx
@@ -59,7 +59,7 @@ export const TableTagSelector = ({
           <Button
             variant="ghost"
             icon={ChevronDownIcon}
-            size="xmini"
+            size="icon-xs"
             className="invisible text-muted-foreground group-hover:visible dark:text-muted-foreground-night"
           />
         )}

--- a/front/components/shared/tools_picker/ActionCard.tsx
+++ b/front/components/shared/tools_picker/ActionCard.tsx
@@ -54,7 +54,7 @@ export function ActionCard({ action, onRemove, onClick }: ActionCardProps) {
       onClick={onClick}
       action={
         <CardActionButton
-          size="mini"
+          size="icon"
           icon={XMarkIcon}
           onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
             onRemove();

--- a/front/components/skills/SuggestedSkillsSection.tsx
+++ b/front/components/skills/SuggestedSkillsSection.tsx
@@ -64,7 +64,7 @@ function SuggestedSkillCard({
         onClick={onMoreInfoClick}
         action={
           <CardActionButton
-            size="mini"
+            size="icon"
             icon={XMarkIcon}
             onClick={(e) => {
               e.stopPropagation();

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -13,7 +13,7 @@
         "@contentful/rich-text-types": "^17.2.5",
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.7.6-rc-3",
+        "@dust-tt/sparkle": "^0.7.8-rc-1",
         "@elastic/elasticsearch": "^8.15.0",
         "@elevenlabs/elevenlabs-js": "^2.17.0",
         "@emoji-mart/data": "^1.2.1",
@@ -2624,9 +2624,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.7.6-rc-3",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.7.6-rc-3.tgz",
-      "integrity": "sha512-uUGSPUHKVwNe/PmtmkTm1GA2PvysJxFY6E0e8oHMzXKz611zDrakUCKcY+bx7b9wyl9YBGwuc33htXxsgAy2Wg==",
+      "version": "0.7.8-rc-1",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.7.8-rc-1.tgz",
+      "integrity": "sha512-I42AoC7Mw0cZEA5kBbbucku+JHWSigoe7I0pDpRxDH0AYM1VltOAqgi6+ZJUGhPF2xRM4hc7ZzoG3EilVe8OlA==",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -13,7 +13,7 @@
         "@contentful/rich-text-types": "^17.2.5",
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.7.6-rc-2",
+        "@dust-tt/sparkle": "^0.7.6-rc-3",
         "@elastic/elasticsearch": "^8.15.0",
         "@elevenlabs/elevenlabs-js": "^2.17.0",
         "@emoji-mart/data": "^1.2.1",
@@ -2624,9 +2624,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.7.6-rc-2",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.7.6-rc-2.tgz",
-      "integrity": "sha512-U9LDOEsyV0CVoNF5JccoCjJTTgBFNHPw/ZVSiNYPqDwMN5GIsTI4eiK6WAtfSjw0cqAU4QmBSCsABiFENV0sCg==",
+      "version": "0.7.6-rc-3",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.7.6-rc-3.tgz",
+      "integrity": "sha512-uUGSPUHKVwNe/PmtmkTm1GA2PvysJxFY6E0e8oHMzXKz611zDrakUCKcY+bx7b9wyl9YBGwuc33htXxsgAy2Wg==",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -13,7 +13,7 @@
         "@contentful/rich-text-types": "^17.2.5",
         "@datadog/browser-logs": "^6.13.0",
         "@dust-tt/client": "file:../sdks/js",
-        "@dust-tt/sparkle": "^0.7.2",
+        "@dust-tt/sparkle": "^0.7.6-rc-2",
         "@elastic/elasticsearch": "^8.15.0",
         "@elevenlabs/elevenlabs-js": "^2.17.0",
         "@emoji-mart/data": "^1.2.1",
@@ -2624,9 +2624,9 @@
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.7.2.tgz",
-      "integrity": "sha512-1eh125pKkINb3Ei0ThEzy1LmDdgg9Oi3+MR0I69Rt8OCJVA6QZTEwy8koqytTjiKCkOLvaIhayUX7QQzu1B5sw==",
+      "version": "0.7.6-rc-2",
+      "resolved": "https://registry.npmjs.org/@dust-tt/sparkle/-/sparkle-0.7.6-rc-2.tgz",
+      "integrity": "sha512-U9LDOEsyV0CVoNF5JccoCjJTTgBFNHPw/ZVSiNYPqDwMN5GIsTI4eiK6WAtfSjw0cqAU4QmBSCsABiFENV0sCg==",
       "license": "ISC",
       "dependencies": {
         "@emoji-mart/data": "^1.1.2",

--- a/front/package.json
+++ b/front/package.json
@@ -39,7 +39,7 @@
     "@contentful/rich-text-types": "^17.2.5",
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.7.2",
+    "@dust-tt/sparkle": "^0.7.6-rc-3",
     "@elastic/elasticsearch": "^8.15.0",
     "@elevenlabs/elevenlabs-js": "^2.17.0",
     "@emoji-mart/data": "^1.2.1",

--- a/front/package.json
+++ b/front/package.json
@@ -39,7 +39,7 @@
     "@contentful/rich-text-types": "^17.2.5",
     "@datadog/browser-logs": "^6.13.0",
     "@dust-tt/client": "file:../sdks/js",
-    "@dust-tt/sparkle": "^0.7.6-rc-3",
+    "@dust-tt/sparkle": "^0.7.8-rc-1",
     "@elastic/elasticsearch": "^8.15.0",
     "@elevenlabs/elevenlabs-js": "^2.17.0",
     "@emoji-mart/data": "^1.2.1",


### PR DESCRIPTION
## Description
Follow up PR of https://github.com/dust-tt/dust/pull/20320, replace the `mini` variant with `icon` when there is only icon. I will create another PRs to remove IconButton and use only Button everywhere.

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
