### PR TITLE
feat(drive): add search file endpoint

### DIFF
--- a/front/pages/api/w/[wId]/google_drive/search_for_authorization.test.ts
+++ b/front/pages/api/w/[wId]/google_drive/search_for_authorization.test.ts
@@ -1,0 +1,451 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import type { OAuthConnectionType, OAuthProvider } from "@app/types";
+import { Err, Ok } from "@app/types";
+
+import handler from "./search_for_authorization";
+
+function createMockConnection({
+  provider,
+  workspaceId,
+  userId,
+}: {
+  provider: OAuthProvider;
+  workspaceId: string;
+  userId: string;
+}): OAuthConnectionType {
+  return {
+    connection_id: "con_123456",
+    created: Date.now(),
+    provider,
+    status: "finalized",
+    metadata: {
+      workspace_id: workspaceId,
+      user_id: userId,
+    },
+  };
+}
+
+function createMockAccessTokenResponse({
+  provider,
+  workspaceId,
+  userId,
+}: {
+  provider: OAuthProvider;
+  workspaceId: string;
+  userId: string;
+}) {
+  return {
+    access_token: "test-access-token",
+    access_token_expiry: null,
+    scrubbed_raw_json: {},
+    connection: createMockConnection({ provider, workspaceId, userId }),
+  };
+}
+
+function createMockMetadataResponse({
+  provider,
+  workspaceId,
+  userId,
+}: {
+  provider: OAuthProvider;
+  workspaceId: string;
+  userId: string;
+}) {
+  return {
+    connection: createMockConnection({ provider, workspaceId, userId }),
+  };
+}
+
+// Mock config
+vi.mock("@app/lib/api/config", () => ({
+  default: {
+    getOAuthAPIConfig: vi.fn(() => ({
+      url: "https://oauth-api.example.com",
+      apiKey: "test-api-key",
+    })),
+  },
+}));
+
+// Mock rate limiter
+vi.mock("@app/lib/utils/rate_limiter", () => ({
+  rateLimiter: vi.fn(),
+}));
+
+import { rateLimiter } from "@app/lib/utils/rate_limiter";
+
+// Create mock OAuthAPI methods
+const mockGetConnectionMetadata = vi.fn();
+const mockGetAccessToken = vi.fn();
+
+// Mock the OAuthAPI class
+vi.mock("@app/types", async (importOriginal) => {
+  const actual = (await importOriginal()) as object;
+  return {
+    ...actual,
+    OAuthAPI: vi.fn().mockImplementation(function () {
+      return {
+        getConnectionMetadata: mockGetConnectionMetadata,
+        getAccessToken: mockGetAccessToken,
+      };
+    }),
+  };
+});
+
+// Mock Google Drive client
+const mockFilesList = vi.fn();
+vi.mock("@app/lib/providers/google_drive/utils", () => ({
+  getGoogleDriveClient: vi.fn(() => ({
+    files: {
+      list: mockFilesList,
+    },
+  })),
+}));
+
+async function setupTest() {
+  const { req, res, workspace, authenticator } =
+    await createPrivateApiMockRequest({
+      role: "user",
+      method: "POST",
+    });
+
+  req.query.wId = workspace.sId;
+
+  // Default rate limiter to allow requests
+  vi.mocked(rateLimiter).mockResolvedValue(60);
+
+  return { req, res, workspace, authenticator };
+}
+
+describe("POST /api/w/[wId]/google_drive/search_for_authorization", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should return 405 for non-POST methods", async () => {
+    const { req, res, workspace } = await createPrivateApiMockRequest({
+      role: "user",
+      method: "GET",
+    });
+
+    req.query.wId = workspace.sId;
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(405);
+    const responseData = res._getJSONData();
+    expect(responseData.error).toBeDefined();
+    expect(responseData.error.type).toBe("method_not_supported_error");
+  });
+
+  it("should return 400 for missing connectionId", async () => {
+    const { req, res } = await setupTest();
+
+    req.body = { fileName: "test document" };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    const responseData = res._getJSONData();
+    expect(responseData.error).toBeDefined();
+    expect(responseData.error.type).toBe("invalid_request_error");
+  });
+
+  it("should return 400 for missing fileName", async () => {
+    const { req, res } = await setupTest();
+
+    req.body = { connectionId: "con_123456" };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    const responseData = res._getJSONData();
+    expect(responseData.error).toBeDefined();
+    expect(responseData.error.type).toBe("invalid_request_error");
+  });
+
+  it("should return 403 for invalid connection ownership", async () => {
+    const { req, res, authenticator } = await setupTest();
+
+    mockGetAccessToken.mockResolvedValue(
+      new Ok(
+        createMockAccessTokenResponse({
+          provider: "google_drive",
+          workspaceId: "different_workspace_id",
+          userId: authenticator.user()?.sId ?? "",
+        })
+      )
+    );
+
+    req.body = { connectionId: "con_123456", fileName: "test" };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(403);
+    const responseData = res._getJSONData();
+    expect(responseData.error).toBeDefined();
+    expect(responseData.error.type).toBe("workspace_auth_error");
+    expect(responseData.error.message).toBe(
+      "Connection does not belong to this user/workspace"
+    );
+  });
+
+  it("should return 403 for wrong provider", async () => {
+    const { req, res, workspace, authenticator } = await setupTest();
+
+    const userId = authenticator.user()?.sId ?? "";
+
+    mockGetAccessToken.mockResolvedValue(
+      new Ok(
+        createMockAccessTokenResponse({
+          provider: "slack",
+          workspaceId: workspace.sId,
+          userId,
+        })
+      )
+    );
+
+    mockGetConnectionMetadata.mockResolvedValue(
+      new Ok(
+        createMockMetadataResponse({
+          provider: "slack",
+          workspaceId: workspace.sId,
+          userId,
+        })
+      )
+    );
+
+    req.body = { connectionId: "con_123456", fileName: "test" };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(403);
+    const responseData = res._getJSONData();
+    expect(responseData.error).toBeDefined();
+    expect(responseData.error.type).toBe("workspace_auth_error");
+    expect(responseData.error.message).toBe(
+      "Connection is not a Google Drive connection"
+    );
+  });
+
+  it("should return 429 when rate limited", async () => {
+    const { req, res, workspace, authenticator } = await setupTest();
+
+    vi.mocked(rateLimiter).mockResolvedValue(0);
+
+    const userId = authenticator.user()?.sId ?? "";
+
+    mockGetAccessToken.mockResolvedValue(
+      new Ok(
+        createMockAccessTokenResponse({
+          provider: "google_drive",
+          workspaceId: workspace.sId,
+          userId,
+        })
+      )
+    );
+
+    mockGetConnectionMetadata.mockResolvedValue(
+      new Ok(
+        createMockMetadataResponse({
+          provider: "google_drive",
+          workspaceId: workspace.sId,
+          userId,
+        })
+      )
+    );
+
+    req.body = { connectionId: "con_123456", fileName: "test" };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(429);
+    const responseData = res._getJSONData();
+    expect(responseData.error).toBeDefined();
+    expect(responseData.error.type).toBe("rate_limit_error");
+  });
+
+  it("should return empty array when no matches", async () => {
+    const { req, res, workspace, authenticator } = await setupTest();
+
+    const userId = authenticator.user()?.sId ?? "";
+
+    mockGetAccessToken.mockResolvedValue(
+      new Ok(
+        createMockAccessTokenResponse({
+          provider: "google_drive",
+          workspaceId: workspace.sId,
+          userId,
+        })
+      )
+    );
+
+    mockGetConnectionMetadata.mockResolvedValue(
+      new Ok(
+        createMockMetadataResponse({
+          provider: "google_drive",
+          workspaceId: workspace.sId,
+          userId,
+        })
+      )
+    );
+
+    mockFilesList.mockResolvedValue({
+      data: {
+        files: [],
+      },
+    });
+
+    req.body = { connectionId: "con_123456", fileName: "nonexistent" };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const responseData = res._getJSONData();
+    expect(responseData.files).toEqual([]);
+  });
+
+  it("should return formatted results on success", async () => {
+    const { req, res, workspace, authenticator } = await setupTest();
+
+    const userId = authenticator.user()?.sId ?? "";
+
+    mockGetAccessToken.mockResolvedValue(
+      new Ok(
+        createMockAccessTokenResponse({
+          provider: "google_drive",
+          workspaceId: workspace.sId,
+          userId,
+        })
+      )
+    );
+
+    mockGetConnectionMetadata.mockResolvedValue(
+      new Ok(
+        createMockMetadataResponse({
+          provider: "google_drive",
+          workspaceId: workspace.sId,
+          userId,
+        })
+      )
+    );
+
+    mockFilesList.mockResolvedValue({
+      data: {
+        files: [
+          {
+            id: "file1",
+            name: "Test Document",
+            mimeType: "application/vnd.google-apps.document",
+            webViewLink: "https://docs.google.com/document/d/file1/edit",
+          },
+          {
+            id: "file2",
+            name: "Test Spreadsheet",
+            mimeType: "application/vnd.google-apps.spreadsheet",
+            webViewLink: "https://docs.google.com/spreadsheets/d/file2/edit",
+          },
+        ],
+      },
+    });
+
+    req.body = { connectionId: "con_123456", fileName: "Test" };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const responseData = res._getJSONData();
+    expect(responseData.files).toHaveLength(2);
+    expect(responseData.files[0]).toEqual({
+      fileId: "file1",
+      fileName: "Test Document",
+      mimeType: "application/vnd.google-apps.document",
+      webViewLink: "https://docs.google.com/document/d/file1/edit",
+    });
+    expect(responseData.files[1]).toEqual({
+      fileId: "file2",
+      fileName: "Test Spreadsheet",
+      mimeType: "application/vnd.google-apps.spreadsheet",
+      webViewLink: "https://docs.google.com/spreadsheets/d/file2/edit",
+    });
+  });
+
+  it("should return 500 when failed to get access token", async () => {
+    const { req, res, workspace, authenticator } = await setupTest();
+
+    const userId = authenticator.user()?.sId ?? "";
+
+    mockGetAccessToken
+      .mockResolvedValueOnce(
+        new Ok(
+          createMockAccessTokenResponse({
+            provider: "google_drive",
+            workspaceId: workspace.sId,
+            userId,
+          })
+        )
+      )
+      .mockResolvedValueOnce(new Err(new Error("Token error")));
+
+    mockGetConnectionMetadata.mockResolvedValue(
+      new Ok(
+        createMockMetadataResponse({
+          provider: "google_drive",
+          workspaceId: workspace.sId,
+          userId,
+        })
+      )
+    );
+
+    req.body = { connectionId: "con_123456", fileName: "test" };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(500);
+    const responseData = res._getJSONData();
+    expect(responseData.error).toBeDefined();
+    expect(responseData.error.type).toBe("internal_server_error");
+    expect(responseData.error.message).toBe("Failed to get access token");
+  });
+
+  it("should return 500 when Google Drive API fails", async () => {
+    const { req, res, workspace, authenticator } = await setupTest();
+
+    const userId = authenticator.user()?.sId ?? "";
+
+    mockGetAccessToken.mockResolvedValue(
+      new Ok(
+        createMockAccessTokenResponse({
+          provider: "google_drive",
+          workspaceId: workspace.sId,
+          userId,
+        })
+      )
+    );
+
+    mockGetConnectionMetadata.mockResolvedValue(
+      new Ok(
+        createMockMetadataResponse({
+          provider: "google_drive",
+          workspaceId: workspace.sId,
+          userId,
+        })
+      )
+    );
+
+    mockFilesList.mockRejectedValue(new Error("Google Drive API error"));
+
+    req.body = { connectionId: "con_123456", fileName: "test" };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(500);
+    const responseData = res._getJSONData();
+    expect(responseData.error).toBeDefined();
+    expect(responseData.error.type).toBe("internal_server_error");
+    expect(responseData.error.message).toBe(
+      "Failed to search Google Drive files"
+    );
+  });
+});

