### PR TITLE
[front] Rename `AgentBuilderSkillsBlock` into `AgentBuilderCapabilitiesBlock`

### DIFF
--- a/front/components/agent_builder/AgentBuilderLeftPanel.tsx
+++ b/front/components/agent_builder/AgentBuilderLeftPanel.tsx
@@ -12,7 +12,7 @@ import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuild
 import { AgentBuilderSpacesBlock } from "@app/components/agent_builder/AgentBuilderSpacesBlock";
 import { AgentBuilderInstructionsBlock } from "@app/components/agent_builder/instructions/AgentBuilderInstructionsBlock";
 import { AgentBuilderSettingsBlock } from "@app/components/agent_builder/settings/AgentBuilderSettingsBlock";
-import { AgentBuilderSkillsBlock } from "@app/components/agent_builder/skills/AgentBuilderSkillsBlock";
+import { AgentBuilderCapabilitiesBlock } from "@app/components/agent_builder/skills/AgentBuilderCapabilitiesBlock";
 import { AgentBuilderTriggersBlock } from "@app/components/agent_builder/triggers/AgentBuilderTriggersBlock";
 
 interface AgentBuilderLeftPanelProps {
@@ -56,7 +56,7 @@ export function AgentBuilderLeftPanel({
             agentConfigurationId={agentConfigurationId}
           />
           <AgentBuilderSpacesBlock />
-          <AgentBuilderSkillsBlock />
+          <AgentBuilderCapabilitiesBlock />
           <AgentBuilderTriggersBlock
             owner={owner}
             isTriggersLoading={isTriggersLoading}

--- a/front/components/agent_builder/skills/AgentBuilderCapabilitiesBlock.tsx
+++ b/front/components/agent_builder/skills/AgentBuilderCapabilitiesBlock.tsx
@@ -116,7 +116,7 @@ function ActionButtons({
   );
 }
 
-export function AgentBuilderSkillsBlock() {
+export function AgentBuilderCapabilitiesBlock() {
   const sendNotification = useSendNotification();
   const { owner } = useAgentBuilderContext();
 


### PR DESCRIPTION
## Description

- This PR renames the `AgentBuilderSkillsBlock` into `AgentBuilderCapabilitiesBlock`. This name matches what is shown in the UI.
- Priori to shipping skills we already had a component called `AgentBuilderCapabilitiesBlock` that only had the tool (long history here) so the name was taken.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
