### PR TITLE
Add pending agent state as soon as we create the agent

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -304,7 +304,6 @@ export default function AgentBuilder({
       return;
     }
 
-    console.log("[AgentBuilder] Creating pending agent...");
     const createPendingAgent = async () => {
       try {
         const response = await clientFetch(

--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -40,6 +40,7 @@ import { appLayoutBack } from "@app/components/sparkle/AppContentLayout";
 import { FormProvider } from "@app/components/sparkle/FormProvider";
 import { useNavigationLock } from "@app/hooks/useNavigationLock";
 import { useSendNotification } from "@app/hooks/useNotification";
+import { clientFetch } from "@app/lib/egress/client";
 import type { AdditionalConfigurationType } from "@app/lib/models/agent/actions/mcp";
 import { useAppRouter } from "@app/lib/platform";
 import { useAgentConfigurationActions } from "@app/lib/swr/actions";
@@ -98,6 +99,7 @@ export default function AgentBuilder({
   const sendNotification = useSendNotification(true);
   const [isSaving, setIsSaving] = useState(false);
   const [isCreatedDialogOpen, setIsCreatedDialogOpen] = useState(false);
+  const [pendingAgentSId, setPendingAgentSId] = useState<string | null>(null);
 
   const { actions, isActionsLoading } = useAgentConfigurationActions(
     owner.sId,
@@ -295,6 +297,39 @@ export default function AgentBuilder({
     void removeParamFromRouter(router, "showCreatedDialog");
   }, [agentConfiguration, router, router.query.showCreatedDialog]);
 
+  // Create pending agent on mount for NEW agents only
+  useEffect(() => {
+    // Only create pending agent for new agents (not editing or duplicating)
+    if (agentConfiguration || duplicateAgentId || pendingAgentSId) {
+      return;
+    }
+
+    console.log("[AgentBuilder] Creating pending agent...");
+    const createPendingAgent = async () => {
+      try {
+        const response = await clientFetch(
+          `/api/w/${owner.sId}/assistant/agent_configurations/create-pending`,
+          { method: "POST" }
+        );
+        if (response.ok) {
+          const data = await response.json();
+          setPendingAgentSId(data.sId);
+        } else {
+          datadogLogger.error(
+            { status: response.status },
+            "[Agent builder] - Failed to create pending agent"
+          );
+        }
+      } catch (error) {
+        datadogLogger.error(
+          { error: normalizeError(error) },
+          "[Agent builder] - Failed to create pending agent"
+        );
+      }
+    };
+    void createPendingAgent();
+  }, [agentConfiguration, duplicateAgentId, owner.sId, pendingAgentSId]);
+
   const handleSubmit = async (formData: AgentBuilderFormData) => {
     try {
       setIsSaving(true);
@@ -304,15 +339,19 @@ export default function AgentBuilder({
         return;
       }
 
+      // For new agents (not editing or duplicating), use pendingAgentSId as agentConfigurationId
+      // For duplicating, pass null to create a new agent
+      // For editing, pass the existing agent's sId
+      const effectiveAgentConfigurationId = duplicateAgentId
+        ? null
+        : (agentConfiguration?.sId ?? pendingAgentSId ?? null);
+
       const result = await submitAgentBuilderForm({
         user,
         formData,
         owner,
         isDraft: false,
-        agentConfigurationId: duplicateAgentId
-          ? null
-          : // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-            agentConfiguration?.sId || null,
+        agentConfigurationId: effectiveAgentConfigurationId,
         areSlackChannelsChanged: form.getFieldState(
           "agentSettings.slackChannels"
         ).isDirty,

--- a/front/lib/api/assistant/configuration/agent.test.ts
+++ b/front/lib/api/assistant/configuration/agent.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createAgentConfiguration,
+  createPendingAgentConfiguration,
+} from "@app/lib/api/assistant/configuration/agent";
+import { Authenticator } from "@app/lib/auth";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+
+describe("createAgentConfiguration with pending agent", () => {
+  it("converts pending agent to active when agentConfigurationId points to a pending agent", async () => {
+    const { authenticator, workspace, user } = await createResourceTest({
+      role: "admin",
+    });
+
+    // Create a pending agent using the helper function
+    const { sId: pendingSId } =
+      await createPendingAgentConfiguration(authenticator);
+
+    // Convert the pending agent to active by passing its sId as agentConfigurationId
+    const result = await createAgentConfiguration(authenticator, {
+      name: "My New Agent",
+      description: "A test agent",
+      instructions: "Test instructions",
+      pictureUrl: "https://dust.tt/static/systemavatar/test_avatar_1.png",
+      status: "active",
+      scope: "hidden",
+      model: {
+        providerId: "anthropic",
+        modelId: "claude-sonnet-4-5-20250929",
+        temperature: 0.5,
+      },
+      agentConfigurationId: pendingSId,
+      templateId: null,
+      requestedSpaceIds: [],
+      tags: [],
+      editors: [user.toJSON()],
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value.sId).toBe(pendingSId);
+      expect(result.value.status).toBe("active");
+      expect(result.value.name).toBe("My New Agent");
+      expect(result.value.description).toBe("A test agent");
+    }
+
+    const agent = await AgentConfigurationModel.findOne({
+      where: { sId: pendingSId, workspaceId: workspace.id },
+    });
+    expect(agent).not.toBeNull();
+    expect(agent!.status).toBe("active");
+    expect(agent!.name).toBe("My New Agent");
+    expect(agent!.version).toBe(0); // Version should remain 0 (updated in place)
+  });
+
+  it("creates new agent if agentConfigurationId does not exist", async () => {
+    const { authenticator, user } = await createResourceTest({
+      role: "admin",
+    });
+
+    const nonExistentSId = generateRandomModelSId();
+
+    const result = await createAgentConfiguration(authenticator, {
+      name: "Fallback Agent",
+      description: "Test",
+      instructions: null,
+      pictureUrl: "https://dust.tt/static/systemavatar/test_avatar_1.png",
+      status: "active",
+      scope: "hidden",
+      model: {
+        providerId: "anthropic",
+        modelId: "claude-sonnet-4-5-20250929",
+        temperature: 0.7,
+      },
+      agentConfigurationId: nonExistentSId,
+      templateId: null,
+      requestedSpaceIds: [],
+      tags: [],
+      editors: [user.toJSON()],
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      // Should have created a new agent with the provided sId
+      expect(result.value.sId).toBe(nonExistentSId);
+      expect(result.value.name).toBe("Fallback Agent");
+      expect(result.value.status).toBe("active");
+    }
+  });
+
+  it("returns error when trying to update pending agent owned by different user", async () => {
+    const { authenticator, workspace, user } = await createResourceTest({
+      role: "admin",
+    });
+
+    // Create another user in the same workspace
+    const otherUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, otherUser, {
+      role: "builder",
+    });
+    const otherAuthenticator = await Authenticator.fromUserIdAndWorkspaceId(
+      otherUser.sId,
+      workspace.sId
+    );
+
+    // Create a pending agent owned by the other user using the helper function
+    const { sId: pendingSId } =
+      await createPendingAgentConfiguration(otherAuthenticator);
+
+    // Should throw because pending agents owned by other users cannot be updated
+    await expect(
+      createAgentConfiguration(authenticator, {
+        name: "My Agent",
+        description: "Test",
+        instructions: null,
+        pictureUrl: "https://dust.tt/static/systemavatar/test_avatar_1.png",
+        status: "active",
+        scope: "hidden",
+        model: {
+          providerId: "anthropic",
+          modelId: "claude-sonnet-4-5-20250929",
+          temperature: 0.7,
+        },
+        agentConfigurationId: pendingSId,
+        templateId: null,
+        requestedSpaceIds: [],
+        tags: [],
+        editors: [user.toJSON()],
+      })
+    ).rejects.toThrow("Cannot update a pending agent owned by another user.");
+  });
+
+  it("creates new version if agent is not in pending status", async () => {
+    const { authenticator, user } = await createResourceTest({
+      role: "admin",
+    });
+
+    // Create an active agent (not pending) using the factory
+    const existingAgent =
+      await AgentConfigurationFactory.createTestAgent(authenticator);
+
+    const result = await createAgentConfiguration(authenticator, {
+      name: "Updated Agent",
+      description: "Test",
+      instructions: null,
+      pictureUrl: "https://dust.tt/static/systemavatar/test_avatar_1.png",
+      status: "active",
+      scope: "hidden",
+      model: {
+        providerId: "anthropic",
+        modelId: "claude-sonnet-4-5-20250929",
+        temperature: 0.7,
+      },
+      agentConfigurationId: existingAgent.sId,
+      templateId: null,
+      requestedSpaceIds: [],
+      tags: [],
+      editors: [user.toJSON()],
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      // Should have created a new version since the agent is not pending
+      expect(result.value.sId).toBe(existingAgent.sId);
+      expect(result.value.name).toBe("Updated Agent");
+      expect(result.value.version).toBe(1); // Version bumped
+    }
+  });
+});

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -762,6 +762,7 @@ function canAccessAgent(
     case "disabled_missing_datasource":
     case "disabled_by_admin":
     case "archived":
+    case "pending":
       return false;
     default:
       assertNever(agentConfiguration.status);

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/index.test.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/index.test.ts
@@ -1,6 +1,7 @@
 import type { RequestMethod } from "node-mocks-http";
 import { describe, expect, it, vi } from "vitest";
 
+import { createPendingAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { getResourceIdFromSId } from "@app/lib/resources/string_ids";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
@@ -145,5 +146,61 @@ describe("PATCH /api/w/[wId]/assistant/agent_configurations/[aId] - additionalRe
     expect(agentConfigurationModel?.requestedSpaceIds).toContain(
       openSpaceModelId
     );
+  });
+});
+
+describe("PATCH /api/w/[wId]/assistant/agent_configurations/[aId] - pending agent", () => {
+  it("should convert a pending agent to active with version 0", async () => {
+    const { req, res, workspace, user, authenticator } = await setupTest();
+
+    await SpaceFactory.defaults(authenticator);
+
+    // Create a pending agent using the helper function
+    const { sId: pendingSId } =
+      await createPendingAgentConfiguration(authenticator);
+
+    req.query = { ...req.query, wId: workspace.sId, aId: pendingSId };
+    req.body = {
+      assistant: {
+        name: "My New Agent",
+        description: "A test agent converted from pending",
+        instructions: "Test instructions",
+        pictureUrl: "https://dust.tt/static/systemavatar/test_avatar_1.png",
+        status: "active",
+        scope: "hidden",
+        model: {
+          providerId: "anthropic",
+          modelId: "claude-sonnet-4-5-20250929",
+          temperature: 0.5,
+        },
+        actions: [],
+        templateId: null,
+        tags: [],
+        editors: [{ sId: user.sId }],
+        skills: [],
+        additionalRequestedSpaceIds: [],
+      },
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const data = res._getJSONData();
+    expect(data).toHaveProperty("agentConfiguration");
+    // Verify the sId is preserved
+    expect(data.agentConfiguration.sId).toBe(pendingSId);
+    // Verify the status changed to active
+    expect(data.agentConfiguration.status).toBe("active");
+    // Verify the name was updated
+    expect(data.agentConfiguration.name).toBe("My New Agent");
+    // Verify version is 0 (not incremented since pending was deleted and new created)
+    expect(data.agentConfiguration.version).toBe(0);
+
+    // Verify only one record exists for this sId (pending was deleted)
+    const agents = await AgentConfigurationModel.findAll({
+      where: { sId: pendingSId, workspaceId: workspace.id },
+    });
+    expect(agents).toHaveLength(1);
+    expect(agents[0].status).toBe("active");
   });
 });

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/create-pending.test.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/create-pending.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+
+import handler from "./create-pending";
+
+describe("POST /api/w/[wId]/assistant/agent_configurations/create-pending", () => {
+  it("creates a pending agent and returns sId, pending agent has correct status and placeholder values", async () => {
+    const { req, res, workspace, user } = await createPrivateApiMockRequest({
+      method: "POST",
+    });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const response = res._getJSONData();
+    expect(response).toHaveProperty("sId");
+    expect(typeof response.sId).toBe("string");
+    expect(response.sId.length).toBeGreaterThan(0);
+
+    const { sId } = response;
+
+    // Verify the agent was created in the database
+    const agent = await AgentConfigurationModel.findOne({
+      where: { sId, workspaceId: workspace.id },
+    });
+
+    expect(agent).not.toBeNull();
+    expect(agent!.status).toBe("pending");
+    expect(agent!.scope).toBe("hidden");
+    expect(agent!.name).toBe("__PENDING__");
+    expect(agent!.description).toBe("");
+    expect(agent!.workspaceId).toBe(workspace.id);
+    expect(agent!.authorId).toBe(user.id);
+    expect(agent!.version).toBe(0);
+  });
+
+  it("returns 405 for non-POST methods", async () => {
+    for (const method of ["GET", "PUT", "DELETE", "PATCH"] as const) {
+      const { req, res } = await createPrivateApiMockRequest({
+        method,
+      });
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(405);
+      expect(res._getJSONData()).toEqual({
+        error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, POST is expected.",
+        },
+      });
+    }
+  });
+});

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/create-pending.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/create-pending.ts
@@ -1,0 +1,45 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { createPendingAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+
+export type PostPendingAgentResponseBody = {
+  sId: string;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<PostPendingAgentResponseBody>>,
+  auth: Authenticator
+): Promise<void> {
+  if (!auth.user()) {
+    return apiError(req, res, {
+      status_code: 401,
+      api_error: {
+        type: "not_authenticated",
+        message: "You must be authenticated to create a pending agent.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "POST": {
+      const { sId } = await createPendingAgentConfiguration(auth);
+      return res.status(200).json({ sId });
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, POST is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/types/api/internal/agent_configuration.ts
+++ b/front/types/api/internal/agent_configuration.ts
@@ -192,6 +192,7 @@ export const PostOrPatchAgentConfigurationRequestBodySchema = t.type({
         t.literal("active"),
         t.literal("archived"),
         t.literal("draft"),
+        t.literal("pending"),
       ]),
       scope: t.union([t.literal("hidden"), t.literal("visible")]),
       model: t.intersection([ModelConfigurationSchema, IsSupportedModelSchema]),

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -36,8 +36,11 @@ export type GlobalAgentStatus =
  *   version
  * - "draft" is used for the "try" button in builder, when the agent is not yet
  *   fully created / updated
+ * - "pending" is used when the agent builder is opened for a new agent, before
+ *   it is saved for the first time (allows capturing sId early). It allows having
+ *   a sId before creating the agent.
  */
-export type AgentStatus = "active" | "archived" | "draft";
+export type AgentStatus = "active" | "archived" | "draft" | "pending";
 export type AgentConfigurationStatus = AgentStatus | GlobalAgentStatus;
 
 /**

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -792,7 +792,9 @@ const GlobalAgentStatusSchema = FlexibleEnumSchema<
   | "disabled_free_workspace"
 >();
 
-const AgentStatusSchema = FlexibleEnumSchema<"active" | "archived" | "draft">();
+const AgentStatusSchema = FlexibleEnumSchema<
+  "active" | "archived" | "draft" | "pending"
+>();
 
 const AgentConfigurationStatusSchema = z.union([
   AgentStatusSchema,


### PR DESCRIPTION
## Description

Create a new state for agent called "pending"
Agents are immediately created with this state when we open the "Create agent" page
Upon saving the agent, the agent is updated to be active with all the actual values.

The purpose is to have an SID which won't change when we actually create the agent, so suggestions made before agent creation can be linked to this sid and stored.

Note: there is already a "draft" state which exists. This is used to create agent for the "Preview" tab in the agent builder. they work differently as a new agent with new SID is created at each save, which is not what we want (we want fix SID). that's why we introduce a new state.

## Tests
manual + unit tests

Here is the database state when first creating the pending one and the updating it to active: the SID stay the same

<img width="1576" height="504" alt="image" src="https://github.com/user-attachments/assets/e0dd4039-1a38-4833-afa9-a4da550aec3b" />


## Risk

Adding complexity in the way we handle agent states

## Deploy Plan

deploy front
