### PR TITLE
[dust-hive] Add dust-hive feed command for running seed scenarios

### DIFF
--- a/x/henry/dust-hive/src/commands/feed.ts
+++ b/x/henry/dust-hive/src/commands/feed.ts
@@ -1,12 +1,18 @@
 import { readdir } from "node:fs/promises";
 import path from "node:path";
 import * as p from "@clack/prompts";
-import { withEnvironment } from "../lib/commands";
+import { setLastActiveEnv } from "../lib/activity";
+import { getEnvironment } from "../lib/environment";
 import { directoryExists, fileExists } from "../lib/fs";
 import { logger } from "../lib/logger";
 import { getWorktreeDir } from "../lib/paths";
-import { CommandError, Err, Ok } from "../lib/result";
+import { restoreTerminal, selectEnvironment } from "../lib/prompt";
+import { CommandError, Err, Ok, type Result, envNotFoundError } from "../lib/result";
 import { getStateInfo } from "../lib/state";
+
+// Folders to ignore when scanning for scenarios
+// These are utility folders that don't contain seed scripts
+const IGNORED_FOLDERS = new Set(["factories"]);
 
 // Get list of available scenarios by scanning the seed directory
 async function getAvailableScenarios(frontPath: string): Promise<string[]> {
@@ -23,7 +29,7 @@ async function getAvailableScenarios(frontPath: string): Promise<string[]> {
 
     const scenarios: string[] = [];
     for (const entry of entries) {
-      if (entry.isDirectory()) {
+      if (entry.isDirectory() && !IGNORED_FOLDERS.has(entry.name)) {
         // Check if seed.ts exists in this directory
         const seedFile = path.join(seedPath, entry.name, "seed.ts");
         const exists = await fileExists(seedFile);
@@ -58,73 +64,99 @@ async function selectScenario(scenarios: string[]): Promise<string | null> {
   return result as string;
 }
 
-export const feedCommand = withEnvironment(
-  "feed",
-  async (env, scenarioNameArg: string | undefined) => {
-    // Check if environment is warm
-    const stateInfo = await getStateInfo(env);
-    if (stateInfo.state !== "warm") {
-      return Err(
-        new CommandError(
-          `Environment '${env.name}' is not warm (current state: ${stateInfo.state}). Run 'dust-hive warm ${env.name}' first.`
-        )
-      );
-    }
-
-    // Get front directory path
-    const worktreePath = getWorktreeDir(env.name);
-    const frontPath = path.join(worktreePath, "front");
-
-    // Get list of available scenarios
-    const availableScenarios = await getAvailableScenarios(frontPath);
-
-    if (availableScenarios.length === 0) {
-      return Err(new CommandError("No scenarios found in front/scripts/seed/"));
-    }
-
-    // If no scenario name provided, prompt interactively
-    let scenarioName = scenarioNameArg;
-    if (!scenarioName) {
-      const selected = await selectScenario(availableScenarios);
-      if (!selected) {
-        return Err(new CommandError("No scenario selected"));
-      }
-      scenarioName = selected;
-    }
-
-    // Check if scenario exists
-    const scenarioScriptPath = path.join(frontPath, "scripts", "seed", scenarioName, "seed.ts");
-    const scenarioExists = await fileExists(scenarioScriptPath);
-
-    if (!scenarioExists) {
-      const scenarioList = availableScenarios.map((s) => `  - ${s}`).join("\n");
-      return Err(
-        new CommandError(
-          `Scenario '${scenarioName}' not found.\n\nAvailable scenarios:\n${scenarioList}`
-        )
-      );
-    }
-
-    // Run the seed script
-    logger.info(`Running seed script for scenario '${scenarioName}'...`);
-    console.log();
-
-    const proc = Bun.spawn(["npx", "tsx", `scripts/seed/${scenarioName}/seed.ts`, "--execute"], {
-      cwd: frontPath,
-      stdout: "inherit",
-      stderr: "inherit",
-      stdin: "inherit",
+export async function feedCommand(
+  nameArg: string | undefined,
+  scenarioNameArg: string | undefined
+): Promise<Result<void>> {
+  // Handle environment selection
+  let envName = nameArg;
+  if (!envName) {
+    const selected = await selectEnvironment({
+      message: "Select environment for feed",
     });
 
-    const exitCode = await proc.exited;
-
-    if (exitCode !== 0) {
-      return Err(new CommandError(`Seed script failed with exit code ${exitCode}`));
+    if (!selected) {
+      return Err(new CommandError("No environment selected"));
     }
 
-    console.log();
-    logger.success(`Scenario '${scenarioName}' seeded successfully`);
-
-    return Ok(undefined);
+    envName = selected;
   }
-);
+
+  const env = await getEnvironment(envName);
+  if (!env) {
+    return Err(envNotFoundError(envName));
+  }
+
+  // Track this environment as last-active
+  await setLastActiveEnv(env.name);
+
+  // Check if environment is warm
+  const stateInfo = await getStateInfo(env);
+  if (stateInfo.state !== "warm") {
+    return Err(
+      new CommandError(
+        `Environment '${env.name}' is not warm (current state: ${stateInfo.state}). Run 'dust-hive warm ${env.name}' first.`
+      )
+    );
+  }
+
+  // Get front directory path
+  const worktreePath = getWorktreeDir(env.name);
+  const frontPath = path.join(worktreePath, "front");
+
+  // Get list of available scenarios
+  const availableScenarios = await getAvailableScenarios(frontPath);
+
+  if (availableScenarios.length === 0) {
+    return Err(new CommandError("No scenarios found in front/scripts/seed/"));
+  }
+
+  // Handle scenario selection
+  let scenarioName = scenarioNameArg;
+  if (!scenarioName) {
+    const selected = await selectScenario(availableScenarios);
+    if (!selected) {
+      return Err(new CommandError("No scenario selected"));
+    }
+    scenarioName = selected;
+  }
+
+  // Restore terminal after all interactive prompts are done
+  // This is important before spawning the seed script subprocess
+  restoreTerminal();
+
+  // Check if scenario exists
+  const scenarioScriptPath = path.join(frontPath, "scripts", "seed", scenarioName, "seed.ts");
+  const scenarioExists = await fileExists(scenarioScriptPath);
+
+  if (!scenarioExists) {
+    const scenarioList = availableScenarios.map((s) => `  - ${s}`).join("\n");
+    return Err(
+      new CommandError(
+        `Scenario '${scenarioName}' not found.\n\nAvailable scenarios:\n${scenarioList}`
+      )
+    );
+  }
+
+  // Run the seed script
+  logger.info(`Running seed script for scenario '${scenarioName}'...`);
+  console.log();
+
+  const proc = Bun.spawn(["npx", "tsx", `scripts/seed/${scenarioName}/seed.ts`, "--execute"], {
+    cwd: frontPath,
+    stdout: "inherit",
+    stderr: "inherit",
+    stdin: "inherit",
+  });
+
+  const exitCode = await proc.exited;
+
+  if (exitCode !== 0) {
+    return Err(new CommandError(`Seed script failed with exit code ${exitCode}`));
+  }
+
+  console.log();
+  logger.success(`Scenario '${scenarioName}' seeded successfully`);
+
+  return Ok(undefined);
+}

--- a/x/henry/dust-hive/src/commands/feed.ts
+++ b/x/henry/dust-hive/src/commands/feed.ts
@@ -1,0 +1,130 @@
+import { readdir } from "node:fs/promises";
+import path from "node:path";
+import * as p from "@clack/prompts";
+import { withEnvironment } from "../lib/commands";
+import { directoryExists, fileExists } from "../lib/fs";
+import { logger } from "../lib/logger";
+import { getWorktreeDir } from "../lib/paths";
+import { CommandError, Err, Ok } from "../lib/result";
+import { getStateInfo } from "../lib/state";
+
+// Get list of available scenarios by scanning the seed directory
+async function getAvailableScenarios(frontPath: string): Promise<string[]> {
+  const seedPath = path.join(frontPath, "scripts", "seed");
+
+  try {
+    const dirExists = await directoryExists(seedPath);
+    if (!dirExists) {
+      return [];
+    }
+
+    // Read directory entries
+    const entries = await readdir(seedPath, { withFileTypes: true });
+
+    const scenarios: string[] = [];
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        // Check if seed.ts exists in this directory
+        const seedFile = path.join(seedPath, entry.name, "seed.ts");
+        const exists = await fileExists(seedFile);
+        if (exists) {
+          scenarios.push(entry.name);
+        }
+      }
+    }
+
+    return scenarios.sort();
+  } catch (_error) {
+    return [];
+  }
+}
+
+// Interactively select a scenario using arrow keys
+async function selectScenario(scenarios: string[]): Promise<string | null> {
+  if (scenarios.length === 0) {
+    return null;
+  }
+
+  const result = await p.select({
+    message: "Select scenario to run",
+    initialValue: scenarios[0],
+    options: scenarios.map((name) => ({ value: name, label: name })),
+  });
+
+  if (p.isCancel(result)) {
+    return null;
+  }
+
+  return result as string;
+}
+
+export const feedCommand = withEnvironment(
+  "feed",
+  async (env, scenarioNameArg: string | undefined) => {
+    // Check if environment is warm
+    const stateInfo = await getStateInfo(env);
+    if (stateInfo.state !== "warm") {
+      return Err(
+        new CommandError(
+          `Environment '${env.name}' is not warm (current state: ${stateInfo.state}). Run 'dust-hive warm ${env.name}' first.`
+        )
+      );
+    }
+
+    // Get front directory path
+    const worktreePath = getWorktreeDir(env.name);
+    const frontPath = path.join(worktreePath, "front");
+
+    // Get list of available scenarios
+    const availableScenarios = await getAvailableScenarios(frontPath);
+
+    if (availableScenarios.length === 0) {
+      return Err(new CommandError("No scenarios found in front/scripts/seed/"));
+    }
+
+    // If no scenario name provided, prompt interactively
+    let scenarioName = scenarioNameArg;
+    if (!scenarioName) {
+      const selected = await selectScenario(availableScenarios);
+      if (!selected) {
+        return Err(new CommandError("No scenario selected"));
+      }
+      scenarioName = selected;
+    }
+
+    // Check if scenario exists
+    const scenarioScriptPath = path.join(frontPath, "scripts", "seed", scenarioName, "seed.ts");
+    const scenarioExists = await fileExists(scenarioScriptPath);
+
+    if (!scenarioExists) {
+      const scenarioList = availableScenarios.map((s) => `  - ${s}`).join("\n");
+      return Err(
+        new CommandError(
+          `Scenario '${scenarioName}' not found.\n\nAvailable scenarios:\n${scenarioList}`
+        )
+      );
+    }
+
+    // Run the seed script
+    logger.info(`Running seed script for scenario '${scenarioName}'...`);
+    console.log();
+
+    const proc = Bun.spawn(["npx", "tsx", `scripts/seed/${scenarioName}/seed.ts`, "--execute"], {
+      cwd: frontPath,
+      stdout: "inherit",
+      stderr: "inherit",
+      stdin: "inherit",
+    });
+
+    const exitCode = await proc.exited;
+
+    if (exitCode !== 0) {
+      return Err(new CommandError(`Seed script failed with exit code ${exitCode}`));
+    }
+
+    console.log();
+    logger.success(`Scenario '${scenarioName}' seeded successfully`);
+
+    return Ok(undefined);
+  }
+);

--- a/x/henry/dust-hive/src/index.ts
+++ b/x/henry/dust-hive/src/index.ts
@@ -317,7 +317,7 @@ cli
   });
 
 cli
-  .command("feed [name] <scenario>", "Run seed script for a scenario")
+  .command("feed [name] [scenario]", "Run seed script for a scenario")
   .action(async (name: string | undefined, scenario: string | undefined) => {
     await prepareAndRun(feedCommand(name, scenario));
   });

--- a/x/henry/dust-hive/src/index.ts
+++ b/x/henry/dust-hive/src/index.ts
@@ -6,6 +6,7 @@ import { coolCommand } from "./commands/cool";
 import { destroyCommand } from "./commands/destroy";
 import { doctorCommand, setupCommand } from "./commands/doctor";
 import { downCommand } from "./commands/down";
+import { feedCommand } from "./commands/feed";
 import { forwardCommand, forwardStatusCommand, forwardStopCommand } from "./commands/forward";
 import { listCommand } from "./commands/list";
 import { logsCommand } from "./commands/logs";
@@ -313,6 +314,12 @@ cli
   )
   .action(async (postgresUri: string) => {
     await prepareAndRun(seedConfigCommand(postgresUri));
+  });
+
+cli
+  .command("feed [name] <scenario>", "Run seed script for a scenario")
+  .action(async (name: string | undefined, scenario: string | undefined) => {
+    await prepareAndRun(feedCommand(name, scenario));
   });
 
 cli.help();

--- a/x/henry/dust-hive/src/lib/commands.ts
+++ b/x/henry/dust-hive/src/lib/commands.ts
@@ -9,6 +9,9 @@ export interface RequireEnvironmentOptions {
   /** If provided, shows a confirmation prompt after selection.
    * Use {name} as placeholder for the selected environment name. */
   confirmMessage?: string;
+  /** If true, skip restoring terminal after interactive selection.
+   * Useful when more interactive prompts follow. Default: false */
+  skipRestoreTerminal?: boolean;
 }
 
 // Require an environment to exist, returning error if not found
@@ -29,7 +32,9 @@ export async function requireEnvironment(
 
     // Restore terminal to cooked mode after interactive prompt
     // This prevents terminal corruption when spawning subprocesses like zellij
-    restoreTerminal();
+    if (!options?.skipRestoreTerminal) {
+      restoreTerminal();
+    }
 
     if (!selected) {
       return Err(new CommandError("No environment selected"));


### PR DESCRIPTION
## Description

Add a `dust-hive`feed command which allow loading data from the front/script/seed scenarios scripts.

```
~/dust-hive/hive-feed hive-feed *26 # dust-hive feed hive-feed basics
info Running seed script for scenario 'basics'...

{"level":"info","time":1769508622802,"pid":85975,"hostname":"Fabiens-MacBook-Pro.local","execute":true,"msg":"Loading workspace..."}
{"level":"info","time":1769508629413,"pid":85975,"hostname":"Fabiens-MacBook-

....

{"level":"info","time":1769508629474,"pid":85975,"hostname":"Fabiens-MacBook-Pro.local","execute":true,"msg":"Basics seed completed"}

ok Scenario 'basics' seeded successfully
```


https://github.com/user-attachments/assets/f845ac16-3789-4eb7-9a99-fa89fdb25b9e



## Tests

manual tests

## Risk
low

## Deploy Plan
none
