### PR TITLE
db: add lastReadAt to ConversationParticipant

### DIFF
--- a/front/lib/models/agent/conversation.ts
+++ b/front/lib/models/agent/conversation.ts
@@ -143,6 +143,7 @@ export class ConversationParticipantModel extends WorkspaceAwareModel<Conversati
   declare action: ParticipantActionType;
   declare unread: boolean;
   declare actionRequired: boolean;
+  declare lastReadAt: Date | null;
 
   declare conversationId: ForeignKey<ConversationModel["id"]>;
   declare userId: ForeignKey<UserModel["id"]>;

--- a/front/lib/models/agent/conversation.ts
+++ b/front/lib/models/agent/conversation.ts
@@ -176,6 +176,10 @@ ConversationParticipantModel.init(
       allowNull: false,
       defaultValue: false,
     },
+    lastReadAt: {
+      type: DataTypes.DATE,
+      allowNull: true,
+    },
   },
   {
     modelName: "conversation_participant",

--- a/front/migrations/db/migration_489.sql
+++ b/front/migrations/db/migration_489.sql
@@ -10,3 +10,4 @@ ALTER TABLE "agent_suggestions" ALTER COLUMN "agentConfigurationIdTmp" SET NOT N
 
 -- Create new index on the new column
 CREATE INDEX CONCURRENTLY "agent_suggestions_workspace_id_agent_configuration_id_tmp" ON "agent_suggestions" ("workspaceId", "agentConfigurationIdTmp");
+

--- a/front/migrations/db/migration_493.sql
+++ b/front/migrations/db/migration_493.sql
@@ -1,11 +1,2 @@
 -- Migration created on janv. 22, 2026
 ALTER TABLE "public"."conversation_participants" ADD COLUMN "lastReadAt" TIMESTAMP WITH TIME ZONE;
-
--- Backfill lastReadAt for ConversationParticipant
--- Sets lastReadAt to current timestamp for participants with unread = false
--- Leaves lastReadAt as NULL for participants with unread = true
-UPDATE "conversation_participants"
-SET "lastReadAt" = NOW()
-WHERE "unread" = false;
-
--- No action needed for unread = true (lastReadAt remains NULL)

--- a/front/migrations/db/migration_493.sql
+++ b/front/migrations/db/migration_493.sql
@@ -1,0 +1,11 @@
+-- Migration created on janv. 22, 2026
+ALTER TABLE "public"."conversation_participants" ADD COLUMN "lastReadAt" TIMESTAMP WITH TIME ZONE;
+
+-- Backfill lastReadAt for ConversationParticipant
+-- Sets lastReadAt to current timestamp for participants with unread = false
+-- Leaves lastReadAt as NULL for participants with unread = true
+UPDATE "conversation_participants"
+SET "lastReadAt" = NOW()
+WHERE "unread" = false;
+
+-- No action needed for unread = true (lastReadAt remains NULL)


### PR DESCRIPTION
## Description
This PR adds a field to ConversationParticipant to track when the conversation was last read.
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
