### PR TITLE
Mock cache with redis in tests (goal is to remove redis from tests)

### DIFF
--- a/front/lib/utils/cache.ts
+++ b/front/lib/utils/cache.ts
@@ -23,7 +23,7 @@ type IsNever<T> = [T] extends [never] ? true : false;
 export type JsonSerializable<T> =
   IsNever<Exclude<RecursiveJsonSerializable<T>, T>> extends true ? T : never;
 
-type CacheableFunction<T, Args extends unknown[]> = (
+export type CacheableFunction<T, Args extends unknown[]> = (
   ...args: Args
 ) => Promise<T>;
 


### PR DESCRIPTION
## Description

Mock cacheWithRedis to avoid side-effect when running tests.
Goal is to remove redis from tests (as it was initially).

## Tests

Local

## Risk

Low, purely front.

## Deploy Plan

Deploy front