### PR TITLE
[front] enh(skills): force tool call in similar skill detection LLM call

### DIFF
--- a/front/lib/api/skills/existing_skill_checker.ts
+++ b/front/lib/api/skills/existing_skill_checker.ts
@@ -151,6 +151,7 @@ ${existingSkills}
       },
       prompt: PROMPT,
       specifications,
+      forceToolCall: SET_SIMILAR_SKILLS_FUNCTION_NAME,
     },
     {
       context: {


### PR DESCRIPTION
## Description

- We sometimes have the console error `"No similar skills generated"` when writing instructions in Skill Builder.
- When reproducing locally this was due to the model outputting generation tokens instead of a function call for the similar skill detection LLM call.
- This PR prevents this by forcing the tool call.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
