### PR TITLE
Allow CORS for poke.dust.tt SPA

### DIFF
--- a/front/config/cors.ts
+++ b/front/config/cors.ts
@@ -9,6 +9,8 @@ const STATIC_ALLOWED_ORIGINS = [
   // Microsoft Power Automate.
   "https://make.powerautomate.com",
   "https://office-addins.dust.tt",
+  // Poke SPA (backoffice).
+  "https://poke.dust.tt",
 ] as const;
 
 const ALLOWED_ORIGIN_PATTERNS = [

--- a/front/middleware.ts
+++ b/front/middleware.ts
@@ -61,10 +61,12 @@ export function middleware(request: NextRequest) {
     });
   }
 
-  // Handle CORS for public API endpoints and poke endpoints (dev only).
+  // Handle CORS for public API endpoints and poke endpoints.
   const isDevelopment = process.env.NODE_ENV === "development";
   const needsCors =
-    url.startsWith("/api/v1") || (isDevelopment && url.startsWith("/api/"));
+    url.startsWith("/api/v1") ||
+    url.startsWith("/api/poke") ||
+    (isDevelopment && url.startsWith("/api/"));
 
   if (needsCors) {
     if (request.method === "OPTIONS") {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR:
- Adds `https://poke.dust.tt` to allowed CORS origins
- Enable CORS for `/api/poke/*` endpoints in production

### Context
Poke is now served as a standalone SPA from `poke.dust.tt` (Cloudflare Pages). It needs to call `/api/poke/*` endpoints on `dust.tt` / `eu.dust.tt`, which requires CORS headers.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
