### PR TITLE
Fix Sparkle Markdown crash handling

### DIFF
--- a/front/components/sparkle/MarkdownErrorBoundary.test.tsx
+++ b/front/components/sparkle/MarkdownErrorBoundary.test.tsx
@@ -1,0 +1,49 @@
+import { Markdown } from "@dust-tt/sparkle";
+import { render, screen, waitFor } from "@testing-library/react";
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+
+describe("Sparkle Markdown", () => {
+  it("shows fallback when react-markdown throws and recovers on content change", async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    const onWindowError = (event: ErrorEvent) => {
+      if (event.error instanceof Error && event.error.message === "boom") {
+        event.preventDefault();
+      }
+    };
+    window.addEventListener("error", onWindowError);
+
+    try {
+      const { rerender } = render(
+        <Markdown
+          content="boom"
+          additionalMarkdownComponents={{
+            p: () => {
+              throw new Error("boom");
+            },
+          }}
+        />
+      );
+
+      expect(
+        screen.getByText("There was an error parsing this markdown content")
+      ).toBeInTheDocument();
+      expect(screen.getByText("boom")).toBeInTheDocument();
+
+      rerender(<Markdown content="ok" />);
+
+      await waitFor(() => {
+        expect(
+          screen.queryByText("There was an error parsing this markdown content")
+        ).not.toBeInTheDocument();
+      });
+      expect(screen.getByText("ok")).toBeInTheDocument();
+    } finally {
+      window.removeEventListener("error", onWindowError);
+      consoleErrorSpy.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
## Description

Wrap Sparkle `Markdown`'s `ReactMarkdown` render in an error boundary so unexpected parser/render errors don’t crash the whole page. Includes a small fallback that shows the raw content.

## Tests

- `cd sparkle && npm run build:esm`
- `cd front && NODE_ENV=test npm test -- components/sparkle/MarkdownErrorBoundary.test.tsx`
- `cd front && NODE_OPTIONS=\"--max-old-space-size=8192\" npx tsc --noEmit`

## Risk

Low. The change only affects error handling during markdown rendering; normal rendering paths are unchanged.

## Deploy Plan

Normal deploy.