### PR TITLE
[RUNNER] Handle failed to write to GCS error in agent loop

### DIFF
--- a/front/lib/api/files/processing.ts
+++ b/front/lib/api/files/processing.ts
@@ -669,26 +669,44 @@ export async function processAndStoreFile(
     });
   }
 
-  if (content.type === "string") {
-    await pipeline(
-      Readable.from(content.value),
-      file.getWriteStream({ auth, version: "original" })
-    );
-  } else if (content.type === "readable") {
-    await pipeline(
-      content.value,
-      file.getWriteStream({ auth, version: "original" })
-    );
-  } else {
-    const r = await parseUploadRequest(
-      file,
-      content.value,
-      file.getWriteStream({ auth, version: "original" })
-    );
-    if (r.isErr()) {
-      await file.markAsFailed();
-      return r;
+  try {
+    if (content.type === "string") {
+      await pipeline(
+        Readable.from(content.value),
+        file.getWriteStream({ auth, version: "original" })
+      );
+    } else if (content.type === "readable") {
+      await pipeline(
+        content.value,
+        file.getWriteStream({ auth, version: "original" })
+      );
+    } else {
+      const r = await parseUploadRequest(
+        file,
+        content.value,
+        file.getWriteStream({ auth, version: "original" })
+      );
+      if (r.isErr()) {
+        await file.markAsFailed();
+        return r;
+      }
     }
+  } catch (err) {
+    await file.markAsFailed();
+    logger.error(
+      {
+        fileModelId: file.id,
+        workspaceId: auth.workspace()?.sId,
+        error: err,
+      },
+      "Failed to upload file to storage."
+    );
+
+    return new Err({
+      name: "dust_error",
+      code: "internal_server_error",
+      message: `Failed to upload file to storage.`,
+    });
   }
 
   const processingRes = await maybeApplyProcessing(auth, file);


### PR DESCRIPTION
## Description

In a conversation using the image_generation tool, if an error happened when writing file to GCS, error was not caught and propagated unhandled which caused a red error message. 
This PR ensures that an understandable error message is sent back to the llm.

<img width="836" height="250" alt="image" src="https://github.com/user-attachments/assets/c9d63439-ca1b-4758-bf7e-ae740b113937" />


## Tests

Local

## Risk

no

## Deploy Plan

front
