### PR TITLE
Add rate limit on search endpoint

### DIFF
--- a/front/pages/api/v1/w/[wId]/search.ts
+++ b/front/pages/api/v1/w/[wId]/search.ts
@@ -8,6 +8,7 @@ import { handleSearch } from "@app/lib/api/search";
 import type { Authenticator } from "@app/lib/auth";
 import { streamToolFiles } from "@app/lib/search/tools/search";
 import type { ToolSearchResult } from "@app/lib/search/tools/types";
+import { rateLimiter } from "@app/lib/utils/rate_limiter";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type {
@@ -18,6 +19,8 @@ import type {
   WithAPIErrorResponse,
 } from "@app/types";
 import { isString } from "@app/types";
+
+const MAX_UNIFIED_SEARCH_PER_USER_PER_MINUTE = 20;
 
 export type DataSourceContentNode = ContentNodeWithParent & {
   dataSource: DataSourceType;
@@ -329,6 +332,24 @@ async function handler(
   >,
   auth: Authenticator
 ): Promise<void> {
+  const rateLimitKey = `unified_search:${auth.getNonNullableUser().sId}`;
+  const remaining = await rateLimiter({
+    key: rateLimitKey,
+    maxPerTimeframe: MAX_UNIFIED_SEARCH_PER_USER_PER_MINUTE,
+    timeframeSeconds: 60, // 1 minute
+    logger,
+  });
+
+  if (remaining === 0) {
+    return apiError(req, res, {
+      status_code: 429,
+      api_error: {
+        type: "rate_limit_error",
+        message: `You have reached the limit of ${MAX_UNIFIED_SEARCH_PER_USER_PER_MINUTE} unified searches per minute.`,
+      },
+    });
+  }
+
   // Support both GET (streaming) and POST (legacy) methods
   if (req.method === "GET") {
     return handleStreamingSearch(req, res, auth);

--- a/front/pages/api/w/[wId]/search.ts
+++ b/front/pages/api/w/[wId]/search.ts
@@ -7,6 +7,7 @@ import { handleSearch, SearchRequestBody } from "@app/lib/api/search";
 import type { Authenticator } from "@app/lib/auth";
 import { streamToolFiles } from "@app/lib/search/tools/search";
 import type { ToolSearchResult } from "@app/lib/search/tools/types";
+import { rateLimiter } from "@app/lib/utils/rate_limiter";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type {
@@ -17,6 +18,8 @@ import type {
   WithAPIErrorResponse,
 } from "@app/types";
 import { isString } from "@app/types";
+
+const MAX_UNIFIED_SEARCH_PER_USER_PER_MINUTE = 20;
 
 export type DataSourceContentNode = ContentNodeWithParent & {
   dataSource: DataSourceType;
@@ -199,6 +202,24 @@ async function handler(
   res: NextApiResponse<WithAPIErrorResponse<PostWorkspaceSearchResponseBody>>,
   auth: Authenticator
 ): Promise<void> {
+  const rateLimitKey = `unified_search:${auth.getNonNullableUser().sId}`;
+  const remaining = await rateLimiter({
+    key: rateLimitKey,
+    maxPerTimeframe: MAX_UNIFIED_SEARCH_PER_USER_PER_MINUTE,
+    timeframeSeconds: 60, // 1 minute
+    logger,
+  });
+
+  if (remaining === 0) {
+    return apiError(req, res, {
+      status_code: 429,
+      api_error: {
+        type: "rate_limit_error",
+        message: `You have reached the limit of ${MAX_UNIFIED_SEARCH_PER_USER_PER_MINUTE} unified searches per minute.`,
+      },
+    });
+  }
+
   // Support both GET (streaming) and POST (legacy) methods
   if (req.method === "GET") {
     return handleStreamingSearch(req, res, auth);


### PR DESCRIPTION
## Description

Add rate limit on unified search (20/minute/user)

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy front