### PR TITLE
refactor(MCP): migrate run_agent server to static metadata pattern

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
@@ -13971,7 +13971,9 @@
         }
       }
     ],
-    "toolsStakes": null
+    "toolsStakes": {
+      "run_agent": "never_ask"
+    }
   },
   {
     "name": "run_dust_app",

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1,6 +1,5 @@
 import type { InternalAllowedIconType } from "@app/components/resources/resources_icons";
 import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
-import { RUN_AGENT_CALL_TOOL_TIMEOUT_MS } from "@app/lib/actions/constants";
 import {
   FRESHSERVICE_SERVER_INSTRUCTIONS,
   JIRA_SERVER_INSTRUCTIONS,
@@ -42,6 +41,7 @@ import {
   QUERY_TABLES_V2_SERVER,
   TABLE_QUERY_V2_SERVER_NAME,
 } from "@app/lib/api/actions/servers/query_tables_v2/metadata";
+import { RUN_AGENT_SERVER } from "@app/lib/api/actions/servers/run_agent/metadata";
 import { RUN_DUST_APP_SERVER } from "@app/lib/api/actions/servers/run_dust_app/metadata";
 import { SANDBOX_SERVER } from "@app/lib/api/actions/servers/sandbox/metadata";
 import { SEARCH_SERVER } from "@app/lib/api/actions/servers/search/metadata";
@@ -1189,19 +1189,10 @@ export const INTERNAL_MCP_SERVERS = {
     allowMultipleInstances: true,
     isRestricted: undefined,
     isPreview: false,
-    tools_stakes: undefined,
     tools_arguments_requiring_approval: undefined,
     tools_retry_policies: { default: "retry_on_interrupt" },
-    timeoutMs: RUN_AGENT_CALL_TOOL_TIMEOUT_MS,
-    serverInfo: {
-      name: "run_agent",
-      version: "1.0.0",
-      description: "Run a child agent (agent as tool).",
-      icon: "ActionRobotIcon",
-      authorization: null,
-      documentationUrl: null,
-      instructions: null,
-    },
+    timeoutMs: RUN_AGENT_SERVER.timeoutMs,
+    metadata: RUN_AGENT_SERVER,
   },
   [TABLE_QUERY_V2_SERVER_NAME]: {
     id: 1009,

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -16,7 +16,6 @@ import { default as microsoftTeamsServer } from "@app/lib/actions/mcp_internal_a
 import { default as outlookServer } from "@app/lib/actions/mcp_internal_actions/servers/outlook";
 import { default as outlookCalendarServer } from "@app/lib/actions/mcp_internal_actions/servers/outlook/calendar_server";
 import { default as productboardServer } from "@app/lib/actions/mcp_internal_actions/servers/productboard";
-import { default as runAgentServer } from "@app/lib/actions/mcp_internal_actions/servers/run_agent";
 import { default as salesforceServer } from "@app/lib/actions/mcp_internal_actions/servers/salesforce";
 import { default as salesloftServer } from "@app/lib/actions/mcp_internal_actions/servers/salesloft";
 import { default as schedulesManagementServer } from "@app/lib/actions/mcp_internal_actions/servers/schedules_management";
@@ -58,6 +57,7 @@ import { default as openaiUsageServer } from "@app/lib/api/actions/servers/opena
 import { default as primitiveTypesDebuggerServer } from "@app/lib/api/actions/servers/primitive_types_debugger";
 import { default as projectContextManagementServer } from "@app/lib/api/actions/servers/project_context_management";
 import { default as tablesQueryServerV2 } from "@app/lib/api/actions/servers/query_tables_v2";
+import { default as runAgentServer } from "@app/lib/api/actions/servers/run_agent";
 import { default as dustAppServer } from "@app/lib/api/actions/servers/run_dust_app";
 import { default as sandboxServer } from "@app/lib/api/actions/servers/sandbox";
 import { default as searchServer } from "@app/lib/api/actions/servers/search";

--- a/front/lib/api/actions/servers/run_agent/metadata.ts
+++ b/front/lib/api/actions/servers/run_agent/metadata.ts
@@ -1,0 +1,122 @@
+// eslint-disable-next-line dust/enforce-client-types-in-public-api
+import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
+
+import { RUN_AGENT_CALL_TOOL_TIMEOUT_MS } from "@app/lib/actions/constants";
+import {
+  AGENT_CONFIGURATION_URI_PATTERN,
+  ConfigurableToolInputSchemas,
+} from "@app/lib/actions/mcp_internal_actions/input_schemas";
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { getResourcePrefix } from "@app/lib/resources/string_ids";
+
+export const RUN_AGENT_TOOL_NAME = "run_agent" as const;
+
+export const RUN_AGENT_DEFAULT_TOOL_STAKE = "never_ask" as const;
+
+export const RUN_AGENT_CONFIGURABLE_PROPERTIES = {
+  executionMode: z
+    .object({
+      options: z
+        .union([
+          z
+            .object({
+              value: z.literal("run-agent"),
+              label: z.literal("Agent runs in the background"),
+            })
+            .describe(
+              "The selected agent runs in a background conversation and passes results back to " +
+                "the main agent.\nThis is the default behavior, well suited for breaking down " +
+                "complex work by delegating specific research/analysis subtasks while " +
+                "maintaining control of the overall response."
+            ),
+          z
+            .object({
+              value: z.literal("handoff"),
+              label: z.literal("Agent responds in conversation"),
+            })
+            .describe(
+              "The selected agent takes over and responds directly in the conversation." +
+                "\nWell suited for a routing use case where the sub-agent should handle " +
+                "the entire interaction going forward."
+            ),
+        ])
+        .optional(),
+      value: z.string(),
+      mimeType: z.literal(INTERNAL_MIME_TYPES.TOOL_INPUT.ENUM),
+    })
+    .default({
+      value: "run-agent",
+      mimeType: INTERNAL_MIME_TYPES.TOOL_INPUT.ENUM,
+    }),
+  childAgent:
+    ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.AGENT],
+};
+
+export const RUN_AGENT_TOOL_SCHEMA = {
+  query: z
+    .string()
+    .describe(
+      "The query sent to the agent. This is the question or instruction that will be " +
+        "processed by the agent, which will respond with its own capabilities and knowledge."
+    ),
+  toolsetsToAdd: z
+    .array(
+      z
+        .string()
+        .regex(new RegExp(`^${getResourcePrefix("mcp_server_view")}_\\w+$`))
+    )
+    .describe(
+      "The toolsets ids to add to the agent in addition to the ones already set in the agent configuration."
+    )
+    .optional()
+    .nullable(),
+  fileOrContentFragmentIds: z
+    .array(z.string().regex(new RegExp(`^[_\\w]+$`)))
+    .describe(
+      "The filesId of the files to pass to the agent conversation. If the file is a content node, use the contentFragmentId instead."
+    )
+    .optional()
+    .nullable(),
+};
+
+export const RUN_AGENT_SERVER = {
+  serverInfo: {
+    name: "run_agent",
+    version: "1.0.0",
+    description: "Run a child agent (agent as tool).",
+    authorization: null,
+    icon: "ActionRobotIcon",
+    documentationUrl: null,
+    instructions: null,
+  },
+  // The actual tool name is dynamic, but we need a placeholder tool
+  // with the configurable properties schema so that the UI can detect that this server
+  // requires child agent configuration before being added.
+  tools: [
+    {
+      name: RUN_AGENT_TOOL_NAME,
+      description: "Run a child agent (agent as tool).",
+      inputSchema: zodToJsonSchema(
+        z.object({
+          ...RUN_AGENT_TOOL_SCHEMA,
+          ...RUN_AGENT_CONFIGURABLE_PROPERTIES,
+        })
+      ) as JSONSchema,
+    },
+  ],
+  // Default stake for dynamically created run_agent tools.
+  // The actual tool name is dynamic but all run_agent tools have the same stake.
+  tools_stakes: { [RUN_AGENT_TOOL_NAME]: RUN_AGENT_DEFAULT_TOOL_STAKE },
+  timeoutMs: RUN_AGENT_CALL_TOOL_TIMEOUT_MS,
+} as const satisfies ServerMetadata & { timeoutMs: number };
+
+export function parseAgentConfigurationUri(uri: string): string | null {
+  const match = uri.match(AGENT_CONFIGURATION_URI_PATTERN);
+  if (!match) {
+    return null;
+  }
+  return match[2];
+}


### PR DESCRIPTION
## Summary

- Migrate `run_agent` internal MCP server to use the static metadata pattern per `NEW_MCP_SERVER.md`
- Create new `metadata.ts` file with server metadata, configurable properties, and tool schema definitions
- Move server implementation to `lib/api/actions/servers/run_agent/`
- Update constants and server index imports

## Details

The `run_agent` server is unique in that its tool name is dynamically generated based on the child agent configuration (`run_${childAgentBlob.name}`). The metadata file extracts what can be static:
- Server info (name, version, description, icon)
- Configurable properties schema (executionMode, childAgent)
- Tool input schema (query, toolsetsToAdd, fileOrContentFragmentIds)
- Timeout configuration

The tool registration remains dynamic in `index.ts` since the tool name and description depend on runtime context.

## Test plan

- [x] Type check passes (`npx tsgo --noEmit`)
- [x] Lint passes (`npm run lint`)
- [x] Manual testing of run_agent functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)