### PR TITLE
[front] enh: Add paginated fetch of project's conversations + Infinite Scroll

### DIFF
--- a/front/components/assistant/conversation/space/conversations/SpaceConversationsTab.tsx
+++ b/front/components/assistant/conversation/space/conversations/SpaceConversationsTab.tsx
@@ -16,13 +16,13 @@ import { SpaceConversationListItem } from "@app/components/assistant/conversatio
 import { SpaceConversationsActions } from "@app/components/assistant/conversation/space/conversations/SpaceConversationsActions";
 import { SpaceJournalEntry } from "@app/components/assistant/conversation/space/conversations/SpaceJournalEntry";
 import { getGroupConversationsByDate } from "@app/components/assistant/conversation/utils";
+import { InfiniteScroll } from "@app/components/InfiniteScroll";
 import { DropzoneContainer } from "@app/components/misc/DropzoneContainer";
 import { ProjectJoinCTA } from "@app/components/spaces/ProjectJoinCTA";
 import { useMarkAllConversationsAsRead } from "@app/hooks/useMarkAllConversationsAsRead";
 import { useSearchConversations } from "@app/hooks/useSearchConversations";
 import { useAppRouter } from "@app/lib/platform";
 import { getConversationRoute } from "@app/lib/utils/router";
-import type { RichSpaceType } from "@app/pages/api/w/[wId]/spaces/[spaceId]";
 import type {
   ContentFragmentsType,
   ConversationType,
@@ -46,7 +46,10 @@ interface SpaceConversationsTabProps {
   user: UserType;
   conversations: ConversationType[];
   isConversationsLoading: boolean;
-  spaceInfo: RichSpaceType;
+  hasMore: boolean;
+  loadMore: () => void;
+  isLoadingMore: boolean;
+  spaceInfo: GetSpaceResponseBody["space"];
   onSubmit: (
     input: string,
     mentions: RichMention[],
@@ -61,6 +64,9 @@ export function SpaceConversationsTab({
   user,
   conversations,
   isConversationsLoading,
+  hasMore,
+  loadMore,
+  isLoadingMore,
   spaceInfo,
   onSubmit,
   onOpenMembersPanel,
@@ -277,6 +283,16 @@ export function SpaceConversationsTab({
                     </div>
                   );
                 })}
+                <InfiniteScroll
+                  nextPage={loadMore}
+                  hasMore={hasMore}
+                  showLoader={isLoadingMore}
+                  loader={
+                    <div className="flex items-center justify-center py-4">
+                      <Spinner size="xs" />
+                    </div>
+                  }
+                />
               </div>
             </div>
           </div>

--- a/front/components/assistant/conversation/space/conversations/SpaceConversationsTab.tsx
+++ b/front/components/assistant/conversation/space/conversations/SpaceConversationsTab.tsx
@@ -23,6 +23,7 @@ import { useMarkAllConversationsAsRead } from "@app/hooks/useMarkAllConversation
 import { useSearchConversations } from "@app/hooks/useSearchConversations";
 import { useAppRouter } from "@app/lib/platform";
 import { getConversationRoute } from "@app/lib/utils/router";
+import type { GetSpaceResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]";
 import type {
   ContentFragmentsType,
   ConversationType,

--- a/front/lib/api/spaces/project_journal_summary.ts
+++ b/front/lib/api/spaces/project_journal_summary.ts
@@ -125,21 +125,14 @@ async function gatherProjectData(
   sections.push(`## Project Information`);
   sections.push(`- **Name**: ${space.name}`);
 
-  // Recent conversations - fetch all and sort/limit in memory
-  const allConversations = await ConversationResource.listConversationsInSpace(
-    auth,
-    {
+  // Recent conversations - fetch paginated (already sorted by updatedAt DESC)
+  const { conversations } =
+    await ConversationResource.listConversationsInSpacePaginated(auth, {
       spaceId: space.sId,
-    }
-  );
-
-  // Sort by updatedAt descending and take top 20
-  const conversations = allConversations
-    .sort(
-      (a, b) =>
-        new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
-    )
-    .slice(0, 20);
+      pagination: {
+        limit: 20,
+      },
+    });
 
   if (conversations.length > 0) {
     sections.push(`\n## Recent Conversations (${conversations.length} total)`);

--- a/front/lib/api/spaces/project_journal_summary.ts
+++ b/front/lib/api/spaces/project_journal_summary.ts
@@ -125,7 +125,6 @@ async function gatherProjectData(
   sections.push(`## Project Information`);
   sections.push(`- **Name**: ${space.name}`);
 
-  // Recent conversations - fetch paginated (already sorted by updatedAt DESC)
   const { conversations } =
     await ConversationResource.listConversationsInSpacePaginated(auth, {
       spaceId: space.sId,

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -3865,7 +3865,12 @@ describe("ConversationResource.listConversationsInSpacePaginated", () => {
     // eslint-disable-next-line dust/no-raw-sql
     await frontSequelize.query(
       `UPDATE conversations SET "updatedAt" = :updatedAt WHERE id = :id`,
-      { replacements: { updatedAt: dateFromDaysAgo(daysAgo).toISOString(), id: convo.id } }
+      {
+        replacements: {
+          updatedAt: dateFromDaysAgo(daysAgo).toISOString(),
+          id: convo.id,
+        },
+      }
     );
     return convo;
   };
@@ -3962,7 +3967,9 @@ describe("ConversationResource.listConversationsInSpacePaginated", () => {
     const lastValueMs = parseInt(result.lastValue ?? "", 10);
     expect(Number.isNaN(lastValueMs)).toBe(false);
     // Check timestamp is close to expected (within 1 second tolerance)
-    expect(Math.abs(lastValueMs - expectedTimestamp.getTime())).toBeLessThan(1000);
+    expect(Math.abs(lastValueMs - expectedTimestamp.getTime())).toBeLessThan(
+      1000
+    );
   });
 
   it("should fetch next page using lastValue cursor", async () => {
@@ -4023,13 +4030,14 @@ describe("ConversationResource.listConversationsInSpacePaginated", () => {
     const maxIterations = 10;
 
     while (iterations < maxIterations) {
-      const result = await ConversationResource.listConversationsInSpacePaginated(
-        adminAuth,
-        {
-          spaceId: space.sId,
-          pagination: { limit: 2, lastValue },
-        }
-      );
+      const result =
+        await ConversationResource.listConversationsInSpacePaginated(
+          adminAuth,
+          {
+            spaceId: space.sId,
+            pagination: { limit: 2, lastValue },
+          }
+        );
 
       allSids.push(...result.conversations.map((c) => c.sId));
 
@@ -4141,26 +4149,22 @@ describe("ConversationResource.listConversationsInSpacePaginated", () => {
     );
 
     // Without includeDeleted - should only return convo1
-    const resultWithoutDeleted = await ConversationResource.listConversationsInSpacePaginated(
-      adminAuth,
-      {
+    const resultWithoutDeleted =
+      await ConversationResource.listConversationsInSpacePaginated(adminAuth, {
         spaceId: space.sId,
         pagination: { limit: 10 },
-      }
-    );
+      });
 
     expect(resultWithoutDeleted.conversations).toHaveLength(1);
     expect(resultWithoutDeleted.conversations[0].sId).toBe(convo1.sId);
 
     // With includeDeleted - should return both
-    const resultWithDeleted = await ConversationResource.listConversationsInSpacePaginated(
-      adminAuth,
-      {
+    const resultWithDeleted =
+      await ConversationResource.listConversationsInSpacePaginated(adminAuth, {
         spaceId: space.sId,
         options: { includeDeleted: true },
         pagination: { limit: 10 },
-      }
-    );
+      });
 
     const sIds = resultWithDeleted.conversations.map((c) => c.sId);
     expect(sIds).toContain(convo1.sId);

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -3846,3 +3846,324 @@ describe("ConversationResource.isConversationCreator", () => {
     }
   });
 });
+
+describe("ConversationResource.listConversationsInSpacePaginated", () => {
+  let adminAuth: Authenticator;
+  let workspace: LightWorkspaceType;
+  let space: SpaceResource;
+  let agents: LightAgentConfigurationType[];
+  let conversationIds: string[];
+
+  const createConvoWithUpdatedAt = async (daysAgo: number) => {
+    const convo = await ConversationFactory.create(adminAuth, {
+      agentConfigurationId: agents[0].sId,
+      requestedSpaceIds: [space.id],
+      spaceId: space.id,
+      messagesCreatedAt: [dateFromDaysAgo(daysAgo)],
+    });
+    const { frontSequelize } = await import("@app/lib/resources/storage");
+    // eslint-disable-next-line dust/no-raw-sql
+    await frontSequelize.query(
+      `UPDATE conversations SET "updatedAt" = :updatedAt WHERE id = :id`,
+      { replacements: { updatedAt: dateFromDaysAgo(daysAgo).toISOString(), id: convo.id } }
+    );
+    return convo;
+  };
+
+  beforeEach(async () => {
+    const {
+      authenticator,
+      user,
+      workspace: w,
+    } = await createResourceTest({
+      role: "admin",
+    });
+
+    workspace = w;
+    const adminUser = user;
+
+    adminAuth = authenticator;
+    agents = await setupTestAgents(workspace, adminUser);
+
+    // Create a space and add user
+    space = await SpaceFactory.regular(workspace);
+    const addMembersRes = await space.addMembers(adminAuth, {
+      userIds: [adminUser.sId],
+    });
+    assert(addMembersRes.isOk(), "Failed to add users to space");
+
+    // Refresh auth after adding members to space (permissions are cached)
+    adminAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      adminUser.sId,
+      workspace.sId
+    );
+
+    conversationIds = [];
+  });
+
+  afterEach(async () => {
+    for (const sId of conversationIds) {
+      await destroyConversation(adminAuth, { conversationId: sId });
+    }
+  });
+
+  it("should return first page with hasMore: true when more results exist", async () => {
+    const convo1 = await createConvoWithUpdatedAt(5);
+    const convo2 = await createConvoWithUpdatedAt(3);
+    const convo3 = await createConvoWithUpdatedAt(1);
+
+    conversationIds = [convo1.sId, convo2.sId, convo3.sId];
+
+    const result = await ConversationResource.listConversationsInSpacePaginated(
+      adminAuth,
+      {
+        spaceId: space.sId,
+        pagination: { limit: 2 },
+      }
+    );
+
+    expect(result.conversations).toHaveLength(2);
+    expect(result.hasMore).toBe(true);
+    expect(result.lastValue).not.toBeNull();
+  });
+
+  it("should return hasMore: false when no more results", async () => {
+    const convo1 = await createConvoWithUpdatedAt(1);
+
+    conversationIds = [convo1.sId];
+
+    const result = await ConversationResource.listConversationsInSpacePaginated(
+      adminAuth,
+      {
+        spaceId: space.sId,
+        pagination: { limit: 10 },
+      }
+    );
+
+    expect(result.conversations).toHaveLength(1);
+    expect(result.hasMore).toBe(false);
+  });
+
+  it("should return correct lastValue as timestamp string", async () => {
+    const convo1 = await createConvoWithUpdatedAt(1);
+
+    conversationIds = [convo1.sId];
+
+    const expectedTimestamp = dateFromDaysAgo(1);
+    const result = await ConversationResource.listConversationsInSpacePaginated(
+      adminAuth,
+      {
+        spaceId: space.sId,
+        pagination: { limit: 10 },
+      }
+    );
+
+    expect(result.lastValue).not.toBeNull();
+    const lastValueMs = parseInt(result.lastValue ?? "", 10);
+    expect(Number.isNaN(lastValueMs)).toBe(false);
+    // Check timestamp is close to expected (within 1 second tolerance)
+    expect(Math.abs(lastValueMs - expectedTimestamp.getTime())).toBeLessThan(1000);
+  });
+
+  it("should fetch next page using lastValue cursor", async () => {
+    const convo1 = await createConvoWithUpdatedAt(4);
+    const convo2 = await createConvoWithUpdatedAt(3);
+    const convo3 = await createConvoWithUpdatedAt(2);
+    const convo4 = await createConvoWithUpdatedAt(1);
+
+    conversationIds = [convo1.sId, convo2.sId, convo3.sId, convo4.sId];
+
+    // First page (newest first by default)
+    const page1 = await ConversationResource.listConversationsInSpacePaginated(
+      adminAuth,
+      {
+        spaceId: space.sId,
+        pagination: { limit: 2 },
+      }
+    );
+
+    expect(page1.conversations).toHaveLength(2);
+    expect(page1.hasMore).toBe(true);
+    const page1Sids = page1.conversations.map((c) => c.sId);
+    expect(page1Sids).toContain(convo4.sId);
+    expect(page1Sids).toContain(convo3.sId);
+
+    // Second page using lastValue
+    const page2 = await ConversationResource.listConversationsInSpacePaginated(
+      adminAuth,
+      {
+        spaceId: space.sId,
+        pagination: { limit: 2, lastValue: page1.lastValue ?? undefined },
+      }
+    );
+
+    expect(page2.conversations).toHaveLength(2);
+    expect(page2.hasMore).toBe(false);
+    const page2Sids = page2.conversations.map((c) => c.sId);
+    expect(page2Sids).toContain(convo2.sId);
+    expect(page2Sids).toContain(convo1.sId);
+
+    // No overlap between pages
+    expect(page1Sids.some((sId) => page2Sids.includes(sId))).toBe(false);
+  });
+
+  it("should iterate through all pages and return all conversations", async () => {
+    const convos = [];
+    for (let i = 0; i < 5; i++) {
+      const convo = await createConvoWithUpdatedAt(5 - i);
+      convos.push(convo);
+    }
+
+    conversationIds = convos.map((c) => c.sId);
+
+    // Collect all conversations through pagination
+    const allSids: string[] = [];
+    let lastValue: string | undefined;
+    let iterations = 0;
+    const maxIterations = 10;
+
+    while (iterations < maxIterations) {
+      const result = await ConversationResource.listConversationsInSpacePaginated(
+        adminAuth,
+        {
+          spaceId: space.sId,
+          pagination: { limit: 2, lastValue },
+        }
+      );
+
+      allSids.push(...result.conversations.map((c) => c.sId));
+
+      if (!result.hasMore) {
+        break;
+      }
+      lastValue = result.lastValue ?? undefined;
+      iterations++;
+    }
+
+    // Should have all 5 conversations
+    expect(allSids).toHaveLength(5);
+    for (const convo of convos) {
+      expect(allSids).toContain(convo.sId);
+    }
+  });
+
+  it("should return newest first by default (desc order)", async () => {
+    const convo1 = await createConvoWithUpdatedAt(3);
+    const convo2 = await createConvoWithUpdatedAt(1);
+
+    conversationIds = [convo1.sId, convo2.sId];
+
+    const result = await ConversationResource.listConversationsInSpacePaginated(
+      adminAuth,
+      {
+        spaceId: space.sId,
+        pagination: { limit: 10 },
+      }
+    );
+
+    expect(result.conversations).toHaveLength(2);
+    // Newest first (convo2 updated 1 day ago should come first)
+    expect(result.conversations[0].sId).toBe(convo2.sId);
+    expect(result.conversations[1].sId).toBe(convo1.sId);
+  });
+
+  it("should return oldest first when orderDirection is asc", async () => {
+    const convo1 = await createConvoWithUpdatedAt(3);
+    const convo2 = await createConvoWithUpdatedAt(1);
+
+    conversationIds = [convo1.sId, convo2.sId];
+
+    const result = await ConversationResource.listConversationsInSpacePaginated(
+      adminAuth,
+      {
+        spaceId: space.sId,
+        pagination: { limit: 10, orderDirection: "asc" },
+      }
+    );
+
+    expect(result.conversations).toHaveLength(2);
+    // Oldest first (convo1 updated 3 days ago should come first)
+    expect(result.conversations[0].sId).toBe(convo1.sId);
+    expect(result.conversations[1].sId).toBe(convo2.sId);
+  });
+
+  it("should return empty result for invalid spaceId", async () => {
+    const result = await ConversationResource.listConversationsInSpacePaginated(
+      adminAuth,
+      {
+        spaceId: "invalid-space-id",
+        pagination: { limit: 10 },
+      }
+    );
+
+    expect(result.conversations).toHaveLength(0);
+    expect(result.hasMore).toBe(false);
+    expect(result.lastValue).toBeNull();
+  });
+
+  it("should return empty result for empty space", async () => {
+    // Create a new empty space
+    const emptySpace = await SpaceFactory.regular(workspace);
+    const addMembersRes = await emptySpace.addMembers(adminAuth, {
+      userIds: [adminAuth.getNonNullableUser().sId],
+    });
+    assert(addMembersRes.isOk(), "Failed to add user to empty space");
+
+    // Refresh auth after adding members
+    adminAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      adminAuth.getNonNullableUser().sId,
+      workspace.sId
+    );
+
+    const result = await ConversationResource.listConversationsInSpacePaginated(
+      adminAuth,
+      {
+        spaceId: emptySpace.sId,
+        pagination: { limit: 10 },
+      }
+    );
+
+    expect(result.conversations).toHaveLength(0);
+    expect(result.hasMore).toBe(false);
+    expect(result.lastValue).toBeNull();
+  });
+
+  it("should respect includeDeleted option", async () => {
+    const convo1 = await createConvoWithUpdatedAt(2);
+    const convo2 = await createConvoWithUpdatedAt(1);
+
+    conversationIds = [convo1.sId, convo2.sId];
+
+    // Delete one conversation
+    await ConversationModel.update(
+      { visibility: "deleted" },
+      { where: { id: convo2.id } }
+    );
+
+    // Without includeDeleted - should only return convo1
+    const resultWithoutDeleted = await ConversationResource.listConversationsInSpacePaginated(
+      adminAuth,
+      {
+        spaceId: space.sId,
+        pagination: { limit: 10 },
+      }
+    );
+
+    expect(resultWithoutDeleted.conversations).toHaveLength(1);
+    expect(resultWithoutDeleted.conversations[0].sId).toBe(convo1.sId);
+
+    // With includeDeleted - should return both
+    const resultWithDeleted = await ConversationResource.listConversationsInSpacePaginated(
+      adminAuth,
+      {
+        spaceId: space.sId,
+        options: { includeDeleted: true },
+        pagination: { limit: 10 },
+      }
+    );
+
+    const sIds = resultWithDeleted.conversations.map((c) => c.sId);
+    expect(sIds).toContain(convo1.sId);
+    expect(sIds).toContain(convo2.sId);
+  });
+});

--- a/front/lib/swr/conversations.ts
+++ b/front/lib/swr/conversations.ts
@@ -35,6 +35,7 @@ import type { GetBySpacesSummaryResponseBody } from "@app/pages/api/w/[wId]/assi
 import type { GetSpaceConversationsResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations/spaces/[spaceId]";
 import type {
   ConversationError,
+  ConversationType,
   ConversationWithoutContentType,
   LightWorkspaceType,
 } from "@app/types";
@@ -122,30 +123,70 @@ export function useSpaceConversationsSummary({
   };
 }
 
+const DEFAULT_CONVERSATIONS_PAGE_SIZE = 20;
+
 export function useSpaceConversations({
   workspaceId,
   spaceId,
-  options,
+  limit = DEFAULT_CONVERSATIONS_PAGE_SIZE,
 }: {
   workspaceId: string;
   spaceId: string | null;
-  options?: { disabled: boolean };
+  limit?: number;
 }) {
-  const spaceConversationsFetcher: Fetcher<GetSpaceConversationsResponseBody> =
+  const conversationsFetcher: Fetcher<GetSpaceConversationsResponseBody> =
     fetcher;
 
-  const { data, error, mutate } = useSWRWithDefaults(
-    spaceId
-      ? `/api/w/${workspaceId}/assistant/conversations/spaces/${spaceId}`
-      : null,
-    spaceConversationsFetcher,
-    options
-  );
+  const { data, error, mutate, size, setSize, isValidating } =
+    useSWRInfiniteWithDefaults(
+      (
+        pageIndex: number,
+        previousPageData: GetSpaceConversationsResponseBody | null
+      ) => {
+        if (!spaceId) {
+          return null;
+        }
+
+        if (previousPageData === null) {
+          return `/api/w/${workspaceId}/assistant/conversations/spaces/${spaceId}`;
+        }
+
+        if (!previousPageData.hasMore) {
+          return null;
+        }
+
+        return `/api/w/${workspaceId}/assistant/conversations/spaces/${spaceId}?lastValue=${previousPageData.lastValue}&limit=${limit}`;
+      },
+      conversationsFetcher,
+      {
+        revalidateAll: false,
+        revalidateOnFocus: false,
+      }
+    );
+
+  const conversations = useMemo(() => {
+    if (!data) {
+      return emptyArray<ConversationType>();
+    }
+    return data.flatMap((page) => page.conversations);
+  }, [data]);
+
+  const hasMore = data ? (data[data.length - 1]?.hasMore ?? false) : false;
+
+  const loadMore = useCallback(() => {
+    if (hasMore && !isValidating) {
+      void setSize(size + 1);
+    }
+  }, [hasMore, isValidating, setSize, size]);
 
   return {
-    conversations: data?.conversations ?? emptyArray(),
+    conversations,
     isConversationsLoading: !error && !data,
     isConversationsError: error,
+    isLoadingMore: isValidating && size > 1,
+    isValidating,
+    hasMore,
+    loadMore,
     mutateConversations: mutate,
   };
 }

--- a/front/pages/api/w/[wId]/assistant/conversations/spaces/[spaceId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/spaces/[spaceId]/index.ts
@@ -82,6 +82,8 @@ async function handler(
       });
 
       // Fetch full conversation details for the paginated results
+      // We're doing N+1 queries here, very bad for scaling
+      // TODO(@jd) - Find a better way
       const spaceConversationsFull = await concurrentExecutor(
         spaceConversations,
         async (c) => getConversation(auth, c.sId),

--- a/front/pages/api/w/[wId]/assistant/conversations/spaces/[spaceId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/spaces/[spaceId]/index.ts
@@ -2,16 +2,19 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { getPaginationParams } from "@app/lib/api/pagination";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { apiError } from "@app/logger/withlogging";
 import type { ConversationType, WithAPIErrorResponse } from "@app/types";
-import { removeNulls } from "@app/types";
+import { isString, removeNulls } from "@app/types";
 
 export type GetSpaceConversationsResponseBody = {
   conversations: ConversationType[];
+  hasMore: boolean;
+  lastValue: string | null;
 };
 
 async function handler(
@@ -20,10 +23,10 @@ async function handler(
   auth: Authenticator
 ): Promise<void> {
   switch (req.method) {
-    case "GET":
+    case "GET": {
       const { spaceId } = req.query;
 
-      if (typeof spaceId !== "string") {
+      if (!isString(spaceId)) {
         return apiError(req, res, {
           status_code: 400,
           api_error: {
@@ -32,6 +35,25 @@ async function handler(
           },
         });
       }
+
+      const paginationRes = getPaginationParams(req, {
+        defaultLimit: 20,
+        defaultOrderColumn: "updatedAt",
+        defaultOrderDirection: "desc",
+        supportedOrderColumn: ["updatedAt"],
+      });
+
+      if (paginationRes.isErr()) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: paginationRes.error.reason,
+          },
+        });
+      }
+
+      const pagination = paginationRes.value;
 
       // Fetch and verify space access
       const space = await SpaceResource.fetchById(auth, spaceId);
@@ -45,14 +67,21 @@ async function handler(
         });
       }
 
-      // Get all conversations for the space
-      const spaceConversations =
-        await ConversationResource.listConversationsInSpace(auth, {
-          spaceId,
-        });
+      // Get paginated conversations for the space
+      const {
+        conversations: spaceConversations,
+        hasMore,
+        lastValue,
+      } = await ConversationResource.listConversationsInSpacePaginated(auth, {
+        spaceId,
+        pagination: {
+          limit: pagination.limit,
+          lastValue: pagination.lastValue,
+          orderDirection: pagination.orderDirection,
+        },
+      });
 
-      // This is not going to scale AT ALL but it's a quick and dirty way to get the full conversations for the space as we display more informations than usual.
-      // TODO(conversations-groups) Implement pagination.
+      // Fetch full conversation details for the paginated results
       const spaceConversationsFull = await concurrentExecutor(
         spaceConversations,
         async (c) => getConversation(auth, c.sId),
@@ -63,8 +92,10 @@ async function handler(
         conversations: removeNulls(
           spaceConversationsFull.map((c) => (c.isOk() ? c.value : null))
         ),
+        hasMore,
+        lastValue,
       });
-
+    }
     default:
       return apiError(req, res, {
         status_code: 405,


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/6205

- `pages/api/v1/w/[wId]/spaces/[spaceId]/conversations/index.ts` now returns a paginated result
- conversation tab in projects uses this pagination for infinite scroll

## Tests


 - Tested manually with this script, running `npx tsx scripts/seed_project_conversations.ts --wId DevWkSpace --count 50`
- Tested that `updatedAt` is indeed the right column to track for ordering, posting a new message actually bumps up this column.
- Some unit tests are also part of the PR

<details><summary>seed script</summary>
<p>


```
import parseArgs from "minimist";

import { createSpaceAndGroup } from "@app/lib/api/spaces";
import { Authenticator } from "@app/lib/auth";
import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
import {
  AgentMessageModel,
  ConversationModel,
  ConversationParticipantModel,
  MessageModel,
  UserMessageModel,
} from "@app/lib/models/agent/conversation";
import { SpaceResource } from "@app/lib/resources/space_resource";
import { generateRandomModelSId } from "@app/lib/resources/string_ids";
import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
import logger from "@app/logger/logger";
import type { ConversationVisibility, ModelId } from "@app/types";

const CONVERSATION_TITLES = [
  "Planning Q1 roadmap",
  "Bug in authentication flow",
  "Customer feedback analysis",
  "Weekly standup notes",
  "API design discussion",
  "Performance optimization ideas",
  "New feature brainstorm",
  "Code review guidelines",
  "Database migration plan",
  "Security audit findings",
  "User research insights",
  "Marketing campaign ideas",
  "Team retrospective",
  "Infrastructure costs review",
  "Product demo preparation",
  "Onboarding improvements",
  "Tech debt prioritization",
  "Integration testing strategy",
  "Release checklist",
  "Documentation update",
  "Accessibility improvements",
  "Mobile app feedback",
  "Analytics dashboard design",
  "Error handling patterns",
  "Caching strategy discussion",
  "CI/CD pipeline optimization",
  "Monitoring and alerting setup",
  "Data privacy compliance",
  "Load testing results",
  "Incident post-mortem",
];

const USER_MESSAGES = [
  "Can you help me understand this?",
  "What's the best approach here?",
  "I need some guidance on this topic.",
  "Can you analyze this for me?",
  "What do you think about this idea?",
  "Please review this and provide feedback.",
  "How should we proceed with this?",
  "Can you summarize the key points?",
  "What are the pros and cons?",
  "Help me draft a response.",
];

async function main() {
  const args = parseArgs(process.argv.slice(2));

  if (!args.wId) {
    console.error(
      "Usage: npx tsx admin/seed_project_conversations.ts --wId <workspaceId> [--count <number>]"
    );
    console.error("  --wId: Workspace ID (required)");
    console.error("  --count: Number of conversations to create (default: 25)");
    process.exit(1);
  }

  const workspaceId = args.wId;
  const conversationCount = args.count ? parseInt(args.count, 10) : 25;

  logger.info({ workspaceId, conversationCount }, "Starting seed script");

  // Get workspace
  const workspace = await WorkspaceResource.fetchById(workspaceId);
  if (!workspace) {
    console.error(`Workspace not found: ${workspaceId}`);
    process.exit(1);
  }

  // Create authenticator for admin
  const auth = await Authenticator.internalAdminForWorkspace(workspaceId);
  const user = auth.user();
  const workspaceType = auth.getNonNullableWorkspace();

  // Find or create a project space
  let projectSpace = await findFirstProject(auth);

  if (!projectSpace) {
    logger.info("No project found, creating one...");
    projectSpace = await findOrCreateProject(auth, "Test Project");
    logger.info({ spaceId: projectSpace.sId }, "Created project");
  } else {
    logger.info(
      { spaceId: projectSpace.sId, name: projectSpace.name },
      "Found existing project"
    );
  }

  // Get a valid agent configuration (optional - conversations work without agent messages)
  const agentConfig = await AgentConfigurationModel.findOne({
    where: { workspaceId: workspace.id, status: "active" },
  });

  if (agentConfig) {
    logger.info({ agentId: agentConfig.sId }, "Using agent configuration");
  } else {
    logger.info(
      "No active agent configuration found - will create conversations without agent responses"
    );
  }

  // Create conversations with varying dates spread across last month
  const now = Date.now();
  const dayMs = 24 * 60 * 60 * 1000;

  // Distribution: today, this week, last week, 2-4 weeks ago
  const getRandomDaysAgo = (index: number, total: number): number => {
    const bucket = index / total;
    if (bucket < 0.2) {
      // 20% from today/yesterday
      return Math.random() * 2;
    } else if (bucket < 0.5) {
      // 30% from this week (2-7 days ago)
      return 2 + Math.random() * 5;
    } else if (bucket < 0.75) {
      // 25% from last week (7-14 days ago)
      return 7 + Math.random() * 7;
    } else {
      // 25% from 2-4 weeks ago
      return 14 + Math.random() * 14;
    }
  };

  for (let i = 0; i < conversationCount; i++) {
    const title = CONVERSATION_TITLES[i % CONVERSATION_TITLES.length];
    const daysAgo = getRandomDaysAgo(i, conversationCount);
    const createdAt = new Date(now - daysAgo * dayMs);

    const conversation = await createConversation(auth, {
      title: `${title} #${i + 1}`,
      visibility: "unlisted",
      spaceId: projectSpace.id,
    });

    // Update createdAt and updatedAt to spread across time
    // Use raw SQL to bypass Sequelize's automatic timestamp management
    await ConversationModel.sequelize?.query(
      `UPDATE conversations SET "createdAt" = :createdAt, "updatedAt" = :updatedAt WHERE id = :id`,
      {
        replacements: {
          createdAt: createdAt.toISOString(),
          updatedAt: createdAt.toISOString(),
          id: conversation.id,
        },
      }
    );

    // Create participant record so the conversation appears in user lists
    if (user) {
      await ConversationParticipantModel.create({
        conversationId: conversation.id,
        action: "posted",
        userId: user.id,
        workspaceId: workspaceType.id,
        actionRequired: false,
        createdAt,
        updatedAt: createdAt,
      });
    }

    // Create a user message
    const userMessageRow = await UserMessageModel.create({
      createdAt,
      updatedAt: createdAt,
      userId: user?.id ?? null,
      workspaceId: workspaceType.id,
      content: USER_MESSAGES[i % USER_MESSAGES.length],
      userContextUsername: "testuser",
      userContextTimezone: "UTC",
      userContextFullName: "Test User",
      userContextEmail: "test@example.com",
      userContextProfilePictureUrl: null,
      userContextOrigin: "web",
      clientSideMCPServerIds: [],
    });

    const userMsg = await MessageModel.create({
      createdAt,
      updatedAt: createdAt,
      sId: generateRandomModelSId(),
      rank: 0,
      conversationId: conversation.id,
      parentId: null,
      userMessageId: userMessageRow.id,
      workspaceId: workspaceType.id,
    });

    // Create an agent response (if agent config exists)
    if (agentConfig) {
      const agentMessageRow = await AgentMessageModel.create({
        createdAt,
        updatedAt: createdAt,
        status: "succeeded",
        agentConfigurationId: agentConfig.sId,
        agentConfigurationVersion: agentConfig.version,
        workspaceId: workspaceType.id,
        skipToolsValidation: false,
      });

      await MessageModel.create({
        createdAt,
        updatedAt: createdAt,
        sId: generateRandomModelSId(),
        rank: 1,
        conversationId: conversation.id,
        parentId: userMsg.id,
        agentMessageId: agentMessageRow.id,
        workspaceId: workspaceType.id,
      });
    }

    logger.info(
      {
        index: i + 1,
        total: conversationCount,
        title: conversation.title,
        daysAgo,
      },
      "Created conversation"
    );
  }

  logger.info(
    {
      conversationCount,
      projectName: projectSpace.name,
      projectId: projectSpace.sId,
    },
    "Seed completed successfully"
  );
}

async function findFirstProject(
  auth: Authenticator
): Promise<SpaceResource | null> {
  const spaces = await SpaceResource.listWorkspaceSpaces(auth, {
    includeProjectSpaces: true,
  });
  return spaces.find((s) => s.kind === "project") ?? null;
}

async function findOrCreateProject(
  auth: Authenticator,
  name: string
): Promise<SpaceResource> {
  const spaces = await SpaceResource.listWorkspaceSpaces(auth, {
    includeProjectSpaces: true,
  });
  const existingProject = spaces.find(
    (s) => s.kind === "project" && s.name === name
  );
  if (existingProject) {
    return existingProject;
  }

  const result = await createSpaceAndGroup(auth, {
    name,
    isRestricted: false,
    spaceKind: "project",
    memberIds: [],
    managementMode: "manual",
  });

  if (result.isErr()) {
    throw new Error(`Failed to create project: ${result.error.message}`);
  }

  return result.value;
}

async function createConversation(
  auth: Authenticator,
  {
    title,
    visibility,
    spaceId,
  }: {
    title: string;
    visibility: ConversationVisibility;
    spaceId: ModelId;
  }
): Promise<ConversationModel> {
  const workspace = auth.getNonNullableWorkspace();

  return ConversationModel.create({
    sId: generateRandomModelSId(),
    workspaceId: workspace.id,
    title,
    visibility,
    spaceId,
    requestedSpaceIds: [spaceId],
  });
}

main()
  .then(() => {
    process.exit(0);
  })
  .catch((err) => {
    logger.error({ error: err }, "Seed script failed");
    console.error(err);
    process.exit(1);
  });

```
</p>
</details> 
## Risk

Low
Blast Radius: Conversations tab in projects

## Deploy Plan

- [ ] Deploy front