### PR TITLE
Fix MCP server creation dialog to avoid hidding the other fields in static oauth.

### DIFF
--- a/front/components/actions/mcp/create/CreateMCPServerDialog.tsx
+++ b/front/components/actions/mcp/create/CreateMCPServerDialog.tsx
@@ -232,14 +232,14 @@ export function CreateMCPServerDialog({
         resetState();
       }}
     >
-      <DialogContent size="xl" height="xl" onClick={(e) => e.stopPropagation()}>
+      <DialogContent size="xl" onClick={(e) => e.stopPropagation()}>
         <FormProvider form={form} asForm={false}>
           <DialogHeader>
             <DialogTitle visual={getAvatarFromIcon(toolIcon, "sm")}>
               Configure {toolName}
             </DialogTitle>
           </DialogHeader>
-          <DialogContainer>
+          <DialogContainer className="max-h-[80vh]">
             <div className="space-y-4">
               {!internalMCPServer &&
                 (!authorization || authorization.provider === "mcp_static") && (


### PR DESCRIPTION
## Description

Make it so the create MCP server dialog fit the whole content (if possible).

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy front