### PR TITLE
Launch oauth within conversation for google write errors

### DIFF
--- a/front/lib/api/actions/servers/google_drive/metadata.ts
+++ b/front/lib/api/actions/servers/google_drive/metadata.ts
@@ -183,6 +183,9 @@ export const GOOGLE_DRIVE_SERVER = {
   serverInfo: {
     name: "google_drive",
     version: "1.0.0",
+    // TODO(google_drive_write): Update description to mention write capabilities
+    // when google_drive_write_enabled feature flag is removed and write is GA:
+    // "Search, read, and create files in Google Drive (Docs, Sheets, Presentations)."
     description: "Search and read files (Docs, Sheets, Presentations).",
     authorization: {
       provider: "google_drive",

--- a/front/lib/api/actions/servers/google_drive/tools/index.ts
+++ b/front/lib/api/actions/servers/google_drive/tools/index.ts
@@ -5,7 +5,10 @@ import type {
   ToolHandlers,
 } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import { makeFileAuthorizationError } from "@app/lib/actions/mcp_internal_actions/utils";
+import {
+  makeFileAuthorizationError,
+  makePersonalAuthenticationError,
+} from "@app/lib/actions/mcp_internal_actions/utils";
 import {
   getDocsClient,
   getDriveClient,
@@ -35,8 +38,9 @@ function is404Error(err: unknown): boolean {
 }
 
 /**
- * Handles file access errors by triggering the authorization flow for 404s.
- * Returns file auth error for 404s, generic MCPError otherwise.
+ * Handles file access errors by triggering the appropriate authorization flow.
+ * - 404 errors: File-level authorization (Google Picker flow)
+ * - 403 errors: OAuth scope re-authentication
  */
 function handleFileAccessError(
   err: unknown,
@@ -44,6 +48,7 @@ function handleFileAccessError(
   extra: ToolHandlerExtra,
   fileMeta?: { name?: string; mimeType?: string }
 ): ToolHandlerResult {
+  // 404: File not accessible with drive.file scope -> use file picker
   if (is404Error(err)) {
     const connectionId =
       extra.agentLoopContext?.runContext?.toolConfiguration.toolServerId ??
@@ -59,6 +64,22 @@ function handleFileAccessError(
     );
   }
 
+  // 403: OAuth scope issue -> prompt re-authentication
+  const error = normalizeError(err);
+  if (
+    error.message?.includes("403") ||
+    error.message?.toLowerCase().includes("permission")
+  ) {
+    // For read tools, only request readonly scope
+    return new Ok(
+      makePersonalAuthenticationError(
+        "google_drive",
+        "https://www.googleapis.com/auth/drive.readonly"
+      ).content
+    );
+  }
+
+  // Other errors
   return new Err(
     new MCPError(normalizeError(err).message || "Failed to access file")
   );
@@ -66,20 +87,27 @@ function handleFileAccessError(
 
 /**
  * Handles permission errors from Google Drive API calls for write operations.
- * Returns an MCPError with appropriate messaging for 403/permission errors.
+ * Returns OAuth re-auth prompt for 403/permission errors.
+ * Write tools are only registered when google_drive_write_enabled FF is enabled,
+ * so if this is called, we know both scopes should be requested.
  */
-function handlePermissionError(err: unknown): MCPError {
+function handlePermissionError(err: unknown): ToolHandlerResult {
   const error = normalizeError(err);
+
   if (
     error.message?.includes("403") ||
     error.message?.toLowerCase().includes("permission")
   ) {
-    return new MCPError(
-      "Insufficient permissions. Please go to Settings > Connections, disconnect Google Drive, and reconnect to enable write access.",
-      { tracked: false }
+    // Request both scopes - write tools only exist when FF is enabled
+    return new Ok(
+      makePersonalAuthenticationError(
+        "google_drive",
+        "https://www.googleapis.com/auth/drive.file https://www.googleapis.com/auth/drive.readonly"
+      ).content
     );
   }
-  return new MCPError(error.message || "Operation failed");
+
+  return new Err(new MCPError(error.message || "Operation failed"));
 }
 
 const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
@@ -333,8 +361,8 @@ const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
 export const TOOLS = buildTools(GOOGLE_DRIVE_TOOLS_METADATA, handlers);
 
 const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
-  create_document: async ({ title }, { authInfo }) => {
-    const docs = await getDocsClient(authInfo);
+  create_document: async ({ title }, extra) => {
+    const docs = await getDocsClient(extra.authInfo);
     if (!docs) {
       return new Err(new MCPError("Failed to authenticate with Google Docs"));
     }
@@ -355,12 +383,12 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
         },
       ]);
     } catch (err) {
-      return new Err(handlePermissionError(err));
+      return handlePermissionError(err);
     }
   },
 
-  create_spreadsheet: async ({ title }, { authInfo }) => {
-    const sheets = await getSheetsClient(authInfo);
+  create_spreadsheet: async ({ title }, extra) => {
+    const sheets = await getSheetsClient(extra.authInfo);
     if (!sheets) {
       return new Err(new MCPError("Failed to authenticate with Google Sheets"));
     }
@@ -383,12 +411,12 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
         },
       ]);
     } catch (err) {
-      return new Err(handlePermissionError(err));
+      return handlePermissionError(err);
     }
   },
 
-  create_presentation: async ({ title }, { authInfo }) => {
-    const slides = await getSlidesClient(authInfo);
+  create_presentation: async ({ title }, extra) => {
+    const slides = await getSlidesClient(extra.authInfo);
     if (!slides) {
       return new Err(new MCPError("Failed to authenticate with Google Slides"));
     }
@@ -409,7 +437,7 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
         },
       ]);
     } catch (err) {
-      return new Err(handlePermissionError(err));
+      return handlePermissionError(err);
     }
   },
 };


### PR DESCRIPTION
closes https://github.com/dust-tt/tasks/issues/6285
## Description
Small change to launch oauth within conversation for google write errors
Also added a reminder to update tool descriptions when we remove the FF
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

Tested manually -- 
before:
<img width="932" height="320" alt="Screenshot 2026-02-02 at 7 16 36 PM" src="https://github.com/user-attachments/assets/e85c439c-0eb2-4d4f-8aaf-3bfd4f4a7d6c" />
after:
<img width="678" height="241" alt="Screenshot 2026-02-02 at 7 40 05 PM" src="https://github.com/user-attachments/assets/92003aa7-48af-4370-bcdc-7b021a49df25" />

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low, new tools and scope behind FF
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [ ] deploy front
<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
