### PR TITLE
feat: Dust mobile app (React Native/Expo iOS)

### DIFF
--- a/x/henry/dust-mobile/.gitignore
+++ b/x/henry/dust-mobile/.gitignore
@@ -1,0 +1,41 @@
+node_modules/
+.expo/
+dist/
+ios/
+android/
+*.jks
+*.p8
+*.p12
+*.key
+*.mobileprovision
+*.orig.*
+web-build/
+.env
+.env.local
+
+# Xcode
+*.xcworkspace
+*.xcodeproj
+DerivedData/
+build/
+*.pbxuser
+*.mode1v3
+*.mode2v3
+*.perspectivev3
+*.hmap
+*.ipa
+*.dSYM.zip
+*.dSYM
+
+# CocoaPods
+Pods/
+
+# Metro
+.metro-health-check*
+
+# macOS
+.DS_Store
+*.pem
+
+# Package lock (use npm install from package.json)
+package-lock.json

--- a/x/henry/dust-mobile/App.tsx
+++ b/x/henry/dust-mobile/App.tsx
@@ -1,0 +1,28 @@
+// Polyfills must be imported first
+import "./src/polyfills";
+import "react-native-gesture-handler";
+
+import React from "react";
+import { GestureHandlerRootView } from "react-native-gesture-handler";
+import { SafeAreaProvider } from "react-native-safe-area-context";
+import { StyleSheet } from "react-native";
+import { AuthProvider } from "./src/context/AuthContext";
+import { RootNavigator } from "./src/navigation/RootNavigator";
+
+export default function App() {
+  return (
+    <GestureHandlerRootView style={styles.container}>
+      <SafeAreaProvider>
+        <AuthProvider>
+          <RootNavigator />
+        </AuthProvider>
+      </SafeAreaProvider>
+    </GestureHandlerRootView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+});

--- a/x/henry/dust-mobile/CLAUDE.md
+++ b/x/henry/dust-mobile/CLAUDE.md
@@ -1,0 +1,51 @@
+# Dust Mobile App
+
+React Native (Expo) iOS app. Chat-only MVP using `@dust-tt/client` SDK.
+
+## Build & Run
+
+```bash
+npm install
+npx expo prebuild --platform ios --clean
+npx expo run:ios
+```
+
+After first build, use `npx expo start --dev-client` to just start Metro.
+
+## Type Check
+
+```bash
+npx tsc --noEmit
+```
+
+## Project Structure
+
+- `App.tsx` — Root: polyfills + providers + navigation
+- `src/services/auth.ts` — OAuth PKCE flow (expo-web-browser + expo-crypto), token refresh
+- `src/services/storage.ts` — SecureStore (tokens), MMKV (user data)
+- `src/hooks/` — React hooks for SDK integration (useDustAPI, useConversations, useStreamingMessage, useSubmitMessage)
+- `src/lib/sseStream.ts` — EventSourcePolyfill-based SSE transport (bypasses SDK's ReadableStream requirement)
+- `src/lib/messageReducer.ts` — Agent message state machine (thinking/acting/writing/done)
+- `src/navigation/` — React Navigation stack with auth guard
+- `src/screens/` — Login, WorkspaceSelection, ConversationList, Conversation
+- `src/components/` — MessageList, AgentMessage, InputBar, AgentPicker, etc.
+
+## Key Architecture Decisions
+
+- **No Expo Go** — requires EAS Build / custom dev client (native modules: MMKV, gesture-handler)
+- **New Architecture enabled** — required by react-native-mmkv 3.x
+- **Buffer polyfill** — must load before any `@dust-tt/client` import (SDK uses `z.instanceof(Buffer)`)
+- **SSE via EventSourcePolyfill** — SDK's `streamAgentMessageEvents` needs ReadableStream (unavailable in RN); we use XHR-based SSE with manual reconnect instead
+- **Token refresh** — proactive (60s before expiry), deduplicates concurrent refresh calls, in-memory cache for hot-path reads
+- **OAuth redirect** — `dust://auth/callback` (registered in WorkOS)
+
+## SDK Integration
+
+The app links `@dust-tt/client` from `../../../sdks/js` via Metro's `watchFolders`. If SDK types change, Metro picks them up automatically.
+
+## Common Issues
+
+- **"Buffer is not defined"** — polyfills.ts must be imported first in App.tsx
+- **MMKV TurboModules error** — ensure `newArchEnabled: true` in app.json
+- **"main" not registered** — package.json `main` must be `"expo/AppEntry"`
+- **Metro can't resolve SDK deps** — install `eventsource-parser` and `zod` in this package

--- a/x/henry/dust-mobile/README.md
+++ b/x/henry/dust-mobile/README.md
@@ -1,0 +1,51 @@
+# Dust Mobile
+
+React Native (Expo) iOS app for Dust. Chat-only MVP using `@dust-tt/client` SDK with OAuth PKCE authentication.
+
+## Prerequisites
+
+- Node.js >= 20
+- Xcode with iOS Simulator (not compatible with Expo Go — requires custom dev client)
+- `sudo xcode-select -s /Applications/Xcode.app/Contents/Developer`
+
+## Setup
+
+```bash
+npm install
+```
+
+## Running
+
+```bash
+# Generate native project + build + run on simulator
+npx expo prebuild --platform ios --clean
+npx expo run:ios
+
+# Or after first build, just start Metro
+npx expo start --dev-client
+```
+
+## Auth
+
+Uses OAuth PKCE flow via `expo-web-browser`. The redirect URI `dust://auth/callback` must be registered in the WorkOS dashboard.
+
+## Architecture
+
+```
+src/
+├── services/       # Auth (OAuth PKCE, token refresh), storage (SecureStore, MMKV)
+├── context/        # AuthContext provider
+├── hooks/          # useDustAPI, useConversations, useStreamingMessage, useSubmitMessage
+├── lib/            # messageReducer, SSE stream transport, SWR config
+├── navigation/     # React Navigation (auth guard → main stack)
+├── screens/        # Login, WorkspaceSelection, ConversationList, Conversation
+├── components/     # MessageList, AgentMessage, InputBar, AgentPicker, etc.
+└── types/          # Shared TypeScript types
+```
+
+### Key decisions
+
+- **Streaming**: Uses `EventSourcePolyfill` (XHR-based SSE) instead of the SDK's `streamAgentMessageEvents` (which requires ReadableStream, unavailable in RN)
+- **Token refresh**: Proactive refresh 60s before expiry, deduplicates concurrent refresh calls
+- **New Architecture**: Enabled (`newArchEnabled: true`) for react-native-mmkv 3.x compatibility
+- **Polyfills**: `Buffer` polyfilled globally before SDK import (required by SDK's Zod schemas)

--- a/x/henry/dust-mobile/app.json
+++ b/x/henry/dust-mobile/app.json
@@ -1,0 +1,19 @@
+{
+  "expo": {
+    "name": "Dust",
+    "slug": "dust-mobile",
+    "version": "0.1.0",
+    "orientation": "portrait",
+    "scheme": "dust",
+    "newArchEnabled": true,
+    "ios": {
+      "bundleIdentifier": "com.dust.mobile",
+      "supportsTablet": false
+    },
+    "plugins": [
+      "expo-secure-store",
+      "expo-asset",
+      "expo-font"
+    ]
+  }
+}

--- a/x/henry/dust-mobile/babel.config.js
+++ b/x/henry/dust-mobile/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ["babel-preset-expo"],
+  };
+};

--- a/x/henry/dust-mobile/eas.json
+++ b/x/henry/dust-mobile/eas.json
@@ -1,0 +1,18 @@
+{
+  "cli": {
+    "version": ">= 12.0.0"
+  },
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal",
+      "ios": {
+        "simulator": true
+      }
+    },
+    "preview": {
+      "distribution": "internal"
+    },
+    "production": {}
+  }
+}

--- a/x/henry/dust-mobile/metro.config.js
+++ b/x/henry/dust-mobile/metro.config.js
@@ -1,0 +1,19 @@
+const { getDefaultConfig } = require("expo/metro-config");
+const path = require("path");
+
+const config = getDefaultConfig(__dirname);
+const sdkPath = path.resolve(__dirname, "../../../sdks/js");
+const rootPath = path.resolve(__dirname, "../../..");
+
+config.watchFolders = [sdkPath, rootPath];
+config.resolver.nodeModulesPaths = [
+  path.resolve(__dirname, "node_modules"),
+  path.resolve(rootPath, "node_modules"),
+];
+// Ensure single copies of react/react-native
+config.resolver.extraNodeModules = {
+  react: path.resolve(__dirname, "node_modules/react"),
+  "react-native": path.resolve(__dirname, "node_modules/react-native"),
+};
+
+module.exports = config;

--- a/x/henry/dust-mobile/package.json
+++ b/x/henry/dust-mobile/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "dust-mobile",
+  "version": "0.1.0",
+  "private": true,
+  "main": "expo/AppEntry",
+  "scripts": {
+    "start": "expo start --dev-client",
+    "ios": "expo run:ios",
+    "build:dev": "eas build --profile development --platform ios",
+    "build:preview": "eas build --profile preview --platform ios",
+    "android": "expo run:android"
+  },
+  "dependencies": {
+    "@dust-tt/client": "file:../../../sdks/js",
+    "@react-navigation/native": "^7.0.0",
+    "@react-navigation/native-stack": "^7.0.0",
+    "buffer": "^6.0.3",
+    "event-source-polyfill": "^1.0.31",
+    "eventsource-parser": "^3.0.6",
+    "expo": "~52.0.0",
+    "expo-asset": "~11.0.5",
+    "expo-auth-session": "~6.0.0",
+    "expo-constants": "~17.0.8",
+    "expo-crypto": "~14.0.0",
+    "expo-dev-client": "~5.0.0",
+    "expo-file-system": "~18.0.12",
+    "expo-font": "~13.0.4",
+    "expo-keep-awake": "~14.0.3",
+    "expo-secure-store": "~14.0.0",
+    "expo-web-browser": "~14.0.0",
+    "jwt-decode": "^4.0.0",
+    "react": "18.3.1",
+    "react-native": "0.76.6",
+    "react-native-gesture-handler": "~2.20.0",
+    "react-native-markdown-display": "^7.0.2",
+    "react-native-mmkv": "^3.2.0",
+    "react-native-safe-area-context": "4.14.0",
+    "react-native-screens": "~4.4.0",
+    "swr": "^2.2.5",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.25.0",
+    "@types/event-source-polyfill": "^1.0.5",
+    "@types/react": "~18.3.0",
+    "typescript": "~5.3.0"
+  }
+}

