### PR TITLE
[front] Add dust-next global agent for custom model testing

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -47,6 +47,7 @@ import {
   MAX_STEPS_USE_PER_RUN_LIMIT,
 } from "@app/types";
 import { DUST_AVATAR_URL } from "@app/types/assistant/avatar";
+import { CUSTOM_MODEL_CONFIGS } from "@app/types/assistant/models/custom_models.generated";
 
 const INSTRUCTION_SECTIONS = {
   primary: `<primary_goal>
@@ -593,6 +594,27 @@ export function _getDustOaiGlobalAgent(
     agentId: GLOBAL_AGENTS_SID.DUST_OAI,
     name: "dust-oai",
     preferredModelConfiguration: GPT_5_2_MODEL_CONFIG,
+    preferredReasoningEffort: "light",
+  });
+}
+
+export function _getDustNextGlobalAgent(
+  auth: Authenticator,
+  args: {
+    settings: GlobalAgentSettingsModel | null;
+    preFetchedDataSources: PrefetchedDataSourcesType | null;
+    mcpServerViews: MCPServerViewsForGlobalAgentsMap;
+    memories: AgentMemoryResource[];
+    availableToolsets: MCPServerViewResource[];
+  }
+): AgentConfigurationType | null {
+  const customModel = CUSTOM_MODEL_CONFIGS[0];
+
+  return _getDustLikeGlobalAgent(auth, args, {
+    agentId: GLOBAL_AGENTS_SID.DUST_NEXT,
+    name: "dust-next",
+    preferredModelConfiguration:
+      customModel ?? CLAUDE_4_5_OPUS_DEFAULT_MODEL_CONFIG,
     preferredReasoningEffort: "light",
   });
 }

--- a/front/lib/api/assistant/global_agents/global_agent_metadata.ts
+++ b/front/lib/api/assistant/global_agents/global_agent_metadata.ts
@@ -280,6 +280,14 @@ export function getGlobalAgentMetadata(sId: GLOBAL_AGENTS_SID): AgentMetadata {
         description: "Same as dust but running OpenAI models.",
         pictureUrl: DUST_AVATAR_URL,
       };
+    case GLOBAL_AGENTS_SID.DUST_NEXT:
+      return {
+        sId: GLOBAL_AGENTS_SID.DUST_NEXT,
+        name: "dust-next",
+        description:
+          "Same as dust but running a custom model for internal testing.",
+        pictureUrl: DUST_AVATAR_URL,
+      };
     case GLOBAL_AGENTS_SID.DUST:
       return {
         sId: GLOBAL_AGENTS_SID.DUST,

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -77,6 +77,7 @@ import {
   isGlobalAgentId,
   isProviderWhitelisted,
 } from "@app/types";
+import { CUSTOM_MODEL_CONFIGS } from "@app/types/assistant/models/custom_models.generated";
 import type { FavoritePlatform } from "@app/types/favorite_platforms";
 import { isFavoritePlatform } from "@app/types/favorite_platforms";
 import type { JobType } from "@app/types/job_type";
@@ -534,6 +535,13 @@ export async function getGlobalAgents(
     );
   }
   if (!flags.includes("dust_next_global_agent")) {
+    agentsIdsToFetch = agentsIdsToFetch.filter(
+      (sId) => sId !== GLOBAL_AGENTS_SID.DUST_NEXT
+    );
+  }
+  // Also hide dust-next if the custom model's own feature flag isn't enabled.
+  const customModelFlag = CUSTOM_MODEL_CONFIGS[0]?.featureFlag;
+  if (customModelFlag && !flags.includes(customModelFlag)) {
     agentsIdsToFetch = agentsIdsToFetch.filter(
       (sId) => sId !== GLOBAL_AGENTS_SID.DUST_NEXT
     );

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -20,6 +20,7 @@ import {
 import {
   _getDustEdgeGlobalAgent,
   _getDustGlobalAgent,
+  _getDustNextGlobalAgent,
   _getDustOaiGlobalAgent,
   _getDustQuickGlobalAgent,
 } from "@app/lib/api/assistant/global_agents/configurations/dust/dust";
@@ -374,6 +375,15 @@ function getGlobalAgent({
         availableToolsets,
       });
       break;
+    case GLOBAL_AGENTS_SID.DUST_NEXT:
+      agentConfiguration = _getDustNextGlobalAgent(auth, {
+        settings,
+        preFetchedDataSources,
+        mcpServerViews,
+        memories,
+        availableToolsets,
+      });
+      break;
     case GLOBAL_AGENTS_SID.DEEP_DIVE:
       agentConfiguration = _getDeepDiveGlobalAgent(auth, {
         settings,
@@ -523,6 +533,11 @@ export async function getGlobalAgents(
       (sId) => sId !== GLOBAL_AGENTS_SID.DUST_OAI
     );
   }
+  if (!flags.includes("dust_next_global_agent")) {
+    agentsIdsToFetch = agentsIdsToFetch.filter(
+      (sId) => sId !== GLOBAL_AGENTS_SID.DUST_NEXT
+    );
+  }
   if (!flags.includes("agent_builder_copilot")) {
     agentsIdsToFetch = agentsIdsToFetch.filter(
       (sId) => sId !== GLOBAL_AGENTS_SID.COPILOT
@@ -537,7 +552,8 @@ export async function getGlobalAgents(
     (agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST) ||
       agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST_EDGE) ||
       agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST_QUICK) ||
-      agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST_OAI))
+      agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST_OAI) ||
+      agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST_NEXT))
   ) {
     memories = await AgentMemoryResource.findByAgentConfigurationIdAndUser(
       auth,
@@ -554,7 +570,8 @@ export async function getGlobalAgents(
     (agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST) ||
       agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST_EDGE) ||
       agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST_QUICK) ||
-      agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST_OAI))
+      agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST_OAI) ||
+      agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST_NEXT))
   ) {
     const globalSpace = await SpaceResource.fetchWorkspaceGlobalSpace(auth);
     availableToolsets = await MCPServerViewResource.listBySpace(

--- a/front/types/assistant/assistant.ts
+++ b/front/types/assistant/assistant.ts
@@ -110,6 +110,7 @@ export enum GLOBAL_AGENTS_SID {
   DUST_EDGE = "dust-edge",
   DUST_QUICK = "dust-quick",
   DUST_OAI = "dust-oai",
+  DUST_NEXT = "dust-next",
   DEEP_DIVE = "deep-dive",
   DUST_TASK = "dust-task",
   DUST_BROWSER_SUMMARY = "dust-browser-summary",

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -26,6 +26,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Access to dust-oai global agent running OpenAI models",
     stage: "dust_only",
   },
+  dust_next_global_agent: {
+    description:
+      "Access to dust-next global agent running a custom model for internal testing",
+    stage: "dust_only",
+  },
   notion_private_integration: {
     description: "Setup Notion private integration tokens",
     stage: "on_demand",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -668,6 +668,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "dust_edge_global_agent"
   | "dust_quick_global_agent"
   | "dust_oai_global_agent"
+  | "dust_next_global_agent"
   | "fireworks_new_model_feature"
   | "front_tool"
   | "google_drive_write_enabled"


### PR DESCRIPTION
## Description

Adds a new `dust-next` global agent that uses the first custom model from `CUSTOM_MODEL_CONFIGS` (loaded from GCS at build time via #20831), falling back to Claude 4.5 Opus if no custom model is configured.

This allows us to test new models in production through the familiar dust-like agent interface, without hardcoding model configurations.

### Changes
- Added `DUST_NEXT` to `GLOBAL_AGENTS_SID` enum
- Added `_getDustNextGlobalAgent` function following the same pattern as dust-edge/dust-quick/dust-oai
- Added `dust_next_global_agent` feature flag (dust_only stage)
- Registered the agent in the global agents dispatcher, metadata, memories, and toolsets prefetch

## Tests

Tested locally by generating `custom_models.generated.ts` from GCS and verifying the agent appears with the custom model config. Typecheck passes.

## Risk

Low — gated behind `dust_next_global_agent` feature flag with `dust_only` stage. Falls back to Claude 4.5 Opus if no custom model is present.

## Deploy Plan

1. Merge and deploy
2. Enable `dust_next_global_agent` feature flag on target workspaces
3. Ensure `custom_model_feature` flag is also enabled (required by the custom model's own feature gate)