### PR TITLE
fix(plans): use atomic upsert to prevent race condition in upsertProPlans

### DIFF
--- a/front/lib/plans/free_plans.test.ts
+++ b/front/lib/plans/free_plans.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import { PlanModel } from "@app/lib/models/plan";
+import { upsertFreePlans } from "@app/lib/plans/free_plans";
+import { FREE_TEST_PLAN_CODE } from "@app/lib/plans/plan_codes";
+
+describe("upsertFreePlans", () => {
+  it("creates plans when they don't exist", async () => {
+    await PlanModel.destroy({ where: { code: FREE_TEST_PLAN_CODE } });
+
+    const beforePlan = await PlanModel.findOne({
+      where: { code: FREE_TEST_PLAN_CODE },
+    });
+    expect(beforePlan).toBeNull();
+
+    await upsertFreePlans(FREE_TEST_PLAN_CODE);
+
+    const afterPlan = await PlanModel.findOne({
+      where: { code: FREE_TEST_PLAN_CODE },
+    });
+    expect(afterPlan).not.toBeNull();
+    expect(afterPlan?.code).toBe(FREE_TEST_PLAN_CODE);
+  });
+
+  it("updates plans when they already exist", async () => {
+    await upsertFreePlans(FREE_TEST_PLAN_CODE);
+
+    const plansBefore = await PlanModel.findAll({
+      where: { code: FREE_TEST_PLAN_CODE },
+    });
+    expect(plansBefore).toHaveLength(1);
+    const createdAt = plansBefore[0].createdAt;
+
+    await upsertFreePlans(FREE_TEST_PLAN_CODE);
+
+    const plansAfter = await PlanModel.findAll({
+      where: { code: FREE_TEST_PLAN_CODE },
+    });
+    expect(plansAfter).toHaveLength(1);
+    expect(plansAfter[0].createdAt.getTime()).toBe(createdAt.getTime());
+  });
+
+  it("handles concurrent calls without race conditions", async () => {
+    await PlanModel.destroy({ where: { code: FREE_TEST_PLAN_CODE } });
+
+    const results = await Promise.allSettled([
+      upsertFreePlans(FREE_TEST_PLAN_CODE),
+      upsertFreePlans(FREE_TEST_PLAN_CODE),
+      upsertFreePlans(FREE_TEST_PLAN_CODE),
+      upsertFreePlans(FREE_TEST_PLAN_CODE),
+      upsertFreePlans(FREE_TEST_PLAN_CODE),
+    ]);
+
+    for (const result of results) {
+      expect(result.status).toBe("fulfilled");
+    }
+
+    const plans = await PlanModel.findAll({
+      where: { code: FREE_TEST_PLAN_CODE },
+    });
+    expect(plans).toHaveLength(1);
+  });
+});

--- a/front/lib/plans/pro_plans.test.ts
+++ b/front/lib/plans/pro_plans.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import { PlanModel } from "@app/lib/models/plan";
+import { PRO_PLAN_SEAT_29_CODE } from "@app/lib/plans/plan_codes";
+import { upsertProPlans } from "@app/lib/plans/pro_plans";
+
+describe("upsertProPlans", () => {
+  it("creates plans when they don't exist", async () => {
+    await PlanModel.destroy({ where: { code: PRO_PLAN_SEAT_29_CODE } });
+
+    const beforePlan = await PlanModel.findOne({
+      where: { code: PRO_PLAN_SEAT_29_CODE },
+    });
+    expect(beforePlan).toBeNull();
+
+    await upsertProPlans(PRO_PLAN_SEAT_29_CODE);
+
+    const afterPlan = await PlanModel.findOne({
+      where: { code: PRO_PLAN_SEAT_29_CODE },
+    });
+    expect(afterPlan).not.toBeNull();
+    expect(afterPlan?.code).toBe(PRO_PLAN_SEAT_29_CODE);
+    expect(afterPlan?.name).toBe("Pro");
+  });
+
+  it("updates plans when they already exist", async () => {
+    await upsertProPlans(PRO_PLAN_SEAT_29_CODE);
+
+    const plansBefore = await PlanModel.findAll({
+      where: { code: PRO_PLAN_SEAT_29_CODE },
+    });
+    expect(plansBefore).toHaveLength(1);
+    const createdAt = plansBefore[0].createdAt;
+
+    await upsertProPlans(PRO_PLAN_SEAT_29_CODE);
+
+    const plansAfter = await PlanModel.findAll({
+      where: { code: PRO_PLAN_SEAT_29_CODE },
+    });
+    expect(plansAfter).toHaveLength(1);
+    expect(plansAfter[0].createdAt.getTime()).toBe(createdAt.getTime());
+  });
+
+  it("handles concurrent calls without race conditions", async () => {
+    await PlanModel.destroy({ where: { code: PRO_PLAN_SEAT_29_CODE } });
+
+    const results = await Promise.allSettled([
+      upsertProPlans(PRO_PLAN_SEAT_29_CODE),
+      upsertProPlans(PRO_PLAN_SEAT_29_CODE),
+      upsertProPlans(PRO_PLAN_SEAT_29_CODE),
+      upsertProPlans(PRO_PLAN_SEAT_29_CODE),
+      upsertProPlans(PRO_PLAN_SEAT_29_CODE),
+    ]);
+
+    for (const result of results) {
+      expect(result.status).toBe("fulfilled");
+    }
+
+    const plans = await PlanModel.findAll({
+      where: { code: PRO_PLAN_SEAT_29_CODE },
+    });
+    expect(plans).toHaveLength(1);
+  });
+});

--- a/front/lib/plans/pro_plans.ts
+++ b/front/lib/plans/pro_plans.ts
@@ -86,6 +86,7 @@ if (isDevelopment() || isTest()) {
 
 /**
  * Function to call when we edit something in PRO_PLANS_DATA to update the database. It will create or update the plans.
+ * Uses atomic upsert to avoid race conditions when called concurrently (e.g., in parallel tests).
  * @param planCode - Optional plan code to upsert. If not provided, all plans are upserted.
  */
 export const upsertProPlans = async (planCode?: string) => {
@@ -94,17 +95,8 @@ export const upsertProPlans = async (planCode?: string) => {
     : PRO_PLANS_DATA;
 
   for (const planData of plansToUpsert) {
-    const plan = await PlanModel.findOne({
-      where: {
-        code: planData.code,
-      },
+    await PlanModel.upsert(planData, {
+      conflictFields: ["code"],
     });
-    if (plan === null) {
-      await PlanModel.create(planData);
-      // console.log(`Pro plan ${planData.code} created.`);
-    } else {
-      await plan.update(planData);
-      // console.log(`Pro plan ${planData.code} updated.`);
-    }
   }
 };


### PR DESCRIPTION
## Summary
Fix "check-then-act" race condition in `upsertProPlans` that could cause unique constraint violations when called concurrently (e.g., in parallel tests via `WorkspaceFactory.basic()`).

## Changes
- Replace check-then-act pattern (`findOne` + `create`/`update`) with Sequelize's atomic `upsert()` method
- Explicitly specify `conflictFields: ["code"]` to ensure conflict resolution uses the correct unique constraint
- Add tests for create, update, and concurrent call scenarios

## Test plan
- [x] New tests pass: `NODE_ENV=test npm test lib/plans/pro_plans.test.ts`
- [x] Concurrent calls test verifies 5 parallel upserts all succeed with only 1 plan created