### PR TITLE
[front] Fixed download link in process data

### DIFF
--- a/front/lib/api/actions/servers/extract_data/helpers.ts
+++ b/front/lib/api/actions/servers/extract_data/helpers.ts
@@ -199,7 +199,7 @@ export async function generateProcessToolOutput({
         resource: {
           mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.EXTRACT_RESULT,
           text: extractResult,
-          uri: jsonFile.getPublicUrl(auth),
+          uri: jsonFile.getPrivateUrl(auth),
           fileId: generatedFile.fileId,
           title: generatedFile.title,
           contentType: generatedFile.contentType,


### PR DESCRIPTION
## Description

In process action details, the link to download the file is using public api url (/v1) and so can't be used in the UI (which should use private)

Use private api link instead


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
deploy front
