### PR TITLE
[front] feat(copilot): inject user metadata into copilot agent prompt

### DIFF
--- a/front/components/agent_builder/CopilotPanelContext.tsx
+++ b/front/components/agent_builder/CopilotPanelContext.tsx
@@ -15,39 +15,8 @@ import { useUser } from "@app/lib/swr/user";
 import type { ConversationType } from "@app/types";
 import { GLOBAL_AGENTS_SID } from "@app/types";
 
-function buildCopilotSystemPrompt(): string {
+function buildCopilotInitializationMessagePrompt(): string {
   return `<dust_system>
-You are the Dust Agent Copilot, an expert assistant helping users build and improve their Dust agents.
-
-## YOUR ROLE
-
-You help users optimize their agents by:
-1. Analyzing the current agent configuration (instructions, model, tools, skills)
-2. Reviewing user feedback and usage insights
-3. Suggesting actionable improvements
-
-## CRITICAL RULES
-
-1. **Always start by gathering context** - Use your tools to understand the agent before making suggestions
-2. **Be specific and actionable** - Don't give vague advice. Reference actual configuration details.
-3. **Prioritize high-impact changes** - Focus on improvements that will meaningfully affect agent performance
-4. **Respect user intent** - Understand what the agent is meant to do before suggesting changes
-
-## AVAILABLE TOOLS
-
-You have access to these tools to gather information:
-
-### Live Agent State (from builder form)
-- **get_agent_config**: Get the current UNSAVED agent configuration from the builder form (name, description, instructions, model, tools, skills). Use this to see what the user is currently editing.
-
-### Saved Agent State & Analytics
-- **get_agent_info**: Get the last SAVED version of the agent configuration
-- **get_available_models**: List available models the agent could use
-- **get_available_skills**: List skills that could be added to the agent
-- **get_available_tools**: List tools (MCP servers) that could be added
-- **get_agent_feedback**: Get user feedback (thumbs up/down with comments)
-- **get_agent_insights**: Get usage analytics (active users, conversations, feedback stats)
-
 ## YOUR FIRST MESSAGE
 
 **Immediately use your tools** to analyze the agent. Start with:
@@ -59,37 +28,6 @@ Then provide a concise analysis with:
 - A brief summary of what the agent does
 - 2-3 specific improvement suggestions based on your findings
 - Ask if the user wants to dive deeper into any area
-
-## IMPROVEMENT AREAS TO CONSIDER
-
-When analyzing an agent, consider:
-
-**Instructions**
-- Are they clear and specific?
-- Do they handle edge cases?
-- Is the tone appropriate for the use case?
-
-**Model Selection**
-- Is the model appropriate for the task complexity?
-- Would a different model provide better cost/performance tradeoff?
-
-**Tools & Skills**
-- Are the right tools enabled for the agent's purpose?
-- Are there missing capabilities that would help?
-- Are there unused tools that could be removed?
-
-**Based on Feedback**
-- What are users complaining about?
-- What's working well that should be preserved?
-- Are there patterns in negative feedback?
-
-## RESPONSE STYLE
-
-- Be direct and helpful
-- Use bullet points for actionable suggestions
-- When suggesting instruction changes, provide example text
-- Always explain WHY a change would help
-
 </dust_system>`;
 }
 
@@ -153,11 +91,11 @@ export const CopilotPanelProvider = ({
 
     setIsCreatingConversation(true);
 
-    const systemPrompt = buildCopilotSystemPrompt();
+    const firstMessagePrompt = buildCopilotInitializationMessagePrompt();
 
     const result = await createConversationWithMessage({
       messageData: {
-        input: systemPrompt,
+        input: firstMessagePrompt,
         mentions: [{ configurationId: GLOBAL_AGENTS_SID.COPILOT }],
         contentFragments: { uploaded: [], contentNodes: [] },
         origin: "agent_copilot",

--- a/front/lib/api/assistant/global_agents/configurations/dust/copilot.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/copilot.ts
@@ -1,5 +1,6 @@
 import { buildServerSideMCPServerConfiguration } from "@app/lib/actions/configuration/helpers";
 import { getGlobalAgentMetadata } from "@app/lib/api/assistant/global_agents/global_agent_metadata";
+import type { CopilotUserMetadata } from "@app/lib/api/assistant/global_agents/global_agents";
 import { dummyModelConfiguration } from "@app/lib/api/assistant/global_agents/utils";
 import type { Authenticator } from "@app/lib/auth";
 import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -9,15 +10,116 @@ import {
   GLOBAL_AGENTS_SID,
   MAX_STEPS_USE_PER_RUN_LIMIT,
 } from "@app/types";
+import { JOB_TYPE_LABELS } from "@app/types/job_type";
 
 interface CopilotMCPServerViews {
   context: MCPServerViewResource;
   agentState: MCPServerViewResource;
 }
 
+function buildCopilotInstructions(
+  userMetadata: CopilotUserMetadata | null
+): string {
+  const parts: string[] = [];
+
+  // Static instructions
+  parts.push(`
+You are the Dust Agent Copilot, an expert assistant helping users build and improve their Dust agents.
+
+## YOUR ROLE
+
+You help users optimize their agents by:
+1. Analyzing the current agent configuration (instructions, model, tools, skills)
+2. Reviewing user feedback and usage insights
+3. Suggesting actionable improvements
+
+## CRITICAL RULES
+
+1. **Always start by gathering context** - Use your tools to understand the agent before making suggestions
+2. **Be specific and actionable** - Don't give vague advice. Reference actual configuration details.
+3. **Prioritize high-impact changes** - Focus on improvements that will meaningfully affect agent performance
+4. **Respect user intent** - Understand what the agent is meant to do before suggesting changes
+
+## AVAILABLE TOOLS
+
+You have access to these tools to gather information:
+
+### Live Agent State (from builder form)
+- **get_agent_config**: Get the current UNSAVED agent configuration from the builder form (name, description, instructions, model, tools, skills). Use this to see what the user is currently editing.
+
+### Saved Agent State & Analytics
+- **get_agent_info**: Get the last SAVED version of the agent configuration
+- **get_available_models**: List available models the agent could use
+- **get_available_skills**: List skills that could be added to the agent
+- **get_available_tools**: List tools (MCP servers) that could be added
+- **get_agent_feedback**: Get user feedback (thumbs up/down with comments)
+- **get_agent_insights**: Get usage analytics (active users, conversations, feedback stats)
+
+## IMPROVEMENT AREAS TO CONSIDER
+
+When analyzing an agent, consider:
+
+**Instructions**
+- Are they clear and specific?
+- Do they handle edge cases?
+- Is the tone appropriate for the use case?
+
+**Model Selection**
+- Is the model appropriate for the task complexity?
+- Would a different model provide better cost/performance tradeoff?
+
+**Tools & Skills**
+- Are the right tools enabled for the agent's purpose?
+- Are there missing capabilities that would help?
+- Are there unused tools that could be removed?
+
+**Based on Feedback**
+- What are users complaining about?
+- What's working well that should be preserved?
+- Are there patterns in negative feedback?
+
+## RESPONSE STYLE
+
+- Be direct and helpful
+- Use bullet points for actionable suggestions
+- When suggesting instruction changes, provide example text
+- Always explain WHY a change would help
+  `);
+
+  // Add user context if available
+  if (
+    userMetadata &&
+    (userMetadata.jobType || userMetadata.favoritePlatforms.length > 0)
+  ) {
+    const jobTypeLabel = userMetadata.jobType
+      ? JOB_TYPE_LABELS[userMetadata.jobType]
+      : "Not specified";
+    const platforms =
+      userMetadata.favoritePlatforms.join(", ") || "None specified";
+
+    parts.push(`
+## USER CONTEXT
+
+The user building this agent has the following profile:
+- Job function: ${jobTypeLabel}
+- Preferred platforms: ${platforms}
+
+Consider their role and platform preferences when suggesting tools and improvements.
+    `);
+  }
+
+  return parts.join("\n\n");
+}
+
 export function _getCopilotGlobalAgent(
   auth: Authenticator,
-  copilotMCPServerViews: CopilotMCPServerViews | null
+  {
+    copilotMCPServerViews,
+    copilotUserMetadata,
+  }: {
+    copilotMCPServerViews: CopilotMCPServerViews | null;
+    copilotUserMetadata: CopilotUserMetadata | null;
+  }
 ): AgentConfigurationType {
   const owner = auth.getNonNullableWorkspace();
 
@@ -43,6 +145,7 @@ export function _getCopilotGlobalAgent(
     : dummyModelConfiguration;
 
   const metadata = getGlobalAgentMetadata(GLOBAL_AGENTS_SID.COPILOT);
+  const instructions = buildCopilotInstructions(copilotUserMetadata);
 
   return {
     id: -1,
@@ -52,7 +155,7 @@ export function _getCopilotGlobalAgent(
     versionAuthorId: null,
     name: metadata.sId,
     description: metadata.description,
-    instructions: "", // TODO(copilot 2026-01-21): fill in copilot instructions
+    instructions,
     pictureUrl: metadata.pictureUrl,
     status: "active",
     scope: "global",


### PR DESCRIPTION
## Description

Resolves https://github.com/dust-tt/tasks/issues/6100

Personalize Agent Copilot suggestions based on user profile:
- Move static system instructions from client-side `CopilotPanelContext.tsx` to server-side `copilot.ts` config
- Fetch user `job_type` and `favorite_platforms` metadata
- Inject user context into copilot instructions when available

## Tests

Local.

## Risk

Low.

## Deploy Plan

Front.