### PR TITLE
[front] feat: Enable phone trial for all new users

### DIFF
--- a/front/lib/plans/trial/index.ts
+++ b/front/lib/plans/trial/index.ts
@@ -12,7 +12,7 @@ const TRIAL_DURATION_DAYS = 15;
  * verification trial flow instead of the credit card paywall.
  * Set to `true` to enable phone trial for all new users.
  */
-export const PHONE_TRIAL_ENABLED = false;
+export const PHONE_TRIAL_ENABLED = true;
 
 /**
  * Checks if a workspace is eligible for the trial page.


### PR DESCRIPTION
## Description

Enable the phone verification trial flow for all new workspaces by flipping `PHONE_TRIAL_ENABLED` from `false` to `true`.

After this change, new users creating a workspace will be directed to verify their phone number for a 15-day free trial instead of going directly to the credit card paywall.

Trial limits:
- 15 days duration
- 100 messages max
- 3 users max
- 5 vaults max

**Rollback behavior:** Setting `PHONE_TRIAL_ENABLED = false` restores the previous behavior:
- New users → credit card paywall with Stripe trial
- Users who already did phone trial → credit card paywall with NO Stripe trial (existing Stripe logic correctly handles this since they have a `FREE_TRIAL_PHONE_PLAN` subscription)

## Tests

- Type check passes
- Existing phone verification flow was already tested internally with `phone_trial_paywall` feature flag

## Risk

Medium risk - this changes the default onboarding experience for all new users.

Mitigations:
- Phone verification flow has been tested internally with feature flag
- Single line change, trivially revertible
- Twilio and Persona integrations are already production-ready

## Deploy Plan

1. Deploy during business hours for monitoring
2. Monitor for:
   - Twilio SMS delivery issues
   - Persona phone validation errors
   - User drop-off rates on `/verify` page
3. Rollback plan: Set `PHONE_TRIAL_ENABLED = false` and redeploy