### PR TITLE
Sandbox client: add getServiceByName, require Authenticator, drop workspaceId

### DIFF
--- a/front/lib/api/sandbox/client.ts
+++ b/front/lib/api/sandbox/client.ts
@@ -70,7 +70,6 @@ export interface SandboxStatus {
 }
 
 export interface SandboxMetadata {
-  workspaceId?: string;
   conversationId?: string;
   agentConfigurationId?: string;
 }


### PR DESCRIPTION
## Description

Three related changes to `NorthflankSandboxClient` in `front/lib/api/sandbox/client.ts`:

- **`getServiceByName()`**: New method to look up an existing sandbox by its Northflank service name. Returns `SandboxStatus` (info + paused state) or `null` if not found. Enables deterministic sandbox naming where callers derive the service name from their own identifiers.
- **Require `Authenticator` in `createSandbox` and `getSandbox`**: Both methods now take `(auth, sandboxId)` instead of `(serviceId)`. A private `serviceIdForSandbox` helper prepends the workspace `sId` to the sandbox ID automatically, ensuring auth is always present when accessing sandboxes.
- **Remove `workspaceId` from `SandboxMetadata`**: Now redundant since workspace context comes from the `Authenticator`.

## Tests

- Type checking passes (`npx tsc --noEmit`)
- Prettier and ESLint pass
- Manual testing pending (requires Northflank integration)

## Risk

**Low** — Additive API changes. No callers of `createSandbox` or `getSandbox` exist yet, so the signature change is non-breaking.

## Deploy Plan

Standard deploy, no special considerations.