### PR TITLE
refactor(mcp): migrate include_data server to new architecture

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -22,6 +22,7 @@ import { FILE_GENERATION_SERVER } from "@app/lib/api/actions/servers/file_genera
 import { GITHUB_SERVER } from "@app/lib/api/actions/servers/github/metadata";
 import { GOOGLE_CALENDAR_SERVER } from "@app/lib/api/actions/servers/google_calendar/metadata";
 import { IMAGE_GENERATION_SERVER } from "@app/lib/api/actions/servers/image_generation/metadata";
+import { INCLUDE_DATA_SERVER } from "@app/lib/api/actions/servers/include_data/metadata";
 import { NOTION_SERVER } from "@app/lib/api/actions/servers/notion/metadata";
 import { STATUSPAGE_SERVER } from "@app/lib/api/actions/servers/statuspage/metadata";
 import { WEB_SEARCH_BROWSE_SERVER } from "@app/lib/api/actions/servers/web_search_browse/metadata";
@@ -316,20 +317,10 @@ export const INTERNAL_MCP_SERVERS = {
     allowMultipleInstances: false,
     isRestricted: undefined,
     isPreview: false,
-    tools_stakes: undefined,
     tools_arguments_requiring_approval: undefined,
     tools_retry_policies: { default: "retry_on_interrupt" },
     timeoutMs: undefined,
-    serverInfo: {
-      name: "include_data",
-      version: "1.0.0",
-      description:
-        "Load complete content for full context up to memory limits.",
-      icon: "ActionTimeIcon",
-      authorization: null,
-      documentationUrl: null,
-      instructions: null,
-    },
+    metadata: INCLUDE_DATA_SERVER,
   },
   run_dust_app: {
     id: 10,

--- a/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/data_sources_file_system.ts
@@ -13,10 +13,10 @@ import { registerFindTool } from "@app/lib/actions/mcp_internal_actions/tools/da
 import { registerListTool } from "@app/lib/actions/mcp_internal_actions/tools/data_sources_file_system/list";
 import { registerLocateTreeTool } from "@app/lib/actions/mcp_internal_actions/tools/data_sources_file_system/locate_tree";
 import { registerSearchTool } from "@app/lib/actions/mcp_internal_actions/tools/data_sources_file_system/search";
-import { registerFindTagsTool } from "@app/lib/actions/mcp_internal_actions/tools/tags/find_tags";
 import { shouldAutoGenerateTags } from "@app/lib/actions/mcp_internal_actions/tools/tags/utils";
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
+import { registerFindTagsTool } from "@app/lib/api/actions/tools/find_tags";
 import type { Authenticator } from "@app/lib/auth";
 
 function createServer(

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -23,7 +23,6 @@ import { default as driveServer } from "@app/lib/actions/mcp_internal_actions/se
 import { default as sheetsServer } from "@app/lib/actions/mcp_internal_actions/servers/google_sheets";
 import { default as httpClientServer } from "@app/lib/actions/mcp_internal_actions/servers/http_client";
 import { default as hubspotServer } from "@app/lib/actions/mcp_internal_actions/servers/hubspot";
-import { default as includeDataServer } from "@app/lib/actions/mcp_internal_actions/servers/include";
 import { default as interactiveContentServer } from "@app/lib/actions/mcp_internal_actions/servers/interactive_content";
 import { default as jiraServer } from "@app/lib/actions/mcp_internal_actions/servers/jira";
 import { default as jitTestingServer } from "@app/lib/actions/mcp_internal_actions/servers/jit_testing";
@@ -69,6 +68,7 @@ import { default as fileGenerationServer } from "@app/lib/api/actions/servers/fi
 import { default as githubServer } from "@app/lib/api/actions/servers/github";
 import { default as calendarServer } from "@app/lib/api/actions/servers/google_calendar";
 import { default as imageGenerationServer } from "@app/lib/api/actions/servers/image_generation";
+import { default as includeDataServer } from "@app/lib/api/actions/servers/include_data";
 import { default as notionServer } from "@app/lib/api/actions/servers/notion";
 import { default as snowflakeServer } from "@app/lib/api/actions/servers/snowflake";
 import { default as statuspageServer } from "@app/lib/api/actions/servers/statuspage";

--- a/front/lib/actions/mcp_internal_actions/servers/process/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/process/index.ts
@@ -17,7 +17,6 @@ import {
 import type { DataSourcesToolConfigurationType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { JsonSchemaSchema } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
-import { registerFindTagsTool } from "@app/lib/actions/mcp_internal_actions/tools/tags/find_tags";
 import { shouldAutoGenerateTags } from "@app/lib/actions/mcp_internal_actions/tools/tags/utils";
 import { getCoreSearchArgs } from "@app/lib/actions/mcp_internal_actions/tools/utils";
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
@@ -30,6 +29,7 @@ import {
   isLightServerSideMCPToolConfiguration,
   isServerSideMCPServerConfiguration,
 } from "@app/lib/actions/types/guards";
+import { registerFindTagsTool } from "@app/lib/api/actions/tools/find_tags";
 import { constructPromptMultiActions } from "@app/lib/api/assistant/generation";
 import type { CoreDataSourceSearchCriteria } from "@app/lib/api/assistant/process_data_sources";
 import { processDataSources } from "@app/lib/api/assistant/process_data_sources";

--- a/front/lib/actions/mcp_internal_actions/servers/search.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/search.ts
@@ -11,7 +11,6 @@ import {
 } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { DataSourcesToolConfigurationType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type { SearchResultResourceType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
-import { registerFindTagsTool } from "@app/lib/actions/mcp_internal_actions/tools/tags/find_tags";
 import {
   checkConflictingTags,
   shouldAutoGenerateTags,
@@ -25,6 +24,7 @@ import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/uti
 import { ensureAuthorizedDataSourceViews } from "@app/lib/actions/mcp_internal_actions/utils/data_source_views";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
+import { registerFindTagsTool } from "@app/lib/api/actions/tools/find_tags";
 import { getRefs } from "@app/lib/api/assistant/citations";
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/lib/actions/mcp_internal_actions/tools/include/helpers.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/include/helpers.ts
@@ -1,0 +1,65 @@
+import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
+
+import type {
+  IncludeResultResourceType,
+  WarningResourceType,
+} from "@app/lib/actions/mcp_internal_actions/output_schemas";
+import { renderRelativeTimeFrameForToolOutput } from "@app/lib/actions/mcp_internal_actions/rendering";
+import {
+  getDataSourceNameFromView,
+  getDisplayNameForDocument,
+} from "@app/lib/data_sources";
+import type { CoreAPIDocument, TimeFrame } from "@app/types";
+import { stripNullBytes } from "@app/types";
+import type { DataSourceViewType } from "@app/types/data_source_view";
+
+export function makeIncludeWarningResource(
+  documents: CoreAPIDocument[],
+  topK: number,
+  timeFrame: TimeFrame | null
+): WarningResourceType | null {
+  const timeFrameAsString = renderRelativeTimeFrameForToolOutput(timeFrame);
+
+  // Check if the number of chunks reached the limit defined in params.topK.
+  const tooManyChunks =
+    documents &&
+    documents.reduce((sum, doc) => sum + doc.chunks.length, 0) >= topK;
+
+  // Determine the retrieval date limit from the last document's timestamp.
+  const retrievalTsLimit = documents?.[documents.length - 1]?.timestamp;
+  const date = retrievalTsLimit ? new Date(retrievalTsLimit) : null;
+  const retrievalDateLimitAsString = date
+    ? `${date.toLocaleString("default", { month: "short" })} ${date.getDate()}`
+    : null;
+
+  return tooManyChunks
+    ? {
+        mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.WARNING,
+        warningTitle: `Only includes documents since ${retrievalDateLimitAsString}.`,
+        warningData: { includeTimeLimit: retrievalDateLimitAsString ?? "" },
+        text: `Warning: could not include all documents ${timeFrameAsString}. Only includes documents since ${retrievalDateLimitAsString}.`,
+        uri: "",
+      }
+    : null;
+}
+
+export function makeIncludeResultResource(
+  doc: CoreAPIDocument,
+  dataSourceView: DataSourceViewType,
+  refs: string[]
+): IncludeResultResourceType {
+  return {
+    mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.DATA_SOURCE_INCLUDE_RESULT,
+    uri: doc.source_url ?? "",
+    text: getDisplayNameForDocument(doc),
+
+    id: doc.document_id,
+    source: {
+      provider: dataSourceView.dataSource.connectorProvider ?? undefined,
+      name: getDataSourceNameFromView(dataSourceView),
+    },
+    tags: doc.tags,
+    ref: refs.shift() as string,
+    chunks: doc.chunks.map((chunk) => stripNullBytes(chunk.text)),
+  };
+}

--- a/front/lib/api/actions/servers/include_data/helpers.ts
+++ b/front/lib/api/actions/servers/include_data/helpers.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line dust/enforce-client-types-in-public-api
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 
 import type {

--- a/front/lib/api/actions/servers/include_data/index.ts
+++ b/front/lib/api/actions/servers/include_data/index.ts
@@ -1,0 +1,26 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
+import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
+import { INCLUDE_DATA_TOOL_NAME } from "@app/lib/api/actions/servers/include_data/metadata";
+import { createIncludeDataTools } from "@app/lib/api/actions/servers/include_data/tools";
+import type { Authenticator } from "@app/lib/auth";
+
+function createServer(
+  auth: Authenticator,
+  agentLoopContext?: AgentLoopContextType
+): McpServer {
+  const server = makeInternalMCPServer("include_data");
+
+  const tools = createIncludeDataTools(auth, agentLoopContext);
+  for (const tool of tools) {
+    registerTool(auth, agentLoopContext, server, tool, {
+      monitoringName: INCLUDE_DATA_TOOL_NAME,
+    });
+  }
+
+  return server;
+}
+
+export default createServer;

--- a/front/lib/api/actions/servers/include_data/metadata.ts
+++ b/front/lib/api/actions/servers/include_data/metadata.ts
@@ -11,27 +11,10 @@ import {
   IncludeInputSchema,
   TagsInputSchema,
 } from "@app/lib/actions/mcp_internal_actions/types";
-
-export const findTagsSchema = {
-  query: z
-    .string()
-    .describe(
-      "The text to search for in existing labels (also called tags) using edge ngram " +
-        "matching (case-insensitive). Matches labels that start with any word in the " +
-        "search text. The returned labels can be used in tagsIn/tagsNot parameters to " +
-        "restrict or exclude content based on the user request and conversation context."
-    ),
-  dataSources:
-    ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE],
-};
-
-export const FIND_TAGS_BASE_DESCRIPTION =
-  "Find exact matching labels (also called tags). " +
-  "Restricting or excluding content succeeds only with existing labels. " +
-  "Searching without verifying labels first typically returns no results. " +
-  "The output of this tool can typically be used in `tagsIn` (if we want " +
-  "to restrict the search to specific tags) or `tagsNot` (if we want to " +
-  "exclude specific tags) parameters.";
+import {
+  FIND_TAGS_BASE_DESCRIPTION,
+  findTagsSchema,
+} from "@app/lib/api/actions/tools/find_tags";
 
 export const INCLUDE_DATA_TOOL_NAME = "include_data" as const;
 

--- a/front/lib/api/actions/servers/include_data/metadata.ts
+++ b/front/lib/api/actions/servers/include_data/metadata.ts
@@ -1,14 +1,37 @@
+// eslint-disable-next-line dust/enforce-client-types-in-public-api
+import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
+import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
   IncludeInputSchema,
   TagsInputSchema,
 } from "@app/lib/actions/mcp_internal_actions/types";
-import { findTagsSchema } from "@app/lib/api/actions/tools/find_tags";
+
+export const findTagsSchema = {
+  query: z
+    .string()
+    .describe(
+      "The text to search for in existing labels (also called tags) using edge ngram " +
+        "matching (case-insensitive). Matches labels that start with any word in the " +
+        "search text. The returned labels can be used in tagsIn/tagsNot parameters to " +
+        "restrict or exclude content based on the user request and conversation context."
+    ),
+  dataSources:
+    ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE],
+};
+
+export const FIND_TAGS_BASE_DESCRIPTION =
+  "Find exact matching labels (also called tags). " +
+  "Restricting or excluding content succeeds only with existing labels. " +
+  "Searching without verifying labels first typically returns no results. " +
+  "The output of this tool can typically be used in `tagsIn` (if we want " +
+  "to restrict the search to specific tags) or `tagsNot` (if we want to " +
+  "exclude specific tags) parameters.";
 
 export const INCLUDE_DATA_TOOL_NAME = "include_data" as const;
 
@@ -37,13 +60,8 @@ export const INCLUDE_DATA_WITH_TAGS_TOOLS_METADATA = createToolsRecord({
   },
   find_tags: {
     description:
-      "Find exact matching labels (also called tags). " +
-      "Restricting or excluding content succeeds only with existing labels. " +
-      "Searching without verifying labels first typically returns no results. " +
-      "The output of this tool can typically be used in `tagsIn` (if we want " +
-      "to restrict the search to specific tags) or `tagsNot` (if we want to " +
-      "exclude specific tags) parameters. " +
-      "This tool is meant to be used before the retrieve_recent_documents tool.",
+      FIND_TAGS_BASE_DESCRIPTION +
+      " This tool is meant to be used before the retrieve_recent_documents tool.",
     schema: findTagsSchema,
     stake: "never_ask",
   },

--- a/front/lib/api/actions/servers/include_data/metadata.ts
+++ b/front/lib/api/actions/servers/include_data/metadata.ts
@@ -1,10 +1,7 @@
-// eslint-disable-next-line dust/enforce-client-types-in-public-api
-import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
-import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {

--- a/front/lib/api/actions/servers/include_data/metadata.ts
+++ b/front/lib/api/actions/servers/include_data/metadata.ts
@@ -1,0 +1,74 @@
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
+
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { findTagsSchema } from "@app/lib/actions/mcp_internal_actions/tools/tags/find_tags";
+import {
+  IncludeInputSchema,
+  TagsInputSchema,
+} from "@app/lib/actions/mcp_internal_actions/types";
+
+export const INCLUDE_DATA_TOOL_NAME = "include_data" as const;
+
+// Base tool without tags support
+export const INCLUDE_DATA_BASE_TOOLS_METADATA = createToolsRecord({
+  retrieve_recent_documents: {
+    description:
+      "Fetch the most recent documents in reverse chronological order up to a pre-allocated size. This tool retrieves content that is already pre-configured by the user, ensuring the latest information is included.",
+    schema: IncludeInputSchema.shape,
+    stake: "never_ask",
+  },
+});
+
+// Extended schema with tags support (used when tags are dynamic)
+const includeWithTagsSchema = {
+  ...IncludeInputSchema.shape,
+  ...TagsInputSchema.shape,
+};
+
+export const INCLUDE_DATA_WITH_TAGS_TOOLS_METADATA = createToolsRecord({
+  retrieve_recent_documents: {
+    description:
+      "Fetch the most recent documents in reverse chronological order up to a pre-allocated size. This tool retrieves content that is already pre-configured by the user, ensuring the latest information is included.",
+    schema: includeWithTagsSchema,
+    stake: "never_ask",
+  },
+  find_tags: {
+    description:
+      "Find exact matching labels (also called tags). " +
+      "Restricting or excluding content succeeds only with existing labels. " +
+      "Searching without verifying labels first typically returns no results. " +
+      "The output of this tool can typically be used in `tagsIn` (if we want " +
+      "to restrict the search to specific tags) or `tagsNot` (if we want to " +
+      "exclude specific tags) parameters. " +
+      "This tool is meant to be used before the retrieve_recent_documents tool.",
+    schema: findTagsSchema,
+    stake: "never_ask",
+  },
+});
+
+// For the server metadata, we use the base schema
+export const INCLUDE_DATA_SERVER = {
+  serverInfo: {
+    name: "include_data",
+    version: "1.0.0",
+    description: "Load complete content for full context up to memory limits.",
+    icon: "ActionTimeIcon",
+    authorization: null,
+    documentationUrl: null,
+    instructions: null,
+  },
+  tools: Object.values(INCLUDE_DATA_BASE_TOOLS_METADATA).map((t) => ({
+    name: t.name,
+    description: t.description,
+    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+  })),
+  tools_stakes: Object.fromEntries(
+    Object.values(INCLUDE_DATA_BASE_TOOLS_METADATA).map((t) => [
+      t.name,
+      t.stake,
+    ])
+  ),
+} as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/include_data/metadata.ts
+++ b/front/lib/api/actions/servers/include_data/metadata.ts
@@ -4,11 +4,11 @@ import { zodToJsonSchema } from "zod-to-json-schema";
 
 import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { findTagsSchema } from "@app/lib/actions/mcp_internal_actions/tools/tags/find_tags";
 import {
   IncludeInputSchema,
   TagsInputSchema,
 } from "@app/lib/actions/mcp_internal_actions/types";
+import { findTagsSchema } from "@app/lib/api/actions/tools/find_tags";
 
 export const INCLUDE_DATA_TOOL_NAME = "include_data" as const;
 

--- a/front/lib/api/actions/servers/include_data/tools/index.ts
+++ b/front/lib/api/actions/servers/include_data/tools/index.ts
@@ -11,15 +11,15 @@ import type {
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
-  makeIncludeResultResource,
-  makeIncludeWarningResource,
-} from "@app/lib/actions/mcp_internal_actions/tools/include/helpers";
-import {
   checkConflictingTags,
   shouldAutoGenerateTags,
 } from "@app/lib/actions/mcp_internal_actions/tools/tags/utils";
 import { getCoreSearchArgs } from "@app/lib/actions/mcp_internal_actions/tools/utils";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
+import {
+  makeIncludeResultResource,
+  makeIncludeWarningResource,
+} from "@app/lib/api/actions/servers/include_data/helpers";
 import {
   INCLUDE_DATA_BASE_TOOLS_METADATA,
   INCLUDE_DATA_WITH_TAGS_TOOLS_METADATA,

--- a/front/lib/api/actions/servers/include_data/tools/index.ts
+++ b/front/lib/api/actions/servers/include_data/tools/index.ts
@@ -1,58 +1,51 @@
-import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { TextContent } from "@modelcontextprotocol/sdk/types.js";
 import assert from "assert";
+import trim from "lodash/trim";
 
 import { MCPError } from "@app/lib/actions/mcp_errors";
-import {
-  FIND_TAGS_TOOL_NAME,
-  INCLUDE_TOOL_NAME,
-} from "@app/lib/actions/mcp_internal_actions/constants";
 import type { DataSourcesToolConfigurationType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type {
   IncludeResultResourceType,
   WarningResourceType,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
-import { renderRelativeTimeFrameForToolOutput } from "@app/lib/actions/mcp_internal_actions/rendering";
-import { registerFindTagsTool } from "@app/lib/actions/mcp_internal_actions/tools/tags/find_tags";
+import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import {
+  makeIncludeResultResource,
+  makeIncludeWarningResource,
+} from "@app/lib/actions/mcp_internal_actions/tools/include/helpers";
 import {
   checkConflictingTags,
   shouldAutoGenerateTags,
 } from "@app/lib/actions/mcp_internal_actions/tools/tags/utils";
 import { getCoreSearchArgs } from "@app/lib/actions/mcp_internal_actions/tools/utils";
-import {
-  IncludeInputSchema,
-  TagsInputSchema,
-} from "@app/lib/actions/mcp_internal_actions/types";
-import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
-import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
+import {
+  INCLUDE_DATA_BASE_TOOLS_METADATA,
+  INCLUDE_DATA_WITH_TAGS_TOOLS_METADATA,
+} from "@app/lib/api/actions/servers/include_data/metadata";
 import { getRefs } from "@app/lib/api/assistant/citations";
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
-import {
-  getDataSourceNameFromView,
-  getDisplayNameForDocument,
-} from "@app/lib/data_sources";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
-import type { CoreAPIDocument, Result, TimeFrame } from "@app/types";
+import type { Result, TimeFrame } from "@app/types";
 import {
   CoreAPI,
   dustManagedCredentials,
   Err,
   Ok,
   removeNulls,
-  stripNullBytes,
   timeFrameFromNow,
 } from "@app/types";
 
-function createServer(
+const DEFAULT_SEARCH_LABELS_UPPER_LIMIT = 2000;
+
+// Create tools with access to auth via closure
+export function createIncludeDataTools(
   auth: Authenticator,
   agentLoopContext?: AgentLoopContextType
-): McpServer {
-  const server = makeInternalMCPServer("include_data");
-
+) {
   const areTagsDynamic = agentLoopContext
     ? shouldAutoGenerateTags(agentLoopContext)
     : false;
@@ -188,23 +181,10 @@ function createServer(
 
         assert(dataSourceView, "DataSource view not found");
 
-        return {
-          mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.DATA_SOURCE_INCLUDE_RESULT,
-          uri: doc.source_url ?? "",
-          text: getDisplayNameForDocument(doc),
-
-          id: doc.document_id,
-          source: {
-            provider: dataSourceView.dataSource.connectorProvider ?? undefined,
-            name: getDataSourceNameFromView(dataSourceView),
-          },
-          tags: doc.tags,
-          ref: refs.shift() as string,
-          chunks: doc.chunks.map((chunk) => stripNullBytes(chunk.text)),
-        };
+        return makeIncludeResultResource(doc, dataSourceView, refs);
       });
 
-    const warningResource = makeWarningResource(
+    const warningResource = makeIncludeWarningResource(
       searchResults.value.documents,
       retrievalTopK,
       timeFrame ?? null
@@ -227,68 +207,109 @@ function createServer(
   }
 
   if (!areTagsDynamic) {
-    server.tool(
-      INCLUDE_TOOL_NAME,
-      "Fetch the most recent documents in reverse chronological order up to a pre-allocated size. This tool retrieves content that is already pre-configured by the user, ensuring the latest information is included.",
-      IncludeInputSchema.shape,
-      withToolLogging(
-        auth,
-        { toolNameForMonitoring: "include", agentLoopContext },
-        includeFunction
-      )
-    );
-  } else {
-    server.tool(
-      INCLUDE_TOOL_NAME,
-      "Fetch the most recent documents in reverse chronological order up to a pre-allocated size. This tool retrieves content that is already pre-configured by the user, ensuring the latest information is included.",
-      {
-        ...IncludeInputSchema.shape,
-        ...TagsInputSchema.shape,
+    // Return base tools without tags
+    const handlers: ToolHandlers<typeof INCLUDE_DATA_BASE_TOOLS_METADATA> = {
+      retrieve_recent_documents: async (params, _extra) => {
+        return includeFunction(params);
       },
-      withToolLogging(
-        auth,
-        { toolNameForMonitoring: "include", agentLoopContext },
-        includeFunction
-      )
-    );
-
-    registerFindTagsTool(auth, server, agentLoopContext, {
-      name: FIND_TAGS_TOOL_NAME,
-      extraDescription: `This tool is meant to be used before the ${INCLUDE_TOOL_NAME} tool.`,
-    });
+    };
+    return buildTools(INCLUDE_DATA_BASE_TOOLS_METADATA, handlers);
   }
 
-  return server;
-}
+  // Return tools with tags support
+  const handlers: ToolHandlers<typeof INCLUDE_DATA_WITH_TAGS_TOOLS_METADATA> = {
+    retrieve_recent_documents: async (params, _extra) => {
+      return includeFunction(params);
+    },
+    find_tags: async ({ query, dataSources }, _extra) => {
+      const coreSearchArgsResults = await concurrentExecutor(
+        dataSources,
+        async (dataSourceConfiguration) =>
+          getCoreSearchArgs(auth, dataSourceConfiguration),
+        { concurrency: 10 }
+      );
 
-function makeWarningResource(
-  documents: CoreAPIDocument[],
-  topK: number,
-  timeFrame: TimeFrame | null
-): WarningResourceType | null {
-  const timeFrameAsString = renderRelativeTimeFrameForToolOutput(timeFrame);
-
-  // Check if the number of chunks reached the limit defined in params.topK.
-  const tooManyChunks =
-    documents &&
-    documents.reduce((sum, doc) => sum + doc.chunks.length, 0) >= topK;
-
-  // Determine the retrieval date limit from the last document's timestamp.
-  const retrievalTsLimit = documents?.[documents.length - 1]?.timestamp;
-  const date = retrievalTsLimit ? new Date(retrievalTsLimit) : null;
-  const retrievalDateLimitAsString = date
-    ? `${date.toLocaleString("default", { month: "short" })} ${date.getDate()}`
-    : null;
-
-  return tooManyChunks
-    ? {
-        mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.WARNING,
-        warningTitle: `Only includes documents since ${retrievalDateLimitAsString}.`,
-        warningData: { includeTimeLimit: retrievalDateLimitAsString ?? "" },
-        text: `Warning: could not include all documents ${timeFrameAsString}. Only includes documents since ${retrievalDateLimitAsString}.`,
-        uri: "",
+      if (coreSearchArgsResults.some((res) => res.isErr())) {
+        return new Err(
+          new MCPError(
+            "Invalid data sources: " +
+              removeNulls(
+                coreSearchArgsResults.map((res) =>
+                  res.isErr() ? res.error : null
+                )
+              )
+                .map((error) => error.message)
+                .join("\n")
+          )
+        );
       }
-    : null;
-}
 
-export default createServer;
+      const coreSearchArgs = removeNulls(
+        coreSearchArgsResults.map((res) => (res.isOk() ? res.value : null))
+      );
+
+      if (coreSearchArgs.length === 0) {
+        return new Err(
+          new MCPError(
+            "Search action must have at least one data source configured.",
+            {
+              tracked: false,
+            }
+          )
+        );
+      }
+
+      const dataSourceViews = coreSearchArgs.map((arg) => arg.dataSourceView);
+
+      const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
+      let result = await coreAPI.searchTags({
+        dataSourceViews,
+        query,
+        queryType: "match",
+      });
+
+      if (result.isErr()) {
+        return new Err(new MCPError("Error searching for labels"));
+      }
+
+      if (result.value.tags.length === 0) {
+        // Performing an additional search with a higher limit to catch uncommon tags.
+        result = await coreAPI.searchTags({
+          dataSourceViews,
+          limit: DEFAULT_SEARCH_LABELS_UPPER_LIMIT,
+          query,
+          queryType: "match",
+        });
+
+        if (result.isErr()) {
+          return new Err(new MCPError("Error searching for labels"));
+        }
+      }
+
+      if (result.value.tags.length === 0) {
+        return new Ok([
+          {
+            type: "text",
+            text: "No labels found matching the search criteria.",
+          },
+        ]);
+      }
+
+      return new Ok([
+        {
+          type: "text",
+          text:
+            "Labels found:\n\n" +
+            removeNulls(
+              result.value.tags.map((tag) =>
+                tag.tag && trim(tag.tag)
+                  ? `${tag.tag} (${tag.match_count} matches)`
+                  : null
+              )
+            ).join("\n"),
+        },
+      ]);
+    },
+  };
+  return buildTools(INCLUDE_DATA_WITH_TAGS_TOOLS_METADATA, handlers);
+}

--- a/front/lib/api/actions/tools/find_tags.ts
+++ b/front/lib/api/actions/tools/find_tags.ts
@@ -1,17 +1,17 @@
-// eslint-disable-next-line dust/enforce-client-types-in-public-api
-import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { TextContent } from "@modelcontextprotocol/sdk/types.js";
 import trim from "lodash/trim";
-import { z } from "zod";
 
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import { FIND_TAGS_TOOL_NAME } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { DataSourcesToolConfigurationType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
-import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { getCoreSearchArgs } from "@app/lib/actions/mcp_internal_actions/tools/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
+import {
+  FIND_TAGS_BASE_DESCRIPTION,
+  findTagsSchema,
+} from "@app/lib/api/actions/servers/include_data/metadata";
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -20,19 +20,6 @@ import type { Result } from "@app/types";
 import { CoreAPI, Err, Ok, removeNulls } from "@app/types";
 
 const DEFAULT_SEARCH_LABELS_UPPER_LIMIT = 2000;
-
-export const findTagsSchema = {
-  query: z
-    .string()
-    .describe(
-      "The text to search for in existing labels (also called tags) using edge ngram " +
-        "matching (case-insensitive). Matches labels that start with any word in the " +
-        "search text. The returned labels can be used in tagsIn/tagsNot parameters to " +
-        "restrict or exclude content based on the user request and conversation context."
-    ),
-  dataSources:
-    ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE],
-};
 
 export async function executeFindTags(
   auth: Authenticator,
@@ -132,16 +119,9 @@ export function registerFindTagsTool(
   agentLoopContext: AgentLoopContextType | undefined,
   { name, extraDescription }: { name: string; extraDescription?: string }
 ) {
-  const baseDescription =
-    `Find exact matching labels (also called tags).` +
-    "Restricting or excluding content succeeds only with existing labels. " +
-    "Searching without verifying labels first typically returns no results." +
-    "The output of this tool can typically be used in `tagsIn` (if we want " +
-    "to restrict the search to specific tags) or `tagsNot` (if we want to " +
-    "exclude specific tags) parameters.";
   const toolDescription = extraDescription
-    ? baseDescription + "\n" + extraDescription
-    : baseDescription;
+    ? FIND_TAGS_BASE_DESCRIPTION + "\n" + extraDescription
+    : FIND_TAGS_BASE_DESCRIPTION;
 
   server.tool(
     name,

--- a/front/lib/api/actions/tools/find_tags.ts
+++ b/front/lib/api/actions/tools/find_tags.ts
@@ -1,13 +1,14 @@
+// eslint-disable-next-line dust/enforce-client-types-in-public-api
+import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { TextContent } from "@modelcontextprotocol/sdk/types.js";
 import trim from "lodash/trim";
+import z from "zod";
 
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import { FIND_TAGS_TOOL_NAME } from "@app/lib/actions/mcp_internal_actions/constants";
-import {
-  ConfigurableToolInputSchemas,
-  type DataSourcesToolConfigurationType,
-} from "@app/lib/actions/mcp_internal_actions/input_schemas";
+import type { DataSourcesToolConfigurationType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
+import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { getCoreSearchArgs } from "@app/lib/actions/mcp_internal_actions/tools/utils";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
@@ -17,8 +18,6 @@ import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types";
 import { CoreAPI, Err, Ok, removeNulls } from "@app/types";
-import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
-import z from "zod";
 
 const DEFAULT_SEARCH_LABELS_UPPER_LIMIT = 2000;
 

--- a/front/lib/api/actions/tools/find_tags.ts
+++ b/front/lib/api/actions/tools/find_tags.ts
@@ -1,5 +1,7 @@
+// eslint-disable-next-line dust/enforce-client-types-in-public-api
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { TextContent } from "@modelcontextprotocol/sdk/types.js";
 import trim from "lodash/trim";
 import { z } from "zod";
 
@@ -14,6 +16,7 @@ import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
+import type { Result } from "@app/types";
 import { CoreAPI, Err, Ok, removeNulls } from "@app/types";
 
 const DEFAULT_SEARCH_LABELS_UPPER_LIMIT = 2000;
@@ -30,6 +33,98 @@ export const findTagsSchema = {
   dataSources:
     ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE],
 };
+
+export async function executeFindTags(
+  auth: Authenticator,
+  query: string,
+  dataSources: DataSourcesToolConfigurationType
+): Promise<Result<TextContent[], MCPError>> {
+  const coreSearchArgsResults = await concurrentExecutor(
+    dataSources,
+    async (dataSourceConfiguration) =>
+      getCoreSearchArgs(auth, dataSourceConfiguration),
+    { concurrency: 10 }
+  );
+
+  if (coreSearchArgsResults.some((res) => res.isErr())) {
+    return new Err(
+      new MCPError(
+        "Invalid data sources: " +
+          removeNulls(
+            coreSearchArgsResults.map((res) => (res.isErr() ? res.error : null))
+          )
+            .map((error) => error.message)
+            .join("\n")
+      )
+    );
+  }
+
+  const coreSearchArgs = removeNulls(
+    coreSearchArgsResults.map((res) => (res.isOk() ? res.value : null))
+  );
+
+  if (coreSearchArgs.length === 0) {
+    return new Err(
+      new MCPError(
+        "Search action must have at least one data source configured.",
+        {
+          tracked: false,
+        }
+      )
+    );
+  }
+
+  const dataSourceViews = coreSearchArgs.map((arg) => arg.dataSourceView);
+
+  const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
+  let result = await coreAPI.searchTags({
+    dataSourceViews,
+    query,
+    queryType: "match",
+  });
+
+  if (result.isErr()) {
+    return new Err(new MCPError("Error searching for labels"));
+  }
+
+  if (result.value.tags.length === 0) {
+    // Performing an additional search with a higher limit to catch uncommon tags.
+    result = await coreAPI.searchTags({
+      dataSourceViews,
+      limit: DEFAULT_SEARCH_LABELS_UPPER_LIMIT,
+      query,
+      queryType: "match",
+    });
+
+    if (result.isErr()) {
+      return new Err(new MCPError("Error searching for labels"));
+    }
+  }
+
+  if (result.value.tags.length === 0) {
+    return new Ok([
+      {
+        type: "text",
+        text: "No labels found matching the search criteria.",
+      },
+    ]);
+  }
+
+  return new Ok([
+    {
+      type: "text",
+      text:
+        "Labels found:\n\n" +
+        removeNulls(
+          result.value.tags.map((tag) =>
+            tag.tag && trim(tag.tag)
+              ? `${tag.tag} (${tag.match_count} matches)`
+              : null
+          )
+        ).join("\n"),
+    },
+  ]);
+}
 
 export function registerFindTagsTool(
   auth: Authenticator,
@@ -66,93 +161,7 @@ export function registerFindTagsTool(
         query: string;
         dataSources: DataSourcesToolConfigurationType[number][];
       }) => {
-        const coreSearchArgsResults = await concurrentExecutor(
-          dataSources,
-          async (dataSourceConfiguration) =>
-            getCoreSearchArgs(auth, dataSourceConfiguration),
-          { concurrency: 10 }
-        );
-
-        if (coreSearchArgsResults.some((res) => res.isErr())) {
-          return new Err(
-            new MCPError(
-              "Invalid data sources: " +
-                removeNulls(
-                  coreSearchArgsResults.map((res) =>
-                    res.isErr() ? res.error : null
-                  )
-                )
-                  .map((error) => error.message)
-                  .join("\n")
-            )
-          );
-        }
-
-        const coreSearchArgs = removeNulls(
-          coreSearchArgsResults.map((res) => (res.isOk() ? res.value : null))
-        );
-
-        if (coreSearchArgs.length === 0) {
-          return new Err(
-            new MCPError(
-              "Search action must have at least one data source configured.",
-              {
-                tracked: false,
-              }
-            )
-          );
-        }
-
-        const dataSourceViews = coreSearchArgs.map((arg) => arg.dataSourceView);
-
-        const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
-        let result = await coreAPI.searchTags({
-          dataSourceViews,
-          query,
-          queryType: "match",
-        });
-
-        if (result.isErr()) {
-          return new Err(new MCPError("Error searching for labels"));
-        }
-
-        if (result.value.tags.length === 0) {
-          // Performing an additional search with a higher limit to catch uncommon tags.
-          result = await coreAPI.searchTags({
-            dataSourceViews,
-            limit: DEFAULT_SEARCH_LABELS_UPPER_LIMIT,
-            query,
-            queryType: "match",
-          });
-
-          if (result.isErr()) {
-            return new Err(new MCPError("Error searching for labels"));
-          }
-        }
-
-        if (result.value.tags.length === 0) {
-          return new Ok([
-            {
-              type: "text",
-              text: "No labels found matching the search criteria.",
-            },
-          ]);
-        }
-
-        return new Ok([
-          {
-            type: "text",
-            text:
-              "Labels found:\n\n" +
-              removeNulls(
-                result.value.tags.map((tag) =>
-                  tag.tag && trim(tag.tag)
-                    ? `${tag.tag} (${tag.match_count} matches)`
-                    : null
-                )
-              ).join("\n"),
-          },
-        ]);
+        return executeFindTags(auth, query, dataSources);
       }
     )
   );

--- a/front/lib/resources/internal_mcp_server_in_memory_resource.ts
+++ b/front/lib/resources/internal_mcp_server_in_memory_resource.ts
@@ -80,27 +80,18 @@ export class InternalMCPServerInMemoryResource {
     const server = new this(id, availability);
 
     const serverMetadata = getInternalMCPServerMetadata(name);
-    if (serverMetadata) {
+    if (typeof serverMetadata !== "undefined") {
       server.metadata = {
         ...serverMetadata.serverInfo,
         tools: serverMetadata.tools,
       };
-    } else {
-      // TODO(SKILLS 2025-12-16 flav): Temporary dynamic import to avoid circular dependency.
-      // Bigger refactoring to extract this logic from the resource will come later.
-      const { getCachedMetadata } =
-        await import("@app/lib/actions/mcp_cached_metadata");
-      const cachedMetadata = await getCachedMetadata(auth, id);
-      if (!cachedMetadata) {
-        return null;
-      }
+      server.internalServerCredential =
+        await server.fetchInternalServerCredential(auth);
 
-      server.metadata = cachedMetadata;
+      return server;
     }
-    server.internalServerCredential =
-      await server.fetchInternalServerCredential(auth);
 
-    return server;
+    return undefined;
   }
 
   static async makeNew(


### PR DESCRIPTION
## Description

* Create new include_data server at lib/api/actions/servers/include_data/ following the standardized MCP server pattern
* Move metadata to metadata.ts using createToolsRecord for type-safe tool definitions with exhaustive handlers
* Move tool handlers to tools/index.ts using the ToolHandlers type for compile-time exhaustivity checking
* Create index.ts entry point using registerTool pattern
* Update constants.ts to use metadata: INCLUDE_DATA_SERVER
* Move logic from lib/actions/mcp_internal_actions/tools/tags/find_tags.ts to lib/api/actions/tools/find_tags.ts
* Update servers/index.ts to import from new location

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
