### PR TITLE
[MCP Slack] Include rich text blocks in read_thread_messages output

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/slack/helpers.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack/helpers.ts
@@ -1118,12 +1118,14 @@ export async function executeReadThreadMessages({
   const formattedOutput = {
     parent_message: {
       text: parentMessage?.text ?? "",
+      blocks: parentMessage?.blocks,
       user: parentMessage?.user ?? "",
       ts: parentMessage?.ts ?? "",
       reply_count: parentMessage?.reply_count ?? 0,
     },
     thread_replies: threadReplies.map((msg) => ({
       text: msg.text ?? "",
+      blocks: msg.blocks,
       user: msg.user ?? "",
       ts: msg.ts ?? "",
     })),


### PR DESCRIPTION
## Description

The personal Slack MCP server's `read_thread_messages` tool was only returning plain `text` from messages, discarding all rich text formatting. Slack stores formatted content in the `blocks` field (bold, italic, code blocks, lists, links with display text, etc.), while `text` is just a plain fallback.

This adds the `blocks` field to match the bot variant's behavior, ensuring agents can access rich text formatting when reading threads.

## Risks

Blast radius: Slack personal MCP server read_thread_messages tool output
Risk: low

## Deploy Plan
- pmrr
- deploy front