### PR TITLE
[ext] Display tool execution displays labels when available

### DIFF
--- a/extension/ui/components/actions/mcp/details/MCPActionDetails.tsx
+++ b/extension/ui/components/actions/mcp/details/MCPActionDetails.tsx
@@ -279,11 +279,20 @@ export function GenericActionDetails({
   action,
   viewType,
 }: MCPActionDetailsProps) {
-  const actionName =
-    (viewType === "conversation" ? "Running a tool" : "Run a tool") +
-    (action.functionCallName
-      ? `: ${asDisplayName(action.functionCallName)}`
-      : "");
+  let actionName: string;
+
+  if (action.displayLabels) {
+    actionName =
+      viewType === "conversation"
+        ? action.displayLabels.running
+        : action.displayLabels.done;
+  } else {
+    actionName =
+      (viewType === "conversation" ? "Running a tool" : "Run a tool") +
+      (action.functionCallName
+        ? `: ${asDisplayName(action.functionCallName)}`
+        : "");
+  }
 
   return (
     <ActionDetailsWrapper


### PR DESCRIPTION
## Description

- Chrome extension counterpart of https://github.com/dust-tt/dust/pull/21066
- This PR improves the generic mcp action detail component to show the display labels when available

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Publish new version of the extension
