### PR TITLE
[front] fix(skills): preserve agent relationships on archiving

### DIFF
--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -612,12 +612,14 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       { customSkillIds: [], globalSkillIds: [] }
     );
 
+    // When fetching by specific IDs, return skills regardless of status.
     return this.baseFetch(
       auth,
       {
         where: {
           id: customSkillIds,
           sId: globalSkillIds,
+          status: ["active", "archived", "suggested"],
         },
       },
       context

--- a/front/pages/api/w/[wId]/skills/[sId]/index.test.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.test.ts
@@ -614,7 +614,10 @@ describe("DELETE /api/w/[wId]/skills/[sId]", () => {
     // Verify the skill is now archived
     const archivedSkill = await SkillResource.fetchById(
       requestUserAuth,
-      suggestedSkill.sId
+      suggestedSkill.sId,
+      {
+        status: "archived",
+      }
     );
     expect(archivedSkill).not.toBeNull();
     expect(archivedSkill?.status).toBe("archived");

--- a/front/pages/api/w/[wId]/skills/[sId]/index.test.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.test.ts
@@ -611,15 +611,17 @@ describe("DELETE /api/w/[wId]/skills/[sId]", () => {
     expect(res._getStatusCode()).toBe(200);
     expect(res._getJSONData()).toEqual({ success: true });
 
-    // Verify the skill is now archived
-    const archivedSkill = await SkillResource.fetchById(
+    // Verify the skill is now archived.
+    const archivedSkills = await SkillResource.listByWorkspace(
       requestUserAuth,
-      suggestedSkill.sId,
       {
         status: "archived",
       }
     );
-    expect(archivedSkill).not.toBeNull();
+    const archivedSkill = archivedSkills.find(
+      (s) => s.sId === suggestedSkill.sId
+    );
+    expect(archivedSkill).not.toBeUndefined();
     expect(archivedSkill?.status).toBe("archived");
   });
 });

--- a/front/pages/api/w/[wId]/skills/[sId]/index.test.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.test.ts
@@ -612,16 +612,11 @@ describe("DELETE /api/w/[wId]/skills/[sId]", () => {
     expect(res._getJSONData()).toEqual({ success: true });
 
     // Verify the skill is now archived.
-    const archivedSkills = await SkillResource.listByWorkspace(
+    const archivedSkill = await SkillResource.fetchById(
       requestUserAuth,
-      {
-        status: "archived",
-      }
+      suggestedSkill.sId
     );
-    const archivedSkill = archivedSkills.find(
-      (s) => s.sId === suggestedSkill.sId
-    );
-    expect(archivedSkill).not.toBeUndefined();
+    expect(archivedSkill).not.toBeNull();
     expect(archivedSkill?.status).toBe("archived");
   });
 });


### PR DESCRIPTION
## Description

- Skill x agent relationships are cleared upon archiving a skill, which makes it a very destructive action.
- This PR fixes this, and ensures that other code paths rely on active skills only.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
