### PR TITLE
Restart non-running GC and DB upsert workflows

### DIFF
--- a/connectors/src/connectors/notion/temporal/client.ts
+++ b/connectors/src/connectors/notion/temporal/client.ts
@@ -100,31 +100,30 @@ export async function launchNotionSyncWorkflow(
       },
       "launchNotionSyncWorkflow: Notion sync workflow already running."
     );
-    return;
-  }
-
-  await client.workflow.start(notionSyncWorkflow, {
-    args: [
-      {
-        connectorId,
-        startFromTs,
-        forceResync,
+  } else {
+    await client.workflow.start(notionSyncWorkflow, {
+      args: [
+        {
+          connectorId,
+          startFromTs,
+          forceResync,
+        },
+      ],
+      taskQueue: QUEUE_NAME,
+      workflowId: getNotionWorkflowId(connectorId, "sync"),
+      searchAttributes: {
+        connectorId: [connectorId],
       },
-    ],
-    taskQueue: QUEUE_NAME,
-    workflowId: getNotionWorkflowId(connectorId, "sync"),
-    searchAttributes: {
-      connectorId: [connectorId],
-    },
-    memo: {
-      connectorId,
-    },
-  });
+      memo: {
+        connectorId,
+      },
+    });
 
-  logger.info(
-    { workspaceId: dataSourceConfig.workspaceId },
-    "launchNotionSyncWorkflow: Started Notion sync workflow."
-  );
+    logger.info(
+      { workspaceId: dataSourceConfig.workspaceId },
+      "launchNotionSyncWorkflow: Started Notion sync workflow."
+    );
+  }
 
   await launchNotionGarbageCollectorWorkflow(connectorId);
   await launchProcessDatabaseUpsertQueueWorkflow(connectorId);


### PR DESCRIPTION
## Description

Issue is that if sync workflow is already running, Resume/Unpause would not try starting the other workflows.

Now launchNotionSyncWorkflow:
  1. If sync workflow is already running → logs warning but continues
  2. If sync workflow is not running → starts it
  3. Always calls launchNotionGarbageCollectorWorkflow and launchProcessDatabaseUpsertQueueWorkflow

  Both helper functions already have their own "already running" checks, so they handle that case gracefully.

## Tests

Manual

## Risk

Poke plugin / CLI only

## Deploy Plan

Connectors