### PR TITLE
Fix progress chip

### DIFF
--- a/connectors/src/api/get_connector.ts
+++ b/connectors/src/api/get_connector.ts
@@ -70,7 +70,10 @@ const _getConnector = async (
     }
   }
 
-  return res.status(200).json(connector.toJSON());
+  return res.status(200).json({
+    ...connector.toJSON(),
+    firstSyncProgress,
+  });
 };
 
 export const getConnectorAPIHandler = withLogging(_getConnector);

--- a/front/components/data_source/DataSourceSyncChip.tsx
+++ b/front/components/data_source/DataSourceSyncChip.tsx
@@ -128,19 +128,13 @@ export default function ConnectorSyncingChip({
       (connector.lastSyncFinishTime === undefined ||
         connector.lastSyncStartTime > connector.lastSyncFinishTime);
 
-    // Show progress during sync if available (full syncs update firstSyncProgress,
-    // incremental syncs don't, so this effectively shows progress for full syncs)
-    if (isSyncInProgress && connector.firstSyncProgress) {
-      return (
-        <Chip color="info" isBusy>
-          Synchronizing ({connector.firstSyncProgress})
-        </Chip>
-      );
-    } else if (isSyncInProgress && !connector.firstSuccessfulSyncTime) {
-      // First sync in progress but no progress info yet
+    if (isSyncInProgress) {
       return (
         <Chip color="info" isBusy>
           Synchronizing
+          {connector.firstSyncProgress
+            ? ` (${connector.firstSyncProgress})`
+            : null}
         </Chip>
       );
     } else if (connector.lastSyncSuccessfulTime) {


### PR DESCRIPTION
## Description

Fix progress chip to show information when we're doing a full sync, not only the first one.

<img width="1037" height="208" alt="Screenshot 2026-01-23 at 14 19 37" src="https://github.com/user-attachments/assets/5365593c-aec4-4089-bc40-1c06e7d80e0c" />

firstSyncProgress was lost for notion and github (computed but never returned ?) 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

low, status chip only

## Deploy Plan

deploy front + connectors
