### PR TITLE
feat: use lastReadAt to compute unread status of conversation

### DIFF
--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -386,6 +386,7 @@ export const ConversationViewer = ({
             break;
 
           case "conversation_title":
+            void debouncedMarkAsRead(conversationId, false);
             void mutateConversation(
               (current) => {
                 if (current) {

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -687,7 +687,7 @@ export async function postUserMessage(
     await ConversationResource.markAsUpdated(auth, { conversation, t });
 
     // Mark the conversation as read for the current user.
-    await ConversationResource.markAsRead(auth, {
+    await ConversationResource.markAsReadForAuthUser(auth, {
       conversation,
       transaction: t,
     });
@@ -997,6 +997,12 @@ export async function editUserMessage(
           agentMessages,
         };
       }
+
+      // Mark the conversation as read for the current user.
+      await ConversationResource.markAsReadForAuthUser(auth, {
+        conversation,
+        transaction: t,
+      });
 
       const userMessage = {
         ...userMessageWithoutMentions,

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -662,13 +662,6 @@ export async function postUserMessage(
       transaction: t,
     });
 
-    // Mark the conversation as unread for all participants except the user.
-    await ConversationResource.markAsUnreadForOtherParticipants(auth, {
-      conversation,
-      excludedUser: user?.toJSON(),
-      transaction: t,
-    });
-
     const { agentMessages, richMentions: agentRichMentions } =
       await createAgentMessages(auth, {
         conversation,
@@ -692,6 +685,12 @@ export async function postUserMessage(
     };
 
     await ConversationResource.markAsUpdated(auth, { conversation, t });
+
+    // Mark the conversation as read for the current user.
+    await ConversationResource.markAsRead(auth, {
+      conversation,
+      transaction: t,
+    });
 
     return {
       userMessage,
@@ -929,13 +928,6 @@ export async function editUserMessage(
           type: "edit",
           message,
         },
-        transaction: t,
-      });
-
-      // Mark the conversation as unread for all participants except the user.
-      await ConversationResource.markAsUnreadForOtherParticipants(auth, {
-        conversation,
-        excludedUser: user?.toJSON(),
         transaction: t,
       });
 

--- a/front/lib/api/assistant/conversation/fetch.ts
+++ b/front/lib/api/assistant/conversation/fetch.ts
@@ -112,8 +112,8 @@ export async function getConversation(
     (content[m.rank] as any).push(m);
   }
 
-  const { actionRequired, unread } =
-    await ConversationResource.getActionRequiredAndUnreadForUser(
+  const { actionRequired, lastReadAt } =
+    await ConversationResource.getActionRequiredAndLastReadAtForUser(
       auth,
       conversation.id
     );
@@ -130,7 +130,7 @@ export async function getConversation(
     triggerId: conversation.triggerSId,
     content,
     actionRequired,
-    unread,
+    unread: lastReadAt === null || conversation.updatedAt > lastReadAt,
     hasError: conversation.hasError,
     requestedGroupIds: [],
     requestedSpaceIds: conversation.getRequestedSpaceIdsFromModel(),

--- a/front/lib/api/assistant/conversation/mentions.test.ts
+++ b/front/lib/api/assistant/conversation/mentions.test.ts
@@ -3413,7 +3413,7 @@ describe("validateUserMention", () => {
     });
   });
 
-  it("should add a participant with unread=true when approving a user mention", async () => {
+  it("should add a participant with lastReadAt=null when approving a user mention", async () => {
     // Create a second user who will be mentioned
     const mentionedUser = await UserFactory.basic();
     await MembershipFactory.associate(workspace, mentionedUser, {
@@ -3469,7 +3469,7 @@ describe("validateUserMention", () => {
 
     expect(result.isOk()).toBe(true);
 
-    // Verify the mentioned user is now a participant with unread=true
+    // Verify the mentioned user is now a participant with lastReadAt=null
     const participant = await ConversationParticipantModel.findOne({
       where: {
         workspaceId: workspace.id,
@@ -3479,7 +3479,7 @@ describe("validateUserMention", () => {
     });
 
     expect(participant).not.toBeNull();
-    expect(participant?.unread).toBe(true);
+    expect(participant?.lastReadAt).toBeNull();
     expect(participant?.action).toBe("subscribed");
   });
 

--- a/front/lib/api/assistant/conversation/mentions.ts
+++ b/front/lib/api/assistant/conversation/mentions.ts
@@ -1140,7 +1140,7 @@ export async function validateUserMention(
       conversation,
       action: "subscribed",
       user: user.toJSON(),
-      unread: true,
+      lastReadAt: null,
     });
 
     if (status === "added") {

--- a/front/lib/models/agent/conversation.ts
+++ b/front/lib/models/agent/conversation.ts
@@ -141,7 +141,7 @@ export class ConversationParticipantModel extends WorkspaceAwareModel<Conversati
   declare updatedAt: CreationOptional<Date>;
 
   declare action: ParticipantActionType;
-  declare unread: boolean;
+  declare unread?: boolean;
   declare actionRequired: boolean;
   declare lastReadAt: Date | null;
 

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -916,7 +916,7 @@ describe("listConversationsForUser", () => {
     const conversationData = userConversations[0].toJSON();
 
     // Verify participation data is used in toJSON.
-    expect(conversationData.unread).toBe(true);
+    expect(conversationData.unread).toBe(false);
     expect(conversationData.actionRequired).toBe(participation.actionRequired);
 
     // Verify other fields are present.

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -916,7 +916,7 @@ describe("listConversationsForUser", () => {
     const conversationData = userConversations[0].toJSON();
 
     // Verify participation data is used in toJSON.
-    expect(conversationData.unread).toBe(participation.unread);
+    expect(conversationData.unread).toBe(true);
     expect(conversationData.actionRequired).toBe(participation.actionRequired);
 
     // Verify other fields are present.
@@ -1033,7 +1033,7 @@ describe("listConversationsForUser", () => {
 
       // Mark the original conversation as read
       await ConversationParticipantModel.update(
-        { unread: false },
+        { lastReadAt: new Date() },
         {
           where: {
             conversationId: (await ConversationResource.fetchById(
@@ -1048,7 +1048,7 @@ describe("listConversationsForUser", () => {
 
       // Mark unreadConvo as unread
       await ConversationParticipantModel.update(
-        { unread: true },
+        { lastReadAt: dateFromDaysAgo(3) },
         {
           where: {
             conversationId: (await ConversationResource.fetchById(
@@ -1063,7 +1063,7 @@ describe("listConversationsForUser", () => {
 
       // Mark readConvo as read
       await ConversationParticipantModel.update(
-        { unread: false },
+        { lastReadAt: new Date() },
         {
           where: {
             conversationId: (await ConversationResource.fetchById(
@@ -1117,7 +1117,7 @@ describe("listConversationsForUser", () => {
       assert(conversation, "Conversation not found");
 
       await ConversationParticipantModel.update(
-        { unread: false },
+        { lastReadAt: new Date() },
         {
           where: {
             conversationId: conversation.id,
@@ -1367,7 +1367,7 @@ describe("listConversationsForUser", () => {
 
       // Mark unreadSpaceConvo as unread
       await ConversationParticipantModel.update(
-        { unread: true },
+        { lastReadAt: dateFromDaysAgo(2) },
         {
           where: {
             conversationId: (await ConversationResource.fetchById(
@@ -1382,7 +1382,7 @@ describe("listConversationsForUser", () => {
 
       // Mark readSpaceConvo as read
       await ConversationParticipantModel.update(
-        { unread: false },
+        { lastReadAt: new Date() },
         {
           where: {
             conversationId: (await ConversationResource.fetchById(
@@ -1397,7 +1397,7 @@ describe("listConversationsForUser", () => {
 
       // Mark unreadPrivateConvo as unread
       await ConversationParticipantModel.update(
-        { unread: true },
+        { lastReadAt: null },
         {
           where: {
             conversationId: (await ConversationResource.fetchById(
@@ -3015,296 +3015,6 @@ describe("Space Handling", () => {
       ).length;
       expect(nonCfCount).toBe(2);
     });
-  });
-});
-
-describe("markAsUnreadForOtherParticipants", () => {
-  let auth: Authenticator;
-  let user1Auth: Authenticator;
-  let user2Auth: Authenticator;
-  let user3Auth: Authenticator;
-  let conversation: ConversationWithoutContentType;
-  let agents: LightAgentConfigurationType[];
-  let conversationId: string;
-
-  beforeEach(async () => {
-    const workspace = await WorkspaceFactory.basic();
-    // Ensure default groups exist
-    await GroupResource.makeDefaultsForWorkspace(workspace);
-    const user = await UserFactory.basic();
-    auth = await Authenticator.fromUserIdAndWorkspaceId(
-      user.sId,
-      workspace.sId
-    );
-    agents = await setupTestAgents(workspace, user);
-
-    // Create additional users
-    const user1 = await UserFactory.basic();
-    const user2 = await UserFactory.basic();
-    const user3 = await UserFactory.basic();
-    await MembershipFactory.associate(workspace, user1, { role: "user" });
-    await MembershipFactory.associate(workspace, user2, { role: "user" });
-    await MembershipFactory.associate(workspace, user3, { role: "user" });
-
-    user1Auth = await Authenticator.fromUserIdAndWorkspaceId(
-      user1.sId,
-      workspace.sId
-    );
-    user2Auth = await Authenticator.fromUserIdAndWorkspaceId(
-      user2.sId,
-      workspace.sId
-    );
-    user3Auth = await Authenticator.fromUserIdAndWorkspaceId(
-      user3.sId,
-      workspace.sId
-    );
-
-    conversation = await ConversationFactory.create(auth, {
-      agentConfigurationId: agents[0].sId,
-      messagesCreatedAt: [dateFromDaysAgo(5)],
-    });
-    conversationId = conversation.sId;
-
-    // Add all users as participants
-    await ConversationResource.upsertParticipation(user1Auth, {
-      conversation,
-      action: "posted",
-      user: user1Auth.getNonNullableUser().toJSON(),
-    });
-    await ConversationResource.upsertParticipation(user2Auth, {
-      conversation,
-      action: "posted",
-      user: user2Auth.getNonNullableUser().toJSON(),
-    });
-    await ConversationResource.upsertParticipation(user3Auth, {
-      conversation,
-      action: "posted",
-      user: user3Auth.getNonNullableUser().toJSON(),
-    });
-  });
-
-  afterEach(async () => {
-    await destroyConversation(auth, { conversationId });
-  });
-
-  it("should not update rows that are already unread", async () => {
-    const { ConversationParticipantModel } =
-      await import("@app/lib/models/agent/conversation");
-
-    const conversationResource = await ConversationResource.fetchById(
-      auth,
-      conversationId
-    );
-    assert(conversationResource, "Conversation resource not found");
-
-    // Set user1 and user2 to unread: true, user3 to unread: false
-    await ConversationParticipantModel.update(
-      { unread: true },
-      {
-        where: {
-          conversationId: conversationResource.id,
-          workspaceId: auth.getNonNullableWorkspace().id,
-          userId: user1Auth.getNonNullableUser().id,
-        },
-      }
-    );
-    await ConversationParticipantModel.update(
-      { unread: true },
-      {
-        where: {
-          conversationId: conversationResource.id,
-          workspaceId: auth.getNonNullableWorkspace().id,
-          userId: user2Auth.getNonNullableUser().id,
-        },
-      }
-    );
-    await ConversationParticipantModel.update(
-      { unread: false },
-      {
-        where: {
-          conversationId: conversationResource.id,
-          workspaceId: auth.getNonNullableWorkspace().id,
-          userId: user3Auth.getNonNullableUser().id,
-        },
-      }
-    );
-
-    // Get the updatedAt timestamps before calling markAsUnreadForOtherParticipants
-    const participant1Before = await ConversationParticipantModel.findOne({
-      where: {
-        conversationId: conversationResource.id,
-        workspaceId: auth.getNonNullableWorkspace().id,
-        userId: user1Auth.getNonNullableUser().id,
-      },
-    });
-    const participant2Before = await ConversationParticipantModel.findOne({
-      where: {
-        conversationId: conversationResource.id,
-        workspaceId: auth.getNonNullableWorkspace().id,
-        userId: user2Auth.getNonNullableUser().id,
-      },
-    });
-    const participant3Before = await ConversationParticipantModel.findOne({
-      where: {
-        conversationId: conversationResource.id,
-        workspaceId: auth.getNonNullableWorkspace().id,
-        userId: user3Auth.getNonNullableUser().id,
-      },
-    });
-
-    assert(participant1Before, "Participant 1 not found");
-    assert(participant2Before, "Participant 2 not found");
-    assert(participant3Before, "Participant 3 not found");
-
-    const updatedAt1Before = participant1Before.updatedAt.getTime();
-    const updatedAt2Before = participant2Before.updatedAt.getTime();
-    const updatedAt3Before = participant3Before.updatedAt.getTime();
-
-    // Wait a bit to ensure updatedAt would change if updated
-    await new Promise((resolve) => setTimeout(resolve, 10));
-
-    // Call markAsUnreadForOtherParticipants
-    const result = await ConversationResource.markAsUnreadForOtherParticipants(
-      auth,
-      {
-        conversation,
-      }
-    );
-
-    expect(result.isOk()).toBe(true);
-    if (result.isOk()) {
-      // Should only update 1 row (user3, who had unread: false)
-      expect(result.value[0]).toBe(1);
-    }
-
-    // Verify user1 (already unread: true) was NOT updated
-    const participant1After = await ConversationParticipantModel.findOne({
-      where: {
-        conversationId: conversationResource.id,
-        workspaceId: auth.getNonNullableWorkspace().id,
-        userId: user1Auth.getNonNullableUser().id,
-      },
-    });
-    assert(participant1After, "Participant 1 not found after update");
-    expect(participant1After.unread).toBe(true);
-    expect(participant1After.updatedAt.getTime()).toBe(updatedAt1Before);
-
-    // Verify user2 (already unread: true) was NOT updated
-    const participant2After = await ConversationParticipantModel.findOne({
-      where: {
-        conversationId: conversationResource.id,
-        workspaceId: auth.getNonNullableWorkspace().id,
-        userId: user2Auth.getNonNullableUser().id,
-      },
-    });
-    assert(participant2After, "Participant 2 not found after update");
-    expect(participant2After.unread).toBe(true);
-    expect(participant2After.updatedAt.getTime()).toBe(updatedAt2Before);
-
-    // Verify user3 (unread: false) WAS updated to unread: true
-    const participant3After = await ConversationParticipantModel.findOne({
-      where: {
-        conversationId: conversationResource.id,
-        workspaceId: auth.getNonNullableWorkspace().id,
-        userId: user3Auth.getNonNullableUser().id,
-      },
-    });
-    assert(participant3After, "Participant 3 not found after update");
-    expect(participant3After.unread).toBe(true);
-    expect(participant3After.updatedAt.getTime()).toBeGreaterThan(
-      updatedAt3Before
-    );
-  });
-
-  it("should update only participants with unread: false when excludedUser is provided", async () => {
-    const { ConversationParticipantModel } =
-      await import("@app/lib/models/agent/conversation");
-
-    const conversationResource = await ConversationResource.fetchById(
-      auth,
-      conversationId
-    );
-    assert(conversationResource, "Conversation resource not found");
-
-    // Set user1 to unread: true, user2 and user3 to unread: false
-    await ConversationParticipantModel.update(
-      { unread: true },
-      {
-        where: {
-          conversationId: conversationResource.id,
-          workspaceId: auth.getNonNullableWorkspace().id,
-          userId: user1Auth.getNonNullableUser().id,
-        },
-      }
-    );
-    await ConversationParticipantModel.update(
-      { unread: false },
-      {
-        where: {
-          conversationId: conversationResource.id,
-          workspaceId: auth.getNonNullableWorkspace().id,
-          userId: user2Auth.getNonNullableUser().id,
-        },
-      }
-    );
-    await ConversationParticipantModel.update(
-      { unread: false },
-      {
-        where: {
-          conversationId: conversationResource.id,
-          workspaceId: auth.getNonNullableWorkspace().id,
-          userId: user3Auth.getNonNullableUser().id,
-        },
-      }
-    );
-
-    // Call markAsUnreadForOtherParticipants with excludedUser (user1)
-    const result = await ConversationResource.markAsUnreadForOtherParticipants(
-      auth,
-      {
-        conversation,
-        excludedUser: user1Auth.getNonNullableUser().toJSON(),
-      }
-    );
-
-    expect(result.isOk()).toBe(true);
-    if (result.isOk()) {
-      // Should update 2 rows (user2 and user3, who had unread: false)
-      expect(result.value[0]).toBe(2);
-    }
-
-    // Verify user1 (excluded) remains unchanged
-    const participant1After = await ConversationParticipantModel.findOne({
-      where: {
-        conversationId: conversationResource.id,
-        workspaceId: auth.getNonNullableWorkspace().id,
-        userId: user1Auth.getNonNullableUser().id,
-      },
-    });
-    assert(participant1After, "Participant 1 not found after update");
-    expect(participant1After.unread).toBe(true);
-
-    // Verify user2 (unread: false, not excluded) was updated
-    const participant2After = await ConversationParticipantModel.findOne({
-      where: {
-        conversationId: conversationResource.id,
-        workspaceId: auth.getNonNullableWorkspace().id,
-        userId: user2Auth.getNonNullableUser().id,
-      },
-    });
-    assert(participant2After, "Participant 2 not found after update");
-    expect(participant2After.unread).toBe(true);
-
-    // Verify user3 (unread: false, not excluded) was updated
-    const participant3After = await ConversationParticipantModel.findOne({
-      where: {
-        conversationId: conversationResource.id,
-        workspaceId: auth.getNonNullableWorkspace().id,
-        userId: user3Auth.getNonNullableUser().id,
-      },
-    });
-    assert(participant3After, "Participant 3 not found after update");
-    expect(participant3After.unread).toBe(true);
   });
 });
 

--- a/front/migrations/20260122_backfill_lastReadAt_ConversationParticipant.sql
+++ b/front/migrations/20260122_backfill_lastReadAt_ConversationParticipant.sql
@@ -1,9 +1,0 @@
--- Script to backfill lastReadAt for ConversationParticipant
--- Sets lastReadAt to current timestamp for participants with unread = false
--- Leaves lastReadAt as NULL for participants with unread = true
-
-UPDATE "conversation_participants"
-SET "lastReadAt" = NOW()
-WHERE "unread" = false;
-
--- No action needed for unread = true (lastReadAt remains NULL)

--- a/front/migrations/20260122_backfill_lastReadAt_ConversationParticipant.sql
+++ b/front/migrations/20260122_backfill_lastReadAt_ConversationParticipant.sql
@@ -1,0 +1,9 @@
+-- Script to backfill lastReadAt for ConversationParticipant
+-- Sets lastReadAt to current timestamp for participants with unread = false
+-- Leaves lastReadAt as NULL for participants with unread = true
+
+UPDATE "conversation_participants"
+SET "lastReadAt" = NOW()
+WHERE "unread" = false;
+
+-- No action needed for unread = true (lastReadAt remains NULL)

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -162,7 +162,7 @@ async function handler(
       }
       const { read } = r.data;
       if (read) {
-        await ConversationResource.markAsRead(auth, {
+        await ConversationResource.markAsReadForAuthUser(auth, {
           conversation,
         });
       }

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -133,7 +133,7 @@ async function handler(
             conversationId: conversation.sId,
             title: bodyValidation.right.title,
           });
-          await ConversationResource.markAsRead(auth, {
+          await ConversationResource.markAsReadForAuthUser(auth, {
             conversation,
           });
 
@@ -142,7 +142,7 @@ async function handler(
           }
           return res.status(200).json({ success: true });
         } else if ("read" in bodyValidation.right) {
-          await ConversationResource.markAsRead(auth, {
+          await ConversationResource.markAsReadForAuthUser(auth, {
             conversation,
           });
 

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -133,6 +133,9 @@ async function handler(
             conversationId: conversation.sId,
             title: bodyValidation.right.title,
           });
+          await ConversationResource.markAsRead(auth, {
+            conversation,
+          });
 
           if (result.isErr()) {
             return apiErrorForConversation(req, res, result.error);

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/participants.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/participants.ts
@@ -113,7 +113,7 @@ async function handler(
         workspaceId: owner.id,
         userId: user.id,
         action: "subscribed",
-        unread: false,
+        lastReadAt: new Date(),
         actionRequired: false,
       });
 

--- a/front/scripts/seed/factories/seedConversations.ts
+++ b/front/scripts/seed/factories/seedConversations.ts
@@ -102,7 +102,7 @@ export async function seedConversations(
         conversation: conversation.toJSON(),
         action: "posted",
         user: conversationUser.toJSON(),
-        unread: false,
+        lastReadAt: new Date(),
       });
 
       // Create user message and agent message for each exchange

--- a/front/temporal/agent_loop/activities/common.ts
+++ b/front/temporal/agent_loop/activities/common.ts
@@ -151,11 +151,6 @@ async function processEventForUnreadState(
 ) {
   // If the event is a done event, we want to mark the conversation as unread for all participants.
   if (TERMINAL_AGENT_MESSAGE_EVENT_TYPES.includes(event.type)) {
-    // No excluded user because the message is created by the agent.
-    await ConversationResource.markAsUnreadForOtherParticipants(auth, {
-      conversation,
-    });
-
     // Publish the agent message done event that will be handled on the client-side.
     await publishConversationRelatedEvent({
       conversationId: conversation.sId,


### PR DESCRIPTION
## Description
This PR transitions from using the boolean `unread` flag to computing unread status based on the `lastReadAt` timestamp.

The unread status is now determined by comparing `lastReadAt` of the conversation participant to the `updatedAt` of the conversation.

https://github.com/user-attachments/assets/68edb2fb-bc66-4676-ad7d-991acccc0936


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Manually
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Some conversations might appear wrongfully as unread.
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
