### PR TITLE
[front] Allow MCP connections to reference credentials

### DIFF
--- a/front/lib/actions/mcp_authentication.ts
+++ b/front/lib/actions/mcp_authentication.ts
@@ -34,6 +34,21 @@ export async function getConnectionForMCPServer(
     connectionType,
   });
   if (connection.isOk()) {
+    if (!connection.value.connectionId) {
+      logger.info(
+        {
+          workspaceId: auth.getNonNullableWorkspace().sId,
+          mcpServerId,
+          connectionType,
+          connectionId: connection.value.connectionId,
+          credentialId: connection.value.credentialId,
+        },
+        "MCP server connection is not configured for OAuth"
+      );
+      return new Err(
+        new DustError("connection_not_found", "Connection not found")
+      );
+    }
     const token = await getOAuthConnectionAccessToken({
       config: apiConfig.getOAuthAPIConfig(),
       logger,

--- a/front/lib/api/oauth/mcp_server_connection_auth.ts
+++ b/front/lib/api/oauth/mcp_server_connection_auth.ts
@@ -33,6 +33,46 @@ export async function getWorkspaceMCPServerAuthRef(
   {
     mode,
   }: {
+    mode: "oauth";
+  }
+): Promise<
+  Result<
+    { authType: "oauth"; connectionId: string },
+    WorkspaceMCPServerAuthRefError
+  >
+>;
+
+export async function getWorkspaceMCPServerAuthRef(
+  auth: Authenticator,
+  mcpServerId: string,
+  {
+    mode,
+  }: {
+    mode: "credentials";
+  }
+): Promise<
+  Result<
+    { authType: "credentials"; credentialId: string },
+    WorkspaceMCPServerAuthRefError
+  >
+>;
+
+export async function getWorkspaceMCPServerAuthRef(
+  auth: Authenticator,
+  mcpServerId: string,
+  {
+    mode,
+  }: {
+    mode: "any";
+  }
+): Promise<Result<MCPServerConnectionAuthRef, WorkspaceMCPServerAuthRefError>>;
+
+export async function getWorkspaceMCPServerAuthRef(
+  auth: Authenticator,
+  mcpServerId: string,
+  {
+    mode,
+  }: {
     mode: MCPServerConnectionAuthMode;
   }
 ): Promise<Result<MCPServerConnectionAuthRef, WorkspaceMCPServerAuthRefError>> {

--- a/front/lib/api/oauth/mcp_server_connection_auth.ts
+++ b/front/lib/api/oauth/mcp_server_connection_auth.ts
@@ -33,46 +33,6 @@ export async function getWorkspaceMCPServerAuthRef(
   {
     mode,
   }: {
-    mode: "oauth";
-  }
-): Promise<
-  Result<
-    { authType: "oauth"; connectionId: string },
-    WorkspaceMCPServerAuthRefError
-  >
->;
-
-export async function getWorkspaceMCPServerAuthRef(
-  auth: Authenticator,
-  mcpServerId: string,
-  {
-    mode,
-  }: {
-    mode: "credentials";
-  }
-): Promise<
-  Result<
-    { authType: "credentials"; credentialId: string },
-    WorkspaceMCPServerAuthRefError
-  >
->;
-
-export async function getWorkspaceMCPServerAuthRef(
-  auth: Authenticator,
-  mcpServerId: string,
-  {
-    mode,
-  }: {
-    mode: "any";
-  }
-): Promise<Result<MCPServerConnectionAuthRef, WorkspaceMCPServerAuthRefError>>;
-
-export async function getWorkspaceMCPServerAuthRef(
-  auth: Authenticator,
-  mcpServerId: string,
-  {
-    mode,
-  }: {
     mode: MCPServerConnectionAuthMode;
   }
 ): Promise<Result<MCPServerConnectionAuthRef, WorkspaceMCPServerAuthRefError>> {
@@ -156,6 +116,12 @@ export async function getWorkspaceOAuthConnectionIdForMCPServer(
   });
   if (authRefRes.isErr()) {
     return authRefRes;
+  }
+  if (authRefRes.value.authType !== "oauth") {
+    return new Err({
+      kind: "invalid_connection",
+      message: "Workspace MCP server connection is not configured for OAuth.",
+    } satisfies WorkspaceMCPServerAuthRefError);
   }
   return new Ok(authRefRes.value.connectionId);
 }

--- a/front/lib/api/oauth/mcp_server_connection_auth.ts
+++ b/front/lib/api/oauth/mcp_server_connection_auth.ts
@@ -1,0 +1,125 @@
+import type { OAuthError } from "@app/lib/api/oauth";
+import type { Authenticator } from "@app/lib/auth";
+import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
+import type { Result } from "@app/types";
+import { Err, Ok } from "@app/types";
+
+export type MCPServerConnectionAuthMode = "oauth" | "credentials" | "any";
+
+export type MCPServerConnectionAuthRef =
+  | { authType: "oauth"; connectionId: string }
+  | { authType: "credentials"; credentialId: string };
+
+function toCredentialRetrievalError(message: string) {
+  return {
+    code: "credential_retrieval_failed" as const,
+    message,
+  } satisfies OAuthError;
+}
+
+export async function getWorkspaceMCPServerAuthRef(
+  auth: Authenticator,
+  mcpServerId: string,
+  {
+    mode,
+    oauthNotConfiguredMessage,
+    credentialsNotConfiguredMessage,
+  }: {
+    mode: MCPServerConnectionAuthMode;
+    oauthNotConfiguredMessage?: string;
+    credentialsNotConfiguredMessage?: string;
+  }
+): Promise<Result<MCPServerConnectionAuthRef, OAuthError>> {
+  const connectionRes = await MCPServerConnectionResource.findByMCPServer(
+    auth,
+    {
+      mcpServerId,
+      connectionType: "workspace",
+    }
+  );
+
+  if (connectionRes.isErr()) {
+    return new Err(
+      toCredentialRetrievalError(
+        "Failed to find MCP server connection: " + connectionRes.error.message
+      )
+    );
+  }
+
+  const hasOAuth =
+    typeof connectionRes.value.connectionId === "string" &&
+    connectionRes.value.connectionId !== "";
+  const hasCredentials =
+    typeof connectionRes.value.credentialId === "string" &&
+    connectionRes.value.credentialId !== "";
+
+  if (!hasOAuth && !hasCredentials) {
+    return new Err(
+      toCredentialRetrievalError(
+        "MCP server connection is invalid: missing auth reference."
+      )
+    );
+  }
+
+  if (mode === "oauth") {
+    if (!hasOAuth) {
+      return new Err(
+        toCredentialRetrievalError(
+          oauthNotConfiguredMessage ??
+            "Workspace MCP server connection is not configured for OAuth."
+        )
+      );
+    }
+    return new Ok({
+      authType: "oauth",
+      connectionId: connectionRes.value.connectionId!,
+    });
+  }
+
+  if (mode === "credentials") {
+    if (!hasCredentials) {
+      return new Err(
+        toCredentialRetrievalError(
+          credentialsNotConfiguredMessage ??
+            "Workspace MCP server connection is not configured for credentials."
+        )
+      );
+    }
+    return new Ok({
+      authType: "credentials",
+      credentialId: connectionRes.value.credentialId!,
+    });
+  }
+
+  // mode === "any"
+  if (hasOAuth) {
+    return new Ok({
+      authType: "oauth",
+      connectionId: connectionRes.value.connectionId!,
+    });
+  }
+
+  return new Ok({
+    authType: "credentials",
+    credentialId: connectionRes.value.credentialId!,
+  });
+}
+
+export async function getWorkspaceOAuthConnectionIdForMCPServer(
+  auth: Authenticator,
+  mcpServerId: string,
+  {
+    oauthNotConfiguredMessage,
+  }: {
+    oauthNotConfiguredMessage?: string;
+  } = {}
+): Promise<Result<string, OAuthError>> {
+  const authRefRes = await getWorkspaceMCPServerAuthRef(auth, mcpServerId, {
+    mode: "oauth",
+    oauthNotConfiguredMessage,
+  });
+  if (authRefRes.isErr()) {
+    return authRefRes;
+  }
+  return new Ok(authRefRes.value.connectionId);
+}

--- a/front/lib/api/oauth/mcp_server_connection_auth.ts
+++ b/front/lib/api/oauth/mcp_server_connection_auth.ts
@@ -2,6 +2,7 @@ import type { Authenticator } from "@app/lib/auth";
 import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
 import type { Result } from "@app/types";
 import { Err, Ok } from "@app/types";
+import { isString } from "@app/types/shared/utils/general";
 
 export type WorkspaceMCPServerAuthRefError =
   | {
@@ -38,9 +39,9 @@ export async function getWorkspaceOAuthConnectionIdForMCPServer(
   }
 
   const hasAnyAuthRef =
-    (typeof connectionRes.value.connectionId === "string" &&
+    (isString(connectionRes.value.connectionId) &&
       connectionRes.value.connectionId !== "") ||
-    (typeof connectionRes.value.credentialId === "string" &&
+    (isString(connectionRes.value.credentialId) &&
       connectionRes.value.credentialId !== "");
 
   if (!hasAnyAuthRef) {
@@ -51,7 +52,7 @@ export async function getWorkspaceOAuthConnectionIdForMCPServer(
   }
 
   const connectionId = connectionRes.value.connectionId;
-  if (!connectionId) {
+  if (!isString(connectionId) || connectionId === "") {
     return new Err({
       kind: "oauth_not_configured",
       message: "Workspace MCP server connection is not configured for OAuth.",

--- a/front/lib/api/oauth/providers/databricks.ts
+++ b/front/lib/api/oauth/providers/databricks.ts
@@ -3,6 +3,7 @@ import querystring from "querystring";
 
 import config from "@app/lib/api/config";
 import type { OAuthError } from "@app/lib/api/oauth";
+import { getWorkspaceOAuthConnectionIdForMCPServer } from "@app/lib/api/oauth/mcp_server_connection_auth";
 import type {
   BaseOAuthStrategyProvider,
   RelatedCredential,
@@ -12,7 +13,6 @@ import {
   getStringFromQuery,
 } from "@app/lib/api/oauth/utils";
 import type { Authenticator } from "@app/lib/auth";
-import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
 import logger from "@app/logger/logger";
 import type { ExtraConfigType } from "@app/pages/w/[wId]/oauth/[provider]/setup";
 import type { Result } from "@app/types";
@@ -102,32 +102,15 @@ export class DatabricksOAuthProvider implements BaseOAuthStrategyProvider {
       const { mcp_server_id } = extraConfig;
 
       if (mcp_server_id) {
-        const mcpServerConnectionRes =
-          await MCPServerConnectionResource.findByMCPServer(auth, {
-            mcpServerId: mcp_server_id,
-            connectionType: "workspace",
-          });
-
-        if (mcpServerConnectionRes.isErr()) {
-          return new Err({
-            code: "credential_retrieval_failed",
-            message:
-              "Failed to find MCP server connection: " +
-              mcpServerConnectionRes.error.message,
-          });
-        }
-
-        if (!mcpServerConnectionRes.value.connectionId) {
-          return new Err({
-            code: "credential_retrieval_failed",
-            message:
-              "Workspace MCP server connection is not configured for OAuth.",
-          });
+        const oauthConnectionIdRes =
+          await getWorkspaceOAuthConnectionIdForMCPServer(auth, mcp_server_id);
+        if (oauthConnectionIdRes.isErr()) {
+          return new Err(oauthConnectionIdRes.error);
         }
 
         const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
         const connectionRes = await oauthApi.getAccessToken({
-          connectionId: mcpServerConnectionRes.value.connectionId,
+          connectionId: oauthConnectionIdRes.value,
         });
         if (connectionRes.isErr()) {
           return new Err({
@@ -186,28 +169,15 @@ export class DatabricksOAuthProvider implements BaseOAuthStrategyProvider {
       const { mcp_server_id, ...restConfig } = extraConfig;
 
       if (mcp_server_id) {
-        const mcpServerConnectionRes =
-          await MCPServerConnectionResource.findByMCPServer(auth, {
-            mcpServerId: mcp_server_id,
-            connectionType: "workspace",
-          });
-
-        if (mcpServerConnectionRes.isErr()) {
-          throw new Error(
-            "Failed to find MCP server connection: " +
-              mcpServerConnectionRes.error.message
-          );
-        }
-
-        if (!mcpServerConnectionRes.value.connectionId) {
-          throw new Error(
-            "Workspace MCP server connection is not configured for OAuth."
-          );
+        const oauthConnectionIdRes =
+          await getWorkspaceOAuthConnectionIdForMCPServer(auth, mcp_server_id);
+        if (oauthConnectionIdRes.isErr()) {
+          throw new Error(oauthConnectionIdRes.error.message);
         }
 
         const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
         const connectionRes = await oauthApi.getAccessToken({
-          connectionId: mcpServerConnectionRes.value.connectionId,
+          connectionId: oauthConnectionIdRes.value,
         });
         if (connectionRes.isErr()) {
           throw new Error(

--- a/front/lib/api/oauth/providers/databricks.ts
+++ b/front/lib/api/oauth/providers/databricks.ts
@@ -117,6 +117,14 @@ export class DatabricksOAuthProvider implements BaseOAuthStrategyProvider {
           });
         }
 
+        if (!mcpServerConnectionRes.value.connectionId) {
+          return new Err({
+            code: "credential_retrieval_failed",
+            message:
+              "Workspace MCP server connection is not configured for OAuth.",
+          });
+        }
+
         const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
         const connectionRes = await oauthApi.getAccessToken({
           connectionId: mcpServerConnectionRes.value.connectionId,
@@ -188,6 +196,12 @@ export class DatabricksOAuthProvider implements BaseOAuthStrategyProvider {
           throw new Error(
             "Failed to find MCP server connection: " +
               mcpServerConnectionRes.error.message
+          );
+        }
+
+        if (!mcpServerConnectionRes.value.connectionId) {
+          throw new Error(
+            "Workspace MCP server connection is not configured for OAuth."
           );
         }
 

--- a/front/lib/api/oauth/providers/databricks.ts
+++ b/front/lib/api/oauth/providers/databricks.ts
@@ -105,7 +105,7 @@ export class DatabricksOAuthProvider implements BaseOAuthStrategyProvider {
         const oauthConnectionIdRes =
           await getWorkspaceOAuthConnectionIdForMCPServer(auth, mcp_server_id);
         if (oauthConnectionIdRes.isErr()) {
-          return new Err(oauthConnectionIdRes.error);
+          return oauthConnectionIdRes;
         }
 
         const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);

--- a/front/lib/api/oauth/providers/databricks.ts
+++ b/front/lib/api/oauth/providers/databricks.ts
@@ -105,7 +105,10 @@ export class DatabricksOAuthProvider implements BaseOAuthStrategyProvider {
         const oauthConnectionIdRes =
           await getWorkspaceOAuthConnectionIdForMCPServer(auth, mcp_server_id);
         if (oauthConnectionIdRes.isErr()) {
-          return oauthConnectionIdRes;
+          return new Err({
+            code: "credential_retrieval_failed",
+            message: oauthConnectionIdRes.error.message,
+          });
         }
 
         const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);

--- a/front/lib/api/oauth/providers/freshservice.ts
+++ b/front/lib/api/oauth/providers/freshservice.ts
@@ -155,6 +155,14 @@ export class FreshserviceOAuthProvider implements BaseOAuthStrategyProvider {
           });
         }
 
+        if (!mcpServerConnectionRes.value.connectionId) {
+          return new Err({
+            code: "credential_retrieval_failed",
+            message:
+              "Workspace MCP server connection is not configured for OAuth.",
+          });
+        }
+
         const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
         const connectionRes = await oauthApi.getConnectionMetadata({
           connectionId: mcpServerConnectionRes.value.connectionId,
@@ -224,6 +232,12 @@ export class FreshserviceOAuthProvider implements BaseOAuthStrategyProvider {
           throw new Error(
             "Failed to find MCP server connection: " +
               mcpServerConnectionRes.error.message
+          );
+        }
+
+        if (!mcpServerConnectionRes.value.connectionId) {
+          throw new Error(
+            "Workspace MCP server connection is not configured for OAuth."
           );
         }
 

--- a/front/lib/api/oauth/providers/freshservice.ts
+++ b/front/lib/api/oauth/providers/freshservice.ts
@@ -143,7 +143,7 @@ export class FreshserviceOAuthProvider implements BaseOAuthStrategyProvider {
         const oauthConnectionIdRes =
           await getWorkspaceOAuthConnectionIdForMCPServer(auth, mcp_server_id);
         if (oauthConnectionIdRes.isErr()) {
-          return new Err(oauthConnectionIdRes.error);
+          return oauthConnectionIdRes;
         }
 
         const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);

--- a/front/lib/api/oauth/providers/freshservice.ts
+++ b/front/lib/api/oauth/providers/freshservice.ts
@@ -143,7 +143,10 @@ export class FreshserviceOAuthProvider implements BaseOAuthStrategyProvider {
         const oauthConnectionIdRes =
           await getWorkspaceOAuthConnectionIdForMCPServer(auth, mcp_server_id);
         if (oauthConnectionIdRes.isErr()) {
-          return oauthConnectionIdRes;
+          return new Err({
+            code: "credential_retrieval_failed",
+            message: oauthConnectionIdRes.error.message,
+          });
         }
 
         const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);

--- a/front/lib/api/oauth/providers/freshservice.ts
+++ b/front/lib/api/oauth/providers/freshservice.ts
@@ -2,6 +2,7 @@ import type { ParsedUrlQuery } from "querystring";
 
 import config from "@app/lib/api/config";
 import type { OAuthError } from "@app/lib/api/oauth";
+import { getWorkspaceOAuthConnectionIdForMCPServer } from "@app/lib/api/oauth/mcp_server_connection_auth";
 import type {
   BaseOAuthStrategyProvider,
   RelatedCredential,
@@ -11,7 +12,6 @@ import {
   getStringFromQuery,
 } from "@app/lib/api/oauth/utils";
 import type { Authenticator } from "@app/lib/auth";
-import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
 import logger from "@app/logger/logger";
 import type { ExtraConfigType } from "@app/pages/w/[wId]/oauth/[provider]/setup";
 import type { Result } from "@app/types";
@@ -140,32 +140,15 @@ export class FreshserviceOAuthProvider implements BaseOAuthStrategyProvider {
         logger.info(
           `Freshservice getRelatedCredential: Using MCP server connection for mcp_server_id: ${mcp_server_id}`
         );
-        const mcpServerConnectionRes =
-          await MCPServerConnectionResource.findByMCPServer(auth, {
-            mcpServerId: mcp_server_id,
-            connectionType: "workspace",
-          });
-
-        if (mcpServerConnectionRes.isErr()) {
-          return new Err({
-            code: "credential_retrieval_failed",
-            message:
-              "Failed to find MCP server connection: " +
-              mcpServerConnectionRes.error.message,
-          });
-        }
-
-        if (!mcpServerConnectionRes.value.connectionId) {
-          return new Err({
-            code: "credential_retrieval_failed",
-            message:
-              "Workspace MCP server connection is not configured for OAuth.",
-          });
+        const oauthConnectionIdRes =
+          await getWorkspaceOAuthConnectionIdForMCPServer(auth, mcp_server_id);
+        if (oauthConnectionIdRes.isErr()) {
+          return new Err(oauthConnectionIdRes.error);
         }
 
         const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
         const connectionRes = await oauthApi.getConnectionMetadata({
-          connectionId: mcpServerConnectionRes.value.connectionId,
+          connectionId: oauthConnectionIdRes.value,
         });
         if (connectionRes.isErr()) {
           return new Err({
@@ -222,28 +205,15 @@ export class FreshserviceOAuthProvider implements BaseOAuthStrategyProvider {
       const { mcp_server_id, ...restConfig } = extraConfig;
 
       if (mcp_server_id) {
-        const mcpServerConnectionRes =
-          await MCPServerConnectionResource.findByMCPServer(auth, {
-            mcpServerId: mcp_server_id,
-            connectionType: "workspace",
-          });
-
-        if (mcpServerConnectionRes.isErr()) {
-          throw new Error(
-            "Failed to find MCP server connection: " +
-              mcpServerConnectionRes.error.message
-          );
-        }
-
-        if (!mcpServerConnectionRes.value.connectionId) {
-          throw new Error(
-            "Workspace MCP server connection is not configured for OAuth."
-          );
+        const oauthConnectionIdRes =
+          await getWorkspaceOAuthConnectionIdForMCPServer(auth, mcp_server_id);
+        if (oauthConnectionIdRes.isErr()) {
+          throw new Error(oauthConnectionIdRes.error.message);
         }
 
         const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
         const connectionRes = await oauthApi.getConnectionMetadata({
-          connectionId: mcpServerConnectionRes.value.connectionId,
+          connectionId: oauthConnectionIdRes.value,
         });
         if (connectionRes.isErr()) {
           throw new Error(

--- a/front/lib/api/oauth/providers/gmail.ts
+++ b/front/lib/api/oauth/providers/gmail.ts
@@ -93,7 +93,10 @@ export class GmailOAuthProvider implements BaseOAuthStrategyProvider {
         const oauthConnectionIdRes =
           await getWorkspaceOAuthConnectionIdForMCPServer(auth, mcp_server_id);
         if (oauthConnectionIdRes.isErr()) {
-          return oauthConnectionIdRes;
+          return new Err({
+            code: "credential_retrieval_failed",
+            message: oauthConnectionIdRes.error.message,
+          });
         }
 
         const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);

--- a/front/lib/api/oauth/providers/gmail.ts
+++ b/front/lib/api/oauth/providers/gmail.ts
@@ -3,6 +3,7 @@ import querystring from "querystring";
 
 import config from "@app/lib/api/config";
 import type { OAuthError } from "@app/lib/api/oauth";
+import { getWorkspaceOAuthConnectionIdForMCPServer } from "@app/lib/api/oauth/mcp_server_connection_auth";
 import type {
   BaseOAuthStrategyProvider,
   RelatedCredential,
@@ -12,7 +13,6 @@ import {
   getStringFromQuery,
 } from "@app/lib/api/oauth/utils";
 import type { Authenticator } from "@app/lib/auth";
-import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
 import logger from "@app/logger/logger";
 import type { ExtraConfigType } from "@app/pages/w/[wId]/oauth/[provider]/setup";
 import type { Result } from "@app/types";
@@ -90,32 +90,15 @@ export class GmailOAuthProvider implements BaseOAuthStrategyProvider {
       const { mcp_server_id } = extraConfig;
 
       if (mcp_server_id) {
-        const mcpServerConnectionRes =
-          await MCPServerConnectionResource.findByMCPServer(auth, {
-            mcpServerId: mcp_server_id,
-            connectionType: "workspace",
-          });
-
-        if (mcpServerConnectionRes.isErr()) {
-          return new Err({
-            code: "credential_retrieval_failed",
-            message:
-              "Failed to find MCP server connection: " +
-              mcpServerConnectionRes.error.message,
-          });
-        }
-
-        if (!mcpServerConnectionRes.value.connectionId) {
-          return new Err({
-            code: "credential_retrieval_failed",
-            message:
-              "Workspace MCP server connection is not configured for OAuth.",
-          });
+        const oauthConnectionIdRes =
+          await getWorkspaceOAuthConnectionIdForMCPServer(auth, mcp_server_id);
+        if (oauthConnectionIdRes.isErr()) {
+          return new Err(oauthConnectionIdRes.error);
         }
 
         const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
         const connectionRes = await oauthApi.getAccessToken({
-          connectionId: mcpServerConnectionRes.value.connectionId,
+          connectionId: oauthConnectionIdRes.value,
         });
         if (connectionRes.isErr()) {
           return new Err({
@@ -167,28 +150,15 @@ export class GmailOAuthProvider implements BaseOAuthStrategyProvider {
       const { mcp_server_id, ...restConfig } = extraConfig;
 
       if (mcp_server_id) {
-        const mcpServerConnectionRes =
-          await MCPServerConnectionResource.findByMCPServer(auth, {
-            mcpServerId: mcp_server_id,
-            connectionType: "workspace",
-          });
-
-        if (mcpServerConnectionRes.isErr()) {
-          throw new Error(
-            "Failed to find MCP server connection: " +
-              mcpServerConnectionRes.error.message
-          );
-        }
-
-        if (!mcpServerConnectionRes.value.connectionId) {
-          throw new Error(
-            "Workspace MCP server connection is not configured for OAuth."
-          );
+        const oauthConnectionIdRes =
+          await getWorkspaceOAuthConnectionIdForMCPServer(auth, mcp_server_id);
+        if (oauthConnectionIdRes.isErr()) {
+          throw new Error(oauthConnectionIdRes.error.message);
         }
 
         const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
         const connectionRes = await oauthApi.getAccessToken({
-          connectionId: mcpServerConnectionRes.value.connectionId,
+          connectionId: oauthConnectionIdRes.value,
         });
         if (connectionRes.isErr()) {
           throw new Error(

--- a/front/lib/api/oauth/providers/gmail.ts
+++ b/front/lib/api/oauth/providers/gmail.ts
@@ -105,6 +105,14 @@ export class GmailOAuthProvider implements BaseOAuthStrategyProvider {
           });
         }
 
+        if (!mcpServerConnectionRes.value.connectionId) {
+          return new Err({
+            code: "credential_retrieval_failed",
+            message:
+              "Workspace MCP server connection is not configured for OAuth.",
+          });
+        }
+
         const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
         const connectionRes = await oauthApi.getAccessToken({
           connectionId: mcpServerConnectionRes.value.connectionId,
@@ -169,6 +177,12 @@ export class GmailOAuthProvider implements BaseOAuthStrategyProvider {
           throw new Error(
             "Failed to find MCP server connection: " +
               mcpServerConnectionRes.error.message
+          );
+        }
+
+        if (!mcpServerConnectionRes.value.connectionId) {
+          throw new Error(
+            "Workspace MCP server connection is not configured for OAuth."
           );
         }
 

--- a/front/lib/api/oauth/providers/gmail.ts
+++ b/front/lib/api/oauth/providers/gmail.ts
@@ -93,7 +93,7 @@ export class GmailOAuthProvider implements BaseOAuthStrategyProvider {
         const oauthConnectionIdRes =
           await getWorkspaceOAuthConnectionIdForMCPServer(auth, mcp_server_id);
         if (oauthConnectionIdRes.isErr()) {
-          return new Err(oauthConnectionIdRes.error);
+          return oauthConnectionIdRes;
         }
 
         const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);

--- a/front/lib/api/oauth/providers/mcp.ts
+++ b/front/lib/api/oauth/providers/mcp.ts
@@ -160,6 +160,14 @@ export class MCPOAuthProvider implements BaseOAuthStrategyProvider {
           });
         }
 
+        if (!mcpServerConnectionRes.value.connectionId) {
+          return new Err({
+            code: "credential_retrieval_failed",
+            message:
+              "Workspace MCP server connection is not configured for OAuth.",
+          });
+        }
+
         const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
         const connectionRes = await oauthApi.getConnectionMetadata({
           connectionId: mcpServerConnectionRes.value.connectionId,
@@ -232,6 +240,12 @@ export class MCPOAuthProvider implements BaseOAuthStrategyProvider {
           throw new Error(
             "Failed to find MCP server connection: " +
               mcpServerConnectionRes.error.message
+          );
+        }
+
+        if (!mcpServerConnectionRes.value.connectionId) {
+          throw new Error(
+            "Workspace MCP server connection is not configured for OAuth."
           );
         }
 

--- a/front/lib/api/oauth/providers/mcp.ts
+++ b/front/lib/api/oauth/providers/mcp.ts
@@ -148,7 +148,7 @@ export class MCPOAuthProvider implements BaseOAuthStrategyProvider {
         const oauthConnectionIdRes =
           await getWorkspaceOAuthConnectionIdForMCPServer(auth, mcp_server_id);
         if (oauthConnectionIdRes.isErr()) {
-          return new Err(oauthConnectionIdRes.error);
+          return oauthConnectionIdRes;
         }
 
         const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);

--- a/front/lib/api/oauth/providers/mcp.ts
+++ b/front/lib/api/oauth/providers/mcp.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 
 import config from "@app/lib/api/config";
 import type { OAuthError } from "@app/lib/api/oauth";
+import { getWorkspaceOAuthConnectionIdForMCPServer } from "@app/lib/api/oauth/mcp_server_connection_auth";
 import type {
   BaseOAuthStrategyProvider,
   RelatedCredential,
@@ -12,7 +13,6 @@ import {
   getStringFromQuery,
 } from "@app/lib/api/oauth/utils";
 import type { Authenticator } from "@app/lib/auth";
-import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
 import { getPKCEConfig } from "@app/lib/utils/pkce";
 import logger from "@app/logger/logger";
 import type { ExtraConfigType } from "@app/pages/w/[wId]/oauth/[provider]/setup";
@@ -145,32 +145,15 @@ export class MCPOAuthProvider implements BaseOAuthStrategyProvider {
       const { mcp_server_id } = extraConfig;
 
       if (mcp_server_id) {
-        const mcpServerConnectionRes =
-          await MCPServerConnectionResource.findByMCPServer(auth, {
-            mcpServerId: mcp_server_id,
-            connectionType: "workspace",
-          });
-
-        if (mcpServerConnectionRes.isErr()) {
-          return new Err({
-            code: "credential_retrieval_failed",
-            message:
-              "Failed to find MCP server connection: " +
-              mcpServerConnectionRes.error.message,
-          });
-        }
-
-        if (!mcpServerConnectionRes.value.connectionId) {
-          return new Err({
-            code: "credential_retrieval_failed",
-            message:
-              "Workspace MCP server connection is not configured for OAuth.",
-          });
+        const oauthConnectionIdRes =
+          await getWorkspaceOAuthConnectionIdForMCPServer(auth, mcp_server_id);
+        if (oauthConnectionIdRes.isErr()) {
+          return new Err(oauthConnectionIdRes.error);
         }
 
         const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
         const connectionRes = await oauthApi.getConnectionMetadata({
-          connectionId: mcpServerConnectionRes.value.connectionId,
+          connectionId: oauthConnectionIdRes.value,
         });
         if (connectionRes.isErr()) {
           return new Err({
@@ -230,28 +213,15 @@ export class MCPOAuthProvider implements BaseOAuthStrategyProvider {
       const { mcp_server_id, ...restConfig } = extraConfig;
 
       if (mcp_server_id) {
-        const mcpServerConnectionRes =
-          await MCPServerConnectionResource.findByMCPServer(auth, {
-            mcpServerId: mcp_server_id,
-            connectionType: "workspace",
-          });
-
-        if (mcpServerConnectionRes.isErr()) {
-          throw new Error(
-            "Failed to find MCP server connection: " +
-              mcpServerConnectionRes.error.message
-          );
-        }
-
-        if (!mcpServerConnectionRes.value.connectionId) {
-          throw new Error(
-            "Workspace MCP server connection is not configured for OAuth."
-          );
+        const oauthConnectionIdRes =
+          await getWorkspaceOAuthConnectionIdForMCPServer(auth, mcp_server_id);
+        if (oauthConnectionIdRes.isErr()) {
+          throw new Error(oauthConnectionIdRes.error.message);
         }
 
         const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
         const connectionRes = await oauthApi.getConnectionMetadata({
-          connectionId: mcpServerConnectionRes.value.connectionId,
+          connectionId: oauthConnectionIdRes.value,
         });
         if (connectionRes.isErr()) {
           throw new Error(

--- a/front/lib/api/oauth/providers/mcp.ts
+++ b/front/lib/api/oauth/providers/mcp.ts
@@ -148,7 +148,10 @@ export class MCPOAuthProvider implements BaseOAuthStrategyProvider {
         const oauthConnectionIdRes =
           await getWorkspaceOAuthConnectionIdForMCPServer(auth, mcp_server_id);
         if (oauthConnectionIdRes.isErr()) {
-          return oauthConnectionIdRes;
+          return new Err({
+            code: "credential_retrieval_failed",
+            message: oauthConnectionIdRes.error.message,
+          });
         }
 
         const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);

--- a/front/lib/api/oauth/providers/notion.ts
+++ b/front/lib/api/oauth/providers/notion.ts
@@ -98,6 +98,12 @@ export class NotionOAuthProvider implements BaseOAuthStrategyProvider {
           );
         }
 
+        if (!mcpServerConnectionRes.value.connectionId) {
+          throw new Error(
+            "Workspace MCP server connection is not configured for OAuth."
+          );
+        }
+
         const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
         const connectionRes = await oauthApi.getConnectionMetadata({
           connectionId: mcpServerConnectionRes.value.connectionId,

--- a/front/lib/api/oauth/providers/notion.ts
+++ b/front/lib/api/oauth/providers/notion.ts
@@ -1,13 +1,13 @@
 import type { ParsedUrlQuery } from "querystring";
 
 import config from "@app/lib/api/config";
+import { getWorkspaceOAuthConnectionIdForMCPServer } from "@app/lib/api/oauth/mcp_server_connection_auth";
 import type { BaseOAuthStrategyProvider } from "@app/lib/api/oauth/providers/base_oauth_stragegy_provider";
 import {
   finalizeUriForProvider,
   getStringFromQuery,
 } from "@app/lib/api/oauth/utils";
 import type { Authenticator } from "@app/lib/auth";
-import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
 import logger from "@app/logger/logger";
 import type { ExtraConfigType } from "@app/pages/w/[wId]/oauth/[provider]/setup";
 import { Err, OAuthAPI, Ok } from "@app/types";
@@ -85,28 +85,15 @@ export class NotionOAuthProvider implements BaseOAuthStrategyProvider {
       const { mcp_server_id, ...restConfig } = extraConfig;
 
       if (mcp_server_id) {
-        const mcpServerConnectionRes =
-          await MCPServerConnectionResource.findByMCPServer(auth, {
-            mcpServerId: mcp_server_id,
-            connectionType: "workspace",
-          });
-
-        if (mcpServerConnectionRes.isErr()) {
-          throw new Error(
-            "Failed to find MCP server connection: " +
-              mcpServerConnectionRes.error.message
-          );
-        }
-
-        if (!mcpServerConnectionRes.value.connectionId) {
-          throw new Error(
-            "Workspace MCP server connection is not configured for OAuth."
-          );
+        const oauthConnectionIdRes =
+          await getWorkspaceOAuthConnectionIdForMCPServer(auth, mcp_server_id);
+        if (oauthConnectionIdRes.isErr()) {
+          throw new Error(oauthConnectionIdRes.error.message);
         }
 
         const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
         const connectionRes = await oauthApi.getConnectionMetadata({
-          connectionId: mcpServerConnectionRes.value.connectionId,
+          connectionId: oauthConnectionIdRes.value,
         });
         if (connectionRes.isErr()) {
           logger.error(
@@ -123,7 +110,7 @@ export class NotionOAuthProvider implements BaseOAuthStrategyProvider {
         // The workspace_id in metadata is the Dust workspace ID, not the Notion workspace ID.
         // We need to get the Notion workspace info from the raw OAuth response
         const oauthRes = await oauthApi.getAccessToken({
-          connectionId: mcpServerConnectionRes.value.connectionId,
+          connectionId: oauthConnectionIdRes.value,
         });
 
         if (oauthRes.isErr()) {

--- a/front/lib/api/oauth/providers/salesforce.ts
+++ b/front/lib/api/oauth/providers/salesforce.ts
@@ -113,6 +113,14 @@ export class SalesforceOAuthProvider implements BaseOAuthStrategyProvider {
           });
         }
 
+        if (!mcpServerConnectionRes.value.connectionId) {
+          return new Err({
+            code: "credential_retrieval_failed",
+            message:
+              "Workspace MCP server connection is not configured for OAuth.",
+          });
+        }
+
         const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
         const connectionRes = await oauthApi.getConnectionMetadata({
           connectionId: mcpServerConnectionRes.value.connectionId,
@@ -176,6 +184,12 @@ export class SalesforceOAuthProvider implements BaseOAuthStrategyProvider {
           throw new Error(
             "Failed to find MCP server connection: " +
               mcpServerConnectionRes.error.message
+          );
+        }
+
+        if (!mcpServerConnectionRes.value.connectionId) {
+          throw new Error(
+            "Workspace MCP server connection is not configured for OAuth."
           );
         }
 

--- a/front/lib/api/oauth/providers/salesforce.ts
+++ b/front/lib/api/oauth/providers/salesforce.ts
@@ -101,7 +101,10 @@ export class SalesforceOAuthProvider implements BaseOAuthStrategyProvider {
         const oauthConnectionIdRes =
           await getWorkspaceOAuthConnectionIdForMCPServer(auth, mcp_server_id);
         if (oauthConnectionIdRes.isErr()) {
-          return oauthConnectionIdRes;
+          return new Err({
+            code: "credential_retrieval_failed",
+            message: oauthConnectionIdRes.error.message,
+          });
         }
 
         const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);

--- a/front/lib/api/oauth/providers/salesforce.ts
+++ b/front/lib/api/oauth/providers/salesforce.ts
@@ -101,7 +101,7 @@ export class SalesforceOAuthProvider implements BaseOAuthStrategyProvider {
         const oauthConnectionIdRes =
           await getWorkspaceOAuthConnectionIdForMCPServer(auth, mcp_server_id);
         if (oauthConnectionIdRes.isErr()) {
-          return new Err(oauthConnectionIdRes.error);
+          return oauthConnectionIdRes;
         }
 
         const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);

--- a/front/lib/api/oauth/providers/slack_tools.ts
+++ b/front/lib/api/oauth/providers/slack_tools.ts
@@ -129,6 +129,12 @@ export class SlackToolsOAuthProvider implements BaseOAuthStrategyProvider {
           );
         }
 
+        if (!mcpServerConnectionRes.value.connectionId) {
+          throw new Error(
+            "Workspace MCP server connection is not configured for OAuth."
+          );
+        }
+
         const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
         const connectionRes = await oauthApi.getConnectionMetadata({
           connectionId: mcpServerConnectionRes.value.connectionId,

--- a/front/lib/api/oauth/providers/slack_tools.ts
+++ b/front/lib/api/oauth/providers/slack_tools.ts
@@ -2,13 +2,13 @@ import assert from "assert";
 import type { ParsedUrlQuery } from "querystring";
 
 import config from "@app/lib/api/config";
+import { getWorkspaceOAuthConnectionIdForMCPServer } from "@app/lib/api/oauth/mcp_server_connection_auth";
 import type { BaseOAuthStrategyProvider } from "@app/lib/api/oauth/providers/base_oauth_stragegy_provider";
 import {
   finalizeUriForProvider,
   getStringFromQuery,
 } from "@app/lib/api/oauth/utils";
 import type { Authenticator } from "@app/lib/auth";
-import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
 import logger from "@app/logger/logger";
 import type { ExtraConfigType } from "@app/pages/w/[wId]/oauth/[provider]/setup";
 import { Err, OAuthAPI, Ok } from "@app/types";
@@ -116,28 +116,15 @@ export class SlackToolsOAuthProvider implements BaseOAuthStrategyProvider {
       const { mcp_server_id, ...restConfig } = extraConfig;
 
       if (mcp_server_id) {
-        const mcpServerConnectionRes =
-          await MCPServerConnectionResource.findByMCPServer(auth, {
-            mcpServerId: mcp_server_id,
-            connectionType: "workspace",
-          });
-
-        if (mcpServerConnectionRes.isErr()) {
-          throw new Error(
-            "Failed to find MCP server connection: " +
-              mcpServerConnectionRes.error.message
-          );
-        }
-
-        if (!mcpServerConnectionRes.value.connectionId) {
-          throw new Error(
-            "Workspace MCP server connection is not configured for OAuth."
-          );
+        const oauthConnectionIdRes =
+          await getWorkspaceOAuthConnectionIdForMCPServer(auth, mcp_server_id);
+        if (oauthConnectionIdRes.isErr()) {
+          throw new Error(oauthConnectionIdRes.error.message);
         }
 
         const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
         const connectionRes = await oauthApi.getConnectionMetadata({
-          connectionId: mcpServerConnectionRes.value.connectionId,
+          connectionId: oauthConnectionIdRes.value,
         });
         if (connectionRes.isErr()) {
           logger.error(

--- a/front/lib/api/oauth/providers/snowflake.ts
+++ b/front/lib/api/oauth/providers/snowflake.ts
@@ -57,7 +57,7 @@ async function getWorkspaceConnectionForMCPServer(
     }
   );
   if (oauthConnectionIdRes.isErr()) {
-    return new Err(oauthConnectionIdRes.error);
+    return oauthConnectionIdRes;
   }
 
   const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);

--- a/front/lib/api/oauth/providers/snowflake.ts
+++ b/front/lib/api/oauth/providers/snowflake.ts
@@ -49,15 +49,17 @@ async function getWorkspaceConnectionForMCPServer(
 ): Promise<Result<OAuthConnectionType, OAuthError>> {
   const oauthConnectionIdRes = await getWorkspaceOAuthConnectionIdForMCPServer(
     auth,
-    mcpServerId,
-    {
-      oauthNotConfiguredMessage:
-        "Workspace Snowflake MCP connection is configured for key-pair authentication. " +
-        "Personal Snowflake connections are OAuth-only. Please ask an admin to configure OAuth for this Snowflake MCP server.",
-    }
+    mcpServerId
   );
   if (oauthConnectionIdRes.isErr()) {
-    return oauthConnectionIdRes;
+    return new Err({
+      code: "credential_retrieval_failed",
+      message:
+        oauthConnectionIdRes.error.kind === "oauth_not_configured"
+          ? "Workspace Snowflake MCP connection is not configured for OAuth. " +
+            "Personal Snowflake connections are OAuth-only. Please ask an admin to configure OAuth for this Snowflake MCP server."
+          : oauthConnectionIdRes.error.message,
+    });
   }
 
   const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);

--- a/front/lib/api/oauth/providers/snowflake.ts
+++ b/front/lib/api/oauth/providers/snowflake.ts
@@ -62,6 +62,15 @@ async function getWorkspaceConnectionForMCPServer(
     });
   }
 
+  if (!mcpServerConnectionRes.value.connectionId) {
+    return new Err({
+      code: "credential_retrieval_failed",
+      message:
+        "Workspace Snowflake MCP connection is configured for key-pair authentication. " +
+        "Personal Snowflake connections are OAuth-only. Please ask an admin to configure OAuth for this Snowflake MCP server.",
+    });
+  }
+
   const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
   const connectionRes = await oauthApi.getAccessToken({
     connectionId: mcpServerConnectionRes.value.connectionId,

--- a/front/lib/api/oauth/providers/ukg_ready.ts
+++ b/front/lib/api/oauth/providers/ukg_ready.ts
@@ -2,6 +2,7 @@ import type { ParsedUrlQuery } from "querystring";
 
 import config from "@app/lib/api/config";
 import type { OAuthError } from "@app/lib/api/oauth";
+import { getWorkspaceOAuthConnectionIdForMCPServer } from "@app/lib/api/oauth/mcp_server_connection_auth";
 import type {
   BaseOAuthStrategyProvider,
   RelatedCredential,
@@ -11,7 +12,6 @@ import {
   getStringFromQuery,
 } from "@app/lib/api/oauth/utils";
 import type { Authenticator } from "@app/lib/auth";
-import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
 import { getPKCEConfig } from "@app/lib/utils/pkce";
 import logger from "@app/logger/logger";
 import type { ExtraConfigType } from "@app/pages/w/[wId]/oauth/[provider]/setup";
@@ -110,32 +110,15 @@ export class UkgReadyOAuthProvider implements BaseOAuthStrategyProvider {
       const { mcp_server_id } = extraConfig;
 
       if (mcp_server_id) {
-        const mcpServerConnectionRes =
-          await MCPServerConnectionResource.findByMCPServer(auth, {
-            mcpServerId: mcp_server_id,
-            connectionType: "workspace",
-          });
-
-        if (mcpServerConnectionRes.isErr()) {
-          return new Err({
-            code: "credential_retrieval_failed",
-            message:
-              "Failed to find MCP server connection: " +
-              mcpServerConnectionRes.error.message,
-          });
-        }
-
-        if (!mcpServerConnectionRes.value.connectionId) {
-          return new Err({
-            code: "credential_retrieval_failed",
-            message:
-              "Workspace MCP server connection is not configured for OAuth.",
-          });
+        const oauthConnectionIdRes =
+          await getWorkspaceOAuthConnectionIdForMCPServer(auth, mcp_server_id);
+        if (oauthConnectionIdRes.isErr()) {
+          return new Err(oauthConnectionIdRes.error);
         }
 
         const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
         const connectionRes = await oauthApi.getConnectionMetadata({
-          connectionId: mcpServerConnectionRes.value.connectionId,
+          connectionId: oauthConnectionIdRes.value,
         });
         if (connectionRes.isErr()) {
           return new Err({
@@ -186,28 +169,15 @@ export class UkgReadyOAuthProvider implements BaseOAuthStrategyProvider {
       const { mcp_server_id, ...restConfig } = extraConfig;
 
       if (mcp_server_id) {
-        const mcpServerConnectionRes =
-          await MCPServerConnectionResource.findByMCPServer(auth, {
-            mcpServerId: mcp_server_id,
-            connectionType: "workspace",
-          });
-
-        if (mcpServerConnectionRes.isErr()) {
-          throw new Error(
-            "Failed to find MCP server connection: " +
-              mcpServerConnectionRes.error.message
-          );
-        }
-
-        if (!mcpServerConnectionRes.value.connectionId) {
-          throw new Error(
-            "Workspace MCP server connection is not configured for OAuth."
-          );
+        const oauthConnectionIdRes =
+          await getWorkspaceOAuthConnectionIdForMCPServer(auth, mcp_server_id);
+        if (oauthConnectionIdRes.isErr()) {
+          throw new Error(oauthConnectionIdRes.error.message);
         }
 
         const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
         const connectionRes = await oauthApi.getConnectionMetadata({
-          connectionId: mcpServerConnectionRes.value.connectionId,
+          connectionId: oauthConnectionIdRes.value,
         });
         if (connectionRes.isErr()) {
           throw new Error(

--- a/front/lib/api/oauth/providers/ukg_ready.ts
+++ b/front/lib/api/oauth/providers/ukg_ready.ts
@@ -125,6 +125,14 @@ export class UkgReadyOAuthProvider implements BaseOAuthStrategyProvider {
           });
         }
 
+        if (!mcpServerConnectionRes.value.connectionId) {
+          return new Err({
+            code: "credential_retrieval_failed",
+            message:
+              "Workspace MCP server connection is not configured for OAuth.",
+          });
+        }
+
         const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
         const connectionRes = await oauthApi.getConnectionMetadata({
           connectionId: mcpServerConnectionRes.value.connectionId,
@@ -188,6 +196,12 @@ export class UkgReadyOAuthProvider implements BaseOAuthStrategyProvider {
           throw new Error(
             "Failed to find MCP server connection: " +
               mcpServerConnectionRes.error.message
+          );
+        }
+
+        if (!mcpServerConnectionRes.value.connectionId) {
+          throw new Error(
+            "Workspace MCP server connection is not configured for OAuth."
           );
         }
 

--- a/front/lib/api/oauth/providers/ukg_ready.ts
+++ b/front/lib/api/oauth/providers/ukg_ready.ts
@@ -113,7 +113,7 @@ export class UkgReadyOAuthProvider implements BaseOAuthStrategyProvider {
         const oauthConnectionIdRes =
           await getWorkspaceOAuthConnectionIdForMCPServer(auth, mcp_server_id);
         if (oauthConnectionIdRes.isErr()) {
-          return new Err(oauthConnectionIdRes.error);
+          return oauthConnectionIdRes;
         }
 
         const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);

--- a/front/lib/api/oauth/providers/ukg_ready.ts
+++ b/front/lib/api/oauth/providers/ukg_ready.ts
@@ -113,7 +113,10 @@ export class UkgReadyOAuthProvider implements BaseOAuthStrategyProvider {
         const oauthConnectionIdRes =
           await getWorkspaceOAuthConnectionIdForMCPServer(auth, mcp_server_id);
         if (oauthConnectionIdRes.isErr()) {
-          return oauthConnectionIdRes;
+          return new Err({
+            code: "credential_retrieval_failed",
+            message: oauthConnectionIdRes.error.message,
+          });
         }
 
         const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);

--- a/front/lib/models/agent/actions/mcp_server_connection.ts
+++ b/front/lib/models/agent/actions/mcp_server_connection.ts
@@ -11,7 +11,8 @@ export class MCPServerConnectionModel extends WorkspaceAwareModel<MCPServerConne
   declare createdAt: CreationOptional<Date>;
   declare updatedAt: CreationOptional<Date>;
 
-  declare connectionId: string;
+  declare connectionId: string | null;
+  declare credentialId: string | null;
   declare connectionType: "workspace" | "personal";
 
   declare userId: ForeignKey<UserModel["id"]>;
@@ -39,7 +40,11 @@ MCPServerConnectionModel.init(
     },
     connectionId: {
       type: DataTypes.STRING,
-      allowNull: false,
+      allowNull: true,
+    },
+    credentialId: {
+      type: DataTypes.STRING,
+      allowNull: true,
     },
     connectionType: {
       type: DataTypes.STRING,
@@ -96,6 +101,17 @@ MCPServerConnectionModel.init(
     ],
     hooks: {
       beforeValidate: (config: MCPServerConnectionModel) => {
+        const hasConnectionId =
+          typeof config.connectionId === "string" && config.connectionId !== "";
+        const hasCredentialId =
+          typeof config.credentialId === "string" && config.credentialId !== "";
+
+        if (hasConnectionId === hasCredentialId) {
+          throw new Error(
+            "Exactly one of connectionId or credentialId must be provided."
+          );
+        }
+
         if (config.serverType) {
           switch (config.serverType) {
             case "internal":

--- a/front/lib/models/agent/actions/mcp_server_connection.ts
+++ b/front/lib/models/agent/actions/mcp_server_connection.ts
@@ -6,6 +6,7 @@ import { frontSequelize } from "@app/lib/resources/storage";
 import { UserModel } from "@app/lib/resources/storage/models/user";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import { isString } from "@app/types/shared/utils/general";
 
 export class MCPServerConnectionModel extends WorkspaceAwareModel<MCPServerConnectionModel> {
   declare createdAt: CreationOptional<Date>;
@@ -102,9 +103,9 @@ MCPServerConnectionModel.init(
     hooks: {
       beforeValidate: (config: MCPServerConnectionModel) => {
         const hasConnectionId =
-          typeof config.connectionId === "string" && config.connectionId !== "";
+          isString(config.connectionId) && config.connectionId !== "";
         const hasCredentialId =
-          typeof config.credentialId === "string" && config.credentialId !== "";
+          isString(config.credentialId) && config.credentialId !== "";
 
         if (hasConnectionId === hasCredentialId) {
           throw new Error(

--- a/front/lib/resources/mcp_server_connection_resource.ts
+++ b/front/lib/resources/mcp_server_connection_resource.ts
@@ -344,6 +344,7 @@ export class MCPServerConnectionResource extends BaseResource<MCPServerConnectio
       sId: this.sId,
       createdAt: this.createdAt,
       updatedAt: this.updatedAt,
+      authType: this.credentialId ? "keypair" : "oauth",
       connectionType: this.connectionType,
       serverType: this.serverType,
       internalMCPServerId: this.internalMCPServerId,
@@ -375,6 +376,7 @@ export interface MCPServerConnectionType {
   sId: string;
   createdAt: Date;
   updatedAt: Date;
+  authType: "oauth" | "keypair";
   user: {
     fullName: string | null;
     imageUrl: string | null;

--- a/front/migrations/20250904_migrate_agents_using_slack_channels.ts
+++ b/front/migrations/20250904_migrate_agents_using_slack_channels.ts
@@ -109,6 +109,13 @@ makeScript(
     }
 
     // Get the OAuth access token
+    if (!mcpServerConnection.connectionId) {
+      logger.error(
+        `MCP server connection ${mcpServerConnection.id} is not configured for OAuth`
+      );
+      return;
+    }
+
     const oauthApi = new OAuthAPI(config.getOAuthAPIConfig(), logger);
     const tokenResult = await oauthApi.getAccessToken({
       connectionId: mcpServerConnection.connectionId,

--- a/front/migrations/db/migration_497.sql
+++ b/front/migrations/db/migration_497.sql
@@ -1,2 +1,14 @@
--- Migration created on Jan 29, 2026
-ALTER TABLE "public"."agent_messages" ADD COLUMN "prunedContext" BOOLEAN DEFAULT false;
+-- Migration created on Feb 02, 2026
+
+-- Allow MCP server connections to be authenticated either via an OAuth connectionId
+-- or via a stored credentials reference (credentialId). Exactly one must be set.
+
+ALTER TABLE "mcp_server_connections"
+    ADD COLUMN IF NOT EXISTS "credentialId" VARCHAR(255);
+
+ALTER TABLE "mcp_server_connections"
+    ALTER COLUMN "connectionId" DROP NOT NULL;
+
+ALTER TABLE "mcp_server_connections"
+    ADD CONSTRAINT "mcp_server_connections_auth_reference_check"
+        CHECK (("connectionId" IS NOT NULL) <> ("credentialId" IS NOT NULL));

--- a/front/migrations/db/migration_497.sql
+++ b/front/migrations/db/migration_497.sql
@@ -1,14 +1,2 @@
--- Migration created on Feb 02, 2026
-
--- Allow MCP server connections to be authenticated either via an OAuth connectionId
--- or via a stored credentials reference (credentialId). Exactly one must be set.
-
-ALTER TABLE "mcp_server_connections"
-    ADD COLUMN IF NOT EXISTS "credentialId" VARCHAR(255);
-
-ALTER TABLE "mcp_server_connections"
-    ALTER COLUMN "connectionId" DROP NOT NULL;
-
-ALTER TABLE "mcp_server_connections"
-    ADD CONSTRAINT "mcp_server_connections_auth_reference_check"
-        CHECK (("connectionId" IS NOT NULL) <> ("credentialId" IS NOT NULL));
+-- Migration created on Jan 29, 2026
+ALTER TABLE "public"."agent_messages" ADD COLUMN "prunedContext" BOOLEAN DEFAULT false;

--- a/front/migrations/db/migration_501.sql
+++ b/front/migrations/db/migration_501.sql
@@ -1,0 +1,15 @@
+-- Migration created on Feb 02, 2026
+
+-- Allow MCP server connections to be authenticated either via an OAuth connectionId
+-- or via a stored credentials reference (credentialId). Exactly one must be set.
+
+ALTER TABLE "mcp_server_connections"
+    ADD COLUMN IF NOT EXISTS "credentialId" VARCHAR(255);
+
+ALTER TABLE "mcp_server_connections"
+    ALTER COLUMN "connectionId" DROP NOT NULL;
+
+ALTER TABLE "mcp_server_connections"
+    ADD CONSTRAINT "mcp_server_connections_auth_reference_check"
+        CHECK (("connectionId" IS NOT NULL) <> ("credentialId" IS NOT NULL));
+

--- a/front/pages/api/w/[wId]/google_drive/picker_token.ts
+++ b/front/pages/api/w/[wId]/google_drive/picker_token.ts
@@ -61,7 +61,17 @@ async function handler(
         });
       }
 
-      const { connectionId } = connectionResult.value;
+      const connectionId = connectionResult.value.connectionId;
+      if (!connectionId) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "invalid_request_error",
+            message:
+              "No Google Drive connection found. Please connect your Google Drive account first.",
+          },
+        });
+      }
 
       // Get the access token for this connection
       const tokenResult = await getOAuthConnectionAccessToken({


### PR DESCRIPTION
## Description

PR #1 (plumbing) for splitting the Snowflake MCP key-pair work.

- Add `credentialId` to `mcp_server_connections` and relax `connectionId` to be nullable.
- Enforce the `connectionId XOR credentialId` invariant at the DB level (check constraint) and at the model level.
- Add a typed helper to fetch the workspace OAuth `connectionId` for an MCP server and update providers to use it.

## Tests

- `npm -w front run tsgo`
- `npm -w front run format:check`

## Risk

Medium (includes a DB migration).

- Migration drops the NOT NULL constraint on `connectionId`, adds `credentialId`, and adds a XOR check constraint.
- Rollback: drop the constraint, drop `credentialId`, and restore `connectionId` NOT NULL.

## Deploy Plan

- Run `front/migrations/db/migration_501.sql` manually before deploying.
- That migration will create the required column, and change the constraints as explained above
- Deploy as usual.