### PR TITLE
Add tools for listing and replying to comments

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
@@ -4725,10 +4725,12 @@
       "create_comment": "low",
       "create_document": "low",
       "create_presentation": "low",
+      "create_reply": "low",
       "create_spreadsheet": "low",
       "get_file_content": "never_ask",
       "get_spreadsheet": "never_ask",
       "get_worksheet": "never_ask",
+      "list_comments": "never_ask",
       "list_drives": "never_ask",
       "search_files": "never_ask",
       "update_document": "medium"

--- a/front/lib/api/actions/servers/google_drive/metadata.ts
+++ b/front/lib/api/actions/servers/google_drive/metadata.ts
@@ -173,10 +173,40 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
     stake: "low",
   },
   create_comment: {
-    description: "Add a comment to a Google Drive file (Doc, Sheet, or Slide).",
+    description:
+      "Add a comment to a Google Drive file (Doc, Sheet, or Presentation).",
     schema: {
       fileId: z.string().describe("The ID of the file to comment on."),
       content: z.string().describe("The text content of the comment."),
+    },
+    stake: "low",
+  },
+  list_comments: {
+    description:
+      "List comments on a Google Drive file (Doc, Sheet, or Presentation). Returns comment threads with their replies.",
+    schema: {
+      fileId: z.string().describe("The ID of the file to list comments from."),
+      pageSize: z
+        .number()
+        .optional()
+        .default(100)
+        .describe("Maximum number of comments to return (max 100)."),
+      pageToken: z.string().optional().describe("Page token for pagination."),
+      includeDeleted: z
+        .boolean()
+        .optional()
+        .default(false)
+        .describe("Whether to include deleted comments."),
+    },
+    stake: "never_ask",
+  },
+  create_reply: {
+    description:
+      "Reply to an existing comment on a Google Drive file (Doc, Sheet, or Presentation).",
+    schema: {
+      fileId: z.string().describe("The ID of the file containing the comment."),
+      commentId: z.string().describe("The ID of the comment to reply to."),
+      content: z.string().describe("The plain text content of the reply."),
     },
     stake: "low",
   },

--- a/front/lib/api/actions/servers/google_drive/tools/index.ts
+++ b/front/lib/api/actions/servers/google_drive/tools/index.ts
@@ -482,6 +482,96 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
     }
   },
 
+  list_comments: async (
+    { fileId, pageSize = 100, pageToken, includeDeleted = false },
+    extra
+  ) => {
+    const drive = await getDriveClient(extra.authInfo);
+    if (!drive) {
+      return new Err(new MCPError("Failed to authenticate with Google Drive"));
+    }
+
+    try {
+      const res = await drive.comments.list({
+        fileId,
+        pageSize: Math.min(pageSize, 100),
+        pageToken,
+        includeDeleted,
+        fields:
+          "comments(id,content,author,createdTime,modifiedTime,deleted,resolved,replies),nextPageToken",
+      });
+
+      return new Ok([
+        {
+          type: "text" as const,
+          text: JSON.stringify(res.data, null, 2),
+        },
+      ]);
+    } catch (err) {
+      return handleFileAccessError(err, fileId, extra);
+    }
+  },
+
+  create_reply: async ({ fileId, commentId, content }, extra) => {
+    const drive = await getDriveClient(extra.authInfo);
+    if (!drive) {
+      return new Err(new MCPError("Failed to authenticate with Google Drive"));
+    }
+
+    try {
+      const res = await drive.replies.create({
+        fileId,
+        commentId,
+        requestBody: {
+          content,
+        },
+        fields: "id,content,author,createdTime",
+      });
+
+      return new Ok([
+        {
+          type: "text" as const,
+          text: JSON.stringify(
+            {
+              replyId: res.data.id,
+              content: res.data.content,
+              author: res.data.author,
+              createdTime: res.data.createdTime,
+            },
+            null,
+            2
+          ),
+        },
+      ]);
+    } catch (err) {
+      // Only fetch metadata for better error messages if the reply creation fails
+      if (isFileNotAuthorizedError(err)) {
+        let fileName = fileId;
+        let mimeType = "unknown";
+
+        // Try to get file metadata for a better error message (non-blocking failure)
+        try {
+          const fileMetadata = await drive.files.get({
+            fileId,
+            supportsAllDrives: true,
+            fields: "id, name, mimeType",
+          });
+          fileName = fileMetadata.data.name ?? fileId;
+          mimeType = fileMetadata.data.mimeType ?? "unknown";
+        } catch {
+          // If metadata fetch also fails, just use fileId as the name
+        }
+
+        return handleFileAccessError(err, fileId, extra, {
+          name: fileName,
+          mimeType,
+        });
+      }
+
+      return handlePermissionError(err);
+    }
+  },
+
   update_document: async ({ documentId, content, mode = "append" }, extra) => {
     const docs = await getDocsClient(extra.authInfo);
     if (!docs) {


### PR DESCRIPTION
## Description
Add new google write tools for listing and replying to comments, listing is never_ask and replying to is low stakes
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Tested manually:
<img width="737" height="544" alt="Screenshot 2026-02-04 at 4 49 51 PM" src="https://github.com/user-attachments/assets/9fd42762-0202-4337-858e-a0b74bfc69d0" />

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low, behind FF
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
- [ ] deploy front

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
