### PR TITLE
[front,sparkle] - refacto(ButtonGroup): streamline API

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -2,6 +2,7 @@ import {
   ArrowPathIcon,
   Button,
   ButtonGroup,
+  ButtonGroupDropdown,
   Chip,
   ClipboardCheckIcon,
   ClipboardIcon,
@@ -533,36 +534,28 @@ export function AgentMessage({
     }
 
     messageButtons.push(
-      <ButtonGroup
-        key="split-button-group"
-        variant="outline"
-        items={[
-          {
-            type: "button",
-            props: {
-              tooltip: isCopied ? "Copied!" : "Copy to clipboard",
-              variant: "ghost-secondary",
-              size: "xs",
-              onClick: handleCopyToClipboard,
-              icon: isCopied ? ClipboardCheckIcon : ClipboardIcon,
-              className: "text-muted-foreground",
-            },
-          },
-          {
-            type: "dropdown",
-            triggerProps: {
-              variant: "ghost-secondary",
-              size: "xs",
-              icon: MoreIcon,
-              className: "text-muted-foreground",
-            },
-            dropdownProps: {
-              items: dropdownItems,
-              align: "end",
-            },
-          },
-        ]}
-      />
+      <ButtonGroup key="split-button-group">
+        <Button
+          tooltip={isCopied ? "Copied!" : "Copy to clipboard"}
+          variant="outline"
+          size="xs"
+          onClick={handleCopyToClipboard}
+          icon={isCopied ? ClipboardCheckIcon : ClipboardIcon}
+          className="text-muted-foreground"
+        />
+        <ButtonGroupDropdown
+          trigger={
+            <Button
+              variant="outline"
+              size="xs"
+              icon={MoreIcon}
+              className="text-muted-foreground"
+            />
+          }
+          items={dropdownItems}
+          align="end"
+        />
+      </ButtonGroup>
     );
   } else {
     if (shouldShowCopy) {

--- a/front/components/assistant/conversation/FeedbackSelector.tsx
+++ b/front/components/assistant/conversation/FeedbackSelector.tsx
@@ -125,38 +125,26 @@ export function FeedbackSelector({
 
   return (
     <div className="flex items-center">
-      <ButtonGroup
-        variant="outline"
-        items={[
-          {
-            type: "button",
-            props: {
-              tooltip: "I found this helpful",
-              variant: feedback?.thumb === "up" ? "primary" : "ghost-secondary",
-              size: "xs",
-              disabled: isSubmittingThumb,
-              onClick: () => handleThumbClick("up"),
-              icon: HandThumbUpIcon,
-              className:
-                feedback?.thumb === "up" ? "" : "text-muted-foreground",
-            },
-          },
-          {
-            type: "button",
-            props: {
-              tooltip: "Report an issue with this answer",
-              variant:
-                feedback?.thumb === "down" ? "primary" : "ghost-secondary",
-              size: "xs",
-              disabled: isSubmittingThumb,
-              onClick: () => handleThumbClick("down"),
-              icon: HandThumbDownIcon,
-              className:
-                feedback?.thumb === "down" ? "" : "text-muted-foreground",
-            },
-          },
-        ]}
-      />
+      <ButtonGroup>
+        <Button
+          tooltip="I found this helpful"
+          variant={feedback?.thumb === "up" ? "primary" : "outline"}
+          size="xs"
+          disabled={isSubmittingThumb}
+          onClick={() => handleThumbClick("up")}
+          icon={HandThumbUpIcon}
+          className={feedback?.thumb === "up" ? "" : "text-muted-foreground"}
+        />
+        <Button
+          tooltip="Report an issue with this answer"
+          variant={feedback?.thumb === "down" ? "primary" : "outline"}
+          size="xs"
+          disabled={isSubmittingThumb}
+          onClick={() => handleThumbClick("down")}
+          icon={HandThumbDownIcon}
+          className={feedback?.thumb === "down" ? "" : "text-muted-foreground"}
+        />
+      </ButtonGroup>
 
       <Dialog
         open={isDialogOpen}

--- a/sparkle/src/components/ButtonGroup.tsx
+++ b/sparkle/src/components/ButtonGroup.tsx
@@ -3,8 +3,6 @@ import * as React from "react";
 
 import { cn } from "@sparkle/lib/utils";
 
-import type { ButtonProps, ButtonSizeType, ButtonVariantType } from "./Button";
-import { Button } from "./Button";
 import type { DropdownMenuItemProps } from "./Dropdown";
 import {
   DropdownMenu,
@@ -13,232 +11,95 @@ import {
   DropdownMenuTrigger,
 } from "./Dropdown";
 
-type ButtonGroupButtonItem = {
-  type: "button";
-  props: ButtonProps;
-};
-
-type ButtonGroupDropdownItem = {
-  type: "dropdown";
-  triggerProps: Omit<ButtonProps, "onClick">;
-  dropdownProps: {
-    items: DropdownMenuItemProps[];
-    align?: "start" | "center" | "end";
-  };
-};
-
-export type ButtonGroupItem = ButtonGroupButtonItem | ButtonGroupDropdownItem;
-
-type DisallowedButtonGroupVariant =
-  | "ghost"
-  | "ghost-secondary"
-  | "highlight"
-  | "warning";
-
-export type ButtonGroupVariantType = Exclude<
-  ButtonVariantType,
-  DisallowedButtonGroupVariant
->;
-
-const DISALLOWED_VARIANTS = new Set<ButtonVariantType>([
-  "ghost",
-  "ghost-secondary",
-  "highlight",
-  "warning",
-]);
-
-const sanitizeVariant = (
-  variant?: ButtonVariantType | null
-): ButtonGroupVariantType => {
-  if (!variant) {
-    return "outline";
-  }
-  if (DISALLOWED_VARIANTS.has(variant)) {
-    if (
-      process.env.NODE_ENV !== "production" &&
-      typeof console !== "undefined"
-    ) {
-      console.warn(
-        `[ButtonGroup] Variant "${variant}" is not allowed. Falling back to "outline".`
-      );
-    }
-    return "outline";
-  }
-  return variant as ButtonGroupVariantType;
-};
-
-const buttonGroupVariants = cva("s-inline-flex", {
+const buttonGroupVariants = cva("s-inline-flex s-w-fit s-items-stretch", {
   variants: {
     orientation: {
       horizontal: "s-flex-row",
       vertical: "s-flex-col",
     },
+    removeGaps: {
+      true: "",
+      false: "s-gap-2",
+    },
   },
+  compoundVariants: [
+    {
+      orientation: "horizontal",
+      removeGaps: true,
+      className: cn(
+        "s-gap-0",
+        "[&>*:not(:first-child)]:!s-rounded-l-none",
+        "[&>*:not(:first-child)]:s-border-l-0",
+        "[&>*:not(:last-child)]:!s-rounded-r-none"
+      ),
+    },
+    {
+      orientation: "vertical",
+      removeGaps: true,
+      className: cn(
+        "s-gap-0",
+        "[&>*:not(:first-child)]:!s-rounded-t-none",
+        "[&>*:not(:first-child)]:s-border-t-0",
+        "[&>*:not(:last-child)]:!s-rounded-b-none"
+      ),
+    },
+  ],
   defaultVariants: {
     orientation: "horizontal",
+    removeGaps: true,
   },
 });
 
 export interface ButtonGroupProps
   extends
-    Omit<React.HTMLAttributes<HTMLDivElement>, "children">,
+    React.HTMLAttributes<HTMLDivElement>,
     VariantProps<typeof buttonGroupVariants> {
-  /**
-   * Array of button or dropdown items to render in the group.
-   */
-  items: ButtonGroupItem[];
-  /**
-   * Variant to apply to all buttons in the group.
-   */
-  variant?: ButtonGroupVariantType;
-  /**
-   * Size to apply to all buttons in the group. Mini buttons must opt-in per item.
-   */
-  size?: Exclude<ButtonSizeType, "mini">;
-  /**
-   * Whether every button should be disabled.
-   */
   disabled?: boolean;
-  /**
-   * Remove gaps and merge borders (segmented-control look).
-   */
-  removeGaps?: boolean;
 }
 
 const ButtonGroup = React.forwardRef<HTMLDivElement, ButtonGroupProps>(
   (
-    {
-      className,
-      orientation = "horizontal",
-      variant,
-      size,
-      disabled,
-      removeGaps = true,
-      items,
-      ...props
-    },
+    { className, orientation = "horizontal", removeGaps = true, ...props },
     ref
   ) => {
-    if (!items || items.length === 0) {
-      return null;
-    }
-
-    const totalItems = items.length;
-
-    const renderedItems = items.map((item, index) => {
-      const isFirst = index === 0;
-      const isLast = index === totalItems - 1;
-
-      const borderRadiusClasses = (() => {
-        if (!removeGaps || totalItems === 1) {
-          return "";
-        }
-
-        if (orientation === "horizontal") {
-          if (isFirst) {
-            return "!s-rounded-r-none";
-          }
-          if (isLast) {
-            return "!s-rounded-l-none";
-          }
-          return "!s-rounded-none";
-        }
-
-        if (isFirst) {
-          return "!s-rounded-b-none";
-        }
-        if (isLast) {
-          return "!s-rounded-t-none";
-        }
-        return "!s-rounded-none";
-      })();
-
-      const borderClasses = (() => {
-        if (!removeGaps) {
-          return "";
-        }
-
-        if (orientation === "horizontal") {
-          return isLast ? "" : "s-border-r-0";
-        }
-
-        return isLast ? "" : "s-border-b-0";
-      })();
-
-      if (item.type === "button") {
-        const nextVariant = sanitizeVariant(variant ?? item.props.variant);
-        const rawSize = size ?? item.props.size;
-        const nextSize: Exclude<ButtonSizeType, "mini"> | undefined =
-          rawSize === "mini"
-            ? undefined
-            : (rawSize as Exclude<ButtonSizeType, "mini"> | undefined);
-
-        return (
-          <Button
-            key={index}
-            {...item.props}
-            variant={nextVariant}
-            size={nextSize}
-            disabled={disabled ?? item.props.disabled}
-            isRounded={false}
-            className={cn(
-              item.props.className,
-              borderRadiusClasses,
-              borderClasses
-            )}
-          />
-        );
-      }
-
-      const nextVariant = sanitizeVariant(variant ?? item.triggerProps.variant);
-      const rawSize = size ?? item.triggerProps.size;
-      const nextSize: Exclude<ButtonSizeType, "mini"> | undefined =
-        rawSize === "mini"
-          ? undefined
-          : (rawSize as Exclude<ButtonSizeType, "mini"> | undefined);
-
-      return (
-        <DropdownMenu key={index}>
-          <DropdownMenuTrigger asChild>
-            <Button
-              {...item.triggerProps}
-              variant={nextVariant}
-              size={nextSize}
-              disabled={disabled ?? item.triggerProps.disabled}
-              isRounded={false}
-              className={cn(
-                item.triggerProps.className,
-                borderRadiusClasses,
-                borderClasses
-              )}
-            />
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align={item.dropdownProps.align ?? "center"}>
-            {item.dropdownProps.items.map((dropdownItem, dropdownIndex) => (
-              <DropdownMenuItem key={dropdownIndex} {...dropdownItem} />
-            ))}
-          </DropdownMenuContent>
-        </DropdownMenu>
-      );
-    });
-
     return (
       <div
         ref={ref}
+        role="group"
+        data-orientation={orientation}
         className={cn(
-          buttonGroupVariants({ orientation }),
-          removeGaps ? "s-gap-0" : "s-gap-2",
+          buttonGroupVariants({ orientation, removeGaps }),
           className
         )}
-        role="group"
         {...props}
-      >
-        {renderedItems}
-      </div>
+      />
     );
   }
 );
 
 ButtonGroup.displayName = "ButtonGroup";
 
-export { ButtonGroup, buttonGroupVariants };
+interface ButtonGroupDropdownProps {
+  trigger: React.ReactElement;
+  items: DropdownMenuItemProps[];
+  align?: "start" | "center" | "end";
+}
+
+function ButtonGroupDropdown({
+  trigger,
+  items,
+  align = "center",
+}: ButtonGroupDropdownProps) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>{trigger}</DropdownMenuTrigger>
+      <DropdownMenuContent align={align}>
+        {items.map((item, index) => (
+          <DropdownMenuItem key={index} {...item} />
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+export { ButtonGroup, ButtonGroupDropdown, buttonGroupVariants };

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -17,8 +17,8 @@ export type {
   RegularButtonProps,
 } from "./Button";
 export { Button } from "./Button";
-export type { ButtonGroupItem, ButtonGroupProps } from "./ButtonGroup";
-export { ButtonGroup } from "./ButtonGroup";
+export type { ButtonGroupProps } from "./ButtonGroup";
+export { ButtonGroup, ButtonGroupDropdown } from "./ButtonGroup";
 export { ButtonsSwitch, ButtonsSwitchList } from "./ButtonsSwitch";
 export type { CardProps } from "./Card";
 export { Card, CardActionButton, CardGrid } from "./Card";

--- a/sparkle/src/stories/ButtonGroup.stories.tsx
+++ b/sparkle/src/stories/ButtonGroup.stories.tsx
@@ -2,18 +2,16 @@ import type { Meta, StoryObj } from "@storybook/react";
 import React from "react";
 
 import {
-  BUTTON_SIZES,
   BUTTON_VARIANTS,
+  type ButtonSizeType,
   type ButtonVariantType,
 } from "@sparkle/components/Button";
-import type {
-  ButtonGroupItem,
-  ButtonGroupVariantType,
-} from "@sparkle/components/ButtonGroup";
 
 import {
   ArrowPathIcon,
+  Button,
   ButtonGroup,
+  ButtonGroupDropdown,
   ChevronDownIcon,
   ClipboardIcon,
   PlusIcon,
@@ -22,38 +20,28 @@ import {
   TrashIcon,
 } from "../index_with_tw_base";
 
-const DEFAULT_ITEMS: ButtonGroupItem[] = [
-  { type: "button", props: { label: "First" } },
-  { type: "button", props: { label: "Second" } },
-  { type: "button", props: { label: "Third" } },
-];
+// Exclude "mini" since these items have labels (mini buttons can't have labels)
+type LabelButtonSizeType = Exclude<ButtonSizeType, "mini">;
 
-const DISALLOWED_GROUP_VARIANTS: ButtonVariantType[] = [
-  "ghost",
-  "ghost-secondary",
-  "highlight",
-  "warning",
-];
-
-const BUTTON_GROUP_VARIANTS = BUTTON_VARIANTS.filter(
-  (variant) => !DISALLOWED_GROUP_VARIANTS.includes(variant)
-) as ButtonGroupVariantType[];
+const DefaultButtons = ({
+  variant = "outline",
+  size = "sm",
+}: {
+  variant?: ButtonVariantType;
+  size?: LabelButtonSizeType;
+}) => (
+  <>
+    <Button label="First" variant={variant} size={size} />
+    <Button label="Second" variant={variant} size={size} />
+    <Button label="Third" variant={variant} size={size} />
+  </>
+);
 
 const meta = {
   title: "Primitives/ButtonGroup",
   component: ButtonGroup,
   tags: ["autodocs"],
   argTypes: {
-    variant: {
-      description: "Variant applied to every button",
-      control: { type: "select" },
-      options: BUTTON_GROUP_VARIANTS,
-    },
-    size: {
-      description: "Size applied to every button",
-      control: { type: "select" },
-      options: BUTTON_SIZES.filter((size) => size !== "mini"),
-    },
     orientation: {
       description: "Stack buttons horizontally or vertically",
       control: { type: "select" },
@@ -67,19 +55,16 @@ const meta = {
       description: "Remove gaps and merge button borders",
       control: "boolean",
     },
-    items: {
+    children: {
       table: { disable: true },
     },
   },
   args: {
-    items: DEFAULT_ITEMS,
-    variant: "outline",
-    size: "sm",
+    children: <DefaultButtons />,
     orientation: "horizontal",
     disabled: false,
     removeGaps: true,
   },
-  render: (args) => <ButtonGroup {...args} />,
 } satisfies Meta<typeof ButtonGroup>;
 
 export default meta;
@@ -90,78 +75,89 @@ export const Playground: Story = {};
 
 export const WithIcons: Story = {
   args: {
-    items: [
-      { type: "button", props: { icon: PlusIcon, label: "Add" } },
-      { type: "button", props: { icon: RobotIcon, label: "Agent" } },
-      { type: "button", props: { label: "More" } },
-    ],
+    children: (
+      <>
+        <Button icon={PlusIcon} label="Add" variant="outline" size="sm" />
+        <Button icon={RobotIcon} label="Agent" variant="outline" size="sm" />
+        <Button label="More" variant="outline" size="sm" />
+      </>
+    ),
   },
 };
 
 export const WithCounters: Story = {
   args: {
-    items: [
-      {
-        type: "button",
-        props: { label: "Inbox", isCounter: true, counterValue: "5" },
-      },
-      {
-        type: "button",
-        props: { label: "Sent", isCounter: true, counterValue: "12" },
-      },
-      {
-        type: "button",
-        props: { label: "Drafts", isCounter: true, counterValue: "3" },
-      },
-    ],
+    children: (
+      <>
+        <Button
+          label="Inbox"
+          isCounter
+          counterValue="5"
+          variant="outline"
+          size="sm"
+        />
+        <Button
+          label="Sent"
+          isCounter
+          counterValue="12"
+          variant="outline"
+          size="sm"
+        />
+        <Button
+          label="Drafts"
+          isCounter
+          counterValue="3"
+          variant="outline"
+          size="sm"
+        />
+      </>
+    ),
   },
 };
 
 export const Vertical: Story = {
   args: {
     orientation: "vertical",
+    children: <DefaultButtons />,
   },
 };
 
 export const Disabled: Story = {
   args: {
     disabled: true,
+    children: <DefaultButtons />,
   },
 };
 
 export const WithGaps: Story = {
   args: {
     removeGaps: false,
+    children: <DefaultButtons />,
   },
 };
 
-const VARIANT_ITEMS: ButtonGroupItem[] = [
-  { type: "button", props: { label: "One" } },
-  { type: "button", props: { label: "Two" } },
-  { type: "button", props: { label: "Three" } },
-];
-
-const ButtonGroupByVariant = ({
-  variant,
-}: {
-  variant: ButtonGroupVariantType;
-}) => (
+const ButtonGroupByVariant = ({ variant }: { variant: ButtonVariantType }) => (
   <>
     <Separator />
     <h3 className="s-text-primary dark:s-text-primary-50">{variant}</h3>
     <div className="s-flex s-items-center s-gap-4">
-      <ButtonGroup variant={variant} size="xs" items={VARIANT_ITEMS} />
-      <ButtonGroup variant={variant} size="sm" items={VARIANT_ITEMS} />
-      <ButtonGroup variant={variant} size="md" items={VARIANT_ITEMS} />
+      <ButtonGroup>
+        <DefaultButtons variant={variant} size="xs" />
+      </ButtonGroup>
+      <ButtonGroup>
+        <DefaultButtons variant={variant} size="sm" />
+      </ButtonGroup>
+      <ButtonGroup>
+        <DefaultButtons variant={variant} size="md" />
+      </ButtonGroup>
     </div>
   </>
 );
 
 export const Gallery: Story = {
-  args: meta.args,
   render: () => (
     <div className="s-flex s-flex-col s-gap-4">
-      {BUTTON_GROUP_VARIANTS.map((variant) => (
+      {BUTTON_VARIANTS.map((variant) => (
         <ButtonGroupByVariant key={variant} variant={variant} />
       ))}
     </div>
@@ -175,97 +171,70 @@ export const WithDropdownMenu: Story = {
         <h3 className="s-mb-2 s-text-sm s-font-medium">
           Split button with dropdown
         </h3>
-        <ButtonGroup
-          variant="outline"
-          items={[
-            {
-              type: "button",
-              props: {
-                icon: ClipboardIcon,
-                tooltip: "Copy to clipboard",
-                variant: "ghost-secondary",
-                size: "xs",
-              },
-            },
-            {
-              type: "dropdown",
-              triggerProps: {
-                variant: "ghost-secondary",
-                size: "xs",
-                icon: ChevronDownIcon,
-              },
-              dropdownProps: {
-                items: [
-                  { label: "Retry", icon: ArrowPathIcon },
-                  { label: "Delete", icon: TrashIcon, variant: "warning" },
-                ],
-              },
-            },
-          ]}
-        />
+        <ButtonGroup>
+          <Button
+            icon={ClipboardIcon}
+            tooltip="Copy to clipboard"
+            variant="outline"
+            size="xs"
+          />
+          <ButtonGroupDropdown
+            trigger={
+              <Button variant="outline" size="xs" icon={ChevronDownIcon} />
+            }
+            items={[
+              { label: "Retry", icon: ArrowPathIcon },
+              { label: "Delete", icon: TrashIcon, variant: "warning" },
+            ]}
+          />
+        </ButtonGroup>
       </div>
 
       <div>
         <h3 className="s-mb-2 s-text-sm s-font-medium">Multiple variations</h3>
         <div className="s-flex s-flex-wrap s-gap-4">
-          <ButtonGroup
-            variant="outline"
-            items={[
-              { type: "button", props: { label: "Copy", size: "sm" } },
-              {
-                type: "dropdown",
-                triggerProps: { size: "sm", icon: ChevronDownIcon },
-                dropdownProps: {
-                  items: [
-                    { label: "Option 1" },
-                    { label: "Option 2" },
-                    { label: "Option 3" },
-                  ],
-                },
-              },
-            ]}
-          />
+          <ButtonGroup>
+            <Button label="Copy" variant="outline" size="sm" />
+            <ButtonGroupDropdown
+              trigger={
+                <Button variant="outline" size="sm" icon={ChevronDownIcon} />
+              }
+              items={[
+                { label: "Option 1" },
+                { label: "Option 2" },
+                { label: "Option 3" },
+              ]}
+            />
+          </ButtonGroup>
 
-          <ButtonGroup
-            variant="primary"
-            items={[
-              { type: "button", props: { label: "Save", size: "sm" } },
-              {
-                type: "dropdown",
-                triggerProps: { size: "sm", icon: ChevronDownIcon },
-                dropdownProps: {
-                  items: [
-                    { label: "Save and close" },
-                    { label: "Save as draft" },
-                  ],
-                },
-              },
-            ]}
-          />
+          <ButtonGroup>
+            <Button label="Save" variant="primary" size="sm" />
+            <ButtonGroupDropdown
+              trigger={
+                <Button variant="primary" size="sm" icon={ChevronDownIcon} />
+              }
+              items={[{ label: "Save and close" }, { label: "Save as draft" }]}
+            />
+          </ButtonGroup>
 
-          <ButtonGroup
-            variant="outline"
-            items={[
-              {
-                type: "button",
-                props: { icon: PlusIcon, label: "Add", size: "sm" },
-              },
-              {
-                type: "button",
-                props: { icon: RobotIcon, label: "Agent", size: "sm" },
-              },
-              {
-                type: "dropdown",
-                triggerProps: { size: "sm", icon: ChevronDownIcon },
-                dropdownProps: {
-                  items: [
-                    { label: "More options", icon: PlusIcon },
-                    { label: "Settings" },
-                  ],
-                },
-              },
-            ]}
-          />
+          <ButtonGroup>
+            <Button icon={PlusIcon} label="Add" variant="outline" size="sm" />
+            <Button
+              icon={RobotIcon}
+              label="Agent"
+              variant="outline"
+              size="sm"
+            />
+            <ButtonGroupDropdown
+              trigger={
+                <Button variant="outline" size="sm" icon={ChevronDownIcon} />
+              }
+              items={[
+                { label: "More options", icon: PlusIcon },
+                { label: "Settings" },
+              ]}
+            />
+          </ButtonGroup>
         </div>
       </div>
     </div>

--- a/sparkle/src/styles/allotment.css
+++ b/sparkle/src/styles/allotment.css
@@ -17,28 +17,37 @@
   width: 100%;
 }
 
-.allotment-module_splitView__L-yRc > .allotment-module_sashContainer__fzwJF > .allotment-module_sash__QA-2t {
+.allotment-module_splitView__L-yRc
+  > .allotment-module_sashContainer__fzwJF
+  > .allotment-module_sash__QA-2t {
   pointer-events: auto;
 }
 
-.allotment-module_splitView__L-yRc > .allotment-module_splitViewContainer__rQnVa {
+.allotment-module_splitView__L-yRc
+  > .allotment-module_splitViewContainer__rQnVa {
   height: 100%;
   position: relative;
   white-space: nowrap;
   width: 100%;
 }
 
-.allotment-module_splitView__L-yRc > .allotment-module_splitViewContainer__rQnVa > .allotment-module_splitViewView__MGZ6O {
+.allotment-module_splitView__L-yRc
+  > .allotment-module_splitViewContainer__rQnVa
+  > .allotment-module_splitViewView__MGZ6O {
   overflow: hidden;
   position: absolute;
   white-space: initial;
 }
 
-.allotment-module_splitView__L-yRc.allotment-module_vertical__WSwwa > .allotment-module_splitViewContainer__rQnVa > .allotment-module_splitViewView__MGZ6O {
+.allotment-module_splitView__L-yRc.allotment-module_vertical__WSwwa
+  > .allotment-module_splitViewContainer__rQnVa
+  > .allotment-module_splitViewView__MGZ6O {
   width: 100%;
 }
 
-.allotment-module_splitView__L-yRc.allotment-module_horizontal__7doS8 > .allotment-module_splitViewContainer__rQnVa > .allotment-module_splitViewView__MGZ6O {
+.allotment-module_splitView__L-yRc.allotment-module_horizontal__7doS8
+  > .allotment-module_splitViewContainer__rQnVa
+  > .allotment-module_splitViewView__MGZ6O {
   height: 100%;
 }
 
@@ -129,7 +138,8 @@
   height: var(--sash-size);
 }
 
-.sash-module_sash__K-9lB:not(.sash-module_disabled__Hm-wx) > .sash-module_orthogonal-drag-handle__Yii2- {
+.sash-module_sash__K-9lB:not(.sash-module_disabled__Hm-wx)
+  > .sash-module_orthogonal-drag-handle__Yii2- {
   content: " ";
   height: calc(var(--sash-size) * 2);
   width: calc(var(--sash-size) * 2);
@@ -139,36 +149,48 @@
   position: absolute;
 }
 
-.sash-module_sash__K-9lB.sash-module_horizontal__kFbiw.sash-module_orthogonal-edge-north__f7Noe:not(.sash-module_disabled__Hm-wx)
+.sash-module_sash__K-9lB.sash-module_horizontal__kFbiw.sash-module_orthogonal-edge-north__f7Noe:not(
+    .sash-module_disabled__Hm-wx
+  )
   > .sash-module_orthogonal-drag-handle__Yii2-.sash-module_start__uZEDk,
-.sash-module_sash__K-9lB.sash-module_horizontal__kFbiw.sash-module_orthogonal-edge-south__6ZrFC:not(.sash-module_disabled__Hm-wx)
+.sash-module_sash__K-9lB.sash-module_horizontal__kFbiw.sash-module_orthogonal-edge-south__6ZrFC:not(
+    .sash-module_disabled__Hm-wx
+  )
   > .sash-module_orthogonal-drag-handle__Yii2-.sash-module_end__0TP-R {
   cursor: nwse-resize;
 }
 
-.sash-module_sash__K-9lB.sash-module_horizontal__kFbiw.sash-module_orthogonal-edge-north__f7Noe:not(.sash-module_disabled__Hm-wx)
+.sash-module_sash__K-9lB.sash-module_horizontal__kFbiw.sash-module_orthogonal-edge-north__f7Noe:not(
+    .sash-module_disabled__Hm-wx
+  )
   > .sash-module_orthogonal-drag-handle__Yii2-.sash-module_end__0TP-R,
-.sash-module_sash__K-9lB.sash-module_horizontal__kFbiw.sash-module_orthogonal-edge-south__6ZrFC:not(.sash-module_disabled__Hm-wx)
+.sash-module_sash__K-9lB.sash-module_horizontal__kFbiw.sash-module_orthogonal-edge-south__6ZrFC:not(
+    .sash-module_disabled__Hm-wx
+  )
   > .sash-module_orthogonal-drag-handle__Yii2-.sash-module_start__uZEDk {
   cursor: nesw-resize;
 }
 
-.sash-module_sash__K-9lB.sash-module_vertical__pB-rs > .sash-module_orthogonal-drag-handle__Yii2-.sash-module_start__uZEDk {
+.sash-module_sash__K-9lB.sash-module_vertical__pB-rs
+  > .sash-module_orthogonal-drag-handle__Yii2-.sash-module_start__uZEDk {
   left: calc(var(--sash-size) * -0.5);
   top: calc(var(--sash-size) * -1);
 }
 
-.sash-module_sash__K-9lB.sash-module_vertical__pB-rs > .sash-module_orthogonal-drag-handle__Yii2-.sash-module_end__0TP-R {
+.sash-module_sash__K-9lB.sash-module_vertical__pB-rs
+  > .sash-module_orthogonal-drag-handle__Yii2-.sash-module_end__0TP-R {
   left: calc(var(--sash-size) * -0.5);
   bottom: calc(var(--sash-size) * -1);
 }
 
-.sash-module_sash__K-9lB.sash-module_horizontal__kFbiw > .sash-module_orthogonal-drag-handle__Yii2-.sash-module_start__uZEDk {
+.sash-module_sash__K-9lB.sash-module_horizontal__kFbiw
+  > .sash-module_orthogonal-drag-handle__Yii2-.sash-module_start__uZEDk {
   top: calc(var(--sash-size) * -0.5);
   left: calc(var(--sash-size) * -1);
 }
 
-.sash-module_sash__K-9lB.sash-module_horizontal__kFbiw > .sash-module_orthogonal-drag-handle__Yii2-.sash-module_end__0TP-R {
+.sash-module_sash__K-9lB.sash-module_horizontal__kFbiw
+  > .sash-module_orthogonal-drag-handle__Yii2-.sash-module_end__0TP-R {
   top: calc(var(--sash-size) * -0.5);
   right: calc(var(--sash-size) * -1);
 }


### PR DESCRIPTION
## Description

This PR refactors the `ButtonGroup` component to simplify its API by moving from an items array-based rendering pattern to a composition-based approach. The component now acts as a layout container that accepts `Button` and `ButtonGroupDropdown` components as children, eliminating the complex `ButtonGroupItem` types and internal rendering logic. It follows shadcn API

## Risk

Medium - this is a breaking API change that affects existing usages

## Tests

Storybook

## Deploy Plan

Deploy front
