### PR TITLE
POC: Add react app

### DIFF
--- a/dockerfiles/front.Dockerfile
+++ b/dockerfiles/front.Dockerfile
@@ -15,8 +15,9 @@ COPY package.json package-lock.json ./
 COPY sdks/js/package.json ./sdks/js/
 COPY sparkle/package.json ./sparkle/
 COPY front/package.json ./front/
+COPY front-spa/package.json ./front-spa/
 
-RUN npm ci -w sdks/js -w sparkle -w front
+RUN npm ci -w sdks/js -w sparkle -w front -w front-spa
 
 # Build SDK
 WORKDIR /app/sdks/js
@@ -27,6 +28,10 @@ RUN npm run build
 WORKDIR /app/sparkle
 COPY /sparkle/ .
 RUN npm run build
+
+# Copy front source
+WORKDIR /app/front-spa
+COPY /front-spa .
 
 # Copy front source
 WORKDIR /app/front

--- a/dust.code-workspace
+++ b/dust.code-workspace
@@ -48,6 +48,21 @@
       }
     },
     {
+      "name": "front-spa",
+      "path": "front-spa",
+      "settings": {
+        "typescript.preferences.useLabelDetailsInCompletion": true,
+        "typescript.preferences.includePackageJsonAutoImports": "off",
+        "typescript.experimental.useTsgo": true,
+        "files.exclude": {
+          "**/node_modules": true,
+          "**/dist": true,
+          "**/.next": true,
+          "**/workers-build": true
+        }
+      }
+    },
+    {
       "name": "connectors",
       "path": "connectors",
       "settings": {

--- a/front-spa/.gitignore
+++ b/front-spa/.gitignore
@@ -1,0 +1,14 @@
+# Dependencies
+node_modules/
+
+# Build output
+dist/
+
+# Vite
+*.local
+
+# Logs
+*.log
+
+# Cache
+.cache/

--- a/front-spa/.prettierrc.cjs
+++ b/front-spa/.prettierrc.cjs
@@ -1,0 +1,8 @@
+module.exports = {
+  singleQuote: false,
+  trailingComma: "es5",
+  requirePragma: false,
+  arrowParens: "always",
+  semi: true,
+  plugins: [require.resolve("prettier-plugin-tailwindcss")],
+};

--- a/front-spa/eslint.config.js
+++ b/front-spa/eslint.config.js
@@ -1,0 +1,106 @@
+import js from "@eslint/js";
+import importPlugin from "eslint-plugin-import";
+import simpleImportSort from "eslint-plugin-simple-import-sort";
+import unusedImports from "eslint-plugin-unused-imports";
+import tseslint from "typescript-eslint";
+import reactHooks from "eslint-plugin-react-hooks";
+
+export default [
+  // Ignores
+  {
+    ignores: [
+      "eslint.config.js",
+      "**/node_modules/**",
+      "**/dist/**",
+      "*.config.cjs",
+      ".prettierrc.cjs",
+    ],
+  },
+
+  // Base configs
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+
+  // Global settings
+  {
+    languageOptions: {
+      parserOptions: {
+        ecmaVersion: "latest",
+        sourceType: "module",
+        ecmaFeatures: {
+          jsx: true,
+        },
+      },
+      globals: {
+        window: "readonly",
+        document: "readonly",
+        navigator: "readonly",
+        console: "readonly",
+        setTimeout: "readonly",
+        clearTimeout: "readonly",
+        setInterval: "readonly",
+        clearInterval: "readonly",
+        fetch: "readonly",
+        URLSearchParams: "readonly",
+      },
+    },
+  },
+
+  // Plugin configurations
+  {
+    plugins: {
+      import: importPlugin,
+      "simple-import-sort": simpleImportSort,
+      "unused-imports": unusedImports,
+      "react-hooks": reactHooks,
+    },
+  },
+
+  // Main rules
+  {
+    files: ["**/*.{js,jsx,ts,tsx}"],
+    rules: {
+      // React hooks
+      "react-hooks/rules-of-hooks": "error",
+      "react-hooks/exhaustive-deps": "warn",
+
+      // Import rules
+      "import/consistent-type-specifier-style": ["error", "prefer-top-level"],
+
+      // Import sorting
+      "simple-import-sort/imports": [
+        "error",
+        {
+          groups: [
+            ["^\\u0000"],
+            ["^node:"],
+            ["^@?\\w"],
+            ["^@dust-tt/front"],
+            ["^@app"],
+            ["^"],
+            ["^\\."],
+          ],
+        },
+      ],
+      "simple-import-sort/exports": "error",
+
+      // TypeScript rules
+      "@typescript-eslint/consistent-type-imports": "error",
+      "@typescript-eslint/no-explicit-any": "off",
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+        },
+      ],
+
+      // Unused imports
+      "unused-imports/no-unused-imports": "error",
+
+      // General rules
+      curly: ["error", "all"],
+      "no-case-declarations": "off",
+    },
+  },
+];

--- a/front-spa/index.html
+++ b/front-spa/index.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Dust</title>
+    <script>
+      // Shim for Node.js Buffer API used by some dependencies
+      globalThis.Buffer = globalThis.Buffer || {
+        isBuffer: function () {
+          return false;
+        },
+        from: function (x) {
+          return new Uint8Array(
+            typeof x === "string"
+              ? Array.from(x).map(function (c) {
+                  return c.charCodeAt(0);
+                })
+              : x
+          );
+        },
+        alloc: function (n) {
+          return new Uint8Array(n);
+        },
+      };
+    </script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/app/main.tsx"></script>
+  </body>
+</html>

--- a/front-spa/package.json
+++ b/front-spa/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@dust-tt/front-spa",
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev:poke": "VITE_APP_NAME=poke VITE_DUST_CLIENT_FACING_URL=$DUST_CLIENT_FACING_URL vite",
+    "dev:app": "VITE_APP_NAME=app VITE_DUST_CLIENT_FACING_URL=$DUST_CLIENT_FACING_URL vite",
+    "build:poke": "VITE_APP_NAME=poke vite build",
+    "build:app": "VITE_APP_NAME=app vite build",
+    "build": "npm run build:poke && npm run build:app",
+    "preview:poke": "VITE_APP_NAME=poke vite preview",
+    "preview:app": "VITE_APP_NAME=app vite preview",
+    "lint": "eslint --cache --cache-location .cache/eslint --cache-strategy content .",
+    "lint:fix": "eslint --fix .",
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
+  },
+  "dependencies": {
+    "@dust-tt/front": "*",
+    "@dust-tt/sparkle": "*",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^7.0.0"
+  },
+  "devDependencies": {
+    "@eslint/js": "^9.39.1",
+    "@tailwindcss/container-queries": "^0.1.1",
+    "@tailwindcss/forms": "^0.5.3",
+    "@types/react": "^18.3.18",
+    "@types/react-dom": "^18.3.5",
+    "@vitejs/plugin-react": "^4.3.4",
+    "autoprefixer": "^10.4.23",
+    "eslint": "^9.18.0",
+    "eslint-plugin-import": "^2.32.0",
+    "eslint-plugin-react-hooks": "7.0.1",
+    "eslint-plugin-simple-import-sort": "^12.1.1",
+    "eslint-plugin-unused-imports": "^4.3.0",
+    "postcss": "^8.5.6",
+    "prettier": "^3.7.4",
+    "prettier-plugin-tailwindcss": "^0.7.2",
+    "tailwind-scrollbar-hide": "^1.1.7",
+    "tailwindcss": "^3.4.19",
+    "tailwindcss-animate": "^1.0.7",
+    "typescript": "^5.9.3",
+    "typescript-eslint": "^8.48.0",
+    "vite": "^5.4.0"
+  }
+}

