### PR TITLE
Bump Microsoft connector workflow version to v2

### DIFF
--- a/connectors/src/connectors/microsoft/temporal/config.ts
+++ b/connectors/src/connectors/microsoft/temporal/config.ts
@@ -1,2 +1,2 @@
-const WORKFLOW_VERSION = 1;
+const WORKFLOW_VERSION = 2;
 export const QUEUE_NAME = `microsoft-queue-v${WORKFLOW_VERSION}`;


### PR DESCRIPTION
## Description

Bump the Microsoft connector Temporal workflow version from 1 to 2, changing the queue name from `microsoft-queue-v1` to `microsoft-queue-v2`.

## Tests

No tests needed — single constant change.

## Risk

Low. New workers will pick up from the new queue. Existing in-flight workflows on v1 will be restarted.

## Deploy Plan

Deploy connectors then restart all microsoft workflows