### PR TITLE
feat: generate title when users are mentioned

### DIFF
--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -687,7 +687,7 @@ export async function postUserMessage(
 
     // If a user is mentioned, we want to make sure the conversation has a title.
     // This ensures that mentioned users receive a notification with a conversation title.
-    if (mentions.some((m) => isUserMention(m))) {
+    if (mentions.some(isUserMention)) {
       await ensureConversationTitle(auth, {
         conversation,
         userMessage: {

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -685,6 +685,19 @@ export async function postUserMessage(
       transaction: t,
     });
 
+    // If a user is mentioned, we want to make sure the conversation has a title.
+    // This ensures that mentioned users receive a notification with a conversation title.
+    if (mentions.some((m) => isUserMention(m))) {
+      await ensureConversationTitle(auth, {
+        conversation,
+        userMessage: {
+          ...userMessageWithoutMentions,
+          richMentions: [],
+          mentions: [],
+        },
+      });
+    }
+
     const richMentions = await createUserMentions(auth, {
       mentions,
       message: userMessageWithoutMentions,


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/6326
This PR ensures that conversations automatically get a title when users are mentioned, so that mentioned users receive notifications with a conversation title.

## Tests

Manually

## Risk

Low. 

## Deploy Plan

Standard deployment - no special steps required.
