### PR TITLE
Validate remote MCP server URLs

### DIFF
--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -422,7 +422,17 @@ export async function connectToMCPServer(
       break;
     }
     case "remoteMCPServerUrl": {
-      const url = new URL(params.remoteMCPServerUrl);
+      let url: URL;
+      try {
+        url = new URL(params.remoteMCPServerUrl);
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      } catch (_) {
+        return new Err(
+          new Error(
+            "Invalid MCP server URL. Please provide a valid URL starting with http:// or https://"
+          )
+        );
+      }
       const req = {
         requestInit: {
           dispatcher: await createMCPDispatcher(auth, url.hostname),

--- a/front/pages/api/w/[wId]/mcp/discover_oauth_metadata.ts
+++ b/front/pages/api/w/[wId]/mcp/discover_oauth_metadata.ts
@@ -60,6 +60,19 @@ async function handler(
 
       const { url, customHeaders } = r.right;
 
+      // Validate URL format
+      try {
+        new URL(url);
+      } catch {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "Invalid URL format. Please provide a valid URL.",
+          },
+        });
+      }
+
       const headers = headersArrayToRecord(customHeaders);
 
       const r2 = await connectToMCPServer(auth, {


### PR DESCRIPTION
## Description

Fixes unhandled API errors when users submit invalid URLs to MCP server discovery endpoints.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Deploy front
