### PR TITLE
Add region picker support for poke SPA

### DIFF
--- a/front-spa/src/poke/PokeApp.tsx
+++ b/front-spa/src/poke/PokeApp.tsx
@@ -7,6 +7,7 @@ import {
 } from "react-router-dom";
 
 import RootLayout from "@dust-tt/front/components/app/RootLayout";
+import { PokeRegionProvider } from "@dust-tt/front/components/poke/PokeRegionContext";
 import { AppPage } from "@dust-tt/front/components/poke/pages/AppPage";
 import { AssistantDetailsPage } from "@dust-tt/front/components/poke/pages/AssistantDetailsPage";
 import { ConnectorRedirectPage } from "@dust-tt/front/components/poke/pages/ConnectorRedirectPage";
@@ -103,7 +104,9 @@ const router = createBrowserRouter(
 export default function PokeApp() {
   return (
     <RootLayout>
-      <RouterProvider router={router} />
+      <PokeRegionProvider>
+        <RouterProvider router={router} />
+      </PokeRegionProvider>
     </RootLayout>
   );
 }

--- a/front/components/poke/PokeRegionContext.tsx
+++ b/front/components/poke/PokeRegionContext.tsx
@@ -1,0 +1,101 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import { useSWRConfig } from "swr";
+
+import type { RegionType } from "@app/lib/api/regions/config";
+import { isRegionType } from "@app/lib/api/regions/config";
+import { setBaseUrlResolver } from "@app/lib/egress/client";
+import { usePokeRegion as usePokeRegionSWR } from "@app/lib/swr/poke";
+
+// Poke allows manual region switching via a dropdown. The selected region is persisted
+// in localStorage so it survives page refreshes. This overrides the default region
+// returned by the API, allowing admins to query data from either region.
+const STORAGE_KEY = "poke-region-override";
+
+function getStoredRegion(): RegionType | null {
+  const stored = localStorage.getItem(STORAGE_KEY);
+
+  return stored && isRegionType(stored) ? stored : null;
+}
+
+function setStoredRegion(region: RegionType | null): void {
+  if (region) {
+    localStorage.setItem(STORAGE_KEY, region);
+  } else {
+    localStorage.removeItem(STORAGE_KEY);
+  }
+}
+
+interface PokeRegionContextValue {
+  currentRegion: RegionType | null;
+  setRegion: (region: RegionType) => void;
+  isLoading: boolean;
+}
+
+const PokeRegionContext = createContext<PokeRegionContextValue | null>(null);
+
+export function PokeRegionProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const { mutate } = useSWRConfig();
+  const { regionData, isRegionLoading } = usePokeRegionSWR();
+  const [override, setOverride] = useState<RegionType | null>(getStoredRegion);
+
+  const regionUrls = regionData?.regionUrls ?? null;
+  const currentRegion = override ?? regionData?.region ?? null;
+
+  // Set up the base URL resolver for clientFetch.
+  useEffect(() => {
+    setBaseUrlResolver(() => {
+      if (override && regionUrls?.[override]) {
+        return regionUrls[override];
+      }
+      return import.meta.env?.VITE_DUST_CLIENT_FACING_URL;
+    });
+
+    return () => setBaseUrlResolver(null);
+  }, [override, regionUrls]);
+
+  const setRegion = useCallback(
+    (region: RegionType) => {
+      setStoredRegion(region);
+      setOverride(region);
+      void mutate(() => true, undefined, { revalidate: true });
+    },
+    [mutate]
+  );
+
+  const value = useMemo(
+    () => ({ currentRegion, setRegion, isLoading: isRegionLoading }),
+    [currentRegion, setRegion, isRegionLoading]
+  );
+
+  return (
+    <PokeRegionContext.Provider value={value}>
+      {children}
+    </PokeRegionContext.Provider>
+  );
+}
+
+export function usePokeRegionContext(): PokeRegionContextValue {
+  const context = useContext(PokeRegionContext);
+  if (!context) {
+    throw new Error(
+      "usePokeRegionContext must be used within a PokeRegionProvider"
+    );
+  }
+
+  return context;
+}
+
+export function usePokeRegionContextSafe(): PokeRegionContextValue | null {
+  return useContext(PokeRegionContext);
+}

--- a/front/components/poke/PokeRegionDropdown.tsx
+++ b/front/components/poke/PokeRegionDropdown.tsx
@@ -6,30 +6,49 @@ import {
   DropdownMenuTrigger,
 } from "@dust-tt/sparkle";
 
