### PR TITLE
Fix: handle newly added github repos

### DIFF
--- a/connectors/migrations/20260122_backfill_missing_github_code_repos.ts
+++ b/connectors/migrations/20260122_backfill_missing_github_code_repos.ts
@@ -1,0 +1,195 @@
+import { makeScript } from "scripts/helpers";
+
+import { getReposPage } from "@connectors/connectors/github/lib/github_api";
+import {
+  GithubCodeRepositoryModel,
+  GithubConnectorStateModel,
+} from "@connectors/lib/models/github";
+import { ConnectorResource } from "@connectors/resources/connector_resource";
+
+/**
+ * Backfill migration to create missing GithubCodeRepository records for repositories
+ * that are accessible via GitHub App installations but don't have code repository records.
+ *
+ * This fixes the issue where repositories added via installation_repositories.added webhook
+ * didn't get GithubCodeRepository records created, causing code sync webhooks to silently skip.
+ *
+ * Usage:
+ *   DRY RUN: npx tsx migrations/20260122_backfill_missing_github_code_repos.ts
+ *   EXECUTE: npx tsx migrations/20260122_backfill_missing_github_code_repos.ts -e
+ */
+makeScript({}, async ({ execute }, logger) => {
+  logger.info("Starting backfill of missing GithubCodeRepository records");
+
+  // 1. Find all connectors with code sync enabled
+  const connectorStates = await GithubConnectorStateModel.findAll({
+    where: { codeSyncEnabled: true },
+  });
+
+  logger.info(
+    `Found ${connectorStates.length} connectors with code sync enabled`
+  );
+
+  let totalCreated = 0;
+  let totalSkipped = 0;
+  let totalErrors = 0;
+
+  for (const connectorState of connectorStates) {
+    const connector = await ConnectorResource.fetchById(
+      connectorState.connectorId
+    );
+
+    if (!connector) {
+      logger.warn(
+        {
+          connectorId: connectorState.connectorId,
+        },
+        "Connector not found, skipping"
+      );
+      totalErrors++;
+      continue;
+    }
+
+    const connectorLogger = logger.child({
+      connectorId: connector.id,
+    });
+
+    try {
+      // 2. Fetch repos from GitHub API
+      connectorLogger.info("Fetching repositories from GitHub API");
+      const githubRepos: Array<{
+        id: number;
+        name: string;
+        owner: { login: string };
+      }> = [];
+
+      let pageNumber = 1;
+      for (;;) {
+        const reposPageResult = await getReposPage(connector, pageNumber);
+        if (reposPageResult.isErr()) {
+          connectorLogger.error(
+            {
+              error: reposPageResult.error,
+            },
+            "Failed to fetch repositories page, skipping connector"
+          );
+          totalErrors++;
+          break;
+        }
+
+        const reposPage = reposPageResult.value;
+        if (reposPage.length === 0) {
+          break;
+        }
+
+        githubRepos.push(
+          ...reposPage.map((r) => ({
+            id: r.id,
+            name: r.name,
+            owner: { login: r.owner.login },
+          }))
+        );
+
+        pageNumber++;
+      }
+
+      connectorLogger.info(
+        `Fetched ${githubRepos.length} repositories from GitHub API`
+      );
+
+      // 3. Check which ones are missing from database
+      const existingRepos = await GithubCodeRepositoryModel.findAll({
+        where: { connectorId: connector.id },
+      });
+      const existingRepoIds = new Set(existingRepos.map((r) => r.repoId));
+
+      // 4. Create missing records
+      let created = 0;
+      let skipped = 0;
+
+      for (const repo of githubRepos) {
+        const repoIdStr = repo.id.toString();
+        if (existingRepoIds.has(repoIdStr)) {
+          skipped++;
+          continue;
+        }
+
+        if (execute) {
+          try {
+            await GithubCodeRepositoryModel.create({
+              connectorId: connector.id,
+              repoId: repoIdStr,
+              repoLogin: repo.owner.login,
+              repoName: repo.name,
+              sourceUrl: `https://github.com/${repo.owner.login}/${repo.name}`,
+              lastSeenAt: new Date(0), // Use epoch to indicate needs first sync
+              codeUpdatedAt: new Date(0), // Use epoch to indicate needs first sync
+              skipReason: null,
+              forceDailySync: false,
+            });
+
+            created++;
+            connectorLogger.info(
+              {
+                repoId: repo.id,
+                repoName: repo.name,
+                repoLogin: repo.owner.login,
+              },
+              "Created GithubCodeRepository record"
+            );
+          } catch (err) {
+            connectorLogger.error(
+              {
+                err,
+                repoId: repo.id,
+                repoName: repo.name,
+              },
+              "Failed to create GithubCodeRepository record"
+            );
+            totalErrors++;
+          }
+        } else {
+          created++;
+          connectorLogger.info(
+            {
+              repoId: repo.id,
+              repoName: repo.name,
+              repoLogin: repo.owner.login,
+            },
+            "Would create GithubCodeRepository record"
+          );
+        }
+      }
+
+      totalCreated += created;
+      totalSkipped += skipped;
+
+      connectorLogger.info(
+        {
+          created,
+          skipped,
+          total: githubRepos.length,
+        },
+        "Finished processing connector"
+      );
+    } catch (err) {
+      connectorLogger.error(
+        {
+          err,
+        },
+        "Error processing connector"
+      );
+      totalErrors++;
+    }
+  }
+
+  logger.info(
+    {
+      totalCreated,
+      totalSkipped,
+      totalErrors,
+      totalConnectors: connectorStates.length,
+    },
+    "Backfill completed"
+  );
+});

