### PR TITLE
Migrate more admin pages out of getServerSideProps

### DIFF
--- a/front/pages/w/[wId]/subscription/index.tsx
+++ b/front/pages/w/[wId]/subscription/index.tsx
@@ -17,20 +17,23 @@ import {
   Spinner,
 } from "@dust-tt/sparkle";
 import type * as t from "io-ts";
-import type { InferGetServerSidePropsType } from "next";
 import Link from "next/link";
 import { useRouter } from "next/router";
+import type { ReactElement } from "react";
 import React, { useEffect, useState } from "react";
 
 import { subNavigationAdmin } from "@app/components/navigation/config";
 import { SubscriptionPlanCards } from "@app/components/plans/SubscriptionPlanCards";
+import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
 import { AppCenteredLayout } from "@app/components/sparkle/AppCenteredLayout";
-import AppRootLayout from "@app/components/sparkle/AppRootLayout";
 import { useSendNotification } from "@app/hooks/useNotification";
+import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
+import { appGetServerSidePropsForAdmin } from "@app/lib/auth/appServerSideProps";
+import type { AuthContextValue } from "@app/lib/auth/AuthContext";
+import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import { getPriceAsString } from "@app/lib/client/subscription";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { clientFetch } from "@app/lib/egress/client";
-import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
 import { isUpgraded } from "@app/lib/plans/plan_codes";
 import {
   isProPlan,
@@ -48,34 +51,13 @@ import type {
   BillingPeriod,
   SubscriptionPerSeatPricing,
   SubscriptionType,
-  WorkspaceType,
 } from "@app/types";
 
-export const getServerSideProps = withDefaultUserAuthRequirements<{
-  owner: WorkspaceType;
-  subscription: SubscriptionType;
-}>(async (context, auth) => {
-  const owner = auth.workspace();
-  const subscription = auth.subscription();
-  const user = auth.user();
-  if (!owner || !auth.isAdmin() || !user || !subscription) {
-    return {
-      notFound: true,
-    };
-  }
+export const getServerSideProps = appGetServerSidePropsForAdmin;
 
-  return {
-    props: {
-      owner,
-      subscription,
-    },
-  };
-});
-
-export default function Subscription({
-  owner,
-  subscription,
-}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+function Subscription() {
+  const owner = useWorkspace();
+  const { subscription } = useAuth();
   const router = useRouter();
   const sendNotification = useSendNotification();
   const [isWebhookProcessing, setIsWebhookProcessing] =
@@ -671,6 +653,15 @@ function CancelFreeTrialDialog({
   );
 }
 
-Subscription.getLayout = (page: React.ReactElement) => {
-  return <AppRootLayout>{page}</AppRootLayout>;
+const PageWithAuthLayout = Subscription as AppPageWithLayout;
+
+PageWithAuthLayout.getLayout = (
+  page: ReactElement,
+  pageProps: AuthContextValue
+) => {
+  return (
+    <AppAuthContextLayout authContext={pageProps}>{page}</AppAuthContextLayout>
+  );
 };
+
+export default PageWithAuthLayout;

--- a/front/pages/w/[wId]/subscription/manage.tsx
+++ b/front/pages/w/[wId]/subscription/manage.tsx
@@ -1,32 +1,19 @@
 import { Spinner } from "@dust-tt/sparkle";
-import type { InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
+import type { ReactElement } from "react";
 import { useEffect } from "react";
 
+import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
+import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
+import { appGetServerSidePropsForAdmin } from "@app/lib/auth/appServerSideProps";
+import type { AuthContextValue } from "@app/lib/auth/AuthContext";
+import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
-import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
-import type { WorkspaceType } from "@app/types";
 
-export const getServerSideProps = withDefaultUserAuthRequirements<{
-  owner: WorkspaceType;
-}>(async (context, auth) => {
-  const owner = auth.workspace();
-  if (!owner || !auth.isAdmin()) {
-    return {
-      notFound: true,
-    };
-  }
+export const getServerSideProps = appGetServerSidePropsForAdmin;
 
-  return {
-    props: {
-      owner,
-    },
-  };
-});
-
-export default function ManageSubscription({
-  owner,
-}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+function ManageSubscription() {
+  const owner = useWorkspace();
   const router = useRouter();
 
   useEffect(() => {
@@ -63,3 +50,16 @@ export default function ManageSubscription({
     </div>
   );
 }
+
+const PageWithAuthLayout = ManageSubscription as AppPageWithLayout;
+
+PageWithAuthLayout.getLayout = (
+  page: ReactElement,
+  pageProps: AuthContextValue
+) => {
+  return (
+    <AppAuthContextLayout authContext={pageProps}>{page}</AppAuthContextLayout>
+  );
+};
+
+export default PageWithAuthLayout;


### PR DESCRIPTION
## Description

Migrating a couple of more admin pages. 

Biggest change is in the payment_processing page which is a transitional "Processing" screen that:
1. Shows a spinner after the user returns from Stripe checkout
2. Waits for the Stripe webhook to update the subscription in the database
3. Redirects to the conversation once the plan code matches

The Stripe check that was removed was validating that a stripeSubscriptionId stored in the DB actually exists on Stripe. This would only fail if there's a data inconsistency between your DB and Stripe (e.g., subscription deleted on Stripe but not in your system).

In practice:
- The page is only reached right after a Stripe checkout flow
- If there's a data inconsistency, showing a 404 vs a spinner doesn't help the user - they'd need support either way
- The actual payment validation happens via Stripe webhooks, not this page
- The admin auth check is still enforced

So removing it is IMHO fine. If we wanted to handle edge cases more gracefully in the future, we could add an SWR hook that validates the subscription status and shows an error message instead of an infinite spinner.


## Tests

Check modified pages are rendering. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 