### PR TITLE
Render SVG as text content

### DIFF
--- a/front/lib/api/assistant/jit_utils.ts
+++ b/front/lib/api/assistant/jit_utils.ts
@@ -15,7 +15,7 @@ import {
   isAgentMessageType,
   isContentFragmentType,
   isInteractiveContentFileContentType,
-  isSupportedImageContentType,
+  isLLMVisionSupportedImageContentType,
 } from "@app/types";
 
 export function listAttachments(
@@ -25,8 +25,8 @@ export function listAttachments(
   for (const versions of conversation.content) {
     const m = versions[versions.length - 1];
     if (isContentFragmentType(m)) {
-      // We don't list images.
-      if (isSupportedImageContentType(m.contentType)) {
+      // Skip images handled by vision APIs; SVG is text-based so we list it.
+      if (isLLMVisionSupportedImageContentType(m.contentType)) {
         continue;
       }
 

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -49,7 +49,7 @@ import {
   assertNever,
   CoreAPI,
   Err,
-  isSupportedImageContentType,
+  isLLMVisionSupportedImageContentType,
   normalizeError,
   Ok,
   removeNulls,
@@ -570,7 +570,7 @@ export async function getContentFragmentFromAttachmentFile(
           conversationAttachmentId(attachment)
         );
 
-  if (isSupportedImageContentType(attachment.contentType)) {
+  if (isLLMVisionSupportedImageContentType(attachment.contentType)) {
     if (excludeImages || !model.supportsVision) {
       return new Ok({
         role: "content_fragment",
@@ -763,7 +763,7 @@ export async function renderLightContentFragmentForModel(
     };
   }
 
-  if (fileStringId && isSupportedImageContentType(contentType)) {
+  if (fileStringId && isLLMVisionSupportedImageContentType(contentType)) {
     if (excludeImages || !model.supportsVision) {
       return {
         role: "content_fragment",

--- a/front/types/files.ts
+++ b/front/types/files.ts
@@ -477,6 +477,18 @@ export function isSupportedImageContentType(
   return false;
 }
 
+/**
+ * Returns true for images that can be sent to LLM vision APIs.
+ * SVG is categorized as "image" for UI display but is vector-based and not supported by vision APIs.
+ */
+export function isLLMVisionSupportedImageContentType(
+  contentType: string
+): contentType is SupportedImageContentType {
+  return (
+    isSupportedImageContentType(contentType) && contentType !== "image/svg+xml"
+  );
+}
+
 export function isSupportedDelimitedTextContentType(
   contentType: string
 ): contentType is SupportedDelimitedTextContentType {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Follow up of https://github.com/dust-tt/dust/pull/20444.

I oversaw that not all LLMs would accept SVG as image (`base64` or `image_url`). 

This PR: 
- renders SVG files as text content for LLMs instead of sending them as `image_url`, since most vision APIs don't support SVG format.
- Expose SVG files to the conversation_cat_file tool so the model can read them as text
- Add centralized `isLLMVisionSupportedImageContentType` helper to distinguish vision-compatible images (JPEG, PNG, etc.) from text-based images (SVG)

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
