### PR TITLE
refactor: migrate connectors to Biome formatting

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -6,3 +6,6 @@
 
 # refactor: migrate sdks/js to Biome formatting
 c2c4f314962afc970419361225dacfba51ee00e5
+
+# refactor: migrate cli to Biome formatting
+0a2f4d5f9ed3a950b4d420b0b502a27bfc48bb2b

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,5 @@
+# Git blame ignore file - contains commits that made formatting-only changes
+# Configure git to use this file: git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+# refactor: migrate connectors to Biome formatting
+39796e781c0a993df6c83710b8f7a7d84c06c59c

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -9,3 +9,6 @@ c2c4f314962afc970419361225dacfba51ee00e5
 
 # refactor: migrate cli to Biome formatting
 0a2f4d5f9ed3a950b4d420b0b502a27bfc48bb2b
+
+# refactor: migrate firebase-functions to Biome formatting
+01afe83163048a19400fc0f84559d3a03335c49f

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -3,3 +3,6 @@
 
 # refactor: migrate connectors to Biome formatting
 39796e781c0a993df6c83710b8f7a7d84c06c59c
+
+# refactor: migrate sdks/js to Biome formatting
+c2c4f314962afc970419361225dacfba51ee00e5

--- a/cli/.prettierrc
+++ b/cli/.prettierrc
@@ -1,7 +1,0 @@
-{
-  "singleQuote": false,
-  "trailingComma": "es5",
-  "requirePragma": false,
-  "arrowParens": "always",
-  "semi": true
-}

--- a/cli/biome.json
+++ b/cli/biome.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.3.13/schema.json",
+  "vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
+  "files": { "ignoreUnknown": false },
+  "formatter": {
+    "enabled": true,
+    "formatWithErrors": false,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineEnding": "lf",
+    "lineWidth": 80,
+    "attributePosition": "auto",
+    "bracketSameLine": false,
+    "bracketSpacing": true,
+    "expand": "auto",
+    "useEditorconfig": true
+  },
+  "linter": { "enabled": false },
+  "javascript": {
+    "formatter": {
+      "jsxQuoteStyle": "double",
+      "quoteProperties": "asNeeded",
+      "trailingCommas": "es5",
+      "semicolons": "always",
+      "arrowParentheses": "always",
+      "bracketSameLine": false,
+      "quoteStyle": "double",
+      "attributePosition": "auto",
+      "bracketSpacing": true
+    }
+  },
+  "html": {
+    "formatter": {
+      "indentScriptAndStyle": false,
+      "selfCloseVoidElements": "always"
+    }
+  },
+  "assist": {
+    "enabled": false
+  }
+}

--- a/cli/package.json
+++ b/cli/package.json
@@ -16,8 +16,8 @@
     "build": "NODE_ENV=development tsup",
     "dev": "NODE_ENV=development tsup --watch",
     "lint": "eslint 'src/**/*.{ts,tsx}'",
-    "format": "prettier --write .",
-    "format:check": "prettier --check .",
+    "format": "biome format --write .",
+    "format:check": "biome check --formatter-enabled=true --linter-enabled=false .",
     "start": "node dist/index.js"
   },
   "keywords": [
@@ -57,6 +57,7 @@
     "node": ">=20.17.0"
   },
   "devDependencies": {
+    "@biomejs/biome": "^2.3.13",
     "@types/express": "^5.0.1",
     "@types/lodash": "^4.17.16",
     "@types/mime-types": "^3.0.1",
@@ -75,7 +76,6 @@
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "eslint-plugin-unused-imports": "^4.3.0",
     "globals": "^14.0.0",
-    "prettier": "^3.7.4",
     "ts-node": "^10.9.2",
     "tsup": "^8.4.0",
     "typescript": "^5.9.3",

--- a/connectors/.prettierrc
+++ b/connectors/.prettierrc
@@ -1,7 +1,0 @@
-{
-  "singleQuote": false,
-  "trailingComma": "es5",
-  "requirePragma": false,
-  "arrowParens": "always",
-  "semi": true
-}

--- a/connectors/biome.json
+++ b/connectors/biome.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.3.13/schema.json",
+  "vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
+  "files": { "ignoreUnknown": false },
+  "formatter": {
+    "enabled": true,
+    "formatWithErrors": false,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineEnding": "lf",
+    "lineWidth": 80,
+    "attributePosition": "auto",
+    "bracketSameLine": false,
+    "bracketSpacing": true,
+    "expand": "auto",
+    "useEditorconfig": true,
+    "includes": ["**"]
+  },
+  "linter": { "enabled": false },
+  "javascript": {
+    "formatter": {
+      "jsxQuoteStyle": "double",
+      "quoteProperties": "asNeeded",
+      "trailingCommas": "es5",
+      "semicolons": "always",
+      "arrowParentheses": "always",
+      "bracketSameLine": false,
+      "quoteStyle": "double",
+      "attributePosition": "auto",
+      "bracketSpacing": true
+    }
+  },
+  "html": {
+    "formatter": {
+      "indentScriptAndStyle": false,
+      "selfCloseVoidElements": "always"
+    }
+  },
+  "assist": {
+    "enabled": false
+  }
+}

