### PR TITLE
[spa] Migrate onboarding pages to thin SSR pattern

### DIFF
--- a/front/lib/auth/appServerSideProps.ts
+++ b/front/lib/auth/appServerSideProps.ts
@@ -1,7 +1,10 @@
 import type { ReactElement } from "react";
 
 import type { AuthContextValue } from "@app/lib/auth/AuthContext";
-import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
+import {
+  withDefaultUserAuthPaywallWhitelisted,
+  withDefaultUserAuthRequirements,
+} from "@app/lib/iam/session";
 
 // Type for page components with a getLayout function.
 export type AppPageWithLayout<P = object> = React.FC<P> & {
@@ -61,3 +64,41 @@ export const appGetServerSidePropsForAdmin =
       },
     };
   });
+
+export const appGetServerSidePropsPaywallWhitelisted =
+  withDefaultUserAuthPaywallWhitelisted<AuthContextValue>(
+    async (_context, auth) => {
+      return {
+        props: {
+          workspace: auth.getNonNullableWorkspace(),
+          subscription: auth.getNonNullableSubscription(),
+          user: auth.getNonNullableUser().toJSON(),
+          isAdmin: auth.isAdmin(),
+          isBuilder: auth.isBuilder(),
+          isSuperUser: false,
+        },
+      };
+    }
+  );
+
+export const appGetServerSidePropsPaywallWhitelistedForAdmin =
+  withDefaultUserAuthPaywallWhitelisted<AuthContextValue>(
+    async (_context, auth) => {
+      if (!auth.isAdmin()) {
+        return {
+          notFound: true,
+        };
+      }
+
+      return {
+        props: {
+          workspace: auth.getNonNullableWorkspace(),
+          subscription: auth.getNonNullableSubscription(),
+          user: auth.getNonNullableUser().toJSON(),
+          isAdmin: auth.isAdmin(),
+          isBuilder: auth.isBuilder(),
+          isSuperUser: false,
+        },
+      };
+    }
+  );

--- a/front/lib/swr/workspaces.ts
+++ b/front/lib/swr/workspaces.ts
@@ -13,8 +13,11 @@ import type { GetSeatAvailabilityResponseBody } from "@app/pages/api/w/[wId]/sea
 import type { GetWorkspaceSeatsCountResponseBody } from "@app/pages/api/w/[wId]/seats/count";
 import type { GetSubscriptionsResponseBody } from "@app/pages/api/w/[wId]/subscriptions";
 import type { GetSubscriptionPricingResponseBody } from "@app/pages/api/w/[wId]/subscriptions/pricing";
+import type { GetSubscriptionStatusResponseBody } from "@app/pages/api/w/[wId]/subscriptions/status";
 import type { GetSubscriptionTrialInfoResponseBody } from "@app/pages/api/w/[wId]/subscriptions/trial-info";
 import type { GetWorkspaceVerifiedDomainsResponseBody } from "@app/pages/api/w/[wId]/verified-domains";
+import type { GetVerifyResponseBody } from "@app/pages/api/w/[wId]/verify";
+import type { GetWelcomeResponseBody } from "@app/pages/api/w/[wId]/welcome";
 import type { GetWorkspaceAnalyticsResponse } from "@app/pages/api/w/[wId]/workspace-analytics";
 import type { LightWorkspaceType, WhitelistableFeature } from "@app/types";
 
