### PR TITLE
[front] - chore(obs): update treemap aggregation

### DIFF
--- a/front/lib/api/assistant/observability/datasource_retrieval_documents.ts
+++ b/front/lib/api/assistant/observability/datasource_retrieval_documents.ts
@@ -143,11 +143,10 @@ export async function fetchDatasourceRetrievalDocumentsMetrics(
 ): Promise<Result<DatasourceRetrievalDocuments, Error>> {
   const workspace = auth.getNonNullableWorkspace();
 
-  const mcpServerConfigs =
-    await AgentMCPServerConfigurationResource.fetchBySIds(
-      auth,
-      mcpServerConfigIds
-    );
+  const mcpServerConfigs = await AgentMCPServerConfigurationResource.fetchByIds(
+    auth,
+    mcpServerConfigIds
+  );
 
   if (mcpServerConfigs.length === 0) {
     return new Ok({ documents: [], groups: [], total: 0 });

--- a/front/lib/api/assistant/observability/datasource_retrieval_documents.ts
+++ b/front/lib/api/assistant/observability/datasource_retrieval_documents.ts
@@ -129,28 +129,33 @@ export async function fetchDatasourceRetrievalDocumentsMetrics(
     agentId,
     days,
     version,
-    mcpServerConfigId,
+    mcpServerConfigIds,
     dataSourceId,
     limit = 50,
   }: {
     agentId: string;
     days?: number;
     version?: string;
-    mcpServerConfigId: string;
+    mcpServerConfigIds: string[];
     dataSourceId: string;
     limit?: number;
   }
 ): Promise<Result<DatasourceRetrievalDocuments, Error>> {
   const workspace = auth.getNonNullableWorkspace();
 
-  const mcpServerConfig = await AgentMCPServerConfigurationResource.fetchById(
-    auth,
-    mcpServerConfigId
-  );
+  const mcpServerConfigs =
+    await AgentMCPServerConfigurationResource.fetchBySIds(
+      auth,
+      mcpServerConfigIds
+    );
 
-  if (!mcpServerConfig) {
+  if (mcpServerConfigs.length === 0) {
     return new Ok({ documents: [], groups: [], total: 0 });
   }
+
+  const mcpServerConfigModelIds = Array.from(
+    new Set(mcpServerConfigs.map((config) => config.id))
+  );
 
   const baseQuery = buildAgentAnalyticsBaseQuery({
     workspaceId: workspace.sId,
@@ -164,8 +169,8 @@ export async function fetchDatasourceRetrievalDocumentsMetrics(
       filter: [
         baseQuery,
         {
-          term: {
-            mcp_server_configuration_id: mcpServerConfig.id,
+          terms: {
+            mcp_server_configuration_id: mcpServerConfigModelIds,
           },
         },
         {

--- a/front/lib/resources/agent_mcp_server_configuration_resource.ts
+++ b/front/lib/resources/agent_mcp_server_configuration_resource.ts
@@ -46,7 +46,7 @@ export class AgentMCPServerConfigurationResource extends BaseResource<AgentMCPSe
     return configs.map((c) => new this(this.model, c.get()));
   }
 
-  static async fetchBySIds(
+  static async fetchByIds(
     auth: Authenticator,
     sIds: string[]
   ): Promise<AgentMCPServerConfigurationResource[]> {

--- a/front/lib/resources/agent_mcp_server_configuration_resource.ts
+++ b/front/lib/resources/agent_mcp_server_configuration_resource.ts
@@ -46,6 +46,29 @@ export class AgentMCPServerConfigurationResource extends BaseResource<AgentMCPSe
     return configs.map((c) => new this(this.model, c.get()));
   }
 
+  static async fetchBySIds(
+    auth: Authenticator,
+    sIds: string[]
+  ): Promise<AgentMCPServerConfigurationResource[]> {
+    const workspaceId = auth.getNonNullableWorkspace().id;
+    const uniqueSIds = Array.from(new Set(sIds));
+
+    if (uniqueSIds.length === 0) {
+      return [];
+    }
+
+    const configs = await this.model.findAll({
+      where: {
+        workspaceId,
+        sId: {
+          [Op.in]: uniqueSIds,
+        },
+      },
+    });
+
+    return configs.map((c) => new this(this.model, c.get()));
+  }
+
   static async fetchById(
     auth: Authenticator,
     sId: string

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -1146,9 +1146,10 @@ export function useAgentDatasourceRetrievalDocuments({
     params.set("version", version);
   }
   if (mcpServerConfigIds) {
-    for (const mcpServerConfigId of new Set(mcpServerConfigIds)) {
-      params.append("mcpServerConfigId", mcpServerConfigId);
-    }
+    params.set(
+      "mcpServerConfigIds",
+      [...new Set(mcpServerConfigIds)].join(",")
+    );
   }
   if (dataSourceId) {
     params.set("dataSourceId", dataSourceId);

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -1121,7 +1121,7 @@ export function useAgentDatasourceRetrievalDocuments({
   agentConfigurationId,
   days = DEFAULT_PERIOD_DAYS,
   version,
-  mcpServerConfigId,
+  mcpServerConfigIds,
   dataSourceId,
   limit = 50,
   disabled,
@@ -1130,19 +1130,25 @@ export function useAgentDatasourceRetrievalDocuments({
   agentConfigurationId: string;
   days?: number;
   version?: string;
-  mcpServerConfigId: string | null;
+  mcpServerConfigIds: string[] | null;
   dataSourceId: string | null;
   limit?: number;
   disabled?: boolean;
 }) {
   const fetcherFn: Fetcher<GetDatasourceRetrievalDocumentsResponse> = fetcher;
-  const isDisabled = !!disabled || !mcpServerConfigId || !dataSourceId;
+  const isDisabled =
+    !!disabled ||
+    !mcpServerConfigIds ||
+    mcpServerConfigIds.length === 0 ||
+    !dataSourceId;
   const params = new URLSearchParams({ days: days.toString() });
   if (version) {
     params.set("version", version);
   }
-  if (mcpServerConfigId) {
-    params.set("mcpServerConfigId", mcpServerConfigId);
+  if (mcpServerConfigIds) {
+    for (const mcpServerConfigId of new Set(mcpServerConfigIds)) {
+      params.append("mcpServerConfigId", mcpServerConfigId);
+    }
   }
   if (dataSourceId) {
     params.set("dataSourceId", dataSourceId);

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/datasource-retrieval-documents.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/datasource-retrieval-documents.ts
@@ -15,9 +15,10 @@ import { isString } from "@app/types";
 const QuerySchema = z.object({
   days: z.coerce.number().positive().default(DEFAULT_PERIOD_DAYS),
   version: z.string().optional(),
-  mcpServerConfigId: z
-    .union([z.string().min(1), z.array(z.string().min(1))])
-    .transform((val) => (Array.isArray(val) ? val : [val])),
+  mcpServerConfigIds: z
+    .string()
+    .min(1)
+    .transform((val) => val.split(",")),
   dataSourceId: z.string().min(1),
   limit: z.coerce.number().positive().max(200).default(50),
 });
@@ -81,13 +82,7 @@ async function handler(
         });
       }
 
-      const {
-        days,
-        version,
-        mcpServerConfigId: mcpServerConfigIds,
-        dataSourceId,
-        limit,
-      } = q.data;
+      const { days, version, mcpServerConfigIds, dataSourceId, limit } = q.data;
 
       const documentsResult = await fetchDatasourceRetrievalDocumentsMetrics(
         auth,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/datasource-retrieval-documents.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/datasource-retrieval-documents.ts
@@ -15,7 +15,9 @@ import { isString } from "@app/types";
 const QuerySchema = z.object({
   days: z.coerce.number().positive().default(DEFAULT_PERIOD_DAYS),
   version: z.string().optional(),
-  mcpServerConfigId: z.string().min(1),
+  mcpServerConfigId: z
+    .union([z.string().min(1), z.array(z.string().min(1))])
+    .transform((val) => (Array.isArray(val) ? val : [val])),
   dataSourceId: z.string().min(1),
   limit: z.coerce.number().positive().max(200).default(50),
 });
@@ -79,7 +81,13 @@ async function handler(
         });
       }
 
-      const { days, version, mcpServerConfigId, dataSourceId, limit } = q.data;
+      const {
+        days,
+        version,
+        mcpServerConfigId: mcpServerConfigIds,
+        dataSourceId,
+        limit,
+      } = q.data;
 
       const documentsResult = await fetchDatasourceRetrievalDocumentsMetrics(
         auth,
@@ -87,7 +95,7 @@ async function handler(
           agentId: assistant.sId,
           days,
           version,
-          mcpServerConfigId,
+          mcpServerConfigIds,
           dataSourceId,
           limit,
         }


### PR DESCRIPTION
## Description

This change updates the treemap chart aggregation logic to group datasource retrievals by tool display name rather than individual MCP server configuration IDs. When multiple MCP server configurations have the same display name (e.g., when a search is deleted and recreated with the same name), they are now aggregated together in the visualization. The backend now groups metrics by `mcpServerDisplayName`, tracking all associated `mcpServerConfigIds` as an array.

## Risk

Low - the feature is behind the `agent_tool_outputs_analytics` flag.

## Tests

- [x] Locally
- [x] Front-edge

## Deploy Plan

Deploy front