### PR TITLE
Remove getServerSideProps for admin/dev-secrets page

### DIFF
--- a/front/components/sparkle/AppAuthContextLayout.tsx
+++ b/front/components/sparkle/AppAuthContextLayout.tsx
@@ -1,0 +1,20 @@
+import type { AuthContextValue } from "@app/lib/auth/AuthContext";
+import { AuthContext } from "@app/lib/auth/AuthContext";
+
+import AppRootLayout from "./AppRootLayout";
+
+interface AppAuthContextLayoutProps {
+  children: React.ReactNode;
+  authContext: AuthContextValue;
+}
+
+export function AppAuthContextLayout({
+  children,
+  authContext,
+}: AppAuthContextLayoutProps) {
+  return (
+    <AuthContext.Provider value={authContext}>
+      <AppRootLayout>{children}</AppRootLayout>
+    </AuthContext.Provider>
+  );
+}

--- a/front/lib/app/serverSideProps.ts
+++ b/front/lib/app/serverSideProps.ts
@@ -1,0 +1,43 @@
+import type { ReactElement } from "react";
+
+import type { AuthContextValue } from "@app/lib/auth/AuthContext";
+import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
+
+// Type for page components with a getLayout function.
+export type AppPageWithLayout<P = object> = React.FC<P> & {
+  getLayout?: (page: ReactElement, pageProps: AuthContextValue) => ReactElement;
+};
+
+export const appGetServerSideProps =
+  withDefaultUserAuthRequirements<AuthContextValue>(async (_context, auth) => {
+    return {
+      props: {
+        workspace: auth.getNonNullableWorkspace(),
+        subscription: auth.getNonNullableSubscription(),
+        user: auth.user()?.toJSON() ?? null,
+        isAdmin: auth.isAdmin(),
+        isBuilder: auth.isBuilder(),
+        isSuperUser: false,
+      },
+    };
+  });
+
+export const appGetServerSidePropsForBuilders =
+  withDefaultUserAuthRequirements<AuthContextValue>(async (_context, auth) => {
+    if (!auth.isBuilder()) {
+      return {
+        notFound: true,
+      };
+    }
+
+    return {
+      props: {
+        workspace: auth.getNonNullableWorkspace(),
+        subscription: auth.getNonNullableSubscription(),
+        user: auth.user()?.toJSON() ?? null,
+        isAdmin: auth.isAdmin(),
+        isBuilder: auth.isBuilder(),
+        isSuperUser: false,
+      },
+    };
+  });

--- a/front/lib/swr/apps.ts
+++ b/front/lib/swr/apps.ts
@@ -90,16 +90,16 @@ export function useRunBlock(
   };
 }
 
-export function useDustAppSecrets(owner: LightWorkspaceType) {
+export function useDustAppSecrets(owner: LightWorkspaceType | null) {
   const keysFetcher: Fetcher<GetDustAppSecretsResponseBody> = fetcher;
   const { data, error } = useSWRWithDefaults(
-    `/api/w/${owner.sId}/dust_app_secrets`,
+    owner ? `/api/w/${owner.sId}/dust_app_secrets` : null,
     keysFetcher
   );
 
   return {
     secrets: data?.secrets ?? emptyArray(),
-    isSecretsLoading: !error && !data,
+    isSecretsLoading: !error && !data && !!owner,
     isSecretsError: error,
   };
 }

--- a/front/lib/swr/workspaces.ts
+++ b/front/lib/swr/workspaces.ts
@@ -7,6 +7,7 @@ import type {
 } from "@app/lib/api/analytics/programmatic_cost";
 import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetWorkspaceResponseBody } from "@app/pages/api/w/[wId]";
+import type { GetWorkspaceAuthContextResponseType } from "@app/pages/api/w/[wId]/auth-context";
 import type { GetWorkspaceFeatureFlagsResponseType } from "@app/pages/api/w/[wId]/feature-flags";
 import type { GetSeatAvailabilityResponseBody } from "@app/pages/api/w/[wId]/seats/availability";
 import type { GetWorkspaceSeatsCountResponseBody } from "@app/pages/api/w/[wId]/seats/count";
