### PR TITLE
Lazy load agent editors groups

### DIFF
--- a/front/lib/api/agent_actions.ts
+++ b/front/lib/api/agent_actions.ts
@@ -30,16 +30,15 @@ export async function getToolsUsage(
     return {};
   }
 
-  const getAgentsForUser = async () =>
-    (
+  const getAgentsForUser = async () => {
+    const editorGroups = await auth.editorGroups();
+    return (
       await GroupResource.findAgentIdsForGroups(
         auth,
-        auth
-          .groups()
-          .filter((g) => g.kind === "agent_editors")
-          .map((g) => g.id)
+        editorGroups.map((g) => g.id)
       )
     ).map((g) => g.agentConfigurationId);
+  };
 
   const getAgentWhereClauseAdmin = () => ({
     status: "active",

--- a/front/lib/api/agent_data_sources.ts
+++ b/front/lib/api/agent_data_sources.ts
@@ -76,16 +76,15 @@ export async function getDataSourceViewsUsageByCategory({
       assertNever(category);
   }
 
-  const getAgentsForUser = async () =>
-    (
+  const getAgentsForUser = async () => {
+    const editorGroups = await auth.editorGroups();
+    return (
       await GroupResource.findAgentIdsForGroups(
         auth,
-        auth
-          .groups()
-          .filter((g) => g.kind === "agent_editors")
-          .map((g) => g.id)
+        editorGroups.map((g) => g.id)
       )
     ).map((g) => g.agentConfigurationId);
+  };
 
   const getAgentWhereClauseAdmin = () => ({
     status: "active",

--- a/front/lib/api/agent_triggers.ts
+++ b/front/lib/api/agent_triggers.ts
@@ -24,16 +24,15 @@ async function getAccessibleAgentsInfoBySId({
     return new Map();
   }
 
-  const getAgentsForUser = async () =>
-    (
+  const getAgentsForUser = async () => {
+    const editorGroups = await auth.editorGroups();
+    return (
       await GroupResource.findAgentIdsForGroups(
         auth,
-        auth
-          .groups()
-          .filter((g) => g.kind === "agent_editors")
-          .map((g) => g.id)
+        editorGroups.map((g) => g.id)
       )
     ).map((g) => g.agentConfigurationId);
+  };
 
   const agentWhereClause = auth.isAdmin()
     ? {

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -1221,9 +1221,6 @@ export async function updateAgentPermissions(
     >
   >
 > {
-  // Load editor groups for permission checks in addMembers/removeMembers.
-  await auth.editorGroups();
-
   const editorGroupRes = await GroupResource.findEditorGroupForAgent(
     auth,
     agent

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -1221,6 +1221,9 @@ export async function updateAgentPermissions(
     >
   >
 > {
+  // Load editor groups for permission checks in addMembers/removeMembers.
+  await auth.editorGroups();
+
   const editorGroupRes = await GroupResource.findEditorGroupForAgent(
     auth,
     agent

--- a/front/lib/api/assistant/configuration/helpers.ts
+++ b/front/lib/api/assistant/configuration/helpers.ts
@@ -113,14 +113,14 @@ export async function enrichAgentConfigurations<V extends AgentFetchVariant>(
   // Compute editor permissions if not provided
   let editorIds = agentIdsForUserAsEditor;
   if (!editorIds) {
-    const agentIdsForGroups = user
-      ? await GroupResource.findAgentIdsForGroups(auth, [
-          ...auth
-            .groups()
-            .filter((g) => g.kind === "agent_editors")
-            .map((g) => g.id),
-        ])
-      : [];
+    const editorGroups = user ? await auth.editorGroups() : [];
+    const agentIdsForGroups =
+      editorGroups.length > 0
+        ? await GroupResource.findAgentIdsForGroups(
+            auth,
+            editorGroups.map((g) => g.id)
+          )
+        : [];
 
     editorIds = agentIdsForGroups.map((g) => g.agentConfigurationId);
   }

--- a/front/lib/api/assistant/configuration/views.ts
+++ b/front/lib/api/assistant/configuration/views.ts
@@ -283,14 +283,14 @@ async function fetchWorkspaceAgentConfigurationsForView(
 ) {
   const user = auth.user();
 
-  const agentIdsForGroups = user
-    ? await GroupResource.findAgentIdsForGroups(auth, [
-        ...auth
-          .groups()
-          .filter((g) => g.kind === "agent_editors")
-          .map((g) => g.id),
-      ])
-    : [];
+  const editorGroups = user ? await auth.editorGroups() : [];
+  const agentIdsForGroups =
+    editorGroups.length > 0
+      ? await GroupResource.findAgentIdsForGroups(
+          auth,
+          editorGroups.map((g) => g.id)
+        )
+      : [];
 
   const agentIdsForUserAsEditor = agentIdsForGroups.map(
     (g) => g.agentConfigurationId

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -867,7 +867,6 @@ export class Authenticator {
         this._editorGroups = [];
         return [];
       }
-
       this._editorGroups = await GroupResource.listUserGroupsInWorkspace({
         user: this._user,
         workspace: renderLightWorkspaceType({ workspace: this._workspace }),

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -895,7 +895,12 @@ export class Authenticator {
   }
 
   groups(): GroupType[] {
-    return this._groups.map((g) => g.toJSON());
+    const groups = this._groups.map((g) => g.toJSON());
+    // Include editor groups in permission checks if they've been loaded.
+    if (this._editorGroups !== null) {
+      groups.push(...this._editorGroups.map((g) => g.toJSON()));
+    }
+    return groups;
   }
 
   /**

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -853,6 +853,10 @@ export class Authenticator {
     return isDustInternal && isDustSuperUser;
   }
 
+  async loadAllGroups(): Promise<void> {
+    await this.editorGroups();
+  }
+
   /**
    * Lazily loads and caches the user's agent_editors groups.
    * These groups are not loaded by default to optimize performance.

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -58,6 +58,16 @@ const DUST_INTERNAL_EMAIL_REGEXP = /^[^@]+@dust\.tt$/;
 
 const DustApiKeyNameHeader = "x-dust-api-key-name";
 
+// Group kinds loaded by default when creating an Authenticator.
+// agent_editors are loaded lazily via editorGroups() to optimize performance.
+const DEFAULT_GROUP_KINDS = [
+  "global",
+  "regular",
+  "provisioned",
+  "skill_editors",
+  "space_editors",
+] as const;
+
 export type AuthMethodType =
   | "system_api_key"
   | "api_key"
@@ -213,13 +223,7 @@ export class Authenticator {
           GroupResource.listUserGroupsInWorkspace({
             user,
             workspace: renderLightWorkspaceType({ workspace }),
-            groupKinds: [
-              "global",
-              "regular",
-              "provisioned",
-              "skill_editors",
-              "space_editors",
-            ],
+            groupKinds: [...DEFAULT_GROUP_KINDS],
           }),
           SubscriptionResource.fetchActiveByWorkspace(
             renderLightWorkspaceType({ workspace })
@@ -243,13 +247,7 @@ export class Authenticator {
       this._groups = await GroupResource.listUserGroupsInWorkspace({
         user: this._user,
         workspace: renderLightWorkspaceType({ workspace: this._workspace }),
-        groupKinds: [
-          "global",
-          "regular",
-          "provisioned",
-          "skill_editors",
-          "space_editors",
-        ],
+        groupKinds: [...DEFAULT_GROUP_KINDS],
         transaction,
       });
       // Reset editor groups cache so they will be reloaded if needed.
@@ -332,13 +330,7 @@ export class Authenticator {
         GroupResource.listUserGroupsInWorkspace({
           user,
           workspace: renderLightWorkspaceType({ workspace }),
-          groupKinds: [
-            "global",
-            "regular",
-            "provisioned",
-            "skill_editors",
-            "space_editors",
-          ],
+          groupKinds: [...DEFAULT_GROUP_KINDS],
         }),
         SubscriptionResource.fetchActiveByWorkspace(
           renderLightWorkspaceType({ workspace })
@@ -390,13 +382,7 @@ export class Authenticator {
       GroupResource.listUserGroupsInWorkspace({
         user,
         workspace: renderLightWorkspaceType({ workspace }),
-        groupKinds: [
-          "global",
-          "regular",
-          "provisioned",
-          "skill_editors",
-          "space_editors",
-        ],
+        groupKinds: [...DEFAULT_GROUP_KINDS],
       }),
       SubscriptionResource.fetchActiveByWorkspace(
         renderLightWorkspaceType({ workspace })
@@ -696,13 +682,7 @@ export class Authenticator {
     const groups = await GroupResource.listUserGroupsInWorkspace({
       user,
       workspace: renderLightWorkspaceType({ workspace: owner }),
-      groupKinds: [
-        "global",
-        "regular",
-        "provisioned",
-        "skill_editors",
-        "space_editors",
-      ],
+      groupKinds: [...DEFAULT_GROUP_KINDS],
     });
 
     return new Authenticator({

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -694,7 +694,7 @@ export class GroupResource extends BaseResource<GroupModel> {
 
     const [group] = groups;
 
-    await group.ensureAuthGroupsLoaded(auth);
+    await group.ensureAuthGroupsAreLoaded(auth);
     if (!group.canRead(auth)) {
       return null;
     }
@@ -1062,6 +1062,8 @@ export class GroupResource extends BaseResource<GroupModel> {
       >
     >
   > {
+    await this.ensureAuthGroupsAreLoaded(auth);
+
     if (
       !auth.canWrite(
         requestedPermissions
@@ -1229,6 +1231,8 @@ export class GroupResource extends BaseResource<GroupModel> {
       >
     >
   > {
+    await this.ensureAuthGroupsAreLoaded(auth);
+
     if (
       !auth.canWrite(
         requestedPermissions
@@ -1380,6 +1384,8 @@ export class GroupResource extends BaseResource<GroupModel> {
       >
     >
   > {
+    await this.ensureAuthGroupsAreLoaded(auth);
+
     if (
       !auth.canWrite(
         requestedPermissions
@@ -1602,7 +1608,7 @@ export class GroupResource extends BaseResource<GroupModel> {
     return this.kind === "provisioned";
   }
 
-  async ensureAuthGroupsLoaded(auth: Authenticator) {
+  async ensureAuthGroupsAreLoaded(auth: Authenticator) {
     if (this.kind === "agent_editors") {
       await auth.editorGroups();
     }

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/editors.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/editors.ts
@@ -117,6 +117,9 @@ async function handler(
 
   const editorGroup = editorGroupRes.value;
 
+  // Load editor groups for permission checks below.
+  await auth.editorGroups();
+
   switch (req.method) {
     case "GET": {
       if (!editorGroup.canRead(auth)) {


### PR DESCRIPTION
fixes: https://github.com/dust-tt/tasks/issues/5994

## Description

Move out editors groups from auth.groups() , lazy load and return when calling auth.editorGroups().
Update agent method that need editorGroups.
GroupResource methods are updated to preload groups, when permission checks are involved. All groups have permission on themselves, so they must be laoded in auth before doing any check. Add a waning if we call can* on a group and the associated group type are not loaded in auth.

## Tests

Unit tests pass, manual tests on agent usage / execution

## Risk

permission issues on agent.

## Deploy Plan

deploy front