### PR TITLE
fix(markdown): avoid instruction-block directive crash in lists

### DIFF
--- a/front/components/assistant/AgentMessageMarkdown.integration.test.tsx
+++ b/front/components/assistant/AgentMessageMarkdown.integration.test.tsx
@@ -190,6 +190,25 @@ describe("AgentMessageMarkdown - Integration Tests", () => {
         expect(container.querySelector("strong")).toBeInTheDocument();
         expect(container.querySelector("em")).toBeInTheDocument();
       });
+
+      it("does not crash when an instruction block starts in a list item", () => {
+        const content = `1. <channel_suggestion>
+
+hello
+
+</channel_suggestion>`;
+
+        const { container } = render(
+          <AgentMessageMarkdown
+            owner={mockOwner}
+            content={content}
+            isInstructions={true}
+          />
+        );
+
+        expect(container.textContent).toContain("CHANNEL_SUGGESTION");
+        expect(container.textContent).toContain("hello");
+      });
     });
   });
 

--- a/front/components/markdown/InstructionBlock.test.ts
+++ b/front/components/markdown/InstructionBlock.test.ts
@@ -80,6 +80,24 @@ describe("preprocessInstructionBlocks", () => {
     expect(preprocessInstructionBlocks(input)).toBe(input);
   });
 
+  it("keeps generated directive content inside list items", () => {
+    const input = `1. <channel_suggestion>
+
+hello
+
+</channel_suggestion>`;
+
+    const expected = `1. :::instruction_block[channel_suggestion]
+
+
+   hello
+
+
+   :::\n`;
+
+    expect(preprocessInstructionBlocks(input)).toBe(expected);
+  });
+
   it("handles content with line breaks and formatting", () => {
     const input = `<example>
 # Heading


### PR DESCRIPTION
## Description

Fixes a crash in the markdown pipeline when XML-style instruction blocks (e.g. `<channel_suggestion>...</channel_suggestion>`) are used inside list items in agent instructions.

`preprocessInstructionBlocks()` now detects list-item prefixes (e.g. `1. ` / `- `) and indents the generated `:::instruction_block[...]` container directive (including its closing `:::`) so it stays inside the list item. This prevents micromark/remark-directive from crashing during subtokenization.

fixes https://github.com/dust-tt/tasks/issues/6273

## Tests

- `cd front && NODE_ENV=test npm test components/markdown/InstructionBlock.test.ts`
- `cd front && NODE_ENV=test npm test components/assistant/AgentMessageMarkdown.integration.test.tsx`

## Risk

Low. Change is scoped to instruction-block preprocessing and only affects cases where XML-style blocks appear inside list items.

## Deploy Plan

- Merge and deploy as usual.