### PR TITLE
[Zendesk MCP] List Ticket Fields ne tool to improve filtering capabilities

### DIFF
--- a/connectors/src/connectors/zendesk/lib/zendesk_api.ts
+++ b/connectors/src/connectors/zendesk/lib/zendesk_api.ts
@@ -33,6 +33,7 @@ import {
   ZendeskSectionsResponseSchema,
   ZendeskTicketCommentsResponseSchema,
   ZendeskTicketFieldResponseSchema,
+  ZendeskTicketFieldsResponseSchema,
   ZendeskTicketResponseSchema,
   ZendeskTicketsResponseSchema,
   ZendeskUserResponseSchema,
@@ -265,6 +266,22 @@ export class ZendeskClient {
       }
       throw e;
     }
+  }
+
+  async listAllTicketFields({
+    subdomain,
+    includeInactive = false,
+  }: {
+    subdomain: string;
+    includeInactive?: boolean;
+  }): Promise<ZendeskTicketField[]> {
+    const url = `https://${subdomain}.zendesk.com/api/v2/ticket_fields.json`;
+    const response = await this.fetchFromZendeskWithRetries(
+      url,
+      ZendeskTicketFieldsResponseSchema
+    );
+    const fields = response.ticket_fields;
+    return includeInactive ? fields : fields.filter((f) => f.active);
   }
 
   async getTicketCount({

--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
@@ -16912,14 +16912,24 @@
         }
       },
       {
+        "name": "list_ticket_fields",
+        "description": "Lists all available Zendesk ticket fields (system and custom) including their IDs, titles, and types. CRITICAL: Call this tool FIRST when searching for business-specific data - these are typically stored as CUSTOM FIELDS, not tags or standard fields. Returns field IDs needed for search_tickets queries.",
+        "inputSchema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "additionalProperties": false,
+          "properties": {},
+          "type": "object"
+        }
+      },
+      {
         "name": "search_tickets",
-        "description": "Search for Zendesk tickets using query syntax. Returns a list of matching tickets with their details. You can search by status, priority, assignee, tags, and other fields. Query examples: 'status:open', 'priority:high', 'status:open priority:urgent', 'assignee:me', 'tags:bug'.",
+        "description": "Search for Zendesk tickets using query syntax. Returns a list of matching tickets with their details. You can search by status, priority, assignee, tags, custom fields, and other fields. IMPORTANT: Business-specific data are often stored in CUSTOM FIELDS, not tags. Use list_ticket_fields FIRST to discover custom field IDs, then search with: custom_field_{id}:\"exact_value\". Query examples: 'status:open', 'priority:high', 'assignee:me', 'tags:bug', 'custom_field_123456:\"ABC123\"'. Note: tags are simple labels, custom fields contain structured data.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
           "additionalProperties": false,
           "properties": {
             "query": {
-              "description": "The search query using Zendesk query syntax. Examples: 'status:open', 'priority:high' status:pending', 'assignee:123', 'tags:bug tags:critical'.Do not include 'type:ticket' as it is automatically added.",
+              "description": "The search query using Zendesk query syntax. Examples: 'status:open', 'priority:high' status:pending', 'assignee:123', 'tags:bug tags:critical', 'custom_field_123456:\"value\"'. IMPORTANT: For business data, use custom_field_{id}:\"value\" syntax - call list_ticket_fields first to get the field ID. Do not include 'type:ticket' as it is automatically added.",
               "type": "string"
             },
             "sortBy": {
@@ -16952,6 +16962,7 @@
     "toolsStakes": {
       "draft_reply": "low",
       "get_ticket": "never_ask",
+      "list_ticket_fields": "never_ask",
       "search_tickets": "never_ask"
     }
   }

--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
@@ -16913,11 +16913,16 @@
       },
       {
         "name": "list_ticket_fields",
-        "description": "Lists all active Zendesk ticket fields (system and custom) including their IDs, titles, types, and status. Returns both standard fields (subject, priority, status) and custom fields created for organization-specific data. Field IDs are required for filtering by custom fields in search_tickets using custom_field_{id}:\"value\" syntax.",
+        "description": "Lists ticket field definitions with their ID, title, type, and whether they are active. Includes built-in fields (Subject, Priority, Status) and custom fields. Returns active fields by default. Set includeInactive=true for all fields.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
           "additionalProperties": false,
-          "properties": {},
+          "properties": {
+            "includeInactive": {
+              "description": "Include inactive fields. Defaults to false.",
+              "type": "boolean"
+            }
+          },
           "type": "object"
         }
       },

