### PR TITLE
[front] - refacto(agents): remove `getServerSideProps` from `agents/` routes

### DIFF
--- a/front/pages/w/[wId]/builder/agents/[aId]/index.tsx
+++ b/front/pages/w/[wId]/builder/agents/[aId]/index.tsx
@@ -6,7 +6,6 @@ import type { ReactElement } from "react";
 import AgentBuilder from "@app/components/agent_builder/AgentBuilder";
 import { AgentBuilderProvider } from "@app/components/agent_builder/AgentBuilderContext";
 import AppRootLayout from "@app/components/sparkle/AppRootLayout";
-import { useRequiredPathParam } from "@app/lib/platform";
 import { useAgentConfiguration } from "@app/lib/swr/assistants";
 import { useWorkspaceAuthContext } from "@app/lib/swr/workspaces";
 import type {
@@ -14,8 +13,9 @@ import type {
   UserType,
   WorkspaceType,
 } from "@app/types";
+import { isString } from "@app/types";
 
-function FullPageSpinner(): JSX.Element {
+function FullPageSpinner() {
   return (
     <div className="flex h-screen items-center justify-center">
       <Spinner size="lg" />
@@ -23,11 +23,24 @@ function FullPageSpinner(): JSX.Element {
   );
 }
 
-export default function EditAgentPage(): JSX.Element {
-  const workspaceId = useRequiredPathParam("wId");
-  const agentId = useRequiredPathParam("aId");
+export default function EditAgentPage() {
+  const router = useRouter();
 
-  return <EditAgentAuthGate workspaceId={workspaceId} agentId={agentId} />;
+  if (!router.isReady) {
+    return null;
+  }
+
+  if (!isString(router.query.wId) || !isString(router.query.aId)) {
+    void router.replace("/404");
+    return <FullPageSpinner />;
+  }
+
+  return (
+    <EditAgentAuthGate
+      workspaceId={router.query.wId}
+      agentId={router.query.aId}
+    />
+  );
 }
 
 interface EditAgentAuthGateProps {
@@ -35,10 +48,7 @@ interface EditAgentAuthGateProps {
   agentId: string;
 }
 
-function EditAgentAuthGate({
-  workspaceId,
-  agentId,
-}: EditAgentAuthGateProps): JSX.Element {
+function EditAgentAuthGate({ workspaceId, agentId }: EditAgentAuthGateProps) {
   const router = useRouter();
   const {
     owner,
@@ -80,7 +90,7 @@ function EditAgentLoader({
   user,
   isAdmin,
   agentId,
-}: EditAgentLoaderProps): JSX.Element {
+}: EditAgentLoaderProps) {
   const router = useRouter();
   const {
     agentConfiguration,
@@ -127,7 +137,7 @@ function EditAgentContent({
   owner,
   user,
   isAdmin,
-}: EditAgentContentProps): JSX.Element {
+}: EditAgentContentProps) {
   if (agentConfiguration.scope === "global") {
     throw new Error("Cannot edit global agent");
   }
@@ -151,7 +161,7 @@ function EditAgentContent({
   );
 }
 
-function getLayout(page: ReactElement): ReactElement {
+function getLayout(page: ReactElement) {
   return <AppRootLayout>{page}</AppRootLayout>;
 }
 

--- a/front/pages/w/[wId]/builder/agents/[aId]/index.tsx
+++ b/front/pages/w/[wId]/builder/agents/[aId]/index.tsx
@@ -6,6 +6,8 @@ import type { ReactElement } from "react";
 import AgentBuilder from "@app/components/agent_builder/AgentBuilder";
 import { AgentBuilderProvider } from "@app/components/agent_builder/AgentBuilderContext";
 import AppRootLayout from "@app/components/sparkle/AppRootLayout";
+import { useWorkspace } from "@app/lib/auth/AuthContext";
+import { useRequiredPathParam } from "@app/lib/platform";
 import { useAgentConfiguration } from "@app/lib/swr/assistants";
 import { useWorkspaceAuthContext } from "@app/lib/swr/workspaces";
 import type {
@@ -25,22 +27,18 @@ function FullPageSpinner() {
 
 export default function EditAgentPage() {
   const router = useRouter();
-
+  const aId = useRequiredPathParam("aId");
+  const owner = useWorkspace();
   if (!router.isReady) {
     return null;
   }
 
-  if (!isString(router.query.wId) || !isString(router.query.aId)) {
+  if (!owner || !isString(aId)) {
     void router.replace("/404");
     return <FullPageSpinner />;
   }
 
-  return (
-    <EditAgentAuthGate
-      workspaceId={router.query.wId}
-      agentId={router.query.aId}
-    />
-  );
+  return <EditAgentAuthGate workspaceId={owner.sId} agentId={aId} />;
 }
 
 interface EditAgentAuthGateProps {

--- a/front/pages/w/[wId]/builder/agents/create.tsx
+++ b/front/pages/w/[wId]/builder/agents/create.tsx
@@ -21,6 +21,7 @@ import { appLayoutBack } from "@app/components/sparkle/AppContentLayout";
 import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
 import AppRootLayout from "@app/components/sparkle/AppRootLayout";
 import { useYAMLUpload } from "@app/hooks/useYAMLUpload";
+import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { useAssistantTemplates } from "@app/lib/swr/assistants";
 import {
   useFeatureFlags,
@@ -50,17 +51,18 @@ function FullPageSpinner() {
 
 export default function CreateAgentPage() {
   const router = useRouter();
+  const owner = useWorkspace();
 
   if (!router.isReady) {
     return null;
   }
 
-  if (!isString(router.query.wId)) {
+  if (!owner) {
     void router.replace("/404");
     return <FullPageSpinner />;
   }
 
-  return <CreateAgentAuthGate workspaceId={router.query.wId} />;
+  return <CreateAgentAuthGate workspaceId={owner.sId} />;
 }
 
 interface CreateAgentAuthGateProps {
@@ -137,9 +139,9 @@ function CreateAgentContent({
   hasFeature,
 }: CreateAgentContentProps) {
   const router = useRouter();
-  const selectedTemplateId = isString(router.query.templateId)
-    ? router.query.templateId
-    : null;
+  const { templateId } = router.query;
+
+  const selectedTemplateId = isString(templateId) ? templateId : null;
   const templateTagsMapping = TEMPLATES_TAGS_CONFIG;
 
   const [searchTerm, setSearchTerm] = useState("");
@@ -313,7 +315,7 @@ function CreateAgentContent({
   );
 }
 
-function getLayout(page: ReactElement): ReactElement {
+function getLayout(page: ReactElement) {
   return <AppRootLayout>{page}</AppRootLayout>;
 }
 

--- a/front/pages/w/[wId]/builder/agents/index.tsx
+++ b/front/pages/w/[wId]/builder/agents/index.tsx
@@ -27,6 +27,7 @@ import { EmptyCallToAction } from "@app/components/EmptyCallToAction";
 import AppRootLayout from "@app/components/sparkle/AppRootLayout";
 import { AppWideModeLayout } from "@app/components/sparkle/AppWideModeLayout";
 import { useHashParam } from "@app/hooks/useHashParams";
+import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
 import { useAgentConfigurations } from "@app/lib/swr/assistants";
 import {
@@ -45,7 +46,7 @@ import type {
   WhitelistableFeature,
   WorkspaceType,
 } from "@app/types";
-import { isAdmin, isBuilder, isString } from "@app/types";
+import { isAdmin, isBuilder } from "@app/types";
 import type { TagType } from "@app/types/tag";
 
 export const AGENT_MANAGER_TABS = [
@@ -97,17 +98,18 @@ function FullPageSpinner() {
 
 export default function WorkspaceAssistantsPage() {
   const router = useRouter();
+  const owner = useWorkspace();
 
   if (!router.isReady) {
     return null;
   }
 
-  if (!isString(router.query.wId)) {
+  if (!owner) {
     void router.replace("/404");
     return <FullPageSpinner />;
   }
 
-  return <WorkspaceAssistantsAuthGate workspaceId={router.query.wId} />;
+  return <WorkspaceAssistantsAuthGate workspaceId={owner.sId} />;
 }
 
 interface WorkspaceAssistantsAuthGateProps {

--- a/front/pages/w/[wId]/builder/agents/index.tsx
+++ b/front/pages/w/[wId]/builder/agents/index.tsx
@@ -14,7 +14,8 @@ import {
 } from "@dust-tt/sparkle";
 import Head from "next/head";
 import { useRouter } from "next/router";
-import { useEffect, useMemo, useRef, useState, type ReactElement } from "react";
+import type { ReactElement } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import { AgentEditBar } from "@app/components/assistant/AgentEditBar";
 import { AgentSidebarMenu } from "@app/components/assistant/conversation/SidebarMenu";
@@ -27,7 +28,6 @@ import AppRootLayout from "@app/components/sparkle/AppRootLayout";
 import { AppWideModeLayout } from "@app/components/sparkle/AppWideModeLayout";
 import { useHashParam } from "@app/hooks/useHashParams";
 import { clientFetch } from "@app/lib/egress/client";
-import { useRequiredPathParam } from "@app/lib/platform";
 import { useAgentConfigurations } from "@app/lib/swr/assistants";
 import {
   useFeatureFlags,
@@ -45,7 +45,7 @@ import type {
   WhitelistableFeature,
   WorkspaceType,
 } from "@app/types";
-import { isAdmin, isBuilder } from "@app/types";
+import { isAdmin, isBuilder, isString } from "@app/types";
 import type { TagType } from "@app/types/tag";
 
 export const AGENT_MANAGER_TABS = [
@@ -87,7 +87,7 @@ function isValidTab(tab: string): tab is AssistantManagerTabsType {
   );
 }
 
-function FullPageSpinner(): JSX.Element {
+function FullPageSpinner() {
   return (
     <div className="flex h-screen items-center justify-center">
       <Spinner size="lg" />
@@ -95,10 +95,19 @@ function FullPageSpinner(): JSX.Element {
   );
 }
 
-export default function WorkspaceAssistantsPage(): JSX.Element {
-  const workspaceId = useRequiredPathParam("wId");
+export default function WorkspaceAssistantsPage() {
+  const router = useRouter();
 
-  return <WorkspaceAssistantsAuthGate workspaceId={workspaceId} />;
+  if (!router.isReady) {
+    return null;
+  }
+
+  if (!isString(router.query.wId)) {
+    void router.replace("/404");
+    return <FullPageSpinner />;
+  }
+
+  return <WorkspaceAssistantsAuthGate workspaceId={router.query.wId} />;
 }
 
 interface WorkspaceAssistantsAuthGateProps {
@@ -107,7 +116,7 @@ interface WorkspaceAssistantsAuthGateProps {
 
 function WorkspaceAssistantsAuthGate({
   workspaceId,
-}: WorkspaceAssistantsAuthGateProps): JSX.Element {
+}: WorkspaceAssistantsAuthGateProps) {
   const router = useRouter();
   const {
     owner,
@@ -145,7 +154,7 @@ function WorkspaceAssistantsFeatureGate({
   owner,
   subscription,
   user,
-}: WorkspaceAssistantsFeatureGateProps): JSX.Element {
+}: WorkspaceAssistantsFeatureGateProps) {
   const router = useRouter();
   const { featureFlags, isFeatureFlagsLoading } = useFeatureFlags({
     workspaceId: owner.sId,
@@ -186,7 +195,7 @@ function WorkspaceAssistantsContent({
   subscription,
   user,
   featureFlags,
-}: WorkspaceAssistantsContentProps): JSX.Element {
+}: WorkspaceAssistantsContentProps) {
   const [assistantSearch, setAssistantSearch] = useState("");
   const [showDisabledFreeWorkspacePopup, setShowDisabledFreeWorkspacePopup] =
     useState<string | null>(null);
@@ -500,7 +509,7 @@ function WorkspaceAssistantsContent({
   );
 }
 
-function getLayout(page: ReactElement): ReactElement {
+function getLayout(page: ReactElement) {
   return <AppRootLayout>{page}</AppRootLayout>;
 }
 

--- a/front/pages/w/[wId]/builder/agents/new.tsx
+++ b/front/pages/w/[wId]/builder/agents/new.tsx
@@ -9,6 +9,7 @@ import type { BuilderFlow } from "@app/components/agent_builder/types";
 import { BUILDER_FLOWS } from "@app/components/agent_builder/types";
 import AppRootLayout from "@app/components/sparkle/AppRootLayout";
 import { throwIfInvalidAgentConfiguration } from "@app/lib/actions/types/guards";
+import { useWorkspace } from "@app/lib/auth/AuthContext";
 import {
   useAgentConfiguration,
   useAssistantTemplate,
@@ -45,17 +46,18 @@ function FullPageSpinner() {
 
 export default function CreateAgentPage() {
   const router = useRouter();
+  const owner = useWorkspace();
 
   if (!router.isReady) {
     return null;
   }
 
-  if (!isString(router.query.wId)) {
+  if (!owner) {
     void router.replace("/404");
     return <FullPageSpinner />;
   }
 
-  return <CreateAgentAuthGate workspaceId={router.query.wId} />;
+  return <CreateAgentAuthGate workspaceId={owner.sId} />;
 }
 
 interface CreateAgentAuthGateProps {
@@ -125,15 +127,15 @@ interface CreateAgentContentProps {
 
 function CreateAgentContent({ owner, user, isAdmin }: CreateAgentContentProps) {
   const router = useRouter();
-  const templateId = isString(router.query.templateId)
-    ? router.query.templateId
-    : null;
-  const duplicateAgentId = isString(router.query.duplicate)
-    ? router.query.duplicate
-    : null;
-  const flow = resolveBuilderFlow(
-    isString(router.query.flow) ? router.query.flow : null
-  );
+  const {
+    templateId: templateIdQuery,
+    duplicate: duplicateQuery,
+    flow: flowQuery,
+  } = router.query;
+
+  const templateId = isString(templateIdQuery) ? templateIdQuery : null;
+  const duplicateAgentId = isString(duplicateQuery) ? duplicateQuery : null;
+  const flow = resolveBuilderFlow(isString(flowQuery) ? flowQuery : null);
 
   const {
     assistantTemplate,


### PR DESCRIPTION
## Description

This PR migrates the agent builder pages (`/w/[wId]/builder/agents/**`) from Next.js `getServerSideProps` to client-side data fetching with custom hooks, following the SPA migration pattern established in recent PRs (#20571, #20616, #20692, #20704, #20718, #20772). The server-side authentication and data fetching logic is replaced with a layered approach using `useWorkspaceAuthContext`, `useAgentConfiguration`, and `useAssistantTemplate` hooks.

**Migrated pages:**
- `agents/[aId]/index.tsx` - edit agent page
- `agents/create.tsx` - template selection page  
- `agents/new.tsx` - agent creation/duplication page
- `agents/index.tsx` - agent list and management page

## Risk

Medium

## Tests

- [x] Locally
- [ ] front-edge

## Deploy Plan

Deploy front.
