### PR TITLE
Add FF for google write and add drive.file scope behind FF

### DIFF
--- a/front/components/actions/mcp/create/ConnectMCPServerDialog.tsx
+++ b/front/components/actions/mcp/create/ConnectMCPServerDialog.tsx
@@ -38,6 +38,7 @@ import {
   useDiscoverOAuthMetadata,
   useUpdateMCPServerView,
 } from "@app/lib/swr/mcp_servers";
+import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import type { WorkspaceType } from "@app/types";
 import { OAUTH_PROVIDER_NAMES } from "@app/types";
 
@@ -89,6 +90,7 @@ export function ConnectMCPServerDialog({
   });
   const { discoverOAuthMetadata } = useDiscoverOAuthMetadata(owner);
   const { updateServerView } = useUpdateMCPServerView(owner, mcpServerView);
+  const { hasFeature } = useFeatureFlags({ workspaceId: owner.sId });
 
   const serverType = useMemo(
     () => getServerTypeAndIdFromSId(mcpServerView.server.sId).serverType,
@@ -190,6 +192,7 @@ export function ConnectMCPServerDialog({
       createMCPServerConnection,
       updateServerView,
       onBeforeAssociateConnection: () => setExternalIsLoading(true),
+      hasGoogleDriveWriteFeature: hasFeature("google_drive_write_enabled"),
     });
 
     if (submitRes.isErr()) {

--- a/front/components/actions/mcp/create/CreateMCPServerDialog.tsx
+++ b/front/components/actions/mcp/create/CreateMCPServerDialog.tsx
@@ -40,6 +40,7 @@ import {
   useCreateRemoteMCPServer,
   useDiscoverOAuthMetadata,
 } from "@app/lib/swr/mcp_servers";
+import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import type { WorkspaceType } from "@app/types";
 
 function getSubmitButtonLabel(
@@ -112,6 +113,7 @@ export function CreateMCPServerDialog({
   const { discoverOAuthMetadata } = useDiscoverOAuthMetadata(owner);
   const { createWithURL } = useCreateRemoteMCPServer(owner);
   const { createInternalMCPServer } = useCreateInternalMCPServer(owner);
+  const { hasFeature } = useFeatureFlags({ workspaceId: owner.sId });
 
   useEffect(() => {
     if (isOpen) {
@@ -150,6 +152,7 @@ export function CreateMCPServerDialog({
       createWithURL,
       createInternalMCPServer,
       onBeforeCreateServer: () => setExternalIsLoading(true),
+      hasGoogleDriveWriteFeature: hasFeature("google_drive_write_enabled"),
     });
 
     if (submitRes.isErr()) {

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -233,6 +233,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Sandbox MCP tool for executing code in isolated Linux containers",
     stage: "dust_only",
   },
+  google_drive_write_enabled: {
+    description:
+      "Google Docs/Sheets/Slides write capabilities via drive.file scope",
+    stage: "dust_only",
+  },
 } as const satisfies Record<string, FeatureFlag>;
 
 export type FeatureFlagStage = "dust_only" | "rolling_out" | "on_demand";

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -665,6 +665,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "dust_oai_global_agent"
   | "fireworks_new_model_feature"
   | "front_tool"
+  | "google_drive_write_enabled"
   | "google_sheets_tool"
   | "hootl_subscriptions"
   | "http_client_tool"


### PR DESCRIPTION
## Description
Add new FF for google write actions
Add drive.file scope and gate behind new FF
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Close [#5949](https://github.com/dust-tt/tasks/issues/5949) and [#5952](https://github.com/dust-tt/tasks/issues/5949)

## Tests
Manually test:
- [x] Verify when disabled the auth flow doesn’t include the new scope
- [x] Verify when ff is disabled, and you try to access search, you are not prompted to reverify 
- [x] Verify when ff is on and you re-auth, you see the new scope type
- [x] Verify when ff is enabled, and you try to access search, you are not prompted to reverify (you should only be prompted if you try to access new tools)
- [x] Verify that if not yet authorized and  and FF is on and you try to search, new scope is included in the authorization connection

New scope:
<img width="1319" height="635" alt="Screenshot 2026-01-27 at 10 12 12 PM" src="https://github.com/user-attachments/assets/e7aa4b89-3daa-460c-a8d2-679bac99e585" />

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low, behind FF
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
- [ ]  deploy front
<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
