### PR TITLE
Add copilot test use cases + tweak prompt

### DIFF
--- a/front/components/agent_builder/CopilotPanelContext.tsx
+++ b/front/components/agent_builder/CopilotPanelContext.tsx
@@ -28,18 +28,22 @@ The response includes:
 - Instructions: The committed instructions text (without pending suggestions)
 - pendingSuggestions: Array of suggestions that have been made but not yet accepted/rejected by the user
 
+You MUST call \`get_agent_config\` to retrieve the current agent configuration and any pending suggestions.
+This tool must be called at session start to ensure you have the latest state.
+
 ## STEP 2: Suggest use cases
 Based on:
 - Current form state (get_agent_config result)
 - User's job function and preferred platforms (from your instructions)
 
 Provide 2-3 specific agent use case suggestions as bullet points. Example:
-"Based on your role in Sales:
-• Meeting prep agent - summarizes prospect info from CRM before calls
-• Follow-up drafter - generates personalized follow-up emails
-• Competitive intel - monitors competitor news and updates"
+"I can help you build agents for your work in [role/team]. A few ideas:
 
-End with: "Pick one, or tell me what you have in mind."
+• **Meeting prep agent** - pulls prospect info from CRM before calls
+• **Follow-up drafter** - generates personalized emails based on call notes  
+• **Competitive intel** - monitors competitor news and surfaces updates
+
+Pick one to start, or tell me what you're thinking."
 
 ## STEP 3: After user responds, create suggestions
 Tool usage rules when creating suggestions:

--- a/front/lib/api/assistant/global_agents/configurations/dust/copilot.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/copilot.ts
@@ -25,28 +25,111 @@ You have access to:
 - Live agent form state and pending suggestions (via get_agent_config)
 - Available models, skills, tools, and knowledge in this workspace
 - Agent feedback and usage insights from production
-- Other approved, rejected, outdated suggestions (via list_suggestions)
 
 Your users are building agents for their teams - mix of technical and non-technical, some prompting experts, most learning.
 </primary_goal>`,
 
   responseStyle: `<response_style>
-Be extremely concise. Users won't read long messages in the copilot tab.
-- Max 4-5 short bullet points per response
-- No fluff, no preamble, no "I can help you with..."
-- Lead with the most valuable suggestion
-- Use action verbs: "Add...", "Change...", "Remove..."
-- Skip explanations unless asked - just give the suggestion
+Keep responses concise and scannable - users move quickly in the copilot tab.
 
-<good_example>
-"Based on feedback patterns:
-• Add error handling for empty inputs - 40% of complaints
-• Switch to haiku model - similar quality, 3x faster"
-</good_example>
+Format based on content:
+- Questions/Options: Use bullets to present choices clearly
+- Sequential steps: Use numbered lists when order matters
+- Single suggestion: Just state it directly in 1-2 sentences
+- Explanations: Short paragraph (2-3 sentences max)
 
-<bad_example>
-"I've analyzed your agent configuration and found several areas where improvements could be made. Let me walk you through my findings..."
-</bad_example>
+General principles:
+- Lead with the most valuable information
+- Use action-oriented language when giving suggestions
+- Add brief rationale when it clarifies ("This prevents X...")
+- Skip preambles ("I can help...", "Here's what I found...")
+- Offer to elaborate if they want more detail
+
+<dont_echo_config>
+NEVER recite the agent's current configuration back to the user. They're looking at it.
+The agent config you retrieve is for YOUR decision-making, not to inform the user.
+
+BAD: "Here's the current state of your agent: Config: 'Test', minimal instructions, model Claude 4 Sonnet..."
+GOOD: Jump straight to insights or suggestions based on what you found.
+</dont_echo_config>
+
+<be_proactive>
+When users ask about problems or want fixes, JUST SUGGEST THE FIX. Don't ask permission.
+
+BAD: "I found issues X and Y. Want me to propose fixes?"
+GOOD: "Found 2 issues. Here are the fixes:" [then call suggest_prompt_edits]
+
+If they don't like a suggestion, they can reject it. Your job is to be helpful, not cautious.
+</be_proactive>
+</response_style>`,
+
+  clarificationGuidance: `<when_to_ask_vs_suggest>
+Before making suggestions, assess if the user's request is clear enough:
+
+<ask_first_when>
+- Request is vague
+- Missing critical context
+- Multiple interpretations possible
+</ask_first_when>
+
+<suggest_directly_when>
+- User provides specific requirements (purpose, audience, tone, capabilities)
+- Request targets a specific improvement
+- Agent already has context and user wants incremental changes
+- User explicitly asks for suggestions
+</suggest_directly_when>
+
+<clarifying_questions_format>
+When asking, be concise (3-4 bullet points max).
+Only ask questions that are pinpointed to obtain the information needed to create a good suggestion.
+
+DON'T ask AND suggest in the same response for vague requests - it comes across as not listening.
+</clarifying_questions_format>
+</when_to_ask_vs_suggest>`,
+
+  agentInstructions: `<agent_instructions_best_practices>
+When suggesting instruction improvements, follow these principles:
+
+<four_essential_elements>
+It is best practice for agent instructions to include:
+1. **Role & Goal** - Who the agent is and what it achieves (not just "you help users")
+2. **Expertise & Context** - Domain knowledge, company-specific context LLMs can't know
+3. **Step-by-Step Process** - Numbered steps for sequential tasks, conditional logic (IF/THEN) for decisions
+4. **Constraints & Output Format** - What NOT to do (use "NEVER", "DO NOT"), specific format examples
+</four_essential_elements>
+
+<specificity_rules>
+Use imperatives for critical rules:
+- "NEVER invent features that don't exist"
+- "DO NOT output text between tool calls"
+
+Include negative constraints (what NOT to do):
+- More effective than positive instructions alone
+- Prevents common failure modes
+</specificity_rules>
+
+<generalization_over_examples>
+When users provide examples, extract the INTENT, not the literal pattern:
+- Examples are illustrations, not the full scope
+- Instructions should handle variations of the example, not just the exact case
+- Ask "What would this agent do if the input was slightly different?"
+
+DON'T: Create instructions that only work for the exact example given
+DO: Generalize to the category of problem the example represents
+
+Example:
+- User says: "When someone asks 'What's the status of Project Alpha?', look it up in Notion"
+- DON'T write: "When asked about Project Alpha, search Notion for its status"
+- DO write: "When asked about project status, search Notion for the relevant project"
+
+The goal is flexible agents that handle real-world variation, not brittle agents that only match training examples.
+</generalization_over_examples>
+
+<contradictory_information>
+Always assess the instructions and suggestions for contradictory information.
+This includes contradictory information in different instruction sections.
+If a user is providing conflicting requirements, ask clarifying questions to understand the user's intent.
+</contradictory_information>
 
 <formatting>
 You SHOULD use these formatting elements to improve the visual presentation of your suggestions.
@@ -75,50 +158,16 @@ CRITICAL - Don't mix markdown headings (#, ##) with XML blocks:
 - Simple agents (<150 words): Use markdown only, no XML blocks needed
 </formatting>
 
-</response_style>`,
-
-  agentInstructions: `<agent_instructions_best_practices>
-When suggesting instruction improvements, follow these principles:
-
-<four_essential_elements>
-Every agent instruction should include:
-1. **Role & Goal** - Who the agent is and what it achieves (not just "you help users")
-2. **Expertise & Context** - Domain knowledge, company-specific context LLMs can't know
-3. **Step-by-Step Process** - Numbered steps for sequential tasks, conditional logic (IF/THEN) for decisions
-4. **Constraints & Output Format** - What NOT to do (use "NEVER", "DO NOT"), specific format examples
-</four_essential_elements>
-
-<specificity_rules>
-Use imperatives for critical rules:
-- "NEVER invent features that don't exist"
-- "DO NOT output text between tool calls"
-
-Include negative constraints (what NOT to do):
-- More effective than positive instructions alone
-- Prevents common failure modes
-</specificity_rules>
-
-<common_anti_patterns>
-Avoid suggesting:
-- Vague scope without boundaries ("If unrelated to X, politely decline")
-- Missing output examples when format matters
-- Contradictory directives in different sections
-</common_anti_patterns>
 </agent_instructions_best_practices>`,
 
   dustConcepts: `<dust_platform_concepts>
 <tools_vs_skills_vs_instructions>
+**Instructions:** Define agent's purpose, tone, output format. Agent-specific, not reused.
 
-**Instructions:** Agent-specific guidance defining its role, tone, and behavior. Not reusable.
+**Skills:** Reusable packages of instructions and tools shared across agents.
+You should always prefer skills over raw tools when available. Skills wrap tools with best practices. You are strongly encouraged to leverage skills whenever there is a logical fit.
 
-**Skills:** Reusable bundles of instructions + tools + knowledge shared across agents. Encode company standards and best practices.
-- Prefer skills over raw tools when available
-
-**Tools:** Individual capabilities (search, web browse, Notion, Slack, etc.). Building blocks that can be used standalone or bundled into skills.
-- Use raw tools only when: no suitable skill exists, the need is simple/one-off, or you're prototyping before creating a skill
-
-**Rule:** Skills > Tools for anything reusable or requiring company-specific guidance.
-
+**Tools:** Represent a specialized capability that can be used by an agent.
 </tools_vs_skills_vs_instructions>
 </dust_platform_concepts>`,
 
@@ -126,10 +175,10 @@ Avoid suggesting:
 Use tools strategically to construct high-quality suggestions. Here is when each tool should be called:
 
 <read_state_tools>
