### PR TITLE
Migrate admin credit page out of getServerSideProps

### DIFF
--- a/front/lib/swr/credits.ts
+++ b/front/lib/swr/credits.ts
@@ -3,6 +3,7 @@ import type { Fetcher } from "swr";
 
 import { clientFetch } from "@app/lib/egress/client";
 import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { GetCreditPurchaseInfoResponseBody } from "@app/pages/api/w/[wId]/credits/purchase";
 import type {
   GetCreditsResponseBody,
   PendingCreditData,
@@ -157,5 +158,36 @@ export function usePurchaseCredits({ workspaceId }: { workspaceId: string }) {
   return {
     purchaseCredits,
     isLoading,
+  };
+}
+
+export function useCreditPurchaseInfo({
+  workspaceId,
+  disabled,
+}: {
+  workspaceId: string;
+  disabled?: boolean;
+}) {
+  const creditPurchaseInfoFetcher: Fetcher<GetCreditPurchaseInfoResponseBody> =
+    fetcher;
+
+  const { data, error, isValidating } = useSWRWithDefaults(
+    `/api/w/${workspaceId}/credits/purchase`,
+    creditPurchaseInfoFetcher,
+    {
+      disabled,
+    }
+  );
+
+  return {
+    isEnterprise: data?.isEnterprise ?? false,
+    currency: data?.currency ?? "usd",
+    discountPercent: data?.discountPercent ?? 0,
+    creditPricing: data?.creditPricing ?? null,
+    creditPurchaseLimits: data?.creditPurchaseLimits ?? null,
+    billingCycleStartDay: data?.billingCycleStartDay ?? null,
+    isCreditPurchaseInfoLoading: !error && !data && !disabled,
+    isCreditPurchaseInfoValidating: isValidating,
+    isCreditPurchaseInfoError: error,
   };
 }

--- a/front/pages/api/w/[wId]/credits/purchase.ts
+++ b/front/pages/api/w/[wId]/credits/purchase.ts
@@ -10,8 +10,11 @@ import {
   createEnterpriseCreditPurchase,
   createProCreditPurchase,
 } from "@app/lib/credits/committed";
+import type { CreditPurchaseLimits } from "@app/lib/credits/limits";
 import { getCreditPurchaseLimits } from "@app/lib/credits/limits";
 import {
+  getCreditPurchasePriceId,
+  getStripePricingData,
   getStripeSubscription,
   isEnterpriseSubscription,
 } from "@app/lib/plans/stripe";
@@ -19,6 +22,8 @@ import { ProgrammaticUsageConfigurationResource } from "@app/lib/resources/progr
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
+import { isSupportedCurrency } from "@app/types/currency";
+import type { StripePricingData } from "@app/types/stripe/pricing";
 
 export const PostCreditPurchaseRequestBody = t.type({
   amountDollars: t.number,
@@ -31,23 +36,36 @@ type PostCreditPurchaseResponseBody = {
   paymentUrl: string | null;
 };
 
+export type GetCreditPurchaseInfoResponseBody = {
+  isEnterprise: boolean;
+  currency: string;
+  discountPercent: number;
+  creditPricing: StripePricingData | null;
+  creditPurchaseLimits: CreditPurchaseLimits | null;
+  billingCycleStartDay: number | null;
+};
+
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<PostCreditPurchaseResponseBody>>,
+  res: NextApiResponse<
+    WithAPIErrorResponse<
+      PostCreditPurchaseResponseBody | GetCreditPurchaseInfoResponseBody
+    >
+  >,
   auth: Authenticator
 ): Promise<void> {
-  // Only admins can purchase credits.
+  // Only admins can view/purchase credits.
   if (!auth.isAdmin()) {
     return apiError(req, res, {
       status_code: 403,
       api_error: {
         type: "workspace_auth_error",
         message:
-          "Only users that are `admins` for the current workspace can purchase credits.",
+          "Only users that are `admins` for the current workspace can access credit purchases.",
       },
     });
   }
-  // Get active subscription.
+
   const subscription = auth.subscription();
   if (!subscription || !subscription.stripeSubscriptionId) {
     return apiError(req, res, {
@@ -60,10 +78,58 @@ async function handler(
     });
   }
 
-  const workspace = auth.getNonNullableWorkspace();
-
   switch (req.method) {
+    case "GET": {
+      const stripeSubscription = await getStripeSubscription(
+        subscription.stripeSubscriptionId
+      );
+
+      let isEnterprise = false;
+      let currency = "usd";
+      let creditPurchaseLimits: CreditPurchaseLimits | null = null;
+      let billingCycleStartDay: number | null = null;
+
+      if (stripeSubscription) {
+        isEnterprise = isEnterpriseSubscription(stripeSubscription);
+        currency = isSupportedCurrency(stripeSubscription.currency)
+          ? stripeSubscription.currency
+          : "usd";
+        creditPurchaseLimits = await getCreditPurchaseLimits(
+          auth,
+          stripeSubscription
+        );
+        if (stripeSubscription.current_period_start) {
+          billingCycleStartDay = new Date(
+            stripeSubscription.current_period_start * 1000
+          ).getDate();
+        }
+      }
+
+      // Fallback billingCycleStartDay from Dust subscription if not set from Stripe.
+      if (billingCycleStartDay === null && subscription.startDate) {
+        billingCycleStartDay = new Date(subscription.startDate).getDate();
+      }
+
+      const programmaticConfig =
+        await ProgrammaticUsageConfigurationResource.fetchByWorkspaceId(auth);
+      const discountPercent = programmaticConfig?.defaultDiscountPercent ?? 0;
+
+      const creditPricing = await getStripePricingData(
+        getCreditPurchasePriceId()
+      );
+
+      return res.status(200).json({
+        isEnterprise,
+        currency,
+        discountPercent,
+        creditPricing,
+        creditPurchaseLimits,
+        billingCycleStartDay,
+      });
+    }
+
     case "POST": {
+      const workspace = auth.getNonNullableWorkspace();
       const bodyValidation = PostCreditPurchaseRequestBody.decode(req.body);
       if (isLeft(bodyValidation)) {
         const pathError = reporter.formatValidationErrors(bodyValidation.left);

--- a/front/pages/w/[wId]/developers/credits-usage.tsx
+++ b/front/pages/w/[wId]/developers/credits-usage.tsx
@@ -5,7 +5,6 @@ import {
   ContentMessage,
   ExclamationCircleIcon,
   Page,
-  Spinner,
 } from "@dust-tt/sparkle";
 import dynamic from "next/dynamic";
 import type { ReactElement } from "react";
@@ -351,24 +350,6 @@ function CreditsUsagePage() {
     );
   }, [credits]);
 
-  if (isCreditPurchaseInfoLoading) {
-    return (
-      <AppCenteredLayout
-        owner={owner}
-        subscription={subscription}
-        subNavigation={subNavigationAdmin({
-          owner,
-          current: "credits_usage",
-          featureFlags,
-        })}
-      >
-        <div className="flex h-full items-center justify-center">
-          <Spinner size="lg" />
-        </div>
-      </AppCenteredLayout>
-    );
-  }
-
   return (
     <AppCenteredLayout
       owner={owner}
@@ -509,7 +490,7 @@ function CreditsUsagePage() {
           creditsByType={creditsByType}
           totalConsumed={totalConsumed}
           totalCredits={totalCredits}
-          isLoading={isCreditsLoading}
+          isLoading={isCreditsLoading || isCreditPurchaseInfoLoading}
           setShowBuyCreditDialog={setShowBuyCreditDialog}
         />
 

--- a/front/pages/w/[wId]/developers/credits-usage.tsx
+++ b/front/pages/w/[wId]/developers/credits-usage.tsx
@@ -5,15 +5,15 @@ import {
   ContentMessage,
   ExclamationCircleIcon,
   Page,
+  Spinner,
 } from "@dust-tt/sparkle";
-import type { InferGetServerSidePropsType } from "next";
 import dynamic from "next/dynamic";
+import type { ReactElement } from "react";
 import React, { useMemo, useState } from "react";
-import type Stripe from "stripe";
 
 import { subNavigationAdmin } from "@app/components/navigation/config";
+import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
 import { AppCenteredLayout } from "@app/components/sparkle/AppCenteredLayout";
-import AppRootLayout from "@app/components/sparkle/AppRootLayout";
 import { BuyCreditDialog } from "@app/components/workspace/BuyCreditDialog";
 import { CreditHistorySheet } from "@app/components/workspace/CreditHistorySheet";
 import { CreditsList, isExpired } from "@app/components/workspace/CreditsList";
@@ -25,84 +25,20 @@ const ProgrammaticCostChart = dynamic(
     ),
   { ssr: false }
 );
+import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
+import { appGetServerSidePropsForAdmin } from "@app/lib/auth/appServerSideProps";
+import type { AuthContextValue } from "@app/lib/auth/AuthContext";
+import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import {
   getBillingCycle,
   getPriceAsString,
 } from "@app/lib/client/subscription";
-import type { CreditPurchaseLimits } from "@app/lib/credits/limits";
-import { getCreditPurchaseLimits } from "@app/lib/credits/limits";
-import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
-import {
-  getCreditPurchasePriceId,
-  getStripePricingData,
-  getStripeSubscription,
-  isEnterpriseSubscription,
-} from "@app/lib/plans/stripe";
-import { ProgrammaticUsageConfigurationResource } from "@app/lib/resources/programmatic_usage_configuration_resource";
-import { useCredits } from "@app/lib/swr/credits";
+import { useCreditPurchaseInfo, useCredits } from "@app/lib/swr/credits";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
-import type { SubscriptionType, WorkspaceType } from "@app/types";
+import type { SubscriptionType } from "@app/types";
 import type { CreditDisplayData, CreditType } from "@app/types/credits";
-import { isSupportedCurrency } from "@app/types/currency";
-import type { StripePricingData } from "@app/types/stripe/pricing";
 
-export const getServerSideProps = withDefaultUserAuthRequirements<{
-  owner: WorkspaceType;
-  subscription: SubscriptionType;
-  isEnterprise: boolean;
-  currency: string;
-  discountPercent: number;
-  creditPricing: StripePricingData | null;
-  creditPurchaseLimits: CreditPurchaseLimits | null;
-  stripeSubscription: Stripe.Subscription | null;
-}>(async (context, auth) => {
-  const owner = auth.getNonNullableWorkspace();
-  const subscription = auth.getNonNullableSubscription();
-
-  if (!auth.isAdmin()) {
-    return { notFound: true };
-  }
-
-  let isEnterprise = false;
-  let currency = "usd";
-  let creditPurchaseLimits: CreditPurchaseLimits | null = null;
-
-  let stripeSubscription: Stripe.Subscription | null = null;
-  if (subscription.stripeSubscriptionId) {
-    stripeSubscription = await getStripeSubscription(
-      subscription.stripeSubscriptionId
-    );
-    if (stripeSubscription) {
-      isEnterprise = isEnterpriseSubscription(stripeSubscription);
-      currency = isSupportedCurrency(stripeSubscription.currency)
-        ? stripeSubscription.currency
-        : "usd";
-      creditPurchaseLimits = await getCreditPurchaseLimits(
-        auth,
-        stripeSubscription
-      );
-    }
-  }
-
-  const programmaticConfig =
-    await ProgrammaticUsageConfigurationResource.fetchByWorkspaceId(auth);
-  const discountPercent = programmaticConfig?.defaultDiscountPercent ?? 0;
-
-  const creditPricing = await getStripePricingData(getCreditPurchasePriceId());
-
-  return {
-    props: {
-      owner,
-      subscription,
-      isEnterprise,
-      currency,
-      discountPercent,
-      creditPricing,
-      creditPurchaseLimits,
-      stripeSubscription,
-    },
-  };
-});
+export const getServerSideProps = appGetServerSidePropsForAdmin;
 
 // A credit is active if it has started and has not expired.
 // This need to be consistent with logic in CreditResource.listActive().
@@ -325,16 +261,9 @@ function UsageSection({
   );
 }
 
-export default function CreditsUsagePage({
-  owner,
-  subscription,
-  isEnterprise,
-  currency,
-  discountPercent,
-  creditPricing,
-  creditPurchaseLimits,
-  stripeSubscription,
-}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+function CreditsUsagePage() {
+  const owner = useWorkspace();
+  const { subscription } = useAuth();
   const [showBuyCreditDialog, setShowBuyCreditDialog] = useState(false);
   const { featureFlags } = useFeatureFlags({
     workspaceId: owner.sId,
@@ -342,18 +271,17 @@ export default function CreditsUsagePage({
   const { credits, pendingCredits, isCreditsLoading } = useCredits({
     workspaceId: owner.sId,
   });
-
-  // Get the billing cycle start day from Stripe subscription, fallback to Dust subscription
-  const getBillingCycleStartDay = (): number | null => {
-    if (stripeSubscription?.current_period_start) {
-      return new Date(stripeSubscription.current_period_start * 1000).getDate();
-    }
-    if (subscription.startDate) {
-      return new Date(subscription.startDate).getDate();
-    }
-    return null;
-  };
-  const billingCycleStartDay = getBillingCycleStartDay();
+  const {
+    isEnterprise,
+    currency,
+    discountPercent,
+    creditPricing,
+    creditPurchaseLimits,
+    billingCycleStartDay,
+    isCreditPurchaseInfoLoading,
+  } = useCreditPurchaseInfo({
+    workspaceId: owner.sId,
+  });
 
   const creditsByType = useMemo(() => {
     const activeCredits = credits.filter((c) => isActive(c));
@@ -422,6 +350,24 @@ export default function CreditsUsagePage({
       [[], []]
     );
   }, [credits]);
+
+  if (isCreditPurchaseInfoLoading) {
+    return (
+      <AppCenteredLayout
+        owner={owner}
+        subscription={subscription}
+        subNavigation={subNavigationAdmin({
+          owner,
+          current: "credits_usage",
+          featureFlags,
+        })}
+      >
+        <div className="flex h-full items-center justify-center">
+          <Spinner size="lg" />
+        </div>
+      </AppCenteredLayout>
+    );
+  }
 
   return (
     <AppCenteredLayout
@@ -600,6 +546,15 @@ export default function CreditsUsagePage({
   );
 }
 
-CreditsUsagePage.getLayout = (page: React.ReactElement) => {
-  return <AppRootLayout>{page}</AppRootLayout>;
+const PageWithAuthLayout = CreditsUsagePage as AppPageWithLayout;
+
+PageWithAuthLayout.getLayout = (
+  page: ReactElement,
+  pageProps: AuthContextValue
+) => {
+  return (
+    <AppAuthContextLayout authContext={pageProps}>{page}</AppAuthContextLayout>
+  );
 };
+
+export default PageWithAuthLayout;


### PR DESCRIPTION
## Description

Migrates the credits-usage page to the thin getServerSideProps pattern with client-side data fetching.

Changes:
- Add GET handler to /api/w/[wId]/credits/purchase returning credit purchase configuration (isEnterprise, currency,
discountPercent, creditPricing, creditPurchaseLimits, billingCycleStartDay)
- Add useCreditPurchaseInfo SWR hook in lib/swr/credits.ts
- Migrate credits-usage.tsx to use appGetServerSidePropsForAdmin with useWorkspace() and useAuth() hooks
- Progressive loading: page renders immediately, sections load independently

## Tests

- Verify credits-usage page loads correctly for admin users
- Verify credit purchase info displays correctly (pricing, limits, enterprise status)
- Verify buy credits dialog works

## Risk

Break this page. 
Can be rolled back. 

## Deploy Plan

Deploy front. 