### PR TITLE
[Mentions] Split pending status for conversation vs project membership

### DIFF
--- a/front/components/assistant/conversation/MentionValidationRequired.tsx
+++ b/front/components/assistant/conversation/MentionValidationRequired.tsx
@@ -10,10 +10,7 @@ import {
 import { useMemo, useState } from "react";
 
 import type { VirtuosoMessage } from "@app/components/assistant/conversation/types";
-import {
-  isMessageTemporayState,
-  isProjectConversation,
-} from "@app/components/assistant/conversation/types";
+import { isMessageTemporayState } from "@app/components/assistant/conversation/types";
 import { useMentionValidation } from "@app/lib/swr/mentions";
 import { useUser } from "@app/lib/swr/user";
 import type {
@@ -29,7 +26,7 @@ interface MentionValidationRequiredProps {
   mention: Extract<
     RichMentionWithStatus,
     {
-      status: "pending";
+      status: "pending_conversation_access" | "pending_project_membership";
     }
   >;
   conversation: ConversationWithoutContentType;
@@ -45,13 +42,13 @@ export function MentionValidationRequired({
 }: MentionValidationRequiredProps) {
   const { user } = useUser();
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const isProjectConv = isProjectConversation(conversation);
+  const isProjectMembership = mention.status === "pending_project_membership";
 
   const { validateMention } = useMentionValidation({
     workspaceId: owner.sId,
     conversationId: conversation.sId,
     messageId: message.sId,
-    isProjectConversation: isProjectConv,
+    isProjectConversation: isProjectMembership,
   });
 
   const isTriggeredByCurrentUser = useMemo(
@@ -92,7 +89,7 @@ export function MentionValidationRequired({
                 @{message.configuration.name}
               </span>{" "}
               mentioned <span className="font-semibold">{mention.label}</span>.
-              {isProjectConv ? (
+              {isProjectMembership ? (
                 <> Do you want to add them to this project?</>
               ) : (
                 <>
@@ -104,7 +101,7 @@ export function MentionValidationRequired({
             </>
           ) : (
             <>
-              {isProjectConv ? (
+              {isProjectMembership ? (
                 <>
                   Add <b>{mention.label}</b> to this project? They'll have
                   access to all project conversations.
@@ -128,10 +125,10 @@ export function MentionValidationRequired({
             onClick={handleReject}
           />
           <Button
-            label={isProjectConv ? "Add to project" : "Yes"}
+            label={isProjectMembership ? "Add to project" : "Yes"}
             variant="highlight"
             size="xs"
-            icon={isProjectConv ? PlusIcon : CheckIcon}
+            icon={isProjectMembership ? PlusIcon : CheckIcon}
             disabled={isSubmitting}
             onClick={handleApprove}
           />

--- a/front/components/assistant/conversation/MentionValidationRequired.tsx
+++ b/front/components/assistant/conversation/MentionValidationRequired.tsx
@@ -26,7 +26,11 @@ interface MentionValidationRequiredProps {
   mention: Extract<
     RichMentionWithStatus,
     {
-      status: "pending_conversation_access" | "pending_project_membership";
+      // "pending" is deprecated but kept for migration compatibility
+      status:
+        | "pending"
+        | "pending_conversation_access"
+        | "pending_project_membership";
     }
   >;
   conversation: ConversationWithoutContentType;

--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -185,7 +185,10 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
 
               // :warning: make sure to use the index in the key, as the mention.id is the userId
 
-              if (mention.status === "pending") {
+              if (
+                mention.status === "pending_conversation_access" ||
+                mention.status === "pending_project_membership"
+              ) {
                 return (
                   <MentionValidationRequired
                     key={index}

--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -185,7 +185,9 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
 
               // :warning: make sure to use the index in the key, as the mention.id is the userId
 
+              // "pending" is deprecated but kept for migration compatibility
               if (
+                mention.status === "pending" ||
                 mention.status === "pending_conversation_access" ||
                 mention.status === "pending_project_membership"
               ) {
@@ -210,7 +212,7 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
                     message={data}
                     owner={context.owner}
                     triggeringUser={triggeringUser}
-                    conversationId={context.conversation.sId}
+                    conversation={context.conversation}
                   />
                 );
               }

--- a/front/lib/api/assistant/conversation/mentions.test.ts
+++ b/front/lib/api/assistant/conversation/mentions.test.ts
@@ -1427,7 +1427,7 @@ describe("createUserMentions", () => {
       pictureUrl:
         mentionedUserJson.image ?? "/static/humanavatar/anonymous.png",
       description: mentionedUserJson.email,
-      status: "pending",
+      status: "pending_conversation_access",
     });
     expect(isRichUserMention(result[0])).toBe(true);
 
@@ -1496,13 +1496,13 @@ describe("createUserMentions", () => {
       id: user1.sId,
       type: "user",
       label: user1Json.fullName,
-      status: "pending",
+      status: "pending_conversation_access",
     });
     expect(user2Mention).toMatchObject({
       id: user2.sId,
       type: "user",
       label: user2Json.fullName,
-      status: "pending",
+      status: "pending_conversation_access",
     });
     expect(isRichUserMention(user1Mention!)).toBe(true);
     expect(isRichUserMention(user2Mention!)).toBe(true);
@@ -1616,7 +1616,7 @@ describe("createUserMentions", () => {
     expect(result[0]).toMatchObject({
       id: mentionedUser.sId,
       type: "user",
-      status: "pending",
+      status: "pending_conversation_access",
     });
     expect(isRichUserMention(result[0])).toBe(true);
 
@@ -1673,7 +1673,7 @@ describe("createUserMentions", () => {
     expect(result[0]).toMatchObject({
       id: mentionedUser.sId,
       type: "user",
-      status: "pending",
+      status: "pending_conversation_access",
     });
     expect(isRichUserMention(result[0])).toBe(true);
 
@@ -1722,7 +1722,7 @@ describe("createUserMentions", () => {
       expect(result[0]).toMatchObject({
         id: mentionedUser.sId,
         type: "user",
-        status: "pending",
+        status: "pending_conversation_access",
       });
       expect(isRichUserMention(result[0])).toBe(true);
 
@@ -1735,7 +1735,7 @@ describe("createUserMentions", () => {
         },
       });
       expect(mentionInDb).not.toBeNull();
-      expect(mentionInDb?.status).toBe("pending");
+      expect(mentionInDb?.status).toBe("pending_conversation_access");
     });
 
     it("should always auto approve mentions for existing participants", async () => {
@@ -1822,7 +1822,7 @@ describe("createUserMentions", () => {
       expect(result[0]).toMatchObject({
         id: mentionedUser.sId,
         type: "user",
-        status: "pending",
+        status: "pending_conversation_access",
       });
       expect(isRichUserMention(result[0])).toBe(true);
     });
@@ -2029,7 +2029,7 @@ describe("createUserMentions", () => {
       expect(result[0]).toMatchObject({
         id: mentionedUser.sId,
         type: "user",
-        status: "pending",
+        status: "pending_conversation_access",
       });
       expect(isRichUserMention(result[0])).toBe(true);
     });
@@ -2132,7 +2132,7 @@ describe("createUserMentions", () => {
       expect(result[0]).toMatchObject({
         id: mentionedUser.sId,
         type: "user",
-        status: "pending",
+        status: "pending_conversation_access",
       });
       expect(isRichUserMention(result[0])).toBe(true);
     });
@@ -2313,7 +2313,7 @@ describe("createUserMentions", () => {
       expect(result[0]).toMatchObject({
         id: mentionedUser.sId,
         type: "user",
-        status: "pending",
+        status: "pending_conversation_access",
       });
       expect(isRichUserMention(result[0])).toBe(true);
 
@@ -2326,7 +2326,7 @@ describe("createUserMentions", () => {
         },
       });
       expect(mentionInDb).not.toBeNull();
-      expect(mentionInDb?.status).toBe("pending");
+      expect(mentionInDb?.status).toBe("pending_conversation_access");
       expect(mentionInDb?.status).not.toBe(
         "user_restricted_by_conversation_access"
       );
@@ -3443,12 +3443,12 @@ describe("validateUserMention", () => {
       });
     });
 
-    // Create the mention with status "pending"
+    // Create the mention with status "pending_conversation_access"
     await MentionModel.create({
       messageId: userMessage.id,
       userId: mentionedUser.id,
       workspaceId: workspace.id,
-      status: "pending",
+      status: "pending_conversation_access",
     });
 
     // Verify the mentioned user is not a participant yet
@@ -3513,12 +3513,12 @@ describe("validateUserMention", () => {
       });
     });
 
-    // Create the mention with status "pending"
+    // Create the mention with status "pending_conversation_access"
     await MentionModel.create({
       messageId: userMessage.id,
       userId: mentionedUser.id,
       workspaceId: workspace.id,
-      status: "pending",
+      status: "pending_conversation_access",
     });
 
     // Reject the mention
@@ -3604,12 +3604,12 @@ describe("validateUserMention", () => {
         });
       });
 
-      // Create the mention with status "pending"
+      // Create the mention with status "pending_project_membership"
       await MentionModel.create({
         messageId: userMessage.id,
         userId: mentionedUser.id,
         workspaceId: workspace.id,
-        status: "pending",
+        status: "pending_project_membership",
       });
 
       const mentionedUserAuth = await Authenticator.fromUserIdAndWorkspaceId(

--- a/front/lib/api/assistant/conversation/mentions.ts
+++ b/front/lib/api/assistant/conversation/mentions.ts
@@ -218,6 +218,10 @@ export const createUserMentions = async (
           });
         }
 
+        // TODO: Alternative approach would be to always set pending_project_membership for
+        // project conversations and decide at render time whether to show "add to project"
+        // (for editors) or "request access" (for non-editors). This would require building
+        // a request access flow. See https://github.com/dust-tt/dust/issues/20852
         let status: MentionStatusType;
         if (!canAccess) {
           status = "user_restricted_by_conversation_access";
@@ -1092,7 +1096,9 @@ export async function validateUserMention(
     userMessages: [],
     agentMessages: [],
   };
+  // "pending" is deprecated but kept for migration compatibility
   const isPendingStatus = (status: MentionStatusType): boolean =>
+    status === "pending" ||
     status === "pending_conversation_access" ||
     status === "pending_project_membership";
 

--- a/front/lib/api/assistant/conversation/mentions.ts
+++ b/front/lib/api/assistant/conversation/mentions.ts
@@ -133,6 +133,7 @@ async function isUserMemberOfSpace(
 
 /**
  * Check if the current user can add members to a project space.
+ * TODO: remove when dedicated method is merged in space 
  */
 async function canCurrentUserAddProjectMembers(
   auth: Authenticator,

--- a/front/lib/api/assistant/conversation/mentions.ts
+++ b/front/lib/api/assistant/conversation/mentions.ts
@@ -133,7 +133,7 @@ async function isUserMemberOfSpace(
 
 /**
  * Check if the current user can add members to a project space.
- * TODO: remove when dedicated method is merged in space 
+ * TODO: remove when dedicated method is merged in space
  */
 async function canCurrentUserAddProjectMembers(
   auth: Authenticator,

--- a/front/lib/api/assistant/conversation/validate_actions.test.ts
+++ b/front/lib/api/assistant/conversation/validate_actions.test.ts
@@ -426,7 +426,7 @@ describe("dismissMention", () => {
         conversation,
       });
 
-      // Verify mention was created with pending status (not restricted)
+      // Verify mention was created with pending_conversation_access status (not restricted)
       const mentionInDb = await MentionModel.findOne({
         where: {
           workspaceId: workspace.id,
@@ -435,7 +435,7 @@ describe("dismissMention", () => {
         },
       });
       expect(mentionInDb).not.toBeNull();
-      expect(mentionInDb?.status).toBe("pending");
+      expect(mentionInDb?.status).toBe("pending_conversation_access");
       expect(mentionInDb?.dismissed).toBe(false);
 
       // Try to dismiss the mention (should not dismiss because it's not restricted)

--- a/front/lib/models/agent/conversation.ts
+++ b/front/lib/models/agent/conversation.ts
@@ -791,7 +791,8 @@ MessageReactionModel.belongsTo(UserModel, {
 });
 
 export type MentionStatusType =
-  | "pending" // Waiting for user input
+  | "pending_conversation_access" // Waiting for user input to invite to conversation
+  | "pending_project_membership" // Waiting for user input to add to project (mentioning user is project editor)
   | "approved" // Auto or manually approved
   | "rejected" // Auto or manually rejected
   | "user_restricted_by_conversation_access" // The conversation access is restricted to the user (the conversation uses at least one space that the user doesn't have access to)

--- a/front/lib/models/agent/conversation.ts
+++ b/front/lib/models/agent/conversation.ts
@@ -791,6 +791,7 @@ MessageReactionModel.belongsTo(UserModel, {
 });
 
 export type MentionStatusType =
+  | "pending" // DEPRECATED: use pending_conversation_access. Kept temporarily for migration.
   | "pending_conversation_access" // Waiting for user input to invite to conversation
   | "pending_project_membership" // Waiting for user input to add to project (mentioning user is project editor)
   | "approved" // Auto or manually approved

--- a/front/migrations/20260130_rename_pending_mention_status.sql
+++ b/front/migrations/20260130_rename_pending_mention_status.sql
@@ -1,7 +1,10 @@
--- Rename "pending" mention status to "pending_conversation_access".
+-- Migrate "pending" mention status to "pending_conversation_access".
+-- The code handles both "pending" and "pending_conversation_access" identically,
+-- so this migration can run before or after deploy without breaking anything.
 -- All existing "pending" are migrated to "pending_conversation_access" (the most common case)
 -- rather than trying to determine project vs conversation context, which would be complex
 -- and could show prompts to non-editors in project conversations.
+-- A follow-up PR will remove "pending" from the codebase once all data is migrated.
 UPDATE
     mentions
 SET

--- a/front/migrations/20260130_rename_pending_mention_status.sql
+++ b/front/migrations/20260130_rename_pending_mention_status.sql
@@ -1,0 +1,10 @@
+-- Rename "pending" mention status to "pending_conversation_access".
+-- All existing "pending" are migrated to "pending_conversation_access" (the most common case)
+-- rather than trying to determine project vs conversation context, which would be complex
+-- and could show prompts to non-editors in project conversations.
+UPDATE
+    mentions
+SET
+    status = 'pending_conversation_access'
+WHERE
+    status = 'pending';

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -117,7 +117,11 @@ export type AgenticMessageData = {
 };
 
 export type RichMentionWithStatus =
-  | (RichMention & { dismissed: boolean; status: "pending" })
+  | (RichMention & {
+      dismissed: boolean;
+      status: "pending_conversation_access";
+    })
+  | (RichMention & { dismissed: boolean; status: "pending_project_membership" })
   | (RichMention & { dismissed: boolean; status: "approved" })
   | (RichMention & { dismissed: boolean; status: "rejected" })
   | (RichMention & {

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -117,6 +117,7 @@ export type AgenticMessageData = {
 };
 
 export type RichMentionWithStatus =
+  | (RichMention & { dismissed: boolean; status: "pending" }) // DEPRECATED: kept for migration
   | (RichMention & {
       dismissed: boolean;
       status: "pending_conversation_access";


### PR DESCRIPTION
## Description

Context: [slack thread](https://dust4ai.slack.com/archives/C09T7N4S6GG/p1769699273241659)

Splits the generic `pending` mention status into two specific statuses:
- `pending_conversation_access`: for inviting users to regular conversations
- `pending_project_membership`: for adding users to projects (mentioner must be project editor)

Key logic change: when mentioning someone in a project conversation, if the current user is NOT an editor of the project, the status is now `user_restricted_by_conversation_access` instead of `pending`. The UI now shows a specific message for project conversations ("only project editors can add new members").

**Migration approach**: The old `pending` status is kept temporarily and handled identically to `pending_conversation_access`. This allows the migration to run before or after deploy without breaking anything. A follow-up PR will remove `pending` once all data is migrated.

Related issue for future improvement: https://github.com/dust-tt/tasks/issues/6571

## Risks

Blast radius: mention validation UI in conversations
Risk: low

## Deploy Plan

1. Deploy front (safe: handles both `pending` and `pending_conversation_access`)
2. Run migration `20260130_rename_pending_mention_status.sql` on front database
3. Follow-up PR to remove deprecated `pending` status