### PR TITLE
Fix update of requestedSpaceIds when deleting space

### DIFF
--- a/front/lib/api/spaces.test.ts
+++ b/front/lib/api/spaces.test.ts
@@ -9,10 +9,7 @@ import {
 import { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
-import {
-  SkillConfigurationModel,
-  SkillMCPServerConfigurationModel,
-} from "@app/lib/models/skill";
+import { SkillConfigurationModel } from "@app/lib/models/skill";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { GroupSpaceMemberResource } from "@app/lib/resources/group_space_resource";
@@ -1051,17 +1048,11 @@ describe("softDeleteSpaceAndLaunchScrubWorkflow", () => {
         space!
       );
 
-      // Create a skill with the space in requestedSpaceIds
+      // Create a skill with the space in requestedSpaceIds and the MCP server view
       const skill = await SkillFactory.create(adminAuth, {
         name: "Test Skill With Tool",
         requestedSpaceIds: [space!.id],
-      });
-
-      // Link the MCP server view to the skill
-      await SkillMCPServerConfigurationModel.create({
-        workspaceId: workspace.id,
-        skillConfigurationId: skill.id,
-        mcpServerViewId: serverView.id,
+        mcpServerViews: [serverView],
       });
 
       // Verify the skill has the space in its requestedSpaceIds

--- a/front/lib/api/spaces.test.ts
+++ b/front/lib/api/spaces.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
 import { getProjectConversationsDatasourceName } from "@app/lib/api/projects";
 import {
   createSpaceAndGroup,
@@ -7,16 +8,26 @@ import {
 } from "@app/lib/api/spaces";
 import { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
+import {
+  SkillConfigurationModel,
+  SkillMCPServerConfigurationModel,
+} from "@app/lib/models/skill";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { GroupSpaceMemberResource } from "@app/lib/resources/group_space_resource";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { GroupSpaceModel } from "@app/lib/resources/storage/models/group_spaces";
 import type { UserResource } from "@app/lib/resources/user_resource";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { KeyFactory } from "@app/tests/utils/KeyFactory";
+import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
+import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
 import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
 import { Err, Ok, SPACE_KINDS } from "@app/types";
@@ -1009,6 +1020,152 @@ describe("softDeleteSpaceAndLaunchScrubWorkflow", () => {
         );
         expect(deleteResult.isOk()).toBe(true);
       }
+    });
+  });
+
+  describe("requestedSpaceIds cleanup", () => {
+    it("should remove deleted space from skill requestedSpaceIds", async () => {
+      // Create a non-restricted regular space (accessible via global group)
+      const spaceResult = await createSpaceAndGroup(
+        adminAuth,
+        {
+          name: "Test Space With Tool",
+          isRestricted: false,
+          spaceKind: "regular",
+          managementMode: "manual",
+          memberIds: [],
+        },
+        { ignoreWorkspaceLimit: true }
+      );
+      expect(spaceResult.isOk()).toBe(true);
+      const space = spaceResult.isOk() ? spaceResult.value : null;
+      expect(space).not.toBeNull();
+
+      // Create an MCP server and view in the space
+      const server = await RemoteMCPServerFactory.create(workspace, {
+        name: "Test Server",
+      });
+      const serverView = await MCPServerViewFactory.create(
+        workspace,
+        server.sId,
+        space!
+      );
+
+      // Create a skill with the space in requestedSpaceIds
+      const skill = await SkillFactory.create(adminAuth, {
+        name: "Test Skill With Tool",
+        requestedSpaceIds: [space!.id],
+      });
+
+      // Link the MCP server view to the skill
+      await SkillMCPServerConfigurationModel.create({
+        workspaceId: workspace.id,
+        skillConfigurationId: skill.id,
+        mcpServerViewId: serverView.id,
+      });
+
+      // Verify the skill has the space in its requestedSpaceIds
+      const skillBefore = await SkillResource.fetchById(adminAuth, skill.sId);
+      expect(skillBefore).not.toBeNull();
+      expect(skillBefore!.requestedSpaceIds).toContain(space!.id);
+
+      // Delete the space
+      const deleteResult = await softDeleteSpaceAndLaunchScrubWorkflow(
+        adminAuth,
+        space!,
+        true // force delete
+      );
+      expect(deleteResult.isOk()).toBe(true);
+
+      // Verify the skill's requestedSpaceIds no longer contains the deleted space
+      // Note: We query the model directly because the MCP server views are cleaned up
+      // asynchronously by the scrub workflow and would fail permission checks
+      const skillAfter = await SkillConfigurationModel.findOne({
+        where: { id: skill.id, workspaceId: workspace.id },
+      });
+      expect(skillAfter).not.toBeNull();
+      expect(skillAfter!.requestedSpaceIds).not.toContain(space!.id);
+      expect(skillAfter!.requestedSpaceIds).toHaveLength(0);
+    });
+
+    it("should only remove deleted space from agent requestedSpaceIds, keeping other spaces", async () => {
+      // Create two non-restricted regular spaces (accessible via global group)
+      const space1Result = await createSpaceAndGroup(
+        adminAuth,
+        {
+          name: "Test Space 1",
+          isRestricted: false,
+          spaceKind: "regular",
+          managementMode: "manual",
+          memberIds: [],
+        },
+        { ignoreWorkspaceLimit: true }
+      );
+      expect(space1Result.isOk()).toBe(true);
+      const space1 = space1Result.isOk() ? space1Result.value : null;
+
+      const space2Result = await createSpaceAndGroup(
+        adminAuth,
+        {
+          name: "Test Space 2",
+          isRestricted: false,
+          spaceKind: "regular",
+          managementMode: "manual",
+          memberIds: [],
+        },
+        { ignoreWorkspaceLimit: true }
+      );
+      expect(space2Result.isOk()).toBe(true);
+      const space2 = space2Result.isOk() ? space2Result.value : null;
+
+      // Create an agent with both spaces in requestedSpaceIds
+      const agentConfig = await AgentConfigurationFactory.createTestAgent(
+        adminAuth,
+        {
+          name: "Test Agent With Two Spaces",
+        }
+      );
+
+      // Update the agent's requestedSpaceIds to include both spaces
+      await AgentConfigurationModel.update(
+        {
+          requestedSpaceIds: [space1!.id, space2!.id],
+        },
+        {
+          where: {
+            id: agentConfig.id,
+            workspaceId: workspace.id,
+          },
+        }
+      );
+
+      // Verify the agent has both spaces in its requestedSpaceIds (using sIds)
+      const agentsBefore = await getAgentConfigurations(adminAuth, {
+        agentIds: [agentConfig.sId],
+        variant: "light",
+      });
+      expect(agentsBefore).toHaveLength(1);
+      expect(agentsBefore[0].requestedSpaceIds).toHaveLength(2);
+      expect(agentsBefore[0].requestedSpaceIds).toContain(space1!.sId);
+      expect(agentsBefore[0].requestedSpaceIds).toContain(space2!.sId);
+
+      // Delete space1
+      const deleteResult = await softDeleteSpaceAndLaunchScrubWorkflow(
+        adminAuth,
+        space1!,
+        true // force delete
+      );
+      expect(deleteResult.isOk()).toBe(true);
+
+      // Verify the agent's requestedSpaceIds no longer contains space1 but still has space2
+      const agentsAfter = await getAgentConfigurations(adminAuth, {
+        agentIds: [agentConfig.sId],
+        variant: "light",
+      });
+      expect(agentsAfter).toHaveLength(1);
+      expect(agentsAfter[0].requestedSpaceIds).toHaveLength(1);
+      expect(agentsAfter[0].requestedSpaceIds).toContain(space2!.sId);
+      expect(agentsAfter[0].requestedSpaceIds).not.toContain(space1!.sId);
     });
   });
 });

