### PR TITLE
Clear existing heartbeat timeout before creating new one

### DIFF
--- a/front/lib/actions/mcp_actions.ts
+++ b/front/lib/actions/mcp_actions.ts
@@ -415,10 +415,9 @@ export async function* tryCallMCPTool(
     let notificationPromise = notificationStream.next();
 
     // Frequently heartbeat to get notified of cancellation.
-    let heartbeatTimeoutId: ReturnType<typeof setTimeout> | null = null;
     const createHeartbeatPromise = (): Promise<void> =>
       new Promise((resolve) => {
-        heartbeatTimeoutId = setTimeout(() => {
+        setTimeout(() => {
           logger.info(toolLogContext, "MCP tool heartbeat");
           heartbeat();
           resolve();
@@ -456,11 +455,6 @@ export async function* tryCallMCPTool(
         notificationPromise = notificationStream.next();
         yield makeToolNotificationEvent(iteratorResult.value);
       }
-    }
-
-    // Clean up any pending heartbeat timeout.
-    if (heartbeatTimeoutId !== null) {
-      clearTimeout(heartbeatTimeoutId);
     }
 
     let toolCallResult: Awaited<typeof toolPromise>;


### PR DESCRIPTION
## Description

The problem is that a new `getHeartbeatPromise()` is created on every iteration of the loop, but the setTimeout callbacks from previous iterations are never cancelled.

This can end up causing many more heartbeat calls than we intended, and maybe that can negative side effects.

The fix is to cancel the previous timeout before creating a new one.

This may or may not help with https://github.com/dust-tt/tasks/issues/6308, but it's worth getting in to see where that leaves us.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Front
