### PR TITLE
[Membership] Add unique index to prevent duplicate active memberships

### DIFF
--- a/front/lib/resources/storage/models/membership.ts
+++ b/front/lib/resources/storage/models/membership.ts
@@ -56,6 +56,12 @@ MembershipModel.init(
       { fields: ["startAt"] },
       { fields: ["endAt"] },
       { fields: ["workspaceId", "userId", "startAt", "endAt"] },
+      // Prevent duplicate active memberships for same user/workspace.
+      {
+        fields: ["userId", "workspaceId"],
+        unique: true,
+        where: { endAt: null },
+      },
     ],
   }
 );

--- a/front/migrations/db/migration_484.sql
+++ b/front/migrations/db/migration_484.sql
@@ -1,0 +1,5 @@
+-- Migration created on Jan 20, 2026
+-- Prevent race condition creating duplicate active memberships for same user/workspace
+CREATE UNIQUE INDEX CONCURRENTLY "memberships_user_workspace_active_unique"
+ON "memberships" ("userId", "workspaceId")
+WHERE "endAt" IS NULL;


### PR DESCRIPTION
## Description

Fixes a race condition in SCIM provisioning where two concurrent provisioning events for the same user could both create active memberships, resulting in duplicate records and panic errors ("Unreachable: Found multiple active memberships for user in workspace").

Adds a unique partial index on `(userId, workspaceId)` where `endAt IS NULL` to enforce at the database level that only one active membership can exist per user per workspace.

## Risks

Blast radius: Membership creation (SCIM provisioning, invites, domain auto-join)
Risk: low (additive index, existing duplicates already cleaned up)

## Deploy Plan

- Run migration_484.sql on EU and US front DBs
- Deploy front