### PR TITLE
[front] Add ability to add skills to a global agent

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/anthropic.ts
+++ b/front/lib/api/assistant/global_agents/configurations/anthropic.ts
@@ -4,10 +4,7 @@ import {
   globalAgentWebSearchGuidelines,
 } from "@app/lib/api/assistant/global_agents/guidelines";
 import type { MCPServerViewsForGlobalAgentsMap } from "@app/lib/api/assistant/global_agents/tools";
-import {
-  _getDefaultWebActionsForGlobalAgent,
-  _getInteractiveContentToolConfiguration,
-} from "@app/lib/api/assistant/global_agents/tools";
+import { _getDefaultWebActionsForGlobalAgent } from "@app/lib/api/assistant/global_agents/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";
 import type { AgentConfigurationType } from "@app/types";
@@ -68,11 +65,8 @@ export function _getClaude3HaikuGlobalAgent({
         agentId: sId,
         mcpServerViews,
       }),
-      ..._getInteractiveContentToolConfiguration({
-        agentId: sId,
-        mcpServerViews,
-      }),
     ],
+    skills: ["frames"],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
     templateId: null,
     requestedGroupIds: [],
@@ -125,11 +119,8 @@ export function _getClaude3OpusGlobalAgent({
         agentId: sId,
         mcpServerViews,
       }),
-      ..._getInteractiveContentToolConfiguration({
-        agentId: sId,
-        mcpServerViews,
-      }),
     ],
+    skills: ["frames"],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
     templateId: null,
     requestedGroupIds: [],
@@ -182,11 +173,8 @@ export function _getClaude3GlobalAgent({
         agentId: sId,
         mcpServerViews,
       }),
-      ..._getInteractiveContentToolConfiguration({
-        agentId: sId,
-        mcpServerViews,
-      }),
     ],
+    skills: ["frames"],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
     templateId: null,
     requestedGroupIds: [],
@@ -239,11 +227,8 @@ export function _getClaude4SonnetGlobalAgent({
         agentId: sId,
         mcpServerViews,
       }),
-      ..._getInteractiveContentToolConfiguration({
-        agentId: sId,
-        mcpServerViews,
-      }),
     ],
+    skills: ["frames"],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
     templateId: null,
     requestedGroupIds: [],
@@ -296,11 +281,8 @@ export function _getClaude3_7GlobalAgent({
         agentId: sId,
         mcpServerViews,
       }),
-      ..._getInteractiveContentToolConfiguration({
-        agentId: sId,
-        mcpServerViews,
-      }),
     ],
+    skills: ["frames"],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
     templateId: null,
     requestedGroupIds: [],
@@ -353,11 +335,8 @@ export function _getClaude4_5SonnetGlobalAgent({
         agentId: sId,
         mcpServerViews,
       }),
-      ..._getInteractiveContentToolConfiguration({
-        agentId: sId,
-        mcpServerViews,
-      }),
     ],
+    skills: ["frames"],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
     visualizationEnabled: false,
     templateId: null,
@@ -411,11 +390,8 @@ export function _getClaude4_5HaikuGlobalAgent({
         agentId: sId,
         mcpServerViews,
       }),
-      ..._getInteractiveContentToolConfiguration({
-        agentId: sId,
-        mcpServerViews,
-      }),
     ],
+    skills: ["frames"],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
     visualizationEnabled: false,
     templateId: null,

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -19,7 +19,6 @@ import type {
 import {
   _getAgentRouterToolsConfiguration,
   _getDefaultWebActionsForGlobalAgent,
-  _getInteractiveContentToolConfiguration,
   _getToolsetsToolsConfiguration,
 } from "@app/lib/api/assistant/global_agents/tools";
 import { dummyModelConfiguration } from "@app/lib/api/assistant/global_agents/utils";
@@ -507,13 +506,6 @@ function _getDustLikeGlobalAgent(
     });
   }
 
