### PR TITLE
Avoid unnecessary fetch when collapsing project section

### DIFF
--- a/front/hooks/useProjectsSectionCollapsed.ts
+++ b/front/hooks/useProjectsSectionCollapsed.ts
@@ -19,11 +19,17 @@ export const useProjectsSectionCollapsed = () => {
 
   const setProjectsSectionCollapsed = useCallback(
     async (collapsed: boolean) => {
+      const newValue = collapsed ? "true" : "false";
+
+      void mutateMetadata(
+        { metadata: { key: PROJECTS_SECTION_COLLAPSED_KEY, value: newValue } },
+        { revalidate: false }
+      );
+
       await setUserMetadataFromClient({
         key: PROJECTS_SECTION_COLLAPSED_KEY,
-        value: collapsed ? "true" : "false",
+        value: newValue,
       });
-      void mutateMetadata();
     },
     [mutateMetadata]
   );


### PR DESCRIPTION
## Description

When clicking the Projects section to collapse/expand it we currently do:

  1. POST /api/user/metadata/projectsSectionCollapsed - saves the state
  2. GET /api/user/metadata/projectsSectionCollapsed - unnecessary re-fetch after mutation

which is unnecessary and takes a long time, degrading the UX.

In this PR, we pass the new data directly to mutate with `revalidate: false` to avoid the unnecessary GET request. We do the async persisting call once the UI is already updated.

## Tests

local

## Risk

low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