@@ -344,5 +347,59 @@ export function useWorkspaceAuthContext({
     isBuilder: data?.isBuilder ?? false,
     isAuthContextLoading: !error && !data && !disabled,
     isAuthContextError: error,
+  };
+}
+
+export function useSubscriptionStatus({
+  workspaceId,
+}: {
+  workspaceId: string;
+}) {
+  const statusFetcher: Fetcher<GetSubscriptionStatusResponseBody> = fetcher;
+
+  const { data, error } = useSWRWithDefaults(
+    `/api/w/${workspaceId}/subscriptions/status`,
+    statusFetcher
+  );
+
+  return {
+    shouldRedirect: data?.shouldRedirect ?? false,
+    redirectUrl: data?.redirectUrl ?? null,
+    isSubscriptionStatusLoading: !error && !data,
+    isSubscriptionStatusError: error,
+  };
+}
+
+export function useWelcomeData({ workspaceId }: { workspaceId: string }) {
+  const welcomeFetcher: Fetcher<GetWelcomeResponseBody> = fetcher;
+
+  const { data, error } = useSWRWithDefaults(
+    `/api/w/${workspaceId}/welcome`,
+    welcomeFetcher
+  );
+
+  return {
+    welcomeData: data ?? null,
+    isFirstAdmin: data?.isFirstAdmin ?? false,
+    emailProvider: data?.emailProvider ?? "other",
+    isWelcomeDataLoading: !error && !data,
+    isWelcomeDataError: error,
+  };
+}
+
+export function useVerifyData({ workspaceId }: { workspaceId: string }) {
+  const verifyFetcher: Fetcher<GetVerifyResponseBody> = fetcher;
+
+  const { data, error } = useSWRWithDefaults(
+    `/api/w/${workspaceId}/verify`,
+    verifyFetcher
+  );
+
+  return {
+    verifyData: data ?? null,
+    isEligibleForTrial: data?.isEligibleForTrial ?? false,
+    initialCountryCode: data?.initialCountryCode ?? "US",
+    isVerifyDataLoading: !error && !data,
+    isVerifyDataError: error,
   };
 }

--- a/front/pages/api/w/[wId]/subscriptions/status.ts
+++ b/front/pages/api/w/[wId]/subscriptions/status.ts
@@ -1,0 +1,73 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { getMessageUsageCount } from "@app/lib/api/assistant/rate_limits";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { isFreeTrialPhonePlan } from "@app/lib/plans/plan_codes";
+import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+
+export type GetSubscriptionStatusResponseBody = {
+  shouldRedirect: boolean;
+  redirectUrl: string | null;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<GetSubscriptionStatusResponseBody | void>
+  >,
+  auth: Authenticator
+): Promise<void> {
+  if (req.method !== "GET") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "The method passed is not supported, GET is expected.",
+      },
+    });
+  }
+
+  const owner = auth.getNonNullableWorkspace();
+
+  // Only admins can be redirected to trial-ended page
+  if (!auth.isAdmin()) {
+    return res.status(200).json({ shouldRedirect: false, redirectUrl: null });
+  }
+
+  const subscription = auth.subscription();
+  if (subscription && isFreeTrialPhonePlan(subscription.plan.code)) {
+    // Active trial - check if messages are exhausted
+    try {
+      const { count, limit } = await getMessageUsageCount(auth);
+      if (limit !== -1 && count >= limit) {
+        return res.status(200).json({
+          shouldRedirect: true,
+          redirectUrl: `/w/${owner.sId}/trial-ended`,
+        });
+      }
+    } catch {
+      // If we can't check message usage, don't redirect
+    }
+  } else {
+    // No active subscription or not a phone trial - check if last subscription was an ended phone trial
+    const lastSubscription =
+      await SubscriptionResource.fetchLastByWorkspace(owner);
+    if (
+      lastSubscription &&
+      isFreeTrialPhonePlan(lastSubscription.getPlan().code) &&
+      lastSubscription.toJSON().status === "ended"
+    ) {
+      return res.status(200).json({
+        shouldRedirect: true,
+        redirectUrl: `/w/${owner.sId}/trial-ended`,
+      });
+    }
+  }
+
+  return res.status(200).json({ shouldRedirect: false, redirectUrl: null });
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/verify.ts
+++ b/front/pages/api/w/[wId]/verify.ts
@@ -27,7 +27,8 @@ async function detectCountryFromIP(req: IncomingMessage): Promise<Country> {
     if (!ip) {
       return "US";
     }
-    return (await resolveCountryCode(ip)) as Country;
+    const countryCode = await resolveCountryCode(ip);
+    return countryCode as Country;
   } catch (error) {
     logger.error({ error }, "Error detecting country from IP");
     return "US";

--- a/front/pages/api/w/[wId]/verify.ts
+++ b/front/pages/api/w/[wId]/verify.ts
@@ -1,0 +1,71 @@
+import type { IncomingMessage } from "http";
+import type { NextApiRequest, NextApiResponse } from "next";
+import type { Country } from "react-phone-number-input";
+
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { resolveCountryCode } from "@app/lib/geo/country-detection";
+import { isWorkspaceEligibleForTrial } from "@app/lib/plans/trial/index";
+import logger from "@app/logger/logger";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+import { isString } from "@app/types";
+
+export type GetVerifyResponseBody = {
+  isEligibleForTrial: boolean;
+  initialCountryCode: Country;
+};
+
+async function detectCountryFromIP(req: IncomingMessage): Promise<Country> {
+  try {
+    // Detect country from IP
+    const { "x-forwarded-for": forwarded } = req.headers;
+    const ip = isString(forwarded)
+      ? forwarded.split(",")[0].trim()
+      : req.socket.remoteAddress;
+
+    if (!ip) {
+      return "US";
+    }
+    return (await resolveCountryCode(ip)) as Country;
+  } catch (error) {
+    logger.error({ error }, "Error detecting country from IP");
+    return "US";
+  }
+}
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetVerifyResponseBody | void>>,
+  auth: Authenticator
+): Promise<void> {
+  if (req.method !== "GET") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "The method passed is not supported, GET is expected.",
+      },
+    });
+  }
+
+  if (!auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "Only admins can access this endpoint.",
+      },
+    });
+  }
+
+  const isEligibleForTrial = await isWorkspaceEligibleForTrial(auth);
+  const initialCountryCode = await detectCountryFromIP(req);
+
+  return res.status(200).json({
+    isEligibleForTrial,
+    initialCountryCode,
+  });
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/verify.ts
+++ b/front/pages/api/w/[wId]/verify.ts
@@ -1,6 +1,7 @@
 import type { IncomingMessage } from "http";
 import type { NextApiRequest, NextApiResponse } from "next";
 import type { Country } from "react-phone-number-input";
