### PR TITLE
[front] enh(poke): improve UI for LLM trace poke page

### DIFF
--- a/front/components/poke/llm_traces/InputTab.tsx
+++ b/front/components/poke/llm_traces/InputTab.tsx
@@ -34,7 +34,10 @@ function ContentArrayView({ content }: ContentArrayViewProps) {
             {c.text}
           </pre>
         ) : (
-          <div key={i} className="text-sm text-muted-foreground">
+          <div
+            key={i}
+            className="text-sm text-muted-foreground dark:text-muted-foreground-night"
+          >
             [Image: {c.image_url.url.slice(0, 50)}...]
           </div>
         )

--- a/front/components/poke/llm_traces/InputTab.tsx
+++ b/front/components/poke/llm_traces/InputTab.tsx
@@ -161,9 +161,12 @@ function ConversationView({ conversation }: ConversationViewProps) {
 
         return (
           <div key={index} className="rounded border p-3">
-            <div className="mb-2">
-              <Chip color={chipColor} size="xs" label={roleName} />
-            </div>
+            <Chip
+              color={chipColor}
+              size="xs"
+              label={roleName}
+              className="mb-2"
+            />
             <MessageContent message={message} />
           </div>
         );

--- a/front/components/poke/llm_traces/InputTab.tsx
+++ b/front/components/poke/llm_traces/InputTab.tsx
@@ -22,13 +22,13 @@ import {
 } from "@app/types/assistant/agent_message_content";
 
 interface ContentArrayViewProps {
-  content: Content[];
+  contents: Content[];
 }
 
-function ContentArrayView({ content }: ContentArrayViewProps) {
+function ContentArrayView({ contents }: ContentArrayViewProps) {
   return (
     <div className="space-y-1">
-      {content.map((c, i) =>
+      {contents.map((c, i) =>
         isTextContent(c) ? (
           <pre key={i} className="whitespace-pre-wrap text-sm">
             {c.text}
@@ -89,7 +89,7 @@ function MessageContent({ message }: MessageContentProps) {
 
   switch (message.role) {
     case "user":
-      return <ContentArrayView content={message.content} />;
+      return <ContentArrayView contents={message.content} />;
 
     case "assistant": {
       const textContents = message.contents.filter(isAgentTextContent);
@@ -134,7 +134,7 @@ function MessageContent({ message }: MessageContentProps) {
           <pre className="whitespace-pre-wrap text-sm">{message.content}</pre>
         );
       }
-      return <ContentArrayView content={message.content} />;
+      return <ContentArrayView contents={message.content} />;
     }
   }
 }

--- a/front/components/poke/llm_traces/InputTab.tsx
+++ b/front/components/poke/llm_traces/InputTab.tsx
@@ -74,6 +74,7 @@ function ToolCallCard({ functionCall }: FunctionCallCardProps) {
         value={parsedArgs}
         rootName={false}
         defaultInspectDepth={2}
+        className="p-2"
       />
     </div>
   );
@@ -125,6 +126,7 @@ function MessageContent({ message }: MessageContentProps) {
               value={parsed}
               rootName={false}
               defaultInspectDepth={2}
+              className="p-2"
             />
           );
         }
@@ -184,6 +186,7 @@ function SpecificationCard({ spec }: SpecificationCardProps) {
         value={spec}
         rootName={false}
         defaultInspectDepth={1}
+        className="p-2"
       />
     </div>
   );

--- a/front/components/poke/llm_traces/InputTab.tsx
+++ b/front/components/poke/llm_traces/InputTab.tsx
@@ -7,11 +7,11 @@ import {
 import { JsonViewer } from "@textea/json-viewer";
 import type { ComponentProps } from "react";
 
+import { ToolCallCard } from "@app/components/poke/llm_traces/ToolCallsView";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import type { LLMTraceInput } from "@app/lib/api/llm/traces/types";
 import type {
   Content,
-  FunctionCallType,
   ModelConversationTypeMultiActions,
   ModelMessageTypeMultiActionsWithoutContentFragment,
 } from "@app/types";
@@ -46,39 +46,6 @@ function ContentArrayView({ contents }: ContentArrayViewProps) {
   );
 }
 
-interface FunctionCallCardProps {
-  functionCall: FunctionCallType;
-}
-
-function ToolCallCard({ functionCall }: FunctionCallCardProps) {
-  const { isDark } = useTheme();
-
-  let parsedArgs: unknown;
-  try {
-    parsedArgs = JSON.parse(functionCall.arguments);
-  } catch {
-    parsedArgs = functionCall.arguments;
-  }
-
-  return (
-    <div className="rounded border p-3">
-      <Chip
-        color="green"
-        size="xs"
-        label={`tool_call: ${functionCall.name}`}
-        className="mb-2"
-      />
-      <JsonViewer
-        theme={isDark ? "dark" : "light"}
-        value={parsedArgs}
-        rootName={false}
-        defaultInspectDepth={2}
-        className="p-2"
-      />
-    </div>
-  );
-}
-
 interface MessageContentProps {
   message: ModelMessageTypeMultiActionsWithoutContentFragment;
 }
@@ -104,7 +71,7 @@ function MessageContent({ message }: MessageContentProps) {
             </pre>
           ))}
           {functionCalls.map((fc, i) => (
-            <ToolCallCard key={i} functionCall={fc} />
+            <ToolCallCard key={i} toolCall={fc} />
           ))}
         </div>
       );

--- a/front/components/poke/llm_traces/InputTab.tsx
+++ b/front/components/poke/llm_traces/InputTab.tsx
@@ -5,12 +5,13 @@ import {
   CollapsibleTrigger,
 } from "@dust-tt/sparkle";
 import { JsonViewer } from "@textea/json-viewer";
-import type {ComponentProps} from "react";
+import type { ComponentProps } from "react";
 
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import type { LLMTraceInput } from "@app/lib/api/llm/traces/types";
 import type {
-  Content, FunctionCallType,
+  Content,
+  FunctionCallType,
   ModelConversationTypeMultiActions,
   ModelMessageTypeMultiActionsWithoutContentFragment,
 } from "@app/types";
@@ -24,9 +25,7 @@ interface ContentArrayViewProps {
   content: Content[];
 }
 
-function ContentArrayView({
-                            content
-}:ContentArrayViewProps) {
+function ContentArrayView({ content }: ContentArrayViewProps) {
   return (
     <div className="space-y-1">
       {content.map((c, i) =>
@@ -48,9 +47,7 @@ interface FunctionCallCardProps {
   functionCall: FunctionCallType;
 }
 
-function ToolCallCard({
-  functionCall,
-}: FunctionCallCardProps) {
+function ToolCallCard({ functionCall }: FunctionCallCardProps) {
   const { isDark } = useTheme();
 
   let parsedArgs: unknown;
@@ -63,7 +60,11 @@ function ToolCallCard({
   return (
     <div className="rounded border p-3">
       <div className="mb-2">
-        <Chip color="green" size="xs" label={`tool_call: ${functionCall.name}`} />
+        <Chip
+          color="green"
+          size="xs"
+          label={`tool_call: ${functionCall.name}`}
+        />
       </div>
       <JsonViewer
         theme={isDark ? "dark" : "light"}
@@ -79,9 +80,7 @@ interface MessageContentProps {
   message: ModelMessageTypeMultiActionsWithoutContentFragment;
 }
 
-function MessageContent({
-  message,
-}: MessageContentProps) {
+function MessageContent({ message }: MessageContentProps) {
   const { isDark } = useTheme();
 
   switch (message.role) {
@@ -127,9 +126,7 @@ function MessageContent({
           );
         }
         return (
-          <pre className="whitespace-pre-wrap text-sm">
-            {message.content}
-          </pre>
+          <pre className="whitespace-pre-wrap text-sm">{message.content}</pre>
         );
       }
       return <ContentArrayView content={message.content} />;
@@ -142,10 +139,7 @@ interface ConversationViewProps {
 }
 
 function ConversationView({ conversation }: ConversationViewProps) {
-  const roleChipColors: Record<
-    string,
-    ComponentProps<typeof Chip>["color"]
-  > = {
+  const roleChipColors: Record<string, ComponentProps<typeof Chip>["color"]> = {
     user: "blue",
     assistant: "green",
     function: "golden",
@@ -177,9 +171,7 @@ interface SpecificationCardProps {
   spec: LLMTraceInput["specifications"][number];
 }
 
-function SpecificationCard({
-  spec,
-}: SpecificationCardProps) {
+function SpecificationCard({ spec }: SpecificationCardProps) {
   const { isDark } = useTheme();
 
   return (

--- a/front/components/poke/llm_traces/InputTab.tsx
+++ b/front/components/poke/llm_traces/InputTab.tsx
@@ -62,13 +62,12 @@ function ToolCallCard({ functionCall }: FunctionCallCardProps) {
 
   return (
     <div className="rounded border p-3">
-      <div className="mb-2">
-        <Chip
-          color="green"
-          size="xs"
-          label={`tool_call: ${functionCall.name}`}
-        />
-      </div>
+      <Chip
+        color="green"
+        size="xs"
+        label={`tool_call: ${functionCall.name}`}
+        className="mb-2"
+      />
       <JsonViewer
         theme={isDark ? "dark" : "light"}
         value={parsedArgs}

--- a/front/components/poke/llm_traces/InputTab.tsx
+++ b/front/components/poke/llm_traces/InputTab.tsx
@@ -1,0 +1,256 @@
+import {
+  Chip,
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@dust-tt/sparkle";
+import { JsonViewer } from "@textea/json-viewer";
+import type {ComponentProps} from "react";
+
+import { useTheme } from "@app/components/sparkle/ThemeContext";
+import type { LLMTraceInput } from "@app/lib/api/llm/traces/types";
+import type {
+  Content, FunctionCallType,
+  ModelConversationTypeMultiActions,
+  ModelMessageTypeMultiActionsWithoutContentFragment,
+} from "@app/types";
+import { isString, isTextContent } from "@app/types";
+import {
+  isAgentFunctionCallContent,
+  isAgentTextContent,
+} from "@app/types/assistant/agent_message_content";
+
+interface ContentArrayViewProps {
+  content: Content[];
+}
+
+function ContentArrayView({
+                            content
+}:ContentArrayViewProps) {
+  return (
+    <div className="space-y-1">
+      {content.map((c, i) =>
+        isTextContent(c) ? (
+          <pre key={i} className="whitespace-pre-wrap text-sm">
+            {c.text}
+          </pre>
+        ) : (
+          <div key={i} className="text-sm text-muted-foreground">
+            [Image: {c.image_url.url.slice(0, 50)}...]
+          </div>
+        )
+      )}
+    </div>
+  );
+}
+
+interface FunctionCallCardProps {
+  functionCall: FunctionCallType;
+}
+
+function ToolCallCard({
+  functionCall,
+}: FunctionCallCardProps) {
+  const { isDark } = useTheme();
+
+  let parsedArgs: unknown;
+  try {
+    parsedArgs = JSON.parse(functionCall.arguments);
+  } catch {
+    parsedArgs = functionCall.arguments;
+  }
+
+  return (
+    <div className="rounded border p-3">
+      <div className="mb-2">
+        <Chip color="green" size="xs" label={`tool_call: ${functionCall.name}`} />
+      </div>
+      <JsonViewer
+        theme={isDark ? "dark" : "light"}
+        value={parsedArgs}
+        rootName={false}
+        defaultInspectDepth={2}
+      />
+    </div>
+  );
+}
+
+interface MessageContentProps {
+  message: ModelMessageTypeMultiActionsWithoutContentFragment;
+}
+
+function MessageContent({
+  message,
+}: MessageContentProps) {
+  const { isDark } = useTheme();
+
+  switch (message.role) {
+    case "user":
+      return <ContentArrayView content={message.content} />;
+
+    case "assistant": {
+      const textContents = message.contents.filter(isAgentTextContent);
+      const functionCalls = message.contents
+        .filter(isAgentFunctionCallContent)
+        .map((c) => c.value);
+
+      return (
+        <div className="space-y-2">
+          {textContents.map((c, i) => (
+            <pre key={i} className="whitespace-pre-wrap text-sm">
+              {c.value}
+            </pre>
+          ))}
+          {functionCalls.map((fc, i) => (
+            <ToolCallCard key={i} functionCall={fc} />
+          ))}
+        </div>
+      );
+    }
+
+    case "function": {
+      if (isString(message.content)) {
+        let parsed;
+        try {
+          parsed = JSON.parse(message.content);
+        } catch {
+          parsed = null;
+        }
+        if (parsed) {
+          return (
+            <JsonViewer
+              theme={isDark ? "dark" : "light"}
+              value={parsed}
+              rootName={false}
+              defaultInspectDepth={2}
+            />
+          );
+        }
+        return (
+          <pre className="whitespace-pre-wrap text-sm">
+            {message.content}
+          </pre>
+        );
+      }
+      return <ContentArrayView content={message.content} />;
+    }
+  }
+}
+
+interface ConversationViewProps {
+  conversation: ModelConversationTypeMultiActions;
+}
+
+function ConversationView({ conversation }: ConversationViewProps) {
+  const roleChipColors: Record<
+    string,
+    ComponentProps<typeof Chip>["color"]
+  > = {
+    user: "blue",
+    assistant: "green",
+    function: "golden",
+  };
+
+  return (
+    <div className="space-y-2">
+      {conversation.messages.map((message, index) => {
+        const chipColor = roleChipColors[message.role] ?? "primary";
+        const roleName =
+          message.role === "function"
+            ? `tool_result: ${message.name}`
+            : message.role;
+
+        return (
+          <div key={index} className="rounded border p-3">
+            <div className="mb-2">
+              <Chip color={chipColor} size="xs" label={roleName} />
+            </div>
+            <MessageContent message={message} />
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+interface SpecificationCardProps {
+  spec: LLMTraceInput["specifications"][number];
+}
+
+function SpecificationCard({
+  spec,
+}: SpecificationCardProps) {
+  const { isDark } = useTheme();
+
+  return (
+    <div className="rounded-lg border p-3">
+      <JsonViewer
+        theme={isDark ? "dark" : "light"}
+        value={spec}
+        rootName={false}
+        defaultInspectDepth={1}
+      />
+    </div>
+  );
+}
+
+interface InputTabProps {
+  input: LLMTraceInput;
+}
+
+export function InputTab({ input }: InputTabProps) {
+  return (
+    <div className="space-y-4 pt-4">
+      {input.prompt && (
+        <div className="rounded-lg border p-4">
+          <Collapsible defaultOpen={false}>
+            <CollapsibleTrigger>
+              <h3 className="text-lg font-medium">
+                System Prompt ({input.prompt.length.toLocaleString()} chars)
+              </h3>
+            </CollapsibleTrigger>
+            <CollapsibleContent>
+              <div className="mt-4 max-h-125 overflow-auto">
+                <pre className="whitespace-pre-wrap text-sm">
+                  {input.prompt}
+                </pre>
+              </div>
+            </CollapsibleContent>
+          </Collapsible>
+        </div>
+      )}
+      {input.specifications.length > 0 && (
+        <div className="rounded-lg border p-4">
+          <Collapsible defaultOpen={false}>
+            <CollapsibleTrigger>
+              <h3 className="text-lg font-medium">
+                Specifications ({input.specifications.length})
+              </h3>
+            </CollapsibleTrigger>
+            <CollapsibleContent>
+              <div className="mt-4 space-y-3">
+                {input.specifications.map((spec, index) => (
+                  <SpecificationCard key={index} spec={spec} />
+                ))}
+              </div>
+            </CollapsibleContent>
+          </Collapsible>
+        </div>
+      )}
+      <div className="rounded-lg border p-4">
+        <Collapsible defaultOpen={true}>
+          <CollapsibleTrigger>
+            <h3 className="text-lg font-medium">
+              Conversation ({input.conversation.messages.length} messages)
+            </h3>
+          </CollapsibleTrigger>
+          <CollapsibleContent>
+            <div className="mt-4">
+              <ConversationView conversation={input.conversation} />
+            </div>
+          </CollapsibleContent>
+        </Collapsible>
+      </div>
+    </div>
+  );
+}

--- a/front/components/poke/llm_traces/InputTab.tsx
+++ b/front/components/poke/llm_traces/InputTab.tsx
@@ -111,29 +111,30 @@ function MessageContent({ message }: MessageContentProps) {
     }
 
     case "function": {
-      if (isString(message.content)) {
-        let parsed;
-        try {
-          parsed = JSON.parse(message.content);
-        } catch {
-          parsed = null;
-        }
-        if (parsed) {
-          return (
-            <JsonViewer
-              theme={isDark ? "dark" : "light"}
-              value={parsed}
-              rootName={false}
-              defaultInspectDepth={2}
-              className="p-2"
-            />
-          );
-        }
+      if (!isString(message.content)) {
+        return <ContentArrayView contents={message.content} />;
+      }
+
+      let parsed;
+      try {
+        parsed = JSON.parse(message.content);
+      } catch {
+        parsed = null;
+      }
+      if (parsed) {
         return (
-          <pre className="whitespace-pre-wrap text-sm">{message.content}</pre>
+          <JsonViewer
+            theme={isDark ? "dark" : "light"}
+            value={parsed}
+            rootName={false}
+            defaultInspectDepth={2}
+            className="p-2"
+          />
         );
       }
-      return <ContentArrayView contents={message.content} />;
+      return (
+        <pre className="whitespace-pre-wrap text-sm">{message.content}</pre>
+      );
     }
   }
 }

--- a/front/components/poke/llm_traces/OutputTab.tsx
+++ b/front/components/poke/llm_traces/OutputTab.tsx
@@ -1,7 +1,14 @@
+import {
+  Chip,
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@dust-tt/sparkle";
 import { JsonViewer } from "@textea/json-viewer";
 
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import type { LLMTraceOutput } from "@app/lib/api/llm/traces/types";
+import { isString } from "@app/types";
 
 interface ToolCallsViewProps {
   toolCalls: NonNullable<LLMTraceOutput["toolCalls"]>;
@@ -13,14 +20,9 @@ function ToolCallsView({ toolCalls }: ToolCallsViewProps) {
   return (
     <div className="space-y-3">
       {toolCalls.map((toolCall, index) => (
-        <div key={index} className="rounded-lg border p-4">
-          <div className="mb-2 flex items-center gap-2">
-            <code className="rounded bg-purple-100 px-2 py-0.5 text-sm font-semibold dark:bg-purple-900">
-              {toolCall.name}
-            </code>
-            <span className="text-xs text-muted-foreground dark:text-muted-foreground-night">
-              ID: {toolCall.id}
-            </span>
+        <div key={index} className="rounded border p-3">
+          <div className="mb-2">
+            <Chip color="green" size="xs" label={`tool_call: ${toolCall.name}`} />
           </div>
           <JsonViewer
             theme={isDark ? "dark" : "light"}
@@ -48,8 +50,8 @@ export function OutputTab({ output }: OutputTabProps) {
   }
 
   const hasContent =
-    output.content !== undefined ||
-    output.reasoning !== undefined ||
+    isString(output.content)  ||
+    isString(output.reasoning) ||
     (output.toolCalls && output.toolCalls.length > 0);
 
   if (!hasContent) {
@@ -61,29 +63,57 @@ export function OutputTab({ output }: OutputTabProps) {
   }
 
   return (
-    <div className="space-y-6 pt-4">
-      {output.content && (
-        <div>
-          <h3 className="mb-2 text-lg font-medium">Content</h3>
-          <pre className="whitespace-pre-wrap text-sm">
-            {output.content}
-          </pre>
+    <div className="space-y-4 pt-4">
+      {isString(output.content) && (
+        <div className="rounded-lg border p-4">
+          <Collapsible defaultOpen={true}>
+            <CollapsibleTrigger>
+              <h3 className="text-lg font-medium">
+                Content ({output.content.length.toLocaleString()} chars)
+              </h3>
+            </CollapsibleTrigger>
+            <CollapsibleContent>
+              <div className="mt-4 max-h-125 overflow-auto">
+                <pre className="whitespace-pre-wrap text-sm">
+                  {output.content}
+                </pre>
+              </div>
+            </CollapsibleContent>
+          </Collapsible>
         </div>
       )}
-      {output.reasoning && (
-        <div>
-          <h3 className="mb-2 text-lg font-medium">Reasoning</h3>
-          <pre className="whitespace-pre-wrap text-sm">
-            {output.reasoning}
-          </pre>
+      {isString(output.reasoning) && (
+        <div className="rounded-lg border p-4">
+          <Collapsible defaultOpen={false}>
+            <CollapsibleTrigger>
+              <h3 className="text-lg font-medium">
+                Reasoning ({output.reasoning.length.toLocaleString()} chars)
+              </h3>
+            </CollapsibleTrigger>
+            <CollapsibleContent>
+              <div className="mt-4 max-h-125 overflow-auto">
+                <pre className="whitespace-pre-wrap text-sm">
+                  {output.reasoning}
+                </pre>
+              </div>
+            </CollapsibleContent>
+          </Collapsible>
         </div>
       )}
       {output.toolCalls && output.toolCalls.length > 0 && (
-        <div>
-          <h3 className="mb-2 text-lg font-medium">
-            Tool Calls ({output.toolCalls.length})
-          </h3>
-          <ToolCallsView toolCalls={output.toolCalls} />
+        <div className="rounded-lg border p-4">
+          <Collapsible defaultOpen={true}>
+            <CollapsibleTrigger>
+              <h3 className="text-lg font-medium">
+                Tool Calls ({output.toolCalls.length})
+              </h3>
+            </CollapsibleTrigger>
+            <CollapsibleContent>
+              <div className="mt-4">
+                <ToolCallsView toolCalls={output.toolCalls} />
+              </div>
+            </CollapsibleContent>
+          </Collapsible>
         </div>
       )}
     </div>

--- a/front/components/poke/llm_traces/OutputTab.tsx
+++ b/front/components/poke/llm_traces/OutputTab.tsx
@@ -1,44 +1,12 @@
 import {
-  Chip,
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@dust-tt/sparkle";
-import { JsonViewer } from "@textea/json-viewer";
 
-import { useTheme } from "@app/components/sparkle/ThemeContext";
+import { ToolCallsView } from "@app/components/poke/llm_traces/ToolCallsView";
 import type { LLMTraceOutput } from "@app/lib/api/llm/traces/types";
 import { isString } from "@app/types";
-
-interface ToolCallsViewProps {
-  toolCalls: NonNullable<LLMTraceOutput["toolCalls"]>;
-}
-
-function ToolCallsView({ toolCalls }: ToolCallsViewProps) {
-  const { isDark } = useTheme();
-
-  return (
-    <div className="space-y-3">
-      {toolCalls.map((toolCall, index) => (
-        <div key={index} className="rounded border p-3">
-          <div className="mb-2">
-            <Chip
-              color="green"
-              size="xs"
-              label={`tool_call: ${toolCall.name}`}
-            />
-          </div>
-          <JsonViewer
-            theme={isDark ? "dark" : "light"}
-            value={toolCall.arguments}
-            rootName={false}
-            defaultInspectDepth={2}
-          />
-        </div>
-      ))}
-    </div>
-  );
-}
 
 interface OutputTabProps {
   output: LLMTraceOutput | undefined;

--- a/front/components/poke/llm_traces/OutputTab.tsx
+++ b/front/components/poke/llm_traces/OutputTab.tsx
@@ -1,0 +1,91 @@
+import { JsonViewer } from "@textea/json-viewer";
+
+import { useTheme } from "@app/components/sparkle/ThemeContext";
+import type { LLMTraceOutput } from "@app/lib/api/llm/traces/types";
+
+interface ToolCallsViewProps {
+  toolCalls: NonNullable<LLMTraceOutput["toolCalls"]>;
+}
+
+function ToolCallsView({ toolCalls }: ToolCallsViewProps) {
+  const { isDark } = useTheme();
+
+  return (
+    <div className="space-y-3">
+      {toolCalls.map((toolCall, index) => (
+        <div key={index} className="rounded-lg border p-4">
+          <div className="mb-2 flex items-center gap-2">
+            <code className="rounded bg-purple-100 px-2 py-0.5 text-sm font-semibold dark:bg-purple-900">
+              {toolCall.name}
+            </code>
+            <span className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+              ID: {toolCall.id}
+            </span>
+          </div>
+          <JsonViewer
+            theme={isDark ? "dark" : "light"}
+            value={toolCall.arguments}
+            rootName={false}
+            defaultInspectDepth={2}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+interface OutputTabProps {
+  output: LLMTraceOutput | undefined;
+}
+
+export function OutputTab({ output }: OutputTabProps) {
+  if (!output) {
+    return (
+      <p className="pt-4 text-sm italic text-muted-foreground dark:text-muted-foreground-night">
+        No output available
+      </p>
+    );
+  }
+
+  const hasContent =
+    output.content !== undefined ||
+    output.reasoning !== undefined ||
+    (output.toolCalls && output.toolCalls.length > 0);
+
+  if (!hasContent) {
+    return (
+      <p className="pt-4 text-sm italic text-muted-foreground dark:text-muted-foreground-night">
+        No output content
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-6 pt-4">
+      {output.content && (
+        <div>
+          <h3 className="mb-2 text-lg font-medium">Content</h3>
+          <pre className="whitespace-pre-wrap text-sm">
+            {output.content}
+          </pre>
+        </div>
+      )}
+      {output.reasoning && (
+        <div>
+          <h3 className="mb-2 text-lg font-medium">Reasoning</h3>
+          <pre className="whitespace-pre-wrap text-sm">
+            {output.reasoning}
+          </pre>
+        </div>
+      )}
+      {output.toolCalls && output.toolCalls.length > 0 && (
+        <div>
+          <h3 className="mb-2 text-lg font-medium">
+            Tool Calls ({output.toolCalls.length})
+          </h3>
+          <ToolCallsView toolCalls={output.toolCalls} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/front/components/poke/llm_traces/OutputTab.tsx
+++ b/front/components/poke/llm_traces/OutputTab.tsx
@@ -22,7 +22,11 @@ function ToolCallsView({ toolCalls }: ToolCallsViewProps) {
       {toolCalls.map((toolCall, index) => (
         <div key={index} className="rounded border p-3">
           <div className="mb-2">
-            <Chip color="green" size="xs" label={`tool_call: ${toolCall.name}`} />
+            <Chip
+              color="green"
+              size="xs"
+              label={`tool_call: ${toolCall.name}`}
+            />
           </div>
           <JsonViewer
             theme={isDark ? "dark" : "light"}
@@ -50,7 +54,7 @@ export function OutputTab({ output }: OutputTabProps) {
   }
 
   const hasContent =
-    isString(output.content)  ||
+    isString(output.content) ||
     isString(output.reasoning) ||
     (output.toolCalls && output.toolCalls.length > 0);
 

--- a/front/components/poke/llm_traces/RawJsonTab.tsx
+++ b/front/components/poke/llm_traces/RawJsonTab.tsx
@@ -19,7 +19,7 @@ export function RawJsonTab({ trace }: RawJsonTabProps) {
 
   return (
     <div>
-      <div className="mb-4 flex justify-end">
+      <div className="mb-4 pt-4 flex justify-end">
         <Button
           label={isCopied ? "Copied!" : "Copy JSON"}
           variant="outline"
@@ -33,6 +33,7 @@ export function RawJsonTab({ trace }: RawJsonTabProps) {
         value={trace}
         rootName="trace"
         defaultInspectDepth={3}
+        className="p-4"
       />
     </div>
   );

--- a/front/components/poke/llm_traces/RawJsonTab.tsx
+++ b/front/components/poke/llm_traces/RawJsonTab.tsx
@@ -1,0 +1,39 @@
+import {
+  Button,
+  ClipboardCheckIcon,
+  ClipboardIcon,
+  useCopyToClipboard,
+} from "@dust-tt/sparkle";
+import { JsonViewer } from "@textea/json-viewer";
+
+import { useTheme } from "@app/components/sparkle/ThemeContext";
+import type { LLMTrace } from "@app/lib/api/llm/traces/types";
+
+interface RawJsonTabProps {
+  trace: LLMTrace;
+}
+
+export function RawJsonTab({ trace }: RawJsonTabProps) {
+  const { isDark } = useTheme();
+  const [isCopied, copy] = useCopyToClipboard();
+
+  return (
+    <div>
+      <div className="mb-4 pt-4 flex justify-end">
+        <Button
+          label={isCopied ? "Copied!" : "Copy JSON"}
+          variant="outline"
+          size="sm"
+          icon={isCopied ? ClipboardCheckIcon : ClipboardIcon}
+          onClick={() => copy(JSON.stringify(trace, null, 2))}
+        />
+      </div>
+      <JsonViewer
+        theme={isDark ? "dark" : "light"}
+        value={trace}
+        rootName="trace"
+        defaultInspectDepth={3}
+      />
+    </div>
+  );
+}

--- a/front/components/poke/llm_traces/RawJsonTab.tsx
+++ b/front/components/poke/llm_traces/RawJsonTab.tsx
@@ -19,7 +19,7 @@ export function RawJsonTab({ trace }: RawJsonTabProps) {
 
   return (
     <div>
-      <div className="mb-4 pt-4 flex justify-end">
+      <div className="mb-4 flex justify-end">
         <Button
           label={isCopied ? "Copied!" : "Copy JSON"}
           variant="outline"

--- a/front/components/poke/llm_traces/ToolCallsView.tsx
+++ b/front/components/poke/llm_traces/ToolCallsView.tsx
@@ -1,0 +1,62 @@
+import { Chip } from "@dust-tt/sparkle";
+import { JsonViewer } from "@textea/json-viewer";
+
+import { useTheme } from "@app/components/sparkle/ThemeContext";
+import { isString } from "@app/types";
+
+interface ToolCallData {
+  id: string;
+  name: string;
+  arguments: string | Record<string, unknown>;
+}
+
+interface ToolCallCardProps {
+  toolCall: ToolCallData;
+}
+
+export function ToolCallCard({ toolCall }: ToolCallCardProps) {
+  const { isDark } = useTheme();
+
+  let parsedArgs: unknown;
+  if (isString(toolCall.arguments)) {
+    try {
+      parsedArgs = JSON.parse(toolCall.arguments);
+    } catch {
+      parsedArgs = toolCall.arguments;
+    }
+  } else {
+    parsedArgs = toolCall.arguments;
+  }
+
+  return (
+    <div className="rounded border p-3">
+      <Chip
+        color="green"
+        size="xs"
+        label={`tool_call: ${toolCall.name}`}
+        className="mb-2"
+      />
+      <JsonViewer
+        theme={isDark ? "dark" : "light"}
+        value={parsedArgs}
+        rootName={false}
+        defaultInspectDepth={2}
+        className="p-2"
+      />
+    </div>
+  );
+}
+
+interface ToolCallsViewProps {
+  toolCalls: ToolCallData[];
+}
+
+export function ToolCallsView({ toolCalls }: ToolCallsViewProps) {
+  return (
+    <div className="space-y-3">
+      {toolCalls.map((toolCall, index) => (
+        <ToolCallCard key={index} toolCall={toolCall} />
+      ))}
+    </div>
+  );
+}

--- a/front/components/poke/pages/LLMTracePage.tsx
+++ b/front/components/poke/pages/LLMTracePage.tsx
@@ -88,8 +88,16 @@ export function LLMTracePage() {
               color="rose"
               label={`Agent: ${trace.context.agentConfigurationId}`}
               size="sm"
-              // The link below may not exist, it's a best effort proposal.
               href={`/poke/${owner.sId}/assistants/${trace.context.agentConfigurationId}`}
+              icon={ExternalLinkIcon}
+            />
+          )}
+          {trace.context.conversationId && (
+            <Chip
+              color="golden"
+              label={`Conversation`}
+              size="sm"
+              href={`/poke/${owner.sId}/conversation/${trace.context.conversationId}`}
               icon={ExternalLinkIcon}
             />
           )}

--- a/front/components/poke/pages/LLMTracePage.tsx
+++ b/front/components/poke/pages/LLMTracePage.tsx
@@ -18,6 +18,25 @@ import { useRequiredPathParam } from "@app/lib/platform";
 import { usePokeLLMTrace } from "@app/poke/swr";
 import { pluralize } from "@app/types";
 
+function formatDuration(durationMs: number) {
+  return durationMs >= 1000
+    ? `${(durationMs / 1000).toFixed(1)}s`
+    : `${durationMs}ms`;
+}
+
+function formatTokens(input?: number, output?: number) {
+  if (input === undefined && output === undefined) {
+    return "N/A";
+  }
+  const inputStr = input !== undefined ? input.toLocaleString() : "?";
+  const outputStr = output !== undefined ? output.toLocaleString() : "?";
+  return `${inputStr} → ${outputStr}`;
+}
+
+function formatTimestamp(timestamp: string): string {
+  return new Date(timestamp).toLocaleString();
+}
+
 export function LLMTracePage() {
   const owner = useWorkspace();
   useSetPokePageTitle(`${owner.name} - LLM Trace`);
@@ -50,25 +69,6 @@ export function LLMTracePage() {
   }
 
   const toolCallCount = trace?.output?.toolCalls?.length;
-
-  const formatDuration = (durationMs: number) => {
-    return durationMs >= 1000
-      ? `${(durationMs / 1000).toFixed(1)}s`
-      : `${durationMs}ms`;
-  };
-
-  const formatTokens = (input?: number, output?: number) => {
-    if (input === undefined && output === undefined) {
-      return "N/A";
-    }
-    const inputStr = input !== undefined ? input.toLocaleString() : "?";
-    const outputStr = output !== undefined ? output.toLocaleString() : "?";
-    return `${inputStr} → ${outputStr}`;
-  };
-
-  function formatTimestamp(timestamp: string): string {
-    return new Date(timestamp).toLocaleString();
-  }
 
   return (
     <div className="max-w-6xl">

--- a/front/components/poke/pages/LLMTracePage.tsx
+++ b/front/components/poke/pages/LLMTracePage.tsx
@@ -58,10 +58,10 @@ export function LLMTracePage() {
   if (isLLMTraceError || !trace) {
     return (
       <div className="flex h-64 flex-col items-center justify-center">
-        <div className="text-lg font-medium text-red-600">
+        <div className="text-lg font-medium text-warning dark:text-warning-night">
           Failed to load LLM trace
         </div>
-        <div className="mt-2 text-sm text-muted-foreground">
+        <div className="mt-2 text-sm text-muted-foreground dark:text-muted-foreground-night">
           The trace may not exist or there was an error fetching it from GCS.
         </div>
       </div>
@@ -76,7 +76,7 @@ export function LLMTracePage() {
         <div className="flex items-center justify-between">
           <div>
             <h1 className="text-2xl font-bold">LLM Trace</h1>
-            <div className="text-sm text-muted-foreground">
+            <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
               Run ID: <code className="text-xs">{runId}</code>
             </div>
           </div>
@@ -158,7 +158,7 @@ export function LLMTracePage() {
                 <Chip color="warning" label="Partial completion" size="xs" />
               )}
             </div>
-            <p className="text-smin text-red-700 dark:text-red-300">
+            <p className="text-sm text-warning dark:text-warning-night">
               {trace.error.message}
             </p>
             <p className="mt-1 text-xs text-red-600 dark:text-red-400">

--- a/front/components/poke/pages/LLMTracePage.tsx
+++ b/front/components/poke/pages/LLMTracePage.tsx
@@ -16,6 +16,7 @@ import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { useRequiredPathParam } from "@app/lib/platform";
 import { usePokeLLMTrace } from "@app/poke/swr";
+import { pluralize } from "@app/types";
 
 export function LLMTracePage() {
   const owner = useWorkspace();
@@ -47,6 +48,8 @@ export function LLMTracePage() {
       </div>
     );
   }
+
+  const toolCallCount = trace?.output?.toolCalls?.length;
 
   const formatDuration = (durationMs: number) => {
     return durationMs >= 1000
@@ -161,8 +164,11 @@ export function LLMTracePage() {
               value="input"
               label={`Input (${trace.input.conversation.messages.length} messages)`}
             />
-            <TabsTrigger value="output" label="Output"  />
-            <TabsTrigger value="raw" label="Raw JSON"  />
+            <TabsTrigger
+              value="output"
+              label={`Output (${toolCallCount ? `${toolCallCount} tool call${pluralize(toolCallCount)}` : "Generation"})`}
+            />
+            <TabsTrigger value="raw" label="Raw JSON" />
           </TabsList>
 
           <TabsContent value="input">

--- a/front/components/poke/pages/LLMTracePage.tsx
+++ b/front/components/poke/pages/LLMTracePage.tsx
@@ -16,7 +16,7 @@ import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { useRequiredPathParam } from "@app/lib/platform";
 import { usePokeLLMTrace } from "@app/poke/swr";
-import { pluralize } from "@app/types";
+import { isString, pluralize } from "@app/types";
 
 function formatDuration(durationMs: number) {
   return durationMs >= 1000
@@ -82,8 +82,8 @@ export function LLMTracePage() {
           </div>
         </div>
 
-        {(trace.context.agentConfigurationId ||
-          trace.context.conversationId) && (
+        {(isString(trace.context.agentConfigurationId) ||
+          isString(trace.context.conversationId)) && (
           <div className="flex flex-wrap gap-2">
             {trace.context.agentConfigurationId && (
               <Chip

--- a/front/components/poke/pages/LLMTracePage.tsx
+++ b/front/components/poke/pages/LLMTracePage.tsx
@@ -82,25 +82,31 @@ export function LLMTracePage() {
           </div>
         </div>
 
+        {(trace.context.agentConfigurationId ||
+          trace.context.conversationId) && (
+          <div className="flex flex-wrap gap-2">
+            {trace.context.agentConfigurationId && (
+              <Chip
+                color="rose"
+                label={`Agent: ${trace.context.agentConfigurationId}`}
+                size="sm"
+                href={`/poke/${owner.sId}/assistants/${trace.context.agentConfigurationId}`}
+                icon={ExternalLinkIcon}
+              />
+            )}
+            {trace.context.conversationId && (
+              <Chip
+                color="golden"
+                label={`Conversation`}
+                size="sm"
+                href={`/poke/${owner.sId}/conversation/${trace.context.conversationId}`}
+                icon={ExternalLinkIcon}
+              />
+            )}
+          </div>
+        )}
+
         <div className="flex flex-wrap gap-2">
-          {trace.context.agentConfigurationId && (
-            <Chip
-              color="rose"
-              label={`Agent: ${trace.context.agentConfigurationId}`}
-              size="sm"
-              href={`/poke/${owner.sId}/assistants/${trace.context.agentConfigurationId}`}
-              icon={ExternalLinkIcon}
-            />
-          )}
-          {trace.context.conversationId && (
-            <Chip
-              color="golden"
-              label={`Conversation`}
-              size="sm"
-              href={`/poke/${owner.sId}/conversation/${trace.context.conversationId}`}
-              icon={ExternalLinkIcon}
-            />
-          )}
           <Chip
             color="blue"
             label={`Model: ${trace.input.modelId}`}
@@ -132,7 +138,7 @@ export function LLMTracePage() {
           )}
           {trace.context.operationType && (
             <Chip
-              color="primary"
+              color="highlight"
               label={`Type: ${trace.context.operationType}`}
               size="sm"
             />

--- a/front/components/poke/pages/LLMTracePage.tsx
+++ b/front/components/poke/pages/LLMTracePage.tsx
@@ -25,8 +25,16 @@ function formatDuration(durationMs: number) {
     : `${durationMs}ms`;
 }
 
-function formatTokenUsage({inputTokens, uncachedInputTokens, outputTokens }: TokenUsage) {
-  const inputStr = inputTokens.toLocaleString() + (uncachedInputTokens ? ` (uncached: ${uncachedInputTokens.toLocaleString()})` : "");
+function formatTokenUsage({
+  inputTokens,
+  uncachedInputTokens,
+  outputTokens,
+}: TokenUsage) {
+  const inputStr =
+    inputTokens.toLocaleString() +
+    (uncachedInputTokens
+      ? ` (uncached: ${uncachedInputTokens.toLocaleString()})`
+      : "");
   const outputStr = outputTokens.toLocaleString();
   return `${inputStr} → ${outputStr}`;
 }
@@ -118,9 +126,7 @@ export function LLMTracePage() {
           {trace.output?.tokenUsage && (
             <Chip
               color="highlight"
-              label={`Tokens: ${formatTokenUsage(
-                trace.output.tokenUsage
-              )}`}
+              label={`Tokens: ${formatTokenUsage(trace.output.tokenUsage)}`}
               size="sm"
             />
           )}

--- a/front/components/poke/pages/LLMTracePage.tsx
+++ b/front/components/poke/pages/LLMTracePage.tsx
@@ -132,7 +132,7 @@ export function LLMTracePage() {
               color={
                 trace.output.finishReason === "error" ? "warning" : "green"
               }
-              label={`Status: ${trace.output.finishReason}`}
+              label={`Finish reason: ${trace.output.finishReason}`}
               size="sm"
             />
           )}

--- a/front/components/poke/pages/LLMTracePage.tsx
+++ b/front/components/poke/pages/LLMTracePage.tsx
@@ -13,6 +13,7 @@ import { InputTab } from "@app/components/poke/llm_traces/InputTab";
 import { OutputTab } from "@app/components/poke/llm_traces/OutputTab";
 import { RawJsonTab } from "@app/components/poke/llm_traces/RawJsonTab";
 import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
+import type { TokenUsage } from "@app/lib/api/llm/types/events";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { useRequiredPathParam } from "@app/lib/platform";
 import { usePokeLLMTrace } from "@app/poke/swr";
@@ -24,12 +25,9 @@ function formatDuration(durationMs: number) {
     : `${durationMs}ms`;
 }
 
-function formatTokens(input?: number, output?: number) {
-  if (input === undefined && output === undefined) {
-    return "N/A";
-  }
-  const inputStr = input !== undefined ? input.toLocaleString() : "?";
-  const outputStr = output !== undefined ? output.toLocaleString() : "?";
+function formatTokenUsage({inputTokens, uncachedInputTokens, outputTokens }: TokenUsage) {
+  const inputStr = inputTokens.toLocaleString() + (uncachedInputTokens ? ` (uncached: ${uncachedInputTokens.toLocaleString()})` : "");
+  const outputStr =outputTokens.toLocaleString();
   return `${inputStr} → ${outputStr}`;
 }
 
@@ -120,9 +118,8 @@ export function LLMTracePage() {
           {trace.output?.tokenUsage && (
             <Chip
               color="highlight"
-              label={`Tokens: ${formatTokens(
-                trace.output.tokenUsage.cacheCreationTokens,
-                trace.output.tokenUsage.outputTokens
+              label={`Tokens: ${formatTokenUsage(
+                trace.output.tokenUsage
               )}`}
               size="sm"
             />

--- a/front/components/poke/pages/LLMTracePage.tsx
+++ b/front/components/poke/pages/LLMTracePage.tsx
@@ -121,7 +121,7 @@ export function LLMTracePage() {
             <Chip
               color="highlight"
               label={`Tokens: ${formatTokens(
-                trace.output.tokenUsage.inputTokens,
+                trace.output.tokenUsage.cacheCreationTokens,
                 trace.output.tokenUsage.outputTokens
               )}`}
               size="sm"

--- a/front/components/poke/pages/LLMTracePage.tsx
+++ b/front/components/poke/pages/LLMTracePage.tsx
@@ -27,7 +27,7 @@ function formatDuration(durationMs: number) {
 
 function formatTokenUsage({inputTokens, uncachedInputTokens, outputTokens }: TokenUsage) {
   const inputStr = inputTokens.toLocaleString() + (uncachedInputTokens ? ` (uncached: ${uncachedInputTokens.toLocaleString()})` : "");
-  const outputStr =outputTokens.toLocaleString();
+  const outputStr = outputTokens.toLocaleString();
   return `${inputStr} → ${outputStr}`;
 }
 


### PR DESCRIPTION
## Description

- This PR improves the display of the Poke page for an LLM trace.
- It splits the layout in 3 tabs: Input with the system prompt, specifications and conversation, Output with the output and Raw json (same as what we have currently).
- Also added a few clickable chips.

<img width="1197" height="729" alt="Screenshot 2026-02-02 at 5 49 09 PM" src="https://github.com/user-attachments/assets/985df865-16a3-48db-9266-da70d217d50e" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
