### PR TITLE
[front] Add display labels definitions on all existing internal tools

### DIFF
--- a/front/lib/actions/mcp_internal_actions/tool_definition.ts
+++ b/front/lib/actions/mcp_internal_actions/tool_definition.ts
@@ -44,7 +44,7 @@ export interface ToolDefinition<
   description: string;
   schema: TSchema;
   stake: MCPToolStakeLevelType;
-  displayLabels?: ToolDisplayLabels;
+  displayLabels: ToolDisplayLabels;
   handler: (
     params: z.infer<z.ZodObject<TSchema>>,
     extra: ToolHandlerExtra
@@ -77,8 +77,13 @@ export function buildTools<T extends Record<string, ToolMeta>>(
   );
 }
 
+// Internal MCP server tools must have displayLabels (unlike remote servers).
+type InternalMCPToolType = MCPToolType & {
+  displayLabels: ToolDisplayLabels;
+};
+
 export interface ServerMetadata {
   serverInfo: InternalMCPServerDefinitionType;
-  tools: MCPToolType[];
+  tools: InternalMCPToolType[];
   tools_stakes: Record<string, MCPToolStakeLevelType>;
 }

--- a/front/lib/actions/mcp_internal_actions/tool_definition.ts
+++ b/front/lib/actions/mcp_internal_actions/tool_definition.ts
@@ -82,8 +82,8 @@ type InternalMCPToolType = MCPToolType & {
   displayLabels: ToolDisplayLabels;
 };
 
-export interface ServerMetadata {
+export type ServerMetadata = {
   serverInfo: InternalMCPServerDefinitionType;
   tools: InternalMCPToolType[];
   tools_stakes: Record<string, MCPToolStakeLevelType>;
-}
+};

--- a/front/lib/api/actions/servers/agent_copilot_agent_state/metadata.ts
+++ b/front/lib/api/actions/servers/agent_copilot_agent_state/metadata.ts
@@ -2,10 +2,8 @@ import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
-import type { MCPToolStakeLevelType } from "@app/lib/actions/constants";
 import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import type { MCPToolType } from "@app/lib/api/mcp";
 
 export const AGENT_COPILOT_AGENT_STATE_TOOL_NAME =
   "agent_copilot_agent_state" as const;
@@ -15,40 +13,13 @@ export const AGENT_COPILOT_AGENT_STATE_TOOLS_METADATA = createToolsRecord({
     description:
       "Get detailed information about the current agent configuration, including name, description, instructions, model settings, and the IDs of all skills and tools currently used by the agent.",
     schema: {},
-    stake: "never_ask" as MCPToolStakeLevelType,
+    stake: "never_ask",
     displayLabels: {
       running: "Getting agent info",
       done: "Get agent info",
     },
   },
 });
-
-type AgentCopilotAgentStateToolKey =
-  keyof typeof AGENT_COPILOT_AGENT_STATE_TOOLS_METADATA;
-
-export const AGENT_COPILOT_AGENT_STATE_TOOLS: MCPToolType[] = (
-  Object.keys(
-    AGENT_COPILOT_AGENT_STATE_TOOLS_METADATA
-  ) as AgentCopilotAgentStateToolKey[]
-).map((key) => ({
-  name: AGENT_COPILOT_AGENT_STATE_TOOLS_METADATA[key].name,
-  description: AGENT_COPILOT_AGENT_STATE_TOOLS_METADATA[key].description,
-  inputSchema: zodToJsonSchema(
-    z.object(AGENT_COPILOT_AGENT_STATE_TOOLS_METADATA[key].schema)
-  ) as JSONSchema,
-  displayLabels: AGENT_COPILOT_AGENT_STATE_TOOLS_METADATA[key].displayLabels,
-}));
-
-export const AGENT_COPILOT_AGENT_STATE_TOOL_STAKES: Record<
-  string,
-  MCPToolStakeLevelType
-> = Object.fromEntries(
-  (
-    Object.keys(
-      AGENT_COPILOT_AGENT_STATE_TOOLS_METADATA
-    ) as AgentCopilotAgentStateToolKey[]
-  ).map((key) => [key, AGENT_COPILOT_AGENT_STATE_TOOLS_METADATA[key].stake])
-);
 
 export const AGENT_COPILOT_AGENT_STATE_SERVER_INFO = {
   name: "agent_copilot_agent_state" as const,
@@ -63,6 +34,16 @@ export const AGENT_COPILOT_AGENT_STATE_SERVER_INFO = {
 
 export const AGENT_COPILOT_AGENT_STATE_SERVER = {
   serverInfo: AGENT_COPILOT_AGENT_STATE_SERVER_INFO,
-  tools: AGENT_COPILOT_AGENT_STATE_TOOLS,
-  tools_stakes: AGENT_COPILOT_AGENT_STATE_TOOL_STAKES,
+  tools: Object.values(AGENT_COPILOT_AGENT_STATE_TOOLS_METADATA).map((t) => ({
+    name: t.name,
+    description: t.description,
+    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+    displayLabels: t.displayLabels,
+  })),
+  tools_stakes: Object.fromEntries(
+    Object.values(AGENT_COPILOT_AGENT_STATE_TOOLS_METADATA).map((t) => [
+      t.name,
+      t.stake,
+    ])
+  ),
 } as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/agent_management/metadata.ts
+++ b/front/lib/api/actions/servers/agent_management/metadata.ts
@@ -53,6 +53,10 @@ export const AGENT_MANAGEMENT_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "high",
+    displayLabels: {
+      running: "Creating agent",
+      done: "Create agent",
+    },
   },
 });
 
@@ -71,6 +75,7 @@ export const AGENT_MANAGEMENT_SERVER = {
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+    displayLabels: t.displayLabels,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(AGENT_MANAGEMENT_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/agent_memory/metadata.ts
+++ b/front/lib/api/actions/servers/agent_memory/metadata.ts
@@ -67,8 +67,8 @@ export const AGENT_MEMORY_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Editing entries",
-      done: "Edit entries",
+      running: "Editing memory entries",
+      done: "Edit memory entries",
     },
   },
   [AGENT_MEMORY_COMPACT_TOOL_NAME]: {

--- a/front/lib/api/actions/servers/agent_memory/metadata.ts
+++ b/front/lib/api/actions/servers/agent_memory/metadata.ts
@@ -17,6 +17,10 @@ export const AGENT_MEMORY_TOOLS_METADATA = createToolsRecord({
     description: "Retrieve all agent memories for the current user",
     schema: {},
     stake: "never_ask",
+    displayLabels: {
+      running: "Retrieving memories",
+      done: "Retrieve memories",
+    },
   },
   [AGENT_MEMORY_RECORD_TOOL_NAME]: {
     description: "Record new memory entries for the current user",
@@ -26,6 +30,10 @@ export const AGENT_MEMORY_TOOLS_METADATA = createToolsRecord({
         .describe("The array of new memory entries to record."),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Recording memories",
+      done: "Record memories",
+    },
   },
   [AGENT_MEMORY_ERASE_TOOL_NAME]: {
     description: "Erase memory entries by indexes for the current user",
@@ -35,6 +43,10 @@ export const AGENT_MEMORY_TOOLS_METADATA = createToolsRecord({
         .describe("The indexes of the memory entries to erase."),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Erasing memory entries",
+      done: "Erase memory entries",
+    },
   },
   [AGENT_MEMORY_EDIT_TOOL_NAME]: {
     description:
@@ -54,6 +66,10 @@ export const AGENT_MEMORY_TOOLS_METADATA = createToolsRecord({
         .describe("The array of memory entries to edit."),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Editing entries",
+      done: "Edit entries",
+    },
   },
   [AGENT_MEMORY_COMPACT_TOOL_NAME]: {
     description:
@@ -73,6 +89,10 @@ export const AGENT_MEMORY_TOOLS_METADATA = createToolsRecord({
         .describe("The array of memory entries to compact/edit."),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Compacting memory",
+      done: "Compact memory",
+    },
   },
 });
 
@@ -90,6 +110,7 @@ export const AGENT_MEMORY_SERVER = {
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+    displayLabels: t.displayLabels,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(AGENT_MEMORY_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/ashby/metadata.ts
+++ b/front/lib/api/actions/servers/ashby/metadata.ts
@@ -27,6 +27,10 @@ export const ASHBY_TOOLS_METADATA = createToolsRecord({
       `Returns up to ${DEFAULT_SEARCH_LIMIT} matching candidates by default.`,
     schema: CandidateSearchSchema,
     stake: "never_ask",
+    displayLabels: {
+      running: "Searching candidates",
+      done: "Search candidates",
+    },
   },
   get_report_data: {
     description: "Retrieve report data and save it as a CSV file.",
@@ -38,6 +42,10 @@ export const ASHBY_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Retrieving report data",
+      done: "Retrieve report data",
+    },
   },
   get_interview_feedback: {
     description:
@@ -46,6 +54,10 @@ export const ASHBY_TOOLS_METADATA = createToolsRecord({
       "interview feedback for the most recent application.",
     schema: CandidateSearchSchema,
     stake: "never_ask",
+    displayLabels: {
+      running: "Retrieving interview feedback",
+      done: "Retrieve interview feedback",
+    },
   },
   get_candidate_notes: {
     description:
@@ -53,6 +65,10 @@ export const ASHBY_TOOLS_METADATA = createToolsRecord({
       "This tool will search for the candidate by name or email and return all notes on their profile.",
     schema: CandidateSearchSchema,
     stake: "never_ask",
+    displayLabels: {
+      running: "Retrieving candidate notes",
+      done: "Retrieve candidate notes",
+    },
   },
   create_candidate_note: {
     description:
@@ -65,6 +81,10 @@ export const ASHBY_TOOLS_METADATA = createToolsRecord({
         .describe("The content of the note in HTML format."),
     },
     stake: "high",
+    displayLabels: {
+      running: "Creating candidate note",
+      done: "Create candidate note",
+    },
   },
 });
 
@@ -83,6 +103,7 @@ export const ASHBY_SERVER = {
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+    displayLabels: t.displayLabels,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(ASHBY_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/ashby/metadata.ts
+++ b/front/lib/api/actions/servers/ashby/metadata.ts
@@ -28,8 +28,8 @@ export const ASHBY_TOOLS_METADATA = createToolsRecord({
     schema: CandidateSearchSchema,
     stake: "never_ask",
     displayLabels: {
-      running: "Searching candidates",
-      done: "Search candidates",
+      running: "Searching candidates on Ashby",
+      done: "Search candidates on Ashby",
     },
   },
   get_report_data: {
@@ -43,8 +43,8 @@ export const ASHBY_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Retrieving report data",
-      done: "Retrieve report data",
+      running: "Retrieving Ashby report data",
+      done: "Retrieve Ashby report data",
     },
   },
   get_interview_feedback: {
@@ -55,8 +55,8 @@ export const ASHBY_TOOLS_METADATA = createToolsRecord({
     schema: CandidateSearchSchema,
     stake: "never_ask",
     displayLabels: {
-      running: "Retrieving interview feedback",
-      done: "Retrieve interview feedback",
+      running: "Retrieving interview feedback from Ashby",
+      done: "Retrieve interview feedback from Ashby",
     },
   },
   get_candidate_notes: {
@@ -66,8 +66,8 @@ export const ASHBY_TOOLS_METADATA = createToolsRecord({
     schema: CandidateSearchSchema,
     stake: "never_ask",
     displayLabels: {
-      running: "Retrieving candidate notes",
-      done: "Retrieve candidate notes",
+      running: "Retrieving candidate notes from Ashby",
+      done: "Retrieve candidate notes from Ashby",
     },
   },
   create_candidate_note: {
@@ -82,8 +82,8 @@ export const ASHBY_TOOLS_METADATA = createToolsRecord({
     },
     stake: "high",
     displayLabels: {
-      running: "Creating candidate note",
-      done: "Create candidate note",
+      running: "Creating candidate note on Ashby",
+      done: "Create candidate note on Ashby",
     },
   },
 });

--- a/front/lib/api/actions/servers/common_utilities/metadata.ts
+++ b/front/lib/api/actions/servers/common_utilities/metadata.ts
@@ -27,12 +27,20 @@ export const COMMON_UTILITIES_TOOLS_METADATA = createToolsRecord({
         .optional(),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Generating random number",
+      done: "Generate random number",
+    },
   },
   generate_random_float: {
     description:
       "Generate a random floating point number between 0 (inclusive) and 1 (exclusive).",
     schema: {},
     stake: "never_ask",
+    displayLabels: {
+      running: "Generating random float",
+      done: "Generate random float",
+    },
   },
   wait: {
     description: `Pause execution for the provided number of milliseconds (maximum ${MAX_WAIT_DURATION_MS}).`,
@@ -48,6 +56,10 @@ export const COMMON_UTILITIES_TOOLS_METADATA = createToolsRecord({
         .describe("The time to wait in milliseconds, up to 3 minutes."),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Waiting",
+      done: "Wait",
+    },
   },
   get_current_time: {
     description:
@@ -63,6 +75,10 @@ export const COMMON_UTILITIES_TOOLS_METADATA = createToolsRecord({
         .optional(),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Getting current time",
+      done: "Get current time",
+    },
   },
   math_operation: {
     description: "Perform mathematical operations.",
@@ -70,6 +86,10 @@ export const COMMON_UTILITIES_TOOLS_METADATA = createToolsRecord({
       expression: z.string().describe("The expression to evaluate. "),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Calculating",
+      done: "Calculate",
+    },
   },
   [SEARCH_AVAILABLE_USERS_TOOL_NAME]: {
     description: "Search for users that are available to the conversation.",
@@ -81,6 +101,10 @@ export const COMMON_UTILITIES_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Searching users",
+      done: "Search users",
+    },
   },
   [GET_MENTION_MARKDOWN_TOOL_NAME]: {
     description:
@@ -94,6 +118,10 @@ export const COMMON_UTILITIES_TOOLS_METADATA = createToolsRecord({
         .describe("A mention to get the markdown directive for."),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Getting mention markdown",
+      done: "Get mention markdown",
+    },
   },
 });
 
@@ -111,6 +139,7 @@ export const COMMON_UTILITIES_SERVER = {
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+    displayLabels: t.displayLabels,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(COMMON_UTILITIES_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/confluence/metadata.ts
+++ b/front/lib/api/actions/servers/confluence/metadata.ts
@@ -14,8 +14,8 @@ export const CONFLUENCE_TOOLS_METADATA = createToolsRecord({
     schema: {},
     stake: "never_ask",
     displayLabels: {
-      running: "Getting current user",
-      done: "Get current user",
+      running: "Getting current Confluence user",
+      done: "Get current Confluence user",
     },
   },
   get_spaces: {
@@ -24,8 +24,8 @@ export const CONFLUENCE_TOOLS_METADATA = createToolsRecord({
     schema: {},
     stake: "never_ask",
     displayLabels: {
-      running: "Listing spaces",
-      done: "List spaces",
+      running: "Listing Confluence spaces",
+      done: "List Confluence spaces",
     },
   },
   get_pages: {
@@ -48,8 +48,8 @@ export const CONFLUENCE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Searching pages",
-      done: "Search pages",
+      running: "Searching Confluence pages",
+      done: "Search Confluence pages",
     },
   },
   get_page: {
@@ -67,8 +67,8 @@ export const CONFLUENCE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Retrieving page",
-      done: "Retrieve page",
+      running: "Retrieving Confluence page",
+      done: "Retrieve Confluence page",
     },
   },
   create_page: {
@@ -102,8 +102,8 @@ export const CONFLUENCE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Creating page",
-      done: "Create page",
+      running: "Creating Confluence page",
+      done: "Create Confluence page",
     },
   },
   update_page: {
@@ -151,8 +151,8 @@ export const CONFLUENCE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Updating page",
-      done: "Update page",
+      running: "Updating Confluence page",
+      done: "Update Confluence page",
     },
   },
 });

--- a/front/lib/api/actions/servers/conversation_files/metadata.ts
+++ b/front/lib/api/actions/servers/conversation_files/metadata.ts
@@ -15,8 +15,8 @@ export const CONVERSATION_FILES_TOOLS_METADATA = createToolsRecord({
     schema: {},
     stake: "never_ask",
     displayLabels: {
-      running: "Listing files",
-      done: "List files",
+      running: "Listing files in conversation",
+      done: "List files in conversation",
     },
   },
   [CONVERSATION_CAT_FILE_ACTION_NAME]: {
@@ -52,8 +52,8 @@ export const CONVERSATION_FILES_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Reading file",
-      done: "Read file",
+      running: "Reading file from conversation",
+      done: "Read file from conversation",
     },
   },
 });

--- a/front/lib/api/actions/servers/conversation_files/metadata.ts
+++ b/front/lib/api/actions/servers/conversation_files/metadata.ts
@@ -14,6 +14,10 @@ export const CONVERSATION_FILES_TOOLS_METADATA = createToolsRecord({
     description: "List all files attached to the conversation.",
     schema: {},
     stake: "never_ask",
+    displayLabels: {
+      running: "Listing files",
+      done: "List files",
+    },
   },
   [CONVERSATION_CAT_FILE_ACTION_NAME]: {
     description:
@@ -47,6 +51,10 @@ export const CONVERSATION_FILES_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Reading file",
+      done: "Read file",
+    },
   },
 });
 
@@ -64,6 +72,7 @@ export const CONVERSATION_FILES_SERVER = {
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+    displayLabels: t.displayLabels,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(CONVERSATION_FILES_TOOLS_METADATA).map((t) => [

--- a/front/lib/api/actions/servers/data_sources_file_system/metadata.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/metadata.ts
@@ -63,8 +63,8 @@ export const DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Reading content",
-      done: "Read content",
+      running: "Reading file from data source",
+      done: "Read file from data source",
     },
   },
   [FILESYSTEM_LIST_TOOL_NAME]: {
@@ -77,8 +77,8 @@ export const DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA = createToolsRecord({
     schema: DataSourceFilesystemListInputSchema.shape,
     stake: "never_ask",
     displayLabels: {
-      running: "Listing contents",
-      done: "List contents",
+      running: "Listing data source contents",
+      done: "List data source contents",
     },
   },
   [FILESYSTEM_SEARCH_TOOL_NAME]: {
@@ -87,8 +87,8 @@ export const DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA = createToolsRecord({
     schema: SearchWithNodesInputSchema.shape,
     stake: "never_ask",
     displayLabels: {
-      running: "Searching content",
-      done: "Search content",
+      running: "Searching data sources",
+      done: "Search data sources",
     },
   },
   [FILESYSTEM_FIND_TOOL_NAME]: {
@@ -98,8 +98,8 @@ export const DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA = createToolsRecord({
     schema: DataSourceFilesystemFindInputSchema.shape,
     stake: "never_ask",
     displayLabels: {
-      running: "Finding nodes",
-      done: "Find nodes",
+      running: "Finding in data sources",
+      done: "Find in data sources",
     },
   },
   [FILESYSTEM_LOCATE_IN_TREE_TOOL_NAME]: {
@@ -117,8 +117,8 @@ export const DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Locating in tree",
-      done: "Locate in tree",
+      running: "Locating content in hierarchy",
+      done: "Locate content in hierarchy",
     },
   },
   [FIND_TAGS_TOOL_NAME]: {

--- a/front/lib/api/actions/servers/data_sources_file_system/metadata.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/metadata.ts
@@ -62,6 +62,10 @@ export const DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Reading content",
+      done: "Read content",
+    },
   },
   [FILESYSTEM_LIST_TOOL_NAME]: {
     description:
@@ -72,12 +76,20 @@ export const DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA = createToolsRecord({
       "(hasChildren: true), it means that this tool can be used again on it.",
     schema: DataSourceFilesystemListInputSchema.shape,
     stake: "never_ask",
+    displayLabels: {
+      running: "Listing contents",
+      done: "List contents",
+    },
   },
   [FILESYSTEM_SEARCH_TOOL_NAME]: {
     description:
       "Search for content nodes semantically using a query string. Returns matching nodes with their content.",
     schema: SearchWithNodesInputSchema.shape,
     stake: "never_ask",
+    displayLabels: {
+      running: "Searching content",
+      done: "Search content",
+    },
   },
   [FILESYSTEM_FIND_TOOL_NAME]: {
     description:
@@ -85,6 +97,10 @@ export const DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA = createToolsRecord({
       "within a specific subtree using rootNodeId. Returns matching nodes without their full content.",
     schema: DataSourceFilesystemFindInputSchema.shape,
     stake: "never_ask",
+    displayLabels: {
+      running: "Finding nodes",
+      done: "Find nodes",
+    },
   },
   [FILESYSTEM_LOCATE_IN_TREE_TOOL_NAME]: {
     description:
@@ -100,6 +116,10 @@ export const DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA = createToolsRecord({
         ],
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Locating in tree",
+      done: "Locate in tree",
+    },
   },
   [FIND_TAGS_TOOL_NAME]: {
     description:
@@ -112,6 +132,10 @@ export const DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA = createToolsRecord({
         ],
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Finding tags",
+      done: "Find tags",
+    },
   },
 });
 
@@ -158,6 +182,7 @@ export const DATA_SOURCES_FILE_SYSTEM_SERVER = {
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+    displayLabels: t.displayLabels,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA).map((t) => [

--- a/front/lib/api/actions/servers/data_warehouses/metadata.ts
+++ b/front/lib/api/actions/servers/data_warehouses/metadata.ts
@@ -52,6 +52,10 @@ export const DATA_WAREHOUSES_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     enableAlerting: true,
+    displayLabels: {
+      running: "Listing warehouse contents",
+      done: "List warehouse contents",
+    },
   },
   find: {
     description:
@@ -93,6 +97,10 @@ export const DATA_WAREHOUSES_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     enableAlerting: true,
+    displayLabels: {
+      running: "Finding tables",
+      done: "Find tables",
+    },
   },
   describe_tables: {
     description:
@@ -112,6 +120,10 @@ export const DATA_WAREHOUSES_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     enableAlerting: true,
+    displayLabels: {
+      running: "Describing tables",
+      done: "Describe tables",
+    },
   },
   query: {
     description:
@@ -138,6 +150,10 @@ export const DATA_WAREHOUSES_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     enableAlerting: true,
+    displayLabels: {
+      running: "Running query",
+      done: "Run query",
+    },
   },
 });
 
@@ -156,6 +172,7 @@ export const DATA_WAREHOUSES_SERVER = {
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+    displayLabels: t.displayLabels,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(DATA_WAREHOUSES_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/data_warehouses/metadata.ts
+++ b/front/lib/api/actions/servers/data_warehouses/metadata.ts
@@ -98,8 +98,8 @@ export const DATA_WAREHOUSES_TOOLS_METADATA = createToolsRecord({
     stake: "never_ask",
     enableAlerting: true,
     displayLabels: {
-      running: "Finding tables",
-      done: "Find tables",
+      running: "Finding tables in warehouse",
+      done: "Find tables in warehouse",
     },
   },
   describe_tables: {
@@ -121,8 +121,8 @@ export const DATA_WAREHOUSES_TOOLS_METADATA = createToolsRecord({
     stake: "never_ask",
     enableAlerting: true,
     displayLabels: {
-      running: "Describing tables",
-      done: "Describe tables",
+      running: "Describing warehouse tables",
+      done: "Describe warehouse tables",
     },
   },
   query: {
@@ -151,8 +151,8 @@ export const DATA_WAREHOUSES_TOOLS_METADATA = createToolsRecord({
     stake: "never_ask",
     enableAlerting: true,
     displayLabels: {
-      running: "Running query",
-      done: "Run query",
+      running: "Running warehouse query",
+      done: "Run warehouse query",
     },
   },
 });

--- a/front/lib/api/actions/servers/databricks/metadata.ts
+++ b/front/lib/api/actions/servers/databricks/metadata.ts
@@ -14,8 +14,8 @@ export const DATABRICKS_TOOLS_METADATA = createToolsRecord({
     schema: {},
     stake: "never_ask",
     displayLabels: {
-      running: "Listing warehouses",
-      done: "List warehouses",
+      running: "Listing warehouses on Databricks",
+      done: "List warehouses on Databricks",
     },
   },
 });

--- a/front/lib/api/actions/servers/extract_data/metadata.ts
+++ b/front/lib/api/actions/servers/extract_data/metadata.ts
@@ -93,8 +93,8 @@ export const EXTRACT_DATA_BASE_TOOLS_METADATA = createToolsRecord({
     schema: baseExtractSchema,
     stake: "never_ask",
     displayLabels: {
-      running: "Extracting data",
-      done: "Extract data",
+      running: "Extracting data from documents",
+      done: "Extract data from documents",
     },
   },
 });
@@ -106,8 +106,8 @@ export const EXTRACT_DATA_WITH_TAGS_TOOLS_METADATA = createToolsRecord({
     schema: extractWithTagsSchema,
     stake: "never_ask",
     displayLabels: {
-      running: "Extracting data",
-      done: "Extract data",
+      running: "Extracting data from documents",
+      done: "Extract data from documents",
     },
   },
   find_tags: {

--- a/front/lib/api/actions/servers/freshservice/metadata.ts
+++ b/front/lib/api/actions/servers/freshservice/metadata.ts
@@ -54,6 +54,10 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
       per_page: z.number().optional().default(30),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Listing tickets",
+      done: "List tickets",
+    },
   },
   get_ticket: {
     description:
@@ -74,12 +78,20 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Getting ticket",
+      done: "Get ticket",
+    },
   },
   get_ticket_read_fields: {
     description:
       "Lists available Freshservice ticket field ids for use in the get_ticket.fields parameter (read-time).",
     schema: {},
     stake: "never_ask",
+    displayLabels: {
+      running: "Getting ticket read fields",
+      done: "Get ticket read fields",
+    },
   },
   get_ticket_write_fields: {
     description:
@@ -91,6 +103,10 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
         .describe("Search term to filter fields by name or label"),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Getting ticket write fields",
+      done: "Get ticket write fields",
+    },
   },
   create_ticket: {
     description:
@@ -115,6 +131,10 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
         .describe("Custom field values"),
     },
     stake: "low",
+    displayLabels: {
+      running: "Creating ticket",
+      done: "Create ticket",
+    },
   },
   update_ticket: {
     description: "Updates an existing ticket in Freshservice",
@@ -137,6 +157,10 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
         .describe("Custom field values"),
     },
     stake: "low",
+    displayLabels: {
+      running: "Updating ticket",
+      done: "Update ticket",
+    },
   },
   add_ticket_note: {
     description: "Adds a note to an existing ticket",
@@ -150,6 +174,10 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
         .describe("Whether the note is private"),
     },
     stake: "low",
+    displayLabels: {
+      running: "Adding ticket note",
+      done: "Add ticket note",
+    },
   },
   add_ticket_reply: {
     description: "Adds a reply to a ticket conversation",
@@ -158,6 +186,10 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
       body: z.string().describe("Content of the note in HTML format"),
     },
     stake: "low",
+    displayLabels: {
+      running: "Adding ticket reply",
+      done: "Add ticket reply",
+    },
   },
 
   // Ticket tasks
@@ -167,6 +199,10 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
       ticket_id: z.number().describe("The ID of the ticket"),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Listing ticket tasks",
+      done: "List ticket tasks",
+    },
   },
   get_ticket_task: {
     description: "Gets detailed information about a specific task on a ticket",
@@ -175,6 +211,10 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
       task_id: z.number().describe("The ID of the task"),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Getting ticket task",
+      done: "Get ticket task",
+    },
   },
   create_ticket_task: {
     description:
@@ -202,6 +242,10 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
         .describe("Group ID to assign the task to"),
     },
     stake: "low",
+    displayLabels: {
+      running: "Creating ticket task",
+      done: "Create ticket task",
+    },
   },
   update_ticket_task: {
     description: "Updates an existing task on a ticket",
@@ -232,6 +276,10 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
         .describe("Updated group ID to assign the task to"),
     },
     stake: "low",
+    displayLabels: {
+      running: "Updating ticket task",
+      done: "Update ticket task",
+    },
   },
   delete_ticket_task: {
     description: "Deletes a task from a ticket",
@@ -240,6 +288,10 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
       task_id: z.number().describe("The ID of the task to delete"),
     },
     stake: "low",
+    displayLabels: {
+      running: "Deleting ticket task",
+      done: "Delete ticket task",
+    },
   },
 
   // Ticket approvals
@@ -250,6 +302,10 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
       approval_id: z.number().describe("The ID of the approval to retrieve"),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Getting ticket approval",
+      done: "Get ticket approval",
+    },
   },
   list_ticket_approvals: {
     description: "Lists all approvals for a specific ticket",
@@ -257,6 +313,10 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
       ticket_id: z.number().describe("The ID of the ticket"),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Listing ticket approvals",
+      done: "List ticket approvals",
+    },
   },
   request_service_approval: {
     description:
@@ -279,6 +339,10 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "low",
+    displayLabels: {
+      running: "Requesting service approval",
+      done: "Request service approval",
+    },
   },
 
   // Departments, Products, On-call schedules
@@ -289,6 +353,10 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
       per_page: z.number().optional().default(30),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Listing departments",
+      done: "List departments",
+    },
   },
   list_products: {
     description: "Lists all products in Freshservice",
@@ -297,6 +365,10 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
       per_page: z.number().optional().default(30),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Listing products",
+      done: "List products",
+    },
   },
   list_oncall_schedules: {
     description: "Lists on-call schedules",
@@ -305,6 +377,10 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
       per_page: z.number().optional().default(30),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Listing on-call schedules",
+      done: "List on-call schedules",
+    },
   },
 
   // Service catalog
