### PR TITLE
Add update slides tool behind google write FF

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
@@ -4784,7 +4784,8 @@
       "list_comments": "never_ask",
       "list_drives": "never_ask",
       "search_files": "never_ask",
-      "update_document": "medium"
+      "update_document": "medium",
+      "update_presentation": "medium"
     }
   },
   {

--- a/front/lib/api/actions/servers/google_drive/metadata.ts
+++ b/front/lib/api/actions/servers/google_drive/metadata.ts
@@ -252,6 +252,23 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
     },
     stake: "medium",
   },
+  update_presentation: {
+    description:
+      "Update an existing Google Slides presentation by adding, modifying, or deleting slides and content.",
+    schema: {
+      presentationId: z
+        .string()
+        .describe("The ID of the presentation to update."),
+      requests: z
+        .array(z.any())
+        .describe(
+          "An array of batch update requests to apply to the presentation. " +
+            "See https://developers.google.com/slides/api/reference/rest/v1/presentations/batchUpdate for request types. " +
+            "Common requests include createSlide, deleteObject, insertText, updateTextStyle, etc."
+        ),
+    },
+    stake: "medium",
+  },
 });
 
 const ALL_TOOLS_METADATA = {

--- a/front/lib/api/actions/servers/google_drive/metadata.ts
+++ b/front/lib/api/actions/servers/google_drive/metadata.ts
@@ -260,9 +260,10 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
         .string()
         .describe("The ID of the presentation to update."),
       requests: z
-        .array(z.any())
+        .array(z.record(z.string(), z.unknown()))
         .describe(
           "An array of batch update requests to apply to the presentation. " +
+            "Each request is an object with a single key indicating the request type. " +
             "See https://developers.google.com/slides/api/reference/rest/v1/presentations/batchUpdate for request types. " +
             "Common requests include createSlide, deleteObject, insertText, updateTextStyle, etc."
         ),


### PR DESCRIPTION
## Description
Add tool for updating google slides
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Tested manually:
<img width="883" height="445" alt="Screenshot 2026-02-04 at 4 51 32 PM" src="https://github.com/user-attachments/assets/5383840a-cc18-48c2-b26e-a59b43bdc6a2" />

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low, behind ff
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
- [ ] deploy front

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
