### PR TITLE
fix: remove display of the anchor when the agent message is being streamed

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -577,20 +577,20 @@ export function AgentMessage({
           className="text-muted-foreground"
         />
       );
-    }
 
-    if (enableExtendedActions) {
-      messageButtons.push(
-        <Button
-          key="copy-msg-link-button"
-          tooltip="Copy message link"
-          variant="ghost-secondary"
-          size="xs"
-          onClick={handleCopyMessageLink}
-          icon={LinkIcon}
-          className="text-muted-foreground"
-        />
-      );
+      if (enableExtendedActions) {
+        messageButtons.push(
+          <Button
+            key="copy-msg-link-button"
+            tooltip="Copy message link"
+            variant="ghost-secondary"
+            size="xs"
+            onClick={handleCopyMessageLink}
+            icon={LinkIcon}
+            className="text-muted-foreground"
+          />
+        );
+      }
     }
 
     if (shouldShowRetry) {


### PR DESCRIPTION
## Description

Fix display of the "copy link to message", it was being displayed when we generate the agent message
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

