### PR TITLE
[SPA] Improve docker images

### DIFF
--- a/.github/actions/build-image/action.yml
+++ b/.github/actions/build-image/action.yml
@@ -86,6 +86,40 @@ runs:
     - name: "Setup Depot"
       uses: "depot/setup-action@v1"
 
+    # Build dedicated dependency images for JS packages
+    #
+    # WHY THIS STEP EXISTS:
+    #   In a monorepo, all packages share package-lock.json. Without this step,
+    #   changes to ANY package's dependencies would invalidate Docker cache for
+    #   ALL packages, causing unnecessary rebuilds.
+    #
+    # WHAT IT DOES:
+    #   Runs scripts/build-deps.sh which:
+    #   1. Computes content hash of js dependencies for each package
+    #   2. Checks if image with that hash exists (skip if yes)
+    #   3. Builds new image only if hash changed (dependencies changed)
+    #   4. Tags images as both :<hash> and :latest
+    #
+    # CACHING:
+    #   - If dependencies unchanged, this step completes instantly
+    #   - If dependencies changed, only affected packages rebuild
+    #   - Hash-tagged images persist across CI runs for cache hits
+    #
+    # OUTPUT:
+    #   Creates local Docker images:
+    #   - dust-front-deps:latest and dust-front-deps:<hash>
+    #   - dust-connectors-deps:latest and dust-connectors-deps:<hash>
+    #   - dust-viz-deps:latest and dust-viz-deps:<hash>
+    #
+    #   These images are then used in the service Dockerfiles via bind mounts
+    #   to copy pre-installed node_modules without re-running npm ci.
+    - name: "Build Dependency Images"
+      if: ${{ contains(fromJSON('["front", "front-edge", "front-canary", "connectors", "connectors-qa", "viz"]'), inputs.component) }}
+      shell: bash
+      run: |
+        echo "🔨 Building dependency images..."
+        ./scripts/build-deps.sh
+
     - name: "Build and Push"
       shell: bash
       env:

--- a/dockerfiles/deps/connectors-deps.Dockerfile
+++ b/dockerfiles/deps/connectors-deps.Dockerfile
@@ -1,0 +1,37 @@
+################################################################################
+# Connectors Dependencies Image
+#
+# PURPOSE:
+#   Pre-install all npm dependencies for the connectors package and its
+#   workspace dependency (sdks/js). Used as a bind mount source in
+#   connectors.Dockerfile.
+#
+# ISOLATION:
+#   This image is completely independent from front-deps and viz-deps.
+#   Changes to connectors dependencies only trigger a rebuild of this image,
+#   not front or viz dependency images.
+#
+# HOW IT'S USED:
+#   In connectors.Dockerfile:
+#     FROM dust-connectors-deps:latest AS connectors-deps-cache
+#     RUN --mount=type=bind,from=connectors-deps-cache,...
+#         cp -r /app/node_modules .
+#
+# OUTPUT:
+#   /app/node_modules
+#   /app/sdks/js/node_modules
+#   /app/connectors/node_modules
+################################################################################
+
+FROM node:20.19.2 AS connectors-deps
+
+WORKDIR /app
+
+# Copy dependency manifests
+COPY package.json package-lock.json ./
+COPY connectors/package.json ./connectors/
+COPY sdks/js/package.json ./sdks/js/
+
+# Install dependencies with npm cache mount for faster rebuilds
+RUN --mount=type=cache,target=/root/.npm \
+  npm ci -w sdks/js -w connectors

