### PR TITLE
feat(drive): add update_document tool with file auth pattern

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
@@ -4757,7 +4757,8 @@
       "get_spreadsheet": "never_ask",
       "get_worksheet": "never_ask",
       "list_drives": "never_ask",
-      "search_files": "never_ask"
+      "search_files": "never_ask",
+      "update_document": "low"
     }
   },
   {

--- a/front/lib/api/actions/servers/google_drive/metadata.ts
+++ b/front/lib/api/actions/servers/google_drive/metadata.ts
@@ -193,7 +193,7 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
           "How to update the document: 'append' adds content at the end, 'replace' replaces all existing content."
         ),
     },
-    stake: "low",
+    stake: "medium",
   },
 });
 

--- a/front/lib/api/actions/servers/google_drive/metadata.ts
+++ b/front/lib/api/actions/servers/google_drive/metadata.ts
@@ -180,6 +180,21 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
   },
+  update_document: {
+    description:
+      "Update an existing Google Docs document by appending or replacing content.",
+    schema: {
+      documentId: z.string().describe("The ID of the document to update."),
+      content: z.string().describe("The text content to insert."),
+      mode: z
+        .enum(["append", "replace"])
+        .default("append")
+        .describe(
+          "How to update the document: 'append' adds content at the end, 'replace' replaces all existing content."
+        ),
+    },
+    stake: "low",
+  },
 });
 
 const ALL_TOOLS_METADATA = {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

Add update_document tool to Google Drive MCP server for appending, or updating a file in Docs.

Implements file authorization error handling - when a user tries to comment on a file they haven't authorized via drive.file scope, returns a tool_file_auth_required event to trigger the authorization UI.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front