### PR TITLE
feat: add MCP server on unread

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
@@ -13899,6 +13899,45 @@
         }
       },
       {
+        "name": "search_unread",
+        "description": "Search for unread conversations in the project. Returns conversations that have been updated since the user last read them, within an optional time window (defaults to 30 days).",
+        "inputSchema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "additionalProperties": false,
+          "properties": {
+            "daysBack": {
+              "default": 30,
+              "description": "Number of days to look back for unread conversations (default: 30 days)",
+              "type": "number"
+            },
+            "dustProject": {
+              "additionalProperties": false,
+              "properties": {
+                "mimeType": {
+                  "const": "application/vnd.dust.tool-input.dust-project",
+                  "type": "string"
+                },
+                "uri": {
+                  "pattern": "^project:\\/\\/dust\\/w\\/(\\w+)\\/projects\\/(\\w+)$",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "uri",
+                "mimeType"
+              ],
+              "type": "object"
+            },
+            "limit": {
+              "default": 20,
+              "description": "Maximum number of conversations to return (default: 20, max: 100)",
+              "type": "number"
+            }
+          },
+          "type": "object"
+        }
+      },
+      {
         "name": "update_file",
         "description": "Update the content of an existing file in the project context. This replaces the entire file content. Provide either 'content' (text string) or 'sourceFileId' (ID of an existing file from the conversation to copy from).",
         "inputSchema": {
@@ -13951,6 +13990,7 @@
       "edit_url": "low",
       "get_information": "never_ask",
       "list_files": "never_ask",
+      "search_unread": "never_ask",
       "update_file": "high"
     }
   },

--- a/front/lib/api/actions/servers/project_context_management/metadata.ts
+++ b/front/lib/api/actions/servers/project_context_management/metadata.ts
@@ -191,6 +191,36 @@ export const PROJECT_CONTEXT_MANAGEMENT_TOOLS_METADATA = createToolsRecord({
       done: "Create conversation",
     },
   },
+  search_unread: {
+    description:
+      "Search for unread conversations in the project. Returns conversations that have been updated since the user last read them, " +
+      "within an optional time window (defaults to 30 days).",
+    schema: {
+      daysBack: z
+        .number()
+        .optional()
+        .default(30)
+        .describe(
+          "Number of days to look back for unread conversations (default: 30 days)"
+        ),
+      limit: z
+        .number()
+        .optional()
+        .default(20)
+        .describe(
+          "Maximum number of conversations to return (default: 20, max: 100)"
+        ),
+      dustProject:
+        ConfigurableToolInputSchemas[
+          INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_PROJECT
+        ].optional(),
+    },
+    stake: "never_ask",
+    displayLabels: {
+      running: "Searching unread conversations",
+      done: "Search unread conversations",
+    },
+  },
 });
 
 const PROJECT_CONTEXT_MANAGEMENT_INSTRUCTIONS =

--- a/front/lib/api/actions/servers/project_context_management/tools/conversation_formatting.ts
+++ b/front/lib/api/actions/servers/project_context_management/tools/conversation_formatting.ts
@@ -1,0 +1,91 @@
+import { isMessageUnread } from "@app/components/assistant/conversation/utils";
+import type {
+  AgentMessageType,
+  ContentFragmentType,
+  ConversationType,
+  UserMessageType,
+} from "@app/types";
+
+/**
+ * Formats a single message for display.
+ */
+function formatMessage(
+  msg: UserMessageType | AgentMessageType | ContentFragmentType,
+  lastReadMs: number | null
+) {
+  const dateStr = new Date(msg.created).toISOString();
+  const unreadFormatted = isMessageUnread(msg, lastReadMs) ? " (unread)" : "";
+
+  if (msg.type === "user_message") {
+    const userName = msg.user?.fullName ?? msg.user?.username ?? "User";
+    const userEmail = msg.user?.email ?? "Unknown";
+    const content = msg.content ?? "";
+    return `>> User (${userName}, ${userEmail}) [${dateStr}]${unreadFormatted}:\n${msg.visibility === "deleted" ? "Deleted message" : content}\n`;
+  }
+
+  if (msg.type === "agent_message") {
+    const agentName = msg.configuration?.name ?? "Assistant";
+    const content = msg.content ?? "";
+    return `>> Assistant (${agentName}) [${dateStr}]${unreadFormatted}:\n${msg.visibility === "deleted" ? "Deleted message" : content}\n`;
+  }
+
+  if (msg.type === "content_fragment") {
+    return `>> Content Fragment [${dateStr}]${unreadFormatted}:\nID: ${msg.contentFragmentId}\nContent-Type: ${msg.contentType}\nTitle: ${msg.title}\nVersion: ${msg.version}\nSource URL: ${msg.sourceUrl}\n`;
+  }
+
+  return "";
+}
+
+/**
+ * Formats raw conversation content into a readable text representation for display.
+ * This creates a simple text representation with all messages.
+ */
+export function formatConversationForDisplay(
+  conversation: ConversationType,
+  workspaceId: string
+) {
+  // Convert conversation content to formatted messages
+  const messages: string[] = [];
+
+  for (const versions of conversation.content) {
+    // Only take the last version of each rank
+    const msg = versions[versions.length - 1];
+    if (!msg) {
+      continue;
+    }
+
+    const formattedMessage = formatMessage(msg, conversation.lastReadMs);
+    if (formattedMessage) {
+      messages.push(formattedMessage);
+    }
+  }
+
+  // Format timestamps
+  const createdDate = new Date(conversation.created).toISOString();
+  const updatedDate = new Date(conversation.updated).toISOString();
+
+  return {
+    sId: conversation.sId,
+    title: conversation.title ?? "Untitled Conversation",
+    created: createdDate,
+    updated: updatedDate,
+    unread: conversation.unread,
+    actionRequired: conversation.actionRequired,
+    hasError: conversation.hasError,
+    messageCount: messages.length,
+    messages: messages.join("\n"),
+    url: `/w/${workspaceId}/assistant/${conversation.sId}`,
+  };
+}
+
+/**
+ * Formats multiple conversations for display.
+ */
+export function formatConversationsForDisplay(
+  conversations: ConversationType[],
+  workspaceId: string
+) {
+  return conversations.map((conv) =>
+    formatConversationForDisplay(conv, workspaceId)
+  );
+}


### PR DESCRIPTION
## Description

Adds a new tool for projects to fetch the unread content (messages) from the current project for the user. 

It'll be useful for the butler

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
