### PR TITLE
[Front] Fix Next.js config static analysis for body parser limit

### DIFF
--- a/front/pages/api/v1/w/[wId]/data_sources/[dsId]/documents/[documentId]/blob.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[dsId]/documents/[documentId]/blob.ts
@@ -2,9 +2,7 @@ import type { GetDocumentBlobResponseType } from "@dust-tt/client";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
-import apiConfig, {
-  DOCUMENT_UPSERT_BODY_PARSER_LIMIT,
-} from "@app/lib/api/config";
+import apiConfig from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import logger from "@app/logger/logger";
@@ -12,10 +10,12 @@ import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
 import { CoreAPI } from "@app/types";
 
+// Next.js config must use literal values (cannot be statically analyzed otherwise).
+// If wishing to change this value, see DOCUMENT_UPSERT_BODY_PARSER_LIMIT in lib/api/config.ts.
 export const config = {
   api: {
     bodyParser: {
-      sizeLimit: DOCUMENT_UPSERT_BODY_PARSER_LIMIT,
+      sizeLimit: "16mb",
     },
   },
 };

--- a/front/pages/api/v1/w/[wId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -1,11 +1,12 @@
 /* eslint-disable dust/enforce-client-types-in-public-api */
-import { DOCUMENT_UPSERT_BODY_PARSER_LIMIT } from "@app/lib/api/config";
 import handler from "@app/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index";
 
+// Next.js config must use literal values (cannot be statically analyzed otherwise).
+// If wishing to change this value, see DOCUMENT_UPSERT_BODY_PARSER_LIMIT in lib/api/config.ts.
 export const config = {
   api: {
     bodyParser: {
-      sizeLimit: DOCUMENT_UPSERT_BODY_PARSER_LIMIT,
+      sizeLimit: "16mb",
     },
   },
 };

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -8,9 +8,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { fromError } from "zod-validation-error";
 
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
-import apiConfig, {
-  DOCUMENT_UPSERT_BODY_PARSER_LIMIT,
-} from "@app/lib/api/config";
+import apiConfig from "@app/lib/api/config";
 import { UNTITLED_TITLE } from "@app/lib/api/content_nodes";
 import { computeWorkspaceOverallSizeCached } from "@app/lib/api/data_sources";
 import type { Authenticator } from "@app/lib/auth";
@@ -34,10 +32,12 @@ import {
   validateUrl,
 } from "@app/types";
 
+// Next.js config must use literal values (cannot be statically analyzed otherwise).
+// If wishing to change this value, see DOCUMENT_UPSERT_BODY_PARSER_LIMIT in lib/api/config.ts.
 export const config = {
   api: {
     bodyParser: {
-      sizeLimit: DOCUMENT_UPSERT_BODY_PARSER_LIMIT,
+      sizeLimit: "16mb",
     },
   },
 };

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/documents/[documentId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/documents/[documentId]/index.ts
@@ -1,9 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import apiConfig, {
-  DOCUMENT_UPSERT_BODY_PARSER_LIMIT,
-} from "@app/lib/api/config";
+import apiConfig from "@app/lib/api/config";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import type { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
@@ -12,10 +10,12 @@ import { apiError } from "@app/logger/withlogging";
 import type { CoreAPIDocument, WithAPIErrorResponse } from "@app/types";
 import { CoreAPI } from "@app/types";
 
+// Next.js config must use literal values (cannot be statically analyzed otherwise).
+// If wishing to change this value, see DOCUMENT_UPSERT_BODY_PARSER_LIMIT in lib/api/config.ts.
 export const config = {
   api: {
     bodyParser: {
-      sizeLimit: DOCUMENT_UPSERT_BODY_PARSER_LIMIT,
+      sizeLimit: "16mb",
     },
   },
 };

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -3,9 +3,7 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import apiConfig, {
-  DOCUMENT_UPSERT_BODY_PARSER_LIMIT,
-} from "@app/lib/api/config";
+import apiConfig from "@app/lib/api/config";
 import { upsertDocument } from "@app/lib/api/data_sources";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";
@@ -21,10 +19,12 @@ import type {
 } from "@app/types";
 import { CoreAPI, PostDataSourceDocumentRequestBodySchema } from "@app/types";
 
+// Next.js config must use literal values (cannot be statically analyzed otherwise).
+// If wishing to change this value, see DOCUMENT_UPSERT_BODY_PARSER_LIMIT in lib/api/config.ts.
 export const config = {
   api: {
     bodyParser: {
-      sizeLimit: DOCUMENT_UPSERT_BODY_PARSER_LIMIT,
+      sizeLimit: "16mb",
     },
   },
 };

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/index.ts
@@ -3,7 +3,6 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import { DOCUMENT_UPSERT_BODY_PARSER_LIMIT } from "@app/lib/api/config";
 import { upsertDocument } from "@app/lib/api/data_sources";
 import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
 import type { Authenticator } from "@app/lib/auth";
@@ -17,10 +16,12 @@ import type {
 } from "@app/types";
 import { PostDataSourceDocumentRequestBodySchema } from "@app/types";
 
+// Next.js config must use literal values (cannot be statically analyzed otherwise).
+// If wishing to change this value, see DOCUMENT_UPSERT_BODY_PARSER_LIMIT in lib/api/config.ts.
 export const config = {
   api: {
     bodyParser: {
-      sizeLimit: DOCUMENT_UPSERT_BODY_PARSER_LIMIT,
+      sizeLimit: "16mb",
     },
   },
 };


### PR DESCRIPTION
## Description

Follows https://github.com/dust-tt/dust/pull/20536

Fixes the Next.js build warning reported in https://github.com/dust-tt/dust/pull/20536#issuecomment-3801786104:

```
⚠ Next.js can't recognize the exported `config` field in route "/api/v1/w/[wId]/data_sources/[dsId]/documents/[documentId]/blob":
Unknown identifier "DOCUMENT_UPSERT_BODY_PARSER_LIMIT" at "config.api.bodyParser.sizeLimit".
```

Next.js parses API route configs at build time without executing the code, so the config object must contain only literal values. This PR replaces the imported constant with literal `"16mb"` values and adds comments pointing to the constant definition for documentation.

## Risks

Blast radius: document upsert API endpoints body parser config
Risk: none

## Deploy Plan
- pmrr
- deploy front