### PR TITLE
[front] enh(MCP): add display labels for tools

### DIFF
--- a/front/components/actions/mcp/details/MCPActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPActionDetails.tsx
@@ -105,6 +105,24 @@ export interface MCPActionDetailsProps {
   viewType: "conversation" | "sidebar";
 }
 
+function getActionLabel(
+  action: AgentMCPActionWithOutputType,
+  viewType: "conversation" | "sidebar"
+): string {
+  if (action.displayLabels) {
+    return viewType === "conversation"
+      ? action.displayLabels.running
+      : action.displayLabels.done;
+  }
+
+  return (
+    (viewType === "conversation" ? "Running a tool" : "Run a tool") +
+    (action.functionCallName
+      ? `: ${asDisplayName(action.functionCallName)}`
+      : "")
+  );
+}
+
 export function MCPActionDetails({
   action,
   viewType,
@@ -357,12 +375,6 @@ export function GenericActionDetails({
       ? JSON.stringify(action.params, undefined, 2)
       : null;
 
-  const actionName =
-    (viewType === "conversation" ? "Running a tool" : "Run a tool") +
-    (action.functionCallName
-      ? `: ${asDisplayName(action.functionCallName)}`
-      : "");
-
   const actionIcon =
     action.internalMCPServerName &&
     InternalActionIcons[
@@ -372,7 +384,7 @@ export function GenericActionDetails({
   return (
     <ActionDetailsWrapper
       viewType={viewType}
-      actionName={actionName}
+      actionName={getActionLabel(action, viewType)}
       visual={actionIcon ?? MCP_SPECIFICATION.cardIcon}
     >
       {viewType !== "conversation" && (

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -51,6 +51,7 @@ import {
 import type {
   InternalMCPServerDefinitionType,
   MCPToolRetryPolicyType,
+  ToolDisplayLabels,
 } from "@app/lib/api/mcp";
 import { getResourceNameAndIdFromSId } from "@app/lib/resources/string_ids";
 import type {
@@ -1813,6 +1814,28 @@ export function getInternalMCPServerToolStakes(
     return server.metadata.tools_stakes;
   }
   return server.tools_stakes;
+}
+
+export function getInternalMCPServerToolDisplayLabels(
+  name: InternalMCPServerNameType
+): Record<string, ToolDisplayLabels> | null {
+  const server = INTERNAL_MCP_SERVERS[name];
+  if (!isServerWithMetadata(server)) {
+    return null;
+  }
+
+  const entries = server.metadata.tools
+    .filter(
+      (tool): tool is typeof tool & { displayLabels: ToolDisplayLabels } =>
+        tool.displayLabels !== undefined
+    )
+    .map((tool) => [tool.name, tool.displayLabels] as const);
+
+  if (entries.length === 0) {
+    return null;
+  }
+
+  return Object.fromEntries(entries);
 }
 
 export function getInternalMCPServerInfo(

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1816,6 +1816,8 @@ export function getInternalMCPServerToolStakes(
   return server.tools_stakes;
 }
 
+// TODO(2026-01-27 MCP): improve typing once all servers are migrated to the metadata pattern.
+// Goal is to tie the tool name to the server name.
 export function getInternalMCPServerToolDisplayLabels(
   name: InternalMCPServerNameType
 ): Record<string, ToolDisplayLabels> | null {

--- a/front/lib/actions/mcp_internal_actions/tool_definition.ts
+++ b/front/lib/actions/mcp_internal_actions/tool_definition.ts
@@ -13,6 +13,7 @@ import type { AgentLoopContextType } from "@app/lib/actions/types";
 import type {
   InternalMCPServerDefinitionType,
   MCPToolType,
+  ToolDisplayLabels,
 } from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import type { Result } from "@app/types";
@@ -42,6 +43,7 @@ export interface ToolDefinition<
   description: string;
   schema: TSchema;
   stake: MCPToolStakeLevelType;
+  displayLabels?: ToolDisplayLabels;
   handler: (
     params: z.infer<z.ZodObject<TSchema>>,
     extra: ToolHandlerExtra

--- a/front/lib/api/actions/servers/agent_copilot_agent_state/metadata.ts
+++ b/front/lib/api/actions/servers/agent_copilot_agent_state/metadata.ts
@@ -16,6 +16,10 @@ export const AGENT_COPILOT_AGENT_STATE_TOOLS_METADATA = createToolsRecord({
       "Get detailed information about the current agent configuration, including name, description, instructions, model settings, and the IDs of all skills and tools currently used by the agent.",
     schema: {},
     stake: "never_ask" as MCPToolStakeLevelType,
+    displayLabels: {
+      running: "Getting agent info",
+      done: "Get agent info",
+    },
   },
 });
 
@@ -32,6 +36,7 @@ export const AGENT_COPILOT_AGENT_STATE_TOOLS: MCPToolType[] = (
   inputSchema: zodToJsonSchema(
     z.object(AGENT_COPILOT_AGENT_STATE_TOOLS_METADATA[key].schema)
   ) as JSONSchema,
+  displayLabels: AGENT_COPILOT_AGENT_STATE_TOOLS_METADATA[key].displayLabels,
 }));
 
 export const AGENT_COPILOT_AGENT_STATE_TOOL_STAKES: Record<

--- a/front/lib/api/actions/servers/agent_copilot_context/metadata.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/metadata.ts
@@ -88,6 +88,10 @@ export const AGENT_COPILOT_CONTEXT_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Listing available knowledge",
+      done: "List available knowledge",
+    },
   },
   get_available_models: {
     description:
@@ -289,6 +293,10 @@ export const AGENT_COPILOT_CONTEXT_TOOLS_METADATA = createToolsRecord({
         .describe("Array of suggestions to update with their new states"),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Updating suggestion state",
+      done: "Update suggestion state",
+    },
   },
 });
 

--- a/front/lib/api/actions/servers/agent_copilot_context/metadata.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/metadata.ts
@@ -101,18 +101,30 @@ export const AGENT_COPILOT_CONTEXT_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Listing available models",
+      done: "List available models",
+    },
   },
   get_available_skills: {
     description:
       "Get the list of available skills that can be added to agents. Returns skills accessible to the current user across all spaces they have access to.",
     schema: {},
     stake: "never_ask",
+    displayLabels: {
+      running: "Listing available skills",
+      done: "List available skills",
+    },
   },
   get_available_tools: {
     description:
       "Get the list of available tools (MCP servers) that can be added to agents. Returns tools accessible to the current user.",
     schema: {},
     stake: "never_ask",
+    displayLabels: {
+      running: "Listing available tools",
+      done: "List available tools",
+    },
   },
   get_agent_feedback: {
     description: "Get user feedback for the agent.",
@@ -131,6 +143,10 @@ export const AGENT_COPILOT_CONTEXT_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Listing agent feedback",
+      done: "List agent feedback",
+    },
   },
   get_agent_insights: {
     description:
@@ -144,6 +160,10 @@ export const AGENT_COPILOT_CONTEXT_TOOLS_METADATA = createToolsRecord({
         .describe("Number of days to include in the analysis (default: 30)"),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Listing agent insights",
+      done: "List agent insights",
+    },
   },
   // Suggestion tools
   suggest_prompt_editions: {
@@ -159,6 +179,10 @@ export const AGENT_COPILOT_CONTEXT_TOOLS_METADATA = createToolsRecord({
         .describe("Analysis or reasoning for the suggestions"),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Suggesting prompt editions",
+      done: "Suggest prompt editions",
+    },
   },
   suggest_tools: {
     description:
@@ -173,6 +197,10 @@ export const AGENT_COPILOT_CONTEXT_TOOLS_METADATA = createToolsRecord({
         .describe("Analysis or reasoning for the suggestion"),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Suggesting tools",
+      done: "Suggest tools",
+    },
   },
   suggest_skills: {
     description:
@@ -187,6 +215,10 @@ export const AGENT_COPILOT_CONTEXT_TOOLS_METADATA = createToolsRecord({
         .describe("Analysis or reasoning for the suggestion"),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Suggesting skills",
+      done: "Suggest skills",
+    },
   },
   suggest_model: {
     description: "Suggest changing the agent's LLM model configuration.",
@@ -200,6 +232,10 @@ export const AGENT_COPILOT_CONTEXT_TOOLS_METADATA = createToolsRecord({
         .describe("Analysis or reasoning for the suggestion"),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Suggesting model",
+      done: "Suggest model",
+    },
   },
   list_suggestions: {
     description:
@@ -228,6 +264,10 @@ export const AGENT_COPILOT_CONTEXT_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Listing suggestions",
+      done: "List suggestions",
+    },
   },
   update_suggestions_state: {
     description:
@@ -267,6 +307,7 @@ export const AGENT_COPILOT_CONTEXT_SERVER = {
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+    displayLabels: t.displayLabels,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(AGENT_COPILOT_CONTEXT_TOOLS_METADATA).map((t) => [

--- a/front/lib/api/actions/servers/agent_router/metadata.ts
+++ b/front/lib/api/actions/servers/agent_router/metadata.ts
@@ -20,6 +20,10 @@ export const AGENT_ROUTER_TOOLS_METADATA = createToolsRecord({
       "(e.g., `:mention[agent-name]{sId=xyz}`) to display a clickable link to the agent.",
     schema: {},
     stake: "never_ask",
+    displayLabels: {
+      running: "Listing agents",
+      done: "List agents",
+    },
   },
   suggest_agents_for_content: {
     description:
@@ -33,6 +37,10 @@ export const AGENT_ROUTER_TOOLS_METADATA = createToolsRecord({
       conversationId: z.string().describe("The conversation id."),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Suggesting agents",
+      done: "Suggest agents",
+    },
   },
 });
 
@@ -50,6 +58,7 @@ export const AGENT_ROUTER_SERVER = {
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+    displayLabels: t.displayLabels,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(AGENT_ROUTER_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/extract_data/metadata.ts
+++ b/front/lib/api/actions/servers/extract_data/metadata.ts
@@ -92,6 +92,10 @@ export const EXTRACT_DATA_BASE_TOOLS_METADATA = createToolsRecord({
     description: TOOL_DESCRIPTION,
     schema: baseExtractSchema,
     stake: "never_ask",
+    displayLabels: {
+      running: "Extracting data",
+      done: "Extract data",
+    },
   },
 });
 
@@ -101,6 +105,10 @@ export const EXTRACT_DATA_WITH_TAGS_TOOLS_METADATA = createToolsRecord({
     description: TOOL_DESCRIPTION,
     schema: extractWithTagsSchema,
     stake: "never_ask",
+    displayLabels: {
+      running: "Extracting data",
+      done: "Extract data",
+    },
   },
   find_tags: {
     description:
@@ -108,6 +116,10 @@ export const EXTRACT_DATA_WITH_TAGS_TOOLS_METADATA = createToolsRecord({
       ` This tool is meant to be used before the ${EXTRACT_DATA_MAIN_TOOL_NAME} tool.`,
     schema: findTagsSchema,
     stake: "never_ask",
+    displayLabels: {
+      running: "Finding tags",
+      done: "Find tags",
+    },
   },
 });
 
@@ -126,6 +138,7 @@ export const EXTRACT_DATA_SERVER = {
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+    displayLabels: t.displayLabels,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(EXTRACT_DATA_BASE_TOOLS_METADATA).map((t) => [

--- a/front/lib/api/actions/servers/file_generation/metadata.ts
+++ b/front/lib/api/actions/servers/file_generation/metadata.ts
@@ -47,8 +47,8 @@ export const FILE_GENERATION_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Getting supported formats",
-      done: "Get supported formats",
+      running: "Listing supported formats",
+      done: "List supported formats",
     },
   },
   convert_file_format: {

--- a/front/lib/api/actions/servers/file_generation/metadata.ts
+++ b/front/lib/api/actions/servers/file_generation/metadata.ts
@@ -46,6 +46,10 @@ export const FILE_GENERATION_TOOLS_METADATA = createToolsRecord({
       output_format: z.enum(OUTPUT_FORMATS).describe("The format to check."),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Getting supported formats",
+      done: "Get supported formats",
+    },
   },
   convert_file_format: {
     description: "Converts a file from one format to another.",
@@ -70,6 +74,10 @@ export const FILE_GENERATION_TOOLS_METADATA = createToolsRecord({
         .describe("The format of the output file."),
     },
     stake: "low",
+    displayLabels: {
+      running: "Converting file",
+      done: "Convert file",
+    },
   },
   generate_file: {
     description: "Generate a file with some content.",
@@ -94,6 +102,10 @@ export const FILE_GENERATION_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "low",
+    displayLabels: {
+      running: "Generating file",
+      done: "Generate file",
+    },
   },
 });
 
@@ -111,6 +123,7 @@ export const FILE_GENERATION_SERVER = {
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+    displayLabels: t.displayLabels,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(FILE_GENERATION_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/github/metadata.ts
+++ b/front/lib/api/actions/servers/github/metadata.ts
@@ -29,6 +29,10 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
         .describe("Labels to associate with this issue."),
     },
     stake: "low",
+    displayLabels: {
+      running: "Creating issue",
+      done: "Create issue",
+    },
   },
   get_pull_request: {
     description:
@@ -44,6 +48,10 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
       pullNumber: z.number().describe("The pull request number."),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Retrieving pull request",
+      done: "Retrieve pull request",
+    },
   },
   create_pull_request_review: {
     description:
@@ -86,6 +94,10 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
         .optional(),
     },
     stake: "low",
+    displayLabels: {
+      running: "Creating pull request review",
+      done: "Create pull request review",
+    },
   },
   list_organization_projects: {
     description:
@@ -98,6 +110,10 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Listing organization projects",
+      done: "List organization projects",
+    },
   },
   add_issue_to_project: {
     description:
@@ -132,6 +148,10 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "low",
+    displayLabels: {
+      running: "Adding issue to project",
+      done: "Add issue to project",
+    },
   },
   comment_on_issue: {
     description: "Add a comment to an existing GitHub issue.",
@@ -148,6 +168,10 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
         .describe("The contents of the comment (GitHub markdown)."),
     },
     stake: "low",
+    displayLabels: {
+      running: "Commenting on issue",
+      done: "Comment on issue",
+    },
   },
   get_issue: {
     description:
@@ -162,6 +186,10 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
       issueNumber: z.number().describe("The issue number."),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Retrieving issue",
+      done: "Retrieve issue",
+    },
   },
   list_issues: {
     description:
@@ -199,6 +227,10 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
       before: z.string().optional().describe("The cursor to start before."),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Listing issues",
+      done: "List issues",
+    },
   },
   search_advanced: {
     description:
@@ -223,6 +255,10 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
       before: z.string().optional().describe("The cursor to start before."),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Searching issues and pull requests",
+      done: "Search issues and pull requests",
+    },
   },
   list_pull_requests: {
     description:
@@ -256,6 +292,10 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
       before: z.string().optional().describe("The cursor to start before."),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Listing pull requests",
+      done: "List pull requests",
+    },
   },
 });
 
@@ -276,6 +316,7 @@ export const GITHUB_SERVER = {
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+    displayLabels: t.displayLabels,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(GITHUB_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/google_calendar/metadata.ts
+++ b/front/lib/api/actions/servers/google_calendar/metadata.ts
@@ -67,8 +67,8 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Getting event",
-      done: "Get event",
+      running: "Retrieving event",
+      done: "Retrieve event",
     },
   },
   create_event: {
@@ -235,8 +235,8 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Getting user timezones",
-      done: "Get user timezones",
+      running: "Checking user timezones",
+      done: "Check user timezones",
     },
   },
 });

--- a/front/lib/api/actions/servers/google_calendar/metadata.ts
+++ b/front/lib/api/actions/servers/google_calendar/metadata.ts
@@ -19,6 +19,10 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = createToolsRecord({
         .describe("Maximum number of calendars to return (max 250)."),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Listing calendars",
+      done: "List calendars",
+    },
   },
   list_events: {
     description:
@@ -47,6 +51,10 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = createToolsRecord({
       pageToken: z.string().optional().describe("Page token for pagination."),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Listing events",
+      done: "List events",
+    },
   },
   get_event: {
     description: "Get a single event from a Google Calendar by event ID.",
@@ -58,6 +66,10 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = createToolsRecord({
       eventId: z.string().describe("The ID of the event to retrieve."),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Getting event",
+      done: "Get event",
+    },
   },
   create_event: {
     description: "Create a new event in a Google Calendar.",
@@ -88,6 +100,10 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "medium",
+    displayLabels: {
+      running: "Creating event",
+      done: "Create event",
+    },
   },
   update_event: {
     description: "Update an existing event in a Google Calendar.",
@@ -121,6 +137,10 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "medium",
+    displayLabels: {
+      running: "Updating event",
+      done: "Update event",
+    },
   },
   delete_event: {
     description: "Delete an event from a Google Calendar.",
@@ -132,6 +152,10 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = createToolsRecord({
       eventId: z.string().describe("The ID of the event to delete."),
     },
     stake: "medium",
+    displayLabels: {
+      running: "Deleting event",
+      done: "Delete event",
+    },
   },
   check_availability: {
     description:
@@ -195,6 +219,10 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Checking availability",
+      done: "Check availability",
+    },
   },
   get_user_timezones: {
     description:
@@ -206,6 +234,10 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = createToolsRecord({
         .describe("Array of email addresses to get timezone information for"),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Getting user timezones",
+      done: "Get user timezones",
+    },
   },
 });
 
@@ -229,6 +261,7 @@ export const GOOGLE_CALENDAR_SERVER = {
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+    displayLabels: t.displayLabels,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(GOOGLE_CALENDAR_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/image_generation/metadata.ts
+++ b/front/lib/api/actions/servers/image_generation/metadata.ts
@@ -56,6 +56,10 @@ export const IMAGE_GENERATION_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "low",
+    displayLabels: {
+      running: "Generating image",
+      done: "Generate image",
+    },
   },
 });
 
@@ -98,6 +102,7 @@ export const IMAGE_GENERATION_SERVER = {
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+    displayLabels: t.displayLabels,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(IMAGE_GENERATION_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/include_data/metadata.ts
+++ b/front/lib/api/actions/servers/include_data/metadata.ts
@@ -22,6 +22,10 @@ export const INCLUDE_DATA_BASE_TOOLS_METADATA = createToolsRecord({
       "Fetch the most recent documents in reverse chronological order up to a pre-allocated size. This tool retrieves content that is already pre-configured by the user, ensuring the latest information is included.",
     schema: IncludeInputSchema.shape,
     stake: "never_ask",
+    displayLabels: {
+      running: "Including data",
+      done: "Include data",
+    },
   },
 });
 
@@ -37,6 +41,10 @@ export const INCLUDE_DATA_WITH_TAGS_TOOLS_METADATA = createToolsRecord({
       "Fetch the most recent documents in reverse chronological order up to a pre-allocated size. This tool retrieves content that is already pre-configured by the user, ensuring the latest information is included.",
     schema: includeWithTagsSchema,
     stake: "never_ask",
+    displayLabels: {
+      running: "Including data",
+      done: "Include data",
+    },
   },
   find_tags: {
     description:
@@ -44,6 +52,10 @@ export const INCLUDE_DATA_WITH_TAGS_TOOLS_METADATA = createToolsRecord({
       " This tool is meant to be used before the retrieve_recent_documents tool.",
     schema: findTagsSchema,
     stake: "never_ask",
+    displayLabels: {
+      running: "Finding tags",
+      done: "Find tags",
+    },
   },
 });
 
@@ -62,6 +74,7 @@ export const INCLUDE_DATA_SERVER = {
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+    displayLabels: t.displayLabels,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(INCLUDE_DATA_BASE_TOOLS_METADATA).map((t) => [

--- a/front/lib/api/actions/servers/notion/metadata.ts
+++ b/front/lib/api/actions/servers/notion/metadata.ts
@@ -238,6 +238,10 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
         .describe("What type of notion objects to search."),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Searching Notion",
+      done: "Search Notion",
+    },
   },
   retrieve_page: {
     description: "Retrieve a Notion page by its ID.",
@@ -245,6 +249,10 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
       pageId: z.string().describe("The Notion page ID."),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Retrieving page",
+      done: "Retrieve page",
+    },
   },
   retrieve_database_schema: {
     description: "Retrieve a Notion database's schema by its ID.",
@@ -252,6 +260,10 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
       databaseId: z.string().describe("The Notion database ID."),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Retrieving database schema",
+      done: "Retrieve database schema",
+    },
   },
   retrieve_database_content: {
     description: "Retrieve the content (pages) of a Notion database by its ID.",
@@ -266,6 +278,10 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
       page_size: z.number().optional().describe("Page size for pagination."),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Retrieving database content",
+      done: "Retrieve database content",
+    },
   },
   query_database: {
     description: "Query a Notion database.",
@@ -280,6 +296,10 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
       page_size: z.number().optional().describe("Page size for pagination."),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Querying database",
+      done: "Query database",
+    },
   },
   create_page: {
     description: "Create a new Notion page.",
@@ -292,6 +312,10 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
       cover: z.any().optional().describe("Cover (optional)."),
     },
     stake: "low",
+    displayLabels: {
+      running: "Creating page",
+      done: "Create page",
+    },
   },
   insert_row_into_database: {
     description: "Create a new Notion page in a database.",
@@ -302,6 +326,10 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
       cover: z.any().optional().describe("Cover (optional)."),
     },
     stake: "low",
+    displayLabels: {
+      running: "Inserting row",
+      done: "Insert row",
+    },
   },
   create_database: {
     description: "Create a new Notion database (table).",
@@ -319,6 +347,10 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
       cover: z.any().optional().describe("Cover (optional)."),
     },
     stake: "low",
