### PR TITLE
[Mentions] Use RequestCard for mention validation UI

### DIFF
--- a/front/components/assistant/conversation/MentionValidationRequired.tsx
+++ b/front/components/assistant/conversation/MentionValidationRequired.tsx
@@ -90,7 +90,7 @@ export function MentionValidationRequired({
 
   return (
     <RequestCard
-      className="my-3"
+      className="my-3 max-w-md"
       icon={ChatBubbleLeftRightIcon}
       title={title}
       description={description}

--- a/front/components/assistant/conversation/MentionValidationRequired.tsx
+++ b/front/components/assistant/conversation/MentionValidationRequired.tsx
@@ -76,8 +76,8 @@ export function MentionValidationRequired({
 
   const description = isMessageTemporayState(message) ? (
     <>
-      <span className="s-font-semibold">@{message.configuration.name}</span>{" "}
-      mentioned <span className="s-font-semibold">{mention.label}</span>.
+      <span className="font-semibold">@{message.configuration.name}</span>{" "}
+      mentioned <span className="font-semibold">{mention.label}</span>.
       {isProjectMembership
         ? " Do you want to add them to this project?"
         : " Do you want to invite them? They'll see the full history and be able to reply."}
@@ -90,7 +90,7 @@ export function MentionValidationRequired({
 
   return (
     <RequestCard
-      className="s-my-3"
+      className="my-3"
       icon={ChatBubbleLeftRightIcon}
       title={title}
       description={description}

--- a/front/components/assistant/conversation/MentionValidationRequired.tsx
+++ b/front/components/assistant/conversation/MentionValidationRequired.tsx
@@ -1,12 +1,4 @@
-import {
-  Button,
-  CheckIcon,
-  ContentMessage,
-  Icon,
-  InformationCircleIcon,
-  PlusIcon,
-  XMarkIcon,
-} from "@dust-tt/sparkle";
+import { ChatBubbleLeftRightIcon, RequestCard } from "@dust-tt/sparkle";
 import { useMemo, useState } from "react";
 
 import type { VirtuosoMessage } from "@app/components/assistant/conversation/types";
@@ -78,62 +70,41 @@ export function MentionValidationRequired({
     return null;
   }
 
+  const title = isProjectMembership
+    ? `Add ${mention.label} to this project?`
+    : `Invite ${mention.label} to this conversation?`;
+
+  const description = isMessageTemporayState(message) ? (
+    <>
+      <span className="s-font-semibold">@{message.configuration.name}</span>{" "}
+      mentioned <span className="s-font-semibold">{mention.label}</span>.
+      {isProjectMembership
+        ? " Do you want to add them to this project?"
+        : " Do you want to invite them? They'll see the full history and be able to reply."}
+    </>
+  ) : isProjectMembership ? (
+    "They'll have access to all project conversations."
+  ) : (
+    "They'll see the full history and be able to reply."
+  );
+
   return (
-    <ContentMessage variant="info" className="my-3 w-full max-w-full">
-      <div className="flex flex-col items-center gap-2 sm:flex-row">
-        <Icon visual={InformationCircleIcon} className="hidden sm:block" />
-        <div>
-          {isMessageTemporayState(message) ? (
-            <>
-              <span className="font-semibold">
-                @{message.configuration.name}
-              </span>{" "}
-              mentioned <span className="font-semibold">{mention.label}</span>.
-              {isProjectMembership ? (
-                <> Do you want to add them to this project?</>
-              ) : (
-                <>
-                  {" "}
-                  Do you want to invite them? They'll see the full history and
-                  be able to reply.
-                </>
-              )}
-            </>
-          ) : (
-            <>
-              {isProjectMembership ? (
-                <>
-                  Add <b>{mention.label}</b> to this project? They'll have
-                  access to all project conversations.
-                </>
-              ) : (
-                <>
-                  Invite <b>{mention.label}</b> to this conversation? They'll
-                  see the full history and be able to reply.
-                </>
-              )}
-            </>
-          )}
-        </div>
-        <div className="ml-auto flex gap-2">
-          <Button
-            label="No"
-            variant="outline"
-            size="xs"
-            icon={XMarkIcon}
-            disabled={isSubmitting}
-            onClick={handleReject}
-          />
-          <Button
-            label={isProjectMembership ? "Add to project" : "Yes"}
-            variant="highlight"
-            size="xs"
-            icon={isProjectMembership ? PlusIcon : CheckIcon}
-            disabled={isSubmitting}
-            onClick={handleApprove}
-          />
-        </div>
-      </div>
-    </ContentMessage>
+    <RequestCard
+      className="s-my-3"
+      icon={ChatBubbleLeftRightIcon}
+      title={title}
+      description={description}
+      primaryAction={{
+        label: isProjectMembership ? "Add to project" : "Invite",
+        onClick: handleApprove,
+        disabled: isSubmitting,
+        isLoading: isSubmitting,
+      }}
+      secondaryAction={{
+        label: "Decline",
+        onClick: handleReject,
+        disabled: isSubmitting,
+      }}
+    />
   );
 }

--- a/sparkle/src/components/Button.tsx
+++ b/sparkle/src/components/Button.tsx
@@ -257,8 +257,7 @@ const chevronVariantMap = {
 } as const;
 
 export interface MetaButtonProps
-  extends
-    React.ButtonHTMLAttributes<HTMLButtonElement>,
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
   asChild?: boolean;
   isRounded?: boolean;

--- a/sparkle/src/components/ButtonsSwitch.tsx
+++ b/sparkle/src/components/ButtonsSwitch.tsx
@@ -54,8 +54,7 @@ const listStyles = cva(
 );
 
 export interface ButtonsSwitchListProps
-  extends
-    React.HTMLAttributes<HTMLDivElement>,
+  extends React.HTMLAttributes<HTMLDivElement>,
     VariantProps<typeof listStyles> {
   size?: ButtonSize;
   disabled?: boolean;
@@ -116,10 +115,8 @@ export const ButtonsSwitchList = React.forwardRef<
 );
 ButtonsSwitchList.displayName = "ButtonsSwitchList";
 
-interface ButtonsSwitchProps extends Omit<
-  React.ComponentProps<typeof Button>,
-  "size" | "variant"
-> {
+interface ButtonsSwitchProps
+  extends Omit<React.ComponentProps<typeof Button>, "size" | "variant"> {
   value: string;
   label?: string;
   icon?: React.ComponentProps<typeof Button>["icon"];


### PR DESCRIPTION
## Description

Follows https://github.com/dust-tt/dust/pull/20894

Replaces the `ContentMessage` component with the new `RequestCard` Sparkle component for the mention validation UI (inviting users to conversations or adding them to projects).

Context: https://github.com/dust-tt/tasks/issues/6204
<img width="1251" height="480" alt="image" src="https://github.com/user-attachments/assets/f6ce01a4-321a-44d8-82bb-bca8c6daf987" />


## Risks

Blast radius: Mention validation UI in conversations
Risk: low

## Deploy Plan

- deploy front