### PR TITLE
Support node_modules for npm workspaces

### DIFF
--- a/x/henry/dust-hive/src/lib/setup.ts
+++ b/x/henry/dust-hive/src/lib/setup.ts
@@ -15,6 +15,15 @@ import { logger } from "./logger";
 // These are personal/local files that aren't tracked in git
 const USER_CONFIG_DIRS = [".claude"];
 
+// @dust-tt packages mapping: npm scope name -> workspace directory relative to repo root
+// These are workspace packages that need to be overridden to point to the worktree
+const DUST_TT_PACKAGES: Record<string, string> = {
+  client: "sdks/js",
+  "dust-cli": "cli",
+  extension: "extension",
+  sparkle: "sparkle",
+};
+
 // Configuration for how to install each dependency type
 export interface DependencyConfig {
   rust: "symlink" | "build";
@@ -42,17 +51,13 @@ async function symlinkNodeModules(srcDir: string, destDir: string): Promise<bool
   return proc.exitCode === 0;
 }
 
-// Setup shallow node_modules with SDK override
+// Setup root node_modules with workspace package overrides
 // Creates a real node_modules directory with symlinks to main repo packages,
-// but overrides @dust-tt/client to point to the worktree's SDK.
-// This ensures TypeScript and runtime resolve the SDK from the worktree,
+// but overrides @dust-tt/* packages to point to the worktree's workspaces.
+// This ensures TypeScript and runtime resolve workspace packages from the worktree,
 // not the main repo (which may have stale types).
-function setupShallowNodeModules(
-  mainNodeModules: string,
-  worktreeSdk: string,
-  targetDir: string
-): void {
-  const target = join(targetDir, "node_modules");
+function setupRootNodeModules(mainNodeModules: string, worktreePath: string): void {
+  const target = join(worktreePath, "node_modules");
 
   // Create target/node_modules/@dust-tt directory
   mkdirSync(join(target, "@dust-tt"), { recursive: true });
@@ -64,16 +69,23 @@ function setupShallowNodeModules(
     }
   }
 
-  // Symlink @dust-tt contents except client
-  const dustTtDir = join(mainNodeModules, "@dust-tt");
-  for (const item of readdirSync(dustTtDir)) {
-    if (item !== "client") {
-      symlinkSync(join(dustTtDir, item), join(target, "@dust-tt", item));
-    }
+  // Override @dust-tt packages to point to worktree's workspaces
+  for (const [pkgName, workspaceDir] of Object.entries(DUST_TT_PACKAGES)) {
+    symlinkSync(join(worktreePath, workspaceDir), join(target, "@dust-tt", pkgName));
   }
+}
 
-  // Link @dust-tt/client to worktree's SDK
-  symlinkSync(worktreeSdk, join(target, "@dust-tt/client"));
+// Setup shallow node_modules for workspace packages (front, connectors)
+// Creates a real node_modules directory with symlinks to main repo packages.
+// With npm workspaces, @dust-tt packages are in root node_modules, not here.
+function setupShallowNodeModules(mainNodeModules: string, targetDir: string): void {
+  const target = join(targetDir, "node_modules");
+  mkdirSync(target, { recursive: true });
+
+  // Symlink all packages from main repo
+  for (const item of readdirSync(mainNodeModules)) {
+    symlinkSync(join(mainNodeModules, item), join(target, item));
+  }
 }
 
 // Symlink cargo target directory to share compilation cache
@@ -221,6 +233,18 @@ export async function installAllDependencies(
     }
   }
 
+  // Handle root node_modules (npm workspaces hoists deps here)
+  // Override @dust-tt/* packages to point to worktree's workspaces
+  logger.step("root: Linking from cache (with workspace overrides)...");
+  try {
+    setupRootNodeModules(`${repoRoot}/node_modules`, worktreePath);
+    logger.success("root: Linked");
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logger.error(`root: Failed to link - ${message}`);
+    failed.push("root");
+  }
+
   // Handle node_modules for sdks/js (simple symlink, it IS the SDK)
   if (config.sdks === "symlink") {
     logger.step("sdks/js: Linking from cache...");
@@ -241,10 +265,8 @@ export async function installAllDependencies(
   }
 
   // Handle node_modules for front and connectors
-  // These use shallow copy with SDK override to ensure @dust-tt/client
-  // resolves to the worktree's SDK (not main repo's potentially stale SDK)
-  const worktreeSdk = `${worktreePath}/sdks/js`;
-  const projectsWithSdkDep = [
+  // With npm workspaces, most deps are hoisted to root. These only have local overrides.
+  const workspaceProjects = [
     {
       key: "front" as const,
       name: "front",
@@ -259,12 +281,12 @@ export async function installAllDependencies(
     },
   ];
 
-  for (const { key, name, mainNodeModules, dest } of projectsWithSdkDep) {
+  for (const { key, name, mainNodeModules, dest } of workspaceProjects) {
     const mode = config[key];
     if (mode === "symlink") {
-      logger.step(`${name}: Linking from cache (with SDK override)...`);
+      logger.step(`${name}: Linking from cache...`);
       try {
-        setupShallowNodeModules(mainNodeModules, worktreeSdk, dest);
+        setupShallowNodeModules(mainNodeModules, dest);
         logger.success(`${name}: Linked`);
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Description

  Handles the root node_modules which now contains all hoisted dependencies:
  - Links all packages from main repo except @dust-tt
  - Creates @dust-tt/* symlinks pointing to worktree's workspace directories


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
