### PR TITLE
fix(connectors): prevent incremental sync from hiding full sync status in Google Drive UI

### DIFF
--- a/connectors/src/connectors/google_drive/temporal/activities/index.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities/index.ts
@@ -6,6 +6,7 @@ export { getDrivesToSync } from "./get_drives_to_sync";
 export { getFilesCountForSync } from "./get_files_count_for_sync";
 export { getFoldersToSync } from "./get_folders_to_sync";
 export { incrementalSync } from "./incremental_sync";
+export { isGoogleDriveFullSyncRunning } from "./is_full_sync_running";
 export { markFolderAsVisited } from "./mark_folder_as_visited";
 export { populateSyncTokens } from "./populate_sync_tokens";
 export { shouldGarbageCollect } from "./should_garbage_collect";

--- a/connectors/src/connectors/google_drive/temporal/activities/is_full_sync_running.ts
+++ b/connectors/src/connectors/google_drive/temporal/activities/is_full_sync_running.ts
@@ -1,0 +1,21 @@
+import { WorkflowNotFoundError } from "@temporalio/client";
+
+import { getTemporalClient } from "@connectors/lib/temporal";
+import type { ModelId } from "@connectors/types";
+
+export async function isGoogleDriveFullSyncRunning(
+  connectorId: ModelId
+): Promise<boolean> {
+  const client = await getTemporalClient();
+  const workflowId = `googleDrive-fullSync-${connectorId}`;
+  try {
+    const handle = client.workflow.getHandle(workflowId);
+    const description = await handle.describe();
+    return description.status.name === "RUNNING";
+  } catch (e) {
+    if (e instanceof WorkflowNotFoundError) {
+      return false;
+    }
+    throw e;
+  }
+}

--- a/connectors/src/connectors/google_drive/temporal/workflows.ts
+++ b/connectors/src/connectors/google_drive/temporal/workflows.ts
@@ -28,6 +28,7 @@ const {
   garbageCollector,
   getFilesCountForSync,
   getFoldersToSync,
+  isGoogleDriveFullSyncRunning,
   populateSyncTokens,
   garbageCollectorFinished,
   markFolderAsVisited,
@@ -196,7 +197,10 @@ export async function googleDriveIncrementalSync(
   nextPageToken: string | undefined = undefined
 ) {
   if (!startSyncTs) {
-    await syncStarted(connectorId);
+    const fullSyncRunning = await isGoogleDriveFullSyncRunning(connectorId);
+    if (!fullSyncRunning) {
+      await syncStarted(connectorId);
+    }
     startSyncTs = new Date().getTime();
   }
 
@@ -289,7 +293,10 @@ export async function googleDriveIncrementalSync(
     });
   }
 
-  await syncSucceeded(connectorId);
+  const fullSyncRunning = await isGoogleDriveFullSyncRunning(connectorId);
+  if (!fullSyncRunning) {
+    await syncSucceeded(connectorId);
+  }
 
   await sleep("5 minutes");
   await continueAsNew<typeof googleDriveIncrementalSync>(connectorId);
@@ -717,7 +724,10 @@ export async function googleDriveIncrementalSyncV2(
   startSyncTs: number | undefined = undefined
 ) {
   if (!startSyncTs) {
-    await syncStarted(connectorId);
+    const fullSyncRunning = await isGoogleDriveFullSyncRunning(connectorId);
+    if (!fullSyncRunning) {
+      await syncStarted(connectorId);
+    }
     startSyncTs = new Date().getTime();
   }
 
@@ -775,7 +785,10 @@ export async function googleDriveIncrementalSyncV2(
     });
   }
 
-  await syncSucceeded(connectorId);
+  const fullSyncRunning = await isGoogleDriveFullSyncRunning(connectorId);
+  if (!fullSyncRunning) {
+    await syncSucceeded(connectorId);
+  }
 
   // Sleep and continue
   await sleep("5 minutes");


### PR DESCRIPTION
## Description

Same fix as #20790 (Microsoft connector), now applied to Google Drive.

The incremental sync workflows (`googleDriveIncrementalSync` and `googleDriveIncrementalSyncV2`) run every ~5 minutes and call `syncStarted`/`syncSucceeded`, which overwrites the timestamps set by the full sync workflow. This causes the UI to only briefly show full sync progress before the incremental sync hides it.

This PR adds an `isGoogleDriveFullSyncRunning` activity that checks whether the full sync workflow (`googleDrive-fullSync-{connectorId}`) is currently running. Both incremental sync workflows now skip `syncStarted`/`syncSucceeded` when a full sync is in progress.

## Tests

- Build passes (`cd connectors && npm run build`).
- Verified the pattern matches the already-merged Microsoft connector fix.

## Risk

Low — the change only skips sync status updates when a full sync is already running and reporting its own status. No data flow or sync logic is affected.

## Deploy Plan

Standard deploy. No migration or special ordering needed.