### PR TITLE
[front] Add llm_timeout_error type and reduce max retries

### DIFF
--- a/front/lib/api/llm/types/errors.ts
+++ b/front/lib/api/llm/types/errors.ts
@@ -10,6 +10,7 @@ export type LLMErrorType =
   | "refusal_error"
   | "maximum_length"
   | "terminated_error"
+  | "llm_timeout_error"
   // HTTP errors
   | "rate_limit_error"
   | "overloaded_error"
@@ -299,6 +300,9 @@ export const getUserFacingLLMErrorMessage = (
     case "unknown_error": {
       return "An unexpected error occurred. Please try again or contact support if the issue persists.";
     }
+    case "llm_timeout_error": {
+      return `${userFacingProvider} is unresponsive. Please try again.`;
+    }
     default: {
       assertNever(type);
     }
@@ -318,6 +322,7 @@ export const LLM_ERROR_TYPE_TO_CATEGORY: Record<
   refusal_error: "unknown_error",
   maximum_length: "context_window_exceeded",
   terminated_error: "retryable_model_error",
+  llm_timeout_error: "retryable_model_error",
 
   // HTTP errors - rate limiting and overload
   rate_limit_error: "retryable_model_error",

--- a/front/temporal/agent_loop/config.ts
+++ b/front/temporal/agent_loop/config.ts
@@ -3,4 +3,4 @@ const QUEUE_VERSION = 2;
 export const QUEUE_NAME = `agent-loop-queue-v${QUEUE_VERSION}`;
 
 // Max retry attempts for the runModelAndCreateActions activity.
-export const RUN_MODEL_MAX_RETRIES = 10;
+export const RUN_MODEL_MAX_RETRIES = 5;

--- a/front/temporal/agent_loop/lib/get_output_from_llm.ts
+++ b/front/temporal/agent_loop/lib/get_output_from_llm.ts
@@ -72,7 +72,7 @@ async function* withPeriodicHeartbeat<T>(
             elapsedMs,
             timeoutMinutes: LLM_EVENT_TIMEOUT_MINUTES,
           },
-          "[AGENT_LOOP_DEBUG] LLM stream timeout - no event received"
+          "[LLM stream] timeout - no event received"
         );
         throw new LLMStreamTimeoutError(elapsedMs, logContext);
       }
@@ -85,7 +85,7 @@ async function* withPeriodicHeartbeat<T>(
             heartbeatCount,
             elapsedMs,
           },
-          "[AGENT_LOOP_DEBUG] LLM stream heartbeat - still waiting for event"
+          "[LLM stream] heartbeat - still waiting for event"
         );
       }
       // Heartbeat won the race, but nextPromise is still pending
@@ -291,7 +291,7 @@ export async function getOutputFromLLMStream(
       return new Err({
         type: "shouldRetryMessage",
         content: {
-          type: "rate_limit_error",
+          type: "llm_timeout_error",
           message: `LLM stream timeout after ${LLM_EVENT_TIMEOUT_MINUTES} minutes waiting for event`,
           isRetryable: true,
         },

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -420,7 +420,7 @@ export async function runModelActivity(
         modelConversationRes.value.modelConversation.messages.length,
       toolCount: specifications.length,
     },
-    "[AGENT_LOOP_DEBUG] Starting LLM stream"
+    "[LLM stream] Starting (agent loop)"
   );
 
   const getOutputFromActionResponse = await getOutputFromLLMStream(auth, {


### PR DESCRIPTION
## Description

- Add new `llm_timeout_error` type for LLM stream timeouts (previously incorrectly used `rate_limit_error`)
- Reduce `RUN_MODEL_MAX_RETRIES` from 10 to 5
- Update log messages for clarity

## Tests

Local

## Risk

Low, purely front.

## Deploy Plan
pmrr
Deploy front