### PR TITLE
[front] - chore(langfuse): store feedback

### DIFF
--- a/front/lib/api/instrumentation/langfuse_datasets.ts
+++ b/front/lib/api/instrumentation/langfuse_datasets.ts
@@ -61,6 +61,8 @@ interface AddTraceToDatasetParams {
   dustTraceId: string;
   feedbackId: number;
   workspaceId: string;
+  feedbackContent: string | null;
+  thumbDirection: "up" | "down";
 }
 
 type LangfuseTraceSummary = {
@@ -122,7 +124,14 @@ async function fetchTraceByDustTraceId(
 export async function addTraceToLangfuseDataset(
   params: AddTraceToDatasetParams
 ): Promise<boolean> {
-  const { datasetName, dustTraceId, feedbackId, workspaceId } = params;
+  const {
+    datasetName,
+    dustTraceId,
+    feedbackId,
+    workspaceId,
+    feedbackContent,
+    thumbDirection,
+  } = params;
 
   const client = getLangfuseClient();
   if (!client) {
@@ -190,6 +199,8 @@ export async function addTraceToLangfuseDataset(
         feedbackId,
         dustTraceId,
         workspaceId,
+        feedbackContent,
+        thumbDirection,
         timestamp: new Date().toISOString(),
       },
     });

--- a/front/temporal/analytics_queue/activities.ts
+++ b/front/temporal/analytics_queue/activities.ts
@@ -723,6 +723,8 @@ async function appendNegativeFeedbackTracesToLangfuseDataset({
       dustTraceId: latestTraceId,
       feedbackId: feedback.id,
       workspaceId,
+      feedbackContent: feedback.content,
+      thumbDirection: feedback.thumbDirection,
     });
   }
 }


### PR DESCRIPTION
## Description
This PR extends the Langfuse dataset integration to include `feedbackContent` and `thumbDirection` when storing negative feedback traces. Previously, only basic metadata (`feedbackId`, `dustTraceId`, `workspaceId`) was stored in the dataset items. Now, the actual user feedback text and thumb direction are included, enabling better categorization and analysis of user feedback within Langfuse datasets.

## Risk
Low.

## Tests
Tested locally by submitting negative feedback on global agent messages and verifying the feedback content and thumb direction appear in the Langfuse dataset item metadata.

## Deploy Plan

Deploy front