### PR TITLE
fix(copilot): fix outdated suggestions rendering as error

### DIFF
--- a/front/lib/swr/agent_suggestions.ts
+++ b/front/lib/swr/agent_suggestions.ts
@@ -1,3 +1,4 @@
+import { useCallback } from "react";
 import type { Fetcher } from "swr";
 
 import { useSendNotification } from "@app/hooks/useNotification";
@@ -72,50 +73,53 @@ export function usePatchAgentSuggestions({
     disabled: true,
   });
 
-  const patchSuggestions = async (
-    suggestionIds: string[],
-    state: PatchSuggestionRequestBody["state"]
-  ): Promise<PatchSuggestionResponseBody | null> => {
-    if (!agentConfigurationId || suggestionIds.length === 0) {
-      return null;
-    }
-
-    try {
-      const res = await clientFetch(
-        `/api/w/${workspaceId}/assistant/agent_configurations/${agentConfigurationId}/suggestions`,
-        {
-          method: "PATCH",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            suggestionIds,
-            state,
-          } satisfies PatchSuggestionRequestBody),
-        }
-      );
-
-      if (!res.ok) {
-        const errorData = await getErrorFromResponse(res);
-        sendNotification({
-          type: "error",
-          title: "Failed to update suggestion",
-          description: errorData.message,
-        });
+  const patchSuggestions = useCallback(
+    async (
+      suggestionIds: string[],
+      state: PatchSuggestionRequestBody["state"]
+    ): Promise<PatchSuggestionResponseBody | null> => {
+      if (!agentConfigurationId || suggestionIds.length === 0) {
         return null;
       }
 
-      void mutateSuggestions();
-      const data = await res.json();
-      return data;
-    } catch {
-      sendNotification({
-        type: "error",
-        title: "Failed to update suggestion",
-      });
-      return null;
-    }
-  };
+      try {
+        const res = await clientFetch(
+          `/api/w/${workspaceId}/assistant/agent_configurations/${agentConfigurationId}/suggestions`,
+          {
+            method: "PATCH",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              suggestionIds,
+              state,
+            } satisfies PatchSuggestionRequestBody),
+          }
+        );
+
+        if (!res.ok) {
+          const errorData = await getErrorFromResponse(res);
+          sendNotification({
+            type: "error",
+            title: "Failed to update suggestion",
+            description: errorData.message,
+          });
+          return null;
+        }
+
+        void mutateSuggestions();
+        const data = await res.json();
+        return data;
+      } catch {
+        sendNotification({
+          type: "error",
+          title: "Failed to update suggestion",
+        });
+        return null;
+      }
+    },
+    [agentConfigurationId, mutateSuggestions, sendNotification, workspaceId]
+  );
 
   return { patchSuggestions };
 }

--- a/front/types/suggestions/agent_suggestion.ts
+++ b/front/types/suggestions/agent_suggestion.ts
@@ -126,6 +126,11 @@ export const AgentSuggestionSchema = BaseAgentSuggestionSchema.and(
 
 export type AgentSuggestionType = z.infer<typeof AgentSuggestionSchema>;
 
+export type AgentInstructionsSuggestionType = Extract<
+  AgentSuggestionType,
+  { kind: "instructions" }
+>;
+
 export interface ToolSuggestionRelations {
   additions: MCPServerViewType[];
   deletions: MCPServerViewType[];
@@ -150,6 +155,6 @@ export type AgentSuggestionWithRelationsType =
   | (Extract<AgentSuggestionType, { kind: "model" }> & {
       relations: ModelSuggestionRelations;
     })
-  | (Extract<AgentSuggestionType, { kind: "instructions" }> & {
+  | (AgentInstructionsSuggestionType & {
       relations: null;
     });


### PR DESCRIPTION
## Description

Fix bug where outdated suggestions were rendering as error cards. The issue was that after marking suggestions as outdated via PATCH, neither `processedSuggestions` nor the refetched backend data contained the outdated state, causing the UI to render error states.

Changes:
- Update local `processedSuggestions` state immediately when marking suggestions outdated
- Wrap `patchSuggestions` in `useCallback` to stabilize reference
- Add `AgentInstructionsSuggestionType` for better typing

## Tests

Manual testing in copilot builder - outdated suggestions now display correctly.

## Risk

Low - isolated to copilot suggestions rendering.

## Deploy Plan

Standard deploy.