### PR TITLE
Refactor to only use group models ids in authenticator with a raw query, significantly reducing memory usage.

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/agent_router.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/agent_router.ts
@@ -42,7 +42,7 @@ function createServer(
       },
       async () => {
         const owner = auth.getNonNullableWorkspace();
-        const requestedGroupIds = auth.groups().map((g) => g.sId);
+        const requestedGroupIds = auth.groupIds();
 
         const prodCredentials = await prodAPICredentialsForOwner(owner);
         const api = new DustAPI(
@@ -107,7 +107,7 @@ function createServer(
       },
       async ({ userMessage }) => {
         const owner = auth.getNonNullableWorkspace();
-        const requestedGroupIds = auth.groups().map((g) => g.sId);
+        const requestedGroupIds = auth.groupIds();
 
         const prodCredentials = await prodAPICredentialsForOwner(owner);
         const api = new DustAPI(

--- a/front/lib/actions/mcp_internal_actions/servers/run_dust_app.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/run_dust_app.ts
@@ -127,7 +127,7 @@ async function prepareAppContext(
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         userId: auth.user()?.sId || "no_user",
         role: auth.role(),
-        groupIds: auth.groups().map((g) => g.sId),
+        groupIds: auth.groupIds(),
         actionConfig,
         dustAppConfiguration: actionConfig.dustAppConfiguration,
         appId: actionConfig.dustAppConfiguration?.appId,
@@ -148,7 +148,7 @@ async function prepareAppContext(
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         userId: auth.user()?.sId || "no_user",
         role: auth.role(),
-        groupIds: auth.groups().map((g) => g.sId),
+        groupIds: auth.groupIds(),
         appId: actionConfig.dustAppConfiguration.appId,
         actionConfig,
       },
@@ -418,7 +418,7 @@ export default async function createServer(
             auth
           );
 
-          const requestedGroupIds = auth.groups().map((g) => g.sId);
+          const requestedGroupIds = auth.groupIds();
 
           const prodCredentials = await prodAPICredentialsForOwner(owner);
           const apiConfig = config.getDustAPIConfig();

--- a/front/lib/actions/mcp_internal_actions/servers/toolsets.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/toolsets.ts
@@ -39,7 +39,7 @@ function createServer(
             .map((action) => action.mcpServerViewId) ?? [];
 
         const owner = auth.getNonNullableWorkspace();
-        const requestedGroupIds = auth.groups().map((g) => g.sId);
+        const requestedGroupIds = auth.groupIds();
         const prodCredentials = await prodAPICredentialsForOwner(owner, {
           useLocalInDev: true,
         });
@@ -116,7 +116,7 @@ function createServer(
           return new Err(new MCPError("User not found", { tracked: false }));
         }
 
-        const requestedGroupIds = auth.groups().map((g) => g.sId);
+        const requestedGroupIds = auth.groupIds();
         const prodCredentials = await prodAPICredentialsForOwner(owner, {
           useLocalInDev: true,
         });

--- a/front/lib/api/agent_actions.ts
+++ b/front/lib/api/agent_actions.ts
@@ -31,15 +31,9 @@ export async function getToolsUsage(
   }
 
   const getAgentsForUser = async () =>
-    (
-      await GroupResource.findAgentIdsForGroups(
-        auth,
-        auth
-          .groups()
-          .filter((g) => g.kind === "agent_editors")
-          .map((g) => g.id)
-      )
-    ).map((g) => g.agentConfigurationId);
+    (await GroupResource.findAgentIdsForGroups(auth, auth.groupModelIds())).map(
+      (g) => g.agentConfigurationId
+    );
 
   const getAgentWhereClauseAdmin = () => ({
     status: "active",

--- a/front/lib/api/agent_data_sources.ts
+++ b/front/lib/api/agent_data_sources.ts
@@ -77,15 +77,9 @@ export async function getDataSourceViewsUsageByCategory({
   }
 
   const getAgentsForUser = async () =>
-    (
-      await GroupResource.findAgentIdsForGroups(
-        auth,
-        auth
-          .groups()
-          .filter((g) => g.kind === "agent_editors")
-          .map((g) => g.id)
-      )
-    ).map((g) => g.agentConfigurationId);
+    (await GroupResource.findAgentIdsForGroups(auth, auth.groupModelIds())).map(
+      (g) => g.agentConfigurationId
+    );
 
   const getAgentWhereClauseAdmin = () => ({
     status: "active",

--- a/front/lib/api/agent_triggers.ts
+++ b/front/lib/api/agent_triggers.ts
@@ -25,15 +25,9 @@ async function getAccessibleAgentsInfoBySId({
   }
 
   const getAgentsForUser = async () =>
-    (
-      await GroupResource.findAgentIdsForGroups(
-        auth,
-        auth
-          .groups()
-          .filter((g) => g.kind === "agent_editors")
-          .map((g) => g.id)
-      )
-    ).map((g) => g.agentConfigurationId);
+    (await GroupResource.findAgentIdsForGroups(auth, auth.groupModelIds())).map(
+      (g) => g.agentConfigurationId
+    );
 
   const agentWhereClause = auth.isAdmin()
     ? {

--- a/front/lib/api/assistant/configuration/helpers.ts
+++ b/front/lib/api/assistant/configuration/helpers.ts
@@ -114,12 +114,7 @@ export async function enrichAgentConfigurations<V extends AgentFetchVariant>(
   let editorIds = agentIdsForUserAsEditor;
   if (!editorIds) {
     const agentIdsForGroups = user
-      ? await GroupResource.findAgentIdsForGroups(auth, [
-          ...auth
-            .groups()
-            .filter((g) => g.kind === "agent_editors")
-            .map((g) => g.id),
-        ])
+      ? await GroupResource.findAgentIdsForGroups(auth, auth.groupModelIds())
       : [];
 
     editorIds = agentIdsForGroups.map((g) => g.agentConfigurationId);

--- a/front/lib/api/assistant/configuration/views.ts
+++ b/front/lib/api/assistant/configuration/views.ts
@@ -284,12 +284,7 @@ async function fetchWorkspaceAgentConfigurationsForView(
   const user = auth.user();
 
   const agentIdsForGroups = user
-    ? await GroupResource.findAgentIdsForGroups(auth, [
-        ...auth
-          .groups()
-          .filter((g) => g.kind === "agent_editors")
-          .map((g) => g.id),
-      ])
+    ? await GroupResource.findAgentIdsForGroups(auth, auth.groupModelIds())
     : [];
 
   const agentIdsForUserAsEditor = agentIdsForGroups.map(

--- a/front/lib/api/llm/tests/conversations.ts
+++ b/front/lib/api/llm/tests/conversations.ts
@@ -31,7 +31,7 @@ function createMockAuthenticator(): Authenticator {
     workspace: null,
     user: null,
     role: "none",
-    groups: [],
+    groupModelIds: [],
     subscription: null,
     authMethod: "internal",
   });

--- a/front/lib/api/user.test.ts
+++ b/front/lib/api/user.test.ts
@@ -29,7 +29,7 @@ describe("getUserForWorkspace", () => {
     const auth = new Authenticator({
       user: user1,
       role: "none",
-      groups: [],
+      groupModelIds: [],
       workspace: null,
       subscription: null,
       authMethod: "internal",
@@ -55,7 +55,7 @@ describe("getUserForWorkspace", () => {
       workspace: workspace1Resource,
       user: user1,
       role: "none",
-      groups: [],
+      groupModelIds: [],
       subscription: null,
       authMethod: "internal",
     });
@@ -81,7 +81,7 @@ describe("getUserForWorkspace", () => {
       workspace: workspace1Resource,
       user: user1,
       role: "user",
-      groups: [],
+      groupModelIds: [],
       subscription: null,
       authMethod: "internal",
     });
@@ -106,7 +106,7 @@ describe("getUserForWorkspace", () => {
       workspace: workspace1Resource,
       user: user1,
       role: "user",
-      groups: [],
+      groupModelIds: [],
       subscription: null,
       authMethod: "internal",
     });
@@ -133,7 +133,7 @@ describe("getUserForWorkspace", () => {
       workspace: workspace1Resource,
       user: user1,
       role: "user",
-      groups: [],
+      groupModelIds: [],
       subscription: null,
       authMethod: "internal",
     });
@@ -157,7 +157,7 @@ describe("getUserForWorkspace", () => {
       workspace: workspace1Resource,
       user: user1,
       role: "user",
-      groups: [],
+      groupModelIds: [],
       subscription: null,
       authMethod: "internal",
     });
@@ -188,7 +188,7 @@ describe("getUserForWorkspace", () => {
       workspace: workspace1Resource,
       user: user1,
       role: "admin",
-      groups: [],
+      groupModelIds: [],
       subscription: null,
       authMethod: "internal",
     });
@@ -200,7 +200,7 @@ describe("getUserForWorkspace", () => {
       workspace: workspace1Resource,
       user: user1,
       role: "user",
-      groups: [],
+      groupModelIds: [],
       subscription: null,
       authMethod: "internal",
     });
@@ -226,7 +226,7 @@ describe("getUserForWorkspace", () => {
       workspace: workspace1Resource,
       user: user1,
       role: "user",
-      groups: [],
+      groupModelIds: [],
       subscription: null,
       authMethod: "internal",
     });
@@ -254,7 +254,7 @@ describe("getUserForWorkspace", () => {
       workspace: workspace1Resource,
       user: user1,
       role: "user",
-      groups: [],
+      groupModelIds: [],
       subscription: null,
       authMethod: "internal",
     });
@@ -281,7 +281,7 @@ describe("getUserForWorkspace", () => {
       workspace: workspace1Resource,
       user: superUser,
       role: "admin",
-      groups: [],
+      groupModelIds: [],
       subscription: null,
     });
 

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -29,7 +29,6 @@ import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import type {
   APIErrorWithStatusCode,
-  GroupType,
   LightWorkspaceType,
   ModelId,
   PermissionType,
@@ -50,6 +49,7 @@ import {
   isString,
   isUser,
   Ok,
+  removeNulls,
   WHITELISTABLE_FEATURES,
 } from "@app/types";
 
@@ -93,7 +93,7 @@ export class Authenticator {
   _role: RoleType;
   _subscription: SubscriptionResource | null;
   _user: UserResource | null;
-  _groups: GroupResource[];
+  _groupModelIds: ModelId[];
   _workspace: WorkspaceResource | null;
   _authMethod: AuthMethodType;
 
@@ -102,7 +102,7 @@ export class Authenticator {
     workspace,
     user,
     role,
-    groups,
+    groupModelIds,
     authMethod,
     subscription,
     key,
@@ -110,7 +110,7 @@ export class Authenticator {
     workspace?: WorkspaceResource | null;
     user?: UserResource | null;
     role: RoleType;
-    groups: GroupResource[];
+    groupModelIds: ModelId[];
     authMethod: AuthMethodType;
     subscription?: SubscriptionResource | null;
     key?: KeyAuthType;
@@ -119,7 +119,7 @@ export class Authenticator {
     this._workspace = workspace || null;
     // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     this._user = user || null;
-    this._groups = groups;
+    this._groupModelIds = groupModelIds;
     this._role = role;
     // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     this._subscription = subscription || null;
@@ -198,16 +198,16 @@ export class Authenticator {
       ]);
 
       let role = "none" as RoleType;
-      let groups: GroupResource[] = [];
+      let groupModelIds: ModelId[] = [];
       let subscription: SubscriptionResource | null = null;
 
       if (user && workspace) {
-        [role, groups, subscription] = await Promise.all([
+        [role, groupModelIds, subscription] = await Promise.all([
           MembershipResource.getActiveRoleForUserInWorkspace({
             user,
             workspace: renderLightWorkspaceType({ workspace }),
           }),
-          GroupResource.listUserGroupsInWorkspace({
+          GroupResource.listUserGroupModelIdsInWorkspace({
             user,
             workspace: renderLightWorkspaceType({ workspace }),
           }),
@@ -222,7 +222,7 @@ export class Authenticator {
         workspace,
         user,
         role,
-        groups,
+        groupModelIds,
         subscription,
       });
     });
@@ -230,11 +230,12 @@ export class Authenticator {
 
   async refresh({ transaction }: { transaction?: Transaction } = {}) {
     if (this._user && this._workspace) {
-      this._groups = await GroupResource.listUserGroupsInWorkspace({
-        user: this._user,
-        workspace: renderLightWorkspaceType({ workspace: this._workspace }),
-        transaction,
-      });
+      this._groupModelIds =
+        await GroupResource.listUserGroupModelIdsInWorkspace({
+          user: this._user,
+          workspace: renderLightWorkspaceType({ workspace: this._workspace }),
+          transaction,
+        });
     } else {
       return;
     }
@@ -279,7 +280,7 @@ export class Authenticator {
       workspace,
       user,
       role: user?.isDustSuperUser ? "admin" : "none",
-      groups,
+      groupModelIds: groups.map((g) => g.id),
       subscription,
     });
   }
@@ -301,16 +302,16 @@ export class Authenticator {
     ]);
 
     let role: RoleType = "none";
-    let groups: GroupResource[] = [];
+    let groupModelIds: ModelId[] = [];
     let subscription: SubscriptionResource | null = null;
 
     if (user && workspace) {
-      [role, groups, subscription] = await Promise.all([
+      [role, groupModelIds, subscription] = await Promise.all([
         MembershipResource.getActiveRoleForUserInWorkspace({
           user,
           workspace: renderLightWorkspaceType({ workspace }),
         }),
-        GroupResource.listUserGroupsInWorkspace({
+        GroupResource.listUserGroupModelIdsInWorkspace({
           user,
           workspace: renderLightWorkspaceType({ workspace }),
         }),
@@ -325,7 +326,7 @@ export class Authenticator {
       workspace,
       user,
       role,
-      groups,
+      groupModelIds,
       subscription,
     });
   }
@@ -353,15 +354,15 @@ export class Authenticator {
     }
 
     let role = "none" as RoleType;
-    let groups: GroupResource[] = [];
+    let groupModelIds: ModelId[] = [];
     let subscription: SubscriptionResource | null = null;
 
-    [role, groups, subscription] = await Promise.all([
+    [role, groupModelIds, subscription] = await Promise.all([
       MembershipResource.getActiveRoleForUserInWorkspace({
         user: user,
         workspace: renderLightWorkspaceType({ workspace }),
       }),
-      GroupResource.listUserGroupsInWorkspace({
+      GroupResource.listUserGroupModelIdsInWorkspace({
         user,
         workspace: renderLightWorkspaceType({ workspace }),
       }),
@@ -374,7 +375,7 @@ export class Authenticator {
       new Authenticator({
         authMethod: "oauth",
         workspace,
-        groups,
+        groupModelIds,
         user,
         role,
         subscription,
@@ -465,7 +466,7 @@ export class Authenticator {
       workspaceAuth: new Authenticator({
         authMethod: key.isSystem ? "system_api_key" : "api_key",
         // If the key is associated with the workspace, we associate the groups.
-        groups: isKeyWorkspace ? allGroups : [],
+        groupModelIds: isKeyWorkspace ? allGroups.map((g) => g.id) : [],
         key: key.toAuthJSON(),
         role,
         subscription: workspaceSubscription,
@@ -473,7 +474,7 @@ export class Authenticator {
       }),
       keyAuth: new Authenticator({
         authMethod: key.isSystem ? "system_api_key" : "api_key",
-        groups: allGroups,
+        groupModelIds: allGroups.map((g) => g.id),
         key: key.toAuthJSON(),
         role: "builder",
         subscription: keySubscription,
@@ -521,7 +522,7 @@ export class Authenticator {
 
     return new Authenticator({
       authMethod: "internal",
-      groups,
+      groupModelIds: groups.map((g) => g.id),
       role: "builder",
       subscription: null,
       workspace,
@@ -555,7 +556,7 @@ export class Authenticator {
       authMethod: "internal",
       workspace,
       role: "builder",
-      groups: globalGroup ? [globalGroup] : [],
+      groupModelIds: globalGroup ? [globalGroup.id] : [],
       subscription,
     });
   }
@@ -594,7 +595,7 @@ export class Authenticator {
       authMethod: "internal",
       workspace,
       role: "admin",
-      groups,
+      groupModelIds: groups.map((g) => g.id),
       subscription,
     });
   }
@@ -660,7 +661,7 @@ export class Authenticator {
       return null;
     }
 
-    const groups = await GroupResource.listUserGroupsInWorkspace({
+    const groupModelIds = await GroupResource.listUserGroupModelIdsInWorkspace({
       user,
       workspace: renderLightWorkspaceType({ workspace: owner }),
     });
@@ -670,7 +671,7 @@ export class Authenticator {
       key: auth._key,
       // We limit scope to a user role.
       role: "user",
-      groups,
+      groupModelIds,
       user,
       subscription: auth._subscription,
       workspace: auth._workspace,
@@ -682,7 +683,7 @@ export class Authenticator {
       authMethod: this.authMethod(),
       key,
       role: this._role,
-      groups: this._groups,
+      groupModelIds: this._groupModelIds,
       user: this._user,
       subscription: this._subscription,
       workspace: this._workspace,
@@ -832,16 +833,40 @@ export class Authenticator {
     return isDustInternal && isDustSuperUser;
   }
 
-  groups(): GroupType[] {
-    return this._groups.map((g) => g.toJSON());
+  groupIds(): string[] {
+    const workspaceId = this._workspace?.id;
+    // Group are always tied to a workspace, so we can't have a group without a workspace.
+    if (!workspaceId) {
+      return [];
+    }
+
+    return this._groupModelIds.map((id) =>
+      GroupResource.modelIdToSId({ id, workspaceId })
+    );
+  }
+
+  groupModelIds(): ModelId[] {
+    return this._groupModelIds;
   }
 
   hasGroup(groupId: string): boolean {
-    return this._groups.some((g) => g.sId === groupId);
+    const workspaceId = this._workspace?.id;
+    // Group are always tied to a workspace, so we can't have a group without a workspace.
+    if (!workspaceId) {
+      return false;
+    }
+
+    return this._groupModelIds.some(
+      (id) =>
+        GroupResource.modelIdToSId({
+          id,
+          workspaceId,
+        }) === groupId
+    );
   }
 
   hasGroupByModelId(groupId: ModelId): boolean {
-    return this._groups.some((g) => g.id === groupId);
+    return this._groupModelIds.includes(groupId);
   }
 
   /**
@@ -911,9 +936,9 @@ export class Authenticator {
     }
 
     // Second path: Group-based permission check.
-    return this.groups().some((userGroup) =>
+    return this._groupModelIds.some((groupId) =>
       resourcePermission.groups.some(
-        (gp) => gp.id === userGroup.id && gp.permissions.includes(permission)
+        (gp) => gp.id === groupId && gp.permissions.includes(permission)
       )
     );
   }
@@ -935,14 +960,15 @@ export class Authenticator {
   }
 
   toJSON(): AuthenticatorType {
-    assert(this._workspace, "Workspace is required to serialize Authenticator");
+    const workspace = this._workspace;
+    assert(workspace, "Workspace is required to serialize Authenticator");
 
     return {
       authMethod: this._authMethod,
-      workspaceId: this._workspace.sId,
+      workspaceId: workspace.sId,
       userId: this._user?.sId ?? null,
       role: this._role,
-      groupIds: this._groups.map((g) => g.sId),
+      groupIds: this.groupIds(),
       subscriptionId: this._subscription?.sId ?? null,
       key: this._key,
     };
@@ -975,42 +1001,9 @@ export class Authenticator {
       return new Err({ code: "subscription_mismatch" });
     }
 
-    let groups: GroupResource[] = [];
-    if (authType.groupIds.length > 0 && workspace) {
-      // Temporary authenticator used solely to fetch the group resources. We
-      // grant it the `admin` role so that it can read any group in the
-      // workspace, irrespective of membership. The returned authenticator
-      // (see below) will still use the original `authType.role`, so this
-      // escalation is confined to the internal bootstrap step and does not
-      // leak outside of this scope.
-      const tempAuth = new Authenticator({
-        authMethod: authType.authMethod,
-        workspace,
-        user,
-        role: "admin",
-        groups: [],
-        subscription,
-        key: authType.key,
-      });
-
-      const groupsResult = await GroupResource.fetchByIds(
-        tempAuth,
-        authType.groupIds
-      );
-
-      if (groupsResult.isOk()) {
-        groups = groupsResult.value;
-      } else {
-        logger.error(
-          {
-            workspaceId: workspace.sId,
-            groupIds: authType.groupIds,
-            error: groupsResult.error,
-          },
-          "[Authenticator.fromJSON] Failed to fetch groups"
-        );
-      }
-    }
+    const groupIds = removeNulls(
+      authType.groupIds.map((sId) => getResourceIdFromSId(sId))
+    );
 
     return new Ok(
       new Authenticator({
@@ -1018,7 +1011,7 @@ export class Authenticator {
         workspace,
         user,
         role: authType.role,
-        groups,
+        groupModelIds: groupIds,
         subscription,
         key: authType.key,
       })

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
@@ -331,7 +331,7 @@ async function handler(
       const runRes = await coreAPI.createRunStream(
         owner,
         keyWorkspaceFlags,
-        auth.groups(),
+        auth.groupIds(),
         {
           projectId: app.dustAPIProjectId,
           runType: "deploy",

--- a/front/pages/api/w/[wId]/assistant/conversations/spaces/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/spaces/index.ts
@@ -25,14 +25,7 @@ async function handler(
 ): Promise<void> {
   switch (req.method) {
     case "GET":
-      const workspace = auth.getNonNullableWorkspace();
-
-      // Filter out non-regular groups as we only want to allow conversations in project spaces (that are linked to regular groups)
-      const allGroups = auth
-        .groups()
-        .filter((g) => g.kind === "regular" && g.workspaceId === workspace.id);
-
-      const spaces = await SpaceResource.listForGroups(auth, allGroups);
+      const spaces = await SpaceResource.listWorkspaceSpacesAsMember(auth);
 
       // Fetch all unread conversations for the user in one query
       const unreadConversations =

--- a/front/pages/api/w/[wId]/skills/[sId]/editors.test.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/editors.test.ts
@@ -20,7 +20,7 @@ describe("PATCH /api/w/[wId]/skills/[sId]/editors", () => {
     const auth = new Authenticator({
       user,
       role: "admin",
-      groups: [],
+      groupModelIds: [],
       workspace: workspaceResource,
       subscription: null,
       authMethod: "internal",
@@ -54,7 +54,7 @@ describe("PATCH /api/w/[wId]/skills/[sId]/editors", () => {
     const auth = new Authenticator({
       user,
       role: "admin",
-      groups: [],
+      groupModelIds: [],
       workspace: workspaceResource,
       subscription: null,
       authMethod: "internal",
@@ -86,7 +86,7 @@ describe("PATCH /api/w/[wId]/skills/[sId]/editors", () => {
     const auth = new Authenticator({
       user,
       role: "admin",
-      groups: [],
+      groupModelIds: [],
       workspace: workspaceResource,
       subscription: null,
       authMethod: "internal",
@@ -117,7 +117,7 @@ describe("PATCH /api/w/[wId]/skills/[sId]/editors", () => {
     const auth = new Authenticator({
       user,
       role: "admin",
-      groups: [],
+      groupModelIds: [],
       workspace: workspaceResource,
       subscription: null,
       authMethod: "internal",
@@ -153,7 +153,7 @@ describe("PATCH /api/w/[wId]/skills/[sId]/editors", () => {
     const auth = new Authenticator({
       user,
       role: "admin",
-      groups: [],
+      groupModelIds: [],
       workspace: workspaceResource,
       subscription: null,
       authMethod: "internal",
@@ -182,7 +182,7 @@ describe("PATCH /api/w/[wId]/skills/[sId]/editors", () => {
     const auth = new Authenticator({
       user,
       role: "admin",
-      groups: [],
+      groupModelIds: [],
       workspace: workspaceResource,
       subscription: null,
       authMethod: "internal",

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
@@ -131,7 +131,7 @@ async function handler(
       const dustRun = await coreAPI.createRun(
         owner,
         keyWorkspaceFlags,
-        auth.groups(),
+        auth.groupIds(),
         {
           projectId: app.dustAPIProjectId,
           runType: "local",

--- a/front/scripts/ensure_project_datasource_and_connector_created.ts
+++ b/front/scripts/ensure_project_datasource_and_connector_created.ts
@@ -190,6 +190,9 @@ makeScript(
           kind: "project",
           deletedAt: null,
         },
+        // WORKSPACE_ISOLATION_BYPASS: This script operates across all workspaces to ensure project connectors are created
+        // @ts-expect-error -- It's a one-off script that operates across all workspaces
+        dangerouslyBypassWorkspaceIsolationSecurity: true,
         attributes: ["id", "workspaceId"],
       });
 

--- a/front/types/core/core_api.ts
+++ b/front/types/core/core_api.ts
@@ -21,7 +21,6 @@ import type {
 } from "@app/types/core/data_source";
 import type { DataSourceViewType } from "@app/types/data_source_view";
 import type { DustAppSecretType } from "@app/types/dust_app_secret";
-import type { GroupType } from "@app/types/groups";
 import type { Project } from "@app/types/project";
 import type { CredentialsType } from "@app/types/provider";
 import type {
@@ -504,7 +503,7 @@ export class CoreAPI {
   async createRun(
     workspace: LightWorkspaceType,
     featureFlags: WhitelistableFeature[],
-    groups: GroupType[],
+    groupIds: string[],
     {
       projectId,
       runType,
@@ -526,7 +525,7 @@ export class CoreAPI {
         headers: {
           "Content-Type": "application/json",
           "X-Dust-Feature-Flags": featureFlags.join(","),
-          "X-Dust-Group-Ids": groups.map((g) => g.sId).join(","),
+          "X-Dust-Group-Ids": groupIds.join(","),
           "X-Dust-IsSystemRun": isSystemKey ? "true" : "false",
           "X-Dust-Workspace-Id": workspace.sId,
         },
@@ -550,7 +549,7 @@ export class CoreAPI {
   async createRunStream(
     workspace: LightWorkspaceType,
     featureFlags: WhitelistableFeature[],
-    groups: GroupType[],
+    groupIds: string[],
     {
       projectId,
       runType,
@@ -577,7 +576,7 @@ export class CoreAPI {
         headers: {
           "Content-Type": "application/json",
           "X-Dust-Feature-Flags": featureFlags.join(","),
-          "X-Dust-Group-Ids": groups.map((g) => g.sId).join(","),
+          "X-Dust-Group-Ids": groupIds.join(","),
           "X-Dust-IsSystemRun": isSystemKey ? "true" : "false",
           "X-Dust-Workspace-Id": workspace.sId,
         },


### PR DESCRIPTION
## Description

Optimize Authenticator to avoid creating and storing the whole group_resource object when we just need the ids. Goal is to reduce memory usage significantly when workspaces have a large numbers of groups (notably, agent editors groups).
Gut feeling is that we are still using sequelize models that are not free and we should use raw queries in `listUserGroupModelIdsInWorkspace()`

Edit: did it with raw sql to really reduce memory.

## Tests

All green + local

## Risk

Medium, core part the codebase.

## Deploy Plan

Deploy front