### PR TITLE
Remove package-lock.json dependency from publish-sparkle workflow

### DIFF
--- a/.github/workflows/publish-sparkle.yml
+++ b/.github/workflows/publish-sparkle.yml
@@ -63,7 +63,7 @@ jobs:
         run: |
           cd sparkle
           CURRENT_VERSION=$(npm version ${{ github.event.inputs.release_type }} --no-git-tag-version)
-          git add package.json
+          git add package.json ../package-lock.json
           git commit -m "chore(release): bump sparkle version to ${CURRENT_VERSION} [skip ci]"
           echo "Created version ${CURRENT_VERSION}"
 

--- a/.github/workflows/publish-sparkle.yml
+++ b/.github/workflows/publish-sparkle.yml
@@ -63,7 +63,7 @@ jobs:
         run: |
           cd sparkle
           CURRENT_VERSION=$(npm version ${{ github.event.inputs.release_type }} --no-git-tag-version)
-          git add package.json package-lock.json
+          git add package.json
           git commit -m "chore(release): bump sparkle version to ${CURRENT_VERSION} [skip ci]"
           echo "Created version ${CURRENT_VERSION}"
 


### PR DESCRIPTION
## Description

`publish-sparkle` workflow seems broken because we are trying to add `package-lock.json` which isn't there after [this PR](https://github.com/dust-tt/dust/pull/19948).

This PR removes the dependency

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

low
## Deploy Plan

sparkle