### PR TITLE
feat(drive): file auth required notification

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -36,6 +36,7 @@ import { ErrorMessage } from "@app/components/assistant/conversation/ErrorMessag
 import type { FeedbackSelectorBaseProps } from "@app/components/assistant/conversation/FeedbackSelector";
 import { FeedbackSelector } from "@app/components/assistant/conversation/FeedbackSelector";
 import { GenerationContext } from "@app/components/assistant/conversation/GenerationContextProvider";
+import { GoogleDriveFileAuthorizationRequired } from "@app/components/assistant/conversation/GoogleDriveFileAuthorizationRequired";
 import { useAutoOpenInteractiveContent } from "@app/components/assistant/conversation/interactive_content/useAutoOpenInteractiveContent";
 import { MCPServerPersonalAuthenticationRequired } from "@app/components/assistant/conversation/MCPServerPersonalAuthenticationRequired";
 import { MCPToolValidationRequired } from "@app/components/assistant/conversation/MCPToolValidationRequired";
@@ -187,6 +188,32 @@ export function AgentMessage({
                 authorizationInfo: {
                   ...authError,
                   supported_use_cases: [],
+                },
+                configurationId: eventPayload.data.configurationId,
+                conversationId: eventPayload.data.conversationId,
+                created: eventPayload.data.created,
+                inputs: eventPayload.data.inputs,
+                messageId: eventPayload.data.messageId,
+                metadata: eventPayload.data.metadata,
+                stake: eventPayload.data.stake,
+                userId: eventPayload.data.userId,
+              },
+            });
+            break;
+
+          case "tool_file_auth_required":
+            const { fileAuthError } = eventPayload.data;
+
+            enqueueBlockedAction({
+              messageId: sId,
+              blockedAction: {
+                status: "blocked_file_authorization_required",
+                actionId: eventPayload.data.actionId,
+                fileAuthorizationInfo: {
+                  fileId: fileAuthError.fileId,
+                  fileName: fileAuthError.fileName,
+                  connectionId: fileAuthError.connectionId,
+                  mimeType: fileAuthError.mimeType,
                 },
                 configurationId: eventPayload.data.configurationId,
                 conversationId: eventPayload.data.conversationId,
@@ -933,6 +960,22 @@ function AgentMessageContent({
             mcpServerId={blockedAction.metadata.mcpServerId}
             provider={blockedAction.authorizationInfo.provider}
             scope={blockedAction.authorizationInfo.scope}
+            retryHandler={() =>
+              retryHandlerWithResetState({
+                conversationId: blockedAction.conversationId,
+                messageId: blockedAction.messageId,
+              })
+            }
+          />
+        );
+
+      case "blocked_file_authorization_required":
+        return (
+          <GoogleDriveFileAuthorizationRequired
+            triggeringUser={triggeringUser}
+            owner={owner}
+            fileAuthorizationInfo={blockedAction.fileAuthorizationInfo}
+            mcpServerId={blockedAction.metadata.mcpServerId}
             retryHandler={() =>
               retryHandlerWithResetState({
                 conversationId: blockedAction.conversationId,

--- a/front/components/assistant/conversation/GoogleDriveFileAuthorizationRequired.tsx
+++ b/front/components/assistant/conversation/GoogleDriveFileAuthorizationRequired.tsx
@@ -1,0 +1,93 @@
+import {
+  Button,
+  CheckCircleIcon,
+  ContentMessage,
+  DocumentTextIcon,
+} from "@dust-tt/sparkle";
+import { useMemo, useState } from "react";
+
+import type { FileAuthorizationInfo } from "@app/lib/actions/mcp";
+import { useUser } from "@app/lib/swr/user";
+import type { LightWorkspaceType, UserType } from "@app/types";
+
+interface GoogleDriveFileAuthorizationRequiredProps {
+  triggeringUser: UserType | null;
+  owner: LightWorkspaceType;
+  fileAuthorizationInfo: FileAuthorizationInfo;
+  mcpServerId: string;
+  retryHandler: () => void;
+}
+
+export function GoogleDriveFileAuthorizationRequired({
+  triggeringUser,
+  owner: _owner,
+  fileAuthorizationInfo,
+  mcpServerId: _mcpServerId,
+  retryHandler: _retryHandler,
+}: GoogleDriveFileAuthorizationRequiredProps) {
+  const { user } = useUser();
+  // TODO(#5954): setIsAuthorized will be called when picker integration is complete
+  const [isAuthorized, _setIsAuthorized] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const isTriggeredByCurrentUser = useMemo(
+    () => triggeringUser?.sId === user?.sId,
+    [triggeringUser, user?.sId]
+  );
+
+  const handleOpenPicker = async () => {
+    setIsLoading(true);
+    // TODO(#5954): Integrate with useGooglePicker hook
+    // For now, placeholder that will be connected in the next ticket.
+    // The picker will:
+    // 1. Open with the connectionId from fileAuthorizationInfo
+    // 2. Pre-select or highlight the file that needs authorization
+    // 3. On successful authorization, call setIsAuthorized(true) and retryHandler()
+    setIsLoading(false);
+  };
+
+  return (
+    <ContentMessage
+      title={isAuthorized ? "File authorized" : "Authorization required"}
+      variant={isAuthorized ? "success" : "primary"}
+      icon={isAuthorized ? CheckCircleIcon : DocumentTextIcon}
+      className="flex w-80 min-w-[300px] flex-col gap-3 sm:min-w-[500px]"
+    >
+      {isTriggeredByCurrentUser ? (
+        <>
+          <div className="font-sm whitespace-normal break-words text-foreground dark:text-foreground-night">
+            {isAuthorized ? (
+              `${fileAuthorizationInfo.fileName} is now accessible. Continuing...`
+            ) : (
+              <>
+                To access{" "}
+                <span className="font-semibold">
+                  {fileAuthorizationInfo.fileName}
+                </span>
+                , please authorize it once.
+              </>
+            )}
+          </div>
+          {!isAuthorized && (
+            <div className="mt-3 flex flex-col justify-end sm:flex-row">
+              <Button
+                label={isLoading ? "Opening picker..." : "Open File Picker"}
+                variant="highlight"
+                size="xs"
+                icon={DocumentTextIcon}
+                disabled={isLoading}
+                onClick={handleOpenPicker}
+              />
+            </div>
+          )}
+        </>
+      ) : (
+        <div className="font-sm whitespace-normal break-words text-foreground dark:text-foreground-night">
+          {triggeringUser?.fullName} needs to authorize a file.
+          <br />
+          <span className="font-semibold">Waiting for them to continue...</span>
+        </div>
+      )}
+    </ContentMessage>
+  );
+}

--- a/front/hooks/useAgentMessageStream.ts
+++ b/front/hooks/useAgentMessageStream.ts
@@ -160,6 +160,7 @@ export function useAgentMessageStream({
           return;
 
         case "tool_personal_auth_required":
+        case "tool_file_auth_required":
         case "tool_approve_execution":
           break;
 

--- a/front/hooks/useAgentMessageStreamLegacy.ts
+++ b/front/hooks/useAgentMessageStreamLegacy.ts
@@ -48,7 +48,9 @@ type AgentMessageStateEvent = (AgentMessageEvents | ToolNotificationEvent) & {
 
 type AgentMessageStateEventWithoutToolApproveExecution = Exclude<
   AgentMessageStateEvent,
-  { type: "tool_approve_execution" } | { type: "tool_personal_auth_required" }
+  | { type: "tool_approve_execution" }
+  | { type: "tool_personal_auth_required" }
+  | { type: "tool_file_auth_required" }
 >;
 
 function updateMessageWithAction(
@@ -328,7 +330,8 @@ export function useAgentMessageStreamLegacy({
 
       if (
         eventType === "tool_approve_execution" ||
-        eventType === "tool_personal_auth_required"
+        eventType === "tool_personal_auth_required" ||
+        eventType === "tool_file_auth_required"
       ) {
         if (customOnEventCallback) {
           customOnEventCallback(eventStr);

--- a/front/lib/actions/mcp.ts
+++ b/front/lib/actions/mcp.ts
@@ -12,11 +12,13 @@ import type { MCPServerAvailability } from "@app/lib/actions/mcp_internal_action
 import type {
   MCPApproveExecutionEvent,
   ToolExecution,
+  ToolFileAuthRequiredEvent,
   ToolPersonalAuthRequiredEvent,
 } from "@app/lib/actions/mcp_internal_actions/events";
 import { hideInternalConfiguration } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import type { ProgressNotificationContentType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import type { AuthorizationInfo } from "@app/lib/actions/mcp_metadata_extraction";
+import type { FileAuthorizationInfo } from "@app/lib/actions/types";
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import type {
   DataSourceConfiguration,
@@ -142,6 +144,8 @@ export type LightMCPToolConfigurationType =
   | LightServerSideMCPToolConfigurationType
   | LightClientSideMCPToolConfigurationType;
 
+export type { FileAuthorizationInfo };
+
 export type BlockedToolExecution = ToolExecution &
   (
     | {
@@ -161,6 +165,14 @@ export type BlockedToolExecution = ToolExecution &
           mcpServerDisplayName: string;
         };
         authorizationInfo: AuthorizationInfo;
+      }
+    | {
+        status: "blocked_file_authorization_required";
+        metadata: MCPValidationMetadataType & {
+          mcpServerId: string;
+          mcpServerDisplayName: string;
+        };
+        fileAuthorizationInfo: FileAuthorizationInfo;
       }
   );
 
@@ -282,15 +294,30 @@ function isToolPersonalAuthRequiredEvent(
   );
 }
 
+function isToolFileAuthRequiredEvent(
+  event: unknown
+): event is ToolFileAuthRequiredEvent {
+  return (
+    typeof event === "object" &&
+    event !== null &&
+    "type" in event &&
+    event.type === "tool_file_auth_required"
+  );
+}
+
 export function isBlockedActionEvent(
   event: unknown
-): event is MCPApproveExecutionEvent | ToolPersonalAuthRequiredEvent {
+): event is
+  | MCPApproveExecutionEvent
+  | ToolPersonalAuthRequiredEvent
+  | ToolFileAuthRequiredEvent {
   return (
     typeof event === "object" &&
     event !== null &&
     "type" in event &&
     (isMCPApproveExecutionEvent(event) ||
       isToolPersonalAuthRequiredEvent(event) ||
+      isToolFileAuthRequiredEvent(event) ||
       isLegacyToolPersonalAuthRequiredEvent(event))
   );
 }

--- a/front/lib/actions/mcp_internal_actions/events.ts
+++ b/front/lib/actions/mcp_internal_actions/events.ts
@@ -45,6 +45,27 @@ export interface ToolPersonalAuthRequiredEvent extends ToolExecution<
   authError: ToolPersonalAuthError;
 }
 
+type ToolFileAuthError = {
+  fileId: string;
+  fileName: string;
+  connectionId: string;
+  mimeType: string;
+  toolName: string;
+  message: string;
+};
+
+// Pauses agent execution to prompt user for file access consent (e.g., Google Drive).
+// Non-terminal because the tool can resume once the user authorizes the file.
+export interface ToolFileAuthRequiredEvent extends ToolExecution<
+  MCPValidationMetadataType & {
+    mcpServerId: string;
+    mcpServerDisplayName: string;
+  }
+> {
+  type: "tool_file_auth_required";
+  fileAuthError: ToolFileAuthError;
+}
+
 export interface MCPApproveExecutionEvent extends ToolExecution {
   type: "tool_approve_execution";
 }

--- a/front/lib/actions/mcp_internal_actions/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/utils.ts
@@ -46,6 +46,36 @@ export function makePersonalAuthenticationError(
   };
 }
 
+export function makeFileAuthorizationError({
+  fileId,
+  fileName,
+  connectionId,
+  mimeType,
+}: {
+  fileId: string;
+  fileName: string;
+  connectionId: string;
+  mimeType: string;
+}) {
+  return {
+    content: [
+      {
+        type: "resource" as const,
+        resource: {
+          mimeType: INTERNAL_MIME_TYPES.TOOL_OUTPUT.AGENT_PAUSE_TOOL_OUTPUT,
+          type: "tool_file_auth_required",
+          fileId,
+          fileName,
+          connectionId,
+          mimeType_file: mimeType,
+          text: `File authorization required for ${fileName}`,
+          uri: "",
+        },
+      },
+    ],
+  };
+}
+
 export function makeMCPToolExit({
   message,
   isError,

--- a/front/lib/actions/statuses.ts
+++ b/front/lib/actions/statuses.ts
@@ -8,6 +8,7 @@ type ToolExecutionFinalStatus = (typeof TOOL_EXECUTION_FINAL_STATUSES)[number];
 
 export const TOOL_EXECUTION_BLOCKED_STATUSES = [
   "blocked_authentication_required",
+  "blocked_file_authorization_required",
   "blocked_validation_required",
   "blocked_child_action_input_required",
 ] as const;

--- a/front/lib/actions/types/index.ts
+++ b/front/lib/actions/types/index.ts
@@ -10,9 +10,34 @@ import type {
   ConversationType,
 } from "@app/types";
 
+export type FileAuthorizationInfo = {
+  fileId: string;
+  fileName: string;
+  connectionId: string;
+  mimeType: string;
+};
+
+export function isFileAuthorizationInfo(
+  value: unknown
+): value is FileAuthorizationInfo {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "fileId" in value &&
+    typeof (value as Record<string, unknown>).fileId === "string" &&
+    "fileName" in value &&
+    typeof (value as Record<string, unknown>).fileName === "string" &&
+    "connectionId" in value &&
+    typeof (value as Record<string, unknown>).connectionId === "string" &&
+    "mimeType" in value &&
+    typeof (value as Record<string, unknown>).mimeType === "string"
+  );
+}
+
 export type StepContext = {
   citationsCount: number;
   citationsOffset: number;
+  fileAuthorizationInfo?: FileAuthorizationInfo;
   resumeState: Record<string, unknown> | null;
   retrievalTopK: number;
   websearchResultCount: number;

--- a/front/lib/api/assistant/streaming/events.ts
+++ b/front/lib/api/assistant/streaming/events.ts
@@ -115,6 +115,7 @@ function isMessageEventParams(
     case "generation_tokens":
     case "tool_approve_execution":
     case "tool_error":
+    case "tool_file_auth_required":
     case "tool_notification":
     case "tool_params":
     case "tool_personal_auth_required":

--- a/front/lib/api/assistant/streaming/types.ts
+++ b/front/lib/api/assistant/streaming/types.ts
@@ -1,5 +1,8 @@
 import type { AgentActionRunningEvents } from "@app/lib/actions/mcp";
-import type { ToolPersonalAuthRequiredEvent } from "@app/lib/actions/mcp_internal_actions/events";
+import type {
+  ToolFileAuthRequiredEvent,
+  ToolPersonalAuthRequiredEvent,
+} from "@app/lib/actions/mcp_internal_actions/events";
 import type {
   AgentActionSuccessEvent,
   AgentErrorEvent,
@@ -21,6 +24,7 @@ export type AgentMessageEvents =
   | AgentMessageSuccessEvent
   | GenerationTokensEvent
   | ToolErrorEvent
+  | ToolFileAuthRequiredEvent
   | ToolPersonalAuthRequiredEvent;
 
 export type ConversationEvents =

--- a/front/lib/api/mcp/run_tool.ts
+++ b/front/lib/api/mcp/run_tool.ts
@@ -12,6 +12,7 @@ import {
 import type {
   MCPApproveExecutionEvent,
   ToolEarlyExitEvent,
+  ToolFileAuthRequiredEvent,
   ToolPersonalAuthRequiredEvent,
 } from "@app/lib/actions/mcp_internal_actions/events";
 import { getExitOrPauseEvents } from "@app/lib/actions/mcp_internal_actions/exit_events";
@@ -56,6 +57,7 @@ export async function* runToolWithStreaming(
   | MCPParamsEvent
   | MCPSuccessEvent
   | ToolNotificationEvent
+  | ToolFileAuthRequiredEvent
   | ToolPersonalAuthRequiredEvent
   | ToolEarlyExitEvent,
   void

--- a/front/lib/resources/agent_mcp_action_resource.ts
+++ b/front/lib/resources/agent_mcp_action_resource.ts
@@ -23,6 +23,7 @@ import {
   TOOL_EXECUTION_BLOCKED_STATUSES,
 } from "@app/lib/actions/statuses";
 import type { StepContext } from "@app/lib/actions/types";
+import { isFileAuthorizationInfo } from "@app/lib/actions/types";
 import { isLightServerSideMCPToolConfiguration } from "@app/lib/actions/types/guards";
 import { getAgentConfigurationsWithVersion } from "@app/lib/api/assistant/configuration/agent";
 import type { Authenticator } from "@app/lib/auth";
@@ -405,6 +406,48 @@ export class AgentMCPActionResource extends BaseResource<AgentMCPActionModel> {
           ...baseActionParams,
           status: action.status,
           authorizationInfo,
+          metadata: {
+            ...baseActionParams.metadata,
+            mcpServerId,
+            mcpServerDisplayName,
+          },
+        });
+      } else if (action.status === "blocked_file_authorization_required") {
+        // TODO: Implement file authorization info extraction from action context
+        // For now, skip as this status won't be reached until tools emit it
+        if (!mcpServerId || !mcpServerDisplayName) {
+          logger.warn(
+            {
+              actionId: action.id,
+              conversationId: conversation.sId,
+              messageId: agentMessage.message.sId,
+              workspaceId: owner.id,
+            },
+            `MCP server view not found for blocked file auth action ${action.id}`
+          );
+          continue;
+        }
+
+        const fileAuthInfo = action.stepContext.fileAuthorizationInfo;
+
+        // Validate file auth info exists and has correct shape - it's stored dynamically in stepContext.
+        if (!isFileAuthorizationInfo(fileAuthInfo)) {
+          logger.warn(
+            {
+              actionId: action.id,
+              conversationId: conversation.sId,
+              messageId: agentMessage.message.sId,
+              workspaceId: owner.id,
+            },
+            `File authorization info not found for blocked action ${action.id}`
+          );
+          continue;
+        }
+
+        blockedActionsList.push({
+          ...baseActionParams,
+          status: action.status,
+          fileAuthorizationInfo: fileAuthInfo,
           metadata: {
             ...baseActionParams.metadata,
             mcpServerId,

--- a/front/temporal/agent_loop/activities/publish_deferred_events.ts
+++ b/front/temporal/agent_loop/activities/publish_deferred_events.ts
@@ -94,6 +94,19 @@ export async function publishDeferredEventsActivity(
         }
         break;
 
+      case "tool_file_auth_required":
+        // Publish the file auth required event.
+        // Similar to tool_personal_auth_required but for file-specific authorization.
+        eventToPublish = {
+          ...event,
+          metadata: {
+            ...event.metadata,
+            // Override the message id to root the event to the right channel.
+            pubsubMessageId: deferredEvent.context.agentMessageId,
+          },
+        };
+        break;
+
       case "tool_approve_execution":
         eventToPublish = {
           ...event,

--- a/front/temporal/agent_loop/activities/run_tool.ts
+++ b/front/temporal/agent_loop/activities/run_tool.ts
@@ -207,9 +207,9 @@ export async function runToolActivity(
         return { deferredEvents, shouldPauseAgentLoop: true };
 
       case "tool_personal_auth_required":
+      case "tool_file_auth_required":
       case "tool_approve_execution":
-        // Update and publish deferred events for these types.
-        // Defer personal auth events to be sent after all tools complete.
+        // Batched for publishing after all parallel tools complete to avoid partial UI state.
         deferredEvents.push({
           event,
           context: {

--- a/front/temporal/agent_loop/lib/deferred_events.ts
+++ b/front/temporal/agent_loop/lib/deferred_events.ts
@@ -1,5 +1,6 @@
 import type {
   MCPApproveExecutionEvent,
+  ToolFileAuthRequiredEvent,
   ToolPersonalAuthRequiredEvent,
 } from "@app/lib/actions/mcp_internal_actions/events";
 import type { ModelId } from "@app/types/shared/model_id";
@@ -9,7 +10,10 @@ import type { ModelId } from "@app/types/shared/model_id";
  * These are events that might need to be sent after all tools in a step complete,
  * rather than immediately when they occur.
  */
-type DeferrableEvent = MCPApproveExecutionEvent | ToolPersonalAuthRequiredEvent;
+type DeferrableEvent =
+  | MCPApproveExecutionEvent
+  | ToolFileAuthRequiredEvent
+  | ToolPersonalAuthRequiredEvent;
 
 /**
  * Context information needed to send a deferred event.

--- a/sdks/js/src/output_schemas.ts
+++ b/sdks/js/src/output_schemas.ts
@@ -618,10 +618,22 @@ export const EarlyExitOutputResourceSchema = z.object({
   uri: z.string(),
 });
 
+export const FileAuthRequiredOutputResourceSchema = z.object({
+  mimeType: z.literal(INTERNAL_MIME_TYPES.TOOL_OUTPUT.AGENT_PAUSE_TOOL_OUTPUT),
+  type: z.literal("tool_file_auth_required"),
+  fileId: z.string(),
+  fileName: z.string(),
+  connectionId: z.string(),
+  mimeType_file: z.string(),
+  text: z.string(),
+  uri: z.string(),
+});
+
 export const AgentPauseOutputResourceSchema = z.union([
   AuthRequiredOutputResourceSchema,
   BlockedAwaitingInputOutputResourceSchema,
   EarlyExitOutputResourceSchema,
+  FileAuthRequiredOutputResourceSchema,
 ]);
 
 export type AgentPauseOutputResourceType = z.infer<

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -1269,6 +1269,7 @@ export type MCPValidationMetadataPublicType = z.infer<
 
 const ToolExecutionBlockedStatusSchema = z.enum([
   "blocked_authentication_required",
+  "blocked_file_authorization_required",
   "blocked_validation_required",
   "blocked_child_action_input_required",
 ]);


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

<img width="521" height="160" alt="Capture d’écran 2026-01-30 à 11 24 25" src="https://github.com/user-attachments/assets/7d9f0e81-8925-425e-9559-2bc21b10b386" />

This PR allows bubbling up to the conversation a notificaiton to authorize the access for certain files.

Closes https://github.com/dust-tt/tasks/issues/5953

We then need to plug the picker to this button

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Can bubble up a file name/id, tested by hand.

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low, unused + behind ff.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front