### PR TITLE
dust-hive: make restart interactive to select env and service

### DIFF
--- a/x/henry/dust-hive/src/commands/restart.ts
+++ b/x/henry/dust-hive/src/commands/restart.ts
@@ -1,27 +1,70 @@
-import { withEnvironment } from "../lib/commands";
+import * as p from "@clack/prompts";
+import { requireEnvironment } from "../lib/commands";
 import { logger } from "../lib/logger";
 import { stopService } from "../lib/process";
+import { restoreTerminal } from "../lib/prompt";
 import { startService, waitForServiceReady } from "../lib/registry";
-import { CommandError, Err, Ok } from "../lib/result";
-import { ALL_SERVICES, isServiceName } from "../lib/services";
+import { CommandError, Err, Ok, type Result } from "../lib/result";
+import { ALL_SERVICES, type ServiceName, isServiceName } from "../lib/services";
 
-export const restartCommand = withEnvironment("restart", async (env, serviceArg: string) => {
-  if (!isServiceName(serviceArg)) {
-    console.log(`\nServices: ${ALL_SERVICES.join(", ")}`);
-    return Err(new CommandError(`Unknown service '${serviceArg ?? ""}'`));
+async function selectService(): Promise<ServiceName | null> {
+  const result = await p.select({
+    message: "Select service to restart",
+    options: ALL_SERVICES.map((name) => ({ value: name, label: name })),
+  });
+
+  if (p.isCancel(result)) {
+    return null;
   }
 
-  logger.info(`Restarting ${serviceArg} in '${env.name}'...`);
+  return result as ServiceName;
+}
 
-  const stopped = await stopService(env.name, serviceArg);
+export async function restartCommand(
+  nameArg: string | undefined,
+  serviceArg: string | undefined
+): Promise<Result<void>> {
+  // Skip restoreTerminal if we need interactive service selection after
+  const skipRestore = !serviceArg;
+  const envResult = await requireEnvironment(nameArg, "restart", {
+    skipRestoreTerminal: skipRestore,
+  });
+  if (!envResult.ok) return envResult;
+
+  const env = envResult.value;
+
+  // Handle service selection
+  let service: ServiceName;
+  if (serviceArg) {
+    // Service provided via CLI argument
+    if (!isServiceName(serviceArg)) {
+      console.log(`\nServices: ${ALL_SERVICES.join(", ")}`);
+      return Err(new CommandError(`Unknown service '${serviceArg}'`));
+    }
+    service = serviceArg;
+  } else {
+    // Interactive selection
+    const selected = await selectService();
+    if (!selected) {
+      return Err(new CommandError("No service selected"));
+    }
+    service = selected;
+  }
+
+  // Restore terminal after all interactive prompts are done
+  restoreTerminal();
+
+  logger.info(`Restarting ${service} in '${env.name}'...`);
+
+  const stopped = await stopService(env.name, service);
   if (!stopped) {
-    logger.info(`${serviceArg} was not running`);
+    logger.info(`${service} was not running`);
   }
 
-  await startService(env, serviceArg);
-  await waitForServiceReady(env, serviceArg);
+  await startService(env, service);
+  await waitForServiceReady(env, service);
 
-  logger.success(`${serviceArg} restarted`);
+  logger.success(`${service} restarted`);
 
   return Ok(undefined);
-});
+}

--- a/x/henry/dust-hive/src/commands/restart.ts
+++ b/x/henry/dust-hive/src/commands/restart.ts
@@ -17,7 +17,7 @@ async function selectService(): Promise<ServiceName | null> {
     return null;
   }
 
-  return result as ServiceName;
+  return result;
 }
 
 export async function restartCommand(

--- a/x/henry/dust-hive/src/index.ts
+++ b/x/henry/dust-hive/src/index.ts
@@ -144,8 +144,8 @@ cli
   });
 
 cli
-  .command("restart [name] <service>", "Restart a single service")
-  .action(async (name: string | undefined, service: string) => {
+  .command("restart [name] [service]", "Restart a single service")
+  .action(async (name: string | undefined, service: string | undefined) => {
     await prepareAndRun(restartCommand(name, service));
   });
 


### PR DESCRIPTION
## Description

Can now be use with just `dust-hive restart` and select the env + service manually

<img width="1602" height="462" alt="image" src="https://github.com/user-attachments/assets/a8478ca1-c789-48ac-8d66-12d2f147f69d" />

or just specify the env and select the service

<img width="1642" height="426" alt="image" src="https://github.com/user-attachments/assets/a70a74a7-09bd-4dda-8606-e1f67394e16f" />

or specify all like before

<img width="1642" height="366" alt="image" src="https://github.com/user-attachments/assets/b111d140-8a17-4431-8f2e-109c08c957c1" />


## Tests

manual tests

## Risk

low

## Deploy Plan

none