--- a/x/henry/dust-mobile/src/components/ActionDisplay.tsx
+++ b/x/henry/dust-mobile/src/components/ActionDisplay.tsx
@@ -1,0 +1,97 @@
+import React, { memo, useState } from "react";
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  StyleSheet,
+  ActivityIndicator,
+} from "react-native";
+
+type ActionType = {
+  toolName: string;
+  functionCallName: string;
+  status: string;
+  params: Record<string, unknown>;
+  [key: string]: unknown;
+};
+
+type Props = {
+  action: ActionType;
+  isActive: boolean;
+};
+
+function getActionLabel(action: ActionType): string {
+  const name = action.functionCallName || action.toolName;
+  // Format function_name to "Function name"
+  return name.replace(/_/g, " ").replace(/^\w/, (c) => c.toUpperCase());
+}
+
+export const ActionDisplay = memo(function ActionDisplay({
+  action,
+  isActive,
+}: Props) {
+  const [expanded, setExpanded] = useState(false);
+  const label = getActionLabel(action);
+
+  return (
+    <View style={styles.container}>
+      <TouchableOpacity
+        style={styles.header}
+        onPress={() => setExpanded(!expanded)}
+      >
+        {isActive ? (
+          <ActivityIndicator size="small" color="#666" />
+        ) : (
+          <Text style={styles.checkmark}>✓</Text>
+        )}
+        <Text style={styles.label}>{label}</Text>
+        <Text style={styles.chevron}>{expanded ? "▼" : "▶"}</Text>
+      </TouchableOpacity>
+
+      {expanded && (
+        <View style={styles.details}>
+          <Text style={styles.detailText}>
+            {JSON.stringify(action, null, 2).slice(0, 500)}
+          </Text>
+        </View>
+      )}
+    </View>
+  );
+});
+
+const styles = StyleSheet.create({
+  container: {
+    marginBottom: 6,
+    borderRadius: 8,
+    backgroundColor: "#f8f8f8",
+    overflow: "hidden",
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    padding: 8,
+    gap: 8,
+  },
+  checkmark: {
+    fontSize: 14,
+    color: "#4caf50",
+  },
+  label: {
+    fontSize: 14,
+    color: "#444",
+    flex: 1,
+  },
+  chevron: {
+    fontSize: 10,
+    color: "#999",
+  },
+  details: {
+    padding: 8,
+    paddingTop: 0,
+  },
+  detailText: {
+    fontSize: 12,
+    color: "#666",
+    fontFamily: "monospace",
+  },
+});

--- a/x/henry/dust-mobile/src/components/AgentMessage.tsx
+++ b/x/henry/dust-mobile/src/components/AgentMessage.tsx
@@ -1,0 +1,158 @@
+import React, { memo } from "react";
+import { View, Text, StyleSheet, ActivityIndicator, Platform } from "react-native";
+import Markdown from "react-native-markdown-display";
+import type { AgentMessagePublicType } from "@dust-tt/client";
+import type { MessageTemporaryState } from "../types";
+import { ActionDisplay } from "./ActionDisplay";
+
+type Props = {
+  message: AgentMessagePublicType;
+  streamingState: MessageTemporaryState | null;
+};
+
+export const AgentMessage = memo(function AgentMessage({
+  message,
+  streamingState,
+}: Props) {
+  const agentState = streamingState?.agentState;
+  const content = message.content || "";
+  const hasActions = message.actions && message.actions.length > 0;
+
+  return (
+    <View style={styles.container}>
+      {/* Agent name */}
+      <Text style={styles.agentName}>
+        {message.configuration.name}
+      </Text>
+
+      {/* Thinking indicator */}
+      {agentState === "thinking" && (
+        <View style={styles.statusRow}>
+          <ActivityIndicator size="small" color="#666" />
+          <Text style={styles.statusText}>Thinking...</Text>
+        </View>
+      )}
+
+      {/* Actions */}
+      {hasActions &&
+        message.actions.map((action, idx) => (
+          <ActionDisplay
+            key={`action-${idx}`}
+            action={action as unknown as React.ComponentProps<typeof ActionDisplay>["action"]}
+            isActive={agentState === "acting"}
+          />
+        ))}
+
+      {/* Acting indicator (when no content yet) */}
+      {agentState === "acting" && !content && (
+        <View style={styles.statusRow}>
+          <ActivityIndicator size="small" color="#666" />
+          <Text style={styles.statusText}>Working...</Text>
+        </View>
+      )}
+
+      {/* Content */}
+      {content ? (
+        <View style={styles.contentContainer}>
+          <Markdown style={markdownStyles}>{content}</Markdown>
+          {agentState === "writing" && (
+            <View style={styles.cursor} />
+          )}
+        </View>
+      ) : null}
+
+      {/* Error state */}
+      {message.status === "failed" && message.error && (
+        <View style={styles.errorContainer}>
+          <Text style={styles.errorText}>{message.error.message}</Text>
+        </View>
+      )}
+
+      {/* Cancelled state */}
+      {message.status === "cancelled" && (
+        <Text style={styles.cancelledText}>Generation cancelled</Text>
+      )}
+    </View>
+  );
+});
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: "flex-start",
+    maxWidth: "90%",
+  },
+  agentName: {
+    fontSize: 13,
+    fontWeight: "600",
+    color: "#666",
+    marginBottom: 4,
+  },
+  statusRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginBottom: 8,
+    gap: 6,
+  },
+  statusText: {
+    fontSize: 14,
+    color: "#666",
+    fontStyle: "italic",
+  },
+  contentContainer: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    alignItems: "flex-end",
+  },
+  cursor: {
+    width: 2,
+    height: 18,
+    backgroundColor: "#000",
+    marginLeft: 1,
+    opacity: 0.7,
+  },
+  errorContainer: {
+    backgroundColor: "#fee",
+    borderRadius: 8,
+    padding: 10,
+    marginTop: 4,
+  },
+  errorText: {
+    color: "#c53030",
+    fontSize: 14,
+  },
+  cancelledText: {
+    fontSize: 13,
+    color: "#999",
+    fontStyle: "italic",
+    marginTop: 4,
+  },
+});
+
+const markdownStyles = StyleSheet.create({
+  body: {
+    fontSize: 16,
+    lineHeight: 24,
+    color: "#1a1a1a",
+  },
+  code_inline: {
+    backgroundColor: "#f0f0f0",
+    borderRadius: 4,
+    paddingHorizontal: 4,
+    fontSize: 14,
+    fontFamily: Platform.OS === "ios" ? "Menlo" : "monospace",
+  },
+  code_block: {
+    backgroundColor: "#f5f5f5",
+    borderRadius: 8,
+    padding: 12,
+    fontSize: 14,
+    fontFamily: Platform.OS === "ios" ? "Menlo" : "monospace",
+  },
+  fence: {
+    backgroundColor: "#f5f5f5",
+    borderRadius: 8,
+    padding: 12,
+    fontSize: 14,
+    fontFamily: Platform.OS === "ios" ? "Menlo" : "monospace",
+  },
+});

--- a/x/henry/dust-mobile/src/components/AgentPicker.tsx
+++ b/x/henry/dust-mobile/src/components/AgentPicker.tsx
@@ -1,0 +1,140 @@
+import React, { useState, useMemo } from "react";
+import {
+  View,
+  Text,
+  FlatList,
+  TextInput,
+  TouchableOpacity,
+  StyleSheet,
+  Modal,
+  Pressable,
+} from "react-native";
+import { useAgentConfigurations } from "../hooks/useAgentConfigurations";
+import type { LightAgentConfigurationType } from "@dust-tt/client";
+
+type Props = {
+  onSelect: (agent: LightAgentConfigurationType) => void;
+  onClose: () => void;
+};
+
+export function AgentPicker({ onSelect, onClose }: Props) {
+  const { agents, isLoading } = useAgentConfigurations();
+  const [search, setSearch] = useState("");
+
+  const filtered = useMemo(() => {
+    if (!search.trim()) return agents;
+    const q = search.toLowerCase();
+    return agents.filter(
+      (a) =>
+        a.name.toLowerCase().includes(q) ||
+        (a.description ?? "").toLowerCase().includes(q)
+    );
+  }, [agents, search]);
+
+  return (
+    <Modal
+      visible
+      animationType="slide"
+      presentationStyle="pageSheet"
+      onRequestClose={onClose}
+    >
+      <View style={styles.container}>
+        <View style={styles.header}>
+          <Text style={styles.title}>Select an agent</Text>
+          <Pressable onPress={onClose}>
+            <Text style={styles.closeText}>Cancel</Text>
+          </Pressable>
+        </View>
+
+        <TextInput
+          style={styles.searchInput}
+          placeholder="Search agents..."
+          value={search}
+          onChangeText={setSearch}
+          placeholderTextColor="#999"
+          autoFocus
+        />
+
+        <FlatList
+          data={filtered}
+          keyExtractor={(item) => item.sId}
+          renderItem={({ item }) => (
+            <TouchableOpacity
+              style={styles.row}
+              onPress={() => onSelect(item)}
+            >
+              <Text style={styles.agentName}>@{item.name}</Text>
+              {item.description && (
+                <Text style={styles.agentDesc} numberOfLines={2}>
+                  {item.description}
+                </Text>
+              )}
+            </TouchableOpacity>
+          )}
+          contentContainerStyle={styles.list}
+          ListEmptyComponent={
+            <Text style={styles.emptyText}>
+              {isLoading ? "Loading agents..." : "No agents found"}
+            </Text>
+          }
+        />
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#fff",
+  },
+  header: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    paddingHorizontal: 16,
+    paddingTop: 16,
+    paddingBottom: 8,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: "700",
+  },
+  closeText: {
+    fontSize: 16,
+    color: "#666",
+  },
+  searchInput: {
+    marginHorizontal: 16,
+    marginBottom: 8,
+    backgroundColor: "#f0f0f0",
+    borderRadius: 10,
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+    fontSize: 16,
+  },
+  list: {
+    paddingHorizontal: 16,
+  },
+  row: {
+    paddingVertical: 12,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: "#e8e8e8",
+  },
+  agentName: {
+    fontSize: 16,
+    fontWeight: "600",
+    color: "#000",
+  },
+  agentDesc: {
+    fontSize: 14,
+    color: "#666",
+    marginTop: 2,
+  },
+  emptyText: {
+    textAlign: "center",
+    color: "#999",
+    paddingTop: 32,
+    fontSize: 16,
+  },
+});