@@ -316,6 +392,10 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
       per_page: z.number().optional().default(30),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Listing service categories",
+      done: "List service categories",
+    },
   },
   list_service_items: {
     description:
@@ -331,6 +411,10 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
       per_page: z.number().optional().default(30),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Listing service items",
+      done: "List service items",
+    },
   },
   search_service_items: {
     description:
@@ -358,6 +442,10 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
       per_page: z.number().optional().default(30),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Searching service items",
+      done: "Search service items",
+    },
   },
   get_service_item: {
     description:
@@ -368,6 +456,10 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
         .describe("The display ID of the service catalog item"),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Getting service item",
+      done: "Get service item",
+    },
   },
   get_service_item_fields: {
     description:
@@ -378,6 +470,10 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
         .describe("The display ID of the service catalog item"),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Getting service item fields",
+      done: "Get service item fields",
+    },
   },
   request_service_item: {
     description:
@@ -404,6 +500,10 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
         .describe("Optional ticket ID to attach this service request to"),
     },
     stake: "low",
+    displayLabels: {
+      running: "Requesting service item",
+      done: "Request service item",
+    },
   },
 
   // Solutions (Knowledge Base)
@@ -415,6 +515,10 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
       per_page: z.number().optional().default(30),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Listing solution categories",
+      done: "List solution categories",
+    },
   },
   list_solution_folders: {
     description:
@@ -425,6 +529,10 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
       per_page: z.number().optional().default(30),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Listing solution folders",
+      done: "List solution folders",
+    },
   },
   list_solution_articles: {
     description:
@@ -443,6 +551,10 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
       per_page: z.number().optional().default(30),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Listing solution articles",
+      done: "List solution articles",
+    },
   },
   get_solution_article: {
     description:
@@ -451,6 +563,10 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
       article_id: z.number().describe("The ID of the solution article"),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Getting solution article",
+      done: "Get solution article",
+    },
   },
   create_solution_article: {
     description:
@@ -470,6 +586,10 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
       tags: z.array(z.string()).optional().describe("Tags for the article"),
     },
     stake: "high",
+    displayLabels: {
+      running: "Creating solution article",
+      done: "Create solution article",
+    },
   },
 
   // Requesters
@@ -483,6 +603,10 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
       per_page: z.number().optional().default(30),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Listing requesters",
+      done: "List requesters",
+    },
   },
   get_requester: {
     description: "Gets detailed information about a specific requester",
@@ -490,6 +614,10 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
       requester_id: z.number().describe("The ID of the requester"),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Getting requester",
+      done: "Get requester",
+    },
   },
 
   // Purchase Orders
@@ -500,6 +628,10 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
       per_page: z.number().optional().default(30),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Listing purchase orders",
+      done: "List purchase orders",
+    },
   },
 
   // SLA Policies
@@ -507,6 +639,10 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     description: "Lists SLA policies",
     schema: {},
     stake: "never_ask",
+    displayLabels: {
+      running: "Listing SLA policies",
+      done: "List SLA policies",
+    },
   },
 
   // Canned responses
@@ -527,6 +663,10 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
       per_page: z.number().optional().default(30),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Listing canned responses",
+      done: "List canned responses",
+    },
   },
   get_canned_response: {
     description: "Gets detailed information about a specific canned response",
@@ -534,6 +674,10 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
       response_id: z.number().describe("The ID of the canned response"),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Getting canned response",
+      done: "Get canned response",
+    },
   },
 });
 
@@ -554,6 +698,7 @@ export const FRESHSERVICE_SERVER = {
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+    displayLabels: t.displayLabels,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(FRESHSERVICE_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/freshservice/metadata.ts
+++ b/front/lib/api/actions/servers/freshservice/metadata.ts
@@ -175,8 +175,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Adding Freshservice ticket note",
-      done: "Add Freshservice ticket note",
+      running: "Adding note to Freshservice ticket",
+      done: "Add note to Freshservice ticket",
     },
   },
   add_ticket_reply: {
@@ -187,8 +187,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Adding Freshservice ticket reply",
-      done: "Add Freshservice ticket reply",
+      running: "Adding reply to Freshservice ticket",
+      done: "Add reply to Freshservice ticket",
     },
   },
 

--- a/front/lib/api/actions/servers/freshservice/metadata.ts
+++ b/front/lib/api/actions/servers/freshservice/metadata.ts
@@ -55,8 +55,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Listing tickets",
-      done: "List tickets",
+      running: "Listing Freshservice tickets",
+      done: "List Freshservice tickets",
     },
   },
   get_ticket: {
@@ -79,8 +79,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Getting ticket",
-      done: "Get ticket",
+      running: "Getting Freshservice ticket",
+      done: "Get Freshservice ticket",
     },
   },
   get_ticket_read_fields: {
@@ -89,8 +89,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     schema: {},
     stake: "never_ask",
     displayLabels: {
-      running: "Getting ticket read fields",
-      done: "Get ticket read fields",
+      running: "Getting Freshservice ticket read fields",
+      done: "Get Freshservice ticket read fields",
     },
   },
   get_ticket_write_fields: {
@@ -104,8 +104,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Getting ticket write fields",
-      done: "Get ticket write fields",
+      running: "Getting Freshservice ticket write fields",
+      done: "Get Freshservice ticket write fields",
     },
   },
   create_ticket: {
@@ -132,8 +132,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Creating ticket",
-      done: "Create ticket",
+      running: "Creating Freshservice ticket",
+      done: "Create Freshservice ticket",
     },
   },
   update_ticket: {
@@ -158,8 +158,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Updating ticket",
-      done: "Update ticket",
+      running: "Updating Freshservice ticket",
+      done: "Update Freshservice ticket",
     },
   },
   add_ticket_note: {
@@ -175,8 +175,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Adding ticket note",
-      done: "Add ticket note",
+      running: "Adding Freshservice ticket note",
+      done: "Add Freshservice ticket note",
     },
   },
   add_ticket_reply: {
@@ -187,8 +187,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Adding ticket reply",
-      done: "Add ticket reply",
+      running: "Adding Freshservice ticket reply",
+      done: "Add Freshservice ticket reply",
     },
   },
 
@@ -200,8 +200,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Listing ticket tasks",
-      done: "List ticket tasks",
+      running: "Listing Freshservice ticket tasks",
+      done: "List Freshservice ticket tasks",
     },
   },
   get_ticket_task: {
@@ -212,8 +212,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Getting ticket task",
-      done: "Get ticket task",
+      running: "Getting Freshservice ticket task",
+      done: "Get Freshservice ticket task",
     },
   },
   create_ticket_task: {
@@ -243,8 +243,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Creating ticket task",
-      done: "Create ticket task",
+      running: "Creating Freshservice ticket task",
+      done: "Create Freshservice ticket task",
     },
   },
   update_ticket_task: {
@@ -277,8 +277,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Updating ticket task",
-      done: "Update ticket task",
+      running: "Updating Freshservice ticket task",
+      done: "Update Freshservice ticket task",
     },
   },
   delete_ticket_task: {
@@ -289,8 +289,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Deleting ticket task",
-      done: "Delete ticket task",
+      running: "Deleting Freshservice ticket task",
+      done: "Delete Freshservice ticket task",
     },
   },
 
@@ -303,8 +303,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Getting ticket approval",
-      done: "Get ticket approval",
+      running: "Getting Freshservice ticket approval",
+      done: "Get Freshservice ticket approval",
     },
   },
   list_ticket_approvals: {
@@ -314,8 +314,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Listing ticket approvals",
-      done: "List ticket approvals",
+      running: "Listing Freshservice ticket approvals",
+      done: "List Freshservice ticket approvals",
     },
   },
   request_service_approval: {
@@ -340,8 +340,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Requesting service approval",
-      done: "Request service approval",
+      running: "Requesting Freshservice approval",
+      done: "Request Freshservice approval",
     },
   },
 

--- a/front/lib/api/actions/servers/freshservice/metadata.ts
+++ b/front/lib/api/actions/servers/freshservice/metadata.ts
@@ -354,8 +354,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Listing departments",
-      done: "List departments",
+      running: "Listing Freshservice departments",
+      done: "List Freshservice departments",
     },
   },
   list_products: {
@@ -366,8 +366,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Listing products",
-      done: "List products",
+      running: "Listing Freshservice products",
+      done: "List Freshservice products",
     },
   },
   list_oncall_schedules: {
@@ -378,8 +378,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Listing on-call schedules",
-      done: "List on-call schedules",
+      running: "Listing Freshservice on-call schedules",
+      done: "List Freshservice on-call schedules",
     },
   },
 
@@ -393,8 +393,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Listing service categories",
-      done: "List service categories",
+      running: "Listing Freshservice service categories",
+      done: "List Freshservice service categories",
     },
   },
   list_service_items: {
@@ -412,8 +412,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Listing service items",
-      done: "List service items",
+      running: "Listing Freshservice service items",
+      done: "List Freshservice service items",
     },
   },
   search_service_items: {
@@ -443,8 +443,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Searching service items",
-      done: "Search service items",
+      running: "Searching Freshservice service items",
+      done: "Search Freshservice service items",
     },
   },
   get_service_item: {
@@ -457,8 +457,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Getting service item",
-      done: "Get service item",
+      running: "Getting Freshservice service item",
+      done: "Get Freshservice service item",
     },
   },
   get_service_item_fields: {
@@ -471,8 +471,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Getting service item fields",
-      done: "Get service item fields",
+      running: "Getting Freshservice service item fields",
+      done: "Get Freshservice service item fields",
     },
   },
   request_service_item: {
@@ -501,8 +501,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Requesting service item",
-      done: "Request service item",
+      running: "Requesting Freshservice service item",
+      done: "Request Freshservice service item",
     },
   },
 
@@ -516,8 +516,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Listing solution categories",
-      done: "List solution categories",
+      running: "Listing Freshservice solution categories",
+      done: "List Freshservice solution categories",
     },
   },
   list_solution_folders: {
@@ -530,8 +530,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Listing solution folders",
-      done: "List solution folders",
+      running: "Listing Freshservice solution folders",
+      done: "List Freshservice solution folders",
     },
   },
   list_solution_articles: {
@@ -552,8 +552,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Listing solution articles",
-      done: "List solution articles",
+      running: "Listing Freshservice solution articles",
+      done: "List Freshservice solution articles",
     },
   },
   get_solution_article: {
@@ -564,8 +564,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Getting solution article",
-      done: "Get solution article",
+      running: "Getting Freshservice solution article",
+      done: "Get Freshservice solution article",
     },
   },
   create_solution_article: {
@@ -587,8 +587,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "high",
     displayLabels: {
-      running: "Creating solution article",
-      done: "Create solution article",
+      running: "Creating Freshservice solution article",
+      done: "Create Freshservice solution article",
     },
   },
 
