### PR TITLE
[front] fix(skills): fix agent creation from template

### DIFF
--- a/front/components/agent_builder/skills/AgentBuilderSkillsBlock.tsx
+++ b/front/components/agent_builder/skills/AgentBuilderSkillsBlock.tsx
@@ -21,9 +21,9 @@ import type {
 import { AgentBuilderSectionContainer } from "@app/components/agent_builder/AgentBuilderSectionContainer";
 import { CapabilitiesSheet } from "@app/components/agent_builder/capabilities/capabilities_sheet/CapabilitiesSheet";
 import { KnowledgeConfigurationSheet } from "@app/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet";
-import { usePresetActionHandler } from "@app/components/agent_builder/capabilities/usePresetActionHandler";
 import { validateMCPActionConfiguration } from "@app/components/agent_builder/capabilities/mcp/utils/formValidation";
 import type { SelectedTool } from "@app/components/agent_builder/capabilities/shared/types";
+import { usePresetActionHandler } from "@app/components/agent_builder/capabilities/usePresetActionHandler";
 import { getSheetStateForActionEdit } from "@app/components/agent_builder/skills/sheetRouting";
 import { useSkillsAndActionsState } from "@app/components/agent_builder/skills/skillsAndActionsState";
 import type { SheetState } from "@app/components/agent_builder/skills/types";
@@ -36,7 +36,6 @@ import { ActionCard } from "@app/components/shared/tools_picker/ActionCard";
 import { useMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
 import type { BuilderAction } from "@app/components/shared/tools_picker/types";
 import { BACKGROUND_IMAGE_STYLE_PROPS } from "@app/components/shared/tools_picker/util";
-import type { TemplateActionPreset } from "@app/types";
 import { useSendNotification } from "@app/hooks/useNotification";
 import {
   getSkillIcon,
@@ -44,6 +43,7 @@ import {
   SKILL_AVATAR_ICON_COLOR,
 } from "@app/lib/skill";
 import { useSkillWithRelations } from "@app/lib/swr/skill_configurations";
+import type { TemplateActionPreset } from "@app/types";
 
 interface SkillCardProps {
   skill: AgentBuilderSkillsType;

--- a/front/components/agent_builder/skills/AgentBuilderSkillsBlock.tsx
+++ b/front/components/agent_builder/skills/AgentBuilderSkillsBlock.tsx
@@ -21,6 +21,7 @@ import type {
 import { AgentBuilderSectionContainer } from "@app/components/agent_builder/AgentBuilderSectionContainer";
 import { CapabilitiesSheet } from "@app/components/agent_builder/capabilities/capabilities_sheet/CapabilitiesSheet";
 import { KnowledgeConfigurationSheet } from "@app/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet";
+import { usePresetActionHandler } from "@app/components/agent_builder/capabilities/usePresetActionHandler";
 import { validateMCPActionConfiguration } from "@app/components/agent_builder/capabilities/mcp/utils/formValidation";
 import type { SelectedTool } from "@app/components/agent_builder/capabilities/shared/types";
 import { getSheetStateForActionEdit } from "@app/components/agent_builder/skills/sheetRouting";
@@ -35,6 +36,7 @@ import { ActionCard } from "@app/components/shared/tools_picker/ActionCard";
 import { useMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
 import type { BuilderAction } from "@app/components/shared/tools_picker/types";
 import { BACKGROUND_IMAGE_STYLE_PROPS } from "@app/components/shared/tools_picker/util";
+import type { TemplateActionPreset } from "@app/types";
 import { useSendNotification } from "@app/hooks/useNotification";
 import {
   getSkillIcon,
@@ -159,6 +161,33 @@ export function AgentBuilderSkillsBlock() {
     );
 
   const [sheetState, setSheetState] = useState<SheetState>({ state: "closed" });
+
+  // Handle preset actions from templates.
+  const setKnowledgeActionFromPreset = useCallback(
+    (
+      actionData: {
+        action: BuilderAction;
+        index: number | null;
+        presetData?: TemplateActionPreset;
+      } | null
+    ) => {
+      if (actionData) {
+        setSheetState({
+          state: "knowledge",
+          action: actionData.action,
+          index: actionData.index,
+          presetData: actionData.presetData,
+        });
+      }
+    },
+    []
+  );
+
+  usePresetActionHandler({
+    fields: actionFields,
+    append: appendActions,
+    setKnowledgeAction: setKnowledgeActionFromPreset,
+  });
 
   // Sheets own closing after save; this handler only upserts into the form state.
   const handleToolEditSave = (updatedAction: BuilderAction) => {


### PR DESCRIPTION
## Description

- The Agent Builder skills block does not load tools from templates.
- This PR fixes that.

<img width="2023" height="599" alt="Screenshot 2026-01-22 at 3 02 21 PM" src="https://github.com/user-attachments/assets/a57a213f-ad13-424e-9aeb-4f97faf01924" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
