### PR TITLE
Add sandbox MCP server boilerplate

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.test.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.test.ts
@@ -63,6 +63,7 @@ describe("INTERNAL_MCP_SERVERS", () => {
       { name: "project_context_management", id: 1021 },
       { name: "agent_copilot_context", id: 1022 },
       { name: "agent_copilot_agent_state", id: 1023 },
+      { name: "sandbox", id: 1024 },
     ];
     expect(
       autoInternalTools,

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -33,6 +33,7 @@ import { OPENAI_USAGE_SERVER } from "@app/lib/api/actions/servers/openai_usage/m
 import { PRIMITIVE_TYPES_DEBUGGER_SERVER } from "@app/lib/api/actions/servers/primitive_types_debugger/metadata";
 import { PROJECT_CONTEXT_MANAGEMENT_SERVER } from "@app/lib/api/actions/servers/project_context_management/metadata";
 import { RUN_DUST_APP_SERVER } from "@app/lib/api/actions/servers/run_dust_app/metadata";
+import { SANDBOX_SERVER } from "@app/lib/api/actions/servers/sandbox/metadata";
 import { SEARCH_SERVER } from "@app/lib/api/actions/servers/search/metadata";
 import { SKILL_MANAGEMENT_SERVER } from "@app/lib/api/actions/servers/skill_management/metadata";
 import { SLACK_BOT_SERVER } from "@app/lib/api/actions/servers/slack_bot/metadata";
@@ -180,6 +181,7 @@ export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   "skill_management",
   "schedules_management",
   "project_context_management",
+  "sandbox",
 ] as const;
 
 export const INTERNAL_SERVERS_WITH_WEBSEARCH = [
@@ -1662,6 +1664,19 @@ export const INTERNAL_MCP_SERVERS = {
     tools_arguments_requiring_approval: undefined,
     tools_retry_policies: undefined,
     timeoutMs: undefined,
+  },
+  sandbox: {
+    id: 1024,
+    availability: "auto",
+    allowMultipleInstances: false,
+    isPreview: true,
+    isRestricted: ({ featureFlags }) => {
+      return !featureFlags.includes("sandbox_tools");
+    },
+    metadata: SANDBOX_SERVER,
+    tools_arguments_requiring_approval: undefined,
+    tools_retry_policies: undefined,
+    timeoutMs: 120000, // 2 minutes for command execution
   },
   // Using satisfies here instead of: type to avoid TypeScript widening the type and breaking the type inference for AutoInternalMCPServerNameType.
 } satisfies {

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -63,6 +63,7 @@ import { default as openaiUsageServer } from "@app/lib/api/actions/servers/opena
 import { default as primitiveTypesDebuggerServer } from "@app/lib/api/actions/servers/primitive_types_debugger";
 import { default as projectContextManagementServer } from "@app/lib/api/actions/servers/project_context_management";
 import { default as dustAppServer } from "@app/lib/api/actions/servers/run_dust_app";
+import { default as sandboxServer } from "@app/lib/api/actions/servers/sandbox";
 import { default as searchServer } from "@app/lib/api/actions/servers/search";
 import { default as skillManagementServer } from "@app/lib/api/actions/servers/skill_management";
 import { default as slackBotServer } from "@app/lib/api/actions/servers/slack_bot";
@@ -241,6 +242,8 @@ export async function getInternalMCPServer(
       return ukgReadyServer(auth, agentLoopContext);
     case "statuspage":
       return statuspageServer(auth, agentLoopContext);
+    case "sandbox":
+      return sandboxServer(auth, agentLoopContext);
     default:
       assertNever(internalMCPServerName);
   }

--- a/front/lib/api/actions/servers/sandbox/index.ts
+++ b/front/lib/api/actions/servers/sandbox/index.ts
@@ -1,0 +1,26 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
+import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
+import { SANDBOX_TOOL_NAME } from "@app/lib/api/actions/servers/sandbox/metadata";
+import { createSandboxTools } from "@app/lib/api/actions/servers/sandbox/tools";
+import type { Authenticator } from "@app/lib/auth";
+
+function createServer(
+  auth: Authenticator,
+  agentLoopContext?: AgentLoopContextType
+): McpServer {
+  const server = makeInternalMCPServer("sandbox");
+
+  const tools = createSandboxTools(auth, agentLoopContext);
+  for (const tool of tools) {
+    registerTool(auth, agentLoopContext, server, tool, {
+      monitoringName: SANDBOX_TOOL_NAME,
+    });
+  }
+
+  return server;
+}
+
+export default createServer;

--- a/front/lib/api/actions/servers/sandbox/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox/metadata.ts
@@ -96,6 +96,8 @@ export const SANDBOX_SERVER = {
       "The sandbox persists for the conversation duration. " +
       "Common tools like Python, Node.js, and standard Unix utilities are pre-installed.",
   },
+  // Note: The `as JSONSchema` cast is standard pattern across all metadata files.
+  // zodToJsonSchema returns a compatible type but TypeScript can't verify it statically.
   tools: Object.values(SANDBOX_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,

--- a/front/lib/api/actions/servers/sandbox/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox/metadata.ts
@@ -50,11 +50,15 @@ export const SANDBOX_TOOLS_METADATA = createToolsRecord({
   },
   read_file: {
     description:
-      "Read the contents of a file from the sandbox. " +
-      "Returns the file content along with a snippet preview. " +
-      "For large files, use this to retrieve results of computations or generated content.",
+      "Read a file from the sandbox and make it available as a Dust file. " +
+      "Use this to retrieve results of computations, generated content, or any file " +
+      "that should be shared with the user in the conversation.",
     schema: {
       path: z.string().describe("Absolute path to the file to read."),
+      title: z
+        .string()
+        .optional()
+        .describe("Title for the file in Dust. Defaults to the filename."),
     },
     stake: "never_ask",
   },
@@ -74,19 +78,6 @@ export const SANDBOX_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
   },
-  push_file_to_dust: {
-    description:
-      "Push a file from the sandbox to Dust, making it available in the conversation. " +
-      "Use this to return generated files (CSVs, images, documents) to the user.",
-    schema: {
-      path: z.string().describe("Absolute path to the file in the sandbox."),
-      title: z
-        .string()
-        .optional()
-        .describe("Title for the file in Dust. Defaults to the filename."),
-    },
-    stake: "low",
-  },
 });
 
 export const SANDBOX_SERVER = {
@@ -100,8 +91,8 @@ export const SANDBOX_SERVER = {
     documentationUrl: null,
     instructions:
       "The sandbox provides an isolated Linux environment for running code, scripts, and shell commands. " +
-      "Use `execute` to run commands, `write_file`/`read_file` for file operations, " +
-      "and `push_file_to_dust` to return generated files. " +
+      "Use `execute` to run commands, `write_file`/`read_file` for file operations. " +
+      "Use `read_file` to retrieve generated files and make them available in the conversation. " +
       "The sandbox persists for the conversation duration. " +
       "Common tools like Python, Node.js, and standard Unix utilities are pre-installed.",
   },

--- a/front/lib/api/actions/servers/sandbox/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox/metadata.ts
@@ -1,0 +1,116 @@
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
+
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+
+export const SANDBOX_TOOL_NAME = "sandbox" as const;
+
+export const SANDBOX_TOOLS_METADATA = createToolsRecord({
+  execute: {
+    description:
+      "Execute a shell command in an isolated sandbox environment. " +
+      "The sandbox is a Linux container with common tools pre-installed. " +
+      "Use this for running scripts, installing packages, or executing code. " +
+      "The sandbox persists for the duration of the conversation.",
+    schema: {
+      command: z
+        .string()
+        .describe(
+          "The shell command to execute. Can be a single command or a script."
+        ),
+      workingDirectory: z
+        .string()
+        .optional()
+        .describe("Working directory for command execution. Defaults to /tmp."),
+      timeoutMs: z
+        .number()
+        .optional()
+        .describe(
+          "Timeout in milliseconds for command execution. Defaults to 60000 (60 seconds)."
+        ),
+    },
+    stake: "low",
+  },
+  write_file: {
+    description:
+      "Write content to a file in the sandbox. " +
+      "Creates parent directories if they don't exist. " +
+      "Overwrites the file if it already exists.",
+    schema: {
+      path: z
+        .string()
+        .describe(
+          "Absolute path where the file should be written in the sandbox."
+        ),
+      content: z.string().describe("The content to write to the file."),
+    },
+    stake: "low",
+  },
+  read_file: {
+    description:
+      "Read the contents of a file from the sandbox. " +
+      "Returns the file content along with a snippet preview. " +
+      "For large files, use this to retrieve results of computations or generated content.",
+    schema: {
+      path: z.string().describe("Absolute path to the file to read."),
+    },
+    stake: "never_ask",
+  },
+  list_files: {
+    description:
+      "List files and directories in the sandbox. " +
+      "Returns file names, sizes, and types (file/directory).",
+    schema: {
+      path: z
+        .string()
+        .optional()
+        .describe("Directory path to list. Defaults to /tmp."),
+      recursive: z
+        .boolean()
+        .optional()
+        .describe("Whether to list files recursively. Defaults to false."),
+    },
+    stake: "never_ask",
+  },
+  push_file_to_dust: {
+    description:
+      "Push a file from the sandbox to Dust, making it available in the conversation. " +
+      "Use this to return generated files (CSVs, images, documents) to the user.",
+    schema: {
+      path: z.string().describe("Absolute path to the file in the sandbox."),
+      title: z
+        .string()
+        .optional()
+        .describe("Title for the file in Dust. Defaults to the filename."),
+    },
+    stake: "low",
+  },
+});
+
+export const SANDBOX_SERVER = {
+  serverInfo: {
+    name: "sandbox",
+    version: "1.0.0",
+    description:
+      "Execute code and commands in an isolated Linux sandbox environment.",
+    authorization: null,
+    icon: "CommandLineIcon",
+    documentationUrl: null,
+    instructions:
+      "The sandbox provides an isolated Linux environment for running code, scripts, and shell commands. " +
+      "Use `execute` to run commands, `write_file`/`read_file` for file operations, " +
+      "and `push_file_to_dust` to return generated files. " +
+      "The sandbox persists for the conversation duration. " +
+      "Common tools like Python, Node.js, and standard Unix utilities are pre-installed.",
+  },
+  tools: Object.values(SANDBOX_TOOLS_METADATA).map((t) => ({
+    name: t.name,
+    description: t.description,
+    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+  })),
+  tools_stakes: Object.fromEntries(
+    Object.values(SANDBOX_TOOLS_METADATA).map((t) => [t.name, t.stake])
+  ),
+} as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/sandbox/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox/metadata.ts
@@ -26,9 +26,10 @@ export const SANDBOX_TOOLS_METADATA = createToolsRecord({
         .describe("Working directory for command execution. Defaults to /tmp."),
       timeoutMs: z
         .number()
+        .max(120000)
         .optional()
         .describe(
-          "Timeout in milliseconds for command execution. Defaults to 60000 (60 seconds)."
+          "Timeout in milliseconds for command execution. Defaults to 60000, max 120000."
         ),
     },
     stake: "low",

--- a/front/lib/api/actions/servers/sandbox/tools/index.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.ts
@@ -37,12 +37,6 @@ export function createSandboxTools(
         new MCPError("Sandbox list_files tool is not implemented yet.")
       );
     },
-
-    push_file_to_dust: async (_args) => {
-      return new Err(
-        new MCPError("Sandbox push_file_to_dust tool is not implemented yet.")
-      );
-    },
   };
 
   return buildTools(SANDBOX_TOOLS_METADATA, handlers);

--- a/front/lib/api/actions/servers/sandbox/tools/index.ts
+++ b/front/lib/api/actions/servers/sandbox/tools/index.ts
@@ -1,0 +1,49 @@
+import { MCPError } from "@app/lib/actions/mcp_errors";
+import type {
+  ToolDefinition,
+  ToolHandlers,
+} from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
+import { SANDBOX_TOOLS_METADATA } from "@app/lib/api/actions/servers/sandbox/metadata";
+import type { Authenticator } from "@app/lib/auth";
+import { Err } from "@app/types";
+
+export function createSandboxTools(
+  _auth: Authenticator,
+  _agentLoopContext?: AgentLoopContextType
+): ToolDefinition[] {
+  const handlers: ToolHandlers<typeof SANDBOX_TOOLS_METADATA> = {
+    execute: async (_args) => {
+      return new Err(
+        new MCPError("Sandbox execute tool is not implemented yet.")
+      );
+    },
+
+    write_file: async (_args) => {
+      return new Err(
+        new MCPError("Sandbox write_file tool is not implemented yet.")
+      );
+    },
+
+    read_file: async (_args) => {
+      return new Err(
+        new MCPError("Sandbox read_file tool is not implemented yet.")
+      );
+    },
+
+    list_files: async (_args) => {
+      return new Err(
+        new MCPError("Sandbox list_files tool is not implemented yet.")
+      );
+    },
+
+    push_file_to_dust: async (_args) => {
+      return new Err(
+        new MCPError("Sandbox push_file_to_dust tool is not implemented yet.")
+      );
+    },
+  };
+
+  return buildTools(SANDBOX_TOOLS_METADATA, handlers);
+}

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -237,6 +237,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Access to Dust Academy learning content",
     stage: "on_demand",
   },
