### PR TITLE
[sparkle] - refacto(Toolbar): move from front to sparkle

### DIFF
--- a/sparkle/src/components/Toolbar.tsx
+++ b/sparkle/src/components/Toolbar.tsx
@@ -77,7 +77,7 @@ export interface ToolbarProps {
   startSlot?: React.ReactNode;
 }
 
-const Toolbar = ({
+function Toolbar({
   variant = "inline",
   children,
   className,
@@ -87,7 +87,7 @@ const Toolbar = ({
   onClose,
   closeButtonProps,
   startSlot,
-}: ToolbarProps) => {
+}: ToolbarProps) {
   const isOverlay = variant === "overlay";
   const isScrollable = scroll ?? isOverlay;
   const {
@@ -97,39 +97,37 @@ const Toolbar = ({
   } = closeButtonProps ?? {};
   const closeButtonSize: ToolbarButtonSize = closeButtonSizeProp ?? "mini";
 
-  const rootClassName = cn(toolbarRootVariants({ variant, className }));
+  const rootClassName = toolbarRootVariants({ variant, className });
+  const contentBaseClassName = toolbarContentVariants({
+    variant,
+    scrollable: isScrollable,
+    className: contentClassName,
+  });
+  const scrollAreaClassNames = toolbarScrollAreaVariants({
+    variant,
+    className: scrollAreaClassName,
+  });
 
-  const contentBaseClassName = cn(
-    toolbarContentVariants({
-      variant,
-      scrollable: isScrollable,
-      className: contentClassName,
-    })
-  );
+  function renderCloseButton(): JSX.Element | null {
+    if (!onClose) {
+      return null;
+    }
 
-  const scrollAreaClassNames = cn(
-    toolbarScrollAreaVariants({ variant, className: scrollAreaClassName })
-  );
+    const buttonProps = {
+      variant: closeVariant,
+      icon: XMarkIcon,
+      onClick: onClose,
+      ...restCloseButtonProps,
+    };
 
-  const closeButton = onClose ? (
-    closeButtonSize === "mini" ? (
-      <Button
-        size="mini"
-        variant={closeVariant}
-        icon={XMarkIcon}
-        onClick={onClose}
-        {...restCloseButtonProps}
-      />
-    ) : (
-      <Button
-        size={closeButtonSize}
-        variant={closeVariant}
-        icon={XMarkIcon}
-        onClick={onClose}
-        {...restCloseButtonProps}
-      />
-    )
-  ) : null;
+    if (closeButtonSize === "mini") {
+      return <Button size="mini" {...buttonProps} />;
+    }
+
+    return <Button size={closeButtonSize} {...buttonProps} />;
+  }
+
+  const closeButton = renderCloseButton();
 
   const leadingContent = startSlot ?? closeButton;
   const content = <div className={contentBaseClassName}>{children}</div>;
@@ -150,7 +148,7 @@ const Toolbar = ({
       )}
     </div>
   );
-};
+}
 
 export interface ToolbarContentGroup {
   id: string;
@@ -162,24 +160,23 @@ export interface ToolbarContentProps {
   separatorClassName?: string;
 }
 
-const ToolbarContent = ({
-  groups,
-  separatorClassName,
-}: ToolbarContentProps) => (
-  <>
-    {groups.map((group, groupIndex) => (
-      <React.Fragment key={group.id}>
-        {group.items}
-        {groupIndex < groups.length - 1 && (
-          <Separator
-            orientation="vertical"
-            className={cn("s-my-1", separatorClassName)}
-          />
-        )}
-      </React.Fragment>
-    ))}
-  </>
-);
+function ToolbarContent({ groups, separatorClassName }: ToolbarContentProps) {
+  return (
+    <>
+      {groups.map((group, groupIndex) => (
+        <React.Fragment key={group.id}>
+          {group.items}
+          {groupIndex < groups.length - 1 && (
+            <Separator
+              orientation="vertical"
+              className={cn("s-my-1", separatorClassName)}
+            />
+          )}
+        </React.Fragment>
+      ))}
+    </>
+  );
+}
 
 export interface ToolbarIconProps {
   icon: React.ComponentType<{ className?: string }>;
@@ -189,18 +186,18 @@ export interface ToolbarIconProps {
   tooltip?: string;
 }
 
-const ToolbarIcon = ({
+function ToolbarIcon({
   icon,
   onClick,
   size,
   active,
   tooltip,
-}: ToolbarIconProps) => {
-  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+}: ToolbarIconProps) {
+  function handleClick(event: React.MouseEvent<HTMLButtonElement>): void {
     event.preventDefault();
     event.stopPropagation();
     onClick();
-  };
+  }
 
   if (size === "mini") {
     return (
@@ -223,7 +220,7 @@ const ToolbarIcon = ({
       variant={active ? "ghost" : "ghost-secondary"}
     />
   );
-};
+}
 
 export interface ToolbarLinkProps {
   isOpen: boolean;
@@ -239,7 +236,7 @@ export interface ToolbarLinkProps {
   tooltip?: string;
 }
 
-const ToolbarLink = ({
+function ToolbarLink({
   isOpen,
   onOpenChange,
   onOpenDialog,
@@ -251,57 +248,63 @@ const ToolbarLink = ({
   size,
   active,
   tooltip,
-}: ToolbarLinkProps) => (
-  <Dialog open={isOpen} onOpenChange={onOpenChange}>
-    <ToolbarIcon
-      icon={LinkMIcon}
-      onClick={onOpenDialog}
-      active={active}
-      tooltip={tooltip}
-      size={size}
-    />
-    <DialogContent
-      onClick={(event: React.MouseEvent<HTMLDivElement>) =>
-        event.stopPropagation()
-      }
-    >
-      <DialogHeader>
-        <DialogTitle>Insert Link</DialogTitle>
-        <DialogDescription>
-          Add a link to your message with custom text.
-        </DialogDescription>
-      </DialogHeader>
-      <DialogContainer>
-        <Input
-          id="link-text"
-          label="Text"
-          placeholder="Text"
-          value={linkText}
-          onChange={(event) => onLinkTextChange(event.target.value)}
-        />
-        <Input
-          id="link-url"
-          label="Link"
-          placeholder="Link"
-          value={linkUrl}
-          autoFocus
-          onChange={(event) => onLinkUrlChange(event.target.value)}
-        />
-      </DialogContainer>
-      <DialogFooter
-        leftButtonProps={{
-          label: "Cancel",
-          variant: "outline",
-          onClick: () => onOpenChange(false),
-        }}
-        rightButtonProps={{
-          label: "Save",
-          variant: "highlight",
-          onClick: onSubmit,
-        }}
+}: ToolbarLinkProps) {
+  function handleDialogClick(event: React.MouseEvent<HTMLDivElement>): void {
+    event.stopPropagation();
+  }
+
+  function handleCancelClick(): void {
+    onOpenChange(false);
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <ToolbarIcon
+        icon={LinkMIcon}
+        onClick={onOpenDialog}
+        active={active}
+        tooltip={tooltip}
+        size={size}
       />
-    </DialogContent>
-  </Dialog>
-);
+      <DialogContent onClick={handleDialogClick}>
+        <DialogHeader>
+          <DialogTitle>Insert Link</DialogTitle>
+          <DialogDescription>
+            Add a link to your message with custom text.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogContainer>
+          <Input
+            id="link-text"
+            label="Text"
+            placeholder="Text"
+            value={linkText}
+            onChange={(event) => onLinkTextChange(event.target.value)}
+          />
+          <Input
+            id="link-url"
+            label="Link"
+            placeholder="Link"
+            value={linkUrl}
+            autoFocus
+            onChange={(event) => onLinkUrlChange(event.target.value)}
+          />
+        </DialogContainer>
+        <DialogFooter
+          leftButtonProps={{
+            label: "Cancel",
+            variant: "outline",
+            onClick: handleCancelClick,
+          }}
+          rightButtonProps={{
+            label: "Save",
+            variant: "highlight",
+            onClick: onSubmit,
+          }}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}
 
 export { Toolbar, ToolbarContent, ToolbarIcon, ToolbarLink };

--- a/sparkle/src/components/Toolbar.tsx
+++ b/sparkle/src/components/Toolbar.tsx
@@ -1,0 +1,307 @@
+import { cva } from "class-variance-authority";
+import React from "react";
+
+import { Button, type ButtonProps } from "@sparkle/components/Button";
+import {
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@sparkle/components/Dialog";
+import { Input } from "@sparkle/components/Input";
+import { ScrollArea } from "@sparkle/components/ScrollArea";
+import { Separator } from "@sparkle/components/Separator";
+import { LinkMIcon, XMarkIcon } from "@sparkle/icons/app";
+import { cn } from "@sparkle/lib/utils";
+
+export type ToolbarVariant = "inline" | "overlay";
+
+type ToolbarButtonSize = NonNullable<ButtonProps["size"]>;
+
+const toolbarRootVariants = cva("s-inline-flex s-items-center", {
+  variants: {
+    variant: {
+      overlay:
+        "s-absolute s-left-0 s-top-0 s-z-10 s-justify-start s-gap-3 s-overflow-hidden s-rounded-xl s-bg-primary-50 s-py-1 s-pl-3 s-duration-700 s-ease-in-out dark:s-bg-muted-background-night",
+      inline:
+        "s-gap-1 s-border-b s-border-t s-border-border s-bg-background s-p-1 dark:s-border-border-night/50 dark:s-bg-background-night sm:s-rounded-2xl sm:s-border sm:s-border-border/50 sm:s-shadow-md",
+    },
+  },
+  defaultVariants: {
+    variant: "inline",
+  },
+});
+
+const toolbarContentVariants = cva("", {
+  variants: {
+    variant: {
+      overlay:
+        "s-flex s-h-full s-w-max s-flex-row s-items-center s-gap-3 s-px-3",
+      inline: "s-inline-flex s-items-center s-gap-1",
+    },
+    scrollable: {
+      true: "s-overflow-x-scroll",
+      false: "",
+    },
+  },
+  defaultVariants: {
+    variant: "inline",
+    scrollable: false,
+  },
+});
+
+const toolbarScrollAreaVariants = cva("s-h-full s-w-full", {
+  variants: {
+    variant: {
+      overlay: "s-border-l s-border-border dark:s-border-border-night/50",
+      inline: "",
+    },
+  },
+  defaultVariants: {
+    variant: "inline",
+  },
+});
+
+export interface ToolbarProps {
+  variant?: ToolbarVariant;
+  children: React.ReactNode;
+  className?: string;
+  contentClassName?: string;
+  scrollAreaClassName?: string;
+  scroll?: boolean;
+  onClose?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  closeButtonProps?: Omit<ButtonProps, "icon" | "onClick" | "label">;
+  startSlot?: React.ReactNode;
+}
+
+const Toolbar = ({
+  variant = "inline",
+  children,
+  className,
+  contentClassName,
+  scrollAreaClassName,
+  scroll,
+  onClose,
+  closeButtonProps,
+  startSlot,
+}: ToolbarProps) => {
+  const isOverlay = variant === "overlay";
+  const isScrollable = scroll ?? isOverlay;
+  const {
+    size: closeButtonSizeProp,
+    variant: closeVariant = "outline",
+    ...restCloseButtonProps
+  } = closeButtonProps ?? {};
+  const closeButtonSize: ToolbarButtonSize = closeButtonSizeProp ?? "mini";
+
+  const rootClassName = cn(toolbarRootVariants({ variant, className }));
+
+  const contentBaseClassName = cn(
+    toolbarContentVariants({
+      variant,
+      scrollable: isScrollable,
+      className: contentClassName,
+    })
+  );
+
+  const scrollAreaClassNames = cn(
+    toolbarScrollAreaVariants({ variant, className: scrollAreaClassName })
+  );
+
+  const closeButton = onClose ? (
+    closeButtonSize === "mini" ? (
+      <Button
+        size="mini"
+        variant={closeVariant}
+        icon={XMarkIcon}
+        onClick={onClose}
+        {...restCloseButtonProps}
+      />
+    ) : (
+      <Button
+        size={closeButtonSize}
+        variant={closeVariant}
+        icon={XMarkIcon}
+        onClick={onClose}
+        {...restCloseButtonProps}
+      />
+    )
+  ) : null;
+
+  const leadingContent = startSlot ?? closeButton;
+  const content = <div className={contentBaseClassName}>{children}</div>;
+
+  return (
+    <div className={rootClassName}>
+      {leadingContent}
+      {isScrollable ? (
+        <ScrollArea
+          orientation="horizontal"
+          className={scrollAreaClassNames}
+          hideScrollBar
+        >
+          {content}
+        </ScrollArea>
+      ) : (
+        content
+      )}
+    </div>
+  );
+};
+
+export interface ToolbarContentGroup {
+  id: string;
+  items: readonly React.ReactNode[];
+}
+
+export interface ToolbarContentProps {
+  groups: readonly ToolbarContentGroup[];
+  separatorClassName?: string;
+}
+
+const ToolbarContent = ({
+  groups,
+  separatorClassName,
+}: ToolbarContentProps) => (
+  <>
+    {groups.map((group, groupIndex) => (
+      <React.Fragment key={group.id}>
+        {group.items}
+        {groupIndex < groups.length - 1 && (
+          <Separator
+            orientation="vertical"
+            className={cn("s-my-1", separatorClassName)}
+          />
+        )}
+      </React.Fragment>
+    ))}
+  </>
+);
+
+export interface ToolbarIconProps {
+  icon: React.ComponentType<{ className?: string }>;
+  onClick: () => void;
+  size: ToolbarButtonSize;
+  active?: boolean;
+  tooltip?: string;
+}
+
+const ToolbarIcon = ({
+  icon,
+  onClick,
+  size,
+  active,
+  tooltip,
+}: ToolbarIconProps) => {
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    onClick();
+  };
+
+  if (size === "mini") {
+    return (
+      <Button
+        tooltip={tooltip}
+        icon={icon}
+        onClick={handleClick}
+        size="mini"
+        variant={active ? "ghost" : "ghost-secondary"}
+      />
+    );
+  }
+
+  return (
+    <Button
+      tooltip={tooltip}
+      icon={icon}
+      onClick={handleClick}
+      size={size}
+      variant={active ? "ghost" : "ghost-secondary"}
+    />
+  );
+};
+
+export interface ToolbarLinkProps {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  onOpenDialog: () => void;
+  onSubmit: () => void;
+  linkText: string;
+  linkUrl: string;
+  onLinkTextChange: (value: string) => void;
+  onLinkUrlChange: (value: string) => void;
+  size: ToolbarButtonSize;
+  active?: boolean;
+  tooltip?: string;
+}
+
+const ToolbarLink = ({
+  isOpen,
+  onOpenChange,
+  onOpenDialog,
+  onSubmit,
+  linkText,
+  linkUrl,
+  onLinkTextChange,
+  onLinkUrlChange,
+  size,
+  active,
+  tooltip,
+}: ToolbarLinkProps) => (
+  <Dialog open={isOpen} onOpenChange={onOpenChange}>
+    <ToolbarIcon
+      icon={LinkMIcon}
+      onClick={onOpenDialog}
+      active={active}
+      tooltip={tooltip}
+      size={size}
+    />
+    <DialogContent
+      onClick={(event: React.MouseEvent<HTMLDivElement>) =>
+        event.stopPropagation()
+      }
+    >
+      <DialogHeader>
+        <DialogTitle>Insert Link</DialogTitle>
+        <DialogDescription>
+          Add a link to your message with custom text.
+        </DialogDescription>
+      </DialogHeader>
+      <DialogContainer>
+        <Input
+          id="link-text"
+          label="Text"
+          placeholder="Text"
+          value={linkText}
+          onChange={(event) => onLinkTextChange(event.target.value)}
+        />
+        <Input
+          id="link-url"
+          label="Link"
+          placeholder="Link"
+          value={linkUrl}
+          autoFocus
+          onChange={(event) => onLinkUrlChange(event.target.value)}
+        />
+      </DialogContainer>
+      <DialogFooter
+        leftButtonProps={{
+          label: "Cancel",
+          variant: "outline",
+          onClick: () => onOpenChange(false),
+        }}
+        rightButtonProps={{
+          label: "Save",
+          variant: "highlight",
+          onClick: onSubmit,
+        }}
+      />
+    </DialogContent>
+  </Dialog>
+);
+
+export { Toolbar, ToolbarContent, ToolbarIcon, ToolbarLink };

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -189,15 +189,6 @@ export { ScrollArea, ScrollBar } from "./ScrollArea";
 export { SearchDropdownMenu } from "./SearchDropdownMenu";
 export { SearchInput, SearchInputWithPopover } from "./SearchInput";
 export { Separator } from "./Separator";
-export type {
-  ToolbarContentGroup,
-  ToolbarContentProps,
-  ToolbarIconProps,
-  ToolbarLinkProps,
-  ToolbarProps,
-  ToolbarVariant,
-} from "./Toolbar";
-export { Toolbar, ToolbarContent, ToolbarIcon, ToolbarLink } from "./Toolbar";
 export {
   Sheet,
   SheetClose,
@@ -219,6 +210,15 @@ export { FlexSplitButton } from "./SplitButton";
 export { Tabs, TabsContent, TabsList, TabsTrigger } from "./Tabs";
 export { ReadOnlyTextArea, TextArea } from "./TextArea";
 export { Timeline, TimelineItem } from "./Timeline";
+export type {
+  ToolbarContentGroup,
+  ToolbarContentProps,
+  ToolbarIconProps,
+  ToolbarLinkProps,
+  ToolbarProps,
+  ToolbarVariant,
+} from "./Toolbar";
+export { Toolbar, ToolbarContent, ToolbarIcon, ToolbarLink } from "./Toolbar";
 export {
   Tooltip,
   TooltipContent,

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -189,6 +189,15 @@ export { ScrollArea, ScrollBar } from "./ScrollArea";
 export { SearchDropdownMenu } from "./SearchDropdownMenu";
 export { SearchInput, SearchInputWithPopover } from "./SearchInput";
 export { Separator } from "./Separator";
+export type {
+  ToolbarContentGroup,
+  ToolbarContentProps,
+  ToolbarIconProps,
+  ToolbarLinkProps,
+  ToolbarProps,
+  ToolbarVariant,
+} from "./Toolbar";
+export { Toolbar, ToolbarContent, ToolbarIcon, ToolbarLink } from "./Toolbar";
 export {
   Sheet,
   SheetClose,

--- a/sparkle/src/stories/Toolbar.stories.tsx
+++ b/sparkle/src/stories/Toolbar.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import React, { useState } from "react";
 
-import type { ToolbarProps } from "@sparkle/index_with_tw_base";
+import type { ToolbarProps } from "../index_with_tw_base";
 import {
   BoldIcon,
   CodeBlockIcon,
@@ -15,21 +15,16 @@ import {
   ToolbarContent,
   ToolbarIcon,
   ToolbarLink,
-} from "@sparkle/index_with_tw_base";
+} from "../index_with_tw_base";
 
 const TOOLBAR_VARIANTS = ["inline", "overlay"] as const;
 
-interface ToolbarPreviewProps {
-  variant?: ToolbarProps["variant"];
-  scroll?: ToolbarProps["scroll"];
-  onClose?: ToolbarProps["onClose"];
-}
+interface ToolbarPreviewProps extends Pick<
+  ToolbarProps,
+  "variant" | "scroll" | "onClose"
+> {}
 
-function ToolbarPreview({
-  variant,
-  scroll,
-  onClose,
-}: ToolbarPreviewProps): JSX.Element {
+function ToolbarPreview({ variant, scroll, onClose }: ToolbarPreviewProps) {
   const [isLinkDialogOpen, setIsLinkDialogOpen] = useState(false);
   const [linkText, setLinkText] = useState("Dust");
   const [linkUrl, setLinkUrl] = useState("dust.tt");
@@ -170,8 +165,8 @@ function ToolbarPreview({
   return toolbar;
 }
 
-function renderToolbarStory(args: ToolbarPreviewProps): JSX.Element {
-  return <ToolbarPreview {...args} />;
+function renderToolbarStory({ variant, scroll, onClose }: ToolbarProps) {
+  return <ToolbarPreview variant={variant} scroll={scroll} onClose={onClose} />;
 }
 
 function handleOverlayClose(
@@ -198,6 +193,7 @@ type Story = StoryObj<typeof meta>;
 
 export const Playground: Story = {
   args: {
+    children: null,
     variant: "inline",
     scroll: false,
   },
@@ -206,6 +202,7 @@ export const Playground: Story = {
 
 export const Overlay: Story = {
   args: {
+    children: null,
     variant: "overlay",
     scroll: true,
     onClose: handleOverlayClose,

--- a/sparkle/src/stories/Toolbar.stories.tsx
+++ b/sparkle/src/stories/Toolbar.stories.tsx
@@ -1,0 +1,214 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import React, { useState } from "react";
+
+import type { ToolbarProps } from "@sparkle/index_with_tw_base";
+import {
+  BoldIcon,
+  CodeBlockIcon,
+  CodeSlashIcon,
+  HeadingIcon,
+  ItalicIcon,
+  ListCheckIcon,
+  ListOrdered2Icon,
+  QuoteTextIcon,
+  Toolbar,
+  ToolbarContent,
+  ToolbarIcon,
+  ToolbarLink,
+} from "@sparkle/index_with_tw_base";
+
+const TOOLBAR_VARIANTS = ["inline", "overlay"] as const;
+
+interface ToolbarPreviewProps {
+  variant?: ToolbarProps["variant"];
+  scroll?: ToolbarProps["scroll"];
+  onClose?: ToolbarProps["onClose"];
+}
+
+function ToolbarPreview({
+  variant,
+  scroll,
+  onClose,
+}: ToolbarPreviewProps): JSX.Element {
+  const [isLinkDialogOpen, setIsLinkDialogOpen] = useState(false);
+  const [linkText, setLinkText] = useState("Dust");
+  const [linkUrl, setLinkUrl] = useState("dust.tt");
+  const isOverlay = variant === "overlay";
+  const buttonSize = isOverlay ? "xs" : "sm";
+
+  function handleToolbarAction(): void {}
+
+  function handleLinkDialogOpen(): void {
+    setIsLinkDialogOpen(true);
+  }
+
+  function handleLinkDialogOpenChange(open: boolean): void {
+    setIsLinkDialogOpen(open);
+  }
+
+  function handleLinkSubmit(): void {
+    setIsLinkDialogOpen(false);
+  }
+
+  function handleLinkTextChange(value: string): void {
+    setLinkText(value);
+  }
+
+  function handleLinkUrlChange(value: string): void {
+    setLinkUrl(value);
+  }
+
+  const groups = [
+    {
+      id: "text",
+      items: [
+        <ToolbarIcon
+          key="heading"
+          icon={HeadingIcon}
+          onClick={handleToolbarAction}
+          active
+          tooltip="Heading"
+          size={buttonSize}
+        />,
+        <ToolbarIcon
+          key="bold"
+          icon={BoldIcon}
+          onClick={handleToolbarAction}
+          active
+          tooltip="Bold"
+          size={buttonSize}
+        />,
+        <ToolbarIcon
+          key="italic"
+          icon={ItalicIcon}
+          onClick={handleToolbarAction}
+          tooltip="Italic"
+          size={buttonSize}
+        />,
+      ],
+    },
+    {
+      id: "link",
+      items: [
+        <ToolbarLink
+          key="link"
+          isOpen={isLinkDialogOpen}
+          onOpenChange={handleLinkDialogOpenChange}
+          onOpenDialog={handleLinkDialogOpen}
+          onSubmit={handleLinkSubmit}
+          linkText={linkText}
+          linkUrl={linkUrl}
+          onLinkTextChange={handleLinkTextChange}
+          onLinkUrlChange={handleLinkUrlChange}
+          active={isLinkDialogOpen}
+          tooltip="Link"
+          size={buttonSize}
+        />,
+      ],
+    },
+    {
+      id: "lists",
+      items: [
+        <ToolbarIcon
+          key="bulleted-list"
+          icon={ListCheckIcon}
+          onClick={handleToolbarAction}
+          tooltip="Bulleted list"
+          size={buttonSize}
+        />,
+        <ToolbarIcon
+          key="ordered-list"
+          icon={ListOrdered2Icon}
+          onClick={handleToolbarAction}
+          tooltip="Ordered list"
+          size={buttonSize}
+        />,
+        <ToolbarIcon
+          key="blockquote"
+          icon={QuoteTextIcon}
+          onClick={handleToolbarAction}
+          tooltip="Blockquote"
+          size={buttonSize}
+        />,
+      ],
+    },
+    {
+      id: "code",
+      items: [
+        <ToolbarIcon
+          key="inline-code"
+          icon={CodeSlashIcon}
+          onClick={handleToolbarAction}
+          tooltip="Inline code"
+          size={buttonSize}
+        />,
+        <ToolbarIcon
+          key="code-block"
+          icon={CodeBlockIcon}
+          onClick={handleToolbarAction}
+          tooltip="Code block"
+          size={buttonSize}
+        />,
+      ],
+    },
+  ];
+
+  const toolbar = (
+    <Toolbar variant={variant} scroll={scroll} onClose={onClose}>
+      <ToolbarContent groups={groups} />
+    </Toolbar>
+  );
+
+  if (isOverlay) {
+    return (
+      <div className="s-relative s-h-14 s-w-full s-max-w-[520px] s-rounded-xl s-border s-border-border/70 s-bg-background s-p-2 dark:s-border-border-night/50 dark:s-bg-background-night">
+        {toolbar}
+      </div>
+    );
+  }
+
+  return toolbar;
+}
+
+function renderToolbarStory(args: ToolbarPreviewProps): JSX.Element {
+  return <ToolbarPreview {...args} />;
+}
+
+function handleOverlayClose(
+  _event: React.MouseEvent<HTMLButtonElement>
+): void {}
+
+const meta = {
+  title: "Components/Toolbar",
+  component: Toolbar,
+  tags: ["autodocs"],
+  argTypes: {
+    variant: {
+      options: TOOLBAR_VARIANTS,
+      control: { type: "select" },
+    },
+    scroll: {
+      control: { type: "boolean" },
+    },
+  },
+} satisfies Meta<typeof Toolbar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {
+  args: {
+    variant: "inline",
+    scroll: false,
+  },
+  render: renderToolbarStory,
+};
+
+export const Overlay: Story = {
+  args: {
+    variant: "overlay",
+    scroll: true,
+    onClose: handleOverlayClose,
+  },
+  render: renderToolbarStory,
+};


### PR DESCRIPTION





## Description

Adds a new `Toolbar` component to Sparkle's design system to enable sharing between front and extension packages. The component supports two variants (`inline` and `overlay`) with configurable scroll behavior, close button functionality, and content grouping with separators. Includes three sub-components: `ToolbarIcon` for button actions, `ToolbarLink` for link insertion with a dialog interface, and `ToolbarContent` for organizing toolbar items into groups. Uses `class-variance-authority` for variant management and integrates with existing Sparkle components (Button, Dialog, ScrollArea, Separator).

## Risk

Low

## Tests

Storybook

## Deploy Plan

- Publish rc
- Deploy front
- Publish GR