### PR TITLE
[front] properly fix share button display 

### DIFF
--- a/front/components/assistant/conversation/interactive_content/frame/ShareFramePopover.tsx
+++ b/front/components/assistant/conversation/interactive_content/frame/ShareFramePopover.tsx
@@ -69,6 +69,7 @@ function FileSharingDropdown({
             label={selectedOption?.label}
             icon={selectedOption?.icon}
             disabled={disabled}
+            className="grid grid-cols-[auto_1fr_auto] truncate"
           />
         </DropdownMenuTrigger>
         <DropdownMenuContent className="w-[var(--radix-dropdown-menu-trigger-width)]">


### PR DESCRIPTION
## Description
This PR is properly fixing https://github.com/dust-tt/dust/pull/20752/changes, if we remove `w-full` it doesn't overflow because

```
The Sparkle Button uses s-box-content, i.e. box-sizing: content-box. With that:
- w-full sets the content width to 100% of the parent.
- Padding and border are added on top of that.
- So the button’s total width is 100% + padding + border, which is wider than the container and causes overflow.
```

TIL

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
