### PR TITLE
Poke SPA search all regions

### DIFF
--- a/front/components/poke/PokeNavbar.tsx
+++ b/front/components/poke/PokeNavbar.tsx
@@ -6,9 +6,13 @@ import {
   Logo,
 } from "@dust-tt/sparkle";
 import type { ComponentProps } from "react";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { PokeFavoriteButton } from "@app/components/poke/PokeFavorites";
+import {
+  usePokeRegionContext,
+  usePokeRegionContextSafe,
+} from "@app/components/poke/PokeRegionContext";
 import { PokeRegionDropdown } from "@app/components/poke/PokeRegionDropdown";
 import {
   PokeCommandDialog,
@@ -17,8 +21,10 @@ import {
   PokeCommandList,
 } from "@app/components/poke/shadcn/ui/command";
 import type { RegionType } from "@app/lib/api/regions/config";
+import { getRegionDisplay } from "@app/lib/poke/regions";
+import { usePokeRegion } from "@app/lib/swr/poke";
 import { classNames } from "@app/lib/utils";
-import { usePokeSearch } from "@app/poke/swr/search";
+import { usePokeSearch, usePokeSearchAllRegions } from "@app/poke/swr/search";
 import type { PokeItemBase } from "@app/types";
 import { isDevelopment } from "@app/types";
 
@@ -90,27 +96,133 @@ function PokeNavbar({ currentRegion, regionUrls, title }: PokeNavbarProps) {
 
 export default PokeNavbar;
 
+/**
+ * Entry point that renders the appropriate search command based on mode.
+ * - SPA mode: Multi-region search with region switching
+ * - NextJS mode: Single-region search (legacy)
+ */
 export function PokeSearchCommand() {
+  const regionContext = usePokeRegionContextSafe();
+
+  // SPA mode has region context available.
+  if (regionContext) {
+    return <PokeSearchCommandSPA />;
+  }
+
+  return <PokeSearchCommandLegacy />;
+}
+
+/**
+ * SPA mode: Search across all regions in parallel.
+ */
+function PokeSearchCommandSPA() {
+  const [open, setOpen] = useState(false);
+  const [searchTerm, setSearchTerm] = useState("");
+
+  const { currentRegion, setRegion } = usePokeRegionContext();
+  const { regionData } = usePokeRegion();
+  const regionUrls = regionData?.regionUrls ?? null;
+
+  const { isError, isLoading, results } = usePokeSearchAllRegions({
+    disabled: searchTerm.length < MIN_SEARCH_CHARACTERS,
+    search: searchTerm,
+    regionUrls,
+  });
+
+  const handleItemClick = useCallback(
+    (item: PokeItemBase) => {
+      // Switch region if the item is from a different region.
+      if (item.region && item.region !== currentRegion) {
+        setRegion(item.region);
+      }
+      setOpen(false);
+    },
+    [currentRegion, setRegion]
+  );
+
+  return (
+    <PokeSearchCommandUI
+      open={open}
+      onOpenChange={setOpen}
+      searchTerm={searchTerm}
+      onSearchTermChange={setSearchTerm}
+      results={results}
+      isLoading={isLoading}
+      isError={isError}
+      onItemClick={handleItemClick}
+      showRegion
+    />
+  );
+}
+
+/**
+ * NextJS mode: Single-region search (legacy).
+ */
+function PokeSearchCommandLegacy() {
   const [open, setOpen] = useState(false);
   const [searchTerm, setSearchTerm] = useState("");
 
   const { isError, isLoading, results } = usePokeSearch({
-    // Disable search until the user has typed at least MIN_SEARCH_CHARACTERS characters.
     disabled: searchTerm.length < MIN_SEARCH_CHARACTERS,
     search: searchTerm,
   });
 
+  const handleItemClick = useCallback(() => {
+    setOpen(false);
+  }, []);
+
+  return (
+    <PokeSearchCommandUI
+      open={open}
+      onOpenChange={setOpen}
+      searchTerm={searchTerm}
+      onSearchTermChange={setSearchTerm}
+      results={results}
+      isLoading={isLoading}
+      isError={isError}
+      onItemClick={handleItemClick}
+      showRegion={false}
+    />
+  );
+}
+
+interface PokeSearchCommandUIProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  searchTerm: string;
+  onSearchTermChange: (term: string) => void;
+  results: PokeItemBase[];
+  isLoading: boolean;
+  isError: boolean;
+  onItemClick: (item: PokeItemBase) => void;
+  showRegion: boolean;
+}
+
+/**
+ * Shared UI component for the search command dialog.
+ */
+function PokeSearchCommandUI({
+  open,
+  onOpenChange,
+  searchTerm,
+  onSearchTermChange,
+  results,
+  isLoading,
+  isError,
+  onItemClick,
+  showRegion,
+}: PokeSearchCommandUIProps) {
   useEffect(() => {
     const down = (e: KeyboardEvent) => {
       if (e.key === "k" && (e.metaKey || e.ctrlKey)) {
         e.preventDefault();
-        setOpen((open) => !open);
+        onOpenChange(!open);
       }
     };
     document.addEventListener("keydown", down);
 
     return () => document.removeEventListener("keydown", down);
-  }, [open, results]);
+  }, [open, onOpenChange]);
 
   return (
     <>
@@ -118,17 +230,17 @@ export function PokeSearchCommand() {
         variant="outline"
         size="sm"
         label="Search (⌘K)"
-        onClick={() => setOpen(true)}
+        onClick={() => onOpenChange(true)}
       />
       <PokeCommandDialog
         open={open}
-        onOpenChange={setOpen}
+        onOpenChange={onOpenChange}
         className="bg-muted-background sm:max-w-[600px]"
         shouldFilter={false}
       >
         <PokeCommandInput
           placeholder="Type a command or search..."
-          onValueChange={(value) => setSearchTerm(value.trim())}
+          onValueChange={(value) => onSearchTermChange(value.trim())}
           className="border-none focus:outline-none focus:ring-0"
         />
         <PokeCommandList>
@@ -178,7 +290,7 @@ export function PokeSearchCommand() {
           )}
 
           {results.map((item, index) => {
-            const CommandItem = () => (
+            const CommandItemContent = () => (
               <PokeCommandItem value={item.name} index={index}>
                 <div className="flex w-full items-center justify-between gap-3 px-2 text-foreground dark:text-foreground-night">
                   <div className="flex min-w-0 items-baseline gap-3">
@@ -189,18 +301,27 @@ export function PokeSearchCommand() {
                     <span className="font-mono text-xs text-muted-foreground dark:text-muted-foreground-night">
                       (id: {item.id})
                     </span>
+                    {showRegion && item.region && (
+                      <span className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+                        {getRegionDisplay(item.region)}
+                      </span>
+                    )}
                   </div>
                   <ChevronRightIcon className="h-4 w-4 flex-shrink-0" />
                 </div>
               </PokeCommandItem>
             );
 
+            const key = `${item.region ?? "default"}-${item.id}`;
+
             return item.link ? (
-              <LinkWrapper href={item.link} key={item.id}>
-                <CommandItem />
-              </LinkWrapper>
+              <div key={key} onClick={() => onItemClick(item)}>
+                <LinkWrapper href={item.link}>
+                  <CommandItemContent />
+                </LinkWrapper>
+              </div>
             ) : (
-              <CommandItem />
+              <CommandItemContent key={key} />
             );
           })}
         </PokeCommandList>

--- a/front/components/poke/pages/DashboardPage.tsx
+++ b/front/components/poke/pages/DashboardPage.tsx
@@ -8,10 +8,14 @@ import {
 import { UsersIcon } from "lucide-react";
 import moment from "moment";
 import type { ChangeEvent } from "react";
-import React, { useState } from "react";
+import React, { useCallback, useState } from "react";
 
 import { PokeFavoritesList } from "@app/components/poke/PokeFavorites";
 import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
+import {
+  usePokeRegionContext,
+  usePokeRegionContextSafe,
+} from "@app/components/poke/PokeRegionContext";
 import {
   PokeTable,
   PokeTableBody,
@@ -25,96 +29,229 @@ import {
   isOldFreePlan,
   isProPlanPrefix,
 } from "@app/lib/plans/plan_codes";
-import { usePokeWorkspaces } from "@app/lib/swr/poke";
+import { getRegionDisplay } from "@app/lib/poke/regions";
+import { usePokeRegion, usePokeWorkspaces } from "@app/lib/swr/poke";
 import { classNames } from "@app/lib/utils";
-import type { PokeWorkspaceType } from "@app/pages/api/poke/workspaces";
+import type { PokeWorkspaceWithRegion } from "@app/poke/swr/search";
+import { usePokeWorkspacesAllRegions } from "@app/poke/swr/search";
 
-const limit: number = 20;
+const WORKSPACE_LIMIT = 20;
 
-const renderWorkspaces = (title: string, workspaces: PokeWorkspaceType[]) => (
-  <>
-    <h1 className="mb-4 mt-8 text-2xl font-bold">{title}</h1>
-    <ul className="flex flex-wrap gap-4">
-      {workspaces.length === 0 && <p>No workspaces found.</p>}
-      {workspaces.map((ws) => (
-        <LinkWrapper href={`/poke/${ws.sId}`} key={ws.id}>
-          <li className="border-material-100 w-80 rounded-lg border p-4 transition-colors duration-200 hover:bg-gray-100 dark:hover:bg-gray-800">
-            <h2 className="text-md flex-grow pb-2 font-bold">{ws.name}</h2>
-            <PokeTable>
-              <PokeTableBody>
-                <PokeTableRow>
-                  <PokeTableCell className="space-x-2" colSpan={3}>
-                    <label>
-                      Created: {moment(ws.createdAt).format("DD-MM-YYYY")}
-                    </label>
-                  </PokeTableCell>
-                </PokeTableRow>
-                <PokeTableRow>
-                  <PokeTableCell className="max-w-[200px] overflow-hidden text-ellipsis">
-                    {ws.adminEmail}{" "}
-                    {ws.workspaceDomains && (
-                      <label>
-                        ({ws.workspaceDomains.map((d) => d.domain).join(", ")})
-                      </label>
-                    )}
-                  </PokeTableCell>
-                  <PokeTableCell align="center">
-                    <label>
-                      <Icon visual={UsersIcon} /> {ws.membersCount}
-                    </label>
-                  </PokeTableCell>
-                  <PokeTableCell align="center">
-                    <label>
-                      <Icon visual={BookOpenIcon} /> {ws.dataSourcesCount}
-                    </label>
-                  </PokeTableCell>
-                </PokeTableRow>
-                <PokeTableRow>
-                  <PokeTableCell className="space-x-2" colSpan={3}>
-                    <label className="rounded bg-green-500 px-1 text-sm text-white">
-                      {ws.sId}
-                    </label>
-                    {ws.subscription && (
-                      <label
-                        className={classNames(
-                          "rounded px-1 text-sm text-gray-500 text-white",
-                          isEntreprisePlanPrefix(ws.subscription.plan.code) &&
-                            "bg-red-500",
-                          isFriendsAndFamilyPlan(ws.subscription.plan.code) &&
-                            "bg-pink-500",
-                          isProPlanPrefix(ws.subscription.plan.code) &&
-                            "bg-orange-500",
-                          isFreePlan(ws.subscription.plan.code) &&
-                            "bg-blue-500",
-                          isOldFreePlan(ws.subscription.plan.code) &&
-                            "bg-gray-300"
+interface WorkspaceListProps {
+  title: string;
+  workspaces: PokeWorkspaceWithRegion[];
+  showRegion?: boolean;
+  onWorkspaceClick?: (ws: PokeWorkspaceWithRegion) => void;
+}
+
+function WorkspaceList({
+  title,
+  workspaces,
+  showRegion = false,
+  onWorkspaceClick,
+}: WorkspaceListProps) {
+  return (
+    <>
+      <h1 className="mb-4 mt-8 text-2xl font-bold">{title}</h1>
+      <ul className="flex flex-wrap gap-4">
+        {workspaces.length === 0 && <p>No workspaces found.</p>}
+        {workspaces.map((ws) => (
+          <div
+            key={`${ws.region ?? "default"}-${ws.id}`}
+            onClick={() => onWorkspaceClick?.(ws)}
+          >
+            <LinkWrapper href={`/poke/${ws.sId}`}>
+              <li className="border-material-100 w-80 rounded-lg border p-4 transition-colors duration-200 hover:bg-gray-100 dark:hover:bg-gray-800">
+                <div className="flex items-center justify-between pb-2">
+                  <h2 className="text-md flex-grow font-bold">{ws.name}</h2>
+                  {showRegion && ws.region && (
+                    <span className="text-xs text-muted-foreground">
+                      {getRegionDisplay(ws.region)}
+                    </span>
+                  )}
+                </div>
+                <PokeTable>
+                  <PokeTableBody>
+                    <PokeTableRow>
+                      <PokeTableCell className="space-x-2" colSpan={3}>
+                        <label>
+                          Created: {moment(ws.createdAt).format("DD-MM-YYYY")}
+                        </label>
+                      </PokeTableCell>
+                    </PokeTableRow>
+                    <PokeTableRow>
+                      <PokeTableCell className="max-w-[200px] overflow-hidden text-ellipsis">
+                        {ws.adminEmail}{" "}
+                        {ws.workspaceDomains && (
+                          <label>
+                            (
+                            {ws.workspaceDomains
+                              .map((d) => d.domain)
+                              .join(", ")}
+                            )
+                          </label>
                         )}
-                      >
-                        {ws.subscription.plan.name}
-                      </label>
-                    )}
-                  </PokeTableCell>
-                </PokeTableRow>
-              </PokeTableBody>
-            </PokeTable>
-          </li>
-        </LinkWrapper>
-      ))}
-    </ul>
-  </>
-);
+                      </PokeTableCell>
+                      <PokeTableCell align="center">
+                        <label>
+                          <Icon visual={UsersIcon} /> {ws.membersCount}
+                        </label>
+                      </PokeTableCell>
+                      <PokeTableCell align="center">
+                        <label>
+                          <Icon visual={BookOpenIcon} /> {ws.dataSourcesCount}
+                        </label>
+                      </PokeTableCell>
+                    </PokeTableRow>
+                    <PokeTableRow>
+                      <PokeTableCell className="space-x-2" colSpan={3}>
+                        <label className="rounded bg-green-500 px-1 text-sm text-white">
+                          {ws.sId}
+                        </label>
+                        {ws.subscription && (
+                          <label
+                            className={classNames(
+                              "rounded px-1 text-sm text-gray-500 text-white",
+                              isEntreprisePlanPrefix(
+                                ws.subscription.plan.code
+                              ) && "bg-red-500",
+                              isFriendsAndFamilyPlan(
+                                ws.subscription.plan.code
+                              ) && "bg-pink-500",
+                              isProPlanPrefix(ws.subscription.plan.code) &&
+                                "bg-orange-500",
+                              isFreePlan(ws.subscription.plan.code) &&
+                                "bg-blue-500",
+                              isOldFreePlan(ws.subscription.plan.code) &&
+                                "bg-gray-300"
+                            )}
+                          >
+                            {ws.subscription.plan.name}
+                          </label>
+                        )}
+                      </PokeTableCell>
+                    </PokeTableRow>
+                  </PokeTableBody>
+                </PokeTable>
+              </li>
+            </LinkWrapper>
+          </div>
+        ))}
+      </ul>
+    </>
+  );
+}
 
+/**
+ * Entry point that renders the appropriate dashboard based on mode.
+ */
 export function DashboardPage() {
+  const regionContext = usePokeRegionContextSafe();
+
+  if (regionContext) {
+    return <DashboardPageSPA />;
+  }
+
+  return <DashboardPageLegacy />;
+}
+
+/**
+ * SPA mode: Search workspaces across all regions.
+ */
+function DashboardPageSPA() {
+  useSetPokePageTitle("Home");
+
+  const { currentRegion, setRegion } = usePokeRegionContext();
+  const { regionData } = usePokeRegion();
+  const regionUrls = regionData?.regionUrls ?? null;
+
+  const {
+    workspaces: upgradedWorkspaces,
+    isWorkspacesLoading: isUpgradedWorkspacesLoading,
+    isWorkspacesError: isUpgradedWorkspacesError,
+  } = usePokeWorkspacesAllRegions({
+    upgraded: true,
+    limit: WORKSPACE_LIMIT,
+    regionUrls,
+  });
+
+  const [searchTerm, setSearchTerm] = useState("");
+  const searchDisabled = searchTerm.trim().length < 3;
+
+  const {
+    workspaces: searchResults,
+    isWorkspacesLoading: isSearchResultsLoading,
+    isWorkspacesError: isSearchResultsError,
+  } = usePokeWorkspacesAllRegions({
+    search: searchTerm,
+    disabled: searchDisabled,
+    limit: WORKSPACE_LIMIT,
+    regionUrls,
+  });
+
+  const handleSearchChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setSearchTerm(event.target.value);
+  };
+
+  const handleWorkspaceClick = useCallback(
+    (ws: PokeWorkspaceWithRegion) => {
+      if (ws.region && ws.region !== currentRegion) {
+        setRegion(ws.region);
+      }
+    },
+    [currentRegion, setRegion]
+  );
+
+  return (
+    <>
+      <PokeFavoritesList />
+      <h1 className="mb-4 text-2xl font-bold">Search in Workspaces</h1>
+      <Input
+        type="text"
+        placeholder="Search"
+        value={searchTerm}
+        onChange={handleSearchChange}
+      />
+      {isSearchResultsError && (
+        <p>An error occurred while fetching search results.</p>
+      )}
+      {!isSearchResultsLoading && !isSearchResultsError && (
+        <WorkspaceList
+          title="Search Results"
+          workspaces={searchResults}
+          showRegion
+          onWorkspaceClick={handleWorkspaceClick}
+        />
+      )}
+      {isSearchResultsLoading && !searchDisabled && (
+        <Spinner size="lg" variant="color" />
+      )}
+      {!isUpgradedWorkspacesLoading && !isUpgradedWorkspacesError && (
+        <WorkspaceList
+          title={`Last ${WORKSPACE_LIMIT} Upgraded Workspaces`}
+          workspaces={upgradedWorkspaces}
+          showRegion
+          onWorkspaceClick={handleWorkspaceClick}
+        />
+      )}
+      {isUpgradedWorkspacesLoading && <Spinner size="lg" variant="color" />}
+    </>
+  );
+}
+
+/**
+ * NextJS mode: Single-region search (legacy).
+ */
+function DashboardPageLegacy() {
   useSetPokePageTitle("Home");
 
   const {
     workspaces: upgradedWorkspaces,
     isWorkspacesLoading: isUpgradedWorkspacesLoading,
     isWorkspacesError: isUpgradedWorkspacesError,
-  } = usePokeWorkspaces({ upgraded: true, limit });
+  } = usePokeWorkspaces({ upgraded: true, limit: WORKSPACE_LIMIT });
 
   const [searchTerm, setSearchTerm] = useState("");
-
   const searchDisabled = searchTerm.trim().length < 3;
 
   const {
@@ -124,7 +261,7 @@ export function DashboardPage() {
   } = usePokeWorkspaces({
     search: searchTerm,
     disabled: searchDisabled,
-    limit,
+    limit: WORKSPACE_LIMIT,
   });
 
   const handleSearchChange = (event: ChangeEvent<HTMLInputElement>) => {
@@ -144,18 +281,18 @@ export function DashboardPage() {
       {isSearchResultsError && (
         <p>An error occurred while fetching search results.</p>
       )}
-      {!isSearchResultsLoading &&
-        !isSearchResultsError &&
-        renderWorkspaces("Search Results", searchResults)}
+      {!isSearchResultsLoading && !isSearchResultsError && (
+        <WorkspaceList title="Search Results" workspaces={searchResults} />
+      )}
       {isSearchResultsLoading && !searchDisabled && (
         <Spinner size="lg" variant="color" />
       )}
-      {!isUpgradedWorkspacesLoading &&
-        !isUpgradedWorkspacesError &&
-        renderWorkspaces(
-          `Last ${limit} Upgraded Workspaces`,
-          upgradedWorkspaces
-        )}
+      {!isUpgradedWorkspacesLoading && !isUpgradedWorkspacesError && (
+        <WorkspaceList
+          title={`Last ${WORKSPACE_LIMIT} Upgraded Workspaces`}
+          workspaces={upgradedWorkspaces}
+        />
+      )}
       {isUpgradedWorkspacesLoading && <Spinner size="lg" variant="color" />}
     </>
   );

--- a/front/poke/swr/search.ts
+++ b/front/poke/swr/search.ts
@@ -71,49 +71,43 @@ export function usePokeSearchAllRegions({
 
     const queryParams = new URLSearchParams({ search });
 
-    const fetchAllRegions = async () => {
-      const regionPromises = SUPPORTED_REGIONS.map(async (region) => {
-        const baseUrl = regionUrls[region];
-        const url = `${baseUrl}/api/poke/search?${queryParams.toString()}`;
+    const run = async () => {
+      try {
+        const regionPromises = SUPPORTED_REGIONS.map(async (region) => {
+          const baseUrl = regionUrls[region];
+          const url = `${baseUrl}/api/poke/search?${queryParams.toString()}`;
 
-        const response = await clientFetch(url, { credentials: "include" });
-        if (!response.ok) {
-          throw new Error(`Failed to fetch from ${region}`);
+          const response = await clientFetch(url, { credentials: "include" });
+          if (!response.ok) {
+            throw new Error(`Failed to fetch from ${region}`);
+          }
+
+          const data: GetPokeSearchItemsResponseBody = await response.json();
+          return data.results.map((item) => ({ ...item, region }));
+        });
+
+        const settledResults = await Promise.allSettled(regionPromises);
+        const allResults: PokeItemBase[] = [];
+
+        for (const result of settledResults) {
+          if (result.status === "fulfilled") {
+            allResults.push(...result.value);
+          }
         }
 
-        const data: GetPokeSearchItemsResponseBody = await response.json();
-        // Tag each result with its source region
-        return data.results.map((item) => ({
-          ...item,
-          region,
-        }));
-      });
-
-      const settledResults = await Promise.allSettled(regionPromises);
-      const allResults: PokeItemBase[] = [];
-
-      for (const result of settledResults) {
-        if (result.status === "fulfilled") {
-          allResults.push(...result.value);
-        }
-      }
-
-      return allResults;
-    };
-
-    fetchAllRegions()
-      .then((allResults) => {
         if (!cancelled) {
           setResults(allResults);
           setIsLoading(false);
         }
-      })
-      .catch(() => {
+      } catch {
         if (!cancelled) {
           setIsError(true);
           setIsLoading(false);
         }
-      });
+      }
+    };
+
+    void run();
 
     return () => {
       cancelled = true;
@@ -177,49 +171,43 @@ export function usePokeWorkspacesAllRegions({
       queryParams.set("limit", String(limit));
     }
 
-    const fetchAllRegions = async () => {
-      const regionPromises = SUPPORTED_REGIONS.map(async (region) => {
-        const baseUrl = regionUrls[region];
-        const url = `${baseUrl}/api/poke/workspaces?${queryParams.toString()}`;
+    const run = async () => {
+      try {
+        const regionPromises = SUPPORTED_REGIONS.map(async (region) => {
+          const baseUrl = regionUrls[region];
+          const url = `${baseUrl}/api/poke/workspaces?${queryParams.toString()}`;
 
-        const response = await clientFetch(url, { credentials: "include" });
-        if (!response.ok) {
-          throw new Error(`Failed to fetch from ${region}`);
+          const response = await clientFetch(url, { credentials: "include" });
+          if (!response.ok) {
+            throw new Error(`Failed to fetch from ${region}`);
+          }
+
+          const data: GetPokeWorkspacesResponseBody = await response.json();
+          return data.workspaces.map((ws) => ({ ...ws, region }));
+        });
+
+        const settledResults = await Promise.allSettled(regionPromises);
+        const allWorkspaces: PokeWorkspaceWithRegion[] = [];
+
+        for (const result of settledResults) {
+          if (result.status === "fulfilled") {
+            allWorkspaces.push(...result.value);
+          }
         }
 
-        const data: GetPokeWorkspacesResponseBody = await response.json();
-        // Tag each workspace with its source region
-        return data.workspaces.map((ws) => ({
-          ...ws,
-          region,
-        }));
-      });
-
-      const settledResults = await Promise.allSettled(regionPromises);
-      const allWorkspaces: PokeWorkspaceWithRegion[] = [];
-
-      for (const result of settledResults) {
-        if (result.status === "fulfilled") {
-          allWorkspaces.push(...result.value);
-        }
-      }
-
-      return allWorkspaces;
-    };
-
-    fetchAllRegions()
-      .then((allWorkspaces) => {
         if (!cancelled) {
           setWorkspaces(allWorkspaces);
           setIsLoading(false);
         }
-      })
-      .catch(() => {
+      } catch {
         if (!cancelled) {
           setIsError(true);
           setIsLoading(false);
         }
-      });
+      }
+    };
+
+    void run();
 
     return () => {
       cancelled = true;

--- a/front/poke/swr/search.ts
+++ b/front/poke/swr/search.ts
@@ -88,15 +88,19 @@ export function usePokeSearchAllRegions({
 
         const settledResults = await Promise.allSettled(regionPromises);
         const allResults: PokeItemBase[] = [];
+        let hasErrors = false;
 
         for (const result of settledResults) {
           if (result.status === "fulfilled") {
             allResults.push(...result.value);
+          } else {
+            hasErrors = true;
           }
         }
 
         if (!cancelled) {
           setResults(allResults);
+          setIsError(hasErrors);
           setIsLoading(false);
         }
       } catch {
@@ -188,15 +192,19 @@ export function usePokeWorkspacesAllRegions({
 
         const settledResults = await Promise.allSettled(regionPromises);
         const allWorkspaces: PokeWorkspaceWithRegion[] = [];
+        let hasErrors = false;
 
         for (const result of settledResults) {
           if (result.status === "fulfilled") {
             allWorkspaces.push(...result.value);
+          } else {
+            hasErrors = true;
           }
         }
 
         if (!cancelled) {
           setWorkspaces(allWorkspaces);
+          setIsError(hasErrors);
           setIsLoading(false);
         }
       } catch {

--- a/front/poke/swr/search.ts
+++ b/front/poke/swr/search.ts
@@ -1,7 +1,16 @@
+import { useEffect, useState } from "react";
 import type { Fetcher } from "swr";
 
+import type { RegionType } from "@app/lib/api/regions/config";
+import { SUPPORTED_REGIONS } from "@app/lib/api/regions/config";
+import { clientFetch } from "@app/lib/egress/client";
 import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetPokeSearchItemsResponseBody } from "@app/pages/api/poke/search";
+import type {
+  GetPokeWorkspacesResponseBody,
+  PokeWorkspaceType,
+} from "@app/pages/api/poke/workspaces";
+import type { PokeItemBase } from "@app/types";
 
 export function usePokeSearch({
   disabled,
@@ -28,5 +37,198 @@ export function usePokeSearch({
     results: data?.results ?? emptyArray(),
     isLoading: !error && !data && !disabled,
     isError: error,
+  };
+}
+
+/**
+ * Search across all regions in parallel.
+ * Returns results tagged with their source region.
+ */
+export function usePokeSearchAllRegions({
+  disabled,
+  search,
+  regionUrls,
+}: {
+  disabled?: boolean;
+  search?: string;
+  regionUrls: Record<RegionType, string> | null;
+}) {
+  const [results, setResults] = useState<PokeItemBase[]>(emptyArray());
+  const [isLoading, setIsLoading] = useState(false);
+  const [isError, setIsError] = useState(false);
+
+  useEffect(() => {
+    if (disabled || !search || !regionUrls) {
+      setResults(emptyArray());
+      setIsLoading(false);
+      setIsError(false);
+      return;
+    }
+
+    let cancelled = false;
+    setIsLoading(true);
+    setIsError(false);
+
+    const queryParams = new URLSearchParams({ search });
+
+    const fetchAllRegions = async () => {
+      const regionPromises = SUPPORTED_REGIONS.map(async (region) => {
+        const baseUrl = regionUrls[region];
+        const url = `${baseUrl}/api/poke/search?${queryParams.toString()}`;
+
+        const response = await clientFetch(url, { credentials: "include" });
+        if (!response.ok) {
+          throw new Error(`Failed to fetch from ${region}`);
+        }
+
+        const data: GetPokeSearchItemsResponseBody = await response.json();
+        // Tag each result with its source region
+        return data.results.map((item) => ({
+          ...item,
+          region,
+        }));
+      });
+
+      const settledResults = await Promise.allSettled(regionPromises);
+      const allResults: PokeItemBase[] = [];
+
+      for (const result of settledResults) {
+        if (result.status === "fulfilled") {
+          allResults.push(...result.value);
+        }
+      }
+
+      return allResults;
+    };
+
+    fetchAllRegions()
+      .then((allResults) => {
+        if (!cancelled) {
+          setResults(allResults);
+          setIsLoading(false);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setIsError(true);
+          setIsLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [disabled, search, regionUrls]);
+
+  return {
+    results,
+    isLoading,
+    isError,
+  };
+}
+
+export type PokeWorkspaceWithRegion = PokeWorkspaceType & {
+  region?: RegionType;
+};
+
+/**
+ * Search workspaces across all regions in parallel.
+ * Returns workspaces tagged with their source region.
+ */
+export function usePokeWorkspacesAllRegions({
+  disabled,
+  search,
+  upgraded,
+  limit,
+  regionUrls,
+}: {
+  disabled?: boolean;
+  search?: string;
+  upgraded?: boolean;
+  limit?: number;
+  regionUrls: Record<RegionType, string> | null;
+}) {
+  const [workspaces, setWorkspaces] = useState<PokeWorkspaceWithRegion[]>(
+    emptyArray()
+  );
+  const [isLoading, setIsLoading] = useState(false);
+  const [isError, setIsError] = useState(false);
+
+  useEffect(() => {
+    if (disabled || !regionUrls) {
+      setWorkspaces(emptyArray());
+      setIsLoading(false);
+      setIsError(false);
+      return;
+    }
+
+    let cancelled = false;
+    setIsLoading(true);
+    setIsError(false);
+
+    const queryParams = new URLSearchParams();
+    if (search) {
+      queryParams.set("search", search);
+    }
+    if (upgraded !== undefined) {
+      queryParams.set("upgraded", String(upgraded));
+    }
+    if (limit !== undefined) {
+      queryParams.set("limit", String(limit));
+    }
+
+    const fetchAllRegions = async () => {
+      const regionPromises = SUPPORTED_REGIONS.map(async (region) => {
+        const baseUrl = regionUrls[region];
+        const url = `${baseUrl}/api/poke/workspaces?${queryParams.toString()}`;
+
+        const response = await clientFetch(url, { credentials: "include" });
+        if (!response.ok) {
+          throw new Error(`Failed to fetch from ${region}`);
+        }
+
+        const data: GetPokeWorkspacesResponseBody = await response.json();
+        // Tag each workspace with its source region
+        return data.workspaces.map((ws) => ({
+          ...ws,
+          region,
+        }));
+      });
+
+      const settledResults = await Promise.allSettled(regionPromises);
+      const allWorkspaces: PokeWorkspaceWithRegion[] = [];
+
+      for (const result of settledResults) {
+        if (result.status === "fulfilled") {
+          allWorkspaces.push(...result.value);
+        }
+      }
+
+      return allWorkspaces;
+    };
+
+    fetchAllRegions()
+      .then((allWorkspaces) => {
+        if (!cancelled) {
+          setWorkspaces(allWorkspaces);
+          setIsLoading(false);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setIsError(true);
+          setIsLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [disabled, search, upgraded, limit, regionUrls]);
+
+  return {
+    workspaces,
+    isWorkspacesLoading: isLoading,
+    isWorkspacesError: isError,
   };
 }

--- a/front/types/poke/index.ts
+++ b/front/types/poke/index.ts
@@ -32,9 +32,6 @@ export interface PokeItemBase {
   region?: RegionType;
 }
 
-// Re-export for convenience
-export type { RegionType } from "@app/lib/api/regions/config";
-
 export type PokeSpaceType = SpaceType & {
   id: ModelId;
   groups: GroupType[];

--- a/front/types/poke/index.ts
+++ b/front/types/poke/index.ts
@@ -2,6 +2,7 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 
 import type { ActionGeneratedFileType } from "@app/lib/actions/types";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
+import type { RegionType } from "@app/lib/api/regions/config";
 
 import type {
   AgentMessageType,
@@ -28,7 +29,11 @@ export interface PokeItemBase {
   link: string | null;
   name: string;
   type: PokeItemType;
+  region?: RegionType;
 }
+
+// Re-export for convenience
+export type { RegionType } from "@app/lib/api/regions/config";
 
 export type PokeSpaceType = SpaceType & {
   id: ModelId;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR:
- Adds multi-region search to Poke SPA for both the command palette (⌘K) and the workspace search on the dashboard
- In SPA mode, searches now query all regions in parallel and display results with region badges (🇪🇺 Europe / 🇺🇸 United
States)
- Clicking a result from a different region automatically switches the region context

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
