### PR TITLE
Add conversation pages to SPA router

### DIFF
--- a/front-spa/src/app/App.tsx
+++ b/front-spa/src/app/App.tsx
@@ -1,3 +1,4 @@
+import { ConversationLayoutWrapper } from "@spa/app/layouts/ConversationLayoutWrapper";
 import { WorkspacePage } from "@spa/app/layouts/WorkspacePage";
 import {
   createBrowserRouter,
@@ -21,6 +22,10 @@ import { ManageSubscriptionPage } from "@dust-tt/front/components/pages/workspac
 import { PaymentProcessingPage } from "@dust-tt/front/components/pages/workspace/subscription/PaymentProcessingPage";
 import { SubscriptionPage } from "@dust-tt/front/components/pages/workspace/subscription/SubscriptionPage";
 import { WorkspaceSettingsPage } from "@dust-tt/front/components/pages/workspace/WorkspaceSettingsPage";
+
+// Conversation pages
+import { ConversationPage } from "@dust-tt/front/components/pages/conversation/ConversationPage";
+import { SpaceConversationsPage } from "@dust-tt/front/components/pages/conversation/SpaceConversationsPage";
 
 // Space pages
 import { DataSourceViewPage } from "@dust-tt/front/components/pages/spaces/DataSourceViewPage";
@@ -49,6 +54,16 @@ const router = createBrowserRouter(
       children: [
         // Profile
         { path: "me", element: <ProfilePage /> },
+
+        // Conversation (wrapped with ConversationLayout)
+        {
+          path: "conversation",
+          element: <ConversationLayoutWrapper />,
+          children: [
+            { path: ":cId", element: <ConversationPage /> },
+            { path: "space/:spaceId", element: <SpaceConversationsPage /> },
+          ],
+        },
 
         // Workspace settings
         { path: "workspace", element: <WorkspaceSettingsPage /> },
@@ -85,10 +100,22 @@ const router = createBrowserRouter(
         // Spaces
         { path: "spaces", element: <SpacesRedirectPage /> },
         { path: "spaces/:spaceId", element: <SpacePage /> },
-        { path: "spaces/:spaceId/categories/actions", element: <SpaceActionsPage /> },
-        { path: "spaces/:spaceId/categories/apps", element: <SpaceAppsListPage /> },
-        { path: "spaces/:spaceId/categories/triggers", element: <SpaceTriggersPage /> },
-        { path: "spaces/:spaceId/categories/:category", element: <SpaceCategoryPage /> },
+        {
+          path: "spaces/:spaceId/categories/actions",
+          element: <SpaceActionsPage />,
+        },
+        {
+          path: "spaces/:spaceId/categories/apps",
+          element: <SpaceAppsListPage />,
+        },
+        {
+          path: "spaces/:spaceId/categories/triggers",
+          element: <SpaceTriggersPage />,
+        },
+        {
+          path: "spaces/:spaceId/categories/:category",
+          element: <SpaceCategoryPage />,
+        },
         {
           path: "spaces/:spaceId/categories/:category/data_source_views/:dataSourceViewId",
           element: <DataSourceViewPage />,
@@ -96,11 +123,26 @@ const router = createBrowserRouter(
 
         // Apps
         { path: "spaces/:spaceId/apps/:aId", element: <AppViewPage /> },
-        { path: "spaces/:spaceId/apps/:aId/settings", element: <AppSettingsPage /> },
-        { path: "spaces/:spaceId/apps/:aId/specification", element: <AppSpecificationPage /> },
-        { path: "spaces/:spaceId/apps/:aId/datasets", element: <DatasetsPage /> },
-        { path: "spaces/:spaceId/apps/:aId/datasets/new", element: <NewDatasetPage /> },
-        { path: "spaces/:spaceId/apps/:aId/datasets/:name", element: <DatasetPage /> },
+        {
+          path: "spaces/:spaceId/apps/:aId/settings",
+          element: <AppSettingsPage />,
+        },
+        {
+          path: "spaces/:spaceId/apps/:aId/specification",
+          element: <AppSpecificationPage />,
+        },
+        {
+          path: "spaces/:spaceId/apps/:aId/datasets",
+          element: <DatasetsPage />,
+        },
+        {
+          path: "spaces/:spaceId/apps/:aId/datasets/new",
+          element: <NewDatasetPage />,
+        },
+        {
+          path: "spaces/:spaceId/apps/:aId/datasets/:name",
+          element: <DatasetPage />,
+        },
         { path: "spaces/:spaceId/apps/:aId/runs", element: <RunsPage /> },
         { path: "spaces/:spaceId/apps/:aId/runs/:runId", element: <RunPage /> },
       ],

--- a/front-spa/src/app/layouts/ConversationLayoutWrapper.tsx
+++ b/front-spa/src/app/layouts/ConversationLayoutWrapper.tsx
@@ -9,15 +9,15 @@ import { useAuth, useWorkspace } from "@dust-tt/front/lib/auth/AuthContext";
  */
 export function ConversationLayoutWrapper() {
   const owner = useWorkspace();
-  const { subscription, user, isAdmin } = useAuth();
+  const { subscription, user, isAdmin, isBuilder, isSuperUser } = useAuth();
 
   const pageProps = {
     workspace: owner,
     subscription,
     user,
     isAdmin,
-    isBuilder: false,
-    isSuperUser: false,
+    isBuilder,
+    isSuperUser,
   };
 
   return (

--- a/front-spa/src/app/layouts/ConversationLayoutWrapper.tsx
+++ b/front-spa/src/app/layouts/ConversationLayoutWrapper.tsx
@@ -1,0 +1,28 @@
+import { Outlet } from "react-router-dom";
+
+import { ConversationLayout } from "@dust-tt/front/components/assistant/conversation/ConversationLayout";
+import { useAuth, useWorkspace } from "@dust-tt/front/lib/auth/AuthContext";
+
+/**
+ * Wrapper component that provides ConversationLayout for SPA conversation routes.
+ * Gets auth context from AppAuthContextLayout and passes it to ConversationLayout.
+ */
+export function ConversationLayoutWrapper() {
+  const owner = useWorkspace();
+  const { subscription, user, isAdmin } = useAuth();
+
+  const pageProps = {
+    workspace: owner,
+    subscription,
+    user,
+    isAdmin,
+    isBuilder: false,
+    isSuperUser: false,
+  };
+
+  return (
+    <ConversationLayout pageProps={pageProps}>
+      <Outlet />
+    </ConversationLayout>
+  );
+}

--- a/front-spa/src/lib/platform.tsx
+++ b/front-spa/src/lib/platform.tsx
@@ -376,6 +376,16 @@ export function usePathParams(): Record<string, string | undefined> {
  * Hook to get a required route param
  * Throws an error if the param is missing
  */
+export function usePathParam(name: string): string | null {
+  const params = usePathParams();
+  const value = params[name];
+  return value ?? null;
+}
+
+/**
+ * Hook to get a required route param
+ * Throws an error if the param is missing
+ */
 export function useRequiredPathParam(name: string): string {
   const params = usePathParams();
   const value = params[name];

--- a/front/hooks/useActiveConversationId.ts
+++ b/front/hooks/useActiveConversationId.ts
@@ -1,6 +1,6 @@
-import { useRequiredPathParam } from "@app/lib/platform";
+import { usePathParam } from "@app/lib/platform";
 
 export function useActiveConversationId() {
-  const cId = useRequiredPathParam("cId");
+  const cId = usePathParam("cId");
   return cId === "new" ? null : cId;
 }

--- a/front/hooks/useActiveConversationId.ts
+++ b/front/hooks/useActiveConversationId.ts
@@ -1,19 +1,6 @@
-import { useMemo } from "react";
-
-import { useAppRouter } from "@app/lib/platform";
+import { useRequiredPathParam } from "@app/lib/platform";
 
 export function useActiveConversationId() {
-  const router = useAppRouter();
-
-  const activeConversationId = useMemo(() => {
-    const conversationId = router.query.cId ?? "";
-
-    if (conversationId && typeof conversationId === "string") {
-      return conversationId === "new" ? null : conversationId;
-    }
-
-    return null;
-  }, [router.query.cId]);
-
-  return activeConversationId;
+  const cId = useRequiredPathParam("cId");
+  return cId === "new" ? null : cId;
 }

--- a/front/lib/platform/index.ts
+++ b/front/lib/platform/index.ts
@@ -15,6 +15,7 @@ export {
   LinkWrapper,
   Script,
   useAppRouter,
+  usePathParam,
   usePathParams,
   useRequiredPathParam,
   useSearchParam,

--- a/front/lib/platform/next.tsx
+++ b/front/lib/platform/next.tsx
@@ -89,6 +89,16 @@ export function usePathParams(): Record<string, string | undefined> {
  * Hook to get a required route param
  * Throws an error if the param is missing
  */
+export function usePathParam(name: string): string | null {
+  const params = usePathParams();
+  const value = params[name];
+  return value ?? null;
+}
+
+/**
+ * Hook to get a required route param
+ * Throws an error if the param is missing
+ */
 export function useRequiredPathParam(name: string): string {
   const params = usePathParams();
   const value = params[name];


### PR DESCRIPTION
## Description

- Add conversation routes to the SPA with proper layout wrapping
- Create ConversationLayoutWrapper to provide required context providers (BlockedActionsProvider, InputBarProvider, etc.)
- Routes added: /w/:wId/conversation/:cId and /w/:wId/conversation/space/:spaceId

## Tests

- Navigate to a conversation URL (e.g., /w/{workspace}/conversation/{conversationId})
- Verify conversation renders correctly with messages
- Verify input bar works and can send messages
- Test creating a new conversation (/conversation/new)
- Test space conversations page (/conversation/space/{spaceId})

## Risk

Break conversations with the change on `front/hooks/useActiveConversationId.ts`
Can be rolled back. 

## Deploy Plan

Merge. 