--- a/connectors/package.json
+++ b/connectors/package.json
@@ -2,8 +2,8 @@
   "name": "connectors",
   "version": "0.1.0",
   "scripts": {
-    "format": "prettier --write .",
-    "format:check": "prettier --check .",
+    "format": "biome format --write .",
+    "format:check": "biome check --formatter-enabled=true --linter-enabled=false .",
     "lint": "eslint .",
     "build": "tsgo --noEmit && tsx esbuild.config.ts",
     "start": "tsx ./src/start.ts -p 3002",
@@ -97,6 +97,7 @@
     "zod-validation-error": "^3.5.4"
   },
   "devDependencies": {
+    "@biomejs/biome": "^2.3.13",
     "@types/eslint": "^8.56.10",
     "@types/gunzip-maybe": "^1.4.2",
     "@types/lodash": "^4.17.7",
@@ -117,7 +118,6 @@
     "eslint-plugin-simple-import-sort": "^12.1.0",
     "eslint-plugin-unused-imports": "^4.3.0",
     "knip": "^5.80.0",
-    "prettier": "^3.7.4",
     "tsconfig-paths-webpack-plugin": "^4.1.0",
     "tsx": "^4.21.0",
     "typescript": "^5.9.3",

--- a/connectors/src/connectors/bigquery/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/bigquery/temporal/cast_known_errors.ts
@@ -7,7 +7,9 @@ import { GaxiosError } from "googleapis-common";
 
 import { ExternalOAuthTokenError } from "@connectors/lib/error";
 
-export class BigQueryCastKnownErrorsInterceptor implements ActivityInboundCallsInterceptor {
+export class BigQueryCastKnownErrorsInterceptor
+  implements ActivityInboundCallsInterceptor
+{
   async execute(
     input: ActivityExecuteInput,
     next: Next<ActivityInboundCallsInterceptor, "execute">

--- a/connectors/src/connectors/confluence/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/confluence/temporal/cast_known_errors.ts
@@ -8,7 +8,9 @@ import type {
 import { ProviderWorkflowError } from "@connectors/lib/error";
 import { ConfluenceClientError } from "@connectors/types";
 
-export class ConfluenceCastKnownErrorsInterceptor implements ActivityInboundCallsInterceptor {
+export class ConfluenceCastKnownErrorsInterceptor
+  implements ActivityInboundCallsInterceptor
+{
   async execute(
     input: ActivityExecuteInput,
     next: Next<ActivityInboundCallsInterceptor, "execute">

--- a/connectors/src/connectors/github/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/github/temporal/cast_known_errors.ts
@@ -21,7 +21,9 @@ const checkRateLimitError = (err: unknown) => {
   }
 };
 
-export class GithubCastKnownErrorsInterceptor implements ActivityInboundCallsInterceptor {
+export class GithubCastKnownErrorsInterceptor
+  implements ActivityInboundCallsInterceptor
+{
   async execute(
     input: ActivityExecuteInput,
     next: Next<ActivityInboundCallsInterceptor, "execute">

--- a/connectors/src/connectors/gong/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/gong/temporal/cast_known_errors.ts
@@ -8,7 +8,9 @@ import type {
 import { GongAPIError } from "@connectors/connectors/gong/lib/errors";
 import { DustConnectorWorkflowError } from "@connectors/lib/error";
 
-export class GongCastKnownErrorsInterceptor implements ActivityInboundCallsInterceptor {
+export class GongCastKnownErrorsInterceptor
+  implements ActivityInboundCallsInterceptor
+{
   async execute(
     input: ActivityExecuteInput,
     next: Next<ActivityInboundCallsInterceptor, "execute">

--- a/connectors/src/connectors/google_drive/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/google_drive/temporal/cast_known_errors.ts
@@ -61,7 +61,9 @@ function isGoogleDriveInsufficientPermissionsError(
   );
 }
 
-export class GoogleDriveCastKnownErrorsInterceptor implements ActivityInboundCallsInterceptor {
+export class GoogleDriveCastKnownErrorsInterceptor
+  implements ActivityInboundCallsInterceptor
+{
   async execute(
     input: ActivityExecuteInput,
     next: Next<ActivityInboundCallsInterceptor, "execute">

--- a/connectors/src/connectors/microsoft/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/microsoft/temporal/cast_known_errors.ts
@@ -50,7 +50,9 @@ export function isGeneralExceptionError(err: unknown): err is GraphError {
   );
 }
 
-export class MicrosoftCastKnownErrorsInterceptor implements ActivityInboundCallsInterceptor {
+export class MicrosoftCastKnownErrorsInterceptor
+  implements ActivityInboundCallsInterceptor
+{
   async execute(
     input: ActivityExecuteInput,
     next: Next<ActivityInboundCallsInterceptor, "execute">

--- a/connectors/src/connectors/notion/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/notion/temporal/cast_known_errors.ts
@@ -15,7 +15,9 @@ import {
   ProviderWorkflowError,
 } from "@connectors/lib/error";
 
-export class NotionCastKnownErrorsInterceptor implements ActivityInboundCallsInterceptor {
+export class NotionCastKnownErrorsInterceptor
+  implements ActivityInboundCallsInterceptor
+{
   // Delay hint for transient upstream 5xx.
   private static readonly TRANSIENT_RETRY_DELAY_MS = 2 * 60 * 60 * 1000;
 

--- a/connectors/src/connectors/salesforce/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/salesforce/temporal/cast_known_errors.ts
@@ -4,7 +4,9 @@ import type {
   Next,
 } from "@temporalio/worker";
 
-export class SalesforceCastKnownErrorsInterceptor implements ActivityInboundCallsInterceptor {
+export class SalesforceCastKnownErrorsInterceptor
+  implements ActivityInboundCallsInterceptor
+{
   async execute(
     input: ActivityExecuteInput,
     next: Next<ActivityInboundCallsInterceptor, "execute">

--- a/connectors/src/connectors/slack/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/slack/temporal/cast_known_errors.ts
@@ -7,7 +7,9 @@ import type {
 
 import { ProviderRateLimitError } from "@connectors/lib/error";
 
-export class SlackCastKnownErrorsInterceptor implements ActivityInboundCallsInterceptor {
+export class SlackCastKnownErrorsInterceptor
+  implements ActivityInboundCallsInterceptor
+{
   async execute(
     input: ActivityExecuteInput,
     next: Next<ActivityInboundCallsInterceptor, "execute">

--- a/connectors/src/connectors/snowflake/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/snowflake/temporal/cast_known_errors.ts
@@ -133,7 +133,9 @@ function isSnowflakeUserAccessDisabledError(
   );
 }
 
-export class SnowflakeCastKnownErrorsInterceptor implements ActivityInboundCallsInterceptor {
+export class SnowflakeCastKnownErrorsInterceptor
+  implements ActivityInboundCallsInterceptor
+{
   async execute(
     input: ActivityExecuteInput,
     next: Next<ActivityInboundCallsInterceptor, "execute">

--- a/connectors/src/connectors/zendesk/temporal/cast_known_errors.ts
+++ b/connectors/src/connectors/zendesk/temporal/cast_known_errors.ts
@@ -13,7 +13,9 @@ import {
   ExternalOAuthTokenError,
 } from "@connectors/lib/error";
 
-export class ZendeskCastKnownErrorsInterceptor implements ActivityInboundCallsInterceptor {
+export class ZendeskCastKnownErrorsInterceptor
+  implements ActivityInboundCallsInterceptor
+{
   async execute(
     input: ActivityExecuteInput,
     next: Next<ActivityInboundCallsInterceptor, "execute">

--- a/connectors/src/lib/temporal_monitoring.ts
+++ b/connectors/src/lib/temporal_monitoring.ts
@@ -47,7 +47,9 @@ export interface ContextWithLogger extends Context {
   logger: typeof logger;
 }
 
-export class ActivityInboundLogInterceptor implements ActivityInboundCallsInterceptor {
+export class ActivityInboundLogInterceptor
+  implements ActivityInboundCallsInterceptor
+{
   public readonly logger: Logger;
   private readonly context: Context;
   private readonly provider: ConnectorProvider;

--- a/connectors/src/resources/connector/bigquery.ts
+++ b/connectors/src/resources/connector/bigquery.ts
@@ -15,7 +15,9 @@ import type {
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { ModelId } from "@connectors/types";
 
-export class BigQueryConnectorStrategy implements ConnectorProviderStrategy<"bigquery"> {
+export class BigQueryConnectorStrategy
+  implements ConnectorProviderStrategy<"bigquery">
+{
   async makeNew(
     connectorId: ModelId,
     blob: WithCreationAttributes<BigQueryConfigurationModel>,

--- a/connectors/src/resources/connector/confluence.ts
+++ b/connectors/src/resources/connector/confluence.ts
@@ -15,7 +15,9 @@ import type {
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { ModelId } from "@connectors/types";
 
-export class ConfluenceConnectorStrategy implements ConnectorProviderStrategy<"confluence"> {
+export class ConfluenceConnectorStrategy
+  implements ConnectorProviderStrategy<"confluence">
+{
   async makeNew(
     connectorId: ModelId,
     blob: WithCreationAttributes<ConfluenceConfigurationModel>,

--- a/connectors/src/resources/connector/discord.ts
+++ b/connectors/src/resources/connector/discord.ts
@@ -11,7 +11,9 @@ import type { ConnectorResource } from "@connectors/resources/connector_resource
 import { DiscordConfigurationResource } from "@connectors/resources/discord_configuration_resource";
 import type { ModelId } from "@connectors/types";
 
-export class DiscordConnectorStrategy implements ConnectorProviderStrategy<"discord_bot"> {
+export class DiscordConnectorStrategy
+  implements ConnectorProviderStrategy<"discord_bot">
+{
   async makeNew(
     connectorId: ModelId,
     blob: WithCreationAttributes<DiscordConfigurationModel>,

--- a/connectors/src/resources/connector/dust_project.ts
+++ b/connectors/src/resources/connector/dust_project.ts
@@ -12,7 +12,9 @@ import { DustProjectConfigurationResource } from "@connectors/resources/dust_pro
 import { DustProjectConversationResource } from "@connectors/resources/dust_project_conversation_resource";
 import type { ModelId } from "@connectors/types";
 
-export class DustProjectConnectorStrategy implements ConnectorProviderStrategy<"dust_project"> {
+export class DustProjectConnectorStrategy
+  implements ConnectorProviderStrategy<"dust_project">
+{
   async makeNew(
     connectorId: ModelId,
     blob: WithCreationAttributes<DustProjectConfigurationModel>,

--- a/connectors/src/resources/connector/github.ts
+++ b/connectors/src/resources/connector/github.ts
@@ -17,7 +17,9 @@ import type {
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { ModelId } from "@connectors/types";
 
-export class GithubConnectorStrategy implements ConnectorProviderStrategy<"github"> {
+export class GithubConnectorStrategy
+  implements ConnectorProviderStrategy<"github">
+{
   async makeNew(
     connectorId: ModelId,
     blob: WithCreationAttributes<GithubConnectorStateModel>,

--- a/connectors/src/resources/connector/gong.ts
+++ b/connectors/src/resources/connector/gong.ts
@@ -14,7 +14,9 @@ import type {
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { ModelId } from "@connectors/types";
 
-export class GongConnectorStrategy implements ConnectorProviderStrategy<"gong"> {
+export class GongConnectorStrategy
+  implements ConnectorProviderStrategy<"gong">
+{
   async makeNew(
     connectorId: ModelId,
     blob: WithCreationAttributes<GongConfigurationModel>,

--- a/connectors/src/resources/connector/google_drive.ts
+++ b/connectors/src/resources/connector/google_drive.ts
@@ -16,7 +16,9 @@ import type {
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { ModelId } from "@connectors/types";
 
-export class GoogleDriveConnectorStrategy implements ConnectorProviderStrategy<"google_drive"> {
+export class GoogleDriveConnectorStrategy
+  implements ConnectorProviderStrategy<"google_drive">
+{
   async makeNew(
     connectorId: ModelId,
     blob: WithCreationAttributes<GoogleDriveConfigModel>,

--- a/connectors/src/resources/connector/intercom.ts
+++ b/connectors/src/resources/connector/intercom.ts
@@ -17,7 +17,9 @@ import type {
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { ModelId } from "@connectors/types";
 
-export class IntercomConnectorStrategy implements ConnectorProviderStrategy<"intercom"> {
+export class IntercomConnectorStrategy
+  implements ConnectorProviderStrategy<"intercom">
+{
   async makeNew(
     connectorId: ModelId,
     blob: WithCreationAttributes<IntercomWorkspaceModel>,

--- a/connectors/src/resources/connector/microsoft.ts
+++ b/connectors/src/resources/connector/microsoft.ts
@@ -11,7 +11,9 @@ import type { ConnectorResource } from "@connectors/resources/connector_resource
 import { MicrosoftConfigurationResource } from "@connectors/resources/microsoft_resource";
 import type { ModelId } from "@connectors/types";
 
-export class MicrosoftConnectorStrategy implements ConnectorProviderStrategy<"microsoft"> {
+export class MicrosoftConnectorStrategy
+  implements ConnectorProviderStrategy<"microsoft">
+{
   async makeNew(
     connectorId: ModelId,
     blob: WithCreationAttributes<MicrosoftConfigurationModel>,

--- a/connectors/src/resources/connector/microsoft_bot.ts
+++ b/connectors/src/resources/connector/microsoft_bot.ts
@@ -11,7 +11,9 @@ import type { ConnectorResource } from "@connectors/resources/connector_resource
 import { MicrosoftBotConfigurationResource } from "@connectors/resources/microsoft_bot_resources";
 import type { ModelId } from "@connectors/types";
 
-export class MicrosoftBotConnectorStrategy implements ConnectorProviderStrategy<"microsoft_bot"> {
+export class MicrosoftBotConnectorStrategy
+  implements ConnectorProviderStrategy<"microsoft_bot">
+{
   async makeNew(
     connectorId: ModelId,
     blob: WithCreationAttributes<MicrosoftBotConfigurationModel>,

--- a/connectors/src/resources/connector/notion.ts
+++ b/connectors/src/resources/connector/notion.ts
@@ -17,7 +17,9 @@ import type {
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { ModelId } from "@connectors/types";
 
-export class NotionConnectorStrategy implements ConnectorProviderStrategy<"notion"> {
+export class NotionConnectorStrategy
+  implements ConnectorProviderStrategy<"notion">
+{
   async makeNew(
     connectorId: ModelId,
     blob: WithCreationAttributes<NotionConnectorStateModel>,

--- a/connectors/src/resources/connector/salesforce.ts
+++ b/connectors/src/resources/connector/salesforce.ts
@@ -15,7 +15,9 @@ import {
   SalesforceSyncedQueryResource,
 } from "../salesforce_resources";
 
-export class SalesforceConnectorStrategy implements ConnectorProviderStrategy<"salesforce"> {
+export class SalesforceConnectorStrategy
+  implements ConnectorProviderStrategy<"salesforce">
+{
   async makeNew(
     connectorId: ModelId,
     blob: WithCreationAttributes<SalesforceConfigurationModel>,

--- a/connectors/src/resources/connector/slack.ts
+++ b/connectors/src/resources/connector/slack.ts
@@ -11,7 +11,9 @@ import type { ConnectorResource } from "@connectors/resources/connector_resource
 import { SlackConfigurationResource } from "@connectors/resources/slack_configuration_resource";
 import type { ModelId } from "@connectors/types";
 
-export class SlackConnectorStrategy implements ConnectorProviderStrategy<"slack"> {
+export class SlackConnectorStrategy
+  implements ConnectorProviderStrategy<"slack">
+{
   async makeNew(
     connectorId: ModelId,
     blob: WithCreationAttributes<SlackConfigurationModel>,

--- a/connectors/src/resources/connector/snowflake.ts
+++ b/connectors/src/resources/connector/snowflake.ts
@@ -15,7 +15,9 @@ import type {
 import type { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { ModelId } from "@connectors/types";
 
-export class SnowflakeConnectorStrategy implements ConnectorProviderStrategy<"snowflake"> {
+export class SnowflakeConnectorStrategy
+  implements ConnectorProviderStrategy<"snowflake">
+{
   async makeNew(
     connectorId: ModelId,
     blob: WithCreationAttributes<SnowflakeConfigurationModel>,

--- a/connectors/src/resources/connector/webcrawler.ts
+++ b/connectors/src/resources/connector/webcrawler.ts
@@ -12,7 +12,9 @@ import { WebCrawlerConfigurationResource } from "@connectors/resources/webcrawle
 import type { WebCrawlerConfiguration } from "@connectors/types";
 import type { ModelId } from "@connectors/types";
 
-export class WebCrawlerStrategy implements ConnectorProviderStrategy<"webcrawler"> {
+export class WebCrawlerStrategy
+  implements ConnectorProviderStrategy<"webcrawler">
+{
   async makeNew(
     connectorId: ModelId,
     blob: WithCreationAttributes<WebCrawlerConfigurationModel> & {

--- a/connectors/src/resources/connector/zendesk.ts
+++ b/connectors/src/resources/connector/zendesk.ts
@@ -18,7 +18,9 @@ import {
 } from "@connectors/resources/zendesk_resources";
 import type { ModelId } from "@connectors/types";
 
-export class ZendeskConnectorStrategy implements ConnectorProviderStrategy<"zendesk"> {
+export class ZendeskConnectorStrategy
+  implements ConnectorProviderStrategy<"zendesk">
+{
   async makeNew(
     connectorId: ModelId,
     blob: WithCreationAttributes<ZendeskConfigurationModel>,

--- a/connectors/src/resources/connector_resource.ts
+++ b/connectors/src/resources/connector_resource.ts
@@ -31,7 +31,8 @@ import { withTransaction } from "@connectors/types/shared/utils/sql_utils";
 // This design will be moved up to BaseResource once we transition away from Sequelize.
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
-export interface ConnectorResource extends ReadonlyAttributesType<ConnectorModel> {}
+export interface ConnectorResource
+  extends ReadonlyAttributesType<ConnectorModel> {}
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class ConnectorResource extends BaseResource<ConnectorModel> {
   static model: ModelStatic<ConnectorModel> = ConnectorModel;

--- a/connectors/src/resources/discord_configuration_resource.ts
+++ b/connectors/src/resources/discord_configuration_resource.ts
@@ -10,7 +10,8 @@ import type { DiscordBotConfigurationType, ModelId } from "@connectors/types";
 import { normalizeError } from "@connectors/types";
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
-export interface DiscordConfigurationResource extends ReadonlyAttributesType<DiscordConfigurationModel> {}
+export interface DiscordConfigurationResource
+  extends ReadonlyAttributesType<DiscordConfigurationModel> {}
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class DiscordConfigurationResource extends BaseResource<DiscordConfigurationModel> {
   static model: ModelStatic<DiscordConfigurationModel> =

--- a/connectors/src/resources/dust_project_configuration_resource.ts
+++ b/connectors/src/resources/dust_project_configuration_resource.ts
@@ -13,7 +13,8 @@ import { normalizeError } from "@connectors/types";
 // This design will be moved up to BaseResource once we transition away from Sequelize.
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
-export interface DustProjectConfigurationResource extends ReadonlyAttributesType<DustProjectConfigurationModel> {}
+export interface DustProjectConfigurationResource
+  extends ReadonlyAttributesType<DustProjectConfigurationModel> {}
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class DustProjectConfigurationResource extends BaseResource<DustProjectConfigurationModel> {
   static model: ModelStatic<DustProjectConfigurationModel> =

--- a/connectors/src/resources/dust_project_conversation_resource.ts
+++ b/connectors/src/resources/dust_project_conversation_resource.ts
@@ -14,7 +14,8 @@ import { normalizeError } from "@connectors/types";
 // This design will be moved up to BaseResource once we transition away from Sequelize.
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
-export interface DustProjectConversationResource extends ReadonlyAttributesType<DustProjectConversationModel> {}
+export interface DustProjectConversationResource
+  extends ReadonlyAttributesType<DustProjectConversationModel> {}
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class DustProjectConversationResource extends BaseResource<DustProjectConversationModel> {
   static model: ModelStatic<DustProjectConversationModel> =

--- a/connectors/src/resources/gong_resources.ts
+++ b/connectors/src/resources/gong_resources.ts
@@ -36,7 +36,8 @@ const TRANSCRIPT_DELAY_TIME_UPPER_BOUND_MS = hoursToMs(3);
 // This design will be moved up to BaseResource once we transition away from Sequelize.
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
-export interface GongConfigurationResource extends ReadonlyAttributesType<GongConfigurationModel> {}
+export interface GongConfigurationResource
+  extends ReadonlyAttributesType<GongConfigurationModel> {}
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class GongConfigurationResource extends BaseResource<GongConfigurationModel> {
@@ -191,7 +192,8 @@ export type GongUserBlob = Omit<
 // This design will be moved up to BaseResource once we transition away from Sequelize.
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
-export interface GongUserResource extends ReadonlyAttributesType<GongUserModel> {}
+export interface GongUserResource
+  extends ReadonlyAttributesType<GongUserModel> {}
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class GongUserResource extends BaseResource<GongUserModel> {
@@ -292,7 +294,8 @@ export class GongUserResource extends BaseResource<GongUserModel> {
 // This design will be moved up to BaseResource once we transition away from Sequelize.
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
-export interface GongTranscriptResource extends ReadonlyAttributesType<GongTranscriptModel> {}
+export interface GongTranscriptResource
+  extends ReadonlyAttributesType<GongTranscriptModel> {}
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class GongTranscriptResource extends BaseResource<GongTranscriptModel> {

--- a/connectors/src/resources/microsoft_bot_resources.ts
+++ b/connectors/src/resources/microsoft_bot_resources.ts
@@ -15,7 +15,8 @@ import type { ModelId } from "@connectors/types";
 // This design will be moved up to BaseResource once we transition away from Sequelize.
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
-export interface MicrosoftBotConfigurationResource extends ReadonlyAttributesType<MicrosoftBotConfigurationModel> {}
+export interface MicrosoftBotConfigurationResource
+  extends ReadonlyAttributesType<MicrosoftBotConfigurationModel> {}
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class MicrosoftBotConfigurationResource extends BaseResource<MicrosoftBotConfigurationModel> {

--- a/connectors/src/resources/microsoft_resource.ts
+++ b/connectors/src/resources/microsoft_resource.ts
@@ -23,7 +23,8 @@ import type { ModelId } from "@connectors/types";
 // This design will be moved up to BaseResource once we transition away from Sequelize.
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
-export interface MicrosoftConfigurationResource extends ReadonlyAttributesType<MicrosoftConfigurationModel> {}
+export interface MicrosoftConfigurationResource
+  extends ReadonlyAttributesType<MicrosoftConfigurationModel> {}
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class MicrosoftConfigurationResource extends BaseResource<MicrosoftConfigurationModel> {
@@ -130,7 +131,8 @@ export class MicrosoftConfigurationResource extends BaseResource<MicrosoftConfig
 // This design will be moved up to BaseResource once we transition away from Sequelize.
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
-export interface MicrosoftRootResource extends ReadonlyAttributesType<MicrosoftRootModel> {}
+export interface MicrosoftRootResource
+  extends ReadonlyAttributesType<MicrosoftRootModel> {}
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class MicrosoftRootResource extends BaseResource<MicrosoftRootModel> {
@@ -230,7 +232,8 @@ export class MicrosoftRootResource extends BaseResource<MicrosoftRootModel> {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
-export interface MicrosoftNodeResource extends ReadonlyAttributesType<MicrosoftNodeModel> {}
+export interface MicrosoftNodeResource
+  extends ReadonlyAttributesType<MicrosoftNodeModel> {}
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class MicrosoftNodeResource extends BaseResource<MicrosoftNodeModel> {

--- a/connectors/src/resources/salesforce_resources.ts
+++ b/connectors/src/resources/salesforce_resources.ts
@@ -20,7 +20,8 @@ import type { ModelId } from "@connectors/types";
 // This design will be moved up to BaseResource once we transition away from Sequelize.
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
-export interface SalesforceConfigurationResource extends ReadonlyAttributesType<SalesforceConfigurationModel> {}
+export interface SalesforceConfigurationResource
+  extends ReadonlyAttributesType<SalesforceConfigurationModel> {}
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class SalesforceConfigurationResource extends BaseResource<SalesforceConfigurationModel> {
@@ -107,7 +108,8 @@ export class SalesforceConfigurationResource extends BaseResource<SalesforceConf
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
-export interface SalesforceSyncedQueryResource extends ReadonlyAttributesType<SalesforceSyncedQueryModel> {}
+export interface SalesforceSyncedQueryResource
+  extends ReadonlyAttributesType<SalesforceSyncedQueryModel> {}
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class SalesforceSyncedQueryResource extends BaseResource<SalesforceSyncedQueryModel> {

--- a/connectors/src/resources/slack_configuration_resource.ts
+++ b/connectors/src/resources/slack_configuration_resource.ts
@@ -25,7 +25,8 @@ import { normalizeError } from "@connectors/types";
 // This design will be moved up to BaseResource once we transition away from Sequelize.
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
-export interface SlackConfigurationResource extends ReadonlyAttributesType<SlackConfigurationModel> {}
+export interface SlackConfigurationResource
+  extends ReadonlyAttributesType<SlackConfigurationModel> {}
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class SlackConfigurationResource extends BaseResource<SlackConfigurationModel> {
   static model: ModelStatic<SlackConfigurationModel> = SlackConfigurationModel;

--- a/connectors/src/resources/webcrawler_resource.ts
+++ b/connectors/src/resources/webcrawler_resource.ts
@@ -34,7 +34,8 @@ import { withTransaction } from "@connectors/types/shared/utils/sql_utils";
 // This design will be moved up to BaseResource once we transition away from Sequelize.
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
-export interface WebCrawlerConfigurationResource extends ReadonlyAttributesType<WebCrawlerConfigurationModel> {}
+export interface WebCrawlerConfigurationResource
+  extends ReadonlyAttributesType<WebCrawlerConfigurationModel> {}
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class WebCrawlerConfigurationResource extends BaseResource<WebCrawlerConfigurationModel> {
   static model: ModelStatic<WebCrawlerConfigurationModel> =

--- a/connectors/src/resources/zendesk_resources.ts
+++ b/connectors/src/resources/zendesk_resources.ts
@@ -33,7 +33,8 @@ import { INTERNAL_MIME_TYPES } from "@connectors/types";
 // This design will be moved up to BaseResource once we transition away from Sequelize.
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
-export interface ZendeskConfigurationResource extends ReadonlyAttributesType<ZendeskConfigurationModel> {}
+export interface ZendeskConfigurationResource
+  extends ReadonlyAttributesType<ZendeskConfigurationModel> {}
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class ZendeskConfigurationResource extends BaseResource<ZendeskConfigurationModel> {
@@ -234,7 +235,8 @@ export class ZendeskConfigurationResource extends BaseResource<ZendeskConfigurat
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
-export interface ZendeskBrandResource extends ReadonlyAttributesType<ZendeskBrandModel> {}
+export interface ZendeskBrandResource
+  extends ReadonlyAttributesType<ZendeskBrandModel> {}
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class ZendeskBrandResource extends BaseResource<ZendeskBrandModel> {
@@ -494,7 +496,8 @@ export class ZendeskBrandResource extends BaseResource<ZendeskBrandModel> {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
-export interface ZendeskCategoryResource extends ReadonlyAttributesType<ZendeskCategoryModel> {}
+export interface ZendeskCategoryResource
+  extends ReadonlyAttributesType<ZendeskCategoryModel> {}
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class ZendeskCategoryResource extends BaseResource<ZendeskCategoryModel> {
@@ -753,7 +756,8 @@ export class ZendeskCategoryResource extends BaseResource<ZendeskCategoryModel> 
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
-export interface ZendeskTicketResource extends ReadonlyAttributesType<ZendeskTicketModel> {}
+export interface ZendeskTicketResource
+  extends ReadonlyAttributesType<ZendeskTicketModel> {}
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class ZendeskTicketResource extends BaseResource<ZendeskTicketModel> {
@@ -951,7 +955,8 @@ export class ZendeskTicketResource extends BaseResource<ZendeskTicketModel> {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
-export interface ZendeskArticleResource extends ReadonlyAttributesType<ZendeskArticleModel> {}
+export interface ZendeskArticleResource
+  extends ReadonlyAttributesType<ZendeskArticleModel> {}
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class ZendeskArticleResource extends BaseResource<ZendeskArticleModel> {

--- a/firebase-functions/slack-webhook-router/.prettierrc
+++ b/firebase-functions/slack-webhook-router/.prettierrc
@@ -1,8 +1,0 @@
-{
-  "singleQuote": false,
-  "trailingComma": "es5",
-  "requirePragma": false,
-  "arrowParens": "always",
-  "semi": true,
-  "plugins": []
-}

--- a/firebase-functions/slack-webhook-router/biome.json
+++ b/firebase-functions/slack-webhook-router/biome.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.3.13/schema.json",
+  "vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
+  "files": { "ignoreUnknown": true },
+  "formatter": {
+    "enabled": true,
+    "formatWithErrors": false,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineEnding": "lf",
+    "lineWidth": 80,
+    "attributePosition": "auto",
+    "bracketSameLine": false,
+    "bracketSpacing": true,
+    "expand": "auto",
+    "useEditorconfig": true
+  },
+  "linter": { "enabled": false },
+  "javascript": {
+    "formatter": {
+      "jsxQuoteStyle": "double",
+      "quoteProperties": "asNeeded",
+      "trailingCommas": "es5",
+      "semicolons": "always",
+      "arrowParentheses": "always",
+      "bracketSameLine": false,
+      "quoteStyle": "double",
+      "attributePosition": "auto",
+      "bracketSpacing": true
+    }
+  },
+  "html": {
+    "formatter": {
+      "indentScriptAndStyle": false,
+      "selfCloseVoidElements": "always"
+    }
+  },
+  "assist": {
+    "enabled": false
+  }
+}

--- a/firebase-functions/slack-webhook-router/package-lock.json
+++ b/firebase-functions/slack-webhook-router/package-lock.json
@@ -16,6 +16,7 @@
         "raw-body": "^3.0.0"
       },
       "devDependencies": {
+        "@biomejs/biome": "^2.3.13",
         "@eslint/js": "^9.0.0",
         "@types/express": "^5.0.0",
         "@types/node": "^20.0.0",
@@ -30,6 +31,169 @@
       },
       "engines": {
         "node": "20"
+      }
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.3.13.tgz",
+      "integrity": "sha512-Fw7UsV0UAtWIBIm0M7g5CRerpu1eKyKAXIazzxhbXYUyMkwNrkX/KLkGI7b+uVDQ5cLUMfOC9vR60q9IDYDstA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "2.3.13",
+        "@biomejs/cli-darwin-x64": "2.3.13",
+        "@biomejs/cli-linux-arm64": "2.3.13",
+        "@biomejs/cli-linux-arm64-musl": "2.3.13",
+        "@biomejs/cli-linux-x64": "2.3.13",
+        "@biomejs/cli-linux-x64-musl": "2.3.13",
+        "@biomejs/cli-win32-arm64": "2.3.13",
+        "@biomejs/cli-win32-x64": "2.3.13"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.3.13.tgz",
+      "integrity": "sha512-0OCwP0/BoKzyJHnFdaTk/i7hIP9JHH9oJJq6hrSCPmJPo8JWcJhprK4gQlhFzrwdTBAW4Bjt/RmCf3ZZe59gwQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.3.13.tgz",
+      "integrity": "sha512-AGr8OoemT/ejynbIu56qeil2+F2WLkIjn2d8jGK1JkchxnMUhYOfnqc9sVzcRxpG9Ycvw4weQ5sprRvtb7Yhcw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.3.13.tgz",
+      "integrity": "sha512-xvOiFkrDNu607MPMBUQ6huHmBG1PZLOrqhtK6pXJW3GjfVqJg0Z/qpTdhXfcqWdSZHcT+Nct2fOgewZvytESkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.3.13.tgz",
+      "integrity": "sha512-TUdDCSY+Eo/EHjhJz7P2GnWwfqet+lFxBZzGHldrvULr59AgahamLs/N85SC4+bdF86EhqDuuw9rYLvLFWWlXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.3.13.tgz",
+      "integrity": "sha512-s+YsZlgiXNq8XkgHs6xdvKDFOj/bwTEevqEY6rC2I3cBHbxXYU1LOZstH3Ffw9hE5tE1sqT7U23C00MzkXztMw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.3.13.tgz",
+      "integrity": "sha512-0bdwFVSbbM//Sds6OjtnmQGp4eUjOTt6kHvR/1P0ieR9GcTUAlPNvPC3DiavTqq302W34Ae2T6u5VVNGuQtGlQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.3.13.tgz",
+      "integrity": "sha512-QweDxY89fq0VvrxME+wS/BXKmqMrOTZlN9SqQ79kQSIc3FrEwvW/PvUegQF6XIVaekncDykB5dzPqjbwSKs9DA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.3.13.tgz",
+      "integrity": "sha512-trDw2ogdM2lyav9WFQsdsfdVy1dvZALymRpgmWsvSez0BJzBjulhOT/t+wyKeh3pZWvwP3VMs1SoOKwO3wecMQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
       }
     },
     "node_modules/@cspotcode/source-map-support": {

--- a/firebase-functions/slack-webhook-router/package.json
+++ b/firebase-functions/slack-webhook-router/package.json
@@ -25,6 +25,7 @@
     "raw-body": "^3.0.0"
   },
   "devDependencies": {
+    "@biomejs/biome": "^2.3.13",
     "@eslint/js": "^9.0.0",
     "@types/express": "^5.0.0",
     "@types/node": "^20.0.0",

--- a/firebase-functions/slack-webhook-router/src/forwarder.ts
+++ b/firebase-functions/slack-webhook-router/src/forwarder.ts
@@ -1,107 +1,106 @@
-import {IncomingHttpHeaders} from "http";
-import {CONFIG} from "./config.js";
-import type {Secrets} from "./secrets.js";
+import { IncomingHttpHeaders } from "http";
+import { CONFIG } from "./config.js";
+import type { Secrets } from "./secrets.js";
 
 export class WebhookForwarder {
-    constructor(private secrets: Secrets) {
+  constructor(private secrets: Secrets) {}
+
+  async forwardToRegions({
+    body,
+    endpoint,
+    method,
+    headers,
+  }: {
+    body: unknown;
+    endpoint: string;
+    method: string;
+    headers: IncomingHttpHeaders;
+  }): Promise<void> {
+    const targets = [
+      {
+        region: "US",
+        url: CONFIG.US_CONNECTOR_URL,
+        secret: this.secrets.usSecret,
+      },
+      {
+        region: "EU",
+        url: CONFIG.EU_CONNECTOR_URL,
+        secret: this.secrets.euSecret,
+      },
+    ];
+
+    const requests = targets.map((target) =>
+      this.forwardToTarget({ target, endpoint, method, body, headers })
+    );
+
+    await Promise.allSettled(requests);
+  }
+
+  private async forwardToTarget({
+    body,
+    endpoint,
+    method,
+    target,
+    headers,
+  }: {
+    body: unknown;
+    endpoint: string;
+    method: string;
+    target: { region: string; url: string; secret: string };
+    headers: IncomingHttpHeaders;
+  }): Promise<void> {
+    try {
+      const response = await this.createRequest({
+        baseUrl: target.url,
+        body,
+        endpoint,
+        method,
+        secret: target.secret,
+        headers,
+      });
+
+      console.log("Webhook forwarding succeeded", {
+        component: "forwarder",
+        region: target.region,
+        endpoint,
+        status: response.status,
+      });
+    } catch (error) {
+      console.error("Webhook forwarding failed", {
+        component: "forwarder",
+        region: target.region,
+        endpoint,
+        error: error instanceof Error ? error.message : String(error),
+      });
     }
+  }
 
-    async forwardToRegions({
-                               body,
-                               endpoint,
-                               method,
-                               headers,
-                           }: {
-        body: unknown;
-        endpoint: string;
-        method: string;
-        headers: IncomingHttpHeaders;
-    }): Promise<void> {
-        const targets = [
-            {
-                region: "US",
-                url: CONFIG.US_CONNECTOR_URL,
-                secret: this.secrets.usSecret,
-            },
-            {
-                region: "EU",
-                url: CONFIG.EU_CONNECTOR_URL,
-                secret: this.secrets.euSecret,
-            },
-        ];
+  private createRequest({
+    baseUrl,
+    body,
+    endpoint,
+    method,
+    secret,
+    headers,
+  }: {
+    baseUrl: string;
+    body: unknown;
+    endpoint: string;
+    method: string;
+    secret: string;
+    headers: IncomingHttpHeaders;
+  }): Promise<Response> {
+    const url = `${baseUrl}/webhooks/${secret}/${endpoint}`;
 
-        const requests = targets.map((target) =>
-            this.forwardToTarget({target, endpoint, method, body, headers})
-        );
-
-        await Promise.allSettled(requests);
-    }
-
-    private async forwardToTarget({
-                                      body,
-                                      endpoint,
-                                      method,
-                                      target,
-                                      headers,
-                                  }: {
-        body: unknown;
-        endpoint: string;
-        method: string;
-        target: { region: string; url: string; secret: string };
-        headers: IncomingHttpHeaders;
-    }): Promise<void> {
-        try {
-            const response = await this.createRequest({
-                baseUrl: target.url,
-                body,
-                endpoint,
-                method,
-                secret: target.secret,
-                headers,
-            });
-
-            console.log("Webhook forwarding succeeded", {
-                component: "forwarder",
-                region: target.region,
-                endpoint,
-                status: response.status,
-            });
-        } catch (error) {
-            console.error("Webhook forwarding failed", {
-                component: "forwarder",
-                region: target.region,
-                endpoint,
-                error: error instanceof Error ? error.message : String(error),
-            });
-        }
-    }
-
-    private createRequest({
-                              baseUrl,
-                              body,
-                              endpoint,
-                              method,
-                              secret,
-                              headers,
-                          }: {
-        baseUrl: string;
-        body: unknown;
-        endpoint: string;
-        method: string;
-        secret: string;
-        headers: IncomingHttpHeaders;
-    }): Promise<Response> {
-        const url = `${baseUrl}/webhooks/${secret}/${endpoint}`;
-
-        // Forward with original content-type and appropriate body format.
-        return fetch(url, {
-            method,
-            headers: {
-                "Content-Type": headers["content-type"] || "application/json",
-                "x-dust-clientid": "slack-webhook-router"
-            },
-            body: typeof body === "string" ? body : JSON.stringify(body),
-            signal: AbortSignal.timeout(CONFIG.FETCH_TIMEOUT_MS),
-        });
-    }
+    // Forward with original content-type and appropriate body format.
+    return fetch(url, {
+      method,
+      headers: {
+        "Content-Type": headers["content-type"] || "application/json",
+        "x-dust-clientid": "slack-webhook-router",
+      },
+      body: typeof body === "string" ? body : JSON.stringify(body),
+      signal: AbortSignal.timeout(CONFIG.FETCH_TIMEOUT_MS),
+    });
+  }
 }

--- a/firebase-functions/webhook-router/biome.json
+++ b/firebase-functions/webhook-router/biome.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.3.13/schema.json",
+  "vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
+  "files": { "ignoreUnknown": true },
+  "formatter": {
+    "enabled": true,
+    "formatWithErrors": false,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineEnding": "lf",
+    "lineWidth": 80,
+    "attributePosition": "auto",
+    "bracketSameLine": false,
+    "bracketSpacing": true,
+    "expand": "auto",
+    "useEditorconfig": true
+  },
+  "linter": { "enabled": false },
+  "javascript": {
+    "formatter": {
+      "jsxQuoteStyle": "double",
+      "quoteProperties": "asNeeded",
+      "trailingCommas": "es5",
+      "semicolons": "always",
+      "arrowParentheses": "always",
+      "bracketSameLine": false,
+      "quoteStyle": "double",
+      "attributePosition": "auto",
+      "bracketSpacing": true
+    }
+  },
+  "html": {
+    "formatter": {
+      "indentScriptAndStyle": false,
+      "selfCloseVoidElements": "always"
+    }
+  },
+  "assist": {
+    "enabled": false
+  }
+}

--- a/firebase-functions/webhook-router/firebase.json
+++ b/firebase-functions/webhook-router/firebase.json
@@ -2,7 +2,12 @@
   "functions": {
     "source": ".",
     "runtime": "nodejs20",
-    "ignore": ["node_modules", ".git", "firebase-debug.log", "firebase-debug.*.log"],
+    "ignore": [
+      "node_modules",
+      ".git",
+      "firebase-debug.log",
+      "firebase-debug.*.log"
+    ],
     "predeploy": ["npm run build"]
   },
   "hosting": {

--- a/firebase-functions/webhook-router/package-lock.json
+++ b/firebase-functions/webhook-router/package-lock.json
@@ -18,6 +18,7 @@
         "raw-body": "^3.0.0"
       },
       "devDependencies": {
+        "@biomejs/biome": "^2.3.13",
         "@eslint/js": "^9.0.0",
         "@types/express": "^5.0.0",
         "@types/node": "^20.0.0",
@@ -32,6 +33,169 @@
       },
       "engines": {
         "node": "20"
+      }
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.3.13.tgz",
+      "integrity": "sha512-Fw7UsV0UAtWIBIm0M7g5CRerpu1eKyKAXIazzxhbXYUyMkwNrkX/KLkGI7b+uVDQ5cLUMfOC9vR60q9IDYDstA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "2.3.13",
+        "@biomejs/cli-darwin-x64": "2.3.13",
+        "@biomejs/cli-linux-arm64": "2.3.13",
+        "@biomejs/cli-linux-arm64-musl": "2.3.13",
+        "@biomejs/cli-linux-x64": "2.3.13",
+        "@biomejs/cli-linux-x64-musl": "2.3.13",
+        "@biomejs/cli-win32-arm64": "2.3.13",
+        "@biomejs/cli-win32-x64": "2.3.13"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.3.13.tgz",
+      "integrity": "sha512-0OCwP0/BoKzyJHnFdaTk/i7hIP9JHH9oJJq6hrSCPmJPo8JWcJhprK4gQlhFzrwdTBAW4Bjt/RmCf3ZZe59gwQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.3.13.tgz",
+      "integrity": "sha512-AGr8OoemT/ejynbIu56qeil2+F2WLkIjn2d8jGK1JkchxnMUhYOfnqc9sVzcRxpG9Ycvw4weQ5sprRvtb7Yhcw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.3.13.tgz",
+      "integrity": "sha512-xvOiFkrDNu607MPMBUQ6huHmBG1PZLOrqhtK6pXJW3GjfVqJg0Z/qpTdhXfcqWdSZHcT+Nct2fOgewZvytESkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.3.13.tgz",
+      "integrity": "sha512-TUdDCSY+Eo/EHjhJz7P2GnWwfqet+lFxBZzGHldrvULr59AgahamLs/N85SC4+bdF86EhqDuuw9rYLvLFWWlXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.3.13.tgz",
+      "integrity": "sha512-s+YsZlgiXNq8XkgHs6xdvKDFOj/bwTEevqEY6rC2I3cBHbxXYU1LOZstH3Ffw9hE5tE1sqT7U23C00MzkXztMw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.3.13.tgz",
+      "integrity": "sha512-0bdwFVSbbM//Sds6OjtnmQGp4eUjOTt6kHvR/1P0ieR9GcTUAlPNvPC3DiavTqq302W34Ae2T6u5VVNGuQtGlQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.3.13.tgz",
+      "integrity": "sha512-QweDxY89fq0VvrxME+wS/BXKmqMrOTZlN9SqQ79kQSIc3FrEwvW/PvUegQF6XIVaekncDykB5dzPqjbwSKs9DA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.3.13.tgz",
+      "integrity": "sha512-trDw2ogdM2lyav9WFQsdsfdVy1dvZALymRpgmWsvSez0BJzBjulhOT/t+wyKeh3pZWvwP3VMs1SoOKwO3wecMQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
       }
     },
     "node_modules/@cspotcode/source-map-support": {

--- a/firebase-functions/webhook-router/package.json
+++ b/firebase-functions/webhook-router/package.json
@@ -28,6 +28,7 @@
     "raw-body": "^3.0.0"
   },
   "devDependencies": {
+    "@biomejs/biome": "^2.3.13",
     "@eslint/js": "^9.0.0",
     "@types/express": "^5.0.0",
     "@types/node": "^20.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
         "dust": "dist/index.js"
       },
       "devDependencies": {
+        "@biomejs/biome": "^2.3.13",
         "@types/express": "^5.0.1",
         "@types/lodash": "^4.17.16",
         "@types/mime-types": "^3.0.1",
@@ -73,7 +74,6 @@
         "eslint-plugin-simple-import-sort": "^12.1.1",
         "eslint-plugin-unused-imports": "^4.3.0",
         "globals": "^14.0.0",
-        "prettier": "^3.7.4",
         "ts-node": "^10.9.2",
         "tsup": "^8.4.0",
         "typescript": "^5.9.3",
@@ -81,6 +81,169 @@
       },
       "engines": {
         "node": ">=20.17.0"
+      }
+    },
+    "cli/node_modules/@biomejs/biome": {
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.3.13.tgz",
+      "integrity": "sha512-Fw7UsV0UAtWIBIm0M7g5CRerpu1eKyKAXIazzxhbXYUyMkwNrkX/KLkGI7b+uVDQ5cLUMfOC9vR60q9IDYDstA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "2.3.13",
+        "@biomejs/cli-darwin-x64": "2.3.13",
+        "@biomejs/cli-linux-arm64": "2.3.13",
+        "@biomejs/cli-linux-arm64-musl": "2.3.13",
+        "@biomejs/cli-linux-x64": "2.3.13",
+        "@biomejs/cli-linux-x64-musl": "2.3.13",
+        "@biomejs/cli-win32-arm64": "2.3.13",
+        "@biomejs/cli-win32-x64": "2.3.13"
+      }
+    },
+    "cli/node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.3.13.tgz",
+      "integrity": "sha512-0OCwP0/BoKzyJHnFdaTk/i7hIP9JHH9oJJq6hrSCPmJPo8JWcJhprK4gQlhFzrwdTBAW4Bjt/RmCf3ZZe59gwQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "cli/node_modules/@biomejs/cli-darwin-x64": {
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.3.13.tgz",
+      "integrity": "sha512-AGr8OoemT/ejynbIu56qeil2+F2WLkIjn2d8jGK1JkchxnMUhYOfnqc9sVzcRxpG9Ycvw4weQ5sprRvtb7Yhcw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "cli/node_modules/@biomejs/cli-linux-arm64": {
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.3.13.tgz",
+      "integrity": "sha512-xvOiFkrDNu607MPMBUQ6huHmBG1PZLOrqhtK6pXJW3GjfVqJg0Z/qpTdhXfcqWdSZHcT+Nct2fOgewZvytESkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "cli/node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.3.13.tgz",
+      "integrity": "sha512-TUdDCSY+Eo/EHjhJz7P2GnWwfqet+lFxBZzGHldrvULr59AgahamLs/N85SC4+bdF86EhqDuuw9rYLvLFWWlXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "cli/node_modules/@biomejs/cli-linux-x64": {
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.3.13.tgz",
+      "integrity": "sha512-s+YsZlgiXNq8XkgHs6xdvKDFOj/bwTEevqEY6rC2I3cBHbxXYU1LOZstH3Ffw9hE5tE1sqT7U23C00MzkXztMw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "cli/node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.3.13.tgz",
+      "integrity": "sha512-0bdwFVSbbM//Sds6OjtnmQGp4eUjOTt6kHvR/1P0ieR9GcTUAlPNvPC3DiavTqq302W34Ae2T6u5VVNGuQtGlQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "cli/node_modules/@biomejs/cli-win32-arm64": {
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.3.13.tgz",
+      "integrity": "sha512-QweDxY89fq0VvrxME+wS/BXKmqMrOTZlN9SqQ79kQSIc3FrEwvW/PvUegQF6XIVaekncDykB5dzPqjbwSKs9DA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "cli/node_modules/@biomejs/cli-win32-x64": {
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.3.13.tgz",
+      "integrity": "sha512-trDw2ogdM2lyav9WFQsdsfdVy1dvZALymRpgmWsvSez0BJzBjulhOT/t+wyKeh3pZWvwP3VMs1SoOKwO3wecMQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
       }
     },
     "connectors": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -160,6 +160,7 @@
         "zod-validation-error": "^3.5.4"
       },
       "devDependencies": {
+        "@biomejs/biome": "^2.3.13",
         "@types/eslint": "^8.56.10",
         "@types/gunzip-maybe": "^1.4.2",
         "@types/lodash": "^4.17.7",
@@ -180,12 +181,174 @@
         "eslint-plugin-simple-import-sort": "^12.1.0",
         "eslint-plugin-unused-imports": "^4.3.0",
         "knip": "^5.80.0",
-        "prettier": "^3.7.4",
         "tsconfig-paths-webpack-plugin": "^4.1.0",
         "tsx": "^4.21.0",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.48.0",
         "vitest": "^4.0.16"
+      }
+    },
+    "connectors/node_modules/@biomejs/biome": {
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.3.13.tgz",
+      "integrity": "sha512-Fw7UsV0UAtWIBIm0M7g5CRerpu1eKyKAXIazzxhbXYUyMkwNrkX/KLkGI7b+uVDQ5cLUMfOC9vR60q9IDYDstA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "2.3.13",
+        "@biomejs/cli-darwin-x64": "2.3.13",
+        "@biomejs/cli-linux-arm64": "2.3.13",
+        "@biomejs/cli-linux-arm64-musl": "2.3.13",
+        "@biomejs/cli-linux-x64": "2.3.13",
+        "@biomejs/cli-linux-x64-musl": "2.3.13",
+        "@biomejs/cli-win32-arm64": "2.3.13",
+        "@biomejs/cli-win32-x64": "2.3.13"
+      }
+    },
+    "connectors/node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.3.13.tgz",
+      "integrity": "sha512-0OCwP0/BoKzyJHnFdaTk/i7hIP9JHH9oJJq6hrSCPmJPo8JWcJhprK4gQlhFzrwdTBAW4Bjt/RmCf3ZZe59gwQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "connectors/node_modules/@biomejs/cli-darwin-x64": {
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.3.13.tgz",
+      "integrity": "sha512-AGr8OoemT/ejynbIu56qeil2+F2WLkIjn2d8jGK1JkchxnMUhYOfnqc9sVzcRxpG9Ycvw4weQ5sprRvtb7Yhcw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "connectors/node_modules/@biomejs/cli-linux-arm64": {
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.3.13.tgz",
+      "integrity": "sha512-xvOiFkrDNu607MPMBUQ6huHmBG1PZLOrqhtK6pXJW3GjfVqJg0Z/qpTdhXfcqWdSZHcT+Nct2fOgewZvytESkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "connectors/node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.3.13.tgz",
+      "integrity": "sha512-TUdDCSY+Eo/EHjhJz7P2GnWwfqet+lFxBZzGHldrvULr59AgahamLs/N85SC4+bdF86EhqDuuw9rYLvLFWWlXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "connectors/node_modules/@biomejs/cli-linux-x64": {
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.3.13.tgz",
+      "integrity": "sha512-s+YsZlgiXNq8XkgHs6xdvKDFOj/bwTEevqEY6rC2I3cBHbxXYU1LOZstH3Ffw9hE5tE1sqT7U23C00MzkXztMw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "connectors/node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.3.13.tgz",
+      "integrity": "sha512-0bdwFVSbbM//Sds6OjtnmQGp4eUjOTt6kHvR/1P0ieR9GcTUAlPNvPC3DiavTqq302W34Ae2T6u5VVNGuQtGlQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "connectors/node_modules/@biomejs/cli-win32-arm64": {
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.3.13.tgz",
+      "integrity": "sha512-QweDxY89fq0VvrxME+wS/BXKmqMrOTZlN9SqQ79kQSIc3FrEwvW/PvUegQF6XIVaekncDykB5dzPqjbwSKs9DA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "connectors/node_modules/@biomejs/cli-win32-x64": {
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.3.13.tgz",
+      "integrity": "sha512-trDw2ogdM2lyav9WFQsdsfdVy1dvZALymRpgmWsvSez0BJzBjulhOT/t+wyKeh3pZWvwP3VMs1SoOKwO3wecMQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
       }
     },
     "connectors/node_modules/@types/express": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -62431,6 +62431,7 @@
         "zod": "^3.23.8"
       },
       "devDependencies": {
+        "@biomejs/biome": "^2.3.13",
         "@tsconfig/recommended": "^1.0.3",
         "@types/event-source-polyfill": "^1.0.5",
         "@types/node": "^20.19.2",
@@ -62444,7 +62445,6 @@
         "eslint-plugin-simple-import-sort": "^12.1.0",
         "eslint-plugin-unused-imports": "^4.3.0",
         "npm-watch": "^0.11.0",
-        "prettier": "^3.7.4",
         "tslib": "^2.6.2",
         "tsx": "^4.19.1",
         "typescript": "^5.9.3",
@@ -62452,6 +62452,169 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "sdks/js/node_modules/@biomejs/biome": {
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.3.13.tgz",
+      "integrity": "sha512-Fw7UsV0UAtWIBIm0M7g5CRerpu1eKyKAXIazzxhbXYUyMkwNrkX/KLkGI7b+uVDQ5cLUMfOC9vR60q9IDYDstA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "2.3.13",
+        "@biomejs/cli-darwin-x64": "2.3.13",
+        "@biomejs/cli-linux-arm64": "2.3.13",
+        "@biomejs/cli-linux-arm64-musl": "2.3.13",
+        "@biomejs/cli-linux-x64": "2.3.13",
+        "@biomejs/cli-linux-x64-musl": "2.3.13",
+        "@biomejs/cli-win32-arm64": "2.3.13",
+        "@biomejs/cli-win32-x64": "2.3.13"
+      }
+    },
+    "sdks/js/node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.3.13.tgz",
+      "integrity": "sha512-0OCwP0/BoKzyJHnFdaTk/i7hIP9JHH9oJJq6hrSCPmJPo8JWcJhprK4gQlhFzrwdTBAW4Bjt/RmCf3ZZe59gwQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "sdks/js/node_modules/@biomejs/cli-darwin-x64": {
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.3.13.tgz",
+      "integrity": "sha512-AGr8OoemT/ejynbIu56qeil2+F2WLkIjn2d8jGK1JkchxnMUhYOfnqc9sVzcRxpG9Ycvw4weQ5sprRvtb7Yhcw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "sdks/js/node_modules/@biomejs/cli-linux-arm64": {
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.3.13.tgz",
+      "integrity": "sha512-xvOiFkrDNu607MPMBUQ6huHmBG1PZLOrqhtK6pXJW3GjfVqJg0Z/qpTdhXfcqWdSZHcT+Nct2fOgewZvytESkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "sdks/js/node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.3.13.tgz",
+      "integrity": "sha512-TUdDCSY+Eo/EHjhJz7P2GnWwfqet+lFxBZzGHldrvULr59AgahamLs/N85SC4+bdF86EhqDuuw9rYLvLFWWlXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "sdks/js/node_modules/@biomejs/cli-linux-x64": {
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.3.13.tgz",
+      "integrity": "sha512-s+YsZlgiXNq8XkgHs6xdvKDFOj/bwTEevqEY6rC2I3cBHbxXYU1LOZstH3Ffw9hE5tE1sqT7U23C00MzkXztMw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "sdks/js/node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.3.13.tgz",
+      "integrity": "sha512-0bdwFVSbbM//Sds6OjtnmQGp4eUjOTt6kHvR/1P0ieR9GcTUAlPNvPC3DiavTqq302W34Ae2T6u5VVNGuQtGlQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "sdks/js/node_modules/@biomejs/cli-win32-arm64": {
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.3.13.tgz",
+      "integrity": "sha512-QweDxY89fq0VvrxME+wS/BXKmqMrOTZlN9SqQ79kQSIc3FrEwvW/PvUegQF6XIVaekncDykB5dzPqjbwSKs9DA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "sdks/js/node_modules/@biomejs/cli-win32-x64": {
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.3.13.tgz",
+      "integrity": "sha512-trDw2ogdM2lyav9WFQsdsfdVy1dvZALymRpgmWsvSez0BJzBjulhOT/t+wyKeh3pZWvwP3VMs1SoOKwO3wecMQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
       }
     },
     "sdks/js/node_modules/@esbuild/aix-ppc64": {

--- a/sdks/js/.node_modules-oYZmCWGV
+++ b/sdks/js/.node_modules-oYZmCWGV
@@ -1,0 +1,1 @@
+/Users/rcs/Projects/dust/sdks/js/node_modules

--- a/sdks/js/.prettierignore
+++ b/sdks/js/.prettierignore
@@ -1,2 +1,0 @@
-build
-.github/**/*.md

--- a/sdks/js/.prettierrc
+++ b/sdks/js/.prettierrc
@@ -1,7 +1,0 @@
-{
-  "singleQuote": false,
-  "trailingComma": "es5",
-  "requirePragma": false,
-  "arrowParens": "always",
-  "semi": true
-}

--- a/sdks/js/biome.json
+++ b/sdks/js/biome.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.3.13/schema.json",
+  "vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
+  "files": { "includes": ["**", "!!**/dist"] },
+  "formatter": {
+    "enabled": true,
+    "formatWithErrors": false,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineEnding": "lf",
+    "lineWidth": 80,
+    "attributePosition": "auto",
+    "bracketSameLine": false,
+    "bracketSpacing": true,
+    "expand": "auto",
+    "useEditorconfig": true,
+    "includes": ["**", "!**/build", "!.github/**/*.md"]
+  },
+  "linter": { "enabled": false },
+  "javascript": {
+    "formatter": {
+      "jsxQuoteStyle": "double",
+      "quoteProperties": "asNeeded",
+      "trailingCommas": "es5",
+      "semicolons": "always",
+      "arrowParentheses": "always",
+      "bracketSameLine": false,
+      "quoteStyle": "double",
+      "attributePosition": "auto",
+      "bracketSpacing": true
+    }
+  },
+  "html": {
+    "formatter": {
+      "indentScriptAndStyle": false,
+      "selfCloseVoidElements": "always"
+    }
+  },
+  "assist": {
+    "enabled": false
+  }
+}

--- a/sdks/js/package.json
+++ b/sdks/js/package.json
@@ -25,8 +25,8 @@
     "build:types": "tsc",
     "build:bundle": "tsx esbuild.config.ts",
     "lint": "eslint .",
-    "format": "prettier --write .",
-    "format:check": "prettier --check .",
+    "format": "biome format --write .",
+    "format:check": "biome check --formatter-enabled=true --linter-enabled=false .",
     "watch": "npm-watch",
     "tsc": "tsc"
   },
@@ -34,6 +34,7 @@
     "node": ">=20"
   },
   "devDependencies": {
+    "@biomejs/biome": "^2.3.13",
     "@tsconfig/recommended": "^1.0.3",
     "@types/event-source-polyfill": "^1.0.5",
     "@types/node": "^20.19.2",
@@ -47,7 +48,6 @@
     "eslint-plugin-simple-import-sort": "^12.1.0",
     "eslint-plugin-unused-imports": "^4.3.0",
     "npm-watch": "^0.11.0",
-    "prettier": "^3.7.4",
     "tslib": "^2.6.2",
     "tsx": "^4.19.1",
     "typescript": "^5.9.3",


### PR DESCRIPTION
## Description

Migrate connectors, sdk/js, cli, firebase-functions to Biome formatting

Locally on connectors for `npm run format:check`
* With biome => 0.4 seconds
* With prettier => 5.30 seconds

⚠️ ⚠️ ⚠️ ⚠️ ⚠️ 
* the formatting is not _exactly_ as prettier (see diff)
* firebase-functions was not formatted, now it is

Biome locally:
* VScode: https://biomejs.dev/reference/vscode/
* Jetbrains: https://plugins.jetbrains.com/plugin/22761-biome/reviews

## Tests

CI
## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
