### PR TITLE
Remove support for `allowUserOutsideCurrentWorkspace`

### DIFF
--- a/front/lib/api/auth_wrappers.ts
+++ b/front/lib/api/auth_wrappers.ts
@@ -227,7 +227,10 @@ export function withPublicAPIAuthentication<T>(
   handler: (
     req: NextApiRequest,
     res: NextApiResponse<WithAPIErrorResponse<T>>,
-    auth: Authenticator
+    auth: Authenticator,
+    // Null is passed for compatibility with withResourceFetchingFromRoute which uses
+    // the 4th parameter to determine legacy endpoint support (null = API route).
+    _sessionOrKeyAuth: null
   ) => Promise<void> | void,
   opts: {
     isStreaming?: boolean;
@@ -326,7 +329,7 @@ export function withPublicAPIAuthentication<T>(
             return apiError(req, res, getMaintenanceError(maintenance));
           }
 
-          return await handler(req, res, auth);
+          return await handler(req, res, auth, null);
         } catch (error) {
           logger.error({ error }, "Failed to verify token");
           return apiError(req, res, {
@@ -423,7 +426,7 @@ export function withPublicAPIAuthentication<T>(
           role: key.role,
         });
       }
-      return handler(req, res, workspaceAuth);
+      return handler(req, res, workspaceAuth, null);
     },
     isStreaming
   );

--- a/front/lib/iam/session.ts
+++ b/front/lib/iam/session.ts
@@ -50,7 +50,6 @@ interface MakeGetServerSidePropsRequirementsWrapperOptions<
   enableLogging?: boolean;
   requireUserPrivilege: R;
   requireCanUseProduct?: boolean;
-  allowUserOutsideCurrentWorkspace?: boolean;
 }
 
 export type CustomGetServerSideProps<
@@ -122,7 +121,6 @@ export function makeGetServerSidePropsRequirementsWrapper<
   enableLogging = true,
   requireUserPrivilege,
   requireCanUseProduct = false,
-  allowUserOutsideCurrentWorkspace,
 }: MakeGetServerSidePropsRequirementsWrapperOptions<RequireUserPrivilege>) {
   return <T extends { [key: string]: any } = { [key: string]: any }>(
     getServerSideProps: CustomGetServerSideProps<
@@ -219,7 +217,7 @@ export function makeGetServerSidePropsRequirementsWrapper<
         }
 
         // If we target a workspace and the user is not in the workspace, return not found.
-        if (!allowUserOutsideCurrentWorkspace && workspace && !auth?.isUser()) {
+        if (workspace && !auth?.isUser()) {
           return {
             notFound: true,
           };
@@ -268,31 +266,16 @@ export const withDefaultUserAuthPaywallWhitelisted =
   makeGetServerSidePropsRequirementsWrapper({
     requireUserPrivilege: "user",
     requireCanUseProduct: false,
-    allowUserOutsideCurrentWorkspace: false,
   });
 
 export const withDefaultUserAuthRequirements =
   makeGetServerSidePropsRequirementsWrapper({
     requireUserPrivilege: "user",
     requireCanUseProduct: true,
-    allowUserOutsideCurrentWorkspace: false,
-  });
-
-/**
- * This should only be used for pages that don't require
- * the current user to be in the current workspace.
- */
-export const withDefaultUserAuthRequirementsNoWorkspaceCheck =
-  makeGetServerSidePropsRequirementsWrapper({
-    requireUserPrivilege: "user",
-    requireCanUseProduct: true,
-    // This is a special case where we don't want to check if the user is in the current workspace.
-    allowUserOutsideCurrentWorkspace: true,
   });
 
 export const withSuperUserAuthRequirements =
   makeGetServerSidePropsRequirementsWrapper({
     requireUserPrivilege: "superuser",
     requireCanUseProduct: false,
-    allowUserOutsideCurrentWorkspace: false,
   });

--- a/front/types/groups.ts
+++ b/front/types/groups.ts
@@ -112,8 +112,7 @@ export function getRoleFromHeaders(
 }
 
 /**
- * Pass the user's role to the API - only use for route which have allowUserOutsideCurrentWorkspace set to
- * true (runApp or runAppStreamed). Other API calls will always require builder/admin role.
+ * Pass the user's role to the API via headers for internal system-key calls (e.g., runApp).
  */
 export function getHeaderFromRole(role: RoleType | undefined) {
   if (!role) {


### PR DESCRIPTION
## Description

This is now unused. Removing as this is basically security debt.

## Tests

Typechecking + tested locally

## Risk

None

## Deploy Plan

- deploy `front`