### PR TITLE
Poke fix ff search

### DIFF
--- a/front/components/poke/plugins/EnumSelect.tsx
+++ b/front/components/poke/plugins/EnumSelect.tsx
@@ -46,7 +46,7 @@ export function EnumSelect({
   }
 
   return (
-    <PopoverRoot modal={true} open={open} onOpenChange={setOpen}>
+    <PopoverRoot modal={false} open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
         <PokeFormControl>
           <PokeButton
@@ -67,6 +67,9 @@ export function EnumSelect({
       <PopoverContent
         className="z-[100] w-[var(--radix-popover-trigger-width)]"
         mountPortal={false}
+        onKeyDown={(e) => {
+          e.stopPropagation();
+        }}
         onWheelCapture={(e) => {
           e.stopPropagation();
         }}
@@ -75,7 +78,11 @@ export function EnumSelect({
         }}
       >
         <PokeCommand className="gap-2 py-3">
-          <PokeCommandInput placeholder={label} className="h-9 p-2" />
+          <PokeCommandInput
+            placeholder={label}
+            className="h-9 p-2"
+            onKeyDown={(e) => e.stopPropagation()}
+          />
           <PokeCommandList>
             <PokeCommandEmpty>No values found.</PokeCommandEmpty>
             <PokeCommandGroup>

--- a/front/components/poke/plugins/EnumSelect.tsx
+++ b/front/components/poke/plugins/EnumSelect.tsx
@@ -38,6 +38,7 @@ export function EnumSelect({
   multiple,
 }: EnumSelectProps) {
   const [open, setOpen] = React.useState(false);
+  const inputRef = React.useRef<HTMLInputElement>(null);
 
   let title = values?.length ? values.sort().join(", ") : placeholder;
 
@@ -65,7 +66,13 @@ export function EnumSelect({
         </PokeFormControl>
       </PopoverTrigger>
       <PopoverContent
-        className="w-[var(--radix-dropdown-menu-trigger-width)]"
+        className="w-[var(--radix-popover-trigger-width)] z-[100]"
+        mountPortal={false}
+        // Focus the search input when the popover opens
+        onOpenAutoFocus={(e) => {
+          e.preventDefault();
+          inputRef.current?.focus();
+        }}
         // Ensure wheel events don't bubble to parent overlays
         onWheelCapture={(e) => {
           e.stopPropagation();
@@ -73,9 +80,13 @@ export function EnumSelect({
         onTouchMoveCapture={(e) => {
           e.stopPropagation();
         }}
+        // Stop keyboard events from bubbling to parent dialog
+        onKeyDownCapture={(e) => {
+          e.stopPropagation();
+        }}
       >
         <PokeCommand className="gap-2 py-3">
-          <PokeCommandInput placeholder={label} className="h-9 p-2" />
+          <PokeCommandInput ref={inputRef} placeholder={label} className="h-9 p-2" />
           <PokeCommandList>
             <PokeCommandEmpty>No values found.</PokeCommandEmpty>
             <PokeCommandGroup>

--- a/front/components/poke/plugins/EnumSelect.tsx
+++ b/front/components/poke/plugins/EnumSelect.tsx
@@ -38,7 +38,6 @@ export function EnumSelect({
   multiple,
 }: EnumSelectProps) {
   const [open, setOpen] = React.useState(false);
-  const inputRef = React.useRef<HTMLInputElement>(null);
 
   let title = values?.length ? values.sort().join(", ") : placeholder;
 
@@ -66,27 +65,17 @@ export function EnumSelect({
         </PokeFormControl>
       </PopoverTrigger>
       <PopoverContent
-        className="w-[var(--radix-popover-trigger-width)] z-[100]"
+        className="z-[100] w-[var(--radix-popover-trigger-width)]"
         mountPortal={false}
-        // Focus the search input when the popover opens
-        onOpenAutoFocus={(e) => {
-          e.preventDefault();
-          inputRef.current?.focus();
-        }}
-        // Ensure wheel events don't bubble to parent overlays
         onWheelCapture={(e) => {
           e.stopPropagation();
         }}
         onTouchMoveCapture={(e) => {
           e.stopPropagation();
         }}
-        // Stop keyboard events from bubbling to parent dialog
-        onKeyDownCapture={(e) => {
-          e.stopPropagation();
-        }}
       >
         <PokeCommand className="gap-2 py-3">
-          <PokeCommandInput ref={inputRef} placeholder={label} className="h-9 p-2" />
+          <PokeCommandInput placeholder={label} className="h-9 p-2" />
           <PokeCommandList>
             <PokeCommandEmpty>No values found.</PokeCommandEmpty>
             <PokeCommandGroup>

--- a/front/components/poke/plugins/RunPluginDialog.tsx
+++ b/front/components/poke/plugins/RunPluginDialog.tsx
@@ -87,7 +87,7 @@ export function RunPluginDialog({
     <Dialog open={true} onOpenChange={handleClose}>
       <DialogContent
         className={cn(
-          "w-auto",
+          "w-auto overflow-visible",
           "bg-muted-background dark:bg-muted-background-night",
           "sm:min-w-[600px] sm:max-w-[1000px]"
         )}


### PR DESCRIPTION
## Description

Fix search input in the "Toggle Feature Flag" plugin dropdown - users couldn't type in the search field when the plugin was opened from a dialog. The issue was caused by the popover being portaled outside the dialog's DOM tree, which broke keyboard input handling.

Changes:
- EnumSelect.tsx:
  - Add mountPortal={false} to keep the popover in the same DOM tree as the dialog, fixing keyboard input.
  - Fix CSS variable from --radix-dropdown-menu-trigger-width to --radix-popover-trigger-width for correct width matching.
- RunPluginDialog.tsx:
  - Add overflow-visible to DialogContent to prevent the popover dropdown from being clipped.

## Tests

- Open Poké, navigate to a workspace.
- Click "Run Toggle Feature Flag plugin".
- Click the "Select value" dropdown.
- Verify you can type in the search field to filter feature flags.
- Verify the dropdown width matches the trigger button.
- Verify the full dropdown is visible (not clipped).

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 