### PR TITLE
fix(oauth): bump atlassian timeout

### DIFF
--- a/core/src/oauth/connection.rs
+++ b/core/src/oauth/connection.rs
@@ -38,6 +38,8 @@ use super::{credential::Credential, providers::utils::ProviderHttpRequestError};
 // is the maximum time the lock will be held.
 static REDIS_LOCK_TTL_SECONDS: u64 = 20;
 // Default timeout for provider token operations. Some providers may override this.
+// To ensure we don't write without holding the lock providers must comply to this timeout when
+// operating on tokens.
 pub static PROVIDER_TIMEOUT_SECONDS: u64 = 10;
 
 /// Returns the timeout in seconds for a specific provider's token operations.

--- a/core/src/oauth/connection.rs
+++ b/core/src/oauth/connection.rs
@@ -34,12 +34,22 @@ use tracing::{error, info};
 
 use super::{credential::Credential, providers::utils::ProviderHttpRequestError};
 
-// We hold the lock for at most 15s. In case of panic preventing the lock from being released, this
+// We hold the lock for at most 20s. In case of panic preventing the lock from being released, this
 // is the maximum time the lock will be held.
-static REDIS_LOCK_TTL_SECONDS: u64 = 15;
-// To ensure we don't write without holding the lock providers must comply to this timeout when
-// operating on tokens.
+static REDIS_LOCK_TTL_SECONDS: u64 = 20;
+// Default timeout for provider token operations. Some providers may override this.
 pub static PROVIDER_TIMEOUT_SECONDS: u64 = 10;
+
+/// Returns the timeout in seconds for a specific provider's token operations.
+/// Some providers (e.g., Atlassian) have slower auth servers and need longer timeouts.
+pub fn provider_timeout_seconds(provider: ConnectionProvider) -> u64 {
+    match provider {
+        ConnectionProvider::Jira
+        | ConnectionProvider::Confluence
+        | ConnectionProvider::ConfluenceTools => 15,
+        _ => PROVIDER_TIMEOUT_SECONDS,
+    }
+}
 // Buffer of time in ms before the expiry of an access token within which we will attempt to
 // refresh it.
 pub static ACCESS_TOKEN_REFRESH_BUFFER_MILLIS: u64 = 10 * 60 * 1000;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Contributes to https://github.com/dust-tt/tasks/issues/6185

According to [logs](https://app.datadoghq.eu/logs?query=%22Failed%20to%20refresh%20access%20token%22%20%40error%3A%22Timeout%20error.%22&agg_m=count&agg_m_source=base&agg_q=%40provider%2Cservice&agg_q_source=base%2Cbase&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&messageDisplay=inline&refresh_mode=sliding&sort_m=%2C&sort_m_source=%2C&sort_t=%2C&storage=hot&stream_sort=desc&top_n=10%2C10&top_o=top%2Ctop&viz=pattern&x_missing=true%2Ctrue&from_ts=1769767323691&to_ts=1770026523691&live=true) we're hitting a lot the timeout for token refresh for atlassian related oauth flows.

Timeout increase:                                                                                                                                                         
  - connection.rs: Added provider_timeout_seconds() - 15s for Atlassian, 10s for others                                                                                                          
  - connection.rs: Redis lock TTL 15s → 20s
  - utils.rs: Use provider-specific timeout

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Untested

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy oauth