### PR TITLE
fix: number of unread messages for space conversations

### DIFF
--- a/front/components/assistant/conversation/space/conversations/SpaceConversationListItem.tsx
+++ b/front/components/assistant/conversation/space/conversations/SpaceConversationListItem.tsx
@@ -15,6 +15,8 @@ import {
 } from "@app/types";
 import { stripMarkdown } from "@app/types";
 
+import { isMessageUnread } from "../../utils";
+
 interface SpaceConversationListItemProps {
   conversation: ConversationType;
   owner: WorkspaceType;
@@ -57,19 +59,7 @@ export function SpaceConversationListItem({
   const countUnreadMessages = useMemo(() => {
     return conversation.content.filter((versions) => {
       const message = versions[versions.length - 1];
-      if (conversation.lastReadMs === null) {
-        return true;
-      }
-      if (message.created > conversation.lastReadMs) {
-        return true;
-      }
-      if (
-        message.type === "agent_message" &&
-        (message.completedTs ?? 0) > conversation.lastReadMs
-      ) {
-        return true;
-      }
-      return false;
+      return isMessageUnread(message, conversation.lastReadMs);
     }).length;
   }, [conversation.content, conversation.lastReadMs]);
 

--- a/front/components/assistant/conversation/space/conversations/SpaceConversationListItem.tsx
+++ b/front/components/assistant/conversation/space/conversations/SpaceConversationListItem.tsx
@@ -57,7 +57,19 @@ export function SpaceConversationListItem({
   const countUnreadMessages = useMemo(() => {
     return conversation.content.filter((versions) => {
       const message = versions[versions.length - 1];
-      return message.created > (conversation.lastReadMs ?? 0);
+      if (conversation.lastReadMs === null) {
+        return true;
+      }
+      if (message.created > conversation.lastReadMs) {
+        return true;
+      }
+      if (
+        message.type === "agent_message" &&
+        (message.completedTs ?? 0) > conversation.lastReadMs
+      ) {
+        return true;
+      }
+      return false;
     }).length;
   }, [conversation.content, conversation.lastReadMs]);
 

--- a/front/components/assistant/conversation/space/conversations/SpaceConversationsTab.tsx
+++ b/front/components/assistant/conversation/space/conversations/SpaceConversationsTab.tsx
@@ -78,6 +78,7 @@ export function SpaceConversationsTab({
 
   const { markAllAsRead, isMarkingAllAsRead } = useMarkAllConversationsAsRead({
     owner,
+    spaceId: spaceInfo.sId,
   });
 
   const [isSearchPopoverOpen, setIsSearchPopoverOpen] = useState(false);

--- a/front/components/assistant/conversation/utils.ts
+++ b/front/components/assistant/conversation/utils.ts
@@ -1,7 +1,12 @@
 import moment from "moment";
 
 import { removeDiacritics, subFilter } from "@app/lib/utils";
-import type { ConversationWithoutContentType } from "@app/types";
+import type {
+  AgentMessageType,
+  ContentFragmentType,
+  ConversationWithoutContentType,
+  UserMessageType,
+} from "@app/types";
 
 import type { VirtuosoMessage } from "./types";
 
@@ -132,4 +137,23 @@ export function findFirstUnreadMessageIndex(
     }
     return false;
   });
+}
+
+export function isMessageUnread(
+  message: UserMessageType | AgentMessageType | ContentFragmentType,
+  lastReadMs: number | null
+): boolean {
+  if (lastReadMs === null) {
+    return true;
+  }
+  if (message.created > lastReadMs) {
+    return true;
+  }
+  if (
+    message.type === "agent_message" &&
+    (message.completedTs ?? 0) > lastReadMs
+  ) {
+    return true;
+  }
+  return false;
 }

--- a/front/hooks/useMarkAllConversationsAsRead.ts
+++ b/front/hooks/useMarkAllConversationsAsRead.ts
@@ -4,16 +4,19 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
 import {
   useConversations,
+  useSpaceConversations,
   useSpaceConversationsSummary,
 } from "@app/lib/swr/conversations";
 import type { ConversationWithoutContentType, WorkspaceType } from "@app/types";
 
 interface useMarkAllConversationsAsReadParams {
   owner: WorkspaceType;
+  spaceId?: string;
 }
 
 export function useMarkAllConversationsAsRead({
   owner,
+  spaceId,
 }: useMarkAllConversationsAsReadParams) {
   const [isMarkingAllAsRead, setIsMarkingAllAsRead] = useState(false);
   const sendNotification = useSendNotification();
@@ -28,6 +31,12 @@ export function useMarkAllConversationsAsRead({
     workspaceId: owner.sId,
     options: { disabled: true },
   });
+
+  const { mutateConversations: mutateSpaceConversations } =
+    useSpaceConversations({
+      workspaceId: owner.sId,
+      spaceId: spaceId ?? null,
+    });
 
   const markAllAsRead = useCallback(
     async (conversations: ConversationWithoutContentType[]) => {
@@ -67,6 +76,7 @@ export function useMarkAllConversationsAsRead({
 
         void mutateConversations();
         void mutateSpaceSummary();
+        void mutateSpaceConversations();
 
         sendNotification({
           type: "success",
@@ -83,7 +93,13 @@ export function useMarkAllConversationsAsRead({
         setIsMarkingAllAsRead(false);
       }
     },
-    [owner.sId, mutateConversations, mutateSpaceSummary, sendNotification]
+    [
+      owner.sId,
+      mutateConversations,
+      mutateSpaceSummary,
+      mutateSpaceConversations,
+      sendNotification,
+    ]
   );
 
   return {

--- a/front/lib/notifications/workflows/conversation-unread.ts
+++ b/front/lib/notifications/workflows/conversation-unread.ts
@@ -5,6 +5,7 @@ import uniqBy from "lodash/uniqBy";
 import { Op } from "sequelize";
 import z from "zod";
 
+import { isMessageUnread } from "@app/components/assistant/conversation/utils";
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
@@ -259,21 +260,7 @@ const getConversationDetails = async ({
   }
 
   const hasUnreadMessages = conversation.content.some((messages) =>
-    messages.some((msg) => {
-      if (conversation.lastReadMs === null) {
-        return true;
-      }
-      if (msg.created > conversation.lastReadMs) {
-        return true;
-      }
-      if (
-        msg.type === "agent_message" &&
-        (msg.completedTs ?? 0) > conversation.lastReadMs
-      ) {
-        return true;
-      }
-      return false;
-    })
+    messages.some((msg) => isMessageUnread(msg, conversation.lastReadMs))
   );
 
   const conversationsRetention = await getConversationsDataRetention(auth);
@@ -442,21 +429,7 @@ const generateUnreadMessagesSummary = async ({
 
   const unreadMessages = conversation.content
     .map((messages) =>
-      messages.filter((msg) => {
-        if (conversation.lastReadMs === null) {
-          return true;
-        }
-        if (msg.created > conversation.lastReadMs) {
-          return true;
-        }
-        if (
-          msg.type === "agent_message" &&
-          (msg.completedTs ?? 0) > conversation.lastReadMs
-        ) {
-          return true;
-        }
-        return false;
-      })
+      messages.filter((msg) => isMessageUnread(msg, conversation.lastReadMs))
     )
     .filter(
       (

--- a/front/lib/swr/conversations.ts
+++ b/front/lib/swr/conversations.ts
@@ -950,7 +950,7 @@ export function useConversationMarkAsRead({
         clearTimeout(timeout);
       }
     };
-  }, [conversation?.sId, markAsRead, conversation?.spaceId]);
+  }, [markAsRead, conversation]);
 
   return {
     markAsRead,


### PR DESCRIPTION
## Description

This PR fixes the calculation of unread message counts for space conversations by properly handling agent messages. 

- Created function to check if a message is unread
- Updated `useMarkAllConversationsAsRead` to mutate space conversations when marking all as read

## Tests

Manually

## Risks

Low risk. 

## Deploy Plan

