### PR TITLE
[front] fix(skills): pass remote db data sources to data warehouse

### DIFF
--- a/front/lib/api/assistant/skill_actions.ts
+++ b/front/lib/api/assistant/skill_actions.ts
@@ -1,7 +1,9 @@
 import { buildServerSideMCPServerConfiguration } from "@app/lib/actions/configuration/helpers";
 import type { MCPServerConfigurationType } from "@app/lib/actions/mcp";
+import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import type { DataSourceConfiguration } from "@app/lib/api/assistant/configuration/types";
 import type { Authenticator } from "@app/lib/auth";
+import { isRemoteDatabase } from "@app/lib/data_sources";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import type { SkillResource } from "@app/lib/resources/skill/skill_resource";
@@ -29,12 +31,12 @@ export async function getSkillServers(
   const inheritedDataSourceViews = removeNulls(
     rawInheritedDataSourceViews.flat()
   );
-  const dataSources: DataSourceConfiguration[] = inheritedDataSourceViews.map(
-    (view) => ({
-      dataSourceViewId: view.sId,
-      workspaceId: auth.getNonNullableWorkspace().sId,
-      filter: view.toViewFilter(),
-    })
+
+  const remoteDbViews = inheritedDataSourceViews.filter((v) =>
+    isRemoteDatabase(v.dataSource)
+  );
+  const nonRemoteDbViews = inheritedDataSourceViews.filter(
+    (v) => !isRemoteDatabase(v.dataSource)
   );
 
   return skills.flatMap((skill) =>
@@ -42,6 +44,26 @@ export async function getSkillServers(
       ...skill.mcpServerViews,
       ...(skill.extendedSkill?.mcpServerViews ?? []),
     ].map((mcpServerView) => {
+      const {
+        requiresDataWarehouseConfiguration,
+        requiresDataSourceConfiguration,
+      } = getMCPServerRequirements(mcpServerView.toJSON());
+
+      let applicableViews: DataSourceViewResource[];
+      if (requiresDataWarehouseConfiguration) {
+        applicableViews = remoteDbViews;
+      } else if (requiresDataSourceConfiguration) {
+        applicableViews = nonRemoteDbViews;
+      } else {
+        applicableViews = [];
+      }
+
+      const dataSources = applicableViews.map((view) => ({
+        dataSourceViewId: view.sId,
+        workspaceId: auth.getNonNullableWorkspace().sId,
+        filter: view.toViewFilter(),
+      }));
+
       return buildServerSideMCPServerConfiguration({
         mcpServerView,
         dataSources,


### PR DESCRIPTION
## Description

- This PR fixes how data sources are configured for the MCP servers created for skills.
- It adds a routing: if the server requires a data warehouse config, then we only show the remote db data sources (Snowflake/BigQuery), otherwise if it requires a data source config then we show non remote db.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