@@ -604,8 +604,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Listing requesters",
-      done: "List requesters",
+      running: "Listing Freshservice requesters",
+      done: "List Freshservice requesters",
     },
   },
   get_requester: {
@@ -615,8 +615,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Getting requester",
-      done: "Get requester",
+      running: "Getting Freshservice requester",
+      done: "Get Freshservice requester",
     },
   },
 
@@ -629,8 +629,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Listing purchase orders",
-      done: "List purchase orders",
+      running: "Listing Freshservice purchase orders",
+      done: "List Freshservice purchase orders",
     },
   },
 
@@ -640,8 +640,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     schema: {},
     stake: "never_ask",
     displayLabels: {
-      running: "Listing SLA policies",
-      done: "List SLA policies",
+      running: "Listing Freshservice SLA policies",
+      done: "List Freshservice SLA policies",
     },
   },
 
@@ -664,8 +664,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Listing canned responses",
-      done: "List canned responses",
+      running: "Listing Freshservice canned responses",
+      done: "List Freshservice canned responses",
     },
   },
   get_canned_response: {
@@ -675,8 +675,8 @@ export const FRESHSERVICE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Getting canned response",
-      done: "Get canned response",
+      running: "Getting Freshservice canned response",
+      done: "Get Freshservice canned response",
     },
   },
 });

--- a/front/lib/api/actions/servers/front/metadata.ts
+++ b/front/lib/api/actions/servers/front/metadata.ts
@@ -29,8 +29,8 @@ export const FRONT_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Searching conversations",
-      done: "Search conversations",
+      running: "Searching Front conversations",
+      done: "Search Front conversations",
     },
   },
   get_conversation: {
@@ -44,8 +44,8 @@ export const FRONT_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Retrieving conversation",
-      done: "Retrieve conversation",
+      running: "Retrieving Front conversation",
+      done: "Retrieve Front conversation",
     },
   },
   get_conversation_messages: {
@@ -59,8 +59,8 @@ export const FRONT_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Retrieving messages",
-      done: "Retrieve messages",
+      running: "Retrieving Front messages",
+      done: "Retrieve Front messages",
     },
   },
   get_contact: {
@@ -79,8 +79,8 @@ export const FRONT_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Looking up contact",
-      done: "Look up contact",
+      running: "Looking up Front contact",
+      done: "Look up Front contact",
     },
   },
   list_tags: {
@@ -88,8 +88,8 @@ export const FRONT_TOOLS_METADATA = createToolsRecord({
     schema: {},
     stake: "never_ask",
     displayLabels: {
-      running: "Listing tags",
-      done: "List tags",
+      running: "Listing Front tags",
+      done: "List Front tags",
     },
   },
   list_teammates: {
@@ -98,8 +98,8 @@ export const FRONT_TOOLS_METADATA = createToolsRecord({
     schema: {},
     stake: "never_ask",
     displayLabels: {
-      running: "Listing teammates",
-      done: "List teammates",
+      running: "Listing Front teammates",
+      done: "List Front teammates",
     },
   },
   get_customer_history: {
@@ -119,8 +119,8 @@ export const FRONT_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Retrieving customer history",
-      done: "Retrieve customer history",
+      running: "Retrieving Front customer history",
+      done: "Retrieve Front customer history",
     },
   },
   list_inboxes: {
@@ -128,8 +128,8 @@ export const FRONT_TOOLS_METADATA = createToolsRecord({
     schema: {},
     stake: "never_ask",
     displayLabels: {
-      running: "Listing inboxes",
-      done: "List inboxes",
+      running: "Listing Front inboxes",
+      done: "List Front inboxes",
     },
   },
   create_conversation: {
@@ -148,8 +148,8 @@ export const FRONT_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Creating conversation",
-      done: "Create conversation",
+      running: "Creating Front conversation",
+      done: "Create Front conversation",
     },
   },
   create_draft: {
@@ -165,8 +165,8 @@ export const FRONT_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Creating draft",
-      done: "Create draft",
+      running: "Creating draft on Front",
+      done: "Create draft on Front",
     },
   },
   add_tags: {
@@ -180,8 +180,8 @@ export const FRONT_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Adding tags",
-      done: "Add tags",
+      running: "Adding tags on Front",
+      done: "Add tags on Front",
     },
   },
   add_comment: {
@@ -197,8 +197,8 @@ export const FRONT_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Adding comment",
-      done: "Add comment",
+      running: "Adding comment on Front",
+      done: "Add comment on Front",
     },
   },
   add_links: {
@@ -212,8 +212,8 @@ export const FRONT_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Linking conversations",
-      done: "Link conversations",
+      running: "Linking Front conversations",
+      done: "Link Front conversations",
     },
   },
   send_message: {
@@ -237,8 +237,8 @@ export const FRONT_TOOLS_METADATA = createToolsRecord({
     },
     stake: "high",
     displayLabels: {
-      running: "Sending message",
-      done: "Send message",
+      running: "Sending message on Front",
+      done: "Send message on Front",
     },
   },
   update_conversation_status: {
@@ -254,8 +254,8 @@ export const FRONT_TOOLS_METADATA = createToolsRecord({
     },
     stake: "high",
     displayLabels: {
-      running: "Updating status",
-      done: "Update status",
+      running: "Updating Front conversation status",
+      done: "Update Front conversation status",
     },
   },
   assign_conversation: {
@@ -266,8 +266,8 @@ export const FRONT_TOOLS_METADATA = createToolsRecord({
     },
     stake: "high",
     displayLabels: {
-      running: "Assigning conversation",
-      done: "Assign conversation",
+      running: "Assigning Front conversation",
+      done: "Assign Front conversation",
     },
   },
 });

--- a/front/lib/api/actions/servers/github/metadata.ts
+++ b/front/lib/api/actions/servers/github/metadata.ts
@@ -30,8 +30,8 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Creating issue",
-      done: "Create issue",
+      running: "Creating GitHub issue",
+      done: "Create GitHub issue",
     },
   },
   get_pull_request: {
@@ -49,8 +49,8 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Retrieving pull request",
-      done: "Retrieve pull request",
+      running: "Retrieving GitHub pull request",
+      done: "Retrieve GitHub pull request",
     },
   },
   create_pull_request_review: {
@@ -95,8 +95,8 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
     },
     stake: "high",
     displayLabels: {
-      running: "Creating pull request review",
-      done: "Create pull request review",
+      running: "Reviewing GitHub pull request",
+      done: "Review GitHub pull request",
     },
   },
   list_organization_projects: {
@@ -111,8 +111,8 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Listing organization projects",
-      done: "List organization projects",
+      running: "Listing GitHub organization projects",
+      done: "List GitHub organization projects",
     },
   },
   add_issue_to_project: {
@@ -149,8 +149,8 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Adding issue to project",
-      done: "Add issue to project",
+      running: "Adding GitHub issue to project",
+      done: "Add GitHub issue to project",
     },
   },
   comment_on_issue: {
@@ -169,8 +169,8 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Commenting on issue",
-      done: "Comment on issue",
+      running: "Commenting on GitHub issue",
+      done: "Comment on GitHub issue",
     },
   },
   get_issue: {
@@ -187,8 +187,8 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Retrieving issue",
-      done: "Retrieve issue",
+      running: "Retrieving GitHub issue",
+      done: "Retrieve GitHub issue",
     },
   },
   list_issues: {
@@ -228,8 +228,8 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Listing issues",
-      done: "List issues",
+      running: "Listing GitHub issues",
+      done: "List GitHub issues",
     },
   },
   search_advanced: {
@@ -256,8 +256,8 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Searching issues and pull requests",
-      done: "Search issues and pull requests",
+      running: "Searching GitHub issues and pull requests",
+      done: "Search GitHub issues and pull requests",
     },
   },
   list_pull_requests: {
@@ -293,8 +293,8 @@ export const GITHUB_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Listing pull requests",
-      done: "List pull requests",
+      running: "Listing GitHub pull requests",
+      done: "List GitHub pull requests",
     },
   },
 });

--- a/front/lib/api/actions/servers/gmail/metadata.ts
+++ b/front/lib/api/actions/servers/gmail/metadata.ts
@@ -24,8 +24,8 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Getting drafts",
-      done: "Get drafts",
+      running: "Getting Gmail drafts",
+      done: "Get Gmail drafts",
     },
   },
   create_draft: {
@@ -48,8 +48,8 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
     },
     stake: "medium",
     displayLabels: {
-      running: "Creating draft",
-      done: "Create draft",
+      running: "Creating Gmail draft",
+      done: "Create Gmail draft",
     },
   },
   delete_draft: {
@@ -61,8 +61,8 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
     },
     stake: "high",
     displayLabels: {
-      running: "Deleting draft",
-      done: "Delete draft",
+      running: "Deleting Gmail draft",
+      done: "Delete Gmail draft",
     },
   },
   get_messages: {
@@ -94,8 +94,8 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Getting messages",
-      done: "Get messages",
+      running: "Getting Gmail messages",
+      done: "Get Gmail messages",
     },
   },
   get_attachment: {
@@ -131,8 +131,8 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Getting attachment",
-      done: "Get attachment",
+      running: "Getting Gmail attachment",
+      done: "Get Gmail attachment",
     },
   },
   create_reply_draft: {
@@ -164,8 +164,8 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
     },
     stake: "medium",
     displayLabels: {
-      running: "Creating reply draft",
-      done: "Create reply draft",
+      running: "Creating Gmail reply draft",
+      done: "Create Gmail reply draft",
     },
   },
   send_mail: {
@@ -191,8 +191,8 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
     },
     stake: "high",
     displayLabels: {
-      running: "Sending email",
-      done: "Send email",
+      running: "Sending Gmail email",
+      done: "Send Gmail email",
     },
   },
 });

--- a/front/lib/api/actions/servers/gmail/metadata.ts
+++ b/front/lib/api/actions/servers/gmail/metadata.ts
@@ -23,6 +23,10 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
         .describe("Token for fetching the next page of results."),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Getting drafts",
+      done: "Get drafts",
+    },
   },
   create_draft: {
     description: `Create a new email draft in Gmail.
@@ -43,6 +47,10 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
       body: z.string().describe("The body of the email"),
     },
     stake: "medium",
+    displayLabels: {
+      running: "Creating draft",
+      done: "Create draft",
+    },
   },
   delete_draft: {
     description: "Delete a draft email from Gmail.",
@@ -52,6 +60,10 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
       to: z.array(z.string()).describe("The email addresses of the recipients"),
     },
     stake: "high",
+    displayLabels: {
+      running: "Deleting draft",
+      done: "Delete draft",
+    },
   },
   get_messages: {
     description:
@@ -81,6 +93,10 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Getting messages",
+      done: "Get messages",
+    },
   },
   get_attachment: {
     description:
@@ -114,6 +130,10 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Getting attachment",
+      done: "Get attachment",
+    },
   },
   create_reply_draft: {
     description: `Create a reply draft to an existing email thread in Gmail.
@@ -143,6 +163,10 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
         .describe("Override the BCC recipients for the reply."),
     },
     stake: "medium",
