### PR TITLE
[front/navigation] - fix: adjust padding condition for NavigationSidebar

### DIFF
--- a/front/components/navigation/NavigationSidebar.tsx
+++ b/front/components/navigation/NavigationSidebar.tsx
@@ -98,7 +98,9 @@ export const NavigationSidebar = React.forwardRef<
       <div
         className={cn(
           "flex flex-col gap-2",
-          appStatus !== null || subscription.paymentFailingSince !== null
+          appStatus?.dustStatus ||
+            appStatus?.providersStatus ||
+            subscription.paymentFailingSince
             ? ""
             : "pt-3"
         )}


### PR DESCRIPTION
## Description

Modify conditional padding logic to account for new appStatus properties DustStatus and ProvidersStatus, besides paymentFailingSince.

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy frton