--- a/connectors/src/api/webhooks/webhook_github.ts
+++ b/connectors/src/api/webhooks/webhook_github.ts
@@ -351,20 +351,67 @@ async function syncRepos(
 ) {
   let hasErrors = false;
   await Promise.all(
-    connectors.map((c) =>
-      launchGithubReposSyncWorkflow(c.id, orgLogin, repos).catch((err) => {
-        logger.error(
-          {
-            err,
-            connectorId: c.id,
-            orgLogin,
-            repos,
-          },
-          "Failed to launch github repos sync workflow"
-        );
-        hasErrors = true;
-      })
-    )
+    connectors.map(async (c) => {
+      // Check if code sync enabled for this connector
+      const connectorState = await GithubConnectorStateModel.findOne({
+        where: { connectorId: c.id },
+      });
+
+      if (connectorState?.codeSyncEnabled) {
+        // Create GithubCodeRepository stub records
+        for (const repo of repos) {
+          try {
+            await GithubCodeRepositoryModel.upsert({
+              connectorId: c.id,
+              repoId: repo.id.toString(),
+              repoLogin: orgLogin,
+              repoName: repo.name,
+              sourceUrl: `https://github.com/${orgLogin}/${repo.name}`,
+              lastSeenAt: new Date(0), // Use epoch to indicate needs first sync
+              codeUpdatedAt: new Date(0), // Use epoch to indicate needs first sync
+              skipReason: null,
+              forceDailySync: false,
+            });
+
+            logger.info(
+              {
+                connectorId: c.id,
+                repoId: repo.id,
+                repoName: repo.name,
+              },
+              "Created GithubCodeRepository record from webhook"
+            );
+          } catch (err) {
+            logger.error(
+              {
+                err,
+                connectorId: c.id,
+                repoId: repo.id,
+                repoName: repo.name,
+              },
+              "Failed to create GithubCodeRepository record from webhook"
+            );
+            hasErrors = true;
+          }
+        }
+      }
+
+      // Existing code: trigger repo sync workflow
+      return launchGithubReposSyncWorkflow(c.id, orgLogin, repos).catch(
+        (err) => {
+          logger.error(
+            {
+              err,
+              connectorId: c.id,
+              orgLogin,
+              repos,
+            },
+            "Failed to launch github repos sync workflow"
+          );
+          hasErrors = true;
+        }
+      );
+    })
   );
   if (hasErrors) {
     res.status(500).end();


### PR DESCRIPTION
## Description

When a new git repo is added we didn't add it ourselves.
Fix is to upsert them when the `installation_repositories` webhook events happens.

[Original issue](https://github.com/dust-tt/tasks/issues/6015)
[Dust explo](https://dust.tt/w/0ec9852c2f/conversation/2lvVvS9CJT)

## Risk

Low, should be no-op for existing repos.

## Deploy Plan

Deploy connectors