### PR TITLE
Hide trial message usage bar until low remaining

### DIFF
--- a/front/components/app/TrialMessageUsage.test.tsx
+++ b/front/components/app/TrialMessageUsage.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { TrialMessageUsage } from "./TrialMessageUsage";
+
+vi.mock("@dust-tt/sparkle", () => ({
+  Button: ({ label }: { label: string }) => (
+    <button type="button">{label}</button>
+  ),
+  LinkWrapper: ({
+    href,
+    children,
+  }: {
+    href: string;
+    children: React.ReactNode;
+  }) => <a href={href}>{children}</a>,
+  cn: (...classes: Array<string | false | null | undefined>) =>
+    classes.filter(Boolean).join(" "),
+}));
+
+const mockedUseTrialMessageUsage = vi.fn();
+vi.mock("@app/lib/swr/trial_message_usage", () => ({
+  useTrialMessageUsage: () => mockedUseTrialMessageUsage(),
+}));
+
+describe("TrialMessageUsage", () => {
+  beforeEach(() => {
+    mockedUseTrialMessageUsage.mockReset();
+  });
+
+  it("does not render when remaining messages are 90 or more", () => {
+    mockedUseTrialMessageUsage.mockReturnValue({
+      messageUsage: { count: 10, limit: 100 }, // remaining 90
+      mutateMessageUsage: vi.fn(),
+    });
+
+    render(<TrialMessageUsage isAdmin={false} workspaceId="w_1" />);
+    expect(screen.queryByText("Trial messages used")).toBeNull();
+  });
+
+  it("renders when remaining messages are less than 90", () => {
+    mockedUseTrialMessageUsage.mockReturnValue({
+      messageUsage: { count: 11, limit: 100 }, // remaining 89
+      mutateMessageUsage: vi.fn(),
+    });
+
+    render(<TrialMessageUsage isAdmin={false} workspaceId="w_1" />);
+    expect(screen.getByText("Trial messages used")).toBeInTheDocument();
+    expect(screen.getByText("11")).toBeInTheDocument();
+    expect(screen.getByText(/\/\s*100/)).toBeInTheDocument();
+  });
+
+  it("does not render when usage is unlimited", () => {
+    mockedUseTrialMessageUsage.mockReturnValue({
+      messageUsage: { count: 0, limit: -1 },
+      mutateMessageUsage: vi.fn(),
+    });
+
+    render(<TrialMessageUsage isAdmin={false} workspaceId="w_1" />);
+    expect(screen.queryByText("Trial messages used")).toBeNull();
+  });
+});

--- a/front/components/app/TrialMessageUsage.tsx
+++ b/front/components/app/TrialMessageUsage.tsx
@@ -5,6 +5,7 @@ import { AGENT_MESSAGE_COMPLETED_EVENT } from "@app/lib/notifications/events";
 import { useTrialMessageUsage } from "@app/lib/swr/trial_message_usage";
 
 const MESSAGE_USAGE_CRITICAL_THRESHOLD = 0.9;
+const DISPLAY_WHEN_REMAINING_BELOW = 90;
 
 interface TrialMessageUsageProps {
   isAdmin: boolean;
@@ -40,6 +41,15 @@ export function TrialMessageUsage({
   }
 
   const { count, limit } = messageUsage;
+  if (limit <= 0) {
+    return null;
+  }
+
+  const remaining = Math.max(limit - count, 0);
+  if (remaining >= DISPLAY_WHEN_REMAINING_BELOW) {
+    return null;
+  }
+
   const percentage = limit > 0 ? count / limit : 0;
   const isCritical = percentage >= MESSAGE_USAGE_CRITICAL_THRESHOLD;
   const isAtLimit = count >= limit;


### PR DESCRIPTION
## Description

Only render the phone trial "messages remaining" usage bar when the workspace has fewer than 90 messages remaining.

## Tests

- `cd front && NODE_ENV=test npm test -- TrialMessageUsage.test.tsx`
- `cd front && NODE_OPTIONS=\"--max-old-space-size=8192\" npx tsc --noEmit`

## Risk

Low. UI-only change; the underlying usage endpoint and counters are unchanged.

## Deploy Plan

Regular deploy.