### PR TITLE
[Credits] Handle unique constraint violation in credit start()

### DIFF
--- a/front/lib/credits/payg.test.ts
+++ b/front/lib/credits/payg.test.ts
@@ -80,7 +80,7 @@ describe("PAYG Credits Database Tests", () => {
 
   // Requires migration_419.sql to be run (unique index on type, workspaceId, startDate, expirationDate)
   describe("unique constraint on (type, workspaceId, startDate, expirationDate)", () => {
-    it("should throw when creating duplicate credits with same dates", async () => {
+    it("should return error when creating duplicate credits with same dates", async () => {
       const startTimestampSeconds = 1700000000;
       const endTimestampSeconds = 1702678400;
       const startDate = new Date(startTimestampSeconds * 1000);
@@ -102,12 +102,17 @@ describe("PAYG Credits Database Tests", () => {
         consumedAmountMicroUsd: 0,
       });
 
-      await expect(
-        credit2.start(auth, {
-          startDate,
-          expirationDate,
-        })
-      ).rejects.toThrow(/unique|Validation error/i);
+      const result = await credit2.start(auth, {
+        startDate,
+        expirationDate,
+      });
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.message).toContain(
+          "A credit with the same type and dates already exists"
+        );
+      }
     });
   });
 


### PR DESCRIPTION
## Description

When starting a credit with dates that conflict with an existing credit (same type, workspace, startDate, expirationDate), return a proper error instead of throwing an unhandled Sequelize `UniqueConstraintError`.

This prevents the plugin execution from crashing and leaving the plugin run in "pending" state.

## Risks

Blast radius: Credit purchase flow when duplicate dates are used
Risk: none (adds error handling that was missing)

## Deploy Plan
- pmrr
- deploy front