### PR TITLE
Set 2-minute query timeout on BigQuery, Snowflake connector, and Snowflake MCP

### DIFF
--- a/core/src/databases/remote_databases/remote_database.rs
+++ b/core/src/databases/remote_databases/remote_database.rs
@@ -1,5 +1,10 @@
+use std::time::Duration;
+
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
+
+/// Maximum duration a data warehouse query is allowed to run before being cancelled.
+pub const QUERY_TIMEOUT: Duration = Duration::from_secs(120);
 
 use crate::{
     databases::{

--- a/core/src/databases/remote_databases/snowflake/api/query.rs
+++ b/core/src/databases/remote_databases/snowflake/api/query.rs
@@ -9,6 +9,8 @@ use reqwest::Client;
 use tokio::sync::Mutex;
 use tokio::time::sleep;
 
+use crate::databases::remote_databases::remote_database::QUERY_TIMEOUT;
+
 use super::{
     chunk::download_chunk,
     error::{Error, Result},
@@ -18,7 +20,6 @@ use super::{
 
 pub const SESSION_EXPIRED: &str = "390112";
 pub const QUERY_IN_PROGRESS_ASYNC_CODE: &str = "333334";
-const DEFAULT_TIMEOUT_SECONDS: u64 = 300;
 
 pub struct QueryExecutor {
     http: Client,
@@ -41,7 +42,7 @@ impl QueryExecutor {
             session_token,
             timeout,
         } = sess;
-        let timeout = timeout.unwrap_or(Duration::from_secs(DEFAULT_TIMEOUT_SECONDS));
+        let timeout = timeout.unwrap_or(QUERY_TIMEOUT);
 
         let request_id = uuid::Uuid::new_v4();
         let url = format!(

--- a/core/src/databases/remote_databases/snowflake/snowflake.rs
+++ b/core/src/databases/remote_databases/snowflake/snowflake.rs
@@ -8,7 +8,7 @@ use serde::Deserialize;
 
 use crate::databases::{
     database::{QueryDatabaseError, QueryResult, SqlDialect},
-    remote_databases::remote_database::RemoteDatabase,
+    remote_databases::remote_database::{RemoteDatabase, QUERY_TIMEOUT},
     table::Table,
     table_schema::{TableSchema, TableSchemaColumn, TableSchemaFieldType},
 };
@@ -253,7 +253,7 @@ impl SnowflakeRemoteDatabase {
                 role: Some(role),
                 database: None,
                 schema: None,
-                timeout: Some(std::time::Duration::from_secs(60)),
+                timeout: Some(QUERY_TIMEOUT),
             },
         )
         .map_err(|e| {


### PR DESCRIPTION
## Description

Enforce a consistent 2-minute query timeout across all database connectors:

- **BigQuery connector** (`core`): Set `job_timeout_ms = 120000` on the `JobConfiguration` so BigQuery cancels long-running jobs. Replace the immediate error on `job_complete == false` with a polling retry loop (2s interval) that waits up to 2 minutes before returning a timeout error.
- **Snowflake connector** (`core`): Increase the session timeout from 60s to 120s and align `DEFAULT_TIMEOUT_SECONDS` from 300s to 120s for consistency.
- **Snowflake MCP server** (`front`): Set `STATEMENT_TIMEOUT_IN_SECONDS = 120` via `ALTER SESSION` after connecting, ensuring the MCP server also enforces the 2-minute limit.

## Tests

- `cargo check` passes in `core/`
- TypeScript type-check passes in `front/`
- Manual verification that the BigQuery polling loop correctly handles incomplete jobs and times out after 2 minutes

## Risk

Low. These are timeout guardrails — they prevent runaway queries but don't change normal query execution. The BigQuery polling loop is a strict improvement over the previous immediate error on incomplete jobs. Snowflake MCP timeout is additive (no previous timeout existed).

## Deploy Plan

Standard deploy. No migration needed. Changes take effect on next request after deploy.