### PR TITLE
[front] chore(skills): move button for attaching knowledge

### DIFF
--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -1,4 +1,3 @@
-import { AttachmentIcon, Button } from "@dust-tt/sparkle";
 import type { Transaction } from "@tiptap/pm/state";
 import type { Editor } from "@tiptap/react";
 import { cva } from "class-variance-authority";
@@ -52,11 +51,13 @@ const editorVariants = cva(
 interface SkillBuilderInstructionsEditorProps {
   compareVersion?: SkillType | null;
   isInstructionDiffMode?: boolean;
+  onAddKnowledge?: (addKnowledge: () => void) => void;
 }
 
 export function SkillBuilderInstructionsEditor({
   compareVersion,
   isInstructionDiffMode = false,
+  onAddKnowledge,
 }: SkillBuilderInstructionsEditorProps) {
   const { field: instructionsField, fieldState: instructionsFieldState } =
     useController<SkillBuilderFormData, typeof INSTRUCTIONS_FIELD_NAME>({
@@ -156,6 +157,12 @@ export function SkillBuilderInstructionsEditor({
   }, [editor]);
 
   useEffect(() => {
+    if (editor && onAddKnowledge) {
+      onAddKnowledge(handleAddKnowledge);
+    }
+  }, [editor, handleAddKnowledge, onAddKnowledge]);
+
+  useEffect(() => {
     return () => {
       debouncedUpdate.cancel();
     };
@@ -220,20 +227,7 @@ export function SkillBuilderInstructionsEditor({
 
   return (
     <div className="space-y-1 p-px">
-      <div className="relative">
-        <SkillInstructionsEditorContent editor={editor} isReadOnly={false} />
-
-        {/* Floating Add Knowledge Button */}
-        <Button
-          size="xs"
-          variant="ghost"
-          icon={AttachmentIcon}
-          onClick={handleAddKnowledge}
-          className="absolute bottom-2 left-2"
-          tooltip="Add knowledge"
-          disabled={!editor}
-        />
-      </div>
+      <SkillInstructionsEditorContent editor={editor} isReadOnly={false} />
 
       {instructionsFieldState.error && (
         <div className="dark:text-warning-night ml-2 text-xs text-warning">

--- a/front/components/skill_builder/SkillBuilderInstructionsSection.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsSection.tsx
@@ -1,5 +1,6 @@
 import {
   ArrowPathIcon,
+  BookOpenIcon,
   Button,
   Label,
   Separator,
@@ -33,6 +34,7 @@ export function SkillBuilderInstructionsSection({
   const [compareVersion, setCompareVersion] =
     useState<SkillWithVersionType | null>(null);
   const [isInstructionDiffMode, setIsInstructionDiffMode] = useState(false);
+  const [addKnowledge, setAddKnowledge] = useState<(() => void) | null>(null);
 
   const { skillHistory } = useSkillHistory({
     owner,
@@ -71,16 +73,19 @@ export function SkillBuilderInstructionsSection({
   return (
     <section className="flex flex-col gap-3">
       <div className="flex flex-col items-end justify-between gap-2 sm:flex-row">
-        <div>
-          <h3 className="heading-lg font-semibold text-foreground dark:text-foreground-night">
-            What guidelines should it provide?
-          </h3>
+        <h3 className="heading-lg font-semibold text-foreground dark:text-foreground-night">
+          What guidelines should it provide?
+        </h3>
+        <div className="flex items-center gap-2">
+          {headerActions}
+          <Button
+            variant="primary"
+            label="Attach knowledge"
+            icon={BookOpenIcon}
+            onClick={addKnowledge ?? undefined}
+            disabled={!addKnowledge}
+          />
         </div>
-        {headerActions && (
-          <div className="flex w-full flex-col gap-2 sm:w-auto">
-            <div className="flex items-center gap-2">{headerActions}</div>
-          </div>
-        )}
       </div>
       {isInstructionDiffMode && compareVersion && (
         <>
@@ -115,6 +120,7 @@ export function SkillBuilderInstructionsSection({
       <SkillBuilderInstructionsEditor
         compareVersion={compareVersion}
         isInstructionDiffMode={isInstructionDiffMode}
+        onAddKnowledge={(fn) => setAddKnowledge(() => fn)}
       />
     </section>
   );


### PR DESCRIPTION
## Description

- This PR moves the button for attaching knowledge in Skill Builder.
- Goal is to increase discoverability.
- The change is front-end only, moves the button but the triggered action is the same.

<img width="789" height="258" alt="Screenshot 2026-01-21 at 6 03 11 PM" src="https://github.com/user-attachments/assets/afa69fb8-9f21-4caa-87c0-d7a75a22af66" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
