### PR TITLE
[front] fix(skills): round avatars in Manage skills/agents pages

### DIFF
--- a/front/components/assistant/manager/AssistantsTable.tsx
+++ b/front/components/assistant/manager/AssistantsTable.tsx
@@ -179,6 +179,7 @@ const getTableColumns = ({
               items: editors.map((editor) => ({
                 name: editor.fullName,
                 visual: editor.image,
+                isRounded: true,
               })),
               nbVisibleItems: 4,
             }}

--- a/front/components/skills/SkillsTable.tsx
+++ b/front/components/skills/SkillsTable.tsx
@@ -71,12 +71,14 @@ const editorsColumn = {
       ? editors.map((editor) => ({
           name: editor.fullName,
           visual: editor.image,
+          isRounded: true,
         }))
-      : // Only dust managed skills should have no editors
+      : // Only Dust-managed skills should have no editors
         [
           {
             name: "Dust",
             visual: DUST_AVATAR_URL,
+            isRounded: false,
           },
         ];
     return <DataTable.CellContent avatarStack={{ items, nbVisibleItems: 4 }} />;

--- a/front/pages/w/[wId]/builder/agents/index.tsx
+++ b/front/pages/w/[wId]/builder/agents/index.tsx
@@ -309,7 +309,7 @@ export default function WorkspaceAssistants({
         agentId={detailedAgentId}
         onClose={() => setDetailedAgentId(null)}
       />
-      <div className="flex w-full flex-col gap-8 pt-2 lg:pt-8">
+      <div className="flex w-full flex-col gap-8 pb-4 pt-2 lg:pt-8">
         <Page.Header title="Manage Agents" icon={ContactsRobotIcon} />
         <Page.Vertical gap="md" align="stretch">
           <div className="flex flex-row gap-2">

--- a/front/pages/w/[wId]/builder/skills/index.tsx
+++ b/front/pages/w/[wId]/builder/skills/index.tsx
@@ -246,7 +246,7 @@ export default function WorkspaceSkills({
         <Head>
           <title>Dust - Manage Skills</title>
         </Head>
-        <div className="flex w-full flex-col gap-8 pb-8 pt-2 lg:pt-8">
+        <div className="flex w-full flex-col gap-8 pb-4 pt-2 lg:pt-8">
           <Page.Header
             title="Manage Skills"
             icon={SKILL_ICON}

--- a/front/pages/w/[wId]/builder/skills/index.tsx
+++ b/front/pages/w/[wId]/builder/skills/index.tsx
@@ -246,7 +246,7 @@ export default function WorkspaceSkills({
         <Head>
           <title>Dust - Manage Skills</title>
         </Head>
-        <div className="flex w-full flex-col gap-8 pt-2 lg:pt-8">
+        <div className="flex w-full flex-col gap-8 pb-8 pt-2 lg:pt-8">
           <Page.Header
             title="Manage Skills"
             icon={SKILL_ICON}

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -1093,7 +1093,7 @@ DataTable.CellContent = function CellContent({
       )}
       {avatarStack && (
         <Avatar.Stack
-          avatars={avatarStack.items}
+          avatars={avatarStack.items.map((item) => ({ ...item, isRounded: true }))}
           nbVisibleItems={avatarStack.nbVisibleItems}
           size="xs"
         />

--- a/sparkle/src/components/DataTable.tsx
+++ b/sparkle/src/components/DataTable.tsx
@@ -1093,7 +1093,7 @@ DataTable.CellContent = function CellContent({
       )}
       {avatarStack && (
         <Avatar.Stack
-          avatars={avatarStack.items.map((item) => ({ ...item, isRounded: true }))}
+          avatars={avatarStack.items}
           nbVisibleItems={avatarStack.nbVisibleItems}
           size="xs"
         />


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/6211.
- This PR rounds the avatars for human users in the Manage agents and Manage skills pages.
- This PR also adds a padding at the bottom of these pages.

<img width="2191" height="601" alt="Screenshot 2026-01-29 at 2 52 48 PM" src="https://github.com/user-attachments/assets/7cf047bd-53e6-4155-ab76-ed34d2c475da" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
