### PR TITLE
[front] fix(search): prioritize space access, allow URL pasting in Skill Builder

### DIFF
--- a/front/components/editor/extensions/skill_builder/KnowledgeNodeView.tsx
+++ b/front/components/editor/extensions/skill_builder/KnowledgeNodeView.tsx
@@ -182,6 +182,7 @@ function KnowledgeSearchComponent({
       includeDataSources: false,
       searchSourceUrls: false,
       includeTools: false,
+      prioritizeSpaceAccess: true,
     }
   );
 

--- a/front/components/editor/extensions/skill_builder/KnowledgeNodeView.tsx
+++ b/front/components/editor/extensions/skill_builder/KnowledgeNodeView.tsx
@@ -180,7 +180,7 @@ function KnowledgeSearchComponent({
       // Tables can't be attached to a skill.
       viewType: "document",
       includeDataSources: false,
-      searchSourceUrls: false,
+      searchSourceUrls: true,
       includeTools: false,
       prioritizeSpaceAccess: true,
     }

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -351,7 +351,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       transaction?: Transaction;
     } = {}
   ): Promise<GroupResource> {
-    const user = auth.getNonNullableUser();
     const workspace = auth.getNonNullableWorkspace();
 
     assert(
@@ -366,7 +365,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
         kind: "skill_editors",
       },
       {
-        memberIds: addCurrentUserAsEditor ? [user.id] : [],
+        memberIds: addCurrentUserAsEditor ? [auth.getNonNullableUser().id] : [],
         transaction,
       }
     );


### PR DESCRIPTION
## Description

This PR improves the search in the Skill Builder instructions.
- Enable space prioritization: if the same node can be made available through multiple data sources views, pick the one that is the least constraining (global space being the least, private space the most).
- Allow URL pasting (requires an exact match).

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
