### PR TITLE
Add Northflank sandbox client

### DIFF
--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -379,6 +379,13 @@ const config = {
       "TEMPORAL_CONNECTORS_NAMESPACE"
     );
   },
+  // Northflank sandbox.
+  getNorthflankApiToken: () => {
+    return EnvironmentConfig.getOptionalEnvVariable("NORTHFLANK_API_TOKEN");
+  },
+  getNorthflankProjectId: () => {
+    return EnvironmentConfig.getOptionalEnvVariable("NORTHFLANK_PROJECT_ID");
+  },
 };
 
 export default config;

--- a/front/lib/api/sandbox/client.ts
+++ b/front/lib/api/sandbox/client.ts
@@ -1,0 +1,485 @@
+/**
+ * Northflank Sandbox Client
+ *
+ * Wraps the Northflank JS SDK to provide sandbox lifecycle management.
+ * Sandboxes are isolated Linux containers for executing code and commands.
+ */
+
+import {
+  ApiClient,
+  ApiClientInMemoryContextProvider,
+} from "@northflank/js-client";
+import path from "path";
+
+import apiConfig from "@app/lib/api/config";
+import { Err, Ok, Result } from "@app/types";
+import { setTimeoutAsync } from "@app/lib/utils/async_utils";
+import { streamToBuffer } from "@app/lib/utils/streams";
+import logger from "@app/logger/logger";
+
+interface SandboxConfig {
+  // Docker image for the sandbox container.
+  baseImage: string;
+  // Northflank compute plan. Affects CPU/memory and cost.
+  // See https://northflank.com/pricing
+  deploymentPlan: string;
+
+  projectId: string;
+  // Tag for spot node scheduling. Spot is cheaper but can be preempted.
+  // Set empty string to use on-demand instances.
+  spotTag: string;
+  // Timeout for sandbox to become ready. Account for cold image pulls.
+  serviceReadyTimeoutMs: number;
+  // Polling interval for readiness checks.
+  pollIntervalMs: number;
+  // Persistent volume size in MB. Minimum 4096 (4GB).
+  volumeSizeMb: number;
+  // Mount path for persistent volume inside the container.
+  volumeMountPath: string;
+}
+
+const DEFAULT_CONFIG: SandboxConfig = {
+  baseImage: "ubuntu:22.04",
+  deploymentPlan: "nf-compute-20", // Smallest plan (0.2 vCPU). Scale up if needed.
+  projectId: apiConfig.getNorthflankProjectId() ?? "dust-sandbox-dev",
+  spotTag: "spot-workload",
+  serviceReadyTimeoutMs: 12_000_000, // 3 minutes
+  pollIntervalMs: 500,
+  volumeSizeMb: 4096, // 4GB minimum
+  volumeMountPath: "/workspace",
+};
+
+export interface CommandResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+export interface SandboxInfo {
+  serviceId: string;
+  volumeId: string;
+  projectId: string;
+  createdAt: Date;
+}
+
+export interface SandboxMetadata {
+  workspaceId?: string;
+  conversationId?: string;
+  agentConfigurationId?: string;
+}
+
+export class ServiceAlreadyExistsError extends Error {
+  constructor(serviceName: string) {
+    super(`Service "${serviceName}" already exists`);
+    this.name = "ServiceAlreadyExistsError";
+  }
+}
+
+export class SandboxReadyTimeoutError extends Error {
+  constructor(serviceId: string, timeoutMs: number) {
+    super(`Sandbox "${serviceId}" did not become ready within ${timeoutMs}ms`);
+    this.name = "SandboxReadyTimeoutError";
+  }
+}
+
+export type SandboxError = ServiceAlreadyExistsError | SandboxReadyTimeoutError;
+
+export class NorthflankSandboxClient {
+  private readonly api: ApiClient;
+  private readonly sandboxConfig: SandboxConfig;
+  private serviceId: string | null = null;
+  private volumeId: string | null = null;
+  private createdAt: Date | null = null;
+
+  private constructor(api: ApiClient, config: SandboxConfig) {
+    this.api = api;
+    this.sandboxConfig = config;
+  }
+
+  /**
+   * Create a new NorthflankSandboxClient instance.
+   */
+  static async create(
+    apiToken: string,
+    configOverrides?: Partial<SandboxConfig>
+  ): Promise<NorthflankSandboxClient> {
+    const config = { ...DEFAULT_CONFIG, ...configOverrides };
+    const contextProvider = new ApiClientInMemoryContextProvider();
+    await contextProvider.addContext({
+      name: "default",
+      token: apiToken,
+    });
+    const api = new ApiClient(contextProvider);
+    return new NorthflankSandboxClient(api, config);
+  }
+
+  /**
+   * Create a new sandbox VM.
+   * @param serviceName Unique name for the service (e.g., based on conversationId)
+   * @param metadata Optional metadata tags for tracking
+   * @returns Result with SandboxInfo on success, or SandboxError on failure
+   */
+  async createSandbox(
+    serviceName: string,
+    metadata?: SandboxMetadata
+  ): Promise<Result<SandboxInfo, SandboxError>> {
+    const tags: string[] = [];
+    if (this.sandboxConfig.spotTag) {
+      tags.push(this.sandboxConfig.spotTag);
+    }
+    if (metadata?.workspaceId) {
+      tags.push(`workspace:${metadata.workspaceId}`);
+    }
+    if (metadata?.conversationId) {
+      tags.push(`conversation:${metadata.conversationId}`);
+    }
+    if (metadata?.agentConfigurationId) {
+      tags.push(`agent:${metadata.agentConfigurationId}`);
+    }
+
+    logger.info(
+      { serviceName, image: this.sandboxConfig.baseImage, tags },
+      "[sandbox] Creating service"
+    );
+
+    const serviceResponse = await this.api.create.service.deployment({
+      parameters: { projectId: this.sandboxConfig.projectId },
+      data: {
+        name: serviceName,
+        tags,
+        billing: {
+          deploymentPlan: this.sandboxConfig.deploymentPlan,
+        },
+        deployment: {
+          instances: 1,
+          external: {
+            imagePath: this.sandboxConfig.baseImage,
+          },
+          docker: {
+            configType: "customCommand",
+            customCommand: "sleep infinity",
+          },
+        },
+        runtimeEnvironment: {},
+      },
+    });
+
+    if (serviceResponse.error) {
+      // Northflank returns 400 "Service already exists" for duplicate names
+      if (
+        serviceResponse.error.status === 400 &&
+        serviceResponse.error.message === "Service already exists"
+      ) {
+        return new Err(new ServiceAlreadyExistsError(serviceName));
+      }
+      throw new Error(
+        `Failed to create sandbox: ${serviceResponse.error.message ?? "Unknown error"}`
+      );
+    }
+
+    const serviceId = serviceResponse.data.id;
+    const createdAt = new Date();
+
+    this.serviceId = serviceId;
+    this.createdAt = createdAt;
+
+    logger.info({ serviceId }, "[sandbox] Service created");
+
+    // Create and attach persistent volume
+    const volumeName = `${serviceName}-vol`;
+    logger.info(
+      { volumeName, sizeMb: this.sandboxConfig.volumeSizeMb },
+      "[sandbox] Creating volume"
+    );
+
+    const volumeResponse = await this.api.create.volume({
+      parameters: { projectId: this.sandboxConfig.projectId },
+      data: {
+        name: volumeName,
+        tags,
+        mounts: [{ containerMountPath: this.sandboxConfig.volumeMountPath }],
+        spec: {
+          accessMode: "ReadWriteOnce",
+          storageSize: this.sandboxConfig.volumeSizeMb,
+        },
+        attachedObjects: [{ id: serviceId, type: "service" }],
+      },
+    });
+
+    if (volumeResponse.error) {
+      // Clean up the service if volume creation fails
+      await this.api.delete.service({
+        parameters: {
+          projectId: this.sandboxConfig.projectId,
+          serviceId,
+        },
+      });
+      throw new Error(
+        `Failed to create volume: ${volumeResponse.error.message ?? "Unknown error"}`
+      );
+    }
+
+    const volumeId = volumeResponse.data.id;
+    this.volumeId = volumeId;
+
+    logger.info({ serviceId, volumeId }, "[sandbox] Volume created and attached");
+
+    const readyResult = await this.waitForReady();
+    if (readyResult.isErr()) {
+      return readyResult;
+    }
+
+    return new Ok({
+      serviceId,
+      volumeId,
+      projectId: this.sandboxConfig.projectId,
+      createdAt,
+    });
+  }
+
+  /**
+   * Attach to an existing sandbox.
+   * Note: projectId from info is not used - the client uses its configured projectId.
+   */
+  attach(info: SandboxInfo): void {
+    this.serviceId = info.serviceId;
+    this.volumeId = info.volumeId;
+    this.createdAt = info.createdAt;
+  }
+
+  /**
+   * Pause the sandbox. Scales to 0 instances but keeps volume intact.
+   */
+  async pause(): Promise<void> {
+    if (!this.serviceId) {
+      throw new Error("Sandbox not created or attached");
+    }
+
+    logger.info({ serviceId: this.serviceId }, "[sandbox] Pausing");
+
+    await this.api.pause.service({
+      parameters: {
+        projectId: this.sandboxConfig.projectId,
+        serviceId: this.serviceId,
+      },
+    });
+
+    logger.info({ serviceId: this.serviceId }, "[sandbox] Paused");
+  }
+
+  /**
+   * Resume a paused sandbox. Scales back to 1 instance and waits for ready.
+   */
+  async resume(): Promise<Result<void, SandboxReadyTimeoutError>> {
+    if (!this.serviceId) {
+      throw new Error("Sandbox not created or attached");
+    }
+
+    logger.info({ serviceId: this.serviceId }, "[sandbox] Resuming");
+
+    await this.api.resume.service({
+      parameters: {
+        projectId: this.sandboxConfig.projectId,
+        serviceId: this.serviceId,
+      },
+      data: {
+        instances: 1,
+      },
+    });
+
+    return this.waitForReady();
+  }
+
+  /**
+   * Wait for the service to be ready
+   */
+  private async waitForReady(): Promise<Result<void, SandboxReadyTimeoutError>> {
+    if (!this.serviceId) {
+      throw new Error("Sandbox not created");
+    }
+
+    logger.info({ serviceId: this.serviceId }, "[sandbox] Waiting for ready");
+
+    const startTime = Date.now();
+    while (Date.now() - startTime < this.sandboxConfig.serviceReadyTimeoutMs) {
+      const response = await this.api.get.service({
+        parameters: {
+          projectId: this.sandboxConfig.projectId,
+          serviceId: this.serviceId,
+        },
+      });
+
+      const status = response.data.status;
+      const deploymentStatus = status?.deployment?.status;
+
+      if (deploymentStatus === "COMPLETED") {
+        logger.info({ serviceId: this.serviceId }, "[sandbox] Service ready");
+        return new Ok(undefined);
+      }
+
+      if (deploymentStatus === "FAILED") {
+        logger.error(
+          { serviceId: this.serviceId, status },
+          "[sandbox] Deployment failed"
+        );
+        throw new Error(
+          `Sandbox deployment failed (status: ${JSON.stringify(status)})`
+        );
+      }
+
+      await setTimeoutAsync(this.sandboxConfig.pollIntervalMs);
+    }
+
+    return new Err(
+      new SandboxReadyTimeoutError(
+        this.serviceId,
+        this.sandboxConfig.serviceReadyTimeoutMs
+      )
+    );
+  }
+
+  /**
+   * Execute a command and return the result
+   */
+  async exec(command: string): Promise<CommandResult> {
+    if (!this.serviceId) {
+      throw new Error("Sandbox not created or attached");
+    }
+
+    const cmdArray = ["bash", "-c", command];
+
+    logger.info(
+      { serviceId: this.serviceId, command },
+      "[sandbox] Executing command"
+    );
+
+    const result = await this.api.exec.execServiceCommand(
+      { projectId: this.sandboxConfig.projectId, serviceId: this.serviceId },
+      {
+        command: cmdArray,
+        shell: "none",
+      }
+    );
+
+    return {
+      exitCode: result.commandResult.exitCode,
+      stdout: result.stdOut,
+      stderr: result.stdErr,
+    };
+  }
+
+  /**
+   * Write content to a file in the sandbox
+   */
+  async writeFile(remotePath: string, content: string | Buffer): Promise<void> {
+    if (!this.serviceId) {
+      throw new Error("Sandbox not created or attached");
+    }
+
+    logger.info(
+      { serviceId: this.serviceId, remotePath },
+      "[sandbox] Writing file"
+    );
+
+    const buffer = typeof content === "string" ? Buffer.from(content) : content;
+
+    // Create parent directories if needed. Skip if:
+    // - dir is empty (shouldn't happen with absolute paths)
+    // - dir is "." (file is in current directory)
+    // - dir is "/" (root always exists)
+    const dir = path.posix.dirname(remotePath);
+    if (dir && dir !== "." && dir !== "/") {
+      await this.exec(`mkdir -p "${dir}"`);
+    }
+
+    await this.api.fileCopy.uploadServiceFileStream(
+      { projectId: this.sandboxConfig.projectId, serviceId: this.serviceId },
+      {
+        source: buffer,
+        remotePath: remotePath,
+      }
+    );
+  }
+
+  /**
+   * Read a file from the sandbox
+   */
+  async readFile(remotePath: string): Promise<Buffer> {
+    if (!this.serviceId) {
+      throw new Error("Sandbox not created or attached");
+    }
+
+    logger.info(
+      { serviceId: this.serviceId, remotePath },
+      "[sandbox] Reading file"
+    );
+
+    const { fileStream } = await this.api.fileCopy.downloadServiceFileStream(
+      { projectId: this.sandboxConfig.projectId, serviceId: this.serviceId },
+      { remotePath: remotePath }
+    );
+
+    const result = await streamToBuffer(fileStream);
+    if (result.isErr()) {
+      throw new Error(result.error);
+    }
+    return result.value;
+  }
+
+  /**
+   * Destroy the sandbox and its volume
+   */
+  async destroy(): Promise<void> {
+    if (!this.serviceId) {
+      return;
+    }
+
+    logger.info(
+      { serviceId: this.serviceId, volumeId: this.volumeId },
+      "[sandbox] Destroying"
+    );
+
+    // Delete service first (detaches the volume)
+    await this.api.delete.service({
+      parameters: {
+        projectId: this.sandboxConfig.projectId,
+        serviceId: this.serviceId,
+      },
+    });
+
+    // Delete the volume
+    if (this.volumeId) {
+      await this.api.delete.volume({
+        parameters: {
+          projectId: this.sandboxConfig.projectId,
+          volumeId: this.volumeId,
+        },
+      });
+    }
+
+    logger.info(
+      { serviceId: this.serviceId, volumeId: this.volumeId },
+      "[sandbox] Destroyed"
+    );
+
+    this.serviceId = null;
+    this.volumeId = null;
+    this.createdAt = null;
+  }
+
+  getServiceId(): string | null {
+    return this.serviceId;
+  }
+
+  getInfo(): SandboxInfo | null {
+    if (!this.serviceId || !this.volumeId || !this.createdAt) {
+      return null;
+    }
+    return {
+      serviceId: this.serviceId,
+      volumeId: this.volumeId,
+      projectId: this.sandboxConfig.projectId,
+      createdAt: this.createdAt,
+    };
+  }
+}

