### PR TITLE
Copilot: add instructions to not suggest instructions if no related tools are available

### DIFF
--- a/front/components/agent_builder/CopilotPanelContext.tsx
+++ b/front/components/agent_builder/CopilotPanelContext.tsx
@@ -53,6 +53,10 @@ Tool usage rules when creating suggestions:
 
 Use \`suggest_*\` tools to create actionable suggestions. Brief explanation (3-4 sentences max). Always include their output verbatim in your response - it renders as interactive cards
 
+Warning: do not suggest instructions if there is no existing tools or skills to do an action.
+For instance if the user wants to create a agent to answer on JIRA issues but there is no tool to interact with JIRA then it won't be possible.
+In that case, instead of doing prompt suggestions ask the user for clarifications.
+
 Balance context gathering with latency - the first copilot message should be fast but helpful in driving builder actions.
 </dust_system>`;
 }
@@ -83,6 +87,10 @@ Tool usage rules when creating suggestions:
 - \`get_available_models\`: Only if user explicitly asks OR obvious need.
 
 Use \`suggest_*\` tools to create actionable suggestions. Brief explanation (3-4 sentences max). Always include their output verbatim in your response - it renders as interactive cards
+
+Warning: do not suggest instructions if there is no existing tools or skills to do an action.
+For instance if the user wants to create a agent to answer on JIRA issues but there is no tool to interact with JIRA then it won't be possible.
+In that case, instead of doing prompt suggestions ask the user for clarifications.
 
 Balance context gathering with latency - the first copilot message should be fast but helpful in driving builder actions.
 </dust_system>`;

--- a/front/tests/copilot-evals/test-suites/instructions-with-tools.ts
+++ b/front/tests/copilot-evals/test-suites/instructions-with-tools.ts
@@ -3,6 +3,7 @@ import {
   AGENT_NEEDING_TOOLS,
   AGENT_WITH_UNREFERENCED_TOOLS,
   AGENT_WITH_VAGUE_TOOL_USAGE,
+  BLANK_AGENT,
 } from "../shared-mock-states/index";
 
 export const instructionsWithToolsSuite: TestSuite = {
@@ -73,6 +74,28 @@ Should NOT just list all available tools - be selective and relevant.`,
       judgeCriteria: `Should match tools to weekly summary use case.
 Should prioritize: tools that provide project status, updates, blockers.
 May offer to add tool usage instructions after tools connected.`,
+    },
+    {
+      scenarioId: "unavailable-tool-requested-1",
+      userMessage:
+        "I want to create an agent that can create and update entries in HubSpot CRM when we close deals.",
+      mockState: BLANK_AGENT,
+      expectedToolCalls: ["get_agent_info", "get_available_tools"],
+      judgeCriteria: `Should check available tools and clearly inform the user that HubSpot is NOT available.
+Must NOT suggest adding instructions that reference HubSpot since the tool doesn't exist.
+Should mention this capability isn't currently supported.
+Score 0 if copilot suggests creating instructions for HubSpot without noting the tool is unavailable.`,
+    },
+    {
+      scenarioId: "unavailable-tool-requested-2",
+      userMessage: "Create an agent which pulls all pager duty incidents",
+      mockState: BLANK_AGENT,
+      expectedToolCalls: ["get_agent_info", "get_available_tools"],
+      judgeCriteria: `Should check available tools and clearly inform the user that PagerDuty is NOT available.
+Must NOT suggest adding instructions that reference pager duty incidents since the tool doesn't exist.
+Should mention this capability isn't currently supported.
+May suggest other way to retrieve the incidents if possible.
+Score 0 if copilot suggests creating instructions for PagerDuty without noting the tool is unavailable.`,
     },
   ],
 };


### PR DESCRIPTION
## Description

Closes https://github.com/dust-tt/tasks/issues/6248

This should prevent cases where the agent create a useless prompt

<img width="800" height="800" alt="image" src="https://github.com/user-attachments/assets/e3960f39-e4f2-4704-a033-d8b3997c84b1" />


## Tests

Manual tests + eval tests

## Risk

low

## Deploy Plan

deploy front
