### PR TITLE
Add separate app for oauth pages

### DIFF
--- a/front-spa/oauth.html
+++ b/front-spa/oauth.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex" />
+    <title>Dust - OAuth</title>
+    <script>
+      // Shim for Node.js Buffer API used by some dependencies
+      globalThis.Buffer = globalThis.Buffer || {
+        isBuffer: function () {
+          return false;
+        },
+        from: function (x) {
+          return new Uint8Array(
+            typeof x === "string"
+              ? Array.from(x).map(function (c) {
+                  return c.charCodeAt(0);
+                })
+              : x
+          );
+        },
+        alloc: function (n) {
+          return new Uint8Array(n);
+        },
+      };
+    </script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/oauth/main.tsx"></script>
+  </body>
+</html>

--- a/front-spa/public-app/_redirects
+++ b/front-spa/public-app/_redirects
@@ -1,6 +1,9 @@
 # /share routes - must be before the catch-all
 /share /_share/ 200
 /share/* /_share/ 200
+# OAuth routes - must be before the catch-all
+/oauth/*  /_oauth/  200
+/w/:wId/oauth/*  /_oauth/ 200
 
 # SPA fallback for main app
 /* /index.html 200

--- a/front-spa/src/oauth/OAuthApp.tsx
+++ b/front-spa/src/oauth/OAuthApp.tsx
@@ -1,0 +1,38 @@
+import { ErrorBoundary } from "@dust-tt/front/components/error_boundary/ErrorBoundary";
+import { OAuthFinalizePage } from "@dust-tt/front/components/pages/oauth/OAuthFinalizePage";
+import { OAuthSetupRedirectPage } from "@dust-tt/front/components/pages/oauth/OAuthSetupRedirectPage";
+import { RegionProvider } from "@dust-tt/front/lib/auth/RegionContext";
+import { FetcherProvider } from "@dust-tt/front/lib/swr/FetcherContext";
+import { fetcher, fetcherWithBody } from "@dust-tt/front/lib/swr/fetcher";
+import { GlobalErrorFallback } from "@spa/app/components/GlobalErrorFallback";
+import { createBrowserRouter, RouterProvider } from "react-router-dom";
+
+const router = createBrowserRouter(
+  [
+    // Setup: /w/:wId/oauth/:provider/setup
+    {
+      path: "/w/:wId/oauth/:provider/setup",
+      element: <OAuthSetupRedirectPage />,
+    },
+    // Finalize: /oauth/:provider/finalize
+    {
+      path: "/oauth/:provider/finalize",
+      element: <OAuthFinalizePage />,
+    },
+  ],
+  {
+    basename: import.meta.env?.VITE_BASE_PATH ?? "",
+  }
+);
+
+export default function OAuthApp() {
+  return (
+    <FetcherProvider fetcher={fetcher} fetcherWithBody={fetcherWithBody}>
+      <RegionProvider>
+        <ErrorBoundary fallback={<GlobalErrorFallback />}>
+          <RouterProvider router={router} />
+        </ErrorBoundary>
+      </RegionProvider>
+    </FetcherProvider>
+  );
+}

--- a/front-spa/src/oauth/main.tsx
+++ b/front-spa/src/oauth/main.tsx
@@ -1,0 +1,18 @@
+// Tailwind base globals
+import "@dust-tt/front/styles/global.css";
+// Use sparkle styles, override local globals
+import "@dust-tt/sparkle/dist/sparkle.css";
+// Local tailwind components override sparkle styles
+import "@dust-tt/front/styles/components.css";
+// Local index.css for any app-specific overrides
+import "@spa/index.css";
+
+import OAuthApp from "@spa/oauth/OAuthApp";
+import React from "react";
+import ReactDOM from "react-dom/client";
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <OAuthApp />
+  </React.StrictMode>
+);

--- a/front-spa/vite.config.ts
+++ b/front-spa/vite.config.ts
@@ -1,18 +1,25 @@
 import react from "@vitejs/plugin-react";
 import path from "path";
-import type { Plugin } from "vite";
+import type { Plugin, PluginOption } from "vite";
 import { defineConfig, loadEnv } from "vite";
 
 const apps = {
   app: {
-    assets: [["share.html", "_share/index.html"]], // underscore prefix avoids Pretty URLs conflict
+    assets: [
+      ["share.html", "_share/index.html"],
+      ["oauth.html", "_oauth/index.html"],
+    ], // underscore prefix avoids Pretty URLs conflict
     inputs: {
       main: path.resolve(__dirname, "index.html"),
       share: path.resolve(__dirname, "share.html"),
+      oauth: path.resolve(__dirname, "oauth.html"),
     },
     serveMapping: (url: string | undefined) => {
       if (url?.startsWith("/share")) {
         return "/share.html";
+      }
+      if (url?.startsWith("/oauth/") || url?.match(/^\/w\/[^/]+\/oauth\//)) {
+        return "/oauth.html";
       }
       return "/index.html";
     },
@@ -166,6 +173,10 @@ export default defineConfig(({ mode }) => {
 
   // Determine which app to build: "poke" or "app" (default: "app")
   const appName = env.VITE_APP_NAME ?? "app";
+  if (appName !== "poke" && appName !== "app") {
+    throw new Error(`Invalid app name: ${appName}`);
+  }
+
   const appDefinition = apps[appName];
 
   // Map NEXT_PUBLIC_* env vars to process.env.NEXT_PUBLIC_* for compatibility
@@ -197,7 +208,7 @@ export default defineConfig(({ mode }) => {
       organizeMultiEntryOutputPlugin(appDefinition),
       reactScanPlugin(enableReactScan),
       react(),
-    ],
+    ].flat() as PluginOption[],
     define: {
       ...envVarDefines,
       // Fallback for any remaining process.env access


### PR DESCRIPTION
## Description

Builds the OAuth setup and finalize pages into a separate independent bundle, similar to the existing `share` app pattern.

### Changes

- **`oauth.html`**: New HTML entry point for the OAuth app with Buffer shim and `noindex` meta tag.
- **`OAuthApp.tsx`**: Minimal React app with two routes:
  - `/w/:wId/oauth/:provider/setup` → `OAuthSetupRedirectPage`
  - `/oauth/:provider/finalize` → `OAuthFinalizePage`
- **`main.tsx`**: Entry point that mounts `OAuthApp` into the DOM.
- **`vite.config.ts`**: Added `oauth.html` as a new multi-entry input, with dev server URL mapping for `/oauth/` and `/w/*/oauth/` paths, and build output organized to `oauth/index.html`.
- **`_redirects`**: Added Netlify rewrite rules for `/oauth/*` and `/w/*/oauth/*` to serve the OAuth SPA.

### Why

Separating the OAuth pages into their own bundle keeps the main app bundle smaller and allows the OAuth flow (setup redirect + finalize callback) to load independently without pulling in the full application.

### Next steps

The OAuth pages are bundled but not yet served from the SPA URL. The generated OAuth redirect URLs still point to the Next.js app (`clientFacingUrl`). Switching to the SPA-served OAuth pages requires updating the allowed redirect URLs for all OAuth apps (across all providers) first.

## Tests

Tested locally: OAuth connection setup and finalize flows work correctly.

## Risk

Low — no functional change. OAuth redirect URLs are unchanged and still point to the Next.js app. The new bundle is deployed but not actively used yet.

## Deploy Plan

No special deploy steps required. The new `oauth/index.html` bundle is built alongside the existing app and share bundles.