### PR TITLE
free the name agentConfigurationId in agent suggestion table to be used by model ID FK

### DIFF
--- a/front/lib/models/agent/agent_suggestion.ts
+++ b/front/lib/models/agent/agent_suggestion.ts
@@ -15,7 +15,7 @@ export class AgentSuggestionModel extends WorkspaceAwareModel<AgentSuggestionMod
   declare updatedAt: CreationOptional<Date>;
 
   // Reference agent by sId because sId cannot be inferred from id alone
-  declare agentConfigurationId: string;
+  declare agentConfigurationIdTmp: string;
   declare agentConfigurationVersion: number;
 
   declare kind: AgentSuggestionKind;
@@ -38,7 +38,7 @@ AgentSuggestionModel.init(
       allowNull: false,
       defaultValue: DataTypes.NOW,
     },
-    agentConfigurationId: {
+    agentConfigurationIdTmp: {
       type: DataTypes.STRING,
       allowNull: false,
     },
@@ -83,7 +83,7 @@ AgentSuggestionModel.init(
     sequelize: frontSequelize,
     indexes: [
       {
-        fields: ["workspaceId", "agentConfigurationId"],
+        fields: ["workspaceId", "agentConfigurationIdTmp"],
         concurrently: true,
       },
     ],

--- a/front/lib/resources/agent_suggestion_resource.test.ts
+++ b/front/lib/resources/agent_suggestion_resource.test.ts
@@ -41,7 +41,7 @@ describe("AgentSuggestionResource", () => {
       expect(suggestion).toBeDefined();
       expect(suggestion.sId).toMatch(/^asu_/);
       expect(suggestion.workspaceId).toBe(workspace.id);
-      expect(suggestion.agentConfigurationId).toBe(agentConfiguration.sId);
+      expect(suggestion.agentConfigurationIdTmp).toBe(agentConfiguration.sId);
       expect(suggestion.kind).toBe("instructions");
       expect(suggestion.state).toBe("pending");
       expect(suggestion.source).toBe("reinforcement");
@@ -270,7 +270,7 @@ describe("AgentSuggestionResource", () => {
 
       await expect(
         AgentSuggestionResource.makeNew(otherAuthenticator, {
-          agentConfigurationId: agentConfiguration.sId,
+          agentConfigurationIdTmp: agentConfiguration.sId,
           agentConfigurationVersion: 1,
           kind: "instructions",
           suggestion: { oldString: "old", newString: "new" },

--- a/front/lib/resources/agent_suggestion_resource.ts
+++ b/front/lib/resources/agent_suggestion_resource.ts
@@ -114,10 +114,10 @@ export class AgentSuggestionResource extends BaseResource<AgentSuggestionModel> 
 
     // Look up the agent's editors group.
     const editorsGroupIdMap = await this.getEditorsGroupIdByAgentSId(auth, [
-      blob.agentConfigurationId,
+      blob.agentConfigurationIdTmp,
     ]);
     const editorsGroupId =
-      editorsGroupIdMap.get(blob.agentConfigurationId) ?? null;
+      editorsGroupIdMap.get(blob.agentConfigurationIdTmp) ?? null;
 
     // Check permission.
     const canWrite =
@@ -158,7 +158,7 @@ export class AgentSuggestionResource extends BaseResource<AgentSuggestionModel> 
     }
 
     const agentSIds = [
-      ...new Set(suggestions.map((s) => s.agentConfigurationId)),
+      ...new Set(suggestions.map((s) => s.agentConfigurationIdTmp)),
     ];
 
     const editorsGroupIdBySId = await this.getEditorsGroupIdByAgentSId(
@@ -174,14 +174,14 @@ export class AgentSuggestionResource extends BaseResource<AgentSuggestionModel> 
         if (auth.isAdmin()) {
           return true;
         }
-        const groupId = editorsGroupIdBySId.get(s.agentConfigurationId);
+        const groupId = editorsGroupIdBySId.get(s.agentConfigurationIdTmp);
         return (
           groupId !== undefined && groupId !== null && authGroupIds.has(groupId)
         );
       })
       .map((suggestion) => {
         const editorsGroupId =
-          editorsGroupIdBySId.get(suggestion.agentConfigurationId) ?? null;
+          editorsGroupIdBySId.get(suggestion.agentConfigurationIdTmp) ?? null;
         return new this(AgentSuggestionModel, suggestion.get(), editorsGroupId);
       });
   }
@@ -274,7 +274,7 @@ export class AgentSuggestionResource extends BaseResource<AgentSuggestionModel> 
       sId: this.sId,
       createdAt: this.createdAt.getTime(),
       updatedAt: this.updatedAt.getTime(),
-      agentConfigurationId: this.agentConfigurationId,
+      agentConfigurationId: this.agentConfigurationIdTmp,
       agentConfigurationVersion: this.agentConfigurationVersion,
       analysis: this.analysis,
       state: this.state,

--- a/front/migrations/db/migration_489.sql
+++ b/front/migrations/db/migration_489.sql
@@ -1,0 +1,12 @@
+-- Migration created on Jan 23, 2026
+
+ALTER TABLE "agent_suggestions" ADD COLUMN "agentConfigurationIdTmp" VARCHAR(255);
+
+-- Copy data from old column to new column
+UPDATE "agent_suggestions" SET "agentConfigurationIdTmp" = "agentConfigurationId";
+
+-- Make the new column NOT NULL after data is copied
+ALTER TABLE "agent_suggestions" ALTER COLUMN "agentConfigurationIdTmp" SET NOT NULL;
+
+-- Create new index on the new column
+CREATE INDEX CONCURRENTLY "agent_suggestions_workspace_id_agent_configuration_id_tmp" ON "agent_suggestions" ("workspaceId", "agentConfigurationIdTmp");

--- a/front/tests/utils/AgentSuggestionFactory.ts
+++ b/front/tests/utils/AgentSuggestionFactory.ts
@@ -22,7 +22,7 @@ export class AgentSuggestionFactory {
     }> = {}
   ): Promise<AgentSuggestionResource> {
     return AgentSuggestionResource.makeNew(auth, {
-      agentConfigurationId,
+      agentConfigurationIdTmp: agentConfigurationId,
       agentConfigurationVersion: overrides.agentConfigurationVersion ?? 1,
       kind: "instructions",
       suggestion: overrides.suggestion ?? {
@@ -49,7 +49,7 @@ export class AgentSuggestionFactory {
     }> = {}
   ): Promise<AgentSuggestionResource> {
     return AgentSuggestionResource.makeNew(auth, {
-      agentConfigurationId,
+      agentConfigurationIdTmp: agentConfigurationId,
       agentConfigurationVersion: overrides.agentConfigurationVersion ?? 1,
       kind: "tools",
       suggestion: overrides.suggestion ?? {
@@ -77,7 +77,7 @@ export class AgentSuggestionFactory {
     }> = {}
   ): Promise<AgentSuggestionResource> {
     return AgentSuggestionResource.makeNew(auth, {
-      agentConfigurationId,
+      agentConfigurationIdTmp: agentConfigurationId,
       agentConfigurationVersion: overrides.agentConfigurationVersion ?? 1,
       kind: "skills",
       suggestion: overrides.suggestion ?? {
@@ -101,7 +101,7 @@ export class AgentSuggestionFactory {
     }> = {}
   ): Promise<AgentSuggestionResource> {
     return AgentSuggestionResource.makeNew(auth, {
-      agentConfigurationId,
+      agentConfigurationIdTmp: agentConfigurationId,
       agentConfigurationVersion: overrides.agentConfigurationVersion ?? 1,
       kind: "model",
       suggestion: overrides.suggestion ?? {


### PR DESCRIPTION
## Description

Next PR will be able to use the name agentConfigurationId directly for the ModelId 
Doing this in many migrations is required to not break the live model

Next: https://github.com/dust-tt/dust/pull/20459

## Tests

no

## Risk

low

## Deploy Plan

block front
merge
run migration
deploy
unblock