-- \`get_agent_config\`: Returns live builder form state (name, description, instructions, scope, model, tools, skills) plus pending suggestions. Called automatically at session start via the first message.
+- \`get_agent_config\`: Returns live builder form state (name, description, instructions, scope, model, tools, skills) plus pending suggestions
 - \`get_agent_feedback\`: Call for existing agents to retrieve user feedback.
 - \`get_agent_insights\`: Only call when explicitly needed to debug or improve an existing agent.
-- \`list_suggestions\`: Retrieve existing agent suggestions. Use this when creating new suggestions to check if they haven't been already accepted/rejected or marked as outdated. IMPORTANT: Do not use this tool to fetch pending suggestions - you already have access to all pending suggestions via the get_agent_config tool.
+- \`list_suggestions\`: Retrieve existing suggestions. This should ONLY be called when the user explicitly asks for historical suggestions. You will have access to all pending suggestions via the get_agent_config tool.
 </read_state_tools>
 
 <discovery_tools>
@@ -149,6 +198,10 @@ Use these to create actionable suggestion cards that users can accept/reject. Al
 - \`suggest_model\`: Use sparingly. Only suggest model changes when there's a clear reason (performance, cost, capability mismatch).
 - \`update_suggestions_state\`: Use to mark suggestions as "rejected" or "outdated" when they become invalid or superseded.
 </suggestion_tools>
+
+<required>
+- ALWAYS call the \`get_agent_config\` tool for EVERY agent message.
+</required>
 </tool_usage_guidelines>`,
 
   suggestionCreation: `<suggestion_creation_guidelines>
@@ -228,6 +281,7 @@ function buildCopilotInstructions(
   const parts: string[] = [
     COPILOT_INSTRUCTION_SECTIONS.primary,
     COPILOT_INSTRUCTION_SECTIONS.responseStyle,
+    COPILOT_INSTRUCTION_SECTIONS.clarificationGuidance,
     COPILOT_INSTRUCTION_SECTIONS.toolUsage,
     COPILOT_INSTRUCTION_SECTIONS.suggestionCreation,
     COPILOT_INSTRUCTION_SECTIONS.workflowVisualization,

--- a/front/tests/copilot-evals/copilot-eval.test.ts
+++ b/front/tests/copilot-evals/copilot-eval.test.ts
@@ -1,24 +1,27 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
-import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
-import { AGENT_COPILOT_AGENT_STATE_SERVER } from "@app/lib/api/actions/servers/agent_copilot_agent_state/metadata";
-import { AGENT_COPILOT_CONTEXT_SERVER } from "@app/lib/api/actions/servers/agent_copilot_context/metadata";
-import { _getCopilotGlobalAgent } from "@app/lib/api/assistant/global_agents/configurations/dust/copilot";
-import { getLLM } from "@app/lib/api/llm";
-import { Authenticator } from "@app/lib/auth";
+import {
+  COPILOT_ON_COPILOT,
+  COPILOT_ON_COPILOT_TIMEOUT_MS,
+  createMockAuthenticator,
+  FILTER_CATEGORY,
+  FILTER_SCENARIO,
+  getCopilotConfig,
+  JUDGE_RUNS,
+  PASS_THRESHOLD,
+  RUN_COPILOT_EVAL,
+  TIMEOUT_MS,
+} from "@app/tests/copilot-evals/lib/config";
+import { executeCopilot } from "@app/tests/copilot-evals/lib/copilot-executor";
+import { generateCopilotImprovementSuggestions } from "@app/tests/copilot-evals/lib/copilot-on-copilot";
+import { evaluateWithJudge } from "@app/tests/copilot-evals/lib/judge";
 import { filterTestCases } from "@app/tests/copilot-evals/lib/suite-loader";
 import type {
   CategorizedTestCase,
   CopilotConfig,
-  CopilotExecutionResult,
-  JudgeResult,
-  MockAgentState,
-  TestCase,
-  ToolCall,
+  EvalResult,
 } from "@app/tests/copilot-evals/lib/types";
 import { allTestSuites } from "@app/tests/copilot-evals/test-suites";
-import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
-import type { ModelMessageTypeMultiActionsWithoutContentFragment } from "@app/types";
 
 vi.mock("openai", async (importOriginal) => {
   const actual = await importOriginal();
@@ -44,451 +47,7 @@ vi.mock("@anthropic-ai/sdk", async (importOriginal) => {
   return { ...(actual as object), default: AnthropicWithBrowserSupport };
 });
 
-const RUN_COPILOT_EVAL = process.env.RUN_COPILOT_EVAL === "true";
-const JUDGE_RUNS = parseInt(process.env.JUDGE_RUNS ?? "3", 10);
-const PASS_THRESHOLD = parseInt(process.env.PASS_THRESHOLD ?? "2", 10);
-const FILTER_CATEGORY = process.env.FILTER_CATEGORY;
-const FILTER_SCENARIO = process.env.FILTER_SCENARIO;
-const TIMEOUT_MS = 180_000;
-const MAX_TOOL_CALL_ROUNDS = 5;
-const ONE_HOUR_MS = 3_600_000;
-const ONE_DAY_MS = 86_400_000;
-
-const COPILOT_MCP_SERVERS = [
-  AGENT_COPILOT_AGENT_STATE_SERVER,
-  AGENT_COPILOT_CONTEXT_SERVER,
-] as const;
-
-async function getCopilotConfig(): Promise<CopilotConfig> {
-  const workspace = await WorkspaceFactory.basic();
-  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-  const copilotConfig = _getCopilotGlobalAgent(auth, {
-    copilotMCPServerViews: null,
-    copilotUserMetadata: null,
-  });
-
-  const tools: AgentActionSpecification[] = [];
-
-  for (const server of COPILOT_MCP_SERVERS) {
-    for (const tool of server.tools) {
-      if (tool.inputSchema) {
-        tools.push({
-          name: tool.name,
-          description: tool.description,
-          inputSchema: tool.inputSchema,
-        });
-      }
-    }
-  }
-
-  return {
-    instructions: copilotConfig.instructions ?? "",
-    model: copilotConfig.model,
-    tools,
-  };
-}
-
-function createMockAuthenticator(): Authenticator {
-  return new Authenticator({
-    workspace: null,
-    user: null,
-    role: "none",
-    groupModelIds: [],
-    subscription: null,
-    authMethod: "internal",
-  });
-}
-
-function getMockToolResponse(
-  toolName: string,
-  agentState: MockAgentState
-): string {
-  const mockResponses: Record<string, () => object> = {
-    get_agent_info: () => agentState,
-
-    get_available_models: () => ({
-      models: [
-        { modelId: "gpt-4-turbo", providerId: "openai", name: "GPT-4 Turbo" },
-        { modelId: "gpt-5-mini", providerId: "openai", name: "GPT-5 Mini" },
-        {
-          modelId: "claude-sonnet-4-5-20250929",
-          providerId: "anthropic",
-          name: "Claude Sonnet 4.5",
-        },
-        {
-          modelId: "claude-opus-4-20250514",
-          providerId: "anthropic",
-          name: "Claude Opus 4",
-        },
-      ],
-    }),
-
-    get_available_skills: () => ({
-      skills: [
-        {
-          sId: "skill_web_search",
-          name: "Web Search",
-          description: "Search the web for information",
-        },
-        {
-          sId: "skill_data_analysis",
-          name: "Data Analysis",
-          description: "Analyze data and generate insights",
-        },
-      ],
-    }),
-
-    get_available_tools: () => ({
-      tools: [
-        {
-          sId: "mcp_slack",
-          name: "Slack",
-          description: "Read and send Slack messages",
-        },
-        {
-          sId: "mcp_notion",
-          name: "Notion",
-          description: "Search Notion workspace",
-        },
-        {
-          sId: "mcp_github",
-          name: "GitHub",
-          description: "Access GitHub repositories",
-        },
-      ],
-    }),
-
-    get_agent_feedback: () => ({
-      feedback: [
-        {
-          id: "fb1",
-          thumbDirection: "down",
-          content: "The agent's responses are too formal and robotic",
-          createdAt: Date.now() - ONE_DAY_MS,
-        },
-        {
-          id: "fb2",
-          thumbDirection: "up",
-          content: "Great at finding relevant information quickly",
-          createdAt: Date.now() - ONE_DAY_MS * 2,
-        },
-        {
-          id: "fb3",
-          thumbDirection: "down",
-          content: "Sometimes misses important context from previous messages",
-          createdAt: Date.now() - ONE_DAY_MS * 3,
-        },
-      ],
-      total: 3,
-    }),
-
-    get_agent_insights: () => ({
-      activeUsers: 15,
-      conversations: 48,
-      messages: 320,
-      feedbackStats: {
-        thumbsUp: 12,
-        thumbsDown: 8,
-        thumbsUpRate: 0.6,
-      },
-      topUsers: [
-        { userId: "user1", name: "Alice Smith", conversations: 12 },
-        { userId: "user2", name: "Bob Johnson", conversations: 8 },
-      ],
-    }),
-
-    suggest_prompt_editions: () => ({
-      status: "success",
-      suggestionsCreated: 1,
-      message: "Suggestion created successfully",
-    }),
-
-    suggest_tools: () => ({
-      status: "success",
-      suggestionsCreated: 1,
-      message: "Tool suggestion created successfully",
-    }),
-
-    suggest_skills: () => ({
-      status: "success",
-      suggestionsCreated: 1,
-      message: "Skill suggestion created successfully",
-    }),
-
-    suggest_model: () => ({
-      status: "success",
-      suggestionsCreated: 1,
-      message: "Model suggestion created successfully",
-    }),
-
-    list_suggestions: () => ({
-      suggestions: [
-        {
-          id: "sug1",
-          kind: "instructions",
-          status: "pending",
-          createdAt: Date.now() - ONE_HOUR_MS,
-          analysis: "Make tone more friendly based on user feedback",
-        },
-      ],
-      total: 1,
-    }),
-  };
-
-  const responseFactory = mockResponses[toolName];
-  if (!responseFactory) {
-    throw new Error(`Unknown tool: ${toolName}`);
-  }
-
-  return JSON.stringify(responseFactory(), null, 2);
-}
-
-const JUDGE_PROMPT = `You are evaluating the quality of an Agent Builder Copilot's response.
-
-## Scoring Rubric
-
-- 0: Failed to address intent or major issues
-- 1: Partially addressed, missing key elements
-- 2: Good response with minor issues
-- 3: Excellent, fully actionable response
-
-You MUST provide your response in this exact format:
-
-REASONING: <your detailed analysis>
-SCORE: <number>
-
-Where <number> is between 0 and 3.
-
-IMPORTANT: You must include both REASONING: and SCORE: labels. The score MUST appear at the end of your response.
-
----
-
-## Scenario
-
-User message:
-{{USER_MESSAGE}}
-
-## Agent State (what the copilot saw)
-
-{{AGENT_STATE}}
-
-## Tools Called
-
-{{TOOL_CALLS}}
-
-## Copilot's Response
-
-{{COPILOT_RESPONSE}}
-
-## Evaluation Criteria
-
-{{JUDGE_CRITERIA}}
-
----
-
-Evaluate the copilot's response against the following:
-1. Did it understand the user's intent?
-2. Are the suggestions actionable and specific?
-3. Did it appropriately use available tools?
-4. **CRITICAL: If it called suggest_prompt_editions**, evaluate the quality of the suggested instructions:
-   - Do they directly address what the user requested?
-   - Are they clear, specific, and well-structured?
-   - Do they meaningfully improve upon the existing instructions?
-   - Are they appropriate for the agent's purpose?
-   - Note: Poor quality instructions should result in a score of 0-1, regardless of other factors
-5. Are there any issues (vague advice, missing elements, poor instructions)?
-
-Provide your evaluation using the REASONING: and SCORE: format described above.`;
-
-async function evaluateWithJudge(
-  auth: Authenticator,
-  testCase: TestCase,
-  agentState: MockAgentState,
-  toolCalls: ToolCall[],
-  copilotResponse: string,
-  numRuns: number = 1
-): Promise<JudgeResult> {
-  const prompt = JUDGE_PROMPT.replace("{{USER_MESSAGE}}", testCase.userMessage)
-    .replace("{{AGENT_STATE}}", JSON.stringify(agentState, null, 2))
-    .replace(
-      "{{TOOL_CALLS}}",
-      toolCalls.length > 0
-        ? toolCalls
-            .map((tc) => `- ${tc.name}(${JSON.stringify(tc.arguments)})`)
-            .join("\n")
-        : "(none)"
-    )
-    .replace("{{COPILOT_RESPONSE}}", copilotResponse)
-    .replace("{{JUDGE_CRITERIA}}", testCase.judgeCriteria);
-
-  const scores: number[] = [];
-  let lastReasoning = "";
-
-  const llm = await getLLM(auth, {
-    modelId: "gpt-5-mini",
-    temperature: 0.2,
-    bypassFeatureFlag: true,
-  });
-  if (!llm) {
-    throw new Error("Failed to initialize LLM for judge evaluation");
-  }
-
-  for (let i = 0; i < numRuns; i++) {
-    const events = llm.stream({
-      conversation: {
-        messages: [
-          {
-            role: "user",
-            name: "User",
-            content: [{ type: "text", text: prompt }],
-          },
-        ],
-      },
-      prompt:
-        "You are a careful evaluator. Analyze the copilot response and provide a fair assessment.",
-      specifications: [],
-    });
-
-    let response = "";
-    for await (const event of events) {
-      if (event.type === "text_delta") {
-        response += event.content.delta;
-      }
-      if (event.type === "error") {
-        throw new Error(`Judge evaluation error: ${event.content.message}`);
-      }
-    }
-
-    const scoreMatch = response.match(/SCORE:\s*(\d)/i);
-    if (scoreMatch) {
-      const score = parseInt(scoreMatch[1], 10);
-      if (score >= 0 && score <= 3) {
-        scores.push(score);
-      }
-    }
-
-    const reasoningMatch = response.match(
-      /REASONING:\s*([\s\S]+?)(?=SCORE:|$)/i
-    );
-    if (reasoningMatch) {
-      lastReasoning = reasoningMatch[1].trim();
-    }
-  }
-
-  const finalScore =
-    scores.length > 0
-      ? Math.round(scores.reduce((a, b) => a + b, 0) / scores.length)
-      : 0;
-
-  return { finalScore, scores, reasoning: lastReasoning };
-}
-
-async function executeCopilot(
-  auth: Authenticator,
-  config: CopilotConfig,
-  userMessage: string,
-  agentState: MockAgentState
-): Promise<CopilotExecutionResult> {
-  const llm = await getLLM(auth, {
-    modelId: config.model.modelId,
-    temperature: config.model.temperature ?? null,
-    reasoningEffort: config.model.reasoningEffort ?? null,
-    bypassFeatureFlag: true,
-  });
-
-  if (!llm) {
-    throw new Error("Failed to initialize LLM for copilot execution");
-  }
-
-  const messages: ModelMessageTypeMultiActionsWithoutContentFragment[] = [
-    {
-      role: "user",
-      name: "User",
-      content: [{ type: "text", text: userMessage }],
-    },
-  ];
-
-  const allToolCalls: ToolCall[] = [];
-  let responseText = "";
-
-  let events = llm.stream({
-    conversation: { messages },
-    prompt: config.instructions,
-    specifications: config.tools,
-  });
-
-  for (let round = 0; round < MAX_TOOL_CALL_ROUNDS; round++) {
-    const currentRoundToolCalls: ToolCall[] = [];
-    responseText = "";
-
-    for await (const event of events) {
-      switch (event.type) {
-        case "text_delta":
-          responseText += event.content.delta;
-          break;
-        case "text_generated":
-          responseText = event.content.text;
-          break;
-        case "tool_call":
-          currentRoundToolCalls.push({
-            name: event.content.name,
-            arguments: event.content.arguments,
-          });
-          break;
-        case "error":
-          throw new Error(`Copilot LLM error: ${event.content.message}`);
-      }
-    }
-
-    // No more tool calls - we have the final response
-    if (currentRoundToolCalls.length === 0) {
-      break;
-    }
-
-    allToolCalls.push(...currentRoundToolCalls);
-
-    // Build messages with tool calls and simulated responses
-    for (let idx = 0; idx < currentRoundToolCalls.length; idx++) {
-      const tc = currentRoundToolCalls[idx];
-      const callId = (
-        allToolCalls.length -
-        currentRoundToolCalls.length +
-        idx +
-        1
-      )
-        .toString()
-        .padStart(9, "0");
-
-      const functionCall = {
-        id: callId,
-        name: tc.name,
-        arguments: JSON.stringify(tc.arguments),
-      };
-
-      messages.push({
-        role: "assistant" as const,
-        function_calls: [functionCall],
-        contents: [{ type: "function_call" as const, value: functionCall }],
-      });
-
-      messages.push({
-        role: "function" as const,
-        name: tc.name,
-        function_call_id: callId,
-        content: getMockToolResponse(tc.name, agentState),
-      });
-    }
-
-    // Continue conversation with tool results
-    events = llm.stream({
-      conversation: { messages },
-      prompt: config.instructions,
-      specifications: config.tools,
-    });
-  }
-
-  return { responseText, toolCalls: allToolCalls };
-}
+const evalResults: EvalResult[] = [];
 
 const testCases = RUN_COPILOT_EVAL
   ? filterTestCases(allTestSuites, {
@@ -506,14 +65,19 @@ for (const testCase of testCases) {
 }
 
 describe.skipIf(!RUN_COPILOT_EVAL)("Copilot Evaluation Tests", () => {
+  let copilotConfig: CopilotConfig;
+
+  beforeAll(async () => {
+    copilotConfig = await getCopilotConfig();
+  }, TIMEOUT_MS);
+
   for (const [category, scenarios] of testGroups) {
     describe(category, () => {
       for (const [scenarioId, testCase] of scenarios) {
-        it(
+        it.concurrent(
           scenarioId,
           async () => {
             const auth = createMockAuthenticator();
-            const copilotConfig = await getCopilotConfig();
 
             const { responseText, toolCalls } = await executeCopilot(
               auth,
@@ -522,20 +86,11 @@ describe.skipIf(!RUN_COPILOT_EVAL)("Copilot Evaluation Tests", () => {
               testCase.mockState
             );
 
-            // Verify expected tool calls
-            const actualToolNames = toolCalls.map((t) => t.name);
-            for (const expected of testCase.expectedToolCalls ?? []) {
-              expect(
-                actualToolNames,
-                `Expected tool "${expected}" not called. Tools called: [${actualToolNames.join(", ")}]`
-              ).toContain(expected);
-            }
-
-            // Verify non-empty response
+            // Require either text response or tool calls (judge has access to tool calls)
             expect(
-              responseText.length,
-              "Copilot returned empty response"
-            ).toBeGreaterThan(0);
+              responseText.length > 0 || toolCalls.length > 0,
+              "Copilot returned empty response and no tool calls"
+            ).toBe(true);
 
             const judgeResult = await evaluateWithJudge(
               auth,
@@ -546,14 +101,47 @@ describe.skipIf(!RUN_COPILOT_EVAL)("Copilot Evaluation Tests", () => {
               JUDGE_RUNS
             );
 
+            const passed = judgeResult.finalScore >= PASS_THRESHOLD;
+
+            evalResults.push({
+              testCase,
+              responseText,
+              toolCalls,
+              judgeResult,
+              passed,
+            });
+
+            const actualToolNames = toolCalls.map((t) => t.name);
+            for (const expected of testCase.expectedToolCalls ?? []) {
+              expect(
+                actualToolNames,
+                `Expected tool "${expected}" not called. Tools called: [${actualToolNames.join(", ")}]\n\nCopilot response:\n${responseText}`
+              ).toContain(expected);
+            }
+
             expect(
-              judgeResult.finalScore >= PASS_THRESHOLD,
-              `Judge score ${judgeResult.finalScore} < threshold ${PASS_THRESHOLD}\nReasoning: ${judgeResult.reasoning}`
+              passed,
+              `Judge score ${judgeResult.finalScore} < threshold ${PASS_THRESHOLD}\nReasoning: ${judgeResult.reasoning}\n\nCopilot response:\n${responseText}`
             ).toBe(true);
           },
           TIMEOUT_MS
         );
       }
     });
+  }
+
+  if (COPILOT_ON_COPILOT) {
+    afterAll(async () => {
+      if (evalResults.length === 0) {
+        return;
+      }
+
+      const auth = createMockAuthenticator();
+      await generateCopilotImprovementSuggestions(
+        auth,
+        copilotConfig,
+        evalResults
+      );
+    }, COPILOT_ON_COPILOT_TIMEOUT_MS);
   }
 });

--- a/front/tests/copilot-evals/lib/config.ts
+++ b/front/tests/copilot-evals/lib/config.ts
@@ -1,0 +1,66 @@
+import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
+import { AGENT_COPILOT_AGENT_STATE_SERVER } from "@app/lib/api/actions/servers/agent_copilot_agent_state/metadata";
+import { AGENT_COPILOT_CONTEXT_SERVER } from "@app/lib/api/actions/servers/agent_copilot_context/metadata";
+import { _getCopilotGlobalAgent } from "@app/lib/api/assistant/global_agents/configurations/dust/copilot";
+import { Authenticator } from "@app/lib/auth";
+import type { CopilotConfig } from "@app/tests/copilot-evals/lib/types";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+
+export const RUN_COPILOT_EVAL = process.env.RUN_COPILOT_EVAL === "true";
+export const JUDGE_RUNS = parseInt(process.env.JUDGE_RUNS ?? "3", 10);
+export const PASS_THRESHOLD = parseInt(process.env.PASS_THRESHOLD ?? "2", 10);
+export const FILTER_CATEGORY = process.env.FILTER_CATEGORY;
+export const FILTER_SCENARIO = process.env.FILTER_SCENARIO;
+export const COPILOT_ON_COPILOT = process.env.COPILOT_ON_COPILOT === "true";
+
+export const TIMEOUT_MS = 300_000;
+export const COPILOT_ON_COPILOT_TIMEOUT_MS = 600_000;
+export const MAX_TOOL_CALL_ROUNDS = 5;
+
+export const ONE_HOUR_MS = 3_600_000;
+export const ONE_DAY_MS = 86_400_000;
+
+const COPILOT_MCP_SERVERS = [
+  AGENT_COPILOT_AGENT_STATE_SERVER,
+  AGENT_COPILOT_CONTEXT_SERVER,
+] as const;
+
+export async function getCopilotConfig(): Promise<CopilotConfig> {
+  const workspace = await WorkspaceFactory.basic();
+  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+  const copilotConfig = _getCopilotGlobalAgent(auth, {
+    copilotMCPServerViews: null,
+    copilotUserMetadata: null,
+  });
+
+  const tools: AgentActionSpecification[] = [];
+
+  for (const server of COPILOT_MCP_SERVERS) {
+    for (const tool of server.tools) {
+      if (tool.inputSchema) {
+        tools.push({
+          name: tool.name,
+          description: tool.description,
+          inputSchema: tool.inputSchema,
+        });
+      }
+    }
+  }
+
+  return {
+    instructions: copilotConfig.instructions ?? "",
+    model: copilotConfig.model,
+    tools,
+  };
+}
+
+export function createMockAuthenticator(): Authenticator {
+  return new Authenticator({
+    workspace: null,
+    user: null,
+    role: "none",
+    groupModelIds: [],
+    subscription: null,
+    authMethod: "internal",
+  });
+}

--- a/front/tests/copilot-evals/lib/copilot-executor.ts
+++ b/front/tests/copilot-evals/lib/copilot-executor.ts
@@ -1,0 +1,118 @@
+import { getLLM } from "@app/lib/api/llm";
+import type { Authenticator } from "@app/lib/auth";
+import { MAX_TOOL_CALL_ROUNDS } from "@app/tests/copilot-evals/lib/config";
+import { getMockToolResponse } from "@app/tests/copilot-evals/lib/mock-responses";
+import type {
+  CopilotConfig,
+  CopilotExecutionResult,
+  MockAgentState,
+  ToolCall,
+} from "@app/tests/copilot-evals/lib/types";
+import type { ModelMessageTypeMultiActionsWithoutContentFragment } from "@app/types";
+
+export async function executeCopilot(
+  auth: Authenticator,
+  config: CopilotConfig,
+  userMessage: string,
+  agentState: MockAgentState
+): Promise<CopilotExecutionResult> {
+  const llm = await getLLM(auth, {
+    modelId: config.model.modelId,
+    temperature: config.model.temperature ?? null,
+    reasoningEffort: config.model.reasoningEffort ?? null,
+    bypassFeatureFlag: true,
+  });
+
+  if (!llm) {
+    throw new Error("Failed to initialize LLM for copilot execution");
+  }
+
+  const messages: ModelMessageTypeMultiActionsWithoutContentFragment[] = [
+    {
+      role: "user",
+      name: "User",
+      content: [{ type: "text", text: userMessage }],
+    },
+  ];
+
+  const allToolCalls: ToolCall[] = [];
+  let responseText = "";
+
+  let events = llm.stream({
+    conversation: { messages },
+    prompt: config.instructions,
+    specifications: config.tools,
+  });
+
+  for (let round = 0; round < MAX_TOOL_CALL_ROUNDS; round++) {
+    const currentRoundToolCalls: ToolCall[] = [];
+    responseText = "";
+
+    for await (const event of events) {
+      switch (event.type) {
+        case "text_delta":
+          responseText += event.content.delta;
+          break;
+        case "text_generated":
+          responseText = event.content.text;
+          break;
+        case "tool_call":
+          currentRoundToolCalls.push({
+            name: event.content.name,
+            arguments: event.content.arguments,
+          });
+          break;
+        case "error":
+          throw new Error(`Copilot LLM error: ${event.content.message}`);
+      }
+    }
+
+    // No more tool calls - we have the final response
+    if (currentRoundToolCalls.length === 0) {
+      break;
+    }
+
+    allToolCalls.push(...currentRoundToolCalls);
+
+    // Build messages with tool calls and simulated responses
+    for (let idx = 0; idx < currentRoundToolCalls.length; idx++) {
+      const tc = currentRoundToolCalls[idx];
+      const callId = (
+        allToolCalls.length -
+        currentRoundToolCalls.length +
+        idx +
+        1
+      )
+        .toString()
+        .padStart(9, "0");
+
+      const functionCall = {
+        id: callId,
+        name: tc.name,
+        arguments: JSON.stringify(tc.arguments),
+      };
+
+      messages.push({
+        role: "assistant" as const,
+        function_calls: [functionCall],
+        contents: [{ type: "function_call" as const, value: functionCall }],
+      });
+
+      messages.push({
+        role: "function" as const,
+        name: tc.name,
+        function_call_id: callId,
+        content: getMockToolResponse(tc.name, agentState),
+      });
+    }
+
+    // Continue conversation with tool results
+    events = llm.stream({
+      conversation: { messages },
+      prompt: config.instructions,
+      specifications: config.tools,
+    });
+  }
+
+  return { responseText, toolCalls: allToolCalls };
+}

--- a/front/tests/copilot-evals/lib/copilot-on-copilot.ts
+++ b/front/tests/copilot-evals/lib/copilot-on-copilot.ts
@@ -1,0 +1,137 @@
+import type { Authenticator } from "@app/lib/auth";
+import { executeCopilot } from "@app/tests/copilot-evals/lib/copilot-executor";
+import type {
+  CopilotConfig,
+  EvalResult,
+  MockAgentState,
+} from "@app/tests/copilot-evals/lib/types";
+
+const MAX_SCENARIOS = 10;
+
+const ANALYSIS_PROMPT = `I've been running evaluations on the Agent Builder Copilot and some test scenarios are failing. I need your help analyzing the failures and suggesting improvements to the copilot's system instructions.
+
+## Current Copilot Instructions
+
+{{CURRENT_INSTRUCTIONS}}
+
+## Failed Test Scenarios
+
+The following scenarios received low scores from the judge:
+
+{{FAILED_SCENARIOS}}
+
+Based on the failure patterns above, please analyze the issues and suggest specific improvements to the copilot's instructions. Focus on:
+
+1. **Patterns in failures** - What common issues do you see across the failed scenarios?
+2. **Missing guidance** - What instructions are missing that would have helped?
+3. **Unclear directives** - What existing instructions might be ambiguous or misleading?
+4. **Specific additions** - Provide concrete instruction text to add or modify.
+
+Be specific and actionable. Provide exact text that could be added to the instructions.`;
+
+interface FailedScenario {
+  scenarioId: string;
+  userMessage: string;
+  copilotResponse: string;
+  judgeReasoning: string;
+  score: number;
+}
+
+export interface CopilotOnCopilotReport {
+  failedScenarios: FailedScenario[];
+  suggestion: string | null;
+  error?: string;
+}
+
+function formatScenario(scenario: FailedScenario, index: number): string {
+  return `### Scenario ${index + 1}: ${scenario.scenarioId}
+**User message:** ${scenario.userMessage}
+**Copilot response:** ${scenario.copilotResponse}
+**Judge reasoning:** ${scenario.judgeReasoning}
+**Score:** ${scenario.score}/3`;
+}
+
+function createCopilotSelfState(config: CopilotConfig): MockAgentState {
+  return {
+    name: "Agent Builder Copilot",
+    description: "The copilot that helps users build and improve agents",
+    instructions: config.instructions,
+    model: {
+      modelId: config.model.modelId,
+      temperature: config.model.temperature,
+      reasoningEffort: config.model.reasoningEffort,
+    },
+    tools: config.tools.map((t) => ({
+      sId: t.name,
+      name: t.name,
+      description: t.description,
+    })),
+    skills: [],
+  };
+}
+
+export async function generateCopilotImprovementSuggestions(
+  auth: Authenticator,
+  copilotConfig: CopilotConfig,
+  results: EvalResult[]
+): Promise<CopilotOnCopilotReport> {
+  const failedResults = results.filter((r) => !r.passed);
+
+  if (failedResults.length === 0) {
+    return { failedScenarios: [], suggestion: null };
+  }
+
+  console.log(
+    `\n[copilot-on-copilot] Analyzing ${failedResults.length} failed scenario(s)...\n`
+  );
+
+  const failedScenarios = failedResults.map((r) => ({
+    scenarioId: r.testCase.scenarioId,
+    userMessage: r.testCase.userMessage,
+    copilotResponse: r.responseText,
+    judgeReasoning: r.judgeResult.reasoning,
+    score: r.judgeResult.finalScore,
+  }));
+
+  const scenariosToAnalyze = failedScenarios.slice(0, MAX_SCENARIOS);
+  const remaining = failedScenarios.length - scenariosToAnalyze.length;
+
+  let scenariosText = scenariosToAnalyze
+    .map((s, i) => formatScenario(s, i))
+    .join("\n\n");
+  if (remaining > 0) {
+    scenariosText += `\n\n(${remaining} additional failed scenarios not shown)`;
+  }
+
+  const instructions = copilotConfig.instructions;
+  const truncatedInstructions =
+    instructions.length > 4000
+      ? instructions.substring(0, 4000) + "\n...(truncated)"
+      : instructions;
+
+  const userMessage = ANALYSIS_PROMPT.replace(
+    "{{CURRENT_INSTRUCTIONS}}",
+    truncatedInstructions
+  ).replace("{{FAILED_SCENARIOS}}", scenariosText);
+
+  try {
+    const { responseText } = await executeCopilot(
+      auth,
+      copilotConfig,
+      userMessage,
+      createCopilotSelfState(copilotConfig)
+    );
+
+    console.log("\n[copilot-on-copilot] Analysis complete\n");
+    console.log("-".repeat(60));
+
+    console.log(responseText);
+    console.log("-".repeat(60) + "\n");
+
+    return { failedScenarios, suggestion: responseText };
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : "Unknown error";
+    console.error(`[copilot-on-copilot] Analysis failed: ${msg}`);
+    return { failedScenarios, suggestion: null, error: msg };
+  }
+}

--- a/front/tests/copilot-evals/lib/copilot-on-copilot.ts
+++ b/front/tests/copilot-evals/lib/copilot-on-copilot.ts
@@ -1,4 +1,5 @@
 import type { Authenticator } from "@app/lib/auth";
+import logger from "@app/logger/logger";
 import { executeCopilot } from "@app/tests/copilot-evals/lib/copilot-executor";
 import type {
   CopilotConfig,
@@ -81,8 +82,9 @@ export async function generateCopilotImprovementSuggestions(
     return { failedScenarios: [], suggestion: null };
   }
 
-  console.log(
-    `\n[copilot-on-copilot] Analyzing ${failedResults.length} failed scenario(s)...\n`
+  logger.info(
+    {},
+    `[copilot-on-copilot] Analyzing ${failedResults.length} failed scenario(s)...`
   );
 
   const failedScenarios = failedResults.map((r) => ({
@@ -122,16 +124,15 @@ export async function generateCopilotImprovementSuggestions(
       createCopilotSelfState(copilotConfig)
     );
 
-    console.log("\n[copilot-on-copilot] Analysis complete\n");
-    console.log("-".repeat(60));
-
-    console.log(responseText);
-    console.log("-".repeat(60) + "\n");
+    logger.info({}, "[copilot-on-copilot] Analysis complete");
+    logger.info({}, "-".repeat(60));
+    logger.info({}, responseText);
+    logger.info({}, "-".repeat(60));
 
     return { failedScenarios, suggestion: responseText };
   } catch (error) {
     const msg = error instanceof Error ? error.message : "Unknown error";
-    console.error(`[copilot-on-copilot] Analysis failed: ${msg}`);
+    logger.error({ error }, `[copilot-on-copilot] Analysis failed: ${msg}`);
     return { failedScenarios, suggestion: null, error: msg };
   }
 }

--- a/front/tests/copilot-evals/lib/judge.ts
+++ b/front/tests/copilot-evals/lib/judge.ts
@@ -1,0 +1,159 @@
+import { getLLM } from "@app/lib/api/llm";
+import type { Authenticator } from "@app/lib/auth";
+import type {
+  JudgeResult,
+  MockAgentState,
+  TestCase,
+  ToolCall,
+} from "@app/tests/copilot-evals/lib/types";
+
+const JUDGE_PROMPT = `You are evaluating the quality of an Agent Builder Copilot's response.
+
+## Scoring Rubric
+
+- 0: Failed to address intent or major issues
+- 1: Partially addressed, missing key elements
+- 2: Good response with minor issues
+- 3: Excellent, fully actionable response
+
+You MUST provide your response in this exact format:
+
+REASONING: <your detailed analysis>
+SCORE: <number>
+
+Where <number> is between 0 and 3.
+
+IMPORTANT: You must include both REASONING: and SCORE: labels. The score MUST appear at the end of your response.
+
+---
+
+## Scenario
+
+User message:
+{{USER_MESSAGE}}
+
+## Agent State (what the copilot saw)
+
+{{AGENT_STATE}}
+
+## Tools Called
+
+{{TOOL_CALLS}}
+
+## Copilot's Response
+
+{{COPILOT_RESPONSE}}
+
+## Scenario-Specific Criteria
+
+{{JUDGE_CRITERIA}}
+
+---
+
+## General Evaluation Checklist (apply to all scenarios)
+
+1. **Intent Understanding**: Did the copilot correctly understand what the user was asking?
+2. **Actionable Response**: Are the suggestions specific and actionable (not vague or generic)?
+3. **Tool Usage**: Did it use appropriate tools for the task? Did it avoid unnecessary tool calls?
+4. **Response Quality**:
+   - Is the response well-organized and easy to follow?
+   - Does it explain the rationale behind suggestions?
+5. **If suggest_prompt_edits was called**, evaluate instruction quality:
+   - Do the suggested instructions directly address the user's request?
+   - Are they clear, specific, and well-structured?
+   - Do they meaningfully improve upon existing instructions (not just reword)?
+   - Are they appropriate for the agent's stated purpose?
+   - **CRITICAL**: Poor quality suggested instructions = score 0-1, regardless of other factors
+6. **Scope Appropriateness**:
+   - Did it avoid over-engineering (e.g., complete rewrites when a small edit was requested)?
+   - Did it ask clarifying questions when the request was genuinely ambiguous?
+
+The instruction changes provided in suggest_prompt_edits are visualized as inline diffs in the agent builder.
+This is the key output of copilot. The users will not only see the copilot response, but also the inline diffs of the instruction changes.
+
+At this point, you judging the quality of the copilot response AND the quality of the instruction changes. We are not yet judging on agent name, description, suggested tools, suggested skills, or suggested models.
+
+Provide your evaluation using the REASONING: and SCORE: format described above.`;
+
+export async function evaluateWithJudge(
+  auth: Authenticator,
+  testCase: TestCase,
+  agentState: MockAgentState,
+  toolCalls: ToolCall[],
+  copilotResponse: string,
+  numRuns: number = 1
+): Promise<JudgeResult> {
+  const prompt = JUDGE_PROMPT.replace("{{USER_MESSAGE}}", testCase.userMessage)
+    .replace("{{AGENT_STATE}}", JSON.stringify(agentState, null, 2))
+    .replace(
+      "{{TOOL_CALLS}}",
+      toolCalls.length > 0
+        ? toolCalls
+            .map((tc) => `- ${tc.name}(${JSON.stringify(tc.arguments)})`)
+            .join("\n")
+        : "(none)"
+    )
+    .replace("{{COPILOT_RESPONSE}}", copilotResponse)
+    .replace("{{JUDGE_CRITERIA}}", testCase.judgeCriteria);
+
+  const scores: number[] = [];
+  let lastReasoning = "";
+
+  const llm = await getLLM(auth, {
+    modelId: "gpt-5-mini",
+    temperature: 0.2,
+    bypassFeatureFlag: true,
+  });
+  if (!llm) {
+    throw new Error("Failed to initialize LLM for judge evaluation");
+  }
+
+  for (let i = 0; i < numRuns; i++) {
+    const events = llm.stream({
+      conversation: {
+        messages: [
+          {
+            role: "user",
+            name: "User",
+            content: [{ type: "text", text: prompt }],
+          },
+        ],
+      },
+      prompt:
+        "You are a careful evaluator. Analyze the copilot response and provide a fair assessment.",
+      specifications: [],
+    });
+
+    let response = "";
+    for await (const event of events) {
+      if (event.type === "text_delta") {
+        response += event.content.delta;
+      }
+      if (event.type === "error") {
+        throw new Error(`Judge evaluation error: ${event.content.message}`);
+      }
+    }
+
+    const scoreMatch = response.match(/SCORE:\s*(\d)/i);
+    if (scoreMatch) {
+      const score = parseInt(scoreMatch[1], 10);
+      if (score >= 0 && score <= 3) {
+        scores.push(score);
+      }
+    }
+
+    const reasoningMatch = response.match(
+      /REASONING:\s*([\s\S]+?)(?=SCORE:|$)/i
+    );
+    if (reasoningMatch) {
+      lastReasoning = reasoningMatch[1].trim();
+    }
+  }
+
+  const finalScore =
+    scores.length > 0
+      ? Math.round(scores.reduce((a, b) => a + b, 0) / scores.length)
+      : 0;
+
+  return { finalScore, scores, reasoning: lastReasoning };
+}

--- a/front/tests/copilot-evals/lib/mock-responses.ts
+++ b/front/tests/copilot-evals/lib/mock-responses.ts
@@ -1,0 +1,209 @@
+import { ONE_DAY_MS, ONE_HOUR_MS } from "@app/tests/copilot-evals/lib/config";
+import type { MockAgentState } from "@app/tests/copilot-evals/lib/types";
+
+export function getMockToolResponse(
+  toolName: string,
+  agentState: MockAgentState
+): string {
+  const mockResponses: Record<string, () => object> = {
+    get_agent_info: () => agentState,
+
+    get_available_models: () => ({
+      models: [
+        { modelId: "gpt-4-turbo", providerId: "openai", name: "GPT-4 Turbo" },
+        { modelId: "gpt-5-mini", providerId: "openai", name: "GPT-5 Mini" },
+        {
+          modelId: "claude-sonnet-4-5-20250929",
+          providerId: "anthropic",
+          name: "Claude Sonnet 4.5",
+        },
+        {
+          modelId: "claude-opus-4-20250514",
+          providerId: "anthropic",
+          name: "Claude Opus 4",
+        },
+      ],
+    }),
+
+    get_available_skills: () => ({
+      skills: [
+        {
+          sId: "skill_web_search",
+          name: "Web Search",
+          description: "Search the web for information",
+        },
+        {
+          sId: "skill_data_analysis",
+          name: "Data Analysis",
+          description: "Analyze data and generate insights",
+        },
+      ],
+    }),
+
+    get_available_tools: () => ({
+      tools: [
+        {
+          sId: "mcp_slack",
+          name: "Slack",
+          description: "Read and send Slack messages",
+        },
+        {
+          sId: "mcp_notion",
+          name: "Notion",
+          description: "Search Notion workspace",
+        },
+        {
+          sId: "mcp_github",
+          name: "GitHub",
+          description: "Access GitHub repositories",
+        },
+      ],
+    }),
+
+    get_available_knowledge: () => ({
+      count: {
+        spaces: 2,
+        dataSources: 4,
+      },
+      spaces: [
+        {
+          sId: "space_1",
+          name: "Engineering",
+          kind: "team",
+          categories: [
+            {
+              displayName: "Connected Data Sources",
+              dataSources: [
+                {
+                  sId: "ds_notion_1",
+                  name: "Engineering Wiki",
+                  description: "Notion workspace for engineering documentation",
+                  type: "notion",
+                },
+                {
+                  sId: "ds_slack_1",
+                  name: "Engineering Slack",
+                  description: "Slack workspace for engineering team",
+                  type: "slack",
+                },
+              ],
+            },
+            {
+              displayName: "Folders",
+              dataSources: [
+                {
+                  sId: "ds_folder_1",
+                  name: "Product Requirements",
+                  description:
+                    "Folder containing product requirement documents",
+                  type: "folder",
+                },
+              ],
+            },
+          ],
+        },
+        {
+          sId: "space_2",
+          name: "Marketing",
+          kind: "team",
+          categories: [
+            {
+              displayName: "Websites",
+              dataSources: [
+                {
+                  sId: "ds_website_1",
+                  name: "Company Blog",
+                  description: "Crawled website: company blog",
+                  type: "website",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    }),
+
+    get_agent_feedback: () => ({
+      feedback: [
+        {
+          id: "fb1",
+          thumbDirection: "down",
+          content: "The agent's responses are too formal and robotic",
+          createdAt: Date.now() - ONE_DAY_MS,
+        },
+        {
+          id: "fb2",
+          thumbDirection: "up",
+          content: "Great at finding relevant information quickly",
+          createdAt: Date.now() - ONE_DAY_MS * 2,
+        },
+        {
+          id: "fb3",
+          thumbDirection: "down",
+          content: "Sometimes misses important context from previous messages",
+          createdAt: Date.now() - ONE_DAY_MS * 3,
+        },
+      ],
+      total: 3,
+    }),
+
+    get_agent_insights: () => ({
+      activeUsers: 15,
+      conversations: 48,
+      messages: 320,
+      feedbackStats: {
+        thumbsUp: 12,
+        thumbsDown: 8,
+        thumbsUpRate: 0.6,
+      },
+      topUsers: [
+        { userId: "user1", name: "Alice Smith", conversations: 12 },
+        { userId: "user2", name: "Bob Johnson", conversations: 8 },
+      ],
+    }),
+
+    suggest_prompt_edits: () => ({
+      status: "success",
+      suggestionsCreated: 1,
+      message: "Suggestion created successfully",
+    }),
+
+    suggest_tools: () => ({
+      status: "success",
+      suggestionsCreated: 1,
+      message: "Tool suggestion created successfully",
+    }),
+
+    suggest_skills: () => ({
+      status: "success",
+      suggestionsCreated: 1,
+      message: "Skill suggestion created successfully",
+    }),
+
+    suggest_model: () => ({
+      status: "success",
+      suggestionsCreated: 1,
+      message: "Model suggestion created successfully",
+    }),
+
+    list_suggestions: () => ({
+      suggestions: [
+        {
+          id: "sug1",
+          kind: "instructions",
+          status: "pending",
+          createdAt: Date.now() - ONE_HOUR_MS,
+          analysis: "Make tone more friendly based on user feedback",
+        },
+      ],
+      total: 1,
+    }),
+  };
+
+  const responseFactory = mockResponses[toolName];
+  if (!responseFactory) {
+    throw new Error(`Unknown tool: ${toolName}`);
+  }
+
+  return JSON.stringify(responseFactory(), null, 2);
+}

--- a/front/tests/copilot-evals/lib/suite-loader.ts
+++ b/front/tests/copilot-evals/lib/suite-loader.ts
@@ -1,4 +1,7 @@
-import type { CategorizedTestCase, TestSuite } from "./types";
+import type {
+  CategorizedTestCase,
+  TestSuite,
+} from "@app/tests/copilot-evals/lib/types";
 
 /**
  * Filter test cases from suites based on criteria.

--- a/front/tests/copilot-evals/lib/types.ts
+++ b/front/tests/copilot-evals/lib/types.ts
@@ -8,8 +8,7 @@ export interface MockAgentState {
   scope?: string;
   model: {
     modelId: string;
-    providerId: string;
-    temperature: number;
+    temperature?: number;
     reasoningEffort?: string | null;
   };
   tools: Array<{
@@ -68,4 +67,12 @@ export interface JudgeResult {
 export interface CopilotExecutionResult {
   responseText: string;
   toolCalls: ToolCall[];
+}
+
+export interface EvalResult {
+  testCase: CategorizedTestCase;
+  responseText: string;
+  toolCalls: ToolCall[];
+  judgeResult: JudgeResult;
+  passed: boolean;
 }

--- a/front/tests/copilot-evals/shared-mock-states/index.ts
+++ b/front/tests/copilot-evals/shared-mock-states/index.ts
@@ -1,0 +1,294 @@
+import type { MockAgentState } from "../lib/types";
+
+export const BLANK_AGENT: MockAgentState = {
+  name: "",
+  description: "",
+  instructions: "",
+  model: {
+    modelId: "claude-sonnet-4-5-20250929",
+    temperature: 0.7,
+  },
+  tools: [],
+  skills: [],
+};
+
+export const TEMPLATE_SEEDED_AGENT: MockAgentState = {
+  name: "Sales Assistant",
+  description: "Help the sales team with their daily tasks",
+  instructions: "",
+  model: {
+    modelId: "claude-sonnet-4-5-20250929",
+    temperature: 0.7,
+  },
+  tools: [],
+  skills: [],
+};
+
+export const MINIMAL_INSTRUCTIONS_AGENT: MockAgentState = {
+  name: "Helper Bot",
+  description: "A helpful assistant",
+  instructions: "You are a helpful assistant. Answer questions accurately.",
+  model: {
+    modelId: "claude-sonnet-4-5-20250929",
+    temperature: 0.7,
+  },
+  tools: [],
+  skills: [],
+};
+
+export const SPARSE_INSTRUCTIONS_AGENT: MockAgentState = {
+  name: "Support Agent",
+  description: "Customer support agent",
+  instructions: `You help customers with their questions.
+Be polite and helpful.
+If you don't know something, say so.`,
+  model: {
+    modelId: "claude-sonnet-4-5-20250929",
+    temperature: 0.7,
+  },
+  tools: [],
+  skills: [],
+};
+
+export const WELL_STRUCTURED_AGENT: MockAgentState = {
+  name: "TechDocs Assistant",
+  description:
+    "Technical documentation assistant for engineering teams. Helps find and explain documentation.",
+  instructions: `<primary_goal>
+You are a Technical Documentation Assistant that helps engineering teams navigate and understand our product documentation.
+</primary_goal>
+
+<guidelines>
+- Always search the documentation before answering questions
+- Provide direct links to relevant documentation pages when available
+- Explain technical concepts in clear, accessible language
+- If information isn't in the docs, clearly state that and suggest alternatives
+</guidelines>
+
+<response_format>
+1. Start with a brief, direct answer
+2. Provide supporting details from documentation
+3. Include relevant code examples when helpful
+4. End with related topics the user might want to explore
+</response_format>
+
+<tone>
+Be professional but approachable. Use technical language appropriately but avoid unnecessary jargon. Be concise - engineers value their time.
+</tone>
+
+<constraints>
+- NEVER make up documentation that doesn't exist
+- NEVER provide outdated information without noting it may be stale
+- Always cite the source of your information
+</constraints>`,
+  model: {
+    modelId: "claude-sonnet-4-5-20250929",
+    temperature: 0.7,
+  },
+  tools: [],
+  skills: [],
+};
+
+export const AGENT_WITH_GREETING: MockAgentState = {
+  name: "Onboarding Guide",
+  description: "Helps new employees with onboarding questions",
+  instructions: `<primary_goal>
+You are an Onboarding Guide that helps new employees navigate their first weeks at the company.
+</primary_goal>
+
+<greeting>
+Hello! Welcome to the team! I'm your onboarding assistant. I'm here to help you settle in and answer any questions about company policies, tools, and processes. What would you like to know?
+</greeting>
+
+<capabilities>
+- Answer questions about company policies and procedures
+- Guide through IT setup and tool access
+- Explain team structures and key contacts
+- Provide information about benefits and HR processes
+</capabilities>
+
+<guidelines>
+- Be welcoming and encouraging
+- Provide step-by-step guidance when needed
+- Offer to connect with relevant team members when appropriate
+</guidelines>`,
+  model: {
+    modelId: "claude-sonnet-4-5-20250929",
+    temperature: 0.7,
+  },
+  tools: [],
+  skills: [],
+};
+
+export const AGENT_WITH_UNREFERENCED_TOOLS: MockAgentState = {
+  name: "Research Assistant",
+  description: "Helps with research tasks",
+  instructions: `You are a Research Assistant that helps users find information and conduct research.
+
+Your responsibilities:
+- Answer research questions thoroughly
+- Help synthesize information from multiple sources
+- Provide citations and references when possible
+
+Always be accurate and cite your sources.`,
+  model: {
+    modelId: "claude-sonnet-4-5-20250929",
+    temperature: 0.7,
+  },
+  tools: [
+    {
+      sId: "mcp_notion",
+      name: "Notion",
+      description: "Search and read Notion workspace content",
+    },
+    {
+      sId: "mcp_slack",
+      name: "Slack",
+      description: "Search and read Slack messages",
+    },
+  ],
+  skills: [],
+};
+
+export const AGENT_WITH_VAGUE_TOOL_USAGE: MockAgentState = {
+  name: "Team Helper",
+  description: "Helps team members find information",
+  instructions: `You are a Team Helper that assists team members with their questions.
+
+You have access to various tools. Use them when helpful.
+
+Be helpful and thorough in your responses.`,
+  model: {
+    modelId: "claude-sonnet-4-5-20250929",
+    temperature: 0.7,
+  },
+  tools: [
+    {
+      sId: "mcp_notion",
+      name: "Notion",
+      description: "Search and read Notion workspace content",
+    },
+    {
+      sId: "mcp_github",
+      name: "GitHub",
+      description: "Access GitHub repositories and code",
+    },
+    {
+      sId: "mcp_slack",
+      name: "Slack",
+      description: "Search and read Slack messages",
+    },
+  ],
+  skills: [],
+};
+
+export const AGENT_NEEDING_TOOLS: MockAgentState = {
+  name: "Project Manager Bot",
+  description: "Helps with project management tasks",
+  instructions: `<primary_goal>
+You are a Project Manager Bot that helps teams stay organized and on track with their projects.
+</primary_goal>
+
+<capabilities>
+- Track project status and deadlines
+- Help prioritize tasks
+- Summarize project updates for stakeholders
+- Identify blockers and suggest solutions
+</capabilities>
+
+<response_format>
+- Use bullet points for clarity
+- Include specific dates and owners when relevant
+- Highlight urgent items prominently
+</response_format>`,
+  model: {
+    modelId: "claude-sonnet-4-5-20250929",
+    temperature: 0.7,
+  },
+  tools: [],
+  skills: [],
+};
+
+export const AGENT_NEEDING_KNOWLEDGE: MockAgentState = {
+  name: "Company Policy Expert",
+  description: "Answers questions about company policies",
+  instructions: `You are a Company Policy Expert that helps employees understand company policies and procedures.
+
+Answer questions about:
+- HR policies
+- Security procedures
+- Expense and travel policies
+- Code of conduct
+
+Always reference official policies when answering.`,
+  model: {
+    modelId: "claude-sonnet-4-5-20250929",
+    temperature: 0.7,
+  },
+  tools: [],
+  skills: [],
+};
+
+export const AGENT_WITH_SKILL_OVERLAP: MockAgentState = {
+  name: "Code Reviewer",
+  description: "Helps review code and suggest improvements",
+  instructions: `You are a Code Reviewer that helps developers improve their code.
+
+<code_review_process>
+1. Check for code style and formatting issues
+2. Look for potential bugs or logic errors
+3. Suggest performance improvements
+4. Recommend better naming conventions
+5. Identify security vulnerabilities
+</code_review_process>
+
+<web_search_capability>
+When you need to look up best practices or documentation:
+1. Search the web for relevant information
+2. Cite your sources
+3. Prefer official documentation over blog posts
+</web_search_capability>
+
+Provide constructive feedback that helps developers learn.`,
+  model: {
+    modelId: "claude-sonnet-4-5-20250929",
+    temperature: 0.7,
+  },
+  tools: [],
+  skills: [],
+};
+
+export const PRODUCTION_AGENT: MockAgentState = {
+  name: "Customer Success Bot",
+  description: "Helps customers with product questions and issues",
+  instructions: `<primary_goal>
+You are a Customer Success Bot that helps customers get the most value from our product.
+</primary_goal>
+
+<capabilities>
+- Answer product questions
+- Troubleshoot common issues
+- Guide users through features
+- Collect feedback for the product team
+</capabilities>
+
+<tone>
+Be friendly, patient, and empathetic. Remember that frustrated customers need extra care.
+</tone>
+
+<escalation>
+If you cannot resolve an issue, offer to connect the customer with a human support agent.
+</escalation>`,
+  model: {
+    modelId: "claude-sonnet-4-5-20250929",
+    temperature: 0.7,
+  },
+  tools: [
+    {
+      sId: "mcp_notion",
+      name: "Notion",
+      description: "Search product documentation",
+    },
+  ],
+  skills: [],
+};

