### PR TITLE
[front] Snowflake MCP keypair backend/runtime auth

### DIFF
--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -230,6 +230,34 @@ export async function connectToMCPServer(
                 client.setAuthInfo(authInfo);
                 server.setAuthInfo(authInfo);
               } else {
+                if (params.oAuthUseCase === "platform_actions") {
+                  const workspaceConnectionRes =
+                    await MCPServerConnectionResource.findByMCPServer(auth, {
+                      mcpServerId: params.mcpServerId,
+                      connectionType: "workspace",
+                    });
+
+                  if (
+                    workspaceConnectionRes.isOk() &&
+                    workspaceConnectionRes.value.credentialId
+                  ) {
+                    const authInfo: AuthInfo = {
+                      token: "",
+                      expiresAt: undefined,
+                      clientId: "",
+                      scopes: [],
+                      extra: {
+                        credentialId: workspaceConnectionRes.value.credentialId,
+                        connectionType: "workspace",
+                      },
+                    };
+
+                    client.setAuthInfo(authInfo);
+                    server.setAuthInfo(authInfo);
+                    break;
+                  }
+                }
+
                 // For now, keeping iso.
                 logger.warn(
                   {

--- a/front/lib/actions/mcp_server_connection_credential_policies/index.ts
+++ b/front/lib/actions/mcp_server_connection_credential_policies/index.ts
@@ -1,0 +1,22 @@
+import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
+import type { CredentialsProvider } from "@app/types";
+
+import { SNOWFLAKE_INTERNAL_SERVER_CREDENTIAL_POLICY } from "./snowflake";
+
+export interface InternalServerCredentialPolicy {
+  provider: CredentialsProvider;
+  validateContent: (content: unknown) => boolean;
+  invalidContentMessage: string;
+}
+
+const INTERNAL_SERVER_CREDENTIAL_POLICIES: Partial<
+  Record<InternalMCPServerNameType, InternalServerCredentialPolicy>
+> = {
+  snowflake: SNOWFLAKE_INTERNAL_SERVER_CREDENTIAL_POLICY,
+};
+
+export function getInternalServerCredentialPolicy(
+  serverName: InternalMCPServerNameType
+): InternalServerCredentialPolicy | null {
+  return INTERNAL_SERVER_CREDENTIAL_POLICIES[serverName] ?? null;
+}

--- a/front/lib/actions/mcp_server_connection_credential_policies/snowflake.ts
+++ b/front/lib/actions/mcp_server_connection_credential_policies/snowflake.ts
@@ -1,0 +1,11 @@
+import { isLeft } from "fp-ts/lib/Either";
+
+import { SnowflakeKeyPairCredentialsSchema } from "@app/types";
+
+export const SNOWFLAKE_INTERNAL_SERVER_CREDENTIAL_POLICY = {
+  provider: "snowflake",
+  validateContent: (content: unknown) =>
+    !isLeft(SnowflakeKeyPairCredentialsSchema.decode(content)),
+  invalidContentMessage:
+    "The credential provided must be a Snowflake key-pair credential.",
+} as const;


### PR DESCRIPTION
## Description

Backend/runtime support for Snowflake internal MCP server key-pair workspace authentication.

- Extend MCP connection creation API to accept credential-backed workspace connections (`credentialId`).
- Refactor MCP connection auth validation into a typed auth-reference flow (`oauth_connection` / `credential`) with a server credential-policy map.
- Keep Snowflake as the first credential policy (ownership + provider + key-pair schema checks).
- Support Snowflake runtime auth via either OAuth token or key-pair credentials in Snowflake client/tool handlers.
- Add provider-agnostic credential-based fallback in MCP metadata auth routing for platform actions.

Stacked PRs:
- UI flow: #21216
- Refactor-only cleanup: #21215

## Tests

Manual

## Risk

Medium.

- Runtime auth path changes for Snowflake MCP tools.
- Connection API now supports credential-backed references with a new generic validation layer.

## Deploy Plan

- Deploy as usual.