### PR TITLE
Allow setting a date in unstuck syncing node plugin to make it more tactical

### DIFF
--- a/connectors/src/connectors/notion/lib/cli.ts
+++ b/connectors/src/connectors/notion/lib/cli.ts
@@ -509,7 +509,13 @@ export const notion = async ({
     // Clearing the parentsLastUpdatedAt field will force a resync of all parents at the end of the next sync
     case "clear-parents-last-updated-at": {
       const connector = await getConnector(args);
-      await clearParentsLastUpdatedAt({ connectorId: connector.id });
+      const resetToDate = args.resetToDate
+        ? new Date(args.resetToDate)
+        : undefined;
+      await clearParentsLastUpdatedAt({
+        connectorId: connector.id,
+        resetToDate,
+      });
       return { success: true };
     }
 

--- a/connectors/src/connectors/notion/temporal/activities.ts
+++ b/connectors/src/connectors/notion/temporal/activities.ts
@@ -3445,8 +3445,10 @@ export async function maybeUpdateOrphaneResourcesParents({
 
 export async function clearParentsLastUpdatedAt({
   connectorId,
+  resetToDate,
 }: {
   connectorId: ModelId;
+  resetToDate?: Date;
 }): Promise<void> {
   const connector = await ConnectorResource.fetchById(connectorId);
   const notionConnectorState = await NotionConnectorStateModel.findOne({
@@ -3464,11 +3466,16 @@ export async function clearParentsLastUpdatedAt({
       workspaceId: connector.workspaceId,
       dataSourceId: connector.dataSourceId,
       provider: "notion",
+      resetToDate: resetToDate ?? null,
     },
-    "Clearing parents last updated at"
+    resetToDate
+      ? "Setting parents last updated at to specific date"
+      : "Clearing parents last updated at"
   );
 
-  await notionConnectorState.update({ parentsLastUpdatedAt: null });
+  await notionConnectorState.update({
+    parentsLastUpdatedAt: resetToDate ?? null,
+  });
 }
 
 // Finds the next database to upsert for the connector.


### PR DESCRIPTION
## Description

The Notion unstuck Node plugin clears `parentsLastUpdatedAt`, which causes all nodes to be reprocessed and can take days. But in many cases, the issue only exists for recent nodes.

This change allows setting a date in the Notion unstuck syncing node plugin to make it more tactical. I opted for a plain date using a date picker to make it easier to choose. We rarely need more granularity than that (and can always update the DB directly if we do).

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Only affects poke plugin

## Deploy Plan

Front, Connectors