### PR TITLE
[front] Mark instructions suggestions as outdated from editor 

### DIFF
--- a/front/components/agent_builder/copilot/CopilotSuggestionsContext.tsx
+++ b/front/components/agent_builder/copilot/CopilotSuggestionsContext.tsx
@@ -240,6 +240,8 @@ export const CopilotSuggestionsProvider = ({
       }
     }
 
+    const outdatedIds: string[] = [];
+
     for (const suggestion of suggestions) {
       // Only apply pending instruction suggestions.
       if (
@@ -266,8 +268,12 @@ export const CopilotSuggestionsProvider = ({
         appliedSuggestionsRef.current.add(suggestion.sId);
       } else {
         // Text no longer matches - mark as outdated.
-        void patchSuggestions([suggestion.sId], "outdated");
+        outdatedIds.push(suggestion.sId);
       }
+    }
+
+    if (outdatedIds.length > 0) {
+      void patchSuggestions(outdatedIds, "outdated");
     }
   }, [suggestions, isSuggestionsLoading, isEditorReady, patchSuggestions]);
 


### PR DESCRIPTION
Closes: https://github.com/dust-tt/tasks/issues/6174

## Description

As suggested in [original issue](https://github.com/dust-tt/tasks/issues/6174), my first approach was to mark all overlapping instructions suggestions as outdated every time a new instruction suggestion was created.
But it turns out that copilot can make multiple suggestions that can be applied on the same original chunk of text. 

Approach I opted for:
- Mark instructions suggestions as outdated if they can't be applied in the editor.
- Remove addition/deletion marks of outdated suggestions in the editor.

## Tests



## Risk


## Deploy Plan

