### PR TITLE
[Connectors] Increase body parser limit for document upsert endpoints

### DIFF
--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -3,6 +3,12 @@ import { EnvironmentConfig } from "@app/types/shared/utils/config";
 
 export const PRODUCTION_DUST_API = "https://dust.tt";
 
+// Body parser limit for document upsert endpoints. This must accommodate the largest allowed
+// document text content (MAX_LARGE_DOCUMENT_TXT_LEN = 5MB in connectors) plus JSON serialization
+// overhead. JSON encoding can expand content significantly due to escaping of special characters
+// (newlines, quotes, backslashes, Unicode). We use 16MB to handle worst-case ~3x expansion.
+export const DOCUMENT_UPSERT_BODY_PARSER_LIMIT = "16mb";
+
 const config = {
   getClientFacingUrl: (): string => {
     // We override the NEXT_PUBLIC_DUST_CLIENT_FACING_URL in `front-internal` to ensure that the

--- a/front/pages/api/v1/w/[wId]/data_sources/[dsId]/documents/[documentId]/blob.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[dsId]/documents/[documentId]/blob.ts
@@ -2,7 +2,9 @@ import type { GetDocumentBlobResponseType } from "@dust-tt/client";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
-import apiConfig from "@app/lib/api/config";
+import apiConfig, {
+  DOCUMENT_UPSERT_BODY_PARSER_LIMIT,
+} from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import logger from "@app/logger/logger";
@@ -13,7 +15,7 @@ import { CoreAPI } from "@app/types";
 export const config = {
   api: {
     bodyParser: {
-      sizeLimit: "8mb",
+      sizeLimit: DOCUMENT_UPSERT_BODY_PARSER_LIMIT,
     },
   },
 };

--- a/front/pages/api/v1/w/[wId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -1,10 +1,11 @@
 /* eslint-disable dust/enforce-client-types-in-public-api */
+import { DOCUMENT_UPSERT_BODY_PARSER_LIMIT } from "@app/lib/api/config";
 import handler from "@app/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index";
 
 export const config = {
   api: {
     bodyParser: {
-      sizeLimit: "8mb",
+      sizeLimit: DOCUMENT_UPSERT_BODY_PARSER_LIMIT,
     },
   },
 };

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -8,7 +8,9 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { fromError } from "zod-validation-error";
 
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
-import apiConfig from "@app/lib/api/config";
+import apiConfig, {
+  DOCUMENT_UPSERT_BODY_PARSER_LIMIT,
+} from "@app/lib/api/config";
 import { UNTITLED_TITLE } from "@app/lib/api/content_nodes";
 import { computeWorkspaceOverallSizeCached } from "@app/lib/api/data_sources";
 import type { Authenticator } from "@app/lib/auth";
@@ -35,7 +37,7 @@ import {
 export const config = {
   api: {
     bodyParser: {
-      sizeLimit: "8mb",
+      sizeLimit: DOCUMENT_UPSERT_BODY_PARSER_LIMIT,
     },
   },
 };

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/documents/[documentId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/documents/[documentId]/index.ts
@@ -1,7 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import apiConfig from "@app/lib/api/config";
+import apiConfig, {
+  DOCUMENT_UPSERT_BODY_PARSER_LIMIT,
+} from "@app/lib/api/config";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import type { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
@@ -13,7 +15,7 @@ import { CoreAPI } from "@app/types";
 export const config = {
   api: {
     bodyParser: {
-      sizeLimit: "8mb",
+      sizeLimit: DOCUMENT_UPSERT_BODY_PARSER_LIMIT,
     },
   },
 };

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -3,7 +3,9 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import apiConfig from "@app/lib/api/config";
+import apiConfig, {
+  DOCUMENT_UPSERT_BODY_PARSER_LIMIT,
+} from "@app/lib/api/config";
 import { upsertDocument } from "@app/lib/api/data_sources";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";
@@ -22,7 +24,7 @@ import { CoreAPI, PostDataSourceDocumentRequestBodySchema } from "@app/types";
 export const config = {
   api: {
     bodyParser: {
-      sizeLimit: "8mb",
+      sizeLimit: DOCUMENT_UPSERT_BODY_PARSER_LIMIT,
     },
   },
 };

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/index.ts
@@ -3,6 +3,7 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { DOCUMENT_UPSERT_BODY_PARSER_LIMIT } from "@app/lib/api/config";
 import { upsertDocument } from "@app/lib/api/data_sources";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";
@@ -19,7 +20,7 @@ import { PostDataSourceDocumentRequestBodySchema } from "@app/types";
 export const config = {
   api: {
     bodyParser: {
-      sizeLimit: "8mb",
+      sizeLimit: DOCUMENT_UPSERT_BODY_PARSER_LIMIT,
     },
   },
 };


### PR DESCRIPTION
## Description

Increase body parser limit from 8MB to 16MB on document upsert API endpoints to accommodate large documents with JSON encoding overhead.

Root cause: connectors allow documents up to 5MB (MAX_LARGE_DOCUMENT_TXT_LEN), but JSON serialization escapes special characters (newlines, quotes, backslashes, Unicode). Furthermore, documents can also have a lot of metadata, causing 2-3x size expansion in worst cases. This caused 413 errors for legitimate files.

Adds centralized constant DOCUMENT_UPSERT_BODY_PARSER_LIMIT with documentation explaining the relationship to the connector limit.

## Risks

Blast radius: document upsert API endpoints (used by connectors and public API)
Risk: low

## Deploy Plan

- deploy front