### PR TITLE
[front] enh: Record api key id & auth method on postUserMessage

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -681,6 +681,13 @@ export async function postUserMessage(
         transaction: t,
       })) ?? -1) + 1;
 
+    // Enrich context with auth data for analytics tracking.
+    const enrichedContext: UserMessageContext = {
+      ...context,
+      apiKeyId: auth.key()?.id ?? null,
+      authMethod: auth.authMethod(),
+    };
+
     // Return the user message without mentions.
     // This way typescript forces us to create the mentions after the user message is created.
     const userMessageWithoutMentions = await createUserMessage(auth, {
@@ -690,7 +697,7 @@ export async function postUserMessage(
         type: "create",
         user: doNotAssociateUser ? null : (user?.toJSON() ?? null),
         rank: nextMessageRank++,
-        context,
+        context: enrichedContext,
         agenticMessageData,
       },
       transaction: t,

--- a/front/lib/api/assistant/conversation/mentions.ts
+++ b/front/lib/api/assistant/conversation/mentions.ts
@@ -565,6 +565,8 @@ export async function createUserMessage(
       userContextLastTriggerRunAt: context.lastTriggerRunAt
         ? new Date(context.lastTriggerRunAt)
         : null,
+      userContextApiKeyId: context.apiKeyId ?? null,
+      userContextAuthMethod: context.authMethod ?? null,
       agenticMessageType,
       agenticOriginMessageId,
       userId: user?.id,

--- a/front/lib/models/agent/conversation.ts
+++ b/front/lib/models/agent/conversation.ts
@@ -283,6 +283,8 @@ export class UserMessageModel extends WorkspaceAwareModel<UserMessageModel> {
   declare agenticOriginMessageId: string | null;
 
   declare userContextLastTriggerRunAt: Date | null;
+  declare userContextApiKeyId: number | null;
+  declare userContextAuthMethod: string | null;
 
   declare userId: ForeignKey<UserModel["id"]> | null;
 
@@ -344,6 +346,14 @@ UserMessageModel.init(
       type: DataTypes.DATE,
       allowNull: true,
       defaultValue: null,
+    },
+    userContextApiKeyId: {
+      type: DataTypes.BIGINT,
+      allowNull: true,
+    },
+    userContextAuthMethod: {
+      type: DataTypes.STRING(50),
+      allowNull: true,
     },
     agenticMessageType: {
       type: DataTypes.STRING(16),

--- a/front/lib/models/agent/conversation.ts
+++ b/front/lib/models/agent/conversation.ts
@@ -6,6 +6,7 @@ import type { AgentStepContentModel } from "@app/lib/models/agent/agent_step_con
 import { TriggerModel } from "@app/lib/models/agent/triggers/triggers";
 import { frontSequelize } from "@app/lib/resources/storage";
 import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
+import { KeyModel } from "@app/lib/resources/storage/models/keys";
 import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
@@ -283,12 +284,13 @@ export class UserMessageModel extends WorkspaceAwareModel<UserMessageModel> {
   declare agenticOriginMessageId: string | null;
 
   declare userContextLastTriggerRunAt: Date | null;
-  declare userContextApiKeyId: number | null;
+  declare userContextApiKeyId: ForeignKey<KeyModel["id"]> | null;
   declare userContextAuthMethod: string | null;
 
   declare userId: ForeignKey<UserModel["id"]> | null;
 
   declare user?: NonAttribute<UserModel>;
+  declare key?: NonAttribute<KeyModel>;
 }
 
 UserMessageModel.init(
@@ -350,6 +352,10 @@ UserMessageModel.init(
     userContextApiKeyId: {
       type: DataTypes.BIGINT,
       allowNull: true,
+      references: {
+        model: KeyModel,
+        key: "id",
+      },
     },
     userContextAuthMethod: {
       type: DataTypes.STRING(50),
@@ -370,6 +376,7 @@ UserMessageModel.init(
     indexes: [
       { fields: ["userContextOrigin"], concurrently: true },
       { fields: ["workspaceId"], concurrently: true },
+      { fields: ["userContextApiKeyId"], concurrently: true },
       {
         // WARNING we use full capital functions and constants as the query where we want this index to be used is in capital letters, and indices are case-sensitive
         // The query https://github.com/dust-tt/dust/blob/6cb11eecb8c8bb549efc5afb25197606d76672b9/front/pages/api/w/%5BwId%5D/workspace-analytics.ts#L67-L126
@@ -401,6 +408,15 @@ UserModel.hasMany(UserMessageModel, {
 });
 UserMessageModel.belongsTo(UserModel, {
   foreignKey: { name: "userId", allowNull: true },
+});
+
+KeyModel.hasMany(UserMessageModel, {
+  foreignKey: { name: "userContextApiKeyId", allowNull: true },
+});
+UserMessageModel.belongsTo(KeyModel, {
+  as: "key",
+  foreignKey: { name: "userContextApiKeyId", allowNull: true },
+  onDelete: "RESTRICT",
 });
 
 export class AgentMessageModel extends WorkspaceAwareModel<AgentMessageModel> {

--- a/front/migrations/20251103_backfill_agent_analytics.ts
+++ b/front/migrations/20251103_backfill_agent_analytics.ts
@@ -208,6 +208,7 @@ async function backfillAgentAnalytics(
               agentMessageRow,
               agentAgentMessageRow,
               userModel: userUserMessageRow.user ?? null,
+              userMessageModel: userUserMessageRow,
               conversationRow,
               contextOrigin: userUserMessageRow.userContextOrigin ?? null,
             });

--- a/front/migrations/db/migration_505.sql
+++ b/front/migrations/db/migration_505.sql
@@ -3,7 +3,11 @@
 -- for analytics purposes, allowing accurate tracking without relying on the current auth context.
 
 ALTER TABLE user_messages
-ADD COLUMN "userContextApiKeyId" BIGINT NULL;
+ADD COLUMN "userContextApiKeyId" BIGINT NULL
+  REFERENCES "keys" ("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 ALTER TABLE user_messages
 ADD COLUMN "userContextAuthMethod" VARCHAR(50) NULL;
+
+CREATE INDEX CONCURRENTLY "user_messages_userContextApiKeyId"
+  ON "user_messages" ("userContextApiKeyId");

--- a/front/migrations/db/migration_505.sql
+++ b/front/migrations/db/migration_505.sql
@@ -1,0 +1,9 @@
+-- Migration: Add API key tracking fields to user_messages table
+-- These fields store the API key ID and auth method at message creation time
+-- for analytics purposes, allowing accurate tracking without relying on the current auth context.
+
+ALTER TABLE user_messages
+ADD COLUMN "userContextApiKeyId" BIGINT NULL;
+
+ALTER TABLE user_messages
+ADD COLUMN "userContextAuthMethod" VARCHAR(50) NULL;

--- a/front/temporal/analytics_queue/activities.ts
+++ b/front/temporal/analytics_queue/activities.ts
@@ -204,17 +204,8 @@ export async function storeAgentAnalytics(
     const keyResource = await KeyResource.fetchByModelId(storedKeyId);
     if (keyResource) {
       apiKeyName = keyResource.name;
-    } else {
-      logger.warn(
-        { storedKeyId },
-        "Could not find key for stored ID, falling back to auth context"
-      );
-      apiKeyName = auth.key()?.name;
     }
-  } else {
-    apiKeyName = auth.key()?.name;
   }
-
   // Build the complete analytics document.
   const document: AgentMessageAnalyticsData = {
     agent_id: agentAgentMessageRow.agentConfigurationId,

--- a/front/temporal/scrub_workspace/activities.ts
+++ b/front/temporal/scrub_workspace/activities.ts
@@ -24,6 +24,7 @@ import {
 import { AgentMemoryResource } from "@app/lib/resources/agent_memory_resource";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import { KeyResource } from "@app/lib/resources/key_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { OnboardingTaskResource } from "@app/lib/resources/onboarding_task_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -120,6 +121,7 @@ export async function scrubWorkspaceData({
     dangerouslyRequestAllGroups: true,
   });
   await deleteAllConversations(auth);
+  await deleteKeys(auth);
   await archiveAssistants(auth);
   await deleteAgentMemories(auth);
   await deleteOnboardingTasks(auth);
@@ -165,6 +167,10 @@ export async function pauseAllTriggers({
       "Failed to disable workspace triggers during scrub"
     );
   }
+}
+
+export async function deleteKeys(auth: Authenticator) {
+  await KeyResource.deleteAllForWorkspace(auth);
 }
 
 export async function deleteAllConversations(auth: Authenticator) {

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -113,6 +113,8 @@ export type UserMessageContext = {
   clientSideMCPServerIds?: string[];
   selectedMCPServerViewIds?: string[];
   selectedSkillIds?: string[];
+  apiKeyId?: number | null;
+  authMethod?: string | null;
 };
 
 export type AgenticMessageData = {


### PR DESCRIPTION
## Description

Record auth method & api key in messages on postUserMessage.
Currently we do not, which means that backfilling agent analytics data overwrite to api key field to undefined.

## Tests

Tested manually

## Risk

Low
Blast radius: agent loop

## Deploy Plan

- run migration 496
- deploy front