### PR TITLE
Allow CORS from staging builds

### DIFF
--- a/front/config/cors.ts
+++ b/front/config/cors.ts
@@ -25,6 +25,9 @@ const STATIC_ALLOWED_ORIGINS = [
 const ALLOWED_ORIGIN_PATTERNS = [
   // Zendesk domains
   new RegExp("^https://.+\\.zendesk\\.com$"),
+  // Staging apps - allow all builds from poke-dust-tt.pages.dev and app-dust-tt.pages.dev.
+  new RegExp("^https://.*\\.poke-dust-tt\\.pages\\.dev$"),
+  new RegExp("^https://.*\\.app-dust-tt\\.pages\\.dev$"),
 ] as const;
 
 type StaticAllowedOriginType = (typeof STATIC_ALLOWED_ORIGINS)[number];


### PR DESCRIPTION
## Description

Allow CORS from staging app builds from cloudflare .
When running "Deploy SPA to Cloudflare Pages" action from a branch ([here](https://github.com/dust-tt/dust/actions/runs/21588114475) )we have the app deployed on something like : https://xxx.pp-dust-tt.pages.dev/ . This allow to test changes on a branch on prod api, without relying on front-edge.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