+import { isSupportedCountry } from "react-phone-number-input";
 
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
@@ -10,6 +11,8 @@ import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
 import { isString } from "@app/types";
+
+const DEFAULT_COUNTRY: Country = "US";
 
 export type GetVerifyResponseBody = {
   isEligibleForTrial: boolean;
@@ -25,13 +28,16 @@ async function detectCountryFromIP(req: IncomingMessage): Promise<Country> {
       : req.socket.remoteAddress;
 
     if (!ip) {
-      return "US";
+      return DEFAULT_COUNTRY;
     }
     const countryCode = await resolveCountryCode(ip);
-    return countryCode as Country;
+    if (isSupportedCountry(countryCode)) {
+      return countryCode;
+    }
+    return DEFAULT_COUNTRY;
   } catch (error) {
     logger.error({ error }, "Error detecting country from IP");
-    return "US";
+    return DEFAULT_COUNTRY;
   }
 }
 

--- a/front/pages/api/w/[wId]/welcome.ts
+++ b/front/pages/api/w/[wId]/welcome.ts
@@ -1,0 +1,54 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import type { EmailProviderType } from "@app/lib/utils/email_provider_detection";
+import { detectEmailProvider } from "@app/lib/utils/email_provider_detection";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+
+export type GetWelcomeResponseBody = {
+  isFirstAdmin: boolean;
+  emailProvider: EmailProviderType;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetWelcomeResponseBody | void>>,
+  auth: Authenticator
+): Promise<void> {
+  if (req.method !== "GET") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "The method passed is not supported, GET is expected.",
+      },
+    });
+  }
+
+  const owner = auth.getNonNullableWorkspace();
+  const user = auth.getNonNullableUser();
+  const isAdmin = auth.isAdmin();
+
+  // Check if this is the first admin (only one member in the workspace).
+  const { total: membersTotal } =
+    await MembershipResource.getMembershipsForWorkspace({
+      workspace: owner,
+    });
+  const isFirstAdmin = isAdmin && membersTotal === 1;
+
+  const userJson = user.toJSON();
+  const emailProvider = await detectEmailProvider(
+    userJson.email,
+    `user-${userJson.sId}`
+  );
+
+  return res.status(200).json({
+    isFirstAdmin,
+    emailProvider,
+  });
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/w/[wId]/subscribe.tsx
+++ b/front/pages/w/[wId]/subscribe.tsx
@@ -1,112 +1,47 @@
-import { BarHeader, Button, LockIcon, Page } from "@dust-tt/sparkle";
+import { BarHeader, Button, LockIcon, Page, Spinner } from "@dust-tt/sparkle";
 import { CreditCardIcon } from "@heroicons/react/20/solid";
