### PR TITLE
[front] Reduce rate limit on unified search, reduce window size

### DIFF
--- a/front/pages/api/w/[wId]/search.ts
+++ b/front/pages/api/w/[wId]/search.ts
@@ -19,7 +19,7 @@ import type {
 } from "@app/types";
 import { isString } from "@app/types";
 
-const MAX_UNIFIED_SEARCH_PER_USER_PER_MINUTE = 20;
+const MAX_UNIFIED_SEARCH_PER_USER_PER_FIVE_SECONDS = 30;
 
 export type DataSourceContentNode = ContentNodeWithParent & {
   dataSource: DataSourceType;
@@ -205,8 +205,8 @@ async function handler(
   const rateLimitKey = `unified_search:${auth.getNonNullableUser().sId}`;
   const remaining = await rateLimiter({
     key: rateLimitKey,
-    maxPerTimeframe: MAX_UNIFIED_SEARCH_PER_USER_PER_MINUTE,
-    timeframeSeconds: 60, // 1 minute
+    maxPerTimeframe: MAX_UNIFIED_SEARCH_PER_USER_PER_FIVE_SECONDS,
+    timeframeSeconds: 5,
     logger,
   });
 
@@ -215,7 +215,7 @@ async function handler(
       status_code: 429,
       api_error: {
         type: "rate_limit_error",
-        message: `You have reached the limit of ${MAX_UNIFIED_SEARCH_PER_USER_PER_MINUTE} unified searches per minute.`,
+        message: `You have reached the limit of ${MAX_UNIFIED_SEARCH_PER_USER_PER_FIVE_SECONDS} unified searches over 5 seconds.`,
       },
     });
   }


### PR DESCRIPTION
## Description

- We introduced a rate limit on the unified search endpoint following a bug where this endpoint would be called on an infinite loop of rerendering (thousands of time per minute).
- Ended up hitting this limit while using it in a very normal setting ([logs](https://app.datadoghq.eu/logs?query=%40route%3A%2Fapi%2Fw%2F%5C%5BwId%5C%5D%2Fsearch%20%40statusCode%3A429&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice%2C%40workspaceId%2C%40user.sId&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1769203322853&to_ts=1769203328969&live=false)).
- This rate limit is redundant with other measures now in place, and would have not protected us from the issue we had observed (we still load the Authenticator).
- This PR sets the rate limit to a value that would let me use the product without hitting it.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
