### PR TITLE
[front] enh(ToolsPicker): add filter buttons to select Skills only or Tools only

### DIFF
--- a/front/components/agent_builder/capabilities/capabilities_sheet/CapabilitiesSelectionPage.tsx
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/CapabilitiesSelectionPage.tsx
@@ -3,11 +3,11 @@ import React, { useMemo, useState } from "react";
 
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import { SkillCard } from "@app/components/agent_builder/capabilities/capabilities_sheet/SkillCard";
-import { CapabilityFilterButtons } from "@app/components/shared/tools_picker/CapabilityFilterButtons";
-import type { CapabilityFilterType } from "@app/components/shared/tools_picker/types";
 import { MCPServerCard } from "@app/components/agent_builder/capabilities/mcp/MCPServerSelectionPage";
 import type { SheetState } from "@app/components/agent_builder/skills/types";
+import { CapabilityFilterButtons } from "@app/components/shared/tools_picker/CapabilityFilterButtons";
 import type { MCPServerViewTypeWithLabel } from "@app/components/shared/tools_picker/MCPServerViewsContext";
+import type { CapabilityFilterType } from "@app/components/shared/tools_picker/types";
 import { useSkillWithRelations } from "@app/lib/swr/skill_configurations";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 

--- a/front/components/agent_builder/capabilities/capabilities_sheet/CapabilitiesSelectionPage.tsx
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/CapabilitiesSelectionPage.tsx
@@ -1,9 +1,10 @@
-import { Button, SearchInput, Spinner } from "@dust-tt/sparkle";
+import { SearchInput, Spinner } from "@dust-tt/sparkle";
 import React, { useMemo, useState } from "react";
 
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import { SkillCard } from "@app/components/agent_builder/capabilities/capabilities_sheet/SkillCard";
-import type { CapabilityFilterType } from "@app/components/agent_builder/capabilities/capabilities_sheet/types";
+import { CapabilityFilterButtons } from "@app/components/shared/tools_picker/CapabilityFilterButtons";
+import type { CapabilityFilterType } from "@app/components/shared/tools_picker/types";
 import { MCPServerCard } from "@app/components/agent_builder/capabilities/mcp/MCPServerSelectionPage";
 import type { SheetState } from "@app/components/agent_builder/skills/types";
 import type { MCPServerViewTypeWithLabel } from "@app/components/shared/tools_picker/MCPServerViewsContext";
