### PR TITLE
[front] Add script to enable Frames skill on past conversations

### DIFF
--- a/front/migrations/20260129_backfill_frames_skill_for_interactive_content.ts
+++ b/front/migrations/20260129_backfill_frames_skill_for_interactive_content.ts
@@ -1,0 +1,176 @@
+import type { Logger } from "pino";
+import { Op } from "sequelize";
+
+import { Authenticator } from "@app/lib/auth";
+import { ConversationSkillModel } from "@app/lib/models/skill/conversation_skill";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import {
+  FileModel,
+  ShareableFileModel,
+} from "@app/lib/resources/storage/models/files";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
+import { makeScript } from "@app/scripts/helpers";
+import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
+import type { LightWorkspaceType } from "@app/types";
+
+/**
+ * This migration finds all conversations that have used interactive content tools
+ * (i.e., have files with contentType = 'application/vnd.dust.frame') and creates
+ * ConversationSkill records to mimic the Frames skill being enabled.
+ *
+ * We use ShareableFileModel as the starting point since shareable file records
+ * are only created for interactive content files (frames).
+ */
+
+async function backfillFramesSkillForWorkspace(
+  workspace: LightWorkspaceType,
+  {
+    execute,
+    logger: parentLogger,
+  }: {
+    execute: boolean;
+    logger: Logger;
+  }
+): Promise<void> {
+  const logger = parentLogger.child({ workspaceId: workspace.sId });
+  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+  // Step 1: we fetch th eshareable files, every frame has an associated shareable file created when
+  // we upload the content in the tool that creates the frame.
+  const shareableFiles = await ShareableFileModel.findAll({
+    where: {
+      workspaceId: workspace.id,
+    },
+    include: [
+      {
+        model: FileModel,
+        required: true,
+      },
+    ],
+  });
+
+  if (shareableFiles.length === 0) {
+    return;
+  }
+
+  // Step 2: we find the corresponding conversations using the use case metadata.
+  const conversationIds = new Set<string>();
+  for (const shareableFile of shareableFiles) {
+    const metadata = shareableFile.file?.useCaseMetadata;
+    if (metadata?.conversationId) {
+      conversationIds.add(metadata.conversationId);
+    }
+  }
+
+  if (conversationIds.size === 0) {
+    logger.info("No conversation found in frame files metadata");
+    return;
+  }
+
+  const conversations = await ConversationResource.fetchByIds(
+    auth,
+    Array.from(conversationIds),
+    { dangerouslySkipPermissionFiltering: true }
+  );
+
+  if (conversations.length === 0) {
+    return;
+  }
+
+  // Step 3: upsert on conversation_skills.
+  const existingSkills = await ConversationSkillModel.findAll({
+    where: {
+      workspaceId: workspace.id,
+      conversationId: { [Op.in]: conversations.map((c) => c.id) },
+      globalSkillId: "frames",
+    },
+  });
+
+  const conversationsWithSkill = new Set(
+    existingSkills.map((s) => s.conversationId)
+  );
+
+  const conversationsNeedingSkill = conversations.filter(
+    (c) => !conversationsWithSkill.has(c.id)
+  );
+
+  if (conversationsNeedingSkill.length === 0) {
+    logger.info(
+      { workspaceId: workspace.sId },
+      "All conversations already have the frames skill"
+    );
+    return;
+  }
+
+  logger.info(
+    {
+      alreadyHaveSkill: conversationsWithSkill.size,
+      needingSkill: conversationsNeedingSkill.length,
+      foundConversations: conversations.length,
+    },
+    "Upserting conversation skills"
+  );
+
+  let created = 0;
+  await concurrentExecutor(
+    conversationsNeedingSkill,
+    async (conversation) => {
+      logger.info(
+        {
+          conversationId: conversation.sId,
+        },
+        "Creating frames skill for conversation"
+      );
+
+      if (execute) {
+        await ConversationSkillModel.create({
+          workspaceId: workspace.id,
+          conversationId: conversation.id,
+          globalSkillId: "frames",
+          customSkillId: null,
+          source: "conversation",
+          agentConfigurationId: null,
+          addedByUserId: null,
+        });
+        created++;
+      }
+    },
+    { concurrency: 8 }
+  );
+}
+
+makeScript(
+  {
+    workspaceId: { type: "string", required: false },
+  },
+  async ({ workspaceId, execute }, logger) => {
+    logger.info("Starting backfill.");
+
+    if (workspaceId) {
+      const workspace = await WorkspaceResource.fetchById(workspaceId);
+      if (!workspace) {
+        throw new Error(`Workspace not found: ${workspaceId}`);
+      }
+      await backfillFramesSkillForWorkspace(
+        renderLightWorkspaceType({ workspace }),
+        {
+          execute,
+          logger,
+        }
+      );
+    } else {
+      await runOnAllWorkspaces(
+        async (workspace) => {
+          await backfillFramesSkillForWorkspace(workspace, { execute, logger });
+        },
+        {
+          concurrency: 2,
+        }
+      );
+    }
+
+    logger.info("All done.");
+  }
+);

