### PR TITLE
copilot suggestions: only allow one tool or skill

### DIFF
--- a/front/components/agent_builder/copilot/CopilotSuggestionsContext.tsx
+++ b/front/components/agent_builder/copilot/CopilotSuggestionsContext.tsx
@@ -20,7 +20,6 @@ import {
   usePatchAgentSuggestions,
 } from "@app/lib/swr/agent_suggestions";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
-import { removeNulls } from "@app/types";
 import type {
   AgentInstructionsSuggestionType,
   AgentSuggestionType,
@@ -141,47 +140,21 @@ export const CopilotSuggestionsProvider = ({
 
       switch (suggestion.kind) {
         case "tools": {
-          const additions = removeNulls(
-            (suggestion.suggestion.additions ?? []).map((a) =>
-              mcpServerViewsMap.get(a.id)
-            )
-          );
-          const deletions = removeNulls(
-            (suggestion.suggestion.deletions ?? []).map((id) =>
-              mcpServerViewsMap.get(id)
-            )
-          );
-          const expectedRelations =
-            (suggestion.suggestion.additions?.length ?? 0) +
-            (suggestion.suggestion.deletions?.length ?? 0);
-          const resolvedRelations = additions.length + deletions.length;
-          if (expectedRelations !== resolvedRelations) {
+          const tool = mcpServerViewsMap.get(suggestion.suggestion.toolId);
+          if (!tool) {
             return null;
           }
 
-          return { ...suggestion, relations: { additions, deletions } };
+          return { ...suggestion, relations: { tool } };
         }
 
         case "skills": {
-          const additions = removeNulls(
-            (suggestion.suggestion.additions ?? []).map((id) =>
-              skillsMap.get(id)
-            )
-          );
-          const deletions = removeNulls(
-            (suggestion.suggestion.deletions ?? []).map((id) =>
-              skillsMap.get(id)
-            )
-          );
-          const expectedRelations =
-            (suggestion.suggestion.additions?.length ?? 0) +
-            (suggestion.suggestion.deletions?.length ?? 0);
-          const resolvedRelations = additions.length + deletions.length;
-          if (expectedRelations !== resolvedRelations) {
+          const skill = skillsMap.get(suggestion.suggestion.skillId);
+          if (!skill) {
             return null;
           }
 
-          return { ...suggestion, relations: { additions, deletions } };
+          return { ...suggestion, relations: { skill } };
         }
 
         case "model": {

--- a/front/components/markdown/suggestion/CopilotSuggestionCard.tsx
+++ b/front/components/markdown/suggestion/CopilotSuggestionCard.tsx
@@ -74,102 +74,69 @@ function InstructionsSuggestionCard({
   );
 }
 
-// Tools suggestion: renders separate card per addition/deletion
-function ToolsSuggestionCards({
+function ToolSuggestionCard({
   agentSuggestion,
 }: {
   agentSuggestion: Extract<AgentSuggestionWithRelationsType, { kind: "tools" }>;
 }) {
-  const { relations, state, sId, analysis } = agentSuggestion;
+  const { suggestion, relations, state, sId, analysis } = agentSuggestion;
   const cardState = mapSuggestionStateToCardState(state);
   const { acceptSuggestion, rejectSuggestion } = useCopilotSuggestions();
   const { setValue, getValues } = useFormContext<AgentBuilderFormData>();
 
-  const handleAcceptAddition = useCallback(
-    async (tool: MCPServerViewType) => {
-      const success = await acceptSuggestion(sId);
-      if (success) {
-        const currentActions = getValues("actions");
-        const alreadyExists = currentActions.some(
-          (a) => a.configuration.mcpServerViewId === tool.sId
-        );
-        if (!alreadyExists) {
-          setValue("actions", [...currentActions, getDefaultMCPAction(tool)], {
-            shouldDirty: true,
-          });
-        }
-      }
-    },
-    [acceptSuggestion, sId, getValues, setValue]
-  );
+  const isAddition = suggestion.action === "add";
+  const tool = relations.tool;
 
-  const handleAcceptDeletion = useCallback(
-    async (tool: MCPServerViewType) => {
-      const success = await acceptSuggestion(sId);
-      if (success) {
-        const currentActions = getValues("actions");
-        setValue(
-          "actions",
-          currentActions.filter(
-            (a) => a.configuration.mcpServerViewId !== tool.sId
-          ),
-          { shouldDirty: true }
-        );
+  const handleAccept = useCallback(() => {
+  const success = await acceptSuggestion(sId);
+  if (success) {
+    if (isAddition) {
+      const currentActions = getValues("actions");
+      const alreadyExists = currentActions.some(
+        (action) => action.configuration.mcpServerViewId === tool.sId
+      );
+      if (!alreadyExists) {
+        const newAction = getDefaultMCPAction(tool);
+        setValue("actions", [...currentActions, newAction], {
+          shouldDirty: true,
+        });
       }
-    },
-    [acceptSuggestion, sId, getValues, setValue]
-  );
+    } else {
+      const currentActions = getValues("actions");
+      const filteredActions = currentActions.filter(
+        (action) => action.configuration.mcpServerViewId !== tool.sId
+      );
+      setValue("actions", filteredActions, { shouldDirty: true });
+    }
+  }
+  }, [acceptSuggestion, sId, getValues, setValue, isAddition, tool]);
 
   const handleReject = useCallback(() => {
     void rejectSuggestion(sId);
   }, [rejectSuggestion, sId]);
 
+  const serverName = getMcpServerViewDisplayName(tool);
+
   return (
-    <div className="flex flex-col gap-2">
-      {relations.additions.map((tool) => {
-        const serverName = getMcpServerViewDisplayName(tool);
-        return (
-          <ActionCardBlock
-            key={`add-${tool.sId}`}
-            title={`Add ${serverName} tool`}
-            visual={<Avatar icon={getIcon(tool.server.icon)} size="sm" />}
-            description={analysis ?? undefined}
-            state={cardState}
-            applyLabel="Add"
-            rejectLabel="Dismiss"
-            acceptedTitle={`${serverName} tool added`}
+    <ActionCardBlock
+      title={
+        isAddition ? `Add ${serverName} tool` : `Remove ${serverName} tool`
+      }
+      visual={<Avatar icon={getIcon(tool.server.icon)} size="sm" />}
+      description={analysis ?? undefined}
+      state={cardState}
+      applyLabel={isAddition ? "Add" : "Remove"}
+      rejectLabel="Dismiss"
+            acceptedTitle={isAddition ? `${serverName} tool added` : ${serverName} tool removed`}
             rejectedTitle={`${serverName} tool dismissed`}
-            actionsPosition="header"
-            onClickAccept={() => handleAcceptAddition(tool)}
-            onClickReject={handleReject}
-          />
-        );
-      })}
-      {relations.deletions.map((tool) => {
-        const serverName = getMcpServerViewDisplayName(tool);
-        return (
-          <ActionCardBlock
-            key={`del-${tool.sId}`}
-            title={`Remove ${serverName} tool`}
-            visual={<Avatar icon={getIcon(tool.server.icon)} size="sm" />}
-            description={analysis ?? undefined}
-            state={cardState}
-            applyLabel="Remove"
-            rejectLabel="Dismiss"
-            acceptedTitle={`${serverName} tool removed`}
-            rejectedTitle={`${serverName} tool dismissed`}
-            actionsPosition="header"
-            onClickAccept={() => handleAcceptDeletion(tool)}
-            onClickReject={handleReject}
-          />
-        );
-      })}
-    </div>
+      actionsPosition="header"
+      onClickAccept={handleAccept}
+      onClickReject={handleReject}
+    />
   );
 }
 
-// Skills suggestion: renders separate card per addition/deletion
-function SkillsSuggestionCards({
+function SkillSuggestionCard({
   agentSuggestion,
 }: {
   agentSuggestion: Extract<
@@ -177,91 +144,57 @@ function SkillsSuggestionCards({
     { kind: "skills" }
   >;
 }) {
-  const { relations, state, sId, analysis } = agentSuggestion;
+  const { suggestion, relations, state, sId, analysis } = agentSuggestion;
   const cardState = mapSuggestionStateToCardState(state);
   const { acceptSuggestion, rejectSuggestion } = useCopilotSuggestions();
   const { setValue, getValues } = useFormContext<AgentBuilderFormData>();
 
-  const handleAcceptAddition = useCallback(
-    async (skill: SkillType) => {
-      const success = await acceptSuggestion(sId);
-      if (success) {
-        const currentSkills = getValues("skills");
-        const alreadyExists = currentSkills.some((s) => s.sId === skill.sId);
-        if (!alreadyExists) {
-          setValue(
-            "skills",
-            [
-              ...currentSkills,
-              {
-                sId: skill.sId,
-                name: skill.name,
-                description: skill.userFacingDescription,
-                icon: skill.icon,
-              },
-            ],
-            { shouldDirty: true }
-          );
-        }
-      }
-    },
-    [acceptSuggestion, sId, getValues, setValue]
-  );
+  const isAddition = suggestion.action === "add";
+  const skill = relations.skill;
 
-  const handleAcceptDeletion = useCallback(
-    async (skill: SkillType) => {
+  const handleAccept = useCallback(() => {
       const success = await acceptSuggestion(sId);
       if (success) {
-        const currentSkills = getValues("skills");
-        setValue(
-          "skills",
-          currentSkills.filter((s) => s.sId !== skill.sId),
-          { shouldDirty: true }
-        );
+    if (isAddition) {
+      const currentSkills = getValues("skills");
+      const alreadyExists = currentSkills.some((s) => s.sId === skill.sId);
+      if (!alreadyExists) {
+        const newSkill = {
+          sId: skill.sId,
+          name: skill.name,
+          description: skill.userFacingDescription,
+          icon: skill.icon,
+        };
+        setValue("skills", [...currentSkills, newSkill], { shouldDirty: true });
       }
-    },
-    [acceptSuggestion, sId, getValues, setValue]
-  );
+    } else {
+      const currentSkills = getValues("skills");
+      const filteredSkills = currentSkills.filter((s) => s.sId !== skill.sId);
+      setValue("skills", filteredSkills, { shouldDirty: true });
+    }
+  }
+  }, [acceptSuggestion, sId, getValues, setValue, isAddition, skill]);
 
   const handleReject = useCallback(() => {
     void rejectSuggestion(sId);
   }, [rejectSuggestion, sId]);
 
   return (
-    <div className="flex flex-col gap-2">
-      {relations.additions.map((skill) => (
-        <ActionCardBlock
-          key={`add-${skill.sId}`}
-          title={`Add ${skill.name} skill`}
-          visual={<Icon visual={getSkillAvatarIcon(skill.icon)} />}
-          description={analysis ?? undefined}
-          state={cardState}
-          applyLabel="Add"
-          rejectLabel="Dismiss"
-          acceptedTitle={`${skill.name} skill added`}
+    <ActionCardBlock
+      title={
+        isAddition ? `Add ${skill.name} skill` : `Remove ${skill.name} skill`
+      }
+      visual={<Icon visual={getSkillAvatarIcon(skill.icon)} />}
+      description={analysis ?? undefined}
+      state={cardState}
+      applyLabel={isAddition ? "Add" : "Remove"}
+      rejectLabel="Dismiss"
+          acceptedTitle={ isAddition ? `${skill.name} skill added` : `${skill.name} skill removed`}
           rejectedTitle={`${skill.name} skill dismissed`}
-          actionsPosition="header"
-          onClickAccept={() => handleAcceptAddition(skill)}
-          onClickReject={handleReject}
-        />
-      ))}
-      {relations.deletions.map((skill) => (
-        <ActionCardBlock
-          key={`del-${skill.sId}`}
-          title={`Remove ${skill.name} skill`}
-          visual={<Icon visual={getSkillAvatarIcon(skill.icon)} />}
-          description={analysis ?? undefined}
-          state={cardState}
-          applyLabel="Remove"
-          rejectLabel="Dismiss"
-          acceptedTitle={`${skill.name} skill removed`}
-          rejectedTitle={`${skill.name} skill dismissed`}
-          actionsPosition="header"
-          onClickAccept={() => handleAcceptDeletion(skill)}
-          onClickReject={handleReject}
-        />
-      ))}
-    </div>
+      actionsPosition="header"
+      onClickAccept={handleAccept}
+      onClickReject={handleReject}
+    />
   );
 }
 
@@ -335,9 +268,9 @@ export function CopilotSuggestionCard({
     case "instructions":
       return <InstructionsSuggestionCard agentSuggestion={agentSuggestion} />;
     case "tools":
-      return <ToolsSuggestionCards agentSuggestion={agentSuggestion} />;
+      return <ToolSuggestionCard agentSuggestion={agentSuggestion} />;
     case "skills":
-      return <SkillsSuggestionCards agentSuggestion={agentSuggestion} />;
+      return <SkillSuggestionCard agentSuggestion={agentSuggestion} />;
     case "model":
       return <ModelSuggestionCard agentSuggestion={agentSuggestion} />;
   }

--- a/front/components/markdown/suggestion/CopilotSuggestionCard.tsx
+++ b/front/components/markdown/suggestion/CopilotSuggestionCard.tsx
@@ -18,9 +18,7 @@ import { useCopilotSuggestions } from "@app/components/agent_builder/copilot/Cop
 import { getDefaultMCPAction } from "@app/components/agent_builder/types";
 import { getIcon } from "@app/components/resources/resources_icons";
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
-import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { getSkillAvatarIcon } from "@app/lib/skill";
-import type { SkillType } from "@app/types/assistant/skill_configuration";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type {
   AgentSuggestionKind,
@@ -87,28 +85,28 @@ function ToolSuggestionCard({
   const isAddition = suggestion.action === "add";
   const tool = relations.tool;
 
-  const handleAccept = useCallback(() => {
-  const success = await acceptSuggestion(sId);
-  if (success) {
-    if (isAddition) {
-      const currentActions = getValues("actions");
-      const alreadyExists = currentActions.some(
-        (action) => action.configuration.mcpServerViewId === tool.sId
-      );
-      if (!alreadyExists) {
-        const newAction = getDefaultMCPAction(tool);
-        setValue("actions", [...currentActions, newAction], {
-          shouldDirty: true,
-        });
+  const handleAccept = useCallback(async () => {
+    const success = await acceptSuggestion(sId);
+    if (success) {
+      if (isAddition) {
+        const currentActions = getValues("actions");
+        const alreadyExists = currentActions.some(
+          (action) => action.configuration.mcpServerViewId === tool.sId
+        );
+        if (!alreadyExists) {
+          const newAction = getDefaultMCPAction(tool);
+          setValue("actions", [...currentActions, newAction], {
+            shouldDirty: true,
+          });
+        }
+      } else {
+        const currentActions = getValues("actions");
+        const filteredActions = currentActions.filter(
+          (action) => action.configuration.mcpServerViewId !== tool.sId
+        );
+        setValue("actions", filteredActions, { shouldDirty: true });
       }
-    } else {
-      const currentActions = getValues("actions");
-      const filteredActions = currentActions.filter(
-        (action) => action.configuration.mcpServerViewId !== tool.sId
-      );
-      setValue("actions", filteredActions, { shouldDirty: true });
     }
-  }
   }, [acceptSuggestion, sId, getValues, setValue, isAddition, tool]);
 
   const handleReject = useCallback(() => {
@@ -127,8 +125,10 @@ function ToolSuggestionCard({
       state={cardState}
       applyLabel={isAddition ? "Add" : "Remove"}
       rejectLabel="Dismiss"
-            acceptedTitle={isAddition ? `${serverName} tool added` : ${serverName} tool removed`}
-            rejectedTitle={`${serverName} tool dismissed`}
+      acceptedTitle={
+        isAddition ? `${serverName} tool added` : `${serverName} tool removed`
+      }
+      rejectedTitle={`${serverName} tool dismissed`}
       actionsPosition="header"
       onClickAccept={handleAccept}
       onClickReject={handleReject}
@@ -152,27 +152,29 @@ function SkillSuggestionCard({
   const isAddition = suggestion.action === "add";
   const skill = relations.skill;
 
-  const handleAccept = useCallback(() => {
-      const success = await acceptSuggestion(sId);
-      if (success) {
-    if (isAddition) {
-      const currentSkills = getValues("skills");
-      const alreadyExists = currentSkills.some((s) => s.sId === skill.sId);
-      if (!alreadyExists) {
-        const newSkill = {
-          sId: skill.sId,
-          name: skill.name,
-          description: skill.userFacingDescription,
-          icon: skill.icon,
-        };
-        setValue("skills", [...currentSkills, newSkill], { shouldDirty: true });
+  const handleAccept = useCallback(async () => {
+    const success = await acceptSuggestion(sId);
+    if (success) {
+      if (isAddition) {
+        const currentSkills = getValues("skills");
+        const alreadyExists = currentSkills.some((s) => s.sId === skill.sId);
+        if (!alreadyExists) {
+          const newSkill = {
+            sId: skill.sId,
+            name: skill.name,
+            description: skill.userFacingDescription,
+            icon: skill.icon,
+          };
+          setValue("skills", [...currentSkills, newSkill], {
+            shouldDirty: true,
+          });
+        }
+      } else {
+        const currentSkills = getValues("skills");
+        const filteredSkills = currentSkills.filter((s) => s.sId !== skill.sId);
+        setValue("skills", filteredSkills, { shouldDirty: true });
       }
-    } else {
-      const currentSkills = getValues("skills");
-      const filteredSkills = currentSkills.filter((s) => s.sId !== skill.sId);
-      setValue("skills", filteredSkills, { shouldDirty: true });
     }
-  }
   }, [acceptSuggestion, sId, getValues, setValue, isAddition, skill]);
 
   const handleReject = useCallback(() => {
@@ -189,8 +191,10 @@ function SkillSuggestionCard({
       state={cardState}
       applyLabel={isAddition ? "Add" : "Remove"}
       rejectLabel="Dismiss"
-          acceptedTitle={ isAddition ? `${skill.name} skill added` : `${skill.name} skill removed`}
-          rejectedTitle={`${skill.name} skill dismissed`}
+      acceptedTitle={
+        isAddition ? `${skill.name} skill added` : `${skill.name} skill removed`
+      }
+      rejectedTitle={`${skill.name} skill dismissed`}
       actionsPosition="header"
       onClickAccept={handleAccept}
       onClickReject={handleReject}

--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
@@ -319,21 +319,23 @@
               "additionalProperties": false,
               "description": "The skill additions and/or deletions to suggest",
               "properties": {
-                "additions": {
-                  "description": "Skill IDs to add to the agent",
-                  "items": {
-                    "type": "string"
-                  },
-                  "type": "array"
+                "action": {
+                  "description": "The action to perform",
+                  "enum": [
+                    "add",
+                    "remove"
+                  ],
+                  "type": "string"
                 },
-                "deletions": {
-                  "description": "Skill IDs to remove from the agent",
-                  "items": {
-                    "type": "string"
-                  },
-                  "type": "array"
+                "skillId": {
+                  "description": "The skill identifier",
+                  "type": "string"
                 }
               },
+              "required": [
+                "action",
+                "skillId"
+              ],
               "type": "object"
             }
           },
@@ -358,36 +360,23 @@
               "additionalProperties": false,
               "description": "The tool additions and/or deletions to suggest",
               "properties": {
-                "additions": {
-                  "description": "Tools to add to the agent",
-                  "items": {
-                    "additionalProperties": false,
-                    "properties": {
-                      "additionalConfiguration": {
-                        "additionalProperties": {},
-                        "description": "Optional configuration for the tool",
-                        "type": "object"
-                      },
-                      "id": {
-                        "description": "The tool/server identifier",
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "id"
-                    ],
-                    "type": "object"
-                  },
-                  "type": "array"
+                "action": {
+                  "description": "The action to perform",
+                  "enum": [
+                    "add",
+                    "remove"
+                  ],
+                  "type": "string"
                 },
-                "deletions": {
-                  "description": "Tool IDs to remove from the agent",
-                  "items": {
-                    "type": "string"
-                  },
-                  "type": "array"
+                "toolId": {
+                  "description": "The tool/server identifier",
+                  "type": "string"
                 }
               },
+              "required": [
+                "action",
+                "toolId"
+              ],
               "type": "object"
             }
           },

--- a/front/lib/api/actions/servers/agent_copilot_context/agent_copilot_context.test.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/agent_copilot_context.test.ts
@@ -688,7 +688,8 @@ describe("agent_copilot_context tools", () => {
       const result = await tool.handler(
         {
           suggestion: {
-            additions: [{ id: view.sId }],
+            action: "add",
+            toolId: view.sId,
           },
           analysis: "Adding tool for better capabilities",
         },
@@ -725,7 +726,8 @@ describe("agent_copilot_context tools", () => {
       const result = await tool.handler(
         {
           suggestion: {
-            additions: [{ id: "non-existent-tool-id" }],
+            action: "add",
+            toolId: "non-existent-tool-id",
           },
         },
         createTestExtra(authenticator)
@@ -753,7 +755,8 @@ describe("agent_copilot_context tools", () => {
       const result = await tool.handler(
         {
           suggestion: {
-            additions: ["non-existent-skill"],
+            action: "add",
+            skillId: "non-existent-skill",
           },
         },
         createTestExtra(authenticator)
@@ -787,7 +790,8 @@ describe("agent_copilot_context tools", () => {
       const result = await tool.handler(
         {
           suggestion: {
-            additions: [skill.sId],
+            action: "add",
+            skillId: skill.sId,
           },
           analysis: "Adding skills for better capabilities",
         },
@@ -824,7 +828,8 @@ describe("agent_copilot_context tools", () => {
       const result = await tool.handler(
         {
           suggestion: {
-            additions: ["non-existent-skill-id"],
+            action: "add",
+            skillId: "non-existent-skill-id",
           },
         },
         createTestExtra(authenticator)

--- a/front/lib/api/actions/servers/agent_copilot_context/metadata.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/metadata.ts
@@ -33,34 +33,14 @@ const InstructionsSuggestionSchema = z.object({
     .describe("Analysis or reasoning for this specific suggestion"),
 });
 
-const ToolAdditionSchema = z.object({
-  id: z.string().describe("The tool/server identifier"),
-  additionalConfiguration: z
-    .record(z.unknown())
-    .optional()
-    .describe("Optional configuration for the tool"),
-});
-
 const ToolsSuggestionSchema = z.object({
-  additions: z
-    .array(ToolAdditionSchema)
-    .optional()
-    .describe("Tools to add to the agent"),
-  deletions: z
-    .array(z.string())
-    .optional()
-    .describe("Tool IDs to remove from the agent"),
+  action: z.enum(["add", "remove"]).describe("The action to perform"),
+  toolId: z.string().describe("The tool/server identifier"),
 });
 
 const SkillsSuggestionSchema = z.object({
-  additions: z
-    .array(z.string())
-    .optional()
-    .describe("Skill IDs to add to the agent"),
-  deletions: z
-    .array(z.string())
-    .optional()
-    .describe("Skill IDs to remove from the agent"),
+  action: z.enum(["add", "remove"]).describe("The action to perform"),
+  skillId: z.string().describe("The skill identifier"),
 });
 
 const ModelSuggestionSchema = z.object({

--- a/front/lib/api/actions/servers/agent_copilot_context/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/tools/index.ts
@@ -39,7 +39,6 @@ import {
 import { CUSTOM_MODEL_CONFIGS } from "@app/types/assistant/models/custom_models.generated";
 import type {
   AgentSuggestionState,
-  SkillsSuggestionType,
   ToolsSuggestionType,
 } from "@app/types/suggestions/agent_suggestion";
 
@@ -672,7 +671,7 @@ const handlers: ToolHandlers<typeof AGENT_COPILOT_CONTEXT_TOOLS_METADATA> = {
 
     // Validate that the tool ID exists and is accessible.
     const { action, toolId } = params.suggestion;
-    const tool = MCPServerViewResource.fetchById(auth, toolId);
+    const tool = await MCPServerViewResource.fetchById(auth, toolId);
 
     if (!tool) {
       return new Err(
@@ -761,8 +760,8 @@ const handlers: ToolHandlers<typeof AGENT_COPILOT_CONTEXT_TOOLS_METADATA> = {
     }
 
     // Validate that the skill ID exists and is accessible.
-    const skillId = params.suggestion.skillId;
-    const skill = SkillResource.fetchById(auth, skillId);
+    const { action, skillId } = params.suggestion;
+    const skill = await SkillResource.fetchById(auth, skillId);
 
     if (!skill) {
       return new Err(

--- a/front/lib/api/actions/servers/agent_copilot_context/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/tools/index.ts
@@ -672,10 +672,9 @@ const handlers: ToolHandlers<typeof AGENT_COPILOT_CONTEXT_TOOLS_METADATA> = {
 
     // Validate that the tool ID exists and is accessible.
     const { action, toolId } = params.suggestion;
-    const availableTools = await listAvailableTools(auth);
-    const availableToolIds = new Set(availableTools.map((t) => t.sId));
+    const tool = MCPServerViewResource.fetchById(auth, toolId);
 
-    if (!availableToolIds.has(toolId)) {
+    if (!tool) {
       return new Err(
         new MCPError(
           `The tool ID "${toolId}" is invalid or not accessible. ` +
@@ -762,11 +761,10 @@ const handlers: ToolHandlers<typeof AGENT_COPILOT_CONTEXT_TOOLS_METADATA> = {
     }
 
     // Validate that the skill ID exists and is accessible.
-    const { action, skillId } = params.suggestion;
-    const availableSkills = await listAvailableSkills(auth);
-    const availableSkillIds = new Set(availableSkills.map((s) => s.sId));
+    const skillId = params.suggestion.skillId;
+    const skill = SkillResource.fetchById(auth, skillId);
 
-    if (!availableSkillIds.has(skillId)) {
+    if (!skill) {
       return new Err(
         new MCPError(
           `The skill ID "${skillId}" is invalid or not accessible. ` +

--- a/front/lib/api/assistant/agent_suggestion_pruning.test.ts
+++ b/front/lib/api/assistant/agent_suggestion_pruning.test.ts
@@ -120,14 +120,15 @@ describe("pruneSuggestionsForAgent", () => {
   });
 
   describe("tools suggestions", () => {
-    it("should mark tool suggestion as outdated when tool to delete no longer exists", async () => {
-      // Create a suggestion to delete a tool that doesn't exist in the agent.
+    it("should mark tool suggestion as outdated when tool to remove no longer exists", async () => {
+      // Create a suggestion to remove a tool that doesn't exist in the agent.
       const suggestion = await AgentSuggestionFactory.createTools(
         authenticator,
         agentConfiguration,
         {
           suggestion: {
-            deletions: ["non_existent_tool"],
+            action: "remove",
+            toolId: "non_existent_tool",
           },
         }
       );
@@ -152,7 +153,8 @@ describe("pruneSuggestionsForAgent", () => {
         agentConfiguration,
         {
           suggestion: {
-            additions: [{ id: "new_tool_to_add" }],
+            action: "add",
+            toolId: "new_tool_to_add",
           },
         }
       );
@@ -188,7 +190,8 @@ describe("pruneSuggestionsForAgent", () => {
         agentConfiguration,
         {
           suggestion: {
-            additions: [skill.sId],
+            action: "add",
+            skillId: skill.sId,
           },
         }
       );
@@ -218,7 +221,8 @@ describe("pruneSuggestionsForAgent", () => {
         agentConfiguration,
         {
           suggestion: {
-            additions: ["go-deep"],
+            action: "add",
+            skillId: "go-deep",
           },
         }
       );
@@ -237,13 +241,14 @@ describe("pruneSuggestionsForAgent", () => {
       expect(fetched?.state).toBe("outdated");
     });
 
-    it("should mark skill suggestion as outdated when skill to delete no longer exists", async () => {
+    it("should mark skill suggestion as outdated when skill to remove no longer exists", async () => {
       const suggestion = await AgentSuggestionFactory.createSkills(
         authenticator,
         agentConfiguration,
         {
           suggestion: {
-            deletions: ["non_existent_skill"],
+            action: "remove",
+            skillId: "non_existent_skill",
           },
         }
       );
@@ -268,7 +273,8 @@ describe("pruneSuggestionsForAgent", () => {
         agentConfiguration,
         {
           suggestion: {
-            additions: ["new_skill_to_add"],
+            action: "add",
+            skillId: "new_skill_to_add",
           },
         }
       );

--- a/front/lib/api/assistant/agent_suggestion_pruning.ts
+++ b/front/lib/api/assistant/agent_suggestion_pruning.ts
@@ -130,7 +130,7 @@ export async function pruneSuggestions(
   await AgentSuggestionResource.bulkUpdateState(auth, allOutdated, "outdated");
 }
 
-/** Outdated if any addition already exists or any deletion no longer exists. */
+/** Outdated if tool to add already exists or tool to remove no longer exists. */
 function getOutdatedToolsSuggestions(
   suggestions: ToolsSuggestionResource[],
   currentActions: MCPServerConfigurationType[]
@@ -147,25 +147,11 @@ function getOutdatedToolsSuggestions(
   const outdatedSuggestions: ToolsSuggestionResource[] = [];
 
   for (const suggestion of suggestions) {
-    let isOutdated = false;
-
-    if (suggestion.suggestion.additions) {
-      for (const addition of suggestion.suggestion.additions) {
-        if (currentToolIds.has(addition.id)) {
-          isOutdated = true;
-          break;
-        }
-      }
-    }
-
-    if (!isOutdated && suggestion.suggestion.deletions) {
-      for (const deletion of suggestion.suggestion.deletions) {
-        if (!currentToolIds.has(deletion)) {
-          isOutdated = true;
-          break;
-        }
-      }
-    }
+    const { action, toolId } = suggestion.suggestion;
+    const isOutdated =
+      action === "add"
+        ? currentToolIds.has(toolId)
+        : !currentToolIds.has(toolId);
 
     if (isOutdated) {
       outdatedSuggestions.push(suggestion);
@@ -175,7 +161,7 @@ function getOutdatedToolsSuggestions(
   return outdatedSuggestions;
 }
 
-/** Outdated if any addition already exists or any deletion no longer exists. */
+/** Outdated if skill to add already exists or skill to remove no longer exists. */
 async function getOutdatedSkillsSuggestions(
   auth: Authenticator,
   suggestions: SkillsSuggestionResource[],
@@ -193,25 +179,11 @@ async function getOutdatedSkillsSuggestions(
   const outdatedSuggestions: SkillsSuggestionResource[] = [];
 
   for (const suggestion of suggestions) {
-    let isOutdated = false;
-
-    if (suggestion.suggestion.additions) {
-      for (const addition of suggestion.suggestion.additions) {
-        if (currentSkillIds.has(addition)) {
-          isOutdated = true;
-          break;
-        }
-      }
-    }
-
-    if (!isOutdated && suggestion.suggestion.deletions) {
-      for (const deletion of suggestion.suggestion.deletions) {
-        if (!currentSkillIds.has(deletion)) {
-          isOutdated = true;
-          break;
-        }
-      }
-    }
+    const { action, skillId } = suggestion.suggestion;
+    const isOutdated =
+      action === "add"
+        ? currentSkillIds.has(skillId)
+        : !currentSkillIds.has(skillId);
 
     if (isOutdated) {
       outdatedSuggestions.push(suggestion);

--- a/front/lib/resources/agent_suggestion_resource.test.ts
+++ b/front/lib/resources/agent_suggestion_resource.test.ts
@@ -65,19 +65,17 @@ describe("AgentSuggestionResource", () => {
   });
 
   describe("tools suggestion", () => {
-    it("should create and fetch a tools suggestion", async () => {
+    it("should create and fetch a tools add suggestion", async () => {
       const suggestion = await AgentSuggestionFactory.createTools(
         authenticator,
         agentConfiguration,
         {
           suggestion: {
-            additions: [
-              { id: "github", additionalConfiguration: { repo: "dust" } },
-              { id: "jira" },
-            ],
-            deletions: ["old_tool"],
+            action: "add",
+            toolId: "github",
+            additionalConfiguration: { repo: "dust" },
           },
-          analysis: "Adding project management tools",
+          analysis: "Adding GitHub tool",
         }
       );
 
@@ -93,23 +91,52 @@ describe("AgentSuggestionResource", () => {
       const json = fetched!.toJSON();
       expect(json.kind).toBe("tools");
       expect(json.suggestion).toEqual({
-        additions: [
-          { id: "github", additionalConfiguration: { repo: "dust" } },
-          { id: "jira" },
-        ],
-        deletions: ["old_tool"],
+        action: "add",
+        toolId: "github",
+        additionalConfiguration: { repo: "dust" },
+      });
+    });
+
+    it("should create and fetch a tools remove suggestion", async () => {
+      const suggestion = await AgentSuggestionFactory.createTools(
+        authenticator,
+        agentConfiguration,
+        {
+          suggestion: {
+            action: "remove",
+            toolId: "old_tool",
+          },
+          analysis: "Removing old tool",
+        }
+      );
+
+      expect(suggestion).toBeDefined();
+      expect(suggestion.kind).toBe("tools");
+
+      const fetched = await AgentSuggestionResource.fetchById(
+        authenticator,
+        suggestion.sId
+      );
+      expect(fetched).toBeDefined();
+
+      const json = fetched!.toJSON();
+      expect(json.kind).toBe("tools");
+      expect(json.suggestion).toEqual({
+        action: "remove",
+        toolId: "old_tool",
       });
     });
   });
 
   describe("skills suggestion", () => {
-    it("should create and fetch a skills suggestion", async () => {
+    it("should create and fetch a skills add suggestion", async () => {
       const suggestion = await AgentSuggestionFactory.createSkills(
         authenticator,
         agentConfiguration,
         {
           suggestion: {
-            additions: ["data_analysis"],
+            action: "add",
+            skillId: "data_analysis",
           },
           source: "copilot",
         }
@@ -128,7 +155,39 @@ describe("AgentSuggestionResource", () => {
       const json = fetched!.toJSON();
       expect(json.kind).toBe("skills");
       expect(json.suggestion).toEqual({
-        additions: ["data_analysis"],
+        action: "add",
+        skillId: "data_analysis",
+      });
+    });
+
+    it("should create and fetch a skills remove suggestion", async () => {
+      const suggestion = await AgentSuggestionFactory.createSkills(
+        authenticator,
+        agentConfiguration,
+        {
+          suggestion: {
+            action: "remove",
+            skillId: "old_skill",
+          },
+          source: "copilot",
+        }
+      );
+
+      expect(suggestion).toBeDefined();
+      expect(suggestion.kind).toBe("skills");
+      expect(suggestion.source).toBe("copilot");
+
+      const fetched = await AgentSuggestionResource.fetchById(
+        authenticator,
+        suggestion.sId
+      );
+      expect(fetched).toBeDefined();
+
+      const json = fetched!.toJSON();
+      expect(json.kind).toBe("skills");
+      expect(json.suggestion).toEqual({
+        action: "remove",
+        skillId: "old_skill",
       });
     });
   });

--- a/front/lib/resources/agent_suggestion_resource.ts
+++ b/front/lib/resources/agent_suggestion_resource.ts
@@ -115,7 +115,8 @@ export class AgentSuggestionResource extends BaseResource<AgentSuggestionModel> 
     blob: Omit<
       CreationAttributes<AgentSuggestionModel>,
       "workspaceId" | "agentConfigurationId"
-    >
+    >,
+    { transaction }: { transaction?: Transaction } = {}
   ): Promise<AgentSuggestionResource> {
     const owner = auth.getNonNullableWorkspace();
 
@@ -134,11 +135,14 @@ export class AgentSuggestionResource extends BaseResource<AgentSuggestionModel> 
       throw new Error("User does not have permission to edit this agent");
     }
 
-    const suggestion = await AgentSuggestionModel.create({
-      ...blob,
-      agentConfigurationId: agentConfiguration.id,
-      workspaceId: owner.id,
-    });
+    const suggestion = await AgentSuggestionModel.create(
+      {
+        ...blob,
+        agentConfigurationId: agentConfiguration.id,
+        workspaceId: owner.id,
+      },
+      { transaction }
+    );
 
     return new this(
       AgentSuggestionModel,
@@ -389,5 +393,14 @@ export class AgentSuggestionResource extends BaseResource<AgentSuggestionModel> 
       source: this.source,
       ...suggestionData,
     };
+  }
+
+  /**
+   * Lists all suggestions for the workspace.
+   */
+  static async listAll(
+    auth: Authenticator
+  ): Promise<AgentSuggestionResource[]> {
+    return this.baseFetch(auth, {});
   }
 }

--- a/front/lib/resources/agent_suggestion_resource.ts
+++ b/front/lib/resources/agent_suggestion_resource.ts
@@ -7,7 +7,6 @@ import type {
   WhereOptions,
 } from "sequelize";
 import { Op } from "sequelize";
-import type { Logger } from "@app/logger/logger";
 
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
 import type { Authenticator } from "@app/lib/auth";

--- a/front/lib/resources/agent_suggestion_resource.ts
+++ b/front/lib/resources/agent_suggestion_resource.ts
@@ -7,6 +7,7 @@ import type {
   WhereOptions,
 } from "sequelize";
 import { Op } from "sequelize";
+import type { Logger } from "@app/logger/logger";
 
 import { getAgentConfigurations } from "@app/lib/api/assistant/configuration/agent";
 import type { Authenticator } from "@app/lib/auth";
@@ -115,8 +116,7 @@ export class AgentSuggestionResource extends BaseResource<AgentSuggestionModel> 
     blob: Omit<
       CreationAttributes<AgentSuggestionModel>,
       "workspaceId" | "agentConfigurationId"
-    >,
-    { transaction }: { transaction?: Transaction } = {}
+    >
   ): Promise<AgentSuggestionResource> {
     const owner = auth.getNonNullableWorkspace();
 
@@ -135,14 +135,11 @@ export class AgentSuggestionResource extends BaseResource<AgentSuggestionModel> 
       throw new Error("User does not have permission to edit this agent");
     }
 
-    const suggestion = await AgentSuggestionModel.create(
-      {
-        ...blob,
-        agentConfigurationId: agentConfiguration.id,
-        workspaceId: owner.id,
-      },
-      { transaction }
-    );
+    const suggestion = await AgentSuggestionModel.create({
+      ...blob,
+      agentConfigurationId: agentConfiguration.id,
+      workspaceId: owner.id,
+    });
 
     return new this(
       AgentSuggestionModel,

--- a/front/migrations/20260203_migrate_suggestion_tools_skills_format.ts
+++ b/front/migrations/20260203_migrate_suggestion_tools_skills_format.ts
@@ -1,330 +1,49 @@
-import type { Logger } from "pino";
-import { z } from "zod";
-
-import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { Authenticator } from "@app/lib/auth";
 import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
-import { withTransaction } from "@app/lib/utils/sql_utils";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import { makeScript } from "@app/scripts/helpers";
 import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
-import type { LightWorkspaceType, SuggestionPayload } from "@app/types";
-import {
-  isSkillsSuggestion,
-  isToolsSuggestion,
-} from "@app/types/suggestions/agent_suggestion";
+import type { LightWorkspaceType } from "@app/types";
 
 /**
- * This migration converts tool and skill suggestions from the legacy format
- * (arrays of additions/deletions) to the new single-item format (action + toolId/skillId).
- *
- * For each legacy suggestion with multiple items, we create multiple new suggestions.
- * The old suggestion is deleted and new ones are created.
- *
- * Legacy tools format:
- * { additions: [{ id: "toolId", additionalConfiguration?: {} }], deletions: ["toolId"] }
- *
- * New tools format:
- * { action: "add" | "remove", toolId: "toolId", additionalConfiguration?: {} }
- *
- * Legacy skills format:
- * { additions: ["skillId"], deletions: ["skillId"] }
- *
- * New skills format:
- * { action: "add" | "remove", skillId: "skillId" }
+ * This migration deletes all tool and skill suggestions.
+ * The format has changed from arrays to single-item suggestions,
+ * and we simply delete the old ones rather than migrating them.
  */
 
-// Legacy schemas for validation.
-const LegacyToolAdditionSchema = z.object({
-  id: z.string(),
-  additionalConfiguration: z.record(z.unknown()).optional(),
-});
-
-const LegacyToolsSuggestionSchema = z.object({
-  additions: z.array(LegacyToolAdditionSchema).optional(),
-  deletions: z.array(z.string()).optional(),
-});
-
-const LegacySkillsSuggestionSchema = z.object({
-  additions: z.array(z.string()).optional(),
-  deletions: z.array(z.string()).optional(),
-});
-
-function isLegacyToolsSuggestion(data: unknown): boolean {
-  const result = LegacyToolsSuggestionSchema.safeParse(data);
-  if (!result.success) {
-    return false;
-  }
-  // Check it's actually in the legacy format (has additions or deletions arrays).
-  return "additions" in result.data || "deletions" in result.data;
-}
-
-function isLegacySkillsSuggestion(data: unknown): boolean {
-  const result = LegacySkillsSuggestionSchema.safeParse(data);
-  if (!result.success) {
-    return false;
-  }
-  // Check it's actually in the legacy format (has additions or deletions arrays).
-  return "additions" in result.data || "deletions" in result.data;
-}
-
 interface MigrationResult {
-  processed: number;
   deleted: number;
-  created: number;
-  skipped: number;
-  errors: number;
 }
 
-async function migrateWorkspaceSuggestions(
+async function deleteToolsAndSkillsSuggestions(
   workspace: LightWorkspaceType,
   {
     execute,
-    logger: parentLogger,
   }: {
     execute: boolean;
-    logger: Logger;
   }
 ): Promise<MigrationResult> {
-  const logger = parentLogger.child({ workspaceId: workspace.sId });
   const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
 
   const result: MigrationResult = {
-    processed: 0,
     deleted: 0,
-    created: 0,
-    skipped: 0,
-    errors: 0,
   };
 
-  // Fetch all suggestions and filter by kind.
-  const allWorkspaceSuggestions = await AgentSuggestionResource.listAll(auth);
-  const allSuggestions = allWorkspaceSuggestions.filter(
+  const allSuggestions = await AgentSuggestionResource.listAll(auth);
+  const suggestionsToDelete = allSuggestions.filter(
     (s) => s.kind === "tools" || s.kind === "skills"
   );
 
-  if (allSuggestions.length === 0) {
+  if (suggestionsToDelete.length === 0) {
     return result;
   }
 
-  logger.info(
-    {
-      count: allSuggestions.length,
-    },
-    "Found suggestions to process"
-  );
-
-  for (const suggestion of allSuggestions) {
-    result.processed++;
-
-    try {
-      if (suggestion.kind === "tools") {
-        // Check if already in new format.
-        if (isToolsSuggestion(suggestion.suggestion)) {
-          logger.info(
-            { id: suggestion.id, kind: "tools" },
-            "Already in new format, skipping"
-          );
-          result.skipped++;
-          continue;
-        }
-
-        // Validate it's in legacy format.
-        if (!isLegacyToolsSuggestion(suggestion.suggestion)) {
-          logger.error(
-            { id: suggestion.id, suggestion: suggestion.suggestion },
-            "Unknown tools suggestion format"
-          );
-          result.errors++;
-          continue;
-        }
-
-        const legacyData = LegacyToolsSuggestionSchema.parse(
-          suggestion.suggestion
-        );
-        const additions = legacyData.additions ?? [];
-        const deletions = legacyData.deletions ?? [];
-
-        // Build all new suggestions.
-        const newSuggestions: Array<SuggestionPayload> = [];
-
-        for (const addition of additions) {
-          newSuggestions.push({
-            action: "add",
-            toolId: addition.id,
-            ...(addition.additionalConfiguration && {
-              additionalConfiguration: addition.additionalConfiguration,
-            }),
-          });
-        }
-
-        for (const deletion of deletions) {
-          newSuggestions.push({
-            action: "remove",
-            toolId: deletion,
-          });
-        }
-
-        logger.info(
-          {
-            id: suggestion.id,
-            oldFormat: legacyData,
-            newSuggestionsCount: newSuggestions.length,
-          },
-          "Migrating tools suggestion"
-        );
-
-        if (execute) {
-          // Get agent configuration to create new suggestions.
-          const agentConfig = await getAgentConfiguration(auth, {
-            agentId: suggestion.agentConfigurationSId,
-            variant: "light",
-          });
-
-          if (!agentConfig) {
-            logger.error(
-              { agentSId: suggestion.agentConfigurationSId },
-              "Agent configuration not found, skipping"
-            );
-            result.errors++;
-            continue;
-          }
-
-          // Wrap delete + create in a transaction.
-          await withTransaction(async (transaction) => {
-            // Delete old suggestion.
-            await suggestion.delete(auth, { transaction });
-            result.deleted++;
-
-            // Create new suggestions.
-            for (const newSuggestion of newSuggestions) {
-              await AgentSuggestionResource.createSuggestionForAgent(
-                auth,
-                agentConfig,
-                {
-                  kind: "tools",
-                  suggestion: newSuggestion,
-                  analysis: suggestion.analysis,
-                  state: suggestion.state,
-                  source: suggestion.source,
-                },
-                { transaction }
-              );
-              result.created++;
-            }
-          });
-        } else {
-          result.deleted++;
-          result.created += newSuggestions.length;
-        }
-      } else if (suggestion.kind === "skills") {
-        // Check if already in new format.
-        if (isSkillsSuggestion(suggestion.suggestion)) {
-          logger.info(
-            { id: suggestion.id, kind: "skills" },
-            "Already in new format, skipping"
-          );
-          result.skipped++;
-          continue;
-        }
-
-        // Validate it's in legacy format.
-        if (!isLegacySkillsSuggestion(suggestion.suggestion)) {
-          logger.error(
-            { id: suggestion.id, suggestion: suggestion.suggestion },
-            "Unknown skills suggestion format"
-          );
-          result.errors++;
-          continue;
-        }
-
-        const legacyData = LegacySkillsSuggestionSchema.parse(
-          suggestion.suggestion
-        );
-        const additions = legacyData.additions ?? [];
-        const deletions = legacyData.deletions ?? [];
-
-        // Build all new suggestions.
-        const newSuggestions: Array<{
-          action: "add" | "remove";
-          skillId: string;
-        }> = [];
-
-        for (const addition of additions) {
-          newSuggestions.push({
-            action: "add",
-            skillId: addition,
-          });
-        }
-
-        for (const deletion of deletions) {
-          newSuggestions.push({
-            action: "remove",
-            skillId: deletion,
-          });
-        }
-
-        logger.info(
-          {
-            id: suggestion.id,
-            oldFormat: legacyData,
-            newSuggestionsCount: newSuggestions.length,
-          },
-          "Migrating skills suggestion"
-        );
-
-        if (execute) {
-          // Get agent configuration to create new suggestions.
-          const agentConfig = await getAgentConfiguration(auth, {
-            agentId: suggestion.agentConfigurationSId,
-            variant: "light",
-          });
-
-          if (!agentConfig) {
-            logger.error(
-              { agentSId: suggestion.agentConfigurationSId },
-              "Agent configuration not found, skipping"
-            );
-            result.errors++;
-            continue;
-          }
-
-          // Wrap delete + create in a transaction.
-          await withTransaction(async (transaction) => {
-            // Delete old suggestion.
-            await suggestion.delete(auth, { transaction });
-            result.deleted++;
-
-            // Create new suggestions.
-            for (const newSuggestion of newSuggestions) {
-              await AgentSuggestionResource.createSuggestionForAgent(
-                auth,
-                agentConfig,
-                {
-                  kind: "skills",
-                  suggestion: newSuggestion,
-                  analysis: suggestion.analysis,
-                  state: suggestion.state,
-                  source: suggestion.source,
-                },
-                { transaction }
-              );
-              result.created++;
-            }
-          });
-        } else {
-          result.deleted++;
-          result.created += newSuggestions.length;
-        }
-      }
-    } catch (error) {
-      logger.error(
-        { id: suggestion.id, error: String(error) },
-        "Error migrating suggestion"
-      );
-      result.errors++;
+  for (const suggestion of suggestionsToDelete) {
+    if (execute) {
+      await suggestion.delete(auth);
     }
+    result.deleted++;
   }
 
   return result;
@@ -335,14 +54,10 @@ makeScript(
     workspaceId: { type: "string", required: false },
   },
   async ({ workspaceId, execute }, logger) => {
-    logger.info("Starting tools/skills suggestion format migration");
+    logger.info("Starting tools/skills suggestion deletion");
 
     const totals: MigrationResult = {
-      processed: 0,
       deleted: 0,
-      created: 0,
-      skipped: 0,
-      errors: 0,
     };
 
     if (workspaceId) {
@@ -350,45 +65,28 @@ makeScript(
       if (!workspace) {
         throw new Error(`Workspace not found: ${workspaceId}`);
       }
-      const result = await migrateWorkspaceSuggestions(
+      const result = await deleteToolsAndSkillsSuggestions(
         renderLightWorkspaceType({ workspace }),
-        { execute, logger }
+        { execute }
       );
-      totals.processed += result.processed;
       totals.deleted += result.deleted;
-      totals.created += result.created;
-      totals.skipped += result.skipped;
-      totals.errors += result.errors;
     } else {
       await runOnAllWorkspaces(
         async (workspace) => {
-          const result = await migrateWorkspaceSuggestions(workspace, {
+          const result = await deleteToolsAndSkillsSuggestions(workspace, {
             execute,
-            logger,
           });
-          totals.processed += result.processed;
           totals.deleted += result.deleted;
-          totals.created += result.created;
-          totals.skipped += result.skipped;
-          totals.errors += result.errors;
         },
-        { concurrency: 2 }
+        { concurrency: 4 }
       );
     }
 
     logger.info(
       {
-        processed: totals.processed,
         deleted: totals.deleted,
-        created: totals.created,
-        skipped: totals.skipped,
-        errors: totals.errors,
       },
       "Migration completed"
     );
-
-    if (totals.errors > 0) {
-      logger.warn("Some suggestions could not be migrated, check logs above");
-    }
   }
 );

--- a/front/migrations/20260203_migrate_suggestion_tools_skills_format.ts
+++ b/front/migrations/20260203_migrate_suggestion_tools_skills_format.ts
@@ -1,0 +1,394 @@
+import type { Logger } from "pino";
+import { z } from "zod";
+
+import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import { Authenticator } from "@app/lib/auth";
+import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { withTransaction } from "@app/lib/utils/sql_utils";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
+import { makeScript } from "@app/scripts/helpers";
+import { runOnAllWorkspaces } from "@app/scripts/workspace_helpers";
+import type { LightWorkspaceType, SuggestionPayload } from "@app/types";
+import {
+  isSkillsSuggestion,
+  isToolsSuggestion,
+} from "@app/types/suggestions/agent_suggestion";
+
+/**
+ * This migration converts tool and skill suggestions from the legacy format
+ * (arrays of additions/deletions) to the new single-item format (action + toolId/skillId).
+ *
+ * For each legacy suggestion with multiple items, we create multiple new suggestions.
+ * The old suggestion is deleted and new ones are created.
+ *
+ * Legacy tools format:
+ * { additions: [{ id: "toolId", additionalConfiguration?: {} }], deletions: ["toolId"] }
+ *
+ * New tools format:
+ * { action: "add" | "remove", toolId: "toolId", additionalConfiguration?: {} }
+ *
+ * Legacy skills format:
+ * { additions: ["skillId"], deletions: ["skillId"] }
+ *
+ * New skills format:
+ * { action: "add" | "remove", skillId: "skillId" }
+ */
+
+// Legacy schemas for validation.
+const LegacyToolAdditionSchema = z.object({
+  id: z.string(),
+  additionalConfiguration: z.record(z.unknown()).optional(),
+});
+
+const LegacyToolsSuggestionSchema = z.object({
+  additions: z.array(LegacyToolAdditionSchema).optional(),
+  deletions: z.array(z.string()).optional(),
+});
+
+const LegacySkillsSuggestionSchema = z.object({
+  additions: z.array(z.string()).optional(),
+  deletions: z.array(z.string()).optional(),
+});
+
+function isLegacyToolsSuggestion(data: unknown): boolean {
+  const result = LegacyToolsSuggestionSchema.safeParse(data);
+  if (!result.success) {
+    return false;
+  }
+  // Check it's actually in the legacy format (has additions or deletions arrays).
+  return "additions" in result.data || "deletions" in result.data;
+}
+
+function isLegacySkillsSuggestion(data: unknown): boolean {
+  const result = LegacySkillsSuggestionSchema.safeParse(data);
+  if (!result.success) {
+    return false;
+  }
+  // Check it's actually in the legacy format (has additions or deletions arrays).
+  return "additions" in result.data || "deletions" in result.data;
+}
+
+interface MigrationResult {
+  processed: number;
+  deleted: number;
+  created: number;
+  skipped: number;
+  errors: number;
+}
+
+async function migrateWorkspaceSuggestions(
+  workspace: LightWorkspaceType,
+  {
+    execute,
+    logger: parentLogger,
+  }: {
+    execute: boolean;
+    logger: Logger;
+  }
+): Promise<MigrationResult> {
+  const logger = parentLogger.child({ workspaceId: workspace.sId });
+  const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+  const result: MigrationResult = {
+    processed: 0,
+    deleted: 0,
+    created: 0,
+    skipped: 0,
+    errors: 0,
+  };
+
+  // Fetch all suggestions and filter by kind.
+  const allWorkspaceSuggestions = await AgentSuggestionResource.listAll(auth);
+  const allSuggestions = allWorkspaceSuggestions.filter(
+    (s) => s.kind === "tools" || s.kind === "skills"
+  );
+
+  if (allSuggestions.length === 0) {
+    return result;
+  }
+
+  logger.info(
+    {
+      count: allSuggestions.length,
+    },
+    "Found suggestions to process"
+  );
+
+  for (const suggestion of allSuggestions) {
+    result.processed++;
+
+    try {
+      if (suggestion.kind === "tools") {
+        // Check if already in new format.
+        if (isToolsSuggestion(suggestion.suggestion)) {
+          logger.info(
+            { id: suggestion.id, kind: "tools" },
+            "Already in new format, skipping"
+          );
+          result.skipped++;
+          continue;
+        }
+
+        // Validate it's in legacy format.
+        if (!isLegacyToolsSuggestion(suggestion.suggestion)) {
+          logger.error(
+            { id: suggestion.id, suggestion: suggestion.suggestion },
+            "Unknown tools suggestion format"
+          );
+          result.errors++;
+          continue;
+        }
+
+        const legacyData = LegacyToolsSuggestionSchema.parse(
+          suggestion.suggestion
+        );
+        const additions = legacyData.additions ?? [];
+        const deletions = legacyData.deletions ?? [];
+
+        // Build all new suggestions.
+        const newSuggestions: Array<SuggestionPayload> = [];
+
+        for (const addition of additions) {
+          newSuggestions.push({
+            action: "add",
+            toolId: addition.id,
+            ...(addition.additionalConfiguration && {
+              additionalConfiguration: addition.additionalConfiguration,
+            }),
+          });
+        }
+
+        for (const deletion of deletions) {
+          newSuggestions.push({
+            action: "remove",
+            toolId: deletion,
+          });
+        }
+
+        logger.info(
+          {
+            id: suggestion.id,
+            oldFormat: legacyData,
+            newSuggestionsCount: newSuggestions.length,
+          },
+          "Migrating tools suggestion"
+        );
+
+        if (execute) {
+          // Get agent configuration to create new suggestions.
+          const agentConfig = await getAgentConfiguration(auth, {
+            agentId: suggestion.agentConfigurationSId,
+            variant: "light",
+          });
+
+          if (!agentConfig) {
+            logger.error(
+              { agentSId: suggestion.agentConfigurationSId },
+              "Agent configuration not found, skipping"
+            );
+            result.errors++;
+            continue;
+          }
+
+          // Wrap delete + create in a transaction.
+          await withTransaction(async (transaction) => {
+            // Delete old suggestion.
+            await suggestion.delete(auth, { transaction });
+            result.deleted++;
+
+            // Create new suggestions.
+            for (const newSuggestion of newSuggestions) {
+              await AgentSuggestionResource.createSuggestionForAgent(
+                auth,
+                agentConfig,
+                {
+                  kind: "tools",
+                  suggestion: newSuggestion,
+                  analysis: suggestion.analysis,
+                  state: suggestion.state,
+                  source: suggestion.source,
+                },
+                { transaction }
+              );
+              result.created++;
+            }
+          });
+        } else {
+          result.deleted++;
+          result.created += newSuggestions.length;
+        }
+      } else if (suggestion.kind === "skills") {
+        // Check if already in new format.
+        if (isSkillsSuggestion(suggestion.suggestion)) {
+          logger.info(
+            { id: suggestion.id, kind: "skills" },
+            "Already in new format, skipping"
+          );
+          result.skipped++;
+          continue;
+        }
+
+        // Validate it's in legacy format.
+        if (!isLegacySkillsSuggestion(suggestion.suggestion)) {
+          logger.error(
+            { id: suggestion.id, suggestion: suggestion.suggestion },
+            "Unknown skills suggestion format"
+          );
+          result.errors++;
+          continue;
+        }
+
+        const legacyData = LegacySkillsSuggestionSchema.parse(
+          suggestion.suggestion
+        );
+        const additions = legacyData.additions ?? [];
+        const deletions = legacyData.deletions ?? [];
+
+        // Build all new suggestions.
+        const newSuggestions: Array<{
+          action: "add" | "remove";
+          skillId: string;
+        }> = [];
+
+        for (const addition of additions) {
+          newSuggestions.push({
+            action: "add",
+            skillId: addition,
+          });
+        }
+
+        for (const deletion of deletions) {
+          newSuggestions.push({
+            action: "remove",
+            skillId: deletion,
+          });
+        }
+
+        logger.info(
+          {
+            id: suggestion.id,
+            oldFormat: legacyData,
+            newSuggestionsCount: newSuggestions.length,
+          },
+          "Migrating skills suggestion"
+        );
+
+        if (execute) {
+          // Get agent configuration to create new suggestions.
+          const agentConfig = await getAgentConfiguration(auth, {
+            agentId: suggestion.agentConfigurationSId,
+            variant: "light",
+          });
+
+          if (!agentConfig) {
+            logger.error(
+              { agentSId: suggestion.agentConfigurationSId },
+              "Agent configuration not found, skipping"
+            );
+            result.errors++;
+            continue;
+          }
+
+          // Wrap delete + create in a transaction.
+          await withTransaction(async (transaction) => {
+            // Delete old suggestion.
+            await suggestion.delete(auth, { transaction });
+            result.deleted++;
+
+            // Create new suggestions.
+            for (const newSuggestion of newSuggestions) {
+              await AgentSuggestionResource.createSuggestionForAgent(
+                auth,
+                agentConfig,
+                {
+                  kind: "skills",
+                  suggestion: newSuggestion,
+                  analysis: suggestion.analysis,
+                  state: suggestion.state,
+                  source: suggestion.source,
+                },
+                { transaction }
+              );
+              result.created++;
+            }
+          });
+        } else {
+          result.deleted++;
+          result.created += newSuggestions.length;
+        }
+      }
+    } catch (error) {
+      logger.error(
+        { id: suggestion.id, error: String(error) },
+        "Error migrating suggestion"
+      );
+      result.errors++;
+    }
+  }
+
+  return result;
+}
+
+makeScript(
+  {
+    workspaceId: { type: "string", required: false },
+  },
+  async ({ workspaceId, execute }, logger) => {
+    logger.info("Starting tools/skills suggestion format migration");
+
+    const totals: MigrationResult = {
+      processed: 0,
+      deleted: 0,
+      created: 0,
+      skipped: 0,
+      errors: 0,
+    };
+
+    if (workspaceId) {
+      const workspace = await WorkspaceResource.fetchById(workspaceId);
+      if (!workspace) {
+        throw new Error(`Workspace not found: ${workspaceId}`);
+      }
+      const result = await migrateWorkspaceSuggestions(
+        renderLightWorkspaceType({ workspace }),
+        { execute, logger }
+      );
+      totals.processed += result.processed;
+      totals.deleted += result.deleted;
+      totals.created += result.created;
+      totals.skipped += result.skipped;
+      totals.errors += result.errors;
+    } else {
+      await runOnAllWorkspaces(
+        async (workspace) => {
+          const result = await migrateWorkspaceSuggestions(workspace, {
+            execute,
+            logger,
+          });
+          totals.processed += result.processed;
+          totals.deleted += result.deleted;
+          totals.created += result.created;
+          totals.skipped += result.skipped;
+          totals.errors += result.errors;
+        },
+        { concurrency: 2 }
+      );
+    }
+
+    logger.info(
+      {
+        processed: totals.processed,
+        deleted: totals.deleted,
+        created: totals.created,
+        skipped: totals.skipped,
+        errors: totals.errors,
+      },
+      "Migration completed"
+    );
+
+    if (totals.errors > 0) {
+      logger.warn("Some suggestions could not be migrated, check logs above");
+    }
+  }
+);

--- a/front/scripts/seed/copilot/assets/suggestions.json
+++ b/front/scripts/seed/copilot/assets/suggestions.json
@@ -3,11 +3,8 @@
     "agentName": "MeteoWithSuggestions",
     "kind": "tools",
     "suggestion": {
-      "additions": [
-        {
-          "id": "web_search_&_browse"
-        }
-      ]
+      "action": "add",
+      "toolId": "web_search_&_browse"
     },
     "analysis": "The agent could benefit from web search capabilities to provide real-time weather information instead of relying only on training data."
   },
@@ -41,7 +38,8 @@
     "agentName": "MeteoWithSuggestions",
     "kind": "skills",
     "suggestion": {
-      "additions": ["frames"]
+      "action": "add",
+      "skillId": "frames"
     },
     "analysis": "Adding the Frames skill would allow the agent to create interactive weather visualizations like temperature charts, precipitation graphs, and forecast timelines."
   }

--- a/front/scripts/seed/factories/seedAgentSuggestions.ts
+++ b/front/scripts/seed/factories/seedAgentSuggestions.ts
@@ -6,10 +6,7 @@ import {
 import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
-import type {
-  ToolAdditionType,
-  ToolsSuggestionType,
-} from "@app/types/suggestions/agent_suggestion";
+import type { ToolsSuggestionType } from "@app/types/suggestions/agent_suggestion";
 
 import type { CreatedAgent, SeedContext, SuggestionAsset } from "./types";
 
@@ -28,13 +25,8 @@ async function resolveMCPServerViewIds(
 ): Promise<ToolsSuggestionType> {
   const { auth } = ctx;
 
-  if (!suggestion.additions || suggestion.additions.length === 0) {
-    return suggestion;
-  }
-
   // Filter additions that are internal MCP server names that need resolution
-  const serverNamesToResolve = suggestion.additions
-    .map((a) => a.id)
+  const serverNamesToResolve = [suggestion.toolId]
     .filter((id) => isInternalMCPServerName(id))
     .filter((id): id is AutoInternalMCPServerNameType =>
       isAutoInternalMCPServerName(id)
@@ -61,20 +53,11 @@ async function resolveMCPServerViewIds(
   }
 
   // Resolve the tool IDs
-  const resolvedAdditions: ToolAdditionType[] = suggestion.additions.map(
-    (addition) => {
-      const resolvedId = serverNameToViewSId.get(addition.id);
-      if (resolvedId) {
-        return { ...addition, id: resolvedId };
-      }
-      // If not found in the map, keep the original ID (it might already be a valid sId)
-      return addition;
-    }
-  );
+  const resolvedToolId = serverNameToViewSId.get(suggestion.toolId);
 
   return {
     ...suggestion,
-    additions: resolvedAdditions,
+    toolId: resolvedToolId ?? suggestion.toolId,
   };
 }
 

--- a/front/scripts/seed/factories/seedAgentSuggestions.ts
+++ b/front/scripts/seed/factories/seedAgentSuggestions.ts
@@ -54,10 +54,15 @@ async function resolveMCPServerViewIds(
 
   // Resolve the tool IDs
   const resolvedToolId = serverNameToViewSId.get(suggestion.toolId);
+  if (resolvedToolId === undefined) {
+    throw new Error(
+      `Failed to resolve MCP server view ID for tool "${suggestion.toolId}"`
+    );
+  }
 
   return {
     ...suggestion,
-    toolId: resolvedToolId ?? suggestion.toolId,
+    toolId: resolvedToolId,
   };
 }
 
@@ -68,6 +73,11 @@ export async function seedAgentSuggestions(
 ): Promise<void> {
   const { auth, execute, logger } = ctx;
   const { agents } = options;
+
+  if (suggestionAssets.some((s) => s.kind === "tools")) {
+    // To seed tool suggestions we need the MCP server views to exist.
+    await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
+  }
 
   for (const suggestionAsset of suggestionAssets) {
     const agent = agents.get(suggestionAsset.agentName);

--- a/front/tests/utils/AgentSuggestionFactory.ts
+++ b/front/tests/utils/AgentSuggestionFactory.ts
@@ -55,13 +55,11 @@ export class AgentSuggestionFactory {
       {
         kind: "tools",
         suggestion: overrides.suggestion ?? {
-          additions: [
-            { id: "notion", additionalConfiguration: { database: "tasks" } },
-            { id: "slack" },
-          ],
-          deletions: ["deprecated_tool"],
+          action: "add",
+          toolId: "notion",
+          additionalConfiguration: { database: "tasks" },
         },
-        analysis: overrides.analysis ?? "Added useful integrations",
+        analysis: overrides.analysis ?? "Added useful integration",
         state: overrides.state ?? "pending",
         source: overrides.source ?? "reinforcement",
       }
@@ -84,9 +82,10 @@ export class AgentSuggestionFactory {
       {
         kind: "skills",
         suggestion: overrides.suggestion ?? {
-          additions: ["code_review", "summarization"],
+          action: "add",
+          skillId: "code_review",
         },
-        analysis: overrides.analysis ?? "Added skills for better assistance",
+        analysis: overrides.analysis ?? "Added skill for better assistance",
         state: overrides.state ?? "pending",
         source: overrides.source ?? "copilot",
       }

--- a/front/types/suggestions/agent_suggestion.ts
+++ b/front/types/suggestions/agent_suggestion.ts
@@ -28,19 +28,21 @@ export const AGENT_SUGGESTION_SOURCES = ["reinforcement", "copilot"] as const;
 
 export type AgentSuggestionSource = (typeof AGENT_SUGGESTION_SOURCES)[number];
 
-const ToolAdditionSchema = z.object({
-  id: z.string(),
-  additionalConfiguration: z.record(z.unknown()).optional(),
-});
-
-const ToolsSuggestionSchema = z.object({
-  additions: z.array(ToolAdditionSchema).optional(),
-  deletions: z.array(z.string()).optional(),
-});
+const ToolsSuggestionSchema = z.union([
+  z.object({
+    action: z.literal("add"),
+    toolId: z.string(),
+    additionalConfiguration: z.record(z.unknown()).optional(),
+  }),
+  z.object({
+    action: z.literal("remove"),
+    toolId: z.string(),
+  }),
+]);
 
 const SkillsSuggestionSchema = z.object({
-  additions: z.array(z.string()).optional(),
-  deletions: z.array(z.string()).optional(),
+  action: z.enum(["add", "remove"]),
+  skillId: z.string(),
 });
 
 const InstructionsSuggestionSchema = z.object({
@@ -59,7 +61,6 @@ const ModelSuggestionSchema = z.object({
   reasoningEffort: z.enum(REASONING_EFFORTS).optional(),
 });
 
-export type ToolAdditionType = z.infer<typeof ToolAdditionSchema>;
 export type ToolsSuggestionType = z.infer<typeof ToolsSuggestionSchema>;
 export type SkillsSuggestionType = z.infer<typeof SkillsSuggestionSchema>;
 export type InstructionsSuggestionType = z.infer<
@@ -132,13 +133,11 @@ export type AgentInstructionsSuggestionType = Extract<
 >;
 
 export interface ToolSuggestionRelations {
-  additions: MCPServerViewType[];
-  deletions: MCPServerViewType[];
+  tool: MCPServerViewType;
 }
 
 export interface SkillSuggestionRelations {
-  additions: SkillType[];
-  deletions: SkillType[];
+  skill: SkillType;
 }
 
 export interface ModelSuggestionRelations {


### PR DESCRIPTION
## Description

 - Only allow one skill or tool per suggestion
 - There is a migration script to migrate existing suggestion by releting and reacreating them

## Tests

 - Manually runned the migration locally
 - Migrated the unit tests

## Risk

Ok, we only have one workspace

## Deploy Plan

deploy front
deactivate the feature flag on Dust workspace
Run migration
re-activate the feature flag

