### PR TITLE
feat(drive): add create_comment tool with file auth pattern

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
@@ -4749,6 +4749,7 @@
       }
     ],
     "toolsStakes": {
+      "create_comment": "low",
       "create_document": "low",
       "create_presentation": "low",
       "create_spreadsheet": "low",

--- a/front/lib/api/actions/servers/google_drive/metadata.ts
+++ b/front/lib/api/actions/servers/google_drive/metadata.ts
@@ -172,6 +172,14 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
   },
+  create_comment: {
+    description: "Add a comment to a Google Drive file (Doc, Sheet, or Slide).",
+    schema: {
+      fileId: z.string().describe("The ID of the file to comment on."),
+      content: z.string().describe("The text content of the comment."),
+    },
+    stake: "low",
+  },
 });
 
 const ALL_TOOLS_METADATA = {

--- a/front/lib/api/actions/servers/google_drive/tools/index.test.ts
+++ b/front/lib/api/actions/servers/google_drive/tools/index.test.ts
@@ -1,0 +1,166 @@
+// eslint-disable-next-line dust/enforce-client-types-in-public-api
+import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
+import { describe, expect, it } from "vitest";
+
+import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+
+import { handleFileAccessError, isFileNotAuthorizedError } from "./index";
+
+describe("isFileNotAuthorizedError", () => {
+  it("should return true for errors containing '404'", () => {
+    expect(
+      isFileNotAuthorizedError(new Error("Request failed with status code 404"))
+    ).toBe(true);
+    expect(isFileNotAuthorizedError(new Error("404 Not Found"))).toBe(true);
+    expect(
+      isFileNotAuthorizedError(new Error("Error 404: Resource not available"))
+    ).toBe(true);
+  });
+
+  it("should return true for errors containing 'not found' (case insensitive)", () => {
+    expect(isFileNotAuthorizedError(new Error("File not found"))).toBe(true);
+    expect(isFileNotAuthorizedError(new Error("File Not Found"))).toBe(true);
+    expect(isFileNotAuthorizedError(new Error("NOT FOUND"))).toBe(true);
+    expect(isFileNotAuthorizedError(new Error("Resource was not found"))).toBe(
+      true
+    );
+  });
+
+  it("should return true for errors about write access not granted", () => {
+    expect(
+      isFileNotAuthorizedError(
+        new Error(
+          "The user has not granted the app 581863864696 write access to the file"
+        )
+      )
+    ).toBe(true);
+    expect(
+      isFileNotAuthorizedError(new Error("User has not granted access"))
+    ).toBe(true);
+    expect(
+      isFileNotAuthorizedError(new Error("No write access to this file"))
+    ).toBe(true);
+  });
+
+  it("should return false for other errors", () => {
+    expect(isFileNotAuthorizedError(new Error("Permission denied"))).toBe(
+      false
+    );
+    expect(isFileNotAuthorizedError(new Error("403 Forbidden"))).toBe(false);
+    expect(isFileNotAuthorizedError(new Error("Internal server error"))).toBe(
+      false
+    );
+    expect(isFileNotAuthorizedError(new Error("Network error"))).toBe(false);
+  });
+
+  it("should handle non-Error objects", () => {
+    expect(isFileNotAuthorizedError("404 error string")).toBe(true);
+    expect(isFileNotAuthorizedError("not found")).toBe(true);
+    expect(isFileNotAuthorizedError({ message: "404" })).toBe(true);
+    expect(isFileNotAuthorizedError("some other error")).toBe(false);
+  });
+
+  it("should handle null and undefined", () => {
+    expect(isFileNotAuthorizedError(null)).toBe(false);
+    expect(isFileNotAuthorizedError(undefined)).toBe(false);
+  });
+});
+
+describe("handleFileAccessError", () => {
+  const createMockExtra = (toolServerId?: string): ToolHandlerExtra =>
+    ({
+      authInfo: undefined,
+      agentLoopContext: toolServerId
+        ? {
+            runContext: {
+              toolConfiguration: {
+                toolServerId,
+              },
+            },
+          }
+        : undefined,
+    }) as ToolHandlerExtra;
+
+  it("should return authorization error for 404 errors", () => {
+    const result = handleFileAccessError(
+      new Error("404 Not Found"),
+      "test-file-id",
+      createMockExtra("my-connection"),
+      { name: "test-file.txt", mimeType: "text/plain" }
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      const content = result.value;
+      expect(content).toHaveLength(1);
+      expect(content[0].type).toBe("resource");
+      if (content[0].type === "resource") {
+        expect(content[0].resource.mimeType).toBe(
+          INTERNAL_MIME_TYPES.TOOL_OUTPUT.AGENT_PAUSE_TOOL_OUTPUT
+        );
+        expect(content[0].resource.type).toBe("tool_file_auth_required");
+        expect(content[0].resource.fileId).toBe("test-file-id");
+        expect(content[0].resource.fileName).toBe("test-file.txt");
+        expect(content[0].resource.connectionId).toBe("my-connection");
+      }
+    }
+  });
+
+  it("should use fileId as fileName when not provided", () => {
+    const result = handleFileAccessError(
+      new Error("not found"),
+      "test-file-id",
+      createMockExtra("my-connection")
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      const content = result.value;
+      if (content[0].type === "resource") {
+        expect(content[0].resource.fileName).toBe("test-file-id");
+      }
+    }
+  });
+
+  it("should use default connectionId when agentLoopContext is not available", () => {
+    const result = handleFileAccessError(
+      new Error("404"),
+      "test-file-id",
+      createMockExtra()
+    );
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      const content = result.value;
+      if (content[0].type === "resource") {
+        expect(content[0].resource.connectionId).toBe("google_drive");
+      }
+    }
+  });
+
+  it("should return MCPError for non-404 errors", () => {
+    const result = handleFileAccessError(
+      new Error("Permission denied"),
+      "test-file-id",
+      createMockExtra("my-connection")
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toBe("Permission denied");
+    }
+  });
+
+  it("should return generic message for errors without message", () => {
+    const result = handleFileAccessError(
+      new Error(""),
+      "test-file-id",
+      createMockExtra("my-connection")
+    );
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toBe("Failed to access file");
+    }
+  });
+});