-  actions.push(
-    ..._getInteractiveContentToolConfiguration({
-      agentId,
-      mcpServerViews,
-    })
-  );
-
   // Fix the action ids.
   actions.forEach((action, i) => {
     action.id = -i;
@@ -523,6 +515,7 @@ function _getDustLikeGlobalAgent(
     ...dustAgent,
     status: "active",
     actions,
+    skills: ["frames"],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
   };
 }

--- a/front/lib/api/assistant/global_agents/configurations/google.ts
+++ b/front/lib/api/assistant/global_agents/configurations/google.ts
@@ -4,10 +4,7 @@ import {
   globalAgentWebSearchGuidelines,
 } from "@app/lib/api/assistant/global_agents/guidelines";
 import type { MCPServerViewsForGlobalAgentsMap } from "@app/lib/api/assistant/global_agents/tools";
-import {
-  _getDefaultWebActionsForGlobalAgent,
-  _getInteractiveContentToolConfiguration,
-} from "@app/lib/api/assistant/global_agents/tools";
+import { _getDefaultWebActionsForGlobalAgent } from "@app/lib/api/assistant/global_agents/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";
 import type { AgentConfigurationType } from "@app/types";
@@ -58,11 +55,8 @@ export function _getGeminiProGlobalAgent({
         agentId: sId,
         mcpServerViews,
       }),
-      ..._getInteractiveContentToolConfiguration({
-        agentId: sId,
-        mcpServerViews,
-      }),
     ],
+    skills: ["frames"],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
     templateId: null,
     requestedGroupIds: [],

--- a/front/lib/api/assistant/global_agents/configurations/helper.ts
+++ b/front/lib/api/assistant/global_agents/configurations/helper.ts
@@ -5,7 +5,6 @@ import type { MCPServerViewsForGlobalAgentsMap } from "@app/lib/api/assistant/gl
 import {
   _getAgentRouterToolsConfiguration,
   _getDefaultWebActionsForGlobalAgent,
-  _getInteractiveContentToolConfiguration,
 } from "@app/lib/api/assistant/global_agents/tools";
 import { dummyModelConfiguration } from "@app/lib/api/assistant/global_agents/utils";
 import type { Authenticator } from "@app/lib/auth";
@@ -90,10 +89,6 @@ The user you're interacting with is granted with the role ${role}. Their name is
       agentId: sId,
       mcpServerViews,
     }),
-    ..._getInteractiveContentToolConfiguration({
-      agentId: sId,
-      mcpServerViews,
-    }),
   ];
 
   return {
@@ -111,6 +106,7 @@ The user you're interacting with is granted with the role ${role}. Their name is
     scope: "global",
     model: model,
     actions,
+    skills: ["frames"],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
     templateId: null,
     requestedGroupIds: [],

--- a/front/lib/api/assistant/global_agents/configurations/mistral.ts
+++ b/front/lib/api/assistant/global_agents/configurations/mistral.ts
@@ -4,10 +4,7 @@ import {
   globalAgentWebSearchGuidelines,
 } from "@app/lib/api/assistant/global_agents/guidelines";
 import type { MCPServerViewsForGlobalAgentsMap } from "@app/lib/api/assistant/global_agents/tools";
-import {
-  _getDefaultWebActionsForGlobalAgent,
-  _getInteractiveContentToolConfiguration,
-} from "@app/lib/api/assistant/global_agents/tools";
+import { _getDefaultWebActionsForGlobalAgent } from "@app/lib/api/assistant/global_agents/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";
 import type { AgentConfigurationType } from "@app/types";
@@ -68,11 +65,8 @@ export function _getMistralLargeGlobalAgent({
         agentId: sId,
         mcpServerViews,
       }),
-      ..._getInteractiveContentToolConfiguration({
-        agentId: sId,
-        mcpServerViews,
-      }),
     ],
+    skills: ["frames"],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
     templateId: null,
     requestedGroupIds: [],
@@ -124,11 +118,8 @@ export function _getMistralMediumGlobalAgent({
         agentId: sId,
         mcpServerViews,
       }),
-      ..._getInteractiveContentToolConfiguration({
-        agentId: sId,
-        mcpServerViews,
-      }),
     ],
+    skills: ["frames"],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
     templateId: null,
     requestedGroupIds: [],
@@ -175,11 +166,8 @@ export function _getMistralSmallGlobalAgent({
         agentId: sId,
         mcpServerViews,
       }),
-      ..._getInteractiveContentToolConfiguration({
-        agentId: sId,
-        mcpServerViews,
-      }),
     ],
+    skills: ["frames"],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
     templateId: null,
     requestedGroupIds: [],

