### PR TITLE
MCP server to return the server side agent state

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.test.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.test.ts
@@ -62,6 +62,7 @@ describe("INTERNAL_MCP_SERVERS", () => {
       { name: "schedules_management", id: 1020 },
       { name: "project_context_management", id: 1021 },
       { name: "agent_copilot_context", id: 1022 },
+      { name: "agent_copilot_agent_state", id: 1023 },
     ];
     expect(
       autoInternalTools,

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -13,6 +13,7 @@ import {
   JIRA_SERVER_INSTRUCTIONS,
   SALESFORCE_SERVER_INSTRUCTIONS,
 } from "@app/lib/actions/mcp_internal_actions/instructions";
+import { AGENT_COPILOT_AGENT_STATE_SERVER } from "@app/lib/actions/mcp_internal_actions/servers/agent_copilot_agent_state/metadata";
 import { AGENT_COPILOT_CONTEXT_SERVER } from "@app/lib/actions/mcp_internal_actions/servers/agent_copilot_context/metadata";
 import { INTERACTIVE_CONTENT_INSTRUCTIONS } from "@app/lib/actions/mcp_internal_actions/servers/interactive_content/instructions";
 import { PRODUCTBOARD_SERVER_INSTRUCTIONS } from "@app/lib/actions/mcp_internal_actions/servers/productboard/instructions";
@@ -94,6 +95,7 @@ export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   // Names should reflect the purpose of the server but not directly the tools it contains.
   // We'll prefix all tools with the server name to avoid conflicts.
   // It's okay to change the name of the server as we don't refer to it directly.
+  "agent_copilot_agent_state",
   "agent_copilot_context",
   "agent_management",
   AGENT_MEMORY_SERVER_NAME,
@@ -1813,6 +1815,19 @@ export const INTERNAL_MCP_SERVERS = {
       return !featureFlags.includes("agent_builder_copilot");
     },
     metadata: AGENT_COPILOT_CONTEXT_SERVER,
+    tools_arguments_requiring_approval: undefined,
+    tools_retry_policies: undefined,
+    timeoutMs: undefined,
+  },
+  agent_copilot_agent_state: {
+    id: 1023,
+    availability: "auto_hidden_builder",
+    allowMultipleInstances: false,
+    isPreview: false,
+    isRestricted: ({ featureFlags }) => {
+      return !featureFlags.includes("agent_builder_copilot");
+    },
+    metadata: AGENT_COPILOT_AGENT_STATE_SERVER,
     tools_arguments_requiring_approval: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,

--- a/front/lib/actions/mcp_internal_actions/servers/agent_copilot_agent_state/agent_copilot_agent_state.test.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/agent_copilot_agent_state/agent_copilot_agent_state.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { Authenticator } from "@app/lib/auth";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { GroupFactory } from "@app/tests/utils/GroupFactory";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { SkillFactory } from "@app/tests/utils/SkillFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+
+import { TOOLS } from "./tools";
+
+// Mock the helper that extracts agent configuration ID from context.
+vi.mock(
+  "@app/lib/actions/mcp_internal_actions/servers/agent_copilot_agent_state/helpers",
+  () => ({
+    getAgentConfigurationIdFromContext: vi.fn(),
+    getAgentConfigurationVersionFromContext: vi.fn(),
+  })
+);
+
+function getToolByName(name: string) {
+  const tool = TOOLS.find((t) => t.name === name);
+  if (!tool) {
+    throw new Error(`Tool ${name} not found`);
+  }
+  return tool;
+}
+
+// Create a minimal extra object for testing.
+function createTestExtra(auth: Authenticator, agentLoopContext?: unknown) {
+  return {
+    signal: new AbortController().signal,
+    auth,
+    agentLoopContext,
+  } as Parameters<(typeof TOOLS)[0]["handler"]>[1];
+}
+
+describe("agent_copilot_agent_state tools", () => {
+  describe("get_agent_info", () => {
+    it("returns error when agent configuration ID is not available", async () => {
+      const workspace = await WorkspaceFactory.basic();
+      await GroupFactory.defaults(workspace);
+      const user = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, user, { role: "admin" });
+
+      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+      // Mock the helper to return null (no agent config ID).
+      const { getAgentConfigurationIdFromContext } =
+        await import("@app/lib/actions/mcp_internal_actions/servers/agent_copilot_agent_state/helpers");
+      vi.mocked(getAgentConfigurationIdFromContext).mockReturnValueOnce(null);
+
+      const tool = getToolByName("get_agent_info");
+      const result = await tool.handler({}, createTestExtra(auth));
+
+      expect(result.isErr()).toBe(true);
+    });
+
+    it("returns error when agent configuration is not found", async () => {
+      const workspace = await WorkspaceFactory.basic();
+      await GroupFactory.defaults(workspace);
+      const user = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, user, { role: "admin" });
+
+      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+      // Mock the helper to return a non-existent agent config ID.
+      const { getAgentConfigurationIdFromContext } =
+        await import("@app/lib/actions/mcp_internal_actions/servers/agent_copilot_agent_state/helpers");
+      vi.mocked(getAgentConfigurationIdFromContext).mockReturnValueOnce(
+        "non-existent-agent-id"
+      );
+
+      const tool = getToolByName("get_agent_info");
+      const result = await tool.handler({}, createTestExtra(auth));
+
+      expect(result.isErr()).toBe(true);
+    });
+
+    it("returns agent info when agent configuration exists", async () => {
+      const workspace = await WorkspaceFactory.basic();
+      const adminAuth = await Authenticator.internalAdminForWorkspace(
+        workspace.sId
+      );
+      await SpaceFactory.defaults(adminAuth);
+      const user = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, user, { role: "admin" });
+
+      const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        user.sId,
+        workspace.sId
+      );
+
+      // Create an agent configuration.
+      const agent = await AgentConfigurationFactory.createTestAgent(userAuth, {
+        name: "Test Agent",
+        description: "Test Description",
+      });
+
+      // Mock the helper to return the agent config ID.
+      const { getAgentConfigurationIdFromContext } =
+        await import("@app/lib/actions/mcp_internal_actions/servers/agent_copilot_agent_state/helpers");
+      vi.mocked(getAgentConfigurationIdFromContext).mockReturnValueOnce(
+        agent.sId
+      );
+
+      const tool = getToolByName("get_agent_info");
+      const result = await tool.handler({}, createTestExtra(userAuth));
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        const content = result.value[0];
+        expect(content.type).toBe("text");
+        if (content.type === "text") {
+          const parsed = JSON.parse(content.text);
+          expect(parsed.sId).toBe(agent.sId);
+          expect(parsed.name).toBe("Test Agent");
+          expect(parsed.description).toBe("Test Description");
+          expect(parsed.model).toBeDefined();
+          expect(parsed.tools).toBeDefined();
+          expect(Array.isArray(parsed.tools)).toBe(true);
+          expect(parsed.skills).toBeDefined();
+          expect(Array.isArray(parsed.skills)).toBe(true);
+        }
+      }
+    });
+
+    it("returns skills associated with the agent", async () => {
+      const workspace = await WorkspaceFactory.basic();
+      const adminAuth = await Authenticator.internalAdminForWorkspace(
+        workspace.sId
+      );
+      await SpaceFactory.defaults(adminAuth);
+      const user = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, user, { role: "admin" });
+
+      const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        user.sId,
+        workspace.sId
+      );
+
+      // Create an agent configuration.
+      const agent = await AgentConfigurationFactory.createTestAgent(userAuth, {
+        name: "Agent with Skills",
+      });
+
+      // Create a skill and link it to the agent.
+      const skill = await SkillFactory.create(userAuth, {
+        name: "Test Skill",
+        userFacingDescription: "A test skill for the agent",
+      });
+
+      await SkillFactory.linkToAgent(userAuth, {
+        skillId: skill.id,
+        agentConfigurationId: agent.id,
+      });
+
+      // Mock the helper to return the agent config ID.
+      const { getAgentConfigurationIdFromContext } =
+        await import("@app/lib/actions/mcp_internal_actions/servers/agent_copilot_agent_state/helpers");
+      vi.mocked(getAgentConfigurationIdFromContext).mockReturnValueOnce(
+        agent.sId
+      );
+
+      const tool = getToolByName("get_agent_info");
+      const result = await tool.handler({}, createTestExtra(userAuth));
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        const content = result.value[0];
+        expect(content.type).toBe("text");
+        if (content.type === "text") {
+          const parsed = JSON.parse(content.text);
+          expect(parsed.skills.length).toBe(1);
+          expect(parsed.skills[0].sId).toBe(skill.sId);
+          expect(parsed.skills[0].name).toBe("Test Skill");
+          expect(parsed.skills[0].userFacingDescription).toBe(
+            "A test skill for the agent"
+          );
+        }
+      }
+    });
+
+    it("returns empty skills array when agent has no skills", async () => {
+      const workspace = await WorkspaceFactory.basic();
+      const adminAuth = await Authenticator.internalAdminForWorkspace(
+        workspace.sId
+      );
+      await SpaceFactory.defaults(adminAuth);
+      const user = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, user, { role: "admin" });
+
+      const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        user.sId,
+        workspace.sId
+      );
+
+      // Create an agent configuration without skills.
+      const agent = await AgentConfigurationFactory.createTestAgent(userAuth, {
+        name: "Agent without Skills",
+      });
+
+      // Mock the helper to return the agent config ID.
+      const { getAgentConfigurationIdFromContext } =
+        await import("@app/lib/actions/mcp_internal_actions/servers/agent_copilot_agent_state/helpers");
+      vi.mocked(getAgentConfigurationIdFromContext).mockReturnValueOnce(
+        agent.sId
+      );
+
+      const tool = getToolByName("get_agent_info");
+      const result = await tool.handler({}, createTestExtra(userAuth));
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        const content = result.value[0];
+        expect(content.type).toBe("text");
+        if (content.type === "text") {
+          const parsed = JSON.parse(content.text);
+          expect(parsed.skills).toEqual([]);
+        }
+      }
+    });
+  });
+});

