### PR TITLE
fix(agent-builder): persist selected project when reloading agent editor (#6255)

### DIFF
--- a/front/lib/agent_builder/server_side_props_helpers.ts
+++ b/front/lib/agent_builder/server_side_props_helpers.ts
@@ -133,6 +133,7 @@ async function getMCPServerActionConfiguration(
   builderAction.configuration.additionalConfiguration =
     action.additionalConfiguration;
   builderAction.configuration.secretName = action.secretName;
+  builderAction.configuration.dustProject = action.dustProject;
 
   return { ...builderAction, id: action.sId };
 }


### PR DESCRIPTION
## Description

Fixes #6255

When loading an agent's actions from the backend, the `dustProject` field was present in the database and API response but wasn't being copied to the form's initial values in the `getMCPServerActionConfiguration` function.

This fix adds the missing line to persist the selected project configuration when reloading the agent editor.

## Tests

## Risk

## Deploy Plan
