### PR TITLE
Defaults to SPA: add env vars, precompile api routes

### DIFF
--- a/x/henry/dust-hive/src/commands/warm.ts
+++ b/x/henry/dust-hive/src/commands/warm.ts
@@ -21,9 +21,10 @@ interface WarmOptions {
 // Routes to pre-compile when warming the front service
 // These compile in parallel with the health check to minimize total wait time
 const CRITICAL_ROUTES = [
-  "/",
-  "/w/precompile", // Will 404/redirect but still triggers compilation
-  "/w/precompile/conversation/precompile", // Same - triggers compilation
+  "/api/auth-context", // Auth context API (no workspace)
+  "/api/w/precompile/auth-context", // Auth context API (with workspace)
+  "/api/poke/auth-context", // Poke auth context API (no workspace)
+  "/api/poke/workspaces/precompile/auth-context", // Poke auth context API (with workspace)
 ];
 
 // Start pre-warming critical Next.js routes immediately (with retry)

--- a/x/henry/dust-hive/src/lib/envgen.ts
+++ b/x/henry/dust-hive/src/lib/envgen.ts
@@ -36,6 +36,8 @@ export DUST_FRONT_INTERNAL_API=http://localhost:${ports.front}
 export DUST_CLIENT_FACING_URL=http://localhost:${ports.front}
 export DUST_PUBLIC_URL=http://localhost:${ports.front}
 export NEXT_PUBLIC_DUST_CLIENT_FACING_URL=http://localhost:${ports.front}
+export NEXT_PUBLIC_DUST_APP_URL=http://localhost:${ports.frontSpaApp}
+export POKE_APP_URL=http://localhost:${ports.frontSpaPoke}
 export DUST_AUTH_REDIRECT_BASE_URL=http://localhost:3000
 export CONNECTORS_PUBLIC_URL=http://localhost:${ports.connectors}
 


### PR DESCRIPTION
## Description

This adds default env vars to generate links to the SPA instead of next pages, and update the list of precompiled pages (we only need api)

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

