### PR TITLE
Add shared Pagination component and Contentful Academy data layer

### DIFF
--- a/front/components/blog/BlogPagination.tsx
+++ b/front/components/blog/BlogPagination.tsx
@@ -1,5 +1,4 @@
-import { ChevronLeftIcon, ChevronRightIcon } from "@dust-tt/sparkle";
-import Link from "next/link";
+import { Pagination } from "@app/components/shared/Pagination";
 
 interface BlogPaginationProps {
   currentPage: number;
@@ -9,7 +8,7 @@ interface BlogPaginationProps {
   tag?: string | null;
 }
 
-function buildPageUrl(page: number, tag?: string | null): string {
+function buildBlogPageUrl(page: number, tag?: string | null): string {
   if (tag) {
     // Tag filtering stays on index page (client-side filtering)
     const params = new URLSearchParams();
@@ -23,143 +22,14 @@ function buildPageUrl(page: number, tag?: string | null): string {
   return page === 1 ? "/blog" : `/blog/page/${page}`;
 }
 
-function PaginationLink({
-  page,
-  isCurrent,
-  tag,
-}: {
-  page: number;
-  isCurrent: boolean;
-  tag?: string | null;
-}) {
-  const href = buildPageUrl(page, tag);
-
-  if (isCurrent) {
-    return (
-      <span className="flex h-7 w-7 items-center justify-center rounded-md bg-primary-100 text-xs font-medium text-primary-800">
-        {page}
-      </span>
-    );
-  }
-
-  return (
-    <Link
-      href={href}
-      className="flex h-7 w-7 items-center justify-center rounded-md text-xs font-medium text-muted-foreground transition-colors hover:bg-gray-100 hover:text-foreground"
-    >
-      {page}
-    </Link>
-  );
-}
-
 export function BlogPagination({
-  currentPage,
-  totalPages,
-  rowCount,
-  pageSize,
   tag,
+  ...paginationProps
 }: BlogPaginationProps) {
-  if (totalPages <= 1) {
-    return null;
-  }
-
-  const startItem = (currentPage - 1) * pageSize + 1;
-  const endItem = Math.min(currentPage * pageSize, rowCount);
-
-  // Generate page numbers to show
-  const getPageNumbers = () => {
-    const pages: (number | "ellipsis-start" | "ellipsis-end")[] = [];
-    const showEllipsisStart = currentPage > 3;
-    const showEllipsisEnd = currentPage < totalPages - 2;
-
-    // Always show first page
-    pages.push(1);
-
-    if (showEllipsisStart) {
-      pages.push("ellipsis-start");
-    }
-
-    // Show pages around current
-    for (
-      let i = Math.max(2, currentPage - 1);
-      i <= Math.min(totalPages - 1, currentPage + 1);
-      i++
-    ) {
-      if (!pages.includes(i)) {
-        pages.push(i);
-      }
-    }
-
-    if (showEllipsisEnd) {
-      pages.push("ellipsis-end");
-    }
-
-    // Always show last page if more than 1 page
-    if (totalPages > 1 && !pages.includes(totalPages)) {
-      pages.push(totalPages);
-    }
-
-    return pages;
-  };
-
-  const pageNumbers = getPageNumbers();
-  const canGoPrev = currentPage > 1;
-  const canGoNext = currentPage < totalPages;
-
   return (
-    <nav
-      className="flex w-full items-center justify-between"
-      aria-label="Pagination"
-    >
-      <div className="flex items-center gap-1">
-        <Link
-          href={canGoPrev ? buildPageUrl(currentPage - 1, tag) : "#"}
-          className={`flex h-7 w-7 items-center justify-center rounded-md transition-colors ${
-            canGoPrev
-              ? "text-muted-foreground hover:bg-gray-100 hover:text-foreground"
-              : "pointer-events-none text-gray-300"
-          }`}
-          aria-disabled={!canGoPrev}
-          tabIndex={canGoPrev ? undefined : -1}
-        >
-          <ChevronLeftIcon className="h-4 w-4" />
-        </Link>
-
-        {pageNumbers.map((pageNum) =>
-          pageNum === "ellipsis-start" || pageNum === "ellipsis-end" ? (
-            <span
-              key={pageNum}
-              className="flex h-7 w-7 items-center justify-center text-xs text-muted-foreground"
-            >
-              ...
-            </span>
-          ) : (
-            <PaginationLink
-              key={pageNum}
-              page={pageNum}
-              isCurrent={pageNum === currentPage}
-              tag={tag}
-            />
-          )
-        )}
-
-        <Link
-          href={canGoNext ? buildPageUrl(currentPage + 1, tag) : "#"}
-          className={`flex h-7 w-7 items-center justify-center rounded-md transition-colors ${
-            canGoNext
-              ? "text-muted-foreground hover:bg-gray-100 hover:text-foreground"
-              : "pointer-events-none text-gray-300"
-          }`}
-          aria-disabled={!canGoNext}
-          tabIndex={canGoNext ? undefined : -1}
-        >
-          <ChevronRightIcon className="h-4 w-4" />
-        </Link>
-      </div>
-
-      <span className="text-xs text-muted-foreground">
-        {startItem}-{endItem} of {rowCount}
-      </span>
-    </nav>
+    <Pagination
+      {...paginationProps}
+      buildPageUrl={(page) => buildBlogPageUrl(page, tag)}
+    />
   );
 }

--- a/front/components/shared/Pagination.tsx
+++ b/front/components/shared/Pagination.tsx
@@ -1,0 +1,152 @@
+import { ChevronLeftIcon, ChevronRightIcon } from "@dust-tt/sparkle";
+import Link from "next/link";
+
+type PageNumber = number | "ellipsis-start" | "ellipsis-end";
+
+function getPageNumbers(currentPage: number, totalPages: number): PageNumber[] {
+  const pages: PageNumber[] = [];
+  const showEllipsisStart = currentPage > 3;
+  const showEllipsisEnd = currentPage < totalPages - 2;
+
+  // Always show first page
+  pages.push(1);
+
+  if (showEllipsisStart) {
+    pages.push("ellipsis-start");
+  }
+
+  // Show pages around current
+  for (
+    let i = Math.max(2, currentPage - 1);
+    i <= Math.min(totalPages - 1, currentPage + 1);
+    i++
+  ) {
+    if (!pages.includes(i)) {
+      pages.push(i);
+    }
+  }
+
+  if (showEllipsisEnd) {
+    pages.push("ellipsis-end");
+  }
+
+  // Always show last page if more than 1 page
+  if (totalPages > 1 && !pages.includes(totalPages)) {
+    pages.push(totalPages);
+  }
+
+  return pages;
+}
+
+interface PaginationLinkProps {
+  page: number;
+  isCurrent: boolean;
+  buildPageUrl: (page: number) => string;
+}
+
+function PaginationLink({
+  page,
+  isCurrent,
+  buildPageUrl,
+}: PaginationLinkProps) {
+  if (isCurrent) {
+    return (
+      <span className="flex h-7 w-7 items-center justify-center rounded-md bg-primary-100 text-xs font-medium text-primary-800">
+        {page}
+      </span>
+    );
+  }
+
+  return (
+    <Link
+      href={buildPageUrl(page)}
+      className="flex h-7 w-7 items-center justify-center rounded-md text-xs font-medium text-muted-foreground transition-colors hover:bg-gray-100 hover:text-foreground"
+    >
+      {page}
+    </Link>
+  );
+}
+
+export interface PaginationProps {
+  currentPage: number;
+  totalPages: number;
+  rowCount: number;
+  pageSize: number;
+  buildPageUrl: (page: number) => string;
+}
+
+export function Pagination({
+  currentPage,
+  totalPages,
+  rowCount,
+  pageSize,
+  buildPageUrl,
+}: PaginationProps) {
+  if (totalPages <= 1) {
+    return null;
+  }
+
+  const startItem = (currentPage - 1) * pageSize + 1;
+  const endItem = Math.min(currentPage * pageSize, rowCount);
+
+  const pageNumbers = getPageNumbers(currentPage, totalPages);
+  const canGoPrev = currentPage > 1;
+  const canGoNext = currentPage < totalPages;
+
+  return (
+    <nav
+      className="flex w-full items-center justify-between"
+      aria-label="Pagination"
+    >
+      <div className="flex items-center gap-1">
+        <Link
+          href={canGoPrev ? buildPageUrl(currentPage - 1) : "#"}
+          className={`flex h-7 w-7 items-center justify-center rounded-md transition-colors ${
+            canGoPrev
+              ? "text-muted-foreground hover:bg-gray-100 hover:text-foreground"
+              : "pointer-events-none text-gray-300"
+          }`}
+          aria-disabled={!canGoPrev}
+          tabIndex={canGoPrev ? undefined : -1}
+        >
+          <ChevronLeftIcon className="h-4 w-4" />
+        </Link>
+
+        {pageNumbers.map((pageNum) =>
+          pageNum === "ellipsis-start" || pageNum === "ellipsis-end" ? (
+            <span
+              key={pageNum}
+              className="flex h-7 w-7 items-center justify-center text-xs text-muted-foreground"
+            >
+              ...
+            </span>
+          ) : (
+            <PaginationLink
+              key={pageNum}
+              page={pageNum}
+              isCurrent={pageNum === currentPage}
+              buildPageUrl={buildPageUrl}
+            />
+          )
+        )}
+
+        <Link
+          href={canGoNext ? buildPageUrl(currentPage + 1) : "#"}
+          className={`flex h-7 w-7 items-center justify-center rounded-md transition-colors ${
+            canGoNext
+              ? "text-muted-foreground hover:bg-gray-100 hover:text-foreground"
+              : "pointer-events-none text-gray-300"
+          }`}
+          aria-disabled={!canGoNext}
+          tabIndex={canGoNext ? undefined : -1}
+        >
+          <ChevronRightIcon className="h-4 w-4" />
+        </Link>
+      </div>
+
+      <span className="text-xs text-muted-foreground">
+        {startItem}-{endItem} of {rowCount}
+      </span>
+    </nav>
+  );
+}

--- a/front/lib/contentful/richTextRenderer.tsx
+++ b/front/lib/contentful/richTextRenderer.tsx
@@ -7,6 +7,7 @@ import Image from "next/image";
 import type { ReactNode } from "react";
 import { useEffect, useState } from "react";
 
+import { LessonLink } from "@app/components/academy/LessonLink";
 import { A, H2, H3, H4, H5 } from "@app/components/home/ContentComponents";
 import { contentfulImageLoader } from "@app/lib/contentful/imageLoader";
 import {
@@ -251,6 +252,9 @@ const renderOptions: Options = {
       </blockquote>
     ),
     [BLOCKS.EMBEDDED_ASSET]: (node) => {
+      if (!node.data?.target?.fields) {
+        return null;
+      }
       const { file, title, description } = node.data.target.fields;
       if (!file) {
         return null;
@@ -306,6 +310,49 @@ const renderOptions: Options = {
         {children}
       </td>
     ),
+    [BLOCKS.EMBEDDED_ENTRY]: (node) => {
+      if (!node.data?.target) {
+        return null;
+      }
+      const entry = node.data.target;
+      const contentType = entry?.sys?.contentType?.sys?.id;
+
+      // Handle lesson entries
+      if (contentType === "lesson") {
+        const fields = entry.fields;
+        const title = isString(fields.title) ? fields.title : "";
+        const slug = isString(fields.slug) ? fields.slug : "";
+        const description = isString(fields.description)
+          ? fields.description
+          : null;
+        const lessonId = isString(fields.lessonId) ? fields.lessonId : null;
+        const estimatedDurationMinutes =
+          typeof fields.estimatedDurationMinutes === "number"
+            ? fields.estimatedDurationMinutes
+            : null;
+        const complexity = isString(fields.complexity)
+          ? fields.complexity
+          : null;
+
+        if (!title || !slug) {
+          return null;
+        }
+
+        return (
+          <LessonLink
+            title={title}
+            slug={slug}
+            description={description}
+            lessonId={lessonId}
+            estimatedDurationMinutes={estimatedDurationMinutes}
+            complexity={complexity}
+          />
+        );
+      }
+
+      // Fallback for other embedded entry types
+      return null;
+    },
     [INLINES.HYPERLINK]: (node, children) => {
       const url = node.data.uri;
       // Check if it's a YouTube URL and embed it

--- a/front/lib/contentful/types.ts
+++ b/front/lib/contentful/types.ts
@@ -192,3 +192,142 @@ export interface CustomerStoryPageProps {
   gtmTrackingId: string | null;
   preview?: boolean;
 }
+
+// Course types
+
+export interface CourseFields {
+  title: string;
+  dateOfAddition: string;
+  courseImage: Asset;
+  description: string;
+  courseId: string;
+  slug: string;
+  tableOfContents?: string;
+  estimatedDurationMinutes?: number;
+  preRequisites?: Document;
+  courseContent: Document;
+  previousCourse?: Entry<CourseSkeleton>;
+  nextCourse?: Entry<CourseSkeleton>;
+  author?: Entry<AuthorSkeleton>;
+}
+
+export type CourseSkeleton = EntrySkeletonType<CourseFields, "course">;
+
+export interface Course {
+  id: string;
+  slug: string;
+  title: string;
+  description: string | null;
+  courseId: string | null;
+  dateOfAddition: string | null;
+  estimatedDurationMinutes: number | null;
+  courseContent: Document;
+  preRequisites: Document | null;
+  tableOfContents: string | null;
+  image: BlogImage | null;
+  author: BlogAuthor | null;
+  previousCourse: CourseSummary | null;
+  nextCourse: CourseSummary | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CourseSummary {
+  kind: "course";
+  id: string;
+  slug: string;
+  title: string;
+  description: string | null;
+  courseId: string | null;
+  dateOfAddition: string | null;
+  estimatedDurationMinutes: number | null;
+  image: BlogImage | null;
+  createdAt: string;
+}
+
+export interface CourseListingPageProps {
+  courses: CourseSummary[];
+  gtmTrackingId: string | null;
+}
+
+export interface CoursePageProps {
+  course: Course;
+  courses: CourseSummary[];
+  gtmTrackingId: string | null;
+  preview?: boolean;
+}
+
+// Lesson types
+
+export interface LessonFields {
+  title: string;
+  dateOfAddition: string;
+  description: string;
+  lessonObjectives?: string;
+  lessonId: string;
+  slug: string;
+  estimatedDurationMinutes?: number;
+  preRequisites?: Document;
+  lessonContent: Document;
+  previousContent?: Entry<CourseSkeleton | LessonSkeleton>;
+  nextContent?: Entry<CourseSkeleton | LessonSkeleton>;
+  Category?: string;
+  tools?: string[];
+  complexity?: string;
+  parentCourse?: Entry<CourseSkeleton>;
+}
+
+export type LessonSkeleton = EntrySkeletonType<LessonFields, "lesson">;
+
+export type ContentSummary = CourseSummary | LessonSummary;
+
+export interface Lesson {
+  id: string;
+  slug: string;
+  title: string;
+  description: string | null;
+  lessonId: string | null;
+  dateOfAddition: string | null;
+  estimatedDurationMinutes: number | null;
+  lessonObjectives: string | null;
+  lessonContent: Document;
+  preRequisites: Document | null;
+  previousContent: ContentSummary | null;
+  nextContent: ContentSummary | null;
+  category: string | null;
+  tools: string[];
+  complexity: string | null;
+  parentCourse: CourseSummary | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface LessonSummary {
+  kind: "lesson";
+  id: string;
+  slug: string;
+  title: string;
+  description: string | null;
+  lessonId: string | null;
+  estimatedDurationMinutes: number | null;
+  createdAt: string;
+}
+
+export function isCourseSummary(
+  content: ContentSummary
+): content is CourseSummary {
+  return content.kind === "course";
+}
+
+export function isLessonSummary(
+  content: ContentSummary
+): content is LessonSummary {
+  return content.kind === "lesson";
+}
+
+export interface LessonPageProps {
+  lesson: Lesson;
+  courses: CourseSummary[];
+  gtmTrackingId: string | null;
+  preview?: boolean;
+}


### PR DESCRIPTION
## Summary

- Extracts the Pagination component from BlogPagination into a reusable shared component
- Adds Course and Lesson types to Contentful types
- Adds Course and Lesson fetching functions to Contentful client
- Adds rich text renderer utilities for Academy content

This PR prepares the data layer for the Academy feature. A follow-up PR will add the UI components and pages.

## Test plan

- [ ] Verify blog pagination still works correctly
- [ ] Types and functions are ready for Academy UI integration

## Risk

Low - refactoring only, no new user-facing features

## Deploy Plan

Front only

🤖 Generated with [Claude Code](https://claude.com/claude-code)