### PR TITLE
[front] - refactor(workspace): tweak layout

### DIFF
--- a/front/components/agent_builder/observability/shared/ChartContainer.tsx
+++ b/front/components/agent_builder/observability/shared/ChartContainer.tsx
@@ -72,7 +72,7 @@ export function ChartContainer({
           </div>
         </div>
         {description && (
-          <div className="my-3 text-xs text-muted-foreground dark:text-muted-foreground-night">
+          <div className="mb-3 text-xs text-muted-foreground dark:text-muted-foreground-night">
             {description}
           </div>
         )}

--- a/front/components/pages/workspace/AnalyticsPage.tsx
+++ b/front/components/pages/workspace/AnalyticsPage.tsx
@@ -170,7 +170,7 @@ export function AnalyticsPage() {
             workspaceId={owner.sId}
             period={period}
           />
-          <div className="grid w-full grid-cols-1 gap-4 xl:grid-cols-2">
+          <div className="flex flex-col gap-4">
             <WorkspaceUsageChart workspaceId={owner.sId} period={period} />
             <WorkspaceSourceChart workspaceId={owner.sId} period={period} />
           </div>

--- a/front/components/pages/workspace/AnalyticsPage.tsx
+++ b/front/components/pages/workspace/AnalyticsPage.tsx
@@ -148,7 +148,7 @@ export function AnalyticsPage() {
           featureFlags,
         })}
       >
-        <Page.Vertical align="stretch" gap="xl">
+        <Page.Vertical align="stretch" gap="lg">
           <Page.Header
             title={
               <div className="flex flex-row w-full justify-between">
@@ -170,7 +170,7 @@ export function AnalyticsPage() {
             workspaceId={owner.sId}
             period={period}
           />
-          <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-5">
             <WorkspaceUsageChart workspaceId={owner.sId} period={period} />
             <WorkspaceSourceChart workspaceId={owner.sId} period={period} />
           </div>

--- a/front/components/workspace/analytics/WorkspaceTopAgentsTable.tsx
+++ b/front/components/workspace/analytics/WorkspaceTopAgentsTable.tsx
@@ -107,7 +107,7 @@ export function WorkspaceTopAgentsTable({
         <ScrollableDataTable<TopAgentRowData>
           data={rows}
           columns={columns}
-          maxHeight="max-h-125"
+          maxHeight="max-h-64"
         />
       )}
     </div>

--- a/front/components/workspace/analytics/WorkspaceTopUsersTable.tsx
+++ b/front/components/workspace/analytics/WorkspaceTopUsersTable.tsx
@@ -105,7 +105,7 @@ export function WorkspaceTopUsersTable({
         <ScrollableDataTable<TopUserRowData>
           data={rows}
           columns={columns}
-          maxHeight="max-h-125"
+          maxHeight="max-h-64"
         />
       )}
     </div>

--- a/sparkle/src/components/Page.tsx
+++ b/sparkle/src/components/Page.tsx
@@ -46,7 +46,11 @@ Page.Header = function ({ title, description, icon }: PageHeaderProps) {
         className="s-text-primary-400 dark:s-text-primary-500"
         size="lg"
       />
-      <Page.H variant="h3">{title}</Page.H>
+      {typeof title === "string" ? (
+        <Page.H variant="h3">{title}</Page.H>
+      ) : (
+        <>{title}</>
+      )}
       {description && <Page.P variant="secondary">{description}</Page.P>}
     </Page.Vertical>
   );


### PR DESCRIPTION






## Description

This PR makes small layout adjustments to the workspace analytics page following the analytics refactor in #20945. It changes the charts section from a 2-column grid to a vertical flex layout for better responsiveness, reduces the max height of the top agents and users tables from `max-h-125` to `max-h-64` for better visibility, and updates the `Page.Header` component to accept ReactNode titles in addition to strings for more flexible header rendering.

## Risk

Low

## Tests

Tested locally.

## Deploy Plan

Deploy front

Deploy front