--- a/front/lib/actions/mcp_internal_actions/servers/agent_copilot_agent_state/helpers.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/agent_copilot_agent_state/helpers.ts
@@ -1,0 +1,46 @@
+import {
+  AGENT_CONFIGURATION_ID_KEY,
+  AGENT_CONFIGURATION_VERSION_KEY,
+} from "@app/lib/actions/mcp_internal_actions/servers/agent_copilot_agent_state/metadata";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
+import { isLightServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
+
+export function getAgentConfigurationIdFromContext(
+  agentLoopContext?: AgentLoopContextType
+): string | null {
+  if (
+    agentLoopContext?.runContext &&
+    isLightServerSideMCPToolConfiguration(
+      agentLoopContext.runContext.toolConfiguration
+    )
+  ) {
+    const value =
+      agentLoopContext.runContext.toolConfiguration.additionalConfiguration[
+        AGENT_CONFIGURATION_ID_KEY
+      ];
+    if (typeof value === "string") {
+      return value;
+    }
+  }
+  return null;
+}
+
+export function getAgentConfigurationVersionFromContext(
+  agentLoopContext?: AgentLoopContextType
+): number | null {
+  if (
+    agentLoopContext?.runContext &&
+    isLightServerSideMCPToolConfiguration(
+      agentLoopContext.runContext.toolConfiguration
+    )
+  ) {
+    const value =
+      agentLoopContext.runContext.toolConfiguration.additionalConfiguration[
+        AGENT_CONFIGURATION_VERSION_KEY
+      ];
+    if (typeof value === "number") {
+      return value;
+    }
+  }
+  return null;
+}

--- a/front/lib/actions/mcp_internal_actions/servers/agent_copilot_agent_state/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/agent_copilot_agent_state/index.ts
@@ -1,0 +1,25 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+import { AGENT_COPILOT_AGENT_STATE_TOOL_NAME } from "@app/lib/actions/mcp_internal_actions/servers/agent_copilot_agent_state/metadata";
+import { TOOLS } from "@app/lib/actions/mcp_internal_actions/servers/agent_copilot_agent_state/tools";
+import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
+import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { Authenticator } from "@app/lib/auth";
+
+function createServer(
+  auth: Authenticator,
+  agentLoopContext?: AgentLoopContextType
+): McpServer {
+  const server = makeInternalMCPServer("agent_copilot_agent_state");
+
+  for (const tool of TOOLS) {
+    registerTool(auth, agentLoopContext, server, tool, {
+      monitoringName: AGENT_COPILOT_AGENT_STATE_TOOL_NAME,
+    });
+  }
+
+  return server;
+}
+
+export default createServer;

--- a/front/lib/actions/mcp_internal_actions/servers/agent_copilot_agent_state/metadata.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/agent_copilot_agent_state/metadata.ts
@@ -1,0 +1,56 @@
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
+
+import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { MCPToolType } from "@app/lib/api/mcp";
+
+export const AGENT_COPILOT_AGENT_STATE_TOOL_NAME =
+  "agent_copilot_agent_state" as const;
+
+// Key used to store the agent configuration version in additionalConfiguration.
+export const AGENT_CONFIGURATION_VERSION_KEY = "agentConfigurationVersion";
+
+// Re-export the AGENT_CONFIGURATION_ID_KEY for convenience.
+export { AGENT_CONFIGURATION_ID_KEY } from "@app/lib/actions/mcp_internal_actions/servers/agent_copilot_context/metadata";
+
+export const getAgentInfoMeta = {
+  name: "get_agent_info" as const,
+  description:
+    "Get detailed information about the current agent configuration, including name, description, instructions, model settings, and the IDs of all skills and tools currently used by the agent.",
+  schema: {},
+  stake: "never_ask" as MCPToolStakeLevelType,
+};
+
+export const TOOLS_META = [getAgentInfoMeta];
+
+export const AGENT_COPILOT_AGENT_STATE_TOOLS: MCPToolType[] = TOOLS_META.map(
+  (t) => ({
+    name: t.name,
+    description: t.description,
+    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+  })
+);
+
+export const AGENT_COPILOT_AGENT_STATE_TOOL_STAKES: Record<
+  string,
+  MCPToolStakeLevelType
+> = Object.fromEntries(TOOLS_META.map((t) => [t.name, t.stake]));
+
+export const AGENT_COPILOT_AGENT_STATE_SERVER_INFO = {
+  name: "agent_copilot_agent_state" as const,
+  version: "1.0.0",
+  description:
+    "Retrieve information about the current agent's configuration, including name, description, instructions, model, and tools.",
+  authorization: null,
+  icon: "ActionRobotIcon" as const,
+  documentationUrl: null,
+  instructions: null,
+};
+
+export const AGENT_COPILOT_AGENT_STATE_SERVER = {
+  serverInfo: AGENT_COPILOT_AGENT_STATE_SERVER_INFO,
+  tools: AGENT_COPILOT_AGENT_STATE_TOOLS,
+  tools_stakes: AGENT_COPILOT_AGENT_STATE_TOOL_STAKES,
+} as const satisfies ServerMetadata;

--- a/front/lib/actions/mcp_internal_actions/servers/agent_copilot_agent_state/tools/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/agent_copilot_agent_state/tools/index.ts
@@ -1,0 +1,98 @@
+import { MCPError } from "@app/lib/actions/mcp_errors";
+import {
+  getAgentConfigurationIdFromContext,
+  getAgentConfigurationVersionFromContext,
+} from "@app/lib/actions/mcp_internal_actions/servers/agent_copilot_agent_state/helpers";
+import { getAgentInfoMeta } from "@app/lib/actions/mcp_internal_actions/servers/agent_copilot_agent_state/metadata";
+import type { ToolDefinition } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { defineTool } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { Err, Ok } from "@app/types";
+
+const getAgentInfoTool = defineTool({
+  ...getAgentInfoMeta,
+  handler: async (_, extra) => {
+    const auth = extra.auth;
+    if (!auth) {
+      return new Err(new MCPError("Authentication required"));
+    }
+
+    const agentConfigurationId = getAgentConfigurationIdFromContext(
+      extra.agentLoopContext
+    );
+
+    if (!agentConfigurationId) {
+      return new Err(
+        new MCPError(
+          "Agent configuration ID not found in tool configuration. This tool requires the agentConfigurationId to be set in additionalConfiguration.",
+          { tracked: false }
+        )
+      );
+    }
+
+    const agentVersion = getAgentConfigurationVersionFromContext(
+      extra.agentLoopContext
+    );
+
+    // Fetch the agent configuration with full details to get the actions.
+    const agentConfiguration = await getAgentConfiguration(auth, {
+      agentId: agentConfigurationId,
+      agentVersion: agentVersion ?? undefined,
+      variant: "full",
+    });
+
+    if (!agentConfiguration) {
+      return new Err(
+        new MCPError(`Agent configuration not found: ${agentConfigurationId}`, {
+          tracked: false,
+        })
+      );
+    }
+
+    // Get skills associated with this agent.
+    const agentSkills = await SkillResource.listByAgentConfiguration(
+      auth,
+      agentConfiguration
+    );
+
+    const agentInfo = {
+      sId: agentConfiguration.sId,
+      version: agentConfiguration.version,
+      name: agentConfiguration.name,
+      description: agentConfiguration.description,
+      instructions: agentConfiguration.instructions,
+      model: {
+        providerId: agentConfiguration.model.providerId,
+        modelId: agentConfiguration.model.modelId,
+        temperature: agentConfiguration.model.temperature,
+        reasoningEffort: agentConfiguration.model.reasoningEffort,
+      },
+      scope: agentConfiguration.scope,
+      status: agentConfiguration.status,
+      tags: agentConfiguration.tags.map((tag) => ({
+        sId: tag.sId,
+        name: tag.name,
+      })),
+      tools: agentConfiguration.actions.map((action) => ({
+        sId: action.sId,
+        name: action.name,
+        description: action.description,
+      })),
+      skills: agentSkills.map((skill) => ({
+        sId: skill.sId,
+        name: skill.name,
+        userFacingDescription: skill.userFacingDescription,
+      })),
+    };
+
+    return new Ok([
+      {
+        type: "text" as const,
+        text: JSON.stringify(agentInfo, null, 2),
+      },
+    ]);
+  },
+});
+
+export const TOOLS = [getAgentInfoTool] as ToolDefinition[];

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -5,6 +5,7 @@ import {
   ADVANCED_SEARCH_SWITCH,
   AGENT_MEMORY_SERVER_NAME,
 } from "@app/lib/actions/mcp_internal_actions/constants";
+import { default as agentCopilotAgentStateServer } from "@app/lib/actions/mcp_internal_actions/servers/agent_copilot_agent_state";
 import { default as agentCopilotContextServer } from "@app/lib/actions/mcp_internal_actions/servers/agent_copilot_context";
 import { default as agentManagementServer } from "@app/lib/actions/mcp_internal_actions/servers/agent_management";
 import { default as agentMemoryServer } from "@app/lib/actions/mcp_internal_actions/servers/agent_memory";
@@ -203,6 +204,8 @@ export async function getInternalMCPServer(
       return outlookServer(auth, agentLoopContext);
     case "outlook_calendar":
       return outlookCalendarServer(auth, agentLoopContext);
+    case "agent_copilot_agent_state":
+      return agentCopilotAgentStateServer(auth, agentLoopContext);
     case "agent_copilot_context":
       return agentCopilotContextServer(auth, agentLoopContext);
     case "agent_management":

--- a/front/lib/actions/mcp_internal_actions/wrappers.ts
+++ b/front/lib/actions/mcp_internal_actions/wrappers.ts
@@ -29,7 +29,8 @@ export function registerTool(
     withToolLogging(
       auth,
       { toolNameForMonitoring: monitoringName, agentLoopContext },
-      (params, extra) => tool.handler(params, { ...extra, agentLoopContext })
+      (params, extra) =>
+        tool.handler(params, { ...extra, agentLoopContext, auth })
     )
   );
 }


### PR DESCRIPTION
## Description

Add new agent_copilot_agent_state internal MCP server with a get_agent_info tool that allows a Copilot agent to retrieve information about another agent.

This is the pure server side implementation, which will be used for Reinforced Agents. There will also be a separate client side implementation used in Agent Builder.

## Tests

Added unit tests.

## Risk

Low, new unused code.

## Deploy Plan

Front