### PR TITLE
[front] Remove application-level retry from runModelActivity

### DIFF
--- a/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
+++ b/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
@@ -36,14 +36,12 @@ export type RunModelAndCreateActionsResult = {
  */
 export async function runModelAndCreateActionsActivity({
   authType,
-  autoRetryCount = 0,
   checkForResume = true,
   runAgentArgs,
   runIds,
   step,
 }: {
   authType: AuthenticatorType;
-  autoRetryCount?: number;
   checkForResume?: boolean;
   runAgentArgs: AgentLoopArgsWithTiming;
   runIds: string[];
@@ -100,7 +98,6 @@ export async function runModelAndCreateActionsActivity({
     runIds,
     step,
     functionCallStepContentIds,
-    autoRetryCount,
   });
 
   if (!modelResult) {

--- a/front/temporal/agent_loop/config.ts
+++ b/front/temporal/agent_loop/config.ts
@@ -1,3 +1,6 @@
 const QUEUE_VERSION = 2;
 
 export const QUEUE_NAME = `agent-loop-queue-v${QUEUE_VERSION}`;
+
+// Max retry attempts for the runModelAndCreateActions activity.
+export const RUN_MODEL_MAX_RETRIES = 10;

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -283,7 +283,6 @@ async function executeStepIteration({
 }> {
   const result = await runModelAndCreateActionsActivity({
     authType,
-    autoRetryCount: 0,
     checkForResume: currentStep === startStep, // Only run resume the first time.
     runAgentArgs: agentLoopArgs,
     runIds,

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -23,6 +23,7 @@ import type * as instrumentationActivities from "@app/temporal/agent_loop/activi
 import type * as publishDeferredEventsActivities from "@app/temporal/agent_loop/activities/publish_deferred_events";
 import type * as runModelAndCreateWrapperActivities from "@app/temporal/agent_loop/activities/run_model_and_create_actions_wrapper";
 import type * as runToolActivities from "@app/temporal/agent_loop/activities/run_tool";
+import { RUN_MODEL_MAX_RETRIES } from "@app/temporal/agent_loop/config";
 import { makeAgentLoopConversationTitleWorkflowId } from "@app/temporal/agent_loop/lib/workflow_ids";
 import { cancelAgentLoopSignal } from "@app/temporal/agent_loop/signals";
 import { MAX_STEPS_USE_PER_RUN_LIMIT } from "@app/types/assistant/agent";
@@ -37,8 +38,6 @@ const toolActivityStartToCloseTimeoutMs =
 
 const TOOL_ACTIVITY_HEARTBEAT_TIMEOUT_MS = 60 * 1000;
 const MODEL_ACTIVITY_HEARTBEAT_TIMEOUT_MS = 60 * 1000;
-
-const RUN_MODEL_MAX_RETRIES = 10;
 
 import {
   OpenTelemetryInboundInterceptor,


### PR DESCRIPTION
## Description
Remove the recursive retry logic (MAX_AUTO_RETRY=3) from runModelActivity. Retries are now handled entirely by Temporal's retry policy (10 attempts).

Changes:
- Remove autoRetryCount parameter from runModelActivity and runModelAndCreateActionsActivity
- Remove handlePossiblyRetryableError function and recursive retry logic
- Remove successful_auto_retry.count metric tracking
- Honor isRetryable flag: non-retryable errors (context length, auth) surface immediately to the user
- On the last Temporal retry attempt, publish error to user instead of throwing (so they see a friendly message)

Trade-off: Each Temporal retry re-runs setup (MCP tools listing, conversation rendering), but code is significantly simpler.

## Risks
Blast radius: Agent loop model execution
Risk: low

## Deploy Plan
- deploy front