### PR TITLE
feat: not send some logs in DD

### DIFF
--- a/front/pages/_app.tsx
+++ b/front/pages/_app.tsx
@@ -33,6 +33,24 @@ if (DATADOG_CLIENT_TOKEN) {
     site: "datadoghq.eu",
     forwardErrorsToLogs: true,
     sessionSampleRate: 100,
+    beforeSend: (log) => {
+      // Filter out benign ResizeObserver errors that have no user impact.
+      // Different browsers use different messages:
+      // - Safari/Firefox: "ResizeObserver loop completed with undelivered notifications"
+      // - Chrome: "ResizeObserver loop limit exceeded"
+      // See: https://github.com/DataDog/browser-sdk/issues/1616
+      if (log.message && typeof log.message === "string") {
+        if (
+          log.message.includes(
+            "ResizeObserver loop completed with undelivered notifications"
+          ) ||
+          log.message.includes("ResizeObserver loop limit exceeded")
+        ) {
+          return false;
+        }
+      }
+      return true;
+    },
   });
 }
 


### PR DESCRIPTION
## Description

We don't want "ResizeObserver loop completed with undelivered notifications" errors to be sent to DD. Those are errors we can't fix and that pollute our logs

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
