### PR TITLE
[front] chore: minor refactoring on `run_agent` MCP server

### DIFF
--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1,6 +1,6 @@
 import type { InternalAllowedIconType } from "@app/components/resources/resources_icons";
-import { RUN_AGENT_CALL_TOOL_TIMEOUT_MS } from "@app/lib/actions/constants";
 import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
+import { RUN_AGENT_CALL_TOOL_TIMEOUT_MS } from "@app/lib/actions/constants";
 import { PRODUCTBOARD_SERVER_INSTRUCTIONS } from "@app/lib/actions/mcp_internal_actions/servers/productboard/instructions";
 import { SLIDESHOW_INSTRUCTIONS } from "@app/lib/actions/mcp_internal_actions/servers/slideshow/instructions";
 import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -1,4 +1,5 @@
 import type { InternalAllowedIconType } from "@app/components/resources/resources_icons";
+import { RUN_AGENT_CALL_TOOL_TIMEOUT_MS } from "@app/lib/actions/constants";
 import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import { PRODUCTBOARD_SERVER_INSTRUCTIONS } from "@app/lib/actions/mcp_internal_actions/servers/productboard/instructions";
 import { SLIDESHOW_INSTRUCTIONS } from "@app/lib/actions/mcp_internal_actions/servers/slideshow/instructions";
@@ -915,7 +916,7 @@ export const INTERNAL_MCP_SERVERS = {
     isPreview: false,
     tools_arguments_requiring_approval: undefined,
     tools_retry_policies: { default: "retry_on_interrupt" },
-    timeoutMs: RUN_AGENT_SERVER.timeoutMs,
+    timeoutMs: RUN_AGENT_CALL_TOOL_TIMEOUT_MS,
     metadata: RUN_AGENT_SERVER,
   },
   [TABLE_QUERY_V2_SERVER_NAME]: {

--- a/front/lib/api/actions/servers/run_agent/index.ts
+++ b/front/lib/api/actions/servers/run_agent/index.ts
@@ -159,14 +159,7 @@ async function leakyGetAgentNameAndDescriptionForChildAgent(
   };
 }
 
