### PR TITLE
[front] Iterate on skills meta prompt

### DIFF
--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -218,7 +218,10 @@ function constructSkillsSection({
     "- **Enabled**: Fully active with instructions loaded. Once enabled, a skill remains active " +
     "for the rest of the conversation.\n\n" +
     "Enable skills proactively when a user's request matches a skill's purpose. " +
-    "Only enable skills you actually need—enabling a skill loads its full instructions into context.\n";
+    "Only enable skills you actually need—enabling a skill loads its full instructions into context.\n" +
+    "When in doubt about enabling a skill, prefer enabling it as it may give you a new " +
+    "perspective on the currently available context.\n" +
+    "Decisions taken prior to enabling a skill may need to be revisited after enabling it.\n";
 
   if (!enabledSkills.length && !equippedSkills.length) {
     skillsSection +=

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -217,8 +217,9 @@ function constructSkillsSection({
     "tool when they become relevant to the conversation.\n" +
     "- **Enabled**: Fully active with instructions loaded. Once enabled, a skill remains active " +
     "for the rest of the conversation.\n\n" +
-    "Enable skills proactively when a user's request matches a skill's purpose. " +
+    "Enable skills proactively when a user's request matches a skill's purpose.\n" +
     "Only enable skills you actually need—enabling a skill loads its full instructions into context.\n" +
+    "If you need to enable multiple skills, enable them in parallel.\n\n" +
     "When in doubt about enabling a skill, prefer enabling it as it may give you a new " +
     "perspective on the currently available context.\n" +
     "Decisions taken prior to enabling a skill may need to be revisited after enabling it.\n";


### PR DESCRIPTION
## Description

- This PR updates the meta prompt that explains what skills are.
- Targets three specific goals:
  - Nudge agents to be less conservative about using skills; we currently have examples where agent thoughts hint at the fact that when in doubt, agents prefer not to enable a skill to prevent loading all of their instructions in context, which seems to echo what we currently have in the prompt.
  - Prevent agents from drawing false interpretations about their own reasoning right after enabling a skill. Agents have no awareness on changes to their system prompt, and interpret the entire conversation as if it was run with their current system prompt.
  - Nudge towards enabling in parallel.

## Tests

- Tested locally.

## Risk

- Low. Busts the cache.

## Deploy Plan

- Deploy front.
