### PR TITLE
Add UKG PKCE logic

### DIFF
--- a/front/lib/api/oauth/providers/ukg_ready.ts
+++ b/front/lib/api/oauth/providers/ukg_ready.ts
@@ -149,7 +149,7 @@ export class UkgReadyOAuthProvider implements BaseOAuthStrategyProvider {
     }
 
     // PKCE OAuth flow only needs client_id (no client_secret)
-    return {
+    return new Ok({
       content: {
         client_id: extraConfig.client_id,
       },

--- a/front/types/oauth/lib.ts
+++ b/front/types/oauth/lib.ts
@@ -275,7 +275,7 @@ export function getProviderRequiredOAuthCredentialInputs({
       return null;
     case "ukg_ready":
       if (useCase === "personal_actions") {
-        // UKG Ready uses standard authorization code flow with client_secret
+        // UKG Ready uses PKCE authorization code flow (no client_secret needed)
         const result: OAuthCredentialInputs = {
           instance_url: {
             label: "UKG Ready Instance URL",
@@ -294,12 +294,6 @@ export function getProviderRequiredOAuthCredentialInputs({
             label: "OAuth Client ID",
             value: undefined,
             helpMessage: "The client ID from your UKG Ready OAuth app",
-            validator: isValidClientIdOrSecret,
-          },
-          client_secret: {
-            label: "OAuth Client Secret",
-            value: undefined,
-            helpMessage: "The client secret from your UKG Ready OAuth app",
             validator: isValidClientIdOrSecret,
           },
         };


### PR DESCRIPTION
## Description

* Following the token API spec: https://secure60.saashr.com/ta/docs/rest/public/?r=__v2__companies__(cid)__oauth2__token
* Adding PKCE logic as this is required for oauth
* Removing client secret as that is not allowed for the authorization_code type
* I am now getting 500s for the refresh token calls. Will meet with UKG in the morning to debug this
* Minor typing fixes

## Tests

<img width="466" height="596" alt="Screenshot 2026-01-22 at 10 18 19 PM" src="https://github.com/user-attachments/assets/f1ebc88c-9cc4-4c5f-85e2-456d794fffa9" />


## Risk

* Low

## Deploy Plan

1. Deploy oauth
2. Deploy front