### PR TITLE
[front] refactor: Replace phone_trial_paywall flag with code constant

### DIFF
--- a/front/lib/plans/trial/index.ts
+++ b/front/lib/plans/trial/index.ts
@@ -1,5 +1,4 @@
 import type { Authenticator } from "@app/lib/auth";
-import { getFeatureFlags } from "@app/lib/auth";
 import {
   FREE_TRIAL_PHONE_PLAN_CODE,
   isOldFreePlan,
@@ -9,24 +8,29 @@ import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 const TRIAL_DURATION_DAYS = 15;
 
 /**
+ * When enabled, new workspaces without a subscription are directed to a phone
+ * verification trial flow instead of the credit card paywall.
+ * Set to `true` to enable phone trial for all new users.
+ */
+const PHONE_TRIAL_ENABLED = false;
+
+/**
  * Checks if a workspace is eligible for the trial page.
  * A workspace is eligible if:
- * - It has the "phone_trial_paywall" feature flag enabled.
- * - It has never had another subscription before.
+ * - Phone trial is enabled via PHONE_TRIAL_ENABLED constant.
+ * - The user is an admin.
+ * - The workspace has never had another subscription before.
  */
 export async function isWorkspaceEligibleForTrial(
   auth: Authenticator
 ): Promise<boolean> {
-  const owner = auth.getNonNullableWorkspace();
+  if (!PHONE_TRIAL_ENABLED) {
+    return false;
+  }
 
   // If you're not admin it means the workspace had a subscription before.
   // so no need to check further.
   if (!auth.isAdmin()) {
-    return false;
-  }
-
-  const featureFlags = await getFeatureFlags(owner);
-  if (!featureFlags.includes("phone_trial_paywall")) {
     return false;
   }
 

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -230,10 +230,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Databricks MCP tool",
     stage: "on_demand",
   },
-  phone_trial_paywall: {
-    description: "Phone verification during trial sign-up",
-    stage: "dust_only",
-  },
   ukg_ready_mcp: {
     description: "UKG Ready MCP tool for workforce management",
     stage: "dust_only",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -680,7 +680,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "openai_o1_feature"
   | "openai_o1_high_reasoning_feature"
   | "openai_usage_mcp"
-  | "phone_trial_paywall"
   | "restrict_agents_publishing"
   | "salesforce_synced_queries"
   | "salesforce_tool_write"


### PR DESCRIPTION
## Description

Replace the `phone_trial_paywall` feature flag with a code constant (`PHONE_TRIAL_ENABLED`) in `front/lib/plans/trial/index.ts`.

This prepares for enabling phone trial for all new users by making it a deploy-time toggle rather than a per-workspace feature flag. The constant approach is simpler and allows instant rollout/rollback without database changes.

Changes:
- Remove `phone_trial_paywall` from feature flags config
- Add `PHONE_TRIAL_ENABLED = false` constant to control phone trial eligibility
- Clean up unused `getFeatureFlags` import

Currently disabled (set to `false`) - will be enabled in a follow-up PR.

## Tests

- Type check passes
- Lint passes  
- No functional change since constant is set to `false` (same behavior as before for workspaces without the flag)

## Risk

Low risk - this is a no-op change since the constant is disabled. The phone trial flow remains inaccessible, matching current production behavior for workspaces without the feature flag.

## Deploy Plan

Standard deployment. No migrations required. Safe to rollback.