-import type { InferGetServerSidePropsType } from "next";
-import { useRouter } from "next/router";
-import React from "react";
+import type { ReactElement } from "react";
+import React, { useEffect } from "react";
+import useSWR from "swr";
 
 import { ProPlansTable } from "@app/components/plans/ProPlansTable";
+import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
 import { UserMenu } from "@app/components/UserMenu";
 import WorkspacePicker from "@app/components/WorkspacePicker";
 import { useSendNotification } from "@app/hooks/useNotification";
-import { getMessageUsageCount } from "@app/lib/api/assistant/rate_limits";
+import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
+import { appGetServerSidePropsPaywallWhitelisted } from "@app/lib/auth/appServerSideProps";
+import type { AuthContextValue } from "@app/lib/auth/AuthContext";
+import { useAuth } from "@app/lib/auth/AuthContext";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { clientFetch } from "@app/lib/egress/client";
-import { withDefaultUserAuthPaywallWhitelisted } from "@app/lib/iam/session";
 import { isFreeTrialPhonePlan, isOldFreePlan } from "@app/lib/plans/plan_codes";
-import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
+import { useAppRouter } from "@app/lib/platform";
+import { fetcher } from "@app/lib/swr/swr";
 import { useUser } from "@app/lib/swr/user";
 import { useWorkspaceSubscriptions } from "@app/lib/swr/workspaces";
 import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
-import type { BillingPeriod, WorkspaceType } from "@app/types";
+import type { GetSubscriptionStatusResponseBody } from "@app/pages/api/w/[wId]/subscriptions/status";
+import type { BillingPeriod } from "@app/types";
 
