### PR TITLE
[Connectors/Microsoft] Handle access blocked errors gracefully

### DIFF
--- a/connectors/src/connectors/microsoft/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/microsoft/temporal/cast_known_errors.ts
@@ -29,6 +29,17 @@ export function isItemNotFoundError(err: unknown): err is GraphError {
   );
 }
 
+// 423 Locked with code "notAllowed" indicates a SharePoint site has been blocked
+// by an administrator. This is an external permission restriction that cannot
+// be resolved in-product.
+export function isAccessBlockedError(err: unknown): err is GraphError {
+  return (
+    err instanceof GraphError &&
+    err.statusCode === 423 &&
+    err.code === "notAllowed"
+  );
+}
+
 export class MicrosoftCastKnownErrorsInterceptor implements ActivityInboundCallsInterceptor {
   async execute(
     input: ActivityExecuteInput,


### PR DESCRIPTION
## Description

When a SharePoint site is blocked by an administrator, the Microsoft Graph API returns a 423 Locked error with code `notAllowed`. Previously, this caused the `getRootNodesToSync` activity to fail and retry indefinitely.

This PR adds an `isAccessBlockedError` helper and catches this error when:
- Fetching root folders/drives
- Fetching site drives

Instead of failing, the blocked site/drive is skipped with a warning log.

## Risks

Blast radius: Microsoft connector sync for workspaces with admin-blocked SharePoint sites
Risk: low

## Deploy Plan
- pmrr
- deploy connectors