### PR TITLE
[sparkle] fix broken style for mini & xmini button

### DIFF
--- a/sparkle/src/components/Button.tsx
+++ b/sparkle/src/components/Button.tsx
@@ -192,8 +192,8 @@ const labelVariants = cva("", {
     size: {
       "icon-xs": "s-hidden",
       icon: "s-hidden",
-      xmini: "s-hidden",
-      mini: "s-hidden",
+      xmini: "",
+      mini: "",
       xs: "",
       sm: "",
       md: "",


### PR DESCRIPTION
## Description
This PR is to fix the broken style for mini & xmini Button introduced here https://github.com/dust-tt/dust/pull/20588

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
