### PR TITLE
[SPA] Bundle @modelcontextprotocol/sdk

### DIFF
--- a/.github/workflows/publish-sdk-client.yml
+++ b/.github/workflows/publish-sdk-client.yml
@@ -29,5 +29,29 @@ jobs:
       - name: Upgrade npm for OIDC support
         run: npm install -g npm@latest
 
-      - working-directory: sdks/js
-        run: npm ci && npm run build && npm publish --provenance --access public
+      - name: Install root dependencies
+        run: npm ci -w sdks/js
+
+      - name: Build SDK
+        working-directory: sdks/js
+        run: npm run build
+
+        # Needed because with bundleDependencies, npm workspace won't install the package
+      - name: Add bundleDependencies to package.json
+        working-directory: sdks/js
+        run: |
+          node -e '
+          const fs = require("fs");
+          const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+          const newDep = "@modelcontextprotocol/sdk";
+          if (!pkg.bundleDependencies) {
+            pkg.bundleDependencies = [newDep];
+          } else if (!pkg.bundleDependencies.includes(newDep)) {
+            pkg.bundleDependencies.push(newDep);
+          }
+          fs.writeFileSync("package.json", JSON.stringify(pkg, null, 2) + "\n");
+          '
+
+      - name: Publish SDK
+        working-directory: sdks/js
+        run: npm publish --provenance --access public


### PR DESCRIPTION
## Description

We want to bundle @modelcontextprotocol/sdk inside the dust client bundle.
Problem is, with npm workspaces, when we use the bundleDependencies property from package.json, the package does not get installed in sdks/js, thus publish command does not find the package in the node_modules and can't bundle it.

This PR adds the property on the fly AFTER install so the package is present in the node_modules

## Tests

command ran locally

## Risk

low

## Deploy Plan

sdks/js