--- a/x/henry/dust-mobile/src/components/ConversationRow.tsx
+++ b/x/henry/dust-mobile/src/components/ConversationRow.tsx
@@ -1,0 +1,64 @@
+import React, { memo } from "react";
+import { View, Text, TouchableOpacity, StyleSheet } from "react-native";
+
+type ConversationSummary = {
+  sId: string;
+  title: string | null;
+  created: number;
+};
+
+type Props = {
+  conversation: ConversationSummary;
+  onPress: () => void;
+};
+
+function formatDate(timestamp: number): string {
+  const date = new Date(timestamp);
+  const now = new Date();
+  const diff = now.getTime() - date.getTime();
+  const days = Math.floor(diff / (1000 * 60 * 60 * 24));
+
+  if (days === 0) return "Today";
+  if (days === 1) return "Yesterday";
+  if (days < 7) return `${days}d ago`;
+  return date.toLocaleDateString();
+}
+
+export const ConversationRow = memo(function ConversationRow({
+  conversation,
+  onPress,
+}: Props) {
+  return (
+    <TouchableOpacity style={styles.row} onPress={onPress}>
+      <View style={styles.content}>
+        <Text style={styles.title} numberOfLines={1}>
+          {conversation.title || "New conversation"}
+        </Text>
+        <Text style={styles.date}>{formatDate(conversation.created)}</Text>
+      </View>
+    </TouchableOpacity>
+  );
+});
+
+const styles = StyleSheet.create({
+  row: {
+    paddingVertical: 14,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: "#e8e8e8",
+  },
+  content: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+  },
+  title: {
+    fontSize: 16,
+    fontWeight: "500",
+    flex: 1,
+    marginRight: 12,
+  },
+  date: {
+    fontSize: 13,
+    color: "#999",
+  },
+});

--- a/x/henry/dust-mobile/src/components/InputBar.tsx
+++ b/x/henry/dust-mobile/src/components/InputBar.tsx
@@ -1,0 +1,191 @@
+import React, { useState, useCallback, useRef } from "react";
+import {
+  View,
+  TextInput,
+  TouchableOpacity,
+  Text,
+  StyleSheet,
+} from "react-native";
+import type { AgentMentionType, LightAgentConfigurationType } from "@dust-tt/client";
+import { MentionBadge } from "./MentionBadge";
+import { AgentPicker } from "./AgentPicker";
+
+type Props = {
+  onSend: (content: string, mentions: AgentMentionType[]) => void;
+  onCancel: () => void;
+  isStreaming: boolean;
+  isSubmitting: boolean;
+  initialAgentId?: string;
+};
+
+export function InputBar({
+  onSend,
+  onCancel,
+  isStreaming,
+  isSubmitting,
+  initialAgentId,
+}: Props) {
+  const [text, setText] = useState("");
+  const [mentions, setMentions] = useState<
+    { configurationId: string; name: string }[]
+  >(initialAgentId ? [{ configurationId: initialAgentId, name: "" }] : []);
+  const [showPicker, setShowPicker] = useState(false);
+  const inputRef = useRef<TextInput>(null);
+
+  const handleSend = useCallback(() => {
+    const trimmed = text.trim();
+    if (!trimmed && mentions.length === 0) return;
+
+    const agentMentions: AgentMentionType[] = mentions.map((m) => ({
+      configurationId: m.configurationId,
+    }));
+
+    onSend(trimmed, agentMentions);
+    setText("");
+    setMentions([]);
+  }, [text, mentions, onSend]);
+
+  const handleTextChange = useCallback(
+    (value: string) => {
+      setText(value);
+      // Detect @ trigger
+      if (value.endsWith("@")) {
+        setShowPicker(true);
+      }
+    },
+    []
+  );
+
+  const handleAgentSelect = useCallback(
+    (agent: LightAgentConfigurationType) => {
+      setShowPicker(false);
+      setMentions((prev) => [
+        ...prev,
+        { configurationId: agent.sId, name: agent.name },
+      ]);
+      // Remove trailing @ from text
+      setText((prev) => (prev.endsWith("@") ? prev.slice(0, -1) : prev));
+      inputRef.current?.focus();
+    },
+    []
+  );
+
+  const handleRemoveMention = useCallback((index: number) => {
+    setMentions((prev) => prev.filter((_, i) => i !== index));
+  }, []);
+
+  const disabled = isStreaming || isSubmitting;
+
+  return (
+    <View style={styles.container}>
+      {/* Mention badges */}
+      {mentions.length > 0 && (
+        <View style={styles.mentionsRow}>
+          {mentions.map((m, idx) => (
+            <MentionBadge
+              key={`${m.configurationId}-${idx}`}
+              name={m.name || "Agent"}
+              onRemove={() => handleRemoveMention(idx)}
+            />
+          ))}
+        </View>
+      )}
+
+      <View style={styles.inputRow}>
+        <TextInput
+          ref={inputRef}
+          style={styles.input}
+          value={text}
+          onChangeText={handleTextChange}
+          placeholder="Message..."
+          placeholderTextColor="#999"
+          multiline
+          maxLength={32000}
+          editable={!disabled}
+        />
+
+        {isStreaming ? (
+          <TouchableOpacity style={styles.cancelButton} onPress={onCancel}>
+            <Text style={styles.cancelText}>Stop</Text>
+          </TouchableOpacity>
+        ) : (
+          <TouchableOpacity
+            style={[
+              styles.sendButton,
+              (!text.trim() && mentions.length === 0) && styles.sendButtonDisabled,
+            ]}
+            onPress={handleSend}
+            disabled={!text.trim() && mentions.length === 0}
+          >
+            <Text style={styles.sendText}>↑</Text>
+          </TouchableOpacity>
+        )}
+      </View>
+
+      {showPicker && (
+        <AgentPicker
+          onSelect={handleAgentSelect}
+          onClose={() => setShowPicker(false)}
+        />
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: "#e0e0e0",
+    backgroundColor: "#fff",
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    paddingBottom: 12,
+  },
+  mentionsRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    marginBottom: 6,
+  },
+  inputRow: {
+    flexDirection: "row",
+    alignItems: "flex-end",
+    gap: 8,
+  },
+  input: {
+    flex: 1,
+    fontSize: 16,
+    maxHeight: 120,
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    backgroundColor: "#f5f5f5",
+    borderRadius: 20,
+    lineHeight: 22,
+  },
+  sendButton: {
+    width: 34,
+    height: 34,
+    borderRadius: 17,
+    backgroundColor: "#000",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  sendButtonDisabled: {
+    backgroundColor: "#ccc",
+  },
+  sendText: {
+    color: "#fff",
+    fontSize: 18,
+    fontWeight: "600",
+  },
+  cancelButton: {
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    backgroundColor: "#e53e3e",
+    borderRadius: 17,
+  },
+  cancelText: {
+    color: "#fff",
+    fontSize: 14,
+    fontWeight: "600",
+  },
+});

--- a/x/henry/dust-mobile/src/components/MentionBadge.tsx
+++ b/x/henry/dust-mobile/src/components/MentionBadge.tsx
@@ -1,0 +1,45 @@
+import React, { memo } from "react";
+import { View, Text, TouchableOpacity, StyleSheet } from "react-native";
+
+type Props = {
+  name: string;
+  onRemove: () => void;
+};
+
+export const MentionBadge = memo(function MentionBadge({
+  name,
+  onRemove,
+}: Props) {
+  return (
+    <View style={styles.badge}>
+      <Text style={styles.text}>@{name}</Text>
+      <TouchableOpacity onPress={onRemove} hitSlop={8}>
+        <Text style={styles.remove}>×</Text>
+      </TouchableOpacity>
+    </View>
+  );
+});
+
+const styles = StyleSheet.create({
+  badge: {
+    flexDirection: "row",
+    alignItems: "center",
+    backgroundColor: "#e8e8e8",
+    borderRadius: 12,
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    marginRight: 4,
+    marginBottom: 4,
+  },
+  text: {
+    fontSize: 14,
+    color: "#333",
+    fontWeight: "500",
+  },
+  remove: {
+    fontSize: 18,
+    color: "#999",
+    marginLeft: 4,
+    lineHeight: 18,
+  },
+});

--- a/x/henry/dust-mobile/src/components/MessageList.tsx
+++ b/x/henry/dust-mobile/src/components/MessageList.tsx
@@ -1,0 +1,79 @@
+import React, { memo } from "react";
+import { FlatList, StyleSheet, View } from "react-native";
+import type { ConversationPublicType } from "@dust-tt/client";
+import type { MessageTemporaryState } from "../types";
+import { UserMessage } from "./UserMessage";
+import { AgentMessage } from "./AgentMessage";
+
+type Props = {
+  conversation?: ConversationPublicType;
+  streamingState: MessageTemporaryState | null;
+};
+
+type MessageItem = {
+  key: string;
+  type: "user_message" | "agent_message";
+  message: unknown;
+  isStreaming: boolean;
+  streamingState: MessageTemporaryState | null;
+};
+
+export const MessageList = memo(function MessageList({
+  conversation,
+  streamingState,
+}: Props) {
+  const messages: MessageItem[] = [];
+
+  if (conversation?.content) {
+    for (const versions of conversation.content) {
+      const latest = versions[versions.length - 1];
+      if (!latest) continue;
+
+      const isStreamingThis =
+        latest.type === "agent_message" &&
+        streamingState?.message.sId === latest.sId;
+
+      messages.push({
+        key: latest.sId,
+        type: latest.type as "user_message" | "agent_message",
+        message: isStreamingThis ? streamingState.message : latest,
+        isStreaming: isStreamingThis,
+        streamingState: isStreamingThis ? streamingState : null,
+      });
+    }
+  }
+
+  // Reverse for inverted FlatList (newest at bottom)
+  const invertedMessages = [...messages].reverse();
+
+  return (
+    <FlatList
+      data={invertedMessages}
+      inverted
+      keyExtractor={(item) => item.key}
+      renderItem={({ item }) => (
+        <View style={styles.messageWrapper}>
+          {item.type === "user_message" ? (
+            <UserMessage message={item.message as never} />
+          ) : (
+            <AgentMessage
+              message={item.message as never}
+              streamingState={item.streamingState}
+            />
+          )}
+        </View>
+      )}
+      contentContainerStyle={styles.list}
+    />
+  );
+});
+
+const styles = StyleSheet.create({
+  list: {
+    padding: 16,
+    paddingBottom: 8,
+  },
+  messageWrapper: {
+    marginBottom: 12,
+  },
+});

--- a/x/henry/dust-mobile/src/components/UserMessage.tsx
+++ b/x/henry/dust-mobile/src/components/UserMessage.tsx
@@ -1,0 +1,36 @@
+import React, { memo } from "react";
+import { View, Text, StyleSheet } from "react-native";
+import type { UserMessageType } from "@dust-tt/client";
+
+type Props = {
+  message: UserMessageType;
+};
+
+export const UserMessage = memo(function UserMessage({ message }: Props) {
+  return (
+    <View style={styles.container}>
+      <View style={styles.bubble}>
+        <Text style={styles.text}>{message.content}</Text>
+      </View>
+    </View>
+  );
+});
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: "flex-end",
+  },
+  bubble: {
+    backgroundColor: "#000",
+    borderRadius: 16,
+    borderBottomRightRadius: 4,
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+    maxWidth: "80%",
+  },
+  text: {
+    color: "#fff",
+    fontSize: 16,
+    lineHeight: 22,
+  },
+});

