### PR TITLE
[front] - feat(obs): remove analytics FF

### DIFF
--- a/front/components/observability/AgentObservability.tsx
+++ b/front/components/observability/AgentObservability.tsx
@@ -12,6 +12,13 @@ import {
 import dynamic from "next/dynamic";
 
 import { useObservabilityContext } from "@app/components/agent_builder/observability/ObservabilityContext";
+import { TabContentChildSectionLayout } from "@app/components/agent_builder/observability/TabContentChildSectionLayout";
+import { TabContentLayout } from "@app/components/agent_builder/observability/TabContentLayout";
+import { SharedObservabilityFilterSelector } from "@app/components/observability/SharedObservabilityFilterSelector";
+import {
+  useAgentAnalytics,
+  useAgentObservabilitySummary,
+} from "@app/lib/swr/assistants";
 
 // Dynamic imports for chart components to exclude recharts from server bundle
 const DatasourceRetrievalTreemapChart = dynamic(
@@ -49,14 +56,6 @@ const UsageMetricsChart = dynamic(
     ),
   { ssr: false }
 );
-import { TabContentChildSectionLayout } from "@app/components/agent_builder/observability/TabContentChildSectionLayout";
-import { TabContentLayout } from "@app/components/agent_builder/observability/TabContentLayout";
-import { SharedObservabilityFilterSelector } from "@app/components/observability/SharedObservabilityFilterSelector";
-import {
-  useAgentAnalytics,
-  useAgentObservabilitySummary,
-} from "@app/lib/swr/assistants";
-import { useFeatureFlags } from "@app/lib/swr/workspaces";
 
 interface AgentObservabilityProps {
   workspaceId: string;
@@ -70,7 +69,6 @@ export function AgentObservability({
   isCustomAgent,
 }: AgentObservabilityProps) {
   const { period, mode, selectedVersion } = useObservabilityContext();
-  const { featureFlags } = useFeatureFlags({ workspaceId });
 
   const isTimeRangeMode = mode === "timeRange";
 
@@ -231,16 +229,12 @@ export function AgentObservability({
           agentConfigurationId={agentConfigurationId}
           isCustomAgent={isCustomAgent}
         />
-        {featureFlags.includes("agent_tool_outputs_analytics") && (
-          <>
-            <Separator />
-            <DatasourceRetrievalTreemapChart
-              workspaceId={workspaceId}
-              agentConfigurationId={agentConfigurationId}
-              isCustomAgent={isCustomAgent}
-            />
-          </>
-        )}
+        <Separator />
+        <DatasourceRetrievalTreemapChart
+          workspaceId={workspaceId}
+          agentConfigurationId={agentConfigurationId}
+          isCustomAgent={isCustomAgent}
+        />
         <Separator />
         <ToolUsageChart
           workspaceId={workspaceId}

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -30,11 +30,6 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Export and Import agents to/from YAML format",
     stage: "dust_only",
   },
-  agent_tool_outputs_analytics: {
-    description:
-      "Store agent tool outputs (e.g., retrieved documents) in Elasticsearch for analytics",
-    stage: "dust_only",
-  },
   agent_builder_copilot: {
     description: "Enable Copilot in Agent Builder",
     stage: "dust_only",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -646,7 +646,6 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "agent_builder_copilot"
   | "agent_management_tool"
   | "agent_to_yaml"
-  | "agent_tool_outputs_analytics"
   | "anthropic_vertex_fallback"
   | "ashby_tool"
   | "claude_4_5_opus_feature"


### PR DESCRIPTION
## Description

Removes the `agent_tool_outputs_analytics` feature flag, permanently enabling the DatasourceRetrievalTreemapChart in the observability dashboard. This chart shows document retrieval patterns by datasource and was previously gated behind the feature flag while being tested
## Risk

Low

## Tests

The feature has been tested locally and on front-edge behind the feature flag

## Deploy Plan

Deploy front
