### PR TITLE
[front] Bind ipv5 addr to fix forward

### DIFF
--- a/x/henry/dust-hive/src/forward-daemon.ts
+++ b/x/henry/dust-hive/src/forward-daemon.ts
@@ -91,6 +91,7 @@ function createForwarder(listenPort: number, targetPort: number, name: string) {
             close(upstream) {
               const clientSocket = upstream.data.upstream;
               if (clientSocket && !upstream.data.clientClosed) {
+                clientSocket.flush();
                 clientSocket.end();
               }
             },
@@ -144,6 +145,7 @@ function createForwarder(listenPort: number, targetPort: number, name: string) {
         const upstream = client.data.upstream;
         if (upstream) {
           upstream.data.clientClosed = true;
+          upstream.flush();
           upstream.end();
         }
       },

--- a/x/henry/dust-hive/src/lib/registry.ts
+++ b/x/henry/dust-hive/src/lib/registry.ts
@@ -103,7 +103,7 @@ export const SERVICE_REGISTRY: Record<ServiceName, ServiceConfig> = {
     cwd: "front-spa",
     needsNvm: false,
     needsEnvSh: true,
-    buildCommand: (env) => `npm run dev:poke -- --port ${env.ports.frontSpaPoke}`,
+    buildCommand: (env) => `npm run dev:poke -- --port ${env.ports.frontSpaPoke} --host 127.0.0.1`,
     readinessCheck: {
       type: "http",
       url: (ports) => `http://localhost:${ports.frontSpaPoke}/`,
@@ -114,7 +114,7 @@ export const SERVICE_REGISTRY: Record<ServiceName, ServiceConfig> = {
     cwd: "front-spa",
     needsNvm: false,
     needsEnvSh: true,
-    buildCommand: (env) => `npm run dev:app -- --port ${env.ports.frontSpaApp}`,
+    buildCommand: (env) => `npm run dev:app -- --port ${env.ports.frontSpaApp} --host 127.0.0.1`,
     readinessCheck: {
       type: "http",
       url: (ports) => `http://localhost:${ports.frontSpaApp}/`,


### PR DESCRIPTION
## Description

vite binds by default to ipv6, force 127.0.0.1 to make it usable with forwarder.
add flush before closing as some data were truncated.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
