### PR TITLE
[front] enh(poke): add skills to agent poke page

### DIFF
--- a/front/components/poke/pages/AssistantDetailsPage.tsx
+++ b/front/components/poke/pages/AssistantDetailsPage.tsx
@@ -5,6 +5,8 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
+  ExternalLinkIcon,
+  IconButton,
   LinkWrapper,
   Page,
   Spinner,
@@ -60,7 +62,7 @@ export function AssistantDetailsPage({
     );
   }
 
-  const { agentConfigurations, authors, lastVersionEditors, spaces } =
+  const { agentConfigurations, authors, lastVersionEditors, spaces, skills } =
     agentDetails;
 
   return (
@@ -189,6 +191,32 @@ export function AssistantDetailsPage({
                           <JsonViewer
                             theme={isDark ? "dark" : "light"}
                             value={decodeSqids(action)}
+                            rootName={false}
+                            defaultInspectDepth={0}
+                          />
+                        </div>
+                      ))}
+                    </div>
+                    <div className="ml-4 text-sm text-muted-foreground dark:text-muted-foreground-night">
+                      <div className="font-bold">Skills:</div>
+                      {skills.map((skill) => (
+                        <div key={skill.sId}>
+                          <div className="flex items-center gap-1">
+                            {skill.name}
+                            <LinkWrapper
+                              href={`/poke/${owner.sId}/skills/${skill.sId}`}
+                              target="_blank"
+                            >
+                              <IconButton
+                                icon={ExternalLinkIcon}
+                                size="xs"
+                                variant="outline"
+                              />
+                            </LinkWrapper>
+                          </div>
+                          <JsonViewer
+                            theme={isDark ? "dark" : "light"}
+                            value={skill}
                             rootName={false}
                             defaultInspectDepth={0}
                           />

--- a/front/components/poke/pages/AssistantDetailsPage.tsx
+++ b/front/components/poke/pages/AssistantDetailsPage.tsx
@@ -199,29 +199,33 @@ export function AssistantDetailsPage({
                     </div>
                     <div className="ml-4 text-sm text-muted-foreground dark:text-muted-foreground-night">
                       <div className="font-bold">Skills:</div>
-                      {skills.map((skill) => (
-                        <div key={skill.sId}>
-                          <div className="flex items-center gap-1">
-                            {skill.name}
-                            <LinkWrapper
-                              href={`/poke/${owner.sId}/skills/${skill.sId}`}
-                              target="_blank"
-                            >
-                              <IconButton
-                                icon={ExternalLinkIcon}
-                                size="xs"
-                                variant="outline"
-                              />
-                            </LinkWrapper>
+                      {skills.length === 0 ? (
+                        <div>No skills</div>
+                      ) : (
+                        skills.map((skill) => (
+                          <div key={skill.sId}>
+                            <div className="flex items-center gap-1">
+                              {skill.name}
+                              <LinkWrapper
+                                href={`/poke/${owner.sId}/skills/${skill.sId}`}
+                                target="_blank"
+                              >
+                                <IconButton
+                                  icon={ExternalLinkIcon}
+                                  size="xs"
+                                  variant="outline"
+                                />
+                              </LinkWrapper>
+                            </div>
+                            <JsonViewer
+                              theme={isDark ? "dark" : "light"}
+                              value={skill}
+                              rootName={false}
+                              defaultInspectDepth={0}
+                            />
                           </div>
-                          <JsonViewer
-                            theme={isDark ? "dark" : "light"}
-                            value={skill}
-                            rootName={false}
-                            defaultInspectDepth={0}
-                          />
-                        </div>
-                      ))}
+                        ))
+                      )}
                     </div>
                     <div className="ml-4 text-sm text-muted-foreground dark:text-muted-foreground-night">
                       <div className="font-bold">Instructions:</div>


### PR DESCRIPTION
## Description

- This PR adds the skills to the agent poke page.

<img width="1035" height="391" alt="Screenshot 2026-01-21 at 11 50 34 PM" src="https://github.com/user-attachments/assets/bfe7803c-7169-42c5-96fe-6bdf67ea8122" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