+    displayLabels: {
+      running: "Creating reply draft",
+      done: "Create reply draft",
+    },
   },
   send_mail: {
     description: `Send an email directly via Gmail.
@@ -166,6 +190,10 @@ export const GMAIL_TOOLS_METADATA = createToolsRecord({
       body: z.string().describe("The body of the email"),
     },
     stake: "high",
+    displayLabels: {
+      running: "Sending email",
+      done: "Send email",
+    },
   },
 });
 
@@ -188,6 +216,7 @@ export const GMAIL_SERVER = {
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+    displayLabels: t.displayLabels,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(GMAIL_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/google_calendar/metadata.ts
+++ b/front/lib/api/actions/servers/google_calendar/metadata.ts
@@ -20,8 +20,8 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Listing calendars",
-      done: "List calendars",
+      running: "Listing Google calendars",
+      done: "List Google calendars",
     },
   },
   list_events: {
@@ -52,8 +52,8 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Listing events",
-      done: "List events",
+      running: "Listing Google Calendar events",
+      done: "List Google Calendar events",
     },
   },
   get_event: {
@@ -67,8 +67,8 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Retrieving event",
-      done: "Retrieve event",
+      running: "Retrieving Google Calendar event",
+      done: "Retrieve Google Calendar event",
     },
   },
   create_event: {
@@ -101,8 +101,8 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = createToolsRecord({
     },
     stake: "medium",
     displayLabels: {
-      running: "Creating event",
-      done: "Create event",
+      running: "Creating Google Calendar event",
+      done: "Create Google Calendar event",
     },
   },
   update_event: {
@@ -138,8 +138,8 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = createToolsRecord({
     },
     stake: "medium",
     displayLabels: {
-      running: "Updating event",
-      done: "Update event",
+      running: "Updating Google Calendar event",
+      done: "Update Google Calendar event",
     },
   },
   delete_event: {
@@ -153,8 +153,8 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = createToolsRecord({
     },
     stake: "medium",
     displayLabels: {
-      running: "Deleting event",
-      done: "Delete event",
+      running: "Deleting Google Calendar event",
+      done: "Delete Google Calendar event",
     },
   },
   check_availability: {
@@ -220,8 +220,8 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Checking availability",
-      done: "Check availability",
+      running: "Checking Google Calendar availability",
+      done: "Check Google Calendar availability",
     },
   },
   get_user_timezones: {
@@ -235,8 +235,8 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Checking user timezones",
-      done: "Check user timezones",
+      running: "Checking Google Calendar user timezones",
+      done: "Check Google Calendar user timezones",
     },
   },
 });

--- a/front/lib/api/actions/servers/google_drive/metadata.ts
+++ b/front/lib/api/actions/servers/google_drive/metadata.ts
@@ -27,8 +27,8 @@ export const GOOGLE_DRIVE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Listing drives",
-      done: "List drives",
+      running: "Listing Google drives",
+      done: "List Google drives",
     },
   },
   search_files: {
@@ -100,8 +100,8 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Searching files",
-      done: "Search files",
+      running: "Searching Google Drive files",
+      done: "Search Google Drive files",
     },
   },
   get_file_content: {
@@ -125,8 +125,8 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Getting file content",
-      done: "Get file content",
+      running: "Getting Google Drive file content",
+      done: "Get Google Drive file content",
     },
   },
   get_spreadsheet: {
@@ -139,8 +139,8 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Getting spreadsheet",
-      done: "Get spreadsheet",
+      running: "Retrieving Google spreadsheet",
+      done: "Retrieve Google spreadsheet",
     },
   },
   get_worksheet: {
@@ -164,8 +164,8 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Getting worksheet",
-      done: "Get worksheet",
+      running: "Retrieving Google worksheet",
+      done: "Retrieve Google worksheet",
     },
   },
 });
@@ -178,8 +178,8 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Creating document",
-      done: "Create document",
+      running: "Creating Google document",
+      done: "Create Google document",
     },
   },
   create_spreadsheet: {
@@ -189,8 +189,8 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Creating spreadsheet",
-      done: "Create spreadsheet",
+      running: "Creating Google spreadsheet",
+      done: "Create Google spreadsheet",
     },
   },
   create_presentation: {
@@ -200,8 +200,8 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Creating presentation",
-      done: "Create presentation",
+      running: "Creating Google presentation",
+      done: "Create Google presentation",
     },
   },
   create_comment: {
@@ -212,8 +212,8 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Creating comment",
-      done: "Create comment",
+      running: "Creating Google Drive comment",
+      done: "Create Google Drive comment",
     },
   },
   update_document: {
@@ -231,8 +231,8 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "medium",
     displayLabels: {
-      running: "Updating document",
-      done: "Update document",
+      running: "Updating Google document",
+      done: "Update Google document",
     },
   },
 });

--- a/front/lib/api/actions/servers/google_drive/metadata.ts
+++ b/front/lib/api/actions/servers/google_drive/metadata.ts
@@ -212,8 +212,8 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Creating Google Drive comment",
-      done: "Create Google Drive comment",
+      running: "Adding comment on Google Drive",
+      done: "Add comment on Google Drive",
     },
   },
   update_document: {

--- a/front/lib/api/actions/servers/google_drive/metadata.ts
+++ b/front/lib/api/actions/servers/google_drive/metadata.ts
@@ -26,6 +26,10 @@ export const GOOGLE_DRIVE_TOOLS_METADATA = createToolsRecord({
       pageToken: z.string().optional().describe("Page token for pagination."),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Listing drives",
+      done: "List drives",
+    },
   },
   search_files: {
     description:
@@ -95,6 +99,10 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
       pageToken: z.string().optional().describe("Page token for pagination."),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Searching files",
+      done: "Search files",
+    },
   },
   get_file_content: {
     description: `Get the content of a Google Drive file with offset-based pagination. Supported mimeTypes: ${SUPPORTED_MIMETYPES.join(", ")}.`,
@@ -116,6 +124,10 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
         ),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Getting file content",
+      done: "Get file content",
+    },
   },
   get_spreadsheet: {
     description:
@@ -126,6 +138,10 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
         .describe("The ID of the spreadsheet to retrieve."),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Getting spreadsheet",
+      done: "Get spreadsheet",
+    },
   },
   get_worksheet: {
     description:
@@ -147,6 +163,10 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
         .describe("How values should be represented in the output."),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Getting worksheet",
+      done: "Get worksheet",
+    },
   },
 });
 
@@ -157,6 +177,10 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
       title: z.string().describe("The title of the new document."),
     },
     stake: "low",
+    displayLabels: {
+      running: "Creating document",
+      done: "Create document",
+    },
   },
   create_spreadsheet: {
     description: "Create a new Google Sheets spreadsheet in the user's Drive.",
@@ -164,6 +188,10 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
       title: z.string().describe("The title of the new spreadsheet."),
     },
     stake: "low",
+    displayLabels: {
+      running: "Creating spreadsheet",
+      done: "Create spreadsheet",
+    },
   },
   create_presentation: {
     description: "Create a new Google Slides presentation in the user's Drive.",
@@ -171,6 +199,10 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
       title: z.string().describe("The title of the new presentation."),
     },
     stake: "low",
+    displayLabels: {
+      running: "Creating presentation",
+      done: "Create presentation",
+    },
   },
   create_comment: {
     description: "Add a comment to a Google Drive file (Doc, Sheet, or Slide).",
@@ -179,6 +211,10 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
       content: z.string().describe("The text content of the comment."),
     },
     stake: "low",
+    displayLabels: {
+      running: "Creating comment",
+      done: "Create comment",
+    },
   },
   update_document: {
     description:
@@ -194,6 +230,10 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "medium",
+    displayLabels: {
+      running: "Updating document",
+      done: "Update document",
+    },
   },
 });
 
@@ -223,6 +263,7 @@ export const GOOGLE_DRIVE_SERVER = {
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+    displayLabels: t.displayLabels,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(ALL_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/google_sheets/metadata.ts
+++ b/front/lib/api/actions/servers/google_sheets/metadata.ts
@@ -25,6 +25,10 @@ export const GOOGLE_SHEETS_TOOLS_METADATA = createToolsRecord({
         .describe("Maximum number of spreadsheets to return (max 1000)."),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Listing spreadsheets",
+      done: "List spreadsheets",
+    },
   },
   get_spreadsheet: {
     description:
@@ -35,6 +39,10 @@ export const GOOGLE_SHEETS_TOOLS_METADATA = createToolsRecord({
         .describe("The ID of the spreadsheet to retrieve."),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Getting spreadsheet",
+      done: "Get spreadsheet",
+    },
   },
   get_worksheet: {
     description:
@@ -56,6 +64,10 @@ export const GOOGLE_SHEETS_TOOLS_METADATA = createToolsRecord({
         .describe("How values should be represented in the output."),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Getting worksheet",
+      done: "Get worksheet",
+    },
   },
   update_cells: {
     description: "Update cells in a Google Sheets spreadsheet.",
@@ -79,6 +91,10 @@ export const GOOGLE_SHEETS_TOOLS_METADATA = createToolsRecord({
         .describe("How the input data should be interpreted."),
     },
     stake: "low",
+    displayLabels: {
+      running: "Updating cells",
+      done: "Update cells",
+    },
   },
   append_data: {
     description: "Append data to a Google Sheets spreadsheet.",
@@ -106,6 +122,10 @@ export const GOOGLE_SHEETS_TOOLS_METADATA = createToolsRecord({
         .describe("How the input data should be inserted."),
     },
     stake: "low",
+    displayLabels: {
+      running: "Appending data",
+      done: "Append data",
+    },
   },
   clear_range: {
     description: "Clear values from a range in a Google Sheets spreadsheet.",
@@ -118,6 +138,10 @@ export const GOOGLE_SHEETS_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "low",
+    displayLabels: {
+      running: "Clearing range",
+      done: "Clear range",
+    },
   },
   create_spreadsheet: {
     description: "Create a new Google Sheets spreadsheet.",
@@ -131,6 +155,10 @@ export const GOOGLE_SHEETS_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "low",
+    displayLabels: {
+      running: "Creating spreadsheet",
+      done: "Create spreadsheet",
+    },
   },
   add_worksheet: {
     description:
@@ -148,6 +176,10 @@ export const GOOGLE_SHEETS_TOOLS_METADATA = createToolsRecord({
         .describe("Number of columns in the new worksheet."),
     },
     stake: "low",
+    displayLabels: {
+      running: "Adding worksheet",
+      done: "Add worksheet",
+    },
   },
   delete_worksheet: {
     description: "Delete a worksheet from a Google Sheets spreadsheet.",
@@ -156,6 +188,10 @@ export const GOOGLE_SHEETS_TOOLS_METADATA = createToolsRecord({
       sheetId: z.number().describe("The ID of the worksheet to delete."),
     },
     stake: "low",
+    displayLabels: {
+      running: "Deleting worksheet",
+      done: "Delete worksheet",
+    },
   },
   format_cells: {
     description: "Apply formatting to cells in a Google Sheets spreadsheet.",
@@ -194,6 +230,10 @@ export const GOOGLE_SHEETS_TOOLS_METADATA = createToolsRecord({
         .describe("Formatting options to apply."),
     },
     stake: "low",
+    displayLabels: {
+      running: "Formatting cells",
+      done: "Format cells",
+    },
   },
   copy_sheet: {
     description:
@@ -214,6 +254,10 @@ export const GOOGLE_SHEETS_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "low",
+    displayLabels: {
+      running: "Copying sheet",
+      done: "Copy sheet",
+    },
   },
   rename_worksheet: {
     description: "Rename a worksheet in a Google Sheets spreadsheet.",
@@ -223,6 +267,10 @@ export const GOOGLE_SHEETS_TOOLS_METADATA = createToolsRecord({
       newTitle: z.string().describe("The new title for the worksheet."),
     },
     stake: "low",
+    displayLabels: {
+      running: "Renaming worksheet",
+      done: "Rename worksheet",
+    },
   },
   move_worksheet: {
     description:
@@ -238,6 +286,10 @@ export const GOOGLE_SHEETS_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "low",
+    displayLabels: {
+      running: "Moving worksheet",
+      done: "Move worksheet",
+    },
   },
 });
 
@@ -260,6 +312,7 @@ export const GOOGLE_SHEETS_SERVER = {
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+    displayLabels: t.displayLabels,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(GOOGLE_SHEETS_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/google_sheets/metadata.ts
+++ b/front/lib/api/actions/servers/google_sheets/metadata.ts
@@ -26,8 +26,8 @@ export const GOOGLE_SHEETS_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Listing spreadsheets",
-      done: "List spreadsheets",
+      running: "Listing Google Sheets spreadsheets",
+      done: "List Google Sheets spreadsheets",
     },
   },
   get_spreadsheet: {
@@ -40,8 +40,8 @@ export const GOOGLE_SHEETS_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Getting spreadsheet",
-      done: "Get spreadsheet",
+      running: "Getting Google Sheets spreadsheet",
+      done: "Get Google Sheets spreadsheet",
     },
   },
   get_worksheet: {
@@ -65,8 +65,8 @@ export const GOOGLE_SHEETS_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Getting worksheet",
-      done: "Get worksheet",
+      running: "Getting Google Sheets worksheet",
+      done: "Get Google Sheets worksheet",
     },
   },
   update_cells: {
@@ -92,8 +92,8 @@ export const GOOGLE_SHEETS_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Updating cells",
-      done: "Update cells",
+      running: "Updating Google Sheets cells",
+      done: "Update Google Sheets cells",
     },
   },
   append_data: {
@@ -123,8 +123,8 @@ export const GOOGLE_SHEETS_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Appending data",
-      done: "Append data",
+      running: "Appending data to Google Sheets",
+      done: "Append data to Google Sheets",
     },
   },
   clear_range: {
@@ -139,8 +139,8 @@ export const GOOGLE_SHEETS_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Clearing range",
-      done: "Clear range",
+      running: "Clearing Google Sheets range",
+      done: "Clear Google Sheets range",
     },
   },
   create_spreadsheet: {
@@ -156,8 +156,8 @@ export const GOOGLE_SHEETS_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Creating spreadsheet",
-      done: "Create spreadsheet",
+      running: "Creating Google Sheets spreadsheet",
+      done: "Create Google Sheets spreadsheet",
     },
   },
   add_worksheet: {
@@ -177,8 +177,8 @@ export const GOOGLE_SHEETS_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Adding worksheet",
-      done: "Add worksheet",
+      running: "Adding Google Sheets worksheet",
+      done: "Add Google Sheets worksheet",
     },
   },
   delete_worksheet: {
@@ -189,8 +189,8 @@ export const GOOGLE_SHEETS_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Deleting worksheet",
-      done: "Delete worksheet",
+      running: "Deleting Google Sheets worksheet",
+      done: "Delete Google Sheets worksheet",
     },
   },
   format_cells: {
@@ -231,8 +231,8 @@ export const GOOGLE_SHEETS_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Formatting cells",
-      done: "Format cells",
+      running: "Formatting Google Sheets cells",
+      done: "Format Google Sheets cells",
     },
   },
   copy_sheet: {
@@ -255,8 +255,8 @@ export const GOOGLE_SHEETS_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Copying sheet",
-      done: "Copy sheet",
+      running: "Copying Google Sheets sheet",
+      done: "Copy Google Sheets sheet",
     },
   },
   rename_worksheet: {
@@ -268,8 +268,8 @@ export const GOOGLE_SHEETS_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Renaming worksheet",
-      done: "Rename worksheet",
+      running: "Renaming Google Sheets worksheet",
+      done: "Rename Google Sheets worksheet",
     },
   },
   move_worksheet: {
@@ -287,8 +287,8 @@ export const GOOGLE_SHEETS_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Moving worksheet",
-      done: "Move worksheet",
+      running: "Moving Google Sheets worksheet",
+      done: "Move Google Sheets worksheet",
     },
   },
 });

--- a/front/lib/api/actions/servers/http_client/metadata.ts
+++ b/front/lib/api/actions/servers/http_client/metadata.ts
@@ -49,6 +49,10 @@ export const HTTP_CLIENT_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     enableAlerting: true,
+    displayLabels: {
+      running: "Sending request",
+      done: "Send request",
+    },
   },
 });
 
@@ -116,6 +120,7 @@ export const HTTP_CLIENT_SERVER = {
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+    displayLabels: t.displayLabels,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(ALL_HTTP_CLIENT_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/http_client/metadata.ts
+++ b/front/lib/api/actions/servers/http_client/metadata.ts
@@ -50,8 +50,8 @@ export const HTTP_CLIENT_TOOLS_METADATA = createToolsRecord({
     stake: "low",
     enableAlerting: true,
     displayLabels: {
-      running: "Sending request",
-      done: "Send request",
+      running: "Sending HTTP request",
+      done: "Send HTTP request",
     },
   },
 });

--- a/front/lib/api/actions/servers/hubspot/metadata.ts
+++ b/front/lib/api/actions/servers/hubspot/metadata.ts
@@ -75,8 +75,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Getting object properties",
-      done: "Get object properties",
+      running: "Retrieving HubSpot object properties",
+      done: "Retrieve HubSpot object properties",
     },
   },
   get_object_by_email: {
@@ -87,8 +87,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Getting object by email",
-      done: "Get object by email",
+      running: "Retrieving HubSpot object by email",
+      done: "Retrieve HubSpot object by email",
     },
   },
   list_owners: {
@@ -99,8 +99,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     schema: {},
     stake: "never_ask",
     displayLabels: {
-      running: "Listing owners",
-      done: "List owners",
+      running: "Listing HubSpot owners",
+      done: "List HubSpot owners",
     },
   },
   search_owners: {
@@ -117,8 +117,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Searching owners",
-      done: "Search owners",
+      running: "Searching HubSpot owners",
+      done: "Search HubSpot owners",
     },
   },
   count_objects_by_properties: {
@@ -131,8 +131,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Counting objects by properties",
-      done: "Count objects by properties",
+      running: "Counting HubSpot objects by properties",
+      done: "Count HubSpot objects by properties",
     },
   },
   get_latest_objects: {
@@ -143,8 +143,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Getting latest objects",
-      done: "Get latest objects",
+      running: "Retrieving latest HubSpot objects",
+      done: "Retrieve latest HubSpot objects",
     },
   },
   get_contact: {
@@ -154,8 +154,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Getting contact",
-      done: "Get contact",
+      running: "Retrieving HubSpot contact",
+      done: "Retrieve HubSpot contact",
     },
   },
   get_company: {
@@ -172,8 +172,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Getting company",
-      done: "Get company",
+      running: "Retrieving HubSpot company",
+      done: "Retrieve HubSpot company",
     },
   },
   get_deal: {
@@ -190,8 +190,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Getting deal",
-      done: "Get deal",
+      running: "Retrieving HubSpot deal",
+      done: "Retrieve HubSpot deal",
     },
   },
   get_meeting: {
@@ -203,8 +203,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Getting meeting",
-      done: "Get meeting",
+      running: "Retrieving HubSpot meeting",
+      done: "Retrieve HubSpot meeting",
     },
   },
   get_file_public_url: {
@@ -214,8 +214,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Getting file public URL",
-      done: "Get file public URL",
+      running: "Retrieving HubSpot file public URL",
+      done: "Retrieve HubSpot file public URL",
     },
   },
   get_associated_meetings: {
@@ -229,8 +229,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Getting associated meetings",
-      done: "Get associated meetings",
+      running: "Retrieving HubSpot associated meetings",
+      done: "Retrieve HubSpot associated meetings",
     },
   },
   search_crm_objects: {
@@ -256,8 +256,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Searching CRM objects",
-      done: "Search CRM objects",
+      running: "Searching HubSpot CRM objects",
+      done: "Search HubSpot CRM objects",
     },
   },
   export_crm_objects_csv: {
@@ -279,8 +279,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Exporting CRM objects to CSV",
-      done: "Export CRM objects to CSV",
+      running: "Exporting HubSpot CRM objects to CSV",
+      done: "Export HubSpot CRM objects to CSV",
     },
   },
   get_hubspot_link: {
@@ -297,8 +297,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Getting HubSpot link",
-      done: "Get HubSpot link",
+      running: "Retrieving HubSpot UI link",
+      done: "Retrieve HubSpot UI link",
     },
   },
   get_hubspot_portal_id: {
@@ -307,8 +307,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     schema: {},
     stake: "never_ask",
     displayLabels: {
-      running: "Getting HubSpot portal ID",
-      done: "Get HubSpot portal ID",
+      running: "Retrieving HubSpot portal ID",
+      done: "Retrieve HubSpot portal ID",
     },
   },
   list_associations: {
@@ -326,8 +326,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Listing associations",
-      done: "List associations",
+      running: "Listing HubSpot associations",
+      done: "List HubSpot associations",
     },
   },
   get_current_user_id: {
@@ -338,8 +338,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     schema: {},
     stake: "never_ask",
     displayLabels: {
-      running: "Getting current user ID",
-      done: "Get current user ID",
+      running: "Retrieving HubSpot current user ID",
+      done: "Retrieve HubSpot current user ID",
     },
   },
   get_user_activity: {
@@ -376,8 +376,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Getting user activity",
-      done: "Get user activity",
+      running: "Retrieving HubSpot user activity",
+      done: "Retrieve HubSpot user activity",
     },
   },
 
@@ -396,8 +396,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     },
     stake: "high",
     displayLabels: {
-      running: "Creating contact",
-      done: "Create contact",
+      running: "Creating HubSpot contact",
+      done: "Create HubSpot contact",
     },
   },
   create_company: {
@@ -414,8 +414,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     },
     stake: "high",
     displayLabels: {
-      running: "Creating company",
-      done: "Create company",
+      running: "Creating HubSpot company",
+      done: "Create HubSpot company",
     },
   },
   create_deal: {
@@ -431,8 +431,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     },
     stake: "high",
     displayLabels: {
-      running: "Creating deal",
-      done: "Create deal",
+      running: "Creating HubSpot deal",
+      done: "Create HubSpot deal",
     },
   },
   create_lead: {
@@ -451,8 +451,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     },
     stake: "high",
     displayLabels: {
-      running: "Creating lead",
-      done: "Create lead",
+      running: "Creating HubSpot lead",
+      done: "Create HubSpot lead",
     },
   },
   create_task: {
@@ -470,8 +470,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     },
     stake: "high",
     displayLabels: {
-      running: "Creating task",
-      done: "Create task",
+      running: "Creating HubSpot task",
+      done: "Create HubSpot task",
     },
   },
   create_note: {
@@ -494,8 +494,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     },
     stake: "high",
     displayLabels: {
-      running: "Creating note",
-      done: "Create note",
+      running: "Creating HubSpot note",
+      done: "Create HubSpot note",
     },
   },
   create_communication: {
@@ -513,8 +513,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     },
     stake: "high",
     displayLabels: {
-      running: "Creating communication",
-      done: "Create communication",
+      running: "Creating HubSpot communication",
+      done: "Create HubSpot communication",
     },
   },
   create_meeting: {
@@ -532,8 +532,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     },
     stake: "high",
     displayLabels: {
-      running: "Creating meeting",
-      done: "Create meeting",
+      running: "Creating HubSpot meeting",
+      done: "Create HubSpot meeting",
     },
   },
   create_association: {
@@ -551,8 +551,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     },
     stake: "high",
     displayLabels: {
-      running: "Creating association",
-      done: "Create association",
+      running: "Creating HubSpot association",
+      done: "Create HubSpot association",
     },
   },
 
@@ -569,8 +569,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     },
     stake: "high",
     displayLabels: {
-      running: "Updating contact",
-      done: "Update contact",
+      running: "Updating HubSpot contact",
+      done: "Update HubSpot contact",
     },
   },
   update_company: {
@@ -585,8 +585,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     },
     stake: "high",
     displayLabels: {
-      running: "Updating company",
-      done: "Update company",
+      running: "Updating HubSpot company",
+      done: "Update HubSpot company",
     },
   },
   update_deal: {
@@ -601,8 +601,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     },
     stake: "high",
     displayLabels: {
-      running: "Updating deal",
-      done: "Update deal",
+      running: "Updating HubSpot deal",
+      done: "Update HubSpot deal",
     },
   },
   remove_association: {
@@ -619,8 +619,8 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
     },
     stake: "high",
     displayLabels: {
-      running: "Removing association",
-      done: "Remove association",
+      running: "Removing HubSpot association",
+      done: "Remove HubSpot association",
     },
   },
 });

--- a/front/lib/api/actions/servers/hubspot/metadata.ts
+++ b/front/lib/api/actions/servers/hubspot/metadata.ts
@@ -74,6 +74,10 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
       creatableOnly: z.boolean().optional(),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Getting object properties",
+      done: "Get object properties",
+    },
   },
   get_object_by_email: {
     description: `Retrieves a Hubspot object using an email address. Supports ${ALL_OBJECTS.join(", ")}.`,
@@ -82,6 +86,10 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
       email: z.string().describe("The email address of the object."),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Getting object by email",
+      done: "Get object by email",
+    },
   },
   list_owners: {
     description:
@@ -90,6 +98,10 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
       "For your own activity, use get_current_user_id instead.",
     schema: {},
     stake: "never_ask",
+    displayLabels: {
+      running: "Listing owners",
+      done: "List owners",
+    },
   },
   search_owners: {
     description:
@@ -104,6 +116,10 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Searching owners",
+      done: "Search owners",
+    },
   },
   count_objects_by_properties: {
     description: `Count objects in Hubspot with matching properties. Supports ${SIMPLE_OBJECTS.join(", ")}. Max limit is 10000 objects.`,
@@ -114,6 +130,10 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
         .describe("Array of property filters to apply."),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Counting objects by properties",
+      done: "Count objects by properties",
+    },
   },
   get_latest_objects: {
     description: `Get latest objects from Hubspot. Supports ${SIMPLE_OBJECTS.join(", ")}. Limit is 200.`,
@@ -122,6 +142,10 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
       limit: z.number().optional(),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Getting latest objects",
+      done: "Get latest objects",
+    },
   },
   get_contact: {
     description: "Retrieves a Hubspot contact by its ID.",
@@ -129,6 +153,10 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
       contactId: z.string().describe("The ID of the contact to retrieve."),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Getting contact",
+      done: "Get contact",
+    },
   },
   get_company: {
     description:
@@ -143,6 +171,10 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Getting company",
+      done: "Get company",
+    },
   },
   get_deal: {
     description:
@@ -157,6 +189,10 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Getting deal",
+      done: "Get deal",
+    },
   },
   get_meeting: {
     description: "Retrieves a Hubspot meeting (engagement) by its ID.",
@@ -166,6 +202,10 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
         .describe("The ID of the meeting (engagement) to retrieve."),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Getting meeting",
+      done: "Get meeting",
+    },
   },
   get_file_public_url: {
     description: "Retrieves a publicly available URL for a file in HubSpot.",
@@ -173,6 +213,10 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
       fileId: z.string().describe("The ID of the file."),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Getting file public URL",
+      done: "Get file public URL",
+    },
   },
   get_associated_meetings: {
     description:
@@ -184,6 +228,10 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
       fromObjectId: z.string().describe("The ID of the object."),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Getting associated meetings",
+      done: "Get associated meetings",
+    },
   },
   search_crm_objects: {
     description:
@@ -207,6 +255,10 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
       after: z.string().optional().describe("Pagination cursor."),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Searching CRM objects",
+      done: "Search CRM objects",
+    },
   },
   export_crm_objects_csv: {
     description:
@@ -226,6 +278,10 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
         .describe("Maximum number of rows to export (hard limit: 2000)."),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Exporting CRM objects to CSV",
+      done: "Export CRM objects to CSV",
+    },
   },
   get_hubspot_link: {
     description:
@@ -240,12 +296,20 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
       pageRequests: z.array(pageRequestSchema),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Getting HubSpot link",
+      done: "Get HubSpot link",
+    },
   },
   get_hubspot_portal_id: {
     description:
       "Gets the current user's portal ID. To use before calling get_hubspot_link",
     schema: {},
     stake: "never_ask",
+    displayLabels: {
+      running: "Getting HubSpot portal ID",
+      done: "Get HubSpot portal ID",
+    },
   },
   list_associations: {
     description:
@@ -261,6 +325,10 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
         .describe("Optional: specific object type to filter associations"),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Listing associations",
+      done: "List associations",
+    },
   },
   get_current_user_id: {
     description:
@@ -269,6 +337,10 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
       "user details, and hub_id. Use this before calling get_user_activity with your own data.",
     schema: {},
     stake: "never_ask",
+    displayLabels: {
+      running: "Getting current user ID",
+      done: "Get current user ID",
+    },
   },
   get_user_activity: {
     description:
@@ -303,6 +375,10 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Getting user activity",
+      done: "Get user activity",
+    },
   },
 
   // Create operations
@@ -319,6 +395,10 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
         .describe("Optional array of associations to create."),
     },
     stake: "high",
+    displayLabels: {
+      running: "Creating contact",
+      done: "Create contact",
+    },
   },
   create_company: {
     description:
@@ -333,6 +413,10 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
         .describe("Optional array of associations to create."),
     },
     stake: "high",
+    displayLabels: {
+      running: "Creating company",
+      done: "Create company",
+    },
   },
   create_deal: {
     description: "Creates a new deal in Hubspot, with optional associations.",
@@ -346,6 +430,10 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
         .describe("Optional array of associations to create."),
     },
     stake: "high",
+    displayLabels: {
+      running: "Creating deal",
+      done: "Create deal",
+    },
   },
   create_lead: {
     description:
@@ -362,6 +450,10 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
         .describe("Optional array of associations to create."),
     },
     stake: "high",
+    displayLabels: {
+      running: "Creating lead",
+      done: "Create lead",
+    },
   },
   create_task: {
     description: "Creates a new task in Hubspot, with optional associations.",
@@ -377,6 +469,10 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
         .describe("Optional array of associations to create."),
     },
     stake: "high",
+    displayLabels: {
+      running: "Creating task",
+      done: "Create task",
+    },
   },
   create_note: {
     description: "Creates a new note in Hubspot, with optional associations.",
@@ -397,6 +493,10 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
         .describe("Direct IDs of objects to associate the note with."),
     },
     stake: "high",
+    displayLabels: {
+      running: "Creating note",
+      done: "Create note",
+    },
   },
   create_communication: {
     description:
@@ -412,6 +512,10 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
         .describe("Direct IDs of objects to associate the communication with."),
     },
     stake: "high",
+    displayLabels: {
+      running: "Creating communication",
+      done: "Create communication",
+    },
   },
   create_meeting: {
     description:
@@ -427,6 +531,10 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
         .describe("Direct IDs of objects to associate the meeting with."),
     },
     stake: "high",
+    displayLabels: {
+      running: "Creating meeting",
+      done: "Create meeting",
+    },
   },
   create_association: {
     description:
@@ -442,6 +550,10 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
       toObjectId: z.string().describe("The ID of the target object"),
     },
     stake: "high",
+    displayLabels: {
+      running: "Creating association",
+      done: "Create association",
+    },
   },
 
   // Update operations
@@ -456,6 +568,10 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "high",
+    displayLabels: {
+      running: "Updating contact",
+      done: "Update contact",
+    },
   },
   update_company: {
     description: "Updates properties of a HubSpot company by ID.",
@@ -468,6 +584,10 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "high",
+    displayLabels: {
+      running: "Updating company",
+      done: "Update company",
+    },
   },
   update_deal: {
     description: "Updates properties of a HubSpot deal by ID.",
@@ -480,6 +600,10 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "high",
+    displayLabels: {
+      running: "Updating deal",
+      done: "Update deal",
+    },
   },
   remove_association: {
     description: "Removes an association between two HubSpot objects.",
@@ -494,6 +618,10 @@ export const HUBSPOT_TOOLS_METADATA = createToolsRecord({
       toObjectId: z.string().describe("The ID of the target object"),
     },
     stake: "high",
+    displayLabels: {
+      running: "Removing association",
+      done: "Remove association",
+    },
   },
 });
 
@@ -514,6 +642,7 @@ export const HUBSPOT_SERVER = {
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+    displayLabels: t.displayLabels,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(HUBSPOT_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/include_data/metadata.ts
+++ b/front/lib/api/actions/servers/include_data/metadata.ts
@@ -23,8 +23,8 @@ export const INCLUDE_DATA_BASE_TOOLS_METADATA = createToolsRecord({
     schema: IncludeInputSchema.shape,
     stake: "never_ask",
     displayLabels: {
-      running: "Including data",
-      done: "Include data",
+      running: "Retrieving recent documents",
+      done: "Retrieve recent documents",
     },
   },
 });
@@ -42,8 +42,8 @@ export const INCLUDE_DATA_WITH_TAGS_TOOLS_METADATA = createToolsRecord({
     schema: includeWithTagsSchema,
     stake: "never_ask",
     displayLabels: {
-      running: "Including data",
-      done: "Include data",
+      running: "Retrieving recent documents",
+      done: "Retrieve recent documents",
     },
   },
   find_tags: {

--- a/front/lib/api/actions/servers/interactive_content/metadata.ts
+++ b/front/lib/api/actions/servers/interactive_content/metadata.ts
@@ -76,8 +76,8 @@ export const INTERACTIVE_CONTENT_TOOLS_METADATA = createToolsRecord({
     enableAlerting: true,
     stake: "never_ask",
     displayLabels: {
-      running: "Creating interactive file",
-      done: "Create interactive file",
+      running: "Creating new Interactive Content file",
+      done: "Create new Interactive Content file",
     },
   },
   [EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME]: {
@@ -168,8 +168,8 @@ export const INTERACTIVE_CONTENT_TOOLS_METADATA = createToolsRecord({
     enableAlerting: true,
     stake: "never_ask",
     displayLabels: {
-      running: "Renaming interactive file",
-      done: "Rename interactive file",
+      running: "Renaming Interactive Content File",
+      done: "Rename Interactive Content file",
     },
   },
   [RETRIEVE_INTERACTIVE_CONTENT_FILE_TOOL_NAME]: {
@@ -188,8 +188,8 @@ export const INTERACTIVE_CONTENT_TOOLS_METADATA = createToolsRecord({
     enableAlerting: true,
     stake: "never_ask",
     displayLabels: {
-      running: "Retrieving Interactive Content file",
-      done: "Retrieve Interactive Content file",
+      running: "Reading Interactive Content file",
+      done: "Read Interactive Content file",
     },
   },
   [GET_INTERACTIVE_CONTENT_FILE_SHARE_URL_TOOL_NAME]: {

--- a/front/lib/api/actions/servers/interactive_content/metadata.ts
+++ b/front/lib/api/actions/servers/interactive_content/metadata.ts
@@ -168,7 +168,7 @@ export const INTERACTIVE_CONTENT_TOOLS_METADATA = createToolsRecord({
     enableAlerting: true,
     stake: "never_ask",
     displayLabels: {
-      running: "Renaming Interactive Content File",
+      running: "Renaming Interactive Content file",
       done: "Rename Interactive Content file",
     },
   },

--- a/front/lib/api/actions/servers/jira/metadata.ts
+++ b/front/lib/api/actions/servers/jira/metadata.ts
@@ -24,8 +24,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
     schema: {},
     stake: "never_ask",
     displayLabels: {
-      running: "Listing issue fields",
-      done: "List issue fields",
+      running: "Listing Jira issue fields",
+      done: "List Jira issue fields",
     },
   },
   get_issue: {
@@ -41,8 +41,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Retrieving issue",
-      done: "Retrieve issue",
+      running: "Retrieving Jira issue",
+      done: "Retrieve Jira issue",
     },
   },
   get_projects: {
@@ -50,8 +50,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
     schema: {},
     stake: "never_ask",
     displayLabels: {
-      running: "Listing projects",
-      done: "List projects",
+      running: "Listing Jira projects",
+      done: "List Jira projects",
     },
   },
   get_project: {
@@ -61,8 +61,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Retrieving project",
-      done: "Retrieve project",
+      running: "Retrieving Jira project",
+      done: "Retrieve Jira project",
     },
   },
   get_project_versions: {
@@ -73,8 +73,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Retrieving project versions",
-      done: "Retrieve project versions",
+      running: "Retrieving Jira project versions",
+      done: "Retrieve Jira project versions",
     },
   },
   get_transitions: {
@@ -85,8 +85,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Retrieving transitions",
-      done: "Retrieve transitions",
+      running: "Retrieving Jira transitions",
+      done: "Retrieve Jira transitions",
     },
   },
   get_issues: {
@@ -107,8 +107,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Searching issues",
-      done: "Search issues",
+      running: "Searching Jira issues",
+      done: "Search Jira issues",
     },
   },
   get_issues_using_jql: {
@@ -137,8 +137,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Searching issues with JQL",
-      done: "Search issues with JQL",
+      running: "Searching Jira issues with JQL",
+      done: "Search Jira issues with JQL",
     },
   },
   get_issue_types: {
@@ -148,8 +148,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Retrieving issue types",
-      done: "Retrieve issue types",
+      running: "Retrieving Jira issue types",
+      done: "Retrieve Jira issue types",
     },
   },
   get_issue_create_fields: {
@@ -163,8 +163,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Retrieving create fields",
-      done: "Retrieve create fields",
+      running: "Retrieving Jira create fields",
+      done: "Retrieve Jira create fields",
     },
   },
   get_connection_info: {
@@ -173,8 +173,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
     schema: {},
     stake: "never_ask",
     displayLabels: {
-      running: "Retrieving connection info",
-      done: "Retrieve connection info",
+      running: "Retrieving Jira connection info",
+      done: "Retrieve Jira connection info",
     },
   },
   get_issue_link_types: {
@@ -183,8 +183,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
     schema: {},
     stake: "never_ask",
     displayLabels: {
-      running: "Retrieving link types",
-      done: "Retrieve link types",
+      running: "Retrieving Jira link types",
+      done: "Retrieve Jira link types",
     },
   },
   get_users: {
@@ -223,8 +223,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Searching users",
-      done: "Search users",
+      running: "Searching Jira users",
+      done: "Search Jira users",
     },
   },
   get_attachments: {
@@ -235,8 +235,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Retrieving attachments",
-      done: "Retrieve attachments",
+      running: "Retrieving Jira attachments",
+      done: "Retrieve Jira attachments",
     },
   },
   read_attachment: {
@@ -248,8 +248,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Reading attachment",
-      done: "Read attachment",
+      running: "Reading attachment from Jira",
+      done: "Read attachment from Jira",
     },
   },
 
@@ -275,8 +275,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Creating comment",
-      done: "Create comment",
+      running: "Adding comment on Jira",
+      done: "Add comment on Jira",
     },
   },
   transition_issue: {
@@ -288,8 +288,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Transitioning issue",
-      done: "Transition issue",
+      running: "Transitioning Jira issue",
+      done: "Transition Jira issue",
     },
   },
   create_issue: {
@@ -302,8 +302,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Creating issue",
-      done: "Create issue",
+      running: "Creating Jira issue",
+      done: "Create Jira issue",
     },
   },
   update_issue: {
@@ -317,8 +317,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Updating issue",
-      done: "Update issue",
+      running: "Updating Jira issue",
+      done: "Update Jira issue",
     },
   },
   create_issue_link: {
@@ -331,8 +331,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Creating issue link",
-      done: "Create issue link",
+      running: "Creating Jira issue link",
+      done: "Create Jira issue link",
     },
   },
   delete_issue_link: {
@@ -342,8 +342,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Deleting issue link",
-      done: "Delete issue link",
+      running: "Deleting Jira issue link",
+      done: "Delete Jira issue link",
     },
   },
   upload_attachment: {
@@ -382,8 +382,8 @@ export const JIRA_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Uploading attachment",
-      done: "Upload attachment",
+      running: "Uploading attachment to Jira",
+      done: "Upload attachment to Jira",
     },
   },
 });

--- a/front/lib/api/actions/servers/jit_testing/metadata.ts
+++ b/front/lib/api/actions/servers/jit_testing/metadata.ts
@@ -67,6 +67,10 @@ export const JIT_TESTING_TOOLS_METADATA = createToolsRecord({
       note: z.string().describe("Optional note for debugging").optional(),
     },
     stake: "high",
+    displayLabels: {
+      running: "Testing JIT",
+      done: "Test JIT",
+    },
   },
 });
 
@@ -84,6 +88,7 @@ export const JIT_TESTING_SERVER = {
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+    displayLabels: t.displayLabels,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(JIT_TESTING_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/microsoft_drive/metadata.ts
+++ b/front/lib/api/actions/servers/microsoft_drive/metadata.ts
@@ -30,8 +30,8 @@ export const MICROSOFT_DRIVE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Searching in files",
-      done: "Search in files",
+      running: "Searching in OneDrive/SharePoint files",
+      done: "Search in OneDrive/SharePoint files",
     },
   },
   search_drive_items: {
@@ -46,8 +46,8 @@ export const MICROSOFT_DRIVE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Searching drive items",
-      done: "Search drive items",
+      running: "Searching OneDrive/SharePoint items",
+      done: "Search OneDrive/SharePoint items",
     },
   },
   update_word_document: {
@@ -75,8 +75,8 @@ export const MICROSOFT_DRIVE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "high",
     displayLabels: {
-      running: "Updating Word document",
-      done: "Update Word document",
+      running: "Updating Microsoft Word document",
+      done: "Update Microsoft Word document",
     },
   },
   get_file_content: {
@@ -119,8 +119,8 @@ export const MICROSOFT_DRIVE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Getting file content",
-      done: "Get file content",
+      running: "Getting OneDrive/SharePoint file content",
+      done: "Get OneDrive/SharePoint file content",
     },
   },
   upload_file: {
@@ -159,8 +159,8 @@ export const MICROSOFT_DRIVE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "high",
     displayLabels: {
-      running: "Uploading file",
-      done: "Upload file",
+      running: "Uploading file to OneDrive/SharePoint",
+      done: "Upload file to OneDrive/SharePoint",
     },
   },
 });

--- a/front/lib/api/actions/servers/microsoft_drive/metadata.ts
+++ b/front/lib/api/actions/servers/microsoft_drive/metadata.ts
@@ -29,6 +29,10 @@ export const MICROSOFT_DRIVE_TOOLS_METADATA = createToolsRecord({
         .describe("Maximum number of results to return (max 25)."),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Searching in files",
+      done: "Search in files",
+    },
   },
   search_drive_items: {
     description:
@@ -41,6 +45,10 @@ export const MICROSOFT_DRIVE_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Searching drive items",
+      done: "Search drive items",
+    },
   },
   update_word_document: {
     description:
@@ -66,6 +74,10 @@ export const MICROSOFT_DRIVE_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "high",
+    displayLabels: {
+      running: "Updating Word document",
+      done: "Update Word document",
+    },
   },
   get_file_content: {
     description:
@@ -106,6 +118,10 @@ export const MICROSOFT_DRIVE_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Getting file content",
+      done: "Get file content",
+    },
   },
   upload_file: {
     description:
@@ -142,6 +158,10 @@ export const MICROSOFT_DRIVE_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "high",
+    displayLabels: {
+      running: "Uploading file",
+      done: "Upload file",
+    },
   },
 });
 
@@ -163,6 +183,7 @@ export const MICROSOFT_DRIVE_SERVER = {
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+    displayLabels: t.displayLabels,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(MICROSOFT_DRIVE_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/microsoft_excel/metadata.ts
+++ b/front/lib/api/actions/servers/microsoft_excel/metadata.ts
@@ -19,8 +19,8 @@ export const MICROSOFT_EXCEL_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Listing Excel files",
-      done: "List Excel files",
+      running: "Listing Microsoft Excel files",
+      done: "List Microsoft Excel files",
     },
   },
   get_worksheets: {
@@ -45,8 +45,8 @@ export const MICROSOFT_EXCEL_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Getting worksheets",
-      done: "Get worksheets",
+      running: "Getting Excel worksheets",
+      done: "Get Excel worksheets",
     },
   },
   read_worksheet: {
@@ -78,8 +78,8 @@ export const MICROSOFT_EXCEL_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Reading worksheet",
-      done: "Read worksheet",
+      running: "Reading Excel worksheet",
+      done: "Read Excel worksheet",
     },
   },
   write_worksheet: {
@@ -117,8 +117,8 @@ export const MICROSOFT_EXCEL_TOOLS_METADATA = createToolsRecord({
     },
     stake: "high",
     displayLabels: {
-      running: "Writing to worksheet",
-      done: "Write to worksheet",
+      running: "Writing to Excel worksheet",
+      done: "Write to Excel worksheet",
     },
   },
   create_worksheet: {
@@ -146,8 +146,8 @@ export const MICROSOFT_EXCEL_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Creating worksheet",
-      done: "Create worksheet",
+      running: "Creating Excel worksheet",
+      done: "Create Excel worksheet",
     },
   },
   clear_range: {
@@ -184,8 +184,8 @@ export const MICROSOFT_EXCEL_TOOLS_METADATA = createToolsRecord({
     },
     stake: "high",
     displayLabels: {
-      running: "Clearing range",
-      done: "Clear range",
+      running: "Clearing Excel range",
+      done: "Clear Excel range",
     },
   },
 });

--- a/front/lib/api/actions/servers/microsoft_excel/metadata.ts
+++ b/front/lib/api/actions/servers/microsoft_excel/metadata.ts
@@ -18,6 +18,10 @@ export const MICROSOFT_EXCEL_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Listing Excel files",
+      done: "List Excel files",
+    },
   },
   get_worksheets: {
     description:
@@ -40,6 +44,10 @@ export const MICROSOFT_EXCEL_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Getting worksheets",
+      done: "Get worksheets",
+    },
   },
   read_worksheet: {
     description:
@@ -69,6 +77,10 @@ export const MICROSOFT_EXCEL_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Reading worksheet",
+      done: "Read worksheet",
+    },
   },
   write_worksheet: {
     description:
@@ -104,6 +116,10 @@ export const MICROSOFT_EXCEL_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "high",
+    displayLabels: {
+      running: "Writing to worksheet",
+      done: "Write to worksheet",
+    },
   },
   create_worksheet: {
     description:
@@ -129,6 +145,10 @@ export const MICROSOFT_EXCEL_TOOLS_METADATA = createToolsRecord({
         .describe("Name for the new worksheet (e.g., 'Q4 Results')"),
     },
     stake: "low",
+    displayLabels: {
+      running: "Creating worksheet",
+      done: "Create worksheet",
+    },
   },
   clear_range: {
     description:
@@ -163,6 +183,10 @@ export const MICROSOFT_EXCEL_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "high",
+    displayLabels: {
+      running: "Clearing range",
+      done: "Clear range",
+    },
   },
 });
 
@@ -184,6 +208,7 @@ export const MICROSOFT_EXCEL_SERVER = {
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+    displayLabels: t.displayLabels,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(MICROSOFT_EXCEL_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/microsoft_teams/metadata.ts
+++ b/front/lib/api/actions/servers/microsoft_teams/metadata.ts
@@ -18,8 +18,8 @@ export const MICROSOFT_TEAMS_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Searching messages",
-      done: "Search messages",
+      running: "Searching Teams messages",
+      done: "Search Teams messages",
     },
   },
   list_teams: {
@@ -28,8 +28,8 @@ export const MICROSOFT_TEAMS_TOOLS_METADATA = createToolsRecord({
     schema: {},
     stake: "never_ask",
     displayLabels: {
-      running: "Listing teams",
-      done: "List teams",
+      running: "Listing Teams teams",
+      done: "List Teams teams",
     },
   },
   list_users: {
@@ -48,8 +48,8 @@ export const MICROSOFT_TEAMS_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Listing users",
-      done: "List users",
+      running: "Listing Teams users",
+      done: "List Teams users",
     },
   },
   list_channels: {
@@ -68,8 +68,8 @@ export const MICROSOFT_TEAMS_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Listing channels",
-      done: "List channels",
+      running: "Listing Teams channels",
+      done: "List Teams channels",
     },
   },
   list_chats: {
@@ -96,8 +96,8 @@ export const MICROSOFT_TEAMS_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Listing chats",
-      done: "List chats",
+      running: "Listing Teams chats",
+      done: "List Teams chats",
     },
   },
   list_messages: {

--- a/front/lib/api/actions/servers/microsoft_teams/metadata.ts
+++ b/front/lib/api/actions/servers/microsoft_teams/metadata.ts
@@ -17,12 +17,20 @@ export const MICROSOFT_TEAMS_TOOLS_METADATA = createToolsRecord({
         .describe("Search query to find relevant messages in Teams."),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Searching messages",
+      done: "Search messages",
+    },
   },
   list_teams: {
     description:
       "List all Teams that the authenticated user has joined. Returns team details including name, description, and team ID.",
     schema: {},
     stake: "never_ask",
+    displayLabels: {
+      running: "Listing teams",
+      done: "List teams",
+    },
   },
   list_users: {
     description:
@@ -39,6 +47,10 @@ export const MICROSOFT_TEAMS_TOOLS_METADATA = createToolsRecord({
         .describe("Maximum number of users to return (default: 25, max: 25)."),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Listing users",
+      done: "List users",
+    },
   },
   list_channels: {
     description:
@@ -55,6 +67,10 @@ export const MICROSOFT_TEAMS_TOOLS_METADATA = createToolsRecord({
         .describe("Filter channels by name (optional, searches display name)."),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Listing channels",
+      done: "List channels",
+    },
   },
   list_chats: {
     description:
@@ -79,6 +95,10 @@ export const MICROSOFT_TEAMS_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Listing chats",
+      done: "List chats",
+    },
   },
   list_messages: {
     description:
@@ -102,6 +122,10 @@ export const MICROSOFT_TEAMS_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Listing messages",
+      done: "List messages",
+    },
   },
   post_message: {
     description:
@@ -149,6 +173,10 @@ export const MICROSOFT_TEAMS_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "medium",
+    displayLabels: {
+      running: "Posting message",
+      done: "Post message",
+    },
   },
 });
 
@@ -169,6 +197,7 @@ export const MICROSOFT_TEAMS_SERVER = {
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+    displayLabels: t.displayLabels,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(MICROSOFT_TEAMS_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/microsoft_teams/metadata.ts
+++ b/front/lib/api/actions/servers/microsoft_teams/metadata.ts
@@ -123,8 +123,8 @@ export const MICROSOFT_TEAMS_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Listing messages",
-      done: "List messages",
+      running: "Listing Teams messages",
+      done: "List Teams messages",
     },
   },
   post_message: {
@@ -174,8 +174,8 @@ export const MICROSOFT_TEAMS_TOOLS_METADATA = createToolsRecord({
     },
     stake: "medium",
     displayLabels: {
-      running: "Posting message",
-      done: "Post message",
+      running: "Posting Teams message",
+      done: "Post Teams message",
     },
   },
 });

--- a/front/lib/api/actions/servers/missing_action_catcher/tools/index.ts
+++ b/front/lib/api/actions/servers/missing_action_catcher/tools/index.ts
@@ -23,6 +23,10 @@ export function createMissingActionCatcherTools(
         description: "",
         schema: {},
         stake: "never_ask",
+        displayLabels: {
+          running: "Processing action",
+          done: "Process action",
+        },
         handler: async () => {
           return new Err(
             new MCPError(
@@ -47,6 +51,10 @@ export function createMissingActionCatcherTools(
       description: "This tool is a placeholder to catch missing actions.",
       schema: {},
       stake: "never_ask",
+      displayLabels: {
+        running: "Processing action",
+        done: "Process action",
+      },
       handler: async () => {
         return new Ok([{ type: "text", text: "No action name found" }]);
       },

--- a/front/lib/api/actions/servers/monday/metadata.ts
+++ b/front/lib/api/actions/servers/monday/metadata.ts
@@ -14,8 +14,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     schema: {},
     stake: "never_ask",
     displayLabels: {
-      running: "Listing boards",
-      done: "List boards",
+      running: "Listing Monday boards",
+      done: "List Monday boards",
     },
   },
   get_board_items: {
@@ -26,8 +26,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Retrieving board items",
-      done: "Retrieve board items",
+      running: "Retrieving Monday board items",
+      done: "Retrieve Monday board items",
     },
   },
   get_item_details: {
@@ -38,8 +38,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Retrieving item details",
-      done: "Retrieve item details",
+      running: "Retrieving Monday item details",
+      done: "Retrieve Monday item details",
     },
   },
   search_items: {
@@ -76,8 +76,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Searching items",
-      done: "Search items",
+      running: "Searching Monday items",
+      done: "Search Monday items",
     },
   },
   get_items_by_column_value: {
@@ -89,8 +89,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Retrieving items by column value",
-      done: "Retrieve items by column value",
+      running: "Retrieving Monday items by column value",
+      done: "Retrieve Monday items by column value",
     },
   },
   find_user_by_name: {
@@ -100,8 +100,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Finding user",
-      done: "Find user",
+      running: "Finding Monday user",
+      done: "Find Monday user",
     },
   },
   get_board_values: {
@@ -112,8 +112,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Retrieving board details",
-      done: "Retrieve board details",
+      running: "Retrieving Monday board details",
+      done: "Retrieve Monday board details",
     },
   },
   get_column_values: {
@@ -125,8 +125,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Retrieving column values",
-      done: "Retrieve column values",
+      running: "Retrieving Monday column values",
+      done: "Retrieve Monday column values",
     },
   },
   get_file_column_values: {
@@ -139,8 +139,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Retrieving file column values",
-      done: "Retrieve file column values",
+      running: "Retrieving Monday file column values",
+      done: "Retrieve Monday file column values",
     },
   },
   get_group_details: {
@@ -152,8 +152,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Retrieving group details",
-      done: "Retrieve group details",
+      running: "Retrieving Monday group details",
+      done: "Retrieve Monday group details",
     },
   },
   get_subitem_values: {
@@ -163,8 +163,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Retrieving subitems",
-      done: "Retrieve subitems",
+      running: "Retrieving Monday subitems",
+      done: "Retrieve Monday subitems",
     },
   },
   get_user_details: {
@@ -174,8 +174,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Retrieving user details",
-      done: "Retrieve user details",
+      running: "Retrieving Monday user details",
+      done: "Retrieve Monday user details",
     },
   },
   get_activity_logs: {
@@ -200,8 +200,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Retrieving activity logs",
-      done: "Retrieve activity logs",
+      running: "Retrieving Monday activity logs",
+      done: "Retrieve Monday activity logs",
     },
   },
   get_board_analytics: {
@@ -212,8 +212,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Retrieving board analytics",
-      done: "Retrieve board analytics",
+      running: "Retrieving Monday board analytics",
+      done: "Retrieve Monday board analytics",
     },
   },
   create_item: {
@@ -234,8 +234,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     },
     stake: "high",
     displayLabels: {
-      running: "Creating item",
-      done: "Create item",
+      running: "Creating Monday item",
+      done: "Create Monday item",
     },
   },
   update_item: {
@@ -250,8 +250,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     },
     stake: "high",
     displayLabels: {
-      running: "Updating item",
-      done: "Update item",
+      running: "Updating Monday item",
+      done: "Update Monday item",
     },
   },
   update_item_name: {
@@ -262,8 +262,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     },
     stake: "high",
     displayLabels: {
-      running: "Updating item name",
-      done: "Update item name",
+      running: "Updating Monday item name",
+      done: "Update Monday item name",
     },
   },
   create_update: {
@@ -274,8 +274,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     },
     stake: "high",
     displayLabels: {
-      running: "Adding update",
-      done: "Add update",
+      running: "Adding Monday update",
+      done: "Add Monday update",
     },
   },
   create_board: {
@@ -297,8 +297,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     },
     stake: "high",
     displayLabels: {
-      running: "Creating board",
-      done: "Create board",
+      running: "Creating Monday board",
+      done: "Create Monday board",
     },
   },
   create_column: {
@@ -316,8 +316,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     },
     stake: "high",
     displayLabels: {
-      running: "Creating column",
-      done: "Create column",
+      running: "Creating Monday column",
+      done: "Create Monday column",
     },
   },
   create_group: {
@@ -332,8 +332,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     },
     stake: "high",
     displayLabels: {
-      running: "Creating group",
-      done: "Create group",
+      running: "Creating Monday group",
+      done: "Create Monday group",
     },
   },
   create_subitem: {
@@ -348,8 +348,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     },
     stake: "high",
     displayLabels: {
-      running: "Creating subitem",
-      done: "Create subitem",
+      running: "Creating Monday subitem",
+      done: "Create Monday subitem",
     },
   },
   update_subitem: {
@@ -362,8 +362,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     },
     stake: "high",
     displayLabels: {
-      running: "Updating subitem",
-      done: "Update subitem",
+      running: "Updating Monday subitem",
+      done: "Update Monday subitem",
     },
   },
   duplicate_group: {
@@ -382,8 +382,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     },
     stake: "high",
     displayLabels: {
-      running: "Duplicating group",
-      done: "Duplicate group",
+      running: "Duplicating Monday group",
+      done: "Duplicate Monday group",
     },
   },
   upload_file_to_column: {
@@ -395,8 +395,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     },
     stake: "high",
     displayLabels: {
-      running: "Uploading file",
-      done: "Upload file",
+      running: "Uploading file to Monday",
+      done: "Upload file to Monday",
     },
   },
   delete_item: {
@@ -406,8 +406,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     },
     stake: "high",
     displayLabels: {
-      running: "Deleting item",
-      done: "Delete item",
+      running: "Deleting Monday item",
+      done: "Delete Monday item",
     },
   },
   delete_group: {
@@ -418,8 +418,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     },
     stake: "high",
     displayLabels: {
-      running: "Deleting group",
-      done: "Delete group",
+      running: "Deleting Monday group",
+      done: "Delete Monday group",
     },
   },
   move_item_to_board: {
@@ -447,8 +447,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     },
     stake: "high",
     displayLabels: {
-      running: "Moving item to board",
-      done: "Move item to board",
+      running: "Moving Monday item to board",
+      done: "Move Monday item to board",
     },
   },
   create_multiple_items: {
@@ -474,8 +474,8 @@ export const MONDAY_TOOLS_METADATA = createToolsRecord({
     },
     stake: "high",
     displayLabels: {
-      running: "Creating multiple items",
-      done: "Create multiple items",
+      running: "Creating multiple Monday items",
+      done: "Create multiple Monday items",
     },
   },
 });

--- a/front/lib/api/actions/servers/notion/metadata.ts
+++ b/front/lib/api/actions/servers/notion/metadata.ts
@@ -250,8 +250,8 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Retrieving page",
-      done: "Retrieve page",
+      running: "Retrieving Notion page",
+      done: "Retrieve Notion page",
     },
   },
   retrieve_database_schema: {
@@ -261,8 +261,8 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Retrieving database schema",
-      done: "Retrieve database schema",
+      running: "Retrieving Notion database schema",
+      done: "Retrieve Notion database schema",
     },
   },
   retrieve_database_content: {
@@ -279,8 +279,8 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Retrieving database content",
-      done: "Retrieve database content",
+      running: "Retrieving Notion database content",
+      done: "Retrieve Notion database content",
     },
   },
   query_database: {
@@ -297,8 +297,8 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Querying database",
-      done: "Query database",
+      running: "Querying Notion database",
+      done: "Query Notion database",
     },
   },
   create_page: {
@@ -313,8 +313,8 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Creating page",
-      done: "Create page",
+      running: "Creating Notion page",
+      done: "Create Notion page",
     },
   },
   insert_row_into_database: {
@@ -327,8 +327,8 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Inserting row",
-      done: "Insert row",
+      running: "Inserting Notion row",
+      done: "Insert Notion row",
     },
   },
   create_database: {
@@ -348,8 +348,8 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Creating database",
-      done: "Create database",
+      running: "Creating Notion database",
+      done: "Create Notion database",
     },
   },
   update_page: {
@@ -360,8 +360,8 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Updating page",
-      done: "Update page",
+      running: "Updating Notion page",
+      done: "Update Notion page",
     },
   },
   retrieve_block: {
@@ -371,8 +371,8 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Retrieving block",
-      done: "Retrieve block",
+      running: "Retrieving Notion block",
+      done: "Retrieve Notion block",
     },
   },
   retrieve_block_children: {
@@ -387,8 +387,8 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Retrieving block children",
-      done: "Retrieve block children",
+      running: "Retrieving Notion block children",
+      done: "Retrieve Notion block children",
     },
   },
   add_page_content: {
@@ -404,8 +404,8 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Adding page content",
-      done: "Add page content",
+      running: "Adding Notion page content",
+      done: "Add Notion page content",
     },
   },
   create_comment: {
@@ -429,8 +429,8 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Creating comment",
-      done: "Create comment",
+      running: "Adding comment on Notion",
+      done: "Add comment on Notion",
     },
   },
   delete_block: {
@@ -441,8 +441,8 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Deleting block",
-      done: "Delete block",
+      running: "Deleting Notion block",
+      done: "Delete Notion block",
     },
   },
   delete_page: {
@@ -453,8 +453,8 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Deleting page",
-      done: "Delete page",
+      running: "Deleting Notion page",
+      done: "Delete Notion page",
     },
   },
   fetch_comments: {
@@ -467,8 +467,8 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Fetching comments",
-      done: "Fetch comments",
+      running: "Fetching comments from Notion",
+      done: "Fetch comments from Notion",
     },
   },
   update_row_database: {
@@ -480,8 +480,8 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Updating row",
-      done: "Update row",
+      running: "Updating Notion row",
+      done: "Update Notion row",
     },
   },
   update_schema_database: {
@@ -493,8 +493,8 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Updating database schema",
-      done: "Update database schema",
+      running: "Updating Notion database schema",
+      done: "Update Notion database schema",
     },
   },
   list_users: {
@@ -502,8 +502,8 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
     schema: {},
     stake: "never_ask",
     displayLabels: {
-      running: "Listing users",
-      done: "List users",
+      running: "Listing Notion users",
+      done: "List Notion users",
     },
   },
   get_about_user: {
@@ -513,8 +513,8 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Retrieving user info",
-      done: "Retrieve user info",
+      running: "Retrieving Notion user info",
+      done: "Retrieve Notion user info",
     },
   },
 });

--- a/front/lib/api/actions/servers/openai_usage/metadata.ts
+++ b/front/lib/api/actions/servers/openai_usage/metadata.ts
@@ -73,6 +73,10 @@ export const OPENAI_USAGE_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "low",
+    displayLabels: {
+      running: "Getting completions usage",
+      done: "Get completions usage",
+    },
   },
   get_organization_costs: {
     description:
@@ -115,6 +119,10 @@ export const OPENAI_USAGE_TOOLS_METADATA = createToolsRecord({
         .describe("Return only costs for these projects. Optional."),
     },
     stake: "low",
+    displayLabels: {
+      running: "Getting organization costs",
+      done: "Get organization costs",
+    },
   },
 });
 
@@ -133,6 +141,7 @@ export const OPENAI_USAGE_SERVER = {
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+    displayLabels: t.displayLabels,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(OPENAI_USAGE_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/outlook/calendar_metadata.ts
+++ b/front/lib/api/actions/servers/outlook/calendar_metadata.ts
@@ -14,8 +14,8 @@ export const OUTLOOK_CALENDAR_TOOLS_METADATA = createToolsRecord({
     schema: {},
     stake: "never_ask",
     displayLabels: {
-      running: "Getting user timezone",
-      done: "Get user timezone",
+      running: "Getting user timezone from Outlook",
+      done: "Get user timezone from Outlook",
     },
   },
   list_calendars: {

--- a/front/lib/api/actions/servers/query_tables_v2/metadata.ts
+++ b/front/lib/api/actions/servers/query_tables_v2/metadata.ts
@@ -22,6 +22,10 @@ export const QUERY_TABLES_V2_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     enableAlerting: true,
+    displayLabels: {
+      running: "Getting database schema",
+      done: "Get database schema",
+    },
   },
   [EXECUTE_DATABASE_QUERY_TOOL_NAME]: {
     description:
@@ -40,6 +44,10 @@ export const QUERY_TABLES_V2_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     enableAlerting: true,
+    displayLabels: {
+      running: "Executing query",
+      done: "Execute query",
+    },
   },
 });
 
@@ -58,6 +66,7 @@ export const QUERY_TABLES_V2_SERVER = {
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+    displayLabels: t.displayLabels,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(QUERY_TABLES_V2_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/query_tables_v2/metadata.ts
+++ b/front/lib/api/actions/servers/query_tables_v2/metadata.ts
@@ -45,8 +45,8 @@ export const QUERY_TABLES_V2_TOOLS_METADATA = createToolsRecord({
     stake: "never_ask",
     enableAlerting: true,
     displayLabels: {
-      running: "Executing query",
-      done: "Execute query",
+      running: "Executing database query",
+      done: "Execute database query",
     },
   },
 });

--- a/front/lib/api/actions/servers/run_agent/metadata.ts
+++ b/front/lib/api/actions/servers/run_agent/metadata.ts
@@ -101,6 +101,10 @@ export const RUN_AGENT_SERVER = {
           ...RUN_AGENT_CONFIGURABLE_PROPERTIES,
         })
       ) as JSONSchema,
+      displayLabels: {
+        running: "Running agent",
+        done: "Run agent",
+      },
     },
   ],
   // Default stake for dynamically created run_agent tools.

--- a/front/lib/api/actions/servers/salesforce/metadata.ts
+++ b/front/lib/api/actions/servers/salesforce/metadata.ts
@@ -15,6 +15,10 @@ export const SALESFORCE_TOOLS_METADATA = createToolsRecord({
       query: z.string().describe("The SOQL read query to execute"),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Executing query",
+      done: "Execute query",
+    },
   },
   list_objects: {
     description: "List the objects in Salesforce: standard and custom objects",
@@ -26,6 +30,10 @@ export const SALESFORCE_TOOLS_METADATA = createToolsRecord({
         .describe("Filter objects by type: all, standard, or custom"),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Listing objects",
+      done: "List objects",
+    },
   },
   describe_object: {
     description: "Describe an object in Salesforce",
@@ -33,6 +41,10 @@ export const SALESFORCE_TOOLS_METADATA = createToolsRecord({
       objectName: z.string().describe("The name of the object to describe"),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Describing object",
+      done: "Describe object",
+    },
   },
   update_object: {
     description: "Update one or more records in Salesforce",
@@ -59,6 +71,10 @@ export const SALESFORCE_TOOLS_METADATA = createToolsRecord({
         .describe("If true, all updates must succeed or all fail"),
     },
     stake: "high",
+    displayLabels: {
+      running: "Updating records",
+      done: "Update records",
+    },
   },
   list_attachments: {
     description: "List all attachments and files for a Salesforce record.",
@@ -66,6 +82,10 @@ export const SALESFORCE_TOOLS_METADATA = createToolsRecord({
       recordId: z.string().describe("The Salesforce record ID"),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Listing attachments",
+      done: "List attachments",
+    },
   },
   read_attachment: {
     description:
@@ -77,6 +97,10 @@ export const SALESFORCE_TOOLS_METADATA = createToolsRecord({
         .describe("The ID of the attachment or file to read"),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Reading attachment",
+      done: "Read attachment",
+    },
   },
 });
 
@@ -97,6 +121,7 @@ export const SALESFORCE_SERVER = {
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+    displayLabels: t.displayLabels,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(SALESFORCE_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/salesforce/metadata.ts
+++ b/front/lib/api/actions/servers/salesforce/metadata.ts
@@ -16,8 +16,8 @@ export const SALESFORCE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Executing query",
-      done: "Execute query",
+      running: "Executing Salesforce query",
+      done: "Execute Salesforce query",
     },
   },
   list_objects: {
@@ -31,8 +31,8 @@ export const SALESFORCE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Listing objects",
-      done: "List objects",
+      running: "Listing Salesforce objects",
+      done: "List Salesforce objects",
     },
   },
   describe_object: {
@@ -42,8 +42,8 @@ export const SALESFORCE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Describing object",
-      done: "Describe object",
+      running: "Describing Salesforce object",
+      done: "Describe Salesforce object",
     },
   },
   update_object: {
@@ -72,8 +72,8 @@ export const SALESFORCE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "high",
     displayLabels: {
-      running: "Updating records",
-      done: "Update records",
+      running: "Updating Salesforce records",
+      done: "Update Salesforce records",
     },
   },
   list_attachments: {
@@ -83,8 +83,8 @@ export const SALESFORCE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Listing attachments",
-      done: "List attachments",
+      running: "Listing Salesforce attachments",
+      done: "List Salesforce attachments",
     },
   },
   read_attachment: {
@@ -98,8 +98,8 @@ export const SALESFORCE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Reading attachment",
-      done: "Read attachment",
+      running: "Reading Salesforce attachment",
+      done: "Read Salesforce attachment",
     },
   },
 });

--- a/front/lib/api/actions/servers/salesforce/metadata.ts
+++ b/front/lib/api/actions/servers/salesforce/metadata.ts
@@ -83,8 +83,8 @@ export const SALESFORCE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Listing Salesforce attachments",
-      done: "List Salesforce attachments",
+      running: "Listing attachments on Salesforce",
+      done: "List attachments on Salesforce",
     },
   },
   read_attachment: {
@@ -98,8 +98,8 @@ export const SALESFORCE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Reading Salesforce attachment",
-      done: "Read Salesforce attachment",
+      running: "Reading attachment from Salesforce",
+      done: "Read attachment from Salesforce",
     },
   },
 });

--- a/front/lib/api/actions/servers/salesloft/metadata.ts
+++ b/front/lib/api/actions/servers/salesloft/metadata.ts
@@ -27,6 +27,10 @@ export const SALESLOFT_TOOLS_METADATA = createToolsRecord({
         .default(true),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Getting actions",
+      done: "Get actions",
+    },
   },
 });
 
@@ -45,6 +49,7 @@ export const SALESLOFT_SERVER = {
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+    displayLabels: t.displayLabels,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(SALESLOFT_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/salesloft/metadata.ts
+++ b/front/lib/api/actions/servers/salesloft/metadata.ts
@@ -28,8 +28,8 @@ export const SALESLOFT_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Getting actions",
-      done: "Get actions",
+      running: "Getting Salesloft actions",
+      done: "Get Salesloft actions",
     },
   },
 });

--- a/front/lib/api/actions/servers/sandbox/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox/metadata.ts
@@ -33,6 +33,10 @@ export const SANDBOX_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "low",
+    displayLabels: {
+      running: "Executing command",
+      done: "Execute command",
+    },
   },
   write_file: {
     description:
@@ -48,6 +52,10 @@ export const SANDBOX_TOOLS_METADATA = createToolsRecord({
       content: z.string().describe("The content to write to the file."),
     },
     stake: "low",
+    displayLabels: {
+      running: "Writing file",
+      done: "Write file",
+    },
   },
   read_file: {
     description:
@@ -62,6 +70,10 @@ export const SANDBOX_TOOLS_METADATA = createToolsRecord({
         .describe("Title for the file in Dust. Defaults to the filename."),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Reading file",
+      done: "Read file",
+    },
   },
   list_files: {
     description:
@@ -78,6 +90,10 @@ export const SANDBOX_TOOLS_METADATA = createToolsRecord({
         .describe("Whether to list files recursively. Defaults to false."),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Listing files",
+      done: "List files",
+    },
   },
 });
 
@@ -103,6 +119,7 @@ export const SANDBOX_SERVER = {
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+    displayLabels: t.displayLabels,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(SANDBOX_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/sandbox/metadata.ts
+++ b/front/lib/api/actions/servers/sandbox/metadata.ts
@@ -34,8 +34,8 @@ export const SANDBOX_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Executing command",
-      done: "Execute command",
+      running: "Executing command in sandbox",
+      done: "Execute command in sandbox",
     },
   },
   write_file: {
@@ -53,8 +53,8 @@ export const SANDBOX_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Writing file",
-      done: "Write file",
+      running: "Writing file to sandbox",
+      done: "Write file to sandbox",
     },
   },
   read_file: {
@@ -71,8 +71,8 @@ export const SANDBOX_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Reading file",
-      done: "Read file",
+      running: "Reading file from sandbox",
+      done: "Read file from sandbox",
     },
   },
   list_files: {
@@ -91,8 +91,8 @@ export const SANDBOX_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Listing files",
-      done: "List files",
+      running: "Listing files in sandbox",
+      done: "List files in sandbox",
     },
   },
 });

--- a/front/lib/api/actions/servers/search/metadata.ts
+++ b/front/lib/api/actions/servers/search/metadata.ts
@@ -20,6 +20,10 @@ export const SEARCH_TOOLS_METADATA = createToolsRecord({
     description: SEARCH_TOOL_DESCRIPTION,
     schema: SearchInputSchema.shape,
     stake: "never_ask" as const,
+    displayLabels: {
+      running: "Searching data sources",
+      done: "Search data sources",
+    },
   },
 });
 
@@ -37,6 +41,7 @@ export const SEARCH_SERVER = {
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+    displayLabels: t.displayLabels,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(SEARCH_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/skill_management/metadata.ts
+++ b/front/lib/api/actions/servers/skill_management/metadata.ts
@@ -17,6 +17,10 @@ export const SKILL_MANAGEMENT_TOOLS_METADATA = createToolsRecord({
       skillName: z.string().describe("The name of the skill to enable"),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Enabling skill",
+      done: "Enable skill",
+    },
   },
 });
 
@@ -40,6 +44,7 @@ export const SKILL_MANAGEMENT_SERVER = {
     inputSchema: zodToJsonSchema(
       z.object(SKILL_MANAGEMENT_TOOLS_METADATA[key].schema)
     ) as JSONSchema,
+    displayLabels: SKILL_MANAGEMENT_TOOLS_METADATA[key].displayLabels,
   })),
   tools_stakes: Object.fromEntries(
     (

--- a/front/lib/api/actions/servers/slab/metadata.ts
+++ b/front/lib/api/actions/servers/slab/metadata.ts
@@ -47,8 +47,8 @@ export const SLAB_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Searching posts",
-      done: "Search posts",
+      running: "Searching Slab posts",
+      done: "Search Slab posts",
     },
   },
   get_post_contents: {
@@ -77,8 +77,8 @@ export const SLAB_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Retrieving post contents",
-      done: "Get post contents",
+      running: "Retrieving Slab post contents",
+      done: "Get Slab post contents",
     },
   },
   get_topics: {
@@ -87,8 +87,8 @@ export const SLAB_TOOLS_METADATA = createToolsRecord({
     schema: {},
     stake: "never_ask",
     displayLabels: {
-      running: "Retrieving topics",
-      done: "Get topics",
+      running: "Retrieving Slab topics",
+      done: "Get Slab topics",
     },
   },
   get_post_metadata: {
@@ -99,8 +99,8 @@ export const SLAB_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Retrieving post metadata",
-      done: "Get post metadata",
+      running: "Retrieving Slab post metadata",
+      done: "Get Slab post metadata",
     },
   },
 });

--- a/front/lib/api/actions/servers/slack_bot/metadata.ts
+++ b/front/lib/api/actions/servers/slack_bot/metadata.ts
@@ -36,6 +36,10 @@ export const SLACK_BOT_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "low",
+    displayLabels: {
+      running: "Posting message",
+      done: "Post message",
+    },
   },
   list_users: {
     description: "List all users in the workspace",
@@ -46,6 +50,10 @@ export const SLACK_BOT_TOOLS_METADATA = createToolsRecord({
         .describe("The name of the user to filter by (optional)"),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Listing users",
+      done: "List users",
+    },
   },
   get_user: {
     description:
@@ -56,6 +64,10 @@ export const SLACK_BOT_TOOLS_METADATA = createToolsRecord({
         .describe("The Slack user ID to look up (for example: U0123456789)."),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Getting user",
+      done: "Get user",
+    },
   },
   list_public_channels: {
     description: "List all public channels in the workspace",
@@ -66,6 +78,10 @@ export const SLACK_BOT_TOOLS_METADATA = createToolsRecord({
         .describe("The name of the channel to filter by (optional)"),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Listing public channels",
+      done: "List public channels",
+    },
   },
   read_channel_history: {
     description:
@@ -92,6 +108,10 @@ export const SLACK_BOT_TOOLS_METADATA = createToolsRecord({
         .describe("Only messages before this timestamp (Unix timestamp)"),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Reading channel history",
+      done: "Read channel history",
+    },
   },
   read_thread_messages: {
     description:
@@ -121,6 +141,10 @@ export const SLACK_BOT_TOOLS_METADATA = createToolsRecord({
         .describe("Only messages before this timestamp (Unix timestamp)"),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Reading thread messages",
+      done: "Read thread messages",
+    },
   },
   add_reaction: {
     description: "Add a reaction emoji to a message",
@@ -136,6 +160,10 @@ export const SLACK_BOT_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "low",
+    displayLabels: {
+      running: "Adding reaction",
+      done: "Add reaction",
+    },
   },
   remove_reaction: {
     description: "Remove a reaction emoji from a message",
@@ -151,6 +179,10 @@ export const SLACK_BOT_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "low",
+    displayLabels: {
+      running: "Removing reaction",
+      done: "Remove reaction",
+    },
   },
 });
 
@@ -177,6 +209,7 @@ export const SLACK_BOT_SERVER = {
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+    displayLabels: t.displayLabels,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(SLACK_BOT_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/slack_bot/metadata.ts
+++ b/front/lib/api/actions/servers/slack_bot/metadata.ts
@@ -37,8 +37,8 @@ export const SLACK_BOT_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Posting message",
-      done: "Post message",
+      running: "Posting Slack message",
+      done: "Post Slack message",
     },
   },
   list_users: {
@@ -51,8 +51,8 @@ export const SLACK_BOT_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Listing users",
-      done: "List users",
+      running: "Listing Slack users",
+      done: "List Slack users",
     },
   },
   get_user: {
@@ -65,8 +65,8 @@ export const SLACK_BOT_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Getting user",
-      done: "Get user",
+      running: "Getting Slack user",
+      done: "Get Slack user",
     },
   },
   list_public_channels: {
@@ -79,8 +79,8 @@ export const SLACK_BOT_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Listing public channels",
-      done: "List public channels",
+      running: "Listing Slack public channels",
+      done: "List Slack public channels",
     },
   },
   read_channel_history: {
@@ -109,8 +109,8 @@ export const SLACK_BOT_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Reading channel history",
-      done: "Read channel history",
+      running: "Reading Slack channel history",
+      done: "Read Slack channel history",
     },
   },
   read_thread_messages: {
@@ -142,8 +142,8 @@ export const SLACK_BOT_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Reading thread messages",
-      done: "Read thread messages",
+      running: "Reading Slack thread messages",
+      done: "Read Slack thread messages",
     },
   },
   add_reaction: {
@@ -161,8 +161,8 @@ export const SLACK_BOT_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Adding reaction",
-      done: "Add reaction",
+      running: "Adding Slack reaction",
+      done: "Add Slack reaction",
     },
   },
   remove_reaction: {
@@ -180,8 +180,8 @@ export const SLACK_BOT_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Removing reaction",
-      done: "Remove reaction",
+      running: "Removing Slack reaction",
+      done: "Remove Slack reaction",
     },
   },
 });

--- a/front/lib/api/actions/servers/slack_personal/metadata.ts
+++ b/front/lib/api/actions/servers/slack_personal/metadata.ts
@@ -66,8 +66,8 @@ export const SLACK_PERSONAL_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Searching Slack messages",
-      done: "Search Slack messages",
+      running: "Searching Slack messages (keyword)",
+      done: "Search Slack messages (keyword)",
     },
   },
   semantic_search_messages: {
@@ -83,8 +83,8 @@ export const SLACK_PERSONAL_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Searching Slack messages",
-      done: "Search Slack messages",
+      running: "Searching Slack messages (semantic)",
+      done: "Search Slack messages (semantic)",
     },
   },
   post_message: {

--- a/front/lib/api/actions/servers/slack_personal/metadata.ts
+++ b/front/lib/api/actions/servers/slack_personal/metadata.ts
@@ -65,6 +65,10 @@ export const SLACK_PERSONAL_TOOLS_METADATA = createToolsRecord({
       ...commonSearchParams,
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Searching messages",
+      done: "Search messages",
+    },
   },
   semantic_search_messages: {
     description:
@@ -78,6 +82,10 @@ export const SLACK_PERSONAL_TOOLS_METADATA = createToolsRecord({
       ...commonSearchParams,
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Semantic searching messages",
+      done: "Semantic search messages",
+    },
   },
   post_message: {
     description:
@@ -108,6 +116,10 @@ export const SLACK_PERSONAL_TOOLS_METADATA = createToolsRecord({
         .describe("The file id of the file to attach to the message."),
     },
     stake: "medium",
+    displayLabels: {
+      running: "Posting message",
+      done: "Post message",
+    },
   },
   schedule_message: {
     description:
@@ -139,6 +151,10 @@ export const SLACK_PERSONAL_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "medium",
+    displayLabels: {
+      running: "Scheduling message",
+      done: "Schedule message",
+    },
   },
   list_users: {
     description: "List all users in the workspace, and optionally user groups",
@@ -155,6 +171,10 @@ export const SLACK_PERSONAL_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Listing users",
+      done: "List users",
+    },
   },
   get_user: {
     description:
@@ -165,6 +185,10 @@ export const SLACK_PERSONAL_TOOLS_METADATA = createToolsRecord({
         .describe("The Slack user ID to look up (for example: U0123456789)."),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Getting user",
+      done: "Get user",
+    },
   },
   search_channels: {
     description: `Search for Slack channels by ID or name.
@@ -195,6 +219,10 @@ IMPORTANT: Always use 'auto' scope unless the user explicitly requests a specifi
         ),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Searching channels",
