### PR TITLE
[MCP Microsoft drive] copy file

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
@@ -9486,9 +9486,45 @@
           ],
           "type": "object"
         }
+      },
+      {
+        "name": "copy_file",
+        "description": "Copy a file or folder to a new location in OneDrive or SharePoint. Returns immediately with a monitor URL to check copy progress. This is the recommended method for creating documents from templates.",
+        "inputSchema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "additionalProperties": false,
+          "properties": {
+            "driveId": {
+              "description": "Drive ID (takes priority over siteId)",
+              "type": "string"
+            },
+            "itemId": {
+              "description": "ID of the item to copy",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name for the copied item",
+              "type": "string"
+            },
+            "parentItemId": {
+              "description": "ID of the parent folder for the copy. If not specified, copies to the same folder.",
+              "type": "string"
+            },
+            "siteId": {
+              "description": "SharePoint site ID",
+              "type": "string"
+            }
+          },
+          "required": [
+            "itemId",
+            "name"
+          ],
+          "type": "object"
+        }
       }
     ],
     "toolsStakes": {
+      "copy_file": "high",
       "get_file_content": "never_ask",
       "search_drive_items": "never_ask",
       "search_in_files": "never_ask",

--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
@@ -9339,11 +9339,11 @@
           "additionalProperties": false,
           "properties": {
             "driveId": {
-              "description": "Drive ID (takes priority over siteId)",
+              "description": "ID of the drive containing the file (takes priority over siteId)",
               "type": "string"
             },
             "itemId": {
-              "description": "ID of the item to copy",
+              "description": "ID of the file or folder to copy",
               "type": "string"
             },
             "name": {
@@ -9351,11 +9351,11 @@
               "type": "string"
             },
             "parentItemId": {
-              "description": "ID of the parent folder for the copy. If not specified, copies to the same folder.",
+              "description": "ID of the destination folder for the copy (defaults to same folder if not specified)",
               "type": "string"
             },
             "siteId": {
-              "description": "SharePoint site ID",
+              "description": "ID of the SharePoint site containing the file (used if driveId not provided)",
               "type": "string"
             }
           },
@@ -9469,7 +9469,7 @@
               "type": "string"
             },
             "driveId": {
-              "description": "The ID of the drive containing the file. Takes priority over siteId if provided.",
+              "description": "The ID of the drive containing the source file. Takes priority over siteId if provided.",
               "type": "string"
             },
             "itemId": {
@@ -9477,7 +9477,7 @@
               "type": "string"
             },
             "siteId": {
-              "description": "The ID of the SharePoint site containing the file. Used if driveId is not provided.",
+              "description": "The ID of the SharePoint site containing the source file. Used if driveId is not provided.",
               "type": "string"
             }
           },

