### PR TITLE
Add project title search to sidebar

### DIFF
--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -375,7 +375,11 @@ export function AgentSidebarMenu({ owner }: AgentSidebarMenuProps) {
               <Spinner size="xs" />
             </div>
           ) : summary.length > 0 ? (
-            <ProjectsList owner={owner} summary={summary} />
+            <ProjectsList
+              owner={owner}
+              summary={summary}
+              titleFilter={titleFilter}
+            />
           ) : (
             <NavigationListItem
               label="Create a Project"
@@ -394,6 +398,7 @@ export function AgentSidebarMenu({ owner }: AgentSidebarMenuProps) {
     isProjectsSectionCollapsed,
     setProjectsSectionCollapsed,
     isSummaryLoading,
+    titleFilter,
   ]);
 
   const conversationsList = useMemo(() => {


### PR DESCRIPTION
## Description
[Task](https://github.com/dust-tt/tasks/issues/6217)

The sidebar search now filters both conversation titles and project names, making it easier to find projects.

- Added `titleFilter` prop to `ProjectsList` component
- Filter projects using the same fuzzy matching (`subFilter` + `removeDiacritics`) as conversation search

## Tests
- [X] Type in the sidebar search box
- [X] Verify conversations are filtered by title (existing behavior)
- [X] Verify projects are filtered by name (new behavior)
- [X] Verify fuzzy matching works (e.g., "gp4" matches "gpt-4")

## Risk
low

## Deploy plan
front