--- a/front/lib/api/sandbox/client.ts
+++ b/front/lib/api/sandbox/client.ts
@@ -68,13 +68,6 @@ export interface SandboxMetadata {
   agentConfigurationId?: string;
 }
 
-// Map metadata keys to tag prefixes. TypeScript enforces completeness.
-const METADATA_TAG_PREFIXES: Record<keyof SandboxMetadata, string> = {
-  workspaceId: "workspace",
-  conversationId: "conversation",
-  agentConfigurationId: "agent",
-};
-
 export class ServiceAlreadyExistsError extends Error {
   constructor(serviceName: string) {
     super(`Service "${serviceName}" already exists`);
@@ -224,10 +217,9 @@ export class NorthflankSandboxClient {
       tags.push(this.config.spotTag);
     }
     if (metadata) {
-      for (const key of Object.keys(METADATA_TAG_PREFIXES) as (keyof SandboxMetadata)[]) {
-        const value = metadata[key];
+      for (const [key, value] of Object.entries(metadata)) {
         if (value) {
-          tags.push(`${METADATA_TAG_PREFIXES[key]}:${value}`);
+          tags.push(`${key}:${value}`);
         }
       }
     }

--- a/front/lib/api/sandbox/client.ts
+++ b/front/lib/api/sandbox/client.ts
@@ -99,7 +99,7 @@ export class Sandbox {
   }
 
   private get serviceParams() {
-    return { projectId: this.config.projectId, serviceId: this.info.serviceId };
+    return { projectId: this.info.projectId, serviceId: this.info.serviceId };
   }
 
   async pause(): Promise<void> {
@@ -197,12 +197,12 @@ export class Sandbox {
   }
 
   async destroy(): Promise<void> {
-    const { serviceId, volumeId } = this.info;
+    const { serviceId, volumeId, projectId } = this.info;
 
     logger.info({ serviceId, volumeId }, "[sandbox] Destroying");
 
     const serviceResponse = await this.api.delete.service({
-      parameters: { projectId: this.config.projectId, serviceId },
+      parameters: { projectId, serviceId },
     });
 
     // Treat 404 as success (already deleted).
@@ -213,7 +213,7 @@ export class Sandbox {
     }
 
     const volumeResponse = await this.api.delete.volume({
-      parameters: { projectId: this.config.projectId, volumeId },
+      parameters: { projectId, volumeId },
     });
 
     // Treat 404 as success (already deleted).
@@ -259,7 +259,7 @@ export class Sandbox {
       const { status } = response.data;
       const deploymentStatus = status?.deployment?.status;
 
-      if (deploymentStatus === "COMPLETED") {
+      if (deploymentStatus === "COMPLETED" && !response.data.servicePaused) {
         logger.info({ serviceId: this.info.serviceId }, "[sandbox] Service ready");
         return new Ok(undefined);
       }

--- a/front/lib/api/sandbox/client.ts
+++ b/front/lib/api/sandbox/client.ts
@@ -172,7 +172,10 @@ export class Sandbox {
 
     const dir = path.posix.dirname(remotePath);
     if (dir && dir !== "." && dir !== "/") {
-      await this.exec(`mkdir -p "${dir}"`);
+      await this.api.exec.execServiceCommand(this.serviceParams, {
+        command: ["mkdir", "-p", dir],
+        shell: "none",
+      });
     }
 
     await this.api.fileCopy.uploadServiceFileStream(this.serviceParams, {

--- a/front/lib/api/sandbox/client.ts
+++ b/front/lib/api/sandbox/client.ts
@@ -105,7 +105,10 @@ export class Sandbox {
 
   async pause(): Promise<void> {
     if (await this.isServicePaused()) {
-      logger.info({ serviceId: this.info.serviceId }, "[sandbox] Already paused");
+      logger.info(
+        { serviceId: this.info.serviceId },
+        "[sandbox] Already paused"
+      );
       return;
     }
 
@@ -131,7 +134,10 @@ export class Sandbox {
    */
   async resume(): Promise<Result<void, SandboxReadyTimeoutError>> {
     if (!(await this.isServicePaused())) {
-      logger.info({ serviceId: this.info.serviceId }, "[sandbox] Already running");
+      logger.info(
+        { serviceId: this.info.serviceId },
+        "[sandbox] Already running"
+      );
       return new Ok(undefined);
     }
 
@@ -152,7 +158,10 @@ export class Sandbox {
   }
 
   async exec(command: string): Promise<CommandResult> {
-    logger.info({ serviceId: this.info.serviceId, command }, "[sandbox] Executing command");
+    logger.info(
+      { serviceId: this.info.serviceId, command },
+      "[sandbox] Executing command"
+    );
 
     const result = await this.api.exec.execServiceCommand(this.serviceParams, {
       command: ["bash", "-c", command],
@@ -167,7 +176,10 @@ export class Sandbox {
   }
 
   async writeFile(remotePath: string, content: string | Buffer): Promise<void> {
-    logger.info({ serviceId: this.info.serviceId, remotePath }, "[sandbox] Writing file");
+    logger.info(
+      { serviceId: this.info.serviceId, remotePath },
+      "[sandbox] Writing file"
+    );
 
     const buffer = typeof content === "string" ? Buffer.from(content) : content;
 
@@ -186,12 +198,15 @@ export class Sandbox {
   }
 
   async readFile(remotePath: string): Promise<Buffer> {
-    logger.info({ serviceId: this.info.serviceId, remotePath }, "[sandbox] Reading file");
-
-    const { fileStream, completionPromise } = await this.api.fileCopy.downloadServiceFileStream(
-      this.serviceParams,
-      { remotePath }
+    logger.info(
+      { serviceId: this.info.serviceId, remotePath },
+      "[sandbox] Reading file"
     );
+
+    const { fileStream, completionPromise } =
+      await this.api.fileCopy.downloadServiceFileStream(this.serviceParams, {
+        remotePath,
+      });
 
     const [result, success] = await Promise.all([
       streamToBuffer(fileStream),
@@ -220,23 +235,33 @@ export class Sandbox {
     logger.info({ serviceId, volumeId }, "[sandbox] Destroyed");
   }
 
-  private async deleteServiceIfExists(projectId: string, serviceId: string): Promise<void> {
+  private async deleteServiceIfExists(
+    projectId: string,
+    serviceId: string
+  ): Promise<void> {
     const response = await this.api.delete.service({
       parameters: { projectId, serviceId },
     });
 
     if (response.error && response.error.status !== 404) {
-      throw new Error(`Failed to delete service: ${normalizeError(response.error).message}`);
+      throw new Error(
+        `Failed to delete service: ${normalizeError(response.error).message}`
+      );
     }
   }
 
-  private async deleteVolumeIfExists(projectId: string, volumeId: string): Promise<void> {
+  private async deleteVolumeIfExists(
+    projectId: string,
+    volumeId: string
+  ): Promise<void> {
     const response = await this.api.delete.volume({
       parameters: { projectId, volumeId },
     });
 
     if (response.error && response.error.status !== 404) {
-      throw new Error(`Failed to delete volume: ${normalizeError(response.error).message}`);
+      throw new Error(
+        `Failed to delete volume: ${normalizeError(response.error).message}`
+      );
     }
   }
 
@@ -256,7 +281,10 @@ export class Sandbox {
 
   /** @internal Used by factory during creation and by resume(). */
   async waitForReady(): Promise<Result<void, SandboxReadyTimeoutError>> {
-    logger.info({ serviceId: this.info.serviceId }, "[sandbox] Waiting for ready");
+    logger.info(
+      { serviceId: this.info.serviceId },
+      "[sandbox] Waiting for ready"
+    );
 
     const startTimeMs = Date.now();
     while (Date.now() - startTimeMs < this.config.serviceReadyTimeoutMs) {
@@ -274,12 +302,18 @@ export class Sandbox {
       const deploymentStatus = status?.deployment?.status;
 
       if (deploymentStatus === "COMPLETED" && !response.data.servicePaused) {
-        logger.info({ serviceId: this.info.serviceId }, "[sandbox] Service ready");
+        logger.info(
+          { serviceId: this.info.serviceId },
+          "[sandbox] Service ready"
+        );
         return new Ok(undefined);
       }
 
       if (deploymentStatus === "FAILED") {
-        logger.error({ serviceId: this.info.serviceId, status }, "[sandbox] Deployment failed");
+        logger.error(
+          { serviceId: this.info.serviceId, status },
+          "[sandbox] Deployment failed"
+        );
         throw new Error(
           `Sandbox deployment failed (status: ${JSON.stringify(status)})`
         );
@@ -289,7 +323,10 @@ export class Sandbox {
     }
 
     return new Err(
-      new SandboxReadyTimeoutError(this.info.serviceId, this.config.serviceReadyTimeoutMs)
+      new SandboxReadyTimeoutError(
+        this.info.serviceId,
+        this.config.serviceReadyTimeoutMs
+      )
     );
   }
 }
@@ -342,7 +379,10 @@ export class NorthflankSandboxClient {
         deployment: {
           instances: 1,
           external: { imagePath: this.config.baseImage },
-          docker: { configType: "customCommand", customCommand: "sleep infinity" },
+          docker: {
+            configType: "customCommand",
+            customCommand: "sleep infinity",
+          },
         },
         runtimeEnvironment: {},
       },
@@ -377,7 +417,10 @@ export class NorthflankSandboxClient {
         name: volumeName,
         tags,
         mounts: [{ containerMountPath: this.config.volumeMountPath }],
-        spec: { accessMode: "ReadWriteOnce", storageSize: this.config.volumeSizeMb },
+        spec: {
+          accessMode: "ReadWriteOnce",
+          storageSize: this.config.volumeSizeMb,
+        },
         attachedObjects: [{ id: serviceId, type: "service" }],
       },
     });
@@ -393,7 +436,10 @@ export class NorthflankSandboxClient {
 
     const volumeId = volumeResponse.data.id;
 
-    logger.info({ serviceId, volumeId }, "[sandbox] Volume created and attached");
+    logger.info(
+      { serviceId, volumeId },
+      "[sandbox] Volume created and attached"
+    );
 
     const info: SandboxInfo = {
       serviceId,

--- a/front/lib/api/sandbox/client.ts
+++ b/front/lib/api/sandbox/client.ts
@@ -279,7 +279,10 @@ export class Sandbox {
     return response.data.servicePaused;
   }
 
-  /** @internal Used by factory during creation and by resume(). */
+  /**
+   * Poll until the sandbox deployment is complete and running.
+   * Returns Err on timeout, throws on deployment failure.
+   */
   async waitForReady(): Promise<Result<void, SandboxReadyTimeoutError>> {
     logger.info(
       { serviceId: this.info.serviceId },

--- a/front/lib/api/sandbox/client.ts
+++ b/front/lib/api/sandbox/client.ts
@@ -68,6 +68,13 @@ export interface SandboxMetadata {
   agentConfigurationId?: string;
 }
 
+// Map metadata keys to tag prefixes. TypeScript enforces completeness.
+const METADATA_TAG_PREFIXES: Record<keyof SandboxMetadata, string> = {
+  workspaceId: "workspace",
+  conversationId: "conversation",
+  agentConfigurationId: "agent",
+};
+
 export class ServiceAlreadyExistsError extends Error {
   constructor(serviceName: string) {
     super(`Service "${serviceName}" already exists`);
@@ -216,14 +223,13 @@ export class NorthflankSandboxClient {
     if (this.config.spotTag) {
       tags.push(this.config.spotTag);
     }
-    if (metadata?.workspaceId) {
-      tags.push(`workspace:${metadata.workspaceId}`);
-    }
-    if (metadata?.conversationId) {
-      tags.push(`conversation:${metadata.conversationId}`);
-    }
-    if (metadata?.agentConfigurationId) {
-      tags.push(`agent:${metadata.agentConfigurationId}`);
+    if (metadata) {
+      for (const key of Object.keys(METADATA_TAG_PREFIXES) as (keyof SandboxMetadata)[]) {
+        const value = metadata[key];
+        if (value) {
+          tags.push(`${METADATA_TAG_PREFIXES[key]}:${value}`);
+        }
+      }
     }
     return tags;
   }

--- a/front/package.json
+++ b/front/package.json
@@ -60,6 +60,7 @@
     "@microsoft/microsoft-graph-client": "^3.0.7",
     "@mistralai/mistralai": "^1.10.0",
     "@modelcontextprotocol/sdk": "git://github.com:dust-tt/typescript-sdk.git#77ce858cd0dd10025a068b897dc29c2c9303fe17",
+    "@northflank/js-client": "^0.8.10",
     "@notionhq/client": "^2.3.0",
     "@novu/framework": "^2.7.1",
     "@novu/js": "^3.11.0",

--- a/knip.ts
+++ b/knip.ts
@@ -17,6 +17,7 @@ const config: KnipConfig = {
         "**/vite.config.js",
         "**/esbuild.worker.ts",
         "components/home/content/Product/BlogSection.tsx", // Temporarily disabled due to broken blog.dust.tt images
+        "lib/api/sandbox/client.ts", // Sandbox client not wired up yet
       ],
       project: ["**/*.{js,jsx,ts,tsx}"],
       ignoreDependencies: [
@@ -29,6 +30,7 @@ const config: KnipConfig = {
         "sqlite3", // used during the build process by sequelize
         "@dust-tt/client",
         "lefthook", // used as pre-commit hook
+        "@northflank/js-client", // sandbox client not wired up yet
       ],
       ignoreBinaries: ["sleep"],
       paths: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -891,6 +891,7 @@
         "@microsoft/microsoft-graph-client": "^3.0.7",
         "@mistralai/mistralai": "^1.10.0",
         "@modelcontextprotocol/sdk": "git://github.com:dust-tt/typescript-sdk.git#77ce858cd0dd10025a068b897dc29c2c9303fe17",
+        "@northflank/js-client": "^0.8.10",
         "@notionhq/client": "^2.3.0",
         "@novu/framework": "^2.7.1",
         "@novu/js": "^3.11.0",
@@ -8451,6 +8452,18 @@
         "node": ">=12"
       }
     },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -9769,6 +9782,36 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@next/bundle-analyzer/node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/@next/bundle-analyzer/node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
     "node_modules/@next/bundle-analyzer/node_modules/webpack-bundle-analyzer": {
       "version": "4.10.1",
       "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.10.1.tgz",
@@ -10024,6 +10067,113 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@northflank/js-client": {
+      "version": "0.8.10",
+      "resolved": "https://registry.npmjs.org/@northflank/js-client/-/js-client-0.8.10.tgz",
+      "integrity": "sha512-UhQWvpzlHfUQ9ZM1loFHGhUxfXnBH1JmyjZP4YYyQBZeLfZssfJGVhGky+ZofWF87fnwzTsmCMrPWe1MdLvSaw==",
+      "license": "MIT",
+      "dependencies": {
+        "bufferutil": "^4.0.9",
+        "lodash-es": "^4.17.23",
+        "node-fetch": "2.6.7",
+        "pump": "^3.0.3",
+        "tar": "^7.5.6",
+        "utf-8-validate": "^6.0.5",
+        "whatwg-url": "14.2.0",
+        "ws": "^8.18.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@northflank/js-client/node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@northflank/js-client/node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@northflank/js-client/node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@northflank/js-client/node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/@northflank/js-client/node_modules/tar": {
+      "version": "7.5.6",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.6.tgz",
+      "integrity": "sha512-xqUeu2JAIJpXyvskvU3uvQW8PAmHrtXp2KDuMJwQqW8Sqq0CaZBAQ+dKS3RBXVhU4wC5NjAdKrmh84241gO9cA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@northflank/js-client/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/@northflank/js-client/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@northflank/js-client/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@notionhq/client": {
@@ -27149,6 +27299,34 @@
         "ws": "^7.5.10"
       }
     },
+    "node_modules/botframework-streaming/node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/botframework-streaming/node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
     "node_modules/botframework-streaming/node_modules/uuid": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
@@ -27365,6 +27543,30 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "license": "MIT"
+    },
+    "node_modules/bufferutil": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.1.0.tgz",
+      "integrity": "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
+    "node_modules/bufferutil/node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
     },
     "node_modules/builtin-status-codes": {
       "version": "3.0.0",
@@ -41136,9 +41338,9 @@
       "license": "MIT"
     },
     "node_modules/lodash-es": {
-      "version": "4.17.22",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.22.tgz",
-      "integrity": "sha512-XEawp1t0gxSi9x01glktRZ5HDy0HXqrM0x5pXQM98EaI0NxO6jVM7omDOxsuEo5UIASAnm2bRp1Jt/e0a2XU8Q==",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
+      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
       "license": "MIT"
     },
     "node_modules/lodash.camelcase": {
@@ -60697,6 +60899,30 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/utf-8-validate": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-6.0.6.tgz",
+      "integrity": "sha512-q3l3P9UtEEiAHcsgsqTgf9PPjctrDWoIXW3NpOHFdRDbLvu4DLIcxHangJ4RLrWkBcKjmcs/6NkerI8T/rE4LA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
+    "node_modules/utf-8-validate/node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
     "node_modules/util": {
       "version": "0.12.5",
       "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
@@ -61522,6 +61748,36 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/webpack-bundle-analyzer/node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer/node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
     },
     "node_modules/webpack-bundle-analyzer/node_modules/ws": {
       "version": "7.5.10",


### PR DESCRIPTION
## Description

Introduce the Northflank sandbox client for managing isolated Linux containers via the Northflank API.

**Two-class design:**
- `NorthflankSandboxClient` - Factory for creating and attaching to sandboxes
- `Sandbox` - Attached instance with all operations

**Factory methods:**
- `create(apiToken, configOverrides?)` - Create a client instance
- `createSandbox(serviceName, metadata?)` - Create a new sandbox with persistent volume
- `attach(info)` - Reconnect to an existing sandbox

**Sandbox operations:**
- `exec(command)` - Run bash commands, returns stdout/stderr/exitCode
- `writeFile(path, content)` - Write files to the sandbox
- `readFile(path)` - Read files from the sandbox
- `pause()` / `resume()` - Pause/resume to save costs (idempotent)
- `destroy()` - Delete sandbox and volume (idempotent, 404 = success)

**Error handling:**
- `Result<T, SandboxError>` for recoverable errors (name collision, timeout)
- Throws for infrastructure failures (API errors, deployment failures)

**Configuration:** Compute plans, spot node scheduling, timeouts, persistent volumes.

This is the foundation for sandbox MCP server tools.

## Tests

- Type-check passes
- Manual testing against Northflank API

## Risk

**Low** - New module with no integration points yet.

## Deploy Plan

Standard deploy. Not used until sandbox MCP server tools are implemented.