+      done: "Search channels",
+    },
   },
   list_messages: {
     description:
@@ -216,6 +244,10 @@ IMPORTANT: Always use 'auto' scope unless the user explicitly requests a specifi
         ),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Listing messages",
+      done: "List messages",
+    },
   },
   read_thread_messages: {
     description:
@@ -249,6 +281,10 @@ IMPORTANT: Always use 'auto' scope unless the user explicitly requests a specifi
         .describe("Only messages before this timestamp (Unix timestamp)"),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Reading thread messages",
+      done: "Read thread messages",
+    },
   },
 });
 
@@ -274,6 +310,7 @@ export const SLACK_PERSONAL_SERVER = {
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+    displayLabels: t.displayLabels,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(SLACK_PERSONAL_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/slack_personal/metadata.ts
+++ b/front/lib/api/actions/servers/slack_personal/metadata.ts
@@ -66,8 +66,8 @@ export const SLACK_PERSONAL_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Searching messages",
-      done: "Search messages",
+      running: "Searching Slack messages",
+      done: "Search Slack messages",
     },
   },
   semantic_search_messages: {
@@ -83,8 +83,8 @@ export const SLACK_PERSONAL_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Semantic searching messages",
-      done: "Semantic search messages",
+      running: "Searching Slack messages",
+      done: "Search Slack messages",
     },
   },
   post_message: {
@@ -117,8 +117,8 @@ export const SLACK_PERSONAL_TOOLS_METADATA = createToolsRecord({
     },
     stake: "medium",
     displayLabels: {
-      running: "Posting message",
-      done: "Post message",
+      running: "Posting Slack message",
+      done: "Post Slack message",
     },
   },
   schedule_message: {
@@ -152,8 +152,8 @@ export const SLACK_PERSONAL_TOOLS_METADATA = createToolsRecord({
     },
     stake: "medium",
     displayLabels: {
-      running: "Scheduling message",
-      done: "Schedule message",
+      running: "Scheduling Slack message",
+      done: "Schedule Slack message",
     },
   },
   list_users: {
@@ -172,8 +172,8 @@ export const SLACK_PERSONAL_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Listing users",
-      done: "List users",
+      running: "Listing Slack users",
+      done: "List Slack users",
     },
   },
   get_user: {
@@ -186,8 +186,8 @@ export const SLACK_PERSONAL_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Getting user",
-      done: "Get user",
+      running: "Getting Slack user",
+      done: "Get Slack user",
     },
   },
   search_channels: {
@@ -220,8 +220,8 @@ IMPORTANT: Always use 'auto' scope unless the user explicitly requests a specifi
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Searching channels",
-      done: "Search channels",
+      running: "Searching Slack channels",
+      done: "Search Slack channels",
     },
   },
   list_messages: {
@@ -245,8 +245,8 @@ IMPORTANT: Always use 'auto' scope unless the user explicitly requests a specifi
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Listing messages",
-      done: "List messages",
+      running: "Listing Slack messages",
+      done: "List Slack messages",
     },
   },
   read_thread_messages: {
@@ -282,8 +282,8 @@ IMPORTANT: Always use 'auto' scope unless the user explicitly requests a specifi
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Reading thread messages",
-      done: "Read thread messages",
+      running: "Reading Slack thread messages",
+      done: "Read Slack thread messages",
     },
   },
 });

