### PR TITLE
fix: do not set lastReadAt when adding a participant

### DIFF
--- a/front/lib/api/assistant/conversation/mentions.ts
+++ b/front/lib/api/assistant/conversation/mentions.ts
@@ -257,6 +257,7 @@ export const createUserMentions = async (
             conversation,
             action: "subscribed",
             user: user.toJSON(),
+            lastReadAt: null,
             transaction,
           });
 


### PR DESCRIPTION
## Description

This PR fixes an issue where `lastReadAt` was incorrectly set when adding a participant to a conversation via user mentions. For project conversations, this caused them to shift from an unread state to read when the user was added.

Fixes https://github.com/dust-tt/tasks/issues/6319

## Tests

Manually

## Risk
Low
## Deploy Plan

