### PR TITLE
[front] Fix project notification link and rename getSpaceConversationsRoute

### DIFF
--- a/front/components/assistant/conversation/ConversationTitle.tsx
+++ b/front/components/assistant/conversation/ConversationTitle.tsx
@@ -12,7 +12,7 @@ import { useAppRouter } from "@app/lib/platform";
 import { useConversation } from "@app/lib/swr/conversations";
 import { useSpaceInfo } from "@app/lib/swr/spaces";
 import { useUser } from "@app/lib/swr/user";
-import { getSpaceConversationsRoute } from "@app/lib/utils/router";
+import { getProjectRoute } from "@app/lib/utils/router";
 import type { WorkspaceType } from "@app/types";
 
 import { EditConversationTitleDialog } from "./EditConversationTitleDialog";
@@ -60,7 +60,7 @@ export function ConversationTitle({ owner }: { owner: WorkspaceType }) {
               aria-label={`Back to ${spaceInfo?.name}`}
               onClick={() => {
                 void router.push(
-                  getSpaceConversationsRoute(owner.sId, conversation.spaceId!),
+                  getProjectRoute(owner.sId, conversation.spaceId!),
                   undefined,
                   {
                     shallow: true,

--- a/front/components/assistant/conversation/CreateProjectModal.tsx
+++ b/front/components/assistant/conversation/CreateProjectModal.tsx
@@ -15,7 +15,7 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import { useAppRouter } from "@app/lib/platform";
 import { useSpaceConversationsSummary } from "@app/lib/swr/conversations";
 import { useCreateSpace } from "@app/lib/swr/spaces";
-import { getSpaceConversationsRoute } from "@app/lib/utils/router";
+import { getProjectRoute } from "@app/lib/utils/router";
 import type { LightWorkspaceType } from "@app/types";
 
 interface CreateProjectModalProps {
@@ -83,7 +83,7 @@ export function CreateProjectModal({
         description: `Project "${trimmedName}" has been created.`,
       });
       handleClose();
-      void router.push(getSpaceConversationsRoute(owner.sId, createdSpace.sId));
+      void router.push(getProjectRoute(owner.sId, createdSpace.sId));
     }
   }, [
     projectName,

--- a/front/components/assistant/conversation/ProjectMenu.tsx
+++ b/front/components/assistant/conversation/ProjectMenu.tsx
@@ -26,7 +26,7 @@ import { useLeaveProject, useSpaceInfo } from "@app/lib/swr/spaces";
 import { useUser } from "@app/lib/swr/user";
 import {
   getConversationRoute,
-  getSpaceConversationsRoute,
+  getProjectRoute,
   setQueryParam,
 } from "@app/lib/utils/router";
 import type { SpaceType, WorkspaceType } from "@app/types";
@@ -145,7 +145,7 @@ export function ProjectMenu({
   const baseUrl = process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL;
   const shareLink =
     baseUrl !== undefined && activeSpaceId
-      ? `${baseUrl}${getSpaceConversationsRoute(owner.sId, activeSpaceId)}`
+      ? `${baseUrl}${getProjectRoute(owner.sId, activeSpaceId)}`
       : undefined;
 
   const spaceName = space?.name ?? spaceInfo?.name ?? "";

--- a/front/components/assistant/conversation/sidebar/ProjectsList.tsx
+++ b/front/components/assistant/conversation/sidebar/ProjectsList.tsx
@@ -12,7 +12,7 @@ import { getSpaceIcon } from "@app/lib/spaces";
 import { useConversation } from "@app/lib/swr/conversations";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import { removeDiacritics, subFilter } from "@app/lib/utils";
-import { getSpaceConversationsRoute } from "@app/lib/utils/router";
+import { getProjectRoute } from "@app/lib/utils/router";
 import type { GetBySpacesSummaryResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations/spaces";
 import type { SpaceType, WorkspaceType } from "@app/types";
 
@@ -35,7 +35,7 @@ const ProjectListItem = memo(
     const router = useAppRouter();
     const { sidebarOpen, setSidebarOpen } = useContext(SidebarContext);
 
-    const spacePath = getSpaceConversationsRoute(owner.sId, space.sId);
+    const spacePath = getProjectRoute(owner.sId, space.sId);
 
     const { isMenuOpen, menuTriggerPosition, handleMenuOpenChange } =
       useProjectMenu();

--- a/front/lib/api/actions/servers/project_context_management/tools/index.ts
+++ b/front/lib/api/actions/servers/project_context_management/tools/index.ts
@@ -31,10 +31,7 @@ import { FileResource } from "@app/lib/resources/file_resource";
 import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
-import {
-  getConversationRoute,
-  getSpaceConversationsRoute,
-} from "@app/lib/utils/router";
+import { getConversationRoute, getProjectRoute } from "@app/lib/utils/router";
 import logger from "@app/logger/logger";
 import type { SupportedFileContentType, UserMessageOrigin } from "@app/types";
 import {
@@ -569,7 +566,7 @@ export function createProjectContextManagementTools(
           }));
 
         // Construct project URL
-        const projectPath = getSpaceConversationsRoute(owner.sId, space.sId);
+        const projectPath = getProjectRoute(owner.sId, space.sId);
         const projectUrl = `${config.getAppUrl()}${projectPath}`;
 
         return new Ok(

--- a/front/lib/api/projects/index.ts
+++ b/front/lib/api/projects/index.ts
@@ -19,7 +19,7 @@ import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import { DataSourceViewResource } from "@app/lib/resources/data_source_view_resource";
 import type { FileResource } from "@app/lib/resources/file_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
-import { getSpaceConversationsRoute } from "@app/lib/utils/router";
+import { getProjectRoute } from "@app/lib/utils/router";
 import logger from "@app/logger/logger";
 import type { ConversationWithoutContentType, Result } from "@app/types";
 import {
@@ -349,8 +349,7 @@ export async function createDataSourceAndConnectorForProject(
         parents: [PROJECT_CONTEXT_FOLDER_ID],
         mimeType: INTERNAL_MIME_TYPES.DUST_PROJECT.CONTEXT_FOLDER,
         sourceUrl:
-          config.getAppUrl() +
-          getSpaceConversationsRoute(workspace.sId, space.sId),
+          config.getAppUrl() + getProjectRoute(workspace.sId, space.sId),
         timestamp: null,
         providerVisibility: null,
         title: PROJECT_CONTEXT_FOLDER_NAME,

--- a/front/lib/notifications/workflows/project-added-as-member.ts
+++ b/front/lib/notifications/workflows/project-added-as-member.ts
@@ -8,7 +8,7 @@ import { getNovuClient } from "@app/lib/notifications";
 import { renderEmail } from "@app/lib/notifications/email-templates/default";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
-import { getSpaceRoute } from "@app/lib/utils/router";
+import { getProjectRoute } from "@app/lib/utils/router";
 import logger from "@app/logger/logger";
 import type { Result, SpaceType } from "@app/types";
 import { Err, normalizeError, Ok } from "@app/types";
@@ -119,7 +119,7 @@ export const projectAddedAsMemberWorkflow = workflow(
           primaryAction: {
             label: "View",
             redirect: {
-              url: getSpaceRoute(payload.workspaceId, payload.projectId),
+              url: getProjectRoute(payload.workspaceId, payload.projectId),
             },
           },
           data: {
@@ -147,7 +147,7 @@ export const projectAddedAsMemberWorkflow = workflow(
             label: "View project",
             url:
               process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL +
-              getSpaceRoute(payload.workspaceId, payload.projectId),
+              getProjectRoute(payload.workspaceId, payload.projectId),
           },
         });
         return {

--- a/front/lib/utils/router.ts
+++ b/front/lib/utils/router.ts
@@ -88,9 +88,6 @@ export const getSpaceRoute = (workspaceId: string, spaceId: string) => {
   return `/w/${workspaceId}/spaces/${spaceId}`;
 };
 
-export const getSpaceConversationsRoute = (
-  workspaceId: string,
-  spaceId: string
-) => {
+export const getProjectRoute = (workspaceId: string, spaceId: string) => {
   return `/w/${workspaceId}/conversation/space/${spaceId}`;
 };


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/6298

The "you have been added to a project" notification was linking to the space settings page (`/w/{wId}/spaces/{spaceId}`) instead of the project conversations page (`/w/{wId}/conversation/space/{spaceId}`).

Changes:
- Fixed the notification link in `project-added-as-member.ts` to use the correct route
- Renamed `getSpaceConversationsRoute` to `getProjectRoute` for clarity

## Risks

Blast radius: Project notification links and navigation to projects
Risk: low

## Deploy Plan
- pmrr
- deploy front