### PR TITLE
[front] fix(skills): add `disabledByAdmin` check on go deep skill

### DIFF
--- a/front/lib/resources/skill/global/go_deep.ts
+++ b/front/lib/resources/skill/global/go_deep.ts
@@ -2,6 +2,7 @@ import {
   DEEP_DIVE_NAME,
   DEEP_DIVE_SERVER_INSTRUCTIONS,
 } from "@app/lib/api/assistant/global_agents/configurations/dust/consts";
+import { isDeepDiveDisabledByAdmin } from "@app/lib/api/assistant/global_agents/configurations/dust/utils";
 import type { GlobalSkillDefinition } from "@app/lib/resources/skill/global/registry";
 
 export const goDeepSkill = {
@@ -20,4 +21,5 @@ export const goDeepSkill = {
   internalMCPServerNames: ["deep_dive"],
   version: 1,
   icon: "ActionAtomIcon",
+  isRestricted: isDeepDiveDisabledByAdmin,
 } as const satisfies GlobalSkillDefinition;

--- a/front/lib/resources/skill/global/registry.ts
+++ b/front/lib/resources/skill/global/registry.ts
@@ -97,17 +97,9 @@ export class GlobalSkillsRegistry {
     auth: Authenticator,
     sId: string
   ): Promise<GlobalSkillDefinition | null> {
-    const skill = GLOBAL_SKILLS_BY_ID.get(sId);
-    if (!skill) {
-      return null;
-    }
-    if (skill.isRestricted) {
-      const isRestricted = await skill.isRestricted(auth);
-      if (isRestricted) {
-        return null;
-      }
-    }
-    return skill;
+    const skills = await this.findAll(auth, { sId });
+
+    return skills[0] ?? null;
   }
 
   static async findAll(

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -475,7 +475,10 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       return allowedCustomSkillsRes;
     }
 
-    const globalSkillDefinitions = GlobalSkillsRegistry.findAll(where);
+    const globalSkillDefinitions = await GlobalSkillsRegistry.findAll(
+      auth,
+      where
+    );
 
     // Fetch global skills with their MCP server configurations.
     const globalSkills = await concurrentExecutor(


### PR DESCRIPTION
## Description

- There is a setting to disable go deep for a given workspace that is not respected by the skill.
- This PR fixes that.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
