### PR TITLE
Use lighter conversation type to reduce payload when loading conversations for project.

### DIFF
--- a/front/components/assistant/conversation/space/conversations/SpaceConversationListItem.tsx
+++ b/front/components/assistant/conversation/space/conversations/SpaceConversationListItem.tsx
@@ -7,18 +7,14 @@ import { useMemo } from "react";
 import { useAppRouter } from "@app/lib/platform";
 import { getConversationRoute } from "@app/lib/utils/router";
 import { formatTimestring } from "@app/lib/utils/timestamps";
-import type { ConversationType, WorkspaceType } from "@app/types";
-import {
-  isAgentMessageType,
-  isContentFragmentType,
-  isUserMessageType,
-} from "@app/types";
+import type { LightConversationType, WorkspaceType } from "@app/types";
+import { isUserMessageTypeWithContentFragments } from "@app/types";
 import { stripMarkdown } from "@app/types";
 
 import { isMessageUnread } from "../../utils";
 
 interface SpaceConversationListItemProps {
-  conversation: ConversationType;
+  conversation: LightConversationType;
   owner: WorkspaceType;
 }
 
@@ -27,25 +23,24 @@ export function SpaceConversationListItem({
   owner,
 }: SpaceConversationListItemProps) {
   const router = useAppRouter();
-  const firstUserMessage = conversation.content
-    .map((m) => m[m.length - 1])
-    .find(isUserMessageType);
+  const firstUserMessage = conversation.content.find(
+    isUserMessageTypeWithContentFragments
+  );
 
   // Compute the reply section avatars.
   const avatars = useMemo(() => {
     const avatars: Parameters<typeof Avatar.Stack>[0]["avatars"] = [];
     // Lookup the messages in reverse order and collect the users and agents icons
     // Slice to skip the first message as it's not a reply.
-    for (const versions of conversation.content.slice(1)) {
-      const message = versions[versions.length - 1];
-      if (isUserMessageType(message)) {
+    for (const message of conversation.content.slice(1)) {
+      if (isUserMessageTypeWithContentFragments(message)) {
         avatars.push({
           isRounded: true,
           name: message.user?.fullName ?? message.context?.fullName ?? "",
           visual:
             message.user?.image ?? message.context?.profilePictureUrl ?? "",
         });
-      } else if (isAgentMessageType(message)) {
+      } else {
         avatars.push({
           isRounded: false,
           name: "@" + (message.configuration.name ?? ""),
@@ -57,8 +52,7 @@ export function SpaceConversationListItem({
   }, [conversation.content]);
 
   const countUnreadMessages = useMemo(() => {
-    return conversation.content.filter((versions) => {
-      const message = versions[versions.length - 1];
+    return conversation.content.filter((message) => {
       return isMessageUnread(message, conversation.lastReadMs);
     }).length;
   }, [conversation.content, conversation.lastReadMs]);
@@ -85,10 +79,7 @@ export function SpaceConversationListItem({
 
   const time = formatTimestring(conversation.updated);
 
-  const agentAndUserMessages = conversation.content.filter(
-    (versions) => !isContentFragmentType(versions[versions.length - 1])
-  );
-  const replyCount = agentAndUserMessages.length - 1;
+  const replyCount = conversation.content.length - 1;
 
   return (
     <>

--- a/front/components/assistant/conversation/space/conversations/SpaceConversationsTab.tsx
+++ b/front/components/assistant/conversation/space/conversations/SpaceConversationsTab.tsx
@@ -26,8 +26,8 @@ import { getConversationRoute } from "@app/lib/utils/router";
 import type { GetSpaceResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]";
 import type {
   ContentFragmentsType,
-  ConversationType,
   ConversationWithoutContentType,
+  LightConversationType,
   Result,
   RichMention,
   UserType,
@@ -45,7 +45,7 @@ type GroupLabel =
 interface SpaceConversationsTabProps {
   owner: WorkspaceType;
   user: UserType;
-  conversations: ConversationType[];
+  conversations: LightConversationType[];
   isConversationsLoading: boolean;
   hasMore: boolean;
   loadMore: () => void;
@@ -96,13 +96,13 @@ export function SpaceConversationsTab({
     initialSearchText: "",
   });
 
-  const conversationsByDate: Record<GroupLabel, ConversationType[]> =
+  const conversationsByDate: Record<GroupLabel, LightConversationType[]> =
     useMemo(() => {
       return conversations.length
         ? (getGroupConversationsByDate({
             conversations,
             titleFilter: "",
-          }) as Record<GroupLabel, ConversationType[]>)
+          }) as Record<GroupLabel, LightConversationType[]>)
         : ({} as Record<GroupLabel, typeof conversations>);
     }, [conversations]);
 

--- a/front/components/assistant/conversation/utils.ts
+++ b/front/components/assistant/conversation/utils.ts
@@ -5,7 +5,9 @@ import type {
   AgentMessageType,
   ContentFragmentType,
   ConversationWithoutContentType,
+  LightAgentMessageType,
   UserMessageType,
+  UserMessageTypeWithContentFragments,
 } from "@app/types";
 
 import type { VirtuosoMessage } from "./types";
@@ -140,7 +142,12 @@ export function findFirstUnreadMessageIndex(
 }
 
 export function isMessageUnread(
-  message: UserMessageType | AgentMessageType | ContentFragmentType,
+  message:
+    | UserMessageType
+    | AgentMessageType
+    | ContentFragmentType
+    | LightAgentMessageType
+    | UserMessageTypeWithContentFragments,
   lastReadMs: number | null
 ): boolean {
   if (lastReadMs === null) {

--- a/front/lib/api/assistant/conversation/fetch.ts
+++ b/front/lib/api/assistant/conversation/fetch.ts
@@ -13,16 +13,60 @@ import type {
   AgentMessageType,
   ContentFragmentType,
   ConversationType,
+  LightAgentMessageType,
+  LightConversationType,
+  LightMessageType,
+  MessageType,
   Result,
   UserMessageType,
+  UserMessageTypeWithContentFragments,
 } from "@app/types";
-import { ConversationError, Err, Ok } from "@app/types";
+import {
+  ConversationError,
+  Err,
+  isAgentMessageType,
+  isArrayOf,
+  isContentFragmentType,
+  isUserMessageType,
+  isUserMessageTypeWithContentFragments,
+  Ok,
+  removeNulls,
+} from "@app/types";
 
-export async function getConversation(
+// Helper type to map viewType to the correct message type
+type MessageTypeForView<V extends "light" | "full"> = V extends "light"
+  ? LightMessageType
+  : V extends "full"
+    ? MessageType
+    : never;
+
+export const getConversation = async (
   auth: Authenticator,
   conversationId: string,
   includeDeleted: boolean = false
-): Promise<Result<ConversationType, ConversationError>> {
+) => _getConversation(auth, conversationId, includeDeleted, "full");
+
+export const getLightConversation = async (
+  auth: Authenticator,
+  conversationId: string,
+  includeDeleted: boolean = false
+) => _getConversation(auth, conversationId, includeDeleted, "light");
+
+async function _getConversation<V extends "light" | "full">(
+  auth: Authenticator,
+  conversationId: string,
+  includeDeleted: boolean = false,
+  viewType: V = "full" as V
+): Promise<
+  Result<
+    V extends "light"
+      ? LightConversationType
+      : V extends "full"
+        ? ConversationType
+        : never,
+    ConversationError
+  >
+> {
   const owner = auth.getNonNullableWorkspace();
 
   const conversation = await ConversationResource.fetchById(
@@ -87,29 +131,29 @@ export async function getConversation(
     auth,
     conversation,
     messages,
-    "full"
+    viewType
   );
 
   if (renderRes.isErr()) {
     return new Err(renderRes.error);
   }
 
-  const messagesWithRankType = renderRes.value;
+  // TypeScript will now properly narrow based on viewType
+  const messagesWithRank = renderRes.value as MessageTypeForView<V>[];
 
   // We pre-create an array that will hold
   // the versions of each User/Assistant/ContentFragment message. The length of that array is by definition the
   // maximal rank of the conversation messages we just retrieved. In the case there is no message
   // the rank is -1 and the array length is 0 as expected.
   const rankMax = messages.reduce((acc, m) => Math.max(acc, m.rank), -1);
-  const content: (
-    | UserMessageType[]
-    | AgentMessageType[]
-    | ContentFragmentType[]
-  )[] = Array.from({ length: rankMax + 1 }, () => []);
+  const content: MessageTypeForView<V>[][] = Array.from(
+    { length: rankMax + 1 },
+    () => []
+  );
 
-  // We need to escape the type system here to fill content.
-  for (const m of messagesWithRankType) {
-    (content[m.rank] as any).push(m);
+  // Fill content array with proper typing
+  for (const m of messagesWithRank) {
+    content[m.rank].push(m);
   }
 
   const { actionRequired, lastReadAt } =
@@ -118,24 +162,123 @@ export async function getConversation(
       conversation.id
     );
 
-  return new Ok({
-    id: conversation.id,
-    created: conversation.createdAt.getTime(),
-    updated: conversation.updatedAt.getTime(),
-    sId: conversation.sId,
-    owner,
-    title: conversation.title,
-    visibility: conversation.visibility,
-    depth: conversation.depth,
-    triggerId: conversation.triggerSId,
-    content,
-    actionRequired,
-    unread: lastReadAt === null || conversation.updatedAt > lastReadAt,
-    lastReadMs: lastReadAt?.getTime() ?? null,
-    hasError: conversation.hasError,
-    requestedGroupIds: [],
-    requestedSpaceIds: conversation.getRequestedSpaceIdsFromModel(),
-    spaceId: conversation.space?.sId ?? null,
-    metadata: conversation.metadata,
-  });
+  if (viewType === "light") {
+    // We only keep the last version of each message.
+    const typeCheckedContent: (
+      | LightAgentMessageType
+      | UserMessageTypeWithContentFragments
+    )[] = removeNulls(
+      (content as LightMessageType[][]).map((c) => {
+        if (c.length === 0) {
+          return null;
+        } else if (
+          isArrayOf<LightMessageType, LightAgentMessageType>(
+            c,
+            (m: LightMessageType): m is LightAgentMessageType => {
+              return m.type === "agent_message";
+            }
+          )
+        ) {
+          return c[c.length - 1];
+        } else if (
+          isArrayOf<LightMessageType, UserMessageTypeWithContentFragments>(
+            c,
+            isUserMessageTypeWithContentFragments
+          )
+        ) {
+          return c[c.length - 1];
+        } else {
+          throw new Error(
+            "Unexpected content type as everything should be array of same type. This should never happen."
+          );
+        }
+      })
+    );
+
+    const conversationType: LightConversationType = {
+      id: conversation.id,
+      created: conversation.createdAt.getTime(),
+      updated: conversation.updatedAt.getTime(),
+      sId: conversation.sId,
+      owner,
+      title: conversation.title,
+      visibility: conversation.visibility,
+      depth: conversation.depth,
+      triggerId: conversation.triggerSId,
+      content: typeCheckedContent,
+      actionRequired,
+      unread: lastReadAt === null || conversation.updatedAt > lastReadAt,
+      lastReadMs: lastReadAt?.getTime() ?? null,
+      hasError: conversation.hasError,
+      requestedSpaceIds: conversation.getRequestedSpaceIdsFromModel(),
+      spaceId: conversation.space?.sId ?? null,
+      metadata: conversation.metadata,
+    };
+
+    return new Ok(conversationType) as Result<
+      V extends "light"
+        ? LightConversationType
+        : V extends "full"
+          ? ConversationType
+          : never,
+      ConversationError
+    >;
+  } else {
+    // TypeScript now knows messagesWithRank is MessageType[]
+    const typeCheckedContent: (
+      | AgentMessageType[]
+      | UserMessageType[]
+      | ContentFragmentType[]
+    )[] = (content as MessageType[][]).map((c) => {
+      if (c.length === 0) {
+        return [];
+      } else if (
+        isArrayOf<MessageType, AgentMessageType>(c, isAgentMessageType)
+      ) {
+        return c.map((m) => m);
+      } else if (
+        isArrayOf<MessageType, UserMessageType>(c, isUserMessageType)
+      ) {
+        return c.map((m) => m);
+      } else if (
+        isArrayOf<MessageType, ContentFragmentType>(c, isContentFragmentType)
+      ) {
+        return c.map((m) => m);
+      } else {
+        throw new Error(
+          "Unexpected content type as everything should be array of same type. This should never happen."
+        );
+      }
+    });
+
+    const conversationType: ConversationType = {
+      id: conversation.id,
+      created: conversation.createdAt.getTime(),
+      updated: conversation.updatedAt.getTime(),
+      sId: conversation.sId,
+      owner,
+      title: conversation.title,
+      visibility: conversation.visibility,
+      depth: conversation.depth,
+      triggerId: conversation.triggerSId,
+      content: typeCheckedContent,
+      actionRequired,
+      unread: lastReadAt === null || conversation.updatedAt > lastReadAt,
+      lastReadMs: lastReadAt?.getTime() ?? null,
+      hasError: conversation.hasError,
+
+      requestedSpaceIds: conversation.getRequestedSpaceIdsFromModel(),
+      spaceId: conversation.space?.sId ?? null,
+      metadata: conversation.metadata,
+    };
+
+    return new Ok(conversationType) as Result<
+      V extends "light"
+        ? LightConversationType
+        : V extends "full"
+          ? ConversationType
+          : never,
+      ConversationError
+    >;
+  }
 }

--- a/front/lib/swr/conversations.ts
+++ b/front/lib/swr/conversations.ts
@@ -35,8 +35,8 @@ import type { GetBySpacesSummaryResponseBody } from "@app/pages/api/w/[wId]/assi
 import type { GetSpaceConversationsResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations/spaces/[spaceId]";
 import type {
   ConversationError,
-  ConversationType,
   ConversationWithoutContentType,
+  LightConversationType,
   LightWorkspaceType,
 } from "@app/types";
 import { isProjectConversation, normalizeError } from "@app/types";
@@ -166,7 +166,7 @@ export function useSpaceConversations({
 
   const conversations = useMemo(() => {
     if (!data) {
-      return emptyArray<ConversationType>();
+      return emptyArray<LightConversationType>();
     }
     return data.flatMap((page) => page.conversations);
   }, [data]);

--- a/front/pages/api/w/[wId]/assistant/conversations/spaces/[spaceId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/spaces/[spaceId]/index.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
+import { getLightConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { getPaginationParams } from "@app/lib/api/pagination";
 import type { Authenticator } from "@app/lib/auth";
@@ -8,11 +8,11 @@ import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { apiError } from "@app/logger/withlogging";
-import type { ConversationType, WithAPIErrorResponse } from "@app/types";
+import type { LightConversationType, WithAPIErrorResponse } from "@app/types";
 import { isString, removeNulls } from "@app/types";
 
 export type GetSpaceConversationsResponseBody = {
-  conversations: ConversationType[];
+  conversations: LightConversationType[];
   hasMore: boolean;
   lastValue: string | null;
 };
@@ -86,7 +86,7 @@ async function handler(
       // TODO(@jd) - Find a better way
       const spaceConversationsFull = await concurrentExecutor(
         spaceConversations,
-        async (c) => getConversation(auth, c.sId),
+        async (c) => getLightConversation(auth, c.sId),
         { concurrency: 10 }
       );
 

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -218,6 +218,7 @@ export type BaseAgentMessageType = {
   visibility: MessageVisibility;
   richMentions: RichMentionWithStatus[];
   completionDurationMs: number | null;
+  reactions: MessageReactionType[];
   prunedContext?: boolean;
 };
 
@@ -236,7 +237,6 @@ export type AgentMessageType = BaseAgentMessageType & {
   contents: Array<{ step: number; content: AgentContentItemType }>;
   parsedContents: Record<number, Array<ParsedContentItem>>;
   modelInteractionDurationMs: number | null;
-  reactions: MessageReactionType[];
 };
 
 export type AgentMessageTypeWithoutMentions = Omit<
@@ -254,8 +254,6 @@ export type LightAgentMessageType = BaseAgentMessageType & {
   };
   citations: Record<string, CitationType>;
   generatedFiles: Omit<ActionGeneratedFileType, "snippet">[];
-  reactions: MessageReactionType[];
-  prunedContext?: boolean;
 };
 
 // This type represents the agent message we can reconstruct by accumulating streaming events
@@ -326,6 +324,16 @@ export type ConversationType = ConversationWithoutContentType & {
   owner: WorkspaceType;
   visibility: ConversationVisibility;
   content: (UserMessageType[] | AgentMessageType[] | ContentFragmentType[])[];
+};
+
+/**
+ * Same as ConversationType but with light agent messages and user messages with content fragments inside.
+ * Only keep the last version of each message.
+ */
+export type LightConversationType = ConversationWithoutContentType & {
+  owner: WorkspaceType;
+  visibility: ConversationVisibility;
+  content: (LightAgentMessageType | UserMessageTypeWithContentFragments)[];
 };
 
 export const isProjectConversation = <T extends ConversationWithoutContentType>(


### PR DESCRIPTION
## Description

Create a "light" version of the ConversationType that uses LightAgentMessageType instead of AgentMessageType and only send the latest version of each message by leveraging the existing "light" rendering of batchRenderAgentMessages.

This reduce the payload quite signficantly but do not affect the DB cost as the light version of agent message requires the same fetches as the normal version.

Improved type checking within "_getConversation()".

## Tests

Local + TS green.

## Risk

Low, existing path should be unaffected.

## Deploy Plan

Deploy front.