### PR TITLE
[Connectors/Microsoft] Fix stack overflow on partial drive delta syncs

### DIFF
--- a/connectors/src/connectors/microsoft/temporal/activities.ts
+++ b/connectors/src/connectors/microsoft/temporal/activities.ts
@@ -891,11 +891,15 @@ export async function syncDeltaForRootNodesInDrive({
     const validMicrosoftNodes = microsoftNodes.filter(
       (node): node is { id: string } => node !== null
     );
-    validMicrosoftNodes.forEach((rootNode) => {
-      sortedChangedItems.push(
-        ...sortForIncrementalUpdate(uniqueChangedItems, rootNode.id)
-      );
-    });
+    // Use for...of instead of push(...) to avoid stack overflow with large arrays
+    for (const rootNode of validMicrosoftNodes) {
+      for (const item of sortForIncrementalUpdate(
+        uniqueChangedItems,
+        rootNode.id
+      )) {
+        sortedChangedItems.push(item);
+      }
+    }
     // if only parts of the drive are selected, look for folders that may
     // have been removed from selection and scrub them
     await scrubRemovedFolders({
@@ -1238,11 +1242,15 @@ export async function fetchDeltaForRootNodesInDrive({
     const validMicrosoftNodes = microsoftNodes.filter(
       (node): node is { id: string } => node !== null
     );
-    validMicrosoftNodes.forEach((rootNode) => {
-      sortedChangedItems.push(
-        ...sortForIncrementalUpdate(uniqueChangedItems, rootNode.id)
-      );
-    });
+    // Use for...of instead of push(...) to avoid stack overflow with large arrays
+    for (const rootNode of validMicrosoftNodes) {
+      for (const item of sortForIncrementalUpdate(
+        uniqueChangedItems,
+        rootNode.id
+      )) {
+        sortedChangedItems.push(item);
+      }
+    }
 
     // if only parts of the drive are selected, look for folders that may
     // have been removed from selection and scrub them


### PR DESCRIPTION
## Description

Follows https://github.com/dust-tt/dust/pull/20362

PR #20362 fixed the `containsWholeDrive` branches but missed the `else` branches in both `syncDeltaForRootNodesInDrive` and `fetchDeltaForRootNodesInDrive` that handle partial drive selections.

The same `push(...array)` pattern was causing stack overflow when `sortForIncrementalUpdate` returns hundreds of thousands of items.

## Risks

Blast radius: Microsoft connector incremental sync (partial drive selections only)
Risk: low

## Deploy Plan
- pmrr
- deploy connectors