### PR TITLE
Skip check for free-no-plan (random subscription id)

### DIFF
--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -993,10 +993,13 @@ export class Authenticator {
         ? await SubscriptionResource.fetchActiveByWorkspace(lightWorkspace)
         : null;
 
+    // Skip mismatch check for no-plan subscriptions: they have ephemeral random sIds
+    // that change on every fetch, so they can never match the original.
     if (
       authType.subscriptionId &&
       subscription &&
-      subscription.sId !== authType.subscriptionId
+      subscription.sId !== authType.subscriptionId &&
+      !subscription.isLegacyFreeNoPlan()
     ) {
       return new Err({ code: "subscription_mismatch" });
     }


### PR DESCRIPTION
## Description

free-no-plan (downgraded workspace) subscriptions have random id, they can't match. Skipping test in that case.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front