### PR TITLE
feat: edit title clicking on it

### DIFF
--- a/front/components/assistant/conversation/ConversationTitle.tsx
+++ b/front/components/assistant/conversation/ConversationTitle.tsx
@@ -1,4 +1,5 @@
 import { ArrowLeftIcon, Button, IconButton, MoreIcon } from "@dust-tt/sparkle";
+import { useState } from "react";
 
 import { ConversationFilesPopover } from "@app/components/assistant/conversation/ConversationFilesPopover";
 import {
@@ -14,6 +15,8 @@ import { useUser } from "@app/lib/swr/user";
 import { getSpaceConversationsRoute } from "@app/lib/utils/router";
 import type { WorkspaceType } from "@app/types";
 
+import { EditConversationTitleDialog } from "./EditConversationTitleDialog";
+
 export function ConversationTitle({ owner }: { owner: WorkspaceType }) {
   const activeConversationId = useActiveConversationId();
   const { user } = useUser();
@@ -27,12 +30,17 @@ export function ConversationTitle({ owner }: { owner: WorkspaceType }) {
   });
   const router = useAppRouter();
 
+  const [showRenameDialog, setShowRenameDialog] = useState(false);
+
   const {
     isMenuOpen,
     menuTriggerPosition,
     handleRightClick,
     handleMenuOpenChange,
   } = useConversationMenu();
+
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+  const currentTitle = conversation?.title || "";
 
   if (!activeConversationId) {
     return null;
@@ -69,10 +77,19 @@ export function ConversationTitle({ owner }: { owner: WorkspaceType }) {
               {spaceInfo.name} -
             </div>
           )}
-          <div className="dd-privacy-mask min-w-0 overflow-hidden truncate text-base font-normal text-muted-foreground">
-            {/* eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing */}
-            {conversation?.title || ""}
+          <div
+            className="dd-privacy-mask min-w-0 cursor-pointer overflow-hidden truncate text-base font-normal text-muted-foreground hover:underline"
+            onClick={() => setShowRenameDialog(true)}
+          >
+            {currentTitle}
           </div>
+          <EditConversationTitleDialog
+            isOpen={showRenameDialog}
+            onClose={() => setShowRenameDialog(false)}
+            owner={owner}
+            conversationId={activeConversationId}
+            currentTitle={currentTitle}
+          />
         </div>
         <div className="flex items-center gap-2">
           <ConversationFilesPopover

--- a/front/components/assistant/conversation/ConversationTitle.tsx
+++ b/front/components/assistant/conversation/ConversationTitle.tsx
@@ -39,8 +39,7 @@ export function ConversationTitle({ owner }: { owner: WorkspaceType }) {
     handleMenuOpenChange,
   } = useConversationMenu();
 
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-  const currentTitle = conversation?.title || "";
+  const currentTitle = conversation?.title ?? "";
 
   if (!activeConversationId) {
     return null;


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/5997

This PR changes the `ConversationTitle` component so that clicking on the title opens a dialog to edit it.


https://github.com/user-attachments/assets/563fa783-7835-47e2-a664-c04083f3bdd4


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Manually.
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
None.
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
