### PR TITLE
[front] Bump LLM even timeout from 3 min to 5 min

### DIFF
--- a/front/temporal/agent_loop/lib/get_output_from_llm.ts
+++ b/front/temporal/agent_loop/lib/get_output_from_llm.ts
@@ -15,7 +15,7 @@ const LLM_HEARTBEAT_INTERVAL_MS = 10_000;
 // Log heartbeat status periodically to track long-waiting LLM calls.
 const HEARTBEAT_LOG_INTERVAL = 6; // Every minute (6 * 10s)
 // Timeout for waiting on a single LLM event (first or subsequent).
-const LLM_EVENT_TIMEOUT_MINUTES = 3;
+const LLM_EVENT_TIMEOUT_MINUTES = 5;
 const LLM_EVENT_TIMEOUT_MS = LLM_EVENT_TIMEOUT_MINUTES * 60 * 1000;
 
 class LLMStreamTimeoutError extends Error {


### PR DESCRIPTION
## Description

- This PR bumps the timeout between two consecutive LLM events from 3 min to 5 min.
- Seeing some cases where we hit this limit consistently ([example](https://dust.tt/poke/h8UXzX9fSZ/conversation/04iHBTVDbr)) while generating inputs for a tool call.
- Temporary change to see how this would improve the situation.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
