### PR TITLE
feat(ppul): per-api key cap limit logic

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -19,6 +19,7 @@ import {
 import { ensureConversationTitle } from "@app/lib/api/assistant/conversation/title";
 import {
   makeAgentMentionsRateLimitKeyForWorkspace,
+  makeKeyCapRateLimitKey,
   makeMessageRateLimitKeyForWorkspace,
   makeProgrammaticUsageRateLimitKeyForWorkspace,
 } from "@app/lib/api/assistant/rate_limits";
@@ -27,6 +28,7 @@ import {
   publishMessageEventsOnMessagePostOrEdit,
 } from "@app/lib/api/assistant/streaming/events";
 import { maybeUpsertFileAttachment } from "@app/lib/api/files/attachments";
+import { getRemainingKeyCapMicroUsd } from "@app/lib/api/key_cap_tracking";
 import { isProgrammaticUsage } from "@app/lib/api/programmatic_usage_tracking";
 import { getSupportedModelConfig } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
@@ -1674,6 +1676,51 @@ async function isMessagesLimitReached(
         isLimitReached: true,
         limitType: "rate_limit_error",
       };
+    }
+
+    // Per-key rate limiting for keys with a cap.
+    // Prevents close-to-0 cap attacks where many messages are sent simultaneously.
+    const remainingCapMicroUsd = await getRemainingKeyCapMicroUsd(auth);
+    if (remainingCapMicroUsd !== null) {
+      const keyAuth = auth.key();
+      if (keyAuth) {
+        const remainingCapDollars = remainingCapMicroUsd / 1_000_000;
+        const keyMaxMessagesPerMinute = Math.max(
+          1,
+          Math.floor(
+            remainingCapDollars / PROGRAMMATIC_RATE_LIMIT_DOLLARS_PER_MESSAGE
+          )
+        );
+
+        const keyRemainingMessages = await rateLimiter({
+          key: makeKeyCapRateLimitKey(keyAuth.id),
+          maxPerTimeframe: keyMaxMessagesPerMinute,
+          timeframeSeconds: 60,
+          logger,
+        });
+
+        if (keyRemainingMessages <= 0) {
+          logger.info(
+            {
+              workspaceId: owner.sId,
+              keyId: keyAuth.id,
+              remainingCapDollars,
+            },
+            "Pre-emptive rate limit triggered for key cap."
+          );
+
+          statsDClient.increment(
+            "assistant.rate_limiter.key_cap.credit_based_limit_triggered",
+            1,
+            { workspace_id: owner.sId }
+          );
+
+          return {
+            isLimitReached: true,
+            limitType: "rate_limit_error",
+          };
+        }
+      }
     }
 
     return {

--- a/front/lib/api/assistant/rate_limits.ts
+++ b/front/lib/api/assistant/rate_limits.ts
@@ -27,6 +27,10 @@ export const makeProgrammaticUsageRateLimitKeyForWorkspace = (
   return `workspace:${owner.id}:programmatic_usage_rate_limit`;
 };
 
+export const makeKeyCapRateLimitKey = (keyId: number) => {
+  return `api_key:${keyId}:cap_rate_limit`;
+};
+
 export async function resetMessageRateLimitForWorkspace(auth: Authenticator) {
   const workspace = auth.getNonNullableWorkspace();
   const plan = auth.getNonNullablePlan();

--- a/front/lib/api/key_cap_tracking.ts
+++ b/front/lib/api/key_cap_tracking.ts
@@ -1,0 +1,179 @@
+import type { estypes } from "@elastic/elasticsearch";
+
+import { searchAnalytics } from "@app/lib/api/elasticsearch";
+import type { Authenticator } from "@app/lib/auth";
+import { KeyResource } from "@app/lib/resources/key_resource";
+import {
+  cacheWithRedis,
+  invalidateCacheWithRedis,
+} from "@app/lib/utils/cache";
+import logger from "@app/logger/logger";
+import { statsDClient } from "@app/logger/statsDClient";
+import type { ModelId } from "@app/types";
+
+import { AGENT_MESSAGE_STATUSES_TO_TRACK } from "./programmatic_usage_tracking";
+
+const KEY_CAP_CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+async function fetchKeyMonthlyCap(keyId: ModelId): Promise<number | null> {
+  const key = await KeyResource.fetchByModelId(keyId);
+
+  if (!key) {
+    return null;
+  }
+
+  return key.monthlyCapMicroUsd;
+}
+
+const keyCapCacheResolver = (keyId: ModelId) => `key-cap:${keyId}`;
+
+/**
+ * Get the monthly cap for a key, with Redis caching.
+ * Returns null if the key has no cap (unlimited) or doesn't exist.
+ */
+export const getKeyMonthlyCapCached = cacheWithRedis(
+  fetchKeyMonthlyCap,
+  keyCapCacheResolver,
+  { ttlMs: KEY_CAP_CACHE_TTL_MS }
+);
+
+/**
+ * Invalidate the Redis cache for a key's monthly cap.
+ * Should be called when updating the cap via the API.
+ */
+export const invalidateKeyCapCache = invalidateCacheWithRedis(
+  fetchKeyMonthlyCap,
+  keyCapCacheResolver
+);
+
+type UsageAggregations = {
+  total_cost?: estypes.AggregationsSumAggregate;
+};
+
+/**
+ * Get the total usage in microUsd for a key over the last 30 days.
+ * Queries Elasticsearch for messages with this key's name.
+ * Fails open (returns 0) on ES errors to avoid blocking API calls.
+ */
+export async function getLast30DaysKeyUsageMicroUsd(
+  keyId: ModelId
+): Promise<number> {
+  // Get the key name for ES query
+  const key = await KeyResource.fetchByModelId(keyId);
+
+  if (!key || !key.name) {
+    // Key not found or has no name - can't query ES
+    return 0;
+  }
+
+  const thirtyDaysAgoMs = Date.now() - 30 * 24 * 60 * 60 * 1000;
+
+  const query: estypes.QueryDslQueryContainer = {
+    bool: {
+      filter: [
+        { term: { api_key_name: key.name } },
+        { range: { timestamp: { gte: thirtyDaysAgoMs } } },
+        { terms: { status: AGENT_MESSAGE_STATUSES_TO_TRACK } },
+      ],
+    },
+  };
+
+  const result = await searchAnalytics<never, UsageAggregations>(query, {
+    aggregations: {
+      total_cost: { sum: { field: "tokens.cost_micro_usd" } },
+    },
+    size: 0,
+  });
+
+  if (result.isErr()) {
+    // Fail open: log the error but don't block API calls
+    logger.error(
+      {
+        keyId,
+        error: result.error.message,
+      },
+      "[Key Cap Tracking] Failed to query ES for key usage, failing open"
+    );
+    return 0;
+  }
+
+  const totalCost = result.value.aggregations?.total_cost?.value ?? 0;
+  return Math.round(totalCost);
+}
+
+/**
+ * Check if a key has reached its monthly usage cap.
+ * Returns false if:
+ * - No key is present in the authenticator
+ * - The key has no cap (unlimited)
+ * - ES query fails (fail open)
+ *
+ * Returns true if usage >= cap.
+ */
+export async function hasKeyReachedUsageCap(
+  auth: Authenticator
+): Promise<boolean> {
+  const keyAuth = auth.key();
+
+  if (!keyAuth) {
+    return false;
+  }
+
+  const cap = await getKeyMonthlyCapCached(keyAuth.id);
+
+  if (cap === null) {
+    // No cap set (unlimited)
+    statsDClient.increment("api_key.cap.check", 1, [
+      `result:no_cap`,
+      `key_id:${keyAuth.id}`,
+    ]);
+    return false;
+  }
+
+  const usage = await getLast30DaysKeyUsageMicroUsd(keyAuth.id);
+  const hasReached = usage >= cap;
+
+  statsDClient.increment("api_key.cap.check", 1, [
+    `result:${hasReached ? "reached" : "under_cap"}`,
+    `key_id:${keyAuth.id}`,
+  ]);
+
+  if (hasReached) {
+    logger.info(
+      {
+        keyId: keyAuth.id,
+        keyName: keyAuth.name,
+        usageMicroUsd: usage,
+        capMicroUsd: cap,
+      },
+      "[Key Cap Tracking] Key has reached usage cap"
+    );
+  }
+
+  return hasReached;
+}
+
+/**
+ * Get the remaining cap in microUsd for a key.
+ * Returns null if the key has no cap (unlimited).
+ * Returns max(0, cap - usage) if the key has a cap.
+ */
+export async function getRemainingKeyCapMicroUsd(
+  auth: Authenticator
+): Promise<number | null> {
+  const keyAuth = auth.key();
+
+  if (!keyAuth) {
+    return null;
+  }
+
+  const cap = await getKeyMonthlyCapCached(keyAuth.id);
+
+  if (cap === null) {
+    // No cap set (unlimited)
+    return null;
+  }
+
+  const usage = await getLast30DaysKeyUsageMicroUsd(keyAuth.id);
+  return Math.max(0, cap - usage);
+}

--- a/front/lib/api/key_cap_tracking.ts
+++ b/front/lib/api/key_cap_tracking.ts
@@ -3,10 +3,7 @@ import type { estypes } from "@elastic/elasticsearch";
 import { searchAnalytics } from "@app/lib/api/elasticsearch";
 import type { Authenticator } from "@app/lib/auth";
 import { KeyResource } from "@app/lib/resources/key_resource";
-import {
-  cacheWithRedis,
-  invalidateCacheWithRedis,
-} from "@app/lib/utils/cache";
+import { cacheWithRedis, invalidateCacheWithRedis } from "@app/lib/utils/cache";
 import logger from "@app/logger/logger";
 import { statsDClient } from "@app/logger/statsDClient";
 import type { ModelId } from "@app/types";

--- a/front/lib/api/programmatic_usage_tracking.ts
+++ b/front/lib/api/programmatic_usage_tracking.ts
@@ -5,6 +5,7 @@ import moment from "moment-timezone";
 import type { RedisClientType } from "redis";
 
 import { DUST_MARKUP_PERCENT } from "@app/lib/api/assistant/token_pricing";
+import { hasKeyReachedUsageCap } from "@app/lib/api/key_cap_tracking";
 import { runOnRedis } from "@app/lib/api/redis";
 import { getWorkspacePublicAPILimits } from "@app/lib/api/workspace";
 import type { Authenticator } from "@app/lib/auth";
@@ -150,9 +151,6 @@ export type UsageLimitType = "none" | "workspace_credits" | "key_cap";
 export async function checkProgrammaticUsageLimits(
   auth: Authenticator
 ): Promise<{ hasReachedLimit: boolean; limitType: UsageLimitType }> {
-  // Lazy import to avoid circular dependency.
-  const { hasKeyReachedUsageCap } = await import("@app/lib/api/key_cap_tracking");
-
   // First check workspace credits.
   const hasNoCredits = await hasReachedProgrammaticUsageLimits(auth);
   if (hasNoCredits) {

--- a/front/lib/api/redis.ts
+++ b/front/lib/api/redis.ts
@@ -12,6 +12,7 @@ export type RedisUsageTagsType =
   | "assistant_generation"
   | "cancel_message_generation"
   | "conversation_events"
+  | "key_usage_tracking"
   | "lock"
   | "mcp_client_side_request"
   | "mcp_client_side_results"

--- a/front/lib/triggers/webhook.ts
+++ b/front/lib/triggers/webhook.ts
@@ -274,22 +274,9 @@ async function checkWorkspaceRateLimit({
       errorMessage = message;
     }
   } else {
-    const { hasReachedLimit, limitType } =
-      await checkProgrammaticUsageLimits(auth);
-    if (hasReachedLimit) {
-      if (limitType === "key_cap") {
-        errorMessage = auth.isAdmin()
-          ? "This API key has reached its monthly usage cap. " +
-            "Please increase the cap in the Developers > API Keys section of the Dust dashboard."
-          : "This API key has reached its monthly usage cap. " +
-            "Please ask a Dust workspace admin to increase the cap.";
-      } else {
-        errorMessage = auth.isAdmin()
-          ? "Your workspace has run out of programmatic usage credits. " +
-            "Please purchase more credits in the Developers > Credits section of the Dust dashboard."
-          : "Your workspace has run out of programmatic usage credits. " +
-            "Please ask a Dust workspace admin to purchase more credits.";
-      }
+    const limitsResult = await checkProgrammaticUsageLimits(auth);
+    if (limitsResult.isErr()) {
+      errorMessage = limitsResult.error.message;
     }
   }
 

--- a/front/lib/triggers/webhook.ts
+++ b/front/lib/triggers/webhook.ts
@@ -1,5 +1,5 @@
 import { toFileContentFragment } from "@app/lib/api/assistant/conversation/content_fragment";
-import { hasReachedProgrammaticUsageLimits } from "@app/lib/api/programmatic_usage_tracking";
+import { checkProgrammaticUsageLimits } from "@app/lib/api/programmatic_usage_tracking";
 import { Authenticator } from "@app/lib/auth";
 import type { DustError } from "@app/lib/error";
 import { getWebhookRequestsBucket } from "@app/lib/file_storage";
@@ -274,12 +274,22 @@ async function checkWorkspaceRateLimit({
       errorMessage = message;
     }
   } else {
-    if (await hasReachedProgrammaticUsageLimits(auth)) {
-      errorMessage = auth.isAdmin()
-        ? "Your workspace has run out of programmatic usage credits. " +
-          "Please purchase more credits in the Developers > Credits section of the Dust dashboard."
-        : "Your workspace has run out of programmatic usage credits. " +
-          "Please ask a Dust workspace admin to purchase more credits.";
+    const { hasReachedLimit, limitType } =
+      await checkProgrammaticUsageLimits(auth);
+    if (hasReachedLimit) {
+      if (limitType === "key_cap") {
+        errorMessage = auth.isAdmin()
+          ? "This API key has reached its monthly usage cap. " +
+            "Please increase the cap in the Developers > API Keys section of the Dust dashboard."
+          : "This API key has reached its monthly usage cap. " +
+            "Please ask a Dust workspace admin to increase the cap.";
+      } else {
+        errorMessage = auth.isAdmin()
+          ? "Your workspace has run out of programmatic usage credits. " +
+            "Please purchase more credits in the Developers > Credits section of the Dust dashboard."
+          : "Your workspace has run out of programmatic usage credits. " +
+            "Please ask a Dust workspace admin to purchase more credits.";
+      }
     }
   }
 

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -167,28 +167,13 @@ async function handler(
 
       if (message) {
         if (isProgrammaticUsage(auth, { userMessageOrigin: origin })) {
-          const { hasReachedLimit, limitType } =
-            await checkProgrammaticUsageLimits(auth);
-          if (hasReachedLimit) {
-            let errorMessage: string;
-            if (limitType === "key_cap") {
-              errorMessage = auth.isAdmin()
-                ? "This API key has reached its monthly usage cap. " +
-                  "Please increase the cap in the Developers > API Keys section of the Dust dashboard."
-                : "This API key has reached its monthly usage cap. " +
-                  "Please ask a Dust workspace admin to increase the cap.";
-            } else {
-              errorMessage = auth.isAdmin()
-                ? "Your workspace has run out of programmatic usage credits. " +
-                  "Please purchase more credits in the Developers > Credits section of the Dust dashboard."
-                : "Your workspace has run out of programmatic usage credits. " +
-                  "Please ask a Dust workspace admin to purchase more credits.";
-            }
+          const limitsResult = await checkProgrammaticUsageLimits(auth);
+          if (limitsResult.isErr()) {
             return apiError(req, res, {
               status_code: 429,
               api_error: {
                 type: "rate_limit_error",
-                message: errorMessage,
+                message: limitsResult.error.message,
               },
             });
           }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Adds per-API key usage caps with 30-day rolling window tracking via Elasticsearch.                                                                                                                                                                                                                         
Main changes :
  - New key_cap_tracking.ts module
  - Pre-emptive rate limiting in isMessagesLimitReached to prevent burst attacks near cap exhaustion
  - checkProgrammaticUsageLimits now checks both workspace credits and per-key caps, returning Result<void, Error> with appropriate error messages
  - Unified limit checking across conversation endpoints and webhooks with centralized error message generation

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Unit

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front