### PR TITLE
Migrate login-error page to client-side query params

### DIFF
--- a/front/pages/login-error.tsx
+++ b/front/pages/login-error.tsx
@@ -5,27 +5,9 @@ import {
   LoginIcon,
   Page,
 } from "@dust-tt/sparkle";
-import type { InferGetServerSidePropsType } from "next";
 import Link from "next/link";
 
-import { makeGetServerSidePropsRequirementsWrapper } from "@app/lib/iam/session";
-
-export const getServerSideProps = makeGetServerSidePropsRequirementsWrapper({
-  requireUserPrivilege: "none",
-})<{
-  domain: string | null;
-  reason: string | null;
-}>(async (context) => {
-  const reason =
-    typeof context.query.reason === "string" ? context.query.reason : null;
-
-  return {
-    props: {
-      domain: (context.query.domain as string) ?? null,
-      reason,
-    },
-  };
-});
+import { useSearchParam } from "@app/lib/platform";
 
 const defaultErrorMessageClassName = "text-base text-primary-100";
 
@@ -173,10 +155,9 @@ function getErrorMessage(domain: string | null, reason: string | null) {
   }
 }
 
-export default function LoginError({
-  domain,
-  reason,
-}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+export default function LoginError() {
+  const domain = useSearchParam("domain");
+  const reason = useSearchParam("reason");
   const errorMessage = getErrorMessage(domain, reason);
 
   return (


### PR DESCRIPTION
## Description

Remove getServerSideProps from login-error.tsx and use useSearchParam hooks for client-side query parameter extraction. This is part of the SPA migration effort.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 