--- a/front/lib/api/actions/servers/snowflake/metadata.ts
+++ b/front/lib/api/actions/servers/snowflake/metadata.ts
@@ -15,8 +15,8 @@ export const SNOWFLAKE_TOOLS_METADATA = createToolsRecord({
     schema: {},
     stake: "never_ask",
     displayLabels: {
-      running: "Listing databases",
-      done: "List databases",
+      running: "Listing Snowflake databases",
+      done: "List Snowflake databases",
     },
   },
   list_schemas: {
@@ -28,8 +28,8 @@ export const SNOWFLAKE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Listing schemas",
-      done: "List schemas",
+      running: "Listing Snowflake schemas",
+      done: "List Snowflake schemas",
     },
   },
   list_tables: {
@@ -43,8 +43,8 @@ export const SNOWFLAKE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Listing tables",
-      done: "List tables",
+      running: "Listing Snowflake tables",
+      done: "List Snowflake tables",
     },
   },
   describe_table: {
@@ -57,8 +57,8 @@ export const SNOWFLAKE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Describing table",
-      done: "Describe table",
+      running: "Describing Snowflake table",
+      done: "Describe Snowflake table",
     },
   },
   query: {
@@ -92,8 +92,8 @@ export const SNOWFLAKE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Executing query",
-      done: "Execute query",
+      running: "Executing Snowflake query",
+      done: "Execute Snowflake query",
     },
   },
 });

