### PR TITLE
[front] Improve handling of missing actions in multi-agents setups

### DIFF
--- a/front/lib/api/actions/servers/missing_action_catcher/tools/index.ts
+++ b/front/lib/api/actions/servers/missing_action_catcher/tools/index.ts
@@ -31,7 +31,8 @@ export function createMissingActionCatcherTools(
                 "  1. Please verify that the function name is correct: " +
                 "pay attention to case sensitivity and separators between words in the name.\n" +
                 "  2. If the function comes from a skill, enable the skill first.\n" +
-                "This action can safely be retried with another name.",
+                "This action can safely be retried with another name or with the same name after " +
+                "enabling a skill.",
               { tracked: false }
             )
           );

--- a/front/lib/api/actions/servers/missing_action_catcher/tools/index.ts
+++ b/front/lib/api/actions/servers/missing_action_catcher/tools/index.ts
@@ -28,9 +28,9 @@ export function createMissingActionCatcherTools(
             new MCPError(
               `Tool "${actionName}" not found. ` +
                 "This answer to the function call is a catch-all.\n" +
-                "  1. Please verify that the function name is correct: " +
-                "pay attention to case sensitivity and separators between words in the name.\n" +
-                "  2. If the function comes from a skill, enable the skill first.\n" +
+                "  1. The function name needs to be checked to ensure it matches one of the tools " +
+                "available (case sensitivity, word separators, ...).\n" +
+                "  2. If the function comes from a skill, the skill needs to be enabled first.\n" +
                 "This action can safely be retried with another name or with the same name after " +
                 "enabling a skill.",
               { tracked: false }

--- a/front/lib/api/actions/servers/missing_action_catcher/tools/index.ts
+++ b/front/lib/api/actions/servers/missing_action_catcher/tools/index.ts
@@ -27,10 +27,11 @@ export function createMissingActionCatcherTools(
           return new Err(
             new MCPError(
               `Tool "${actionName}" not found. ` +
-                "This answer to the function call is a catch-all. " +
-                "Please verify that the function name is correct : " +
-                "pay attention to case sensitivity and separators between words in the name. " +
-                "It's safe to retry automatically with another name.",
+                "This answer to the function call is a catch-all.\n" +
+                "  1. Please verify that the function name is correct: " +
+                "pay attention to case sensitivity and separators between words in the name.\n" +
+                "  2. If the function comes from a skill, enable the skill first.\n" +
+                "This action can safely be retried with another name.",
               { tracked: false }
             )
           );


### PR DESCRIPTION
## Description

- In a conversation that involves multiple agents with different sets of skills enabled, by seeing a certain agent using a tool the other agents may assume the tool is enabled and fail to realize they need to enable the skill as well.
- This PR updates the output of the missing action catcher tool to help the agent identify such situations.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
