### PR TITLE
Fix: restricted project conversations could be accessed by sid.

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -145,7 +145,7 @@ export async function createConversation(
       depth,
       triggerId,
       spaceId,
-      requestedSpaceIds: [],
+      requestedSpaceIds: spaceId ? [spaceId] : [],
       metadata: metadata ?? {},
     },
     space

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -113,6 +113,11 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       );
     }
 
+    // Add spaceId to the requestedSpaceIds if it is not already part of the requestedSpaceIds.
+    if (space && !blob.requestedSpaceIds.includes(space.id)) {
+      blob.requestedSpaceIds.push(space.id);
+    }
+
     const conversation = await this.model.create({
       ...blob,
       workspaceId: workspace.id,
@@ -178,9 +183,6 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     const uniqueSpaceIds = uniq([
       // Include requestedSpaceIds from conversations.
       ...conversations.flatMap((c) => c.requestedSpaceIds),
-
-      // Include spaceId of the conversations if it exists.
-      ...conversations.flatMap((c) => c.spaceId ?? []),
     ]);
 
     // Only fetch spaces if there are any used spaces.
@@ -1384,7 +1386,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
   ) {
     return this.update(
       {
-        requestedSpaceIds,
+        requestedSpaceIds: uniq(requestedSpaceIds),
       },
       transaction
     );
@@ -1568,11 +1570,6 @@ export class ConversationResource extends BaseResource<ConversationModel> {
         workspaceId: this.workspaceId,
       })
     );
-
-    // Add the main space (if any).
-    if (this.space) {
-      spaceIds.push(this.space.sId);
-    }
 
     return spaceIds;
   }


### PR DESCRIPTION
## Description

Fix security issue where private project conversations could be accessed by anyone in the workspace that had the SID.
(updated existing convos to add the missing spaceId in requestedSpaceIds)

## Tests

Added

## Risk

Low

## Deploy Plan

Deploy front