--- a/x/henry/dust-mobile/src/context/AuthContext.tsx
+++ b/x/henry/dust-mobile/src/context/AuthContext.tsx
@@ -1,0 +1,31 @@
+import React, { createContext, useContext } from "react";
+import { useAuth } from "../hooks/useAuth";
+import type { StoredUser } from "../types";
+import type { WorkspaceType } from "@dust-tt/client";
+
+type AuthContextType = {
+  user: StoredUser | null;
+  isAuthenticated: boolean;
+  isLoading: boolean;
+  authError: string | null;
+  handleLogin: (organizationId?: string) => Promise<void>;
+  handleLogout: () => Promise<void>;
+  handleSelectWorkspace: (workspace: WorkspaceType) => void;
+  selectedWorkspace: WorkspaceType | undefined;
+};
+
+const AuthContext = createContext<AuthContextType | null>(null);
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const auth = useAuth();
+
+  return <AuthContext.Provider value={auth}>{children}</AuthContext.Provider>;
+}
+
+export function useAuthContext(): AuthContextType {
+  const ctx = useContext(AuthContext);
+  if (!ctx) {
+    throw new Error("useAuthContext must be used within AuthProvider");
+  }
+  return ctx;
+}

--- a/x/henry/dust-mobile/src/hooks/useAgentConfigurations.ts
+++ b/x/henry/dust-mobile/src/hooks/useAgentConfigurations.ts
@@ -1,0 +1,36 @@
+import useSWR from "swr";
+import { useDustAPI } from "./useDustAPI";
+import { useCallback } from "react";
+import { useAppStateRevalidation, swrConfig } from "../lib/swr";
+import type { LightAgentConfigurationType } from "@dust-tt/client";
+
+export function useAgentConfigurations() {
+  const dustAPI = useDustAPI();
+
+  const { data, error, isLoading, mutate } = useSWR(
+    "agent-configurations",
+    async () => {
+      const result = await dustAPI.getAgentConfigurations({});
+      if (result.isErr()) {
+        throw new Error(result.error.message);
+      }
+      return result.value;
+    },
+    {
+      ...swrConfig,
+      dedupingInterval: 30000, // Agents don't change often
+    }
+  );
+
+  const revalidate = useCallback(() => {
+    mutate();
+  }, [mutate]);
+
+  useAppStateRevalidation(revalidate);
+
+  return {
+    agents: (data ?? []) as LightAgentConfigurationType[],
+    isLoading,
+    error,
+  };
+}

--- a/x/henry/dust-mobile/src/hooks/useAuth.ts
+++ b/x/henry/dust-mobile/src/hooks/useAuth.ts
@@ -1,0 +1,99 @@
+import { useState, useEffect, useCallback } from "react";
+import type { StoredUser } from "../types";
+import {
+  initiateLogin,
+  fetchUserAndWorkspaces,
+  getAccessToken,
+  logout as authLogout,
+  checkSSOEnforcement,
+} from "../services/auth";
+import { secureStorage, appStorage } from "../services/storage";
+import type { WorkspaceType } from "@dust-tt/client";
+
+export function useAuth() {
+  const [user, setUser] = useState<StoredUser | null>(null);
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const [authError, setAuthError] = useState<string | null>(null);
+
+  // Load persisted auth state on mount
+  useEffect(() => {
+    (async () => {
+      const storedUser = appStorage.getUser();
+      const tokens = await secureStorage.getTokens();
+
+      if (storedUser && tokens) {
+        setUser(storedUser);
+        setIsAuthenticated(true);
+
+        // Proactively refresh if near expiry
+        if (tokens.expiresAt < Date.now() + 60_000) {
+          await getAccessToken();
+        }
+      }
+      setIsLoading(false);
+    })();
+  }, []);
+
+  const handleLogin = useCallback(async (organizationId?: string) => {
+    setAuthError(null);
+    try {
+      const tokens = await initiateLogin(organizationId);
+      if (!tokens) {
+        setAuthError("Login was cancelled or failed.");
+        return;
+      }
+
+      const fetchedUser = await fetchUserAndWorkspaces(tokens.accessToken);
+      if (!fetchedUser) {
+        setAuthError("Failed to fetch user information.");
+        return;
+      }
+
+      setUser(fetchedUser);
+      setIsAuthenticated(true);
+    } catch (e) {
+      setAuthError(e instanceof Error ? e.message : "Login failed.");
+    }
+  }, []);
+
+  const handleSelectWorkspace = useCallback(
+    (workspace: WorkspaceType) => {
+      if (!user) return;
+
+      // Check SSO enforcement
+      if (!checkSSOEnforcement(user, workspace.sId)) {
+        // Re-trigger login with SSO organization_id
+        handleLogin(`workspace-${workspace.sId}`);
+        return;
+      }
+
+      const updatedUser: StoredUser = {
+        ...user,
+        selectedWorkspace: workspace.sId,
+      };
+      setUser(updatedUser);
+      appStorage.setUser(updatedUser);
+    },
+    [user, handleLogin]
+  );
+
+  const handleLogout = useCallback(async () => {
+    await authLogout();
+    setUser(null);
+    setIsAuthenticated(false);
+  }, []);
+
+  return {
+    user,
+    isAuthenticated,
+    isLoading,
+    authError,
+    handleLogin,
+    handleLogout,
+    handleSelectWorkspace,
+    selectedWorkspace: user?.workspaces.find(
+      (w) => w.sId === user.selectedWorkspace
+    ),
+  };
+}

--- a/x/henry/dust-mobile/src/hooks/useConversation.ts
+++ b/x/henry/dust-mobile/src/hooks/useConversation.ts
@@ -1,0 +1,35 @@
+import useSWR from "swr";
+import { useDustAPI } from "./useDustAPI";
+import { useCallback } from "react";
+import { useAppStateRevalidation, swrConfig } from "../lib/swr";
+import type { ConversationPublicType } from "@dust-tt/client";
+
+export function useConversation(conversationId: string | undefined) {
+  const dustAPI = useDustAPI();
+
+  const { data, error, isLoading, mutate } = useSWR(
+    conversationId ? `conversation-${conversationId}` : null,
+    async () => {
+      if (!conversationId) return null;
+      const result = await dustAPI.getConversation({ conversationId });
+      if (result.isErr()) {
+        throw new Error(result.error.message);
+      }
+      return result.value;
+    },
+    swrConfig
+  );
+
+  const revalidate = useCallback(() => {
+    mutate();
+  }, [mutate]);
+
+  useAppStateRevalidation(revalidate);
+
+  return {
+    conversation: data as ConversationPublicType | null | undefined,
+    isLoading,
+    error,
+    mutate,
+  };
+}

--- a/x/henry/dust-mobile/src/hooks/useConversations.ts
+++ b/x/henry/dust-mobile/src/hooks/useConversations.ts
@@ -1,0 +1,33 @@
+import useSWR from "swr";
+import { useDustAPI } from "./useDustAPI";
+import { useCallback } from "react";
+import { useAppStateRevalidation, swrConfig } from "../lib/swr";
+
+export function useConversations() {
+  const dustAPI = useDustAPI();
+
+  const { data, error, isLoading, mutate } = useSWR(
+    "conversations",
+    async () => {
+      const result = await dustAPI.getConversations();
+      if (result.isErr()) {
+        throw new Error(result.error.message);
+      }
+      return result.value;
+    },
+    swrConfig
+  );
+
+  const revalidate = useCallback(() => {
+    mutate();
+  }, [mutate]);
+
+  useAppStateRevalidation(revalidate);
+
+  return {
+    conversations: data ?? [],
+    isLoading,
+    error,
+    mutate,
+  };
+}

--- a/x/henry/dust-mobile/src/hooks/useDustAPI.ts
+++ b/x/henry/dust-mobile/src/hooks/useDustAPI.ts
@@ -1,0 +1,26 @@
+import { useMemo } from "react";
+import { DustAPI } from "@dust-tt/client";
+import { useAuthContext } from "../context/AuthContext";
+import { getAccessToken } from "../services/auth";
+
+export function useDustAPI(): DustAPI {
+  const { user, selectedWorkspace } = useAuthContext();
+
+  if (!user || !selectedWorkspace) {
+    throw new Error("useDustAPI: not authenticated or no workspace selected");
+  }
+
+  return useMemo(() => {
+    return new DustAPI(
+      { url: user.dustDomain },
+      {
+        apiKey: () => getAccessToken().then((t) => t ?? ""),
+        workspaceId: selectedWorkspace.sId,
+        extraHeaders: {
+          "X-Request-Origin": "mobile",
+        },
+      },
+      console
+    );
+  }, [user.dustDomain, selectedWorkspace.sId]);
+}

