### PR TITLE
[front] feat(skills): add non-handoff Go deep global skill

### DIFF
--- a/front/lib/actions/configuration/helpers.ts
+++ b/front/lib/actions/configuration/helpers.ts
@@ -81,11 +81,13 @@ export function buildServerSideMCPServerConfiguration({
   mcpServerView,
   dataSources = null,
   serverNameOverride,
+  childAgentId = null,
   additionalConfiguration = {},
 }: {
   mcpServerView: MCPServerViewResource;
   dataSources?: DataSourceConfiguration[] | null;
   serverNameOverride?: string;
+  childAgentId?: string | null;
   additionalConfiguration?: AdditionalConfigurationType;
 }): ServerSideMCPServerConfigurationType {
   const { server } = mcpServerView.toJSON();
@@ -101,7 +103,7 @@ export function buildServerSideMCPServerConfiguration({
     internalMCPServerId: mcpServerView.internalMCPServerId,
     dataSources,
     tables: null,
-    childAgentId: null,
+    childAgentId,
     additionalConfiguration,
     timeFrame: null,
     dustAppConfiguration: null,

--- a/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
@@ -39,7 +39,6 @@ import {
   MAX_STEPS_USE_PER_RUN_LIMIT,
 } from "@app/types";
 import { DUST_AVATAR_URL } from "@app/types/assistant/avatar";
-import If from "ajv/lib/vocabularies/applicator/if";
 
 const MAX_CONCURRENT_SUB_AGENT_TASKS = 6;
 

--- a/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
@@ -266,7 +266,7 @@ Heavily bias against using the interactive_content tool for what could be writte
 Never use the slideshow tool unless explicitly requested by the user.
 </output_guidelines>`;
 
-const deepDiveInstructions = `${deepDivePrimaryGoal}\n${requestComplexityPrompt}\n${toolsPrompt}\n${outputPrompt}`;
+export const deepDiveInstructions = `${deepDivePrimaryGoal}\n${requestComplexityPrompt}\n${toolsPrompt}\n${outputPrompt}`;
 
 const subAgentInstructions = `${subAgentPrimaryGoal}\n${offloadedBrowsingPrompt}\n${toolsPrompt}
 <output_format>

--- a/front/lib/api/assistant/skill_actions.ts
+++ b/front/lib/api/assistant/skill_actions.ts
@@ -41,13 +41,15 @@ export async function getSkillServers(
 
   return skills.flatMap((skill) =>
     [
-      ...skill.mcpServerViews,
-      ...(skill.extendedSkill?.mcpServerViews ?? []),
-    ].map((mcpServerView) => {
+      ...skill.mcpServerConfigurations,
+      ...(skill.extendedSkill?.mcpServerConfigurations ?? []),
+    ].map((config) => {
+      const { view, childAgentId, serverNameOverride } = config;
+
       const {
         requiresDataWarehouseConfiguration,
         requiresDataSourceConfiguration,
-      } = getMCPServerRequirements(mcpServerView.toJSON());
+      } = getMCPServerRequirements(view.toJSON());
 
       let applicableViews: DataSourceViewResource[];
       if (requiresDataWarehouseConfiguration) {
@@ -58,15 +60,17 @@ export async function getSkillServers(
         applicableViews = [];
       }
 
-      const dataSources = applicableViews.map((view) => ({
-        dataSourceViewId: view.sId,
+      const dataSources = applicableViews.map((dsView) => ({
+        dataSourceViewId: dsView.sId,
         workspaceId: auth.getNonNullableWorkspace().sId,
-        filter: view.toViewFilter(),
+        filter: dsView.toViewFilter(),
       }));
 
       return buildServerSideMCPServerConfiguration({
-        mcpServerView,
+        mcpServerView: view,
         dataSources,
+        childAgentId,
+        serverNameOverride,
       });
     })
   );

--- a/front/lib/resources/skill/global/discover_knowledge.ts
+++ b/front/lib/resources/skill/global/discover_knowledge.ts
@@ -29,7 +29,10 @@ export const discoverKnowledgeSkill = {
   agentFacingDescription:
     "Search documents, browse folder hierarchies, read file contents, and query data warehouse tables with SQL.",
   instructions: DISCOVER_KNOWLEDGE_INSTRUCTIONS,
-  internalMCPServerNames: ["data_sources_file_system", "data_warehouses"],
+  mcpServers: [
+    { name: "data_sources_file_system" },
+    { name: "data_warehouses" },
+  ],
   version: 1,
   icon: "ActionBookOpenIcon",
   inheritAgentConfigurationDataSources: true,

--- a/front/lib/resources/skill/global/discover_tools.ts
+++ b/front/lib/resources/skill/global/discover_tools.ts
@@ -31,7 +31,7 @@ export const discoverToolsSkill = {
 
     return buildDiscoverToolsInstructions(availableToolsets);
   },
-  internalMCPServerNames: ["toolsets"],
+  mcpServers: [{ name: "toolsets" }],
   version: 1,
   icon: "ToolsIcon",
   isAutoEnabled: true,

--- a/front/lib/resources/skill/global/frames.ts
+++ b/front/lib/resources/skill/global/frames.ts
@@ -9,7 +9,7 @@ export const framesSkill = {
   agentFacingDescription:
     "Create interactive visualizations, charts, dashboards, and presentations as executable React components.",
   instructions: INTERACTIVE_CONTENT_INSTRUCTIONS,
-  internalMCPServerNames: ["interactive_content"],
+  mcpServers: [{ name: "interactive_content" }],
   version: 1,
   icon: "ActionFrameIcon",
 } as const satisfies GlobalSkillDefinition;

--- a/front/lib/resources/skill/global/go_deep.ts
+++ b/front/lib/resources/skill/global/go_deep.ts
@@ -1,25 +1,36 @@
-import {
-  DEEP_DIVE_NAME,
-  DEEP_DIVE_SERVER_INSTRUCTIONS,
-} from "@app/lib/api/assistant/global_agents/configurations/dust/consts";
+import { deepDiveInstructions } from "@app/lib/api/assistant/global_agents/configurations/dust/deep-dive";
 import { isDeepDiveDisabledByAdmin } from "@app/lib/api/assistant/global_agents/configurations/dust/utils";
 import type { GlobalSkillDefinition } from "@app/lib/resources/skill/global/registry";
+import { GLOBAL_AGENTS_SID } from "@app/types";
 
 export const goDeepSkill = {
   sId: "go-deep",
   name: "Go Deep",
   userFacingDescription:
-    `Hand off complex questions to the @${DEEP_DIVE_NAME} agent for comprehensive analysis ` +
-    `across company data, databases, and web sources—thorough analysis that may take several ` +
-    `minutes.`,
+    "Enable comprehensive analysis across company data, databases, and web " +
+    "sources — thorough analysis that may take several minutes.",
   agentFacingDescription:
     "Use when the user asks complex, multi-faceted questions requiring " +
     "comprehensive research across multiple data sources, databases, and web " +
     "resources. Ideal for analysis tasks that need thorough investigation " +
     "beyond your current capabilities.",
-  instructions: DEEP_DIVE_SERVER_INSTRUCTIONS,
-  internalMCPServerNames: ["deep_dive"],
-  version: 1,
+  instructions: deepDiveInstructions,
+  mcpServers: [
+    {
+      name: "run_agent",
+      childAgentId: GLOBAL_AGENTS_SID.DUST_TASK,
+      serverNameOverride: "sub_agent",
+    },
+    {
+      name: "run_agent",
+      childAgentId: GLOBAL_AGENTS_SID.DUST_PLANNING,
+      serverNameOverride: "planning_agent",
+    },
+    { name: "data_sources_file_system" },
+    { name: "web_search_&_browse" },
+    { name: "data_warehouses" },
+  ],
+  version: 2,
   icon: "ActionAtomIcon",
   isRestricted: isDeepDiveDisabledByAdmin,
 } as const satisfies GlobalSkillDefinition;

--- a/front/lib/resources/skill/global/go_deep.ts
+++ b/front/lib/resources/skill/global/go_deep.ts
@@ -1,4 +1,4 @@
-import { deepDiveInstructions } from "@app/lib/api/assistant/global_agents/configurations/dust/deep-dive";
+import { getDeepDiveInstructions } from "@app/lib/api/assistant/global_agents/configurations/dust/deep-dive";
 import { isDeepDiveDisabledByAdmin } from "@app/lib/api/assistant/global_agents/configurations/dust/utils";
 import type { GlobalSkillDefinition } from "@app/lib/resources/skill/global/registry";
 import { GLOBAL_AGENTS_SID } from "@app/types";
@@ -14,7 +14,7 @@ export const goDeepSkill = {
     "comprehensive research across multiple data sources, databases, and web " +
     "resources. Ideal for analysis tasks that need thorough investigation " +
     "beyond your current capabilities.",
-  instructions: deepDiveInstructions,
+  instructions: getDeepDiveInstructions({ includeToolsetsPrompt: false }),
   mcpServers: [
     {
       name: "run_agent",

--- a/front/lib/resources/skill/global/registry.ts
+++ b/front/lib/resources/skill/global/registry.ts
@@ -9,6 +9,12 @@ import type { ResourceSId } from "@app/lib/resources/string_ids";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { removeNulls } from "@app/types";
 
+export type MCPServerDefinition = {
+  name: AutoInternalMCPServerNameType;
+  childAgentId?: string;
+  serverNameOverride?: string;
+};
+
 interface BaseGlobalSkillDefinition {
   readonly agentFacingDescription: string;
   readonly userFacingDescription: string;
@@ -16,7 +22,7 @@ interface BaseGlobalSkillDefinition {
   readonly sId: string;
   readonly version: number;
   readonly icon: string;
-  readonly internalMCPServerNames?: AutoInternalMCPServerNameType[];
+  readonly mcpServers?: MCPServerDefinition[];
   readonly inheritAgentConfigurationDataSources?: boolean;
   readonly isAutoEnabled?: boolean;
   readonly isRestricted?: (auth: Authenticator) => Promise<boolean>;


### PR DESCRIPTION
## Description

- The `go_deep` skill currently performs a handoff to the deep dive agent, which prevents it from searching on spaces other than Company Space.
- This PR reworks this skill to add deep dive's capabilities and instructions to the main agent. The goal is to make the main agent able to do what deep dive does.
- Still one major limitation in that using global agents for dust task only allows it to access the global space. Will fix in a follow up PR.
- We'll be able to remove the `deep_dive` tool after GA.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
