### PR TITLE
[front] Add dedicated trial-ended page for phone trial users

### DIFF
--- a/front/components/paywall/DontLoseSection.tsx
+++ b/front/components/paywall/DontLoseSection.tsx
@@ -1,0 +1,117 @@
+import {
+  ChatBubbleLeftRightIcon,
+  CloudArrowLeftRightIcon,
+  Icon,
+  RobotIcon,
+  SparklesIcon,
+} from "@dust-tt/sparkle";
+import type { ComponentType } from "react";
+
+import { useAgentConfigurations } from "@app/lib/swr/assistants";
+import type { WorkspaceType } from "@app/types";
+
+interface DontLoseSectionProps {
+  owner: WorkspaceType;
+}
+
+interface DontLoseItemProps {
+  icon: ComponentType;
+  title: string;
+  description: string;
+  isLoading?: boolean;
+}
+
+function DontLoseItem({
+  icon,
+  title,
+  description,
+  isLoading,
+}: DontLoseItemProps) {
+  if (isLoading) {
+    return (
+      <div className="flex items-start gap-3">
+        <div className="h-5 w-5 animate-pulse rounded bg-muted-background dark:bg-muted-background-night" />
+        <div className="flex flex-col gap-1">
+          <div className="h-5 w-32 animate-pulse rounded bg-muted-background dark:bg-muted-background-night" />
+          <div className="h-4 w-48 animate-pulse rounded bg-muted-background dark:bg-muted-background-night" />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-start gap-3">
+      <div className="mt-0.5 shrink-0">
+        <Icon
+          visual={icon}
+          size="sm"
+          className="text-primary-400 dark:text-primary-400-night"
+        />
+      </div>
+      <div className="flex flex-col">
+        <span className="font-semibold text-foreground dark:text-foreground-night">
+          {title}
+        </span>
+        <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+          {description}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+export function DontLoseSection({ owner }: DontLoseSectionProps) {
+  // Fetch agent configurations to get count
+  const {
+    agentConfigurations,
+    isAgentConfigurationsLoading,
+    isAgentConfigurationsError,
+  } = useAgentConfigurations({
+    workspaceId: owner.sId,
+    agentsGetView: "list",
+  });
+
+  const agentCount = agentConfigurations.length;
+
+  const isLoading = isAgentConfigurationsLoading && !isAgentConfigurationsError;
+
+  // Only show agent count if 10 or more agents
+  const agentTitle =
+    !isAgentConfigurationsError && agentCount >= 10
+      ? `Your ${agentCount} custom agents`
+      : "Your custom agents";
+
+  return (
+    <div className="flex flex-col gap-6">
+      <h2 className="text-lg font-semibold text-foreground dark:text-foreground-night">
+        Don't lose:
+      </h2>
+      <div className="flex flex-col gap-5">
+        <DontLoseItem
+          icon={RobotIcon}
+          title={agentTitle}
+          description="All the AI agents you've configured with your workflows"
+          isLoading={isLoading}
+        />
+        <DontLoseItem
+          icon={ChatBubbleLeftRightIcon}
+          title="Your conversation history & context"
+          description="Everything your agents have learned from your interactions"
+          isLoading={isLoading}
+        />
+        <DontLoseItem
+          icon={CloudArrowLeftRightIcon}
+          title="Your connected company data"
+          description="All your connected company data."
+          isLoading={isLoading}
+        />
+        <DontLoseItem
+          icon={SparklesIcon}
+          title="Your advanced AI models access"
+          description="Access to GPT-5, Claude 4.5, Gemini, and Mistral"
+          isLoading={isLoading}
+        />
+      </div>
+    </div>
+  );
+}

--- a/front/components/paywall/TrialPricingCard.tsx
+++ b/front/components/paywall/TrialPricingCard.tsx
@@ -1,0 +1,95 @@
+import {
+  Button,
+  ButtonsSwitch,
+  ButtonsSwitchList,
+  CheckIcon,
+  Icon,
+} from "@dust-tt/sparkle";
+
+import {
+  getPriceWithCurrency,
+  PRO_PLAN_COST_MONTHLY,
+  PRO_PLAN_COST_YEARLY,
+} from "@app/lib/client/subscription";
+import type { BillingPeriod } from "@app/types";
+
+interface TrialPricingCardProps {
+  billingPeriod: BillingPeriod;
+  onBillingPeriodChange: (period: BillingPeriod) => void;
+  onSubscribe: () => void;
+  isSubmitting: boolean;
+}
+
+const FEATURES = [
+  "Advanced AI models: GPT-5, Claude 4.5, Gemini, Mistral...",
+  "Custom agents: Build AI with your company knowledge",
+  "Data connections: Slack, Notion, Google Drive, GitHub...",
+  "Native integrations (Zendesk, Slack, Chrome Extension)",
+  "Email support: Get help when you need it",
+];
+
+export function TrialPricingCard({
+  billingPeriod,
+  onBillingPeriodChange,
+  onSubscribe,
+  isSubmitting,
+}: TrialPricingCardProps) {
+  const price =
+    billingPeriod === "monthly"
+      ? getPriceWithCurrency(PRO_PLAN_COST_MONTHLY)
+      : getPriceWithCurrency(PRO_PLAN_COST_YEARLY);
+
+  return (
+    <div className="flex flex-col gap-6">
+      {/* Price and billing toggle */}
+      <div className="flex items-center justify-between gap-4">
+        <div className="flex items-center gap-1">
+          <span className="text-3xl font-bold tabular-nums text-foreground dark:text-foreground-night">
+            {price}
+          </span>
+          <span className="whitespace-nowrap text-xs leading-tight text-muted-foreground dark:text-muted-foreground-night">
+            per user
+            <br />
+            per month
+          </span>
+        </div>
+
+        {/* Billing toggle */}
+        <ButtonsSwitchList
+          defaultValue={billingPeriod}
+          size="xs"
+          onValueChange={(v) => onBillingPeriodChange(v as BillingPeriod)}
+        >
+          <ButtonsSwitch value="monthly" label="Monthly" />
+          <ButtonsSwitch value="yearly" label="Yearly" />
+        </ButtonsSwitchList>
+      </div>
+
+      {/* Features list */}
+      <ul className="flex flex-col gap-3">
+        {FEATURES.map((feature, index) => (
+          <li key={index} className="flex items-start gap-2">
+            <Icon
+              visual={CheckIcon}
+              size="sm"
+              className="mt-0.5 shrink-0 text-highlight-500 dark:text-highlight-500-night"
+            />
+            <span className="text-sm text-foreground dark:text-foreground-night">
+              {feature}
+            </span>
+          </li>
+        ))}
+      </ul>
+
+      {/* CTA Button */}
+      <Button
+        variant="highlight"
+        size="md"
+        label="Continue with Pro"
+        onClick={onSubscribe}
+        disabled={isSubmitting}
+        className="w-full"
+      />
+    </div>
+  );
+}

--- a/front/pages/w/[wId]/subscribe.tsx
+++ b/front/pages/w/[wId]/subscribe.tsx
@@ -8,10 +8,12 @@ import { ProPlansTable } from "@app/components/plans/ProPlansTable";
 import { UserMenu } from "@app/components/UserMenu";
 import WorkspacePicker from "@app/components/WorkspacePicker";
 import { useSendNotification } from "@app/hooks/useNotification";
+import { getMessageUsageCount } from "@app/lib/api/assistant/rate_limits";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { clientFetch } from "@app/lib/egress/client";
 import { withDefaultUserAuthPaywallWhitelisted } from "@app/lib/iam/session";
 import { isFreeTrialPhonePlan, isOldFreePlan } from "@app/lib/plans/plan_codes";
+import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { useUser } from "@app/lib/swr/user";
 import { useWorkspaceSubscriptions } from "@app/lib/swr/workspaces";
 import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
@@ -26,6 +28,44 @@ export const getServerSideProps = withDefaultUserAuthPaywallWhitelisted<{
     return {
       notFound: true,
     };
+  }
+
+  // Check if current subscription is a phone trial - only redirect admins to trial-ended
+  // Non-admins should stay on /subscribe to see the "Workspace locked" UI
+  if (auth.isAdmin()) {
+    const subscription = auth.subscription();
+    if (subscription && isFreeTrialPhonePlan(subscription.plan.code)) {
+      // Active trial - check if messages are exhausted
+      try {
+        const { count, limit } = await getMessageUsageCount(auth);
+        if (limit !== -1 && count >= limit) {
+          return {
+            redirect: {
+              destination: `/w/${owner.sId}/trial-ended`,
+              permanent: false,
+            },
+          };
+        }
+      } catch {
+        // If we can't check message usage, don't redirect - let them see the subscribe page
+      }
+    } else {
+      // No active subscription or not a phone trial - check if last subscription was an ended phone trial
+      const lastSubscription =
+        await SubscriptionResource.fetchLastByWorkspace(owner);
+      if (
+        lastSubscription &&
+        isFreeTrialPhonePlan(lastSubscription.getPlan().code) &&
+        lastSubscription.toJSON().status === "ended"
+      ) {
+        return {
+          redirect: {
+            destination: `/w/${owner.sId}/trial-ended`,
+            permanent: false,
+          },
+        };
+      }
+    }
   }
 
   return {

--- a/front/pages/w/[wId]/trial-ended.tsx
+++ b/front/pages/w/[wId]/trial-ended.tsx
@@ -1,0 +1,118 @@
+import { Card, ContentMessage, DustLogo } from "@dust-tt/sparkle";
+import type { InferGetServerSidePropsType } from "next";
+import { useRouter } from "next/router";
+import React, { useState } from "react";
+
+import { DontLoseSection } from "@app/components/paywall/DontLoseSection";
+import { TrialPricingCard } from "@app/components/paywall/TrialPricingCard";
+import { ThemeProvider } from "@app/components/sparkle/ThemeContext";
+import { useSendNotification } from "@app/hooks/useNotification";
+import { useSubmitFunction } from "@app/lib/client/utils";
+import { clientFetch } from "@app/lib/egress/client";
+import { withDefaultUserAuthPaywallWhitelisted } from "@app/lib/iam/session";
+import type { BillingPeriod, WorkspaceType } from "@app/types";
+
+export const getServerSideProps = withDefaultUserAuthPaywallWhitelisted<{
+  owner: WorkspaceType;
+}>(async (context, auth) => {
+  const owner = auth.workspace();
+  if (!owner || !auth.isAdmin()) {
+    return {
+      notFound: true,
+    };
+  }
+
+  return {
+    props: {
+      owner,
+    },
+  };
+});
+
+export default function TrialEnded({
+  owner,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  const router = useRouter();
+  const sendNotification = useSendNotification();
+  const [billingPeriod, setBillingPeriod] = useState<BillingPeriod>("monthly");
+
+  const { submit: handleSubscribePlan, isSubmitting } = useSubmitFunction(
+    async (period: BillingPeriod) => {
+      const res = await clientFetch(`/api/w/${owner.sId}/subscriptions`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          billingPeriod: period,
+        }),
+      });
+
+      if (!res.ok) {
+        sendNotification({
+          type: "error",
+          title: "Subscription failed",
+          description: "Failed to subscribe to a new plan.",
+        });
+      } else {
+        const content = await res.json();
+        if (content.checkoutUrl) {
+          await router.push(content.checkoutUrl);
+        } else {
+          sendNotification({
+            type: "error",
+            title: "Subscription failed",
+            description:
+              "Failed to subscribe to a new plan. Please try again in a few minutes.",
+          });
+        }
+      }
+    }
+  );
+
+  return (
+    <ThemeProvider>
+      <main className="flex min-h-screen flex-col items-center justify-center px-4 py-8">
+        {/* Logo and headline */}
+        <div className="mb-12 flex flex-col items-center">
+          <DustLogo className="h-8 w-32" />
+          <h1 className="mt-4 text-xl font-medium text-foreground dark:text-foreground-night">
+            Your free trial has ended
+          </h1>
+        </div>
+
+        {/* Main content: two columns */}
+        <div className="flex w-full max-w-4xl flex-col gap-8 lg:flex-row lg:items-start lg:gap-12">
+          {/* Left column: Don't lose section */}
+          <div className="flex-1">
+            <DontLoseSection owner={owner} />
+          </div>
+
+          {/* Right column: Pricing card */}
+          <Card variant="secondary" size="md" className="flex-1">
+            <TrialPricingCard
+              billingPeriod={billingPeriod}
+              onBillingPeriodChange={setBillingPeriod}
+              onSubscribe={() => handleSubscribePlan(billingPeriod)}
+              isSubmitting={isSubmitting}
+            />
+          </Card>
+        </div>
+
+        {/* Footer banner */}
+        <div className="mt-12 w-full max-w-4xl">
+          <ContentMessage
+            variant="primary"
+            size="lg"
+            className="text-center text-sm"
+          >
+            Without a subscription, your agents and connections will be paused.{" "}
+            <span className="font-semibold">
+              We'll keep your data safe for 30 days.
+            </span>
+          </ContentMessage>
+        </div>
+      </main>
+    </ThemeProvider>
+  );
+}


### PR DESCRIPTION
## Description

This PR adds a dedicated `/trial-ended` page for users whose phone verification free trial has ended or whose message quota is exhausted.

**Changes:**
- New `/w/[wId]/trial-ended` page with redesigned UI:
  - "Don't lose" section showing personalized workspace assets (custom agents count, connected services)
  - Pricing card with monthly/yearly billing toggle, feature list, and CTA
  - Footer banner with data retention message (30 days)
  
- Redirect logic in `subscribe.tsx` to route users to trial-ended when:
  - Their `FREE_TRIAL_PHONE_PLAN` subscription status is "ended"
  - Their trial is active but message quota is exhausted

- New reusable components in `components/paywall/`:
  - `DontLoseSection`: Displays personalized list of workspace assets at risk
  - `TrialPricingCard`: Pricing display with billing period toggle

**Screenshots:**
<img width="1861" height="1241" alt="Screenshot 2026-01-21 at 14 37 22" src="https://github.com/user-attachments/assets/7424011f-804d-4270-9e33-9a6ed051df77" />



## Tests

Tested manually by:
1. Setting up a workspace with an ended `FREE_TRIAL_PHONE_PLAN` subscription
2. Verified redirect from `/subscribe` to `/trial-ended`
3. Tested billing period toggle (monthly/yearly) and verified pricing updates
4. Tested subscribe flow redirects to Stripe checkout
5. Verified error handling when APIs return 403 (ended subscription)

## Risk

Low risk:
- New page only affects users with `FREE_TRIAL_PHONE_PLAN` subscriptions
- Existing subscribe page behavior unchanged for other subscription types
- Graceful fallback when data fetching fails (generic text instead of counts)

## Deploy Plan

Standard deployment. No migrations or feature flags required.