### PR TITLE
[Mentions] Remove deprecated pending status

### DIFF
--- a/front/components/assistant/conversation/MentionValidationRequired.tsx
+++ b/front/components/assistant/conversation/MentionValidationRequired.tsx
@@ -26,11 +26,7 @@ interface MentionValidationRequiredProps {
   mention: Extract<
     RichMentionWithStatus,
     {
-      // "pending" is deprecated but kept for migration compatibility
-      status:
-        | "pending"
-        | "pending_conversation_access"
-        | "pending_project_membership";
+      status: "pending_conversation_access" | "pending_project_membership";
     }
   >;
   conversation: ConversationWithoutContentType;

--- a/front/components/assistant/conversation/MessageItem.tsx
+++ b/front/components/assistant/conversation/MessageItem.tsx
@@ -185,9 +185,7 @@ export const MessageItem = React.forwardRef<HTMLDivElement, MessageItemProps>(
 
               // :warning: make sure to use the index in the key, as the mention.id is the userId
 
-              // "pending" is deprecated but kept for migration compatibility
               if (
-                mention.status === "pending" ||
                 mention.status === "pending_conversation_access" ||
                 mention.status === "pending_project_membership"
               ) {

--- a/front/lib/api/assistant/conversation/mentions.ts
+++ b/front/lib/api/assistant/conversation/mentions.ts
@@ -1097,9 +1097,7 @@ export async function validateUserMention(
     userMessages: [],
     agentMessages: [],
   };
-  // "pending" is deprecated but kept for migration compatibility
   const isPendingStatus = (status: MentionStatusType): boolean =>
-    status === "pending" ||
     status === "pending_conversation_access" ||
     status === "pending_project_membership";
 

--- a/front/lib/models/agent/conversation.ts
+++ b/front/lib/models/agent/conversation.ts
@@ -791,7 +791,6 @@ MessageReactionModel.belongsTo(UserModel, {
 });
 
 export type MentionStatusType =
-  | "pending" // DEPRECATED: use pending_conversation_access. Kept temporarily for migration.
   | "pending_conversation_access" // Waiting for user input to invite to conversation
   | "pending_project_membership" // Waiting for user input to add to project (mentioning user is project editor)
   | "approved" // Auto or manually approved

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -117,7 +117,6 @@ export type AgenticMessageData = {
 };
 
 export type RichMentionWithStatus =
-  | (RichMention & { dismissed: boolean; status: "pending" }) // DEPRECATED: kept for migration
   | (RichMention & {
       dismissed: boolean;
       status: "pending_conversation_access";


### PR DESCRIPTION
## Description

Follow-up to https://github.com/dust-tt/dust/pull/20825

Removes the deprecated `pending` mention status that was kept temporarily for safe migration. Now that the migration has run and all `pending` statuses have been converted to `pending_conversation_access`, this cleanup removes:
- `pending` from `MentionStatusType`
- `pending` from `RichMentionWithStatus`
- Deprecated comments referencing `pending`

## Risks

Blast radius: mention validation UI in conversations
Risk: none (cleanup only, no behavioral change)

## Deploy Plan
- pmrr
- deploy front