### PR TITLE
fix(oauth): include resource parameter in MCP token requests per RFC 8707

### DIFF
--- a/core/src/oauth/providers/mcp.rs
+++ b/core/src/oauth/providers/mcp.rs
@@ -110,6 +110,11 @@ impl Provider for MCPConnectionProvider {
             form_data.push(("client_secret", secret));
         }
 
+        // Include resource parameter per RFC 8707 if available.
+        if let Some(ref resource) = metadata.resource {
+            form_data.push(("resource", resource));
+        }
+
         let req = self
             .reqwest_client()
             .post(metadata.token_endpoint)
@@ -182,6 +187,11 @@ impl Provider for MCPConnectionProvider {
         // Only include client_secret if it's provided
         if let Some(ref secret) = client_secret {
             form_data.push(("client_secret", secret));
+        }
+
+        // Include resource parameter per RFC 8707 if available.
+        if let Some(ref resource) = metadata.resource {
+            form_data.push(("resource", resource));
         }
 
         let req = self


### PR DESCRIPTION
## Description

Followup of #20296.

Fixes https://github.com/dust-tt/tasks/issues/6169

PR #20296 added the `resource` parameter (RFC 8707) to the OAuth authorization request, but omitted it from the token exchange and token refresh POST bodies. Authorization servers that strictly enforce RFC 8707 — such as Hackuity's — reject token requests missing this parameter.

This adds `resource` to the form data in both `finalize()` (authorization code exchange) and `refresh()` (token refresh) in the MCP OAuth provider. The parameter is only included when present in the connection metadata, so there's no impact on servers that don't use it.

## Tests

- `cargo check` passes
- The change follows the exact same conditional pattern as `client_secret`, which is already tested in production
- The `resource` field is already stored in `MCPConnectionMetadata` — this just wires it into the two POST requests where it was missing

## Risk

Low. The `resource` parameter is only sent when it exists in the connection metadata (it's `Option<String>`). Servers that don't expect it will ignore it per standard OAuth behavior. Servers that require it (like Hackuity's) will now work correctly.

## Deploy Plan

OAuth service only.