### PR TITLE
[Relocation] Fix user_metadata FK violation

### DIFF
--- a/front/temporal/relocation/activities/source_region/front/sql.ts
+++ b/front/temporal/relocation/activities/source_region/front/sql.ts
@@ -70,10 +70,16 @@ export async function readCoreEntitiesFromSourceRegion({
   });
 
   // Fetch all associated users metadata of the workspace.
+  // Only fetch metadata where workspaceId is null (global) or matches the workspace being
+  // relocated. This avoids FK violations when inserting into destination region for metadata
+  // referencing other workspaces.
   const userMetadata = await UserMetadataModel.findAll({
     where: {
       userId: {
         [Op.in]: memberships.map((m) => m.userId),
+      },
+      workspaceId: {
+        [Op.or]: [{ [Op.is]: null }, { [Op.eq]: workspace.id }],
       },
     },
     raw: true,


### PR DESCRIPTION
## Description

Context: https://dust4ai.slack.com/archives/C050SM8NSPK/p1769011789620619

During workspace relocation, the readCoreEntitiesFromSourceRegion function fetches all user_metadata records for workspace members. However, users may have metadata records associated with other workspaces they belong to. When these records are inserted into the destination region, they fail with a FK violation because the referenced workspace does not exist there.

The fix filters user_metadata to only include records where workspaceId is either:
- NULL (global user metadata), or
- Equal to the workspace being relocated

## Risks

Blast radius: workspace relocation workflow
Risk: low

## Deploy Plan

- deploy front