### PR TITLE
Centralize model config access through lib/api/models

### DIFF
--- a/front/admin/cli.ts
+++ b/front/admin/cli.ts
@@ -10,6 +10,7 @@ import {
   getDataSources,
   softDeleteDataSourceAndLaunchScrubWorkflow,
 } from "@app/lib/api/data_sources";
+import { getModelConfigByModelId } from "@app/lib/api/models";
 import { garbageCollectGoogleDriveDocument } from "@app/lib/api/poke/plugins/data_sources/garbage_collect_google_drive_document";
 import { Authenticator } from "@app/lib/auth";
 import { FREE_UPGRADED_PLAN_CODE } from "@app/lib/plans/plan_codes";
@@ -37,12 +38,7 @@ import {
   stopRetrieveTranscriptsWorkflow,
 } from "@app/temporal/labs/transcripts/client";
 import { REGISTERED_CHECKS } from "@app/temporal/production_checks/activities";
-import {
-  ConnectorsAPI,
-  isRoleType,
-  removeNulls,
-  SUPPORTED_MODEL_CONFIGS,
-} from "@app/types";
+import { ConnectorsAPI, isRoleType, removeNulls } from "@app/types";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 
 // `cli` takes an object type and a command as first two arguments and then a list of arguments.
@@ -336,9 +332,7 @@ const conversation = async (command: string, args: parseArgs.ParsedArgs) => {
       if (!args.modelId) {
         throw new Error("Missing --modelId argument");
       }
-      const model = SUPPORTED_MODEL_CONFIGS.find(
-        (m) => m.modelId === args.modelId
-      );
+      const model = getModelConfigByModelId(args.modelId);
       if (!model) {
         throw new Error(`Model not found: '${args.modelId}'`);
       }

--- a/front/components/agent_builder/instructions/AdvancedSettings.tsx
+++ b/front/components/agent_builder/instructions/AdvancedSettings.tsx
@@ -84,7 +84,7 @@ export function AdvancedSettings() {
         <DropdownMenuContent align="start">
           <ModelSelectionSubmenu models={models} />
 
-          <ReasoningEffortSubmenu />
+          <ReasoningEffortSubmenu models={models} />
 
           {supportsResponseFormat && (
             <DropdownMenuItem

--- a/front/components/agent_builder/instructions/ReasoningEffortSubmenu.tsx
+++ b/front/components/agent_builder/instructions/ReasoningEffortSubmenu.tsx
@@ -25,7 +25,9 @@ interface ReasoningEffortSubmenuProps {
   models: ModelConfigurationType[];
 }
 
-export function ReasoningEffortSubmenu({ models }: ReasoningEffortSubmenuProps) {
+export function ReasoningEffortSubmenu({
+  models,
+}: ReasoningEffortSubmenuProps) {
   const modelSettings = useWatch<
     AgentBuilderFormData,
     "generationSettings.modelSettings"

--- a/front/components/agent_builder/instructions/ReasoningEffortSubmenu.tsx
+++ b/front/components/agent_builder/instructions/ReasoningEffortSubmenu.tsx
@@ -7,12 +7,11 @@ import {
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
 } from "@dust-tt/sparkle";
-import React, { useEffect } from "react";
+import React, { useEffect, useMemo } from "react";
 import { useController, useWatch } from "react-hook-form";
 
 import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
-import { getSupportedModelConfig } from "@app/lib/assistant";
-import type { AgentReasoningEffort } from "@app/types";
+import type { AgentReasoningEffort, ModelConfigurationType } from "@app/types";
 import { asDisplayName } from "@app/types";
 
 const REASONING_EFFORT_DESCRIPTIONS: Record<AgentReasoningEffort, string> = {
@@ -22,7 +21,11 @@ const REASONING_EFFORT_DESCRIPTIONS: Record<AgentReasoningEffort, string> = {
   high: "Deep reasoning (slower)",
 };
 
-export function ReasoningEffortSubmenu() {
+interface ReasoningEffortSubmenuProps {
+  models: ModelConfigurationType[];
+}
+
+export function ReasoningEffortSubmenu({ models }: ReasoningEffortSubmenuProps) {
   const modelSettings = useWatch<
     AgentBuilderFormData,
     "generationSettings.modelSettings"
@@ -37,10 +40,15 @@ export function ReasoningEffortSubmenu() {
     name: "generationSettings.reasoningEffort",
   });
 
-  const modelConfig = getSupportedModelConfig({
-    modelId: modelSettings.modelId,
-    providerId: modelSettings.providerId,
-  });
+  const modelConfig = useMemo(
+    () =>
+      models.find(
+        (m) =>
+          m.modelId === modelSettings.modelId &&
+          m.providerId === modelSettings.providerId
+      ),
+    [models, modelSettings.modelId, modelSettings.providerId]
+  );
 
   useEffect(() => {
     if (modelConfig) {

--- a/front/lib/actions/utils.ts
+++ b/front/lib/actions/utils.ts
@@ -5,7 +5,7 @@ import type { MCPToolConfigurationType } from "@app/lib/actions/mcp";
 import { INTERNAL_SERVERS_WITH_WEBSEARCH } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { StepContext } from "@app/lib/actions/types";
 import { isServerSideMCPToolConfigurationWithName } from "@app/lib/actions/types/guards";
-import { getSupportedModelConfig } from "@app/lib/assistant";
+import { getSupportedModelConfig } from "@app/lib/api/models";
 import type { AgentConfigurationType } from "@app/types";
 
 export const WEBSEARCH_ACTION_NUM_RESULTS = 16;
@@ -37,6 +37,11 @@ export function getRetrievalTopK({
   stepActions: MCPToolConfigurationType[];
 }): number {
   const model = getSupportedModelConfig(agentConfiguration.model);
+  if (!model) {
+    throw new Error(
+      `Model config not found for ${agentConfiguration.model.modelId}`
+    );
+  }
 
   const searchActions = stepActions.filter((tool) =>
     isServerSideMCPToolConfigurationWithName(tool, "search")

--- a/front/lib/api/actions/servers/agent_copilot_context/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/tools/index.ts
@@ -13,6 +13,7 @@ import { getAgentFeedbacks } from "@app/lib/api/assistant/feedback";
 import { fetchAgentOverview } from "@app/lib/api/assistant/observability/overview";
 import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
+import { getSupportedModelConfigs } from "@app/lib/api/models";
 import type { Authenticator } from "@app/lib/auth";
 import { getDisplayNameForDataSource } from "@app/lib/data_sources";
 import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
@@ -23,13 +24,7 @@ import { SpaceResource } from "@app/lib/resources/space_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type { DataSourceViewCategory, SpaceType } from "@app/types";
 import { removeNulls } from "@app/types";
-import {
-  Err,
-  isModelProviderId,
-  normalizeError,
-  Ok,
-  SUPPORTED_MODEL_CONFIGS,
-} from "@app/types";
+import { Err, isModelProviderId, normalizeError, Ok } from "@app/types";
 
 // Knowledge categories relevant for agent builder (excluding apps, actions, triggers)
 const KNOWLEDGE_CATEGORIES: DataSourceViewCategory[] = [
@@ -223,7 +218,8 @@ const handlers: ToolHandlers<typeof AGENT_COPILOT_CONTEXT_TOOLS_METADATA> = {
 
     const owner = auth.getNonNullableWorkspace();
 
-    let models = SUPPORTED_MODEL_CONFIGS.filter((m) => !m.isLegacy);
+    const allModels = getSupportedModelConfigs();
+    let models = allModels.filter((m) => !m.isLegacy);
 
     if (providerId) {
       if (!isModelProviderId(providerId)) {
@@ -238,8 +234,7 @@ const handlers: ToolHandlers<typeof AGENT_COPILOT_CONTEXT_TOOLS_METADATA> = {
 
     // Filter by whitelisted providers for the workspace.
     const whiteListedProviders =
-      owner.whiteListedProviders ??
-      SUPPORTED_MODEL_CONFIGS.map((m) => m.providerId);
+      owner.whiteListedProviders ?? allModels.map((m) => m.providerId);
     models = models.filter((m) => whiteListedProviders.includes(m.providerId));
 
     const modelList = models.map((m) => ({

--- a/front/lib/api/actions/servers/conversation_files/tools/index.ts
+++ b/front/lib/api/actions/servers/conversation_files/tools/index.ts
@@ -12,7 +12,7 @@ import {
   renderAttachmentXml,
 } from "@app/lib/api/assistant/conversation/attachments";
 import { listAttachments } from "@app/lib/api/assistant/jit_utils";
-import { getSupportedModelConfig } from "@app/lib/assistant";
+import { getSupportedModelConfig } from "@app/lib/api/models";
 import type { Authenticator } from "@app/lib/auth";
 import {
   CONTENT_OUTDATED_MSG,
@@ -86,6 +86,9 @@ const handlers: ToolHandlers<typeof CONVERSATION_FILES_TOOLS_METADATA> = {
     const model = getSupportedModelConfig(
       extra.agentLoopContext.runContext.agentConfiguration.model
     );
+    if (!model) {
+      return new Err(new MCPError("Model configuration not found"));
+    }
 
     const fileRes = await getFileFromConversation(
       auth,

--- a/front/lib/api/actions/servers/extract_data/helpers.ts
+++ b/front/lib/api/actions/servers/extract_data/helpers.ts
@@ -9,7 +9,7 @@ import { getCoreSearchArgs } from "@app/lib/actions/mcp_internal_actions/tools/u
 import type { ActionGeneratedFileType } from "@app/lib/actions/types";
 import { constructPromptMultiActions } from "@app/lib/api/assistant/generation";
 import type { CoreDataSourceSearchCriteria } from "@app/lib/api/assistant/process_data_sources";
-import { getSupportedModelConfig } from "@app/lib/assistant";
+import { getSupportedModelConfig } from "@app/lib/api/models";
 import type { Authenticator } from "@app/lib/auth";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type {
@@ -127,12 +127,19 @@ export async function getPromptForProcessDustApp({
   const userMessage: UserMessageType =
     lastUserMessageTuple[0] as UserMessageType;
 
+  const model = getSupportedModelConfig(agentConfiguration.model);
+  if (!model) {
+    throw new Error(
+      `Model config not found for ${agentConfiguration.model.modelId}`
+    );
+  }
+
   return constructPromptMultiActions(auth, {
     userMessage,
     agentConfiguration,
     fallbackPrompt:
       "Process the retrieved data to extract structured information based on the provided schema.",
-    model: getSupportedModelConfig(agentConfiguration.model),
+    model,
     hasAvailableActions: false,
     enabledSkills: [],
     equippedSkills: [],

--- a/front/lib/api/actions/servers/run_dust_app/helpers.ts
+++ b/front/lib/api/actions/servers/run_dust_app/helpers.ts
@@ -18,6 +18,7 @@ import type { ToolGeneratedFileType } from "@app/lib/actions/mcp_internal_action
 import type { AgentLoopRunContextType } from "@app/lib/actions/types";
 import { renderConversationForModel } from "@app/lib/api/assistant/conversation_rendering";
 import { getDatasetSchema } from "@app/lib/api/datasets";
+import { getSupportedModelConfig } from "@app/lib/api/models";
 import type { Authenticator } from "@app/lib/auth";
 import { extractConfig } from "@app/lib/config";
 import { AppResource } from "@app/lib/resources/app_resource";
@@ -30,7 +31,7 @@ import type {
   SpecificationBlockType,
   SupportedFileContentType,
 } from "@app/types";
-import { extensionsForContentType, SUPPORTED_MODEL_CONFIGS } from "@app/types";
+import { extensionsForContentType } from "@app/types";
 import { safeParseJSON } from "@app/types/shared/utils/json_utils";
 
 const MIN_GENERATION_TOKENS = 2048;
@@ -288,10 +289,8 @@ export async function prepareParamsWithHistory(
   if (
     schema?.some((s) => s.key === DUST_CONVERSATION_HISTORY_MAGIC_INPUT_KEY)
   ) {
-    const model = SUPPORTED_MODEL_CONFIGS.find(
-      (m) =>
-        m.modelId === agentLoopRunContext.agentConfiguration.model.modelId &&
-        m.providerId === agentLoopRunContext.agentConfiguration.model.providerId
+    const model = getSupportedModelConfig(
+      agentLoopRunContext.agentConfiguration.model
     );
 
     if (model) {

--- a/front/lib/api/assistant/agent_message_content_parser.ts
+++ b/front/lib/api/assistant/agent_message_content_parser.ts
@@ -1,3 +1,4 @@
+import assert from "assert";
 import escapeRegExp from "lodash/escapeRegExp";
 
 import { getSupportedModelConfig } from "@app/lib/api/models";
@@ -299,12 +300,7 @@ export function getDelimitersConfiguration({
   agentConfiguration: LightAgentConfigurationType;
 }): DelimitersConfiguration {
   const model = getSupportedModelConfig(agentConfiguration.model);
-  if (!model) {
-    return {
-      delimiters: [],
-      incompleteDelimiterPatterns: [],
-    };
-  }
+  assert(model, "Model configuration not found in getDelimitersConfiguration");
 
   if (DEEPSEEK_MODELS.includes(model.modelId)) {
     return DEEPSEEK_CHAIN_OF_THOUGHT_DELIMITERS_CONFIGURATION;
@@ -331,13 +327,10 @@ export function getCoTDelimitersConfiguration({
   agentConfiguration: LightAgentConfigurationType;
 }): DelimitersConfiguration {
   const model = getSupportedModelConfig(agentConfiguration.model);
-  if (!model) {
-    return {
-      delimiters: CHAIN_OF_THOUGHT_DELIMITERS_CONFIGURATION.delimiters,
-      incompleteDelimiterPatterns:
-        CHAIN_OF_THOUGHT_DELIMITERS_CONFIGURATION.incompleteDelimiterPatterns,
-    };
-  }
+  assert(
+    model,
+    "Model configuration not found in getCoTDelimitersConfiguration"
+  );
 
   if (DEEPSEEK_MODELS.includes(model.modelId)) {
     return DEEPSEEK_CHAIN_OF_THOUGHT_DELIMITERS_CONFIGURATION;

--- a/front/lib/api/assistant/agent_message_content_parser.ts
+++ b/front/lib/api/assistant/agent_message_content_parser.ts
@@ -1,6 +1,6 @@
 import escapeRegExp from "lodash/escapeRegExp";
 
-import { getSupportedModelConfig } from "@app/lib/assistant";
+import { getSupportedModelConfig } from "@app/lib/api/models";
 import type {
   GenerationTokensEvent,
   LightAgentConfigurationType,
@@ -299,6 +299,12 @@ export function getDelimitersConfiguration({
   agentConfiguration: LightAgentConfigurationType;
 }): DelimitersConfiguration {
   const model = getSupportedModelConfig(agentConfiguration.model);
+  if (!model) {
+    return {
+      delimiters: [],
+      incompleteDelimiterPatterns: [],
+    };
+  }
 
   if (DEEPSEEK_MODELS.includes(model.modelId)) {
     return DEEPSEEK_CHAIN_OF_THOUGHT_DELIMITERS_CONFIGURATION;
@@ -325,6 +331,13 @@ export function getCoTDelimitersConfiguration({
   agentConfiguration: LightAgentConfigurationType;
 }): DelimitersConfiguration {
   const model = getSupportedModelConfig(agentConfiguration.model);
+  if (!model) {
+    return {
+      delimiters: CHAIN_OF_THOUGHT_DELIMITERS_CONFIGURATION.delimiters,
+      incompleteDelimiterPatterns:
+        CHAIN_OF_THOUGHT_DELIMITERS_CONFIGURATION.incompleteDelimiterPatterns,
+    };
+  }
 
   if (DEEPSEEK_MODELS.includes(model.modelId)) {
     return DEEPSEEK_CHAIN_OF_THOUGHT_DELIMITERS_CONFIGURATION;

--- a/front/lib/api/assistant/configuration/helpers.ts
+++ b/front/lib/api/assistant/configuration/helpers.ts
@@ -1,6 +1,6 @@
 import { fetchMCPServerActionConfigurations } from "@app/lib/actions/configuration/mcp";
 import { getFavoriteStates } from "@app/lib/api/assistant/get_favorite_states";
-import { getSupportedModelConfig } from "@app/lib/assistant";
+import { getSupportedModelConfig } from "@app/lib/api/models";
 import type { Authenticator } from "@app/lib/auth";
 import { getPublicUploadBucket } from "@app/lib/file_storage";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -29,8 +29,8 @@ import {
 } from "@app/lib/api/assistant/streaming/events";
 import { maybeUpsertFileAttachment } from "@app/lib/api/files/attachments";
 import { getRemainingKeyCapMicroUsd } from "@app/lib/api/key_cap_tracking";
+import { getSupportedModelConfig } from "@app/lib/api/models";
 import { isProgrammaticUsage } from "@app/lib/api/programmatic_usage_tracking";
-import { getSupportedModelConfig } from "@app/lib/assistant";
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { extractFromString } from "@app/lib/mentions/format";
@@ -602,7 +602,7 @@ export async function postUserMessage(
     const featureFlags = await getFeatureFlags(owner);
     const supportedModelConfig = getSupportedModelConfig(agentConfig.model);
     if (
-      supportedModelConfig.featureFlag &&
+      supportedModelConfig?.featureFlag &&
       !featureFlags.includes(supportedModelConfig.featureFlag)
     ) {
       return new Err({

--- a/front/lib/api/assistant/conversation_rendering/helpers.ts
+++ b/front/lib/api/assistant/conversation_rendering/helpers.ts
@@ -5,7 +5,7 @@
 
 import { isTextContent } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { rewriteContentForModel } from "@app/lib/actions/mcp_utils";
-import { getSupportedModelConfig } from "@app/lib/assistant";
+import { getSupportedModelConfig } from "@app/lib/api/models";
 import type { Authenticator } from "@app/lib/auth";
 import {
   replaceMentionsWithAt,
@@ -120,6 +120,9 @@ export function getSteps(
   }
 ): Step[] {
   const supportedModel = getSupportedModelConfig(model);
+  if (!supportedModel) {
+    return [];
+  }
   const actions = removeNulls(message.actions);
 
   // We store for each step (identified by its index) the "contents" array (raw model outputs, including

--- a/front/lib/api/llm/index.ts
+++ b/front/lib/api/llm/index.ts
@@ -14,8 +14,8 @@ import { XaiLLM } from "@app/lib/api/llm/clients/xai";
 import { isXaiWhitelistedModelId } from "@app/lib/api/llm/clients/xai/types";
 import type { LLM } from "@app/lib/api/llm/llm";
 import type { LLMParameters } from "@app/lib/api/llm/types/options";
+import { getModelConfigByModelId } from "@app/lib/api/models";
 import type { Authenticator } from "@app/lib/auth";
-import { SUPPORTED_MODEL_CONFIGS } from "@app/types";
 
 export async function getLLM(
   auth: Authenticator,
@@ -30,10 +30,8 @@ export async function getLLM(
     context,
   }: LLMParameters
 ): Promise<LLM | null> {
-  const modelConfiguration = SUPPORTED_MODEL_CONFIGS.find(
-    (config) => config.modelId === modelId
-  );
-  if (!modelConfiguration) {
+  const modelConfig = getModelConfigByModelId(modelId);
+  if (!modelConfig) {
     return null;
   }
 

--- a/front/lib/api/llm/tests/llm.test.ts
+++ b/front/lib/api/llm/tests/llm.test.ts
@@ -1,3 +1,4 @@
+import assert from "assert";
 import clone from "lodash/clone";
 import { describe, it, vi } from "vitest";
 
@@ -215,6 +216,8 @@ function getSupportedConversations({
     modelId,
     providerId,
   });
+  assert(modelConfig, `Model config not found for ${providerId} / ${modelId}`);
+
   if (modelConfig.supportsVision) {
     conversationsToTest.push(...TEST_VISION_CONVERSATIONS);
   }

--- a/front/lib/api/llm/tests/llm.test.ts
+++ b/front/lib/api/llm/tests/llm.test.ts
@@ -20,7 +20,7 @@ import type {
   TestConfig,
   TestConversation,
 } from "@app/lib/api/llm/tests/types";
-import { getSupportedModelConfig } from "@app/lib/assistant";
+import { getSupportedModelConfig } from "@app/lib/api/models";
 import type { ModelIdType, ModelProviderIdType } from "@app/types";
 import {
   // Anthropic models

--- a/front/lib/api/models/index.ts
+++ b/front/lib/api/models/index.ts
@@ -1,0 +1,59 @@
+import type {
+  AgentModelConfigurationType,
+  ModelConfigurationType,
+  SupportedModel,
+} from "@app/types";
+import { SUPPORTED_MODEL_CONFIGS } from "@app/types";
+
+/**
+ * Lazy-loaded cache for model configurations.
+ * Currently wraps static arrays - Next PR will add GCS loading for custom models.
+ */
+let _modelConfigs: ModelConfigurationType[] | null = null;
+
+/**
+ * Initialize model configurations.
+ * Called once at app startup (Next PR will make this load from GCS).
+ */
+export function initializeModelConfigs(): void {
+  _modelConfigs = [...SUPPORTED_MODEL_CONFIGS];
+}
+
+/**
+ * Get all supported model configurations.
+ * Stays synchronous reads from cache with lazy initialization fallback.
+ */
+export function getSupportedModelConfigs(): readonly ModelConfigurationType[] {
+  // Fallback to static if not initialized.
+  _modelConfigs ??= [...SUPPORTED_MODEL_CONFIGS];
+  return _modelConfigs;
+}
+
+/**
+ * Get a specific supported model configuration by model/provider ID.
+ * Returns null if the model configuration is not found.
+ * Stays synchronous reads from cache.
+ */
+export function getSupportedModelConfig(
+  supportedModel: SupportedModel | AgentModelConfigurationType
+): ModelConfigurationType | null {
+  const configs = getSupportedModelConfigs();
+  const config = configs.find(
+    (m) =>
+      m.modelId === supportedModel.modelId &&
+      m.providerId === supportedModel.providerId
+  );
+
+  return config ?? null;
+}
+
+/**
+ * Get a specific model configuration by model ID only.
+ * Stays synchronous reads from cache.
+ */
+export function getModelConfigByModelId(
+  modelId: string
+): ModelConfigurationType | undefined {
+  const configs = getSupportedModelConfigs();
+  return configs.find((m) => m.modelId === modelId);
+}

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -1,23 +1,11 @@
-import { getSupportedModelConfig } from "@app/lib/api/models";
 import { isUpgraded } from "@app/lib/plans/plan_codes";
 import type {
   ModelConfigurationType,
   PlanType,
-  SupportedModel,
   WhitelistableFeature,
   WorkspaceType,
 } from "@app/types";
 import { isProviderWhitelisted } from "@app/types";
-
-export function isLargeModel(model: unknown): model is SupportedModel {
-  const maybeSupportedModel = model as SupportedModel;
-  const m = getSupportedModelConfig(maybeSupportedModel);
-  if (m) {
-    return m.largeModel;
-  }
-
-  return false;
-}
 
 // Returns true if the model is available to the workspace, regardless of whether it is whitelisted or not.
 export function isModelAvailable(

--- a/front/lib/assistant.ts
+++ b/front/lib/assistant.ts
@@ -1,37 +1,22 @@
+import { getSupportedModelConfig } from "@app/lib/api/models";
 import { isUpgraded } from "@app/lib/plans/plan_codes";
 import type {
-  AgentModelConfigurationType,
   ModelConfigurationType,
   PlanType,
   SupportedModel,
   WhitelistableFeature,
   WorkspaceType,
 } from "@app/types";
-import { isProviderWhitelisted, SUPPORTED_MODEL_CONFIGS } from "@app/types";
+import { isProviderWhitelisted } from "@app/types";
 
 export function isLargeModel(model: unknown): model is SupportedModel {
   const maybeSupportedModel = model as SupportedModel;
-  const m = SUPPORTED_MODEL_CONFIGS.find(
-    (m) =>
-      m.modelId === maybeSupportedModel.modelId &&
-      m.providerId === maybeSupportedModel.providerId
-  );
+  const m = getSupportedModelConfig(maybeSupportedModel);
   if (m) {
     return m.largeModel;
   }
-  return false;
-}
 
-export function getSupportedModelConfig(
-  supportedModel: SupportedModel | AgentModelConfigurationType
-) {
-  // here it is safe to cast the result to non-nullable because SupportedModel
-  // is derived from the const array of configs above
-  return SUPPORTED_MODEL_CONFIGS.find(
-    (m) =>
-      m.modelId === supportedModel.modelId &&
-      m.providerId === supportedModel.providerId
-  ) as (typeof SUPPORTED_MODEL_CONFIGS)[number];
+  return false;
 }
 
 // Returns true if the model is available to the workspace, regardless of whether it is whitelisted or not.

--- a/front/lib/resources/run_resource.ts
+++ b/front/lib/resources/run_resource.ts
@@ -10,6 +10,7 @@ import { Op, Sequelize } from "sequelize";
 
 import { computeTokensCostForUsageInMicroUsd } from "@app/lib/api/assistant/token_pricing";
 import type { TokenUsage } from "@app/lib/api/llm/types/events";
+import { getModelConfigByModelId } from "@app/lib/api/models";
 import type { Authenticator } from "@app/lib/auth";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { AppModel } from "@app/lib/resources/storage/models/apps";
@@ -28,7 +29,7 @@ import type {
   ModelProviderIdType,
   Result,
 } from "@app/types";
-import { Err, normalizeError, Ok, SUPPORTED_MODEL_CONFIGS } from "@app/types";
+import { Err, normalizeError, Ok } from "@app/types";
 
 type RunResourceWithApp = RunResource & { app: AppModel };
 
@@ -284,9 +285,7 @@ export class RunResource extends BaseResource<RunModel> {
   }
 
   async recordTokenUsage(usage: TokenUsage, modelId: ModelIdType) {
-    const modelConfig = SUPPORTED_MODEL_CONFIGS.find(
-      (config) => config.modelId === modelId
-    );
+    const modelConfig = getModelConfigByModelId(modelId);
 
     if (!modelConfig) {
       logger.warn({ modelId }, "Unsupported model for usage recording");

--- a/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
@@ -12,7 +12,7 @@ import { getJITServers } from "@app/lib/api/assistant/jit_actions";
 import { listAttachments } from "@app/lib/api/assistant/jit_utils";
 import { getSkillServers } from "@app/lib/api/assistant/skill_actions";
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
-import { getSupportedModelConfig } from "@app/lib/assistant";
+import { getSupportedModelConfig } from "@app/lib/api/models";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";

--- a/front/scripts/debug/profile_conversation_rendering.ts
+++ b/front/scripts/debug/profile_conversation_rendering.ts
@@ -3,10 +3,13 @@ import inspector from "node:inspector/promises";
 
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { renderConversationForModel } from "@app/lib/api/assistant/conversation_rendering";
+import {
+  getModelConfigByModelId,
+  getSupportedModelConfigs,
+} from "@app/lib/api/models";
 import { Authenticator } from "@app/lib/auth";
 import { saveProfile } from "@app/pages/api/debug/profiler";
 import { makeScript } from "@app/scripts/helpers";
-import { SUPPORTED_MODEL_CONFIGS } from "@app/types";
 
 makeScript(
   {
@@ -26,7 +29,7 @@ makeScript(
       type: "string",
       alias: "m",
       description: "Model to use for rendering",
-      options: SUPPORTED_MODEL_CONFIGS.map((m) => m.modelId),
+      options: getSupportedModelConfigs().map((m) => m.modelId),
       required: true,
     },
   },
@@ -60,7 +63,7 @@ makeScript(
 
     console.timeEnd("Fetching conversation");
 
-    const model = SUPPORTED_MODEL_CONFIGS.find((m) => m.modelId === modelId);
+    const model = getModelConfigByModelId(modelId);
     assert(model, `Model not found for ${modelId}`);
 
     console.time("Rendering conversation");

--- a/front/scripts/update_agent_models.ts
+++ b/front/scripts/update_agent_models.ts
@@ -1,10 +1,14 @@
 import { Op } from "sequelize";
 
+import {
+  getModelConfigByModelId,
+  getSupportedModelConfigs,
+} from "@app/lib/api/models";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
 import { makeScript } from "@app/scripts/helpers";
 import type { ModelId, SupportedModel } from "@app/types";
-import { isSupportedModel, SUPPORTED_MODEL_CONFIGS } from "@app/types";
+import { isSupportedModel } from "@app/types";
 
 type SupportedModelIds = SupportedModel["modelId"];
 type SelectCriteria = {
@@ -87,7 +91,7 @@ async function updateWorkspaceAssistants(
     }
 
     const targetProviderId = forceProviderChange
-      ? SUPPORTED_MODEL_CONFIGS.find((m) => m.modelId === toModel)?.providerId
+      ? getModelConfigByModelId(toModel)?.providerId
       : agent.providerId;
     if (execute) {
       await agent.update({ modelId: toModel, providerId: targetProviderId });
@@ -113,7 +117,7 @@ makeScript(
     },
     toModel: {
       type: "string",
-      choices: SUPPORTED_MODEL_CONFIGS.map((m) => m.modelId),
+      choices: getSupportedModelConfigs().map((m) => m.modelId),
       demandOption: true,
     },
     workspaceIds: {

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -34,7 +34,7 @@ import { getLLM } from "@app/lib/api/llm";
 import type { LLMTraceContext } from "@app/lib/api/llm/traces/types";
 import { getUserFacingLLMErrorMessage } from "@app/lib/api/llm/types/errors";
 import { DEFAULT_MCP_TOOL_RETRY_POLICY } from "@app/lib/api/mcp";
-import { getSupportedModelConfig } from "@app/lib/assistant";
+import { getSupportedModelConfig } from "@app/lib/api/models";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
### Context

This is the first of two PRs to support custom models loaded at runtime.
- PR1 (this PR): Centralize all model config access through `lib/api/models` so there's a single place to modify when we add runtime loading.
- PR2: Make `initializeModelConfigs()` async and load custom models from GCS at startup, merging them with static configs. All callsites remain unchanged since getters stay synchronous.

This PR:
- Centralizess all access to `SUPPORTED_MODEL_CONFIGS` through `lib/api/models`
- Exports three getter functions: `getSupportedModelConfigs()`, `getSupportedModelConfig()`, `getModelConfigByModelId()`
- Prepares architecture for loading custom models at runtime (Next PR)

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
