### PR TITLE
Pierre/prune

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -97,7 +97,7 @@ import { assertNever } from "@app/types/shared/utils/assert_never";
 function PrunedContextChip() {
   return (
     <Tooltip
-      label="Some tool results were removed to keep this conversation within its context size limit. The answer may be less accurate or miss details."
+      label="Some tool results were too large and removed to keep this conversation within its context size limit. The answer may be less accurate or miss details."
       trigger={
         <Chip
           label="Answer may be inaccurate"

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -10,10 +10,12 @@ import {
   ConversationMessageContainer,
   ConversationMessageContent,
   ConversationMessageTitle,
+  ExclamationCircleIcon,
   InteractiveImageGrid,
   LinkIcon,
   MoreIcon,
   StopIcon,
+  Tooltip,
   TrashIcon,
   useCopyToClipboard,
 } from "@dust-tt/sparkle";
@@ -91,6 +93,22 @@ import {
   isSupportedImageContentType,
 } from "@app/types";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+
+function PrunedContextChip() {
+  return (
+    <Tooltip
+      label="Some tool results were removed to keep this conversation within its size limit. The answer may be less accurate or miss details."
+      trigger={
+        <Chip
+          label="Degraded response"
+          size="xs"
+          color="golden"
+          icon={ExclamationCircleIcon}
+        />
+      }
+    />
+  );
+}
 
 interface AgentMessageProps {
   conversationId: string;
@@ -724,6 +742,11 @@ export function AgentMessage({
         <ConversationMessageTitle
           name={agentConfiguration.name}
           timestamp={timestamp}
+          infoChip={
+            (agentMessage.prunedContext ?? false) ? (
+              <PrunedContextChip />
+            ) : undefined
+          }
           completionStatus={
             isDeleted ? undefined : (
               <AgentMessageCompletionStatus agentMessage={agentMessage} />
@@ -747,6 +770,11 @@ export function AgentMessage({
           className="hidden @sm:flex"
           name={agentConfiguration.name}
           timestamp={timestamp}
+          infoChip={
+            (agentMessage.prunedContext ?? false) ? (
+              <PrunedContextChip />
+            ) : undefined
+          }
           completionStatus={
             isDeleted ? undefined : (
               <AgentMessageCompletionStatus agentMessage={agentMessage} />

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -260,6 +260,7 @@ export function AgentMessage({
           case "tool_error":
           case "tool_notification":
           case "tool_params":
+          case "agent_context_pruned":
             // Do nothing
             break;
           default:

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -97,10 +97,10 @@ import { assertNever } from "@app/types/shared/utils/assert_never";
 function PrunedContextChip() {
   return (
     <Tooltip
-      label="Some tool results were removed to keep this conversation within its size limit. The answer may be less accurate or miss details."
+      label="Some tool results were removed to keep this conversation within its context size limit. The answer may be less accurate or miss details."
       trigger={
         <Chip
-          label="Degraded response"
+          label="Answer may be inaccurate"
           size="xs"
           color="golden"
           icon={ExclamationCircleIcon}

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -744,9 +744,7 @@ export function AgentMessage({
           name={agentConfiguration.name}
           timestamp={timestamp}
           infoChip={
-            (agentMessage.prunedContext ?? false) ? (
-              <PrunedContextChip />
-            ) : undefined
+            agentMessage.prunedContext ? <PrunedContextChip /> : undefined
           }
           completionStatus={
             isDeleted ? undefined : (
@@ -772,9 +770,7 @@ export function AgentMessage({
           name={agentConfiguration.name}
           timestamp={timestamp}
           infoChip={
-            (agentMessage.prunedContext ?? false) ? (
-              <PrunedContextChip />
-            ) : undefined
+            agentMessage.prunedContext ? <PrunedContextChip /> : undefined
           }
           completionStatus={
             isDeleted ? undefined : (

--- a/front/hooks/useAgentMessageStream.ts
+++ b/front/hooks/useAgentMessageStream.ts
@@ -261,6 +261,17 @@ export function useAgentMessageStream({
           );
           break;
 
+        case "agent_context_pruned":
+          methods.data.map((m) =>
+            isMessageTemporayState(m) && m.sId === sId
+              ? {
+                  ...m,
+                  prunedContext: true,
+                }
+              : m
+          );
+          break;
+
         case "agent_generation_cancelled":
           methods.data.map((m) =>
             isMessageTemporayState(m) && m.sId === sId

--- a/front/hooks/useAgentMessageStreamLegacy.ts
+++ b/front/hooks/useAgentMessageStreamLegacy.ts
@@ -210,6 +210,15 @@ function messageReducer(
         agentState: "acting",
       };
 
+    case "agent_context_pruned":
+      return {
+        ...state,
+        message: {
+          ...state.message,
+          prunedContext: true,
+        },
+      };
+
     default:
       assertNever(event);
   }

--- a/front/lib/api/assistant/citations.ts
+++ b/front/lib/api/assistant/citations.ts
@@ -175,5 +175,6 @@ export function getLightAgentMessageFromAgentMessage(
     richMentions: agentMessage.richMentions,
     completionDurationMs: agentMessage.completionDurationMs,
     reactions: agentMessage.reactions,
+    prunedContext: agentMessage.prunedContext,
   };
 }

--- a/front/lib/api/assistant/conversation_rendering/index.ts
+++ b/front/lib/api/assistant/conversation_rendering/index.ts
@@ -60,6 +60,7 @@ export async function renderConversationForModel(
     {
       modelConversation: ModelConversationTypeMultiActions;
       tokensUsed: number;
+      prunedContext: boolean;
     },
     Error
   >
@@ -112,6 +113,17 @@ export async function renderConversationForModel(
       currentInteraction,
       availableTokens
     );
+    if (currentInteraction.prunedContext) {
+      logger.warn(
+        {
+          workspaceId: conversation.owner.sId,
+          conversationId: conversation.sId,
+          currentInteractionTokens,
+          availableTokens,
+        },
+        "Last tool result was pruned to fit in context window."
+      );
+    }
     currentInteractionTokens = getInteractionTokenCount(currentInteraction);
     if (currentInteractionTokens > availableTokens) {
       logger.error(
@@ -209,6 +221,8 @@ export async function renderConversationForModel(
         message.role !== "content_fragment"
     );
 
+  const prunedContext = currentInteraction.prunedContext ?? false;
+
   logger.info(
     {
       workspaceId: conversation.owner.sId,
@@ -217,6 +231,7 @@ export async function renderConversationForModel(
       promptToken: promptCount,
       tokensUsed,
       messageSelected: finalMessages.length,
+      prunedContext,
       elapsed: Date.now() - now,
     },
     "[ASSISTANT_TRACE] renderConversationForModelEnhanced"
@@ -227,6 +242,7 @@ export async function renderConversationForModel(
       messages: finalMessages,
     },
     tokensUsed,
+    prunedContext,
   });
 }
 

--- a/front/lib/api/assistant/conversation_rendering/pruning.ts
+++ b/front/lib/api/assistant/conversation_rendering/pruning.ts
@@ -15,6 +15,7 @@ export type MessageWithTokens = ModelMessageTypeMultiActions & {
 
 export type InteractionWithTokens = {
   messages: MessageWithTokens[];
+  prunedContext?: boolean;
 };
 
 /**
@@ -70,9 +71,15 @@ export function progressivelyPruneInteraction(
     }
   }
 
+  let prunedContext = false;
+
   // Prune from oldest to newest, recalculating tokens each time.
   let prunedMessages = [...interaction.messages];
   for (const index of toolResultIndices) {
+    // If very last tool result is pruned, we mark prunedContext as true.
+    if (index === toolResultIndices[toolResultIndices.length - 1]) {
+      prunedContext = true;
+    }
     const message = prunedMessages[index];
     if (message.role === "function") {
       // Create a new array with the pruned message.
@@ -96,6 +103,7 @@ export function progressivelyPruneInteraction(
 
   return {
     messages: prunedMessages,
+    prunedContext,
   };
 }
 

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -641,6 +641,7 @@ async function batchRenderAgentMessages<V extends RenderMessageVariant>(
           actions
         ),
         reactions: reactionsByMessageId[message.id] ?? [],
+        prunedContext: agentMessage.prunedContext ?? false,
       } satisfies AgentMessageType;
 
       if (viewType === "full") {

--- a/front/lib/api/assistant/streaming/events.ts
+++ b/front/lib/api/assistant/streaming/events.ts
@@ -109,6 +109,7 @@ function isMessageEventParams(
 ): params is MessageEventParams {
   switch (eventType) {
     case "agent_action_success":
+    case "agent_context_pruned":
     case "agent_error":
     case "agent_generation_cancelled":
     case "agent_message_success":

--- a/front/lib/api/assistant/streaming/types.ts
+++ b/front/lib/api/assistant/streaming/types.ts
@@ -5,6 +5,7 @@ import type {
 } from "@app/lib/actions/mcp_internal_actions/events";
 import type {
   AgentActionSuccessEvent,
+  AgentContextPrunedEvent,
   AgentErrorEvent,
   AgentGenerationCancelledEvent,
   AgentMessageDoneEvent,
@@ -19,6 +20,7 @@ import type {
 export type AgentMessageEvents =
   | AgentActionRunningEvents
   | AgentActionSuccessEvent
+  | AgentContextPrunedEvent
   | AgentErrorEvent
   | AgentGenerationCancelledEvent
   | AgentMessageSuccessEvent

--- a/front/lib/models/agent/conversation.ts
+++ b/front/lib/models/agent/conversation.ts
@@ -373,6 +373,7 @@ export class AgentMessageModel extends WorkspaceAwareModel<AgentMessageModel> {
 
   declare modelInteractionDurationMs: number | null;
   declare completedAt: Date | null;
+  declare prunedContext: boolean | null;
 }
 
 AgentMessageModel.init(
@@ -452,6 +453,11 @@ AgentMessageModel.init(
       type: DataTypes.DATE,
       allowNull: true,
       defaultValue: null,
+    },
+    prunedContext: {
+      type: DataTypes.BOOLEAN,
+      allowNull: true,
+      defaultValue: false,
     },
   },
   {

--- a/front/migrations/db/migration_497.sql
+++ b/front/migrations/db/migration_497.sql
@@ -1,0 +1,2 @@
+-- Migration created on Jan 29, 2026
+ALTER TABLE "public"."agent_messages" ADD COLUMN "prunedContext" BOOLEAN DEFAULT false;

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -424,6 +424,15 @@ export async function runModelActivity(
     "[LLM stream] Starting (agent loop)"
   );
 
+  if (
+    modelConversationRes.value.prunedContext === true &&
+    !agentMessageRow.prunedContext
+  ) {
+    await agentMessageRow.update({
+      prunedContext: true,
+    });
+  }
+
   const getOutputFromActionResponse = await getOutputFromLLMStream(auth, {
     modelConversationRes,
     conversation,

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -431,6 +431,18 @@ export async function runModelActivity(
     await agentMessageRow.update({
       prunedContext: true,
     });
+
+    await updateResourceAndPublishEvent(auth, {
+      event: {
+        type: "agent_context_pruned",
+        created: Date.now(),
+        configurationId: agentConfiguration.sId,
+        messageId: agentMessage.sId,
+      },
+      agentMessageRow,
+      conversation,
+      step,
+    });
   }
 
   const getOutputFromActionResponse = await getOutputFromLLMStream(auth, {
@@ -557,6 +569,7 @@ export async function runModelActivity(
         completedTs,
         agentMessage.actions
       ),
+      prunedContext: agentMessageRow.prunedContext ?? false,
     } satisfies AgentMessageType;
 
     await updateResourceAndPublishEvent(auth, {

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -393,3 +393,10 @@ export type AgentStepContentEvent = {
     | AgentFunctionCallContentType
     | AgentReasoningContentType;
 };
+
+export type AgentContextPrunedEvent = {
+  type: "agent_context_pruned";
+  created: number;
+  configurationId: string;
+  messageId: string;
+};

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -216,6 +216,7 @@ export type BaseAgentMessageType = {
   visibility: MessageVisibility;
   richMentions: RichMentionWithStatus[];
   completionDurationMs: number | null;
+  prunedContext?: boolean;
 };
 
 export type ParsedContentItem =
@@ -256,6 +257,7 @@ export type LightAgentMessageType = BaseAgentMessageType & {
   citations: Record<string, CitationType>;
   generatedFiles: Omit<ActionGeneratedFileType, "snippet">[];
   reactions: MessageReactionType[];
+  prunedContext?: boolean;
 };
 
 // This type represents the agent message we can reconstruct by accumulating streaming events


### PR DESCRIPTION
## Description

During agent loop, tools can return huge payload, which results in pruning tools results before sending the conv to the llm to fit in context window.
When the last tool result is pruned, the agent answer might not be relevant.
This PR shows a warning when that heppens.

<img width="782" height="524" alt="image" src="https://github.com/user-attachments/assets/b32f5f9e-efb5-4ed5-969d-c76d7d4e4f3b" />


## Tests

local

## Risk

no

## Deploy Plan

Block front deploy
Migrate
Deploy
Unblock front deploy
