### PR TITLE
[front] - chore(workspace): analytics tweaks

### DIFF
--- a/front/components/workspace/analytics/WorkspaceTopAgentsTable.tsx
+++ b/front/components/workspace/analytics/WorkspaceTopAgentsTable.tsx
@@ -94,7 +94,7 @@ export function WorkspaceTopAgentsTable({
           Top agents
         </h3>
         <p className="text-xs text-muted-foreground dark:text-muted-foreground-night">
-          Agents with the most messages in this time range.
+          Top 100 agents with the most messages in this time range.
         </p>
       </div>
       {isTopAgentsLoading ? (

--- a/front/components/workspace/analytics/WorkspaceTopAgentsTable.tsx
+++ b/front/components/workspace/analytics/WorkspaceTopAgentsTable.tsx
@@ -3,7 +3,6 @@ import type { CellContext, ColumnDef } from "@tanstack/react-table";
 import { useMemo } from "react";
 
 import type { ObservabilityTimeRangeType } from "@app/components/agent_builder/observability/constants";
-import { usePaginationFromUrl } from "@app/hooks/usePaginationFromUrl";
 import { useWorkspaceTopAgents } from "@app/lib/swr/workspaces";
 
 interface TopAgentRowData {
@@ -65,11 +64,6 @@ export function WorkspaceTopAgentsTable({
   workspaceId,
   period,
 }: WorkspaceTopAgentsTableProps) {
-  const { pagination, setPagination } = usePaginationFromUrl({
-    urlPrefix: "topAgents",
-    initialPageSize: 25,
-  });
-
   const { topAgents, isTopAgentsLoading, isTopAgentsError } =
     useWorkspaceTopAgents({
       workspaceId,
@@ -114,8 +108,6 @@ export function WorkspaceTopAgentsTable({
           data={rows}
           columns={columns}
           maxHeight="max-h-64"
-          pagination={pagination}
-          setPagination={setPagination}
         />
       )}
     </div>

--- a/front/components/workspace/analytics/WorkspaceTopAgentsTable.tsx
+++ b/front/components/workspace/analytics/WorkspaceTopAgentsTable.tsx
@@ -3,6 +3,7 @@ import type { CellContext, ColumnDef } from "@tanstack/react-table";
 import { useMemo } from "react";
 
 import type { ObservabilityTimeRangeType } from "@app/components/agent_builder/observability/constants";
+import { usePaginationFromUrl } from "@app/hooks/usePaginationFromUrl";
 import { useWorkspaceTopAgents } from "@app/lib/swr/workspaces";
 
 interface TopAgentRowData {
@@ -64,11 +65,16 @@ export function WorkspaceTopAgentsTable({
   workspaceId,
   period,
 }: WorkspaceTopAgentsTableProps) {
+  const { pagination, setPagination } = usePaginationFromUrl({
+    urlPrefix: "topAgents",
+    initialPageSize: 25,
+  });
+
   const { topAgents, isTopAgentsLoading, isTopAgentsError } =
     useWorkspaceTopAgents({
       workspaceId,
       days: period,
-      limit: 10,
+      limit: 100,
       disabled: !workspaceId,
     });
 
@@ -108,6 +114,8 @@ export function WorkspaceTopAgentsTable({
           data={rows}
           columns={columns}
           maxHeight="max-h-64"
+          pagination={pagination}
+          setPagination={setPagination}
         />
       )}
     </div>

--- a/front/components/workspace/analytics/WorkspaceTopUsersTable.tsx
+++ b/front/components/workspace/analytics/WorkspaceTopUsersTable.tsx
@@ -3,6 +3,7 @@ import type { CellContext, ColumnDef } from "@tanstack/react-table";
 import { useMemo } from "react";
 
 import type { ObservabilityTimeRangeType } from "@app/components/agent_builder/observability/constants";
+import { usePaginationFromUrl } from "@app/hooks/usePaginationFromUrl";
 import { useWorkspaceTopUsers } from "@app/lib/swr/workspaces";
 
 interface TopUserRowData {
@@ -61,11 +62,16 @@ export function WorkspaceTopUsersTable({
   workspaceId,
   period,
 }: WorkspaceTopUsersTableProps) {
+  const { pagination, setPagination } = usePaginationFromUrl({
+    urlPrefix: "topUsers",
+    initialPageSize: 25,
+  });
+
   const { topUsers, isTopUsersLoading, isTopUsersError } = useWorkspaceTopUsers(
     {
       workspaceId,
       days: period,
-      limit: 10,
+      limit: 100,
       disabled: !workspaceId,
     }
   );
@@ -106,6 +112,8 @@ export function WorkspaceTopUsersTable({
           data={rows}
           columns={columns}
           maxHeight="max-h-64"
+          pagination={pagination}
+          setPagination={setPagination}
         />
       )}
     </div>

--- a/front/components/workspace/analytics/WorkspaceTopUsersTable.tsx
+++ b/front/components/workspace/analytics/WorkspaceTopUsersTable.tsx
@@ -92,7 +92,7 @@ export function WorkspaceTopUsersTable({
           Top users
         </h3>
         <p className="text-xs text-muted-foreground dark:text-muted-foreground-night">
-          Users with the most messages in this time range.
+          Top 100 users with the most messages in this time range.
         </p>
       </div>
       {isTopUsersLoading ? (

--- a/front/components/workspace/analytics/WorkspaceTopUsersTable.tsx
+++ b/front/components/workspace/analytics/WorkspaceTopUsersTable.tsx
@@ -3,7 +3,6 @@ import type { CellContext, ColumnDef } from "@tanstack/react-table";
 import { useMemo } from "react";
 
 import type { ObservabilityTimeRangeType } from "@app/components/agent_builder/observability/constants";
-import { usePaginationFromUrl } from "@app/hooks/usePaginationFromUrl";
 import { useWorkspaceTopUsers } from "@app/lib/swr/workspaces";
 
 interface TopUserRowData {
@@ -62,11 +61,6 @@ export function WorkspaceTopUsersTable({
   workspaceId,
   period,
 }: WorkspaceTopUsersTableProps) {
-  const { pagination, setPagination } = usePaginationFromUrl({
-    urlPrefix: "topUsers",
-    initialPageSize: 25,
-  });
-
   const { topUsers, isTopUsersLoading, isTopUsersError } = useWorkspaceTopUsers(
     {
       workspaceId,
@@ -112,8 +106,6 @@ export function WorkspaceTopUsersTable({
           data={rows}
           columns={columns}
           maxHeight="max-h-64"
-          pagination={pagination}
-          setPagination={setPagination}
         />
       )}
     </div>

--- a/front/pages/api/w/[wId]/analytics/top-agents.ts
+++ b/front/pages/api/w/[wId]/analytics/top-agents.ts
@@ -14,7 +14,7 @@ import type { WithAPIErrorResponse } from "@app/types";
 
 const QuerySchema = z.object({
   days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
-  limit: z.coerce.number().positive().max(50).optional().default(10),
+  limit: z.coerce.number().positive().max(100).optional().default(25),
 });
 
 export type WorkspaceTopAgentRow = {

--- a/front/pages/api/w/[wId]/analytics/top-users.ts
+++ b/front/pages/api/w/[wId]/analytics/top-users.ts
@@ -14,7 +14,7 @@ import type { WithAPIErrorResponse } from "@app/types";
 
 const QuerySchema = z.object({
   days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
-  limit: z.coerce.number().positive().max(50).optional().default(10),
+  limit: z.coerce.number().positive().max(100).optional().default(25),
 });
 
 export type WorkspaceTopUserRow = {
@@ -44,7 +44,7 @@ type TopUserBucket = {
 
 function getUserDisplayName(user: UserResource | undefined): string {
   if (!user) {
-    return "Unknown user";
+    return "Programmatic usage";
   }
   const fullName = user.fullName();
   if (fullName) {
@@ -53,7 +53,7 @@ function getUserDisplayName(user: UserResource | undefined): string {
   if (user.username) {
     return user.username;
   }
-  return user.email || "Unknown user";
+  return user.email || "Programmatic usage";
 }
 
 async function handler(


### PR DESCRIPTION
## Description

This PR improves the workspace analytics tables following the analytics refactor in #20945. It increases the data limit for top agents and top users tables from 10 to 100 entries, allowing workspace admins to see more detailed insights.

## Risk

Low - incremental improvements to the recently refactored analytics page.

## Tests

- [x] Locally
- [x] Front edge

## Deploy Plan

Deploy front