### PR TITLE
Add Template Support For Frames Creation Using Skills/Knowledge

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/interactive_content/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/interactive_content/index.ts
@@ -4,6 +4,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
 import { MCPError } from "@app/lib/actions/mcp_errors";
+import { fetchTemplateContent } from "@app/lib/actions/mcp_internal_actions/servers/interactive_content/template_utils";
 import {
   CREATE_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
   EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
@@ -12,7 +13,6 @@ import {
   RETRIEVE_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
   REVERT_INTERACTIVE_CONTENT_FILE_TOOL_NAME,
 } from "@app/lib/actions/mcp_internal_actions/servers/interactive_content/types";
-import { fetchTemplateContent } from "@app/lib/actions/mcp_internal_actions/servers/interactive_content/template_utils";
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";

--- a/front/lib/actions/mcp_internal_actions/servers/interactive_content/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/interactive_content/index.ts
@@ -137,35 +137,25 @@ function createServer(
         { file_name, mime_type, mode, source, description },
         { sendNotification, _meta }
       ) => {
-        const { conversation, agentConfiguration } =
-          agentLoopContext?.runContext ?? {};
+        const { runContext } = agentLoopContext ?? {};
 
-        if (!conversation) {
+        if (!runContext) {
           return new Err(
             new MCPError(
-              "Conversation ID is required to create a client executable file."
+              "Agent loop context is required to use template nodes.",
+              { tracked: false }
             )
           );
         }
 
+        const { conversation, agentConfiguration } = runContext;
+
         let fileContent: string;
 
-        // Fetch template content if mode is 'template'
         if (mode === "template") {
-          if (!agentLoopContext?.runContext) {
-            return new Err(
-              new MCPError(
-                "Agent loop context is required to use template nodes.",
-                { tracked: false }
-              )
-            );
-          }
-
-          const templateResult = await fetchTemplateContent(
-            auth,
-            agentLoopContext.runContext,
-            { templateNodeId: source }
-          );
+          const templateResult = await fetchTemplateContent(auth, runContext, {
+            templateNodeId: source,
+          });
 
           if (templateResult.isErr()) {
             return templateResult;
@@ -173,7 +163,6 @@ function createServer(
 
           fileContent = templateResult.value;
         } else {
-          // Inline content path (mode === 'inline')
           fileContent = source;
         }
 

--- a/front/lib/actions/mcp_internal_actions/servers/interactive_content/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/interactive_content/index.ts
@@ -28,7 +28,12 @@ import { formatValidationWarningsForLLM } from "@app/lib/api/files/content_valid
 import type { Authenticator } from "@app/lib/auth";
 import type { FileResource } from "@app/lib/resources/file_resource";
 import type { InteractiveContentFileContentType } from "@app/types";
-import { Err, frameContentType, INTERACTIVE_CONTENT_FILE_FORMATS, Ok } from "@app/types";
+import {
+  Err,
+  frameContentType,
+  INTERACTIVE_CONTENT_FILE_FORMATS,
+  Ok,
+} from "@app/types";
 
 const MAX_FILE_SIZE_BYTES = 1 * 1024 * 1024; // 1MB
 

--- a/front/lib/actions/mcp_internal_actions/servers/interactive_content/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/interactive_content/index.ts
@@ -105,8 +105,8 @@ function createServer(
       mode: z
         .enum(["template", "inline"])
         .describe(
-          "Creation mode: 'template' to use an existing content node as a starting point " +
-            "(efficient, no tokens consumed), or 'inline' to provide content directly."
+          "Creation mode: 'template' to reference an existing content node from knowledge " +
+            "(content fetched server-side), or 'inline' to provide content directly."
         ),
       source: z
         .string()

--- a/front/lib/actions/mcp_internal_actions/servers/interactive_content/instructions.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/interactive_content/instructions.ts
@@ -22,11 +22,29 @@ export const INTERACTIVE_CONTENT_INSTRUCTIONS = `\
 You have access to an Interactive Content system that allows you to create and update executable files. When creating visualizations, you should create files instead of using the :::visualization directive.
 This toolset is called Frame in the product, users may refer to it as such.
 
-### File Management Guidelines:
-- Use the \`${CREATE_INTERACTIVE_CONTENT_FILE_TOOL_NAME}\` tool to create JavaScript/TypeScript files
+### Using Templates
+
+When templates are available, use them instead of creating content from scratch. Templates are referenced with \`<knowledge id="...">\` tags. To use a template:
+
+1. Set \`mode: "template"\`
+2. Take the ID value from the \`<knowledge id="...">\` tag
+3. Pass it to the \`source\` parameter
+4. Do not read the template content, it will be fetched automatically
+
+Example: \`<knowledge id="template_node_id">\` -> use \`mode: "template"\` and \`source: "template_node_id"\`
+
+This approach is more efficient because the content is fetched server-side without consuming tokens.
+
+### Creating Files
+
+Use the \`${CREATE_INTERACTIVE_CONTENT_FILE_TOOL_NAME}\` tool to create JavaScript/TypeScript files:
 - Use MIME type \`${VIZ_MIME_TYPE}\`
 - Supported file extensions: .js, .jsx, .ts, .tsx
 - Files are automatically made available to the user for execution
+
+You can create files in two ways:
+1. **From a template** (preferred when available): Set \`mode: "template"\` and pass the template node ID in \`source\`
+2. **With inline content**: Set \`mode: "inline"\` and pass your code in \`source\`
 
 ### Updating Existing Files:
 - To modify existing Interactive Content files, always use \`${RETRIEVE_INTERACTIVE_CONTENT_FILE_TOOL_NAME}\` first to read the current content
@@ -34,21 +52,20 @@ This toolset is called Frame in the product, users may refer to it as such.
 - The edit tool requires exact text matching - include surrounding context for unique identification
 - Never attempt to edit without first retrieving the current file content
 
-### Validation:
+### Validation
+
 Validation is performed automatically when you create or edit files.
 
 **Tailwind validation (non-blocking):** Files are saved even with Tailwind warnings. When you
 receive warnings in the tool response, they include the exact \`old_string\` and
-\`expected_replacements\` count. You MUST fix these warnings using
-\`${EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME}\` with the provided values. If you receive
-multiple warnings, fix all of them in a single response using multiple edit tool calls.
-Common warning: "Forbidden Tailwind arbitrary value 'h-[600px]'" means you should replace with
-predefined classes like h-96 or use inline styles. Do NOT regenerate the entire file; use
-targeted edits only.
+\`expected_replacements\` count. Fix these warnings using \`${EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME}\`
+with the provided values. If you receive multiple warnings, fix all of them in a single response
+using multiple edit tool calls. Common warning: "Forbidden Tailwind arbitrary value 'h-[600px]'"
+means you should replace with predefined classes like h-96 or use inline styles. Do not regenerate
+the entire file; use targeted edits only.
 
-**CRITICAL: Use exact values from warnings.** When you receive warnings, they include the exact
-\`old_string\` and \`expected_replacements\` to use. You MUST use these values EXACTLY AS PROVIDED.
-Do not add context, do not modify them, do not interpret them, do not retrieve the file first.
+When fixing validation warnings, use the exact values provided. Do not add context, modify them,
+interpret them, or retrieve the file first.
 
 Example warning response:
 \`\`\`
@@ -99,13 +116,28 @@ ${VIZ_MISCELLANEOUS_GUIDELINES}
 
 ${VIZ_USE_FILE_EXAMPLES}
 
-Example File Creation:
+Example: Creating a file from a template
+
+If you see \`<knowledge id="template_node_id">\` in instructions, create a file using that template:
+
+\`\`\`
+${CREATE_INTERACTIVE_CONTENT_FILE_TOOL_NAME}({
+  file_name: "NewVisualization.tsx",
+  mime_type: "${VIZ_MIME_TYPE}",
+  mode: "template",
+  source: "template_node_id",  // ID from <knowledge id="...">
+  description: "Chart based on RandomStart template"
+})
+\`\`\`
+
+Example: Creating a file with inline content
 
 \`\`\`
 ${CREATE_INTERACTIVE_CONTENT_FILE_TOOL_NAME}({
   file_name: "SineCosineChart.tsx",
   mime_type: "${VIZ_MIME_TYPE}",
-  content: \`[React component code]\`
+  mode: "inline",
+  source: \`[React component code]\`
 })
 \`\`\`
 

--- a/front/lib/actions/mcp_internal_actions/servers/interactive_content/instructions.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/interactive_content/instructions.ts
@@ -22,19 +22,6 @@ export const INTERACTIVE_CONTENT_INSTRUCTIONS = `\
 You have access to an Interactive Content system that allows you to create and update executable files. When creating visualizations, you should create files instead of using the :::visualization directive.
 This toolset is called Frame in the product, users may refer to it as such.
 
-### Using Templates
-
-When templates are available, use them instead of creating content from scratch. Templates are referenced with \`<knowledge id="...">\` tags. To use a template:
-
-1. Set \`mode: "template"\`
-2. Take the ID value from the \`<knowledge id="...">\` tag
-3. Pass it to the \`source\` parameter
-4. Do not read the template content, it will be fetched automatically
-
-Example: \`<knowledge id="template_node_id">\` -> use \`mode: "template"\` and \`source: "template_node_id"\`
-
-This approach is more efficient because the content is fetched server-side without consuming tokens.
-
 ### Creating Files
 
 Use the \`${CREATE_INTERACTIVE_CONTENT_FILE_TOOL_NAME}\` tool to create JavaScript/TypeScript files:
@@ -42,9 +29,20 @@ Use the \`${CREATE_INTERACTIVE_CONTENT_FILE_TOOL_NAME}\` tool to create JavaScri
 - Supported file extensions: .js, .jsx, .ts, .tsx
 - Files are automatically made available to the user for execution
 
-You can create files in two ways:
-1. **From a template** (preferred when available): Set \`mode: "template"\` and pass the template node ID in \`source\`
-2. **With inline content**: Set \`mode: "inline"\` and pass your code in \`source\`
+The tool supports two creation modes via the \`mode\` parameter:
+
+**Template mode** (\`mode: "template"\`):
+- References existing content from knowledge via \`<knowledge id="...">\` tags
+- Pass the ID from the knowledge tag to the \`source\` parameter
+- Content is fetched server-side without consuming context tokens
+- Example: \`<knowledge id="template_node_id">\` → \`source: "template_node_id"\`
+- Common pattern: Create from template, then use \`${EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME}\` to customize
+- This approach works well when adapting existing templates (preserves structure/style, no token cost for base content)
+
+**Inline mode** (\`mode: "inline"\`):
+- Provide the file content directly in the \`source\` parameter
+- The full code is passed as a string
+- Typical use cases: No suitable template exists, complete rewrite needed, or full code visibility required upfront
 
 ### Updating Existing Files:
 - To modify existing Interactive Content files, always use \`${RETRIEVE_INTERACTIVE_CONTENT_FILE_TOOL_NAME}\` first to read the current content
@@ -116,22 +114,20 @@ ${VIZ_MISCELLANEOUS_GUIDELINES}
 
 ${VIZ_USE_FILE_EXAMPLES}
 
-Example: Creating a file from a template
+Examples:
 
-If you see \`<knowledge id="template_node_id">\` in instructions, create a file using that template:
-
+**Creating a file from a knowledge template:**
 \`\`\`
 ${CREATE_INTERACTIVE_CONTENT_FILE_TOOL_NAME}({
   file_name: "NewVisualization.tsx",
   mime_type: "${VIZ_MIME_TYPE}",
   mode: "template",
   source: "template_node_id",  // ID from <knowledge id="...">
-  description: "Chart based on RandomStart template"
+  description: "Sales dashboard"
 })
 \`\`\`
 
-Example: Creating a file with inline content
-
+**Creating a file with inline content:**
 \`\`\`
 ${CREATE_INTERACTIVE_CONTENT_FILE_TOOL_NAME}({
   file_name: "SineCosineChart.tsx",

--- a/front/lib/actions/mcp_internal_actions/servers/interactive_content/template_utils.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/interactive_content/template_utils.ts
@@ -1,0 +1,154 @@
+import type { AgentLoopRunContextType } from "@app/lib/actions/types";
+import { getSkillDataSourceConfigurations } from "@app/lib/api/assistant/skill_actions";
+import config from "@app/lib/api/config";
+import type { Authenticator } from "@app/lib/auth";
+import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import logger from "@app/logger/logger";
+import type { Result } from "@app/types";
+import { CoreAPI, Err, Ok } from "@app/types";
+
+import { MCPError } from "../../../mcp_errors";
+import { makeCoreSearchNodesFilters } from "../../tools/utils";
+
+const MAX_TEMPLATE_SIZE_BYTES = 1 * 1024 * 1024; // 1MB
+
+/**
+ * Fetches template content from a knowledge node using the agent's skills configuration.
+ */
+export async function fetchTemplateContent(
+  auth: Authenticator,
+  runContext: AgentLoopRunContextType,
+  { templateNodeId }: { templateNodeId: string }
+): Promise<Result<string, MCPError>> {
+  const { agentConfiguration, conversation } = runContext;
+
+  // Fetch skills for this agent and conversation (same pattern as agent loop).
+  const { enabledSkills } = await SkillResource.listForAgentLoop(auth, {
+    agentConfiguration,
+    conversation,
+  });
+
+  // Get merged data source configurations from skills.
+  const dataSourceConfigurations = await getSkillDataSourceConfigurations(
+    auth,
+    {
+      skills: enabledSkills,
+    }
+  );
+
+  if (dataSourceConfigurations.length === 0) {
+    return new Err(
+      new MCPError(
+        "No data sources found in skills configuration. " +
+          "Template nodes can only be used when the agent has skills with attached knowledge.",
+        { tracked: false }
+      )
+    );
+  }
+
+  // Resolve DataSourceConfiguration[] to ResolvedDataSourceConfiguration[].
+  const agentDataSourceConfigurations = [];
+  for (const config of dataSourceConfigurations) {
+    const dataSourceView = await DataSourceViewResource.fetchById(
+      auth,
+      config.dataSourceViewId
+    );
+
+    if (!dataSourceView) {
+      return new Err(
+        new MCPError(`Data source view not found: ${config.dataSourceViewId}`, {
+          tracked: false,
+        })
+      );
+    }
+
+    const dataSource = dataSourceView.dataSource;
+
+    agentDataSourceConfigurations.push({
+      ...config,
+      dataSource: {
+        dustAPIProjectId: dataSource.dustAPIProjectId,
+        dustAPIDataSourceId: dataSource.dustAPIDataSourceId,
+        connectorProvider: dataSource.connectorProvider,
+        name: dataSource.name,
+      },
+      dataSourceView,
+    });
+  }
+
+  // Search for the template node.
+  const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
+  const searchResult = await coreAPI.searchNodes({
+    filter: {
+      node_ids: [templateNodeId],
+      data_source_views: makeCoreSearchNodesFilters({
+        agentDataSourceConfigurations,
+      }),
+    },
+  });
+
+  if (searchResult.isErr() || searchResult.value.nodes.length === 0) {
+    return new Err(
+      new MCPError(
+        `Could not find template node: ${templateNodeId}. ${
+          searchResult.isErr()
+            ? `Error: ${searchResult.error.message}`
+            : "The node may not exist or may not be accessible through your skills configuration."
+        }`,
+        { tracked: false }
+      )
+    );
+  }
+
+  const node = searchResult.value.nodes[0];
+  if (node.node_type !== "document") {
+    return new Err(
+      new MCPError(
+        `Template node is of type ${node.node_type}, not a document. Only document nodes can be used as templates.`,
+        { tracked: false }
+      )
+    );
+  }
+
+  // Get dataSource from the data source configuration.
+  const dataSource = agentDataSourceConfigurations.find(
+    (config) => config.dataSource.dustAPIDataSourceId === node.data_source_id
+  )?.dataSource;
+
+  if (!dataSource) {
+    return new Err(
+      new MCPError(
+        `Could not find data source for template node: ${templateNodeId}`,
+        { tracked: false }
+      )
+    );
+  }
+
+  // Read the template node content.
+  const readResult = await coreAPI.getDataSourceDocumentText({
+    dataSourceId: node.data_source_id,
+    documentId: node.node_id,
+    projectId: dataSource.dustAPIProjectId,
+  });
+  if (readResult.isErr()) {
+    return new Err(
+      new MCPError(
+        `Could not read template node: ${templateNodeId}. Error: ${readResult.error.message}`,
+        { tracked: false }
+      )
+    );
+  }
+
+  const templateContent = readResult.value.text;
+  if (templateContent.length > MAX_TEMPLATE_SIZE_BYTES) {
+    return new Err(
+      new MCPError(
+        `Template content is too large (${templateContent.length} bytes). Maximum size is ${MAX_TEMPLATE_SIZE_BYTES} bytes (1MB).`,
+        { tracked: false }
+      )
+    );
+  }
+
+  return new Ok(templateContent);
+}

--- a/front/lib/actions/mcp_internal_actions/servers/interactive_content/template_utils.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/interactive_content/template_utils.ts
@@ -49,12 +49,18 @@ export async function fetchTemplateContent(
 
   // Resolve DataSourceConfiguration[] to ResolvedDataSourceConfiguration[].
   const agentDataSourceConfigurations = [];
-  for (const config of dataSourceConfigurations) {
-    const dataSourceView = await DataSourceViewResource.fetchById(
-      auth,
-      config.dataSourceViewId
-    );
+  const dataSourceViews = await DataSourceViewResource.fetchByIds(
+    auth,
+    dataSourceConfigurations.map((c) => c.dataSourceViewId)
+  );
 
+  const dataSourceViewMap = new Map<string, DataSourceViewResource>();
+  for (const view of dataSourceViews) {
+    dataSourceViewMap.set(view.sId, view);
+  }
+
+  for (const config of dataSourceConfigurations) {
+    const dataSourceView = dataSourceViewMap.get(config.dataSourceViewId);
     if (!dataSourceView) {
       return new Err(
         new MCPError(`Data source view not found: ${config.dataSourceViewId}`, {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Agents can now create Frames using existing content nodes from their skills/knowledge as templates. This enables:
- Efficient content reuse: Reference existing React components, visualizations, or code snippets without repeating large amounts of code
- Token savings: Template content is fetched server-side without consuming context tokens
- Consistency: Use approved/validated templates as starting points for new visualizations

### Usage

When an agent has skills with attached knowledge, template nodes are referenced via `<knowledge id="...">` tags. The agent can now:

```
// Create from template (new capability)
create_interactive_content_file({
  mode: "template",
  source: "dashboard_template_tsx",  // fetches from knowledge
  file_name: "SalesReport.tsx",
  mime_type: "application/vnd.dust.frame+javascript"
})
```

```
// Create with inline content (existing capability)
create_interactive_content_file({
  mode: "inline",
  source: "export default function() { ... }",
  file_name: "CustomChart.tsx",
  mime_type: "application/vnd.dust.frame+javascript"
})
```

### Implementation

Schema Design

Used a discriminated union pattern to make template vs inline creation explicit:
- mode: "template" | "inline" (required discriminator)
- source: single field interpreted based on mode (template ID or content)

This approach was chosen because:
- MCP clients (including Claude Code) don't support anyOf/oneOf at the top level
- Discriminated unions are clearer to LLMs than two optional fields
- Forces explicit mode selection, preventing the agent from ignoring templates

<img width="860" height="1771" alt="image" src="https://github.com/user-attachments/assets/dc239829-7c27-4523-8f83-9bf2881832f4" />

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
This PR changes the existing tool prototype though, which from previous experience isn't great. Let's see how it goes. It's safe to rollback.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
