### PR TITLE
feat: use lastReadAt from user conversation reads table

### DIFF
--- a/front/lib/api/assistant/conversation/mentions.test.ts
+++ b/front/lib/api/assistant/conversation/mentions.test.ts
@@ -23,6 +23,7 @@ import {
   ConversationParticipantModel,
   MentionModel,
   MessageModel,
+  UserConversationReadsModel,
 } from "@app/lib/models/agent/conversation";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { GroupResource } from "@app/lib/resources/group_resource";
@@ -3599,9 +3600,16 @@ describe("validateUserMention", () => {
         userId: mentionedUser.id,
       },
     });
+    const conversationRead = await UserConversationReadsModel.findOne({
+      where: {
+        workspaceId: workspace.id,
+        conversationId: conversation.id,
+        userId: mentionedUser.id,
+      },
+    });
 
     expect(participant).not.toBeNull();
-    expect(participant?.lastReadAt).toBeNull();
+    expect(conversationRead?.lastReadAt).toBeUndefined();
     expect(participant?.action).toBe("subscribed");
   });
 

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -1053,7 +1053,7 @@ describe("listConversationsForUser", () => {
         ))!.id,
         workspaceId: userAuth.getNonNullableWorkspace().id,
         userId: userAuth.getNonNullableUser().id,
-        lastReadAt: new Date(),
+        lastReadAt: dateFromDaysAgo(10),
       });
 
       // Mark readConvo as read
