### PR TITLE
Add background on mentions

### DIFF
--- a/front/lib/mentions/ui/MentionDisplay.tsx
+++ b/front/lib/mentions/ui/MentionDisplay.tsx
@@ -42,7 +42,7 @@ function MentionTrigger({
       className={cn(
         "inline-block cursor-pointer rounded px-0.5 text-highlight-600 dark:text-highlight-600-night",
         isCurrentUserMentioned
-          ? "bg-golden-200 dark:bg-golden-200-night"
+          ? "bg-golden-100 dark:bg-golden-100-night"
           : "bg-highlight-100 dark:bg-highlight-100-night"
       )}
     >

--- a/front/lib/mentions/ui/MentionDisplay.tsx
+++ b/front/lib/mentions/ui/MentionDisplay.tsx
@@ -40,8 +40,10 @@ function MentionTrigger({
   return (
     <span
       className={cn(
-        "inline-block cursor-pointer text-highlight-600 dark:text-highlight-600-night",
-        isCurrentUserMentioned && "bg-golden-100 dark:bg-golden-100-night"
+        "inline-block cursor-pointer rounded px-0.5 text-highlight-600 dark:text-highlight-600-night",
+        isCurrentUserMentioned
+          ? "bg-golden-200 dark:bg-golden-200-night"
+          : "bg-highlight-100 dark:bg-highlight-100-night"
       )}
     >
       @{mention.label}


### PR DESCRIPTION
## Description

Add a background on mentions so that they are easier to read ([task](https://github.com/dust-tt/tasks/issues/6038))

### Light
<img width="1105" height="262" alt="Screenshot 2026-01-22 at 16 41 21" src="https://github.com/user-attachments/assets/8f4ba3b8-e05f-4af0-a952-e306a9980445" />



### Dark
<img width="1094" height="210" alt="Screenshot 2026-01-22 at 16 40 03" src="https://github.com/user-attachments/assets/f050d103-6d75-482e-8cfa-321967ae81a9" />



## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
