### PR TITLE
Add sorting for poke column headers, make new react component for this

### DIFF
--- a/front/components/poke/PokeColumnSortableHeader.tsx
+++ b/front/components/poke/PokeColumnSortableHeader.tsx
@@ -1,0 +1,24 @@
+import { IconButton } from "@dust-tt/sparkle";
+import { ArrowsUpDownIcon } from "@heroicons/react/20/solid";
+import type { Column } from "@tanstack/react-table";
+
+interface PokeColumnSortableHeaderProps<TData> {
+  column: Column<TData, unknown>;
+  label: string;
+}
+
+export function PokeColumnSortableHeader<TData>({
+  column,
+  label,
+}: PokeColumnSortableHeaderProps<TData>) {
+  return (
+    <div className="flex items-center space-x-2">
+      <p>{label}</p>
+      <IconButton
+        variant="outline"
+        icon={ArrowsUpDownIcon}
+        onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+      />
+    </div>
+  );
+}

--- a/front/components/poke/apps/columns.tsx
+++ b/front/components/poke/apps/columns.tsx
@@ -3,9 +3,9 @@ import {
   IconButton,
   LinkWrapper,
 } from "@dust-tt/sparkle";
-import { ArrowsUpDownIcon } from "@heroicons/react/20/solid";
 import type { ColumnDef } from "@tanstack/react-table";
 
+import { PokeColumnSortableHeader } from "@app/components/poke/PokeColumnSortableHeader";
 import type { AppType, LightWorkspaceType } from "@app/types";
 
 export function makeColumnsForApps(
@@ -25,37 +25,15 @@ export function makeColumnsForApps(
           </LinkWrapper>
         );
       },
-      header: ({ column }) => {
-        return (
-          <div className="flex space-x-2">
-            <p>sId</p>
-            <IconButton
-              variant="outline"
-              icon={ArrowsUpDownIcon}
-              onClick={() =>
-                column.toggleSorting(column.getIsSorted() === "asc")
-              }
-            />
-          </div>
-        );
-      },
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="sId" />
+      ),
     },
     {
       accessorKey: "name",
-      header: ({ column }) => {
-        return (
-          <div className="flex space-x-2">
-            <p>Name</p>
-            <IconButton
-              variant="outline"
-              icon={ArrowsUpDownIcon}
-              onClick={() =>
-                column.toggleSorting(column.getIsSorted() === "asc")
-              }
-            />
-          </div>
-        );
-      },
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Name" />
+      ),
     },
     {
       accessorKey: "description",

--- a/front/components/poke/assistants/columns.tsx
+++ b/front/components/poke/assistants/columns.tsx
@@ -6,9 +6,9 @@ import {
   TrashIcon,
   XMarkIcon,
 } from "@dust-tt/sparkle";
-import { ArrowsUpDownIcon } from "@heroicons/react/20/solid";
 import type { ColumnDef } from "@tanstack/react-table";
 
+import { PokeColumnSortableHeader } from "@app/components/poke/PokeColumnSortableHeader";
 import { clientFetch } from "@app/lib/egress/client";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import type { PokeAgentConfigurationType } from "@app/pages/api/poke/workspaces/[wId]/agent_configurations";
@@ -31,49 +31,33 @@ export function makeColumnsForAssistants(
           </LinkWrapper>
         );
       },
-      header: ({ column }) => {
-        return (
-          <div className="flex space-x-2">
-            <p>Id</p>
-            <IconButton
-              variant="outline"
-              icon={ArrowsUpDownIcon}
-              onClick={() =>
-                column.toggleSorting(column.getIsSorted() === "asc")
-              }
-            />
-          </div>
-        );
-      },
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="sId" />
+      ),
     },
     {
       accessorKey: "name",
-      header: ({ column }) => {
-        return (
-          <div className="flex space-x-2">
-            <p>Name</p>
-            <IconButton
-              variant="outline"
-              icon={ArrowsUpDownIcon}
-              onClick={() =>
-                column.toggleSorting(column.getIsSorted() === "asc")
-              }
-            />
-          </div>
-        );
-      },
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Name" />
+      ),
     },
     {
       accessorKey: "scope",
-      header: "Scope",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Scope" />
+      ),
     },
     {
       accessorKey: "status",
-      header: "Status",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Status" />
+      ),
     },
     {
       accessorKey: "versionCreatedAt",
-      header: "Created at",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Created at" />
+      ),
       cell: ({ row }) => {
         const createdAt: string | null = row.getValue("versionCreatedAt");
 
@@ -93,20 +77,9 @@ export function makeColumnsForAssistants(
         }
         return row.versionAuthorId?.toString() ?? "";
       },
