### PR TITLE
fix: dedup mentions

### DIFF
--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -173,16 +173,18 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
             />
           )}
           {data.visibility !== "deleted" &&
-            data.richMentions.map((mention) => {
+            data.richMentions.map((mention, index) => {
               // To please the type checker
               if (!context.conversation) {
                 return null;
               }
 
+              // :warning: make sure to use the index in the key, as the mention.id is the userId
+
               if (mention.status === "pending") {
                 return (
                   <MentionValidationRequired
-                    key={mention.id}
+                    key={index}
                     mention={mention}
                     message={data}
                     owner={context.owner}
@@ -196,7 +198,7 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
               ) {
                 return (
                   <MentionInvalid
-                    key={mention.id}
+                    key={index}
                     mention={mention}
                     message={data}
                     owner={context.owner}


### PR DESCRIPTION
## Description

We have a bug where mentions validation are re-rendered in a loop. 

It's most probably because the `key` we use is the `userId`, and we had a bug that allowed to validate multiple times the same person

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
