### PR TITLE
copilot: Add foreign key from suggestion table to agent configuration

### DIFF
--- a/front/lib/models/agent/agent_suggestion.ts
+++ b/front/lib/models/agent/agent_suggestion.ts
@@ -78,6 +78,15 @@ AgentSuggestionModel.init(
     sequelize: frontSequelize,
     indexes: [
       {
+        name: "agent_suggestions_list_by_agent_configuration",
+        fields: ["workspaceId", "agentConfigurationId", "state", "kind"],
+        concurrently: true,
+      },
+      {
+        fields: ["workspaceId", "agentConfigurationId", "kind"],
+        concurrently: true,
+      },
+      {
         fields: ["agentConfigurationId"],
         concurrently: true,
       },

--- a/front/lib/models/agent/agent_suggestion.ts
+++ b/front/lib/models/agent/agent_suggestion.ts
@@ -1,6 +1,7 @@
-import type { CreationOptional } from "sequelize";
+import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
 import { DataTypes } from "sequelize";
 
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type {
@@ -14,9 +15,7 @@ export class AgentSuggestionModel extends WorkspaceAwareModel<AgentSuggestionMod
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
-  // Reference agent by sId because sId cannot be inferred from id alone
-  declare agentConfigurationIdTmp: string;
-  declare agentConfigurationVersion: number;
+  declare agentConfigurationId: ForeignKey<AgentConfigurationModel["id"]>;
 
   declare kind: AgentSuggestionKind;
   declare suggestion: SuggestionPayload;
@@ -24,6 +23,13 @@ export class AgentSuggestionModel extends WorkspaceAwareModel<AgentSuggestionMod
 
   declare state: AgentSuggestionState;
   declare source: AgentSuggestionSource;
+
+  // The property name uses underscore to match Sequelize's default naming from modelName "agent_configuration"
+  declare agent_configuration: NonAttribute<AgentConfigurationModel>;
+
+  getAgentConfiguration(): AgentConfigurationModel | null {
+    return this.agent_configuration ?? null;
+  }
 }
 
 AgentSuggestionModel.init(
@@ -38,15 +44,9 @@ AgentSuggestionModel.init(
       allowNull: false,
       defaultValue: DataTypes.NOW,
     },
-    agentConfigurationIdTmp: {
-      type: DataTypes.STRING,
+    agentConfigurationId: {
+      type: DataTypes.BIGINT,
       allowNull: false,
-    },
-    agentConfigurationVersion: {
-      type: DataTypes.INTEGER,
-      allowNull: false,
-      comment:
-        "Version of the agent configuration when the suggestion was created",
     },
     kind: {
       type: DataTypes.STRING,
@@ -83,9 +83,19 @@ AgentSuggestionModel.init(
     sequelize: frontSequelize,
     indexes: [
       {
-        fields: ["workspaceId", "agentConfigurationIdTmp"],
+        fields: ["agentConfigurationId"],
         concurrently: true,
       },
     ],
   }
 );
+
+// Association with AgentConfigurationModel
+AgentSuggestionModel.belongsTo(AgentConfigurationModel, {
+  foreignKey: { name: "agentConfigurationId", allowNull: false },
+  onDelete: "RESTRICT",
+});
+AgentConfigurationModel.hasMany(AgentSuggestionModel, {
+  foreignKey: { name: "agentConfigurationId", allowNull: false },
+  as: "suggestions",
+});

--- a/front/lib/models/agent/agent_suggestion.ts
+++ b/front/lib/models/agent/agent_suggestion.ts
@@ -24,12 +24,7 @@ export class AgentSuggestionModel extends WorkspaceAwareModel<AgentSuggestionMod
   declare state: AgentSuggestionState;
   declare source: AgentSuggestionSource;
 
-  // The property name uses underscore to match Sequelize's default naming from modelName "agent_configuration"
-  declare agent_configuration: NonAttribute<AgentConfigurationModel>;
-
-  getAgentConfiguration(): AgentConfigurationModel | null {
-    return this.agent_configuration ?? null;
-  }
+  declare agentConfiguration: NonAttribute<AgentConfigurationModel>;
 }
 
 AgentSuggestionModel.init(
@@ -94,6 +89,7 @@ AgentSuggestionModel.init(
 AgentSuggestionModel.belongsTo(AgentConfigurationModel, {
   foreignKey: { name: "agentConfigurationId", allowNull: false },
   onDelete: "RESTRICT",
+  as: "agentConfiguration",
 });
 AgentConfigurationModel.hasMany(AgentSuggestionModel, {
   foreignKey: { name: "agentConfigurationId", allowNull: false },

--- a/front/lib/models/agent/agent_suggestion.ts
+++ b/front/lib/models/agent/agent_suggestion.ts
@@ -78,7 +78,7 @@ AgentSuggestionModel.init(
     sequelize: frontSequelize,
     indexes: [
       {
-        name: "agent_suggestions_list_by_agent_configuration",
+        name: "agent_suggestions_list_by_agent_configuration_idx",
         fields: ["workspaceId", "agentConfigurationId", "state", "kind"],
         concurrently: true,
       },

--- a/front/lib/resources/agent_suggestion_resource.test.ts
+++ b/front/lib/resources/agent_suggestion_resource.test.ts
@@ -27,7 +27,7 @@ describe("AgentSuggestionResource", () => {
     it("should create and fetch an instructions suggestion", async () => {
       const suggestion = await AgentSuggestionFactory.createInstructions(
         authenticator,
-        agentConfiguration.id,
+        agentConfiguration,
         {
           suggestion: {
             oldString: "Be helpful",
@@ -68,7 +68,7 @@ describe("AgentSuggestionResource", () => {
     it("should create and fetch a tools suggestion", async () => {
       const suggestion = await AgentSuggestionFactory.createTools(
         authenticator,
-        agentConfiguration.id,
+        agentConfiguration,
         {
           suggestion: {
             additions: [
@@ -106,7 +106,7 @@ describe("AgentSuggestionResource", () => {
     it("should create and fetch a skills suggestion", async () => {
       const suggestion = await AgentSuggestionFactory.createSkills(
         authenticator,
-        agentConfiguration.id,
+        agentConfiguration,
         {
           suggestion: {
             additions: ["data_analysis"],
@@ -137,7 +137,7 @@ describe("AgentSuggestionResource", () => {
     it("should create and fetch a model suggestion", async () => {
       const suggestion = await AgentSuggestionFactory.createModel(
         authenticator,
-        agentConfiguration.id,
+        agentConfiguration,
         {
           suggestion: {
             modelId: "claude-haiku-4-5-20251001",
@@ -175,7 +175,7 @@ describe("AgentSuggestionResource", () => {
       async (newState: "approved" | "declined" | "outdated") => {
         const suggestion = await AgentSuggestionFactory.createInstructions(
           authenticator,
-          agentConfiguration.id,
+          agentConfiguration,
           {
             suggestion: { oldString: "old", newString: "new" },
           }
@@ -196,7 +196,7 @@ describe("AgentSuggestionResource", () => {
     it("should fail to update state when user is not an editor of the agent", async () => {
       const suggestion = await AgentSuggestionFactory.createInstructions(
         authenticator,
-        agentConfiguration.id,
+        agentConfiguration,
         {
           suggestion: { oldString: "old", newString: "new" },
         }
@@ -220,7 +220,7 @@ describe("AgentSuggestionResource", () => {
     it("should delete a suggestion", async () => {
       const suggestion = await AgentSuggestionFactory.createTools(
         authenticator,
-        agentConfiguration.id
+        agentConfiguration
       );
       const sId = suggestion.sId;
 
@@ -237,7 +237,7 @@ describe("AgentSuggestionResource", () => {
     it("should fail to delete when user is not an editor of the agent", async () => {
       const suggestion = await AgentSuggestionFactory.createTools(
         authenticator,
-        agentConfiguration.id
+        agentConfiguration
       );
 
       // Create a different user who is not an editor of the agent.
@@ -258,7 +258,7 @@ describe("AgentSuggestionResource", () => {
     });
   });
 
-  describe("makeNew permission check", () => {
+  describe("createSuggestionForAgent permission check", () => {
     it("should fail to create suggestion when user is not an editor of the agent", async () => {
       // Create a different user who is not an editor of the agent.
       const otherUser = await UserFactory.basic();
@@ -269,14 +269,17 @@ describe("AgentSuggestionResource", () => {
       );
 
       await expect(
-        AgentSuggestionResource.makeNew(otherAuthenticator, {
-          agentConfigurationId: agentConfiguration.id,
-          kind: "instructions",
-          suggestion: { oldString: "old", newString: "new" },
-          analysis: null,
-          state: "pending",
-          source: "copilot",
-        })
+        AgentSuggestionResource.createSuggestionForAgent(
+          otherAuthenticator,
+          agentConfiguration,
+          {
+            kind: "instructions",
+            suggestion: { oldString: "old", newString: "new" },
+            analysis: null,
+            state: "pending",
+            source: "copilot",
+          }
+        )
       ).rejects.toThrow("User does not have permission to edit this agent");
     });
   });
@@ -285,7 +288,7 @@ describe("AgentSuggestionResource", () => {
     it("should not return suggestion when user is not an editor of the agent", async () => {
       const suggestion = await AgentSuggestionFactory.createInstructions(
         authenticator,
-        agentConfiguration.id
+        agentConfiguration
       );
 
       // Create a different user who is not an editor of the agent.
@@ -309,7 +312,7 @@ describe("AgentSuggestionResource", () => {
       const instructionsSuggestion =
         await AgentSuggestionFactory.createInstructions(
           authenticator,
-          agentConfiguration.id,
+          agentConfiguration,
           {
             suggestion: {
               oldString: "old",
@@ -339,16 +342,16 @@ describe("AgentSuggestionResource", () => {
       // Create multiple suggestions.
       await AgentSuggestionFactory.createInstructions(
         authenticator,
-        agentConfiguration.id,
+        agentConfiguration,
         { suggestion: { oldString: "a", newString: "b" } }
       );
       await AgentSuggestionFactory.createTools(
         authenticator,
-        agentConfiguration.id
+        agentConfiguration
       );
       await AgentSuggestionFactory.createModel(
         authenticator,
-        agentConfiguration.id
+        agentConfiguration
       );
 
       const suggestions =
@@ -363,12 +366,12 @@ describe("AgentSuggestionResource", () => {
     it("should filter by state", async () => {
       const pending = await AgentSuggestionFactory.createInstructions(
         authenticator,
-        agentConfiguration.id,
+        agentConfiguration,
         { suggestion: { oldString: "a", newString: "b" }, state: "pending" }
       );
       await AgentSuggestionFactory.createTools(
         authenticator,
-        agentConfiguration.id
+        agentConfiguration
       );
 
       await pending.updateState(authenticator, "approved");
@@ -397,16 +400,16 @@ describe("AgentSuggestionResource", () => {
     it("should filter by kind", async () => {
       await AgentSuggestionFactory.createInstructions(
         authenticator,
-        agentConfiguration.id,
+        agentConfiguration,
         { suggestion: { oldString: "a", newString: "b" } }
       );
       await AgentSuggestionFactory.createTools(
         authenticator,
-        agentConfiguration.id
+        agentConfiguration
       );
       await AgentSuggestionFactory.createModel(
         authenticator,
-        agentConfiguration.id
+        agentConfiguration
       );
 
       const instructionsSuggestions =
@@ -433,17 +436,17 @@ describe("AgentSuggestionResource", () => {
     it("should filter by both state and kind", async () => {
       const instructions1 = await AgentSuggestionFactory.createInstructions(
         authenticator,
-        agentConfiguration.id,
+        agentConfiguration,
         { suggestion: { oldString: "a", newString: "b" } }
       );
       await AgentSuggestionFactory.createInstructions(
         authenticator,
-        agentConfiguration.id,
+        agentConfiguration,
         { suggestion: { oldString: "c", newString: "d" } }
       );
       await AgentSuggestionFactory.createTools(
         authenticator,
-        agentConfiguration.id
+        agentConfiguration
       );
 
       await instructions1.updateState(authenticator, "approved");
@@ -472,7 +475,7 @@ describe("AgentSuggestionResource", () => {
     it("should not return suggestions when user is not an editor of the agent", async () => {
       await AgentSuggestionFactory.createInstructions(
         authenticator,
-        agentConfiguration.id,
+        agentConfiguration,
         { suggestion: { oldString: "a", newString: "b" } }
       );
 
@@ -497,7 +500,7 @@ describe("AgentSuggestionResource", () => {
       // Create a suggestion for the initial agent (version 0).
       const suggestion1 = await AgentSuggestionFactory.createInstructions(
         authenticator,
-        agentConfiguration.id,
+        agentConfiguration,
         { suggestion: { oldString: "v0-old", newString: "v0-new" } }
       );
 
@@ -515,7 +518,7 @@ describe("AgentSuggestionResource", () => {
       // Create a suggestion for the new version.
       const suggestion2 = await AgentSuggestionFactory.createTools(
         authenticator,
-        updatedAgent.id
+        updatedAgent
       );
 
       // Verify listByAgentConfigurationId returns both suggestions.

--- a/front/lib/resources/agent_suggestion_resource.ts
+++ b/front/lib/resources/agent_suggestion_resource.ts
@@ -163,6 +163,7 @@ export class AgentSuggestionResource extends BaseResource<AgentSuggestionModel> 
       include: [
         {
           model: AgentConfigurationModel,
+          as: "agentConfiguration",
           required: true,
         },
       ],
@@ -175,7 +176,7 @@ export class AgentSuggestionResource extends BaseResource<AgentSuggestionModel> 
 
     // Get unique agent sIds from the included AgentConfigurationModel.
     const agentSIds = [
-      ...new Set(suggestions.map((s) => s.getAgentConfiguration()?.sId ?? "")),
+      ...new Set(suggestions.map((s) => s.agentConfiguration?.sId ?? "")),
     ].filter((sId) => sId !== "");
 
     const editorsGroupIdBySId = await this.getEditorsGroupIdByAgentSId(
@@ -189,7 +190,7 @@ export class AgentSuggestionResource extends BaseResource<AgentSuggestionModel> 
         if (auth.isAdmin()) {
           return true;
         }
-        const agentConfig = s.getAgentConfiguration();
+        const agentConfig = s.agentConfiguration;
         if (!agentConfig) {
           return false;
         }
@@ -201,7 +202,7 @@ export class AgentSuggestionResource extends BaseResource<AgentSuggestionModel> 
         );
       })
       .map((suggestion) => {
-        const agentConfig = suggestion.getAgentConfiguration();
+        const agentConfig = suggestion.agentConfiguration;
         const editorsGroupId = agentConfig
           ? (editorsGroupIdBySId.get(agentConfig.sId) ?? null)
           : null;

--- a/front/migrations/db/migration_489.sql
+++ b/front/migrations/db/migration_489.sql
@@ -26,6 +26,12 @@ FOREIGN KEY ("agentConfigurationId")
 REFERENCES "agent_configurations" ("id")
 ON DELETE RESTRICT ON UPDATE CASCADE;
 
--- Step 4: Create index on agentConfigurationId for efficient FK lookups
+-- Step 4: Create indexes
 CREATE INDEX CONCURRENTLY "agent_suggestions_agentConfigurationId"
 ON "agent_suggestions" ("agentConfigurationId");
+
+CREATE INDEX CONCURRENTLY "agent_suggestions_list_by_agent_configuration"
+ON "agent_suggestions" ("workspaceId", "agentConfigurationId", "state", "kind");
+
+CREATE INDEX CONCURRENTLY "agent_suggestions_workspace_agent_config_kind"
+ON "agent_suggestions" ("workspaceId", "agentConfigurationId", "kind");

--- a/front/migrations/db/migration_489.sql
+++ b/front/migrations/db/migration_489.sql
@@ -1,12 +1,31 @@
 -- Migration created on Jan 23, 2026
+-- Change agent_suggestions to use a proper FK to agent_configurations instead of sId + version tuple
+-- Part 1: Pre-deploy - Add new column and backfill (backward compatible)
+-- This migration works with the state after copilot-rename-column where:
+-- - agentConfigurationIdTmp contains the agent sId (formerly agentConfigurationId)
+-- - agentConfigurationVersion contains the version
 
-ALTER TABLE "agent_suggestions" ADD COLUMN "agentConfigurationIdTmp" VARCHAR(255);
+-- Step 1: Add new column (nullable initially)
+ALTER TABLE "agent_suggestions"
+ADD COLUMN "agentConfigurationId" BIGINT;
 
--- Copy data from old column to new column
-UPDATE "agent_suggestions" SET "agentConfigurationIdTmp" = "agentConfigurationId";
+-- Step 2: Backfill from agent_configurations table using the renamed column
+UPDATE "agent_suggestions" s
+SET "agentConfigurationId" = ac.id
+FROM "agent_configurations" ac
+WHERE ac."sId" = s."agentConfigurationIdTmp"
+  AND ac."version" = s."agentConfigurationVersion";
 
--- Make the new column NOT NULL after data is copied
-ALTER TABLE "agent_suggestions" ALTER COLUMN "agentConfigurationIdTmp" SET NOT NULL;
+-- Step 3: Make NOT NULL and add FK constraint
+ALTER TABLE "agent_suggestions"
+ALTER COLUMN "agentConfigurationId" SET NOT NULL;
 
--- Create new index on the new column
-CREATE INDEX CONCURRENTLY "agent_suggestions_workspace_id_agent_configuration_id_tmp" ON "agent_suggestions" ("workspaceId", "agentConfigurationIdTmp");
+ALTER TABLE "agent_suggestions"
+ADD CONSTRAINT "agent_suggestions_agentConfigurationId_fkey"
+FOREIGN KEY ("agentConfigurationId")
+REFERENCES "agent_configurations" ("id")
+ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- Step 4: Create indexes
+CREATE INDEX CONCURRENTLY "agent_suggestions_agentConfigurationId"
+ON "agent_suggestions" ("agentConfigurationId");

--- a/front/migrations/db/migration_489.sql
+++ b/front/migrations/db/migration_489.sql
@@ -26,6 +26,6 @@ FOREIGN KEY ("agentConfigurationId")
 REFERENCES "agent_configurations" ("id")
 ON DELETE RESTRICT ON UPDATE CASCADE;
 
--- Step 4: Create indexes
+-- Step 4: Create index on agentConfigurationId for efficient FK lookups
 CREATE INDEX CONCURRENTLY "agent_suggestions_agentConfigurationId"
 ON "agent_suggestions" ("agentConfigurationId");

--- a/front/migrations/db/migration_489.sql
+++ b/front/migrations/db/migration_489.sql
@@ -1,37 +1,12 @@
 -- Migration created on Jan 23, 2026
--- Change agent_suggestions to use a proper FK to agent_configurations instead of sId + version tuple
--- Part 1: Pre-deploy - Add new column and backfill (backward compatible)
--- This migration works with the state after copilot-rename-column where:
--- - agentConfigurationIdTmp contains the agent sId (formerly agentConfigurationId)
--- - agentConfigurationVersion contains the version
 
--- Step 1: Add new column (nullable initially)
-ALTER TABLE "agent_suggestions"
-ADD COLUMN "agentConfigurationId" BIGINT;
+ALTER TABLE "agent_suggestions" ADD COLUMN "agentConfigurationIdTmp" VARCHAR(255);
 
--- Step 2: Backfill from agent_configurations table using the renamed column
-UPDATE "agent_suggestions" s
-SET "agentConfigurationId" = ac.id
-FROM "agent_configurations" ac
-WHERE ac."sId" = s."agentConfigurationIdTmp"
-  AND ac."version" = s."agentConfigurationVersion";
+-- Copy data from old column to new column
+UPDATE "agent_suggestions" SET "agentConfigurationIdTmp" = "agentConfigurationId";
 
--- Step 3: Make NOT NULL and add FK constraint
-ALTER TABLE "agent_suggestions"
-ALTER COLUMN "agentConfigurationId" SET NOT NULL;
+-- Make the new column NOT NULL after data is copied
+ALTER TABLE "agent_suggestions" ALTER COLUMN "agentConfigurationIdTmp" SET NOT NULL;
 
-ALTER TABLE "agent_suggestions"
-ADD CONSTRAINT "agent_suggestions_agentConfigurationId_fkey"
-FOREIGN KEY ("agentConfigurationId")
-REFERENCES "agent_configurations" ("id")
-ON DELETE RESTRICT ON UPDATE CASCADE;
-
--- Step 4: Create indexes
-CREATE INDEX CONCURRENTLY "agent_suggestions_agentConfigurationId"
-ON "agent_suggestions" ("agentConfigurationId");
-
-CREATE INDEX CONCURRENTLY "agent_suggestions_list_by_agent_configuration"
-ON "agent_suggestions" ("workspaceId", "agentConfigurationId", "state", "kind");
-
-CREATE INDEX CONCURRENTLY "agent_suggestions_workspace_agent_config_kind"
-ON "agent_suggestions" ("workspaceId", "agentConfigurationId", "kind");
+-- Create new index on the new column
+CREATE INDEX CONCURRENTLY "agent_suggestions_workspace_id_agent_configuration_id_tmp" ON "agent_suggestions" ("workspaceId", "agentConfigurationIdTmp");

--- a/front/migrations/db/migration_490.sql
+++ b/front/migrations/db/migration_490.sql
@@ -31,7 +31,7 @@ ON DELETE RESTRICT ON UPDATE CASCADE;
 CREATE INDEX CONCURRENTLY "agent_suggestions_agentConfigurationId"
 ON "agent_suggestions" ("agentConfigurationId");
 
-CREATE INDEX CONCURRENTLY "agent_suggestions_list_by_agent_configuration"
+CREATE INDEX CONCURRENTLY "agent_suggestions_list_by_agent_configuration_idx"
 ON "agent_suggestions" ("workspaceId", "agentConfigurationId", "state", "kind");
 
 CREATE INDEX CONCURRENTLY "agent_suggestions_workspace_agent_config_kind"

--- a/front/migrations/db/migration_490.sql
+++ b/front/migrations/db/migration_490.sql
@@ -1,10 +1,38 @@
 -- Migration created on Jan 23, 2026
 -- Change agent_suggestions to use a proper FK to agent_configurations instead of sId + version tuple
--- Part 2: Post-deploy - Drop old columns and index
+-- Part 1: Pre-deploy - Add new column and backfill (backward compatible)
 
--- Step 1: Drop old index that used the old columns
-DROP INDEX IF EXISTS "agent_suggestions_workspace_agent_config";
+-- Step 1: Drop old index and column if necessary
+DROP INDEX IF EXISTS "agent_suggestions_workspace_id_agent_configuration_id";
+ALTER TABLE "agent_suggestions" DROP COLUMN IF EXISTS "agentConfigurationId";
 
--- Step 2: Drop old columns
-ALTER TABLE "agent_suggestions" DROP COLUMN "agentConfigurationSId";
-ALTER TABLE "agent_suggestions" DROP COLUMN "agentConfigurationVersion";
+-- Step 2: Add new agentConfigurationId column (nullable initially)
+ALTER TABLE "agent_suggestions"
+ADD COLUMN "agentConfigurationId" BIGINT;
+
+-- Step 3: Backfill from agent_configurations table using the renamed column
+UPDATE "agent_suggestions" s
+SET "agentConfigurationId" = ac.id
+FROM "agent_configurations" ac
+WHERE ac."sId" = s."agentConfigurationIdTmp"
+  AND ac."version" = s."agentConfigurationVersion";
+
+-- Step 4: Make NOT NULL and add FK constraint
+ALTER TABLE "agent_suggestions"
+ALTER COLUMN "agentConfigurationId" SET NOT NULL;
+
+ALTER TABLE "agent_suggestions"
+ADD CONSTRAINT "agent_suggestions_agentConfigurationId_fkey"
+FOREIGN KEY ("agentConfigurationId")
+REFERENCES "agent_configurations" ("id")
+ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- Step 5: Create indexes
+CREATE INDEX CONCURRENTLY "agent_suggestions_agentConfigurationId"
+ON "agent_suggestions" ("agentConfigurationId");
+
+CREATE INDEX CONCURRENTLY "agent_suggestions_list_by_agent_configuration"
+ON "agent_suggestions" ("workspaceId", "agentConfigurationId", "state", "kind");
+
+CREATE INDEX CONCURRENTLY "agent_suggestions_workspace_agent_config_kind"
+ON "agent_suggestions" ("workspaceId", "agentConfigurationId", "kind");

--- a/front/migrations/db/migration_490.sql
+++ b/front/migrations/db/migration_490.sql
@@ -1,6 +1,6 @@
 -- Migration created on Jan 23, 2026
 -- Change agent_suggestions to use a proper FK to agent_configurations instead of sId + version tuple
--- Part 2: Post-deploy - Drop old columns and update index
+-- Part 2: Post-deploy - Drop old columns and index
 
 -- Step 1: Drop old index that used the old columns
 DROP INDEX IF EXISTS "agent_suggestions_workspace_agent_config";
@@ -8,10 +8,3 @@ DROP INDEX IF EXISTS "agent_suggestions_workspace_agent_config";
 -- Step 2: Drop old columns
 ALTER TABLE "agent_suggestions" DROP COLUMN "agentConfigurationSId";
 ALTER TABLE "agent_suggestions" DROP COLUMN "agentConfigurationVersion";
-
--- Step 3: Create new composite indexes to support listByAgentConfigurationId queries
-CREATE INDEX CONCURRENTLY "agent_suggestions_workspace_agent_config_state_kind"
-ON "agent_suggestions" ("workspaceId", "agentConfigurationId", "state", "kind");
-
-CREATE INDEX CONCURRENTLY "agent_suggestions_workspace_agent_config_kind"
-ON "agent_suggestions" ("workspaceId", "agentConfigurationId", "kind");

--- a/front/migrations/db/migration_490.sql
+++ b/front/migrations/db/migration_490.sql
@@ -1,0 +1,14 @@
+-- Migration created on Jan 23, 2026
+-- Change agent_suggestions to use a proper FK to agent_configurations instead of sId + version tuple
+-- Part 2: Post-deploy - Drop old columns and update index
+
+-- Step 1: Drop old index that used the old columns
+DROP INDEX IF EXISTS "agent_suggestions_workspace_agent_config";
+
+-- Step 2: Drop old columns
+ALTER TABLE "agent_suggestions" DROP COLUMN "agentConfigurationSId";
+ALTER TABLE "agent_suggestions" DROP COLUMN "agentConfigurationVersion";
+
+-- Step 3: Create new composite index
+CREATE INDEX CONCURRENTLY "agent_suggestions_workspace_agent_config"
+ON "agent_suggestions" ("workspaceId", "agentConfigurationId");

--- a/front/migrations/db/migration_490.sql
+++ b/front/migrations/db/migration_490.sql
@@ -9,6 +9,9 @@ DROP INDEX IF EXISTS "agent_suggestions_workspace_agent_config";
 ALTER TABLE "agent_suggestions" DROP COLUMN "agentConfigurationSId";
 ALTER TABLE "agent_suggestions" DROP COLUMN "agentConfigurationVersion";
 
--- Step 3: Create new composite index
-CREATE INDEX CONCURRENTLY "agent_suggestions_workspace_agent_config"
-ON "agent_suggestions" ("workspaceId", "agentConfigurationId");
+-- Step 3: Create new composite indexes to support listByAgentConfigurationId queries
+CREATE INDEX CONCURRENTLY "agent_suggestions_workspace_agent_config_state_kind"
+ON "agent_suggestions" ("workspaceId", "agentConfigurationId", "state", "kind");
+
+CREATE INDEX CONCURRENTLY "agent_suggestions_workspace_agent_config_kind"
+ON "agent_suggestions" ("workspaceId", "agentConfigurationId", "kind");

--- a/front/migrations/db/migration_491.sql
+++ b/front/migrations/db/migration_491.sql
@@ -1,0 +1,10 @@
+-- Migration created on Jan 23, 2026
+-- Change agent_suggestions to use a proper FK to agent_configurations instead of sId + version tuple
+-- Part 2: Post-deploy - Drop old columns and index
+
+-- Step 1: Drop old index from migration_489 (on agentConfigurationIdTmp)
+DROP INDEX IF EXISTS "agent_suggestions_workspace_id_agent_configuration_id_tmp";
+
+-- Step 2: Drop old columns (agentConfigurationIdTmp was formerly agentConfigurationId containing the sId)
+ALTER TABLE "agent_suggestions" DROP COLUMN "agentConfigurationIdTmp";
+ALTER TABLE "agent_suggestions" DROP COLUMN "agentConfigurationVersion";

--- a/front/tests/utils/AgentConfigurationFactory.ts
+++ b/front/tests/utils/AgentConfigurationFactory.ts
@@ -56,4 +56,46 @@ export class AgentConfigurationFactory {
 
     return result.value;
   }
+
+  /**
+   * Updates an existing agent configuration, creating a new version.
+   * Pass the sId of the existing agent to update it.
+   */
+  static async updateTestAgent(
+    auth: Authenticator,
+    agentSId: string,
+    overrides: Partial<{
+      name: string;
+      description: string;
+      instructions: string;
+    }> = {}
+  ): Promise<LightAgentConfigurationType> {
+    const user = auth.user();
+    assert(user, "User is required");
+
+    const result = await createAgentConfiguration(auth, {
+      name: overrides.name ?? "Test Agent",
+      description: overrides.description ?? "Test Agent Description",
+      instructions: overrides.instructions ?? "Updated Test Instructions",
+      pictureUrl: "https://dust.tt/static/systemavatar/test_avatar_1.png",
+      status: "active",
+      scope: "visible",
+      model: {
+        providerId: "openai",
+        modelId: "gpt-4-turbo",
+        temperature: 0.7,
+      },
+      templateId: null,
+      requestedSpaceIds: [],
+      tags: [],
+      editors: [user.toJSON()],
+      agentConfigurationId: agentSId,
+    });
+
+    if (result.isErr()) {
+      throw result.error;
+    }
+
+    return result.value;
+  }
 }

--- a/front/tests/utils/AgentSuggestionFactory.ts
+++ b/front/tests/utils/AgentSuggestionFactory.ts
@@ -1,5 +1,6 @@
 import type { Authenticator } from "@app/lib/auth";
 import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
+import type { ModelId } from "@app/types";
 import type {
   AgentSuggestionSource,
   AgentSuggestionState,
@@ -12,9 +13,8 @@ import type {
 export class AgentSuggestionFactory {
   static async createInstructions(
     auth: Authenticator,
-    agentConfigurationId: string,
+    agentConfigurationId: ModelId,
     overrides: Partial<{
-      agentConfigurationVersion: number;
       suggestion: InstructionsSuggestionType;
       analysis: string | null;
       state: AgentSuggestionState;
@@ -22,8 +22,7 @@ export class AgentSuggestionFactory {
     }> = {}
   ): Promise<AgentSuggestionResource> {
     return AgentSuggestionResource.makeNew(auth, {
-      agentConfigurationIdTmp: agentConfigurationId,
-      agentConfigurationVersion: overrides.agentConfigurationVersion ?? 1,
+      agentConfigurationId,
       kind: "instructions",
       suggestion: overrides.suggestion ?? {
         oldString: "You are a helpful assistant.",
@@ -39,9 +38,8 @@ export class AgentSuggestionFactory {
 
   static async createTools(
     auth: Authenticator,
-    agentConfigurationId: string,
+    agentConfigurationId: ModelId,
     overrides: Partial<{
-      agentConfigurationVersion: number;
       suggestion: ToolsSuggestionType;
       analysis: string | null;
       state: AgentSuggestionState;
@@ -49,8 +47,7 @@ export class AgentSuggestionFactory {
     }> = {}
   ): Promise<AgentSuggestionResource> {
     return AgentSuggestionResource.makeNew(auth, {
-      agentConfigurationIdTmp: agentConfigurationId,
-      agentConfigurationVersion: overrides.agentConfigurationVersion ?? 1,
+      agentConfigurationId,
       kind: "tools",
       suggestion: overrides.suggestion ?? {
         additions: [
@@ -67,9 +64,8 @@ export class AgentSuggestionFactory {
 
   static async createSkills(
     auth: Authenticator,
-    agentConfigurationId: string,
+    agentConfigurationId: ModelId,
     overrides: Partial<{
-      agentConfigurationVersion: number;
       suggestion: SkillsSuggestionType;
       analysis: string | null;
       state: AgentSuggestionState;
@@ -77,8 +73,7 @@ export class AgentSuggestionFactory {
     }> = {}
   ): Promise<AgentSuggestionResource> {
     return AgentSuggestionResource.makeNew(auth, {
-      agentConfigurationIdTmp: agentConfigurationId,
-      agentConfigurationVersion: overrides.agentConfigurationVersion ?? 1,
+      agentConfigurationId,
       kind: "skills",
       suggestion: overrides.suggestion ?? {
         additions: ["code_review", "summarization"],
@@ -91,9 +86,8 @@ export class AgentSuggestionFactory {
 
   static async createModel(
     auth: Authenticator,
-    agentConfigurationId: string,
+    agentConfigurationId: ModelId,
     overrides: Partial<{
-      agentConfigurationVersion: number;
       suggestion: ModelSuggestionType;
       analysis: string | null;
       state: AgentSuggestionState;
@@ -101,8 +95,7 @@ export class AgentSuggestionFactory {
     }> = {}
   ): Promise<AgentSuggestionResource> {
     return AgentSuggestionResource.makeNew(auth, {
-      agentConfigurationIdTmp: agentConfigurationId,
-      agentConfigurationVersion: overrides.agentConfigurationVersion ?? 1,
+      agentConfigurationId,
       kind: "model",
       suggestion: overrides.suggestion ?? {
         modelId: "claude-haiku-4-5-20251001",

--- a/front/tests/utils/AgentSuggestionFactory.ts
+++ b/front/tests/utils/AgentSuggestionFactory.ts
@@ -1,6 +1,6 @@
 import type { Authenticator } from "@app/lib/auth";
 import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
-import type { ModelId } from "@app/types";
+import type { LightAgentConfigurationType } from "@app/types";
 import type {
   AgentSuggestionSource,
   AgentSuggestionState,
@@ -13,7 +13,7 @@ import type {
 export class AgentSuggestionFactory {
   static async createInstructions(
     auth: Authenticator,
-    agentConfigurationId: ModelId,
+    agentConfiguration: LightAgentConfigurationType,
     overrides: Partial<{
       suggestion: InstructionsSuggestionType;
       analysis: string | null;
@@ -21,24 +21,27 @@ export class AgentSuggestionFactory {
       source: AgentSuggestionSource;
     }> = {}
   ): Promise<AgentSuggestionResource> {
-    return AgentSuggestionResource.makeNew(auth, {
-      agentConfigurationId,
-      kind: "instructions",
-      suggestion: overrides.suggestion ?? {
-        oldString: "You are a helpful assistant.",
-        newString: "You are an expert assistant specialized in coding.",
-        expectedOccurrences: 1,
-      },
-      analysis:
-        overrides.analysis ?? "Improved instructions for better coding help",
-      state: overrides.state ?? "pending",
-      source: overrides.source ?? "reinforcement",
-    });
+    return AgentSuggestionResource.createSuggestionForAgent(
+      auth,
+      agentConfiguration,
+      {
+        kind: "instructions",
+        suggestion: overrides.suggestion ?? {
+          oldString: "You are a helpful assistant.",
+          newString: "You are an expert assistant specialized in coding.",
+          expectedOccurrences: 1,
+        },
+        analysis:
+          overrides.analysis ?? "Improved instructions for better coding help",
+        state: overrides.state ?? "pending",
+        source: overrides.source ?? "reinforcement",
+      }
+    );
   }
 
   static async createTools(
     auth: Authenticator,
-    agentConfigurationId: ModelId,
+    agentConfiguration: LightAgentConfigurationType,
     overrides: Partial<{
       suggestion: ToolsSuggestionType;
       analysis: string | null;
@@ -46,25 +49,28 @@ export class AgentSuggestionFactory {
       source: AgentSuggestionSource;
     }> = {}
   ): Promise<AgentSuggestionResource> {
-    return AgentSuggestionResource.makeNew(auth, {
-      agentConfigurationId,
-      kind: "tools",
-      suggestion: overrides.suggestion ?? {
-        additions: [
-          { id: "notion", additionalConfiguration: { database: "tasks" } },
-          { id: "slack" },
-        ],
-        deletions: ["deprecated_tool"],
-      },
-      analysis: overrides.analysis ?? "Added useful integrations",
-      state: overrides.state ?? "pending",
-      source: overrides.source ?? "reinforcement",
-    });
+    return AgentSuggestionResource.createSuggestionForAgent(
+      auth,
+      agentConfiguration,
+      {
+        kind: "tools",
+        suggestion: overrides.suggestion ?? {
+          additions: [
+            { id: "notion", additionalConfiguration: { database: "tasks" } },
+            { id: "slack" },
+          ],
+          deletions: ["deprecated_tool"],
+        },
+        analysis: overrides.analysis ?? "Added useful integrations",
+        state: overrides.state ?? "pending",
+        source: overrides.source ?? "reinforcement",
+      }
+    );
   }
 
   static async createSkills(
     auth: Authenticator,
-    agentConfigurationId: ModelId,
+    agentConfiguration: LightAgentConfigurationType,
     overrides: Partial<{
       suggestion: SkillsSuggestionType;
       analysis: string | null;
@@ -72,21 +78,24 @@ export class AgentSuggestionFactory {
       source: AgentSuggestionSource;
     }> = {}
   ): Promise<AgentSuggestionResource> {
-    return AgentSuggestionResource.makeNew(auth, {
-      agentConfigurationId,
-      kind: "skills",
-      suggestion: overrides.suggestion ?? {
-        additions: ["code_review", "summarization"],
-      },
-      analysis: overrides.analysis ?? "Added skills for better assistance",
-      state: overrides.state ?? "pending",
-      source: overrides.source ?? "copilot",
-    });
+    return AgentSuggestionResource.createSuggestionForAgent(
+      auth,
+      agentConfiguration,
+      {
+        kind: "skills",
+        suggestion: overrides.suggestion ?? {
+          additions: ["code_review", "summarization"],
+        },
+        analysis: overrides.analysis ?? "Added skills for better assistance",
+        state: overrides.state ?? "pending",
+        source: overrides.source ?? "copilot",
+      }
+    );
   }
 
   static async createModel(
     auth: Authenticator,
-    agentConfigurationId: ModelId,
+    agentConfiguration: LightAgentConfigurationType,
     overrides: Partial<{
       suggestion: ModelSuggestionType;
       analysis: string | null;
@@ -94,16 +103,19 @@ export class AgentSuggestionFactory {
       source: AgentSuggestionSource;
     }> = {}
   ): Promise<AgentSuggestionResource> {
-    return AgentSuggestionResource.makeNew(auth, {
-      agentConfigurationId,
-      kind: "model",
-      suggestion: overrides.suggestion ?? {
-        modelId: "claude-haiku-4-5-20251001",
-        reasoningEffort: "medium",
-      },
-      analysis: overrides.analysis ?? "Suggested a more capable model",
-      state: overrides.state ?? "pending",
-      source: overrides.source ?? "reinforcement",
-    });
+    return AgentSuggestionResource.createSuggestionForAgent(
+      auth,
+      agentConfiguration,
+      {
+        kind: "model",
+        suggestion: overrides.suggestion ?? {
+          modelId: "claude-haiku-4-5-20251001",
+          reasoningEffort: "medium",
+        },
+        analysis: overrides.analysis ?? "Suggested a more capable model",
+        state: overrides.state ?? "pending",
+        source: overrides.source ?? "reinforcement",
+      }
+    );
   }
 }

--- a/front/types/suggestions/agent_suggestion.ts
+++ b/front/types/suggestions/agent_suggestion.ts
@@ -92,8 +92,7 @@ type BaseAgentSuggestionType = {
   sId: string;
   createdAt: number;
   updatedAt: number;
-  agentConfigurationId: string;
-  agentConfigurationVersion: number;
+  agentConfigurationId: ModelId;
   analysis: string | null;
   state: AgentSuggestionState;
   source: AgentSuggestionSource;


### PR DESCRIPTION
## Description

Lot of sequelize changes in this. The main purpose is use a foreign key to store the relation between agent suggestion and agent configuration.
This remove the old agentConfigurationId containing Sid  (done in github.com/dust-tt/dust/pull/20480/, renamed toagentConfigurationIdOld) and introduce a new column called agentConfigurationId corresponding to the ModelId (bigint).

This also introduce a new methods in the resource listByAgentConfigurationId to get all the suggestions for a given agent cross versions. It adds the corresponding indexes for this method.

There a re 2 migration scripts to be not breaking (+ the one in github.com/dust-tt/dust/pull/20480/)
 - first script create the new columns, FK and indexes (to be merged before deploy)
 - second script remove the old object now unused (to be merged after deploy)

## Tests

Unit tests

## Risk

medium: lot's of sequelize changes but feature is still unused

## Deploy Plan

lock front
merge
run migration 490
deploy
run migration 491
unlock front