### PR TITLE
feat: script to backfill conversation participant lastReadAt

### DIFF
--- a/front/migrations/20260126_backfill_conversation_participant_last_read_at.ts
+++ b/front/migrations/20260126_backfill_conversation_participant_last_read_at.ts
@@ -1,0 +1,103 @@
+import { QueryTypes } from "sequelize";
+
+import { frontSequelize } from "@app/lib/resources/storage";
+import { makeScript } from "@app/scripts/helpers";
+
+const BATCH_SIZE = 1000;
+
+makeScript({}, async ({ execute }, logger) => {
+  // Count total records
+  const [countResult] = await frontSequelize.query<{ count: string }>(
+    `SELECT COUNT(*) as count
+     FROM conversation_participants
+     WHERE unread = false AND "lastReadAt" IS NULL`,
+    { type: QueryTypes.SELECT }
+  );
+
+  const totalCount = parseInt(countResult.count);
+
+  logger.info(
+    { totalCount, execute },
+    execute
+      ? `Found ${totalCount} participants to update`
+      : `Would update ${totalCount} participants (dry run)`
+  );
+
+  if (totalCount === 0) {
+    logger.info("No participants to update");
+    return;
+  }
+
+  let processedCount = 0;
+  let batchNumber = 0;
+  let lastId = 0;
+  let batchIds: number[] = [];
+
+  do {
+    batchNumber++;
+
+    // Select IDs for the next batch
+    const idResults = await frontSequelize.query<{ id: number }>(
+      `SELECT id
+       FROM conversation_participants
+       WHERE id > :lastId
+         AND unread = false
+         AND "lastReadAt" IS NULL
+       ORDER BY id ASC
+       LIMIT :batchSize`,
+      {
+        replacements: { lastId, batchSize: BATCH_SIZE },
+        type: QueryTypes.SELECT,
+      }
+    );
+
+    batchIds = idResults.map((row) => row.id);
+
+    if (batchIds.length === 0) {
+      break;
+    }
+
+    logger.info(
+      {
+        batchNumber,
+        batchSize: batchIds.length,
+        firstId: batchIds[0],
+        lastId: batchIds[batchIds.length - 1],
+        processedCount,
+        totalCount,
+        progress: `${Math.round((processedCount / totalCount) * 100)}%`,
+      },
+      execute
+        ? `Processing batch ${batchNumber}`
+        : `Would process batch ${batchNumber} (dry run)`
+    );
+
+    if (execute) {
+      // Update the batch
+      await frontSequelize.query(
+        `UPDATE conversation_participants
+         SET "lastReadAt" = NOW()
+         WHERE id IN (:ids)`,
+        {
+          replacements: { ids: batchIds },
+          type: QueryTypes.UPDATE,
+        }
+      );
+
+      logger.info(
+        { batchNumber, updated: batchIds.length },
+        `Updated batch ${batchNumber}`
+      );
+    }
+
+    processedCount += batchIds.length;
+    lastId = batchIds[batchIds.length - 1];
+  } while (batchIds.length === BATCH_SIZE);
+
+  logger.info(
+    { totalProcessed: processedCount, totalCount, execute },
+    execute
+      ? `Migration completed: updated ${processedCount} participants`
+      : `Dry run completed: would have updated ${totalCount} participants`
+  );
+});


### PR DESCRIPTION
## Description
This PR creates a script to backfill the lastReadAt for conversation participants.

The lastReadAt should be
- set to the current date for the participants with unread = false
- left null for the participants with unread = true.
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Manually.
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