--- a/front/migrations/20260129_backfill_frames_skill_for_interactive_content.ts
+++ b/front/migrations/20260129_backfill_frames_skill_for_interactive_content.ts
@@ -56,7 +56,6 @@ async function backfillFramesSkillForWorkspace(
   }
 
   if (conversationIds.size === 0) {
-    logger.info("No conversation found in frame files metadata");
     return;
   }
 

--- a/front/migrations/20260129_backfill_frames_skill_for_interactive_content.ts
+++ b/front/migrations/20260129_backfill_frames_skill_for_interactive_content.ts
@@ -99,7 +99,7 @@ async function backfillFramesSkillForWorkspace(
     return;
   }
 
-  let created = 0;
+  let enabledCount = 0;
   await concurrentExecutor(
     conversationsNeedingSkill,
     async (conversation) => {
@@ -120,13 +120,13 @@ async function backfillFramesSkillForWorkspace(
           agentConfigurationId: null,
           addedByUserId: null,
         });
-        created++;
+        enabledCount++;
       }
     },
     { concurrency: 8 }
   );
 
-  logger.info({ created }, "Backfill completed for workspace");
+  logger.info({ enabledCount }, "Backfill completed for workspace");
 }
 
 makeScript(

--- a/front/migrations/20260129_backfill_frames_skill_for_interactive_content.ts
+++ b/front/migrations/20260129_backfill_frames_skill_for_interactive_content.ts
@@ -121,7 +121,7 @@ async function backfillFramesSkillForWorkspace(
         {
           conversationId: conversation.sId,
         },
-        "Creating frames skill for conversation"
+        "Enabling frames skill for conversation"
       );
 
       if (execute) {

--- a/front/migrations/20260129_backfill_frames_skill_for_interactive_content.ts
+++ b/front/migrations/20260129_backfill_frames_skill_for_interactive_content.ts
@@ -37,7 +37,7 @@ async function backfillFramesSkillForWorkspace(
   const logger = parentLogger.child({ workspaceId: workspace.sId });
   const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
-  // Step 1: we fetch th eshareable files, every frame has an associated shareable file created when
+  // Step 1: we fetch the shareable files, every frame has an associated shareable file created when
   // we upload the content in the tool that creates the frame.
   const shareableFiles = await ShareableFileModel.findAll({
     where: {
@@ -97,10 +97,7 @@ async function backfillFramesSkillForWorkspace(
   );
 
   if (conversationsNeedingSkill.length === 0) {
-    logger.info(
-      { workspaceId: workspace.sId },
-      "All conversations already have the frames skill"
-    );
+    logger.info("All conversations already have the frames skill");
     return;
   }
 
@@ -108,7 +105,7 @@ async function backfillFramesSkillForWorkspace(
     {
       alreadyHaveSkill: conversationsWithSkill.size,
       needingSkill: conversationsNeedingSkill.length,
-      foundConversations: conversations.length,
+      totalConversations: conversations.length,
     },
     "Upserting conversation skills"
   );
@@ -139,6 +136,8 @@ async function backfillFramesSkillForWorkspace(
     },
     { concurrency: 8 }
   );
+
+  logger.info({ created }, "Backfill completed for workspace");
 }
 
 makeScript(

--- a/front/migrations/20260129_backfill_frames_skill_for_interactive_content.ts
+++ b/front/migrations/20260129_backfill_frames_skill_for_interactive_content.ts
@@ -15,15 +15,6 @@ import { makeScript } from "@app/scripts/helpers";
 import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
 import type { LightWorkspaceType } from "@app/types";
 
-/**
- * This migration finds all conversations that have used interactive content tools
- * (i.e., have files with contentType = 'application/vnd.dust.frame') and creates
- * ConversationSkill records to mimic the Frames skill being enabled.
- *
- * We use ShareableFileModel as the starting point since shareable file records
- * are only created for interactive content files (frames).
- */
-
 async function backfillFramesSkillForWorkspace(
   workspace: LightWorkspaceType,
   {

--- a/front/migrations/20260129_backfill_frames_skill_for_interactive_content.ts
+++ b/front/migrations/20260129_backfill_frames_skill_for_interactive_content.ts
@@ -96,11 +96,6 @@ async function backfillFramesSkillForWorkspace(
     (c) => !conversationsWithSkill.has(c.id)
   );
 
-  if (conversationsNeedingSkill.length === 0) {
-    logger.info("All conversations already have the frames skill");
-    return;
-  }
-
   logger.info(
     {
       alreadyHaveSkill: conversationsWithSkill.size,
@@ -109,6 +104,10 @@ async function backfillFramesSkillForWorkspace(
     },
     "Upserting conversation skills"
   );
+
+  if (conversationsNeedingSkill.length === 0) {
+    return;
+  }
 
   let created = 0;
   await concurrentExecutor(


### PR DESCRIPTION
## Description

We have examples of old conversations that used a frame where the model assumes the skill is already enabled as it sees it being used already.
This PR adds a backfill script to retro-actively enable the Frames skill on such conversations.
It retrieves these conversation by going from the `shareable_files` and then through the use case metadata.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- No deploy.
