### PR TITLE
[Connectors/Microsoft] Fix stack overflow on large delta syncs

### DIFF
--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -709,7 +709,10 @@ export async function syncDeltaForRootNodesInDrive({
   );
 
   if (containsWholeDrive) {
-    sortedChangedItems.push(...sortForIncrementalUpdate(uniqueChangedItems));
+    // Use for...of instead of push(...) to avoid stack overflow with large arrays
+    for (const item of sortForIncrementalUpdate(uniqueChangedItems)) {
+      sortedChangedItems.push(item);
+    }
   } else {
     const microsoftNodes = await concurrentExecutor(
       rootNodeIds,
@@ -1053,7 +1056,10 @@ export async function fetchDeltaForRootNodesInDrive({
   );
 
   if (containsWholeDrive) {
-    sortedChangedItems.push(...sortForIncrementalUpdate(uniqueChangedItems));
+    // Use for...of instead of push(...) to avoid stack overflow with large arrays
+    for (const item of sortForIncrementalUpdate(uniqueChangedItems)) {
+      sortedChangedItems.push(item);
+    }
   } else {
     const microsoftNodes = await concurrentExecutor(
       rootNodeIds,
@@ -1295,12 +1301,11 @@ function sortForIncrementalUpdate(changedList: DriveItem[], rootId?: string) {
       return sortedItemList;
     }
 
-    sortedItemList.push(...nextLevel);
-
-    // Mark nodes as seen for the next iterations.
-    nextLevel.forEach((item) => {
+    // Use for...of instead of push(...) to avoid stack overflow with large arrays
+    for (const item of nextLevel) {
+      sortedItemList.push(item);
       sortedItemSet.add(getDriveItemInternalId(item));
-    });
+    }
   }
 }
 


### PR DESCRIPTION
## Description

Context: [Slack thread](https://dust4ai.slack.com/archives/C05F84CFP0E/p1768991339614299)

Fix `RangeError: Maximum call stack size exceeded` in `fetchDeltaForRootNodesInDrive` activity when processing large Microsoft delta syncs.

The issue was caused by using `push(...array)` which expands every array element into a function argument. When the array has hundreds of thousands of items, this exceeds JavaScript maximum call stack size.

Replace with `for...of` loops in three locations in `activities.ts`.

## Risks

Blast radius: Microsoft connector incremental sync
Risk: low

## Deploy Plan
- pmrr
- deploy connectors