### PR TITLE
[sparkle] - fix(ScrollArea): ensure div in scrollarea displays as block

### DIFF
--- a/sparkle/src/styles/tailwind.css
+++ b/sparkle/src/styles/tailwind.css
@@ -15,6 +15,7 @@
 
 @layer utilities {
   .s-scrollarea-viewport > div {
+    display: block !important;
     height: 100%;
   }
 }


### PR DESCRIPTION
## Description

Radix ScrollArea 1.2.0+ now injects an internal `div` with `style="min-width: 100%; display: table;"` into `ScrollArea`.

This breaks layouts in many scenarios:
- Text truncation with `text-overflow: ellipsis` doesn't work (items stretch instead)
- max-width is not respected in table formatting context
- Vertical-only scrollareas expand horizontally

Seems to be a known and unsolved issue https://github.com/radix-ui/primitives/issues/3646.

  There's no official migration path. The workaround suggested by the community (and what we implemented) is exactly:
```css
[viewport] > div {
  display: block !important;
}
```

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front
