### PR TITLE
feat: update lastReadAt when reading conversation

### DIFF
--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -346,9 +346,8 @@ export const ConversationViewer = ({
                   },
                   { revalidate: false }
                 );
-
-                void debouncedMarkAsRead(conversationId, false);
               }
+              void debouncedMarkAsRead(conversationId, false);
             }
             break;
           case "agent_message_new":

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -895,7 +895,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     }
 
     const updated = await ConversationParticipantModel.update(
-      { unread: false },
+      { unread: false, lastReadAt: new Date() },
       {
         where: {
           conversationId: conversation.id,

--- a/front/lib/swr/conversations.ts
+++ b/front/lib/swr/conversations.ts
@@ -844,7 +844,7 @@ export function useConversationMarkAsRead({
 
   useEffect(() => {
     let timeout: NodeJS.Timeout | null = null;
-    if (conversation?.sId && conversation.unread) {
+    if (conversation?.sId) {
       timeout = setTimeout(
         () => markAsRead(conversation.sId, true),
         DELAY_BEFORE_MARKING_AS_READ
@@ -856,7 +856,7 @@ export function useConversationMarkAsRead({
         clearTimeout(timeout);
       }
     };
-  }, [conversation?.sId, conversation?.unread, markAsRead]);
+  }, [conversation?.sId, markAsRead]);
 
   return {
     markAsRead,

--- a/front/migrations/20260122_backfill_lastReadAt_ConversationParticipant.sql
+++ b/front/migrations/20260122_backfill_lastReadAt_ConversationParticipant.sql
@@ -1,9 +1,0 @@
--- Script to backfill lastReadAt for ConversationParticipant
--- Sets lastReadAt to current timestamp for participants with unread = false
--- Leaves lastReadAt as NULL for participants with unread = true
-
-UPDATE "conversation_participants"
-SET "lastReadAt" = NOW()
-WHERE "unread" = false;
-
--- No action needed for unread = true (lastReadAt remains NULL)

--- a/front/migrations/20260122_backfill_lastReadAt_ConversationParticipant.sql
+++ b/front/migrations/20260122_backfill_lastReadAt_ConversationParticipant.sql
@@ -1,0 +1,9 @@
+-- Script to backfill lastReadAt for ConversationParticipant
+-- Sets lastReadAt to current timestamp for participants with unread = false
+-- Leaves lastReadAt as NULL for participants with unread = true
+
+UPDATE "conversation_participants"
+SET "lastReadAt" = NOW()
+WHERE "unread" = false;
+
+-- No action needed for unread = true (lastReadAt remains NULL)


### PR DESCRIPTION
## Description
This PR does the following makes sure that the `lastReadAt` is updated when
    - a user opens a conversation
    - a user sends a message
    - an agent message is completed and the user is viewing the conversation
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Manually
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
