### PR TITLE
fix: allow creating API keys with the same name as deactivated keys

### DIFF
--- a/front/lib/resources/key_resource.ts
+++ b/front/lib/resources/key_resource.ts
@@ -114,11 +114,15 @@ export class KeyResource extends BaseResource<KeyModel> {
     return key;
   }
 
-  static async fetchByName(auth: Authenticator, { name }: { name: string }) {
+  static async fetchByName(
+    auth: Authenticator,
+    { name, onlyActive }: { name: string; onlyActive?: boolean }
+  ) {
     const key = await this.model.findOne({
       where: {
         workspaceId: auth.getNonNullableWorkspace().id,
         name: name,
+        ...(onlyActive ? { status: "active" } : {}),
       },
     });
 

--- a/front/pages/api/w/[wId]/keys/index.ts
+++ b/front/pages/api/w/[wId]/keys/index.ts
@@ -99,6 +99,7 @@ async function handler(
 
       const existingKey = await KeyResource.fetchByName(auth, {
         name: trimmedName,
+        onlyActive: true,
       });
       if (existingKey) {
         return apiError(req, res, {


### PR DESCRIPTION
## Description

When a user deactivates an API key and then tries to create a new one with the same name, the backend rejects it because `fetchByName` matches disabled keys too. This adds an optional `onlyActive` param to `fetchByName` and uses it in the key creation endpoint, so only active keys block name reuse.

## Tests

- Typecheck passes (`tsc --noEmit`)
- The other caller of `fetchByName` (`admin/cli.ts`) is unaffected — it doesn't pass `onlyActive`, preserving existing behavior

## Risk

Low. Default behavior of `fetchByName` is unchanged. Only the key creation endpoint opts in to the new filter.

## Deploy Plan

Standard deploy — no migrations, no feature flags needed.