### PR TITLE
Add temporary set_agent_instructions client tool

### DIFF
--- a/front/components/agent_builder/copilot/tools/setAgentInstructions.ts
+++ b/front/components/agent_builder/copilot/tools/setAgentInstructions.ts
@@ -1,0 +1,33 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+/**
+ * Registers the set_agent_instructions tool on the MCP server.
+ * This tool allows the copilot to update the agent's instructions in the form.
+ */
+export function registerSetAgentInstructionsTool(
+  mcpServer: McpServer,
+  setInstructions: (instructions: string) => void
+): void {
+  mcpServer.tool(
+    "set_agent_instructions",
+    "Replace the agent's instructions with new content. Use this to update the agent's instructions based on user requests.",
+    {
+      instructions: z
+        .string()
+        .describe("The new instructions to set for the agent"),
+    },
+    ({ instructions }) => {
+      setInstructions(instructions);
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: "Instructions updated successfully.",
+          },
+        ],
+      };
+    }
+  );
+}

--- a/front/components/agent_builder/copilot/useMCPServer.ts
+++ b/front/components/agent_builder/copilot/useMCPServer.ts
@@ -5,6 +5,7 @@ import { useFormContext } from "react-hook-form";
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
 import { registerGetAgentConfigTool } from "@app/components/agent_builder/copilot/tools/getAgentConfig";
+import { registerSetAgentInstructionsTool } from "@app/components/agent_builder/copilot/tools/setAgentInstructions";
 import { BrowserMCPTransport } from "@app/lib/client/BrowserMCPTransport";
 
 // Server name used for MCP registration. This is a client-side MCP server
@@ -30,7 +31,7 @@ export function useCopilotMCPServer({
   enabled,
 }: UseCopilotMCPServerOptions): UseCopilotMCPServerResult {
   const { owner } = useAgentBuilderContext();
-  const { getValues } = useFormContext<AgentBuilderFormData>();
+  const { getValues, setValue } = useFormContext<AgentBuilderFormData>();
 
   const [serverId, setServerId] = useState<string | undefined>(undefined);
   const [isConnected, setIsConnected] = useState(false);
@@ -47,6 +48,14 @@ export function useCopilotMCPServer({
   const getFormValues = useCallback(() => {
     return getValues();
   }, [getValues]);
+
+  // Create a stable callback for setting the instructions.
+  const setInstructions = useCallback(
+    (instructions: string) => {
+      setValue("instructions", instructions);
+    },
+    [setValue]
+  );
 
   useEffect(() => {
     // Don't initialize if the feature is disabled.
@@ -74,6 +83,7 @@ export function useCopilotMCPServer({
 
         // Register tools.
         registerGetAgentConfigTool(mcpServer, getFormValues);
+        registerSetAgentInstructionsTool(mcpServer, setInstructions);
 
         // Create the browser transport.
         const transport = new BrowserMCPTransport(
@@ -138,7 +148,7 @@ export function useCopilotMCPServer({
       setServerId(undefined);
       setIsConnected(false);
     };
-  }, [enabled, owner.sId, getFormValues]);
+  }, [enabled, owner.sId, getFormValues, setInstructions]);
 
   return {
     serverId,


### PR DESCRIPTION
## Description

Basic `set_agent_instructions` to unblock demos. This will be removed once we have fancier client tools.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Front