### PR TITLE
[Connectors/Microsoft] Launch garbage collection workflow on connector creation

### DIFF
--- a/connectors/src/connectors/microsoft/index.ts
+++ b/connectors/src/connectors/microsoft/index.ts
@@ -128,9 +128,16 @@ export class MicrosoftConnectorManager extends BaseConnectorManager<null> {
 
     await syncSucceeded(connector.id);
 
-    const res = await launchMicrosoftIncrementalSyncWorkflow(connector.id);
-    if (res.isErr()) {
-      throw res.error;
+    const incrementalSyncRes = await launchMicrosoftIncrementalSyncWorkflow(
+      connector.id
+    );
+    if (incrementalSyncRes.isErr()) {
+      throw incrementalSyncRes.error;
+    }
+
+    const gcRes = await launchMicrosoftGarbageCollectionWorkflow(connector.id);
+    if (gcRes.isErr()) {
+      throw gcRes.error;
     }
 
     return new Ok(connector.id.toString());


### PR DESCRIPTION
## Description

Production checks signaled garbage collection workflow missing for Microsoft connectors where no permissions were ever set (confirmed via logs).

The issue: when a connector is created, only incremental sync is launched. Full sync and GC are only started when `setPermissions()` is called. If the user closes the permissions modal without selecting anything, GC never starts.

Fix: Launch GC workflow alongside incremental sync in `create()`. The GC will run on its daily cron schedule even if there's nothing to collect yet.

## Risks

Blast radius: Microsoft connector creation
Risk: low

## Deploy Plan
- pmrr
- deploy connectors