### PR TITLE
Updates PDF export to use the public viz URL

### DIFF
--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -249,9 +249,9 @@ const config = {
   getDocumentRendererUrl: (): string | undefined => {
     return EnvironmentConfig.getOptionalEnvVariable("DOCUMENT_RENDERER_URL");
   },
-  // Internal viz service URL (K8s service in production).
-  getVizInternalUrl: (): string | undefined => {
-    return EnvironmentConfig.getOptionalEnvVariable("VIZ_INTERNAL_URL");
+  // Public viz URL (used by Gotenberg which routes through egress proxy).
+  getVizPublicUrl: (): string | undefined => {
+    return EnvironmentConfig.getOptionalEnvVariable("VIZ_PUBLIC_URL");
   },
   // Status page.
   getStatusPageProvidersPageId: (): string => {

--- a/front/pages/api/w/[wId]/files/[fileId]/export/pdf.test.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/export/pdf.test.ts
@@ -27,9 +27,7 @@ vi.mock("@app/types", async (importOriginal) => {
 vi.mock("@app/lib/api/config", () => ({
   default: {
     getDocumentRendererUrl: vi.fn().mockReturnValue("http://localhost:3100"),
-    getVizInternalUrl: vi
-      .fn()
-      .mockReturnValue("http://viz-service.default.svc.cluster.local"),
+    getVizPublicUrl: vi.fn().mockReturnValue("https://viz.dust.tt"),
     getClientFacingUrl: vi.fn().mockReturnValue("http://localhost:3000"),
     getVizJwtSecret: vi.fn().mockReturnValue("test-secret"),
   },

--- a/front/pages/api/w/[wId]/files/[fileId]/export/pdf.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/export/pdf.ts
@@ -130,14 +130,15 @@ async function handler(
     workspaceId: owner.sId,
   });
 
-  // Build viz URL.
-  const vizUrl = config.getVizInternalUrl();
+  // Build viz URL. Use public URL since Gotenberg routes through egress proxy
+  // which blocks internal K8s IPs.
+  const vizUrl = config.getVizPublicUrl();
   if (!vizUrl) {
     return apiError(req, res, {
       status_code: 501,
       api_error: {
         type: "internal_server_error",
-        message: "VIZ_URL is not configured.",
+        message: "VIZ_PUBLIC_URL is not configured.",
       },
     });
   }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
]Problem: External images/fonts in Frames weren't loading in exported PDFs because Gotenberg's `--chromium-allow-list` blocked external URLs.

Solution:
- Route all Chromium requests through the squid proxy (which blocks private IPs but allows external URLs)
- Use public viz URL (`VIZ_PUBLIC_URL`) since the proxy blocks internal K8s IPs
- Add `--chromium-deny-list` as belt-and-suspenders protection against internal IP access

Security layers:
1. Gotenberg deny-list blocks private IPs/hostnames at application level
2. Squid proxy blocks private networks at network level

See infra PR here: https://github.com/dust-tt/dust-infra/pull/619

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [ ] Add `VIZ_PUBLIC_URL` in both regions
- [ ] Deploy front
