### PR TITLE
fix(front): skip project journal entries API call for non-project spaces

### DIFF
--- a/front/components/assistant/conversation/space/conversations/SpaceJournalEntry.tsx
+++ b/front/components/assistant/conversation/space/conversations/SpaceJournalEntry.tsx
@@ -22,6 +22,7 @@ export function SpaceJournalEntry({ owner, space }: SpaceJournalEntryProps) {
     useProjectJournalEntries({
       workspaceId: owner.sId,
       spaceId: space.sId,
+      spaceKind: space.kind,
       limit: 1,
     });
 

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -959,27 +959,32 @@ export function useUpdateProjectMetadata({
 export function useProjectJournalEntries({
   workspaceId,
   spaceId,
+  spaceKind,
   limit = 1,
   disabled = false,
 }: {
   workspaceId: string;
   spaceId: string | null;
+  spaceKind: SpaceKind | null;
   limit?: number;
   disabled?: boolean;
 }) {
   const journalEntriesFetcher: Fetcher<GetProjectJournalEntriesResponseBody> =
     fetcher;
 
+  // Only fetch journal entries for project spaces.
+  const isDisabled = disabled || spaceId === null || spaceKind !== "project";
+
   const { data, error, mutate } = useSWRWithDefaults(
     `/api/w/${workspaceId}/spaces/${spaceId}/project_journal_entries?limit=${limit}`,
     journalEntriesFetcher,
-    { disabled: disabled || spaceId === null }
+    { disabled: isDisabled }
   );
 
   return {
     journalEntries: data?.entries ?? emptyArray(),
     latestJournalEntry: data?.entries?.[0] ?? null,
-    isJournalEntriesLoading: !error && !data && !disabled,
+    isJournalEntriesLoading: !error && !data && !isDisabled,
     isJournalEntriesError: error,
     mutateJournalEntries: mutate,
   };


### PR DESCRIPTION
Project journal entries should only be fetched for spaces with kind='project'.
Updated useProjectJournalEntries hook to accept spaceKind parameter and skip
the API call when the space is not a project space, preventing unnecessary
'Project journal entries are only available for project spaces' errors in logs.

## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
