### PR TITLE
[front](fix) Update MCP metadata snapshot with sandbox server

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
@@ -14138,6 +14138,108 @@
     }
   },
   {
+    "name": "sandbox",
+    "tools": [
+      {
+        "name": "execute",
+        "description": "Execute a shell command in an isolated sandbox environment. The sandbox is a Linux container with common tools pre-installed. Use this for running scripts, installing packages, or executing code. The sandbox persists for the duration of the conversation.",
+        "inputSchema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "additionalProperties": false,
+          "properties": {
+            "command": {
+              "description": "The shell command to execute. Can be a single command or a script.",
+              "type": "string"
+            },
+            "timeoutMs": {
+              "description": "Timeout in milliseconds for command execution. Defaults to 60000, max 120000.",
+              "maximum": 120000,
+              "type": "number"
+            },
+            "workingDirectory": {
+              "description": "Working directory for command execution. Defaults to /tmp.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "command"
+          ],
+          "type": "object"
+        }
+      },
+      {
+        "name": "list_files",
+        "description": "List files and directories in the sandbox. Returns file names, sizes, and types (file/directory).",
+        "inputSchema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "description": "Directory path to list. Defaults to /tmp.",
+              "type": "string"
+            },
+            "recursive": {
+              "description": "Whether to list files recursively. Defaults to false.",
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        }
+      },
+      {
+        "name": "read_file",
+        "description": "Read a file from the sandbox and make it available as a Dust file. Use this to retrieve results of computations, generated content, or any file that should be shared with the user in the conversation.",
+        "inputSchema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "additionalProperties": false,
+          "properties": {
+            "path": {
+              "description": "Absolute path to the file to read.",
+              "type": "string"
+            },
+            "title": {
+              "description": "Title for the file in Dust. Defaults to the filename.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path"
+          ],
+          "type": "object"
+        }
+      },
+      {
+        "name": "write_file",
+        "description": "Write content to a file in the sandbox. Creates parent directories if they don't exist. Overwrites the file if it already exists.",
+        "inputSchema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "additionalProperties": false,
+          "properties": {
+            "content": {
+              "description": "The content to write to the file.",
+              "type": "string"
+            },
+            "path": {
+              "description": "Absolute path where the file should be written in the sandbox.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "content"
+          ],
+          "type": "object"
+        }
+      }
+    ],
+    "toolsStakes": {
+      "execute": "low",
+      "list_files": "never_ask",
+      "read_file": "never_ask",
+      "write_file": "low"
+    }
+  },
+  {
     "name": "schedules_management",
     "tools": [
       {


### PR DESCRIPTION
## Description

Fix the CI failure on main caused by missing MCP metadata snapshot update.

PR #20639 added the sandbox MCP server with 4 tools (`execute`, `list_files`, `read_file`, `write_file`) but didn't update the metadata snapshot, causing the snapshot test to fail expecting 60 items but finding 61.

## Tests

- Ran `npm test lib/actions/mcp_internal_actions/mcp_servers_metadata.test.ts` locally - all 3 tests pass

## Risk

Low - only updates a test snapshot file, no runtime code changes.

## Deploy Plan

Merge to unblock CI on main. No special deployment considerations.