### PR TITLE
Moved title to component pages

### DIFF
--- a/front-spa/src/poke/PokeApp.tsx
+++ b/front-spa/src/poke/PokeApp.tsx
@@ -36,171 +36,61 @@ import { TemplatesListPage } from "@dust-tt/front/components/poke/pages/Template
 import { TriggerDetailsPage } from "@dust-tt/front/components/poke/pages/TriggerDetailsPage";
 import { WorkspacePage } from "@dust-tt/front/components/poke/pages/WorkspacePage";
 
-const router = createBrowserRouter(
-  [
-    {
-      path: "/poke",
-      element: <PokePage />,
-      children: [
-        // Static routes first
-        {
-          index: true,
-          element: <DashboardPage />,
-          handle: { title: "Home" },
-        },
-        {
-          path: "kill",
-          element: <KillPage />,
-          handle: { title: "Kill Switches" },
-        },
-        {
-          path: "plans",
-          element: <PlansPage />,
-          handle: { title: "Plans" },
-        },
-        {
-          path: "pokefy",
-          element: <PokefyPage />,
-          handle: { title: "Pokefy" },
-        },
-        {
-          path: "production-checks",
-          element: <ProductionChecksPage />,
-          handle: { title: "Production Checks" },
-        },
-        {
-          path: "email-templates",
-          element: <EmailTemplatesPage />,
-          handle: { title: "Email Templates" },
-        },
-        {
-          path: "templates",
-          element: <TemplatesListPage />,
-          handle: { title: "Templates" },
-        },
-        {
-          path: "templates/:tId",
-          element: <TemplateDetailPage />,
-          handle: { title: "Template" },
-        },
-        {
-          path: "plugins",
-          element: <PluginsPage />,
-          handle: { title: "Plugins" },
-        },
-        {
-          path: "connectors/:connectorId",
-          element: <ConnectorRedirectPage />,
-          handle: { title: "Connector Redirect" },
-        },
-      ],
-    },
-    {
-      path: "/poke/:wId",
-      element: <PokeWorkspacePage />,
-      children: [
-        // Dynamic workspace routes
-        {
-          index: true,
-          element: <WorkspacePage />,
-          handle: { title: "Workspace" },
-        },
-        {
-          path: "memberships",
-          element: <MembershipsPage />,
-          handle: { title: "Memberships" },
-        },
-        {
-          path: "llm-traces/:runId",
-          element: <LLMTracePage />,
-          handle: { title: "LLM Trace" },
-        },
-        {
-          path: "assistants/:aId",
-          element: <AssistantDetailsPage />,
-          handle: { title: "Assistant" },
-        },
-        {
-          path: "assistants/:aId/triggers/:triggerId",
-          element: <TriggerDetailsPage />,
-          handle: { title: "Trigger" },
-        },
-        {
-          path: "conversation/:cId",
-          element: <ConversationPage />,
-          handle: { title: "Conversation" },
-        },
-        {
-          path: "data_sources/:dsId",
-          element: <DataSourcePage />,
-          handle: { title: "Data Source" },
-        },
-        {
-          path: "data_sources/:dsId/notion-requests",
-          element: <NotionRequestsPage />,
-          handle: { title: "Notion Requests" },
-        },
-        {
-          path: "data_sources/:dsId/query",
-          element: <DataSourceQueryPage />,
-          handle: { title: "Query" },
-        },
-        {
-          path: "data_sources/:dsId/search",
-          element: <DataSourceSearchPage />,
-          handle: { title: "Search" },
-        },
-        {
-          path: "data_sources/:dsId/view",
-          element: <DataSourceViewPage />,
-          handle: { title: "View Document" },
-        },
-        {
-          path: "groups/:groupId",
-          element: <GroupPage />,
-          handle: { title: "Group" },
-        },
-        {
-          path: "files/:sId",
-          element: <FramePage />,
-          handle: { title: "File" },
-        },
-        {
-          path: "skills/:sId",
-          element: <SkillDetailsPage />,
-          handle: { title: "Skill" },
-        },
-        {
-          path: "spaces/:spaceId",
-          element: <SpacePage />,
-          handle: { title: "Space" },
-        },
-        {
-          path: "spaces/:spaceId/apps/:appId",
-          element: <AppPage />,
-          handle: { title: "App" },
-        },
-        {
-          path: "spaces/:spaceId/data_source_views/:dsvId",
-          element: <SpaceDataSourceViewPage />,
-          handle: { title: "Data Source View" },
-        },
-        {
-          path: "spaces/:spaceId/mcp_server_views/:svId",
-          element: <MCPServerViewPage />,
-          handle: { title: "MCP Server View" },
-        },
-      ],
-    },
-    {
-      path: "*",
-      element: <Navigate to="/poke" replace />,
-    },
-  ],
+const router = createBrowserRouter([
   {
-    basename: import.meta.env.VITE_BASE_PATH ?? "",
-  }
-);
+    path: "/poke",
+    element: <PokePage />,
+    children: [
+      { index: true, element: <DashboardPage /> },
+      { path: "kill", element: <KillPage /> },
+      { path: "plans", element: <PlansPage /> },
+      { path: "pokefy", element: <PokefyPage /> },
+      { path: "production-checks", element: <ProductionChecksPage /> },
+      { path: "email-templates", element: <EmailTemplatesPage /> },
+      { path: "templates", element: <TemplatesListPage /> },
+      { path: "templates/:tId", element: <TemplateDetailPage /> },
+      { path: "plugins", element: <PluginsPage /> },
+      { path: "connectors/:connectorId", element: <ConnectorRedirectPage /> },
+    ],
+  },
+  {
+    path: "/poke/:wId",
+    element: <PokeWorkspacePage />,
+    children: [
+      { index: true, element: <WorkspacePage /> },
+      { path: "memberships", element: <MembershipsPage /> },
+      { path: "llm-traces/:runId", element: <LLMTracePage /> },
+      { path: "assistants/:aId", element: <AssistantDetailsPage /> },
+      {
+        path: "assistants/:aId/triggers/:triggerId",
+        element: <TriggerDetailsPage />,
+      },
+      { path: "conversation/:cId", element: <ConversationPage /> },
+      { path: "data_sources/:dsId", element: <DataSourcePage /> },
+      {
+        path: "data_sources/:dsId/notion-requests",
+        element: <NotionRequestsPage />,
+      },
+      { path: "data_sources/:dsId/query", element: <DataSourceQueryPage /> },
+      { path: "data_sources/:dsId/search", element: <DataSourceSearchPage /> },
+      { path: "data_sources/:dsId/view", element: <DataSourceViewPage /> },
+      { path: "groups/:groupId", element: <GroupPage /> },
+      { path: "files/:sId", element: <FramePage /> },
+      { path: "skills/:sId", element: <SkillDetailsPage /> },
+      { path: "spaces/:spaceId", element: <SpacePage /> },
+      { path: "spaces/:spaceId/apps/:appId", element: <AppPage /> },
+      {
+        path: "spaces/:spaceId/data_source_views/:dsvId",
+        element: <SpaceDataSourceViewPage />,
+      },
+      {
+        path: "spaces/:spaceId/mcp_server_views/:svId",
+        element: <MCPServerViewPage />,
+      },
+    ],
+  },
+  { path: "*", element: <Navigate to="/poke" replace /> },
+]);
 
 export default function PokeApp() {
   return (

--- a/front-spa/src/poke/layouts/PokePage.tsx
+++ b/front-spa/src/poke/layouts/PokePage.tsx
@@ -1,30 +1,16 @@
 import { Spinner } from "@dust-tt/sparkle";
 import { usePokeLoginRedirect } from "@spa/hooks/usePokeLoginRedirect";
 import type { ReactNode } from "react";
-import { Outlet, useMatches } from "react-router-dom";
+import { Outlet } from "react-router-dom";
 
 import { PokeLayoutNoWorkspace } from "@dust-tt/front/components/poke/PokeLayout.tsx";
 import { usePokeAuthContext } from "@dust-tt/front/lib/swr/poke.ts";
-
-interface RouteHandle {
-  title?: string;
-}
 
 interface PokeLayoutProps {
   children?: ReactNode;
 }
 
 export function PokePage({ children }: PokeLayoutProps) {
-  // Get title from the deepest matched route's handle
-  const matches = useMatches();
-  const title = matches
-    .slice()
-    .reverse()
-    .find((match) => (match.handle as RouteHandle)?.title)?.handle as
-    | RouteHandle
-    | undefined;
-  const pageTitle = title?.title ?? "Poke";
-
   const { authContext, isAuthenticated, isLoading } = usePokeAuthContext();
   const { isRedirecting } = usePokeLoginRedirect({
     isLoading,
@@ -40,7 +26,7 @@ export function PokePage({ children }: PokeLayoutProps) {
   }
 
   return (
-    <PokeLayoutNoWorkspace title={pageTitle} authContext={authContext}>
+    <PokeLayoutNoWorkspace authContext={authContext}>
       {children ?? <Outlet />}
     </PokeLayoutNoWorkspace>
   );

--- a/front-spa/src/poke/layouts/PokeWorkspacePage.tsx
+++ b/front-spa/src/poke/layouts/PokeWorkspacePage.tsx
@@ -2,14 +2,10 @@ import { Spinner } from "@dust-tt/sparkle";
 import { usePokeLoginRedirect } from "@spa/hooks/usePokeLoginRedirect";
 import { useRequiredPathParam } from "@spa/lib/platform";
 import type { ReactNode } from "react";
-import { Outlet, useMatches } from "react-router-dom";
+import { Outlet } from "react-router-dom";
 
 import PokeLayout from "@dust-tt/front/components/poke/PokeLayout.tsx";
 import { usePokeWorkspaceAuthContext } from "@dust-tt/front/lib/swr/poke.ts";
-
-interface RouteHandle {
-  title?: string;
-}
 
 interface PokeLayoutProps {
   children?: ReactNode;
@@ -17,16 +13,6 @@ interface PokeLayoutProps {
 
 export function PokeWorkspacePage({ children }: PokeLayoutProps) {
   const wId = useRequiredPathParam("wId");
-
-  // Get title from the deepest matched route's handle
-  const matches = useMatches();
-  const title = matches
-    .slice()
-    .reverse()
-    .find((match) => (match.handle as RouteHandle)?.title)?.handle as
-    | RouteHandle
-    | undefined;
-  const pageTitle = title?.title ?? "Poke";
 
   const { authContext, isAuthenticated, isLoading } =
     usePokeWorkspaceAuthContext({
@@ -46,8 +32,6 @@ export function PokeWorkspacePage({ children }: PokeLayoutProps) {
   }
 
   return (
-    <PokeLayout title={pageTitle} authContext={authContext}>
-      {children ?? <Outlet />}
-    </PokeLayout>
+    <PokeLayout authContext={authContext}>{children ?? <Outlet />}</PokeLayout>
   );
 }

--- a/front/components/poke/PokeLayout.tsx
+++ b/front/components/poke/PokeLayout.tsx
@@ -36,14 +36,12 @@ export function useSetPokePageTitle() {
 // Layout for workspace-scoped poke pages (uses AuthContext).
 export default function PokeLayout({
   children,
-  title: initialTitle,
   authContext,
 }: {
   children: React.ReactNode;
-  title?: string;
   authContext: AuthContextValue;
 }) {
-  const [title, setTitle] = useState(initialTitle ?? "Poke");
+  const [title, setTitle] = useState("Poke");
 
   const titleContextValue = useMemo(
     () => ({ title, setTitle }),
@@ -67,14 +65,12 @@ export default function PokeLayout({
 // Layout for global poke pages without workspace (uses AuthContextNoWorkspace).
 export function PokeLayoutNoWorkspace({
   children,
-  title: initialTitle,
   authContext,
 }: {
   children: React.ReactNode;
-  title?: string;
   authContext: AuthContextNoWorkspaceValue;
 }) {
-  const [title, setTitle] = useState(initialTitle ?? "Poke");
+  const [title, setTitle] = useState("Poke");
 
   const titleContextValue = useMemo(
     () => ({ title, setTitle }),

--- a/front/components/poke/PokeLayout.tsx
+++ b/front/components/poke/PokeLayout.tsx
@@ -1,4 +1,10 @@
-import React, { createContext, useContext, useMemo, useState } from "react";
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 
 import PokeNavbar from "@app/components/poke/PokeNavbar";
 import { ThemeProvider } from "@app/components/sparkle/ThemeContext";
@@ -29,8 +35,11 @@ export function usePokePageTitle() {
   return useContext(PokePageTitleContext).title;
 }
 
-export function useSetPokePageTitle() {
-  return useContext(PokePageTitleContext).setTitle;
+export function useSetPokePageTitle(title: string) {
+  const setTitle = useContext(PokePageTitleContext).setTitle;
+  useEffect(() => {
+    setTitle(title);
+  }, [setTitle, title]);
 }
 
 // Layout for workspace-scoped poke pages (uses AuthContext).

--- a/front/components/poke/PokeLayout.tsx
+++ b/front/components/poke/PokeLayout.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext } from "react";
+import React, { createContext, useContext, useMemo, useState } from "react";
 
 import PokeNavbar from "@app/components/poke/PokeNavbar";
 import { ThemeProvider } from "@app/components/sparkle/ThemeContext";
@@ -15,26 +15,45 @@ export interface PokeLayoutProps {
   currentRegion: RegionType;
 }
 
-const PokePageTitleContext = createContext<string>("");
+interface PokePageTitleContextValue {
+  title: string;
+  setTitle: (title: string) => void;
+}
+
+const PokePageTitleContext = createContext<PokePageTitleContextValue>({
+  title: "Poke",
+  setTitle: () => {},
+});
 
 export function usePokePageTitle() {
-  return useContext(PokePageTitleContext);
+  return useContext(PokePageTitleContext).title;
+}
+
+export function useSetPokePageTitle() {
+  return useContext(PokePageTitleContext).setTitle;
 }
 
 // Layout for workspace-scoped poke pages (uses AuthContext).
 export default function PokeLayout({
   children,
-  title,
+  title: initialTitle,
   authContext,
 }: {
   children: React.ReactNode;
-  title: string;
+  title?: string;
   authContext: AuthContextValue;
 }) {
+  const [title, setTitle] = useState(initialTitle ?? "Poke");
+
+  const titleContextValue = useMemo(
+    () => ({ title, setTitle }),
+    [title, setTitle]
+  );
+
   return (
     <AuthContext.Provider value={authContext}>
       <ThemeProvider>
-        <PokePageTitleContext.Provider value={title}>
+        <PokePageTitleContext.Provider value={titleContextValue}>
           <Head>
             <title>{"Poke - " + title}</title>
           </Head>
@@ -48,17 +67,24 @@ export default function PokeLayout({
 // Layout for global poke pages without workspace (uses AuthContextNoWorkspace).
 export function PokeLayoutNoWorkspace({
   children,
-  title,
+  title: initialTitle,
   authContext,
 }: {
   children: React.ReactNode;
-  title: string;
+  title?: string;
   authContext: AuthContextNoWorkspaceValue;
 }) {
+  const [title, setTitle] = useState(initialTitle ?? "Poke");
+
+  const titleContextValue = useMemo(
+    () => ({ title, setTitle }),
+    [title, setTitle]
+  );
+
   return (
     <AuthContextNoWorkspace.Provider value={authContext}>
       <ThemeProvider>
-        <PokePageTitleContext.Provider value={title}>
+        <PokePageTitleContext.Provider value={titleContextValue}>
           <Head>
             <title>{"Poke - " + title}</title>
           </Head>

--- a/front/components/poke/pages/AppPage.tsx
+++ b/front/components/poke/pages/AppPage.tsx
@@ -7,9 +7,11 @@ import {
   Spinner,
 } from "@dust-tt/sparkle";
 import { JsonViewer } from "@textea/json-viewer";
+import { useEffect } from "react";
 
 import { ViewAppTable } from "@app/components/poke/apps/view";
 import { PluginList } from "@app/components/poke/plugins/PluginList";
+import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
@@ -25,6 +27,12 @@ import type {
 
 export function AppPage() {
   const owner = useWorkspace();
+  const setPageTitle = useSetPokePageTitle();
+  useEffect(
+    () => setPageTitle(`${owner.name} - App`),
+    [setPageTitle, owner.name]
+  );
+
   const appId = useRequiredPathParam("appId");
   const hash = useSearchParam("hash");
   const {

--- a/front/components/poke/pages/AppPage.tsx
+++ b/front/components/poke/pages/AppPage.tsx
@@ -7,7 +7,6 @@ import {
   Spinner,
 } from "@dust-tt/sparkle";
 import { JsonViewer } from "@textea/json-viewer";
-import { useEffect } from "react";
 
 import { ViewAppTable } from "@app/components/poke/apps/view";
 import { PluginList } from "@app/components/poke/plugins/PluginList";
@@ -27,11 +26,7 @@ import type {
 
 export function AppPage() {
   const owner = useWorkspace();
-  const setPageTitle = useSetPokePageTitle();
-  useEffect(
-    () => setPageTitle(`${owner.name} - App`),
-    [setPageTitle, owner.name]
-  );
+  useSetPokePageTitle(`${owner.name} - App`);
 
   const appId = useRequiredPathParam("appId");
   const hash = useSearchParam("hash");

--- a/front/components/poke/pages/AssistantDetailsPage.tsx
+++ b/front/components/poke/pages/AssistantDetailsPage.tsx
@@ -16,9 +16,9 @@ import {
 import { JsonViewer } from "@textea/json-viewer";
 
 import { AgentOverviewTable } from "@app/components/poke/assistants/AgentOverviewTable";
-import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
 import { ConversationAgentDataTable } from "@app/components/poke/conversation/agent_table";
 import { PluginList } from "@app/components/poke/plugins/PluginList";
+import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
 import { TriggerDataTable } from "@app/components/poke/triggers/table";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { useWorkspace } from "@app/lib/auth/AuthContext";

--- a/front/components/poke/pages/AssistantDetailsPage.tsx
+++ b/front/components/poke/pages/AssistantDetailsPage.tsx
@@ -14,7 +14,6 @@ import {
   UserGroupIcon,
 } from "@dust-tt/sparkle";
 import { JsonViewer } from "@textea/json-viewer";
-import { useEffect } from "react";
 
 import { AgentOverviewTable } from "@app/components/poke/assistants/AgentOverviewTable";
 import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
@@ -30,11 +29,7 @@ import { SUPPORTED_MODEL_CONFIGS } from "@app/types";
 
 export function AssistantDetailsPage() {
   const owner = useWorkspace();
-  const setPageTitle = useSetPokePageTitle();
-  useEffect(
-    () => setPageTitle(`${owner.name} - Assistants`),
-    [setPageTitle, owner.name]
-  );
+  useSetPokePageTitle(`${owner.name} - Assistants`);
 
   const aId = useRequiredPathParam("aId");
   const { isDark } = useTheme();

--- a/front/components/poke/pages/AssistantDetailsPage.tsx
+++ b/front/components/poke/pages/AssistantDetailsPage.tsx
@@ -14,8 +14,10 @@ import {
   UserGroupIcon,
 } from "@dust-tt/sparkle";
 import { JsonViewer } from "@textea/json-viewer";
+import { useEffect } from "react";
 
 import { AgentOverviewTable } from "@app/components/poke/assistants/AgentOverviewTable";
+import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
 import { ConversationAgentDataTable } from "@app/components/poke/conversation/agent_table";
 import { PluginList } from "@app/components/poke/plugins/PluginList";
 import { TriggerDataTable } from "@app/components/poke/triggers/table";
@@ -28,6 +30,12 @@ import { SUPPORTED_MODEL_CONFIGS } from "@app/types";
 
 export function AssistantDetailsPage() {
   const owner = useWorkspace();
+  const setPageTitle = useSetPokePageTitle();
+  useEffect(
+    () => setPageTitle(`${owner.name} - Assistants`),
+    [setPageTitle, owner.name]
+  );
+
   const aId = useRequiredPathParam("aId");
   const { isDark } = useTheme();
 

--- a/front/components/poke/pages/ConnectorRedirectPage.tsx
+++ b/front/components/poke/pages/ConnectorRedirectPage.tsx
@@ -7,8 +7,7 @@ import { useAppRouter, useRequiredPathParam } from "@app/lib/platform";
 import { fetcher } from "@app/lib/swr/swr";
 
 export function ConnectorRedirectPage() {
-  const setPageTitle = useSetPokePageTitle();
-  useEffect(() => setPageTitle("Connector Redirect"), [setPageTitle]);
+  useSetPokePageTitle("Connector Redirect");
 
   const connectorId = useRequiredPathParam("connectorId");
   const router = useAppRouter();

--- a/front/components/poke/pages/ConnectorRedirectPage.tsx
+++ b/front/components/poke/pages/ConnectorRedirectPage.tsx
@@ -2,10 +2,14 @@ import { Spinner } from "@dust-tt/sparkle";
 import { useEffect } from "react";
 import useSWR from "swr";
 
+import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
 import { useAppRouter, useRequiredPathParam } from "@app/lib/platform";
 import { fetcher } from "@app/lib/swr/swr";
 
 export function ConnectorRedirectPage() {
+  const setPageTitle = useSetPokePageTitle();
+  useEffect(() => setPageTitle("Connector Redirect"), [setPageTitle]);
+
   const connectorId = useRequiredPathParam("connectorId");
   const router = useAppRouter();
 

--- a/front/components/poke/pages/ConversationPage.tsx
+++ b/front/components/poke/pages/ConversationPage.tsx
@@ -20,7 +20,7 @@ import {
   XMarkIcon,
 } from "@dust-tt/sparkle";
 import { CodeBracketIcon, DocumentTextIcon } from "@heroicons/react/24/outline";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
@@ -292,11 +292,7 @@ const ContentFragmentView = ({ message }: ContentFragmentViewProps) => {
 
 export function ConversationPage() {
   const owner = useWorkspace();
-  const setPageTitle = useSetPokePageTitle();
-  useEffect(
-    () => setPageTitle(`${owner.name} - Conversation`),
-    [setPageTitle, owner.name]
-  );
+  useSetPokePageTitle(`${owner.name} - Conversation`);
 
   const conversationId = useRequiredPathParam("cId");
   const {

--- a/front/components/poke/pages/ConversationPage.tsx
+++ b/front/components/poke/pages/ConversationPage.tsx
@@ -22,6 +22,7 @@ import {
 import { CodeBracketIcon, DocumentTextIcon } from "@heroicons/react/24/outline";
 import { useEffect, useState } from "react";
 
+import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
 import { useRequiredPathParam } from "@app/lib/platform";
@@ -291,6 +292,12 @@ const ContentFragmentView = ({ message }: ContentFragmentViewProps) => {
 
 export function ConversationPage() {
   const owner = useWorkspace();
+  const setPageTitle = useSetPokePageTitle();
+  useEffect(
+    () => setPageTitle(`${owner.name} - Conversation`),
+    [setPageTitle, owner.name]
+  );
+
   const conversationId = useRequiredPathParam("cId");
   const {
     data: conversationConfig,

--- a/front/components/poke/pages/ConversationPage.tsx
+++ b/front/components/poke/pages/ConversationPage.tsx
@@ -20,7 +20,7 @@ import {
   XMarkIcon,
 } from "@dust-tt/sparkle";
 import { CodeBracketIcon, DocumentTextIcon } from "@heroicons/react/24/outline";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
 import { useWorkspace } from "@app/lib/auth/AuthContext";

--- a/front/components/poke/pages/DashboardPage.tsx
+++ b/front/components/poke/pages/DashboardPage.tsx
@@ -10,9 +10,8 @@ import moment from "moment";
 import type { ChangeEvent } from "react";
 import React, { useState } from "react";
 
-import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
-
 import { PokeFavoritesList } from "@app/components/poke/PokeFavorites";
+import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
 import {
   PokeTable,
   PokeTableBody,

--- a/front/components/poke/pages/DashboardPage.tsx
+++ b/front/components/poke/pages/DashboardPage.tsx
@@ -8,7 +8,7 @@ import {
 import { UsersIcon } from "lucide-react";
 import moment from "moment";
 import type { ChangeEvent } from "react";
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 
 import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
 
@@ -106,8 +106,7 @@ const renderWorkspaces = (title: string, workspaces: PokeWorkspaceType[]) => (
 );
 
 export function DashboardPage() {
-  const setPageTitle = useSetPokePageTitle();
-  useEffect(() => setPageTitle("Home"), [setPageTitle]);
+  useSetPokePageTitle("Home");
 
   const {
     workspaces: upgradedWorkspaces,

--- a/front/components/poke/pages/DashboardPage.tsx
+++ b/front/components/poke/pages/DashboardPage.tsx
@@ -8,7 +8,9 @@ import {
 import { UsersIcon } from "lucide-react";
 import moment from "moment";
 import type { ChangeEvent } from "react";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
+
+import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
 
 import { PokeFavoritesList } from "@app/components/poke/PokeFavorites";
 import {
@@ -104,6 +106,9 @@ const renderWorkspaces = (title: string, workspaces: PokeWorkspaceType[]) => (
 );
 
 export function DashboardPage() {
+  const setPageTitle = useSetPokePageTitle();
+  useEffect(() => setPageTitle("Home"), [setPageTitle]);
+
   const {
     workspaces: upgradedWorkspaces,
     isWorkspacesLoading: isUpgradedWorkspacesLoading,

--- a/front/components/poke/pages/DataSourcePage.tsx
+++ b/front/components/poke/pages/DataSourcePage.tsx
@@ -887,11 +887,7 @@ const ConfigToggle = ({
 
 export function DataSourcePage() {
   const owner = useWorkspace();
-  const setPageTitle = useSetPokePageTitle();
-  useEffect(
-    () => setPageTitle(`${owner.name} - Data Source`),
-    [setPageTitle, owner.name]
-  );
+  useSetPokePageTitle(`${owner.name} - Data Source`);
 
   const dsId = useRequiredPathParam("dsId");
   const router = useAppRouter();

--- a/front/components/poke/pages/DataSourcePage.tsx
+++ b/front/components/poke/pages/DataSourcePage.tsx
@@ -19,8 +19,8 @@ import { useEffect, useState } from "react";
 
 import { ViewDataSourceTable } from "@app/components/poke/data_sources/view";
 import { PluginList } from "@app/components/poke/plugins/PluginList";
-import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
 import { PokePermissionTree } from "@app/components/poke/PokeConnectorPermissionsTree";
+import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
 import { SlackChannelPatternInput } from "@app/components/poke/PokeSlackChannelPatternInput";
 import {
   PokeAlert,

--- a/front/components/poke/pages/DataSourcePage.tsx
+++ b/front/components/poke/pages/DataSourcePage.tsx
@@ -19,6 +19,7 @@ import { useEffect, useState } from "react";
 
 import { ViewDataSourceTable } from "@app/components/poke/data_sources/view";
 import { PluginList } from "@app/components/poke/plugins/PluginList";
+import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
 import { PokePermissionTree } from "@app/components/poke/PokeConnectorPermissionsTree";
 import { SlackChannelPatternInput } from "@app/components/poke/PokeSlackChannelPatternInput";
 import {
@@ -886,6 +887,12 @@ const ConfigToggle = ({
 
 export function DataSourcePage() {
   const owner = useWorkspace();
+  const setPageTitle = useSetPokePageTitle();
+  useEffect(
+    () => setPageTitle(`${owner.name} - Data Source`),
+    [setPageTitle, owner.name]
+  );
+
   const dsId = useRequiredPathParam("dsId");
   const router = useAppRouter();
 

--- a/front/components/poke/pages/DataSourceQueryPage.tsx
+++ b/front/components/poke/pages/DataSourceQueryPage.tsx
@@ -6,7 +6,7 @@ import {
   Spinner,
   TextArea,
 } from "@dust-tt/sparkle";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
@@ -248,11 +248,7 @@ function QueryContent({ owner, dataSource }: QueryContentProps) {
 
 export function DataSourceQueryPage() {
   const owner = useWorkspace();
-  const setPageTitle = useSetPokePageTitle();
-  useEffect(
-    () => setPageTitle(`${owner.name} - Query`),
-    [setPageTitle, owner.name]
-  );
+  useSetPokePageTitle(`${owner.name} - Query`);
 
   const dsId = useRequiredPathParam("dsId");
   const {

--- a/front/components/poke/pages/DataSourceQueryPage.tsx
+++ b/front/components/poke/pages/DataSourceQueryPage.tsx
@@ -6,8 +6,9 @@ import {
   Spinner,
   TextArea,
 } from "@dust-tt/sparkle";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
+import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
 import { useRequiredPathParam } from "@app/lib/platform";
@@ -247,6 +248,12 @@ function QueryContent({ owner, dataSource }: QueryContentProps) {
 
 export function DataSourceQueryPage() {
   const owner = useWorkspace();
+  const setPageTitle = useSetPokePageTitle();
+  useEffect(
+    () => setPageTitle(`${owner.name} - Query`),
+    [setPageTitle, owner.name]
+  );
+
   const dsId = useRequiredPathParam("dsId");
   const {
     data: dataSourceDetails,

--- a/front/components/poke/pages/DataSourceSearchPage.tsx
+++ b/front/components/poke/pages/DataSourceSearchPage.tsx
@@ -1,6 +1,7 @@
 import { Input, Spinner } from "@dust-tt/sparkle";
 import { useEffect, useState } from "react";
 
+import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { getDisplayNameForDocument } from "@app/lib/data_sources";
 import { clientFetch } from "@app/lib/egress/client";
@@ -11,6 +12,12 @@ import type { DocumentType } from "@app/types";
 
 export function DataSourceSearchPage() {
   const owner = useWorkspace();
+  const setPageTitle = useSetPokePageTitle();
+  useEffect(
+    () => setPageTitle(`${owner.name} - Search`),
+    [setPageTitle, owner.name]
+  );
+
   const dsId = useRequiredPathParam("dsId");
   const [searchQuery, setSearchQuery] = useState("");
   const [tagsIn, setTagsIn] = useState("");

--- a/front/components/poke/pages/DataSourceSearchPage.tsx
+++ b/front/components/poke/pages/DataSourceSearchPage.tsx
@@ -12,11 +12,7 @@ import type { DocumentType } from "@app/types";
 
 export function DataSourceSearchPage() {
   const owner = useWorkspace();
-  const setPageTitle = useSetPokePageTitle();
-  useEffect(
-    () => setPageTitle(`${owner.name} - Search`),
-    [setPageTitle, owner.name]
-  );
+  useSetPokePageTitle(`${owner.name} - Search`);
 
   const dsId = useRequiredPathParam("dsId");
   const [searchQuery, setSearchQuery] = useState("");

--- a/front/components/poke/pages/DataSourceViewPage.tsx
+++ b/front/components/poke/pages/DataSourceViewPage.tsx
@@ -1,5 +1,7 @@
 import { Input, Page, Spinner, TextArea } from "@dust-tt/sparkle";
+import { useEffect } from "react";
 
+import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { useRequiredPathParam, useSearchParam } from "@app/lib/platform";
 import { classNames } from "@app/lib/utils";
@@ -7,6 +9,12 @@ import { usePokeDocument } from "@app/poke/swr/document";
 
 export function DataSourceViewPage() {
   const owner = useWorkspace();
+  const setPageTitle = useSetPokePageTitle();
+  useEffect(
+    () => setPageTitle(`${owner.name} - View Document`),
+    [setPageTitle, owner.name]
+  );
+
   const dsId = useRequiredPathParam("dsId");
   const documentId = useSearchParam("documentId");
   const {

--- a/front/components/poke/pages/DataSourceViewPage.tsx
+++ b/front/components/poke/pages/DataSourceViewPage.tsx
@@ -1,5 +1,4 @@
 import { Input, Page, Spinner, TextArea } from "@dust-tt/sparkle";
-import { useEffect } from "react";
 
 import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
@@ -9,11 +8,7 @@ import { usePokeDocument } from "@app/poke/swr/document";
 
 export function DataSourceViewPage() {
   const owner = useWorkspace();
-  const setPageTitle = useSetPokePageTitle();
-  useEffect(
-    () => setPageTitle(`${owner.name} - View Document`),
-    [setPageTitle, owner.name]
-  );
+  useSetPokePageTitle(`${owner.name} - View Document`);
 
   const dsId = useRequiredPathParam("dsId");
   const documentId = useSearchParam("documentId");

--- a/front/components/poke/pages/EmailTemplatesPage.tsx
+++ b/front/components/poke/pages/EmailTemplatesPage.tsx
@@ -6,6 +6,7 @@ import { useFieldArray, useForm } from "react-hook-form";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
+import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
 import {
   PokeForm,
   PokeFormControl,
@@ -337,6 +338,9 @@ function SchemaFormField({
 }
 
 export function EmailTemplatesPage() {
+  const setPageTitle = useSetPokePageTitle();
+  useEffect(() => setPageTitle("Email Templates"), [setPageTitle]);
+
   const [selectedTemplateId, setSelectedTemplateId] =
     useState<string>("default");
   const [previewMode, setPreviewMode] = useState<"desktop" | "mobile">(

--- a/front/components/poke/pages/EmailTemplatesPage.tsx
+++ b/front/components/poke/pages/EmailTemplatesPage.tsx
@@ -338,8 +338,7 @@ function SchemaFormField({
 }
 
 export function EmailTemplatesPage() {
-  const setPageTitle = useSetPokePageTitle();
-  useEffect(() => setPageTitle("Email Templates"), [setPageTitle]);
+  useSetPokePageTitle("Email Templates");
 
   const [selectedTemplateId, setSelectedTemplateId] =
     useState<string>("default");

--- a/front/components/poke/pages/FramePage.tsx
+++ b/front/components/poke/pages/FramePage.tsx
@@ -9,7 +9,6 @@ import {
   Spinner,
   useCopyToClipboard,
 } from "@dust-tt/sparkle";
-import { useEffect } from "react";
 
 import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
@@ -18,11 +17,7 @@ import { usePokeFileDetails } from "@app/poke/swr/frame_details";
 
 export function FramePage() {
   const owner = useWorkspace();
-  const setPageTitle = useSetPokePageTitle();
-  useEffect(
-    () => setPageTitle(`${owner.name} - File`),
-    [setPageTitle, owner.name]
-  );
+  useSetPokePageTitle(`${owner.name} - File`);
 
   const sId = useRequiredPathParam("sId");
   const { file, content, isFileLoading, isFileError } = usePokeFileDetails({

--- a/front/components/poke/pages/FramePage.tsx
+++ b/front/components/poke/pages/FramePage.tsx
@@ -9,13 +9,21 @@ import {
   Spinner,
   useCopyToClipboard,
 } from "@dust-tt/sparkle";
+import { useEffect } from "react";
 
+import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { useRequiredPathParam } from "@app/lib/platform";
 import { usePokeFileDetails } from "@app/poke/swr/frame_details";
 
 export function FramePage() {
   const owner = useWorkspace();
+  const setPageTitle = useSetPokePageTitle();
+  useEffect(
+    () => setPageTitle(`${owner.name} - File`),
+    [setPageTitle, owner.name]
+  );
+
   const sId = useRequiredPathParam("sId");
   const { file, content, isFileLoading, isFileError } = usePokeFileDetails({
     owner,

--- a/front/components/poke/pages/GroupPage.tsx
+++ b/front/components/poke/pages/GroupPage.tsx
@@ -1,5 +1,4 @@
 import { LinkWrapper, Spinner } from "@dust-tt/sparkle";
-import { useEffect } from "react";
 
 import { ViewGroupTable } from "@app/components/poke/groups/view";
 import { MembersDataTable } from "@app/components/poke/members/table";
@@ -10,11 +9,7 @@ import { usePokeGroupDetails } from "@app/poke/swr/group_details";
 
 export function GroupPage() {
   const owner = useWorkspace();
-  const setPageTitle = useSetPokePageTitle();
-  useEffect(
-    () => setPageTitle(`${owner.name} - Group`),
-    [setPageTitle, owner.name]
-  );
+  useSetPokePageTitle(`${owner.name} - Group`);
 
   const groupId = useRequiredPathParam("groupId");
   const {

--- a/front/components/poke/pages/GroupPage.tsx
+++ b/front/components/poke/pages/GroupPage.tsx
@@ -1,13 +1,21 @@
 import { LinkWrapper, Spinner } from "@dust-tt/sparkle";
+import { useEffect } from "react";
 
 import { ViewGroupTable } from "@app/components/poke/groups/view";
 import { MembersDataTable } from "@app/components/poke/members/table";
+import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { useRequiredPathParam } from "@app/lib/platform";
 import { usePokeGroupDetails } from "@app/poke/swr/group_details";
 
 export function GroupPage() {
   const owner = useWorkspace();
+  const setPageTitle = useSetPokePageTitle();
+  useEffect(
+    () => setPageTitle(`${owner.name} - Group`),
+    [setPageTitle, owner.name]
+  );
+
   const groupId = useRequiredPathParam("groupId");
   const {
     data: groupDetails,

--- a/front/components/poke/pages/KillPage.tsx
+++ b/front/components/poke/pages/KillPage.tsx
@@ -1,5 +1,5 @@
 import { SliderToggle, Spinner } from "@dust-tt/sparkle";
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { useSWRConfig } from "swr/_internal";
 
 import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
@@ -26,8 +26,7 @@ const killSwitchMap: Record<
 };
 
 export function KillPage() {
-  const setPageTitle = useSetPokePageTitle();
-  useEffect(() => setPageTitle("Kill Switches"), [setPageTitle]);
+  useSetPokePageTitle("Kill Switches");
 
   const { killSwitches, isKillSwitchesLoading } = usePokeKillSwitches();
   const [loading, setLoading] = useState(false);

--- a/front/components/poke/pages/KillPage.tsx
+++ b/front/components/poke/pages/KillPage.tsx
@@ -1,7 +1,8 @@
 import { SliderToggle, Spinner } from "@dust-tt/sparkle";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useSWRConfig } from "swr/_internal";
 
+import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
 import type { KillSwitchType } from "@app/lib/poke/types";
@@ -25,6 +26,9 @@ const killSwitchMap: Record<
 };
 
 export function KillPage() {
+  const setPageTitle = useSetPokePageTitle();
+  useEffect(() => setPageTitle("Kill Switches"), [setPageTitle]);
+
   const { killSwitches, isKillSwitchesLoading } = usePokeKillSwitches();
   const [loading, setLoading] = useState(false);
   const { mutate } = useSWRConfig();

--- a/front/components/poke/pages/LLMTracePage.tsx
+++ b/front/components/poke/pages/LLMTracePage.tsx
@@ -8,13 +8,21 @@ import {
   Spinner,
   useCopyToClipboard,
 } from "@dust-tt/sparkle";
+import { useEffect } from "react";
 
+import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { useRequiredPathParam } from "@app/lib/platform";
 import { usePokeLLMTrace } from "@app/poke/swr";
 
 export function LLMTracePage() {
   const owner = useWorkspace();
+  const setPageTitle = useSetPokePageTitle();
+  useEffect(
+    () => setPageTitle(`${owner.name} - LLM Trace`),
+    [setPageTitle, owner.name]
+  );
+
   const runId = useRequiredPathParam("runId");
   const { trace, isLLMTraceLoading, isLLMTraceError } = usePokeLLMTrace({
     workspace: owner,

--- a/front/components/poke/pages/LLMTracePage.tsx
+++ b/front/components/poke/pages/LLMTracePage.tsx
@@ -8,7 +8,6 @@ import {
   Spinner,
   useCopyToClipboard,
 } from "@dust-tt/sparkle";
-import { useEffect } from "react";
 
 import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
@@ -17,11 +16,7 @@ import { usePokeLLMTrace } from "@app/poke/swr";
 
 export function LLMTracePage() {
   const owner = useWorkspace();
-  const setPageTitle = useSetPokePageTitle();
-  useEffect(
-    () => setPageTitle(`${owner.name} - LLM Trace`),
-    [setPageTitle, owner.name]
-  );
+  useSetPokePageTitle(`${owner.name} - LLM Trace`);
 
   const runId = useRequiredPathParam("runId");
   const { trace, isLLMTraceLoading, isLLMTraceError } = usePokeLLMTrace({

--- a/front/components/poke/pages/MCPServerViewPage.tsx
+++ b/front/components/poke/pages/MCPServerViewPage.tsx
@@ -1,5 +1,4 @@
 import { LinkWrapper, Spinner } from "@dust-tt/sparkle";
-import { useEffect } from "react";
 
 import { ViewMCPServerViewTable } from "@app/components/poke/mcp_server_views/view";
 import { PluginList } from "@app/components/poke/plugins/PluginList";
@@ -11,11 +10,7 @@ import { usePokeMCPServerViewDetails } from "@app/poke/swr/mcp_server_view_detai
 
 export function MCPServerViewPage() {
   const owner = useWorkspace();
-  const setPageTitle = useSetPokePageTitle();
-  useEffect(
-    () => setPageTitle(`${owner.name} - MCP Server View`),
-    [setPageTitle, owner.name]
-  );
+  useSetPokePageTitle(`${owner.name} - MCP Server View`);
 
   const svId = useRequiredPathParam("svId");
   const {

--- a/front/components/poke/pages/MCPServerViewPage.tsx
+++ b/front/components/poke/pages/MCPServerViewPage.tsx
@@ -1,7 +1,9 @@
 import { LinkWrapper, Spinner } from "@dust-tt/sparkle";
+import { useEffect } from "react";
 
 import { ViewMCPServerViewTable } from "@app/components/poke/mcp_server_views/view";
 import { PluginList } from "@app/components/poke/plugins/PluginList";
+import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { useRequiredPathParam } from "@app/lib/platform";
@@ -9,6 +11,12 @@ import { usePokeMCPServerViewDetails } from "@app/poke/swr/mcp_server_view_detai
 
 export function MCPServerViewPage() {
   const owner = useWorkspace();
+  const setPageTitle = useSetPokePageTitle();
+  useEffect(
+    () => setPageTitle(`${owner.name} - MCP Server View`),
+    [setPageTitle, owner.name]
+  );
+
   const svId = useRequiredPathParam("svId");
   const {
     data: mcpServerViewDetails,

--- a/front/components/poke/pages/MembershipsPage.tsx
+++ b/front/components/poke/pages/MembershipsPage.tsx
@@ -1,12 +1,20 @@
 import { LinkWrapper, Spinner } from "@dust-tt/sparkle";
+import { useEffect } from "react";
 
 import { InvitationsDataTable } from "@app/components/poke/invitations/table";
 import { MembersDataTable } from "@app/components/poke/members/table";
+import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { usePokeMemberships } from "@app/poke/swr/memberships";
 
 export function MembershipsPage() {
   const owner = useWorkspace();
+  const setPageTitle = useSetPokePageTitle();
+  useEffect(
+    () => setPageTitle(`${owner.name} - Memberships`),
+    [setPageTitle, owner.name]
+  );
+
   const {
     data: membershipsData,
     isLoading,

--- a/front/components/poke/pages/MembershipsPage.tsx
+++ b/front/components/poke/pages/MembershipsPage.tsx
@@ -1,5 +1,4 @@
 import { LinkWrapper, Spinner } from "@dust-tt/sparkle";
-import { useEffect } from "react";
 
 import { InvitationsDataTable } from "@app/components/poke/invitations/table";
 import { MembersDataTable } from "@app/components/poke/members/table";
@@ -9,11 +8,7 @@ import { usePokeMemberships } from "@app/poke/swr/memberships";
 
 export function MembershipsPage() {
   const owner = useWorkspace();
-  const setPageTitle = useSetPokePageTitle();
-  useEffect(
-    () => setPageTitle(`${owner.name} - Memberships`),
-    [setPageTitle, owner.name]
-  );
+  useSetPokePageTitle(`${owner.name} - Memberships`);
 
   const {
     data: membershipsData,

--- a/front/components/poke/pages/NotionRequestsPage.tsx
+++ b/front/components/poke/pages/NotionRequestsPage.tsx
@@ -6,8 +6,9 @@ import {
   TextArea,
 } from "@dust-tt/sparkle";
 import { JsonViewer } from "@textea/json-viewer";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
+import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
@@ -18,6 +19,12 @@ type HttpMethod = "GET" | "POST";
 
 export function NotionRequestsPage() {
   const owner = useWorkspace();
+  const setPageTitle = useSetPokePageTitle();
+  useEffect(
+    () => setPageTitle(`${owner.name} - Notion Requests`),
+    [setPageTitle, owner.name]
+  );
+
   const dsId = useRequiredPathParam("dsId");
   const { isDark } = useTheme();
   const [url, setUrl] = useState("");

--- a/front/components/poke/pages/NotionRequestsPage.tsx
+++ b/front/components/poke/pages/NotionRequestsPage.tsx
@@ -6,7 +6,7 @@ import {
   TextArea,
 } from "@dust-tt/sparkle";
 import { JsonViewer } from "@textea/json-viewer";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
@@ -19,11 +19,7 @@ type HttpMethod = "GET" | "POST";
 
 export function NotionRequestsPage() {
   const owner = useWorkspace();
-  const setPageTitle = useSetPokePageTitle();
-  useEffect(
-    () => setPageTitle(`${owner.name} - Notion Requests`),
-    [setPageTitle, owner.name]
-  );
+  useSetPokePageTitle(`${owner.name} - Notion Requests`);
 
   const dsId = useRequiredPathParam("dsId");
   const { isDark } = useTheme();

--- a/front/components/poke/pages/PlansPage.tsx
+++ b/front/components/poke/pages/PlansPage.tsx
@@ -8,7 +8,7 @@ import {
   XMarkIcon,
 } from "@dust-tt/sparkle";
 import type * as t from "io-ts";
-import React, { useEffect } from "react";
+import React from "react";
 import { useSWRConfig } from "swr";
 
 import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
@@ -27,8 +27,7 @@ import type { PlanTypeSchema } from "@app/pages/api/poke/plans";
 import type { PlanType } from "@app/types";
 
 export function PlansPage() {
-  const setPageTitle = useSetPokePageTitle();
-  useEffect(() => setPageTitle("Plans"), [setPageTitle]);
+  useSetPokePageTitle("Plans");
 
   const { mutate } = useSWRConfig();
 

--- a/front/components/poke/pages/PlansPage.tsx
+++ b/front/components/poke/pages/PlansPage.tsx
@@ -8,9 +8,10 @@ import {
   XMarkIcon,
 } from "@dust-tt/sparkle";
 import type * as t from "io-ts";
-import React from "react";
+import React, { useEffect } from "react";
 import { useSWRConfig } from "swr";
 
+import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
 import type { EditingPlanType } from "@app/components/poke/plans/form";
 import {
   Field,
@@ -26,6 +27,9 @@ import type { PlanTypeSchema } from "@app/pages/api/poke/plans";
 import type { PlanType } from "@app/types";
 
 export function PlansPage() {
+  const setPageTitle = useSetPokePageTitle();
+  useEffect(() => setPageTitle("Plans"), [setPageTitle]);
+
   const { mutate } = useSWRConfig();
 
   const sendNotification = useSendNotification();

--- a/front/components/poke/pages/PlansPage.tsx
+++ b/front/components/poke/pages/PlansPage.tsx
@@ -11,7 +11,6 @@ import type * as t from "io-ts";
 import React from "react";
 import { useSWRConfig } from "swr";
 
-import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
 import type { EditingPlanType } from "@app/components/poke/plans/form";
 import {
   Field,
@@ -20,6 +19,7 @@ import {
   toPlanType,
   useEditingPlan,
 } from "@app/components/poke/plans/form";
+import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
 import { usePokePlans } from "@app/lib/swr/poke";

--- a/front/components/poke/pages/PluginsPage.tsx
+++ b/front/components/poke/pages/PluginsPage.tsx
@@ -1,6 +1,12 @@
+import { useEffect } from "react";
+
+import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
 import { PluginList } from "@app/components/poke/plugins/PluginList";
 
 export function PluginsPage() {
+  const setPageTitle = useSetPokePageTitle();
+  useEffect(() => setPageTitle("Plugins"), [setPageTitle]);
+
   return (
     <div className="h-full flex-grow flex-col items-center justify-center p-8 pt-8">
       <PluginList

--- a/front/components/poke/pages/PluginsPage.tsx
+++ b/front/components/poke/pages/PluginsPage.tsx
@@ -1,11 +1,8 @@
-import { useEffect } from "react";
-
 import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
 import { PluginList } from "@app/components/poke/plugins/PluginList";
 
 export function PluginsPage() {
-  const setPageTitle = useSetPokePageTitle();
-  useEffect(() => setPageTitle("Plugins"), [setPageTitle]);
+  useSetPokePageTitle("Plugins");
 
   return (
     <div className="h-full flex-grow flex-col items-center justify-center p-8 pt-8">

--- a/front/components/poke/pages/PluginsPage.tsx
+++ b/front/components/poke/pages/PluginsPage.tsx
@@ -1,5 +1,5 @@
-import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
 import { PluginList } from "@app/components/poke/plugins/PluginList";
+import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
 
 export function PluginsPage() {
   useSetPokePageTitle("Plugins");

--- a/front/components/poke/pages/PokefyPage.tsx
+++ b/front/components/poke/pages/PokefyPage.tsx
@@ -1,8 +1,12 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
+import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
 import { convertUrlToPoke } from "@app/lib/utils/url-to-poke";
 
 export function PokefyPage() {
+  const setPageTitle = useSetPokePageTitle();
+  useEffect(() => setPageTitle("Pokefy"), [setPageTitle]);
+
   const [url, setUrl] = useState("");
   const [error, setError] = useState("");
 

--- a/front/components/poke/pages/PokefyPage.tsx
+++ b/front/components/poke/pages/PokefyPage.tsx
@@ -1,11 +1,10 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
 import { convertUrlToPoke } from "@app/lib/utils/url-to-poke";
 
 export function PokefyPage() {
-  const setPageTitle = useSetPokePageTitle();
-  useEffect(() => setPageTitle("Pokefy"), [setPageTitle]);
+  useSetPokePageTitle("Pokefy");
 
   const [url, setUrl] = useState("");
   const [error, setError] = useState("");

--- a/front/components/poke/pages/ProductionChecksPage.tsx
+++ b/front/components/poke/pages/ProductionChecksPage.tsx
@@ -10,8 +10,9 @@ import {
   Spinner,
 } from "@dust-tt/sparkle";
 import type { ComponentProps } from "react";
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 
+import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
 import { cn } from "@app/components/poke/shadcn/lib/utils";
 import { useSendNotification } from "@app/hooks/useNotification";
 import {
@@ -491,6 +492,9 @@ function ProductionCheckCard({
 }
 
 export function ProductionChecksPage() {
+  const setPageTitle = useSetPokePageTitle();
+  useEffect(() => setPageTitle("Production Checks"), [setPageTitle]);
+
   const { checks, isProductionChecksLoading, mutateProductionChecks } =
     usePokeProductionChecks();
   const { runCheck, isCheckRunning } = useRunProductionCheck();

--- a/front/components/poke/pages/ProductionChecksPage.tsx
+++ b/front/components/poke/pages/ProductionChecksPage.tsx
@@ -492,8 +492,7 @@ function ProductionCheckCard({
 }
 
 export function ProductionChecksPage() {
-  const setPageTitle = useSetPokePageTitle();
-  useEffect(() => setPageTitle("Production Checks"), [setPageTitle]);
+  useSetPokePageTitle("Production Checks");
 
   const { checks, isProductionChecksLoading, mutateProductionChecks } =
     usePokeProductionChecks();

--- a/front/components/poke/pages/ProductionChecksPage.tsx
+++ b/front/components/poke/pages/ProductionChecksPage.tsx
@@ -10,7 +10,7 @@ import {
   Spinner,
 } from "@dust-tt/sparkle";
 import type { ComponentProps } from "react";
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 
 import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
 import { cn } from "@app/components/poke/shadcn/lib/utils";

--- a/front/components/poke/pages/SkillDetailsPage.tsx
+++ b/front/components/poke/pages/SkillDetailsPage.tsx
@@ -1,6 +1,5 @@
 import { LinkWrapper, Spinner, TextArea } from "@dust-tt/sparkle";
 import { JsonViewer } from "@textea/json-viewer";
-import { useEffect } from "react";
 
 import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
 import { SkillOverviewTable } from "@app/components/poke/skills/SkillOverviewTable";
@@ -11,11 +10,7 @@ import { usePokeSkillDetails } from "@app/poke/swr/skill_details";
 
 export function SkillDetailsPage() {
   const owner = useWorkspace();
-  const setPageTitle = useSetPokePageTitle();
-  useEffect(
-    () => setPageTitle(`${owner.name} - Skill`),
-    [setPageTitle, owner.name]
-  );
+  useSetPokePageTitle(`${owner.name} - Skill`);
 
   const sId = useRequiredPathParam("sId");
   const { isDark } = useTheme();

--- a/front/components/poke/pages/SkillDetailsPage.tsx
+++ b/front/components/poke/pages/SkillDetailsPage.tsx
@@ -1,6 +1,8 @@
 import { LinkWrapper, Spinner, TextArea } from "@dust-tt/sparkle";
 import { JsonViewer } from "@textea/json-viewer";
+import { useEffect } from "react";
 
+import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
 import { SkillOverviewTable } from "@app/components/poke/skills/SkillOverviewTable";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
@@ -9,6 +11,12 @@ import { usePokeSkillDetails } from "@app/poke/swr/skill_details";
 
 export function SkillDetailsPage() {
   const owner = useWorkspace();
+  const setPageTitle = useSetPokePageTitle();
+  useEffect(
+    () => setPageTitle(`${owner.name} - Skill`),
+    [setPageTitle, owner.name]
+  );
+
   const sId = useRequiredPathParam("sId");
   const { isDark } = useTheme();
 

--- a/front/components/poke/pages/SpaceDataSourceViewPage.tsx
+++ b/front/components/poke/pages/SpaceDataSourceViewPage.tsx
@@ -1,5 +1,4 @@
 import { LinkWrapper, Spinner } from "@dust-tt/sparkle";
-import { useEffect } from "react";
 
 import { DataSourceViewSelector } from "@app/components/data_source_view/DataSourceViewSelector";
 import { ViewDataSourceViewTable } from "@app/components/poke/data_source_views/view";
@@ -14,11 +13,7 @@ import { defaultSelectionConfiguration } from "@app/types";
 
 export function SpaceDataSourceViewPage() {
   const owner = useWorkspace();
-  const setPageTitle = useSetPokePageTitle();
-  useEffect(
-    () => setPageTitle(`${owner.name} - Data Source View`),
-    [setPageTitle, owner.name]
-  );
+  useSetPokePageTitle(`${owner.name} - Data Source View`);
 
   const dsvId = useRequiredPathParam("dsvId");
   const {

--- a/front/components/poke/pages/SpaceDataSourceViewPage.tsx
+++ b/front/components/poke/pages/SpaceDataSourceViewPage.tsx
@@ -1,8 +1,10 @@
 import { LinkWrapper, Spinner } from "@dust-tt/sparkle";
+import { useEffect } from "react";
 
 import { DataSourceViewSelector } from "@app/components/data_source_view/DataSourceViewSelector";
 import { ViewDataSourceViewTable } from "@app/components/poke/data_source_views/view";
 import { PluginList } from "@app/components/poke/plugins/PluginList";
+import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { useRequiredPathParam } from "@app/lib/platform";
 import { usePokeDataSourceViewDetails } from "@app/poke/swr/data_source_view_details";
@@ -12,6 +14,12 @@ import { defaultSelectionConfiguration } from "@app/types";
 
 export function SpaceDataSourceViewPage() {
   const owner = useWorkspace();
+  const setPageTitle = useSetPokePageTitle();
+  useEffect(
+    () => setPageTitle(`${owner.name} - Data Source View`),
+    [setPageTitle, owner.name]
+  );
+
   const dsvId = useRequiredPathParam("dsvId");
   const {
     data: dataSourceViewDetails,

--- a/front/components/poke/pages/SpacePage.tsx
+++ b/front/components/poke/pages/SpacePage.tsx
@@ -1,9 +1,11 @@
 import { LinkWrapper, Spinner } from "@dust-tt/sparkle";
+import { useEffect } from "react";
 
 import { DataSourceViewsDataTable } from "@app/components/poke/data_source_views/table";
 import { MCPServerViewsDataTable } from "@app/components/poke/mcp_server_views/table";
 import { MembersDataTable } from "@app/components/poke/members/table";
 import { PluginList } from "@app/components/poke/plugins/PluginList";
+import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
 import { ViewSpaceViewTable } from "@app/components/poke/spaces/view";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { useRequiredPathParam } from "@app/lib/platform";
@@ -11,6 +13,12 @@ import { usePokeSpaceDetails } from "@app/poke/swr/space_details";
 
 export function SpacePage() {
   const owner = useWorkspace();
+  const setPageTitle = useSetPokePageTitle();
+  useEffect(
+    () => setPageTitle(`${owner.name} - Space`),
+    [setPageTitle, owner.name]
+  );
+
   const spaceId = useRequiredPathParam("spaceId");
   const {
     data: spaceDetails,

--- a/front/components/poke/pages/SpacePage.tsx
+++ b/front/components/poke/pages/SpacePage.tsx
@@ -1,5 +1,4 @@
 import { LinkWrapper, Spinner } from "@dust-tt/sparkle";
-import { useEffect } from "react";
 
 import { DataSourceViewsDataTable } from "@app/components/poke/data_source_views/table";
 import { MCPServerViewsDataTable } from "@app/components/poke/mcp_server_views/table";
@@ -13,11 +12,7 @@ import { usePokeSpaceDetails } from "@app/poke/swr/space_details";
 
 export function SpacePage() {
   const owner = useWorkspace();
-  const setPageTitle = useSetPokePageTitle();
-  useEffect(
-    () => setPageTitle(`${owner.name} - Space`),
-    [setPageTitle, owner.name]
-  );
+  useSetPokePageTitle(`${owner.name} - Space`);
 
   const spaceId = useRequiredPathParam("spaceId");
   const {

--- a/front/components/poke/pages/TemplateDetailPage.tsx
+++ b/front/components/poke/pages/TemplateDetailPage.tsx
@@ -23,6 +23,7 @@ import { useFieldArray, useForm } from "react-hook-form";
 import { MultiSelect } from "react-multi-select-component";
 
 import { makeUrlForEmojiAndBackground } from "@app/components/agent_builder/settings/avatar_picker/utils";
+import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
 import { cn } from "@app/components/poke/shadcn/lib/utils";
 import {
   PokeForm,
@@ -423,6 +424,9 @@ function PreviewDialog({ form }: { form: any }) {
 }
 
 export function TemplateDetailPage() {
+  const setPageTitle = useSetPokePageTitle();
+  useEffect(() => setPageTitle("Template"), [setPageTitle]);
+
   const templateId = useRequiredPathParam("tId");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const router = useAppRouter();

--- a/front/components/poke/pages/TemplateDetailPage.tsx
+++ b/front/components/poke/pages/TemplateDetailPage.tsx
@@ -424,8 +424,7 @@ function PreviewDialog({ form }: { form: any }) {
 }
 
 export function TemplateDetailPage() {
-  const setPageTitle = useSetPokePageTitle();
-  useEffect(() => setPageTitle("Template"), [setPageTitle]);
+  useSetPokePageTitle("Template");
 
   const templateId = useRequiredPathParam("tId");
   const [isSubmitting, setIsSubmitting] = useState(false);

--- a/front/components/poke/pages/TemplatesListPage.tsx
+++ b/front/components/poke/pages/TemplatesListPage.tsx
@@ -1,11 +1,8 @@
-import { useEffect } from "react";
-
 import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
 import { TemplatesDataTable } from "@app/components/poke/templates/TemplatesDataTable";
 
 export function TemplatesListPage() {
-  const setPageTitle = useSetPokePageTitle();
-  useEffect(() => setPageTitle("Templates"), [setPageTitle]);
+  useSetPokePageTitle("Templates");
 
   return (
     <div className="mx-auto h-full w-full max-w-7xl flex-grow flex-col items-center justify-center p-8 pt-8">

--- a/front/components/poke/pages/TemplatesListPage.tsx
+++ b/front/components/poke/pages/TemplatesListPage.tsx
@@ -1,6 +1,12 @@
+import { useEffect } from "react";
+
+import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
 import { TemplatesDataTable } from "@app/components/poke/templates/TemplatesDataTable";
 
 export function TemplatesListPage() {
+  const setPageTitle = useSetPokePageTitle();
+  useEffect(() => setPageTitle("Templates"), [setPageTitle]);
+
   return (
     <div className="mx-auto h-full w-full max-w-7xl flex-grow flex-col items-center justify-center p-8 pt-8">
       <TemplatesDataTable />

--- a/front/components/poke/pages/TriggerDetailsPage.tsx
+++ b/front/components/poke/pages/TriggerDetailsPage.tsx
@@ -1,5 +1,4 @@
 import { LinkWrapper, Spinner } from "@dust-tt/sparkle";
-import { useEffect } from "react";
 
 import { ConversationDataTable } from "@app/components/poke/conversation/table";
 import { PluginList } from "@app/components/poke/plugins/PluginList";
@@ -12,11 +11,7 @@ import { usePokeTriggerDetails } from "@app/poke/swr/trigger_details";
 
 export function TriggerDetailsPage() {
   const owner = useWorkspace();
-  const setPageTitle = useSetPokePageTitle();
-  useEffect(
-    () => setPageTitle(`${owner.name} - Trigger`),
-    [setPageTitle, owner.name]
-  );
+  useSetPokePageTitle(`${owner.name} - Trigger`);
 
   const triggerId = useRequiredPathParam("triggerId");
   const {

--- a/front/components/poke/pages/TriggerDetailsPage.tsx
+++ b/front/components/poke/pages/TriggerDetailsPage.tsx
@@ -1,7 +1,9 @@
 import { LinkWrapper, Spinner } from "@dust-tt/sparkle";
+import { useEffect } from "react";
 
 import { ConversationDataTable } from "@app/components/poke/conversation/table";
 import { PluginList } from "@app/components/poke/plugins/PluginList";
+import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
 import { PokeRecentWebhookRequests } from "@app/components/poke/triggers/RecentWebhookRequests";
 import { ViewTriggerTable } from "@app/components/poke/triggers/view";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
@@ -10,6 +12,12 @@ import { usePokeTriggerDetails } from "@app/poke/swr/trigger_details";
 
 export function TriggerDetailsPage() {
   const owner = useWorkspace();
+  const setPageTitle = useSetPokePageTitle();
+  useEffect(
+    () => setPageTitle(`${owner.name} - Trigger`),
+    [setPageTitle, owner.name]
+  );
+
   const triggerId = useRequiredPathParam("triggerId");
   const {
     data: triggerDetails,

--- a/front/components/poke/pages/WorkspacePage.tsx
+++ b/front/components/poke/pages/WorkspacePage.tsx
@@ -10,9 +10,9 @@ import {
   TabsList,
   TabsTrigger,
 } from "@dust-tt/sparkle";
+
 import { AppDataTable } from "@app/components/poke/apps/table";
 import { AssistantsDataTable } from "@app/components/poke/assistants/table";
-import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
 import { CreditsDataTable } from "@app/components/poke/credits/table";
 import { DataSourceViewsDataTable } from "@app/components/poke/data_source_views/table";
 import { DataSourceDataTable } from "@app/components/poke/data_sources/table";
@@ -20,6 +20,7 @@ import { FeatureFlagsDataTable } from "@app/components/poke/features/table";
 import { GroupDataTable } from "@app/components/poke/groups/table";
 import { MCPServerViewsDataTable } from "@app/components/poke/mcp_server_views/table";
 import { PluginList } from "@app/components/poke/plugins/PluginList";
+import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
 import {
   PokeAlert,
   PokeAlertDescription,

--- a/front/components/poke/pages/WorkspacePage.tsx
+++ b/front/components/poke/pages/WorkspacePage.tsx
@@ -10,8 +10,6 @@ import {
   TabsList,
   TabsTrigger,
 } from "@dust-tt/sparkle";
-import { useEffect } from "react";
-
 import { AppDataTable } from "@app/components/poke/apps/table";
 import { AssistantsDataTable } from "@app/components/poke/assistants/table";
 import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
@@ -46,11 +44,7 @@ import { isString } from "@app/types";
 
 export function WorkspacePage() {
   const owner = useWorkspace();
-  const setPageTitle = useSetPokePageTitle();
-  useEffect(
-    () => setPageTitle(owner.name ?? "Workspace"),
-    [setPageTitle, owner.name]
-  );
+  useSetPokePageTitle(owner.name ?? "Workspace");
 
   const router = useAppRouter();
 

--- a/front/components/poke/pages/WorkspacePage.tsx
+++ b/front/components/poke/pages/WorkspacePage.tsx
@@ -10,9 +10,11 @@ import {
   TabsList,
   TabsTrigger,
 } from "@dust-tt/sparkle";
+import { useEffect } from "react";
 
 import { AppDataTable } from "@app/components/poke/apps/table";
 import { AssistantsDataTable } from "@app/components/poke/assistants/table";
+import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
 import { CreditsDataTable } from "@app/components/poke/credits/table";
 import { DataSourceViewsDataTable } from "@app/components/poke/data_source_views/table";
 import { DataSourceDataTable } from "@app/components/poke/data_sources/table";
@@ -44,6 +46,12 @@ import { isString } from "@app/types";
 
 export function WorkspacePage() {
   const owner = useWorkspace();
+  const setPageTitle = useSetPokePageTitle();
+  useEffect(
+    () => setPageTitle(owner.name ?? "Workspace"),
+    [setPageTitle, owner.name]
+  );
+
   const router = useAppRouter();
 
   const {

--- a/front/pages/poke/[wId]/assistants/[aId]/index.tsx
+++ b/front/pages/poke/[wId]/assistants/[aId]/index.tsx
@@ -11,14 +11,7 @@ export const getServerSideProps = pokeGetServerSideProps;
 const Page = AssistantDetailsPage as PageWithLayout;
 
 Page.getLayout = (page: ReactElement, pageProps: AuthContextValue) => {
-  return (
-    <PokeLayout
-      title={`${pageProps.workspace?.name ?? "Workspace"} - Assistants`}
-      authContext={pageProps}
-    >
-      {page}
-    </PokeLayout>
-  );
+  return <PokeLayout authContext={pageProps}>{page}</PokeLayout>;
 };
 
 export default Page;

--- a/front/pages/poke/[wId]/assistants/[aId]/triggers/[triggerId]/index.tsx
+++ b/front/pages/poke/[wId]/assistants/[aId]/triggers/[triggerId]/index.tsx
@@ -11,14 +11,7 @@ export const getServerSideProps = pokeGetServerSideProps;
 const Page = TriggerDetailsPage as PageWithLayout;
 
 Page.getLayout = (page: ReactElement, pageProps: AuthContextValue) => {
-  return (
-    <PokeLayout
-      title={`${pageProps.workspace?.name ?? "Workspace"} - Trigger`}
-      authContext={pageProps}
-    >
-      {page}
-    </PokeLayout>
-  );
+  return <PokeLayout authContext={pageProps}>{page}</PokeLayout>;
 };
 
 export default Page;

--- a/front/pages/poke/[wId]/conversation/[cId]/index.tsx
+++ b/front/pages/poke/[wId]/conversation/[cId]/index.tsx
@@ -11,14 +11,7 @@ export const getServerSideProps = pokeGetServerSideProps;
 const Page = ConversationPage as PageWithLayout;
 
 Page.getLayout = (page: ReactElement, pageProps: AuthContextValue) => {
-  return (
-    <PokeLayout
-      title={`${pageProps.workspace?.name ?? "Workspace"} - Conversation`}
-      authContext={pageProps}
-    >
-      {page}
-    </PokeLayout>
-  );
+  return <PokeLayout authContext={pageProps}>{page}</PokeLayout>;
 };
 
 export default Page;

--- a/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/index.tsx
@@ -11,14 +11,7 @@ export const getServerSideProps = pokeGetServerSideProps;
 const Page = DataSourcePage as PageWithLayout;
 
 Page.getLayout = (page: ReactElement, pageProps: AuthContextValue) => {
-  return (
-    <PokeLayout
-      title={`${pageProps.workspace?.name ?? "Workspace"} - Data Source`}
-      authContext={pageProps}
-    >
-      {page}
-    </PokeLayout>
-  );
+  return <PokeLayout authContext={pageProps}>{page}</PokeLayout>;
 };
 
 export default Page;

--- a/front/pages/poke/[wId]/data_sources/[dsId]/notion-requests.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/notion-requests.tsx
@@ -11,14 +11,7 @@ export const getServerSideProps = pokeGetServerSideProps;
 const Page = NotionRequestsPage as PageWithLayout;
 
 Page.getLayout = (page: ReactElement, pageProps: AuthContextValue) => {
-  return (
-    <PokeLayout
-      title={`${pageProps.workspace?.name ?? "Workspace"} - Notion Requests`}
-      authContext={pageProps}
-    >
-      {page}
-    </PokeLayout>
-  );
+  return <PokeLayout authContext={pageProps}>{page}</PokeLayout>;
 };
 
 export default Page;

--- a/front/pages/poke/[wId]/data_sources/[dsId]/query.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/query.tsx
@@ -11,14 +11,7 @@ export const getServerSideProps = pokeGetServerSideProps;
 const Page = DataSourceQueryPage as PageWithLayout;
 
 Page.getLayout = (page: ReactElement, pageProps: AuthContextValue) => {
-  return (
-    <PokeLayout
-      title={`${pageProps.workspace?.name ?? "Workspace"} - Query`}
-      authContext={pageProps}
-    >
-      {page}
-    </PokeLayout>
-  );
+  return <PokeLayout authContext={pageProps}>{page}</PokeLayout>;
 };
 
 export default Page;

--- a/front/pages/poke/[wId]/data_sources/[dsId]/search.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/search.tsx
@@ -11,14 +11,7 @@ export const getServerSideProps = pokeGetServerSideProps;
 const Page = DataSourceSearchPage as PageWithLayout;
 
 Page.getLayout = (page: ReactElement, pageProps: AuthContextValue) => {
-  return (
-    <PokeLayout
-      title={`${pageProps.workspace?.name ?? "Workspace"} - Search`}
-      authContext={pageProps}
-    >
-      {page}
-    </PokeLayout>
-  );
+  return <PokeLayout authContext={pageProps}>{page}</PokeLayout>;
 };
 
 export default Page;

--- a/front/pages/poke/[wId]/data_sources/[dsId]/view.tsx
+++ b/front/pages/poke/[wId]/data_sources/[dsId]/view.tsx
@@ -11,14 +11,7 @@ export const getServerSideProps = pokeGetServerSideProps;
 const Page = DataSourceViewPage as PageWithLayout;
 
 Page.getLayout = (page: ReactElement, pageProps: AuthContextValue) => {
-  return (
-    <PokeLayout
-      title={`${pageProps.workspace?.name ?? "Workspace"} - View Document`}
-      authContext={pageProps}
-    >
-      {page}
-    </PokeLayout>
-  );
+  return <PokeLayout authContext={pageProps}>{page}</PokeLayout>;
 };
 
 export default Page;

--- a/front/pages/poke/[wId]/files/[sId]/index.tsx
+++ b/front/pages/poke/[wId]/files/[sId]/index.tsx
@@ -11,14 +11,7 @@ export const getServerSideProps = pokeGetServerSideProps;
 const Page = FramePage as PageWithLayout;
 
 Page.getLayout = (page: ReactElement, pageProps: AuthContextValue) => {
-  return (
-    <PokeLayout
-      title={`${pageProps.workspace?.name ?? "Workspace"} - File`}
-      authContext={pageProps}
-    >
-      {page}
-    </PokeLayout>
-  );
+  return <PokeLayout authContext={pageProps}>{page}</PokeLayout>;
 };
 
 export default Page;

--- a/front/pages/poke/[wId]/groups/[groupId]/index.tsx
+++ b/front/pages/poke/[wId]/groups/[groupId]/index.tsx
@@ -11,14 +11,7 @@ export const getServerSideProps = pokeGetServerSideProps;
 const Page = GroupPage as PageWithLayout;
 
 Page.getLayout = (page: ReactElement, pageProps: AuthContextValue) => {
-  return (
-    <PokeLayout
-      title={`${pageProps.workspace?.name ?? "Workspace"} - Group`}
-      authContext={pageProps}
-    >
-      {page}
-    </PokeLayout>
-  );
+  return <PokeLayout authContext={pageProps}>{page}</PokeLayout>;
 };
 
 export default Page;

--- a/front/pages/poke/[wId]/index.tsx
+++ b/front/pages/poke/[wId]/index.tsx
@@ -11,14 +11,7 @@ export const getServerSideProps = pokeGetServerSideProps;
 const Page = WorkspacePage as PageWithLayout;
 
 Page.getLayout = (page: ReactElement, pageProps: AuthContextValue) => {
-  return (
-    <PokeLayout
-      title={`${pageProps.workspace?.name ?? "Workspace"}`}
-      authContext={pageProps}
-    >
-      {page}
-    </PokeLayout>
-  );
+  return <PokeLayout authContext={pageProps}>{page}</PokeLayout>;
 };
 
 export default Page;

--- a/front/pages/poke/[wId]/llm-traces/[runId].tsx
+++ b/front/pages/poke/[wId]/llm-traces/[runId].tsx
@@ -11,14 +11,7 @@ export const getServerSideProps = pokeGetServerSideProps;
 const Page = LLMTracePage as PageWithLayout;
 
 Page.getLayout = (page: ReactElement, pageProps: AuthContextValue) => {
-  return (
-    <PokeLayout
-      title={`${pageProps.workspace?.name ?? "Workspace"} - LLM Trace`}
-      authContext={pageProps}
-    >
-      {page}
-    </PokeLayout>
-  );
+  return <PokeLayout authContext={pageProps}>{page}</PokeLayout>;
 };
 
 export default Page;

--- a/front/pages/poke/[wId]/memberships.tsx
+++ b/front/pages/poke/[wId]/memberships.tsx
@@ -11,14 +11,7 @@ export const getServerSideProps = pokeGetServerSideProps;
 const Page = MembershipsPage as PageWithLayout;
 
 Page.getLayout = (page: ReactElement, pageProps: AuthContextValue) => {
-  return (
-    <PokeLayout
-      title={`${pageProps.workspace?.name ?? "Workspace"} - Memberships`}
-      authContext={pageProps}
-    >
-      {page}
-    </PokeLayout>
-  );
+  return <PokeLayout authContext={pageProps}>{page}</PokeLayout>;
 };
 
 export default Page;

--- a/front/pages/poke/[wId]/skills/[sId]/index.tsx
+++ b/front/pages/poke/[wId]/skills/[sId]/index.tsx
@@ -11,14 +11,7 @@ export const getServerSideProps = pokeGetServerSideProps;
 const Page = SkillDetailsPage as PageWithLayout;
 
 Page.getLayout = (page: ReactElement, pageProps: AuthContextValue) => {
-  return (
-    <PokeLayout
-      title={`${pageProps.workspace?.name ?? "Workspace"} - Skill`}
-      authContext={pageProps}
-    >
-      {page}
-    </PokeLayout>
-  );
+  return <PokeLayout authContext={pageProps}>{page}</PokeLayout>;
 };
 
 export default Page;

--- a/front/pages/poke/[wId]/spaces/[spaceId]/apps/[appId]/index.tsx
+++ b/front/pages/poke/[wId]/spaces/[spaceId]/apps/[appId]/index.tsx
@@ -11,14 +11,7 @@ export const getServerSideProps = pokeGetServerSideProps;
 const Page = AppPage as PageWithLayout;
 
 Page.getLayout = (page: ReactElement, pageProps: AuthContextValue) => {
-  return (
-    <PokeLayout
-      title={`${pageProps.workspace?.name ?? "Workspace"} - App`}
-      authContext={pageProps}
-    >
-      {page}
-    </PokeLayout>
-  );
+  return <PokeLayout authContext={pageProps}>{page}</PokeLayout>;
 };
 
 export default Page;

--- a/front/pages/poke/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.tsx
+++ b/front/pages/poke/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.tsx
@@ -11,14 +11,7 @@ export const getServerSideProps = pokeGetServerSideProps;
 const Page = SpaceDataSourceViewPage as PageWithLayout;
 
 Page.getLayout = (page: ReactElement, pageProps: AuthContextValue) => {
-  return (
-    <PokeLayout
-      title={`${pageProps.workspace?.name ?? "Workspace"} - Data Source View`}
-      authContext={pageProps}
-    >
-      {page}
-    </PokeLayout>
-  );
+  return <PokeLayout authContext={pageProps}>{page}</PokeLayout>;
 };
 
 export default Page;

--- a/front/pages/poke/[wId]/spaces/[spaceId]/index.tsx
+++ b/front/pages/poke/[wId]/spaces/[spaceId]/index.tsx
@@ -11,14 +11,7 @@ export const getServerSideProps = pokeGetServerSideProps;
 const Page = SpacePage as PageWithLayout;
 
 Page.getLayout = (page: ReactElement, pageProps: AuthContextValue) => {
-  return (
-    <PokeLayout
-      title={`${pageProps.workspace?.name ?? "Workspace"} - Space`}
-      authContext={pageProps}
-    >
-      {page}
-    </PokeLayout>
-  );
+  return <PokeLayout authContext={pageProps}>{page}</PokeLayout>;
 };
 
 export default Page;

--- a/front/pages/poke/[wId]/spaces/[spaceId]/mcp_server_views/[svId]/index.tsx
+++ b/front/pages/poke/[wId]/spaces/[spaceId]/mcp_server_views/[svId]/index.tsx
@@ -11,14 +11,7 @@ export const getServerSideProps = pokeGetServerSideProps;
 const Page = MCPServerViewPage as PageWithLayout;
 
 Page.getLayout = (page: ReactElement, pageProps: AuthContextValue) => {
-  return (
-    <PokeLayout
-      title={`${pageProps.workspace?.name ?? "Workspace"} - MCP Server View`}
-      authContext={pageProps}
-    >
-      {page}
-    </PokeLayout>
-  );
+  return <PokeLayout authContext={pageProps}>{page}</PokeLayout>;
 };
 
 export default Page;

--- a/front/pages/poke/connectors/[connectorId]/index.tsx
+++ b/front/pages/poke/connectors/[connectorId]/index.tsx
@@ -15,7 +15,7 @@ Page.getLayout = (
   pageProps: AuthContextNoWorkspaceValue
 ) => {
   return (
-    <PokeLayoutNoWorkspace title="Connector Redirect" authContext={pageProps}>
+    <PokeLayoutNoWorkspace authContext={pageProps}>
       {page}
     </PokeLayoutNoWorkspace>
   );

--- a/front/pages/poke/email-templates/index.tsx
+++ b/front/pages/poke/email-templates/index.tsx
@@ -15,7 +15,7 @@ Page.getLayout = (
   pageProps: AuthContextNoWorkspaceValue
 ) => {
   return (
-    <PokeLayoutNoWorkspace title="Email Templates" authContext={pageProps}>
+    <PokeLayoutNoWorkspace authContext={pageProps}>
       {page}
     </PokeLayoutNoWorkspace>
   );

--- a/front/pages/poke/index.tsx
+++ b/front/pages/poke/index.tsx
@@ -15,7 +15,7 @@ Page.getLayout = (
   pageProps: AuthContextNoWorkspaceValue
 ) => {
   return (
-    <PokeLayoutNoWorkspace title="Home" authContext={pageProps}>
+    <PokeLayoutNoWorkspace authContext={pageProps}>
       {page}
     </PokeLayoutNoWorkspace>
   );

--- a/front/pages/poke/kill.tsx
+++ b/front/pages/poke/kill.tsx
@@ -15,7 +15,7 @@ Page.getLayout = (
   pageProps: AuthContextNoWorkspaceValue
 ) => {
   return (
-    <PokeLayoutNoWorkspace title="Kill Switches" authContext={pageProps}>
+    <PokeLayoutNoWorkspace authContext={pageProps}>
       {page}
     </PokeLayoutNoWorkspace>
   );

--- a/front/pages/poke/plans.tsx
+++ b/front/pages/poke/plans.tsx
@@ -15,7 +15,7 @@ Page.getLayout = (
   pageProps: AuthContextNoWorkspaceValue
 ) => {
   return (
-    <PokeLayoutNoWorkspace title="Plans" authContext={pageProps}>
+    <PokeLayoutNoWorkspace authContext={pageProps}>
       {page}
     </PokeLayoutNoWorkspace>
   );

--- a/front/pages/poke/plugins/index.tsx
+++ b/front/pages/poke/plugins/index.tsx
@@ -15,7 +15,7 @@ Page.getLayout = (
   pageProps: AuthContextNoWorkspaceValue
 ) => {
   return (
-    <PokeLayoutNoWorkspace title="Plugins" authContext={pageProps}>
+    <PokeLayoutNoWorkspace authContext={pageProps}>
       {page}
     </PokeLayoutNoWorkspace>
   );

--- a/front/pages/poke/pokefy.tsx
+++ b/front/pages/poke/pokefy.tsx
@@ -15,7 +15,7 @@ Page.getLayout = (
   pageProps: AuthContextNoWorkspaceValue
 ) => {
   return (
-    <PokeLayoutNoWorkspace title="Pokefy" authContext={pageProps}>
+    <PokeLayoutNoWorkspace authContext={pageProps}>
       {page}
     </PokeLayoutNoWorkspace>
   );

--- a/front/pages/poke/production-checks.tsx
+++ b/front/pages/poke/production-checks.tsx
@@ -15,7 +15,7 @@ Page.getLayout = (
   pageProps: AuthContextNoWorkspaceValue
 ) => {
   return (
-    <PokeLayoutNoWorkspace title="Production Checks" authContext={pageProps}>
+    <PokeLayoutNoWorkspace authContext={pageProps}>
       {page}
     </PokeLayoutNoWorkspace>
   );

--- a/front/pages/poke/templates/[tId].tsx
+++ b/front/pages/poke/templates/[tId].tsx
@@ -15,7 +15,7 @@ Page.getLayout = (
   pageProps: AuthContextNoWorkspaceValue
 ) => {
   return (
-    <PokeLayoutNoWorkspace title="Template" authContext={pageProps}>
+    <PokeLayoutNoWorkspace authContext={pageProps}>
       {page}
     </PokeLayoutNoWorkspace>
   );

--- a/front/pages/poke/templates/index.tsx
+++ b/front/pages/poke/templates/index.tsx
@@ -15,7 +15,7 @@ Page.getLayout = (
   pageProps: AuthContextNoWorkspaceValue
 ) => {
   return (
-    <PokeLayoutNoWorkspace title="Templates" authContext={pageProps}>
+    <PokeLayoutNoWorkspace authContext={pageProps}>
       {page}
     </PokeLayoutNoWorkspace>
   );


### PR DESCRIPTION
Fixes: https://github.com/dust-tt/tasks/issues/6187

## Description

Moved page titles to state, used in layout.
Poke pages only.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

low

## Deploy Plan

deploy front.