--- a/front/lib/api/assistant/global_agents/configurations/openai.ts
+++ b/front/lib/api/assistant/global_agents/configurations/openai.ts
@@ -4,10 +4,7 @@ import {
   globalAgentWebSearchGuidelines,
 } from "@app/lib/api/assistant/global_agents/guidelines";
 import type { MCPServerViewsForGlobalAgentsMap } from "@app/lib/api/assistant/global_agents/tools";
-import {
-  _getDefaultWebActionsForGlobalAgent,
-  _getInteractiveContentToolConfiguration,
-} from "@app/lib/api/assistant/global_agents/tools";
+import { _getDefaultWebActionsForGlobalAgent } from "@app/lib/api/assistant/global_agents/tools";
 import type { Authenticator } from "@app/lib/auth";
 import type { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";
 import type {
@@ -70,11 +67,8 @@ export function _getGPT35TurboGlobalAgent({
         agentId: sId,
         mcpServerViews,
       }),
-      ..._getInteractiveContentToolConfiguration({
-        agentId: sId,
-        mcpServerViews,
-      }),
     ],
+    skills: ["frames"],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
     templateId: null,
     requestedGroupIds: [],
@@ -129,11 +123,8 @@ export function _getGPT4GlobalAgent({
         agentId: sId,
         mcpServerViews,
       }),
-      ..._getInteractiveContentToolConfiguration({
-        agentId: sId,
-        mcpServerViews,
-      }),
     ],
+    skills: ["frames"],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
     templateId: null,
     requestedGroupIds: [],
@@ -194,11 +185,8 @@ export function _getGPT5GlobalAgent({
         agentId: sId,
         mcpServerViews,
       }),
-      ..._getInteractiveContentToolConfiguration({
-        agentId: sId,
-        mcpServerViews,
-      }),
     ],
+    skills: ["frames"],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
     templateId: null,
     requestedGroupIds: [],
@@ -261,11 +249,8 @@ export function _getGPT5ThinkingGlobalAgent({
         agentId: sId,
         mcpServerViews,
       }),
-      ..._getInteractiveContentToolConfiguration({
-        agentId: sId,
-        mcpServerViews,
-      }),
     ],
+    skills: ["frames"],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
     templateId: null,
     requestedGroupIds: [],
@@ -324,11 +309,8 @@ export function _getGPT5MiniGlobalAgent({
         agentId: sId,
         mcpServerViews,
       }),
-      ..._getInteractiveContentToolConfiguration({
-        agentId: sId,
-        mcpServerViews,
-      }),
     ],
+    skills: ["frames"],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
     templateId: null,
     requestedGroupIds: [],
@@ -386,11 +368,8 @@ export function _getGPT5NanoGlobalAgent({
         agentId: sId,
         mcpServerViews,
       }),
-      ..._getInteractiveContentToolConfiguration({
-        agentId: sId,
-        mcpServerViews,
-      }),
     ],
+    skills: ["frames"],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
     templateId: null,
     requestedGroupIds: [],
@@ -446,11 +425,8 @@ export function _getO3MiniGlobalAgent({
         agentId: sId,
         mcpServerViews,
       }),
-      ..._getInteractiveContentToolConfiguration({
-        agentId: sId,
-        mcpServerViews,
-      }),
     ],
+    skills: ["frames"],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
     templateId: null,
     requestedGroupIds: [],
@@ -501,11 +477,8 @@ export function _getO1GlobalAgent({
         agentId: sId,
         mcpServerViews,
       }),
-      ..._getInteractiveContentToolConfiguration({
-        agentId: sId,
-        mcpServerViews,
-      }),
     ],
+    skills: ["frames"],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
     templateId: null,
     requestedGroupIds: [],
@@ -601,11 +574,8 @@ export function _getO1HighReasoningGlobalAgent({
         agentId: sId,
         mcpServerViews,
       }),
-      ..._getInteractiveContentToolConfiguration({
-        agentId: sId,
-        mcpServerViews,
-      }),
     ],
+    skills: ["frames"],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
     templateId: null,
     requestedGroupIds: [],
@@ -656,11 +626,8 @@ export function _getO3GlobalAgent({
         agentId: sId,
         mcpServerViews,
       }),
