### PR TITLE
Sanitize content before creating AgentMCPActionOutputItem

### DIFF
--- a/front/lib/actions/mcp_execution.ts
+++ b/front/lib/actions/mcp_execution.ts
@@ -365,7 +365,7 @@ export async function processToolResults(
     cleanContent.map((c) => ({
       workspaceId: action.workspaceId,
       agentMCPActionId: action.id,
-      content: c.content,
+      content: sanitizeStringsDeep(c.content),
       fileId: c.file?.id,
     }))
   );


### PR DESCRIPTION
## Description

**Problem**: The processToolResults function was inserting MCP tool output into the database without sanitizing all string fields. When the tool output contained problematic Unicode characters (like null bytes \u0000), PostgreSQL's JSONB parser would reject them with "unsupported Unicode escape sequence" errors.

  **Solution**: Apply sanitizeStringsDeep to the content before inserting it into the database. This function recursively sanitizes all string values by:
  1. Removing null bytes via stripNullBytes
  2. Replacing lone surrogate characters with the Unicode replacement character via toWellFormed

This matches the existing pattern used in processToolNotification (line 98) which already sanitizes content before insertion.

Fixes https://github.com/dust-tt/tasks/issues/6306

## Tests



## Risk

I assume low, but need review by agent loop experts

## Deploy Plan

Front