### PR TITLE
[front] Add eslint rule on tool-level instructions

### DIFF
--- a/eslint-plugin-dust/index.js
+++ b/eslint-plugin-dust/index.js
@@ -9,6 +9,7 @@ const enforceClientTypesInPublicApi = require("./rules/enforce-client-types-in-p
 const nextjsNoDataFetchingInGetssp = require("./rules/nextjs-no-data-fetching-in-getssp");
 const nextjsPageComponentNaming = require("./rules/nextjs-page-component-naming");
 const noNextImports = require("./rules/no-next-imports");
+const noMcpServerInstructions = require("./rules/no-mcp-server-instructions");
 
 const plugin = {
   meta: {
@@ -25,6 +26,7 @@ const plugin = {
     "nextjs-no-data-fetching-in-getssp": nextjsNoDataFetchingInGetssp,
     "nextjs-page-component-naming": nextjsPageComponentNaming,
     "no-next-imports": noNextImports,
+    "no-mcp-server-instructions": noMcpServerInstructions,
   },
 };
 

--- a/eslint-plugin-dust/rules/no-mcp-server-instructions.js
+++ b/eslint-plugin-dust/rules/no-mcp-server-instructions.js
@@ -1,7 +1,5 @@
 "use strict";
 
-const INSTRUCTIONS_COMMENT_PREFIX = "MCP INSTRUCTIONS:";
-
 function isNullLiteral(node) {
   return node.type === "Literal" && node.value === null;
 }
@@ -26,7 +24,7 @@ function findInstructionsProperty(serverInfoNode) {
     (prop) =>
       prop.type === "Property" &&
       prop.key.type === "Identifier" &&
-      prop.key.name === "instructions",
+      prop.key.name === "instructions"
   );
 }
 
@@ -43,14 +41,13 @@ module.exports = {
     type: "suggestion",
     docs: {
       description:
-        "Require explanatory comment when INTERNAL_MCP_SERVERS items have non-null instructions",
+        "Disallow non-null instructions in INTERNAL_MCP_SERVERS",
     },
     schema: [],
   },
 
   create: function (context) {
     let inInternalMcpServers = false;
-    const sourceCode = context.sourceCode || context.getSourceCode();
 
     return {
       VariableDeclarator(node) {
@@ -78,22 +75,15 @@ module.exports = {
           return;
         }
 
-        const comments = sourceCode.getCommentsBefore(instructionsProp);
-        const hasExplanatoryComment = comments.some((comment) =>
-          comment.value.trim().startsWith(INSTRUCTIONS_COMMENT_PREFIX),
-        );
-
-        if (!hasExplanatoryComment) {
-          context.report({
-            node: instructionsProp,
-            message:
-              "Instructions in INTERNAL_MCP_SERVERS need to be avoided. " +
-              "Tools should be self-explanatory and straightforward to use: avoid coupling " +
-              '(e.g., "always use tool A before B", should be bundled in tool B itself). ' +
-              "Proper design eliminates the need for server-level instructions, preventing " +
-              "context bloat and instruction clashes.",
-          });
-        }
+        context.report({
+          node: instructionsProp,
+          message:
+            "Instructions in INTERNAL_MCP_SERVERS need to be avoided. " +
+            "Tools should be self-explanatory and straightforward to use: avoid coupling " +
+            '(e.g., "always use tool A before B", should be bundled in tool B itself). ' +
+            "Proper design eliminates the need for server-level instructions, preventing " +
+            "context bloat and instruction clashes.",
+        });
       },
     };
   },

--- a/eslint-plugin-dust/rules/no-mcp-server-instructions.js
+++ b/eslint-plugin-dust/rules/no-mcp-server-instructions.js
@@ -47,6 +47,11 @@ module.exports = {
   },
 
   create: function (context) {
+    const filename = context.filename || context.getFilename();
+    if (!filename.endsWith("constants.ts")) {
+      return {};
+    }
+
     let inInternalMcpServers = false;
 
     return {

--- a/eslint-plugin-dust/rules/no-mcp-server-instructions.js
+++ b/eslint-plugin-dust/rules/no-mcp-server-instructions.js
@@ -1,0 +1,100 @@
+"use strict";
+
+const INSTRUCTIONS_COMMENT_PREFIX = "MCP INSTRUCTIONS:";
+
+function isNullLiteral(node) {
+  return node.type === "Literal" && node.value === null;
+}
+
+function isInternalMcpServersDeclarator(node) {
+  if (
+    node.id.type !== "Identifier" ||
+    node.id.name !== "INTERNAL_MCP_SERVERS"
+  ) {
+    return false;
+  }
+  const init = node.init;
+  return (
+    init?.type === "ObjectExpression" ||
+    (init?.type === "TSSatisfiesExpression" &&
+      init.expression?.type === "ObjectExpression")
+  );
+}
+
+function findInstructionsProperty(serverInfoNode) {
+  return serverInfoNode.value.properties.find(
+    (prop) =>
+      prop.type === "Property" &&
+      prop.key.type === "Identifier" &&
+      prop.key.name === "instructions",
+  );
+}
+
+function isServerInfoProperty(node) {
+  return (
+    node.key.type === "Identifier" &&
+    node.key.name === "serverInfo" &&
+    node.value.type === "ObjectExpression"
+  );
+}
+
+module.exports = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Require explanatory comment when INTERNAL_MCP_SERVERS items have non-null instructions",
+    },
+    schema: [],
+  },
+
+  create: function (context) {
+    let inInternalMcpServers = false;
+    const sourceCode = context.sourceCode || context.getSourceCode();
+
+    return {
+      VariableDeclarator(node) {
+        if (isInternalMcpServersDeclarator(node)) {
+          inInternalMcpServers = true;
+        }
+      },
+
+      "VariableDeclarator:exit"(node) {
+        if (
+          node.id.type === "Identifier" &&
+          node.id.name === "INTERNAL_MCP_SERVERS"
+        ) {
+          inInternalMcpServers = false;
+        }
+      },
+
+      Property(node) {
+        if (!inInternalMcpServers || !isServerInfoProperty(node)) {
+          return;
+        }
+
+        const instructionsProp = findInstructionsProperty(node);
+        if (!instructionsProp || isNullLiteral(instructionsProp.value)) {
+          return;
+        }
+
+        const comments = sourceCode.getCommentsBefore(instructionsProp);
+        const hasExplanatoryComment = comments.some((comment) =>
+          comment.value.trim().startsWith(INSTRUCTIONS_COMMENT_PREFIX),
+        );
+
+        if (!hasExplanatoryComment) {
+          context.report({
+            node: instructionsProp,
+            message:
+              "Instructions in INTERNAL_MCP_SERVERS need to be avoided. " +
+              "Tools should be self-explanatory and straightforward to use: avoid coupling " +
+              '(e.g., "always use tool A before B", should be bundled in tool B itself). ' +
+              "Proper design eliminates the need for server-level instructions, preventing " +
+              "context bloat and instruction clashes.",
+          });
+        }
+      },
+    };
+  },
+};

