### PR TITLE
skills: improve UI to display similar skills

### DIFF
--- a/front/components/skill_builder/SimilarSkillsDisplay.tsx
+++ b/front/components/skill_builder/SimilarSkillsDisplay.tsx
@@ -1,8 +1,4 @@
-import {
-  ContentMessage,
-  InformationCircleIcon,
-  Spinner,
-} from "@dust-tt/sparkle";
+import { Spinner } from "@dust-tt/sparkle";
 
 import { getSkillAvatarIcon } from "@app/lib/skill";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
@@ -30,37 +26,32 @@ export function SimilarSkillsDisplay({
   }
 
   return (
-    <ContentMessage
-      variant="outline"
-      size="md"
-      title="Similar skills found"
-      icon={InformationCircleIcon}
-    >
-      <div className="mt-2 space-y-3">
+    <div className="space-y-3">
+      <div className="flex items-center gap-2">
+        <span className="heading-sm text-foreground dark:text-foreground-night">
+          Similar skills found
+        </span>
+        {isLoading && <Spinner size="xs" />}
+      </div>
+      <div className="space-y-3">
         {similarSkills.map((skill) => {
           const SkillAvatar = getSkillAvatarIcon(skill.icon);
 
           return (
-            <div key={skill.sId} className="flex items-start gap-2">
-              <SkillAvatar name={skill.name} size="xs" />
+            <div key={skill.sId} className="flex items-start gap-3">
+              <SkillAvatar name={skill.name} size="sm" />
               <div className="flex flex-col">
                 <span className="text-sm font-medium text-foreground dark:text-foreground-night">
                   {skill.name}
                 </span>
-                <span className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+                <span className="line-clamp-1 text-xs text-muted-foreground dark:text-muted-foreground-night">
                   {skill.agentFacingDescription}
                 </span>
               </div>
             </div>
           );
         })}
-        {isLoading && (
-          <div className="flex items-center gap-2 text-sm text-muted-foreground dark:text-muted-foreground-night">
-            <Spinner size="xs" />
-            <span>Checking for similar skills...</span>
-          </div>
-        )}
       </div>
-    </ContentMessage>
+    </div>
   );
 }


### PR DESCRIPTION
## Description

 - remove surrounding line
 - remove icon near "Similar skills found"
 - make icons bigger
 - truncate description at the end of first line
 - spinner is after "Similar skills found" when thre are found skills


Remaining: Links to skill page when it exists

## Tests

### When nothing is found yet
<img width="1364" height="600" alt="image" src="https://github.com/user-attachments/assets/24844f94-587d-4733-b8a0-919267d89c3b" />

### Skill displayed:
<img width="2044" height="744" alt="image" src="https://github.com/user-attachments/assets/af250544-74ec-44bc-81cd-547ec594f060" />

### Skill displayed + loading
<img width="1930" height="870" alt="image" src="https://github.com/user-attachments/assets/d3ec511b-7295-41e5-bdc5-7d1b87145eac" />

## Risk

low, behind feature flag

## Deploy Plan

deploy front
