### PR TITLE
[front] feat(skills): Add `isDisabledForAgentLoop` property on global skills

### DIFF
--- a/front/lib/resources/skill/global/registry.ts
+++ b/front/lib/resources/skill/global/registry.ts
@@ -8,6 +8,7 @@ import type { AllSkillConfigurationFindOptions } from "@app/lib/resources/skill/
 import type { ResourceSId } from "@app/lib/resources/string_ids";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { removeNulls } from "@app/types";
+import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
 
 export type MCPServerDefinition = {
   name: AutoInternalMCPServerNameType;
@@ -26,6 +27,9 @@ interface BaseGlobalSkillDefinition {
   readonly inheritAgentConfigurationDataSources?: boolean;
   readonly isAutoEnabled?: boolean;
   readonly isRestricted?: (auth: Authenticator) => Promise<boolean>;
+  readonly isDisabledForAgentLoop?: (
+    agentLoopData: AgentLoopExecutionData
+  ) => boolean;
 }
 
 type WithStaticInstructions<T extends BaseGlobalSkillDefinition> = T & {

--- a/front/lib/resources/skill/global/registry.ts
+++ b/front/lib/resources/skill/global/registry.ts
@@ -27,6 +27,7 @@ interface BaseGlobalSkillDefinition {
   readonly inheritAgentConfigurationDataSources?: boolean;
   readonly isAutoEnabled?: boolean;
   readonly isRestricted?: (auth: Authenticator) => Promise<boolean>;
+  // Optional callback to hide a skill from a given agent loop (both from equipped and enabled).
   readonly isDisabledForAgentLoop?: (
     agentLoopData: AgentLoopExecutionData
   ) => boolean;

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1010,10 +1010,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
   /**
    * List skills for the agent loop, returning both (extended) enabled skills and equipped skills.
-   *
-   * When called with full `AgentLoopExecutionData`, skills with `isDisabledForAgentLoop` returning
-   * true will be filtered out. When called with just `{ agentConfiguration, conversation }`, no
-   * filtering is applied (for auxiliary tools).
    */
   static async listForAgentLoop(
     auth: Authenticator,
@@ -1554,7 +1550,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
       // Save the current version before updating.
       await this.saveVersion(auth, { transaction });
 
-      // Snapshot the previously requested space IDs before updating.
+      // Snapshot the previous requested space IDs before updating.
       const previousRequestedSpaceIds = [...this.requestedSpaceIds];
 
       const editedBy = auth.user()?.id;

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1017,16 +1017,17 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
    */
   static async listForAgentLoop(
     auth: Authenticator,
-    params: AgentLoopExecutionData | {
-      agentConfiguration: AgentConfigurationType;
-      conversation: ConversationType;
-    }
+    params:
+      | AgentLoopExecutionData
+      | {
+          agentConfiguration: AgentConfigurationType;
+          conversation: ConversationType;
+        }
   ): Promise<{
     enabledSkills: (SkillResource & { extendedSkill: SkillResource | null })[];
     equippedSkills: SkillResource[];
   }> {
-    const { agentConfiguration, conversation } =
-      params;
+    const { agentConfiguration, conversation } = params;
     // Light type-guard to check whether we have a full AgentLoopExecutionData.
     const agentLoopData = "userMessage" in params ? params : undefined;
 

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -42,7 +42,6 @@ import {
   createSpaceIdToGroupsMap,
 } from "@app/lib/resources/permission_utils";
 import type { GlobalSkillDefinition } from "@app/lib/resources/skill/global/registry";
-import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
 import { GlobalSkillsRegistry } from "@app/lib/resources/skill/global/registry";
 import type { SkillConfigurationFindOptions } from "@app/lib/resources/skill/types";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -74,6 +73,7 @@ import {
   removeNulls,
   SKILL_GROUP_PREFIX,
 } from "@app/types";
+import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
 import type {
   SkillStatus,
   SkillType,

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -971,7 +971,6 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
   /**
    * List enabled skills for a conversation.
-   *
    * If agentConfiguration is provided, includes both agent-enabled and conversation-enabled skills.
    * Otherwise, returns only conversation-enabled skills (JIT).
    */

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -1014,10 +1014,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
     auth: Authenticator,
     params:
       | AgentLoopExecutionData
-      | {
-          agentConfiguration: AgentConfigurationType;
-          conversation: ConversationType;
-        }
+      | Pick<AgentLoopExecutionData, "agentConfiguration" | "conversation">
   ): Promise<{
     enabledSkills: (SkillResource & { extendedSkill: SkillResource | null })[];
     equippedSkills: SkillResource[];

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -181,10 +181,7 @@ export async function runModelActivity(
     );
 
   const { enabledSkills, equippedSkills } =
-    await SkillResource.listForAgentLoop(auth, {
-      agentConfiguration,
-      conversation,
-    });
+    await SkillResource.listForAgentLoop(auth, runAgentData);
 
   const skillServers = await getSkillServers(auth, {
     agentConfiguration,


### PR DESCRIPTION
## Description

- This PR adds the ability to add an optional `isDisabledForAgentLoop` callback when defining a global skill.
- This callback can be used to dynamically hide a global skill depending on the context (e.g. user message origin).
- This will be useful to hide the mentions skill when used via Slack or Teams.

## Tests

- Tested locally.

## Risk

- Medium.

## Deploy Plan

- Deploy front.
