### PR TITLE
[front] Add `AgentMessageCompletionStatus` on cancelled messages

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -6,7 +6,6 @@ import {
   Chip,
   ClipboardCheckIcon,
   ClipboardIcon,
-  ContentMessageInline,
   ConversationMessageAvatar,
   ConversationMessageContainer,
   ConversationMessageContent,
@@ -1060,9 +1059,9 @@ function AgentMessageContent({
         </div>
       )}
       {agentMessage.status === "cancelled" && (
-        <ContentMessageInline icon={StopIcon} variant="primary">
-          Message generation was interrupted.
-        </ContentMessageInline>
+        <div className="text-faint dark:text-faint-night">
+          Message generation was interrupted
+        </div>
       )}
     </div>
   );

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -698,7 +698,7 @@ export function AgentMessage({
           name={agentConfiguration.name}
           timestamp={timestamp}
           completionStatus={
-            isCancelledOrDeleted ? undefined : (
+            isDeleted ? undefined : (
               <AgentMessageCompletionStatus agentMessage={agentMessage} />
             )
           }
@@ -721,7 +721,7 @@ export function AgentMessage({
           name={agentConfiguration.name}
           timestamp={timestamp}
           completionStatus={
-            isCancelledOrDeleted ? undefined : (
+            isDeleted ? undefined : (
               <AgentMessageCompletionStatus agentMessage={agentMessage} />
             )
           }
@@ -734,28 +734,26 @@ export function AgentMessage({
           {isDeleted ? (
             <DeletedMessage />
           ) : (
-            <>
-              <AgentMessageContent
-                onQuickReplySend={handleQuickReply}
-                owner={owner}
-                conversationId={conversationId}
-                retryHandler={retryHandler}
-                isLastMessage={isLastMessage}
-                agentMessage={agentMessage}
-                references={references}
-                streaming={shouldStream}
-                lastTokenClassification={
-                  agentMessage.streaming.agentState === "thinking"
-                    ? "tokens"
-                    : null
-                }
-                activeReferences={activeReferences}
-                setActiveReferences={setActiveReferences}
-                triggeringUser={triggeringUser}
-                additionalMarkdownComponents={additionalMarkdownComponents}
-                additionalMarkdownPlugins={additionalMarkdownPlugins}
-              />
-            </>
+            <AgentMessageContent
+              onQuickReplySend={handleQuickReply}
+              owner={owner}
+              conversationId={conversationId}
+              retryHandler={retryHandler}
+              isLastMessage={isLastMessage}
+              agentMessage={agentMessage}
+              references={references}
+              streaming={shouldStream}
+              lastTokenClassification={
+                agentMessage.streaming.agentState === "thinking"
+                  ? "tokens"
+                  : null
+              }
+              activeReferences={activeReferences}
+              setActiveReferences={setActiveReferences}
+              triggeringUser={triggeringUser}
+              additionalMarkdownComponents={additionalMarkdownComponents}
+              additionalMarkdownPlugins={additionalMarkdownPlugins}
+            />
           )}
         </ConversationMessageContent>
         {!isCancelledOrDeleted &&

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -6,6 +6,7 @@ import {
   Chip,
   ClipboardCheckIcon,
   ClipboardIcon,
+  ContentMessageInline,
   ConversationMessageAvatar,
   ConversationMessageContainer,
   ConversationMessageContent,
@@ -1059,9 +1060,9 @@ function AgentMessageContent({
         </div>
       )}
       {agentMessage.status === "cancelled" && (
-        <div className="text-faint dark:text-faint-night">
-          Message generation was interrupted
-        </div>
+        <ContentMessageInline icon={StopIcon} variant="primary">
+          Message generation was interrupted.
+        </ContentMessageInline>
       )}
     </div>
   );

--- a/front/components/assistant/conversation/DeletedMessage.tsx
+++ b/front/components/assistant/conversation/DeletedMessage.tsx
@@ -1,5 +1,8 @@
+import { ContentMessageInline, TrashIcon } from "@dust-tt/sparkle";
 import React from "react";
 
 export const DeletedMessage = () => (
-  <div className="text-faint dark:text-faint-night">Message was deleted</div>
+  <ContentMessageInline icon={TrashIcon} variant="primary">
+    Message was deleted.
+  </ContentMessageInline>
 );

--- a/front/components/assistant/conversation/DeletedMessage.tsx
+++ b/front/components/assistant/conversation/DeletedMessage.tsx
@@ -1,8 +1,5 @@
-import { ContentMessageInline, TrashIcon } from "@dust-tt/sparkle";
 import React from "react";
 
 export const DeletedMessage = () => (
-  <ContentMessageInline icon={TrashIcon} variant="primary">
-    Message was deleted.
-  </ContentMessageInline>
+  <div className="text-faint dark:text-faint-night">Message was deleted</div>
 );


### PR DESCRIPTION
## Description

- This PR adds back the agent message breakdown on cancelled message.
- Goal is to have a UI that represents with better fidelity what is exposed to the model.
- Here the intermediary tool calls are still rendered to the model but are nowhere to be found in the UI.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
