### PR TITLE
[front] feat(subscription): redesign plan selection with custom cards and billing toggle

### DIFF
--- a/front/components/plans/SubscriptionPlanCards.tsx
+++ b/front/components/plans/SubscriptionPlanCards.tsx
@@ -1,0 +1,127 @@
+import { Button, CheckIcon, Icon } from "@dust-tt/sparkle";
+
+import {
+  getPriceWithCurrency,
+  PRO_PLAN_COST_MONTHLY,
+  PRO_PLAN_COST_YEARLY,
+} from "@app/lib/client/subscription";
+import type { BillingPeriod } from "@app/types";
+
+const PRO_FEATURES = [
+  "From 1 user",
+  "Advanced AI models: GPT-5, Claude 4.5, Gemini, Mistral...",
+  "Data connections: Slack, Notion, Google Drive, GitHub...",
+  "Native integrations (Zendesk, Slack, Chrome Extension)",
+  "Email support: Get help when you need it",
+  "Free credits for programmatic usage (API, GSheet, Zapier)",
+];
+
+const ENTERPRISE_FEATURES = [
+  "Everything in Pro, plus:",
+  "Advanced security and controls",
+  "Larger storage and file size limits",
+  "Access to programmatic usage",
+  "Single Sign-On (SSO) (Okta, Entra ID, Jumpcloud)",
+  "User provisioning (SCIM)",
+  "Flexible billing options (SEPA, Credit Card)",
+  "Advanced connections (Salesforce, etc)",
+  "Priority access to new features",
+  "US / EU data hosting",
+  "Priority support",
+  "Dedicated Customer Success",
+];
+
+interface SubscriptionPlanCardsProps {
+  billingPeriod: BillingPeriod;
+  onSubscribe: () => void;
+  isProcessing: boolean;
+}
+
+export function SubscriptionPlanCards({
+  billingPeriod,
+  onSubscribe,
+  isProcessing,
+}: SubscriptionPlanCardsProps) {
+  const price =
+    billingPeriod === "monthly"
+      ? getPriceWithCurrency(PRO_PLAN_COST_MONTHLY)
+      : getPriceWithCurrency(PRO_PLAN_COST_YEARLY);
+
+  return (
+    <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+      {/* Pro card */}
+      <div className="flex flex-col rounded-xl border border-border p-6">
+        <div className="mb-4">
+          <h3 className="text-lg font-semibold text-foreground">Pro</h3>
+          <div className="mt-1 flex items-baseline gap-1">
+            <span className="text-3xl font-bold tabular-nums text-foreground">
+              {price}
+            </span>
+            <span className="text-sm text-muted-foreground">per user</span>
+          </div>
+        </div>
+        <div className="mb-4 border-t border-border" />
+        <ul className="flex flex-1 flex-col gap-3">
+          {PRO_FEATURES.map((feature, index) => (
+            <li key={index} className="flex items-start gap-2">
+              <Icon
+                visual={CheckIcon}
+                size="sm"
+                className="mt-0.5 shrink-0 text-highlight-500 dark:text-highlight-500-night"
+              />
+              <span className="text-sm text-foreground">{feature}</span>
+            </li>
+          ))}
+        </ul>
+        <div className="mt-6">
+          <Button
+            variant="highlight"
+            size="md"
+            label="Subscribe to Pro"
+            onClick={onSubscribe}
+            disabled={isProcessing}
+            className="w-full"
+          />
+        </div>
+      </div>
+
+      {/* Enterprise card */}
+      <div className="flex flex-col rounded-xl border border-border p-6">
+        <div className="mb-4">
+          <h3 className="text-lg font-semibold text-foreground">Enterprise</h3>
+          <div className="mt-1 flex items-baseline gap-1">
+            <span className="text-3xl font-bold tabular-nums text-foreground">
+              Custom
+            </span>
+            <span className="text-sm text-muted-foreground">
+              pay-per-use, 100+ users
+            </span>
+          </div>
+        </div>
+        <div className="mb-4 border-t border-border" />
+        <ul className="flex flex-1 flex-col gap-3">
+          {ENTERPRISE_FEATURES.map((feature, index) => (
+            <li key={index} className="flex items-start gap-2">
+              <Icon
+                visual={CheckIcon}
+                size="sm"
+                className="mt-0.5 shrink-0 text-highlight-500 dark:text-highlight-500-night"
+              />
+              <span className="text-sm text-foreground">{feature}</span>
+            </li>
+          ))}
+        </ul>
+        <div className="mt-6">
+          <Button
+            variant="outline"
+            size="md"
+            label="Contact sales"
+            href="/home/contact"
+            disabled={isProcessing}
+            className="w-full"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/front/components/plans/SubscriptionPlanCards.tsx
+++ b/front/components/plans/SubscriptionPlanCards.tsx
@@ -117,6 +117,7 @@ export function SubscriptionPlanCards({
             size="md"
             label="Contact sales"
             href="/home/contact"
+            target="_blank"
             disabled={isProcessing}
             className="w-full"
           />

--- a/front/components/plans/SubscriptionPlanCards.tsx
+++ b/front/components/plans/SubscriptionPlanCards.tsx
@@ -17,6 +17,7 @@ const PRO_FEATURES = [
 ];
 
 const ENTERPRISE_FEATURES = [
+  "Everything in Pro",
   "Advanced security and controls",
   "Larger storage and file size limits",
   "Access to programmatic usage",
@@ -98,9 +99,6 @@ export function SubscriptionPlanCards({
           </div>
         </div>
         <div className="mb-4 border-t border-border" />
-        <p className="mb-3 text-sm font-semibold text-foreground">
-          Everything in Pro, plus:
-        </p>
         <ul className="flex flex-1 flex-col gap-3">
           {ENTERPRISE_FEATURES.map((feature, index) => (
             <li key={index} className="flex items-start gap-2">

--- a/front/components/plans/SubscriptionPlanCards.tsx
+++ b/front/components/plans/SubscriptionPlanCards.tsx
@@ -9,7 +9,7 @@ import type { BillingPeriod } from "@app/types";
 
 const PRO_FEATURES = [
   "From 1 user",
-  "Advanced AI models: GPT-5, Claude 4.5, Gemini, Mistral...",
+  "Advanced AI models: GPT-5, Claude 4.5, Gemini, Mistral, and more",
   "Data connections: Slack, Notion, Google Drive, GitHub, and more",
   "Native integrations (Zendesk, Slack, Chrome Extension)",
   "Email support: Get help when you need it",

--- a/front/components/plans/SubscriptionPlanCards.tsx
+++ b/front/components/plans/SubscriptionPlanCards.tsx
@@ -10,14 +10,13 @@ import type { BillingPeriod } from "@app/types";
 const PRO_FEATURES = [
   "From 1 user",
   "Advanced AI models: GPT-5, Claude 4.5, Gemini, Mistral...",
-  "Data connections: Slack, Notion, Google Drive, GitHub...",
+  "Data connections: Slack, Notion, Google Drive, GitHub, and more",
   "Native integrations (Zendesk, Slack, Chrome Extension)",
   "Email support: Get help when you need it",
   "Free credits for programmatic usage (API, GSheet, Zapier)",
 ];
 
 const ENTERPRISE_FEATURES = [
-  "Everything in Pro, plus:",
   "Advanced security and controls",
   "Larger storage and file size limits",
   "Access to programmatic usage",
@@ -50,10 +49,10 @@ export function SubscriptionPlanCards({
   return (
     <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
       {/* Pro card */}
-      <div className="flex flex-col rounded-xl border border-border p-6">
+      <div className="flex flex-col rounded-[20px] border border-border p-5">
         <div className="mb-4">
-          <h3 className="text-lg font-semibold text-foreground">Pro</h3>
-          <div className="mt-1 flex items-baseline gap-1">
+          <h3 className="text-lg font-medium text-foreground">Pro</h3>
+          <div className="mt-1 flex items-baseline gap-2">
             <span className="text-3xl font-bold tabular-nums text-foreground">
               {price}
             </span>
@@ -86,19 +85,22 @@ export function SubscriptionPlanCards({
       </div>
 
       {/* Enterprise card */}
-      <div className="flex flex-col rounded-xl border border-border p-6">
+      <div className="flex flex-col rounded-[20px] border border-border p-5">
         <div className="mb-4">
-          <h3 className="text-lg font-semibold text-foreground">Enterprise</h3>
-          <div className="mt-1 flex items-baseline gap-1">
+          <h3 className="text-lg font-medium text-foreground">Enterprise</h3>
+          <div className="mt-1 flex items-baseline gap-2">
             <span className="text-3xl font-bold tabular-nums text-foreground">
               Custom
             </span>
             <span className="text-sm text-muted-foreground">
-              pay-per-use, 100+ users
+              pay-per-use, from 100+ users
             </span>
           </div>
         </div>
         <div className="mb-4 border-t border-border" />
+        <p className="mb-3 text-sm font-semibold text-foreground">
+          Everything in Pro, plus:
+        </p>
         <ul className="flex flex-1 flex-col gap-3">
           {ENTERPRISE_FEATURES.map((feature, index) => (
             <li key={index} className="flex items-start gap-2">

--- a/front/pages/w/[wId]/subscription/index.tsx
+++ b/front/pages/w/[wId]/subscription/index.tsx
@@ -507,7 +507,11 @@ export default function Subscription({
                 <ButtonsSwitchList
                   defaultValue={billingPeriod}
                   size="xs"
-                  onValueChange={(v) => setBillingPeriod(v as BillingPeriod)}
+                  onValueChange={(v) => {
+                    if (v === "monthly" || v === "yearly") {
+                      setBillingPeriod(v);
+                    }
+                  }}
                 >
                   <ButtonsSwitch value="monthly" label="Monthly billing" />
                   <ButtonsSwitch value="yearly" label="Yearly billing" />

--- a/front/pages/w/[wId]/subscription/index.tsx
+++ b/front/pages/w/[wId]/subscription/index.tsx
@@ -1,5 +1,7 @@
 import {
   Button,
+  ButtonsSwitch,
+  ButtonsSwitchList,
   CardIcon,
   Chip,
   ContentMessage,
@@ -21,7 +23,7 @@ import { useRouter } from "next/router";
 import React, { useEffect, useState } from "react";
 
 import { subNavigationAdmin } from "@app/components/navigation/config";
-import { PricePlans } from "@app/components/plans/PlansTables";
+import { SubscriptionPlanCards } from "@app/components/plans/SubscriptionPlanCards";
 import { AppCenteredLayout } from "@app/components/sparkle/AppCenteredLayout";
 import AppRootLayout from "@app/components/sparkle/AppRootLayout";
 import { useSendNotification } from "@app/hooks/useNotification";
@@ -43,6 +45,7 @@ import {
 import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 import type { PatchSubscriptionRequestBody } from "@app/pages/api/w/[wId]/subscriptions";
 import type {
+  BillingPeriod,
   SubscriptionPerSeatPricing,
   SubscriptionType,
   WorkspaceType,
@@ -78,6 +81,8 @@ export default function Subscription({
   const [isWebhookProcessing, setIsWebhookProcessing] =
     React.useState<boolean>(false);
 
+  const [billingPeriod, setBillingPeriod] =
+    useState<BillingPeriod>("monthly");
   const [showSkipFreeTrialDialog, setShowSkipFreeTrialDialog] = useState(false);
   const [showCancelFreeTrialDialog, setShowCancelFreeTrialDialog] =
     useState(false);
@@ -130,7 +135,7 @@ export default function Subscription({
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          billingPeriod: "monthly",
+          billingPeriod,
         }),
       });
 
@@ -269,8 +274,6 @@ export default function Subscription({
     isSubscribingPlan || isGoingToStripePortal || isUpgradingToBusiness;
 
   const chipColor = !isUpgraded(plan) ? "green" : "blue";
-
-  const onClickProPlan = async () => handleSubscribePlan();
 
   const planLabel =
     trialDaysRemaining === null
@@ -496,23 +499,37 @@ export default function Subscription({
             </Page.Vertical>
           )}
           {displayPricingTable && (
-            <>
-              <div className="pt-2">
-                <Page.H variant="h5">Manage my plan</Page.H>
-                <div className="h-full w-full pt-2">
-                  <PricePlans
-                    owner={owner}
-                    plan={plan}
-                    onClickProPlan={onClickProPlan}
-                    isProcessing={isProcessing}
-                    display="subscribe"
-                  />
+            <div className="pt-2">
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <Page.H variant="h5">Choose a plan</Page.H>
+                  <Page.P>Pick a plan that best suits your team.</Page.P>
                 </div>
+                <ButtonsSwitchList
+                  defaultValue={billingPeriod}
+                  size="xs"
+                  onValueChange={(v) =>
+                    setBillingPeriod(v as BillingPeriod)
+                  }
+                >
+                  <ButtonsSwitch
+                    value="monthly"
+                    label="Monthly billing"
+                  />
+                  <ButtonsSwitch
+                    value="yearly"
+                    label="Yearly billing"
+                  />
+                </ButtonsSwitchList>
               </div>
-              <Link href="/terms" target="_blank" className="text-sm">
-                Terms of use apply to all plans.
-              </Link>
-            </>
+              <div className="pt-4">
+                <SubscriptionPlanCards
+                  billingPeriod={billingPeriod}
+                  onSubscribe={handleSubscribePlan}
+                  isProcessing={isProcessing}
+                />
+              </div>
+            </div>
           )}
         </Page.Vertical>
       </Page.Vertical>

--- a/front/pages/w/[wId]/subscription/index.tsx
+++ b/front/pages/w/[wId]/subscription/index.tsx
@@ -81,8 +81,7 @@ export default function Subscription({
   const [isWebhookProcessing, setIsWebhookProcessing] =
     React.useState<boolean>(false);
 
-  const [billingPeriod, setBillingPeriod] =
-    useState<BillingPeriod>("monthly");
+  const [billingPeriod, setBillingPeriod] = useState<BillingPeriod>("monthly");
   const [showSkipFreeTrialDialog, setShowSkipFreeTrialDialog] = useState(false);
   const [showCancelFreeTrialDialog, setShowCancelFreeTrialDialog] =
     useState(false);
@@ -508,18 +507,10 @@ export default function Subscription({
                 <ButtonsSwitchList
                   defaultValue={billingPeriod}
                   size="xs"
-                  onValueChange={(v) =>
-                    setBillingPeriod(v as BillingPeriod)
-                  }
+                  onValueChange={(v) => setBillingPeriod(v as BillingPeriod)}
                 >
-                  <ButtonsSwitch
-                    value="monthly"
-                    label="Monthly billing"
-                  />
-                  <ButtonsSwitch
-                    value="yearly"
-                    label="Yearly billing"
-                  />
+                  <ButtonsSwitch value="monthly" label="Monthly billing" />
+                  <ButtonsSwitch value="yearly" label="Yearly billing" />
                 </ButtonsSwitchList>
               </div>
               <div className="pt-4">


### PR DESCRIPTION
## Description

Redesign the "Choose a plan" section on the subscription page (`/w/[wId]/subscription`) for unsubscribed users:

- Replace the Sparkle `PriceTable`-based layout with custom Pro and Enterprise plan cards
- Add a monthly/yearly billing toggle that drives the subscription API call
- Pro card: dynamic pricing based on billing period, feature list, "Subscribe to Pro" CTA
- Enterprise card: "Custom pay-per-use" pricing, feature list, "Contact sales" CTA linking to `/home/contact`
- Responsive grid layout (stacked on mobile, side by side on desktop)
- The existing billing section for already-subscribed users is unchanged


<img width="847" height="861" alt="Screenshot 2026-01-23 at 12 58 13" src="https://github.com/user-attachments/assets/73f391b2-8527-4304-96f5-800542da5a5c" />



## Tests

- TypeScript type-check passes (`npx tsc --noEmit`)
- ESLint passes with no new warnings
- Manual verification on the subscription page

## Risk

Low. Only affects the plan selection UI for unsubscribed workspaces. The existing `PricePlans` component is untouched (still used by the landing page). The billing toggle correctly passes the selected period to the subscription API.

## Deploy Plan

Standard front deploy. No migrations or environment variable changes needed.