### PR TITLE
[front] Enhance instructions for enabling Frames skill

### DIFF
--- a/front/lib/resources/skill/global/frames.ts
+++ b/front/lib/resources/skill/global/frames.ts
@@ -10,7 +10,8 @@ export const framesSkill = {
   agentFacingDescription:
     "Create interactive visualizations, charts, dashboards, and presentations as executable React " +
     "components. These visualizations are typically called 'Frames' and can be used in various " +
-    "contexts: daily digests, data analytics, sales reports, and more.",
+    "contexts: daily digests, data analytics, sales reports, and more. Consider using when tsx " +
+    "or React code is shared in the conversation.",
   instructions: INTERACTIVE_CONTENT_INSTRUCTIONS,
   mcpServers: [{ name: "interactive_content" }],
   version: 1,

--- a/front/lib/resources/skill/global/frames.ts
+++ b/front/lib/resources/skill/global/frames.ts
@@ -5,9 +5,12 @@ export const framesSkill = {
   sId: "frames",
   name: "Create Frames",
   userFacingDescription:
-    "Turn insights into interactive dashboards and presentations your team can explore, customize, and share. Living documents that adapt to different stakeholders.",
+    "Turn insights into interactive dashboards and presentations your team can explore, customize," +
+    " and share. Living documents that adapt to different stakeholders.",
   agentFacingDescription:
-    "Create interactive visualizations, charts, dashboards, and presentations as executable React components.",
+    "Create interactive visualizations, charts, dashboards, and presentations as executable React " +
+    "components. These visualizations are typically called 'Frames' and can be used in various " +
+    "contexts: daily digests, data analytics, sales reports, and more.",
   instructions: INTERACTIVE_CONTENT_INSTRUCTIONS,
   mcpServers: [{ name: "interactive_content" }],
   version: 1,

--- a/front/lib/resources/skill/global/frames.ts
+++ b/front/lib/resources/skill/global/frames.ts
@@ -11,7 +11,7 @@ export const framesSkill = {
     "Create interactive visualizations, charts, dashboards, and presentations as executable React " +
     "components. These visualizations are typically called 'Frames' and can be used in various " +
     "contexts: daily digests, data analytics, sales reports, and more. Consider using when tsx " +
-    "or React code is shared in the conversation.",
+    "or React code is shared or available in the conversation.",
   instructions: INTERACTIVE_CONTENT_INSTRUCTIONS,
   mcpServers: [{ name: "interactive_content" }],
   version: 1,


### PR DESCRIPTION
## Description

- This PR updates the instructions of Frames to 1. add some details to them and 2. nudge the model towards enabling when tsx or React code is available.
- Ultimately we want to move away from users pasting their tsx code in agent instructions or retrieved from a data source and pass them as a template via a customized skill, but there are agents that rely on this and that do not trigger as reliably as before.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
