### PR TITLE
Remove legacy raw_contents from AgentMessageType

### DIFF
--- a/front/lib/api/assistant/conversation_rendering/message_rendering.test.ts
+++ b/front/lib/api/assistant/conversation_rendering/message_rendering.test.ts
@@ -116,7 +116,6 @@ describe("renderAllMessages", () => {
             } as AgentMessageType["configuration"],
             skipToolsValidation: false,
             actions: [],
-            rawContents: [],
             contents: [],
             parsedContents: {},
             modelInteractionDurationMs: null,

--- a/front/lib/api/assistant/conversation_rendering/message_rendering.ts
+++ b/front/lib/api/assistant/conversation_rendering/message_rendering.ts
@@ -117,29 +117,6 @@ export function renderAgentSteps(
     }
   }
 
-  // Legacy agent message support
-  if (!message.rawContents.length && message.content?.trim()) {
-    // This should not happen anymore, putting logs to check if anything goes wrong.
-    logger.error(
-      {
-        workspaceId: conversation.owner.sId,
-        conversationId: conversation.sId,
-        agentMessageId: message.sId,
-      },
-      "Unexpected legacy agent message state, agent message with empty `rawContents` and non-empty `content`"
-    );
-    messages.push({
-      role: "assistant",
-      name: message.configuration.name,
-      contents: [
-        {
-          type: "text_content",
-          value: message.content,
-        },
-      ],
-    });
-  }
-
   return messages;
 }
 

