### PR TITLE
[LINT] Fix Scheduled lint on front codebase

### DIFF
--- a/.github/workflows/scheduled-tests-front.yml
+++ b/.github/workflows/scheduled-tests-front.yml
@@ -1,6 +1,9 @@
 name: Scheduled Lint (front)
 
 on:
+  push:
+    paths:
+      - ".github/workflows/scheduled-tests-front.yml"
   schedule:
     # Run twice a day at 8 AM and 8 PM UTC
     - cron: "0 8,20 * * *"
@@ -29,19 +32,11 @@ jobs:
               🧪 Starting scheduled front tests
               • Workflow: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
+      - name: Setup Node Dependencies
+        uses: ./.github/actions/setup-node-deps
         with:
-          node-version: 20.13.0
-      - name: Install SDK/JS dependencies
-        working-directory: sdks/js
-        run: npm ci
-      - name: Build SDK/JS
-        working-directory: sdks/js
-        run: npm run build
-      - name: Install Front dependencies
-        working-directory: front
-        run: npm ci
+          build-sdks: "true"
+
       - name: Run ESLint (Full Check, No Cache)
         working-directory: front
         run: npm run lint

--- a/.github/workflows/scheduled-tests-front.yml
+++ b/.github/workflows/scheduled-tests-front.yml
@@ -36,6 +36,7 @@ jobs:
         uses: ./.github/actions/setup-node-deps
         with:
           build-sdks: "true"
+          build-sparkle: "true"
 
       - name: Run ESLint (Full Check, No Cache)
         working-directory: front


### PR DESCRIPTION
## Description

Scheduled lint workflow was not using reusable `setup-dep` action, and failed. Because types from Sparkle were not properly imported, and eslint could not infer that the use of "||" was actually ok (non nullish).

Fix: use `setup-dep` action with `build-sparkle` to true.

Failed workflow:
https://github.com/dust-tt/dust/actions/runs/21350534415

## Tests

This PR 

## Risk

no

## Deploy Plan

no
