### PR TITLE
[front] Add click action on Input Bar Skill chips

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -44,6 +44,7 @@ import { getSkillIcon } from "@app/lib/skill";
 import { useSpaces, useSpacesSearch } from "@app/lib/swr/spaces";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import { classNames } from "@app/lib/utils";
+import { getManageSkillsRoute } from "@app/lib/utils/router";
 import type {
   ConversationWithoutContentType,
   DataSourceViewContentNode,
@@ -616,6 +617,8 @@ const InputBarContainer = ({
                   size="xs"
                   label={skill.name}
                   icon={getSkillIcon(skill.icon)}
+                  href={getManageSkillsRoute(owner.sId, skill.sId)}
+                  target="_blank"
                   className="m-0.5 hidden bg-background text-foreground dark:bg-background-night dark:text-foreground-night md:flex"
                   onRemove={
                     disableInput
@@ -628,6 +631,8 @@ const InputBarContainer = ({
                 <Chip
                   size="xs"
                   icon={getSkillIcon(skill.icon)}
+                  href={getManageSkillsRoute(owner.sId, skill.sId)}
+                  target="_blank"
                   className="m-0.5 flex bg-background text-foreground dark:bg-background-night dark:text-foreground-night md:hidden"
                   onRemove={
                     disableInput

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -57,6 +57,7 @@ import type {
 import {
   assertNever,
   getSupportedFileExtensions,
+  isBuilder,
   normalizeError,
   toRichAgentMentionType,
 } from "@app/types";
@@ -617,7 +618,11 @@ const InputBarContainer = ({
                   size="xs"
                   label={skill.name}
                   icon={getSkillIcon(skill.icon)}
-                  href={getManageSkillsRoute(owner.sId, skill.sId)}
+                  href={
+                    isBuilder(owner)
+                      ? getManageSkillsRoute(owner.sId, skill.sId)
+                      : undefined
+                  }
                   target="_blank"
                   className="m-0.5 hidden bg-background text-foreground dark:bg-background-night dark:text-foreground-night md:flex"
                   onRemove={
@@ -631,7 +636,11 @@ const InputBarContainer = ({
                 <Chip
                   size="xs"
                   icon={getSkillIcon(skill.icon)}
-                  href={getManageSkillsRoute(owner.sId, skill.sId)}
+                  href={
+                    isBuilder(owner)
+                      ? getManageSkillsRoute(owner.sId, skill.sId)
+                      : undefined
+                  }
                   target="_blank"
                   className="m-0.5 flex bg-background text-foreground dark:bg-background-night dark:text-foreground-night md:hidden"
                   onRemove={

--- a/front/lib/utils/router.ts
+++ b/front/lib/utils/router.ts
@@ -66,6 +66,12 @@ export const getSkillBuilderRoute = (
   return queryParams ? `${fullPath}?${queryParams}` : fullPath;
 };
 
+export const getManageSkillsRoute = (workspaceId: string, skillId?: string) => {
+  return (
+    `/w/${workspaceId}/builder/skills` + (skillId ? `#?skillId=${skillId}` : "")
+  );
+};
+
 export const getConversationRoute = (
   workspaceId: string,
   conversationIdOrNew: string | null = "new",


### PR DESCRIPTION
## Description

- This PR makes the Chips for JIT Skills in the Input Bar clickable.
- Clicking on one opens a new tab with the Manage Skills page, open on the skill.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
