### PR TITLE
[front] refactor: Make Stripe trial conditional on phone trial toggle

### DIFF
--- a/front/lib/plans/trial/index.ts
+++ b/front/lib/plans/trial/index.ts
@@ -12,7 +12,7 @@ const TRIAL_DURATION_DAYS = 15;
  * verification trial flow instead of the credit card paywall.
  * Set to `true` to enable phone trial for all new users.
  */
-const PHONE_TRIAL_ENABLED = false;
+export const PHONE_TRIAL_ENABLED = false;
 
 /**
  * Checks if a workspace is eligible for the trial page.


### PR DESCRIPTION
## Description

Make the Stripe trial logic conditional on the `PHONE_TRIAL_ENABLED` constant:

- **When phone trial is enabled:** Skip Stripe trial entirely (users get their trial through phone verification)
- **When phone trial is disabled:** Preserve existing behavior - offer Stripe trial to workspaces that never had a subscription (except grandfathered old free plan users)

Changes:
- Export `PHONE_TRIAL_ENABLED` from `front/lib/plans/trial/index.ts`
- Import it in `stripe.ts` and wrap the Stripe trial logic in a conditional

This ensures that when phone trial is enabled, users don't get double trials (phone + Stripe).

## Tests

- Type check passes
- No functional change when `PHONE_TRIAL_ENABLED = false` (current state)

## Risk

Low risk - this is a no-op while `PHONE_TRIAL_ENABLED = false`. The conditional logic only takes effect once phone trial is enabled.

## Deploy Plan

Standard deployment. Should be merged before or after the phone trial enable PR (#20590) - order doesn't matter since this is a no-op until phone trial is enabled.