### PR TITLE
Fixes incorrect token usage reporting to Langfuse when using Anthropic prompt caching

### DIFF
--- a/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/anthropic_to_events.ts
@@ -325,9 +325,9 @@ function tokenUsage(
 ): TokenUsageEvent {
   const cachedTokens = usage.cache_read_input_tokens ?? 0;
   const cacheCreationTokens = usage.cache_creation_input_tokens ?? 0;
+  const uncachedInputTokens = usage.input_tokens ?? 0;
   // Include all input tokens to keep consistency with core implementation
-  const inputTokens =
-    (usage.input_tokens ?? 0) + cachedTokens + cacheCreationTokens;
+  const inputTokens = uncachedInputTokens + cachedTokens + cacheCreationTokens;
 
   return {
     type: "token_usage",
@@ -336,6 +336,7 @@ function tokenUsage(
       outputTokens: usage.output_tokens,
       cachedTokens,
       cacheCreationTokens,
+      uncachedInputTokens,
       totalTokens: inputTokens + usage.output_tokens,
     },
     metadata,

--- a/front/lib/api/llm/clients/anthropic/utils/test/fixtures/llm_events/empty_tool_call.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/test/fixtures/llm_events/empty_tool_call.ts
@@ -30,6 +30,7 @@ export const emptyToolCallLLMEvents: LLMEvent[] = [
       cachedTokens: 0,
       cacheCreationTokens: 0,
       totalTokens: 120,
+      uncachedInputTokens: 100,
     },
     metadata: {
       clientId: "anthropic" as const,

--- a/front/lib/api/llm/clients/anthropic/utils/test/fixtures/llm_events/reasoning.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/test/fixtures/llm_events/reasoning.ts
@@ -79,6 +79,7 @@ export const reasoningLLMEvents: LLMEvent[] = [
       cachedTokens: 0,
       cacheCreationTokens: 0,
       totalTokens: 2680,
+      uncachedInputTokens: 2500,
     },
     metadata: {
       clientId: "anthropic" as const,

--- a/front/lib/api/llm/clients/anthropic/utils/test/fixtures/llm_events/tool_use.ts
+++ b/front/lib/api/llm/clients/anthropic/utils/test/fixtures/llm_events/tool_use.ts
@@ -59,6 +59,7 @@ export const toolUseLLMEvents: LLMEvent[] = [
       outputTokens: 128,
       cachedTokens: 0,
       cacheCreationTokens: 0,
+      uncachedInputTokens: 1766,
       totalTokens: 1894,
     },
     metadata: {

--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -302,7 +302,8 @@ export abstract class LLM {
       if (tokenUsage) {
         generation.update({
           usageDetails: {
-            input: tokenUsage.inputTokens,
+            // Report the uncached input tokens if provider supports it.
+            input: tokenUsage.uncachedInputTokens ?? tokenUsage.inputTokens,
             output: tokenUsage.outputTokens,
             total: tokenUsage.totalTokens,
             cache_read_input_tokens: tokenUsage.cachedTokens ?? 0,

--- a/front/lib/api/llm/types/events.ts
+++ b/front/lib/api/llm/types/events.ts
@@ -68,6 +68,9 @@ export interface TokenUsage {
   outputTokens: number;
   reasoningTokens?: number;
   totalTokens: number;
+  // Raw input tokens after the last cache breakpoint (not from cache).
+  // This is the raw `input_tokens` value from providers that support caching.
+  uncachedInputTokens?: number;
 }
 
 export interface TokenUsageEvent {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
### Problem:
The `inputTokens` field in `TokenUsage` is computed as the total input tokens (raw + cached + creation), but we were sending this value to Langfuse as `input`, alongside `cache_read_input_tokens`. This caused double-counting and incorrect cost calculations.

For example, with a small user message and cached system prompt:
- inputTokens: 9844 (computed total)
- cachedTokens: 9842
- Langfuse received input: 9844 + cache_read: 9842 → misleading

Fix:
Added uncachedInputTokens field to track the raw input_tokens from Anthropic (tokens after the last cache breakpoint).
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