--- a/front/pages/api/w/[wId]/google_drive/search_for_authorization.ts
+++ b/front/pages/api/w/[wId]/google_drive/search_for_authorization.ts
@@ -1,0 +1,176 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import config from "@app/lib/api/config";
+import { checkConnectionOwnership } from "@app/lib/api/oauth";
+import type { Authenticator } from "@app/lib/auth";
+import { getGoogleDriveClient } from "@app/lib/providers/google_drive/utils";
+import { rateLimiter } from "@app/lib/utils/rate_limiter";
+import logger from "@app/logger/logger";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+import { OAuthAPI } from "@app/types";
+import { normalizeError } from "@app/types/shared/utils/error_utils";
+
+const RequestBodySchema = z.object({
+  connectionId: z.string().min(1, "connectionId is required"),
+  fileName: z.string().min(1, "fileName is required"),
+});
+
+interface GoogleDriveFile {
+  fileId: string;
+  fileName: string;
+  mimeType: string;
+  webViewLink: string;
+}
+
+export interface SearchForAuthorizationResponseType {
+  files: GoogleDriveFile[];
+}
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<SearchForAuthorizationResponseType>
+  >,
+  auth: Authenticator
+): Promise<void> {
+  const owner = auth.getNonNullableWorkspace();
+
+  switch (req.method) {
+    case "POST": {
+      const parseResult = RequestBodySchema.safeParse(req.body);
+      if (!parseResult.success) {
+        const firstError = parseResult.error.errors[0];
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: firstError?.message || "Invalid request body",
+          },
+        });
+      }
+
+      const { connectionId, fileName } = parseResult.data;
+
+      const ownershipCheck = await checkConnectionOwnership(auth, connectionId);
+      if (ownershipCheck.isErr()) {
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "workspace_auth_error",
+            message: "Connection does not belong to this user/workspace",
+          },
+        });
+      }
+
+      const oauthAPI = new OAuthAPI(config.getOAuthAPIConfig(), logger);
+
+      const metadataRes = await oauthAPI.getConnectionMetadata({
+        connectionId,
+      });
+
+      if (metadataRes.isErr()) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Connection not found",
+          },
+        });
+      }
+
+      if (metadataRes.value.connection.provider !== "google_drive") {
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "workspace_auth_error",
+            message: "Connection is not a Google Drive connection",
+          },
+        });
+      }
+
+      const remaining = await rateLimiter({
+        key: `workspace:${owner.id}:google_drive_search`,
+        maxPerTimeframe: 60,
+        timeframeSeconds: 60,
+        logger,
+      });
+      if (remaining <= 0) {
+        return apiError(req, res, {
+          status_code: 429,
+          api_error: {
+            type: "rate_limit_error",
+            message: "Rate limit exceeded. Please try again later.",
+          },
+        });
+      }
+
+      const tokenRes = await oauthAPI.getAccessToken({ connectionId });
+      if (tokenRes.isErr()) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "Failed to get access token",
+          },
+        });
+      }
+
+      const accessToken = tokenRes.value.access_token;
+      const drive = getGoogleDriveClient(accessToken);
+
+      // Prevent query injection in Google Drive API search syntax.
+      const escapedFileName = fileName.replace(/'/g, "\\'");
+      const query = `name contains '${escapedFileName}' and (mimeType='application/vnd.google-apps.document' or mimeType='application/vnd.google-apps.spreadsheet') and trashed=false`;
+
+      try {
+        const searchRes = await drive.files.list({
+          q: query,
+          pageSize: 10,
+          orderBy: "modifiedTime desc",
+          fields: "files(id, name, mimeType, webViewLink)",
+          includeItemsFromAllDrives: true,
+          supportsAllDrives: true,
+          corpora: "allDrives",
+        });
+
+        const files: GoogleDriveFile[] = (searchRes.data.files ?? []).map(
+          (file) => ({
+            fileId: file.id ?? "",
+            fileName: file.name ?? "",
+            mimeType: file.mimeType ?? "",
+            webViewLink: file.webViewLink ?? "",
+          })
+        );
+
+        return res.status(200).json({ files });
+      } catch (err) {
+        const error = normalizeError(err);
+        logger.error(
+          { error, connectionId, fileName },
+          "Failed to search Google Drive files"
+        );
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "Failed to search Google Drive files",
+          },
+        });
+      }
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, POST is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

This PR adds a google drive search endpoint to facilitate the work on the next tickets. This will allow searching for files to auth for with the approvalw widget.

Closes https://github.com/dust-tt/tasks/issues/5951

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low, unused

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front