-      header: ({ column }) => {
-        return (
-          <div className="flex space-x-2">
-            <p>Author</p>
-            <IconButton
-              variant="outline"
-              icon={ArrowsUpDownIcon}
-              onClick={() =>
-                column.toggleSorting(column.getIsSorted() === "asc")
-              }
-            />
-          </div>
-        );
-      },
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Author" />
+      ),
       cell: ({ row }) => {
         const author = row.original.versionAuthor;
         if (author) {
@@ -117,7 +90,12 @@ export function makeColumnsForAssistants(
     },
     {
       accessorKey: "retention",
-      header: "Conversation retention",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader
+          column={column}
+          label="Conversation retention"
+        />
+      ),
       cell: ({ row }) => {
         const sId: string = row.getValue("sId");
         const retention: number = agentsRetention[sId];

--- a/front/components/poke/conversation/columns.tsx
+++ b/front/components/poke/conversation/columns.tsx
@@ -1,7 +1,7 @@
-import { IconButton, LinkWrapper } from "@dust-tt/sparkle";
-import { ArrowsUpDownIcon } from "@heroicons/react/20/solid";
+import { LinkWrapper } from "@dust-tt/sparkle";
 import type { ColumnDef } from "@tanstack/react-table";
 
+import { PokeColumnSortableHeader } from "@app/components/poke/PokeColumnSortableHeader";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import type {
   ConversationWithoutContentType,
@@ -14,20 +14,9 @@ export function makeColumnsForConversations(
   return [
     {
       accessorKey: "sId",
-      header: ({ column }) => {
-        return (
-          <div className="flex space-x-2">
-            <p>sId</p>
-            <IconButton
-              variant="outline"
-              icon={ArrowsUpDownIcon}
-              onClick={() =>
-                column.toggleSorting(column.getIsSorted() === "asc")
-              }
-            />
-          </div>
-        );
-      },
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="sId" />
+      ),
       cell: ({ row }) => {
         const conversation = row.original;
 
@@ -42,18 +31,24 @@ export function makeColumnsForConversations(
     },
     {
       accessorKey: "createdAt",
-      header: "Created At",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Created at" />
+      ),
       cell: ({ row }) => {
         return formatTimestampToFriendlyDate(row.original.created);
       },
     },
     {
       accessorKey: "title",
-      header: "Title",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Title" />
+      ),
     },
     {
       accessorKey: "visibility",
-      header: "Visibility",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Visibility" />
+      ),
     },
   ];
 }

--- a/front/components/poke/credits/columns.tsx
+++ b/front/components/poke/credits/columns.tsx
@@ -1,7 +1,7 @@
-import { Chip, IconButton } from "@dust-tt/sparkle";
-import { ArrowsUpDownIcon } from "@heroicons/react/20/solid";
+import { Chip } from "@dust-tt/sparkle";
 import type { ColumnDef } from "@tanstack/react-table";
 
+import { PokeColumnSortableHeader } from "@app/components/poke/PokeColumnSortableHeader";
 import { TYPE_COLORS } from "@app/components/workspace/CreditsList";
 import type { PokeCreditType } from "@app/pages/api/poke/workspaces/[wId]/credits";
 import { dateToHumanReadable } from "@app/types";
@@ -14,24 +14,15 @@ export function makeColumnsForCredits(): ColumnDef<PokeCreditType>[] {
   return [
     {
       accessorKey: "id",
-      header: "ID",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="ID" />
+      ),
     },
     {
       accessorKey: "type",
-      header: ({ column }) => {
-        return (
-          <div className="flex items-center space-x-2">
-            <p>Type</p>
-            <IconButton
-              variant="outline"
-              icon={ArrowsUpDownIcon}
-              onClick={() =>
-                column.toggleSorting(column.getIsSorted() === "asc")
-              }
-            />
-          </div>
-        );
-      },
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Type" />
+      ),
       cell: ({ row }) => {
         const { type } = row.original;
         return (
@@ -43,58 +34,25 @@ export function makeColumnsForCredits(): ColumnDef<PokeCreditType>[] {
     },
     {
       accessorKey: "initialAmountMicroUsd",
-      header: ({ column }) => {
-        return (
-          <div className="flex items-center space-x-2">
-            <p>Initial</p>
-            <IconButton
-              variant="outline"
-              icon={ArrowsUpDownIcon}
-              onClick={() =>
-                column.toggleSorting(column.getIsSorted() === "asc")
-              }
-            />
-          </div>
-        );
-      },
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Initial" />
+      ),
       cell: ({ row }) =>
         formatMicroUsdToUsd(row.original.initialAmountMicroUsd),
     },
     {
       accessorKey: "consumedAmountMicroUsd",
-      header: ({ column }) => {
-        return (
-          <div className="flex items-center space-x-2">
-            <p>Consumed</p>
-            <IconButton
-              variant="outline"
-              icon={ArrowsUpDownIcon}
-              onClick={() =>
-                column.toggleSorting(column.getIsSorted() === "asc")
-              }
-            />
-          </div>
-        );
-      },
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Consumed" />
+      ),
       cell: ({ row }) =>
         formatMicroUsdToUsd(row.original.consumedAmountMicroUsd),
     },
     {
       accessorKey: "remainingAmountMicroUsd",
-      header: ({ column }) => {
-        return (
-          <div className="flex items-center space-x-2">
-            <p>Remaining</p>
-            <IconButton
-              variant="outline"
-              icon={ArrowsUpDownIcon}
-              onClick={() =>
-                column.toggleSorting(column.getIsSorted() === "asc")
-              }
-            />
-          </div>
-        );
-      },
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Remaining" />
+      ),
       cell: ({ row }) => {
         const remaining = row.original.remainingAmountMicroUsd;
         const initial = row.original.initialAmountMicroUsd;
@@ -111,20 +69,9 @@ export function makeColumnsForCredits(): ColumnDef<PokeCreditType>[] {
     },
     {
       accessorKey: "startDate",
-      header: ({ column }) => {
-        return (
-          <div className="flex items-center space-x-2">
-            <p>Start Date</p>
-            <IconButton
-              variant="outline"
-              icon={ArrowsUpDownIcon}
-              onClick={() =>
-                column.toggleSorting(column.getIsSorted() === "asc")
-              }
-            />
-          </div>
-        );
-      },
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Start date" />
+      ),
       cell: ({ row }) => {
         const { startDate } = row.original;
         if (!startDate) {
@@ -139,20 +86,9 @@ export function makeColumnsForCredits(): ColumnDef<PokeCreditType>[] {
     },
     {
       accessorKey: "expirationDate",
-      header: ({ column }) => {
-        return (
-          <div className="flex items-center space-x-2">
-            <p>Expiration</p>
-            <IconButton
-              variant="outline"
-              icon={ArrowsUpDownIcon}
-              onClick={() =>
-                column.toggleSorting(column.getIsSorted() === "asc")
-              }
-            />
-          </div>
-        );
-      },
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Expiration" />
+      ),
       cell: ({ row }) => {
         const { expirationDate } = row.original;
         if (!expirationDate) {
@@ -170,7 +106,9 @@ export function makeColumnsForCredits(): ColumnDef<PokeCreditType>[] {
     },
     {
       accessorKey: "discount",
-      header: "Billed Discount",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Billed discount" />
+      ),
       cell: ({ row }) => {
         const { discount } = row.original;
         if (discount === null) {
@@ -181,20 +119,9 @@ export function makeColumnsForCredits(): ColumnDef<PokeCreditType>[] {
     },
     {
       accessorKey: "createdAt",
-      header: ({ column }) => {
-        return (
-          <div className="flex items-center space-x-2">
-            <p>Created</p>
-            <IconButton
-              variant="outline"
-              icon={ArrowsUpDownIcon}
-              onClick={() =>
-                column.toggleSorting(column.getIsSorted() === "asc")
-              }
-            />
-          </div>
-        );
-      },
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Created" />
+      ),
       cell: ({ row }) => {
         return (
           <span className="text-sm">

--- a/front/components/poke/data_source_views/columns.tsx
+++ b/front/components/poke/data_source_views/columns.tsx
@@ -1,7 +1,7 @@
-import { IconButton, LinkWrapper } from "@dust-tt/sparkle";
-import { ArrowsUpDownIcon } from "@heroicons/react/20/solid";
+import { LinkWrapper } from "@dust-tt/sparkle";
 import type { ColumnDef } from "@tanstack/react-table";
 
+import { PokeColumnSortableHeader } from "@app/components/poke/PokeColumnSortableHeader";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import type { AgentsUsageType } from "@app/types";
 
@@ -25,20 +25,9 @@ export function makeColumnsForDataSourceViews(): ColumnDef<DataSourceView>[] {
 
         return <LinkWrapper href={dataSourceViewLink}>{sId}</LinkWrapper>;
       },
-      header: ({ column }) => {
-        return (
-          <div className="flex space-x-2">
-            <p>sId</p>
-            <IconButton
-              variant="outline"
-              icon={ArrowsUpDownIcon}
-              onClick={() =>
-                column.toggleSorting(column.getIsSorted() === "asc")
-              }
-            />
-          </div>
-        );
-      },
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="sId" />
+      ),
     },
     {
       accessorKey: "dataSourceName",
@@ -49,37 +38,15 @@ export function makeColumnsForDataSourceViews(): ColumnDef<DataSourceView>[] {
           <LinkWrapper href={dataSourceLink}>{dataSourceName}</LinkWrapper>
         );
       },
-      header: ({ column }) => {
-        return (
-          <div className="flex space-x-2">
-            <p>Data Source</p>
-            <IconButton
-              variant="outline"
-              icon={ArrowsUpDownIcon}
-              onClick={() =>
-                column.toggleSorting(column.getIsSorted() === "asc")
-              }
-            />
-          </div>
-        );
-      },
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Data source" />
+      ),
     },
     {
       accessorKey: "usage",
-      header: ({ column }) => {
-        return (
-          <div className="flex space-x-2">
-            <p>Usage</p>
-            <IconButton
-              variant="outline"
-              icon={ArrowsUpDownIcon}
-              onClick={() =>
-                column.toggleSorting(column.getIsSorted() === "asc")
-              }
-            />
-          </div>
-        );
-      },
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Usage" />
+      ),
       cell: ({ row }) => {
         const usage = row.original.usage;
         if (!usage) {
@@ -112,15 +79,21 @@ export function makeColumnsForDataSourceViews(): ColumnDef<DataSourceView>[] {
 
     {
       accessorKey: "editedBy",
-      header: "Last edited by",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Last edited by" />
+      ),
     },
     {
       accessorKey: "kind",
-      header: "Kind",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Kind" />
+      ),
     },
     {
       accessorKey: "editedAt",
-      header: "Last edited at",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Last edited at" />
+      ),
       cell: ({ row }) => {
         const editedAt: number | undefined = row.getValue("editedAt");
 

--- a/front/components/poke/data_sources/columns.tsx
+++ b/front/components/poke/data_sources/columns.tsx
@@ -1,7 +1,7 @@
-import { IconButton, LinkWrapper } from "@dust-tt/sparkle";
-import { ArrowsUpDownIcon } from "@heroicons/react/20/solid";
+import { LinkWrapper } from "@dust-tt/sparkle";
 import type { ColumnDef } from "@tanstack/react-table";
 
+import { PokeColumnSortableHeader } from "@app/components/poke/PokeColumnSortableHeader";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import type { WorkspaceType } from "@app/types";
 
@@ -29,49 +29,33 @@ export function makeColumnsForDataSources(
           </LinkWrapper>
         );
       },
-      header: ({ column }) => {
-        return (
-          <div className="flex space-x-2">
-            <p>sId</p>
-            <IconButton
-              variant="outline"
-              icon={ArrowsUpDownIcon}
-              onClick={() =>
-                column.toggleSorting(column.getIsSorted() === "asc")
-              }
-            />
-          </div>
-        );
-      },
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="sId" />
+      ),
     },
     {
       accessorKey: "name",
-      header: ({ column }) => {
-        return (
-          <div className="flex space-x-2">
-            <p>Name</p>
-            <IconButton
-              variant="outline"
-              icon={ArrowsUpDownIcon}
-              onClick={() =>
-                column.toggleSorting(column.getIsSorted() === "asc")
-              }
-            />
-          </div>
-        );
-      },
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Name" />
+      ),
     },
     {
       accessorKey: "connectorProvider",
-      header: "Provider",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Provider" />
+      ),
     },
     {
       accessorKey: "editedBy",
-      header: "Last edited by",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Last edited by" />
+      ),
     },
     {
       accessorKey: "editedAt",
-      header: "Last edited at",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Last edited at" />
+      ),
       cell: ({ row }) => {
         const editedAt: number | undefined = row.getValue("editedAt");
 

--- a/front/components/poke/features/columns.tsx
+++ b/front/components/poke/features/columns.tsx
@@ -1,7 +1,7 @@
-import { Chip, IconButton } from "@dust-tt/sparkle";
-import { ArrowsUpDownIcon } from "@heroicons/react/20/solid";
+import { Chip } from "@dust-tt/sparkle";
 import type { ColumnDef } from "@tanstack/react-table";
 
+import { PokeColumnSortableHeader } from "@app/components/poke/PokeColumnSortableHeader";
 import type { FeatureFlagStage, WhitelistableFeature } from "@app/types";
 import { dateToHumanReadable, FEATURE_FLAG_STAGE_LABELS } from "@app/types";
 
@@ -17,37 +17,15 @@ export function makeColumnsForFeatureFlags(): ColumnDef<FeatureFlagsDisplayType>
   return [
     {
       accessorKey: "name",
-      header: ({ column }) => {
-        return (
-          <div className="flex items-center space-x-2">
-            <p>Name</p>
-            <IconButton
-              variant="outline"
-              icon={ArrowsUpDownIcon}
-              onClick={() =>
-                column.toggleSorting(column.getIsSorted() === "asc")
-              }
-            />
-          </div>
-        );
-      },
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Name" />
+      ),
     },
     {
       accessorKey: "stage",
-      header: ({ column }) => {
-        return (
-          <div className="flex items-center space-x-2">
-            <p>Stage</p>
-            <IconButton
-              variant="outline"
-              icon={ArrowsUpDownIcon}
-              onClick={() =>
-                column.toggleSorting(column.getIsSorted() === "asc")
-              }
-            />
-          </div>
-        );
-      },
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Stage" />
+      ),
       cell: ({ row }) => {
         const { stage } = row.original;
         const warningStages: FeatureFlagStage[] = ["dust_only", "rolling_out"];
@@ -75,20 +53,9 @@ export function makeColumnsForFeatureFlags(): ColumnDef<FeatureFlagsDisplayType>
     },
     {
       accessorKey: "enabled",
-      header: ({ column }) => {
-        return (
-          <div className="flex items-center space-x-2">
-            <p>Status</p>
-            <IconButton
-              variant="outline"
-              icon={ArrowsUpDownIcon}
-              onClick={() =>
-                column.toggleSorting(column.getIsSorted() === "asc")
-              }
-            />
-          </div>
-        );
-      },
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Status" />
+      ),
       cell: ({ row }) => {
         const { enabled } = row.original;
         return (
@@ -102,20 +69,9 @@ export function makeColumnsForFeatureFlags(): ColumnDef<FeatureFlagsDisplayType>
     },
     {
       accessorKey: "enabledAt",
-      header: ({ column }) => {
-        return (
-          <div className="flex items-center space-x-2">
-            <p>Enabled Date</p>
-            <IconButton
-              variant="outline"
-              icon={ArrowsUpDownIcon}
-              onClick={() =>
-                column.toggleSorting(column.getIsSorted() === "asc")
-              }
-            />
-          </div>
-        );
-      },
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Enabled date" />
+      ),
       cell: ({ row }) => {
         const { enabledAt } = row.original;
         if (!enabledAt) {

--- a/front/components/poke/groups/columns.tsx
+++ b/front/components/poke/groups/columns.tsx
@@ -1,7 +1,7 @@
-import { Chip, IconButton, LinkWrapper } from "@dust-tt/sparkle";
-import { ArrowsUpDownIcon } from "@heroicons/react/20/solid";
+import { Chip, LinkWrapper } from "@dust-tt/sparkle";
 import type { ColumnDef } from "@tanstack/react-table";
 
+import { PokeColumnSortableHeader } from "@app/components/poke/PokeColumnSortableHeader";
 import type { GroupKind, GroupType, WorkspaceType } from "@app/types";
 
 export const getPokeGroupKindChipColor = (kind: GroupKind) => {
@@ -35,37 +35,15 @@ export function makeColumnsForGroups(
           </LinkWrapper>
         );
       },
-      header: ({ column }) => {
-        return (
-          <div className="flex space-x-2">
-            <p>sId</p>
-            <IconButton
-              variant="outline"
-              icon={ArrowsUpDownIcon}
-              onClick={() =>
-                column.toggleSorting(column.getIsSorted() === "asc")
-              }
-            />
-          </div>
-        );
-      },
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="sId" />
+      ),
     },
     {
       accessorKey: "name",
-      header: ({ column }) => {
-        return (
-          <div className="flex space-x-2">
-            <p>Name</p>
-            <IconButton
-              variant="outline"
-              icon={ArrowsUpDownIcon}
-              onClick={() =>
-                column.toggleSorting(column.getIsSorted() === "asc")
-              }
-            />
-          </div>
-        );
-      },
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Name" />
+      ),
     },
     {
       accessorKey: "kind",
@@ -73,20 +51,9 @@ export function makeColumnsForGroups(
         const kind: GroupKind = row.getValue("kind");
         return <Chip color={getPokeGroupKindChipColor(kind)}>{kind}</Chip>;
       },
-      header: ({ column }) => {
-        return (
-          <div className="flex space-x-2">
-            <p>Kind</p>
-            <IconButton
-              variant="outline"
-              icon={ArrowsUpDownIcon}
-              onClick={() =>
-                column.toggleSorting(column.getIsSorted() === "asc")
-              }
-            />
-          </div>
-        );
-      },
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Kind" />
+      ),
     },
     {
       accessorKey: "memberCount",
@@ -95,20 +62,9 @@ export function makeColumnsForGroups(
 
         return memberCount.toString();
       },
-      header: ({ column }) => {
-        return (
-          <div className="flex space-x-2">
-            <p>Members</p>
-            <IconButton
-              variant="outline"
-              icon={ArrowsUpDownIcon}
-              onClick={() =>
-                column.toggleSorting(column.getIsSorted() === "asc")
-              }
-            />
-          </div>
-        );
-      },
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Members" />
+      ),
     },
   ];
 }

--- a/front/components/poke/invitations/columns.tsx
+++ b/front/components/poke/invitations/columns.tsx
@@ -6,6 +6,7 @@ import {
 } from "@dust-tt/sparkle";
 import type { ColumnDef } from "@tanstack/react-table";
 
+import { PokeColumnSortableHeader } from "@app/components/poke/PokeColumnSortableHeader";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import type { MembershipInvitationTypeWithLink } from "@app/types";
 
@@ -16,23 +17,31 @@ export function makeColumnsForInvitations(
   return [
     {
       accessorKey: "sId",
-      header: "ID",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="sId" />
+      ),
     },
     {
       accessorKey: "inviteEmail",
-      header: "email",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Email" />
+      ),
     },
     {
       accessorKey: "status",
-      header: "Status",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Status" />
+      ),
     },
     {
       accessorKey: "isExpired",
-      header: "Expired",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Expired" />
+      ),
     },
     {
       accessorKey: "inviteLink",
-      header: "Invitation Link",
+      header: "Invitation link",
       cell: ({ row }) => {
         const inviteLink: string = row.getValue("inviteLink");
         return (
@@ -79,7 +88,9 @@ export function makeColumnsForInvitations(
     },
     {
       accessorKey: "createdAt",
-      header: "Created at",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Created at" />
+      ),
       cell: ({ row }) => {
         const createdAt: string | null = row.getValue("createdAt");
 
@@ -92,7 +103,9 @@ export function makeColumnsForInvitations(
     },
     {
       accessorKey: "initialRole",
-      header: "Role",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Role" />
+      ),
     },
     {
       id: "actions",

--- a/front/components/poke/mcp_server_views/columns.tsx
+++ b/front/components/poke/mcp_server_views/columns.tsx
@@ -1,7 +1,7 @@
-import { IconButton, LinkWrapper } from "@dust-tt/sparkle";
-import { ArrowsUpDownIcon } from "@heroicons/react/20/solid";
+import { LinkWrapper } from "@dust-tt/sparkle";
 import type { ColumnDef } from "@tanstack/react-table";
 
+import { PokeColumnSortableHeader } from "@app/components/poke/PokeColumnSortableHeader";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 
 interface MCPServerView {
@@ -29,7 +29,9 @@ export function makeColumnsForMCPServerViews(): ColumnDef<MCPServerView>[] {
 
         return <LinkWrapper href={mcpServerViewLink}>{sId}</LinkWrapper>;
       },
-      header: "sId",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="sId" />
+      ),
     },
     {
       accessorKey: "server.name",
@@ -40,20 +42,9 @@ export function makeColumnsForMCPServerViews(): ColumnDef<MCPServerView>[] {
           <LinkWrapper href={mcpServerViewLink}>{server.name}</LinkWrapper>
         );
       },
-      header: ({ column }) => {
-        return (
-          <div className="flex space-x-2">
-            <p>Server Name</p>
-            <IconButton
-              variant="outline"
-              icon={ArrowsUpDownIcon}
-              onClick={() =>
-                column.toggleSorting(column.getIsSorted() === "asc")
-              }
-            />
-          </div>
-        );
-      },
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Server name" />
+      ),
     },
     {
       accessorKey: "space",
@@ -61,31 +52,24 @@ export function makeColumnsForMCPServerViews(): ColumnDef<MCPServerView>[] {
         const { spaceLink, spaceId } = row.original;
         return <LinkWrapper href={spaceLink}>{spaceId}</LinkWrapper>;
       },
-      header: "Space",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Space" />
+      ),
     },
     {
       accessorKey: "editedBy",
-      header: "Last edited by",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Last edited by" />
+      ),
     },
     {
       accessorKey: "createdAt",
       cell: ({ row }) => {
         return formatTimestampToFriendlyDate(row.original.createdAt);
       },
-      header: ({ column }) => {
-        return (
-          <div className="flex space-x-2">
-            <p>Created At</p>
-            <IconButton
-              variant="outline"
-              icon={ArrowsUpDownIcon}
-              onClick={() =>
-                column.toggleSorting(column.getIsSorted() === "asc")
-              }
-            />
-          </div>
-        );
-      },
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Created at" />
+      ),
     },
     {
       accessorKey: "editedAt",
@@ -94,20 +78,9 @@ export function makeColumnsForMCPServerViews(): ColumnDef<MCPServerView>[] {
           ? formatTimestampToFriendlyDate(row.original.editedAt)
           : "";
       },
-      header: ({ column }) => {
-        return (
-          <div className="flex space-x-2">
-            <p>Last edited at</p>
-            <IconButton
-              variant="outline"
-              icon={ArrowsUpDownIcon}
-              onClick={() =>
-                column.toggleSorting(column.getIsSorted() === "asc")
-              }
-            />
-          </div>
-        );
-      },
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Last edited at" />
+      ),
     },
   ];
 }

