### PR TITLE
[Projects] Add editors management to project settings

### DIFF
--- a/front/components/pages/conversation/SpaceConversationsPage.tsx
+++ b/front/components/pages/conversation/SpaceConversationsPage.tsx
@@ -90,7 +90,7 @@ export function SpaceConversationsPage() {
         window.history.replaceState(
           null,
           "",
-          `${window.location.pathname}${window.location.search}#${newTab}`
+          `${window.location.pathname}${window.location.search}#${newTab}`,
         );
       }
     };
@@ -109,7 +109,7 @@ export function SpaceConversationsPage() {
     window.history.replaceState(
       null,
       "",
-      `${window.location.pathname}${window.location.search}#${tab}`
+      `${window.location.pathname}${window.location.search}#${tab}`,
     );
     setCurrentTab(tab);
   }, []);
@@ -119,7 +119,7 @@ export function SpaceConversationsPage() {
       input: string,
       mentions: RichMention[],
       contentFragments: ContentFragmentsType,
-      selectedMCPServerViewIds?: string[]
+      selectedMCPServerViewIds?: string[],
     ): Promise<Result<undefined, DustError>> => {
       if (isSubmitting) {
         return new Err({
@@ -164,7 +164,7 @@ export function SpaceConversationsPage() {
         await router.push(
           getConversationRoute(owner.sId, conversationRes.value.sId),
           undefined,
-          { shallow: true }
+          { shallow: true },
         );
 
         // Update the conversations list
@@ -178,7 +178,7 @@ export function SpaceConversationsPage() {
               ],
             };
           },
-          { revalidate: false }
+          { revalidate: false },
         );
 
         return new Ok(undefined);
@@ -193,7 +193,7 @@ export function SpaceConversationsPage() {
       router,
       mutateConversations,
       createConversationWithMessage,
-    ]
+    ],
   );
 
   // Show loading state while fetching space info
@@ -270,6 +270,7 @@ export function SpaceConversationsPage() {
             owner={owner}
             space={spaceInfo}
             initialMembers={spaceInfo.members}
+            initialEditors={spaceInfo.editors}
             planAllowsSCIM={planAllowsSCIM}
             initialGroups={
               planAllowsSCIM &&
@@ -277,7 +278,7 @@ export function SpaceConversationsPage() {
               spaceInfo.groupIds.length > 0 &&
               groups
                 ? groups.filter((group) =>
-                    spaceInfo.groupIds.includes(group.sId)
+                    spaceInfo.groupIds.includes(group.sId),
                   )
                 : []
             }


### PR DESCRIPTION
## Description

Follows #20890.

Implements editors management for projects:
- Returns `editors` from GET `/spaces/[spaceId]` endpoint (from `space_editors` groups)
- Adds "Editors" section in project settings using the existing `EditorsSheet` component
- Passes actual `editorIds` when saving instead of empty array

This fixes the issue where project settings showed no editors and saving failed with "Projects must have at least one editor".

## Risks

Blast radius: Project settings
Risk: low

## Deploy Plan

- deploy front