### PR TITLE
[front] poke: Update generated links to poke to use dedicated url

### DIFF
--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -27,6 +27,13 @@ const config = {
     }
     return process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL;
   },
+  // URL for the poke app (front-spa). Falls back to getClientFacingUrl()/poke when not set.
+  getPokeAppUrl: (): string => {
+    return (
+      EnvironmentConfig.getOptionalEnvVariable("POKE_APP_URL") ??
+      `${config.getClientFacingUrl()}/poke`
+    );
+  },
   // For OAuth/WorkOS redirects. Allows overriding the redirect base URL separately
   // from NEXT_PUBLIC_DUST_CLIENT_FACING_URL. Falls back to getClientFacingUrl() when not set.
   getAuthRedirectBaseUrl: (): string => {

--- a/front/lib/poke/search.ts
+++ b/front/lib/poke/search.ts
@@ -29,7 +29,7 @@ async function searchPokeWorkspaces(
       {
         id: workspaceInfos.id,
         name: workspaceInfos.name,
-        link: `${config.getClientFacingUrl()}/poke/${workspaceInfos.sId}`,
+        link: `${config.getPokeAppUrl()}/${workspaceInfos.sId}`,
         type: "Workspace",
       },
     ];
@@ -42,7 +42,7 @@ async function searchPokeWorkspaces(
       return workspaces.map((w) => ({
         id: w.id,
         name: w.name,
-        link: `${config.getClientFacingUrl()}/poke/${w.sId}`,
+        link: `${config.getPokeAppUrl()}/${w.sId}`,
         type: "Workspace",
       }));
     }
@@ -56,7 +56,7 @@ async function searchPokeWorkspaces(
         {
           id: workspaceByOrgId.id,
           name: workspaceByOrgId.name,
-          link: `${config.getClientFacingUrl()}/poke/${workspaceByOrgId.sId}`,
+          link: `${config.getPokeAppUrl()}/${workspaceByOrgId.sId}`,
           type: "Workspace",
         },
       ];
@@ -93,7 +93,7 @@ async function searchConnectorModelId(
         {
           id: parseInt(connector.id, 10),
           name: `${workspace.name}'s ${asDisplayName(connector.type)}`,
-          link: `${config.getClientFacingUrl()}/poke/${connector.workspaceId}/data_sources/${connector.dataSourceId}`,
+          link: `${config.getPokeAppUrl()}/${connector.workspaceId}/data_sources/${connector.dataSourceId}`,
           type: "Connector",
         },
       ];
@@ -147,7 +147,7 @@ async function searchPokeFrames(searchTerm: string): Promise<PokeItemBase[]> {
     {
       id: file.id,
       name: `Frame (token: ${searchTerm.slice(0, 8)}...)`,
-      link: `${config.getClientFacingUrl()}/poke/${workspace.sId}/files/${file.sId}`,
+      link: `${config.getPokeAppUrl()}/${workspace.sId}/files/${file.sId}`,
       type: "Frame",
     },
   ];

--- a/front/lib/poke/utils.ts
+++ b/front/lib/poke/utils.ts
@@ -32,7 +32,7 @@ export async function dataSourceToPokeJSON(
   return {
     ...dataSource.toJSON(),
     link: workspace
-      ? `${config.getClientFacingUrl()}/poke/${workspace.sId}/data_sources/${dataSource.sId}`
+      ? `${config.getPokeAppUrl()}/${workspace.sId}/data_sources/${dataSource.sId}`
       : null,
     name:
       (workspace ? `${workspace.name}'s ` : "") +
@@ -55,7 +55,7 @@ export async function dataSourceViewToPokeJSON(
     ...dataSourceView.toJSON(),
     dataSource: await dataSourceToPokeJSON(dataSourceView.dataSource),
     link: workspace
-      ? `${config.getClientFacingUrl()}/poke/${workspace.sId}/spaces/${dataSourceView.space.sId}/data_source_views/${dataSourceView.sId}`
+      ? `${config.getPokeAppUrl()}/${workspace.sId}/spaces/${dataSourceView.space.sId}/data_source_views/${dataSourceView.sId}`
       : null,
     name:
       (workspace ? `${workspace.name}'s ` : "") +
@@ -106,7 +106,7 @@ export async function mcpServerViewToPokeJSON(
       developerSecretSelection: null,
     },
     link: workspace
-      ? `${config.getClientFacingUrl()}/poke/${workspace.sId}/spaces/${mcpServerView.space.sId}/mcp_server_views/${mcpServerView.sId}`
+      ? `${config.getPokeAppUrl()}/${workspace.sId}/spaces/${mcpServerView.space.sId}/mcp_server_views/${mcpServerView.sId}`
       : null,
     name: json.server.name,
     type: "MCP Server View",


### PR DESCRIPTION
## Description

Update generated links to poke to use POKE_APP_URL. Will have to be set once we go to poke.dust.tt . All poke links will go to this URL.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Set POKE_APP_URL secret
deploy front
