### PR TITLE
Add Client-Side MCP Server for Agent Builder Copilot

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -16,8 +16,8 @@ import { AgentBuilderLayout } from "@app/components/agent_builder/AgentBuilderLa
 import { AgentBuilderLeftPanel } from "@app/components/agent_builder/AgentBuilderLeftPanel";
 import { AgentBuilderRightPanel } from "@app/components/agent_builder/AgentBuilderRightPanel";
 import { AgentCreatedDialog } from "@app/components/agent_builder/AgentCreatedDialog";
-import { useDataSourceViewsContext } from "@app/components/agent_builder/DataSourceViewsContext";
 import { useCopilotMCPServer } from "@app/components/agent_builder/copilot/useMCPServer";
+import { useDataSourceViewsContext } from "@app/components/agent_builder/DataSourceViewsContext";
 import {
   PersonalConnectionRequiredDialog,
   useAwaitableDialog,

--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -17,6 +17,7 @@ import { AgentBuilderLeftPanel } from "@app/components/agent_builder/AgentBuilde
 import { AgentBuilderRightPanel } from "@app/components/agent_builder/AgentBuilderRightPanel";
 import { AgentCreatedDialog } from "@app/components/agent_builder/AgentCreatedDialog";
 import { useDataSourceViewsContext } from "@app/components/agent_builder/DataSourceViewsContext";
+import { useCopilotMCPServer } from "@app/components/agent_builder/copilot/useMCPServer";
 import {
   PersonalConnectionRequiredDialog,
   useAwaitableDialog,
@@ -441,51 +442,117 @@ export default function AgentBuilder({
   return (
     <AgentBuilderFormContext.Provider value={form}>
       <FormProvider form={form} asForm={false}>
-        <PersonalConnectionRequiredDialog
-          owner={owner}
-          mcpServerViewsWithPersonalConnections={
-            dialogProps.mcpServerViewsWithPersonalConnections
-          }
-          isOpen={dialogProps.isOpen}
-          onCancel={dialogProps.onCancel}
-          onClose={dialogProps.onClose}
-        />
-        {agentConfiguration && (
-          <AgentCreatedDialog
-            open={isCreatedDialogOpen}
-            onOpenChange={setIsCreatedDialogOpen}
-            agentName={agentConfiguration.name}
-            agentId={agentConfiguration.sId}
-            owner={owner}
-          />
-        )}
-        <AgentBuilderLayout
-          leftPanel={
-            <AgentBuilderLeftPanel
-              title={title}
-              onCancel={handleCancel}
-              saveButtonProps={{
-                size: "sm",
-                label: saveLabel,
-                variant: "highlight",
-                onClick: handleSave,
-                disabled: isSaveDisabled,
-              }}
-              // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-              agentConfigurationId={agentConfiguration?.sId || null}
-              isActionsLoading={isActionsLoading}
-              isTriggersLoading={isTriggersLoading}
-            />
-          }
-          rightPanel={
-            <ConversationSidePanelProvider>
-              <AgentBuilderRightPanel
-                agentConfigurationSId={agentConfiguration?.sId}
-              />
-            </ConversationSidePanelProvider>
-          }
+        <AgentBuilderContent
+          agentConfiguration={agentConfiguration}
+          title={title}
+          handleCancel={handleCancel}
+          saveLabel={saveLabel}
+          handleSave={handleSave}
+          isSaveDisabled={isSaveDisabled}
+          isActionsLoading={isActionsLoading}
+          isTriggersLoading={isTriggersLoading}
+          dialogProps={dialogProps}
+          isCreatedDialogOpen={isCreatedDialogOpen}
+          setIsCreatedDialogOpen={setIsCreatedDialogOpen}
         />
       </FormProvider>
     </AgentBuilderFormContext.Provider>
+  );
+}
+
+/**
+ * Inner component that has access to FormContext and can use the MCP server hook.
+ */
+interface AgentBuilderContentProps {
+  agentConfiguration?: LightAgentConfigurationType;
+  title: string;
+  handleCancel: () => Promise<void>;
+  saveLabel: string;
+  handleSave: () => void;
+  isSaveDisabled: boolean;
+  isActionsLoading: boolean;
+  isTriggersLoading: boolean;
+  dialogProps: {
+    mcpServerViewsWithPersonalConnections: ReturnType<
+      typeof useAwaitableDialog
+    >["mcpServerViewsWithPersonalConnections"];
+    isOpen: boolean;
+    onCancel: () => void;
+    onClose: () => void;
+  };
+  isCreatedDialogOpen: boolean;
+  setIsCreatedDialogOpen: (open: boolean) => void;
+}
+
+function AgentBuilderContent({
+  agentConfiguration,
+  title,
+  handleCancel,
+  saveLabel,
+  handleSave,
+  isSaveDisabled,
+  isActionsLoading,
+  isTriggersLoading,
+  dialogProps,
+  isCreatedDialogOpen,
+  setIsCreatedDialogOpen,
+}: AgentBuilderContentProps) {
+  const { owner } = useAgentBuilderContext();
+  const { hasFeature } = useFeatureFlags({ workspaceId: owner.sId });
+
+  // Initialize the client-side MCP server for the agent builder copilot.
+  // Only enabled when the agent_builder_copilot feature flag is active.
+  const { serverId: clientSideMCPServerId } = useCopilotMCPServer({
+    enabled: hasFeature("agent_builder_copilot"),
+  });
+
+  return (
+    <>
+      <PersonalConnectionRequiredDialog
+        owner={owner}
+        mcpServerViewsWithPersonalConnections={
+          dialogProps.mcpServerViewsWithPersonalConnections
+        }
+        isOpen={dialogProps.isOpen}
+        onCancel={dialogProps.onCancel}
+        onClose={dialogProps.onClose}
+      />
+      {agentConfiguration && (
+        <AgentCreatedDialog
+          open={isCreatedDialogOpen}
+          onOpenChange={setIsCreatedDialogOpen}
+          agentName={agentConfiguration.name}
+          agentId={agentConfiguration.sId}
+          owner={owner}
+        />
+      )}
+      <AgentBuilderLayout
+        leftPanel={
+          <AgentBuilderLeftPanel
+            title={title}
+            onCancel={handleCancel}
+            saveButtonProps={{
+              size: "sm",
+              label: saveLabel,
+              variant: "highlight",
+              onClick: handleSave,
+              disabled: isSaveDisabled,
+            }}
+            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+            agentConfigurationId={agentConfiguration?.sId || null}
+            isActionsLoading={isActionsLoading}
+            isTriggersLoading={isTriggersLoading}
+          />
+        }
+        rightPanel={
+          <ConversationSidePanelProvider>
+            <AgentBuilderRightPanel
+              agentConfigurationSId={agentConfiguration?.sId}
+              clientSideMCPServerId={clientSideMCPServerId}
+            />
+          </ConversationSidePanelProvider>
+        }
+      />
+    </>
   );
 }

--- a/front/components/agent_builder/AgentBuilderPreview.tsx
+++ b/front/components/agent_builder/AgentBuilderPreview.tsx
@@ -80,6 +80,7 @@ interface PreviewContentProps {
   isSavingDraftAgent: boolean;
   isTrialPlan: boolean;
   isAdmin: boolean;
+  clientSideMCPServerId?: string;
 }
 
 function PreviewContent({
@@ -93,6 +94,7 @@ function PreviewContent({
   isSavingDraftAgent,
   isTrialPlan,
   isAdmin,
+  clientSideMCPServerId,
 }: PreviewContentProps) {
   return (
     <>
@@ -113,6 +115,9 @@ function PreviewContent({
                 isSavingDraftAgent,
                 resetConversation,
                 actionsToShow: ["attachment"],
+                clientSideMCPServerIds: clientSideMCPServerId
+                  ? [clientSideMCPServerId]
+                  : undefined,
               }}
               key={conversation.sId}
             />
@@ -157,7 +162,13 @@ function PreviewContent({
   );
 }
 
-export function AgentBuilderPreview() {
+interface AgentBuilderPreviewProps {
+  clientSideMCPServerId?: string;
+}
+
+export function AgentBuilderPreview({
+  clientSideMCPServerId,
+}: AgentBuilderPreviewProps) {
   const { owner, isAdmin } = useAgentBuilderContext();
   const { user } = useUser();
   const { activeSubscription } = useWorkspaceActiveSubscription({ owner });
@@ -192,6 +203,7 @@ export function AgentBuilderPreview() {
     useDraftConversation({
       draftAgent,
       getDraftAgent,
+      clientSideMCPServerId,
     });
 
   const debounceTimerRef = useRef<NodeJS.Timeout>();
@@ -299,6 +311,7 @@ export function AgentBuilderPreview() {
         isSavingDraftAgent={isSavingDraftAgent}
         isTrialPlan={!!isTrialPlan}
         isAdmin={isAdmin}
+        clientSideMCPServerId={clientSideMCPServerId}
       />
     );
   };

--- a/front/components/agent_builder/AgentBuilderRightPanel.tsx
+++ b/front/components/agent_builder/AgentBuilderRightPanel.tsx
@@ -148,11 +148,13 @@ function CollapsedTabs({ onTabSelect, hasTemplate }: CollapsedTabsProps) {
 interface ExpandedContentProps {
   selectedTab: AgentBuilderRightPanelTabType;
   agentConfigurationSId?: string;
+  clientSideMCPServerId?: string;
 }
 
 function ExpandedContent({
   selectedTab,
   agentConfigurationSId,
+  clientSideMCPServerId,
 }: ExpandedContentProps) {
   const { assistantTemplate, setPresetActionToAdd } = useAgentBuilderContext();
 
@@ -166,7 +168,7 @@ function ExpandedContent({
       )}
       {selectedTab === "preview" && (
         <div className="min-h-0 flex-1">
-          <AgentBuilderPreview />
+          <AgentBuilderPreview clientSideMCPServerId={clientSideMCPServerId} />
         </div>
       )}
       <ObservabilityProvider>
@@ -205,10 +207,12 @@ function ExpandedContent({
 
 interface AgentBuilderRightPanelProps {
   agentConfigurationSId?: string;
+  clientSideMCPServerId?: string;
 }
 
 export function AgentBuilderRightPanel({
   agentConfigurationSId,
+  clientSideMCPServerId,
 }: AgentBuilderRightPanelProps) {
   const { isPreviewPanelOpen, setIsPreviewPanelOpen } =
     usePreviewPanelContext();
@@ -248,6 +252,7 @@ export function AgentBuilderRightPanel({
         <ExpandedContent
           selectedTab={selectedTab}
           agentConfigurationSId={agentConfigurationSId}
+          clientSideMCPServerId={clientSideMCPServerId}
         />
       ) : (
         <CollapsedTabs

--- a/front/components/agent_builder/copilot/tools/getAgentConfig.ts
+++ b/front/components/agent_builder/copilot/tools/getAgentConfig.ts
@@ -1,0 +1,55 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
+
+/**
+ * Registers the get_agent_config tool on the MCP server.
+ * This tool allows the copilot to access the live (unsaved) agent builder form state.
+ */
+export function registerGetAgentConfigTool(
+  mcpServer: McpServer,
+  getFormValues: () => AgentBuilderFormData
+): void {
+  mcpServer.tool(
+    "get_agent_config",
+    "Get the current (unsaved) agent configuration from the agent builder form. Use this to understand what the user is currently configuring for their agent.",
+    {},
+    () => {
+      const formData = getFormValues();
+
+      // Transform form data to the expected tool output format.
+      const config = {
+        name: formData.agentSettings.name,
+        description: formData.agentSettings.description,
+        instructions: formData.instructions,
+        scope: formData.agentSettings.scope,
+        model: {
+          modelId: formData.generationSettings.modelSettings.modelId,
+          providerId: formData.generationSettings.modelSettings.providerId,
+          temperature: formData.generationSettings.temperature,
+          reasoningEffort: formData.generationSettings.reasoningEffort,
+        },
+        tools: formData.actions.map((action) => ({
+          sId: action.id,
+          name: action.name,
+          description: action.description,
+        })),
+        skills: formData.skills.map((skill) => ({
+          sId: skill.sId,
+          name: skill.name,
+          description: skill.description,
+        })),
+        maxStepsPerRun: formData.maxStepsPerRun,
+      };
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify(config, null, 2),
+          },
+        ],
+      };
+    }
+  );
+}

--- a/front/components/agent_builder/copilot/tools/getAgentConfig.ts
+++ b/front/components/agent_builder/copilot/tools/getAgentConfig.ts
@@ -17,7 +17,6 @@ export function registerGetAgentConfigTool(
     () => {
       const formData = getFormValues();
 
-      // Transform form data to the expected tool output format.
       const config = {
         name: formData.agentSettings.name,
         description: formData.agentSettings.description,

--- a/front/components/agent_builder/copilot/useMCPServer.ts
+++ b/front/components/agent_builder/copilot/useMCPServer.ts
@@ -7,9 +7,9 @@ import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBu
 import { registerGetAgentConfigTool } from "@app/components/agent_builder/copilot/tools/getAgentConfig";
 import { BrowserMCPTransport } from "@app/lib/client/BrowserMCPTransport";
 
-// Server name used for MCP registration. This server is exclusively used by the
-// Agent Builder Copilot to access live form state.
-const SERVER_NAME = "agent-builder-copilot";
+// Server name used for MCP registration. This is a client-side MCP server
+// exclusively used by the Agent Builder Copilot to access live form state.
+const SERVER_NAME = "agent-builder-copilot-client";
 
 export interface UseCopilotMCPServerResult {
   serverId: string | undefined;

--- a/front/components/agent_builder/copilot/useMCPServer.ts
+++ b/front/components/agent_builder/copilot/useMCPServer.ts
@@ -1,0 +1,149 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useFormContext } from "react-hook-form";
+
+import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
+import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
+import { registerGetAgentConfigTool } from "@app/components/agent_builder/copilot/tools/getAgentConfig";
+import { BrowserMCPTransport } from "@app/lib/client/BrowserMCPTransport";
+
+// Server name used for MCP registration. This server is exclusively used by the
+// Agent Builder Copilot to access live form state.
+const SERVER_NAME = "agent-builder-copilot";
+
+export interface UseCopilotMCPServerResult {
+  serverId: string | undefined;
+  isConnected: boolean;
+  isConnecting: boolean;
+  error: Error | null;
+}
+
+interface UseCopilotMCPServerOptions {
+  enabled: boolean;
+}
+
+/**
+ * React hook that manages a client-side MCP server for the Agent Builder Copilot.
+ * Exposes tools that allow the copilot to access the live (unsaved) agent builder form state.
+ */
+export function useCopilotMCPServer({
+  enabled,
+}: UseCopilotMCPServerOptions): UseCopilotMCPServerResult {
+  const { owner } = useAgentBuilderContext();
+  const { getValues } = useFormContext<AgentBuilderFormData>();
+
+  const [serverId, setServerId] = useState<string | undefined>(undefined);
+  const [isConnected, setIsConnected] = useState(false);
+  const [isConnecting, setIsConnecting] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  // Use refs to store the MCP server and transport instances
+  // to ensure cleanup happens correctly and to avoid re-creating on every render.
+  const mcpServerRef = useRef<McpServer | null>(null);
+  const transportRef = useRef<BrowserMCPTransport | null>(null);
+
+  // Create a stable callback for getting the current form values.
+  // This is used by the MCP tool handler.
+  const getFormValues = useCallback(() => {
+    return getValues();
+  }, [getValues]);
+
+  useEffect(() => {
+    // Don't initialize if the feature is disabled.
+    if (!enabled) {
+      return;
+    }
+
+    let isMounted = true;
+
+    const initializeMCPServer = async () => {
+      if (mcpServerRef.current) {
+        // Already initialized.
+        return;
+      }
+
+      setIsConnecting(true);
+      setError(null);
+
+      try {
+        // Create the MCP server.
+        const mcpServer = new McpServer({
+          name: SERVER_NAME,
+          version: "1.0.0",
+        });
+
+        // Register tools.
+        registerGetAgentConfigTool(mcpServer, getFormValues);
+
+        // Create the browser transport.
+        const transport = new BrowserMCPTransport(
+          owner.sId,
+          SERVER_NAME,
+          (newServerId) => {
+            if (isMounted) {
+              setServerId(newServerId);
+            }
+          }
+        );
+
+        // Set up transport error handling.
+        transport.onerror = (err) => {
+          console.error("[useCopilotMCPServer] Transport error:", err);
+          if (isMounted) {
+            setError(err);
+          }
+        };
+
+        transport.onclose = () => {
+          if (isMounted) {
+            setIsConnected(false);
+          }
+        };
+
+        // Connect the MCP server to the transport.
+        await mcpServer.connect(transport);
+
+        if (isMounted) {
+          mcpServerRef.current = mcpServer;
+          transportRef.current = transport;
+          setIsConnected(true);
+          setIsConnecting(false);
+        }
+      } catch (err) {
+        console.error("[useCopilotMCPServer] Failed to initialize:", err);
+        if (isMounted) {
+          setError(err instanceof Error ? err : new Error(String(err)));
+          setIsConnecting(false);
+        }
+      }
+    };
+
+    void initializeMCPServer();
+
+    // Cleanup on unmount.
+    return () => {
+      isMounted = false;
+
+      // Close the MCP server and transport.
+      if (mcpServerRef.current) {
+        void mcpServerRef.current.close();
+        mcpServerRef.current = null;
+      }
+
+      if (transportRef.current) {
+        void transportRef.current.close();
+        transportRef.current = null;
+      }
+
+      setServerId(undefined);
+      setIsConnected(false);
+    };
+  }, [enabled, owner.sId, getFormValues]);
+
+  return {
+    serverId,
+    isConnected,
+    isConnecting,
+    error,
+  };
+}

--- a/front/components/agent_builder/hooks/useAgentPreview.ts
+++ b/front/components/agent_builder/hooks/useAgentPreview.ts
@@ -106,9 +106,11 @@ export function useDraftAgent() {
 export function useDraftConversation({
   draftAgent,
   getDraftAgent,
+  clientSideMCPServerId,
 }: {
   draftAgent: LightAgentConfigurationType | null;
   getDraftAgent: () => Promise<LightAgentConfigurationType | null>;
+  clientSideMCPServerId?: string;
 }) {
   const { owner } = useAgentBuilderContext();
   const { user } = useUser();
@@ -160,6 +162,10 @@ export function useDraftConversation({
           configurationId: mention.id,
         })),
         contentFragments,
+        // Include client-side MCP server IDs for the agent builder copilot.
+        clientSideMCPServerIds: clientSideMCPServerId
+          ? [clientSideMCPServerId]
+          : undefined,
       };
 
       const result = await createConversationWithMessage({
@@ -185,6 +191,7 @@ export function useDraftConversation({
       });
     },
     [
+      clientSideMCPServerId,
       createConversationWithMessage,
       draftAgent?.sId,
       getDraftAgent,

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -610,12 +610,13 @@ export const ConversationViewer = ({
       return new Ok(undefined);
     },
     [
-      submitMessage,
-      user,
+      agentBuilderContext?.clientSideMCPServerIds,
       conversationId,
+      mutateConversations,
       sendNotification,
       setPlanLimitReached,
-      mutateConversations,
+      submitMessage,
+      user,
     ]
   );
 

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -487,6 +487,7 @@ export const ConversationViewer = ({
         input,
         mentions: mentions.map(toMentionType),
         contentFragments,
+        clientSideMCPServerIds: agentBuilderContext?.clientSideMCPServerIds,
       };
 
       const lastMessageRank = Math.max(

--- a/front/components/assistant/conversation/types.ts
+++ b/front/components/assistant/conversation/types.ts
@@ -77,6 +77,7 @@ export type VirtuosoMessageListContext = {
     isSavingDraftAgent: boolean;
     actionsToShow: InputBarContainerProps["actions"];
     resetConversation: () => void;
+    clientSideMCPServerIds?: string[];
   };
   feedbacksByMessageId: Record<string, AgentMessageFeedbackType>;
 };

--- a/front/lib/client/BrowserMCPTransport.ts
+++ b/front/lib/client/BrowserMCPTransport.ts
@@ -1,0 +1,343 @@
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
+
+import { clientFetch } from "@app/lib/egress/client";
+
+const HEARTBEAT_INTERVAL_MS = 15 * 60 * 1000; // 15 minutes.
+const RECONNECT_DELAY_MS = 5 * 1000; // 5 seconds.
+
+/**
+ * Browser-specific MCP transport implementation.
+ * Uses private API with session authentication (credentials: 'include').
+ *
+ * - Uses native EventSource for SSE (receives requests from Dust)
+ * - Uses fetch with credentials for HTTP POST (sends results back to Dust)
+ * - Supports workspace-scoped MCP registration only
+ */
+export class BrowserMCPTransport implements Transport {
+  private eventSource: EventSource | null = null;
+  private lastEventId: string | null = null;
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  private serverId: string | null = null;
+  private isClosing = false;
+
+  // Required by Transport interface.
+  public onmessage?: (message: JSONRPCMessage) => void;
+  public onclose?: () => void;
+  public onerror?: (error: Error) => void;
+  public sessionId?: string;
+
+  constructor(
+    private readonly workspaceId: string,
+    private readonly serverName: string,
+    private readonly onServerIdReceived: (serverId: string) => void
+  ) {}
+
+  /**
+   * Register the MCP server with the Dust backend.
+   */
+  private async registerServer(): Promise<boolean> {
+    try {
+      const response = await clientFetch(
+        `/api/w/${this.workspaceId}/mcp/register`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          credentials: "include",
+          body: JSON.stringify({ serverName: this.serverName }),
+        }
+      );
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        console.error(
+          "[BrowserMCPTransport] Failed to register MCP server:",
+          errorData
+        );
+        return false;
+      }
+
+      const data = (await response.json()) as {
+        serverId: string;
+        expiresAt: string;
+      };
+      this.serverId = data.serverId;
+
+      // Notify the parent that the serverId has been updated.
+      this.onServerIdReceived(data.serverId);
+
+      // Setup heartbeat to keep the server registration alive.
+      this.setupHeartbeat(data.serverId);
+
+      return true;
+    } catch (error) {
+      console.error(
+        "[BrowserMCPTransport] Failed to register MCP server:",
+        error
+      );
+      return false;
+    }
+  }
+
+  /**
+   * Send periodic heartbeats to keep the server registration alive.
+   */
+  private setupHeartbeat(serverId: string): void {
+    // Clear any existing heartbeat timer.
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer);
+    }
+
+    // Set up a new heartbeat timer (every HEARTBEAT_INTERVAL_MS).
+    this.heartbeatTimer = setInterval(async () => {
+      if (this.isClosing) {
+        return;
+      }
+
+      try {
+        const response = await clientFetch(
+          `/api/w/${this.workspaceId}/mcp/heartbeat`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            credentials: "include",
+            body: JSON.stringify({ serverId }),
+          }
+        );
+
+        if (!response.ok) {
+          console.error("[BrowserMCPTransport] Failed to heartbeat MCP server");
+          await this.registerServer();
+          return;
+        }
+
+        const data = (await response.json()) as { success: boolean };
+        if (!data.success) {
+          console.error(
+            "[BrowserMCPTransport] Server not registered, re-registering"
+          );
+          await this.registerServer();
+        }
+      } catch (error) {
+        console.error(
+          "[BrowserMCPTransport] Failed to heartbeat MCP server:",
+          error
+        );
+        await this.registerServer();
+      }
+    }, HEARTBEAT_INTERVAL_MS);
+  }
+
+  /**
+   * Start the transport and connect to the SSE endpoint.
+   * This method is required by the Transport interface.
+   */
+  async start(): Promise<void> {
+    try {
+      // First, register the server (or ensure it's registered).
+      const registered = await this.registerServer();
+      if (!registered) {
+        throw new Error("Failed to register MCP server");
+      }
+
+      // Connect to the workspace-scoped requests endpoint.
+      await this.connectToRequestsStream();
+
+      console.log("[BrowserMCPTransport] MCP transport started successfully");
+    } catch (error) {
+      console.error(
+        "[BrowserMCPTransport] Failed to start MCP transport:",
+        error
+      );
+      this.onerror?.(error instanceof Error ? error : new Error(String(error)));
+      throw error;
+    }
+  }
+
+  /**
+   * Connect to the SSE stream for the workspace.
+   */
+  private async connectToRequestsStream(): Promise<void> {
+    if (!this.serverId) {
+      console.error("[BrowserMCPTransport] Server ID is not set");
+      return;
+    }
+
+    if (this.isClosing) {
+      return;
+    }
+
+    // Close any existing connection.
+    if (this.eventSource) {
+      this.eventSource.close();
+      this.eventSource = null;
+    }
+
+    // Build URL with query parameters.
+    const url = new URL(
+      `/api/w/${this.workspaceId}/mcp/requests`,
+      window.location.origin
+    );
+    url.searchParams.set("serverId", this.serverId);
+    if (this.lastEventId) {
+      url.searchParams.set("lastEventId", this.lastEventId);
+    }
+
+    // Create native EventSource (uses session cookies automatically).
+    this.eventSource = new EventSource(url.toString());
+
+    this.eventSource.onmessage = (event) => {
+      try {
+        if (event.data === "done") {
+          // Ignore this event.
+          return;
+        }
+
+        const eventData = JSON.parse(event.data) as {
+          eventId?: string;
+          data?: JSONRPCMessage;
+        };
+
+        // Save the eventId for reconnection purposes.
+        if (eventData.eventId) {
+          this.lastEventId = eventData.eventId;
+        }
+
+        // The actual request is in the data property.
+        const { data } = eventData;
+        if (!data) {
+          console.error(
+            "[BrowserMCPTransport] No data field found in the event"
+          );
+          return;
+        }
+
+        // Forward the message to the handler.
+        if (this.onmessage) {
+          this.onmessage(data);
+        } else {
+          console.error(
+            "[BrowserMCPTransport] onmessage handler not set - MCP response won't be sent"
+          );
+        }
+      } catch (error) {
+        console.error(
+          "[BrowserMCPTransport] Failed to parse MCP request:",
+          error
+        );
+        this.onerror?.(new Error(`Failed to parse MCP request: ${error}`));
+      }
+    };
+
+    this.eventSource.onerror = () => {
+      if (this.isClosing) {
+        return;
+      }
+
+      // Close the existing connection to prevent automatic reconnects.
+      this.eventSource?.close();
+
+      console.error(
+        "[BrowserMCPTransport] Error in MCP EventSource connection"
+      );
+      this.onerror?.(new Error("SSE connection error"));
+
+      // Attempt to reconnect after a delay.
+      setTimeout(() => {
+        if (!this.isClosing && this.serverId) {
+          console.log(
+            "[BrowserMCPTransport] Attempting to reconnect to SSE..."
+          );
+          void this.connectToRequestsStream().catch((reconnectError) => {
+            console.error(
+              "[BrowserMCPTransport] Failed to reconnect:",
+              reconnectError
+            );
+          });
+        }
+      }, RECONNECT_DELAY_MS);
+    };
+
+    this.eventSource.onopen = () => {
+      console.log("[BrowserMCPTransport] MCP SSE connection established");
+    };
+  }
+
+  /**
+   * Send a message to the server.
+   * This method is required by the Transport interface.
+   */
+  async send(message: JSONRPCMessage): Promise<void> {
+    if (!this.serverId) {
+      console.error("[BrowserMCPTransport] Server ID is not set");
+      return;
+    }
+
+    try {
+      // Send tool results back to Dust via HTTP POST.
+      const response = await clientFetch(
+        `/api/w/${this.workspaceId}/mcp/results`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          credentials: "include",
+          body: JSON.stringify({
+            serverId: this.serverId,
+            result: message,
+          }),
+        }
+      );
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        console.error(
+          "[BrowserMCPTransport] Failed to send MCP result:",
+          errorData
+        );
+        this.onerror?.(
+          new Error(`Failed to send MCP result: ${response.status}`)
+        );
+      }
+    } catch (error) {
+      console.error("[BrowserMCPTransport] Failed to send MCP result:", error);
+      this.onerror?.(new Error(`Failed to send MCP result: ${error}`));
+    }
+  }
+
+  /**
+   * Close the transport and disconnect from the SSE endpoint.
+   * This method is required by the Transport interface.
+   */
+  async close(): Promise<void> {
+    this.isClosing = true;
+
+    // Clear heartbeat timer.
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = null;
+    }
+
+    // Close SSE connection.
+    if (this.eventSource) {
+      console.log("[BrowserMCPTransport] Closing MCP SSE connection");
+      this.eventSource.close();
+      this.eventSource = null;
+    }
+
+    // Trigger onclose callback.
+    this.onclose?.();
+  }
+
+  /**
+   * Get the current server ID.
+   */
+  getServerId(): string | undefined {
+    return this.serverId ?? undefined;
+  }
+}

--- a/front/lib/client/BrowserMCPTransport.ts
+++ b/front/lib/client/BrowserMCPTransport.ts
@@ -12,7 +12,6 @@ const RECONNECT_DELAY_MS = 5 * 1000; // 5 seconds.
  *
  * - Uses native EventSource for SSE (receives requests from Dust)
  * - Uses fetch with credentials for HTTP POST (sends results back to Dust)
- * - Supports workspace-scoped MCP registration only
  */
 export class BrowserMCPTransport implements Transport {
   private eventSource: EventSource | null = null;
@@ -34,7 +33,7 @@ export class BrowserMCPTransport implements Transport {
   ) {}
 
   /**
-   * Register the MCP server with the Dust backend.
+   * Register the MCP server.
    */
   private async registerServer(): Promise<boolean> {
     try {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See https://github.com/dust-tt/dust/issues/20083.

This PR Implements a client-side MCP server for the Agent Builder Copilot (Phase 1), allowing the copilot to access live (unsaved) form state when helping users configure their agents.

This PR lays the foundation and focus on adding the `get_agent_config` tool. Follow up PRs will work around suggestions.

To see how it works, we pass the client-side MCP server conditionally (gated behind the copilot FF) to the preview conversation. This is temporary and will obviously evolves as we make progress.

![AgentBuilderCoPilot](https://github.com/user-attachments/assets/6bb4cdb0-74c9-43c9-ad3c-bdaea546722b)

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
