### PR TITLE
[front] fix(oauth): avoid token refresh in connection ownership check

### DIFF
--- a/front/lib/api/oauth.ts
+++ b/front/lib/api/oauth.ts
@@ -290,8 +290,10 @@ export async function checkConnectionOwnership(
   }
 
   // Ensure the connectionId has been created by the current user and is not being stolen.
+  // Uses getConnectionMetadata instead of getAccessToken to avoid triggering a token refresh,
+  // which can fail for providers like Snowflake where the refresh buffer >= token TTL.
   const oauthAPI = new OAuthAPI(config.getOAuthAPIConfig(), logger);
-  const connectionRes = await oauthAPI.getAccessToken({
+  const connectionRes = await oauthAPI.getConnectionMetadata({
     connectionId,
   });
   if (


### PR DESCRIPTION
## Summary

- Use `getConnectionMetadata` instead of `getAccessToken` in `checkConnectionOwnership` to avoid triggering a token refresh that can fail for Snowflake connections
- For Snowflake, the refresh buffer (10 min) >= token TTL (10 min), so every `getAccessToken` call triggers a refresh. When this fails during connection creation, the `MCPServerConnectionResource` is never saved, forcing the user to re-authenticate
- The ownership check only needs `user_id` and `workspace_id` from connection metadata, not a valid access token

## Test plan

- [ ] Verify Snowflake MCP tool connection works without requiring double OAuth
- [ ] Verify other OAuth providers' connection creation still works correctly