### PR TITLE
[front] enh(skills): iterate on similar skills detection

### DIFF
--- a/front/lib/api/skills/existing_skill_checker.ts
+++ b/front/lib/api/skills/existing_skill_checker.ts
@@ -47,7 +47,9 @@ Skills are NOT similar if they only share:
 # Instructions
 Return skill IDs that would cause confusion about which skill to use.
 Prefer precision over recall; only return truly overlapping skills.
-An empty array is the correct answer when no duplicates exist.
+
+IMPORTANT: Returning an empty array is the expected outcome in most cases.
+Only return skill IDs when you are confident there is a genuine duplicate. When in doubt, return an empty array.
 
 # Examples
 ## Example 1 - Clear duplicates

--- a/front/lib/api/skills/existing_skill_checker.ts
+++ b/front/lib/api/skills/existing_skill_checker.ts
@@ -36,13 +36,16 @@ const PROMPT = `# Role
 You identify existing skills in a workspace that duplicate or overlap with a new skill being created.
 
 # Similarity Criteria
-Skills are similar when they have BOTH:
-1. Same target platform/service (e.g., GitHub, Jira, Slack, Google Sheets)
-2. Overlapping functionality (e.g., both create issues, both send messages, both manage tickets)
+Skills are similar when they serve the same user need or solve the same problem.
+Ask yourself: "Would you be confused about which skill to use?"
 
-Skills are NOT similar if they only share:
-- The same platform but completely different actions (e.g., "read GitHub PRs" vs "create GitHub releases")
-- The same action type but different platforms (e.g., "create tickets on Jira" vs "create issues on GitHub")
+Examples of similar skills:
+- "Create GitHub issues for bugs" and "Open bug tickets on GitHub" (same outcome)
+- "Send weekly reports via email" and "Email team updates every week" (same purpose)
+
+Examples of skills that are NOT similar:
+- "Read GitHub PRs" and "Create GitHub issues" (different actions, even if same platform)
+- "Create Jira tickets" and "Create GitHub issues" (different tools, even if similar action)
 
 # Instructions
 Return skill IDs that would cause confusion about which skill to use.


### PR DESCRIPTION
## Description

- This PR iterates on the prompt of the LLM call that finds similar skills to one being built.
- Monitored [here](https://app.datadoghq.eu/dashboard/aj2-eg7-qjh?fromUser=false&refresh_mode=sliding&from_ts=1768372378254&to_ts=1768977178254&live=true).
- Overall great results, seeing a few false positive on similar tasks but on different platform. Expecting to see this pattern more often on wider companies with more overlapping sets of internal tools.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