-      ..._getInteractiveContentToolConfiguration({
-        agentId: sId,
-        mcpServerViews,
-      }),
     ],
+    skills: ["frames"],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
     templateId: null,
     requestedGroupIds: [],

--- a/front/lib/api/assistant/global_agents/tools.ts
+++ b/front/lib/api/assistant/global_agents/tools.ts
@@ -194,39 +194,3 @@ export function _getAgentRouterToolsConfiguration({
     },
   ];
 }
-
-export function _getInteractiveContentToolConfiguration({
-  agentId,
-  mcpServerViews,
-}: {
-  agentId: GLOBAL_AGENTS_SID;
-  mcpServerViews: MCPServerViewsForGlobalAgentsMap;
-}): ServerSideMCPServerConfigurationType[] {
-  const { interactive_content: interactiveContentMCPServerView } =
-    mcpServerViews;
-
-  if (!interactiveContentMCPServerView) {
-    return [];
-  }
-
-  return [
-    {
-      id: -1,
-      sId: agentId + "-interactive-content",
-      type: "mcp_server_configuration",
-      name: "interactive_content",
-      description: "Create & update Interactive Content files.",
-      mcpServerViewId: interactiveContentMCPServerView.sId,
-      internalMCPServerId: interactiveContentMCPServerView.internalMCPServerId,
-      dataSources: null,
-      tables: null,
-      childAgentId: null,
-      additionalConfiguration: {},
-      timeFrame: null,
-      dustAppConfiguration: null,
-      jsonSchema: null,
-      secretName: null,
-      dustProject: null,
-    },
-  ];
-}

--- a/front/lib/api/assistant/jit/skills.ts
+++ b/front/lib/api/assistant/jit/skills.ts
@@ -1,14 +1,13 @@
 import type { ServerSideMCPServerConfigurationType } from "@app/lib/actions/mcp";
 import type { Authenticator } from "@app/lib/auth";
-import { AgentSkillModel } from "@app/lib/models/agent/agent_skill";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import logger from "@app/logger/logger";
 import type {
   AgentConfigurationType,
   ConversationWithoutContentType,
 } from "@app/types";
