### PR TITLE
[PoC] Block-targeted HTML suggestions with decoration-only diff rendering

### DIFF
--- a/front/components/agent_builder/copilot/CopilotSuggestionsContext.tsx
+++ b/front/components/agent_builder/copilot/CopilotSuggestionsContext.tsx
@@ -24,10 +24,12 @@ import {
   usePatchAgentSuggestions,
 } from "@app/lib/swr/agent_suggestions";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
-import type {AgentInstructionsSuggestionType, AgentSuggestionType, AgentSuggestionWithRelationsType} from "@app/types/suggestions/agent_suggestion";
-import {
-  isBlockBasedInstructionsSuggestion
+import type {
+  AgentInstructionsSuggestionType,
+  AgentSuggestionType,
+  AgentSuggestionWithRelationsType,
 } from "@app/types/suggestions/agent_suggestion";
+import { isBlockBasedInstructionsSuggestion } from "@app/types/suggestions/agent_suggestion";
 
 export interface CopilotSuggestionsContextType {
   getSuggestionWithRelations: (

--- a/front/components/agent_builder/copilot/tools/getAgentConfig.ts
+++ b/front/components/agent_builder/copilot/tools/getAgentConfig.ts
@@ -1,10 +1,8 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
-import type {AgentSuggestionType} from "@app/types/suggestions/agent_suggestion";
-import {
-  isLegacyInstructionsSuggestion
-} from "@app/types/suggestions/agent_suggestion";
+import type { AgentSuggestionType } from "@app/types/suggestions/agent_suggestion";
+import { isLegacyInstructionsSuggestion } from "@app/types/suggestions/agent_suggestion";
 
 export interface GetAgentConfigCallbacks {
   getFormValues: () => AgentBuilderFormData;

--- a/front/components/agent_builder/copilot/useMCPServer.ts
+++ b/front/components/agent_builder/copilot/useMCPServer.ts
@@ -86,8 +86,8 @@ export function useCopilotMCPServer({
           getPendingSuggestions: suggestionsContextRef.current
             ? () => suggestionsContextRef.current!.getPendingSuggestions()
             : undefined,
-          getCommittedInstructions: suggestionsContextRef.current
-            ? () => suggestionsContextRef.current!.getCommittedInstructions()
+          getCommittedInstructionsHtml: suggestionsContextRef.current
+            ? () => suggestionsContextRef.current!.getCommittedInstructionsHtml()
             : undefined,
         });
 

--- a/front/components/agent_builder/copilot/useMCPServer.ts
+++ b/front/components/agent_builder/copilot/useMCPServer.ts
@@ -87,7 +87,8 @@ export function useCopilotMCPServer({
             ? () => suggestionsContextRef.current!.getPendingSuggestions()
             : undefined,
           getCommittedInstructionsHtml: suggestionsContextRef.current
-            ? () => suggestionsContextRef.current!.getCommittedInstructionsHtml()
+            ? () =>
+                suggestionsContextRef.current!.getCommittedInstructionsHtml()
             : undefined,
         });
 

--- a/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
+++ b/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
@@ -18,6 +18,7 @@ import { BlockInsertDropdown } from "@app/components/agent_builder/instructions/
 import { InstructionTipsPopover } from "@app/components/agent_builder/instructions/InstructionsTipsPopover";
 import { useBlockInsertDropdown } from "@app/components/agent_builder/instructions/useBlockInsertDropdown";
 import { AgentInstructionDiffExtension } from "@app/components/editor/extensions/agent_builder/AgentInstructionDiffExtension";
+import { BlockIdExtension } from "@app/components/editor/extensions/agent_builder/BlockIdExtension";
 import { BlockInsertExtension } from "@app/components/editor/extensions/agent_builder/BlockInsertExtension";
 import { InstructionBlockExtension } from "@app/components/editor/extensions/agent_builder/InstructionBlockExtension";
 import { InstructionSuggestionExtension } from "@app/components/editor/extensions/agent_builder/InstructionSuggestionExtension";
@@ -135,6 +136,7 @@ export function AgentBuilderInstructionsEditor({
       InstructionBlockExtension,
       AgentInstructionDiffExtension,
       InstructionSuggestionExtension,
+      BlockIdExtension,
       BlockInsertExtension.configure({
         suggestion: suggestionHandler,
       }),

--- a/front/components/editor/extensions/agent_builder/BlockIdExtension.ts
+++ b/front/components/editor/extensions/agent_builder/BlockIdExtension.ts
@@ -1,0 +1,58 @@
+import UniqueID from "@tiptap/extension-unique-id";
+
+/**
+ * Simple hash function for generating stable block IDs.
+ * Uses djb2 algorithm for fast, reasonably distributed hashes.
+ */
+function hashString(str: string): string {
+  let hash = 5381;
+  for (let i = 0; i < str.length; i++) {
+    hash = (hash * 33) ^ str.charCodeAt(i);
+  }
+  // Convert to unsigned 32-bit and then to hex.
+  return (hash >>> 0).toString(16).padStart(8, "0");
+}
+
+/**
+ * Extracts text content from a ProseMirror node.
+ */
+function getNodeTextContent(node: { textContent?: string }): string {
+  return node.textContent ?? "";
+}
+
+/**
+ * Block ID extension that adds stable, content-based IDs to block-level nodes.
+ * Uses TipTap's official UniqueID extension with custom ID generation based on content hash.
+ *
+ * IDs are computed from the node type and content hash, making them deterministic:
+ * - Same content always produces the same ID
+ * - IDs are stable across page loads
+ * - Format: "{nodeType}-{contentHash}" (e.g., "paragraph-a1b2c3d4")
+ *
+ * Renders as `data-block-id` attribute in HTML output.
+ */
+export const BlockIdExtension = UniqueID.configure({
+  types: [
+    "paragraph",
+    "heading",
+    "listItem",
+    "codeBlock",
+    "bulletList",
+    "orderedList",
+  ],
+  attributeName: "blockId",
+  generateID: ({ node }) => {
+    const textContent = getNodeTextContent(node);
+    const hash = hashString(textContent);
+    return `${node.type.name}-${hash}`;
+  },
+});
+
+/**
+ * Computes a stable block ID from the block type and text content.
+ * Exported for use in tests.
+ */
+export function computeBlockId(blockType: string, textContent: string): string {
+  const hash = hashString(textContent);
+  return `${blockType}-${hash}`;
+}

--- a/front/components/editor/extensions/agent_builder/BlockIdExtension.ts
+++ b/front/components/editor/extensions/agent_builder/BlockIdExtension.ts
@@ -32,14 +32,7 @@ function getNodeTextContent(node: { textContent?: string }): string {
  * Renders as `data-block-id` attribute in HTML output.
  */
 export const BlockIdExtension = UniqueID.configure({
-  types: [
-    "paragraph",
-    "heading",
-    "listItem",
-    "codeBlock",
-    "bulletList",
-    "orderedList",
-  ],
+  types: ["paragraph", "heading"],
   attributeName: "blockId",
   generateID: ({ node }) => {
     const textContent = getNodeTextContent(node);

--- a/front/components/editor/extensions/agent_builder/InstructionSuggestionExtension.test.ts
+++ b/front/components/editor/extensions/agent_builder/InstructionSuggestionExtension.test.ts
@@ -42,7 +42,9 @@ describe("InstructionSuggestionExtension", () => {
       expect(paragraph?.type).toBe("paragraph");
 
       // Document should still have original content (no marks).
-      const content = paragraph?.content as Array<{ text?: string }> | undefined;
+      const content = paragraph?.content as
+        | Array<{ text?: string }>
+        | undefined;
       expect(content?.length).toBe(1);
       expect(content?.[0]?.text).toBe("Hello world");
 
@@ -119,9 +121,10 @@ describe("InstructionSuggestionExtension", () => {
       expect(result).toBe(true);
 
       // HTML is stored as-is, parsed during decoration building.
-      const suggestion = editor.storage.instructionSuggestion.activeSuggestions.get(
-        "test-html-storage"
-      );
+      const suggestion =
+        editor.storage.instructionSuggestion.activeSuggestions.get(
+          "test-html-storage"
+        );
       expect(suggestion).toBeDefined();
       expect(suggestion?.newContent).toBe("<h2>Heading text</h2>");
     });

--- a/front/components/editor/extensions/agent_builder/InstructionSuggestionExtension.ts
+++ b/front/components/editor/extensions/agent_builder/InstructionSuggestionExtension.ts
@@ -49,10 +49,13 @@ const pluginKey = new PluginKey<PluginState>("suggestionPlugin");
 // ============================================================================
 
 const CLASSES = {
-  remove: "suggestion-deletion rounded px-0.5 line-through bg-red-100 dark:bg-red-900/50 text-red-800 dark:text-red-200",
-  removeDimmed: "suggestion-deletion rounded px-0.5 line-through bg-red-50 dark:bg-red-900/20 text-gray-400",
+  remove:
+    "suggestion-deletion rounded px-0.5 line-through bg-red-100 dark:bg-red-900/50 text-red-800 dark:text-red-200",
+  removeDimmed:
+    "suggestion-deletion rounded px-0.5 line-through bg-red-50 dark:bg-red-900/20 text-gray-400",
   add: "suggestion-addition rounded px-0.5 bg-blue-100 dark:bg-blue-900/50 text-blue-800 dark:text-blue-200",
-  addDimmed: "suggestion-addition rounded px-0.5 bg-blue-50 dark:bg-blue-900/20 text-gray-400",
+  addDimmed:
+    "suggestion-addition rounded px-0.5 bg-blue-50 dark:bg-blue-900/20 text-gray-400",
 };
 
 // ============================================================================
@@ -77,7 +80,11 @@ function diffBlockContent(
   tr.replaceWith(1, oldNode.content.size + 1, newNode.content);
 
   // Feed steps to ChangeSet (use tr.doc, the actual transform result).
-  const changeSet = ChangeSet.create(oldDoc).addSteps(tr.doc, tr.mapping.maps, null);
+  const changeSet = ChangeSet.create(oldDoc).addSteps(
+    tr.doc,
+    tr.mapping.maps,
+    null
+  );
 
   // Map positions back to content-relative (subtract 1 for block node start).
   return changeSet.changes.map((change) => ({
@@ -211,7 +218,9 @@ function buildDecorations(
               contentStart + change.fromA,
               () => {
                 const span = document.createElement("span");
-                span.className = isHighlighted ? CLASSES.add : CLASSES.addDimmed;
+                span.className = isHighlighted
+                  ? CLASSES.add
+                  : CLASSES.addDimmed;
                 span.setAttribute("data-suggestion-id", suggestionId);
                 span.contentEditable = "false";
 
@@ -277,7 +286,11 @@ function createPlugin(getHighlightedId: () => string | null) {
           return {
             suggestions,
             highlightedId,
-            decorations: buildDecorations(newState, suggestions, effectiveHighlightedId),
+            decorations: buildDecorations(
+              newState,
+              suggestions,
+              effectiveHighlightedId
+            ),
           };
         }
 
@@ -288,7 +301,9 @@ function createPlugin(getHighlightedId: () => string | null) {
 
     props: {
       decorations(editorState) {
-        return pluginKey.getState(editorState)?.decorations ?? DecorationSet.empty;
+        return (
+          pluginKey.getState(editorState)?.decorations ?? DecorationSet.empty
+        );
       },
     },
   });
@@ -326,7 +341,9 @@ declare module "@tiptap/core" {
   interface Commands<ReturnType> {
     instructionSuggestion: {
       applySuggestion: (options: ApplySuggestionOptions) => ReturnType;
-      applyLegacySuggestion: (options: LegacyApplySuggestionOptions) => ReturnType;
+      applyLegacySuggestion: (
+        options: LegacyApplySuggestionOptions
+      ) => ReturnType;
       acceptSuggestion: (suggestionId: string) => ReturnType;
       rejectSuggestion: (suggestionId: string) => ReturnType;
       acceptAllSuggestions: () => ReturnType;
@@ -366,7 +383,11 @@ function extractText(node: JSONContent): string {
   if (node.content) {
     const childText = node.content.map(extractText).join("");
 
-    if (["paragraph", "heading", "bulletList", "orderedList"].includes(node.type ?? "")) {
+    if (
+      ["paragraph", "heading", "bulletList", "orderedList"].includes(
+        node.type ?? ""
+      )
+    ) {
       return childText + "\n\n";
     }
     if (node.type === "listItem") {
@@ -560,7 +581,11 @@ export const InstructionSuggestionExtension = Extension.create({
               }
 
               const { node: blockNode, pos: blockPos } = found;
-              const newNode = parseHTMLToBlock(op.newContent, schema, blockNode);
+              const newNode = parseHTMLToBlock(
+                op.newContent,
+                schema,
+                blockNode
+              );
               if (!newNode) {
                 continue;
               }
@@ -576,9 +601,10 @@ export const InstructionSuggestionExtension = Extension.create({
           }
 
           this.storage.activeSuggestions.delete(suggestionId);
-          this.storage.activeSuggestionIds = this.storage.activeSuggestionIds.filter(
-            (id: string) => id !== suggestionId
-          );
+          this.storage.activeSuggestionIds =
+            this.storage.activeSuggestionIds.filter(
+              (id: string) => id !== suggestionId
+            );
 
           return true;
         },
@@ -601,9 +627,10 @@ export const InstructionSuggestionExtension = Extension.create({
           }
 
           this.storage.activeSuggestions.delete(suggestionId);
-          this.storage.activeSuggestionIds = this.storage.activeSuggestionIds.filter(
-            (id: string) => id !== suggestionId
-          );
+          this.storage.activeSuggestionIds =
+            this.storage.activeSuggestionIds.filter(
+              (id: string) => id !== suggestionId
+            );
 
           return true;
         },

--- a/front/components/markdown/suggestion/CopilotSuggestionCard.tsx
+++ b/front/components/markdown/suggestion/CopilotSuggestionCard.tsx
@@ -23,11 +23,9 @@ import { getIcon } from "@app/components/resources/resources_icons";
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import { getSkillAvatarIcon } from "@app/lib/skill";
 import { assertNever } from "@app/types/shared/utils/assert_never";
-import type {
-  AgentInstructionsSuggestionType,
-  AgentSuggestionKind,
-  AgentSuggestionState,
-  AgentSuggestionWithRelationsType,
+import type {AgentInstructionsSuggestionType, AgentSuggestionKind, AgentSuggestionState, AgentSuggestionWithRelationsType} from "@app/types/suggestions/agent_suggestion";
+import {
+  isLegacyInstructionsSuggestion
 } from "@app/types/suggestions/agent_suggestion";
 
 function mapSuggestionStateToCardState(
@@ -84,7 +82,6 @@ function InstructionsSuggestionCard({
 }: {
   agentSuggestion: AgentInstructionsSuggestionType;
 }) {
-  const { oldString, newString } = agentSuggestion.suggestion;
   const { focusOnSuggestion } = useCopilotSuggestions();
 
   const cardState = mapSuggestionStateToCardState(agentSuggestion.state);
@@ -92,9 +89,28 @@ function InstructionsSuggestionCard({
     focusOnSuggestion(agentSuggestion.sId)
   );
 
+  // Handle both block-based and legacy suggestion formats.
+  let changes: Array<{ old: string; new: string }>;
+  if (isLegacyInstructionsSuggestion(agentSuggestion.suggestion)) {
+    changes = [
+      {
+        old: agentSuggestion.suggestion.oldString,
+        new: agentSuggestion.suggestion.newString,
+      },
+    ];
+  } else {
+    // For block-based suggestions, we show the HTML content as a replacement.
+    changes = [
+      {
+        old: `[Block ${agentSuggestion.suggestion.targetBlockId}]`,
+        new: agentSuggestion.suggestion.content,
+      },
+    ];
+  }
+
   return (
     <DiffBlock
-      changes={[{ old: oldString, new: newString }]}
+      changes={changes}
       actions={actions}
       className={cardState !== "active" ? "opacity-70" : undefined}
     />

--- a/front/components/markdown/suggestion/CopilotSuggestionCard.tsx
+++ b/front/components/markdown/suggestion/CopilotSuggestionCard.tsx
@@ -23,10 +23,13 @@ import { getIcon } from "@app/components/resources/resources_icons";
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import { getSkillAvatarIcon } from "@app/lib/skill";
 import { assertNever } from "@app/types/shared/utils/assert_never";
-import type {AgentInstructionsSuggestionType, AgentSuggestionKind, AgentSuggestionState, AgentSuggestionWithRelationsType} from "@app/types/suggestions/agent_suggestion";
-import {
-  isLegacyInstructionsSuggestion
+import type {
+  AgentInstructionsSuggestionType,
+  AgentSuggestionKind,
+  AgentSuggestionState,
+  AgentSuggestionWithRelationsType,
 } from "@app/types/suggestions/agent_suggestion";
+import { isLegacyInstructionsSuggestion } from "@app/types/suggestions/agent_suggestion";
 
 function mapSuggestionStateToCardState(
   state: AgentSuggestionState

--- a/front/lib/api/actions/servers/agent_copilot_context/metadata.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/metadata.ts
@@ -19,14 +19,16 @@ const KNOWLEDGE_CATEGORIES = ["managed", "folder", "website"] as const;
 // Suggestion tool schemas
 
 const InstructionsSuggestionSchema = z.object({
-  oldString: z
+  targetBlockId: z
     .string()
-    .describe("The exact text to find (including surrounding context)"),
-  newString: z.string().describe("The exact replacement text"),
-  expectedOccurrences: z
-    .number()
-    .optional()
-    .describe("Number of occurrences to replace."),
+    .describe(
+      "The data-blockid of the block to modify (format: block-{type}-{hash}, e.g., block-paragraph-7f3a2b1c)"
+    ),
+  content: z
+    .string()
+    .describe(
+      "The full HTML content for this block, including the tag (e.g., '<p>New text</p>' or '<h2>Section Title</h2>')"
+    ),
   analysis: z
     .string()
     .optional()
@@ -156,16 +158,16 @@ export const AGENT_COPILOT_CONTEXT_TOOLS_METADATA = createToolsRecord({
   // Suggestion tools
   suggest_prompt_edits: {
     description:
-      "Create suggestions to modify the agent's instructions/prompt. " +
-      "CRITICAL: Make SMALL, SCOPED edits - each oldString should be 1-3 lines max, targeting specific phrases or sentences. " +
-      "NEVER replace entire instruction blocks. " +
-      "Example: To improve clarity, create 3 separate suggestions: one to change 'respond with' → 'reply using', another to add a bullet point, another to rephrase a sentence. " +
+      "Create suggestions to modify the agent's instructions/prompt using block-based targeting. " +
+      "The instructions HTML contains blocks with data-blockid attributes (format: block-{type}-{hash}, e.g., block-paragraph-7f3a2b1c). " +
+      "Each suggestion targets a specific block by its ID and provides the new content for that block. " +
+      "Word-level diffs will be computed and displayed inline. " +
       "IMPORTANT: Include the tool output verbatim in your response - it renders as interactive card(s).",
     schema: {
       suggestions: z
         .array(InstructionsSuggestionSchema)
         .describe(
-          "Array of small, scoped instruction modifications. Each should target 1-3 lines max. Each suggestion can have its own analysis."
+          "Array of block modifications. Each targets a block by its data-blockid and provides new content. Each suggestion can have its own analysis."
         ),
     },
     stake: "never_ask",

--- a/front/lib/api/assistant/agent_suggestion_pruning.ts
+++ b/front/lib/api/assistant/agent_suggestion_pruning.ts
@@ -4,10 +4,16 @@ import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_res
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import logger from "@app/logger/logger";
 import type { AgentConfigurationType } from "@app/types";
-import type {InstructionsSuggestionType, LegacyInstructionsSuggestionType, ModelSuggestionType, SkillsSuggestionType, ToolsSuggestionType} from "@app/types/suggestions/agent_suggestion";
+import type {
+  InstructionsSuggestionType,
+  LegacyInstructionsSuggestionType,
+  ModelSuggestionType,
+  SkillsSuggestionType,
+  ToolsSuggestionType,
+} from "@app/types/suggestions/agent_suggestion";
 import {
   isLegacyInstructionsSuggestion,
-  parseAgentSuggestionData
+  parseAgentSuggestionData,
 } from "@app/types/suggestions/agent_suggestion";
 
 type ToolsSuggestionResource = AgentSuggestionResource & {

--- a/front/lib/api/assistant/global_agents/configurations/dust/copilot.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/copilot.ts
@@ -145,91 +145,116 @@ When newlines hurt:
 </agent_instructions_best_practices>`,
 
   blockAwareEditing: `<block_aware_editing>
-Agent instructions are organized into "blocks" - logical containers that group related instructions. A block can be:
-- **XML tags**: \`<primary_goal>content</primary_goal>\`
-- **Markdown sections**: \`## Primary Goal\` followed by content until the next heading
+Agent instructions are organized into "blocks" - logical containers that group related instructions. Each block in the editor has a unique \`data-blockid\` attribute that is computed from the block type and content hash (e.g., "block-paragraph-a1b2c3d4").
 
-Both serve the same purpose: creating cohesive, navigable units. Your job is to recognize whichever structure the agent uses and work within it.
-Match your suggestions to whatever structure exists. Don't convert markdown agents to XML or vice versa unless explicitly asked.
+This content-based ID system ensures stability: if you add a new block before an existing one, the existing block's ID remains unchanged since it's based on content, not position.
+
+When you receive the agent instructions via \`get_agent_config\`, they will be in HTML format with block IDs:
+\`\`\`html
+<p data-blockid="block-paragraph-7f3a2b1c">You are a helpful assistant.</p>
+<p data-blockid="block-paragraph-e9d8c7b6">Always respond in JSON format.</p>
+\`\`\`
+
+<suggestion_format>
+Your suggestions should target specific blocks and provide the full HTML content:
+- \`targetBlockId\`: The exact data-blockid from the HTML (copy it exactly)
+- \`content\`: The full HTML content for this block, **including the HTML tag**
+
+The \`content\` field must be valid HTML with the appropriate tag. This allows:
+- Modifying text within a block
+- Changing block types (e.g., \`<p>\` → \`<h2>\`)
+- Using HTML inline formatting (\`<strong>\`, \`<em>\`, \`<code>\`)
+
+Example suggestions:
+\`\`\`json
+{
+  "targetBlockId": "block-paragraph-e9d8c7b6",
+  "content": "<p>Always respond in well-formatted JSON with proper indentation.</p>"
+}
+\`\`\`
+
+Changing a paragraph to a heading:
+\`\`\`json
+{
+  "targetBlockId": "block-paragraph-abc12345",
+  "content": "<h2>Output Format</h2>"
+}
+\`\`\`
+</suggestion_format>
 
 <block_editing_principles>
 1. Think in blocks, not documents - Before suggesting, identify what blocks exist and which one(s) your change affects.
-2. Prefer inline changes within a single block - For small improvements, edit content INSIDE the relevant block without touching other blocks.
-3. Bias toward one suggestion per block - Unless changes are clearly coupled, create separate suggestions for separate blocks. Users can accept/reject independently.
-4. Cross-block changes require justification - Modify multiple blocks only when:
-   - Creating a new agent from scratch
-   - Fundamental structural changes (splitting/merging blocks)
-   - Changes that genuinely span concerns
+2. Target one block per suggestion - Each suggestion should modify exactly one block. Users can accept/reject independently.
+3. Copy block IDs exactly - The IDs are hashes; don't try to construct them yourself.
+4. Always include the HTML tag in content - The \`content\` field must include the wrapping tag (e.g., \`<p>...</p>\`).
+5. Word-level diffs are computed automatically - Just provide the new content; the system will highlight what changed.
 </block_editing_principles>
 
 <block_examples>
 EXAMPLE 1: User says "change the output format to JSON"
-Agent structure:
-\`\`\`
-## Role
-You are a data analyst that processes customer feedback.
-
-## Output Format
-Return results as a bulleted list.
+Agent HTML:
+\`\`\`html
+<p data-blockid="block-paragraph-abc12345">You are a data analyst that processes customer feedback.</p>
+<p data-blockid="block-paragraph-def67890">Return results as a bulleted list.</p>
 \`\`\`
 
-WRONG - Editing multiple blocks:
-\`\`\`
-oldString: "## Role\\nYou are a data analyst that processes customer feedback.\\n\\n## Output Format\\nReturn results as a bulleted list."
-newString: "## Role\\nYou are a data analyst that processes customer feedback and returns JSON.\\n\\n## Output Format\\nReturn results as JSON."
-\`\`\`
-Only Output Format needs changing. Role should not be modified.
-
-CORRECT - Edit only the affected block:
-\`\`\`
-oldString: "Return results as a bulleted list."
-newString: "Return results as JSON."
+CORRECT - Target the specific block with full HTML:
+\`\`\`json
+{
+  "targetBlockId": "block-paragraph-def67890",
+  "content": "<p>Return results as JSON.</p>"
+}
 \`\`\`
 
 ---
 
-EXAMPLE 2: User says "add a constraint about PII"
-Agent structure:
-\`\`\`
-<primary_goal>You analyze customer feedback.</primary_goal>
-<output_format>...</output_format>
+EXAMPLE 2: User says "add more detail to the role"
+Agent HTML:
+\`\`\`html
+<p data-blockid="block-paragraph-abc12345">You analyze customer feedback.</p>
 \`\`\`
 
-WRONG - Adding to wrong block:
-\`\`\`
-oldString: "<primary_goal>You analyze customer feedback.</primary_goal>"
-newString: "<primary_goal>You analyze customer feedback. Never output PII.</primary_goal>"
-\`\`\`
-Constraints need their own block.
-
-CORRECT - Create dedicated constraints block:
-\`\`\`
-oldString: "</output_format>"
-newString: "</output_format>\\n\\n<constraints>\\nNEVER output personally identifiable information (names, emails, phone numbers).\\nRedact or anonymize any PII in examples.\\n</constraints>"
+CORRECT - Modify the block content with full HTML:
+\`\`\`json
+{
+  "targetBlockId": "block-paragraph-abc12345",
+  "content": "<p>You are an expert data analyst who analyzes customer feedback to identify trends, sentiment patterns, and actionable insights.</p>"
+}
 \`\`\`
 
 ---
 
-EXAMPLE 3: User says "create a meeting prep agent" (empty instructions)
-
-CORRECT - Create complete structure:
-Simple agent (markdown):
-\`\`\`
-oldString: ""
-newString: "## Role\\nYou prepare briefings for upcoming meetings.\\n\\n## Process\\n1. When given a meeting, identify attendees\\n2. Pull relevant context from CRM and past notes\\n3. Summarize key points and suggested talking points\\n\\n## Output\\nProvide a one-page briefing with sections for: Attendees, Context, Key Points, Suggested Questions"
+EXAMPLE 3: User says "make that a heading"
+Agent HTML:
+\`\`\`html
+<p data-blockid="block-paragraph-abc12345">Output Guidelines</p>
 \`\`\`
 
-Complex agent (XML):
+CORRECT - Change block type by using a different HTML tag:
+\`\`\`json
+{
+  "targetBlockId": "block-paragraph-abc12345",
+  "content": "<h2>Output Guidelines</h2>"
+}
 \`\`\`
-oldString: ""
-newString: "<primary_goal>\\nYou prepare comprehensive briefings for meetings...\\n</primary_goal>\\n\\n<process>\\n1. Identify meeting type (internal/external/sales/support)\\n2. Based on type:\\n   - Sales: Pull CRM opportunity data...\\n   - Support: Pull ticket history...\\n</process>\\n\\n<output_format>\\n..."
+
+---
+
+EXAMPLE 4: User says "create a meeting prep agent" (empty instructions)
+For empty instructions, use the block ID from the empty paragraph shown in the HTML:
+\`\`\`json
+{
+  "targetBlockId": "block-0",
+  "content": "<p>You prepare briefings for upcoming meetings.</p>"
+}
 \`\`\`
+</block_examples>
 
 <structure_recommendations>
 When creating an agent, choose the appropriate structure and formatting:
 - For Simple agents (single purpose, <150 words, no conditionals), use markdown only. Headings optional. Keep it lightweight.
 - For Medium agents (2-3 concerns, 150-400 words), use markdown headers (\`##\`) to separate sections.
-- For Complex agents (multiple capabilities, conditionals, 400+ words), use XML blocks for clear separation and collapsibility. Custom tag names allowed: letters, numbers, dots, underscores, hyphens, colons.
+- For Complex agents (multiple capabilities, conditionals, 400+ words), use XML blocks for clear separation and collapsibility.
 
 Allowed formatting within blocks:
 - **Bold** (\`**text**\`): Key terms and critical points
@@ -239,11 +264,6 @@ Allowed formatting within blocks:
 - Numbered lists (\`1.\`, \`2.\`): Sequential steps only
 - Code blocks: \`\`\`language\\ncode\`\`\`
 - Links: \`[text](url)\`
-- Horizontal rules (\`---\`): Only for simple agents without XML blocks
-
-Don't mix markdown headings (\`#\`, \`##\`) with XML blocks:
-- Complex agents (3+ sections): Use XML blocks for structure, markdown within
-- Simple agents (<150 words): Use markdown only, no XML blocks needed
 </structure_recommendations>
 </block_aware_editing>`,
 

--- a/front/lib/resources/agent_suggestion_resource.test.ts
+++ b/front/lib/resources/agent_suggestion_resource.test.ts
@@ -423,8 +423,12 @@ describe("AgentSuggestionResource", () => {
       // Type narrowing based on kind
       switch (json.kind) {
         case "instructions":
-          expect(json.suggestion.oldString).toBe("old");
-          expect(json.suggestion.newString).toBe("new");
+          // Verify it's a legacy suggestion with oldString/newString
+          expect("oldString" in json.suggestion).toBe(true);
+          if ("oldString" in json.suggestion) {
+            expect(json.suggestion.oldString).toBe("old");
+            expect(json.suggestion.newString).toBe("new");
+          }
           break;
         case "tools":
         case "skills":

--- a/front/package.json
+++ b/front/package.json
@@ -100,6 +100,7 @@
     "@tiptap/extension-heading": "^3.18.0",
     "@tiptap/extension-link": "^3.18.0",
     "@tiptap/extension-mention": "^3.18.0",
+    "@tiptap/extension-unique-id": "^3.19.0",
     "@tiptap/extensions": "^3.18.0",
     "@tiptap/markdown": "^3.18.0",
     "@tiptap/pm": "^3.18.0",

--- a/front/package.json
+++ b/front/package.json
@@ -181,6 +181,7 @@
     "postcss": "^8.5.6",
     "posthog-js": "^1.266.1",
     "posthog-node": "^5.8.5",
+    "prosemirror-changeset": "^2.3.1",
     "react": "^18.3.1",
     "react-beforeunload": "^2.5.3",
     "react-cookie": "^7.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1011,6 +1011,7 @@
         "postcss": "^8.5.6",
         "posthog-js": "^1.266.1",
         "posthog-node": "^5.8.5",
+        "prosemirror-changeset": "^2.3.1",
         "react": "^18.3.1",
         "react-beforeunload": "^2.5.3",
         "react-cookie": "^7.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -930,6 +930,7 @@
         "@tiptap/extension-heading": "^3.18.0",
         "@tiptap/extension-link": "^3.18.0",
         "@tiptap/extension-mention": "^3.18.0",
+        "@tiptap/extension-unique-id": "^3.19.0",
         "@tiptap/extensions": "^3.18.0",
         "@tiptap/markdown": "^3.18.0",
         "@tiptap/pm": "^3.18.0",
@@ -1778,16 +1779,16 @@
       }
     },
     "front/node_modules/@tiptap/core": {
-      "version": "3.18.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.18.0.tgz",
-      "integrity": "sha512-Gczd4GbK1DNgy/QUPElMVozoa0GW9mW8E31VIi7Q4a9PHHz8PcrxPmuWwtJ2q0PF8MWpOSLuBXoQTWaXZRPRnQ==",
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.19.0.tgz",
+      "integrity": "sha512-bpqELwPW+DG8gWiD8iiFtSl4vIBooG5uVJod92Qxn3rA9nFatyXRr4kNbMJmOZ66ezUvmCjXVe/5/G4i5cyzKA==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/pm": "^3.18.0"
+        "@tiptap/pm": "^3.19.0"
       }
     },
     "front/node_modules/@tiptap/extension-blockquote": {
@@ -2139,6 +2140,36 @@
         "@tiptap/core": "^3.18.0"
       }
     },
+    "front/node_modules/@tiptap/extension-unique-id": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-unique-id/-/extension-unique-id-3.19.0.tgz",
+      "integrity": "sha512-gzRW4LHkRq90k8DXte0GqkUj10d5032xf73+i5B4TeNTFiQup4LTPBHmx9WAum6up9Uz3qCZ7fq0pkkRoyT8zg==",
+      "license": "MIT",
+      "dependencies": {
+        "uuid": "^10.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.19.0",
+        "@tiptap/pm": "^3.19.0"
+      }
+    },
+    "front/node_modules/@tiptap/extension-unique-id/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "front/node_modules/@tiptap/extensions": {
       "version": "3.18.0",
       "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.18.0.tgz",
@@ -2183,9 +2214,9 @@
       }
     },
     "front/node_modules/@tiptap/pm": {
-      "version": "3.18.0",
-      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.18.0.tgz",
-      "integrity": "sha512-8RoI5gW0xBVCsuxahpK8vx7onAw6k2/uR3hbGBBnH+HocDMaAZKot3nTyY546ij8ospIC1mnQ7k4BhVUZesZDQ==",
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.19.0.tgz",
+      "integrity": "sha512-789zcnM4a8OWzvbD2DL31d0wbSm9BVeO/R7PLQwLIGysDI3qzrcclyZ8yhqOEVuvPitRRwYLq+mY14jz7kY4cw==",
       "license": "MIT",
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",


### PR DESCRIPTION
## Description

> [!TIP]
> See below on how to experiment

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
### Background

The current suggestion system uses string matching (find/replace) to locate and apply changes, which is fragile. Suggestions silently fail when the target text is ambiguous, duplicated, or slightly reformatted. Diffs are rendered by modifying the document content and applying ProseMirror marks, which means the document is mutated before the user accepts, making reject a rollback operation.

This PoC explores a fundamentally different approach inspired by Tiptap's AI toolkit.

### What changed

**Block ID targeting.** Every paragraph and heading node gets a stable, content-based data-blockid attribute (e.g., paragraph-a1b2c3d4). The copilot receives the full instruction HTML with these IDs and targets specific blocks by ID rather than searching for text.

**HTML-based suggestions.** Suggestions now carry `{ targetBlockId, content }` where content is HTML (e.g., `<p>New text with <strong>bold</strong></p>`). This preserves inline formatting and gives the copilot precise control over what each block should become.

**Decoration-only rendering.** The document is never modified until the user explicitly accepts. Diffs are computed on the fly using prosemirror-changeset and rendered purely through ProseMirror decorations:
Decoration.inline with strikethrough for deleted text (exists in document)
Decoration.widget for added text (not in document, shown as non-editable spans)
Accept replaces the block content. Reject removes the decorations — nothing else needed since the document was never touched.

**Decoration recomputation.** Decorations are rebuilt whenever suggestions change or the document is edited, ensuring diffs stay accurate even if the user modifies the document while suggestions are pending.

#### Known limitations
- No container-level operations. Block IDs are only on paragraph/heading, not on lists or list items. The copilot cannot restructure a `<ul>` into an `<ol>` in a single operation. It must target individual paragraphs within the list. This is intentional to keep widget content inline-safe.
- Node type changes not supported on accept. If a suggestion replaces `<p>` content with `<h2>` content, the text changes but the node stays a paragraph. The block type is preserved.

## What matters most on this PoC:
Suggestion positioning accuracy. Do diffs appear at the correct location in the document? Are the right words struck through? Are additions placed correctly?
Accept flow — does accepting a suggestion correctly replace the block content?
Reject flow — does rejecting cleanly remove all decorations with no document side effects?
Multi-suggestion — do multiple pending suggestions on different blocks render and resolve independently?

> [!WARNING]  
> You must delete previous instruction suggestions to test.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
