### PR TITLE
[connectors] Handle ExternalOAuthTokenError in GitHub retrievePermissions

### DIFF
--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -26,6 +26,7 @@ import {
   BaseConnectorManager,
   ConnectorManagerError,
 } from "@connectors/connectors/interface";
+import { ExternalOAuthTokenError } from "@connectors/lib/error";
 import {
   GithubCodeDirectoryModel,
   GithubCodeFileModel,
@@ -279,7 +280,8 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
       );
     }
 
-    if (!parentInternalId) {
+    try {
+      if (!parentInternalId) {
       // No parentInternalId: we return the repositories.
 
       let nodes: ContentNode[] = [];
@@ -492,6 +494,18 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
         default:
           assertNever(type);
       }
+    }
+    } catch (e) {
+      if (e instanceof ExternalOAuthTokenError) {
+        return new Err(
+          new ConnectorManagerError(
+            "EXTERNAL_OAUTH_TOKEN_ERROR",
+            "GitHub authorization error, please re-authorize."
+          )
+        );
+      }
+      // Unhandled error, throwing to get a 500.
+      throw e;
     }
   }
 

--- a/connectors/src/connectors/github/index.ts
+++ b/connectors/src/connectors/github/index.ts
@@ -282,219 +282,219 @@ export class GithubConnectorManager extends BaseConnectorManager<null> {
 
     try {
       if (!parentInternalId) {
-      // No parentInternalId: we return the repositories.
+        // No parentInternalId: we return the repositories.
 
-      let nodes: ContentNode[] = [];
-      let pageNumber = 1; // 1-indexed
-      for (;;) {
-        const pageRes = await getReposPage(
-          c,
-          pageNumber,
-          MAX_REPOSITORIES_PAGE_SIZE
-        );
-
-        if (pageRes.isErr()) {
-          return new Err(
-            new ConnectorManagerError(
-              "EXTERNAL_OAUTH_TOKEN_ERROR",
-              pageRes.error.message
-            )
+        let nodes: ContentNode[] = [];
+        let pageNumber = 1; // 1-indexed
+        for (;;) {
+          const pageRes = await getReposPage(
+            c,
+            pageNumber,
+            MAX_REPOSITORIES_PAGE_SIZE
           );
-        }
 
-        const page = pageRes.value;
-        pageNumber += 1;
-        if (page.length === 0) {
-          break;
-        }
-
-        nodes = nodes.concat(
-          page.map((repo) => ({
-            internalId: getRepositoryInternalId(repo.id),
-            parentInternalId: null,
-            type: "folder",
-            title: repo.name,
-            sourceUrl: repo.url,
-            expandable: true,
-            permission: "read",
-            lastUpdatedAt: null,
-            mimeType: INTERNAL_MIME_TYPES.GITHUB.REPOSITORY,
-          }))
-        );
-      }
-
-      nodes.sort((a, b) => {
-        return a.title.localeCompare(b.title);
-      });
-
-      return new Ok(nodes);
-    } else {
-      const { type, repoId } = matchGithubInternalIdType(parentInternalId);
-      if (isNaN(repoId)) {
-        return new Err(
-          new ConnectorManagerError(
-            "INVALID_PARENT_INTERNAL_ID",
-            `Invalid parentInternalId Github repoId: ${parentInternalId}`
-          )
-        );
-      }
-
-      switch (type) {
-        case "REPO_FULL": {
-          const [latestDiscussion, latestIssue, repoRes, codeRepo] =
-            await Promise.all([
-              GithubDiscussionModel.findOne({
-                where: {
-                  connectorId: c.id,
-                  repoId: repoId.toString(),
-                },
-                order: [["updatedAt", "DESC"]],
-              }),
-              GithubIssueModel.findOne({
-                where: {
-                  connectorId: c.id,
-                  repoId: repoId.toString(),
-                },
-                order: [["updatedAt", "DESC"]],
-              }),
-              getRepo(c, repoId),
-              GithubCodeRepositoryModel.findOne({
-                where: {
-                  connectorId: c.id,
-                  repoId: repoId.toString(),
-                },
-              }),
-            ]);
-
-          if (repoRes.isErr()) {
+          if (pageRes.isErr()) {
             return new Err(
               new ConnectorManagerError(
                 "EXTERNAL_OAUTH_TOKEN_ERROR",
-                repoRes.error.message
+                pageRes.error.message
               )
             );
           }
 
-          const repo = repoRes.value;
-
-          const nodes: ContentNode[] = [];
-
-          if (latestIssue) {
-            nodes.push({
-              internalId: getIssuesInternalId(repoId),
-              parentInternalId,
-              type: "folder",
-              title: "Issues",
-              sourceUrl: getIssuesUrl(repo.url),
-              expandable: false,
-              permission: "read",
-              lastUpdatedAt: latestIssue.updatedAt.getTime(),
-              mimeType: INTERNAL_MIME_TYPES.GITHUB.ISSUES,
-            });
+          const page = pageRes.value;
+          pageNumber += 1;
+          if (page.length === 0) {
+            break;
           }
 
-          if (latestDiscussion) {
-            nodes.push({
-              internalId: getDiscussionsInternalId(repoId),
-              parentInternalId,
+          nodes = nodes.concat(
+            page.map((repo) => ({
+              internalId: getRepositoryInternalId(repo.id),
+              parentInternalId: null,
               type: "folder",
-              title: "Discussions",
-              sourceUrl: getDiscussionsUrl(repo.url),
-              expandable: false,
-              permission: "read",
-              lastUpdatedAt: latestDiscussion.updatedAt.getTime(),
-              mimeType: INTERNAL_MIME_TYPES.GITHUB.DISCUSSIONS,
-            });
-          }
-
-          if (codeRepo) {
-            nodes.push({
-              internalId: getCodeRootInternalId(repoId),
-              parentInternalId,
-              type: "folder",
-              title: "Code",
+              title: repo.name,
               sourceUrl: repo.url,
               expandable: true,
               permission: "read",
-              lastUpdatedAt: codeRepo.codeUpdatedAt.getTime(),
-              mimeType: INTERNAL_MIME_TYPES.GITHUB.CODE_ROOT,
-            });
-          }
-
-          return new Ok(nodes);
+              lastUpdatedAt: null,
+              mimeType: INTERNAL_MIME_TYPES.GITHUB.REPOSITORY,
+            }))
+          );
         }
-        case "REPO_CODE":
-        case "REPO_CODE_DIR": {
-          const [files, directories] = await Promise.all([
-            GithubCodeFileModel.findAll({
-              where: {
-                connectorId: c.id,
-                parentInternalId,
-              },
-            }),
-            GithubCodeDirectoryModel.findAll({
-              where: {
-                connectorId: c.id,
-                parentInternalId,
-              },
-            }),
-          ]);
 
-          files.sort((a, b) => {
-            return a.fileName.localeCompare(b.fileName);
-          });
-          directories.sort((a, b) => {
-            return a.dirName.localeCompare(b.dirName);
-          });
+        nodes.sort((a, b) => {
+          return a.title.localeCompare(b.title);
+        });
 
-          const nodes: ContentNode[] = [];
-
-          directories.forEach((directory) => {
-            nodes.push({
-              internalId: directory.internalId,
-              parentInternalId,
-              type: "folder",
-              title: directory.dirName,
-              sourceUrl: directory.sourceUrl,
-              expandable: true,
-              permission: "read",
-              lastUpdatedAt: directory.codeUpdatedAt.getTime(),
-              mimeType: INTERNAL_MIME_TYPES.GITHUB.CODE_DIRECTORY,
-            });
-          });
-
-          files.forEach((file) => {
-            nodes.push({
-              internalId: file.documentId,
-              parentInternalId,
-              type: "document",
-              title: file.fileName,
-              sourceUrl: file.sourceUrl,
-              expandable: false,
-              permission: "read",
-              lastUpdatedAt: file.codeUpdatedAt.getTime(),
-              mimeType: INTERNAL_MIME_TYPES.GITHUB.CODE_FILE,
-            });
-          });
-
-          return new Ok(nodes);
-        }
-        // we should never be getting issues, discussions, code files, single issues or discussions as parent
-        case "REPO_ISSUES":
-        case "REPO_DISCUSSIONS":
-        case "REPO_CODE_FILE":
-        case "REPO_DISCUSSION":
-        case "REPO_ISSUE":
+        return new Ok(nodes);
+      } else {
+        const { type, repoId } = matchGithubInternalIdType(parentInternalId);
+        if (isNaN(repoId)) {
           return new Err(
             new ConnectorManagerError(
               "INVALID_PARENT_INTERNAL_ID",
-              `Invalid parentInternalId Github type: ${type}`
+              `Invalid parentInternalId Github repoId: ${parentInternalId}`
             )
           );
-        default:
-          assertNever(type);
+        }
+
+        switch (type) {
+          case "REPO_FULL": {
+            const [latestDiscussion, latestIssue, repoRes, codeRepo] =
+              await Promise.all([
+                GithubDiscussionModel.findOne({
+                  where: {
+                    connectorId: c.id,
+                    repoId: repoId.toString(),
+                  },
+                  order: [["updatedAt", "DESC"]],
+                }),
+                GithubIssueModel.findOne({
+                  where: {
+                    connectorId: c.id,
+                    repoId: repoId.toString(),
+                  },
+                  order: [["updatedAt", "DESC"]],
+                }),
+                getRepo(c, repoId),
+                GithubCodeRepositoryModel.findOne({
+                  where: {
+                    connectorId: c.id,
+                    repoId: repoId.toString(),
+                  },
+                }),
+              ]);
+
+            if (repoRes.isErr()) {
+              return new Err(
+                new ConnectorManagerError(
+                  "EXTERNAL_OAUTH_TOKEN_ERROR",
+                  repoRes.error.message
+                )
+              );
+            }
+
+            const repo = repoRes.value;
+
+            const nodes: ContentNode[] = [];
+
+            if (latestIssue) {
+              nodes.push({
+                internalId: getIssuesInternalId(repoId),
+                parentInternalId,
+                type: "folder",
+                title: "Issues",
+                sourceUrl: getIssuesUrl(repo.url),
+                expandable: false,
+                permission: "read",
+                lastUpdatedAt: latestIssue.updatedAt.getTime(),
+                mimeType: INTERNAL_MIME_TYPES.GITHUB.ISSUES,
+              });
+            }
+
+            if (latestDiscussion) {
+              nodes.push({
+                internalId: getDiscussionsInternalId(repoId),
+                parentInternalId,
+                type: "folder",
+                title: "Discussions",
+                sourceUrl: getDiscussionsUrl(repo.url),
+                expandable: false,
+                permission: "read",
+                lastUpdatedAt: latestDiscussion.updatedAt.getTime(),
+                mimeType: INTERNAL_MIME_TYPES.GITHUB.DISCUSSIONS,
+              });
+            }
+
+            if (codeRepo) {
+              nodes.push({
+                internalId: getCodeRootInternalId(repoId),
+                parentInternalId,
+                type: "folder",
+                title: "Code",
+                sourceUrl: repo.url,
+                expandable: true,
+                permission: "read",
+                lastUpdatedAt: codeRepo.codeUpdatedAt.getTime(),
+                mimeType: INTERNAL_MIME_TYPES.GITHUB.CODE_ROOT,
+              });
+            }
+
+            return new Ok(nodes);
+          }
+          case "REPO_CODE":
+          case "REPO_CODE_DIR": {
+            const [files, directories] = await Promise.all([
+              GithubCodeFileModel.findAll({
+                where: {
+                  connectorId: c.id,
+                  parentInternalId,
+                },
+              }),
+              GithubCodeDirectoryModel.findAll({
+                where: {
+                  connectorId: c.id,
+                  parentInternalId,
+                },
+              }),
+            ]);
+
+            files.sort((a, b) => {
+              return a.fileName.localeCompare(b.fileName);
+            });
+            directories.sort((a, b) => {
+              return a.dirName.localeCompare(b.dirName);
+            });
+
+            const nodes: ContentNode[] = [];
+
+            directories.forEach((directory) => {
+              nodes.push({
+                internalId: directory.internalId,
+                parentInternalId,
+                type: "folder",
+                title: directory.dirName,
+                sourceUrl: directory.sourceUrl,
+                expandable: true,
+                permission: "read",
+                lastUpdatedAt: directory.codeUpdatedAt.getTime(),
+                mimeType: INTERNAL_MIME_TYPES.GITHUB.CODE_DIRECTORY,
+              });
+            });
+
+            files.forEach((file) => {
+              nodes.push({
+                internalId: file.documentId,
+                parentInternalId,
+                type: "document",
+                title: file.fileName,
+                sourceUrl: file.sourceUrl,
+                expandable: false,
+                permission: "read",
+                lastUpdatedAt: file.codeUpdatedAt.getTime(),
+                mimeType: INTERNAL_MIME_TYPES.GITHUB.CODE_FILE,
+              });
+            });
+
+            return new Ok(nodes);
+          }
+          // we should never be getting issues, discussions, code files, single issues or discussions as parent
+          case "REPO_ISSUES":
+          case "REPO_DISCUSSIONS":
+          case "REPO_CODE_FILE":
+          case "REPO_DISCUSSION":
+          case "REPO_ISSUE":
+            return new Err(
+              new ConnectorManagerError(
+                "INVALID_PARENT_INTERNAL_ID",
+                `Invalid parentInternalId Github type: ${type}`
+              )
+            );
+          default:
+            assertNever(type);
+        }
       }
-    }
     } catch (e) {
       if (e instanceof ExternalOAuthTokenError) {
         return new Err(


### PR DESCRIPTION
## Description

Fixes [unhandled api errors](https://app.datadoghq.eu/logs?query=%22Unhandled%20API%20Error%22%20status%3Aerror%20%40dd.env%3Aprod&agg_m=count&agg_m_source=base&agg_q=%40url&agg_t=count&analyticsOptions=%5B%22bars%22%2C%22dog_classic%22%2Cnull%2Cnull%2C%22value%22%5D&clustering_pattern_field_path=message&cols=host%2Cservice&fromUser=true&messageDisplay=inline&panel=%7B%22queryString%22%3A%22%40url%3A%5C%22%2Fconnectors%2F274877909369%2Fpermissions%3FviewType%3Dall%26%5C%22%22%2C%22filters%22%3A%5B%7B%22isClicked%22%3Atrue%2C%22source%22%3A%22log%22%2C%22path%22%3A%22url%22%2C%22value%22%3A%22%2Fconnectors%2F274877909369%2Fpermissions%3FviewType%3Dall%26%22%7D%5D%2C%22queryId%22%3A%22a%22%2C%22timeRange%22%3A%7B%22from%22%3A1769077200000%2C%22to%22%3A1769077800000%2C%22live%22%3Afalse%7D%7D&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=toplist&from_ts=1769077200000&to_ts=1769077800000&live=false)

When a GitHub OAuth token is revoked, the `retrievePermissions` method was throwing an unhandled `ExternalOAuthTokenError` instead of returning a proper API error. This fix adds a try-catch block following the same pattern used by other connectors (Slack, Google Drive, Microsoft, Confluence).

Now when a token is revoked, the API returns a 401 with `connector_authorization_error` type instead of a 500 unhandled error.

## Risks

Blast radius: GitHub connector permissions endpoint
Risk: low

## Deploy Plan
- pmrr
- deploy connectors