### PR TITLE
[front] Clean up debug logs and reduce LLM timeout to 3 minutes

### DIFF
--- a/front/lib/api/llm/clients/anthropic/index.ts
+++ b/front/lib/api/llm/clients/anthropic/index.ts
@@ -24,7 +24,6 @@ import type {
   LLMStreamParameters,
 } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
-import logger from "@app/logger/logger";
 import { dustManagedCredentials } from "@app/types";
 
 export class AnthropicLLM extends LLM {
@@ -59,17 +58,6 @@ export class AnthropicLLM extends LLM {
         toMessage(msg, { isLast: index === array.length - 1 })
       );
 
-      logger.info(
-        {
-          modelId: this.modelId,
-          messageCount: messages.length,
-          toolCount: specifications.length,
-          conversationId: this.context?.conversationId,
-          traceId: this.traceId,
-        },
-        "[AGENT_LOOP_DEBUG] Anthropic internalStream creating stream"
-      );
-
       const events = this.client.beta.messages.stream({
         model: this.modelId,
         thinking: toThinkingConfig(
@@ -97,27 +85,8 @@ export class AnthropicLLM extends LLM {
         output_format: toOutputFormatParam(this.responseFormat),
       });
 
-      logger.info(
-        {
-          modelId: this.modelId,
-          conversationId: this.context?.conversationId,
-          traceId: this.traceId,
-        },
-        "[AGENT_LOOP_DEBUG] Anthropic stream object created, starting iteration"
-      );
-
       yield* streamLLMEvents(events, this.metadata);
     } catch (err) {
-      logger.error(
-        {
-          modelId: this.modelId,
-          error: err instanceof Error ? err.message : String(err),
-          errorName: err instanceof Error ? err.name : "unknown",
-          conversationId: this.context?.conversationId,
-          traceId: this.traceId,
-        },
-        "[AGENT_LOOP_DEBUG] Anthropic internalStream caught error"
-      );
       if (err instanceof APIError) {
         yield handleError(err, this.metadata);
       } else {

--- a/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
@@ -22,7 +22,6 @@ import type {
 import { EventError } from "@app/lib/api/llm/types/events";
 import type { LLMClientMetadata } from "@app/lib/api/llm/types/options";
 import { parseToolArguments } from "@app/lib/api/llm/utils/tool_arguments";
-import logger from "@app/logger/logger";
 import { assertNever } from "@app/types";
 
 export async function* streamLLMEvents(
@@ -33,32 +32,11 @@ export async function* streamLLMEvents(
   // Aggregate output items to build a SuccessCompletionEvent at the end of a turn.
   const aggregate = new SuccessAggregate();
 
-  logger.info(
-    { modelId: metadata.modelId },
-    "[AGENT_LOOP_DEBUG] streamLLMEvents starting iteration over Anthropic SDK stream"
-  );
-
-  let isFirstEvent = true;
-  const iterationStartMs = Date.now();
-
   // There is an issue in Anthropic SDK showcasing that stream events get mutated after they are yielded.
   // https://github.com/anthropics/anthropic-sdk-typescript/issues/777
   // They say it has been fixed in the version we are using but in practice we still see it happening.
   // To work around this, we clone each event before processing it.
   for await (const mutableMessageStreamEvent of messageStreamEvents) {
-    if (isFirstEvent) {
-      const elapsedMs = Date.now() - iterationStartMs;
-      logger.info(
-        {
-          modelId: metadata.modelId,
-          elapsedMs,
-          eventType: mutableMessageStreamEvent.type,
-        },
-        "[AGENT_LOOP_DEBUG] streamLLMEvents received first event from Anthropic API"
-      );
-      isFirstEvent = false;
-    }
-
     const messageStreamEvent = cloneDeep(mutableMessageStreamEvent);
 
     for (const ev of handleMessageStreamEvent(
@@ -70,11 +48,6 @@ export async function* streamLLMEvents(
       yield ev;
     }
   }
-
-  logger.info(
-    { modelId: metadata.modelId },
-    "[AGENT_LOOP_DEBUG] streamLLMEvents completed iteration"
-  );
 
   yield {
     type: "success",

--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -213,15 +213,6 @@ export abstract class LLM {
     ];
     statsDClient.increment("llm_interaction.count", 1, metricTags);
 
-    logger.info(
-      {
-        modelId: this.modelId,
-        traceId: this.traceId,
-        conversationId: this.context.conversationId,
-      },
-      "[AGENT_LOOP_DEBUG] LLM streamWithTracing starting completeStream iteration"
-    );
-
     let currentEvent: LLMEvent | null = null;
     let timeToFirstEventMs: number | undefined = undefined;
 

--- a/front/temporal/agent_loop/lib/get_output_from_llm.ts
+++ b/front/temporal/agent_loop/lib/get_output_from_llm.ts
@@ -15,7 +15,7 @@ const LLM_HEARTBEAT_INTERVAL_MS = 10_000;
 // Log heartbeat status periodically to track long-waiting LLM calls.
 const HEARTBEAT_LOG_INTERVAL = 6; // Every minute (6 * 10s)
 // Timeout for waiting on a single LLM event (first or subsequent).
-const LLM_EVENT_TIMEOUT_MINUTES = 5;
+const LLM_EVENT_TIMEOUT_MINUTES = 3;
 const LLM_EVENT_TIMEOUT_MS = LLM_EVENT_TIMEOUT_MINUTES * 60 * 1000;
 
 class LLMStreamTimeoutError extends Error {
@@ -91,19 +91,6 @@ async function* withPeriodicHeartbeat<T>(
       // Heartbeat won the race, but nextPromise is still pending
       // Continue racing with the same nextPromise
       continue;
-    }
-
-    // Log if we waited a significant time for first event.
-    if (heartbeatCount > 0) {
-      const elapsedMs = Date.now() - lastEventTimeMs;
-      logger.info(
-        {
-          ...logContext,
-          heartbeatCount,
-          elapsedMs,
-        },
-        "[AGENT_LOOP_DEBUG] LLM stream received first event after waiting"
-      );
     }
 
     // Stream value arrived


### PR DESCRIPTION
## Description
Follows https://github.com/dust-tt/dust/pull/20560 and https://github.com/dust-tt/dust/pull/20589

Remove investigative debug logs, keeping only essential ones:
- Starting LLM stream
- Heartbeat waiting
- Timeout error

Reduce `LLM_EVENT_TIMEOUT_MINUTES` from 5 to 3.

## Risks
Blast radius: Agent loop logging
Risk: none

## Deploy Plan
- pmrr
- deploy front