--- a/x/henry/dust-mobile/src/hooks/useStreamingMessage.ts
+++ b/x/henry/dust-mobile/src/hooks/useStreamingMessage.ts
@@ -1,0 +1,183 @@
+import { useState, useRef, useCallback, useEffect } from "react";
+import type { AgentMessagePublicType } from "@dust-tt/client";
+import { useAuthContext } from "../context/AuthContext";
+import { connectMessageStream, buildMessageEventsUrl } from "../lib/sseStream";
+import { messageReducer, createInitialState } from "../lib/messageReducer";
+import type { MessageTemporaryState } from "../types";
+import { useDustAPI } from "./useDustAPI";
+
+const TOKEN_THROTTLE_MS = 50;
+
+type StreamingState = {
+  isStreaming: boolean;
+  state: MessageTemporaryState | null;
+  error: Error | null;
+};
+
+export function useStreamingMessage() {
+  const { user, selectedWorkspace } = useAuthContext();
+  const dustAPI = useDustAPI();
+  const [streamingState, setStreamingState] = useState<StreamingState>({
+    isStreaming: false,
+    state: null,
+    error: null,
+  });
+
+  const streamHandle = useRef<{ close: () => void } | null>(null);
+  const tokenBuffer = useRef("");
+  const tokenFlushTimer = useRef<NodeJS.Timeout | null>(null);
+  const stateRef = useRef<MessageTemporaryState | null>(null);
+
+  const flushTokens = useCallback(() => {
+    if (tokenBuffer.current && stateRef.current) {
+      const event = {
+        type: "generation_tokens" as const,
+        classification: "tokens",
+        text: tokenBuffer.current,
+      };
+      const newState = messageReducer(stateRef.current, event);
+      stateRef.current = newState;
+      setStreamingState((s) => ({ ...s, state: newState }));
+      tokenBuffer.current = "";
+    }
+  }, []);
+
+  const startStreaming = useCallback(
+    (conversationId: string, agentMessage: AgentMessagePublicType) => {
+      if (!user || !selectedWorkspace) return;
+
+      // Clean up any existing stream
+      streamHandle.current?.close();
+      if (tokenFlushTimer.current) {
+        clearInterval(tokenFlushTimer.current);
+      }
+
+      const initialState = createInitialState(agentMessage);
+      stateRef.current = initialState;
+      setStreamingState({
+        isStreaming: true,
+        state: initialState,
+        error: null,
+      });
+
+      const url = buildMessageEventsUrl(
+        user.dustDomain,
+        selectedWorkspace.sId,
+        conversationId,
+        agentMessage.sId
+      );
+
+      // Set up token throttle flush
+      tokenFlushTimer.current = setInterval(flushTokens, TOKEN_THROTTLE_MS);
+
+      const handle = connectMessageStream({
+        url,
+        onEvent: (eventData) => {
+          const event = eventData as { type: string; [key: string]: unknown };
+
+          // Buffer generation tokens for throttling
+          if (
+            event.type === "generation_tokens" &&
+            event.classification === "tokens"
+          ) {
+            tokenBuffer.current += event.text as string;
+            return;
+          }
+
+          // Chain of thought tokens — also throttle
+          if (
+            event.type === "generation_tokens" &&
+            event.classification === "chain_of_thought"
+          ) {
+            if (stateRef.current) {
+              const newState = messageReducer(stateRef.current, event);
+              stateRef.current = newState;
+              setStreamingState((s) => ({ ...s, state: newState }));
+            }
+            return;
+          }
+
+          // Tool approval events — show message to use web app
+          if (
+            event.type === "tool_approve_execution" ||
+            event.type === "tool_personal_auth_required"
+          ) {
+            setStreamingState((s) => ({
+              ...s,
+              error: new Error(
+                "This agent requires action approval. Please use the web app to continue."
+              ),
+            }));
+            return;
+          }
+
+          // All other events — flush tokens first, then process
+          flushTokens();
+          if (stateRef.current) {
+            const newState = messageReducer(stateRef.current, event);
+            stateRef.current = newState;
+            setStreamingState((s) => ({ ...s, state: newState }));
+          }
+        },
+        onDone: () => {
+          flushTokens();
+          if (tokenFlushTimer.current) {
+            clearInterval(tokenFlushTimer.current);
+          }
+          setStreamingState((s) => ({ ...s, isStreaming: false }));
+        },
+        onError: (error) => {
+          flushTokens();
+          if (tokenFlushTimer.current) {
+            clearInterval(tokenFlushTimer.current);
+          }
+          setStreamingState((s) => ({
+            ...s,
+            isStreaming: false,
+            error,
+          }));
+        },
+      });
+
+      streamHandle.current = handle;
+    },
+    [user, selectedWorkspace, flushTokens]
+  );
+
+  const cancelStreaming = useCallback(
+    async (conversationId: string, messageId: string) => {
+      streamHandle.current?.close();
+      if (tokenFlushTimer.current) {
+        clearInterval(tokenFlushTimer.current);
+      }
+      flushTokens();
+      setStreamingState((s) => ({ ...s, isStreaming: false }));
+
+      try {
+        await dustAPI.cancelMessageGeneration({
+          conversationId,
+          messageIds: [messageId],
+        });
+      } catch {
+        // Best effort cancel
+      }
+    },
+    [dustAPI, flushTokens]
+  );
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      streamHandle.current?.close();
+      if (tokenFlushTimer.current) {
+        clearInterval(tokenFlushTimer.current);
+      }
+    };
+  }, []);
+
+  return {
+    ...streamingState,
+    startStreaming,
+    cancelStreaming,
+  };
+}

--- a/x/henry/dust-mobile/src/hooks/useSubmitMessage.ts
+++ b/x/henry/dust-mobile/src/hooks/useSubmitMessage.ts
@@ -1,0 +1,173 @@
+import { useState, useCallback } from "react";
+import { useDustAPI } from "./useDustAPI";
+import { useStreamingMessage } from "./useStreamingMessage";
+import { useAuthContext } from "../context/AuthContext";
+import type {
+  AgentMessagePublicType,
+  AgentMentionType,
+  ConversationPublicType,
+} from "@dust-tt/client";
+
+type SubmitState = {
+  isSubmitting: boolean;
+  error: string | null;
+};
+
+const POLL_DELAYS = [500, 1000, 2000, 2000, 3000];
+
+export function useSubmitMessage(
+  conversationId: string | undefined,
+  onConversationCreated?: (conversation: ConversationPublicType) => void
+) {
+  const dustAPI = useDustAPI();
+  const { user } = useAuthContext();
+  const streaming = useStreamingMessage();
+  const [submitState, setSubmitState] = useState<SubmitState>({
+    isSubmitting: false,
+    error: null,
+  });
+
+  const submit = useCallback(
+    async (content: string, mentions: AgentMentionType[]) => {
+      if (!user) return;
+
+      setSubmitState({ isSubmitting: true, error: null });
+
+      const messageContext = {
+        username: user.username ?? user.firstName ?? "user",
+        timezone: Intl.DateTimeFormat().resolvedOptions().timeZone ?? "UTC",
+        fullName: user.fullName ?? null,
+        email: user.email ?? null,
+        profilePictureUrl: user.image ?? null,
+        origin: "api" as const,
+      };
+
+      try {
+        if (!conversationId) {
+          // Create new conversation
+          const result = await dustAPI.createConversation({
+            visibility: "unlisted",
+            message: {
+              content,
+              mentions,
+              context: messageContext,
+            },
+            blocking: false,
+          });
+
+          if (result.isErr()) {
+            setSubmitState({
+              isSubmitting: false,
+              error: result.error.message,
+            });
+            return;
+          }
+
+          const { conversation, message: userMessage } = result.value;
+          onConversationCreated?.(conversation);
+
+          // Find the agent message that was created in response
+          const agentMessage = userMessage
+            ? findAgentMessage(conversation, userMessage.sId)
+            : null;
+
+          if (agentMessage) {
+            streaming.startStreaming(conversation.sId, agentMessage);
+          }
+        } else {
+          // Post to existing conversation
+          const result = await dustAPI.postUserMessage({
+            conversationId,
+            message: {
+              content,
+              mentions,
+              context: messageContext,
+            },
+          });
+
+          if (result.isErr()) {
+            setSubmitState({
+              isSubmitting: false,
+              error: result.error.message,
+            });
+            return;
+          }
+
+          const userMessage = result.value;
+
+          // Poll for agent message creation
+          const agentMessage = await pollForAgentMessage(
+            conversationId,
+            userMessage.sId
+          );
+
+          if (agentMessage) {
+            streaming.startStreaming(conversationId, agentMessage);
+          } else {
+            setSubmitState({
+              isSubmitting: false,
+              error: "Agent did not respond. Please try again.",
+            });
+            return;
+          }
+        }
+
+        setSubmitState({ isSubmitting: false, error: null });
+      } catch (e) {
+        setSubmitState({
+          isSubmitting: false,
+          error: e instanceof Error ? e.message : "Failed to send message",
+        });
+      }
+    },
+    [conversationId, dustAPI, user, streaming, onConversationCreated]
+  );
+
+  async function pollForAgentMessage(
+    convId: string,
+    userMessageSId: string
+  ): Promise<AgentMessagePublicType | null> {
+    for (const delay of POLL_DELAYS) {
+      await sleep(delay);
+
+      const result = await dustAPI.getConversation({
+        conversationId: convId,
+      });
+
+      if (result.isErr()) continue;
+
+      const conversation = result.value;
+      const agentMessage = findAgentMessage(conversation, userMessageSId);
+      if (agentMessage && agentMessage.status === "created") {
+        return agentMessage;
+      }
+    }
+    return null;
+  }
+
+  return {
+    submit,
+    ...submitState,
+    streaming,
+  };
+}
+
+function findAgentMessage(
+  conversation: ConversationPublicType,
+  userMessageSId: string
+): AgentMessagePublicType | null {
+  for (const versions of conversation.content) {
+    const latest = versions[versions.length - 1];
+    if (
+      latest.type === "agent_message" &&
+      latest.parentMessageId === userMessageSId
+    ) {
+      return latest;
+    }
+  }
+  return null;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/x/henry/dust-mobile/src/lib/messageReducer.ts
+++ b/x/henry/dust-mobile/src/lib/messageReducer.ts
@@ -1,0 +1,121 @@
+import type { AgentMessagePublicType } from "@dust-tt/client";
+import type { AgentStateClassification, MessageTemporaryState } from "../types";
+
+type AgentEvent = {
+  type: string;
+  [key: string]: unknown;
+};
+
+export function createInitialState(
+  message: AgentMessagePublicType
+): MessageTemporaryState {
+  return {
+    message,
+    agentState: message.status === "succeeded" ? "done" : "thinking",
+    lastUpdated: new Date(),
+  };
+}
+
+export function messageReducer(
+  state: MessageTemporaryState,
+  event: AgentEvent
+): MessageTemporaryState {
+  switch (event.type) {
+    case "generation_tokens": {
+      const classification = event.classification as string;
+      let message = { ...state.message };
+      let agentState: AgentStateClassification = state.agentState;
+
+      if (classification === "tokens") {
+        message = {
+          ...message,
+          content: (message.content || "") + (event.text as string),
+        };
+        agentState = "writing";
+      } else if (classification === "chain_of_thought") {
+        message = {
+          ...message,
+          chainOfThought:
+            (message.chainOfThought || "") + (event.text as string),
+        };
+        agentState = "thinking";
+      }
+
+      return { ...state, message, agentState, lastUpdated: new Date() };
+    }
+
+    case "agent_action_success": {
+      const action = event.action as AgentMessagePublicType["actions"][number];
+      const updatedActions = [...state.message.actions, action];
+      return {
+        ...state,
+        message: {
+          ...state.message,
+          actions: updatedActions,
+          status: "created",
+        },
+        lastUpdated: new Date(),
+      };
+    }
+
+    case "tool_params": {
+      return {
+        ...state,
+        agentState: "acting",
+        lastUpdated: new Date(),
+      };
+    }
+
+    case "tool_notification": {
+      return {
+        ...state,
+        agentState: "acting",
+        lastUpdated: new Date(),
+      };
+    }
+
+    case "agent_error":
+    case "tool_error": {
+      return {
+        ...state,
+        message: {
+          ...state.message,
+          status: "failed",
+          error: {
+            code: (event.error as { code?: string })?.code || "unknown",
+            message:
+              (event.error as { message?: string })?.message || "An error occurred",
+            metadata: null,
+          },
+        },
+        agentState: "done",
+        lastUpdated: new Date(),
+      };
+    }
+
+    case "agent_generation_cancelled": {
+      return {
+        ...state,
+        message: {
+          ...state.message,
+          status: "cancelled",
+        },
+        agentState: "done",
+        lastUpdated: new Date(),
+      };
+    }
+
+    case "agent_message_success": {
+      const successMessage = event.message as AgentMessagePublicType;
+      return {
+        ...state,
+        message: successMessage,
+        agentState: "done",
+        lastUpdated: new Date(),
+      };
+    }
+
+    default:
+      return state;
+  }
+}

--- a/x/henry/dust-mobile/src/lib/sseStream.ts
+++ b/x/henry/dust-mobile/src/lib/sseStream.ts
@@ -1,0 +1,138 @@
+import { EventSourcePolyfill } from "event-source-polyfill";
+import { getAccessToken } from "../services/auth";
+
+const MAX_RECONNECT_ATTEMPTS = 10;
+const RECONNECT_DELAY_MS = 5000;
+const HEARTBEAT_TIMEOUT_MS = 90000;
+
+type SSEStreamOptions = {
+  url: string;
+  onEvent: (data: unknown) => void;
+  onDone: () => void;
+  onError: (error: Error) => void;
+};
+
+type SSEStreamHandle = {
+  close: () => void;
+};
+
+const TERMINAL_EVENTS = new Set([
+  "agent_message_success",
+  "agent_error",
+  "agent_generation_cancelled",
+  "user_message_error",
+]);
+
+export function connectMessageStream(
+  options: SSEStreamOptions
+): SSEStreamHandle {
+  const { url, onEvent, onDone, onError } = options;
+
+  let source: EventSourcePolyfill | null = null;
+  let lastEventId: string | null = null;
+  let reconnectAttempts = 0;
+  let closed = false;
+
+  async function connect() {
+    if (closed) return;
+
+    const token = await getAccessToken();
+    if (!token) {
+      onError(new Error("No access token available"));
+      return;
+    }
+
+    const streamUrl = lastEventId
+      ? `${url}${url.includes("?") ? "&" : "?"}lastEventId=${encodeURIComponent(lastEventId)}`
+      : url;
+
+    source = new EventSourcePolyfill(streamUrl, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+      heartbeatTimeout: HEARTBEAT_TIMEOUT_MS,
+    });
+
+    source.onopen = () => {
+      reconnectAttempts = 0;
+    };
+
+    source.onmessage = (event: { data: string }) => {
+      if (closed) return;
+
+      // Server pagination signal — reconnect with fresh token
+      if (event.data === "done") {
+        source?.close();
+        reconnect();
+        return;
+      }
+
+      try {
+        const parsed = JSON.parse(event.data);
+        const eventData = parsed.data ?? parsed;
+        const eventId = parsed.eventId;
+
+        if (eventId) {
+          lastEventId = eventId;
+        }
+
+        // Skip server-side control events
+        if (eventData.type === "end-of-stream") {
+          return;
+        }
+
+        onEvent(eventData);
+
+        // Check for terminal events
+        if (TERMINAL_EVENTS.has(eventData.type)) {
+          source?.close();
+          onDone();
+        }
+      } catch {
+        // Skip unparseable events
+      }
+    };
+
+    source.onerror = () => {
+      if (closed) return;
+      source?.close();
+      reconnect();
+    };
+  }
+
+  function reconnect() {
+    if (closed) return;
+
+    reconnectAttempts++;
+    if (reconnectAttempts > MAX_RECONNECT_ATTEMPTS) {
+      onError(new Error("Max reconnection attempts reached"));
+      return;
+    }
+
+    setTimeout(() => {
+      if (!closed) {
+        connect();
+      }
+    }, RECONNECT_DELAY_MS);
+  }
+
+  function close() {
+    closed = true;
+    source?.close();
+    source = null;
+  }
+
+  // Start connection
+  connect();
+
+  return { close };
+}
+
+export function buildMessageEventsUrl(
+  dustDomain: string,
+  workspaceId: string,
+  conversationId: string,
+  messageId: string
+): string {
+  return `${dustDomain}/api/v1/w/${workspaceId}/assistant/conversations/${conversationId}/messages/${messageId}/events`;
+}