+    displayLabels: {
+      running: "Creating database",
+      done: "Create database",
+    },
   },
   update_page: {
     description: "Update a Notion page's properties.",
@@ -327,6 +359,10 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
       properties: propertiesSchema,
     },
     stake: "low",
+    displayLabels: {
+      running: "Updating page",
+      done: "Update page",
+    },
   },
   retrieve_block: {
     description: "Retrieve a Notion block by its ID.",
@@ -334,6 +370,10 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
       blockId: z.string().describe("The Notion block ID."),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Retrieving block",
+      done: "Retrieve block",
+    },
   },
   retrieve_block_children: {
     description: "Retrieve the children of a Notion block or page by its ID.",
@@ -346,6 +386,10 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
       page_size: z.number().optional().describe("Page size for pagination."),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Retrieving block children",
+      done: "Retrieve block children",
+    },
   },
   add_page_content: {
     description:
@@ -359,6 +403,10 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "low",
+    displayLabels: {
+      running: "Adding page content",
+      done: "Add page content",
+    },
   },
   create_comment: {
     description:
@@ -380,6 +428,10 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
       comment: z.string().describe("The comment text."),
     },
     stake: "low",
+    displayLabels: {
+      running: "Creating comment",
+      done: "Create comment",
+    },
   },
   delete_block: {
     description:
@@ -388,6 +440,10 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
       blockId: z.string().describe("The ID of the block"),
     },
     stake: "low",
