### PR TITLE
feat(snowflake): support shared credentials for Snowflake MCP server

### DIFF
--- a/front/components/actions/mcp/MCPServerOAuthConnexion.tsx
+++ b/front/components/actions/mcp/MCPServerOAuthConnexion.tsx
@@ -208,7 +208,10 @@ export function MCPServerOAuthConnexion({
         </div>
       </div>
 
-      <ProviderSetupInstructions provider={authorization.provider} />
+      <ProviderSetupInstructions
+        provider={authorization.provider}
+        useCase={useCase}
+      />
 
       {inputs && (
         <div className="w-full space-y-4 pt-4">

--- a/front/components/actions/mcp/provider_setup_instructions/SnowflakeSetupInstructions.tsx
+++ b/front/components/actions/mcp/provider_setup_instructions/SnowflakeSetupInstructions.tsx
@@ -6,7 +6,15 @@ import {
 import { ChevronDownIcon, ChevronRightIcon } from "lucide-react";
 import { useState } from "react";
 
-export function SnowflakeSetupInstructions() {
+import type { MCPOAuthUseCase } from "@app/types";
+
+interface SnowflakeSetupInstructionsProps {
+  useCase: MCPOAuthUseCase | null;
+}
+
+export function SnowflakeSetupInstructions({
+  useCase,
+}: SnowflakeSetupInstructionsProps) {
   const [isOpen, setIsOpen] = useState(false);
 
   const redirectUri = `${process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL}/oauth/snowflake/finalize`;
@@ -81,8 +89,10 @@ export function SnowflakeSetupInstructions() {
 
             <p className="text-muted-foreground dark:text-muted-foreground-night">
               <strong>Note:</strong> The warehouse you specify below will be
-              used for all users. The default role can be overridden by
-              individual users during their personal authentication.
+              used for all users.
+              {useCase === "platform_actions"
+                ? " The role will also be shared across all users."
+                : " The default role can be overridden by individual users during their personal authentication."}
             </p>
           </div>
         </CollapsibleContent>

--- a/front/components/actions/mcp/provider_setup_instructions/index.tsx
+++ b/front/components/actions/mcp/provider_setup_instructions/index.tsx
@@ -1,6 +1,11 @@
-import type { OAuthProvider } from "@app/types";
+import type { MCPOAuthUseCase, OAuthProvider } from "@app/types";
 
 import { SnowflakeSetupInstructions } from "./SnowflakeSetupInstructions";
+
+interface ProviderSetupInstructionsProps {
+  provider: OAuthProvider;
+  useCase: MCPOAuthUseCase | null;
+}
 
 /**
  * Renders provider-specific setup instructions in the connection dialog.
@@ -11,12 +16,11 @@ import { SnowflakeSetupInstructions } from "./SnowflakeSetupInstructions";
  */
 export function ProviderSetupInstructions({
   provider,
-}: {
-  provider: OAuthProvider;
-}) {
+  useCase,
+}: ProviderSetupInstructionsProps) {
   switch (provider) {
     case "snowflake":
-      return <SnowflakeSetupInstructions />;
+      return <SnowflakeSetupInstructions useCase={useCase} />;
     default:
       return null;
   }

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1507,7 +1507,7 @@ export const INTERNAL_MCP_SERVERS = {
         "Execute read-only SQL queries and browse schema in Snowflake.",
       authorization: {
         provider: "snowflake" as const,
-        supported_use_cases: ["personal_actions"] as const,
+        supported_use_cases: ["personal_actions", "platform_actions"] as const,
       },
       icon: "SnowflakeLogo",
       documentationUrl: "https://docs.dust.tt/docs/snowflake-tool",

--- a/front/lib/api/actions/servers/snowflake/metadata.ts
+++ b/front/lib/api/actions/servers/snowflake/metadata.ts
@@ -86,7 +86,7 @@ export const SNOWFLAKE_SERVER = {
       "Execute read-only SQL queries and browse schema in Snowflake.",
     authorization: {
       provider: "snowflake",
-      supported_use_cases: ["personal_actions"],
+      supported_use_cases: ["personal_actions", "platform_actions"],
     },
     icon: "SnowflakeLogo",
     documentationUrl: "https://docs.dust.tt/docs/snowflake-tool",

--- a/front/types/oauth/lib.ts
+++ b/front/types/oauth/lib.ts
@@ -409,7 +409,7 @@ export function getProviderRequiredOAuthCredentialInputs({
             label: "Default Snowflake Role",
             value: undefined,
             helpMessage:
-              "The default role for users (e.g., ANALYST). Users can override this during their personal authentication.",
+              "The Snowflake role to use (e.g., ANALYST). In personal mode, users can override this during their authentication.",
             validator: isValidSnowflakeRole,
             overridableAtPersonalAuth: true,
             personalAuthLabel: "Snowflake Role",

--- a/front/types/oauth/lib.ts
+++ b/front/types/oauth/lib.ts
@@ -409,7 +409,9 @@ export function getProviderRequiredOAuthCredentialInputs({
             label: "Default Snowflake Role",
             value: undefined,
             helpMessage:
-              "The Snowflake role to use (e.g., ANALYST). In personal mode, users can override this during their authentication.",
+              useCase === "platform_actions"
+                ? "The Snowflake role for all users (e.g., ANALYST)."
+                : "The default Snowflake role (e.g., ANALYST). Users can override this during their personal authentication.",
             validator: isValidSnowflakeRole,
             overridableAtPersonalAuth: true,
             personalAuthLabel: "Snowflake Role",


### PR DESCRIPTION
## Description

> **Base PR:** #20474

Add support for shared credentials (`platform_actions`) to the Snowflake MCP server, alongside the existing personal credentials (`personal_actions`) mode.

When configured with shared credentials:
- An admin authenticates once via OAuth with a service account
- All workspace users share that connection (no individual auth required)
- The Snowflake role and warehouse are fixed by the admin

Changes:
- Added `"platform_actions"` to Snowflake's `supported_use_cases` in both the server constants and metadata
- Updated `ProviderSetupInstructions` to pass `useCase` through, so `SnowflakeSetupInstructions` shows context-appropriate text depending on the selected mode
- Updated the role field help message to be accurate for both modes

## Tests

- Type-checked with `tsc --noEmit` (passes cleanly)
- ESLint passes on all modified files
- Verified by tracing the existing `platform_actions` code path (used by HubSpot, Salesforce, Notion, etc.) — the infrastructure already handles workspace-level token resolution, error routing (admin auth error instead of personal auth prompt), and credential passing to the Snowflake client

## Risk

**Low.** The `platform_actions` infrastructure is well-established and used by many other MCP servers. The Snowflake tool handlers already read credentials from `authInfo.extra` which is populated identically whether the connection is personal or workspace. The main risk is that the admin's OAuth refresh token could expire, blocking all users — but this is the same pattern used by other platform_actions providers and is handled by the standard "admin needs to reconfigure" error message.

## Deploy Plan

Standard deploy after #20474 is merged. No migrations or infrastructure changes needed. The feature is gated behind the existing `snowflake_tool` feature flag, and workspaces with existing personal_actions connections are unaffected (their `oAuthUseCase` remains set to `personal_actions`).