### PR TITLE
[front] - refactor(agent): `agents/` routes for SPA

### DIFF
--- a/front/pages/api/w/[wId]/mcp/views/index.ts
+++ b/front/pages/api/w/[wId]/mcp/views/index.ts
@@ -33,17 +33,17 @@ export type GetMCPServerViewsListResponseBody = {
 };
 
 // We don't allow to fetch "auto_hidden_builder".
-const isAllowedAvailability = (
+function isAllowedAvailability(
   availability: string
-): availability is MCPViewsRequestAvailabilityType => {
+): availability is MCPViewsRequestAvailabilityType {
   return availability === "manual" || availability === "auto";
-};
+}
 
 async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<GetMCPServerViewsListResponseBody>>,
   auth: Authenticator
-) {
+): Promise<void> {
   const { method } = req;
 
   switch (method) {
@@ -79,6 +79,10 @@ async function handler(
       }
 
       const query = r.data;
+
+      if (auth.isAdmin()) {
+        await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
+      }
 
       const serverViews = await concurrentExecutor(
         query.spaceIds,

--- a/front/pages/w/[wId]/builder/agents/[aId]/index.tsx
+++ b/front/pages/w/[wId]/builder/agents/[aId]/index.tsx
@@ -14,9 +14,7 @@ import { useAgentConfiguration } from "@app/lib/swr/assistants";
 
 export const getServerSideProps = appGetServerSideProps;
 
-interface EditAgentProps {}
-
-function EditAgent(_props: EditAgentProps) {
+function EditAgent() {
   const router = useAppRouter();
   const owner = useWorkspace();
   const { user, isAdmin } = useAuth();
@@ -33,17 +31,9 @@ function EditAgent(_props: EditAgentProps) {
 
   if (
     isAgentConfigurationError ||
-    (!isAgentConfigurationLoading && !agentConfiguration)
+    (!isAgentConfigurationLoading && !agentConfiguration) ||
+    (agentConfiguration && !agentConfiguration.canEdit && !isAdmin)
   ) {
-    void router.replace("/404");
-    return (
-      <div className="flex h-screen items-center justify-center">
-        <Spinner size="lg" />
-      </div>
-    );
-  }
-
-  if (agentConfiguration && !agentConfiguration.canEdit && !isAdmin) {
     void router.replace("/404");
     return (
       <div className="flex h-screen items-center justify-center">

--- a/front/pages/w/[wId]/builder/agents/[aId]/index.tsx
+++ b/front/pages/w/[wId]/builder/agents/[aId]/index.tsx
@@ -1,83 +1,65 @@
-import tracer from "dd-trace";
-import type { InferGetServerSidePropsType } from "next";
+import { Spinner } from "@dust-tt/sparkle";
 import Head from "next/head";
+import type { ReactElement } from "react";
 
 import AgentBuilder from "@app/components/agent_builder/AgentBuilder";
 import { AgentBuilderProvider } from "@app/components/agent_builder/AgentBuilderContext";
-import AppRootLayout from "@app/components/sparkle/AppRootLayout";
-import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
-import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
-import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
-import type {
-  LightAgentConfigurationType,
-  UserType,
-  WorkspaceType,
-} from "@app/types";
+import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
+import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
+import { appGetServerSideProps } from "@app/lib/auth/appServerSideProps";
+import type { AuthContextValue } from "@app/lib/auth/AuthContext";
+import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
+import { useAppRouter, useRequiredPathParam } from "@app/lib/platform";
+import { useAgentConfiguration } from "@app/lib/swr/assistants";
 
-export const getServerSideProps = withDefaultUserAuthRequirements<{
-  agentConfiguration: LightAgentConfigurationType;
-  owner: WorkspaceType;
-  user: UserType;
-  isAdmin: boolean;
-}>(async (context, auth) => {
-  return tracer.trace("getServerSideProps", async () => {
-    const owner = auth.workspace();
-    const plan = auth.plan();
-    const subscription = auth.subscription();
-    if (
-      !owner ||
-      !plan ||
-      !subscription ||
-      !auth.isUser() ||
-      !context.params?.aId
-    ) {
-      return {
-        notFound: true,
-      };
-    }
+export const getServerSideProps = appGetServerSideProps;
 
-    await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
+interface EditAgentProps {}
 
-    const [configuration] = await Promise.all([
-      getAgentConfiguration(auth, {
-        agentId: context.params?.aId as string,
-        variant: "light",
-      }),
-      MCPServerViewResource.ensureAllAutoToolsAreCreated(auth),
-    ]);
+function EditAgent(_props: EditAgentProps): JSX.Element {
+  const router = useAppRouter();
+  const owner = useWorkspace();
+  const { user, isAdmin } = useAuth();
+  const agentId = useRequiredPathParam("aId");
 
-    if (!configuration) {
-      return {
-        notFound: true,
-      };
-    }
-
-    if (!configuration.canEdit && !auth.isAdmin()) {
-      return {
-        notFound: true,
-      };
-    }
-
-    const user = auth.getNonNullableUser().toJSON();
-    const isAdmin = auth.isAdmin();
-
-    return {
-      props: {
-        agentConfiguration: configuration,
-        owner,
-        user,
-        isAdmin,
-      },
-    };
+  const {
+    agentConfiguration,
+    isAgentConfigurationLoading,
+    isAgentConfigurationError,
+  } = useAgentConfiguration({
+    workspaceId: owner.sId,
+    agentConfigurationId: agentId,
   });
-});
 
-export default function EditAgent({
-  agentConfiguration,
-  owner,
-  user,
-  isAdmin,
-}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  if (
+    isAgentConfigurationError ||
+    (!isAgentConfigurationLoading && !agentConfiguration)
+  ) {
+    void router.replace("/404");
+    return (
+      <div className="flex h-screen items-center justify-center">
+        <Spinner size="lg" />
+      </div>
+    );
+  }
+
+  if (agentConfiguration && !agentConfiguration.canEdit && !isAdmin) {
+    void router.replace("/404");
+    return (
+      <div className="flex h-screen items-center justify-center">
+        <Spinner size="lg" />
+      </div>
+    );
+  }
+
+  if (isAgentConfigurationLoading || !agentConfiguration) {
+    return (
+      <div className="flex h-screen items-center justify-center">
+        <Spinner size="lg" />
+      </div>
+    );
+  }
+
   if (agentConfiguration.scope === "global") {
     throw new Error("Cannot edit global agent");
   }
@@ -101,6 +83,15 @@ export default function EditAgent({
   );
 }
 
-EditAgent.getLayout = (page: React.ReactElement) => {
-  return <AppRootLayout>{page}</AppRootLayout>;
+const PageWithAuthLayout = EditAgent as AppPageWithLayout;
+
+PageWithAuthLayout.getLayout = (
+  page: ReactElement,
+  pageProps: AuthContextValue
+) => {
+  return (
+    <AppAuthContextLayout authContext={pageProps}>{page}</AppAuthContextLayout>
+  );
 };
+
+export default PageWithAuthLayout;

--- a/front/pages/w/[wId]/builder/agents/[aId]/index.tsx
+++ b/front/pages/w/[wId]/builder/agents/[aId]/index.tsx
@@ -16,7 +16,7 @@ export const getServerSideProps = appGetServerSideProps;
 
 interface EditAgentProps {}
 
-function EditAgent(_props: EditAgentProps): JSX.Element {
+function EditAgent(_props: EditAgentProps) {
   const router = useAppRouter();
   const owner = useWorkspace();
   const { user, isAdmin } = useAuth();

--- a/front/pages/w/[wId]/builder/agents/create.tsx
+++ b/front/pages/w/[wId]/builder/agents/create.tsx
@@ -35,7 +35,7 @@ export const getServerSideProps = appGetServerSideProps;
 
 interface CreateAgentProps {}
 
-function CreateAgent(_props: CreateAgentProps): JSX.Element {
+function CreateAgent(_props: CreateAgentProps) {
   const router = useAppRouter();
   const owner = useWorkspace();
   const { subscription } = useAuth();

--- a/front/pages/w/[wId]/builder/agents/create.tsx
+++ b/front/pages/w/[wId]/builder/agents/create.tsx
@@ -33,9 +33,7 @@ import { isTemplateTagCodeArray, TEMPLATES_TAGS_CONFIG } from "@app/types";
 
 export const getServerSideProps = appGetServerSideProps;
 
-interface CreateAgentProps {}
-
-function CreateAgent(_props: CreateAgentProps) {
+function CreateAgent() {
   const router = useAppRouter();
   const owner = useWorkspace();
   const { subscription } = useAuth();

--- a/front/pages/w/[wId]/builder/agents/index.tsx
+++ b/front/pages/w/[wId]/builder/agents/index.tsx
@@ -84,7 +84,7 @@ function isValidTab(tab: string): tab is AssistantManagerTabsType {
 
 interface WorkspaceAssistantsProps {}
 
-function WorkspaceAssistants(_props: WorkspaceAssistantsProps): JSX.Element {
+function WorkspaceAssistants(_props: WorkspaceAssistantsProps) {
   const router = useAppRouter();
   const owner = useWorkspace();
   const { subscription, user, isBuilder } = useAuth();

--- a/front/pages/w/[wId]/builder/agents/index.tsx
+++ b/front/pages/w/[wId]/builder/agents/index.tsx
@@ -12,8 +12,8 @@ import {
   TabsList,
   TabsTrigger,
 } from "@dust-tt/sparkle";
-import type { InferGetServerSidePropsType } from "next";
 import Head from "next/head";
+import type { ReactElement } from "react";
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import { AgentEditBar } from "@app/components/assistant/AgentEditBar";
@@ -23,13 +23,15 @@ import { AgentDetails } from "@app/components/assistant/details/AgentDetails";
 import { AssistantsTable } from "@app/components/assistant/manager/AssistantsTable";
 import { TagsFilterMenu } from "@app/components/assistant/TagsFilterMenu";
 import { EmptyCallToAction } from "@app/components/EmptyCallToAction";
-import AppRootLayout from "@app/components/sparkle/AppRootLayout";
+import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
 import { AppWideModeLayout } from "@app/components/sparkle/AppWideModeLayout";
 import { useHashParam } from "@app/hooks/useHashParams";
-import { isRestrictedFromAgentCreation } from "@app/lib/auth";
+import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
+import { appGetServerSideProps } from "@app/lib/auth/appServerSideProps";
+import type { AuthContextValue } from "@app/lib/auth/AuthContext";
+import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
-import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
-import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
+import { useAppRouter } from "@app/lib/platform";
 import { useAgentConfigurations } from "@app/lib/swr/assistants";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import {
@@ -37,13 +39,8 @@ import {
   getAgentSearchString,
   subFilter,
 } from "@app/lib/utils";
-import type {
-  LightAgentConfigurationType,
-  SubscriptionType,
-  UserType,
-  WorkspaceType,
-} from "@app/types";
-import { isAdmin, isBuilder } from "@app/types";
+import type { LightAgentConfigurationType } from "@app/types";
+import { isAdmin } from "@app/types";
 import type { TagType } from "@app/types/tag";
 
 export const AGENT_MANAGER_TABS = [
@@ -79,49 +76,18 @@ export const AGENT_MANAGER_TABS = [
 export type AssistantManagerTabsType =
   (typeof AGENT_MANAGER_TABS)[number]["id"];
 
-export const getServerSideProps = withDefaultUserAuthRequirements<{
-  owner: WorkspaceType;
-  subscription: SubscriptionType;
-  user: UserType;
-}>(async (context, auth) => {
-  const owner = auth.workspace();
-  const subscription = auth.subscription();
-
-  if (!owner || !subscription) {
-    return {
-      notFound: true,
-    };
-  }
-
-  if (await isRestrictedFromAgentCreation(owner)) {
-    return {
-      notFound: true,
-    };
-  }
-
-  await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
-  const user = auth.getNonNullableUser();
-
-  return {
-    props: {
-      owner,
-      subscription,
-      user: user.toJSON(),
-    },
-  };
-});
+export const getServerSideProps = appGetServerSideProps;
 
 function isValidTab(tab: string): tab is AssistantManagerTabsType {
-  return AGENT_MANAGER_TABS.map((tab) => tab.id).includes(
-    tab as AssistantManagerTabsType
-  );
+  return AGENT_MANAGER_TABS.some((tabItem) => tabItem.id === tab);
 }
 
-export default function WorkspaceAssistants({
-  owner,
-  subscription,
-  user,
-}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+interface WorkspaceAssistantsProps {}
+
+function WorkspaceAssistants(_props: WorkspaceAssistantsProps): JSX.Element {
+  const router = useAppRouter();
+  const owner = useWorkspace();
+  const { subscription, user, isBuilder } = useAuth();
   const [assistantSearch, setAssistantSearch] = useState("");
   const [showDisabledFreeWorkspacePopup, setShowDisabledFreeWorkspacePopup] =
     useState<string | null>(null);
@@ -130,21 +96,23 @@ export default function WorkspaceAssistants({
   const [isBatchEdit, setIsBatchEdit] = useState(false);
   const [selection, setSelection] = useState<string[]>([]);
 
-  const { featureFlags } = useFeatureFlags({
+  const { featureFlags, isFeatureFlagsLoading } = useFeatureFlags({
     workspaceId: owner.sId,
   });
 
   const isRestrictedFromAgentCreation =
-    featureFlags.includes("disallow_agent_creation_to_users") &&
-    !isBuilder(owner);
+    featureFlags.includes("disallow_agent_creation_to_users") && !isBuilder;
+  const shouldDisableAgentFetching =
+    isFeatureFlagsLoading || isRestrictedFromAgentCreation;
+  const isSearchActive = assistantSearch.trim() !== "";
 
   const activeTab = useMemo(() => {
-    if (assistantSearch.trim() !== "") {
+    if (isSearchActive) {
       return "search";
     }
 
     return selectedTab && isValidTab(selectedTab) ? selectedTab : "all_custom";
-  }, [assistantSearch, selectedTab]);
+  }, [isSearchActive, selectedTab]);
 
   // only fetch the agents that are relevant to the current scope, except when
   // user searches: search across all agents
@@ -156,6 +124,7 @@ export default function WorkspaceAssistants({
     workspaceId: owner.sId,
     agentsGetView: "manage",
     includes: ["authors", "usage", "feedbacks", "editors"],
+    disabled: shouldDisableAgentFetching,
   });
 
   const selectedAgents = agentConfigurations.filter((a) =>
@@ -169,7 +138,7 @@ export default function WorkspaceAssistants({
     workspaceId: owner.sId,
     agentsGetView: "archived",
     includes: ["usage", "feedbacks", "editors"],
-    disabled: selectedTab !== "archived",
+    disabled: shouldDisableAgentFetching || selectedTab !== "archived",
   });
 
   const agentsByTab = useMemo(() => {
@@ -264,10 +233,10 @@ export default function WorkspaceAssistants({
       throw new Error("Unexpected: Search tab not found");
     }
 
-    return assistantSearch.trim() !== ""
+    return isSearchActive
       ? [searchTab]
       : AGENT_MANAGER_TABS.filter((tab) => tab.id !== "search");
-  }, [assistantSearch]);
+  }, [isSearchActive]);
 
   const searchBarRef = useRef<HTMLInputElement>(null);
 
@@ -275,10 +244,12 @@ export default function WorkspaceAssistants({
     if (searchBarRef.current) {
       searchBarRef.current.focus();
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [searchBarRef.current]);
+  }, []);
 
   useEffect(() => {
+    if (isFeatureFlagsLoading || isRestrictedFromAgentCreation) {
+      return;
+    }
     const handleKeyPress = (event: KeyboardEvent) => {
       if (event.key === "/") {
         event.preventDefault();
@@ -292,7 +263,24 @@ export default function WorkspaceAssistants({
     return () => {
       window.removeEventListener("keydown", handleKeyPress);
     };
-  }, []);
+  }, [isFeatureFlagsLoading, isRestrictedFromAgentCreation]);
+
+  if (isFeatureFlagsLoading) {
+    return (
+      <div className="flex h-screen items-center justify-center">
+        <Spinner size="lg" />
+      </div>
+    );
+  }
+
+  if (isRestrictedFromAgentCreation) {
+    void router.replace("/404");
+    return (
+      <div className="flex h-screen items-center justify-center">
+        <Spinner size="lg" />
+      </div>
+    );
+  }
 
   return (
     <AppWideModeLayout
@@ -439,6 +427,15 @@ export default function WorkspaceAssistants({
   );
 }
 
-WorkspaceAssistants.getLayout = (page: React.ReactElement) => {
-  return <AppRootLayout>{page}</AppRootLayout>;
+const PageWithAuthLayout = WorkspaceAssistants as AppPageWithLayout;
+
+PageWithAuthLayout.getLayout = (
+  page: ReactElement,
+  pageProps: AuthContextValue
+) => {
+  return (
+    <AppAuthContextLayout authContext={pageProps}>{page}</AppAuthContextLayout>
+  );
 };
+
+export default PageWithAuthLayout;

--- a/front/pages/w/[wId]/builder/agents/index.tsx
+++ b/front/pages/w/[wId]/builder/agents/index.tsx
@@ -82,9 +82,7 @@ function isValidTab(tab: string): tab is AssistantManagerTabsType {
   return AGENT_MANAGER_TABS.some((tabItem) => tabItem.id === tab);
 }
 
-interface WorkspaceAssistantsProps {}
-
-function WorkspaceAssistants(_props: WorkspaceAssistantsProps) {
+function WorkspaceAssistants() {
   const router = useAppRouter();
   const owner = useWorkspace();
   const { subscription, user, isBuilder } = useAuth();

--- a/front/pages/w/[wId]/builder/agents/new.tsx
+++ b/front/pages/w/[wId]/builder/agents/new.tsx
@@ -93,22 +93,12 @@ function CreateAgent() {
   }
 
   if (
-    duplicateAgentId &&
-    (isAgentConfigurationError ||
-      (!isAgentConfigurationLoading && !agentConfiguration))
-  ) {
-    void router.replace("/404");
-    return (
-      <div className="flex h-screen items-center justify-center">
-        <Spinner size="lg" />
-      </div>
-    );
-  }
-
-  if (
-    templateId &&
-    (isAssistantTemplateError ||
-      (!isAssistantTemplateLoading && !assistantTemplate))
+    (duplicateAgentId &&
+      (isAgentConfigurationError ||
+        (!isAgentConfigurationLoading && !agentConfiguration))) ||
+    (templateId &&
+      (isAssistantTemplateError ||
+        (!isAssistantTemplateLoading && !assistantTemplate)))
   ) {
     void router.replace("/404");
     return (

--- a/front/pages/w/[wId]/builder/agents/new.tsx
+++ b/front/pages/w/[wId]/builder/agents/new.tsx
@@ -29,9 +29,7 @@ function isBuilderFlow(value: string): value is BuilderFlow {
 
 export const getServerSideProps = appGetServerSideProps;
 
-interface CreateAgentProps {}
-
-function CreateAgent(_props: CreateAgentProps) {
+function CreateAgent() {
   const router = useAppRouter();
   const owner = useWorkspace();
   const { user, isAdmin, isBuilder } = useAuth();

--- a/front/pages/w/[wId]/builder/agents/new.tsx
+++ b/front/pages/w/[wId]/builder/agents/new.tsx
@@ -1,135 +1,135 @@
-import type { InferGetServerSidePropsType } from "next";
+import { Spinner } from "@dust-tt/sparkle";
 import Head from "next/head";
-import type { ParsedUrlQuery } from "querystring";
+import type { ReactElement } from "react";
 
 import AgentBuilder from "@app/components/agent_builder/AgentBuilder";
 import { AgentBuilderProvider } from "@app/components/agent_builder/AgentBuilderContext";
 import type { BuilderFlow } from "@app/components/agent_builder/types";
 import { BUILDER_FLOWS } from "@app/components/agent_builder/types";
-import AppRootLayout from "@app/components/sparkle/AppRootLayout";
+import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
 import { throwIfInvalidAgentConfiguration } from "@app/lib/actions/types/guards";
-import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
-import config from "@app/lib/api/config";
-import { isRestrictedFromAgentCreation } from "@app/lib/auth";
-import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
-import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
-import { useAssistantTemplate } from "@app/lib/swr/assistants";
+import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
+import { appGetServerSideProps } from "@app/lib/auth/appServerSideProps";
+import type { AuthContextValue } from "@app/lib/auth/AuthContext";
+import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
+import { useAppRouter, useSearchParam } from "@app/lib/platform";
+import {
+  useAgentConfiguration,
+  useAssistantTemplate,
+} from "@app/lib/swr/assistants";
+import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import type {
+  AgentConfigurationScope,
   AgentConfigurationType,
-  PlanType,
-  SubscriptionType,
-  TemplateAgentConfigurationType,
-  UserType,
-  WorkspaceType,
 } from "@app/types";
 
-function getDuplicateAndTemplateIdFromQuery(query: ParsedUrlQuery) {
-  const { duplicate, templateId } = query;
-
-  return {
-    duplicate: duplicate && typeof duplicate === "string" ? duplicate : null,
-    templateId:
-      templateId && typeof templateId === "string" ? templateId : null,
-  };
+function isBuilderFlow(value: string): value is BuilderFlow {
+  return BUILDER_FLOWS.some((flow) => flow === value);
 }
 
-export const getServerSideProps = withDefaultUserAuthRequirements<{
-  owner: WorkspaceType;
-  user: UserType;
-  isAdmin: boolean;
-  subscription: SubscriptionType;
-  plan: PlanType;
-  agentConfiguration:
-    | AgentConfigurationType
-    | TemplateAgentConfigurationType
-    | null;
-  flow: BuilderFlow;
-  baseUrl: string;
-  templateId: string | null;
-  duplicateAgentId: string | null;
-}>(async (context, auth) => {
-  const owner = auth.workspace();
-  const plan = auth.plan();
-  const subscription = auth.subscription();
-  if (!owner || !plan || !auth.isUser() || !subscription) {
-    return {
-      notFound: true,
-    };
+export const getServerSideProps = appGetServerSideProps;
+
+interface CreateAgentProps {}
+
+function CreateAgent(_props: CreateAgentProps): JSX.Element {
+  const router = useAppRouter();
+  const owner = useWorkspace();
+  const { user, isAdmin, isBuilder } = useAuth();
+
+  const flowParam = useSearchParam("flow");
+  const flow: BuilderFlow =
+    flowParam && isBuilderFlow(flowParam) ? flowParam : "personal_assistants";
+
+  const duplicateAgentId = useSearchParam("duplicate");
+  const templateId = useSearchParam("templateId");
+
+  const { featureFlags, isFeatureFlagsLoading } = useFeatureFlags({
+    workspaceId: owner.sId,
+  });
+  const isRestrictedFromAgentCreation =
+    featureFlags.includes("disallow_agent_creation_to_users") && !isBuilder;
+
+  const {
+    agentConfiguration,
+    isAgentConfigurationLoading,
+    isAgentConfigurationError,
+  } = useAgentConfiguration({
+    workspaceId: owner.sId,
+    agentConfigurationId: duplicateAgentId,
+    disabled: !duplicateAgentId,
+  });
+
+  const {
+    assistantTemplate,
+    isAssistantTemplateLoading,
+    isAssistantTemplateError,
+  } = useAssistantTemplate({ templateId });
+
+  let duplicateConfiguration: AgentConfigurationType | null = null;
+  if (agentConfiguration && duplicateAgentId) {
+    const scope: AgentConfigurationScope =
+      flow === "personal_assistants" ? "hidden" : "visible";
+    duplicateConfiguration =
+      agentConfiguration.scope === scope
+        ? agentConfiguration
+        : { ...agentConfiguration, scope };
   }
 
-  if (await isRestrictedFromAgentCreation(owner)) {
-    return {
-      notFound: true,
-    };
+  const isDuplicateLoading = !!duplicateAgentId && isAgentConfigurationLoading;
+
+  if (isFeatureFlagsLoading) {
+    return (
+      <div className="flex h-screen items-center justify-center">
+        <Spinner size="lg" />
+      </div>
+    );
   }
 
-  const flow: BuilderFlow = BUILDER_FLOWS.includes(
-    context.query.flow as BuilderFlow
-  )
-    ? (context.query.flow as BuilderFlow)
-    : "personal_assistants";
-
-  let configuration:
-    | AgentConfigurationType
-    | TemplateAgentConfigurationType
-    | null = null;
-  const { duplicate, templateId } = getDuplicateAndTemplateIdFromQuery(
-    context.query
-  );
-
-  await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
-
-  if (duplicate) {
-    configuration = await getAgentConfiguration(auth, {
-      agentId: duplicate,
-      variant: "full",
-    });
-
-    if (!configuration) {
-      return {
-        notFound: true,
-      };
-    }
-    // We reset the scope according to the current flow. This ensures that cloning a workspace
-    // agent with flow `personal_assistants` will initialize the agent as private.
-    configuration.scope = flow === "personal_assistants" ? "hidden" : "visible";
+  if (isRestrictedFromAgentCreation) {
+    void router.replace("/404");
+    return (
+      <div className="flex h-screen items-center justify-center">
+        <Spinner size="lg" />
+      </div>
+    );
   }
 
-  const user = auth.getNonNullableUser().toJSON();
-  const isAdmin = auth.isAdmin();
-
-  return {
-    props: {
-      agentConfiguration: configuration,
-      baseUrl: config.getClientFacingUrl(),
-      flow,
-      owner,
-      plan,
-      subscription,
-      templateId,
-      duplicateAgentId: duplicate,
-      user,
-      isAdmin,
-    },
-  };
-});
-
-export default function CreateAgent({
-  agentConfiguration,
-  owner,
-  user,
-  isAdmin,
-  templateId,
-  duplicateAgentId,
-}: InferGetServerSidePropsType<typeof getServerSideProps>) {
-  const { assistantTemplate } = useAssistantTemplate({ templateId });
-
-  if (agentConfiguration) {
-    throwIfInvalidAgentConfiguration(agentConfiguration);
+  if (
+    duplicateAgentId &&
+    (isAgentConfigurationError ||
+      (!isAgentConfigurationLoading && !agentConfiguration))
+  ) {
+    void router.replace("/404");
+    return (
+      <div className="flex h-screen items-center justify-center">
+        <Spinner size="lg" />
+      </div>
+    );
   }
 
-  if (templateId && !assistantTemplate) {
-    return null;
+  if (
+    templateId &&
+    (isAssistantTemplateError ||
+      (!isAssistantTemplateLoading && !assistantTemplate))
+  ) {
+    void router.replace("/404");
+    return (
+      <div className="flex h-screen items-center justify-center">
+        <Spinner size="lg" />
+      </div>
+    );
+  }
+
+  if (isDuplicateLoading || (templateId && isAssistantTemplateLoading)) {
+    return (
+      <div className="flex h-screen items-center justify-center">
+        <Spinner size="lg" />
+      </div>
+    );
+  }
+
+  if (duplicateConfiguration) {
+    throwIfInvalidAgentConfiguration(duplicateConfiguration);
   }
 
   return (
@@ -143,17 +143,22 @@ export default function CreateAgent({
         <title>Dust - New Agent</title>
       </Head>
       <AgentBuilder
-        agentConfiguration={
-          agentConfiguration && "sId" in agentConfiguration
-            ? agentConfiguration
-            : undefined
-        }
+        agentConfiguration={duplicateConfiguration ?? undefined}
         duplicateAgentId={duplicateAgentId}
       />
     </AgentBuilderProvider>
   );
 }
 
-CreateAgent.getLayout = (page: React.ReactElement) => {
-  return <AppRootLayout>{page}</AppRootLayout>;
+const PageWithAuthLayout = CreateAgent as AppPageWithLayout;
+
+PageWithAuthLayout.getLayout = (
+  page: ReactElement,
+  pageProps: AuthContextValue
+) => {
+  return (
+    <AppAuthContextLayout authContext={pageProps}>{page}</AppAuthContextLayout>
+  );
 };
+
+export default PageWithAuthLayout;

--- a/front/pages/w/[wId]/builder/agents/new.tsx
+++ b/front/pages/w/[wId]/builder/agents/new.tsx
@@ -31,7 +31,7 @@ export const getServerSideProps = appGetServerSideProps;
 
 interface CreateAgentProps {}
 
-function CreateAgent(_props: CreateAgentProps): JSX.Element {
+function CreateAgent(_props: CreateAgentProps) {
   const router = useAppRouter();
   const owner = useWorkspace();
   const { user, isAdmin, isBuilder } = useAuth();


### PR DESCRIPTION
## Description

This PR refactors the `agents/` routes to follow the SPA migration pattern established in recent PRs. The main changes include:

- Replaced `getServerSideProps` with `appGetServerSideProps` for thin server-side authentication
- Migrated to client-side data fetching using `useAuth()`, `useWorkspace()`, `useAgentConfiguration()`, and `useAssistantTemplate()` hooks
- Replaced `AppRootLayout` with `AppAuthContextLayout` and the `AppPageWithLayout` pattern
- Added a safety check in the MCP views API endpoint to ensure all auto tools are created for admin users before fetching views

**Refactored pages:**
- `agents/[aId]/index.tsx` - agent editing page
- `agents/create.tsx` - agent template selection page  
- `agents/new.tsx` - agent creation/duplication page
- `agents/index.tsx` - agent management page

## Risk

The changes introduce client-side loading states and redirects which could cause brief loading spinners before redirecting users. The MCP auto tools creation is now called for admin users on every MCP views fetch, which could add latency.

## Tests

- [x] Locally
- [ ] Front-edge

## Deploy Plan

Deploy front