### PR TITLE
Fix: Be specific when using the useSpaces() hook to avoid loading all spaces & projects.

### DIFF
--- a/front/components/actions/mcp/details/MCPAgentManagementActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPAgentManagementActionDetails.tsx
@@ -15,6 +15,7 @@ import { useSWRConfig } from "swr";
 import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
 import type { ToolExecutionDetailsProps } from "@app/components/actions/mcp/details/types";
 import { isAgentCreationResultResourceType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
+import { GLOBAL_SPACE_NAME } from "@app/types";
 
 export function MCPAgentManagementActionDetails({
   toolOutput,
@@ -107,7 +108,7 @@ export function MCPAgentManagementActionDetails({
             <ul className="list-inside list-disc text-sm text-muted-foreground dark:text-muted-foreground-night">
               <li>Web search and browse tools</li>
               <li>Search across workspace data sources</li>
-              <li>Query tools for data warehouses in Company Data</li>
+              <li>Query tools for data warehouses in {GLOBAL_SPACE_NAME}</li>
               {subAgent && <li>Run @{subAgent.name} sub-agent</li>}
             </ul>
           </div>

--- a/front/components/actions/mcp/details/MCPListToolsActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPListToolsActionDetails.tsx
@@ -14,11 +14,12 @@ export function MCPListToolsActionDetails({
   viewType,
 }: ToolExecutionDetailsProps) {
   const { spaces } = useSpaces({
+    kinds: ["global"],
     workspaceId: owner.sId,
   });
   const { serverViews: mcpServerViews } = useMCPServerViews({
     owner,
-    space: spaces.find((s) => s.kind === "global"),
+    space: spaces[0] ?? undefined,
     availability: "all",
   });
   const results =

--- a/front/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
@@ -63,11 +63,12 @@ export function MCPRunAgentActionDetails({
 
   const { spaces } = useSpaces({
     workspaceId: owner.sId,
+    kinds: ["global"],
     disabled: addedMCPServerViewIds.length === 0,
   });
   const { serverViews: mcpServerViews } = useMCPServerViews({
     owner,
-    space: spaces.find((s) => s.kind === "global"),
+    space: spaces[0] ?? undefined,
     availability: "all",
     disabled: addedMCPServerViewIds.length === 0,
   });

--- a/front/components/agent_builder/SpacesContext.tsx
+++ b/front/components/agent_builder/SpacesContext.tsx
@@ -30,6 +30,7 @@ interface SpacesProviderProps {
 export const SpacesProvider = ({ owner, children }: SpacesProviderProps) => {
   const sendNotification = useSendNotification();
   const { spaces, isSpacesLoading, isSpacesError } = useSpaces({
+    kinds: "all",
     workspaceId: owner.sId,
   });
 

--- a/front/components/assistant/ToolsPicker.tsx
+++ b/front/components/assistant/ToolsPicker.tsx
@@ -148,14 +148,11 @@ export function ToolsPicker({
   const { hasFeature } = useFeatureFlags({ workspaceId: owner.sId });
   const hasSkillsFeature = hasFeature("skills");
 
-  const { spaces } = useSpaces({
+  const { spaces: globalSpaces } = useSpaces({
     workspaceId: owner.sId,
+    kinds: ["global"],
     disabled: !shouldFetchToolsData,
   });
-  const globalSpaces = useMemo(
-    () => spaces.filter((s) => s.kind === "global"),
-    [spaces]
-  );
 
   const isAdmin = owner.role === "admin";
 

--- a/front/components/assistant/conversation/input_bar/InputBarAttachments.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachments.tsx
@@ -25,10 +25,9 @@ import {
   getLocationForDataSourceViewContentNode,
   getVisualForDataSourceViewContentNode,
 } from "@app/lib/content_nodes";
-import { getSpaceIcon } from "@app/lib/spaces";
+import { getSpaceIcon, getSpaceName } from "@app/lib/spaces";
 import { useSpaces } from "@app/lib/swr/spaces";
 import type { DataSourceViewContentNode, LightWorkspaceType } from "@app/types";
-import { GLOBAL_SPACE_NAME } from "@app/types";
 
 interface FileAttachmentsProps {
   service: FileUploaderService;
@@ -56,6 +55,7 @@ export function InputBarAttachments({
 }: InputBarAttachmentsProps) {
   const { spaces } = useSpaces({
     workspaceId: owner.sId,
+    kinds: ["global", "regular", "project"],
     disabled: !nodes?.items.length,
   });
   const spacesMap = useMemo(
@@ -64,7 +64,7 @@ export function InputBarAttachments({
         spaces?.map((space) => [
           space.sId,
           {
-            name: space.kind === "global" ? GLOBAL_SPACE_NAME : space.name,
+            name: getSpaceName(space),
             icon: getSpaceIcon(space),
           },
         ]) || []

--- a/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarAttachmentsPicker.tsx
@@ -218,6 +218,7 @@ export const InputBarAttachmentsPicker = ({
 
   const { spaces, isSpacesLoading } = useSpaces({
     workspaceId: owner.sId,
+    kinds: ["global", "regular", "project"],
     disabled: !isOpen,
   });
 

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -427,6 +427,7 @@ const InputBarContainer = ({
 
   const { spaces, isSpacesLoading } = useSpaces({
     workspaceId: owner.sId,
+    kinds: ["global", "regular", "project"],
     disabled: !nodeOrUrlCandidate,
   });
 

--- a/front/components/assistant/details/tabs/AgentInfoTab/AssistantSkillsToolsSection.tsx
+++ b/front/components/assistant/details/tabs/AgentInfoTab/AssistantSkillsToolsSection.tsx
@@ -192,9 +192,10 @@ function useAvailableToolsets({
 
   const { spaces } = useSpaces({
     workspaceId: owner.sId,
+    kinds: ["global"],
     disabled: !toolsetsAction,
   });
-  const globalSpace = spaces.find((s) => s.kind === "global");
+  const globalSpace = spaces[0] ?? undefined;
 
   const { serverViews: globalServerViews, isMCPServerViewsLoading } =
     useMCPServerViews({

--- a/front/components/data_source_view/DataSourceViewsSpaceSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewsSpaceSelector.tsx
@@ -39,7 +39,10 @@ export const DataSourceViewsSpaceSelector = ({
   isRootSelectable,
   selectionMode = "checkbox",
 }: DataSourceViewsSpaceSelectorProps) => {
-  const { spaces, isSpacesLoading } = useSpaces({ workspaceId: owner.sId });
+  const { spaces, isSpacesLoading } = useSpaces({
+    kinds: "all",
+    workspaceId: owner.sId,
+  });
 
   const defaultSpace = useMemo(() => {
     const firstKey = Object.keys(selectionConfigurations)[0] ?? null;

--- a/front/components/editor/extensions/skill_builder/KnowledgeNodeView.tsx
+++ b/front/components/editor/extensions/skill_builder/KnowledgeNodeView.tsx
@@ -160,6 +160,7 @@ function KnowledgeSearchComponent({
   // Get spaces for location display.
   const { spaces } = useSpaces({
     workspaceId: owner.sId,
+    kinds: ["global", "regular", "project"],
     disabled: false,
   });
 

--- a/front/components/markdown/tool/ToolSetupCard.tsx
+++ b/front/components/markdown/tool/ToolSetupCard.tsx
@@ -24,7 +24,7 @@ import {
   TRACKING_AREAS,
 } from "@app/lib/tracking";
 import type { WorkspaceType } from "@app/types";
-import { asDisplayToolName } from "@app/types";
+import { asDisplayToolName, GLOBAL_SPACE_NAME } from "@app/types";
 
 interface ToolSetupCardProps {
   toolName: string;
@@ -45,6 +45,7 @@ export function ToolSetupCard({
 
   const { spaces: spacesAsUser } = useSpaces({
     workspaceId: owner.sId,
+    kinds: ["global", "regular"],
     disabled: isAdmin,
   });
   const { spaces: spacesAsAdmin } = useSpacesAsAdmin({
@@ -117,7 +118,7 @@ export function ToolSetupCard({
       return "Configured";
     }
     if (isToolActivatedInSystemSpace) {
-      return "Add to Company Data";
+      return `Add to ${GLOBAL_SPACE_NAME}`;
     }
     return "Configure";
   };

--- a/front/components/me/UserToolsTable.tsx
+++ b/front/components/me/UserToolsTable.tsx
@@ -39,7 +39,10 @@ export function UserToolsTable({ owner }: UserToolsTableProps) {
   const sendNotification = useSendNotification();
   const [searchQuery, setSearchQuery] = useState("");
 
-  const { spaces } = useSpaces({ workspaceId: owner.sId });
+  const { spaces } = useSpaces({
+    workspaceId: owner.sId,
+    kinds: ["global", "regular"],
+  });
   const { serverViews, isLoading: isMCPServerViewsLoading } =
     useManualMCPServerViewsFromSpaces(owner, spaces);
   const { connections, isConnectionsLoading } = useMCPServerConnections({

--- a/front/components/skills/SkillInfoTab.tsx
+++ b/front/components/skills/SkillInfoTab.tsx
@@ -35,6 +35,7 @@ export function SkillInfoTab({
   const shouldLoadSpaces = skill.requestedSpaceIds.length > 0;
   const { spaces: spacesFromHook, isSpacesLoading } = useSpaces({
     workspaceId: owner.sId,
+    kinds: ["global", "regular", "project"],
     disabled: !shouldLoadSpaces || !!spaces,
   });
 

--- a/front/components/spaces/FoldersHeaderMenu.tsx
+++ b/front/components/spaces/FoldersHeaderMenu.tsx
@@ -21,6 +21,7 @@ import type {
   LightWorkspaceType,
   SpaceType,
 } from "@app/types";
+import { GLOBAL_SPACE_NAME } from "@app/types";
 
 interface FoldersHeaderMenuProps {
   canWriteInSpace: boolean;
@@ -48,7 +49,7 @@ export const FoldersHeaderMenu = ({
         <Tooltip
           label={
             space.kind === "global"
-              ? `Only builders of the workspace can add data in the Company Data space.`
+              ? `Only builders of the workspace can add data in the ${GLOBAL_SPACE_NAME} space.`
               : `Only members of the space can add data.`
           }
           side="top"
@@ -71,7 +72,7 @@ export const FoldersHeaderMenu = ({
         <Tooltip
           label={
             space.kind === "global"
-              ? `Only builders of the workspace can edit a folder in the Company Data space.`
+              ? `Only builders of the workspace can edit a folder in the ${GLOBAL_SPACE_NAME} space.`
               : `Only members of the space can edit a folder.`
           }
           side="top"

--- a/front/components/spaces/SpaceBreadcrumb.tsx
+++ b/front/components/spaces/SpaceBreadcrumb.tsx
@@ -62,7 +62,7 @@ export function SpaceBreadCrumbs({
     const items: BreadcrumbItem[] = [
       {
         icon: getSpaceIcon(space),
-        label: space.kind === "global" ? "Company Data" : space.name,
+        label: getSpaceName(space),
         href: `/w/${owner.sId}/spaces/${space.sId}`,
       },
       {

--- a/front/components/spaces/SpaceDataSourceViewContentList.tsx
+++ b/front/components/spaces/SpaceDataSourceViewContentList.tsx
@@ -305,6 +305,7 @@ export const SpaceDataSourceViewContentList = ({
     dataSourceView.kind === "default" && isManaged(dataSourceView.dataSource);
   const { spaces } = useSpaces({
     workspaceId: owner.sId,
+    kinds: ["global", "regular"],
     disabled: !showSpaceUsage,
   });
   const { dataSourceViews, mutateDataSourceViews } = useDataSourceViews(owner, {

--- a/front/components/spaces/SpaceSearchLayout.tsx
+++ b/front/components/spaces/SpaceSearchLayout.tsx
@@ -578,6 +578,7 @@ function SearchResultsTable({
   const router = useRouter();
 
   const { spaces } = useSpaces({
+    kinds: ["global", "regular"],
     workspaceId: owner.sId,
   });
 

--- a/front/components/spaces/SpaceSideBarMenu.tsx
+++ b/front/components/spaces/SpaceSideBarMenu.tsx
@@ -85,6 +85,7 @@ export default function SpaceSideBarMenu({
 
   const { spaces: spacesAsUser, isSpacesLoading: isSpacesAsUserLoading } =
     useSpaces({
+      kinds: ["global", "regular"],
       workspaceId: owner.sId,
     });
 

--- a/front/lib/actions/mcp_internal_actions/servers/agent_copilot_context/tools/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/agent_copilot_context/tools/index.ts
@@ -129,7 +129,7 @@ const getAvailableToolsTool = defineTool({
       return new Err(new MCPError("Authentication required"));
     }
 
-    // Get all spaces the user has access to.
+    // Get all spaces the user is member of.
     const userSpaces = await SpaceResource.listWorkspaceSpacesAsMember(auth);
 
     // Fetch all MCP server views from those spaces.

--- a/front/lib/api/assistant/conversation/mentions.ts
+++ b/front/lib/api/assistant/conversation/mentions.ts
@@ -119,12 +119,16 @@ async function isUserMemberOfSpace(
     return false;
   }
 
-  const user = await UserResource.fetchById(userId);
-  if (!user) {
+  const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+    userId,
+    auth.getNonNullableWorkspace().sId
+  );
+
+  if (!userAuth) {
     return false;
   }
 
-  return space.isMember(user);
+  return space.isMember(userAuth);
 }
 
 export const createUserMentions = async (
@@ -949,7 +953,7 @@ export async function validateUserMention(
     }
 
     // TODO(projects): isEditor will check editor permissions once project roles PR is merged.
-    const canEdit = await space.isEditor(currentUser);
+    const canEdit = space.isEditor(auth);
     if (!canEdit) {
       return new Err({
         status_code: 403,

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -31,6 +31,7 @@ import type {
   APIErrorWithStatusCode,
   GroupType,
   LightWorkspaceType,
+  ModelId,
   PermissionType,
   PlanType,
   ResourcePermission,
@@ -833,6 +834,14 @@ export class Authenticator {
 
   groups(): GroupType[] {
     return this._groups.map((g) => g.toJSON());
+  }
+
+  hasGroup(groupId: string): boolean {
+    return this._groups.some((g) => g.sId === groupId);
+  }
+
+  hasGroupByModelId(groupId: ModelId): boolean {
+    return this._groups.some((g) => g.id === groupId);
   }
 
   /**

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -32,7 +32,13 @@ import type {
   SpaceKind,
   SpaceType,
 } from "@app/types";
-import { Err, GLOBAL_SPACE_NAME, Ok, removeNulls } from "@app/types";
+import {
+  assertNever,
+  Err,
+  GLOBAL_SPACE_NAME,
+  Ok,
+  removeNulls,
+} from "@app/types";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
@@ -200,28 +206,41 @@ export class SpaceResource extends BaseResource<SpaceModel> {
 
   static async listWorkspaceSpaces(
     auth: Authenticator,
-    options?: { includeConversationsSpace?: boolean; includeDeleted?: boolean },
+    options?: {
+      includeConversationsSpace?: boolean;
+      includeProjectSpaces?: boolean;
+      includeDeleted?: boolean;
+    },
     t?: Transaction
   ): Promise<SpaceResource[]> {
     const spaces = await this.baseFetch(
       auth,
       {
         includeDeleted: options?.includeDeleted,
+        where: {
+          kind: {
+            [Op.in]: [
+              "system",
+              "global",
+              "regular",
+              "public",
+              ...(options?.includeConversationsSpace ? ["conversations"] : []),
+              ...(options?.includeProjectSpaces ? ["project"] : []),
+            ],
+          },
+        },
       },
       t
     );
 
-    if (!options?.includeConversationsSpace) {
-      return spaces.filter((s) => !s.isConversations());
-    }
     return spaces;
   }
 
   static async listWorkspaceSpacesAsMember(auth: Authenticator) {
     const spaces = await this.baseFetch(auth);
 
-    // Filtering to the spaces the auth can read that are not conversations.
-    return spaces.filter((s) => s.canRead(auth) && !s.isConversations());
+    // TODO(projects): we might want to filter early on the groups membership to avoid fetching all spaces and then filtering.
+    return spaces.filter((s) => s.isMember(auth));
   }
 
   static async listWorkspaceDefaultSpaces(
@@ -761,32 +780,53 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   }
 
   /**
-   * Check if a user is a member of this space.
-   * Returns true if the user belongs to any non-global group linked to this space.
-   * Global groups are excluded from this check because membership in a global group
-   * doesn't indicate explicit space membership. System groups also have no impact
-   * on membership (since isMember will return false for system groups).
+   * Check if the auth is a member of this space.
    */
-  // TODO(projects): update this method to check groups whose group_vaults relationship is
-  // space_member or space_editor (not space_viewer) when the PR adding the relationship is live.
-  // At that point, we can reinstate global groups in the check if their relation is member or editor.
-  async isMember(user: UserResource): Promise<boolean> {
-    for (const group of this.groups) {
-      if (group.isGlobal()) {
-        continue;
-      }
-      if (await group.isMember(user)) {
-        return true;
-      }
-    }
 
-    return false;
+  isMember(auth: Authenticator): boolean {
+    // TODO(projects): update this method to check groups whose group_vaults relationship is
+    // to remove the complexity of checking the global group based on the space type.
+    switch (this.kind) {
+      case "regular":
+        for (const group of this.groups) {
+          // In regular spaces, having the global group means that you are a member.
+          if (group.isGlobal()) {
+            return true;
+          }
+          if (auth.hasGroupByModelId(group.id)) {
+            return true;
+          }
+        }
+        return false;
+      case "project":
+        for (const group of this.groups) {
+          // Ignore the global group for project spaces as it means that the group is public but not that you are a member.
+          if (group.isGlobal()) {
+            continue;
+          }
+          if (auth.hasGroupByModelId(group.id)) {
+            return true;
+          }
+        }
+        return false;
+      case "global":
+        return true;
+      case "conversations":
+      case "system":
+        return false;
+      case "public":
+        // I have a doubt on this one.
+        return true;
+
+      default:
+        assertNever(this.kind);
+    }
   }
 
   // TODO(projects): update this method to check groups whose group_vaults relationship is
   // space_editor (not space_viewer or space_member) when the PR adding the relationship is live.
-  async isEditor(user: UserResource): Promise<boolean> {
-    return this.isMember(user);
+  isEditor(auth: Authenticator): boolean {
+    return this.isMember(auth);
   }
 
   /**

--- a/front/lib/spaces.ts
+++ b/front/lib/spaces.ts
@@ -22,7 +22,7 @@ import type {
   WhitelistableFeature,
   WorkspaceType,
 } from "@app/types";
-import { assertNever } from "@app/types";
+import { assertNever, GLOBAL_SPACE_NAME } from "@app/types";
 
 const SPACE_SECTION_GROUP_ORDER = [
   "system",
@@ -56,7 +56,7 @@ export function getSpaceIcon(
 }
 
 export const getSpaceName = (space: SpaceType) => {
-  return space.kind === "global" ? "Company Space" : space.name;
+  return space.kind === "global" ? GLOBAL_SPACE_NAME : space.name;
 };
 
 export const dustAppsListUrl = (

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -46,15 +46,18 @@ import type {
   PatchProjectMetadataBodyType,
   ProjectMetadataType,
   SearchWarningCode,
+  SpaceKind,
   SpaceType,
 } from "@app/types";
 import { MIN_SEARCH_QUERY_SIZE } from "@app/types";
 
 export function useSpaces({
   workspaceId,
+  kinds,
   disabled,
 }: {
   workspaceId: string;
+  kinds: SpaceKind[] | "all";
   disabled?: boolean;
 }) {
   const spacesFetcher: Fetcher<GetSpacesResponseBody> = fetcher;
@@ -65,14 +68,23 @@ export function useSpaces({
     { disabled }
   );
 
+  const spaces = useMemo(() => {
+    return (
+      data?.spaces?.filter((s) => kinds === "all" || kinds.includes(s.kind)) ??
+      emptyArray<SpaceType>()
+    );
+  }, [data?.spaces, kinds]);
+
   return {
-    spaces: data?.spaces ?? emptyArray(),
+    spaces,
     isSpacesLoading: !error && !data && !disabled,
     isSpacesError: error,
     mutate,
   };
 }
 
+// Note that this hook only returns spaces of kind "global", "regular" and "system" (backend enforced).
+// The other kinds are left aside as they are not relevant for the admins point of view.
 export function useSpacesAsAdmin({
   workspaceId,
   disabled,
@@ -392,6 +404,7 @@ export function useCreateSpace({ owner }: { owner: LightWorkspaceType }) {
   const sendNotification = useSendNotification();
   const { mutate: mutateSpaces } = useSpaces({
     workspaceId: owner.sId,
+    kinds: "all",
     disabled: true, // Needed just to mutate.
   });
   const { mutate: mutateSpacesAsAdmin } = useSpacesAsAdmin({
@@ -485,6 +498,7 @@ export function useUpdateSpace({ owner }: { owner: LightWorkspaceType }) {
   const sendNotification = useSendNotification();
   const { mutate: mutateSpaces } = useSpaces({
     workspaceId: owner.sId,
+    kinds: "all",
     disabled: true, // Needed just to mutate
   });
   const { mutate: mutateSpacesAsAdmin } = useSpacesAsAdmin({
@@ -593,6 +607,7 @@ export function useDeleteSpace({
   const sendNotification = useSendNotification();
   const { mutate: mutateSpaces } = useSpaces({
     workspaceId: owner.sId,
+    kinds: "all",
     disabled: true, // Needed just to mutate
   });
   const { mutate: mutateSpacesAsAdmin } = useSpacesAsAdmin({

--- a/front/pages/w/[wId]/labs/transcripts/index.tsx
+++ b/front/pages/w/[wId]/labs/transcripts/index.tsx
@@ -76,6 +76,7 @@ export default function LabsTranscriptsIndex({
     useState(false);
 
   const { spaces, isSpacesLoading } = useSpaces({
+    kinds: ["global", "regular"],
     workspaceId: owner.sId,
   });
   const { agentConfigurations } = useAgentConfigurations({

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -554,6 +554,7 @@ export async function deleteSpacesActivity({
   const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
   const spaces = await SpaceResource.listWorkspaceSpaces(auth, {
     includeConversationsSpace: true,
+    includeProjectSpaces: true,
     includeDeleted: true,
   });
 

--- a/front/scripts/ensure_project_datasource_and_connector_created.ts
+++ b/front/scripts/ensure_project_datasource_and_connector_created.ts
@@ -173,7 +173,7 @@ makeScript(
       }
       const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
       const allSpaces = await SpaceResource.listWorkspaceSpaces(auth, {
-        includeDeleted: false,
+        includeProjectSpaces: true,
       });
       const projectSpacesResources = allSpaces.filter(
         (s) => s.kind === "project"

--- a/front/temporal/scrub_workspace/activities.ts
+++ b/front/temporal/scrub_workspace/activities.ts
@@ -261,7 +261,9 @@ async function deleteDatasources(auth: Authenticator) {
 // Remove all user-created spaces and their associated groups,
 // preserving only the system and global spaces.
 async function deleteSpaces(auth: Authenticator) {
-  const spaces = await SpaceResource.listWorkspaceSpaces(auth);
+  const spaces = await SpaceResource.listWorkspaceSpaces(auth, {
+    includeProjectSpaces: true,
+  });
 
   // Filter out system and global spaces.
   const filteredSpaces = spaces.filter(


### PR DESCRIPTION
## Description

Update `listWorkspaceSpacesAsMember()` to leverage `isMember()` and update `isMember()` to support all kinds of spaces.
Also, filter the spaces kinds client-side depending on the use case.

## Tests

Local + updated.

## Risk

Medium as it affects the list of spaces returned.

## Deploy Plan

Deploy front