### PR TITLE
[front] fix(skills): handle repeated clicks on Add knowledge in Skill Builder

### DIFF
--- a/front/components/editor/extensions/skill_builder/KnowledgeNodeView.tsx
+++ b/front/components/editor/extensions/skill_builder/KnowledgeNodeView.tsx
@@ -311,12 +311,12 @@ function KnowledgeSearchComponent({
 
   // Delete empty node helper.
   const deleteIfEmpty = useCallback(
-    (delay: number = 50) => {
+    (delayMs: number = 50) => {
       setTimeout(() => {
         if (!searchQuery.trim()) {
           onCancel();
         }
-      }, delay);
+      }, delayMs);
     },
     [searchQuery, onCancel]
   );

--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -151,9 +151,32 @@ export function SkillBuilderInstructionsEditor({
   });
 
   const handleAddKnowledge = useCallback(() => {
-    if (editor) {
-      editor.chain().focus().insertKnowledgeNode().run();
+    if (!editor) {
+      return;
     }
+
+    // Check if there's already an empty knowledge node (in search mode).
+    // If so, do nothing - clicking the button already dismissed it via handleInteractOutside.
+    const { doc } = editor.state;
+    let hasEmptyKnowledgeNode = false;
+    doc.descendants((node) => {
+      if (node.type.name === KNOWLEDGE_NODE_TYPE) {
+        const selectedItems = node.attrs?.selectedItems as
+          | KnowledgeItem[]
+          | undefined;
+        if (!selectedItems || selectedItems.length === 0) {
+          hasEmptyKnowledgeNode = true;
+          return false;
+        }
+      }
+      return true;
+    });
+
+    if (hasEmptyKnowledgeNode) {
+      return;
+    }
+
+    editor.chain().focus().insertKnowledgeNode().run();
   }, [editor]);
 
   useEffect(() => {


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/6144.
- This PR fixes the behavior when clicking repeatedly on the "Add knowledge" button in Skill Builder.
- Instead of adding a bunch of dropdowns, skip the addition if there is an empty node.

## Tests

- Tested locally. This removes the node due to it being empty.

## Risk

- Low.

## Deploy Plan

- Deploy front.
