### PR TITLE
[front] fix console logs on `"AbortError"`

### DIFF
--- a/front/hooks/useDebounce.ts
+++ b/front/hooks/useDebounce.ts
@@ -42,7 +42,7 @@ export function useDebounce(
     [debouncedUpdate, minLength]
   );
 
-  // Cleanup on unmount
+  // Cleanup on unmount.
   useEffect(() => {
     return () => {
       debouncedUpdate.cancel();
@@ -103,7 +103,7 @@ export function useDebounceWithAbort<T = string>(
 
   const trigger = useCallback(
     (value: T) => {
-      // Clear existing debounce timeout
+      // Clear the existing debounce timeout.
       if (debounceHandle.current) {
         clearTimeout(debounceHandle.current);
         debounceHandle.current = undefined;
@@ -116,18 +116,23 @@ export function useDebounceWithAbort<T = string>(
           abortControllerRef.current.abort();
         }
 
-        // Create new abort controller
+        // Create a new abort controller.
         abortControllerRef.current = new AbortController();
         const signal = abortControllerRef.current.signal;
 
-        // Execute async function
-        void asyncFn(value, signal);
+        // Execute async function, ignoring AbortError since it's expected when requests are cancelled
+        void asyncFn(value, signal).catch((err) => {
+          if (err instanceof DOMException && err.name === "AbortError") {
+            return;
+          }
+          throw err;
+        });
       }, delayMs);
     },
     [asyncFn, delayMs]
   );
 
-  // Cleanup on unmount
+  // Cleanup on unmount.
   useEffect(() => {
     return () => {
       if (debounceHandle.current) {

--- a/front/hooks/useDebounce.ts
+++ b/front/hooks/useDebounce.ts
@@ -120,9 +120,13 @@ export function useDebounceWithAbort<T = string>(
         abortControllerRef.current = new AbortController();
         const signal = abortControllerRef.current.signal;
 
-        // Execute async function, ignoring AbortError since it's expected when requests are cancelled
+        // Execute async function, ignoring AbortError caused by our own abort signal.
         void asyncFn(value, signal).catch((err) => {
-          if (err instanceof DOMException && err.name === "AbortError") {
+          if (
+            err instanceof DOMException &&
+            err.name === "AbortError" &&
+            signal.aborted
+          ) {
             return;
           }
           throw err;

--- a/front/hooks/useDebounce.ts
+++ b/front/hooks/useDebounce.ts
@@ -6,6 +6,8 @@ interface UseDebounceOptions {
   minLength?: number;
 }
 
+const USE_DEBOUNCE_WITH_ABORT_ABORT_REASON = "Aborted in useDebounceWithAbort";
+
 export function useDebounce(
   initialValue: string,
   options: UseDebounceOptions = {}
@@ -68,7 +70,7 @@ interface UseDebounceWithAbortOptions {
 
 /**
  * Hook that debounces an async function call with AbortController support.
- * Useful for API calls that should be cancelled when a new request is made.
+ * Useful for API calls that should be canceled when a new request is made.
  *
  * @param asyncFn - The async function to debounce. It receives the value and an AbortSignal.
  * @param options - Configuration options (delay)
@@ -113,7 +115,9 @@ export function useDebounceWithAbort<T = string>(
       debounceHandle.current = setTimeout(() => {
         // Cancel previous request
         if (abortControllerRef.current) {
-          abortControllerRef.current.abort();
+          abortControllerRef.current.abort(
+            USE_DEBOUNCE_WITH_ABORT_ABORT_REASON
+          );
         }
 
         // Create a new abort controller.
@@ -122,11 +126,7 @@ export function useDebounceWithAbort<T = string>(
 
         // Execute async function, ignoring AbortError caused by our own abort signal.
         void asyncFn(value, signal).catch((err) => {
-          if (
-            err instanceof DOMException &&
-            err.name === "AbortError" &&
-            signal.aborted
-          ) {
+          if (signal.reason === USE_DEBOUNCE_WITH_ABORT_ABORT_REASON) {
             return;
           }
           throw err;


### PR DESCRIPTION
## Description

- We get errors in dev in places that rely on `useDebounceWithAbort`, which aborts our own outgoing requests to the backend on a debounce.
- According to the doc, if no `reason` is passed to `AbortController.abort`, the reason is set to "AbortError" `DOMException`.
- This PR ignores these errors if due to our own signal.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