+  sandbox_tools: {
+    description:
+      "Sandbox MCP tool for executing code in isolated Linux containers",
+    stage: "dust_only",
+  },
 } as const satisfies Record<string, FeatureFlag>;
 
 export type FeatureFlagStage = "dust_only" | "rolling_out" | "on_demand";

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -685,6 +685,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "salesforce_tool_write"
   | "salesforce_tool"
   | "salesloft_tool"
+  | "sandbox_tools"
   | "self_created_slack_app_connector_rollout"
   | "show_debug_tools"
   | "skills_similar_display"


### PR DESCRIPTION
## Description

Add boilerplate for the sandbox MCP server, which will enable code execution in isolated Linux containers.

This PR adds:
- `sandbox_tools` feature flag (dust_only stage) to gate the server
- Server registration in the internal MCP registry (ID 1024)
- Tool metadata definitions for 4 tools:
  - `execute` - Execute shell commands in the sandbox
  - `write_file` - Write content to a file in the sandbox
  - `read_file` - Read a file from the sandbox and make it available as a Dust file
  - `list_files` - List directory contents in the sandbox
- Stub implementations returning "not implemented" errors

Tool implementations will be added in follow-up PRs.

## Tests

- Type-check passes locally
- Server will show up in tools list when `sandbox_tools` feature flag is enabled
- Tools return "not implemented" error when called (expected for this boilerplate PR)

## Risk

**Low risk** - The server is gated behind a `dust_only` feature flag, so it won't be visible to any users. The stub implementations ensure no actual code execution happens.

## Deploy Plan

Standard deploy - no special considerations. The feature flag ensures no user impact.