### PR TITLE
fix(copilot): local suggestion state + form updates on success

### DIFF
--- a/front/components/agent_builder/copilot/CopilotSuggestionsContext.tsx
+++ b/front/components/agent_builder/copilot/CopilotSuggestionsContext.tsx
@@ -298,20 +298,13 @@ export const CopilotSuggestionsProvider = ({
       }
 
       // Optimistic update for card state
-      setProcessedSuggestions((prev) => {
-        const next = new Map(prev);
-        next.set(sId, { ...suggestion, state: "approved" });
-        return next;
-      });
+      setProcessedSuggestions((prev) =>
+        new Map(prev).set(sId, { ...suggestion, state: "approved" })
+      );
 
       const result = await patchSuggestions([sId], "approved");
       if (!result || result.suggestions.length === 0) {
-        // Revert on error
-        setProcessedSuggestions((prev) => {
-          const next = new Map(prev);
-          next.set(sId, suggestion);
-          return next;
-        });
+        setProcessedSuggestions((prev) => new Map(prev).set(sId, suggestion));
         return false;
       }
 
@@ -339,20 +332,13 @@ export const CopilotSuggestionsProvider = ({
       }
 
       // Optimistic update for card state
-      setProcessedSuggestions((prev) => {
-        const next = new Map(prev);
-        next.set(sId, { ...suggestion, state: "rejected" });
-        return next;
-      });
+      setProcessedSuggestions((prev) =>
+        new Map(prev).set(sId, { ...suggestion, state: "rejected" })
+      );
 
       const result = await patchSuggestions([sId], "rejected");
       if (!result || result.suggestions.length === 0) {
-        // Revert on error
-        setProcessedSuggestions((prev) => {
-          const next = new Map(prev);
-          next.set(sId, suggestion);
-          return next;
-        });
+        setProcessedSuggestions((prev) => new Map(prev).set(sId, suggestion));
         return false;
       }
 
@@ -391,13 +377,12 @@ export const CopilotSuggestionsProvider = ({
         return false;
       }
 
-      setProcessedSuggestions((prev) => {
-        const next = new Map(prev);
-        for (const s of instructionSuggestions) {
-          next.set(s.sId, { ...s, state: "approved" });
-        }
-        return next;
-      });
+      setProcessedSuggestions((prev) =>
+        instructionSuggestions.reduce(
+          (map, s) => map.set(s.sId, { ...s, state: "approved" }),
+          new Map(prev)
+        )
+      );
 
       editor.commands.acceptAllSuggestions();
       for (const sId of instructionSuggestionIds) {
@@ -431,13 +416,12 @@ export const CopilotSuggestionsProvider = ({
         return false;
       }
 
-      setProcessedSuggestions((prev) => {
-        const next = new Map(prev);
-        for (const s of instructionSuggestions) {
-          next.set(s.sId, { ...s, state: "rejected" });
-        }
-        return next;
-      });
+      setProcessedSuggestions((prev) =>
+        instructionSuggestions.reduce(
+          (map, s) => map.set(s.sId, { ...s, state: "rejected" }),
+          new Map(prev)
+        )
+      );
 
       editor.commands.rejectAllSuggestions();
       for (const sId of instructionSuggestionIds) {

--- a/front/components/agent_builder/copilot/CopilotSuggestionsContext.tsx
+++ b/front/components/agent_builder/copilot/CopilotSuggestionsContext.tsx
@@ -20,11 +20,7 @@ import {
   usePatchAgentSuggestions,
 } from "@app/lib/swr/agent_suggestions";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
-import {
-  isInstructionAgentSuggestionType,
-  isInstructionsSuggestion,
-  removeNulls,
-} from "@app/types";
+import { removeNulls } from "@app/types";
 import type {
   AgentSuggestionType,
   AgentSuggestionWithRelationsType,
@@ -386,8 +382,11 @@ export const CopilotSuggestionsProvider = ({
         return true;
       }
 
-      const sIds = instructionSuggestions.map((s) => s.sId);
-      const result = await patchSuggestions(sIds, "approved");
+      const instructionSuggestionIds = instructionSuggestions.map((s) => s.sId);
+      const result = await patchSuggestions(
+        instructionSuggestionIds,
+        "approved"
+      );
       if (!result) {
         return false;
       }
@@ -401,7 +400,7 @@ export const CopilotSuggestionsProvider = ({
       });
 
       editor.commands.acceptAllSuggestions();
-      for (const sId of sIds) {
+      for (const sId of instructionSuggestionIds) {
         appliedSuggestionsRef.current.delete(sId);
       }
 
@@ -423,8 +422,11 @@ export const CopilotSuggestionsProvider = ({
         return true;
       }
 
-      const sIds = instructionSuggestions.map((s) => s.sId);
-      const result = await patchSuggestions(sIds, "rejected");
+      const instructionSuggestionIds = instructionSuggestions.map((s) => s.sId);
+      const result = await patchSuggestions(
+        instructionSuggestionIds,
+        "rejected"
+      );
       if (!result) {
         return false;
       }
@@ -438,7 +440,7 @@ export const CopilotSuggestionsProvider = ({
       });
 
       editor.commands.rejectAllSuggestions();
-      for (const sId of sIds) {
+      for (const sId of instructionSuggestionIds) {
         appliedSuggestionsRef.current.delete(sId);
       }
 

--- a/front/components/agent_builder/copilot/useMCPServer.ts
+++ b/front/components/agent_builder/copilot/useMCPServer.ts
@@ -31,7 +31,7 @@ export function useCopilotMCPServer({
   enabled,
 }: UseCopilotMCPServerOptions): UseCopilotMCPServerResult {
   const { owner } = useAgentBuilderContext();
-  const { getValues, setValue } = useFormContext<AgentBuilderFormData>();
+  const { getValues } = useFormContext<AgentBuilderFormData>();
   const suggestionsContext = useCopilotSuggestions();
 
   const [serverId, setServerId] = useState<string | undefined>(undefined);
@@ -54,17 +54,7 @@ export function useCopilotMCPServer({
 
   // Create a stable callback for getting the current form values.
   // This is used by the MCP tool handler.
-  const getFormValues = useCallback(() => {
-    return getValues();
-  }, [getValues]);
-
-  // Create a stable callback for setting the instructions.
-  const setInstructions = useCallback(
-    (instructions: string) => {
-      setValue("instructions", instructions);
-    },
-    [setValue]
-  );
+  const getFormValues = useCallback(() => getValues(), [getValues]);
 
   useEffect(() => {
     // Don't initialize if the feature is disabled.
@@ -94,7 +84,7 @@ export function useCopilotMCPServer({
         registerGetAgentConfigTool(mcpServer, {
           getFormValues,
           getPendingSuggestions: suggestionsContextRef.current
-            ? () => suggestionsContextRef.current!.suggestions
+            ? () => suggestionsContextRef.current!.getPendingSuggestions()
             : undefined,
           getCommittedInstructions: suggestionsContextRef.current
             ? () => suggestionsContextRef.current!.getCommittedInstructions()
@@ -164,7 +154,7 @@ export function useCopilotMCPServer({
       setServerId(undefined);
       setIsConnected(false);
     };
-  }, [enabled, owner.sId, getFormValues, setInstructions]);
+  }, [enabled, owner.sId, getFormValues]);
 
   return {
     serverId,

--- a/front/components/markdown/suggestion/CopilotSuggestionCard.tsx
+++ b/front/components/markdown/suggestion/CopilotSuggestionCard.tsx
@@ -131,6 +131,8 @@ function ToolsSuggestionCards({
             state={cardState}
             applyLabel="Add"
             rejectLabel="Dismiss"
+            acceptedTitle={`${serverName} tool added`}
+            rejectedTitle={`${serverName} tool dismissed`}
             actionsPosition="header"
             onClickAccept={() => handleAcceptAddition(tool)}
             onClickReject={handleReject}
@@ -148,6 +150,8 @@ function ToolsSuggestionCards({
             state={cardState}
             applyLabel="Remove"
             rejectLabel="Dismiss"
+            acceptedTitle={`${serverName} tool removed`}
+            rejectedTitle={`${serverName} tool dismissed`}
             actionsPosition="header"
             onClickAccept={() => handleAcceptDeletion(tool)}
             onClickReject={handleReject}
@@ -215,6 +219,8 @@ function SkillsSuggestionCards({
           state={cardState}
           applyLabel="Add"
           rejectLabel="Dismiss"
+          acceptedTitle={`${skill.name} skill added`}
+          rejectedTitle={`${skill.name} skill dismissed`}
           actionsPosition="header"
           onClickAccept={() => handleAcceptAddition(skill)}
           onClickReject={handleReject}
@@ -229,6 +235,8 @@ function SkillsSuggestionCards({
           state={cardState}
           applyLabel="Remove"
           rejectLabel="Dismiss"
+          acceptedTitle={`${skill.name} skill removed`}
+          rejectedTitle={`${skill.name} skill dismissed`}
           actionsPosition="header"
           onClickAccept={() => handleAcceptDeletion(skill)}
           onClickReject={handleReject}
@@ -295,6 +303,8 @@ function ModelSuggestionCard({
       state={cardState}
       applyLabel="Change"
       rejectLabel="Dismiss"
+      acceptedTitle={`Model changed to ${modelName}`}
+      rejectedTitle={`${modelName} model dismissed`}
       actionsPosition="header"
       onClickAccept={handleAccept}
       onClickReject={handleReject}

--- a/front/components/markdown/suggestion/CopilotSuggestionCard.tsx
+++ b/front/components/markdown/suggestion/CopilotSuggestionCard.tsx
@@ -86,32 +86,38 @@ function ToolsSuggestionCards({
   const { setValue, getValues } = useFormContext<AgentBuilderFormData>();
 
   const handleAcceptAddition = useCallback(
-    (tool: MCPServerViewType) => {
-      const currentActions = getValues("actions");
-      const alreadyExists = currentActions.some(
-        (action) => action.configuration.mcpServerViewId === tool.sId
-      );
-      if (!alreadyExists) {
-        const newAction = getDefaultMCPAction(tool);
-        setValue("actions", [...currentActions, newAction], {
-          shouldDirty: true,
-        });
+    async (tool: MCPServerViewType) => {
+      const success = await acceptSuggestion(sId);
+      if (success) {
+        const currentActions = getValues("actions");
+        const alreadyExists = currentActions.some(
+          (a) => a.configuration.mcpServerViewId === tool.sId
+        );
+        if (!alreadyExists) {
+          setValue("actions", [...currentActions, getDefaultMCPAction(tool)], {
+            shouldDirty: true,
+          });
+        }
       }
-      void acceptSuggestion(sId);
     },
-    [getValues, setValue, acceptSuggestion, sId]
+    [acceptSuggestion, sId, getValues, setValue]
   );
 
   const handleAcceptDeletion = useCallback(
-    (tool: MCPServerViewType) => {
-      const currentActions = getValues("actions");
-      const filteredActions = currentActions.filter(
-        (action) => action.configuration.mcpServerViewId !== tool.sId
-      );
-      setValue("actions", filteredActions, { shouldDirty: true });
-      void acceptSuggestion(sId);
+    async (tool: MCPServerViewType) => {
+      const success = await acceptSuggestion(sId);
+      if (success) {
+        const currentActions = getValues("actions");
+        setValue(
+          "actions",
+          currentActions.filter(
+            (a) => a.configuration.mcpServerViewId !== tool.sId
+          ),
+          { shouldDirty: true }
+        );
+      }
     },
-    [getValues, setValue, acceptSuggestion, sId]
+    [acceptSuggestion, sId, getValues, setValue]
   );
 
   const handleReject = useCallback(() => {
@@ -177,31 +183,44 @@ function SkillsSuggestionCards({
   const { setValue, getValues } = useFormContext<AgentBuilderFormData>();
 
   const handleAcceptAddition = useCallback(
-    (skill: SkillType) => {
-      const currentSkills = getValues("skills");
-      const alreadyExists = currentSkills.some((s) => s.sId === skill.sId);
-      if (!alreadyExists) {
-        const newSkill = {
-          sId: skill.sId,
-          name: skill.name,
-          description: skill.userFacingDescription,
-          icon: skill.icon,
-        };
-        setValue("skills", [...currentSkills, newSkill], { shouldDirty: true });
+    async (skill: SkillType) => {
+      const success = await acceptSuggestion(sId);
+      if (success) {
+        const currentSkills = getValues("skills");
+        const alreadyExists = currentSkills.some((s) => s.sId === skill.sId);
+        if (!alreadyExists) {
+          setValue(
+            "skills",
+            [
+              ...currentSkills,
+              {
+                sId: skill.sId,
+                name: skill.name,
+                description: skill.userFacingDescription,
+                icon: skill.icon,
+              },
+            ],
+            { shouldDirty: true }
+          );
+        }
       }
-      void acceptSuggestion(sId);
     },
-    [getValues, setValue, acceptSuggestion, sId]
+    [acceptSuggestion, sId, getValues, setValue]
   );
 
   const handleAcceptDeletion = useCallback(
-    (skill: SkillType) => {
-      const currentSkills = getValues("skills");
-      const filteredSkills = currentSkills.filter((s) => s.sId !== skill.sId);
-      setValue("skills", filteredSkills, { shouldDirty: true });
-      void acceptSuggestion(sId);
+    async (skill: SkillType) => {
+      const success = await acceptSuggestion(sId);
+      if (success) {
+        const currentSkills = getValues("skills");
+        setValue(
+          "skills",
+          currentSkills.filter((s) => s.sId !== skill.sId),
+          { shouldDirty: true }
+        );
+      }
     },
-    [getValues, setValue, acceptSuggestion, sId]
+    [acceptSuggestion, sId, getValues, setValue]
   );
 
   const handleReject = useCallback(() => {
@@ -269,25 +288,22 @@ function ModelSuggestionCard({
     name: "generationSettings.reasoningEffort",
   });
 
-  const handleAccept = useCallback(() => {
-    const model = relations.model;
-    if (model) {
-      // Update the form with the new model settings
+  const handleAccept = useCallback(async () => {
+    const success = await acceptSuggestion(sId);
+    if (success && relations.model) {
       modelSettingsField.onChange({
-        modelId: model.modelId,
-        providerId: model.providerId,
+        modelId: relations.model.modelId,
+        providerId: relations.model.providerId,
       });
-      // Update reasoning effort if specified in the suggestion, otherwise use model default
       reasoningEffortField.onChange(
-        suggestion.reasoningEffort ?? model.defaultReasoningEffort
+        suggestion.reasoningEffort ?? relations.model.defaultReasoningEffort
       );
     }
-    void acceptSuggestion(sId);
   }, [
-    relations.model,
-    suggestion.reasoningEffort,
     sId,
     acceptSuggestion,
+    relations.model,
+    suggestion.reasoningEffort,
     modelSettingsField,
     reasoningEffortField,
   ]);

--- a/front/components/markdown/suggestion/CopilotSuggestionDirective.tsx
+++ b/front/components/markdown/suggestion/CopilotSuggestionDirective.tsx
@@ -74,7 +74,13 @@ export function getCopilotSuggestionPlugin() {
       ) {
         triggerRefetch(sId);
       }
-    }, [sId, suggestion, isSuggestionsValidating, triggerRefetch, hasAttemptedRefetch]);
+    }, [
+      sId,
+      suggestion,
+      isSuggestionsValidating,
+      triggerRefetch,
+      hasAttemptedRefetch,
+    ]);
 
     if (!sId || !kind) {
       return <SuggestionCardSkeleton kind={kind} />;

--- a/front/lib/swr/agent_suggestions.ts
+++ b/front/lib/swr/agent_suggestions.ts
@@ -80,32 +80,41 @@ export function usePatchAgentSuggestions({
       return null;
     }
 
-    const res = await clientFetch(
-      `/api/w/${workspaceId}/assistant/agent_configurations/${agentConfigurationId}/suggestions`,
-      {
-        method: "PATCH",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          suggestionIds,
-          state,
-        } satisfies PatchSuggestionRequestBody),
-      }
-    );
+    try {
+      const res = await clientFetch(
+        `/api/w/${workspaceId}/assistant/agent_configurations/${agentConfigurationId}/suggestions`,
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            suggestionIds,
+            state,
+          } satisfies PatchSuggestionRequestBody),
+        }
+      );
 
-    if (!res.ok) {
-      const errorData = await getErrorFromResponse(res);
+      if (!res.ok) {
+        const errorData = await getErrorFromResponse(res);
+        sendNotification({
+          type: "error",
+          title: "Failed to update suggestion",
+          description: errorData.message,
+        });
+        return null;
+      }
+
+      void mutateSuggestions();
+      const data = await res.json();
+      return data;
+    } catch {
       sendNotification({
         type: "error",
-        title: "Error updating suggestions",
-        description: `Error: ${errorData.message}`,
+        title: "Failed to update suggestion",
       });
       return null;
     }
-
-    void mutateSuggestions();
-    return res.json();
   };
 
   return { patchSuggestions };


### PR DESCRIPTION
Fixes: https://github.com/dust-tt/tasks/issues/6309

## Description

Refactors copilot suggestions for better UX and error handling:

**Local suggestion state layer**
- Processed (accepted/rejected) suggestions stored locally to prevent card "blink" while backend syncs
- Backend query fetches only `pending` state, local layer tracks processed state

**Fixed error flash on new suggestion**
- `hasAttemptedRefetch` marked only after debounced fetch completes, not when queued

**Form updates on success only**
- Cards await result and update form only on success (rollback would be very undigestable to do)
- Suggestion state still has optimistic update with rollback

**Error handling**
- Added try/catch for network errors in `patchSuggestions`
- Consistent notification pattern: "Failed to update suggestion"

**Minor**
- Accepted/rejected titles on suggestion cards
- Removed unused `setInstructions` callback

## Tests

![Screen Recording 2026-02-03 at 18 35 07](https://github.com/user-attachments/assets/30448cec-7ac0-4dd7-9edb-3b1eb524afce)


## Risk


## Deploy Plan

