### PR TITLE
[front] fix(skills): add renaming on name conflict upon archiving

### DIFF
--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -52,6 +52,7 @@ import {
   makeSId,
 } from "@app/lib/resources/string_ids";
 import { UserResource } from "@app/lib/resources/user_resource";
+import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { withTransaction } from "@app/lib/utils/sql_utils";
 import type {
@@ -1471,8 +1472,10 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       });
 
       if (existingArchivedSkill) {
-        const { updatedAt: d } = existingArchivedSkill;
-        const timestamp = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")} ${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}`;
+        const timestamp = formatTimestampToFriendlyDate(
+          existingArchivedSkill.updatedAt.getTime(),
+          "compactWithDay"
+        );
         await existingArchivedSkill.update(
           { name: `${existingArchivedSkill.name} (archived on ${timestamp})` },
           { transaction }


### PR DESCRIPTION
## Description

- This PR updates the archiving flow to avoid the unicity constraint on (`workspaceId`, `name`, `status`).
- We currently handle the code paths for `status: active` well but not the one for the archiving.
- This PR renames the pre-existing archived skill on conflict, which is an 80/20 (based on the assumption that this old one will most likely not be re-used)

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.