-function createServer(
-  auth: Authenticator,
-  agentLoopContext?: AgentLoopContextType
-): Promise<McpServer> {
-  return createRunAgentServer(auth, agentLoopContext);
-}
-
-async function createRunAgentServer(
+async function createServer(
   auth: Authenticator,
   agentLoopContext?: AgentLoopContextType
 ): Promise<McpServer> {

--- a/front/lib/api/actions/servers/run_agent/index.ts
+++ b/front/lib/api/actions/servers/run_agent/index.ts
@@ -10,6 +10,7 @@ import assert from "assert";
 import _ from "lodash";
 
 import { MCPError } from "@app/lib/actions/mcp_errors";
+import { AGENT_CONFIGURATION_URI_PATTERN } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type { MCPProgressNotificationType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import { getOrCreateConversation } from "@app/lib/actions/mcp_internal_actions/servers/run_agent/conversation";
 import { isTransientStreamError } from "@app/lib/actions/mcp_internal_actions/servers/run_agent/network_errors";
@@ -32,7 +33,6 @@ import {
   isServerSideMCPServerConfiguration,
 } from "@app/lib/actions/types/guards";
 import { RUN_AGENT_ACTION_NUM_RESULTS } from "@app/lib/actions/utils";
-import { AGENT_CONFIGURATION_URI_PATTERN } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import {
   RUN_AGENT_CONFIGURABLE_PROPERTIES,
   RUN_AGENT_PLACEHOLDER_TOOL_NAME,

--- a/front/lib/api/actions/servers/run_agent/index.ts
+++ b/front/lib/api/actions/servers/run_agent/index.ts
@@ -208,7 +208,7 @@ async function createServer(
       withToolLogging(
         auth,
         {
-          toolNameForMonitoring: RUN_AGENT_TOOL_NAME,
+          toolNameForMonitoring: RUN_AGENT_PLACEHOLDER_TOOL_NAME,
           agentLoopContext,
           enableAlerting: true,
         },
@@ -239,7 +239,7 @@ async function createServer(
     withToolLogging(
       auth,
       {
-        toolNameForMonitoring: RUN_AGENT_TOOL_NAME,
+        toolNameForMonitoring: RUN_AGENT_PLACEHOLDER_TOOL_NAME,
         agentLoopContext,
         enableAlerting: true,
       },

--- a/front/lib/api/actions/servers/run_agent/index.ts
+++ b/front/lib/api/actions/servers/run_agent/index.ts
@@ -32,10 +32,10 @@ import {
   isServerSideMCPServerConfiguration,
 } from "@app/lib/actions/types/guards";
 import { RUN_AGENT_ACTION_NUM_RESULTS } from "@app/lib/actions/utils";
+import { AGENT_CONFIGURATION_URI_PATTERN } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import {
-  parseAgentConfigurationUri,
   RUN_AGENT_CONFIGURABLE_PROPERTIES,
-  RUN_AGENT_TOOL_NAME,
+  RUN_AGENT_PLACEHOLDER_TOOL_NAME,
   RUN_AGENT_TOOL_SCHEMA,
 } from "@app/lib/api/actions/servers/run_agent/metadata";
 import {
@@ -61,6 +61,14 @@ import {
 } from "@app/types";
 
 const ABORT_SIGNAL_CANCEL_REASON = "CancelledFailure: CANCELLED";
+
+function parseAgentConfigurationUri(uri: string): Result<string, Error> {
+  const match = uri.match(AGENT_CONFIGURATION_URI_PATTERN);
+  if (!match) {
+    return new Err(new Error(`Invalid URI for an agent configuration: ${uri}`));
+  }
+  return new Ok(match[2]);
+}
 
 function isRunAgentHandoffMode(
   agentLoopContext?: AgentLoopContextType

--- a/front/lib/api/actions/servers/run_agent/index.ts
+++ b/front/lib/api/actions/servers/run_agent/index.ts
@@ -282,14 +282,13 @@ async function createRunAgentServer(
           conversation: mainConversation,
         } = agentLoopContext.runContext;
 
-        const parsedChildAgentId = parseAgentConfigurationUri(uri);
-        if (!parsedChildAgentId) {
+        const parsedChildAgentIdRes = parseAgentConfigurationUri(uri);
+        if (parsedChildAgentIdRes.isErr()) {
           return finalizeAndReturn(
-            new Err(
-              new MCPError(`Invalid URI for an agent configuration: ${uri}`)
-            )
+            new Err(new MCPError(parsedChildAgentIdRes.error.message))
           );
         }
+        const parsedChildAgentId = parsedChildAgentIdRes.value;
 
         const user = auth.user();
 

--- a/front/lib/api/actions/servers/run_agent/metadata.ts
+++ b/front/lib/api/actions/servers/run_agent/metadata.ts
@@ -12,8 +12,6 @@ import { getResourcePrefix } from "@app/lib/resources/string_ids";
 // The actual tool name is dynamic: `run_<agent_name>`.
 export const RUN_AGENT_PLACEHOLDER_TOOL_NAME = "run_agent" as const;
 
-export const RUN_AGENT_DEFAULT_TOOL_STAKE = "never_ask" as const;
-
 export const RUN_AGENT_CONFIGURABLE_PROPERTIES = {
   executionMode: z
     .object({
@@ -106,8 +104,8 @@ export const RUN_AGENT_SERVER = {
     },
   ],
   // Default stake for dynamically created run_agent tools.
-  // The actual tool name is dynamic but all run_agent tools have the same stake.
+  // The actual tool name is dynamic, but all run_agent tools have the same stake.
   tools_stakes: {
-    [RUN_AGENT_PLACEHOLDER_TOOL_NAME]: RUN_AGENT_DEFAULT_TOOL_STAKE,
+    [RUN_AGENT_PLACEHOLDER_TOOL_NAME]: "never_ask",
   },
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/run_agent/metadata.ts
+++ b/front/lib/api/actions/servers/run_agent/metadata.ts
@@ -112,11 +112,3 @@ export const RUN_AGENT_SERVER = {
   tools_stakes: { [RUN_AGENT_TOOL_NAME]: RUN_AGENT_DEFAULT_TOOL_STAKE },
   timeoutMs: RUN_AGENT_CALL_TOOL_TIMEOUT_MS,
 } as const satisfies ServerMetadata & { timeoutMs: number };
-
-export function parseAgentConfigurationUri(uri: string): string | null {
-  const match = uri.match(AGENT_CONFIGURATION_URI_PATTERN);
-  if (!match) {
-    return null;
-  }
-  return match[2];
-}

--- a/front/lib/api/actions/servers/run_agent/metadata.ts
+++ b/front/lib/api/actions/servers/run_agent/metadata.ts
@@ -4,7 +4,6 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
-import { RUN_AGENT_CALL_TOOL_TIMEOUT_MS } from "@app/lib/actions/constants";
 import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { getResourcePrefix } from "@app/lib/resources/string_ids";
@@ -111,5 +110,4 @@ export const RUN_AGENT_SERVER = {
   tools_stakes: {
     [RUN_AGENT_PLACEHOLDER_TOOL_NAME]: RUN_AGENT_DEFAULT_TOOL_STAKE,
   },
-  timeoutMs: RUN_AGENT_CALL_TOOL_TIMEOUT_MS,
-} as const satisfies ServerMetadata & { timeoutMs: number };
+} as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/run_agent/metadata.ts
+++ b/front/lib/api/actions/servers/run_agent/metadata.ts
@@ -5,14 +5,13 @@ import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
 import { RUN_AGENT_CALL_TOOL_TIMEOUT_MS } from "@app/lib/actions/constants";
-import {
-  AGENT_CONFIGURATION_URI_PATTERN,
-  ConfigurableToolInputSchemas,
-} from "@app/lib/actions/mcp_internal_actions/input_schemas";
+import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { getResourcePrefix } from "@app/lib/resources/string_ids";
 
-export const RUN_AGENT_TOOL_NAME = "run_agent" as const;
+// This is a placeholder tool name used in the metadata for UI detection.
+// The actual tool name is dynamic: `run_<agent_name>`.
+export const RUN_AGENT_PLACEHOLDER_TOOL_NAME = "run_agent" as const;
 
 export const RUN_AGENT_DEFAULT_TOOL_STAKE = "never_ask" as const;
 
@@ -97,7 +96,7 @@ export const RUN_AGENT_SERVER = {
   // requires child agent configuration before being added.
   tools: [
     {
-      name: RUN_AGENT_TOOL_NAME,
+      name: RUN_AGENT_PLACEHOLDER_TOOL_NAME,
       description: "Run a child agent (agent as tool).",
       inputSchema: zodToJsonSchema(
         z.object({
@@ -109,6 +108,8 @@ export const RUN_AGENT_SERVER = {
   ],
   // Default stake for dynamically created run_agent tools.
   // The actual tool name is dynamic but all run_agent tools have the same stake.
-  tools_stakes: { [RUN_AGENT_TOOL_NAME]: RUN_AGENT_DEFAULT_TOOL_STAKE },
+  tools_stakes: {
+    [RUN_AGENT_PLACEHOLDER_TOOL_NAME]: RUN_AGENT_DEFAULT_TOOL_STAKE,
+  },
   timeoutMs: RUN_AGENT_CALL_TOOL_TIMEOUT_MS,
 } as const satisfies ServerMetadata & { timeoutMs: number };


### PR DESCRIPTION
## Description

Follow up on https://github.com/dust-tt/dust/pull/20657
This PR implements a few minor cleanup tasks on the `run_agent` MCP server:
- Rename `RUN_AGENT_TOOL_NAME` into `RUN_AGENT_PLACEHOLDER_TOOL_NAME` as this won't be the actual tool name
- Move `parseAgentConfigurationUri` outside of the metadata file
- Reintroduce a Result pattern on `parseAgentConfigurationUri`
- Remove an unused wrapper
- Move the timeout definition to the configuration instead of the metadata

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
