### PR TITLE
Optimize prompt caching by removing user-specific context from system prompt

### DIFF
--- a/front/lib/api/assistant/conversation_rendering/helpers.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/helpers.test.ts
@@ -1,15 +1,33 @@
 import { describe, expect, it } from "vitest";
 
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import type { TextContent } from "@app/types";
 
 import { renderUserMessage } from "./helpers";
 
 describe("renderUserMessage", () => {
-  function buildMessage(overrides: Partial<any> = {}) {
+  async function buildMessage(overrides: Partial<any> = {}) {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(
+      authenticator,
+      {
+        name: "Test Agent",
+        description: "A test agent for prompt stability",
+      }
+    );
+
+    const conversation = await ConversationFactory.create(authenticator, {
+      agentConfigurationId: agentConfig.sId,
+      messagesCreatedAt: [],
+    });
+
     // We only include the fields used by renderUserMessage to keep the test
     // simple. The type used in production has many more fields, but they are
     // not needed here.
-    return {
+    const userMessage = {
       content: "",
       user: {
         sId: "user_123",
@@ -18,15 +36,20 @@ describe("renderUserMessage", () => {
       },
       ...overrides,
     } as any;
+
+    return {
+      userMessage,
+      conversation,
+    };
   }
 
-  it("replaces :mention[name]{...} with @name", () => {
-    const m = buildMessage({
+  it("replaces :mention[name]{...} with @name", async () => {
+    const { conversation, userMessage } = await buildMessage({
       content: "Hello :mention[John Doe]{sId=user_123}, how are you?",
       context: {},
     });
 
-    const res = renderUserMessage(m);
+    const res = renderUserMessage(conversation, userMessage);
 
     expect(res.role).toBe("user");
     expect(res.content[0].type).toBe("text");
@@ -36,8 +59,8 @@ describe("renderUserMessage", () => {
     expect(text).not.toContain(":mention[John Doe]{user_123}");
   });
 
-  it("adds Sender metadata with full name, username and email", () => {
-    const m = buildMessage({
+  it("adds Sender metadata with full name, username and email", async () => {
+    const { conversation, userMessage } = await buildMessage({
       content: "Hello!",
       context: {
         // to be different from the user
@@ -47,7 +70,7 @@ describe("renderUserMessage", () => {
       },
     });
 
-    const res = renderUserMessage(m);
+    const res = renderUserMessage(conversation, userMessage);
     expect(res.content[0].type).toBe("text");
     const text = (res.content[0] as TextContent).text;
 
@@ -59,15 +82,15 @@ describe("renderUserMessage", () => {
 Hello!`);
   });
 
-  it("uses username as name when fullName is not provided", () => {
-    const m = buildMessage({
+  it("uses username as name when fullName is not provided", async () => {
+    const { conversation, userMessage } = await buildMessage({
       content: "Hello!",
       context: {
         username: "jdoe",
       },
     });
 
-    const res = renderUserMessage(m);
+    const res = renderUserMessage(conversation, userMessage);
 
     expect(res.name).toBe("jdoe");
     expect(res.content[0].type).toBe("text");
@@ -79,14 +102,14 @@ Hello!`);
 Hello!`);
   });
 
-  it("adds sent at metadata when created is provided (timezone stable via context)", () => {
-    const m = buildMessage({
+  it("adds sent at metadata when created is provided (timezone stable via context)", async () => {
+    const { conversation, userMessage } = await buildMessage({
       content: "Ping",
       created: "2025-01-15T12:34:56.000Z",
       context: { timezone: "UTC" },
     });
 
-    const res = renderUserMessage(m);
+    const res = renderUserMessage(conversation, userMessage);
     expect(res.content[0].type).toBe("text");
     const text = (res.content[0] as TextContent).text;
 
@@ -102,8 +125,8 @@ Hello!`);
     );
   });
 
-  it("adds trigger source metadata and previous run when origin is 'triggered'", () => {
-    const m = buildMessage({
+  it("adds trigger source metadata and previous run when origin is 'triggered'", async () => {
+    const { conversation, userMessage } = await buildMessage({
       content: "Scheduled report",
       context: {
         origin: "triggered",
@@ -112,7 +135,7 @@ Hello!`);
       },
     });
 
-    const res = renderUserMessage(m);
+    const res = renderUserMessage(conversation, userMessage);
     expect(res.content[0].type).toBe("text");
     const text = (res.content[0] as TextContent).text;
 
@@ -125,25 +148,29 @@ Hello!`);
     expect(prevRunLine).toBeDefined();
   });
 
-  it("adds generic source metadata when origin is provided (non-triggered)", () => {
-    const m = buildMessage({
+  it("adds generic source metadata when origin is provided (non-triggered)", async () => {
+    const { conversation, userMessage } = await buildMessage({
       content: "From email",
       context: {
         origin: "email",
       },
     });
 
-    const res = renderUserMessage(m);
+    const res = renderUserMessage(conversation, userMessage);
     expect(res.content[0].type).toBe("text");
     const text = (res.content[0] as TextContent).text;
 
     expect(text).toContain("- Source: email");
   });
 
-  it("does not include system context when no metadata is available", () => {
-    const m = buildMessage({ content: "Just text", context: {}, user: null });
+  it("does not include system context when no metadata is available", async () => {
+    const { conversation, userMessage } = await buildMessage({
+      content: "Just text",
+      context: {},
+      user: null,
+    });
 
-    const res = renderUserMessage(m);
+    const res = renderUserMessage(conversation, userMessage);
     expect(res.content[0].type).toBe("text");
     const text = (res.content[0] as TextContent).text;
 

--- a/front/lib/api/assistant/conversation_rendering/helpers.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/helpers.test.ts
@@ -77,6 +77,7 @@ describe("renderUserMessage", () => {
     // Should include a dust system block and a Sender line.
     expect(text).toEqual(`<dust_system>
 - Sender: John Doe (:mention_user[John Doe]{sId=user_123}) <john@example.com>
+- Conversation: ${conversation.sId}
 </dust_system>
 
 Hello!`);
@@ -97,6 +98,7 @@ Hello!`);
     const text = (res.content[0] as TextContent).text;
     expect(text).toEqual(`<dust_system>
 - Sender: John Doe (:mention_user[John Doe]{sId=user_123}) <john@example.com>
+- Conversation: ${conversation.sId}
 </dust_system>
 
 Hello!`);
@@ -163,7 +165,7 @@ Hello!`);
     expect(text).toContain("- Source: email");
   });
 
-  it("does not include system context when no metadata is available", async () => {
+  it("includes only conversation metadata when no user metadata is available", async () => {
     const { conversation, userMessage } = await buildMessage({
       content: "Just text",
       context: {},
@@ -174,6 +176,11 @@ Hello!`);
     expect(res.content[0].type).toBe("text");
     const text = (res.content[0] as TextContent).text;
 
-    expect(text).toEqual(`Just text`);
+    // Should still include the conversation sId even without user info
+    expect(text).toEqual(`<dust_system>
+- Conversation: ${conversation.sId}
+</dust_system>
+
+Just text`);
   });
 });

--- a/front/lib/api/assistant/conversation_rendering/helpers.ts
+++ b/front/lib/api/assistant/conversation_rendering/helpers.ts
@@ -243,7 +243,10 @@ export function getSteps(
 /**
  * Renders a user message with metadata
  */
-export function renderUserMessage(conversation: ConversationWithoutContentType,  m: UserMessageType): UserMessageTypeModel {
+export function renderUserMessage(
+  conversation: ConversationWithoutContentType,
+  m: UserMessageType
+): UserMessageTypeModel {
   const content = replaceMentionsWithAt(m.content);
 
   const metadataItems: string[] = [];

--- a/front/lib/api/assistant/conversation_rendering/helpers.ts
+++ b/front/lib/api/assistant/conversation_rendering/helpers.ts
@@ -15,6 +15,7 @@ import { renderLightContentFragmentForModel } from "@app/lib/resources/content_f
 import logger from "@app/logger/logger";
 import type {
   AgentMessageType,
+  ConversationWithoutContentType,
   FunctionCallType,
   FunctionMessageTypeModel,
   ModelConfigurationType,
@@ -242,7 +243,7 @@ export function getSteps(
 /**
  * Renders a user message with metadata
  */
-export function renderUserMessage(m: UserMessageType): UserMessageTypeModel {
+export function renderUserMessage(conversation: ConversationWithoutContentType,  m: UserMessageType): UserMessageTypeModel {
   const content = replaceMentionsWithAt(m.content);
 
   const metadataItems: string[] = [];
@@ -276,6 +277,9 @@ export function renderUserMessage(m: UserMessageType): UserMessageTypeModel {
   if (identityTokens.length > 0) {
     metadataItems.push(`- Sender: ${identityTokens.join(" ")}`);
   }
+
+  // TODO(2026-02-01 flav): Move this to another system message.
+  metadataItems.push(`- Conversation: ${conversation.sId}`);
 
   const timeZone =
     m.context.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone;

--- a/front/lib/api/assistant/conversation_rendering/message_rendering.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/message_rendering.test.ts
@@ -5,6 +5,7 @@ import type { Authenticator } from "@app/lib/auth";
 import type {
   AgentMessageType,
   ConversationType,
+  ConversationWithoutContentType,
   ModelConfigurationType,
   UserMessageType,
 } from "@app/types";
@@ -38,7 +39,7 @@ describe("renderAllMessages", () => {
     } as unknown as ModelConfigurationType;
 
     vi.mocked(renderUserMessage).mockImplementation(
-      (m: UserMessageType) =>
+      (conversation: ConversationWithoutContentType, m: UserMessageType) =>
         ({
           role: "user",
           name: m.context.username,

--- a/front/lib/api/assistant/conversation_rendering/message_rendering.ts
+++ b/front/lib/api/assistant/conversation_rendering/message_rendering.ts
@@ -188,7 +188,7 @@ export async function renderAllMessages(
       }
     } else if (isUserMessageType(m)) {
       if (m.visibility === "visible") {
-        messages.push(renderUserMessage(m));
+        messages.push(renderUserMessage(conversation, m));
       }
     } else if (isContentFragmentType(m)) {
       if (m.visibility === "visible") {

--- a/front/lib/api/assistant/generation.test.ts
+++ b/front/lib/api/assistant/generation.test.ts
@@ -4,7 +4,6 @@ import {
   GET_MENTION_MARKDOWN_TOOL_NAME,
   SEARCH_AVAILABLE_USERS_TOOL_NAME,
 } from "@app/lib/api/actions/servers/common_utilities/metadata";
-import { createConversation } from "@app/lib/api/assistant/conversation";
 import {
   constructGuidelinesSection,
   constructProjectContextSection,
@@ -17,6 +16,7 @@ import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import type {
   AgentConfigurationType,
+  ConversationType,
   ConversationWithoutContentType,
   ModelConfigurationType,
   UserMessageType,
@@ -200,13 +200,13 @@ describe("constructPromptMultiActions - system prompt stability", () => {
   let workspace1: WorkspaceType;
   let agentConfig1: AgentConfigurationType;
   let userMessage1: UserMessageType;
-  let conversation1: ConversationWithoutContentType;
+  let conversation1: ConversationType;
 
   let authenticator2: Authenticator;
   let workspace2: WorkspaceType;
   let agentConfig2: AgentConfigurationType;
   let userMessage2: UserMessageType;
-  let conversation2: ConversationWithoutContentType;
+  let conversation2: ConversationType;
 
   let modelConfig: ModelConfigurationType;
 
@@ -224,10 +224,9 @@ describe("constructPromptMultiActions - system prompt stability", () => {
       }
     );
 
-    conversation1 = await createConversation(authenticator1, {
-      title: "Test Conversation 1",
-      visibility: "unlisted",
-      spaceId: null,
+    conversation1 = await ConversationFactory.create(authenticator1, {
+      agentConfigurationId: agentConfig1.sId,
+      messagesCreatedAt: [],
     });
 
     const { userMessage: um1 } = await ConversationFactory.createUserMessage({
@@ -252,10 +251,9 @@ describe("constructPromptMultiActions - system prompt stability", () => {
       }
     );
 
-    conversation2 = await createConversation(authenticator2, {
-      title: "Test Conversation 2 - Different Title",
-      visibility: "unlisted",
-      spaceId: null,
+    conversation2 = await ConversationFactory.create(authenticator2, {
+      agentConfigurationId: agentConfig2.sId,
+      messagesCreatedAt: [],
     });
 
     const { userMessage: um2 } = await ConversationFactory.createUserMessage({

--- a/front/lib/api/assistant/generation.test.ts
+++ b/front/lib/api/assistant/generation.test.ts
@@ -290,30 +290,6 @@ describe("constructPromptMultiActions - system prompt stability", () => {
     expect(prompt1).toBe(prompt2);
   });
 
-  it("should generate identical prompts regardless of call order or timing", () => {
-    const params = {
-      userMessage: userMessage1,
-      agentConfiguration: agentConfig1,
-      model: modelConfig,
-      hasAvailableActions: false,
-      agentsList: null,
-      enabledSkills: [],
-      equippedSkills: [],
-    };
-
-    // Simulate multiple "conversations" being rendered.
-    const prompts: string[] = [];
-    for (let i = 0; i < 5; i++) {
-      prompts.push(constructPromptMultiActions(authenticator1, params));
-    }
-
-    // All prompts should be identical.
-    const firstPrompt = prompts[0];
-    for (const prompt of prompts) {
-      expect(prompt).toBe(firstPrompt);
-    }
-  });
-
   it("should generate identical prompts with different conversation metadata from the same workspace", () => {
     // Same workspace, same agent, but different conversation metadata
     const baseParams = {

--- a/front/lib/api/assistant/generation.test.ts
+++ b/front/lib/api/assistant/generation.test.ts
@@ -1,17 +1,26 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 
 import {
   GET_MENTION_MARKDOWN_TOOL_NAME,
   SEARCH_AVAILABLE_USERS_TOOL_NAME,
 } from "@app/lib/api/actions/servers/common_utilities/metadata";
+import { createConversation } from "@app/lib/api/assistant/conversation";
 import {
   constructGuidelinesSection,
   constructProjectContextSection,
+  constructPromptMultiActions,
 } from "@app/lib/api/assistant/generation";
+import { getSupportedModelConfigs } from "@app/lib/api/models";
+import type { Authenticator } from "@app/lib/auth";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import type {
   AgentConfigurationType,
   ConversationWithoutContentType,
+  ModelConfigurationType,
   UserMessageType,
+  WorkspaceType,
 } from "@app/types";
 
 describe("constructGuidelinesSection", () => {
@@ -158,7 +167,7 @@ describe("constructProjectContextSection", () => {
 
     expect(result).not.toBeNull();
     expect(result).toEqual(`# PROJECT CONTEXT
-  
+
 This conversation is associated with a project. The project provides:
 - Persistent file storage shared across all conversations in this project
 - Project metadata (description and URLs) for organizational context
@@ -179,5 +188,210 @@ This conversation is associated with a project. The project provides:
 
 When information should be preserved for future conversations or context, add it to project files.
 `);
+  });
+});
+
+describe("constructPromptMultiActions - system prompt stability", () => {
+  // This test ensures that the system prompt remains stable across multiple calls
+  // with the same inputs. This is critical for prompt caching - high-entropy data
+  // (timestamps with time precision, unique IDs, etc.) would reduce cache hits.
+
+  let authenticator1: Authenticator;
+  let workspace1: WorkspaceType;
+  let agentConfig1: AgentConfigurationType;
+  let userMessage1: UserMessageType;
+  let conversation1: ConversationWithoutContentType;
+
+  let authenticator2: Authenticator;
+  let workspace2: WorkspaceType;
+  let agentConfig2: AgentConfigurationType;
+  let userMessage2: UserMessageType;
+  let conversation2: ConversationWithoutContentType;
+
+  let modelConfig: ModelConfigurationType;
+
+  beforeEach(async () => {
+    // Set up first workspace with conversation and user message
+    const setup1 = await createResourceTest({ role: "admin" });
+    authenticator1 = setup1.authenticator;
+    workspace1 = setup1.workspace;
+
+    agentConfig1 = await AgentConfigurationFactory.createTestAgent(
+      authenticator1,
+      {
+        name: "Test Agent",
+        description: "A test agent for prompt stability",
+      }
+    );
+
+    conversation1 = await createConversation(authenticator1, {
+      title: "Test Conversation 1",
+      visibility: "unlisted",
+      spaceId: null,
+    });
+
+    const { userMessage: um1 } = await ConversationFactory.createUserMessage({
+      auth: authenticator1,
+      workspace: workspace1,
+      conversation: conversation1,
+      content: "Hello, this is a test message",
+      origin: "web",
+    });
+    userMessage1 = um1;
+
+    // Set up second workspace with different conversation
+    const setup2 = await createResourceTest({ role: "admin" });
+    authenticator2 = setup2.authenticator;
+    workspace2 = setup2.workspace;
+
+    agentConfig2 = await AgentConfigurationFactory.createTestAgent(
+      authenticator2,
+      {
+        name: "Test Agent",
+        description: "A test agent for prompt stability",
+      }
+    );
+
+    conversation2 = await createConversation(authenticator2, {
+      title: "Test Conversation 2 - Different Title",
+      visibility: "unlisted",
+      spaceId: null,
+    });
+
+    const { userMessage: um2 } = await ConversationFactory.createUserMessage({
+      auth: authenticator2,
+      workspace: workspace2,
+      conversation: conversation2,
+      content: "Different test message content",
+      origin: "web",
+    });
+    userMessage2 = um2;
+
+    // Get a real model config.
+    const modelConfigs = getSupportedModelConfigs();
+    const gpt4Config = modelConfigs.find(
+      (m) => m.providerId === "openai" && m.modelId === "gpt-4-turbo"
+    );
+    modelConfig = gpt4Config ?? modelConfigs[0];
+  });
+
+  it("should generate identical system prompts for the same inputs", () => {
+    const params = {
+      userMessage: userMessage1,
+      agentConfiguration: agentConfig1,
+      model: modelConfig,
+      hasAvailableActions: true,
+      agentsList: null,
+      enabledSkills: [],
+      equippedSkills: [],
+    };
+
+    const prompt1 = constructPromptMultiActions(authenticator1, params);
+    const prompt2 = constructPromptMultiActions(authenticator1, params);
+
+    expect(prompt1).toBe(prompt2);
+  });
+
+  it("should generate identical prompts regardless of call order or timing", () => {
+    const params = {
+      userMessage: userMessage1,
+      agentConfiguration: agentConfig1,
+      model: modelConfig,
+      hasAvailableActions: false,
+      agentsList: null,
+      enabledSkills: [],
+      equippedSkills: [],
+    };
+
+    // Simulate multiple "conversations" being rendered.
+    const prompts: string[] = [];
+    for (let i = 0; i < 5; i++) {
+      prompts.push(constructPromptMultiActions(authenticator1, params));
+    }
+
+    // All prompts should be identical.
+    const firstPrompt = prompts[0];
+    for (const prompt of prompts) {
+      expect(prompt).toBe(firstPrompt);
+    }
+  });
+
+  it("should generate identical prompts with different conversation metadata from the same workspace", () => {
+    // Same workspace, same agent, but different conversation metadata
+    const baseParams = {
+      userMessage: userMessage1,
+      agentConfiguration: agentConfig1,
+      model: modelConfig,
+      hasAvailableActions: true,
+      agentsList: null,
+      enabledSkills: [],
+      equippedSkills: [],
+    };
+
+    // Create two different conversation metadata objects
+    const convMetadata1: ConversationWithoutContentType = {
+      ...conversation1,
+      id: 111,
+      sId: "conv-aaa",
+      title: "First Conversation",
+    };
+
+    const convMetadata2: ConversationWithoutContentType = {
+      ...conversation1,
+      id: 222,
+      sId: "conv-bbb",
+      title: "Second Conversation - Different",
+      unread: true,
+      metadata: { different: "metadata" },
+    };
+
+    const prompt1 = constructPromptMultiActions(authenticator1, {
+      ...baseParams,
+      conversation: convMetadata1,
+    });
+    const prompt2 = constructPromptMultiActions(authenticator1, {
+      ...baseParams,
+      conversation: convMetadata2,
+    });
+
+    // Both should produce identical prompts since conversation-specific metadata
+    // (id, sId, title, timestamps) should NOT be included in the system prompt
+    expect(prompt1).toBe(prompt2);
+  });
+
+  it("should generate different prompts for different workspaces", () => {
+    // Different workspaces should produce different prompts (workspace name is in the prompt)
+    const params1 = {
+      userMessage: userMessage1,
+      agentConfiguration: agentConfig1,
+      model: modelConfig,
+      hasAvailableActions: true,
+      agentsList: null,
+      enabledSkills: [],
+      equippedSkills: [],
+      conversation: conversation1,
+    };
+
+    const params2 = {
+      userMessage: userMessage2,
+      agentConfiguration: agentConfig2,
+      model: modelConfig,
+      hasAvailableActions: true,
+      agentsList: null,
+      enabledSkills: [],
+      equippedSkills: [],
+      conversation: conversation2,
+    };
+
+    const prompt1 = constructPromptMultiActions(authenticator1, params1);
+    const prompt2 = constructPromptMultiActions(authenticator2, params2);
+
+    // Different workspaces should produce different prompts
+    // (workspace name is included in the context section)
+    expect(prompt1).not.toBe(prompt2);
+
+    // Verify the workspace names are actually in the prompts
+    expect(prompt1).toContain(`workspace: ${workspace1.name}`);
+    expect(prompt2).toContain(`workspace: ${workspace2.name}`);
   });
 });


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Currently, our system prompt includes user-specific and conversation-specific metadata:
- `conversation_id`
- `user_full_name`
- `user_email`

This creates a unique system prompt for every conversation and user combination, resulting in **0% cache hit rate** across the workspace.

This moves conversation-specific metadata out of the system prompt and into the per-message `<dust_system>` tag where user metadata already lives.

**System prompt BEFORE:**
```
conversation_id: upvxrtNBKm
workspace: Dust
user_full_name: Aubin Tchoi
user_email: [aubin@dust.tt](mailto:aubin@dust.tt)
[...static instructions...]
```

**System prompt AFTER:**
```
workspace: Dust
[...static instructions...]
```

**User message serialization AFTER:**
```
<dust_system>
- Conversation: upvxrtNBKm
- Sender: Flavien David (@Flavien David) <flavien@dust.tt>
- Sent at: Feb 02, 2026, 08:52:41 PST
- Source: web
</dust_system>

[user message content]
```

### Impact
- System prompt becomes identical for all users/conversations in the workspace
- Enables high cache hit rates across all workspace requests

### Trade-offs
- Conversation ID now appears in every user message (slightly more verbose)
- This is temporary: Phase 2 will move it to a separate system block for supported providers

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
