### PR TITLE
fix(dust-hive): wait for SDK build before starting front in warm

### DIFF
--- a/x/henry/dust-hive/src/commands/warm.ts
+++ b/x/henry/dust-hive/src/commands/warm.ts
@@ -96,6 +96,10 @@ export const warmCommand = withEnvironment("warm", async (env, options: WarmOpti
     );
   }
 
+  // Wait for SDK to be ready (first build complete) before starting front
+  // Front's TypeScript compiler needs SDK types from dist/
+  await waitForServiceReady(env, "sdk");
+
   // Check if already warm
   const dockerRunning = await isDockerRunning(env.name);
   if (dockerRunning) {


### PR DESCRIPTION
## Description

Fixes a race condition when using `spawn --warm` where front would start before the SDK's initial build completed. This caused TypeScript compilation errors because the `@dust-tt/client` symlink pointed to missing dist files.

The warm command now waits for the SDK readiness check (`dist/client.esm.js` exists) before starting front.

## Tests

- Ran `bun run check` (typecheck, lint, tests all pass)
- Tested manually with `dust-hive spawn --warm` to verify front no longer errors during startup

## Risk

Low - adds a serial wait for SDK build completion before starting front, but this is necessary since front depends on SDK types.

## Deploy Plan

N/A - dust-hive is a local dev tool