### PR TITLE
fix(oauth): atlassian grace handle when no refresh

### DIFF
--- a/core/src/oauth/providers/confluence.rs
+++ b/core/src/oauth/providers/confluence.rs
@@ -143,11 +143,17 @@ impl Provider for ConfluenceConnectionProvider {
             },
             _ => Err(anyhow!("Missing `expires_in` in response from Confluence"))?,
         };
-        let refresh_token = match raw_json["refresh_token"].as_str() {
-            Some(token) => token,
-            None => Err(anyhow!(
-                "Missing `refresh_token` in response from Confluence"
-            ))?,
+        // Use new refresh token if provided, otherwise keep the existing one.
+        // Atlassian sometimes doesn't return a new refresh token in the response.
+        let final_refresh_token = match raw_json["refresh_token"].as_str() {
+            Some(token) => token.to_string(),
+            None => {
+                info!(
+                    connection_id = connection.connection_id(),
+                    "No refresh_token in Confluence response, keeping existing token"
+                );
+                refresh_token
+            }
         };
 
         Ok(RefreshResult {
@@ -155,7 +161,7 @@ impl Provider for ConfluenceConnectionProvider {
             access_token_expiry: Some(
                 utils::now() + (expires_in - PROVIDER_TIMEOUT_SECONDS) * 1000,
             ),
-            refresh_token: Some(refresh_token.to_string()),
+            refresh_token: Some(final_refresh_token),
             raw_json,
         })
     }

--- a/core/src/oauth/providers/jira.rs
+++ b/core/src/oauth/providers/jira.rs
@@ -136,9 +136,17 @@ impl Provider for JiraConnectionProvider {
             },
             _ => Err(anyhow!("Missing `expires_in` in response from JIRA"))?,
         };
-        let refresh_token = match raw_json["refresh_token"].as_str() {
-            Some(token) => token,
-            None => Err(anyhow!("Missing `refresh_token` in response from JIRA"))?,
+        // Use new refresh token if provided, otherwise keep the existing one.
+        // Atlassian sometimes doesn't return a new refresh token in the response.
+        let final_refresh_token = match raw_json["refresh_token"].as_str() {
+            Some(token) => token.to_string(),
+            None => {
+                info!(
+                    connection_id = connection.connection_id(),
+                    "No refresh_token in JIRA response, keeping existing token"
+                );
+                refresh_token
+            }
         };
 
         Ok(RefreshResult {
@@ -146,7 +154,7 @@ impl Provider for JiraConnectionProvider {
             access_token_expiry: Some(
                 utils::now() + (expires_in - PROVIDER_TIMEOUT_SECONDS) * 1000,
             ),
-            refresh_token: Some(refresh_token.to_string()),
+            refresh_token: Some(final_refresh_token),
             raw_json,
         })
     }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Contributes to https://github.com/dust-tt/tasks/issues/6185
It seems like occasionally atlassian's oauth endpoint returns responses without the refresh_token property, breaking the token chain. If you don't handle this gracefully, you lose the ability to refresh.

This PR adds graceful missing refresh token:                                                                                                                                                 
  - jira.rs: Keep existing token if new one not returned + info log                                                                                                                              
  - confluence.rs: Same                                                                                                                                                                          
  - confluence_tools.rs: Same  

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

No tested

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy oauth