### PR TITLE
feat(agent-builder): enable client MCP server for copilot tab

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -592,11 +592,13 @@ function AgentBuilderContent({
               agentConfiguration?.sId ?? pendingAgentId ?? null
             }
             targetAgentConfigurationVersion={agentConfiguration?.version ?? 0}
+            clientSideMCPServerIds={
+              clientSideMCPServerId ? [clientSideMCPServerId] : []
+            }
           >
             <ConversationSidePanelProvider>
               <AgentBuilderRightPanel
                 agentConfigurationSId={agentConfiguration?.sId}
-                clientSideMCPServerId={clientSideMCPServerId}
               />
             </ConversationSidePanelProvider>
           </CopilotPanelProvider>

--- a/front/components/agent_builder/AgentBuilderCopilot.tsx
+++ b/front/components/agent_builder/AgentBuilderCopilot.tsx
@@ -60,6 +60,7 @@ interface CopilotContentProps {
   resetConversation: () => void;
   isTrialPlan: boolean;
   isAdmin: boolean;
+  clientSideMCPServerIds: string[];
 }
 
 function CopilotContent({
@@ -70,6 +71,7 @@ function CopilotContent({
   resetConversation,
   isTrialPlan,
   isAdmin,
+  clientSideMCPServerIds,
 }: CopilotContentProps) {
   return (
     <>
@@ -89,6 +91,7 @@ function CopilotContent({
                 isSubmitting: false,
                 resetConversation,
                 actionsToShow: [],
+                clientSideMCPServerIds,
               }}
               key={conversation.sId}
             />
@@ -120,6 +123,7 @@ export function AgentBuilderCopilot() {
     creationFailed,
     startConversation,
     resetConversation,
+    clientSideMCPServerIds,
   } = useCopilotPanelContext();
 
   // Auto-start conversation when component mounts
@@ -150,6 +154,7 @@ export function AgentBuilderCopilot() {
         resetConversation={resetConversation}
         isTrialPlan={!!isTrialPlan}
         isAdmin={isAdmin}
+        clientSideMCPServerIds={clientSideMCPServerIds}
       />
     );
   };

--- a/front/components/agent_builder/AgentBuilderPreview.tsx
+++ b/front/components/agent_builder/AgentBuilderPreview.tsx
@@ -80,7 +80,6 @@ interface PreviewContentProps {
   isSavingDraftAgent: boolean;
   isTrialPlan: boolean;
   isAdmin: boolean;
-  clientSideMCPServerId?: string;
 }
 
 function PreviewContent({
@@ -94,7 +93,6 @@ function PreviewContent({
   isSavingDraftAgent,
   isTrialPlan,
   isAdmin,
-  clientSideMCPServerId,
 }: PreviewContentProps) {
   return (
     <>
@@ -115,9 +113,6 @@ function PreviewContent({
                 isSubmitting: isSavingDraftAgent,
                 resetConversation,
                 actionsToShow: ["attachment"],
-                clientSideMCPServerIds: clientSideMCPServerId
-                  ? [clientSideMCPServerId]
-                  : undefined,
               }}
               key={conversation.sId}
             />
@@ -162,13 +157,7 @@ function PreviewContent({
   );
 }
 
-interface AgentBuilderPreviewProps {
-  clientSideMCPServerId?: string;
-}
-
-export function AgentBuilderPreview({
-  clientSideMCPServerId,
-}: AgentBuilderPreviewProps) {
+export function AgentBuilderPreview() {
   const { owner, isAdmin } = useAgentBuilderContext();
   const { user } = useUser();
   const { activeSubscription } = useWorkspaceActiveSubscription({ owner });
@@ -203,7 +192,6 @@ export function AgentBuilderPreview({
     useDraftConversation({
       draftAgent,
       getDraftAgent,
-      clientSideMCPServerId,
     });
 
   const debounceTimerRef = useRef<NodeJS.Timeout>();
@@ -311,7 +299,6 @@ export function AgentBuilderPreview({
         isSavingDraftAgent={isSavingDraftAgent}
         isTrialPlan={!!isTrialPlan}
         isAdmin={isAdmin}
-        clientSideMCPServerId={clientSideMCPServerId}
       />
     );
   };

--- a/front/components/agent_builder/AgentBuilderRightPanel.tsx
+++ b/front/components/agent_builder/AgentBuilderRightPanel.tsx
@@ -177,14 +177,12 @@ interface ExpandedContentProps {
   selectedTab: AgentBuilderRightPanelTabType;
   agentConfigurationSId?: string;
   hasCopilot: boolean;
-  clientSideMCPServerId?: string;
 }
 
 function ExpandedContent({
   selectedTab,
   agentConfigurationSId,
   hasCopilot,
-  clientSideMCPServerId,
 }: ExpandedContentProps) {
   const { assistantTemplate, setPresetActionToAdd } = useAgentBuilderContext();
 
@@ -203,7 +201,7 @@ function ExpandedContent({
       )}
       {selectedTab === "preview" && (
         <div className="min-h-0 flex-1">
-          <AgentBuilderPreview clientSideMCPServerId={clientSideMCPServerId} />
+          <AgentBuilderPreview />
         </div>
       )}
       <ObservabilityProvider>
@@ -242,12 +240,10 @@ function ExpandedContent({
 
 interface AgentBuilderRightPanelProps {
   agentConfigurationSId?: string;
-  clientSideMCPServerId?: string;
 }
 
 export function AgentBuilderRightPanel({
   agentConfigurationSId,
-  clientSideMCPServerId,
 }: AgentBuilderRightPanelProps) {
   const { isPreviewPanelOpen, setIsPreviewPanelOpen } =
     usePreviewPanelContext();
@@ -291,7 +287,6 @@ export function AgentBuilderRightPanel({
           selectedTab={selectedTab}
           agentConfigurationSId={agentConfigurationSId}
           hasCopilot={hasCopilot}
-          clientSideMCPServerId={clientSideMCPServerId}
         />
       ) : (
         <CollapsedTabs

--- a/front/components/agent_builder/CopilotPanelContext.tsx
+++ b/front/components/agent_builder/CopilotPanelContext.tsx
@@ -37,10 +37,11 @@ You help users optimize their agents by:
 
 You have access to these tools to gather information:
 
-### Agent State
-- **get_agent_info**: Get the current agent's name, description, instructions, model settings, tools, and skills
+### Live Agent State (from builder form)
+- **get_agent_config**: Get the current UNSAVED agent configuration from the builder form (name, description, instructions, model, tools, skills). Use this to see what the user is currently editing.
 
-### Context & Analytics
+### Saved Agent State & Analytics
+- **get_agent_info**: Get the last SAVED version of the agent configuration
 - **get_available_models**: List available models the agent could use
 - **get_available_skills**: List skills that could be added to the agent
 - **get_available_tools**: List tools (MCP servers) that could be added
@@ -50,7 +51,7 @@ You have access to these tools to gather information:
 ## YOUR FIRST MESSAGE
 
 **Immediately use your tools** to analyze the agent. Start with:
-1. Call \`get_agent_info\` to understand the current configuration
+1. Call \`get_agent_config\` to see what the user is currently editing (unsaved changes)
 2. Call \`get_agent_feedback\` to see what users are saying
 3. Call \`get_agent_insights\` to understand usage patterns
 
@@ -98,6 +99,7 @@ interface CopilotPanelContextType {
   creationFailed: boolean;
   startConversation: () => Promise<void>;
   resetConversation: () => void;
+  clientSideMCPServerIds: string[];
 }
 
 const CopilotPanelContext = createContext<CopilotPanelContextType | undefined>(
@@ -118,12 +120,14 @@ interface CopilotPanelProviderProps {
   children: ReactNode;
   targetAgentConfigurationId: string | null;
   targetAgentConfigurationVersion: number;
+  clientSideMCPServerIds: string[];
 }
 
 export const CopilotPanelProvider = ({
   children,
   targetAgentConfigurationId,
   targetAgentConfigurationVersion,
+  clientSideMCPServerIds,
 }: CopilotPanelProviderProps) => {
   const { owner } = useAgentBuilderContext();
   const { user } = useUser();
@@ -157,6 +161,7 @@ export const CopilotPanelProvider = ({
         mentions: [{ configurationId: GLOBAL_AGENTS_SID.COPILOT }],
         contentFragments: { uploaded: [], contentNodes: [] },
         origin: "agent_copilot",
+        clientSideMCPServerIds,
       },
       // TODO(copilot 2026-01-23): same visibility as the 'Preview' tab conversation.
       // We should rename it.
@@ -180,6 +185,7 @@ export const CopilotPanelProvider = ({
 
     setIsCreatingConversation(false);
   }, [
+    clientSideMCPServerIds,
     createConversationWithMessage,
     sendNotification,
     targetAgentConfigurationId,
@@ -199,8 +205,10 @@ export const CopilotPanelProvider = ({
       creationFailed,
       startConversation,
       resetConversation,
+      clientSideMCPServerIds,
     }),
     [
+      clientSideMCPServerIds,
       conversation,
       isCreatingConversation,
       creationFailed,

--- a/front/components/agent_builder/hooks/useAgentPreview.ts
+++ b/front/components/agent_builder/hooks/useAgentPreview.ts
@@ -106,11 +106,9 @@ export function useDraftAgent() {
 export function useDraftConversation({
   draftAgent,
   getDraftAgent,
-  clientSideMCPServerId,
 }: {
   draftAgent: LightAgentConfigurationType | null;
   getDraftAgent: () => Promise<LightAgentConfigurationType | null>;
-  clientSideMCPServerId?: string;
 }) {
   const { owner } = useAgentBuilderContext();
   const { user } = useUser();
@@ -162,10 +160,6 @@ export function useDraftConversation({
           configurationId: mention.id,
         })),
         contentFragments,
-        // Include client-side MCP server IDs for the agent builder copilot.
-        clientSideMCPServerIds: clientSideMCPServerId
-          ? [clientSideMCPServerId]
-          : undefined,
       };
 
       const result = await createConversationWithMessage({
@@ -191,7 +185,6 @@ export function useDraftConversation({
       });
     },
     [
-      clientSideMCPServerId,
       createConversationWithMessage,
       draftAgent?.sId,
       getDraftAgent,


### PR DESCRIPTION
## Description

Move the client-side MCP server from Preview tab to Copilot tab, allowing the copilot agent to access live form state via the `get_agent_config` tool.

Update the copilot initial prompt to use it in favor of the server side one.

## Tests

![Screen Recording 2026-01-23 at 16 34 46](https://github.com/user-attachments/assets/bf6bd1f1-c67b-4417-8ba2-c66a3ea20996)
![Screen Recording 2026-01-23 at 16 36 02](https://github.com/user-attachments/assets/c80584c9-15c6-433c-9944-149b04207604)


## Risk

Low.

## Deploy Plan

Front.