### PR TITLE
Move TOOL_NAME_SEPARATOR to constants to avoid circular dependencies

### DIFF
--- a/front/lib/actions/constants.ts
+++ b/front/lib/actions/constants.ts
@@ -53,6 +53,8 @@ export const DEFAULT_MCP_ACTION_VERSION = "1.0.0";
 export const DEFAULT_MCP_ACTION_DESCRIPTION =
   "Call a tool to answer a question.";
 
+export const TOOL_NAME_SEPARATOR = "__";
+
 export const MCP_TOOL_STAKE_LEVELS = [
   "high",
   "medium",

--- a/front/lib/actions/mcp_actions.test.ts
+++ b/front/lib/actions/mcp_actions.test.ts
@@ -1,12 +1,12 @@
 import { assert, describe, expect, it } from "vitest";
 
 import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
+import { TOOL_NAME_SEPARATOR } from "@app/lib/actions/constants";
 import type { ServerSideMCPServerConfigurationType } from "@app/lib/actions/mcp";
 import {
   getPrefixedToolName,
   getToolExtraFields,
   listToolsForServerSideMCPServer,
-  TOOL_NAME_SEPARATOR,
 } from "@app/lib/actions/mcp_actions";
 import { internalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
 import type { MCPConnectionParams } from "@app/lib/actions/mcp_metadata";

--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -25,6 +25,7 @@ import {
   FALLBACK_INTERNAL_AUTO_SERVERS_TOOL_STAKE_LEVEL,
   FALLBACK_MCP_TOOL_STAKE_LEVEL,
   RETRY_ON_INTERRUPT_MAX_ATTEMPTS,
+  TOOL_NAME_SEPARATOR,
 } from "@app/lib/actions/constants";
 import type {
   ClientSideMCPServerConfigurationType,
@@ -116,8 +117,6 @@ function isEmptyInputSchema(schema: JSONSchema): boolean {
 }
 
 const MAX_TOOL_NAME_LENGTH = 64;
-
-export const TOOL_NAME_SEPARATOR = "__";
 
 // Define the new type here for now, or move to a dedicated types file later.
 export interface ServerToolsAndInstructions {

--- a/front/lib/actions/utils.test.ts
+++ b/front/lib/actions/utils.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
-import { TOOL_NAME_SEPARATOR } from "@app/lib/actions/mcp_actions";
+import { TOOL_NAME_SEPARATOR } from "@app/lib/actions/constants";
 import {
   hasUserAlwaysApprovedTool,
   setUserAlwaysApprovedTool,

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -7,9 +7,9 @@ import {
   ENABLE_SKILL_TOOL_NAME,
   GET_MENTION_MARKDOWN_TOOL_NAME,
   SEARCH_AVAILABLE_USERS_TOOL_NAME,
+  TOOL_NAME_SEPARATOR,
 } from "@app/lib/actions/constants";
 import type { ServerToolsAndInstructions } from "@app/lib/actions/mcp_actions";
-import { TOOL_NAME_SEPARATOR } from "@app/lib/actions/mcp_actions";
 import { SKILL_MANAGEMENT_SERVER_NAME } from "@app/lib/actions/mcp_internal_actions/constants";
 import {
   isMCPConfigurationForInternalNotion,

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -1,6 +1,8 @@
-import { DEFAULT_AGENT_ROUTER_ACTION_NAME } from "@app/lib/actions/constants";
+import {
+  DEFAULT_AGENT_ROUTER_ACTION_NAME,
+  TOOL_NAME_SEPARATOR,
+} from "@app/lib/actions/constants";
 import type { MCPServerConfigurationType } from "@app/lib/actions/mcp";
-import { TOOL_NAME_SEPARATOR } from "@app/lib/actions/mcp_actions";
 import { autoInternalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
 import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";

--- a/front/migrations/20251119_backfill_mcp_server_configuration_sid_analytics.ts
+++ b/front/migrations/20251119_backfill_mcp_server_configuration_sid_analytics.ts
@@ -1,8 +1,8 @@
 import { subDays } from "date-fns";
 import { Op } from "sequelize";
 
+import { TOOL_NAME_SEPARATOR } from "@app/lib/actions/constants";
 import { ANALYTICS_ALIAS_NAME, getClient } from "@app/lib/api/elasticsearch";
-import { TOOL_NAME_SEPARATOR } from "@app/lib/actions/mcp_actions";
 import { getInternalMCPServerNameFromSId } from "@app/lib/actions/mcp_internal_actions/constants";
 import { Authenticator } from "@app/lib/auth";
 import { AgentMCPServerConfigurationModel } from "@app/lib/models/agent/actions/mcp";

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -2,11 +2,9 @@ import { heartbeat } from "@temporalio/activity";
 import assert from "assert";
 import tracer from "dd-trace";
 
+import { TOOL_NAME_SEPARATOR } from "@app/lib/actions/constants";
 import { buildToolSpecification } from "@app/lib/actions/mcp";
-import {
-  TOOL_NAME_SEPARATOR,
-  tryListMCPTools,
-} from "@app/lib/actions/mcp_actions";
+import { tryListMCPTools } from "@app/lib/actions/mcp_actions";
 import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { StepContext } from "@app/lib/actions/types";
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";

--- a/front/temporal/analytics_queue/activities.ts
+++ b/front/temporal/analytics_queue/activities.ts
@@ -1,4 +1,4 @@
-import { TOOL_NAME_SEPARATOR } from "@app/lib/actions/mcp_actions";
+import { TOOL_NAME_SEPARATOR } from "@app/lib/actions/constants";
 import { isSearchResultResourceType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { isToolExecutionStatusBlocked } from "@app/lib/actions/statuses";
 import { isLightServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";


### PR DESCRIPTION
## Description

We currently have several import cycle warnings because `TOOL_NAME_SEPARATOR` is exported from `lib/actions/mcp_actions.ts`, which becomes called by mcp servers while cycling back to them through the `mcp_metadata` dependency.

```
lib/api/actions/servers/agent_copilot_context/tools/index.ts:17:31 lint/nursery/noImportCycles ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

  ⚠ This import is part of a cycle.

    15 │ import type { MCPServerViewType } from "@app/lib/api/mcp";
    16 │ import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
  > 17 │ import { SkillResource } from "@app/lib/resources/skill/skill_resource";
       │                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    18 │ import { SpaceResource } from "@app/lib/resources/space_resource";
    19 │ import {

  ℹ This import resolves to lib/resources/skill/skill_resource.ts
        ... which imports lib/api/assistant/configuration/agent.ts
        ... which imports lib/api/assistant/global_agents/global_agents.ts
        ... which imports lib/api/assistant/global_agents/configurations/dust/dust.ts
        ... which imports lib/actions/mcp_actions.ts
        ... which imports lib/actions/mcp_metadata.ts
        ... which imports lib/actions/mcp_internal_actions/index.ts
        ... which imports lib/actions/mcp_internal_actions/servers/index.ts
        ... which imports lib/api/actions/servers/agent_copilot_context/index.ts
        ... which imports lib/api/actions/servers/agent_copilot_context/tools/index.ts
        ... which is the file we're importing from.
```

In this PR, we delegate the definition of `TOOL_NAME_SEPARATOR` to `lib/actions/constants.ts`, which break these cycles.

## Tests

Local

## Risk

Low, easy rollback

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
