### PR TITLE
feat(api): allow system keys to bypass builder check in run endpoint

### DIFF
--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
@@ -549,5 +549,6 @@ async function handler(
 
 export default withPublicAPIAuthentication(
   // Check read on the workspace authenticator - for public space, everybody can read
-  withResourceFetchingFromRoute(handler, { space: { requireCanRead: true } })
+  withResourceFetchingFromRoute(handler, { space: { requireCanRead: true } }),
+  { allowSystemKeyBypassBuilderCheck: true }
 );


### PR DESCRIPTION
## Description

Add `allowSystemKeyBypassBuilderCheck` option to `withPublicAPIAuthentication` that allows system keys to bypass the `isBuilder()` check even when the `X-Dust-Role` header is set to a non-builder role.

This is needed for internal calls (e.g., from `run_dust_app` MCP server) where the role header is passed for tracking the original user's role, but the system key itself should still be trusted to execute dust apps.

**Security:** The bypass requires the system key to belong to the target workspace (`keyRes.value.workspaceId === owner.id`), preserving workspace isolation.

Changes:
- Add new `allowSystemKeyBypassBuilderCheck` option to auth wrapper options type (with JSDoc)
- Check for system key + workspace match + flag before bypassing builder check
- Enable this option on the runs endpoint

## Tests

- Type check passes
- Lint passes
- Manual testing of MCP server calls with role headers

## Risk

Low - this is an additive change that only affects system keys when explicitly opted in. The flag defaults to `false`, so existing behavior is preserved. The bypass is further constrained to require workspace ownership, preventing cross-workspace access.

## Deploy Plan

Standard deploy - no special considerations needed.