### PR TITLE
Fix space members edition

### DIFF
--- a/front/components/assistant/conversation/space/about/SpaceAboutTab.tsx
+++ b/front/components/assistant/conversation/space/about/SpaceAboutTab.tsx
@@ -290,6 +290,7 @@ export function SpaceAboutTab({
       await doUpdate(space, {
         isRestricted,
         groupIds: selectedGroups.map((group) => group.sId),
+        editorGroupIds: [], // todo(projects): handle editor groups in the UI
         managementMode: "group",
         name: space.name,
       });
@@ -297,6 +298,7 @@ export function SpaceAboutTab({
       await doUpdate(space, {
         isRestricted,
         memberIds: selectedMembers.map((member) => member.sId),
+        editorIds: [], // todo(projects): handle editors in the UI
         managementMode: "manual",
         name: space.name,
       });

--- a/front/components/spaces/CreateOrEditSpaceModal.tsx
+++ b/front/components/spaces/CreateOrEditSpaceModal.tsx
@@ -200,6 +200,7 @@ export function CreateOrEditSpaceModal({
         await doUpdate(space, {
           isRestricted,
           groupIds: selectedGroups.map((group) => group.sId),
+          editorGroupIds: [],
           managementMode: "group",
           name: trimmedName,
         });
@@ -207,6 +208,7 @@ export function CreateOrEditSpaceModal({
         await doUpdate(space, {
           isRestricted,
           memberIds: selectedMembers.map((vm) => vm.sId),
+          editorIds: [],
           managementMode: "manual",
           name: trimmedName,
         });

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -1078,7 +1078,7 @@ export class GroupResource extends BaseResource<GroupModel> {
       transaction,
     }: {
       users: UserType[];
-      requestedPermissions?: CombinedResourcePermissions;
+      requestedPermissions?: CombinedResourcePermissions[];
       transaction?: Transaction;
     }
   ): Promise<
@@ -1093,13 +1093,7 @@ export class GroupResource extends BaseResource<GroupModel> {
       >
     >
   > {
-    if (
-      !auth.canWrite(
-        requestedPermissions
-          ? [requestedPermissions]
-          : this.requestedPermissions()
-      )
-    ) {
+    if (!auth.canWrite(requestedPermissions ?? this.requestedPermissions())) {
       return new Err(
         new DustError(
           "unauthorized",
@@ -1216,7 +1210,7 @@ export class GroupResource extends BaseResource<GroupModel> {
       transaction,
     }: {
       user: UserType;
-      requestedPermissions?: CombinedResourcePermissions;
+      requestedPermissions?: CombinedResourcePermissions[];
       transaction?: Transaction;
     }
   ): Promise<
@@ -1246,7 +1240,7 @@ export class GroupResource extends BaseResource<GroupModel> {
       transaction,
     }: {
       users: UserType[];
-      requestedPermissions?: CombinedResourcePermissions;
+      requestedPermissions?: CombinedResourcePermissions[];
       transaction?: Transaction;
     }
   ): Promise<
@@ -1260,13 +1254,7 @@ export class GroupResource extends BaseResource<GroupModel> {
       >
     >
   > {
-    if (
-      !auth.canWrite(
-        requestedPermissions
-          ? [requestedPermissions]
-          : this.requestedPermissions()
-      )
-    ) {
+    if (!auth.canWrite(requestedPermissions ?? this.requestedPermissions())) {
       return new Err(
         new DustError(
           "unauthorized",
@@ -1366,7 +1354,7 @@ export class GroupResource extends BaseResource<GroupModel> {
       transaction,
     }: {
       user: UserType;
-      requestedPermissions?: CombinedResourcePermissions;
+      requestedPermissions?: CombinedResourcePermissions[];
       transaction?: Transaction;
     }
   ): Promise<
@@ -1395,7 +1383,7 @@ export class GroupResource extends BaseResource<GroupModel> {
       transaction,
     }: {
       users: UserType[];
-      requestedPermissions?: CombinedResourcePermissions;
+      requestedPermissions?: CombinedResourcePermissions[];
       transaction?: Transaction;
     }
   ): Promise<
@@ -1411,13 +1399,7 @@ export class GroupResource extends BaseResource<GroupModel> {
       >
     >
   > {
-    if (
-      !auth.canWrite(
-        requestedPermissions
-          ? [requestedPermissions]
-          : this.requestedPermissions()
-      )
-    ) {
+    if (!auth.canWrite(requestedPermissions ?? this.requestedPermissions())) {
       return new Err(
         new DustError(
           "unauthorized",
@@ -1625,6 +1607,10 @@ export class GroupResource extends BaseResource<GroupModel> {
 
   isRegular(): boolean {
     return this.kind === "regular";
+  }
+
+  isSpaceEditor(): boolean {
+    return this.kind === "space_editors";
   }
 
   isProvisioned(): boolean {

--- a/front/lib/resources/group_space_resource.test.ts
+++ b/front/lib/resources/group_space_resource.test.ts
@@ -1,0 +1,373 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { Authenticator } from "@app/lib/auth";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import {
+  GroupSpaceEditorResource,
+  GroupSpaceMemberResource,
+  GroupSpaceViewerResource,
+} from "@app/lib/resources/group_space_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces";
+import { GroupFactory } from "@app/tests/utils/GroupFactory";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+
+describe("GroupSpaceMemberResource", () => {
+  let workspace: Awaited<ReturnType<typeof WorkspaceFactory.basic>>;
+  let auth: Authenticator;
+  let regularSpace: SpaceResource;
+
+  beforeEach(async () => {
+    workspace = await WorkspaceFactory.basic();
+    const adminUser = await UserFactory.basic();
+
+    // Create default groups (including global group)
+    await GroupFactory.defaults(workspace);
+
+    await MembershipFactory.associate(workspace, adminUser, { role: "admin" });
+
+    auth = await Authenticator.fromUserIdAndWorkspaceId(
+      adminUser.sId,
+      workspace.sId
+    );
+
+    regularSpace = await SpaceFactory.regular(workspace);
+  });
+
+  describe("makeNew", () => {
+    it("should create a new GroupSpaceMemberResource with correct properties", async () => {
+      const testGroup = await GroupResource.makeNew({
+        name: "Test Group",
+        workspaceId: workspace.id,
+        kind: "regular",
+      });
+
+      const groupSpaceMember = await GroupSpaceMemberResource.makeNew(auth, {
+        group: testGroup,
+        space: regularSpace,
+      });
+
+      expect(groupSpaceMember).toBeInstanceOf(GroupSpaceMemberResource);
+      expect(groupSpaceMember.groupId).toBe(testGroup.id);
+      expect(groupSpaceMember.vaultId).toBe(regularSpace.id);
+      expect(groupSpaceMember.workspaceId).toBe(workspace.id);
+      expect(groupSpaceMember.kind).toBe("member");
+    });
+  });
+
+  describe("fetchBySpace", () => {
+    it("should return empty array when no member GroupSpace exists for the space", async () => {
+      // Create a space without any member groups
+      const emptySpace = await SpaceResource.makeNew(
+        {
+          name: "Empty Space",
+          kind: "regular",
+          workspaceId: workspace.id,
+        },
+        { members: [] }
+      );
+
+      const result = await GroupSpaceMemberResource.fetchBySpace({
+        space: emptySpace,
+        filterOnManagementMode: false,
+      });
+
+      expect(result).toEqual([]);
+    });
+
+    it("should fetch an existing GroupSpaceMemberResource by space", async () => {
+      // regularSpace already has a member group from SpaceFactory.regular
+      // Let's fetch it
+      const result = await GroupSpaceMemberResource.fetchBySpace({
+        space: regularSpace,
+      });
+
+      expect(result.length).toBeGreaterThan(0);
+      expect(result[0]).toBeInstanceOf(GroupSpaceMemberResource);
+      expect(result[0]?.vaultId).toBe(regularSpace.id);
+      expect(result[0]?.kind).toBe("member");
+      // The group should be the one created by SpaceFactory
+      expect(result[0]?.groupId).toBeDefined();
+    });
+
+    // Note: Testing the assertion "Group must exist for member group space" is not possible
+    // in this test environment due to database foreign key constraints that prevent
+    // creating orphaned GroupSpace records. The assertion is still valid in production
+    // if data integrity issues occur.
+  });
+});
+
+describe("GroupSpaceEditorResource", () => {
+  let workspace: Awaited<ReturnType<typeof WorkspaceFactory.basic>>;
+  let auth: Authenticator;
+  let projectSpace: SpaceResource;
+  let editorGroup: GroupResource;
+
+  beforeEach(async () => {
+    workspace = await WorkspaceFactory.basic();
+    const adminUser = await UserFactory.basic();
+
+    // Create default groups (including global group)
+    await GroupFactory.defaults(workspace);
+
+    await MembershipFactory.associate(workspace, adminUser, { role: "admin" });
+
+    auth = await Authenticator.fromUserIdAndWorkspaceId(
+      adminUser.sId,
+      workspace.sId
+    );
+
+    // Create a project space
+    projectSpace = await SpaceFactory.project(workspace);
+
+    // Create an editor group
+    editorGroup = await GroupResource.makeNew({
+      name: "Test Editor Group",
+      workspaceId: workspace.id,
+      kind: "space_editors",
+    });
+  });
+
+  describe("makeNew", () => {
+    it("should throw an assertion error when space is not a project space", async () => {
+      const regularSpace = await SpaceFactory.regular(workspace);
+
+      await expect(
+        GroupSpaceEditorResource.makeNew(auth, {
+          group: editorGroup,
+          space: regularSpace,
+        })
+      ).rejects.toThrow("Editor groups only apply to project spaces");
+    });
+
+    it("should throw an assertion error when group is not a space editor or provisioned group", async () => {
+      const regularGroup = await GroupResource.makeNew({
+        name: "Regular Group",
+        workspaceId: workspace.id,
+        kind: "regular",
+      });
+
+      await expect(
+        GroupSpaceEditorResource.makeNew(auth, {
+          group: regularGroup,
+          space: projectSpace,
+        })
+      ).rejects.toThrow(
+        "Only space editor or provisioned groups can be an editor group"
+      );
+    });
+
+    it("should allow creating editor resource with provisioned group", async () => {
+      const provisionedGroup = await GroupResource.makeNew({
+        name: "Provisioned Group",
+        workspaceId: workspace.id,
+        kind: "provisioned",
+      });
+
+      const groupSpaceEditor = await GroupSpaceEditorResource.makeNew(auth, {
+        group: provisionedGroup,
+        space: projectSpace,
+      });
+
+      expect(groupSpaceEditor).toBeInstanceOf(GroupSpaceEditorResource);
+      expect(groupSpaceEditor.kind).toBe("project_editor");
+    });
+  });
+
+  describe("fetchBySpace", () => {
+    it("should return the existing editor group space for a project", async () => {
+      const result = await GroupSpaceEditorResource.fetchBySpace({
+        space: projectSpace,
+      });
+
+      expect(result.length).toBeGreaterThan(0);
+      expect(result[0]).toBeInstanceOf(GroupSpaceEditorResource);
+      expect(result[0]?.vaultId).toBe(projectSpace.id);
+      expect(result[0]?.kind).toBe("project_editor");
+    });
+
+    it("should return empty array when no editor GroupSpace exists for the project", async () => {
+      // Delete existing editor group spaces
+      await GroupSpaceModel.destroy({
+        where: {
+          vaultId: projectSpace.id,
+          kind: "project_editor",
+          workspaceId: workspace.id,
+        },
+      });
+
+      const result = await GroupSpaceEditorResource.fetchBySpace({
+        space: projectSpace,
+      });
+
+      expect(result).toEqual([]);
+    });
+
+    it("should throw an assertion error when space is not a project space", async () => {
+      const regularSpace = await SpaceFactory.regular(workspace);
+
+      await expect(
+        GroupSpaceEditorResource.fetchBySpace({ space: regularSpace })
+      ).rejects.toThrow("Editor groups only apply to project spaces");
+    });
+
+    // Note: Testing the assertion "Group must exist for editor group space" is not possible
+    // in this test environment due to database foreign key constraints that prevent
+    // creating orphaned GroupSpace records. The assertion is still valid in production
+    // if data integrity issues occur.
+
+    it("should throw an assertion error when group is not matching the management mode", async () => {
+      const regularGroup = await GroupResource.makeNew({
+        name: "Regular Group",
+        workspaceId: workspace.id,
+        kind: "regular",
+      });
+
+      // Delete existing editor groups
+      await GroupSpaceModel.destroy({
+        where: {
+          vaultId: projectSpace.id,
+          kind: "project_editor",
+          workspaceId: workspace.id,
+        },
+      });
+
+      // Create a GroupSpaceModel with a non-editor group
+      await GroupSpaceModel.create({
+        groupId: regularGroup.id,
+        vaultId: projectSpace.id,
+        workspaceId: workspace.id,
+        kind: "project_editor",
+      });
+
+      // When filtering on management mode, the group won't be found because it doesn't match the expected kind
+      await expect(
+        GroupSpaceEditorResource.fetchBySpace({
+          space: projectSpace,
+        })
+      ).rejects.toThrow(
+        "Only space_editors or provisioned groups can be editor groups"
+      );
+    });
+  });
+});
+
+describe("GroupSpaceViewerResource", () => {
+  let workspace: Awaited<ReturnType<typeof WorkspaceFactory.basic>>;
+  let auth: Authenticator;
+  let projectSpace: SpaceResource;
+  let globalGroup: GroupResource;
+
+  beforeEach(async () => {
+    workspace = await WorkspaceFactory.basic();
+    const adminUser = await UserFactory.basic();
+
+    // Create default groups (including global group)
+    const { globalGroup: gGroup } = await GroupFactory.defaults(workspace);
+    globalGroup = gGroup;
+
+    await MembershipFactory.associate(workspace, adminUser, { role: "admin" });
+
+    auth = await Authenticator.fromUserIdAndWorkspaceId(
+      adminUser.sId,
+      workspace.sId
+    );
+
+    // Create a project space
+    projectSpace = await SpaceFactory.project(workspace);
+  });
+
+  describe("makeNew", () => {
+    it("should throw an assertion error when space is not a project space", async () => {
+      const regularSpace = await SpaceFactory.regular(workspace);
+
+      await expect(
+        GroupSpaceViewerResource.makeNew(auth, {
+          group: globalGroup,
+          space: regularSpace,
+        })
+      ).rejects.toThrow("Viewer groups only apply to project spaces");
+    });
+
+    it("should throw an assertion error when group is not the global group", async () => {
+      const regularGroup = await GroupResource.makeNew({
+        name: "Regular Group",
+        workspaceId: workspace.id,
+        kind: "regular",
+      });
+
+      await expect(
+        GroupSpaceViewerResource.makeNew(auth, {
+          group: regularGroup,
+          space: projectSpace,
+        })
+      ).rejects.toThrow("Only the global group can be a viewer group");
+    });
+  });
+
+  describe("fetchBySpace", () => {
+    it("should return null when no viewer GroupSpace exists for the project", async () => {
+      const result = await GroupSpaceViewerResource.fetchBySpace({
+        space: projectSpace,
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it("should fetch an existing GroupSpaceViewerResource by space", async () => {
+      await GroupSpaceViewerResource.makeNew(auth, {
+        group: globalGroup,
+        space: projectSpace,
+      });
+
+      const result = await GroupSpaceViewerResource.fetchBySpace({
+        space: projectSpace,
+      });
+
+      expect(result).toBeInstanceOf(GroupSpaceViewerResource);
+      expect(result?.groupId).toBe(globalGroup.id);
+      expect(result?.vaultId).toBe(projectSpace.id);
+      expect(result?.kind).toBe("project_viewer");
+    });
+
+    it("should throw an assertion error when space is not a project space", async () => {
+      const regularSpace = await SpaceFactory.regular(workspace);
+
+      await expect(
+        GroupSpaceViewerResource.fetchBySpace({
+          space: regularSpace,
+        })
+      ).rejects.toThrow("Viewer groups only apply to project spaces");
+    });
+
+    // Note: Testing the assertion "Group must exist for viewer group space" is not possible
+    // in this test environment due to database foreign key constraints that prevent
+    // creating orphaned GroupSpace records. The assertion is still valid in production
+    // if data integrity issues occur.
+
+    it("should throw an assertion error when group is not the global group", async () => {
+      const regularGroup = await GroupResource.makeNew({
+        name: "Regular Group",
+        workspaceId: workspace.id,
+        kind: "regular",
+      });
+
+      // Create a GroupSpaceModel with a non-global group
+      await GroupSpaceModel.create({
+        groupId: regularGroup.id,
+        vaultId: projectSpace.id,
+        workspaceId: workspace.id,
+        kind: "project_viewer",
+      });
+
+      await expect(
+        GroupSpaceViewerResource.fetchBySpace({
+          space: projectSpace,
+        })
+      ).rejects.toThrow("Only the global group can be a viewer group");
+    });
+  });
+});

--- a/front/lib/resources/group_space_resource.ts
+++ b/front/lib/resources/group_space_resource.ts
@@ -1,0 +1,670 @@
+import assert from "assert";
+import type { Attributes, ModelStatic, Transaction } from "sequelize";
+
+import type { Authenticator } from "@app/lib/auth";
+import type { DustError } from "@app/lib/error";
+import { BaseResource } from "@app/lib/resources/base_resource";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces";
+import { GroupModel } from "@app/lib/resources/storage/models/groups";
+import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
+import type {
+  CombinedResourcePermissions,
+  GroupPermission,
+  Result,
+  UserType,
+} from "@app/types";
+import { assertNever, Err, Ok, removeNulls } from "@app/types";
+
+// Base class for group-space junction resources
+// Attributes are marked as read-only to reflect the stateless nature of our Resource.
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export interface GroupSpaceBaseResource extends ReadonlyAttributesType<GroupSpaceModel> {}
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export abstract class GroupSpaceBaseResource extends BaseResource<GroupSpaceModel> {
+  static model: ModelStatic<GroupSpaceModel> = GroupSpaceModel;
+
+  constructor(
+    model: ModelStatic<GroupSpaceModel>,
+    blob: Attributes<GroupSpaceModel>,
+    readonly space: SpaceResource,
+    readonly group: GroupResource
+  ) {
+    super(GroupSpaceModel, blob);
+  }
+
+  /**
+   * Helper method to find the editor groups for a space.
+   * Returns the group_vaults with kind "project_editor".
+   */
+  async getEditorGroupSpaces(
+    filterOnManagementMode: boolean = true
+  ): Promise<GroupSpaceEditorResource[]> {
+    return GroupSpaceEditorResource.fetchBySpace({
+      space: this.space,
+      filterOnManagementMode,
+    });
+  }
+
+  abstract requestedPermissions(): Promise<CombinedResourcePermissions[]>;
+
+  /**
+   * Add multiple members to the group with permissions from this group-space relationship.
+   */
+  async addMembers(
+    auth: Authenticator,
+    {
+      users,
+      transaction,
+    }: {
+      users: UserType[];
+      transaction?: Transaction;
+    }
+  ): Promise<
+    Result<
+      undefined,
+      DustError<
+        | "unauthorized"
+        | "user_not_found"
+        | "user_already_member"
+        | "group_requirements_not_met"
+        | "system_or_global_group"
+      >
+    >
+  > {
+    const requestedPermissions = await this.requestedPermissions();
+    const addMembersRes = await this.group.addMembers(auth, {
+      users,
+      requestedPermissions,
+      transaction,
+    });
+    if (addMembersRes.isErr()) {
+      return new Err(addMembersRes.error);
+    }
+    return new Ok(addMembersRes.value);
+  }
+
+  /**
+   * Remove multiple members from the group with permissions from this group-space relationship.
+   */
+  async removeMembers(
+    auth: Authenticator,
+    {
+      users,
+      transaction,
+    }: {
+      users: UserType[];
+      transaction?: Transaction;
+    }
+  ): Promise<
+    Result<
+      undefined,
+      DustError<
+        | "unauthorized"
+        | "user_not_found"
+        | "user_not_member"
+        | "system_or_global_group"
+      >
+    >
+  > {
+    const requestedPermissions = await this.requestedPermissions();
+    const removeMembersRes = await this.group.removeMembers(auth, {
+      users,
+      requestedPermissions,
+      transaction,
+    });
+    if (removeMembersRes.isErr()) {
+      return new Err(removeMembersRes.error);
+    }
+    return new Ok(removeMembersRes.value);
+  }
+
+  /**
+   * Set the exact list of members for the group with permissions from this group-space relationship.
+   * This will add new members and remove members not in the list.
+   */
+  async setMembers(
+    auth: Authenticator,
+    {
+      users,
+      transaction,
+    }: {
+      users: UserType[];
+      transaction?: Transaction;
+    }
+  ): Promise<
+    Result<
+      undefined,
+      DustError<
+        | "unauthorized"
+        | "user_not_found"
+        | "user_not_member"
+        | "user_already_member"
+        | "group_requirements_not_met"
+        | "system_or_global_group"
+      >
+    >
+  > {
+    const requestedPermissions = await this.requestedPermissions();
+    const setMembersRes = await this.group.setMembers(auth, {
+      users,
+      requestedPermissions,
+      transaction,
+    });
+    if (setMembersRes.isErr()) {
+      return new Err(setMembersRes.error);
+    }
+    return new Ok(setMembersRes.value);
+  }
+
+  /**
+   * Delete the group-space relationship.
+   */
+  async delete(
+    auth: Authenticator,
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<Result<undefined, Error>> {
+    try {
+      await GroupSpaceModel.destroy({
+        where: {
+          groupId: this.groupId,
+          vaultId: this.vaultId,
+          workspaceId: auth.getNonNullableWorkspace().id,
+          kind: this.kind,
+        },
+        transaction,
+      });
+
+      await GroupModel.destroy({
+        where: {
+          id: this.groupId,
+          workspaceId: auth.getNonNullableWorkspace().id,
+          // Delete the corresponding group if it's regular or space_editors (system, global, provisioned groups should not be deleted)
+          kind: ["regular", "space_editors"],
+        },
+        transaction,
+      });
+
+      return new Ok(undefined);
+    } catch (error) {
+      return new Err(error instanceof Error ? error : new Error(String(error)));
+    }
+  }
+}
+
+// GroupSpaceMemberResource - represents member permission (kind=member)
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export interface GroupSpaceMemberResource extends ReadonlyAttributesType<GroupSpaceModel> {}
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export class GroupSpaceMemberResource extends GroupSpaceBaseResource {
+  constructor(
+    model: ModelStatic<GroupSpaceModel>,
+    blob: Attributes<GroupSpaceModel>,
+    space: SpaceResource,
+    group: GroupResource
+  ) {
+    super(model, blob, space, group);
+  }
+
+  static async makeNew(
+    auth: Authenticator,
+    {
+      group,
+      space,
+      transaction,
+    }: {
+      group: GroupResource;
+      space: SpaceResource;
+      transaction?: Transaction;
+    }
+  ): Promise<GroupSpaceMemberResource> {
+    const groupSpace = await GroupSpaceModel.create(
+      {
+        groupId: group.id,
+        vaultId: space.id,
+        workspaceId: auth.getNonNullableWorkspace().id,
+        kind: "member",
+      },
+      { transaction }
+    );
+
+    return new GroupSpaceMemberResource(
+      GroupSpaceModel,
+      groupSpace.get(),
+      space,
+      group
+    );
+  }
+
+  static async fetchBySpace({
+    space,
+    filterOnManagementMode = false, // if true, filters groups based on space management mode
+    transaction,
+  }: {
+    space: SpaceResource;
+    filterOnManagementMode?: boolean;
+    transaction?: Transaction;
+  }): Promise<GroupSpaceMemberResource[]> {
+    const groupSpaces = await GroupSpaceModel.findAll({
+      where: {
+        kind: "member",
+        vaultId: space.id,
+        workspaceId: space.workspaceId,
+      },
+      transaction,
+    });
+
+    const groupSpacesResources = await Promise.all(
+      groupSpaces.map(async (groupSpace) => {
+        const groupModels = await GroupModel.findAll({
+          where: {
+            id: groupSpace.groupId,
+            workspaceId: space.workspaceId,
+          },
+          transaction,
+        });
+        assert(
+          groupModels.length === 1,
+          "One and only one group must exist for member group space"
+        );
+        const groupModel = groupModels[0];
+        assert(
+          groupModel.kind !== "space_editors",
+          "Editors groups cannot be member groups"
+        );
+        if (filterOnManagementMode) {
+          // Keep only regular groups in manual mode, provisioned groups in provisioned mode
+          const filterOnKind =
+            space.managementMode === "manual" ? "regular" : "provisioned";
+          if (groupModel.kind !== filterOnKind) {
+            return null;
+          }
+        }
+        const group = new GroupResource(GroupModel, groupModel.get());
+
+        return new GroupSpaceMemberResource(
+          GroupSpaceModel,
+          groupSpace.get(),
+          space,
+          group
+        );
+      })
+    );
+    return removeNulls(groupSpacesResources);
+  }
+
+  async requestedPermissions(): Promise<CombinedResourcePermissions[]> {
+    switch (this.space.kind) {
+      case "system":
+        return [
+          {
+            groups: [
+              {
+                id: this.groupId,
+                permissions: ["read", "write"],
+              },
+            ],
+            roles: [{ role: "admin", permissions: ["admin", "write"] }],
+            workspaceId: this.workspaceId,
+          },
+        ];
+      case "public":
+        return [
+          {
+            groups: [
+              {
+                id: this.groupId,
+                permissions: ["read", "write"],
+              },
+            ],
+            roles: [
+              { role: "admin", permissions: ["admin", "read", "write"] },
+              { role: "builder", permissions: ["read", "write"] },
+              { role: "user", permissions: ["read"] },
+              // Everyone can read.
+              { role: "none", permissions: ["read"] },
+            ],
+            workspaceId: this.workspaceId,
+          },
+        ];
+      case "global":
+      case "conversations":
+        return [
+          {
+            groups: [
+              {
+                id: this.groupId,
+                permissions: ["read"],
+              },
+            ],
+            roles: [
+              { role: "admin", permissions: ["admin", "read", "write"] },
+              { role: "builder", permissions: ["read", "write"] },
+            ],
+            workspaceId: this.workspaceId,
+          },
+        ];
+      case "regular":
+        return [
+          {
+            groups: [
+              {
+                id: this.group.id,
+                permissions: ["read"],
+              },
+            ],
+            roles: [
+              {
+                role: "admin",
+                permissions: ["admin", "read", "write"],
+              },
+            ],
+            workspaceId: this.space.workspaceId,
+          },
+        ];
+      case "project": {
+        // Only gets the editor groups correponding to the space management mode
+        const editorGroupSpaces = await this.getEditorGroupSpaces(true);
+        const editorGroupsPermissions: GroupPermission[] =
+          editorGroupSpaces.map((egs) => ({
+            id: egs.groupId,
+            permissions: ["admin", "read", "write"],
+          }));
+        return [
+          {
+            groups: [
+              {
+                id: this.group.id,
+                permissions: ["read"],
+              },
+              ...editorGroupsPermissions,
+            ],
+            roles: [
+              {
+                role: "admin",
+                permissions: ["admin", "read", "write"],
+              },
+            ],
+            workspaceId: this.space.workspaceId,
+          },
+        ];
+      }
+      default:
+        assertNever(this.space.kind);
+    }
+  }
+}
+
+// GroupSpaceEditorResource - represents editor permission (kind=project_editor)
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export interface GroupSpaceEditorResource extends ReadonlyAttributesType<GroupSpaceModel> {}
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export class GroupSpaceEditorResource extends GroupSpaceBaseResource {
+  constructor(
+    model: ModelStatic<GroupSpaceModel>,
+    blob: Attributes<GroupSpaceModel>,
+    space: SpaceResource,
+    group: GroupResource
+  ) {
+    super(model, blob, space, group);
+  }
+
+  static async makeNew(
+    auth: Authenticator,
+    {
+      group,
+      space,
+      transaction,
+    }: {
+      group: GroupResource;
+      space: SpaceResource;
+      transaction?: Transaction;
+    }
+  ): Promise<GroupSpaceEditorResource> {
+    assert(space.isProject(), "Editor groups only apply to project spaces");
+    assert(
+      group.isSpaceEditor() || group.isProvisioned(),
+      "Only space editor or provisioned groups can be an editor group"
+    );
+    const groupSpace = await GroupSpaceModel.create(
+      {
+        groupId: group.id,
+        vaultId: space.id,
+        workspaceId: auth.getNonNullableWorkspace().id,
+        kind: "project_editor",
+      },
+      { transaction }
+    );
+
+    return new GroupSpaceEditorResource(
+      GroupSpaceModel,
+      groupSpace.get(),
+      space,
+      group
+    );
+  }
+
+  static async fetchBySpace({
+    space,
+    filterOnManagementMode = false, // if true, filters groups based on space management mode
+    transaction,
+  }: {
+    space: SpaceResource;
+    filterOnManagementMode?: boolean;
+    transaction?: Transaction;
+  }): Promise<GroupSpaceEditorResource[]> {
+    assert(space.isProject(), "Editor groups only apply to project spaces");
+    const groupSpaces = await GroupSpaceModel.findAll({
+      where: {
+        kind: "project_editor",
+        vaultId: space.id,
+        workspaceId: space.workspaceId,
+      },
+    });
+
+    const groupSpacesResources = await Promise.all(
+      groupSpaces.map(async (groupSpace) => {
+        const groupModels = await GroupModel.findAll({
+          where: {
+            id: groupSpace.groupId,
+            workspaceId: space.workspaceId,
+          },
+          transaction,
+        });
+        assert(
+          groupModels.length === 1,
+          "One and only one group must exist for editor group space"
+        );
+        const groupModel = groupModels[0];
+        assert(
+          groupModel.kind === "space_editors" ||
+            groupModel.kind === "provisioned",
+          "Only space_editors or provisioned groups can be editor groups"
+        );
+
+        if (filterOnManagementMode) {
+          // Keep only space_editors groups in manual mode, provisioned groups in provisioned mode
+          const filterOnKind =
+            space.managementMode === "manual" ? "space_editors" : "provisioned";
+          if (groupModel.kind !== filterOnKind) {
+            return null;
+          }
+        }
+
+        const group = new GroupResource(GroupModel, groupModel.get());
+        assert(
+          group.isSpaceEditor() || group.isProvisioned(),
+          "Only space editors or provisioned groups can be an editor group"
+        );
+
+        return new GroupSpaceEditorResource(
+          GroupSpaceModel,
+          groupSpace.get(),
+          space,
+          group
+        );
+      })
+    );
+    return removeNulls(groupSpacesResources);
+  }
+
+  async requestedPermissions(): Promise<CombinedResourcePermissions[]> {
+    if (this.space.isProject()) {
+      // Only gets the editor groups correponding to the space management mode
+      const editorGroupSpaces = await this.getEditorGroupSpaces(true);
+      const editorGroupsPermissions: GroupPermission[] = editorGroupSpaces.map(
+        (egs) => ({
+          id: egs.groupId,
+          permissions: ["admin", "read", "write"],
+        })
+      );
+      return [
+        {
+          groups: editorGroupsPermissions,
+          roles: [
+            {
+              role: "admin",
+              permissions: ["admin", "read", "write"],
+            },
+          ],
+          workspaceId: this.space.workspaceId,
+        },
+      ];
+    }
+    return [];
+  }
+}
+
+// GroupSpaceViewerResource - represents viewer permission (kind=project_viewer)
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export interface GroupSpaceViewerResource extends ReadonlyAttributesType<GroupSpaceModel> {}
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
+export class GroupSpaceViewerResource extends GroupSpaceBaseResource {
+  constructor(
+    model: ModelStatic<GroupSpaceModel>,
+    blob: Attributes<GroupSpaceModel>,
+    space: SpaceResource,
+    group: GroupResource
+  ) {
+    super(model, blob, space, group);
+  }
+
+  static async makeNew(
+    auth: Authenticator,
+    {
+      group,
+      space,
+      transaction,
+    }: {
+      group: GroupResource;
+      space: SpaceResource;
+      transaction?: Transaction;
+    }
+  ): Promise<GroupSpaceViewerResource> {
+    assert(space.isProject(), "Viewer groups only apply to project spaces");
+    assert(group.isGlobal(), "Only the global group can be a viewer group");
+    const groupSpace = await GroupSpaceModel.create(
+      {
+        groupId: group.id,
+        vaultId: space.id,
+        workspaceId: auth.getNonNullableWorkspace().id,
+        kind: "project_viewer",
+      },
+      { transaction }
+    );
+
+    return new GroupSpaceViewerResource(
+      GroupSpaceModel,
+      groupSpace.get(),
+      space,
+      group
+    );
+  }
+
+  static async fetchBySpace({
+    space,
+    transaction,
+  }: {
+    space: SpaceResource;
+    transaction?: Transaction;
+  }): Promise<GroupSpaceViewerResource | null> {
+    assert(space.isProject(), "Viewer groups only apply to project spaces");
+    const groupSpaces = await GroupSpaceModel.findAll({
+      where: {
+        kind: "project_viewer",
+        vaultId: space.id,
+        workspaceId: space.workspaceId,
+      },
+      transaction,
+    });
+
+    assert(
+      groupSpaces.length <= 1,
+      "There should be at most one viewer group per project"
+    );
+    if (groupSpaces.length === 0) {
+      return null;
+    }
+
+    const groupModels = await GroupModel.findAll({
+      where: {
+        id: groupSpaces[0].groupId,
+        workspaceId: space.workspaceId,
+      },
+      transaction,
+    });
+    assert(
+      groupModels.length === 1,
+      "One and only one group must exist for viewer group space"
+    );
+    const groupModel = groupModels[0];
+    assert(
+      groupModel.kind === "global",
+      "Only the global group can be a viewer group"
+    );
+
+    const group = new GroupResource(GroupModel, groupModel.get());
+    assert(group.isGlobal(), "Only the global group can be a viewer group");
+
+    return new GroupSpaceViewerResource(
+      GroupSpaceModel,
+      groupSpaces[0].get(),
+      space,
+      group
+    );
+  }
+
+  async requestedPermissions(): Promise<CombinedResourcePermissions[]> {
+    assert(
+      this.space.isProject(),
+      "Viewer permissions only apply to project spaces"
+    );
+    // Only gets the editor groups correponding to the space management mode
+    const editorGroupSpaces = await this.getEditorGroupSpaces(true);
+    const editorGroupsPermissions: GroupPermission[] = editorGroupSpaces.map(
+      (egs) => ({
+        id: egs.groupId,
+        permissions: ["admin", "read", "write"],
+      })
+    );
+    return [
+      {
+        groups: [
+          {
+            id: this.group.id,
+            permissions: ["read"],
+          },
+          ...editorGroupsPermissions,
+        ],
+        roles: [
+          {
+            role: "admin",
+            permissions: ["admin", "read", "write"],
+          },
+        ],
+        workspaceId: this.space.workspaceId,
+      },
+    ];
+  }
+}

--- a/front/lib/resources/space_resource.test.ts
+++ b/front/lib/resources/space_resource.test.ts
@@ -3,6 +3,10 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { GroupResource } from "@app/lib/resources/group_resource";
+import {
+  GroupSpaceEditorResource,
+  GroupSpaceMemberResource,
+} from "@app/lib/resources/group_space_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
 import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces";
@@ -95,6 +99,7 @@ describe("SpaceResource", () => {
           isRestricted: false,
           managementMode: "manual",
           memberIds: [user1.sId],
+          editorIds: [],
         });
 
         expect(result.isErr()).toBe(true);
@@ -113,6 +118,7 @@ describe("SpaceResource", () => {
           isRestricted: false,
           managementMode: "manual",
           memberIds: [user1.sId],
+          editorIds: [],
         });
 
         expect(result.isErr()).toBe(true);
@@ -130,6 +136,7 @@ describe("SpaceResource", () => {
           isRestricted: true,
           managementMode: "manual",
           memberIds: [user1.sId, user2.sId],
+          editorIds: [],
         });
 
         expect(result.isOk()).toBe(true);
@@ -159,6 +166,7 @@ describe("SpaceResource", () => {
           isRestricted: true,
           managementMode: "group",
           groupIds: [provisionedGroup.sId],
+          editorGroupIds: [],
         });
         expect(groupResult.isOk()).toBe(true);
 
@@ -175,6 +183,7 @@ describe("SpaceResource", () => {
           isRestricted: true,
           managementMode: "manual",
           memberIds: [user1.sId],
+          editorIds: [],
         });
 
         expect(result.isOk()).toBe(true);
@@ -205,6 +214,7 @@ describe("SpaceResource", () => {
           isRestricted: true,
           managementMode: "group",
           groupIds: [provisionedGroup.sId],
+          editorGroupIds: [],
         });
         expect(groupResult.isOk()).toBe(true);
 
@@ -234,6 +244,7 @@ describe("SpaceResource", () => {
             isRestricted: true,
             managementMode: "manual",
             memberIds: [user1.sId, user2.sId],
+            editorIds: [],
           }
         );
         expect(manualResult.isOk()).toBe(true);
@@ -269,6 +280,7 @@ describe("SpaceResource", () => {
           isRestricted: true,
           managementMode: "group",
           groupIds: [provisionedGroup1.sId, provisionedGroup2.sId],
+          editorGroupIds: [],
         });
 
         expect(result.isOk()).toBe(true);
@@ -309,6 +321,7 @@ describe("SpaceResource", () => {
           isRestricted: true,
           managementMode: "group",
           groupIds: [provisionedGroup1.sId],
+          editorGroupIds: [],
         });
         expect(firstResult.isOk()).toBe(true);
 
@@ -326,6 +339,7 @@ describe("SpaceResource", () => {
             isRestricted: true,
             managementMode: "group",
             groupIds: [provisionedGroup2.sId],
+            editorGroupIds: [],
           }
         );
 
@@ -351,6 +365,7 @@ describe("SpaceResource", () => {
           isRestricted: true,
           managementMode: "manual",
           memberIds: [user1.sId],
+          editorIds: [],
         });
         expect(manualResult.isOk()).toBe(true);
 
@@ -373,6 +388,7 @@ describe("SpaceResource", () => {
           isRestricted: true,
           managementMode: "group",
           groupIds: [provisionedGroup.sId],
+          editorGroupIds: [],
         });
 
         expect(result.isOk()).toBe(true);
@@ -397,6 +413,7 @@ describe("SpaceResource", () => {
           isRestricted: true,
           managementMode: "manual",
           memberIds: [user1.sId, user2.sId],
+          editorIds: [],
         });
 
         // Verify members are active
@@ -427,6 +444,7 @@ describe("SpaceResource", () => {
           isRestricted: true,
           managementMode: "group",
           groupIds: [provisionedGroup.sId],
+          editorGroupIds: [],
         });
         expect(result.isOk()).toBe(true);
 
@@ -450,6 +468,7 @@ describe("SpaceResource", () => {
           isRestricted: false,
           managementMode: "manual",
           memberIds: [user1.sId],
+          editorIds: [],
         });
 
         expect(result.isOk()).toBe(true);
@@ -467,11 +486,9 @@ describe("SpaceResource", () => {
 
       it("should remove global group when changing from open to restricted", async () => {
         // First add global group to make it open
-        await GroupSpaceModel.create({
-          groupId: globalGroup.id,
-          vaultId: regularSpace.id,
-          workspaceId: workspace.id,
-          kind: "member",
+        await GroupSpaceMemberResource.makeNew(adminAuth, {
+          group: globalGroup,
+          space: regularSpace,
         });
 
         // Reload space to get updated groups
@@ -488,6 +505,7 @@ describe("SpaceResource", () => {
             isRestricted: true,
             managementMode: "manual",
             memberIds: [user1.sId],
+            editorIds: [],
           }
         );
 
@@ -511,6 +529,7 @@ describe("SpaceResource", () => {
           isRestricted: true,
           managementMode: "manual",
           memberIds: [user1.sId],
+          editorIds: [],
         });
 
         const groupSpacesBefore = await GroupSpaceModel.findAll({
@@ -529,6 +548,7 @@ describe("SpaceResource", () => {
           isRestricted: true,
           managementMode: "manual",
           memberIds: [user2.sId],
+          editorIds: [],
         });
 
         const groupSpacesAfter = await GroupSpaceModel.findAll({
@@ -552,6 +572,7 @@ describe("SpaceResource", () => {
           isRestricted: true,
           managementMode: "group",
           groupIds: ["invalid-group-id"],
+          editorGroupIds: [],
         });
 
         expect(result.isErr()).toBe(true);
@@ -568,6 +589,7 @@ describe("SpaceResource", () => {
           isRestricted: true,
           managementMode: "manual",
           memberIds: ["invalid-user-id"],
+          editorIds: [],
         });
 
         // The method should handle this gracefully
@@ -583,6 +605,7 @@ describe("SpaceResource", () => {
           isRestricted: true,
           managementMode: "group",
           groupIds: [],
+          editorGroupIds: [],
         });
         expect(groupResult.isOk()).toBe(true);
 
@@ -597,6 +620,7 @@ describe("SpaceResource", () => {
           isRestricted: true,
           managementMode: "manual",
           memberIds: [user1.sId],
+          editorIds: [],
         });
         expect(manualResult.isOk()).toBe(true);
 
@@ -605,6 +629,326 @@ describe("SpaceResource", () => {
           regularSpace.sId
         );
         expect(updatedSpace2?.managementMode).toBe("manual");
+      });
+    });
+
+    describe("project space editor and member permissions", () => {
+      let projectSpace: SpaceResource;
+      let projectMemberGroup: GroupResource;
+      let projectEditorGroup: GroupResource;
+      let editorUser: UserResource;
+      let memberUser: UserResource;
+      let nonMemberUser: UserResource;
+
+      beforeEach(async () => {
+        // Create users for testing
+        editorUser = await UserFactory.basic();
+        memberUser = await UserFactory.basic();
+        nonMemberUser = await UserFactory.basic();
+
+        await MembershipFactory.associate(workspace, editorUser, {
+          role: "user",
+        });
+        await MembershipFactory.associate(workspace, memberUser, {
+          role: "user",
+        });
+        await MembershipFactory.associate(workspace, nonMemberUser, {
+          role: "user",
+        });
+
+        // Create a project space with member and editor groups
+        projectMemberGroup = await GroupResource.makeNew({
+          name: "Project Members Group",
+          workspaceId: workspace.id,
+          kind: "regular",
+        });
+      });
+
+      describe("with manual groups", () => {
+        beforeEach(async () => {
+          projectEditorGroup = await GroupResource.makeNew({
+            name: "Project Editors Group",
+            workspaceId: workspace.id,
+            kind: "space_editors",
+          });
+
+          projectSpace = await SpaceResource.makeNew(
+            {
+              name: "Test Project Space",
+              kind: "project",
+              workspaceId: workspace.id,
+              managementMode: "manual",
+            },
+            { members: [projectMemberGroup] }
+          );
+
+          // Link the editor group to the project space with kind="project_editor"
+          await GroupSpaceEditorResource.makeNew(adminAuth, {
+            group: projectEditorGroup,
+            space: projectSpace,
+          });
+        });
+
+        it("should not allow simple members to update space permissions", async () => {
+          // Add user as a simple member
+          await projectMemberGroup.addMember(adminAuth, {
+            user: memberUser.toJSON(),
+          });
+
+          // Create an authenticator for the member user
+          const memberAuth = await Authenticator.fromUserIdAndWorkspaceId(
+            memberUser.sId,
+            workspace.sId
+          );
+
+          // Reload space to get updated groups
+          const reloadedSpace = await SpaceResource.fetchById(
+            adminAuth,
+            projectSpace.sId
+          );
+
+          // Member should NOT be able to update space permissions
+          const result = await reloadedSpace!.updatePermissions(memberAuth, {
+            name: "Test Project Space",
+            isRestricted: true,
+            managementMode: "manual",
+            memberIds: [user1.sId],
+            editorIds: [],
+          });
+
+          expect(result.isErr()).toBe(true);
+          if (result.isErr()) {
+            expect(result.error.code).toBe("unauthorized");
+          }
+        });
+
+        it("should not allow non-members to update space permissions", async () => {
+          // Create an authenticator for a non-member user
+          const nonMemberAuth = await Authenticator.fromUserIdAndWorkspaceId(
+            nonMemberUser.sId,
+            workspace.sId
+          );
+
+          // Reload space to get updated groups
+          const reloadedSpace = await SpaceResource.fetchById(
+            adminAuth,
+            projectSpace.sId
+          );
+
+          // Non-member should NOT be able to update space permissions
+          const result = await reloadedSpace!.updatePermissions(nonMemberAuth, {
+            name: "Test Project Space",
+            isRestricted: true,
+            managementMode: "manual",
+            memberIds: [user1.sId],
+            editorIds: [],
+          });
+
+          expect(result.isErr()).toBe(true);
+          if (result.isErr()) {
+            expect(result.error.code).toBe("unauthorized");
+          }
+        });
+
+        it("should allow editors to manage members through updatePermissions", async () => {
+          // Add editor to the editor group
+          await projectEditorGroup.addMember(adminAuth, {
+            user: editorUser.toJSON(),
+          });
+
+          // Create an authenticator for the editor user
+          const editorAuth = await Authenticator.fromUserIdAndWorkspaceId(
+            editorUser.sId,
+            workspace.sId
+          );
+
+          // Reload space to get updated groups
+          const reloadedSpace = await SpaceResource.fetchById(
+            editorAuth,
+            projectSpace.sId
+          );
+
+          // Editor should be able to manage members through updatePermissions
+          const result = await reloadedSpace!.updatePermissions(editorAuth, {
+            name: "Test Project Space",
+            isRestricted: true,
+            managementMode: "manual",
+            memberIds: [user1.sId, user2.sId],
+            editorIds: [editorUser.sId],
+          });
+
+          expect(result.isOk()).toBe(true);
+
+          // Verify members were added
+          const members = await projectMemberGroup.getActiveMembers(adminAuth);
+          const memberSIds = members.map((m) => m.sId);
+          expect(memberSIds).toContain(user1.sId);
+          expect(memberSIds).toContain(user2.sId);
+
+          // Verify editor is still in the editor group
+          const editors = await projectEditorGroup.getActiveMembers(adminAuth);
+          const editorSIds = editors.map((m) => m.sId);
+          expect(editorSIds).toContain(editorUser.sId);
+        });
+      });
+
+      describe("with provisioned groups", () => {
+        let provisionedMemberGroup: GroupResource;
+        let provisionedEditorGroup: GroupResource;
+
+        beforeEach(async () => {
+          // Create provisioned groups
+          provisionedMemberGroup = await GroupResource.makeNew({
+            name: "Provisioned Members Group",
+            workspaceId: workspace.id,
+            kind: "provisioned",
+          });
+
+          provisionedEditorGroup = await GroupResource.makeNew({
+            name: "Provisioned Editors Group",
+            workspaceId: workspace.id,
+            kind: "provisioned",
+          });
+
+          projectSpace = await SpaceResource.makeNew(
+            {
+              name: "Test Project Space",
+              kind: "project",
+              workspaceId: workspace.id,
+              managementMode: "group",
+            },
+            { members: [projectMemberGroup, provisionedMemberGroup] }
+          );
+
+          // Link the editor group to the project space with kind="project_editor"
+          await GroupSpaceEditorResource.makeNew(adminAuth, {
+            group: provisionedEditorGroup,
+            space: projectSpace,
+          });
+        });
+
+        it("should not allow simple members to update space permissions", async () => {
+          // Add user as a simple member to the provisioned group
+          await provisionedMemberGroup.addMember(adminAuth, {
+            user: memberUser.toJSON(),
+          });
+
+          // Create an authenticator for the member user
+          const memberAuth = await Authenticator.fromUserIdAndWorkspaceId(
+            memberUser.sId,
+            workspace.sId
+          );
+
+          // Reload space to get updated groups
+          const reloadedSpace = await SpaceResource.fetchById(
+            adminAuth,
+            projectSpace.sId
+          );
+
+          // Member should NOT be able to update space permissions
+          const result = await reloadedSpace!.updatePermissions(memberAuth, {
+            name: "Test Project Space",
+            isRestricted: true,
+            managementMode: "group",
+            groupIds: [provisionedMemberGroup.sId],
+            editorGroupIds: [],
+          });
+
+          expect(result.isErr()).toBe(true);
+          if (result.isErr()) {
+            expect(result.error.code).toBe("unauthorized");
+          }
+        });
+
+        it("should not allow non-members to update space permissions", async () => {
+          // Create an authenticator for a non-member user
+          const nonMemberAuth = await Authenticator.fromUserIdAndWorkspaceId(
+            nonMemberUser.sId,
+            workspace.sId
+          );
+
+          // Reload space to get updated groups
+          const reloadedSpace = await SpaceResource.fetchById(
+            adminAuth,
+            projectSpace.sId
+          );
+
+          // Non-member should NOT be able to update space permissions
+          const result = await reloadedSpace!.updatePermissions(nonMemberAuth, {
+            name: "Test Project Space",
+            isRestricted: true,
+            managementMode: "group",
+            groupIds: [provisionedMemberGroup.sId],
+            editorGroupIds: [],
+          });
+
+          expect(result.isErr()).toBe(true);
+          if (result.isErr()) {
+            expect(result.error.code).toBe("unauthorized");
+          }
+        });
+
+        it("should allow editors to manage members through updatePermissions", async () => {
+          // Add editor to the provisioned editor group
+          await provisionedEditorGroup.addMember(adminAuth, {
+            user: editorUser.toJSON(),
+          });
+
+          // Create another provisioned group for the new members
+          const newProvisionedMemberGroup = await GroupResource.makeNew({
+            name: "New Provisioned Members Group",
+            workspaceId: workspace.id,
+            kind: "provisioned",
+          });
+
+          // Add members to the new provisioned group
+          await newProvisionedMemberGroup.addMembers(adminAuth, {
+            users: [user1.toJSON(), user2.toJSON(), editorUser.toJSON()],
+          });
+
+          // Create an authenticator for the editor user
+          const editorAuth = await Authenticator.fromUserIdAndWorkspaceId(
+            editorUser.sId,
+            workspace.sId
+          );
+
+          // Reload space to get updated groups
+          const reloadedSpace = await SpaceResource.fetchById(
+            editorAuth,
+            projectSpace.sId
+          );
+
+          expect(newProvisionedMemberGroup.canRead(editorAuth)).toBe(true);
+
+          // Editor should be able to manage members through updatePermissions
+          const result = await reloadedSpace!.updatePermissions(editorAuth, {
+            name: "Test Project Space",
+            isRestricted: true,
+            managementMode: "group",
+            groupIds: [newProvisionedMemberGroup.sId],
+            editorGroupIds: [provisionedEditorGroup.sId], // Keep the editor group
+          });
+
+          expect(result.isOk()).toBe(true);
+
+          // Verify the new provisioned group is associated
+          const groupSpaces = await GroupSpaceMemberResource.fetchBySpace({
+            space: projectSpace,
+          });
+          const associatedGroupIds = groupSpaces.map((gs) => gs.groupId);
+          expect(associatedGroupIds).toContain(newProvisionedMemberGroup.id);
+
+          // Verify editor group is still associated
+          const editorGroupSpaces = await GroupSpaceModel.findAll({
+            where: {
+              vaultId: projectSpace.id,
+              workspaceId: workspace.id,
+              kind: "project_editor",
+            },
+          });
+          const editorGroupIds = editorGroupSpaces.map((gs) => gs.groupId);
+          expect(editorGroupIds).toContain(provisionedEditorGroup.id);
+        });
       });
     });
   });

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -12,6 +12,11 @@ import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
+import {
+  GroupSpaceEditorResource,
+  GroupSpaceMemberResource,
+  GroupSpaceViewerResource,
+} from "@app/lib/resources/group_space_resource";
 import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
 import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces";
 import { GroupModel } from "@app/lib/resources/storage/models/groups";
@@ -37,6 +42,7 @@ import {
   Err,
   GLOBAL_SPACE_NAME,
   Ok,
+  PROJECT_EDITOR_GROUP_PREFIX,
   removeNulls,
 } from "@app/types";
 
@@ -516,8 +522,12 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       name: string;
       isRestricted: boolean;
     } & (
-      | { memberIds: string[]; managementMode: "manual" }
-      | { groupIds: string[]; managementMode: "group" }
+      | { memberIds: string[]; managementMode: "manual"; editorIds: string[] }
+      | {
+          groupIds: string[];
+          managementMode: "group";
+          editorGroupIds: string[];
+        }
     )
   ): Promise<
     Result<
@@ -554,19 +564,6 @@ export class SpaceResource extends BaseResource<SpaceModel> {
 
     const { isRestricted } = params;
 
-    const regularGroups = this.groups.filter(
-      (group) => group.kind === "regular"
-    );
-
-    // Ensure exactly one regular group is associated with the space.
-    // IMPORTANT: This constraint is critical for the requestedPermissions() method logic.
-    // Modifying this requires careful review and updates to requestedPermissions().
-    assert(
-      regularGroups.length === 1,
-      `Expected exactly one regular group for the space, but found ${regularGroups.length}.`
-    );
-    const [defaultSpaceGroup] = regularGroups;
-
     const wasRestricted = this.groups.every((g) => !g.isGlobal());
 
     const groupRes = await GroupResource.fetchWorkspaceGlobalGroup(auth);
@@ -582,12 +579,25 @@ export class SpaceResource extends BaseResource<SpaceModel> {
 
       // If the space should be restricted and was not restricted before, remove the global group.
       if (!wasRestricted && isRestricted) {
-        await this.removeGroup(auth, globalGroup);
+        await this.removeGroup(auth, globalGroup, t);
       }
 
       // If the space should not be restricted and was restricted before, add the global group.
       if (wasRestricted && !isRestricted) {
-        await this.addGroup(auth, globalGroup);
+        if (this.isProject()) {
+          // Global group gets viewer permissions in projects
+          await GroupSpaceViewerResource.makeNew(auth, {
+            group: globalGroup,
+            space: this,
+            transaction: t,
+          });
+        } else {
+          await GroupSpaceMemberResource.makeNew(auth, {
+            group: globalGroup,
+            space: this,
+            transaction: t,
+          });
+        }
       }
 
       const previousManagementMode = this.managementMode;
@@ -609,33 +619,91 @@ export class SpaceResource extends BaseResource<SpaceModel> {
 
       if (managementMode === "manual") {
         const memberIds = params.memberIds;
+        const editorIds = params.editorIds;
+
         // Handle member-based management
         const users = await UserResource.fetchByIds(memberIds);
 
-        const setMembersRes = await defaultSpaceGroup.setMembers(auth, {
+        // Get the GroupSpaceMemberResource for the member group
+        const memberGroupSpaces = await GroupSpaceMemberResource.fetchBySpace({
+          space: this,
+          transaction: t,
+          filterOnManagementMode: true,
+        });
+
+        assert(
+          memberGroupSpaces.length === 1,
+          "In manual management mode, there should be exactly one member group space."
+        );
+
+        const setMembersRes = await memberGroupSpaces[0].setMembers(auth, {
           users: users.map((u) => u.toJSON()),
           transaction: t,
         });
         if (setMembersRes.isErr()) {
           return setMembersRes;
         }
+
+        // Handle editor group - create if needed and update members
+        if (this.isProject()) {
+          let editorGroupSpaces = await GroupSpaceEditorResource.fetchBySpace({
+            space: this,
+            transaction: t,
+            filterOnManagementMode: true,
+          });
+
+          if (!editorGroupSpaces.length) {
+            // Create a new editor group
+            const editorGroup = await GroupResource.makeNew(
+              {
+                name: `${PROJECT_EDITOR_GROUP_PREFIX} ${this.name}`,
+                kind: "space_editors",
+                workspaceId: this.workspaceId,
+              },
+              { transaction: t }
+            );
+
+            // Link the editor group to the space
+            const editorGroupSpace = await GroupSpaceEditorResource.makeNew(
+              auth,
+              {
+                group: editorGroup,
+                space: this,
+                transaction: t,
+              }
+            );
+            editorGroupSpaces = [editorGroupSpace];
+          }
+          assert(
+            editorGroupSpaces.length === 1,
+            "In manual management mode, there should be exactly one editor group space."
+          );
+
+          // Set members of the editor group using the GroupSpaceEditorResource
+          const editorUsers = await UserResource.fetchByIds(editorIds);
+          assert(
+            editorUsers.length > 0,
+            "Projects must have at least one editor."
+          );
+          const setEditorsRes = await editorGroupSpaces[0].setMembers(auth, {
+            users: editorUsers.map((u) => u.toJSON()),
+            transaction: t,
+          });
+          if (setEditorsRes.isErr()) {
+            return setEditorsRes;
+          }
+        }
       } else if (managementMode === "group") {
         // Handle group-based management
         const groupIds = params.groupIds;
+        const editorGroupIds = params.editorGroupIds;
 
         // Remove existing external groups
         const existingExternalGroups = this.groups.filter(
           (g) => g.kind === "provisioned"
         );
         for (const group of existingExternalGroups) {
-          await GroupSpaceModel.destroy({
-            where: {
-              groupId: group.id,
-              vaultId: this.id,
-              workspaceId: auth.getNonNullableWorkspace().id,
-            },
-            transaction: t,
-          });
+          await this.removeGroup(auth, group, t);
         }
 
         // Add the new groups
@@ -646,18 +714,40 @@ export class SpaceResource extends BaseResource<SpaceModel> {
         if (selectedGroupsResult.isErr()) {
           return selectedGroupsResult;
         }
-
         const selectedGroups = selectedGroupsResult.value;
         for (const selectedGroup of selectedGroups) {
-          await GroupSpaceModel.create(
-            {
-              groupId: selectedGroup.id,
-              vaultId: this.id,
-              workspaceId: this.workspaceId,
-              kind: "member",
-            },
-            { transaction: t }
+          await GroupSpaceMemberResource.makeNew(auth, {
+            group: selectedGroup,
+            space: this,
+            transaction: t,
+          });
+        }
+
+        if (this.isProject()) {
+          assert(
+            editorGroupIds.length > 0,
+            "Projects must have at least one editor group."
           );
+          // Add the new editor groups
+          const editorGroupsResult = await GroupResource.fetchByIds(
+            auth,
+            editorGroupIds
+          );
+          if (editorGroupsResult.isErr()) {
+            return editorGroupsResult;
+          }
+          const selectedEditorGroups = editorGroupsResult.value;
+          assert(
+            selectedEditorGroups.length > 0,
+            "Projects must have at least one editor group."
+          );
+          for (const selectedEditorGroup of selectedEditorGroups) {
+            await GroupSpaceEditorResource.makeNew(auth, {
+              group: selectedEditorGroup,
+              space: this,
+              transaction: t,
+            });
+          }
         }
       }
 
@@ -665,22 +755,18 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     });
   }
 
-  private async addGroup(auth: Authenticator, group: GroupResource) {
-    await GroupSpaceModel.create({
-      groupId: group.id,
-      vaultId: this.id,
-      workspaceId: auth.getNonNullableWorkspace().id,
-      kind: "member",
-    });
-  }
-
-  private async removeGroup(auth: Authenticator, group: GroupResource) {
+  private async removeGroup(
+    auth: Authenticator,
+    group: GroupResource,
+    transaction?: Transaction
+  ) {
     await GroupSpaceModel.destroy({
       where: {
         groupId: group.id,
         vaultId: this.id,
         workspaceId: auth.getNonNullableWorkspace().id,
       },
+      transaction,
     });
   }
 
@@ -700,6 +786,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
         | "user_already_member"
         | "group_requirements_not_met"
         | "system_or_global_group"
+        | "group_not_found"
       >
     >
   > {
@@ -712,14 +799,32 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       );
     }
 
-    const defaultSpaceGroup = this.getSpaceManualMemberGroup();
+    assert(
+      this.isRegular() || this.isProject(),
+      "Only regular spaces and projects can have manual members."
+    );
+    assert(
+      this.managementMode === "manual",
+      "Can only add members in manual management mode."
+    );
+
     const users = await UserResource.fetchByIds(userIds);
 
     if (!users) {
       return new Err(new DustError("user_not_found", "User not found."));
     }
 
-    const addMemberRes = await defaultSpaceGroup.addMembers(auth, {
+    const memberGroupSpaces = await GroupSpaceMemberResource.fetchBySpace({
+      space: this,
+      filterOnManagementMode: true,
+    });
+
+    assert(
+      memberGroupSpaces.length === 1,
+      "In manual management mode, there should be exactly one member group space."
+    );
+
+    const addMemberRes = await memberGroupSpaces[0].addMembers(auth, {
       users: users.map((user) => user.toJSON()),
     });
 
@@ -745,6 +850,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
         | "user_not_found"
         | "user_not_member"
         | "system_or_global_group"
+        | "group_not_found"
       >
     >
   > {
@@ -752,19 +858,29 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       return new Err(
         new DustError(
           "unauthorized",
-          "You do not have permission to add members to this space."
+          "You do not have permission to remove members from this space."
         )
       );
     }
 
-    const defaultSpaceGroup = this.getSpaceManualMemberGroup();
     const users = await UserResource.fetchByIds(userIds);
 
     if (!users) {
       return new Err(new DustError("user_not_found", "User not found."));
     }
 
-    const removeMemberRes = await defaultSpaceGroup.removeMembers(auth, {
+    // Get the GroupSpaceMemberResource for the member group
+    const memberGroupSpaces = await GroupSpaceMemberResource.fetchBySpace({
+      space: this,
+      filterOnManagementMode: true,
+    });
+
+    assert(
+      memberGroupSpaces.length === 1,
+      "In manual management mode, there should be exactly one member group space."
+    );
+
+    const removeMemberRes = await memberGroupSpaces[0].removeMembers(auth, {
       users: users.map((user) => user.toJSON()),
     });
 
@@ -960,7 +1076,38 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       ];
     }
 
-    // Restricted space.
+    if (this.isProject()) {
+      return [
+        {
+          workspaceId: this.workspaceId,
+          roles: [
+            { role: "admin", permissions: ["admin", "read", "write"] },
+            { role: "user", permissions: this.isOpen() ? ["read"] : [] }, // Non-restricted projects are visible to all users
+          ],
+          groups: this.groups.reduce((acc, group) => {
+            if (groupFilter(group)) {
+              const groupKind = group.group_vaults?.kind;
+              if (groupKind === "project_editor") {
+                // Project editors get admin permissions
+                acc.push({
+                  id: group.id,
+                  permissions: ["admin", "read", "write"],
+                });
+              } else {
+                // Members get read permissions in restricted projects (the unrestricted case is handled by the roles above)
+                acc.push({
+                  id: group.id,
+                  permissions: ["read", "write"],
+                });
+              }
+            }
+            return acc;
+          }, [] as GroupPermission[]),
+        },
+      ];
+    }
+
+    // Restricted regular space.
     return [
       {
         workspaceId: this.workspaceId,
@@ -1020,7 +1167,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   }
 
   isProjectAndRestricted() {
-    return this.isProject() && !this.groups.some((group) => group.isGlobal());
+    return this.isProject() && !this.isOpen();
   }
 
   isRegularAndOpen() {

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -553,6 +553,7 @@ export function useUpdateSpace({ owner }: { owner: LightWorkspaceType }) {
             isRestricted,
             managementMode,
             memberIds: params.memberIds,
+            editorIds: params.editorIds,
           }),
         })
       );
@@ -568,6 +569,7 @@ export function useUpdateSpace({ owner }: { owner: LightWorkspaceType }) {
             isRestricted,
             managementMode,
             groupIds: params.groupIds,
+            editorGroupIds: params.editorGroupIds,
           }),
         })
       );

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -554,7 +554,7 @@ export function useUpdateSpace({ owner }: { owner: LightWorkspaceType }) {
             managementMode,
             memberIds: params.memberIds,
             editorIds: params.editorIds,
-          }),
+          } satisfies PatchSpaceMembersRequestBodyType),
         })
       );
     } else if (managementMode === "group") {
@@ -570,7 +570,7 @@ export function useUpdateSpace({ owner }: { owner: LightWorkspaceType }) {
             managementMode,
             groupIds: params.groupIds,
             editorGroupIds: params.editorGroupIds,
-          }),
+          } satisfies PatchSpaceMembersRequestBodyType),
         })
       );
     }

--- a/front/migrations/20241205_update_space_group_names.ts
+++ b/front/migrations/20241205_update_space_group_names.ts
@@ -3,6 +3,11 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
 import { makeScript } from "@app/scripts/helpers";
 import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
+import {
+  PROJECT_EDITOR_GROUP_PREFIX,
+  PROJECT_GROUP_PREFIX,
+  SPACE_GROUP_PREFIX,
+} from "@app/types";
 
 makeScript({}, async ({ execute }) => {
   await runOnAllWorkspaces(async (w) => {
@@ -19,10 +24,13 @@ makeScript({}, async ({ execute }) => {
       if (regularGroups.length === 1) {
         const group = regularGroups[0];
         if (execute) {
-          await group.updateName(auth, `Group for space ${space.name}`);
+          await group.updateName(
+            auth,
+            `${space.isProject() ? PROJECT_GROUP_PREFIX : SPACE_GROUP_PREFIX} ${space.name}`
+          );
         }
         logger.info(
-          `[Execute: ${execute}] Updating group ${group.id} to "Group for space ${space.name}"`
+          `[Execute: ${execute}] Updating group ${group.id} to "${space.isProject() ? PROJECT_GROUP_PREFIX : SPACE_GROUP_PREFIX} ${space.name}"`
         );
       }
 
@@ -32,10 +40,13 @@ makeScript({}, async ({ execute }) => {
       if (spaceEditorsGroups.length === 1) {
         const group = spaceEditorsGroups[0];
         if (execute) {
-          await group.updateName(auth, `Editors for space ${space.name}`);
+          await group.updateName(
+            auth,
+            `${PROJECT_EDITOR_GROUP_PREFIX} ${space.name}`
+          );
         }
         logger.info(
-          `[Execute: ${execute}] Updating group ${group.id} to "Editors for space ${space.name}"`
+          `[Execute: ${execute}] Updating group ${group.id} to "${PROJECT_EDITOR_GROUP_PREFIX} ${space.name}"`
         );
       }
     }

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/members/[userId].ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/members/[userId].ts
@@ -116,6 +116,14 @@ async function handler(
                   "Users cannot be removed from system or global groups.",
               },
             });
+          case "group_not_found":
+            return apiError(req, res, {
+              status_code: 404,
+              api_error: {
+                type: "group_not_found",
+                message: "The group was not found in the workspace.",
+              },
+            });
           default:
             assertNever(updateRes.error.code);
         }

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/members/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/members/index.ts
@@ -160,6 +160,14 @@ async function handler(
                   "Users cannot be removed from system or global groups.",
               },
             });
+          case "group_not_found":
+            return apiError(req, res, {
+              status_code: 404,
+              api_error: {
+                type: "group_not_found",
+                message: "The group was not found in the workspace.",
+              },
+            });
           default:
             assertNever(updateRes.error.code);
         }

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/members.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/members.ts
@@ -25,10 +25,12 @@ const PatchSpaceMembersRequestBodySchema = t.intersection([
     t.type({
       memberIds: t.array(t.string),
       managementMode: t.literal("manual"),
+      editorIds: t.array(t.string),
     }),
     t.type({
       groupIds: t.array(t.string),
       managementMode: t.literal("group"),
+      editorGroupIds: t.array(t.string),
     }),
   ]),
 ]);

--- a/front/tests/utils/SpaceFactory.ts
+++ b/front/tests/utils/SpaceFactory.ts
@@ -4,8 +4,14 @@ import type { Authenticator } from "@app/lib/auth";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
 import type { WorkspaceType } from "@app/types";
-import { removeNulls } from "@app/types";
+import {
+  PROJECT_EDITOR_GROUP_PREFIX,
+  PROJECT_GROUP_PREFIX,
+  removeNulls,
+  SPACE_GROUP_PREFIX,
+} from "@app/types";
 
 export class SpaceFactory {
   static async defaults(auth: Authenticator) {
@@ -52,7 +58,7 @@ export class SpaceFactory {
   static async regular(workspace: WorkspaceType) {
     const name = "space " + faker.string.alphanumeric(8);
     const group = await GroupResource.makeNew({
-      name: `Group for space ${name}`,
+      name: `${SPACE_GROUP_PREFIX} ${name}`,
       workspaceId: workspace.id,
       kind: "regular",
     });
@@ -78,13 +84,26 @@ export class SpaceFactory {
     );
   }
 
-  static async project(workspace: WorkspaceType) {
+  static async project(workspace: WorkspaceType, creatorId?: number) {
     const name = "project " + faker.string.alphanumeric(8);
     const group = await GroupResource.makeNew({
-      name: `Group for space ${name}`,
+      name: `${PROJECT_GROUP_PREFIX} ${name}`,
       workspaceId: workspace.id,
       kind: "regular",
     });
+
+    // Create an editor group with the creator as a member if creatorId is provided
+    const defaultCreator = await UserFactory.basic();
+    const editorGroup = await GroupResource.makeNew(
+      {
+        name: `${PROJECT_EDITOR_GROUP_PREFIX} ${name}`,
+        workspaceId: workspace.id,
+        kind: "space_editors",
+      },
+      {
+        memberIds: [creatorId ?? defaultCreator.id],
+      }
+    );
 
     return SpaceResource.makeNew(
       {
@@ -92,7 +111,7 @@ export class SpaceFactory {
         kind: "project",
         workspaceId: workspace.id,
       },
-      { members: [group] }
+      { members: [group], editors: [editorGroup] }
     );
   }
 }

--- a/front/types/groups.ts
+++ b/front/types/groups.ts
@@ -127,4 +127,5 @@ export const AGENT_GROUP_PREFIX = "Group for Agent";
 export const SKILL_GROUP_PREFIX = "Group for Skill";
 export const SPACE_GROUP_PREFIX = "Group for space";
 export const PROJECT_GROUP_PREFIX = "Group for project";
+export const PROJECT_EDITOR_GROUP_PREFIX = "Editors for project";
 export const GLOBAL_SPACE_NAME = "Company Data";


### PR DESCRIPTION
This PR is the fix of the PR [20297](https://github.com/dust-tt/dust/pull/20297), which was reverted due to a bug. 

## Description

This PR sets the permission in projects.

Create a project: anyone can create projects
Update a project: project editors can manage the project
Projects have several layers of permissions:

viewers (can be everyone or nobody, base on if the project is restricted or not),
members (can see the project)
and editors (manage project members and settings without requiring workspace admin privileges). Project creators are editors by default.

## Tests

Added unit tests

## Risk

Medium. The code is shared with the regular spaces. A risk of breaking regular spaces permissions exist.

## Deploy Plan

Deploy front
