### PR TITLE
feat: summarize unread messages in notification email

### DIFF
--- a/front/lib/api/llm/traces/types.ts
+++ b/front/lib/api/llm/traces/types.ts
@@ -20,6 +20,7 @@ interface LLMTraceContextBase {
     | "agent_observability_summary"
     | "agent_suggestion"
     | "conversation_title_suggestion"
+    | "conversation_unread_summary"
     | "process_data_sources"
     | "process_schema_generator"
     | "skill_builder_description_suggestion"

--- a/front/lib/error.ts
+++ b/front/lib/error.ts
@@ -47,7 +47,12 @@ export type DustErrorCode =
   // Triggers errors
   | "webhook_source_not_found"
   // Space errors
-  | "space_already_exists";
+  | "space_already_exists"
+  // Conversation errors
+  | "conversation_not_found"
+  | "no_unread_messages_found"
+  | "no_whitelisted_model_found"
+  | "generation_failed";
 
 export class DustError<T extends DustErrorCode = DustErrorCode> extends Error {
   constructor(

--- a/front/lib/notifications/email-templates/conversations-unread.tsx
+++ b/front/lib/notifications/email-templates/conversations-unread.tsx
@@ -15,6 +15,7 @@ export const ConversationsUnreadEmailTemplatePropsSchema = z.object({
     z.object({
       id: z.string(),
       title: z.string(),
+      summary: z.string().nullable(),
     })
   ),
 });
@@ -44,6 +45,7 @@ const ConversationsUnreadEmailTemplate = ({
             >
               {conversation.title}
             </a>
+            {conversation.summary && <div>{conversation.summary}</div>}
           </li>
         ))}
       </ul>

--- a/front/lib/notifications/email-templates/conversations-unread.tsx
+++ b/front/lib/notifications/email-templates/conversations-unread.tsx
@@ -43,11 +43,6 @@ const ConversationsUnreadEmailTemplate = ({
                   getConversationRoute(workspace.id, conversation.id)
                 }
                 target="_blank"
-                style={{
-                  textDecoration: "underline",
-                  color: "inherit",
-                  fontWeight: "bold",
-                }}
               >
                 {conversation.title}
               </a>

--- a/front/lib/notifications/email-templates/conversations-unread.tsx
+++ b/front/lib/notifications/email-templates/conversations-unread.tsx
@@ -31,24 +31,31 @@ const ConversationsUnreadEmailTemplate = ({
 }: ConversationsUnreadEmailTemplateProps) => {
   return (
     <EmailLayout workspace={workspace}>
-      <h3>Hi {name},</h3>
+      <p>Hi {name},</p>
       <p>You have unread message(s) in the following conversations:</p>
-      <ul>
+      <div>
         {conversations.map((conversation) => (
-          <li key={conversation.id}>
-            <a
-              href={
-                process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL +
-                getConversationRoute(workspace.id, conversation.id)
-              }
-              target="_blank"
-            >
-              {conversation.title}
-            </a>
+          <div key={conversation.id}>
+            <h3>
+              <a
+                href={
+                  process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL +
+                  getConversationRoute(workspace.id, conversation.id)
+                }
+                target="_blank"
+                style={{
+                  textDecoration: "underline",
+                  color: "inherit",
+                  fontWeight: "bold",
+                }}
+              >
+                {conversation.title}
+              </a>
+            </h3>
             {conversation.summary && <div>{conversation.summary}</div>}
-          </li>
+          </div>
         ))}
-      </ul>
+      </div>
     </EmailLayout>
   );
 };

--- a/front/lib/notifications/workflows/conversation-unread.ts
+++ b/front/lib/notifications/workflows/conversation-unread.ts
@@ -145,7 +145,7 @@ const NOTIFICATION_PREFERENCES_DELAYS: Record<
   NotificationPreferencesDelay,
   NotificationDelayConfig
 > = {
-  "5_minutes": { amount: 1, unit: "minutes" },
+  "5_minutes": { amount: 5, unit: "minutes" },
   "15_minutes": { amount: 15, unit: "minutes" },
   "30_minutes": { amount: 30, unit: "minutes" },
   "1_hour": { amount: 1, unit: "hours" },
@@ -209,8 +209,6 @@ const getConversationDetails = async ({
   const workspaceName = auth.getNonNullableWorkspace().name;
   const subject = conversation.title ?? "Dust conversation";
   const isFromTrigger = !!conversation.triggerId;
-
-  console.log("TRIGGERED BY MESSAGE ID", payload.messageId);
 
   // Retrieve the message that triggered the notification.
   const message = conversation.content


### PR DESCRIPTION
## Description

This PR adds AI generated summaries of unread messages to the conversation notification emails sent to users.

- Implements a new `generateUnreadMessagesSummary` function that uses a small LLM model to generate summaries.
- Updates the email template to display the summary below each conversation title.


<img width="1082" height="476" alt="Capture d’écran 2026-01-27 à 15 39 05" src="https://github.com/user-attachments/assets/8aae791a-48bb-4132-a6c3-29e3efadf7c6" />

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Manually.
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
