### PR TITLE
[front] - chore(workspace): analytics polish

### DIFF
--- a/front/components/workspace/analytics/WorkspaceAnalyticsOverviewCards.tsx
+++ b/front/components/workspace/analytics/WorkspaceAnalyticsOverviewCards.tsx
@@ -30,11 +30,11 @@ export function WorkspaceAnalyticsOverviewCards({
   const totalMembers =
     isOverviewError || overview?.totalMembers === undefined
       ? "-"
-      : overview.totalMembers;
+      : overview.totalMembers.toLocaleString();
   const activeUsers =
     isOverviewError || overview?.activeUsers === undefined
       ? "-"
-      : overview.activeUsers;
+      : overview.activeUsers.toLocaleString();
 
   return (
     <div className="grid grid-cols-2 gap-6">
@@ -50,7 +50,7 @@ export function WorkspaceAnalyticsOverviewCards({
         }
       />
       <ValueCard
-        title="Active users"
+        title={`Active users (last ${period} days)`}
         className="h-24"
         content={
           <div className="flex flex-col gap-1 text-2xl">

--- a/front/components/workspace/analytics/WorkspaceSourceChart.tsx
+++ b/front/components/workspace/analytics/WorkspaceSourceChart.tsx
@@ -38,7 +38,7 @@ export function WorkspaceSourceChart({
   return (
     <ChartContainer
       title="Source"
-      description="Message volume broken down by source."
+      description={`Message volume broken down by source over the last ${period} days.`}
       isLoading={isContextOriginLoading}
       errorMessage={
         isContextOriginError ? "Failed to load source breakdown." : undefined
@@ -51,6 +51,7 @@ export function WorkspaceSourceChart({
     >
       <PieChart>
         <Tooltip
+          isAnimationActive={false}
           cursor={false}
           wrapperStyle={{ outline: "none", zIndex: 50 }}
           content={({ active }) => {
@@ -59,7 +60,7 @@ export function WorkspaceSourceChart({
             }
             const rows = data.map((d) => ({
               label: d.label,
-              value: d.count,
+              value: d.count.toLocaleString(),
               percent: d.percent,
               colorClassName: getSourceColor(d.origin),
             }));
@@ -98,7 +99,9 @@ export function WorkspaceSourceChart({
             dominantBaseline="middle"
             className="fill-foreground dark:fill-foreground-night"
           >
-            <tspan className="text-2xl font-semibold">{total}</tspan>
+            <tspan className="text-2xl font-semibold">
+              {total.toLocaleString()}
+            </tspan>
             <tspan x="50%" dy="1.2em" className="text-sm">
               Messages
             </tspan>

--- a/front/components/workspace/analytics/WorkspaceToolUsageChart.tsx
+++ b/front/components/workspace/analytics/WorkspaceToolUsageChart.tsx
@@ -84,17 +84,18 @@ function ToolUsageTooltip({
   const title = point.date ?? formatShortDate(point.timestamp);
   const label = displayMode === "users" ? "users" : "executions";
 
-  const rows = toolsForChart.map((tool) => ({
+  const values = toolsForChart.map((tool) => point.values[tool] ?? 0);
+  const rows = toolsForChart.map((tool, idx) => ({
     label: asDisplayToolName(tool),
-    value: point.values[tool] ?? 0,
+    value: values[idx].toLocaleString(),
     colorClassName: getToolColor(tool, toolsForChart),
   }));
 
   if (toolsForChart.length > 1) {
-    const total = rows.reduce((sum, r) => sum + r.value, 0);
+    const total = values.reduce((sum, v) => sum + v, 0);
     rows.push({
       label: `Total ${label}`,
-      value: total,
+      value: total.toLocaleString(),
       colorClassName: "",
     });
   }
@@ -294,7 +295,7 @@ export function WorkspaceToolUsageChart({
   return (
     <ChartContainer
       title="Tool usage"
-      description="Track how tools are being used across your workspace."
+      description={`Tool usage across your workspace over the last ${period} days.`}
       isLoading={isLoading}
       errorMessage={hasError ? "Failed to load tool usage data." : undefined}
       emptyMessage={
@@ -336,6 +337,7 @@ export function WorkspaceToolUsageChart({
           allowDecimals={false}
         />
         <Tooltip
+          isAnimationActive={false}
           content={(props: TooltipContentProps<number, string>) => (
             <ToolUsageTooltip
               {...props}

--- a/front/components/workspace/analytics/WorkspaceTopAgentsTable.tsx
+++ b/front/components/workspace/analytics/WorkspaceTopAgentsTable.tsx
@@ -88,7 +88,7 @@ export function WorkspaceTopAgentsTable({
           Top agents
         </h3>
         <p className="text-xs text-muted-foreground dark:text-muted-foreground-night">
-          Top 100 agents with the most messages in this time range.
+          Top 100 agents with the most messages over the last {period} days.
         </p>
       </div>
       {isTopAgentsLoading ? (

--- a/front/components/workspace/analytics/WorkspaceTopUsersTable.tsx
+++ b/front/components/workspace/analytics/WorkspaceTopUsersTable.tsx
@@ -86,7 +86,7 @@ export function WorkspaceTopUsersTable({
           Top users
         </h3>
         <p className="text-xs text-muted-foreground dark:text-muted-foreground-night">
-          Top 100 users with the most messages in this time range.
+          Top 100 users with the most messages over the last {period} days.
         </p>
       </div>
       {isTopUsersLoading ? (

--- a/front/components/workspace/analytics/WorkspaceUsageChart.tsx
+++ b/front/components/workspace/analytics/WorkspaceUsageChart.tsx
@@ -1,3 +1,5 @@
+import { ButtonsSwitch, ButtonsSwitchList } from "@dust-tt/sparkle";
+import { useState } from "react";
 import {
   CartesianGrid,
   Line,
@@ -11,15 +13,16 @@ import type { TooltipContentProps } from "recharts/types/component/Tooltip";
 import type { ObservabilityTimeRangeType } from "@app/components/agent_builder/observability/constants";
 import {
   CHART_HEIGHT,
-  USAGE_METRICS_LEGEND,
   USAGE_METRICS_PALETTE,
 } from "@app/components/agent_builder/observability/constants";
 import { padSeriesToTimeRange } from "@app/components/agent_builder/observability/utils";
 import { ChartContainer } from "@app/components/charts/ChartContainer";
-import { legendFromConstant } from "@app/components/charts/ChartLegend";
+import type { LegendItem } from "@app/components/charts/ChartLegend";
 import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
 import { useWorkspaceUsageMetrics } from "@app/lib/swr/workspaces";
 import { formatShortDate } from "@app/lib/utils/timestamps";
+
+type UsageDisplayMode = "activity" | "users";
 
 interface WorkspaceUsageMetricsDatum {
   timestamp: number;
@@ -51,8 +54,15 @@ function zeroFactory(timestamp: number): WorkspaceUsageMetricsDatum {
   };
 }
 
-function UsageMetricsTooltip(props: TooltipContentProps<number, string>) {
-  const { active, payload } = props;
+interface UsageMetricsTooltipProps extends TooltipContentProps<number, string> {
+  displayMode: UsageDisplayMode;
+}
+
+function UsageMetricsTooltip({
+  active,
+  payload,
+  displayMode,
+}: UsageMetricsTooltipProps) {
   if (!active || !payload || payload.length === 0) {
     return null;
   }
@@ -65,28 +75,29 @@ function UsageMetricsTooltip(props: TooltipContentProps<number, string>) {
   const row = first.payload;
   const title = row.date ?? formatShortDate(row.timestamp);
 
-  return (
-    <ChartTooltipCard
-      title={title}
-      rows={[
-        {
-          label: "Messages",
-          value: row.count,
-          colorClassName: USAGE_METRICS_PALETTE.messages,
-        },
-        {
-          label: "Conversations",
-          value: row.conversations,
-          colorClassName: USAGE_METRICS_PALETTE.conversations,
-        },
-        {
-          label: "Active users",
-          value: row.activeUsers,
-          colorClassName: USAGE_METRICS_PALETTE.activeUsers,
-        },
-      ]}
-    />
-  );
+  const rows =
+    displayMode === "activity"
+      ? [
+          {
+            label: "Messages",
+            value: row.count.toLocaleString(),
+            colorClassName: USAGE_METRICS_PALETTE.messages,
+          },
+          {
+            label: "Conversations",
+            value: row.conversations.toLocaleString(),
+            colorClassName: USAGE_METRICS_PALETTE.conversations,
+          },
+        ]
+      : [
+          {
+            label: "Active users",
+            value: row.activeUsers.toLocaleString(),
+            colorClassName: USAGE_METRICS_PALETTE.activeUsers,
+          },
+        ];
+
+  return <ChartTooltipCard title={title} rows={rows} />;
 }
 
 interface WorkspaceUsageChartProps {
@@ -98,6 +109,8 @@ export function WorkspaceUsageChart({
   workspaceId,
   period,
 }: WorkspaceUsageChartProps) {
+  const [displayMode, setDisplayMode] = useState<UsageDisplayMode>("activity");
+
   const { usageMetrics, isUsageMetricsLoading, isUsageMetricsError } =
     useWorkspaceUsageMetrics({
       workspaceId,
@@ -106,10 +119,27 @@ export function WorkspaceUsageChart({
       disabled: !workspaceId,
     });
 
-  const legendItems = legendFromConstant(
-    USAGE_METRICS_LEGEND,
-    USAGE_METRICS_PALETTE
-  );
+  const legendItems: LegendItem[] =
+    displayMode === "activity"
+      ? [
+          {
+            key: "messages",
+            label: "Messages",
+            colorClassName: USAGE_METRICS_PALETTE.messages,
+          },
+          {
+            key: "conversations",
+            label: "Conversations",
+            colorClassName: USAGE_METRICS_PALETTE.conversations,
+          },
+        ]
+      : [
+          {
+            key: "activeUsers",
+            label: "Active users",
+            colorClassName: USAGE_METRICS_PALETTE.activeUsers,
+          },
+        ];
 
   const data = padSeriesToTimeRange<WorkspaceUsageMetricsDatum>(
     usageMetrics,
@@ -118,10 +148,29 @@ export function WorkspaceUsageChart({
     zeroFactory
   );
 
+  const modeSelector = (
+    <ButtonsSwitchList defaultValue={displayMode} size="xs">
+      <ButtonsSwitch
+        value="activity"
+        label="Activity"
+        onClick={() => setDisplayMode("activity")}
+      />
+      <ButtonsSwitch
+        value="users"
+        label="Users"
+        onClick={() => setDisplayMode("users")}
+      />
+    </ButtonsSwitchList>
+  );
+
   return (
     <ChartContainer
       title="Activity"
-      description="Messages, conversations, and active users."
+      description={
+        displayMode === "activity"
+          ? `Messages and conversations over the last ${period} days.`
+          : `Active users over the last ${period} days.`
+      }
       isLoading={isUsageMetricsLoading}
       errorMessage={
         isUsageMetricsError ? "Failed to load workspace usage." : undefined
@@ -131,46 +180,12 @@ export function WorkspaceUsageChart({
       }
       height={CHART_HEIGHT}
       legendItems={legendItems}
+      additionalControls={modeSelector}
     >
       <LineChart
         data={data}
         margin={{ top: 10, right: 30, left: 10, bottom: 20 }}
       >
-        <defs>
-          <linearGradient
-            id="workspaceFillMessages"
-            x1="0"
-            y1="0"
-            x2="0"
-            y2="1"
-            className={USAGE_METRICS_PALETTE.messages}
-          >
-            <stop offset="5%" stopColor="currentColor" stopOpacity={0.8} />
-            <stop offset="95%" stopColor="currentColor" stopOpacity={0.1} />
-          </linearGradient>
-          <linearGradient
-            id="workspaceFillConversations"
-            x1="0"
-            y1="0"
-            x2="0"
-            y2="1"
-            className={USAGE_METRICS_PALETTE.conversations}
-          >
-            <stop offset="5%" stopColor="currentColor" stopOpacity={0.8} />
-            <stop offset="95%" stopColor="currentColor" stopOpacity={0.1} />
-          </linearGradient>
-          <linearGradient
-            id="workspaceFillActiveUsers"
-            x1="0"
-            y1="0"
-            x2="0"
-            y2="1"
-            className={USAGE_METRICS_PALETTE.activeUsers}
-          >
-            <stop offset="5%" stopColor="currentColor" stopOpacity={0.8} />
-            <stop offset="95%" stopColor="currentColor" stopOpacity={0.1} />
-          </linearGradient>
-        </defs>
         <CartesianGrid
           vertical={false}
           className="stroke-border dark:stroke-border-night"
@@ -191,10 +206,12 @@ export function WorkspaceUsageChart({
           tickLine={false}
           axisLine={false}
           tickMargin={8}
+          allowDecimals={false}
         />
         <Tooltip
+          isAnimationActive={false}
           content={(props: TooltipContentProps<number, string>) => (
-            <UsageMetricsTooltip {...props} />
+            <UsageMetricsTooltip {...props} displayMode={displayMode} />
           )}
           cursor={false}
           wrapperStyle={{ outline: "none", zIndex: 50 }}
@@ -205,33 +222,38 @@ export function WorkspaceUsageChart({
             boxShadow: "none",
           }}
         />
-        <Line
-          type={period === 7 || period === 14 ? "linear" : "monotone"}
-          strokeWidth={2}
-          dataKey="count"
-          name="Messages"
-          className={USAGE_METRICS_PALETTE.messages}
-          stroke="currentColor"
-          dot={false}
-        />
-        <Line
-          type={period === 7 || period === 14 ? "linear" : "monotone"}
-          strokeWidth={2}
-          dataKey="conversations"
-          name="Conversations"
-          className={USAGE_METRICS_PALETTE.conversations}
-          stroke="currentColor"
-          dot={false}
-        />
-        <Line
-          type={period === 7 || period === 14 ? "linear" : "monotone"}
-          strokeWidth={2}
-          dataKey="activeUsers"
-          name="Active users"
-          className={USAGE_METRICS_PALETTE.activeUsers}
-          stroke="currentColor"
-          dot={false}
-        />
+        {displayMode === "activity" ? (
+          <>
+            <Line
+              type={period === 7 || period === 14 ? "linear" : "monotone"}
+              strokeWidth={2}
+              dataKey="count"
+              name="Messages"
+              className={USAGE_METRICS_PALETTE.messages}
+              stroke="currentColor"
+              dot={false}
+            />
+            <Line
+              type={period === 7 || period === 14 ? "linear" : "monotone"}
+              strokeWidth={2}
+              dataKey="conversations"
+              name="Conversations"
+              className={USAGE_METRICS_PALETTE.conversations}
+              stroke="currentColor"
+              dot={false}
+            />
+          </>
+        ) : (
+          <Line
+            type={period === 7 || period === 14 ? "linear" : "monotone"}
+            strokeWidth={2}
+            dataKey="activeUsers"
+            name="Active users"
+            className={USAGE_METRICS_PALETTE.activeUsers}
+            stroke="currentColor"
+            dot={false}
+          />
+        )}
       </LineChart>
     </ChartContainer>
   );


### PR DESCRIPTION



## Description

This PR polishes the workspace analytics display with improved number formatting, localization support, and clearer time context. Numbers are now formatted with localized separators across all charts (e.g., `1,234` instead of `1234`). All chart descriptions and table messages now include the time range context (`over the last X days`) for better clarity. The Activity chart now offers a toggle between "Activity" (messages + conversations) and "Users" (active users) views, with tooltips and legends adapting accordingly.

## Risk

Low - UI polish

## Tests

- [x] Locally

## Deploy Plan

Deploy front
