### PR TITLE
[front] -  refacto(spaces): migrate page

### DIFF
--- a/front/lib/swr/apps.ts
+++ b/front/lib/swr/apps.ts
@@ -139,23 +139,27 @@ export function useDustAppSecrets(owner: LightWorkspaceType | null) {
 
 export function useRuns(
   owner: LightWorkspaceType,
-  app: AppType,
+  app: AppType | null,
   limit: number,
   offset: number,
   runType: RunRunType,
   wIdTarget: string | null
 ) {
   const runsFetcher: Fetcher<GetRunsResponseBody> = fetcher;
-  let url = `/api/w/${owner.sId}/spaces/${app.space.sId}/apps/${app.sId}/runs?limit=${limit}&offset=${offset}&runType=${runType}`;
-  if (wIdTarget) {
-    url += `&wIdTarget=${wIdTarget}`;
+  const disabled = !app;
+  let url: string | null = null;
+  if (app) {
+    url = `/api/w/${owner.sId}/spaces/${app.space.sId}/apps/${app.sId}/runs?limit=${limit}&offset=${offset}&runType=${runType}`;
+    if (wIdTarget) {
+      url += `&wIdTarget=${wIdTarget}`;
+    }
   }
-  const { data, error } = useSWRWithDefaults(url, runsFetcher);
+  const { data, error } = useSWRWithDefaults(url, runsFetcher, { disabled });
 
   return {
     runs: data?.runs ?? emptyArray(),
     total: data ? data.total : 0,
-    isRunsLoading: !error && !data,
+    isRunsLoading: !disabled && !error && !data,
     isRunsError: error,
   };
 }

--- a/front/lib/swr/apps.ts
+++ b/front/lib/swr/apps.ts
@@ -78,12 +78,14 @@ export function useApp({
 
 export function useSavedRunStatus(
   owner: LightWorkspaceType,
-  app: AppType,
+  app: AppType | null,
   refresh: (data: GetRunStatusResponseBody | undefined) => number
 ) {
   const runStatusFetcher: Fetcher<GetRunStatusResponseBody> = fetcher;
   const { data, error } = useSWRWithDefaults(
-    `/api/w/${owner.sId}/spaces/${app.space.sId}/apps/${app.sId}/runs/saved/status`,
+    app
+      ? `/api/w/${owner.sId}/spaces/${app.space.sId}/apps/${app.sId}/runs/saved/status`
+      : null,
     runStatusFetcher,
     {
       refreshInterval: refresh,
@@ -92,7 +94,7 @@ export function useSavedRunStatus(
 
   return {
     run: data ? data.run : null,
-    isRunLoading: !error && !data,
+    isRunLoading: !!app && !error && !data,
     isRunError: error,
   };
 }
@@ -205,9 +207,13 @@ export function useCancelRun({
   app,
 }: {
   owner: LightWorkspaceType;
-  app: AppType;
+  app: AppType | null;
 }) {
   const doCancel = async (runId: string): Promise<boolean> => {
+    if (!app) {
+      return false;
+    }
+
     try {
       const res = await clientFetch(
         `/api/w/${owner.sId}/spaces/${app.space.sId}/apps/${app.sId}/runs/${runId}/cancel`,

--- a/front/lib/swr/apps.ts
+++ b/front/lib/swr/apps.ts
@@ -7,7 +7,9 @@ import type { GetDustAppSecretsResponseBody } from "@app/pages/api/w/[wId]/dust_
 import type { GetKeysResponseBody } from "@app/pages/api/w/[wId]/keys";
 import type { GetProvidersResponseBody } from "@app/pages/api/w/[wId]/providers";
 import type { GetAppsResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/apps";
+import type { GetOrPostAppResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]";
 import type { GetRunsResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/runs";
+import type { GetRunResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]";
 import type { GetRunBlockResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/blocks/[type]/[name]";
 import type { PostRunCancelResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/cancel";
 import type { GetRunStatusResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/status";
@@ -42,6 +44,35 @@ export function useApps({
     isAppsLoading: !error && !data,
     isAppsError: !!error,
     mutateApps: mutate,
+  };
+}
+
+export function useApp({
+  workspaceId,
+  spaceId,
+  appId,
+  disabled,
+}: {
+  workspaceId: string;
+  spaceId: string;
+  appId: string;
+  disabled?: boolean;
+}) {
+  const appFetcher: Fetcher<GetOrPostAppResponseBody> = fetcher;
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    `/api/w/${workspaceId}/spaces/${spaceId}/apps/${appId}`,
+    appFetcher,
+    {
+      disabled,
+    }
+  );
+
+  return {
+    app: data?.app ?? null,
+    isAppLoading: !error && !data && !disabled,
+    isAppError: !!error,
+    mutateApp: mutate,
   };
 }
 
@@ -202,4 +233,33 @@ export function useCancelRun({
   };
 
   return { doCancel };
+}
+
+export function useRunWithSpec({
+  workspaceId,
+  spaceId,
+  appId,
+  runId,
+  disabled,
+}: {
+  workspaceId: string;
+  spaceId: string;
+  appId: string;
+  runId: string;
+  disabled?: boolean;
+}) {
+  const runFetcher: Fetcher<GetRunResponseBody> = fetcher;
+
+  const { data, error } = useSWRWithDefaults(
+    `/api/w/${workspaceId}/spaces/${spaceId}/apps/${appId}/runs/${runId}`,
+    runFetcher,
+    { disabled }
+  );
+
+  return {
+    run: data?.run ?? null,
+    spec: data?.spec ?? null,
+    isRunLoading: !error && !data && !disabled,
+    isRunError: !!error,
+  };
 }

--- a/front/lib/swr/datasets.ts
+++ b/front/lib/swr/datasets.ts
@@ -11,38 +11,44 @@ export function useDatasets({
   disabled,
 }: {
   owner: LightWorkspaceType;
-  app: AppType;
-  disabled: boolean;
+  app: AppType | null;
+  disabled?: boolean;
 }) {
   const datasetsFetcher: Fetcher<GetDatasetsResponseBody> = fetcher;
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+  const isDisabled = disabled || !app;
 
   const { data, error } = useSWRWithDefaults(
-    `/api/w/${owner.sId}/spaces/${app.space.sId}/apps/${app.sId}/datasets`,
+    app
+      ? `/api/w/${owner.sId}/spaces/${app.space.sId}/apps/${app.sId}/datasets`
+      : null,
     datasetsFetcher,
     {
-      disabled,
+      disabled: isDisabled,
     }
   );
 
   return {
     datasets: data?.datasets ?? emptyArray(),
-    isDatasetsLoading: !error && !data,
+    isDatasetsLoading: !isDisabled && !error && !data,
     isDatasetsError: !!error,
   };
 }
 
 export function useDataset(
   owner: LightWorkspaceType,
-  app: AppType,
+  app: AppType | null,
   dataset: string | undefined,
   showData = false
 ) {
   const datasetFetcher: Fetcher<GetDatasetResponseBody> = fetcher;
-  const disabled = !dataset;
+  const disabled = !dataset || !app;
   const { data, error, mutate } = useSWRWithDefaults(
-    `/api/w/${owner.sId}/spaces/${app.space.sId}/apps/${app.sId}/datasets/${dataset}${
-      showData ? "?data=true" : ""
-    }`,
+    app && dataset
+      ? `/api/w/${owner.sId}/spaces/${app.space.sId}/apps/${app.sId}/datasets/${dataset}${
+          showData ? "?data=true" : ""
+        }`
+      : null,
     datasetFetcher,
     { disabled }
   );

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -26,7 +26,6 @@ import type {
   PostSpaceRequestBodyType,
   PostSpacesResponseBody,
 } from "@app/pages/api/w/[wId]/spaces";
-import type { GetWorkspaceSeatsCountResponseBody } from "@app/pages/api/w/[wId]/seats/count";
 import type {
   GetSpaceResponseBody,
   PatchSpaceResponseBody,
@@ -683,52 +682,6 @@ export function useSystemSpace({
     isSystemSpaceLoading: !error && !data && !disabled,
     isSystemSpaceError: error,
     mutateSystemSpace: mutate,
-  };
-}
-
-export function useGlobalSpace({
-  workspaceId,
-  disabled = false,
-}: {
-  workspaceId: string;
-  disabled?: boolean;
-}) {
-  const globalSpaceFetcher: Fetcher<GetSpacesResponseBody> = fetcher;
-
-  const { data, error, mutate } = useSWRWithDefaults(
-    `/api/w/${workspaceId}/spaces?kind=global`,
-    globalSpaceFetcher,
-    { disabled }
-  );
-
-  return {
-    globalSpace: data ? data.spaces[0] : null,
-    isGlobalSpaceLoading: !error && !data && !disabled,
-    isGlobalSpaceError: error,
-    mutateGlobalSpace: mutate,
-  };
-}
-
-export function useActiveSeats({
-  workspaceId,
-  disabled = false,
-}: {
-  workspaceId: string;
-  disabled?: boolean;
-}) {
-  const seatsFetcher: Fetcher<GetWorkspaceSeatsCountResponseBody> = fetcher;
-
-  const { data, error, mutate } = useSWRWithDefaults(
-    `/api/w/${workspaceId}/seats/count`,
-    seatsFetcher,
-    { disabled }
-  );
-
-  return {
-    activeSeats: data?.seatsCount ?? 0,
-    isActiveSeatsLoading: !error && !data && !disabled,
-    isActiveSeatsError: error,
-    mutateActiveSeats: mutate,
   };
 }
 

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -26,6 +26,7 @@ import type {
   PostSpaceRequestBodyType,
   PostSpacesResponseBody,
 } from "@app/pages/api/w/[wId]/spaces";
+import type { GetWorkspaceSeatsCountResponseBody } from "@app/pages/api/w/[wId]/seats/count";
 import type {
   GetSpaceResponseBody,
   PatchSpaceResponseBody,
@@ -136,6 +137,8 @@ export function useSpaceInfo({
 
   return {
     spaceInfo: data ? data.space : null,
+    canWriteInSpace: data?.space.canWrite ?? false,
+    canReadInSpace: data?.space.isMember ?? false,
     mutateSpaceInfo: mutate,
     isSpaceInfoLoading: !error && !data && !disabled,
     isSpaceInfoError: error,
@@ -165,6 +168,7 @@ export function useSpaceDataSourceView({
 
   return {
     dataSourceView: data?.dataSourceView,
+    connector: data?.connector ?? null,
     isDataSourceViewLoading: !disabled && !error && !data,
     isDataSourceViewError: error,
     mutate,
@@ -679,6 +683,52 @@ export function useSystemSpace({
     isSystemSpaceLoading: !error && !data && !disabled,
     isSystemSpaceError: error,
     mutateSystemSpace: mutate,
+  };
+}
+
+export function useGlobalSpace({
+  workspaceId,
+  disabled = false,
+}: {
+  workspaceId: string;
+  disabled?: boolean;
+}) {
+  const globalSpaceFetcher: Fetcher<GetSpacesResponseBody> = fetcher;
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    `/api/w/${workspaceId}/spaces?kind=global`,
+    globalSpaceFetcher,
+    { disabled }
+  );
+
+  return {
+    globalSpace: data ? data.spaces[0] : null,
+    isGlobalSpaceLoading: !error && !data && !disabled,
+    isGlobalSpaceError: error,
+    mutateGlobalSpace: mutate,
+  };
+}
+
+export function useActiveSeats({
+  workspaceId,
+  disabled = false,
+}: {
+  workspaceId: string;
+  disabled?: boolean;
+}) {
+  const seatsFetcher: Fetcher<GetWorkspaceSeatsCountResponseBody> = fetcher;
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    `/api/w/${workspaceId}/seats/count`,
+    seatsFetcher,
+    { disabled }
+  );
+
+  return {
+    activeSeats: data?.seatsCount ?? 0,
+    isActiveSeatsLoading: !error && !data && !disabled,
+    isActiveSeatsError: error,
+    mutateActiveSeats: mutate,
   };
 }
 

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/index.ts
@@ -1,0 +1,80 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
+import { getRun } from "@app/lib/api/run";
+import type { Authenticator } from "@app/lib/auth";
+import { AppResource } from "@app/lib/resources/app_resource";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { RunType, SpecificationType, WithAPIErrorResponse } from "@app/types";
+
+export type GetRunResponseBody = {
+  run: RunType;
+  spec: SpecificationType;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetRunResponseBody>>,
+  auth: Authenticator,
+  { space }: { space: SpaceResource }
+): Promise<void> {
+  const { aId, runId } = req.query;
+
+  if (typeof aId !== "string" || typeof runId !== "string") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid request parameters",
+      },
+    });
+  }
+
+  const app = await AppResource.fetchById(auth, aId);
+
+  if (!app || !app.canRead(auth) || app.space.sId !== space.sId) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "app_not_found",
+        message: "The app you're trying to access was not found",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      const result = await getRun(auth, app.toJSON(), runId);
+
+      if (!result) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "run_not_found",
+            message: "The run was not found",
+          },
+        });
+      }
+
+      return res.status(200).json({
+        run: result.run,
+        spec: result.spec,
+      });
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(
+  withResourceFetchingFromRoute(handler, { space: { requireCanRead: true } })
+);

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/index.ts
@@ -7,7 +7,11 @@ import type { Authenticator } from "@app/lib/auth";
 import { AppResource } from "@app/lib/resources/app_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { apiError } from "@app/logger/withlogging";
-import type { RunType, SpecificationType, WithAPIErrorResponse } from "@app/types";
+import type {
+  RunType,
+  SpecificationType,
+  WithAPIErrorResponse,
+} from "@app/types";
 
 export type GetRunResponseBody = {
   run: RunType;

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.ts
@@ -16,8 +16,11 @@ import type {
   DataSourceViewType,
   WithAPIErrorResponse,
 } from "@app/types";
-import { ConnectorsAPI, PatchDataSourceViewSchema } from "@app/types";
-import { assertNever } from "@app/types/shared/utils/assert_never";
+import {
+  assertNever,
+  ConnectorsAPI,
+  PatchDataSourceViewSchema,
+} from "@app/types";
 
 export type PatchDataSourceViewResponseBody = {
   dataSourceView: DataSourceViewType;

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.ts
@@ -16,11 +16,8 @@ import type {
   DataSourceViewType,
   WithAPIErrorResponse,
 } from "@app/types";
-import {
-  assertNever,
-  ConnectorsAPI,
-  PatchDataSourceViewSchema,
-} from "@app/types";
+import { ConnectorsAPI, PatchDataSourceViewSchema } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export type PatchDataSourceViewResponseBody = {
   dataSourceView: DataSourceViewType;
@@ -126,7 +123,7 @@ async function handler(
               },
             });
           default:
-            assertNever(r.error.code);
+            return assertNever(r.error.code);
         }
       }
 

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.ts
@@ -3,14 +3,20 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import config from "@app/lib/api/config";
 import { handlePatchDataSourceView } from "@app/lib/api/data_source_view";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import type { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
+import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
-import type { DataSourceViewType, WithAPIErrorResponse } from "@app/types";
-import { PatchDataSourceViewSchema } from "@app/types";
+import type {
+  ConnectorType,
+  DataSourceViewType,
+  WithAPIErrorResponse,
+} from "@app/types";
+import { ConnectorsAPI, PatchDataSourceViewSchema } from "@app/types";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export type PatchDataSourceViewResponseBody = {
@@ -19,6 +25,7 @@ export type PatchDataSourceViewResponseBody = {
 
 export type GetDataSourceViewResponseBody = {
   dataSourceView: DataSourceViewType;
+  connector: ConnectorType | null;
 };
 
 async function handler(
@@ -39,8 +46,26 @@ async function handler(
 
   switch (req.method) {
     case "GET": {
+      let connector: ConnectorType | null = null;
+      const connectorId = dataSourceView.dataSource.connectorId;
+
+      if (connectorId) {
+        const connectorsAPI = new ConnectorsAPI(
+          config.getConnectorsAPIConfig(),
+          logger
+        );
+        const connectorRes = await connectorsAPI.getConnector(connectorId);
+        if (connectorRes.isOk()) {
+          connector = {
+            ...connectorRes.value,
+            connectionId: null,
+          };
+        }
+      }
+
       return res.status(200).json({
         dataSourceView: dataSourceView.toJSON(),
+        connector,
       });
     }
 
@@ -102,8 +127,28 @@ async function handler(
         }
       }
 
+      // Re-fetch connector data for the updated DSV
+      let connector: ConnectorType | null = null;
+      const updatedConnectorId = r.value.dataSource.connectorId;
+
+      if (updatedConnectorId) {
+        const connectorsAPI = new ConnectorsAPI(
+          config.getConnectorsAPIConfig(),
+          logger
+        );
+        const connectorRes =
+          await connectorsAPI.getConnector(updatedConnectorId);
+        if (connectorRes.isOk()) {
+          connector = {
+            ...connectorRes.value,
+            connectionId: null,
+          };
+        }
+      }
+
       return res.status(200).json({
         dataSourceView: r.value.toJSON(),
+        connector,
       });
     }
 

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/index.ts
@@ -35,6 +35,7 @@ export type SpaceCategoryInfo = {
 export type GetSpaceResponseBody = {
   space: SpaceType & {
     categories: { [key: string]: SpaceCategoryInfo };
+    canWrite: boolean;
     isMember: boolean;
     canRead: boolean;
     canWrite: boolean;
@@ -131,6 +132,7 @@ async function handler(
         space: {
           ...space.toJSON(),
           categories,
+          canWrite: space.canWrite(auth),
           isMember: space.canRead(auth),
           canRead: space.canRead(auth),
           canWrite: space.canWrite(auth),

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/index.ts
@@ -36,9 +36,8 @@ export type GetSpaceResponseBody = {
   space: SpaceType & {
     categories: { [key: string]: SpaceCategoryInfo };
     canWrite: boolean;
-    isMember: boolean;
     canRead: boolean;
-    canWrite: boolean;
+    isMember: boolean;
     members: UserType[];
   };
 };
@@ -133,9 +132,8 @@ async function handler(
           ...space.toJSON(),
           categories,
           canWrite: space.canWrite(auth),
-          isMember: space.canRead(auth),
           canRead: space.canRead(auth),
-          canWrite: space.canWrite(auth),
+          isMember: space.canRead(auth),
           members: currentMembers.map((member) => member.toJSON()),
         },
       });

--- a/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets/[name]/index.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets/[name]/index.tsx
@@ -7,9 +7,9 @@ import { useEffect, useState } from "react";
 
 import DatasetView from "@app/components/app/DatasetView";
 import { subNavigationApp } from "@app/components/navigation/config";
+import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
 import { AppCenteredLayout } from "@app/components/sparkle/AppCenteredLayout";
 import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
-import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
 import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
 import { appGetServerSideProps } from "@app/lib/auth/appServerSideProps";
 import type { AuthContextValue } from "@app/lib/auth/AuthContext";

--- a/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets/new.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets/new.tsx
@@ -1,65 +1,44 @@
 import "@uiw/react-textarea-code-editor/dist.css";
 
-import { Button } from "@dust-tt/sparkle";
-import type { InferGetServerSidePropsType } from "next";
+import { Button, Spinner } from "@dust-tt/sparkle";
 import { useRouter } from "next/router";
+import type { ReactElement } from "react";
 import { useEffect, useState } from "react";
 
 import DatasetView from "@app/components/app/DatasetView";
 import { DustAppPageLayout } from "@app/components/apps/DustAppPageLayout";
-import AppRootLayout from "@app/components/sparkle/AppRootLayout";
-import { getDatasets } from "@app/lib/api/datasets";
+import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
+import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
+import { appGetServerSideProps } from "@app/lib/auth/appServerSideProps";
+import type { AuthContextValue } from "@app/lib/auth/AuthContext";
+import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
 import { useRegisterUnloadHandlers } from "@app/lib/front";
-import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
-import { AppResource } from "@app/lib/resources/app_resource";
-import type { WorkspaceType } from "@app/types";
-import type { AppType } from "@app/types";
+import { useApp } from "@app/lib/swr/apps";
+import { useDatasets } from "@app/lib/swr/datasets";
 import type { DatasetSchema, DatasetType } from "@app/types";
-import type { SubscriptionType } from "@app/types";
+import { isString } from "@app/types";
 
-export const getServerSideProps = withDefaultUserAuthRequirements<{
-  owner: WorkspaceType;
-  subscription: SubscriptionType;
-  app: AppType;
-  datasets: DatasetType[];
-}>(async (context, auth) => {
-  const owner = auth.workspace();
-  const subscription = auth.subscription();
+export const getServerSideProps = appGetServerSideProps;
 
-  if (!owner || !auth.isBuilder() || !subscription) {
-    return {
-      notFound: true,
-    };
-  }
-
-  const app = await AppResource.fetchById(auth, context.params?.aId as string);
-
-  if (!app) {
-    return {
-      notFound: true,
-    };
-  }
-
-  const datasets = await getDatasets(auth, app.toJSON());
-
-  return {
-    props: {
-      owner,
-      subscription,
-      app: app.toJSON(),
-      datasets,
-    },
-  };
-});
-
-export default function NewDatasetView({
-  owner,
-  subscription,
-  app,
-  datasets,
-}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+function NewDatasetView() {
   const router = useRouter();
+  const { spaceId, aId } = router.query;
+  const owner = useWorkspace();
+  const { subscription, isBuilder } = useAuth();
+
+  const { app, isAppLoading } = useApp({
+    workspaceId: owner.sId,
+    spaceId: isString(spaceId) ? spaceId : "",
+    appId: isString(aId) ? aId : "",
+    disabled: !isString(spaceId) || !isString(aId),
+  });
+
+  const { datasets, isDatasetsLoading } = useDatasets({
+    owner,
+    app: app!,
+    disabled: !app,
+  });
 
   const [disable, setDisabled] = useState(true);
   const [loading, setLoading] = useState(false);
@@ -71,12 +50,21 @@ export default function NewDatasetView({
 
   useRegisterUnloadHandlers(editorDirty);
 
+  // Redirect non-builders
+  useEffect(() => {
+    if (!isBuilder && app) {
+      void router.push(
+        `/w/${owner.sId}/spaces/${app.space.sId}/apps/${app.sId}/datasets`
+      );
+    }
+  }, [isBuilder, app, router, owner.sId]);
+
   // This is a little wonky, but in order to redirect to the dataset's main page and not pop up the
   // "You have unsaved changes" dialog, we need to set editorDirty to false and then do the router
   // redirect in the next render cycle. We use the isFinishedEditing state variable to tell us when
   // this should happen.
   useEffect(() => {
-    if (isFinishedEditing) {
+    if (isFinishedEditing && app) {
       void router.push(
         `/w/${owner.sId}/spaces/${app.space.sId}/apps/${app.sId}/datasets`
       );
@@ -101,6 +89,10 @@ export default function NewDatasetView({
   };
 
   const handleSubmit = async () => {
+    if (!app) {
+      return;
+    }
+
     setLoading(true);
     const res = await clientFetch(
       `/api/w/${owner.sId}/spaces/${app.space.sId}/apps/${app.sId}/datasets`,
@@ -119,6 +111,16 @@ export default function NewDatasetView({
     setEditorDirty(false);
     setIsFinishedEditing(true);
   };
+
+  const isLoading = isAppLoading || isDatasetsLoading;
+
+  if (isLoading || !app) {
+    return (
+      <div className="flex h-screen items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
 
   return (
     <DustAppPageLayout
@@ -155,6 +157,15 @@ export default function NewDatasetView({
   );
 }
 
-NewDatasetView.getLayout = function getLayout(page: React.ReactElement) {
-  return <AppRootLayout>{page}</AppRootLayout>;
+const PageWithAuthLayout = NewDatasetView as AppPageWithLayout;
+
+PageWithAuthLayout.getLayout = (
+  page: ReactElement,
+  pageProps: AuthContextValue
+) => {
+  return (
+    <AppAuthContextLayout authContext={pageProps}>{page}</AppAuthContextLayout>
+  );
 };
+
+export default PageWithAuthLayout;

--- a/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets/new.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets/new.tsx
@@ -28,7 +28,7 @@ function NewDatasetView() {
   const owner = useWorkspace();
   const { subscription, isBuilder } = useAuth();
 
-  const { app, isAppLoading } = useApp({
+  const { app, isAppLoading, isAppError } = useApp({
     workspaceId: owner.sId,
     spaceId,
     appId: aId,
@@ -36,8 +36,7 @@ function NewDatasetView() {
 
   const { datasets, isDatasetsLoading } = useDatasets({
     owner,
-    app: app!,
-    disabled: !app,
+    app,
   });
 
   const [disable, setDisabled] = useState(true);
@@ -113,6 +112,16 @@ function NewDatasetView() {
   };
 
   const isLoading = isAppLoading || isDatasetsLoading;
+
+  // Show 404 on error or if app not found after loading completes
+  if (isAppError || (!isLoading && !app)) {
+    void router.replace("/404");
+    return (
+      <div className="flex h-screen items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
 
   if (isLoading || !app) {
     return (

--- a/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets/new.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets/new.tsx
@@ -14,24 +14,24 @@ import type { AuthContextValue } from "@app/lib/auth/AuthContext";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
 import { useRegisterUnloadHandlers } from "@app/lib/front";
+import { useRequiredPathParam } from "@app/lib/platform";
 import { useApp } from "@app/lib/swr/apps";
 import { useDatasets } from "@app/lib/swr/datasets";
 import type { DatasetSchema, DatasetType } from "@app/types";
-import { isString } from "@app/types";
 
 export const getServerSideProps = appGetServerSideProps;
 
 function NewDatasetView() {
   const router = useRouter();
-  const { spaceId, aId } = router.query;
+  const spaceId = useRequiredPathParam("spaceId");
+  const aId = useRequiredPathParam("aId");
   const owner = useWorkspace();
   const { subscription, isBuilder } = useAuth();
 
   const { app, isAppLoading } = useApp({
     workspaceId: owner.sId,
-    spaceId: isString(spaceId) ? spaceId : "",
-    appId: isString(aId) ? aId : "",
-    disabled: !isString(spaceId) || !isString(aId),
+    spaceId,
+    appId: aId,
   });
 
   const { datasets, isDatasetsLoading } = useDatasets({

--- a/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/index.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/index.tsx
@@ -129,12 +129,12 @@ function AppView() {
 
   // Initialize spec and config when app loads
   if (app && !specInitialized) {
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     const initialSpec = JSON.parse(
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       app.savedSpecification || `[]`
     ) as SpecificationType;
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     const initialConfig = extractConfig(
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       JSON.parse(app.savedSpecification || `{}`)
     );
     setSpec(initialSpec);

--- a/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/index.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/index.tsx
@@ -22,6 +22,7 @@ import type { AuthContextValue } from "@app/lib/auth/AuthContext";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import { extractConfig } from "@app/lib/config";
 import { clientFetch } from "@app/lib/egress/client";
+import { useRequiredPathParam } from "@app/lib/platform";
 import {
   addBlock,
   deleteBlock,
@@ -37,7 +38,6 @@ import type {
   SpecificationBlockType,
   SpecificationType,
 } from "@app/types";
-import { isString } from "@app/types";
 
 export const getServerSideProps = appGetServerSideProps;
 
@@ -105,16 +105,16 @@ const isRunnable = (
 
 function AppView() {
   const router = useRouter();
-  const { spaceId, aId } = router.query;
+  const spaceId = useRequiredPathParam("spaceId");
+  const aId = useRequiredPathParam("aId");
   const owner = useWorkspace();
   const { subscription, isAdmin, isBuilder } = useAuth();
   const readOnly = !isBuilder;
 
   const { app, isAppLoading } = useApp({
     workspaceId: owner.sId,
-    spaceId: isString(spaceId) ? spaceId : "",
-    appId: isString(aId) ? aId : "",
-    disabled: !isString(spaceId) || !isString(aId),
+    spaceId,
+    appId: aId,
   });
 
   const { mutate } = useSWRConfig();

--- a/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/index.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/index.tsx
@@ -143,7 +143,7 @@ function AppView() {
     setSpecInitialized(true);
   }
 
-  const { run } = useSavedRunStatus(owner, app!, (data) => {
+  const { run } = useSavedRunStatus(owner, app, (data) => {
     if (data && data.run) {
       switch (data?.run.status.run) {
         case "running":
@@ -309,7 +309,7 @@ function AppView() {
     }, 0);
   };
 
-  const { doCancel } = useCancelRun({ owner, app: app! });
+  const { doCancel } = useCancelRun({ owner, app });
 
   const handleCancelRun = async () => {
     if (!run?.run_id || cancelRequested || !app) {

--- a/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/index.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/index.tsx
@@ -111,7 +111,7 @@ function AppView() {
   const { subscription, isAdmin, isBuilder } = useAuth();
   const readOnly = !isBuilder;
 
-  const { app, isAppLoading } = useApp({
+  const { app, isAppLoading, isAppError } = useApp({
     workspaceId: owner.sId,
     spaceId,
     appId: aId,
@@ -354,6 +354,16 @@ function AppView() {
       setCancelRequested(false);
     }
   };
+
+  // Show 404 on error or if app not found after loading completes
+  if (isAppError || (!isAppLoading && !app)) {
+    void router.replace("/404");
+    return (
+      <div className="flex h-screen items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
 
   if (isAppLoading || !app) {
     return (

--- a/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/index.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/index.tsx
@@ -3,10 +3,11 @@ import {
   Button,
   DocumentTextIcon,
   PlayIcon,
+  Spinner,
   StopIcon,
 } from "@dust-tt/sparkle";
-import type { InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
+import type { ReactElement } from "react";
 import { useRef, useState } from "react";
 import { useSWRConfig } from "swr";
 
@@ -14,78 +15,31 @@ import NewBlock from "@app/components/app/NewBlock";
 import SpecRunView from "@app/components/app/SpecRunView";
 import { ViewAppAPIModal } from "@app/components/app/ViewAppAPIModal";
 import { DustAppPageLayout } from "@app/components/apps/DustAppPageLayout";
-import AppRootLayout from "@app/components/sparkle/AppRootLayout";
+import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
+import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
+import { appGetServerSideProps } from "@app/lib/auth/appServerSideProps";
+import type { AuthContextValue } from "@app/lib/auth/AuthContext";
+import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import { extractConfig } from "@app/lib/config";
 import { clientFetch } from "@app/lib/egress/client";
-import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
-import { AppResource } from "@app/lib/resources/app_resource";
-import { SpaceResource } from "@app/lib/resources/space_resource";
 import {
   addBlock,
   deleteBlock,
   moveBlockDown,
   moveBlockUp,
 } from "@app/lib/specification";
-import { useCancelRun, useSavedRunStatus } from "@app/lib/swr/apps";
+import { useApp, useCancelRun, useSavedRunStatus } from "@app/lib/swr/apps";
 import type {
   APIErrorResponse,
-  AppType,
   BlockRunConfig,
   BlockType,
   CoreAPIError,
   SpecificationBlockType,
   SpecificationType,
-  SubscriptionType,
-  WorkspaceType,
 } from "@app/types";
+import { isString } from "@app/types";
 
-export const getServerSideProps = withDefaultUserAuthRequirements<{
-  owner: WorkspaceType;
-  subscription: SubscriptionType;
-  readOnly: boolean;
-  isAdmin: boolean;
-  app: AppType;
-}>(async (context, auth) => {
-  const owner = auth.workspace();
-  const subscription = auth.subscription();
-
-  const { spaceId } = context.query;
-  if (typeof spaceId !== "string") {
-    return {
-      notFound: true,
-    };
-  }
-
-  const space = await SpaceResource.fetchById(auth, spaceId);
-
-  const isAdmin = auth.isAdmin();
-
-  if (!owner || !subscription || !space || !space.canReadOrAdministrate(auth)) {
-    return {
-      notFound: true,
-    };
-  }
-
-  const readOnly = !auth.isBuilder();
-
-  const app = await AppResource.fetchById(auth, context.params?.aId as string);
-
-  if (!app) {
-    return {
-      notFound: true,
-    };
-  }
-
-  return {
-    props: {
-      owner,
-      subscription,
-      isAdmin,
-      readOnly,
-      app: app.toJSON(),
-    },
-  };
-});
+export const getServerSideProps = appGetServerSideProps;
 
 let saveTimeout = null as string | number | NodeJS.Timeout | null;
 
@@ -149,30 +103,47 @@ const isRunnable = (
   return true;
 };
 
-export default function AppView({
-  owner,
-  subscription,
-  readOnly,
-  isAdmin,
-  app,
-}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+function AppView() {
+  const router = useRouter();
+  const { spaceId, aId } = router.query;
+  const owner = useWorkspace();
+  const { subscription, isAdmin, isBuilder } = useAuth();
+  const readOnly = !isBuilder;
+
+  const { app, isAppLoading } = useApp({
+    workspaceId: owner.sId,
+    spaceId: isString(spaceId) ? spaceId : "",
+    appId: isString(aId) ? aId : "",
+    disabled: !isString(spaceId) || !isString(aId),
+  });
+
   const { mutate } = useSWRConfig();
 
-  const [spec, setSpec] = useState(
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-    JSON.parse(app.savedSpecification || `[]`) as SpecificationType
-  );
-
-  const [config, setConfig] = useState(
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-    extractConfig(JSON.parse(app.savedSpecification || `{}`))
-  );
-  const [runnable, setRunnable] = useState(isRunnable(readOnly, spec, config));
+  const [spec, setSpec] = useState<SpecificationType>([]);
+  const [config, setConfig] = useState<BlockRunConfig>({});
+  const [runnable, setRunnable] = useState(false);
+  const [specInitialized, setSpecInitialized] = useState(false);
   const [runRequested, setRunRequested] = useState(false);
   const [runError, setRunError] = useState(null as null | CoreAPIError);
   const [cancelRequested, setCancelRequested] = useState(false);
 
-  const { run } = useSavedRunStatus(owner, app, (data) => {
+  // Initialize spec and config when app loads
+  if (app && !specInitialized) {
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+    const initialSpec = JSON.parse(
+      app.savedSpecification || `[]`
+    ) as SpecificationType;
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+    const initialConfig = extractConfig(
+      JSON.parse(app.savedSpecification || `{}`)
+    );
+    setSpec(initialSpec);
+    setConfig(initialConfig);
+    setRunnable(isRunnable(readOnly, initialSpec, initialConfig));
+    setSpecInitialized(true);
+  }
+
+  const { run } = useSavedRunStatus(owner, app!, (data) => {
     if (data && data.run) {
       switch (data?.run.status.run) {
         case "running":
@@ -193,6 +164,10 @@ export default function AppView({
     Date.now() - run.created > 60 * 60 * 1000; // 1 hour in milliseconds
 
   const saveState = async (spec: SpecificationType, config: BlockRunConfig) => {
+    if (!app) {
+      return;
+    }
+
     if (saveTimeout) {
       clearTimeout(saveTimeout);
       saveTimeout = null;
@@ -213,8 +188,6 @@ export default function AppView({
             }),
           }
         );
-
-        console.log("STATE SAVED", spec, config);
       }
     }, 1000);
   };
@@ -280,6 +253,10 @@ export default function AppView({
   };
 
   const handleRun = () => {
+    if (!app) {
+      return;
+    }
+
     setRunRequested(true);
 
     // We disable runRequested after 1s, time to disable the Run button while the network
@@ -332,10 +309,10 @@ export default function AppView({
     }, 0);
   };
 
-  const { doCancel } = useCancelRun({ owner, app });
+  const { doCancel } = useCancelRun({ owner, app: app! });
 
   const handleCancelRun = async () => {
-    if (!run?.run_id || cancelRequested) {
+    if (!run?.run_id || cancelRequested || !app) {
       return;
     }
 
@@ -378,7 +355,13 @@ export default function AppView({
     }
   };
 
-  const router = useRouter();
+  if (isAppLoading || !app) {
+    return (
+      <div className="flex h-screen items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
 
   return (
     <DustAppPageLayout
@@ -559,6 +542,15 @@ export default function AppView({
   );
 }
 
-AppView.getLayout = (page: React.ReactElement) => {
-  return <AppRootLayout>{page}</AppRootLayout>;
+const PageWithAuthLayout = AppView as AppPageWithLayout;
+
+PageWithAuthLayout.getLayout = (
+  page: ReactElement,
+  pageProps: AuthContextValue
+) => {
+  return (
+    <AppAuthContextLayout authContext={pageProps}>{page}</AppAuthContextLayout>
+  );
 };
+
+export default PageWithAuthLayout;

--- a/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/settings.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/settings.tsx
@@ -1,85 +1,62 @@
-import { Button, Input, Label } from "@dust-tt/sparkle";
-import type { InferGetServerSidePropsType } from "next";
+import { Button, Input, Label, Spinner } from "@dust-tt/sparkle";
 import { useRouter } from "next/router";
+import type { ReactElement } from "react";
 import { useContext, useState } from "react";
 import { useEffect } from "react";
 
 import { DustAppPageLayout } from "@app/components/apps/DustAppPageLayout";
 import { ConfirmContext } from "@app/components/Confirm";
-import AppRootLayout from "@app/components/sparkle/AppRootLayout";
+import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
+import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
+import { appGetServerSideProps } from "@app/lib/auth/appServerSideProps";
+import type { AuthContextValue } from "@app/lib/auth/AuthContext";
+import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
-import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
-import { AppResource } from "@app/lib/resources/app_resource";
 import { dustAppsListUrl } from "@app/lib/spaces";
+import { useApp } from "@app/lib/swr/apps";
+import { useSpaceInfo } from "@app/lib/swr/spaces";
 import { MODELS_STRING_MAX_LENGTH } from "@app/lib/utils";
-import type { AppType } from "@app/types";
-import type { SubscriptionType } from "@app/types";
 import type { APIError } from "@app/types";
-import type { WorkspaceType } from "@app/types";
-import { APP_NAME_REGEXP } from "@app/types";
+import { APP_NAME_REGEXP, isString } from "@app/types";
 
-export const getServerSideProps = withDefaultUserAuthRequirements<{
-  owner: WorkspaceType;
-  subscription: SubscriptionType;
-  app: AppType;
-}>(async (context, auth) => {
-  const owner = auth.workspace();
-  const subscription = auth.subscription();
-  if (!owner || !subscription) {
-    return {
-      notFound: true,
-    };
-  }
+export const getServerSideProps = appGetServerSideProps;
 
-  const { spaceId } = context.query;
-  if (typeof spaceId !== "string") {
-    return {
-      notFound: true,
-    };
-  }
+function SettingsView() {
+  const router = useRouter();
+  const { spaceId, aId } = router.query;
+  const owner = useWorkspace();
+  const { subscription, isBuilder } = useAuth();
 
-  if (!auth.isBuilder()) {
-    return {
-      redirect: {
-        destination: `/w/${owner.sId}/spaces/${context.query.spaceId}/apps/${context.query.aId}`,
-        permanent: false,
-      },
-    };
-  }
+  const { spaceInfo: space, isSpaceInfoLoading } = useSpaceInfo({
+    workspaceId: owner.sId,
+    spaceId: isString(spaceId) ? spaceId : null,
+  });
 
-  const app = await AppResource.fetchById(auth, context.params?.aId as string);
+  const { app, isAppLoading } = useApp({
+    workspaceId: owner.sId,
+    spaceId: isString(spaceId) ? spaceId : "",
+    appId: isString(aId) ? aId : "",
+    disabled: !isString(spaceId) || !isString(aId),
+  });
 
-  if (!app) {
-    return {
-      notFound: true,
-    };
-  }
-
-  return {
-    props: {
-      owner,
-      subscription,
-      app: app.toJSON(),
-    },
-  };
-});
-
-export default function SettingsView({
-  owner,
-  subscription,
-  app,
-}: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const [disable, setDisabled] = useState(true);
 
-  const [appName, setAppName] = useState(app.name);
+  const [appName, setAppName] = useState("");
   const [appNameError, setAppNameError] = useState<boolean>(false);
-
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-  const [appDescription, setAppDescription] = useState(app.description || "");
+  const [appDescription, setAppDescription] = useState("");
 
   const [isDeleting, setIsDeleting] = useState(false);
   const [isUpdating, setIsUpdating] = useState(false);
   const confirm = useContext(ConfirmContext);
+
+  // Initialize form values when app loads
+  useEffect(() => {
+    if (app) {
+      setAppName(app.name);
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+      setAppDescription(app.description || "");
+    }
+  }, [app]);
 
   const formValidation = () => {
     if (appName.length == 0) {
@@ -94,9 +71,11 @@ export default function SettingsView({
     }
   };
 
-  const router = useRouter();
-
   const handleDelete = async () => {
+    if (!app || !space) {
+      return false;
+    }
+
     if (
       await confirm({
         title: "Double checking",
@@ -127,6 +106,10 @@ export default function SettingsView({
   };
 
   const handleUpdate = async () => {
+    if (!app) {
+      return;
+    }
+
     setIsUpdating(true);
     const res = await clientFetch(
       `/api/w/${owner.sId}/spaces/${app.space.sId}/apps/${app.sId}`,
@@ -159,6 +142,23 @@ export default function SettingsView({
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [appName]);
+
+  // Redirect non-builders
+  useEffect(() => {
+    if (!isBuilder && app && space) {
+      void router.push(`/w/${owner.sId}/spaces/${space.sId}/apps/${app.sId}`);
+    }
+  }, [isBuilder, app, space, router, owner.sId]);
+
+  const isLoading = isSpaceInfoLoading || isAppLoading;
+
+  if (isLoading || !app || !space) {
+    return (
+      <div className="flex h-screen items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
 
   return (
     <DustAppPageLayout
@@ -215,6 +215,15 @@ export default function SettingsView({
   );
 }
 
-SettingsView.getLayout = (page: React.ReactElement) => {
-  return <AppRootLayout>{page}</AppRootLayout>;
+const PageWithAuthLayout = SettingsView as AppPageWithLayout;
+
+PageWithAuthLayout.getLayout = (
+  page: ReactElement,
+  pageProps: AuthContextValue
+) => {
+  return (
+    <AppAuthContextLayout authContext={pageProps}>{page}</AppAuthContextLayout>
+  );
 };
+
+export default PageWithAuthLayout;

--- a/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/specification.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/specification.tsx
@@ -1,108 +1,62 @@
-import { Tabs, TabsList, TabsTrigger } from "@dust-tt/sparkle";
-import type { InferGetServerSidePropsType } from "next";
+import { Spinner, Tabs, TabsList, TabsTrigger } from "@dust-tt/sparkle";
 import { useRouter } from "next/router";
+import type { ReactElement } from "react";
+import { useMemo } from "react";
 
 import { subNavigationApp } from "@app/components/navigation/config";
 import { AppCenteredLayout } from "@app/components/sparkle/AppCenteredLayout";
 import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
-import AppRootLayout from "@app/components/sparkle/AppRootLayout";
-import config from "@app/lib/api/config";
-import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
-import { AppResource } from "@app/lib/resources/app_resource";
+import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
+import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
+import { appGetServerSideProps } from "@app/lib/auth/appServerSideProps";
+import type { AuthContextValue } from "@app/lib/auth/AuthContext";
+import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import { dustAppsListUrl } from "@app/lib/spaces";
 import { dumpSpecification } from "@app/lib/specification";
-import logger from "@app/logger/logger";
-import type { AppType, SubscriptionType, WorkspaceType } from "@app/types";
-import { CoreAPI } from "@app/types";
+import { useApp } from "@app/lib/swr/apps";
+import type { SpecificationType } from "@app/types";
+import { isString } from "@app/types";
 
-export const getServerSideProps = withDefaultUserAuthRequirements<{
-  owner: WorkspaceType;
-  subscription: SubscriptionType;
-  readOnly: boolean;
-  app: AppType;
-  specification: string;
-  specificationFromCore: { created: number; data: string; hash: string } | null;
-}>(async (context, auth) => {
-  const owner = auth.workspace();
-  const subscription = auth.subscription();
+export const getServerSideProps = appGetServerSideProps;
 
-  if (!owner || !subscription) {
-    return {
-      notFound: true,
-    };
-  }
-
-  const readOnly = !auth.isBuilder();
-
-  const app = await AppResource.fetchById(auth, context.params?.aId as string);
-
-  if (!app) {
-    return {
-      notFound: true,
-    };
-  }
-
-  const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
-  const datasets = await coreAPI.getDatasets({
-    projectId: app.dustAPIProjectId,
-  });
-  if (datasets.isErr()) {
-    return {
-      notFound: true,
-    };
-  }
-
-  let specificationFromCore = null;
-  const specificationFromCoreHash = context.query?.hash;
-
-  if (
-    specificationFromCoreHash &&
-    typeof specificationFromCoreHash === "string"
-  ) {
-    const coreSpec = await coreAPI.getSpecification({
-      projectId: app.dustAPIProjectId,
-      specificationHash: specificationFromCoreHash,
-    });
-
-    if (coreSpec.isOk()) {
-      specificationFromCore = {
-        ...coreSpec.value.specification,
-        hash: specificationFromCoreHash,
-      };
-    }
-  }
-
-  const latestDatasets = {} as { [key: string]: string };
-  for (const d in datasets.value.datasets) {
-    latestDatasets[d] = datasets.value.datasets[d][0].hash;
-  }
-
-  const spec = dumpSpecification(
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-    JSON.parse(app.savedSpecification || "[]"),
-    latestDatasets
-  );
-
-  return {
-    props: {
-      owner,
-      subscription,
-      readOnly,
-      app: app.toJSON(),
-      specification: spec,
-      specificationFromCore,
-    },
-  };
-});
-
-export default function Specification({
-  owner,
-  subscription,
-  app,
-  specification,
-  specificationFromCore,
-}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+function Specification() {
   const router = useRouter();
+  const { spaceId, aId } = router.query;
+  const owner = useWorkspace();
+  const { subscription } = useAuth();
+
+  const { app, isAppLoading } = useApp({
+    workspaceId: owner.sId,
+    spaceId: isString(spaceId) ? spaceId : "",
+    appId: isString(aId) ? aId : "",
+    disabled: !isString(spaceId) || !isString(aId),
+  });
+
+  // Compute the specification string from the app's saved specification
+  const specification = useMemo(() => {
+    if (!app) {
+      return "";
+    }
+    try {
+      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+      const spec = JSON.parse(
+        app.savedSpecification || "[]"
+      ) as SpecificationType;
+      // Note: We don't have access to latestDatasets here, so we pass an empty object.
+      // This means dataset hashes won't be shown, but the specification structure will be correct.
+      return dumpSpecification(spec, {});
+    } catch {
+      return "";
+    }
+  }, [app]);
+
+  if (isAppLoading || !app) {
+    return (
+      <div className="flex h-screen items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
 
   return (
     <AppCenteredLayout
@@ -139,24 +93,25 @@ export default function Specification({
           </TabsList>
         </Tabs>
         <div className="mt-8 flex flex-col gap-4">
-          <h3>Current specifications : </h3>
+          <h3>Current specifications:</h3>
           <div className="whitespace-pre font-mono text-sm text-gray-700">
             {specification}
           </div>
-          {specificationFromCore && (
-            <>
-              <h3>Saved specifications {specificationFromCore.hash}: </h3>
-              <div className="whitespace-pre font-mono text-sm text-gray-700">
-                {specificationFromCore.data}
-              </div>
-            </>
-          )}
         </div>
       </div>
     </AppCenteredLayout>
   );
 }
 
-Specification.getLayout = (page: React.ReactElement) => {
-  return <AppRootLayout>{page}</AppRootLayout>;
+const PageWithAuthLayout = Specification as AppPageWithLayout;
+
+PageWithAuthLayout.getLayout = (
+  page: ReactElement,
+  pageProps: AuthContextValue
+) => {
+  return (
+    <AppAuthContextLayout authContext={pageProps}>{page}</AppAuthContextLayout>
+  );
 };
+
+export default PageWithAuthLayout;

--- a/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/specification.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/specification.tsx
@@ -4,9 +4,9 @@ import type { ReactElement } from "react";
 import { useMemo } from "react";
 
 import { subNavigationApp } from "@app/components/navigation/config";
+import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
 import { AppCenteredLayout } from "@app/components/sparkle/AppCenteredLayout";
 import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
-import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
 import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
 import { appGetServerSideProps } from "@app/lib/auth/appServerSideProps";
 import type { AuthContextValue } from "@app/lib/auth/AuthContext";
@@ -38,8 +38,8 @@ function Specification() {
       return "";
     }
     try {
-      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       const spec = JSON.parse(
+        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         app.savedSpecification || "[]"
       ) as SpecificationType;
       // Note: We don't have access to latestDatasets here, so we pass an empty object.

--- a/front/pages/w/[wId]/spaces/[spaceId]/categories/[category]/data_source_views/[dataSourceViewId].tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/categories/[category]/data_source_views/[dataSourceViewId].tsx
@@ -3,8 +3,7 @@ import { useRouter } from "next/router";
 import type { ReactElement } from "react";
 
 import { SpaceDataSourceViewContentList } from "@app/components/spaces/SpaceDataSourceViewContentList";
-import type { SpaceLayoutPageProps } from "@app/components/spaces/SpaceLayout";
-import { SpaceLayout } from "@app/components/spaces/SpaceLayout";
+import { SpaceLayoutWrapper } from "@app/components/spaces/SpaceLayout";
 import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
 import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
 import { appGetServerSideProps } from "@app/lib/auth/appServerSideProps";
@@ -16,7 +15,6 @@ import {
   useSpaceInfo,
   useSystemSpace,
 } from "@app/lib/swr/spaces";
-import type { DataSourceViewCategory } from "@app/types";
 import { isValidDataSourceViewCategory } from "@app/types";
 
 export const getServerSideProps = appGetServerSideProps;
@@ -74,37 +72,24 @@ function Space() {
     );
   }
 
-  const pageProps: SpaceLayoutPageProps = {
-    canReadInSpace,
-    canWriteInSpace,
-    category: validCategory,
-    isAdmin,
-    owner,
-    plan,
-    space,
-    subscription,
-  };
-
   return (
-    <SpaceLayout pageProps={pageProps} useBackendSearch>
-      <SpaceDataSourceViewContentList
-        owner={owner}
-        space={space}
-        plan={plan}
-        canWriteInSpace={canWriteInSpace}
-        canReadInSpace={canReadInSpace}
-        parentId={parentId ?? undefined}
-        dataSourceView={dataSourceView}
-        onSelect={(selectedParentId) => {
-          void router.push(
-            `/w/${owner.sId}/spaces/${dataSourceView.spaceId}/categories/${validCategory}/data_source_views/${dataSourceView.sId}?parentId=${selectedParentId}`
-          );
-        }}
-        isAdmin={isAdmin}
-        systemSpace={systemSpace}
-        connector={connector}
-      />
-    </SpaceLayout>
+    <SpaceDataSourceViewContentList
+      owner={owner}
+      space={space}
+      plan={plan}
+      canWriteInSpace={canWriteInSpace}
+      canReadInSpace={canReadInSpace}
+      parentId={parentId ?? undefined}
+      dataSourceView={dataSourceView}
+      onSelect={(selectedParentId) => {
+        void router.push(
+          `/w/${owner.sId}/spaces/${dataSourceView.spaceId}/categories/${validCategory}/data_source_views/${dataSourceView.sId}?parentId=${selectedParentId}`
+        );
+      }}
+      isAdmin={isAdmin}
+      systemSpace={systemSpace}
+      connector={connector}
+    />
   );
 }
 
@@ -115,7 +100,9 @@ PageWithAuthLayout.getLayout = (
   pageProps: AuthContextValue
 ) => {
   return (
-    <AppAuthContextLayout authContext={pageProps}>{page}</AppAuthContextLayout>
+    <AppAuthContextLayout authContext={pageProps}>
+      <SpaceLayoutWrapper useBackendSearch>{page}</SpaceLayoutWrapper>
+    </AppAuthContextLayout>
   );
 };
 

--- a/front/pages/w/[wId]/spaces/[spaceId]/categories/[category]/data_source_views/[dataSourceViewId].tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/categories/[category]/data_source_views/[dataSourceViewId].tsx
@@ -10,19 +10,23 @@ import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
 import { appGetServerSideProps } from "@app/lib/auth/appServerSideProps";
 import type { AuthContextValue } from "@app/lib/auth/AuthContext";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
+import { useRequiredPathParam, useSearchParam } from "@app/lib/platform";
 import {
   useSpaceDataSourceView,
   useSpaceInfo,
   useSystemSpace,
 } from "@app/lib/swr/spaces";
 import type { DataSourceViewCategory } from "@app/types";
-import { isString, isValidDataSourceViewCategory } from "@app/types";
+import { isValidDataSourceViewCategory } from "@app/types";
 
 export const getServerSideProps = appGetServerSideProps;
 
 function Space() {
   const router = useRouter();
-  const { spaceId, dataSourceViewId, category, parentId } = router.query;
+  const spaceId = useRequiredPathParam("spaceId");
+  const dataSourceViewId = useRequiredPathParam("dataSourceViewId");
+  const category = useRequiredPathParam("category");
+  const parentId = useSearchParam("parentId");
   const owner = useWorkspace();
   const { subscription, isAdmin, user } = useAuth();
   const plan = subscription.plan;
@@ -34,7 +38,7 @@ function Space() {
     isSpaceInfoLoading,
   } = useSpaceInfo({
     workspaceId: owner.sId,
-    spaceId: isString(spaceId) ? spaceId : null,
+    spaceId,
   });
 
   const { systemSpace, isSystemSpaceLoading } = useSystemSpace({
@@ -44,12 +48,12 @@ function Space() {
   const { dataSourceView, connector, isDataSourceViewLoading } =
     useSpaceDataSourceView({
       owner,
-      spaceId: isString(spaceId) ? spaceId : null,
-      dataSourceViewId: isString(dataSourceViewId) ? dataSourceViewId : null,
+      spaceId,
+      dataSourceViewId,
     });
 
   const validCategory = isValidDataSourceViewCategory(category)
-    ? (category as DataSourceViewCategory)
+    ? category
     : null;
 
   const isLoading =
@@ -89,7 +93,7 @@ function Space() {
         plan={plan}
         canWriteInSpace={canWriteInSpace}
         canReadInSpace={canReadInSpace}
-        parentId={isString(parentId) ? parentId : undefined}
+        parentId={parentId ?? undefined}
         dataSourceView={dataSourceView}
         onSelect={(selectedParentId) => {
           void router.push(

--- a/front/pages/w/[wId]/spaces/[spaceId]/categories/[category]/index.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/categories/[category]/index.tsx
@@ -13,11 +13,11 @@ import { appGetServerSideProps } from "@app/lib/auth/appServerSideProps";
 import type { AuthContextValue } from "@app/lib/auth/AuthContext";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import {
-  useActiveSeats,
   useSpaceDataSourceViews,
   useSpaceInfo,
   useSystemSpace,
 } from "@app/lib/swr/spaces";
+import { useWorkspaceSeatsCount } from "@app/lib/swr/workspaces";
 import type {
   ConnectorProvider,
   DataSourceViewCategoryWithoutApps,
@@ -53,7 +53,7 @@ function Space() {
     workspaceId: owner.sId,
   });
 
-  const { activeSeats, isActiveSeatsLoading } = useActiveSeats({
+  const { seatsCount, isSeatsCountLoading } = useWorkspaceSeatsCount({
     workspaceId: owner.sId,
     disabled: !isAdmin,
   });
@@ -121,15 +121,14 @@ function Space() {
     setupWithSuffixSuffix,
   ]);
 
-  // Validate category
   const validCategory = isDataSourceViewCategoryWithoutApps(category)
-    ? (category as DataSourceViewCategoryWithoutApps)
+    ? category
     : null;
 
   const isLoading =
     isSpaceInfoLoading ||
     isSystemSpaceLoading ||
-    (isAdmin && isActiveSeatsLoading) ||
+    (isAdmin && isSeatsCountLoading) ||
     (isSystemSpace && isSpaceDataSourceViewsLoading);
 
   if (isLoading || !space || !systemSpace || !validCategory || !user) {
@@ -163,7 +162,7 @@ function Space() {
         canWriteInSpace={canWriteInSpace}
         category={validCategory}
         integrations={integrations}
-        activeSeats={activeSeats}
+        activeSeats={seatsCount}
         onSelect={(sId) => {
           void router.push(
             `/w/${owner.sId}/spaces/${space.sId}/categories/${validCategory}/data_source_views/${sId}`

--- a/front/pages/w/[wId]/spaces/[spaceId]/categories/[category]/index.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/categories/[category]/index.tsx
@@ -1,85 +1,84 @@
-import type { InferGetServerSidePropsType } from "next";
+import { Spinner } from "@dust-tt/sparkle";
 import { useRouter } from "next/router";
 import type { ReactElement } from "react";
+import { useMemo } from "react";
 
 import type { DataSourceIntegration } from "@app/components/spaces/AddConnectionMenu";
 import type { SpaceLayoutPageProps } from "@app/components/spaces/SpaceLayout";
 import { SpaceLayout } from "@app/components/spaces/SpaceLayout";
 import { SpaceResourcesList } from "@app/components/spaces/SpaceResourcesList";
-import AppRootLayout from "@app/components/sparkle/AppRootLayout";
+import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
+import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
+import { appGetServerSideProps } from "@app/lib/auth/appServerSideProps";
+import type { AuthContextValue } from "@app/lib/auth/AuthContext";
+import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import {
-  augmentDataSourceWithConnectorDetails,
-  getDataSources,
-} from "@app/lib/api/data_sources";
-import { isManaged } from "@app/lib/data_sources";
-import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
-import { countActiveSeatsInWorkspaceCached } from "@app/lib/plans/usage/seats";
-import { SpaceResource } from "@app/lib/resources/space_resource";
+  useActiveSeats,
+  useSpaceDataSourceViews,
+  useSpaceInfo,
+  useSystemSpace,
+} from "@app/lib/swr/spaces";
 import type {
   ConnectorProvider,
   DataSourceViewCategoryWithoutApps,
-  DataSourceWithConnectorDetailsType,
-  SpaceType,
-  UserType,
 } from "@app/types";
 import {
   CONNECTOR_PROVIDERS,
   isConnectorProvider,
   isDataSourceViewCategoryWithoutApps,
-  removeNulls,
+  isString,
 } from "@app/types";
 
-export const getServerSideProps = withDefaultUserAuthRequirements<
-  SpaceLayoutPageProps & {
-    category: DataSourceViewCategoryWithoutApps;
-    isAdmin: boolean;
-    canWriteInSpace: boolean;
-    space: SpaceType;
-    systemSpace: SpaceType;
-    integrations: DataSourceIntegration[];
-    user: UserType;
-    activeSeats: number;
-  }
->(async (context, auth) => {
-  const owner = auth.getNonNullableWorkspace();
-  const subscription = auth.subscription();
-  const plan = auth.getNonNullablePlan();
-  const isAdmin = auth.isAdmin();
-  const user = auth.getNonNullableUser();
+export const getServerSideProps = appGetServerSideProps;
 
-  const { category, setupWithSuffixConnector, setupWithSuffixSuffix, spaceId } =
-    context.query;
+function Space() {
+  const router = useRouter();
+  const { spaceId, category, setupWithSuffixConnector, setupWithSuffixSuffix } =
+    router.query;
+  const owner = useWorkspace();
+  const { subscription, isAdmin, isBuilder, user } = useAuth();
+  const plan = subscription.plan;
 
-  if (!subscription || typeof spaceId !== "string") {
-    return {
-      notFound: true,
-    };
-  }
+  const {
+    spaceInfo: space,
+    canWriteInSpace,
+    canReadInSpace,
+    isSpaceInfoLoading,
+  } = useSpaceInfo({
+    workspaceId: owner.sId,
+    spaceId: isString(spaceId) ? spaceId : null,
+  });
 
-  const systemSpace = await SpaceResource.fetchWorkspaceSystemSpace(auth);
-  const space = await SpaceResource.fetchById(auth, spaceId);
-  if (!space || !systemSpace || !space.canReadOrAdministrate(auth)) {
-    return {
-      notFound: true,
-    };
-  }
+  const { systemSpace, isSystemSpaceLoading } = useSystemSpace({
+    workspaceId: owner.sId,
+  });
 
-  if (!isDataSourceViewCategoryWithoutApps(category)) {
-    return {
-      notFound: true,
-    };
-  }
+  const { activeSeats, isActiveSeatsLoading } = useActiveSeats({
+    workspaceId: owner.sId,
+    disabled: !isAdmin,
+  });
 
-  const isBuilder = auth.isBuilder();
-  const canWriteInSpace = space.canWrite(auth);
+  // For system spaces, fetch managed data source views to compute available integrations
+  const isSystemSpace = space?.kind === "system";
+  const { spaceDataSourceViews, isSpaceDataSourceViewsLoading } =
+    useSpaceDataSourceViews({
+      workspaceId: owner.sId,
+      spaceId: isString(spaceId) ? spaceId : "",
+      category: "managed",
+      disabled: !isSystemSpace,
+    });
 
-  const integrations: DataSourceIntegration[] = [];
+  // Compute integrations for system spaces
+  const integrations = useMemo((): DataSourceIntegration[] => {
+    if (!isSystemSpace) {
+      return [];
+    }
 
-  if (space.isSystem()) {
     let setupWithSuffix: {
       connector: ConnectorProvider;
       suffix: string;
     } | null = null;
+
     if (
       setupWithSuffixConnector &&
       isConnectorProvider(setupWithSuffixConnector as string) &&
@@ -92,34 +91,20 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
       };
     }
 
-    const allDataSources = await getDataSources(auth, {
-      includeEditedBy: true,
-    });
+    const usedConnectorProviders = new Set(
+      spaceDataSourceViews
+        .map((dsv) => dsv.dataSource.connectorProvider)
+        .filter((p): p is ConnectorProvider => p !== null)
+    );
 
-    const managedDataSources: DataSourceWithConnectorDetailsType[] =
-      removeNulls(
-        await Promise.all(
-          allDataSources.map(async (managedDataSource) => {
-            const ds = managedDataSource.toJSON();
-            if (!isManaged(ds)) {
-              return null;
-            }
-            const augmentedDataSource =
-              await augmentDataSourceWithConnectorDetails(ds);
-
-            return augmentedDataSource;
-          })
-        )
-      );
+    const result: DataSourceIntegration[] = [];
     for (const connectorProvider of CONNECTOR_PROVIDERS) {
       if (
-        !managedDataSources.find(
-          (i) => i.connectorProvider === connectorProvider
-        ) ||
+        !usedConnectorProviders.has(connectorProvider) ||
         setupWithSuffix?.connector === connectorProvider
       ) {
-        integrations.push({
-          connectorProvider: connectorProvider,
+        result.push({
+          connectorProvider,
           setupWithSuffix:
             setupWithSuffix?.connector === connectorProvider
               ? setupWithSuffix.suffix
@@ -127,70 +112,77 @@ export const getServerSideProps = withDefaultUserAuthRequirements<
         });
       }
     }
+
+    return result;
+  }, [
+    isSystemSpace,
+    spaceDataSourceViews,
+    setupWithSuffixConnector,
+    setupWithSuffixSuffix,
+  ]);
+
+  // Validate category
+  const validCategory = isDataSourceViewCategoryWithoutApps(category)
+    ? (category as DataSourceViewCategoryWithoutApps)
+    : null;
+
+  const isLoading =
+    isSpaceInfoLoading ||
+    isSystemSpaceLoading ||
+    (isAdmin && isActiveSeatsLoading) ||
+    (isSystemSpace && isSpaceDataSourceViewsLoading);
+
+  if (isLoading || !space || !systemSpace || !validCategory || !user) {
+    return (
+      <div className="flex h-screen items-center justify-center">
+        <Spinner />
+      </div>
+    );
   }
 
-  const activeSeats = await countActiveSeatsInWorkspaceCached(owner.sId);
-
-  return {
-    props: {
-      canReadInSpace: space.canRead(auth),
-      canWriteInSpace,
-      category,
-      integrations,
-      isAdmin,
-      isBuilder,
-      owner,
-      user: user.toJSON(),
-      plan,
-      space: space.toJSON(),
-      subscription,
-      systemSpace: systemSpace.toJSON(),
-      activeSeats,
-    },
+  const pageProps: SpaceLayoutPageProps = {
+    canReadInSpace,
+    canWriteInSpace,
+    category: validCategory,
+    isAdmin,
+    owner,
+    plan,
+    space,
+    subscription,
   };
-});
-
-export default function Space({
-  category,
-  isAdmin,
-  canWriteInSpace,
-  owner,
-  user,
-  plan,
-  space,
-  systemSpace,
-  integrations,
-  activeSeats,
-}: InferGetServerSidePropsType<typeof getServerSideProps>) {
-  const router = useRouter();
 
   return (
-    <SpaceResourcesList
-      owner={owner}
-      user={user}
-      plan={plan}
-      space={space}
-      systemSpace={systemSpace}
-      isAdmin={isAdmin}
-      canWriteInSpace={canWriteInSpace}
-      category={category}
-      integrations={integrations}
-      activeSeats={activeSeats}
-      onSelect={(sId) => {
-        void router.push(
-          `/w/${owner.sId}/spaces/${space.sId}/categories/${category}/data_source_views/${sId}`
-        );
-      }}
-    />
+    <SpaceLayout pageProps={pageProps} useBackendSearch>
+      <SpaceResourcesList
+        owner={owner}
+        user={user}
+        plan={plan}
+        space={space}
+        systemSpace={systemSpace}
+        isAdmin={isAdmin}
+        canWriteInSpace={canWriteInSpace}
+        category={validCategory}
+        integrations={integrations}
+        activeSeats={activeSeats}
+        onSelect={(sId) => {
+          void router.push(
+            `/w/${owner.sId}/spaces/${space.sId}/categories/${validCategory}/data_source_views/${sId}`
+          );
+        }}
+      />
+    </SpaceLayout>
   );
 }
 
-Space.getLayout = (page: ReactElement, pageProps: any) => {
+const PageWithAuthLayout = Space as AppPageWithLayout;
+
+PageWithAuthLayout.getLayout = (
+  page: ReactElement,
+  pageProps: AuthContextValue
+) => {
   return (
-    <AppRootLayout>
-      <SpaceLayout pageProps={pageProps} useBackendSearch>
-        {page}
-      </SpaceLayout>
-    </AppRootLayout>
+    <AppAuthContextLayout authContext={pageProps}>{page}</AppAuthContextLayout>
   );
 };
+
+export default PageWithAuthLayout;

--- a/front/pages/w/[wId]/spaces/[spaceId]/categories/actions/index.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/categories/actions/index.tsx
@@ -1,90 +1,81 @@
-import type { InferGetServerSidePropsType } from "next";
+import { Spinner } from "@dust-tt/sparkle";
+import { useRouter } from "next/router";
 import type { ReactElement } from "react";
 
 import { SpaceActionsList } from "@app/components/spaces/SpaceActionsList";
 import type { SpaceLayoutPageProps } from "@app/components/spaces/SpaceLayout";
 import { SpaceLayout } from "@app/components/spaces/SpaceLayout";
 import { SystemSpaceActionsList } from "@app/components/spaces/SystemSpaceActionsList";
-import AppRootLayout from "@app/components/sparkle/AppRootLayout";
-import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
-import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
-import { SpaceResource } from "@app/lib/resources/space_resource";
-import type { DataSourceViewCategory, SpaceType, UserType } from "@app/types";
+import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
+import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
+import { appGetServerSideProps } from "@app/lib/auth/appServerSideProps";
+import type { AuthContextValue } from "@app/lib/auth/AuthContext";
+import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
+import { useSpaceInfo } from "@app/lib/swr/spaces";
+import { isString } from "@app/types";
 
-export const getServerSideProps = withDefaultUserAuthRequirements<
-  SpaceLayoutPageProps & {
-    category: DataSourceViewCategory;
-    isAdmin: boolean;
-    user: UserType;
-    space: SpaceType;
-  }
->(async (context, auth) => {
-  const owner = auth.getNonNullableWorkspace();
-  const user = auth.getNonNullableUser();
-  const subscription = auth.subscription();
-  const plan = auth.getNonNullablePlan();
-  const isAdmin = auth.isAdmin();
+export const getServerSideProps = appGetServerSideProps;
 
-  const { spaceId } = context.query;
+function Space() {
+  const router = useRouter();
+  const { spaceId } = router.query;
+  const owner = useWorkspace();
+  const { subscription, isAdmin, isBuilder, user } = useAuth();
+  const plan = subscription.plan;
 
-  if (!subscription || typeof spaceId !== "string") {
-    return {
-      notFound: true,
-    };
-  }
+  const {
+    spaceInfo: space,
+    canWriteInSpace,
+    canReadInSpace,
+    isSpaceInfoLoading,
+  } = useSpaceInfo({
+    workspaceId: owner.sId,
+    spaceId: isString(spaceId) ? spaceId : null,
+  });
 
-  await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
-
-  const systemSpace = await SpaceResource.fetchWorkspaceSystemSpace(auth);
-  const space = await SpaceResource.fetchById(auth, spaceId);
-  if (!space || !systemSpace || !space.canReadOrAdministrate(auth)) {
-    return {
-      notFound: true,
-    };
-  }
-
-  const isBuilder = auth.isBuilder();
-  const canWriteInSpace = space.canWrite(auth);
-
-  return {
-    props: {
-      canReadInSpace: space.canRead(auth),
-      canWriteInSpace,
-      category: "actions",
-      isAdmin,
-      isBuilder,
-      owner,
-      user: user.toJSON(),
-      plan,
-      space: space.toJSON(),
-      subscription,
-    },
-  };
-});
-
-export default function Space({
-  isAdmin,
-  owner,
-  user,
-  space,
-}: InferGetServerSidePropsType<typeof getServerSideProps>) {
-  if (space.kind === "system") {
+  if (isSpaceInfoLoading || !space || !user) {
     return (
+      <div className="flex h-screen items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  const pageProps: SpaceLayoutPageProps = {
+    canReadInSpace,
+    canWriteInSpace,
+    category: "actions",
+    isAdmin,
+    owner,
+    plan,
+    space,
+    subscription,
+  };
+
+  const content =
+    space.kind === "system" ? (
       <SystemSpaceActionsList
         isAdmin={isAdmin}
         owner={owner}
         user={user}
         space={space}
       />
+    ) : (
+      <SpaceActionsList isAdmin={isAdmin} owner={owner} space={space} />
     );
-  }
-  return <SpaceActionsList isAdmin={isAdmin} owner={owner} space={space} />;
+
+  return <SpaceLayout pageProps={pageProps}>{content}</SpaceLayout>;
 }
 
-Space.getLayout = (page: ReactElement, pageProps: any) => {
+const PageWithAuthLayout = Space as AppPageWithLayout;
+
+PageWithAuthLayout.getLayout = (
+  page: ReactElement,
+  pageProps: AuthContextValue
+) => {
   return (
-    <AppRootLayout>
-      <SpaceLayout pageProps={pageProps}>{page}</SpaceLayout>
-    </AppRootLayout>
+    <AppAuthContextLayout authContext={pageProps}>{page}</AppAuthContextLayout>
   );
 };
+
+export default PageWithAuthLayout;

--- a/front/pages/w/[wId]/spaces/[spaceId]/categories/apps/index.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/categories/apps/index.tsx
@@ -10,14 +10,14 @@ import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
 import { appGetServerSideProps } from "@app/lib/auth/appServerSideProps";
 import type { AuthContextValue } from "@app/lib/auth/AuthContext";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
+import { useRequiredPathParam } from "@app/lib/platform";
 import { useSpaceInfo } from "@app/lib/swr/spaces";
-import { isString } from "@app/types";
 
 export const getServerSideProps = appGetServerSideProps;
 
 function Space() {
   const router = useRouter();
-  const { spaceId } = router.query;
+  const spaceId = useRequiredPathParam("spaceId");
   const owner = useWorkspace();
   const { subscription, isAdmin, isBuilder } = useAuth();
   const plan = subscription.plan;
@@ -29,7 +29,7 @@ function Space() {
     isSpaceInfoLoading,
   } = useSpaceInfo({
     workspaceId: owner.sId,
-    spaceId: isString(spaceId) ? spaceId : null,
+    spaceId,
   });
 
   if (isSpaceInfoLoading || !space) {

--- a/front/pages/w/[wId]/spaces/[spaceId]/categories/triggers/index.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/categories/triggers/index.tsx
@@ -1,5 +1,4 @@
 import { Spinner } from "@dust-tt/sparkle";
-import { useRouter } from "next/router";
 import type { ReactElement } from "react";
 
 import type { SpaceLayoutPageProps } from "@app/components/spaces/SpaceLayout";
@@ -11,14 +10,13 @@ import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
 import { appGetServerSideProps } from "@app/lib/auth/appServerSideProps";
 import type { AuthContextValue } from "@app/lib/auth/AuthContext";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
+import { useRequiredPathParam } from "@app/lib/platform";
 import { useSpaceInfo } from "@app/lib/swr/spaces";
-import { isString } from "@app/types";
 
 export const getServerSideProps = appGetServerSideProps;
 
 function Space() {
-  const router = useRouter();
-  const { spaceId } = router.query;
+  const spaceId = useRequiredPathParam("spaceId");
   const owner = useWorkspace();
   const { subscription, isAdmin, user } = useAuth();
   const plan = subscription.plan;
@@ -30,7 +28,7 @@ function Space() {
     isSpaceInfoLoading,
   } = useSpaceInfo({
     workspaceId: owner.sId,
-    spaceId: isString(spaceId) ? spaceId : null,
+    spaceId,
   });
 
   if (isSpaceInfoLoading || !space || !user) {

--- a/front/pages/w/[wId]/spaces/[spaceId]/categories/triggers/index.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/categories/triggers/index.tsx
@@ -1,87 +1,81 @@
-import type { InferGetServerSidePropsType } from "next";
+import { Spinner } from "@dust-tt/sparkle";
+import { useRouter } from "next/router";
 import type { ReactElement } from "react";
 
 import type { SpaceLayoutPageProps } from "@app/components/spaces/SpaceLayout";
 import { SpaceLayout } from "@app/components/spaces/SpaceLayout";
 import { SpaceTriggersList } from "@app/components/spaces/SpaceTriggersList";
 import { SystemSpaceTriggersList } from "@app/components/spaces/SystemSpaceTriggersList";
-import AppRootLayout from "@app/components/sparkle/AppRootLayout";
-import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
-import { SpaceResource } from "@app/lib/resources/space_resource";
-import type { DataSourceViewCategory, SpaceType, UserType } from "@app/types";
+import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
+import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
+import { appGetServerSideProps } from "@app/lib/auth/appServerSideProps";
+import type { AuthContextValue } from "@app/lib/auth/AuthContext";
+import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
+import { useSpaceInfo } from "@app/lib/swr/spaces";
+import { isString } from "@app/types";
 
-export const getServerSideProps = withDefaultUserAuthRequirements<
-  SpaceLayoutPageProps & {
-    category: DataSourceViewCategory;
-    isAdmin: boolean;
-    user: UserType;
-    space: SpaceType;
-  }
->(async (context, auth) => {
-  const owner = auth.getNonNullableWorkspace();
-  const user = auth.getNonNullableUser();
-  const subscription = auth.subscription();
-  const plan = auth.getNonNullablePlan();
-  const isAdmin = auth.isAdmin();
+export const getServerSideProps = appGetServerSideProps;
 
-  const { spaceId } = context.query;
+function Space() {
+  const router = useRouter();
+  const { spaceId } = router.query;
+  const owner = useWorkspace();
+  const { subscription, isAdmin, isBuilder, user } = useAuth();
+  const plan = subscription.plan;
 
-  if (!subscription || typeof spaceId !== "string") {
-    return {
-      notFound: true,
-    };
-  }
+  const {
+    spaceInfo: space,
+    canWriteInSpace,
+    canReadInSpace,
+    isSpaceInfoLoading,
+  } = useSpaceInfo({
+    workspaceId: owner.sId,
+    spaceId: isString(spaceId) ? spaceId : null,
+  });
 
-  const space = await SpaceResource.fetchById(auth, spaceId);
-  if (space === null || !space.canReadOrAdministrate(auth)) {
-    return {
-      notFound: true,
-    };
-  }
-
-  const isBuilder = auth.isBuilder();
-  const canWriteInSpace = space.canWrite(auth);
-
-  return {
-    props: {
-      canReadInSpace: space.canRead(auth),
-      canWriteInSpace,
-      category: "triggers",
-      isAdmin,
-      isBuilder,
-      owner,
-      user: user.toJSON(),
-      plan,
-      space: space.toJSON(),
-      subscription,
-    },
-  };
-});
-
-export default function Space({
-  isAdmin,
-  owner,
-  space,
-  user,
-}: InferGetServerSidePropsType<typeof getServerSideProps>) {
-  if (space.kind === "system") {
+  if (isSpaceInfoLoading || !space || !user) {
     return (
+      <div className="flex h-screen items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  const pageProps: SpaceLayoutPageProps = {
+    canReadInSpace,
+    canWriteInSpace,
+    category: "triggers",
+    isAdmin,
+    owner,
+    plan,
+    space,
+    subscription,
+  };
+
+  const content =
+    space.kind === "system" ? (
       <SystemSpaceTriggersList
         isAdmin={isAdmin}
         owner={owner}
         space={space}
         user={user}
       />
+    ) : (
+      <SpaceTriggersList owner={owner} space={space} />
     );
-  }
 
-  return <SpaceTriggersList owner={owner} space={space} />;
+  return <SpaceLayout pageProps={pageProps}>{content}</SpaceLayout>;
 }
 
-Space.getLayout = (page: ReactElement, pageProps: any) => {
+const PageWithAuthLayout = Space as AppPageWithLayout;
+
+PageWithAuthLayout.getLayout = (
+  page: ReactElement,
+  pageProps: AuthContextValue
+) => {
   return (
-    <AppRootLayout>
-      <SpaceLayout pageProps={pageProps}>{page}</SpaceLayout>
-    </AppRootLayout>
+    <AppAuthContextLayout authContext={pageProps}>{page}</AppAuthContextLayout>
   );
 };
+
+export default PageWithAuthLayout;

--- a/front/pages/w/[wId]/spaces/[spaceId]/categories/triggers/index.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/categories/triggers/index.tsx
@@ -20,7 +20,7 @@ function Space() {
   const router = useRouter();
   const { spaceId } = router.query;
   const owner = useWorkspace();
-  const { subscription, isAdmin, isBuilder, user } = useAuth();
+  const { subscription, isAdmin, user } = useAuth();
   const plan = subscription.plan;
 
   const {

--- a/front/pages/w/[wId]/spaces/[spaceId]/index.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/index.tsx
@@ -1,115 +1,118 @@
-import { Page } from "@dust-tt/sparkle";
-import type { InferGetServerSidePropsType } from "next";
+import { Page, Spinner } from "@dust-tt/sparkle";
 import { useRouter } from "next/router";
 import type { ReactElement } from "react";
-import React from "react";
+import React, { useEffect } from "react";
 
+import { SpaceJournalEntry } from "@app/components/assistant/conversation/space/conversations/SpaceJournalEntry";
 import { CreateOrEditSpaceModal } from "@app/components/spaces/CreateOrEditSpaceModal";
 import { SpaceCategoriesList } from "@app/components/spaces/SpaceCategoriesList";
 import type { SpaceLayoutPageProps } from "@app/components/spaces/SpaceLayout";
 import { SpaceLayout } from "@app/components/spaces/SpaceLayout";
-import AppRootLayout from "@app/components/sparkle/AppRootLayout";
-import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
-import { SpaceResource } from "@app/lib/resources/space_resource";
+import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
+import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
+import { appGetServerSideProps } from "@app/lib/auth/appServerSideProps";
+import type { AuthContextValue } from "@app/lib/auth/AuthContext";
+import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
+import { useRequiredPathParam } from "@app/lib/platform";
+import { useSpaceInfo } from "@app/lib/swr/spaces";
 
-export const getServerSideProps = withDefaultUserAuthRequirements<
-  SpaceLayoutPageProps & {
-    canWriteInSpace: boolean;
-    isBuilder: boolean;
-  }
->(async (context, auth) => {
-  const owner = auth.getNonNullableWorkspace();
-  const subscription = auth.subscription();
-  const isAdmin = auth.isAdmin();
-  const plan = auth.getNonNullablePlan();
+export const getServerSideProps = appGetServerSideProps;
 
-  const { spaceId } = context.query;
-  if (!subscription || typeof spaceId !== "string") {
-    return {
-      notFound: true,
-    };
-  }
-
-  const space = await SpaceResource.fetchById(auth, spaceId);
-  if (!space || !space.canReadOrAdministrate(auth)) {
-    return {
-      notFound: true,
-    };
-  }
-
-  // No root page for System spaces since it contains only managed data sources.
-  if (space.isSystem()) {
-    return {
-      redirect: {
-        destination: `/w/${owner.sId}/spaces/${space.sId}/categories/managed`,
-        permanent: false,
-      },
-    };
-  }
-
-  const canWriteInSpace = space.canWrite(auth);
-  const isBuilder = auth.isBuilder();
-
-  return {
-    props: {
-      canReadInSpace: space.canRead(auth),
-      canWriteInSpace,
-      isAdmin,
-      isBuilder,
-      owner,
-      plan,
-      space: space.toJSON(),
-      subscription,
-    },
-  };
-});
-
-export default function Space({
-  isAdmin,
-  isBuilder,
-  canWriteInSpace,
-  owner,
-  space,
-  plan,
-}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+function Space() {
   const [showSpaceEditionModal, setShowSpaceEditionModal] =
     React.useState(false);
 
   const router = useRouter();
+  const spaceId = useRequiredPathParam("spaceId");
+  const owner = useWorkspace();
+  const { subscription, isAdmin, isBuilder } = useAuth();
+  const plan = subscription.plan;
+
+  const {
+    spaceInfo: space,
+    canWriteInSpace,
+    canReadInSpace,
+    isSpaceInfoLoading,
+  } = useSpaceInfo({
+    workspaceId: owner.sId,
+    spaceId,
+  });
+
+  // Redirect system spaces to managed category
+  useEffect(() => {
+    if (space && space.kind === "system") {
+      void router.replace(
+        `/w/${owner.sId}/spaces/${space.sId}/categories/managed`
+      );
+    }
+  }, [space, owner.sId, router]);
+
+  if (isSpaceInfoLoading || !space) {
+    return (
+      <div className="flex h-screen items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  // Don't render if system space (redirect is happening)
+  if (space.kind === "system") {
+    return (
+      <div className="flex h-screen items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  const pageProps: SpaceLayoutPageProps = {
+    canReadInSpace,
+    canWriteInSpace,
+    isAdmin,
+    owner,
+    plan,
+    space,
+    subscription,
+  };
 
   return (
-    <Page.Vertical gap="xl" align="stretch">
-      <SpaceCategoriesList
-        owner={owner}
-        canWriteInSpace={canWriteInSpace}
-        space={space}
-        onSelect={(category) => {
-          void router.push(
-            `/w/${owner.sId}/spaces/${space.sId}/categories/${category}`
-          );
-        }}
-        isAdmin={isAdmin}
-        isBuilder={isBuilder}
-        onButtonClick={() => setShowSpaceEditionModal(true)}
-      />
-      <CreateOrEditSpaceModal
-        owner={owner}
-        isOpen={showSpaceEditionModal}
-        onClose={() => setShowSpaceEditionModal(false)}
-        space={space}
-        isAdmin={isAdmin}
-        plan={plan}
-      />
-    </Page.Vertical>
+    <SpaceLayout pageProps={pageProps} useBackendSearch>
+      <Page.Vertical gap="xl" align="stretch">
+        <SpaceJournalEntry owner={owner} space={space} />
+        <SpaceCategoriesList
+          owner={owner}
+          canWriteInSpace={canWriteInSpace}
+          space={space}
+          onSelect={(category) => {
+            void router.push(
+              `/w/${owner.sId}/spaces/${space.sId}/categories/${category}`
+            );
+          }}
+          isAdmin={isAdmin}
+          isBuilder={isBuilder}
+          onButtonClick={() => setShowSpaceEditionModal(true)}
+        />
+        <CreateOrEditSpaceModal
+          owner={owner}
+          isOpen={showSpaceEditionModal}
+          onClose={() => setShowSpaceEditionModal(false)}
+          space={space}
+          isAdmin={isAdmin}
+          plan={plan}
+        />
+      </Page.Vertical>
+    </SpaceLayout>
   );
 }
 
-Space.getLayout = (page: ReactElement, pageProps: any) => {
+const PageWithAuthLayout = Space as AppPageWithLayout;
+
+PageWithAuthLayout.getLayout = (
+  page: ReactElement,
+  pageProps: AuthContextValue
+) => {
   return (
-    <AppRootLayout>
-      <SpaceLayout pageProps={pageProps} useBackendSearch>
-        {page}
-      </SpaceLayout>
-    </AppRootLayout>
+    <AppAuthContextLayout authContext={pageProps}>{page}</AppAuthContextLayout>
   );
 };
+
+export default PageWithAuthLayout;

--- a/front/pages/w/[wId]/spaces/index.tsx
+++ b/front/pages/w/[wId]/spaces/index.tsx
@@ -9,11 +9,7 @@ import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
 import { appGetServerSideProps } from "@app/lib/auth/appServerSideProps";
 import type { AuthContextValue } from "@app/lib/auth/AuthContext";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
-import {
-  useGlobalSpace,
-  useSpaceInfo,
-  useSystemSpace,
-} from "@app/lib/swr/spaces";
+import { useSpaceInfo, useSpaces, useSystemSpace } from "@app/lib/swr/spaces";
 
 export const getServerSideProps = appGetServerSideProps;
 
@@ -43,10 +39,13 @@ function DefaultSpace() {
     disabled: !isAdmin,
   });
 
-  const { globalSpace, isGlobalSpaceLoading } = useGlobalSpace({
-    workspaceId: owner.sId,
-    disabled: isAdmin,
-  });
+  const { spaces: globalSpaces, isSpacesLoading: isGlobalSpaceLoading } =
+    useSpaces({
+      workspaceId: owner.sId,
+      kinds: ["global"],
+      disabled: isAdmin,
+    });
+  const globalSpace = globalSpaces[0] ?? null;
 
   useEffect(() => {
     // Wait for navigation selection to load

--- a/front/pages/w/[wId]/spaces/index.tsx
+++ b/front/pages/w/[wId]/spaces/index.tsx
@@ -1,63 +1,123 @@
-import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
-import { getPersistedNavigationSelection } from "@app/lib/persisted_navigation_selection";
-import { SpaceResource } from "@app/lib/resources/space_resource";
+import { Spinner } from "@dust-tt/sparkle";
+import { useRouter } from "next/router";
+import type { ReactElement } from "react";
+import { useEffect } from "react";
 
-// This endpoint is used as a pass through to redirect to the global space.
-export const getServerSideProps = withDefaultUserAuthRequirements(
-  async (context, auth) => {
-    const owner = auth.getNonNullableWorkspace();
-    const subscription = auth.subscription();
+import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
+import { usePersistedNavigationSelection } from "@app/hooks/usePersistedNavigationSelection";
+import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
+import { appGetServerSideProps } from "@app/lib/auth/appServerSideProps";
+import type { AuthContextValue } from "@app/lib/auth/AuthContext";
+import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
+import {
+  useGlobalSpace,
+  useSpaceInfo,
+  useSystemSpace,
+} from "@app/lib/swr/spaces";
 
-    if (!subscription) {
-      return {
-        notFound: true,
-      };
+export const getServerSideProps = appGetServerSideProps;
+
+// This page redirects to the appropriate space based on user preferences and role.
+function DefaultSpace() {
+  const router = useRouter();
+  const owner = useWorkspace();
+  const { isAdmin } = useAuth();
+
+  const { navigationSelection, isLoading: isNavSelectionLoading } =
+    usePersistedNavigationSelection();
+
+  const lastSpaceId = navigationSelection.lastSpaceId;
+  const lastSpaceCategory = navigationSelection.lastSpaceCategory;
+
+  // Fetch the last selected space if available
+  const { spaceInfo: lastSpace, isSpaceInfoLoading: isLastSpaceLoading } =
+    useSpaceInfo({
+      workspaceId: owner.sId,
+      spaceId: lastSpaceId ?? null,
+      disabled: !lastSpaceId,
+    });
+
+  // Fetch fallback spaces
+  const { systemSpace, isSystemSpaceLoading } = useSystemSpace({
+    workspaceId: owner.sId,
+    disabled: !isAdmin,
+  });
+
+  const { globalSpace, isGlobalSpaceLoading } = useGlobalSpace({
+    workspaceId: owner.sId,
+    disabled: isAdmin,
+  });
+
+  useEffect(() => {
+    // Wait for navigation selection to load
+    if (isNavSelectionLoading) {
+      return;
     }
 
-    // Try to go to the last selected space.
-    const selection = await getPersistedNavigationSelection(
-      auth.getNonNullableUser()
-    );
-    if (selection.lastSpaceId) {
-      const space = await SpaceResource.fetchById(auth, selection.lastSpaceId);
-      if (space && space.canReadOrAdministrate(auth)) {
+    // If we have a last selected space, wait for it to load and redirect if accessible
+    if (lastSpaceId) {
+      if (isLastSpaceLoading) {
+        return;
+      }
+      if (lastSpace) {
         const redirectPath =
-          `/w/${owner.sId}/spaces/${space.sId}` +
-          (selection.lastSpaceCategory
-            ? `/categories/${selection.lastSpaceCategory}`
-            : "");
-
-        return {
-          redirect: {
-            destination: redirectPath,
-            permanent: false,
-          },
-        };
+          `/w/${owner.sId}/spaces/${lastSpace.sId}` +
+          (lastSpaceCategory ? `/categories/${lastSpaceCategory}` : "");
+        void router.replace(redirectPath);
+        return;
       }
     }
 
-    if (owner.role === "admin") {
-      // Fall back to the system space (connection admin).
-      const space = await SpaceResource.fetchWorkspaceSystemSpace(auth);
-
-      return {
-        redirect: {
-          destination: `/w/${owner.sId}/spaces/${space.sId}`,
-          permanent: false,
-        },
-      };
+    // Fall back to system space for admins
+    if (isAdmin) {
+      if (isSystemSpaceLoading) {
+        return;
+      }
+      if (systemSpace) {
+        void router.replace(`/w/${owner.sId}/spaces/${systemSpace.sId}`);
+        return;
+      }
     } else {
-      // Fall back to the global space (company data).
-      const space = await SpaceResource.fetchWorkspaceGlobalSpace(auth);
-
-      return {
-        redirect: {
-          destination: `/w/${owner.sId}/spaces/${space.sId}`,
-          permanent: false,
-        },
-      };
+      // Fall back to global space for non-admins
+      if (isGlobalSpaceLoading) {
+        return;
+      }
+      if (globalSpace) {
+        void router.replace(`/w/${owner.sId}/spaces/${globalSpace.sId}`);
+        return;
+      }
     }
-  }
-);
+  }, [
+    isNavSelectionLoading,
+    lastSpaceId,
+    lastSpaceCategory,
+    isLastSpaceLoading,
+    lastSpace,
+    isAdmin,
+    isSystemSpaceLoading,
+    systemSpace,
+    isGlobalSpaceLoading,
+    globalSpace,
+    owner.sId,
+    router,
+  ]);
 
-export default function DefaultSpace() {}
+  return (
+    <div className="flex h-screen items-center justify-center">
+      <Spinner />
+    </div>
+  );
+}
+
+const PageWithAuthLayout = DefaultSpace as AppPageWithLayout;
+
+PageWithAuthLayout.getLayout = (
+  page: ReactElement,
+  pageProps: AuthContextValue
+) => {
+  return (
+    <AppAuthContextLayout authContext={pageProps}>{page}</AppAuthContextLayout>
+  );
+};
+
+export default PageWithAuthLayout;


### PR DESCRIPTION



## Description

This PR migrates space-related pages away from `getServerSideProps` to use client-side data fetching with SWR hooks, following the pattern established in recent PRs (#20571, #20616, #20692, #20704).

**Migrated pages:**
- Space apps pages: `apps/[aId]/index.tsx`, `apps/[aId]/datasets/**`, `apps/[aId]/runs/**`, `apps/[aId]/settings.tsx`, `apps/[aId]/specification.tsx`
- Space category pages: `categories/[category]/index.tsx`, `categories/[category]/data_source_views/[dataSourceViewId].tsx`, `categories/actions/index.tsx`, `categories/apps/index.tsx`, `categories/triggers/index.tsx`
- Space root: `[spaceId]/index.tsx`

**New hooks and utilities:**
- `useApp` - fetches individual app details (workspaceId, spaceId, appId)
- `useRunWithSpec` - fetches run details and specification by runId
- `SpaceLayoutWrapper` - fetches space and data source view data via hooks and renders `SpaceLayout`
- Added `connector` field to data source view API responses to reduce additional fetches
- New API endpoint: `/api/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]`

**Pattern:**
```typescript
export const getServerSideProps = appGetServerSideProps;

function MyPage() {
  const owner = useWorkspace();
  const { subscription, isAdmin } = useAuth();
  const { app, isAppLoading } = useApp({ workspaceId, spaceId, appId });
  
  if (isAppLoading || !app) {
    return <Spinner />;
  }
  // render page
}

const PageWithAuthLayout = MyPage as AppPageWithLayout;
PageWithAuthLayout.getLayout = (page, pageProps) => (
  <AppAuthContextLayout authContext={pageProps}>{page}</AppAuthContextLayout>
);
export default PageWithAuthLayout;
```

## Risk

This refactors multiple space-related pages. Pages now load data client-side instead of server-side, which may cause brief loading states
## Tests

- [x] Locally
- [ ] Front edge

Manual testing of space pages navigation and functionality:
- App pages (datasets, runs, settings)
- Category pages (managed, apps, actions, triggers)
- Space root redirects

## Deploy Plan

Deploy front