### PR TITLE
feat: update reads table when reading conversation

### DIFF
--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -1700,16 +1700,16 @@ export class ConversationResource extends BaseResource<ConversationModel> {
 
     const conversationIds = conversations.map((c) => c.id);
 
-    const userId = auth.getNonNullableUser().id;
-    const workspaceId = auth.getNonNullableWorkspace().id;
+    const userModelId = auth.getNonNullableUser().id;
+    const workspaceModelId = auth.getNonNullableWorkspace().id;
 
     await ConversationParticipantModel.update(
       { lastReadAt: new Date(), actionRequired: false },
       {
         where: {
           conversationId: { [Op.in]: conversationIds },
-          workspaceId,
-          userId,
+          workspaceId: workspaceModelId,
+          userId: userModelId,
         },
       }
     );
@@ -1718,8 +1718,8 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     const existingReads = await UserConversationReadsModel.findAll({
       where: {
         conversationId: { [Op.in]: conversationIds },
-        userId,
-        workspaceId,
+        userId: userModelId,
+        workspaceId: workspaceModelId,
       },
     });
 
@@ -1744,8 +1744,8 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     await UserConversationReadsModel.bulkCreate(
       conversationIdsNeedingNewReads.map((conversationId) => ({
         conversationId,
-        userId,
-        workspaceId,
+        userId: userModelId,
+        workspaceId: workspaceModelId,
         lastReadAt: new Date(),
       }))
     );

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -976,6 +976,15 @@ export class ConversationResource extends BaseResource<ConversationModel> {
         transaction,
       }
     );
+    await UserConversationReadsModel.upsert(
+      {
+        conversationId: conversation.id,
+        userId: auth.getNonNullableUser().id,
+        workspaceId: auth.getNonNullableWorkspace().id,
+        lastReadAt: new Date(),
+      },
+      { transaction }
+    );
     return new Ok(updated);
   }
 
@@ -1087,6 +1096,17 @@ export class ConversationResource extends BaseResource<ConversationModel> {
           },
           { transaction: t }
         );
+        if (lastReadAt) {
+          await UserConversationReadsModel.upsert(
+            {
+              conversationId: conversation.id,
+              userId: user.id,
+              workspaceId: auth.getNonNullableWorkspace().id,
+              lastReadAt,
+            },
+            { transaction: t }
+          );
+        }
         status = "added";
       }
     }, transaction);
@@ -1680,15 +1700,54 @@ export class ConversationResource extends BaseResource<ConversationModel> {
 
     const conversationIds = conversations.map((c) => c.id);
 
+    const userId = auth.getNonNullableUser().id;
+    const workspaceId = auth.getNonNullableWorkspace().id;
+
     await ConversationParticipantModel.update(
       { lastReadAt: new Date(), actionRequired: false },
       {
         where: {
           conversationId: { [Op.in]: conversationIds },
-          workspaceId: auth.getNonNullableWorkspace().id,
-          userId: auth.getNonNullableUser().id,
+          workspaceId,
+          userId,
         },
       }
+    );
+
+    // Update the existing UserConversationReads entries
+    const existingReads = await UserConversationReadsModel.findAll({
+      where: {
+        conversationId: { [Op.in]: conversationIds },
+        userId,
+        workspaceId,
+      },
+    });
+
+    await UserConversationReadsModel.update(
+      { lastReadAt: new Date() },
+      {
+        where: {
+          id: {
+            [Op.in]: existingReads.map((read) => read.id),
+          },
+        },
+      }
+    );
+
+    // Create entries for conversations that do not have one yet
+    const conversationIdsWithExistingReads = new Set(
+      existingReads.map((read) => read.conversationId)
+    );
+    const conversationIdsNeedingNewReads = conversationIds.filter(
+      (id) => !conversationIdsWithExistingReads.has(id)
+    );
+    await UserConversationReadsModel.bulkCreate(
+      conversationIdsNeedingNewReads.map((conversationId) => ({
+        conversationId,
+        userId,
+        workspaceId,
+        lastReadAt: new Date(),
+      }))
     );
 
     return new Ok(undefined);


### PR DESCRIPTION
## Description

This PR updates the `UserConversationReads` table whenever a conversation is marked as read by a user.

- Updates the table in `markAsReadForAuthUser`, `upsertParticipation` and `batchMarkAsReadAndClearActionRequired` methods

## Tests

Manually

## Risks

Low risk. This PR only adds writes to the new `UserConversationReads` table without removing any existing functionality. The `ConversationParticipant` table continues to be updated as before.

## Deploy Plan

Standard deployment - no special steps required.
