### PR TITLE
[front] fix tool stakes for `agent_memory`

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
@@ -575,10 +575,10 @@
       }
     ],
     "toolsStakes": {
-      "compact_memory": "low",
-      "edit_entries": "low",
-      "erase_entries": "low",
-      "record_entries": "low",
+      "compact_memory": "never_ask",
+      "edit_entries": "never_ask",
+      "erase_entries": "never_ask",
+      "record_entries": "never_ask",
       "retrieve": "never_ask"
     }
   },

--- a/front/lib/api/actions/servers/agent_memory/metadata.ts
+++ b/front/lib/api/actions/servers/agent_memory/metadata.ts
@@ -34,7 +34,7 @@ export const AGENT_MEMORY_TOOLS_METADATA = createToolsRecord({
         .array(z.number())
         .describe("The indexes of the memory entries to erase."),
     },
-    stake: "low",
+    stake: "never_ask",
   },
   [AGENT_MEMORY_EDIT_TOOL_NAME]: {
     description:

--- a/front/lib/api/actions/servers/agent_memory/metadata.ts
+++ b/front/lib/api/actions/servers/agent_memory/metadata.ts
@@ -25,7 +25,7 @@ export const AGENT_MEMORY_TOOLS_METADATA = createToolsRecord({
         .array(z.string())
         .describe("The array of new memory entries to record."),
     },
-    stake: "low",
+    stake: "never_ask",
   },
   [AGENT_MEMORY_ERASE_TOOL_NAME]: {
     description: "Erase memory entries by indexes for the current user",
@@ -53,7 +53,7 @@ export const AGENT_MEMORY_TOOLS_METADATA = createToolsRecord({
         )
         .describe("The array of memory entries to edit."),
     },
-    stake: "low",
+    stake: "never_ask",
   },
   [AGENT_MEMORY_COMPACT_TOOL_NAME]: {
     description:
@@ -72,7 +72,7 @@ export const AGENT_MEMORY_TOOLS_METADATA = createToolsRecord({
         )
         .describe("The array of memory entries to compact/edit."),
     },
-    stake: "low",
+    stake: "never_ask",
   },
 });
 


### PR DESCRIPTION
## Description

- The tool stakes for the tools from the `agent_memory` MCP server were changed from `never_ask` to `low` in https://github.com/dust-tt/dust/pull/20620
- This PR adds them back to `never_ask`.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
