### PR TITLE
Copilot: add MCP method to update suggestion state

### DIFF
--- a/front/lib/api/actions/servers/agent_copilot_context/agent_copilot_context.test.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/agent_copilot_context.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it, vi } from "vitest";
 
 import type { Authenticator } from "@app/lib/auth";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
-import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
 import { AgentSuggestionFactory } from "@app/tests/utils/AgentSuggestionFactory";
+import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
 import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
@@ -831,7 +831,7 @@ describe("agent_copilot_context tools", () => {
       const tool = getToolByName("update_suggestions_state");
       const result = await tool.handler(
         {
-          suggestions: [{ suggestionId: "non-existent-id", state: "approved" }],
+          suggestions: [{ suggestionId: "non-existent-id", state: "rejected" }],
         },
         createTestExtra(authenticator)
       );
@@ -849,11 +849,7 @@ describe("agent_copilot_context tools", () => {
       }
     });
 
-    it.each([
-      { state: "approved" as const },
-      { state: "rejected" as const },
-      { state: "outdated" as const },
-    ])(
+    it.each([{ state: "rejected" as const }, { state: "outdated" as const }])(
       "updates suggestion state to $state and returns all fields",
       async ({ state }) => {
         const { authenticator } = await createResourceTest({ role: "admin" });

--- a/front/lib/api/actions/servers/agent_copilot_context/agent_copilot_context.test.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/agent_copilot_context.test.ts
@@ -881,14 +881,6 @@ describe("agent_copilot_context tools", () => {
             const parsed = JSON.parse(content.text);
             expect(parsed.results).toHaveLength(1);
             expect(parsed.results[0].success).toBe(true);
-            expect(parsed.results[0].suggestion.sId).toBe(suggestion.sId);
-            expect(parsed.results[0].suggestion.kind).toBe("skills");
-            expect(parsed.results[0].suggestion.state).toBe(state);
-            expect(parsed.results[0].suggestion.analysis).toBe(
-              "Test analysis for skills"
-            );
-            expect(parsed.results[0].suggestion.createdAt).toBeDefined();
-            expect(parsed.results[0].suggestion.updatedAt).toBeDefined();
           }
         }
       }
@@ -932,11 +924,8 @@ describe("agent_copilot_context tools", () => {
 
           expect(parsed.results[0].success).toBe(true);
           expect(parsed.results[0].suggestionId).toBe(suggestion1.sId);
-          expect(parsed.results[0].suggestion.state).toBe("outdated");
-
           expect(parsed.results[1].success).toBe(true);
           expect(parsed.results[1].suggestionId).toBe(suggestion2.sId);
-          expect(parsed.results[1].suggestion.state).toBe("outdated");
         }
       }
     });

--- a/front/lib/api/actions/servers/agent_copilot_context/metadata.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/metadata.ts
@@ -231,7 +231,7 @@ export const AGENT_COPILOT_CONTEXT_TOOLS_METADATA = createToolsRecord({
   },
   update_suggestions_state: {
     description:
-      "Update the state of one or more suggestions. Use this to approve, reject, or mark suggestions as outdated.",
+      "Update the state of one or more suggestions. Use this to reject or mark suggestions as outdated.",
     schema: {
       suggestions: z
         .array(
@@ -240,9 +240,9 @@ export const AGENT_COPILOT_CONTEXT_TOOLS_METADATA = createToolsRecord({
               .string()
               .describe("The sId of the suggestion to update"),
             state: z
-              .enum(["approved", "rejected", "outdated"])
+              .enum(["rejected", "outdated"])
               .describe(
-                "The new state for the suggestion. Cannot be set to 'pending'."
+                "The new state for the suggestion: 'rejected' or 'outdated'."
               ),
           })
         )

--- a/front/lib/api/actions/servers/agent_copilot_context/metadata.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/metadata.ts
@@ -229,6 +229,27 @@ export const AGENT_COPILOT_CONTEXT_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
   },
+  update_suggestions_state: {
+    description:
+      "Update the state of one or more suggestions. Use this to approve, reject, or mark suggestions as outdated.",
+    schema: {
+      suggestions: z
+        .array(
+          z.object({
+            suggestionId: z
+              .string()
+              .describe("The sId of the suggestion to update"),
+            state: z
+              .enum(["approved", "rejected", "outdated"])
+              .describe(
+                "The new state for the suggestion. Cannot be set to 'pending'."
+              ),
+          })
+        )
+        .describe("Array of suggestions to update with their new states"),
+    },
+    stake: "never_ask",
+  },
 });
 
 export const AGENT_COPILOT_CONTEXT_SERVER = {

--- a/front/lib/api/actions/servers/agent_copilot_context/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/tools/index.ts
@@ -866,5 +866,4 @@ function getCategoryDisplayName(category: DataSourceViewCategory): string {
   }
 }
 
-
 export const TOOLS = buildTools(AGENT_COPILOT_CONTEXT_TOOLS_METADATA, handlers);

--- a/front/lib/api/actions/servers/agent_copilot_context/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/tools/index.ts
@@ -22,7 +22,6 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { DataSourceViewCategory, SpaceType } from "@app/types";
 import { removeNulls } from "@app/types";
-import type { AgentSuggestionType } from "@app/types";
 import {
   Err,
   isModelProviderId,
@@ -797,7 +796,6 @@ const handlers: ToolHandlers<typeof AGENT_COPILOT_CONTEXT_TOOLS_METADATA> = {
     const results: {
       success: boolean;
       suggestionId: string;
-      suggestion?: AgentSuggestionType;
       error?: string;
     }[] = [];
 
@@ -833,7 +831,6 @@ const handlers: ToolHandlers<typeof AGENT_COPILOT_CONTEXT_TOOLS_METADATA> = {
         results.push({
           success: true,
           suggestionId,
-          suggestion: suggestion.toJSON(),
         });
       } catch (error) {
         results.push({


### PR DESCRIPTION
## Description

Closes https://github.com/dust-tt/tasks/issues/6102

Add a new method to update suggestion state.
I slightly changed from the design to support updating multiple suggestions at once. I think it is a use case if someone tell the model "accept all" or if the model wants to mark all previous suggestion as outdated

## Tests

unit tests

## Risk

low, feature flag

## Deploy Plan
deploy front
