### PR TITLE
[sparkle] - fix(Scrollarea): height

### DIFF
--- a/sparkle/src/components/ScrollArea.tsx
+++ b/sparkle/src/components/ScrollArea.tsx
@@ -76,7 +76,7 @@ const ScrollArea = React.forwardRef<
           ref={viewportRef || localViewportRef}
           onScroll={handleScroll}
           className={cn(
-            "s-h-full s-w-full s-rounded-[inherit]",
+            "s-scrollarea-viewport s-h-full s-w-full s-rounded-[inherit]",
             viewportClassName
           )}
         >

--- a/sparkle/src/styles/tailwind.css
+++ b/sparkle/src/styles/tailwind.css
@@ -12,3 +12,9 @@
     @apply s-bg-purple-100;
   }
 }
+
+@layer utilities {
+  .s-scrollarea-viewport > div {
+    height: 100%;
+  }
+}


### PR DESCRIPTION
## Description

This PR applies custom viewport class `s-scrollarea-viewport` to make sure that a `DialogContainer` takes 100% of the available height. 

This was initially identified here:
<img width="2556" height="1324" alt="Screenshot 2026-01-26 at 16 23 48" src="https://github.com/user-attachments/assets/cb98d9a8-7f5e-4417-b845-476970bf59cd" />

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front