### PR TITLE
[front] - feat(obs): tools latency chart

### DIFF
--- a/front/components/agent_builder/observability/charts/ToolExecutionTimeChart.tsx
+++ b/front/components/agent_builder/observability/charts/ToolExecutionTimeChart.tsx
@@ -1,0 +1,310 @@
+import {
+  Button,
+  ButtonsSwitch,
+  ButtonsSwitchList,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from "@dust-tt/sparkle";
+import { useEffect, useState } from "react";
+import { Bar, BarChart, CartesianGrid, Tooltip, XAxis, YAxis } from "recharts";
+import type { TooltipContentProps } from "recharts/types/component/Tooltip";
+
+import {
+  CHART_HEIGHT,
+  MAX_TOOLS_DISPLAYED,
+  TOOL_EXECUTION_TIME_LEGEND,
+  TOOL_EXECUTION_TIME_PALETTE,
+} from "@app/components/agent_builder/observability/constants";
+import { useToolLatencyData } from "@app/components/agent_builder/observability/hooks";
+import { useObservabilityContext } from "@app/components/agent_builder/observability/ObservabilityContext";
+import { ChartContainer } from "@app/components/agent_builder/observability/shared/ChartContainer";
+import { legendFromConstant } from "@app/components/agent_builder/observability/shared/ChartLegend";
+import { ChartTooltipCard } from "@app/components/agent_builder/observability/shared/ChartTooltip";
+import type { ToolLatencyDatum } from "@app/components/agent_builder/observability/types";
+import type { ToolLatencyView } from "@app/lib/api/assistant/observability/tool_latency";
+
+function formatDurationMs(durationMs: number): string {
+  if (durationMs >= 1000) {
+    const durationSeconds = durationMs / 1000;
+    return `${durationSeconds.toFixed(1)}s`;
+  }
+  return `${Math.round(durationMs)}ms`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isToolLatencyDatum(data: unknown): data is ToolLatencyDatum {
+  if (!isRecord(data)) {
+    return false;
+  }
+
+  return (
+    typeof data.name === "string" &&
+    typeof data.label === "string" &&
+    typeof data.count === "number" &&
+    typeof data.avgLatencyMs === "number" &&
+    typeof data.p50LatencyMs === "number" &&
+    typeof data.p95LatencyMs === "number"
+  );
+}
+
+function ToolExecutionTimeTooltip(
+  props: TooltipContentProps<number, string>
+): JSX.Element | null {
+  const { active, payload } = props;
+  if (!active || !payload || payload.length === 0) {
+    return null;
+  }
+
+  const first = payload[0];
+  if (!first?.payload || !isToolLatencyDatum(first.payload)) {
+    return null;
+  }
+
+  const row = first.payload;
+
+  return (
+    <ChartTooltipCard
+      title={row.label}
+      rows={[
+        {
+          label: "Average",
+          value: formatDurationMs(row.avgLatencyMs),
+          colorClassName: TOOL_EXECUTION_TIME_PALETTE.avgLatencyMs,
+        },
+        {
+          label: "P50",
+          value: formatDurationMs(row.p50LatencyMs),
+          colorClassName: TOOL_EXECUTION_TIME_PALETTE.p50LatencyMs,
+        },
+        {
+          label: "P95",
+          value: formatDurationMs(row.p95LatencyMs),
+          colorClassName: TOOL_EXECUTION_TIME_PALETTE.p95LatencyMs,
+        },
+      ]}
+      footer={`Executions: ${row.count}`}
+    />
+  );
+}
+
+interface ToolExecutionTimeChartProps {
+  workspaceId: string;
+  agentConfigurationId: string;
+  isCustomAgent: boolean;
+}
+
+export function ToolExecutionTimeChart({
+  workspaceId,
+  agentConfigurationId,
+  isCustomAgent,
+}: ToolExecutionTimeChartProps): JSX.Element {
+  const { period, mode, selectedVersion } = useObservabilityContext();
+  const [view, setView] = useState<ToolLatencyView>("server");
+  const [selectedServerName, setSelectedServerName] = useState<string | null>(
+    null
+  );
+
+  const isVersionMode = isCustomAgent && mode === "version";
+  const filterVersion = isVersionMode ? selectedVersion?.version : undefined;
+  const isSelectionReady = !isVersionMode || !!selectedVersion;
+  const isBaseDisabled =
+    !workspaceId || !agentConfigurationId || !isSelectionReady;
+
+  const serverLatency = useToolLatencyData({
+    workspaceId,
+    agentConfigurationId,
+    period,
+    view: "server",
+    filterVersion,
+    disabled: isBaseDisabled,
+  });
+
+  const serverRows = serverLatency.data;
+  const serverOptions = serverRows.map((row) => ({
+    name: row.name,
+    label: row.label,
+  }));
+
+  useEffect(() => {
+    if (view !== "tool") {
+      return;
+    }
+
+    if (serverRows.length === 0) {
+      if (selectedServerName !== null) {
+        setSelectedServerName(null);
+      }
+      return;
+    }
+
+    const hasSelectedServer = selectedServerName
+      ? serverRows.some((server) => server.name === selectedServerName)
+      : false;
+
+    if (!selectedServerName || !hasSelectedServer) {
+      setSelectedServerName(serverRows[0].name);
+    }
+  }, [view, serverRows, selectedServerName, setSelectedServerName]);
+
+  const toolLatency = useToolLatencyData({
+    workspaceId,
+    agentConfigurationId,
+    period,
+    view: "tool",
+    filterVersion,
+    serverName: selectedServerName,
+    disabled: isBaseDisabled || view !== "tool",
+  });
+
+  const activeData = view === "server" ? serverLatency.data : toolLatency.data;
+  const displayData = activeData.slice(0, MAX_TOOLS_DISPLAYED);
+
+  const isLoading =
+    view === "server"
+      ? serverLatency.isLoading
+      : serverLatency.isLoading || toolLatency.isLoading;
+
+  const errorMessage =
+    view === "server"
+      ? serverLatency.errorMessage
+      : (toolLatency.errorMessage ?? serverLatency.errorMessage);
+
+  let emptyMessage: string | undefined;
+  if (view === "server") {
+    if (displayData.length === 0) {
+      emptyMessage = "No successful tool executions for this selection.";
+    }
+  } else if (serverRows.length === 0) {
+    emptyMessage = "No successful tool executions for this selection.";
+  } else if (displayData.length === 0) {
+    emptyMessage = "No successful tool executions for this server.";
+  }
+
+  const legendItems = legendFromConstant(
+    TOOL_EXECUTION_TIME_LEGEND,
+    TOOL_EXECUTION_TIME_PALETTE
+  );
+
+  const selectedServerLabel =
+    serverOptions.find((server) => server.name === selectedServerName)?.label ??
+    (serverLatency.isLoading ? "Loading" : "Select server");
+
+  const xAxisLabel = view === "server" ? "Server" : "Tool";
+
+  return (
+    <ChartContainer
+      title="Tool execution time"
+      description="Average, p50, and p95 runtime for successful tool calls."
+      isLoading={isLoading}
+      errorMessage={errorMessage}
+      emptyMessage={emptyMessage}
+      height={CHART_HEIGHT}
+      legendItems={legendItems}
+      additionalControls={
+        <div className="flex items-center gap-2">
+          <ButtonsSwitchList defaultValue={view} size="xs">
+            <ButtonsSwitch
+              value="server"
+              label="By server"
+              onClick={() => setView("server")}
+            />
+            <ButtonsSwitch
+              value="tool"
+              label="By tool"
+              onClick={() => setView("tool")}
+            />
+          </ButtonsSwitchList>
+          {view === "tool" && (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  label={selectedServerLabel}
+                  size="xs"
+                  variant="outline"
+                  isSelect
+                  disabled={serverOptions.length === 0}
+                />
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuLabel label="Servers" />
+                {serverOptions.map((server) => (
+                  <DropdownMenuItem
+                    key={server.name}
+                    label={server.label}
+                    onClick={() => setSelectedServerName(server.name)}
+                  />
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
+        </div>
+      }
+    >
+      <BarChart
+        data={displayData}
+        margin={{ top: 10, right: 30, left: 10, bottom: 20 }}
+      >
+        <CartesianGrid
+          vertical={false}
+          className="stroke-border dark:stroke-border-night"
+        />
+        <XAxis
+          dataKey="label"
+          className="text-xs text-muted-foreground dark:text-muted-foreground-night"
+          tickLine={false}
+          axisLine={false}
+          tickMargin={8}
+          minTickGap={16}
+          label={{
+            value: xAxisLabel,
+            position: "insideBottom",
+            offset: -8,
+            style: { textAnchor: "middle" },
+          }}
+        />
+        <YAxis
+          className="text-xs text-muted-foreground dark:text-muted-foreground-night"
+          tickLine={false}
+          axisLine={false}
+          tickMargin={8}
+          tickFormatter={formatDurationMs}
+        />
+        <Tooltip
+          content={ToolExecutionTimeTooltip}
+          cursor={false}
+          wrapperStyle={{ outline: "none", zIndex: 50 }}
+          contentStyle={{
+            background: "transparent",
+            border: "none",
+            padding: 0,
+            boxShadow: "none",
+          }}
+        />
+        <Bar
+          dataKey="avgLatencyMs"
+          name="Average"
+          fill="currentColor"
+          className={TOOL_EXECUTION_TIME_PALETTE.avgLatencyMs}
+        />
+        <Bar
+          dataKey="p50LatencyMs"
+          name="P50"
+          fill="currentColor"
+          className={TOOL_EXECUTION_TIME_PALETTE.p50LatencyMs}
+        />
+        <Bar
+          dataKey="p95LatencyMs"
+          name="P95"
+          fill="currentColor"
+          className={TOOL_EXECUTION_TIME_PALETTE.p95LatencyMs}
+        />
+      </BarChart>
+    </ChartContainer>
+  );
+}

--- a/front/components/agent_builder/observability/charts/ToolExecutionTimeChart.tsx
+++ b/front/components/agent_builder/observability/charts/ToolExecutionTimeChart.tsx
@@ -211,7 +211,7 @@ export function ToolExecutionTimeChart({
           <ButtonsSwitchList defaultValue={view} size="xs">
             <ButtonsSwitch
               value="server"
-              label="By server"
+              label="By capability"
               onClick={() => setView("server")}
             />
             <ButtonsSwitch
@@ -232,7 +232,7 @@ export function ToolExecutionTimeChart({
                 />
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
-                <DropdownMenuLabel label="Servers" />
+                <DropdownMenuLabel label="Capability" />
                 {serverOptions.map((server) => (
                   <DropdownMenuItem
                     key={server.name}

--- a/front/components/agent_builder/observability/charts/ToolExecutionTimeChart.tsx
+++ b/front/components/agent_builder/observability/charts/ToolExecutionTimeChart.tsx
@@ -22,6 +22,7 @@ import { useToolLatencyData } from "@app/components/agent_builder/observability/
 import { useObservabilityContext } from "@app/components/agent_builder/observability/ObservabilityContext";
 import { ChartContainer } from "@app/components/agent_builder/observability/shared/ChartContainer";
 import { legendFromConstant } from "@app/components/agent_builder/observability/shared/ChartLegend";
+import { RoundedBarShape } from "@app/components/agent_builder/observability/shared/ChartShapes";
 import { ChartTooltipCard } from "@app/components/agent_builder/observability/shared/ChartTooltip";
 import type { ToolLatencyDatum } from "@app/components/agent_builder/observability/types";
 import type { ToolLatencyView } from "@app/lib/api/assistant/observability/tool_latency";
@@ -287,22 +288,25 @@ export function ToolExecutionTimeChart({
           }}
         />
         <Bar
-          dataKey="avgLatencyMs"
-          name="Average"
-          fill="currentColor"
-          className={TOOL_EXECUTION_TIME_PALETTE.avgLatencyMs}
-        />
-        <Bar
           dataKey="p50LatencyMs"
           name="P50"
           fill="currentColor"
           className={TOOL_EXECUTION_TIME_PALETTE.p50LatencyMs}
+          shape={<RoundedBarShape />}
+        />
+        <Bar
+          dataKey="avgLatencyMs"
+          name="Average"
+          fill="currentColor"
+          className={TOOL_EXECUTION_TIME_PALETTE.avgLatencyMs}
+          shape={<RoundedBarShape />}
         />
         <Bar
           dataKey="p95LatencyMs"
           name="P95"
           fill="currentColor"
           className={TOOL_EXECUTION_TIME_PALETTE.p95LatencyMs}
+          shape={<RoundedBarShape />}
         />
       </BarChart>
     </ChartContainer>

--- a/front/components/agent_builder/observability/charts/ToolUsageChart.tsx
+++ b/front/components/agent_builder/observability/charts/ToolUsageChart.tsx
@@ -16,7 +16,7 @@ import { CHART_HEIGHT } from "@app/components/agent_builder/observability/consta
 import { useToolUsageData } from "@app/components/agent_builder/observability/hooks";
 import { useObservabilityContext } from "@app/components/agent_builder/observability/ObservabilityContext";
 import { ChartContainer } from "@app/components/agent_builder/observability/shared/ChartContainer";
-import { RoundedTopBarShape } from "@app/components/agent_builder/observability/shared/ChartShapes";
+import { RoundedBarShape } from "@app/components/agent_builder/observability/shared/ChartShapes";
 import type {
   ChartDatum,
   ToolChartModeType,
@@ -183,7 +183,7 @@ export function ToolUsageChart({
             className={getIndexedColor(toolName, topTools)}
             name={toolName}
             shape={
-              <RoundedTopBarShape toolName={toolName} stackOrder={topTools} />
+              <RoundedBarShape seriesKey={toolName} stackOrderKeys={topTools} />
             }
             onMouseEnter={() => setHoveredTool(toolName)}
             onMouseLeave={() => setHoveredTool(null)}

--- a/front/components/agent_builder/observability/constants.ts
+++ b/front/components/agent_builder/observability/constants.ts
@@ -28,6 +28,18 @@ export const LATENCY_LEGEND = [
   { key: "median", label: "Median" },
 ] as const;
 
+export const TOOL_EXECUTION_TIME_PALETTE = {
+  avgLatencyMs: "text-blue-500 dark:text-blue-500-night",
+  p50LatencyMs: "text-violet-500 dark:text-violet-500-night",
+  p95LatencyMs: "text-orange-500 dark:text-orange-500-night",
+} as const;
+
+export const TOOL_EXECUTION_TIME_LEGEND = [
+  { key: "avgLatencyMs", label: "Average" },
+  { key: "p50LatencyMs", label: "P50" },
+  { key: "p95LatencyMs", label: "P95" },
+] as const;
+
 export const COST_PALETTE = {
   costMicroUsd: "text-blue-400 dark:text-blue-400-night",
   totalCredits: "text-orange-400 dark:text-orange-400-night",

--- a/front/components/agent_builder/observability/types.ts
+++ b/front/components/agent_builder/observability/types.ts
@@ -27,6 +27,15 @@ export type ToolChartUsagePayload = {
   payload?: ChartDatum;
 };
 
+export type ToolLatencyDatum = {
+  name: string;
+  label: string;
+  count: number;
+  avgLatencyMs: number;
+  p50LatencyMs: number;
+  p95LatencyMs: number;
+};
+
 export type SourceChartDatum = {
   origin: UserMessageOrigin;
   count: number;

--- a/front/components/observability/AgentObservability.tsx
+++ b/front/components/observability/AgentObservability.tsx
@@ -49,6 +49,13 @@ const ToolUsageChart = dynamic(
     ),
   { ssr: false }
 );
+const ToolExecutionTimeChart = dynamic(
+  () =>
+    import("@app/components/agent_builder/observability/charts/ToolExecutionTimeChart").then(
+      (mod) => mod.ToolExecutionTimeChart
+    ),
+  { ssr: false }
+);
 const UsageMetricsChart = dynamic(
   () =>
     import("@app/components/agent_builder/observability/charts/UsageMetricsChart").then(
@@ -237,6 +244,12 @@ export function AgentObservability({
         />
         <Separator />
         <ToolUsageChart
+          workspaceId={workspaceId}
+          agentConfigurationId={agentConfigurationId}
+          isCustomAgent={isCustomAgent}
+        />
+        <Separator />
+        <ToolExecutionTimeChart
           workspaceId={workspaceId}
           agentConfigurationId={agentConfigurationId}
           isCustomAgent={isCustomAgent}

--- a/front/components/observability/AgentObservability.tsx
+++ b/front/components/observability/AgentObservability.tsx
@@ -237,6 +237,12 @@ export function AgentObservability({
           isCustomAgent={isCustomAgent}
         />
         <Separator />
+        <LatencyChart
+          workspaceId={workspaceId}
+          agentConfigurationId={agentConfigurationId}
+          isCustomAgent={isCustomAgent}
+        />
+        <Separator />
         <DatasourceRetrievalTreemapChart
           workspaceId={workspaceId}
           agentConfigurationId={agentConfigurationId}
@@ -250,12 +256,6 @@ export function AgentObservability({
         />
         <Separator />
         <ToolExecutionTimeChart
-          workspaceId={workspaceId}
-          agentConfigurationId={agentConfigurationId}
-          isCustomAgent={isCustomAgent}
-        />
-        <Separator />
-        <LatencyChart
           workspaceId={workspaceId}
           agentConfigurationId={agentConfigurationId}
           isCustomAgent={isCustomAgent}

--- a/front/lib/api/assistant/observability/tool_latency.ts
+++ b/front/lib/api/assistant/observability/tool_latency.ts
@@ -18,6 +18,16 @@ export type ToolLatencyByVersion = {
   };
 };
 
+export type ToolLatencyView = "server" | "tool";
+
+export type ToolLatencyRow = {
+  name: string;
+  count: number;
+  avgLatencyMs: number;
+  p50LatencyMs: number;
+  p95LatencyMs: number;
+};
+
 type TermBucket = {
   key: string;
   doc_count: number;
@@ -38,7 +48,9 @@ type ToolBucket = TermBucket & {
 
 type VersionBucket = TermBucket & {
   tools?: {
-    tool_names?: estypes.AggregationsMultiBucketAggregateBase<ToolBucket>;
+    succeeded?: {
+      tool_names?: estypes.AggregationsMultiBucketAggregateBase<ToolBucket>;
+    };
   };
   first_seen?: estypes.AggregationsMinAggregate;
 };
@@ -46,6 +58,114 @@ type VersionBucket = TermBucket & {
 type ToolLatencyAggs = {
   by_version?: estypes.AggregationsMultiBucketAggregateBase<VersionBucket>;
 };
+
+type ToolLatencyByNameAggs = {
+  tools?: {
+    succeeded?: {
+      by_name?: estypes.AggregationsMultiBucketAggregateBase<ToolBucket>;
+    };
+  };
+};
+
+function buildLatencyRows(
+  buckets?: estypes.AggregationsMultiBucketAggregateBase<ToolBucket>
+): ToolLatencyRow[] {
+  const toolBuckets = bucketsToArray<ToolBucket>(buckets?.buckets);
+
+  return toolBuckets.map((tb) => {
+    const count = tb.doc_count || DEFAULT_METRIC_VALUE;
+    const avgLatencyMs = Math.round(
+      tb.avg_latency?.value ?? DEFAULT_METRIC_VALUE
+    );
+    const p50LatencyMs = Math.round(
+      tb.percentiles?.values?.["50.0"] ?? DEFAULT_METRIC_VALUE
+    );
+    const p95LatencyMs = Math.round(
+      tb.percentiles?.values?.["95.0"] ?? DEFAULT_METRIC_VALUE
+    );
+
+    return {
+      name: tb.key,
+      count,
+      avgLatencyMs,
+      p50LatencyMs,
+      p95LatencyMs,
+    };
+  });
+}
+
+export async function fetchToolLatencyMetricsByName(
+  baseQuery: estypes.QueryDslQueryContainer,
+  { view, serverName }: { view: ToolLatencyView; serverName?: string }
+): Promise<Result<ToolLatencyRow[], Error>> {
+  if (view === "tool" && !serverName) {
+    return new Err(new Error("Missing server name for tool latency view."));
+  }
+
+  const nameField =
+    view === "server" ? "tools_used.server_name" : "tools_used.tool_name";
+
+  const nestedFilter: estypes.QueryDslQueryContainer = {
+    bool: {
+      filter: [
+        { term: { "tools_used.status": "succeeded" } },
+        ...(view === "tool"
+          ? [{ term: { "tools_used.server_name": serverName } }]
+          : []),
+      ],
+    },
+  };
+
+  const aggs: Record<string, estypes.AggregationsAggregationContainer> = {
+    tools: {
+      nested: { path: "tools_used" },
+      aggs: {
+        succeeded: {
+          filter: nestedFilter,
+          aggs: {
+            by_name: {
+              terms: {
+                field: nameField,
+                size: 50,
+                order: { _count: "desc" },
+              },
+              aggs: {
+                avg_latency: {
+                  avg: { field: "tools_used.execution_time_ms" },
+                },
+                percentiles: {
+                  percentiles: {
+                    field: "tools_used.execution_time_ms",
+                    percents: [50, 95],
+                    keyed: true,
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const result = await searchAnalytics<never, ToolLatencyByNameAggs>(
+    baseQuery,
+    {
+      aggregations: aggs,
+      size: 0,
+    }
+  );
+
+  if (result.isErr()) {
+    return new Err(new Error(result.error.message));
+  }
+
+  const rows = buildLatencyRows(
+    result.value.aggregations?.tools?.succeeded?.by_name
+  );
+
+  return new Ok(rows);
+}
 
 export async function fetchToolLatencyMetrics(
   baseQuery: estypes.QueryDslQueryContainer
@@ -64,20 +184,25 @@ export async function fetchToolLatencyMetrics(
         tools: {
           nested: { path: "tools_used" },
           aggs: {
-            tool_names: {
-              terms: {
-                field: "tools_used.tool_name",
-                size: 50,
-              },
+            succeeded: {
+              filter: { term: { "tools_used.status": "succeeded" } },
               aggs: {
-                avg_latency: {
-                  avg: { field: "tools_used.execution_time_ms" },
-                },
-                percentiles: {
-                  percentiles: {
-                    field: "tools_used.execution_time_ms",
-                    percents: [50, 95],
-                    keyed: true,
+                tool_names: {
+                  terms: {
+                    field: "tools_used.tool_name",
+                    size: 50,
+                  },
+                  aggs: {
+                    avg_latency: {
+                      avg: { field: "tools_used.execution_time_ms" },
+                    },
+                    percentiles: {
+                      percentiles: {
+                        field: "tools_used.execution_time_ms",
+                        percents: [50, 95],
+                        keyed: true,
+                      },
+                    },
                   },
                 },
               },
@@ -103,7 +228,7 @@ export async function fetchToolLatencyMetrics(
 
   const byVersion: ToolLatencyByVersion[] = versionBuckets.map((vb) => {
     const toolBuckets = bucketsToArray<ToolBucket>(
-      vb.tools?.tool_names?.buckets
+      vb.tools?.succeeded?.tool_names?.buckets
     );
 
     const tools: ToolLatencyByVersion["tools"] = {};

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -29,6 +29,7 @@ import type { GetAgentOverviewResponseBody } from "@app/pages/api/w/[wId]/assist
 import type { GetContextOriginResponse } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/source";
 import type { GetAgentSummaryResponseBody } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/summary";
 import type { GetToolExecutionResponse } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/tool-execution";
+import type { GetToolLatencyResponse } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/tool-latency";
 import type { GetToolStepIndexResponse } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/tool-step-index";
 import type { GetUsageMetricsResponse } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/usage-metrics";
 import type { GetVersionMarkersResponse } from "@app/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/version-markers";
@@ -43,6 +44,10 @@ import type {
   LightWorkspaceType,
   UserType,
 } from "@app/types";
+import type {
+  ToolLatencyRow,
+  ToolLatencyView,
+} from "@app/lib/api/assistant/observability/tool_latency";
 import { normalizeError } from "@app/types";
 
 export function useAgentMcpConfigurations({
@@ -1049,6 +1054,53 @@ export function useAgentToolExecution({
     isToolExecutionLoading: !error && !data && !disabled,
     isToolExecutionError: error,
     isToolExecutionValidating: isValidating,
+  };
+}
+
+type AgentToolLatencyResult = {
+  toolLatencyRows: ToolLatencyRow[];
+  isToolLatencyLoading: boolean;
+  isToolLatencyError: unknown;
+  isToolLatencyValidating: boolean;
+};
+
+export function useAgentToolLatency({
+  workspaceId,
+  agentConfigurationId,
+  days = DEFAULT_PERIOD_DAYS,
+  version,
+  view,
+  serverName,
+  disabled,
+}: {
+  workspaceId: string;
+  agentConfigurationId: string;
+  days?: number;
+  version?: string;
+  view: ToolLatencyView;
+  serverName?: string;
+  disabled?: boolean;
+}): AgentToolLatencyResult {
+  const fetcherFn: Fetcher<GetToolLatencyResponse> = fetcher;
+  const params = new URLSearchParams({ days: days.toString(), view });
+  if (version) {
+    params.set("version", version);
+  }
+  if (serverName) {
+    params.set("serverName", serverName);
+  }
+  const key = `/api/w/${workspaceId}/assistant/agent_configurations/${agentConfigurationId}/observability/tool-latency?${params.toString()}`;
+
+  const { data, error, isValidating } = useSWRWithDefaults(
+    disabled ? null : key,
+    fetcherFn
+  );
+
+  return {
+    toolLatencyRows: data?.rows ?? emptyArray(),
+    isToolLatencyLoading: !error && !data && !disabled,
+    isToolLatencyError: error,
+    isToolLatencyValidating: isValidating,
   };
 }
 

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -8,6 +8,10 @@ import type {
   AgentMessageFeedbackType,
   AgentMessageFeedbackWithMetadataType,
 } from "@app/lib/api/assistant/feedback";
+import type {
+  ToolLatencyRow,
+  ToolLatencyView,
+} from "@app/lib/api/assistant/observability/tool_latency";
 import { clientFetch } from "@app/lib/egress/client";
 import {
   emptyArray,
@@ -44,10 +48,6 @@ import type {
   LightWorkspaceType,
   UserType,
 } from "@app/types";
-import type {
-  ToolLatencyRow,
-  ToolLatencyView,
-} from "@app/lib/api/assistant/observability/tool_latency";
 import { normalizeError } from "@app/types";
 
 export function useAgentMcpConfigurations({

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/tool-latency.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/observability/tool-latency.ts
@@ -4,28 +4,43 @@ import { fromError } from "zod-validation-error";
 
 import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
-import type { ToolLatencyByVersion } from "@app/lib/api/assistant/observability/tool_latency";
-import { fetchToolLatencyMetrics } from "@app/lib/api/assistant/observability/tool_latency";
+import type {
+  ToolLatencyByVersion,
+  ToolLatencyRow,
+  ToolLatencyView,
+} from "@app/lib/api/assistant/observability/tool_latency";
+import {
+  fetchToolLatencyMetrics,
+  fetchToolLatencyMetricsByName,
+} from "@app/lib/api/assistant/observability/tool_latency";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
+import { isString } from "@app/types";
 
 const QuerySchema = z.object({
   days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
+  version: z.string().optional(),
+  view: z.enum(["server", "tool"]).optional(),
+  serverName: z.string().optional(),
 });
 
 export type GetToolLatencyResponse = {
   byVersion: ToolLatencyByVersion[];
+  rows?: ToolLatencyRow[];
+  view?: ToolLatencyView;
+  serverName?: string;
 };
 
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<GetToolLatencyResponse>>,
   auth: Authenticator
-) {
-  if (typeof req.query.aId !== "string") {
+): Promise<void> {
+  const { aId } = req.query;
+  if (!isString(aId)) {
     return apiError(req, res, {
       status_code: 400,
       api_error: {
@@ -36,7 +51,7 @@ async function handler(
   }
 
   const assistant = await getAgentConfiguration(auth, {
-    agentId: req.query.aId,
+    agentId: aId,
     variant: "light",
   });
 
@@ -73,14 +88,52 @@ async function handler(
         });
       }
 
-      const days = q.data.days;
+      const { days, version, view, serverName } = q.data;
       const owner = auth.getNonNullableWorkspace();
 
       const baseQuery = buildAgentAnalyticsBaseQuery({
         workspaceId: owner.sId,
         agentId: assistant.sId,
         days,
+        version,
       });
+
+      if (view) {
+        if (view === "tool" && !serverName) {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: "serverName is required when view is tool.",
+            },
+          });
+        }
+
+        const toolLatencyResult = await fetchToolLatencyMetricsByName(
+          baseQuery,
+          {
+            view,
+            serverName,
+          }
+        );
+
+        if (toolLatencyResult.isErr()) {
+          return apiError(req, res, {
+            status_code: 500,
+            api_error: {
+              type: "internal_server_error",
+              message: `Failed to retrieve tool latency metrics: ${fromError(toolLatencyResult.error).toString()}`,
+            },
+          });
+        }
+
+        return res.status(200).json({
+          byVersion: [],
+          rows: toolLatencyResult.value,
+          view,
+          serverName,
+        });
+      }
 
       const toolLatencyResult = await fetchToolLatencyMetrics(baseQuery);
 


### PR DESCRIPTION
## Description

This PR adds a new "Tool execution time" chart to agent observability showing average, P50, and P95 latency metrics for successful tool calls. The chart supports two views: by capability (server) and by individual tool, with dynamic filtering to drill down into specific tools within a capability.

Tool breakdown:
<img width="1160" height="408" alt="Screenshot 2026-01-28 at 11 18 27" src="https://github.com/user-attachments/assets/93dd620d-f44b-4627-b9f6-28e3b8f8a2d0" />

Capabilities:
<img width="1159" height="398" alt="Screenshot 2026-01-28 at 11 18 39" src="https://github.com/user-attachments/assets/5f7a71a4-991e-461d-955b-45a9af8984d0" />

## Risk
Low. Frontend-only changes that add a new observability chart without modifying existing functionality.

## Tests

- [x] Locally
- [x] Front-edge

## Deploy Plan

Deploy front