### PR TITLE
fix(projects): better display for generated summary

### DIFF
--- a/front/components/assistant/conversation/space/conversations/SpaceJournalEntry.tsx
+++ b/front/components/assistant/conversation/space/conversations/SpaceJournalEntry.tsx
@@ -104,7 +104,8 @@ export function SpaceJournalEntry({ owner, space }: SpaceJournalEntryProps) {
         title="Journal Entry"
         icon={BookOpenIcon}
         className="[&>div]:!items-start"
-        action={
+      >
+        <div className="flex flex-col py-2 ">
           <div className="flex items-center gap-2">
             <Tooltip
               trigger={<Chip color="golden" size="xs" label={formattedDate} />}
@@ -118,25 +119,25 @@ export function SpaceJournalEntry({ owner, space }: SpaceJournalEntryProps) {
               onClick={handleGenerate}
             />
           </div>
-        }
-      >
-        {isLongContent ? (
-          <Collapsible>
-            <div>
-              <Markdown content={previewContent} />
-              <CollapsibleTrigger
-                label="Show more"
-                variant="secondary"
-                className="mt-2"
-              />
-            </div>
-            <CollapsibleContent className="mt-2">
-              <Markdown content={remainingContent} />
-            </CollapsibleContent>
-          </Collapsible>
-        ) : (
-          <Markdown content={latestJournalEntry.journalEntry} />
-        )}
+
+          {isLongContent ? (
+            <Collapsible>
+              <div>
+                <Markdown content={previewContent} />
+                <CollapsibleTrigger
+                  label="Show more"
+                  variant="secondary"
+                  className="mt-2"
+                />
+              </div>
+              <CollapsibleContent className="mt-2">
+                <Markdown content={remainingContent} />
+              </CollapsibleContent>
+            </Collapsible>
+          ) : (
+            <Markdown content={latestJournalEntry.journalEntry} />
+          )}
+        </div>
       </ContentMessage>
     </Page.Vertical>
   );


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

This PR changes the display of generated summaries, they're currently hard to digest because the take only 2/3 of the content message, and are unusable on phone

before/after

<img width="1608" height="1045" alt="Capture d’écran 2026-02-02 à 09 52 48" src="https://github.com/user-attachments/assets/187fa473-78cc-4fa5-a7d8-8e36e54c2c20" />
<img width="1608" height="1045" alt="Capture d’écran 2026-02-02 à 09 52 10" src="https://github.com/user-attachments/assets/f08d7526-5237-4ee3-8302-08ec8f959ec6" />

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

by ahnd

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

 deploy front