### PR TITLE
[Connectors/Microsoft] Initialize workflows when permissions modal closes at creation

### DIFF
--- a/front/components/spaces/SpaceResourcesList.tsx
+++ b/front/components/spaces/SpaceResourcesList.tsx
@@ -288,6 +288,7 @@ export const SpaceResourcesList = ({
   const [assistantSId, setAssistantSId] = useState<string | null>(null);
   const [showConnectorPermissionsModal, setShowConnectorPermissionsModal] =
     useState(false);
+  const [isNewlyCreatedConnector, setIsNewlyCreatedConnector] = useState(false);
   const [selectedDataSourceView, setSelectedDataSourceView] =
     useState<DataSourceViewsWithDetails | null>(null);
   const [showDeleteConfirmDialog, setShowDeleteConfirmDialog] = useState(false);
@@ -546,6 +547,7 @@ export const SpaceResourcesList = ({
                   if (
                     isConnectorPermissionsEditable(dataSource.connectorProvider)
                   ) {
+                    setIsNewlyCreatedConnector(true);
                     setShowConnectorPermissionsModal(true);
                   }
                 }
@@ -660,10 +662,12 @@ export const SpaceResourcesList = ({
           initialModalState={
             shouldOpenSlackEditionModal ? "edition" : "selection"
           }
+          isNewlyCreated={isNewlyCreatedConnector}
           isOpen={showConnectorPermissionsModal && !!selectedDataSourceView}
           onClose={() => {
             setShowConnectorPermissionsModal(false);
             setShouldOpenSlackEditionModal(false);
+            setIsNewlyCreatedConnector(false);
           }}
           readOnly={false}
           isAdmin={isAdmin}


### PR DESCRIPTION
## Description

Production checks signal garbage collection flow missing for connectors, which upon investigation had no permissions ever set (confirmed via logs). 

When a connector is created, the permissions modal opens automatically. If the user closes the modal without selecting any resources, `setPermissions()` is never called, so full sync and garbage collection workflows are never started - leaving the connector in a broken state.

Fix: Add an `isNewlyCreated` flag to `ConnectorPermissionsModal` that triggers a `setPermissions` API call (with empty resources if needed) when the modal closes. This initializes all workflows while letting users come back later to select resources.

## Risks

Blast radius: Connector creation flow for all connector types with editable permissions
Risk: low

## Deploy Plan

- deploy front