### PR TITLE
feat(drive): add file creation

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
@@ -4751,6 +4751,9 @@
       }
     ],
     "toolsStakes": {
+      "create_document": "low",
+      "create_presentation": "low",
+      "create_spreadsheet": "low",
       "get_file_content": "never_ask",
       "get_spreadsheet": "never_ask",
       "get_worksheet": "never_ask",

--- a/front/lib/api/actions/servers/google_drive/helpers.ts
+++ b/front/lib/api/actions/servers/google_drive/helpers.ts
@@ -1,8 +1,10 @@
 import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 
 import {
+  getGoogleDocsClient,
   getGoogleDriveClient,
   getGoogleSheetsClient,
+  getGoogleSlidesClient,
 } from "@app/lib/providers/google_drive/utils";
 
 export async function getDriveClient(authInfo?: AuthInfo) {
@@ -19,4 +21,20 @@ export async function getSheetsClient(authInfo?: AuthInfo) {
     return null;
   }
   return getGoogleSheetsClient(accessToken);
+}
+
+export async function getDocsClient(authInfo?: AuthInfo) {
+  const accessToken = authInfo?.token;
+  if (!accessToken) {
+    return null;
+  }
+  return getGoogleDocsClient(accessToken);
+}
+
+export async function getSlidesClient(authInfo?: AuthInfo) {
+  const accessToken = authInfo?.token;
+  if (!accessToken) {
+    return null;
+  }
+  return getGoogleSlidesClient(accessToken);
 }

--- a/front/lib/api/actions/servers/google_drive/index.ts
+++ b/front/lib/api/actions/servers/google_drive/index.ts
@@ -4,19 +4,34 @@ import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/uti
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { GOOGLE_DRIVE_TOOL_NAME } from "@app/lib/api/actions/servers/google_drive/metadata";
-import { TOOLS } from "@app/lib/api/actions/servers/google_drive/tools";
+import {
+  TOOLS,
+  WRITE_TOOLS,
+} from "@app/lib/api/actions/servers/google_drive/tools";
 import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
 
-function createServer(
+async function createServer(
   auth: Authenticator,
   agentLoopContext?: AgentLoopContextType
-): McpServer {
+): Promise<McpServer> {
   const server = makeInternalMCPServer("google_drive");
 
+  // Register read tools (always available).
   for (const tool of TOOLS) {
     registerTool(auth, agentLoopContext, server, tool, {
       monitoringName: GOOGLE_DRIVE_TOOL_NAME,
     });
+  }
+
+  // Register write tools if feature flag is enabled.
+  const featureFlags = await getFeatureFlags(auth.getNonNullableWorkspace());
+  if (featureFlags.includes("google_drive_write_enabled")) {
+    for (const tool of WRITE_TOOLS) {
+      registerTool(auth, agentLoopContext, server, tool, {
+        monitoringName: GOOGLE_DRIVE_TOOL_NAME,
+      });
+    }
   }
 
   return server;

--- a/front/lib/api/actions/servers/google_drive/metadata.ts
+++ b/front/lib/api/actions/servers/google_drive/metadata.ts
@@ -144,6 +144,35 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
   },
 });
 
+export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
+  create_document: {
+    description: "Create a new Google Docs document in the user's Drive.",
+    schema: {
+      title: z.string().describe("The title of the new document."),
+    },
+    stake: "low",
+  },
+  create_spreadsheet: {
+    description: "Create a new Google Sheets spreadsheet in the user's Drive.",
+    schema: {
+      title: z.string().describe("The title of the new spreadsheet."),
+    },
+    stake: "low",
+  },
+  create_presentation: {
+    description: "Create a new Google Slides presentation in the user's Drive.",
+    schema: {
+      title: z.string().describe("The title of the new presentation."),
+    },
+    stake: "low",
+  },
+});
+
+const ALL_TOOLS_METADATA = {
+  ...GOOGLE_DRIVE_TOOLS_METADATA,
+  ...GOOGLE_DRIVE_WRITE_TOOLS_METADATA,
+};
+
 export const GOOGLE_DRIVE_SERVER = {
   serverInfo: {
     name: "google_drive",
@@ -158,12 +187,12 @@ export const GOOGLE_DRIVE_SERVER = {
     documentationUrl: "https://docs.dust.tt/docs/google-drive",
     instructions: null,
   },
-  tools: Object.values(GOOGLE_DRIVE_TOOLS_METADATA).map((t) => ({
+  tools: Object.values(ALL_TOOLS_METADATA).map((t) => ({
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
   })),
   tools_stakes: Object.fromEntries(
-    Object.values(GOOGLE_DRIVE_TOOLS_METADATA).map((t) => [t.name, t.stake])
+    Object.values(ALL_TOOLS_METADATA).map((t) => [t.name, t.stake])
   ),
 } as const satisfies ServerMetadata;

--- a/front/lib/providers/google_drive/utils.ts
+++ b/front/lib/providers/google_drive/utils.ts
@@ -14,3 +14,15 @@ export function getGoogleSheetsClient(accessToken: string) {
     auth: oauth2Client,
   });
 }
+
+export function getGoogleDocsClient(accessToken: string) {
+  const oauth2Client = new google.auth.OAuth2();
+  oauth2Client.setCredentials({ access_token: accessToken });
+  return google.docs({ version: "v1", auth: oauth2Client });
+}
+
+export function getGoogleSlidesClient(accessToken: string) {
+  const oauth2Client = new google.auth.OAuth2();
+  oauth2Client.setCredentials({ access_token: accessToken });
+  return google.slides({ version: "v1", auth: oauth2Client });
+}


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

This PR scaffhold a basic interaction in google drive MCP Tool to create files with just a title.
  - Add three new MCP tools to Google Drive server: create_document, create_spreadsheet, create_presentation
  - Tools are gated behind the google_drive_write_enabled feature flag
  - Add Google Docs and Slides API clients alongside existing Sheets client
  - Include user-friendly error message for 403 permission errors (prompts reconnection)
  - Tools return document ID, title, and edit URL on success

<img width="871" height="299" alt="Capture d’écran 2026-01-29 à 16 25 58" src="https://github.com/user-attachments/assets/9019750d-e7cd-47da-955f-20db635bb56d" />

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low, behind ff.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front