### PR TITLE
[front] Fix slack connection UI behind feature flag

### DIFF
--- a/front/components/data_source/ConnectorPermissionsModal.tsx
+++ b/front/components/data_source/ConnectorPermissionsModal.tsx
@@ -266,6 +266,7 @@ function UpdateConnectionOAuthModal({
   const { isDark } = useTheme();
   const [extraConfig, setExtraConfig] = useState<Record<string, string>>({});
   const [isExtraConfigValid, setIsExtraConfigValid] = useState(true);
+  const { hasFeature } = useFeatureFlags({ workspaceId: owner.sId });
 
   const { user } = useUser();
 
@@ -277,13 +278,17 @@ function UpdateConnectionOAuthModal({
     configKey: "privateIntegrationCredentialId",
     dataSource,
     owner,
-    disabled: !isSlack,
+    disabled:
+      !isSlack || !hasFeature("self_created_slack_app_connector_rollout"),
   });
 
   const { isLegacySlackApp } = useSlackIsLegacy({
     workspaceId: owner.sId,
     credentialId: slackCredentialId,
-    disabled: !isSlack || !slackCredentialId,
+    disabled:
+      !isSlack ||
+      !slackCredentialId ||
+      !hasFeature("self_created_slack_app_connector_rollout"),
   });
 
   // TODO(slackstorm 2025-12-18): Decide if we want to migrate existing slack connections to the new model. Remove all those flags if it's the case.
@@ -291,7 +296,8 @@ function UpdateConnectionOAuthModal({
   const showSlackAppMigrationDisclaimer =
     MIGRATE_LEGACY_SLACK_APPS && isLegacySlackApp;
   const showSlackOauthExtraComponent =
-    MIGRATE_LEGACY_SLACK_APPS || !isLegacySlackApp;
+    MIGRATE_LEGACY_SLACK_APPS ||
+    hasFeature("self_created_slack_app_connector_rollout");
 
   if (!connectorProvider || !user) {
     return null;

--- a/front/lib/swr/oauth.ts
+++ b/front/lib/swr/oauth.ts
@@ -66,7 +66,7 @@ export function useSlackIsLegacy({
     credentialId ? `?credentialId=${encodeURIComponent(credentialId)}` : ""
   }`;
 
-  const { data, error, mutate } = useSWRWithDefaults(
+  const { data, error, mutate, isLoading } = useSWRWithDefaults(
     url,
     slackIsLegacyFetcher,
     {
@@ -75,10 +75,9 @@ export function useSlackIsLegacy({
   );
 
   return {
-    isLegacySlackApp: data?.isLegacySlackApp ?? null,
-    error,
-    isLoading:
-      !error && !data && !!credentialId && !(disabled ?? !credentialId),
+    isLegacySlackApp: data?.isLegacySlackApp ?? false,
+    isError: !!error,
+    isLoading,
     mutateIsLegacy: mutate,
   };
 }

--- a/front/pages/api/w/[wId]/credentials/slack_is_legacy.ts
+++ b/front/pages/api/w/[wId]/credentials/slack_is_legacy.ts
@@ -58,7 +58,7 @@ async function handler(
         return apiError(req, res, {
           status_code: 404,
           api_error: {
-            type: "invalid_request_error",
+            type: "connector_credentials_not_found",
             message: "The credential you requested was not found.",
           },
         });
@@ -68,10 +68,11 @@ async function handler(
 
       if (credential.metadata.workspace_id !== owner.sId) {
         return apiError(req, res, {
-          status_code: 404,
+          status_code: 400,
           api_error: {
             type: "invalid_request_error",
-            message: "The credential you requested was not found.",
+            message:
+              "The credential you requested does not belong to your workspace.",
           },
         });
       }

--- a/front/types/error.ts
+++ b/front/types/error.ts
@@ -57,6 +57,7 @@ const API_ERROR_TYPES = [
   "connector_oauth_user_missing_rights",
   "connector_provider_not_supported",
   "connector_credentials_error",
+  "connector_credentials_not_found",
   "connector_operation_in_progress",
   "agent_configuration_not_found",
   "agent_group_permission_error",


### PR DESCRIPTION
## Description

Gate slack legacy check and migration UI behind `self_created_slack_app_connector_rollout` feature flag to prevent users from seeing self-created app credential form without it.

Previously it was checking the related credential to determine if the user was on the legacy slack app. This does not work with the relocation scenario : the connector is duplicated in the new region, but the related credential does not exist
-> this was leading to the migrated workspace to see the form even if it was previously set up with our slack app

Tiny misc fixes:
- Add feature flag checks to `useSlackIsLegacy` and `useConnectorPrivateIntegrationCredential` hooks
- Fix `isLoading` state in `useSlackIsLegacy` to use SWR's native isLoading
- Add `connector_credentials_not_found` error type for clearer error handling
- Fix 404 → 400 status for credential workspace mismatch

## Tests

Manual testing with feature flag enabled/disabled.

## Risk


## Deploy Plan