--- a/front/components/poke/members/columns.tsx
+++ b/front/components/poke/members/columns.tsx
@@ -1,7 +1,7 @@
 import { IconButton, TrashIcon } from "@dust-tt/sparkle";
-import { ArrowsUpDownIcon } from "@heroicons/react/20/solid";
 import type { ColumnDef } from "@tanstack/react-table";
 
+import { PokeColumnSortableHeader } from "@app/components/poke/PokeColumnSortableHeader";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import type {
   ActiveRoleType,
@@ -35,58 +35,27 @@ export function makeColumnsForMembers({
   const baseColumns: ColumnDef<MemberDisplayType>[] = [
     {
       accessorKey: "sId",
-      header: ({ column }) => {
-        return (
-          <div className="flex space-x-2">
-            <p>Id</p>
-            <IconButton
-              variant="outline"
-              icon={ArrowsUpDownIcon}
-              onClick={() =>
-                column.toggleSorting(column.getIsSorted() === "asc")
-              }
-            />
-          </div>
-        );
-      },
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="sId" />
+      ),
     },
     {
       accessorKey: "name",
-      header: ({ column }) => {
-        return (
-          <div className="flex space-x-2">
-            <p>Name</p>
-            <IconButton
-              variant="outline"
-              icon={ArrowsUpDownIcon}
-              onClick={() =>
-                column.toggleSorting(column.getIsSorted() === "asc")
-              }
-            />
-          </div>
-        );
-      },
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Name" />
+      ),
     },
     {
       accessorKey: "email",
-      header: "email",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Email" />
+      ),
     },
     {
       accessorKey: "lastLoginAt",
-      header: ({ column }) => {
-        return (
-          <div className="flex space-x-2">
-            <p>Last login</p>
-            <IconButton
-              variant="outline"
-              icon={ArrowsUpDownIcon}
-              onClick={() =>
-                column.toggleSorting(column.getIsSorted() === "asc")
-              }
-            />
-          </div>
-        );
-      },
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Last login" />
+      ),
       cell: ({ row }) => {
         const lastLoginAt: number | null = row.getValue("lastLoginAt");
 
@@ -99,7 +68,9 @@ export function makeColumnsForMembers({
     },
     {
       accessorKey: "createdAt",
-      header: "Created at",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Created at" />
+      ),
       cell: ({ row }) => {
         const createdAt: string | null = row.getValue("createdAt");
 
@@ -112,20 +83,9 @@ export function makeColumnsForMembers({
     },
     {
       accessorKey: "role",
-      header: ({ column }) => {
-        return (
-          <div className="flex space-x-2">
-            <p>Role</p>
-            <IconButton
-              variant="outline"
-              icon={ArrowsUpDownIcon}
-              onClick={() =>
-                column.toggleSorting(column.getIsSorted() === "asc")
-              }
-            />
-          </div>
-        );
-      },
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Role" />
+      ),
       filterFn: (row, id, value) => {
         return value.includes(row.getValue(id));
       },

--- a/front/components/poke/skills/columns.tsx
+++ b/front/components/poke/skills/columns.tsx
@@ -1,7 +1,7 @@
-import { Button, LinkWrapper } from "@dust-tt/sparkle";
-import { ArrowsUpDownIcon } from "@heroicons/react/20/solid";
+import { LinkWrapper } from "@dust-tt/sparkle";
 import type { ColumnDef } from "@tanstack/react-table";
 
+import { PokeColumnSortableHeader } from "@app/components/poke/PokeColumnSortableHeader";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import type { LightWorkspaceType } from "@app/types";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
@@ -26,45 +26,27 @@ export function makeColumnsForSkills(
           </LinkWrapper>
         );
       },
-      header: ({ column }) => {
-        return (
-          <div className="flex space-x-2">
-            <p>Id</p>
-            <Button
-              variant="ghost"
-              icon={ArrowsUpDownIcon}
-              onClick={() =>
-                column.toggleSorting(column.getIsSorted() === "asc")
-              }
-            />
-          </div>
-        );
-      },
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="sId" />
+      ),
     },
     {
       accessorKey: "name",
-      header: ({ column }) => {
-        return (
-          <div className="flex space-x-2">
-            <p>Name</p>
-            <Button
-              variant="ghost"
-              icon={ArrowsUpDownIcon}
-              onClick={() =>
-                column.toggleSorting(column.getIsSorted() === "asc")
-              }
-            />
-          </div>
-        );
-      },
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Name" />
+      ),
     },
     {
       accessorKey: "status",
-      header: "Status",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Status" />
+      ),
     },
     {
       accessorKey: "createdAt",
-      header: "Created at",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Created at" />
+      ),
       cell: ({ row }) => {
         const createdAt: number | null = row.getValue("createdAt");
         return createdAt ? formatTimestampToFriendlyDate(createdAt) : null;
@@ -72,7 +54,9 @@ export function makeColumnsForSkills(
     },
     {
       accessorKey: "updatedAt",
-      header: "Updated at",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Updated at" />
+      ),
       cell: ({ row }) => {
         const updatedAt: number | null = row.getValue("updatedAt");
         return updatedAt ? formatTimestampToFriendlyDate(updatedAt) : null;

--- a/front/components/poke/spaces/columns.tsx
+++ b/front/components/poke/spaces/columns.tsx
@@ -1,7 +1,7 @@
-import { IconButton, LinkWrapper } from "@dust-tt/sparkle";
-import { ArrowsUpDownIcon } from "@heroicons/react/20/solid";
+import { LinkWrapper } from "@dust-tt/sparkle";
 import type { ColumnDef } from "@tanstack/react-table";
 
+import { PokeColumnSortableHeader } from "@app/components/poke/PokeColumnSortableHeader";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import type { SpaceType, WorkspaceType } from "@app/types";
 
@@ -20,54 +20,21 @@ export function makeColumnsForSpaces(
           </LinkWrapper>
         );
       },
-      header: ({ column }) => {
-        return (
-          <div className="flex space-x-2">
-            <p>sId</p>
-            <IconButton
-              variant="outline"
-              icon={ArrowsUpDownIcon}
-              onClick={() =>
-                column.toggleSorting(column.getIsSorted() === "asc")
-              }
-            />
-          </div>
-        );
-      },
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="sId" />
+      ),
     },
     {
       accessorKey: "name",
-      header: ({ column }) => {
-        return (
-          <div className="flex space-x-2">
-            <p>Name</p>
-            <IconButton
-              variant="outline"
-              icon={ArrowsUpDownIcon}
-              onClick={() =>
-                column.toggleSorting(column.getIsSorted() === "asc")
-              }
-            />
-          </div>
-        );
-      },
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Name" />
+      ),
     },
     {
       accessorKey: "kind",
-      header: ({ column }) => {
-        return (
-          <div className="flex space-x-2">
-            <p>Kind</p>
-            <IconButton
-              variant="outline"
-              icon={ArrowsUpDownIcon}
-              onClick={() =>
-                column.toggleSorting(column.getIsSorted() === "asc")
-              }
-            />
-          </div>
-        );
-      },
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Kind" />
+      ),
     },
     {
       accessorKey: "isRestricted",
@@ -76,23 +43,15 @@ export function makeColumnsForSpaces(
 
         return isRestricted ? "Yes" : "No";
       },
-      header: ({ column }) => {
-        return (
-          <div className="flex space-x-2">
-            <p>Is Restricted</p>
-            <IconButton
-              variant="outline"
-              icon={ArrowsUpDownIcon}
-              onClick={() =>
-                column.toggleSorting(column.getIsSorted() === "asc")
-              }
-            />
-          </div>
-        );
-      },
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Is restricted" />
+      ),
     },
     {
       accessorKey: "createdAt",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Created at" />
+      ),
       cell: ({ row }) => {
         const createdAt: number = row.getValue("createdAt");
 
@@ -101,6 +60,9 @@ export function makeColumnsForSpaces(
     },
     {
       accessorKey: "updatedAt",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Updated at" />
+      ),
       cell: ({ row }) => {
         const updatedAt: number = row.getValue("updatedAt");
 

--- a/front/components/poke/subscriptions/columns.tsx
+++ b/front/components/poke/subscriptions/columns.tsx
@@ -1,6 +1,6 @@
-import { IconButton } from "@dust-tt/sparkle";
-import { ArrowsUpDownIcon } from "@heroicons/react/20/solid";
 import type { ColumnDef, Row } from "@tanstack/react-table";
+
+import { PokeColumnSortableHeader } from "@app/components/poke/PokeColumnSortableHeader";
 
 export type SubscriptionsDisplayType = {
   id: string;
@@ -34,54 +34,21 @@ export function makeColumnsForSubscriptions(): ColumnDef<SubscriptionsDisplayTyp
   return [
     {
       accessorKey: "id",
-      header: ({ column }) => {
-        return (
-          <div className="flex space-x-2">
-            <p>Id</p>
-            <IconButton
-              variant="ghost"
-              icon={ArrowsUpDownIcon}
-              onClick={() =>
-                column.toggleSorting(column.getIsSorted() === "asc")
-              }
-            />
-          </div>
-        );
-      },
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="ID" />
+      ),
     },
     {
       accessorKey: "name",
-      header: ({ column }) => {
-        return (
-          <div className="flex space-x-2">
-            <p>Plan Code</p>
-            <IconButton
-              variant="ghost"
-              icon={ArrowsUpDownIcon}
-              onClick={() =>
-                column.toggleSorting(column.getIsSorted() === "asc")
-              }
-            />
-          </div>
-        );
-      },
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Plan code" />
+      ),
     },
     {
       accessorKey: "status",
-      header: ({ column }) => {
-        return (
-          <div className="flex space-x-2">
-            <p>Status</p>
-            <IconButton
-              variant="ghost"
-              icon={ArrowsUpDownIcon}
-              onClick={() =>
-                column.toggleSorting(column.getIsSorted() === "asc")
-              }
-            />
-          </div>
-        );
-      },
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Status" />
+      ),
     },
     {
       accessorKey: "stripeSubscriptionId",
@@ -103,38 +70,16 @@ export function makeColumnsForSubscriptions(): ColumnDef<SubscriptionsDisplayTyp
     {
       accessorKey: "startDate",
       sortingFn: sortDate,
-      header: ({ column }) => {
-        return (
-          <div className="flex space-x-2">
-            <p>Start Date</p>
-            <IconButton
-              variant="ghost"
-              icon={ArrowsUpDownIcon}
-              onClick={() =>
-                column.toggleSorting(column.getIsSorted() === "asc")
-              }
-            />
-          </div>
-        );
-      },
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Start date" />
+      ),
     },
     {
       accessorKey: "endDate",
       sortingFn: sortDate,
-      header: ({ column }) => {
-        return (
-          <div className="flex space-x-2">
-            <p>End Date</p>
-            <IconButton
-              variant="ghost"
-              icon={ArrowsUpDownIcon}
-              onClick={() =>
-                column.toggleSorting(column.getIsSorted() === "asc")
-              }
-            />
-          </div>
-        );
-      },
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="End date" />
+      ),
     },
   ];
 }

