### PR TITLE
[projects] Fix project creation error

### DIFF
--- a/front/components/assistant/conversation/CreateProjectModal.tsx
+++ b/front/components/assistant/conversation/CreateProjectModal.tsx
@@ -17,7 +17,6 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import { useAppRouter } from "@app/lib/platform";
 import { useSpaceConversationsSummary } from "@app/lib/swr/conversations";
 import { useCreateSpace } from "@app/lib/swr/spaces";
-import { useUser } from "@app/lib/swr/user";
 import { getSpaceConversationsRoute } from "@app/lib/utils/router";
 import type { LightWorkspaceType } from "@app/types";
 
@@ -37,7 +36,6 @@ export function CreateProjectModal({
   const [isRestricted, setIsRestricted] = useState(false);
 
   const doCreate = useCreateSpace({ owner });
-  const { user } = useUser();
   const router = useAppRouter();
 
   const sendNotification = useSendNotification();
@@ -74,7 +72,7 @@ export function CreateProjectModal({
       name: trimmedName,
       isRestricted,
       managementMode: "manual",
-      memberIds: user?.sId ? [user.sId] : [],
+      memberIds: [],
       spaceKind: "project",
     });
 
@@ -97,7 +95,6 @@ export function CreateProjectModal({
     handleClose,
     sendNotification,
     mutateSpaceSummary,
-    user,
     router,
     owner.sId,
   ]);


### PR DESCRIPTION
## Description
Fixes project creation failing with "Cannot add members to projects on creation."

The `CreateProjectModal` was passing the current user's sId in `memberIds` when creating projects. However, the `createSpaceAndGroup` function already automatically adds the creator to the project's editor group (lines 418-431 in `spaces.ts`), making this parameter unnecessary and triggering an assertion failure.

## Risks
Blast radius: project creation
Risk: none

## Deploy Plan
- deploy front