--- a/front/lib/api/actions/servers/google_drive/tools/index.ts
+++ b/front/lib/api/actions/servers/google_drive/tools/index.ts
@@ -23,28 +23,32 @@ import { Err, Ok } from "@app/types";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
 /**
- * Checks if an error is a 404 (file not found / not authorized).
- * Google returns 404 when user doesn't have access to a file via drive.file scope.
+ * Checks if an error indicates the file is not authorized.
+ * Google returns 404 when user doesn't have access to a file via drive.file scope,
+ * or a permission error when the user hasn't granted write access.
  */
-function is404Error(err: unknown): boolean {
+export function isFileNotAuthorizedError(err: unknown): boolean {
   const error = normalizeError(err);
+  const message = error.message?.toLowerCase() ?? "";
   return (
-    error.message?.includes("404") ||
-    error.message?.toLowerCase().includes("not found")
+    message.includes("404") ||
+    message.includes("not found") ||
+    message.includes("has not granted") ||
+    message.includes("write access")
   );
 }
 
 /**
- * Handles file access errors by triggering the authorization flow for 404s.
- * Returns file auth error for 404s, generic MCPError otherwise.
+ * Handles file access errors by triggering the authorization flow for unauthorized files.
+ * Returns file auth error for 404s and permission errors, generic MCPError otherwise.
  */
-function handleFileAccessError(
+export function handleFileAccessError(
   err: unknown,
   fileId: string,
   extra: ToolHandlerExtra,
   fileMeta?: { name?: string; mimeType?: string }
 ): ToolHandlerResult {
-  if (is404Error(err)) {
+  if (isFileNotAuthorizedError(err)) {
     const connectionId =
       extra.agentLoopContext?.runContext?.toolConfiguration.toolServerId ??
       "google_drive";
@@ -409,6 +413,63 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
         },
       ]);
     } catch (err) {
+      return new Err(handlePermissionError(err));
+    }
+  },
+
+  create_comment: async ({ fileId, content }, extra) => {
+    const drive = await getDriveClient(extra.authInfo);
+    if (!drive) {
+      return new Err(new MCPError("Failed to authenticate with Google Drive"));
+    }
+
+    try {
+      const res = await drive.comments.create({
+        fileId,
+        fields: "id,content,createdTime,author",
+        requestBody: { content },
+      });
+      return new Ok([
+        {
+          type: "text" as const,
+          text: JSON.stringify(
+            {
+              commentId: res.data.id,
+              content: res.data.content,
+              createdTime: res.data.createdTime,
+              author: res.data.author?.displayName,
+              fileId,
+            },
+            null,
+            2
+          ),
+        },
+      ]);
+    } catch (err) {
+      // Only fetch metadata for better error messages if the comment creation fails
+      if (isFileNotAuthorizedError(err)) {
+        let fileName = fileId;
+        let mimeType = "unknown";
+
+        // Try to get file metadata for a better error message (non-blocking failure)
+        try {
+          const fileMetadata = await drive.files.get({
+            fileId,
+            supportsAllDrives: true,
+            fields: "id, name, mimeType",
+          });
+          fileName = fileMetadata.data.name ?? fileId;
+          mimeType = fileMetadata.data.mimeType ?? "unknown";
+        } catch {
+          // If metadata fetch also fails, just use fileId as the name
+        }
+
+        return handleFileAccessError(err, fileId, extra, {
+          name: fileName,
+          mimeType,
+        });
+      }
+
       return new Err(handlePermissionError(err));
     }
   },


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

  Add `create_comment` tool to Google Drive MCP server for adding comments to Docs, Sheets, and Slides.                                                             
                                                                                                                                                                    
  Implements file authorization error handling - when a user tries to comment on a file they haven't authorized via `drive.file` scope, returns a `tool_file_auth_required` event to trigger the authorization UI.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front