### PR TITLE
type the body of space creation requests

### DIFF
--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -423,6 +423,7 @@ export function useCreateSpace({ owner }: { owner: LightWorkspaceType }) {
 
     const url = `/api/w/${owner.sId}/spaces`;
     let res;
+    let body: PostSpaceRequestBodyType;
 
     if (managementMode === "manual") {
       const { memberIds } = params;
@@ -432,18 +433,20 @@ export function useCreateSpace({ owner }: { owner: LightWorkspaceType }) {
         return null;
       }
 
+      body = {
+        name,
+        memberIds,
+        managementMode,
+        isRestricted,
+        spaceKind,
+      };
+
       res = await clientFetch(url, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({
-          name,
-          memberIds,
-          managementMode,
-          isRestricted,
-          spaceKind,
-        } as PostSpaceRequestBodyType),
+        body: JSON.stringify(body),
       });
     } else if (managementMode === "group") {
       const { groupIds } = params;
@@ -453,17 +456,20 @@ export function useCreateSpace({ owner }: { owner: LightWorkspaceType }) {
         return null;
       }
 
+      body = {
+        name,
+        groupIds,
+        managementMode,
+        isRestricted,
+        spaceKind,
+      };
+
       res = await clientFetch(url, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({
-          name,
-          isRestricted,
-          groupIds,
-          managementMode,
-        }),
+        body: JSON.stringify(body),
       });
     } else {
       return null;


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/6075

The body sent to the /spaces endpoint was not typed. This broke because of a side effect of adding the new property `spaceKind` as part of the projects initiative


## Tests

no

## Risk

none

## Deploy Plan

front only
