### PR TITLE
[front] Disambiguate SharePoint top-level folders by site

### DIFF
--- a/front/components/agent_builder/capabilities/knowledge/DataSourceNodeTable.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/DataSourceNodeTable.tsx
@@ -62,7 +62,7 @@ export function DataSourceNodeTable({ viewType }: DataSourceNodeTableProps) {
         return {
           id: node.internalId,
           title: getDisplayTitleForDataSourceViewContentNode(node, {
-            prefixSiteName: isTopLevelInView,
+            disambiguate: isTopLevelInView,
           }),
           icon: getVisualForDataSourceViewContentNode(node),
           onClick: node.expandable ? () => addNodeEntry(node) : undefined,

--- a/front/components/agent_builder/capabilities/knowledge/DataSourceNodeTable.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/DataSourceNodeTable.tsx
@@ -20,16 +20,6 @@ interface DataSourceNodeTableProps {
   viewType: ContentNodesViewType;
 }
 
-function getDuplicateTitles(nodes: { title: string }[]): Set<string> {
-  const counts = new Map<string, number>();
-  for (const node of nodes) {
-    counts.set(node.title, (counts.get(node.title) ?? 0) + 1);
-  }
-  return new Set(
-    [...counts.entries()].filter(([, c]) => c > 1).map(([t]) => t)
-  );
-}
-
 export function DataSourceNodeTable({ viewType }: DataSourceNodeTableProps) {
   const { owner } = useAgentBuilderContext();
   const { navigationHistory, addNodeEntry } = useDataSourceBuilderContext();
@@ -66,19 +56,13 @@ export function DataSourceNodeTable({ viewType }: DataSourceNodeTableProps) {
     }
   }, [hasNextPage, isLoadingMore, loadMore]);
 
-  const duplicateTitles = useMemo(() => {
-    return isTopLevelInView
-      ? getDuplicateTitles(childNodes)
-      : new Set<string>();
-  }, [childNodes, isTopLevelInView]);
-
   const listItems: DataSourceListItem[] = useMemo(
     () =>
       childNodes.map((node) => {
         return {
           id: node.internalId,
           title: getDisplayTitleForDataSourceViewContentNode(node, {
-            prefixSiteName: isTopLevelInView && duplicateTitles.has(node.title),
+            prefixSiteName: isTopLevelInView,
           }),
           icon: getVisualForDataSourceViewContentNode(node),
           onClick: node.expandable ? () => addNodeEntry(node) : undefined,
@@ -89,7 +73,7 @@ export function DataSourceNodeTable({ viewType }: DataSourceNodeTableProps) {
           },
         };
       }),
-    [childNodes, addNodeEntry, duplicateTitles, isTopLevelInView]
+    [childNodes, addNodeEntry, isTopLevelInView]
   );
 
   if (isNodesLoading) {

--- a/front/components/agent_builder/capabilities/knowledge/DataSourceSearchResults.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/DataSourceSearchResults.tsx
@@ -240,8 +240,7 @@ export function DataSourceSearchResults({
       return {
         id,
         title: getDisplayTitleForDataSourceViewContentNode(node, {
-          prefixSiteName:
-            node.dataSourceView.dataSource.connectorProvider === "microsoft",
+          disambiguate: true,
         }),
         icon: getVisualForDataSourceViewContentNode(node),
         onClick: node.expandable

--- a/front/components/agent_builder/capabilities/knowledge/DataSourceSearchResults.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/DataSourceSearchResults.tsx
@@ -235,25 +235,13 @@ export function DataSourceSearchResults({
   }, [searchResults]);
 
   const listItems: DataSourceListItem[] = useMemo(() => {
-    const counts = new Map<string, number>();
-    for (const node of searchResults) {
-      if (node.dataSourceView.dataSource.connectorProvider !== "microsoft") {
-        continue;
-      }
-      counts.set(node.title, (counts.get(node.title) ?? 0) + 1);
-    }
-    const duplicateTitles = new Set(
-      [...counts.entries()].filter(([, c]) => c > 1).map(([t]) => t)
-    );
-
     return searchResults.map((node) => {
       const id = `${node.dataSourceView.sId}:${node.internalId}`;
       return {
         id,
         title: getDisplayTitleForDataSourceViewContentNode(node, {
           prefixSiteName:
-            node.dataSourceView.dataSource.connectorProvider === "microsoft" &&
-            duplicateTitles.has(node.title),
+            node.dataSourceView.dataSource.connectorProvider === "microsoft",
         }),
         icon: getVisualForDataSourceViewContentNode(node),
         onClick: node.expandable

--- a/front/components/agent_builder/capabilities/knowledge/DataSourceSearchResults.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/DataSourceSearchResults.tsx
@@ -235,11 +235,26 @@ export function DataSourceSearchResults({
   }, [searchResults]);
 
   const listItems: DataSourceListItem[] = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const node of searchResults) {
+      if (node.dataSourceView.dataSource.connectorProvider !== "microsoft") {
+        continue;
+      }
+      counts.set(node.title, (counts.get(node.title) ?? 0) + 1);
+    }
+    const duplicateTitles = new Set(
+      [...counts.entries()].filter(([, c]) => c > 1).map(([t]) => t)
+    );
+
     return searchResults.map((node) => {
       const id = `${node.dataSourceView.sId}:${node.internalId}`;
       return {
         id,
-        title: getDisplayTitleForDataSourceViewContentNode(node),
+        title: getDisplayTitleForDataSourceViewContentNode(node, {
+          prefixSiteName:
+            node.dataSourceView.dataSource.connectorProvider === "microsoft" &&
+            duplicateTitles.has(node.title),
+        }),
         icon: getVisualForDataSourceViewContentNode(node),
         onClick: node.expandable
           ? () => handleSearchResultClick(node)

--- a/front/components/spaces/SpaceDataSourceViewContentList.tsx
+++ b/front/components/spaces/SpaceDataSourceViewContentList.tsx
@@ -100,7 +100,7 @@ const getTableColumns = ({
     id: "title",
     accessorFn: (row) =>
       getDisplayTitleForDataSourceViewContentNode(row, {
-        prefixSiteName: isTopLevelInView,
+        disambiguate: isTopLevelInView,
       }),
     sortingFn: (a, b, columnId) => {
       const aValue = a.getValue(columnId) as string;

--- a/front/components/spaces/SpaceSideBarMenu.tsx
+++ b/front/components/spaces/SpaceSideBarMenu.tsx
@@ -461,13 +461,13 @@ const SpaceDataSourceViewItem = ({
   owner,
   space,
   node,
-  siblingDuplicateTitles,
+  prefixSiteNameForNode,
 }: {
   item: DataSourceViewType;
   owner: LightWorkspaceType;
   space: SpaceType;
   node?: DataSourceViewContentNode;
-  siblingDuplicateTitles?: Set<string>;
+  prefixSiteNameForNode?: boolean;
 }): ReactElement => {
   const { isDark } = useTheme();
   const { setNavigationSelection } = usePersistedNavigationSelection();
@@ -528,22 +528,9 @@ const SpaceDataSourceViewItem = ({
   const expandableNodes = nodes.filter((node) => node.expandable);
   const hiddenNodesCount = Math.max(0, totalNodesCount - nodes.length);
 
-  const duplicateTitlesForTopLevelChildren = useMemo(() => {
-    if (node) {
-      return undefined;
-    }
-    const counts = new Map<string, number>();
-    for (const child of expandableNodes) {
-      counts.set(child.title, (counts.get(child.title) ?? 0) + 1);
-    }
-    return new Set(
-      [...counts.entries()].filter(([, c]) => c > 1).map(([t]) => t)
-    );
-  }, [expandableNodes, node]);
-
   const label = node
     ? getDisplayTitleForDataSourceViewContentNode(node, {
-        prefixSiteName: siblingDuplicateTitles?.has(node.title) ?? false,
+        prefixSiteName: prefixSiteNameForNode === true,
       })
     : getDataSourceNameFromView(item);
 
@@ -568,14 +555,14 @@ const SpaceDataSourceViewItem = ({
     >
       {isExpanded && (
         <Tree isLoading={isNodesLoading}>
-          {expandableNodes.map((node) => (
+          {expandableNodes.map((childNode) => (
             <SpaceDataSourceViewItem
               item={item}
-              key={node.internalId}
+              key={childNode.internalId}
               owner={owner}
               space={space}
-              node={node}
-              siblingDuplicateTitles={duplicateTitlesForTopLevelChildren}
+              node={childNode}
+              prefixSiteNameForNode={node === undefined}
             />
           ))}
           {hiddenNodesCount > 0 && (

--- a/front/components/spaces/SpaceSideBarMenu.tsx
+++ b/front/components/spaces/SpaceSideBarMenu.tsx
@@ -461,13 +461,13 @@ const SpaceDataSourceViewItem = ({
   owner,
   space,
   node,
-  prefixSiteNameForNode,
+  disambiguateForNode,
 }: {
   item: DataSourceViewType;
   owner: LightWorkspaceType;
   space: SpaceType;
   node?: DataSourceViewContentNode;
-  prefixSiteNameForNode?: boolean;
+  disambiguateForNode?: boolean;
 }): ReactElement => {
   const { isDark } = useTheme();
   const { setNavigationSelection } = usePersistedNavigationSelection();
@@ -530,7 +530,7 @@ const SpaceDataSourceViewItem = ({
 
   const label = node
     ? getDisplayTitleForDataSourceViewContentNode(node, {
-        prefixSiteName: prefixSiteNameForNode === true,
+        disambiguate: disambiguateForNode === true,
       })
     : getDataSourceNameFromView(item);
 
@@ -562,7 +562,7 @@ const SpaceDataSourceViewItem = ({
               owner={owner}
               space={space}
               node={childNode}
-              prefixSiteNameForNode={node === undefined}
+              disambiguateForNode={node === undefined}
             />
           ))}
           {hiddenNodesCount > 0 && (

--- a/front/lib/providers/content_nodes_display.ts
+++ b/front/lib/providers/content_nodes_display.ts
@@ -1,15 +1,16 @@
 import type { DataSourceViewContentNode } from "@app/types";
 
-import { getMicrosoftSharePointRootFolderDisplayTitle } from "./microsoft/content_nodes_display";
+import { getMicrosoftSharePointDisplayTitle } from "./microsoft/content_nodes_display";
 
 export function getDisplayTitleForDataSourceViewContentNode(
-  node: DataSourceViewContentNode
+  node: DataSourceViewContentNode,
+  { prefixSiteName }: { prefixSiteName?: boolean } = {}
 ): string {
   const provider = node.dataSourceView.dataSource.connectorProvider;
 
   switch (provider) {
     case "microsoft":
-      return getMicrosoftSharePointRootFolderDisplayTitle(node);
+      return getMicrosoftSharePointDisplayTitle(node, { prefixSiteName });
     default:
       return node.title;
   }

--- a/front/lib/providers/content_nodes_display.ts
+++ b/front/lib/providers/content_nodes_display.ts
@@ -4,13 +4,13 @@ import { getMicrosoftSharePointDisplayTitle } from "./microsoft/content_nodes_di
 
 export function getDisplayTitleForDataSourceViewContentNode(
   node: DataSourceViewContentNode,
-  { prefixSiteName }: { prefixSiteName?: boolean } = {}
+  { disambiguate }: { disambiguate?: boolean } = {}
 ): string {
   const provider = node.dataSourceView.dataSource.connectorProvider;
 
   switch (provider) {
     case "microsoft":
-      return getMicrosoftSharePointDisplayTitle(node, { prefixSiteName });
+      return getMicrosoftSharePointDisplayTitle(node, { disambiguate });
     default:
       return node.title;
   }

--- a/front/lib/providers/microsoft/content_nodes_display.ts
+++ b/front/lib/providers/microsoft/content_nodes_display.ts
@@ -40,9 +40,3 @@ export function getMicrosoftSharePointDisplayTitle(
   const siteName = extractSharePointSiteNameFromSourceUrl(node.sourceUrl);
   return siteName ? `${siteName} → ${node.title}` : node.title;
 }
-
-export function getMicrosoftSharePointRootFolderDisplayTitle(
-  node: DataSourceViewContentNode
-): string {
-  return getMicrosoftSharePointDisplayTitle(node);
-}

--- a/front/lib/providers/microsoft/content_nodes_display.ts
+++ b/front/lib/providers/microsoft/content_nodes_display.ts
@@ -21,19 +21,18 @@ function extractSharePointSiteNameFromSourceUrl(
 }
 
 type MicrosoftSharePointDisplayTitleOptions = {
-  prefixSiteName?: boolean;
+  disambiguate?: boolean;
 };
 
 export function getMicrosoftSharePointDisplayTitle(
   node: DataSourceViewContentNode,
-  { prefixSiteName }: MicrosoftSharePointDisplayTitleOptions = {}
+  { disambiguate }: MicrosoftSharePointDisplayTitleOptions = {}
 ): string {
   if (node.type !== "folder" || !node.sourceUrl) {
     return node.title;
   }
 
-  const shouldPrefix =
-    prefixSiteName === true || node.parentInternalId === null;
+  const shouldPrefix = disambiguate === true || node.parentInternalId === null;
   if (!shouldPrefix) {
     return node.title;
   }

--- a/front/lib/providers/microsoft/content_nodes_display.ts
+++ b/front/lib/providers/microsoft/content_nodes_display.ts
@@ -20,17 +20,30 @@ function extractSharePointSiteNameFromSourceUrl(
   }
 }
 
-export function getMicrosoftSharePointRootFolderDisplayTitle(
-  node: DataSourceViewContentNode
+type MicrosoftSharePointDisplayTitleOptions = {
+  prefixSiteName?: boolean;
+};
+
+export function getMicrosoftSharePointDisplayTitle(
+  node: DataSourceViewContentNode,
+  { prefixSiteName }: MicrosoftSharePointDisplayTitleOptions = {}
 ): string {
-  if (
-    node.type !== "folder" ||
-    node.parentInternalId !== null ||
-    !node.sourceUrl
-  ) {
+  if (node.type !== "folder" || !node.sourceUrl) {
+    return node.title;
+  }
+
+  const shouldPrefix =
+    prefixSiteName === true || node.parentInternalId === null;
+  if (!shouldPrefix) {
     return node.title;
   }
 
   const siteName = extractSharePointSiteNameFromSourceUrl(node.sourceUrl);
   return siteName ? `${siteName} → ${node.title}` : node.title;
+}
+
+export function getMicrosoftSharePointRootFolderDisplayTitle(
+  node: DataSourceViewContentNode
+): string {
+  return getMicrosoftSharePointDisplayTitle(node);
 }

--- a/front/tests/lib/providers/microsoft/content_nodes_display.test.ts
+++ b/front/tests/lib/providers/microsoft/content_nodes_display.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import {
-  getMicrosoftSharePointDisplayTitle,
-  getMicrosoftSharePointRootFolderDisplayTitle,
-} from "@app/lib/providers/microsoft/content_nodes_display";
+import { getMicrosoftSharePointDisplayTitle } from "@app/lib/providers/microsoft/content_nodes_display";
 import type { DataSourceViewContentNode } from "@app/types";
 
 function makeNode(
@@ -52,10 +49,10 @@ function makeNode(
   };
 }
 
-describe("getMicrosoftSharePointRootFolderDisplayTitle", () => {
+describe("getMicrosoftSharePointDisplayTitle", () => {
   it("prefixes SharePoint root folders with site name", () => {
     const node = makeNode();
-    expect(getMicrosoftSharePointRootFolderDisplayTitle(node)).toBe(
+    expect(getMicrosoftSharePointDisplayTitle(node)).toBe(
       "Project Alpha → 01 Engagement"
     );
   });
@@ -65,7 +62,7 @@ describe("getMicrosoftSharePointRootFolderDisplayTitle", () => {
       sourceUrl:
         "https://tenant.sharepoint.us/sites/Project%20Alpha/Shared%20Documents/01%20Engagement",
     });
-    expect(getMicrosoftSharePointRootFolderDisplayTitle(node)).toBe(
+    expect(getMicrosoftSharePointDisplayTitle(node)).toBe(
       "Project Alpha → 01 Engagement"
     );
   });
@@ -76,7 +73,7 @@ describe("getMicrosoftSharePointRootFolderDisplayTitle", () => {
         "https://tenant.sharepoint.com/:f:/r/sites/Customer%20X/Shared%20Documents/02%20Work%20Plans?csf=1&web=1",
       title: "02 Work Plans",
     });
-    expect(getMicrosoftSharePointRootFolderDisplayTitle(node)).toBe(
+    expect(getMicrosoftSharePointDisplayTitle(node)).toBe(
       "Customer X → 02 Work Plans"
     );
   });
@@ -86,27 +83,21 @@ describe("getMicrosoftSharePointRootFolderDisplayTitle", () => {
       sourceUrl:
         "https://tenant.sharepoint.com/teams/Team%20Blue/Shared%20Documents/01%20Engagement",
     });
-    expect(getMicrosoftSharePointRootFolderDisplayTitle(node)).toBe(
+    expect(getMicrosoftSharePointDisplayTitle(node)).toBe(
       "Team Blue → 01 Engagement"
     );
   });
 
   it("does not prefix non-root nodes", () => {
     const node = makeNode({ parentInternalId: "parent" });
-    expect(getMicrosoftSharePointRootFolderDisplayTitle(node)).toBe(
-      "01 Engagement"
-    );
+    expect(getMicrosoftSharePointDisplayTitle(node)).toBe("01 Engagement");
   });
 
   it("does not prefix when sourceUrl is missing", () => {
     const node = makeNode({ sourceUrl: null });
-    expect(getMicrosoftSharePointRootFolderDisplayTitle(node)).toBe(
-      "01 Engagement"
-    );
+    expect(getMicrosoftSharePointDisplayTitle(node)).toBe("01 Engagement");
   });
-});
 
-describe("getMicrosoftSharePointDisplayTitle", () => {
   it("prefixes non-root nodes when requested", () => {
     const node = makeNode({ parentInternalId: "parent" });
     expect(

--- a/front/tests/lib/providers/microsoft/content_nodes_display.test.ts
+++ b/front/tests/lib/providers/microsoft/content_nodes_display.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { getMicrosoftSharePointRootFolderDisplayTitle } from "@app/lib/providers/microsoft/content_nodes_display";
+import {
+  getMicrosoftSharePointDisplayTitle,
+  getMicrosoftSharePointRootFolderDisplayTitle,
+} from "@app/lib/providers/microsoft/content_nodes_display";
 import type { DataSourceViewContentNode } from "@app/types";
 
 function makeNode(
@@ -100,5 +103,19 @@ describe("getMicrosoftSharePointRootFolderDisplayTitle", () => {
     expect(getMicrosoftSharePointRootFolderDisplayTitle(node)).toBe(
       "01 Engagement"
     );
+  });
+});
+
+describe("getMicrosoftSharePointDisplayTitle", () => {
+  it("prefixes non-root nodes when requested", () => {
+    const node = makeNode({ parentInternalId: "parent" });
+    expect(
+      getMicrosoftSharePointDisplayTitle(node, { prefixSiteName: true })
+    ).toBe("Project Alpha → 01 Engagement");
+  });
+
+  it("does not prefix non-root nodes by default", () => {
+    const node = makeNode({ parentInternalId: "parent" });
+    expect(getMicrosoftSharePointDisplayTitle(node)).toBe("01 Engagement");
   });
 });

--- a/front/tests/lib/providers/microsoft/content_nodes_display.test.ts
+++ b/front/tests/lib/providers/microsoft/content_nodes_display.test.ts
@@ -110,7 +110,7 @@ describe("getMicrosoftSharePointDisplayTitle", () => {
   it("prefixes non-root nodes when requested", () => {
     const node = makeNode({ parentInternalId: "parent" });
     expect(
-      getMicrosoftSharePointDisplayTitle(node, { prefixSiteName: true })
+      getMicrosoftSharePointDisplayTitle(node, { disambiguate: true })
     ).toBe("Project Alpha → 01 Engagement");
   });
 


### PR DESCRIPTION
## Description

Context: #20929 prefixed SharePoint *sync root* folders (nodes with no parent in our tree) with the site name to disambiguate identical structures across project sites. In practice, the UI surfaces most users interact with (space browser + agent builder pickers) often show the *top level of the view* as children of those roots (e.g. many sites expose the same `General/01 XYZ/...` structure). Those nodes are not sync roots, so #20929 didn’t fully address the ambiguity.

This PR prefixes the SharePoint site name (derived from `sourceUrl`) for **all Microsoft nodes shown at the top level of a view** so the first selectable level is disambiguated by site.

Applies to:
- Space browser folder list (top-level)
- Space sidebar tree (top-level)
- Agent builder folder picker and search results

## Tests

- `cd front && NODE_ENV=test npm test -- tests/lib/providers/microsoft/content_nodes_display.test.ts`
- `cd front && npm run format:check`
- `cd front && npm run lint` (warnings pre-existing)

## Risk

Low. Display-only change for Microsoft nodes; adds a site prefix at the top level of the view.

## Deploy Plan

Regular front deploy.