### PR TITLE
[front] - feat(obs): open document on treemap click

### DIFF
--- a/front/components/agent_builder/AgentBuilderObservability.tsx
+++ b/front/components/agent_builder/AgentBuilderObservability.tsx
@@ -32,7 +32,7 @@ export function AgentBuilderObservability({
     </div>
   ) : (
     <AgentObservability
-      workspaceId={owner.sId}
+      owner={owner}
       agentConfigurationId={agentConfiguration.sId}
       isCustomAgent={agentConfiguration.scope !== "global"}
     />

--- a/front/components/agent_builder/observability/charts/DatasourceRetrievalTreemapChart.tsx
+++ b/front/components/agent_builder/observability/charts/DatasourceRetrievalTreemapChart.tsx
@@ -44,6 +44,7 @@ interface TreemapNode {
   connectorProvider?: ConnectorProvider;
   parentId?: string | null;
   documentId?: string;
+  sourceUrl?: string | null;
   children?: TreemapNode[];
 
   [key: string]: unknown;
@@ -67,6 +68,7 @@ interface TreemapContentProps {
   connectorProvider?: ConnectorProvider;
   parentId?: string | null;
   documentId?: string;
+  sourceUrl?: string | null;
   children?: TreemapNode[] | null;
   root?: {
     depth?: number;
@@ -110,6 +112,7 @@ function TreemapContent({
   connectorProvider,
   parentId,
   documentId,
+  sourceUrl,
   children,
   root,
   onNodeClick,
@@ -178,6 +181,7 @@ function TreemapContent({
                   connectorProvider,
                   parentId,
                   documentId,
+                  sourceUrl,
                 });
               }
             : undefined
@@ -384,6 +388,7 @@ export function DatasourceRetrievalTreemapChart({
             name: d.displayName,
             documentId: d.documentId,
             parentId: d.parentId,
+            sourceUrl: d.sourceUrl,
             size: d.count,
             color: zoomSelection.color,
             baseColor: zoomSelection.baseColor,
@@ -412,6 +417,13 @@ export function DatasourceRetrievalTreemapChart({
       color: node.color,
       baseColor: node.baseColor,
     });
+  }, []);
+
+  const handleDocumentClick = useCallback((node: TreemapNode) => {
+    if (!node.sourceUrl) {
+      return;
+    }
+    window.open(node.sourceUrl, "_blank");
   }, []);
 
   const makeTooltipRenderer = useCallback(
@@ -475,7 +487,7 @@ export function DatasourceRetrievalTreemapChart({
               dataKey="size"
               aspectRatio={4 / 3}
               isAnimationActive={false}
-              content={<TreemapContent />}
+              content={<TreemapContent onNodeClick={handleDocumentClick} />}
             >
               <Tooltip
                 cursor={false}

--- a/front/components/agent_builder/observability/charts/DatasourceRetrievalTreemapChart.tsx
+++ b/front/components/agent_builder/observability/charts/DatasourceRetrievalTreemapChart.tsx
@@ -419,12 +419,11 @@ export function DatasourceRetrievalTreemapChart({
     });
   }, []);
 
-  const handleDocumentClick = useCallback((node: TreemapNode) => {
-    if (!node.sourceUrl) {
-      return;
+  const handleDocumentClick = (node: TreemapNode) => {
+    if (node.sourceUrl) {
+      window.open(node.sourceUrl, "_blank");
     }
-    window.open(node.sourceUrl, "_blank");
-  }, []);
+  };
 
   const makeTooltipRenderer = useCallback(
     (total: number) => (props: { payload?: { payload?: TreemapNode }[] }) => {

--- a/front/components/assistant/details/tabs/AgentInsightsTab.tsx
+++ b/front/components/assistant/details/tabs/AgentInsightsTab.tsx
@@ -14,7 +14,7 @@ export function AgentInsightsTab({
   return (
     <ObservabilityProvider>
       <AgentObservability
-        workspaceId={owner.sId}
+        owner={owner}
         agentConfigurationId={agentConfiguration.sId}
         isCustomAgent={agentConfiguration.scope !== "global"}
       />

--- a/front/components/observability/AgentObservability.tsx
+++ b/front/components/observability/AgentObservability.tsx
@@ -19,6 +19,7 @@ import {
   useAgentAnalytics,
   useAgentObservabilitySummary,
 } from "@app/lib/swr/assistants";
+import type { LightWorkspaceType } from "@app/types";
 
 // Dynamic imports for chart components to exclude recharts from server bundle
 const DatasourceRetrievalTreemapChart = dynamic(
@@ -65,13 +66,13 @@ const UsageMetricsChart = dynamic(
 );
 
 interface AgentObservabilityProps {
-  workspaceId: string;
+  owner: LightWorkspaceType;
   agentConfigurationId: string;
   isCustomAgent: boolean;
 }
 
 export function AgentObservability({
-  workspaceId,
+  owner,
   agentConfigurationId,
   isCustomAgent,
 }: AgentObservabilityProps) {
@@ -80,7 +81,7 @@ export function AgentObservability({
   const isTimeRangeMode = mode === "timeRange";
 
   const { agentAnalytics, isAgentAnalyticsLoading } = useAgentAnalytics({
-    workspaceId,
+    workspaceId: owner.sId,
     agentConfigurationId,
     period,
     version:
@@ -96,7 +97,7 @@ export function AgentObservability({
 
   const { summaryText, isSummaryLoading, isSummaryError, refetchSummary } =
     useAgentObservabilitySummary({
-      workspaceId,
+      workspaceId: owner.sId,
       agentConfigurationId,
       days: period,
       disabled: !isTimeRangeMode,
@@ -107,7 +108,7 @@ export function AgentObservability({
       title="Insights"
       headerAction={
         <SharedObservabilityFilterSelector
-          workspaceId={workspaceId}
+          workspaceId={owner.sId}
           agentConfigurationId={agentConfigurationId}
           isCustomAgent={isCustomAgent}
         />
@@ -226,37 +227,37 @@ export function AgentObservability({
 
       <TabContentChildSectionLayout title="Details">
         <UsageMetricsChart
-          workspaceId={workspaceId}
+          workspaceId={owner.sId}
           agentConfigurationId={agentConfigurationId}
           isCustomAgent={isCustomAgent}
         />
         <Separator />
         <SourceChart
-          workspaceId={workspaceId}
+          workspaceId={owner.sId}
           agentConfigurationId={agentConfigurationId}
           isCustomAgent={isCustomAgent}
         />
         <Separator />
         <LatencyChart
-          workspaceId={workspaceId}
+          workspaceId={owner.sId}
           agentConfigurationId={agentConfigurationId}
           isCustomAgent={isCustomAgent}
         />
         <Separator />
         <DatasourceRetrievalTreemapChart
-          workspaceId={workspaceId}
+          workspaceId={owner.sId}
           agentConfigurationId={agentConfigurationId}
           isCustomAgent={isCustomAgent}
         />
         <Separator />
         <ToolUsageChart
-          workspaceId={workspaceId}
+          workspaceId={owner.sId}
           agentConfigurationId={agentConfigurationId}
           isCustomAgent={isCustomAgent}
         />
         <Separator />
         <ToolExecutionTimeChart
-          workspaceId={workspaceId}
+          workspaceId={owner.sId}
           agentConfigurationId={agentConfigurationId}
           isCustomAgent={isCustomAgent}
         />

--- a/front/lib/api/assistant/observability/datasource_retrieval_documents.ts
+++ b/front/lib/api/assistant/observability/datasource_retrieval_documents.ts
@@ -28,6 +28,7 @@ export type DatasourceRetrievalDocumentData = {
   displayName: string;
   parentId: string | null;
   parents: string[];
+  sourceUrl: string | null;
   count: number;
 };
 
@@ -228,6 +229,7 @@ export async function fetchDatasourceRetrievalDocumentsMetrics(
       displayName: bucket.key,
       parentId: null,
       parents: [bucket.key],
+      sourceUrl: null,
       count: bucket.doc_count,
     })
   );
@@ -264,6 +266,7 @@ export async function fetchDatasourceRetrievalDocumentsMetrics(
       displayName: getNodeTitle(node),
       parentId: node.parent_id,
       parents: node.parents,
+      sourceUrl: node.source_url ?? null,
     };
   });
 


### PR DESCRIPTION
## Description

Extends the document treemap chart to enable navigation from documents to their source URLs. When clicking on a document node in the zoomed-in view, the document's source URL is now opened in a new browser tab. 

## Risk

Low

## Tests

Locally

## Deploy Plan

Deploy front