@@ -81,26 +82,7 @@ export function CapabilitiesSelectionPageContent({
         name="capability-search"
       />
 
-      <div className="flex gap-2">
-        <Button
-          label="All"
-          variant={filter === "all" ? "primary" : "outline"}
-          size="sm"
-          onClick={() => setFilter("all")}
-        />
-        <Button
-          label="Skills"
-          variant={filter === "skills" ? "primary" : "outline"}
-          size="sm"
-          onClick={() => setFilter("skills")}
-        />
-        <Button
-          label="Tools"
-          variant={filter === "tools" ? "primary" : "outline"}
-          size="sm"
-          onClick={() => setFilter("tools")}
-        />
-      </div>
+      <CapabilityFilterButtons filter={filter} setFilter={setFilter} />
 
       {isCapabilitiesLoading ? (
         <div className="flex h-40 items-center justify-center">

--- a/front/components/agent_builder/capabilities/capabilities_sheet/types.ts
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/types.ts
@@ -6,8 +6,6 @@ import type {
 } from "@app/components/agent_builder/skills/types";
 import type { BuilderAction } from "@app/components/shared/tools_picker/types";
 
-export type CapabilityFilterType = "all" | "tools" | "skills";
-
 export type CapabilitiesSheetContentProps = {
   isOpen: boolean;
   sheetState: CapabilitiesSheetState;

--- a/front/components/assistant/ToolsPicker.tsx
+++ b/front/components/assistant/ToolsPicker.tsx
@@ -15,6 +15,8 @@ import {
 import { useEffect, useMemo, useState } from "react";
 
 import { CreateMCPServerDialog } from "@app/components/actions/mcp/create/CreateMCPServerDialog";
+import { CapabilityFilterButtons } from "@app/components/shared/tools_picker/CapabilityFilterButtons";
+import type { CapabilityFilterType } from "@app/components/shared/tools_picker/types";
 import {
   getMcpServerViewDescription,
   getMcpServerViewDisplayName,
@@ -121,8 +123,6 @@ interface ToolsPickerProps {
   buttonSize?: "xs" | "sm" | "md";
 }
 
-type FilterType = "all" | "skills" | "tools";
-
 export function ToolsPicker({
   owner,
   selectedMCPServerViews,
@@ -136,7 +136,7 @@ export function ToolsPicker({
 }: ToolsPickerProps) {
   const [searchText, setSearchText] = useState("");
   const [isOpen, setIsOpen] = useState(false);
-  const [filter, setFilter] = useState<FilterType>("all");
+  const [filter, setFilter] = useState<CapabilityFilterType>("all");
   const [setupSheetServer, setSetupSheetServer] =
     useState<MCPServerType | null>(null);
   const [setupSheetRemoteServerConfig, setSetupSheetRemoteServerConfig] =
@@ -377,24 +377,11 @@ export function ToolsPicker({
                 }}
               />
               {hasSkillsFeature && (
-                <div className="flex gap-2 px-3 py-2">
-                  <Button
-                    label="All"
-                    variant={filter === "all" ? "primary" : "outline"}
+                <div className="px-3 py-2">
+                  <CapabilityFilterButtons
+                    filter={filter}
+                    setFilter={setFilter}
                     size="xs"
-                    onClick={() => setFilter("all")}
-                  />
-                  <Button
-                    label="Skills"
-                    variant={filter === "skills" ? "primary" : "outline"}
-                    size="xs"
-                    onClick={() => setFilter("skills")}
-                  />
-                  <Button
-                    label="Tools"
-                    variant={filter === "tools" ? "primary" : "outline"}
-                    size="xs"
-                    onClick={() => setFilter("tools")}
                   />
                 </div>
               )}

--- a/front/components/assistant/ToolsPicker.tsx
+++ b/front/components/assistant/ToolsPicker.tsx
@@ -299,7 +299,9 @@ export function ToolsPicker({
   const showToolsSection = filter === "all" || filter === "tools";
 
   const hasVisibleSkills =
-    showSkillsSection && hasSkillsFeature && filteredSkillsUnselected.length > 0;
+    showSkillsSection &&
+    hasSkillsFeature &&
+    filteredSkillsUnselected.length > 0;
   const hasVisibleTools =
     showToolsSection &&
     (filteredServerViewsUnselected.length > 0 ||
@@ -497,30 +499,24 @@ export function ToolsPicker({
               label={
                 searchText.length > 0
                   ? "No result"
-                  : filter === "skills"
-                    ? "No more skills to select"
-                    : filter === "tools"
-                      ? "No more tools to select"
-                      : hasSkillsFeature
-                        ? "No more skills or tools to select"
-                        : "No more tools to select"
+                  : filter !== "all"
+                    ? `No more ${filter} to select`
+                    : hasSkillsFeature
+                      ? "No more skills or tools to select"
+                      : "No more tools to select"
               }
               description={
                 searchText.length > 0
-                  ? filter === "skills"
-                    ? "No skills found matching your search."
-                    : filter === "tools"
-                      ? "No tools found matching your search."
-                      : hasSkillsFeature
-                        ? "No skills or tools found matching your search."
-                        : "No tools found matching your search."
-                  : filter === "skills"
-                    ? "All available skills are already selected."
-                    : filter === "tools"
-                      ? "All available tools are already selected."
-                      : hasSkillsFeature
-                        ? "All available skills and tools are already selected."
-                        : "All available tools are already selected."
+                  ? filter !== "all"
+                    ? `No ${filter} found matching your search.`
+                    : hasSkillsFeature
+                      ? "No skills or tools found matching your search."
+                      : "No tools found matching your search."
+                  : filter !== "all"
+                    ? `All available ${filter} are already selected.`
+                    : hasSkillsFeature
+                      ? "All available skills and tools are already selected."
+                      : "All available tools are already selected."
               }
               keyPrefix="tools-picker"
               disabled

--- a/front/components/shared/tools_picker/CapabilityFilterButtons.tsx
+++ b/front/components/shared/tools_picker/CapabilityFilterButtons.tsx
@@ -1,0 +1,38 @@
+import { Button } from "@dust-tt/sparkle";
+
+import type { CapabilityFilterType } from "@app/components/shared/tools_picker/types";
+
+interface CapabilityFilterButtonsProps {
+  filter: CapabilityFilterType;
+  setFilter: (filter: CapabilityFilterType) => void;
+  size?: "xs" | "sm";
+}
+
+export function CapabilityFilterButtons({
+  filter,
+  setFilter,
+  size = "sm",
+}: CapabilityFilterButtonsProps) {
+  return (
+    <div className="flex gap-2">
+      <Button
+        label="All"
+        variant={filter === "all" ? "primary" : "outline"}
+        size={size}
+        onClick={() => setFilter("all")}
+      />
+      <Button
+        label="Skills"
+        variant={filter === "skills" ? "primary" : "outline"}
+        size={size}
+        onClick={() => setFilter("skills")}
+      />
+      <Button
+        label="Tools"
+        variant={filter === "tools" ? "primary" : "outline"}
+        size={size}
+        onClick={() => setFilter("tools")}
+      />
+    </div>
+  );
+}

--- a/front/components/shared/tools_picker/types.ts
+++ b/front/components/shared/tools_picker/types.ts
@@ -7,6 +7,8 @@ import { MODEL_IDS } from "@app/types/assistant/models/models";
 import { MODEL_PROVIDER_IDS } from "@app/types/assistant/models/providers";
 import { REASONING_EFFORTS } from "@app/types/assistant/models/reasoning";
 
+export type CapabilityFilterType = "all" | "skills" | "tools";
+
 const modelIdSchema = z.enum(MODEL_IDS);
 const providerIdSchema = z.enum(MODEL_PROVIDER_IDS);
 const reasoningEffortSchema = z.enum(REASONING_EFFORTS);


### PR DESCRIPTION
## Description

- This PR adds a button list to filter on All, Skills or Tools in the Tools picker (input bar).
- This pattern matches the one in Agent Builder.

<img width="669" height="605" alt="Screenshot 2026-01-23 at 5 59 10 PM" src="https://github.com/user-attachments/assets/ac103a48-bbe1-4705-a5c5-7a3a36d8b5d5" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
