### PR TITLE
Add poke page for viewing interactive content files (frames)

### DIFF
--- a/front-spa/src/poke/PokeApp.tsx
+++ b/front-spa/src/poke/PokeApp.tsx
@@ -17,6 +17,7 @@ import { DataSourceQueryPage } from "@dust-tt/front/components/poke/pages/DataSo
 import { DataSourceSearchPage } from "@dust-tt/front/components/poke/pages/DataSourceSearchPage";
 import { DataSourceViewPage } from "@dust-tt/front/components/poke/pages/DataSourceViewPage";
 import { EmailTemplatesPage } from "@dust-tt/front/components/poke/pages/EmailTemplatesPage";
+import { FramePage } from "@dust-tt/front/components/poke/pages/FramePage";
 import { GroupPage } from "@dust-tt/front/components/poke/pages/GroupPage";
 import { KillPage } from "@dust-tt/front/components/poke/pages/KillPage";
 import { LLMTracePage } from "@dust-tt/front/components/poke/pages/LLMTracePage";
@@ -158,6 +159,11 @@ const router = createBrowserRouter(
           path: "groups/:groupId",
           element: <GroupPage />,
           handle: { title: "Group" },
+        },
+        {
+          path: "files/:sId",
+          element: <FramePage />,
+          handle: { title: "File" },
         },
         {
           path: "skills/:sId",

--- a/front/components/poke/PokeNavbar.tsx
+++ b/front/components/poke/PokeNavbar.tsx
@@ -42,6 +42,8 @@ function getPokeItemChipColor(
       return "rose";
     case "Connector":
       return "green";
+    case "Frame":
+      return "highlight";
     default:
       return "primary";
   }
@@ -164,6 +166,12 @@ export function PokeSearchCommand() {
                 <div>
                   <span className="font-medium">Connector ID:</span>{" "}
                   <span className="font-mono">78901</span>
+                </div>
+                <div>
+                  <span className="font-medium">Frame token:</span>{" "}
+                  <span className="font-mono">
+                    a1b2c3d4-e5f6-7890-abcd-ef1234567890
+                  </span>
                 </div>
               </div>
             </div>

--- a/front/components/poke/pages/FramePage.tsx
+++ b/front/components/poke/pages/FramePage.tsx
@@ -1,0 +1,184 @@
+import {
+  Button,
+  Chip,
+  ClipboardCheckIcon,
+  ClipboardIcon,
+  CodeBlock,
+  ExternalLinkIcon,
+  Page,
+  Spinner,
+  useCopyToClipboard,
+} from "@dust-tt/sparkle";
+
+import { useWorkspace } from "@app/lib/auth/AuthContext";
+import { useRequiredPathParam } from "@app/lib/platform";
+import { usePokeFileDetails } from "@app/poke/swr/frame_details";
+
+export function FramePage() {
+  const owner = useWorkspace();
+  const sId = useRequiredPathParam("sId");
+  const { file, content, isFileLoading, isFileError } = usePokeFileDetails({
+    owner,
+    sId,
+  });
+
+  const [isCopiedContent, copyContent] = useCopyToClipboard();
+  const [isCopiedMetadata, copyMetadata] = useCopyToClipboard();
+
+  if (isFileLoading) {
+    return (
+      <div className="flex h-64 items-center justify-center">
+        <Spinner size="lg" />
+      </div>
+    );
+  }
+
+  if (isFileError || !file) {
+    return (
+      <div className="flex h-64 flex-col items-center justify-center">
+        <div className="text-lg font-medium text-red-600">
+          Failed to load file
+        </div>
+        <div className="mt-2 text-sm text-muted-foreground">
+          The file may not exist or there was an error fetching it.
+        </div>
+      </div>
+    );
+  }
+
+  const formatFileSize = (bytes: number) => {
+    if (bytes < 1024) {
+      return `${bytes} B`;
+    }
+    if (bytes < 1024 * 1024) {
+      return `${(bytes / 1024).toFixed(1)} KB`;
+    }
+    return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+  };
+
+  return (
+    <div className="mx-auto max-w-6xl">
+      <Page.Vertical align="stretch" gap="lg">
+        {/* Header */}
+        <div>
+          <h1 className="text-2xl font-bold">
+            File Details (Interactive Content)
+          </h1>
+          <div className="text-sm text-muted-foreground">
+            File ID: <code className="text-xs">{file.sId}</code>
+          </div>
+        </div>
+
+        {/* Summary Chips */}
+        <div className="flex flex-wrap gap-2">
+          <Chip
+            color={file.status === "ready" ? "green" : "warning"}
+            label={`Status: ${file.status}`}
+            size="sm"
+          />
+          <Chip color="info" label={`Version: ${file.version}`} size="sm" />
+          <Chip
+            color="primary"
+            label={`Size: ${formatFileSize(file.fileSize)}`}
+            size="sm"
+          />
+        </div>
+
+        {/* Metadata Card */}
+        <div className="rounded-lg border">
+          <div className="rounded-t-lg border-b bg-muted px-4 py-2">
+            <h3 className="font-medium">File Metadata</h3>
+          </div>
+          <div className="grid grid-cols-2 gap-4 p-4">
+            <div>
+              <div className="text-sm text-muted-foreground">File ID</div>
+              <div className="font-mono text-sm">{file.sId}</div>
+            </div>
+            <div>
+              <div className="text-sm text-muted-foreground">File Name</div>
+              <div className="font-mono text-sm">{file.fileName}</div>
+            </div>
+            <div>
+              <div className="text-sm text-muted-foreground">Content Type</div>
+              <div className="font-mono text-sm">{file.contentType}</div>
+            </div>
+            <div>
+              <div className="text-sm text-muted-foreground">Use Case</div>
+              <div className="font-mono text-sm">{file.useCase}</div>
+            </div>
+            {file.useCaseMetadata?.conversationId && (
+              <div className="col-span-2">
+                <div className="text-sm text-muted-foreground">
+                  Conversation
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className="font-mono text-sm">
+                    {file.useCaseMetadata.conversationId}
+                  </span>
+                  <Button
+                    label="View"
+                    variant="ghost"
+                    size="xs"
+                    icon={ExternalLinkIcon}
+                    href={`/poke/${owner.sId}/conversation/${file.useCaseMetadata.conversationId}`}
+                  />
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Use Case Metadata Card */}
+        {file.useCaseMetadata &&
+          Object.keys(file.useCaseMetadata).length > 0 && (
+            <div className="rounded-lg border">
+              <div className="flex items-center justify-between rounded-t-lg border-b bg-muted px-4 py-2">
+                <h3 className="font-medium">Use Case Metadata</h3>
+                <Button
+                  label={isCopiedMetadata ? "Copied!" : "Copy"}
+                  variant="ghost"
+                  size="xs"
+                  icon={isCopiedMetadata ? ClipboardCheckIcon : ClipboardIcon}
+                  onClick={() =>
+                    copyMetadata(JSON.stringify(file.useCaseMetadata, null, 2))
+                  }
+                />
+              </div>
+              <div className="p-4">
+                <CodeBlock
+                  wrapLongLines
+                  className="language-json max-h-48 overflow-auto"
+                >
+                  {JSON.stringify(file.useCaseMetadata, null, 2)}
+                </CodeBlock>
+              </div>
+            </div>
+          )}
+
+        {/* Content Card */}
+        {content && (
+          <div className="rounded-lg border">
+            <div className="flex items-center justify-between rounded-t-lg border-b bg-muted px-4 py-2">
+              <h3 className="font-medium">File Content</h3>
+              <Button
+                label={isCopiedContent ? "Copied!" : "Copy Content"}
+                variant="ghost"
+                size="xs"
+                icon={isCopiedContent ? ClipboardCheckIcon : ClipboardIcon}
+                onClick={() => copyContent(content)}
+              />
+            </div>
+            <div className="p-4">
+              <CodeBlock
+                wrapLongLines
+                className="language-tsx max-h-96 overflow-auto"
+              >
+                {content}
+              </CodeBlock>
+            </div>
+          </div>
+        )}
+      </Page.Vertical>
+    </div>
+  );
+}

--- a/front/pages/api/poke/workspaces/[wId]/files/[sId].ts
+++ b/front/pages/api/poke/workspaces/[wId]/files/[sId].ts
@@ -1,0 +1,100 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
+import { FileResource } from "@app/lib/resources/file_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { FileTypeWithMetadata, WithAPIErrorResponse } from "@app/types";
+import { isString } from "@app/types";
+
+export interface GetPokeFileResponseBody {
+  content: string;
+  file: FileTypeWithMetadata;
+}
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetPokeFileResponseBody>>,
+  session: SessionWithUser
+): Promise<void> {
+  const { sId, wId } = req.query;
+  if (!isString(wId)) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_not_found",
+        message: "Workspace not found.",
+      },
+    });
+  }
+
+  const auth = await Authenticator.fromSuperUserSession(session, wId);
+  if (!auth.isDustSuperUser()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "user_not_found",
+        message: "Could not find the user.",
+      },
+    });
+  }
+
+  if (!isString(sId)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "The sId parameter is required.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET":
+      const file = await FileResource.fetchById(auth, sId);
+      if (!file) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "file_not_found",
+            message: "File not found.",
+          },
+        });
+      }
+
+      // Only allow access to interactive content files (frames).
+      if (!file.isInteractiveContent) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Only interactive content files can be viewed.",
+          },
+        });
+      }
+
+      const readStream = file.getReadStream({ auth, version: "original" });
+      const chunks: Buffer[] = [];
+      for await (const chunk of readStream) {
+        chunks.push(chunk);
+      }
+      const content = Buffer.concat(chunks).toString("utf-8");
+
+      return res.status(200).json({
+        file: file.toJSONWithMetadata(auth),
+        content,
+      });
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForPoke(handler);

