### PR TITLE
Add conversation sandbox system with automatic lifecycle management

### DIFF
--- a/front/lib/api/sandbox/conversation_sandbox.ts
+++ b/front/lib/api/sandbox/conversation_sandbox.ts
@@ -1,0 +1,281 @@
+/**
+ * Conversation Sandbox Service
+ *
+ * Manages sandbox lifecycle per conversation with:
+ * - Lazy creation when first needed
+ * - Auto-pause after 20 minutes of inactivity
+ * - Auto-destroy after 7 days of inactivity
+ * - Auto-wake when accessing a paused sandbox
+ */
+
+import apiConfig from "@app/lib/api/config";
+import type {
+  CommandResult,
+  Sandbox,
+  SandboxError,
+} from "@app/lib/api/sandbox/client";
+import {
+  NorthflankSandboxClient,
+  ServiceAlreadyExistsError,
+} from "@app/lib/api/sandbox/client";
+import type { Authenticator } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import logger from "@app/logger/logger";
+import {
+  signalSandboxActivity,
+  startSandboxLifecycleWorkflow,
+} from "@app/temporal/sandbox_lifecycle/client";
+import type { Result } from "@app/types";
+import { Err, Ok } from "@app/types";
+
+/**
+ * Generate deterministic service name from conversation sId.
+ * Format: csb-{conversationSId}
+ */
+export function getSandboxServiceName(conversationSId: string): string {
+  return `csb-${conversationSId}`;
+}
+
+export type SandboxAttachStatus = "created" | "resumed" | "attached";
+
+export interface SandboxAttachResult {
+  sandbox: Sandbox;
+  status: SandboxAttachStatus;
+}
+
+export class ConversationNotFoundError extends Error {
+  constructor(conversationSId: string) {
+    super(`Conversation "${conversationSId}" not found or access denied`);
+    this.name = "ConversationNotFoundError";
+  }
+}
+
+export type ConversationSandboxError =
+  | ConversationNotFoundError
+  | SandboxError;
+
+/**
+ * Get or create a sandbox for a conversation.
+ *
+ * - If sandbox doesn't exist: creates it, starts lifecycle workflow
+ * - If sandbox exists and running: attaches to it
+ * - If sandbox exists and paused: resumes it
+ *
+ * Access control: Verifies conversation access via ConversationResource.fetchById
+ *
+ * Returns status indicating what happened:
+ * - "created": Fresh sandbox with new filesystem
+ * - "resumed": Was paused, now running (filesystem preserved)
+ * - "attached": Already running (filesystem preserved)
+ */
+export async function getOrCreateConversationSandbox(
+  auth: Authenticator,
+  conversationSId: string
+): Promise<Result<SandboxAttachResult, ConversationSandboxError>> {
+  // Access control: verify user can access this conversation
+  const conversation = await ConversationResource.fetchById(
+    auth,
+    conversationSId
+  );
+  if (!conversation) {
+    return new Err(new ConversationNotFoundError(conversationSId));
+  }
+
+  const serviceName = getSandboxServiceName(conversationSId);
+  const client = await getClient();
+
+  // Check if sandbox already exists
+  const existingStatus = await client.getServiceByName(serviceName);
+
+  if (existingStatus) {
+    const sandbox = client.attach(existingStatus.info);
+
+    if (existingStatus.isPaused) {
+      // Resume paused sandbox
+      logger.info(
+        { conversationSId, serviceName },
+        "[conversation-sandbox] Resuming paused sandbox"
+      );
+
+      const resumeResult = await sandbox.resume();
+      if (resumeResult.isErr()) {
+        return resumeResult;
+      }
+
+      // Signal activity to reset the lifecycle timer
+      await signalSandboxActivity(serviceName);
+
+      return new Ok({ sandbox, status: "resumed" });
+    }
+
+    // Already running, just attach
+    logger.info(
+      { conversationSId, serviceName },
+      "[conversation-sandbox] Attaching to running sandbox"
+    );
+
+    // Signal activity to reset the lifecycle timer
+    await signalSandboxActivity(serviceName);
+
+    return new Ok({ sandbox, status: "attached" });
+  }
+
+  // Create new sandbox
+  logger.info(
+    { conversationSId, serviceName },
+    "[conversation-sandbox] Creating new sandbox"
+  );
+
+  const createResult = await client.createSandbox(serviceName, {
+    workspaceId: auth.getNonNullableWorkspace().sId,
+    conversationId: conversationSId,
+  });
+
+  if (createResult.isErr()) {
+    // Handle race condition: another request created it first
+    if (createResult.error instanceof ServiceAlreadyExistsError) {
+      logger.info(
+        { conversationSId, serviceName },
+        "[conversation-sandbox] Service created by another request, attaching"
+      );
+
+      // Retry: get the existing service
+      const retryStatus = await client.getServiceByName(serviceName);
+      if (retryStatus) {
+        const sandbox = client.attach(retryStatus.info);
+
+        if (retryStatus.isPaused) {
+          const resumeResult = await sandbox.resume();
+          if (resumeResult.isErr()) {
+            return resumeResult;
+          }
+          await signalSandboxActivity(serviceName);
+          return new Ok({ sandbox, status: "resumed" });
+        }
+
+        await signalSandboxActivity(serviceName);
+        return new Ok({ sandbox, status: "attached" });
+      }
+    }
+
+    return createResult;
+  }
+
+  // Start lifecycle workflow for the new sandbox
+  await startSandboxLifecycleWorkflow(serviceName);
+
+  return new Ok({ sandbox: createResult.value, status: "created" });
+}
+
+/**
+ * Execute a command in a conversation's sandbox.
+ *
+ * Handles sandbox lifecycle automatically:
+ * - Creates sandbox if needed
+ * - Resumes if paused
+ * - Signals activity to reset lifecycle timer
+ */
+export async function executeInConversationSandbox(
+  auth: Authenticator,
+  conversationSId: string,
+  command: string
+): Promise<
+  Result<
+    { result: CommandResult; sandboxStatus: SandboxAttachStatus },
+    ConversationSandboxError
+  >
+> {
+  const sandboxResult = await getOrCreateConversationSandbox(
+    auth,
+    conversationSId
+  );
+
+  if (sandboxResult.isErr()) {
+    return sandboxResult;
+  }
+
+  const { sandbox, status } = sandboxResult.value;
+  const result = await sandbox.exec(command);
+
+  // Signal activity after command execution
+  const serviceName = getSandboxServiceName(conversationSId);
+  await signalSandboxActivity(serviceName);
+
+  return new Ok({ result, sandboxStatus: status });
+}
+
+/**
+ * Write a file in a conversation's sandbox.
+ */
+export async function writeFileInConversationSandbox(
+  auth: Authenticator,
+  conversationSId: string,
+  remotePath: string,
+  content: string | Buffer
+): Promise<
+  Result<{ sandboxStatus: SandboxAttachStatus }, ConversationSandboxError>
+> {
+  const sandboxResult = await getOrCreateConversationSandbox(
+    auth,
+    conversationSId
+  );
+
+  if (sandboxResult.isErr()) {
+    return sandboxResult;
+  }
+
+  const { sandbox, status } = sandboxResult.value;
+  await sandbox.writeFile(remotePath, content);
+
+  // Signal activity after file operation
+  const serviceName = getSandboxServiceName(conversationSId);
+  await signalSandboxActivity(serviceName);
+
+  return new Ok({ sandboxStatus: status });
+}
+
+/**
+ * Read a file from a conversation's sandbox.
+ */
+export async function readFileFromConversationSandbox(
+  auth: Authenticator,
+  conversationSId: string,
+  remotePath: string
+): Promise<
+  Result<
+    { content: Buffer; sandboxStatus: SandboxAttachStatus },
+    ConversationSandboxError
+  >
+> {
+  const sandboxResult = await getOrCreateConversationSandbox(
+    auth,
+    conversationSId
+  );
+
+  if (sandboxResult.isErr()) {
+    return sandboxResult;
+  }
+
+  const { sandbox, status } = sandboxResult.value;
+  const content = await sandbox.readFile(remotePath);
+
+  // Signal activity after file operation
+  const serviceName = getSandboxServiceName(conversationSId);
+  await signalSandboxActivity(serviceName);
+
+  return new Ok({ content, sandboxStatus: status });
+}
+
+// Cached client instance
+let clientInstance: NorthflankSandboxClient | null = null;
+
+async function getClient(): Promise<NorthflankSandboxClient> {
+  if (!clientInstance) {
+    const apiToken = apiConfig.getNorthflankApiToken();
+    if (!apiToken) {
+      throw new Error("NORTHFLANK_API_TOKEN not configured");
+    }
+    clientInstance = await NorthflankSandboxClient.create(apiToken);
+  }
+  return clientInstance;
+}

