### PR TITLE
[front] enh(similar-skills): add button to open Manage Skills page

### DIFF
--- a/front/components/skill_builder/SimilarSkillsDisplay.tsx
+++ b/front/components/skill_builder/SimilarSkillsDisplay.tsx
@@ -1,4 +1,4 @@
-import { ExternalLinkIcon, IconButton, Spinner } from "@dust-tt/sparkle";
+import { ExternalLinkIcon, Icon, Spinner } from "@dust-tt/sparkle";
 import Link from "next/link";
 import React from "react";
 
@@ -53,12 +53,9 @@ export function SimilarSkillsDisplay({
                   <Link
                     href={`/w/${owner.sId}/builder/skills/${skill.sId}`}
                     target="_blank"
+                    className="text-muted-foreground hover:text-foreground dark:text-muted-foreground-night dark:hover:text-foreground-night"
                   >
-                    <IconButton
-                      icon={ExternalLinkIcon}
-                      size="xmini"
-                      variant="outline"
-                    />
+                    <Icon visual={ExternalLinkIcon} size="xs" />
                   </Link>
                 </div>
                 <span className="line-clamp-1 text-xs text-muted-foreground dark:text-muted-foreground-night">

--- a/front/components/skill_builder/SimilarSkillsDisplay.tsx
+++ b/front/components/skill_builder/SimilarSkillsDisplay.tsx
@@ -51,7 +51,7 @@ export function SimilarSkillsDisplay({
                     {skill.name}
                   </span>
                   <Link
-                    href={`/w/${owner.sId}/builder/skills/${skill.sId}`}
+                    href={`/w/${owner.sId}/builder/skills#?skillId=${skill.sId}`}
                     target="_blank"
                     className="text-muted-foreground hover:text-foreground dark:text-muted-foreground-night dark:hover:text-foreground-night"
                   >

--- a/front/components/skill_builder/SimilarSkillsDisplay.tsx
+++ b/front/components/skill_builder/SimilarSkillsDisplay.tsx
@@ -56,8 +56,8 @@ export function SimilarSkillsDisplay({
                   >
                     <IconButton
                       icon={ExternalLinkIcon}
-                      size="xs"
-                      variant="ghost"
+                      size="xmini"
+                      variant="outline"
                     />
                   </Link>
                 </div>

--- a/front/components/skill_builder/SimilarSkillsDisplay.tsx
+++ b/front/components/skill_builder/SimilarSkillsDisplay.tsx
@@ -1,14 +1,19 @@
-import { Spinner } from "@dust-tt/sparkle";
+import { ExternalLinkIcon, IconButton, Spinner } from "@dust-tt/sparkle";
+import Link from "next/link";
+import React from "react";
 
 import { getSkillAvatarIcon } from "@app/lib/skill";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
+import type { LightWorkspaceType } from "@app/types/user";
 
-type SimilarSkillsDisplayProps = {
+interface SimilarSkillsDisplayProps {
+  owner: LightWorkspaceType;
   similarSkills: SkillType[];
   isLoading: boolean;
-};
+}
 
 export function SimilarSkillsDisplay({
+  owner,
   similarSkills,
   isLoading,
 }: SimilarSkillsDisplayProps) {
@@ -41,9 +46,21 @@ export function SimilarSkillsDisplay({
             <div key={skill.sId} className="flex items-start gap-3">
               <SkillAvatar name={skill.name} size="sm" />
               <div className="flex flex-col">
-                <span className="text-sm font-medium text-foreground dark:text-foreground-night">
-                  {skill.name}
-                </span>
+                <div className="flex items-center gap-1">
+                  <span className="text-sm font-medium text-foreground dark:text-foreground-night">
+                    {skill.name}
+                  </span>
+                  <Link
+                    href={`/w/${owner.sId}/builder/skills/${skill.sId}`}
+                    target="_blank"
+                  >
+                    <IconButton
+                      icon={ExternalLinkIcon}
+                      size="xs"
+                      variant="ghost"
+                    />
+                  </Link>
+                </div>
                 <span className="line-clamp-1 text-xs text-muted-foreground dark:text-muted-foreground-night">
                   {skill.agentFacingDescription}
                 </span>

--- a/front/components/skill_builder/SkillBuilderAgentFacingDescriptionSection.tsx
+++ b/front/components/skill_builder/SkillBuilderAgentFacingDescriptionSection.tsx
@@ -102,6 +102,7 @@ export function SkillBuilderAgentFacingDescriptionSection() {
           />
           {isSimilarSkillsEnabled && (
             <SimilarSkillsDisplay
+              owner={owner}
               similarSkills={similarSkills}
               isLoading={isLoading}
             />


### PR DESCRIPTION
## Description

- This PR adds a link to the Manage skills page for similar skills detected.

<img width="975" height="401" alt="Screenshot 2026-01-22 at 12 10 18 AM" src="https://github.com/user-attachments/assets/ed030666-2433-4059-98b1-5329c2991169" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
