### PR TITLE
[Front/OAuth] Return Result type from getRelatedCredential

### DIFF
--- a/front/lib/api/oauth.ts
+++ b/front/lib/api/oauth.ts
@@ -50,7 +50,8 @@ export type OAuthError = {
   code:
     | "connection_creation_failed"
     | "connection_not_implemented"
-    | "connection_finalization_failed";
+    | "connection_finalization_failed"
+    | "credential_retrieval_failed";
   message: string;
   oAuthAPIError?: OAuthAPIError;
 };
@@ -121,12 +122,25 @@ export async function createConnectionAndGetSetupUrl(
   const userId = auth.getNonNullableUser().sId;
 
   if (providerStrategy.getRelatedCredential) {
-    const credentials = await providerStrategy.getRelatedCredential!(auth, {
-      extraConfig,
-      workspaceId,
-      userId,
-      useCase,
-    });
+    const credentialResult = await providerStrategy.getRelatedCredential!(
+      auth,
+      {
+        extraConfig,
+        workspaceId,
+        userId,
+        useCase,
+      }
+    );
+
+    // If getRelatedCredential returned an error, propagate it
+    if (credentialResult && credentialResult.isErr()) {
+      return new Err(credentialResult.error);
+    }
+
+    // credentialResult is either undefined or Ok at this point
+    const credentials = credentialResult?.isOk()
+      ? credentialResult.value
+      : undefined;
     if (credentials) {
       if (!providerStrategy.getUpdatedExtraConfig) {
         // You probably need to clean up the extra config to remove any sensitive data (such as client_secret).

--- a/front/lib/api/oauth/providers/base_oauth_stragegy_provider.ts
+++ b/front/lib/api/oauth/providers/base_oauth_stragegy_provider.ts
@@ -1,5 +1,6 @@
 import type { ParsedUrlQuery } from "querystring";
 
+import type { OAuthError } from "@app/lib/api/oauth";
 import type { Authenticator } from "@app/lib/auth";
 import type { ExtraConfigType } from "@app/pages/w/[wId]/oauth/[provider]/setup";
 import type { Result } from "@app/types";
@@ -42,6 +43,10 @@ export interface BaseOAuthStrategyProvider {
   ) => boolean;
 
   // If the provider has a method for getting the related credential and/or if we need to update the config.
+  // Returns:
+  // - Ok(credential) if credentials were successfully retrieved
+  // - Err(error) if credentials retrieval failed (e.g., token revoked)
+  // - undefined if no related credential is needed for this provider/useCase
   getRelatedCredential?: (
     auth: Authenticator,
     {
@@ -55,7 +60,7 @@ export interface BaseOAuthStrategyProvider {
       userId: string;
       useCase: OAuthUseCase;
     }
-  ) => Promise<RelatedCredential | undefined>;
+  ) => Promise<Result<RelatedCredential, OAuthError> | undefined>;
 
   getUpdatedExtraConfig?: (
     auth: Authenticator,

--- a/front/lib/api/oauth/providers/gmail.ts
+++ b/front/lib/api/oauth/providers/gmail.ts
@@ -2,6 +2,7 @@ import type { ParsedUrlQuery } from "querystring";
 import querystring from "querystring";
 
 import config from "@app/lib/api/config";
+import type { OAuthError } from "@app/lib/api/oauth";
 import type {
   BaseOAuthStrategyProvider,
   RelatedCredential,
@@ -14,7 +15,8 @@ import type { Authenticator } from "@app/lib/auth";
 import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
 import logger from "@app/logger/logger";
 import type { ExtraConfigType } from "@app/pages/w/[wId]/oauth/[provider]/setup";
-import { OAuthAPI } from "@app/types";
+import type { Result } from "@app/types";
+import { Err, OAuthAPI, Ok } from "@app/types";
 import type { OAuthConnectionType, OAuthUseCase } from "@app/types/oauth/lib";
 
 export class GmailOAuthProvider implements BaseOAuthStrategyProvider {
@@ -78,7 +80,7 @@ export class GmailOAuthProvider implements BaseOAuthStrategyProvider {
       userId: string;
       useCase: OAuthUseCase;
     }
-  ): Promise<RelatedCredential> {
+  ): Promise<Result<RelatedCredential, OAuthError>> {
     if (useCase === "personal_actions") {
       // For personal actions we reuse the existing connection credential id from the existing
       // workspace connection (setup by admin) if we have it, otherwise we fallback to assuming
@@ -93,10 +95,12 @@ export class GmailOAuthProvider implements BaseOAuthStrategyProvider {
           });
 
         if (mcpServerConnectionRes.isErr()) {
-          throw new Error(
-            "Failed to find MCP server connection: " +
-              mcpServerConnectionRes.error.message
-          );
+          return new Err({
+            code: "credential_retrieval_failed",
+            message:
+              "Failed to find MCP server connection: " +
+              mcpServerConnectionRes.error.message,
+          });
         }
 
         const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
@@ -104,31 +108,35 @@ export class GmailOAuthProvider implements BaseOAuthStrategyProvider {
           connectionId: mcpServerConnectionRes.value.connectionId,
         });
         if (connectionRes.isErr()) {
-          throw new Error(
-            "Failed to get connection metadata: " + connectionRes.error.message
-          );
+          return new Err({
+            code: "credential_retrieval_failed",
+            message:
+              "Failed to get connection metadata: " +
+              connectionRes.error.message,
+            oAuthAPIError: connectionRes.error,
+          });
         }
         const connection = connectionRes.value.connection;
         const connectionId = connection.connection_id;
 
-        return {
+        return new Ok({
           content: {
             from_connection_id: connectionId,
           },
           metadata: { workspace_id: workspaceId, user_id: userId },
-        };
+        });
       }
     }
 
     const { client_secret } = extraConfig;
 
-    return {
+    return new Ok({
       content: {
         client_secret: client_secret,
         client_id: extraConfig.client_id,
       },
       metadata: { workspace_id: workspaceId, user_id: userId },
-    };
+    });
   }
 
   async getUpdatedExtraConfig(

--- a/front/lib/api/oauth/providers/mcp.ts
+++ b/front/lib/api/oauth/providers/mcp.ts
@@ -2,6 +2,7 @@ import type { ParsedUrlQuery } from "querystring";
 import { z } from "zod";
 
 import config from "@app/lib/api/config";
+import type { OAuthError } from "@app/lib/api/oauth";
 import type {
   BaseOAuthStrategyProvider,
   RelatedCredential,
@@ -15,7 +16,8 @@ import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_conne
 import { getPKCEConfig } from "@app/lib/utils/pkce";
 import logger from "@app/logger/logger";
 import type { ExtraConfigType } from "@app/pages/w/[wId]/oauth/[provider]/setup";
-import { OAuthAPI } from "@app/types";
+import type { Result } from "@app/types";
+import { Err, OAuthAPI, Ok } from "@app/types";
 import type {
   OAuthConnectionType,
   OAuthProvider,
@@ -135,7 +137,7 @@ export class MCPOAuthProvider implements BaseOAuthStrategyProvider {
       userId: string;
       useCase: OAuthUseCase;
     }
-  ): Promise<RelatedCredential> {
+  ): Promise<Result<RelatedCredential, OAuthError>> {
     if (useCase === "personal_actions") {
       // For personal actions we reuse the existing connection credential id from the existing
       // workspace connection (setup by admin) if we have it.
@@ -149,10 +151,12 @@ export class MCPOAuthProvider implements BaseOAuthStrategyProvider {
           });
 
         if (mcpServerConnectionRes.isErr()) {
-          throw new Error(
-            "Failed to find MCP server connection: " +
-              mcpServerConnectionRes.error.message
-          );
+          return new Err({
+            code: "credential_retrieval_failed",
+            message:
+              "Failed to find MCP server connection: " +
+              mcpServerConnectionRes.error.message,
+          });
         }
 
         const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
@@ -160,19 +164,23 @@ export class MCPOAuthProvider implements BaseOAuthStrategyProvider {
           connectionId: mcpServerConnectionRes.value.connectionId,
         });
         if (connectionRes.isErr()) {
-          throw new Error(
-            "Failed to get connection metadata: " + connectionRes.error.message
-          );
+          return new Err({
+            code: "credential_retrieval_failed",
+            message:
+              "Failed to get connection metadata: " +
+              connectionRes.error.message,
+            oAuthAPIError: connectionRes.error,
+          });
         }
         const connection = connectionRes.value.connection;
         const connectionId = connection.connection_id;
 
-        return {
+        return new Ok({
           content: {
             from_connection_id: connectionId,
           },
           metadata: { workspace_id: workspaceId, user_id: userId },
-        };
+        });
       }
     } else if (useCase === "platform_actions") {
       const { client_secret } = extraConfig;
@@ -186,12 +194,15 @@ export class MCPOAuthProvider implements BaseOAuthStrategyProvider {
         content.client_secret = client_secret;
       }
 
-      return {
+      return new Ok({
         content,
         metadata: { workspace_id: workspaceId, user_id: userId },
-      };
+      });
     }
-    throw new Error("MCP oauth provider does not support use case: " + useCase);
+    return new Err({
+      code: "credential_retrieval_failed",
+      message: "MCP oauth provider does not support use case: " + useCase,
+    });
   }
 
   async getUpdatedExtraConfig(

--- a/front/lib/api/oauth/providers/microsoft.ts
+++ b/front/lib/api/oauth/providers/microsoft.ts
@@ -2,6 +2,7 @@ import type { ParsedUrlQuery } from "querystring";
 import querystring from "querystring";
 
 import config from "@app/lib/api/config";
+import type { OAuthError } from "@app/lib/api/oauth";
 import type {
   BaseOAuthStrategyProvider,
   RelatedCredential,
@@ -12,7 +13,8 @@ import {
 } from "@app/lib/api/oauth/utils";
 import type { Authenticator } from "@app/lib/auth";
 import type { ExtraConfigType } from "@app/pages/w/[wId]/oauth/[provider]/setup";
-import { isString } from "@app/types";
+import type { Result } from "@app/types";
+import { isString, Ok } from "@app/types";
 import type { OAuthConnectionType, OAuthUseCase } from "@app/types/oauth/lib";
 
 export class MicrosoftOAuthProvider implements BaseOAuthStrategyProvider {
@@ -77,18 +79,18 @@ export class MicrosoftOAuthProvider implements BaseOAuthStrategyProvider {
       workspaceId: string;
       userId: string;
     }
-  ): Promise<RelatedCredential | undefined> {
+  ): Promise<Result<RelatedCredential, OAuthError> | undefined> {
     const { client_id, client_secret } = extraConfig;
     if (!client_id || !client_secret) {
       return undefined;
     }
-    return {
+    return new Ok({
       content: {
         client_id,
         client_secret,
       },
       metadata: { workspace_id: workspaceId, user_id: userId },
-    };
+    });
   }
 
   async getUpdatedExtraConfig(

--- a/front/lib/api/oauth/providers/salesforce.ts
+++ b/front/lib/api/oauth/providers/salesforce.ts
@@ -1,6 +1,7 @@
 import type { ParsedUrlQuery } from "querystring";
 
 import config from "@app/lib/api/config";
+import type { OAuthError } from "@app/lib/api/oauth";
 import type {
   BaseOAuthStrategyProvider,
   RelatedCredential,
@@ -14,7 +15,8 @@ import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_conne
 import { getPKCEConfig } from "@app/lib/utils/pkce";
 import logger from "@app/logger/logger";
 import type { ExtraConfigType } from "@app/pages/w/[wId]/oauth/[provider]/setup";
-import { isValidSalesforceDomain, OAuthAPI } from "@app/types";
+import type { Result } from "@app/types";
+import { Err, isValidSalesforceDomain, OAuthAPI, Ok } from "@app/types";
 import type { OAuthConnectionType, OAuthUseCase } from "@app/types/oauth/lib";
 
 export class SalesforceOAuthProvider implements BaseOAuthStrategyProvider {
@@ -86,7 +88,7 @@ export class SalesforceOAuthProvider implements BaseOAuthStrategyProvider {
       userId: string;
       useCase: OAuthUseCase;
     }
-  ): Promise<RelatedCredential> {
+  ): Promise<Result<RelatedCredential, OAuthError>> {
     if (useCase === "personal_actions") {
       // For personal actions we reuse the existing connection credential id from the existing
       // workspace connection (setup by admin) if we have it, otherwise we fallback to assuming
@@ -101,10 +103,12 @@ export class SalesforceOAuthProvider implements BaseOAuthStrategyProvider {
           });
 
         if (mcpServerConnectionRes.isErr()) {
-          throw new Error(
-            "Failed to find MCP server connection: " +
-              mcpServerConnectionRes.error.message
-          );
+          return new Err({
+            code: "credential_retrieval_failed",
+            message:
+              "Failed to find MCP server connection: " +
+              mcpServerConnectionRes.error.message,
+          });
         }
 
         const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
@@ -112,31 +116,35 @@ export class SalesforceOAuthProvider implements BaseOAuthStrategyProvider {
           connectionId: mcpServerConnectionRes.value.connectionId,
         });
         if (connectionRes.isErr()) {
-          throw new Error(
-            "Failed to get connection metadata: " + connectionRes.error.message
-          );
+          return new Err({
+            code: "credential_retrieval_failed",
+            message:
+              "Failed to get connection metadata: " +
+              connectionRes.error.message,
+            oAuthAPIError: connectionRes.error,
+          });
         }
         const connection = connectionRes.value.connection;
         const connectionId = connection.connection_id;
 
-        return {
+        return new Ok({
           content: {
             from_connection_id: connectionId,
           },
           metadata: { workspace_id: workspaceId, user_id: userId },
-        };
+        });
       }
     }
 
     const { client_secret } = extraConfig;
 
-    return {
+    return new Ok({
       content: {
         client_secret,
         client_id: extraConfig.client_id,
       },
       metadata: { workspace_id: workspaceId, user_id: userId },
-    };
+    });
   }
 
   async getUpdatedExtraConfig(

--- a/front/lib/api/oauth/providers/slack.ts
+++ b/front/lib/api/oauth/providers/slack.ts
@@ -2,6 +2,7 @@ import assert from "assert";
 import type { ParsedUrlQuery } from "querystring";
 
 import config from "@app/lib/api/config";
+import type { OAuthError } from "@app/lib/api/oauth";
 import type {
   BaseOAuthStrategyProvider,
   RelatedCredential,
@@ -13,6 +14,7 @@ import {
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import type { ExtraConfigType } from "@app/pages/w/[wId]/oauth/[provider]/setup";
+import type { Result } from "@app/types";
 import { assertNever, Err, Ok } from "@app/types";
 import type { OAuthConnectionType, OAuthUseCase } from "@app/types/oauth/lib";
 
@@ -150,7 +152,7 @@ export class SlackOAuthProvider implements BaseOAuthStrategyProvider {
       userId: string;
       useCase: OAuthUseCase;
     }
-  ): Promise<RelatedCredential | undefined> {
+  ): Promise<Result<RelatedCredential, OAuthError> | undefined> {
     if (useCase !== "connection") {
       return undefined;
     }
@@ -168,13 +170,13 @@ export class SlackOAuthProvider implements BaseOAuthStrategyProvider {
 
     // Note: we don't store the signing secret as it's not needed for OAuth connections.
     // It is only used for webhook validation
-    return {
+    return new Ok({
       content: {
         client_id,
         client_secret,
       },
       metadata: { workspace_id: workspaceId, user_id: userId },
-    };
+    });
   }
 
   async getUpdatedExtraConfig(

--- a/front/lib/api/oauth/providers/vanta.ts
+++ b/front/lib/api/oauth/providers/vanta.ts
@@ -1,5 +1,6 @@
 import type { ParsedUrlQuery } from "querystring";
 
+import type { OAuthError } from "@app/lib/api/oauth";
 import type {
   BaseOAuthStrategyProvider,
   RelatedCredential,
@@ -9,6 +10,8 @@ import {
   getStringFromQuery,
 } from "@app/lib/api/oauth/utils";
 import type { ExtraConfigType } from "@app/pages/w/[wId]/oauth/[provider]/setup";
+import type { Result } from "@app/types";
+import { Ok } from "@app/types";
 import type { OAuthConnectionType, OAuthUseCase } from "@app/types/oauth/lib";
 
 export class VantaOAuthProvider implements BaseOAuthStrategyProvider {
@@ -43,14 +46,14 @@ export class VantaOAuthProvider implements BaseOAuthStrategyProvider {
       userId: string;
       useCase: OAuthUseCase;
     }
-  ): Promise<RelatedCredential> {
-    return {
+  ): Promise<Result<RelatedCredential, OAuthError>> {
+    return new Ok({
       content: {
         client_id: extraConfig.client_id as string,
         client_secret: extraConfig.client_secret as string,
       },
       metadata: { workspace_id: workspaceId, user_id: userId },
-    };
+    });
   }
 
   async getUpdatedExtraConfig(): Promise<ExtraConfigType> {


### PR DESCRIPTION
## Description
Fixes unhandled `getServerSideProps` errors when OAuth tokens are revoked by returning `Result` type instead of throwing.

Changes `getRelatedCredential` interface to return `Result<RelatedCredential, OAuthError> | undefined` and updates all OAuth providers.

## Risks
Blast radius: OAuth setup flow for MCP servers (Gmail, Salesforce, Databricks, etc.)
Risk: low (error handling improvement, no functional changes)

## Deploy Plan
- deploy front