### PR TITLE
feat: add rename functionality for project files

### DIFF
--- a/front/components/assistant/conversation/space/RenameFileDialog.tsx
+++ b/front/components/assistant/conversation/space/RenameFileDialog.tsx
@@ -1,0 +1,126 @@
+import {
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Input,
+} from "@dust-tt/sparkle";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+import type { ProjectFileType } from "@app/lib/swr/projects";
+import { useRenameProjectFile } from "@app/lib/swr/projects";
+import type { LightWorkspaceType } from "@app/types";
+
+function splitFileName(fileName: string): {
+  baseName: string;
+  extension: string;
+} {
+  const lastDotIndex = fileName.lastIndexOf(".");
+  if (lastDotIndex === -1 || lastDotIndex === 0) {
+    return { baseName: fileName, extension: "" };
+  }
+  return {
+    baseName: fileName.slice(0, lastDotIndex),
+    extension: fileName.slice(lastDotIndex),
+  };
+}
+
+interface RenameFileDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onRenamed: () => void;
+  owner: LightWorkspaceType;
+  file: ProjectFileType | null;
+}
+
+export function RenameFileDialog({
+  isOpen,
+  onClose,
+  onRenamed,
+  owner,
+  file,
+}: RenameFileDialogProps) {
+  const [baseName, setBaseName] = useState<string>("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const renameFile = useRenameProjectFile({ owner });
+
+  const extension = useMemo(() => {
+    if (!file) {
+      return "";
+    }
+    return splitFileName(file.fileName).extension;
+  }, [file]);
+
+  useEffect(() => {
+    if (isOpen && file) {
+      const { baseName: initialBaseName } = splitFileName(file.fileName);
+      setBaseName(initialBaseName);
+      setTimeout(() => {
+        inputRef.current?.focus();
+        inputRef.current?.select();
+      }, 0);
+    }
+  }, [isOpen, file]);
+
+  const handleRename = useCallback(async () => {
+    if (!file || !baseName.trim()) {
+      return;
+    }
+    const newFileName = baseName.trim() + extension;
+    const result = await renameFile(file.sId, newFileName);
+    if (result.isOk()) {
+      onRenamed();
+      onClose();
+    }
+  }, [file, baseName, extension, renameFile, onRenamed, onClose]);
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Rename file</DialogTitle>
+        </DialogHeader>
+        <DialogContainer>
+          <div className="flex items-center gap-1">
+            <Input
+              ref={inputRef}
+              placeholder="Enter new file name..."
+              value={baseName}
+              onChange={(e) => setBaseName(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  void handleRename();
+                }
+              }}
+            />
+            {extension && (
+              <span className="text-sm text-muted-foreground">{extension}</span>
+            )}
+          </div>
+        </DialogContainer>
+        <DialogFooter
+          rightButtonProps={{
+            label: "Rename",
+            variant: "primary",
+            onClick: handleRename,
+            disabled: !baseName.trim(),
+          }}
+          leftButtonProps={{
+            label: "Cancel",
+            variant: "outline",
+          }}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/front/lib/swr/projects.ts
+++ b/front/lib/swr/projects.ts
@@ -7,24 +7,15 @@ import {
   getErrorFromResponse,
   useSWRWithDefaults,
 } from "@app/lib/swr/swr";
-import type { GetProjectFilesResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/project_files";
 import type {
-  FileTypeWithMetadata,
-  LightWorkspaceType,
-  Result,
-} from "@app/types";
+  GetProjectFilesResponseBody,
+  ProjectFileType,
+} from "@app/pages/api/w/[wId]/spaces/[spaceId]/project_files";
+import type { LightWorkspaceType, Result } from "@app/types";
 import { normalizeError } from "@app/types";
 import { Err, Ok } from "@app/types";
 
-export type ProjectFileType = FileTypeWithMetadata & {
-  createdAt: number;
-  updatedAt: number;
-  user: {
-    sId: string;
-    name: string | null;
-    imageUrl: string | null;
-  } | null;
-};
+export type { ProjectFileType };
 
 export function useProjectFiles({
   owner,
@@ -80,6 +71,53 @@ export function useDeleteProjectFile({ owner }: { owner: LightWorkspaceType }) {
       sendNotification({
         type: "error",
         title: "Failed to delete file",
+        description: errorMessage,
+      });
+      return new Err(new Error(errorMessage));
+    }
+  };
+}
+
+export function useRenameProjectFile({ owner }: { owner: LightWorkspaceType }) {
+  const sendNotification = useSendNotification();
+
+  return async (
+    fileId: string,
+    fileName: string
+  ): Promise<Result<void, Error>> => {
+    try {
+      const res = await clientFetch(
+        `/api/w/${owner.sId}/files/${fileId}/rename`,
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ fileName }),
+        }
+      );
+
+      if (!res.ok) {
+        const errorData = await getErrorFromResponse(res);
+        sendNotification({
+          type: "error",
+          title: "Failed to rename file",
+          description: errorData.message,
+        });
+        return new Err(new Error(errorData.message));
+      }
+
+      sendNotification({
+        type: "success",
+        title: `File renamed to "${fileName}"`,
+      });
+
+      return new Ok(undefined);
+    } catch (e) {
+      const errorMessage = normalizeError(e).message;
+      sendNotification({
+        type: "error",
+        title: "Failed to rename file",
         description: errorMessage,
       });
       return new Err(new Error(errorMessage));

--- a/front/pages/api/w/[wId]/files/[fileId]/rename.test.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/rename.test.ts
@@ -1,0 +1,333 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { FeatureFlagFactory } from "@app/tests/utils/FeatureFlagFactory";
+import { FileFactory } from "@app/tests/utils/FileFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+
+import handler from "./rename";
+
+// Mock FileStorage to avoid GCS calls
+vi.mock("@app/lib/file_storage", () => {
+  const createMockGCSFile = () => ({
+    createReadStream: vi.fn().mockReturnValue({
+      on: vi.fn().mockImplementation(function (this: any) {
+        return this;
+      }),
+      pipe: vi.fn(),
+    }),
+    getSignedUrl: vi.fn().mockResolvedValue(["https://signed-url.test"]),
+    createWriteStream: vi.fn().mockReturnValue({
+      on: vi.fn().mockImplementation(function (
+        this: any,
+        event: string,
+        cb: any
+      ) {
+        if (event === "finish") {
+          // eslint-disable-next-line @typescript-eslint/no-implied-eval
+          setImmediate(cb);
+        }
+        return this;
+      }),
+      write: vi.fn(),
+      end: vi.fn(),
+    }),
+    delete: vi.fn().mockResolvedValue(undefined),
+    publicUrl: vi.fn().mockReturnValue("https://public-url.test"),
+  });
+
+  const createMockFileStorage = () => ({
+    file: vi.fn(createMockGCSFile),
+    getSignedUrl: vi.fn().mockResolvedValue("https://signed-url.test"),
+    uploadFileToBucket: vi.fn().mockResolvedValue(undefined),
+    uploadRawContentToBucket: vi.fn().mockResolvedValue(undefined),
+    fetchFileContent: vi.fn().mockResolvedValue("mock content"),
+    delete: vi.fn().mockResolvedValue(undefined),
+  });
+
+  return {
+    FileStorage: vi.fn().mockImplementation(createMockFileStorage),
+    getPrivateUploadBucket: vi.fn(createMockFileStorage),
+    getPublicUploadBucket: vi.fn(createMockFileStorage),
+    getUpsertQueueBucket: vi.fn(createMockFileStorage),
+  };
+});
+
+describe("PATCH /api/w/[wId]/files/[fileId]/rename", () => {
+  it("should return 404 when file does not exist", async () => {
+    const { req, res } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "user",
+    });
+
+    req.query = {
+      ...req.query,
+      fileId: "non-existent-file",
+    };
+    req.body = { fileName: "new-name.txt" };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(404);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "file_not_found",
+        message: "File not found.",
+      },
+    });
+  });
+
+  it("should return 400 when fileName is missing", async () => {
+    const { req, res, workspace, user } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "builder",
+    });
+
+    const file = await FileFactory.create(workspace, user, {
+      contentType: "application/pdf",
+      fileName: "test.pdf",
+      fileSize: 1024,
+      status: "ready",
+      useCase: "avatar",
+    });
+
+    req.query = {
+      ...req.query,
+      fileId: file.sId,
+    };
+    req.body = {};
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "invalid_request_error",
+        message: "fileName is required and must be a non-empty string.",
+      },
+    });
+  });
+
+  it("should return 400 when fileName is empty", async () => {
+    const { req, res, workspace, user } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "builder",
+    });
+
+    const file = await FileFactory.create(workspace, user, {
+      contentType: "application/pdf",
+      fileName: "test.pdf",
+      fileSize: 1024,
+      status: "ready",
+      useCase: "avatar",
+    });
+
+    req.query = {
+      ...req.query,
+      fileId: file.sId,
+    };
+    req.body = { fileName: "   " };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "invalid_request_error",
+        message: "fileName is required and must be a non-empty string.",
+      },
+    });
+  });
+
+  it("should allow builder to rename any file", async () => {
+    const { req, res, workspace, user } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "builder",
+    });
+
+    const file = await FileFactory.create(workspace, user, {
+      contentType: "application/pdf",
+      fileName: "old-name.pdf",
+      fileSize: 1024,
+      status: "ready",
+      useCase: "avatar",
+    });
+
+    req.query = {
+      ...req.query,
+      fileId: file.sId,
+    };
+    req.body = { fileName: "new-name.pdf" };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData().file.fileName).toBe("new-name.pdf");
+  });
+
+  it("should deny non-builder from renaming non-project files", async () => {
+    const { req, res, workspace, user } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "user",
+    });
+
+    const file = await FileFactory.create(workspace, user, {
+      contentType: "application/pdf",
+      fileName: "test.pdf",
+      fileSize: 1024,
+      status: "ready",
+      useCase: "avatar",
+    });
+
+    req.query = {
+      ...req.query,
+      fileId: file.sId,
+    };
+    req.body = { fileName: "new-name.pdf" };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(403);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "workspace_auth_error",
+        message:
+          "Only users that are `builders` for the current workspace can modify files.",
+      },
+    });
+  });
+
+  describe("project_context files", () => {
+    it("should allow user with space write access to rename project files", async () => {
+      const { req, res, workspace, user } = await createPrivateApiMockRequest({
+        method: "PATCH",
+        role: "user",
+      });
+
+      // Enable the projects feature flag
+      await FeatureFlagFactory.basic("projects", workspace);
+
+      // Create a project space where the user is an editor (has write access)
+      const projectSpace = await SpaceFactory.project(workspace, user.id);
+
+      const file = await FileFactory.create(workspace, user, {
+        contentType: "application/pdf",
+        fileName: "old-name.pdf",
+        fileSize: 1024,
+        status: "ready",
+        useCase: "project_context",
+        useCaseMetadata: {
+          spaceId: projectSpace.sId,
+        },
+      });
+
+      req.query = {
+        ...req.query,
+        fileId: file.sId,
+      };
+      req.body = { fileName: "new-name.pdf" };
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+      expect(res._getJSONData().file.fileName).toBe("new-name.pdf");
+    });
+
+    it("should deny user without space write access from renaming project files", async () => {
+      const { req, res, workspace, user } = await createPrivateApiMockRequest({
+        method: "PATCH",
+        role: "user",
+      });
+
+      // Enable the projects feature flag
+      await FeatureFlagFactory.basic("projects", workspace);
+
+      // Create a regular space (user has no access)
+      const space = await SpaceFactory.regular(workspace);
+
+      const file = await FileFactory.create(workspace, user, {
+        contentType: "application/pdf",
+        fileName: "test.pdf",
+        fileSize: 1024,
+        status: "ready",
+        useCase: "project_context",
+        useCaseMetadata: {
+          spaceId: space.sId,
+        },
+      });
+
+      req.query = {
+        ...req.query,
+        fileId: file.sId,
+      };
+      req.body = { fileName: "new-name.pdf" };
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(403);
+      expect(res._getJSONData()).toEqual({
+        error: {
+          type: "workspace_auth_error",
+          message: "You cannot edit files in that space.",
+        },
+      });
+    });
+  });
+
+  it("should return 405 for unsupported methods", async () => {
+    const { req, res, workspace, user } = await createPrivateApiMockRequest({
+      method: "GET",
+      role: "builder",
+    });
+
+    // Create a file so we get past the 404 check
+    const file = await FileFactory.create(workspace, user, {
+      contentType: "application/pdf",
+      fileName: "test.pdf",
+      fileSize: 1024,
+      status: "ready",
+      useCase: "avatar",
+    });
+
+    req.query = {
+      ...req.query,
+      fileId: file.sId,
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(405);
+    expect(res._getJSONData()).toEqual({
+      error: {
+        type: "method_not_supported_error",
+        message: "The method passed is not supported, PATCH is expected.",
+      },
+    });
+  });
+
+  it("should trim whitespace from fileName", async () => {
+    const { req, res, workspace, user } = await createPrivateApiMockRequest({
+      method: "PATCH",
+      role: "builder",
+    });
+
+    const file = await FileFactory.create(workspace, user, {
+      contentType: "application/pdf",
+      fileName: "old-name.pdf",
+      fileSize: 1024,
+      status: "ready",
+      useCase: "avatar",
+    });
+
+    req.query = {
+      ...req.query,
+      fileId: file.sId,
+    };
+    req.body = { fileName: "  new-name.pdf  " };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData().file.fileName).toBe("new-name.pdf");
+  });
+});

