### PR TITLE
[front] enh: reduce max text size for creating file for tool output

### DIFF
--- a/front/lib/actions/action_output_limits.ts
+++ b/front/lib/actions/action_output_limits.ts
@@ -1,7 +1,12 @@
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
 // Size limits for MCP tool outputs
-export const MAX_TEXT_CONTENT_SIZE = 2 * 1024 * 1024; // 2MB.
+
+// Approximate baseline context window size we target:
+// 200k tokens * ~4 characters per token * 2 bytes per character.
+const BASELINE_CONTEXT_WINDOW_SIZE = 2 * 4 * 200 * 1000;
+// We don't want to go over 1/4 of the baseline context window size in one tool result.
+export const MAX_TEXT_CONTENT_SIZE = BASELINE_CONTEXT_WINDOW_SIZE / 4;
 export const MAX_IMAGE_CONTENT_SIZE = 2 * 1024 * 1024; // 2MB.
 export const MAX_RESOURCE_CONTENT_SIZE = 20 * 1024 * 1024; // 20MB.
 


### PR DESCRIPTION
## Description

- When we receive a textual tool output that is too large we upsert it as a file rather than returning it as a tool output.
- This behavior is based on a threshold on the content size.
- This PR reduces this threshold from 1M characters to 200k characters.

## Tests

## Risk

- Medium: this threshold is used for various other things, notably remote MCP servers, so this is a non negligible change in behavior. Taking the principled approach of applying the same limit for the same reasons here.

## Deploy Plan

- Deploy front.
