### PR TITLE
Migrate conversation pages to thin SSR pattern

### DIFF
--- a/front/components/assistant/conversation/ConversationLayout.tsx
+++ b/front/components/assistant/conversation/ConversationLayout.tsx
@@ -21,6 +21,7 @@ import { ErrorBoundary } from "@app/components/error_boundary/ErrorBoundary";
 import AppContentLayout from "@app/components/sparkle/AppContentLayout";
 import { useActiveConversationId } from "@app/hooks/useActiveConversationId";
 import { useURLSheet } from "@app/hooks/useURLSheet";
+import type { AuthContextValue } from "@app/lib/auth/AuthContext";
 import { ONBOARDING_CONVERSATION_ENABLED } from "@app/lib/onboarding";
 import { useAppRouter } from "@app/lib/platform";
 import { useConversation } from "@app/lib/swr/conversations";
@@ -30,31 +31,21 @@ import type {
   LightWorkspaceType,
   SubscriptionType,
   UserType,
-  WorkspaceType,
 } from "@app/types";
 import { isString } from "@app/types";
-
-export interface ConversationLayoutProps {
-  baseUrl: string;
-  conversationId: string | null;
-  owner: WorkspaceType;
-  subscription: SubscriptionType;
-  user: UserType;
-  isAdmin: boolean;
-}
 
 export function ConversationLayout({
   children,
   pageProps,
 }: {
   children: React.ReactNode;
-  pageProps: ConversationLayoutProps;
+  pageProps: AuthContextValue;
 }) {
-  const { owner, subscription, user, isAdmin } = pageProps;
+  const { workspace, subscription, user, isAdmin } = pageProps;
 
   return (
     <ConversationLayoutContent
-      owner={owner}
+      owner={workspace}
       subscription={subscription}
       user={user}
       isAdmin={isAdmin}

--- a/front/hooks/useOnboardingConversation.ts
+++ b/front/hooks/useOnboardingConversation.ts
@@ -1,7 +1,7 @@
-import { useRouter } from "next/router";
 import { useCallback, useEffect, useRef } from "react";
 
 import { clientFetch } from "@app/lib/egress/client";
+import { useAppRouter, useSearchParam } from "@app/lib/platform";
 import type { PostSendOnboardingResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations/send-onboarding";
 
 interface UseOnboardingConversationProps {
@@ -13,7 +13,8 @@ export function useOnboardingConversation({
   workspaceId,
   conversationId,
 }: UseOnboardingConversationProps) {
-  const router = useRouter();
+  const router = useAppRouter();
+  const welcome = useSearchParam("welcome");
   const isCreatingRef = useRef(false);
 
   const createOnboardingConversation = useCallback(async () => {
@@ -56,10 +57,10 @@ export function useOnboardingConversation({
 
   useEffect(() => {
     const shouldCreateOnboarding =
-      router.query.welcome === "true" && conversationId === null;
+      welcome === "true" && conversationId === null;
 
     if (shouldCreateOnboarding) {
       void createOnboardingConversation();
     }
-  }, [router.query.welcome, conversationId, createOnboardingConversation]);
+  }, [welcome, conversationId, createOnboardingConversation]);
 }

--- a/front/hooks/useOnboardingConversation.ts
+++ b/front/hooks/useOnboardingConversation.ts
@@ -1,0 +1,65 @@
+import { useRouter } from "next/router";
+import { useCallback, useEffect, useRef } from "react";
+
+import { clientFetch } from "@app/lib/egress/client";
+import type { PostSendOnboardingResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations/send-onboarding";
+
+interface UseOnboardingConversationProps {
+  workspaceId: string;
+  conversationId: string | null;
+}
+
+export function useOnboardingConversation({
+  workspaceId,
+  conversationId,
+}: UseOnboardingConversationProps) {
+  const router = useRouter();
+  const isCreatingRef = useRef(false);
+
+  const createOnboardingConversation = useCallback(async () => {
+    if (isCreatingRef.current) {
+      return;
+    }
+    isCreatingRef.current = true;
+
+    const language =
+      typeof navigator !== "undefined"
+        ? (navigator.language?.split("-")[0] ?? null)
+        : null;
+
+    const res = await clientFetch(
+      `/api/w/${workspaceId}/assistant/conversations/send-onboarding`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ language }),
+      }
+    );
+
+    if (res.ok) {
+      const data = (await res.json()) as PostSendOnboardingResponseBody;
+      if (data.conversationSId) {
+        await router.replace(
+          `/w/${workspaceId}/conversation/${data.conversationSId}`
+        );
+        return;
+      }
+    }
+
+    // If no conversation was created or there was an error, remove the welcome param
+    const currentPath = router.asPath.replace(/[?&]welcome=true/, "");
+    await router.replace(currentPath);
+    isCreatingRef.current = false;
+  }, [workspaceId, router]);
+
+  useEffect(() => {
+    const shouldCreateOnboarding =
+      router.query.welcome === "true" && conversationId === null;
+
+    if (shouldCreateOnboarding) {
+      void createOnboardingConversation();
+    }
+  }, [router.query.welcome, conversationId, createOnboardingConversation]);
+}

--- a/front/lib/auth/AuthContext.tsx
+++ b/front/lib/auth/AuthContext.tsx
@@ -7,8 +7,9 @@ import type {
 } from "@app/types";
 
 // Context for pages that have workspace (app pages, workspace-scoped poke pages).
+// User is non-nullable because withDefaultUserAuthRequirements guarantees authentication.
 export interface AuthContextValue {
-  user: UserType | null;
+  user: UserType;
   workspace: LightWorkspaceType;
   subscription: SubscriptionType;
   isAdmin: boolean;

--- a/front/lib/auth/appServerSideProps.ts
+++ b/front/lib/auth/appServerSideProps.ts
@@ -14,7 +14,7 @@ export const appGetServerSideProps =
       props: {
         workspace: auth.getNonNullableWorkspace(),
         subscription: auth.getNonNullableSubscription(),
-        user: auth.user()?.toJSON() ?? null,
+        user: auth.getNonNullableUser().toJSON(),
         isAdmin: auth.isAdmin(),
         isBuilder: auth.isBuilder(),
         isSuperUser: false,
@@ -34,7 +34,7 @@ export const appGetServerSidePropsForBuilders =
       props: {
         workspace: auth.getNonNullableWorkspace(),
         subscription: auth.getNonNullableSubscription(),
-        user: auth.user()?.toJSON() ?? null,
+        user: auth.getNonNullableUser().toJSON(),
         isAdmin: auth.isAdmin(),
         isBuilder: auth.isBuilder(),
         isSuperUser: false,
@@ -54,7 +54,7 @@ export const appGetServerSidePropsForAdmin =
       props: {
         workspace: auth.getNonNullableWorkspace(),
         subscription: auth.getNonNullableSubscription(),
-        user: auth.user()?.toJSON() ?? null,
+        user: auth.getNonNullableUser().toJSON(),
         isAdmin: auth.isAdmin(),
         isBuilder: auth.isBuilder(),
         isSuperUser: false,

--- a/front/lib/auth/pokeServerSideProps.ts
+++ b/front/lib/auth/pokeServerSideProps.ts
@@ -33,7 +33,7 @@ export const pokeGetServerSideProps =
       props: {
         workspace,
         subscription,
-        user: auth.user()?.toJSON() ?? null,
+        user: auth.getNonNullableUser().toJSON(),
         isAdmin: auth.isAdmin(),
         isBuilder: auth.isBuilder(),
         isSuperUser: true,

--- a/front/lib/development.ts
+++ b/front/lib/development.ts
@@ -63,11 +63,15 @@ export async function sendOnboardingConversation(
       headers: {
         "Content-Type": "application/json",
       },
+      body: JSON.stringify({ force: true }),
     }
   );
 
   if (response.ok) {
     const data = await response.json();
+    if (!data.conversationSId) {
+      return { isOk: false, error: "Failed to create onboarding conversation" };
+    }
     return { isOk: true, conversationSId: data.conversationSId };
   } else {
     return { isOk: false, error: "Error sending onboarding conversation" };

--- a/front/pages/api/w/[wId]/assistant/conversations/send-onboarding.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/send-onboarding.ts
@@ -8,7 +8,7 @@ import type { WithAPIErrorResponse } from "@app/types";
 import { isString } from "@app/types";
 
 export type PostSendOnboardingResponseBody = {
-  conversationSId: string;
+  conversationSId: string | null;
 };
 
 async function handler(
@@ -18,57 +18,36 @@ async function handler(
   >,
   auth: Authenticator
 ): Promise<void> {
-  if (!auth.isDustSuperUser()) {
+  if (req.method !== "POST") {
     return apiError(req, res, {
-      status_code: 403,
+      status_code: 405,
       api_error: {
-        type: "workspace_auth_error",
-        message: "Only superusers can send onboarding conversations.",
+        type: "method_not_supported_error",
+        message: "The method passed is not supported, POST is expected.",
       },
     });
   }
 
-  switch (req.method) {
-    case "POST":
-      // Accept language from body (for testing) or fall back to Accept-Language header.
-      const bodyLanguage = req.body?.language;
-      const acceptLanguage = req.headers["accept-language"];
-      const language = isString(bodyLanguage)
-        ? bodyLanguage
-        : (acceptLanguage?.split(",")[0]?.split("-")[0] ?? null);
+  // Accept language from body or fall back to Accept-Language header.
+  const bodyLanguage = req.body?.language;
+  const acceptLanguage = req.headers["accept-language"];
+  const language = isString(bodyLanguage)
+    ? bodyLanguage
+    : (acceptLanguage?.split(",")[0]?.split("-")[0] ?? null);
 
-      const result = await createOnboardingConversationIfNeeded(auth, {
-        force: true,
-        language,
-      });
+  // Only superusers can force creation (for testing purposes).
+  const force = auth.isDustSuperUser() && req.body?.force === true;
 
-      if (result.isErr()) {
-        return apiError(req, res, result.error);
-      }
+  const result = await createOnboardingConversationIfNeeded(auth, {
+    force,
+    language,
+  });
 
-      const conversationSId = result.value;
-      if (!conversationSId) {
-        return apiError(req, res, {
-          status_code: 500,
-          api_error: {
-            type: "internal_server_error",
-            message: "Failed to create onboarding conversation.",
-          },
-        });
-      }
-
-      res.status(200).json({ conversationSId });
-      return;
-
-    default:
-      return apiError(req, res, {
-        status_code: 405,
-        api_error: {
-          type: "method_not_supported_error",
-          message: "The method passed is not supported, POST is expected.",
-        },
-      });
+  if (result.isErr()) {
+    return apiError(req, res, result.error);
   }
+
+  return res.status(200).json({ conversationSId: result.value });
 }
 
 export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/index.ts
@@ -36,6 +36,8 @@ export type GetSpaceResponseBody = {
   space: SpaceType & {
     categories: { [key: string]: SpaceCategoryInfo };
     isMember: boolean;
+    canRead: boolean;
+    canWrite: boolean;
     members: UserType[];
   };
 };
@@ -130,6 +132,8 @@ async function handler(
           ...space.toJSON(),
           categories,
           isMember: space.canRead(auth),
+          canRead: space.canRead(auth),
+          canWrite: space.canWrite(auth),
           members: currentMembers.map((member) => member.toJSON()),
         },
       });

--- a/front/pages/w/[wId]/conversation/space/[spaceId]/index.tsx
+++ b/front/pages/w/[wId]/conversation/space/[spaceId]/index.tsx
@@ -2,138 +2,59 @@ import {
   BookOpenIcon,
   ChatBubbleLeftRightIcon,
   Cog6ToothIcon,
+  Spinner,
   Tabs,
   TabsContent,
   TabsList,
   TabsTrigger,
 } from "@dust-tt/sparkle";
-import type { InferGetServerSidePropsType } from "next";
 import { useRouter } from "next/router";
 import type { ReactElement } from "react";
 import React, { useCallback, useState } from "react";
 
-import type { ConversationLayoutProps } from "@app/components/assistant/conversation/ConversationLayout";
 import { ConversationLayout } from "@app/components/assistant/conversation/ConversationLayout";
 import { SpaceAboutTab } from "@app/components/assistant/conversation/space/about/SpaceAboutTab";
 import { SpaceConversationsTab } from "@app/components/assistant/conversation/space/conversations/SpaceConversationsTab";
 import { SpaceContextTab } from "@app/components/assistant/conversation/space/SpaceContextTab";
-import AppRootLayout from "@app/components/sparkle/AppRootLayout";
+import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
 import { useActiveSpaceId } from "@app/hooks/useActiveSpaceId";
 import { useCreateConversationWithMessage } from "@app/hooks/useCreateConversationWithMessage";
 import { useSendNotification } from "@app/hooks/useNotification";
-import config from "@app/lib/api/config";
+import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
+import { appGetServerSideProps } from "@app/lib/auth/appServerSideProps";
+import type { AuthContextValue } from "@app/lib/auth/AuthContext";
+import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import type { DustError } from "@app/lib/error";
-import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
-import { SpaceResource } from "@app/lib/resources/space_resource";
 import { useSpaceConversations } from "@app/lib/swr/conversations";
 import { useGroups } from "@app/lib/swr/groups";
-import { useSpaceInfo } from "@app/lib/swr/spaces";
+import { useSpaceInfo, useSystemSpace } from "@app/lib/swr/spaces";
 import { getConversationRoute } from "@app/lib/utils/router";
-import type {
-  ContentFragmentsType,
-  PlanType,
-  Result,
-  RichMention,
-  SpaceType,
-  SubscriptionType,
-  UserType,
-  WorkspaceType,
-} from "@app/types";
+import type { ContentFragmentsType, Result, RichMention } from "@app/types";
 import { Err, Ok, toMentionType } from "@app/types";
 
-export interface ProjectLayoutProps {
-  baseUrl: string;
-  owner: WorkspaceType;
-  subscription: SubscriptionType;
-  user: UserType;
-  isAdmin: boolean;
-
-  canReadInSpace: boolean;
-  canWriteInSpace: boolean;
-  plan: PlanType;
-  systemSpace: SpaceType;
-}
-
-export const getServerSideProps =
-  withDefaultUserAuthRequirements<ProjectLayoutProps>(async (context, auth) => {
-    const owner = auth.workspace();
-    const user = auth.user()?.toJSON();
-    const subscription = auth.subscription();
-    const isAdmin = auth.isAdmin();
-    const plan = auth.plan();
-
-    if (!owner || !user || !auth.isUser() || !subscription) {
-      return {
-        redirect: {
-          destination: "/",
-          permanent: false,
-        },
-      };
-    }
-
-    const { spaceId } = context.params;
-    if (typeof spaceId !== "string") {
-      return {
-        notFound: true,
-      };
-    }
-
-    const space = await SpaceResource.fetchById(auth, spaceId);
-    if (!space || !space.canReadOrAdministrate(auth)) {
-      return {
-        notFound: true,
-      };
-    }
-
-    if (!plan) {
-      return {
-        notFound: true,
-      };
-    }
-
-    const systemSpace = (
-      await SpaceResource.fetchWorkspaceSystemSpace(auth)
-    ).toJSON();
-    const canWriteInSpace = space.canWrite(auth);
-    const canReadInSpace = space.canRead(auth);
-
-    return {
-      props: {
-        user,
-        owner,
-        isAdmin,
-        subscription,
-        systemSpace,
-        plan,
-        canWriteInSpace,
-        canReadInSpace,
-        baseUrl: config.getClientFacingUrl(),
-      },
-    };
-  });
+export const getServerSideProps = appGetServerSideProps;
 
 type SpaceTab = "conversations" | "context" | "settings";
 
-export default function SpaceConversations({
-  owner,
-  subscription,
-  user,
-  isAdmin,
-  systemSpace,
-  plan,
-  canWriteInSpace,
-  canReadInSpace,
-}: InferGetServerSidePropsType<typeof getServerSideProps>) {
-  const createConversationWithMessage = useCreateConversationWithMessage({
-    owner,
-    user,
-  });
+function SpaceConversationsPage() {
+  const owner = useWorkspace();
+  const { subscription, user, isAdmin } = useAuth();
   const router = useRouter();
   const spaceId = useActiveSpaceId();
   const sendNotification = useSendNotification();
-  const { spaceInfo } = useSpaceInfo({
+
+  const { spaceInfo, isSpaceInfoLoading, isSpaceInfoError } = useSpaceInfo({
     workspaceId: owner.sId,
     spaceId: spaceId,
+  });
+
+  const { systemSpace, isSystemSpaceLoading } = useSystemSpace({
+    workspaceId: owner.sId,
+  });
+
+  const createConversationWithMessage = useCreateConversationWithMessage({
+    owner,
+    user,
   });
 
   const { conversations, isConversationsLoading, mutateConversations } =
@@ -154,6 +75,9 @@ export default function SpaceConversations({
 
   // Parse and validate the current tab from URL hash
   const getCurrentTabFromHash = useCallback((): SpaceTab => {
+    if (typeof window === "undefined") {
+      return "conversations";
+    }
     const hash = window.location.hash.slice(1); // Remove the # prefix
     if (hash === "context" || hash === "settings" || hash === "conversations") {
       return hash;
@@ -280,6 +204,34 @@ export default function SpaceConversations({
     ]
   );
 
+  // Show loading state while fetching space info
+  if (isSpaceInfoLoading || isSystemSpaceLoading) {
+    return (
+      <div className="flex h-full w-full items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  // Handle space not found or access denied
+  if (isSpaceInfoError || !spaceInfo || !systemSpace) {
+    return (
+      <div className="flex h-full w-full items-center justify-center">
+        <div className="text-center">
+          <h2 className="text-lg font-semibold">Space not found</h2>
+          <p className="text-muted-foreground">
+            The space you&apos;re looking for doesn&apos;t exist or you
+            don&apos;t have access to it.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  // Extract permissions from spaceInfo (now includes canRead and canWrite from API)
+  const canReadInSpace = spaceInfo.canRead ?? spaceInfo.isMember;
+  const canWriteInSpace = spaceInfo.canWrite ?? false;
+
   return (
     <div className="flex h-full w-full flex-col">
       <Tabs
@@ -298,67 +250,65 @@ export default function SpaceConversations({
         </TabsList>
 
         <TabsContent value="conversations">
-          {spaceInfo && (
-            <SpaceConversationsTab
-              owner={owner}
-              user={user}
-              conversations={conversations}
-              isConversationsLoading={isConversationsLoading}
-              spaceInfo={spaceInfo}
-              onSubmit={handleConversationCreation}
-            />
-          )}
+          <SpaceConversationsTab
+            owner={owner}
+            user={user}
+            conversations={conversations}
+            isConversationsLoading={isConversationsLoading}
+            spaceInfo={spaceInfo}
+            onSubmit={handleConversationCreation}
+          />
         </TabsContent>
 
         <TabsContent value="context">
-          {spaceInfo && (
-            <SpaceContextTab
-              owner={owner}
-              space={spaceInfo}
-              systemSpace={systemSpace}
-              plan={plan}
-              isAdmin={isAdmin}
-              canReadInSpace={canReadInSpace}
-              canWriteInSpace={canWriteInSpace}
-            />
-          )}
+          <SpaceContextTab
+            owner={owner}
+            space={spaceInfo}
+            systemSpace={systemSpace}
+            plan={subscription.plan}
+            isAdmin={isAdmin}
+            canReadInSpace={canReadInSpace}
+            canWriteInSpace={canWriteInSpace}
+          />
         </TabsContent>
 
         <TabsContent value="settings">
-          {spaceInfo && (
-            <SpaceAboutTab
-              key={spaceId}
-              owner={owner}
-              space={spaceInfo}
-              initialMembers={spaceInfo.members}
-              planAllowsSCIM={planAllowsSCIM}
-              initialGroups={
-                planAllowsSCIM &&
-                spaceInfo.groupIds &&
-                spaceInfo.groupIds.length > 0 &&
-                groups
-                  ? groups.filter((group) =>
-                      spaceInfo.groupIds.includes(group.sId)
-                    )
-                  : []
-              }
-              initialManagementMode={spaceInfo.managementMode}
-              initialIsRestricted={spaceInfo.isRestricted}
-            />
-          )}
+          <SpaceAboutTab
+            key={spaceId}
+            owner={owner}
+            space={spaceInfo}
+            initialMembers={spaceInfo.members}
+            planAllowsSCIM={planAllowsSCIM}
+            initialGroups={
+              planAllowsSCIM &&
+              spaceInfo.groupIds &&
+              spaceInfo.groupIds.length > 0 &&
+              groups
+                ? groups.filter((group) =>
+                    spaceInfo.groupIds.includes(group.sId)
+                  )
+                : []
+            }
+            initialManagementMode={spaceInfo.managementMode}
+            initialIsRestricted={spaceInfo.isRestricted}
+          />
         </TabsContent>
       </Tabs>
     </div>
   );
 }
 
-SpaceConversations.getLayout = (
+const PageWithAuthLayout = SpaceConversationsPage as AppPageWithLayout;
+
+PageWithAuthLayout.getLayout = (
   page: ReactElement,
-  pageProps: ConversationLayoutProps
+  pageProps: AuthContextValue
 ) => {
   return (
-    <AppRootLayout>
+    <AppAuthContextLayout authContext={pageProps}>
       <ConversationLayout pageProps={pageProps}>{page}</ConversationLayout>
-    </AppRootLayout>
+    </AppAuthContextLayout>
   );
 };
+
+export default PageWithAuthLayout;


### PR DESCRIPTION
## Description

Migrate main conversation page (`/w/[wId]/conversation/[cId]`) to thin SSR pattern
Migrate space conversation page (`/w/[wId]/conversation/space/[spaceId]`) to thin SSR pattern
Move onboarding conversation creation from SSR to client-side API call
Make `user` non-nullable in `AuthContextValue` (guaranteed by `withDefaultUserAuthRequirements`)


  ### Auth Context
  - `AuthContextValue.user` is now `UserType` instead of `UserType | null`
  - Updated `appGetServerSideProps` variants and `pokeGetServerSideProps` to use `auth.getNonNullableUser()`

  ### API Changes
  - Add `canRead` and `canWrite` permission flags to `GET /api/w/[wId]/spaces/[spaceId]` response
  - Modify `POST /api/w/[wId]/assistant/conversations/send-onboarding` to support both regular users and superusers:
    - Regular users: creates onboarding conversation only when conditions are met
    - Superusers with `force: true`: always creates (for testing via Dev Tools)

  ### Page Migrations
  Both conversation pages now use `appGetServerSideProps` with client-side data fetching:
  - Use `useWorkspace()` and `useAuth()` hooks instead of SSR props
  - Use `useSpaceInfo` hook for space permissions (now includes `canRead`/`canWrite`)
  - Use `useSystemSpace` hook instead of server-side fetch
  - Handle loading and error states client-side

## Tests

- [x] Navigate to `/w/{wId}/conversation/new` - should load correctly
- [x] Navigate with `?assistant=xyz` - should redirect to `?agent=xyz` and put agent in mention
- [x] Navigate with `?agentDetail=xyz` - should open this agent modal
- [ ] Navigate to `/w/{wId}/conversation/space/{spaceId}` - should load with correct permissions
- [ ] Verify tabs show/hide based on permissions
- [ ] Test with user who cannot access space - should show error message
- [x] Test "Send onboarding conversation" from Dev Tools (superuser) - should create and redirect

-> will test the project in front edge.

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 