### PR TITLE
[front] Improve `CapabilitiesPicker` loading UX

### DIFF
--- a/front/components/assistant/CapabilitiesPicker.tsx
+++ b/front/components/assistant/CapabilitiesPicker.tsx
@@ -386,9 +386,10 @@ export function CapabilitiesPicker({
             </>
           }
         >
-          {!isSkillsDataReady && !isToolsDataReady && (
-            <CapabilitiesPickerLoading />
-          )}
+          {!(showSkillsSection && isSkillsDataReady) &&
+            !(showToolsSection && isToolsDataReady) && (
+              <CapabilitiesPickerLoading />
+            )}
 
           {isSkillsDataReady && hasVisibleSkills && (
             <>

--- a/front/components/assistant/CapabilitiesPicker.tsx
+++ b/front/components/assistant/CapabilitiesPicker.tsx
@@ -339,7 +339,7 @@ export function CapabilitiesPicker({
         <DropdownMenuContent
           className="max-h-96 w-96"
           align="start"
-          onAnimationEnd={(e) => {
+          onAnimationEnd={() => {
             if (!isOpen) {
               setIsClosing(false);
             }

--- a/front/components/assistant/CapabilitiesPicker.tsx
+++ b/front/components/assistant/CapabilitiesPicker.tsx
@@ -135,7 +135,9 @@ export function CapabilitiesPicker({
 }: CapabilitiesPickerProps) {
   const [searchText, setSearchText] = useState("");
   const [isOpen, setIsOpen] = useState(false);
+  const [isClosing, setIsClosing] = useState(false);
   const [filter, setFilter] = useState<CapabilityFilterType>("all");
+
   const [setupSheetServer, setSetupSheetServer] =
     useState<MCPServerType | null>(null);
   const [setupSheetRemoteServerConfig, setSetupSheetRemoteServerConfig] =
@@ -145,7 +147,7 @@ export function CapabilitiesPicker({
     useState<MCPServerType | null>(null);
 
   const shouldFetchToolsData =
-    isOpen || isSettingUpServer || !!pendingServerToAdd;
+    isOpen || isClosing || isSettingUpServer || !!pendingServerToAdd;
 
   const { spaces: globalSpaces } = useSpaces({
     workspaceId: owner.sId,
@@ -312,6 +314,7 @@ export function CapabilitiesPicker({
         onOpenChange={(open) => {
           setIsOpen(open);
           if (open) {
+            setIsClosing(false);
             trackEvent({
               area: TRACKING_AREAS.TOOLS,
               object: "tool_picker",
@@ -319,6 +322,8 @@ export function CapabilitiesPicker({
             });
             setSearchText("");
             setFilter("all");
+          } else {
+            setIsClosing(true);
           }
         }}
       >
@@ -334,6 +339,11 @@ export function CapabilitiesPicker({
         <DropdownMenuContent
           className="max-h-96 w-96"
           align="start"
+          onAnimationEnd={(e) => {
+            if (!isOpen) {
+              setIsClosing(false);
+            }
+          }}
           dropdownHeaders={
             <>
               <DropdownMenuSearchbar

--- a/front/components/assistant/CapabilitiesPicker.tsx
+++ b/front/components/assistant/CapabilitiesPicker.tsx
@@ -227,8 +227,9 @@ export function CapabilitiesPicker({
     disabled: !shouldFetchToolsData,
   });
 
-  const isDataReady =
-    !isServerViewsLoading && !isAvailableMCPServersLoading && !isSkillsLoading;
+  const isSkillsDataReady = !isSkillsLoading;
+  const isToolsDataReady =
+    !isServerViewsLoading && !isAvailableMCPServersLoading;
 
   const filteredSkillsUnselected = useMemo(() => {
     const selectedSkillIds = new Set(selectedSkills.map((s) => s.sId));
@@ -252,7 +253,7 @@ export function CapabilitiesPicker({
   // - We filter by manual availability to show only servers that need install step, and by search text if present.
   // - We don't compute uninstalled servers until BOTH data sources have loaded to prevent flicker.
   const filteredUninstalledServers = useMemo(() => {
-    if (!isAdmin || !isDataReady || !shouldFetchToolsData) {
+    if (!isAdmin || !isToolsDataReady || !shouldFetchToolsData) {
       return [];
     }
 
@@ -278,7 +279,7 @@ export function CapabilitiesPicker({
       .sort((a, b) => mcpServersSortingFn({ mcpServer: a }, { mcpServer: b }));
   }, [
     isAdmin,
-    isDataReady,
+    isToolsDataReady,
     shouldFetchToolsData,
     serverViews,
     availableMCPServers,
@@ -298,7 +299,11 @@ export function CapabilitiesPicker({
     showToolsSection &&
     (filteredServerViewsUnselected.length > 0 ||
       filteredUninstalledServers.length > 0);
-  const hasNoVisibleItems = !hasVisibleSkills && !hasVisibleTools;
+  const hasNoVisibleItems =
+    isSkillsDataReady &&
+    isToolsDataReady &&
+    !hasVisibleSkills &&
+    !hasVisibleTools;
 
   return (
     <>
@@ -381,9 +386,11 @@ export function CapabilitiesPicker({
             </>
           }
         >
-          {!isDataReady && <CapabilitiesPickerLoading />}
+          {!isSkillsDataReady && !isToolsDataReady && (
+            <CapabilitiesPickerLoading />
+          )}
 
-          {isDataReady && hasVisibleSkills && (
+          {isSkillsDataReady && hasVisibleSkills && (
             <>
               <div className="text-element-700 px-4 py-2 text-xs font-semibold">
                 Skills
@@ -414,7 +421,7 @@ export function CapabilitiesPicker({
             </>
           )}
 
-          {isDataReady &&
+          {isToolsDataReady &&
             showToolsSection &&
             filteredServerViewsUnselected.length > 0 && (
               <>
@@ -447,7 +454,7 @@ export function CapabilitiesPicker({
               </>
             )}
 
-          {isDataReady &&
+          {isToolsDataReady &&
             showToolsSection &&
             filteredUninstalledServers.length > 0 &&
             filteredUninstalledServers.map((server) => (
@@ -482,7 +489,7 @@ export function CapabilitiesPicker({
               />
             ))}
 
-          {isDataReady && hasNoVisibleItems && (
+          {hasNoVisibleItems && (
             <CapabilityItem
               id="no-selected"
               icon={() => <Icon visual={BoltIcon} size="xs" />}


### PR DESCRIPTION
## Description

- From the input bar the loading time in the `CapabilitiesPicker` is currently the max between the time it takes to load tools (MCP server views + available MCP servers) and the time it takes to load skills (much lower).
- Skills are shown at the top of the list, so by showing them as soon as possible we make the UI much more responsive.
- This PR separates the loading states to make this improvement.
- This PR also removes a glitch where we see the "No more skills and tools to select" during the closing animation.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
