### PR TITLE
[front] Remove Frames server-level instructions

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1,6 +1,5 @@
 import type { InternalAllowedIconType } from "@app/components/resources/resources_icons";
 import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
-import { INTERACTIVE_CONTENT_INSTRUCTIONS } from "@app/lib/actions/mcp_internal_actions/servers/interactive_content/instructions";
 import { PRODUCTBOARD_SERVER_INSTRUCTIONS } from "@app/lib/actions/mcp_internal_actions/servers/productboard/instructions";
 import { SLIDESHOW_INSTRUCTIONS } from "@app/lib/actions/mcp_internal_actions/servers/slideshow/instructions";
 import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
@@ -474,9 +473,7 @@ export const INTERNAL_MCP_SERVERS = {
       authorization: null,
       icon: "ActionFrameIcon",
       documentationUrl: null,
-      // Will be removed as soon as we add the ability to add skills to global agents.
-      // eslint-disable-next-line dust/no-mcp-server-instructions
-      instructions: INTERACTIVE_CONTENT_INSTRUCTIONS,
+      instructions: null,
     },
   },
   outlook: {

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -161,28 +161,11 @@ function constructToolsSection({
   // whether their server has explicit instructions or is detailed in this specific prompt overview.
   let toolServersPrompt = "";
 
-  const areInstructionsAlreadyIncludedInSkillSection = ({
-    serverName,
-  }: ServerToolsAndInstructions): boolean => {
-    if (serverName !== "interactive_content" && serverName !== "deep_dive") {
-      return false;
-    }
-    return equippedSkills
-      .concat(enabledSkills)
-      .some((skill) => skill.sId === serverName);
-  };
-
   if (serverToolsAndInstructions && serverToolsAndInstructions.length > 0) {
     toolServersPrompt = "\n## AVAILABLE TOOL SERVERS\n";
     toolServersPrompt +=
       "Each server provides a list of tools made available to the agent.\n";
     for (const serverData of serverToolsAndInstructions) {
-      if (areInstructionsAlreadyIncludedInSkillSection(serverData)) {
-        // Prevent interactive_content and deep_dive server instructions
-        // from being duplicated in the prompt if they are already included in the skills section.
-        continue;
-      }
-
       toolServersPrompt += `\n### SERVER NAME: ${serverData.serverName}\n`;
       if (serverData.instructions) {
         toolServersPrompt += `Server instructions: ${serverData.instructions}\n`;

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -117,15 +117,11 @@ function constructToolsSection({
   model,
   agentConfiguration,
   serverToolsAndInstructions,
-  enabledSkills,
-  equippedSkills,
 }: {
   hasAvailableActions: boolean;
   model: ModelConfigurationType;
   agentConfiguration: AgentConfigurationType;
   serverToolsAndInstructions?: ServerToolsAndInstructions[];
-  enabledSkills: (SkillResource & { extendedSkill: SkillResource | null })[];
-  equippedSkills: SkillResource[];
 }): string {
   let toolsSection = "# TOOLS\n";
 
@@ -474,8 +470,6 @@ export function constructPromptMultiActions(
       model,
       agentConfiguration,
       serverToolsAndInstructions,
-      enabledSkills,
-      equippedSkills,
     }),
     constructSkillsSection({
       enabledSkills,

--- a/front/types/shared/utils/string_utils.ts
+++ b/front/types/shared/utils/string_utils.ts
@@ -140,10 +140,6 @@ export function asDisplayToolName(name?: string | null) {
     return "";
   }
 
-  // TODO(skills-GA 2026-01-13): remove this renaming (all 3 below) once we GA.
-  // The tool will be named interactive content, Frames the skill
-  // that wraps these tools with React client-side code generation.
-
   if (name === "interactive_content") {
     return "Create Frames";
   }


### PR DESCRIPTION
## Description

- This PR removes the instructions that were defined on the `interactive_content` MCP server.
- The same instructions are available on the skill.
- This PR also removes the deduplication logic we had to prevent having them in double.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
