### PR TITLE
[front] Don't call auth-context in pages components

### DIFF
--- a/front/components/pages/oauth/OAuthFinalizePage.tsx
+++ b/front/components/pages/oauth/OAuthFinalizePage.tsx
@@ -3,7 +3,6 @@ import { useEffect, useMemo } from "react";
 
 import { useAppRouter, usePathParam } from "@app/lib/platform";
 import { useFinalize } from "@app/lib/swr/oauth";
-import { useAuthContext } from "@app/lib/swr/workspaces";
 import logger from "@app/logger/logger";
 import { isOAuthProvider } from "@app/types";
 
@@ -11,9 +10,6 @@ export function OAuthFinalizePage() {
   const router = useAppRouter();
   const providerParam = usePathParam("provider");
   const doFinalize = useFinalize();
-
-  // Ensure user is authenticated (redirects to login if not)
-  const { isAuthenticated } = useAuthContext();
 
   // Validate provider (null if router not ready or invalid provider)
   const provider =
@@ -35,7 +31,7 @@ export function OAuthFinalizePage() {
 
   useEffect(() => {
     // Wait for router to be ready, auth to be confirmed, and provider to be valid
-    if (!router.isReady || !isAuthenticated || !provider) {
+    if (!router.isReady || !provider) {
       return;
     }
 
@@ -96,10 +92,10 @@ export function OAuthFinalizePage() {
       }, 1000);
     }
     void finalizeOAuth();
-  }, [router.isReady, isAuthenticated, provider, queryParams, doFinalize]);
+  }, [router.isReady, provider, queryParams, doFinalize]);
 
   // Show spinner while authenticating or waiting for router
-  if (!isAuthenticated || !providerParam) {
+  if (!providerParam) {
     return (
       <div className="flex h-64 items-center justify-center">
         <Spinner size="xl" />


### PR DESCRIPTION
## Description

We don't call auth-context in pages component. Authentication is usually check within getServerSideProps on nextjs, and in app wrapper in spa - but in this case we don't need to check for page display as the api call (/api/oauth/finalize will already check permission - and w only check that teh user is logged in).

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front

