### PR TITLE
feat: add Leave Project button for project members

### DIFF
--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -70,7 +70,10 @@ import { useMarkAllConversationsAsRead } from "@app/hooks/useMarkAllConversation
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useProjectsSectionCollapsed } from "@app/hooks/useProjectsSectionCollapsed";
 import { useYAMLUpload } from "@app/hooks/useYAMLUpload";
-import { CONVERSATIONS_UPDATED_EVENT } from "@app/lib/notifications/events";
+import {
+  CONVERSATIONS_UPDATED_EVENT,
+  PROJECTS_UPDATED_EVENT,
+} from "@app/lib/notifications/events";
 import type { AppRouter } from "@app/lib/platform";
 import { useAppRouter } from "@app/lib/platform";
 import { SKILL_ICON } from "@app/lib/skill";
@@ -168,6 +171,19 @@ export function AgentSidebarMenu({ owner }: AgentSidebarMenuProps) {
       );
     };
   }, [hasSpaceConversations, mutateConversations, mutateSpaceSummary]);
+
+  useEffect(() => {
+    if (!hasSpaceConversations) {
+      return;
+    }
+    const handleProjectsUpdated = () => {
+      void mutateSpaceSummary();
+    };
+    window.addEventListener(PROJECTS_UPDATED_EVENT, handleProjectsUpdated);
+    return () => {
+      window.removeEventListener(PROJECTS_UPDATED_EVENT, handleProjectsUpdated);
+    };
+  }, [hasSpaceConversations, mutateSpaceSummary]);
 
   const [isMultiSelect, setIsMultiSelect] = useState(false);
   const [selectedConversations, setSelectedConversations] = useState<

