### PR TITLE
[front] enh: skip duplicate skill enablement

### DIFF
--- a/front/lib/api/actions/servers/skill_management/tools/index.ts
+++ b/front/lib/api/actions/servers/skill_management/tools/index.ts
@@ -40,10 +40,14 @@ const handlers: ToolHandlers<typeof SKILL_MANAGEMENT_TOOLS_METADATA> = {
       );
     }
 
+    const { alreadyEnabled } = enableResult.value;
+
     return new Ok([
       {
         type: "text" as const,
-        text: `Skill "${skill.name}" has been enabled.`,
+        text: alreadyEnabled
+          ? `Skill "${skill.name}" was already enabled.`
+          : `Skill "${skill.name}" has been enabled.`,
       },
     ]);
   },

--- a/front/lib/api/actions/servers/skill_management/tools/index.ts
+++ b/front/lib/api/actions/servers/skill_management/tools/index.ts
@@ -46,7 +46,7 @@ const handlers: ToolHandlers<typeof SKILL_MANAGEMENT_TOOLS_METADATA> = {
       {
         type: "text" as const,
         text: alreadyEnabled
-          ? `Skill "${skill.name}" was already enabled.`
+          ? `Skill "${skill.name}" was already enabled. No action taken.`
           : `Skill "${skill.name}" has been enabled.`,
       },
     ]);

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1870,20 +1870,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       );
     }
 
-    // Check if this skill is already enabled for this agent in this conversation.
-    const existingConversationSkill = await ConversationSkillModel.findOne({
-      where: {
-        ...this.skillReference,
-        workspaceId: workspace.id,
-        conversationId: conversation.id,
-        agentConfigurationId: agentConfiguration.sId,
-      },
-    });
-
-    if (existingConversationSkill) {
-      return new Ok({ alreadyEnabled: true });
-    }
-
     const conversationSkillBlob: ConversationSkillCreationAttributes = {
       ...this.skillReference,
       workspaceId: workspace.id,
@@ -1892,6 +1878,15 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       source: "agent_enabled",
       agentConfigurationId: agentConfiguration.sId,
     };
+
+    // Check if this skill is already enabled for this agent in this conversation.
+    const existingConversationSkill = await ConversationSkillModel.findOne({
+      where: conversationSkillBlob,
+    });
+
+    if (existingConversationSkill) {
+      return new Ok({ alreadyEnabled: true });
+    }
 
     await ConversationSkillModel.create(conversationSkillBlob);
 


### PR DESCRIPTION
## Description

- This PR improves the tool that enables a skill to surface to the model whether the skill was already enabled or not.
- Had a conversation where I explicitly asked the model to enable a skill that was enabled and it was not aware of it.
- Overall a minor change, slightly improves the information surfaced to the model in some rare cases and prevents having duplicate rows in `conversation_skills` that represent the same info.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
