### PR TITLE
[connectors] (github): Set github connector in error when repository is not found

### DIFF
--- a/connectors/src/connectors/github/temporal/activities/sync_code.ts
+++ b/connectors/src/connectors/github/temporal/activities/sync_code.ts
@@ -34,7 +34,6 @@ import {
   GithubCodeRepositoryModel,
   GithubConnectorStateModel,
 } from "@connectors/lib/models/github";
-import { syncFailed } from "@connectors/lib/sync_status";
 import { heartbeat } from "@connectors/lib/temporal";
 import { getActivityLogger } from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
@@ -429,12 +428,10 @@ export async function githubCleanupCodeSyncActivity({
 
   if (!githubCodeRepository) {
     // The repository was removed during the sync (e.g., deleted from GitHub or unselected).
-    // Mark the connector as errored to notify the user.
-    logger.error(
+    logger.warn(
       { connectorId: connector.id, repoId },
       "GithubCodeRepository not found during cleanup - repository may have been removed"
     );
-    await syncFailed(connector.id, "third_party_internal_error");
     return;
   }
 


### PR DESCRIPTION
## Description

Set github connector in error when repository is not found.
Log message, calls syncFailed.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy connectors
