### PR TITLE
Update copilot instructions to be block aware

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/dust/copilot.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/copilot.ts
@@ -131,34 +131,121 @@ This includes contradictory information in different instruction sections.
 If a user is providing conflicting requirements, ask clarifying questions to understand the user's intent.
 </contradictory_information>
 
-<formatting>
-You SHOULD use these formatting elements to improve the visual presentation of your suggestions.
+<newline_discipline>
+Be conservative with newlines. Only add them when they genuinely improve readability.
 
-For major logical sections in complex agents, use XML instruction blocks:
-- Examples: \`<primary_goal>\`, \`<instructions>\`, \`<guidelines>\`, \`<context>\`, \`<output_format>\`, etc.
-- Custom tag names allowed: letters, numbers, dots, underscores, hyphens, colons
-- Blocks are collapsible in the editor UI
-- Example: \`<primary_goal>content</primary_goal>\`
+When newlines help:
+- Between blocks (one blank line to separate sections)
+- To separate distinct logical steps in a process
 
-Within XML blocks or for simple agents, use standard markdown:
-- **Bold**: \`**text**\` - for key terms and critical points
-- *Italic*: \`*text*\` - for emphasis
-- Inline code: \`\\\`code\\\`\` - for tool names, parameters
-- Bullet lists: \`-\` prefix
-- Numbered lists: \`1.\`, \`2.\` - only for sequential steps
-- Code blocks with optional language:
-  \`\`\`python
-  code
-  \`\`\`
-- Links: \`[text](url)\`
-- Horizontal rules: \`---\` - only for simple agents without XML blocks
-
-CRITICAL - Don't mix markdown headings (#, ##) with XML blocks:
-- Complex agents (3+ sections): Use XML blocks for structure, markdown within
-- Simple agents (<150 words): Use markdown only, no XML blocks needed
-</formatting>
+When newlines hurt:
+- Multiple consecutive blank lines
+<newline_discipline>
 
 </agent_instructions_best_practices>`,
