### PR TITLE
feat: improve mail template when user added as participant

### DIFF
--- a/front/lib/notifications/email-templates/conversation-added-as-participant.tsx
+++ b/front/lib/notifications/email-templates/conversation-added-as-participant.tsx
@@ -1,0 +1,56 @@
+import { render } from "@react-email/render";
+import * as React from "react";
+import { z } from "zod";
+
+import { EmailLayout } from "@app/lib/notifications/email-templates/_layout";
+import { getConversationRoute } from "@app/lib/utils/router";
+
+export const ConversationAddedAsParticipantEmailTemplatePropsSchema = z.object({
+  name: z.string(),
+  workspace: z.object({
+    id: z.string(),
+    name: z.string(),
+  }),
+  userThatAddedYouFullname: z.string(),
+  conversation: z.object({
+    id: z.string(),
+    title: z.string(),
+    summary: z.string().nullable(),
+  }),
+});
+
+type ConversationAddedAsParticipantEmailTemplateProps = z.infer<
+  typeof ConversationAddedAsParticipantEmailTemplatePropsSchema
+>;
+
+const ConversationAddedAsParticipantEmailTemplate = ({
+  name,
+  workspace,
+  userThatAddedYouFullname,
+  conversation,
+}: ConversationAddedAsParticipantEmailTemplateProps) => {
+  const url =
+    process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL +
+    getConversationRoute(workspace.id, conversation.id);
+
+  return (
+    <EmailLayout workspace={workspace}>
+      <p>Hi {name},</p>
+      <h3>
+        {userThatAddedYouFullname} added you to the conversation "
+        {conversation.title}".
+      </h3>
+      {conversation.summary && <div>{conversation.summary}</div>}
+      <hr style={{ border: "1px solid #e0e0e0" }} />
+      <a href={url} target="_blank">
+        View conversation
+      </a>
+    </EmailLayout>
+  );
+};
+
+export function renderEmail(
+  args: ConversationAddedAsParticipantEmailTemplateProps
+) {
+  return render(<ConversationAddedAsParticipantEmailTemplate {...args} />);
+}


### PR DESCRIPTION
## Description

This PR improves the email template sent when a user is added as a participant to a conversation.

- Creates a dedicated email template component (`conversation-added-as-participant.tsx`) to replace the generic template previously used
<img width="1093" height="483" alt="Capture d’écran 2026-02-04 à 15 25 56" src="https://github.com/user-attachments/assets/5a796132-bb5c-4e1e-841e-dd9afdeb1b48" />

## Tests

Manually

## Risks


## Deploy Plan

