### PR TITLE
[front] Fix tool stake for `execute_database_query`

### DIFF
--- a/front/lib/api/actions/servers/query_tables_v2/metadata.ts
+++ b/front/lib/api/actions/servers/query_tables_v2/metadata.ts
@@ -37,7 +37,7 @@ export const QUERY_TABLES_V2_TOOLS_METADATA = createToolsRecord({
         .string()
         .describe("The name of the file to save the results to."),
     },
-    stake: "low",
+    stake: "never_ask",
   },
 });
 


### PR DESCRIPTION
## Description

- This PR reverts back the tool stake of the `execute_database_query` tool to `never_ask`.
- Was updated to `low` in https://github.com/dust-tt/dust/pull/20645

## Tests

## Risk

- Low.

## Deploy Plan

- Deploy front.
