### PR TITLE
[front] Rename prop `viewType` in action details components

### DIFF
--- a/front/components/actions/ActionDetailsWrapper.tsx
+++ b/front/components/actions/ActionDetailsWrapper.tsx
@@ -4,17 +4,17 @@ import type { ComponentType } from "react";
 interface ActionDetailsWrapperProps {
   actionName: string;
   children?: React.ReactNode;
-  viewType: "conversation" | "sidebar";
+  displayContext: "conversation" | "sidebar";
   visual: ComponentType<{ className?: string }>;
 }
 
 export function ActionDetailsWrapper({
   actionName,
   children,
-  viewType,
+  displayContext,
   visual,
 }: ActionDetailsWrapperProps) {
-  if (viewType === "conversation") {
+  if (displayContext === "conversation") {
     return (
       <div className="flex w-full flex-col gap-y-2">
         <div

--- a/front/components/actions/ActionDetailsWrapper.tsx
+++ b/front/components/actions/ActionDetailsWrapper.tsx
@@ -1,10 +1,11 @@
 import { cn, Icon, Spinner } from "@dust-tt/sparkle";
 import type { ComponentType } from "react";
+import { ActionDetailsDisplayContext } from "@app/components/actions/mcp/details/types";
 
 interface ActionDetailsWrapperProps {
   actionName: string;
   children?: React.ReactNode;
-  displayContext: "conversation" | "sidebar";
+  displayContext: ActionDetailsDisplayContext;
   visual: ComponentType<{ className?: string }>;
 }
 

--- a/front/components/actions/ActionDetailsWrapper.tsx
+++ b/front/components/actions/ActionDetailsWrapper.tsx
@@ -1,5 +1,6 @@
 import { cn, Icon, Spinner } from "@dust-tt/sparkle";
 import type { ComponentType } from "react";
+
 import type { ActionDetailsDisplayContext } from "@app/components/actions/mcp/details/types";
 
 interface ActionDetailsWrapperProps {

--- a/front/components/actions/ActionDetailsWrapper.tsx
+++ b/front/components/actions/ActionDetailsWrapper.tsx
@@ -1,6 +1,6 @@
 import { cn, Icon, Spinner } from "@dust-tt/sparkle";
 import type { ComponentType } from "react";
-import { ActionDetailsDisplayContext } from "@app/components/actions/mcp/details/types";
+import type { ActionDetailsDisplayContext } from "@app/components/actions/mcp/details/types";
 
 interface ActionDetailsWrapperProps {
   actionName: string;

--- a/front/components/actions/mcp/details/MCPActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPActionDetails.tsx
@@ -104,21 +104,24 @@ export interface MCPActionDetailsProps {
   owner: LightWorkspaceType;
   lastNotification: ProgressNotificationContentType | null;
   messageStatus?: "created" | "succeeded" | "failed" | "cancelled";
-  viewType: "conversation" | "sidebar";
+  displayContext: "conversation" | "sidebar";
 }
 
-function getActionLabel(
-  action: AgentMCPActionWithOutputType,
-  viewType: "conversation" | "sidebar"
-): string {
+function getActionLabel({
+  action,
+  displayContext,
+}: {
+  action: AgentMCPActionWithOutputType;
+  displayContext: "conversation" | "sidebar";
+}): string {
   if (action.displayLabels) {
-    return viewType === "conversation"
+    return displayContext === "conversation"
       ? action.displayLabels.running
       : action.displayLabels.done;
   }
 
   return (
-    (viewType === "conversation" ? "Running a tool" : "Run a tool") +
+    (displayContext === "conversation" ? "Running a tool" : "Run a tool") +
     (action.functionCallName
       ? `: ${asDisplayName(action.functionCallName)}`
       : "")
@@ -127,7 +130,7 @@ function getActionLabel(
 
 export function MCPActionDetails({
   action,
-  viewType,
+  displayContext,
   owner,
   lastNotification,
   messageStatus,
@@ -165,7 +168,7 @@ export function MCPActionDetails({
     owner,
     toolOutput: output,
     toolParams: params,
-    viewType,
+    displayContext,
   };
 
   if (
@@ -176,9 +179,11 @@ export function MCPActionDetails({
       case SEARCH_TOOL_NAME:
         return (
           <SearchResultDetails
-            viewType={viewType}
+            displayContext={displayContext}
             actionName={
-              viewType === "conversation" ? "Searching data" : "Search data"
+              displayContext === "conversation"
+                ? "Searching data"
+                : "Search data"
             }
             actionOutput={output}
             visual={MagnifyingGlassIcon}
@@ -193,9 +198,9 @@ export function MCPActionDetails({
       case FILESYSTEM_FIND_TOOL_NAME:
         return (
           <SearchResultDetails
-            viewType={viewType}
+            displayContext={displayContext}
             actionName={
-              viewType === "conversation"
+              displayContext === "conversation"
                 ? "Browsing data sources"
                 : "Browse data sources"
             }
@@ -223,9 +228,9 @@ export function MCPActionDetails({
   ) {
     return (
       <SearchResultDetails
-        viewType={viewType}
+        displayContext={displayContext}
         actionName={
-          viewType === "conversation" ? "Including data" : "Include data"
+          displayContext === "conversation" ? "Including data" : "Include data"
         }
         actionOutput={output}
         visual={ClockIcon}
@@ -245,10 +250,12 @@ export function MCPActionDetails({
       case WEBSEARCH_TOOL_NAME:
         return (
           <SearchResultDetails
-            viewType={viewType}
+            displayContext={displayContext}
             query={isWebsearchInputType(params) ? params.query : null}
             actionName={
-              viewType === "conversation" ? "Searching the web" : "Web search"
+              displayContext === "conversation"
+                ? "Searching the web"
+                : "Web search"
             }
             actionOutput={output}
             visual={GlobeAltIcon}
@@ -361,7 +368,7 @@ export function MCPActionDetails({
       owner={owner}
       lastNotification={lastNotification}
       messageStatus={messageStatus}
-      viewType={viewType}
+      displayContext={displayContext}
       action={{ ...action, output }}
     />
   );
@@ -370,7 +377,7 @@ export function MCPActionDetails({
 export function GenericActionDetails({
   owner,
   action,
-  viewType,
+  displayContext,
 }: MCPActionDetailsProps) {
   const inputs =
     Object.keys(action.params).length > 0
@@ -385,11 +392,11 @@ export function GenericActionDetails({
 
   return (
     <ActionDetailsWrapper
-      viewType={viewType}
-      actionName={getActionLabel(action, viewType)}
+      displayContext={displayContext}
+      actionName={getActionLabel({ action, displayContext })}
       visual={actionIcon ?? MCP_SPECIFICATION.cardIcon}
     >
-      {viewType !== "conversation" && (
+      {displayContext !== "conversation" && (
         <div className="dd-privacy-mask flex flex-col gap-4 py-4 pl-6">
           <Collapsible defaultOpen={false}>
             <CollapsibleTrigger>

--- a/front/components/actions/mcp/details/MCPActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPActionDetails.tsx
@@ -43,7 +43,10 @@ import { MCPSkillEnableActionDetails } from "@app/components/actions/mcp/details
 import { MCPTablesQueryActionDetails } from "@app/components/actions/mcp/details/MCPTablesQueryActionDetails";
 import { SearchResultDetails } from "@app/components/actions/mcp/details/MCPToolOutputDetails";
 import { MCPToolsetsEnableActionDetails } from "@app/components/actions/mcp/details/MCPToolsetsEnableActionDetails";
-import type { ToolExecutionDetailsProps } from "@app/components/actions/mcp/details/types";
+import type {
+  ActionDetailsDisplayContext,
+  ToolExecutionDetailsProps,
+} from "@app/components/actions/mcp/details/types";
 import { InternalActionIcons } from "@app/components/resources/resources_icons";
 import {
   DEFAULT_CONVERSATION_CAT_FILE_ACTION_NAME,
@@ -104,7 +107,7 @@ export interface MCPActionDetailsProps {
   owner: LightWorkspaceType;
   lastNotification: ProgressNotificationContentType | null;
   messageStatus?: "created" | "succeeded" | "failed" | "cancelled";
-  displayContext: "conversation" | "sidebar";
+  displayContext: ActionDetailsDisplayContext;
 }
 
 function getActionLabel({
@@ -112,7 +115,7 @@ function getActionLabel({
   displayContext,
 }: {
   action: AgentMCPActionWithOutputType;
-  displayContext: "conversation" | "sidebar";
+  displayContext: ActionDetailsDisplayContext;
 }): string {
   if (action.displayLabels) {
     return displayContext === "conversation"

--- a/front/components/actions/mcp/details/MCPAgentManagementActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPAgentManagementActionDetails.tsx
@@ -83,7 +83,9 @@ export function MCPAgentManagementActionDetails({
   return (
     <ActionDetailsWrapper
       displayContext={displayContext}
-      actionName="Create Agent"
+      actionName={
+        displayContext === "conversation" ? "Creating agent" : "Create Agent"
+      }
       visual={ActionRobotIcon}
     >
       <div className="flex flex-col gap-6 pl-6 pt-4">

--- a/front/components/actions/mcp/details/MCPAgentManagementActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPAgentManagementActionDetails.tsx
@@ -20,7 +20,7 @@ import { GLOBAL_SPACE_NAME } from "@app/types";
 export function MCPAgentManagementActionDetails({
   toolOutput,
   toolParams,
-  viewType,
+  displayContext,
   owner,
   messageStatus,
 }: ToolExecutionDetailsProps) {
@@ -56,9 +56,9 @@ export function MCPAgentManagementActionDetails({
     // Fallback to showing the raw output if no structured data
     return (
       <ActionDetailsWrapper
-        viewType={viewType}
+        displayContext={displayContext}
         actionName={
-          viewType === "conversation" ? "Creating agent" : "Create Agent"
+          displayContext === "conversation" ? "Creating agent" : "Create Agent"
         }
         visual={ActionRobotIcon}
       >
@@ -82,7 +82,7 @@ export function MCPAgentManagementActionDetails({
 
   return (
     <ActionDetailsWrapper
-      viewType={viewType}
+      displayContext={displayContext}
       actionName="Create Agent"
       visual={ActionRobotIcon}
     >

--- a/front/components/actions/mcp/details/MCPAgentMemoryActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPAgentMemoryActionDetails.tsx
@@ -16,7 +16,7 @@ import type { ToolExecutionDetailsProps } from "@app/components/actions/mcp/deta
 
 export function MCPAgentMemoryRetrieveActionDetails({
   toolOutput,
-  viewType,
+  displayContext,
 }: ToolExecutionDetailsProps) {
   const parsedMemories = useMemo(
     () => parseMemoriesFromOutput(toolOutput),
@@ -25,7 +25,7 @@ export function MCPAgentMemoryRetrieveActionDetails({
 
   return (
     <ActionDetailsWrapper
-      viewType={viewType}
+      displayContext={displayContext}
       actionName="Retrieve Agent Memory"
       visual={ActionLightbulbIcon}
     >
@@ -45,12 +45,12 @@ export function MCPAgentMemoryRetrieveActionDetails({
 
 export function MCPAgentMemoryRecordActionDetails({
   toolParams,
-  viewType,
+  displayContext,
 }: ToolExecutionDetailsProps) {
   const entries = Array.isArray(toolParams.entries) ? toolParams.entries : [];
   return (
     <ActionDetailsWrapper
-      viewType={viewType}
+      displayContext={displayContext}
       actionName="Record Agent Memory"
       visual={ActionLightbulbIcon}
     >
@@ -72,7 +72,7 @@ export function MCPAgentMemoryRecordActionDetails({
 
 export function MCPAgentMemoryEditActionDetails({
   toolOutput,
-  viewType,
+  displayContext,
   toolName,
 }: ToolExecutionDetailsProps & { toolName: string }) {
   const updatedMemories = useMemo(
@@ -87,7 +87,7 @@ export function MCPAgentMemoryEditActionDetails({
     toolName === "compact_memory" ? "Compacted memories" : "Edited memories";
   return (
     <ActionDetailsWrapper
-      viewType={viewType}
+      displayContext={displayContext}
       actionName={toolNameText}
       visual={ActionLightbulbIcon}
     >
@@ -108,7 +108,7 @@ export function MCPAgentMemoryEditActionDetails({
 export function MCPAgentMemoryEraseActionDetails({
   toolParams,
   toolOutput,
-  viewType,
+  displayContext,
 }: ToolExecutionDetailsProps) {
   const indexes = Array.isArray(toolParams.indexes) ? toolParams.indexes : [];
   const remainingMemories = useMemo(
@@ -117,7 +117,7 @@ export function MCPAgentMemoryEraseActionDetails({
   );
   return (
     <ActionDetailsWrapper
-      viewType={viewType}
+      displayContext={displayContext}
       actionName="Erase Agent Memory"
       visual={ActionLightbulbIcon}
     >

--- a/front/components/actions/mcp/details/MCPBrowseActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPBrowseActionDetails.tsx
@@ -13,7 +13,7 @@ import { validateUrl } from "@app/types/shared/utils/url_utils";
 export function MCPBrowseActionDetails({
   toolOutput,
   toolParams,
-  viewType,
+  displayContext,
   owner,
 }: ToolExecutionDetailsProps) {
   const urls = isWebbrowseInputType(toolParams) ? toolParams.urls : null;
@@ -25,16 +25,20 @@ export function MCPBrowseActionDetails({
 
   return (
     <ActionDetailsWrapper
-      viewType={viewType}
+      displayContext={displayContext}
       actionName={
-        viewType === "conversation" ? "Browsing the web" : "Web navigation"
+        displayContext === "conversation"
+          ? "Browsing the web"
+          : "Web navigation"
       }
       visual={GlobeAltIcon}
     >
       <div className="flex flex-col gap-4 pl-6 pt-4">
         <div className="flex flex-col gap-1">
           <div className="text-sm font-normal text-muted-foreground dark:text-muted-foreground-night">
-            {(viewType === "conversation" || browseResults.length === 0) && urls
+            {(displayContext === "conversation" ||
+              browseResults.length === 0) &&
+            urls
               ? urls.map((url, idx) => (
                   <div
                     className="group flex max-h-60 flex-row items-center gap-x-1 overflow-y-auto overflow-x-hidden pb-1"

--- a/front/components/actions/mcp/details/MCPConversationFilesActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPConversationFilesActionDetails.tsx
@@ -14,7 +14,7 @@ const MAX_PREVIEW_LINES = 10;
 
 export function MCPConversationCatFileDetails({
   toolOutput,
-  viewType,
+  displayContext,
 }: ToolExecutionDetailsProps) {
   const contentBlock = toolOutput?.find(isTextContent);
   const content = contentBlock?.text ?? null;
@@ -22,9 +22,9 @@ export function MCPConversationCatFileDetails({
   if (!content) {
     return (
       <ActionDetailsWrapper
-        viewType={viewType}
+        displayContext={displayContext}
         actionName={
-          viewType === "conversation"
+          displayContext === "conversation"
             ? "Reading conversation file"
             : "Read conversation file"
         }
@@ -43,15 +43,15 @@ export function MCPConversationCatFileDetails({
 
   return (
     <ActionDetailsWrapper
-      viewType={viewType}
+      displayContext={displayContext}
       actionName={
-        viewType === "conversation"
+        displayContext === "conversation"
           ? "Reading conversation file"
           : "Read conversation file"
       }
       visual={DocumentIcon}
     >
-      {viewType === "sidebar" && (
+      {displayContext === "sidebar" && (
         <div className="flex flex-col gap-4 pl-6 pt-4">
           <Collapsible defaultOpen={false}>
             <CollapsibleTrigger>

--- a/front/components/actions/mcp/details/MCPDataSourcesFileSystemActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPDataSourcesFileSystemActionDetails.tsx
@@ -24,7 +24,7 @@ import { formatDataSourceDisplayName } from "@app/types";
 
 export function DataSourceNodeContentDetails({
   toolOutput,
-  viewType,
+  displayContext,
 }: ToolExecutionDetailsProps) {
   const dataSourceNodeContent = toolOutput
     ?.filter(isDataSourceNodeContentType)
@@ -37,9 +37,9 @@ export function DataSourceNodeContentDetails({
 
   return (
     <ActionDetailsWrapper
-      viewType={viewType}
+      displayContext={displayContext}
       actionName={
-        viewType === "conversation"
+        displayContext === "conversation"
           ? "Retrieving file content"
           : "Retrieve file content"
       }
@@ -63,7 +63,7 @@ export function DataSourceNodeContentDetails({
           )}
         </div>
 
-        {viewType === "sidebar" && sourceUrl && text && (
+        {displayContext === "sidebar" && sourceUrl && text && (
           <Markdown
             content={text}
             isStreaming={false}
@@ -78,7 +78,7 @@ export function DataSourceNodeContentDetails({
 
 export function FilesystemPathDetails({
   toolOutput,
-  viewType,
+  displayContext,
 }: ToolExecutionDetailsProps) {
   const filesystemPath = toolOutput
     ?.filter(isFilesystemPathType)
@@ -115,8 +115,10 @@ export function FilesystemPathDetails({
 
   return (
     <ActionDetailsWrapper
-      viewType={viewType}
-      actionName={viewType === "conversation" ? "Locating item" : "Locate item"}
+      displayContext={displayContext}
+      actionName={
+        displayContext === "conversation" ? "Locating item" : "Locate item"
+      }
       visual={ActionPinDistanceIcon}
     >
       <div className="flex flex-col gap-4 pl-6 pt-4">

--- a/front/components/actions/mcp/details/MCPDataWarehousesBrowseDetails.tsx
+++ b/front/components/actions/mcp/details/MCPDataWarehousesBrowseDetails.tsx
@@ -13,7 +13,7 @@ import { getDocumentIcon } from "@app/lib/content_nodes";
 
 export function MCPDataWarehousesBrowseDetails({
   toolOutput,
-  viewType,
+  displayContext,
 }: ToolExecutionDetailsProps) {
   const browseResult = toolOutput
     ?.filter(isWarehousesBrowseType)
@@ -27,9 +27,9 @@ export function MCPDataWarehousesBrowseDetails({
 
   return (
     <ActionDetailsWrapper
-      viewType={viewType}
+      displayContext={displayContext}
       actionName={
-        viewType === "conversation"
+        displayContext === "conversation"
           ? "Browsing Data Warehouses"
           : "Browse Data Warehouses"
       }
@@ -42,7 +42,7 @@ export function MCPDataWarehousesBrowseDetails({
           </div>
         )}
 
-        {viewType === "sidebar" && data.length > 0 && (
+        {displayContext === "sidebar" && data.length > 0 && (
           <div className="flex flex-col gap-2">
             {data.map((node, index) => {
               const IconComponent = getDocumentIcon(node.connectorProvider);

--- a/front/components/actions/mcp/details/MCPDeepDiveActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPDeepDiveActionDetails.tsx
@@ -19,7 +19,7 @@ import { DUST_AVATAR_URL } from "@app/types/assistant/avatar";
 export function MCPDeepDiveActionDetails({
   owner,
   toolOutput,
-  viewType,
+  displayContext,
 }: ToolExecutionDetailsProps) {
   const handoffResource =
     toolOutput?.find(isAgentPauseOutputResourceType) ?? null;
@@ -44,7 +44,7 @@ export function MCPDeepDiveActionDetails({
 
   return (
     <ActionDetailsWrapper
-      viewType={viewType}
+      displayContext={displayContext}
       actionName="Hand off to Deep dive"
       visual={() => <Avatar visual={DUST_AVATAR_URL} size="xs" busy={isBusy} />}
     >

--- a/front/components/actions/mcp/details/MCPExtractActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPExtractActionDetails.tsx
@@ -44,7 +44,7 @@ interface MCPExtractActionResultsProps {
 export function MCPExtractActionDetails({
   toolParams,
   toolOutput,
-  viewType,
+  displayContext,
 }: ToolExecutionDetailsProps) {
   const queryResource = toolOutput
     ?.filter(isExtractQueryResourceType)
@@ -58,9 +58,9 @@ export function MCPExtractActionDetails({
 
   return (
     <ActionDetailsWrapper
-      viewType={viewType}
+      displayContext={displayContext}
       actionName={
-        viewType === "conversation" ? "Extracting data" : "Extract data"
+        displayContext === "conversation" ? "Extracting data" : "Extract data"
       }
       visual={ScanIcon}
     >
@@ -97,7 +97,7 @@ export function MCPExtractActionDetails({
           </div>
         )}
 
-        {viewType === "sidebar" && (
+        {displayContext === "sidebar" && (
           <div>
             <Collapsible defaultOpen={false}>
               <CollapsibleTrigger>

--- a/front/components/actions/mcp/details/MCPGetDatabaseSchemaActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPGetDatabaseSchemaActionDetails.tsx
@@ -19,7 +19,7 @@ import {
 
 export function MCPGetDatabaseSchemaActionDetails({
   toolOutput,
-  viewType,
+  displayContext,
 }: ToolExecutionDetailsProps) {
   // Extract different types of outputs
   const schemaBlocks =
@@ -30,15 +30,15 @@ export function MCPGetDatabaseSchemaActionDetails({
 
   return (
     <ActionDetailsWrapper
-      viewType={viewType}
+      displayContext={displayContext}
       actionName={
-        viewType === "conversation"
+        displayContext === "conversation"
           ? "Getting database schema"
           : "Get database schema"
       }
       visual={TableIcon}
     >
-      {viewType === "sidebar" && (
+      {displayContext === "sidebar" && (
         <div className="flex flex-col gap-4 pl-6 pt-4">
           <>
             <DatabaseSchemaSection schemas={schemaBlocks} />

--- a/front/components/actions/mcp/details/MCPImageGenerationActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPImageGenerationActionDetails.tsx
@@ -2,7 +2,10 @@ import { ActionImageIcon, Chip, cn, Separator } from "@dust-tt/sparkle";
 import React from "react";
 
 import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
-import type { ToolExecutionDetailsProps } from "@app/components/actions/mcp/details/types";
+import type {
+  ActionDetailsDisplayContext,
+  ToolExecutionDetailsProps,
+} from "@app/components/actions/mcp/details/types";
 import { isGenerateImageInputType } from "@app/lib/actions/mcp_internal_actions/types";
 import { useFileMetadata } from "@app/lib/swr/files";
 import type { LightWorkspaceType } from "@app/types";
@@ -108,7 +111,7 @@ export function MCPImageGenerationActionDetails({
 }
 
 interface MCPImageGenerationGroupedDetailsProps {
-  displayContext: "conversation" | "sidebar";
+  displayContext: ActionDetailsDisplayContext;
   actions: AgentMCPActionWithOutputType[];
   owner: LightWorkspaceType;
 }

--- a/front/components/actions/mcp/details/MCPImageGenerationActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPImageGenerationActionDetails.tsx
@@ -39,16 +39,18 @@ function ReferenceImageChip({ fileId, owner }: ReferenceImageChipProps) {
 }
 
 export function MCPImageGenerationActionDetails({
-  viewType,
+  displayContext,
   toolParams,
   owner,
 }: ToolExecutionDetailsProps) {
   if (!isGenerateImageInputType(toolParams)) {
     return (
       <ActionDetailsWrapper
-        viewType={viewType}
+        displayContext={displayContext}
         actionName={
-          viewType === "conversation" ? "Generating image" : "Generate image"
+          displayContext === "conversation"
+            ? "Generating image"
+            : "Generate image"
         }
         visual={ActionImageIcon}
       />
@@ -60,16 +62,18 @@ export function MCPImageGenerationActionDetails({
 
   return (
     <ActionDetailsWrapper
-      viewType={viewType}
+      displayContext={displayContext}
       actionName={
-        viewType === "conversation" ? "Generating image" : "Generate image"
+        displayContext === "conversation"
+          ? "Generating image"
+          : "Generate image"
       }
       visual={ActionImageIcon}
     >
       <div
         className={cn(
           "flex flex-col gap-3",
-          viewType === "conversation" ? "pl-6" : "pt-2"
+          displayContext === "conversation" ? "pl-6" : "pt-2"
         )}
       >
         <div className="flex flex-wrap gap-1">
@@ -93,7 +97,7 @@ export function MCPImageGenerationActionDetails({
         <p
           className={cn(
             "text-sm text-muted-foreground dark:text-muted-foreground-night",
-            viewType === "conversation" ? "line-clamp-3" : ""
+            displayContext === "conversation" ? "line-clamp-3" : ""
           )}
         >
           {prompt}
@@ -104,26 +108,26 @@ export function MCPImageGenerationActionDetails({
 }
 
 interface MCPImageGenerationGroupedDetailsProps {
-  viewType: "conversation" | "sidebar";
+  displayContext: "conversation" | "sidebar";
   actions: AgentMCPActionWithOutputType[];
   owner: LightWorkspaceType;
 }
 
 export function MCPImageGenerationGroupedDetails({
-  viewType,
+  displayContext,
   actions,
   owner,
 }: MCPImageGenerationGroupedDetailsProps) {
   return (
     <ActionDetailsWrapper
-      viewType={viewType}
+      displayContext={displayContext}
       actionName={`Generating ${actions.length} images`}
       visual={ActionImageIcon}
     >
       <div
         className={cn(
           "flex flex-col gap-4",
-          viewType === "conversation" ? "pl-6" : "pt-2"
+          displayContext === "conversation" ? "pl-6" : "pt-2"
         )}
       >
         {actions.map((action, index) => {
@@ -165,7 +169,7 @@ export function MCPImageGenerationGroupedDetails({
                 <p
                   className={cn(
                     "text-sm text-muted-foreground dark:text-muted-foreground-night",
-                    viewType === "conversation" ? "line-clamp-3" : ""
+                    displayContext === "conversation" ? "line-clamp-3" : ""
                   )}
                 >
                   {prompt}

--- a/front/components/actions/mcp/details/MCPListToolsActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPListToolsActionDetails.tsx
@@ -11,7 +11,7 @@ import { useSpaces } from "@app/lib/swr/spaces";
 export function MCPListToolsActionDetails({
   owner,
   toolOutput,
-  viewType,
+  displayContext,
 }: ToolExecutionDetailsProps) {
   const { spaces } = useSpaces({
     kinds: ["global"],
@@ -28,11 +28,13 @@ export function MCPListToolsActionDetails({
 
   return (
     <ActionDetailsWrapper
-      viewType={viewType}
-      actionName={viewType === "conversation" ? `Listing tools` : `List tools`}
+      displayContext={displayContext}
+      actionName={
+        displayContext === "conversation" ? `Listing tools` : `List tools`
+      }
       visual={BoltIcon}
     >
-      {viewType !== "conversation" && (
+      {displayContext !== "conversation" && (
         <div className="pl-6 pt-4 text-sm font-normal text-muted-foreground dark:text-muted-foreground-night">
           <div className="flex flex-wrap gap-1">
             {results.map((result) => {

--- a/front/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
@@ -52,7 +52,7 @@ export function MCPRunAgentActionDetails({
   owner,
   toolOutput,
   toolParams,
-  viewType,
+  displayContext,
 }: ToolExecutionDetailsProps) {
   const addedMCPServerViewIds: string[] = useMemo(() => {
     if (!toolParams["toolsetsToAdd"]) {
@@ -203,9 +203,9 @@ export function MCPRunAgentActionDetails({
 
   return (
     <ActionDetailsWrapper
-      viewType={viewType}
+      displayContext={displayContext}
       actionName={
-        viewType === "conversation"
+        displayContext === "conversation"
           ? `Running @${agentName}`
           : `Run @${agentName}`
       }
@@ -217,7 +217,7 @@ export function MCPRunAgentActionDetails({
           : RobotIcon
       }
     >
-      {viewType === "conversation" ? (
+      {displayContext === "conversation" ? (
         query && (
           <div className="text-sm font-normal text-muted-foreground dark:text-muted-foreground-night">
             {query}

--- a/front/components/actions/mcp/details/MCPSkillEnableActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPSkillEnableActionDetails.tsx
@@ -4,7 +4,7 @@ import { isSkillEnableInputType } from "@app/lib/actions/mcp_internal_actions/ty
 import { SKILL_ICON } from "@app/lib/skill";
 
 export function MCPSkillEnableActionDetails({
-  viewType,
+  displayContext,
   toolParams,
 }: ToolExecutionDetailsProps) {
   const skillName = isSkillEnableInputType(toolParams)
@@ -12,12 +12,12 @@ export function MCPSkillEnableActionDetails({
     : null;
 
   const actionName =
-    (viewType === "conversation" ? "Enabling skill" : "Enable skill") +
+    (displayContext === "conversation" ? "Enabling skill" : "Enable skill") +
     (skillName ? `: ${skillName}` : "");
 
   return (
     <ActionDetailsWrapper
-      viewType={viewType}
+      displayContext={displayContext}
       actionName={actionName}
       visual={SKILL_ICON}
     />

--- a/front/components/actions/mcp/details/MCPTablesQueryActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPTablesQueryActionDetails.tsx
@@ -20,7 +20,7 @@ import {
 export function MCPTablesQueryActionDetails({
   toolOutput,
   toolParams,
-  viewType,
+  displayContext,
   owner,
 }: ToolExecutionDetailsProps) {
   const thinkingBlocks =
@@ -43,13 +43,13 @@ export function MCPTablesQueryActionDetails({
 
   return (
     <ActionDetailsWrapper
-      viewType={viewType}
+      displayContext={displayContext}
       actionName={
-        viewType === "conversation" ? "Querying tables" : "Query tables"
+        displayContext === "conversation" ? "Querying tables" : "Query tables"
       }
       visual={TableIcon}
     >
-      {viewType === "conversation" ? (
+      {displayContext === "conversation" ? (
         thinkingBlocks.length > 0 && (
           <div className="flex flex-col gap-4 pl-6 pt-4">
             {thinkingBlocks.map((block) => (

--- a/front/components/actions/mcp/details/MCPToolOutputDetails.tsx
+++ b/front/components/actions/mcp/details/MCPToolOutputDetails.tsx
@@ -18,7 +18,6 @@ import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapp
 import { AttachmentCitation } from "@app/components/assistant/conversation/attachment/AttachmentCitation";
 import { toolGeneratedFileToAttachmentCitation } from "@app/components/assistant/conversation/attachment/utils";
 import type {
-  ReasoningSuccessOutputType,
   SqlQueryOutputType,
   ThinkingOutputType,
   ToolGeneratedFileType,
@@ -34,6 +33,7 @@ import {
 import { getDocumentIcon } from "@app/lib/content_nodes";
 import type { LightWorkspaceType } from "@app/types";
 import { removeNulls } from "@app/types";
+import { ActionDetailsDisplayContext } from "@app/components/actions/mcp/details/types";
 
 interface ThinkingBlockProps {
   resource: ThinkingOutputType;
@@ -57,28 +57,6 @@ export function ThinkingBlock({ resource }: ThinkingBlockProps) {
             isLastMessage={false}
           />
         </ContentMessage>
-      </div>
-    )
-  );
-}
-
-interface ReasoningSuccessBlockProps {
-  resource: ReasoningSuccessOutputType;
-}
-
-export function ReasoningSuccessBlock({
-  resource,
-}: ReasoningSuccessBlockProps) {
-  return (
-    resource.text && (
-      <div className="text-sm font-normal text-muted-foreground dark:text-muted-foreground-night">
-        <Markdown
-          content={resource.text}
-          textColor="text-muted-foreground dark:text-muted-foreground-night"
-          isStreaming={false}
-          forcedTextSize="md"
-          isLastMessage={false}
-        />
       </div>
     )
   );
@@ -129,7 +107,7 @@ interface SearchResultProps {
   actionName: string;
   visual: React.ComponentType<{ className?: string }>;
   actionOutput: CallToolResult["content"] | null;
-  displayContext: "conversation" | "sidebar";
+  displayContext: ActionDetailsDisplayContext;
   query: string | null;
 }
 

--- a/front/components/actions/mcp/details/MCPToolOutputDetails.tsx
+++ b/front/components/actions/mcp/details/MCPToolOutputDetails.tsx
@@ -129,14 +129,14 @@ interface SearchResultProps {
   actionName: string;
   visual: React.ComponentType<{ className?: string }>;
   actionOutput: CallToolResult["content"] | null;
-  viewType: "conversation" | "sidebar";
+  displayContext: "conversation" | "sidebar";
   query: string | null;
 }
 
 export function SearchResultDetails({
   actionName,
   visual,
-  viewType,
+  displayContext,
   actionOutput,
   query,
 }: SearchResultProps) {
@@ -214,11 +214,11 @@ export function SearchResultDetails({
 
   return (
     <ActionDetailsWrapper
-      viewType={viewType}
+      displayContext={displayContext}
       actionName={actionName}
       visual={visual}
     >
-      {viewType === "conversation" ? (
+      {displayContext === "conversation" ? (
         <div className="text-sm font-normal text-muted-foreground dark:text-muted-foreground-night">
           {displayQuery}
         </div>
@@ -238,7 +238,7 @@ export function SearchResultDetails({
               />
             )}
           </div>
-          {actionOutput && viewType === "sidebar" && (
+          {actionOutput && displayContext === "sidebar" && (
             <div>
               <Collapsible defaultOpen={false}>
                 <CollapsibleTrigger>

--- a/front/components/actions/mcp/details/MCPToolOutputDetails.tsx
+++ b/front/components/actions/mcp/details/MCPToolOutputDetails.tsx
@@ -15,6 +15,7 @@ import {
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
 import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
+import type { ActionDetailsDisplayContext } from "@app/components/actions/mcp/details/types";
 import { AttachmentCitation } from "@app/components/assistant/conversation/attachment/AttachmentCitation";
 import { toolGeneratedFileToAttachmentCitation } from "@app/components/assistant/conversation/attachment/utils";
 import type {
@@ -33,7 +34,6 @@ import {
 import { getDocumentIcon } from "@app/lib/content_nodes";
 import type { LightWorkspaceType } from "@app/types";
 import { removeNulls } from "@app/types";
-import { ActionDetailsDisplayContext } from "@app/components/actions/mcp/details/types";
 
 interface ThinkingBlockProps {
   resource: ThinkingOutputType;

--- a/front/components/actions/mcp/details/MCPToolsetsEnableActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPToolsetsEnableActionDetails.tsx
@@ -4,12 +4,14 @@ import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapp
 import type { ToolExecutionDetailsProps } from "@app/components/actions/mcp/details/types";
 
 export function MCPToolsetsEnableActionDetails({
-  viewType,
+  displayContext,
 }: ToolExecutionDetailsProps) {
   return (
     <ActionDetailsWrapper
-      viewType={viewType}
-      actionName={viewType === "conversation" ? "Enabled tool" : "Enable tool"}
+      displayContext={displayContext}
+      actionName={
+        displayContext === "conversation" ? "Enabled tool" : "Enable tool"
+      }
       visual={BoltIcon}
     />
   );

--- a/front/components/actions/mcp/details/types.ts
+++ b/front/components/actions/mcp/details/types.ts
@@ -3,6 +3,8 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import type { ProgressNotificationContentType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import type { LightWorkspaceType } from "@app/types";
 
+export type ActionDetailsDisplayContext = "conversation" | "sidebar";
+
 // Generic interface for every component that displays details for a certain type of tool output.
 export interface ToolExecutionDetailsProps {
   lastNotification: ProgressNotificationContentType | null;
@@ -10,5 +12,5 @@ export interface ToolExecutionDetailsProps {
   owner: LightWorkspaceType;
   toolOutput: CallToolResult["content"] | null;
   toolParams: Record<string, unknown>;
-  displayContext: "conversation" | "sidebar";
+  displayContext: ActionDetailsDisplayContext;
 }

--- a/front/components/actions/mcp/details/types.ts
+++ b/front/components/actions/mcp/details/types.ts
@@ -10,5 +10,5 @@ export interface ToolExecutionDetailsProps {
   owner: LightWorkspaceType;
   toolOutput: CallToolResult["content"] | null;
   toolParams: Record<string, unknown>;
-  viewType: "conversation" | "sidebar";
+  displayContext: "conversation" | "sidebar";
 }

--- a/front/components/assistant/conversation/actions/AgentMessageActions.tsx
+++ b/front/components/assistant/conversation/actions/AgentMessageActions.tsx
@@ -104,7 +104,7 @@ export function AgentMessageActions({
             />
           ) : (
             <MCPActionDetails
-              viewType="conversation"
+              displayContext="conversation"
               action={lastAction}
               owner={owner}
               lastNotification={lastNotification}

--- a/front/components/assistant/conversation/actions/AgentMessageActions.tsx
+++ b/front/components/assistant/conversation/actions/AgentMessageActions.tsx
@@ -98,7 +98,7 @@ export function AgentMessageActions({
         <Card variant="secondary" className="max-w-xl">
           {imageGenerationActions.length > 1 ? (
             <MCPImageGenerationGroupedDetails
-              viewType="conversation"
+              displayContext="conversation"
               actions={imageGenerationActions}
               owner={owner}
             />

--- a/front/components/assistant/conversation/actions/PanelAgentStep.tsx
+++ b/front/components/assistant/conversation/actions/PanelAgentStep.tsx
@@ -80,7 +80,7 @@ export function PanelAgentStep({
         return (
           <div key={`action-${entry.action.id}`}>
             <MCPActionDetails
-              viewType="sidebar"
+              displayContext="sidebar"
               action={entry.action}
               lastNotification={streamProgress ?? null}
               owner={owner}
@@ -102,7 +102,7 @@ export function PanelAgentStep({
             return (
               <div key={`streaming-action-${action.id}`} className="mb-4">
                 <MCPActionDetails
-                  viewType="sidebar"
+                  displayContext="sidebar"
                   action={action}
                   lastNotification={lastNotification}
                   owner={owner}


### PR DESCRIPTION
## Description

- This PR renames the prop `viewType` in action details components, in favor of `displayContext`.
- Also adds a type instead of repeating it and removes the unused component `ReasoningSuccessBlock` (was used by tables query v1).

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