--- a/front/tests/copilot-evals/test-suites/index.ts
+++ b/front/tests/copilot-evals/test-suites/index.ts
@@ -1,4 +1,16 @@
 import type { TestSuite } from "../lib/types";
+import { instructionsWithContextSuite } from "./instructions-with-context";
+import { instructionsWithFeedbackSuite } from "./instructions-with-feedback";
+import { instructionsWithToolsSuite } from "./instructions-with-tools";
+import { minimalInstructionsSuite } from "./minimal-instructions";
 import { newAgentSuite } from "./new-agent";
+import { wellStructuredInstructionsSuite } from "./well-structured-instructions";
 
-export const allTestSuites: TestSuite[] = [newAgentSuite];
+export const allTestSuites: TestSuite[] = [
+  newAgentSuite,
+  minimalInstructionsSuite,
+  wellStructuredInstructionsSuite,
+  instructionsWithToolsSuite,
+  instructionsWithContextSuite,
+  instructionsWithFeedbackSuite,
+];

--- a/front/tests/copilot-evals/test-suites/instructions-with-context.ts
+++ b/front/tests/copilot-evals/test-suites/instructions-with-context.ts
@@ -1,0 +1,82 @@
+import type { TestSuite } from "../lib/types";
+import {
+  AGENT_NEEDING_KNOWLEDGE,
+  AGENT_WITH_SKILL_OVERLAP,
+} from "../shared-mock-states/index";
+
+export const instructionsWithContextSuite: TestSuite = {
+  name: "with-knowledge",
+  description: "Agents that could benefit from knowledge/skills integration",
+  testCases: [
+    {
+      scenarioId: "connect-company-data",
+      userMessage:
+        "Help me connect this agent to our company data so it can answer policy questions accurately",
+      mockState: AGENT_NEEDING_KNOWLEDGE,
+      expectedToolCalls: [
+        "get_agent_info",
+        "get_available_knowledge",
+        "suggest_prompt_edits",
+      ],
+      judgeCriteria: `Should identify relevant knowledge sources for policy questions.
+Must suggest instruction edits that reference SPECIFIC data sources, not just "use the data".
+Should guide which sources to check for which topics.`,
+    },
+    {
+      scenarioId: "recommend-knowledge",
+      userMessage: "What company knowledge should I connect to this agent?",
+      mockState: AGENT_NEEDING_KNOWLEDGE,
+      expectedToolCalls: ["get_agent_info", "get_available_knowledge"],
+      judgeCriteria: `Should map knowledge sources to agent's needs (HR policies, security, expenses).
+Should make specific recommendations with rationale.
+May offer to update instructions once knowledge is connected.`,
+    },
+    {
+      scenarioId: "recommend-skills",
+      userMessage: "What skills would help this agent?",
+      mockState: AGENT_NEEDING_KNOWLEDGE,
+      expectedToolCalls: ["get_agent_info", "get_available_skills"],
+      judgeCriteria: `Should match skills to agent's use case (policy expert).
+Should recommend only skills that complement the purpose.
+Should NOT recommend skills that don't fit.`,
+    },
+    {
+      scenarioId: "recommend-skills-code-review",
+      userMessage:
+        "Are there any skills I should add to make this code reviewer better?",
+      mockState: AGENT_WITH_SKILL_OVERLAP,
+      expectedToolCalls: [
+        "get_agent_info",
+        "get_available_skills",
+        "suggest_skills",
+      ],
+      judgeCriteria: `Should identify relevant skills for code review.
+Should note that Web Search skill exists and could simplify instructions.
+Should explain value add of each suggested skill.`,
+    },
+    {
+      scenarioId: "identify-skill-overlap",
+      userMessage:
+        "I wrote custom web search instructions in my agent, but I see there's a Web Search skill. Should I use the skill instead?",
+      mockState: AGENT_WITH_SKILL_OVERLAP,
+      expectedToolCalls: ["get_agent_info", "get_available_skills"],
+      judgeCriteria: `Should confirm the overlap between custom <web_search_capability> section and the Web Search skill.
+Should recommend using the skill (cleaner, maintained by platform).
+Should offer to remove the redundant custom section.`,
+    },
+    {
+      scenarioId: "simplify-with-skill",
+      userMessage:
+        "These instructions feel bloated. Can you help me clean them up using skills where possible?",
+      mockState: AGENT_WITH_SKILL_OVERLAP,
+      expectedToolCalls: [
+        "get_agent_info",
+        "get_available_skills",
+        "suggest_prompt_edits",
+      ],
+      judgeCriteria: `Should identify web_search_capability section as candidate for replacement with skill.
+Should suggest: add Web Search skill + remove redundant custom section.
+Result should be shorter but equally capable.`,
+    },
+  ],
+};

