### PR TITLE
[Claude Code] Add dust-call-agent skill

### DIFF
--- a/.claude/skills/dust-call-agent/SKILL.md
+++ b/.claude/skills/dust-call-agent/SKILL.md
@@ -8,6 +8,6 @@ Access Dust agents that have context on all the company, e.g. recent projects, e
 `$ dust chat -a deep-dive -m "Research all info we have on kubernetes probe failures in recent weeks.`
 
 A conversation with an agent can be continued after the first message using the argument `-c CONVERSATION_STRING_ID`. The conversation id will be returned in the JSON result from the initial call.
-`$ dust chat -a prea -c 'TdWyn4aDt1' -m "also papertrail this: ..."`
+`$ dust chat -a issueBot -c 'TdWyn4aDt1' -m "also add a subsequent issue about this: ..."`
 
 If the tool errors because login is needed, ask the user to perform it manually.

--- a/.claude/skills/dust-call-agent/SKILL.md
+++ b/.claude/skills/dust-call-agent/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: dust-call-agent
+description: Call a Dust agent to get information (read a slack thread, a notion URL, a google drive document...), perform an action (post a message to slack, create a calendar event, ...), provide context on any topic regarding Dust (the company, current discussions, customers...) or in general have the Dust agent perform a given task.
+---
+
+Access Dust agents that have context on all the company, e.g. recent projects, engineering, sales, marketing, etc., via the Dust CLI non-interactively, e.g.:
+`$ dust chat -a prea -m "papertrail this: ..."`
+`$ dust chat -a deep-dive -m "Research all info we have on kubernetes probe failures in recent weeks.`
+
+A conversation with an agent can be continued after the first message using the argument `-c CONVERSATION_STRING_ID`. The conversation id will be returned in the JSON result from the initial call.
+`$ dust chat -a prea -c 'TdWyn4aDt1' -m "also papertrail this: ..."`
+
+If the tool errors because login is needed, ask the user to perform it manually.

--- a/.claude/skills/dust-call-agent/SKILL.md
+++ b/.claude/skills/dust-call-agent/SKILL.md
@@ -4,7 +4,7 @@ description: Call a Dust agent to get information (read a slack thread, a notion
 ---
 
 Access Dust agents that have context on all the company, e.g. recent projects, engineering, sales, marketing, etc., via the Dust CLI non-interactively, e.g.:
-`$ dust chat -a prea -m "papertrail this: ..."`
+`$ dust chat -a issueBot -m "create an issue for this: ..."`
 `$ dust chat -a deep-dive -m "Research all info we have on kubernetes probe failures in recent weeks.`
 
 A conversation with an agent can be continued after the first message using the argument `-c CONVERSATION_STRING_ID`. The conversation id will be returned in the JSON result from the initial call.


### PR DESCRIPTION
## Description

Add a Claude Code skill for calling Dust agents via the CLI. This enables Claude Code to use Dust agents for tasks like reading slack threads, notion pages, Google Drive documents, or performing actions through agents like `issueBot` and `deep-dive`.

## Risks

Blast radius: Claude Code skills (no production code affected)
Risk: none

## Deploy Plan

- No deployment needed (Claude Code configuration only)