### PR TITLE
[front] update export ui for frames

### DIFF
--- a/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
+++ b/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
@@ -157,7 +157,7 @@ function ExportContentDropdown({
           isSelect
           label={isExportingPdf ? "Exporting..." : "Export"}
           variant="ghost"
-          tooltip={isExportingPdf ? "Exporting..." : "Export"}
+          disabled={isExportingPdf}
         />
       </DropdownMenuTrigger>
       <DropdownMenuContent>

--- a/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
+++ b/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
@@ -172,12 +172,8 @@ function ExportContentDropdown({
             </DropdownMenuItem>
           </DropdownMenuSubContent>
         </DropdownMenuSub>
-        <DropdownMenuItem onClick={exportAsPng}>
-          PNG
-        </DropdownMenuItem>
-        <DropdownMenuItem onClick={downloadAsCode}>
-          Template
-        </DropdownMenuItem>
+        <DropdownMenuItem onClick={exportAsPng}>PNG</DropdownMenuItem>
+        <DropdownMenuItem onClick={downloadAsCode}>Template</DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
+++ b/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
@@ -157,7 +157,6 @@ function ExportContentDropdown({
           isSelect
           label={isExportingPdf ? "Exporting..." : "Export"}
           variant="ghost"
-          isLoading={isExportingPdf}
           tooltip={isExportingPdf ? "Exporting..." : "Export"}
         />
       </DropdownMenuTrigger>

--- a/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
+++ b/front/components/assistant/conversation/interactive_content/FrameRenderer.tsx
@@ -9,7 +9,6 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuSeparator,
   DropdownMenuSub,
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
@@ -156,19 +155,15 @@ function ExportContentDropdown({
         <Button
           icon={ArrowDownOnSquareIcon}
           isSelect
-          label={isExportingPdf ? "Exporting..." : "Download"}
+          label={isExportingPdf ? "Exporting..." : "Export"}
           variant="ghost"
-          disabled={isExportingPdf}
+          isLoading={isExportingPdf}
+          tooltip={isExportingPdf ? "Exporting..." : "Export"}
         />
       </DropdownMenuTrigger>
       <DropdownMenuContent>
-        <DropdownMenuItem onClick={exportAsPng}>
-          Download as PNG
-        </DropdownMenuItem>
         <DropdownMenuSub>
-          <DropdownMenuSubTrigger disabled={isExportingPdf}>
-            Download as PDF
-          </DropdownMenuSubTrigger>
+          <DropdownMenuSubTrigger disabled={isExportingPdf} label="PDF" />
           <DropdownMenuSubContent>
             <DropdownMenuItem onClick={() => exportAsPdf("portrait")}>
               Portrait
@@ -178,9 +173,11 @@ function ExportContentDropdown({
             </DropdownMenuItem>
           </DropdownMenuSubContent>
         </DropdownMenuSub>
-        <DropdownMenuSeparator />
+        <DropdownMenuItem onClick={exportAsPng}>
+          PNG
+        </DropdownMenuItem>
         <DropdownMenuItem onClick={downloadAsCode}>
-          Download as template
+          Template
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>


### PR DESCRIPTION
## Description
This PR is to update the export UI for frames 
<img width="558" height="360" alt="CleanShot 2026-01-26 at 15 48 18@2x" src="https://github.com/user-attachments/assets/1f9a213f-7920-46b2-953d-721c157be446" />


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
