### PR TITLE
Allow picking projects as datasources for agents.

### DIFF
--- a/front/components/agent_builder/capabilities/knowledge/DataSourceBuilderSelector.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/DataSourceBuilderSelector.tsx
@@ -47,7 +47,7 @@ export const DataSourceBuilderSelector = ({
   const { spaces } = useSpacesContext();
   const { supportedDataSourceViews: dataSourceViews } =
     useDataSourceViewsContext();
-  const { navigationHistory, navigateTo, setSpaceEntry } =
+  const { navigationHistory, navigateTo, setSpaceEntry, setCategoryEntry } =
     useDataSourceBuilderContext();
   const router = useRouter();
   const { systemSpace } = useSystemSpace({ workspaceId: owner.sId });
@@ -80,9 +80,7 @@ export const DataSourceBuilderSelector = ({
   // Filter spaces to only those with data source views
   const filteredSpaces = useMemo(() => {
     const spaceIds = new Set(dataSourceViews.map((dsv) => dsv.spaceId));
-    // TODO(projects): Remove projects from the list until we fix the wording accordingly to avoid confusion.
-    // Projects will be useful for using their conversations or context as datasources.
-    return spaces.filter((s) => spaceIds.has(s.sId) && s.kind !== "project");
+    return spaces.filter((s) => spaceIds.has(s.sId));
   }, [spaces, dataSourceViews]);
 
   // Get current space and node for search - memoized to prevent re-rendering issues
@@ -100,11 +98,23 @@ export const DataSourceBuilderSelector = ({
     [navigationHistory]
   );
 
+  // Automatically select the first space if there is only one
   useEffect(() => {
     if (filteredSpaces.length === 1) {
       setSpaceEntry(filteredSpaces[0]);
     }
-  }, [filteredSpaces]);
+  }, [filteredSpaces, setSpaceEntry]);
+
+  // Automatically select the managed category if we are in a "project" kind of space
+  useEffect(() => {
+    if (
+      currentSpace &&
+      currentSpace.kind === "project" &&
+      currentNavigationEntry.type === "space"
+    ) {
+      setCategoryEntry("managed");
+    }
+  }, [currentSpace, currentNavigationEntry, setCategoryEntry]);
 
   const [searchScope, setSearchScope] = useState<"node" | "space">("space");
 
@@ -260,7 +270,7 @@ export const DataSourceBuilderSelector = ({
       <div className="flex flex-1 items-center justify-center">
         <div className="flex flex-col gap-2 px-4 text-center">
           <div className="text-lg font-medium text-foreground">
-            No spaces with data sources available
+            No data sources available
           </div>
           <div className="max-w-sm text-muted-foreground">
             Connect data sources or ask your admin to set them up
@@ -356,7 +366,7 @@ function getBreadcrumbConfig(
   switch (entry.type) {
     case "root":
       return {
-        label: "Spaces",
+        label: "All",
       };
     case "space":
       return {

--- a/front/components/agent_builder/capabilities/knowledge/DataSourceSpaceSelector.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/DataSourceSpaceSelector.tsx
@@ -71,7 +71,7 @@ export function DataSourceSpaceSelector({
 
   return (
     <>
-      <span className="text-sm font-medium">Select your space:</span>
+      <span className="text-sm font-medium">From:</span>
       <DataSourceList
         items={spaceItems}
         showCheckboxOnlyForPartialSelection

--- a/front/lib/connector_providers.ts
+++ b/front/lib/connector_providers.ts
@@ -117,7 +117,7 @@ export const CONNECTOR_CONFIGURATIONS: Record<
     isDeletable: false,
   },
   dust_project: {
-    name: "Dust Project",
+    name: "Conversations & Context",
     connectorProvider: "dust_project",
     status: "preview",
     isDeletable: false,


### PR DESCRIPTION
## Description

Allow picking a datasource.
Automatically set the managed category for projects to avoid confusion and one step.

## Tests

Local
<img width="490" height="566" alt="image" src="https://github.com/user-attachments/assets/581bbb08-c8bf-47dc-8c29-7c39be40c4f3" />
<img width="520" height="446" alt="image" src="https://github.com/user-attachments/assets/951bc7b9-1a39-493f-974a-49b3f2306258" />
<img width="591" height="441" alt="image" src="https://github.com/user-attachments/assets/b7f37e1b-33a4-4363-9beb-73dca9e0bf64" />
<img width="684" height="546" alt="image" src="https://github.com/user-attachments/assets/967c00d8-5f56-4226-acaa-50692410e9e0" />

## Risk

Low

## Deploy Plan

Deploy front