### PR TITLE
feat: remove lastReadAt from conversation participant table

### DIFF
--- a/front/lib/models/agent/conversation.ts
+++ b/front/lib/models/agent/conversation.ts
@@ -143,7 +143,6 @@ export class ConversationParticipantModel extends WorkspaceAwareModel<Conversati
   declare action: ParticipantActionType;
   declare unread?: boolean;
   declare actionRequired: boolean;
-  declare lastReadAt: Date | null;
 
   declare conversationId: ForeignKey<ConversationModel["id"]>;
   declare userId: ForeignKey<UserModel["id"]>;
@@ -176,10 +175,6 @@ ConversationParticipantModel.init(
       type: DataTypes.BOOLEAN,
       allowNull: false,
       defaultValue: false,
-    },
-    lastReadAt: {
-      type: DataTypes.DATE,
-      allowNull: true,
     },
   },
   {

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -970,21 +970,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     if (!auth.user()) {
       return new Err(new Error("user_not_authenticated"));
     }
-
-    const updated = await ConversationParticipantModel.update(
-      { lastReadAt: new Date() },
-      {
-        where: {
-          conversationId: conversation.id,
-          workspaceId: auth.getNonNullableWorkspace().id,
-          userId: auth.getNonNullableUser().id,
-        },
-        // Do not update `updatedAt.
-        silent: true,
-        transaction,
-      }
-    );
-    await UserConversationReadsModel.upsert(
+    const updated = await UserConversationReadsModel.upsert(
       {
         conversationId: conversation.id,
         userId: auth.getNonNullableUser().id,
@@ -1107,7 +1093,6 @@ export class ConversationResource extends BaseResource<ConversationModel> {
             action,
             userId: user.id,
             workspaceId: auth.getNonNullableWorkspace().id,
-            lastReadAt,
             actionRequired: false,
           },
           { transaction: t }
@@ -1726,7 +1711,7 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     const workspaceModelId = auth.getNonNullableWorkspace().id;
 
     await ConversationParticipantModel.update(
-      { lastReadAt: new Date(), actionRequired: false },
+      { actionRequired: false },
       {
         where: {
           conversationId: { [Op.in]: conversationIds },

--- a/front/migrations/db/migration_500.sql
+++ b/front/migrations/db/migration_500.sql
@@ -1,0 +1,2 @@
+-- Migration created on févr. 02, 2026
+ALTER TABLE "public"."conversation_participants" DROP COLUMN "lastReadAt";


### PR DESCRIPTION
## Description

This PR removes the `lastReadAt` column from the `conversation_participants` table.

- Updated `markAsRead` method to only update `UserConversationReadsModel` (previously updated both tables)
- Updated `markAllAsRead` method to no longer set `lastReadAt` on conversation participants
- Added database migration to drop the `lastReadAt` column from the `conversation_participants` table

## Tests

Manually

## Risk
This PR relies on the previous PR that migrated all read tracking logic to use the `user_conversation_reads` table. 

## Deploy Plan
Make sure that the backfill script has been run and the previous PRs deployed before deploying this one.