@@ -316,5 +317,32 @@ export function useWorkspaceSeatsCount({
     isSeatsCountLoading: !error && !data && !disabled,
     isSeatsCountError: error,
     mutateSeatsCount: mutate,
+  };
+}
+
+export function useWorkspaceAuthContext({
+  workspaceId,
+  disabled,
+}: {
+  workspaceId: string;
+  disabled?: boolean;
+}) {
+  const authContextFetcher: Fetcher<GetWorkspaceAuthContextResponseType> =
+    fetcher;
+
+  const { data, error } = useSWRWithDefaults(
+    `/api/w/${workspaceId}/auth-context`,
+    authContextFetcher,
+    { disabled }
+  );
+
+  return {
+    owner: data?.workspace ?? null,
+    subscription: data?.subscription ?? null,
+    user: data?.user ?? null,
+    isAdmin: data?.isAdmin ?? false,
+    isBuilder: data?.isBuilder ?? false,
+    isAuthContextLoading: !error && !data && !disabled,
+    isAuthContextError: error,
   };
 }

--- a/front/pages/api/w/[wId]/auth-context.ts
+++ b/front/pages/api/w/[wId]/auth-context.ts
@@ -1,0 +1,53 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
+import { apiError } from "@app/logger/withlogging";
+import type {
+  LightWorkspaceType,
+  SubscriptionType,
+  UserType,
+  WithAPIErrorResponse,
+} from "@app/types";
+
+export type GetWorkspaceAuthContextResponseType = {
+  user: UserType;
+  workspace: LightWorkspaceType;
+  subscription: SubscriptionType;
+  isAdmin: boolean;
+  isBuilder: boolean;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<GetWorkspaceAuthContextResponseType>
+  >,
+  auth: Authenticator,
+  _session: SessionWithUser
+): Promise<void> {
+  if (req.method !== "GET") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "The method passed is not supported, GET is expected.",
+      },
+    });
+  }
+
+  const user = auth.getNonNullableUser();
+  const workspace = auth.getNonNullableWorkspace();
+  const subscription = auth.getNonNullableSubscription();
+
+  return res.status(200).json({
+    user: user.toJSON(),
+    workspace,
+    subscription,
+    isAdmin: auth.isAdmin(),
+    isBuilder: auth.isBuilder(),
+  });
+}
+
+export default withSessionAuthenticationForWorkspace(handler);


### PR DESCRIPTION
## Description

Migrates the dev-secrets page to use a thin `getServerSideProps` pattern (like poke pages), passing auth context via React Context instead of as component
props.

This is the first step toward SPA compatibility for user-facing pages, following the pattern established in poke pages.

### Changes

**New files:**

- `lib/app/serverSideProps.ts` - App-specific SSR helpers:
  - `appGetServerSideProps` - returns auth context for workspace members
  - `appGetServerSidePropsForBuilders` - same, but returns 404 if not builder
  - `AppPageWithLayout` type for pages with `getLayout`

- `components/sparkle/AppAuthContextLayout.tsx` - Layout wrapper that provides `AuthContext.Provider`

- `pages/api/w/[wId]/auth-context.ts` - API endpoint for auth context (for future client-side fetching)

**Modified files:**

- `pages/w/[wId]/developers/dev-secrets.tsx` - Migrated to new pattern:
  - Uses `appGetServerSidePropsForBuilders`
  - Uses `useWorkspace()` and `useAuth()` from AuthContext
  - Uses `getLayout` with `AppAuthContextLayout`

- `lib/swr/workspaces.ts` - Added `useWorkspaceAuthContext` hook (for future use)

- `lib/swr/apps.ts` - `useDustAppSecrets` now accepts `null`

### Pattern

```typescript
export const getServerSideProps = appGetServerSidePropsForBuilders;

function MyPage() {
  const owner = useWorkspace();
  const { subscription, isAdmin } = useAuth();
  // ...
}

const PageWithAuthLayout = MyPage as AppPageWithLayout;
PageWithAuthLayout.getLayout = (page, pageProps) => (
  <AppAuthContextLayout authContext={pageProps}>{page}</AppAuthContextLayout>
);
export default PageWithAuthLayout;
```

### Test plan

- Verify page loads correctly for builder users
- Verify 404 is shown for non-builder users
- Verify secrets CRUD operations work (create, update, delete)

### Deploy 

Deploy front