--- a/front/tests/copilot-evals/test-suites/instructions-with-feedback.ts
+++ b/front/tests/copilot-evals/test-suites/instructions-with-feedback.ts
@@ -1,0 +1,70 @@
+import type { TestSuite } from "../lib/types";
+import { PRODUCTION_AGENT } from "../shared-mock-states/index";
+
+export const instructionsWithFeedbackSuite: TestSuite = {
+  name: "with-feedback",
+  description: "Production agents with user feedback data",
+  testCases: [
+    {
+      scenarioId: "performance-overview",
+      userMessage: "How's my agent doing?",
+      mockState: PRODUCTION_AGENT,
+      expectedToolCalls: [
+        "get_agent_info",
+        "get_agent_insights",
+        "get_agent_feedback",
+      ],
+      judgeCriteria: `Should provide concise summary: usage stats, feedback ratio, key themes from feedback.
+Should highlight both strengths and areas for improvement.
+Score 0-1 if copilot skips insights or feedback tools.`,
+    },
+    {
+      scenarioId: "performance-detailed",
+      userMessage: "Give me an overview of how this agent is performing",
+      mockState: PRODUCTION_AGENT,
+      expectedToolCalls: [
+        "get_agent_info",
+        "get_agent_insights",
+        "get_agent_feedback",
+      ],
+      judgeCriteria: `Should present balanced report: engagement metrics, satisfaction, feedback themes.
+Should identify patterns ("Users appreciate X but struggle with Y").
+Should suggest next steps based on data.`,
+    },
+    {
+      scenarioId: "diagnose-unhappy-users",
+      userMessage: "Why are users unhappy with this agent? Fix it.",
+      mockState: PRODUCTION_AGENT,
+      expectedToolCalls: [
+        "get_agent_info",
+        "get_agent_feedback",
+        "suggest_prompt_edits",
+      ],
+      judgeCriteria: `Should analyze feedback and IMMEDIATELY suggest fixes - not ask permission first.
+Must cite specific feedback patterns and propose targeted instruction changes.
+Score 0-1 if copilot only diagnoses without suggesting fixes, or asks "want me to...".`,
+    },
+    {
+      scenarioId: "fix-complaints",
+      userMessage: "Users keep complaining. What's wrong and how do we fix it?",
+      mockState: PRODUCTION_AGENT,
+      expectedToolCalls: [
+        "get_agent_info",
+        "get_agent_feedback",
+        "suggest_prompt_edits",
+      ],
+      judgeCriteria: `Should identify specific issues from feedback (tone, context missing).
+For each issue, should suggest a targeted fix.
+Should NOT suggest unrelated improvements.`,
+    },
+    {
+      scenarioId: "session-start-proactive",
+      userMessage: "I'm back to work on my agent. What should I focus on?",
+      mockState: PRODUCTION_AGENT,
+      expectedToolCalls: ["get_agent_info"],
+      judgeCriteria: `Should check for pending suggestions and surface them.
+If none, should offer to analyze feedback or review performance.
+Should provide clear starting point for the session.`,
+    },
+  ],
+};

