### PR TITLE
Add logs when analytics download fails

### DIFF
--- a/front/components/pages/workspace/AnalyticsPage.tsx
+++ b/front/components/pages/workspace/AnalyticsPage.tsx
@@ -18,6 +18,8 @@ import {
   useFeatureFlags,
   useWorkspaceSubscriptions,
 } from "@app/lib/swr/workspaces";
+import datadogLogger from "@app/logger/datadogLogger";
+import { normalizeError } from "@app/types";
 
 export function AnalyticsPage() {
   const owner = useWorkspace();
@@ -94,8 +96,16 @@ export function AnalyticsPage() {
       document.body.appendChild(link);
       link.click();
       document.body.removeChild(link);
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
     } catch (error) {
+      const normalizedError = normalizeError(error);
+      datadogLogger.error(
+        {
+          error: normalizedError.message,
+          workspaceId: owner.sId,
+          month: selectedMonth,
+        },
+        "[Analytics] Failed to download activity data"
+      );
       alert("Failed to download activity data.");
     } finally {
       setDownloadingMonth(null);


### PR DESCRIPTION
## Description

This PR adds logs when the Analytics download fails in order to help us debug.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Deploy front
