### PR TITLE
[front] refactor: rename `ToolsPicker` into `CapabilitiesPicker`

### DIFF
--- a/front/components/assistant/CapabilitiesPicker.tsx
+++ b/front/components/assistant/CapabilitiesPicker.tsx
@@ -45,11 +45,11 @@ import type { WorkspaceType } from "@app/types";
 import { asDisplayName } from "@app/types";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 
-function ToolsPickerLoading({ count = 5 }: { count?: number }) {
+function CapabilitiesPickerLoading({ count = 5 }: { count?: number }) {
   return (
     <div className="py-1">
       {Array.from({ length: count }).map((_, i) => (
-        <div key={`tools-picker-loading-${i}`} className="px-1 py-1">
+        <div key={`capabilities-picker-loading-${i}`} className="px-1 py-1">
           <div className="flex items-center gap-3 rounded-md p-2">
             <LoadingBlock className="h-5 w-5 rounded-full dark:bg-muted-foreground-night" />
             <div className="flex min-w-0 flex-1 flex-col gap-1">
@@ -391,7 +391,7 @@ export function CapabilitiesPicker({
             </>
           }
         >
-          {!isDataReady && <ToolsPickerLoading />}
+          {!isDataReady && <CapabilitiesPickerLoading />}
 
           {isDataReady && hasVisibleSkills && (
             <>
@@ -433,12 +433,12 @@ export function CapabilitiesPicker({
                 </div>
                 {filteredServerViewsUnselected.map((v) => (
                   <CapabilityItem
-                    key={`tools-picker-${v.sId}`}
+                    key={`capabilities-picker-${v.sId}`}
                     id={v.sId}
                     icon={() => getAvatar(v.server)}
                     label={getMcpServerViewDisplayName(v)}
                     description={getMcpServerViewDescription(v)}
-                    keyPrefix="tools-picker"
+                    keyPrefix="capabilities-picker"
                     onClick={() => {
                       trackEvent({
                         area: TRACKING_AREAS.TOOLS,
@@ -518,7 +518,7 @@ export function CapabilitiesPicker({
                       ? "All available skills and tools are already selected."
                       : "All available tools are already selected."
               }
-              keyPrefix="tools-picker"
+              keyPrefix="capabilities-picker"
               disabled
               className="italic"
             />

--- a/front/components/assistant/CapabilitiesPicker.tsx
+++ b/front/components/assistant/CapabilitiesPicker.tsx
@@ -341,7 +341,7 @@ export function CapabilitiesPicker({
             <>
               <DropdownMenuSearchbar
                 autoFocus
-                name="search-tools"
+                name="search-capabilities"
                 placeholder="Search capabilities"
                 value={searchText}
                 onChange={setSearchText}

--- a/front/components/assistant/CapabilitiesPicker.tsx
+++ b/front/components/assistant/CapabilitiesPicker.tsx
@@ -110,7 +110,7 @@ function CapabilityItem({
   );
 }
 
-interface ToolsPickerProps {
+interface CapabilitiesPickerProps {
   owner: WorkspaceType;
   selectedMCPServerViews: MCPServerViewType[];
   onSelect: (serverView: MCPServerViewType) => void;
@@ -123,7 +123,7 @@ interface ToolsPickerProps {
   buttonSize?: "xs" | "sm" | "md";
 }
 
-export function ToolsPicker({
+export function CapabilitiesPicker({
   owner,
   selectedMCPServerViews,
   onSelect,
@@ -133,7 +133,7 @@ export function ToolsPicker({
   isLoading = false,
   disabled = false,
   buttonSize = "xs",
-}: ToolsPickerProps) {
+}: CapabilitiesPickerProps) {
   const [searchText, setSearchText] = useState("");
   const [isOpen, setIsOpen] = useState(false);
   const [filter, setFilter] = useState<CapabilityFilterType>("all");

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -62,7 +62,7 @@ import {
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 
 export const INPUT_BAR_ACTIONS = [
-  "tools",
+  "capabilities",
   "attachment",
   "agents-list",
   "agents-list-with-actions",
@@ -727,7 +727,7 @@ const InputBarContainer = ({
                       />
                     </>
                   )}
-                  {actions.includes("tools") && (
+                  {actions.includes("capabilities") && (
                     <ToolsPicker
                       owner={owner}
                       selectedMCPServerViews={selectedMCPServerViews}

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -27,7 +27,7 @@ import {
 } from "@app/components/assistant/conversation/input_bar/pasted_utils";
 import { MobileToolbar } from "@app/components/assistant/conversation/input_bar/toolbar/MobileToolbar";
 import { Toolbar } from "@app/components/assistant/conversation/input_bar/toolbar/Toolbar";
-import { ToolsPicker } from "@app/components/assistant/ToolsPicker";
+import { CapabilitiesPicker } from "@app/components/assistant/CapabilitiesPicker";
 import type { CustomEditorProps } from "@app/components/editor/input_bar/useCustomEditor";
 import useCustomEditor from "@app/components/editor/input_bar/useCustomEditor";
 import useHandleMentions from "@app/components/editor/input_bar/useHandleMentions";
@@ -728,7 +728,7 @@ const InputBarContainer = ({
                     </>
                   )}
                   {actions.includes("capabilities") && (
-                    <ToolsPicker
+                    <CapabilitiesPicker
                       owner={owner}
                       selectedMCPServerViews={selectedMCPServerViews}
                       onSelect={onMCPServerViewSelect}

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -19,6 +19,7 @@ import React, {
 } from "react";
 
 import { AgentPicker } from "@app/components/assistant/AgentPicker";
+import { CapabilitiesPicker } from "@app/components/assistant/CapabilitiesPicker";
 import { InputBarAttachmentsPicker } from "@app/components/assistant/conversation/input_bar/InputBarAttachmentsPicker";
 import { InputBarContext } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import {
@@ -27,7 +28,6 @@ import {
 } from "@app/components/assistant/conversation/input_bar/pasted_utils";
 import { MobileToolbar } from "@app/components/assistant/conversation/input_bar/toolbar/MobileToolbar";
 import { Toolbar } from "@app/components/assistant/conversation/input_bar/toolbar/Toolbar";
-import { CapabilitiesPicker } from "@app/components/assistant/CapabilitiesPicker";
 import type { CustomEditorProps } from "@app/components/editor/input_bar/useCustomEditor";
 import useCustomEditor from "@app/components/editor/input_bar/useCustomEditor";
 import useHandleMentions from "@app/components/editor/input_bar/useHandleMentions";


### PR DESCRIPTION
## Description

- This PR renames the component `ToolsPicker` into `CapabilitiesPicker` as it allows selecting both skills and tools.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
