### PR TITLE
[Conversation] Fix race condition in agent loop workflow launch

### DIFF
--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -684,6 +684,9 @@ describe("postUserMessage", () => {
         .filter((id): id is string => id !== null);
       expect(agentConfigIdsInDb).toContain(agentConfig1.sId);
       expect(agentConfigIdsInDb).toContain(agentConfig2.sId);
+
+      // Verify launchAgentLoopWorkflow was called for agent mentions
+      expect(launchAgentLoopWorkflow).toHaveBeenCalled();
     }
   });
 
@@ -746,6 +749,9 @@ describe("postUserMessage", () => {
         },
       });
       expect(mentionInDb).not.toBeNull();
+
+      // Verify launchAgentLoopWorkflow was NOT called (no agent mentions)
+      expect(launchAgentLoopWorkflow).not.toHaveBeenCalled();
     }
   });
 
@@ -815,6 +821,9 @@ describe("postUserMessage", () => {
         },
       });
       expect(mentionsInDb.length).toBe(2);
+
+      // Verify launchAgentLoopWorkflow was called for agent mentions
+      expect(launchAgentLoopWorkflow).toHaveBeenCalled();
     }
   });
 
@@ -848,6 +857,9 @@ describe("postUserMessage", () => {
       // Verify userMessage has empty richMentions
       expect(userMessage.richMentions).toBeDefined();
       expect(userMessage.richMentions.length).toBe(0);
+
+      // Verify launchAgentLoopWorkflow was NOT called (no agent mentions)
+      expect(launchAgentLoopWorkflow).not.toHaveBeenCalled();
     }
   });
 });
@@ -973,6 +985,9 @@ describe("editUserMessage", () => {
         .filter((id): id is string => id !== null);
       expect(agentConfigIdsInDb).toContain(agentConfig1.sId);
       expect(agentConfigIdsInDb).toContain(agentConfig2.sId);
+
+      // Verify launchAgentLoopWorkflow was called for agent mentions
+      expect(launchAgentLoopWorkflow).toHaveBeenCalled();
     }
   });
 
@@ -1025,6 +1040,9 @@ describe("editUserMessage", () => {
         },
       });
       expect(mentionInDb).not.toBeNull();
+
+      // Verify launchAgentLoopWorkflow was NOT called (no agent mentions)
+      expect(launchAgentLoopWorkflow).not.toHaveBeenCalled();
     }
   });
 
@@ -1084,6 +1102,9 @@ describe("editUserMessage", () => {
         },
       });
       expect(mentionsInDb.length).toBe(2);
+
+      // Verify launchAgentLoopWorkflow was called for agent mentions
+      expect(launchAgentLoopWorkflow).toHaveBeenCalled();
     }
   });
 
@@ -1116,6 +1137,9 @@ describe("editUserMessage", () => {
         },
       });
       expect(mentionsInDb.length).toBe(0);
+
+      // Verify launchAgentLoopWorkflow was NOT called (no agent mentions)
+      expect(launchAgentLoopWorkflow).not.toHaveBeenCalled();
     }
   });
 
@@ -1159,6 +1183,9 @@ describe("editUserMessage", () => {
       if (isRichUserMention(userMention)) {
         expect(userMention.id).toBe(mentionedUser.sId);
       }
+
+      // Verify launchAgentLoopWorkflow was NOT called (no agent mentions)
+      expect(launchAgentLoopWorkflow).not.toHaveBeenCalled();
     }
   });
 });