+    displayLabels: {
+      running: "Deleting block",
+      done: "Delete block",
+    },
   },
   delete_page: {
     description:
@@ -396,6 +452,10 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
       pageId: z.string().describe("The ID of the page"),
     },
     stake: "low",
+    displayLabels: {
+      running: "Deleting page",
+      done: "Delete page",
+    },
   },
   fetch_comments: {
     description:
@@ -406,6 +466,10 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
         .describe("The ID of the page or block to fetch comments from."),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Fetching comments",
+      done: "Fetch comments",
+    },
   },
   update_row_database: {
     description:
@@ -415,6 +479,10 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
       properties: propertiesSchema,
     },
     stake: "low",
+    displayLabels: {
+      running: "Updating row",
+      done: "Update row",
+    },
   },
   update_schema_database: {
     description:
@@ -424,11 +492,19 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
       properties: propertiesSchema,
     },
     stake: "low",
+    displayLabels: {
+      running: "Updating database schema",
+      done: "Update database schema",
+    },
   },
   list_users: {
     description: "List all users in the Notion workspace.",
     schema: {},
     stake: "never_ask",
+    displayLabels: {
+      running: "Listing users",
+      done: "List users",
+    },
   },
   get_about_user: {
     description: "Get information about a specific user by userId.",
@@ -436,6 +512,10 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
       userId: z.string().describe("The Notion user ID."),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Getting user info",
+      done: "Get user info",
+    },
   },
 });
 
