### PR TITLE
fix: mentioning users in prompt

### DIFF
--- a/front/lib/api/assistant/generation.test.ts
+++ b/front/lib/api/assistant/generation.test.ts
@@ -37,12 +37,37 @@ describe("constructGuidelinesSection", () => {
         userMessage,
       });
 
-      // For web origin, should use the tool-based approach
+      // For web origin, should use the tool-based approach with clear instructions
       expect(result).toContain(
-        `Use the \`${SEARCH_AVAILABLE_USERS_TOOL_NAME}\` tool to search for users`
+        `Call \`${SEARCH_AVAILABLE_USERS_TOOL_NAME}\` with a search term`
       );
       expect(result).toContain(
-        `Use the \`${GET_MENTION_MARKDOWN_TOOL_NAME}\` tool to get the markdown directive`
+        `Call \`${GET_MENTION_MARKDOWN_TOOL_NAME}\` with the exact id and label`
+      );
+
+      // Should include the critical warning
+      expect(result).toContain(
+        "CRITICAL: You MUST use the tools - DO NOT guess the format"
+      );
+      expect(result).toContain(
+        "Attempting to guess or construct the format manually WILL FAIL"
+      );
+
+      // Should explain the format distinction
+      expect(result).toContain(
+        "Format distinction (for reference only - NEVER construct manually)"
+      );
+      expect(result).toContain(
+        "Agent mentions: `:mention[Name]{sId=agent_id}` (no suffix)"
+      );
+      expect(result).toContain(
+        "User mentions: `:mention_user[Name]{sId=user_id}` (note the `_user` suffix)"
+      );
+
+      // Should include common mistakes section
+      expect(result).toContain("Common mistakes to AVOID:");
+      expect(result).toContain(
+        "❌ WRONG: `:mention[John Doe]{sId=user_123}` (missing _user suffix)"
       );
 
       // Should NOT tell to use simple @username

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -346,8 +346,8 @@ export function constructGuidelinesSection({
 
   guidelinesSection +=
     "\n## RENDERING MARKDOWN IMAGES\n" +
-    'When rendering markdown images, always use the file id of the image, which can be extracted from the corresponding `<attachment id="{FILE_ID}" type... title...>` tag in the conversation history.' +
-    'Also always use the file title which can similarly be extracted from the same `<attachment id... type... title="{TITLE}">` tag in the conversation history.' +
+    'When rendering markdown images, always use the file id of the image, which can be extracted from the corresponding `<attachment id="{FILE_ID}" type... title...>` tag in the conversation history. ' +
+    'Also, always use the file title which can similarly be extracted from the same `<attachment id... type... title="{TITLE}">` tag in the conversation history.' +
     "\nEvery image markdown should follow this pattern ![{TITLE}]({FILE_ID}).\n";
 
   const isSlackOrTeams =
@@ -357,17 +357,34 @@ export function constructGuidelinesSection({
   if (!isSlackOrTeams) {
     guidelinesSection +=
       `\n## MENTIONING USERS\n` +
-      "You have the abillity to mention users in a message using the markdown directive." +
-      '\nUsers can also refer to mention as "ping".' +
-      `\nUse the \`${SEARCH_AVAILABLE_USERS_TOOL_NAME}\` tool to search for users that are available to the conversation.` +
-      `\nUse the \`${GET_MENTION_MARKDOWN_TOOL_NAME}\` tool to get the markdown directive to use to mention a user in a message.` +
-      "\nImportant:" +
-      "\n - In conversation with more than one user talking, always answer to users by prefixing your message with their markdown mention directive in order to address them directly, avoid confusion and ensure users are happy." +
-      "\n - Use the markdown directive only when you want to ping the user, if you just want to refer to them, use their name only.";
+      'You can notify users in this conversation by mentioning them (also called "pinging").\n' +
+      "\n### CRITICAL: You MUST use the tools - DO NOT guess the format\n" +
+      "User mentions require a specific markdown format that is DIFFERENT from agent mentions.\n" +
+      "Attempting to guess or construct the format manually WILL FAIL and the user will NOT be notified.\n" +
+      "\n### How to mention a user (required 2-step process):\n" +
+      `1. Call \`${SEARCH_AVAILABLE_USERS_TOOL_NAME}\` with a search term (or empty string "" to list all users)\n` +
+      `   - Returns JSON array with user info: [{"id": "user_123", "label": "John Doe", "type": "user", ...}]\n` +
+      `   - Extract the "id" and "label" fields from the user you want to mention\n` +
+      `2. Call \`${GET_MENTION_MARKDOWN_TOOL_NAME}\` with the exact id and label from step 1\n` +
+      `   - Pass: { mention: { id: "user_123", label: "John Doe" } }\n` +
+      `   - Returns the correct mention string to include directly in your response\n` +
+      "\n### Format distinction (for reference only - NEVER construct manually):\n" +
+      "- Agent mentions: `:mention[Name]{sId=agent_id}` (no suffix)\n" +
+      "- User mentions: `:mention_user[Name]{sId=user_id}` (note the `_user` suffix)\n" +
+      "- The `_user` suffix is critical - wrong format = no notification sent\n" +
+      "\n### Common mistakes to AVOID:\n" +
+      "❌ WRONG: `:mention[John Doe]{sId=user_123}` (missing _user suffix)\n" +
+      "❌ WRONG: `@John Doe` (only works in Slack/Teams, not web)\n" +
+      "❌ WRONG: Trying to construct the format yourself without tools\n" +
+      `✓ CORRECT: Always use ${SEARCH_AVAILABLE_USERS_TOOL_NAME} + ${GET_MENTION_MARKDOWN_TOOL_NAME}\n` +
+      "\n### When to mention users:\n" +
+      "- In multi-user conversations, prefix your response with a mention to address specific users directly\n" +
+      "- Only use mentions when you want to ping/notify the user (they receive a notification)\n" +
+      "- To simply refer to someone without notifying them, use their name as plain text";
   } else {
     guidelinesSection +=
       `\n## MENTIONING USERS\n` +
-      "You have the abillity to mention users in a message using the markdown directive." +
+      "You have the ability to mention users in a message using the markdown directive." +
       '\nUsers can also refer to mention as "ping".' +
       `\nDo not use the \`${SEARCH_AVAILABLE_USERS_TOOL_NAME}\` or the \`${GET_MENTION_MARKDOWN_TOOL_NAME}\` tools to mention users.\n` +
       "\nUse a simple @username to mention users in your messages in this conversation.";
@@ -422,9 +439,9 @@ function constructInstructionsSection({
 /**
  * Generation of the prompt for agents with multiple actions.
  *
- * `agentsList` is passed by caller so that if there's an {ASSISTANTS_LIST} in
+ * `agentsList` is passed by the caller so that if there's an {ASSISTANTS_LIST} in
  * the instructions, it can be replaced appropriately. The Extract action
- * doesn't need that replacement, and needs to avoid a dependency on
+ * doesn't need that replacement and needs to avoid a dependency on
  * getAgentConfigurations here, so it passes null.
  */
 export function constructPromptMultiActions(


### PR DESCRIPTION
## Description

From claude

```
Dramatically Improved Guidelines ⭐ (HIGHEST PRIORITY)

Replace the current guidelines in `front/lib/api/assistant/generation.ts` (lines 357-375) with explicit, clear instructions that:
- **Explicitly prohibit guessing** the format
- **Warn about consequences** (silent failure, no notification)
- **Provide step-by-step instructions** with exact syntax examples
- **Show negative examples** of what NOT to do
- **Explain the critical distinction** between agent and user mention formats

**Key improvements**:
```typescript
"### CRITICAL: You MUST use the tools - DO NOT guess the format\n" +
"User mentions require a specific markdown format that is DIFFERENT from agent mentions.\n" +
"Attempting to guess or construct the format manually WILL FAIL and the user will NOT be notified.\n"
```

Next step is to add a skill for that, see https://dust4ai.slack.com/archives/C09T7N4S6GG/p1769598496389079

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
