### PR TITLE
[front] - feat(workspace): tools usage in analytics

### DIFF
--- a/front/components/agent_builder/observability/shared/ChartContainer.tsx
+++ b/front/components/agent_builder/observability/shared/ChartContainer.tsx
@@ -50,7 +50,7 @@ export function ChartContainer({
   const [isFullscreen, setIsFullscreen] = useState(false);
   return (
     <>
-      <div className="observability-chart-container">
+      <div className="observability-chart-container rounded-lg border border-border bg-card p-4 dark:border-border-night">
         <div className="flex items-center justify-between">
           <div className="flex items-center justify-between gap-2">
             <h3 className="text-base font-medium text-foreground dark:text-foreground-night">

--- a/front/components/observability/AgentObservability.tsx
+++ b/front/components/observability/AgentObservability.tsx
@@ -5,7 +5,6 @@ import {
   HandThumbDownIcon,
   HandThumbUpIcon,
   LoadingBlock,
-  Separator,
   Spinner,
   ValueCard,
 } from "@dust-tt/sparkle";
@@ -240,7 +239,6 @@ export function AgentObservability({
             isCustomAgent={isCustomAgent}
           />
         </Suspense>
-        <Separator />
         <Suspense fallback={<ChartFallback />}>
           <SourceChart
             workspaceId={owner.sId}
@@ -248,7 +246,6 @@ export function AgentObservability({
             isCustomAgent={isCustomAgent}
           />
         </Suspense>
-        <Separator />
         <Suspense fallback={<ChartFallback />}>
           <LatencyChart
             workspaceId={owner.sId}
@@ -256,7 +253,6 @@ export function AgentObservability({
             isCustomAgent={isCustomAgent}
           />
         </Suspense>
-        <Separator />
         <Suspense fallback={<ChartFallback />}>
           <DatasourceRetrievalTreemapChart
             workspaceId={owner.sId}
@@ -264,7 +260,6 @@ export function AgentObservability({
             isCustomAgent={isCustomAgent}
           />
         </Suspense>
-        <Separator />
         <Suspense fallback={<ChartFallback />}>
           <ToolUsageChart
             workspaceId={owner.sId}
@@ -272,7 +267,6 @@ export function AgentObservability({
             isCustomAgent={isCustomAgent}
           />
         </Suspense>
-        <Separator />
         <Suspense fallback={<ChartFallback />}>
           <ToolExecutionTimeChart
             workspaceId={owner.sId}

--- a/front/components/pages/workspace/AnalyticsPage.tsx
+++ b/front/components/pages/workspace/AnalyticsPage.tsx
@@ -9,6 +9,7 @@ import { ActivityReport } from "@app/components/workspace/ActivityReport";
 import { WorkspaceAnalyticsOverviewCards } from "@app/components/workspace/analytics/WorkspaceAnalyticsOverviewCards";
 import { WorkspaceAnalyticsTimeRangeSelector } from "@app/components/workspace/analytics/WorkspaceAnalyticsTimeRangeSelector";
 import { WorkspaceSourceChart } from "@app/components/workspace/analytics/WorkspaceSourceChart";
+import { WorkspaceToolUsageChart } from "@app/components/workspace/analytics/WorkspaceToolUsageChart";
 import { WorkspaceTopAgentsTable } from "@app/components/workspace/analytics/WorkspaceTopAgentsTable";
 import { WorkspaceTopUsersTable } from "@app/components/workspace/analytics/WorkspaceTopUsersTable";
 import { WorkspaceUsageChart } from "@app/components/workspace/analytics/WorkspaceUsageChart";
@@ -183,6 +184,7 @@ export function AnalyticsPage() {
           <div className="flex flex-col gap-5">
             <WorkspaceUsageChart workspaceId={owner.sId} period={period} />
             <WorkspaceSourceChart workspaceId={owner.sId} period={period} />
+            <WorkspaceToolUsageChart workspaceId={owner.sId} period={period} />
           </div>
           <WorkspaceTopUsersTable workspaceId={owner.sId} period={period} />
           <WorkspaceTopAgentsTable workspaceId={owner.sId} period={period} />

--- a/front/components/pages/workspace/AnalyticsPage.tsx
+++ b/front/components/pages/workspace/AnalyticsPage.tsx
@@ -159,7 +159,7 @@ export function AnalyticsPage() {
           featureFlags,
         })}
       >
-        <Page.Vertical align="stretch" gap="lg">
+        <Page.Vertical align="stretch" gap="xl">
           <Page.Header
             title={
               <div className="flex flex-row w-full justify-between">
@@ -181,11 +181,9 @@ export function AnalyticsPage() {
             workspaceId={owner.sId}
             period={period}
           />
-          <div className="flex flex-col gap-5">
-            <WorkspaceUsageChart workspaceId={owner.sId} period={period} />
-            <WorkspaceSourceChart workspaceId={owner.sId} period={period} />
-            <WorkspaceToolUsageChart workspaceId={owner.sId} period={period} />
-          </div>
+          <WorkspaceUsageChart workspaceId={owner.sId} period={period} />
+          <WorkspaceSourceChart workspaceId={owner.sId} period={period} />
+          <WorkspaceToolUsageChart workspaceId={owner.sId} period={period} />
           <WorkspaceTopUsersTable workspaceId={owner.sId} period={period} />
           <WorkspaceTopAgentsTable workspaceId={owner.sId} period={period} />
           <ActivityReport

--- a/front/components/workspace/ActivityReport.tsx
+++ b/front/components/workspace/ActivityReport.tsx
@@ -4,7 +4,6 @@ import {
   ContextItem,
   GoogleSpreadsheetLogo,
   Icon,
-  Page,
   Pagination,
 } from "@dust-tt/sparkle";
 import { DownloadIcon } from "lucide-react";
@@ -57,12 +56,14 @@ export function ActivityReport({
   return (
     <>
       {!!monthOptions.length && (
-        <div className="flex-grow">
+        <div className="flex-grow rounded-lg border border-border bg-card p-4 dark:border-border-night">
           <div className="flex flex-col gap-3">
-            <Page.H variant="h6">Detailed activity report</Page.H>
-            <Page.P variant="secondary">
+            <h3 className="text-base font-medium text-foreground dark:text-foreground-night">
+              Detailed activity report
+            </h3>
+            <p className="text-xs text-muted-foreground dark:text-muted-foreground-night">
               Download workspace activity details.
-            </Page.P>
+            </p>
             <div className="flex flex-row items-center gap-2">
               <Checkbox
                 aria-label="Include inactive users and assistants"

--- a/front/components/workspace/analytics/WorkspaceToolUsageChart.tsx
+++ b/front/components/workspace/analytics/WorkspaceToolUsageChart.tsx
@@ -64,7 +64,7 @@ function getDataKeySuffix(displayMode: ToolUsageDisplayMode): string {
   return displayMode === "users" ? "_users" : "_executions";
 }
 
-interface ToolUsageTooltipProps {
+interface ToolUsageTooltipProps extends TooltipContentProps<number, string> {
   displayMode: ToolUsageDisplayMode;
   selectedTools: string[];
 }
@@ -73,7 +73,7 @@ function ToolUsageTooltip({
   displayMode,
   selectedTools,
   ...props
-}: TooltipContentProps<number, string> & ToolUsageTooltipProps) {
+}: ToolUsageTooltipProps) {
   const { active, payload } = props;
   if (!active || !payload || payload.length === 0) {
     return null;
@@ -92,7 +92,7 @@ function ToolUsageTooltip({
 
   const rows = selectedTools.map((tool) => ({
     label: asDisplayToolName(tool),
-    value: (row[`${tool}${suffix}`] as number) ?? 0,
+    value: row[`${tool}${suffix}`] ?? 0,
     colorClassName: getToolColor(tool, selectedTools),
   }));
 
@@ -184,7 +184,9 @@ export function WorkspaceToolUsageChart({
   ];
 
   const isLoading =
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     isToolsLoading ||
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     (selectedTools.length === 0 && isAllToolsLoading) ||
     toolUsages.some((t, i) => toolsToFetch[i] && t.isToolUsageLoading);
 

--- a/front/components/workspace/analytics/WorkspaceToolUsageChart.tsx
+++ b/front/components/workspace/analytics/WorkspaceToolUsageChart.tsx
@@ -1,0 +1,399 @@
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@dust-tt/sparkle";
+import { useMemo, useState } from "react";
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import type { TooltipContentProps } from "recharts/types/component/Tooltip";
+
+import type { ObservabilityTimeRangeType } from "@app/components/agent_builder/observability/constants";
+import {
+  CHART_HEIGHT,
+  INDEXED_COLORS,
+} from "@app/components/agent_builder/observability/constants";
+import { ChartContainer } from "@app/components/agent_builder/observability/shared/ChartContainer";
+import type { LegendItem } from "@app/components/agent_builder/observability/shared/ChartLegend";
+import { ChartTooltipCard } from "@app/components/agent_builder/observability/shared/ChartTooltip";
+import { getTimeRangeBounds } from "@app/components/agent_builder/observability/utils";
+import {
+  useWorkspaceTools,
+  useWorkspaceToolUsage,
+} from "@app/lib/swr/workspaces";
+import { formatShortDate } from "@app/lib/utils/timestamps";
+import { asDisplayToolName } from "@app/types/shared/utils/string_utils";
+
+type ToolUsageDisplayMode = "users" | "executions";
+
+const MAX_SELECTED_TOOLS = 5;
+
+interface ToolUsagePoint {
+  timestamp: number;
+  date: string;
+  [key: string]: number | string; // Dynamic keys for each tool
+}
+
+function getToolColor(toolName: string, allTools: string[]): string {
+  const idx = allTools.indexOf(toolName);
+  return INDEXED_COLORS[(idx >= 0 ? idx : 0) % INDEXED_COLORS.length];
+}
+
+function getToolSelectorLabel(selectedTools: string[]): string {
+  if (selectedTools.length === 0) {
+    return "All tools";
+  }
+  if (selectedTools.length === 1) {
+    return asDisplayToolName(selectedTools[0]);
+  }
+  return `${selectedTools.length} tools`;
+}
+
+function getDataKeySuffix(displayMode: ToolUsageDisplayMode): string {
+  return displayMode === "users" ? "_users" : "_executions";
+}
+
+interface ToolUsageTooltipProps {
+  displayMode: ToolUsageDisplayMode;
+  selectedTools: string[];
+}
+
+function ToolUsageTooltip({
+  displayMode,
+  selectedTools,
+  ...props
+}: TooltipContentProps<number, string> & ToolUsageTooltipProps) {
+  const { active, payload } = props;
+  if (!active || !payload || payload.length === 0) {
+    return null;
+  }
+
+  const first = payload[0];
+  if (!first?.payload) {
+    return null;
+  }
+
+  const row = first.payload as ToolUsagePoint;
+  const title = row.date ?? formatShortDate(row.timestamp);
+
+  const suffix = getDataKeySuffix(displayMode);
+  const label = displayMode === "users" ? "users" : "executions";
+
+  const rows = selectedTools.map((tool) => ({
+    label: asDisplayToolName(tool),
+    value: (row[`${tool}${suffix}`] as number) ?? 0,
+    colorClassName: getToolColor(tool, selectedTools),
+  }));
+
+  // Add total if multiple tools
+  if (selectedTools.length > 1) {
+    const total = rows.reduce(
+      (sum, r) => sum + (typeof r.value === "number" ? r.value : 0),
+      0
+    );
+    rows.push({
+      label: `Total ${label}`,
+      value: total,
+      colorClassName: "",
+    });
+  }
+
+  return <ChartTooltipCard title={title} rows={rows} />;
+}
+
+interface WorkspaceToolUsageChartProps {
+  workspaceId: string;
+  period: ObservabilityTimeRangeType;
+}
+
+export function WorkspaceToolUsageChart({
+  workspaceId,
+  period,
+}: WorkspaceToolUsageChartProps) {
+  const [displayMode, setDisplayMode] =
+    useState<ToolUsageDisplayMode>("executions");
+  const [selectedTools, setSelectedTools] = useState<string[]>([]);
+
+  // Fetch list of available tools for dropdown
+  const { tools: availableTools, isToolsLoading } = useWorkspaceTools({
+    workspaceId,
+    days: period,
+    disabled: !workspaceId,
+  });
+
+  // Fetch data for all tools (when no selection) or each selected tool
+  const toolsToFetch = selectedTools.length > 0 ? selectedTools : [];
+
+  // Fetch aggregated data when no specific tools are selected
+  const { toolUsage: allToolsUsage, isToolUsageLoading: isAllToolsLoading } =
+    useWorkspaceToolUsage({
+      workspaceId,
+      days: period,
+      disabled: !workspaceId || selectedTools.length > 0,
+    });
+
+  // Fetch data for each selected tool
+  const tool1Usage = useWorkspaceToolUsage({
+    workspaceId,
+    days: period,
+    serverName: toolsToFetch[0],
+    disabled: !workspaceId || !toolsToFetch[0],
+  });
+  const tool2Usage = useWorkspaceToolUsage({
+    workspaceId,
+    days: period,
+    serverName: toolsToFetch[1],
+    disabled: !workspaceId || !toolsToFetch[1],
+  });
+  const tool3Usage = useWorkspaceToolUsage({
+    workspaceId,
+    days: period,
+    serverName: toolsToFetch[2],
+    disabled: !workspaceId || !toolsToFetch[2],
+  });
+  const tool4Usage = useWorkspaceToolUsage({
+    workspaceId,
+    days: period,
+    serverName: toolsToFetch[3],
+    disabled: !workspaceId || !toolsToFetch[3],
+  });
+  const tool5Usage = useWorkspaceToolUsage({
+    workspaceId,
+    days: period,
+    serverName: toolsToFetch[4],
+    disabled: !workspaceId || !toolsToFetch[4],
+  });
+
+  const toolUsages = [
+    tool1Usage,
+    tool2Usage,
+    tool3Usage,
+    tool4Usage,
+    tool5Usage,
+  ];
+
+  const isLoading =
+    isToolsLoading ||
+    (selectedTools.length === 0 && isAllToolsLoading) ||
+    toolUsages.some((t, i) => toolsToFetch[i] && t.isToolUsageLoading);
+
+  const hasError = toolUsages.some(
+    (t, i) => toolsToFetch[i] && t.isToolUsageError
+  );
+
+  // Merge data from all selected tools into a single dataset
+  const data = useMemo(() => {
+    const suffix = getDataKeySuffix(displayMode);
+    const valueKey = displayMode === "users" ? "uniqueUsers" : "executionCount";
+
+    // Generate all dates in the range
+    const [startDate, endDate] = getTimeRangeBounds(period);
+    const startTime = new Date(startDate + "T00:00:00Z").getTime();
+    const endTime = new Date(endDate + "T00:00:00Z").getTime();
+    const dayMs = 24 * 60 * 60 * 1000;
+    const numDays = Math.floor((endTime - startTime) / dayMs) + 1;
+
+    const points: ToolUsagePoint[] = [];
+
+    for (let i = 0; i < numDays; i++) {
+      const timestamp = startTime + i * dayMs;
+      const point: ToolUsagePoint = {
+        timestamp,
+        date: formatShortDate(timestamp),
+      };
+
+      if (selectedTools.length === 0) {
+        // Show aggregated "all tools" data
+        const allData = allToolsUsage.find((p) => p.timestamp === timestamp);
+        point["all_tools" + suffix] = allData ? allData[valueKey] : 0;
+      } else {
+        // Show data for each selected tool
+        selectedTools.forEach((tool, idx) => {
+          const toolData = toolUsages[idx]?.toolUsage.find(
+            (p) => p.timestamp === timestamp
+          );
+          point[`${tool}${suffix}`] = toolData ? toolData[valueKey] : 0;
+        });
+      }
+
+      points.push(point);
+    }
+
+    return points;
+  }, [displayMode, period, selectedTools, allToolsUsage, toolUsages]);
+
+  const handleToolToggle = (tool: string, checked: boolean) => {
+    if (checked) {
+      if (selectedTools.length < MAX_SELECTED_TOOLS) {
+        setSelectedTools([...selectedTools, tool]);
+      }
+    } else {
+      setSelectedTools(selectedTools.filter((t) => t !== tool));
+    }
+  };
+
+  const handleSelectAll = () => {
+    setSelectedTools([]);
+  };
+
+  const suffix = getDataKeySuffix(displayMode);
+  const toolsForChart =
+    selectedTools.length > 0 ? selectedTools : ["all_tools"];
+
+  const legendItems: LegendItem[] = toolsForChart.map((tool) => ({
+    key: tool,
+    label: tool === "all_tools" ? "All tools" : asDisplayToolName(tool),
+    colorClassName: getToolColor(tool, toolsForChart),
+  }));
+
+  const toolSelector = (
+    <DropdownMenu modal={false}>
+      <DropdownMenuTrigger asChild>
+        <Button
+          label={getToolSelectorLabel(selectedTools)}
+          size="xs"
+          variant="outline"
+          isSelect
+          disabled={isToolsLoading}
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem label="All tools" onClick={handleSelectAll} />
+        <DropdownMenuSeparator />
+        <DropdownMenuLabel>
+          Select tools (max {MAX_SELECTED_TOOLS})
+        </DropdownMenuLabel>
+        <div className="max-h-64 overflow-auto">
+          {availableTools.map((tool) => (
+            <DropdownMenuCheckboxItem
+              key={tool.serverName}
+              label={asDisplayToolName(tool.serverName)}
+              checked={selectedTools.includes(tool.serverName)}
+              disabled={
+                !selectedTools.includes(tool.serverName) &&
+                selectedTools.length >= MAX_SELECTED_TOOLS
+              }
+              onCheckedChange={(checked) =>
+                handleToolToggle(tool.serverName, checked)
+              }
+              onSelect={(event) => {
+                event.preventDefault();
+              }}
+            />
+          ))}
+        </div>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+
+  const modeSelector = (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          label={displayMode === "users" ? "Unique users" : "Executions"}
+          size="xs"
+          variant="outline"
+          isSelect
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem
+          label="Executions"
+          onClick={() => setDisplayMode("executions")}
+        />
+        <DropdownMenuItem
+          label="Unique users"
+          onClick={() => setDisplayMode("users")}
+        />
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+
+  return (
+    <ChartContainer
+      title="Tool usage"
+      description="Track how tools are being used across your workspace."
+      isLoading={isLoading}
+      errorMessage={hasError ? "Failed to load tool usage data." : undefined}
+      emptyMessage={
+        data.length === 0 ? "No tool usage data for this selection." : undefined
+      }
+      height={CHART_HEIGHT}
+      legendItems={legendItems}
+      additionalControls={
+        <div className="flex items-center gap-2">
+          {toolSelector}
+          {modeSelector}
+        </div>
+      }
+    >
+      <LineChart
+        data={data}
+        margin={{ top: 10, right: 30, left: 10, bottom: 20 }}
+      >
+        <CartesianGrid
+          vertical={false}
+          className="stroke-border dark:stroke-border-night"
+        />
+        <XAxis
+          dataKey="date"
+          type="category"
+          scale="point"
+          allowDuplicatedCategory={false}
+          className="text-xs text-muted-foreground dark:text-muted-foreground-night"
+          tickLine={false}
+          axisLine={false}
+          tickMargin={8}
+          minTickGap={16}
+        />
+        <YAxis
+          className="text-xs text-muted-foreground dark:text-muted-foreground-night"
+          tickLine={false}
+          axisLine={false}
+          tickMargin={8}
+          allowDecimals={false}
+        />
+        <Tooltip
+          content={(props: TooltipContentProps<number, string>) => (
+            <ToolUsageTooltip
+              {...props}
+              displayMode={displayMode}
+              selectedTools={toolsForChart}
+            />
+          )}
+          cursor={false}
+          wrapperStyle={{ outline: "none", zIndex: 50 }}
+          contentStyle={{
+            background: "transparent",
+            border: "none",
+            padding: 0,
+            boxShadow: "none",
+          }}
+        />
+        {toolsForChart.map((tool) => (
+          <Line
+            key={tool}
+            type={period === 7 || period === 14 ? "linear" : "monotone"}
+            strokeWidth={2}
+            dataKey={`${tool}${suffix}`}
+            name={tool === "all_tools" ? "All tools" : asDisplayToolName(tool)}
+            className={getToolColor(tool, toolsForChart)}
+            stroke="currentColor"
+            dot={false}
+          />
+        ))}
+      </LineChart>
+    </ChartContainer>
+  );
+}

--- a/front/lib/api/assistant/observability/tool_usage.ts
+++ b/front/lib/api/assistant/observability/tool_usage.ts
@@ -1,0 +1,210 @@
+import type { estypes } from "@elastic/elasticsearch";
+
+import {
+  bucketsToArray,
+  formatUTCDateFromMillis,
+  searchAnalytics,
+} from "@app/lib/api/elasticsearch";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+export type ToolUsagePoint = {
+  timestamp: number;
+  date: string;
+  uniqueUsers: number;
+  executionCount: number;
+};
+
+export type AvailableTool = {
+  serverName: string;
+  totalExecutions: number;
+};
+
+type DateBucket = {
+  key: number;
+  key_as_string: string;
+  doc_count: number;
+  tools_nested: {
+    doc_count: number;
+    unique_users: {
+      doc_count: number;
+      cardinality: estypes.AggregationsCardinalityAggregate;
+    };
+  };
+};
+
+type ToolUsageAggs = {
+  by_date: estypes.AggregationsMultiBucketAggregateBase<DateBucket>;
+};
+
+type FilteredDateBucket = {
+  key: number;
+  key_as_string: string;
+  doc_count: number;
+  tools_nested: {
+    filtered: {
+      doc_count: number;
+      unique_users: {
+        doc_count: number;
+        cardinality: estypes.AggregationsCardinalityAggregate;
+      };
+    };
+  };
+};
+
+type FilteredToolUsageAggs = {
+  by_date: estypes.AggregationsMultiBucketAggregateBase<FilteredDateBucket>;
+};
+
+type ToolBucket = {
+  key: string;
+  doc_count: number;
+};
+
+type ToolListAggs = {
+  tools_nested: {
+    by_server: estypes.AggregationsMultiBucketAggregateBase<ToolBucket>;
+  };
+};
+
+function bucketToPoint(bucket: DateBucket): ToolUsagePoint {
+  return {
+    timestamp: bucket.key,
+    date: formatUTCDateFromMillis(bucket.key),
+    uniqueUsers: bucket.tools_nested?.unique_users?.cardinality?.value ?? 0,
+    executionCount: bucket.tools_nested?.doc_count ?? 0,
+  };
+}
+
+function filteredBucketToPoint(bucket: FilteredDateBucket): ToolUsagePoint {
+  return {
+    timestamp: bucket.key,
+    date: formatUTCDateFromMillis(bucket.key),
+    uniqueUsers:
+      bucket.tools_nested?.filtered?.unique_users?.cardinality?.value ?? 0,
+    executionCount: bucket.tools_nested?.filtered?.doc_count ?? 0,
+  };
+}
+
+export async function fetchToolUsageMetrics(
+  baseQuery: estypes.QueryDslQueryContainer,
+  serverName: string | null
+): Promise<Result<ToolUsagePoint[], Error>> {
+  // When serverName is provided, filter the nested tools_used aggregation
+  // When null, aggregate across all tools
+
+  const nestedAggs: Record<string, estypes.AggregationsAggregationContainer> =
+    serverName
+      ? {
+          filtered: {
+            filter: { term: { "tools_used.server_name": serverName } },
+            aggs: {
+              unique_users: {
+                reverse_nested: {},
+                aggs: {
+                  cardinality: {
+                    cardinality: { field: "user_id" },
+                  },
+                },
+              },
+            },
+          },
+        }
+      : {
+          unique_users: {
+            reverse_nested: {},
+            aggs: {
+              cardinality: {
+                cardinality: { field: "user_id" },
+              },
+            },
+          },
+        };
+
+  const aggs: Record<string, estypes.AggregationsAggregationContainer> = {
+    by_date: {
+      date_histogram: {
+        field: "timestamp",
+        calendar_interval: "day",
+        time_zone: "UTC",
+      },
+      aggs: {
+        tools_nested: {
+          nested: { path: "tools_used" },
+          aggs: nestedAggs,
+        },
+      },
+    },
+  };
+
+  if (serverName) {
+    const result = await searchAnalytics<never, FilteredToolUsageAggs>(
+      baseQuery,
+      { aggregations: aggs, size: 0 }
+    );
+
+    if (result.isErr()) {
+      return new Err(new Error(result.error.message));
+    }
+
+    const dateBuckets = bucketsToArray<FilteredDateBucket>(
+      result.value.aggregations?.by_date?.buckets
+    );
+
+    return new Ok(dateBuckets.map(filteredBucketToPoint));
+  }
+
+  const result = await searchAnalytics<never, ToolUsageAggs>(baseQuery, {
+    aggregations: aggs,
+    size: 0,
+  });
+
+  if (result.isErr()) {
+    return new Err(new Error(result.error.message));
+  }
+
+  const dateBuckets = bucketsToArray<DateBucket>(
+    result.value.aggregations?.by_date?.buckets
+  );
+
+  return new Ok(dateBuckets.map(bucketToPoint));
+}
+
+export async function fetchAvailableTools(
+  baseQuery: estypes.QueryDslQueryContainer
+): Promise<Result<AvailableTool[], Error>> {
+  const aggs: Record<string, estypes.AggregationsAggregationContainer> = {
+    tools_nested: {
+      nested: { path: "tools_used" },
+      aggs: {
+        by_server: {
+          terms: {
+            field: "tools_used.server_name",
+            size: 100,
+            order: { _count: "desc" },
+          },
+        },
+      },
+    },
+  };
+
+  const result = await searchAnalytics<never, ToolListAggs>(baseQuery, {
+    aggregations: aggs,
+    size: 0,
+  });
+
+  if (result.isErr()) {
+    return new Err(new Error(result.error.message));
+  }
+
+  const toolBuckets = bucketsToArray<ToolBucket>(
+    result.value.aggregations?.tools_nested?.by_server?.buckets
+  );
+
+  const tools: AvailableTool[] = toolBuckets.map((bucket) => ({
+    serverName: bucket.key,
+    totalExecutions: bucket.doc_count,
+  }));
+
+  return new Ok(tools);
+}

--- a/front/lib/swr/workspaces.ts
+++ b/front/lib/swr/workspaces.ts
@@ -14,6 +14,8 @@ import type { GetWorkspaceResponseBody } from "@app/pages/api/w/[wId]";
 import type { GetWorkspaceAnalyticsOverviewResponse } from "@app/pages/api/w/[wId]/analytics/overview";
 import type { GetWorkspaceContextOriginResponse } from "@app/pages/api/w/[wId]/analytics/source";
 import type { GetWorkspaceTopAgentsResponse } from "@app/pages/api/w/[wId]/analytics/top-agents";
+import type { GetWorkspaceToolUsageResponse } from "@app/pages/api/w/[wId]/analytics/tool-usage";
+import type { GetWorkspaceToolsResponse } from "@app/pages/api/w/[wId]/analytics/tools";
 import type { GetWorkspaceTopUsersResponse } from "@app/pages/api/w/[wId]/analytics/top-users";
 import type { GetWorkspaceUsageMetricsResponse } from "@app/pages/api/w/[wId]/analytics/usage-metrics";
 import type { GetWorkspaceAuthContextResponseType } from "@app/pages/api/w/[wId]/auth-context";
@@ -163,6 +165,62 @@ export function useWorkspaceContextOrigin({
     isContextOriginLoading: !error && !data && !disabled,
     isContextOriginError: error,
     isContextOriginValidating: isValidating,
+  };
+}
+
+export function useWorkspaceTools({
+  workspaceId,
+  days = DEFAULT_PERIOD_DAYS,
+  disabled,
+}: {
+  workspaceId: string;
+  days?: number;
+  disabled?: boolean;
+}) {
+  const fetcherFn: Fetcher<GetWorkspaceToolsResponse> = fetcher;
+  const key = `/api/w/${workspaceId}/analytics/tools?days=${days}`;
+
+  const { data, error, isValidating } = useSWRWithDefaults(
+    disabled ? null : key,
+    fetcherFn
+  );
+
+  return {
+    tools: data?.tools ?? emptyArray(),
+    isToolsLoading: !error && !data && !disabled,
+    isToolsError: error,
+    isToolsValidating: isValidating,
+  };
+}
+
+export function useWorkspaceToolUsage({
+  workspaceId,
+  days = DEFAULT_PERIOD_DAYS,
+  serverName,
+  disabled,
+}: {
+  workspaceId: string;
+  days?: number;
+  serverName?: string;
+  disabled?: boolean;
+}) {
+  const fetcherFn: Fetcher<GetWorkspaceToolUsageResponse> = fetcher;
+  const params = new URLSearchParams({ days: String(days) });
+  if (serverName) {
+    params.set("serverName", serverName);
+  }
+  const key = `/api/w/${workspaceId}/analytics/tool-usage?${params.toString()}`;
+
+  const { data, error, isValidating } = useSWRWithDefaults(
+    disabled ? null : key,
+    fetcherFn
+  );
+
+  return {
+    toolUsage: data?.points ?? emptyArray(),
+    isToolUsageLoading: !error && !data && !disabled,
+    isToolUsageError: error,
+    isToolUsageValidating: isValidating,
   };
 }
 

--- a/front/lib/swr/workspaces.ts
+++ b/front/lib/swr/workspaces.ts
@@ -13,9 +13,9 @@ import type { GetNoWorkspaceAuthContextResponseType } from "@app/pages/api/auth-
 import type { GetWorkspaceResponseBody } from "@app/pages/api/w/[wId]";
 import type { GetWorkspaceAnalyticsOverviewResponse } from "@app/pages/api/w/[wId]/analytics/overview";
 import type { GetWorkspaceContextOriginResponse } from "@app/pages/api/w/[wId]/analytics/source";
-import type { GetWorkspaceTopAgentsResponse } from "@app/pages/api/w/[wId]/analytics/top-agents";
 import type { GetWorkspaceToolUsageResponse } from "@app/pages/api/w/[wId]/analytics/tool-usage";
 import type { GetWorkspaceToolsResponse } from "@app/pages/api/w/[wId]/analytics/tools";
+import type { GetWorkspaceTopAgentsResponse } from "@app/pages/api/w/[wId]/analytics/top-agents";
 import type { GetWorkspaceTopUsersResponse } from "@app/pages/api/w/[wId]/analytics/top-users";
 import type { GetWorkspaceUsageMetricsResponse } from "@app/pages/api/w/[wId]/analytics/usage-metrics";
 import type { GetWorkspaceAuthContextResponseType } from "@app/pages/api/w/[wId]/auth-context";

--- a/front/pages/api/w/[wId]/analytics/tool-usage.ts
+++ b/front/pages/api/w/[wId]/analytics/tool-usage.ts
@@ -1,0 +1,93 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+
+import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import type { ToolUsagePoint } from "@app/lib/api/assistant/observability/tool_usage";
+import { fetchToolUsageMetrics } from "@app/lib/api/assistant/observability/tool_usage";
+import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+import { isString } from "@app/types";
+
+const QuerySchema = z.object({
+  days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
+  serverName: z.string().optional(),
+});
+
+export type GetWorkspaceToolUsageResponse = {
+  points: ToolUsagePoint[];
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetWorkspaceToolUsageResponse>>,
+  auth: Authenticator
+) {
+  if (!auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "Only workspace admins can access workspace analytics.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      const { days: queryDays, serverName: queryServerName } = req.query;
+      const q = QuerySchema.safeParse({
+        days: queryDays,
+        serverName: isString(queryServerName) ? queryServerName : undefined,
+      });
+      if (!q.success) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid query parameters: ${q.error.message}`,
+          },
+        });
+      }
+
+      const { days, serverName } = q.data;
+      const owner = auth.getNonNullableWorkspace();
+
+      const baseQuery = buildAgentAnalyticsBaseQuery({
+        workspaceId: owner.sId,
+        days,
+      });
+
+      const usageResult = await fetchToolUsageMetrics(
+        baseQuery,
+        serverName ?? null
+      );
+
+      if (usageResult.isErr()) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: `Failed to retrieve tool usage metrics: ${usageResult.error.message}`,
+          },
+        });
+      }
+
+      return res.status(200).json({
+        points: usageResult.value,
+      });
+    }
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/analytics/tools.ts
+++ b/front/pages/api/w/[wId]/analytics/tools.ts
@@ -1,0 +1,85 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+
+import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import type { AvailableTool } from "@app/lib/api/assistant/observability/tool_usage";
+import { fetchAvailableTools } from "@app/lib/api/assistant/observability/tool_usage";
+import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+
+const QuerySchema = z.object({
+  days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
+});
+
+export type GetWorkspaceToolsResponse = {
+  tools: AvailableTool[];
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetWorkspaceToolsResponse>>,
+  auth: Authenticator
+) {
+  if (!auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "Only workspace admins can access workspace analytics.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      const { days: queryDays } = req.query;
+      const q = QuerySchema.safeParse({ days: queryDays });
+      if (!q.success) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid query parameters: ${q.error.message}`,
+          },
+        });
+      }
+
+      const { days } = q.data;
+      const owner = auth.getNonNullableWorkspace();
+
+      const baseQuery = buildAgentAnalyticsBaseQuery({
+        workspaceId: owner.sId,
+        days,
+      });
+
+      const toolsResult = await fetchAvailableTools(baseQuery);
+
+      if (toolsResult.isErr()) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: `Failed to retrieve tools: ${toolsResult.error.message}`,
+          },
+        });
+      }
+
+      return res.status(200).json({
+        tools: toolsResult.value,
+      });
+    }
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);


### PR DESCRIPTION
## Description

Adds a new "Tool usage" chart to the workspace analytics page that tracks tool execution metrics across the workspace. The chart displays up to 5 selected tools simultaneously and offers two display modes: execution count or unique users. It leverages Elasticsearch aggregations to compute daily metrics. The implementation includes two new API endpoints (`/analytics/tools` and `/analytics/tool-usage`) that query tool execution data from the analytics index using nested aggregations on the `tools_used` field.

## Risk

Low - adds a new chart

## Tests

- [x] Locally
- [x] front-edge 

## Deploy Plan

Deploy front
