### PR TITLE
fix: back navigation from project conversation redirects to conv list

### DIFF
--- a/front/pages/w/[wId]/conversation/space/[spaceId]/index.tsx
+++ b/front/pages/w/[wId]/conversation/space/[spaceId]/index.tsx
@@ -12,14 +12,12 @@ import { useRouter } from "next/router";
 import type { ReactElement } from "react";
 import React, { useCallback, useState } from "react";
 
-import { ConversationContainerVirtuoso } from "@app/components/assistant/conversation/ConversationContainer";
 import type { ConversationLayoutProps } from "@app/components/assistant/conversation/ConversationLayout";
 import { ConversationLayout } from "@app/components/assistant/conversation/ConversationLayout";
 import { SpaceAboutTab } from "@app/components/assistant/conversation/space/about/SpaceAboutTab";
 import { SpaceConversationsTab } from "@app/components/assistant/conversation/space/conversations/SpaceConversationsTab";
 import { SpaceContextTab } from "@app/components/assistant/conversation/space/SpaceContextTab";
 import AppRootLayout from "@app/components/sparkle/AppRootLayout";
-import { useActiveConversationId } from "@app/hooks/useActiveConversationId";
 import { useActiveSpaceId } from "@app/hooks/useActiveSpaceId";
 import { useCreateConversationWithMessage } from "@app/hooks/useCreateConversationWithMessage";
 import { useSendNotification } from "@app/hooks/useNotification";
@@ -131,7 +129,6 @@ export default function SpaceConversations({
     user,
   });
   const router = useRouter();
-  const activeConversationId = useActiveConversationId();
   const spaceId = useActiveSpaceId();
   const sendNotification = useSendNotification();
   const { spaceInfo } = useSpaceInfo({
@@ -282,16 +279,6 @@ export default function SpaceConversations({
       createConversationWithMessage,
     ]
   );
-
-  if (activeConversationId) {
-    return (
-      <ConversationContainerVirtuoso
-        owner={owner}
-        subscription={subscription}
-        user={user}
-      />
-    );
-  }
 
   return (
     <div className="flex h-full w-full flex-col">


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/6029

This PR fixes back navigation from project conversations to properly redirect users to the conversation list.

- Removed conditional rendering of `ConversationContainerVirtuoso` in the space page that was preventing proper navigation

https://github.com/user-attachments/assets/0154770b-039d-4918-a927-8b3e9a160cb5


## Tests
Manually.
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