--- a/front-spa/poke.html
+++ b/front-spa/poke.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Dust - Poke</title>
+    <script>
+      // Shim for Node.js Buffer API used by some dependencies
+      globalThis.Buffer = globalThis.Buffer || {
+        isBuffer: function () {
+          return false;
+        },
+        from: function (x) {
+          return new Uint8Array(
+            typeof x === "string"
+              ? Array.from(x).map(function (c) {
+                  return c.charCodeAt(0);
+                })
+              : x
+          );
+        },
+        alloc: function (n) {
+          return new Uint8Array(n);
+        },
+      };
+    </script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/poke/main.tsx"></script>
+  </body>
+</html>

--- a/front-spa/postcss.config.cjs
+++ b/front-spa/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: { config: "./tailwind.config.cjs" },
+    autoprefixer: {},
+  },
+};

--- a/front-spa/src/app/App.tsx
+++ b/front-spa/src/app/App.tsx
@@ -1,0 +1,18 @@
+import { createBrowserRouter, RouterProvider } from "react-router-dom";
+
+import RootLayout from "@dust-tt/front/components/app/RootLayout";
+
+const router = createBrowserRouter([
+  {
+    path: "/",
+    element: <div className="p-8">Main App - Coming Soon</div>,
+  },
+]);
+
+export default function App() {
+  return (
+    <RootLayout>
+      <RouterProvider router={router} />
+    </RootLayout>
+  );
+}

--- a/front-spa/src/app/main.tsx
+++ b/front-spa/src/app/main.tsx
@@ -1,0 +1,18 @@
+// Tailwind base globals
+import "@dust-tt/front/styles/global.css";
+// Use sparkle styles, override local globals
+import "@dust-tt/sparkle/dist/sparkle.css";
+// Local tailwind components override sparkle styles
+import "@dust-tt/front/styles/components.css";
+// Local index.css for any app-specific overrides
+import "@spa/index.css";
+
+import App from "@spa/app/App";
+import React from "react";
+import ReactDOM from "react-dom/client";
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/front-spa/src/hooks/usePokeLoginRedirect.ts
+++ b/front-spa/src/hooks/usePokeLoginRedirect.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from "react";
+
+interface UsePokeLoginRedirectParams {
+  isLoading: boolean;
+  isAuthenticated: boolean;
+}
+
+interface UsePokeLoginRedirectResult {
+  isRedirecting: boolean;
+}
+
+/**
+ * Hook that handles login redirect for Poke pages.
+ * Redirects to login when user is not authenticated.
+ */
+export function usePokeLoginRedirect({
+  isLoading,
+  isAuthenticated,
+}: UsePokeLoginRedirectParams): UsePokeLoginRedirectResult {
+  const [isRedirecting, setIsRedirecting] = useState(false);
+
+  useEffect(() => {
+    if (!isLoading && !isAuthenticated) {
+      setIsRedirecting(true);
+      const baseUrl = import.meta.env.VITE_DUST_CLIENT_FACING_URL ?? "";
+      window.location.href = `${baseUrl}/api/workos/login?returnTo=${encodeURIComponent(
+        window.location.pathname + window.location.search
+      )}`;
+    }
+  }, [isLoading, isAuthenticated]);
+
+  return { isRedirecting };
+}

--- a/front-spa/src/index.css
+++ b/front-spa/src/index.css
@@ -1,0 +1,2 @@
+/* App-specific CSS overrides go here */
+/* Tailwind directives are already included in @dust-tt/front/styles/global.css */

--- a/front-spa/src/lib/ReactRouterLinkWrapper.tsx
+++ b/front-spa/src/lib/ReactRouterLinkWrapper.tsx
@@ -1,0 +1,76 @@
+import type { MouseEvent, ReactNode } from "react";
+import { forwardRef } from "react";
+import { Link } from "react-router-dom";
+import type { UrlObject } from "url";
+import url from "url";
+
+// Link wrapper that uses React Router's Link for SPA navigation
+export const ReactRouterLinkWrapper = forwardRef<
+  HTMLAnchorElement,
+  {
+    href: string | UrlObject;
+    className?: string;
+    children: ReactNode;
+    ariaLabel?: string;
+    ariaCurrent?:
+      | boolean
+      | "time"
+      | "false"
+      | "true"
+      | "page"
+      | "step"
+      | "location"
+      | "date";
+    onClick?: (event: MouseEvent<HTMLAnchorElement>) => void;
+    target?: string;
+    rel?: string;
+  }
+>(function ReactRouterLinkWrapper(
+  {
+    href,
+    className,
+    children,
+    ariaCurrent,
+    ariaLabel,
+    onClick,
+    target = "_self",
+    rel,
+  },
+  ref
+) {
+  // Convert UrlObject to string if needed
+  const hrefString = typeof href !== "string" ? url.format(href) : href;
+
+  // For external links or API routes, use regular anchor
+  if (hrefString.startsWith("http") || hrefString.startsWith("/api/")) {
+    return (
+      <a
+        ref={ref}
+        href={hrefString}
+        className={className}
+        onClick={onClick}
+        aria-current={ariaCurrent}
+        aria-label={ariaLabel}
+        target={target}
+        rel={rel}
+      >
+        {children}
+      </a>
+    );
+  }
+
+  return (
+    <Link
+      ref={ref}
+      to={hrefString}
+      className={className}
+      onClick={onClick}
+      aria-current={ariaCurrent}
+      aria-label={ariaLabel}
+      target={target}
+      rel={rel}
+    >
+      {children}
+    </Link>
+  );
+});