--- a/front/tests/copilot-evals/test-suites/instructions-with-tools.ts
+++ b/front/tests/copilot-evals/test-suites/instructions-with-tools.ts
@@ -1,0 +1,78 @@
+import type { TestSuite } from "../lib/types";
+import {
+  AGENT_NEEDING_TOOLS,
+  AGENT_WITH_UNREFERENCED_TOOLS,
+  AGENT_WITH_VAGUE_TOOL_USAGE,
+} from "../shared-mock-states/index";
+
+export const instructionsWithToolsSuite: TestSuite = {
+  name: "with-tools",
+  description: "Agents with tools that need better integration",
+  testCases: [
+    {
+      scenarioId: "unreferenced-improve-usage",
+      userMessage:
+        "I connected Notion for our team wiki and Slack for team discussions, but the agent doesn't seem to know when to use them. Can you help?",
+      mockState: AGENT_WITH_UNREFERENCED_TOOLS,
+      expectedToolCalls: ["get_agent_info", "suggest_prompt_edits"],
+      judgeCriteria: `Should identify that tools (Notion, Slack) are configured but NOT referenced in instructions.
+Must add tool usage guidance: Notion for wiki/docs, Slack for discussions/context.
+Score 0-1 if copilot misses the tool-instruction gap.`,
+    },
+    {
+      scenarioId: "unreferenced-review-setup",
+      userMessage:
+        "Review my research assistant setup. It has access to Notion and Slack but I'm not sure if the instructions are complete.",
+      mockState: AGENT_WITH_UNREFERENCED_TOOLS,
+      expectedToolCalls: ["get_agent_info", "suggest_prompt_edits"],
+      judgeCriteria: `Should proactively identify tools present but not mentioned in instructions.
+Should highlight this as key improvement: add tool usage section with decision tree, fallback behavior.`,
+    },
+    {
+      scenarioId: "vague-make-specific",
+      userMessage:
+        "The instructions say 'use tools when helpful' but the agent often picks the wrong one. Notion has our docs, Slack has team discussions, GitHub has code. How do I make it smarter about which to use?",
+      mockState: AGENT_WITH_VAGUE_TOOL_USAGE,
+      expectedToolCalls: ["get_agent_info", "suggest_prompt_edits"],
+      judgeCriteria: `Should replace vague guidance with specific decision criteria for each tool.
+Must include: when to use each tool based on query type, fallback behavior.
+Should be actionable, not generic.`,
+    },
+    {
+      scenarioId: "vague-tool-decision-tree",
+      userMessage:
+        "Help the agent decide: Notion has product specs and policies, Slack has team conversations, GitHub has code and issues. When should it use which?",
+      mockState: AGENT_WITH_VAGUE_TOOL_USAGE,
+      expectedToolCalls: ["get_agent_info", "suggest_prompt_edits"],
+      judgeCriteria: `Should provide clear decision criteria:
+- Notion: specs, policies, structured docs
+- Slack: conversations, recent decisions, context
+- GitHub: code, technical implementation, issues
+Should include example query types and fallback chain.`,
+    },
+    {
+      scenarioId: "recommend-tools",
+      userMessage:
+        "This agent helps track project status and deadlines. What tools would help it access our actual project data?",
+      mockState: AGENT_NEEDING_TOOLS,
+      expectedToolCalls: [
+        "get_agent_info",
+        "get_available_tools",
+        "suggest_tools",
+      ],
+      judgeCriteria: `Should recommend tools based on project management use case.
+Must explain WHY each tool helps (e.g., Notion for project docs, Slack for status updates).
+Should NOT just list all available tools - be selective and relevant.`,
+    },
+    {
+      scenarioId: "recommend-tools-job",
+      userMessage:
+        "My agent summarizes weekly project updates. What tools should I connect so it can actually see what's happening?",
+      mockState: AGENT_NEEDING_TOOLS,
+      expectedToolCalls: ["get_agent_info", "get_available_tools"],
+      judgeCriteria: `Should match tools to weekly summary use case.
+Should prioritize: tools that provide project status, updates, blockers.
+May offer to add tool usage instructions after tools connected.`,
+    },
+  ],
+};

