### PR TITLE
[front & sparkle] add new icon size to Button

### DIFF
--- a/extension/ui/components/input_bar/InputBarContainer.tsx
+++ b/extension/ui/components/input_bar/InputBarContainer.tsx
@@ -318,7 +318,7 @@ export const InputBarContainer = ({
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button
-                  size="mini"
+                  size="icon"
                   variant="highlight"
                   icon={ChevronDownIcon}
                   disabled={disabled}

--- a/front/components/agent_builder/FeedbacksSection.tsx
+++ b/front/components/agent_builder/FeedbacksSection.tsx
@@ -288,7 +288,7 @@ function FeedbackCard({
       action={
         <div className="flex gap-1">
           <CardActionButton
-            size="mini"
+            size="icon"
             icon={feedback.dismissed ? EyeIcon : EyeSlashIcon}
             onClick={() => toggleDismiss(!feedback.dismissed)}
             disabled={isDismissing}
@@ -296,7 +296,7 @@ function FeedbackCard({
           />
           {conversationUrl && (
             <CardActionButton
-              size="mini"
+              size="icon"
               icon={ExternalLinkIcon}
               href={conversationUrl ?? ""}
               disabled={!conversationUrl}

--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeFooter.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeFooter.tsx
@@ -85,7 +85,7 @@ function KnowledgeFooterItem({
       visual={<Icon size="sm" visual={VisualComponent} />}
       action={
         <Button
-          size="mini"
+          size="icon"
           variant="ghost"
           icon={XMarkIcon}
           onClick={() => removeNodeWithPath(item)}

--- a/front/components/agent_builder/skills/AgentBuilderSkillsBlock.tsx
+++ b/front/components/agent_builder/skills/AgentBuilderSkillsBlock.tsx
@@ -61,7 +61,7 @@ function SkillCard({ skill, onRemove, onClick }: SkillCardProps) {
       onClick={onClick}
       action={
         <CardActionButton
-          size="mini"
+          size="icon"
           icon={XMarkIcon}
           onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
             onRemove();

--- a/front/components/agent_builder/triggers/TriggerCard.tsx
+++ b/front/components/agent_builder/triggers/TriggerCard.tsx
@@ -90,7 +90,7 @@ export const TriggerCard = ({
       action={
         (isEditor || isAdmin) && (
           <CardActionButton
-            size="mini"
+            size="icon"
             icon={XMarkIcon}
             onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
               e.stopPropagation();

--- a/front/components/app/DatasetView.tsx
+++ b/front/components/app/DatasetView.tsx
@@ -618,7 +618,7 @@ export default function DatasetView({
                             {datasetKeys.length > 1 ? (
                               <>
                                 <Button
-                                  size="mini"
+                                  size="icon"
                                   variant="ghost"
                                   className="text-muted-foreground"
                                   icon={XCircleIcon}
@@ -629,7 +629,7 @@ export default function DatasetView({
                                 />
 
                                 <Button
-                                  size="mini"
+                                  size="icon"
                                   variant="ghost"
                                   className="text-muted-foreground"
                                   icon={PlusCircleIcon}
@@ -798,7 +798,7 @@ export default function DatasetView({
                         {datasetData.length > 1 ? (
                           <Button
                             icon={XCircleIcon}
-                            size="mini"
+                            size="icon"
                             variant="ghost"
                             onClick={() => {
                               handleDeleteEntry(i);
@@ -807,7 +807,7 @@ export default function DatasetView({
                         ) : null}
                         <Button
                           icon={PlusCircleIcon}
-                          size="mini"
+                          size="icon"
                           variant="ghost"
                           onClick={() => {
                             handleNewEntry(i);

--- a/front/components/app/NewBlock.tsx
+++ b/front/components/app/NewBlock.tsx
@@ -130,7 +130,7 @@ export default function NewBlock({
             icon={PlusIcon}
             disabled={disabled}
             variant="ghost-secondary"
-            size="mini"
+            size="icon"
           />
         ) : (
           <Button

--- a/front/components/app/blocks/Block.tsx
+++ b/front/components/app/blocks/Block.tsx
@@ -123,7 +123,7 @@ export default function Block({
                     : "Results are computed at each run"
                 }
                 variant="ghost-secondary"
-                size="mini"
+                size="icon"
                 icon={
                   block.config && block.config.use_cache
                     ? Square3Stack3DIcon
@@ -145,19 +145,19 @@ export default function Block({
                   variant="ghost-secondary"
                   icon={ChevronUpIcon}
                   onClick={onBlockUp}
-                  size="mini"
+                  size="icon"
                 />
                 <Button
                   variant="ghost-secondary"
                   icon={ChevronDownIcon}
                   onClick={onBlockDown}
-                  size="mini"
+                  size="icon"
                 />
                 <Button
                   variant="ghost-secondary"
                   icon={TrashIcon}
                   onClick={onBlockDelete}
-                  size="mini"
+                  size="icon"
                 />
               </>
             )}

--- a/front/components/app/blocks/Output.tsx
+++ b/front/components/app/blocks/Output.tsx
@@ -353,7 +353,7 @@ const JsonCopyLink = ({ value }: { value: string }) => {
           onClick={handleClick}
           tooltip="Copy JSON to clipboard"
           icon={ClipboardIcon}
-          size="mini"
+          size="icon"
           variant="ghost-secondary"
         />
       )}

--- a/front/components/assistant/conversation/MessageEmojiPicker.tsx
+++ b/front/components/assistant/conversation/MessageEmojiPicker.tsx
@@ -32,7 +32,7 @@ export function MessageEmojiPicker({
           key="emoji-picker-button"
           tooltip="Add reaction"
           variant="outline"
-          size="xs"
+          size="xmini"
           icon={EmotionLaughIcon}
           isSelect={true}
           className={cn("text-muted-foreground", className)}

--- a/front/components/assistant/conversation/MessageEmojiPicker.tsx
+++ b/front/components/assistant/conversation/MessageEmojiPicker.tsx
@@ -32,10 +32,10 @@ export function MessageEmojiPicker({
           key="emoji-picker-button"
           tooltip="Add reaction"
           variant="outline"
-          size="xmini"
+          size="mini"
           icon={EmotionLaughIcon}
-          isSelect={true}
-          className={cn("text-muted-foreground", className)}
+          isSelect
+          className={cn("text-muted-foreground w-12", className)}
         />
       </PopoverTrigger>
       <PopoverContent fullWidth>

--- a/front/components/assistant/conversation/MessageEmojiPicker.tsx
+++ b/front/components/assistant/conversation/MessageEmojiPicker.tsx
@@ -32,10 +32,10 @@ export function MessageEmojiPicker({
           key="emoji-picker-button"
           tooltip="Add reaction"
           variant="outline"
-          size="mini"
+          size="xmini"
           icon={EmotionLaughIcon}
           isSelect
-          className={cn("text-muted-foreground w-12", className)}
+          className={cn("text-muted-foreground", className)}
         />
       </PopoverTrigger>
       <PopoverContent fullWidth>

--- a/front/components/assistant/conversation/MessageReactions.tsx
+++ b/front/components/assistant/conversation/MessageReactions.tsx
@@ -64,7 +64,7 @@ export function MessageReactions({
           trigger={
             <Button
               label={`+${hiddenReactions.length}`}
-              size="xs"
+              size="xmini"
               variant="outline"
               aria-label="More reactions"
             />

--- a/front/components/assistant/conversation/ReactionPill.tsx
+++ b/front/components/assistant/conversation/ReactionPill.tsx
@@ -36,7 +36,7 @@ export function ReactionPill({
       trigger={
         <Button
           label={`${emoji} ${count}`}
-          size="xs"
+          size="xmini"
           variant={hasCurrentUserReacted ? "primary" : "outline"}
           onClick={onClick}
         />

--- a/front/components/assistant/conversation/UserMessage.tsx
+++ b/front/components/assistant/conversation/UserMessage.tsx
@@ -496,7 +496,7 @@ function ActionMenu({
           <DropdownMenuTrigger asChild>
             <Button
               icon={MoreIcon}
-              size="xs"
+              size="icon-xs"
               variant="outline"
               aria-label="Message actions"
               className={cn(

--- a/front/components/assistant/details/tabs/AgentMemoryTab.tsx
+++ b/front/components/assistant/details/tabs/AgentMemoryTab.tsx
@@ -137,7 +137,7 @@ export function AgentMemoryTab({
                     className="flex flex-col gap-2"
                     action={
                       <CardActionButton
-                        size="mini"
+                        size="icon"
                         icon={TrashIcon}
                         onClick={() => {
                           setMemoryToDelete(memory.sId);

--- a/front/components/shared/tools_picker/ActionCard.tsx
+++ b/front/components/shared/tools_picker/ActionCard.tsx
@@ -54,7 +54,7 @@ export function ActionCard({ action, onRemove, onClick }: ActionCardProps) {
       onClick={onClick}
       action={
         <CardActionButton
-          size="mini"
+          size="icon"
           icon={XMarkIcon}
           onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
             onRemove();

--- a/front/components/skills/SuggestedSkillsSection.tsx
+++ b/front/components/skills/SuggestedSkillsSection.tsx
@@ -64,7 +64,7 @@ function SuggestedSkillCard({
         onClick={onMoreInfoClick}
         action={
           <CardActionButton
-            size="mini"
+            size="icon"
             icon={XMarkIcon}
             onClick={(e) => {
               e.stopPropagation();

--- a/sparkle/playground/src/components/ConversationView.tsx
+++ b/sparkle/playground/src/components/ConversationView.tsx
@@ -181,13 +181,13 @@ export function ConversationView({
         rightActions={
           <div className="s-flex s-gap-2">
             <Button
-              size="mini"
+              size="icon"
               variant="ghost"
               icon={FolderIcon}
               onClick={onBack}
             />
             <Button
-              size="mini"
+              size="icon"
               variant="ghost"
               icon={MoreIcon}
               onClick={onBack}

--- a/sparkle/playground/src/components/RichTextArea.tsx
+++ b/sparkle/playground/src/components/RichTextArea.tsx
@@ -1229,7 +1229,7 @@ export const RichTextArea = forwardRef<RichTextAreaHandle, RichTextAreaProps>(
               <HoveringBar size="xs">
                 <Button
                   icon={BoldIcon}
-                  size="mini"
+                  size="icon"
                   variant={
                     editor.isActive("bold") ? "primary" : "ghost-secondary"
                   }
@@ -1240,7 +1240,7 @@ export const RichTextArea = forwardRef<RichTextAreaHandle, RichTextAreaProps>(
                 />
                 <Button
                   icon={ItalicIcon}
-                  size="mini"
+                  size="icon"
                   variant={
                     editor.isActive("italic") ? "primary" : "ghost-secondary"
                   }
@@ -1252,7 +1252,7 @@ export const RichTextArea = forwardRef<RichTextAreaHandle, RichTextAreaProps>(
                 <HoveringBar.Separator />
                 <Button
                   icon={LinkIcon}
-                  size="mini"
+                  size="icon"
                   variant={
                     editor.isActive("link") ? "primary" : "ghost-secondary"
                   }

--- a/sparkle/playground/src/stories/AgentBuilder.tsx
+++ b/sparkle/playground/src/stories/AgentBuilder.tsx
@@ -539,20 +539,20 @@ export default function AgentBuilder() {
                         <div className="s-flex s-flex-1 s-flex-wrap s-items-center s-gap-2 s-px-3 s-py-2">
                           <Button
                             icon={HeadingIcon}
-                            size="mini"
+                            size="icon"
                             variant="ghost-secondary"
                             tooltip="Heading"
                           />
                           <Button
                             icon={BoldIcon}
-                            size="mini"
+                            size="icon"
                             variant="ghost-secondary"
                             tooltip="Bold"
                             tooltipShortcut="Cmd+B"
                           />
                           <Button
                             icon={ItalicIcon}
-                            size="mini"
+                            size="icon"
                             variant="ghost-secondary"
                             tooltip="Italic"
                             tooltipShortcut="Cmd+I"
@@ -560,39 +560,39 @@ export default function AgentBuilder() {
                           <Separator orientation="vertical" />
                           <Button
                             icon={LinkIcon}
-                            size="mini"
+                            size="icon"
                             variant="ghost-secondary"
                             tooltip="Insert a link"
                           />
                           <Button
                             icon={ListCheckIcon}
-                            size="mini"
+                            size="icon"
                             variant="ghost-secondary"
                             tooltip="Bulleted list"
                           />
                           <Button
                             icon={ListOrdered2Icon}
-                            size="mini"
+                            size="icon"
                             variant="ghost-secondary"
                             tooltip="Ordered list"
                           />
                           <Separator orientation="vertical" />
                           <Button
                             icon={QuoteTextIcon}
-                            size="mini"
+                            size="icon"
                             variant="ghost-secondary"
                             tooltip="Quotation block"
                           />
                           <Button
                             icon={CodeBlockIcon}
-                            size="mini"
+                            size="icon"
                             variant="ghost-secondary"
                             tooltip="Code Block"
                           />
                           <Separator orientation="vertical" />
                           <Button
                             icon={TagBlockIcon}
-                            size="mini"
+                            size="icon"
                             variant="ghost-secondary"
                             tooltip="XML tag"
                           />
@@ -600,7 +600,7 @@ export default function AgentBuilder() {
                           <DropdownMenu>
                             <DropdownMenuTrigger asChild>
                               <Button
-                                size="mini"
+                                size="icon"
                                 variant="ghost-secondary"
                                 icon={HistoryIcon}
                                 isSelect

--- a/sparkle/playground/src/stories/Projects.tsx
+++ b/sparkle/playground/src/stories/Projects.tsx
@@ -957,7 +957,7 @@ function DustMain() {
         </DropdownMenu>
         <Button
           variant="ghost-secondary"
-          size="mini"
+          size="icon"
           icon={isSidebarCollapsed ? SidebarLeftOpenIcon : SidebarLeftCloseIcon}
           onClick={() => sidebarLayoutRef.current?.toggle()}
         />

--- a/sparkle/playground/src/stories/Spaces.tsx
+++ b/sparkle/playground/src/stories/Spaces.tsx
@@ -757,7 +757,7 @@ function DustMain() {
         </DropdownMenu>
         <Button
           variant="ghost-secondary"
-          size="mini"
+          size="icon"
           icon={isSidebarCollapsed ? SidebarLeftOpenIcon : SidebarLeftCloseIcon}
           onClick={() => sidebarLayoutRef.current?.toggle()}
         />

--- a/sparkle/src/components/AssistantCard.tsx
+++ b/sparkle/src/components/AssistantCard.tsx
@@ -4,7 +4,7 @@ import {
   Avatar,
   Card,
   CardActionButton,
-  MiniButtonProps,
+  IconOnlyButtonProps,
 } from "@sparkle/components/";
 import { CardVariantType } from "@sparkle/components/Card";
 import { MoreIcon } from "@sparkle/icons/app/";
@@ -21,13 +21,13 @@ interface BaseAssistantCardProps {
   variant?: CardVariantType;
 }
 
-type AssistantCardMore = Omit<MiniButtonProps, "icon" | "size">;
+type AssistantCardMore = Omit<IconOnlyButtonProps, "icon" | "size">;
 
 export const AssistantCardMore = React.forwardRef<
   HTMLButtonElement,
   AssistantCardMore
 >(({ ...props }, ref) => {
-  return <CardActionButton size="mini" ref={ref} icon={MoreIcon} {...props} />;
+  return <CardActionButton size="icon" ref={ref} icon={MoreIcon} {...props} />;
 });
 AssistantCardMore.displayName = "AssistantCardMore";
 

--- a/sparkle/src/components/Button.tsx
+++ b/sparkle/src/components/Button.tsx
@@ -442,6 +442,8 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         disabled={isLoading || props.disabled}
         className={cn(
           (isPulsing || isPulsingBriefly) && "s-animate-pulse",
+          isSelect && (size === "xmini" || size === "icon-xs") && "s-w-auto s-px-1.5",
+          isSelect && (size === "mini" || size === "icon") && "s-w-auto s-px-2",
           className
         )}
         aria-label={ariaLabel || tooltip || label}

--- a/sparkle/src/components/Button.tsx
+++ b/sparkle/src/components/Button.tsx
@@ -231,8 +231,8 @@ const chevronVariantMap = {
 
 export interface MetaButtonProps
   extends
-  React.ButtonHTMLAttributes<HTMLButtonElement>,
-  VariantProps<typeof buttonVariants> {
+    React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
   asChild?: boolean;
   isRounded?: boolean;
 }

--- a/sparkle/src/components/Button.tsx
+++ b/sparkle/src/components/Button.tsx
@@ -287,6 +287,40 @@ const COUNTER_SIZE_MAP: Record<ButtonSize, CounterSizeType> = {
   md: "md",
 };
 
+const loadingContainerVariants = cva("-s-mx-0.5", {
+  variants: {
+    size: {
+      "icon-xs": "s-w-5 s-px-0.5",
+      icon: "s-w-5 s-px-0.5",
+      xmini: "s-w-5 s-px-0.5",
+      mini: "s-w-5 s-px-0.5",
+      xs: "s-w-5 s-px-0.5",
+      sm: "",
+      md: "",
+    },
+  },
+  defaultVariants: {
+    size: "sm",
+  },
+});
+
+const selectButtonSizeVariants = cva("", {
+  variants: {
+    size: {
+      "icon-xs": "s-w-auto s-px-1.5",
+      xmini: "s-w-auto s-px-1.5",
+      mini: "s-w-auto s-px-2",
+      icon: "s-w-auto s-px-2",
+      xs: "",
+      sm: "",
+      md: "",
+    },
+  },
+  defaultVariants: {
+    size: "sm",
+  },
+});
+
 type CommonButtonProps = Omit<MetaButtonProps, "children"> &
   Omit<LinkWrapperProps, "children"> & {
     isSelect?: boolean;
@@ -378,10 +412,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       <>
         {isLoading ? (
           <div
-            className={cn(
-              "-s-mx-0.5",
-              isSmallButtonSize(size) && "s-w-5 s-px-0.5"
-            )}
+            className={loadingContainerVariants({ size })}
           >
             <Spinner
               size={isSmallButtonSize(size) ? "xs" : iconSize}
@@ -442,8 +473,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         disabled={isLoading || props.disabled}
         className={cn(
           (isPulsing || isPulsingBriefly) && "s-animate-pulse",
-          isSelect && (size === "xmini" || size === "icon-xs") && "s-w-auto s-px-1.5",
-          isSelect && (size === "mini" || size === "icon") && "s-w-auto s-px-2",
+          isSelect && selectButtonSizeVariants({ size }),
           className
         )}
         aria-label={ariaLabel || tooltip || label}

--- a/sparkle/src/components/Button.tsx
+++ b/sparkle/src/components/Button.tsx
@@ -9,11 +9,7 @@ import {
   LinkWrapper,
   LinkWrapperProps,
   Spinner,
-  TooltipContent,
-  TooltipPortal,
-  TooltipProvider,
-  TooltipRoot,
-  TooltipTrigger,
+  Tooltip,
 } from "@sparkle/components/";
 import { SpinnerProps } from "@sparkle/components/Spinner";
 import { ChevronDownIcon } from "@sparkle/icons/app";
@@ -298,6 +294,7 @@ type CommonButtonProps = Omit<MetaButtonProps, "children"> &
     isPulsing?: boolean;
     briefPulse?: boolean;
     tooltip?: string;
+    tooltipShortcut?: string;
     isCounter?: boolean;
     counterValue?: string;
     isRounded?: boolean;
@@ -326,6 +323,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       isLoading = false,
       variant = "primary",
       tooltip,
+      tooltipShortcut,
       isSelect = false,
       isPulsing = false,
       briefPulse = false,
@@ -462,14 +460,12 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     );
 
     const wrappedContent = tooltip ? (
-      <TooltipProvider>
-        <TooltipRoot>
-          <TooltipTrigger asChild>{innerButton}</TooltipTrigger>
-          <TooltipPortal>
-            <TooltipContent>{tooltip}</TooltipContent>
-          </TooltipPortal>
-        </TooltipRoot>
-      </TooltipProvider>
+      <Tooltip
+        trigger={innerButton}
+        tooltipTriggerAsChild={true}
+        label={tooltip}
+        shortcut={tooltipShortcut}
+      />
     ) : (
       innerButton
     );

--- a/sparkle/src/components/Button.tsx
+++ b/sparkle/src/components/Button.tsx
@@ -60,7 +60,7 @@ function isSmallButtonSize(
 // Define button styling with cva
 const buttonVariants = cva(
   cn(
-    "s-inline-flex s-items-center s-justify-center s-whitespace-nowrap s-ring-offset-background s-transition-colors s-ring-inset s-select-none",
+    "s-box-content s-inline-flex s-items-center s-justify-center s-whitespace-nowrap s-ring-offset-background s-transition-colors s-ring-inset s-select-none",
     "focus-visible:s-outline-none focus-visible:s-ring-2 focus-visible:s-ring-ring focus-visible:s-ring-offset-0",
     "dark:focus-visible:s-ring-0 dark:focus-visible:s-ring-offset-1"
   ),

--- a/sparkle/src/components/Button.tsx
+++ b/sparkle/src/components/Button.tsx
@@ -303,10 +303,6 @@ type CommonButtonProps = Omit<MetaButtonProps, "children"> &
     isRounded?: boolean;
   };
 
-/**
- * Icon-only button sizes (fixed width).
- * When using these sizes, an icon is required and labels are not allowed.
- */
 export type IconOnlyButtonProps = CommonButtonProps & {
   size: IconOnlySize;
   icon: React.ComponentType;

--- a/sparkle/src/components/Card.tsx
+++ b/sparkle/src/components/Card.tsx
@@ -1,7 +1,8 @@
 import { cva } from "class-variance-authority";
 import React from "react";
 
-import { Button, MiniButtonProps } from "@sparkle/components/Button";
+import type { IconOnlyButtonProps } from "@sparkle/components/Button";
+import { Button } from "@sparkle/components/Button";
 import { LinkWrapperProps } from "@sparkle/components/LinkWrapper";
 import {
   noHrefLink,
@@ -227,7 +228,7 @@ CardActions.displayName = "CardActions";
 
 export const CardActionButton = React.forwardRef<
   HTMLButtonElement,
-  MiniButtonProps
+  IconOnlyButtonProps
 >(({ className, variant = "outline", icon = XMarkIcon, ...props }, ref) => {
   return (
     <Button

--- a/sparkle/src/components/Citation.tsx
+++ b/sparkle/src/components/Citation.tsx
@@ -163,7 +163,7 @@ const CitationClose = React.forwardRef<HTMLButtonElement, CitationCloseProps>(
       <Button
         ref={ref}
         variant="ghost"
-        size="mini"
+        size="icon"
         className={className}
         icon={XMarkIcon}
         onClick={(e) => {

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -984,7 +984,7 @@ DataTable.MoreButton = function MoreButton({
       >
         <Button
           icon={MoreIcon}
-          size="mini"
+          size="icon"
           variant="ghost-secondary"
           disabled={disabled}
           className={cn(

--- a/sparkle/src/components/Toolbar.tsx
+++ b/sparkle/src/components/Toolbar.tsx
@@ -121,7 +121,7 @@ function Toolbar({
     };
 
     if (closeButtonSize === "mini") {
-      return <Button size="mini" {...buttonProps} />;
+      return <Button size="icon" {...buttonProps} />;
     }
 
     return <Button size={closeButtonSize} {...buttonProps} />;
@@ -205,7 +205,7 @@ function ToolbarIcon({
         tooltip={tooltip}
         icon={icon}
         onClick={handleClick}
-        size="mini"
+        size="icon"
         variant={active ? "ghost" : "ghost-secondary"}
       />
     );

--- a/sparkle/src/components/VoicePicker.tsx
+++ b/sparkle/src/components/VoicePicker.tsx
@@ -1,6 +1,9 @@
 import * as React from "react";
 
-import type { ButtonProps, ButtonSizeType } from "@sparkle/components/Button";
+import type {
+  ButtonProps,
+  RegularButtonSize,
+} from "@sparkle/components/Button";
 import { Button } from "@sparkle/components/Button";
 import { MicIcon, SquareIcon } from "@sparkle/icons/app";
 import { cn } from "@sparkle/lib/utils";
@@ -24,7 +27,7 @@ export interface VoicePickerProps {
   elapsedSeconds: number;
   onRecordStart: () => void | Promise<void>;
   onRecordStop: () => void | Promise<void>;
-  size?: Exclude<ButtonSizeType, "xmini" | "mini">;
+  size?: Exclude<RegularButtonSize, "xmini" | "mini">;
   disabled?: boolean;
   showStopLabel?: boolean;
   pressDelayMs?: number;

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -13,7 +13,7 @@ export type { BreadcrumbItem } from "./Breadcrumbs";
 export { Breadcrumbs } from "./Breadcrumbs";
 export type {
   ButtonProps,
-  MiniButtonProps,
+  IconOnlyButtonProps,
   RegularButtonProps,
 } from "./Button";
 export { Button } from "./Button";

--- a/sparkle/src/stories/Button.stories.tsx
+++ b/sparkle/src/stories/Button.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import React from "react";
 
-import { BUTTON_SIZES, BUTTON_VARIANTS } from "@sparkle/components/Button";
+import { REGULAR_BUTTON_SIZES, BUTTON_VARIANTS } from "@sparkle/components/Button";
 
 import { Button, PlusIcon, RobotIcon, Separator } from "../index_with_tw_base";
 
@@ -24,7 +24,7 @@ const meta = {
     size: {
       description:
         "The size of the button (Note: 'mini' size requires an icon and cannot have a label)",
-      options: BUTTON_SIZES,
+      options: REGULAR_BUTTON_SIZES,
       control: { type: "select" },
     },
     icon: {
@@ -101,13 +101,14 @@ export const ExampleButton: Story = {
 };
 
 export const MiniButton: Story = {
-  render: () => <Button size="mini" icon={PlusIcon} />,
+  render: () => <Button size="icon" icon={PlusIcon} />,
 };
 
 const ButtonBySize = ({
   size,
 }: {
-  size: Exclude<React.ComponentProps<typeof Button>["size"], "mini">;
+  // Only regular button sizes that support a label (no icon-only or mini)
+  size: Exclude<(typeof REGULAR_BUTTON_SIZES)[number], "mini">;
 }) => (
   <>
     <Separator />

--- a/sparkle/src/stories/Button.stories.tsx
+++ b/sparkle/src/stories/Button.stories.tsx
@@ -1,7 +1,10 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import React from "react";
 
-import { REGULAR_BUTTON_SIZES, BUTTON_VARIANTS } from "@sparkle/components/Button";
+import {
+  REGULAR_BUTTON_SIZES,
+  BUTTON_VARIANTS,
+} from "@sparkle/components/Button";
 
 import { Button, PlusIcon, RobotIcon, Separator } from "../index_with_tw_base";
 

--- a/sparkle/src/stories/ButtonGroup.stories.tsx
+++ b/sparkle/src/stories/ButtonGroup.stories.tsx
@@ -3,7 +3,7 @@ import React from "react";
 
 import {
   BUTTON_VARIANTS,
-  type ButtonSizeType,
+  type RegularButtonSize,
   type ButtonVariantType,
 } from "@sparkle/components/Button";
 
@@ -20,15 +20,13 @@ import {
   TrashIcon,
 } from "../index_with_tw_base";
 
-// Exclude "mini" since these items have labels (mini buttons can't have labels)
-type LabelButtonSizeType = Exclude<ButtonSizeType, "mini">;
 
 const DefaultButtons = ({
   variant = "outline",
   size = "sm",
 }: {
   variant?: ButtonVariantType;
-  size?: LabelButtonSizeType;
+    size?: RegularButtonSize;
 }) => (
   <>
     <Button label="First" variant={variant} size={size} />

--- a/sparkle/src/stories/ButtonGroup.stories.tsx
+++ b/sparkle/src/stories/ButtonGroup.stories.tsx
@@ -20,13 +20,12 @@ import {
   TrashIcon,
 } from "../index_with_tw_base";
 
-
 const DefaultButtons = ({
   variant = "outline",
   size = "sm",
 }: {
   variant?: ButtonVariantType;
-    size?: RegularButtonSize;
+  size?: RegularButtonSize;
 }) => (
   <>
     <Button label="First" variant={variant} size={size} />

--- a/sparkle/src/stories/Card.stories.tsx
+++ b/sparkle/src/stories/Card.stories.tsx
@@ -219,7 +219,7 @@ export const WithActions: Story = {
           onClick={() => {
             alert(`You clicked on ${card.title}`);
           }}
-          action={<CardActionButton size="mini" icon={XMarkIcon} />}
+          action={<CardActionButton size="icon" icon={XMarkIcon} />}
         >
           <div className="s-flex s-w-full s-flex-col s-gap-1 s-text-sm">
             <div className="s-flex s-w-full s-gap-1 s-font-semibold s-text-foreground">
@@ -249,7 +249,7 @@ export const SelectableGrid: Story = {
             size="md"
             selected={selected === index}
             onClick={() => setSelected(index)}
-            action={<CardActionButton size="mini" icon={XMarkIcon} />}
+            action={<CardActionButton size="icon" icon={XMarkIcon} />}
           >
             <div className="s-flex s-w-full s-flex-col s-gap-1 s-text-sm">
               <div className="s-flex s-w-full s-gap-1 s-font-semibold s-text-foreground">

--- a/sparkle/src/stories/Chip.stories.tsx
+++ b/sparkle/src/stories/Chip.stories.tsx
@@ -114,7 +114,7 @@ export const AllColors: Story = {
   render: () => (
     <div className="s-flex s-flex-col s-gap-4">
       <div className="s-flex s-flex-wrap s-gap-2">
-        <Chip size="mini" color="primary" label="Primary" />
+        <Chip size="xs" color="primary" label="Primary" />
         <Chip size="xs" color="primary" label="Primary" />
         <Chip size="sm" color="primary" label="Primary" />
       </div>

--- a/sparkle/src/stories/Dropdown.stories.tsx
+++ b/sparkle/src/stories/Dropdown.stories.tsx
@@ -136,7 +136,7 @@ export const ComplexDropdown: Story = {
               label="Profile"
               endComponent={
                 <Button
-                  size="mini"
+                  size="icon"
                   icon={ArrowUpOnSquareIcon}
                   variant="ghost"
                 />

--- a/sparkle/src/stories/HoveringBar.stories.tsx
+++ b/sparkle/src/stories/HoveringBar.stories.tsx
@@ -28,11 +28,11 @@ export const Default: Story = {
   args: {
     children: (
       <>
-        <Button icon={HeadingIcon} size="mini" variant="ghost-secondary" />
-        <Button icon={BoldIcon} size="mini" variant="ghost-secondary" />
-        <Button icon={ItalicIcon} size="mini" variant="ghost-secondary" />
+        <Button icon={HeadingIcon} size="icon" variant="ghost-secondary" />
+        <Button icon={BoldIcon} size="icon" variant="ghost-secondary" />
+        <Button icon={ItalicIcon} size="icon" variant="ghost-secondary" />
         <HoveringBar.Separator />
-        <Button icon={LinkIcon} size="mini" variant="ghost-secondary" />
+        <Button icon={LinkIcon} size="icon" variant="ghost-secondary" />
       </>
     ),
   },
@@ -55,58 +55,58 @@ export const FullFormattingToolbar = () => (
   <HoveringBar>
     <Button
       icon={HeadingIcon}
-      size="mini"
+      size="icon"
       variant="ghost-secondary"
       tooltip="Heading"
     />
     <Button
       icon={BoldIcon}
-      size="mini"
+      size="icon"
       variant="ghost-secondary"
       tooltip="Bold"
     />
     <Button
       icon={ItalicIcon}
-      size="mini"
+      size="icon"
       variant="ghost-secondary"
       tooltip="Italic"
     />
     <HoveringBar.Separator />
     <Button
       icon={LinkIcon}
-      size="mini"
+      size="icon"
       variant="ghost-secondary"
       tooltip="Link"
     />
     <HoveringBar.Separator />
     <Button
       icon={ListCheckIcon}
-      size="mini"
+      size="icon"
       variant="ghost-secondary"
       tooltip="Bulleted list"
     />
     <Button
       icon={ListOrdered2Icon}
-      size="mini"
+      size="icon"
       variant="ghost-secondary"
       tooltip="Ordered list"
     />
     <Button
       icon={QuoteTextIcon}
-      size="mini"
+      size="icon"
       variant="ghost-secondary"
       tooltip="Blockquote"
     />
     <HoveringBar.Separator />
     <Button
       icon={CodeSlashIcon}
-      size="mini"
+      size="icon"
       variant="ghost-secondary"
       tooltip="Inline code"
     />
     <Button
       icon={CodeBlockIcon}
-      size="mini"
+      size="icon"
       variant="ghost-secondary"
       tooltip="Code block"
     />
@@ -116,18 +116,18 @@ export const FullFormattingToolbar = () => (
 export const WithOverflow = () => (
   <div style={{ maxWidth: "200px" }}>
     <HoveringBar className="s-w-full">
-      <Button icon={HeadingIcon} size="mini" variant="ghost-secondary" />
-      <Button icon={BoldIcon} size="mini" variant="ghost-secondary" />
-      <Button icon={ItalicIcon} size="mini" variant="ghost-secondary" />
+      <Button icon={HeadingIcon} size="icon" variant="ghost-secondary" />
+      <Button icon={BoldIcon} size="icon" variant="ghost-secondary" />
+      <Button icon={ItalicIcon} size="icon" variant="ghost-secondary" />
       <HoveringBar.Separator />
-      <Button icon={LinkIcon} size="mini" variant="ghost-secondary" />
+      <Button icon={LinkIcon} size="icon" variant="ghost-secondary" />
       <HoveringBar.Separator />
-      <Button icon={ListCheckIcon} size="mini" variant="ghost-secondary" />
-      <Button icon={ListOrdered2Icon} size="mini" variant="ghost-secondary" />
-      <Button icon={QuoteTextIcon} size="mini" variant="ghost-secondary" />
+      <Button icon={ListCheckIcon} size="icon" variant="ghost-secondary" />
+      <Button icon={ListOrdered2Icon} size="icon" variant="ghost-secondary" />
+      <Button icon={QuoteTextIcon} size="icon" variant="ghost-secondary" />
       <HoveringBar.Separator />
-      <Button icon={CodeSlashIcon} size="mini" variant="ghost-secondary" />
-      <Button icon={CodeBlockIcon} size="mini" variant="ghost-secondary" />
+      <Button icon={CodeSlashIcon} size="icon" variant="ghost-secondary" />
+      <Button icon={CodeBlockIcon} size="icon" variant="ghost-secondary" />
     </HoveringBar>
   </div>
 );

--- a/sparkle/src/stories/Playground.stories.tsx
+++ b/sparkle/src/stories/Playground.stories.tsx
@@ -262,7 +262,7 @@ export const Demo = () => {
                   <Button
                     variant="highlight"
                     icon={ArrowUpIcon}
-                    size="mini"
+                    size="icon"
                     tooltip="Send message"
                     isRounded
                     disabled={recordState === "recording"}

--- a/sparkle/src/stories/SidebarLayout.stories.tsx
+++ b/sparkle/src/stories/SidebarLayout.stories.tsx
@@ -38,7 +38,7 @@ const SampleSidebar = ({
       {onToggle && (
         <Button
           variant="ghost-secondary"
-          size="mini"
+          size="icon"
           icon={isCollapsed ? SidebarLeftOpenIcon : SidebarLeftCloseIcon}
           onClick={onToggle}
         />
@@ -132,7 +132,7 @@ const ComplexSidebar = ({
       {onToggle && (
         <Button
           variant="ghost-secondary"
-          size="mini"
+          size="icon"
           icon={isCollapsed ? SidebarLeftOpenIcon : SidebarLeftCloseIcon}
           onClick={onToggle}
         />

--- a/sparkle/src/stories/SplitButton.stories.tsx
+++ b/sparkle/src/stories/SplitButton.stories.tsx
@@ -21,7 +21,7 @@ export const FlexSplitButtonVariants: Story = {
         variant="highlight"
         icon={ArrowUpIcon}
         splitAction={
-          <Button size="mini" variant="highlight" icon={ChevronDownIcon} />
+          <Button size="icon" variant="highlight" icon={ChevronDownIcon} />
         }
       />
       <FlexSplitButton
@@ -29,7 +29,7 @@ export const FlexSplitButtonVariants: Story = {
         variant="primary"
         icon={ArrowUpIcon}
         splitAction={
-          <Button size="mini" variant="primary" icon={ChevronDownIcon} />
+          <Button size="icon" variant="primary" icon={ChevronDownIcon} />
         }
       />
       <FlexSplitButton
@@ -37,7 +37,7 @@ export const FlexSplitButtonVariants: Story = {
         variant="outline"
         icon={ArrowUpIcon}
         splitAction={
-          <Button size="mini" variant="outline" icon={ChevronDownIcon} />
+          <Button size="icon" variant="outline" icon={ChevronDownIcon} />
         }
       />
       <FlexSplitButton
@@ -46,7 +46,7 @@ export const FlexSplitButtonVariants: Story = {
         icon={ArrowUpIcon}
         splitAction={
           <Button
-            size="mini"
+            size="icon"
             variant="highlight-secondary"
             icon={ChevronDownIcon}
           />
@@ -57,7 +57,7 @@ export const FlexSplitButtonVariants: Story = {
         variant="warning"
         icon={ArrowUpIcon}
         splitAction={
-          <Button size="mini" variant="warning" icon={ChevronDownIcon} />
+          <Button size="icon" variant="warning" icon={ChevronDownIcon} />
         }
       />
       <FlexSplitButton
@@ -66,7 +66,7 @@ export const FlexSplitButtonVariants: Story = {
         icon={ArrowUpIcon}
         splitAction={
           <Button
-            size="mini"
+            size="icon"
             variant="warning-secondary"
             icon={ChevronDownIcon}
           />
@@ -77,7 +77,7 @@ export const FlexSplitButtonVariants: Story = {
         variant="ghost"
         icon={ArrowUpIcon}
         splitAction={
-          <Button size="mini" variant="ghost" icon={ChevronDownIcon} />
+          <Button size="icon" variant="ghost" icon={ChevronDownIcon} />
         }
       />
       <FlexSplitButton
@@ -86,7 +86,7 @@ export const FlexSplitButtonVariants: Story = {
         icon={ArrowUpIcon}
         splitAction={
           <Button
-            size="mini"
+            size="icon"
             variant="ghost-secondary"
             icon={ChevronDownIcon}
           />
@@ -105,7 +105,7 @@ export const FlexSplitButtonLoading: Story = {
         icon={ArrowUpIcon}
         isLoading
         splitAction={
-          <Button size="mini" variant="highlight" icon={ChevronDownIcon} />
+          <Button size="icon" variant="highlight" icon={ChevronDownIcon} />
         }
       />
       <FlexSplitButton
@@ -114,7 +114,7 @@ export const FlexSplitButtonLoading: Story = {
         icon={ArrowUpIcon}
         isLoading
         splitAction={
-          <Button size="mini" variant="primary" icon={ChevronDownIcon} />
+          <Button size="icon" variant="primary" icon={ChevronDownIcon} />
         }
       />
       <FlexSplitButton
@@ -123,7 +123,7 @@ export const FlexSplitButtonLoading: Story = {
         icon={ArrowUpIcon}
         isLoading
         splitAction={
-          <Button size="mini" variant="outline" icon={ChevronDownIcon} />
+          <Button size="icon" variant="outline" icon={ChevronDownIcon} />
         }
       />
       <FlexSplitButton
@@ -133,7 +133,7 @@ export const FlexSplitButtonLoading: Story = {
         isLoading
         splitAction={
           <Button
-            size="mini"
+            size="icon"
             variant="highlight-secondary"
             icon={ChevronDownIcon}
           />
@@ -145,7 +145,7 @@ export const FlexSplitButtonLoading: Story = {
         icon={ArrowUpIcon}
         isLoading
         splitAction={
-          <Button size="mini" variant="warning" icon={ChevronDownIcon} />
+          <Button size="icon" variant="warning" icon={ChevronDownIcon} />
         }
       />
       <FlexSplitButton
@@ -155,7 +155,7 @@ export const FlexSplitButtonLoading: Story = {
         isLoading
         splitAction={
           <Button
-            size="mini"
+            size="icon"
             variant="warning-secondary"
             icon={ChevronDownIcon}
           />
@@ -167,7 +167,7 @@ export const FlexSplitButtonLoading: Story = {
         icon={ArrowUpIcon}
         isLoading
         splitAction={
-          <Button size="mini" variant="ghost" icon={ChevronDownIcon} />
+          <Button size="icon" variant="ghost" icon={ChevronDownIcon} />
         }
       />
       <FlexSplitButton
@@ -177,7 +177,7 @@ export const FlexSplitButtonLoading: Story = {
         isLoading
         splitAction={
           <Button
-            size="mini"
+            size="icon"
             variant="ghost-secondary"
             icon={ChevronDownIcon}
           />

--- a/sparkle/src/stories/Tree.stories.tsx
+++ b/sparkle/src/stories/Tree.stories.tsx
@@ -140,7 +140,7 @@ export const TreeExample = () => {
                     type="leaf"
                     actions={
                       <div className="s-flex s-grow s-flex-row s-items-center s-justify-between">
-                        <Button size="mini" variant="outline" icon={EyeIcon} />
+                        <Button size="icon" variant="outline" icon={EyeIcon} />
                         <div className="s-flex s-flex-row s-items-center s-gap-1 s-text-sm s-text-muted-foreground">
                           <Icon visual={HistoryIcon} size="xs" />
                           1y


### PR DESCRIPTION
## Description
This PR is to add new size `icon` and `icon-xs` to Button component, and you can use mini and xmini for label only buttons. I will clean up IconButton component and keep only Button in next PR. 

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
