### PR TITLE
[front] link color in programmatic usage page

### DIFF
--- a/front/components/pages/workspace/developers/CreditsUsagePage.tsx
+++ b/front/components/pages/workspace/developers/CreditsUsagePage.tsx
@@ -4,6 +4,7 @@ import {
   cn,
   ContentMessage,
   ExclamationCircleIcon,
+  Hoverable,
   Page,
 } from "@dust-tt/sparkle";
 import { lazy, Suspense, useMemo, useState } from "react";
@@ -362,9 +363,9 @@ export function CreditsUsagePage() {
         paygUsage={
           isEnterprise
             ? {
-                consumed: creditsByType.payg.consumed,
-                total: creditsByType.payg.total,
-              }
+              consumed: creditsByType.payg.consumed,
+              total: creditsByType.payg.total,
+            }
             : null
         }
       />
@@ -379,21 +380,21 @@ export function CreditsUsagePage() {
                 Monitor usage and credits for programmatic usage (API keys,
                 automated workflows, etc.). Usage cost is based on token
                 consumption, according to our{" "}
-                <a
+                <Hoverable
                   href="/home/api-pricing"
                   target="_blank"
-                  className="text-primary underline hover:text-primary-dark"
+                  variant="primary"
                 >
                   pricing page
-                </a>
+                </Hoverable>
                 . Learn more in the{" "}
-                <a
+                <Hoverable
                   href="https://docs.dust.tt/docs/programmatic-usage"
                   target="_blank"
-                  className="text-primary underline hover:text-primary-dark"
+                  variant="primary"
                 >
                   programmatic usage documentation
-                </a>
+                </Hoverable>
                 .
               </p>
             </div>

--- a/front/components/pages/workspace/developers/CreditsUsagePage.tsx
+++ b/front/components/pages/workspace/developers/CreditsUsagePage.tsx
@@ -363,9 +363,9 @@ export function CreditsUsagePage() {
         paygUsage={
           isEnterprise
             ? {
-              consumed: creditsByType.payg.consumed,
-              total: creditsByType.payg.total,
-            }
+                consumed: creditsByType.payg.consumed,
+                total: creditsByType.payg.total,
+              }
             : null
         }
       />


### PR DESCRIPTION
## Description
This PR is to fix the link color in dark theme for programmatic usage page 

before:
<img width="1820" height="278" alt="CleanShot 2026-02-02 at 10 39 55@2x" src="https://github.com/user-attachments/assets/a30dd232-a535-43dc-bfb5-76ee9a6f2a02" />


after:
<img width="1736" height="304" alt="CleanShot 2026-02-02 at 10 36 56@2x" src="https://github.com/user-attachments/assets/abb0ded6-f96e-484c-a6c1-6e45d8f5147f" />


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
