### PR TITLE
Replace the use of SubscriptionModel.create by SubscriptionResource.makeNew

### DIFF
--- a/front/lib/resources/subscription_resource.ts
+++ b/front/lib/resources/subscription_resource.ts
@@ -85,9 +85,13 @@ export class SubscriptionResource extends BaseResource<SubscriptionModel> {
 
   static async makeNew(
     blob: CreationAttributes<SubscriptionModel>,
-    plan: PlanType
+    plan: PlanType,
+    transaction?: Transaction
   ) {
-    const subscription = await SubscriptionModel.create({ ...blob });
+    const subscription = await SubscriptionModel.create(
+      { ...blob },
+      { transaction }
+    );
     return new SubscriptionResource(
       SubscriptionModel,
       subscription.get(),

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -29,6 +29,7 @@ import {
   isPAYGEnabled,
 } from "@app/lib/credits/payg";
 import { PlanModel, SubscriptionModel } from "@app/lib/models/plan";
+import { renderPlanFromModel } from "@app/lib/plans/renderers";
 import {
   assertStripeSubscriptionIsValid,
   createCustomerPortalSession,
@@ -287,7 +288,7 @@ async function handler(
               const stripeSubscription =
                 await stripe.subscriptions.retrieve(stripeSubscriptionId);
 
-              await SubscriptionModel.create(
+              await SubscriptionResource.makeNew(
                 {
                   sId: generateRandomModelSId(),
                   workspaceId: workspace.id,
@@ -297,7 +298,8 @@ async function handler(
                   startDate: now,
                   stripeSubscriptionId: stripeSubscriptionId,
                 },
-                { transaction: t }
+                renderPlanFromModel({ plan }),
+                t
               );
             });
             if (userId) {


### PR DESCRIPTION
## Description

Only 2 usages of SubscriptionModel.create
The resource does the same thing but requires the Plan to be provided as a type and not a model

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
