### PR TITLE
refactor(mcp): extract provider setup instructions into generic registry

### DIFF
--- a/front/components/actions/mcp/MCPServerOAuthConnexion.tsx
+++ b/front/components/actions/mcp/MCPServerOAuthConnexion.tsx
@@ -1,9 +1,6 @@
 import {
   Card,
   cn,
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
   Hoverable,
   Icon,
   Input,
@@ -12,11 +9,11 @@ import {
   Tooltip,
   UserIcon,
 } from "@dust-tt/sparkle";
-import { ChevronDownIcon, ChevronRightIcon } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { useController, useFormContext } from "react-hook-form";
 
 import type { MCPServerOAuthFormValues } from "@app/components/actions/mcp/forms/types";
+import { ProviderSetupInstructions } from "@app/components/actions/mcp/provider_setup_instructions";
 import type { AuthorizationInfo } from "@app/lib/actions/mcp_metadata_extraction";
 import type {
   MCPOAuthUseCase,
@@ -211,7 +208,7 @@ export function MCPServerOAuthConnexion({
         </div>
       </div>
 
-      {authorization.provider === "snowflake" && <SnowflakeSetupInstructions />}
+      <ProviderSetupInstructions provider={authorization.provider} />
 
       {inputs && (
         <div className="w-full space-y-4 pt-4">
@@ -326,89 +323,4 @@ function UseCaseCard({
   }
 
   return card;
-}
-
-function SnowflakeSetupInstructions() {
-  const [isOpen, setIsOpen] = useState(false);
-
-  const redirectUri = `${process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL}/oauth/snowflake/finalize`;
-
-  return (
-    <div className="w-full pt-4">
-      <Collapsible open={isOpen} onOpenChange={setIsOpen}>
-        <CollapsibleTrigger hideChevron>
-          <div className="flex w-full items-center gap-2 rounded-lg border border-border bg-muted/50 p-3 text-left text-sm font-medium text-foreground transition-colors hover:bg-muted dark:border-border-night dark:bg-muted-night/50 dark:text-foreground-night dark:hover:bg-muted-night">
-            {isOpen ? (
-              <ChevronDownIcon className="h-4 w-4 shrink-0" />
-            ) : (
-              <ChevronRightIcon className="h-4 w-4 shrink-0" />
-            )}
-            <span>Snowflake Custom OAuth Setup Guide</span>
-          </div>
-        </CollapsibleTrigger>
-        <CollapsibleContent>
-          <div className="mt-3 space-y-4 rounded-lg border border-border bg-background p-4 text-sm dark:border-border-night dark:bg-background-night">
-            <p className="text-muted-foreground dark:text-muted-foreground-night">
-              Before connecting, you need to create a Custom OAuth Security
-              Integration in your Snowflake account. Run the following SQL
-              commands as an <strong>ACCOUNTADMIN</strong>:
-            </p>
-
-            <div className="space-y-3">
-              <div>
-                <p className="mb-2 font-medium text-foreground dark:text-foreground-night">
-                  1. Create the OAuth Security Integration:
-                </p>
-                <pre className="overflow-x-auto whitespace-pre-wrap rounded-md bg-muted p-3 text-xs dark:bg-muted-night">
-                  {`CREATE SECURITY INTEGRATION dust_oauth
-  TYPE = OAUTH
-  ENABLED = TRUE
-  OAUTH_CLIENT = CUSTOM
-  OAUTH_CLIENT_TYPE = 'CONFIDENTIAL'
-  OAUTH_REDIRECT_URI = '${redirectUri}'
-  OAUTH_ISSUE_REFRESH_TOKENS = TRUE
-  OAUTH_REFRESH_TOKEN_VALIDITY = 7776000;`}
-                </pre>
-              </div>
-
-              <div>
-                <p className="mb-2 font-medium text-foreground dark:text-foreground-night">
-                  2. Get the Client ID and Client Secret:
-                </p>
-                <pre className="overflow-x-auto whitespace-pre-wrap rounded-md bg-muted p-3 text-xs dark:bg-muted-night">
-                  {`SELECT SYSTEM$SHOW_OAUTH_CLIENT_SECRETS('DUST_OAUTH');`}
-                </pre>
-                <p className="mt-2 text-muted-foreground dark:text-muted-foreground-night">
-                  This returns a JSON object with{" "}
-                  <code className="rounded bg-muted px-1 dark:bg-muted-night">
-                    OAUTH_CLIENT_ID
-                  </code>{" "}
-                  and{" "}
-                  <code className="rounded bg-muted px-1 dark:bg-muted-night">
-                    OAUTH_CLIENT_SECRET
-                  </code>
-                  . Copy these values into the form below.
-                </p>
-              </div>
-
-              <div>
-                <p className="mb-2 font-medium text-foreground dark:text-foreground-night">
-                  3. (Optional) Grant the integration to specific roles:
-                </p>
-                <pre className="overflow-x-auto whitespace-pre-wrap rounded-md bg-muted p-3 text-xs dark:bg-muted-night">
-                  {`GRANT USAGE ON INTEGRATION dust_oauth TO ROLE <role_name>;`}
-                </pre>
-              </div>
-            </div>
-
-            <p className="text-muted-foreground dark:text-muted-foreground-night">
-              <strong>Note:</strong> The warehouse you specify below will be
-              used for all users. The default role can be overridden by
-              individual users during their personal authentication.
-            </p>
-          </div>
-        </CollapsibleContent>
-      </Collapsible>
-    </div>
-  );
 }

--- a/front/components/actions/mcp/provider_setup_instructions/SnowflakeSetupInstructions.tsx
+++ b/front/components/actions/mcp/provider_setup_instructions/SnowflakeSetupInstructions.tsx
@@ -1,0 +1,92 @@
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@dust-tt/sparkle";
+import { ChevronDownIcon, ChevronRightIcon } from "lucide-react";
+import { useState } from "react";
+
+export function SnowflakeSetupInstructions() {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const redirectUri = `${process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL}/oauth/snowflake/finalize`;
+
+  return (
+    <div className="w-full pt-4">
+      <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+        <CollapsibleTrigger hideChevron>
+          <div className="flex w-full items-center gap-2 rounded-lg border border-border bg-muted/50 p-3 text-left text-sm font-medium text-foreground transition-colors hover:bg-muted dark:border-border-night dark:bg-muted-night/50 dark:text-foreground-night dark:hover:bg-muted-night">
+            {isOpen ? (
+              <ChevronDownIcon className="h-4 w-4 shrink-0" />
+            ) : (
+              <ChevronRightIcon className="h-4 w-4 shrink-0" />
+            )}
+            <span>Snowflake Custom OAuth Setup Guide</span>
+          </div>
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <div className="mt-3 space-y-4 rounded-lg border border-border bg-background p-4 text-sm dark:border-border-night dark:bg-background-night">
+            <p className="text-muted-foreground dark:text-muted-foreground-night">
+              Before connecting, you need to create a Custom OAuth Security
+              Integration in your Snowflake account. Run the following SQL
+              commands as an <strong>ACCOUNTADMIN</strong>:
+            </p>
+
+            <div className="space-y-3">
+              <div>
+                <p className="mb-2 font-medium text-foreground dark:text-foreground-night">
+                  1. Create the OAuth Security Integration:
+                </p>
+                <pre className="overflow-x-auto whitespace-pre-wrap rounded-md bg-muted p-3 text-xs dark:bg-muted-night">
+                  {`CREATE SECURITY INTEGRATION dust_oauth
+  TYPE = OAUTH
+  ENABLED = TRUE
+  OAUTH_CLIENT = CUSTOM
+  OAUTH_CLIENT_TYPE = 'CONFIDENTIAL'
+  OAUTH_REDIRECT_URI = '${redirectUri}'
+  OAUTH_ISSUE_REFRESH_TOKENS = TRUE
+  OAUTH_REFRESH_TOKEN_VALIDITY = 7776000;`}
+                </pre>
+              </div>
+
+              <div>
+                <p className="mb-2 font-medium text-foreground dark:text-foreground-night">
+                  2. Get the Client ID and Client Secret:
+                </p>
+                <pre className="overflow-x-auto whitespace-pre-wrap rounded-md bg-muted p-3 text-xs dark:bg-muted-night">
+                  {`SELECT SYSTEM$SHOW_OAUTH_CLIENT_SECRETS('DUST_OAUTH');`}
+                </pre>
+                <p className="mt-2 text-muted-foreground dark:text-muted-foreground-night">
+                  This returns a JSON object with{" "}
+                  <code className="rounded bg-muted px-1 dark:bg-muted-night">
+                    OAUTH_CLIENT_ID
+                  </code>{" "}
+                  and{" "}
+                  <code className="rounded bg-muted px-1 dark:bg-muted-night">
+                    OAUTH_CLIENT_SECRET
+                  </code>
+                  . Copy these values into the form below.
+                </p>
+              </div>
+
+              <div>
+                <p className="mb-2 font-medium text-foreground dark:text-foreground-night">
+                  3. (Optional) Grant the integration to specific roles:
+                </p>
+                <pre className="overflow-x-auto whitespace-pre-wrap rounded-md bg-muted p-3 text-xs dark:bg-muted-night">
+                  {`GRANT USAGE ON INTEGRATION dust_oauth TO ROLE <role_name>;`}
+                </pre>
+              </div>
+            </div>
+
+            <p className="text-muted-foreground dark:text-muted-foreground-night">
+              <strong>Note:</strong> The warehouse you specify below will be
+              used for all users. The default role can be overridden by
+              individual users during their personal authentication.
+            </p>
+          </div>
+        </CollapsibleContent>
+      </Collapsible>
+    </div>
+  );
+}

--- a/front/components/actions/mcp/provider_setup_instructions/index.tsx
+++ b/front/components/actions/mcp/provider_setup_instructions/index.tsx
@@ -1,0 +1,23 @@
+import type { OAuthProvider } from "@app/types";
+
+import { SnowflakeSetupInstructions } from "./SnowflakeSetupInstructions";
+
+/**
+ * Renders provider-specific setup instructions in the connection dialog.
+ * These guide admins through provider-specific setup steps
+ * (e.g., creating security integrations in Snowflake).
+ *
+ * Returns null if the provider has no setup instructions.
+ */
+export function ProviderSetupInstructions({
+  provider,
+}: {
+  provider: OAuthProvider;
+}) {
+  switch (provider) {
+    case "snowflake":
+      return <SnowflakeSetupInstructions />;
+    default:
+      return null;
+  }
+}


### PR DESCRIPTION
## Description

The `MCPServerOAuthConnexion` component had a hardcoded `if (authorization.provider === "snowflake")` check to render Snowflake-specific setup instructions (SQL commands for creating the OAuth security integration). This couples a generic component to a specific provider.

This PR extracts the pattern into a proper generic registry:

- **`provider_setup_instructions/index.tsx`** — A `ProviderSetupInstructions` component that switches on the provider name and renders the appropriate instructions (or null if none exist).
- **`provider_setup_instructions/SnowflakeSetupInstructions.tsx`** — The extracted Snowflake-specific component (unchanged behavior).

New providers that need setup instructions can simply add a case to the switch and their own component file, without touching the generic OAuth connection component.

## Tests

- Type-checked with `tsc --noEmit`
- ESLint passes on all modified/new files
- No behavioral change — same instructions rendered in the same place

## Risk

**None.** Pure refactor, no logic changes. The Snowflake setup instructions render identically.

## Deploy Plan

Standard deploy. No migrations or infrastructure changes.