### PR TITLE
[sparkle] - fix(Dialog): fix overflowing text

### DIFF
--- a/front/components/agent_builder/AgentCreatedDialog.tsx
+++ b/front/components/agent_builder/AgentCreatedDialog.tsx
@@ -1,8 +1,8 @@
 import {
   ChatBubbleBottomCenterTextIcon,
   Dialog,
+  DialogContainer,
   DialogContent,
-  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
@@ -40,11 +40,11 @@ export function AgentCreatedDialog({
       <DialogContent>
         <DialogHeader>
           <DialogTitle>Agent {agentHandle} has been created!</DialogTitle>
-          <DialogDescription>
-            You can now use {agentHandle} in conversations. Start a chat or keep
-            editing this agent.
-          </DialogDescription>
         </DialogHeader>
+        <DialogContainer>
+          You can now use {agentHandle} in conversations. Start a chat or keep
+          editing this agent.
+        </DialogContainer>
         <DialogFooter
           leftButtonProps={{
             label: "Keep editing",

--- a/sparkle/src/components/Dialog.tsx
+++ b/sparkle/src/components/Dialog.tsx
@@ -177,7 +177,7 @@ const DialogContainer = ({
   className,
 }: DialogContainerProps) => {
   const contentStyles = cn(
-    "s-copy-base s-px-5 s-py-4 s-text-foreground dark:s-text-foreground-night"
+    "s-copy-base s-break-words s-px-5 s-py-4 s-text-foreground dark:s-text-foreground-night"
   );
 
   const scrollableContent = (
@@ -264,6 +264,7 @@ const DialogTitle = React.forwardRef<
       ref={ref}
       className={cn(
         "s-heading-lg",
+        "s-min-w-0 s-break-words",
         "s-text-foreground dark:s-text-foreground-night",
         className
       )}


### PR DESCRIPTION
## Description

This PR fixes text overflow issues in Dialog components by adding proper word-breaking styles. Long text (like agent handles or titles) that previously overflowed the dialog boundaries now wraps correctly

Fixes this 
<img width="1020" height="284" alt="Capture d’écran 2026-01-29 à 18 06 41" src="https://github.com/user-attachments/assets/73550b75-4893-4e1e-932f-94131ad8f456" />

## Risk

Low - purely visual CSS changes to Sparkle Dialog components. The word-break utilities ensure text wraps gracefully without breaking existing layouts.

## Tests

Tested locally with long agent names and titles.

## Deploy Plan

Deploy front.