--- a/front/eslint.config.ts
+++ b/front/eslint.config.ts
@@ -228,6 +228,7 @@ export default defineConfig(
       "dust/no-direct-sparkle-notification": "warn",
       "dust/no-bulk-lodash": "error",
       "dust/enforce-client-types-in-public-api": "error",
+      "dust/no-mcp-server-instructions": "error",
     },
   },
 

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -366,6 +366,9 @@ export const INTERNAL_MCP_SERVERS = {
       },
       icon: "SalesforceLogo",
       documentationUrl: "https://docs.dust.tt/docs/salesforce",
+      // Predates the introduction of the rule, would require extensive work to improve, already
+      // widely adopted.
+      // eslint-disable-next-line dust/no-mcp-server-instructions
       instructions: SALESFORCE_SERVER_INSTRUCTIONS,
     },
   },
@@ -489,6 +492,8 @@ export const INTERNAL_MCP_SERVERS = {
       authorization: null,
       icon: "ActionFrameIcon",
       documentationUrl: null,
+      // Will be removed as soon as we add the ability to add skills to global agents.
+      // eslint-disable-next-line dust/no-mcp-server-instructions
       instructions: INTERACTIVE_CONTENT_INSTRUCTIONS,
     },
   },
@@ -557,6 +562,8 @@ export const INTERNAL_MCP_SERVERS = {
       authorization: null,
       icon: "ActionDocumentTextIcon",
       documentationUrl: null,
+      // TBD if turned into a global skill or not.
+      // eslint-disable-next-line dust/no-mcp-server-instructions
       instructions: SLIDESHOW_INSTRUCTIONS,
     },
   },
@@ -577,6 +584,8 @@ export const INTERNAL_MCP_SERVERS = {
       authorization: null,
       icon: "ActionAtomIcon",
       documentationUrl: "https://docs.dust.tt/docs/go-deep",
+      // Will be removed as soon as we add the ability to add skills to global agents.
+      // eslint-disable-next-line dust/no-mcp-server-instructions
       instructions: DEEP_DIVE_SERVER_INSTRUCTIONS,
     },
   },
@@ -924,6 +933,9 @@ export const INTERNAL_MCP_SERVERS = {
       },
       icon: "ProductboardLogo",
       documentationUrl: "https://docs.dust.tt/docs/productboard",
+      // Predates the introduction of the rule, would require extensive work to improve, already
+      // widely adopted.
+      // eslint-disable-next-line dust/no-mcp-server-instructions
       instructions: PRODUCTBOARD_SERVER_INSTRUCTIONS,
     },
   },


### PR DESCRIPTION
## Description

- This PR adds an eslint that discourages the addition of instructions on MCP servers.
- This is a behavior we want to avoid long term. As a first step we can avoid adding it to new tools.

## Tests

- N/A.

## Risk

- N/A.

## Deploy Plan

- No deploy.