+
+  blockAwareEditing: `<block_aware_editing>
+Agent instructions are organized into "blocks" - logical containers that group related instructions. A block can be:
+- **XML tags**: \`<primary_goal>content</primary_goal>\`
+- **Markdown sections**: \`## Primary Goal\` followed by content until the next heading
+
+Both serve the same purpose: creating cohesive, navigable units. Your job is to recognize whichever structure the agent uses and work within it.
+Match your suggestions to whatever structure exists. Don't convert markdown agents to XML or vice versa unless explicitly asked.
+
+<block_editing_principles>
+1. Think in blocks, not documents - Before suggesting, identify what blocks exist and which one(s) your change affects.
+2. Prefer inline changes within a single block - For small improvements, edit content INSIDE the relevant block without touching other blocks.
+3. Bias toward one suggestion per block - Unless changes are clearly coupled, create separate suggestions for separate blocks. Users can accept/reject independently.
+4. Cross-block changes require justification - Modify multiple blocks only when:
+   - Creating a new agent from scratch
+   - Fundamental structural changes (splitting/merging blocks)
+   - Changes that genuinely span concerns
+</block_editing_principles>
+
+<block_examples>
+EXAMPLE 1: User says "change the output format to JSON"
+Agent structure:
+\`\`\`
+## Role
+You are a data analyst that processes customer feedback.
+
+## Output Format
+Return results as a bulleted list.
+\`\`\`
+
+WRONG - Editing multiple blocks:
+\`\`\`
+oldString: "## Role\\nYou are a data analyst that processes customer feedback.\\n\\n## Output Format\\nReturn results as a bulleted list."
+newString: "## Role\\nYou are a data analyst that processes customer feedback and returns JSON.\\n\\n## Output Format\\nReturn results as JSON."
+\`\`\`
+Only Output Format needs changing. Role should not be modified.
+
+CORRECT - Edit only the affected block:
+\`\`\`
+oldString: "Return results as a bulleted list."
+newString: "Return results as JSON."
+\`\`\`
+
+---
+
+EXAMPLE 2: User says "add a constraint about PII"
+Agent structure:
+\`\`\`
+<primary_goal>You analyze customer feedback.</primary_goal>
+<output_format>...</output_format>
+\`\`\`
+
+WRONG - Adding to wrong block:
+\`\`\`
+oldString: "<primary_goal>You analyze customer feedback.</primary_goal>"
+newString: "<primary_goal>You analyze customer feedback. Never output PII.</primary_goal>"
+\`\`\`
+Constraints need their own block.
+
+CORRECT - Create dedicated constraints block:
+\`\`\`
+oldString: "</output_format>"
+newString: "</output_format>\\n\\n<constraints>\\nNEVER output personally identifiable information (names, emails, phone numbers).\\nRedact or anonymize any PII in examples.\\n</constraints>"
+\`\`\`
+
+---
+
+EXAMPLE 3: User says "create a meeting prep agent" (empty instructions)
+
+CORRECT - Create complete structure:
+Simple agent (markdown):
+\`\`\`
+oldString: ""
+newString: "## Role\\nYou prepare briefings for upcoming meetings.\\n\\n## Process\\n1. When given a meeting, identify attendees\\n2. Pull relevant context from CRM and past notes\\n3. Summarize key points and suggested talking points\\n\\n## Output\\nProvide a one-page briefing with sections for: Attendees, Context, Key Points, Suggested Questions"
+\`\`\`
+
+Complex agent (XML):
+\`\`\`
+oldString: ""
+newString: "<primary_goal>\\nYou prepare comprehensive briefings for meetings...\\n</primary_goal>\\n\\n<process>\\n1. Identify meeting type (internal/external/sales/support)\\n2. Based on type:\\n   - Sales: Pull CRM opportunity data...\\n   - Support: Pull ticket history...\\n</process>\\n\\n<output_format>\\n..."
+\`\`\`
+
+<structure_recommendations>
+When creating an agent, choose the appropriate structure and formatting:
+- For Simple agents (single purpose, <150 words, no conditionals), use markdown only. Headings optional. Keep it lightweight.
+- For Medium agents (2-3 concerns, 150-400 words), use markdown headers (\`##\`) to separate sections.
+- For Complex agents (multiple capabilities, conditionals, 400+ words), use XML blocks for clear separation and collapsibility. Custom tag names allowed: letters, numbers, dots, underscores, hyphens, colons.
+
+Allowed formatting within blocks:
+- **Bold** (\`**text**\`): Key terms and critical points
+- *Italic* (\`*text*\`): Emphasis
+- Inline code (\`\\\`code\\\`\`): Tool names, parameters
+- Bullet lists (\`-\`): General lists
+- Numbered lists (\`1.\`, \`2.\`): Sequential steps only
+- Code blocks: \`\`\`language\\ncode\`\`\`
+- Links: \`[text](url)\`
+- Horizontal rules (\`---\`): Only for simple agents without XML blocks
+
+Don't mix markdown headings (\`#\`, \`##\`) with XML blocks:
+- Complex agents (3+ sections): Use XML blocks for structure, markdown within
+- Simple agents (<150 words): Use markdown only, no XML blocks needed
+</structure_recommendations>
+</block_aware_editing>`,
 
   dustConcepts: `<dust_platform_concepts>
 <tools_vs_skills_vs_instructions>
@@ -287,6 +374,7 @@ function buildCopilotInstructions(
     COPILOT_INSTRUCTION_SECTIONS.workflowVisualization,
     COPILOT_INSTRUCTION_SECTIONS.unsavedChanges,
     COPILOT_INSTRUCTION_SECTIONS.agentInstructions,
+    COPILOT_INSTRUCTION_SECTIONS.blockAwareEditing,
     COPILOT_INSTRUCTION_SECTIONS.dustConcepts,
   ];
 


### PR DESCRIPTION
## Description

* Adding logic to be be more "block aware". Bias towards block in-line changes. Bias against cross-block changes unless justified. Provided A/B examples.

## Tests

* Local testing. Tests are passing and seeing quality results for manual agent creation. Only call out is that for less complex agents, it is no longer biasing towards xml (leaning more to use markdown), which I think is reasonable.

* ## Risk

* Low

## Deploy Plan

* Deploy front