### PR TITLE
Enforce suggestion limits, and make the analysis per suggestion

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
@@ -269,15 +269,15 @@
           "$schema": "http://json-schema.org/draft-07/schema#",
           "additionalProperties": false,
           "properties": {
-            "analysis": {
-              "description": "Analysis or reasoning for the suggestions",
-              "type": "string"
-            },
             "suggestions": {
-              "description": "Array of small, scoped instruction modifications. Each should target 1-3 lines max.",
+              "description": "Array of small, scoped instruction modifications. Each should target 1-3 lines max. Each suggestion can have its own analysis.",
               "items": {
                 "additionalProperties": false,
                 "properties": {
+                  "analysis": {
+                    "description": "Analysis or reasoning for this specific suggestion",
+                    "type": "string"
+                  },
                   "expectedOccurrences": {
                     "description": "Number of occurrences to replace.",
                     "type": "number"

--- a/front/lib/api/actions/servers/agent_copilot_context/metadata.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/metadata.ts
@@ -27,6 +27,10 @@ const InstructionsSuggestionSchema = z.object({
     .number()
     .optional()
     .describe("Number of occurrences to replace."),
+  analysis: z
+    .string()
+    .optional()
+    .describe("Analysis or reasoning for this specific suggestion"),
 });
 
 const ToolAdditionSchema = z.object({
@@ -181,12 +185,8 @@ export const AGENT_COPILOT_CONTEXT_TOOLS_METADATA = createToolsRecord({
       suggestions: z
         .array(InstructionsSuggestionSchema)
         .describe(
-          "Array of small, scoped instruction modifications. Each should target 1-3 lines max."
+          "Array of small, scoped instruction modifications. Each should target 1-3 lines max. Each suggestion can have its own analysis."
         ),
-      analysis: z
-        .string()
-        .optional()
-        .describe("Analysis or reasoning for the suggestions"),
     },
     stake: "never_ask",
     displayLabels: {


### PR DESCRIPTION
## Description

Two changes:
1. We enforce a limit on the number of pending suggestions on the server MCP. If new suggestions would exceed it, we return a message asking the model to mark some as obsolete.
2. For suggest_prompt_editions, make the analysis be per suggestion instead of shared

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low, under flag

## Deploy Plan

Front