### PR TITLE
feat: add user message aware skills

### DIFF
--- a/front/lib/api/actions/servers/agent_copilot_agent_state/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_copilot_agent_state/tools/index.ts
@@ -54,10 +54,9 @@ const handlers: ToolHandlers<typeof AGENT_COPILOT_AGENT_STATE_TOOLS_METADATA> =
       }
 
       // Get skills associated with this agent.
-      const agentSkills = await SkillResource.listByAgentConfiguration(
-        auth,
-        agentConfiguration
-      );
+      const agentSkills = await SkillResource.listByAgentConfiguration(auth, {
+        agentConfiguration,
+      });
 
       const agentInfo = {
         sId: agentConfiguration.sId,

--- a/front/lib/api/assistant/agent_suggestion_pruning.ts
+++ b/front/lib/api/assistant/agent_suggestion_pruning.ts
@@ -184,10 +184,9 @@ async function getOutdatedSkillsSuggestions(
   if (suggestions.length === 0) {
     return [];
   }
-  const currentSkills = await SkillResource.listByAgentConfiguration(
-    auth,
-    agentConfiguration
-  );
+  const currentSkills = await SkillResource.listByAgentConfiguration(auth, {
+    agentConfiguration,
+  });
   const currentSkillIds = new Set(currentSkills.map((s) => s.sId));
 
   const outdatedSuggestions: SkillsSuggestionResource[] = [];

--- a/front/lib/resources/skill/global/discover_tools.ts
+++ b/front/lib/resources/skill/global/discover_tools.ts
@@ -14,7 +14,10 @@ export const discoverToolsSkill = {
     "Automatically discover and activate specialized tools as needed. Extend your agent's capabilities on-demand without manual configuration.",
   agentFacingDescription:
     "List available toolsets and enable them for the current conversation.",
-  fetchInstructions: async (auth: Authenticator, spaceIds: string[]) => {
+  fetchInstructions: async (
+    auth: Authenticator,
+    { spaceIds }: { spaceIds: string[] }
+  ) => {
     const allToolsets = await MCPServerViewResource.listBySpaceIds(
       auth,
       spaceIds,

--- a/front/lib/resources/skill/global/registry.ts
+++ b/front/lib/resources/skill/global/registry.ts
@@ -7,6 +7,7 @@ import { goDeepSkill } from "@app/lib/resources/skill/global/go_deep";
 import type { AllSkillConfigurationFindOptions } from "@app/lib/resources/skill/types";
 import type { ResourceSId } from "@app/lib/resources/string_ids";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import type { UserMessageType } from "@app/types";
 import { removeNulls } from "@app/types";
 
 export type MCPServerDefinition = {
@@ -37,7 +38,10 @@ type WithDynamicInstructions<T extends BaseGlobalSkillDefinition> = T & {
   readonly instructions?: never;
   readonly fetchInstructions: (
     auth: Authenticator,
-    spaceIds: string[]
+    {
+      spaceIds,
+      userMessage,
+    }: { spaceIds: string[]; userMessage?: UserMessageType }
   ) => Promise<string>;
 };
 

--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -712,7 +712,7 @@ describe("SkillResource", () => {
       // Verify agent-skill link exists before deletion using Resource.
       const skillsForAgentBefore = await SkillResource.listByAgentConfiguration(
         testContext.authenticator,
-        agent
+        { agentConfiguration: agent }
       );
       expect(skillsForAgentBefore.some((s) => s.id === skillResource.id)).toBe(
         true
@@ -725,7 +725,7 @@ describe("SkillResource", () => {
       // Verify agent-skill link is deleted.
       const skillsForAgentAfter = await SkillResource.listByAgentConfiguration(
         testContext.authenticator,
-        agent
+        { agentConfiguration: agent }
       );
       expect(skillsForAgentAfter.some((s) => s.id === skillResource.id)).toBe(
         false

--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/details.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/details.ts
@@ -82,7 +82,7 @@ async function handler(
 
       const skillResources = await SkillResource.listByAgentConfiguration(
         auth,
-        latestAgentConfiguration
+        { agentConfiguration: latestAgentConfiguration }
       );
 
       return res.status(200).json({

--- a/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
@@ -167,6 +167,7 @@ async function handler(
         await SkillResource.listForAgentLoop(auth, {
           agentConfiguration,
           conversation,
+          userMessage,
         });
 
       const skillServers = await getSkillServers(auth, {

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/skills.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/skills.ts
@@ -45,8 +45,9 @@ async function handler(
 
   switch (req.method) {
     case "GET": {
-      const skills = await SkillResource.listByAgentConfiguration(auth, agent);
-
+      const skills = await SkillResource.listByAgentConfiguration(auth, {
+        agentConfiguration: agent,
+      });
       return res.status(200).json({
         skills: skills.map((s) => s.toJSON(auth)),
       });

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -184,6 +184,7 @@ export async function runModelActivity(
     await SkillResource.listForAgentLoop(auth, {
       agentConfiguration,
       conversation,
+      userMessage,
     });
 
   const skillServers = await getSkillServers(auth, {


### PR DESCRIPTION
## Description

Improve prompt of skills to allow having an optional-latest-user-message, like we have in the `generation.ts`.

See next PR on a usage => https://github.com/dust-tt/dust/pull/20811

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