--- a/x/henry/dust-mobile/src/lib/swr.ts
+++ b/x/henry/dust-mobile/src/lib/swr.ts
@@ -1,0 +1,34 @@
+import { useEffect, useRef } from "react";
+import { AppState, type AppStateStatus } from "react-native";
+import type { SWRConfiguration } from "swr";
+
+export const swrConfig: SWRConfiguration = {
+  revalidateOnFocus: false, // No window focus events in RN
+  revalidateOnReconnect: true,
+  errorRetryCount: 3,
+  dedupingInterval: 2000,
+};
+
+/**
+ * Revalidate SWR data when app returns to foreground.
+ */
+export function useAppStateRevalidation(revalidate: () => void) {
+  const appState = useRef(AppState.currentState);
+
+  useEffect(() => {
+    const subscription = AppState.addEventListener(
+      "change",
+      (nextState: AppStateStatus) => {
+        if (
+          appState.current.match(/inactive|background/) &&
+          nextState === "active"
+        ) {
+          revalidate();
+        }
+        appState.current = nextState;
+      }
+    );
+
+    return () => subscription.remove();
+  }, [revalidate]);
+}

--- a/x/henry/dust-mobile/src/navigation/MainNavigator.tsx
+++ b/x/henry/dust-mobile/src/navigation/MainNavigator.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import { ConversationListScreen } from "../screens/ConversationListScreen";
+import { ConversationScreen } from "../screens/ConversationScreen";
+import type { MainStackParamList } from "./types";
+
+const Stack = createNativeStackNavigator<MainStackParamList>();
+
+export function MainNavigator() {
+  return (
+    <Stack.Navigator>
+      <Stack.Screen
+        name="ConversationList"
+        component={ConversationListScreen}
+        options={{ title: "Conversations" }}
+      />
+      <Stack.Screen
+        name="Conversation"
+        component={ConversationScreen}
+        options={{ title: "" }}
+      />
+    </Stack.Navigator>
+  );
+}

--- a/x/henry/dust-mobile/src/navigation/RootNavigator.tsx
+++ b/x/henry/dust-mobile/src/navigation/RootNavigator.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { NavigationContainer } from "@react-navigation/native";
+import { createNativeStackNavigator } from "@react-navigation/native-stack";
+import { ActivityIndicator, View, StyleSheet } from "react-native";
+import { useAuthContext } from "../context/AuthContext";
+import { LoginScreen } from "../screens/LoginScreen";
+import { WorkspaceSelectionScreen } from "../screens/WorkspaceSelectionScreen";
+import { MainNavigator } from "./MainNavigator";
+import type { RootStackParamList } from "./types";
+
+const Stack = createNativeStackNavigator<RootStackParamList>();
+
+export function RootNavigator() {
+  const { isAuthenticated, isLoading, selectedWorkspace } = useAuthContext();
+
+  if (isLoading) {
+    return (
+      <View style={styles.loading}>
+        <ActivityIndicator size="large" />
+      </View>
+    );
+  }
+
+  return (
+    <NavigationContainer>
+      <Stack.Navigator screenOptions={{ headerShown: false }}>
+        {!isAuthenticated ? (
+          <Stack.Screen name="Login" component={LoginScreen} />
+        ) : !selectedWorkspace ? (
+          <Stack.Screen
+            name="WorkspaceSelection"
+            component={WorkspaceSelectionScreen}
+          />
+        ) : (
+          <Stack.Screen name="Main" component={MainNavigator} />
+        )}
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  loading: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+});

--- a/x/henry/dust-mobile/src/navigation/types.ts
+++ b/x/henry/dust-mobile/src/navigation/types.ts
@@ -1,0 +1,35 @@
+import type { NativeStackScreenProps } from "@react-navigation/native-stack";
+
+export type RootStackParamList = {
+  Login: undefined;
+  WorkspaceSelection: undefined;
+  Main: undefined;
+};
+
+export type MainStackParamList = {
+  ConversationList: undefined;
+  Conversation: {
+    conversationId?: string;
+    agentId?: string;
+  };
+};
+
+export type LoginScreenProps = NativeStackScreenProps<
+  RootStackParamList,
+  "Login"
+>;
+
+export type WorkspaceSelectionScreenProps = NativeStackScreenProps<
+  RootStackParamList,
+  "WorkspaceSelection"
+>;
+
+export type ConversationListScreenProps = NativeStackScreenProps<
+  MainStackParamList,
+  "ConversationList"
+>;
+
+export type ConversationScreenProps = NativeStackScreenProps<
+  MainStackParamList,
+  "Conversation"
+>;

--- a/x/henry/dust-mobile/src/polyfills.ts
+++ b/x/henry/dust-mobile/src/polyfills.ts
@@ -1,0 +1,5 @@
+import { Buffer } from "buffer";
+
+// Must be loaded before any @dust-tt/client import.
+// The SDK uses z.instanceof(Buffer) at module init and Buffer.from() in file downloads.
+globalThis.Buffer = Buffer as unknown as typeof globalThis.Buffer;