--- a/dockerfiles/deps/front-deps.Dockerfile
+++ b/dockerfiles/deps/front-deps.Dockerfile
@@ -1,0 +1,64 @@
+################################################################################
+# Front Dependencies Image
+#
+# PURPOSE:
+#   Pre-install all npm dependencies for the front package and its workspace
+#   dependencies (sparkle, sdks/js). This image is used as a bind mount source
+#   in the main front.Dockerfile to avoid re-running npm ci on every build.
+#
+# PROBLEM SOLVED:
+#   Without this approach, any change to package-lock.json (even for other
+#   packages like connectors) would invalidate the npm install layer for front,
+#   causing unnecessary rebuilds.
+#
+# HOW IT'S USED:
+#   In front.Dockerfile:
+#     FROM dust-front-deps:latest AS front-deps-cache
+#     RUN --mount=type=bind,from=front-deps-cache,source=/app/node_modules,...
+#         cp -r /app/node_modules .
+#
+# CACHING:
+#   - BuildKit cache mount (--mount=type=cache) speeds up npm downloads
+#   - Docker layer cache reuses this layer if package-lock.json unchanged
+#   - Content-based hash tagging (by build-deps.sh) enables cache hits across runs
+#
+# OUTPUT:
+#   /app/node_modules (root monorepo node_modules)
+#   /app/sdks/js/node_modules
+#   /app/sparkle/node_modules
+#   /app/front/node_modules
+################################################################################
+
+FROM node:20.19.2 AS front-deps
+
+WORKDIR /app
+
+# Copy dependency manifests
+# These files determine what gets installed, so they're copied first to
+# maximize Docker layer caching (if these don't change, npm ci layer is cached)
+COPY package.json package-lock.json ./
+COPY sdks/js/package.json ./sdks/js/
+COPY sparkle/package.json ./sparkle/
+COPY front/package.json ./front/
+
+# Install dependencies for front and its workspace dependencies
+#
+# --mount=type=cache,target=/root/.npm:
+#   Creates a persistent cache volume for npm downloads. When this image is
+#   rebuilt (e.g., after package-lock.json changes), npm checks this cache
+#   first before downloading from the registry, significantly speeding up builds.
+#
+# npm ci -w sdks/js -w sparkle -w front:
+#   Installs dependencies for multiple workspaces in a single command.
+#   This is more efficient than installing each workspace separately.
+RUN --mount=type=cache,target=/root/.npm \
+  npm ci -w sdks/js -w sparkle -w front
+
+# At this point, the image contains:
+# - /app/node_modules (hoisted dependencies for the entire monorepo)
+# - /app/sdks/js/node_modules (sdks/js-specific dependencies)
+# - /app/sparkle/node_modules (sparkle-specific dependencies)
+# - /app/front/node_modules (front-specific dependencies)
+#
+# These node_modules directories will be mounted into the main front.Dockerfile
+# to avoid re-running npm ci during service builds.

--- a/dockerfiles/deps/viz-deps.Dockerfile
+++ b/dockerfiles/deps/viz-deps.Dockerfile
@@ -1,0 +1,33 @@
+################################################################################
+# Viz Dependencies Image
+#
+# PURPOSE:
+#   Pre-install all npm dependencies for the viz package. Viz is standalone
+#   and doesn't depend on other internal packages like sdks/js or sparkle.
+#
+# ISOLATION:
+#   This image is completely independent from front-deps and connectors-deps.
+#   Changes to viz dependencies only trigger a rebuild of this image.
+#
+# HOW IT'S USED:
+#   In viz.Dockerfile:
+#     FROM dust-viz-deps:latest AS viz-deps-cache
+#     RUN --mount=type=bind,from=viz-deps-cache,...
+#         cp -r /app/node_modules .
+#
+# OUTPUT:
+#   /app/node_modules
+#   /app/viz/node_modules
+################################################################################
+
+FROM node:20.19.2 AS viz-deps
+
+WORKDIR /app
+
+# Copy dependency manifests
+COPY package.json package-lock.json ./
+COPY viz/package.json ./viz/
+
+# Install dependencies with npm cache mount for faster rebuilds
+RUN --mount=type=cache,target=/root/.npm \
+  npm ci -w viz

--- a/dockerfiles/viz.Dockerfile
+++ b/dockerfiles/viz.Dockerfile
@@ -1,3 +1,6 @@
+# Import viz dependencies from cache mount
+FROM dust-viz-deps:latest AS viz-deps-cache
+
 FROM node:20.19.2 AS viz
 
 RUN apt-get update && apt-get install -y vim redis-tools postgresql-client htop
@@ -6,7 +9,12 @@ WORKDIR /app
 COPY package.json package-lock.json ./
 COPY viz/package.json ./viz/
 
-RUN npm ci -w viz
+# Use the viz-deps image as a cache mount to get node_modules
+# This way, changes to other packages won't invalidate this layer
+RUN --mount=type=bind,from=viz-deps-cache,source=/app/node_modules,target=/app/node_modules \
+  --mount=type=bind,from=viz-deps-cache,source=/app/viz/node_modules,target=/app/viz/node_modules \
+  cp -r /app/node_modules . && \
+  cp -r /app/viz/node_modules ./viz/
 
 WORKDIR /app/viz
 COPY /viz .

