### PR TITLE
feat: prioritize project members in mention suggestions

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -294,6 +294,7 @@ const InputBarContainer = ({
     onUrlDetected: handleUrlDetected,
     owner,
     conversationId: conversation?.sId,
+    spaceId: space?.sId,
     onInlineText: handleInlineText,
     onLongTextPaste: async ({ text, from, to }) => {
       let filename = "";

--- a/front/components/editor/input_bar/MentionDropdown.tsx
+++ b/front/components/editor/input_bar/MentionDropdown.tsx
@@ -34,6 +34,7 @@ export const MentionDropdown = forwardRef<
       onClose,
       owner,
       conversationId,
+      spaceId,
       includeCurrentUser,
       select,
     },
@@ -50,6 +51,7 @@ export const MentionDropdown = forwardRef<
     const { suggestions, isLoading } = useMentionSuggestions({
       workspaceId: owner.sId,
       conversationId,
+      spaceId,
       query,
       select,
       includeCurrentUser,

--- a/front/components/editor/input_bar/mentionSuggestion.tsx
+++ b/front/components/editor/input_bar/mentionSuggestion.tsx
@@ -18,11 +18,13 @@ export const mentionPluginKey = new PluginKey("mention-suggestion");
 export function createMentionSuggestion({
   owner,
   conversationId,
+  spaceId,
   select,
   includeCurrentUser = false,
 }: {
   owner: WorkspaceType;
   conversationId?: string | null;
+  spaceId?: string;
   includeCurrentUser?: boolean;
   select: {
     agents: boolean;
@@ -56,6 +58,7 @@ export function createMentionSuggestion({
               ...props,
               owner,
               conversationId,
+              spaceId,
               includeCurrentUser,
               onClose: closeDropdown,
               select,
@@ -71,6 +74,7 @@ export function createMentionSuggestion({
             onClose: closeDropdown,
             owner,
             conversationId,
+            spaceId,
           });
         },
 

--- a/front/components/editor/input_bar/types.ts
+++ b/front/components/editor/input_bar/types.ts
@@ -10,6 +10,7 @@ export interface MentionDropdownProps {
   query: string;
   owner: WorkspaceType;
   conversationId: string | null;
+  spaceId?: string;
   includeCurrentUser?: boolean;
   command: (item: RichMention) => void;
   clientRect?: (() => DOMRect | null) | null;

--- a/front/components/editor/input_bar/useCustomEditor.tsx
+++ b/front/components/editor/input_bar/useCustomEditor.tsx
@@ -172,6 +172,7 @@ export interface CustomEditorProps {
   onUrlDetected?: (candidate: UrlCandidate | NodeCandidate | null) => void;
   owner: WorkspaceType;
   conversationId?: string | null;
+  spaceId?: string;
   // If provided, large pasted text will be routed to this callback along with selection bounds
   onLongTextPaste?: (payload: {
     text: string;
@@ -185,11 +186,13 @@ export interface CustomEditorProps {
 export const buildEditorExtensions = ({
   owner,
   conversationId,
+  spaceId,
   onInlineText,
   onUrlDetected,
 }: {
   owner: WorkspaceType;
   conversationId?: string | null;
+  spaceId?: string;
   onInlineText?: (fileId: string, textContent: string) => void;
   onUrlDetected?: (candidate: UrlCandidate | NodeCandidate | null) => void;
 }) => {
@@ -258,6 +261,7 @@ export const buildEditorExtensions = ({
       suggestion: createMentionSuggestion({
         owner,
         conversationId,
+        spaceId,
         select: {
           agents: true,
           users: true,
@@ -292,6 +296,7 @@ const useCustomEditor = ({
   onUrlDetected,
   owner,
   conversationId,
+  spaceId,
   onLongTextPaste,
   longTextPasteCharsThreshold,
   onInlineText,
@@ -302,6 +307,7 @@ const useCustomEditor = ({
       extensions: buildEditorExtensions({
         owner,
         conversationId,
+        spaceId,
         onInlineText,
         onUrlDetected,
       }),

--- a/front/lib/api/assistant/conversation/mention_suggestions.ts
+++ b/front/lib/api/assistant/conversation/mention_suggestions.ts
@@ -213,7 +213,7 @@ export const suggestionsOfMentions = async (
     }
   }
 
-  // If the conversation belogns to a project, get the project members.
+  // If the conversation belongs to a project, get the project members.
   // This aims to prioritize them in the suggestions
   if (spaceId) {
     const conversationSpace = await SpaceResource.fetchById(auth, spaceId);

--- a/front/lib/api/assistant/conversation/mention_suggestions.ts
+++ b/front/lib/api/assistant/conversation/mention_suggestions.ts
@@ -9,7 +9,9 @@ import {
   SUGGESTION_PRIORITY,
 } from "@app/lib/mentions/editor/suggestion";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type {
   RichAgentMentionInConversation,
   RichMention,
@@ -124,6 +126,7 @@ export const suggestionsOfMentions = async (
   {
     query,
     conversationId,
+    spaceId,
     select = {
       agents: true,
       users: true,
@@ -132,6 +135,7 @@ export const suggestionsOfMentions = async (
   }: {
     query: string;
     conversationId?: string | null;
+    spaceId?: string | null;
     select?: {
       agents: boolean;
       users: boolean;
@@ -150,6 +154,7 @@ export const suggestionsOfMentions = async (
   const userSuggestions: RichUserMentionInConversation[] = [];
   let participantUsers: RichUserMentionInConversation[] = [];
   let participantAgents: RichAgentMentionInConversation[] = [];
+  const projectMemberIds: Set<string> = new Set();
 
   // Get conversation participants if conversationId is provided
   // This aims to prioritize them in the suggestions
@@ -208,6 +213,20 @@ export const suggestionsOfMentions = async (
     }
   }
 
+  // If the conversation belogns to a project, get the project members.
+  // This aims to prioritize them in the suggestions
+  if (spaceId) {
+    const conversationSpace = await SpaceResource.fetchById(auth, spaceId);
+
+    const allMembers = await concurrentExecutor(
+      conversationSpace?.groups.filter((g) => g.kind !== "global") ?? [],
+      (group) => group.getActiveMembers(auth),
+      { concurrency: 8 }
+    );
+
+    allMembers.flat().forEach((m) => projectMemberIds.add(m.sId));
+  }
+
   if (select.agents) {
     const agentConfigurations = await getAgentConfigurationsForView({
       auth,
@@ -247,6 +266,7 @@ export const suggestionsOfMentions = async (
         .map((u) => ({
           ...toRichUserMentionType(u.toJSON()),
           isParticipant: participantUsers.some((pu) => pu.id === u.sId),
+          isProjectMember: spaceId ? projectMemberIds.has(u.sId) : undefined,
           lastActivityAt:
             participantUsers.find((pu) => pu.id === u.sId)?.lastActivityAt ?? 0,
         }));

--- a/front/lib/mentions/editor/suggestion.test.ts
+++ b/front/lib/mentions/editor/suggestion.test.ts
@@ -424,24 +424,28 @@ describe("sortEditorSuggestionUsers", () => {
   const createUserMention = (
     id: string,
     label: string,
-    isParticipant?: boolean,
-    lastActivityAt?: number
+    options?: {
+      isParticipant?: boolean;
+      lastActivityAt?: number;
+      isProjectMember?: boolean;
+    }
   ): RichUserMentionInConversation => ({
     type: "user",
     id,
     label,
     pictureUrl: "",
     description: `${label}@example.com`,
-    isParticipant,
-    lastActivityAt,
+    isParticipant: options?.isParticipant,
+    isProjectMember: options?.isProjectMember,
+    lastActivityAt: options?.lastActivityAt,
   });
 
   describe("participant sorting", () => {
     it("should prioritize participants over non-participants", () => {
       const users = [
-        createUserMention("1", "Alice", false),
-        createUserMention("2", "Bob", true),
-        createUserMention("3", "Charlie", false),
+        createUserMention("1", "Alice", { isParticipant: false }),
+        createUserMention("2", "Bob", { isParticipant: true }),
+        createUserMention("3", "Charlie", { isParticipant: false }),
       ];
 
       const result = sortEditorSuggestionUsers(users);
@@ -450,12 +454,36 @@ describe("sortEditorSuggestionUsers", () => {
       expect(result[0].isParticipant).toBe(true);
     });
 
+    it("should prioritize project members over non-members", () => {
+      const users = [
+        createUserMention("1", "Alice", { isProjectMember: false }),
+        createUserMention("2", "Bob", { isProjectMember: true }),
+        createUserMention("3", "Charlie", { isProjectMember: false }),
+      ];
+
+      const result = sortEditorSuggestionUsers(users);
+
+      expect(result[0].label).toBe("Bob");
+      expect(result[0].isProjectMember).toBe(true);
+    });
+
+    it("should prioritize participants over project members", () => {
+      const users = [
+        createUserMention("1", "Alice", { isProjectMember: true }),
+        createUserMention("2", "Bob", { isParticipant: true }),
+        createUserMention("3", "Charlie", { isProjectMember: true }),
+      ];
+      const result = sortEditorSuggestionUsers(users);
+      expect(result[0].label).toBe("Bob");
+      expect(result[0].isParticipant).toBe(true);
+    });
+
     it("should keep all participants at the top", () => {
       const users = [
-        createUserMention("1", "Alice", false),
-        createUserMention("2", "Bob", true),
-        createUserMention("3", "Charlie", true),
-        createUserMention("4", "David", false),
+        createUserMention("1", "Alice", { isParticipant: false }),
+        createUserMention("2", "Bob", { isParticipant: true }),
+        createUserMention("3", "Charlie", { isParticipant: true }),
+        createUserMention("4", "David", { isParticipant: false }),
       ];
 
       const result = sortEditorSuggestionUsers(users);
@@ -468,10 +496,10 @@ describe("sortEditorSuggestionUsers", () => {
 
     it("should maintain non-participant order", () => {
       const users = [
-        createUserMention("1", "Alice", false),
-        createUserMention("2", "Bob", true),
-        createUserMention("3", "Charlie", false),
-        createUserMention("4", "David", false),
+        createUserMention("1", "Alice", { isParticipant: false }),
+        createUserMention("2", "Bob", { isParticipant: true }),
+        createUserMention("3", "Charlie", { isParticipant: false }),
+        createUserMention("4", "David", { isParticipant: false }),
       ];
 
       const result = sortEditorSuggestionUsers(users);
@@ -488,9 +516,18 @@ describe("sortEditorSuggestionUsers", () => {
   describe("lastActivityAt sorting", () => {
     it("should sort participants by lastActivityAt (most recent first)", () => {
       const users = [
-        createUserMention("1", "Alice", true, 1000),
-        createUserMention("2", "Bob", true, 3000),
-        createUserMention("3", "Charlie", true, 2000),
+        createUserMention("1", "Alice", {
+          isParticipant: true,
+          lastActivityAt: 1000,
+        }),
+        createUserMention("2", "Bob", {
+          isParticipant: true,
+          lastActivityAt: 3000,
+        }),
+        createUserMention("3", "Charlie", {
+          isParticipant: true,
+          lastActivityAt: 2000,
+        }),
       ];
 
       const result = sortEditorSuggestionUsers(users);
@@ -502,9 +539,18 @@ describe("sortEditorSuggestionUsers", () => {
 
     it("should handle undefined lastActivityAt as 0", () => {
       const users = [
-        createUserMention("1", "Alice", true, 1000),
-        createUserMention("2", "Bob", true, undefined),
-        createUserMention("3", "Charlie", true, 2000),
+        createUserMention("1", "Alice", {
+          isParticipant: true,
+          lastActivityAt: 1000,
+        }),
+        createUserMention("2", "Bob", {
+          isParticipant: true,
+          lastActivityAt: undefined,
+        }),
+        createUserMention("3", "Charlie", {
+          isParticipant: true,
+          lastActivityAt: 2000,
+        }),
       ];
 
       const result = sortEditorSuggestionUsers(users);
@@ -516,10 +562,22 @@ describe("sortEditorSuggestionUsers", () => {
 
     it("should handle mix of defined and undefined lastActivityAt", () => {
       const users = [
-        createUserMention("1", "Alice", true, undefined),
-        createUserMention("2", "Bob", true, 1000),
-        createUserMention("3", "Charlie", true, undefined),
-        createUserMention("4", "David", true, 500),
+        createUserMention("1", "Alice", {
+          isParticipant: true,
+          lastActivityAt: undefined,
+        }),
+        createUserMention("2", "Bob", {
+          isParticipant: true,
+          lastActivityAt: 1000,
+        }),
+        createUserMention("3", "Charlie", {
+          isParticipant: true,
+          lastActivityAt: undefined,
+        }),
+        createUserMention("4", "David", {
+          isParticipant: true,
+          lastActivityAt: 500,
+        }),
       ];
 
       const result = sortEditorSuggestionUsers(users);
@@ -534,9 +592,18 @@ describe("sortEditorSuggestionUsers", () => {
 
     it("should not sort non-participants by lastActivityAt", () => {
       const users = [
-        createUserMention("1", "Alice", false, 1000),
-        createUserMention("2", "Bob", false, 3000),
-        createUserMention("3", "Charlie", false, 2000),
+        createUserMention("1", "Alice", {
+          isParticipant: false,
+          lastActivityAt: 1000,
+        }),
+        createUserMention("2", "Bob", {
+          isParticipant: false,
+          lastActivityAt: 3000,
+        }),
+        createUserMention("3", "Charlie", {
+          isParticipant: false,
+          lastActivityAt: 2000,
+        }),
       ];
 
       const result = sortEditorSuggestionUsers(users);
@@ -556,7 +623,12 @@ describe("sortEditorSuggestionUsers", () => {
     });
 
     it("should handle array with single user", () => {
-      const users = [createUserMention("1", "Alice", true, 1000)];
+      const users = [
+        createUserMention("1", "Alice", {
+          isParticipant: true,
+          lastActivityAt: 1000,
+        }),
+      ];
 
       const result = sortEditorSuggestionUsers(users);
 
@@ -566,9 +638,18 @@ describe("sortEditorSuggestionUsers", () => {
 
     it("should handle all participants", () => {
       const users = [
-        createUserMention("1", "Alice", true, 1000),
-        createUserMention("2", "Bob", true, 2000),
-        createUserMention("3", "Charlie", true, 3000),
+        createUserMention("1", "Alice", {
+          isParticipant: true,
+          lastActivityAt: 1000,
+        }),
+        createUserMention("2", "Bob", {
+          isParticipant: true,
+          lastActivityAt: 2000,
+        }),
+        createUserMention("3", "Charlie", {
+          isParticipant: true,
+          lastActivityAt: 3000,
+        }),
       ];
 
       const result = sortEditorSuggestionUsers(users);
@@ -581,9 +662,9 @@ describe("sortEditorSuggestionUsers", () => {
 
     it("should handle all non-participants", () => {
       const users = [
-        createUserMention("1", "Alice", false),
-        createUserMention("2", "Bob", false),
-        createUserMention("3", "Charlie", false),
+        createUserMention("1", "Alice", { isParticipant: false }),
+        createUserMention("2", "Bob", { isParticipant: false }),
+        createUserMention("3", "Charlie", { isParticipant: false }),
       ];
 
       const result = sortEditorSuggestionUsers(users);
@@ -596,9 +677,12 @@ describe("sortEditorSuggestionUsers", () => {
 
     it("should handle participants with undefined isParticipant flag", () => {
       const users = [
-        createUserMention("1", "Alice", undefined),
-        createUserMention("2", "Bob", true, 1000),
-        createUserMention("3", "Charlie", undefined),
+        createUserMention("1", "Alice"),
+        createUserMention("2", "Bob", {
+          isParticipant: true,
+          lastActivityAt: 1000,
+        }),
+        createUserMention("3", "Charlie"),
       ];
 
       const result = sortEditorSuggestionUsers(users);
@@ -614,11 +698,20 @@ describe("sortEditorSuggestionUsers", () => {
   describe("combined real-world scenarios", () => {
     it("should handle typical conversation with multiple participants", () => {
       const users = [
-        createUserMention("1", "Alice", false), // Not in conversation
-        createUserMention("2", "Bob", true, 1000), // Participant, older activity
-        createUserMention("3", "Charlie", false), // Not in conversation
-        createUserMention("4", "David", true, 3000), // Participant, recent activity
-        createUserMention("5", "Eve", true, 2000), // Participant, middle activity
+        createUserMention("1", "Alice", { isParticipant: false }), // Not in conversation
+        createUserMention("2", "Bob", {
+          isParticipant: true,
+          lastActivityAt: 1000,
+        }), // Participant, older activity
+        createUserMention("3", "Charlie", { isParticipant: false }), // Not in conversation
+        createUserMention("4", "David", {
+          isParticipant: true,
+          lastActivityAt: 3000,
+        }), // Participant, recent activity
+        createUserMention("5", "Eve", {
+          isParticipant: true,
+          lastActivityAt: 2000,
+        }), // Participant, middle activity
       ];
 
       const result = sortEditorSuggestionUsers(users);
@@ -637,10 +730,13 @@ describe("sortEditorSuggestionUsers", () => {
 
     it("should handle conversation with one active participant", () => {
       const users = [
-        createUserMention("1", "Alice", false),
-        createUserMention("2", "Bob", true, Date.now()),
-        createUserMention("3", "Charlie", false),
-        createUserMention("4", "David", false),
+        createUserMention("1", "Alice", { isParticipant: false }),
+        createUserMention("2", "Bob", {
+          isParticipant: true,
+          lastActivityAt: Date.now(),
+        }),
+        createUserMention("3", "Charlie", { isParticipant: false }),
+        createUserMention("4", "David", { isParticipant: false }),
       ];
 
       const result = sortEditorSuggestionUsers(users);
@@ -657,9 +753,18 @@ describe("sortEditorSuggestionUsers", () => {
 
     it("should handle participants with same lastActivityAt", () => {
       const users = [
-        createUserMention("1", "Alice", true, 1000),
-        createUserMention("2", "Bob", true, 1000),
-        createUserMention("3", "Charlie", true, 1000),
+        createUserMention("1", "Alice", {
+          isParticipant: true,
+          lastActivityAt: 1000,
+        }),
+        createUserMention("2", "Bob", {
+          isParticipant: true,
+          lastActivityAt: 1000,
+        }),
+        createUserMention("3", "Charlie", {
+          isParticipant: true,
+          lastActivityAt: 1000,
+        }),
       ];
 
       const result = sortEditorSuggestionUsers(users);

--- a/front/lib/mentions/editor/suggestion.ts
+++ b/front/lib/mentions/editor/suggestion.ts
@@ -104,6 +104,17 @@ export function sortEditorSuggestionUsers(
     if (a.isParticipant && b.isParticipant) {
       return (b.lastActivityAt ?? 0) - (a.lastActivityAt ?? 0);
     }
+    // If project members, we move them up.
+    if (a.isProjectMember && !b.isProjectMember) {
+      return -1;
+    }
+    if (b.isProjectMember && !a.isProjectMember) {
+      return 1;
+    }
+    // If both are project members, we sort by last activity.
+    if (a.isProjectMember && b.isProjectMember) {
+      return (b.lastActivityAt ?? 0) - (a.lastActivityAt ?? 0);
+    }
     return 0;
   });
 }

--- a/front/lib/swr/mentions.tsx
+++ b/front/lib/swr/mentions.tsx
@@ -19,6 +19,7 @@ type MentionSuggestionsResponseBody = {
 export function useMentionSuggestions({
   workspaceId,
   conversationId,
+  spaceId,
   query = "",
   select,
   disabled = false,
@@ -26,6 +27,7 @@ export function useMentionSuggestions({
 }: {
   workspaceId: string;
   conversationId: string | null;
+  spaceId?: string;
   query?: string;
   select: {
     agents: boolean;
@@ -57,6 +59,10 @@ export function useMentionSuggestions({
   }
   if (includeCurrentUser) {
     searchParams.append("current", "true");
+  }
+
+  if (!conversationId && spaceId) {
+    searchParams.append("spaceId", spaceId);
   }
 
   const url =

--- a/front/pages/api/w/[wId]/assistant/conversations/[cId]/mentions/suggestions.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/[cId]/mentions/suggestions.ts
@@ -54,6 +54,7 @@ async function handler(
   }
 
   const { select: selectParam, current } = req.query;
+  const spaceId = conversationRes.space?.sId;
 
   const { query: queryParam } = req.query;
   const query = isString(queryParam) ? queryParam.trim().toLowerCase() : "";
@@ -76,6 +77,7 @@ async function handler(
     conversationId,
     select,
     current: current === "true",
+    spaceId,
   });
 
   return res.status(200).json({ suggestions });

--- a/front/pages/api/w/[wId]/assistant/mentions/suggestions.ts
+++ b/front/pages/api/w/[wId]/assistant/mentions/suggestions.ts
@@ -26,7 +26,9 @@ async function handler(
     });
   }
 
-  const { select: selectParam, current } = req.query;
+  const { select: selectParam, current, spaceId: spaceIdParam } = req.query;
+
+  const spaceId = isString(spaceIdParam) ? spaceIdParam : undefined;
 
   const { query: queryParam } = req.query;
   const query = isString(queryParam) ? queryParam.trim().toLowerCase() : "";
@@ -48,6 +50,7 @@ async function handler(
     query,
     select,
     current: current === "true",
+    spaceId,
   });
 
   return res.status(200).json({ suggestions });

--- a/front/types/assistant/mentions.ts
+++ b/front/types/assistant/mentions.ts
@@ -67,6 +67,7 @@ export interface RichUserMention extends BaseRichMention {
 
 export interface RichUserMentionInConversation extends RichUserMention {
   isParticipant?: boolean;
+  isProjectMember?: boolean;
   lastActivityAt?: number;
 }
 


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/6028
This PR prioritizes project members in the mention suggestions dropdown when in a conversation that belongs to a project.

- Updates the sorting logic to prioritize project members (after conversation participants but before other users)

## Tests

Manually

## Risks

Low - this only affects the ordering of mention suggestions and does not change any core functionality.

## Deploy Plan