--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
@@ -9333,7 +9333,7 @@
     "tools": [
       {
         "name": "copy_file",
-        "description": "Copy a file or folder to a new location in OneDrive or SharePoint. Returns immediately with a monitor URL to check copy progress. This is the recommended method for creating documents from templates.",
+        "description": "Copy a file or folder to a new location in OneDrive or SharePoint.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
           "additionalProperties": false,

--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
@@ -9332,6 +9332,41 @@
     "name": "microsoft_drive",
     "tools": [
       {
+        "name": "copy_file",
+        "description": "Copy a file or folder to a new location in OneDrive or SharePoint. Returns immediately with a monitor URL to check copy progress. This is the recommended method for creating documents from templates.",
+        "inputSchema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "additionalProperties": false,
+          "properties": {
+            "driveId": {
+              "description": "Drive ID (takes priority over siteId)",
+              "type": "string"
+            },
+            "itemId": {
+              "description": "ID of the item to copy",
+              "type": "string"
+            },
+            "name": {
+              "description": "Name for the copied item",
+              "type": "string"
+            },
+            "parentItemId": {
+              "description": "ID of the parent folder for the copy. If not specified, copies to the same folder.",
+              "type": "string"
+            },
+            "siteId": {
+              "description": "SharePoint site ID",
+              "type": "string"
+            }
+          },
+          "required": [
+            "itemId",
+            "name"
+          ],
+          "type": "object"
+        }
+      },
+      {
         "name": "get_file_content",
         "description": "Retrieve the content of files from SharePoint/OneDrive (Powerpoint, Word, Excel, etc.). Uses driveId if provided, otherwise falls back to siteId.",
         "inputSchema": {
@@ -9486,45 +9521,10 @@
           ],
           "type": "object"
         }
-      },
-      {
-        "name": "copy_file",
-        "description": "Copy a file or folder to a new location in OneDrive or SharePoint. Returns immediately with a monitor URL to check copy progress. This is the recommended method for creating documents from templates.",
-        "inputSchema": {
-          "$schema": "http://json-schema.org/draft-07/schema#",
-          "additionalProperties": false,
-          "properties": {
-            "driveId": {
-              "description": "Drive ID (takes priority over siteId)",
-              "type": "string"
-            },
-            "itemId": {
-              "description": "ID of the item to copy",
-              "type": "string"
-            },
-            "name": {
-              "description": "Name for the copied item",
-              "type": "string"
-            },
-            "parentItemId": {
-              "description": "ID of the parent folder for the copy. If not specified, copies to the same folder.",
-              "type": "string"
-            },
-            "siteId": {
-              "description": "SharePoint site ID",
-              "type": "string"
-            }
-          },
-          "required": [
-            "itemId",
-            "name"
-          ],
-          "type": "object"
-        }
       }
     ],
     "toolsStakes": {
-      "copy_file": "high",
+      "copy_file": "never_ask",
       "get_file_content": "never_ask",
       "search_drive_items": "never_ask",
       "search_in_files": "never_ask",

--- a/front/lib/api/actions/servers/microsoft_drive/metadata.ts
+++ b/front/lib/api/actions/servers/microsoft_drive/metadata.ts
@@ -145,7 +145,7 @@ export const MICROSOFT_DRIVE_TOOLS_METADATA = createToolsRecord({
   },
   copy_file: {
     description:
-      "Copy a file or folder to a new location in OneDrive or SharePoint. Returns immediately with a monitor URL to check copy progress. This is the recommended method for creating documents from templates.",
+      "Copy a file or folder to a new location in OneDrive or SharePoint.",
     schema: {
       itemId: z.string().describe("ID of the item to copy"),
       driveId: z

--- a/front/lib/api/actions/servers/microsoft_drive/metadata.ts
+++ b/front/lib/api/actions/servers/microsoft_drive/metadata.ts
@@ -51,13 +51,13 @@ export const MICROSOFT_DRIVE_TOOLS_METADATA = createToolsRecord({
         .string()
         .optional()
         .describe(
-          "The ID of the drive containing the file. Takes priority over siteId if provided."
+          "The ID of the drive containing the source file. Takes priority over siteId if provided."
         ),
       siteId: z
         .string()
         .optional()
         .describe(
-          "The ID of the SharePoint site containing the file. Used if driveId is not provided."
+          "The ID of the SharePoint site containing the source file. Used if driveId is not provided."
         ),
       documentXml: z
         .string()
@@ -147,17 +147,24 @@ export const MICROSOFT_DRIVE_TOOLS_METADATA = createToolsRecord({
     description:
       "Copy a file or folder to a new location in OneDrive or SharePoint.",
     schema: {
-      itemId: z.string().describe("ID of the item to copy"),
+      itemId: z.string().describe("ID of the file or folder to copy"),
       driveId: z
         .string()
         .optional()
-        .describe("Drive ID (takes priority over siteId)"),
-      siteId: z.string().optional().describe("SharePoint site ID"),
+        .describe(
+          "ID of the drive containing the file (takes priority over siteId)"
+        ),
+      siteId: z
+        .string()
+        .optional()
+        .describe(
+          "ID of the SharePoint site containing the file (used if driveId not provided)"
+        ),
       parentItemId: z
         .string()
         .optional()
         .describe(
-          "ID of the parent folder for the copy. If not specified, copies to the same folder."
+          "ID of the destination folder for the copy (defaults to same folder if not specified)"
         ),
       name: z.string().describe("Name for the copied item"),
     },

--- a/front/lib/api/actions/servers/microsoft_drive/metadata.ts
+++ b/front/lib/api/actions/servers/microsoft_drive/metadata.ts
@@ -143,6 +143,26 @@ export const MICROSOFT_DRIVE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "high",
   },
+  copy_file: {
+    description:
+      "Copy a file or folder to a new location in OneDrive or SharePoint. Returns immediately with a monitor URL to check copy progress. This is the recommended method for creating documents from templates.",
+    schema: {
+      itemId: z.string().describe("ID of the item to copy"),
+      driveId: z
+        .string()
+        .optional()
+        .describe("Drive ID (takes priority over siteId)"),
+      siteId: z.string().optional().describe("SharePoint site ID"),
+      parentItemId: z
+        .string()
+        .optional()
+        .describe(
+          "ID of the parent folder for the copy. If not specified, copies to the same folder."
+        ),
+      name: z.string().describe("Name for the copied item"),
+    },
+    stake: "high",
+  },
 });
 
 export const MICROSOFT_DRIVE_SERVER = {

--- a/front/lib/api/actions/servers/microsoft_drive/metadata.ts
+++ b/front/lib/api/actions/servers/microsoft_drive/metadata.ts
@@ -161,7 +161,7 @@ export const MICROSOFT_DRIVE_TOOLS_METADATA = createToolsRecord({
         ),
       name: z.string().describe("Name for the copied item"),
     },
-    stake: "high",
+    stake: "never_ask",
   },
 });
 

--- a/front/lib/api/actions/servers/microsoft_drive/tools/index.ts
+++ b/front/lib/api/actions/servers/microsoft_drive/tools/index.ts
@@ -428,15 +428,20 @@ const handlers: ToolHandlers<typeof MICROSOFT_DRIVE_TOOLS_METADATA> = {
         requestBody.parentReference = { id: parentItemId };
       }
 
-      const response = await client
+      const response = (await client
         .api(`${sourceEndpoint}/copy`)
-        .post(requestBody);
+        .post(requestBody)) as {
+        "@odata.location"?: string;
+        location?: string;
+      };
+
+      const monitorUrl = response["@odata.location"] ?? response.location;
 
       const result = {
         status: "accepted",
         message: "Copy operation initiated successfully",
         fileName: name,
-        monitorUrl: response["@odata.location"] ?? response.location,
+        monitorUrl,
         note: "The copy operation is asynchronous. Use the monitorUrl to check progress and get the final document ID, or use search_drive_items to find the document by name.",
       };
 

--- a/front/lib/api/actions/servers/microsoft_drive/tools/index.ts
+++ b/front/lib/api/actions/servers/microsoft_drive/tools/index.ts
@@ -402,7 +402,7 @@ const handlers: ToolHandlers<typeof MICROSOFT_DRIVE_TOOLS_METADATA> = {
   },
 
   copy_file: async ({ itemId, driveId, siteId, parentItemId, name }, extra) => {
-    // Validation: au moins driveId ou siteId requis
+    // Validation: at least driveId or siteId is required
     if (!driveId && !siteId) {
       return new Err(new MCPError("Either driveId or siteId must be provided"));
     }
@@ -413,24 +413,24 @@ const handlers: ToolHandlers<typeof MICROSOFT_DRIVE_TOOLS_METADATA> = {
         return new Err(new MCPError("Failed to get Microsoft Graph client"));
       }
 
-      // Construire l'endpoint source
+      // Build the source endpoint
       const sourceEndpoint = await getDriveItemEndpoint(
         itemId,
         driveId,
         siteId
       );
 
-      // Construire le corps de la requête
+      // Build the request body
       const requestBody: any = { name };
 
-      // Destination parent (optionnel)
+      // Parent destination (optional)
       if (parentItemId) {
         requestBody.parentReference = {
           id: parentItemId,
           driveId: driveId,
         };
 
-        // Si siteId fourni sans driveId, résoudre le driveId du site
+        // If siteId provided without driveId, resolve the site's driveId
         if (siteId && !driveId) {
           const siteResponse = await client.api(`/sites/${siteId}`).get();
           const siteDriveId = siteResponse.drive?.id;
@@ -443,17 +443,17 @@ const handlers: ToolHandlers<typeof MICROSOFT_DRIVE_TOOLS_METADATA> = {
         }
       }
 
-      // Effectuer la copie (opération asynchrone)
+      // Perform the copy (asynchronous operation)
       const response = await client
         .api(`${sourceEndpoint}/copy`)
         .post(requestBody);
 
-      // L'API retourne 202 Accepted avec monitoring URL
+      // API returns 202 Accepted with monitoring URL
       const result = {
         status: "accepted",
         message: "Copy operation initiated successfully",
         fileName: name,
-        monitorUrl: response["@odata.location"] || response.location,
+        monitorUrl: response["@odata.location"] ?? response.location,
         note: "The copy operation is asynchronous. Use the monitorUrl to check progress and get the final document ID, or use search_drive_items to find the document by name.",
       };
 


### PR DESCRIPTION
## Description
Adds `copy_file` tool to Microsoft Drive MCP server for copying files and folders in OneDrive/SharePoint. This enables creating documents from templates by copying existing files with a new name and optional destination folder.

The tool supports both driveId and siteId parameters and handles asynchronous copy operations by returning a monitor URL.

## Risk
The copy operation is asynchronous via Microsoft Graph API and returns a 202 Accepted response. The tool does not wait for completion - users must use the monitor URL or `search_drive_items` to verify the copy finished.

## Tests
Manually tested with SharePoint files and folders.

## Deploy Plan
Run front
