### PR TITLE
[front] enh(skills): move current skill check in backend for similar skill detection

### DIFF
--- a/front/components/skill_builder/SkillBuilderAgentFacingDescriptionSection.tsx
+++ b/front/components/skill_builder/SkillBuilderAgentFacingDescriptionSection.tsx
@@ -36,7 +36,10 @@ export function SkillBuilderAgentFacingDescriptionSection() {
         return;
       }
 
-      const result = await getSimilarSkills(description, signal);
+      const result = await getSimilarSkills(description, {
+        excludeSkillId: skillId, // Exclude the skill being edited.
+        signal,
+      });
 
       // Only update state if the request was not aborted
       if (!signal.aborted) {
@@ -44,9 +47,8 @@ export function SkillBuilderAgentFacingDescriptionSection() {
         if (result.isOk()) {
           const similarSkillIds = result.value;
           const similarSkillIdsSet = new Set(similarSkillIds);
-          const matchedSkills = skills.filter(
-            (skill) =>
-              similarSkillIdsSet.has(skill.sId) && skill.sId !== skillId
+          const matchedSkills = skills.filter((skill) =>
+            similarSkillIdsSet.has(skill.sId)
           );
           setSimilarSkills(matchedSkills);
         }

--- a/front/lib/api/skills/existing_skill_checker.ts
+++ b/front/lib/api/skills/existing_skill_checker.ts
@@ -97,7 +97,10 @@ function truncateDescription(description: string): string {
 
 export async function getSimilarSkills(
   auth: Authenticator,
-  inputs: { naturalDescription: string }
+  inputs: {
+    naturalDescription: string;
+    excludeSkillId: string | null;
+  }
 ): Promise<Result<{ similar_skills: string[] }, Error>> {
   const owner = auth.getNonNullableWorkspace();
 
@@ -109,16 +112,20 @@ export async function getSimilarSkills(
   }
 
   // Retrieve existing skills
-  const skills: SkillResource[] = await SkillResource.listByWorkspace(auth, {
+  const allSkills: SkillResource[] = await SkillResource.listByWorkspace(auth, {
     limit: MAX_SKILLS_SENT_TO_LLM,
     onlyCustom: true,
   });
-  if (skills.length === MAX_SKILLS_SENT_TO_LLM) {
+  if (allSkills.length === MAX_SKILLS_SENT_TO_LLM) {
     logger.warn(
       { workspaceId: owner.sId },
       "The number of skills fetched reached the limit. Some skills might not be considered in the similarity check."
     );
   }
+
+  const skills = inputs.excludeSkillId
+    ? allSkills.filter((s) => s.sId !== inputs.excludeSkillId)
+    : allSkills;
 
   const existingSkills = skills
     .map(

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -87,7 +87,13 @@ export function useSkillsWithRelations({
 
 export function useSimilarSkills({ owner }: { owner: LightWorkspaceType }) {
   const getSimilarSkills = useCallback(
-    async (naturalDescription: string, signal?: AbortSignal) => {
+    async (
+      naturalDescription: string,
+      options: {
+        excludeSkillId: string | null;
+        signal?: AbortSignal;
+      }
+    ) => {
       const response: GetSimilarSkillsResponseBody = await fetcher(
         `/api/w/${owner.sId}/skills/similar`,
         {
@@ -95,8 +101,11 @@ export function useSimilarSkills({ owner }: { owner: LightWorkspaceType }) {
           headers: {
             "Content-Type": "application/json",
           },
-          body: JSON.stringify({ naturalDescription }),
-          signal,
+          body: JSON.stringify({
+            naturalDescription,
+            excludeSkillId: options?.excludeSkillId ?? undefined,
+          }),
+          signal: options?.signal,
         }
       );
       return new Ok(response.similar_skills);

--- a/front/pages/api/w/[wId]/skills/similar.ts
+++ b/front/pages/api/w/[wId]/skills/similar.ts
@@ -33,7 +33,7 @@ async function handler(
 
   switch (req.method) {
     case "POST": {
-      const { naturalDescription } = req.body;
+      const { naturalDescription, excludeSkillId } = req.body;
 
       if (!isString(naturalDescription)) {
         return apiError(req, res, {
@@ -45,7 +45,20 @@ async function handler(
         });
       }
 
-      const result = await getSimilarSkills(auth, { naturalDescription });
+      if (excludeSkillId !== undefined && !isString(excludeSkillId)) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "excludeSkillId must be a string if provided.",
+          },
+        });
+      }
+
+      const result = await getSimilarSkills(auth, {
+        naturalDescription,
+        excludeSkillId: excludeSkillId ?? null,
+      });
 
       if (result.isErr()) {
         logger.error(


### PR DESCRIPTION
## Description

- When detecting skills that are similar to one being created/edited in Skill Builder we need to ignore the one being currently edited.
- This check is performed on the front-end by excluding it from the results.
- This PR moves it to the backend to improve our observability.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
