### PR TITLE
copilot: Add API to list suggestions

### DIFF
--- a/front/pages/api/w/[wId]/assistant/agents/suggestions.test.ts
+++ b/front/pages/api/w/[wId]/assistant/agents/suggestions.test.ts
@@ -1,11 +1,14 @@
 import type { RequestMethod } from "node-mocks-http";
 import { describe, expect, it } from "vitest";
 
+import { Authenticator } from "@app/lib/auth";
 import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { AgentSuggestionFactory } from "@app/tests/utils/AgentSuggestionFactory";
 import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
 import type { MembershipRoleType } from "@app/types/memberships";
 import type { AgentSuggestionState } from "@app/types/suggestions/agent_suggestion";
 
@@ -118,7 +121,7 @@ describe("PATCH /api/w/[wId]/assistant/agents/suggestions", () => {
   });
 
   it("returns 405 for unsupported methods", async () => {
-    for (const method of ["GET", "POST", "PUT", "DELETE"] as const) {
+    for (const method of ["POST", "PUT", "DELETE"] as const) {
       const { req, res } = await setupTest({ method });
 
       await handler(req, res);
@@ -223,5 +226,151 @@ describe("PATCH /api/w/[wId]/assistant/agents/suggestions", () => {
 
     expect(res._getStatusCode()).toBe(200);
     expect(res._getJSONData().suggestion.state).toBe("approved");
+  });
+});
+
+describe("GET /api/w/[wId]/assistant/agents/suggestions", () => {
+  it("returns agent's suggestions", async () => {
+    const { req, res, authenticator } = await setupTest({ method: "GET" });
+
+    const agent =
+      await AgentConfigurationFactory.createTestAgent(authenticator);
+    const suggestion = await AgentSuggestionFactory.createInstructions(
+      authenticator,
+      agent,
+      { state: "pending" }
+    );
+
+    req.query = { ...req.query, agentId: agent.sId };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const responseData = res._getJSONData();
+    expect(responseData.suggestions).toHaveLength(1);
+    expect(responseData.suggestions[0].sId).toBe(suggestion.sId);
+  });
+
+  it("should not return other agent's suggestions", async () => {
+    const { req, res, authenticator } = await setupTest({ method: "GET" });
+
+    const agent1 = await AgentConfigurationFactory.createTestAgent(
+      authenticator,
+      { name: "Test Agent 1" }
+    );
+    const agent2 = await AgentConfigurationFactory.createTestAgent(
+      authenticator,
+      { name: "Test Agent 2" }
+    );
+
+    const suggestion1 = await AgentSuggestionFactory.createInstructions(
+      authenticator,
+      agent1,
+      { state: "pending" }
+    );
+    await AgentSuggestionFactory.createInstructions(authenticator, agent2, {
+      state: "pending",
+    });
+
+    req.query = { ...req.query, agentId: agent1.sId };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const responseData = res._getJSONData();
+    expect(responseData.suggestions).toHaveLength(1);
+    expect(responseData.suggestions[0].sId).toBe(suggestion1.sId);
+  });
+
+  it("filters on kind and state correctly", async () => {
+    const { req, res, authenticator } = await setupTest({ method: "GET" });
+
+    const agent =
+      await AgentConfigurationFactory.createTestAgent(authenticator);
+
+    const matchingSuggestion = await AgentSuggestionFactory.createInstructions(
+      authenticator,
+      agent,
+      {
+        state: "pending",
+      }
+    );
+    await AgentSuggestionFactory.createTools(authenticator, agent, {
+      state: "pending",
+    });
+    await AgentSuggestionFactory.createInstructions(authenticator, agent, {
+      state: "approved",
+    });
+
+    req.query = {
+      ...req.query,
+      agentId: agent.sId,
+      states: ["pending"],
+      kind: "instructions",
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const responseData = res._getJSONData();
+    expect(responseData.suggestions).toHaveLength(1);
+    expect(responseData.suggestions[0].sId).toBe(matchingSuggestion.sId);
+    expect(responseData.suggestions[0].kind).toBe("instructions");
+    expect(responseData.suggestions[0].state).toBe("pending");
+  });
+
+  it("limits the number of returned suggestions", async () => {
+    const { req, res, authenticator } = await setupTest({ method: "GET" });
+
+    const agent =
+      await AgentConfigurationFactory.createTestAgent(authenticator);
+
+    await AgentSuggestionFactory.createInstructions(authenticator, agent, {
+      state: "pending",
+    });
+    await AgentSuggestionFactory.createTools(authenticator, agent, {
+      state: "pending",
+    });
+    await AgentSuggestionFactory.createSkills(authenticator, agent, {
+      state: "pending",
+    });
+
+    req.query = { ...req.query, agentId: agent.sId, limit: "2" };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const responseData = res._getJSONData();
+    expect(responseData.suggestions).toHaveLength(2);
+  });
+
+  it("returns empty list for non-editor of the agent", async () => {
+    // Create workspace with user1 (who will make the request but is NOT the agent owner)
+    const { req, res, workspace } = await setupTest({
+      method: "GET",
+    });
+
+    // Create another user owning the agent and creating the suggestion
+    const agentOwner = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, agentOwner, {
+      role: "builder",
+    });
+    const ownerAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      agentOwner.sId,
+      workspace.sId
+    );
+    const agent = await AgentConfigurationFactory.createTestAgent(ownerAuth);
+
+    // Create suggestion for the agent (as owner)
+    await AgentSuggestionFactory.createInstructions(ownerAuth, agent, {
+      state: "pending",
+    });
+
+    // Make API request as not editor of the agent: should not see any result.
+    req.query = { ...req.query, agentId: agent.sId };
+    await handler(req, res);
+    expect(res._getStatusCode()).toBe(200);
+    const responseData = res._getJSONData();
+    expect(responseData.suggestions).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Description

Add the GET endpoint to list the suggestions for a given agent.
Added at the same place as the PATCH endpoint for consistency. This means the agentId is not taken as path param but I think it is OK.

We have discussed quite a lot where we should put it between:
 - it's own endpoint 
 - in the agent builder endpoint to always save and retrieve with the agent

After many back and forth, we chose to start with standalone endpoint so we can iterate without breaking anything.

## Tests

Add unit tests

## Risk

low

## Deploy Plan

deploy front