### PR TITLE
Add more supported fields to Jira MCP search

### DIFF
--- a/front/lib/actions/mcp_internal_actions/servers/jira/types.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/jira/types.ts
@@ -13,6 +13,7 @@ export type SortDirection = (typeof SORT_DIRECTIONS)[number];
 export const FIELD_MAPPINGS = {
   assignee: { jqlField: "assignee" },
   created: { jqlField: "created", supportsOperators: true },
+  creator: { jqlField: "creator" },
   dueDate: { jqlField: "dueDate", supportsOperators: true },
   fixVersion: { jqlField: "fixVersion" },
   issueType: { jqlField: "issueType" },
@@ -24,6 +25,9 @@ export const FIELD_MAPPINGS = {
   resolved: { jqlField: "resolved", supportsOperators: true },
   status: { jqlField: "status" },
   summary: { jqlField: "summary", supportsFuzzy: true },
+  updated: { jqlField: "updated", supportsOperators: true },
+  votes: { jqlField: "votes", supportsOperators: true },
+  watchers: { jqlField: "watchers", supportsOperators: true },
   customField: {
     jqlField: "customField",
     isCustomField: true,


### PR DESCRIPTION
## Description
The Jira MCP supports more fields than we have listed in the MCP FIELD_MAPPING
As a result, when an agent tries to respond to something like "search for all jira issues updated in the last 24 hours" it will construct a search query, see that "updated" isn't supported which causes the tool to fail and log in data dog, and then switch to using the jql tool which succeeds. This error is currently not impacting user results but does add time, an extra tool to the process, and pollute our logging 

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Currently, we see:
<img width="949" height="774" alt="Screenshot 2026-01-26 at 9 56 49 AM" src="https://github.com/user-attachments/assets/d423d241-a5dd-4bc3-b5f0-102537b1de27" />

With this change, the first tool succeeds:
<img width="1091" height="774" alt="Screenshot 2026-01-26 at 11 33 30 AM" src="https://github.com/user-attachments/assets/4df4d2bd-f3c8-447c-89d0-458c46f3c284" />


<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low, these are supported fields and error is already recovering gracefully 
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [ ] Deploy front


<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