-export const getServerSideProps = withDefaultUserAuthPaywallWhitelisted<{
-  owner: WorkspaceType;
-  isAdmin: boolean;
-}>(async (context, auth) => {
-  const owner = auth.workspace();
-  if (!owner || !auth.isUser()) {
-    return {
-      notFound: true,
-    };
-  }
+export const getServerSideProps = appGetServerSidePropsPaywallWhitelisted;
 
-  // Check if current subscription is a phone trial - only redirect admins to trial-ended
-  // Non-admins should stay on /subscribe to see the "Workspace locked" UI
-  if (auth.isAdmin()) {
-    const subscription = auth.subscription();
-    if (subscription && isFreeTrialPhonePlan(subscription.plan.code)) {
-      // Active trial - check if messages are exhausted
-      try {
-        const { count, limit } = await getMessageUsageCount(auth);
-        if (limit !== -1 && count >= limit) {
-          return {
-            redirect: {
-              destination: `/w/${owner.sId}/trial-ended`,
-              permanent: false,
-            },
-          };
-        }
-      } catch {
-        // If we can't check message usage, don't redirect - let them see the subscribe page
-      }
-    } else {
-      // No active subscription or not a phone trial - check if last subscription was an ended phone trial
-      const lastSubscription =
-        await SubscriptionResource.fetchLastByWorkspace(owner);
-      if (
-        lastSubscription &&
-        isFreeTrialPhonePlan(lastSubscription.getPlan().code) &&
-        lastSubscription.toJSON().status === "ended"
-      ) {
-        return {
-          redirect: {
-            destination: `/w/${owner.sId}/trial-ended`,
-            permanent: false,
-          },
-        };
-      }
-    }
-  }
-
-  return {
-    props: {
-      owner,
-      isAdmin: auth.isAdmin(),
-    },
-  };
-});
-
-export default function Subscribe({
-  owner,
-  isAdmin,
-}: InferGetServerSidePropsType<typeof getServerSideProps>) {
-  const router = useRouter();
+function Subscribe() {
+  const { workspace, isAdmin } = useAuth();
+  const router = useAppRouter();
   const sendNotification = useSendNotification();
   const { user } = useUser();
 
   const { subscriptions } = useWorkspaceSubscriptions({
-    owner,
+    owner: workspace,
   });
-
-  // We treat user as being in free trial if they don't have any non free subs,
-  // regardless of whether they're active or not.
-  const isInFreePhoneTrial = !subscriptions.some(
-    (sub) => !isFreeTrialPhonePlan(sub.plan.code)
-  );
 
   const [billingPeriod, setBillingPeriod] =
     React.useState<BillingPeriod>("monthly");
 
-  // If you had another subscription before, you will not get the free trial again: we use this to show the correct message.
-  // Current plan is either FREE_NO_PLAN or FREE_TEST_PLAN if you're on this paywall.
-  // FREE_NO_PLAN is not on the database, checking it comes down to having at least 1 subscription.
-  const noPreviousSubscription =
-    subscriptions.length === 0 ||
-    (subscriptions.length === 1 && isOldFreePlan(subscriptions[0].plan.code)); // FREE_TEST_PLAN did not pay, they should be asked to start instead of resume
-
   const { submit: handleSubscribePlan } = useSubmitFunction(
     async (billingPeriod) => {
-      const res = await clientFetch(`/api/w/${owner.sId}/subscriptions`, {
+      const res = await clientFetch(`/api/w/${workspace.sId}/subscriptions`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -138,6 +73,40 @@ export default function Subscribe({
     }
   );
 
+  // Check if we need to redirect to trial-ended page.
+  const { data: statusData } = useSWR<GetSubscriptionStatusResponseBody>(
+    `/api/w/${workspace.sId}/subscriptions/status`,
+    fetcher
+  );
+
+  useEffect(() => {
+    if (statusData?.shouldRedirect && statusData.redirectUrl) {
+      void router.replace(statusData.redirectUrl);
+    }
+  }, [statusData, router]);
+
+  // Show loading while checking redirect.
+  if (!statusData) {
+    return (
+      <div className="flex h-screen items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  // We treat user as being in free trial if they don't have any non free subs,
+  // regardless of whether they're active or not.
+  const isInFreePhoneTrial = !subscriptions.some(
+    (sub) => !isFreeTrialPhonePlan(sub.plan.code)
+  );
+
+  // If you had another subscription before, you will not get the free trial again: we use this to show the correct message.
+  // Current plan is either FREE_NO_PLAN or FREE_TEST_PLAN if you're on this paywall.
+  // FREE_NO_PLAN is not on the database, checking it comes down to having at least 1 subscription.
+  const noPreviousSubscription =
+    subscriptions.length === 0 ||
+    (subscriptions.length === 1 && isOldFreePlan(subscriptions[0].plan.code)); // FREE_TEST_PLAN did not pay, they should be asked to start instead of resume
+
   return (
     <>
       <BarHeader
@@ -147,11 +116,11 @@ export default function Subscribe({
           <>
             <div className="flex flex-row items-center">
               {user?.organizations && user.organizations.length > 1 && (
-                <WorkspacePicker user={user} workspace={owner} />
+                <WorkspacePicker user={user} workspace={workspace} />
               )}
               <div>
                 {user && (
-                  <UserMenu user={user} owner={owner} subscription={null} />
+                  <UserMenu user={user} owner={workspace} subscription={null} />
                 )}
               </div>
             </div>
@@ -268,7 +237,7 @@ export default function Subscribe({
               </Page.Vertical>
               <Page.Horizontal sizing="grow">
                 <ProPlansTable
-                  owner={owner}
+                  owner={workspace}
                   size="xs"
                   display="subscribe"
                   setBillingPeriod={setBillingPeriod}
@@ -291,7 +260,7 @@ export default function Subscribe({
               </Page.Vertical>
               <Page.Vertical sizing="grow">
                 <ProPlansTable
-                  owner={owner}
+                  owner={workspace}
                   size="xs"
                   display="subscribe"
                   setBillingPeriod={setBillingPeriod}
@@ -304,3 +273,13 @@ export default function Subscribe({
     </>
   );
 }
+
+const SubscribePage = Subscribe as AppPageWithLayout;
+
+SubscribePage.getLayout = (page: ReactElement, pageProps: AuthContextValue) => {
+  return (
+    <AppAuthContextLayout authContext={pageProps}>{page}</AppAuthContextLayout>
+  );
+};
+
+export default SubscribePage;

--- a/front/pages/w/[wId]/verify.tsx
+++ b/front/pages/w/[wId]/verify.tsx
@@ -1,80 +1,60 @@
-import { Button, DustLogoSquare, Page } from "@dust-tt/sparkle";
-import type { IncomingMessage } from "http";
-import type { InferGetServerSidePropsType } from "next";
-import { useRouter } from "next/router";
+import { Button, DustLogoSquare, Page, Spinner } from "@dust-tt/sparkle";
+import type { ReactElement } from "react";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import type { Country } from "react-phone-number-input";
+import useSWR from "swr";
 
+import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
 import { ThemeProvider } from "@app/components/sparkle/ThemeContext";
 import { PhoneNumberCodeInput } from "@app/components/trial/PhoneNumberCodeInput";
 import { PhoneNumberInput } from "@app/components/trial/PhoneNumberInput";
+import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
+import { appGetServerSidePropsPaywallWhitelistedForAdmin } from "@app/lib/auth/appServerSideProps";
+import type { AuthContextValue } from "@app/lib/auth/AuthContext";
+import { useAuth } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
-import { resolveCountryCode } from "@app/lib/geo/country-detection";
-import { withDefaultUserAuthPaywallWhitelisted } from "@app/lib/iam/session";
-import { isWorkspaceEligibleForTrial } from "@app/lib/plans/trial/index";
 import {
   CODE_LENGTH,
   isValidPhoneNumber,
   maskPhoneNumber,
   RESEND_COOLDOWN_SECONDS,
 } from "@app/lib/plans/trial/phone";
-import logger from "@app/logger/logger";
-import type { WorkspaceType } from "@app/types";
-import { isString } from "@app/types";
+import { useAppRouter } from "@app/lib/platform";
+import { fetcher } from "@app/lib/swr/swr";
+import type { GetVerifyResponseBody } from "@app/pages/api/w/[wId]/verify";
 
 type Step = "phone" | "code";
 
-async function detectCountryFromIP(req: IncomingMessage): Promise<Country> {
-  try {
-    // Detect country from IP
-    const { "x-forwarded-for": forwarded } = req.headers;
-    const ip = isString(forwarded)
-      ? forwarded.split(",")[0].trim()
-      : req.socket.remoteAddress;
+export const getServerSideProps =
+  appGetServerSidePropsPaywallWhitelistedForAdmin;
 
-    if (!ip) {
-      return "US";
-    }
-    return (await resolveCountryCode(ip)) as Country;
-  } catch (error) {
-    logger.error({ error }, "Error detecting country from IP");
-    return "US";
-  }
-}
+function Verify() {
+  const { workspace } = useAuth();
+  const router = useAppRouter();
 
-export const getServerSideProps = withDefaultUserAuthPaywallWhitelisted<{
-  owner: WorkspaceType;
-  initialCountryCode: Country;
-}>(async (context, auth) => {
-  const owner = auth.workspace();
-  if (!owner || !auth.isAdmin()) {
-    return { notFound: true };
-  }
+  // Fetch verify data (isEligibleForTrial, initialCountryCode) from API.
+  const { data: verifyData } = useSWR<GetVerifyResponseBody>(
+    `/api/w/${workspace.sId}/verify`,
+    fetcher
+  );
 
-  const isValidForTrial = await isWorkspaceEligibleForTrial(auth);
-  if (!isValidForTrial) {
-    return { notFound: true };
-  }
-
-  const initialCountryCode = await detectCountryFromIP(context.req);
-  return { props: { owner, initialCountryCode } };
-});
-
-export default function Verify({
-  owner,
-  initialCountryCode,
-}: InferGetServerSidePropsType<typeof getServerSideProps>) {
-  const router = useRouter();
   const [step, setStep] = useState<Step>("phone");
   const [isLoading, setIsLoading] = useState(false);
 
   const [phoneNumber, setPhoneNumber] = useState("");
-  const [countryCode, setCountryCode] = useState<Country>(initialCountryCode);
+  const [countryCode, setCountryCode] = useState<Country>("US");
+  const [countryInitialized, setCountryInitialized] = useState(false);
   const [phoneError, setPhoneError] = useState<string | null>(null);
 
   const [code, setCode] = useState<string[]>(Array(CODE_LENGTH).fill(""));
   const [resendCooldown, setResendCooldown] = useState(0);
   const inputRefs = useRef<(HTMLInputElement | null)[]>([]);
+
+  // Initialize countryCode once data is loaded.
+  if (verifyData && !countryInitialized) {
+    setCountryCode(verifyData.initialCountryCode);
+    setCountryInitialized(true);
+  }
 
   useEffect(() => {
     // Note: This is a temporary solution, needs to be replaced when we properly validate the phone.
@@ -112,11 +92,14 @@ export default function Verify({
     const e164Phone = phoneNumber;
     let response: Response;
     try {
-      response = await clientFetch(`/api/w/${owner.sId}/verification/start`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ phoneNumber: e164Phone }),
-      });
+      response = await clientFetch(
+        `/api/w/${workspace.sId}/verification/start`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ phoneNumber: e164Phone }),
+        }
+      );
     } catch {
       setPhoneError("Unexpected error. Please try again.");
       return;
@@ -159,7 +142,7 @@ export default function Verify({
       const e164Phone = phoneNumber;
 
       const verifyResponse = await clientFetch(
-        `/api/w/${owner.sId}/verification/validate`,
+        `/api/w/${workspace.sId}/verification/validate`,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -174,7 +157,7 @@ export default function Verify({
       }
 
       const trialResponse = await clientFetch(
-        `/api/w/${owner.sId}/trial/start`,
+        `/api/w/${workspace.sId}/trial/start`,
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -187,7 +170,7 @@ export default function Verify({
         return;
       }
 
-      void router.push(`/w/${owner.sId}/welcome`);
+      void router.push(`/w/${workspace.sId}/welcome`);
     } catch {
       setPhoneError("Network error. Please try again.");
     } finally {
@@ -259,6 +242,25 @@ export default function Verify({
     setCode(Array(CODE_LENGTH).fill(""));
     setPhoneError(null);
   };
+
+  // Show loading while fetching verify data.
+  if (!verifyData) {
+    return (
+      <div className="flex h-screen items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  // Redirect to subscribe if not eligible for trial.
+  if (!verifyData.isEligibleForTrial) {
+    void router.replace(`/w/${workspace.sId}/subscribe`);
+    return (
+      <div className="flex h-screen items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
 
   if (step === "code") {
     return (
@@ -449,3 +451,13 @@ function CodeVerificationStep({
     </Page>
   );
 }
+
+const VerifyPage = Verify as AppPageWithLayout;
+
+VerifyPage.getLayout = (page: ReactElement, pageProps: AuthContextValue) => {
+  return (
+    <AppAuthContextLayout authContext={pageProps}>{page}</AppAuthContextLayout>
+  );
+};
+
+export default VerifyPage;


### PR DESCRIPTION
## Summary
- Migrate 5 onboarding/paywall pages from heavy SSR to thin SSR with client-side data fetching
- Add thin SSR helpers for paywall-whitelisted pages
- Create API endpoints for server-side logic that was previously in `getServerSideProps`

## Pages migrated
- `pages/w/[wId]/subscribe.tsx`
- `pages/w/[wId]/trial.tsx`
- `pages/w/[wId]/trial-ended.tsx`
- `pages/w/[wId]/welcome.tsx`
- `pages/w/[wId]/verify.tsx`

## New API endpoints
- `GET /api/w/[wId]/subscriptions/status` - returns redirect info for subscription status
- `GET /api/w/[wId]/welcome` - returns `isFirstAdmin` and `emailProvider`
- `GET /api/w/[wId]/verify` - returns `isEligibleForTrial` and `initialCountryCode`

## New helpers
- `appGetServerSidePropsPaywallWhitelisted` - thin SSR for paywall-whitelisted pages
- `appGetServerSidePropsPaywallWhitelistedForAdmin` - same but restricted to admins

## Test plan
- [ ] Navigate to `/w/{wId}/subscribe` - should load and show subscription options
- [ ] Navigate to `/w/{wId}/trial` - should load for admins
- [ ] Navigate to `/w/{wId}/trial-ended` - should load for admins with ended trial
- [ ] Navigate to `/w/{wId}/welcome` - should load onboarding flow
- [ ] Navigate to `/w/{wId}/verify` - should load phone verification for eligible workspaces, redirect to subscribe otherwise
