### PR TITLE
[Sparkle] Add RequestCard component for confirmation requests

### DIFF
--- a/sparkle/src/components/RequestCard.tsx
+++ b/sparkle/src/components/RequestCard.tsx
@@ -89,9 +89,9 @@ export const RequestCard = React.forwardRef<HTMLDivElement, RequestCardProps>(
         </div>
 
         {description && (
-          <p className="s-text-sm s-text-muted-foreground dark:s-text-muted-foreground-night">
+          <div className="s-text-sm s-text-muted-foreground dark:s-text-muted-foreground-night">
             {description}
-          </p>
+          </div>
         )}
 
         {details && (

--- a/sparkle/src/components/RequestCard.tsx
+++ b/sparkle/src/components/RequestCard.tsx
@@ -68,7 +68,7 @@ export const RequestCard = React.forwardRef<HTMLDivElement, RequestCardProps>(
     ref
   ) => {
     return (
-      <Card ref={ref} variant="secondary" size="md" className={className}>
+      <Card ref={ref} variant="primary" size="md" className={className}>
         <div className="s-flex s-w-full s-flex-col s-gap-3">
           <div className="s-flex s-items-center s-gap-3">
             <Avatar

--- a/sparkle/src/components/RequestCard.tsx
+++ b/sparkle/src/components/RequestCard.tsx
@@ -137,7 +137,7 @@ export const RequestCard = React.forwardRef<HTMLDivElement, RequestCardProps>(
           <div className="s-flex s-items-center s-justify-end s-gap-2">
             {secondaryAction && (
               <Button
-                variant="ghost"
+                variant="outline"
                 size="sm"
                 label={secondaryAction.label}
                 onClick={secondaryAction.onClick}

--- a/sparkle/src/components/RequestCard.tsx
+++ b/sparkle/src/components/RequestCard.tsx
@@ -2,6 +2,7 @@ import React, { ComponentType, ReactNode } from "react";
 
 import { Avatar } from "@sparkle/components/Avatar";
 import { Button } from "@sparkle/components/Button";
+import { Card } from "@sparkle/components/Card";
 import { Checkbox } from "@sparkle/components/Checkbox";
 import {
   Collapsible,
@@ -67,102 +68,94 @@ export const RequestCard = React.forwardRef<HTMLDivElement, RequestCardProps>(
     ref
   ) => {
     return (
-      <div
-        ref={ref}
-        className={cn(
-          "s-flex s-flex-col s-gap-3",
-          "s-rounded-2xl s-p-4",
-          "s-border s-border-border dark:s-border-border-night",
-          "s-bg-background dark:s-bg-background-night",
-          "s-text-foreground dark:s-text-foreground-night",
-          className
-        )}
-      >
-        <div className="s-flex s-items-center s-gap-3">
-          <Avatar
-            size="sm"
-            icon={icon}
-            visual={visual}
-            backgroundColor="s-bg-muted-background dark:s-bg-muted-background-night"
-          />
-          <span className="s-text-sm s-font-semibold">{title}</span>
-        </div>
-
-        {description && (
-          <div className="s-text-sm s-text-muted-foreground dark:s-text-muted-foreground-night">
-            {description}
-          </div>
-        )}
-
-        {details && (
-          <Collapsible defaultOpen={details.defaultOpen}>
-            <CollapsibleTrigger
-              label={details.trigger || "Details"}
-              variant="secondary"
+      <Card ref={ref} variant="secondary" size="md" className={className}>
+        <div className="s-flex s-w-full s-flex-col s-gap-3">
+          <div className="s-flex s-items-center s-gap-3">
+            <Avatar
+              size="sm"
+              icon={icon}
+              visual={visual}
+              backgroundColor="s-bg-muted-background dark:s-bg-muted-background-night"
             />
-            <CollapsibleContent>
-              <div
+            <span className="s-text-sm s-font-semibold">{title}</span>
+          </div>
+
+          {description && (
+            <div className="s-text-sm s-text-muted-foreground dark:s-text-muted-foreground-night">
+              {description}
+            </div>
+          )}
+
+          {details && (
+            <Collapsible defaultOpen={details.defaultOpen}>
+              <CollapsibleTrigger
+                label={details.trigger || "Details"}
+                variant="secondary"
+              />
+              <CollapsibleContent>
+                <div
+                  className={cn(
+                    "s-mt-2 s-rounded-lg s-p-3 s-text-sm",
+                    "s-bg-muted-background dark:s-bg-muted-background-night"
+                  )}
+                >
+                  {details.content}
+                </div>
+              </CollapsibleContent>
+            </Collapsible>
+          )}
+
+          {checkbox && (
+            <label className="s-flex s-cursor-pointer s-items-center s-gap-2">
+              <Checkbox
+                checked={checkbox.checked}
+                onCheckedChange={checkbox.onChange}
+                size="xs"
+              />
+              <span
                 className={cn(
-                  "s-mt-2 s-rounded-lg s-p-3 s-text-sm",
-                  "s-bg-muted-background dark:s-bg-muted-background-night"
+                  "s-flex s-items-center s-gap-1.5 s-text-sm",
+                  "s-text-muted-foreground dark:s-text-muted-foreground-night"
                 )}
               >
-                {details.content}
-              </div>
-            </CollapsibleContent>
-          </Collapsible>
-        )}
-
-        {checkbox && (
-          <label className="s-flex s-cursor-pointer s-items-center s-gap-2">
-            <Checkbox
-              checked={checkbox.checked}
-              onCheckedChange={checkbox.onChange}
-              size="xs"
-            />
-            <span
-              className={cn(
-                "s-flex s-items-center s-gap-1.5 s-text-sm",
-                "s-text-muted-foreground dark:s-text-muted-foreground-night"
-              )}
-            >
-              {checkbox.label}
-              {checkbox.avatar && (
-                <>
-                  <Avatar
-                    size="xxs"
-                    name={checkbox.avatar.name}
-                    visual={checkbox.avatar.visual}
-                    isRounded
-                  />
-                  {checkbox.avatar.name}
-                </>
-              )}
-            </span>
-          </label>
-        )}
-
-        <div className="s-flex s-items-center s-justify-end s-gap-2">
-          {secondaryAction && (
-            <Button
-              variant="ghost"
-              size="sm"
-              label={secondaryAction.label}
-              onClick={secondaryAction.onClick}
-              isLoading={secondaryAction.isLoading}
-              disabled={secondaryAction.disabled}
-            />
+                {checkbox.label}
+                {checkbox.avatar && (
+                  <>
+                    <Avatar
+                      size="xxs"
+                      name={checkbox.avatar.name}
+                      visual={checkbox.avatar.visual}
+                      isRounded
+                    />
+                    {checkbox.avatar.name}
+                  </>
+                )}
+              </span>
+            </label>
           )}
-          <Button
-            variant={primaryAction.variant || "highlight"}
-            size="sm"
-            label={primaryAction.label}
-            onClick={primaryAction.onClick}
-            isLoading={primaryAction.isLoading}
-            disabled={primaryAction.disabled}
-          />
+
+          <div className="s-flex s-items-center s-justify-end s-gap-2">
+            {secondaryAction && (
+              <Button
+                variant="ghost"
+                size="sm"
+                label={secondaryAction.label}
+                onClick={secondaryAction.onClick}
+                isLoading={secondaryAction.isLoading}
+                disabled={secondaryAction.disabled}
+              />
+            )}
+            <Button
+              variant={primaryAction.variant || "highlight"}
+              size="sm"
+              label={primaryAction.label}
+              onClick={primaryAction.onClick}
+              isLoading={primaryAction.isLoading}
+              disabled={primaryAction.disabled}
+            />
+          </div>
         </div>
-      </div>
+      </Card>
     );
   }
 );

--- a/sparkle/src/components/RequestCard.tsx
+++ b/sparkle/src/components/RequestCard.tsx
@@ -1,0 +1,170 @@
+import React, { ComponentType, ReactNode } from "react";
+
+import { Avatar } from "@sparkle/components/Avatar";
+import { Button } from "@sparkle/components/Button";
+import { Checkbox } from "@sparkle/components/Checkbox";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@sparkle/components/Collapsible";
+import { cn } from "@sparkle/lib/utils";
+
+export interface RequestCardProps {
+  title: string;
+  icon?: ComponentType<{ className?: string }>;
+  visual?: ReactNode;
+
+  description?: string | ReactNode;
+
+  details?: {
+    trigger?: string;
+    content: ReactNode;
+    defaultOpen?: boolean;
+  };
+
+  checkbox?: {
+    label: string;
+    checked: boolean;
+    onChange: (checked: boolean) => void;
+    avatar?: {
+      name?: string;
+      visual?: string;
+    };
+  };
+
+  primaryAction: {
+    label: string;
+    onClick: () => void;
+    variant?: "highlight" | "warning";
+    isLoading?: boolean;
+    disabled?: boolean;
+  };
+
+  secondaryAction?: {
+    label: string;
+    onClick: () => void;
+    isLoading?: boolean;
+    disabled?: boolean;
+  };
+
+  className?: string;
+}
+
+export const RequestCard = React.forwardRef<HTMLDivElement, RequestCardProps>(
+  (
+    {
+      title,
+      icon,
+      visual,
+      description,
+      details,
+      checkbox,
+      primaryAction,
+      secondaryAction,
+      className,
+    },
+    ref
+  ) => {
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          "s-flex s-flex-col s-gap-3",
+          "s-rounded-2xl s-p-4",
+          "s-border s-border-border dark:s-border-border-night",
+          "s-bg-background dark:s-bg-background-night",
+          "s-text-foreground dark:s-text-foreground-night",
+          className
+        )}
+      >
+        <div className="s-flex s-items-center s-gap-3">
+          <Avatar
+            size="sm"
+            icon={icon}
+            visual={visual}
+            backgroundColor="s-bg-muted-background dark:s-bg-muted-background-night"
+          />
+          <span className="s-text-sm s-font-semibold">{title}</span>
+        </div>
+
+        {description && (
+          <p className="s-text-sm s-text-muted-foreground dark:s-text-muted-foreground-night">
+            {description}
+          </p>
+        )}
+
+        {details && (
+          <Collapsible defaultOpen={details.defaultOpen}>
+            <CollapsibleTrigger
+              label={details.trigger || "Details"}
+              variant="secondary"
+            />
+            <CollapsibleContent>
+              <div
+                className={cn(
+                  "s-mt-2 s-rounded-lg s-p-3 s-text-sm",
+                  "s-bg-muted-background dark:s-bg-muted-background-night"
+                )}
+              >
+                {details.content}
+              </div>
+            </CollapsibleContent>
+          </Collapsible>
+        )}
+
+        {checkbox && (
+          <label className="s-flex s-cursor-pointer s-items-center s-gap-2">
+            <Checkbox
+              checked={checkbox.checked}
+              onCheckedChange={checkbox.onChange}
+              size="xs"
+            />
+            <span
+              className={cn(
+                "s-flex s-items-center s-gap-1.5 s-text-sm",
+                "s-text-muted-foreground dark:s-text-muted-foreground-night"
+              )}
+            >
+              {checkbox.label}
+              {checkbox.avatar && (
+                <>
+                  <Avatar
+                    size="xxs"
+                    name={checkbox.avatar.name}
+                    visual={checkbox.avatar.visual}
+                    isRounded
+                  />
+                  {checkbox.avatar.name}
+                </>
+              )}
+            </span>
+          </label>
+        )}
+
+        <div className="s-flex s-items-center s-justify-end s-gap-2">
+          {secondaryAction && (
+            <Button
+              variant="ghost"
+              size="sm"
+              label={secondaryAction.label}
+              onClick={secondaryAction.onClick}
+              isLoading={secondaryAction.isLoading}
+              disabled={secondaryAction.disabled}
+            />
+          )}
+          <Button
+            variant={primaryAction.variant || "highlight"}
+            size="sm"
+            label={primaryAction.label}
+            onClick={primaryAction.onClick}
+            isLoading={primaryAction.isLoading}
+            disabled={primaryAction.disabled}
+          />
+        </div>
+      </div>
+    );
+  }
+);
+
+RequestCard.displayName = "RequestCard";

--- a/sparkle/src/components/RequestCard.tsx
+++ b/sparkle/src/components/RequestCard.tsx
@@ -11,6 +11,13 @@ import {
 } from "@sparkle/components/Collapsible";
 import { cn } from "@sparkle/lib/utils";
 
+interface RequestCardActionProps {
+  label: string;
+  onClick: () => void;
+  isLoading?: boolean;
+  disabled?: boolean;
+}
+
 export interface RequestCardProps {
   title: string;
   icon?: ComponentType<{ className?: string }>;
@@ -34,20 +41,11 @@ export interface RequestCardProps {
     };
   };
 
-  primaryAction: {
-    label: string;
-    onClick: () => void;
+  primaryAction: RequestCardActionProps & {
     variant?: "highlight" | "warning";
-    isLoading?: boolean;
-    disabled?: boolean;
   };
 
-  secondaryAction?: {
-    label: string;
-    onClick: () => void;
-    isLoading?: boolean;
-    disabled?: boolean;
-  };
+  secondaryAction?: RequestCardActionProps;
 
   className?: string;
 }

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -182,9 +182,9 @@ export {
 } from "./Popover";
 export { PriceTable } from "./PriceTable";
 export { RadioGroup, RadioGroupCustomItem, RadioGroupItem } from "./RadioGroup";
+export { RainbowEffect } from "./RainbowEffect";
 export type { RequestCardProps } from "./RequestCard";
 export { RequestCard } from "./RequestCard";
-export { RainbowEffect } from "./RainbowEffect";
 export {
   ResizableHandle,
   ResizablePanel,

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -182,6 +182,8 @@ export {
 } from "./Popover";
 export { PriceTable } from "./PriceTable";
 export { RadioGroup, RadioGroupCustomItem, RadioGroupItem } from "./RadioGroup";
+export type { RequestCardProps } from "./RequestCard";
+export { RequestCard } from "./RequestCard";
 export { RainbowEffect } from "./RainbowEffect";
 export {
   ResizableHandle,

--- a/sparkle/src/stories/RequestCard.stories.tsx
+++ b/sparkle/src/stories/RequestCard.stories.tsx
@@ -1,0 +1,142 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import React from "react";
+
+import { RequestCard } from "@sparkle/components/RequestCard";
+import { ChatBubbleLeftRightIcon, CommandLineIcon } from "@sparkle/icons/app";
+import { GmailLogo } from "@sparkle/logo/platforms";
+
+const meta: Meta<typeof RequestCard> = {
+  title: "Components/RequestCard",
+  component: RequestCard,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "A card component for displaying confirmation requests in conversations, such as inviting users or approving tool execution.",
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const InviteUser: Story = {
+  args: {
+    icon: ChatBubbleLeftRightIcon,
+    title: "Invite Edouard Wautier to Design?",
+    description:
+      "They'll gain access to confidential project data, see the full history, and reply.",
+    primaryAction: {
+      label: "Invite",
+      onClick: () => alert("Invite clicked"),
+    },
+    secondaryAction: {
+      label: "Cancel",
+      onClick: () => alert("Cancel clicked"),
+    },
+  },
+};
+
+export const ToolExecution: Story = {
+  render: () => {
+    const [alwaysAllow, setAlwaysAllow] = React.useState(false);
+
+    return (
+      <RequestCard
+        visual={<GmailLogo className="s-h-full s-w-full" />}
+        title='Execute "Create Draft" from Gmail'
+        details={{
+          trigger: "Details",
+          content: (
+            <pre className="s-font-mono s-text-xs">
+              {JSON.stringify(
+                {
+                  to: "user@example.com",
+                  subject: "Hello from Dust",
+                  body: "This is a draft email.",
+                },
+                null,
+                2
+              )}
+            </pre>
+          ),
+        }}
+        checkbox={{
+          label: "Always allow for",
+          checked: alwaysAllow,
+          onChange: setAlwaysAllow,
+          avatar: {
+            name: "Edouard",
+            visual: "https://dust.tt/static/droidavatar/Droid_Lime_3.jpg",
+          },
+        }}
+        primaryAction={{
+          label: "Allow",
+          onClick: () => alert("Allow clicked"),
+        }}
+        secondaryAction={{
+          label: "Decline",
+          onClick: () => alert("Decline clicked"),
+        }}
+      />
+    );
+  },
+};
+
+export const WithDescription: Story = {
+  args: {
+    icon: CommandLineIcon,
+    title: "Run database migration?",
+    description: (
+      <>
+        This will execute the migration on{" "}
+        <strong>production-db-us-east</strong>. Make sure you have reviewed the
+        changes.
+      </>
+    ),
+    primaryAction: {
+      label: "Run",
+      onClick: () => alert("Run clicked"),
+    },
+    secondaryAction: {
+      label: "Cancel",
+      onClick: () => alert("Cancel clicked"),
+    },
+  },
+};
+
+export const LoadingState: Story = {
+  args: {
+    icon: CommandLineIcon,
+    title: "Execute command?",
+    primaryAction: {
+      label: "Execute",
+      onClick: () => {},
+      isLoading: true,
+    },
+    secondaryAction: {
+      label: "Cancel",
+      onClick: () => {},
+      disabled: true,
+    },
+  },
+};
+
+export const WarningVariant: Story = {
+  args: {
+    icon: CommandLineIcon,
+    title: "Delete 5 files?",
+    description: "This action cannot be undone.",
+    primaryAction: {
+      label: "Delete",
+      variant: "warning",
+      onClick: () => alert("Delete clicked"),
+    },
+    secondaryAction: {
+      label: "Cancel",
+      onClick: () => alert("Cancel clicked"),
+    },
+  },
+};


### PR DESCRIPTION
## Description

Partly adresses https://github.com/dust-tt/tasks/issues/6204

Creates a new `RequestCard` Sparkle component for displaying confirmation/action requests in conversations. Use cases include:
- Inviting users to conversations or projects
- Approving tool execution (MCP tools)
- Other accept/reject scenarios

**Features:**
- Icon or visual (logo) in header with Avatar background
- Title text
- Optional description
- Optional collapsible details section
- Optional checkbox with inline avatar ("Always allow for [User]")
- Primary and secondary action buttons with loading/disabled states
<img width="1235" height="1054" alt="image" src="https://github.com/user-attachments/assets/b6dbb1ae-b972-4cb7-b7e4-0d4913432219" />

## Risks

Blast radius: New Sparkle component, no existing code affected
Risk: none

## Deploy Plan

- deploy sparkle (npm publish)