### PR TITLE
[Agent Loop] Properly handle getAgentLoopData errors

### DIFF
--- a/front/lib/api/assistant/conversation/title.ts
+++ b/front/lib/api/assistant/conversation/title.ts
@@ -39,9 +39,8 @@ export async function ensureConversationTitleFromAgentLoop(
         {
           conversationId: agentLoopArgs.conversationId,
           agentMessageId: agentLoopArgs.agentMessageId,
-          errorType: runAgentDataRes.error.type,
         },
-        "getAgentLoopData returned soft-delete error in ensureConversationTitle, skipping"
+        "Message or conversation was deleted, exiting"
       );
       return null;
     }

--- a/front/lib/api/assistant/conversation/title.ts
+++ b/front/lib/api/assistant/conversation/title.ts
@@ -15,7 +15,6 @@ import type {
 } from "@app/types";
 import {
   CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG,
-  ConversationError,
   Err,
   GEMINI_2_5_FLASH_MODEL_CONFIG,
   getSmallWhitelistedModel,
@@ -24,7 +23,10 @@ import {
   Ok,
 } from "@app/types";
 import type { AgentLoopArgs } from "@app/types/assistant/agent_run";
-import { getAgentLoopData } from "@app/types/assistant/agent_run";
+import {
+  getAgentLoopData,
+  isAgentLoopDataSoftDeleteError,
+} from "@app/types/assistant/agent_run";
 
 export async function ensureConversationTitleFromAgentLoop(
   authType: AuthenticatorType,
@@ -32,13 +34,17 @@ export async function ensureConversationTitleFromAgentLoop(
 ): Promise<string | null> {
   const runAgentDataRes = await getAgentLoopData(authType, agentLoopArgs);
   if (runAgentDataRes.isErr()) {
-    if (
-      runAgentDataRes.error instanceof ConversationError &&
-      runAgentDataRes.error.type === "conversation_not_found"
-    ) {
+    if (isAgentLoopDataSoftDeleteError(runAgentDataRes.error)) {
+      logger.info(
+        {
+          conversationId: agentLoopArgs.conversationId,
+          agentMessageId: agentLoopArgs.agentMessageId,
+          errorType: runAgentDataRes.error.type,
+        },
+        "getAgentLoopData returned soft-delete error in ensureConversationTitle, skipping"
+      );
       return null;
     }
-
     throw runAgentDataRes.error;
   }
 

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -311,9 +311,8 @@ export async function finalizeCancellation(
         {
           conversationId: agentLoopArgs.conversationId,
           agentMessageId: agentLoopArgs.agentMessageId,
-          errorType: runAgentDataRes.error.type,
         },
-        "getAgentLoopData returned soft-delete error in finalizeCancellation, skipping"
+        "Message or conversation was deleted, exiting"
       );
       return;
     }

--- a/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
+++ b/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
@@ -6,6 +6,7 @@ import type { Authenticator, AuthenticatorType } from "@app/lib/auth";
 import { AgentMCPActionModel } from "@app/lib/models/agent/actions/mcp";
 import { AgentStepContentModel } from "@app/lib/models/agent/agent_step_content";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import logger from "@app/logger/logger";
 import { logAgentLoopStepStart } from "@app/temporal/agent_loop/activities/instrumentation";
 import type { ActionBlob } from "@app/temporal/agent_loop/lib/create_tool_actions";
 import { createToolActionsActivity } from "@app/temporal/agent_loop/lib/create_tool_actions";
@@ -17,7 +18,10 @@ import type {
   AgentLoopArgsWithTiming,
   AgentLoopExecutionData,
 } from "@app/types/assistant/agent_run";
-import { getAgentLoopData } from "@app/types/assistant/agent_run";
+import {
+  getAgentLoopData,
+  isAgentLoopDataSoftDeleteError,
+} from "@app/types/assistant/agent_run";
 
 export type RunModelAndCreateActionsResult = {
   actionBlobs: ActionBlob[];
@@ -47,7 +51,18 @@ export async function runModelAndCreateActionsActivity({
 }): Promise<RunModelAndCreateActionsResult | null> {
   const runAgentDataRes = await getAgentLoopData(authType, runAgentArgs);
   if (runAgentDataRes.isErr()) {
-    return null;
+    if (isAgentLoopDataSoftDeleteError(runAgentDataRes.error)) {
+      logger.info(
+        {
+          conversationId: runAgentArgs.conversationId,
+          agentMessageId: runAgentArgs.agentMessageId,
+          errorType: runAgentDataRes.error.type,
+        },
+        "getAgentLoopData returned soft-delete error, stopping execution"
+      );
+      return null;
+    }
+    throw runAgentDataRes.error;
   }
 
   const { auth, ...runAgentData } = runAgentDataRes.value;

--- a/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
+++ b/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
@@ -56,9 +56,8 @@ export async function runModelAndCreateActionsActivity({
         {
           conversationId: runAgentArgs.conversationId,
           agentMessageId: runAgentArgs.agentMessageId,
-          errorType: runAgentDataRes.error.type,
         },
-        "getAgentLoopData returned soft-delete error, stopping execution"
+        "Message or conversation was deleted, exiting"
       );
       return null;
     }

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -12,9 +12,12 @@ import { updateResourceAndPublishEvent } from "@app/temporal/agent_loop/activiti
 import type { ToolExecutionResult } from "@app/temporal/agent_loop/lib/deferred_events";
 import { sliceConversationForAgentMessage } from "@app/temporal/agent_loop/lib/loop_utils";
 import type { ModelId } from "@app/types";
-import { assertNever, ConversationError } from "@app/types";
+import { assertNever } from "@app/types";
 import type { AgentLoopArgsWithTiming } from "@app/types/assistant/agent_run";
-import { getAgentLoopData } from "@app/types/assistant/agent_run";
+import {
+  getAgentLoopData,
+  isAgentLoopDataSoftDeleteError,
+} from "@app/types/assistant/agent_run";
 
 const CONVERSATION_CACHE_TTL_MS = 5000;
 
@@ -52,17 +55,14 @@ export async function runToolActivity(
     },
   });
   if (runAgentDataRes.isErr()) {
-    // If the conversation is not found, we cannot run the tool and should stop execution here.
-    if (
-      runAgentDataRes.error instanceof ConversationError &&
-      runAgentDataRes.error.type === "conversation_not_found"
-    ) {
-      logger.warn(
+    if (isAgentLoopDataSoftDeleteError(runAgentDataRes.error)) {
+      logger.info(
         {
           actionId,
           runIds,
+          errorType: runAgentDataRes.error.type,
         },
-        "conversation_not_found while running tool, stopping execution"
+        "getAgentLoopData returned soft-delete error while running tool, stopping execution"
       );
       return { deferredEvents };
     }

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -60,9 +60,8 @@ export async function runToolActivity(
         {
           actionId,
           runIds,
-          errorType: runAgentDataRes.error.type,
         },
-        "getAgentLoopData returned soft-delete error while running tool, stopping execution"
+        "Message or conversation was deleted, exiting"
       );
       return { deferredEvents };
     }

--- a/front/types/assistant/agent_run.ts
+++ b/front/types/assistant/agent_run.ts
@@ -14,6 +14,17 @@ import { cacheWithRedis } from "@app/lib/utils/cache";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types";
 import { ConversationError, Err, isGlobalAgentId, Ok } from "@app/types";
+import type { AgentConfigurationType } from "@app/types/assistant/agent";
+import type {
+  AgentMessageType,
+  ConversationType,
+  UserMessageOrigin,
+  UserMessageType,
+} from "@app/types/assistant/conversation";
+import {
+  isAgentMessageType,
+  isUserMessageType,
+} from "@app/types/assistant/conversation";
 
 /**
  * Error types for getAgentLoopData that indicate soft-deleted resources.
@@ -45,17 +56,6 @@ export function isAgentLoopDataSoftDeleteError(
     AGENT_LOOP_DATA_SOFT_DELETE_ERROR_TYPES.includes(error.type)
   );
 }
-import type { AgentConfigurationType } from "@app/types/assistant/agent";
-import type {
-  AgentMessageType,
-  ConversationType,
-  UserMessageOrigin,
-  UserMessageType,
-} from "@app/types/assistant/conversation";
-import {
-  isAgentMessageType,
-  isUserMessageType,
-} from "@app/types/assistant/conversation";
 
 export type ConversationCaching =
   | { useCachedGetConversation: false }

--- a/front/types/assistant/agent_run.ts
+++ b/front/types/assistant/agent_run.ts
@@ -9,10 +9,42 @@ import {
   AgentMessageModel,
   MessageModel,
 } from "@app/lib/models/agent/conversation";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { cacheWithRedis } from "@app/lib/utils/cache";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types";
 import { ConversationError, Err, isGlobalAgentId, Ok } from "@app/types";
+
+/**
+ * Error types for getAgentLoopData that indicate soft-deleted resources.
+ * These are safe to ignore in callers since the resource was intentionally deleted.
+ */
+export const AGENT_LOOP_DATA_SOFT_DELETE_ERROR_TYPES = [
+  "conversation_deleted",
+  "agent_message_deleted",
+  "user_message_deleted",
+] as const;
+
+export type AgentLoopDataSoftDeleteErrorType =
+  (typeof AGENT_LOOP_DATA_SOFT_DELETE_ERROR_TYPES)[number];
+
+export class AgentLoopDataError extends Error {
+  readonly type: AgentLoopDataSoftDeleteErrorType;
+
+  constructor(type: AgentLoopDataSoftDeleteErrorType) {
+    super(`Agent loop data unavailable: ${type}`);
+    this.type = type;
+  }
+}
+
+export function isAgentLoopDataSoftDeleteError(
+  error: Error
+): error is AgentLoopDataError {
+  return (
+    error instanceof AgentLoopDataError &&
+    AGENT_LOOP_DATA_SOFT_DELETE_ERROR_TYPES.includes(error.type)
+  );
+}
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type {
   AgentMessageType,
@@ -91,7 +123,12 @@ export type AgentLoopArgsWithTiming = AgentLoopArgs & {
 export async function getAgentLoopData(
   authType: AuthenticatorType,
   agentLoopArgs: AgentLoopArgs
-): Promise<Result<AgentLoopExecutionData & { auth: Authenticator }, Error>> {
+): Promise<
+  Result<
+    AgentLoopExecutionData & { auth: Authenticator },
+    AgentLoopDataError | Error
+  >
+> {
   let authResult = await Authenticator.fromJSON(authType);
 
   // If subscription changed while the message was running, get a fresh auth with the current
@@ -139,6 +176,20 @@ export async function getAgentLoopData(
         caching.unicitySuffix
       );
     } catch (error) {
+      if (
+        error instanceof ConversationError &&
+        error.type === "conversation_not_found"
+      ) {
+        // Check if the conversation was soft-deleted.
+        const conv = await ConversationResource.fetchById(
+          auth,
+          conversationId,
+          { includeDeleted: true }
+        );
+        if (conv?.visibility === "deleted") {
+          return new Err(new AgentLoopDataError("conversation_deleted"));
+        }
+      }
       if (error instanceof ConversationError) {
         return new Err(error);
       }
@@ -147,6 +198,17 @@ export async function getAgentLoopData(
   } else {
     const conversationRes = await getConversation(auth, conversationId);
     if (conversationRes.isErr()) {
+      if (conversationRes.error.type === "conversation_not_found") {
+        // Check if the conversation was soft-deleted.
+        const conv = await ConversationResource.fetchById(
+          auth,
+          conversationId,
+          { includeDeleted: true }
+        );
+        if (conv?.visibility === "deleted") {
+          return new Err(new AgentLoopDataError("conversation_deleted"));
+        }
+      }
       return conversationRes;
     }
     conversation = conversationRes.value;
@@ -173,6 +235,11 @@ export async function getAgentLoopData(
     return new Err(new Error("Agent message not found"));
   }
 
+  // Check if the agent message was soft-deleted.
+  if (agentMessage.visibility === "deleted") {
+    return new Err(new AgentLoopDataError("agent_message_deleted"));
+  }
+
   // Find the user message group by searching in reverse order.
   const userMessageGroup = conversation.content.findLast((messageGroup) =>
     messageGroup.some((m) => m.sId === userMessageId)
@@ -188,6 +255,11 @@ export async function getAgentLoopData(
     userMessage.version !== userMessageVersion
   ) {
     return new Err(new Error("Unexpected: User message not found"));
+  }
+
+  // Check if the user message was soft-deleted.
+  if (userMessage.visibility === "deleted") {
+    return new Err(new AgentLoopDataError("user_message_deleted"));
   }
 
   // Get the AgentMessage database row by querying through Message model.


### PR DESCRIPTION
## Description

When `getAgentLoopData` encounters an error, callers were either silently ignoring all errors or checking only for `conversation_not_found` without proper verification. This raised a few issues.

This PR add consistent checks: it's fine to ignore (convo / message deleted) or we raise an error.

It adds typed errors for soft-deleted resources:
- `conversation_deleted` - conversation has `visibility === "deleted"`
- `agent_message_deleted` - agent message has `visibility === "deleted"`
- `user_message_deleted` - user message has `visibility === "deleted"`

Changes:
- Add `AgentLoopDataError` class with soft-delete error types
- Add `isAgentLoopDataSoftDeleteError` type guard
- Update `getAgentLoopData` to return typed errors when encountering soft-deleted resources
- Update 4 callers to:
  - Check for soft-delete errors using the type guard → safe to ignore
  - Throw for any other unexpected errors

## Risks

Blast radius: Agent loop execution - affects error handling in all agent loop activities
Risk: low (only changes error handling logic to be more explicit, no changes to happy path)

## Deploy Plan

- deploy front