### PR TITLE
Add support for SVG upload

### DIFF
--- a/front/lib/api/files/upload.ts
+++ b/front/lib/api/files/upload.ts
@@ -464,6 +464,16 @@ const getProcessingFunction = ({
     return undefined;
   }
 
+  // SVG files are stored as-is without any processing (no resize).
+  if (contentType === "image/svg+xml") {
+    if (
+      ["conversation", "project_context", "tool_output"].includes(useCase)
+    ) {
+      return storeRawText;
+    }
+    return undefined;
+  }
+
   if (isSupportedImageContentType(contentType)) {
     if (useCase === "conversation" || useCase === "project_context") {
       return makeResizeAndUploadImageToFileStorage(

--- a/front/lib/api/files/upload.ts
+++ b/front/lib/api/files/upload.ts
@@ -466,9 +466,7 @@ const getProcessingFunction = ({
 
   // SVG files are stored as-is without any processing (no resize).
   if (contentType === "image/svg+xml") {
-    if (
-      ["conversation", "project_context", "tool_output"].includes(useCase)
-    ) {
+    if (["conversation", "project_context", "tool_output"].includes(useCase)) {
       return storeRawText;
     }
     return undefined;

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -165,6 +165,7 @@ export const FILE_FORMATS = {
   "image/png": { cat: "image", exts: [".png"], isSafeToDisplay: true },
   "image/gif": { cat: "image", exts: [".gif"], isSafeToDisplay: true },
   "image/webp": { cat: "image", exts: [".webp"], isSafeToDisplay: true },
+  "image/svg+xml": { cat: "image", exts: [".svg"], isSafeToDisplay: true },
 
   // Structured.
   "text/csv": { cat: "delimited", exts: [".csv"], isSafeToDisplay: true },

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -203,6 +203,7 @@ export const supportedImageFileFormats = {
   "image/png": [".png"],
   "image/gif": [".gif"],
   "image/webp": [".webp"],
+  "image/svg+xml": [".svg"],
 } as const;
 
 export const supportedAudioFileFormats = {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Working towards improving Frames templating, we need support for users to upload SVG file directly in the conversation interface. Those files should be considered like regular text files, not searchable, only includable.

Example:
```
            {
              "type": "text",
              "text": "<attachment id=\"fil_eH6wl30Sv3\" type=\"image/svg+xml\" title=\"dust.svg\" version=\"latest\" isIncludable=\"true\" isQueryable=\"false\" isSearchable=\"false\"/>"
            },
```

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