--- a/x/henry/dust-mobile/src/screens/ConversationListScreen.tsx
+++ b/x/henry/dust-mobile/src/screens/ConversationListScreen.tsx
@@ -1,0 +1,150 @@
+import React, { useState, useCallback } from "react";
+import {
+  View,
+  Text,
+  FlatList,
+  TouchableOpacity,
+  TextInput,
+  StyleSheet,
+  RefreshControl,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { useConversations } from "../hooks/useConversations";
+import { ConversationRow } from "../components/ConversationRow";
+import { AgentPicker } from "../components/AgentPicker";
+import type { ConversationListScreenProps } from "../navigation/types";
+import type { LightAgentConfigurationType } from "@dust-tt/client";
+
+export function ConversationListScreen({
+  navigation,
+}: ConversationListScreenProps) {
+  const { conversations, isLoading, mutate } = useConversations();
+  const [searchQuery, setSearchQuery] = useState("");
+  const [showAgentPicker, setShowAgentPicker] = useState(false);
+
+  const filteredConversations = conversations.filter((c) =>
+    (c.title ?? "").toLowerCase().includes(searchQuery.toLowerCase())
+  );
+
+  const handleRefresh = useCallback(() => {
+    mutate();
+  }, [mutate]);
+
+  const handleNewConversation = useCallback(
+    (agent: LightAgentConfigurationType) => {
+      setShowAgentPicker(false);
+      navigation.navigate("Conversation", { agentId: agent.sId });
+    },
+    [navigation]
+  );
+
+  const handleOpenConversation = useCallback(
+    (conversationId: string) => {
+      navigation.navigate("Conversation", { conversationId });
+    },
+    [navigation]
+  );
+
+  return (
+    <SafeAreaView style={styles.container} edges={["bottom"]}>
+      <View style={styles.searchContainer}>
+        <TextInput
+          style={styles.searchInput}
+          placeholder="Search conversations..."
+          value={searchQuery}
+          onChangeText={setSearchQuery}
+          placeholderTextColor="#999"
+        />
+      </View>
+
+      <FlatList
+        data={filteredConversations}
+        keyExtractor={(item) => item.sId}
+        renderItem={({ item }) => (
+          <ConversationRow
+            conversation={item}
+            onPress={() => handleOpenConversation(item.sId)}
+          />
+        )}
+        refreshControl={
+          <RefreshControl refreshing={isLoading} onRefresh={handleRefresh} />
+        }
+        contentContainerStyle={styles.list}
+        ListEmptyComponent={
+          <View style={styles.empty}>
+            <Text style={styles.emptyText}>
+              {isLoading ? "Loading..." : "No conversations yet"}
+            </Text>
+          </View>
+        }
+      />
+
+      <TouchableOpacity
+        style={styles.fab}
+        onPress={() => setShowAgentPicker(true)}
+      >
+        <Text style={styles.fabText}>+</Text>
+      </TouchableOpacity>
+
+      {showAgentPicker && (
+        <AgentPicker
+          onSelect={handleNewConversation}
+          onClose={() => setShowAgentPicker(false)}
+        />
+      )}
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#fff",
+  },
+  searchContainer: {
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+  },
+  searchInput: {
+    backgroundColor: "#f0f0f0",
+    borderRadius: 10,
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+    fontSize: 16,
+  },
+  list: {
+    paddingHorizontal: 16,
+  },
+  empty: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    paddingTop: 64,
+  },
+  emptyText: {
+    color: "#999",
+    fontSize: 16,
+  },
+  fab: {
+    position: "absolute",
+    right: 20,
+    bottom: 20,
+    width: 56,
+    height: 56,
+    borderRadius: 28,
+    backgroundColor: "#000",
+    justifyContent: "center",
+    alignItems: "center",
+    shadowColor: "#000",
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.25,
+    shadowRadius: 4,
+    elevation: 5,
+  },
+  fabText: {
+    color: "#fff",
+    fontSize: 28,
+    lineHeight: 30,
+    fontWeight: "300",
+  },
+});

--- a/x/henry/dust-mobile/src/screens/ConversationScreen.tsx
+++ b/x/henry/dust-mobile/src/screens/ConversationScreen.tsx
@@ -1,0 +1,100 @@
+import React, { useState, useCallback, useEffect } from "react";
+import {
+  View,
+  StyleSheet,
+  KeyboardAvoidingView,
+  Platform,
+  AppState,
+} from "react-native";
+import { useConversation } from "../hooks/useConversation";
+import { useSubmitMessage } from "../hooks/useSubmitMessage";
+import { MessageList } from "../components/MessageList";
+import { InputBar } from "../components/InputBar";
+import type { ConversationScreenProps } from "../navigation/types";
+import type {
+  AgentMentionType,
+  ConversationPublicType,
+} from "@dust-tt/client";
+
+export function ConversationScreen({
+  route,
+  navigation,
+}: ConversationScreenProps) {
+  const { conversationId: initialConversationId, agentId } = route.params;
+  const [conversationId, setConversationId] = useState(initialConversationId);
+  const { conversation, mutate } = useConversation(conversationId);
+
+  const handleConversationCreated = useCallback(
+    (conv: ConversationPublicType) => {
+      setConversationId(conv.sId);
+      if (conv.title) {
+        navigation.setOptions({ title: conv.title });
+      }
+    },
+    [navigation]
+  );
+
+  const { submit, isSubmitting, streaming } = useSubmitMessage(
+    conversationId,
+    handleConversationCreated
+  );
+
+  // Set title from conversation
+  useEffect(() => {
+    if (conversation?.title) {
+      navigation.setOptions({ title: conversation.title });
+    }
+  }, [conversation?.title, navigation]);
+
+  // Revalidate on foreground
+  useEffect(() => {
+    const subscription = AppState.addEventListener("change", (state) => {
+      if (state === "active" && conversationId) {
+        mutate();
+      }
+    });
+    return () => subscription.remove();
+  }, [conversationId, mutate]);
+
+  const handleSend = useCallback(
+    (content: string, mentions: AgentMentionType[]) => {
+      submit(content, mentions);
+    },
+    [submit]
+  );
+
+  const handleCancel = useCallback(() => {
+    if (conversationId && streaming.state?.message.sId) {
+      streaming.cancelStreaming(conversationId, streaming.state.message.sId);
+    }
+  }, [conversationId, streaming]);
+
+  return (
+    <KeyboardAvoidingView
+      style={styles.container}
+      behavior={Platform.OS === "ios" ? "padding" : "height"}
+      keyboardVerticalOffset={88}
+    >
+      <View style={styles.container}>
+        <MessageList
+          conversation={conversation ?? undefined}
+          streamingState={streaming.state}
+        />
+        <InputBar
+          onSend={handleSend}
+          onCancel={handleCancel}
+          isStreaming={streaming.isStreaming}
+          isSubmitting={isSubmitting}
+          initialAgentId={agentId}
+        />
+      </View>
+    </KeyboardAvoidingView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#fff",
+  },
+});

--- a/x/henry/dust-mobile/src/screens/LoginScreen.tsx
+++ b/x/henry/dust-mobile/src/screens/LoginScreen.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { View, Text, TouchableOpacity, StyleSheet } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { useAuthContext } from "../context/AuthContext";
+
+export function LoginScreen() {
+  const { handleLogin, authError } = useAuthContext();
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.content}>
+        <Text style={styles.title}>Dust</Text>
+        <Text style={styles.subtitle}>Your AI assistant</Text>
+
+        <TouchableOpacity
+          style={styles.button}
+          onPress={() => handleLogin()}
+        >
+          <Text style={styles.buttonText}>Sign in</Text>
+        </TouchableOpacity>
+
+        {authError && <Text style={styles.error}>{authError}</Text>}
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#fff",
+  },
+  content: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    paddingHorizontal: 32,
+  },
+  title: {
+    fontSize: 48,
+    fontWeight: "700",
+    color: "#000",
+    marginBottom: 8,
+  },
+  subtitle: {
+    fontSize: 18,
+    color: "#666",
+    marginBottom: 48,
+  },
+  button: {
+    backgroundColor: "#000",
+    paddingHorizontal: 32,
+    paddingVertical: 16,
+    borderRadius: 12,
+    width: "100%",
+    alignItems: "center",
+  },
+  buttonText: {
+    color: "#fff",
+    fontSize: 17,
+    fontWeight: "600",
+  },
+  error: {
+    color: "#e53e3e",
+    marginTop: 16,
+    textAlign: "center",
+  },
+});

--- a/x/henry/dust-mobile/src/screens/WorkspaceSelectionScreen.tsx
+++ b/x/henry/dust-mobile/src/screens/WorkspaceSelectionScreen.tsx
@@ -1,0 +1,93 @@
+import React from "react";
+import {
+  View,
+  Text,
+  FlatList,
+  TouchableOpacity,
+  StyleSheet,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { useAuthContext } from "../context/AuthContext";
+import type { WorkspaceType } from "@dust-tt/client";
+
+export function WorkspaceSelectionScreen() {
+  const { user, handleSelectWorkspace, handleLogout } = useAuthContext();
+  const workspaces = user?.workspaces ?? [];
+
+  const renderItem = ({ item }: { item: WorkspaceType }) => (
+    <TouchableOpacity
+      style={styles.row}
+      onPress={() => handleSelectWorkspace(item)}
+    >
+      <Text style={styles.workspaceName}>{item.name}</Text>
+      {item.ssoEnforced && <Text style={styles.ssoBadge}>SSO</Text>}
+    </TouchableOpacity>
+  );
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.header}>
+        <Text style={styles.title}>Select workspace</Text>
+        <TouchableOpacity onPress={handleLogout}>
+          <Text style={styles.logoutText}>Sign out</Text>
+        </TouchableOpacity>
+      </View>
+      <FlatList
+        data={workspaces}
+        keyExtractor={(item) => item.sId}
+        renderItem={renderItem}
+        contentContainerStyle={styles.list}
+      />
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#fff",
+  },
+  header: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: "#e0e0e0",
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: "700",
+  },
+  logoutText: {
+    fontSize: 15,
+    color: "#666",
+  },
+  list: {
+    padding: 16,
+  },
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingVertical: 16,
+    paddingHorizontal: 16,
+    backgroundColor: "#f8f8f8",
+    borderRadius: 12,
+    marginBottom: 8,
+  },
+  workspaceName: {
+    fontSize: 17,
+    fontWeight: "500",
+    flex: 1,
+  },
+  ssoBadge: {
+    fontSize: 12,
+    color: "#666",
+    backgroundColor: "#e0e0e0",
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: 4,
+    overflow: "hidden",
+  },
+});