--- a/front/components/poke/triggers/columns.tsx
+++ b/front/components/poke/triggers/columns.tsx
@@ -1,7 +1,7 @@
 import { IconButton, LinkWrapper, TrashIcon } from "@dust-tt/sparkle";
-import { ArrowsUpDownIcon } from "@heroicons/react/20/solid";
 import type { ColumnDef } from "@tanstack/react-table";
 
+import { PokeColumnSortableHeader } from "@app/components/poke/PokeColumnSortableHeader";
 import { clientFetch } from "@app/lib/egress/client";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import type { TriggerWithProviderType } from "@app/pages/api/poke/workspaces/[wId]/triggers";
@@ -41,54 +41,21 @@ export function makeColumnsForTriggers(
           </LinkWrapper>
         );
       },
-      header: ({ column }) => {
-        return (
-          <div className="flex space-x-2">
-            <p>Id</p>
-            <IconButton
-              variant="outline"
-              icon={ArrowsUpDownIcon}
-              onClick={() =>
-                column.toggleSorting(column.getIsSorted() === "asc")
-              }
-            />
-          </div>
-        );
-      },
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="sId" />
+      ),
     },
     {
       accessorKey: "name",
-      header: ({ column }) => {
-        return (
-          <div className="flex space-x-2">
-            <p>Name</p>
-            <IconButton
-              variant="outline"
-              icon={ArrowsUpDownIcon}
-              onClick={() =>
-                column.toggleSorting(column.getIsSorted() === "asc")
-              }
-            />
-          </div>
-        );
-      },
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Name" />
+      ),
     },
     {
       id: "agentName",
-      header: ({ column }) => {
-        return (
-          <div className="flex space-x-2">
-            <p>Agent Name</p>
-            <IconButton
-              variant="outline"
-              icon={ArrowsUpDownIcon}
-              onClick={() =>
-                column.toggleSorting(column.getIsSorted() === "asc")
-              }
-            />
-          </div>
-        );
-      },
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Agent name" />
+      ),
       accessorFn: (row) => {
         const agent = agentConfigMap.get(row.agentConfigurationId);
         return agent?.name ?? row.agentConfigurationId;
@@ -96,24 +63,15 @@ export function makeColumnsForTriggers(
     },
     {
       accessorKey: "kind",
-      header: "Kind",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Kind" />
+      ),
     },
     {
       accessorKey: "provider",
-      header: ({ column }) => {
-        return (
-          <div className="flex space-x-2">
-            <p>Provider</p>
-            <IconButton
-              variant="outline"
-              icon={ArrowsUpDownIcon}
-              onClick={() =>
-                column.toggleSorting(column.getIsSorted() === "asc")
-              }
-            />
-          </div>
-        );
-      },
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Provider" />
+      ),
       cell: ({ row }) => {
         const trigger = row.original;
         if (trigger.kind === "webhook") {
@@ -127,7 +85,9 @@ export function makeColumnsForTriggers(
     },
     {
       accessorKey: "configuration",
-      header: "Configuration",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Configuration" />
+      ),
       cell: ({ row }) => {
         const trigger = row.original;
         if (trigger.kind === "schedule") {
@@ -138,7 +98,9 @@ export function makeColumnsForTriggers(
     },
     {
       accessorKey: "enabled",
-      header: "Enabled",
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Enabled" />
+      ),
       cell: ({ row }) => {
         return row.getValue("enabled") ? "Yes" : "No";
       },
@@ -151,20 +113,9 @@ export function makeColumnsForTriggers(
         }
         return row.editor?.toString() ?? "";
       },
-      header: ({ column }) => {
-        return (
-          <div className="flex space-x-2">
-            <p>Editor</p>
-            <IconButton
-              variant="outline"
-              icon={ArrowsUpDownIcon}
-              onClick={() =>
-                column.toggleSorting(column.getIsSorted() === "asc")
-              }
-            />
-          </div>
-        );
-      },
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Editor" />
+      ),
       cell: ({ row }) => {
         const trigger = row.original;
         if (trigger.editorUser) {
@@ -175,20 +126,9 @@ export function makeColumnsForTriggers(
     },
     {
       accessorKey: "createdAt",
-      header: ({ column }) => {
-        return (
-          <div className="flex space-x-2">
-            <p>Created At</p>
-            <IconButton
-              variant="outline"
-              icon={ArrowsUpDownIcon}
-              onClick={() =>
-                column.toggleSorting(column.getIsSorted() === "asc")
-              }
-            />
-          </div>
-        );
-      },
+      header: ({ column }) => (
+        <PokeColumnSortableHeader column={column} label="Created at" />
+      ),
       cell: ({ row }) => {
         const trigger = row.original;
         return formatTimestampToFriendlyDate(trigger.createdAt);


### PR DESCRIPTION
closes https://github.com/dust-tt/tasks/issues/6249
## Description

1. Adding sorting to all poke column headers other than description
2. Created a new `PokeColumnSortableHeader` with improved text alignment to reduce replication
3. Streamlined label casing and names across all columns

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Tested manually:
<img width="1438" height="405" alt="Screenshot 2026-02-03 at 2 49 12 PM" src="https://github.com/user-attachments/assets/e4609c1c-76c8-41e6-b34a-b37558b27768" />

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low, poke only
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [ ] deploy front

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
