### PR TITLE
[front] Add debug logging for agent loop LLM stream timeout investigation

### DIFF
--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -213,6 +213,15 @@ export abstract class LLM {
     ];
     statsDClient.increment("llm_interaction.count", 1, metricTags);
 
+    logger.info(
+      {
+        modelId: this.modelId,
+        traceId: this.traceId,
+        conversationId: this.context.conversationId,
+      },
+      "[AGENT_LOOP_DEBUG] LLM streamWithTracing starting completeStream iteration"
+    );
+
     let currentEvent: LLMEvent | null = null;
     let timeToFirstEventMs: number | undefined = undefined;
 

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -471,6 +471,16 @@ export async function runModelActivity(
   // listing, conversation rendering, etc.).
   heartbeat();
 
+  localLogger.info(
+    {
+      modelId: model.modelId,
+      messageCount:
+        modelConversationRes.value.modelConversation.messages.length,
+      toolCount: specifications.length,
+    },
+    "[AGENT_LOOP_DEBUG] Starting LLM stream"
+  );
+
   const getOutputFromActionResponse = await getOutputFromLLMStream(auth, {
     modelConversationRes,
     conversation,


### PR DESCRIPTION
## Description
Add diagnostic logs with `[AGENT_LOOP_DEBUG]` prefix across the LLM streaming pipeline to trace where 10-minute timeouts occur in `runModelAndCreateActionsActivity`. All logs include `conversationId` and `traceId` for correlation.

## Risks
Blast radius: Agent loop logging only
Risk: none

## Deploy Plan
- deploy front