### PR TITLE
Change tool validation wording

### DIFF
--- a/front/components/assistant/conversation/MCPToolValidationRequired.tsx
+++ b/front/components/assistant/conversation/MCPToolValidationRequired.tsx
@@ -106,7 +106,7 @@ export function MCPToolValidationRequired({
       .map((arg) => `${blockedAction.inputs[arg]}`);
 
     return `Always allow @${blockedAction.metadata.agentName} to ${asDisplayName(blockedAction.metadata.toolName)} ${
-      argValues.length > 0 ? ` using ${argValues.join(", ")}` : ""
+      argValues.length > 0 ? ` for the following parameters: ${argValues.join(", ")}` : ""
     }`;
   }, [
     blockedAction.stake,

--- a/front/components/assistant/conversation/MCPToolValidationRequired.tsx
+++ b/front/components/assistant/conversation/MCPToolValidationRequired.tsx
@@ -106,7 +106,9 @@ export function MCPToolValidationRequired({
       .map((arg) => `${blockedAction.inputs[arg]}`);
 
     return `Always allow @${blockedAction.metadata.agentName} to ${asDisplayName(blockedAction.metadata.toolName)} ${
-      argValues.length > 0 ? ` for the following parameters: ${argValues.join(", ")}` : ""
+      argValues.length > 0
+        ? ` for the following parameters: ${argValues.join(", ")}`
+        : ""
     }`;
   }, [
     blockedAction.stake,


### PR DESCRIPTION
## Description

Changes the Medium stake MCP tools validation wording from `Allow @\Assistant to do something using xxx` to `Allow @\Assistant to do something for the following parameters: xxx`

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

None

## Deploy Plan

Deploy front