--- a/front/pages/api/w/[wId]/files/[fileId]/rename.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/rename.ts
@@ -84,7 +84,7 @@ async function handler(
         });
       }
 
-      const { fileName } = req.body as { fileName?: string };
+      const { fileName } = req.body;
       if (!isString(fileName) || fileName.trim() === "") {
         return apiError(req, res, {
           status_code: 400,

--- a/front/pages/api/w/[wId]/files/[fileId]/rename.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/rename.ts
@@ -1,0 +1,114 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { getFeatureFlags } from "@app/lib/auth";
+import { FileResource } from "@app/lib/resources/file_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { FileType, WithAPIErrorResponse } from "@app/types";
+import { isString } from "@app/types";
+
+export type RenameFileResponseBody = {
+  file: FileType;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<RenameFileResponseBody>>,
+  auth: Authenticator
+): Promise<void> {
+  const { fileId } = req.query;
+  if (!isString(fileId)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Missing fileId query parameter.",
+      },
+    });
+  }
+
+  const file = await FileResource.fetchById(auth, fileId);
+  if (!file) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "file_not_found",
+        message: "File not found.",
+      },
+    });
+  }
+
+  // Check feature flag for project_context files
+  if (file.useCase === "project_context") {
+    const featureFlags = await getFeatureFlags(auth.getNonNullableWorkspace());
+    if (!featureFlags.includes("projects")) {
+      return apiError(req, res, {
+        status_code: 500,
+        api_error: {
+          type: "internal_server_error",
+          message: "Feature not supported",
+        },
+      });
+    }
+  }
+
+  // Get space for permission checks
+  let space: SpaceResource | null = null;
+  if (file.useCaseMetadata?.spaceId) {
+    space = await SpaceResource.fetchById(auth, file.useCaseMetadata.spaceId);
+  }
+
+  switch (req.method) {
+    case "PATCH": {
+      // Check permissions for renaming
+      if (file.useCase === "project_context") {
+        if (!space || !space.canWrite(auth)) {
+          return apiError(req, res, {
+            status_code: 403,
+            api_error: {
+              type: "workspace_auth_error",
+              message: "You cannot edit files in that space.",
+            },
+          });
+        }
+      } else if (!auth.isBuilder()) {
+        return apiError(req, res, {
+          status_code: 403,
+          api_error: {
+            type: "workspace_auth_error",
+            message:
+              "Only users that are `builders` for the current workspace can modify files.",
+          },
+        });
+      }
+
+      const { fileName } = req.body as { fileName?: string };
+      if (!isString(fileName) || fileName.trim() === "") {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "fileName is required and must be a non-empty string.",
+          },
+        });
+      }
+
+      await file.rename(fileName.trim());
+
+      return res.status(200).json({ file: file.toJSON(auth) });
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, PATCH is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);


### PR DESCRIPTION


https://github.com/user-attachments/assets/1b7f53b8-d7e8-45f3-81fb-ef12708cedef



## Description
Add ability to rename files in the project knowledge tab.

- New PATCH endpoint at `/api/w/[wId]/files/[fileId]/rename` (because main file endpoint disable body parsing)
- `RenameFileDialog` component with extension preservation
- `useRenameProjectFile` hook following existing SWR patterns

## Tests
- [x] Upload a file to a project's knowledge tab
- [x] Click the "..." menu and select "Rename"
- [x] Verify the dialog shows the current filename (without extension)
- [x] Rename the file and verify it updates in the list

## Risk
low

## Deploy plan
front