### PR TITLE
Use isProjectConversation instead of checking spaceId.

### DIFF
--- a/front/components/assistant/conversation/MentionValidationRequired.tsx
+++ b/front/components/assistant/conversation/MentionValidationRequired.tsx
@@ -10,10 +10,7 @@ import {
 import { useMemo, useState } from "react";
 
 import type { VirtuosoMessage } from "@app/components/assistant/conversation/types";
-import {
-  isMessageTemporayState,
-  isProjectConversation,
-} from "@app/components/assistant/conversation/types";
+import { isMessageTemporayState } from "@app/components/assistant/conversation/types";
 import { useMentionValidation } from "@app/lib/swr/mentions";
 import { useUser } from "@app/lib/swr/user";
 import type {
@@ -22,6 +19,7 @@ import type {
   RichMentionWithStatus,
   UserType,
 } from "@app/types";
+import { isProjectConversation } from "@app/types";
 
 interface MentionValidationRequiredProps {
   triggeringUser: UserType | null;

--- a/front/components/assistant/conversation/types.ts
+++ b/front/components/assistant/conversation/types.ts
@@ -118,10 +118,6 @@ export const isMessageTemporayState = (
 export const getMessageDate = (msg: VirtuosoMessage): Date =>
   new Date(msg.created);
 
-export const isProjectConversation = (
-  conversation: ConversationWithoutContentType
-): boolean => !!conversation.spaceId;
-
 export const makeInitialMessageStreamState = (
   message: LightAgentMessageType | LightAgentMessageWithActionsType
 ): MessageTemporaryState => {

--- a/front/lib/api/actions/servers/project_context_management/helpers.ts
+++ b/front/lib/api/actions/servers/project_context_management/helpers.ts
@@ -7,7 +7,7 @@ import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { FileResource } from "@app/lib/resources/file_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import type { FileUseCase, Result } from "@app/types";
-import { Err, normalizeError, Ok } from "@app/types";
+import { Err, isProjectConversation, normalizeError, Ok } from "@app/types";
 
 // Use cases that are not allowed for copying.
 const DISALLOWED_USE_CASES: FileUseCase[] = [
@@ -97,7 +97,7 @@ export async function getProjectSpace(
 
     const conversation = conversationRes.value;
 
-    if (!conversation.spaceId) {
+    if (!isProjectConversation(conversation)) {
       return new Err(
         new MCPError(
           "This conversation is not in a project. Project context management is only available in project conversations.",

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -95,7 +95,10 @@ import {
   removeNulls,
   toMentionType,
 } from "@app/types";
-import { isAgentMessageType } from "@app/types/assistant/conversation";
+import {
+  isAgentMessageType,
+  isProjectConversation,
+} from "@app/types/assistant/conversation";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 
 // Rate limit for programmatic usage: 1 message per this amount of dollars per minute.
@@ -1314,7 +1317,10 @@ export async function postNewContentFragment(
   }
 
   // Project conversations only allow content fragments from the project space or the global space.
-  if (conversation.spaceId && isContentFragmentInputWithContentNode(cf)) {
+  if (
+    isProjectConversation(conversation) &&
+    isContentFragmentInputWithContentNode(cf)
+  ) {
     const dsView = await DataSourceViewResource.fetchById(
       auth,
       cf.nodeDataSourceViewId

--- a/front/lib/api/assistant/conversation/mentions.ts
+++ b/front/lib/api/assistant/conversation/mentions.ts
@@ -62,6 +62,7 @@ import {
   isAgentMention,
   isAgentMessageType,
   isContentFragmentType,
+  isProjectConversation,
   isRichUserMention,
   isUserMention,
   isUserMessageType,
@@ -195,7 +196,7 @@ export const createUserMentions = async (
         }
 
         // Auto approve mentions for users who are members of the conversation's project space.
-        if (!autoApprove && conversation.spaceId) {
+        if (!autoApprove && isProjectConversation(conversation)) {
           autoApprove = await isUserMemberOfSpace(auth, {
             userId: user.sId,
             spaceId: conversation.spaceId,
@@ -662,7 +663,7 @@ export const createAgentMessages = async (
             }
 
             // In case of Project's conversation, we need to check if the agent configuration is using only the project spaces or public spaces, otherwise we reject the mention and do not create the agent message.
-            if (conversation.spaceId) {
+            if (isProjectConversation(conversation)) {
               // Check to skip heavy work if the agent configuration is only using the project space.
               if (
                 configuration.requestedSpaceIds.some(
@@ -926,7 +927,7 @@ export async function validateUserMention(
   const isApproval = approvalState === "approved";
 
   // For project conversations, add user to project space first when approving.
-  if (conversation.spaceId && isApproval) {
+  if (isProjectConversation(conversation) && isApproval) {
     const space = await SpaceResource.fetchById(auth, conversation.spaceId);
     if (!space) {
       return new Err({

--- a/front/lib/api/assistant/jit/project_context_management.ts
+++ b/front/lib/api/assistant/jit/project_context_management.ts
@@ -6,6 +6,7 @@ import { getFeatureFlags } from "@app/lib/auth";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import type { ConversationWithoutContentType } from "@app/types";
+import { isProjectConversation } from "@app/types";
 
 /**
  * Get the project_context_management MCP server for managing project files.
@@ -18,7 +19,10 @@ export async function getProjectContextManagementServer(
   const owner = auth.getNonNullableWorkspace();
   const featureFlags = await getFeatureFlags(owner);
 
-  if (!featureFlags.includes("projects") || !conversation.spaceId) {
+  if (
+    !featureFlags.includes("projects") ||
+    !isProjectConversation(conversation)
+  ) {
     return null;
   }
 

--- a/front/lib/api/assistant/jit/projects.ts
+++ b/front/lib/api/assistant/jit/projects.ts
@@ -9,6 +9,7 @@ import { getFeatureFlags } from "@app/lib/auth";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import type { ConversationWithoutContentType } from "@app/types";
+import { isProjectConversation } from "@app/types";
 
 /**
  * Get the project_search MCP server for searching project context files.
@@ -21,7 +22,10 @@ export async function getProjectSearchServer(
   const owner = auth.getNonNullableWorkspace();
   const featureFlags = await getFeatureFlags(owner);
 
-  if (!featureFlags.includes("projects") || !conversation.spaceId) {
+  if (
+    !featureFlags.includes("projects") ||
+    !isProjectConversation(conversation)
+  ) {
     return null;
   }
 

--- a/front/lib/api/assistant/jit/utils.ts
+++ b/front/lib/api/assistant/jit/utils.ts
@@ -15,7 +15,7 @@ import { FileResource } from "@app/lib/resources/file_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
 import type { ConversationWithoutContentType } from "@app/types";
-import { CoreAPI } from "@app/types";
+import { CoreAPI, isProjectConversation } from "@app/types";
 
 export async function getTablesFromMultiSheetSpreadsheet(
   auth: Authenticator,
@@ -67,7 +67,7 @@ export async function getProjectContextDataSourceView(
   auth: Authenticator,
   conversation: ConversationWithoutContentType
 ): Promise<DataSourceViewResource | null> {
-  if (!conversation.spaceId) {
+  if (!isProjectConversation(conversation)) {
     // Conversation not in a space (private conversation).
     return null;
   }

--- a/front/lib/swr/conversations.ts
+++ b/front/lib/swr/conversations.ts
@@ -38,7 +38,7 @@ import type {
   ConversationWithoutContentType,
   LightWorkspaceType,
 } from "@app/types";
-import { normalizeError } from "@app/types";
+import { isProjectConversation, normalizeError } from "@app/types";
 
 const DELAY_BEFORE_MARKING_AS_READ = 2000;
 
@@ -893,13 +893,12 @@ export function useConversationMarkAsRead({
   useEffect(() => {
     let timeout: NodeJS.Timeout | null = null;
     if (conversation?.sId) {
-      const isProjectConversation = !!conversation.spaceId;
-
       timeout = setTimeout(
         () =>
           markAsRead(conversation.sId, {
-            mutateList: !isProjectConversation,
-            mutateSpaceConversationsSummary: isProjectConversation,
+            mutateList: !isProjectConversation(conversation),
+            mutateSpaceConversationsSummary:
+              isProjectConversation(conversation),
           }),
         DELAY_BEFORE_MARKING_AS_READ
       );

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -317,6 +317,10 @@ export type ConversationType = ConversationWithoutContentType & {
   content: (UserMessageType[] | AgentMessageType[] | ContentFragmentType[])[];
 };
 
+export const isProjectConversation = <T extends ConversationWithoutContentType>(
+  conversation: T
+): conversation is T & { spaceId: string } => !!conversation.spaceId;
+
 export type ParticipantActionType = "posted" | "reacted" | "subscribed";
 
 /**


### PR DESCRIPTION
## Description

Use utility function to avoid leveraging an implementation details (in case .spaceId becomes not enough to distinguish project's conversations).

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy front