### PR TITLE
[SPA] Build: use separate cache mounts

### DIFF
--- a/dockerfiles/connectors.Dockerfile
+++ b/dockerfiles/connectors.Dockerfile
@@ -24,7 +24,7 @@ COPY package.json package-lock.json ./
 COPY connectors/package.json ./connectors/
 COPY sdks/js/package.json ./sdks/js/
 
-RUN npm ci -w sdks/js -w connectors
+RUN --mount=type=cache,id=npm-cache,target=/root/.npm npm ci -w sdks/js -w connectors
 
 # Build SDK
 WORKDIR /app/sdks/js

--- a/dockerfiles/front.Dockerfile
+++ b/dockerfiles/front.Dockerfile
@@ -17,7 +17,7 @@ COPY sparkle/package.json ./sparkle/
 COPY front/package.json ./front/
 COPY front-spa/package.json ./front-spa/
 
-RUN npm ci -w sdks/js -w sparkle -w front -w front-spa
+RUN --mount=type=cache,id=npm-cache,target=/root/.npm npm ci -w sdks/js -w sparkle -w front -w front-spa
 
 # Build SDK
 WORKDIR /app/sdks/js

--- a/dockerfiles/prodbox.Dockerfile
+++ b/dockerfiles/prodbox.Dockerfile
@@ -13,8 +13,7 @@ WORKDIR /dust
 COPY . .
 
 # Install dependencies
-RUN npm ci
-
+RUN --mount=type=cache,id=npm-cache,target=/root/.npm npm ci
 
 RUN cd sdks/js && npm run build
 

--- a/dockerfiles/viz.Dockerfile
+++ b/dockerfiles/viz.Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 COPY package.json package-lock.json ./
 COPY viz/package.json ./viz/
 
-RUN npm ci -w viz
+RUN --mount=type=cache,id=npm-cache,target=/root/.npm npm ci -w viz
 
 WORKDIR /app/viz
 COPY /viz .


### PR DESCRIPTION
## Description

Use cache mount for node dependencies.

Each node package now depends on the root package-lock. So everytime `connectors` installs a new package, all the layers after `COPY package.json package-lock.json ./` will be rebuilt in `front.Dockerfile`. 
It is not obvious to prune the lock file for each package without using Nx or Turborepo, which seems overkill for now. 
So front will reinstall its dependencies even if not needed. 

This PR makes intall faster by using cache mount.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
