### PR TITLE
Fix: only allow agents using global space or project's space in project.

### DIFF
--- a/front/lib/api/assistant/conversation/mentions.test.ts
+++ b/front/lib/api/assistant/conversation/mentions.test.ts
@@ -1219,7 +1219,131 @@ describe("createAgentMessages", () => {
       expect(mentionInDb?.status).toBe("agent_restricted_by_space_usage");
     });
 
-    it("should allow agent mentions when agent uses open spaces other than conversation's space", async () => {
+    it("should allow agent mentions when agent uses global space other than conversation's space", async () => {
+      // Create a space for the conversation
+      const conversationSpace = await SpaceFactory.regular(workspace);
+      const user = auth.getNonNullableUser();
+      const adminAuth = await Authenticator.internalAdminForWorkspace(
+        workspace.sId
+      );
+      await conversationSpace.addMembers(adminAuth, {
+        userIds: [user.sId],
+      });
+
+      // Create a fresh authenticator after adding user to space to refresh permissions
+      const userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+        user.sId,
+        workspace.sId
+      );
+
+      // Fetch the global space
+      const globalSpace =
+        await SpaceResource.fetchWorkspaceGlobalSpace(adminAuth);
+      expect(globalSpace).not.toBeNull();
+      expect(globalSpace.isGlobal()).toBe(true);
+
+      // Refresh the conversation space to get updated permissions
+      const refreshedConversationSpace = await SpaceResource.fetchById(
+        userAuth,
+        conversationSpace.sId
+      );
+      expect(refreshedConversationSpace).not.toBeNull();
+
+      // Create conversation in the conversationSpace
+      const spaceConversation = await createConversation(userAuth, {
+        title: "Space Conversation",
+        visibility: "unlisted",
+        spaceId: refreshedConversationSpace!.id,
+      });
+
+      // Create agent configuration that uses both the conversation's space and the global space
+      const agentConfig = await AgentConfigurationFactory.createTestAgent(
+        userAuth,
+        {
+          name: "Global Space Agent",
+        }
+      );
+
+      const conversationSpaceModelId = getResourceIdFromSId(
+        refreshedConversationSpace!.sId
+      );
+      const globalSpaceModelId = getResourceIdFromSId(globalSpace.sId);
+      expect(conversationSpaceModelId).not.toBeNull();
+      expect(globalSpaceModelId).not.toBeNull();
+
+      await AgentConfigurationModel.update(
+        {
+          requestedSpaceIds: [conversationSpaceModelId!, globalSpaceModelId!],
+        },
+        {
+          where: {
+            workspaceId: workspace.id,
+            sId: agentConfig.sId,
+            version: agentConfig.version,
+          },
+        }
+      );
+
+      // Manually construct the updated agent config with requestedSpaceIds as sIds
+      // We can't use getAgentConfiguration because it filters by space access,
+      // and the agent now has global space requirements
+      const updatedAgentConfig: LightAgentConfigurationType = {
+        ...agentConfig,
+        requestedSpaceIds: [refreshedConversationSpace!.sId, globalSpace.sId],
+      };
+
+      const { userMessage } = await ConversationFactory.createUserMessage({
+        auth: userAuth,
+        workspace,
+        conversation: spaceConversation,
+        content: `Hello @${agentConfig.name}`,
+      });
+
+      const mentions: MentionType[] = [
+        {
+          configurationId: agentConfig.sId,
+        } satisfies AgentMention,
+      ];
+
+      const { agentMessages, richMentions } = await createAgentMessages(
+        userAuth,
+        {
+          conversation: spaceConversation,
+          metadata: {
+            type: "create",
+            mentions,
+            agentConfigurations: [updatedAgentConfig],
+            skipToolsValidation: false,
+            nextMessageRank: 1,
+            userMessage,
+          },
+        }
+      );
+
+      // Should create agent message successfully because global space is allowed
+      expect(agentMessages).toHaveLength(1);
+      expect(agentMessages[0].configuration.sId).toBe(agentConfig.sId);
+
+      // Verify richMentions are returned correctly
+      expect(richMentions).toHaveLength(1);
+      if (isRichAgentMention(richMentions[0])) {
+        expect(richMentions[0].id).toBe(agentConfig.sId);
+        expect(richMentions[0].status).toBe("approved");
+      }
+
+      // Verify mention was created with approved status
+      const mentionInDb = await MentionModel.findOne({
+        where: {
+          workspaceId: workspace.id,
+          messageId: userMessage.id,
+          agentConfigurationId: agentConfig.sId,
+        },
+      });
+      expect(mentionInDb).not.toBeNull();
+      expect(mentionInDb?.status).toBe("approved");
+    });
+
+    it("should reject agent mentions when agent uses open (non-global) spaces other than conversation's space", async () => {
       // Create a space for the conversation
       const conversationSpace = await SpaceFactory.regular(workspace);
       const user = auth.getNonNullableUser();
@@ -1263,6 +1387,8 @@ describe("createAgentMessages", () => {
       );
       expect(refreshedOpenSpace).not.toBeNull();
       expect(refreshedOpenSpace?.isOpen()).toBe(true);
+      // Verify it's not global
+      expect(refreshedOpenSpace?.isGlobal()).toBe(false);
 
       // Refresh the conversation space to get updated permissions
       const refreshedConversationSpace = await SpaceResource.fetchById(
@@ -1306,17 +1432,14 @@ describe("createAgentMessages", () => {
         }
       );
 
-      // Refresh agent config to get updated requestedSpaceIds
-      const updatedAgentConfigRes = await getAgentConfiguration(userAuth, {
-        agentId: agentConfig.sId,
-        agentVersion: agentConfig.version,
-        variant: "light",
-      });
-      expect(updatedAgentConfigRes).not.toBeNull();
-      if (!updatedAgentConfigRes) {
-        throw new Error("Failed to fetch updated agent configuration");
-      }
-      const updatedAgentConfig = updatedAgentConfigRes;
+      // Manually construct the updated agent config with requestedSpaceIds as sIds
+      const updatedAgentConfig: LightAgentConfigurationType = {
+        ...agentConfig,
+        requestedSpaceIds: [
+          refreshedConversationSpace!.sId,
+          refreshedOpenSpace!.sId,
+        ],
+      };
 
       const { userMessage } = await ConversationFactory.createUserMessage({
         auth: userAuth,
@@ -1346,18 +1469,17 @@ describe("createAgentMessages", () => {
         }
       );
 
-      // Should create agent message successfully because open spaces are allowed
-      expect(agentMessages).toHaveLength(1);
-      expect(agentMessages[0].configuration.sId).toBe(agentConfig.sId);
+      // Should NOT create agent message because open (non-global) spaces are rejected
+      expect(agentMessages).toHaveLength(0);
 
-      // Verify richMentions are returned correctly
+      // Verify richMentions shows the restriction
       expect(richMentions).toHaveLength(1);
       if (isRichAgentMention(richMentions[0])) {
         expect(richMentions[0].id).toBe(agentConfig.sId);
-        expect(richMentions[0].status).toBe("approved");
+        expect(richMentions[0].status).toBe("agent_restricted_by_space_usage");
       }
 
-      // Verify mention was created with approved status
+      // Verify mention was created with restricted status
       const mentionInDb = await MentionModel.findOne({
         where: {
           workspaceId: workspace.id,
@@ -1366,7 +1488,7 @@ describe("createAgentMessages", () => {
         },
       });
       expect(mentionInDb).not.toBeNull();
-      expect(mentionInDb?.status).toBe("approved");
+      expect(mentionInDb?.status).toBe("agent_restricted_by_space_usage");
     });
   });
 });

--- a/front/lib/api/assistant/conversation/mentions.ts
+++ b/front/lib/api/assistant/conversation/mentions.ts
@@ -677,7 +677,7 @@ export const createAgentMessages = async (
                     (spaceId) => spaceId !== conversation.spaceId
                   )
                 );
-                if (spaces.some((space) => !space.isOpen())) {
+                if (spaces.some((space) => !space.isGlobal())) {
                   // This create the mentions from the original user message.
                   // Not to be mixed with the mentions from the agent message (which will be filled later).
                   const mentionRow = await MentionModel.create(


### PR DESCRIPTION
## Description

I overlooked that even if the space used by an agent is open, we put it in the requestedSpaceIds. If later it became restricted, the conversation would potentially become unreachable for some project members.
(i did not do the same mistake for content node)

## Tests

Updated & added

## Risk

Low

## Deploy Plan

Deploy front