### PR TITLE
[front] Improve UI for run agent action details

### DIFF
--- a/front/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
@@ -275,26 +275,24 @@ export function MCPRunAgentActionDetails({
             )}
             {/* eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing */}
             {childAgent && (chainOfThought || response) && (
-              <div className="relative">
-                {conversationUrl && (
-                  <div className="absolute right-0">
+              <Collapsible defaultOpen={true}>
+                <div className="flex items-center justify-between py-2">
+                  <CollapsibleTrigger>
+                    <span className="text-sm font-semibold text-foreground dark:text-foreground-night">
+                      @{childAgent.name}'s Answer
+                    </span>
+                  </CollapsibleTrigger>
+                  {conversationUrl && (
                     <Button
                       icon={ExternalLinkIcon}
                       label="View full conversation"
                       variant="outline"
                       onClick={() => window.open(conversationUrl, "_blank")}
                       size="xs"
-                      className="!p-1"
                     />
-                  </div>
-                )}
-                <Collapsible defaultOpen={true}>
-                  <CollapsibleTrigger>
-                    <span className="p-1 text-sm font-semibold text-foreground dark:text-foreground-night">
-                      @{childAgent.name}'s Answer
-                    </span>
-                  </CollapsibleTrigger>
-                  <CollapsibleContent>
+                  )}
+                </div>
+                <CollapsibleContent>
                     <div className="flex flex-col gap-4">
                       {chainOfThought && (
                         <div className="text-sm font-normal text-muted-foreground dark:text-muted-foreground-night">
@@ -364,8 +362,7 @@ export function MCPRunAgentActionDetails({
                       )}
                     </div>
                   </CollapsibleContent>
-                </Collapsible>
-              </div>
+              </Collapsible>
             )}
             {generatedFiles.length > 0 && (
               <div className="flex flex-col gap-2">

--- a/front/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
@@ -104,7 +104,7 @@ export function MCPRunAgentActionDetails({
       const output = lastNotification.data.output;
       if (isStoreResourceProgressOutput(output)) {
         const runAgentQueryResource = output.contents.find(
-          isRunAgentQueryResourceType,
+          isRunAgentQueryResourceType
         );
         if (runAgentQueryResource) {
           setQuery(runAgentQueryResource.resource.text);
@@ -183,7 +183,7 @@ export function MCPRunAgentActionDetails({
   };
   const additionalMarkdownPlugins: PluggableList = useMemo(
     () => [getCiteDirective(), agentMentionDirective],
-    [],
+    []
   );
 
   const additionalMarkdownComponents: Components = useMemo(
@@ -192,7 +192,7 @@ export function MCPRunAgentActionDetails({
       // Warning: we can't rename easily `mention` to agent_mention, because the messages DB contains this name
       mention: getAgentMentionPlugin(owner),
     }),
-    [owner],
+    [owner]
   );
 
   if (!childAgent) {
@@ -245,7 +245,7 @@ export function MCPRunAgentActionDetails({
                 <ContentMessage title="Added Tools" variant="primary" size="lg">
                   {addedMCPServerViewIds.map((id) => {
                     const mcpServerView = mcpServerViews.find(
-                      (v) => v.sId === id,
+                      (v) => v.sId === id
                     );
                     if (!mcpServerView) {
                       return null;
@@ -348,7 +348,7 @@ export function MCPRunAgentActionDetails({
                                     <AttachmentCitation
                                       key={index}
                                       attachmentCitation={markdownCitationToAttachmentCitation(
-                                        document,
+                                        document
                                       )}
                                       owner={owner}
                                       conversationId={null}

--- a/front/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
@@ -104,7 +104,7 @@ export function MCPRunAgentActionDetails({
       const output = lastNotification.data.output;
       if (isStoreResourceProgressOutput(output)) {
         const runAgentQueryResource = output.contents.find(
-          isRunAgentQueryResourceType
+          isRunAgentQueryResourceType,
         );
         if (runAgentQueryResource) {
           setQuery(runAgentQueryResource.resource.text);
@@ -183,7 +183,7 @@ export function MCPRunAgentActionDetails({
   };
   const additionalMarkdownPlugins: PluggableList = useMemo(
     () => [getCiteDirective(), agentMentionDirective],
-    []
+    [],
   );
 
   const additionalMarkdownComponents: Components = useMemo(
@@ -192,7 +192,7 @@ export function MCPRunAgentActionDetails({
       // Warning: we can't rename easily `mention` to agent_mention, because the messages DB contains this name
       mention: getAgentMentionPlugin(owner),
     }),
-    [owner]
+    [owner],
   );
 
   if (!childAgent) {
@@ -245,7 +245,7 @@ export function MCPRunAgentActionDetails({
                 <ContentMessage title="Added Tools" variant="primary" size="lg">
                   {addedMCPServerViewIds.map((id) => {
                     const mcpServerView = mcpServerViews.find(
-                      (v) => v.sId === id
+                      (v) => v.sId === id,
                     );
                     if (!mcpServerView) {
                       return null;
@@ -293,75 +293,75 @@ export function MCPRunAgentActionDetails({
                   )}
                 </div>
                 <CollapsibleContent>
-                    <div className="flex flex-col gap-4">
-                      {chainOfThought && (
-                        <div className="text-sm font-normal text-muted-foreground dark:text-muted-foreground-night">
-                          <ContentMessage
-                            title="Agent thoughts"
-                            variant="primary"
-                            size="lg"
+                  <div className="flex flex-col gap-4">
+                    {chainOfThought && (
+                      <div className="text-sm font-normal text-muted-foreground dark:text-muted-foreground-night">
+                        <ContentMessage
+                          title="Agent thoughts"
+                          variant="primary"
+                          size="lg"
+                        >
+                          <Markdown
+                            content={chainOfThought}
+                            isStreaming={isStreamingChainOfThought}
+                            forcedTextSize="text-sm"
+                            textColor="text-muted-foreground"
+                            isLastMessage={false}
+                          />
+                        </ContentMessage>
+                      </div>
+                    )}
+                    {response && (
+                      <div className="text-sm font-normal text-muted-foreground dark:text-muted-foreground-night">
+                        <ContentMessage
+                          title="Response"
+                          variant="primary"
+                          size="lg"
+                        >
+                          <CitationsContext.Provider
+                            value={{
+                              references,
+                              updateActiveReferences,
+                            }}
                           >
                             <Markdown
-                              content={chainOfThought}
-                              isStreaming={isStreamingChainOfThought}
+                              content={response}
+                              isStreaming={isStreamingResponse}
                               forcedTextSize="text-sm"
                               textColor="text-muted-foreground"
                               isLastMessage={false}
+                              additionalMarkdownPlugins={
+                                additionalMarkdownPlugins
+                              }
+                              additionalMarkdownComponents={
+                                additionalMarkdownComponents
+                              }
                             />
-                          </ContentMessage>
-                        </div>
-                      )}
-                      {response && (
-                        <div className="text-sm font-normal text-muted-foreground dark:text-muted-foreground-night">
-                          <ContentMessage
-                            title="Response"
-                            variant="primary"
-                            size="lg"
-                          >
-                            <CitationsContext.Provider
-                              value={{
-                                references,
-                                updateActiveReferences,
-                              }}
-                            >
-                              <Markdown
-                                content={response}
-                                isStreaming={isStreamingResponse}
-                                forcedTextSize="text-sm"
-                                textColor="text-muted-foreground"
-                                isLastMessage={false}
-                                additionalMarkdownPlugins={
-                                  additionalMarkdownPlugins
-                                }
-                                additionalMarkdownComponents={
-                                  additionalMarkdownComponents
-                                }
-                              />
-                            </CitationsContext.Provider>
+                          </CitationsContext.Provider>
 
-                            {activeReferences.length > 0 && (
-                              <div className="mt-4">
-                                <CitationGrid variant="grid">
-                                  {activeReferences
-                                    .sort((a, b) => a.index - b.index)
-                                    .map(({ document, index }) => (
-                                      <AttachmentCitation
-                                        key={index}
-                                        attachmentCitation={markdownCitationToAttachmentCitation(
-                                          document
-                                        )}
-                                        owner={owner}
-                                        conversationId={null}
-                                      />
-                                    ))}
-                                </CitationGrid>
-                              </div>
-                            )}
-                          </ContentMessage>
-                        </div>
-                      )}
-                    </div>
-                  </CollapsibleContent>
+                          {activeReferences.length > 0 && (
+                            <div className="mt-4">
+                              <CitationGrid variant="grid">
+                                {activeReferences
+                                  .sort((a, b) => a.index - b.index)
+                                  .map(({ document, index }) => (
+                                    <AttachmentCitation
+                                      key={index}
+                                      attachmentCitation={markdownCitationToAttachmentCitation(
+                                        document,
+                                      )}
+                                      owner={owner}
+                                      conversationId={null}
+                                    />
+                                  ))}
+                              </CitationGrid>
+                            </div>
+                          )}
+                        </ContentMessage>
+                      </div>
+                    )}
+                  </div>
+                </CollapsibleContent>
               </Collapsible>
             )}
             {generatedFiles.length > 0 && (


### PR DESCRIPTION
## Description

- This PR improves the side panel UI for run agent tool executions.
- Primary goal is to add some padding under the "View full conversation" button.

Before
<img width="1136" height="729" alt="Screenshot 2026-02-03 at 12 09 17 PM" src="https://github.com/user-attachments/assets/80ecf742-010c-4e4f-b1a7-f95d06f8e6f2" />

After
<img width="1136" height="729" alt="Screenshot 2026-02-03 at 12 08 18 PM" src="https://github.com/user-attachments/assets/b24115e7-55b9-41c3-8033-9b1045e4c5c4" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