--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -11,6 +11,8 @@ import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFa
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { GroupSpaceFactory } from "@app/tests/utils/GroupSpaceFactory";
+import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
+import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
 import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 
@@ -731,132 +733,176 @@ describe("SkillResource", () => {
     });
   });
 
-  describe("listByRequestedSpaceId", () => {
-    it("should return skills that have a specific space in their requestedSpaceIds", async () => {
-      const space1 = await SpaceFactory.regular(testContext.workspace);
-      const space2 = await SpaceFactory.regular(testContext.workspace);
-      await GroupSpaceFactory.associate(space1, testContext.globalGroup);
-      await GroupSpaceFactory.associate(space2, testContext.globalGroup);
-
-      // Create a skill with space1 in requestedSpaceIds.
-      const skillWithSpace1 = await SkillFactory.create(
-        testContext.authenticator,
-        {
-          name: "Skill With Space 1",
-          requestedSpaceIds: [space1.id],
-        }
-      );
-
-      // Create a skill with both spaces in requestedSpaceIds.
-      const skillWithBothSpaces = await SkillFactory.create(
-        testContext.authenticator,
-        {
-          name: "Skill With Both Spaces",
-          requestedSpaceIds: [space1.id, space2.id],
-        }
-      );
-
-      // Create a skill with only space2 in requestedSpaceIds.
-      await SkillFactory.create(testContext.authenticator, {
-        name: "Skill With Space 2 Only",
-        requestedSpaceIds: [space2.id],
-      });
-
-      // Create a skill with no requestedSpaceIds.
-      await SkillFactory.create(testContext.authenticator, {
-        name: "Skill With No Spaces",
-        requestedSpaceIds: [],
-      });
-
-      // List skills by space1.
-      const skillsWithSpace1 = await SkillResource.listByRequestedSpaceId(
-        testContext.authenticator,
-        space1.id
-      );
-
-      expect(skillsWithSpace1).toHaveLength(2);
-      const skillIds = skillsWithSpace1.map((s) => s.id);
-      expect(skillIds).toContain(skillWithSpace1.id);
-      expect(skillIds).toContain(skillWithBothSpaces.id);
-    });
-
-    it("should return empty array when no skills have the space", async () => {
+  describe("listByMCPServerViewIds", () => {
+    it("should return skills that use any of the given MCP server view IDs", async () => {
       const space = await SpaceFactory.regular(testContext.workspace);
       await GroupSpaceFactory.associate(space, testContext.globalGroup);
 
-      // Create a skill without this space.
+      const server = await RemoteMCPServerFactory.create(testContext.workspace);
+      const serverView = await MCPServerViewFactory.create(
+        testContext.workspace,
+        server.sId,
+        space
+      );
+
+      // Create a skill with the MCP server view
+      const skill1 = await SkillFactory.create(testContext.authenticator, {
+        name: "Skill With MCP",
+        requestedSpaceIds: [space.id],
+        mcpServerViews: [serverView],
+      });
+
+      // Create a skill without MCP server views
       await SkillFactory.create(testContext.authenticator, {
-        name: "Skill Without Space",
+        name: "Skill Without MCP",
         requestedSpaceIds: [],
       });
 
-      const skills = await SkillResource.listByRequestedSpaceId(
+      // Test that skills with the MCP server view are returned
+      const skillsWithMCP = await SkillResource.listByMCPServerViewIds(
         testContext.authenticator,
-        space.id
+        [serverView.id]
       );
+      expect(skillsWithMCP).toHaveLength(1);
+      expect(skillsWithMCP[0].id).toBe(skill1.id);
 
-      expect(skills).toHaveLength(0);
+      // Test with empty array returns empty
+      const emptyResult = await SkillResource.listByMCPServerViewIds(
+        testContext.authenticator,
+        []
+      );
+      expect(emptyResult).toHaveLength(0);
+
+      // Test with non-existent IDs returns empty
+      const nonExistentResult = await SkillResource.listByMCPServerViewIds(
+        testContext.authenticator,
+        [999999]
+      );
+      expect(nonExistentResult).toHaveLength(0);
     });
   });
 
-  describe("updateRequestedSpaceIds", () => {
-    it("should update the requestedSpaceIds for a skill", async () => {
-      const space1 = await SpaceFactory.regular(testContext.workspace);
-      const space2 = await SpaceFactory.regular(testContext.workspace);
-      await GroupSpaceFactory.associate(space1, testContext.globalGroup);
-      await GroupSpaceFactory.associate(space2, testContext.globalGroup);
+  describe("listByDataSourceViewIds", () => {
+    it("should return skills that use any of the given data source view IDs", async () => {
+      const space = await SpaceFactory.regular(testContext.workspace);
+      await GroupSpaceFactory.associate(space, testContext.globalGroup);
 
-      const skill = await SkillFactory.create(testContext.authenticator, {
-        name: "Skill To Update",
-        requestedSpaceIds: [space1.id],
+      const dsv1 = await DataSourceViewFactory.folder(
+        testContext.workspace,
+        space,
+        testContext.user
+      );
+      const dsv2 = await DataSourceViewFactory.folder(
+        testContext.workspace,
+        space,
+        testContext.user
+      );
+      const skill1 = await SkillFactory.create(testContext.authenticator, {
+        name: "Skill With DSV1",
+        requestedSpaceIds: [space.id],
       });
 
-      // Verify initial state.
-      expect(skill.requestedSpaceIds).toEqual([space1.id]);
+      await createDataSourceConfiguration({
+        dataSourceView: dsv1,
+        parentsIn: ["node1"],
+        skillId: skill1.id,
+      });
 
-      // Update to include both spaces.
-      const result = await skill.updateRequestedSpaceIds(
-        [space1.id, space2.id],
-        {}
-      );
-      expect(result.isOk()).toBe(true);
+      // Create another skill without data source configuration
+      await SkillFactory.create(testContext.authenticator, {
+        name: "Skill Without DSV",
+        requestedSpaceIds: [],
+      });
 
-      // Fetch the skill again to verify the update.
-      const updatedSkill = await SkillResource.fetchByModelIdWithAuth(
+      // Test that skills with dsv1 are returned
+      const skillsWithDsv1 = await SkillResource.listByDataSourceViewIds(
         testContext.authenticator,
-        skill.id
+        [dsv1.id]
       );
-      expect(updatedSkill).not.toBeNull();
-      expect(updatedSkill!.requestedSpaceIds.map((id) => Number(id))).toEqual([
-        space1.id,
-        space2.id,
-      ]);
+      expect(skillsWithDsv1).toHaveLength(1);
+      expect(skillsWithDsv1[0].id).toBe(skill1.id);
+
+      // Test with non-existent ID returns empty
+      const emptyResult = await SkillResource.listByDataSourceViewIds(
+        testContext.authenticator,
+        [dsv2.id]
+      );
+      expect(emptyResult).toHaveLength(0);
+
+      // Test with empty array returns empty
+      const emptyArrayResult = await SkillResource.listByDataSourceViewIds(
+        testContext.authenticator,
+        []
+      );
+      expect(emptyArrayResult).toHaveLength(0);
     });
+  });
 
-    it("should remove a space from requestedSpaceIds", async () => {
-      const space1 = await SpaceFactory.regular(testContext.workspace);
-      const space2 = await SpaceFactory.regular(testContext.workspace);
-      await GroupSpaceFactory.associate(space1, testContext.globalGroup);
-      await GroupSpaceFactory.associate(space2, testContext.globalGroup);
+  describe("getAttachedKnowledge", () => {
+    it("should return attached knowledge from data source configurations", async () => {
+      const space = await SpaceFactory.regular(testContext.workspace);
+      await GroupSpaceFactory.associate(space, testContext.globalGroup);
+
+      const dsv = await DataSourceViewFactory.folder(
+        testContext.workspace,
+        space,
+        testContext.user
+      );
 
       const skill = await SkillFactory.create(testContext.authenticator, {
-        name: "Skill To Update",
-        requestedSpaceIds: [space1.id, space2.id],
+        name: "Skill With Knowledge",
+        requestedSpaceIds: [space.id],
       });
 
-      // Remove space2 from the skill.
-      const result = await skill.updateRequestedSpaceIds([space1.id], {});
-      expect(result.isOk()).toBe(true);
+      // Add data source configuration
+      await createDataSourceConfiguration({
+        dataSourceView: dsv,
+        parentsIn: ["node1", "node2"],
+        skillId: skill.id,
+      });
 
-      // Fetch the skill again to verify the update.
-      const updatedSkill = await SkillResource.fetchByModelIdWithAuth(
+      // Re-fetch the skill to get the updated data source configurations
+      const freshSkill = await SkillResource.fetchByModelIdWithAuth(
         testContext.authenticator,
         skill.id
       );
-      expect(updatedSkill).not.toBeNull();
-      expect(updatedSkill!.requestedSpaceIds.map((id) => Number(id))).toEqual([
-        space1.id,
-      ]);
+      expect(freshSkill).not.toBeNull();
+
+      const attachedKnowledge = await freshSkill!.getAttachedKnowledge(
+        testContext.authenticator
+      );
+
+      expect(attachedKnowledge).toHaveLength(2);
+      expect(attachedKnowledge[0].nodeId).toBe("node1");
+      expect(attachedKnowledge[1].nodeId).toBe("node2");
+      expect(attachedKnowledge[0].dataSourceView.id).toBe(dsv.id);
+    });
+  });
+
+  describe("computeRequestedSpaceIds", () => {
+    it("should compute space IDs from attached knowledge", async () => {
+      const space = await SpaceFactory.regular(testContext.workspace);
+      await GroupSpaceFactory.associate(space, testContext.globalGroup);
+
+      const dsv = await DataSourceViewFactory.folder(
+        testContext.workspace,
+        space,
+        testContext.user
+      );
+
+      const attachedKnowledge: SkillAttachedKnowledge[] = [
+        { dataSourceView: dsv, nodeId: "node1" },
+      ];
+
+      const requestedSpaceIds = await SkillResource.computeRequestedSpaceIds(
+        testContext.authenticator,
+        {
+          mcpServerViews: [],
+          attachedKnowledge,
+        }
+      );
+
+      expect(requestedSpaceIds).toContain(space.id);
     });
   });
 

--- a/front/pages/api/w/[wId]/skills/[sId]/index.ts
+++ b/front/pages/api/w/[wId]/skills/[sId]/index.ts
@@ -209,12 +209,6 @@ async function handler(
         });
       }
 
-      const spaceIdsFromMcpServerViews =
-        await MCPServerViewResource.listSpaceRequirementsByIds(
-          auth,
-          mcpServerViewIds
-        );
-
       // Validate all data source views from attached knowledge exist and user has access.
       const { attachedKnowledge } = body;
       const dataSourceViewIds = uniq(
@@ -246,14 +240,13 @@ async function handler(
         })
       );
 
-      const spaceIdsFromAttachedKnowledge = dataSourceViews.map(
-        (dsv) => dsv.space.id
+      const requestedSpaceIds = await SkillResource.computeRequestedSpaceIds(
+        auth,
+        {
+          mcpServerViews,
+          attachedKnowledge: attachedKnowledgeWithDataSourceViews,
+        }
       );
-
-      const requestedSpaceIds = uniq([
-        ...spaceIdsFromMcpServerViews,
-        ...spaceIdsFromAttachedKnowledge,
-      ]);
 
       // When saving a suggested skill, automatically activate it.
       const shouldActivate = skillResource.status === "suggested";


### PR DESCRIPTION
## Description

The issue was that on space deletion the space remained in the requestedSpaceIds of the agent because it was remaining in the requestedSpaceIds of the skill.

The new behaviour:
 - the space id is removed from the skills requestedSpaceIds
 - the space id is removed directly from the agent's requestedSpaceIds, while before it was recomputed from skill/actions. This means manually added space remain in the requestedSpaceIds and we only remove the deleted one. 

## Tests

Added unit tests
Manually tested deleting a space with skill having it as restricted space

## Risk

low

## Deploy Plan

deploy front
