### PR TITLE
Fix workspace isolation for WorkspaceHasDomain queries

### DIFF
--- a/front/lib/api/poke/plugins/workspaces/manage_authorized_domains.ts
+++ b/front/lib/api/poke/plugins/workspaces/manage_authorized_domains.ts
@@ -8,8 +8,7 @@ import {
 } from "@app/lib/api/workos/organization";
 import { getOrCreateWorkOSOrganization } from "@app/lib/api/workos/organization";
 import type { Authenticator } from "@app/lib/auth";
-import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
-import { WorkspaceHasDomainModel } from "@app/lib/resources/storage/models/workspace_has_domain";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { isDomain } from "@app/lib/utils";
 import type { Result } from "@app/types";
 import { Err, mapToEnumValues, Ok } from "@app/types";
@@ -17,12 +16,12 @@ import { Err, mapToEnumValues, Ok } from "@app/types";
 async function handleAddDomain(
   auth: Authenticator,
   { domain }: { domain: string },
-  existingDomain: WorkspaceHasDomainModel | null
+  existingDomainWorkspace: WorkspaceResource | null
 ): Promise<Result<PluginResponse, Error>> {
   const workspace = auth.getNonNullableWorkspace();
 
-  if (existingDomain) {
-    if (existingDomain.workspaceId === workspace.id) {
+  if (existingDomainWorkspace) {
+    if (existingDomainWorkspace.id === workspace.id) {
       return new Ok({
         display: "text",
         value: `Domain ${domain} is already authorized for this workspace.`,
@@ -30,7 +29,7 @@ async function handleAddDomain(
     }
     return new Err(
       new Error(
-        `This domain is already authorized for workspace ${existingDomain.workspace.sId}.`
+        `This domain is already authorized for workspace ${existingDomainWorkspace.sId}.`
       )
     );
   }
@@ -76,11 +75,11 @@ async function handleAddDomain(
 export async function handleRemoveDomain(
   auth: Authenticator,
   { domain }: { domain: string },
-  existingDomain: WorkspaceHasDomainModel | null
+  existingDomainWorkspace: WorkspaceResource | null
 ): Promise<Result<PluginResponse, Error>> {
   const workspace = auth.getNonNullableWorkspace();
 
-  if (!existingDomain || existingDomain.workspaceId !== workspace.id) {
+  if (!existingDomainWorkspace || existingDomainWorkspace.id !== workspace.id) {
     return new Err(
       new Error(`Domain ${domain} is not authorized for this workspace.`)
     );
@@ -141,21 +140,13 @@ export const addAuthorizedDomain = createPlugin({
     }
 
     // Check if domain exists in any workspace.
-    const existingDomain = await WorkspaceHasDomainModel.findOne({
-      where: { domain },
-      include: [
-        {
-          model: WorkspaceModel,
-          as: "workspace",
-          required: true,
-        },
-      ],
-    });
+    const existingDomainWorkspace =
+      await WorkspaceResource.fetchByDomain(domain);
 
     if (operation[0] === "add") {
-      return handleAddDomain(auth, { domain }, existingDomain);
+      return handleAddDomain(auth, { domain }, existingDomainWorkspace);
     } else {
-      return handleRemoveDomain(auth, { domain }, existingDomain);
+      return handleRemoveDomain(auth, { domain }, existingDomainWorkspace);
     }
   },
 });

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -317,7 +317,7 @@ export async function checkWorkspaceSeatAvailabilityUsingAuth(
 }
 
 export async function evaluateWorkspaceSeatAvailability(
-  workspace: WorkspaceType | WorkspaceModel,
+  workspace: WorkspaceType | WorkspaceModel | WorkspaceResource,
   subscription: SubscriptionType
 ): Promise<boolean> {
   const { maxUsers } = subscription.plan.limits.users;


### PR DESCRIPTION
## Description

Centralizes cross-workspace domain queries in `WorkspaceResource` following the pattern from #19371.

When trying to create a new workspace locally I couldn't because of an error related to workspace isolation. Probably introduced in https://github.com/dust-tt/dust/pull/18799

Adds a private `fetchWorkspaceAndDomainInfo()` helper with three public methods:
- `fetchByDomain()` - returns workspace only
- `fetchByDomainWithInfo()` - returns workspace + domain info
- `isDomainAutoJoinEnabled()` - returns boolean

## Changes
- `lib/resources/workspace_resource.ts`: Added private helper + public methods
- `lib/iam/workspaces.ts`: Uses `fetchByDomainWithInfo`
- `pages/no-workspace.tsx`: Uses `fetchByDomainWithInfo`
- `pages/api/enrichment/company.ts`: Uses `isDomainAutoJoinEnabled`
- `lib/api/poke/plugins/workspaces/manage_authorized_domains.ts`: Uses `fetchByDomain`

## Tests

Locally I created a new workspace and I don't have anymore the error on /login. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 