### PR TITLE
[Front] Remove unused body parser limit constant

### DIFF
--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -3,12 +3,6 @@ import { EnvironmentConfig } from "@app/types/shared/utils/config";
 
 export const PRODUCTION_DUST_API = "https://dust.tt";
 
-// Body parser limit for document upsert endpoints. This must accommodate the largest allowed
-// document text content (MAX_LARGE_DOCUMENT_TXT_LEN = 5MB in connectors) plus JSON serialization
-// overhead. JSON encoding can expand content significantly due to escaping of special characters
-// (newlines, quotes, backslashes, Unicode). We use 16MB to handle worst-case ~3x expansion.
-export const DOCUMENT_UPSERT_BODY_PARSER_LIMIT = "16mb";
-
 const config = {
   getClientFacingUrl: (): string => {
     // We override the NEXT_PUBLIC_DUST_CLIENT_FACING_URL in `front-internal` to ensure that the

--- a/front/pages/api/v1/w/[wId]/data_sources/[dsId]/documents/[documentId]/blob.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[dsId]/documents/[documentId]/blob.ts
@@ -10,8 +10,8 @@ import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
 import { CoreAPI } from "@app/types";
 
-// Next.js config must use literal values (cannot be statically analyzed otherwise).
-// If wishing to change this value, see DOCUMENT_UPSERT_BODY_PARSER_LIMIT in lib/api/config.ts.
+// Next.js config requires literal values (static analysis). 16MB accommodates 5MB document content
+// (MAX_LARGE_DOCUMENT_TXT_LEN in connectors) plus ~3x JSON encoding overhead for escaping.
 export const config = {
   api: {
     bodyParser: {

--- a/front/pages/api/v1/w/[wId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -1,8 +1,8 @@
 /* eslint-disable dust/enforce-client-types-in-public-api */
 import handler from "@app/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index";
 
-// Next.js config must use literal values (cannot be statically analyzed otherwise).
-// If wishing to change this value, see DOCUMENT_UPSERT_BODY_PARSER_LIMIT in lib/api/config.ts.
+// Next.js config requires literal values (static analysis). 16MB accommodates 5MB document content
+// (MAX_LARGE_DOCUMENT_TXT_LEN in connectors) plus ~3x JSON encoding overhead for escaping.
 export const config = {
   api: {
     bodyParser: {

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -32,8 +32,8 @@ import {
   validateUrl,
 } from "@app/types";
 
-// Next.js config must use literal values (cannot be statically analyzed otherwise).
-// If wishing to change this value, see DOCUMENT_UPSERT_BODY_PARSER_LIMIT in lib/api/config.ts.
+// Next.js config requires literal values (static analysis). 16MB accommodates 5MB document content
+// (MAX_LARGE_DOCUMENT_TXT_LEN in connectors) plus ~3x JSON encoding overhead for escaping.
 export const config = {
   api: {
     bodyParser: {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/documents/[documentId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_source_views/[dsvId]/documents/[documentId]/index.ts
@@ -10,8 +10,8 @@ import { apiError } from "@app/logger/withlogging";
 import type { CoreAPIDocument, WithAPIErrorResponse } from "@app/types";
 import { CoreAPI } from "@app/types";
 
-// Next.js config must use literal values (cannot be statically analyzed otherwise).
-// If wishing to change this value, see DOCUMENT_UPSERT_BODY_PARSER_LIMIT in lib/api/config.ts.
+// Next.js config requires literal values (static analysis). 16MB accommodates 5MB document content
+// (MAX_LARGE_DOCUMENT_TXT_LEN in connectors) plus ~3x JSON encoding overhead for escaping.
 export const config = {
   api: {
     bodyParser: {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/[documentId]/index.ts
@@ -19,8 +19,8 @@ import type {
 } from "@app/types";
 import { CoreAPI, PostDataSourceDocumentRequestBodySchema } from "@app/types";
 
-// Next.js config must use literal values (cannot be statically analyzed otherwise).
-// If wishing to change this value, see DOCUMENT_UPSERT_BODY_PARSER_LIMIT in lib/api/config.ts.
+// Next.js config requires literal values (static analysis). 16MB accommodates 5MB document content
+// (MAX_LARGE_DOCUMENT_TXT_LEN in connectors) plus ~3x JSON encoding overhead for escaping.
 export const config = {
   api: {
     bodyParser: {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/data_sources/[dsId]/documents/index.ts
@@ -16,8 +16,8 @@ import type {
 } from "@app/types";
 import { PostDataSourceDocumentRequestBodySchema } from "@app/types";
 
-// Next.js config must use literal values (cannot be statically analyzed otherwise).
-// If wishing to change this value, see DOCUMENT_UPSERT_BODY_PARSER_LIMIT in lib/api/config.ts.
+// Next.js config requires literal values (static analysis). 16MB accommodates 5MB document content
+// (MAX_LARGE_DOCUMENT_TXT_LEN in connectors) plus ~3x JSON encoding overhead for escaping.
 export const config = {
   api: {
     bodyParser: {


### PR DESCRIPTION
## Description

Follows https://github.com/dust-tt/dust/pull/20855

Removes the now-unused `DOCUMENT_UPSERT_BODY_PARSER_LIMIT` constant from `lib/api/config.ts` and inlines the documentation directly in the API route comments. Since Next.js config requires literal values for static analysis, the constant was no longer being imported.

## Risks

Blast radius: none (dead code removal)
Risk: none

## Deploy Plan
- pmrr
- deploy front