--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
@@ -16913,7 +16913,7 @@
       },
       {
         "name": "list_ticket_fields",
-        "description": "Lists all available Zendesk ticket fields (system and custom) including their IDs, titles, and types. CRITICAL: Call this tool FIRST when searching for business-specific data - these are typically stored as CUSTOM FIELDS, not tags or standard fields. Returns field IDs needed for search_tickets queries.",
+        "description": "Lists all active Zendesk ticket fields (system and custom) including their IDs, titles, types, and status. Returns both standard fields (subject, priority, status) and custom fields created for organization-specific data. Field IDs are required for filtering by custom fields in search_tickets using custom_field_{id}:\"value\" syntax.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
           "additionalProperties": false,
@@ -16923,13 +16923,13 @@
       },
       {
         "name": "search_tickets",
-        "description": "Search for Zendesk tickets using query syntax. Returns a list of matching tickets with their details. You can search by status, priority, assignee, tags, custom fields, and other fields. IMPORTANT: Business-specific data are often stored in CUSTOM FIELDS, not tags. Use list_ticket_fields FIRST to discover custom field IDs, then search with: custom_field_{id}:\"exact_value\". Query examples: 'status:open', 'priority:high', 'assignee:me', 'tags:bug', 'custom_field_123456:\"ABC123\"'. Note: tags are simple labels, custom fields contain structured data.",
+        "description": "Search for Zendesk tickets using query syntax. Returns up to 1,000 matching tickets with their details. Supports filtering by status, priority, type, assignee, tags, custom fields, dates, and text fields. Custom fields use syntax: custom_field_{id}:\"exact_value\". Tags are simple labels; business-specific data are typically stored in custom fields. Use list_ticket_fields to discover available custom field IDs.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
           "additionalProperties": false,
           "properties": {
             "query": {
-              "description": "The search query using Zendesk query syntax. Examples: 'status:open', 'priority:high' status:pending', 'assignee:123', 'tags:bug tags:critical', 'custom_field_123456:\"value\"'. IMPORTANT: For business data, use custom_field_{id}:\"value\" syntax - call list_ticket_fields first to get the field ID. Do not include 'type:ticket' as it is automatically added.",
+              "description": "Search query using Zendesk query syntax. Supports field:value pairs for status, priority, type, assignee, tags, and custom_field_{id}:\"value\" for custom fields. Multiple conditions are combined with AND logic. Do not include 'type:ticket' as it is automatically added.",
               "type": "string"
             },
             "sortBy": {

--- a/front/lib/api/actions/servers/zendesk/client.ts
+++ b/front/lib/api/actions/servers/zendesk/client.ts
@@ -250,6 +250,19 @@ class ZendeskClient {
     return new Ok(result.value.ticket_fields.filter((f) => f.active));
   }
 
+  async listAllTicketFields(): Promise<Result<ZendeskTicketField[], Error>> {
+    const result = await this.request(
+      `ticket_fields.json`,
+      ZendeskTicketFieldsResponseSchema
+    );
+
+    if (result.isErr()) {
+      return new Err(result.error);
+    }
+
+    return new Ok(result.value.ticket_fields.filter((f) => f.active));
+  }
+
   async getTicketComments(
     ticketId: number
   ): Promise<Result<ZendeskTicketComment[], Error>> {

--- a/front/lib/api/actions/servers/zendesk/client.ts
+++ b/front/lib/api/actions/servers/zendesk/client.ts
@@ -250,9 +250,11 @@ class ZendeskClient {
     return new Ok(result.value.ticket_fields.filter((f) => f.active));
   }
 
-  async listAllTicketFields(
-    includeInactive = false
-  ): Promise<Result<ZendeskTicketField[], Error>> {
+  async listAllTicketFields({
+    includeInactive = false,
+  }: { includeInactive?: boolean } = {}): Promise<
+    Result<ZendeskTicketField[], Error>
+  > {
     const result = await this.request(
       `ticket_fields.json`,
       ZendeskTicketFieldsResponseSchema

--- a/front/lib/api/actions/servers/zendesk/client.ts
+++ b/front/lib/api/actions/servers/zendesk/client.ts
@@ -250,7 +250,9 @@ class ZendeskClient {
     return new Ok(result.value.ticket_fields.filter((f) => f.active));
   }
 
-  async listAllTicketFields(): Promise<Result<ZendeskTicketField[], Error>> {
+  async listAllTicketFields(
+    includeInactive = false
+  ): Promise<Result<ZendeskTicketField[], Error>> {
     const result = await this.request(
       `ticket_fields.json`,
       ZendeskTicketFieldsResponseSchema
@@ -260,7 +262,8 @@ class ZendeskClient {
       return new Err(result.error);
     }
 
-    return new Ok(result.value.ticket_fields.filter((f) => f.active));
+    const fields = result.value.ticket_fields;
+    return new Ok(includeInactive ? fields : fields.filter((f) => f.active));
   }
 
   async getTicketComments(

--- a/front/lib/api/actions/servers/zendesk/metadata.ts
+++ b/front/lib/api/actions/servers/zendesk/metadata.ts
@@ -38,16 +38,19 @@ export const ZENDESK_TOOLS_METADATA = createToolsRecord({
   search_tickets: {
     description:
       "Search for Zendesk tickets using query syntax. Returns a list of matching tickets with their " +
-      "details. You can search by status, priority, assignee, tags, and other fields. Query " +
-      "examples: 'status:open', 'priority:high', 'status:open priority:urgent', 'assignee:me', " +
-      "'tags:bug'.",
+      "details. You can search by status, priority, assignee, tags, custom fields, and other fields. " +
+      "IMPORTANT: Business-specific data are often stored in CUSTOM FIELDS, not tags. Use list_ticket_fields FIRST to discover custom field IDs, then " +
+      'search with: custom_field_{id}:"exact_value". ' +
+      "Query examples: 'status:open', 'priority:high', 'assignee:me', 'tags:bug', " +
+      "'custom_field_123456:\"ABC123\"'. Note: tags are simple labels, custom fields contain structured data.",
     schema: {
       query: z
         .string()
         .describe(
           "The search query using Zendesk query syntax. Examples: 'status:open', 'priority:high' " +
-            "status:pending', 'assignee:123', 'tags:bug tags:critical'." +
-            "Do not include 'type:ticket' as it is automatically added."
+            "status:pending', 'assignee:123', 'tags:bug tags:critical', 'custom_field_123456:\"value\"'. " +
+            'IMPORTANT: For business data, use custom_field_{id}:"value" syntax - ' +
+            "call list_ticket_fields first to get the field ID. Do not include 'type:ticket' as it is automatically added."
         ),
       sortBy: z
         .enum(["updated_at", "created_at", "priority", "status", "ticket_type"])
@@ -60,6 +63,14 @@ export const ZENDESK_TOOLS_METADATA = createToolsRecord({
         .optional()
         .describe("Sort order. Defaults to 'desc' if not specified."),
     },
+    stake: "never_ask",
+  },
+  list_ticket_fields: {
+    description:
+      "Lists all available Zendesk ticket fields (system and custom) including their IDs, titles, and types. " +
+      "CRITICAL: Call this tool FIRST when searching for business-specific data - these are typically stored as CUSTOM FIELDS, not tags or standard fields. " +
+      "Returns field IDs needed for search_tickets queries.",
+    schema: {},
     stake: "never_ask",
   },
   draft_reply: {
@@ -91,7 +102,54 @@ export const ZENDESK_SERVER = {
     },
     icon: "ZendeskLogo",
     documentationUrl: null,
-    instructions: null,
+    instructions: `
+    ZENDESK SEARCH QUERY SYNTAX
+
+OPERATORS
+: (equal) < > <= >= (comparison) "" (exact) - (exclude) * (wildcard)
+
+TICKET PROPERTIES
+status:open|pending|hold|solved|closed
+priority:low|normal|high|urgent
+ticket_type:question|incident|problem|task
+created|updated|solved|due_date:{date|relative}
+assignee|requester|submitter|commenter|cc:{value|none|me}
+subject|description|comment:{term}
+tags:{tag}
+group|organization:{name|id|none}
+via:email|chat|phone|web|api|twitter|facebook|sms
+custom_field_{id}:{value|*}
+has_attachment:true|false
+brand:{name|id}
+form:{name}
+
+USER PROPERTIES
+name|email|phone:{value}
+role:admin|agent|end-user
+group|organization:{name}
+tags|notes|details:{text}
+external_id:{id}
+
+ORGANIZATION PROPERTIES
+name:{name}
+tags|notes|details:{text}
+external_id:{id}
+
+COMBINING QUERIES
+Space = AND logic
+Multiple same property = OR logic
+Use - for exclusion
+
+SORTING
+sort_by:created_at|updated_at|priority|status|ticket_type
+sort_order:asc|desc
+
+DATES
+Format: YYYY-MM-DD or YYYY-MM-DDTHH:MM:SSZ
+Relative: created>4hours, updated>7days
+
+LIMITS
+Max 1000 results per query`,
   },
   tools: Object.values(ZENDESK_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/zendesk/metadata.ts
+++ b/front/lib/api/actions/servers/zendesk/metadata.ts
@@ -37,20 +37,17 @@ export const ZENDESK_TOOLS_METADATA = createToolsRecord({
   },
   search_tickets: {
     description:
-      "Search for Zendesk tickets using query syntax. Returns a list of matching tickets with their " +
-      "details. You can search by status, priority, assignee, tags, custom fields, and other fields. " +
-      "IMPORTANT: Business-specific data are often stored in CUSTOM FIELDS, not tags. Use list_ticket_fields FIRST to discover custom field IDs, then " +
-      'search with: custom_field_{id}:"exact_value". ' +
-      "Query examples: 'status:open', 'priority:high', 'assignee:me', 'tags:bug', " +
-      "'custom_field_123456:\"ABC123\"'. Note: tags are simple labels, custom fields contain structured data.",
+      "Search for Zendesk tickets using query syntax. Returns up to 1,000 matching tickets with their details. " +
+      "Supports filtering by status, priority, type, assignee, tags, custom fields, dates, and text fields. " +
+      'Custom fields use syntax: custom_field_{id}:"exact_value". Tags are simple labels; business-specific data ' +
+      "are typically stored in custom fields. Use list_ticket_fields to discover available custom field IDs.",
     schema: {
       query: z
         .string()
         .describe(
-          "The search query using Zendesk query syntax. Examples: 'status:open', 'priority:high' " +
-            "status:pending', 'assignee:123', 'tags:bug tags:critical', 'custom_field_123456:\"value\"'. " +
-            'IMPORTANT: For business data, use custom_field_{id}:"value" syntax - ' +
-            "call list_ticket_fields first to get the field ID. Do not include 'type:ticket' as it is automatically added."
+          "Search query using Zendesk query syntax. Supports field:value pairs for status, priority, type, assignee, tags, " +
+            'and custom_field_{id}:"value" for custom fields. Multiple conditions are combined with AND logic. ' +
+            "Do not include 'type:ticket' as it is automatically added."
         ),
       sortBy: z
         .enum(["updated_at", "created_at", "priority", "status", "ticket_type"])
@@ -67,9 +64,9 @@ export const ZENDESK_TOOLS_METADATA = createToolsRecord({
   },
   list_ticket_fields: {
     description:
-      "Lists all available Zendesk ticket fields (system and custom) including their IDs, titles, and types. " +
-      "CRITICAL: Call this tool FIRST when searching for business-specific data - these are typically stored as CUSTOM FIELDS, not tags or standard fields. " +
-      "Returns field IDs needed for search_tickets queries.",
+      "Lists all active Zendesk ticket fields (system and custom) including their IDs, titles, types, and status. " +
+      "Returns both standard fields (subject, priority, status) and custom fields created for organization-specific data. " +
+      'Field IDs are required for filtering by custom fields in search_tickets using custom_field_{id}:"value" syntax.',
     schema: {},
     stake: "never_ask",
   },
@@ -102,54 +99,7 @@ export const ZENDESK_SERVER = {
     },
     icon: "ZendeskLogo",
     documentationUrl: null,
-    instructions: `
-    ZENDESK SEARCH QUERY SYNTAX
-
-OPERATORS
-: (equal) < > <= >= (comparison) "" (exact) - (exclude) * (wildcard)
-
-TICKET PROPERTIES
-status:open|pending|hold|solved|closed
-priority:low|normal|high|urgent
-ticket_type:question|incident|problem|task
-created|updated|solved|due_date:{date|relative}
-assignee|requester|submitter|commenter|cc:{value|none|me}
-subject|description|comment:{term}
-tags:{tag}
-group|organization:{name|id|none}
-via:email|chat|phone|web|api|twitter|facebook|sms
-custom_field_{id}:{value|*}
-has_attachment:true|false
-brand:{name|id}
-form:{name}
-
-USER PROPERTIES
-name|email|phone:{value}
-role:admin|agent|end-user
-group|organization:{name}
-tags|notes|details:{text}
-external_id:{id}
-
-ORGANIZATION PROPERTIES
-name:{name}
-tags|notes|details:{text}
-external_id:{id}
-
-COMBINING QUERIES
-Space = AND logic
-Multiple same property = OR logic
-Use - for exclusion
-
-SORTING
-sort_by:created_at|updated_at|priority|status|ticket_type
-sort_order:asc|desc
-
-DATES
-Format: YYYY-MM-DD or YYYY-MM-DDTHH:MM:SSZ
-Relative: created>4hours, updated>7days
-
-LIMITS
-Max 1000 results per query`,
+    instructions: null,
   },
   tools: Object.values(ZENDESK_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/zendesk/metadata.ts
+++ b/front/lib/api/actions/servers/zendesk/metadata.ts
@@ -64,7 +64,7 @@ export const ZENDESK_TOOLS_METADATA = createToolsRecord({
   },
   list_ticket_fields: {
     description:
-      "Lists all active Zendesk ticket fields (system and custom) including their IDs, titles, types, and status. " +
+      "Lists all active Zendesk ticket fields (system and custom) including their IDs, titles, types, and active status. " +
       "Returns both standard fields (subject, priority, status) and custom fields created for organization-specific data. " +
       'Field IDs are required for filtering by custom fields in search_tickets using custom_field_{id}:"value" syntax.',
     schema: {},

--- a/front/lib/api/actions/servers/zendesk/metadata.ts
+++ b/front/lib/api/actions/servers/zendesk/metadata.ts
@@ -64,10 +64,15 @@ export const ZENDESK_TOOLS_METADATA = createToolsRecord({
   },
   list_ticket_fields: {
     description:
-      "Lists all active Zendesk ticket fields (system and custom) including their IDs, titles, types, and active status. " +
-      "Returns both standard fields (subject, priority, status) and custom fields created for organization-specific data. " +
-      'Field IDs are required for filtering by custom fields in search_tickets using custom_field_{id}:"value" syntax.',
-    schema: {},
+      "Lists ticket field definitions with their ID, title, type, and whether they are active. " +
+      "Includes built-in fields (Subject, Priority, Status) and custom fields. " +
+      "Returns active fields by default. Set includeInactive=true for all fields.",
+    schema: {
+      includeInactive: z
+        .boolean()
+        .optional()
+        .describe("Include inactive fields. Defaults to false."),
+    },
     stake: "never_ask",
   },
   draft_reply: {

--- a/front/lib/api/actions/servers/zendesk/rendering.ts
+++ b/front/lib/api/actions/servers/zendesk/rendering.ts
@@ -222,5 +222,5 @@ export function renderTicketFields(fields: ZendeskTicketField[]): string {
     );
   }
 
-  return lines.join("\n");
+  return lines.join("\n") + "\n";
 }

--- a/front/lib/api/actions/servers/zendesk/rendering.ts
+++ b/front/lib/api/actions/servers/zendesk/rendering.ts
@@ -208,3 +208,19 @@ export function renderTicketComments(
 
   return lines.join("\n");
 }
+
+export function renderTicketFields(fields: ZendeskTicketField[]): string {
+  if (fields.length === 0) {
+    return "No ticket fields found.";
+  }
+
+  const lines = [`Found ${fields.length} ticket field(s):\n`];
+
+  for (const field of fields) {
+    lines.push(
+      `- ID: ${field.id} | Title: ${field.title} | Type: ${field.type} | Active: ${field.active}`
+    );
+  }
+
+  return lines.join("\n");
+}

--- a/front/lib/api/actions/servers/zendesk/tools/index.ts
+++ b/front/lib/api/actions/servers/zendesk/tools/index.ts
@@ -157,14 +157,14 @@ const handlers: ToolHandlers<typeof ZENDESK_TOOLS_METADATA> = {
     ]);
   },
 
-  list_ticket_fields: async (_, { authInfo }) => {
+  list_ticket_fields: async ({ includeInactive }, { authInfo }) => {
     const clientResult = getZendeskClient(authInfo);
     if (clientResult.isErr()) {
       return clientResult;
     }
     const client = clientResult.value;
 
-    const result = await client.listAllTicketFields();
+    const result = await client.listAllTicketFields({ includeInactive });
 
     if (result.isErr()) {
       return new Err(

--- a/front/lib/api/actions/servers/zendesk/tools/index.ts
+++ b/front/lib/api/actions/servers/zendesk/tools/index.ts
@@ -156,6 +156,39 @@ const handlers: ToolHandlers<typeof ZENDESK_TOOLS_METADATA> = {
     ]);
   },
 
+  list_ticket_fields: async (_, { authInfo }) => {
+    const clientResult = getZendeskClient(authInfo);
+    if (clientResult.isErr()) {
+      return clientResult;
+    }
+    const client = clientResult.value;
+
+    const result = await client.listAllTicketFields();
+
+    if (result.isErr()) {
+      return new Err(
+        new MCPError(`Failed to list ticket fields: ${result.error.message}`, {
+          tracked: isTrackedError(result.error),
+        })
+      );
+    }
+
+    const fields = result.value;
+    const fieldSummaries = fields.map((f) => ({
+      id: f.id,
+      title: f.title,
+      type: f.type,
+      active: f.active,
+    }));
+
+    return new Ok([
+      {
+        type: "text" as const,
+        text: `Found ${fields.length} active ticket field(s):\n\n${JSON.stringify(fieldSummaries, null, 2)}`,
+      },
+    ]);
+  },
+
   draft_reply: async ({ ticketId, body }, { authInfo }) => {
     const clientResult = getZendeskClient(authInfo);
     if (clientResult.isErr()) {

--- a/front/lib/api/actions/servers/zendesk/tools/index.ts
+++ b/front/lib/api/actions/servers/zendesk/tools/index.ts
@@ -10,6 +10,7 @@ import { ZENDESK_TOOLS_METADATA } from "@app/lib/api/actions/servers/zendesk/met
 import {
   renderTicket,
   renderTicketComments,
+  renderTicketFields,
   renderTicketMetrics,
 } from "@app/lib/api/actions/servers/zendesk/rendering";
 import type { ZendeskUser } from "@app/lib/api/actions/servers/zendesk/types";
@@ -174,17 +175,11 @@ const handlers: ToolHandlers<typeof ZENDESK_TOOLS_METADATA> = {
     }
 
     const fields = result.value;
-    const fieldSummaries = fields.map((f) => ({
-      id: f.id,
-      title: f.title,
-      type: f.type,
-      active: f.active,
-    }));
 
     return new Ok([
       {
         type: "text" as const,
-        text: `Found ${fields.length} active ticket field(s):\n\n${JSON.stringify(fieldSummaries, null, 2)}`,
+        text: renderTicketFields(fields),
       },
     ]);
   },

--- a/front/lib/api/actions/servers/zendesk/types.ts
+++ b/front/lib/api/actions/servers/zendesk/types.ts
@@ -236,7 +236,7 @@ export const ZendeskCategorySchema = z
     created_at: z.string(),
     updated_at: z.string(),
     html_url: z.string(),
-    description: z.string(),
+    description: z.string().nullable(),
   })
   .passthrough();
 


### PR DESCRIPTION
## Description

Adds a new `list_ticket_fields` tool to the Zendesk MCP server to enable agents to discover custom field IDs.

## Risk

Low. This is a new read-only tool that lists existing ticket fields. The stake is set to "never_ask" like other Zendesk tools.

## Tests

Updated snapshot test with new tool definition.

## Deploy Plan

Run front