### PR TITLE
[front] - refacto(skills): remove `getServerSideProps`

### DIFF
--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -15,7 +15,10 @@ import type {
   GetSkillsResponseBody,
   GetSkillsWithRelationsResponseBody,
 } from "@app/pages/api/w/[wId]/skills";
-import type { GetSkillWithRelationsResponseBody } from "@app/pages/api/w/[wId]/skills/[sId]";
+import type {
+  GetSkillResponseBody,
+  GetSkillWithRelationsResponseBody,
+} from "@app/pages/api/w/[wId]/skills/[sId]";
 import type { GetSkillHistoryResponseBody } from "@app/pages/api/w/[wId]/skills/[sId]/history";
 import type { GetSimilarSkillsResponseBody } from "@app/pages/api/w/[wId]/skills/similar";
 import type { LightWorkspaceType } from "@app/types";
@@ -23,7 +26,68 @@ import { Ok } from "@app/types";
 import type {
   SkillStatus,
   SkillType,
+  SkillWithRelationsType,
 } from "@app/types/assistant/skill_configuration";
+
+export function useSkill(options: {
+  workspaceId: string;
+  skillId: string | null;
+  withRelations: true;
+  disabled?: boolean;
+}): {
+  skill: SkillWithRelationsType | null;
+  isSkillLoading: boolean;
+  isSkillError: boolean;
+  mutateSkill: () => void;
+};
+export function useSkill(options: {
+  workspaceId: string;
+  skillId: string | null;
+  withRelations?: false;
+  disabled?: boolean;
+}): {
+  skill: SkillType | null;
+  isSkillLoading: boolean;
+  isSkillError: boolean;
+  mutateSkill: () => void;
+};
+export function useSkill({
+  workspaceId,
+  skillId,
+  withRelations = false,
+  disabled = false,
+}: {
+  workspaceId: string;
+  skillId: string | null;
+  withRelations?: boolean;
+  disabled?: boolean;
+}): {
+  skill: SkillType | SkillWithRelationsType | null;
+  isSkillLoading: boolean;
+  isSkillError: boolean;
+  mutateSkill: () => void;
+} {
+  const skillFetcher: Fetcher<
+    GetSkillResponseBody | GetSkillWithRelationsResponseBody
+  > = fetcher;
+
+  const url = skillId
+    ? `/api/w/${workspaceId}/skills/${skillId}${withRelations ? "?withRelations=true" : ""}`
+    : null;
+
+  const { data, error, isLoading, mutate } = useSWRWithDefaults(
+    url,
+    skillFetcher,
+    { disabled }
+  );
+
+  return {
+    skill: data?.skill ?? null,
+    isSkillLoading: isLoading,
+    isSkillError: !!error,
+    mutateSkill: mutate,
+  };
+}
 
 export function useSkills({
   owner,

--- a/front/lib/swr/skill_configurations.ts
+++ b/front/lib/swr/skill_configurations.ts
@@ -330,7 +330,7 @@ export function useSkillWithRelations(
   owner: LightWorkspaceType,
   options?: SWRMutationConfiguration<
     GetSkillWithRelationsResponseBody,
-    any,
+    Error,
     string,
     string
   >

--- a/front/pages/w/[wId]/builder/skills/[sId].tsx
+++ b/front/pages/w/[wId]/builder/skills/[sId].tsx
@@ -5,12 +5,10 @@ import type { ReactElement } from "react";
 import SkillBuilder from "@app/components/skill_builder/SkillBuilder";
 import { SkillBuilderProvider } from "@app/components/skill_builder/SkillBuilderContext";
 import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
+import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
+import { appGetServerSideProps } from "@app/lib/auth/appServerSideProps";
 import type { AuthContextValue } from "@app/lib/auth/AuthContext";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
-import {
-  appGetServerSideProps,
-  type AppPageWithLayout,
-} from "@app/lib/auth/appServerSideProps";
 import { useAppRouter, useRequiredPathParam } from "@app/lib/platform/next";
 import { useSkill } from "@app/lib/swr/skill_configurations";
 

--- a/front/pages/w/[wId]/builder/skills/[sId].tsx
+++ b/front/pages/w/[wId]/builder/skills/[sId].tsx
@@ -28,45 +28,32 @@ function EditSkill() {
     withRelations: true,
   });
 
-  if (isSkillError || (!isSkillLoading && !skill)) {
+  const isNotFound =
+    isSkillError ||
+    (!isSkillLoading && !skill) ||
+    (skill && (!skill.canWrite || skill.status === "archived"));
+
+  if (isNotFound) {
     void router.replace("/404");
+  }
+
+  if (isNotFound || isSkillLoading || !skill) {
     return (
       <div className="flex h-screen items-center justify-center">
         <Spinner size="xl" />
       </div>
     );
   }
-
-  if (isSkillLoading || !skill) {
-    return (
-      <div className="flex h-screen items-center justify-center">
-        <Spinner size="xl" />
-      </div>
-    );
-  }
-
-  if (!skill.canWrite || skill.status === "archived") {
-    void router.replace("/404");
-    return (
-      <div className="flex h-screen items-center justify-center">
-        <Spinner size="xl" />
-      </div>
-    );
-  }
-
-  const extendedSkill = skill.relations?.extendedSkill ?? null;
 
   return (
     <SkillBuilderProvider owner={owner} user={user} skillId={skill.sId}>
-      <>
-        <Head>
-          <title>{`Dust - ${skill.name}`}</title>
-        </Head>
-        <SkillBuilder
-          skill={skill}
-          extendedSkill={extendedSkill ?? undefined}
-        />
-      </>
+      <Head>
+        <title>{`Dust - ${skill.name}`}</title>
+      </Head>
+      <SkillBuilder
+        skill={skill}
+        extendedSkill={skill.relations?.extendedSkill ?? undefined}
+      />
     </SkillBuilderProvider>
   );
 }

--- a/front/pages/w/[wId]/builder/skills/[sId].tsx
+++ b/front/pages/w/[wId]/builder/skills/[sId].tsx
@@ -1,74 +1,61 @@
-import type { InferGetServerSidePropsType } from "next";
+import { Spinner } from "@dust-tt/sparkle";
 import Head from "next/head";
-import React from "react";
+import type { ReactElement } from "react";
 
 import SkillBuilder from "@app/components/skill_builder/SkillBuilder";
 import { SkillBuilderProvider } from "@app/components/skill_builder/SkillBuilderContext";
-import AppRootLayout from "@app/components/sparkle/AppRootLayout";
-import { withDefaultUserAuthRequirements } from "@app/lib/iam/session";
-import { SkillResource } from "@app/lib/resources/skill/skill_resource";
-import type { SubscriptionType, UserType, WorkspaceType } from "@app/types";
-import { isString } from "@app/types";
-import type { SkillType } from "@app/types/assistant/skill_configuration";
+import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
+import type { AuthContextValue } from "@app/lib/auth/AuthContext";
+import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
+import {
+  appGetServerSideProps,
+  type AppPageWithLayout,
+} from "@app/lib/auth/appServerSideProps";
+import { useAppRouter, useRequiredPathParam } from "@app/lib/platform/next";
+import { useSkill } from "@app/lib/swr/skill_configurations";
 
-export const getServerSideProps = withDefaultUserAuthRequirements<{
-  skill: SkillType;
-  extendedSkill: SkillType | null;
-  owner: WorkspaceType;
-  user: UserType;
-  subscription: SubscriptionType;
-}>(async (context, auth) => {
-  const owner = auth.workspace();
-  const subscription = auth.subscription();
+export const getServerSideProps = appGetServerSideProps;
 
-  if (!owner || !auth.isUser() || !subscription || !context.params?.sId) {
-    return {
-      notFound: true,
-    };
+function EditSkill() {
+  const router = useAppRouter();
+  const owner = useWorkspace();
+  const { user } = useAuth();
+  const skillId = useRequiredPathParam("sId");
+
+  const { skill, isSkillLoading, isSkillError } = useSkill({
+    workspaceId: owner.sId,
+    skillId,
+    withRelations: true,
+  });
+
+  if (isSkillError || (!isSkillLoading && !skill)) {
+    void router.replace("/404");
+    return (
+      <div className="flex h-screen items-center justify-center">
+        <Spinner size="xl" />
+      </div>
+    );
   }
 
-  if (!isString(context.params?.sId)) {
-    return {
-      notFound: true,
-    };
+  if (isSkillLoading || !skill) {
+    return (
+      <div className="flex h-screen items-center justify-center">
+        <Spinner size="xl" />
+      </div>
+    );
   }
 
-  const skillResource = await SkillResource.fetchById(auth, context.params.sId);
-  if (!skillResource) {
-    return {
-      notFound: true,
-    };
+  if (!skill.canWrite || skill.status === "archived") {
+    void router.replace("/404");
+    return (
+      <div className="flex h-screen items-center justify-center">
+        <Spinner size="xl" />
+      </div>
+    );
   }
 
-  if (!skillResource.canWrite(auth) || skillResource.status === "archived") {
-    return {
-      notFound: true,
-    };
-  }
+  const extendedSkill = skill.relations?.extendedSkill ?? null;
 
-  const extendedSkillResource = skillResource.extendedSkillId
-    ? await SkillResource.fetchById(auth, skillResource.extendedSkillId)
-    : null;
-
-  return {
-    props: {
-      skill: skillResource.toJSON(auth),
-      extendedSkill: extendedSkillResource
-        ? extendedSkillResource.toJSON(auth)
-        : null,
-      owner,
-      subscription,
-      user: auth.getNonNullableUser().toJSON(),
-    },
-  };
-});
-
-export default function EditSkill({
-  skill,
-  extendedSkill,
-  owner,
-  user,
-}: InferGetServerSidePropsType<typeof getServerSideProps>) {
   return (
     <SkillBuilderProvider owner={owner} user={user} skillId={skill.sId}>
       <>
@@ -84,6 +71,15 @@ export default function EditSkill({
   );
 }
 
-EditSkill.getLayout = (page: React.ReactElement) => {
-  return <AppRootLayout>{page}</AppRootLayout>;
+const EditSkillWithLayout = EditSkill as AppPageWithLayout;
+
+EditSkillWithLayout.getLayout = (
+  page: ReactElement,
+  pageProps: AuthContextValue
+) => {
+  return (
+    <AppAuthContextLayout authContext={pageProps}>{page}</AppAuthContextLayout>
+  );
 };
+
+export default EditSkillWithLayout;

--- a/front/pages/w/[wId]/builder/skills/index.tsx
+++ b/front/pages/w/[wId]/builder/skills/index.tsx
@@ -21,12 +21,10 @@ import { SuggestedSkillsSection } from "@app/components/skills/SuggestedSkillsSe
 import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
 import { AppWideModeLayout } from "@app/components/sparkle/AppWideModeLayout";
 import { useHashParam } from "@app/hooks/useHashParams";
+import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
+import { appGetServerSidePropsForBuilders } from "@app/lib/auth/appServerSideProps";
 import type { AuthContextValue } from "@app/lib/auth/AuthContext";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
-import {
-  appGetServerSidePropsForBuilders,
-  type AppPageWithLayout,
-} from "@app/lib/auth/appServerSideProps";
 import { SKILL_ICON } from "@app/lib/skill";
 import { useSkillsWithRelations } from "@app/lib/swr/skill_configurations";
 import { compareForFuzzySort, subFilter } from "@app/lib/utils";

--- a/front/pages/w/[wId]/builder/skills/new.tsx
+++ b/front/pages/w/[wId]/builder/skills/new.tsx
@@ -2,7 +2,6 @@ import { Spinner } from "@dust-tt/sparkle";
 import Head from "next/head";
 import type { ReactElement } from "react";
 
-import { SpacesProvider } from "@app/components/agent_builder/SpacesContext";
 import SkillBuilder from "@app/components/skill_builder/SkillBuilder";
 import { SkillBuilderProvider } from "@app/components/skill_builder/SkillBuilderContext";
 import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
@@ -43,12 +42,10 @@ function CreateSkill() {
 
   return (
     <SkillBuilderProvider owner={owner} user={user} skillId={null}>
-      <SpacesProvider owner={owner}>
-        <Head>
-          <title>Dust - New Skill</title>
-        </Head>
-        <SkillBuilder extendedSkill={extendedSkill ?? undefined} />
-      </SpacesProvider>
+      <Head>
+        <title>Dust - New Skill</title>
+      </Head>
+      <SkillBuilder extendedSkill={extendedSkill ?? undefined} />
     </SkillBuilderProvider>
   );
 }

--- a/front/pages/w/[wId]/builder/skills/new.tsx
+++ b/front/pages/w/[wId]/builder/skills/new.tsx
@@ -5,12 +5,10 @@ import type { ReactElement } from "react";
 import SkillBuilder from "@app/components/skill_builder/SkillBuilder";
 import { SkillBuilderProvider } from "@app/components/skill_builder/SkillBuilderContext";
 import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
+import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
+import { appGetServerSidePropsForBuilders } from "@app/lib/auth/appServerSideProps";
 import type { AuthContextValue } from "@app/lib/auth/AuthContext";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
-import {
-  appGetServerSidePropsForBuilders,
-  type AppPageWithLayout,
-} from "@app/lib/auth/appServerSideProps";
 import { useSearchParam } from "@app/lib/platform/next";
 import { useSkill } from "@app/lib/swr/skill_configurations";
 


### PR DESCRIPTION
## Description

This PR removes `getServerSideProps` from skill-related pages, migrating them to client-side data fetching with SWR hooks. This is part of the ongoing SPA migration effort.

The changes introduce a new `useSkill` hook with overloaded signatures to handle fetching skills with or without relations. Server-side data fetching is replaced with client-side hooks using `useWorkspace()` and `useAuth()` from AuthContext, and pages now use `AppAuthContextLayout` instead of `AppRootLayout`.

**Migrated pages:**
- `/builder/skills/[sId]` - edit skill page  
- `/builder/skills/new` - create skill page
- `/builder/skills/index` - skills list page

## Risk

Medium - follows the established pattern from previous migration PRs (#20571, #20616, #20718, #20876).

## Tests

- [x] Locally
- [] Deploy front-edge

## Deploy Plan

Deploy front