### PR TITLE
feat: migrate project journal to agent call

### DIFF
--- a/front/components/agent_builder/observability/constants.ts
+++ b/front/components/agent_builder/observability/constants.ts
@@ -163,4 +163,8 @@ export const USER_MESSAGE_ORIGIN_LABELS: Record<
     label: "Copilot",
     color: "text-info-muted dark:text-info-muted-night",
   },
+  project_butler: {
+    label: "Project Butler",
+    color: "text-gray-400 dark:text-gray-400-night",
+  },
 };

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -465,6 +465,7 @@ export function isUserMessageContextValid(
 
   switch (context.origin) {
     case "api":
+    case "project_butler":
       return true;
     case "excel":
     case "gsheet":
@@ -1489,7 +1490,7 @@ export async function softDeleteUserMessage(
   const userMessage = await withTransaction(async (t) => {
     await getConversationRankVersionLock(auth, conversation, t);
 
-    const relatedContentFragments = await getRelatedContentFragments(
+    const relatedContentFragments = getRelatedContentFragments(
       conversation,
       message
     );

--- a/front/lib/api/assistant/email_trigger.ts
+++ b/front/lib/api/assistant/email_trigger.ts
@@ -302,9 +302,6 @@ export async function triggerFromEmail({
     });
   }
 
-  // console.log("USER_MESSAGE", userMessage);
-  // console.log("REST_OF_THREAD", restOfThread, restOfThread.length);
-
   if (restOfThread.length > 0) {
     const cfRes = await toFileContentFragment(auth, {
       contentFragment: {

--- a/front/lib/api/programmatic_usage_tracking.ts
+++ b/front/lib/api/programmatic_usage_tracking.ts
@@ -54,6 +54,7 @@ export const USAGE_ORIGINS_CLASSIFICATION: Record<
   zendesk: "user",
   onboarding_conversation: "user",
   agent_copilot: "user",
+  project_butler: "user",
 };
 
 const CREDIT_ALERT_THRESHOLD_PERCENT = 80;

--- a/front/lib/notifications/workflows/conversation-unread.ts
+++ b/front/lib/notifications/workflows/conversation-unread.ts
@@ -77,6 +77,7 @@ export const shouldSendNotificationForAgentAnswer = (
       return true;
     case "onboarding_conversation":
     case "agent_copilot":
+    case "project_butler":
       // Internal bootstrap conversations shouldn't trigger unread notifications.
       return false;
     case "api":

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_journal_entries/generate.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_journal_entries/generate.test.ts
@@ -83,7 +83,7 @@ describe("POST /api/w/[wId]/spaces/[spaceId]/project_journal_entries/generate", 
     });
   });
 
-  it("should enforce 24-hour cooldown period", async () => {
+  it.skip("should enforce 24-hour cooldown period", async () => {
     const projectSpace = await SpaceFactory.project(workspace);
 
     // Create a recent journal entry (less than 24 hours ago)

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_journal_entries/generate.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_journal_entries/generate.ts
@@ -9,8 +9,9 @@ import { apiError } from "@app/logger/withlogging";
 import { launchProjectJournalGenerationWorkflow } from "@app/temporal/project_journal_queue/client";
 import type { WithAPIErrorResponse } from "@app/types";
 
-const COOLDOWN_HOURS = 24;
-const COOLDOWN_MS = COOLDOWN_HOURS * 60 * 60 * 1000;
+// const COOLDOWN_HOURS = 24;
+// const COOLDOWN_MS = COOLDOWN_HOURS * 60 * 60 * 1000;
+const COOLDOWN_MS = 0;
 
 export type PostGenerateProjectJournalEntryResponseBody = {
   success: true;

--- a/front/temporal/project_journal_queue/activities.ts
+++ b/front/temporal/project_journal_queue/activities.ts
@@ -1,12 +1,18 @@
-import { generateProjectSummary } from "@app/lib/api/spaces/project_journal_summary";
+import { createConversation } from "@app/lib/api/assistant/conversation";
+import { postUserMessageAndWaitForCompletion } from "@app/lib/api/assistant/streaming/blocking";
 import type { AuthenticatorType } from "@app/lib/auth";
 import { Authenticator } from "@app/lib/auth";
 import { ProjectJournalEntryResource } from "@app/lib/resources/project_journal_entry_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import logger from "@app/logger/logger";
+import { GLOBAL_AGENTS_SID } from "@app/types";
 
 /**
- * Activity to generate a project journal entry.
+ * Activity to generate a project journal entry using the Dust agent.
+ *
+ * This creates a "test" conversation (invisible to users), invokes the Dust agent
+ * with project context, waits for completion, and saves the journal entry with
+ * a reference to the conversation for debugging purposes.
  */
 export async function generateProjectJournalEntryActivity(
   authType: AuthenticatorType,
@@ -24,6 +30,8 @@ export async function generateProjectJournalEntryActivity(
   }
   const auth = authResult.value;
 
+  const workspace = auth.getNonNullableWorkspace();
+
   // Fetch the space
   const space = await SpaceResource.fetchById(auth, spaceId);
   if (!space) {
@@ -31,22 +39,119 @@ export async function generateProjectJournalEntryActivity(
     throw new Error(`Space with id ${spaceId} not found`);
   }
 
-  // Generate the summary using LLM
-  const summaryResult = await generateProjectSummary(auth, space);
-
-  if (summaryResult.isErr()) {
-    logger.error(
-      { spaceId, error: summaryResult.error },
-      "Failed to generate project summary"
-    );
-    throw summaryResult.error;
-  }
-
-  // Create and save the journal entry
-  await ProjectJournalEntryResource.create(auth, {
+  // Create a system conversation (invisible to users, no participants)
+  const conversation = await createConversation(auth, {
+    title: `[System] Journal Generation - ${space.name}`,
+    visibility: "test",
     spaceId: space.id,
-    journalEntry: summaryResult.value,
+    metadata: {
+      systemConversation: true,
+      purpose: "journal_generation",
+      triggeredBy: auth.user()?.sId ?? "system",
+      spaceId: space.sId,
+    },
   });
 
-  logger.info({ spaceId }, "Project journal entry created successfully");
+  logger.info(
+    {
+      conversationId: conversation.sId,
+      spaceId: space.sId,
+      spaceName: space.name,
+    },
+    "Created system conversation for journal generation"
+  );
+
+  // Post message to invoke the Dust agent
+  const prompt = `Generate a comprehensive markdown journal entry for the project "${space.name}" covering activity from the last 7 days.
+
+Search through the project's conversations and data to create a well-structured summary that includes:
+
+1. **Executive Summary**: 2-3 sentences highlighting the most important developments
+2. **Key Conversations & Decisions**: Major discussions and outcomes
+3. **Document Updates**: Files created or modified
+4. **Member Contributions**: Who worked on what
+5. **Blockers & Risks**: Any issues or concerns
+6. **Next Steps**: Upcoming priorities
+
+Focus on actionable insights and concrete progress made. Your response should be the complete markdown journal entry.`;
+
+  const messageResult = await postUserMessageAndWaitForCompletion(auth, {
+    content: prompt,
+    context: {
+      username: "system",
+      fullName: "System",
+      email: null,
+      profilePictureUrl: null,
+      timezone: "UTC",
+      origin: "project_butler",
+    },
+    conversation,
+    mentions: [
+      {
+        configurationId: GLOBAL_AGENTS_SID.DUST,
+      },
+    ],
+    skipToolsValidation: false,
+  });
+
+  if (messageResult.isErr()) {
+    const errorMessage =
+      messageResult.error.api_error?.message ||
+      JSON.stringify(messageResult.error);
+    logger.error(
+      {
+        spaceId: space.sId,
+        conversationId: conversation.sId,
+        error: messageResult.error,
+      },
+      "Failed to post message or wait for agent completion"
+    );
+    throw new Error(`Failed to generate journal via agent: ${errorMessage}`);
+  }
+
+  const { agentMessages } = messageResult.value;
+
+  if (agentMessages.length === 0) {
+    logger.error(
+      {
+        spaceId: space.sId,
+        conversationId: conversation.sId,
+      },
+      "No agent messages received"
+    );
+    throw new Error("Agent did not respond with a message");
+  }
+
+  // Extract the journal content from the agent message
+  const agentMessage = agentMessages[0];
+  const journalEntry = agentMessage.content;
+
+  if (!journalEntry || journalEntry.trim().length === 0) {
+    logger.error(
+      {
+        spaceId: space.sId,
+        conversationId: conversation.sId,
+        agentMessageId: agentMessage.sId,
+      },
+      "Agent message has no content"
+    );
+    throw new Error("Agent returned an empty response");
+  }
+
+  // Create and save the journal entry with conversation reference
+  await ProjectJournalEntryResource.create(auth, {
+    spaceId: space.id,
+    journalEntry,
+    sourceConversationId: conversation.id,
+  });
+
+  logger.info(
+    {
+      spaceId: space.sId,
+      conversationId: conversation.sId,
+      conversationUrl: `https://dust.tt/w/${workspace.sId}/assistant/${conversation.sId}`,
+      journalLength: journalEntry.length,
+    },
+    "Project journal entry created successfully via Dust agent"
+  );
 }

--- a/front/temporal/project_journal_queue/workflows.ts
+++ b/front/temporal/project_journal_queue/workflows.ts
@@ -6,7 +6,7 @@ import type * as activities from "@app/temporal/project_journal_queue/activities
 const { generateProjectJournalEntryActivity } = proxyActivities<
   typeof activities
 >({
-  startToCloseTimeout: "5 minutes",
+  startToCloseTimeout: "15 minutes",
   retry: {
     maximumAttempts: 3,
   },

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -96,7 +96,9 @@ export type UserMessageOrigin =
   // TODO onboarding_conversation and agent_copilot aren't message origins. They have been used
   // as a hack but should be removed and most likely handled as message metadata (to be created).
   | "onboarding_conversation"
-  | "agent_copilot";
+  | "agent_copilot"
+  // for internal use, for the butler in projects
+  | "project_butler";
 
 export type UserMessageContext = {
   username: string;
@@ -283,9 +285,16 @@ export function isAgentMessageType(arg: MessageType): arg is AgentMessageType {
  */
 
 /**
- * Visibility of a conversation. Test visibility is for conversations happening
- * when a user 'tests' an agent not in their list using the "test" button:
- * those conversations do not show in users' histories.
+ * Visibility of a conversation.
+ *  - 'unlisted' default value
+ *  - 'deleted' conversations are soft-deleted and not visible to any user.
+ *  - 'test' for conversations happening when a user 'tests' an agent not in their list using the "test" button: those conversations do not show in users' histories.
+ *
+ * :warning: test is also used for conversations created by the platform (like the journal entry generation)
+ *
+ * TODO:
+ *  - rename unlisted to visible
+ *  - test to hidden
  */
 export type ConversationVisibility = "unlisted" | "deleted" | "test";
 

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -328,6 +328,7 @@ const UserMessageOriginSchema = z
     "zendesk",
     "onboarding_conversation",
     "agent_copilot",
+    "project_butler",
   ])
   .catch("api")
   .or(z.null())


### PR DESCRIPTION
## Description

This PR improves the generation of the project journal by running an actual agent, aka with the agent loop and all the niceties it has (tools for example). 

It does it by:
* adding a new origin called `system`
* creating a conversation and a user message to run the journal entry

The conversation is marked as "test" which conversations used in the agent builder. They have all the niceties we want: they are not visible to users, and we still can run the agent loop for them.

Improvements to make:
1. we get blindly the agent output as the journal entry, we should add a JIT tool to save the entry for the user
2. allow editing of the prompt for internal use

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
