### PR TITLE
[front] Snowflake MCP key-pair auth (workspace)

### DIFF
--- a/front/components/actions/mcp/MCPServerOAuthConnexion.tsx
+++ b/front/components/actions/mcp/MCPServerOAuthConnexion.tsx
@@ -49,12 +49,14 @@ interface MCPServerOAuthConnexionProps {
   // It's managed via useState in the dialog (workflow state), not in form state.
   authorization: AuthorizationInfo;
   documentationUrl?: string;
+  hideUseCaseSelection?: boolean;
 }
 
 export function MCPServerOAuthConnexion({
   toolName,
   authorization,
   documentationUrl,
+  hideUseCaseSelection = false,
 }: MCPServerOAuthConnexionProps) {
   const { setError, clearErrors, setValue, control } =
     useFormContext<MCPServerOAuthFormValues>();
@@ -189,27 +191,29 @@ export function MCPServerOAuthConnexion({
 
   return (
     <div className="flex flex-col items-center gap-4">
-      <div className="w-full space-y-4">
-        <div className="heading-lg text-foreground dark:text-foreground-night">
-          {supportsBoth ? "How do you want to connect?" : "Connection type"}
+      {!hideUseCaseSelection && (
+        <div className="w-full space-y-4">
+          <div className="heading-lg text-foreground dark:text-foreground-night">
+            {supportsBoth ? "How do you want to connect?" : "Connection type"}
+          </div>
+          <div className="grid w-full grid-cols-2 gap-4">
+            <UseCaseCard
+              useCaseType="personal_actions"
+              isSelected={useCase === "personal_actions"}
+              isSupported={supportsPersonalActions}
+              toolName={toolName}
+              onSelect={handleUseCaseSelect}
+            />
+            <UseCaseCard
+              useCaseType="platform_actions"
+              isSelected={useCase === "platform_actions"}
+              isSupported={supportsPlatformActions}
+              toolName={toolName}
+              onSelect={handleUseCaseSelect}
+            />
+          </div>
         </div>
-        <div className="grid w-full grid-cols-2 gap-4">
-          <UseCaseCard
-            useCaseType="personal_actions"
-            isSelected={useCase === "personal_actions"}
-            isSupported={supportsPersonalActions}
-            toolName={toolName}
-            onSelect={handleUseCaseSelect}
-          />
-          <UseCaseCard
-            useCaseType="platform_actions"
-            isSelected={useCase === "platform_actions"}
-            isSupported={supportsPlatformActions}
-            toolName={toolName}
-            onSelect={handleUseCaseSelect}
-          />
-        </div>
-      </div>
+      )}
 
       <ProviderSetupInstructions
         provider={authorization.provider}
@@ -270,7 +274,7 @@ interface UseCaseCardProps {
   onSelect: (useCase: MCPOAuthUseCase) => void;
 }
 
-function UseCaseCard({
+export function UseCaseCard({
   useCaseType,
   isSelected,
   isSupported,

--- a/front/components/actions/mcp/MCPServerSettings.tsx
+++ b/front/components/actions/mcp/MCPServerSettings.tsx
@@ -128,6 +128,10 @@ export function MCPServerSettings({
                 : {OAUTH_USE_CASE_TO_DESCRIPTION["personal_actions"]}
               </>
             )}
+            <div className="mt-2 text-xs">
+              Authentication method:{" "}
+              {connection.authType === "keypair" ? "Key-pair (RSA)" : "OAuth"}
+            </div>
           </div>
         </div>
       )}

--- a/front/components/actions/mcp/create/ConnectMCPServerDialog.tsx
+++ b/front/components/actions/mcp/create/ConnectMCPServerDialog.tsx
@@ -1,10 +1,19 @@
 import {
+  Button,
   Dialog,
   DialogContainer,
   DialogContent,
   DialogFooter,
   DialogHeader,
   DialogTitle,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+  Input,
+  Label,
+  TextArea,
 } from "@dust-tt/sparkle";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useEffect, useMemo, useState } from "react";
@@ -17,6 +26,7 @@ import { getConnectMCPServerDialogDefaultValues } from "@app/components/actions/
 import {
   AUTH_CREDENTIALS_ERROR_KEY,
   MCPServerOAuthConnexion,
+  UseCaseCard,
 } from "@app/components/actions/mcp/MCPServerOAuthConnexion";
 import type {
   CustomResourceIconType,
@@ -33,13 +43,14 @@ import {
 import { DEFAULT_MCP_SERVER_ICON } from "@app/lib/actions/mcp_icons";
 import type { AuthorizationInfo } from "@app/lib/actions/mcp_metadata_extraction";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
+import { clientFetch } from "@app/lib/egress/client";
 import {
   useCreateMCPServerConnection,
   useDiscoverOAuthMetadata,
   useUpdateMCPServerView,
 } from "@app/lib/swr/mcp_servers";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
-import type { WorkspaceType } from "@app/types";
+import type { MCPOAuthUseCase, WorkspaceType } from "@app/types";
 import { OAUTH_PROVIDER_NAMES } from "@app/types";
 
 interface ConnectMCPServerDialogProps {
@@ -75,6 +86,31 @@ export function ConnectMCPServerDialog({
     control: form.control,
     name: "useCase",
   });
+
+  type SnowflakeKeypairFormData = {
+    account: string;
+    username: string;
+    role: string;
+    warehouse: string;
+    privateKey: string;
+  };
+
+  const [snowflakeAuthMethod, setSnowflakeAuthMethod] = useState<
+    "oauth" | "keypair"
+  >("oauth");
+  const [snowflakeKeypairAccount, setSnowflakeKeypairAccount] = useState("");
+  const [snowflakeKeypairUsername, setSnowflakeKeypairUsername] = useState("");
+  const [snowflakeKeypairRole, setSnowflakeKeypairRole] = useState("");
+  const [snowflakeKeypairWarehouse, setSnowflakeKeypairWarehouse] =
+    useState("");
+  const [snowflakeKeypairPrivateKey, setSnowflakeKeypairPrivateKey] =
+    useState("");
+  const [snowflakeKeypairPassphrase, setSnowflakeKeypairPassphrase] =
+    useState("");
+  const [
+    snowflakeKeypairSubmitAttempted,
+    setSnowflakeKeypairSubmitAttempted,
+  ] = useState(false);
 
   const [isLoading, setIsLoading] = useState(false);
   const [
@@ -176,11 +212,171 @@ export function ConnectMCPServerDialog({
     setIsLoading(false);
     setRemoteMCPServerOAuthDiscoveryDone(false);
     setAuthorization(null);
+    setSnowflakeAuthMethod("oauth");
+    setSnowflakeKeypairAccount("");
+    setSnowflakeKeypairUsername("");
+    setSnowflakeKeypairRole("");
+    setSnowflakeKeypairWarehouse("");
+    setSnowflakeKeypairPrivateKey("");
+    setSnowflakeKeypairPassphrase("");
+    setSnowflakeKeypairSubmitAttempted(false);
   };
+
+  const isSnowflake = authorization?.provider === "snowflake";
+  const snowflakeSupportsKeypair =
+    isSnowflake && authorization?.supported_auth_methods?.includes("keypair");
+  const supportsPersonalActions =
+    authorization?.supported_use_cases.includes("personal_actions") ?? false;
+  const supportsPlatformActions =
+    authorization?.supported_use_cases.includes("platform_actions") ?? false;
+
+  useEffect(() => {
+    if (!isSnowflake || !snowflakeSupportsKeypair) {
+      return;
+    }
+    if (useCase !== "platform_actions" && snowflakeAuthMethod === "keypair") {
+      setSnowflakeAuthMethod("oauth");
+      setSnowflakeKeypairSubmitAttempted(false);
+    }
+  }, [isSnowflake, snowflakeAuthMethod, snowflakeSupportsKeypair, useCase]);
+
+  const keypairValidation = useMemo(() => {
+    const errors: Partial<Record<keyof SnowflakeKeypairFormData, string>> = {};
+
+    if (!snowflakeKeypairAccount.trim()) {
+      errors.account = "Snowflake account is required.";
+    }
+    if (!snowflakeKeypairUsername.trim()) {
+      errors.username = "Username is required.";
+    }
+    if (!snowflakeKeypairRole.trim()) {
+      errors.role = "Role is required.";
+    }
+    if (!snowflakeKeypairWarehouse.trim()) {
+      errors.warehouse = "Warehouse is required.";
+    }
+
+    const key = snowflakeKeypairPrivateKey.trim();
+    if (!key) {
+      errors.privateKey = "Private key is required.";
+    } else if (/-----BEGIN PUBLIC KEY-----/.test(key)) {
+      errors.privateKey =
+        "This looks like a public key. Please paste the private key PEM.";
+    } else if (
+      !/-----BEGIN (ENCRYPTED )?PRIVATE KEY-----/.test(key) &&
+      !/-----BEGIN RSA PRIVATE KEY-----/.test(key)
+    ) {
+      errors.privateKey =
+        "Unsupported key format. Paste a PEM private key (PKCS#8 or RSA).";
+    }
+
+    return { isValid: Object.keys(errors).length === 0, errors };
+  }, [
+    snowflakeKeypairAccount,
+    snowflakeKeypairPrivateKey,
+    snowflakeKeypairRole,
+    snowflakeKeypairUsername,
+    snowflakeKeypairWarehouse,
+  ]);
 
   const handleSave = async (values: MCPServerOAuthFormValues) => {
     if (!authorization) {
       return;
+    }
+
+    if (
+      isSnowflake &&
+      snowflakeSupportsKeypair &&
+      useCase === "platform_actions" &&
+      snowflakeAuthMethod === "keypair"
+    ) {
+      setSnowflakeKeypairSubmitAttempted(true);
+      if (!keypairValidation.isValid) {
+        sendNotification({
+          type: "error",
+          title: "Invalid Snowflake key-pair configuration",
+          description: "Please fix the highlighted fields and try again.",
+        });
+        return;
+      }
+
+      setIsLoading(true);
+      const passphrase =
+        snowflakeKeypairPassphrase.trim() === ""
+          ? undefined
+          : snowflakeKeypairPassphrase;
+
+      try {
+        const credRes = await clientFetch(`/api/w/${owner.sId}/credentials`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            provider: "snowflake",
+            credentials: {
+              auth_type: "keypair",
+              account: snowflakeKeypairAccount.trim(),
+              username: snowflakeKeypairUsername.trim(),
+              role: snowflakeKeypairRole.trim(),
+              warehouse: snowflakeKeypairWarehouse.trim(),
+              private_key: snowflakeKeypairPrivateKey.trim(),
+              private_key_passphrase: passphrase,
+            },
+          }),
+        });
+
+        if (!credRes.ok) {
+          const data = (await credRes
+            .json()
+            .catch(() => null)) as
+            | { error?: { message?: string } }
+            | null;
+          throw new Error(
+            data?.error?.message ??
+              "Failed to store Snowflake credentials. Please try again."
+          );
+        }
+
+        const data = (await credRes.json()) as { credentials: { id: string } };
+        const credentialId = data.credentials.id;
+        if (!credentialId) {
+          throw new Error(
+            "Failed to store Snowflake credentials. Please try again."
+          );
+        }
+
+        setExternalIsLoading(true);
+
+        const connectionRes = await createMCPServerConnection({
+          credentialId,
+          mcpServerId: mcpServerView.server.sId,
+          mcpServerDisplayName: getMcpServerDisplayName(mcpServerView.server),
+          provider: authorization.provider,
+        });
+        if (!connectionRes) {
+          throw new Error("Failed to create MCP server connection.");
+        }
+
+        await updateServerView({
+          oAuthUseCase: "platform_actions",
+        });
+
+        setExternalIsLoading(false);
+        setIsLoading(false);
+        setIsOpen(false);
+        resetState();
+        return;
+      } catch (e) {
+        sendNotification({
+          type: "error",
+          title: "Failed to connect Snowflake",
+          description: e instanceof Error ? e.message : "Unknown error.",
+        });
+        setExternalIsLoading(false);
+        setIsLoading(false);
+        return;
+      }
     }
 
     setIsLoading(true);
@@ -211,8 +407,16 @@ export function ConnectMCPServerDialog({
     resetState();
   };
 
-  // Form is valid when: use case selected AND no credential validation errors.
-  const isFormValid = !!useCase && !hasCredentialErrors;
+  // Form is valid when: use case selected AND (OAuth creds valid or keypair form valid).
+  const isFormValid =
+    useCase !== null
+      ? isSnowflake &&
+        snowflakeSupportsKeypair &&
+        useCase === "platform_actions" &&
+        snowflakeAuthMethod === "keypair"
+        ? keypairValidation.isValid
+        : !hasCredentialErrors
+      : false;
 
   return (
     <Dialog
@@ -230,15 +434,202 @@ export function ConnectMCPServerDialog({
             </DialogTitle>
           </DialogHeader>
           <DialogContainer>
-            {authorization && (
-              <MCPServerOAuthConnexion
-                toolName={toolName}
-                authorization={authorization}
-                documentationUrl={
-                  mcpServerView.server?.documentationUrl ?? undefined
-                }
-              />
-            )}
+            {authorization &&
+              isSnowflake &&
+              snowflakeSupportsKeypair &&
+              (supportsPersonalActions || supportsPlatformActions) && (
+                <div className="w-full space-y-4">
+                  <div className="heading-lg text-foreground dark:text-foreground-night">
+                    Connection type
+                  </div>
+                  <div className="grid w-full grid-cols-2 gap-4">
+                    <UseCaseCard
+                      useCaseType="personal_actions"
+                      isSelected={useCase === "personal_actions"}
+                      isSupported={supportsPersonalActions}
+                      toolName={toolName}
+                      onSelect={(selectedUseCase: MCPOAuthUseCase) => {
+                        form.setValue("useCase", selectedUseCase);
+                      }}
+                    />
+                    <UseCaseCard
+                      useCaseType="platform_actions"
+                      isSelected={useCase === "platform_actions"}
+                      isSupported={supportsPlatformActions}
+                      toolName={toolName}
+                      onSelect={(selectedUseCase: MCPOAuthUseCase) => {
+                        form.setValue("useCase", selectedUseCase);
+                      }}
+                    />
+                  </div>
+
+                  {useCase === "platform_actions" && (
+                    <div className="space-y-2">
+                      <Label>Authentication method</Label>
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button
+                            variant="outline"
+                            isSelect
+                            label={
+                              snowflakeAuthMethod === "oauth"
+                                ? "OAuth"
+                                : "Key-pair (RSA)"
+                            }
+                          />
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent>
+                          <DropdownMenuRadioGroup value={snowflakeAuthMethod}>
+                            <DropdownMenuRadioItem
+                              value="oauth"
+                              label="OAuth"
+                              onClick={() => {
+                                setSnowflakeAuthMethod("oauth");
+                                setSnowflakeKeypairSubmitAttempted(false);
+                              }}
+                            />
+                            <DropdownMenuRadioItem
+                              value="keypair"
+                              label="Key-pair (RSA)"
+                              onClick={() => {
+                                setSnowflakeAuthMethod("keypair");
+                                form.clearErrors(AUTH_CREDENTIALS_ERROR_KEY);
+                              }}
+                            />
+                          </DropdownMenuRadioGroup>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    </div>
+                  )}
+
+                  {useCase === "platform_actions" &&
+                  snowflakeAuthMethod === "keypair" ? (
+                    <div className="w-full space-y-4 pt-2">
+                      <div className="space-y-2">
+                        <Label>Snowflake Account</Label>
+                        <Input
+                          value={snowflakeKeypairAccount}
+                          onChange={(e) =>
+                            setSnowflakeKeypairAccount(e.target.value)
+                          }
+                          isError={
+                            snowflakeKeypairSubmitAttempted &&
+                            !!keypairValidation.errors.account
+                          }
+                          message={
+                            snowflakeKeypairSubmitAttempted
+                              ? keypairValidation.errors.account
+                              : undefined
+                          }
+                          messageStatus="error"
+                        />
+                      </div>
+                      <div className="space-y-2">
+                        <Label>Username</Label>
+                        <Input
+                          value={snowflakeKeypairUsername}
+                          onChange={(e) =>
+                            setSnowflakeKeypairUsername(e.target.value)
+                          }
+                          isError={
+                            snowflakeKeypairSubmitAttempted &&
+                            !!keypairValidation.errors.username
+                          }
+                          message={
+                            snowflakeKeypairSubmitAttempted
+                              ? keypairValidation.errors.username
+                              : undefined
+                          }
+                          messageStatus="error"
+                        />
+                      </div>
+                      <div className="space-y-2">
+                        <Label>Role</Label>
+                        <Input
+                          value={snowflakeKeypairRole}
+                          onChange={(e) =>
+                            setSnowflakeKeypairRole(e.target.value)
+                          }
+                          isError={
+                            snowflakeKeypairSubmitAttempted &&
+                            !!keypairValidation.errors.role
+                          }
+                          message={
+                            snowflakeKeypairSubmitAttempted
+                              ? keypairValidation.errors.role
+                              : undefined
+                          }
+                          messageStatus="error"
+                        />
+                      </div>
+                      <div className="space-y-2">
+                        <Label>Warehouse</Label>
+                        <Input
+                          value={snowflakeKeypairWarehouse}
+                          onChange={(e) =>
+                            setSnowflakeKeypairWarehouse(e.target.value)
+                          }
+                          isError={
+                            snowflakeKeypairSubmitAttempted &&
+                            !!keypairValidation.errors.warehouse
+                          }
+                          message={
+                            snowflakeKeypairSubmitAttempted
+                              ? keypairValidation.errors.warehouse
+                              : undefined
+                          }
+                          messageStatus="error"
+                        />
+                      </div>
+                      <div className="space-y-2">
+                        <Label>Private Key (PEM)</Label>
+                        <TextArea
+                          rows={6}
+                          value={snowflakeKeypairPrivateKey}
+                          onChange={(e) =>
+                            setSnowflakeKeypairPrivateKey(e.target.value)
+                          }
+                        />
+                        {snowflakeKeypairSubmitAttempted &&
+                          keypairValidation.errors.privateKey && (
+                            <div className="text-sm text-warning-600">
+                              {keypairValidation.errors.privateKey}
+                            </div>
+                          )}
+                      </div>
+                      <div className="space-y-2">
+                        <Label>Passphrase (optional)</Label>
+                        <Input
+                          value={snowflakeKeypairPassphrase}
+                          onChange={(e) =>
+                            setSnowflakeKeypairPassphrase(e.target.value)
+                          }
+                        />
+                      </div>
+                    </div>
+                  ) : (
+                    <MCPServerOAuthConnexion
+                      toolName={toolName}
+                      authorization={authorization}
+                      documentationUrl={
+                        mcpServerView.server?.documentationUrl ?? undefined
+                      }
+                      hideUseCaseSelection
+                    />
+                  )}
+                </div>
+              )}
+
+            {authorization &&
+              !(isSnowflake && snowflakeSupportsKeypair) && (
+                <MCPServerOAuthConnexion
+                  toolName={toolName}
+                  authorization={authorization}
+                  documentationUrl={
+                    mcpServerView.server?.documentationUrl ?? undefined
+                  }
+                />
+              )}
           </DialogContainer>
           <DialogFooter
             leftButtonProps={{

--- a/front/lib/actions/mcp_authentication.test.ts
+++ b/front/lib/actions/mcp_authentication.test.ts
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getResolvedAuthForMCPServer } from "@app/lib/actions/mcp_authentication";
+import { internalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
+import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { Ok } from "@app/types";
+
+vi.mock("@app/lib/api/config", () => ({
+  default: {
+    getOAuthAPIConfig: vi.fn(() => ({
+      url: "https://oauth-api.example.com",
+      apiKey: "test-api-key",
+    })),
+  },
+}));
+
+const { mockGetOAuthConnectionAccessToken, mockGetCredentials } = vi.hoisted(
+  () => ({
+    mockGetOAuthConnectionAccessToken: vi.fn(),
+    mockGetCredentials: vi.fn(),
+  })
+);
+
+vi.mock("@app/types", async (importOriginal) => {
+  const actual = (await importOriginal()) as any;
+  return {
+    ...actual,
+    getOAuthConnectionAccessToken: mockGetOAuthConnectionAccessToken,
+    OAuthAPI: vi.fn().mockImplementation(function () {
+      return {
+        getCredentials: mockGetCredentials,
+      };
+    }),
+  };
+});
+
+describe("getResolvedAuthForMCPServer", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns oauth variant when connectionId is configured", async () => {
+    const { authenticator, workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+
+    const snowflakeServerId = internalMCPServerNameToSId({
+      name: "snowflake",
+      workspaceId: workspace.id,
+      prefix: 123,
+    });
+
+    await MCPServerConnectionResource.makeNew(authenticator, {
+      connectionId: "con_test",
+      credentialId: null,
+      connectionType: "workspace",
+      serverType: "internal",
+      internalMCPServerId: snowflakeServerId,
+    });
+
+    mockGetOAuthConnectionAccessToken.mockResolvedValue(
+      new Ok({
+        connection: {
+          connection_id: "con_test",
+          created: Date.now(),
+          metadata: {
+            snowflake_account: "acc",
+            snowflake_warehouse: "wh",
+          },
+          provider: "snowflake",
+          status: "finalized",
+        },
+        access_token: "token",
+        access_token_expiry: null,
+        scrubbed_raw_json: {},
+      } as any)
+    );
+
+    const res = await getResolvedAuthForMCPServer(authenticator, {
+      mcpServerId: snowflakeServerId,
+      connectionType: "workspace",
+    });
+
+    expect(res.isOk()).toBe(true);
+    if (res.isOk()) {
+      expect(res.value.authType).toBe("oauth");
+      if (res.value.authType !== "oauth") {
+        throw new Error("Expected oauth auth type");
+      }
+      expect(res.value.access_token).toBe("token");
+    }
+  });
+
+  it("returns keypair variant when credentialId is configured", async () => {
+    const { authenticator, workspace } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "admin",
+    });
+
+    const snowflakeServerId = internalMCPServerNameToSId({
+      name: "snowflake",
+      workspaceId: workspace.id,
+      prefix: 123,
+    });
+
+    await MCPServerConnectionResource.makeNew(authenticator, {
+      connectionId: null,
+      credentialId: "cred_test",
+      connectionType: "workspace",
+      serverType: "internal",
+      internalMCPServerId: snowflakeServerId,
+    });
+
+    mockGetCredentials.mockResolvedValue(
+      new Ok({
+        credential: {
+          credential_id: "cred_test",
+          created: Date.now(),
+          provider: "snowflake",
+          metadata: {
+            workspace_id: workspace.sId,
+            user_id: authenticator.getNonNullableUser().sId,
+          },
+          content: {
+            auth_type: "keypair",
+            account: "acc",
+            username: "user",
+            role: "role",
+            warehouse: "wh",
+            private_key: "-----BEGIN PRIVATE KEY-----\nMIIB...\n-----END PRIVATE KEY-----",
+          },
+        },
+      } as any)
+    );
+
+    const res = await getResolvedAuthForMCPServer(authenticator, {
+      mcpServerId: snowflakeServerId,
+      connectionType: "workspace",
+    });
+
+    expect(res.isOk()).toBe(true);
+    if (res.isOk()) {
+      expect(res.value.authType).toBe("keypair");
+      if (res.value.authType !== "keypair") {
+        throw new Error("Expected keypair auth type");
+      }
+      expect(res.value.credentials.username).toBe("user");
+      expect(res.value.credentials.private_key).toContain("PRIVATE KEY");
+    }
+  });
+});

--- a/front/lib/actions/mcp_authentication.ts
+++ b/front/lib/actions/mcp_authentication.ts
@@ -1,3 +1,4 @@
+import { getInternalMCPServerNameAndWorkspaceId } from "@app/lib/actions/mcp_internal_actions/constants";
 import apiConfig from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
@@ -5,7 +6,7 @@ import type { MCPServerConnectionConnectionType } from "@app/lib/resources/mcp_s
 import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
 import logger from "@app/logger/logger";
 import type { OAuthConnectionType, OAuthProvider, Result } from "@app/types";
-import { Err, getOAuthConnectionAccessToken, Ok } from "@app/types";
+import { Err, getOAuthConnectionAccessToken, OAuthAPI, Ok } from "@app/types";
 
 // Dedicated function to get the connection details for an MCP server.
 // Not using the one from mcp_metadata.ts to avoid circular dependency.
@@ -34,6 +35,15 @@ export async function getConnectionForMCPServer(
     connectionType,
   });
   if (connection.isOk()) {
+    if (!connection.value.connectionId) {
+      return new Err(
+        new DustError(
+          "connection_not_found",
+          "No OAuth connection found for MCP server"
+        )
+      );
+    }
+
     const token = await getOAuthConnectionAccessToken({
       config: apiConfig.getOAuthAPIConfig(),
       logger,
@@ -75,6 +85,178 @@ export async function getConnectionForMCPServer(
       )
     );
   }
+}
+
+export type MCPServerResolvedAuth =
+  | {
+      authType: "oauth";
+      connection: OAuthConnectionType;
+      access_token: string;
+      access_token_expiry: number | null;
+      scrubbed_raw_json: unknown;
+    }
+  | {
+      authType: "keypair";
+      credentials: SnowflakeKeypairCredentials;
+    };
+
+type SnowflakeKeypairCredentials = {
+  account: string;
+  username: string;
+  role: string;
+  warehouse: string;
+  private_key: string;
+  private_key_passphrase?: string;
+};
+
+function isSnowflakeKeypairCredential(
+  value: unknown
+): value is SnowflakeKeypairCredentials {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.account === "string" &&
+    typeof v.username === "string" &&
+    typeof v.role === "string" &&
+    typeof v.warehouse === "string" &&
+    typeof v.private_key === "string" &&
+    (v.private_key_passphrase === undefined ||
+      typeof v.private_key_passphrase === "string")
+  );
+}
+
+export async function getResolvedAuthForMCPServer(
+  auth: Authenticator,
+  {
+    mcpServerId,
+    connectionType,
+  }: {
+    mcpServerId: string;
+    connectionType: MCPServerConnectionConnectionType;
+  }
+): Promise<
+  Result<MCPServerResolvedAuth, DustError<"mcp_access_token_error" | "connection_not_found">>
+> {
+  const connection = await MCPServerConnectionResource.findByMCPServer(auth, {
+    mcpServerId,
+    connectionType,
+  });
+
+  if (connection.isErr()) {
+    return new Err(
+      new DustError("connection_not_found", "No connection found for MCP server")
+    );
+  }
+
+  if (connection.value.connectionId) {
+    const token = await getOAuthConnectionAccessToken({
+      config: apiConfig.getOAuthAPIConfig(),
+      logger,
+      connectionId: connection.value.connectionId,
+    });
+    if (token.isOk()) {
+      return new Ok({ authType: "oauth", ...token.value });
+    }
+
+    logger.warn(
+      {
+        workspaceId: auth.getNonNullableWorkspace().sId,
+        mcpServerId,
+        connectionType,
+        error: token.error,
+      },
+      "Failed to get access token for MCP server"
+    );
+    return new Err(
+      new DustError(
+        "mcp_access_token_error",
+        "Failed to get access token for MCP server"
+      )
+    );
+  }
+
+  if (!connection.value.credentialId) {
+    return new Err(
+      new DustError("connection_not_found", "No connection found for MCP server")
+    );
+  }
+
+  if (connectionType !== "workspace") {
+    return new Err(
+      new DustError(
+        "mcp_access_token_error",
+        "Key-pair authentication is not supported for personal connections."
+      )
+    );
+  }
+
+  const internalServerRes = getInternalMCPServerNameAndWorkspaceId(mcpServerId);
+  if (
+    internalServerRes.isErr() ||
+    internalServerRes.value.name !== "snowflake" ||
+    internalServerRes.value.workspaceModelId !== auth.getNonNullableWorkspace().id
+  ) {
+    return new Err(
+      new DustError(
+        "mcp_access_token_error",
+        "Key-pair authentication is only supported for the internal Snowflake MCP server."
+      )
+    );
+  }
+
+  const oauthApi = new OAuthAPI(apiConfig.getOAuthAPIConfig(), logger);
+  const credentialRes = await oauthApi.getCredentials({
+    credentialsId: connection.value.credentialId,
+  });
+
+  if (credentialRes.isErr()) {
+    logger.warn(
+      {
+        workspaceId: auth.getNonNullableWorkspace().sId,
+        mcpServerId,
+        connectionType,
+        credentialId: connection.value.credentialId,
+        error: credentialRes.error,
+      },
+      "Failed to get credentials for MCP server"
+    );
+    return new Err(
+      new DustError(
+        "mcp_access_token_error",
+        "Failed to get credentials for MCP server"
+      )
+    );
+  }
+
+  const { credential } = credentialRes.value;
+  if (
+    credential.metadata.workspace_id !== auth.getNonNullableWorkspace().sId ||
+    credential.provider !== "snowflake" ||
+    !isSnowflakeKeypairCredential(credential.content)
+  ) {
+    return new Err(
+      new DustError(
+        "mcp_access_token_error",
+        "Snowflake key-pair credential is invalid or not accessible."
+      )
+    );
+  }
+
+  return new Ok({
+    authType: "keypair",
+    credentials: {
+      account: credential.content.account,
+      username: credential.content.username,
+      role: credential.content.role,
+      warehouse: credential.content.warehouse,
+      private_key: credential.content.private_key,
+      ...(credential.content.private_key_passphrase !== undefined
+        ? { private_key_passphrase: credential.content.private_key_passphrase }
+        : {}),
+    },
+  });
 }
 
 const MCPServerRequiresPersonalAuthenticationErrorName =

--- a/front/lib/actions/mcp_metadata_extraction.ts
+++ b/front/lib/actions/mcp_metadata_extraction.ts
@@ -17,6 +17,7 @@ import { isOAuthProvider } from "@app/types";
 export type AuthorizationInfo = {
   provider: OAuthProvider;
   supported_use_cases: MCPOAuthUseCase[];
+  supported_auth_methods?: Array<"oauth" | "keypair">;
   scope?: string;
   // API-layer only: injected in responses to signal whether a prerequisite
   // workspace-level connection exists for personal OAuth flows.

--- a/front/lib/api/actions/servers/snowflake/metadata.ts
+++ b/front/lib/api/actions/servers/snowflake/metadata.ts
@@ -107,6 +107,7 @@ export const SNOWFLAKE_SERVER = {
     authorization: {
       provider: "snowflake",
       supported_use_cases: ["personal_actions", "platform_actions"],
+      supported_auth_methods: ["oauth", "keypair"],
     },
     icon: "SnowflakeLogo",
     documentationUrl: "https://docs.dust.tt/docs/snowflake-tool",

--- a/front/lib/api/actions/servers/snowflake/tools/index.test.ts
+++ b/front/lib/api/actions/servers/snowflake/tools/index.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { Ok } from "@app/types";
+
+const mockSnowflakeClientConstructor = vi.fn();
+
+class SnowflakeClientMock {
+  constructor(options: unknown) {
+    return mockSnowflakeClientConstructor(options);
+  }
+}
+
+vi.mock("@app/lib/api/actions/servers/snowflake/client", () => ({
+  SnowflakeClient: SnowflakeClientMock,
+}));
+
+describe("Snowflake MCP tool auth parsing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses OAuth token when authInfo.token is provided", async () => {
+    mockSnowflakeClientConstructor.mockReturnValue({
+      listDatabases: vi.fn().mockResolvedValue(new Ok(["DB1"])),
+    });
+
+    const { TOOLS } = await import("@app/lib/api/actions/servers/snowflake/tools");
+    const tool = TOOLS.find((t) => t.name === "list_databases");
+    expect(tool).toBeDefined();
+
+    const res = await tool!.handler(
+      {},
+      {
+        authInfo: {
+          token: "oauth_token",
+          extra: {
+            snowflake_account: "acc",
+            snowflake_warehouse: "wh",
+          },
+        },
+      } as any
+    );
+
+    expect(res.isOk()).toBe(true);
+    expect(mockSnowflakeClientConstructor).toHaveBeenCalledWith({
+      account: "acc",
+      warehouse: "wh",
+      auth: { type: "oauth", accessToken: "oauth_token" },
+    });
+  });
+
+  it("uses key-pair credentials when authInfo.extra indicates keypair", async () => {
+    mockSnowflakeClientConstructor.mockReturnValue({
+      listDatabases: vi.fn().mockResolvedValue(new Ok(["DB1"])),
+    });
+
+    const { TOOLS } = await import("@app/lib/api/actions/servers/snowflake/tools");
+    const tool = TOOLS.find((t) => t.name === "list_databases");
+    expect(tool).toBeDefined();
+
+    const res = await tool!.handler(
+      {},
+      {
+        authInfo: {
+          token: "",
+          extra: {
+            snowflake_auth_type: "keypair",
+            snowflake_account: "acc",
+            snowflake_warehouse: "wh",
+            snowflake_username: "user",
+            snowflake_role: "role",
+            snowflake_private_key: "-----BEGIN PRIVATE KEY-----\nMIIB...\n-----END PRIVATE KEY-----",
+          },
+        },
+      } as any
+    );
+
+    expect(res.isOk()).toBe(true);
+    expect(mockSnowflakeClientConstructor).toHaveBeenCalledWith({
+      account: "acc",
+      warehouse: "wh",
+      auth: {
+        type: "keypair",
+        username: "user",
+        role: "role",
+        privateKey: "-----BEGIN PRIVATE KEY-----\nMIIB...\n-----END PRIVATE KEY-----",
+      },
+    });
+  });
+
+  it("fails safely when misconfigured", async () => {
+    mockSnowflakeClientConstructor.mockReturnValue({
+      listDatabases: vi.fn().mockResolvedValue(new Ok(["DB1"])),
+    });
+
+    const { TOOLS } = await import("@app/lib/api/actions/servers/snowflake/tools");
+    const tool = TOOLS.find((t) => t.name === "list_databases");
+    expect(tool).toBeDefined();
+
+    const res = await tool!.handler(
+      {},
+      {
+        authInfo: {
+          token: "",
+          extra: {
+            snowflake_auth_type: "keypair",
+            snowflake_account: "acc",
+            snowflake_warehouse: "wh",
+            snowflake_username: "user",
+            snowflake_role: "role",
+            // missing snowflake_private_key
+          },
+        },
+      } as any
+    );
+
+    expect(res.isErr()).toBe(true);
+    if (res.isErr()) {
+      expect(res.error.message).toContain("Snowflake connection not configured");
+    }
+  });
+});

--- a/front/lib/api/mcp_oauth_prerequisites.ts
+++ b/front/lib/api/mcp_oauth_prerequisites.ts
@@ -26,6 +26,13 @@ export async function listWorkspaceConnectedMCPServerIds(
   const serverIds = new Set<string>();
 
   for (const connection of workspaceConnections) {
+    // Workspace OAuth prerequisites are satisfied only by OAuth-backed connections.
+    // Key-pair connections are intentionally not considered a valid prerequisite for
+    // personal OAuth flows.
+    if (!connection.connectionId) {
+      continue;
+    }
+
     if (connection.internalMCPServerId) {
       serverIds.add(connection.internalMCPServerId);
       continue;

--- a/front/lib/api/oauth/providers/databricks.ts
+++ b/front/lib/api/oauth/providers/databricks.ts
@@ -117,6 +117,14 @@ export class DatabricksOAuthProvider implements BaseOAuthStrategyProvider {
           });
         }
 
+        if (!mcpServerConnectionRes.value.connectionId) {
+          return new Err({
+            code: "credential_retrieval_failed",
+            message:
+              "Workspace MCP server connection is not configured for OAuth.",
+          });
+        }
+
         const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
         const connectionRes = await oauthApi.getAccessToken({
           connectionId: mcpServerConnectionRes.value.connectionId,
@@ -189,6 +197,10 @@ export class DatabricksOAuthProvider implements BaseOAuthStrategyProvider {
             "Failed to find MCP server connection: " +
               mcpServerConnectionRes.error.message
           );
+        }
+
+        if (!mcpServerConnectionRes.value.connectionId) {
+          throw new Error("Workspace MCP server connection is not configured for OAuth.");
         }
 
         const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);

--- a/front/lib/api/oauth/providers/freshservice.ts
+++ b/front/lib/api/oauth/providers/freshservice.ts
@@ -155,6 +155,14 @@ export class FreshserviceOAuthProvider implements BaseOAuthStrategyProvider {
           });
         }
 
+        if (!mcpServerConnectionRes.value.connectionId) {
+          return new Err({
+            code: "credential_retrieval_failed",
+            message:
+              "Workspace MCP server connection is not configured for OAuth.",
+          });
+        }
+
         const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
         const connectionRes = await oauthApi.getConnectionMetadata({
           connectionId: mcpServerConnectionRes.value.connectionId,
@@ -225,6 +233,10 @@ export class FreshserviceOAuthProvider implements BaseOAuthStrategyProvider {
             "Failed to find MCP server connection: " +
               mcpServerConnectionRes.error.message
           );
+        }
+
+        if (!mcpServerConnectionRes.value.connectionId) {
+          throw new Error("Workspace MCP server connection is not configured for OAuth.");
         }
 
         const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);

--- a/front/lib/api/oauth/providers/gmail.ts
+++ b/front/lib/api/oauth/providers/gmail.ts
@@ -105,6 +105,14 @@ export class GmailOAuthProvider implements BaseOAuthStrategyProvider {
           });
         }
 
+        if (!mcpServerConnectionRes.value.connectionId) {
+          return new Err({
+            code: "credential_retrieval_failed",
+            message:
+              "Workspace MCP server connection is not configured for OAuth.",
+          });
+        }
+
         const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
         const connectionRes = await oauthApi.getAccessToken({
           connectionId: mcpServerConnectionRes.value.connectionId,
@@ -170,6 +178,10 @@ export class GmailOAuthProvider implements BaseOAuthStrategyProvider {
             "Failed to find MCP server connection: " +
               mcpServerConnectionRes.error.message
           );
+        }
+
+        if (!mcpServerConnectionRes.value.connectionId) {
+          throw new Error("Workspace MCP server connection is not configured for OAuth.");
         }
 
         const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);

--- a/front/lib/api/oauth/providers/mcp.ts
+++ b/front/lib/api/oauth/providers/mcp.ts
@@ -160,6 +160,14 @@ export class MCPOAuthProvider implements BaseOAuthStrategyProvider {
           });
         }
 
+        if (!mcpServerConnectionRes.value.connectionId) {
+          return new Err({
+            code: "credential_retrieval_failed",
+            message:
+              "Workspace MCP server connection is not configured for OAuth.",
+          });
+        }
+
         const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
         const connectionRes = await oauthApi.getConnectionMetadata({
           connectionId: mcpServerConnectionRes.value.connectionId,
@@ -233,6 +241,10 @@ export class MCPOAuthProvider implements BaseOAuthStrategyProvider {
             "Failed to find MCP server connection: " +
               mcpServerConnectionRes.error.message
           );
+        }
+
+        if (!mcpServerConnectionRes.value.connectionId) {
+          throw new Error("Workspace MCP server connection is not configured for OAuth.");
         }
 
         const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);

--- a/front/lib/api/oauth/providers/notion.ts
+++ b/front/lib/api/oauth/providers/notion.ts
@@ -98,6 +98,10 @@ export class NotionOAuthProvider implements BaseOAuthStrategyProvider {
           );
         }
 
+        if (!mcpServerConnectionRes.value.connectionId) {
+          throw new Error("Workspace MCP server connection is not configured for OAuth.");
+        }
+
         const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
         const connectionRes = await oauthApi.getConnectionMetadata({
           connectionId: mcpServerConnectionRes.value.connectionId,

--- a/front/lib/api/oauth/providers/salesforce.ts
+++ b/front/lib/api/oauth/providers/salesforce.ts
@@ -113,6 +113,14 @@ export class SalesforceOAuthProvider implements BaseOAuthStrategyProvider {
           });
         }
 
+        if (!mcpServerConnectionRes.value.connectionId) {
+          return new Err({
+            code: "credential_retrieval_failed",
+            message:
+              "Workspace MCP server connection is not configured for OAuth.",
+          });
+        }
+
         const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
         const connectionRes = await oauthApi.getConnectionMetadata({
           connectionId: mcpServerConnectionRes.value.connectionId,
@@ -177,6 +185,10 @@ export class SalesforceOAuthProvider implements BaseOAuthStrategyProvider {
             "Failed to find MCP server connection: " +
               mcpServerConnectionRes.error.message
           );
+        }
+
+        if (!mcpServerConnectionRes.value.connectionId) {
+          throw new Error("Workspace MCP server connection is not configured for OAuth.");
         }
 
         const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);

--- a/front/lib/api/oauth/providers/slack_tools.ts
+++ b/front/lib/api/oauth/providers/slack_tools.ts
@@ -129,6 +129,10 @@ export class SlackToolsOAuthProvider implements BaseOAuthStrategyProvider {
           );
         }
 
+        if (!mcpServerConnectionRes.value.connectionId) {
+          throw new Error("Workspace MCP server connection is not configured for OAuth.");
+        }
+
         const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
         const connectionRes = await oauthApi.getConnectionMetadata({
           connectionId: mcpServerConnectionRes.value.connectionId,

--- a/front/lib/api/oauth/providers/snowflake.ts
+++ b/front/lib/api/oauth/providers/snowflake.ts
@@ -62,6 +62,15 @@ async function getWorkspaceConnectionForMCPServer(
     });
   }
 
+  if (!mcpServerConnectionRes.value.connectionId) {
+    return new Err({
+      code: "credential_retrieval_failed",
+      message:
+        "Workspace Snowflake MCP connection is configured for key-pair authentication. " +
+        "Personal Snowflake connections are OAuth-only. Please ask an admin to configure OAuth for this Snowflake MCP server.",
+    });
+  }
+
   const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
   const connectionRes = await oauthApi.getAccessToken({
     connectionId: mcpServerConnectionRes.value.connectionId,

--- a/front/lib/api/oauth/providers/ukg_ready.ts
+++ b/front/lib/api/oauth/providers/ukg_ready.ts
@@ -125,6 +125,14 @@ export class UkgReadyOAuthProvider implements BaseOAuthStrategyProvider {
           });
         }
 
+        if (!mcpServerConnectionRes.value.connectionId) {
+          return new Err({
+            code: "credential_retrieval_failed",
+            message:
+              "Workspace MCP server connection is not configured for OAuth.",
+          });
+        }
+
         const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
         const connectionRes = await oauthApi.getConnectionMetadata({
           connectionId: mcpServerConnectionRes.value.connectionId,
@@ -189,6 +197,10 @@ export class UkgReadyOAuthProvider implements BaseOAuthStrategyProvider {
             "Failed to find MCP server connection: " +
               mcpServerConnectionRes.error.message
           );
+        }
+
+        if (!mcpServerConnectionRes.value.connectionId) {
+          throw new Error("Workspace MCP server connection is not configured for OAuth.");
         }
 
         const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);

--- a/front/lib/models/agent/actions/mcp_server_connection.ts
+++ b/front/lib/models/agent/actions/mcp_server_connection.ts
@@ -11,7 +11,8 @@ export class MCPServerConnectionModel extends WorkspaceAwareModel<MCPServerConne
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
-  declare connectionId: string;
+  declare connectionId: string | null;
+  declare credentialId: string | null;
   declare connectionType: "workspace" | "personal";
 
   declare userId: ForeignKey<UserModel["id"]>;
@@ -39,7 +40,11 @@ MCPServerConnectionModel.init(
     },
     connectionId: {
       type: DataTypes.STRING,
-      allowNull: false,
+      allowNull: true,
+    },
+    credentialId: {
+      type: DataTypes.STRING,
+      allowNull: true,
     },
     connectionType: {
       type: DataTypes.STRING,
@@ -96,6 +101,17 @@ MCPServerConnectionModel.init(
     ],
     hooks: {
       beforeValidate: (config: MCPServerConnectionModel) => {
+        const hasConnectionId =
+          typeof config.connectionId === "string" && config.connectionId !== "";
+        const hasCredentialId =
+          typeof config.credentialId === "string" && config.credentialId !== "";
+
+        if (hasConnectionId === hasCredentialId) {
+          throw new Error(
+            "Exactly one of connectionId or credentialId must be provided."
+          );
+        }
+
         if (config.serverType) {
           switch (config.serverType) {
             case "internal":

--- a/front/lib/resources/mcp_server_connection_resource.ts
+++ b/front/lib/resources/mcp_server_connection_resource.ts
@@ -344,6 +344,7 @@ export class MCPServerConnectionResource extends BaseResource<MCPServerConnectio
       sId: this.sId,
       createdAt: this.createdAt,
       updatedAt: this.updatedAt,
+      authType: this.credentialId ? "keypair" : "oauth",
       connectionType: this.connectionType,
       serverType: this.serverType,
       internalMCPServerId: this.internalMCPServerId,
@@ -375,6 +376,7 @@ export interface MCPServerConnectionType {
   sId: string;
   createdAt: Date;
   updatedAt: Date;
+  authType: "oauth" | "keypair";
   user: {
     fullName: string | null;
     imageUrl: string | null;

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -659,17 +659,21 @@ export function useCreateMCPServerConnection({
   const { mutate } = useMutateMCPServersViewsForAdmin(owner);
 
   const sendNotification = useSendNotification();
+  type AuthRef =
+    | { connectionId: string; credentialId?: never }
+    | { credentialId: string; connectionId?: never };
+
   const createMCPServerConnection = async ({
     connectionId,
+    credentialId,
     mcpServerId,
     mcpServerDisplayName,
     provider,
   }: {
-    connectionId: string;
     mcpServerId: string;
     mcpServerDisplayName: string;
     provider: OAuthProvider;
-  }): Promise<PostConnectionResponseBody | null> => {
+  } & AuthRef): Promise<PostConnectionResponseBody | null> => {
     const response = await clientFetch(
       `/api/w/${owner.sId}/mcp/connections/${connectionType}`,
       {
@@ -679,6 +683,7 @@ export function useCreateMCPServerConnection({
         },
         body: JSON.stringify({
           connectionId,
+          credentialId,
           mcpServerId,
           provider,
         }),

--- a/front/migrations/20250904_migrate_agents_using_slack_channels.ts
+++ b/front/migrations/20250904_migrate_agents_using_slack_channels.ts
@@ -108,6 +108,13 @@ makeScript(
       return;
     }
 
+    if (!mcpServerConnection.connectionId) {
+      logger.error(
+        `MCP server connection is not configured for OAuth for internal server ID: ${mcpServerView.internalMCPServerId}`
+      );
+      return;
+    }
+
     // Get the OAuth access token
     const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
     const tokenResult = await oauthApi.getAccessToken({

--- a/front/migrations/db/migration_497.sql
+++ b/front/migrations/db/migration_497.sql
@@ -1,0 +1,14 @@
+-- Migration created on Feb 02, 2026
+
+-- Allow MCP server connections to be authenticated either via an OAuth connectionId
+-- or via a stored credentials reference (credentialId). Exactly one must be set.
+
+ALTER TABLE "mcp_server_connections"
+    ADD COLUMN IF NOT EXISTS "credentialId" VARCHAR(255);
+
+ALTER TABLE "mcp_server_connections"
+    ALTER COLUMN "connectionId" DROP NOT NULL;
+
+ALTER TABLE "mcp_server_connections"
+    ADD CONSTRAINT "mcp_server_connections_auth_reference_check"
+        CHECK (("connectionId" IS NOT NULL) <> ("credentialId" IS NOT NULL));

--- a/front/pages/api/w/[wId]/mcp/connections/[connectionType]/index.test.ts
+++ b/front/pages/api/w/[wId]/mcp/connections/[connectionType]/index.test.ts
@@ -1,13 +1,43 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { internalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
 import type { MCPServerConnectionType } from "@app/lib/resources/mcp_server_connection_resource";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
 import { MCPServerConnectionFactory } from "@app/tests/utils/MCPServerConnectionFactory";
 import { RemoteMCPServerFactory } from "@app/tests/utils/RemoteMCPServerFactory";
+import { Ok } from "@app/types";
 
 import handler from "./index";
 
+// Mock config for OAuth API.
+vi.mock("@app/lib/api/config", () => ({
+  default: {
+    getOAuthAPIConfig: vi.fn(() => ({
+      url: "https://oauth-api.example.com",
+      apiKey: "test-api-key",
+    })),
+  },
+}));
+
+const mockGetCredentials = vi.fn();
+
+vi.mock("@app/types", async (importOriginal) => {
+  const actual = (await importOriginal()) as any;
+  return {
+    ...actual,
+    OAuthAPI: vi.fn().mockImplementation(function () {
+      return {
+        getCredentials: mockGetCredentials,
+      };
+    }),
+  };
+});
+
 describe("MCP Connections API Handler", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("should return personal connections filtered by user ID", async () => {
     const { req, res, workspace, authenticator } =
       await createPrivateApiMockRequest({
@@ -232,5 +262,277 @@ describe("MCP Connections API Handler", () => {
     expect(response.connections).toHaveLength(1);
     expect(response.connections[0].sId).toBe(connection2.sId);
     expect(response.connections[0].sId).not.toBe(connection1.sId);
+  });
+
+  describe("POST", () => {
+    it("rejects missing auth reference", async () => {
+      const { req, res, workspace } = await createPrivateApiMockRequest({
+        method: "POST",
+      });
+      req.query.connectionType = "personal";
+
+      const remoteServer = await RemoteMCPServerFactory.create(workspace);
+      req.body = {
+        mcpServerId: remoteServer.sId,
+      };
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(400);
+      expect(res._getJSONData()).toEqual({
+        error: {
+          type: "invalid_request_error",
+          message: "Missing authentication reference.",
+        },
+      });
+    });
+
+    it("rejects providing both connectionId and credentialId", async () => {
+      const { req, res, workspace } = await createPrivateApiMockRequest({
+        method: "POST",
+        role: "admin",
+      });
+      req.query.connectionType = "workspace";
+
+      const remoteServer = await RemoteMCPServerFactory.create(workspace);
+      req.body = {
+        mcpServerId: remoteServer.sId,
+        connectionId: "not_a_con_id",
+        credentialId: "cred_123",
+      };
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(400);
+      expect(res._getJSONData()).toEqual({
+        error: {
+          type: "invalid_request_error",
+          message: "Provide either connectionId or credentialId, not both.",
+        },
+      });
+    });
+
+    it("rejects credentialId for personal connections", async () => {
+      const { req, res, workspace } = await createPrivateApiMockRequest({
+        method: "POST",
+      });
+      req.query.connectionType = "personal";
+
+      const remoteServer = await RemoteMCPServerFactory.create(workspace);
+      req.body = {
+        mcpServerId: remoteServer.sId,
+        credentialId: "cred_123",
+      };
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(400);
+      expect(res._getJSONData()).toEqual({
+        error: {
+          type: "invalid_request_error",
+          message: "Personal MCP server connections are OAuth-only.",
+        },
+      });
+    });
+
+    it("rejects credentialId for non-Snowflake servers", async () => {
+      const { req, res, workspace } = await createPrivateApiMockRequest({
+        method: "POST",
+        role: "admin",
+      });
+      req.query.connectionType = "workspace";
+
+      const remoteServer = await RemoteMCPServerFactory.create(workspace);
+      req.body = {
+        mcpServerId: remoteServer.sId,
+        credentialId: "cred_123",
+      };
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(400);
+      expect(res._getJSONData()).toEqual({
+        error: {
+          type: "invalid_request_error",
+          message:
+            "Key-pair authentication is only supported for workspace connections to the internal Snowflake MCP server.",
+        },
+      });
+    });
+
+	    it("validates credential ownership for Snowflake keypair connections", async () => {
+	      const { req, res, workspace } = await createPrivateApiMockRequest({
+	        method: "POST",
+	        role: "admin",
+	      });
+      req.query.connectionType = "workspace";
+
+      const snowflakeServerId = internalMCPServerNameToSId({
+        name: "snowflake",
+        workspaceId: workspace.id,
+        prefix: 123,
+      });
+
+      mockGetCredentials.mockResolvedValue(
+        new Ok({
+          credential: {
+            credential_id: "cred_123",
+            created: Date.now(),
+            provider: "snowflake",
+            metadata: {
+              workspace_id: workspace.sId,
+              user_id: "usr_other",
+            },
+            content: {
+              auth_type: "keypair",
+              account: "acc",
+              username: "user",
+              role: "role",
+              warehouse: "wh",
+              private_key: "-----BEGIN PRIVATE KEY-----\nMIIB...\n-----END PRIVATE KEY-----",
+            },
+          },
+        } as any)
+      );
+
+      req.body = {
+        mcpServerId: snowflakeServerId,
+        credentialId: "cred_123",
+      };
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(400);
+      expect(res._getJSONData()).toEqual({
+        error: {
+          type: "invalid_request_error",
+          message: "Invalid credential.",
+        },
+      });
+    });
+
+    it("rejects non-keypair Snowflake credentials for keypair connections", async () => {
+      const { req, res, workspace, user } = await createPrivateApiMockRequest({
+        method: "POST",
+        role: "admin",
+      });
+      req.query.connectionType = "workspace";
+
+      const snowflakeServerId = internalMCPServerNameToSId({
+        name: "snowflake",
+        workspaceId: workspace.id,
+        prefix: 123,
+      });
+
+      mockGetCredentials.mockResolvedValue(
+        new Ok({
+          credential: {
+            credential_id: "cred_123",
+            created: Date.now(),
+            provider: "snowflake",
+            metadata: {
+              workspace_id: workspace.sId,
+              user_id: user.sId,
+            },
+            content: {
+              auth_type: "password",
+              account: "acc",
+              username: "user",
+              role: "role",
+              warehouse: "wh",
+              password: "not-used",
+            },
+          },
+        } as any)
+      );
+
+      req.body = {
+        mcpServerId: snowflakeServerId,
+        credentialId: "cred_123",
+      };
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(400);
+      expect(res._getJSONData()).toEqual({
+        error: {
+          type: "invalid_request_error",
+          message:
+            "The provided credential is not a Snowflake key-pair credential.",
+        },
+      });
+    });
+
+    it("creates a keypair Snowflake workspace connection when credential is valid", async () => {
+      const { req, res, workspace, user } = await createPrivateApiMockRequest({
+        method: "POST",
+        role: "admin",
+      });
+      req.query.connectionType = "workspace";
+
+      const snowflakeServerId = internalMCPServerNameToSId({
+        name: "snowflake",
+        workspaceId: workspace.id,
+        prefix: 123,
+      });
+
+      mockGetCredentials.mockResolvedValue(
+        new Ok({
+          credential: {
+            credential_id: "cred_123",
+            created: Date.now(),
+            provider: "snowflake",
+            metadata: {
+              workspace_id: workspace.sId,
+              user_id: user.sId,
+            },
+            content: {
+              auth_type: "keypair",
+              account: "acc",
+              username: "user",
+              role: "role",
+              warehouse: "wh",
+              private_key: "-----BEGIN PRIVATE KEY-----\nMIIB...\n-----END PRIVATE KEY-----",
+            },
+          },
+        } as any)
+      );
+
+      req.body = {
+        mcpServerId: snowflakeServerId,
+        credentialId: "cred_123",
+      };
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+      const data = res._getJSONData();
+      expect(data.success).toBe(true);
+      expect(data.connection.authType).toBe("keypair");
+    });
+
+    it("requires admin for workspace connections", async () => {
+      const { req, res, workspace } = await createPrivateApiMockRequest({
+        method: "POST",
+      });
+      req.query.connectionType = "workspace";
+
+      const remoteServer = await RemoteMCPServerFactory.create(workspace);
+      req.body = {
+        mcpServerId: remoteServer.sId,
+        connectionId: "not_a_con_id",
+      };
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(403);
+      expect(res._getJSONData()).toEqual({
+        error: {
+          type: "app_auth_error",
+          message:
+            "Only workspace admins can create workspace-wide MCP server connections.",
+        },
+      });
+    });
   });
 });

--- a/front/pages/api/w/[wId]/mcp/connections/[connectionType]/index.ts
+++ b/front/pages/api/w/[wId]/mcp/connections/[connectionType]/index.ts
@@ -4,7 +4,9 @@ import * as reporter from "io-ts-reporters";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getServerTypeAndIdFromSId } from "@app/lib/actions/mcp_helper";
+import { getInternalMCPServerNameAndWorkspaceId } from "@app/lib/actions/mcp_internal_actions/constants";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import apiConfig from "@app/lib/api/config";
 import { checkConnectionOwnership } from "@app/lib/api/oauth";
 import type { Authenticator } from "@app/lib/auth";
 import type { MCPServerConnectionType } from "@app/lib/resources/mcp_server_connection_resource";
@@ -12,13 +14,20 @@ import {
   isMCPServerConnectionConnectionType,
   MCPServerConnectionResource,
 } from "@app/lib/resources/mcp_server_connection_resource";
+import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
+import { OAuthAPI } from "@app/types";
 
-const PostConnectionBodySchema = t.type({
-  connectionId: t.string,
-  mcpServerId: t.string,
-});
+const PostConnectionBodySchema = t.intersection([
+  t.type({
+    mcpServerId: t.string,
+  }),
+  t.partial({
+    connectionId: t.string,
+    credentialId: t.string,
+  }),
+]);
 export type PostConnectionBodyType = t.TypeOf<typeof PostConnectionBodySchema>;
 
 export type PostConnectionResponseBody = {
@@ -63,6 +72,17 @@ async function handler(
         connections: connections.map((c) => c.toJSON()),
       });
     case "POST":
+      if (connectionType === "workspace" && !auth.isAdmin()) {
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "app_auth_error",
+            message:
+              "Only workspace admins can create workspace-wide MCP server connections.",
+          },
+        });
+      }
+
       const bodyValidation = PostConnectionBodySchema.decode(req.body);
       if (isLeft(bodyValidation)) {
         const pathError = reporter.formatValidationErrors(bodyValidation.left);
@@ -77,7 +97,37 @@ async function handler(
       }
 
       const validatedBody = bodyValidation.right;
-      const { connectionId, mcpServerId } = validatedBody;
+      const { connectionId, credentialId, mcpServerId } = validatedBody;
+
+      if (!connectionId && !credentialId) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Missing authentication reference.",
+          },
+        });
+      }
+
+      if (connectionId && credentialId) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Provide either connectionId or credentialId, not both.",
+          },
+        });
+      }
+
+      if (connectionType === "personal" && credentialId) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Personal MCP server connections are OAuth-only.",
+          },
+        });
+      }
 
       if (connectionId) {
         const checkConnectionOwnershipRes = await checkConnectionOwnership(
@@ -97,10 +147,76 @@ async function handler(
 
       const { serverType, id } = getServerTypeAndIdFromSId(mcpServerId);
 
+      if (credentialId) {
+        if (serverType !== "internal" || connectionType !== "workspace") {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message:
+                "Key-pair authentication is only supported for workspace connections to the internal Snowflake MCP server.",
+            },
+          });
+        }
+
+        const internalServerRes =
+          getInternalMCPServerNameAndWorkspaceId(mcpServerId);
+        if (
+          internalServerRes.isErr() ||
+          internalServerRes.value.name !== "snowflake" ||
+          internalServerRes.value.workspaceModelId !==
+            auth.getNonNullableWorkspace().id
+        ) {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message:
+                "Key-pair authentication is only supported for the internal Snowflake MCP server.",
+            },
+          });
+        }
+
+        const oauthApi = new OAuthAPI(apiConfig.getOAuthAPIConfig(), logger);
+        const credentialRes = await oauthApi.getCredentials({
+          credentialsId: credentialId,
+        });
+
+        if (
+          credentialRes.isErr() ||
+          credentialRes.value.credential.metadata.user_id !==
+            auth.getNonNullableUser().sId ||
+          credentialRes.value.credential.metadata.workspace_id !==
+            auth.getNonNullableWorkspace().sId ||
+          credentialRes.value.credential.provider !== "snowflake"
+        ) {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: "Invalid credential.",
+            },
+          });
+        }
+
+        const content = credentialRes.value.credential.content;
+        if (!("private_key" in content)) {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message:
+                "The provided credential is not a Snowflake key-pair credential.",
+            },
+          });
+        }
+      }
+
       const connectionResource = await MCPServerConnectionResource.makeNew(
         auth,
         {
-          connectionId,
+          connectionId: connectionId ?? null,
+          credentialId: credentialId ?? null,
           connectionType,
           serverType,
           internalMCPServerId: serverType === "internal" ? mcpServerId : null,


### PR DESCRIPTION
## Description

- Add RSA key-pair authentication for workspace (shared account) Snowflake MCP connections as an alternative to OAuth.
- Keep personal Snowflake MCP connections OAuth-only and restrict workspace connection creation/editing to admins.
- Persist auth mode via XOR `connectionId`/`credentialId` and expose `authType` for UI display (no secrets).
- Resolve auth at runtime and pass token vs key-pair credentials to the internal Snowflake MCP server.

## Tests

- `cd front && npm run lint`
- `cd front && NODE_OPTIONS=\"--max-old-space-size=8192\" npx tsc --noEmit`
- `cd front && NODE_ENV=test npm test pages/api/w/[wId]/mcp/connections/[connectionType]/index.test.ts`
- `cd front && NODE_ENV=test npm test lib/actions/mcp_authentication.test.ts lib/api/actions/servers/snowflake/tools/index.test.ts`

## Risk

Low–medium.
- `mcp_server_connections.connectionId` is now nullable; OAuth-only codepaths explicitly validate `connectionId` is present.
- Key material is stored in the existing credentials system and never returned in API responses.

## Deploy Plan

- Run `front/migrations/db/migration_497.sql`.
- Deploy `front`.