### PR TITLE
Allow override of NEXT_PUBLIC_DUST_APP_URL on front-edge

### DIFF
--- a/.github/actions/build-image/action.yml
+++ b/.github/actions/build-image/action.yml
@@ -51,6 +51,10 @@ inputs:
   contentful_access_token:
     description: "Contentful access token"
     required: false
+  override_dust_app_url:
+    description: "Override NEXT_PUBLIC_DUST_APP_URL with https://app.dust.tt (front-edge only)"
+    required: false
+    default: "false"
 
 outputs:
   current_version:
@@ -155,6 +159,11 @@ runs:
           if [[ -n "${{ inputs.contentful_access_token }}" ]]; then
             build_args+=("--build-arg CONTENTFUL_ACCESS_TOKEN=${{ inputs.contentful_access_token }}")
           fi
+        fi
+
+        # Override NEXT_PUBLIC_DUST_APP_URL for front-edge if requested
+        if [[ "$COMPONENT" == "front-edge" && "${{ inputs.override_dust_app_url }}" == "true" ]]; then
+          build_args+=("--build-arg NEXT_PUBLIC_DUST_APP_URL=https://app.dust.tt")
         fi
 
         # Special handling for front component, build both front and workers targets

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,6 +43,11 @@ on:
         options:
           - "us"
           - "eu"
+      override_dust_app_url:
+        description: "Override NEXT_PUBLIC_DUST_APP_URL with https://app.dust.tt (front-edge only)"
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -163,6 +168,7 @@ jobs:
           contentful_space_id: ${{ secrets.CONTENTFUL_SPACE_ID }}
           contentful_access_token: ${{ secrets.CONTENTFUL_ACCESS_TOKEN }}
           workload_identity_provider: "projects/357744735673/locations/global/workloadIdentityPools/github-pool-apps/providers/github-provider-apps"
+          override_dust_app_url: ${{ inputs.override_dust_app_url }}
 
       - name: Notify build success
         uses: ./.github/actions/slack-notify


### PR DESCRIPTION
## Description

Similar to https://github.com/dust-tt/dust/pull/21069 , but server-side, for front-edge only, as an option. When front-edge is built with this, it will generate links to app.dust.tt instead of using [eu.]dust.tt.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk


## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

