### PR TITLE
[Slack] Parallelize channel migration to avoid timeout

### DIFF
--- a/connectors/src/connectors/slack/lib/channels.ts
+++ b/connectors/src/connectors/slack/lib/channels.ts
@@ -33,7 +33,7 @@ import {
   withSlackErrorHandling,
 } from "./slack_client";
 
-const MIGRATE_CHANNELS_CONCURRENCY = 8;
+const MIGRATE_CHANNELS_CONCURRENCY = 4;
 
 export type SlackChannelType = {
   id: number;

--- a/connectors/src/connectors/slack/lib/channels.ts
+++ b/connectors/src/connectors/slack/lib/channels.ts
@@ -21,6 +21,7 @@ import { SlackConfigurationResource } from "@connectors/resources/slack_configur
 import type { ConnectorPermission, ModelId } from "@connectors/types";
 import {
   cacheWithRedis,
+  concurrentExecutor,
   INTERNAL_MIME_TYPES,
   normalizeError,
   withRetries,
@@ -31,6 +32,8 @@ import {
   reportSlackUsage,
   withSlackErrorHandling,
 } from "./slack_client";
+
+const MIGRATE_CHANNELS_CONCURRENCY = 8;
 
 export type SlackChannelType = {
   id: number;
@@ -592,38 +595,38 @@ export async function migrateChannelsFromLegacyBotToNewBot(
     "Found channels to migrate"
   );
 
-  for (const channel of publicChannels) {
-    if (!channel.id) {
-      continue;
-    }
+  const channelsWithId = publicChannels.flatMap((c) =>
+    c.id ? [{ ...c, id: c.id }] : []
+  );
 
-    await heartbeat();
+  await concurrentExecutor(
+    channelsWithId,
+    async (channel) => {
+      const { id: channelId } = channel;
 
-    childLogger.info(
-      {
-        channelId: channel.id,
-      },
-      "Migrating channel"
-    );
+      childLogger.info({ channelId }, "Migrating channel");
 
-    const { id: channelId } = channel;
-
-    // Join the new bot to the channel. Wrap with retries to handle rate limits.
-    const joinRes = await joinChannelWithRetries(
-      slackBotConnector.id,
-      channelId
-    );
-
-    if (joinRes.isErr()) {
-      childLogger.error(
-        { error: joinRes.error, channelId: channel.id },
-        "Could not join channel"
+      // Join the new bot to the channel. Wrap with retries to handle rate limits.
+      const joinRes = await joinChannelWithRetries(
+        slackBotConnector.id,
+        channelId
       );
 
-      // Ignore the error and continue.
-      continue;
+      if (joinRes.isErr()) {
+        childLogger.error(
+          { error: joinRes.error, channelId },
+          "Could not join channel"
+        );
+        // Ignore the error and continue.
+      }
+    },
+    {
+      concurrency: MIGRATE_CHANNELS_CONCURRENCY,
+      onBatchComplete: async () => {
+        await heartbeat();
+      },
     }
-  }
+  );
 
   return new Ok({ migratedChannelsCount: channels.length });
 }


### PR DESCRIPTION
## Description

Fixes startToClose timeout issues on `migrateChannelsFromLegacyBotToNewBotWorkflow`.

Context: [Datadog logs showing 400 channels with retries exceeding timeout](https://app.datadoghq.eu/logs?query=%28%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40attempt%3A%3E19%20%40dd.service%3Aconnectors-worker%20region%3Aeurope-west1%20%40level%3Aerror%20%40workflowId%3A%2A%29%20AND%20%40workflowId%3Aslack-migrateChannelsFromLegacyBotToNewBot-274877910961-274877910813)

Channels were being synced sequentially, and each channel join retries 3 times with 10s delays. With a large number of channels and many retries, the activity can exceed the 60-minute start-to-close timeout.

Changed to use `concurrentExecutor` with concurrency of 8 when joining new channels.

## Risks

Blast radius: Slack channel migration from legacy to new bot
Risk: low

## Deploy Plan

- deploy connectors