### PR TITLE
[connectors] Reuse same workflowIds

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/workflows.ts
+++ b/connectors/src/connectors/google_drive/temporal/workflows.ts
@@ -612,10 +612,6 @@ export async function googleDriveFullSyncV2({
   }
 }
 
-export function googleDriveFullSyncV2WorkflowId(connectorId: ModelId): string {
-  return `googleDrive-fullSyncV2-${connectorId}`;
-}
-
 /**
  * Child workflow that handles incremental sync for a single drive.
  * Processes all changes for the drive with pagination, and launches folder sync for new folders.
@@ -784,10 +780,4 @@ export async function googleDriveIncrementalSyncV2(
   // Sleep and continue
   await sleep("5 minutes");
   await continueAsNew<typeof googleDriveIncrementalSyncV2>(connectorId);
-}
-
-export function googleDriveIncrementalSyncV2WorkflowId(
-  connectorId: ModelId
-): string {
-  return `googleDrive-incrementalSyncV2-${connectorId}`;
 }


### PR DESCRIPTION
## Description

Use same workflow id for parallel/non parallel (fix production check)

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

none


## Deploy Plan

disable all parallel sync workflows first to terminate workflow with V2 ids
deploy connectors
re-enable them

