### PR TITLE
Fix: filter out agentic messages from user data.

### DIFF
--- a/front/lib/workspace_usage.ts
+++ b/front/lib/workspace_usage.ts
@@ -391,6 +391,10 @@ export async function getUserUsageData(
               userId: {
                 [Op.not]: null,
               },
+              // Filter out "fake" user messages created by the system (new system that replaced the "origin" field for detection of agent messages)
+              agenticMessageType: {
+                [Op.is]: null,
+              },
             },
           },
           {


### PR DESCRIPTION
## Description

We were showing up agentic message data in user's activity report because we didn't filter out the new way to determine agentic messages.

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy front