### PR TITLE
Make projects a collapsible section

### DIFF
--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -342,6 +342,7 @@ export function AgentSidebarMenu({ owner }: AgentSidebarMenuProps) {
       <NavigationList className="px-2">
         <NavigationListCollapsibleSection
           label="Projects"
+          type="collapse"
           defaultOpen
           action={
             isAdmin(owner) ? (

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -68,6 +68,7 @@ import { useDeleteConversation } from "@app/hooks/useDeleteConversation";
 import { useHideTriggeredConversations } from "@app/hooks/useHideTriggeredConversations";
 import { useMarkAllConversationsAsRead } from "@app/hooks/useMarkAllConversationsAsRead";
 import { useSendNotification } from "@app/hooks/useNotification";
+import { useProjectsSectionCollapsed } from "@app/hooks/useProjectsSectionCollapsed";
 import { useYAMLUpload } from "@app/hooks/useYAMLUpload";
 import { CONVERSATIONS_UPDATED_EVENT } from "@app/lib/notifications/events";
 import type { AppRouter } from "@app/lib/platform";
@@ -171,6 +172,9 @@ export function AgentSidebarMenu({ owner }: AgentSidebarMenuProps) {
   const doDelete = useDeleteConversation(owner);
 
   const { hideTriggeredConversations } = useHideTriggeredConversations();
+
+  const { isProjectsSectionCollapsed, setProjectsSectionCollapsed } =
+    useProjectsSectionCollapsed();
 
   const hasSkills = hasFeature("skills");
 
@@ -338,12 +342,16 @@ export function AgentSidebarMenu({ owner }: AgentSidebarMenuProps) {
     if (!hasSpaceConversations) {
       return null;
     }
+    const projectCount = summary.length;
+    const showCount = isProjectsSectionCollapsed && projectCount > 0;
+
     return (
       <NavigationList className="px-2">
         <NavigationListCollapsibleSection
-          label="Projects"
+          label={showCount ? `Projects (${projectCount})` : "Projects"}
           type="collapse"
-          defaultOpen
+          open={!isProjectsSectionCollapsed}
+          onOpenChange={(open) => setProjectsSectionCollapsed(!open)}
           action={
             isAdmin(owner) ? (
               <Button
@@ -372,7 +380,14 @@ export function AgentSidebarMenu({ owner }: AgentSidebarMenuProps) {
         </NavigationListCollapsibleSection>
       </NavigationList>
     );
-  }, [hasSpaceConversations, owner, summary, setIsCreateProjectModalOpen]);
+  }, [
+    hasSpaceConversations,
+    owner,
+    summary,
+    setIsCreateProjectModalOpen,
+    isProjectsSectionCollapsed,
+    setProjectsSectionCollapsed,
+  ]);
 
   const conversationsList = useMemo(() => {
     return (

--- a/front/hooks/useProjectsSectionCollapsed.ts
+++ b/front/hooks/useProjectsSectionCollapsed.ts
@@ -1,0 +1,36 @@
+import { useCallback } from "react";
+
+import { useUserMetadata } from "@app/lib/swr/user";
+import { setUserMetadataFromClient } from "@app/lib/user";
+
+const PROJECTS_SECTION_COLLAPSED_KEY = "projectsSectionCollapsed";
+
+export const useProjectsSectionCollapsed = () => {
+  const { metadata, isMetadataLoading, mutateMetadata } = useUserMetadata(
+    PROJECTS_SECTION_COLLAPSED_KEY,
+    {
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
+    }
+  );
+
+  // Default to open (not collapsed) if no metadata exists yet.
+  const isProjectsSectionCollapsed = metadata?.value === "true";
+
+  const setProjectsSectionCollapsed = useCallback(
+    async (collapsed: boolean) => {
+      await setUserMetadataFromClient({
+        key: PROJECTS_SECTION_COLLAPSED_KEY,
+        value: collapsed ? "true" : "false",
+      });
+      void mutateMetadata();
+    },
+    [mutateMetadata]
+  );
+
+  return {
+    isProjectsSectionCollapsed,
+    setProjectsSectionCollapsed,
+    isLoading: isMetadataLoading,
+  };
+};


### PR DESCRIPTION
## Description

Projects can sometimes be confidential, hence users want the ability to collapse the project section to hide them ([task](https://github.com/dust-tt/tasks/issues/6043))

## Tests

Local

## Risk

Low
## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
