### PR TITLE
[front] refactor(mcp): migrate run_dust_app server to new pattern

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -24,6 +24,7 @@ import { GOOGLE_CALENDAR_SERVER } from "@app/lib/api/actions/servers/google_cale
 import { IMAGE_GENERATION_SERVER } from "@app/lib/api/actions/servers/image_generation/metadata";
 import { INCLUDE_DATA_SERVER } from "@app/lib/api/actions/servers/include_data/metadata";
 import { NOTION_SERVER } from "@app/lib/api/actions/servers/notion/metadata";
+import { RUN_DUST_APP_SERVER } from "@app/lib/api/actions/servers/run_dust_app/metadata";
 import { SOUND_STUDIO_SERVER } from "@app/lib/api/actions/servers/sound_studio/metadata";
 import { SPEECH_GENERATOR_SERVER } from "@app/lib/api/actions/servers/speech_generator/metadata";
 import { STATUSPAGE_SERVER } from "@app/lib/api/actions/servers/statuspage/metadata";
@@ -323,19 +324,10 @@ export const INTERNAL_MCP_SERVERS = {
       return !featureFlags.includes("legacy_dust_apps");
     },
     isPreview: false,
-    tools_stakes: undefined,
     tools_arguments_requiring_approval: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,
-    serverInfo: {
-      name: "run_dust_app",
-      version: "1.0.0",
-      description: "Run Dust Apps with specified parameters.",
-      icon: "CommandLineIcon",
-      authorization: null,
-      documentationUrl: null,
-      instructions: null,
-    },
+    metadata: RUN_DUST_APP_SERVER,
   },
   notion: {
     id: 11,

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -38,7 +38,6 @@ import { default as extractDataServer } from "@app/lib/actions/mcp_internal_acti
 import { default as productboardServer } from "@app/lib/actions/mcp_internal_actions/servers/productboard";
 import { default as projectContextManagementServer } from "@app/lib/actions/mcp_internal_actions/servers/project_context_management";
 import { default as runAgentServer } from "@app/lib/actions/mcp_internal_actions/servers/run_agent";
-import { default as dustAppServer } from "@app/lib/actions/mcp_internal_actions/servers/run_dust_app";
 import { default as salesforceServer } from "@app/lib/actions/mcp_internal_actions/servers/salesforce";
 import { default as salesloftServer } from "@app/lib/actions/mcp_internal_actions/servers/salesloft";
 import { default as schedulesManagementServer } from "@app/lib/actions/mcp_internal_actions/servers/schedules_management";
@@ -68,6 +67,7 @@ import { default as calendarServer } from "@app/lib/api/actions/servers/google_c
 import { default as imageGenerationServer } from "@app/lib/api/actions/servers/image_generation";
 import { default as includeDataServer } from "@app/lib/api/actions/servers/include_data";
 import { default as notionServer } from "@app/lib/api/actions/servers/notion";
+import { default as dustAppServer } from "@app/lib/api/actions/servers/run_dust_app";
 import { default as snowflakeServer } from "@app/lib/api/actions/servers/snowflake";
 import { default as soundStudio } from "@app/lib/api/actions/servers/sound_studio";
 import { default as speechGenerator } from "@app/lib/api/actions/servers/speech_generator";

--- a/front/lib/api/actions/servers/run_dust_app/index.ts
+++ b/front/lib/api/actions/servers/run_dust_app/index.ts
@@ -1,0 +1,240 @@
+// eslint-disable-next-line dust/enforce-client-types-in-public-api
+import { DustAPI, INTERNAL_MIME_TYPES } from "@dust-tt/client";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { TextContent } from "@modelcontextprotocol/sdk/types.js";
+
+import { MCPError } from "@app/lib/actions/mcp_errors";
+import { matchesInternalMCPServerName } from "@app/lib/actions/mcp_internal_actions/constants";
+import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
+import type { ToolGeneratedFileType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
+import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
+import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
+import {
+  isLightServerSideMCPToolConfiguration,
+  isServerSideMCPServerConfigurationWithName,
+} from "@app/lib/actions/types/guards";
+import config from "@app/lib/api/config";
+import type { Authenticator } from "@app/lib/auth";
+import { prodAPICredentialsForOwner } from "@app/lib/auth";
+import { sanitizeJSONOutput } from "@app/lib/utils";
+import logger from "@app/logger/logger";
+import { Err, getHeaderFromGroupIds, getHeaderFromRole, Ok } from "@app/types";
+
+import {
+  containsFileOutput,
+  convertDatasetSchemaToZodRawShape,
+  prepareAppContext,
+  prepareParamsWithHistory,
+  processDustFileOutput,
+} from "./helpers";
+import { RUN_DUST_APP_TOOL_NAME } from "./metadata";
+
+/**
+ * Creates the run_dust_app MCP server.
+ *
+ * This server is special because tools are dynamically created based on the Dust app
+ * configuration. The server handles three different contexts:
+ *
+ * 1. listToolsContext: Used to list available tools for an agent. Creates a tool
+ *    based on the configured Dust app's input schema.
+ *
+ * 2. runContext: Used when actually running the Dust app. Creates a tool that
+ *    executes the app with the provided parameters.
+ *
+ * 3. Default context: Used during configuration to select which Dust app to use.
+ *    Creates a configuration tool using the DUST_APP input schema.
+ */
+export default async function createServer(
+  auth: Authenticator,
+  agentLoopContext?: AgentLoopContextType
+): Promise<McpServer> {
+  const server = makeInternalMCPServer("run_dust_app");
+  const owner = auth.getNonNullableWorkspace();
+
+  if (agentLoopContext?.listToolsContext) {
+    // Context: Listing tools for an agent
+    const { agentActionConfiguration } = agentLoopContext.listToolsContext;
+    if (
+      !isServerSideMCPServerConfigurationWithName(
+        agentActionConfiguration,
+        "run_dust_app"
+      )
+    ) {
+      throw new Error("Invalid Dust app run agent configuration");
+    }
+
+    const { app, schema } = await prepareAppContext(
+      auth,
+      agentActionConfiguration
+    );
+
+    if (!app.description) {
+      throw new Error("Missing app description");
+    }
+
+    server.tool(
+      app.name,
+      app.description,
+      convertDatasetSchemaToZodRawShape(schema),
+      withToolLogging(
+        auth,
+        { toolNameForMonitoring: RUN_DUST_APP_TOOL_NAME, agentLoopContext },
+        async () => {
+          return new Ok([
+            {
+              type: "text",
+              text: "Successfully list Dust App configuration",
+            },
+          ]);
+        }
+      )
+    );
+  } else if (agentLoopContext?.runContext) {
+    // Context: Running the Dust app
+    const { toolConfiguration } = agentLoopContext.runContext;
+    if (
+      !isLightServerSideMCPToolConfiguration(toolConfiguration) ||
+      !matchesInternalMCPServerName(
+        toolConfiguration.internalMCPServerId,
+        "run_dust_app"
+      )
+    ) {
+      throw new Error("Invalid Dust app run tool configuration");
+    }
+
+    const { app, schema, appConfig } = await prepareAppContext(
+      auth,
+      toolConfiguration
+    );
+
+    if (!app.description) {
+      throw new Error("Missing app description");
+    }
+
+    server.tool(
+      app.name,
+      app.description,
+      convertDatasetSchemaToZodRawShape(schema),
+      withToolLogging(
+        auth,
+        { toolNameForMonitoring: RUN_DUST_APP_TOOL_NAME, agentLoopContext },
+        async (params) => {
+          const content: (
+            | TextContent
+            | { type: "resource"; resource: ToolGeneratedFileType }
+          )[] = [];
+
+          const preparedParams = await prepareParamsWithHistory(
+            params,
+            schema,
+            agentLoopContext.runContext,
+            auth
+          );
+
+          const requestedGroupIds = auth.groupIds();
+
+          const prodCredentials = await prodAPICredentialsForOwner(owner);
+          const apiConfig = config.getDustAPIConfig();
+          const api = new DustAPI(
+            apiConfig,
+            {
+              ...prodCredentials,
+              extraHeaders: {
+                ...getHeaderFromGroupIds(requestedGroupIds),
+                ...getHeaderFromRole(auth.role()), // Keep the user's role for api.runApp call only
+              },
+            },
+            logger,
+            apiConfig.nodeEnv === "development" ? "http://localhost:3000" : null
+          );
+
+          const runRes = await api.runAppStreamed(
+            {
+              workspaceId: owner.sId,
+              appId: app.sId,
+              appSpaceId: app.space.sId,
+              appHash: "latest",
+            },
+            appConfig,
+            [preparedParams],
+            { useWorkspaceCredentials: true }
+          );
+
+          if (runRes.isErr()) {
+            return new Err(
+              new MCPError(`Error running Dust app: ${runRes.error.message}`)
+            );
+          }
+
+          const { eventStream } = runRes.value;
+          let lastBlockOutput = null;
+
+          for await (const event of eventStream) {
+            if (event.type === "error") {
+              return new Err(
+                new MCPError(`Error running Dust app: ${event.content.message}`)
+              );
+            }
+
+            if (event.type === "block_execution") {
+              const e = event.content.execution[0][0];
+              if (e.error) {
+                return new Err(
+                  new MCPError(`Error in block execution: ${e.error}`)
+                );
+              }
+              lastBlockOutput = e.value;
+            }
+          }
+
+          const sanitizedOutput = sanitizeJSONOutput(lastBlockOutput);
+
+          if (
+            containsFileOutput(sanitizedOutput) &&
+            agentLoopContext.runContext?.conversation
+          ) {
+            const fileContent = await processDustFileOutput(
+              auth,
+              sanitizedOutput,
+              agentLoopContext.runContext.conversation,
+              app.name
+            );
+            content.push(...fileContent);
+          }
+
+          content.push({
+            type: "text",
+            text: JSON.stringify(sanitizedOutput, null, 2),
+          });
+
+          return new Ok(content);
+        }
+      )
+    );
+  } else {
+    // Context: Configuration - selecting which Dust app to use
+    server.tool(
+      "run_dust_app",
+      "Run a Dust App with specified parameters.",
+      {
+        dustApp:
+          ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_APP],
+      },
+      withToolLogging(
+        auth,
+        { toolNameForMonitoring: RUN_DUST_APP_TOOL_NAME, agentLoopContext },
+        async () => {
+          return new Ok([
+            {
+              type: "text",
+              text: "Successfully saved Dust App configuration",
+            },
+          ]);
+        }
+      )
+    );
+  }
+
+  return server;
+}

--- a/front/lib/api/actions/servers/run_dust_app/index.ts
+++ b/front/lib/api/actions/servers/run_dust_app/index.ts
@@ -14,21 +14,20 @@ import {
   isLightServerSideMCPToolConfiguration,
   isServerSideMCPServerConfigurationWithName,
 } from "@app/lib/actions/types/guards";
-import config from "@app/lib/api/config";
-import type { Authenticator } from "@app/lib/auth";
-import { prodAPICredentialsForOwner } from "@app/lib/auth";
-import { sanitizeJSONOutput } from "@app/lib/utils";
-import logger from "@app/logger/logger";
-import { Err, getHeaderFromGroupIds, getHeaderFromRole, Ok } from "@app/types";
-
 import {
   containsFileOutput,
   convertDatasetSchemaToZodRawShape,
   prepareAppContext,
   prepareParamsWithHistory,
   processDustFileOutput,
-} from "./helpers";
-import { RUN_DUST_APP_TOOL_NAME } from "./metadata";
+} from "@app/lib/api/actions/servers/run_dust_app/helpers";
+import { RUN_DUST_APP_TOOL_NAME } from "@app/lib/api/actions/servers/run_dust_app/metadata";
+import config from "@app/lib/api/config";
+import type { Authenticator } from "@app/lib/auth";
+import { prodAPICredentialsForOwner } from "@app/lib/auth";
+import { sanitizeJSONOutput } from "@app/lib/utils";
+import logger from "@app/logger/logger";
+import { Err, getHeaderFromGroupIds, getHeaderFromRole, Ok } from "@app/types";
 
 /**
  * Creates the run_dust_app MCP server.

--- a/front/lib/api/actions/servers/run_dust_app/metadata.ts
+++ b/front/lib/api/actions/servers/run_dust_app/metadata.ts
@@ -1,0 +1,49 @@
+// eslint-disable-next-line dust/enforce-client-types-in-public-api
+import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
+
+import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+
+export const RUN_DUST_APP_TOOL_NAME = "run_dust_app" as const;
+
+/**
+ * Tools metadata for run_dust_app server.
+ *
+ * This server is special because the actual tool is dynamically created based on
+ * the Dust app configuration. The "run_dust_app" tool here is used for the
+ * configuration flow where users select which Dust app to run.
+ */
+export const RUN_DUST_APP_TOOLS_METADATA = createToolsRecord({
+  run_dust_app: {
+    description: "Run a Dust App with specified parameters.",
+    schema: {
+      dustApp:
+        ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_APP],
+    },
+    stake: "never_ask",
+  },
+});
+
+export const RUN_DUST_APP_SERVER = {
+  serverInfo: {
+    name: "run_dust_app" as const,
+    version: "1.0.0",
+    description: "Run Dust Apps with specified parameters.",
+    icon: "CommandLineIcon" as const,
+    authorization: null,
+    documentationUrl: null,
+    instructions: null,
+  },
+  tools: Object.values(RUN_DUST_APP_TOOLS_METADATA).map((t) => ({
+    name: t.name,
+    description: t.description,
+    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+  })),
+  tools_stakes: Object.fromEntries(
+    Object.values(RUN_DUST_APP_TOOLS_METADATA).map((t) => [t.name, t.stake])
+  ),
+} as const satisfies ServerMetadata;


### PR DESCRIPTION
## Description

- Move run_dust_app server to lib/api/actions/servers/run_dust_app/
- Separate metadata (metadata.ts) from implementation (index.ts)
- Extract helper functions to helpers.ts
- Update constants.ts to use metadata import
- Update servers/index.ts to import from new location
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