-import { isGlobalAgentId } from "@app/types";
 
 /**
  * Get the skill_management MCP server if the agent has configured skills.
@@ -18,30 +17,13 @@ export async function getSkillManagementServer(
   agentConfiguration: AgentConfigurationType,
   conversation: ConversationWithoutContentType
 ): Promise<ServerSideMCPServerConfigurationType | null> {
-  const owner = auth.getNonNullableWorkspace();
+  const refs = await SkillResource.getSkillReferencesForAgent(
+    auth,
+    agentConfiguration
+  );
 
-  // For global agents, check if skills are defined in the config.
-  // Ideally, we would want to take in input an AgentResource that would have bundled the logic
-  // about loading skills and exposes a unified interface.
-  if (isGlobalAgentId(agentConfiguration.sId)) {
-    if (
-      !agentConfiguration.skills?.length ||
-      agentConfiguration.skills.length === 0
-    ) {
-      return null;
-    }
-  } else {
-    // For non-global agents, check if there are skills configured on the agent.
-    const skillCount = await AgentSkillModel.count({
-      where: {
-        agentConfigurationId: agentConfiguration.id,
-        workspaceId: owner.id,
-      },
-    });
-
-    if (skillCount === 0) {
-      return null;
-    }
+  if (refs.length === 0) {
+    return null;
   }
 
   const skillManagementView =

--- a/front/lib/api/assistant/jit_actions.test.ts
+++ b/front/lib/api/assistant/jit_actions.test.ts
@@ -19,8 +19,8 @@ import { FileFactory } from "@app/tests/utils/FileFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import type {
+  AgentConfigurationType,
   ConversationType,
-  LightAgentConfigurationType,
   WorkspaceType,
 } from "@app/types";
 
@@ -45,7 +45,7 @@ describe("getJITServers", () => {
   let workspace: WorkspaceType;
   let conversationsSpace: SpaceResource;
   let conversation: ConversationType;
-  let agentConfig: LightAgentConfigurationType;
+  let agentConfig: AgentConfigurationType;
 
   beforeEach(async () => {
     const setup = await createResourceTest({ role: "admin" });

--- a/front/lib/api/assistant/jit_actions.ts
+++ b/front/lib/api/assistant/jit_actions.ts
@@ -14,8 +14,8 @@ import { getSchedulesManagementServer } from "@app/lib/api/assistant/jit/schedul
 import { getSkillManagementServer } from "@app/lib/api/assistant/jit/skills";
 import type { Authenticator } from "@app/lib/auth";
 import type {
+  AgentConfigurationType,
   ConversationWithoutContentType,
-  LightAgentConfigurationType,
 } from "@app/types";
 
 export async function getJITServers(
@@ -25,7 +25,7 @@ export async function getJITServers(
     conversation,
     attachments,
   }: {
-    agentConfiguration: LightAgentConfigurationType;
+    agentConfiguration: AgentConfigurationType;
     conversation: ConversationWithoutContentType;
     attachments: ConversationAttachmentType[];
   }

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -776,6 +776,8 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     agentConfiguration: LightAgentConfigurationType | AgentConfigurationType
   ): Promise<SkillResource[]> {
     // For global agents, skills are defined in the config, not in the database.
+    // Ideally, we would want to take in input an AgentResource that would have bundled the logic
+    // about loading skills and exposes a unified interface.
     if (
       isGlobalAgentId(agentConfiguration.sId) &&
       "skills" in agentConfiguration &&
@@ -795,7 +797,9 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       },
     });
 
-    return this.fetchBySkillReferences(auth, agentSkills, { agentConfiguration });
+    return this.fetchBySkillReferences(auth, agentSkills, {
+      agentConfiguration,
+    });
   }
 
   static modelIdToSId({

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1835,7 +1835,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     if (!hasSkill) {
       return new Err(
         new Error(
-          `Skill ${this.name} was not added to agent ${agentConfiguration.name}.`
+          `Skill ${this.name} is not equipped by agent ${agentConfiguration.name}.`
         )
       );
     }

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -773,7 +773,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
   static async listByAgentConfiguration(
     auth: Authenticator,
-    agentConfiguration: LightAgentConfigurationType | AgentConfigurationType
+    agentConfiguration: AgentConfigurationType
   ): Promise<SkillResource[]> {
     const refs = await this.getSkillReferencesForAgent(
       auth,
@@ -796,7 +796,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
    */
   static async getSkillReferencesForAgent(
     auth: Authenticator,
-    agentConfiguration: LightAgentConfigurationType | AgentConfigurationType
+    agentConfiguration: AgentConfigurationType
   ): Promise<
     {
       customSkillId: ModelId | null;

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/skills.test.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/skills.test.ts
@@ -125,24 +125,6 @@ describe("GET /api/w/[wId]/assistant/agent_configurations/[aId]/skills", () => {
     expect(data.error.message).toBe("Invalid agent configuration ID.");
   });
 
-  it("should return empty array for global agents", async () => {
-    const { req, res, workspace } = await setupTest();
-
-    // Use a global agent sId format
-    req.query = {
-      ...req.query,
-      wId: workspace.sId,
-      aId: "dust",
-    };
-
-    await handler(req, res);
-
-    // Global agents return empty skills array (not yet implemented)
-    expect(res._getStatusCode()).toBe(200);
-    const data = res._getJSONData();
-    expect(data.skills).toEqual([]);
-  });
-
   it("should only return skills from the correct workspace", async () => {
     const { req, res, workspace, user } = await setupTest();
 

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/skills.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/skills.ts
@@ -46,9 +46,19 @@ async function handler(
   switch (req.method) {
     case "GET": {
       if (isGlobalAgentId(agent.sId)) {
-        // TODO(skills 2025-12-09): Implement fetching skills for global agents.
+        const fullAgent = await getAgentConfiguration(auth, {
+          agentId: aId,
+          variant: "full",
+        });
+
+        if (!fullAgent?.skills?.length) {
+          return res.status(200).json({ skills: [] });
+        }
+
+        const skills = await SkillResource.fetchByIds(auth, fullAgent.skills);
+
         return res.status(200).json({
-          skills: [],
+          skills: skills.map((s) => s.toJSON(auth)),
         });
       }
 

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/skills.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/skills.ts
@@ -6,7 +6,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
-import { isGlobalAgentId, isString } from "@app/types";
+import { isString } from "@app/types";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 
 export interface GetAgentSkillsResponseBody {
@@ -31,7 +31,7 @@ async function handler(
 
   const agent = await getAgentConfiguration(auth, {
     agentId: aId,
-    variant: "light",
+    variant: "full",
   });
   if (!agent) {
     return apiError(req, res, {
@@ -45,23 +45,6 @@ async function handler(
 
   switch (req.method) {
     case "GET": {
-      if (isGlobalAgentId(agent.sId)) {
-        const fullAgent = await getAgentConfiguration(auth, {
-          agentId: aId,
-          variant: "full",
-        });
-
-        if (!fullAgent?.skills?.length) {
-          return res.status(200).json({ skills: [] });
-        }
-
-        const skills = await SkillResource.fetchByIds(auth, fullAgent.skills);
-
-        return res.status(200).json({
-          skills: skills.map((s) => s.toJSON(auth)),
-        });
-      }
-
       const skills = await SkillResource.listByAgentConfiguration(auth, agent);
 
       return res.status(200).json({

--- a/front/tests/utils/AgentConfigurationFactory.ts
+++ b/front/tests/utils/AgentConfigurationFactory.ts
@@ -3,7 +3,7 @@ import assert from "assert";
 import { createAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import type { Authenticator } from "@app/lib/auth";
 import type {
-  LightAgentConfigurationType,
+  AgentConfigurationType,
   ModelIdType,
   ModelProviderIdType,
 } from "@app/types";
@@ -14,14 +14,14 @@ export class AgentConfigurationFactory {
     overrides: Partial<{
       name: string;
       description: string;
-      scope: Exclude<LightAgentConfigurationType["scope"], "global">;
+      scope: Exclude<AgentConfigurationType["scope"], "global">;
       model: {
         providerId: ModelProviderIdType;
         modelId: ModelIdType;
         temperature?: number;
       };
     }> = {}
-  ): Promise<LightAgentConfigurationType> {
+  ): Promise<AgentConfigurationType> {
     const name = overrides.name ?? "Test Agent";
     const description = overrides.description ?? "Test Agent Description";
     const scope = overrides.scope ?? "visible";
@@ -54,7 +54,7 @@ export class AgentConfigurationFactory {
       throw result.error;
     }
 
-    return result.value;
+    return { ...result.value, actions: [] };
   }
 
   /**
@@ -63,13 +63,13 @@ export class AgentConfigurationFactory {
    */
   static async updateTestAgent(
     auth: Authenticator,
-    agentSId: string,
+    agentId: string,
     overrides: Partial<{
       name: string;
       description: string;
       instructions: string;
     }> = {}
-  ): Promise<LightAgentConfigurationType> {
+  ): Promise<AgentConfigurationType> {
     const user = auth.user();
     assert(user, "User is required");
 
@@ -89,13 +89,13 @@ export class AgentConfigurationFactory {
       requestedSpaceIds: [],
       tags: [],
       editors: [user.toJSON()],
-      agentConfigurationId: agentSId,
+      agentConfigurationId: agentId,
     });
 
     if (result.isErr()) {
       throw result.error;
     }
 
-    return result.value;
+    return { ...result.value, actions: [] };
   }
 }

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -2,6 +2,7 @@ import type {
   MCPServerConfigurationType,
   MCPToolConfigurationType,
 } from "@app/lib/actions/mcp";
+import type { GlobalSkillId } from "@app/lib/resources/skill/global/registry";
 import type {
   ModelIdType,
   ModelProviderIdType,
@@ -162,6 +163,7 @@ export type LightAgentConfigurationType = {
 export type AgentConfigurationType = LightAgentConfigurationType & {
   // If empty, no actions are performed, otherwise the actions are performed.
   actions: MCPServerConfigurationType[];
+  skills?: GlobalSkillId[];
 };
 
 export interface TemplateAgentConfigurationType {


### PR DESCRIPTION
## Description

- This PR adds the ability to add skills to a global agent.
- Also migrates existing global agents to use the Frames skill (not sure why we add Frames to global agents?).

## Tests

- Tested locally.

## Risk

- Medium. Major change in behavior for the global agents.
- Existing conversations that were using Frame have already been backfilled to have the skill enabled to prevent the model assuming the skill had already been enabled before.

## Deploy Plan

- Deploy front.
