### PR TITLE
[Projects] Implement isEditor check and grant admin permission to project editors

### DIFF
--- a/front/lib/api/assistant/conversation/mentions.ts
+++ b/front/lib/api/assistant/conversation/mentions.ts
@@ -949,7 +949,6 @@ export async function validateUserMention(
       });
     }
 
-    // TODO(projects): isEditor will check editor permissions once project roles PR is merged.
     const canEdit = space.isEditor(auth);
     if (!canEdit) {
       return new Err({

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -843,12 +843,17 @@ export class SpaceResource extends BaseResource<SpaceModel> {
 
   /**
    * Check if the auth can edit this space.
-   * For projects, only members of space_editors groups are editors.
+   * For projects, workspace admins or members of space_editors groups are editors.
    * For other space types, all members are editors.
    */
   isEditor(auth: Authenticator): boolean {
     if (!this.isProject()) {
       return this.isMember(auth);
+    }
+
+    // Workspace admins can edit any project.
+    if (auth.isAdmin()) {
+      return true;
     }
 
     // For projects, check if user is in a space_editors group.


### PR DESCRIPTION
## Description

Implements proper `isEditor` check for projects and grants `admin` permission to project editors so they can manage project membership.

Changes:
- `isEditor` now checks if user is in a `space_editors` group for projects (non-projects: all members are editors)
- `requestedPermissions` now grants `["read", "write", "admin"]` to `space_editors` groups on projects
- Removed related TODO comments in `space_resource.ts` and `mentions.ts`

Previously, project editors would pass the `isEditor` check but fail downstream when calling `addMembers` because `canAdministrate` required `admin` permission which only workspace admins had.

## Risks

Blast radius: Project permission checks (isEditor, canAdministrate for projects)
Risk: low

## Deploy Plan

- deploy front