### PR TITLE
[front] fix(snowflake): allow trailing semicolons in queries

### DIFF
--- a/front/lib/api/actions/servers/snowflake/client.ts
+++ b/front/lib/api/actions/servers/snowflake/client.ts
@@ -409,7 +409,7 @@ export class SnowflakeClient {
     // Strip trailing semicolons before wrapping. Multi-statement injection is
     // already prevented by the SDK (MULTI_STATEMENT_COUNT defaults to 1) and by
     // the EXPLAIN/LIMIT wrappers which would produce invalid SQL with embedded semicolons.
-    sql = sql.replace(/;\s*$/, "");
+    const sanitizedSql = sql.replace(/;\s*$/, "");
 
     const connRes = await this.connect();
     if (connRes.isErr()) {
@@ -451,7 +451,7 @@ export class SnowflakeClient {
       // This checks what the query actually does, not what it looks like.
       const validationResult = await this.validateReadOnlyWithExplain(
         conn,
-        sql
+        sanitizedSql
       );
 
       if (validationResult.isErr()) {
@@ -459,7 +459,7 @@ export class SnowflakeClient {
       }
 
       // Wrap query to enforce row limit
-      const wrappedSql = `SELECT * FROM (${sql.trim()}) AS _limited_query LIMIT ${maxRows}`;
+      const wrappedSql = `SELECT * FROM (${sanitizedSql.trim()}) AS _limited_query LIMIT ${maxRows}`;
 
       return await this.executeQuery(conn, wrappedSql);
     } finally {

--- a/front/lib/api/actions/servers/snowflake/client.ts
+++ b/front/lib/api/actions/servers/snowflake/client.ts
@@ -406,15 +406,10 @@ export class SnowflakeClient {
     warehouse?: string,
     maxRows: number = 1000
   ): Promise<Result<SnowflakeQueryResult, Error>> {
-    // Check for semicolons which could indicate multi-statement injection.
-    // EXPLAIN might only analyze the first statement, so we block this upfront.
-    if (sql.includes(";")) {
-      return new Err(
-        new Error(
-          "Multiple statements are not allowed. Please submit a single query."
-        )
-      );
-    }
+    // Strip trailing semicolons before wrapping. Multi-statement injection is
+    // already prevented by the SDK (MULTI_STATEMENT_COUNT defaults to 1) and by
+    // the EXPLAIN/LIMIT wrappers which would produce invalid SQL with embedded semicolons.
+    sql = sql.replace(/;\s*$/, "");
 
     const connRes = await this.connect();
     if (connRes.isErr()) {


### PR DESCRIPTION
## Description

The Snowflake MCP server was rejecting valid single-statement queries that end with a semicolon (e.g., `SELECT * FROM table LIMIT 10;`) with the error "Multiple statements are not allowed."

The strict `sql.includes(";")` check was overly broad. It's also redundant since multi-statement injection is already prevented by:
1. The Snowflake SDK's `MULTI_STATEMENT_COUNT` defaulting to `1` (server-side rejection)
2. The `EXPLAIN USING TABULAR` wrapper producing invalid SQL with embedded semicolons
3. The `SELECT * FROM (...) LIMIT` wrapper producing invalid SQL with embedded semicolons

Replaced the check with a simple trailing semicolon strip, which is needed for the subquery wrapping to produce valid SQL.

## Tests

Verified typecheck passes. The fix is straightforward — removing an overly strict check that has three layers of redundant protection behind it.

## Risk

Low. This is strictly less restrictive than before. Multi-statement execution is still blocked by the SDK and the query wrappers.

## Deploy Plan

Standard deploy, no special considerations.