### PR TITLE
Make phone trial limit 14 days, and reword button

### DIFF
--- a/front/lib/plans/trial/constants.ts
+++ b/front/lib/plans/trial/constants.ts
@@ -1,4 +1,4 @@
-export const TRIAL_DURATION_DAYS = 15;
+export const TRIAL_DURATION_DAYS = 14;
 
 /**
  * When enabled, new workspaces without a subscription are directed to a phone

--- a/front/pages/w/[wId]/trial.tsx
+++ b/front/pages/w/[wId]/trial.tsx
@@ -44,7 +44,7 @@ export default function Trial({
   };
 
   const features = [
-    "Free 30-day trial",
+    "Free 14-day trial",
     "Advanced models (GPT-5, Claude..)",
     "Custom agents which can execute actions",
     "Connections (GitHub, Google Drive, Notion, Slack...)",
@@ -87,7 +87,11 @@ export default function Trial({
                   variant="primary"
                   label="Start free trial"
                 />
-                <Button onClick={skip} variant="outline" label="Skip for now" />
+                <Button
+                  onClick={skip}
+                  variant="outline"
+                  label="Subscribe now"
+                />
               </div>
             </Page.Vertical>
           </Page.Horizontal>


### PR DESCRIPTION
## Description

- Make the limit 14 days throughout
- Rename 'Skip for now' to 'Subscribe now'

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Front