### PR TITLE
[front] fix(skills): fix extended skills tools lilsting

### DIFF
--- a/front/lib/api/assistant/skill_actions.ts
+++ b/front/lib/api/assistant/skill_actions.ts
@@ -18,7 +18,7 @@ export async function getSkillServers(
     skills,
   }: {
     agentConfiguration: LightAgentConfigurationType;
-    skills: SkillResource[];
+    skills: (SkillResource & { extendedSkill: SkillResource | null })[];
   }
 ): Promise<MCPServerConfigurationType[]> {
   const rawInheritedDataSourceViews = await concurrentExecutor(
@@ -38,7 +38,10 @@ export async function getSkillServers(
   );
 
   return skills.flatMap((skill) =>
-    skill.mcpServerViews.map((mcpServerView) => {
+    [
+      ...skill.mcpServerViews,
+      ...(skill.extendedSkill?.mcpServerViews ?? []),
+    ].map((mcpServerView) => {
       return buildServerSideMCPServerConfiguration({
         mcpServerView,
         dataSources,


### PR DESCRIPTION
## Description

- This PR fixes how MCP servers associated to a skill are listed by including the ones that come from a potential extended skill.

## Tests

- Tested locally.

## Risk

- Low, behind FF.

## Deploy Plan

- Deploy front.