--- a/scripts/build-deps.sh
+++ b/scripts/build-deps.sh
@@ -1,0 +1,206 @@
+#!/bin/bash
+set -e
+
+################################################################################
+# Smart Dependency Builder
+#
+# PURPOSE:
+#   Build dedicated dependency images for each JS package in the monorepo with
+#   content-based caching to prevent unnecessary rebuilds when dependencies
+#   haven't changed.
+#
+# PROBLEM SOLVED:
+#   In a monorepo, all packages share the same package-lock.json. When one
+#   package (e.g., connectors) updates its dependencies, Docker would normally
+#   invalidate the cache for ALL packages (front, viz, etc.) even if their
+#   dependencies didn't change.
+#
+# SOLUTION:
+#   - Create separate dependency images for each package (front, connectors, viz)
+#   - Tag each image with a content-based hash of its dependencies
+#   - Only rebuild when the hash changes (dependencies actually changed)
+#   - Service Dockerfiles mount these images to copy pre-installed node_modules
+#
+# CACHING STRATEGY (3 levels):
+#   1. Hash-based image caching: If image with hash exists, skip build entirely (~2s)
+#   2. Docker layer cache: Reuse layers from previous build when possible (~30s)
+#   3. npm cache mount: Only download changed packages from npm registry (~1-2min)
+#
+# USAGE:
+#   ./scripts/build-deps.sh
+#
+# OUTPUT:
+#   - dust-front-deps:latest and dust-front-deps:<hash>
+#   - dust-connectors-deps:latest and dust-connectors-deps:<hash>
+#   - dust-viz-deps:latest and dust-viz-deps:<hash>
+################################################################################
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+cd "$REPO_ROOT"
+
+################################################################################
+# compute_deps_hash - Calculate content-based hash for a workspace's dependencies
+#
+# ARGUMENTS:
+#   $1: workspace name (e.g., "front", "connectors")
+#   $@: list of packages that contribute to this workspace's dependencies
+#
+# RETURNS:
+#   12-character hash based on package-lock.json + relevant package.json files
+#
+# HOW IT WORKS:
+#   1. Concatenate package-lock.json (monorepo root) with all relevant package.json files
+#   2. Compute MD5 hash of the combined content
+#   3. Take first 12 characters as the image tag
+#
+# WHY THIS WORKS:
+#   - If dependencies haven't changed, hash stays the same → image exists → skip build
+#   - If any dependency changes, hash changes → new image needed → rebuild
+################################################################################
+compute_deps_hash() {
+  local workspace=$1
+  shift
+  local packages=("$@")
+
+  # Combine all relevant package.json files into a temporary file
+  local temp_file=$(mktemp)
+  cat package-lock.json > "$temp_file"
+  for pkg in "${packages[@]}"; do
+    if [ -f "$pkg/package.json" ]; then
+      cat "$pkg/package.json" >> "$temp_file"
+    fi
+  done
+
+  # Compute hash (platform-specific MD5 command)
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    # macOS uses 'md5 -q'
+    local hash=$(md5 -q "$temp_file" | cut -c1-12)
+  else
+    # Linux uses 'md5sum'
+    local hash=$(md5sum "$temp_file" | cut -d' ' -f1 | cut -c1-12)
+  fi
+
+  rm "$temp_file"
+  echo "$hash"
+}
+
+################################################################################
+# build_deps_if_needed - Build dependency image only if it doesn't exist
+#
+# ARGUMENTS:
+#   $1: package name (e.g., "front")
+#   $2: path to Dockerfile (e.g., "dockerfiles/deps/front-deps.Dockerfile")
+#   $@: list of packages this depends on (e.g., "front" "sparkle" "sdks/js")
+#
+# BEHAVIOR:
+#   1. Compute content hash for this package's dependencies
+#   2. Check if image with this hash already exists
+#      - YES → Tag it as :latest and skip build (instant!)
+#      - NO  → Build new image, tag with hash and :latest
+#   3. After building, clean up old hash-tagged images to save disk space
+#
+# OPTIMIZATION:
+#   Uses --cache-from to reuse Docker layers from the previous :latest image.
+#   This speeds up builds when package.json changes but package-lock.json doesn't.
+#
+# CLEANUP:
+#   After a successful build, removes old hash-tagged images that have a different
+#   Image ID than the one just built. This prevents disk bloat while preserving
+#   the current hash-tagged image for caching between CI runs.
+################################################################################
+build_deps_if_needed() {
+  local name=$1
+  local dockerfile=$2
+  shift 2
+  local packages=("$@")
+
+  # Generate content-based hash
+  local hash=$(compute_deps_hash "$name" "${packages[@]}")
+  local image_name="dust-${name}-deps:${hash}"
+  local image_latest="dust-${name}-deps:latest"
+
+  echo "📦 ${name}: hash ${hash}"
+
+  # STEP 1: Check if image with this hash already exists
+  # This is the fastest path - no Docker build needed at all
+  if docker image inspect "${image_name}" > /dev/null 2>&1; then
+    echo "   ✅ Already exists, skipping build"
+    # Ensure :latest points to this hash-tagged image
+    docker tag "${image_name}" "${image_latest}" 2>/dev/null || true
+    return 0
+  fi
+
+  # STEP 2: Image doesn't exist, we need to build it
+  echo "   🔨 Building..."
+  export DOCKER_BUILDKIT=1
+
+  # OPTIMIZATION: Use previous :latest image as cache source
+  # This allows Docker to reuse layers when only package.json changed
+  # but package-lock.json stayed the same (e.g., metadata updates)
+  CACHE_FROM_ARG=""
+  if docker image inspect "${image_latest}" > /dev/null 2>&1; then
+    CACHE_FROM_ARG="--cache-from ${image_latest}"
+    echo "      Using ${image_latest} as build cache"
+  fi
+
+  # Build the image with both hash and latest tags
+  docker build \
+    -f "$dockerfile" \
+    -t "${image_name}" \
+    -t "${image_latest}" \
+    ${CACHE_FROM_ARG} \
+    . > /dev/null 2>&1
+
+  echo "   ✅ Built successfully"
+
+  # STEP 3: Clean up old hash-tagged images to prevent disk bloat
+  # We keep:
+  #   - The image we just built (identified by Image ID)
+  #   - The :latest tag (excluded by grep)
+  # We remove:
+  #   - Old hash-tagged images with different Image IDs
+  #
+  # WHY THIS IS SAFE:
+  #   - The hash-tagged image is what enables caching between CI runs
+  #   - We only remove hashes that are no longer current
+  #   - The current hash is preserved for future cache hits
+  CURRENT_IMAGE_ID=$(docker image inspect "${image_name}" --format '{{.Id}}' 2>/dev/null)
+
+  echo "   🧹 Cleaning up old hash-tagged images..."
+  docker images --filter "reference=dust-${name}-deps" --format "{{.Repository}}:{{.Tag}} {{.ID}}" | \
+    grep -v ":latest " | \
+    grep -v " ${CURRENT_IMAGE_ID#sha256:}" | \
+    awk '{print $1}' | \
+    xargs -r docker rmi 2>/dev/null || true
+}
+
+################################################################################
+# MAIN EXECUTION
+################################################################################
+
+echo "🚀 Smart Dependency Builder"
+echo "============================"
+echo ""
+
+# Build dependency image for front (includes sparkle and sdks/js)
+# These packages form a dependency chain: front depends on sparkle and sdks/js
+build_deps_if_needed "front" "dockerfiles/deps/front-deps.Dockerfile" \
+  "front" "sparkle" "sdks/js"
+
+# Build dependency image for connectors (includes sdks/js)
+# Connectors depends on sdks/js
+build_deps_if_needed "connectors" "dockerfiles/deps/connectors-deps.Dockerfile" \
+  "connectors" "sdks/js"
+
+# Build dependency image for viz (standalone)
+# Viz has no internal dependencies
+build_deps_if_needed "viz" "dockerfiles/deps/viz-deps.Dockerfile" \
+  "viz"
+
+echo ""
+echo "============================"
+echo "✅ All dependency images ready!"
+echo ""
+echo "Images are tagged with content hashes and will only rebuild when dependencies change."


### PR DESCRIPTION
## Description

Front, connectors and viz now reliy on the same package-lock.json.
If a new package is installed in connectors, front will need a full rebuild (reinstalling all dependencies) whereas it doesn't need to.
This PR:
- creates build-dep images for front, connectors and viz (with .npm cache)
- adds a script that checks the hash of the package-lock and package.json to rebuild build-dep images 
- use these images as a cache mount to get node_modules

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
