### PR TITLE
[Projects] Fix restricted project creation

### DIFF
--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -432,8 +432,13 @@ export function useCreateSpace({ owner }: { owner: LightWorkspaceType }) {
     if (managementMode === "manual") {
       const { memberIds } = params;
 
-      // Must have memberIds for manual management mode
-      if (isRestricted && (!memberIds || memberIds.length < 1)) {
+      // Must have memberIds for manual management mode, except for projects
+      // where the backend handles adding the creator to the editor group
+      if (
+        spaceKind !== "project" &&
+        isRestricted &&
+        (!memberIds || memberIds.length < 1)
+      ) {
         return null;
       }
 


### PR DESCRIPTION
## Description

Follows #20817 which removed memberIds from CreateProjectModal.

The `useCreateSpace` hook had a validation check that requires `memberIds.length >= 1` for restricted spaces with manual management mode. However, for projects:
- The backend expects `memberIds = []` (asserts this in `createSpaceAndGroup`)
- The backend automatically adds the creator to the editor group

This mismatch caused restricted project creation to silently fail (returning `null` without making the API call).

## Risks

Blast radius: Project creation
Risk: low

## Deploy Plan
- pmrr
- deploy front