### PR TITLE
Fix Sheet component title display in dark mode

### DIFF
--- a/sparkle/src/components/Sheet.tsx
+++ b/sparkle/src/components/Sheet.tsx
@@ -313,7 +313,13 @@ const SheetTitle = React.forwardRef<
   SheetTitleProps
 >(({ className, icon, ...props }, ref) => (
   <>
-    {icon && <Icon visual={icon} size="lg" className="s-text-foreground" />}
+    {icon && (
+      <Icon
+        visual={icon}
+        size="lg"
+        className="s-text-foreground dark:s-text-foreground-night"
+      />
+    )}
     <SheetPrimitive.Title
       ref={ref}
       className={cn("s-heading-lg", className)}


### PR DESCRIPTION
## Description

In dark mode, the sheet component title cannot display some icons (for instance the markdown or audio file icons) correctly. This PR fixes it.


## Tests

local
## Risk

low
## Deploy Plan

sparkle