### PR TITLE
Add react useEffect skill

### DIFF
--- a/.claude/skills/dust-writing-react-effects/SKILL.md
+++ b/.claude/skills/dust-writing-react-effects/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: writing-react-effects
+description: Writes React components without unnecessary useEffect. Use when creating/reviewing React components, refactoring effects, or when code uses useEffect to transform data or handle events.
+---
+
+# Writing React Effects Skill
+
+Guides writing React components that avoid unnecessary `useEffect` calls.
+
+## Core Principle
+
+> Effects are an escape hatch for synchronizing with **external systems** (network, DOM, third-party widgets). If there's no external system, you don't need an Effect.
+
+## Calculate Derived State During Rendering
+
+If a value can be computed from current props/state, do not store it in state or update it in an effect. Derive it during render to avoid extra renders and state drift. Do not set state in effects solely in response to prop changes; prefer derived values or keyed resets instead.
+
+**Incorrect (redundant state and effect):**
+
+```tsx
+function Form() {
+  const [firstName, setFirstName] = useState('First')
+  const [lastName, setLastName] = useState('Last')
+  const [fullName, setFullName] = useState('')
+
+  useEffect(() => {
+    setFullName(firstName + ' ' + lastName)
+  }, [firstName, lastName])
+
+  return <p>{fullName}</p>
+}
+```
+
+**Correct (derive during render):**
+
+```tsx
+function Form() {
+  const [firstName, setFirstName] = useState('First')
+  const [lastName, setLastName] = useState('Last')
+  const fullName = firstName + ' ' + lastName
+
+  return <p>{fullName}</p>
+}
+```
+
+References: [You Might Not Need an Effect](https://react.dev/learn/you-might-not-need-an-effect)


### PR DESCRIPTION
## Description
This PR is to add agent skill and linter rule to avoid writing unnecessary useEffect. I took it mostly from [this reddit post](https://www.reddit.com/r/reactjs/comments/1pxv4lf/i_made_a_decision_tree_to_stop_myself_from/) and [vercel's react best practices](https://github.com/vercel-labs/agent-skills/blob/main/skills/react-best-practices/rules/rerender-derived-state-no-effect.md). 
We had several [incidents](https://dust4ai.slack.com/archives/C05B529FHV1/p1769008861992879)) in the past because of unstable references in useEffect/useMemo and I had been thinking how we can stop this. We will have React Compiler for SPA, but you still need to provide stable references for an effect dependency. This got me thinking that we should just use less `useEffect` since we often use it wrong and we can avoid many cases 🙃 

Won't be 100% accurate but from what I tested it works well together. I will test more and create some PRs to remove useEffect. 

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