--- a/front/lib/api/actions/servers/statuspage/metadata.ts
+++ b/front/lib/api/actions/servers/statuspage/metadata.ts
@@ -20,8 +20,8 @@ export const STATUSPAGE_TOOLS_METADATA = createToolsRecord({
     schema: {},
     stake: "never_ask",
     displayLabels: {
-      running: "Listing status pages",
-      done: "List status pages",
+      running: "Listing Statuspage pages",
+      done: "List Statuspage pages",
     },
   },
   list_components: {
@@ -37,8 +37,8 @@ export const STATUSPAGE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Listing components",
-      done: "List components",
+      running: "Listing Statuspage components",
+      done: "List Statuspage components",
     },
   },
   list_incidents: {
@@ -62,8 +62,8 @@ export const STATUSPAGE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Listing incidents",
-      done: "List incidents",
+      running: "Listing Statuspage incidents",
+      done: "List Statuspage incidents",
     },
   },
   get_incident: {
@@ -84,8 +84,8 @@ export const STATUSPAGE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Getting incident",
-      done: "Get incident",
+      running: "Getting Statuspage incident",
+      done: "Get Statuspage incident",
     },
   },
   create_incident: {
@@ -122,8 +122,8 @@ export const STATUSPAGE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "high",
     displayLabels: {
-      running: "Creating incident",
-      done: "Create incident",
+      running: "Creating Statuspage incident",
+      done: "Create Statuspage incident",
     },
   },
   update_incident: {
@@ -161,8 +161,8 @@ export const STATUSPAGE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "high",
     displayLabels: {
-      running: "Updating incident",
-      done: "Update incident",
+      running: "Updating Statuspage incident",
+      done: "Update Statuspage incident",
     },
   },
 });

