### PR TITLE
Remove ability to execute dust apps cross workspace

### DIFF
--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
@@ -207,16 +207,14 @@ async function handler(
 
   res: NextApiResponse<WithAPIErrorResponse<RunAppResponseType>>,
   auth: Authenticator,
-  { space }: { space: SpaceResource },
-  keyAuth: Authenticator
+  { space }: { space: SpaceResource }
 ): Promise<void> {
   const owner = auth.getNonNullableWorkspace();
-  const keyWorkspaceId = keyAuth.getNonNullableWorkspace().id;
   const [app, providers, secrets] = await Promise.all([
     AppResource.fetchById(auth, req.query.aId as string),
     ProviderModel.findAll({
       where: {
-        workspaceId: keyWorkspaceId,
+        workspaceId: owner.id,
       },
     }),
     getDustAppSecrets(auth, true),
@@ -232,7 +230,7 @@ async function handler(
     });
   }
 
-  if (!app.canRead(keyAuth)) {
+  if (!app.canRead(auth)) {
     return apiError(req, res, {
       status_code: 403,
       api_error: {
@@ -286,9 +284,7 @@ async function handler(
       }
 
       // Fetch the feature flags for the owner of the run.
-      const keyWorkspaceFlags = await getFeatureFlags(
-        keyAuth.getNonNullableWorkspace()
-      );
+      const keyWorkspaceFlags = await getFeatureFlags(owner);
 
       let credentials: CredentialsType | null = null;
       if (useDustCredentials) {
@@ -328,15 +324,14 @@ async function handler(
           },
           app: app.sId,
           useOpenAIEUEndpoint: credentials?.OPENAI_USE_EU_ENDPOINT,
-          userWorkspace: keyAuth.getNonNullableWorkspace().sId,
         },
         "App run creation"
       );
 
       const runRes = await coreAPI.createRunStream(
-        keyAuth.getNonNullableWorkspace(),
+        owner,
         keyWorkspaceFlags,
-        keyAuth.groups(),
+        auth.groups(),
         {
           projectId: app.dustAPIProjectId,
           runType: "deploy",
@@ -463,7 +458,7 @@ async function handler(
           dustRunId,
           appId: app.id,
           runType: "deploy",
-          workspaceId: keyWorkspaceId,
+          workspaceId: owner.id,
           useWorkspaceCredentials: !useDustCredentials,
         });
 
@@ -554,8 +549,5 @@ async function handler(
 
 export default withPublicAPIAuthentication(
   // Check read on the workspace authenticator - for public space, everybody can read
-  withResourceFetchingFromRoute(handler, { space: { requireCanRead: true } }),
-  {
-    allowUserOutsideCurrentWorkspace: true,
-  }
+  withResourceFetchingFromRoute(handler, { space: { requireCanRead: true } })
 );


### PR DESCRIPTION
## Description

Now that dust-apps are fully unused we do not rely anymore on cross-workspace dust apps execution which was a finicky part of our API security-wise.

Follow-up remove support for `allowUserOutsideCurrentWorkspace`

## Tests

Tested locally (created a legacy dust app and run it)

## Risk

Medium (security strenghtening, worst case we close access)

## Deploy Plan

- deploy `front`