--- a/front/scripts/temporal-build/build-temporal-bundles.ts
+++ b/front/scripts/temporal-build/build-temporal-bundles.ts
@@ -63,6 +63,8 @@ function getWorkerDirectory(workerName: WorkerName): string | null {
       return path.join(baseDir, "temporal/relocation");
     case "remote_tools_sync":
       return path.join(baseDir, "temporal/remote_tools");
+    case "sandbox_lifecycle":
+      return path.join(baseDir, "temporal/sandbox_lifecycle");
     case "scrub_workspace_queue":
       return path.join(baseDir, "temporal/scrub_workspace");
     case "update_workspace_usage":

--- a/front/temporal/sandbox_lifecycle/activities.ts
+++ b/front/temporal/sandbox_lifecycle/activities.ts
@@ -1,0 +1,71 @@
+import apiConfig from "@app/lib/api/config";
+import { NorthflankSandboxClient } from "@app/lib/api/sandbox/client";
+import logger from "@app/logger/logger";
+
+async function getSandboxClient(): Promise<NorthflankSandboxClient> {
+  const apiToken = apiConfig.getNorthflankApiToken();
+  if (!apiToken) {
+    throw new Error("NORTHFLANK_API_TOKEN not configured");
+  }
+  return NorthflankSandboxClient.create(apiToken);
+}
+
+export interface PauseSandboxActivityArgs {
+  serviceName: string;
+}
+
+export async function pauseSandboxActivity({
+  serviceName,
+}: PauseSandboxActivityArgs): Promise<void> {
+  logger.info({ serviceName }, "[sandbox-lifecycle] Pausing sandbox");
+
+  const client = await getSandboxClient();
+  const status = await client.getServiceByName(serviceName);
+
+  if (!status) {
+    logger.info(
+      { serviceName },
+      "[sandbox-lifecycle] Sandbox not found, skipping pause"
+    );
+    return;
+  }
+
+  if (status.isPaused) {
+    logger.info(
+      { serviceName },
+      "[sandbox-lifecycle] Sandbox already paused"
+    );
+    return;
+  }
+
+  const sandbox = client.attach(status.info);
+  await sandbox.pause();
+
+  logger.info({ serviceName }, "[sandbox-lifecycle] Sandbox paused");
+}
+
+export interface DestroySandboxActivityArgs {
+  serviceName: string;
+}
+
+export async function destroySandboxActivity({
+  serviceName,
+}: DestroySandboxActivityArgs): Promise<void> {
+  logger.info({ serviceName }, "[sandbox-lifecycle] Destroying sandbox");
+
+  const client = await getSandboxClient();
+  const status = await client.getServiceByName(serviceName);
+
+  if (!status) {
+    logger.info(
+      { serviceName },
+      "[sandbox-lifecycle] Sandbox not found, skipping destroy"
+    );
+    return;
+  }
+
+  const sandbox = client.attach(status.info);
+  await sandbox.destroy();
+
+  logger.info({ serviceName }, "[sandbox-lifecycle] Sandbox destroyed");
+}

--- a/front/temporal/sandbox_lifecycle/client.ts
+++ b/front/temporal/sandbox_lifecycle/client.ts
@@ -1,0 +1,75 @@
+import { WorkflowExecutionAlreadyStartedError } from "@temporalio/client";
+
+import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
+import logger from "@app/logger/logger";
+import { QUEUE_NAME } from "@app/temporal/sandbox_lifecycle/config";
+import {
+  sandboxActivitySignal,
+  sandboxLifecycleWorkflow,
+} from "@app/temporal/sandbox_lifecycle/workflows";
+
+/**
+ * Generate a deterministic workflow ID for a sandbox.
+ */
+function getSandboxWorkflowId(serviceName: string): string {
+  return `sandbox-lifecycle-${serviceName}`;
+}
+
+/**
+ * Start a lifecycle workflow for a new sandbox.
+ *
+ * Idempotent - if workflow already exists, this is a no-op.
+ */
+export async function startSandboxLifecycleWorkflow(
+  serviceName: string
+): Promise<void> {
+  const client = await getTemporalClientForFrontNamespace();
+  const workflowId = getSandboxWorkflowId(serviceName);
+
+  try {
+    await client.workflow.start(sandboxLifecycleWorkflow, {
+      args: [{ serviceName }],
+      taskQueue: QUEUE_NAME,
+      workflowId,
+      memo: { serviceName },
+    });
+
+    logger.info(
+      { serviceName, workflowId },
+      "[sandbox-lifecycle] Started lifecycle workflow"
+    );
+  } catch (err) {
+    if (err instanceof WorkflowExecutionAlreadyStartedError) {
+      logger.info(
+        { serviceName, workflowId },
+        "[sandbox-lifecycle] Workflow already exists (idempotent)"
+      );
+      return;
+    }
+    throw err;
+  }
+}
+
+/**
+ * Signal the sandbox lifecycle workflow that activity occurred.
+ *
+ * This resets the inactivity timer, preventing auto-pause and auto-destroy.
+ * Call this whenever the sandbox is used (command executed, file operations, etc.)
+ *
+ * If the workflow doesn't exist (sandbox was destroyed), this is a no-op.
+ */
+export async function signalSandboxActivity(serviceName: string): Promise<void> {
+  const client = await getTemporalClientForFrontNamespace();
+  const workflowId = getSandboxWorkflowId(serviceName);
+
+  try {
+    const handle = client.workflow.getHandle(workflowId);
+    await handle.signal(sandboxActivitySignal);
+  } catch (err) {
+    // Workflow may not exist if sandbox was destroyed - that's OK
+    logger.warn(
+      { serviceName, workflowId, err },
+      "[sandbox-lifecycle] Failed to signal workflow (may be destroyed)"
+    );
+  }
+}

--- a/front/temporal/sandbox_lifecycle/config.ts
+++ b/front/temporal/sandbox_lifecycle/config.ts
@@ -1,0 +1,9 @@
+const QUEUE_VERSION = 1;
+
+export const QUEUE_NAME = `sandbox-lifecycle-queue-v${QUEUE_VERSION}`;
+
+// Pause sandbox after 20 minutes of inactivity.
+export const PAUSE_AFTER_INACTIVITY_MS = 20 * 60 * 1000;
+
+// Destroy sandbox after 7 days of inactivity.
+export const DESTROY_AFTER_INACTIVITY_MS = 7 * 24 * 60 * 60 * 1000;

--- a/front/temporal/sandbox_lifecycle/worker.ts
+++ b/front/temporal/sandbox_lifecycle/worker.ts
@@ -1,0 +1,38 @@
+import type { Context } from "@temporalio/activity";
+import { Worker } from "@temporalio/worker";
+
+import {
+  getTemporalWorkerConnection,
+  TEMPORAL_MAXED_CACHED_WORKFLOWS,
+} from "@app/lib/temporal";
+import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
+import logger from "@app/logger/logger";
+import { getWorkflowConfig } from "@app/temporal/bundle_helper";
+import * as activities from "@app/temporal/sandbox_lifecycle/activities";
+import { QUEUE_NAME } from "@app/temporal/sandbox_lifecycle/config";
+
+export async function runSandboxLifecycleWorker(): Promise<void> {
+  const { connection, namespace } = await getTemporalWorkerConnection();
+
+  const worker = await Worker.create({
+    ...getWorkflowConfig({
+      workerName: "sandbox_lifecycle",
+      getWorkflowsPath: () => require.resolve("./workflows"),
+    }),
+    activities,
+    taskQueue: QUEUE_NAME,
+    maxCachedWorkflows: TEMPORAL_MAXED_CACHED_WORKFLOWS,
+    maxConcurrentActivityTaskExecutions: 4,
+    connection,
+    namespace,
+    interceptors: {
+      activity: [
+        (ctx: Context) => ({
+          inbound: new ActivityInboundLogInterceptor(ctx, logger),
+        }),
+      ],
+    },
+  });
+
+  await worker.run();
+}

--- a/front/temporal/sandbox_lifecycle/workflows.ts
+++ b/front/temporal/sandbox_lifecycle/workflows.ts
@@ -1,0 +1,86 @@
+import {
+  condition,
+  defineSignal,
+  proxyActivities,
+  setHandler,
+} from "@temporalio/workflow";
+
+import type * as activities from "@app/temporal/sandbox_lifecycle/activities";
+import {
+  DESTROY_AFTER_INACTIVITY_MS,
+  PAUSE_AFTER_INACTIVITY_MS,
+} from "@app/temporal/sandbox_lifecycle/config";
+
+const { pauseSandboxActivity, destroySandboxActivity } = proxyActivities<
+  typeof activities
+>({
+  startToCloseTimeout: "5 minutes",
+});
+
+// Signal sent when sandbox is used (command executed, file read/written, etc.)
+export const sandboxActivitySignal = defineSignal("sandboxActivity");
+
+export interface SandboxLifecycleWorkflowArgs {
+  serviceName: string;
+}
+
+/**
+ * Per-sandbox lifecycle workflow.
+ *
+ * Manages automatic pause (after 20min inactivity) and destroy (after 7 days inactivity).
+ * Receives signals on sandbox activity to reset the inactivity timer.
+ */
+export async function sandboxLifecycleWorkflow({
+  serviceName,
+}: SandboxLifecycleWorkflowArgs): Promise<void> {
+  let lastActivityMs = Date.now();
+  let isPaused = false;
+
+  // Handle activity signals - reset the inactivity timer
+  setHandler(sandboxActivitySignal, () => {
+    lastActivityMs = Date.now();
+    // If we were paused, the sandbox was resumed externally, so update state
+    isPaused = false;
+  });
+
+  while (true) {
+    const timeSinceActivityMs = Date.now() - lastActivityMs;
+
+    if (timeSinceActivityMs >= DESTROY_AFTER_INACTIVITY_MS) {
+      // 7 days of inactivity - destroy and exit
+      await destroySandboxActivity({ serviceName });
+      return;
+    }
+
+    if (!isPaused && timeSinceActivityMs >= PAUSE_AFTER_INACTIVITY_MS) {
+      // 20 minutes of inactivity - pause
+      await pauseSandboxActivity({ serviceName });
+      isPaused = true;
+    }
+
+    // Calculate how long to wait until the next state transition
+    let waitMs: number;
+    if (isPaused) {
+      // Already paused, wait until destroy threshold
+      waitMs =
+        DESTROY_AFTER_INACTIVITY_MS - timeSinceActivityMs + lastActivityMs;
+    } else {
+      // Not paused, wait until pause threshold
+      waitMs = PAUSE_AFTER_INACTIVITY_MS - timeSinceActivityMs;
+    }
+
+    // Wait for either: timeout expires OR activity signal received
+    // condition() returns true if the predicate becomes true, false on timeout
+    const gotActivity = await condition(
+      () => Date.now() - lastActivityMs < timeSinceActivityMs,
+      waitMs
+    );
+
+    // If we got activity, the timer was reset and we continue the loop
+    // If timeout expired, we continue the loop and check thresholds again
+    if (gotActivity) {
+      // Timer was reset by signal, continue loop with fresh state
+      continue;
+    }
+  }
+}

--- a/front/temporal/worker_registry.ts
+++ b/front/temporal/worker_registry.ts
@@ -12,6 +12,7 @@ import { runNotificationsQueueWorker } from "@app/temporal/notifications_queue/w
 import { runProductionChecksWorker } from "@app/temporal/production_checks/worker";
 import { runRelocationWorker } from "@app/temporal/relocation/worker";
 import { runRemoteToolsSyncWorker } from "@app/temporal/remote_tools/worker";
+import { runSandboxLifecycleWorker } from "@app/temporal/sandbox_lifecycle/worker";
 import { runScrubWorkspaceQueueWorker } from "@app/temporal/scrub_workspace/worker";
 import { runAgentTriggerWorker } from "@app/temporal/triggers/common/worker";
 import { runAgentTriggerWebhookWorker } from "@app/temporal/triggers/webhook/worker";
@@ -37,6 +38,7 @@ export type WorkerName =
   | "production_checks"
   | "relocation"
   | "remote_tools_sync"
+  | "sandbox_lifecycle"
   | "scrub_workspace_queue"
   | "update_workspace_usage"
   | "upsert_queue"
@@ -59,6 +61,7 @@ export const workerFunctions: Record<WorkerName, () => Promise<void>> = {
   production_checks: runProductionChecksWorker,
   relocation: runRelocationWorker,
   remote_tools_sync: runRemoteToolsSyncWorker,
+  sandbox_lifecycle: runSandboxLifecycleWorker,
   scrub_workspace_queue: runScrubWorkspaceQueueWorker,
   update_workspace_usage: runUpdateWorkspaceUsageWorker,
   upsert_queue: runUpsertQueueWorker,


### PR DESCRIPTION
## Description

Implements per-conversation sandboxes for code execution with automatic lifecycle management:

- **Lazy creation**: Sandbox is created when an agent first needs to execute code in a conversation
- **Auto-pause**: Sandbox pauses after 20 minutes of inactivity to reduce costs
- **Auto-wake**: Paused sandboxes automatically resume when accessed
- **Auto-destroy**: Sandboxes are destroyed after 7 days of inactivity
- **Access control**: Enforced via `ConversationResource.fetchById` - no access to sandbox without conversation access

### Key Design Decisions

**Deterministic naming** (`csb-{conversationSId}`):
- Allows looking up sandboxes by name without storing Northflank IDs in our database
- Eliminates need for DB storage entirely

**Per-sandbox Temporal workflow**:
- Each sandbox has its own workflow that receives activity signals
- Workflow uses `condition()` with timeout to wait for signals
- No database needed - Temporal handles all lifecycle state

### New Files

- `front/lib/api/sandbox/conversation_sandbox.ts` - Service layer with `getOrCreateConversationSandbox()`, returns status: `"created"` | `"resumed"` | `"attached"`
- `front/temporal/sandbox_lifecycle/` - Temporal workflow, activities, client, worker

### Modified Files

- `front/lib/api/sandbox/client.ts` - Added `getServiceByName()` for looking up existing sandboxes
- `front/temporal/worker_registry.ts` - Registered new `sandbox_lifecycle` worker

## Tests

- Type checking passes
- Linting passes
- Manual testing pending (requires Northflank integration)

## Risk

**Low risk** - This is additive functionality that doesn't affect existing code paths.

Potential risks:
- Race condition on sandbox creation → Handled by catching `ServiceAlreadyExistsError` and retrying with attach
- Temporal workflow failures → Activities are idempotent, workflow will retry
- Northflank API failures → Errors propagated via Result pattern

## Deploy Plan

1. Deploy code (no migrations needed)
2. Ensure `sandbox_lifecycle` worker is running
3. Feature is ready for use via the conversation sandbox API