--- a/front/components/pages/conversation/SpaceConversationsPage.tsx
+++ b/front/components/pages/conversation/SpaceConversationsPage.tsx
@@ -252,6 +252,7 @@ export function SpaceConversationsPage() {
               owner={owner}
               spaceId={spaceInfo.sId}
               spaceName={spaceInfo.name}
+              isRestricted={spaceInfo.isRestricted}
               onLeaveSuccess={() => {
                 void router.push(getConversationRoute(owner.sId, "new"));
               }}

--- a/front/components/pages/conversation/SpaceConversationsPage.tsx
+++ b/front/components/pages/conversation/SpaceConversationsPage.tsx
@@ -13,6 +13,7 @@ import React, { useCallback, useState } from "react";
 import { SpaceAboutTab } from "@app/components/assistant/conversation/space/about/SpaceAboutTab";
 import { SpaceConversationsTab } from "@app/components/assistant/conversation/space/conversations/SpaceConversationsTab";
 import { SpaceContextTab } from "@app/components/assistant/conversation/space/SpaceContextTab";
+import { LeaveProjectButton } from "@app/components/spaces/LeaveProjectButton";
 import { useActiveSpaceId } from "@app/hooks/useActiveSpaceId";
 import { useCreateConversationWithMessage } from "@app/hooks/useCreateConversationWithMessage";
 import { useSendNotification } from "@app/hooks/useNotification";
@@ -231,15 +232,32 @@ export function SpaceConversationsPage() {
         onValueChange={(value) => handleTabChange(value as SpaceTab)}
         className="flex min-h-0 flex-1 flex-col pt-3"
       >
-        <TabsList className="px-6">
-          <TabsTrigger
-            value="conversations"
-            label="Conversations"
-            icon={ChatBubbleLeftRightIcon}
-          />
-          <TabsTrigger value="context" label="Context" icon={BookOpenIcon} />
-          <TabsTrigger value="settings" label="Settings" icon={Cog6ToothIcon} />
-        </TabsList>
+        <div className="flex items-center justify-between px-6">
+          <TabsList>
+            <TabsTrigger
+              value="conversations"
+              label="Conversations"
+              icon={ChatBubbleLeftRightIcon}
+            />
+            <TabsTrigger value="context" label="Context" icon={BookOpenIcon} />
+            <TabsTrigger
+              value="settings"
+              label="Settings"
+              icon={Cog6ToothIcon}
+            />
+          </TabsList>
+
+          {spaceInfo.kind === "project" && spaceInfo.isMember && (
+            <LeaveProjectButton
+              owner={owner}
+              spaceId={spaceInfo.sId}
+              spaceName={spaceInfo.name}
+              onLeaveSuccess={() => {
+                void router.push(getConversationRoute(owner.sId, "new"));
+              }}
+            />
+          )}
+        </div>
 
         <TabsContent value="conversations">
           <SpaceConversationsTab

--- a/front/components/spaces/LeaveProjectButton.tsx
+++ b/front/components/spaces/LeaveProjectButton.tsx
@@ -9,6 +9,7 @@ interface LeaveProjectButtonProps {
   owner: LightWorkspaceType;
   spaceId: string;
   spaceName: string;
+  isRestricted: boolean;
   onLeaveSuccess?: () => void;
 }
 
@@ -16,6 +17,7 @@ export function LeaveProjectButton({
   owner,
   spaceId,
   spaceName,
+  isRestricted,
   onLeaveSuccess,
 }: LeaveProjectButtonProps) {
   const [isLeaving, setIsLeaving] = useState(false);
@@ -25,11 +27,13 @@ export function LeaveProjectButton({
   const handleLeaveClick = async () => {
     const confirmed = await showDialog({
       title: "Leave this project?",
-      children: (
+      children: isRestricted ? (
         <p>
           You will no longer have access to conversations and context in{" "}
           <strong>{spaceName}</strong>.
         </p>
+      ) : (
+        <p>You can rejoin this project anytime.</p>
       ),
       alertDialog: true,
       validateLabel: "Leave",

--- a/front/components/spaces/LeaveProjectButton.tsx
+++ b/front/components/spaces/LeaveProjectButton.tsx
@@ -1,0 +1,62 @@
+import { Button } from "@dust-tt/sparkle";
+import { useState } from "react";
+
+import { useAwaitableDialog } from "@app/hooks/useAwaitableDialog";
+import { useLeaveProject } from "@app/lib/swr/spaces";
+import type { LightWorkspaceType } from "@app/types";
+
+interface LeaveProjectButtonProps {
+  owner: LightWorkspaceType;
+  spaceId: string;
+  spaceName: string;
+  onLeaveSuccess?: () => void;
+}
+
+export function LeaveProjectButton({
+  owner,
+  spaceId,
+  spaceName,
+  onLeaveSuccess,
+}: LeaveProjectButtonProps) {
+  const [isLeaving, setIsLeaving] = useState(false);
+  const doLeave = useLeaveProject({ owner, spaceId });
+  const { AwaitableDialog, showDialog } = useAwaitableDialog();
+
+  const handleLeaveClick = async () => {
+    const confirmed = await showDialog({
+      title: "Leave this project?",
+      children: (
+        <p>
+          You will no longer have access to conversations and context in{" "}
+          <strong>{spaceName}</strong>.
+        </p>
+      ),
+      alertDialog: true,
+      validateLabel: "Leave",
+      validateVariant: "warning",
+      cancelLabel: "Cancel",
+    });
+
+    if (confirmed) {
+      setIsLeaving(true);
+      const success = await doLeave();
+      setIsLeaving(false);
+
+      if (success && onLeaveSuccess) {
+        onLeaveSuccess();
+      }
+    }
+  };
+
+  return (
+    <>
+      <Button
+        variant="primary"
+        label="Leave the project"
+        onClick={handleLeaveClick}
+        isLoading={isLeaving}
+      />
+      <AwaitableDialog />
+    </>
+  );
+}

--- a/front/lib/notifications/events.ts
+++ b/front/lib/notifications/events.ts
@@ -13,3 +13,11 @@ export class AgentMessageCompletedEvent extends CustomEvent<void> {
     super(AGENT_MESSAGE_COMPLETED_EVENT);
   }
 }
+
+export const PROJECTS_UPDATED_EVENT = "projects-updated";
+
+export class ProjectsUpdatedEvent extends CustomEvent<void> {
+  constructor() {
+    super(PROJECTS_UPDATED_EVENT);
+  }
+}

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/index.ts
@@ -133,7 +133,7 @@ async function handler(
           categories,
           canWrite: space.canWrite(auth),
           canRead: space.canRead(auth),
-          isMember: space.canRead(auth),
+          isMember: space.isMember(auth),
           members: currentMembers.map((member) => member.toJSON()),
         },
       });

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/leave.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/leave.test.ts
@@ -4,7 +4,6 @@ import { describe, expect, it } from "vitest";
 
 import { Authenticator } from "@app/lib/auth";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
-import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
@@ -143,18 +142,10 @@ describe("POST /api/w/[wId]/spaces/[spaceId]/leave", () => {
       expect(res._getStatusCode()).toBe(200);
       expect(res._getJSONData().success).toBe(true);
 
-      // Verify user was removed from member group
       const memberGroup = project.groups.find((g) => g.kind === "regular");
       if (memberGroup) {
-        const membership = await GroupMembershipModel.findOne({
-          where: {
-            groupId: memberGroup.id,
-            userId: user.id,
-            workspaceId: workspace.id,
-          },
-          order: [["createdAt", "DESC"]],
-        });
-        expect(membership?.endAt).not.toBeNull();
+        const isMember = await memberGroup.isMember(user);
+        expect(isMember).toBe(false);
       }
     });
 

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/leave.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/leave.test.ts
@@ -1,0 +1,175 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import type { MockRequest, MockResponse } from "node-mocks-http";
+import { describe, expect, it } from "vitest";
+
+import { Authenticator } from "@app/lib/auth";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
+import type { UserResource } from "@app/lib/resources/user_resource";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import type { MembershipRoleType, WorkspaceType } from "@app/types";
+
+import handler from "./leave";
+
+describe("POST /api/w/[wId]/spaces/[spaceId]/leave", () => {
+  // Shared test context
+  let req: MockRequest<NextApiRequest>;
+  let res: MockResponse<NextApiResponse>;
+  let workspace: WorkspaceType;
+  let user: UserResource;
+  let adminAuth: Authenticator;
+
+  // Helper to set up request context
+  async function setupRequest(options: {
+    method?: string;
+    role?: MembershipRoleType;
+  }) {
+    const result = await createPrivateApiMockRequest({
+      method: (options.method ?? "POST") as any,
+      role: options.role ?? "user",
+    });
+    req = result.req;
+    res = result.res;
+    workspace = result.workspace;
+    user = result.user;
+    adminAuth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+    return result;
+  }
+
+  // Helper to add user to a project
+  async function addUserToProject(
+    project: SpaceResource,
+    targetUser: UserResource,
+    options: { asEditor?: boolean } = {}
+  ) {
+    const memberGroup = project.groups.find((g) => g.kind === "regular");
+    const editorGroup = project.groups.find((g) => g.kind === "space_editors");
+
+    if (memberGroup) {
+      await memberGroup.addMembers(adminAuth, { users: [targetUser.toJSON()] });
+    }
+    if (options.asEditor && editorGroup) {
+      await editorGroup.addMembers(adminAuth, { users: [targetUser.toJSON()] });
+    }
+  }
+
+  describe("validation", () => {
+    it("should return 400 when space is not a project", async () => {
+      await setupRequest({ role: "user" });
+
+      const regularSpace = await SpaceFactory.regular(workspace);
+      const memberGroup = regularSpace.groups.find((g) => g.kind === "regular");
+      if (memberGroup) {
+        await memberGroup.addMembers(adminAuth, { users: [user.toJSON()] });
+      }
+
+      req.query.spaceId = regularSpace.sId;
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(400);
+      expect(res._getJSONData().error.type).toBe("invalid_request_error");
+      expect(res._getJSONData().error.message).toContain("only leave projects");
+    });
+
+    it("should return 403 when user is not a member of the project", async () => {
+      await setupRequest({ role: "admin" }); // Admin can access but won't be a member
+
+      const otherUser = await UserFactory.basic();
+      const project = await SpaceFactory.project(workspace, otherUser.id);
+
+      req.query.spaceId = project.sId;
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(403);
+      expect(res._getJSONData().error.type).toBe("workspace_auth_error");
+      expect(res._getJSONData().error.message).toContain("not a member");
+    });
+
+    it("should return 405 for unsupported methods", async () => {
+      for (const method of ["GET", "PUT", "DELETE", "PATCH"]) {
+        await setupRequest({ method, role: "user" });
+
+        const otherEditor = await UserFactory.basic();
+        const project = await SpaceFactory.project(workspace, otherEditor.id);
+        await addUserToProject(project, user, { asEditor: true });
+
+        req.query.spaceId = project.sId;
+        await handler(req, res);
+
+        expect(res._getStatusCode()).toBe(405);
+        expect(res._getJSONData().error.type).toBe(
+          "method_not_supported_error"
+        );
+      }
+    });
+  });
+
+  describe("last editor protection", () => {
+    it("should return 403 when user is the last editor", async () => {
+      await setupRequest({ role: "user" });
+
+      // User is created as the only editor via SpaceFactory
+      const project = await SpaceFactory.project(workspace, user.id);
+      await addUserToProject(project, user); // Add to member group only
+
+      req.query.spaceId = project.sId;
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(403);
+      expect(res._getJSONData().error.type).toBe("workspace_auth_error");
+      expect(res._getJSONData().error.message).toContain("last editor");
+    });
+  });
+
+  describe("successful leave", () => {
+    it("should return 200 when editor leaves project with multiple editors", async () => {
+      await setupRequest({ role: "user" });
+
+      // Create another editor and make them a workspace member
+      const otherEditor = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, otherEditor, {
+        role: "user",
+      });
+
+      const project = await SpaceFactory.project(workspace, otherEditor.id);
+      await addUserToProject(project, user, { asEditor: true });
+
+      req.query.spaceId = project.sId;
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+      expect(res._getJSONData().success).toBe(true);
+
+      // Verify user was removed from member group
+      const memberGroup = project.groups.find((g) => g.kind === "regular");
+      if (memberGroup) {
+        const membership = await GroupMembershipModel.findOne({
+          where: {
+            groupId: memberGroup.id,
+            userId: user.id,
+            workspaceId: workspace.id,
+          },
+          order: [["createdAt", "DESC"]],
+        });
+        expect(membership?.endAt).not.toBeNull();
+      }
+    });
+
+    it("should return 200 when non-editor member leaves project", async () => {
+      await setupRequest({ role: "user" });
+
+      const editorUser = await UserFactory.basic();
+      const project = await SpaceFactory.project(workspace, editorUser.id);
+      await addUserToProject(project, user, { asEditor: false });
+
+      req.query.spaceId = project.sId;
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+      expect(res._getJSONData().success).toBe(true);
+    });
+  });
+});

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/leave.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/leave.ts
@@ -1,0 +1,109 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { Op } from "sequelize";
+
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+
+interface PostLeaveProjectResponseBody {
+  success: boolean;
+}
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<PostLeaveProjectResponseBody>>,
+  auth: Authenticator,
+  { space }: { space: SpaceResource }
+): Promise<void> {
+  switch (req.method) {
+    case "POST": {
+      // Only allow leaving projects
+      if (!space.isProject()) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "You can only leave projects, not regular spaces.",
+          },
+        });
+      }
+
+      // Check if user is a member of the project
+      if (!space.isMember(auth)) {
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "workspace_auth_error",
+            message: "You are not a member of this project.",
+          },
+        });
+      }
+
+      const user = auth.getNonNullableUser();
+      const workspace = auth.getNonNullableWorkspace();
+
+      // Get the member group (kind: "regular") and editor group (kind: "space_editors")
+      const memberGroup = space.groups.find((g) => g.kind === "regular");
+      const editorGroup = space.groups.find((g) => g.kind === "space_editors");
+
+      // Check if user is in the editor group and if they're the last editor
+      if (editorGroup) {
+        const activeEditors = await editorGroup.getActiveMembers(auth);
+        const isUserEditor = activeEditors.some((m) => m.sId === user.sId);
+
+        if (isUserEditor && activeEditors.length === 1) {
+          return apiError(req, res, {
+            status_code: 403,
+            api_error: {
+              type: "workspace_auth_error",
+              message:
+                "You cannot leave this project as you are the last editor. Please add another editor first.",
+            },
+          });
+        }
+      }
+
+      // Remove user from both member and editor groups
+      const groupsToLeave = [memberGroup, editorGroup].filter(
+        (g): g is NonNullable<typeof g> => g !== undefined
+      );
+
+      const now = new Date();
+      for (const group of groupsToLeave) {
+        await GroupMembershipModel.update(
+          { endAt: now },
+          {
+            where: {
+              groupId: group.id,
+              userId: user.id,
+              workspaceId: workspace.id,
+              startAt: { [Op.lte]: now },
+              [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: now } }],
+            },
+          }
+        );
+      }
+
+      return res.status(200).json({ success: true });
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, POST is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(
+  withResourceFetchingFromRoute(handler, {
+    space: { requireCanReadOrAdministrate: true },
+  })
+);


### PR DESCRIPTION
## Description


https://github.com/user-attachments/assets/322e6015-a4ed-432c-b4f3-3400aa01a39d


[Add a "Leave Project" button that allows users to leave projects they're members of](https://github.com/dust-tt/tasks/issues/6220).

- Add `POST /api/w/[wId]/spaces/[spaceId]/leave` endpoint for self-service project leaving
- Add `LeaveProjectButton` component with confirmation dialog using `useAwaitableDialog`
- Add `useLeaveProject` hook that dispatches `PROJECTS_UPDATED_EVENT` for instant sidebar refresh
- Sidebar listens to the new event to update the projects list immediately
- Prevent the last editor from leaving (must add another editor first)
- Redirect to "new conversation" page after leaving a project
- Include functional tests for the API endpoint

## Tests
- [x] Unit tests for API endpoint (6 tests passing)
- [x] Manual testing: leave a project, verify sidebar updates instantly
- [x] Manual testing: try to leave as last editor, verify error message

## Risk
low

## Deploy plan
front