--- a/x/henry/dust-mobile/src/services/auth.ts
+++ b/x/henry/dust-mobile/src/services/auth.ts
@@ -1,0 +1,260 @@
+import * as WebBrowser from "expo-web-browser";
+import * as Crypto from "expo-crypto";
+import { jwtDecode } from "jwt-decode";
+import type { StoredTokens, StoredUser } from "../types";
+import { secureStorage, appStorage } from "./storage";
+
+WebBrowser.maybeCompleteAuthSession();
+
+const DUST_US_URL = "https://dust.tt";
+const DEFAULT_TOKEN_EXPIRY_SECONDS = 300; // 5 minutes
+const PROACTIVE_REFRESH_WINDOW_MS = 60_000; // 1 minute
+
+// In-memory token cache (SecureStore is async/slow for hot-path reads)
+let cachedTokens: StoredTokens | null = null;
+
+// Deduplication lock for parallel refresh calls
+let refreshPromise: Promise<StoredTokens | null> | null = null;
+
+const REDIRECT_URI = "dust://auth/callback";
+
+type JWTClaims = {
+  sub: string;
+  region?: string;
+  exp?: number;
+};
+
+function getDustDomain(region?: string): string {
+  if (region === "europe-west1") {
+    return "https://eu.dust.tt";
+  }
+  return DUST_US_URL;
+}
+
+// Generate PKCE code verifier and challenge (same as extension's background.ts)
+async function generatePKCE(): Promise<{
+  codeVerifier: string;
+  codeChallenge: string;
+}> {
+  // Generate 32 random bytes for code verifier
+  const randomBytes = await Crypto.getRandomBytesAsync(32);
+  const codeVerifier = base64URLEncode(randomBytes);
+
+  // SHA-256 hash the verifier for the challenge
+  const digest = await Crypto.digestStringAsync(
+    Crypto.CryptoDigestAlgorithm.SHA256,
+    codeVerifier,
+    { encoding: Crypto.CryptoEncoding.BASE64 }
+  );
+  const codeChallenge = base64ToBase64URL(digest);
+
+  return { codeVerifier, codeChallenge };
+}
+
+function base64URLEncode(bytes: Uint8Array): string {
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function base64ToBase64URL(base64: string): string {
+  return base64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+export async function initiateLogin(
+  organizationId?: string
+): Promise<StoredTokens | null> {
+  const { codeVerifier, codeChallenge } = await generatePKCE();
+
+  // Construct auth URL exactly like the Chrome extension (no client_id)
+  const params: Record<string, string> = {
+    response_type: "code",
+    redirect_uri: REDIRECT_URI,
+    code_challenge_method: "S256",
+    code_challenge: codeChallenge,
+    provider: "authkit",
+  };
+
+  if (organizationId) {
+    params.organization_id = organizationId;
+  }
+
+  const queryString = new URLSearchParams(params).toString();
+  const authUrl = `${DUST_US_URL}/api/v1/auth/authorize?${queryString}`;
+
+  // Open in-app browser, wait for redirect back to our scheme
+  const result = await WebBrowser.openAuthSessionAsync(authUrl, REDIRECT_URI);
+
+  if (result.type !== "success" || !result.url) {
+    return null;
+  }
+
+  // Parse the authorization code from the redirect URL
+  const url = new URL(result.url);
+  const code = url.searchParams.get("code");
+
+  if (!code) {
+    return null;
+  }
+
+  const tokens = await exchangeCodeForTokens(code, codeVerifier);
+  return tokens;
+}
+
+async function exchangeCodeForTokens(
+  code: string,
+  codeVerifier: string
+): Promise<StoredTokens | null> {
+  const body = new URLSearchParams({
+    grant_type: "authorization_code",
+    code_verifier: codeVerifier,
+    code,
+    redirect_uri: REDIRECT_URI,
+  });
+
+  const response = await fetch(`${DUST_US_URL}/api/v1/auth/authenticate`, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: body.toString(),
+  });
+
+  if (!response.ok) {
+    return null;
+  }
+
+  const data = await response.json();
+  const expiresIn = data.expires_in ?? DEFAULT_TOKEN_EXPIRY_SECONDS;
+  const tokens: StoredTokens = {
+    accessToken: data.access_token,
+    refreshToken: data.refresh_token,
+    expiresAt: Date.now() + expiresIn * 1000,
+  };
+
+  cachedTokens = tokens;
+  await secureStorage.setTokens(tokens);
+  return tokens;
+}
+
+export async function fetchUserAndWorkspaces(
+  accessToken: string
+): Promise<StoredUser | null> {
+  const claims = jwtDecode<JWTClaims>(accessToken);
+  const dustDomain = getDustDomain(claims.region);
+
+  const response = await fetch(`${dustDomain}/api/v1/me`, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+
+  if (!response.ok) {
+    return null;
+  }
+
+  const { user } = await response.json();
+  const storedUser: StoredUser = {
+    ...user,
+    workspaces: user.workspaces ?? [],
+    selectedWorkspace: null,
+    dustDomain,
+  };
+
+  appStorage.setUser(storedUser);
+  return storedUser;
+}
+
+export async function getAccessToken(): Promise<string | null> {
+  // Use cached tokens if fresh
+  if (cachedTokens && cachedTokens.expiresAt > Date.now() + PROACTIVE_REFRESH_WINDOW_MS) {
+    return cachedTokens.accessToken;
+  }
+
+  // Load from storage if no cache
+  if (!cachedTokens) {
+    cachedTokens = await secureStorage.getTokens();
+  }
+
+  if (!cachedTokens) {
+    return null;
+  }
+
+  // If still fresh after loading from storage
+  if (cachedTokens.expiresAt > Date.now() + PROACTIVE_REFRESH_WINDOW_MS) {
+    return cachedTokens.accessToken;
+  }
+
+  // Need refresh — deduplicate concurrent calls
+  if (!refreshPromise) {
+    refreshPromise = performRefresh(cachedTokens.refreshToken);
+  }
+
+  const refreshed = await refreshPromise;
+  refreshPromise = null;
+
+  if (refreshed) {
+    return refreshed.accessToken;
+  }
+  return null;
+}
+
+async function performRefresh(
+  refreshTokenValue: string
+): Promise<StoredTokens | null> {
+  const user = appStorage.getUser();
+  if (!user) return null;
+
+  const body = new URLSearchParams({
+    grant_type: "refresh_token",
+    refresh_token: refreshTokenValue,
+  });
+
+  try {
+    const response = await fetch(
+      `${user.dustDomain}/api/v1/auth/authenticate`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: body.toString(),
+      }
+    );
+
+    if (!response.ok) {
+      cachedTokens = null;
+      await secureStorage.clearTokens();
+      return null;
+    }
+
+    const data = await response.json();
+    const expiresIn = data.expires_in ?? DEFAULT_TOKEN_EXPIRY_SECONDS;
+    const tokens: StoredTokens = {
+      accessToken: data.access_token,
+      refreshToken: data.refresh_token || refreshTokenValue,
+      expiresAt: Date.now() + expiresIn * 1000,
+    };
+
+    cachedTokens = tokens;
+    await secureStorage.setTokens(tokens);
+    return tokens;
+  } catch {
+    return null;
+  }
+}
+
+export async function logout(): Promise<void> {
+  cachedTokens = null;
+  await secureStorage.clearTokens();
+  appStorage.clearUser();
+}
+
+export function checkSSOEnforcement(
+  user: StoredUser,
+  workspaceId: string
+): boolean {
+  const workspace = user.workspaces.find((w) => w.sId === workspaceId);
+  if (!workspace?.ssoEnforced) return true;
+
+  return (
+    user.connectionStrategy === "SSO" &&
+    user.connection === `workspace-${workspaceId}`
+  );
+}

--- a/x/henry/dust-mobile/src/services/storage.ts
+++ b/x/henry/dust-mobile/src/services/storage.ts
@@ -1,0 +1,42 @@
+import * as SecureStore from "expo-secure-store";
+import { MMKV } from "react-native-mmkv";
+import type { StoredTokens, StoredUser } from "../types";
+
+const mmkv = new MMKV();
+
+const TOKENS_KEY = "dust_tokens";
+const USER_KEY = "dust_user";
+
+// Secure storage for tokens (encrypted, async)
+export const secureStorage = {
+  async getTokens(): Promise<StoredTokens | null> {
+    const raw = await SecureStore.getItemAsync(TOKENS_KEY);
+    if (!raw) return null;
+    return JSON.parse(raw) as StoredTokens;
+  },
+
+  async setTokens(tokens: StoredTokens): Promise<void> {
+    await SecureStore.setItemAsync(TOKENS_KEY, JSON.stringify(tokens));
+  },
+
+  async clearTokens(): Promise<void> {
+    await SecureStore.deleteItemAsync(TOKENS_KEY);
+  },
+};
+
+// Fast MMKV storage for user data (not sensitive)
+export const appStorage = {
+  getUser(): StoredUser | null {
+    const raw = mmkv.getString(USER_KEY);
+    if (!raw) return null;
+    return JSON.parse(raw) as StoredUser;
+  },
+
+  setUser(user: StoredUser): void {
+    mmkv.set(USER_KEY, JSON.stringify(user));
+  },
+
+  clearUser(): void {
+    mmkv.delete(USER_KEY);
+  },
+};

--- a/x/henry/dust-mobile/src/types/index.ts
+++ b/x/henry/dust-mobile/src/types/index.ts
@@ -1,0 +1,54 @@
+import type {
+  AgentMessagePublicType,
+  ConversationPublicType,
+  LightAgentConfigurationType,
+  UserMessageType,
+  UserType,
+  WorkspaceType,
+} from "@dust-tt/client";
+
+export type StoredTokens = {
+  accessToken: string;
+  refreshToken: string;
+  expiresAt: number;
+};
+
+export type StoredUser = UserType & {
+  workspaces: WorkspaceType[];
+  selectedWorkspace: string | null;
+  dustDomain: string;
+  connectionStrategy?: string;
+  connection?: string;
+};
+
+export type AgentStateClassification =
+  | "thinking"
+  | "acting"
+  | "writing"
+  | "done";
+
+export type MessageTemporaryState = {
+  message: AgentMessagePublicType;
+  agentState: AgentStateClassification;
+  lastUpdated: Date;
+};
+
+export type MessageWithContentFragments =
+  | AgentMessagePublicType
+  | UserMessageType;
+
+export type ConversationWithMessages = ConversationPublicType;
+
+export type NavigationParamList = {
+  Login: undefined;
+  WorkspaceSelection: undefined;
+  Main: undefined;
+  ConversationList: undefined;
+  Conversation: {
+    conversationId?: string;
+    agentId?: string;
+  };
+  AgentPicker: undefined;
+};
+
+export type { LightAgentConfigurationType };

--- a/x/henry/dust-mobile/tsconfig.json
+++ b/x/henry/dust-mobile/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "expo/tsconfig.base",
+  "compilerOptions": {
+    "strict": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a React Native (Expo) iOS app at `x/henry/dust-mobile/`
- Chat-only MVP using `@dust-tt/client` SDK with OAuth PKCE authentication
- Streaming agent messages via EventSourcePolyfill (XHR-based SSE)

## What's included

- OAuth PKCE flow via `expo-web-browser` + `expo-crypto` (redirect: `dust://auth/callback`)
- Token refresh with deduplication and proactive refresh
- Workspace selection with SSO enforcement
- Conversation list (SWR-backed, pull-to-refresh)
- Conversation view with streaming messages (token throttling, cancel support)
- Agent picker with search for @mentions
- Message reducer for tracking agent state (thinking/acting/writing/done)
- AppState-based revalidation on foreground resume

## Test plan

- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] Metro bundles all 1223 modules successfully
- [x] App builds and runs on iOS Simulator (iPhone 15 Pro)
- [x] MMKV initializes correctly (New Architecture enabled)
- [x] OAuth flow reaches WorkOS and returns auth code
- [ ] Full end-to-end: login → workspace → conversations → chat (requires WorkOS redirect URI config)

## Risk

Low — this is a new standalone directory under `x/henry/` with no changes to existing code.