### PR TITLE
[front] - refactor(llm): fix Langfuse input

### DIFF
--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -152,14 +152,16 @@ export abstract class LLM {
     const buffer = new LLMTraceBuffer(this.traceId, workspaceId, this.context);
 
     // Use custom trace input if provided, otherwise use the full conversation.
-    const traceInput =
-      this.getTraceInput?.(conversation) ??
-      buildDefaultTraceInput(prompt, conversation);
+    // Full conversation with system prompt for observation (actual LLM call details).
+    const observationInput = buildDefaultTraceInput(prompt, conversation);
+
+    // Simplified input for trace if custom getter provided.
+    const traceInput = this.getTraceInput?.(conversation) ?? observationInput;
 
     const generation = startObservation(
       "llm-completion",
       {
-        input: traceInput,
+        input: observationInput,
         model: this.modelId,
         modelParameters: {
           reasoningEffort: this.reasoningEffort ?? "",


### PR DESCRIPTION
## Description

This PR fixes a Langfuse tracing issue where the observation input was incorrectly using the custom `getTraceInput` value. The observation input now always captures the full conversation with the system prompt (used for actual LLM call details), while the trace input is still simplified via a custom getter.

## Risk

Low - only affect data sent to Langfuse, not the actual LLM behavior

## Tests

N/A

## Deploy Plan

Deploy front