### PR TITLE
[front] Replace deep dive tool with skill on `@dust`

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -6,7 +6,6 @@ import {
   AGENT_ROUTER_SERVER_NAME,
   SUGGEST_AGENTS_TOOL_NAME,
 } from "@app/lib/api/actions/servers/agent_router/metadata";
-import { DEEP_DIVE_NAME } from "@app/lib/api/assistant/global_agents/configurations/dust/consts";
 import {
   getCompanyDataAction,
   getCompanyDataWarehousesAction,
@@ -464,27 +463,6 @@ function _getDustLikeGlobalAgent(
     })
   );
 
-  if (deepDiveMCPServerView) {
-    actions.push({
-      id: -1,
-      sId: agentId + "-deep-dive",
-      type: "mcp_server_configuration",
-      name: "deep_dive" satisfies InternalMCPServerNameType,
-      description: `Handoff the query to the @${DEEP_DIVE_NAME} agent`,
-      mcpServerViewId: deepDiveMCPServerView.sId,
-      internalMCPServerId: deepDiveMCPServerView.internalMCPServerId,
-      dataSources: null,
-      tables: null,
-      childAgentId: null,
-      additionalConfiguration: {},
-      timeFrame: null,
-      dustAppConfiguration: null,
-      jsonSchema: null,
-      secretName: null,
-      dustProject: null,
-    });
-  }
-
   if (hasAgentMemory) {
     actions.push({
       id: -1,
@@ -515,7 +493,7 @@ function _getDustLikeGlobalAgent(
     ...dustAgent,
     status: "active",
     actions,
-    skills: ["frames"],
+    skills: ["frames", "go-deep"],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
   };
 }

--- a/front/lib/api/assistant/global_agents/tools.ts
+++ b/front/lib/api/assistant/global_agents/tools.ts
@@ -29,12 +29,10 @@ export const MCP_SERVERS_FOR_GLOBAL_AGENTS: readonly AutoInternalMCPServerNameTy
     "web_search_&_browse",
     "search",
     "data_sources_file_system",
-    "interactive_content",
     "run_agent",
     "toolsets",
     "data_warehouses",
     "slideshow",
-    "deep_dive",
     "agent_memory",
   ] as const;
 


### PR DESCRIPTION
## Description

- This PR replaces the deep dive tool on the dust global agent with the Go deep skill.
- Previous behavior: handoff to the deep dive global agent.
- New behavior: dust can enable the skill and then go deep (e.g. has access to the dust-task and dust-planning sub agents + dsfs + data warehouse + web tools and has instructions that binds them all together)

## Tests

- Tested locally.

## Risk

- Medium. Non negligible change in behavior.

## Deploy Plan

- Deploy front.
