### PR TITLE
feat: add project join flow for non-members

### DIFF
--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -28,6 +28,7 @@ import {
   isMessageTemporayState,
   isUserMessage,
 } from "@app/components/assistant/conversation/types";
+import { ProjectJoinCTA } from "@app/components/spaces/ProjectJoinCTA";
 import { useCancelMessage, useConversation } from "@app/lib/swr/conversations";
 import { useIsMobile } from "@app/lib/swr/useIsMobile";
 import {
@@ -44,15 +45,10 @@ export const AgentInputBar = ({
   context: VirtuosoMessageListContext;
 }) => {
   const [blockedActionIndex, setBlockedActionIndex] = useState<number>(0);
+  const [isStopping, setIsStopping] = useState<boolean>(false);
   const generationContext = useContext(GenerationContext);
   const { getBlockedActions, hasPendingValidations, startPulsingAction } =
     useBlockedActionsContext();
-
-  if (!generationContext) {
-    throw new Error(
-      "AssistantInputBarVirtuoso must be used within a GenerationContextProvider"
-    );
-  }
 
   const { mutateConversation } = useConversation({
     conversationId: context.conversation?.sId,
@@ -64,13 +60,10 @@ export const AgentInputBar = ({
     conversationId: context.conversation?.sId,
   });
 
-  const generatingMessages =
-    generationContext.getConversationGeneratingMessages(
-      context.conversation?.sId ?? ""
-    );
-
   const isMobile = useIsMobile();
   const methods = useVirtuosoMethods<VirtuosoMessage>();
+  const { bottomOffset, listOffset, visibleListHeight } = useVirtuosoLocation();
+
   const lastUserMessage = methods.data
     .get()
     .filter(isUserMessage)
@@ -90,7 +83,7 @@ export const AgentInputBar = ({
       return [toRichAgentMentionType(draftAgent)];
     }
 
-    // we only prefill if there is only one agent mention in user's previous message
+    // We only prefill if there is only one agent mention in user's previous message.
     const shouldPrefill =
       lastUserMessage &&
       lastUserMessage.richMentions.length === 1 &&
@@ -102,8 +95,6 @@ export const AgentInputBar = ({
 
     return lastUserMessage.richMentions;
   }, [draftAgent, lastUserMessage]);
-
-  const { bottomOffset, listOffset, visibleListHeight } = useVirtuosoLocation();
 
   // Calculate positions and determine which user messages are navigable.
   const {
@@ -193,9 +184,6 @@ export const AgentInputBar = ({
     };
   }, [methods, listOffset, visibleListHeight, bottomOffset]);
 
-  const showStopButton = generatingMessages.length > 0;
-  const showMessageNavigation = !context.agentBuilderContext;
-  const showNavigationContainer = showStopButton || showMessageNavigation;
   const blockedActions = getBlockedActions(context.user.sId);
 
   // Keep blockedActionIndex in sync when blockedActions array changes.
@@ -206,7 +194,50 @@ export const AgentInputBar = ({
     }
   }, [blockedActionIndex, blockedActions.length]);
 
-  const [isStopping, setIsStopping] = useState<boolean>(false);
+  useEffect(() => {
+    if (
+      isStopping &&
+      generationContext &&
+      !generationContext.generatingMessages.some(
+        (m) => m.conversationId === context.conversation?.sId
+      )
+    ) {
+      setIsStopping(false);
+    }
+  }, [isStopping, generationContext, context.conversation]);
+
+  if (!generationContext) {
+    throw new Error(
+      "AssistantInputBarVirtuoso must be used within a GenerationContextProvider"
+    );
+  }
+
+  if (
+    context.isProjectMember === false &&
+    context.projectSpaceId &&
+    context.projectSpaceName
+  ) {
+    return (
+      <div className="relative z-20 mx-auto flex max-h-dvh w-full flex-col py-2 sm:w-full sm:max-w-4xl sm:py-4">
+        <ProjectJoinCTA
+          owner={context.owner}
+          spaceId={context.projectSpaceId}
+          spaceName={context.projectSpaceName}
+          isRestricted={context.isProjectRestricted ?? false}
+          userName={context.user.fullName}
+        />
+      </div>
+    );
+  }
+
+  const generatingMessages =
+    generationContext.getConversationGeneratingMessages(
+      context.conversation?.sId ?? ""
+    );
+
+  const showStopButton = generatingMessages.length > 0;
+  const showMessageNavigation = !context.agentBuilderContext;
+  const showNavigationContainer = showStopButton || showMessageNavigation;
 
   const getStopButtonLabel = () => {
     if (isStopping) {
@@ -220,7 +251,7 @@ export const AgentInputBar = ({
     if (!context.conversation) {
       return;
     }
-    setIsStopping(true); // we don't set it back to false immediately cause it takes a bit of time to cancel
+    setIsStopping(true); // We don't set it back to false immediately cause it takes a bit of time to cancel.
     await cancelMessage(
       generationContext.generatingMessages
         .filter((m) => m.conversationId === context.conversation?.sId)
@@ -228,17 +259,6 @@ export const AgentInputBar = ({
     );
     void mutateConversation();
   };
-
-  useEffect(() => {
-    if (
-      isStopping &&
-      !generationContext.generatingMessages.some(
-        (m) => m.conversationId === context.conversation?.sId
-      )
-    ) {
-      setIsStopping(false);
-    }
-  }, [isStopping, generationContext.generatingMessages, context.conversation]);
 
   return (
     <div

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -50,6 +50,7 @@ import {
   useConversationParticipants,
   useConversations,
 } from "@app/lib/swr/conversations";
+import { useSpaceInfo } from "@app/lib/swr/spaces";
 import { classNames } from "@app/lib/utils";
 import type {
   AgentGenerationCancelledEvent,
@@ -126,6 +127,12 @@ export const ConversationViewer = ({
   } = useConversation({
     conversationId,
     workspaceId: owner.sId,
+  });
+
+  const { spaceInfo } = useSpaceInfo({
+    workspaceId: owner.sId,
+    spaceId: conversation?.spaceId ?? "",
+    disabled: !conversation?.spaceId,
   });
 
   const { markAsRead } = useConversationMarkAsRead({
@@ -706,6 +713,10 @@ export const ConversationViewer = ({
     );
   }, [feedbacks]);
 
+  const isProjectMember = conversation?.spaceId
+    ? (spaceInfo?.isMember ?? false) // Default false while loading (restrictive)
+    : undefined;
+
   const context: VirtuosoMessageListContext = useMemo(() => {
     return {
       user,
@@ -713,11 +724,16 @@ export const ConversationViewer = ({
       handleSubmit,
       conversation,
       draftKey: `conversation-${conversationId}`,
-      enableExtendedActions: !!conversation?.spaceId,
+      enableExtendedActions:
+        !!conversation?.spaceId && isProjectMember !== false,
       agentBuilderContext,
       feedbacksByMessageId,
       additionalMarkdownComponents,
       additionalMarkdownPlugins,
+      isProjectMember,
+      isProjectRestricted: spaceInfo?.isRestricted,
+      projectSpaceId: conversation?.spaceId ?? undefined,
+      projectSpaceName: spaceInfo?.name,
     };
   }, [
     user,
@@ -729,6 +745,9 @@ export const ConversationViewer = ({
     feedbacksByMessageId,
     additionalMarkdownComponents,
     additionalMarkdownPlugins,
+    isProjectMember,
+    spaceInfo?.isRestricted,
+    spaceInfo?.name,
   ]);
 
   return (

--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -70,10 +70,7 @@ import { useMarkAllConversationsAsRead } from "@app/hooks/useMarkAllConversation
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useProjectsSectionCollapsed } from "@app/hooks/useProjectsSectionCollapsed";
 import { useYAMLUpload } from "@app/hooks/useYAMLUpload";
-import {
-  CONVERSATIONS_UPDATED_EVENT,
-  PROJECTS_UPDATED_EVENT,
-} from "@app/lib/notifications/events";
+import { CONVERSATIONS_UPDATED_EVENT } from "@app/lib/notifications/events";
 import type { AppRouter } from "@app/lib/platform";
 import { useAppRouter } from "@app/lib/platform";
 import { SKILL_ICON } from "@app/lib/skill";
@@ -171,19 +168,6 @@ export function AgentSidebarMenu({ owner }: AgentSidebarMenuProps) {
       );
     };
   }, [hasSpaceConversations, mutateConversations, mutateSpaceSummary]);
-
-  useEffect(() => {
-    if (!hasSpaceConversations) {
-      return;
-    }
-    const handleProjectsUpdated = () => {
-      void mutateSpaceSummary();
-    };
-    window.addEventListener(PROJECTS_UPDATED_EVENT, handleProjectsUpdated);
-    return () => {
-      window.removeEventListener(PROJECTS_UPDATED_EVENT, handleProjectsUpdated);
-    };
-  }, [hasSpaceConversations, mutateSpaceSummary]);
 
   const [isMultiSelect, setIsMultiSelect] = useState(false);
   const [selectedConversations, setSelectedConversations] = useState<

--- a/front/components/assistant/conversation/space/conversations/SpaceConversationsTab.tsx
+++ b/front/components/assistant/conversation/space/conversations/SpaceConversationsTab.tsx
@@ -17,17 +17,18 @@ import { SpaceConversationsActions } from "@app/components/assistant/conversatio
 import { SpaceJournalEntry } from "@app/components/assistant/conversation/space/conversations/SpaceJournalEntry";
 import { getGroupConversationsByDate } from "@app/components/assistant/conversation/utils";
 import { DropzoneContainer } from "@app/components/misc/DropzoneContainer";
+import { ProjectJoinCTA } from "@app/components/spaces/ProjectJoinCTA";
 import { useMarkAllConversationsAsRead } from "@app/hooks/useMarkAllConversationsAsRead";
 import { useSearchConversations } from "@app/hooks/useSearchConversations";
 import { useAppRouter } from "@app/lib/platform";
 import { getConversationRoute } from "@app/lib/utils/router";
+import type { GetSpaceResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]";
 import type {
   ContentFragmentsType,
   ConversationType,
   ConversationWithoutContentType,
   Result,
   RichMention,
-  SpaceType,
   UserType,
   WorkspaceType,
 } from "@app/types";
@@ -45,7 +46,7 @@ interface SpaceConversationsTabProps {
   user: UserType;
   conversations: ConversationType[];
   isConversationsLoading: boolean;
-  spaceInfo: SpaceType;
+  spaceInfo: GetSpaceResponseBody["space"];
   onSubmit: (
     input: string,
     mentions: RichMention[],
@@ -157,14 +158,24 @@ export function SpaceConversationsTab({
             <h2 className="heading-2xl text-foreground dark:text-foreground-night">
               {spaceInfo.name}
             </h2>
-            <InputBar
-              owner={owner}
-              user={user}
-              onSubmit={onSubmit}
-              draftKey={`space-${spaceInfo.sId}-new-conversation`}
-              space={spaceInfo}
-              disableAutoFocus={false}
-            />
+            {spaceInfo.isMember ? (
+              <InputBar
+                owner={owner}
+                user={user}
+                onSubmit={onSubmit}
+                draftKey={`space-${spaceInfo.sId}-new-conversation`}
+                space={spaceInfo}
+                disableAutoFocus={false}
+              />
+            ) : (
+              <ProjectJoinCTA
+                owner={owner}
+                spaceId={spaceInfo.sId}
+                spaceName={spaceInfo.name}
+                isRestricted={spaceInfo.isRestricted}
+                userName={user.fullName}
+              />
+            )}
           </div>
 
           <SpaceJournalEntry owner={owner} space={spaceInfo} />

--- a/front/components/assistant/conversation/types.ts
+++ b/front/components/assistant/conversation/types.ts
@@ -85,6 +85,11 @@ export type VirtuosoMessageListContext = {
   feedbacksByMessageId: Record<string, AgentMessageFeedbackType>;
   additionalMarkdownComponents?: Components;
   additionalMarkdownPlugins?: PluggableList;
+  // Project membership fields (undefined for non-project conversations)
+  isProjectMember?: boolean;
+  isProjectRestricted?: boolean;
+  projectSpaceId?: string;
+  projectSpaceName?: string;
 };
 
 export const isTriggeredOrigin = (origin?: UserMessageOrigin | null) => {

--- a/front/components/pages/conversation/SpaceConversationsPage.tsx
+++ b/front/components/pages/conversation/SpaceConversationsPage.tsx
@@ -253,9 +253,7 @@ export function SpaceConversationsPage() {
               spaceId={spaceInfo.sId}
               spaceName={spaceInfo.name}
               isRestricted={spaceInfo.isRestricted}
-              onLeaveSuccess={() => {
-                void router.push(getConversationRoute(owner.sId, "new"));
-              }}
+              userName={user.fullName}
             />
           )}
         </div>

--- a/front/components/spaces/LeaveProjectButton.tsx
+++ b/front/components/spaces/LeaveProjectButton.tsx
@@ -10,7 +10,7 @@ interface LeaveProjectButtonProps {
   spaceId: string;
   spaceName: string;
   isRestricted: boolean;
-  onLeaveSuccess?: () => void;
+  userName: string;
 }
 
 export function LeaveProjectButton({
@@ -18,10 +18,10 @@ export function LeaveProjectButton({
   spaceId,
   spaceName,
   isRestricted,
-  onLeaveSuccess,
+  userName,
 }: LeaveProjectButtonProps) {
   const [isLeaving, setIsLeaving] = useState(false);
-  const doLeave = useLeaveProject({ owner, spaceId });
+  const doLeave = useLeaveProject({ owner, spaceId, spaceName, userName });
   const { AwaitableDialog, showDialog } = useAwaitableDialog();
 
   const handleLeaveClick = async () => {
@@ -44,10 +44,10 @@ export function LeaveProjectButton({
     if (confirmed) {
       setIsLeaving(true);
       const success = await doLeave();
-      setIsLeaving(false);
-
-      if (success && onLeaveSuccess) {
-        onLeaveSuccess();
+      // Only reset if the leave failed. On success, the SWR mutation will trigger
+      // a re-render with updated membership state.
+      if (!success) {
+        setIsLeaving(false);
       }
     }
   };

--- a/front/components/spaces/ProjectJoinCTA.tsx
+++ b/front/components/spaces/ProjectJoinCTA.tsx
@@ -1,0 +1,47 @@
+import { Button, EmptyCTA } from "@dust-tt/sparkle";
+import { useState } from "react";
+
+import { useJoinProject } from "@app/lib/swr/spaces";
+import type { LightWorkspaceType } from "@app/types";
+
+interface ProjectJoinCTAProps {
+  owner: LightWorkspaceType;
+  spaceId: string;
+  spaceName: string;
+  isRestricted: boolean;
+  userName: string;
+}
+
+export function ProjectJoinCTA({
+  owner,
+  spaceId,
+  spaceName,
+  isRestricted,
+  userName,
+}: ProjectJoinCTAProps) {
+  const [isJoining, setIsJoining] = useState(false);
+  const doJoin = useJoinProject({ owner, spaceId, spaceName, userName });
+
+  const handleJoin = async () => {
+    setIsJoining(true);
+    const success = await doJoin();
+    if (!success) {
+      setIsJoining(false);
+    }
+  };
+
+  const message = isRestricted
+    ? "You need to be invited to participate in this project."
+    : "Join this project to participate in conversations.";
+
+  const action = isRestricted ? null : (
+    <Button
+      label={isJoining ? "Joining..." : `Join the ${spaceName} project`}
+      variant="highlight"
+      onClick={handleJoin}
+      disabled={isJoining}
+    />
+  );
+
+  return <EmptyCTA message={message} action={action} />;
+}

--- a/front/lib/notifications/events.ts
+++ b/front/lib/notifications/events.ts
@@ -13,11 +13,3 @@ export class AgentMessageCompletedEvent extends CustomEvent<void> {
     super(AGENT_MESSAGE_COMPLETED_EVENT);
   }
 }
-
-export const PROJECTS_UPDATED_EVENT = "projects-updated";
-
-export class ProjectsUpdatedEvent extends CustomEvent<void> {
-  constructor() {
-    super(PROJECTS_UPDATED_EVENT);
-  }
-}

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -1382,6 +1382,7 @@ export class GroupResource extends BaseResource<GroupModel> {
    * Users can always remove themselves from groups they are members of.
    *
    * Only works for "regular" and "space_editors" groups.
+   * TODO(remy): Replace this with dangerouslyRemoveMembers once available
    */
   async leaveGroup(
     auth: Authenticator,
@@ -1433,6 +1434,7 @@ export class GroupResource extends BaseResource<GroupModel> {
    * Users can add themselves to groups (for self-join flows like joining public projects).
    *
    * Only works for "regular" groups.
+   * TODO(remy): Replace this with dangerouslyAddMembers once available
    */
   async joinGroup(
     auth: Authenticator,

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -8,8 +8,8 @@ import type {
 } from "@app/lib/api/pagination";
 import { getDisplayNameForDataSource } from "@app/lib/data_sources";
 import { clientFetch } from "@app/lib/egress/client";
-import { PROJECTS_UPDATED_EVENT } from "@app/lib/notifications/events";
 import { getSpaceName } from "@app/lib/spaces";
+import { useSpaceConversationsSummary } from "@app/lib/swr/conversations";
 import {
   emptyArray,
   fetcher,
@@ -1039,15 +1039,23 @@ export function useGenerateProjectJournalEntry({
 export function useLeaveProject({
   owner,
   spaceId,
+  spaceName,
+  userName,
 }: {
   owner: LightWorkspaceType;
   spaceId: string;
+  spaceName: string;
+  userName: string;
 }) {
   const sendNotification = useSendNotification();
   const { mutateSpaceInfo } = useSpaceInfo({
     workspaceId: owner.sId,
     spaceId,
     disabled: true, // Needed just to mutate
+  });
+  const { mutate: mutateSpaceSummary } = useSpaceConversationsSummary({
+    workspaceId: owner.sId,
+    options: { disabled: true }, // Needed just to mutate
   });
 
   const doLeave = async (): Promise<boolean> => {
@@ -1058,10 +1066,10 @@ export function useLeaveProject({
 
     if (res.ok) {
       void mutateSpaceInfo();
-      window.dispatchEvent(new CustomEvent(PROJECTS_UPDATED_EVENT));
+      void mutateSpaceSummary();
       sendNotification({
         type: "success",
-        title: "Left project",
+        title: `${userName} left project ${spaceName}`,
         description: "You have successfully left the project.",
       });
       return true;
@@ -1077,4 +1085,55 @@ export function useLeaveProject({
   };
 
   return doLeave;
+}
+
+export function useJoinProject({
+  owner,
+  spaceId,
+  spaceName,
+  userName,
+}: {
+  owner: LightWorkspaceType;
+  spaceId: string;
+  spaceName: string;
+  userName: string;
+}) {
+  const sendNotification = useSendNotification();
+  const { mutateSpaceInfo } = useSpaceInfo({
+    workspaceId: owner.sId,
+    spaceId,
+    disabled: true,
+  });
+  const { mutate: mutateSpaceSummary } = useSpaceConversationsSummary({
+    workspaceId: owner.sId,
+    options: { disabled: true }, // Needed just to mutate
+  });
+
+  const doJoin = async (): Promise<boolean> => {
+    const res = await clientFetch(
+      `/api/w/${owner.sId}/spaces/${spaceId}/join`,
+      { method: "POST" }
+    );
+
+    if (res.ok) {
+      void mutateSpaceInfo();
+      void mutateSpaceSummary();
+      sendNotification({
+        type: "success",
+        title: `${userName} joined project ${spaceName}`,
+        description: "You can now participate in conversations.",
+      });
+      return true;
+    } else {
+      const errorData = await getErrorFromResponse(res);
+      sendNotification({
+        type: "error",
+        title: "Could not join project",
+        description: `Error: ${errorData.message}`,
+      });
+      return false;
+    }
+  };
+
+  return doJoin;
 }

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/join.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/join.ts
@@ -1,0 +1,94 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { withResourceFetchingFromRoute } from "@app/lib/api/resource_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import type { SpaceResource } from "@app/lib/resources/space_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+
+interface PostJoinProjectResponseBody {
+  success: boolean;
+}
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<PostJoinProjectResponseBody>>,
+  auth: Authenticator,
+  { space }: { space: SpaceResource }
+): Promise<void> {
+  switch (req.method) {
+    case "POST": {
+      if (!space.isProject()) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "You can only join projects, not regular spaces.",
+          },
+        });
+      }
+
+      if (space.isProjectAndRestricted()) {
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "workspace_auth_error",
+            message:
+              "This project is restricted. You need to be invited to join.",
+          },
+        });
+      }
+
+      if (space.isMember(auth)) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "You are already a member of this project.",
+          },
+        });
+      }
+
+      const memberGroup = space.groups.find((g) => g.kind === "regular");
+
+      if (!memberGroup) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "Project member group not found.",
+          },
+        });
+      }
+
+      const result = await memberGroup.joinGroup(auth);
+      if (result.isErr()) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: result.error.message,
+          },
+        });
+      }
+
+      return res.status(200).json({ success: true });
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, POST is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(
+  withResourceFetchingFromRoute(handler, {
+    space: { requireCanReadOrAdministrate: true },
+  })
+);


### PR DESCRIPTION


https://github.com/user-attachments/assets/d94c33d6-7962-4f1b-b47b-e351a560ad31



## Description
Allow workspace members to join public projects directly from the conversation view. Non-members see a CTA prompting them to join.

- Add `POST /api/w/[wId]/spaces/[spaceId]/join` endpoint for self-joining
  - I'll remove this endpoint and the `leave` one introduced [here](https://github.com/dust-tt/dust/pull/20937/changes#diff-e3dbaf0ce9041da7a22dbc492befd721b68e68ad6ad3dd6bb58d6fba7b55961c) in favor of `dangerouslyRemoveMembers` and `dangerouslyAddMembers` once [this PR](https://github.com/dust-tt/dust/pull/20843/changes#diff-e3dbaf0ce9041da7a22dbc492befd721b68e68ad6ad3dd6bb58d6fba7b55961c) is merged
- Add `joinGroup` method on `GroupResource` for self-join flows
- Create `ProjectJoinCTA` component shown to non-members
- Update `ConversationViewer` to track project membership status
- Block reactions for non-project members
- Add `useJoinProject` and update `useLeaveProject` hooks

## Tests
- [x] Access a project conversation as non-member, verify CTA appears
- [x] Click "Join" on public project, verify success and CTA disappears
- [x] Verify restricted projects show "invitation required" message
- [x] Verify reactions blocked for non-members
- [x] Leave project, verify CTA reappears

## Risk
low

## Deploy plan
front