### PR TITLE
Small flexibility improvements to remote mcp metadata logic

### DIFF
--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -432,6 +432,9 @@ export async function connectToMCPServer(
       };
       try {
         await connectToRemoteMCPServer(mcpClient, url, req);
+
+        // Test if OAuth is required - some servers allow connect() but require auth for operations
+        await mcpClient.listTools();
       } catch (e: unknown) {
         if (e instanceof MCPOAuthRequiredError) {
           logger.info(

--- a/front/lib/actions/mcp_oauth_provider.ts
+++ b/front/lib/actions/mcp_oauth_provider.ts
@@ -41,6 +41,7 @@ export class MCPOAuthProvider implements OAuthClientProvider {
       software_id: "dust",
       token_endpoint_auth_method: "none",
       grant_types: ["authorization_code", "refresh_token"],
+      response_types: ["code"],
     };
   }
 


### PR DESCRIPTION
## Description

* Adding support for https://mcp.granola.ai/mcp
* Required response_type to be explicitly added to metadata (not optional for this endpont)
* This server allows the connect call, but only throws oauth required error when tool endpoint is called

## Tests

* Local validation of MCP server

## Risk

* Low

## Deploy Plan

* Deploy front