### PR TITLE
Fix admin Tools breadcrumb label

### DIFF
--- a/front/components/pages/spaces/SpaceActionsPage.tsx
+++ b/front/components/pages/spaces/SpaceActionsPage.tsx
@@ -1,7 +1,6 @@
 import { Spinner } from "@dust-tt/sparkle";
 
 import { SpaceActionsList } from "@app/components/spaces/SpaceActionsList";
-import type { SpaceLayoutPageProps } from "@app/components/spaces/SpaceLayout";
 import { SpaceLayout } from "@app/components/spaces/SpaceLayout";
 import { SystemSpaceActionsList } from "@app/components/spaces/SystemSpaceActionsList";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
@@ -32,19 +31,19 @@ export function SpaceActionsPage() {
     );
   }
 
-  const pageProps: SpaceLayoutPageProps = {
-    canReadInSpace,
-    canWriteInSpace,
-    category: "actions",
-    isAdmin,
-    owner,
-    plan,
-    space,
-    subscription,
-  };
-
   return (
-    <SpaceLayout pageProps={pageProps}>
+    <SpaceLayout
+      pageProps={{
+        canReadInSpace,
+        canWriteInSpace,
+        category: "actions",
+        isAdmin,
+        owner,
+        plan,
+        space,
+        subscription,
+      }}
+    >
       {space.kind === "system" ? (
         <SystemSpaceActionsList
           isAdmin={isAdmin}

--- a/front/components/pages/spaces/SpaceActionsPage.tsx
+++ b/front/components/pages/spaces/SpaceActionsPage.tsx
@@ -1,7 +1,8 @@
 import { Spinner } from "@dust-tt/sparkle";
 
 import { SpaceActionsList } from "@app/components/spaces/SpaceActionsList";
-import { SpaceLayoutWrapper } from "@app/components/spaces/SpaceLayout";
+import type { SpaceLayoutPageProps } from "@app/components/spaces/SpaceLayout";
+import { SpaceLayout } from "@app/components/spaces/SpaceLayout";
 import { SystemSpaceActionsList } from "@app/components/spaces/SystemSpaceActionsList";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import { useRequiredPathParam } from "@app/lib/platform";
@@ -10,9 +11,15 @@ import { useSpaceInfo } from "@app/lib/swr/spaces";
 export function SpaceActionsPage() {
   const spaceId = useRequiredPathParam("spaceId");
   const owner = useWorkspace();
-  const { isAdmin, user } = useAuth();
+  const { subscription, isAdmin, user } = useAuth();
+  const plan = subscription.plan;
 
-  const { spaceInfo: space, isSpaceInfoLoading } = useSpaceInfo({
+  const {
+    spaceInfo: space,
+    canWriteInSpace,
+    canReadInSpace,
+    isSpaceInfoLoading,
+  } = useSpaceInfo({
     workspaceId: owner.sId,
     spaceId,
   });
@@ -25,22 +32,29 @@ export function SpaceActionsPage() {
     );
   }
 
-  if (space.kind === "system") {
-    return (
-      <SpaceLayoutWrapper>
+  const pageProps: SpaceLayoutPageProps = {
+    canReadInSpace,
+    canWriteInSpace,
+    category: "actions",
+    isAdmin,
+    owner,
+    plan,
+    space,
+    subscription,
+  };
+
+  return (
+    <SpaceLayout pageProps={pageProps}>
+      {space.kind === "system" ? (
         <SystemSpaceActionsList
           isAdmin={isAdmin}
           owner={owner}
           user={user}
           space={space}
         />
-      </SpaceLayoutWrapper>
-    );
-  }
-
-  return (
-    <SpaceLayoutWrapper>
-      <SpaceActionsList isAdmin={isAdmin} owner={owner} space={space} />
-    </SpaceLayoutWrapper>
+      ) : (
+        <SpaceActionsList isAdmin={isAdmin} owner={owner} space={space} />
+      )}
+    </SpaceLayout>
   );
 }


### PR DESCRIPTION
## Description

Fixes the breadcrumb/header label on Spaces → Administration → Tools.

The Tools page uses the static `/categories/actions` route, so the layout could not infer the current category from URL params and the breadcrumb fell back to the system space name.

fixes https://github.com/dust-tt/tasks/issues/6266

## Tests

Manual: navigated to Spaces → Administration → Tools and verified the breadcrumb shows \"Tools\".

## Risk

Low. This only sets the category prop for the Tools page layout.

## Deploy Plan

Normal deploy.