### PR TITLE
migrate labs and profile pages to thin SSR pattern

### DIFF
--- a/front/pages/w/[wId]/labs/index.tsx
+++ b/front/pages/w/[wId]/labs/index.tsx
@@ -6,20 +6,18 @@ import {
   Page,
   TestTubeIcon,
 } from "@dust-tt/sparkle";
-import type { InferGetServerSidePropsType } from "next";
+import type { ReactElement } from "react";
 
 import { AgentSidebarMenu } from "@app/components/assistant/conversation/SidebarMenu";
 import { FeatureAccessButton } from "@app/components/labs/FeatureAccessButton";
+import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
 import { AppCenteredLayout } from "@app/components/sparkle/AppCenteredLayout";
-import AppRootLayout from "@app/components/sparkle/AppRootLayout";
-import { getFeatureFlags } from "@app/lib/auth";
-import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
-import type {
-  LabsFeatureItemType,
-  SubscriptionType,
-  WhitelistableFeature,
-  WorkspaceType,
-} from "@app/types";
+import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
+import { appGetServerSideProps } from "@app/lib/auth/appServerSideProps";
+import type { AuthContextValue } from "@app/lib/auth/AuthContext";
+import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
+import { useFeatureFlags } from "@app/lib/swr/workspaces";
+import type { LabsFeatureItemType, WhitelistableFeature } from "@app/types";
 
 const LABS_FEATURES: LabsFeatureItemType[] = [
   {
@@ -43,33 +41,7 @@ const LABS_FEATURES: LabsFeatureItemType[] = [
   },
 ];
 
-export const getServerSideProps = withDefaultUserAuthRequirements<{
-  owner: WorkspaceType;
-  subscription: SubscriptionType;
-  featureFlags: WhitelistableFeature[];
-  isAdmin: boolean;
-}>(async (_context, auth) => {
-  const owner = auth.workspace();
-  const subscription = auth.subscription();
-  const user = auth.user();
-
-  if (!owner || !subscription || !user) {
-    return {
-      notFound: true,
-    };
-  }
-
-  const featureFlags = await getFeatureFlags(owner);
-
-  return {
-    props: {
-      owner,
-      subscription,
-      featureFlags,
-      isAdmin: auth.isAdmin(),
-    },
-  };
-});
+export const getServerSideProps = appGetServerSideProps;
 
 const getVisibleFeatures = (featureFlags: WhitelistableFeature[]) => {
   return LABS_FEATURES.filter(
@@ -78,12 +50,11 @@ const getVisibleFeatures = (featureFlags: WhitelistableFeature[]) => {
   );
 };
 
-export default function LabsTranscriptsIndex({
-  owner,
-  subscription,
-  featureFlags,
-  isAdmin,
-}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+function LabsPage() {
+  const owner = useWorkspace();
+  const { subscription, isAdmin } = useAuth();
+  const { featureFlags } = useFeatureFlags({ workspaceId: owner.sId });
+
   const visibleFeatures = getVisibleFeatures(featureFlags);
 
   return (
@@ -130,6 +101,15 @@ export default function LabsTranscriptsIndex({
   );
 }
 
-LabsTranscriptsIndex.getLayout = (page: React.ReactElement) => {
-  return <AppRootLayout>{page}</AppRootLayout>;
+const PageWithAuthLayout = LabsPage as AppPageWithLayout;
+
+PageWithAuthLayout.getLayout = (
+  page: ReactElement,
+  pageProps: AuthContextValue
+) => {
+  return (
+    <AppAuthContextLayout authContext={pageProps}>{page}</AppAuthContextLayout>
+  );
 };
+
+export default PageWithAuthLayout;


### PR DESCRIPTION
## Description

- Migrate `me/index.tsx` to use `appGetServerSideProps` with client-side data fetching
- Migrate `labs/index.tsx` to use `appGetServerSideProps` with `useFeatureFlags` hook
- Migrate `labs/transcripts/index.tsx` with client-side feature flag redirect
- Migrate `labs/mcp_actions/index.tsx` to use `appGetServerSidePropsForAdmin` with client-side feature flag check
- Migrate `labs/mcp_actions/[agentId]/index.tsx` to use `appGetServerSidePropsForAdmin` with client-side agent fetching via `useAgentConfiguration`

## Tests

Check those pages render correctly. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 
