### PR TITLE
[front] chore: Rename Non-API programmatic usage to Unamed API Keys

### DIFF
--- a/front/lib/api/analytics/programmatic_cost.ts
+++ b/front/lib/api/analytics/programmatic_cost.ts
@@ -495,7 +495,7 @@ export async function handleProgrammaticCostRequest(
         availableGroupBuckets.forEach((bucket) => {
           let groupLabel = bucket.key;
           if (bucket.key === "non_api_programmatic") {
-            groupLabel = "Non-API programmatic usage";
+            groupLabel = "Unnamed API keys";
           } else if (bucket.key === "unknown") {
             groupLabel = "Unknown";
           } else if (groupBy === "agent" && agentNames[bucket.key]) {


### PR DESCRIPTION
## Description

Non-API programmatic usage is a bit confusing, given it's a bucket to group costs by un-named api-keys

## Tests

N/A

## Risk

Low

## Deploy Plan

- [ ] Deploy front