--- a/front/lib/api/assistant/conversation/mentions.test.ts
+++ b/front/lib/api/assistant/conversation/mentions.test.ts
@@ -615,22 +615,20 @@ describe("createAgentMessages", () => {
     expect(agentConfigWithSpaces?.requestedSpaceIds).toContain(space2.sId);
 
     // Call createAgentMessages
-    const { richMentions } = await withTransaction(
-      async (transaction) => {
-        return createAgentMessages(auth, {
-          conversation: testConversation,
-          metadata: {
-            type: "create",
-            mentions,
-            agentConfigurations: [agentConfigWithSpaces!],
-            skipToolsValidation: false,
-            nextMessageRank: 1,
-            userMessage,
-          },
-          transaction,
-        });
-      }
-    );
+    const { richMentions } = await withTransaction(async (transaction) => {
+      return createAgentMessages(auth, {
+        conversation: testConversation,
+        metadata: {
+          type: "create",
+          mentions,
+          agentConfigurations: [agentConfigWithSpaces!],
+          skipToolsValidation: false,
+          nextMessageRank: 1,
+          userMessage,
+        },
+        transaction,
+      });
+    });
 
     // Verify richMentions are returned correctly
     expect(richMentions).toHaveLength(1);
@@ -744,22 +742,20 @@ describe("createAgentMessages", () => {
     expect(agentConfigWithSpaces?.requestedSpaceIds).toContain(space2.sId);
 
     // Call createAgentMessages
-    const { richMentions } = await withTransaction(
-      async (transaction) => {
-        return createAgentMessages(auth, {
-          conversation: testConversation,
-          metadata: {
-            type: "create",
-            mentions,
-            agentConfigurations: [agentConfigWithSpaces!],
-            skipToolsValidation: false,
-            nextMessageRank: 1,
-            userMessage,
-          },
-          transaction,
-        });
-      }
-    );
+    const { richMentions } = await withTransaction(async (transaction) => {
+      return createAgentMessages(auth, {
+        conversation: testConversation,
+        metadata: {
+          type: "create",
+          mentions,
+          agentConfigurations: [agentConfigWithSpaces!],
+          skipToolsValidation: false,
+          nextMessageRank: 1,
+          userMessage,
+        },
+        transaction,
+      });
+    });
 
     // Verify richMentions are returned correctly
     expect(richMentions).toHaveLength(1);
@@ -873,22 +869,20 @@ describe("createAgentMessages", () => {
     expect(agentConfigWithSpaces?.requestedSpaceIds).toContain(space2.sId);
 
     // Call createAgentMessages
-    const { richMentions } = await withTransaction(
-      async (transaction) => {
-        return createAgentMessages(auth, {
-          conversation: testConversation,
-          metadata: {
-            type: "create",
-            mentions,
-            agentConfigurations: [agentConfigWithSpaces!],
-            skipToolsValidation: false,
-            nextMessageRank: 1,
-            userMessage,
-          },
-          transaction,
-        });
-      }
-    );
+    const { richMentions } = await withTransaction(async (transaction) => {
+      return createAgentMessages(auth, {
+        conversation: testConversation,
+        metadata: {
+          type: "create",
+          mentions,
+          agentConfigurations: [agentConfigWithSpaces!],
+          skipToolsValidation: false,
+          nextMessageRank: 1,
+          userMessage,
+        },
+        transaction,
+      });
+    });
 
     // Verify richMentions are returned correctly
     expect(richMentions).toHaveLength(1);

--- a/front/lib/api/assistant/conversation/mentions.test.ts
+++ b/front/lib/api/assistant/conversation/mentions.test.ts
@@ -5,15 +5,9 @@ vi.mock("@app/lib/api/assistant/agent_usage", () => ({
   signalAgentUsage: vi.fn(),
 }));
 
-// Mock runAgentLoopWorkflow before importing the module that uses it
-vi.mock("@app/lib/api/assistant/conversation/agent_loop", () => ({
-  runAgentLoopWorkflow: vi.fn(),
-}));
-
 import { signalAgentUsage } from "@app/lib/api/assistant/agent_usage";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { createConversation } from "@app/lib/api/assistant/conversation";
-import { runAgentLoopWorkflow } from "@app/lib/api/assistant/conversation/agent_loop";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import {
   createAgentMessages,
@@ -292,14 +286,8 @@ describe("createAgentMessages", () => {
       workspaceId: workspace.sId,
     });
 
-    // Verify runAgentLoopWorkflow was called with correct arguments
-    expect(runAgentLoopWorkflow).toHaveBeenCalledTimes(1);
-    expect(runAgentLoopWorkflow).toHaveBeenCalledWith({
-      auth,
-      agentMessages,
-      conversation,
-      userMessage,
-    });
+    // Note: runAgentLoopWorkflow is no longer called from createAgentMessages.
+    // It's now called from postUserMessage/editUserMessage after the transaction commits.
   });
 
   it("should return empty array when no agent mentions are provided", async () => {
@@ -329,9 +317,6 @@ describe("createAgentMessages", () => {
 
     // Verify signalAgentUsage was not called when no agent mentions are provided
     expect(signalAgentUsage).not.toHaveBeenCalled();
-
-    // Verify runAgentLoopWorkflow was not called when no agent messages are created
-    expect(runAgentLoopWorkflow).not.toHaveBeenCalled();
   });
 
   it("should set skipToolsValidation correctly", async () => {
@@ -375,15 +360,6 @@ describe("createAgentMessages", () => {
     expect(signalAgentUsage).toHaveBeenCalledWith({
       agentConfigurationId: agentConfig1.sId,
       workspaceId: workspace.sId,
-    });
-
-    // Verify runAgentLoopWorkflow was called with correct arguments
-    expect(runAgentLoopWorkflow).toHaveBeenCalledTimes(1);
-    expect(runAgentLoopWorkflow).toHaveBeenCalledWith({
-      auth,
-      agentMessages,
-      conversation,
-      userMessage,
     });
   });
 
@@ -434,15 +410,6 @@ describe("createAgentMessages", () => {
       agentConfigurationId: agentConfig1.sId,
       workspaceId: workspace.sId,
     });
-
-    // Verify runAgentLoopWorkflow was called with correct arguments
-    expect(runAgentLoopWorkflow).toHaveBeenCalledTimes(1);
-    expect(runAgentLoopWorkflow).toHaveBeenCalledWith({
-      auth,
-      agentMessages,
-      conversation,
-      userMessage,
-    });
   });
 
   it("should set parentAgentMessageId to null when context origin is not agent_handover", async () => {
@@ -487,15 +454,6 @@ describe("createAgentMessages", () => {
     expect(signalAgentUsage).toHaveBeenCalledWith({
       agentConfigurationId: agentConfig1.sId,
       workspaceId: workspace.sId,
-    });
-
-    // Verify runAgentLoopWorkflow was called with correct arguments
-    expect(runAgentLoopWorkflow).toHaveBeenCalledTimes(1);
-    expect(runAgentLoopWorkflow).toHaveBeenCalledWith({
-      auth,
-      agentMessages,
-      conversation,
-      userMessage,
     });
   });
 
@@ -557,15 +515,6 @@ describe("createAgentMessages", () => {
     expect(signalAgentUsage).toHaveBeenCalledWith({
       agentConfigurationId: agentConfig2.sId,
       workspaceId: workspace.sId,
-    });
-
-    // Verify runAgentLoopWorkflow was called with correct arguments
-    expect(runAgentLoopWorkflow).toHaveBeenCalledTimes(1);
-    expect(runAgentLoopWorkflow).toHaveBeenCalledWith({
-      auth,
-      agentMessages,
-      conversation,
-      userMessage,
     });
   });
 
@@ -689,15 +638,6 @@ describe("createAgentMessages", () => {
       expect(richMentions[0].id).toBe(agentConfig.sId);
       expect(richMentions[0].status).toBe("approved");
     }
-
-    // Verify runAgentLoopWorkflow was called with correct arguments
-    expect(runAgentLoopWorkflow).toHaveBeenCalledTimes(1);
-    expect(runAgentLoopWorkflow).toHaveBeenCalledWith({
-      auth,
-      agentMessages,
-      conversation: testConversation,
-      userMessage,
-    });
 
     // Fetch conversation after createAgentMessages
     const conversationAfter = await ConversationResource.fetchById(
@@ -828,15 +768,6 @@ describe("createAgentMessages", () => {
       expect(richMentions[0].status).toBe("approved");
     }
 
-    // Verify runAgentLoopWorkflow was called with correct arguments
-    expect(runAgentLoopWorkflow).toHaveBeenCalledTimes(1);
-    expect(runAgentLoopWorkflow).toHaveBeenCalledWith({
-      auth,
-      agentMessages,
-      conversation: testConversation,
-      userMessage,
-    });
-
     // Fetch conversation after createAgentMessages
     const conversationAfter = await ConversationResource.fetchById(
       auth,
@@ -965,15 +896,6 @@ describe("createAgentMessages", () => {
       expect(richMentions[0].id).toBe(agentConfig.sId);
       expect(richMentions[0].status).toBe("approved");
     }
-
-    // Verify runAgentLoopWorkflow was called with correct arguments
-    expect(runAgentLoopWorkflow).toHaveBeenCalledTimes(1);
-    expect(runAgentLoopWorkflow).toHaveBeenCalledWith({
-      auth,
-      agentMessages,
-      conversation: testConversation,
-      userMessage,
-    });
 
     // Fetch conversation after createAgentMessages
     const conversationAfter = await ConversationResource.fetchById(

--- a/front/lib/api/assistant/conversation/mentions.test.ts
+++ b/front/lib/api/assistant/conversation/mentions.test.ts
@@ -615,7 +615,7 @@ describe("createAgentMessages", () => {
     expect(agentConfigWithSpaces?.requestedSpaceIds).toContain(space2.sId);
 
     // Call createAgentMessages
-    const { agentMessages, richMentions } = await withTransaction(
+    const { richMentions } = await withTransaction(
       async (transaction) => {
         return createAgentMessages(auth, {
           conversation: testConversation,
@@ -744,7 +744,7 @@ describe("createAgentMessages", () => {
     expect(agentConfigWithSpaces?.requestedSpaceIds).toContain(space2.sId);
 
     // Call createAgentMessages
-    const { agentMessages, richMentions } = await withTransaction(
+    const { richMentions } = await withTransaction(
       async (transaction) => {
         return createAgentMessages(auth, {
           conversation: testConversation,
@@ -873,7 +873,7 @@ describe("createAgentMessages", () => {
     expect(agentConfigWithSpaces?.requestedSpaceIds).toContain(space2.sId);
 
     // Call createAgentMessages
-    const { agentMessages, richMentions } = await withTransaction(
+    const { richMentions } = await withTransaction(
       async (transaction) => {
         return createAgentMessages(auth, {
           conversation: testConversation,

--- a/front/lib/api/assistant/conversation/mentions.ts
+++ b/front/lib/api/assistant/conversation/mentions.ts
@@ -70,7 +70,6 @@ import {
   toMentionType,
 } from "@app/types";
 
-import { runAgentLoopWorkflow } from "./agent_loop";
 import { getConversation } from "./fetch";
 
 /**
@@ -829,17 +828,6 @@ export const createAgentMessages = async (
     conversation,
     t: transaction,
   });
-
-  if (metadata.type === "create") {
-    if (agentMessages.length > 0) {
-      await runAgentLoopWorkflow({
-        auth,
-        agentMessages,
-        conversation,
-        userMessage: metadata.userMessage,
-      });
-    }
-  }
 
   return { agentMessages, richMentions };
 };


### PR DESCRIPTION
Fixes https://github.com/dust-tt/tasks/issues/6000

## Description

Context: [Temporal workflow failure](https://cloud.temporal.io/namespaces/eu-dust-front-prod.gmnlm/workflows/usage-tracking-2WJ4Akk9tx-SEit7YFnEE-Ax4bbnhqSP/019bdabc-6df9-7edc-80f4-ac08200006d9/history)

A regression was introduced in https://github.com/dust-tt/dust/pull/18525 : the agent loop workflow was being launched inside the database transaction that creates user and agent messages (`postUserMessage`, `editUserMessage`). This resulted in a race condition where the agent loop might silently exit early and the tracking workflow fail when trying to grab agentMessages/userMessages

The agent loop relies on user and agent messages being persisted in the database before it can execute. By moving the workflow launch after the transaction commits, we ensure the messages are available when the workflow starts.

Note: `retryAgentMessage` already correctly launches the workflow after its transaction commits.

## Risk

Blast radius: conversation message posting and editing
Risk: low (moving async operation outside transaction is a safe fix)

## Deploy Plan

- deploy front
