### PR TITLE
[front] Add workspace isolation bypass on `extension_configurations` query

### DIFF
--- a/front/lib/resources/extension.ts
+++ b/front/lib/resources/extension.ts
@@ -119,7 +119,8 @@ export class ExtensionConfigurationResource extends BaseResource<ExtensionConfig
       where: {
         workspaceId: workspaceIds,
       },
-      // Exceptional case where we need to fetch the blacklistedDomains across multiple workspaces.
+      // WORKSPACE_ISOLATION_BYPASS: exceptional case where we need to fetch the blacklistedDomains \
+      // across multiple workspaces in the login flow.
       dangerouslyBypassWorkspaceIsolationSecurity: true,
     });
 

--- a/front/lib/resources/extension.ts
+++ b/front/lib/resources/extension.ts
@@ -8,8 +8,8 @@ import type {
 import type { Authenticator } from "@app/lib/auth";
 import { ExtensionConfigurationModel } from "@app/lib/models/extension";
 import { BaseResource } from "@app/lib/resources/base_resource";
-import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
+import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
 import { makeSId } from "@app/lib/resources/string_ids";
 import type { ExtensionConfigurationType, ModelId, Result } from "@app/types";
 import { Err, normalizeError, Ok } from "@app/types";

--- a/front/lib/resources/extension.ts
+++ b/front/lib/resources/extension.ts
@@ -8,6 +8,7 @@ import type {
 import type { Authenticator } from "@app/lib/auth";
 import { ExtensionConfigurationModel } from "@app/lib/models/extension";
 import { BaseResource } from "@app/lib/resources/base_resource";
+import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import { makeSId } from "@app/lib/resources/string_ids";
 import type { ExtensionConfigurationType, ModelId, Result } from "@app/types";
@@ -19,7 +20,7 @@ import { Err, normalizeError, Ok } from "@app/types";
 export interface ExtensionConfigurationResource extends ReadonlyAttributesType<ExtensionConfigurationModel> {}
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class ExtensionConfigurationResource extends BaseResource<ExtensionConfigurationModel> {
-  static model: ModelStatic<ExtensionConfigurationModel> =
+  static model: ModelStaticWorkspaceAware<ExtensionConfigurationModel> =
     ExtensionConfigurationModel;
 
   constructor(
@@ -118,6 +119,7 @@ export class ExtensionConfigurationResource extends BaseResource<ExtensionConfig
       where: {
         workspaceId: workspaceIds,
       },
+      dangerouslyBypassWorkspaceIsolationSecurity: true,
     });
 
     return configs.map(

--- a/front/lib/resources/extension.ts
+++ b/front/lib/resources/extension.ts
@@ -119,6 +119,7 @@ export class ExtensionConfigurationResource extends BaseResource<ExtensionConfig
       where: {
         workspaceId: workspaceIds,
       },
+      // Exceptional case where we need to fetch the blacklistedDomains across multiple workspaces.
       dangerouslyBypassWorkspaceIsolationSecurity: true,
     });
 


### PR DESCRIPTION
## Description

- When developing on the extension the login currently fails on a workspace isolation error.
- The underlying query fetches the `extension_configurations` across multiple workspaces and is a legitimate case of such queries.
- This PR adds a bypass to allow logging in when developing locally.
- No change in production (in production we only log on workspace isolation errors).

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
