### PR TITLE
[front] Watch MCP code and global skills in dev worker hot reload

### DIFF
--- a/front/admin/dev_worker.sh
+++ b/front/admin/dev_worker.sh
@@ -13,6 +13,8 @@ NODE_ENV=development npx concurrently \
     --watch 'lib/api/assistant' \
     --watch 'lib/actions' \
     --watch 'lib/api/mcp' \
+    --watch 'lib/api/actions' \
+    --watch 'lib/resources/skill/global' \
     --ext 'ts,js' \
     --signal 'SIGTERM' \
     --delay 5" # 5 seconds delay to avoid restarting the agent loop worker too often.


### PR DESCRIPTION
## Description

This PR updates the `dev_worker.sh` script to watch changes on `lib/api/actions`, which now contains the implementation of the MCP servers, and `lib/resources/skill/global`, which contains the implementation for global skills.

## Tests

- Tested locally.

## Risk

- None, dev tool.

## Deploy Plan

- No deploy