--- a/front/pages/poke/[wId]/files/[sId]/index.tsx
+++ b/front/pages/poke/[wId]/files/[sId]/index.tsx
@@ -1,0 +1,24 @@
+import type { ReactElement } from "react";
+
+import { FramePage } from "@app/components/poke/pages/FramePage";
+import PokeLayout from "@app/components/poke/PokeLayout";
+import type { AuthContextValue } from "@app/lib/auth/AuthContext";
+import type { PageWithLayout } from "@app/lib/auth/pokeServerSideProps";
+import { pokeGetServerSideProps } from "@app/lib/auth/pokeServerSideProps";
+
+export const getServerSideProps = pokeGetServerSideProps;
+
+const Page = FramePage as PageWithLayout;
+
+Page.getLayout = (page: ReactElement, pageProps: AuthContextValue) => {
+  return (
+    <PokeLayout
+      title={`${pageProps.workspace?.name ?? "Workspace"} - File`}
+      authContext={pageProps}
+    >
+      {page}
+    </PokeLayout>
+  );
+};
+
+export default Page;

--- a/front/poke/swr/frame_details.ts
+++ b/front/poke/swr/frame_details.ts
@@ -1,0 +1,30 @@
+import type { Fetcher } from "swr";
+
+import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { GetPokeFileResponseBody } from "@app/pages/api/poke/workspaces/[wId]/files/[sId]";
+import type { LightWorkspaceType } from "@app/types";
+
+export function usePokeFileDetails({
+  owner,
+  sId,
+  disabled,
+}: {
+  owner: LightWorkspaceType;
+  sId: string | null;
+  disabled?: boolean;
+}) {
+  const fileFetcher: Fetcher<GetPokeFileResponseBody> = fetcher;
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    sId && !disabled ? `/api/poke/workspaces/${owner.sId}/files/${sId}` : null,
+    fileFetcher
+  );
+
+  return {
+    file: data?.file ?? null,
+    content: data?.content ?? null,
+    isFileLoading: !error && !data && !disabled && !!sId,
+    isFileError: error,
+    mutateFile: mutate,
+  };
+}

--- a/front/types/poke/index.ts
+++ b/front/types/poke/index.ts
@@ -20,7 +20,8 @@ type PokeItemType =
   | "Data Source"
   | "Data Source View"
   | "Connector"
-  | "MCP Server View";
+  | "MCP Server View"
+  | "Frame";
 
 export interface PokeItemBase {
   id: ModelId;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Adds ability to search for frames by their share token in the poke cmd+k search bar and view file details including metadata and content.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
