### PR TITLE
Onb dupli welcome

### DIFF
--- a/front/pages/w/[wId]/verify.tsx
+++ b/front/pages/w/[wId]/verify.tsx
@@ -171,7 +171,7 @@ function Verify() {
         return;
       }
 
-      void router.push(`/w/${workspace.sId}/welcome`);
+      void router.push(`/w/${workspace.sId}/conversation/new?welcome=true`);
     } catch {
       setPhoneError("Network error. Please try again.");
     } finally {

--- a/front/pages/w/[wId]/welcome.tsx
+++ b/front/pages/w/[wId]/welcome.tsx
@@ -227,6 +227,7 @@ function FavoritePlatformsStep({
         <Button
           label="Next"
           disabled={isSubmitting}
+          isLoading={isSubmitting}
           size="sm"
           onClick={onSubmit}
         />
@@ -263,6 +264,7 @@ function FavoritePlatformsStep({
         <div className="flex justify-end">
           <Button
             label="Next"
+            isLoading={isSubmitting}
             disabled={isSubmitting}
             size="md"
             onClick={onSubmit}


### PR DESCRIPTION
## Description

Fix duplicate /welcome page visit during trial onboarding flow.
After signup, users going through the trial flow were seeing the `/welcome` page twice: once after signup to fill their
profile, and again after phone verification (redundant since profile was already filled).

**Before:**
Signup → /welcome → /trial → /verify → /welcome (again!) → /conversation

**After:**
Signup → /welcome → /trial → /verify → /conversation

After successful phone verification, we now redirect users directly to `/conversation/new?welcome=true` instead of `/welcome`. This matches the existing payment flow behavior and the `welcome=true` param still triggers the onboarding conversation creation.

## Tests

- [x] Sign up as a new user eligible for trial
- [x] Fill out the welcome form (name, job type)
- [x] Get redirected to trial page, click "Start free trial"
- [x] Complete phone verification
- [x] Verify you land directly in a conversation (not /welcome again)
- [x] Verify the onboarding conversation is created

## Risk

Break onboarding. 
Can be rolled back. 

## Deploy Plan

Deploy front. 