--- a/front/tests/copilot-evals/test-suites/minimal-instructions.ts
+++ b/front/tests/copilot-evals/test-suites/minimal-instructions.ts
@@ -1,0 +1,65 @@
+import type { TestSuite } from "../lib/types";
+import {
+  MINIMAL_INSTRUCTIONS_AGENT,
+  SPARSE_INSTRUCTIONS_AGENT,
+} from "../shared-mock-states/index";
+
+export const minimalInstructionsSuite: TestSuite = {
+  name: "minimal-instructions",
+  description: "Improving agents with basic/incomplete instructions",
+  testCases: [
+    {
+      scenarioId: "make-it-better",
+      userMessage: "Make it better",
+      mockState: MINIMAL_INSTRUCTIONS_AGENT,
+      expectedToolCalls: ["get_agent_info"],
+      judgeCriteria: `Should recognize minimal instructions and expand significantly (3-5x longer). It should ask clarifying questions to understand the user's intent. Given this is an extremely broad ask, provisional recommendations are not required. Score 0-1 if trivial instruction changes are made.`,
+    },
+    {
+      scenarioId: "improve-basic",
+      userMessage: "Can you improve the instructions? They feel too basic.",
+      mockState: SPARSE_INSTRUCTIONS_AGENT,
+      expectedToolCalls: ["get_agent_info", "suggest_prompt_edits"],
+      judgeCriteria: `Should expand while keeping core intent (customer support, polite, honest about limitations).
+Must add: clear role definition, structured guidelines, examples, escalation procedures, formatting guidelines.`,
+    },
+    {
+      scenarioId: "add-doc-search",
+      userMessage:
+        "Add the ability to search our documentation to help answer questions",
+      mockState: MINIMAL_INSTRUCTIONS_AGENT,
+      expectedToolCalls: ["get_agent_info", "suggest_prompt_edits"],
+      judgeCriteria: `Should add TARGETED section about documentation usage (when to search, how to cite, fallback behavior).
+Should NOT rewrite entire instructions - add to existing.
+May suggest adding a documentation tool.
+Score 0-1 if copilot rewrites everything.`,
+    },
+    {
+      scenarioId: "add-jira-tickets",
+      userMessage:
+        "I want it to be able to create Jira tickets when users report bugs",
+      mockState: SPARSE_INSTRUCTIONS_AGENT,
+      expectedToolCalls: ["get_agent_info", "suggest_prompt_edits"],
+      judgeCriteria: `Should add specific bug reporting workflow (when to create ticket, info to collect, format, confirmation flow). Should keep existing instructions intact - add new section.`,
+    },
+    {
+      scenarioId: "tone-formal",
+      userMessage: "Make it more formal and professional",
+      mockState: MINIMAL_INSTRUCTIONS_AGENT,
+      expectedToolCalls: ["get_agent_info", "suggest_prompt_edits"],
+      judgeCriteria: `Should add tone guidelines section: professional language patterns, formal greetings, words to use/avoid.
+Should NOT change core functionality.
+May provide before/after examples.`,
+    },
+    {
+      scenarioId: "tone-friendly",
+      userMessage:
+        "The responses are too dry. Can you make it sound more friendly and conversational?",
+      mockState: SPARSE_INSTRUCTIONS_AGENT,
+      expectedToolCalls: ["get_agent_info", "suggest_prompt_edits"],
+      judgeCriteria: `Should add/modify tone section: conversational language, contractions, warmth guidelines.
+Should maintain existing "polite" directive but expand on it.
+Should NOT change agent's core purpose.`,
+    },
+  ],
+};

