### PR TITLE
Add tooltip to 'Created by' field in knowledge tab

### DIFF
--- a/front/components/assistant/conversation/space/SpaceKnowledgeTab.tsx
+++ b/front/components/assistant/conversation/space/SpaceKnowledgeTab.tsx
@@ -9,6 +9,7 @@ import {
   PencilSquareIcon,
   SearchInput,
   Spinner,
+  Tooltip,
   TrashIcon,
 } from "@dust-tt/sparkle";
 import type { CellContext, ColumnDef } from "@tanstack/react-table";
@@ -139,14 +140,20 @@ export function SpaceKnowledgeTab({ owner, space }: SpaceKnowledgeTabProps) {
           }
           return (
             <DataTable.CellContent>
-              <div className="flex items-center gap-2">
+              <div className="flex min-w-0 items-center gap-2">
                 <Avatar
                   name={user.name}
                   visual={user.imageUrl ?? undefined}
                   size="xs"
                   isRounded
                 />
-                <span className="text-sm">{user.name}</span>
+                <Tooltip
+                  tooltipTriggerAsChild
+                  label={user.name}
+                  trigger={
+                    <span className="truncate text-sm">{user.name}</span>
+                  }
+                />
               </div>
             </DataTable.CellContent>
           );


### PR DESCRIPTION
<img width="1509" height="862" alt="Screenshot 2026-02-05 at 10 09 36" src="https://github.com/user-attachments/assets/3a87fd06-d3cc-41ba-9a61-da4fa8897206" />

## Description
[task](https://github.com/dust-tt/tasks/issues/6337)

Add a hover tooltip to the "Created by" field in the knowledge tab when the user name is too long to display fully. Truncate it and finish with "..." for improved UX.

- Added `Tooltip` component from Sparkle to wrap the user name
- Added `truncate` class for ellipsis when name overflows
- Added `min-w-0` to flex container to enable proper truncation

## Tests
- [x] Navigate to a space's knowledge tab with uploaded files
- [x] Verify long user names are truncated with "..."
- [x] Hover over a name to see the full name in tooltip

## Risk
low

## Deploy plan
front