### PR TITLE
Add [GEN10] coding rule for config usage

### DIFF
--- a/front/CODING_RULES.md
+++ b/front/CODING_RULES.md
@@ -167,6 +167,25 @@ const timeoutMs = 5000;
 const delaySeconds = 30;
 ```
 
+### [GEN10] Using config for environment variables
+
+Never access environment variables directly via `process.env`. Instead, use the `@app/lib/api/config`
+module which provides type-safe access to environment variables.
+
+Example:
+
+```
+// BAD
+const apiUrl = process.env.API_URL;
+const isProduction = process.env.NODE_ENV === "production";
+
+// GOOD
+import config from "@app/lib/api/config";
+
+const apiUrl = config.getApiUrl();
+const isProduction = config.getNodeEnv() === "production";
+```
+
 ## SECURITY
 
 ### [SEC1] No sensitive data outside of HTTP bodies or headers


### PR DESCRIPTION
## Description
Add coding rule [GEN10] requiring use of `@app/lib/api/config` for environment variables instead of direct `process.env` access.

## Risks
Blast radius: documentation only
Risk: none

## Deploy Plan
- deploy front