### PR TITLE
[core] enh(search): fix exact match boosting

### DIFF
--- a/core/src/search_stores/search_store.rs
+++ b/core/src/search_stores/search_store.rs
@@ -890,11 +890,11 @@ impl ElasticsearchSearchStore {
             // - Stricter matching than regular match query
             // - Perfect for catching exact title matches.
             Query::from(Query::r#match_phrase(field, query).boost(EXACT_MATCH_BOOST)),
-            // Exact keyword match for perfect exact matches (case insensitive)
-            // - Uses term query on keyword field with lowercase
+            // Exact keyword match for perfect exact matches (case-sensitive)
+            // - Uses a term query on keyword field
             // - Highest boost for exact title matches
             Query::from(
-                Query::term(keyword_field, query.to_lowercase())
+                Query::term(keyword_field, query)
                     .boost(EXACT_MATCH_BOOST * EXACT_KEYWORD_MATCH_MULTIPLIER),
             ),
         ];

--- a/core/src/search_stores/search_store.rs
+++ b/core/src/search_stores/search_store.rs
@@ -756,7 +756,7 @@ impl ElasticsearchSearchStore {
         {
             let nodes_query = Query::bool()
                 .filter(Query::term("_index", DATA_SOURCE_NODE_INDEX_NAME))
-                .filter(self.build_nodes_content_query(&query, &filter, options, &mut counter)?);
+                .must(self.build_nodes_content_query(&query, &filter, options, &mut counter)?);
 
             should_queries.push(nodes_query);
             indices_to_query.push(DATA_SOURCE_NODE_INDEX_NAME);


### PR DESCRIPTION
## Description

Initial observation: given the exact title of a document, searching for it very often does not show it as the first result in the data source node search.
Upon investigation, this comes from 2 distinct root causes:
  1. the exact match boost is applied on a match between the lowercase version of the queried title and the `title.keyword`, which is not lowercased (no normalizer), therefore not boosting the actual exact match if it contains an uppercase letter, and potentially boosting a completely different document that would have the lowercase name.
  2. More importantly, the boost values seem to be ignored entirely due to the query being a `filter` rather than a `match`.

## Tests

- Tested locally.

## Risk

- Low, perfs to be monitored.

## Deploy Plan

- Deploy core.
