### PR TITLE
feat: improve project metadata mcp

### DIFF
--- a/front/lib/api/assistant/generation.test.ts
+++ b/front/lib/api/assistant/generation.test.ts
@@ -132,12 +132,13 @@ describe("constructProjectContextSection", () => {
   
 This conversation is associated with a project. The project provides:
 - Persistent file storage shared across all conversations in this project
+- Project metadata (description and URLs) for organizational context
 - Semantic search capabilities over project files
 - Collaborative context that persists beyond individual conversations
 
 ## Using Project Tools
 
-**project_context_management**: Use these tools to manage persistent project files
+**project_context_management**: Use these tools to manage persistent project files and metadata
 **search_project_context**: Use this tool to semantically search across all project files when you need to:
 - Find relevant information within the project
 - Locate specific content across multiple files

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -91,12 +91,13 @@ export function constructProjectContextSection(
   
 This conversation is associated with a project. The project provides:
 - Persistent file storage shared across all conversations in this project
+- Project metadata (description and URLs) for organizational context
 - Semantic search capabilities over project files
 - Collaborative context that persists beyond individual conversations
 
 ## Using Project Tools
 
-**project_context_management**: Use these tools to manage persistent project files
+**project_context_management**: Use these tools to manage persistent project files and metadata
 **search_project_context**: Use this tool to semantically search across all project files when you need to:
 - Find relevant information within the project
 - Locate specific content across multiple files


### PR DESCRIPTION
## Description

In the project metadata MCP add tools to edit the project metadata.

I went to only add *not* delete. Also no editing of the project name. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
