### PR TITLE
copilot: Polish the list_suggestions MCP method

### DIFF
--- a/front/lib/api/actions/servers/agent_copilot_context/agent_copilot_context.test.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/agent_copilot_context.test.ts
@@ -653,7 +653,7 @@ describe("agent_copilot_context tools", () => {
       }
     });
 
-    it("lists suggestions with specific status and kind filters", async () => {
+    it("lists suggestions with specific statuses and kind filters", async () => {
       const { authenticator } = await createResourceTest({ role: "admin" });
 
       const { getAgentConfigurationIdFromContext } =
@@ -665,7 +665,7 @@ describe("agent_copilot_context tools", () => {
       const tool = getToolByName("list_suggestions");
       const result = await tool.handler(
         {
-          status: "approved",
+          statuses: ["pending", "rejected"],
           kind: "tools",
         },
         createTestExtra(authenticator)

--- a/front/lib/api/actions/servers/agent_copilot_context/agent_copilot_context.test.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/agent_copilot_context.test.ts
@@ -653,7 +653,7 @@ describe("agent_copilot_context tools", () => {
       }
     });
 
-    it("lists suggestions with specific statuses and kind filters", async () => {
+    it("lists suggestions with specific states and kind filters", async () => {
       const { authenticator } = await createResourceTest({ role: "admin" });
 
       const { getAgentConfigurationIdFromContext } =
@@ -665,7 +665,7 @@ describe("agent_copilot_context tools", () => {
       const tool = getToolByName("list_suggestions");
       const result = await tool.handler(
         {
-          statuses: ["pending", "rejected"],
+          states: ["pending", "rejected"],
           kind: "tools",
         },
         createTestExtra(authenticator)

--- a/front/lib/api/actions/servers/agent_copilot_context/metadata.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/metadata.ts
@@ -181,18 +181,26 @@ export const AGENT_COPILOT_CONTEXT_TOOLS_METADATA = createToolsRecord({
     description:
       "List existing suggestions for the agent's configuration changes.",
     schema: {
-      status: z
-        .enum(AGENT_SUGGESTION_STATES)
+      statuses: z
+        .array(z.enum(AGENT_SUGGESTION_STATES))
         .optional()
-        .default("pending")
+        .default(["pending"])
         .describe(
-          `Filter by suggestion status (default: 'pending'). Options: ${AGENT_SUGGESTION_STATES.join(", ")}`
+          `Filter by suggestion statuses (default: ['pending']). Options: ${AGENT_SUGGESTION_STATES.join(", ")}`
         ),
       kind: z
         .enum(AGENT_SUGGESTION_KINDS)
         .optional()
         .describe(
           `Filter by suggestion type. Options: ${AGENT_SUGGESTION_KINDS.join(", ")}. If not provided, returns all types.`
+        ),
+      limit: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .describe(
+          "Maximum number of suggestions to return. Results are ordered by creation date (most recent first). If not provided, returns all matching suggestions."
         ),
     },
     stake: "never_ask",

--- a/front/lib/api/actions/servers/agent_copilot_context/metadata.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/metadata.ts
@@ -181,12 +181,12 @@ export const AGENT_COPILOT_CONTEXT_TOOLS_METADATA = createToolsRecord({
     description:
       "List existing suggestions for the agent's configuration changes.",
     schema: {
-      statuses: z
+      states: z
         .array(z.enum(AGENT_SUGGESTION_STATES))
         .optional()
         .default(["pending"])
         .describe(
-          `Filter by suggestion statuses (default: ['pending']). Options: ${AGENT_SUGGESTION_STATES.join(", ")}`
+          `Filter by suggestion states (default: ['pending']). Options: ${AGENT_SUGGESTION_STATES.join(", ")}`
         ),
       kind: z
         .enum(AGENT_SUGGESTION_KINDS)

--- a/front/lib/api/actions/servers/agent_copilot_context/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/tools/index.ts
@@ -627,7 +627,7 @@ const handlers: ToolHandlers<typeof AGENT_COPILOT_CONTEXT_TOOLS_METADATA> = {
         auth,
         agentConfigurationId,
         {
-          states: params.statuses,
+          states: params.states,
           kind: params.kind,
           limit: params.limit,
         }

--- a/front/lib/api/actions/servers/agent_copilot_context/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/tools/index.ts
@@ -627,8 +627,9 @@ const handlers: ToolHandlers<typeof AGENT_COPILOT_CONTEXT_TOOLS_METADATA> = {
         auth,
         agentConfigurationId,
         {
-          state: params.status,
+          states: params.statuses,
           kind: params.kind,
+          limit: params.limit,
         }
       );
 

--- a/front/lib/resources/agent_suggestion_resource.ts
+++ b/front/lib/resources/agent_suggestion_resource.ts
@@ -237,8 +237,9 @@ export class AgentSuggestionResource extends BaseResource<AgentSuggestionModel> 
     auth: Authenticator,
     agentId: string,
     filters?: {
-      state?: AgentSuggestionState;
+      states?: AgentSuggestionState[];
       kind?: AgentSuggestionKind;
+      limit?: number;
     }
   ): Promise<AgentSuggestionResource[]> {
     const owner = auth.getNonNullableWorkspace();
@@ -261,12 +262,15 @@ export class AgentSuggestionResource extends BaseResource<AgentSuggestionModel> 
     // Build the where clause with optional filters.
     const whereClause: WhereOptions<AgentSuggestionModel> = {
       agentConfigurationId: agentConfigIds,
-      ...(filters?.state && { state: filters.state }),
+      ...(filters?.states &&
+        filters.states.length > 0 && { state: filters.states }),
       ...(filters?.kind && { kind: filters.kind }),
     };
 
     return this.baseFetch(auth, {
       where: whereClause,
+      order: [["createdAt", "DESC"]],
+      limit: filters?.limit,
     });
   }
 

--- a/front/pages/api/w/[wId]/assistant/agents/suggestions.test.ts
+++ b/front/pages/api/w/[wId]/assistant/agents/suggestions.test.ts
@@ -130,7 +130,7 @@ describe("PATCH /api/w/[wId]/assistant/agents/suggestions", () => {
 
   it.each<Exclude<AgentSuggestionState, "pending">>([
     "approved",
-    "declined",
+    "rejected",
     "outdated",
   ])("updates suggestion state to %s", async (newState) => {
     const { req, res, authenticator } = await setupTest();

--- a/front/pages/api/w/[wId]/assistant/agents/suggestions.ts
+++ b/front/pages/api/w/[wId]/assistant/agents/suggestions.ts
@@ -15,7 +15,7 @@ const PatchSuggestionRequestBodySchema = t.type({
   suggestionId: t.string,
   state: t.union([
     t.literal("approved"),
-    t.literal("declined"),
+    t.literal("rejected"),
     t.literal("outdated"),
   ]),
 });

--- a/front/types/suggestions/agent_suggestion.ts
+++ b/front/types/suggestions/agent_suggestion.ts
@@ -16,7 +16,7 @@ export type AgentSuggestionKind = (typeof AGENT_SUGGESTION_KINDS)[number];
 export const AGENT_SUGGESTION_STATES = [
   "pending",
   "approved",
-  "declined",
+  "rejected",
   "outdated",
 ] as const;
 


### PR DESCRIPTION
## Description

closes https://github.com/dust-tt/tasks/issues/6103

Improvments to the list_suggestions MCP tool:

 - change "declined" status to "rejected"
 - support multiple statuses and default to `[pending]`
 - add a limit param
 - order by creation date

## Tests

Updated unit tests

## Risk

Changing "declined" to "rejected" without DB update but the DB is empty

## Deploy Plan

deploy front