--- a/front/lib/api/assistant/messages.ts
+++ b/front/lib/api/assistant/messages.ts
@@ -624,10 +624,6 @@ async function batchRenderAgentMessages<V extends RenderMessageVariant>(
         actions,
         content,
         chainOfThought,
-        rawContents: textContents.map((c) => ({
-          step: c.step,
-          content: c.content.value,
-        })),
         contents: agentStepContents,
         parsedContents,
         error,

--- a/front/lib/api/v1/backward_compatibility.ts
+++ b/front/lib/api/v1/backward_compatibility.ts
@@ -1,0 +1,186 @@
+// eslint-disable-next-line dust/enforce-client-types-in-public-api -- We are in a backward compatibility layer
+import type {
+  AgentMessagePublicType,
+  ConversationPublicType,
+  ConversationWithoutContentPublicType,
+} from "@dust-tt/client";
+
+import config from "@app/lib/api/config";
+import type { Authenticator } from "@app/lib/auth";
+import { getConversationRoute } from "@app/lib/utils/router";
+import type { AgentsGetViewType, ContentFragmentType } from "@app/types";
+import { isArrayOf, isContentFragmentType } from "@app/types";
+import type {
+  AgentMessageType,
+  ConversationType,
+  ConversationVisibility,
+  ConversationWithoutContentType,
+  MessageType,
+  UserMessageType,
+} from "@app/types/assistant/conversation";
+import {
+  isAgentMessageType,
+  isUserMessageType,
+} from "@app/types/assistant/conversation";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+
+/**
+ * Normalizes deprecated visibility values to their current equivalents.
+ * The "workspace" visibility value is deprecated and should be treated as "unlisted".
+ *
+ * @param visibility - The visibility value (may be deprecated)
+ * @returns The normalized visibility value (defaults to "unlisted" if undefined)
+ */
+export function normalizeConversationVisibility(
+  visibility: ConversationVisibility | "workspace" | undefined
+): ConversationVisibility {
+  // Temporary translation layer for deprecated "workspace" visibility.
+  if (visibility === "workspace") {
+    return "unlisted";
+  }
+  return visibility ?? "unlisted";
+}
+
+/**
+ * Normalizes deprecated agent view values to their current equivalents.
+ * The "workspace" view is deprecated and should be treated as "published".
+ *
+ * @param view - The agent view value (may be deprecated)
+ * @returns The normalized view value
+ */
+export function normalizeAgentView(
+  view: AgentsGetViewType | "workspace"
+): AgentsGetViewType {
+  // workspace is deprecated, return all visible agents
+  if (view === "workspace") {
+    return "published";
+  }
+  return view;
+}
+
+/**
+ * Adds backward-compatible fields to a conversation without content response.
+ * These fields are maintained for API backward compatibility with older SDK versions.
+ *
+ * @param conversation - The conversation object
+ * @param auth - The authenticator to get workspace info
+ * @returns The conversation with backward-compatible fields added
+ */
+export function addBackwardCompatibleConversationWithoutContentFields(
+  auth: Authenticator,
+  conversation: ConversationWithoutContentType
+): ConversationWithoutContentPublicType {
+  return {
+    ...conversation,
+    // Remove once all old SDKs users are updated
+    requestedGroupIds: [],
+    // These properties are excluded from ConversationWithoutContentType used internally
+    // but are still returned for the public API to stay backward compatible.
+    visibility: "unlisted" as ConversationVisibility, // Hardcoded as "deleted" conversations are not returned by the API
+    owner: auth.getNonNullableWorkspace(),
+  };
+}
+
+export function addBackwardCompatibleConversationFields(
+  conversation: ConversationType
+): ConversationPublicType {
+  return {
+    ...conversation,
+    requestedGroupIds: [],
+    content: conversation.content.map((c) => {
+      if (c.length === 0) {
+        return [];
+      } else if (
+        isArrayOf<MessageType, AgentMessageType>(c, isAgentMessageType)
+      ) {
+        return c.map((m) => addBackwardCompatibleAgentMessageFields(m));
+      } else if (
+        isArrayOf<MessageType, UserMessageType>(c, isUserMessageType)
+      ) {
+        return c.map((m) => m);
+      } else if (
+        isArrayOf<MessageType, ContentFragmentType>(c, isContentFragmentType)
+      ) {
+        return c.map((m) => m);
+      }
+      assertNever(c[0]);
+    }),
+    url: getConversationRoute(
+      conversation.owner.sId,
+      conversation.sId,
+      undefined,
+      config.getClientFacingUrl()
+    ),
+  };
+}
+
+// Legacy method to get the raw contents of an agent message, only for the public API backward compatibility.
+function getRawContents(msg: AgentMessageType): Array<{
+  step: number;
+  content: string;
+}> {
+  const rawContents: Array<{
+    step: number;
+    content: string;
+  }> = [];
+  for (const c of msg.contents) {
+    if (c.content.type === "text_content") {
+      rawContents.push({
+        step: c.step,
+        content: c.content.value,
+      });
+    }
+  }
+  return rawContents;
+}
+
+export function addBackwardCompatibleAgentMessageFields(
+  agentMessage: AgentMessageType
+): AgentMessagePublicType {
+  return {
+    ...agentMessage,
+    rawContents: getRawContents(agentMessage),
+  };
+}
+
+/**
+ * Adds backward-compatible fields to a full conversation response (with content).
+ * These fields are maintained for API backward compatibility with older SDK versions.
+ *
+ * @param conversation - The conversation object with content
+ * @returns The conversation with backward-compatible fields added
+ */
+export function addBackwardCompatibleFullConversationFields(
+  conversation: ConversationType & { url?: string }
+): ConversationType & {
+  url?: string;
+  requestedGroupIds: never[];
+} {
+  return {
+    ...conversation,
+    // Remove once all old SDKs users are updated
+    requestedGroupIds: [],
+  };
+}
+
+/**
+ * Adds backward-compatible fields to agent configuration responses.
+ * These fields are maintained for API backward compatibility with older SDK versions.
+ *
+ * @param agentConfiguration - The agent configuration object
+ * @returns The agent configuration with backward-compatible fields added
+ */
+export function addBackwardCompatibleAgentConfigurationFields<
+  T extends Record<string, unknown>,
+>(
+  agentConfiguration: T
+): T & {
+  requestedGroupIds: never[];
+  requestedSpaceIds: never[];
+} {
+  return {
+    ...agentConfiguration,
+    requestedGroupIds: [],
+    requestedSpaceIds: [],
+  };
+}

--- a/front/lib/swr/conversations.ts
+++ b/front/lib/swr/conversations.ts
@@ -123,7 +123,7 @@ export function useSpaceConversationsSummary({
   };
 }
 
-const DEFAULT_CONVERSATIONS_PAGE_SIZE = 20;
+const DEFAULT_CONVERSATIONS_PAGE_SIZE = 12;
 
 export function useSpaceConversations({
   workspaceId,

--- a/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
@@ -202,7 +202,6 @@ async function handler(
         configuration: agentConfiguration,
         skipToolsValidation: false,
         actions: [],
-        rawContents: [],
         contents: [],
         parsedContents: {},
         modelInteractionDurationMs: null,

--- a/front/pages/api/v1/w/[wId]/assistant/agent_configurations.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/agent_configurations.ts
@@ -7,6 +7,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
 import { getAgentsRecentAuthors } from "@app/lib/api/assistant/recent_authors";
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
+import { normalizeAgentView } from "@app/lib/api/v1/backward_compatibility";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
@@ -129,10 +130,7 @@ async function handler(
 
       let agentConfigurations = await getAgentConfigurationsForView({
         auth,
-        agentsGetView:
-          agentsGetView === "workspace"
-            ? "published" // workspace is deprecated, return all visible agents
-            : agentsGetView,
+        agentsGetView: normalizeAgentView(agentsGetView),
         variant: "light",
       });
 

--- a/front/pages/api/v1/w/[wId]/assistant/agent_configurations/search.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/agent_configurations/search.ts
@@ -3,6 +3,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import { searchAgentConfigurationsByName } from "@app/lib/api/assistant/configuration/agent";
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
+import { addBackwardCompatibleAgentConfigurationFields } from "@app/lib/api/v1/backward_compatibility";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
@@ -78,11 +79,9 @@ async function handler(
         q
       );
       return res.status(200).json({
-        agentConfigurations: agentConfigurations.map((agentConfiguration) => ({
-          ...agentConfiguration,
-          requestedGroupIds: [],
-          requestedSpaceIds: [],
-        })),
+        agentConfigurations: agentConfigurations.map((agentConfiguration) =>
+          addBackwardCompatibleAgentConfigurationFields(agentConfiguration)
+        ),
       });
     }
     default:

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/events.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/events.ts
@@ -4,6 +4,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { getConversationEvents } from "@app/lib/api/assistant/pubsub";
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
+import { addBackwardCompatibleAgentMessageFields } from "@app/lib/api/v1/backward_compatibility";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import logger from "@app/logger/logger";
@@ -113,17 +114,38 @@ async function handler(
         controller.abort();
       });
 
-      const eventStream: AsyncGenerator<ConversationEventType> =
-        getConversationEvents({
-          conversationId: conversation.sId,
-          lastEventId,
-          signal,
-        });
+      const eventStream = getConversationEvents({
+        conversationId: conversation.sId,
+        lastEventId,
+        signal,
+      });
 
       let backpressureCount = 0;
 
       for await (const event of eventStream) {
-        const writeSuccessful = res.write(`data: ${JSON.stringify(event)}\n\n`);
+        let publicEvent: ConversationEventType | undefined;
+
+        if (event.data.type === "agent_message_new") {
+          publicEvent = {
+            eventId: event.eventId,
+            data: {
+              ...event.data,
+              message: {
+                ...event.data.message,
+                ...addBackwardCompatibleAgentMessageFields(event.data.message),
+              },
+            },
+          };
+        } else {
+          publicEvent = {
+            eventId: event.eventId,
+            data: event.data,
+          };
+        }
+
+        const writeSuccessful = res.write(
+          `data: ${JSON.stringify(publicEvent)}\n\n`
+        );
         if (!writeSuccessful) {
           backpressureCount++;
           statsDClient.increment("streaming.backpressure.count", 1, [

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/index.ts
@@ -6,6 +6,7 @@ import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
+import { addBackwardCompatibleFullConversationFields } from "@app/lib/api/v1/backward_compatibility";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { getConversationRoute } from "@app/lib/utils/router";
@@ -136,7 +137,7 @@ async function handler(
   switch (req.method) {
     case "GET": {
       return res.status(200).json({
-        conversation: {
+        conversation: addBackwardCompatibleFullConversationFields({
           ...conversation,
           url: getConversationRoute(
             conversation.owner.sId,
@@ -144,8 +145,7 @@ async function handler(
             undefined,
             config.getClientFacingUrl()
           ),
-          requestedGroupIds: [], // Remove once all old SDKs users are updated
-        },
+        }) as GetConversationResponseType["conversation"],
       });
     }
 

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/edit.ts
@@ -7,6 +7,7 @@ import { editUserMessage } from "@app/lib/api/assistant/conversation";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
+import { addBackwardCompatibleAgentMessageFields } from "@app/lib/api/v1/backward_compatibility";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
@@ -162,7 +163,10 @@ async function handler(
 
       res.status(200).json({
         message: editedMessageRes.value.userMessage,
-        agentMessages: editedMessageRes.value.agentMessages ?? undefined,
+        agentMessages:
+          editedMessageRes.value.agentMessages.map(
+            addBackwardCompatibleAgentMessageFields
+          ) ?? undefined,
       });
       return;
 

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/retry.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/[mId]/retry.ts
@@ -8,6 +8,7 @@ import { retryAgentMessage } from "@app/lib/api/assistant/conversation";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
+import { addBackwardCompatibleAgentMessageFields } from "@app/lib/api/v1/backward_compatibility";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types";
@@ -100,7 +101,11 @@ async function handler(
         return apiError(req, res, retriedMessageRes.error);
       }
 
-      res.status(200).json({ message: retriedMessageRes.value });
+      res.status(200).json({
+        message: addBackwardCompatibleAgentMessageFields(
+          retriedMessageRes.value
+        ),
+      });
       return;
 
     default:

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/[cId]/messages/index.ts
@@ -19,6 +19,7 @@ import {
   checkProgrammaticUsageLimits,
   isProgrammaticUsage,
 } from "@app/lib/api/programmatic_usage/tracking";
+import { addBackwardCompatibleAgentMessageFields } from "@app/lib/api/v1/backward_compatibility";
 import type { Authenticator } from "@app/lib/auth";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
@@ -256,7 +257,9 @@ async function handler(
 
       res.status(200).json({
         message: messageRes.value.userMessage,
-        agentMessages: messageRes.value.agentMessages,
+        agentMessages: messageRes.value.agentMessages.map(
+          addBackwardCompatibleAgentMessageFields
+        ),
       });
       return;
 

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -26,6 +26,11 @@ import {
   checkProgrammaticUsageLimits,
   isProgrammaticUsage,
 } from "@app/lib/api/programmatic_usage/tracking";
+import {
+  addBackwardCompatibleConversationWithoutContentFields,
+  addBackwardCompatibleFullConversationFields,
+  normalizeConversationVisibility,
+} from "@app/lib/api/v1/backward_compatibility";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -295,8 +300,7 @@ async function handler(
 
       let conversation = await createConversation(auth, {
         title: title ?? null,
-        // Temporary translation layer for deprecated "workspace" visibility.
-        visibility: visibility === "workspace" ? "unlisted" : visibility,
+        visibility: normalizeConversationVisibility(visibility),
         depth,
         spaceId: null,
       });
@@ -475,7 +479,7 @@ async function handler(
       }
 
       res.status(200).json({
-        conversation: {
+        conversation: addBackwardCompatibleFullConversationFields({
           ...conversation,
           url: getConversationRoute(
             conversation.owner.sId,
@@ -483,8 +487,7 @@ async function handler(
             undefined,
             config.getClientFacingUrl()
           ),
-          requestedGroupIds: [], // Remove once all old SDKs users are updated
-        },
+        }) as PostConversationsResponseType["conversation"],
         message: newMessage ?? undefined,
         contentFragment: newContentFragment ?? undefined,
       });
@@ -503,17 +506,12 @@ async function handler(
       const conversations =
         await ConversationResource.listConversationsForUser(auth);
       res.status(200).json({
-        conversations: conversations.map((c) => ({
-          ...c.toJSON(),
-
-          // Theses 2 properties are excluded from the ConversationWithoutContentType used internally (as they are not needed anywhere).
-          // They are still returned for the public API to stay backward compatible.
-          visibility: "unlisted", // Hardcoded as "deleted" conversations are not returned by the API
-          owner: auth.getNonNullableWorkspace(),
-
-          // This one is no excluded (yet)
-          requestedGroupIds: [], // No need to leak to the public API. Hardcoded as an empty array. Can be removed once the chrome extension is updated.
-        })),
+        conversations: conversations.map((c) =>
+          addBackwardCompatibleConversationWithoutContentFields(
+            auth,
+            c.toJSON()
+          )
+        ),
       });
       return;
 

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/conversations/index.ts
@@ -4,6 +4,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
 import config from "@app/lib/api/config";
+import { addBackwardCompatibleConversationFields } from "@app/lib/api/v1/backward_compatibility";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -125,7 +126,9 @@ async function handler(
       );
 
       return res.status(200).json({
-        conversations: responseConversations,
+        conversations: responseConversations.map(
+          addBackwardCompatibleConversationFields
+        ),
       });
     }
 

--- a/front/temporal/agent_loop/lib/loop_utils.ts
+++ b/front/temporal/agent_loop/lib/loop_utils.ts
@@ -64,10 +64,6 @@ export function sliceConversationForAgentMessage(
     (content) => content.step < step
   );
 
-  slicedAgentMessage.rawContents = slicedAgentMessage.rawContents.filter(
-    (content) => content.step < step
-  );
-
   slicedAgentMessage.actions = slicedAgentMessage.actions.filter(
     (action) => action.step < step
   );

--- a/front/tests/utils/ConversationFactory.ts
+++ b/front/tests/utils/ConversationFactory.ts
@@ -292,7 +292,6 @@ export class ConversationFactory {
       configuration: agentConfig,
       skipToolsValidation: false,
       actions: [],
-      rawContents: [],
       contents: [],
       parsedContents: {},
       reactions: [],

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -8,6 +8,7 @@ import type {
   RichMention,
 } from "@app/types";
 import type { AgentMCPActionWithOutputType } from "@app/types/actions";
+import type { AgentContentItemType } from "@app/types/assistant/agent_message_content";
 
 import type { UserType, WorkspaceType } from "../user";
 import type {
@@ -15,7 +16,6 @@ import type {
   GenericErrorContent,
   LightAgentConfigurationType,
 } from "./agent";
-import type { AgentContentItemType } from "./agent_message_content";
 
 export type MessageVisibility = "visible" | "deleted";
 
@@ -233,10 +233,6 @@ export type AgentMessageType = BaseAgentMessageType & {
   configuration: LightAgentConfigurationType;
   skipToolsValidation: boolean;
   actions: AgentMCPActionWithOutputType[];
-  rawContents: Array<{
-    step: number;
-    content: string;
-  }>;
   contents: Array<{ step: number; content: AgentContentItemType }>;
   parsedContents: Record<number, Array<ParsedContentItem>>;
   modelInteractionDurationMs: number | null;

--- a/front/types/shared/typescipt_utils.ts
+++ b/front/types/shared/typescipt_utils.ts
@@ -11,3 +11,10 @@ export type RequireAtLeastOne<T, Keys extends keyof T = keyof T> = Pick<
   {
     [K in Keys]-?: Required<Pick<T, K>> & Partial<Pick<T, Exclude<Keys, K>>>;
   }[Keys];
+
+export function isArrayOf<U, T extends U>(
+  value: U[],
+  itemChecker: (item: U) => item is T
+): value is T[] {
+  return Array.isArray(value) && value.every(itemChecker);
+}


### PR DESCRIPTION
## Description

On my way to remove bloat from the AgentMessageType.
This removes the legacy "rawContents" from the private `AgentMessageType`. Added a compatibility layer for the public api.

This [task](https://github.com/dust-tt/tasks/issues/3623) actually.

## Tests

Local + TS.

## Risk

Low, i doubt anyone is really using it.

## Deploy Plan

Deploy front