### PR TITLE
[front] Fix MCP server name deduplication

### DIFF
--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -734,7 +734,7 @@ function deduplicateMCPServerConfigurations({
     const viewId = isServerSideMCPServerConfiguration(config)
       ? config.mcpServerViewId
       : config.clientSideMcpServerId;
-    const key = `${viewId}:${config.name}`;
+    const key = `${viewId}:${slugify(config.name)}`;
 
     if (seen.has(key)) {
       return false;


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/6201.
- This PR fixes the MCP server name deduplication by operating on the slugified names.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front
