### PR TITLE
fix(copilot): only fetch copilot global agent if explicitely requested

### DIFF
--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -590,9 +590,10 @@ export async function getGlobalAgents(
   // user agents).
   let agentsIdsToFetch =
     agentIds ??
-    Object.values(GLOBAL_AGENTS_SID).filter(
-      (sId) => !RETIRED_GLOBAL_AGENTS_SID.includes(sId)
-    );
+    Object.values(GLOBAL_AGENTS_SID)
+      .filter((sId) => !RETIRED_GLOBAL_AGENTS_SID.includes(sId))
+      // We only want to fetch copilot global agent if explicitely requested.
+      .filter((sId) => sId !== GLOBAL_AGENTS_SID.COPILOT);
 
   const flags = await getFeatureFlags(owner);
 


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/6080
Only fetch copilot global agent if explicitely requested, preventing from returning it in mention suggestions and home page.

## Tests

Local.

## Risk

Low.

## Deploy Plan

Front.