### PR TITLE
[front] enh(poke): extend list of available tools in poke suggested skill creation

### DIFF
--- a/front/components/poke/skills/CreateSkillSuggestionSheet.tsx
+++ b/front/components/poke/skills/CreateSkillSuggestionSheet.tsx
@@ -215,33 +215,35 @@ export function CreateSkillSuggestionSheet({
             <div className="flex flex-col gap-2">
               <div className="flex items-center justify-between">
                 <Label>MCP Servers</Label>
-                {isMCPServerViewsLoading ? (
-                  <Spinner size="xs" />
-                ) : (
-                  <DropdownMenu modal={false}>
-                    <DropdownMenuTrigger asChild>
-                      <Button
-                        icon={PlusIcon}
-                        variant="outline"
-                        label="Add"
-                        isSelect
-                        size="xs"
-                      />
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent
-                      className="w-80"
-                      onAnimationEnd={() => setMCPSearchText("")}
-                    >
-                      <DropdownMenuSearchbar
-                        autoFocus
-                        placeholder="Search MCP servers..."
-                        name="mcp-search"
-                        value={mcpSearchText}
-                        onChange={setMCPSearchText}
-                      />
-                      <DropdownMenuSeparator />
-                      <div className="max-h-60 overflow-auto">
-                        {filteredMcpServerViews.map((view) => (
+                <DropdownMenu modal={false}>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      icon={PlusIcon}
+                      variant="outline"
+                      label="Add"
+                      isSelect
+                      size="xs"
+                    />
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent
+                    className="w-80"
+                    onAnimationEnd={() => setMCPSearchText("")}
+                  >
+                    <DropdownMenuSearchbar
+                      autoFocus
+                      placeholder="Search MCP servers..."
+                      name="mcp-search"
+                      value={mcpSearchText}
+                      onChange={setMCPSearchText}
+                    />
+                    <DropdownMenuSeparator />
+                    <div className="max-h-60 overflow-auto">
+                      {isMCPServerViewsLoading ? (
+                        <div className="flex items-center justify-center py-4">
+                          <Spinner size="sm" />
+                        </div>
+                      ) : (
+                        filteredMcpServerViews.map((view) => (
                           <DropdownMenuCheckboxItem
                             key={view.sId}
                             label={getMcpServerViewDisplayName(view)}
@@ -262,11 +264,11 @@ export function CreateSkillSuggestionSheet({
                             }}
                             onSelect={(e) => e.preventDefault()}
                           />
-                        ))}
-                      </div>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                )}
+                        ))
+                      )}
+                    </div>
+                  </DropdownMenuContent>
+                </DropdownMenu>
               </div>
               {selectedMCPServerViews.length > 0 && (
                 <div className="flex flex-wrap gap-2">

--- a/front/components/poke/skills/CreateSkillSuggestionSheet.tsx
+++ b/front/components/poke/skills/CreateSkillSuggestionSheet.tsx
@@ -290,7 +290,7 @@ export function CreateSkillSuggestionSheet({
 
             <div className="flex justify-end gap-2">
               <Button
-                variant="ghost"
+                variant="outline"
                 label="Cancel"
                 onClick={handleClose}
                 disabled={isSubmitting}

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -12,7 +12,6 @@ import type {
 } from "sequelize";
 import { Op } from "sequelize";
 
-import type { AutoInternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import {
   getAgentConfiguration,
   updateAgentRequirements,
@@ -306,18 +305,17 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       "workspaceId" | "status" | "editedBy" | "requestedSpaceIds"
     >,
     {
-      mcpServerNames,
+      mcpServerViewIds,
     }: {
-      mcpServerNames: AutoInternalMCPServerNameType[];
+      mcpServerViewIds: string[];
     }
   ): Promise<Result<SkillResource, Error>> {
-    const mcpServerViews =
-      await MCPServerViewResource.getMCPServerViewsForAutoInternalTools(
-        auth,
-        mcpServerNames
-      );
+    const mcpServerViews = await MCPServerViewResource.fetchByIds(
+      auth,
+      mcpServerViewIds
+    );
 
-    if (mcpServerViews.length !== mcpServerNames.length) {
+    if (mcpServerViews.length !== mcpServerViewIds.length) {
       return new Err(new Error("Some MCP server views are missing."));
     }
 

--- a/front/pages/api/poke/workspaces/[wId]/mcp/views/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/mcp/views/index.ts
@@ -5,6 +5,7 @@ import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
 
@@ -44,8 +45,18 @@ async function handler(
 
   switch (req.method) {
     case "GET":
-      // Get all MCP server views for the workspace
-      const mcpServerViews = await MCPServerViewResource.listByWorkspace(auth);
+      const { globalSpaceOnly } = req.query;
+
+      let mcpServerViews: MCPServerViewResource[];
+      if (globalSpaceOnly === "true") {
+        const globalSpace = await SpaceResource.fetchWorkspaceGlobalSpace(auth);
+        mcpServerViews = await MCPServerViewResource.listBySpace(
+          auth,
+          globalSpace
+        );
+      } else {
+        mcpServerViews = await MCPServerViewResource.listByWorkspace(auth);
+      }
 
       return res.status(200).json({
         serverViews: mcpServerViews.map((sv) => sv.toJSON()),

--- a/front/pages/api/poke/workspaces/[wId]/skills/suggestions.ts
+++ b/front/pages/api/poke/workspaces/[wId]/skills/suggestions.ts
@@ -1,8 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 
-import type { AutoInternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
-import { INTERNAL_MCP_SERVERS } from "@app/lib/actions/mcp_internal_actions/constants";
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { getSkillIconSuggestion } from "@app/lib/api/skills/icon_suggestion";
 import { Authenticator } from "@app/lib/auth";
@@ -13,10 +11,6 @@ import type { WithAPIErrorResponse } from "@app/types";
 import { isString } from "@app/types";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 
-const AUTO_INTERNAL_MCP_SERVER_NAMES = Object.entries(INTERNAL_MCP_SERVERS)
-  .filter(([, server]) => server.availability === "auto")
-  .map(([name]) => name);
-
 const PostSkillSuggestionBodySchema = z.object({
   name: z.string().min(1, "Name is required."),
   userFacingDescription: z.string().min(1, "Description is required."),
@@ -25,17 +19,7 @@ const PostSkillSuggestionBodySchema = z.object({
     .min(1, "What will this skill be used for is required."),
   instructions: z.string().min(1, "Instructions are required."),
   icon: z.string().nullable(),
-  mcpServerNames: z.array(
-    z
-      .string()
-      .refine(
-        (name): name is AutoInternalMCPServerNameType =>
-          AUTO_INTERNAL_MCP_SERVER_NAMES.includes(
-            name as AutoInternalMCPServerNameType
-          ),
-        { message: "Invalid MCP server name." }
-      )
-  ),
+  mcpServerViewIds: z.array(z.string()),
 });
 
 export type PostSkillSuggestionBodyType = z.infer<
@@ -95,7 +79,7 @@ async function handler(
         agentFacingDescription,
         instructions,
         icon,
-        mcpServerNames,
+        mcpServerViewIds,
       } = bodyResult.data;
 
       let skillIcon = icon;
@@ -122,7 +106,7 @@ async function handler(
           extendedSkillId: null,
         },
         {
-          mcpServerNames,
+          mcpServerViewIds,
         }
       );
 

--- a/front/poke/swr/mcp_server_views.ts
+++ b/front/poke/swr/mcp_server_views.ts
@@ -18,10 +18,13 @@ export function usePokeMCPServerViews({
 }: UsePokeMCPServerViewsProps) {
   const mcpServerViewsFetcher: Fetcher<PokeListMCPServerViews> = fetcher;
 
-  const queryParams = globalSpaceOnly ? "?globalSpaceOnly=true" : "";
+  const params = new URLSearchParams();
+  if (globalSpaceOnly) {
+    params.set("globalSpaceOnly", "true");
+  }
 
   const { data, error, mutate } = useSWRWithDefaults(
-    `/api/poke/workspaces/${owner.sId}/mcp/views${queryParams}`,
+    `/api/poke/workspaces/${owner.sId}/mcp/views?${params.toString()}`,
     mcpServerViewsFetcher,
     { disabled }
   );

--- a/front/poke/swr/mcp_server_views.ts
+++ b/front/poke/swr/mcp_server_views.ts
@@ -4,17 +4,24 @@ import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeListMCPServerViews } from "@app/pages/api/poke/workspaces/[wId]/mcp/views";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 
+interface UsePokeMCPServerViewsProps extends PokeConditionalFetchProps {
+  globalSpaceOnly?: boolean;
+}
+
 /*
  * MCP server views for poke.
  */
 export function usePokeMCPServerViews({
   disabled,
   owner,
-}: PokeConditionalFetchProps) {
+  globalSpaceOnly,
+}: UsePokeMCPServerViewsProps) {
   const mcpServerViewsFetcher: Fetcher<PokeListMCPServerViews> = fetcher;
 
+  const queryParams = globalSpaceOnly ? "?globalSpaceOnly=true" : "";
+
   const { data, error, mutate } = useSWRWithDefaults(
-    `/api/poke/workspaces/${owner.sId}/mcp/views`,
+    `/api/poke/workspaces/${owner.sId}/mcp/views${queryParams}`,
     mcpServerViewsFetcher,
     { disabled }
   );


### PR DESCRIPTION
## Description

- The ability to push a skill suggestion from poke was added in https://github.com/dust-tt/dust/pull/20487
- This PR improves the list of MCP servers available when creating a skill suggestion to match what is available in the Skill Builder: MCP servers with `auto` or `manual` availability (no `auto_hidden_builder`) without any configuration required.
- No major visual change apart from the style of the Cancel button being fixed.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
