### PR TITLE
Allow folder filtering on Outlook get_messages tool

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
@@ -12289,13 +12289,13 @@
       },
       {
         "name": "get_messages",
-        "description": "Get messages from Outlook inbox. Supports search queries to filter messages and filter by folder.",
+        "description": "Get messages from Outlook inbox. Supports search queries to filter messages and filter by folder name.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
           "additionalProperties": false,
           "properties": {
-            "folderId": {
-              "description": "The ID of the folder to get messages from. Use list_folders to get folder IDs. Leave empty to get messages from all folders.",
+            "folderName": {
+              "description": "The name of the folder to get messages from. Examples: \"Inbox\", \"Sent Items\", \"Drafts\". The tool will search for a folder matching this name. Leave empty to get messages from all folders.",
               "type": "string"
             },
             "search": {
@@ -12318,16 +12318,6 @@
               "type": "number"
             }
           },
-          "type": "object"
-        }
-      },
-      {
-        "name": "list_folders",
-        "description": "List all mail folders in Outlook. Use this to get folder IDs for filtering messages.",
-        "inputSchema": {
-          "$schema": "http://json-schema.org/draft-07/schema#",
-          "additionalProperties": false,
-          "properties": {},
           "type": "object"
         }
       },
@@ -12423,7 +12413,6 @@
       "get_contacts": "never_ask",
       "get_drafts": "never_ask",
       "get_messages": "never_ask",
-      "list_folders": "never_ask",
       "update_contact": "high"
     }
   },

--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
@@ -12289,11 +12289,15 @@
       },
       {
         "name": "get_messages",
-        "description": "Get messages from Outlook inbox. Supports search queries to filter messages.",
+        "description": "Get messages from Outlook inbox. Supports search queries to filter messages and filter by folder.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
           "additionalProperties": false,
           "properties": {
+            "folderId": {
+              "description": "The ID of the folder to get messages from. Use list_folders to get folder IDs. Leave empty to get messages from all folders.",
+              "type": "string"
+            },
             "search": {
               "description": "Search query to filter messages. Examples: \"from:someone@example.com\", \"subject:meeting\", \"hasAttachments:true\". Leave empty to get recent messages.",
               "type": "string"
@@ -12314,6 +12318,16 @@
               "type": "number"
             }
           },
+          "type": "object"
+        }
+      },
+      {
+        "name": "list_folders",
+        "description": "List all mail folders in Outlook. Use this to get folder IDs for filtering messages.",
+        "inputSchema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "additionalProperties": false,
+          "properties": {},
           "type": "object"
         }
       },
@@ -12409,6 +12423,7 @@
       "get_contacts": "never_ask",
       "get_drafts": "never_ask",
       "get_messages": "never_ask",
+      "list_folders": "never_ask",
       "update_contact": "high"
     }
   },

--- a/front/lib/api/actions/servers/outlook/mail_metadata.ts
+++ b/front/lib/api/actions/servers/outlook/mail_metadata.ts
@@ -10,7 +10,7 @@ export const OUTLOOK_TOOL_NAME = "outlook" as const;
 export const OUTLOOK_TOOLS_METADATA = createToolsRecord({
   get_messages: {
     description:
-      "Get messages from Outlook inbox. Supports search queries to filter messages and filter by folder.",
+      "Get messages from Outlook inbox. Supports search queries to filter messages and filter by folder name.",
     schema: {
       search: z
         .string()
@@ -18,11 +18,11 @@ export const OUTLOOK_TOOLS_METADATA = createToolsRecord({
         .describe(
           'Search query to filter messages. Examples: "from:someone@example.com", "subject:meeting", "hasAttachments:true". Leave empty to get recent messages.'
         ),
-      folderId: z
+      folderName: z
         .string()
         .optional()
         .describe(
-          "The ID of the folder to get messages from. Use list_folders to get folder IDs. Leave empty to get messages from all folders."
+          'The name of the folder to get messages from. Examples: "Inbox", "Sent Items", "Drafts". The tool will search for a folder matching this name. Leave empty to get messages from all folders.'
         ),
       top: z
         .number()
@@ -43,16 +43,6 @@ export const OUTLOOK_TOOLS_METADATA = createToolsRecord({
     displayLabels: {
       running: "Fetching messages",
       done: "Fetch messages",
-    },
-  },
-  list_folders: {
-    description:
-      "List all mail folders in Outlook. Use this to get folder IDs for filtering messages.",
-    schema: {},
-    stake: "never_ask",
-    displayLabels: {
-      running: "Listing folders",
-      done: "List folders",
     },
   },
   get_drafts: {

--- a/front/lib/api/actions/servers/outlook/mail_metadata.ts
+++ b/front/lib/api/actions/servers/outlook/mail_metadata.ts
@@ -10,13 +10,19 @@ export const OUTLOOK_TOOL_NAME = "outlook" as const;
 export const OUTLOOK_TOOLS_METADATA = createToolsRecord({
   get_messages: {
     description:
-      "Get messages from Outlook inbox. Supports search queries to filter messages.",
+      "Get messages from Outlook inbox. Supports search queries to filter messages and filter by folder.",
     schema: {
       search: z
         .string()
         .optional()
         .describe(
           'Search query to filter messages. Examples: "from:someone@example.com", "subject:meeting", "hasAttachments:true". Leave empty to get recent messages.'
+        ),
+      folderId: z
+        .string()
+        .optional()
+        .describe(
+          "The ID of the folder to get messages from. Use list_folders to get folder IDs. Leave empty to get messages from all folders."
         ),
       top: z
         .number()
@@ -37,6 +43,16 @@ export const OUTLOOK_TOOLS_METADATA = createToolsRecord({
     displayLabels: {
       running: "Fetching messages",
       done: "Fetch messages",
+    },
+  },
+  list_folders: {
+    description:
+      "List all mail folders in Outlook. Use this to get folder IDs for filtering messages.",
+    schema: {},
+    stake: "never_ask",
+    displayLabels: {
+      running: "Listing folders",
+      done: "List folders",
     },
   },
   get_drafts: {


### PR DESCRIPTION
## Description

This PR improves the Outlook mail MCP tools by:
- adding a `list_folders` tool: get the mail folder collection directly under the root folder of the signed-in user
- adding a `folderId` props on the `get_messages` tool: if provided, the tool will only return results that are in this folder

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Deploy front
