### PR TITLE
[front] Add padding at the bottom of the agent/skills details sheets

### DIFF
--- a/front/components/assistant/details/AgentDetails.tsx
+++ b/front/components/assistant/details/AgentDetails.tsx
@@ -224,7 +224,7 @@ export function AgentDetails({
 
   return (
     <Sheet open={!!agentId} onOpenChange={onClose}>
-      <SheetContent size="lg" className="outline-none">
+      <SheetContent size="lg" className="outline-none pb-4">
         <VisuallyHidden>
           <SheetTitle />
         </VisuallyHidden>

--- a/front/components/skills/SkillDetailsSheet.tsx
+++ b/front/components/skills/SkillDetailsSheet.tsx
@@ -45,7 +45,7 @@ export function SkillDetailsSheet({
 }: SkillDetailsProps) {
   return (
     <Sheet open={skill !== null} onOpenChange={onClose}>
-      <SheetContent size="lg">
+      <SheetContent size="lg" className="pb-4">
         <VisuallyHidden>
           <SheetTitle />
         </VisuallyHidden>


### PR DESCRIPTION
## Description

- Follow up on https://github.com/dust-tt/dust/pull/20780.
- This PR adds a bottom padding to the Skills/Agent details sheets (visible [here](https://dust.tt/w/0ec9852c2f/builder/skills#?selectedTab=active&skillId=skl_rICtlrKdpPfi) at the bottom for instance).

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