--- a/front/lib/api/actions/servers/toolsets/metadata.ts
+++ b/front/lib/api/actions/servers/toolsets/metadata.ts
@@ -13,6 +13,10 @@ export const TOOLSETS_TOOLS_METADATA = createToolsRecord({
       "List the available toolsets with their names and descriptions. This is like using 'ls' in Unix.",
     schema: {},
     stake: "never_ask",
+    displayLabels: {
+      running: "Listing toolsets",
+      done: "List toolsets",
+    },
   },
   enable: {
     description: "Enable a toolset for this conversation.",
@@ -20,6 +24,10 @@ export const TOOLSETS_TOOLS_METADATA = createToolsRecord({
       toolsetId: z.string().describe("The ID of the toolset to enable."),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Enabling toolset",
+      done: "Enable toolset",
+    },
   },
 });
 
@@ -37,6 +45,7 @@ export const TOOLSETS_SERVER = {
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+    displayLabels: t.displayLabels,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(TOOLSETS_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/ukg_ready/metadata.ts
+++ b/front/lib/api/actions/servers/ukg_ready/metadata.ts
@@ -14,8 +14,8 @@ export const UKG_READY_TOOLS_METADATA = createToolsRecord({
     schema: {},
     stake: "never_ask",
     displayLabels: {
-      running: "Retrieving employee info",
-      done: "Retrieve employee info",
+      running: "Retrieving UKG Ready employee info",
+      done: "Retrieve UKG Ready employee info",
     },
   },
   get_pto_requests: {
@@ -37,8 +37,8 @@ export const UKG_READY_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Retrieving PTO requests",
-      done: "Retrieve PTO requests",
+      running: "Retrieving UKG Ready PTO requests",
+      done: "Retrieve UKG Ready PTO requests",
     },
   },
   get_accrual_balances: {
@@ -59,8 +59,8 @@ export const UKG_READY_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Retrieving accrual balances",
-      done: "Retrieve accrual balances",
+      running: "Retrieving UKG Ready accrual balances",
+      done: "Retrieve UKG Ready accrual balances",
     },
   },
   get_pto_request_notes: {
@@ -74,8 +74,8 @@ export const UKG_READY_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Retrieving PTO notes",
-      done: "Retrieve PTO notes",
+      running: "Retrieving UKG Ready PTO notes",
+      done: "Retrieve UKG Ready PTO notes",
     },
   },
   create_pto_request: {
@@ -131,8 +131,8 @@ export const UKG_READY_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Creating PTO request",
-      done: "Create PTO request",
+      running: "Creating UKG Ready PTO request",
+      done: "Create UKG Ready PTO request",
     },
   },
   delete_pto_request: {
@@ -148,8 +148,8 @@ export const UKG_READY_TOOLS_METADATA = createToolsRecord({
     },
     stake: "low",
     displayLabels: {
-      running: "Deleting PTO request",
-      done: "Delete PTO request",
+      running: "Deleting UKG Ready PTO request",
+      done: "Delete UKG Ready PTO request",
     },
   },
   get_schedules: {
@@ -172,8 +172,8 @@ export const UKG_READY_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Listing schedules",
-      done: "List schedules",
+      running: "Listing UKG Ready schedules",
+      done: "List UKG Ready schedules",
     },
   },
   get_employees: {
@@ -181,8 +181,8 @@ export const UKG_READY_TOOLS_METADATA = createToolsRecord({
     schema: {},
     stake: "never_ask",
     displayLabels: {
-      running: "Listing employees",
-      done: "List employees",
+      running: "Listing UKG Ready employees",
+      done: "List UKG Ready employees",
     },
   },
 });

--- a/front/lib/api/actions/servers/vanta/metadata.ts
+++ b/front/lib/api/actions/servers/vanta/metadata.ts
@@ -72,6 +72,7 @@ export const VANTA_TOOLS_METADATA = createToolsRecord({
       ...PaginationSchema,
     },
     stake: "never_ask",
+    displayLabels: { running: "Listing tests", done: "List tests" },
   },
   list_test_entities: {
     description:
@@ -85,6 +86,7 @@ export const VANTA_TOOLS_METADATA = createToolsRecord({
       ...PaginationSchema,
     },
     stake: "never_ask",
+    displayLabels: { running: "Listing test entities", done: "List test entities" },
   },
   list_controls: {
     description:
@@ -101,6 +103,7 @@ export const VANTA_TOOLS_METADATA = createToolsRecord({
       ...PaginationSchema,
     },
     stake: "never_ask",
+    displayLabels: { running: "Listing controls", done: "List controls" },
   },
   list_control_tests: {
     description:
@@ -110,6 +113,7 @@ export const VANTA_TOOLS_METADATA = createToolsRecord({
       ...PaginationSchema,
     },
     stake: "never_ask",
+    displayLabels: { running: "Listing control tests", done: "List control tests" },
   },
   list_control_documents: {
     description:
@@ -121,6 +125,7 @@ export const VANTA_TOOLS_METADATA = createToolsRecord({
       ...PaginationSchema,
     },
     stake: "never_ask",
+    displayLabels: { running: "Listing control documents", done: "List control documents" },
   },
   list_documents: {
     description:
@@ -135,6 +140,7 @@ export const VANTA_TOOLS_METADATA = createToolsRecord({
       ...PaginationSchema,
     },
     stake: "never_ask",
+    displayLabels: { running: "Listing documents", done: "List documents" },
   },
   list_document_resources: {
     description:
@@ -147,6 +153,7 @@ export const VANTA_TOOLS_METADATA = createToolsRecord({
       ...PaginationSchema,
     },
     stake: "never_ask",
+    displayLabels: { running: "Listing document resources", done: "List document resources" },
   },
   list_integrations: {
     description:
@@ -159,6 +166,7 @@ export const VANTA_TOOLS_METADATA = createToolsRecord({
       ...PaginationSchema,
     },
     stake: "never_ask",
+    displayLabels: { running: "Listing integrations", done: "List integrations" },
   },
   list_frameworks: {
     description:
@@ -171,6 +179,7 @@ export const VANTA_TOOLS_METADATA = createToolsRecord({
       ...PaginationSchema,
     },
     stake: "never_ask",
+    displayLabels: { running: "Listing frameworks", done: "List frameworks" },
   },
   list_framework_controls: {
     description:
@@ -182,6 +191,7 @@ export const VANTA_TOOLS_METADATA = createToolsRecord({
       ...PaginationSchema,
     },
     stake: "never_ask",
+    displayLabels: { running: "Listing framework controls", done: "List framework controls" },
   },
   list_people: {
     description:
@@ -194,6 +204,7 @@ export const VANTA_TOOLS_METADATA = createToolsRecord({
       ...PaginationSchema,
     },
     stake: "never_ask",
+    displayLabels: { running: "Listing people", done: "List people" },
   },
   list_risks: {
     description:
@@ -206,6 +217,7 @@ export const VANTA_TOOLS_METADATA = createToolsRecord({
       ...PaginationSchema,
     },
     stake: "never_ask",
+    displayLabels: { running: "Listing risks", done: "List risks" },
   },
   list_vulnerabilities: {
     description:
@@ -264,6 +276,7 @@ export const VANTA_TOOLS_METADATA = createToolsRecord({
       ...PaginationSchema,
     },
     stake: "never_ask",
+    displayLabels: { running: "Listing vulnerabilities", done: "List vulnerabilities" },
   },
 });
 
@@ -285,6 +298,7 @@ export const VANTA_SERVER = {
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+    displayLabels: t.displayLabels,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(VANTA_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/actions/servers/vanta/metadata.ts
+++ b/front/lib/api/actions/servers/vanta/metadata.ts
@@ -72,7 +72,7 @@ export const VANTA_TOOLS_METADATA = createToolsRecord({
       ...PaginationSchema,
     },
     stake: "never_ask",
-    displayLabels: { running: "Listing tests", done: "List tests" },
+    displayLabels: { running: "Listing Vanta tests", done: "List Vanta tests" },
   },
   list_test_entities: {
     description:
@@ -87,8 +87,8 @@ export const VANTA_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Listing test entities",
-      done: "List test entities",
+      running: "Listing Vanta test entities",
+      done: "List Vanta test entities",
     },
   },
   list_controls: {
@@ -106,7 +106,10 @@ export const VANTA_TOOLS_METADATA = createToolsRecord({
       ...PaginationSchema,
     },
     stake: "never_ask",
-    displayLabels: { running: "Listing controls", done: "List controls" },
+    displayLabels: {
+      running: "Listing Vanta controls",
+      done: "List Vanta controls",
+    },
   },
   list_control_tests: {
     description:
@@ -117,8 +120,8 @@ export const VANTA_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Listing control tests",
-      done: "List control tests",
+      running: "Listing Vanta control tests",
+      done: "List Vanta control tests",
     },
   },
   list_control_documents: {
@@ -132,8 +135,8 @@ export const VANTA_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Listing control documents",
-      done: "List control documents",
+      running: "Listing Vanta control documents",
+      done: "List Vanta control documents",
     },
   },
   list_documents: {
@@ -149,7 +152,10 @@ export const VANTA_TOOLS_METADATA = createToolsRecord({
       ...PaginationSchema,
     },
     stake: "never_ask",
-    displayLabels: { running: "Listing documents", done: "List documents" },
+    displayLabels: {
+      running: "Listing Vanta documents",
+      done: "List Vanta documents",
+    },
   },
   list_document_resources: {
     description:
@@ -163,8 +169,8 @@ export const VANTA_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Listing document resources",
-      done: "List document resources",
+      running: "Listing Vanta document resources",
+      done: "List Vanta document resources",
     },
   },
   list_integrations: {
@@ -179,8 +185,8 @@ export const VANTA_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Listing integrations",
-      done: "List integrations",
+      running: "Listing Vanta integrations",
+      done: "List Vanta integrations",
     },
   },
   list_frameworks: {
@@ -194,7 +200,10 @@ export const VANTA_TOOLS_METADATA = createToolsRecord({
       ...PaginationSchema,
     },
     stake: "never_ask",
-    displayLabels: { running: "Listing frameworks", done: "List frameworks" },
+    displayLabels: {
+      running: "Listing Vanta frameworks",
+      done: "List Vanta frameworks",
+    },
   },
   list_framework_controls: {
     description:
@@ -207,8 +216,8 @@ export const VANTA_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Listing framework controls",
-      done: "List framework controls",
+      running: "Listing Vanta framework controls",
+      done: "List Vanta framework controls",
     },
   },
   list_people: {
@@ -222,7 +231,10 @@ export const VANTA_TOOLS_METADATA = createToolsRecord({
       ...PaginationSchema,
     },
     stake: "never_ask",
-    displayLabels: { running: "Listing people", done: "List people" },
+    displayLabels: {
+      running: "Listing people on Vanta",
+      done: "List people on Vanta",
+    },
   },
   list_risks: {
     description:
@@ -235,7 +247,10 @@ export const VANTA_TOOLS_METADATA = createToolsRecord({
       ...PaginationSchema,
     },
     stake: "never_ask",
-    displayLabels: { running: "Listing risks", done: "List risks" },
+    displayLabels: {
+      running: "Listing risks on Vanta",
+      done: "List risks on Vanta",
+    },
   },
   list_vulnerabilities: {
     description:
@@ -295,8 +310,8 @@ export const VANTA_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Listing vulnerabilities",
-      done: "List vulnerabilities",
+      running: "Listing vulnerabilities on Vanta",
+      done: "List vulnerabilities on Vanta",
     },
   },
 });

--- a/front/lib/api/actions/servers/vanta/metadata.ts
+++ b/front/lib/api/actions/servers/vanta/metadata.ts
@@ -86,7 +86,10 @@ export const VANTA_TOOLS_METADATA = createToolsRecord({
       ...PaginationSchema,
     },
     stake: "never_ask",
-    displayLabels: { running: "Listing test entities", done: "List test entities" },
+    displayLabels: {
+      running: "Listing test entities",
+      done: "List test entities",
+    },
   },
   list_controls: {
     description:
@@ -113,7 +116,10 @@ export const VANTA_TOOLS_METADATA = createToolsRecord({
       ...PaginationSchema,
     },
     stake: "never_ask",
-    displayLabels: { running: "Listing control tests", done: "List control tests" },
+    displayLabels: {
+      running: "Listing control tests",
+      done: "List control tests",
+    },
   },
   list_control_documents: {
     description:
@@ -125,7 +131,10 @@ export const VANTA_TOOLS_METADATA = createToolsRecord({
       ...PaginationSchema,
     },
     stake: "never_ask",
-    displayLabels: { running: "Listing control documents", done: "List control documents" },
+    displayLabels: {
+      running: "Listing control documents",
+      done: "List control documents",
+    },
   },
   list_documents: {
     description:
@@ -153,7 +162,10 @@ export const VANTA_TOOLS_METADATA = createToolsRecord({
       ...PaginationSchema,
     },
     stake: "never_ask",
-    displayLabels: { running: "Listing document resources", done: "List document resources" },
+    displayLabels: {
+      running: "Listing document resources",
+      done: "List document resources",
+    },
   },
   list_integrations: {
     description:
@@ -166,7 +178,10 @@ export const VANTA_TOOLS_METADATA = createToolsRecord({
       ...PaginationSchema,
     },
     stake: "never_ask",
-    displayLabels: { running: "Listing integrations", done: "List integrations" },
+    displayLabels: {
+      running: "Listing integrations",
+      done: "List integrations",
+    },
   },
   list_frameworks: {
     description:
@@ -191,7 +206,10 @@ export const VANTA_TOOLS_METADATA = createToolsRecord({
       ...PaginationSchema,
     },
     stake: "never_ask",
-    displayLabels: { running: "Listing framework controls", done: "List framework controls" },
+    displayLabels: {
+      running: "Listing framework controls",
+      done: "List framework controls",
+    },
   },
   list_people: {
     description:
@@ -276,7 +294,10 @@ export const VANTA_TOOLS_METADATA = createToolsRecord({
       ...PaginationSchema,
     },
     stake: "never_ask",
-    displayLabels: { running: "Listing vulnerabilities", done: "List vulnerabilities" },
+    displayLabels: {
+      running: "Listing vulnerabilities",
+      done: "List vulnerabilities",
+    },
   },
 });
 

--- a/front/lib/api/actions/servers/zendesk/metadata.ts
+++ b/front/lib/api/actions/servers/zendesk/metadata.ts
@@ -34,7 +34,10 @@ export const ZENDESK_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "never_ask",
-    displayLabels: { running: "Retrieving Zendesk ticket", done: "Retrieve Zendesk ticket" },
+    displayLabels: {
+      running: "Retrieving Zendesk ticket",
+      done: "Retrieve Zendesk ticket",
+    },
   },
   search_tickets: {
     description:
@@ -62,7 +65,10 @@ export const ZENDESK_TOOLS_METADATA = createToolsRecord({
         .describe("Sort order. Defaults to 'desc' if not specified."),
     },
     stake: "never_ask",
-    displayLabels: { running: "Searching Zendesk tickets", done: "Search Zendesk tickets" },
+    displayLabels: {
+      running: "Searching Zendesk tickets",
+      done: "Search Zendesk tickets",
+    },
   },
   list_ticket_fields: {
     description:
@@ -95,7 +101,10 @@ export const ZENDESK_TOOLS_METADATA = createToolsRecord({
       body: z.string().describe("The content of the draft reply."),
     },
     stake: "low", // Low because it's a draft.
-    displayLabels: { running: "Drafting Zendesk reply", done: "Draft Zendesk reply" },
+    displayLabels: {
+      running: "Drafting Zendesk reply",
+      done: "Draft Zendesk reply",
+    },
   },
 });
 

--- a/front/lib/api/actions/servers/zendesk/metadata.ts
+++ b/front/lib/api/actions/servers/zendesk/metadata.ts
@@ -34,7 +34,7 @@ export const ZENDESK_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "never_ask",
-    displayLabels: { running: "Retrieving ticket", done: "Retrieve ticket" },
+    displayLabels: { running: "Retrieving Zendesk ticket", done: "Retrieve Zendesk ticket" },
   },
   search_tickets: {
     description:
@@ -62,7 +62,7 @@ export const ZENDESK_TOOLS_METADATA = createToolsRecord({
         .describe("Sort order. Defaults to 'desc' if not specified."),
     },
     stake: "never_ask",
-    displayLabels: { running: "Searching tickets", done: "Search tickets" },
+    displayLabels: { running: "Searching Zendesk tickets", done: "Search Zendesk tickets" },
   },
   list_ticket_fields: {
     description:
@@ -77,8 +77,8 @@ export const ZENDESK_TOOLS_METADATA = createToolsRecord({
     },
     stake: "never_ask",
     displayLabels: {
-      running: "Listing ticket fields",
-      done: "List ticket fields",
+      running: "Listing Zendesk ticket fields",
+      done: "List Zendesk ticket fields",
     },
   },
   draft_reply: {
@@ -95,7 +95,7 @@ export const ZENDESK_TOOLS_METADATA = createToolsRecord({
       body: z.string().describe("The content of the draft reply."),
     },
     stake: "low", // Low because it's a draft.
-    displayLabels: { running: "Drafting reply", done: "Draft reply" },
+    displayLabels: { running: "Drafting Zendesk reply", done: "Draft Zendesk reply" },
   },
 });
 

--- a/front/lib/api/actions/servers/zendesk/metadata.ts
+++ b/front/lib/api/actions/servers/zendesk/metadata.ts
@@ -34,6 +34,7 @@ export const ZENDESK_TOOLS_METADATA = createToolsRecord({
         ),
     },
     stake: "never_ask",
+    displayLabels: { running: "Retrieving ticket", done: "Retrieve ticket" },
   },
   search_tickets: {
     description:
@@ -61,6 +62,7 @@ export const ZENDESK_TOOLS_METADATA = createToolsRecord({
         .describe("Sort order. Defaults to 'desc' if not specified."),
     },
     stake: "never_ask",
+    displayLabels: { running: "Searching tickets", done: "Search tickets" },
   },
   list_ticket_fields: {
     description:
@@ -74,6 +76,10 @@ export const ZENDESK_TOOLS_METADATA = createToolsRecord({
         .describe("Include inactive fields. Defaults to false."),
     },
     stake: "never_ask",
+    displayLabels: {
+      running: "Listing ticket fields",
+      done: "List ticket fields",
+    },
   },
   draft_reply: {
     description:
@@ -89,6 +95,7 @@ export const ZENDESK_TOOLS_METADATA = createToolsRecord({
       body: z.string().describe("The content of the draft reply."),
     },
     stake: "low", // Low because it's a draft.
+    displayLabels: { running: "Drafting reply", done: "Draft reply" },
   },
 });
 
@@ -110,6 +117,7 @@ export const ZENDESK_SERVER = {
     name: t.name,
     description: t.description,
     inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+    displayLabels: t.displayLabels,
   })),
   tools_stakes: Object.fromEntries(
     Object.values(ZENDESK_TOOLS_METADATA).map((t) => [t.name, t.stake])

--- a/front/lib/api/mcp.ts
+++ b/front/lib/api/mcp.ts
@@ -50,6 +50,8 @@ export type MCPToolType = {
   name: string;
   description: string;
   inputSchema?: JSONSchema;
+  // Optional for remote MCP servers (external sources may not have this).
+  // Mandatory for internal MCP servers (enforced via ServerMetadata type).
   displayLabels?: ToolDisplayLabels;
 };
 


### PR DESCRIPTION
## Description

- This PR makes the definition of display labels (displayed in the conversation while the tool is running/in the sidebar once it has completed) mandatory in type and adds them for existing internal tools.
- Next step is to add support in the Chrome extension and in Slack (requires updating the public type).

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- DEploy front.
