### PR TITLE
Remove assert-never export from types/index.ts

### DIFF
--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -38,12 +38,12 @@ import {
 } from "@app/temporal/labs/transcripts/client";
 import { REGISTERED_CHECKS } from "@app/temporal/production_checks/activities";
 import {
-  assertNever,
   ConnectorsAPI,
   isRoleType,
   removeNulls,
   SUPPORTED_MODEL_CONFIGS,
 } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 // `cli` takes an object type and a command as first two arguments and then a list of arguments.
 const workspace = async (command: string, args: parseArgs.ParsedArgs) => {

--- a/front/components/ViewFolderAPIModal.tsx
+++ b/front/components/ViewFolderAPIModal.tsx
@@ -16,7 +16,7 @@ import { useState } from "react";
 
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import type { DataSourceType, SpaceType, WorkspaceType } from "@app/types";
-import { assertNever } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 const CodeEditor = dynamic(
   () => import("@uiw/react-textarea-code-editor").then((mod) => mod.default),

--- a/front/components/agent_builder/capabilities/capabilities_sheet/utils.tsx
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/utils.tsx
@@ -33,7 +33,7 @@ import type { ConfigurationState } from "@app/components/agent_builder/skills/ty
 import { isConfigurationState } from "@app/components/agent_builder/skills/types";
 import { getAvatar } from "@app/lib/actions/mcp_icons";
 import { getSkillIcon } from "@app/lib/skill";
-import { assertNever } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export function useCapabilitiesPageAndFooter({
   sheetState,

--- a/front/components/agent_builder/shared/tables.ts
+++ b/front/components/agent_builder/shared/tables.ts
@@ -11,7 +11,8 @@ import type {
   LightContentNode,
   LightWorkspaceType,
 } from "@app/types";
-import { assertNever, normalizeError } from "@app/types";
+import { normalizeError } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export function getTableIdForContentNode(
   dataSource: DataSourceType,

--- a/front/components/agent_builder/triggers/schedule/ScheduleEditionScheduler.tsx
+++ b/front/components/agent_builder/triggers/schedule/ScheduleEditionScheduler.tsx
@@ -15,7 +15,7 @@ import type { TriggerViewsSheetFormValues } from "@app/components/agent_builder/
 import { useDebounceWithAbort } from "@app/hooks/useDebounce";
 import { useTextAsCronRule } from "@app/lib/swr/agent_triggers";
 import type { LightWorkspaceType } from "@app/types";
-import { assertNever } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 const MIN_DESCRIPTION_LENGTH = 10;
 

--- a/front/components/app/ReachedLimitPopup.tsx
+++ b/front/components/app/ReachedLimitPopup.tsx
@@ -15,7 +15,7 @@ import { isFreeTrialPhonePlan } from "@app/lib/plans/plan_codes";
 import type { AppRouter } from "@app/lib/platform";
 import { useAppRouter } from "@app/lib/platform";
 import type { SubscriptionType, WorkspaceType } from "@app/types";
-import { assertNever } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export type WorkspaceLimit =
   | "cant_invite_no_seats_available"

--- a/front/components/app/ViewAppAPIModal.tsx
+++ b/front/components/app/ViewAppAPIModal.tsx
@@ -18,7 +18,7 @@ import { useState } from "react";
 
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import type { AppType, RunConfig, RunType, WorkspaceType } from "@app/types";
-import { assertNever } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 const CodeEditor = dynamic(
   () => import("@uiw/react-textarea-code-editor").then((mod) => mod.default),

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -84,11 +84,11 @@ import type {
   WorkspaceType,
 } from "@app/types";
 import {
-  assertNever,
   isGlobalAgentId,
   isInteractiveContentFileContentType,
   isSupportedImageContentType,
 } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 interface AgentMessageProps {
   conversationId: string;

--- a/front/components/assistant/conversation/ConversationSidePanelContext.tsx
+++ b/front/components/assistant/conversation/ConversationSidePanelContext.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, useEffect } from "react";
 import type { ImperativePanelHandle } from "react-resizable-panels";
 
 import { useHashParam } from "@app/hooks/useHashParams";
-import { assertNever } from "@app/types";
 import type { ConversationSidePanelType } from "@app/types/conversation_side_panel";
 import {
   AGENT_ACTIONS_SIDE_PANEL_TYPE,
@@ -10,6 +9,7 @@ import {
   SIDE_PANEL_HASH_PARAM,
   SIDE_PANEL_TYPE_HASH_PARAM,
 } from "@app/types/conversation_side_panel";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 type OpenPanelParams =
   | {

--- a/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
+++ b/front/components/assistant/conversation/actions/VisualizationActionIframe.tsx
@@ -31,7 +31,8 @@ import type {
   VisualizationRPCCommand,
   VisualizationRPCRequest,
 } from "@app/types";
-import { assertNever, isVisualizationRPCRequest } from "@app/types";
+import { isVisualizationRPCRequest } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 interface BaseVisualization {
   complete: boolean;

--- a/front/components/assistant/conversation/attachment/utils.tsx
+++ b/front/components/assistant/conversation/attachment/utils.tsx
@@ -40,10 +40,10 @@ import type {
   ContentNodeType,
 } from "@app/types";
 import {
-  assertNever,
   isContentNodeContentFragment,
   isFileContentFragment,
 } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export const isTextualContentType = (
   attachmentCitation: AttachmentCitation

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -55,13 +55,13 @@ import type {
   WorkspaceType,
 } from "@app/types";
 import {
-  assertNever,
   getSupportedFileExtensions,
   isBuilder,
   normalizeError,
   toRichAgentMentionType,
 } from "@app/types";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export const INPUT_BAR_ACTIONS = [
   "capabilities",

--- a/front/components/assistant/details/tabs/AgentInfoTab/AssistantSkillsToolsSection.tsx
+++ b/front/components/assistant/details/tabs/AgentInfoTab/AssistantSkillsToolsSection.tsx
@@ -24,7 +24,8 @@ import { useMCPServers, useMCPServerViews } from "@app/lib/swr/mcp_servers";
 import { useAgentConfigurationSkills } from "@app/lib/swr/skills";
 import { useSpaces } from "@app/lib/swr/spaces";
 import type { AgentConfigurationType, LightWorkspaceType } from "@app/types";
-import { asDisplayName, assertNever, removeNulls } from "@app/types";
+import { asDisplayName, removeNulls } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 interface AssistantToolsSectionProps {
   agentConfiguration: AgentConfigurationType;

--- a/front/components/data_source/ConnectorPermissionsModal.tsx
+++ b/front/components/data_source/ConnectorPermissionsModal.tsx
@@ -84,7 +84,8 @@ import type {
   UpdateConnectorRequestBody,
   WorkspaceType,
 } from "@app/types";
-import { assertNever, isOAuthProvider } from "@app/types";
+import { isOAuthProvider } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 const getUseResourceHook =
   (owner: LightWorkspaceType, dataSource: DataSourceType) =>

--- a/front/components/data_source/DataSourceSyncChip.tsx
+++ b/front/components/data_source/DataSourceSyncChip.tsx
@@ -4,7 +4,8 @@ import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
 import { DATASOURCE_QUOTA_PER_SEAT } from "@app/lib/plans/usage/types";
 import { timeAgoFrom } from "@app/lib/utils";
 import type { ConnectorType } from "@app/types";
-import { assertNever, fileSizeToHumanReadable } from "@app/types";
+import { fileSizeToHumanReadable } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 interface ConnectorSyncingChipProps {
   activeSeats: number;

--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -62,11 +62,11 @@ import type {
   SpaceType,
 } from "@app/types";
 import {
-  assertNever,
   defaultSelectionConfiguration,
   MIN_SEARCH_QUERY_SIZE,
   removeNulls,
 } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 const ONLY_ONE_SPACE_PER_SELECTION = true;
 const ITEMS_PER_PAGE = 50;

--- a/front/components/data_source_view/context/DataSourceBuilderContext.tsx
+++ b/front/components/data_source_view/context/DataSourceBuilderContext.tsx
@@ -61,7 +61,7 @@ import type {
   TagsFilter,
   TagsFilterMode,
 } from "@app/types";
-import { assertNever } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 type StateType = {
   /**

--- a/front/components/data_source_view/context/PageContext.tsx
+++ b/front/components/data_source_view/context/PageContext.tsx
@@ -1,7 +1,7 @@
 import { createContext, useContext, useMemo, useReducer } from "react";
 
 import type { ConfigurationPagePageId } from "@app/components/agent_builder/types";
-import { assertNever } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 type PageState = {
   currentPageId: ConfigurationPagePageId;

--- a/front/components/data_source_view/context/utils.ts
+++ b/front/components/data_source_view/context/utils.ts
@@ -16,7 +16,7 @@ import type {
   DataSourceViewType,
   SpaceType,
 } from "@app/types";
-import { assertNever } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export function pathToString(path: string[]): string {
   return path.join("/");

--- a/front/components/navigation/Navigation.tsx
+++ b/front/components/navigation/Navigation.tsx
@@ -21,7 +21,7 @@ import { SidebarContext } from "@app/components/sparkle/SidebarContext";
 import { useUser } from "@app/lib/swr/user";
 import { classNames } from "@app/lib/utils";
 import type { SubscriptionType, WorkspaceType } from "@app/types";
-import { assertNever } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 interface NavigationProps {
   hideSidebar: boolean;

--- a/front/components/poke/pages/ConversationPage.tsx
+++ b/front/components/poke/pages/ConversationPage.tsx
@@ -36,7 +36,8 @@ import type {
   PokeAgentMessageType,
   UserMessageType,
 } from "@app/types";
-import { assertNever, isFileContentFragment } from "@app/types";
+import { isFileContentFragment } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 interface UserMessageViewProps {
   message: UserMessageType;

--- a/front/components/poke/plans/form.tsx
+++ b/front/components/poke/plans/form.tsx
@@ -14,11 +14,8 @@ import { useCallback, useState } from "react";
 
 import { classNames } from "@app/lib/utils";
 import type { PlanType } from "@app/types";
-import {
-  assertNever,
-  isMaxMessagesTimeframeType,
-  MAX_MESSAGE_TIMEFRAMES,
-} from "@app/types";
+import { isMaxMessagesTimeframeType, MAX_MESSAGE_TIMEFRAMES } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export type EditingPlanType = {
   code: string;

--- a/front/components/spaces/AddConnectionMenu.tsx
+++ b/front/components/spaces/AddConnectionMenu.tsx
@@ -51,13 +51,8 @@ import type {
   SpaceType,
   WorkspaceType,
 } from "@app/types";
-import {
-  assertNever,
-  Err,
-  isOAuthProvider,
-  Ok,
-  setupOAuthConnection,
-} from "@app/types";
+import { Err, isOAuthProvider, Ok, setupOAuthConnection } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export type DataSourceIntegration = {
   connectorProvider: ConnectorProvider;

--- a/front/components/spaces/SpaceSideBarMenu.tsx
+++ b/front/components/spaces/SpaceSideBarMenu.tsx
@@ -60,7 +60,8 @@ import type {
   SpaceType,
   WhitelistableFeature,
 } from "@app/types";
-import { assertNever, DATA_SOURCE_VIEW_CATEGORIES } from "@app/types";
+import { DATA_SOURCE_VIEW_CATEGORIES } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 interface SpaceSideBarMenuProps {
   owner: LightWorkspaceType;

--- a/front/components/workspace/BuyCreditDialog.tsx
+++ b/front/components/workspace/BuyCreditDialog.tsx
@@ -23,8 +23,8 @@ import { useCallback, useMemo, useState } from "react";
 import { getPriceAsString } from "@app/lib/client/subscription";
 import type { CreditPurchaseLimits } from "@app/lib/credits/limits";
 import { usePurchaseCredits } from "@app/lib/swr/credits";
-import { assertNever } from "@app/types";
 import { CURRENCY_SYMBOLS, isSupportedCurrency } from "@app/types/currency";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { StripePricingData } from "@app/types/stripe/pricing";
 
 type PurchaseState = "idle" | "processing" | "success" | "redirect" | "error";

--- a/front/components/workspace/DirectorySync.tsx
+++ b/front/components/workspace/DirectorySync.tsx
@@ -31,7 +31,7 @@ import {
 } from "@app/lib/swr/workos";
 import type { WorkOSConnectionSyncStatus } from "@app/lib/types/workos";
 import type { LightWorkspaceType, PlanType, WorkspaceType } from "@app/types";
-import { assertNever } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 import { GroupsList } from "../groups/GroupsList";
 import { WorkspaceSection } from "./WorkspaceSection";

--- a/front/hooks/useAgentMessageStream.ts
+++ b/front/hooks/useAgentMessageStream.ts
@@ -17,8 +17,8 @@ import type {
   LightAgentMessageWithActionsType,
   LightWorkspaceType,
 } from "@app/types";
-import { assertNever } from "@app/types";
 import type { AgentMCPActionWithOutputType } from "@app/types/actions";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 // Throttle the update of the message to avoid excessive re-renders.
 const updateMessageThrottled = _.throttle(

--- a/front/hooks/useAgentMessageStreamLegacy.ts
+++ b/front/hooks/useAgentMessageStreamLegacy.ts
@@ -11,11 +11,12 @@ import type {
   LightWorkspaceType,
   ModelId,
 } from "@app/types";
-import { assertNever, isLightAgentMessageWithActionsType } from "@app/types";
+import { isLightAgentMessageWithActionsType } from "@app/types";
 import type {
   AgentMCPActionType,
   AgentMCPActionWithOutputType,
 } from "@app/types/actions";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 type AgentStateClassification =
   | "placeholder"

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -31,11 +31,9 @@ import type {
   TimeFrame,
   ToolErrorEvent,
 } from "@app/types";
-import {
-  assertNever,
-  isPersonalAuthenticationRequiredErrorContent,
-} from "@app/types";
+import { isPersonalAuthenticationRequiredErrorContent } from "@app/types";
 import type { AgentMCPActionWithOutputType } from "@app/types/actions";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export type ActionApprovalStateType =
   | "approved"

--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -43,13 +43,13 @@ import type {
   SupportedFileContentType,
 } from "@app/types";
 import {
-  assertNever,
   extensionsForContentType,
   isSupportedFileContentType,
   removeNulls,
   stripNullBytes,
   toWellFormed,
 } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 /**
  * Recursively sanitizes all string values in an object by removing null bytes and lone surrogates.

--- a/front/lib/actions/mcp_internal_actions/input_configuration.ts
+++ b/front/lib/actions/mcp_internal_actions/input_configuration.ts
@@ -33,7 +33,8 @@ import {
   setValueAtPath,
 } from "@app/lib/utils/json_schemas";
 import type { WorkspaceType } from "@app/types";
-import { assertNever, isString, removeNulls } from "@app/types";
+import { isString, removeNulls } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 function getDataSourceURI(config: DataSourceConfiguration): string {
   const { workspaceId, sId, dataSourceViewId, filter } = config;

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -72,7 +72,7 @@ import { default as valtownServer } from "@app/lib/api/actions/servers/val_town"
 import { default as webSearchBrowseServer } from "@app/lib/api/actions/servers/web_search_browse";
 import { default as zendeskServer } from "@app/lib/api/actions/servers/zendesk";
 import type { Authenticator } from "@app/lib/auth";
-import { assertNever } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 /**
  * Check if we are in advanced search mode,

--- a/front/lib/actions/mcp_internal_actions/tools/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/utils.ts
@@ -28,7 +28,8 @@ import type {
   DataSourceViewType,
   Result,
 } from "@app/types";
-import { assertNever, Err, Ok, removeNulls } from "@app/types";
+import { Err, Ok, removeNulls } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 // Type to represent data source configuration with resolved data source model
 export type ResolvedDataSourceConfiguration = DataSourceConfiguration & {

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -40,7 +40,8 @@ import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_conne
 import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
 import logger from "@app/logger/logger";
 import type { MCPOAuthUseCase, Result } from "@app/types";
-import { assertNever, Err, normalizeError, Ok } from "@app/types";
+import { Err, normalizeError, Ok } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 const DEFAULT_MCP_CLIENT_CONNECT_TIMEOUT_MS = 25_000;
 

--- a/front/lib/actions/tool_status.ts
+++ b/front/lib/actions/tool_status.ts
@@ -3,7 +3,8 @@ import type { MCPToolConfigurationType } from "@app/lib/actions/mcp";
 import { isServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
 import type { Authenticator } from "@app/lib/auth";
 import type { AgentMessageType } from "@app/types";
-import { assertNever, isNumberOrBoolean, isString } from "@app/types";
+import { isNumberOrBoolean, isString } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export interface ToolInputContext {
   agentId: string;

--- a/front/lib/api/actions/servers/file_generation/helpers.ts
+++ b/front/lib/api/actions/servers/file_generation/helpers.ts
@@ -4,7 +4,7 @@ import {
   OUTPUT_FORMATS,
 } from "@app/lib/api/actions/servers/file_generation/metadata";
 import type { SupportedFileContentType } from "@app/types";
-import { assertNever } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export function isValidOutputType(
   extension: string

--- a/front/lib/api/actions/servers/query_tables_v2/helpers.ts
+++ b/front/lib/api/actions/servers/query_tables_v2/helpers.ts
@@ -20,8 +20,9 @@ import type { Authenticator } from "@app/lib/auth";
 import type { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import logger from "@app/logger/logger";
 import type { ConnectorProvider } from "@app/types";
-import { assertNever, Err, Ok } from "@app/types";
+import { Err, Ok } from "@app/types";
 import { CoreAPI } from "@app/types/core/core_api";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 const TABLES_QUERY_SECTION_FILE_MIN_COLUMN_LENGTH = 500;
 

--- a/front/lib/api/agent_data_sources.ts
+++ b/front/lib/api/agent_data_sources.ts
@@ -21,7 +21,8 @@ import type {
   ModelId,
   Result,
 } from "@app/types";
-import { assertNever, CONNECTOR_PROVIDERS, Err, Ok } from "@app/types";
+import { CONNECTOR_PROVIDERS, Err, Ok } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 // To use in case of heavy db load emergency with these usages queries
 // If it is a problem, let's add caching

--- a/front/lib/api/assistant/agent_message_content_parser.ts
+++ b/front/lib/api/assistant/agent_message_content_parser.ts
@@ -13,11 +13,11 @@ import {
   TOGETHERAI_DEEPSEEK_R1_MODEL_ID,
   TOGETHERAI_DEEPSEEK_V3_MODEL_ID,
 } from "@app/types";
-import { assertNever } from "@app/types";
 import {
   CHAIN_OF_THOUGHT_DELIMITERS_CONFIGURATION,
   DEEPSEEK_CHAIN_OF_THOUGHT_DELIMITERS_CONFIGURATION,
 } from "@app/types/assistant/chain_of_thought_meta_prompt";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 type AgentMessageTokenClassification = GenerationTokensEvent["classification"];
 

--- a/front/lib/api/assistant/configuration/views.ts
+++ b/front/lib/api/assistant/configuration/views.ts
@@ -23,7 +23,7 @@ import type {
   WorkspaceType,
 } from "@app/types";
 import { compareAgentsForSort } from "@app/types";
-import { assertNever } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 const sortStrategies: Record<SortStrategyType, SortStrategy> = {
   alphabetical: {

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -82,7 +82,6 @@ import type {
   UserMessageType,
 } from "@app/types";
 import {
-  assertNever,
   ConversationError,
   Err,
   isAgentMention,
@@ -97,6 +96,7 @@ import {
   toMentionType,
 } from "@app/types";
 import { isAgentMessageType } from "@app/types/assistant/conversation";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 // Rate limit for programmatic usage: 1 message per this amount of dollars per minute.
 const PROGRAMMATIC_RATE_LIMIT_DOLLARS_PER_MESSAGE = 3;

--- a/front/lib/api/assistant/conversation/attachments.ts
+++ b/front/lib/api/assistant/conversation/attachments.ts
@@ -19,12 +19,12 @@ import type {
   SupportedFileContentType,
 } from "@app/types";
 import {
-  assertNever,
   DATA_SOURCE_NODE_ID,
   isContentNodeContentFragment,
   isExpiredContentFragment,
   isFileContentFragment,
 } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export type BaseConversationAttachmentType = {
   title: string;

--- a/front/lib/api/assistant/conversation/mentions.ts
+++ b/front/lib/api/assistant/conversation/mentions.ts
@@ -58,7 +58,6 @@ import type {
   WorkspaceType,
 } from "@app/types";
 import {
-  assertNever,
   Err,
   isAgentMention,
   isAgentMessageType,
@@ -70,6 +69,7 @@ import {
   removeNulls,
   toMentionType,
 } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 import { getConversation } from "./fetch";
 

--- a/front/lib/api/assistant/conversation_rendering/index.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.ts
@@ -12,13 +12,13 @@ import type {
   Result,
 } from "@app/types";
 import {
-  assertNever,
   Err,
   isContentFragmentMessageTypeModel,
   isImageContent,
   isTextContent,
   Ok,
 } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 import type { InteractionWithTokens, MessageWithTokens } from "./pruning";
 import {

--- a/front/lib/api/assistant/conversation_rendering/message_rendering.ts
+++ b/front/lib/api/assistant/conversation_rendering/message_rendering.ts
@@ -19,12 +19,12 @@ import type {
   ModelMessageTypeMultiActions,
 } from "@app/types";
 import {
-  assertNever,
   isAgentMessageType,
   isContentFragmentType,
   isUserMessageType,
 } from "@app/types";
 import type { AgentTextContentType } from "@app/types/assistant/agent_message_content";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 /**
  * Renders agent message steps into model messages

--- a/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
@@ -29,7 +29,6 @@ import type {
   WorkspaceType,
 } from "@app/types";
 import {
-  assertNever,
   CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG,
   CLAUDE_4_5_SONNET_DEFAULT_MODEL_CONFIG,
   GEMINI_2_5_FLASH_MODEL_CONFIG,
@@ -41,6 +40,7 @@ import {
   MAX_STEPS_USE_PER_RUN_LIMIT,
 } from "@app/types";
 import { DUST_AVATAR_URL } from "@app/types/assistant/avatar";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 const MAX_CONCURRENT_SUB_AGENT_TASKS = 6;
 

--- a/front/lib/api/assistant/global_agents/global_agent_metadata.ts
+++ b/front/lib/api/assistant/global_agents/global_agent_metadata.ts
@@ -3,7 +3,6 @@ import {
   DEEP_DIVE_NAME,
 } from "@app/lib/api/assistant/global_agents/configurations/dust/consts";
 import {
-  assertNever,
   CLAUDE_3_5_SONNET_DEFAULT_MODEL_CONFIG,
   CLAUDE_3_7_SONNET_DEFAULT_MODEL_CONFIG,
   CLAUDE_3_HAIKU_DEFAULT_MODEL_CONFIG,
@@ -26,6 +25,7 @@ import {
   O3_MODEL_CONFIG,
 } from "@app/types";
 import { DUST_AVATAR_URL } from "@app/types/assistant/avatar";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 type AgentMetadata = {
   sId: string;

--- a/front/lib/api/assistant/streaming/events.ts
+++ b/front/lib/api/assistant/streaming/events.ts
@@ -16,7 +16,7 @@ import type {
   UserMessageNewEvent,
   UserMessageTypeWithContentFragments,
 } from "@app/types";
-import { assertNever } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 /**
  * Generic event publication interface.

--- a/front/lib/api/assistant/suggestions/index.ts
+++ b/front/lib/api/assistant/suggestions/index.ts
@@ -12,7 +12,8 @@ import type {
   Result,
   WorkspaceType,
 } from "@app/types";
-import { assertNever, Err, getSmallWhitelistedModel } from "@app/types";
+import { Err, getSmallWhitelistedModel } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 function getModelForSuggestionType(
   owner: WorkspaceType,

--- a/front/lib/api/content_nodes.ts
+++ b/front/lib/api/content_nodes.ts
@@ -10,7 +10,7 @@ import type {
   CoreAPIContentNode,
   DataSourceViewType,
 } from "@app/types";
-import { assertNever } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export const NON_EXPANDABLE_NODES_MIME_TYPES = [
   INTERNAL_MIME_TYPES.GITHUB.DISCUSSIONS,

--- a/front/lib/api/data_source_view.ts
+++ b/front/lib/api/data_source_view.ts
@@ -20,7 +20,8 @@ import type {
   PatchDataSourceViewType,
   Result,
 } from "@app/types";
-import { assertNever, CoreAPI, Err, Ok } from "@app/types";
+import { CoreAPI, Err, Ok } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 const DEFAULT_PAGINATION_LIMIT = 1000;
 const CORE_MAX_PAGE_SIZE = 1000;

--- a/front/lib/api/data_sources.ts
+++ b/front/lib/api/data_sources.ts
@@ -55,7 +55,6 @@ import type {
   WorkspaceType,
 } from "@app/types";
 import {
-  assertNever,
   ConnectorsAPI,
   CoreAPI,
   DEFAULT_EMBEDDING_PROVIDER_ID,
@@ -69,6 +68,7 @@ import {
   sectionFullText,
   validateUrl,
 } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 import { ConversationResource } from "../resources/conversation_resource";
 

--- a/front/lib/api/files/processing.ts
+++ b/front/lib/api/files/processing.ts
@@ -28,7 +28,6 @@ import {
   normalizeError,
 } from "@app/types";
 import {
-  assertNever,
   Err,
   extensionsForContentType,
   isSupportedDelimitedTextContentType,
@@ -37,6 +36,7 @@ import {
   Ok,
   TextExtraction,
 } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 const UPLOAD_DELAY_AFTER_CREATION_MS = 1000 * 60 * 1; // 1 minute.
 const CONVERSATION_IMG_MAX_SIZE_PIXELS = "1538";

--- a/front/lib/api/files/upsert.ts
+++ b/front/lib/api/files/upsert.ts
@@ -33,7 +33,6 @@ import type {
 } from "@app/types";
 import { isSupportedAudioContentType } from "@app/types";
 import {
-  assertNever,
   Err,
   isInteractiveContentFileContentType,
   isSupportedImageContentType,
@@ -41,6 +40,7 @@ import {
   slugify,
   TABLE_PREFIX,
 } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 // Upload to dataSource
 const upsertDocumentToDatasource: ProcessingFunction = async (

--- a/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
@@ -22,7 +22,7 @@ import type {
 import { EventError } from "@app/lib/api/llm/types/events";
 import type { LLMClientMetadata } from "@app/lib/api/llm/types/options";
 import { parseToolArguments } from "@app/lib/api/llm/utils/tool_arguments";
-import { assertNever } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export async function* streamLLMEvents(
   messageStreamEvents: AsyncIterable<BetaRawMessageStreamEvent>,

--- a/front/lib/api/llm/clients/anthropic/utils/conversation_to_anthropic.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/conversation_to_anthropic.ts
@@ -20,12 +20,13 @@ import type {
   ModelMessageTypeMultiActionsWithoutContentFragment,
   UserMessageTypeModel,
 } from "@app/types";
-import { assertNever, isString } from "@app/types";
+import { isString } from "@app/types";
 import type {
   AgentFunctionCallContentType,
   AgentReasoningContentType,
   AgentTextContentType,
 } from "@app/types/assistant/agent_message_content";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 function userContentToParam(
   content: Content

--- a/front/lib/api/llm/clients/anthropic/utils/index.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/index.ts
@@ -8,7 +8,7 @@ import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { ANTHROPIC_PROVIDER_ID } from "@app/lib/api/llm/clients/anthropic/types";
 import { parseResponseFormatSchema } from "@app/lib/api/llm/utils";
 import type { ReasoningEffort } from "@app/types";
-import { assertNever } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 // thinking.enabled.budget_tokens: Input should be greater than or equal to 1024
 const ANTHROPIC_MINIMUM_THINKING_BUDGET = 1024;

--- a/front/lib/api/llm/clients/google/utils/conversation_to_google.ts
+++ b/front/lib/api/llm/clients/google/utils/conversation_to_google.ts
@@ -14,12 +14,12 @@ import type {
   ModelMessageTypeMultiActionsWithoutContentFragment,
   TextContent,
 } from "@app/types";
-import { assertNever } from "@app/types";
 import type {
   AgentFunctionCallContentType,
   AgentReasoningContentType,
   AgentTextContentType,
 } from "@app/types/assistant/agent_message_content";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { trustedFetchImageBase64 } from "@app/types/shared/utils/image_utils";
 
 const GOOGLE_AI_STUDIO_SUPPORTED_MIME_TYPES = [

--- a/front/lib/api/llm/clients/google/utils/to_thinking.ts
+++ b/front/lib/api/llm/clients/google/utils/to_thinking.ts
@@ -9,7 +9,7 @@ import {
 } from "@app/lib/api/llm/clients/google/types";
 import { parseResponseFormatSchema } from "@app/lib/api/llm/utils";
 import type { ReasoningEffort } from "@app/types";
-import { assertNever } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 const THINKING_BUDGET_CONFIG_MAPPING: Record<ReasoningEffort, number> = {
   // Budget of 0 would throw for some thinking models,

--- a/front/lib/api/llm/clients/mistral/utils/conversation_to_mistral.ts
+++ b/front/lib/api/llm/clients/mistral/utils/conversation_to_mistral.ts
@@ -13,12 +13,13 @@ import type {
   Content,
   ModelMessageTypeMultiActionsWithoutContentFragment,
 } from "@app/types";
-import { assertNever, safeParseJSON } from "@app/types";
+import { safeParseJSON } from "@app/types";
 import type {
   AgentFunctionCallContentType,
   AgentReasoningContentType,
   AgentTextContentType,
 } from "@app/types/assistant/agent_message_content";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export function sanitizeToolCallId(id: string): string {
   // Replace anything not a-zA-Z-0-9 with 0 as mistral enforces that but function_call_id can

--- a/front/lib/api/llm/tests/conversations.ts
+++ b/front/lib/api/llm/tests/conversations.ts
@@ -18,7 +18,8 @@ import type {
   ModelConversationTypeMultiActions,
   ModelMessageTypeMultiActionsWithoutContentFragment,
 } from "@app/types";
-import { assertNever, safeParseJSON } from "@app/types";
+import { safeParseJSON } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 const SYSTEM_PROMPT = "You are a helpful assistant.";
 

--- a/front/lib/api/llm/types/errors.ts
+++ b/front/lib/api/llm/types/errors.ts
@@ -2,7 +2,8 @@ import type { LLMEvent } from "@app/lib/api/llm/types/events";
 import { EventError } from "@app/lib/api/llm/types/events";
 import type { LLMClientMetadata } from "@app/lib/api/llm/types/options";
 import type { AgentErrorCategory, ModelProviderIdType } from "@app/types";
-import { assertNever, normalizeError } from "@app/types";
+import { normalizeError } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export type LLMErrorType =
   // LLM errors

--- a/front/lib/api/llm/utils/openai_like/chat/conversation_to_openai.ts
+++ b/front/lib/api/llm/utils/openai_like/chat/conversation_to_openai.ts
@@ -20,8 +20,8 @@ import type {
   FunctionMessageTypeModel,
   UserMessageTypeModel,
 } from "@app/types";
-import { assertNever } from "@app/types";
 import type { AgentContentItemType } from "@app/types/assistant/agent_message_content";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 type ChatCompletionContentPart =
   | ChatCompletionContentPartText

--- a/front/lib/api/llm/utils/openai_like/chat/openai_to_events.ts
+++ b/front/lib/api/llm/utils/openai_like/chat/openai_to_events.ts
@@ -5,7 +5,7 @@ import type { LLMEvent } from "@app/lib/api/llm/types/events";
 import { EventError } from "@app/lib/api/llm/types/events";
 import type { LLMClientMetadata } from "@app/lib/api/llm/types/options";
 import { parseToolArguments } from "@app/lib/api/llm/utils/tool_arguments";
-import { assertNever } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export async function* streamLLMEvents(
   chatCompletionStream: AsyncIterable<ChatCompletionChunk>,

--- a/front/lib/api/llm/utils/openai_like/responses/conversation_to_openai.ts
+++ b/front/lib/api/llm/utils/openai_like/responses/conversation_to_openai.ts
@@ -33,8 +33,8 @@ import type {
   FunctionMessageTypeModel,
   UserMessageTypeModel,
 } from "@app/types";
-import { assertNever } from "@app/types";
 import type { AgentContentItemType } from "@app/types/assistant/agent_message_content";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 function toInputContent(content: Content): ResponseInputContent {
   switch (content.type) {

--- a/front/lib/api/llm/utils/openai_like/responses/openai_to_events.ts
+++ b/front/lib/api/llm/utils/openai_like/responses/openai_to_events.ts
@@ -12,7 +12,7 @@ import type { LLMEvent } from "@app/lib/api/llm/types/events";
 import { EventError } from "@app/lib/api/llm/types/events";
 import type { LLMClientMetadata } from "@app/lib/api/llm/types/options";
 import { parseToolArguments } from "@app/lib/api/llm/utils/tool_arguments";
-import { assertNever } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export async function* streamLLMEvents(
   responseStreamEvents: AsyncIterable<ResponseStreamEvent>,

--- a/front/lib/api/oauth/providers/slack.ts
+++ b/front/lib/api/oauth/providers/slack.ts
@@ -15,8 +15,9 @@ import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import type { ExtraConfigType } from "@app/pages/w/[wId]/oauth/[provider]/setup";
 import type { Result } from "@app/types";
-import { assertNever, Err, Ok } from "@app/types";
+import { Err, Ok } from "@app/types";
 import type { OAuthConnectionType, OAuthUseCase } from "@app/types/oauth/lib";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export class SlackOAuthProvider implements BaseOAuthStrategyProvider {
   setupUri({

--- a/front/lib/api/poke/plugins/data_sources/operations.ts
+++ b/front/lib/api/poke/plugins/data_sources/operations.ts
@@ -1,13 +1,8 @@
 import config from "@app/lib/api/config";
 import { createPlugin } from "@app/lib/api/poke/types";
 import logger, { auditLog } from "@app/logger/logger";
-import {
-  assertNever,
-  ConnectorsAPI,
-  Err,
-  mapToEnumValues,
-  Ok,
-} from "@app/types";
+import { ConnectorsAPI, Err, mapToEnumValues, Ok } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 const OPERATIONS = [
   "PAUSE: pause the connector",

--- a/front/lib/api/poke/utils.ts
+++ b/front/lib/api/poke/utils.ts
@@ -12,7 +12,7 @@ import type {
   SupportedResourceType,
 } from "@app/types";
 import type { LightWorkspaceType } from "@app/types";
-import { assertNever } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export type ResourceTypeMap = {
   agents: LightAgentConfigurationType;

--- a/front/lib/api/projects/index.ts
+++ b/front/lib/api/projects/index.ts
@@ -23,7 +23,6 @@ import { getSpaceConversationsRoute } from "@app/lib/utils/router";
 import logger from "@app/logger/logger";
 import type { ConversationWithoutContentType, Result } from "@app/types";
 import {
-  assertNever,
   ConnectorsAPI,
   CoreAPI,
   DEFAULT_EMBEDDING_PROVIDER_ID,
@@ -33,6 +32,7 @@ import {
   Err,
   Ok,
 } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 /**
  * Generates a unique data source name for project conversations connector.

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -31,13 +31,13 @@ import logger from "@app/logger/logger";
 import { launchScrubSpaceWorkflow } from "@app/poke/temporal/client";
 import type { AgentsUsageType, Result } from "@app/types";
 import {
-  assertNever,
   Err,
   Ok,
   PROJECT_EDITOR_GROUP_PREFIX,
   PROJECT_GROUP_PREFIX,
   SPACE_GROUP_PREFIX,
 } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export async function softDeleteSpaceAndLaunchScrubWorkflow(
   auth: Authenticator,

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -35,15 +35,8 @@ import type {
   WorkspaceSegmentationType,
   WorkspaceType,
 } from "@app/types";
-import {
-  ACTIVE_ROLES,
-  assertNever,
-  Err,
-  isBuilder,
-  md5,
-  Ok,
-  removeNulls,
-} from "@app/types";
+import { ACTIVE_ROLES, Err, isBuilder, md5, Ok, removeNulls } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 import { GroupResource } from "../resources/group_resource";
 import { frontSequelize } from "../resources/storage";

--- a/front/lib/api/workspace_verification/start_verification.ts
+++ b/front/lib/api/workspace_verification/start_verification.ts
@@ -5,7 +5,8 @@ import { WorkspaceVerificationAttemptResource } from "@app/lib/resources/workspa
 import { rateLimiter } from "@app/lib/utils/rate_limiter";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types";
-import { assertNever, Err, Ok } from "@app/types";
+import { Err, Ok } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { VerificationErrorType } from "@app/types/workspace_verification";
 
 const MAX_ATTEMPTS_PER_PHONE = 3;

--- a/front/lib/connector_providers.ts
+++ b/front/lib/connector_providers.ts
@@ -3,7 +3,7 @@ import type {
   PlanType,
   WhitelistableFeature,
 } from "@app/types";
-import { assertNever } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export type ConnectorProviderConfiguration = {
   name: string;

--- a/front/lib/content_nodes.ts
+++ b/front/lib/content_nodes.ts
@@ -23,7 +23,7 @@ import type {
   SpaceType,
 } from "@app/types";
 import { isConnectorProvider } from "@app/types";
-import { assertNever } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 import {
   CHANNEL_INTERNAL_MIME_TYPES,

--- a/front/lib/credits/free.ts
+++ b/front/lib/credits/free.ts
@@ -13,7 +13,8 @@ import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import { statsDClient } from "@app/logger/statsDClient";
 import type { Result } from "@app/types";
-import { assertNever, Err, Ok } from "@app/types";
+import { Err, Ok } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 const BRACKET_1_USERS = 10;
 const BRACKET_1_MICRO_USD_PER_USER = 5_000_000; // $5

--- a/front/lib/credits/payg.ts
+++ b/front/lib/credits/payg.ts
@@ -13,7 +13,8 @@ import { ProgrammaticUsageConfigurationResource } from "@app/lib/resources/progr
 import logger from "@app/logger/logger";
 import { statsDClient } from "@app/logger/statsDClient";
 import type { Result } from "@app/types";
-import { assertNever, Err, Ok } from "@app/types";
+import { Err, Ok } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 type CreatePAYGCreditError = {
   error_type: "already_exists" | "invalid_discount" | "unknown";

--- a/front/lib/matcher/parser.ts
+++ b/front/lib/matcher/parser.ts
@@ -4,9 +4,9 @@ import {
   isOperator,
   isVariadicOperation,
 } from "@app/lib/matcher/types";
-import { assertNever } from "@app/types";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 import type { LogicalOp, MatcherExpression, Operation } from "./types";
 

--- a/front/lib/mentions/format.ts
+++ b/front/lib/mentions/format.ts
@@ -15,7 +15,7 @@ import type {
   RichMention,
   UserMention,
 } from "@app/types";
-import { assertNever } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 /**
  * Regular expression for parsing agent mention strings.

--- a/front/lib/models/agent/actions/mcp_server_connection.ts
+++ b/front/lib/models/agent/actions/mcp_server_connection.ts
@@ -5,7 +5,7 @@ import { RemoteMCPServerModel } from "@app/lib/models/agent/actions/remote_mcp_s
 import { frontSequelize } from "@app/lib/resources/storage";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
-import { assertNever } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export class MCPServerConnectionModel extends WorkspaceAwareModel<MCPServerConnectionModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/models/agent/actions/mcp_server_view.ts
+++ b/front/lib/models/agent/actions/mcp_server_view.ts
@@ -8,7 +8,7 @@ import { SpaceModel } from "@app/lib/resources/storage/models/spaces";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { SoftDeletableWorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import type { MCPOAuthUseCase } from "@app/types";
-import { assertNever } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export class MCPServerViewModel extends SoftDeletableWorkspaceAwareModel<MCPServerViewModel> {
   declare createdAt: CreationOptional<Date>;

--- a/front/lib/notifications/workflows/conversation-unread.ts
+++ b/front/lib/notifications/workflows/conversation-unread.ts
@@ -27,7 +27,6 @@ import type {
   UserType,
 } from "@app/types";
 import {
-  assertNever,
   ConversationError,
   Err,
   getSmallWhitelistedModel,
@@ -51,6 +50,7 @@ import {
   makeNotificationPreferencesUserMetadata,
   NOTIFICATION_DELAY_OPTIONS,
 } from "@app/types/notification_preferences";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 const ConversationUnreadPayloadSchema = z.object({
   workspaceId: z.string(),

--- a/front/lib/plans/stripe.ts
+++ b/front/lib/plans/stripe.ts
@@ -21,9 +21,9 @@ import type {
   UserType,
   WorkspaceType,
 } from "@app/types";
-import { assertNever } from "@app/types";
 import { Err, isDevelopment, normalizeError, Ok } from "@app/types";
 import { SUPPORTED_CURRENCIES } from "@app/types/currency";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { StripePricingData } from "@app/types/stripe/pricing";
 
 const DEV_PRO_PLAN_PRODUCT_ID = "prod_OwKvN4XrUwFw5a";

--- a/front/lib/plans/usage/index.ts
+++ b/front/lib/plans/usage/index.ts
@@ -12,7 +12,8 @@ import {
   REPORT_USAGE_METADATA_KEY,
 } from "@app/lib/plans/usage/types";
 import type { LightWorkspaceType, Result } from "@app/types";
-import { assertNever, Err, Ok } from "@app/types";
+import { Err, Ok } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export function getUsageToReportForSubscriptionItem(
   item: Stripe.SubscriptionItem

--- a/front/lib/poke/regions.ts
+++ b/front/lib/poke/regions.ts
@@ -1,5 +1,5 @@
 import type { RegionType } from "@app/lib/api/regions/config";
-import { assertNever } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export const getRegionDisplay = (region: RegionType): string => {
   switch (region) {

--- a/front/lib/production_checks/history.ts
+++ b/front/lib/production_checks/history.ts
@@ -17,7 +17,7 @@ import type {
   CheckResultStatus,
   CheckSummaryStatus,
 } from "@app/types";
-import { assertNever } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 const COMPLETED_CHECKS_QUERY = `(WorkflowType = "${WORKFLOW_TYPE_RUN_ALL_CHECKS}" OR WorkflowType = "${WORKFLOW_TYPE_RUN_SINGLE_CHECK}") AND ExecutionStatus = "Completed"`;
 

--- a/front/lib/resources/content_fragment_resource.ts
+++ b/front/lib/resources/content_fragment_resource.ts
@@ -46,7 +46,6 @@ import type {
   Result,
 } from "@app/types";
 import {
-  assertNever,
   CoreAPI,
   Err,
   isLLMVisionSupportedImageContentType,
@@ -54,6 +53,7 @@ import {
   Ok,
   removeNulls,
 } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export const CONTENT_OUTDATED_MSG =
   "Content is outdated. Please refer to the latest version of this content.";

--- a/front/lib/resources/data_source_view_resource.ts
+++ b/front/lib/resources/data_source_view_resource.ts
@@ -44,14 +44,8 @@ import type {
   Result,
   UserType,
 } from "@app/types";
-import {
-  assertNever,
-  CoreAPI,
-  Err,
-  formatUserFullName,
-  Ok,
-  removeNulls,
-} from "@app/types";
+import { CoreAPI, Err, formatUserFullName, Ok, removeNulls } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 import type { UserResource } from "./user_resource";
 

--- a/front/lib/resources/group_space_resource.ts
+++ b/front/lib/resources/group_space_resource.ts
@@ -15,7 +15,8 @@ import type {
   Result,
   UserType,
 } from "@app/types";
-import { assertNever, Err, Ok, removeNulls } from "@app/types";
+import { Err, Ok, removeNulls } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 // Base class for group-space junction resources
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.

--- a/front/lib/resources/mcp_server_view_resource.ts
+++ b/front/lib/resources/mcp_server_view_resource.ts
@@ -43,13 +43,8 @@ import type {
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { MCPOAuthUseCase, ModelId, Result } from "@app/types";
-import {
-  assertNever,
-  Err,
-  formatUserFullName,
-  Ok,
-  removeNulls,
-} from "@app/types";
+import { Err, formatUserFullName, Ok, removeNulls } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -30,7 +30,8 @@ import type {
   Result,
   UserType,
 } from "@app/types";
-import { assertNever, Err, Ok } from "@app/types";
+import { Err, Ok } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 type GetMembershipsOptions = RequireAtLeastOne<{
   users: UserResource[];

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -38,13 +38,13 @@ import type {
   SpaceType,
 } from "@app/types";
 import {
-  assertNever,
   Err,
   GLOBAL_SPACE_NAME,
   Ok,
   PROJECT_EDITOR_GROUP_PREFIX,
   removeNulls,
 } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.

--- a/front/lib/resources/trigger_resource.ts
+++ b/front/lib/resources/trigger_resource.ts
@@ -28,13 +28,7 @@ import {
   deleteTriggerSchedule,
 } from "@app/temporal/triggers/schedule/client";
 import type { ModelId, Result, UserType } from "@app/types";
-import {
-  assertNever,
-  Err,
-  errorToString,
-  normalizeError,
-  Ok,
-} from "@app/types";
+import { Err, errorToString, normalizeError, Ok } from "@app/types";
 import type {
   ScheduleConfig,
   TriggerExecutionMode,
@@ -42,6 +36,7 @@ import type {
   TriggerType,
   WebhookConfig,
 } from "@app/types/assistant/triggers";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.

--- a/front/lib/search.ts
+++ b/front/lib/search.ts
@@ -6,7 +6,8 @@ import type {
   CoreAPISearchScope,
   Result,
 } from "@app/types";
-import { assertNever, Err, Ok } from "@app/types";
+import { Err, Ok } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export function getCoreViewTypeFilter(viewType: ContentNodesViewType) {
   switch (viewType) {

--- a/front/lib/spaces.ts
+++ b/front/lib/spaces.ts
@@ -22,7 +22,8 @@ import type {
   WhitelistableFeature,
   WorkspaceType,
 } from "@app/types";
-import { assertNever, GLOBAL_SPACE_NAME } from "@app/types";
+import { GLOBAL_SPACE_NAME } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 const SPACE_SECTION_GROUP_ORDER = [
   "system",

--- a/front/lib/triggers/webhook.ts
+++ b/front/lib/triggers/webhook.ts
@@ -23,7 +23,6 @@ import { statsDClient } from "@app/logger/statsDClient";
 import { launchAgentTriggerWorkflow } from "@app/temporal/triggers/common/client";
 import type { ContentFragmentInputWithFileIdType, Result } from "@app/types";
 import {
-  assertNever,
   Err,
   errorToString,
   isString,
@@ -36,6 +35,7 @@ import type {
   WebhookTriggerType,
 } from "@app/types/assistant/triggers";
 import { isWebhookTrigger } from "@app/types/assistant/triggers";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { WebhookProvider } from "@app/types/triggers/webhooks";
 import { WEBHOOK_PRESETS } from "@app/types/triggers/webhooks";
 

--- a/front/lib/utils/find_agents_in_message.ts
+++ b/front/lib/utils/find_agents_in_message.ts
@@ -3,7 +3,7 @@ import type { AugmentedMessageFromLLM } from "@app/lib/api/assistant/voice_agent
 import { findAgentsInMessageGeneration } from "@app/lib/api/assistant/voice_agent_finder";
 import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
-import { assertNever } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export type AugmentedMessage =
   | {

--- a/front/lib/utils/rate_limiter.ts
+++ b/front/lib/utils/rate_limiter.ts
@@ -8,7 +8,8 @@ import type {
   MaxMessagesTimeframeType,
   Result,
 } from "@app/types";
-import { assertNever, Err, normalizeError, Ok } from "@app/types";
+import { Err, normalizeError, Ok } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export class RateLimitError extends Error {}
 

--- a/front/lib/utils/websearch.ts
+++ b/front/lib/utils/websearch.ts
@@ -4,13 +4,13 @@ import _ from "lodash";
 import logger from "@app/logger/logger";
 import type { Result } from "@app/types";
 import {
-  assertNever,
   dustManagedCredentials,
   Err,
   normalizeError,
   Ok,
   removeNulls,
 } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 const credentials = dustManagedCredentials();
 

--- a/front/migrations/20240412_force_use_at_iteration.ts
+++ b/front/migrations/20240412_force_use_at_iteration.ts
@@ -1,4 +1,4 @@
-// import { assertNever, removeNulls } from "@app/types";
+// import { removeNulls } from "@app/types";
 // import * as _ from "lodash";
 
 // import { AgentDustAppRunConfiguration } from "@app/lib/models/assistant/actions/dust_app_run";
@@ -10,6 +10,7 @@
 // } from "@app/lib/models/assistant/agent";
 // import logger from "@app/logger/logger";
 // import { makeScript } from "@app/scripts/helpers";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 // // Fetch all agents, with all generation configs and all actions.
 // // Goal is to backfill forceUseAtIteration for all generations and actions.

--- a/front/migrations/20240701_fix_broken_action_names.ts
+++ b/front/migrations/20240701_fix_broken_action_names.ts
@@ -1,6 +1,5 @@
 // import type { AgentAction } from "@app/types";
-// import { assertNever } from "@app/types";
-// import _ from "lodash";
+// // import _ from "lodash";
 // import { QueryTypes } from "sequelize";
 //
 // import { AgentBrowseConfiguration } from "@app/lib/models/assistant/actions/browse";
@@ -10,6 +9,7 @@
 // import { AgentWebsearchConfiguration } from "@app/lib/models/assistant/actions/websearch";
 // import { frontSequelize } from "@app/lib/resources/storage";
 // import { makeScript } from "@app/scripts/helpers";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 //
 // makeScript({}, async ({ execute }) => {
 //   type ActionConfig = {

--- a/front/migrations/20241129_migrate_int_to_bigint.ts
+++ b/front/migrations/20241129_migrate_int_to_bigint.ts
@@ -4,7 +4,7 @@ import type { PoolClient } from "pg";
 import { Pool } from "pg";
 
 import { makeScript } from "@app/scripts/helpers";
-import { assertNever } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 // Types.
 interface MigrationConfig {

--- a/front/pages/api/lookup/[resource]/index.ts
+++ b/front/pages/api/lookup/[resource]/index.ts
@@ -11,7 +11,7 @@ import {
 import { getBearerToken } from "@app/lib/auth";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
-import { assertNever } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export type WorkspaceLookupResponse = {
   workspace: {

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/index.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/index.ts
@@ -9,7 +9,7 @@ import { DataSourceViewResource } from "@app/lib/resources/data_source_view_reso
 import { apiError } from "@app/logger/withlogging";
 import type { DataSourceType } from "@app/types";
 import type { WithAPIErrorResponse } from "@app/types";
-import { assertNever } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export type DeleteDataSourceResponseBody = DataSourceType;
 

--- a/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/search.ts
+++ b/front/pages/api/poke/workspaces/[wId]/data_sources/[dsId]/search.ts
@@ -12,7 +12,7 @@ import type { SessionWithUser } from "@app/lib/iam/provider";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
-import { assertNever } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/poke/workspaces/[wId]/revoke.ts
+++ b/front/pages/api/poke/workspaces/[wId]/revoke.ts
@@ -7,7 +7,7 @@ import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
-import { assertNever } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export type RevokeUserResponseBody = {
   success: true;

--- a/front/pages/api/poke/workspaces/[wId]/roles.ts
+++ b/front/pages/api/poke/workspaces/[wId]/roles.ts
@@ -11,7 +11,8 @@ import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { ServerSideTracking } from "@app/lib/tracking/server";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
-import { ActiveRoleSchema, assertNever } from "@app/types";
+import { ActiveRoleSchema } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export type PostRoleUserResponseBody = {
   success: true;

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -52,7 +52,8 @@ import { apiError, withLogging } from "@app/logger/withlogging";
 import { launchScheduleWorkspaceScrubWorkflow } from "@app/temporal/scrub_workspace/client";
 import { launchWorkOSWorkspaceSubscriptionCreatedWorkflow } from "@app/temporal/workos_events_queue/client";
 import type { WithAPIErrorResponse } from "@app/types";
-import { assertNever, isString } from "@app/types";
+import { isString } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export type GetResponseBody = {
   success: boolean;

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
@@ -27,11 +27,11 @@ import type {
   WithAPIErrorResponse,
 } from "@app/types";
 import {
-  assertNever,
   CoreAPI,
   credentialsFromProviders,
   dustManagedCredentials,
 } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export const config = {
   api: {

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.ts
@@ -10,7 +10,7 @@ import type { Authenticator } from "@app/lib/auth";
 import type { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
-import { assertNever } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 /**
  * @swagger

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/search.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/search.ts
@@ -10,7 +10,7 @@ import type { Authenticator } from "@app/lib/auth";
 import type { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
-import { assertNever } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 /**
  * @swagger

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/search.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/search.ts
@@ -10,7 +10,7 @@ import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
-import { assertNever } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 /**
  * @swagger

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tId]/index.ts
@@ -10,7 +10,8 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
-import { assertNever, CoreAPI, isString } from "@app/types";
+import { CoreAPI, isString } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 /**
  * @swagger

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/members/[userId].ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/members/[userId].ts
@@ -7,7 +7,8 @@ import type { Authenticator } from "@app/lib/auth";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
-import { assertNever, isString } from "@app/types";
+import { isString } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 /**
  * @ignoreswagger

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/members/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/members/index.ts
@@ -12,7 +12,8 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
-import { assertNever, isString } from "@app/types";
+import { isString } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 /**
  * @ignoreswagger

--- a/front/pages/api/v1/w/[wId]/workspace-usage.ts
+++ b/front/pages/api/v1/w/[wId]/workspace-usage.ts
@@ -22,7 +22,7 @@ import {
 } from "@app/lib/workspace_usage";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse, WorkspaceType } from "@app/types";
-import { assertNever } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 /**
  * @swagger

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/editors.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/editors.ts
@@ -13,7 +13,7 @@ import { GroupResource } from "@app/lib/resources/group_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import type { UserType, WithAPIErrorResponse } from "@app/types";
-import { assertNever } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 // Changed schema to accept optional add/remove lists
 export const PatchAgentEditorsRequestBodySchema = t.intersection([

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/managed/permissions/index.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/managed/permissions/index.ts
@@ -16,11 +16,8 @@ import type {
   DataSourceType,
   WithAPIErrorResponse,
 } from "@app/types";
-import {
-  assertNever,
-  ConnectorsAPI,
-  isValidContentNodesViewType,
-} from "@app/types";
+import { ConnectorsAPI, isValidContentNodesViewType } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 const SetConnectorPermissionsRequestBodySchema = t.type({
   resources: t.array(

--- a/front/pages/api/w/[wId]/mcp/[serverId]/index.ts
+++ b/front/pages/api/w/[wId]/mcp/[serverId]/index.ts
@@ -16,7 +16,7 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
 import { headersArrayToRecord } from "@app/types";
-import { assertNever } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 const PatchMCPServerBodySchema = z
   .object({

--- a/front/pages/api/w/[wId]/mcp/views/[viewId]/index.ts
+++ b/front/pages/api/w/[wId]/mcp/views/[viewId]/index.ts
@@ -9,7 +9,8 @@ import { DustError } from "@app/lib/error";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { MCPOAuthUseCase, Result, WithAPIErrorResponse } from "@app/types";
-import { assertNever, Err, Ok } from "@app/types";
+import { Err, Ok } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 const PatchMCPServerViewBodySchema = z
   .object({

--- a/front/pages/api/w/[wId]/members/[uId]/index.ts
+++ b/front/pages/api/w/[wId]/members/[uId]/index.ts
@@ -15,7 +15,8 @@ import type {
   UserTypeWithWorkspaces,
   WithAPIErrorResponse,
 } from "@app/types";
-import { assertNever, isMembershipRoleType } from "@app/types";
+import { isMembershipRoleType } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export type GetMemberResponseBody = {
   member: {

--- a/front/pages/api/w/[wId]/services/transcribe/index.ts
+++ b/front/pages/api/w/[wId]/services/transcribe/index.ts
@@ -8,7 +8,7 @@ import { transcribeStream } from "@app/lib/utils/transcribe_service";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
-import { assertNever } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
 export const config = {

--- a/front/pages/api/w/[wId]/skills/[sId]/editors.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/editors.ts
@@ -9,7 +9,8 @@ import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { UserType, WithAPIErrorResponse } from "@app/types";
-import { assertNever, isString } from "@app/types";
+import { isString } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 const PatchSkillEditorsRequestBodySchema = t.intersection([
   t.type({}),

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/index.ts
@@ -10,7 +10,8 @@ import type { DataSourceViewResource } from "@app/lib/resources/data_source_view
 import { KillSwitchResource } from "@app/lib/resources/kill_switch_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { DataSourceViewType, WithAPIErrorResponse } from "@app/types";
-import { assertNever, PatchDataSourceViewSchema } from "@app/types";
+import { PatchDataSourceViewSchema } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export type PatchDataSourceViewResponseBody = {
   dataSourceView: DataSourceViewType;

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tableId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/tables/[tableId]/index.ts
@@ -11,7 +11,8 @@ import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
-import { assertNever, PatchDataSourceTableRequestBodySchema } from "@app/types";
+import { PatchDataSourceTableRequestBodySchema } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export type PatchTableResponseBody = {
   table?: { table_id: string };

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/members.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/members.ts
@@ -10,7 +10,7 @@ import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { auditLog } from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { SpaceType, WithAPIErrorResponse } from "@app/types";
-import { assertNever } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 interface PatchSpaceMembersResponseBody {
   space: SpaceType;

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/search_conversations.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/search_conversations.ts
@@ -13,7 +13,7 @@ import type {
   ConversationWithoutContentType,
   WithAPIErrorResponse,
 } from "@app/types";
-import { assertNever } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export type SearchConversationsResponseBody = {
   conversations: ConversationWithoutContentType[];

--- a/front/pages/api/w/[wId]/spaces/index.ts
+++ b/front/pages/api/w/[wId]/spaces/index.ts
@@ -9,7 +9,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { SpaceType, WithAPIErrorResponse } from "@app/types";
-import { assertNever } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 const PostSpaceRequestBodySchema = t.intersection([
   t.type({

--- a/front/pages/api/w/[wId]/subscriptions/index.ts
+++ b/front/pages/api/w/[wId]/subscriptions/index.ts
@@ -17,7 +17,7 @@ import type {
   SubscriptionType,
   WithAPIErrorResponse,
 } from "@app/types";
-import { assertNever } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export type PostSubscriptionResponseBody = {
   plan: PlanType;

--- a/front/pages/api/w/[wId]/verification/start.ts
+++ b/front/pages/api/w/[wId]/verification/start.ts
@@ -8,7 +8,7 @@ import { startVerification } from "@app/lib/api/workspace_verification";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
-import { assertNever } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import type {
   StartVerificationResponse,
   VerificationErrorResponse,

--- a/front/pages/api/w/[wId]/webhook_sources/views/[viewId]/index.ts
+++ b/front/pages/api/w/[wId]/webhook_sources/views/[viewId]/index.ts
@@ -13,7 +13,8 @@ import { WebhookSourcesViewResource } from "@app/lib/resources/webhook_sources_v
 import { normalizeWebhookIcon } from "@app/lib/webhookSource";
 import { apiError } from "@app/logger/withlogging";
 import type { Result, WithAPIErrorResponse } from "@app/types";
-import { assertNever, Err, Ok } from "@app/types";
+import { Err, Ok } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
 
 const PatchWebhookSourceViewBodySchema = z.object({

--- a/front/pages/api/w/[wId]/workspace-usage.ts
+++ b/front/pages/api/w/[wId]/workspace-usage.ts
@@ -16,7 +16,7 @@ import {
 } from "@app/lib/workspace_usage";
 import { apiError } from "@app/logger/withlogging";
 import type { WorkspaceType } from "@app/types";
-import { assertNever } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 const MonthSchema = t.refinement(
   t.string,

--- a/front/scripts/dev/transcribe_audio_file.ts
+++ b/front/scripts/dev/transcribe_audio_file.ts
@@ -9,7 +9,8 @@ import {
 } from "@app/lib/utils/transcribe_service";
 import type { Logger } from "@app/logger/logger";
 import { makeScript } from "@app/scripts/helpers";
-import { assertNever, isDevelopment } from "@app/types";
+import { isDevelopment } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
 async function transcribeAudioFile(

--- a/front/scripts/relocation/relocate_workspace.ts
+++ b/front/scripts/relocation/relocate_workspace.ts
@@ -26,7 +26,7 @@ import { Authenticator } from "@app/lib/auth";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { makeScript } from "@app/scripts/helpers";
 import { launchWorkspaceRelocationWorkflow } from "@app/temporal/relocation/client";
-import { assertNever } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 const RELOCATION_STEPS = [
   "relocate",

--- a/front/scripts/temporal-build/build-temporal-bundles.ts
+++ b/front/scripts/temporal-build/build-temporal-bundles.ts
@@ -5,7 +5,7 @@ import TsconfigPathsPlugin from "tsconfig-paths-webpack-plugin";
 
 import type { WorkerName } from "@app/temporal/worker_registry";
 import { ALL_WORKERS } from "@app/temporal/worker_registry";
-import { assertNever } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 interface WorkerInfo {
   name: string;

--- a/front/temporal/agent_loop/activities/publish_deferred_events.ts
+++ b/front/temporal/agent_loop/activities/publish_deferred_events.ts
@@ -4,7 +4,7 @@ import { publishConversationRelatedEvent } from "@app/lib/api/assistant/streamin
 import type { AgentMessageEvents } from "@app/lib/api/assistant/streaming/types";
 import { AgentMessageModel } from "@app/lib/models/agent/conversation";
 import type { DeferredEvent } from "@app/temporal/agent_loop/lib/deferred_events";
-import { assertNever } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 /**
  * Activity to publish events that were deferred during tool execution.

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -12,12 +12,12 @@ import { updateResourceAndPublishEvent } from "@app/temporal/agent_loop/activiti
 import type { ToolExecutionResult } from "@app/temporal/agent_loop/lib/deferred_events";
 import { sliceConversationForAgentMessage } from "@app/temporal/agent_loop/lib/loop_utils";
 import type { ModelId } from "@app/types";
-import { assertNever } from "@app/types";
 import type { AgentLoopArgsWithTiming } from "@app/types/assistant/agent_run";
 import {
   getAgentLoopData,
   isAgentLoopDataSoftDeleteError,
 } from "@app/types/assistant/agent_run";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 const CONVERSATION_CACHE_TTL_MS = 5000;
 

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -46,8 +46,9 @@ import { RUN_MODEL_MAX_RETRIES } from "@app/temporal/agent_loop/config";
 import { getOutputFromLLMStream } from "@app/temporal/agent_loop/lib/get_output_from_llm";
 import { sliceConversationForAgentMessage } from "@app/temporal/agent_loop/lib/loop_utils";
 import type { AgentActionsEvent, AgentMessageType, ModelId } from "@app/types";
-import { assertNever, isTextContent, removeNulls } from "@app/types";
+import { isTextContent, removeNulls } from "@app/types";
 import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 // This method is used by the multi-actions execution loop to pick the next
 // action to execute and generate its inputs.

--- a/front/temporal/labs/transcripts/activities.ts
+++ b/front/temporal/labs/transcripts/activities.ts
@@ -38,13 +38,13 @@ import {
 } from "@app/temporal/labs/transcripts/utils/modjo";
 import type { AgentMessageType, UserMessageContext } from "@app/types";
 import {
-  assertNever,
   dustManagedCredentials,
   isEmptyString,
   isProviderWithDefaultWorkspaceConfiguration,
 } from "@app/types";
 import { Err } from "@app/types";
 import { CoreAPI } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 class TranscriptNonRetryableError extends Error {}
 

--- a/front/temporal/triggers/common/activities.ts
+++ b/front/temporal/triggers/common/activities.ts
@@ -23,8 +23,9 @@ import type {
   ConversationType,
   Result,
 } from "@app/types";
-import { assertNever, Ok } from "@app/types";
+import { Ok } from "@app/types";
 import type { TriggerType } from "@app/types/assistant/triggers";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 
 import { makeTriggerScheduleId } from "../schedule/client";
 

--- a/front/types/index.ts
+++ b/front/types/index.ts
@@ -84,7 +84,6 @@ export * from "./shared/retries";
 export * from "./shared/text_extraction";
 export * from "./shared/typescipt_utils";
 export * from "./shared/user_operation";
-export * from "./shared/utils/assert_never";
 export * from "./shared/utils/config";
 export * from "./shared/utils/date_utils";
 export * from "./shared/utils/error_utils";

--- a/front/types/shared/utils/string_utils.ts
+++ b/front/types/shared/utils/string_utils.ts
@@ -2,9 +2,8 @@ import removeMarkdown from "remove-markdown";
 
 import { replaceContentNodeMarkdownWithQuotedTitle } from "@app/lib/content_nodes";
 import { replaceMentionsWithAt } from "@app/lib/mentions/format";
-
-import type { Result } from "../result";
-import { Err, Ok } from "../result";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
 
 /**
  * Substring that ensures we don't cut a string in the middle of a unicode


### PR DESCRIPTION
## Description

This fixes a few circular imports.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

This is a no-op, it simply changes import path for `assertNever`.
