### PR TITLE
Fix enableAlerting settings for MCPs

### DIFF
--- a/front/lib/actions/mcp_internal_actions/wrappers.ts
+++ b/front/lib/actions/mcp_internal_actions/wrappers.ts
@@ -28,7 +28,11 @@ export function registerTool(
     tool.schema,
     withToolLogging(
       auth,
-      { toolNameForMonitoring: monitoringName, agentLoopContext },
+      {
+        toolNameForMonitoring: monitoringName,
+        agentLoopContext,
+        enableAlerting: tool.enableAlerting,
+      },
       (params, extra) =>
         tool.handler(params, { ...extra, agentLoopContext, auth })
     )

--- a/front/lib/api/actions/servers/agent_router/metadata.ts
+++ b/front/lib/api/actions/servers/agent_router/metadata.ts
@@ -19,6 +19,7 @@ export const AGENT_ROUTER_TOOLS_METADATA = createToolsRecord({
       "(e.g., `:mention[agent-name]{sId=xyz}`) to display a clickable link to the agent.",
     schema: {},
     stake: "never_ask",
+    enableAlerting: true,
     displayLabels: {
       running: "Listing agents",
       done: "List agents",
@@ -36,6 +37,7 @@ export const AGENT_ROUTER_TOOLS_METADATA = createToolsRecord({
       conversationId: z.string().describe("The conversation id."),
     },
     stake: "never_ask",
+    enableAlerting: true,
     displayLabels: {
       running: "Suggesting agents",
       done: "Suggest agents",

--- a/front/lib/api/actions/servers/data_warehouses/metadata.ts
+++ b/front/lib/api/actions/servers/data_warehouses/metadata.ts
@@ -51,6 +51,7 @@ export const DATA_WAREHOUSES_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "never_ask",
+    enableAlerting: true,
   },
   find: {
     description:
@@ -91,6 +92,7 @@ export const DATA_WAREHOUSES_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "never_ask",
+    enableAlerting: true,
   },
   describe_tables: {
     description:
@@ -109,6 +111,7 @@ export const DATA_WAREHOUSES_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "never_ask",
+    enableAlerting: true,
   },
   query: {
     description:
@@ -134,6 +137,7 @@ export const DATA_WAREHOUSES_TOOLS_METADATA = createToolsRecord({
         .describe("The name of the file to save the results to."),
     },
     stake: "never_ask",
+    enableAlerting: true,
   },
 });
 

--- a/front/lib/api/actions/servers/http_client/metadata.ts
+++ b/front/lib/api/actions/servers/http_client/metadata.ts
@@ -48,6 +48,7 @@ export const HTTP_CLIENT_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "low",
+    enableAlerting: true,
   },
 });
 

--- a/front/lib/api/actions/servers/interactive_content/metadata.ts
+++ b/front/lib/api/actions/servers/interactive_content/metadata.ts
@@ -125,6 +125,7 @@ export const INTERACTIVE_CONTENT_TOOLS_METADATA = createToolsRecord({
             "to replace multiple identical instances of the same text."
         ),
     },
+    enableAlerting: true,
     stake: "never_ask",
     displayLabels: {
       running: "Updating Interactive Content file",
@@ -184,7 +185,7 @@ export const INTERACTIVE_CONTENT_TOOLS_METADATA = createToolsRecord({
           "The ID of the Interactive Content file to retrieve (e.g., 'fil_abc123')"
         ),
     },
-    enableAlerting: false,
+    enableAlerting: true,
     stake: "never_ask",
     displayLabels: {
       running: "Retrieving Interactive Content file",
@@ -202,7 +203,7 @@ export const INTERACTIVE_CONTENT_TOOLS_METADATA = createToolsRecord({
           "The ID of the Interactive Content file to get share URL for (e.g., 'fil_abc123')"
         ),
     },
-    enableAlerting: true,
+    enableAlerting: false,
     stake: "never_ask",
     displayLabels: {
       running: "Getting share URL",

--- a/front/lib/api/actions/servers/query_tables_v2/metadata.ts
+++ b/front/lib/api/actions/servers/query_tables_v2/metadata.ts
@@ -21,6 +21,7 @@ export const QUERY_TABLES_V2_TOOLS_METADATA = createToolsRecord({
         ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.TABLE],
     },
     stake: "never_ask",
+    enableAlerting: true,
   },
   [EXECUTE_DATABASE_QUERY_TOOL_NAME]: {
     description:
@@ -38,6 +39,7 @@ export const QUERY_TABLES_V2_TOOLS_METADATA = createToolsRecord({
         .describe("The name of the file to save the results to."),
     },
     stake: "never_ask",
+    enableAlerting: true,
   },
 });
 

--- a/front/lib/api/actions/servers/web_search_browse/metadata.ts
+++ b/front/lib/api/actions/servers/web_search_browse/metadata.ts
@@ -23,6 +23,7 @@ export const WEB_SEARCH_BROWSE_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "never_ask",
+    enableAlerting: true,
     displayLabels: {
       running: "Searching the web",
       done: "Web search",
@@ -49,6 +50,7 @@ export const WEB_SEARCH_BROWSE_TOOLS_METADATA = createToolsRecord({
         .describe("If true, also retrieve outgoing links from the page."),
     },
     stake: "never_ask",
+    enableAlerting: true,
     displayLabels: {
       running: "Browsing web page",
       done: "Browse web page",


### PR DESCRIPTION
## Description

Some enableAlerting settings got lost during the MCP migration. This PR reestablish them based on their value on commit `abb8fe02c62c21c7ab168084a00e9adfda49b973` (prior to migration)

## Tests

local

## Risk

low
## Deploy Plan

front