### PR TITLE
[front] Batch fetch MCP server views for global agents

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/anthropic.ts
+++ b/front/lib/api/assistant/global_agents/configurations/anthropic.ts
@@ -3,13 +3,13 @@ import {
   globalAgentGuidelines,
   globalAgentWebSearchGuidelines,
 } from "@app/lib/api/assistant/global_agents/guidelines";
+import type { MCPServerViewsForGlobalAgentsMap } from "@app/lib/api/assistant/global_agents/tools";
 import {
   _getDefaultWebActionsForGlobalAgent,
   _getInteractiveContentToolConfiguration,
 } from "@app/lib/api/assistant/global_agents/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";
-import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import type { AgentConfigurationType } from "@app/types";
 import {
   CLAUDE_3_5_SONNET_DEFAULT_MODEL_CONFIG,
@@ -33,12 +33,10 @@ import {
 
 export function _getClaude3HaikuGlobalAgent({
   settings,
-  webSearchBrowseMCPServerView,
-  interactiveContentMCPServerView,
+  mcpServerViews,
 }: {
   settings: GlobalAgentSettingsModel | null;
-  webSearchBrowseMCPServerView: MCPServerViewResource | null;
-  interactiveContentMCPServerView: MCPServerViewResource | null;
+  mcpServerViews: MCPServerViewsForGlobalAgentsMap;
 }): AgentConfigurationType {
   const status = settings ? settings.status : "disabled_by_admin";
 
@@ -68,11 +66,11 @@ export function _getClaude3HaikuGlobalAgent({
     actions: [
       ..._getDefaultWebActionsForGlobalAgent({
         agentId: sId,
-        webSearchBrowseMCPServerView,
+        webSearchBrowseMCPServerView: mcpServerViews["web_search_&_browse"],
       }),
       ..._getInteractiveContentToolConfiguration({
         agentId: sId,
-        interactiveContentMCPServerView,
+        interactiveContentMCPServerView: mcpServerViews.interactive_content,
       }),
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
@@ -88,13 +86,11 @@ export function _getClaude3HaikuGlobalAgent({
 export function _getClaude3OpusGlobalAgent({
   auth,
   settings,
-  webSearchBrowseMCPServerView,
-  interactiveContentMCPServerView,
+  mcpServerViews,
 }: {
   auth: Authenticator;
   settings: GlobalAgentSettingsModel | null;
-  webSearchBrowseMCPServerView: MCPServerViewResource | null;
-  interactiveContentMCPServerView: MCPServerViewResource | null;
+  mcpServerViews: MCPServerViewsForGlobalAgentsMap;
 }): AgentConfigurationType {
   let status = settings?.status ?? "active";
   if (!auth.isUpgraded()) {
@@ -127,11 +123,11 @@ export function _getClaude3OpusGlobalAgent({
     actions: [
       ..._getDefaultWebActionsForGlobalAgent({
         agentId: sId,
-        webSearchBrowseMCPServerView,
+        webSearchBrowseMCPServerView: mcpServerViews["web_search_&_browse"],
       }),
       ..._getInteractiveContentToolConfiguration({
         agentId: sId,
-        interactiveContentMCPServerView,
+        interactiveContentMCPServerView: mcpServerViews.interactive_content,
       }),
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
@@ -147,13 +143,11 @@ export function _getClaude3OpusGlobalAgent({
 export function _getClaude3GlobalAgent({
   auth,
   settings,
-  webSearchBrowseMCPServerView,
-  interactiveContentMCPServerView,
+  mcpServerViews,
 }: {
   auth: Authenticator;
   settings: GlobalAgentSettingsModel | null;
-  webSearchBrowseMCPServerView: MCPServerViewResource | null;
-  interactiveContentMCPServerView: MCPServerViewResource | null;
+  mcpServerViews: MCPServerViewsForGlobalAgentsMap;
 }): AgentConfigurationType {
   let status = settings?.status ?? "active";
   if (!auth.isUpgraded()) {
@@ -186,11 +180,11 @@ export function _getClaude3GlobalAgent({
     actions: [
       ..._getDefaultWebActionsForGlobalAgent({
         agentId: sId,
-        webSearchBrowseMCPServerView,
+        webSearchBrowseMCPServerView: mcpServerViews["web_search_&_browse"],
       }),
       ..._getInteractiveContentToolConfiguration({
         agentId: sId,
-        interactiveContentMCPServerView,
+        interactiveContentMCPServerView: mcpServerViews.interactive_content,
       }),
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
@@ -206,13 +200,11 @@ export function _getClaude3GlobalAgent({
 export function _getClaude4SonnetGlobalAgent({
   auth,
   settings,
-  webSearchBrowseMCPServerView,
-  interactiveContentMCPServerView,
+  mcpServerViews,
 }: {
   auth: Authenticator;
   settings: GlobalAgentSettingsModel | null;
-  webSearchBrowseMCPServerView: MCPServerViewResource | null;
-  interactiveContentMCPServerView: MCPServerViewResource | null;
+  mcpServerViews: MCPServerViewsForGlobalAgentsMap;
 }): AgentConfigurationType {
   let status = settings?.status ?? "active";
   if (!auth.isUpgraded()) {
@@ -245,11 +237,11 @@ export function _getClaude4SonnetGlobalAgent({
     actions: [
       ..._getDefaultWebActionsForGlobalAgent({
         agentId: sId,
-        webSearchBrowseMCPServerView,
+        webSearchBrowseMCPServerView: mcpServerViews["web_search_&_browse"],
       }),
       ..._getInteractiveContentToolConfiguration({
         agentId: sId,
-        interactiveContentMCPServerView,
+        interactiveContentMCPServerView: mcpServerViews.interactive_content,
       }),
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
@@ -265,13 +257,11 @@ export function _getClaude4SonnetGlobalAgent({
 export function _getClaude3_7GlobalAgent({
   auth,
   settings,
-  webSearchBrowseMCPServerView,
-  interactiveContentMCPServerView,
+  mcpServerViews,
 }: {
   auth: Authenticator;
   settings: GlobalAgentSettingsModel | null;
-  webSearchBrowseMCPServerView: MCPServerViewResource | null;
-  interactiveContentMCPServerView: MCPServerViewResource | null;
+  mcpServerViews: MCPServerViewsForGlobalAgentsMap;
 }): AgentConfigurationType {
   let status = settings?.status ?? "active";
   if (!auth.isUpgraded()) {
@@ -304,11 +294,11 @@ export function _getClaude3_7GlobalAgent({
     actions: [
       ..._getDefaultWebActionsForGlobalAgent({
         agentId: sId,
-        webSearchBrowseMCPServerView,
+        webSearchBrowseMCPServerView: mcpServerViews["web_search_&_browse"],
       }),
       ..._getInteractiveContentToolConfiguration({
         agentId: sId,
-        interactiveContentMCPServerView,
+        interactiveContentMCPServerView: mcpServerViews.interactive_content,
       }),
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
@@ -324,13 +314,11 @@ export function _getClaude3_7GlobalAgent({
 export function _getClaude4_5SonnetGlobalAgent({
   auth,
   settings,
-  webSearchBrowseMCPServerView,
-  interactiveContentMCPServerView,
+  mcpServerViews,
 }: {
   auth: Authenticator;
   settings: GlobalAgentSettingsModel | null;
-  webSearchBrowseMCPServerView: MCPServerViewResource | null;
-  interactiveContentMCPServerView: MCPServerViewResource | null;
+  mcpServerViews: MCPServerViewsForGlobalAgentsMap;
 }): AgentConfigurationType {
   let status = settings?.status ?? "active";
   if (!auth.isUpgraded()) {
@@ -363,11 +351,11 @@ export function _getClaude4_5SonnetGlobalAgent({
     actions: [
       ..._getDefaultWebActionsForGlobalAgent({
         agentId: sId,
-        webSearchBrowseMCPServerView,
+        webSearchBrowseMCPServerView: mcpServerViews["web_search_&_browse"],
       }),
       ..._getInteractiveContentToolConfiguration({
         agentId: sId,
-        interactiveContentMCPServerView,
+        interactiveContentMCPServerView: mcpServerViews.interactive_content,
       }),
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
@@ -384,13 +372,11 @@ export function _getClaude4_5SonnetGlobalAgent({
 export function _getClaude4_5HaikuGlobalAgent({
   auth,
   settings,
-  webSearchBrowseMCPServerView,
-  interactiveContentMCPServerView,
+  mcpServerViews,
 }: {
   auth: Authenticator;
   settings: GlobalAgentSettingsModel | null;
-  webSearchBrowseMCPServerView: MCPServerViewResource | null;
-  interactiveContentMCPServerView: MCPServerViewResource | null;
+  mcpServerViews: MCPServerViewsForGlobalAgentsMap;
 }): AgentConfigurationType {
   let status = settings?.status ?? "active";
   if (!auth.isUpgraded()) {
@@ -423,11 +409,11 @@ export function _getClaude4_5HaikuGlobalAgent({
     actions: [
       ..._getDefaultWebActionsForGlobalAgent({
         agentId: sId,
-        webSearchBrowseMCPServerView,
+        webSearchBrowseMCPServerView: mcpServerViews["web_search_&_browse"],
       }),
       ..._getInteractiveContentToolConfiguration({
         agentId: sId,
-        interactiveContentMCPServerView,
+        interactiveContentMCPServerView: mcpServerViews.interactive_content,
       }),
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,

--- a/front/lib/api/assistant/global_agents/configurations/anthropic.ts
+++ b/front/lib/api/assistant/global_agents/configurations/anthropic.ts
@@ -66,11 +66,11 @@ export function _getClaude3HaikuGlobalAgent({
     actions: [
       ..._getDefaultWebActionsForGlobalAgent({
         agentId: sId,
-        webSearchBrowseMCPServerView: mcpServerViews["web_search_&_browse"],
+        mcpServerViews,
       }),
       ..._getInteractiveContentToolConfiguration({
         agentId: sId,
-        interactiveContentMCPServerView: mcpServerViews.interactive_content,
+        mcpServerViews,
       }),
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
@@ -123,11 +123,11 @@ export function _getClaude3OpusGlobalAgent({
     actions: [
       ..._getDefaultWebActionsForGlobalAgent({
         agentId: sId,
-        webSearchBrowseMCPServerView: mcpServerViews["web_search_&_browse"],
+        mcpServerViews,
       }),
       ..._getInteractiveContentToolConfiguration({
         agentId: sId,
-        interactiveContentMCPServerView: mcpServerViews.interactive_content,
+        mcpServerViews,
       }),
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
@@ -180,11 +180,11 @@ export function _getClaude3GlobalAgent({
     actions: [
       ..._getDefaultWebActionsForGlobalAgent({
         agentId: sId,
-        webSearchBrowseMCPServerView: mcpServerViews["web_search_&_browse"],
+        mcpServerViews,
       }),
       ..._getInteractiveContentToolConfiguration({
         agentId: sId,
-        interactiveContentMCPServerView: mcpServerViews.interactive_content,
+        mcpServerViews,
       }),
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
@@ -237,11 +237,11 @@ export function _getClaude4SonnetGlobalAgent({
     actions: [
       ..._getDefaultWebActionsForGlobalAgent({
         agentId: sId,
-        webSearchBrowseMCPServerView: mcpServerViews["web_search_&_browse"],
+        mcpServerViews,
       }),
       ..._getInteractiveContentToolConfiguration({
         agentId: sId,
-        interactiveContentMCPServerView: mcpServerViews.interactive_content,
+        mcpServerViews,
       }),
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
@@ -294,11 +294,11 @@ export function _getClaude3_7GlobalAgent({
     actions: [
       ..._getDefaultWebActionsForGlobalAgent({
         agentId: sId,
-        webSearchBrowseMCPServerView: mcpServerViews["web_search_&_browse"],
+        mcpServerViews,
       }),
       ..._getInteractiveContentToolConfiguration({
         agentId: sId,
-        interactiveContentMCPServerView: mcpServerViews.interactive_content,
+        mcpServerViews,
       }),
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
@@ -351,11 +351,11 @@ export function _getClaude4_5SonnetGlobalAgent({
     actions: [
       ..._getDefaultWebActionsForGlobalAgent({
         agentId: sId,
-        webSearchBrowseMCPServerView: mcpServerViews["web_search_&_browse"],
+        mcpServerViews,
       }),
       ..._getInteractiveContentToolConfiguration({
         agentId: sId,
-        interactiveContentMCPServerView: mcpServerViews.interactive_content,
+        mcpServerViews,
       }),
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
@@ -409,11 +409,11 @@ export function _getClaude4_5HaikuGlobalAgent({
     actions: [
       ..._getDefaultWebActionsForGlobalAgent({
         agentId: sId,
-        webSearchBrowseMCPServerView: mcpServerViews["web_search_&_browse"],
+        mcpServerViews,
       }),
       ..._getInteractiveContentToolConfiguration({
         agentId: sId,
-        interactiveContentMCPServerView: mcpServerViews.interactive_content,
+        mcpServerViews,
       }),
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,

--- a/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
@@ -447,7 +447,7 @@ export function _getDeepDiveGlobalAgent(
     mcpServerViews: MCPServerViewsForGlobalAgentsMap;
   }
 ): AgentConfigurationType | null {
-  const runAgentMCPServerView = mcpServerViews.run_agent;
+  const { run_agent: runAgentMCPServerView } = mcpServerViews;
   const owner = auth.getNonNullableWorkspace();
   const pictureUrl = DUST_AVATAR_URL;
   const modelConfig = getModelConfig(owner, "anthropic");
@@ -498,7 +498,7 @@ export function _getDeepDiveGlobalAgent(
 
   const companyDataAction = getCompanyDataAction(
     preFetchedDataSources,
-    mcpServerViews.data_sources_file_system
+    mcpServerViews
   );
   if (companyDataAction) {
     actions.push(companyDataAction);
@@ -507,25 +507,27 @@ export function _getDeepDiveGlobalAgent(
   actions.push(
     ..._getDefaultWebActionsForGlobalAgent({
       agentId: GLOBAL_AGENTS_SID.DEEP_DIVE,
-      webSearchBrowseMCPServerView: mcpServerViews["web_search_&_browse"],
+      mcpServerViews,
     }),
     ..._getToolsetsToolsConfiguration({
       agentId: GLOBAL_AGENTS_SID.DUST_TASK,
-      toolsetsMcpServerView: mcpServerViews.toolsets,
+      mcpServerViews,
     })
   );
 
   // Add data warehouses tool with all warehouses in global space (all remote DBs)
   const dataWarehousesAction = getCompanyDataWarehousesAction(
     preFetchedDataSources,
-    mcpServerViews.data_warehouses
+    mcpServerViews
   );
   if (dataWarehousesAction) {
     actions.push(dataWarehousesAction);
   }
 
   // Add Interactive Content tool.
-  const interactiveContentMCPServerView = mcpServerViews.interactive_content;
+  const { interactive_content: interactiveContentMCPServerView } =
+    mcpServerViews;
+
   if (interactiveContentMCPServerView) {
     actions.push({
       id: -1,
@@ -586,7 +588,7 @@ export function _getDeepDiveGlobalAgent(
   }
 
   // Add Slideshow tool.
-  const slideshowMCPServerView = mcpServerViews.slideshow;
+  const { slideshow: slideshowMCPServerView } = mcpServerViews;
   if (slideshowMCPServerView) {
     actions.push({
       id: -1,
@@ -692,13 +694,14 @@ export function _getDustTaskGlobalAgent(
 
   const companyDataAction = getCompanyDataAction(
     preFetchedDataSources,
-    mcpServerViews.data_sources_file_system
+    mcpServerViews
   );
   if (companyDataAction) {
     actions.push(companyDataAction);
   }
 
-  const webSearchBrowseMCPServerView = mcpServerViews["web_search_&_browse"];
+  const { "web_search_&_browse": webSearchBrowseMCPServerView } =
+    mcpServerViews;
   if (webSearchBrowseMCPServerView) {
     actions.push({
       id: -1,
@@ -723,7 +726,7 @@ export function _getDustTaskGlobalAgent(
 
   const dataWarehousesAction = getCompanyDataWarehousesAction(
     preFetchedDataSources,
-    mcpServerViews.data_warehouses
+    mcpServerViews
   );
   if (dataWarehousesAction) {
     actions.push(dataWarehousesAction);

--- a/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
@@ -10,7 +10,10 @@ import {
   getCompanyDataAction,
   getCompanyDataWarehousesAction,
 } from "@app/lib/api/assistant/global_agents/configurations/dust/shared";
-import type { PrefetchedDataSourcesType } from "@app/lib/api/assistant/global_agents/tools";
+import type {
+  MCPServerViewsForGlobalAgentsMap,
+  PrefetchedDataSourcesType,
+} from "@app/lib/api/assistant/global_agents/tools";
 import {
   _getDefaultWebActionsForGlobalAgent,
   _getToolsetsToolsConfiguration,
@@ -18,7 +21,6 @@ import {
 import { dummyModelConfiguration } from "@app/lib/api/assistant/global_agents/utils";
 import type { Authenticator } from "@app/lib/auth";
 import type { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";
-import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import type {
   AgentConfigurationType,
   AgentModelConfigurationType,
@@ -438,25 +440,14 @@ export function _getDeepDiveGlobalAgent(
   {
     settings,
     preFetchedDataSources,
-    webSearchBrowseMCPServerView,
-    dataSourcesFileSystemMCPServerView,
-    interactiveContentMCPServerView,
-    runAgentMCPServerView,
-    dataWarehousesMCPServerView,
-    toolsetsMCPServerView,
-    slideshowMCPServerView,
+    mcpServerViews,
   }: {
     settings: GlobalAgentSettingsModel | null;
     preFetchedDataSources: PrefetchedDataSourcesType | null;
-    webSearchBrowseMCPServerView: MCPServerViewResource | null;
-    dataSourcesFileSystemMCPServerView: MCPServerViewResource | null;
-    interactiveContentMCPServerView: MCPServerViewResource | null;
-    runAgentMCPServerView: MCPServerViewResource | null;
-    dataWarehousesMCPServerView: MCPServerViewResource | null;
-    toolsetsMCPServerView: MCPServerViewResource | null;
-    slideshowMCPServerView: MCPServerViewResource | null;
+    mcpServerViews: MCPServerViewsForGlobalAgentsMap;
   }
 ): AgentConfigurationType | null {
+  const runAgentMCPServerView = mcpServerViews.run_agent;
   const owner = auth.getNonNullableWorkspace();
   const pictureUrl = DUST_AVATAR_URL;
   const modelConfig = getModelConfig(owner, "anthropic");
@@ -507,7 +498,7 @@ export function _getDeepDiveGlobalAgent(
 
   const companyDataAction = getCompanyDataAction(
     preFetchedDataSources,
-    dataSourcesFileSystemMCPServerView
+    mcpServerViews.data_sources_file_system
   );
   if (companyDataAction) {
     actions.push(companyDataAction);
@@ -516,24 +507,25 @@ export function _getDeepDiveGlobalAgent(
   actions.push(
     ..._getDefaultWebActionsForGlobalAgent({
       agentId: GLOBAL_AGENTS_SID.DEEP_DIVE,
-      webSearchBrowseMCPServerView,
+      webSearchBrowseMCPServerView: mcpServerViews["web_search_&_browse"],
     }),
     ..._getToolsetsToolsConfiguration({
       agentId: GLOBAL_AGENTS_SID.DUST_TASK,
-      toolsetsMcpServerView: toolsetsMCPServerView,
+      toolsetsMcpServerView: mcpServerViews.toolsets,
     })
   );
 
   // Add data warehouses tool with all warehouses in global space (all remote DBs)
   const dataWarehousesAction = getCompanyDataWarehousesAction(
     preFetchedDataSources,
-    dataWarehousesMCPServerView
+    mcpServerViews.data_warehouses
   );
   if (dataWarehousesAction) {
     actions.push(dataWarehousesAction);
   }
 
   // Add Interactive Content tool.
+  const interactiveContentMCPServerView = mcpServerViews.interactive_content;
   if (interactiveContentMCPServerView) {
     actions.push({
       id: -1,
@@ -594,6 +586,7 @@ export function _getDeepDiveGlobalAgent(
   }
 
   // Add Slideshow tool.
+  const slideshowMCPServerView = mcpServerViews.slideshow;
   if (slideshowMCPServerView) {
     actions.push({
       id: -1,
@@ -636,15 +629,11 @@ export function _getDustTaskGlobalAgent(
   {
     settings,
     preFetchedDataSources,
-    webSearchBrowseMCPServerView,
-    dataSourcesFileSystemMCPServerView,
-    dataWarehousesMCPServerView,
+    mcpServerViews,
   }: {
     settings: GlobalAgentSettingsModel | null;
     preFetchedDataSources: PrefetchedDataSourcesType | null;
-    webSearchBrowseMCPServerView: MCPServerViewResource | null;
-    dataSourcesFileSystemMCPServerView: MCPServerViewResource | null;
-    dataWarehousesMCPServerView: MCPServerViewResource | null;
+    mcpServerViews: MCPServerViewsForGlobalAgentsMap;
   }
 ): AgentConfigurationType | null {
   const owner = auth.getNonNullableWorkspace();
@@ -703,12 +692,13 @@ export function _getDustTaskGlobalAgent(
 
   const companyDataAction = getCompanyDataAction(
     preFetchedDataSources,
-    dataSourcesFileSystemMCPServerView
+    mcpServerViews.data_sources_file_system
   );
   if (companyDataAction) {
     actions.push(companyDataAction);
   }
 
+  const webSearchBrowseMCPServerView = mcpServerViews["web_search_&_browse"];
   if (webSearchBrowseMCPServerView) {
     actions.push({
       id: -1,
@@ -733,7 +723,7 @@ export function _getDustTaskGlobalAgent(
 
   const dataWarehousesAction = getCompanyDataWarehousesAction(
     preFetchedDataSources,
-    dataWarehousesMCPServerView
+    mcpServerViews.data_warehouses
   );
   if (dataWarehousesAction) {
     actions.push(dataWarehousesAction);

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -13,7 +13,10 @@ import {
   getCompanyDataWarehousesAction,
 } from "@app/lib/api/assistant/global_agents/configurations/dust/shared";
 import { globalAgentGuidelines } from "@app/lib/api/assistant/global_agents/guidelines";
-import type { PrefetchedDataSourcesType } from "@app/lib/api/assistant/global_agents/tools";
+import type {
+  MCPServerViewsForGlobalAgentsMap,
+  PrefetchedDataSourcesType,
+} from "@app/lib/api/assistant/global_agents/tools";
 import {
   _getAgentRouterToolsConfiguration,
   _getDefaultWebActionsForGlobalAgent,
@@ -284,28 +287,13 @@ function _getDustLikeGlobalAgent(
   {
     settings,
     preFetchedDataSources,
-    agentRouterMCPServerView,
-    webSearchBrowseMCPServerView,
-    dataSourcesFileSystemMCPServerView,
-    toolsetsMCPServerView,
-    deepDiveMCPServerView,
-    interactiveContentMCPServerView,
-    dataWarehousesMCPServerView,
-
-    agentMemoryMCPServerView,
+    mcpServerViews,
     memories,
     availableToolsets,
   }: {
     settings: GlobalAgentSettingsModel | null;
     preFetchedDataSources: PrefetchedDataSourcesType | null;
-    agentRouterMCPServerView: MCPServerViewResource | null;
-    webSearchBrowseMCPServerView: MCPServerViewResource | null;
-    dataSourcesFileSystemMCPServerView: MCPServerViewResource | null;
-    toolsetsMCPServerView: MCPServerViewResource | null;
-    deepDiveMCPServerView: MCPServerViewResource | null;
-    interactiveContentMCPServerView: MCPServerViewResource | null;
-    dataWarehousesMCPServerView: MCPServerViewResource | null;
-    agentMemoryMCPServerView: MCPServerViewResource | null;
+    mcpServerViews: MCPServerViewsForGlobalAgentsMap;
     memories: AgentMemoryResource[];
     availableToolsets: MCPServerViewResource[];
   },
@@ -321,6 +309,12 @@ function _getDustLikeGlobalAgent(
     preferredReasoningEffort?: ReasoningEffort;
   }
 ): AgentConfigurationType | null {
+  const webSearchBrowseMCPServerView = mcpServerViews["web_search_&_browse"];
+  const dataSourcesFileSystemMCPServerView =
+    mcpServerViews.data_sources_file_system;
+  const toolsetsMCPServerView = mcpServerViews.toolsets;
+  const deepDiveMCPServerView = mcpServerViews.deep_dive;
+  const agentMemoryMCPServerView = mcpServerViews.agent_memory;
   const owner = auth.getNonNullableWorkspace();
 
   const description = `Dust is your general purpose agent. It has access to all of your company data and tools available in the Company space. Dust can help you:
@@ -379,7 +373,7 @@ function _getDustLikeGlobalAgent(
 
   const dataWarehousesAction = getCompanyDataWarehousesAction(
     preFetchedDataSources,
-    dataWarehousesMCPServerView
+    mcpServerViews.data_warehouses
   );
 
   const instructions = buildInstructions({
@@ -468,7 +462,7 @@ function _getDustLikeGlobalAgent(
     }),
     ..._getAgentRouterToolsConfiguration(
       agentId,
-      agentRouterMCPServerView,
+      mcpServerViews.agent_router,
       autoInternalMCPServerNameToSId({
         name: "agent_router",
         workspaceId: owner.id,
@@ -519,7 +513,7 @@ function _getDustLikeGlobalAgent(
   actions.push(
     ..._getInteractiveContentToolConfiguration({
       agentId,
-      interactiveContentMCPServerView,
+      interactiveContentMCPServerView: mcpServerViews.interactive_content,
     })
   );
 
@@ -541,14 +535,7 @@ export function _getDustGlobalAgent(
   args: {
     settings: GlobalAgentSettingsModel | null;
     preFetchedDataSources: PrefetchedDataSourcesType | null;
-    agentRouterMCPServerView: MCPServerViewResource | null;
-    webSearchBrowseMCPServerView: MCPServerViewResource | null;
-    dataSourcesFileSystemMCPServerView: MCPServerViewResource | null;
-    toolsetsMCPServerView: MCPServerViewResource | null;
-    deepDiveMCPServerView: MCPServerViewResource | null;
-    interactiveContentMCPServerView: MCPServerViewResource | null;
-    dataWarehousesMCPServerView: MCPServerViewResource | null;
-    agentMemoryMCPServerView: MCPServerViewResource | null;
+    mcpServerViews: MCPServerViewsForGlobalAgentsMap;
     memories: AgentMemoryResource[];
     availableToolsets: MCPServerViewResource[];
   }
@@ -565,14 +552,7 @@ export function _getDustEdgeGlobalAgent(
   args: {
     settings: GlobalAgentSettingsModel | null;
     preFetchedDataSources: PrefetchedDataSourcesType | null;
-    agentRouterMCPServerView: MCPServerViewResource | null;
-    webSearchBrowseMCPServerView: MCPServerViewResource | null;
-    dataSourcesFileSystemMCPServerView: MCPServerViewResource | null;
-    toolsetsMCPServerView: MCPServerViewResource | null;
-    deepDiveMCPServerView: MCPServerViewResource | null;
-    interactiveContentMCPServerView: MCPServerViewResource | null;
-    dataWarehousesMCPServerView: MCPServerViewResource | null;
-    agentMemoryMCPServerView: MCPServerViewResource | null;
+    mcpServerViews: MCPServerViewsForGlobalAgentsMap;
     memories: AgentMemoryResource[];
     availableToolsets: MCPServerViewResource[];
   }
@@ -590,14 +570,7 @@ export function _getDustQuickGlobalAgent(
   args: {
     settings: GlobalAgentSettingsModel | null;
     preFetchedDataSources: PrefetchedDataSourcesType | null;
-    agentRouterMCPServerView: MCPServerViewResource | null;
-    webSearchBrowseMCPServerView: MCPServerViewResource | null;
-    dataSourcesFileSystemMCPServerView: MCPServerViewResource | null;
-    toolsetsMCPServerView: MCPServerViewResource | null;
-    deepDiveMCPServerView: MCPServerViewResource | null;
-    interactiveContentMCPServerView: MCPServerViewResource | null;
-    dataWarehousesMCPServerView: MCPServerViewResource | null;
-    agentMemoryMCPServerView: MCPServerViewResource | null;
+    mcpServerViews: MCPServerViewsForGlobalAgentsMap;
     memories: AgentMemoryResource[];
     availableToolsets: MCPServerViewResource[];
   }
@@ -615,14 +588,7 @@ export function _getDustOaiGlobalAgent(
   args: {
     settings: GlobalAgentSettingsModel | null;
     preFetchedDataSources: PrefetchedDataSourcesType | null;
-    agentRouterMCPServerView: MCPServerViewResource | null;
-    webSearchBrowseMCPServerView: MCPServerViewResource | null;
-    dataSourcesFileSystemMCPServerView: MCPServerViewResource | null;
-    toolsetsMCPServerView: MCPServerViewResource | null;
-    deepDiveMCPServerView: MCPServerViewResource | null;
-    interactiveContentMCPServerView: MCPServerViewResource | null;
-    dataWarehousesMCPServerView: MCPServerViewResource | null;
-    agentMemoryMCPServerView: MCPServerViewResource | null;
+    mcpServerViews: MCPServerViewsForGlobalAgentsMap;
     memories: AgentMemoryResource[];
     availableToolsets: MCPServerViewResource[];
   }

--- a/front/lib/api/assistant/global_agents/configurations/dust/shared.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/shared.ts
@@ -1,6 +1,8 @@
 import type { MCPServerConfigurationType } from "@app/lib/actions/mcp";
-import type { MCPServerViewsForGlobalAgentsMap } from "@app/lib/api/assistant/global_agents/tools";
-import { PrefetchedDataSourcesType } from "@app/lib/api/assistant/global_agents/tools";
+import type {
+  MCPServerViewsForGlobalAgentsMap,
+  PrefetchedDataSourcesType,
+} from "@app/lib/api/assistant/global_agents/tools";
 import {
   isIncludedInDefaultCompanyData,
   isRemoteDatabase,

--- a/front/lib/api/assistant/global_agents/configurations/dust/shared.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/shared.ts
@@ -1,5 +1,8 @@
 import type { MCPServerConfigurationType } from "@app/lib/actions/mcp";
-import type { PrefetchedDataSourcesType } from "@app/lib/api/assistant/global_agents/tools";
+import {
+  MCPServerViewsForGlobalAgentsMap,
+  PrefetchedDataSourcesType,
+} from "@app/lib/api/assistant/global_agents/tools";
 import {
   isIncludedInDefaultCompanyData,
   isRemoteDatabase,
@@ -9,9 +12,12 @@ import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 
 export function getCompanyDataAction(
   preFetchedDataSources: PrefetchedDataSourcesType | null,
-  dataSourcesFileSystemMCPServerView: MCPServerViewResource | null
+  mcpServerViews: MCPServerViewsForGlobalAgentsMap
 ): MCPServerConfigurationType | null {
-  if (!preFetchedDataSources) {
+  const { data_sources_file_system: dataSourcesFileSystemMCPServerView } =
+    mcpServerViews;
+
+  if (!preFetchedDataSources || !dataSourcesFileSystemMCPServerView) {
     return null;
   }
 
@@ -20,7 +26,7 @@ export function getCompanyDataAction(
       dsView.isInGlobalSpace &&
       isIncludedInDefaultCompanyData(dsView.dataSource)
   );
-  if (dataSourceViews.length === 0 || !dataSourcesFileSystemMCPServerView) {
+  if (dataSourceViews.length === 0) {
     return null;
   }
 
@@ -55,9 +61,11 @@ export function getCompanyDataAction(
 
 export function getCompanyDataWarehousesAction(
   preFetchedDataSources: PrefetchedDataSourcesType | null,
-  dataWarehousesMCPServerView: MCPServerViewResource | null
+  mcpServerViews: MCPServerViewsForGlobalAgentsMap
 ): MCPServerConfigurationType | null {
-  if (!preFetchedDataSources) {
+  const { data_warehouses: dataWarehousesMCPServerView } = mcpServerViews;
+
+  if (!preFetchedDataSources || !dataWarehousesMCPServerView) {
     return null;
   }
 
@@ -65,7 +73,7 @@ export function getCompanyDataWarehousesAction(
     (dsView) => dsView.isInGlobalSpace && isRemoteDatabase(dsView.dataSource)
   );
 
-  if (globalWarehouses.length === 0 || !dataWarehousesMCPServerView) {
+  if (globalWarehouses.length === 0) {
     return null;
   }
 

--- a/front/lib/api/assistant/global_agents/configurations/dust/shared.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/shared.ts
@@ -1,8 +1,6 @@
 import type { MCPServerConfigurationType } from "@app/lib/actions/mcp";
-import {
-  MCPServerViewsForGlobalAgentsMap,
-  PrefetchedDataSourcesType,
-} from "@app/lib/api/assistant/global_agents/tools";
+import type { MCPServerViewsForGlobalAgentsMap } from "@app/lib/api/assistant/global_agents/tools";
+import { PrefetchedDataSourcesType } from "@app/lib/api/assistant/global_agents/tools";
 import {
   isIncludedInDefaultCompanyData,
   isRemoteDatabase,

--- a/front/lib/api/assistant/global_agents/configurations/dust/shared.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/shared.ts
@@ -7,7 +7,6 @@ import {
   isIncludedInDefaultCompanyData,
   isRemoteDatabase,
 } from "@app/lib/data_sources";
-import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 
 export function getCompanyDataAction(

--- a/front/lib/api/assistant/global_agents/configurations/google.ts
+++ b/front/lib/api/assistant/global_agents/configurations/google.ts
@@ -56,11 +56,11 @@ export function _getGeminiProGlobalAgent({
     actions: [
       ..._getDefaultWebActionsForGlobalAgent({
         agentId: sId,
-        webSearchBrowseMCPServerView: mcpServerViews["web_search_&_browse"],
+        mcpServerViews,
       }),
       ..._getInteractiveContentToolConfiguration({
         agentId: sId,
-        interactiveContentMCPServerView: mcpServerViews.interactive_content,
+        mcpServerViews,
       }),
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,

--- a/front/lib/api/assistant/global_agents/configurations/google.ts
+++ b/front/lib/api/assistant/global_agents/configurations/google.ts
@@ -3,13 +3,13 @@ import {
   globalAgentGuidelines,
   globalAgentWebSearchGuidelines,
 } from "@app/lib/api/assistant/global_agents/guidelines";
+import type { MCPServerViewsForGlobalAgentsMap } from "@app/lib/api/assistant/global_agents/tools";
 import {
   _getDefaultWebActionsForGlobalAgent,
   _getInteractiveContentToolConfiguration,
 } from "@app/lib/api/assistant/global_agents/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";
-import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import type { AgentConfigurationType } from "@app/types";
 import {
   GEMINI_3_PRO_MODEL_CONFIG,
@@ -20,13 +20,11 @@ import {
 export function _getGeminiProGlobalAgent({
   auth,
   settings,
-  webSearchBrowseMCPServerView,
-  interactiveContentMCPServerView,
+  mcpServerViews,
 }: {
   auth: Authenticator;
   settings: GlobalAgentSettingsModel | null;
-  webSearchBrowseMCPServerView: MCPServerViewResource | null;
-  interactiveContentMCPServerView: MCPServerViewResource | null;
+  mcpServerViews: MCPServerViewsForGlobalAgentsMap;
 }): AgentConfigurationType {
   let status = settings?.status ?? "active";
   if (!auth.isUpgraded()) {
@@ -58,11 +56,11 @@ export function _getGeminiProGlobalAgent({
     actions: [
       ..._getDefaultWebActionsForGlobalAgent({
         agentId: sId,
-        webSearchBrowseMCPServerView,
+        webSearchBrowseMCPServerView: mcpServerViews["web_search_&_browse"],
       }),
       ..._getInteractiveContentToolConfiguration({
         agentId: sId,
-        interactiveContentMCPServerView,
+        interactiveContentMCPServerView: mcpServerViews.interactive_content,
       }),
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,

--- a/front/lib/api/assistant/global_agents/configurations/helper.ts
+++ b/front/lib/api/assistant/global_agents/configurations/helper.ts
@@ -1,5 +1,4 @@
 import type { MCPServerConfigurationType } from "@app/lib/actions/mcp";
-import { autoInternalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
 import { getGlobalAgentMetadata } from "@app/lib/api/assistant/global_agents/global_agent_metadata";
 import { globalAgentGuidelines } from "@app/lib/api/assistant/global_agents/guidelines";
 import type { MCPServerViewsForGlobalAgentsMap } from "@app/lib/api/assistant/global_agents/tools";
@@ -81,31 +80,21 @@ The user you're interacting with is granted with the role ${role}. Their name is
 
   const actions: MCPServerConfigurationType[] = [];
 
-  actions.push(
-    ..._getDefaultWebActionsForGlobalAgent({
-      agentId: GLOBAL_AGENTS_SID.HELPER,
-      webSearchBrowseMCPServerView: mcpServerViews["web_search_&_browse"],
-    })
-  );
-
-  actions.push(
-    ..._getAgentRouterToolsConfiguration(
-      GLOBAL_AGENTS_SID.HELPER,
-      mcpServerViews.agent_router,
-      autoInternalMCPServerNameToSId({
-        name: "agent_router",
-        workspaceId: owner.id,
-      })
-    )
-  );
-
   const sId = GLOBAL_AGENTS_SID.HELPER;
   const metadata = getGlobalAgentMetadata(sId);
 
   actions.push(
+    ..._getDefaultWebActionsForGlobalAgent({
+      agentId: sId,
+      mcpServerViews,
+    }),
+    ..._getAgentRouterToolsConfiguration({
+      agentId: sId,
+      mcpServerViews,
+    }),
     ..._getInteractiveContentToolConfiguration({
       agentId: sId,
-      interactiveContentMCPServerView: mcpServerViews.interactive_content,
+      mcpServerViews,
     })
   );
 

--- a/front/lib/api/assistant/global_agents/configurations/helper.ts
+++ b/front/lib/api/assistant/global_agents/configurations/helper.ts
@@ -2,6 +2,7 @@ import type { MCPServerConfigurationType } from "@app/lib/actions/mcp";
 import { autoInternalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
 import { getGlobalAgentMetadata } from "@app/lib/api/assistant/global_agents/global_agent_metadata";
 import { globalAgentGuidelines } from "@app/lib/api/assistant/global_agents/guidelines";
+import type { MCPServerViewsForGlobalAgentsMap } from "@app/lib/api/assistant/global_agents/tools";
 import {
   _getAgentRouterToolsConfiguration,
   _getDefaultWebActionsForGlobalAgent,
@@ -9,7 +10,6 @@ import {
 } from "@app/lib/api/assistant/global_agents/tools";
 import { dummyModelConfiguration } from "@app/lib/api/assistant/global_agents/utils";
 import type { Authenticator } from "@app/lib/auth";
-import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import type {
   AgentConfigurationType,
   AgentModelConfigurationType,
@@ -23,14 +23,10 @@ import {
 
 export function _getHelperGlobalAgent({
   auth,
-  agentRouterMCPServerView,
-  webSearchBrowseMCPServerView,
-  interactiveContentMCPServerView,
+  mcpServerViews,
 }: {
   auth: Authenticator;
-  agentRouterMCPServerView: MCPServerViewResource | null;
-  webSearchBrowseMCPServerView: MCPServerViewResource | null;
-  interactiveContentMCPServerView: MCPServerViewResource | null;
+  mcpServerViews: MCPServerViewsForGlobalAgentsMap;
 }): AgentConfigurationType {
   let prompt = `<primary_goal>
 You are a customer success AI agent called @help designed by Dust and embedded in the platform. Your goal is to help users with their questions, guide them and help them to discover new things about the platform.
@@ -88,14 +84,14 @@ The user you're interacting with is granted with the role ${role}. Their name is
   actions.push(
     ..._getDefaultWebActionsForGlobalAgent({
       agentId: GLOBAL_AGENTS_SID.HELPER,
-      webSearchBrowseMCPServerView,
+      webSearchBrowseMCPServerView: mcpServerViews["web_search_&_browse"],
     })
   );
 
   actions.push(
     ..._getAgentRouterToolsConfiguration(
       GLOBAL_AGENTS_SID.HELPER,
-      agentRouterMCPServerView,
+      mcpServerViews.agent_router,
       autoInternalMCPServerNameToSId({
         name: "agent_router",
         workspaceId: owner.id,
@@ -109,7 +105,7 @@ The user you're interacting with is granted with the role ${role}. Their name is
   actions.push(
     ..._getInteractiveContentToolConfiguration({
       agentId: sId,
-      interactiveContentMCPServerView,
+      interactiveContentMCPServerView: mcpServerViews.interactive_content,
     })
   );
 

--- a/front/lib/api/assistant/global_agents/configurations/helper.ts
+++ b/front/lib/api/assistant/global_agents/configurations/helper.ts
@@ -78,12 +78,10 @@ The user you're interacting with is granted with the role ${role}. Their name is
     : dummyModelConfiguration;
   const status = modelConfiguration ? "active" : "disabled_by_admin";
 
-  const actions: MCPServerConfigurationType[] = [];
-
   const sId = GLOBAL_AGENTS_SID.HELPER;
   const metadata = getGlobalAgentMetadata(sId);
 
-  actions.push(
+  const actions: MCPServerConfigurationType[] = [
     ..._getDefaultWebActionsForGlobalAgent({
       agentId: sId,
       mcpServerViews,
@@ -95,8 +93,8 @@ The user you're interacting with is granted with the role ${role}. Their name is
     ..._getInteractiveContentToolConfiguration({
       agentId: sId,
       mcpServerViews,
-    })
-  );
+    }),
+  ];
 
   return {
     id: -1,

--- a/front/lib/api/assistant/global_agents/configurations/mistral.ts
+++ b/front/lib/api/assistant/global_agents/configurations/mistral.ts
@@ -3,13 +3,13 @@ import {
   globalAgentGuidelines,
   globalAgentWebSearchGuidelines,
 } from "@app/lib/api/assistant/global_agents/guidelines";
+import type { MCPServerViewsForGlobalAgentsMap } from "@app/lib/api/assistant/global_agents/tools";
 import {
   _getDefaultWebActionsForGlobalAgent,
   _getInteractiveContentToolConfiguration,
 } from "@app/lib/api/assistant/global_agents/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";
-import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import type { AgentConfigurationType } from "@app/types";
 import {
   GLOBAL_AGENTS_SID,
@@ -30,13 +30,11 @@ import {
 export function _getMistralLargeGlobalAgent({
   auth,
   settings,
-  webSearchBrowseMCPServerView,
-  interactiveContentMCPServerView,
+  mcpServerViews,
 }: {
   auth: Authenticator;
   settings: GlobalAgentSettingsModel | null;
-  webSearchBrowseMCPServerView: MCPServerViewResource | null;
-  interactiveContentMCPServerView: MCPServerViewResource | null;
+  mcpServerViews: MCPServerViewsForGlobalAgentsMap;
 }): AgentConfigurationType {
   let status = settings?.status ?? "active";
   if (!auth.isUpgraded()) {
@@ -68,11 +66,11 @@ export function _getMistralLargeGlobalAgent({
     actions: [
       ..._getDefaultWebActionsForGlobalAgent({
         agentId: sId,
-        webSearchBrowseMCPServerView,
+        webSearchBrowseMCPServerView: mcpServerViews["web_search_&_browse"],
       }),
       ..._getInteractiveContentToolConfiguration({
         agentId: sId,
-        interactiveContentMCPServerView,
+        interactiveContentMCPServerView: mcpServerViews.interactive_content,
       }),
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
@@ -88,13 +86,11 @@ export function _getMistralLargeGlobalAgent({
 export function _getMistralMediumGlobalAgent({
   auth,
   settings,
-  webSearchBrowseMCPServerView,
-  interactiveContentMCPServerView,
+  mcpServerViews,
 }: {
   auth: Authenticator;
   settings: GlobalAgentSettingsModel | null;
-  webSearchBrowseMCPServerView: MCPServerViewResource | null;
-  interactiveContentMCPServerView: MCPServerViewResource | null;
+  mcpServerViews: MCPServerViewsForGlobalAgentsMap;
 }): AgentConfigurationType {
   let status = settings?.status ?? "disabled_by_admin";
   if (!auth.isUpgraded()) {
@@ -126,11 +122,11 @@ export function _getMistralMediumGlobalAgent({
     actions: [
       ..._getDefaultWebActionsForGlobalAgent({
         agentId: sId,
-        webSearchBrowseMCPServerView,
+        webSearchBrowseMCPServerView: mcpServerViews["web_search_&_browse"],
       }),
       ..._getInteractiveContentToolConfiguration({
         agentId: sId,
-        interactiveContentMCPServerView,
+        interactiveContentMCPServerView: mcpServerViews.interactive_content,
       }),
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
@@ -145,12 +141,10 @@ export function _getMistralMediumGlobalAgent({
 
 export function _getMistralSmallGlobalAgent({
   settings,
-  webSearchBrowseMCPServerView,
-  interactiveContentMCPServerView,
+  mcpServerViews,
 }: {
   settings: GlobalAgentSettingsModel | null;
-  webSearchBrowseMCPServerView: MCPServerViewResource | null;
-  interactiveContentMCPServerView: MCPServerViewResource | null;
+  mcpServerViews: MCPServerViewsForGlobalAgentsMap;
 }): AgentConfigurationType {
   const status = settings ? settings.status : "disabled_by_admin";
 
@@ -179,11 +173,11 @@ export function _getMistralSmallGlobalAgent({
     actions: [
       ..._getDefaultWebActionsForGlobalAgent({
         agentId: sId,
-        webSearchBrowseMCPServerView,
+        webSearchBrowseMCPServerView: mcpServerViews["web_search_&_browse"],
       }),
       ..._getInteractiveContentToolConfiguration({
         agentId: sId,
-        interactiveContentMCPServerView,
+        interactiveContentMCPServerView: mcpServerViews.interactive_content,
       }),
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,

--- a/front/lib/api/assistant/global_agents/configurations/mistral.ts
+++ b/front/lib/api/assistant/global_agents/configurations/mistral.ts
@@ -66,11 +66,11 @@ export function _getMistralLargeGlobalAgent({
     actions: [
       ..._getDefaultWebActionsForGlobalAgent({
         agentId: sId,
-        webSearchBrowseMCPServerView: mcpServerViews["web_search_&_browse"],
+        mcpServerViews,
       }),
       ..._getInteractiveContentToolConfiguration({
         agentId: sId,
-        interactiveContentMCPServerView: mcpServerViews.interactive_content,
+        mcpServerViews,
       }),
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
@@ -122,11 +122,11 @@ export function _getMistralMediumGlobalAgent({
     actions: [
       ..._getDefaultWebActionsForGlobalAgent({
         agentId: sId,
-        webSearchBrowseMCPServerView: mcpServerViews["web_search_&_browse"],
+        mcpServerViews,
       }),
       ..._getInteractiveContentToolConfiguration({
         agentId: sId,
-        interactiveContentMCPServerView: mcpServerViews.interactive_content,
+        mcpServerViews,
       }),
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
@@ -173,11 +173,11 @@ export function _getMistralSmallGlobalAgent({
     actions: [
       ..._getDefaultWebActionsForGlobalAgent({
         agentId: sId,
-        webSearchBrowseMCPServerView: mcpServerViews["web_search_&_browse"],
+        mcpServerViews,
       }),
       ..._getInteractiveContentToolConfiguration({
         agentId: sId,
-        interactiveContentMCPServerView: mcpServerViews.interactive_content,
+        mcpServerViews,
       }),
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,

--- a/front/lib/api/assistant/global_agents/configurations/openai.ts
+++ b/front/lib/api/assistant/global_agents/configurations/openai.ts
@@ -3,13 +3,13 @@ import {
   globalAgentGuidelines,
   globalAgentWebSearchGuidelines,
 } from "@app/lib/api/assistant/global_agents/guidelines";
+import type { MCPServerViewsForGlobalAgentsMap } from "@app/lib/api/assistant/global_agents/tools";
 import {
   _getDefaultWebActionsForGlobalAgent,
   _getInteractiveContentToolConfiguration,
 } from "@app/lib/api/assistant/global_agents/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";
-import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import type {
   AgentConfigurationStatus,
   AgentConfigurationType,
@@ -37,12 +37,10 @@ import {
 
 export function _getGPT35TurboGlobalAgent({
   settings,
-  webSearchBrowseMCPServerView,
-  interactiveContentMCPServerView,
+  mcpServerViews,
 }: {
   settings: GlobalAgentSettingsModel | null;
-  webSearchBrowseMCPServerView: MCPServerViewResource | null;
-  interactiveContentMCPServerView: MCPServerViewResource | null;
+  mcpServerViews: MCPServerViewsForGlobalAgentsMap;
 }): AgentConfigurationType {
   const status = settings ? settings.status : "active";
 
@@ -70,11 +68,11 @@ export function _getGPT35TurboGlobalAgent({
     actions: [
       ..._getDefaultWebActionsForGlobalAgent({
         agentId: sId,
-        webSearchBrowseMCPServerView,
+        webSearchBrowseMCPServerView: mcpServerViews["web_search_&_browse"],
       }),
       ..._getInteractiveContentToolConfiguration({
         agentId: sId,
-        interactiveContentMCPServerView,
+        interactiveContentMCPServerView: mcpServerViews.interactive_content,
       }),
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
@@ -90,13 +88,11 @@ export function _getGPT35TurboGlobalAgent({
 export function _getGPT4GlobalAgent({
   auth,
   settings,
-  webSearchBrowseMCPServerView,
-  interactiveContentMCPServerView,
+  mcpServerViews,
 }: {
   auth: Authenticator;
   settings: GlobalAgentSettingsModel | null;
-  webSearchBrowseMCPServerView: MCPServerViewResource | null;
-  interactiveContentMCPServerView: MCPServerViewResource | null;
+  mcpServerViews: MCPServerViewsForGlobalAgentsMap;
 }): AgentConfigurationType {
   let status: AgentConfigurationStatus = "active";
 
@@ -131,11 +127,11 @@ export function _getGPT4GlobalAgent({
     actions: [
       ..._getDefaultWebActionsForGlobalAgent({
         agentId: sId,
-        webSearchBrowseMCPServerView,
+        webSearchBrowseMCPServerView: mcpServerViews["web_search_&_browse"],
       }),
       ..._getInteractiveContentToolConfiguration({
         agentId: sId,
-        interactiveContentMCPServerView,
+        interactiveContentMCPServerView: mcpServerViews.interactive_content,
       }),
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
@@ -151,13 +147,11 @@ export function _getGPT4GlobalAgent({
 export function _getGPT5GlobalAgent({
   auth,
   settings,
-  webSearchBrowseMCPServerView,
-  interactiveContentMCPServerView,
+  mcpServerViews,
 }: {
   auth: Authenticator;
   settings: GlobalAgentSettingsModel | null;
-  webSearchBrowseMCPServerView: MCPServerViewResource | null;
-  interactiveContentMCPServerView: MCPServerViewResource | null;
+  mcpServerViews: MCPServerViewsForGlobalAgentsMap;
 }): AgentConfigurationType {
   let status: AgentConfigurationStatus = "active";
 
@@ -198,11 +192,11 @@ export function _getGPT5GlobalAgent({
     actions: [
       ..._getDefaultWebActionsForGlobalAgent({
         agentId: sId,
-        webSearchBrowseMCPServerView,
+        webSearchBrowseMCPServerView: mcpServerViews["web_search_&_browse"],
       }),
       ..._getInteractiveContentToolConfiguration({
         agentId: sId,
-        interactiveContentMCPServerView,
+        interactiveContentMCPServerView: mcpServerViews.interactive_content,
       }),
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
@@ -222,13 +216,11 @@ export function _getGPT5GlobalAgent({
 export function _getGPT5ThinkingGlobalAgent({
   auth,
   settings,
-  webSearchBrowseMCPServerView,
-  interactiveContentMCPServerView,
+  mcpServerViews,
 }: {
   auth: Authenticator;
   settings: GlobalAgentSettingsModel | null;
-  webSearchBrowseMCPServerView: MCPServerViewResource | null;
-  interactiveContentMCPServerView: MCPServerViewResource | null;
+  mcpServerViews: MCPServerViewsForGlobalAgentsMap;
 }): AgentConfigurationType {
   let status: AgentConfigurationStatus = "active";
 
@@ -267,11 +259,11 @@ export function _getGPT5ThinkingGlobalAgent({
     actions: [
       ..._getDefaultWebActionsForGlobalAgent({
         agentId: sId,
-        webSearchBrowseMCPServerView,
+        webSearchBrowseMCPServerView: mcpServerViews["web_search_&_browse"],
       }),
       ..._getInteractiveContentToolConfiguration({
         agentId: sId,
-        interactiveContentMCPServerView,
+        interactiveContentMCPServerView: mcpServerViews.interactive_content,
       }),
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
@@ -287,13 +279,11 @@ export function _getGPT5ThinkingGlobalAgent({
 export function _getGPT5MiniGlobalAgent({
   auth,
   settings,
-  webSearchBrowseMCPServerView,
-  interactiveContentMCPServerView,
+  mcpServerViews,
 }: {
   auth: Authenticator;
   settings: GlobalAgentSettingsModel | null;
-  webSearchBrowseMCPServerView: MCPServerViewResource | null;
-  interactiveContentMCPServerView: MCPServerViewResource | null;
+  mcpServerViews: MCPServerViewsForGlobalAgentsMap;
 }): AgentConfigurationType {
   let status: AgentConfigurationStatus = "active";
 
@@ -332,11 +322,11 @@ export function _getGPT5MiniGlobalAgent({
     actions: [
       ..._getDefaultWebActionsForGlobalAgent({
         agentId: sId,
-        webSearchBrowseMCPServerView,
+        webSearchBrowseMCPServerView: mcpServerViews["web_search_&_browse"],
       }),
       ..._getInteractiveContentToolConfiguration({
         agentId: sId,
-        interactiveContentMCPServerView,
+        interactiveContentMCPServerView: mcpServerViews.interactive_content,
       }),
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
@@ -351,13 +341,11 @@ export function _getGPT5MiniGlobalAgent({
 export function _getGPT5NanoGlobalAgent({
   auth,
   settings,
-  webSearchBrowseMCPServerView,
-  interactiveContentMCPServerView,
+  mcpServerViews,
 }: {
   auth: Authenticator;
   settings: GlobalAgentSettingsModel | null;
-  webSearchBrowseMCPServerView: MCPServerViewResource | null;
-  interactiveContentMCPServerView: MCPServerViewResource | null;
+  mcpServerViews: MCPServerViewsForGlobalAgentsMap;
 }): AgentConfigurationType {
   let status: AgentConfigurationStatus = "active";
 
@@ -396,11 +384,11 @@ export function _getGPT5NanoGlobalAgent({
     actions: [
       ..._getDefaultWebActionsForGlobalAgent({
         agentId: sId,
-        webSearchBrowseMCPServerView,
+        webSearchBrowseMCPServerView: mcpServerViews["web_search_&_browse"],
       }),
       ..._getInteractiveContentToolConfiguration({
         agentId: sId,
-        interactiveContentMCPServerView,
+        interactiveContentMCPServerView: mcpServerViews.interactive_content,
       }),
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
@@ -416,13 +404,11 @@ export function _getGPT5NanoGlobalAgent({
 export function _getO3MiniGlobalAgent({
   auth,
   settings,
-  webSearchBrowseMCPServerView,
-  interactiveContentMCPServerView,
+  mcpServerViews,
 }: {
   auth: Authenticator;
   settings: GlobalAgentSettingsModel | null;
-  webSearchBrowseMCPServerView: MCPServerViewResource | null;
-  interactiveContentMCPServerView: MCPServerViewResource | null;
+  mcpServerViews: MCPServerViewsForGlobalAgentsMap;
 }): AgentConfigurationType {
   let status: AgentConfigurationStatus = "active";
 
@@ -458,11 +444,11 @@ export function _getO3MiniGlobalAgent({
     actions: [
       ..._getDefaultWebActionsForGlobalAgent({
         agentId: sId,
-        webSearchBrowseMCPServerView,
+        webSearchBrowseMCPServerView: mcpServerViews["web_search_&_browse"],
       }),
       ..._getInteractiveContentToolConfiguration({
         agentId: sId,
-        interactiveContentMCPServerView,
+        interactiveContentMCPServerView: mcpServerViews.interactive_content,
       }),
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
@@ -478,13 +464,11 @@ export function _getO3MiniGlobalAgent({
 export function _getO1GlobalAgent({
   auth,
   settings,
-  webSearchBrowseMCPServerView,
-  interactiveContentMCPServerView,
+  mcpServerViews,
 }: {
   auth: Authenticator;
   settings: GlobalAgentSettingsModel | null;
-  webSearchBrowseMCPServerView: MCPServerViewResource | null;
-  interactiveContentMCPServerView: MCPServerViewResource | null;
+  mcpServerViews: MCPServerViewsForGlobalAgentsMap;
 }): AgentConfigurationType {
   let status = settings?.status ?? "active";
   if (!auth.isUpgraded()) {
@@ -515,11 +499,11 @@ export function _getO1GlobalAgent({
     actions: [
       ..._getDefaultWebActionsForGlobalAgent({
         agentId: sId,
-        webSearchBrowseMCPServerView,
+        webSearchBrowseMCPServerView: mcpServerViews["web_search_&_browse"],
       }),
       ..._getInteractiveContentToolConfiguration({
         agentId: sId,
-        interactiveContentMCPServerView,
+        interactiveContentMCPServerView: mcpServerViews.interactive_content,
       }),
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
@@ -579,13 +563,11 @@ export function _getO1MiniGlobalAgent({
 export function _getO1HighReasoningGlobalAgent({
   auth,
   settings,
-  webSearchBrowseMCPServerView,
-  interactiveContentMCPServerView,
+  mcpServerViews,
 }: {
   auth: Authenticator;
   settings: GlobalAgentSettingsModel | null;
-  webSearchBrowseMCPServerView: MCPServerViewResource | null;
-  interactiveContentMCPServerView: MCPServerViewResource | null;
+  mcpServerViews: MCPServerViewsForGlobalAgentsMap;
 }): AgentConfigurationType {
   let status = settings?.status ?? "active";
   if (!auth.isUpgraded()) {
@@ -617,11 +599,11 @@ export function _getO1HighReasoningGlobalAgent({
     actions: [
       ..._getDefaultWebActionsForGlobalAgent({
         agentId: sId,
-        webSearchBrowseMCPServerView,
+        webSearchBrowseMCPServerView: mcpServerViews["web_search_&_browse"],
       }),
       ..._getInteractiveContentToolConfiguration({
         agentId: sId,
-        interactiveContentMCPServerView,
+        interactiveContentMCPServerView: mcpServerViews.interactive_content,
       }),
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
@@ -637,13 +619,11 @@ export function _getO1HighReasoningGlobalAgent({
 export function _getO3GlobalAgent({
   auth,
   settings,
-  webSearchBrowseMCPServerView,
-  interactiveContentMCPServerView,
+  mcpServerViews,
 }: {
   auth: Authenticator;
   settings: GlobalAgentSettingsModel | null;
-  webSearchBrowseMCPServerView: MCPServerViewResource | null;
-  interactiveContentMCPServerView: MCPServerViewResource | null;
+  mcpServerViews: MCPServerViewsForGlobalAgentsMap;
 }): AgentConfigurationType {
   let status = settings?.status ?? "active";
   if (!auth.isUpgraded()) {
@@ -674,11 +654,11 @@ export function _getO3GlobalAgent({
     actions: [
       ..._getDefaultWebActionsForGlobalAgent({
         agentId: sId,
-        webSearchBrowseMCPServerView,
+        webSearchBrowseMCPServerView: mcpServerViews["web_search_&_browse"],
       }),
       ..._getInteractiveContentToolConfiguration({
         agentId: sId,
-        interactiveContentMCPServerView,
+        interactiveContentMCPServerView: mcpServerViews.interactive_content,
       }),
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,

--- a/front/lib/api/assistant/global_agents/configurations/openai.ts
+++ b/front/lib/api/assistant/global_agents/configurations/openai.ts
@@ -68,11 +68,11 @@ export function _getGPT35TurboGlobalAgent({
     actions: [
       ..._getDefaultWebActionsForGlobalAgent({
         agentId: sId,
-        webSearchBrowseMCPServerView: mcpServerViews["web_search_&_browse"],
+        mcpServerViews,
       }),
       ..._getInteractiveContentToolConfiguration({
         agentId: sId,
-        interactiveContentMCPServerView: mcpServerViews.interactive_content,
+        mcpServerViews,
       }),
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
@@ -127,11 +127,11 @@ export function _getGPT4GlobalAgent({
     actions: [
       ..._getDefaultWebActionsForGlobalAgent({
         agentId: sId,
-        webSearchBrowseMCPServerView: mcpServerViews["web_search_&_browse"],
+        mcpServerViews,
       }),
       ..._getInteractiveContentToolConfiguration({
         agentId: sId,
-        interactiveContentMCPServerView: mcpServerViews.interactive_content,
+        mcpServerViews,
       }),
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
@@ -192,11 +192,11 @@ export function _getGPT5GlobalAgent({
     actions: [
       ..._getDefaultWebActionsForGlobalAgent({
         agentId: sId,
-        webSearchBrowseMCPServerView: mcpServerViews["web_search_&_browse"],
+        mcpServerViews,
       }),
       ..._getInteractiveContentToolConfiguration({
         agentId: sId,
-        interactiveContentMCPServerView: mcpServerViews.interactive_content,
+        mcpServerViews,
       }),
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
@@ -259,11 +259,11 @@ export function _getGPT5ThinkingGlobalAgent({
     actions: [
       ..._getDefaultWebActionsForGlobalAgent({
         agentId: sId,
-        webSearchBrowseMCPServerView: mcpServerViews["web_search_&_browse"],
+        mcpServerViews,
       }),
       ..._getInteractiveContentToolConfiguration({
         agentId: sId,
-        interactiveContentMCPServerView: mcpServerViews.interactive_content,
+        mcpServerViews,
       }),
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
@@ -322,11 +322,11 @@ export function _getGPT5MiniGlobalAgent({
     actions: [
       ..._getDefaultWebActionsForGlobalAgent({
         agentId: sId,
-        webSearchBrowseMCPServerView: mcpServerViews["web_search_&_browse"],
+        mcpServerViews,
       }),
       ..._getInteractiveContentToolConfiguration({
         agentId: sId,
-        interactiveContentMCPServerView: mcpServerViews.interactive_content,
+        mcpServerViews,
       }),
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
@@ -384,11 +384,11 @@ export function _getGPT5NanoGlobalAgent({
     actions: [
       ..._getDefaultWebActionsForGlobalAgent({
         agentId: sId,
-        webSearchBrowseMCPServerView: mcpServerViews["web_search_&_browse"],
+        mcpServerViews,
       }),
       ..._getInteractiveContentToolConfiguration({
         agentId: sId,
-        interactiveContentMCPServerView: mcpServerViews.interactive_content,
+        mcpServerViews,
       }),
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
@@ -444,11 +444,11 @@ export function _getO3MiniGlobalAgent({
     actions: [
       ..._getDefaultWebActionsForGlobalAgent({
         agentId: sId,
-        webSearchBrowseMCPServerView: mcpServerViews["web_search_&_browse"],
+        mcpServerViews,
       }),
       ..._getInteractiveContentToolConfiguration({
         agentId: sId,
-        interactiveContentMCPServerView: mcpServerViews.interactive_content,
+        mcpServerViews,
       }),
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
@@ -499,11 +499,11 @@ export function _getO1GlobalAgent({
     actions: [
       ..._getDefaultWebActionsForGlobalAgent({
         agentId: sId,
-        webSearchBrowseMCPServerView: mcpServerViews["web_search_&_browse"],
+        mcpServerViews,
       }),
       ..._getInteractiveContentToolConfiguration({
         agentId: sId,
-        interactiveContentMCPServerView: mcpServerViews.interactive_content,
+        mcpServerViews,
       }),
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
@@ -599,11 +599,11 @@ export function _getO1HighReasoningGlobalAgent({
     actions: [
       ..._getDefaultWebActionsForGlobalAgent({
         agentId: sId,
-        webSearchBrowseMCPServerView: mcpServerViews["web_search_&_browse"],
+        mcpServerViews,
       }),
       ..._getInteractiveContentToolConfiguration({
         agentId: sId,
-        interactiveContentMCPServerView: mcpServerViews.interactive_content,
+        mcpServerViews,
       }),
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
@@ -654,11 +654,11 @@ export function _getO3GlobalAgent({
     actions: [
       ..._getDefaultWebActionsForGlobalAgent({
         agentId: sId,
-        webSearchBrowseMCPServerView: mcpServerViews["web_search_&_browse"],
+        mcpServerViews,
       }),
       ..._getInteractiveContentToolConfiguration({
         agentId: sId,
-        interactiveContentMCPServerView: mcpServerViews.interactive_content,
+        mcpServerViews,
       }),
     ],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,

--- a/front/lib/api/assistant/global_agents/configurations/retired_managed.ts
+++ b/front/lib/api/assistant/global_agents/configurations/retired_managed.ts
@@ -1,7 +1,10 @@
 import type { MCPServerConfigurationType } from "@app/lib/actions/mcp";
 import { getGlobalAgentMetadata } from "@app/lib/api/assistant/global_agents/global_agent_metadata";
 import { BREVITY_PROMPT } from "@app/lib/api/assistant/global_agents/guidelines";
-import type { PrefetchedDataSourcesType } from "@app/lib/api/assistant/global_agents/tools";
+import type {
+  MCPServerViewsForGlobalAgentsMap,
+  PrefetchedDataSourcesType,
+} from "@app/lib/api/assistant/global_agents/tools";
 import { dummyModelConfiguration } from "@app/lib/api/assistant/global_agents/utils";
 import type { Authenticator } from "@app/lib/auth";
 import type { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";
@@ -151,11 +154,11 @@ export function _getGoogleDriveGlobalAgent(
   {
     settings,
     preFetchedDataSources,
-    searchMCPServerView,
+    mcpServerViews,
   }: {
     settings: GlobalAgentSettingsModel | null;
     preFetchedDataSources: PrefetchedDataSourcesType | null;
-    searchMCPServerView: MCPServerViewResource | null;
+    mcpServerViews: MCPServerViewsForGlobalAgentsMap;
   }
 ): AgentConfigurationType | null {
   const agentId = GLOBAL_AGENTS_SID.GOOGLE_DRIVE;
@@ -172,7 +175,7 @@ export function _getGoogleDriveGlobalAgent(
       "Assist the user based on the retrieved data from their Google Drives." +
       `\n${BREVITY_PROMPT}`,
     preFetchedDataSources,
-    searchMCPServerView,
+    searchMCPServerView: mcpServerViews.search,
   });
 }
 
@@ -181,11 +184,11 @@ export function _getSlackGlobalAgent(
   {
     settings,
     preFetchedDataSources,
-    searchMCPServerView,
+    mcpServerViews,
   }: {
     settings: GlobalAgentSettingsModel | null;
     preFetchedDataSources: PrefetchedDataSourcesType | null;
-    searchMCPServerView: MCPServerViewResource | null;
+    mcpServerViews: MCPServerViewsForGlobalAgentsMap;
   }
 ) {
   const agentId = GLOBAL_AGENTS_SID.SLACK;
@@ -202,7 +205,7 @@ export function _getSlackGlobalAgent(
       "Assist the user based on the retrieved data from their Slack channels." +
       `\n${BREVITY_PROMPT}`,
     preFetchedDataSources,
-    searchMCPServerView,
+    searchMCPServerView: mcpServerViews.search,
   });
 }
 
@@ -211,11 +214,11 @@ export function _getGithubGlobalAgent(
   {
     settings,
     preFetchedDataSources,
-    searchMCPServerView,
+    mcpServerViews,
   }: {
     settings: GlobalAgentSettingsModel | null;
     preFetchedDataSources: PrefetchedDataSourcesType | null;
-    searchMCPServerView: MCPServerViewResource | null;
+    mcpServerViews: MCPServerViewsForGlobalAgentsMap;
   }
 ) {
   const agentId = GLOBAL_AGENTS_SID.GITHUB;
@@ -232,7 +235,7 @@ export function _getGithubGlobalAgent(
       "Assist the user based on the retrieved data from their Github Issues and Discussions." +
       `\n${BREVITY_PROMPT}`,
     preFetchedDataSources,
-    searchMCPServerView,
+    searchMCPServerView: mcpServerViews.search,
   });
 }
 
@@ -241,11 +244,11 @@ export function _getNotionGlobalAgent(
   {
     settings,
     preFetchedDataSources,
-    searchMCPServerView,
+    mcpServerViews,
   }: {
     settings: GlobalAgentSettingsModel | null;
     preFetchedDataSources: PrefetchedDataSourcesType | null;
-    searchMCPServerView: MCPServerViewResource | null;
+    mcpServerViews: MCPServerViewsForGlobalAgentsMap;
   }
 ) {
   const agentId = GLOBAL_AGENTS_SID.NOTION;
@@ -262,7 +265,7 @@ export function _getNotionGlobalAgent(
       "Assist the user based on the retrieved data from their Notion Spaces." +
       `\n${BREVITY_PROMPT}`,
     preFetchedDataSources,
-    searchMCPServerView,
+    searchMCPServerView: mcpServerViews.search,
   });
 }
 
@@ -271,11 +274,11 @@ export function _getIntercomGlobalAgent(
   {
     settings,
     preFetchedDataSources,
-    searchMCPServerView,
+    mcpServerViews,
   }: {
     settings: GlobalAgentSettingsModel | null;
     preFetchedDataSources: PrefetchedDataSourcesType | null;
-    searchMCPServerView: MCPServerViewResource | null;
+    mcpServerViews: MCPServerViewsForGlobalAgentsMap;
   }
 ) {
   const agentId = GLOBAL_AGENTS_SID.INTERCOM;
@@ -292,6 +295,6 @@ export function _getIntercomGlobalAgent(
       "Assist the user based on the retrieved data from their Intercom Workspace." +
       `\n${BREVITY_PROMPT}`,
     preFetchedDataSources,
-    searchMCPServerView,
+    searchMCPServerView: mcpServerViews.search,
   });
 }

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -147,21 +147,6 @@ function getGlobalAgent({
   } | null;
   copilotUserMetadata: CopilotUserMetadata | null;
 }): AgentConfigurationType | null {
-  const agentRouterMCPServerView = mcpServerViews.get("agent_router") ?? null;
-  const webSearchBrowseMCPServerView =
-    mcpServerViews.get("web_search_&_browse") ?? null;
-  const searchMCPServerView = mcpServerViews.get("search") ?? null;
-  const dataSourcesFileSystemMCPServerView =
-    mcpServerViews.get("data_sources_file_system") ?? null;
-  const interactiveContentMCPServerView =
-    mcpServerViews.get("interactive_content") ?? null;
-  const runAgentMCPServerView = mcpServerViews.get("run_agent") ?? null;
-  const toolsetsMCPServerView = mcpServerViews.get("toolsets") ?? null;
-  const dataWarehousesMCPServerView =
-    mcpServerViews.get("data_warehouses") ?? null;
-  const slideshowMCPServerView = mcpServerViews.get("slideshow") ?? null;
-  const deepDiveMCPServerView = mcpServerViews.get("deep_dive") ?? null;
-  const agentMemoryMCPServerView = mcpServerViews.get("agent_memory") ?? null;
   const settings =
     globalAgentSettings.find((settings) => settings.agentId === sId) ?? null;
 
@@ -169,66 +154,54 @@ function getGlobalAgent({
 
   switch (sId) {
     case GLOBAL_AGENTS_SID.HELPER:
-      agentConfiguration = _getHelperGlobalAgent({
-        auth,
-        agentRouterMCPServerView,
-        webSearchBrowseMCPServerView,
-        interactiveContentMCPServerView,
-      });
+      agentConfiguration = _getHelperGlobalAgent({ auth, mcpServerViews });
       break;
     case GLOBAL_AGENTS_SID.GPT35_TURBO:
       agentConfiguration = _getGPT35TurboGlobalAgent({
         settings,
-        webSearchBrowseMCPServerView,
-        interactiveContentMCPServerView,
+        mcpServerViews,
       });
       break;
     case GLOBAL_AGENTS_SID.GPT4:
       agentConfiguration = _getGPT4GlobalAgent({
         auth,
         settings,
-        webSearchBrowseMCPServerView,
-        interactiveContentMCPServerView,
+        mcpServerViews,
       });
       break;
     case GLOBAL_AGENTS_SID.GPT5:
       agentConfiguration = _getGPT5GlobalAgent({
         auth,
         settings,
-        webSearchBrowseMCPServerView,
-        interactiveContentMCPServerView,
+        mcpServerViews,
       });
       break;
     case GLOBAL_AGENTS_SID.GPT5_NANO:
       agentConfiguration = _getGPT5NanoGlobalAgent({
         auth,
         settings,
-        webSearchBrowseMCPServerView,
-        interactiveContentMCPServerView,
+        mcpServerViews,
       });
       break;
     case GLOBAL_AGENTS_SID.GPT5_MINI:
       agentConfiguration = _getGPT5MiniGlobalAgent({
         auth,
         settings,
-        webSearchBrowseMCPServerView,
-        interactiveContentMCPServerView,
+        mcpServerViews,
       });
       break;
     case GLOBAL_AGENTS_SID.GPT5_THINKING:
       agentConfiguration = _getGPT5ThinkingGlobalAgent({
         auth,
         settings,
-        webSearchBrowseMCPServerView,
-        interactiveContentMCPServerView,
+        mcpServerViews,
       });
       break;
     case GLOBAL_AGENTS_SID.O1:
       agentConfiguration = _getO1GlobalAgent({
         auth,
         settings,
-        webSearchBrowseMCPServerView,
-        interactiveContentMCPServerView,
+        mcpServerViews,
       });
       break;
     case GLOBAL_AGENTS_SID.O1_MINI:
@@ -238,110 +211,96 @@ function getGlobalAgent({
       agentConfiguration = _getO1HighReasoningGlobalAgent({
         auth,
         settings,
-        webSearchBrowseMCPServerView,
-        interactiveContentMCPServerView,
+        mcpServerViews,
       });
       break;
     case GLOBAL_AGENTS_SID.O3_MINI:
       agentConfiguration = _getO3MiniGlobalAgent({
         auth,
         settings,
-        webSearchBrowseMCPServerView,
-        interactiveContentMCPServerView,
+        mcpServerViews,
       });
       break;
     case GLOBAL_AGENTS_SID.O3:
       agentConfiguration = _getO3GlobalAgent({
         auth,
         settings,
-        webSearchBrowseMCPServerView,
-        interactiveContentMCPServerView,
+        mcpServerViews,
       });
       break;
     case GLOBAL_AGENTS_SID.CLAUDE_4_5_SONNET:
       agentConfiguration = _getClaude4_5SonnetGlobalAgent({
         auth,
         settings,
-        webSearchBrowseMCPServerView,
-        interactiveContentMCPServerView,
+        mcpServerViews,
       });
       break;
     case GLOBAL_AGENTS_SID.CLAUDE_4_5_HAIKU:
       agentConfiguration = _getClaude4_5HaikuGlobalAgent({
         auth,
         settings,
-        webSearchBrowseMCPServerView,
-        interactiveContentMCPServerView,
+        mcpServerViews,
       });
       break;
     case GLOBAL_AGENTS_SID.CLAUDE_4_SONNET:
       agentConfiguration = _getClaude4SonnetGlobalAgent({
         auth,
         settings,
-        webSearchBrowseMCPServerView,
-        interactiveContentMCPServerView,
+        mcpServerViews,
       });
       break;
     case GLOBAL_AGENTS_SID.CLAUDE_3_OPUS:
       agentConfiguration = _getClaude3OpusGlobalAgent({
         auth,
         settings,
-        webSearchBrowseMCPServerView,
-        interactiveContentMCPServerView,
+        mcpServerViews,
       });
       break;
     case GLOBAL_AGENTS_SID.CLAUDE_3_SONNET:
       agentConfiguration = _getClaude3GlobalAgent({
         auth,
         settings,
-        webSearchBrowseMCPServerView,
-        interactiveContentMCPServerView,
+        mcpServerViews,
       });
       break;
     case GLOBAL_AGENTS_SID.CLAUDE_3_HAIKU:
       agentConfiguration = _getClaude3HaikuGlobalAgent({
         settings,
-        webSearchBrowseMCPServerView,
-        interactiveContentMCPServerView,
+        mcpServerViews,
       });
       break;
     case GLOBAL_AGENTS_SID.CLAUDE_3_7_SONNET:
       agentConfiguration = _getClaude3_7GlobalAgent({
         auth,
         settings,
-        webSearchBrowseMCPServerView,
-        interactiveContentMCPServerView,
+        mcpServerViews,
       });
       break;
     case GLOBAL_AGENTS_SID.MISTRAL_LARGE:
       agentConfiguration = _getMistralLargeGlobalAgent({
         settings,
         auth,
-        webSearchBrowseMCPServerView,
-        interactiveContentMCPServerView,
+        mcpServerViews,
       });
       break;
     case GLOBAL_AGENTS_SID.MISTRAL_MEDIUM:
       agentConfiguration = _getMistralMediumGlobalAgent({
         settings,
         auth,
-        webSearchBrowseMCPServerView,
-        interactiveContentMCPServerView,
+        mcpServerViews,
       });
       break;
     case GLOBAL_AGENTS_SID.MISTRAL_SMALL:
       agentConfiguration = _getMistralSmallGlobalAgent({
         settings,
-        webSearchBrowseMCPServerView,
-        interactiveContentMCPServerView,
+        mcpServerViews,
       });
       break;
     case GLOBAL_AGENTS_SID.GEMINI_PRO:
       agentConfiguration = _getGeminiProGlobalAgent({
         auth,
         settings,
-        webSearchBrowseMCPServerView,
-        interactiveContentMCPServerView,
+        mcpServerViews,
       });
       break;
     case GLOBAL_AGENTS_SID.DEEPSEEK_R1:
@@ -351,49 +310,42 @@ function getGlobalAgent({
       agentConfiguration = _getSlackGlobalAgent(auth, {
         settings,
         preFetchedDataSources,
-        searchMCPServerView,
+        mcpServerViews,
       });
       break;
     case GLOBAL_AGENTS_SID.GOOGLE_DRIVE:
       agentConfiguration = _getGoogleDriveGlobalAgent(auth, {
         settings,
         preFetchedDataSources,
-        searchMCPServerView,
+        mcpServerViews,
       });
       break;
     case GLOBAL_AGENTS_SID.NOTION:
       agentConfiguration = _getNotionGlobalAgent(auth, {
         settings,
         preFetchedDataSources,
-        searchMCPServerView,
+        mcpServerViews,
       });
       break;
     case GLOBAL_AGENTS_SID.GITHUB:
       agentConfiguration = _getGithubGlobalAgent(auth, {
         settings,
         preFetchedDataSources,
-        searchMCPServerView,
+        mcpServerViews,
       });
       break;
     case GLOBAL_AGENTS_SID.INTERCOM:
       agentConfiguration = _getIntercomGlobalAgent(auth, {
         settings,
         preFetchedDataSources,
-        searchMCPServerView,
+        mcpServerViews,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST:
       agentConfiguration = _getDustGlobalAgent(auth, {
         settings,
         preFetchedDataSources,
-        agentRouterMCPServerView,
-        webSearchBrowseMCPServerView,
-        dataSourcesFileSystemMCPServerView,
-        toolsetsMCPServerView,
-        deepDiveMCPServerView,
-        interactiveContentMCPServerView,
-        dataWarehousesMCPServerView,
-        agentMemoryMCPServerView,
+        mcpServerViews,
         memories,
         availableToolsets,
       });
@@ -402,14 +354,7 @@ function getGlobalAgent({
       agentConfiguration = _getDustEdgeGlobalAgent(auth, {
         settings,
         preFetchedDataSources,
-        agentRouterMCPServerView,
-        webSearchBrowseMCPServerView,
-        dataSourcesFileSystemMCPServerView,
-        toolsetsMCPServerView,
-        deepDiveMCPServerView,
-        interactiveContentMCPServerView,
-        dataWarehousesMCPServerView,
-        agentMemoryMCPServerView,
+        mcpServerViews,
         memories,
         availableToolsets,
       });
@@ -418,14 +363,7 @@ function getGlobalAgent({
       agentConfiguration = _getDustQuickGlobalAgent(auth, {
         settings,
         preFetchedDataSources,
-        agentRouterMCPServerView,
-        webSearchBrowseMCPServerView,
-        dataSourcesFileSystemMCPServerView,
-        toolsetsMCPServerView,
-        deepDiveMCPServerView,
-        interactiveContentMCPServerView,
-        dataWarehousesMCPServerView,
-        agentMemoryMCPServerView,
+        mcpServerViews,
         memories,
         availableToolsets,
       });
@@ -434,14 +372,7 @@ function getGlobalAgent({
       agentConfiguration = _getDustOaiGlobalAgent(auth, {
         settings,
         preFetchedDataSources,
-        agentRouterMCPServerView,
-        webSearchBrowseMCPServerView,
-        dataSourcesFileSystemMCPServerView,
-        toolsetsMCPServerView,
-        deepDiveMCPServerView,
-        interactiveContentMCPServerView,
-        dataWarehousesMCPServerView,
-        agentMemoryMCPServerView,
+        mcpServerViews,
         memories,
         availableToolsets,
       });
@@ -450,22 +381,14 @@ function getGlobalAgent({
       agentConfiguration = _getDeepDiveGlobalAgent(auth, {
         settings,
         preFetchedDataSources,
-        webSearchBrowseMCPServerView,
-        dataSourcesFileSystemMCPServerView,
-        interactiveContentMCPServerView,
-        runAgentMCPServerView,
-        dataWarehousesMCPServerView,
-        toolsetsMCPServerView,
-        slideshowMCPServerView,
+        mcpServerViews,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_TASK:
       agentConfiguration = _getDustTaskGlobalAgent(auth, {
         settings,
         preFetchedDataSources,
-        webSearchBrowseMCPServerView,
-        dataSourcesFileSystemMCPServerView,
-        dataWarehousesMCPServerView,
+        mcpServerViews,
       });
       break;
     case GLOBAL_AGENTS_SID.DUST_BROWSER_SUMMARY:
@@ -565,17 +488,17 @@ export async function getGlobalAgents(
   const mcpServerViewsByServerId = new Map(
     allMCPServerViews.map((v) => [v.internalMCPServerId, v])
   );
-  const mcpServerViews: MCPServerViewsForGlobalAgentsMap = new Map();
-  for (const name of MCP_SERVERS_FOR_GLOBAL_AGENTS) {
-    const mcpServerId = autoInternalMCPServerNameToSId({
+  const mcpServerViews = Object.fromEntries(
+    MCP_SERVERS_FOR_GLOBAL_AGENTS.map((name) => [
       name,
-      workspaceId: owner.id,
-    });
-    const view = mcpServerViewsByServerId.get(mcpServerId);
-    if (view) {
-      mcpServerViews.set(name, view);
-    }
-  }
+      mcpServerViewsByServerId.get(
+        autoInternalMCPServerNameToSId({
+          name,
+          workspaceId: owner.id,
+        })
+      ) ?? null,
+    ])
+  ) as MCPServerViewsForGlobalAgentsMap;
 
   // If agentIds have been passed we fetch those. Otherwise we fetch them all, removing the retired
   // one (which will remove these models from the list of default agents in the product + list of
@@ -631,7 +554,7 @@ export async function getGlobalAgents(
   let memories: AgentMemoryResource[] = [];
   if (
     variant === "full" &&
-    mcpServerViews.has("agent_memory") &&
+    mcpServerViews.agent_memory !== null &&
     auth.user() &&
     (agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST) ||
       agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST_EDGE) ||
@@ -649,7 +572,7 @@ export async function getGlobalAgents(
   let availableToolsets: MCPServerViewResource[] = [];
   if (
     variant === "full" &&
-    mcpServerViews.has("toolsets") &&
+    mcpServerViews.toolsets !== null &&
     (agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST) ||
       agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST_EDGE) ||
       agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST_QUICK) ||

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -1,5 +1,6 @@
 import { AGENT_COPILOT_AGENT_STATE_TOOL_NAME } from "@app/lib/api/actions/servers/agent_copilot_agent_state/metadata";
 import { AGENT_COPILOT_CONTEXT_TOOL_NAME } from "@app/lib/api/actions/servers/agent_copilot_context/metadata";
+import { autoInternalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
 import { getFavoriteStates } from "@app/lib/api/assistant/get_favorite_states";
 import {
   _getClaude3_7GlobalAgent,
@@ -52,8 +53,14 @@ import {
   _getNotionGlobalAgent,
   _getSlackGlobalAgent,
 } from "@app/lib/api/assistant/global_agents/configurations/retired_managed";
-import type { PrefetchedDataSourcesType } from "@app/lib/api/assistant/global_agents/tools";
-import { getDataSourcesAndWorkspaceIdForGlobalAgents } from "@app/lib/api/assistant/global_agents/tools";
+import type {
+  MCPServerViewsForGlobalAgentsMap,
+  PrefetchedDataSourcesType,
+} from "@app/lib/api/assistant/global_agents/tools";
+import {
+  getDataSourcesAndWorkspaceIdForGlobalAgents,
+  MCP_SERVERS_FOR_GLOBAL_AGENTS,
+} from "@app/lib/api/assistant/global_agents/tools";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";
@@ -121,17 +128,7 @@ function getGlobalAgent({
   sId,
   preFetchedDataSources,
   globalAgentSettings,
-  agentRouterMCPServerView,
-  webSearchBrowseMCPServerView,
-  searchMCPServerView,
-  dataSourcesFileSystemMCPServerView,
-  interactiveContentMCPServerView,
-  runAgentMCPServerView,
-  toolsetsMCPServerView,
-  dataWarehousesMCPServerView,
-  slideshowMCPServerView,
-  deepDiveMCPServerView,
-  agentMemoryMCPServerView,
+  mcpServerViews,
   memories,
   availableToolsets,
   copilotMCPServerViews,
@@ -141,17 +138,7 @@ function getGlobalAgent({
   sId: string | number;
   preFetchedDataSources: PrefetchedDataSourcesType | null;
   globalAgentSettings: GlobalAgentSettingsModel[];
-  agentRouterMCPServerView: MCPServerViewResource | null;
-  webSearchBrowseMCPServerView: MCPServerViewResource | null;
-  searchMCPServerView: MCPServerViewResource | null;
-  dataSourcesFileSystemMCPServerView: MCPServerViewResource | null;
-  interactiveContentMCPServerView: MCPServerViewResource | null;
-  runAgentMCPServerView: MCPServerViewResource | null;
-  toolsetsMCPServerView: MCPServerViewResource | null;
-  dataWarehousesMCPServerView: MCPServerViewResource | null;
-  slideshowMCPServerView: MCPServerViewResource | null;
-  deepDiveMCPServerView: MCPServerViewResource | null;
-  agentMemoryMCPServerView: MCPServerViewResource | null;
+  mcpServerViews: MCPServerViewsForGlobalAgentsMap;
   memories: AgentMemoryResource[];
   availableToolsets: MCPServerViewResource[];
   copilotMCPServerViews: {
@@ -160,6 +147,21 @@ function getGlobalAgent({
   } | null;
   copilotUserMetadata: CopilotUserMetadata | null;
 }): AgentConfigurationType | null {
+  const agentRouterMCPServerView = mcpServerViews.get("agent_router") ?? null;
+  const webSearchBrowseMCPServerView =
+    mcpServerViews.get("web_search_&_browse") ?? null;
+  const searchMCPServerView = mcpServerViews.get("search") ?? null;
+  const dataSourcesFileSystemMCPServerView =
+    mcpServerViews.get("data_sources_file_system") ?? null;
+  const interactiveContentMCPServerView =
+    mcpServerViews.get("interactive_content") ?? null;
+  const runAgentMCPServerView = mcpServerViews.get("run_agent") ?? null;
+  const toolsetsMCPServerView = mcpServerViews.get("toolsets") ?? null;
+  const dataWarehousesMCPServerView =
+    mcpServerViews.get("data_warehouses") ?? null;
+  const slideshowMCPServerView = mcpServerViews.get("slideshow") ?? null;
+  const deepDiveMCPServerView = mcpServerViews.get("deep_dive") ?? null;
+  const agentMemoryMCPServerView = mcpServerViews.get("agent_memory") ?? null;
   const settings =
     globalAgentSettings.find((settings) => settings.agentId === sId) ?? null;
 
@@ -545,94 +547,35 @@ export async function getGlobalAgents(
     throw new Error("Unexpected `auth` without `plan`.");
   }
 
-  const [
-    preFetchedDataSources,
-    globalAgentSettings,
-    agentRouterMCPServerView,
-    webSearchBrowseMCPServerView,
-    searchMCPServerView,
-    dataSourcesFileSystemMCPServerView,
-    interactiveContentMCPServerView,
-    runAgentMCPServerView,
-    toolsetsMCPServerView,
-    dataWarehousesMCPServerView,
-    slideshowMCPServerView,
-    deepDiveMCPServerView,
-    agentMemoryMCPServerView,
-  ] = await Promise.all([
-    variant === "full"
-      ? getDataSourcesAndWorkspaceIdForGlobalAgents(auth)
-      : null,
-    GlobalAgentSettingsModel.findAll({
-      where: { workspaceId: owner.id },
-    }),
-    variant === "full"
-      ? MCPServerViewResource.getMCPServerViewForAutoInternalTool(
-          auth,
-          "agent_router"
-        )
-      : null,
-    variant === "full"
-      ? MCPServerViewResource.getMCPServerViewForAutoInternalTool(
-          auth,
-          "web_search_&_browse"
-        )
-      : null,
-    variant === "full"
-      ? MCPServerViewResource.getMCPServerViewForAutoInternalTool(
-          auth,
-          "search"
-        )
-      : null,
-    variant === "full"
-      ? MCPServerViewResource.getMCPServerViewForAutoInternalTool(
-          auth,
-          "data_sources_file_system"
-        )
-      : null,
-    variant === "full"
-      ? MCPServerViewResource.getMCPServerViewForAutoInternalTool(
-          auth,
-          "interactive_content"
-        )
-      : null,
-    variant === "full"
-      ? MCPServerViewResource.getMCPServerViewForAutoInternalTool(
-          auth,
-          "run_agent"
-        )
-      : null,
-    variant === "full"
-      ? MCPServerViewResource.getMCPServerViewForAutoInternalTool(
-          auth,
-          "toolsets"
-        )
-      : null,
-    variant === "full"
-      ? MCPServerViewResource.getMCPServerViewForAutoInternalTool(
-          auth,
-          "data_warehouses"
-        )
-      : null,
-    variant === "full"
-      ? MCPServerViewResource.getMCPServerViewForAutoInternalTool(
-          auth,
-          "slideshow"
-        )
-      : null,
-    variant === "full"
-      ? MCPServerViewResource.getMCPServerViewForAutoInternalTool(
-          auth,
-          "deep_dive"
-        )
-      : null,
-    variant === "full"
-      ? MCPServerViewResource.getMCPServerViewForAutoInternalTool(
-          auth,
-          "agent_memory"
-        )
-      : null,
-  ]);
+  const [preFetchedDataSources, globalAgentSettings, allMCPServerViews] =
+    await Promise.all([
+      variant === "full"
+        ? getDataSourcesAndWorkspaceIdForGlobalAgents(auth)
+        : null,
+      GlobalAgentSettingsModel.findAll({
+        where: { workspaceId: owner.id },
+      }),
+      variant === "full"
+        ? MCPServerViewResource.getMCPServerViewsForAutoInternalTools(auth, [
+            ...MCP_SERVERS_FOR_GLOBAL_AGENTS,
+          ])
+        : [],
+    ]);
+
+  const mcpServerViewsByServerId = new Map(
+    allMCPServerViews.map((v) => [v.internalMCPServerId, v])
+  );
+  const mcpServerViews: MCPServerViewsForGlobalAgentsMap = new Map();
+  for (const name of MCP_SERVERS_FOR_GLOBAL_AGENTS) {
+    const mcpServerId = autoInternalMCPServerNameToSId({
+      name,
+      workspaceId: owner.id,
+    });
+    const view = mcpServerViewsByServerId.get(mcpServerId);
+    if (view) {
+      mcpServerViews.set(name, view);
+    }
+  }
 
   // If agentIds have been passed we fetch those. Otherwise we fetch them all, removing the retired
   // one (which will remove these models from the list of default agents in the product + list of
@@ -688,7 +631,7 @@ export async function getGlobalAgents(
   let memories: AgentMemoryResource[] = [];
   if (
     variant === "full" &&
-    agentMemoryMCPServerView &&
+    mcpServerViews.has("agent_memory") &&
     auth.user() &&
     (agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST) ||
       agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST_EDGE) ||
@@ -706,7 +649,7 @@ export async function getGlobalAgents(
   let availableToolsets: MCPServerViewResource[] = [];
   if (
     variant === "full" &&
-    toolsetsMCPServerView &&
+    mcpServerViews.has("toolsets") &&
     (agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST) ||
       agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST_EDGE) ||
       agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST_QUICK) ||
@@ -753,17 +696,7 @@ export async function getGlobalAgents(
       sId,
       preFetchedDataSources,
       globalAgentSettings,
-      agentRouterMCPServerView,
-      webSearchBrowseMCPServerView,
-      searchMCPServerView,
-      dataSourcesFileSystemMCPServerView,
-      interactiveContentMCPServerView,
-      runAgentMCPServerView,
-      toolsetsMCPServerView,
-      dataWarehousesMCPServerView,
-      slideshowMCPServerView,
-      deepDiveMCPServerView,
-      agentMemoryMCPServerView,
+      mcpServerViews,
       memories,
       availableToolsets,
       copilotMCPServerViews,

--- a/front/lib/api/assistant/global_agents/tools.ts
+++ b/front/lib/api/assistant/global_agents/tools.ts
@@ -5,7 +5,10 @@ import {
   DEFAULT_WEBSEARCH_ACTION_NAME,
 } from "@app/lib/actions/constants";
 import type { ServerSideMCPServerConfigurationType } from "@app/lib/actions/mcp";
-import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
+import type {
+  AutoInternalMCPServerNameType,
+  InternalMCPServerNameType,
+} from "@app/lib/actions/mcp_internal_actions/constants";
 import type { Authenticator } from "@app/lib/auth";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -15,6 +18,26 @@ export type PrefetchedDataSourcesType = {
   dataSourceViews: (DataSourceViewType & { isInGlobalSpace: boolean })[];
   workspaceId: string;
 };
+
+export const MCP_SERVERS_FOR_GLOBAL_AGENTS: readonly AutoInternalMCPServerNameType[] =
+  [
+    "agent_router",
+    "web_search_&_browse",
+    "search",
+    "data_sources_file_system",
+    "interactive_content",
+    "run_agent",
+    "toolsets",
+    "data_warehouses",
+    "slideshow",
+    "deep_dive",
+    "agent_memory",
+  ] as const;
+
+export type MCPServerViewsForGlobalAgentsMap = Map<
+  (typeof MCP_SERVERS_FOR_GLOBAL_AGENTS)[number],
+  MCPServerViewResource
+>;
 
 export async function getDataSourcesAndWorkspaceIdForGlobalAgents(
   auth: Authenticator

--- a/front/lib/api/assistant/global_agents/tools.ts
+++ b/front/lib/api/assistant/global_agents/tools.ts
@@ -34,9 +34,9 @@ export const MCP_SERVERS_FOR_GLOBAL_AGENTS: readonly AutoInternalMCPServerNameTy
     "agent_memory",
   ] as const;
 
-export type MCPServerViewsForGlobalAgentsMap = Map<
+export type MCPServerViewsForGlobalAgentsMap = Record<
   (typeof MCP_SERVERS_FOR_GLOBAL_AGENTS)[number],
-  MCPServerViewResource
+  MCPServerViewResource | null
 >;
 
 export async function getDataSourcesAndWorkspaceIdForGlobalAgents(

--- a/front/lib/api/assistant/global_agents/tools.ts
+++ b/front/lib/api/assistant/global_agents/tools.ts
@@ -92,11 +92,14 @@ export async function getDataSourcesAndWorkspaceIdForGlobalAgents(
 
 export function _getDefaultWebActionsForGlobalAgent({
   agentId,
-  webSearchBrowseMCPServerView,
+  mcpServerViews,
 }: {
   agentId: GLOBAL_AGENTS_SID;
-  webSearchBrowseMCPServerView: MCPServerViewResource | null;
+  mcpServerViews: MCPServerViewsForGlobalAgentsMap;
 }): ServerSideMCPServerConfigurationType[] {
+  const { "web_search_&_browse": webSearchBrowseMCPServerView } =
+    mcpServerViews;
+
   if (!webSearchBrowseMCPServerView) {
     return [];
   }
@@ -124,11 +127,13 @@ export function _getDefaultWebActionsForGlobalAgent({
 
 export function _getToolsetsToolsConfiguration({
   agentId,
-  toolsetsMcpServerView,
+  mcpServerViews,
 }: {
   agentId: GLOBAL_AGENTS_SID;
-  toolsetsMcpServerView: MCPServerViewResource | null;
+  mcpServerViews: MCPServerViewsForGlobalAgentsMap;
 }): ServerSideMCPServerConfigurationType[] {
+  const { toolsets: toolsetsMcpServerView } = mcpServerViews;
+
   if (!toolsetsMcpServerView) {
     return [];
   }
@@ -155,12 +160,16 @@ export function _getToolsetsToolsConfiguration({
   ];
 }
 
-export function _getAgentRouterToolsConfiguration(
-  agentId: GLOBAL_AGENTS_SID,
-  mcpServerView: MCPServerViewResource | null,
-  internalMCPServerId: string
-): ServerSideMCPServerConfigurationType[] {
-  if (!mcpServerView) {
+export function _getAgentRouterToolsConfiguration({
+  agentId,
+  mcpServerViews,
+}: {
+  agentId: GLOBAL_AGENTS_SID;
+  mcpServerViews: MCPServerViewsForGlobalAgentsMap;
+}): ServerSideMCPServerConfigurationType[] {
+  const { agent_router: agentRouterMCPServerView } = mcpServerViews;
+
+  if (!agentRouterMCPServerView) {
     return [];
   }
   return [
@@ -170,8 +179,8 @@ export function _getAgentRouterToolsConfiguration(
       type: "mcp_server_configuration",
       name: DEFAULT_AGENT_ROUTER_ACTION_NAME satisfies InternalMCPServerNameType,
       description: DEFAULT_AGENT_ROUTER_ACTION_DESCRIPTION,
-      mcpServerViewId: mcpServerView.sId,
-      internalMCPServerId,
+      mcpServerViewId: agentRouterMCPServerView.sId,
+      internalMCPServerId: agentRouterMCPServerView.internalMCPServerId,
       dataSources: null,
       tables: null,
       childAgentId: null,
@@ -186,11 +195,14 @@ export function _getAgentRouterToolsConfiguration(
 
 export function _getInteractiveContentToolConfiguration({
   agentId,
-  interactiveContentMCPServerView,
+  mcpServerViews,
 }: {
   agentId: GLOBAL_AGENTS_SID;
-  interactiveContentMCPServerView: MCPServerViewResource | null;
+  mcpServerViews: MCPServerViewsForGlobalAgentsMap;
 }): ServerSideMCPServerConfigurationType[] {
+  const { interactive_content: interactiveContentMCPServerView } =
+    mcpServerViews;
+
   if (!interactiveContentMCPServerView) {
     return [];
   }


### PR DESCRIPTION
## Description

- Global agents rely on a large number of MCP server views, which are all fetched separately in one big Promise all.
- This PR refactors this fetch into a single batch fetch, mostly for readability: only need to add the name of the server in an array instead of adding some boilerplate code for the fetch.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
