### PR TITLE
copilot: delete the suggestion for whole workspace when deleting a workspace

### DIFF
--- a/front/lib/resources/agent_suggestion_resource.ts
+++ b/front/lib/resources/agent_suggestion_resource.ts
@@ -291,6 +291,28 @@ export class AgentSuggestionResource extends BaseResource<AgentSuggestionModel> 
     return new Ok(undefined);
   }
 
+  /**
+   * WARNING: This method deletes ALL suggestions for a workspace.
+   * Only workspace admins can perform this operation.
+   * This is intended for internal use only (e.g., workspace deletion workflows).
+   */
+  static async deleteAllForWorkspace(
+    auth: Authenticator,
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<void> {
+    if (!auth.isAdmin()) {
+      throw new Error("Only workspace admins can delete all suggestions");
+    }
+
+    const owner = auth.getNonNullableWorkspace();
+    await AgentSuggestionModel.destroy({
+      where: {
+        workspaceId: owner.id,
+      },
+      transaction,
+    });
+  }
+
   get sId(): string {
     return AgentSuggestionResource.modelIdToSId({
       id: this.id,

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -27,6 +27,7 @@ import { DustAppSecretModel } from "@app/lib/models/dust_app_secret";
 import { MembershipInvitationModel } from "@app/lib/models/membership_invitation";
 import { SubscriptionModel } from "@app/lib/models/plan";
 import { AgentMemoryResource } from "@app/lib/resources/agent_memory_resource";
+import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
 import { AppResource } from "@app/lib/resources/app_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { CreditResource } from "@app/lib/resources/credit_resource";
@@ -258,6 +259,8 @@ export async function deleteAgentsActivity({
       workspaceId: workspace.id,
     },
   });
+
+  await AgentSuggestionResource.deleteAllForWorkspace(auth);
 
   await GlobalAgentSettingsModel.destroy({
     where: {


### PR DESCRIPTION
## Description

closes https://github.com/dust-tt/tasks/issues/6060

 - add a resource method to delete all the suggestion from a workspace
 - use it in the script to delete a workspace

## Tests

 - added unit tests

## Risk

low

## Deploy Plan

deploy front