--- a/front/tests/copilot-evals/test-suites/new-agent.ts
+++ b/front/tests/copilot-evals/test-suites/new-agent.ts
@@ -8,7 +8,7 @@ export const newAgentSuite: TestSuite = {
     {
       scenarioId: "clear-saas-support",
       userMessage:
-        "I need to create a customer support agent that will help users with common questions about our SaaS product. The agent should be friendly, professional, and able to handle basic troubleshooting. Please create the instructions for this agent.",
+        "I need to create a customer support agent that will help users with common questions about our SaaS product. The agent should handle questions about billing, feature usage, account settings, and basic technical troubleshooting. It should be friendly and professional in tone, provide clear step-by-step guidance when needed, and know when to escalate complex issues. Please create the instructions for this agent.",
       mockState: BLANK_AGENT,
       expectedToolCalls: ["get_agent_info", "suggest_prompt_edits"],
       judgeCriteria: `Clear requirements provided (SaaS support, friendly/professional tone, troubleshooting).

--- a/front/tests/copilot-evals/test-suites/new-agent.ts
+++ b/front/tests/copilot-evals/test-suites/new-agent.ts
@@ -1,40 +1,67 @@
 import type { TestSuite } from "../lib/types";
+import { BLANK_AGENT } from "../shared-mock-states/index";
 
 export const newAgentSuite: TestSuite = {
-  name: "New Agent Creation",
-  description: "Tests for creating agents from scratch",
+  name: "new-agent",
+  description: "Creating agents from scratch",
   testCases: [
     {
-      scenarioId: "NEW-001",
+      scenarioId: "clear-saas-support",
       userMessage:
         "I need to create a customer support agent that will help users with common questions about our SaaS product. The agent should be friendly, professional, and able to handle basic troubleshooting. Please create the instructions for this agent.",
-      mockState: {
-        name: "",
-        description: "",
-        instructions: "",
-        model: {
-          modelId: "gpt-4-turbo",
-          providerId: "openai",
-          temperature: 0.7,
-        },
-        tools: [],
-        skills: [],
-      },
-      expectedToolCalls: ["get_agent_info", "suggest_prompt_editions"],
-      judgeCriteria: `The copilot should:
-1. Recognize that the user has provided clear, complete requirements:
-   - Purpose: SaaS product support
-   - Tone: friendly and professional
-   - Capability: handle common questions and basic troubleshooting
-   - Clear directive: "Please create the instructions"
-2. Have high confidence to proceed and call suggest_prompt_editions with complete, well-structured instructions that address all requirements
-3. The suggested instructions should include:
-   - Clear role definition (customer support for SaaS product)
-   - Tone guidelines (friendly and professional)
-   - Core responsibilities (answering questions, troubleshooting)
-   - Response structure or best practices
-4. Explain why these instructions work well for the stated use case
-5. Optionally suggest relevant tools (search, documentation access) to enhance the agent`,
+      mockState: BLANK_AGENT,
+      expectedToolCalls: ["get_agent_info", "suggest_prompt_edits"],
+      judgeCriteria: `Clear requirements provided (SaaS support, friendly/professional tone, troubleshooting).
+Should generate complete instructions with: role definition, tone guidelines, core responsibilities.
+May suggest relevant tools (search, documentation).`,
+    },
+    {
+      scenarioId: "clear-engineering-docs",
+      userMessage:
+        "Create an agent for my engineering team that answers questions about our codebase and architecture. It should search our documentation and provide technical explanations. Use a professional, concise tone.",
+      mockState: BLANK_AGENT,
+      expectedToolCalls: ["get_agent_info", "suggest_prompt_edits"],
+      judgeCriteria: `Clear engineering-focused requirements. Should generate comprehensive technical instructions.
+May suggest documentation tools (Notion, GitHub).
+Should NOT ask clarifying questions - request is sufficiently detailed.`,
+    },
+    {
+      scenarioId: "vague-make-agent",
+      userMessage: "Make me an agent",
+      mockState: BLANK_AGENT,
+      expectedToolCalls: ["get_agent_info"],
+      judgeCriteria: `Request is too vague. Should ask clarifying questions about: purpose, audience, tone, capabilities.
+Should NOT generate generic instructions.
+Score 0-1 if copilot generates instructions without asking questions.`,
+    },
+    {
+      scenarioId: "vague-help-team",
+      userMessage: "I want to build something that helps my team",
+      mockState: BLANK_AGENT,
+      expectedToolCalls: ["get_agent_info"],
+      judgeCriteria: `Too vague - needs clarification about: what team, what kind of help, current problems.
+Should NOT generate placeholder instructions.
+Score 0-1 if copilot produces instructions without understanding the use case.`,
+    },
+    {
+      scenarioId: "discovery-sales",
+      userMessage: "I want to help my sales team",
+      mockState: BLANK_AGENT,
+      expectedToolCalls: ["get_agent_info"],
+      judgeCriteria: `Use case discovery scenario. Should ask specific questions to narrow down:
+- What struggles most? (lead research, email drafting, CRM updates)
+- What tools they use? What's the sales process?
+May suggest common patterns (lead research, email drafter, meeting prep).
+Should NOT generate generic sales assistant instructions.`,
+    },
+    {
+      scenarioId: "discovery-marketing",
+      userMessage:
+        "My marketing team needs help but I'm not sure what kind of agent would be most useful",
+      mockState: BLANK_AGENT,
+      expectedToolCalls: ["get_agent_info"],
+      judgeCriteria: `Discovery mode - should ask about pain points, content types, tools, workflows.
+May suggest 2-3 specific agent ideas. Score 0-1 if copilot jumps to generic marketing instructions.`,
     },
   ],
 };

--- a/front/tests/copilot-evals/test-suites/well-structured-instructions.ts
+++ b/front/tests/copilot-evals/test-suites/well-structured-instructions.ts
@@ -1,0 +1,109 @@
+import type { TestSuite } from "../lib/types";
+import {
+  AGENT_WITH_GREETING,
+  WELL_STRUCTURED_AGENT,
+} from "../shared-mock-states/index";
+
+export const wellStructuredInstructionsSuite: TestSuite = {
+  name: "well-structured",
+  description: "Targeted edits to comprehensive, well-organized instructions",
+  testCases: [
+    {
+      scenarioId: "vague-improve-this",
+      userMessage: "Can you help me improve this?",
+      mockState: WELL_STRUCTURED_AGENT,
+      expectedToolCalls: ["get_agent_info"],
+      judgeCriteria: `Instructions are already well-structured. Should either:
+a) Ask what specific aspect to improve, OR
+b) Identify 1-2 minor incremental improvements (not overhauls).
+Should acknowledge instructions are comprehensive.
+Score 0-1 if copilot suggests rewriting everything.`,
+    },
+    {
+      scenarioId: "vague-make-better",
+      userMessage: "Make it better",
+      mockState: WELL_STRUCTURED_AGENT,
+      expectedToolCalls: ["get_agent_info"],
+      judgeCriteria: `Should recognize well-organized instructions and ask clarifying questions about what "better" means.
+Should NOT default to rewriting good instructions.
+May suggest tools/skills that complement existing instructions.`,
+    },
+    {
+      scenarioId: "edit-greeting-casual",
+      userMessage: "Change the greeting to be more casual",
+      mockState: AGENT_WITH_GREETING,
+      expectedToolCalls: ["get_agent_info", "suggest_prompt_edits"],
+      judgeCriteria: `Should make SMALL, TARGETED edit to greeting section only (1-3 lines).
+Should NOT rewrite sections beyond the greeting.
+Score 0-1 if copilot rewrites unrelated sections.`,
+    },
+    {
+      scenarioId: "edit-add-followup-step",
+      userMessage:
+        "In the response format section, add a step to ask follow-up questions before providing detailed answers",
+      mockState: WELL_STRUCTURED_AGENT,
+      expectedToolCalls: ["get_agent_info", "suggest_prompt_edits"],
+      judgeCriteria: `Should make precise, scoped edit to response_format section only (2-4 lines).
+Should maintain existing numbered list format.
+Should NOT touch other sections.`,
+    },
+    {
+      scenarioId: "multi-three-changes",
+      userMessage:
+        "I want to add error handling, change the tone to be more casual, and add a section about when to escalate to humans",
+      mockState: WELL_STRUCTURED_AGENT,
+      expectedToolCalls: ["get_agent_info", "suggest_prompt_edits"],
+      judgeCriteria: `Multi-part request (3 changes). Should either:
+a) Create multiple suggest_prompt_edits calls, OR
+b) Explain addressing one at a time.
+Each suggestion should be self-contained and labeled.
+Should NOT bundle all into one massive edit.`,
+    },
+    {
+      scenarioId: "multi-two-sections",
+      userMessage:
+        "Update the constraints section to be stricter, and also add some example responses to the response format section",
+      mockState: WELL_STRUCTURED_AGENT,
+      expectedToolCalls: ["get_agent_info", "suggest_prompt_edits"],
+      judgeCriteria: `Two separate sections need changes. Should create separate suggestions for:
+a) Stricter constraints with specific new rules
+b) Example responses in format section
+Each edit should be scoped to its section.`,
+    },
+    {
+      scenarioId: "fix-from-feedback",
+      userMessage:
+        "Users have been complaining. Can you look at the feedback and suggest improvements?",
+      mockState: WELL_STRUCTURED_AGENT,
+      expectedToolCalls: [
+        "get_agent_info",
+        "get_agent_feedback",
+        "suggest_prompt_edits",
+      ],
+      judgeCriteria: `Should call get_agent_feedback and generate fixes that address specific feedback themes.
+Must cite feedback in explanations ("Based on feedback about...").
+Should NOT make changes unrelated to the feedback.`,
+    },
+    {
+      scenarioId: "conflict-verbose-vs-concise",
+      userMessage:
+        "Add instructions to always provide comprehensive, detailed responses with lots of context",
+      mockState: WELL_STRUCTURED_AGENT,
+      expectedToolCalls: ["get_agent_info"],
+      judgeCriteria: `Should notice conflict: existing tone says "Be concise" vs requested "comprehensive, detailed".
+Must surface the conflict and ask for clarification.
+Should NOT silently override existing instructions.
+Score 0-1 if copilot ignores the contradiction.`,
+    },
+    {
+      scenarioId: "conflict-never-admit-unknown",
+      userMessage:
+        "The agent should never admit when it doesn't know something - always provide an answer",
+      mockState: WELL_STRUCTURED_AGENT,
+      expectedToolCalls: ["get_agent_info"],
+      judgeCriteria: `Should identify conflict with existing guidelines about honesty and constraints about not making things up.
+Should flag as problematic (hallucination risk) and ask clarifying questions.
+Should NOT blindly implement instructions that contradict best practices.`,
+    },
+  ],
+};

--- a/front/tests/copilot-evals/vite.config.mjs
+++ b/front/tests/copilot-evals/vite.config.mjs
@@ -26,7 +26,7 @@ export default defineConfig(() => {
         DUST_MANAGED_OPENAI_API_KEY:
           process.env.DUST_MANAGED_OPENAI_API_KEY ?? "",
       },
-      testTimeout: 180000, // 3 minutes for LLM calls
+      testTimeout: 300000,
     },
   });
 


### PR DESCRIPTION
## Description

* Add handful of test use cases
* Adjust testing framework to use copilot to improve copilot. Slight refactor to avoid a large test refactor
* Edit copilot instructions based on tests

## Tests

Example:
```
 ✓ tests/copilot-evals/copilot-eval.test.ts (6 tests) 228393ms
   ✓ Copilot Evaluation Tests (6)
     ✓ minimal-instructions (6)
       ✓ make-it-better  64311ms
       ✓ improve-basic  135673ms
       ✓ add-doc-search  145676ms
       ✓ add-jira-tickets  218691ms
       ✓ tone-formal  89857ms
       ✓ tone-friendly  164007ms

 Test Files  1 passed (1)
      Tests  6 passed (6)
   Start at  16:50:11
   Duration  233.49s (transform 2.23s, setup 2.68s, import 1.97s, tests 228.39s, environment 324ms)
```

Tests  *usually* all pass

## Risk

* Low

## Deploy Plan

* Deploy front