### PR TITLE
[Webcrawler] Handle WorkflowExecutionAlreadyStartedError in firecrawl completed workflow

### DIFF
--- a/connectors/src/connectors/webcrawler/temporal/client.ts
+++ b/connectors/src/connectors/webcrawler/temporal/client.ts
@@ -324,9 +324,9 @@ export async function launchFirecrawlCrawlCompletedWorkflow(
     return new Ok(workflowId);
   } catch (e) {
     if (e instanceof WorkflowExecutionAlreadyStartedError) {
-      logger.info(
+      logger.warn(
         { workflowId, connectorId, crawlId },
-        "Firecrawl crawl completed workflow already started, skipping duplicate webhook."
+        "Workflow already started"
       );
       return new Ok(workflowId);
     }

--- a/connectors/src/connectors/webcrawler/temporal/client.ts
+++ b/connectors/src/connectors/webcrawler/temporal/client.ts
@@ -324,9 +324,9 @@ export async function launchFirecrawlCrawlCompletedWorkflow(
     return new Ok(workflowId);
   } catch (e) {
     if (e instanceof WorkflowExecutionAlreadyStartedError) {
-      logger.warn(
+      logger.info(
         { workflowId, connectorId, crawlId },
-        "Workflow already started"
+        "Firecrawl crawl completed workflow already started, skipping duplicate webhook."
       );
       return new Ok(workflowId);
     }

--- a/connectors/src/connectors/webcrawler/temporal/workflows.ts
+++ b/connectors/src/connectors/webcrawler/temporal/workflows.ts
@@ -172,9 +172,6 @@ export async function firecrawlCrawlCompletedWorkflow(
         err.name === "WorkflowExecutionAlreadyStartedError"
       ) {
         // Garbage collector already running from a previous webhook, skip.
-        console.info(
-          `Garbage collector workflow ${workflowId} already running, skipping.`
-        );
         return;
       }
       throw err;

--- a/connectors/src/connectors/webcrawler/temporal/workflows.ts
+++ b/connectors/src/connectors/webcrawler/temporal/workflows.ts
@@ -151,31 +151,18 @@ export async function firecrawlCrawlCompletedWorkflow(
     // and upserting a page) which may lead to dropping a few pages which is not catastrophic.
     await sleep(120_000);
 
-    const workflowId = garbageCollectWebsiteWorkflowId(
-      connectorId,
-      res.lastSyncStartTs
-    );
-
-    try {
-      await startChild(garbageCollectWebsiteWorkflow, {
-        workflowId,
-        searchAttributes: {
-          connectorId: [connectorId],
-        },
-        args: [connectorId, res.lastSyncStartTs],
-        parentClosePolicy: ParentClosePolicy.ABANDON,
-        memo: workflowInfo().memo,
-      });
-    } catch (err) {
-      if (
-        err instanceof Error &&
-        err.name === "WorkflowExecutionAlreadyStartedError"
-      ) {
-        // Garbage collector already running from a previous webhook, skip.
-        return;
-      }
-      throw err;
-    }
+    await startChild(garbageCollectWebsiteWorkflow, {
+      workflowId: garbageCollectWebsiteWorkflowId(
+        connectorId,
+        res.lastSyncStartTs
+      ),
+      searchAttributes: {
+        connectorId: [connectorId],
+      },
+      args: [connectorId, res.lastSyncStartTs],
+      parentClosePolicy: ParentClosePolicy.ABANDON,
+      memo: workflowInfo().memo,
+    });
   }
 }
 

--- a/connectors/src/connectors/webcrawler/temporal/workflows.ts
+++ b/connectors/src/connectors/webcrawler/temporal/workflows.ts
@@ -151,18 +151,29 @@ export async function firecrawlCrawlCompletedWorkflow(
     // and upserting a page) which may lead to dropping a few pages which is not catastrophic.
     await sleep(120_000);
 
-    await startChild(garbageCollectWebsiteWorkflow, {
-      workflowId: garbageCollectWebsiteWorkflowId(
-        connectorId,
-        res.lastSyncStartTs
-      ),
-      searchAttributes: {
-        connectorId: [connectorId],
-      },
-      args: [connectorId, res.lastSyncStartTs],
-      parentClosePolicy: ParentClosePolicy.ABANDON,
-      memo: workflowInfo().memo,
-    });
+    try {
+      await startChild(garbageCollectWebsiteWorkflow, {
+        workflowId: garbageCollectWebsiteWorkflowId(
+          connectorId,
+          res.lastSyncStartTs
+        ),
+        searchAttributes: {
+          connectorId: [connectorId],
+        },
+        args: [connectorId, res.lastSyncStartTs],
+        parentClosePolicy: ParentClosePolicy.ABANDON,
+        memo: workflowInfo().memo,
+      });
+    } catch (err) {
+      if (
+        err instanceof Error &&
+        err.name === "WorkflowExecutionAlreadyStartedError"
+      ) {
+        // Garbage collector already running from a previous webhook, skip.
+        return;
+      }
+      throw err;
+    }
   }
 }
 


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/5999

When concurrent `crawl.completed` webhooks arrive from Firecrawl from a given connector and the garbage collector workflow is already running, the `startChild` call would fail with `WorkflowExecutionAlreadyStartedError`, causing the completed workflow itself to fail.

This adds error handling around the `startChild` call to gracefully skip when the garbage collector is already running, following the same pattern used in the Google Drive connector (`google_drive/temporal/workflows.ts:676-685`).

## Risks

Blast radius: Webcrawler firecrawl connector only
Risk: low

## Deploy Plan
- pmrr
- deploy connectors