### PR TITLE
[front] Fix link to Temporal workflows in Poke conversation

### DIFF
--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -386,6 +386,9 @@ const config = {
       "TEMPORAL_CONNECTORS_NAMESPACE"
     );
   },
+  getTemporalAgentNamespace: () => {
+    return EnvironmentConfig.getOptionalEnvVariable("TEMPORAL_AGENT_NAMESPACE");
+  },
   // Northflank sandbox.
   getNorthflankApiToken: () => {
     return EnvironmentConfig.getOptionalEnvVariable("NORTHFLANK_API_TOKEN");

--- a/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/config.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/config.ts
@@ -64,7 +64,7 @@ async function handler(
       const conversationDataSource =
         await DataSourceResource.fetchByConversation(auth, cRes.value);
 
-      const temporalWorkspace = config.getTemporalConnectorsNamespace() ?? "";
+      const temporalWorkspace = config.getTemporalAgentNamespace() ?? "";
       return res.status(200).json({
         conversationDataSourceId: conversationDataSource?.sId ?? null,
         langfuseUiBaseUrl: config.getLangfuseUiBaseUrl() ?? null,


### PR DESCRIPTION
## Description

- This PR fixes the link to the Temporal workflows for a conversation in poke.
- The namespace was the one for connectors instead of the agent loop.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