+import { usePokeRegionContextSafe } from "@app/components/poke/PokeRegionContext";
 import type { RegionType } from "@app/lib/api/regions/config";
 import { SUPPORTED_REGIONS } from "@app/lib/api/regions/config";
 import { getRegionDisplay } from "@app/lib/poke/regions";
 import { isDevelopment } from "@app/types";
 
 interface PokeRegionDropdownProps {
-  currentRegion: RegionType;
+  currentRegion?: RegionType;
   regionUrls?: Record<RegionType, string>;
 }
 
 export function PokeRegionDropdown({
-  currentRegion,
+  currentRegion: propRegion,
   regionUrls,
 }: PokeRegionDropdownProps) {
+  // Use safe context hook to avoid errors in Next.js mode.
+  const regionContext = usePokeRegionContextSafe();
+
+  // Use context if available (SPA mode), otherwise use prop (Next.js mode).
+  const currentRegion = regionContext?.currentRegion ?? propRegion;
+
   const handleRegionChange = (region: RegionType) => {
     if (region === currentRegion) {
       return;
     }
+
+    // SPA mode: use context to switch region without page reload.
+    if (regionContext) {
+      regionContext.setRegion(region);
+      return;
+    }
+
+    // Next.js mode: redirect to the other region's URL.
     if (regionUrls) {
       const regionUrl = regionUrls[region];
       // eslint-disable-next-line react-hooks/immutability
       window.location.href = regionUrl + "/poke";
     }
   };
+
+  if (!currentRegion) {
+    return null;
+  }
 
   return (
     <DropdownMenu>

--- a/front/lib/egress/client.ts
+++ b/front/lib/egress/client.ts
@@ -1,24 +1,29 @@
-// Vite environment variables type declaration
 declare global {
   interface ImportMeta {
     env?: {
       VITE_DUST_CLIENT_FACING_URL?: string;
-      VITE_BASE_PATH?: string;
     };
   }
 }
 
-// Get the API base URL from environment variables.
-// In Vite SPA: uses VITE_DUST_CLIENT_FACING_URL
-// In Next.js: uses relative URLs
+// Pluggable base URL resolver.
+let baseUrlResolver: (() => string | undefined) | null = null;
+
+export function setBaseUrlResolver(
+  fn: (() => string | undefined) | null
+): void {
+  baseUrlResolver = fn;
+}
+
+function getSpaBaseUrl(): string | undefined {
+  return typeof import.meta !== "undefined"
+    ? import.meta.env?.VITE_DUST_CLIENT_FACING_URL
+    : undefined;
+}
+
 function getApiBaseUrl(): string | undefined {
-  // Check for Vite env var first (SPA mode)
-  if (
-    typeof import.meta !== "undefined" &&
-    import.meta.env?.VITE_DUST_CLIENT_FACING_URL
-  ) {
-    return import.meta.env.VITE_DUST_CLIENT_FACING_URL;
-  }
+  // Use custom resolver if set, otherwise fall back to SPA build-time URL.
+  return baseUrlResolver ? baseUrlResolver() : getSpaBaseUrl();
 }
 
 // Client-side fetch helper. This is a simple alias for the global fetch, used to satisfy
@@ -30,13 +35,10 @@ export function clientFetch(
 ): Promise<Response> {
   const baseUrl = getApiBaseUrl();
 
-  // Only prepend base URL for relative paths (starting with /)
+  // Only prepend base URL for relative paths (starting with /).
   if (baseUrl && typeof input === "string" && input.startsWith("/")) {
     input = `${baseUrl}${input}`;
-    init = {
-      ...init,
-      credentials: "include",
-    };
+    init = { ...init, credentials: "include" };
   }
 
   // eslint-disable-next-line no-restricted-globals

--- a/front/pages/api/poke/region.ts
+++ b/front/pages/api/poke/region.ts
@@ -19,7 +19,6 @@ async function handler(
   session: SessionWithUser
 ) {
   const auth = await Authenticator.fromSuperUserSession(session, null);
-
   if (!auth.isDustSuperUser()) {
     return apiError(req, res, {
       status_code: 404,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR:
- Adds runtime region switching for the poke SPA without page reload
- Poke admins can now switch between EU and US regions via the dropdown, and API calls automatically target the selected region

### Changes

**`front/lib/egress/client.ts`**
- Add pluggable `setBaseUrlResolver()` for app-specific base URL logic
- Keep `clientFetch` generic with no poke-specific code

**`front/components/poke/PokeRegionContext.tsx`** (new)
- Context for managing region state in poke SPA
- Persists region override in localStorage
- Sets up the base URL resolver for `clientFetch`
- Clears SWR cache on region change to refetch from new backend

**`front/components/poke/PokeRegionDropdown.tsx`**
- Use context in SPA mode (no page reload)
- Fall back to redirect in Next.js mode (existing behavior)

**`front-spa/src/poke/PokeApp.tsx`**
- Wrap app with `PokeRegionProvider`

## How it works
1. User selects region in dropdown
2. Region stored in localStorage + context state updated
3. `clientFetch` resolver returns the selected region's URL
4. SWR cache cleared → all data refetched from new region

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
