### PR TITLE
[connectors] enh(slack bot): show tool execution displays labels when available

### DIFF
--- a/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
+++ b/connectors/src/connectors/slack/chat/stream_conversation_handler.ts
@@ -42,6 +42,10 @@ const SLACK_MESSAGE_UPDATE_THROTTLE_MS = 1_000;
 const SLACK_MESSAGE_UPDATE_SLOW_THROTTLE_MS = 5_000;
 const SLACK_MESSAGE_LONG_THRESHOLD_CHARS = 400;
 
+function getActionRunningLabel(action: AgentActionPublicType): string {
+  return action.displayLabels?.running ?? TOOL_RUNNING_LABEL;
+}
+
 // Dynamic throttling: longer messages get less frequent updates to reduce UX disruption when the content is expanded.
 // Posting an update on an expanded message will collapse it, frequent updates prevent users from reading the content.
 const getThrottleDelay = (textLength: number): number => {
@@ -165,7 +169,7 @@ async function streamAgentAnswerToSlack(
             assistantName,
             agentConfigurations,
             text: answer,
-            thinkingAction: TOOL_RUNNING_LABEL,
+            thinkingAction: getActionRunningLabel(event.action),
           },
           ...conversationData,
           canBeIgnored: true,

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -773,6 +773,13 @@ const ActionGeneratedFileSchema = z.object({
 
 export type ActionGeneratedFileType = z.infer<typeof ActionGeneratedFileSchema>;
 
+const DisplayLabelsSchema = z
+  .object({
+    running: z.string(),
+    done: z.string(),
+  })
+  .nullable();
+
 const AgentActionTypeSchema = z.object({
   id: ModelIdSchema,
   sId: z.string(),
@@ -791,6 +798,7 @@ const AgentActionTypeSchema = z.object({
   citationsAllocated: z.number(),
   output: CallToolResultSchema.shape.content.nullable(),
   generatedFiles: z.array(ActionGeneratedFileSchema),
+  displayLabels: DisplayLabelsSchema,
 });
 
 const GlobalAgentStatusSchema = FlexibleEnumSchema<


### PR DESCRIPTION
## Description

- When calling an agent from Slack, we currently always display `Agent is thinking...... (Using a tool)` when a tool is running.
- This PR improves this part by displaying the running label when available.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy connectors.