@@ -1314,10 +1314,7 @@ describe("listConversationsForUser", () => {
 
       // Mark unreadSpaceConvo as unread
       await UserConversationReadsModel.upsert({
-        conversationId: (await ConversationResource.fetchById(
-          adminAuth,
-          unreadSpaceConvo.sId
-        ))!.id,
+        conversationId: unreadSpaceConvo.id,
         workspaceId: userAuth.getNonNullableWorkspace().id,
         userId: userAuth.getNonNullableUser().id,
         lastReadAt: dateFromDaysAgo(2),

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -1006,7 +1006,7 @@ describe("listConversationsForUser", () => {
 
   describe("onlyUnread filter", () => {
     it("should return only unread conversations when onlyUnread is true", async () => {
-      const { ConversationParticipantModel } = await import(
+      const { UserConversationReadsModel } = await import(
         "@app/lib/models/agent/conversation"
       );
 
@@ -1035,49 +1035,37 @@ describe("listConversationsForUser", () => {
       });
 
       // Mark the original conversation as read
-      await ConversationParticipantModel.update(
-        { lastReadAt: new Date() },
-        {
-          where: {
-            conversationId: (await ConversationResource.fetchById(
-              adminAuth,
-              conversationIds[0]
-            ))!.id,
-            workspaceId: userAuth.getNonNullableWorkspace().id,
-            userId: userAuth.getNonNullableUser().id,
-          },
-        }
-      );
+      await UserConversationReadsModel.upsert({
+        conversationId: (await ConversationResource.fetchById(
+          adminAuth,
+          conversationIds[0]
+        ))!.id,
+        workspaceId: userAuth.getNonNullableWorkspace().id,
+        userId: userAuth.getNonNullableUser().id,
+        lastReadAt: new Date(),
+      });
 
       // Mark unreadConvo as unread
-      await ConversationParticipantModel.update(
-        { lastReadAt: dateFromDaysAgo(3) },
-        {
-          where: {
-            conversationId: (await ConversationResource.fetchById(
-              adminAuth,
-              unreadConvo.sId
-            ))!.id,
-            workspaceId: userAuth.getNonNullableWorkspace().id,
-            userId: userAuth.getNonNullableUser().id,
-          },
-        }
-      );
+      await UserConversationReadsModel.upsert({
+        conversationId: (await ConversationResource.fetchById(
+          adminAuth,
+          unreadConvo.sId
+        ))!.id,
+        workspaceId: userAuth.getNonNullableWorkspace().id,
+        userId: userAuth.getNonNullableUser().id,
+        lastReadAt: new Date(),
+      });
 
       // Mark readConvo as read
-      await ConversationParticipantModel.update(
-        { lastReadAt: new Date() },
-        {
-          where: {
-            conversationId: (await ConversationResource.fetchById(
-              adminAuth,
-              readConvo.sId
-            ))!.id,
-            workspaceId: userAuth.getNonNullableWorkspace().id,
-            userId: userAuth.getNonNullableUser().id,
-          },
-        }
-      );
+      await UserConversationReadsModel.upsert({
+        conversationId: (await ConversationResource.fetchById(
+          adminAuth,
+          readConvo.sId
+        ))!.id,
+        workspaceId: userAuth.getNonNullableWorkspace().id,
+        userId: userAuth.getNonNullableUser().id,
+        lastReadAt: new Date(),
+      });
 
       // Test with onlyUnread: true
       const unreadConversations =
@@ -1110,7 +1098,7 @@ describe("listConversationsForUser", () => {
 
     it("should return empty array when onlyUnread is true but user has no unread conversations", async () => {
       // Mark all conversations as read
-      const { ConversationParticipantModel } = await import(
+      const { UserConversationReadsModel } = await import(
         "@app/lib/models/agent/conversation"
       );
 
@@ -1120,16 +1108,12 @@ describe("listConversationsForUser", () => {
       );
       assert(conversation, "Conversation not found");
 
-      await ConversationParticipantModel.update(
-        { lastReadAt: new Date() },
-        {
-          where: {
-            conversationId: conversation.id,
-            workspaceId: userAuth.getNonNullableWorkspace().id,
-            userId: userAuth.getNonNullableUser().id,
-          },
-        }
-      );
+      await UserConversationReadsModel.upsert({
+        conversationId: conversation.id,
+        workspaceId: userAuth.getNonNullableWorkspace().id,
+        userId: userAuth.getNonNullableUser().id,
+        lastReadAt: new Date(),
+      });
 
       const unreadConversations =
         await ConversationResource.listConversationsForUser(userAuth, {
@@ -1262,7 +1246,7 @@ describe("listConversationsForUser", () => {
 
   describe("combined filters", () => {
     it("should filter by both onlyUnread and kind when both are specified", async () => {
-      const { ConversationParticipantModel } = await import(
+      const { UserConversationReadsModel } = await import(
         "@app/lib/models/agent/conversation"
       );
 
@@ -1329,49 +1313,38 @@ describe("listConversationsForUser", () => {
       });
 
       // Mark unreadSpaceConvo as unread
-      await ConversationParticipantModel.update(
-        { lastReadAt: dateFromDaysAgo(2) },
-        {
-          where: {
-            conversationId: (await ConversationResource.fetchById(
-              userAuth,
-              unreadSpaceConvo.sId
-            ))!.id,
-            workspaceId: userAuth.getNonNullableWorkspace().id,
-            userId: userAuth.getNonNullableUser().id,
-          },
-        }
-      );
+      await UserConversationReadsModel.upsert({
+        conversationId: (await ConversationResource.fetchById(
+          adminAuth,
+          unreadSpaceConvo.sId
+        ))!.id,
+        workspaceId: userAuth.getNonNullableWorkspace().id,
+        userId: userAuth.getNonNullableUser().id,
+        lastReadAt: dateFromDaysAgo(2),
+      });
 
       // Mark readSpaceConvo as read
-      await ConversationParticipantModel.update(
-        { lastReadAt: new Date() },
-        {
-          where: {
-            conversationId: (await ConversationResource.fetchById(
-              userAuth,
-              readSpaceConvo.sId
-            ))!.id,
-            workspaceId: userAuth.getNonNullableWorkspace().id,
-            userId: userAuth.getNonNullableUser().id,
-          },
-        }
-      );
+      await UserConversationReadsModel.upsert({
+        conversationId: (await ConversationResource.fetchById(
+          userAuth,
+          readSpaceConvo.sId
+        ))!.id,
+        workspaceId: userAuth.getNonNullableWorkspace().id,
+        userId: userAuth.getNonNullableUser().id,
+        lastReadAt: new Date(),
+      });
 
       // Mark unreadPrivateConvo as unread
-      await ConversationParticipantModel.update(
-        { lastReadAt: null },
-        {
-          where: {
-            conversationId: (await ConversationResource.fetchById(
-              adminAuth,
-              unreadPrivateConvo.sId
-            ))!.id,
-            workspaceId: userAuth.getNonNullableWorkspace().id,
-            userId: userAuth.getNonNullableUser().id,
-          },
-        }
-      );
+      await UserConversationReadsModel.destroy({
+        where: {
+          conversationId: (await ConversationResource.fetchById(
+            adminAuth,
+            unreadPrivateConvo.sId
+          ))!.id,
+          workspaceId: userAuth.getNonNullableWorkspace().id,
+          userId: userAuth.getNonNullableUser().id,
+        },
+      });
 
       // Test with onlyUnread: true and kind: "space" - should only return unread space conversations
       const unreadSpaceConversations =

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -287,21 +287,29 @@ export class ConversationResource extends BaseResource<ConversationModel> {
 
     const participations = await ConversationParticipantModel.findAll({
       where: whereClause,
-      attributes: [
-        "actionRequired",
-        "conversationId",
-        "lastReadAt",
-        "updatedAt",
-        "userId",
-      ],
+      attributes: ["actionRequired", "conversationId", "updatedAt"],
     });
+
+    const conversationReads = await UserConversationReadsModel.findAll({
+      where: {
+        conversationId: {
+          [Op.in]: participations.map((p) => p.conversationId),
+        },
+        workspaceId: auth.getNonNullableWorkspace().id,
+        userId: user.id,
+      },
+    });
+
+    const conversationReadMap = new Map<number, Date>(
+      conversationReads.map((read) => [read.conversationId, read.lastReadAt])
+    );
 
     return new Map(
       participations.map((p) => [
         p.conversationId,
         {
           actionRequired: p.actionRequired,
-          lastReadAt: p.lastReadAt,
+          lastReadAt: conversationReadMap.get(p.conversationId) ?? null,
           updated: p.updatedAt.getTime(),
         },
       ])
@@ -1007,9 +1015,17 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       },
     });
 
+    const conversationRead = await UserConversationReadsModel.findOne({
+      where: {
+        conversationId: id,
+        workspaceId: auth.getNonNullableWorkspace().id,
+        userId: auth.getNonNullableUser().id,
+      },
+    });
+
     return {
       actionRequired: participant?.actionRequired ?? false,
-      lastReadAt: participant?.lastReadAt ?? null,
+      lastReadAt: conversationRead?.lastReadAt ?? null,
     };
   }
 
@@ -1595,14 +1611,19 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     const participants = await ConversationParticipantModel.findAll({
       where: {
         workspaceId: auth.getNonNullableWorkspace().id,
-        conversationId: this.id,
       },
     });
 
-    const lastReadAtMap = new Map<number, Date | null>();
-    for (const participant of participants) {
-      lastReadAtMap.set(participant.userId, participant.lastReadAt);
-    }
+    const conversationReads = await UserConversationReadsModel.findAll({
+      where: {
+        workspaceId: auth.getNonNullableWorkspace().id,
+        userId: { [Op.in]: participants.map((p) => p.userId) },
+        conversationId: this.id,
+      },
+    });
+    const lastReadAtMap = new Map<number, Date>(
+      conversationReads.map((cr) => [cr.userId, cr.lastReadAt])
+    );
 
     const userResources = await UserResource.fetchByModelIds(
       participants.map((p) => p.userId)

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -1611,6 +1611,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     const participants = await ConversationParticipantModel.findAll({
       where: {
         workspaceId: auth.getNonNullableWorkspace().id,
+        conversationId: this.id,
       },
     });
 


### PR DESCRIPTION
## Description

This PR migrates uses the `lastReadAt` from the `UserConversationReads` table, replacing the one from the `ConversationParticipant table`

## Tests
Manually.

## Risks
This change assumes the backfill script from the previous PR in the stack has completed successfully. If the `UserConversationReadsModel` table is not populated correctly, users may see conversations incorrectly marked as unread.

## Deploy Plan
This PR should be deployed only after running the backfill script.
