### PR TITLE
Add get_available_knowledge method

### DIFF
--- a/front/lib/api/actions/servers/agent_copilot_context/metadata.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/metadata.ts
@@ -13,6 +13,9 @@ import {
 
 export const AGENT_COPILOT_CONTEXT_TOOL_NAME = "agent_copilot_context" as const;
 
+// Knowledge categories relevant for agent builder (excluding apps, actions, triggers)
+const KNOWLEDGE_CATEGORIES = ["managed", "folder", "website"] as const;
+
 // Suggestion tool schemas
 
 const InstructionsSuggestionSchema = z.object({
@@ -65,6 +68,27 @@ const ModelSuggestionSchema = z.object({
 });
 
 export const AGENT_COPILOT_CONTEXT_TOOLS_METADATA = createToolsRecord({
+  get_available_knowledge: {
+    description:
+      "Get the list of available knowledge sources that can be added to an agent. " +
+      "Returns a hierarchical structure organized by spaces, with connected data sources, folders, and websites listed under each space. " +
+      "Only includes sources accessible to the current user.",
+    schema: {
+      spaceId: z
+        .string()
+        .optional()
+        .describe(
+          "Optional space ID to filter results to a specific space. If not provided, returns knowledge from all accessible spaces."
+        ),
+      category: z
+        .enum(KNOWLEDGE_CATEGORIES)
+        .optional()
+        .describe(
+          "Optional category to filter results. Options: 'managed' (connected data sources like Notion, Slack), 'folder' (custom folders), 'website' (crawled websites). If not provided, returns all categories."
+        ),
+    },
+    stake: "never_ask",
+  },
   get_available_models: {
     description:
       "Get the list of available models. Can optionally filter by provider.",

--- a/front/lib/api/actions/servers/agent_copilot_context/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/tools/index.ts
@@ -36,21 +36,18 @@ const KNOWLEDGE_CATEGORIES: DataSourceViewCategory[] = [
   "website",
 ];
 
-// Type for a data source item in the knowledge hierarchy
 interface KnowledgeDataSource {
   sId: string;
   name: string;
   connectorProvider: string | null;
 }
 
-// Type for a knowledge category in the hierarchy
 interface KnowledgeCategoryData {
   category: DataSourceViewCategory;
   displayName: string;
   dataSources: KnowledgeDataSource[];
 }
 
-// Type for a space in the knowledge hierarchy
 interface KnowledgeSpace {
   sId: string;
   name: string;

--- a/front/lib/api/actions/servers/agent_copilot_context/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/tools/index.ts
@@ -13,10 +13,14 @@ import { getAgentFeedbacks } from "@app/lib/api/assistant/feedback";
 import { fetchAgentOverview } from "@app/lib/api/assistant/observability/overview";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
+import { getDisplayNameForDataSource } from "@app/lib/data_sources";
 import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
+import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import type { DataSourceViewCategory, SpaceType } from "@app/types";
 import {
   Err,
   isModelProviderId,
@@ -25,7 +29,142 @@ import {
   SUPPORTED_MODEL_CONFIGS,
 } from "@app/types";
 
+// Knowledge categories relevant for agent builder (excluding apps, actions, triggers)
+const KNOWLEDGE_CATEGORIES: DataSourceViewCategory[] = [
+  "managed",
+  "folder",
+  "website",
+];
+
+// Type for a data source item in the knowledge hierarchy
+interface KnowledgeDataSource {
+  sId: string;
+  name: string;
+  connectorProvider: string | null;
+}
+
+// Type for a knowledge category in the hierarchy
+interface KnowledgeCategoryData {
+  category: DataSourceViewCategory;
+  displayName: string;
+  dataSources: KnowledgeDataSource[];
+}
+
+// Type for a space in the knowledge hierarchy
+interface KnowledgeSpace {
+  sId: string;
+  name: string;
+  kind: SpaceType["kind"];
+  categories: KnowledgeCategoryData[];
+}
+
 const handlers: ToolHandlers<typeof AGENT_COPILOT_CONTEXT_TOOLS_METADATA> = {
+  get_available_knowledge: async ({ spaceId, category }, extra) => {
+    const auth = extra.auth;
+    if (!auth) {
+      return new Err(new MCPError("Authentication required"));
+    }
+
+    // Get all spaces the user is a member of.
+    let spaces = await SpaceResource.listWorkspaceSpacesAsMember(auth);
+
+    // Filter to specific space if provided.
+    if (spaceId) {
+      spaces = spaces.filter((s) => s.sId === spaceId);
+      if (spaces.length === 0) {
+        return new Err(
+          new MCPError(`Space not found or not accessible: ${spaceId}`, {
+            tracked: false,
+          })
+        );
+      }
+    }
+
+    // Determine which categories to fetch.
+    const categoriesToFetch: DataSourceViewCategory[] = category
+      ? [category]
+      : KNOWLEDGE_CATEGORIES;
+
+    // Fetch data source views for all spaces in parallel.
+    const spaceResults = await concurrentExecutor(
+      spaces,
+      async (space) => {
+        // Fetch data source views for this space.
+        const dataSourceViews = await DataSourceViewResource.listBySpace(
+          auth,
+          space
+        );
+
+        // Filter and group by category.
+        const categoriesData: KnowledgeCategoryData[] = [];
+
+        for (const cat of categoriesToFetch) {
+          const viewsForCategory = dataSourceViews
+            .filter((dsv) => dsv.toJSON().category === cat)
+            .map((dsv) => {
+              const json = dsv.toJSON();
+              return {
+                sId: json.sId,
+                name: getDisplayNameForDataSource(json.dataSource),
+                connectorProvider: json.dataSource.connectorProvider,
+              };
+            });
+
+          if (viewsForCategory.length > 0) {
+            categoriesData.push({
+              category: cat,
+              displayName: getCategoryDisplayName(cat),
+              dataSources: viewsForCategory,
+            });
+          }
+        }
+
+        // Only include spaces that have at least one category with data.
+        if (categoriesData.length === 0) {
+          return null;
+        }
+
+        return {
+          sId: space.sId,
+          name: space.name,
+          kind: space.kind,
+          categories: categoriesData,
+        } as KnowledgeSpace;
+      },
+      { concurrency: 8 }
+    );
+
+    // Filter out null results (spaces with no data sources).
+    const knowledgeSpaces = spaceResults.filter(
+      (result): result is KnowledgeSpace => result !== null
+    );
+
+    // Calculate totals.
+    let totalDataSources = 0;
+    for (const space of knowledgeSpaces) {
+      for (const cat of space.categories) {
+        totalDataSources += cat.dataSources.length;
+      }
+    }
+
+    return new Ok([
+      {
+        type: "text" as const,
+        text: JSON.stringify(
+          {
+            count: {
+              spaces: knowledgeSpaces.length,
+              dataSources: totalDataSources,
+            },
+            spaces: knowledgeSpaces,
+          },
+          null,
+          2
+        ),
+      },
+    ]);
+  },
+
   get_available_models: async ({ providerId }, extra) => {
     const auth = extra.auth;
     if (!auth) {
@@ -650,5 +789,18 @@ const handlers: ToolHandlers<typeof AGENT_COPILOT_CONTEXT_TOOLS_METADATA> = {
     ]);
   },
 };
+
+function getCategoryDisplayName(category: DataSourceViewCategory): string {
+  switch (category) {
+    case "managed":
+      return "Connected data";
+    case "folder":
+      return "Folders";
+    case "website":
+      return "Websites";
+    default:
+      return category;
+  }
+}
 
 export const TOOLS = buildTools(AGENT_COPILOT_CONTEXT_TOOLS_METADATA, handlers);

--- a/front/lib/api/actions/servers/agent_copilot_context/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/tools/index.ts
@@ -21,6 +21,7 @@ import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { DataSourceViewCategory, SpaceType } from "@app/types";
+import { removeNulls } from "@app/types";
 import {
   Err,
   isModelProviderId,
@@ -126,15 +127,13 @@ const handlers: ToolHandlers<typeof AGENT_COPILOT_CONTEXT_TOOLS_METADATA> = {
           name: space.name,
           kind: space.kind,
           categories: categoriesData,
-        } as KnowledgeSpace;
+        } satisfies KnowledgeSpace;
       },
       { concurrency: 8 }
     );
 
     // Filter out null results (spaces with no data sources).
-    const knowledgeSpaces = spaceResults.filter(
-      (result): result is KnowledgeSpace => result !== null
-    );
+    const knowledgeSpaces = removeNulls(spaceResults);
 
     // Calculate totals.
     let totalDataSources = 0;


### PR DESCRIPTION
## Description

Add a get_available_knowledge method to the agent_copilot_context MCP toolset. Details:
- It returns available knowledge in a way that matches what is available in Agent Builder, and only include things that the user has access to.
- Return the knowledge in a hierarchical way, but without going deep as this would result in far too much data.
- The top level is the list of spaces
  - Under each space, there is potentially Connected data, Folders and Websites
  - For connected data, only include the list of data sources (e.g. Notion, Slack, …), but don’t drill any deeper
  - For Folders, include the list of folders, but don’t go deeper
  - For Websites, include the list of websites

Fixes https://github.com/dust-tt/tasks/issues/6106

## Tests

Updated unit tests

## Risk

Low, new code path under flag

## Deploy Plan

Front