### PR TITLE
Display admin auth error only if connection not found

### DIFF
--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -355,7 +355,10 @@ export async function connectToMCPServer(
                   connectionType: "workspace",
                 });
                 // If no admin connection exists, return an error to display a message to the user saying that the server requires the admin to setup the connection.
-                if (adminConnection.isErr() && adminConnection.error.message === "connection_not_found") {
+                if (
+                  adminConnection.isErr() &&
+                  adminConnection.error.message === "connection_not_found"
+                ) {
                   return new Err(
                     new MCPServerRequiresAdminAuthenticationError(
                       params.mcpServerId,

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -355,7 +355,7 @@ export async function connectToMCPServer(
                   connectionType: "workspace",
                 });
                 // If no admin connection exists, return an error to display a message to the user saying that the server requires the admin to setup the connection.
-                if (adminConnection.isErr()) {
+                if (adminConnection.isErr() && adminConnection.error.message === "connection_not_found") {
                   return new Err(
                     new MCPServerRequiresAdminAuthenticationError(
                       params.mcpServerId,


### PR DESCRIPTION
## Description

This PR adds a check for the specific connection_not_found error message before returning MCPServerRequiresAdminAuthenticationError, aligning the Remote MCP server behavior with the Internal MCP server pattern (see [PR](https://github.com/dust-tt/dust/pull/20162/changes)).

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Deploy front
