### PR TITLE
Fix stale endDate after trial uncancel

### DIFF
--- a/front/lib/plans/stripe_webhook_cancellation_sync.test.ts
+++ b/front/lib/plans/stripe_webhook_cancellation_sync.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  computeTrialingCancellationUpdateFromStripe,
+  getCancelAtDateFromStripeSubscription,
+  shouldSyncTrialingCancellationFromPreviousAttributes,
+} from "@app/lib/plans/stripe_webhook_cancellation_sync";
+
+describe("stripe_webhook_cancellation_sync", () => {
+  it("detects trialing cancellation fields in previous_attributes", () => {
+    expect(
+      shouldSyncTrialingCancellationFromPreviousAttributes({
+        cancel_at_period_end: true,
+      } as any)
+    ).toBe(true);
+    expect(
+      shouldSyncTrialingCancellationFromPreviousAttributes({
+        default_payment_method: "pm_123",
+      } as any)
+    ).toBe(false);
+  });
+
+  it("maps cancel_at to a Date", () => {
+    const date = getCancelAtDateFromStripeSubscription({
+      cancel_at: 1000,
+    } as any);
+    expect(date?.toISOString()).toBe("1970-01-01T00:16:40.000Z");
+  });
+
+  it("returns null when not trialing", () => {
+    const update = computeTrialingCancellationUpdateFromStripe({
+      stripeSubscription: { status: "active" } as any,
+      previousAttributes: { cancel_at_period_end: true } as any,
+      now: new Date("2026-01-01T00:00:00.000Z"),
+    });
+    expect(update).toBeNull();
+  });
+
+  it("computes endDate when cancellation is scheduled during trial", () => {
+    const now = new Date("2026-01-01T00:00:00.000Z");
+    const update = computeTrialingCancellationUpdateFromStripe({
+      stripeSubscription: { status: "trialing", cancel_at: 123 } as any,
+      previousAttributes: { cancel_at_period_end: true } as any,
+      now,
+    });
+    expect(update?.endDate?.toISOString()).toBe("1970-01-01T00:02:03.000Z");
+    expect(update?.requestCancelAt?.toISOString()).toBe(now.toISOString());
+  });
+
+  it("clears endDate when cancellation is removed during trial", () => {
+    const update = computeTrialingCancellationUpdateFromStripe({
+      stripeSubscription: { status: "trialing", cancel_at: null } as any,
+      previousAttributes: { cancel_at_period_end: true, cancel_at: 123 } as any,
+      now: new Date("2026-01-01T00:00:00.000Z"),
+    });
+    expect(update).toEqual({ endDate: null, requestCancelAt: null });
+  });
+});
+

--- a/front/lib/plans/stripe_webhook_cancellation_sync.ts
+++ b/front/lib/plans/stripe_webhook_cancellation_sync.ts
@@ -1,0 +1,42 @@
+import type Stripe from "stripe";
+
+export function shouldSyncTrialingCancellationFromPreviousAttributes(
+  previousAttributes: Stripe.Event.Data.PreviousAttributes
+): boolean {
+  return (
+    "cancel_at_period_end" in previousAttributes ||
+    "cancel_at" in previousAttributes ||
+    "canceled_at" in previousAttributes ||
+    "cancellation_details" in previousAttributes
+  );
+}
+
+export function getCancelAtDateFromStripeSubscription(
+  stripeSubscription: Stripe.Subscription
+): Date | null {
+  return typeof stripeSubscription.cancel_at === "number"
+    ? new Date(stripeSubscription.cancel_at * 1000)
+    : null;
+}
+
+export function computeTrialingCancellationUpdateFromStripe({
+  stripeSubscription,
+  previousAttributes,
+  now,
+}: {
+  stripeSubscription: Stripe.Subscription;
+  previousAttributes: Stripe.Event.Data.PreviousAttributes;
+  now: Date;
+}): { endDate: Date | null; requestCancelAt: Date | null } | null {
+  if (stripeSubscription.status !== "trialing") {
+    return null;
+  }
+
+  if (!shouldSyncTrialingCancellationFromPreviousAttributes(previousAttributes)) {
+    return null;
+  }
+
+  const endDate = getCancelAtDateFromStripeSubscription(stripeSubscription);
+  return { endDate, requestCancelAt: endDate ? now : null };
+}
+


### PR DESCRIPTION
## Description

When a Stripe subscription is `trialing`, Stripe can temporarily set `cancel_at_period_end=true` (with `cancel_at` equal to `trial_end`) and later clear it if the customer reactivates during the trial.

Our webhook logic updated `subscriptions.endDate` when the trial cancellation was scheduled, but did not clear it when the cancellation was removed while still `trialing`, leaving a stale past `endDate` that triggers "subscription ended" UI even though Stripe remains active and billing.

This PR syncs `endDate`/`requestCancelAt` for `trialing` subscriptions when Stripe schedules or un-schedules cancellation.

## Tests

- `cd front && NODE_ENV=test npx vitest --run lib/plans/stripe_webhook_cancellation_sync.test.ts`
- `cd front && npm run lint:lefthook -- pages/api/stripe/webhook.ts lib/plans/stripe_webhook_cancellation_sync.ts lib/plans/stripe_webhook_cancellation_sync.test.ts`
- `cd front && npx tsgo --noEmit`

## Risk

Low. Change is scoped to the Stripe webhook handler for `customer.subscription.updated` when the subscription is `trialing`.

## Deploy Plan

Deploy `front` as usual.