--- a/front-spa/src/lib/platform.ts
+++ b/front-spa/src/lib/platform.ts
@@ -1,0 +1,345 @@
+/**
+ * SPA platform implementation
+ * Used when running in Vite SPA environment (React Router)
+ */
+import { ReactRouterLinkWrapper } from "@spa/lib/ReactRouterLinkWrapper";
+import {
+  Children,
+  isValidElement,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import {
+  useLocation,
+  useNavigate,
+  useOutletContext,
+  useParams as useRouterParams,
+  useSearchParams as useRouterSearchParams,
+} from "react-router-dom";
+
+import type {
+  AppRouter,
+  HeadProps,
+  RouterEvents,
+  ScriptProps,
+  TransitionOptions,
+  UrlObject,
+} from "@dust-tt/front/lib/platform/types";
+
+/**
+ * Safe wrapper around useNavigate that handles the case where
+ * we're not inside a Router context (can happen during production build initialization)
+ */
+function useSafeNavigate() {
+  try {
+    return useNavigate();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Safe wrapper around useLocation that handles the case where
+ * we're not inside a Router context
+ */
+function useSafeLocation() {
+  try {
+    return useLocation();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Safe wrapper around useSearchParam that handles the case where
+ * we're not inside a Router context
+ */
+function useSafeSearchParams() {
+  try {
+    return useRouterSearchParams();
+  } catch {
+    return [new URLSearchParams(window.location.search), () => {}] as const;
+  }
+}
+
+/**
+ * Convert URL object to string
+ */
+function urlToString(url: string | UrlObject): string {
+  if (typeof url === "string") {
+    return url;
+  }
+  let result = url.pathname ?? "";
+  if (url.query && Object.keys(url.query).length > 0) {
+    const params = new URLSearchParams();
+    for (const [key, value] of Object.entries(url.query)) {
+      if (value !== undefined) {
+        if (Array.isArray(value)) {
+          value.forEach((v) => params.append(key, v));
+        } else {
+          params.append(key, value);
+        }
+      }
+    }
+    const queryString = params.toString();
+    if (queryString) {
+      result += "?" + queryString;
+    }
+  }
+  if (url.hash) {
+    result += url.hash;
+  }
+  return result;
+}
+
+/**
+ * Create a no-op events object for SPA
+ * In SPA mode, we don't have router events like Next.js
+ */
+function createNoopEvents(): RouterEvents {
+  return {
+    on: () => {},
+    off: () => {},
+    emit: () => {},
+  };
+}
+
+export function useAppRouter(): AppRouter {
+  const navigate = useSafeNavigate();
+  const location = useSafeLocation();
+  const [searchParams] = useSafeSearchParams();
+
+  // Force re-render when location changes via window (fallback mode)
+  const [, setForceUpdate] = useState(0);
+  useEffect(() => {
+    if (!location) {
+      // We're in fallback mode, listen to popstate to update
+      const handlePopState = () => setForceUpdate((n) => n + 1);
+      window.addEventListener("popstate", handlePopState);
+      return () => window.removeEventListener("popstate", handlePopState);
+    }
+  }, [location]);
+
+  const push = useCallback(
+    async (
+      url: string | UrlObject,
+      _as?: string,
+      _options?: TransitionOptions
+    ) => {
+      const urlString = urlToString(url);
+      if (navigate) {
+        await navigate(urlString);
+      } else {
+        // Fallback to window.location if not in Router context
+        window.location.href = urlString;
+      }
+      return true;
+    },
+    [navigate]
+  );
+
+  const replace = useCallback(
+    async (
+      url: string | UrlObject,
+      _as?: string,
+      _options?: TransitionOptions
+    ) => {
+      const urlString = urlToString(url);
+      if (navigate) {
+        await navigate(urlString, { replace: true });
+      } else {
+        // Fallback to window.location if not in Router context
+        window.location.replace(urlString);
+      }
+      return true;
+    },
+    [navigate]
+  );
+
+  const back = useCallback(async () => {
+    if (navigate) {
+      await navigate(-1);
+    } else {
+      window.history.back();
+    }
+  }, [navigate]);
+
+  const reload = useCallback(() => {
+    window.location.reload();
+  }, []);
+
+  const query = useMemo(() => {
+    const result: Record<string, string | string[] | undefined> = {};
+    searchParams.forEach((value: string, key: string) => {
+      const existing = result[key];
+      if (existing !== undefined) {
+        if (Array.isArray(existing)) {
+          existing.push(value);
+        } else {
+          result[key] = [existing, value];
+        }
+      } else {
+        result[key] = value;
+      }
+    });
+    return result;
+  }, [searchParams]);
+
+  const pathname = location?.pathname ?? window.location.pathname;
+  const search = location?.search ?? window.location.search;
+
+  // In SPA mode, router is always ready (no SSR hydration needed)
+  const isReady = true;
+
+  // No-op events for SPA
+  const events = useMemo(() => createNoopEvents(), []);
+
+  return {
+    push,
+    replace,
+    back,
+    reload,
+    pathname,
+    asPath: pathname + search,
+    query,
+    isReady,
+    events,
+    // beforePopState is a noop in SPA mode (not supported in React Router)
+    // TODO: Check usage in AppContentLayout and remove it.
+    beforePopState: () => {},
+  };
+}
+
+/**
+ * Head component for SPA - manages document head elements
+ * This is a simplified implementation that extracts title and link elements
+ */
+export function Head({ children }: HeadProps) {
+  useEffect(() => {
+    const cleanupFns: (() => void)[] = [];
+
+    Children.forEach(children, (child) => {
+      if (!isValidElement(child)) {
+        return;
+      }
+
+      const props = child.props as Record<string, unknown>;
+
+      if (child.type === "title") {
+        const previousTitle = document.title;
+        document.title = String(props.children ?? "");
+        cleanupFns.push(() => {
+          document.title = previousTitle;
+        });
+      } else if (child.type === "link") {
+        const link = document.createElement("link");
+        Object.entries(props).forEach(([key, value]) => {
+          if (key !== "children" && value !== undefined) {
+            link.setAttribute(key, String(value));
+          }
+        });
+        document.head.appendChild(link);
+        cleanupFns.push(() => {
+          document.head.removeChild(link);
+        });
+      } else if (child.type === "meta") {
+        const meta = document.createElement("meta");
+        Object.entries(props).forEach(([key, value]) => {
+          if (key !== "children" && value !== undefined) {
+            meta.setAttribute(key, String(value));
+          }
+        });
+        document.head.appendChild(meta);
+        cleanupFns.push(() => {
+          document.head.removeChild(meta);
+        });
+      }
+    });
+
+    return () => {
+      cleanupFns.forEach((fn) => fn());
+    };
+  }, [children]);
+
+  return null;
+}
+
+/**
+ * Script component for SPA - loads external scripts
+ */
+export function Script({ id, src, children }: ScriptProps) {
+  useEffect(() => {
+    const script = document.createElement("script");
+
+    if (id) {
+      script.id = id;
+    }
+
+    if (src) {
+      script.src = src;
+      script.async = true;
+    } else if (children) {
+      script.textContent = children;
+    }
+
+    document.body.appendChild(script);
+
+    return () => {
+      document.body.removeChild(script);
+    };
+  }, [id, src, children]);
+
+  return null;
+}
+
+export const LinkWrapper = ReactRouterLinkWrapper;
+
+/**
+ * Hook to get page context (auth data) in SPA
+ * Uses React Router's outlet context
+ */
+export function usePageContext<T>(): T | null {
+  try {
+    return useOutletContext<T>();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Hook to get route params in SPA
+ * Returns route parameters from the URL (e.g., :wId, :aId)
+ */
+export function usePathParams(): Record<string, string | undefined> {
+  try {
+    return useRouterParams();
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Hook to get a required route param
+ * Throws an error if the param is missing
+ */
+export function useRequiredPathParam(name: string): string {
+  const params = usePathParams();
+  const value = params[name];
+  if (!value) {
+    throw new Error(`Required route parameter "${name}" is missing`);
+  }
+  return value;
+}
+
+/**
+ * Hook to get a search/query param in SPA
+ * Returns the value of the specified query parameter or null
+ */
+export function useSearchParam(name: string): string | null {
+  const [searchParams] = useSafeSearchParams();
+  return searchParams.get(name);
+}
+
+export type { AppRouter, HeadProps, ScriptProps };

--- a/front-spa/src/poke/PokeApp.tsx
+++ b/front-spa/src/poke/PokeApp.tsx
@@ -1,0 +1,205 @@
+import { PokePage } from "@spa/poke/layouts/PokePage";
+import { PokeWorkspacePage } from "@spa/poke/layouts/PokeWorkspacePage";
+import {
+  createBrowserRouter,
+  Navigate,
+  RouterProvider,
+} from "react-router-dom";
+
+import RootLayout from "@dust-tt/front/components/app/RootLayout";
+import { AppPage } from "@dust-tt/front/components/poke/pages/AppPage";
+import { AssistantDetailsPage } from "@dust-tt/front/components/poke/pages/AssistantDetailsPage";
+import { ConnectorRedirectPage } from "@dust-tt/front/components/poke/pages/ConnectorRedirectPage";
+import { ConversationPage } from "@dust-tt/front/components/poke/pages/ConversationPage";
+import { DashboardPage } from "@dust-tt/front/components/poke/pages/DashboardPage";
+import { DataSourcePage } from "@dust-tt/front/components/poke/pages/DataSourcePage";
+import { DataSourceQueryPage } from "@dust-tt/front/components/poke/pages/DataSourceQueryPage";
+import { DataSourceSearchPage } from "@dust-tt/front/components/poke/pages/DataSourceSearchPage";
+import { DataSourceViewPage } from "@dust-tt/front/components/poke/pages/DataSourceViewPage";
+import { EmailTemplatesPage } from "@dust-tt/front/components/poke/pages/EmailTemplatesPage";
+import { GroupPage } from "@dust-tt/front/components/poke/pages/GroupPage";
+import { KillPage } from "@dust-tt/front/components/poke/pages/KillPage";
+import { LLMTracePage } from "@dust-tt/front/components/poke/pages/LLMTracePage";
+import { MCPServerViewPage } from "@dust-tt/front/components/poke/pages/MCPServerViewPage";
+import { MembershipsPage } from "@dust-tt/front/components/poke/pages/MembershipsPage";
+import { NotionRequestsPage } from "@dust-tt/front/components/poke/pages/NotionRequestsPage";
+import { PlansPage } from "@dust-tt/front/components/poke/pages/PlansPage";
+import { PluginsPage } from "@dust-tt/front/components/poke/pages/PluginsPage";
+import { PokefyPage } from "@dust-tt/front/components/poke/pages/PokefyPage";
+import { ProductionChecksPage } from "@dust-tt/front/components/poke/pages/ProductionChecksPage";
+import { SkillDetailsPage } from "@dust-tt/front/components/poke/pages/SkillDetailsPage";
+import { SpaceDataSourceViewPage } from "@dust-tt/front/components/poke/pages/SpaceDataSourceViewPage";
+import { SpacePage } from "@dust-tt/front/components/poke/pages/SpacePage";
+import { TemplateDetailPage } from "@dust-tt/front/components/poke/pages/TemplateDetailPage";
+import { TemplatesListPage } from "@dust-tt/front/components/poke/pages/TemplatesListPage";
+import { TriggerDetailsPage } from "@dust-tt/front/components/poke/pages/TriggerDetailsPage";
+import { WorkspacePage } from "@dust-tt/front/components/poke/pages/WorkspacePage";
+
+const router = createBrowserRouter(
+  [
+    {
+      path: "/poke",
+      element: <PokePage />,
+      children: [
+        // Static routes first
+        {
+          index: true,
+          element: <DashboardPage />,
+          handle: { title: "Home" },
+        },
+        {
+          path: "kill",
+          element: <KillPage />,
+          handle: { title: "Kill Switches" },
+        },
+        {
+          path: "plans",
+          element: <PlansPage />,
+          handle: { title: "Plans" },
+        },
+        {
+          path: "pokefy",
+          element: <PokefyPage />,
+          handle: { title: "Pokefy" },
+        },
+        {
+          path: "production-checks",
+          element: <ProductionChecksPage />,
+          handle: { title: "Production Checks" },
+        },
+        {
+          path: "email-templates",
+          element: <EmailTemplatesPage />,
+          handle: { title: "Email Templates" },
+        },
+        {
+          path: "templates",
+          element: <TemplatesListPage />,
+          handle: { title: "Templates" },
+        },
+        {
+          path: "templates/:tId",
+          element: <TemplateDetailPage />,
+          handle: { title: "Template" },
+        },
+        {
+          path: "plugins",
+          element: <PluginsPage />,
+          handle: { title: "Plugins" },
+        },
+        {
+          path: "connectors/:connectorId",
+          element: <ConnectorRedirectPage />,
+          handle: { title: "Connector Redirect" },
+        },
+      ],
+    },
+    {
+      path: "/poke/:wId",
+      element: <PokeWorkspacePage />,
+      children: [
+        // Dynamic workspace routes
+        {
+          index: true,
+          element: <WorkspacePage />,
+          handle: { title: "Workspace" },
+        },
+        {
+          path: "memberships",
+          element: <MembershipsPage />,
+          handle: { title: "Memberships" },
+        },
+        {
+          path: "llm-traces/:runId",
+          element: <LLMTracePage />,
+          handle: { title: "LLM Trace" },
+        },
+        {
+          path: "assistants/:aId",
+          element: <AssistantDetailsPage />,
+          handle: { title: "Assistant" },
+        },
+        {
+          path: "assistants/:aId/triggers/:triggerId",
+          element: <TriggerDetailsPage />,
+          handle: { title: "Trigger" },
+        },
+        {
+          path: "conversation/:cId",
+          element: <ConversationPage />,
+          handle: { title: "Conversation" },
+        },
+        {
+          path: "data_sources/:dsId",
+          element: <DataSourcePage />,
+          handle: { title: "Data Source" },
+        },
+        {
+          path: "data_sources/:dsId/notion-requests",
+          element: <NotionRequestsPage />,
+          handle: { title: "Notion Requests" },
+        },
+        {
+          path: "data_sources/:dsId/query",
+          element: <DataSourceQueryPage />,
+          handle: { title: "Query" },
+        },
+        {
+          path: "data_sources/:dsId/search",
+          element: <DataSourceSearchPage />,
+          handle: { title: "Search" },
+        },
+        {
+          path: "data_sources/:dsId/view",
+          element: <DataSourceViewPage />,
+          handle: { title: "View Document" },
+        },
+        {
+          path: "groups/:groupId",
+          element: <GroupPage />,
+          handle: { title: "Group" },
+        },
+        {
+          path: "skills/:sId",
+          element: <SkillDetailsPage />,
+          handle: { title: "Skill" },
+        },
+        {
+          path: "spaces/:spaceId",
+          element: <SpacePage />,
+          handle: { title: "Space" },
+        },
+        {
+          path: "spaces/:spaceId/apps/:appId",
+          element: <AppPage />,
+          handle: { title: "App" },
+        },
+        {
+          path: "spaces/:spaceId/data_source_views/:dsvId",
+          element: <SpaceDataSourceViewPage />,
+          handle: { title: "Data Source View" },
+        },
+        {
+          path: "spaces/:spaceId/mcp_server_views/:svId",
+          element: <MCPServerViewPage />,
+          handle: { title: "MCP Server View" },
+        },
+      ],
+    },
+    {
+      path: "*",
+      element: <Navigate to="/poke" replace />,
+    },
+  ],
+  {
+    basename: import.meta.env.VITE_BASE_PATH ?? "",
+  }
+);
+
+export default function PokeApp() {
+  return (
+    <RootLayout>
+      <RouterProvider router={router} />
+    </RootLayout>
+  );
+}

--- a/front-spa/src/poke/layouts/PokePage.tsx
+++ b/front-spa/src/poke/layouts/PokePage.tsx
@@ -1,0 +1,47 @@
+import { Spinner } from "@dust-tt/sparkle";
+import { usePokeLoginRedirect } from "@spa/hooks/usePokeLoginRedirect";
+import type { ReactNode } from "react";
+import { Outlet, useMatches } from "react-router-dom";
+
+import { PokeLayoutNoWorkspace } from "@dust-tt/front/components/poke/PokeLayout.tsx";
+import { usePokeAuthContext } from "@dust-tt/front/lib/swr/poke.ts";
+
+interface RouteHandle {
+  title?: string;
+}
+
+interface PokeLayoutProps {
+  children?: ReactNode;
+}
+
+export function PokePage({ children }: PokeLayoutProps) {
+  // Get title from the deepest matched route's handle
+  const matches = useMatches();
+  const title = matches
+    .slice()
+    .reverse()
+    .find((match) => (match.handle as RouteHandle)?.title)?.handle as
+    | RouteHandle
+    | undefined;
+  const pageTitle = title?.title ?? "Poke";
+
+  const { authContext, isAuthenticated, isLoading } = usePokeAuthContext();
+  const { isRedirecting } = usePokeLoginRedirect({
+    isLoading,
+    isAuthenticated,
+  });
+
+  if (isLoading || isRedirecting || !authContext) {
+    return (
+      <div className="flex h-screen w-full items-center justify-center">
+        <Spinner size="xl" />
+      </div>
+    );
+  }
+
+  return (
+    <PokeLayoutNoWorkspace title={pageTitle} authContext={authContext}>
+      {children ?? <Outlet />}
+    </PokeLayoutNoWorkspace>
+  );
+}

--- a/front-spa/src/poke/layouts/PokeWorkspacePage.tsx
+++ b/front-spa/src/poke/layouts/PokeWorkspacePage.tsx
@@ -1,0 +1,53 @@
+import { Spinner } from "@dust-tt/sparkle";
+import { usePokeLoginRedirect } from "@spa/hooks/usePokeLoginRedirect";
+import { useRequiredPathParam } from "@spa/lib/platform";
+import type { ReactNode } from "react";
+import { Outlet, useMatches } from "react-router-dom";
+
+import PokeLayout from "@dust-tt/front/components/poke/PokeLayout.tsx";
+import { usePokeWorkspaceAuthContext } from "@dust-tt/front/lib/swr/poke.ts";
+
+interface RouteHandle {
+  title?: string;
+}
+
+interface PokeLayoutProps {
+  children?: ReactNode;
+}
+
+export function PokeWorkspacePage({ children }: PokeLayoutProps) {
+  const wId = useRequiredPathParam("wId");
+
+  // Get title from the deepest matched route's handle
+  const matches = useMatches();
+  const title = matches
+    .slice()
+    .reverse()
+    .find((match) => (match.handle as RouteHandle)?.title)?.handle as
+    | RouteHandle
+    | undefined;
+  const pageTitle = title?.title ?? "Poke";
+
+  const { authContext, isAuthenticated, isLoading } =
+    usePokeWorkspaceAuthContext({
+      wId,
+    });
+  const { isRedirecting } = usePokeLoginRedirect({
+    isLoading,
+    isAuthenticated,
+  });
+
+  if (isLoading || isRedirecting || !authContext) {
+    return (
+      <div className="flex h-screen w-full items-center justify-center">
+        <Spinner size="xl" />
+      </div>
+    );
+  }
+
+  return (
+    <PokeLayout title={pageTitle} authContext={authContext}>
+      {children ?? <Outlet />}
+    </PokeLayout>
+  );
+}

--- a/front-spa/src/poke/main.tsx
+++ b/front-spa/src/poke/main.tsx
@@ -1,0 +1,18 @@
+// Tailwind base globals
+import "@dust-tt/front/styles/global.css";
+// Use sparkle styles, override local globals
+import "@dust-tt/sparkle/dist/sparkle.css";
+// Local tailwind components override sparkle styles
+import "@dust-tt/front/styles/components.css";
+// Local index.css for any app-specific overrides
+import "@spa/index.css";
+
+import PokeApp from "@spa/poke/PokeApp";
+import React from "react";
+import ReactDOM from "react-dom/client";
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <PokeApp />
+  </React.StrictMode>
+);

--- a/front-spa/tailwind.config.cjs
+++ b/front-spa/tailwind.config.cjs
@@ -1,0 +1,14 @@
+// Extend the front tailwind config with SPA-specific content paths
+const frontConfig = require("../front/tailwind.config.js");
+
+module.exports = {
+  ...frontConfig,
+  content: [
+    // SPA source files
+    "./src/**/*.{js,ts,jsx,tsx}",
+    // Front components used by SPA
+    "../front/components/**/*.{js,ts,jsx,tsx}",
+    // Front lib used by SPA
+    "../front/lib/**/*.{js,ts,jsx,tsx}",
+  ],
+};

--- a/front-spa/tsconfig.json
+++ b/front-spa/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "baseUrl": ".",
+    "paths": {
+      "@spa/*": ["./src/*"],
+      "@dust-tt/front/*": ["../front/*"],
+      "@app/*": ["../front/*"]
+    }
+  },
+  "include": ["src", "../front"]
+}

--- a/front-spa/vite.config.ts
+++ b/front-spa/vite.config.ts
@@ -1,0 +1,171 @@
+import react from "@vitejs/plugin-react";
+import path from "path";
+import type { Plugin } from "vite";
+import { defineConfig, loadEnv } from "vite";
+
+// Virtual module plugin to stub out server-side only modules
+function stubModulesPlugin(): Plugin {
+  const stubs: Record<string, string> = {
+    // Stream: minimal stub for Node.js stream module
+    stream:
+      "export class Readable { pipe() { return this; } on() { return this; } once() { return this; } destroy() {} } export class Writable { write() { return true; } end() {} on() { return this; } once() { return this; } } export class Transform extends Readable {} export class Duplex extends Readable { write() { return true; } end() {} } export default { Readable, Writable, Transform, Duplex };",
+    // Buffer: minimal stub for Node.js Buffer
+    buffer:
+      "export const Buffer = { isBuffer: () => false, from: (x) => new Uint8Array(typeof x === 'string' ? [...x].map(c => c.charCodeAt(0)) : x), alloc: (n) => new Uint8Array(n) }; export default { Buffer };",
+  };
+
+  // Stubs for resolved file paths (after @dust-tt/front alias is applied)
+  const filePathStubs: Record<string, string> = {
+    // Logger
+    "logger/logger":
+      "const noop = () => {}; const logger = { info: noop, warn: noop, error: noop, debug: noop, trace: noop, fatal: noop, child: () => logger }; export default logger;",
+    // Text extraction
+    "types/shared/text_extraction/index":
+      "export const pagePrefixesPerMimeType = {}; export const isTextExtractionSupportedContentType = () => false; export class TextExtraction { constructor() {} fromStream() { throw new Error('Not available in browser'); } }",
+    // Structured data
+    "types/shared/utils/structured_data":
+      "export class InvalidStructuredDataHeaderError extends Error {} export const getSanitizedHeaders = () => { throw new Error('Not available in browser'); }; export const guessDelimiter = async () => undefined; export const parseAndStringifyCsv = async () => { throw new Error('Not available in browser'); };",
+  };
+
+  return {
+    name: "stub-server-modules",
+    enforce: "pre",
+    resolveId(id) {
+      if (id in stubs) {
+        return `\0virtual:${id}`;
+      }
+      return null;
+    },
+    load(id) {
+      // Handle virtual modules
+      if (id.startsWith("\0virtual:")) {
+        const moduleId = id.slice("\0virtual:".length);
+        return stubs[moduleId];
+      }
+      // Handle resolved file paths
+      for (const [pathSuffix, stub] of Object.entries(filePathStubs)) {
+        if (id.endsWith(pathSuffix + ".ts") || id.endsWith(pathSuffix)) {
+          return stub;
+        }
+      }
+      return null;
+    },
+  };
+}
+
+// Plugin to serve the correct HTML file in dev mode
+function serveHtmlPlugin(htmlFile: string): Plugin {
+  return {
+    name: "serve-html",
+    configureServer(server) {
+      server.middlewares.use((req, _res, next) => {
+        // Rewrite root requests to the correct HTML file
+        if (req.url === "/" || req.url === "/index.html") {
+          req.url = `/${htmlFile}`;
+        }
+        next();
+      });
+    },
+  };
+}
+
+export default defineConfig(({ mode }) => {
+  // Load env file based on `mode` in the current working directory.
+  // Set the third parameter to '' to load all env regardless of the `VITE_` prefix.
+  const fileEnv = loadEnv(mode, process.cwd(), "");
+
+  // Merge with process.env to include shell environment variables (for build scripts)
+  const env = { ...fileEnv, ...process.env };
+
+  // Determine which app to build: "poke" or "app" (default: "app")
+  const appName = env.VITE_APP_NAME ?? "app";
+  const isPokeApp = appName === "poke";
+
+  // Map NEXT_PUBLIC_* env vars to process.env.NEXT_PUBLIC_* for compatibility
+  const envVarDefines: Record<string, string> = {};
+  for (const key of Object.keys(env)) {
+    if (key.startsWith("NEXT_PUBLIC_")) {
+      envVarDefines[`process.env.${key}`] = JSON.stringify(env[key]);
+    }
+    // Also define VITE_* vars for import.meta.env (ensures shell vars are included)
+    if (key.startsWith("VITE_")) {
+      envVarDefines[`import.meta.env.${key}`] = JSON.stringify(env[key]);
+    }
+  }
+
+  // Base path for the app (set via VITE_BASE_PATH env var from build script)
+  const basePath = env.VITE_BASE_PATH ?? "/";
+
+  // HTML entry file based on app
+  const htmlEntry = isPokeApp ? "poke.html" : "index.html";
+
+  return {
+    base: basePath,
+    root: path.resolve(__dirname, "."),
+    publicDir: path.resolve(__dirname, "../front/public"),
+    plugins: [stubModulesPlugin(), serveHtmlPlugin(htmlEntry), react()],
+    define: {
+      ...envVarDefines,
+      // Fallback for any remaining process.env access
+      "process.env": {},
+    },
+    server: {
+      port: isPokeApp ? 3010 : 3011,
+      // No proxy - client calls API directly using VITE_DUST_CLIENT_FACING_URL
+      fs: {
+        // Allow serving files from the front directory (for shared code)
+        allow: [
+          path.resolve(__dirname, "."),
+          path.resolve(__dirname, "../front"),
+          path.resolve(__dirname, "../node_modules"),
+        ],
+      },
+    },
+    resolve: {
+      // Use array format for aliases to ensure proper ordering (most specific first)
+      alias: [
+        // @spa alias for local SPA source files
+        {
+          find: "@spa",
+          replacement: path.resolve(__dirname, "src"),
+        },
+        // Platform abstraction: redirect @app/lib/platform to SPA implementation
+        {
+          find: "@app/lib/platform",
+          replacement: path.resolve(__dirname, "src/lib/platform.ts"),
+        },
+        // @app alias for front internal imports
+        {
+          find: "@app",
+          replacement: path.resolve(__dirname, "../front"),
+        },
+        // @dust-tt/front maps to the front workspace
+        {
+          find: "@dust-tt/front",
+          replacement: path.resolve(__dirname, "../front"),
+        },
+        // Resolve SDK dependencies from root node_modules (hoisted by npm workspaces)
+        {
+          find: "eventsource-parser",
+          replacement: path.resolve(
+            __dirname,
+            "../node_modules/eventsource-parser"
+          ),
+        },
+        // Handle zod and its subpath imports (e.g., zod/v3)
+        {
+          find: /^zod(\/.*)?$/,
+          replacement: path.resolve(__dirname, "../node_modules/zod$1"),
+        },
+      ],
+      dedupe: ["react", "react-dom"],
+    },
+    build: {
+      outDir: path.resolve(__dirname, `dist/${appName}`),
+      sourcemap: true,
+      rollupOptions: {
+        input: path.resolve(__dirname, htmlEntry),
+      },
+    },
+  };
+});

--- a/front/.gitignore
+++ b/front/.gitignore
@@ -37,6 +37,7 @@ next-env.d.ts
 
 # build output
 dist/
+public/spa/
 
 # cache
 .cache/

--- a/front/admin/build-spa.sh
+++ b/front/admin/build-spa.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Build the Vite SPA from front-spa workspace and copy to Next.js public folder
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FRONT_DIR="$(dirname "$SCRIPT_DIR")"
+ROOT_DIR="$(dirname "$FRONT_DIR")"
+FRONT_SPA_DIR="$ROOT_DIR/front-spa"
+
+rm -rf "$FRONT_DIR/public/spa"
+
+echo "Building poke SPA from front-spa workspace..."
+cd "$FRONT_SPA_DIR"
+VITE_BASE_PATH=/spa VITE_DUST_CLIENT_FACING_URL="$DUST_CLIENT_FACING_URL" npm run build:poke
+
+echo "Copying build to front/public/spa..."
+cp -r "$FRONT_SPA_DIR/dist/poke" "$FRONT_DIR/public/spa"
+
+echo "Done! SPA available at /spa/"

--- a/front/lib/egress/client.ts
+++ b/front/lib/egress/client.ts
@@ -1,3 +1,26 @@
+// Vite environment variables type declaration
+declare global {
+  interface ImportMeta {
+    env?: {
+      VITE_DUST_CLIENT_FACING_URL?: string;
+      VITE_BASE_PATH?: string;
+    };
+  }
+}
+
+// Get the API base URL from environment variables.
+// In Vite SPA: uses VITE_DUST_CLIENT_FACING_URL
+// In Next.js: uses relative URLs
+function getApiBaseUrl(): string | undefined {
+  // Check for Vite env var first (SPA mode)
+  if (
+    typeof import.meta !== "undefined" &&
+    import.meta.env?.VITE_DUST_CLIENT_FACING_URL
+  ) {
+    return import.meta.env.VITE_DUST_CLIENT_FACING_URL;
+  }
+}
+
 // Client-side fetch helper. This is a simple alias for the global fetch, used to satisfy
 // the linter rule that discourages direct use of `fetch`. On the client, we cannot route
 // through a proxy, so this is just a pass-through.
@@ -5,6 +28,17 @@ export function clientFetch(
   input: RequestInfo | URL,
   init?: RequestInit
 ): Promise<Response> {
+  const baseUrl = getApiBaseUrl();
+
+  // Only prepend base URL for relative paths (starting with /)
+  if (baseUrl && typeof input === "string" && input.startsWith("/")) {
+    input = `${baseUrl}${input}`;
+    init = {
+      ...init,
+      credentials: "include",
+    };
+  }
+
   // eslint-disable-next-line no-restricted-globals
   return fetch(input, init);
 }

--- a/front/lib/swr/poke.ts
+++ b/front/lib/swr/poke.ts
@@ -1,9 +1,11 @@
 import type { Fetcher } from "swr";
 
 import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { GetPokeAuthContextResponseType } from "@app/pages/api/poke/auth-context";
 import type { GetPokePlansResponseBody } from "@app/pages/api/poke/plans";
 import type { GetRegionResponseType } from "@app/pages/api/poke/region";
 import type { GetPokeWorkspacesResponseBody } from "@app/pages/api/poke/workspaces";
+import type { GetPokeWorkspaceAuthContextResponseType } from "@app/pages/api/poke/workspaces/[wId]/auth-context";
 import type { GetPokeFeaturesResponseBody } from "@app/pages/api/poke/workspaces/[wId]/features";
 import type { GetDataSourcePermissionsResponseBody } from "@app/pages/api/w/[wId]/data_sources/[dsId]/managed/permissions";
 import type {
@@ -84,7 +86,7 @@ export function usePokeWorkspaces({
   }
 
   const { data, error } = useSWRWithDefaults(
-    `api/poke/workspaces${query}`,
+    `/api/poke/workspaces${query}`,
     workspacesFetcher,
     {
       disabled,
@@ -151,5 +153,34 @@ export function usePokeWorkOSDSyncStatus({
     error,
     isLoading: !error && !data,
     mutate,
+  };
+}
+
+export function usePokeAuthContext() {
+  // Fetch global poke auth (superuser check)
+  const { data, isLoading, error } = useSWRWithDefaults<
+    string,
+    GetPokeAuthContextResponseType
+  >("/api/poke/auth-context", fetcher);
+
+  return {
+    authContext: data,
+    isAuthenticated: !!data?.user && data.isSuperUser,
+    isLoading,
+    isError: !!error,
+  };
+}
+
+export function usePokeWorkspaceAuthContext({ wId }: { wId: string }) {
+  const { data, isLoading, error } = useSWRWithDefaults<
+    string,
+    GetPokeWorkspaceAuthContextResponseType
+  >(`/api/poke/workspaces/${wId}/auth-context`, fetcher);
+
+  return {
+    authContext: data,
+    isAuthenticated: !!data?.user && data.isSuperUser,
+    isLoading,
+    isError: !!error,
   };
 }

--- a/front/middleware.ts
+++ b/front/middleware.ts
@@ -61,8 +61,12 @@ export function middleware(request: NextRequest) {
     });
   }
 
-  // Handle CORS only for public API endpoints.
-  if (url.startsWith("/api/v1")) {
+  // Handle CORS for public API endpoints and poke endpoints (dev only).
+  const isDevelopment = process.env.NODE_ENV === "development";
+  const needsCors =
+    url.startsWith("/api/v1") || (isDevelopment && url.startsWith("/api/"));
+
+  if (needsCors) {
     if (request.method === "OPTIONS") {
       // Handle preflight request.
       const response = new NextResponse(null, { status: 200 });
@@ -130,7 +134,6 @@ function setCorsHeaders(
     response.headers.set("Access-Control-Allow-Credentials", "true");
   } else {
     logger.info({ origin }, "Forbidden: Unauthorized Origin");
-
     return new NextResponse(null, {
       status: 403,
       statusText: "Forbidden: Unauthorized Origin",

--- a/front/package.json
+++ b/front/package.json
@@ -1,11 +1,17 @@
 {
-  "name": "front",
+  "name": "@dust-tt/front",
   "version": "0.1.0",
+  "exports": {
+    "./components/*": "./components/*",
+    "./lib/*": "./lib/*",
+    "./styles/*": "./styles/*",
+    "./types/*": "./types/*"
+  },
   "scripts": {
     "dev:all": "concurrently --kill-others \"cd ../types/ && npm run start\" \"sleep 20 && cd ../sdks/js/ && npm run start\" \"sleep 22 && next dev\" \"sleep 22 && tsx ./start_worker.ts\"",
     "dev": "next dev",
     "dev-datadog": "NODE_OPTIONS='-r dd-trace/init' DD_TAGS=service:front-edge DD_TAGS=env:dev-ben DD_GIT_COMMIT_SHA=`git rev-parse HEAD` DD_GIT_REPOSITORY_URL=https://github.com/dust-tt/dust/ npm run dev",
-    "build": "next build",
+    "build": "./admin/build-spa.sh && next build",
     "build:temporal-bundles": "tsx scripts/temporal-build/build-temporal-bundles.ts",
     "build:workers": "tsx esbuild.worker.ts",
     "start": "next start --keepAliveTimeout 5000",
@@ -271,6 +277,7 @@
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.48.0",
+    "vite": "^7.3.0",
     "vitest": "^4.0.16",
     "vitest-canvas-mock": "^1.1.3",
     "webpack-stats-plugin": "^1.1.3",

--- a/front/pages/api/poke/auth-context.ts
+++ b/front/pages/api/poke/auth-context.ts
@@ -1,8 +1,8 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
-import { fetchUserFromSession } from "@app/lib/iam/users";
 import { apiError } from "@app/logger/withlogging";
 import type { UserType, WithAPIErrorResponse } from "@app/types";
 
@@ -28,11 +28,8 @@ async function handler(
     });
   }
 
-  // Fetch the actual user from the database
-  const userResource = await fetchUserFromSession(session);
-  if (!userResource) {
-    return res.status(200).json({ user: null, isSuperUser: false });
-  }
+  const auth = await Authenticator.fromSuperUserSession(session, null);
+  const userResource = auth.getNonNullableUser();
 
   // If we reach here, user is a superuser (withSessionAuthenticationForPoke checks this)
   return res.status(200).json({

--- a/front/pages/api/poke/workspaces/[wId]/auth-context.ts
+++ b/front/pages/api/poke/workspaces/[wId]/auth-context.ts
@@ -16,6 +16,8 @@ export type GetPokeWorkspaceAuthContextResponseType = {
   user: UserType;
   workspace: LightWorkspaceType;
   subscription: SubscriptionType;
+  isAdmin: true; // Superusers have admin privileges
+  isBuilder: true; // Superusers have builder privileges
   isSuperUser: true;
 };
 
@@ -50,9 +52,9 @@ async function handler(
   const auth = await Authenticator.fromSuperUserSession(session, wId);
   const workspace = auth.workspace();
   const subscription = auth.subscription();
-  const user = auth.user();
+  const userResource = auth.getNonNullableUser();
 
-  if (!workspace || !subscription || !user || !auth.isDustSuperUser()) {
+  if (!workspace || !subscription) {
     return apiError(req, res, {
       status_code: 404,
       api_error: {
@@ -63,9 +65,11 @@ async function handler(
   }
 
   return res.status(200).json({
-    user: user.toJSON(),
+    user: userResource.toJSON(),
     workspace,
     subscription,
+    isAdmin: true,
+    isBuilder: true,
     isSuperUser: true,
   });
 }

--- a/front/tsconfig.json
+++ b/front/tsconfig.json
@@ -33,7 +33,8 @@
     "**/*.jsx",
     "**/*.js",
     "**/*.mjs",
-    "./.eslintrc.js"
+    "./.eslintrc.js",
+    ".next/types/**/*.ts"
   ],
-  "exclude": ["node_modules", ".next", "dist"]
+  "exclude": ["node_modules", ".next", "dist", "app"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "workspaces": [
         "front",
+        "front-spa",
         "sparkle",
         "connectors",
         "cli",
@@ -703,6 +704,7 @@
       }
     },
     "front": {
+      "name": "@dust-tt/front",
       "version": "0.1.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.71.0",
@@ -944,6 +946,7 @@
         "tsx": "^4.21.0",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.48.0",
+        "vite": "^7.3.0",
         "vitest": "^4.0.16",
         "vitest-canvas-mock": "^1.1.3",
         "webpack-stats-plugin": "^1.1.3",
@@ -951,6 +954,581 @@
       },
       "peerDependencies": {
         "typescript": "^5.9.3"
+      }
+    },
+    "front-spa": {
+      "name": "@dust-tt/front-spa",
+      "version": "0.1.0",
+      "dependencies": {
+        "@dust-tt/front": "*",
+        "@dust-tt/sparkle": "*",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+        "react-router-dom": "^7.0.0"
+      },
+      "devDependencies": {
+        "@eslint/js": "^9.39.1",
+        "@tailwindcss/container-queries": "^0.1.1",
+        "@tailwindcss/forms": "^0.5.3",
+        "@types/react": "^18.3.18",
+        "@types/react-dom": "^18.3.5",
+        "@vitejs/plugin-react": "^4.3.4",
+        "autoprefixer": "^10.4.23",
+        "eslint": "^9.18.0",
+        "eslint-plugin-import": "^2.32.0",
+        "eslint-plugin-react-hooks": "7.0.1",
+        "eslint-plugin-simple-import-sort": "^12.1.1",
+        "eslint-plugin-unused-imports": "^4.3.0",
+        "postcss": "^8.5.6",
+        "prettier": "^3.7.4",
+        "prettier-plugin-tailwindcss": "^0.7.2",
+        "tailwind-scrollbar-hide": "^1.1.7",
+        "tailwindcss": "^3.4.19",
+        "tailwindcss-animate": "^1.0.7",
+        "typescript": "^5.9.3",
+        "typescript-eslint": "^8.48.0",
+        "vite": "^5.4.0"
+      }
+    },
+    "front-spa/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "front-spa/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "front-spa/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "front-spa/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "front-spa/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "front-spa/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "front-spa/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "front-spa/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "front-spa/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "front-spa/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "front-spa/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "front-spa/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "front-spa/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "front-spa/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "front-spa/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "front-spa/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "front-spa/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "front-spa/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "front-spa/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "front-spa/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "front-spa/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "front-spa/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "front-spa/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "front-spa/node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "front-spa/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "front-spa/node_modules/react-router-dom": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.0.tgz",
+      "integrity": "sha512-5CO/l5Yahi2SKC6rGZ+HDEjpjkGaG/ncEP7eWFTvFxbHP8yeeI0PxTDjimtpXYlR3b3i9/WIL4VJttPrESIf2g==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.13.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "front-spa/node_modules/react-router-dom/node_modules/react-router": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.0.tgz",
+      "integrity": "sha512-PZgus8ETambRT17BUm/LL8lX3Of+oiLaPuVTRH3l1eLvSPpKO3AvhAEb5N7ihAFZQrYDqkvvWfFh9p0z9VsjLw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "front-spa/node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
       }
     },
     "front/node_modules/@google/genai": {
@@ -6098,6 +6676,14 @@
     },
     "node_modules/@dust-tt/extension": {
       "resolved": "extension",
+      "link": true
+    },
+    "node_modules/@dust-tt/front": {
+      "resolved": "front",
+      "link": true
+    },
+    "node_modules/@dust-tt/front-spa": {
+      "resolved": "front-spa",
       "link": true
     },
     "node_modules/@dust-tt/sparkle": {
@@ -34423,10 +35009,6 @@
       "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==",
       "license": "MIT"
     },
-    "node_modules/front": {
-      "resolved": "front",
-      "link": true
-    },
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
@@ -54693,6 +55275,12 @@
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "license": "ISC",
       "optional": true
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "workspaces": [
     "front",
+    "front-spa",
     "sparkle",
     "connectors",
     "cli",


### PR DESCRIPTION
## Description

Add react app

In front-spa, run: 
`npm run dev` to get local dev server on port 3010 .
`npm run build` to get build the production react app .
`npm run preview` to server the production app .

VITE_DUST_CLIENT_FACING_URL must be to set with your dust api endpoint (`npm run dev` sets it to your `$DUST_CLIENT_FACING_URL` )

You need to be logged through standard app first (login redirect does not work yet)

When running `npm run build` in front, we build the production app and copy it into /public/spa, so that it's served directly from next (`admin/build-spa.sh` script )

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
