### PR TITLE
[Connectors/Microsoft] Handle 401 generalException by skipping affected root resources

### DIFF
--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -33,6 +33,7 @@ import {
 } from "@connectors/connectors/microsoft/lib/utils";
 import {
   isAccessBlockedError,
+  isGeneralExceptionError,
   isItemNotFoundError,
 } from "@connectors/connectors/microsoft/temporal/cast_known_errors";
 import {
@@ -140,6 +141,18 @@ export async function getRootNodesToSyncFromResources(
                   error: error.message,
                 },
                 "Root resource access blocked by administrator, skipping"
+              );
+              return null;
+            }
+            if (isGeneralExceptionError(error)) {
+              logger.warn(
+                {
+                  connectorId,
+                  internalId: resource.internalId,
+                  errorCode: error.code,
+                  errorMessage: error.message,
+                },
+                "Skipping root resource due to 401 generalException - possible site permission change. See https://learn.microsoft.com/en-us/answers/questions/5616949/receiving-general-exception-while-processing-when"
               );
               return null;
             }

--- a/connectors/src/connectors/microsoft/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/microsoft/temporal/cast_known_errors.ts
@@ -40,6 +40,16 @@ export function isAccessBlockedError(err: unknown): err is GraphError {
   );
 }
 
+// 401 with code "generalException" typically indicates site-level permission changes
+// or revoked access. See https://learn.microsoft.com/en-us/answers/questions/5616949/receiving-general-exception-while-processing-when
+export function isGeneralExceptionError(err: unknown): err is GraphError {
+  return (
+    err instanceof GraphError &&
+    err.statusCode === 401 &&
+    err.code === "generalException"
+  );
+}
+
 export class MicrosoftCastKnownErrorsInterceptor implements ActivityInboundCallsInterceptor {
   async execute(
     input: ActivityExecuteInput,


### PR DESCRIPTION
## Description

Context: [Slack thread](https://dust4ai.slack.com/archives/C05F84CFP0E/p1768991339614299)

When a Microsoft connector encounters a 401 `generalException` error on a root resource, it now skips that resource with a warning log instead of retrying indefinitely.

This error typically indicates site-level permission changes (admin revoked access, site restructured, etc.) that won't be resolved by retries. See [Microsoft Q&A](https://learn.microsoft.com/en-us/answers/questions/2279548) for details on possible causes.

## Risks

Blast radius: Microsoft connector incremental sync
Risk: low - gracefully degrades by skipping inaccessible resources

## Deploy Plan
- pmrr
- deploy connectors