### PR TITLE
Bump Viz PDF readiness to 5 seconds

### DIFF
--- a/viz/app/components/VisualizationWrapper.tsx
+++ b/viz/app/components/VisualizationWrapper.tsx
@@ -459,7 +459,7 @@ export function VisualizationWrapper({
             } else {
               // Set data-viz-ready attribute once fully rendered to enable screen capture.
               // In PDF mode, delay to let Recharts animations complete (react-smooth is JS-based).
-              const delayMs = isPdfMode ? 2000 : 0;
+              const delayMs = isPdfMode ? 5000 : 0;
               setTimeout(() => setVizReady(true), delayMs);
             }
           }}


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Many frames are loading data (while this does not take a lot of time), post-processing it (like Papaparse) actually takes some time. While we implement a more robust solution (AI assisted) this PR bumps the delay before capturing from 2 seconds to 5 seconds.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