@@ -456,6 +536,7 @@ export const NOTION_SERVER = {
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+    displayLabels: t.displayLabels,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(NOTION_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/notion/metadata.ts
+++ b/front/lib/api/actions/servers/notion/metadata.ts
@@ -513,8 +513,8 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Getting user info",
-      done: "Get user info",
+      running: "Retrieving user info",
+      done: "Retrieve user info",
     },
   },
 });

--- a/front/lib/api/actions/servers/primitive_types_debugger/metadata.ts
+++ b/front/lib/api/actions/servers/primitive_types_debugger/metadata.ts
@@ -89,11 +89,19 @@ export const PRIMITIVE_TYPES_DEBUGGER_TOOLS_METADATA = createToolsRecord({
     description: "This tool is used to test the tool without user config.",
     schema: toolWithoutUserConfigSchema,
     stake: "never_ask",
+    displayLabels: {
+      running: "Running debug tool",
+      done: "Run debug tool",
+    },
   },
   pass_through: {
     description: "Super useful tool that should be used at all times.",
     schema: passThroughSchema,
     stake: "never_ask",
+    displayLabels: {
+      running: "Passing through",
+      done: "Pass through",
+    },
   },
 });
 
@@ -113,6 +121,7 @@ export const PRIMITIVE_TYPES_DEBUGGER_SERVER = {
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+    displayLabels: t.displayLabels,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(PRIMITIVE_TYPES_DEBUGGER_TOOLS_METADATA).map((t) => [

--- a/front/lib/api/actions/servers/project_context_management/metadata.ts
+++ b/front/lib/api/actions/servers/project_context_management/metadata.ts
@@ -14,6 +14,10 @@ export const PROJECT_CONTEXT_MANAGEMENT_TOOLS_METADATA = createToolsRecord({
       "List all files in the project context. Returns file metadata including names, IDs, and content types.",
     schema: {},
     stake: "never_ask",
+    displayLabels: {
+      running: "Listing project files",
+      done: "List project files",
+    },
   },
   add_project_file: {
     description:
@@ -41,6 +45,10 @@ export const PROJECT_CONTEXT_MANAGEMENT_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "high",
+    displayLabels: {
+      running: "Adding project file",
+      done: "Add project file",
+    },
   },
   update_project_file: {
     description:
@@ -62,6 +70,10 @@ export const PROJECT_CONTEXT_MANAGEMENT_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "high",
+    displayLabels: {
+      running: "Updating project file",
+      done: "Update project file",
+    },
   },
   edit_project_description: {
     description:
@@ -72,6 +84,10 @@ export const PROJECT_CONTEXT_MANAGEMENT_TOOLS_METADATA = createToolsRecord({
         .describe("New project description (free-form text)."),
     },
     stake: "low",
+    displayLabels: {
+      running: "Editing project description",
+      done: "Edit project description",
+    },
   },
   add_project_url: {
     description:
@@ -83,6 +99,10 @@ export const PROJECT_CONTEXT_MANAGEMENT_TOOLS_METADATA = createToolsRecord({
       url: z.string().describe("The URL to add"),
     },
     stake: "low",
+    displayLabels: {
+      running: "Adding project URL",
+      done: "Add project URL",
+    },
   },
   edit_project_url: {
     description:
@@ -100,6 +120,10 @@ export const PROJECT_CONTEXT_MANAGEMENT_TOOLS_METADATA = createToolsRecord({
         .describe("New URL value (leave empty to keep current)"),
     },
     stake: "low",
+    displayLabels: {
+      running: "Editing project URL",
+      done: "Edit project URL",
+    },
   },
   read_project_journal_entry: {
     description:
@@ -111,6 +135,10 @@ export const PROJECT_CONTEXT_MANAGEMENT_TOOLS_METADATA = createToolsRecord({
         .describe("Maximum number of journal entries to return (default: 1)"),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Reading journal entries",
+      done: "Read journal entries",
+    },
   },
 });
 
@@ -135,6 +163,7 @@ export const PROJECT_CONTEXT_MANAGEMENT_SERVER = {
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+    displayLabels: t.displayLabels,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(PROJECT_CONTEXT_MANAGEMENT_TOOLS_METADATA).map((t) => [

--- a/front/lib/api/actions/servers/run_dust_app/metadata.ts
+++ b/front/lib/api/actions/servers/run_dust_app/metadata.ts
@@ -25,6 +25,10 @@ export const RUN_DUST_APP_TOOLS_METADATA = createToolsRecord({
         ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_APP],
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Running Dust app",
+      done: "Run Dust app",
+    },
   },
 });
 
@@ -42,6 +46,7 @@ export const RUN_DUST_APP_SERVER = {
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+    displayLabels: t.displayLabels,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(RUN_DUST_APP_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/snowflake/metadata.ts
+++ b/front/lib/api/actions/servers/snowflake/metadata.ts
@@ -14,6 +14,10 @@ export const SNOWFLAKE_TOOLS_METADATA = createToolsRecord({
       "List all databases accessible to the authenticated Snowflake user.",
     schema: {},
     stake: "never_ask",
+    displayLabels: {
+      running: "Listing databases",
+      done: "List databases",
+    },
   },
   list_schemas: {
     description: "List all schemas within a specified Snowflake database.",
@@ -23,6 +27,10 @@ export const SNOWFLAKE_TOOLS_METADATA = createToolsRecord({
         .describe("The name of the database to list schemas from."),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Listing schemas",
+      done: "List schemas",
+    },
   },
   list_tables: {
     description:
@@ -34,6 +42,10 @@ export const SNOWFLAKE_TOOLS_METADATA = createToolsRecord({
         .describe("The name of the schema to list tables from."),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Listing tables",
+      done: "List tables",
+    },
   },
   describe_table: {
     description:
@@ -44,6 +56,10 @@ export const SNOWFLAKE_TOOLS_METADATA = createToolsRecord({
       table: z.string().describe("The name of the table to describe."),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Describing table",
+      done: "Describe table",
+    },
   },
   query: {
     description:
@@ -75,6 +91,10 @@ export const SNOWFLAKE_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Executing query",
+      done: "Execute query",
+    },
   },
 });
 
@@ -97,6 +117,7 @@ export const SNOWFLAKE_SERVER = {
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+    displayLabels: t.displayLabels,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(SNOWFLAKE_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/sound_studio/metadata.ts
+++ b/front/lib/api/actions/servers/sound_studio/metadata.ts
@@ -40,6 +40,10 @@ export const SOUND_STUDIO_TOOLS_METADATA = createToolsRecord({
         .describe("Base filename (without extension) for the generated audio."),
     },
     stake: "low",
+    displayLabels: {
+      running: "Generating sound effect",
+      done: "Generate sound effect",
+    },
   },
 });
 
@@ -57,6 +61,7 @@ export const SOUND_STUDIO_SERVER = {
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+    displayLabels: t.displayLabels,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(SOUND_STUDIO_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/speech_generator/metadata.ts
+++ b/front/lib/api/actions/servers/speech_generator/metadata.ts
@@ -75,6 +75,10 @@ export const SPEECH_GENERATOR_TOOLS_METADATA = createToolsRecord({
         .describe("Base filename (without extension) for the generated audio."),
     },
     stake: "low",
+    displayLabels: {
+      running: "Generating speech",
+      done: "Generate speech",
+    },
   },
   text_to_dialogue: {
     description: "Generate dialogue audio from multiple lines with speakers.",
@@ -111,6 +115,10 @@ export const SPEECH_GENERATOR_TOOLS_METADATA = createToolsRecord({
         .describe("Base filename (without extension) for the generated audio."),
     },
     stake: "low",
+    displayLabels: {
+      running: "Generating dialogue",
+      done: "Generate dialogue",
+    },
   },
 });
 
@@ -128,6 +136,7 @@ export const SPEECH_GENERATOR_SERVER = {
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+    displayLabels: t.displayLabels,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(SPEECH_GENERATOR_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/statuspage/metadata.ts
+++ b/front/lib/api/actions/servers/statuspage/metadata.ts
@@ -19,6 +19,10 @@ export const STATUSPAGE_TOOLS_METADATA = createToolsRecord({
       "Use this to discover available page IDs before using other tools.",
     schema: {},
     stake: "never_ask",
+    displayLabels: {
+      running: "Listing status pages",
+      done: "List status pages",
+    },
   },
   list_components: {
     description:
@@ -32,6 +36,10 @@ export const STATUSPAGE_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Listing components",
+      done: "List components",
+    },
   },
   list_incidents: {
     description:
@@ -53,6 +61,10 @@ export const STATUSPAGE_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Listing incidents",
+      done: "List incidents",
+    },
   },
   get_incident: {
     description:
@@ -71,6 +83,10 @@ export const STATUSPAGE_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Getting incident",
+      done: "Get incident",
+    },
   },
   create_incident: {
     description:
@@ -105,6 +121,10 @@ export const STATUSPAGE_TOOLS_METADATA = createToolsRecord({
       ),
     },
     stake: "high",
+    displayLabels: {
+      running: "Creating incident",
+      done: "Create incident",
+    },
   },
   update_incident: {
     description:
@@ -140,6 +160,10 @@ export const STATUSPAGE_TOOLS_METADATA = createToolsRecord({
       ),
     },
     stake: "high",
+    displayLabels: {
+      running: "Updating incident",
+      done: "Update incident",
+    },
   },
 });
 
@@ -158,6 +182,7 @@ export const STATUSPAGE_SERVER = {
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+    displayLabels: t.displayLabels,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(STATUSPAGE_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/ukg_ready/metadata.ts
+++ b/front/lib/api/actions/servers/ukg_ready/metadata.ts
@@ -14,8 +14,8 @@ export const UKG_READY_TOOLS_METADATA = createToolsRecord({
     schema: {},
     stake: "never_ask",
     displayLabels: {
-      running: "Getting employee info",
-      done: "Get employee info",
+      running: "Retrieving employee info",
+      done: "Retrieve employee info",
     },
   },
   get_pto_requests: {
@@ -37,8 +37,8 @@ export const UKG_READY_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Getting PTO requests",
-      done: "Get PTO requests",
+      running: "Retrieving PTO requests",
+      done: "Retrieve PTO requests",
     },
   },
   get_accrual_balances: {
@@ -59,8 +59,8 @@ export const UKG_READY_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Getting accrual balances",
-      done: "Get accrual balances",
+      running: "Retrieving accrual balances",
+      done: "Retrieve accrual balances",
     },
   },
   get_pto_request_notes: {
@@ -74,8 +74,8 @@ export const UKG_READY_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Getting PTO notes",
-      done: "Get PTO notes",
+      running: "Retrieving PTO notes",
+      done: "Retrieve PTO notes",
     },
   },
   create_pto_request: {
@@ -172,8 +172,8 @@ export const UKG_READY_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Getting schedules",
-      done: "Get schedules",
+      running: "Listing schedules",
+      done: "List schedules",
     },
   },
   get_employees: {
@@ -181,8 +181,8 @@ export const UKG_READY_TOOLS_METADATA = createToolsRecord({
     schema: {},
     stake: "never_ask",
     displayLabels: {
-      running: "Getting employees",
-      done: "Get employees",
+      running: "Listing employees",
+      done: "List employees",
     },
   },
 });

--- a/front/lib/api/actions/servers/ukg_ready/metadata.ts
+++ b/front/lib/api/actions/servers/ukg_ready/metadata.ts
@@ -13,6 +13,10 @@ export const UKG_READY_TOOLS_METADATA = createToolsRecord({
       "Get your own employee information from UKG Ready, including your employee ID, name, and username.",
     schema: {},
     stake: "never_ask",
+    displayLabels: {
+      running: "Getting employee info",
+      done: "Get employee info",
+    },
   },
   get_pto_requests: {
     description:
@@ -32,6 +36,10 @@ export const UKG_READY_TOOLS_METADATA = createToolsRecord({
         .describe("List of usernames to filter by"),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Getting PTO requests",
+      done: "Get PTO requests",
+    },
   },
   get_accrual_balances: {
     description: "Get accrual balances for yourself or a specific employee.",
@@ -50,6 +58,10 @@ export const UKG_READY_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Getting accrual balances",
+      done: "Get accrual balances",
+    },
   },
   get_pto_request_notes: {
     description: "Get notes/comments for a specific PTO request.",
@@ -61,6 +73,10 @@ export const UKG_READY_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Getting PTO notes",
+      done: "Get PTO notes",
+    },
   },
   create_pto_request: {
     description:
@@ -114,6 +130,10 @@ export const UKG_READY_TOOLS_METADATA = createToolsRecord({
         .describe("Optional comment/note for the PTO request"),
     },
     stake: "low",
+    displayLabels: {
+      running: "Creating PTO request",
+      done: "Create PTO request",
+    },
   },
   delete_pto_request: {
     description: "Delete one or more PTO/time-off requests.",
@@ -127,6 +147,10 @@ export const UKG_READY_TOOLS_METADATA = createToolsRecord({
         .describe("Optional comment explaining the deletion"),
     },
     stake: "low",
+    displayLabels: {
+      running: "Deleting PTO request",
+      done: "Delete PTO request",
+    },
   },
   get_schedules: {
     description: "Get work schedules for yourself or a specific employee.",
@@ -147,11 +171,19 @@ export const UKG_READY_TOOLS_METADATA = createToolsRecord({
         .describe("Filter schedules to this date (YYYY-MM-DD)"),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Getting schedules",
+      done: "Get schedules",
+    },
   },
   get_employees: {
     description: "Get a list of active employees.",
     schema: {},
     stake: "never_ask",
+    displayLabels: {
+      running: "Getting employees",
+      done: "Get employees",
+    },
   },
 });
 
@@ -173,6 +205,7 @@ export const UKG_READY_SERVER = {
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+    displayLabels: t.displayLabels,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(UKG_READY_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/web_search_browse/metadata.ts
+++ b/front/lib/api/actions/servers/web_search_browse/metadata.ts
@@ -25,6 +25,10 @@ export const WEB_SEARCH_BROWSE_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Searching the web",
+      done: "Web search",
+    },
   },
   webbrowser: {
     description:
@@ -47,6 +51,10 @@ export const WEB_SEARCH_BROWSE_TOOLS_METADATA = createToolsRecord({
         .describe("If true, also retrieve outgoing links from the page."),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Browsing web page",
+      done: "Browse web page",
+    },
   },
 });
 
@@ -64,6 +72,7 @@ export const WEB_SEARCH_BROWSE_SERVER = {
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+    displayLabels: t.displayLabels,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(WEB_SEARCH_BROWSE_TOOLS_METADATA).map((t) => [

--- a/front/lib/api/assistant/citations.ts
+++ b/front/lib/api/assistant/citations.ts
@@ -55,9 +55,7 @@ export function citationMetaPrompt(isUsingRunAgent: boolean) {
 export function getCitationsFromActions(
   actions: Omit<
     AgentMCPActionWithOutputType,
-    // TODO(2025-09-22 aubin): add proper typing for the statuses in the SDK (not really needed but
-    //  nice to have IMHO).
-    "internalMCPServerName" | "toolName" | "status"
+    "internalMCPServerName" | "toolName" | "status" | "displayLabels"
   >[]
 ): Record<string, CitationType> {
   const searchResultsWithDocs = removeNulls(

--- a/front/lib/api/mcp.ts
+++ b/front/lib/api/mcp.ts
@@ -41,10 +41,16 @@ export function getRetryPolicyFromToolConfiguration(
       DEFAULT_MCP_TOOL_RETRY_POLICY;
 }
 
+export type ToolDisplayLabels = {
+  running: string; // e.g. "Searching data"
+  done: string; // e.g. "Search data"
+};
+
 export type MCPToolType = {
   name: string;
   description: string;
   inputSchema?: JSONSchema;
+  displayLabels?: ToolDisplayLabels;
 };
 
 export type MCPToolWithAvailabilityType = MCPToolType & {

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -11,7 +11,10 @@ import { Op } from "sequelize";
 import type { BlockedToolExecution } from "@app/lib/actions/mcp";
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
-import { getInternalMCPServerNameFromSId } from "@app/lib/actions/mcp_internal_actions/constants";
+import {
+  getInternalMCPServerNameFromSId,
+  getInternalMCPServerToolDisplayLabels,
+} from "@app/lib/actions/mcp_internal_actions/constants";
 import { isToolGeneratedFile } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { hideFileFromActionOutput } from "@app/lib/actions/mcp_utils";
 import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
@@ -667,6 +670,15 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
       "Action linked to a non-function call step content."
     );
 
+    const internalMCPServerName = this.metadata.internalMCPServerName;
+    const toolName = this.toolConfiguration.originalName;
+
+    const displayLabels = internalMCPServerName
+      ? (getInternalMCPServerToolDisplayLabels(internalMCPServerName)?.[
+          toolName
+        ] ?? null)
+      : null;
+
     return {
       id: this.id,
       sId: this.sId,
@@ -676,13 +688,14 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
       citationsAllocated: this.citationsAllocated,
       functionCallName: this.functionCallName,
       functionCallId: this.stepContent.value.value.id,
-      internalMCPServerName: this.metadata.internalMCPServerName,
-      toolName: this.toolConfiguration.originalName,
+      internalMCPServerName,
+      toolName,
       mcpServerId: this.metadata.mcpServerId,
       params: this.augmentedInputs,
       status: this.status,
       step: this.stepContent.step,
       executionDurationMs: this.executionDurationMs,
+      displayLabels,
     };
   }
 

--- a/front/runbooks/NEW_MCP_SERVER.md
+++ b/front/runbooks/NEW_MCP_SERVER.md
@@ -110,6 +110,10 @@ export const YOUR_PROVIDER_TOOLS_METADATA = createToolsRecord({
       maxResults: z.number().optional().describe("Maximum results to return."),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Listing Items",
+      done: "List items",
+    },
   },
   get_item: {
     description: "Get a single item by ID.",
@@ -117,6 +121,10 @@ export const YOUR_PROVIDER_TOOLS_METADATA = createToolsRecord({
       itemId: z.string().describe("The ID of the item to retrieve."),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Retrieving item",
+      done: "Retrieve item",
+    },
   },
   create_item: {
     description: "Create a new item.",
@@ -125,6 +133,10 @@ export const YOUR_PROVIDER_TOOLS_METADATA = createToolsRecord({
       description: z.string().optional().describe("Description of the item."),
     },
     stake: "low",
+    displayLabels: {
+      running: "Creating item",
+      done: "Create item",
+    },
   },
 });
 
@@ -147,6 +159,7 @@ export const YOUR_PROVIDER_SERVER = {
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+    displayLabels: t.displayLabels,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(YOUR_PROVIDER_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/temporal/agent_loop/lib/event_coalescer.test.ts
+++ b/front/temporal/agent_loop/lib/event_coalescer.test.ts
@@ -56,6 +56,7 @@ describe("EventCoalescer", () => {
       executionDurationMs: null,
       generatedFiles: [],
       output: null,
+      displayLabels: null,
     },
   });
 

--- a/front/types/actions.ts
+++ b/front/types/actions.ts
@@ -23,6 +23,10 @@ export type AgentMCPActionType = {
   status: ToolExecutionStatus;
   step: number;
   executionDurationMs: number | null;
+  displayLabels: {
+    running: string;
+    done: string;
+  } | null;
 };
 
 export type AgentMCPActionWithOutputType = AgentMCPActionType & {


### PR DESCRIPTION
## Description

- This PR allows defining display labels for tools when they are running and when they are done.
- These labels are surfaced in the front-end and used in the action details.
- Only applies to tools migrated to the metadata pattern, we need to fully migrated every MCP server to rely on this entirely and cleanup the typing.

## Tests

- Tested locally and via the Chrome extension.

## Risk

- Low.

## Deploy Plan

- Deploy front.
