### PR TITLE
[Slack MCP] fix dm id resolution when file is attached

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/slack/helpers.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/slack/helpers.ts
@@ -251,8 +251,22 @@ export async function resolveChannelId({
   const searchString = channelNameOrId
     .trim()
     .replace(/^#/, "")
-    .replace(/^@/, "")
-    .replace(/^U/, "D");
+    .replace(/^@/, "");
+
+  // If searchString looks like a user ID (starts with U), open a DM with that user.
+  if (searchString.match(/^U[A-Z0-9]+$/)) {
+    try {
+      const openResp = await slackClient.conversations.open({
+        users: searchString,
+      });
+      if (openResp.ok && openResp.channel?.id) {
+        return openResp.channel.id;
+      }
+    } catch {
+      // conversations.open failed, user ID cannot be resolved.
+    }
+    return null;
+  }
 
   // If searchString looks like a Slack channel/DM ID (starts with C, G, or D), try direct lookup first.
   if (searchString.match(/^[CGD][A-Z0-9]+$/)) {

--- a/front/lib/api/oauth/providers/slack_tools.ts
+++ b/front/lib/api/oauth/providers/slack_tools.ts
@@ -42,6 +42,8 @@ export class SlackToolsOAuthProvider implements BaseOAuthStrategyProvider {
           return [
             // Write permissions.
             "chat:write",
+            "im:write",
+            "mpim:write",
             // Get and read chat and thread in any channels.
             "channels:history",
             "groups:history",


### PR DESCRIPTION
## Description

Fixes DM conversation resolution when a user ID (starting with `U`) is provided. The previous approach of simply replacing the `U` prefix with `D` doesn't work reliably because user IDs and DM channel IDs don't have a direct 1:1 mapping (not always). To properly get the DM channel ID from a user ID, we need to call the `conversations.open` endpoint. This requires adding the `im:write` and `mpim:write` OAuth scope.

## Risk

OAuth scope changes (`im:write`, `mpim:write`) require users to reconnect their Slack account. We'll only ask to Vanta to do it (Request coming from them). 

## Tests

Tested manually with user IDs to verify DM channel resolution works correctly.

## Deploy Plan

Run front.
