### PR TITLE
copilot: add new MCP to configure sub agent suggestions

### DIFF
--- a/front/components/agent_builder/copilot/CopilotSuggestionsContext.tsx
+++ b/front/components/agent_builder/copilot/CopilotSuggestionsContext.tsx
@@ -23,6 +23,7 @@ import {
   usePatchAgentSuggestions,
 } from "@app/lib/swr/agent_suggestions";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
+import { assertNever } from "@app/types/shared/utils/assert_never";
 import type {
   AgentInstructionsSuggestionType,
   AgentSuggestionType,
@@ -152,6 +153,15 @@ export const CopilotSuggestionsProvider = ({
           return { ...suggestion, relations: { tool } };
         }
 
+        case "sub_agent": {
+          const tool = mcpServerViewsMap.get(suggestion.suggestion.toolId);
+          if (!tool) {
+            return null;
+          }
+
+          return { ...suggestion, relations: { tool } };
+        }
+
         case "skills": {
           const skill = skillsMap.get(suggestion.suggestion.skillId);
           if (!skill) {
@@ -172,6 +182,9 @@ export const CopilotSuggestionsProvider = ({
 
         case "instructions":
           return { ...suggestion, relations: null };
+
+        default:
+          assertNever(suggestion);
       }
     },
     [getSuggestion, skillsMap, mcpServerViewsMap]

--- a/front/components/agent_builder/copilot/tools/getAgentConfig.ts
+++ b/front/components/agent_builder/copilot/tools/getAgentConfig.ts
@@ -53,9 +53,13 @@ When there are pending suggestions, the "instructions" field shows the original 
           reasoningEffort: formData.generationSettings.reasoningEffort,
         },
         tools: formData.actions.map((action) => ({
-          sId: action.id,
+          sId: action.configuration.mcpServerViewId,
           name: action.name,
           description: action.description,
+          // If the childAgentId is set, include it
+          ...(action.configuration.childAgentId
+            ? { childAgentId: action.configuration.childAgentId }
+            : {}),
         })),
         skills: formData.skills.map((skill) => ({
           sId: skill.sId,

--- a/front/components/markdown/suggestion/CopilotSuggestionCard.tsx
+++ b/front/components/markdown/suggestion/CopilotSuggestionCard.tsx
@@ -13,15 +13,19 @@ import {
   LoadingBlock,
   XMarkIcon,
 } from "@dust-tt/sparkle";
-import React, { useCallback } from "react";
+import React, { useCallback, useMemo } from "react";
 import { useController, useFormContext } from "react-hook-form";
 
+import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
+import { nameToStorageFormat } from "@app/components/agent_builder/capabilities/mcp/utils/actionNameUtils";
 import { useCopilotSuggestions } from "@app/components/agent_builder/copilot/CopilotSuggestionsContext";
 import { getDefaultMCPAction } from "@app/components/agent_builder/types";
 import { getIcon } from "@app/components/resources/resources_icons";
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
+import type { MCPServerViewType } from "@app/lib/api/mcp";
 import { getSkillAvatarIcon } from "@app/lib/skill";
+import { useAgentConfigurations } from "@app/lib/swr/assistants";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type {
   AgentInstructionsSuggestionType,
@@ -101,6 +105,37 @@ function InstructionsSuggestionCard({
   );
 }
 
+function isToolAlreadyAdded(
+  currentActions: AgentBuilderFormData["actions"],
+  toolSId: string
+): boolean {
+  return currentActions.some(
+    (action) => action.configuration.mcpServerViewId === toolSId
+  );
+}
+
+function isSubAgentAlreadyAdded(
+  currentActions: AgentBuilderFormData["actions"],
+  childAgentId: string
+): boolean {
+  return currentActions.some(
+    (action) => action.configuration.childAgentId === childAgentId
+  );
+}
+
+function getNewSubAgentAction(
+  tool: MCPServerViewType,
+  childAgentId: string,
+  childAgentName: string | null
+): ReturnType<typeof getDefaultMCPAction> {
+  const newAction = getDefaultMCPAction(tool);
+  newAction.configuration.childAgentId = childAgentId;
+  if (childAgentName) {
+    newAction.name = nameToStorageFormat(`run_${childAgentName}`);
+  }
+  return newAction;
+}
+
 function ToolSuggestionCard({
   agentSuggestion,
 }: {
@@ -119,10 +154,7 @@ function ToolSuggestionCard({
     if (success) {
       if (isAddition) {
         const currentActions = getValues("actions");
-        const alreadyExists = currentActions.some(
-          (action) => action.configuration.mcpServerViewId === tool.sId
-        );
-        if (!alreadyExists) {
+        if (!isToolAlreadyAdded(currentActions, tool.sId)) {
           const newAction = getDefaultMCPAction(tool);
           setValue("actions", [...currentActions, newAction], {
             shouldDirty: true,
@@ -142,21 +174,112 @@ function ToolSuggestionCard({
     void rejectSuggestion(sId);
   }, [rejectSuggestion, sId]);
 
-  const serverName = getMcpServerViewDisplayName(tool);
+  const displayName = getMcpServerViewDisplayName(tool);
 
   return (
     <ActionCardBlock
       title={
-        isAddition ? `Add ${serverName} tool` : `Remove ${serverName} tool`
+        isAddition ? `Add ${displayName} tool` : `Remove ${displayName} tool`
       }
       visual={<Avatar icon={getIcon(tool.server.icon)} size="sm" />}
       description={analysis ?? undefined}
       state={cardState}
       applyLabel={isAddition ? "Add" : "Remove"}
+      rejectLabel="Dismiss"
       acceptedTitle={
-        isAddition ? `${serverName} tool added` : `${serverName} tool removed`
+        isAddition ? `${displayName} tool added` : `${displayName} tool removed`
       }
-      rejectedTitle={`${serverName} tool suggestion rejected`}
+      rejectedTitle={`${displayName} tool dismissed`}
+      actionsPosition="header"
+      onClickAccept={handleAccept}
+      onClickReject={handleReject}
+    />
+  );
+}
+
+function SubAgentSuggestionCard({
+  agentSuggestion,
+}: {
+  agentSuggestion: Extract<
+    AgentSuggestionWithRelationsType,
+    { kind: "sub_agent" }
+  >;
+}) {
+  const { suggestion, relations, state, sId, analysis } = agentSuggestion;
+  const cardState = mapSuggestionStateToCardState(state);
+  const { acceptSuggestion, rejectSuggestion } = useCopilotSuggestions();
+  const { setValue, getValues } = useFormContext<AgentBuilderFormData>();
+  const { owner } = useAgentBuilderContext();
+
+  const isAddition = suggestion.action === "add";
+  const tool = relations.tool;
+  const childAgentId = suggestion.childAgentId;
+
+  // Fetch agent configurations to resolve childAgentId to name.
+  const { agentConfigurations } = useAgentConfigurations({
+    workspaceId: owner.sId,
+    agentsGetView: "list",
+  });
+
+  // Resolve child agent name from childAgentId.
+  const childAgentName = useMemo(() => {
+    const childAgent = agentConfigurations.find((a) => a.sId === childAgentId);
+    return childAgent?.name ?? null;
+  }, [childAgentId, agentConfigurations]);
+
+  const handleAccept = useCallback(async () => {
+    const success = await acceptSuggestion(sId);
+    if (success) {
+      if (isAddition) {
+        const currentActions = getValues("actions");
+        if (!isSubAgentAlreadyAdded(currentActions, childAgentId)) {
+          const newAction = getNewSubAgentAction(
+            tool,
+            childAgentId,
+            childAgentName
+          );
+          setValue("actions", [...currentActions, newAction], {
+            shouldDirty: true,
+          });
+        }
+      } else {
+        const currentActions = getValues("actions");
+        const filteredActions = currentActions.filter(
+          (action) => action.configuration.childAgentId !== childAgentId
+        );
+        setValue("actions", filteredActions, { shouldDirty: true });
+      }
+    }
+  }, [
+    acceptSuggestion,
+    sId,
+    getValues,
+    setValue,
+    isAddition,
+    tool,
+    childAgentId,
+    childAgentName,
+  ]);
+
+  const handleReject = useCallback(() => {
+    void rejectSuggestion(sId);
+  }, [rejectSuggestion, sId]);
+
+  const displayName = childAgentName
+    ? `Run ${childAgentName}`
+    : "Run sub-agent";
+
+  return (
+    <ActionCardBlock
+      title={isAddition ? `Add ${displayName}` : `Remove ${displayName}`}
+      visual={<Avatar icon={getIcon(tool.server.icon)} size="sm" />}
+      description={analysis ?? undefined}
+      state={cardState}
+      applyLabel={isAddition ? "Add" : "Remove"}
+      acceptedTitle={
+        isAddition ? `${displayName} added` : `${displayName} removed`
+      }
+      rejectedTitle={`${displayName} dismissed`}
       actionsPosition="header"
       onClickAccept={handleAccept}
       onClickReject={handleReject}
@@ -299,10 +422,14 @@ export function CopilotSuggestionCard({
       return <InstructionsSuggestionCard agentSuggestion={agentSuggestion} />;
     case "tools":
       return <ToolSuggestionCard agentSuggestion={agentSuggestion} />;
+    case "sub_agent":
+      return <SubAgentSuggestionCard agentSuggestion={agentSuggestion} />;
     case "skills":
       return <SkillSuggestionCard agentSuggestion={agentSuggestion} />;
     case "model":
       return <ModelSuggestionCard agentSuggestion={agentSuggestion} />;
+    default:
+      assertNever(agentSuggestion);
   }
 }
 

--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
@@ -62,6 +62,22 @@
         }
       },
       {
+        "name": "get_available_agents",
+        "description": "Get the list of available agents that can be used as sub-agents. Returns active agents accessible to the current user, excluding global agents.",
+        "inputSchema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "additionalProperties": false,
+          "properties": {
+            "limit": {
+              "default": 100,
+              "description": "Maximum number of agents to return (default: 100)",
+              "type": "number"
+            }
+          },
+          "type": "object"
+        }
+      },
+      {
         "name": "get_available_knowledge",
         "description": "Get the list of available knowledge sources that can be added to an agent. Returns a hierarchical structure organized by spaces, with connected data sources, folders, and websites listed under each space. Only includes sources accessible to the current user.",
         "inputSchema": {
@@ -128,10 +144,11 @@
           "additionalProperties": false,
           "properties": {
             "kind": {
-              "description": "Filter by suggestion type. Options: instructions, tools, skills, model. If not provided, returns all types.",
+              "description": "Filter by suggestion type. Options: instructions, tools, sub_agent, skills, model. If not provided, returns all types.",
               "enum": [
                 "instructions",
                 "tools",
+                "sub_agent",
                 "skills",
                 "model"
               ],
@@ -346,8 +363,39 @@
         }
       },
       {
+        "name": "suggest_sub_agent",
+        "description": "Suggest adding or removing a sub-agent from the agent's configuration. A sub-agent allows the main agent to delegate tasks to a child agent. IMPORTANT: Include the tool output verbatim in your response - it renders as interactive card.",
+        "inputSchema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "additionalProperties": false,
+          "properties": {
+            "action": {
+              "description": "The action to perform: 'add' to add the sub-agent, 'remove' to remove it",
+              "enum": [
+                "add",
+                "remove"
+              ],
+              "type": "string"
+            },
+            "analysis": {
+              "description": "Analysis or reasoning for the suggestion",
+              "type": "string"
+            },
+            "subAgentId": {
+              "description": "The sId of the agent to add or remove as a sub-agent",
+              "type": "string"
+            }
+          },
+          "required": [
+            "action",
+            "subAgentId"
+          ],
+          "type": "object"
+        }
+      },
+      {
         "name": "suggest_tools",
-        "description": "Suggest adding or removing tools from the agent's configuration. IMPORTANT: Include the tool output verbatim in your response - it renders as interactive card.",
+        "description": "Suggest adding or removing tools from the agent's configuration. This tool does not support sub_agent suggestions - use `suggest_sub_agent` instead for that purpose. IMPORTANT: Include the tool output verbatim in your response - it renders as interactive card.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
           "additionalProperties": false,
@@ -430,6 +478,7 @@
     "toolsStakes": {
       "get_agent_feedback": "never_ask",
       "get_agent_insights": "never_ask",
+      "get_available_agents": "never_ask",
       "get_available_knowledge": "never_ask",
       "get_available_models": "never_ask",
       "get_available_skills": "never_ask",
@@ -438,6 +487,7 @@
       "suggest_model": "never_ask",
       "suggest_prompt_edits": "never_ask",
       "suggest_skills": "never_ask",
+      "suggest_sub_agent": "never_ask",
       "suggest_tools": "never_ask",
       "update_suggestions_state": "never_ask"
     }

--- a/front/lib/api/actions/servers/agent_copilot_context/agent_copilot_context.test.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/agent_copilot_context.test.ts
@@ -818,7 +818,7 @@ describe("agent_copilot_context tools", () => {
         if (content.type === "text") {
           // The suggestion should be of kind "tools" since it adds the run_agent tool.
           expect(content.text).toMatch(
-            /:agent_suggestion\[\]\{sId=\S+ kind=tools\}/
+            /:agent_suggestion\[\]\{sId=\S+ kind=sub_agent\}/
           );
         }
       }
@@ -864,7 +864,7 @@ describe("agent_copilot_context tools", () => {
         if (content.type === "text") {
           // The suggestion should be of kind "tools" since it removes the run_agent tool.
           expect(content.text).toMatch(
-            /:agent_suggestion\[\]\{sId=\S+ kind=tools\}/
+            /:agent_suggestion\[\]\{sId=\S+ kind=sub_agent\}/
           );
         }
       }

--- a/front/lib/api/actions/servers/agent_copilot_context/agent_copilot_context.test.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/agent_copilot_context.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { USED_MODEL_CONFIGS } from "@app/components/providers/types";
 import type { Authenticator } from "@app/lib/auth";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { AgentSuggestionFactory } from "@app/tests/utils/AgentSuggestionFactory";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
@@ -376,6 +377,40 @@ describe("agent_copilot_context tools", () => {
     });
   });
 
+  describe("get_available_agents", () => {
+    it("returns agents accessible to the user", async () => {
+      const { authenticator } = await createResourceTest({ role: "admin" });
+
+      // Create an agent configuration.
+      const agentConfiguration =
+        await AgentConfigurationFactory.createTestAgent(authenticator);
+
+      const tool = getToolByName("get_available_agents");
+      const result = await tool.handler({}, createTestExtra(authenticator));
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        const content = result.value[0];
+        expect(content.type).toBe("text");
+        if (content.type === "text") {
+          const parsed = JSON.parse(content.text);
+          expect(parsed.count).toBeGreaterThan(0);
+          expect(parsed.agents).toBeDefined();
+          expect(Array.isArray(parsed.agents)).toBe(true);
+
+          // Find our created agent.
+          const foundAgent = parsed.agents.find(
+            (a: { sId: string }) => a.sId === agentConfiguration.sId
+          );
+          expect(foundAgent).toBeDefined();
+          expect(foundAgent.name).toBe(agentConfiguration.name);
+          expect(foundAgent.description).toBe(agentConfiguration.description);
+          expect(foundAgent.scope).toBeDefined();
+        }
+      }
+    });
+  });
+
   describe("get_agent_feedback", () => {
     it("returns error when agent configuration ID is not available", async () => {
       const { authenticator } = await createResourceTest({ role: "admin" });
@@ -738,6 +773,100 @@ describe("agent_copilot_context tools", () => {
         expect(result.error.message).toContain("non-existent-tool-id");
         expect(result.error.message).toContain("invalid or not accessible");
         expect(result.error.message).toContain("get_available_tools");
+      }
+    });
+  });
+
+  describe("suggest_sub_agent", () => {
+    it("creates sub-agent suggestion with add action successfully", async () => {
+      const { authenticator } = await createResourceTest({ role: "admin" });
+
+      // Ensure auto internal tools (including run_agent) are created.
+      await MCPServerViewResource.ensureAllAutoToolsAreCreated(authenticator);
+
+      // Create the main agent configuration.
+      const mainAgentConfiguration =
+        await AgentConfigurationFactory.createTestAgent(authenticator);
+
+      // Create a sub-agent configuration.
+      const subAgentConfiguration =
+        await AgentConfigurationFactory.createTestAgent(authenticator, {
+          name: "SubAgent",
+        });
+
+      const { getAgentConfigurationIdFromContext } = await import(
+        "@app/lib/api/actions/servers/agent_copilot_helpers"
+      );
+      vi.mocked(getAgentConfigurationIdFromContext).mockReturnValueOnce(
+        mainAgentConfiguration.sId
+      );
+
+      const tool = getToolByName("suggest_sub_agent");
+      const result = await tool.handler(
+        {
+          action: "add",
+          subAgentId: subAgentConfiguration.sId,
+          analysis: "Adding sub-agent for delegation",
+        },
+        createTestExtra(authenticator)
+      );
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        const content = result.value[0];
+        expect(content.type).toBe("text");
+        if (content.type === "text") {
+          // The suggestion should be of kind "tools" since it adds the run_agent tool.
+          expect(content.text).toMatch(
+            /:agent_suggestion\[\]\{sId=\S+ kind=tools\}/
+          );
+        }
+      }
+    });
+
+    it("creates sub-agent suggestion with remove action successfully", async () => {
+      const { authenticator } = await createResourceTest({ role: "admin" });
+
+      // Ensure auto internal tools (including run_agent) are created.
+      await MCPServerViewResource.ensureAllAutoToolsAreCreated(authenticator);
+
+      // Create the main agent configuration.
+      const mainAgentConfiguration =
+        await AgentConfigurationFactory.createTestAgent(authenticator);
+
+      // Create a sub-agent configuration.
+      const subAgentConfiguration =
+        await AgentConfigurationFactory.createTestAgent(authenticator, {
+          name: "SubAgent",
+        });
+
+      const { getAgentConfigurationIdFromContext } = await import(
+        "@app/lib/api/actions/servers/agent_copilot_helpers"
+      );
+      vi.mocked(getAgentConfigurationIdFromContext).mockReturnValueOnce(
+        mainAgentConfiguration.sId
+      );
+
+      const tool = getToolByName("suggest_sub_agent");
+      const result = await tool.handler(
+        {
+          action: "remove",
+          subAgentId: subAgentConfiguration.sId,
+          analysis: "Removing sub-agent",
+        },
+        createTestExtra(authenticator)
+      );
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        const content = result.value[0];
+        expect(content.type).toBe("text");
+        if (content.type === "text") {
+          // The suggestion should be of kind "tools" since it removes the run_agent tool.
+          expect(content.text).toMatch(
+            /:agent_suggestion\[\]\{sId=\S+ kind=tools\}/
+          );
+        }
       }
     });
   });

--- a/front/lib/api/actions/servers/agent_copilot_context/metadata.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/metadata.ts
@@ -114,6 +114,22 @@ export const AGENT_COPILOT_CONTEXT_TOOLS_METADATA = createToolsRecord({
       done: "List available tools",
     },
   },
+  get_available_agents: {
+    description:
+      "Get the list of available agents that can be used as sub-agents. Returns active agents accessible to the current user, excluding global agents.",
+    schema: {
+      limit: z
+        .number()
+        .optional()
+        .default(100)
+        .describe("Maximum number of agents to return (default: 100)"),
+    },
+    stake: "never_ask",
+    displayLabels: {
+      running: "Listing available agents",
+      done: "List available agents",
+    },
+  },
   get_agent_feedback: {
     description: "Get user feedback for the agent.",
     schema: {
@@ -176,7 +192,9 @@ export const AGENT_COPILOT_CONTEXT_TOOLS_METADATA = createToolsRecord({
   },
   suggest_tools: {
     description:
-      "Suggest adding or removing tools from the agent's configuration. IMPORTANT: Include the tool output verbatim in your response - it renders as interactive card.",
+      "Suggest adding or removing tools from the agent's configuration. " +
+      "This tool does not support sub_agent suggestions - use `suggest_sub_agent` instead for that purpose. " +
+      "IMPORTANT: Include the tool output verbatim in your response - it renders as interactive card.",
     schema: {
       suggestion: ToolsSuggestionSchema.describe(
         "The tool additions and/or deletions to suggest"
@@ -190,6 +208,29 @@ export const AGENT_COPILOT_CONTEXT_TOOLS_METADATA = createToolsRecord({
     displayLabels: {
       running: "Suggesting tools",
       done: "Suggest tools",
+    },
+  },
+  suggest_sub_agent: {
+    description:
+      "Suggest adding or removing a sub-agent from the agent's configuration. A sub-agent allows the main agent to delegate tasks to a child agent. IMPORTANT: Include the tool output verbatim in your response - it renders as interactive card.",
+    schema: {
+      action: z
+        .enum(["add", "remove"])
+        .describe(
+          "The action to perform: 'add' to add the sub-agent, 'remove' to remove it"
+        ),
+      subAgentId: z
+        .string()
+        .describe("The sId of the agent to add or remove as a sub-agent"),
+      analysis: z
+        .string()
+        .optional()
+        .describe("Analysis or reasoning for the suggestion"),
+    },
+    stake: "never_ask",
+    displayLabels: {
+      running: "Suggesting sub-agent",
+      done: "Suggest sub-agent",
     },
   },
   suggest_skills: {

--- a/front/lib/resources/agent_suggestion_resource.test.ts
+++ b/front/lib/resources/agent_suggestion_resource.test.ts
@@ -73,7 +73,6 @@ describe("AgentSuggestionResource", () => {
           suggestion: {
             action: "add",
             toolId: "github",
-            additionalConfiguration: { repo: "dust" },
           },
           analysis: "Adding GitHub tool",
         }
@@ -93,7 +92,6 @@ describe("AgentSuggestionResource", () => {
       expect(json.suggestion).toEqual({
         action: "add",
         toolId: "github",
-        additionalConfiguration: { repo: "dust" },
       });
     });
 

--- a/front/scripts/seed/copilot/assets/suggestions.json
+++ b/front/scripts/seed/copilot/assets/suggestions.json
@@ -42,5 +42,15 @@
       "skillId": "frames"
     },
     "analysis": "Adding the Frames skill would allow the agent to create interactive weather visualizations like temperature charts, precipitation graphs, and forecast timelines."
+  },
+  {
+    "agentName": "MeteoWithSuggestions",
+    "kind": "sub_agent",
+    "suggestion": {
+      "action": "add",
+      "toolId": "run_agent",
+      "childAgentId": "TechNewsDigest"
+    },
+    "analysis": "Adding TechNewsDigest as a sub-agent would allow the weather assistant to delegate tech news queries to a specialized agent when users ask about tech-related weather impacts on technology infrastructure."
   }
 ]

--- a/front/scripts/seed/copilot/seed.test.ts
+++ b/front/scripts/seed/copilot/seed.test.ts
@@ -169,7 +169,7 @@ describe("copilot seed script integration test", () => {
         meteoAgent!.sId,
         { limit: 100 }
       );
-    expect(meteoSuggestions.length).toBe(5);
+    expect(meteoSuggestions.length).toBe(6);
 
     // Verify suggestion kinds
     const suggestionKinds = meteoSuggestions.map((s) => s.toJSON().kind);
@@ -177,6 +177,7 @@ describe("copilot seed script integration test", () => {
     expect(suggestionKinds).toContain("model");
     expect(suggestionKinds).toContain("skills");
     expect(suggestionKinds.filter((k) => k === "instructions").length).toBe(2);
+    expect(suggestionKinds).toContain("sub_agent");
 
     // 5. Create feedbacks
     await seedFeedbacks(ctx, assets.feedbacks);

--- a/front/scripts/seed/factories/types.ts
+++ b/front/scripts/seed/factories/types.ts
@@ -3,10 +3,7 @@ import type { SpaceResource } from "@app/lib/resources/space_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import type { Logger } from "@app/logger/logger";
 import type { LightWorkspaceType } from "@app/types";
-import type {
-  AgentSuggestionKind,
-  SuggestionPayload,
-} from "@app/types/suggestions/agent_suggestion";
+import type { AgentSuggestionData } from "@app/types/suggestions/agent_suggestion";
 
 // Seed context shared across all seed functions
 export interface SeedContext {
@@ -86,9 +83,7 @@ export interface SeedSpaceResult {
   restrictedSpace: SpaceResource | undefined;
 }
 
-export interface SuggestionAsset {
+export type SuggestionAsset = AgentSuggestionData & {
   agentName: string;
-  kind: AgentSuggestionKind;
-  suggestion: SuggestionPayload;
   analysis: string | null;
-}
+};

--- a/front/tests/utils/AgentSuggestionFactory.ts
+++ b/front/tests/utils/AgentSuggestionFactory.ts
@@ -7,6 +7,7 @@ import type {
   InstructionsSuggestionType,
   ModelSuggestionType,
   SkillsSuggestionType,
+  SubAgentSuggestionType,
   ToolsSuggestionType,
 } from "@app/types/suggestions/agent_suggestion";
 
@@ -57,11 +58,37 @@ export class AgentSuggestionFactory {
         suggestion: overrides.suggestion ?? {
           action: "add",
           toolId: "notion",
-          additionalConfiguration: { database: "tasks" },
         },
         analysis: overrides.analysis ?? "Added useful integration",
         state: overrides.state ?? "pending",
         source: overrides.source ?? "reinforcement",
+      }
+    );
+  }
+
+  static async createSubAgent(
+    auth: Authenticator,
+    agentConfiguration: LightAgentConfigurationType,
+    overrides: Partial<{
+      suggestion: SubAgentSuggestionType;
+      analysis: string | null;
+      state: AgentSuggestionState;
+      source: AgentSuggestionSource;
+    }> = {}
+  ): Promise<AgentSuggestionResource> {
+    return AgentSuggestionResource.createSuggestionForAgent(
+      auth,
+      agentConfiguration,
+      {
+        kind: "sub_agent",
+        suggestion: overrides.suggestion ?? {
+          action: "add",
+          toolId: "run_agent",
+          childAgentId: "child_agent_sid",
+        },
+        analysis: overrides.analysis ?? "Added sub-agent delegation",
+        state: overrides.state ?? "pending",
+        source: overrides.source ?? "copilot",
       }
     );
   }


### PR DESCRIPTION
## Description

Closes https://github.com/dust-tt/tasks/issues/6310

 - Add MCP to list available agents
 - Add MCP to suggest sub agent
 - Add dust-hive seed's tools suggestion with run_agent 

## Tests

Unit tests for MCP

Manual tests for UI

https://github.com/user-attachments/assets/6fe80395-c912-4c17-9bbe-5df9dcb50d8d

## Risk

low

## Deploy Plan

deploy front 
