### PR TITLE
Nuke public spaces

### DIFF
--- a/front/components/spaces/SpaceSideBarMenu.tsx
+++ b/front/components/spaces/SpaceSideBarMenu.tsx
@@ -156,10 +156,6 @@ export default function SpaceSideBarMenu({
     <div className="flex h-0 min-h-full w-full overflow-y-auto">
       <NavigationList className="w-full px-3">
         {sortedGroupedSpaces.map(({ section, spaces }, index) => {
-          if (section === "public" && !spaces.length) {
-            return null;
-          }
-
           if (section === "restricted" && !spaces.length && !isAdmin) {
             return null;
           }
@@ -234,9 +230,6 @@ const getSpaceSectionDetails = (
 
     case "system":
       return { label: "Administration", displayCreateSpaceButton: false };
-
-    case "public":
-      return { label: "Public", displayCreateSpaceButton: false };
 
     default:
       assertNever(kind);

--- a/front/lib/api/spaces.test.ts
+++ b/front/lib/api/spaces.test.ts
@@ -402,9 +402,7 @@ describe("createSpaceAndGroup", () => {
           adminAuth,
           undefined
         );
-        const regularSpaces = allSpaces.filter(
-          (s) => s.kind === "regular" || s.kind === "public"
-        );
+        const regularSpaces = allSpaces.filter((s) => s.kind === "regular");
         const spacesToCreate = Math.max(
           0,
           testMaxVaults - regularSpaces.length
@@ -463,9 +461,7 @@ describe("createSpaceAndGroup", () => {
           adminAuth,
           undefined
         );
-        const regularSpaces = allSpaces.filter(
-          (s) => s.kind === "regular" || s.kind === "public"
-        );
+        const regularSpaces = allSpaces.filter((s) => s.kind === "regular");
         const spacesToCreate = Math.max(
           0,
           testMaxVaults - regularSpaces.length
@@ -761,12 +757,7 @@ describe("softDeleteSpaceAndLaunchScrubWorkflow", () => {
       );
 
       // Document which kinds are NOT allowed to be deleted
-      const knownDisallowedKinds = [
-        "global",
-        "system",
-        "conversations",
-        "public",
-      ];
+      const knownDisallowedKinds = ["global", "system", "conversations"];
 
       expect(unhandledKinds.sort()).toEqual(knownDisallowedKinds.sort());
     });
@@ -821,27 +812,6 @@ describe("softDeleteSpaceAndLaunchScrubWorkflow", () => {
       );
     });
 
-    it("should fail to delete a public space", async () => {
-      // Create a public space
-      const publicSpace = await SpaceResource.makeNew(
-        {
-          name: "Test Public Space",
-          kind: "public",
-          workspaceId: workspace.id,
-        },
-        { members: [globalGroup] }
-      );
-
-      await expect(async () => {
-        await softDeleteSpaceAndLaunchScrubWorkflow(
-          adminAuth,
-          publicSpace,
-          false
-        );
-      }).rejects.toThrow(
-        "Cannot delete spaces that are not regular or project"
-      );
-    });
   });
 
   describe("API key validation", () => {

--- a/front/lib/api/spaces.test.ts
+++ b/front/lib/api/spaces.test.ts
@@ -811,7 +811,6 @@ describe("softDeleteSpaceAndLaunchScrubWorkflow", () => {
         "Cannot delete spaces that are not regular or project"
       );
     });
-
   });
 
   describe("API key validation", () => {

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -151,7 +151,7 @@ export class Authenticator {
    * @returns Array of ResourcePermission objects, one entry per sub-array
    */
   static createResourcePermissionsFromGroupIds(
-    groupIds: string[][],
+    groupIds: string[][]
   ): ResourcePermission[] {
     const getIdFromSIdOrThrow = (groupId: string) => {
       const id = getResourceIdFromSId(groupId);
@@ -171,7 +171,7 @@ export class Authenticator {
   }
 
   static async userFromSession(
-    session: SessionWithUser | null,
+    session: SessionWithUser | null
   ): Promise<UserResource | null> {
     if (session) {
       return UserResource.fetchByWorkOSUserId(session.user.workOSUserId);
@@ -190,7 +190,7 @@ export class Authenticator {
    */
   static async fromSession(
     session: SessionWithUser | null,
-    wId: string,
+    wId: string
   ): Promise<Authenticator> {
     return tracer.trace("fromSession", async () => {
       const [workspace, user] = await Promise.all([
@@ -213,7 +213,7 @@ export class Authenticator {
             workspace: renderLightWorkspaceType({ workspace }),
           }),
           SubscriptionResource.fetchActiveByWorkspace(
-            renderLightWorkspaceType({ workspace }),
+            renderLightWorkspaceType({ workspace })
           ),
         ]);
       }
@@ -253,7 +253,7 @@ export class Authenticator {
    */
   static async fromSuperUserSession(
     session: SessionWithUser | null,
-    wId: string | null,
+    wId: string | null
   ): Promise<Authenticator> {
     const [workspace, user] = await Promise.all([
       wId ? WorkspaceResource.fetchById(wId) : null,
@@ -271,7 +271,7 @@ export class Authenticator {
             })
           : [],
         SubscriptionResource.fetchActiveByWorkspace(
-          renderLightWorkspaceType({ workspace }),
+          renderLightWorkspaceType({ workspace })
         ),
       ]);
     }
@@ -295,7 +295,7 @@ export class Authenticator {
    */
   static async fromUserIdAndWorkspaceId(
     uId: string,
-    wId: string,
+    wId: string
   ): Promise<Authenticator> {
     const [workspace, user] = await Promise.all([
       WorkspaceResource.fetchById(wId),
@@ -317,7 +317,7 @@ export class Authenticator {
           workspace: renderLightWorkspaceType({ workspace }),
         }),
         SubscriptionResource.fetchActiveByWorkspace(
-          renderLightWorkspaceType({ workspace }),
+          renderLightWorkspaceType({ workspace })
         ),
       ]);
     }
@@ -368,7 +368,7 @@ export class Authenticator {
         workspace: renderLightWorkspaceType({ workspace }),
       }),
       SubscriptionResource.fetchActiveByWorkspace(
-        renderLightWorkspaceType({ workspace }),
+        renderLightWorkspaceType({ workspace })
       ),
     ]);
 
@@ -380,7 +380,7 @@ export class Authenticator {
         user,
         role,
         subscription,
-      }),
+      })
     );
   }
 
@@ -400,7 +400,7 @@ export class Authenticator {
     key: KeyResource,
     wId: string,
     requestedGroupIds?: string[],
-    requestedRole?: RoleType,
+    requestedRole?: RoleType
   ): Promise<{
     workspaceAuth: Authenticator;
     keyAuth: Authenticator;
@@ -432,7 +432,7 @@ export class Authenticator {
 
     const getSubscriptionForWorkspace = (workspace: WorkspaceResource) =>
       SubscriptionResource.fetchActiveByWorkspace(
-        renderLightWorkspaceType({ workspace }),
+        renderLightWorkspaceType({ workspace })
       );
 
     let keyGroups: GroupResource[] = [];
@@ -457,7 +457,7 @@ export class Authenticator {
             getSubscriptionForWorkspace(keyWorkspace),
             // Workspace related attributes.
             getSubscriptionForWorkspace(workspace),
-          ],
+          ]
         );
       }
     }
@@ -510,7 +510,7 @@ export class Authenticator {
 
     // We use the system key for the workspace to fetch the groups.
     const systemKeyForWorkspaceRes = await getOrCreateSystemApiKey(
-      renderLightWorkspaceType({ workspace }),
+      renderLightWorkspaceType({ workspace })
     );
     if (systemKeyForWorkspaceRes.isErr()) {
       throw new Error(`Could not get system key for workspace ${workspaceId}`);
@@ -518,7 +518,7 @@ export class Authenticator {
 
     const groups = await GroupResource.listGroupsWithSystemKey(
       systemKeyForWorkspaceRes.value,
-      groupIds,
+      groupIds
     );
 
     return new Authenticator({
@@ -536,7 +536,7 @@ export class Authenticator {
    * @param workspaceId string
    */
   static async internalBuilderForWorkspace(
-    workspaceId: string,
+    workspaceId: string
   ): Promise<Authenticator> {
     const workspace = await WorkspaceResource.fetchById(workspaceId);
     if (!workspace) {
@@ -549,7 +549,7 @@ export class Authenticator {
     [globalGroup, subscription] = await Promise.all([
       GroupResource.internalFetchWorkspaceGlobalGroup(workspace.id),
       SubscriptionResource.fetchActiveByWorkspace(
-        renderLightWorkspaceType({ workspace }),
+        renderLightWorkspaceType({ workspace })
       ),
     ]);
 
@@ -568,7 +568,7 @@ export class Authenticator {
     workspaceId: string,
     options?: {
       dangerouslyRequestAllGroups: boolean;
-    },
+    }
   ): Promise<Authenticator> {
     const workspace = await WorkspaceResource.fetchById(workspaceId);
     if (!workspace) {
@@ -588,7 +588,7 @@ export class Authenticator {
         }
       })(),
       SubscriptionResource.fetchActiveByWorkspace(
-        renderLightWorkspaceType({ workspace }),
+        renderLightWorkspaceType({ workspace })
       ),
     ]);
 
@@ -612,7 +612,7 @@ export class Authenticator {
    */
   async exchangeSystemKeyForUserAuthByEmail(
     auth: Authenticator,
-    { userEmail }: { userEmail: string },
+    { userEmail }: { userEmail: string }
   ): Promise<Authenticator | null> {
     if (!auth.isSystemKey()) {
       logger.error(
@@ -621,7 +621,7 @@ export class Authenticator {
           userEmail,
           workspaceId: auth.workspace()?.sId,
         },
-        "Attempted to exchange non-system key authenticator for user authenticator",
+        "Attempted to exchange non-system key authenticator for user authenticator"
       );
 
       throw new Error("Provided authenticator does not have a system key.");
@@ -654,7 +654,7 @@ export class Authenticator {
 
     // Take the oldest active membership.
     const [activeMembership] = activeMemberships.sort(
-      (a, b) => new Date(a.startAt).getTime() - new Date(b.startAt).getTime(),
+      (a, b) => new Date(a.startAt).getTime() - new Date(b.startAt).getTime()
     );
     // Find the user associated with the active membership.
     const user = users.find((u) => u.id === activeMembership.userId);
@@ -742,7 +742,7 @@ export class Authenticator {
 
     if (!workspace) {
       throw new Error(
-        "Unexpected unauthenticated call to `getNonNullableWorkspace`.",
+        "Unexpected unauthenticated call to `getNonNullableWorkspace`."
       );
     }
 
@@ -758,7 +758,7 @@ export class Authenticator {
 
     if (!subscription) {
       throw new Error(
-        "Unexpected unauthenticated call to `getNonNullableSubscription`.",
+        "Unexpected unauthenticated call to `getNonNullableSubscription`."
       );
     }
 
@@ -774,7 +774,7 @@ export class Authenticator {
 
     if (!subscriptionResource) {
       throw new Error(
-        "Unexpected unauthenticated call to `getNonNullableSubscriptionResource`.",
+        "Unexpected unauthenticated call to `getNonNullableSubscriptionResource`."
       );
     }
 
@@ -790,7 +790,7 @@ export class Authenticator {
 
     if (!plan) {
       throw new Error(
-        "Unexpected unauthenticated call to `getNonNullablePlan`.",
+        "Unexpected unauthenticated call to `getNonNullablePlan`."
       );
     }
 
@@ -815,7 +815,7 @@ export class Authenticator {
 
     if (!user) {
       throw new Error(
-        "Unexpected unauthenticated call to `getNonNullableUser`.",
+        "Unexpected unauthenticated call to `getNonNullableUser`."
       );
     }
 
@@ -842,7 +842,7 @@ export class Authenticator {
     }
 
     return this._groupModelIds.map((id) =>
-      GroupResource.modelIdToSId({ id, workspaceId }),
+      GroupResource.modelIdToSId({ id, workspaceId })
     );
   }
 
@@ -862,7 +862,7 @@ export class Authenticator {
         GroupResource.modelIdToSId({
           id,
           workspaceId,
-        }) === groupId,
+        }) === groupId
     );
   }
 
@@ -878,11 +878,11 @@ export class Authenticator {
    */
   hasPermissionForAllResources(
     resourcePermissions: ResourcePermission[],
-    permission: PermissionType,
+    permission: PermissionType
   ): boolean {
     // Apply conjunction (AND) over all resource permission entries.
     return resourcePermissions.every((rp) =>
-      this.hasResourcePermission(rp, permission),
+      this.hasResourcePermission(rp, permission)
     );
   }
 
@@ -909,7 +909,7 @@ export class Authenticator {
    */
   private hasResourcePermission(
     resourcePermission: ResourcePermission,
-    permission: PermissionType,
+    permission: PermissionType
   ): boolean {
     // First path: Role-based permission check.
     if (hasRolePermissions(resourcePermission)) {
@@ -917,7 +917,7 @@ export class Authenticator {
 
       // Check workspace-specific role permissions.
       const hasRolePermission = resourcePermission.roles.some(
-        (r) => this.role() === r.role && r.permissions.includes(permission),
+        (r) => this.role() === r.role && r.permissions.includes(permission)
       );
 
       if (
@@ -931,8 +931,8 @@ export class Authenticator {
     // Second path: Group-based permission check.
     return this._groupModelIds.some((groupId) =>
       resourcePermission.groups.some(
-        (gp) => gp.id === groupId && gp.permissions.includes(permission),
-      ),
+        (gp) => gp.id === groupId && gp.permissions.includes(permission)
+      )
     );
   }
 
@@ -968,7 +968,7 @@ export class Authenticator {
   }
 
   static async fromJSON(
-    authType: AuthenticatorType,
+    authType: AuthenticatorType
   ): Promise<Result<Authenticator, { code: "subscription_mismatch" }>> {
     const [workspace, user] = await Promise.all([
       authType.workspaceId
@@ -998,7 +998,7 @@ export class Authenticator {
     }
 
     const groupIds = removeNulls(
-      authType.groupIds.map((sId) => getResourceIdFromSId(sId)),
+      authType.groupIds.map((sId) => getResourceIdFromSId(sId))
     );
 
     return new Ok(
@@ -1010,7 +1010,7 @@ export class Authenticator {
         groupModelIds: groupIds,
         subscription,
         key: authType.key,
-      }),
+      })
     );
   }
 }
@@ -1023,7 +1023,7 @@ export class Authenticator {
  */
 export async function getSession(
   req: NextApiRequest | GetServerSidePropsContext["req"],
-  res: NextApiResponse | GetServerSidePropsContext["res"],
+  res: NextApiResponse | GetServerSidePropsContext["res"]
 ): Promise<SessionWithUser | null> {
   const workOsSession = await getWorkOSSession(req, res);
   // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
@@ -1036,7 +1036,7 @@ export async function getSession(
  * @returns
  */
 export async function getBearerToken(
-  req: NextApiRequest,
+  req: NextApiRequest
 ): Promise<Result<string, APIErrorWithStatusCode>> {
   if (!req.headers.authorization) {
     return new Err({
@@ -1049,7 +1049,7 @@ export async function getBearerToken(
   }
 
   const parse = req.headers.authorization.match(
-    /^Bearer\s+([A-Za-z0-9-._~+/]+=*)$/i,
+    /^Bearer\s+([A-Za-z0-9-._~+/]+=*)$/i
   );
   if (!parse || !parse[1]) {
     return new Err({
@@ -1070,7 +1070,7 @@ export async function getBearerToken(
  * @returns Result<Key, APIErrorWithStatusCode>
  */
 export async function getAPIKey(
-  req: NextApiRequest,
+  req: NextApiRequest
 ): Promise<Result<KeyResource, APIErrorWithStatusCode>> {
   const token = await getBearerToken(req);
 
@@ -1113,13 +1113,13 @@ export async function getAPIKey(
  * @returns Promise<Result<KeyResource, Error>>
  */
 export async function getOrCreateSystemApiKey(
-  workspace: LightWorkspaceType,
+  workspace: LightWorkspaceType
 ): Promise<Result<KeyResource, Error>> {
   let key = await KeyResource.fetchSystemKeyForWorkspace(workspace);
 
   if (!key) {
     const group = await GroupResource.internalFetchWorkspaceSystemGroup(
-      workspace.id,
+      workspace.id
     );
     key = await KeyResource.makeNew(
       {
@@ -1129,7 +1129,7 @@ export async function getOrCreateSystemApiKey(
         role: "admin",
         name: DEFAULT_SYSTEM_KEY_NAME,
       },
-      group,
+      group
     );
   }
 
@@ -1157,7 +1157,7 @@ export async function prodAPICredentialsForOwner(
     useLocalInDev,
   }: {
     useLocalInDev: boolean;
-  } = { useLocalInDev: false },
+  } = { useLocalInDev: false }
 ): Promise<{
   apiKey: string;
   workspaceId: string;
@@ -1180,7 +1180,7 @@ export async function prodAPICredentialsForOwner(
         owner,
         error: systemAPIKeyRes.error,
       },
-      "Could not create system API key for workspace",
+      "Could not create system API key for workspace"
     );
     throw new Error(`Could not create system API key for workspace`);
   }
@@ -1193,7 +1193,7 @@ export async function prodAPICredentialsForOwner(
 
 export const getFeatureFlags = memoizer.sync({
   load: async (
-    workspace: LightWorkspaceType,
+    workspace: LightWorkspaceType
   ): Promise<WhitelistableFeature[]> => {
     if (ACTIVATE_ALL_FEATURES_DEV && isDevelopment()) {
       return [...WHITELISTABLE_FEATURES];
@@ -1211,7 +1211,7 @@ export const getFeatureFlags = memoizer.sync({
 });
 
 export async function isRestrictedFromAgentCreation(
-  owner: LightWorkspaceType,
+  owner: LightWorkspaceType
 ): Promise<boolean> {
   const featureFlags = await getFeatureFlags(owner);
 

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -151,7 +151,7 @@ export class Authenticator {
    * @returns Array of ResourcePermission objects, one entry per sub-array
    */
   static createResourcePermissionsFromGroupIds(
-    groupIds: string[][]
+    groupIds: string[][],
   ): ResourcePermission[] {
     const getIdFromSIdOrThrow = (groupId: string) => {
       const id = getResourceIdFromSId(groupId);
@@ -171,7 +171,7 @@ export class Authenticator {
   }
 
   static async userFromSession(
-    session: SessionWithUser | null
+    session: SessionWithUser | null,
   ): Promise<UserResource | null> {
     if (session) {
       return UserResource.fetchByWorkOSUserId(session.user.workOSUserId);
@@ -190,7 +190,7 @@ export class Authenticator {
    */
   static async fromSession(
     session: SessionWithUser | null,
-    wId: string
+    wId: string,
   ): Promise<Authenticator> {
     return tracer.trace("fromSession", async () => {
       const [workspace, user] = await Promise.all([
@@ -213,7 +213,7 @@ export class Authenticator {
             workspace: renderLightWorkspaceType({ workspace }),
           }),
           SubscriptionResource.fetchActiveByWorkspace(
-            renderLightWorkspaceType({ workspace })
+            renderLightWorkspaceType({ workspace }),
           ),
         ]);
       }
@@ -253,7 +253,7 @@ export class Authenticator {
    */
   static async fromSuperUserSession(
     session: SessionWithUser | null,
-    wId: string | null
+    wId: string | null,
   ): Promise<Authenticator> {
     const [workspace, user] = await Promise.all([
       wId ? WorkspaceResource.fetchById(wId) : null,
@@ -271,7 +271,7 @@ export class Authenticator {
             })
           : [],
         SubscriptionResource.fetchActiveByWorkspace(
-          renderLightWorkspaceType({ workspace })
+          renderLightWorkspaceType({ workspace }),
         ),
       ]);
     }
@@ -295,7 +295,7 @@ export class Authenticator {
    */
   static async fromUserIdAndWorkspaceId(
     uId: string,
-    wId: string
+    wId: string,
   ): Promise<Authenticator> {
     const [workspace, user] = await Promise.all([
       WorkspaceResource.fetchById(wId),
@@ -317,7 +317,7 @@ export class Authenticator {
           workspace: renderLightWorkspaceType({ workspace }),
         }),
         SubscriptionResource.fetchActiveByWorkspace(
-          renderLightWorkspaceType({ workspace })
+          renderLightWorkspaceType({ workspace }),
         ),
       ]);
     }
@@ -368,7 +368,7 @@ export class Authenticator {
         workspace: renderLightWorkspaceType({ workspace }),
       }),
       SubscriptionResource.fetchActiveByWorkspace(
-        renderLightWorkspaceType({ workspace })
+        renderLightWorkspaceType({ workspace }),
       ),
     ]);
 
@@ -380,7 +380,7 @@ export class Authenticator {
         user,
         role,
         subscription,
-      })
+      }),
     );
   }
 
@@ -400,7 +400,7 @@ export class Authenticator {
     key: KeyResource,
     wId: string,
     requestedGroupIds?: string[],
-    requestedRole?: RoleType
+    requestedRole?: RoleType,
   ): Promise<{
     workspaceAuth: Authenticator;
     keyAuth: Authenticator;
@@ -432,7 +432,7 @@ export class Authenticator {
 
     const getSubscriptionForWorkspace = (workspace: WorkspaceResource) =>
       SubscriptionResource.fetchActiveByWorkspace(
-        renderLightWorkspaceType({ workspace })
+        renderLightWorkspaceType({ workspace }),
       );
 
     let keyGroups: GroupResource[] = [];
@@ -457,7 +457,7 @@ export class Authenticator {
             getSubscriptionForWorkspace(keyWorkspace),
             // Workspace related attributes.
             getSubscriptionForWorkspace(workspace),
-          ]
+          ],
         );
       }
     }
@@ -510,7 +510,7 @@ export class Authenticator {
 
     // We use the system key for the workspace to fetch the groups.
     const systemKeyForWorkspaceRes = await getOrCreateSystemApiKey(
-      renderLightWorkspaceType({ workspace })
+      renderLightWorkspaceType({ workspace }),
     );
     if (systemKeyForWorkspaceRes.isErr()) {
       throw new Error(`Could not get system key for workspace ${workspaceId}`);
@@ -518,7 +518,7 @@ export class Authenticator {
 
     const groups = await GroupResource.listGroupsWithSystemKey(
       systemKeyForWorkspaceRes.value,
-      groupIds
+      groupIds,
     );
 
     return new Authenticator({
@@ -536,7 +536,7 @@ export class Authenticator {
    * @param workspaceId string
    */
   static async internalBuilderForWorkspace(
-    workspaceId: string
+    workspaceId: string,
   ): Promise<Authenticator> {
     const workspace = await WorkspaceResource.fetchById(workspaceId);
     if (!workspace) {
@@ -549,7 +549,7 @@ export class Authenticator {
     [globalGroup, subscription] = await Promise.all([
       GroupResource.internalFetchWorkspaceGlobalGroup(workspace.id),
       SubscriptionResource.fetchActiveByWorkspace(
-        renderLightWorkspaceType({ workspace })
+        renderLightWorkspaceType({ workspace }),
       ),
     ]);
 
@@ -568,7 +568,7 @@ export class Authenticator {
     workspaceId: string,
     options?: {
       dangerouslyRequestAllGroups: boolean;
-    }
+    },
   ): Promise<Authenticator> {
     const workspace = await WorkspaceResource.fetchById(workspaceId);
     if (!workspace) {
@@ -588,7 +588,7 @@ export class Authenticator {
         }
       })(),
       SubscriptionResource.fetchActiveByWorkspace(
-        renderLightWorkspaceType({ workspace })
+        renderLightWorkspaceType({ workspace }),
       ),
     ]);
 
@@ -612,7 +612,7 @@ export class Authenticator {
    */
   async exchangeSystemKeyForUserAuthByEmail(
     auth: Authenticator,
-    { userEmail }: { userEmail: string }
+    { userEmail }: { userEmail: string },
   ): Promise<Authenticator | null> {
     if (!auth.isSystemKey()) {
       logger.error(
@@ -621,7 +621,7 @@ export class Authenticator {
           userEmail,
           workspaceId: auth.workspace()?.sId,
         },
-        "Attempted to exchange non-system key authenticator for user authenticator"
+        "Attempted to exchange non-system key authenticator for user authenticator",
       );
 
       throw new Error("Provided authenticator does not have a system key.");
@@ -654,7 +654,7 @@ export class Authenticator {
 
     // Take the oldest active membership.
     const [activeMembership] = activeMemberships.sort(
-      (a, b) => new Date(a.startAt).getTime() - new Date(b.startAt).getTime()
+      (a, b) => new Date(a.startAt).getTime() - new Date(b.startAt).getTime(),
     );
     // Find the user associated with the active membership.
     const user = users.find((u) => u.id === activeMembership.userId);
@@ -742,7 +742,7 @@ export class Authenticator {
 
     if (!workspace) {
       throw new Error(
-        "Unexpected unauthenticated call to `getNonNullableWorkspace`."
+        "Unexpected unauthenticated call to `getNonNullableWorkspace`.",
       );
     }
 
@@ -758,7 +758,7 @@ export class Authenticator {
 
     if (!subscription) {
       throw new Error(
-        "Unexpected unauthenticated call to `getNonNullableSubscription`."
+        "Unexpected unauthenticated call to `getNonNullableSubscription`.",
       );
     }
 
@@ -774,7 +774,7 @@ export class Authenticator {
 
     if (!subscriptionResource) {
       throw new Error(
-        "Unexpected unauthenticated call to `getNonNullableSubscriptionResource`."
+        "Unexpected unauthenticated call to `getNonNullableSubscriptionResource`.",
       );
     }
 
@@ -790,7 +790,7 @@ export class Authenticator {
 
     if (!plan) {
       throw new Error(
-        "Unexpected unauthenticated call to `getNonNullablePlan`."
+        "Unexpected unauthenticated call to `getNonNullablePlan`.",
       );
     }
 
@@ -815,7 +815,7 @@ export class Authenticator {
 
     if (!user) {
       throw new Error(
-        "Unexpected unauthenticated call to `getNonNullableUser`."
+        "Unexpected unauthenticated call to `getNonNullableUser`.",
       );
     }
 
@@ -842,7 +842,7 @@ export class Authenticator {
     }
 
     return this._groupModelIds.map((id) =>
-      GroupResource.modelIdToSId({ id, workspaceId })
+      GroupResource.modelIdToSId({ id, workspaceId }),
     );
   }
 
@@ -862,7 +862,7 @@ export class Authenticator {
         GroupResource.modelIdToSId({
           id,
           workspaceId,
-        }) === groupId
+        }) === groupId,
     );
   }
 
@@ -878,11 +878,11 @@ export class Authenticator {
    */
   hasPermissionForAllResources(
     resourcePermissions: ResourcePermission[],
-    permission: PermissionType
+    permission: PermissionType,
   ): boolean {
     // Apply conjunction (AND) over all resource permission entries.
     return resourcePermissions.every((rp) =>
-      this.hasResourcePermission(rp, permission)
+      this.hasResourcePermission(rp, permission),
     );
   }
 
@@ -909,23 +909,15 @@ export class Authenticator {
    */
   private hasResourcePermission(
     resourcePermission: ResourcePermission,
-    permission: PermissionType
+    permission: PermissionType,
   ): boolean {
     // First path: Role-based permission check.
     if (hasRolePermissions(resourcePermission)) {
       const workspace = this.getNonNullableWorkspace();
 
-      // Check for public access first. Only case of cross-workspace permission.
-      const publicPermission = resourcePermission.roles
-        .find((r) => r.role === "none")
-        ?.permissions.includes(permission);
-      if (publicPermission) {
-        return true;
-      }
-
       // Check workspace-specific role permissions.
       const hasRolePermission = resourcePermission.roles.some(
-        (r) => this.role() === r.role && r.permissions.includes(permission)
+        (r) => this.role() === r.role && r.permissions.includes(permission),
       );
 
       if (
@@ -939,8 +931,8 @@ export class Authenticator {
     // Second path: Group-based permission check.
     return this._groupModelIds.some((groupId) =>
       resourcePermission.groups.some(
-        (gp) => gp.id === groupId && gp.permissions.includes(permission)
-      )
+        (gp) => gp.id === groupId && gp.permissions.includes(permission),
+      ),
     );
   }
 
@@ -976,7 +968,7 @@ export class Authenticator {
   }
 
   static async fromJSON(
-    authType: AuthenticatorType
+    authType: AuthenticatorType,
   ): Promise<Result<Authenticator, { code: "subscription_mismatch" }>> {
     const [workspace, user] = await Promise.all([
       authType.workspaceId
@@ -1006,7 +998,7 @@ export class Authenticator {
     }
 
     const groupIds = removeNulls(
-      authType.groupIds.map((sId) => getResourceIdFromSId(sId))
+      authType.groupIds.map((sId) => getResourceIdFromSId(sId)),
     );
 
     return new Ok(
@@ -1018,7 +1010,7 @@ export class Authenticator {
         groupModelIds: groupIds,
         subscription,
         key: authType.key,
-      })
+      }),
     );
   }
 }
@@ -1031,7 +1023,7 @@ export class Authenticator {
  */
 export async function getSession(
   req: NextApiRequest | GetServerSidePropsContext["req"],
-  res: NextApiResponse | GetServerSidePropsContext["res"]
+  res: NextApiResponse | GetServerSidePropsContext["res"],
 ): Promise<SessionWithUser | null> {
   const workOsSession = await getWorkOSSession(req, res);
   // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
@@ -1044,7 +1036,7 @@ export async function getSession(
  * @returns
  */
 export async function getBearerToken(
-  req: NextApiRequest
+  req: NextApiRequest,
 ): Promise<Result<string, APIErrorWithStatusCode>> {
   if (!req.headers.authorization) {
     return new Err({
@@ -1057,7 +1049,7 @@ export async function getBearerToken(
   }
 
   const parse = req.headers.authorization.match(
-    /^Bearer\s+([A-Za-z0-9-._~+/]+=*)$/i
+    /^Bearer\s+([A-Za-z0-9-._~+/]+=*)$/i,
   );
   if (!parse || !parse[1]) {
     return new Err({
@@ -1078,7 +1070,7 @@ export async function getBearerToken(
  * @returns Result<Key, APIErrorWithStatusCode>
  */
 export async function getAPIKey(
-  req: NextApiRequest
+  req: NextApiRequest,
 ): Promise<Result<KeyResource, APIErrorWithStatusCode>> {
   const token = await getBearerToken(req);
 
@@ -1121,13 +1113,13 @@ export async function getAPIKey(
  * @returns Promise<Result<KeyResource, Error>>
  */
 export async function getOrCreateSystemApiKey(
-  workspace: LightWorkspaceType
+  workspace: LightWorkspaceType,
 ): Promise<Result<KeyResource, Error>> {
   let key = await KeyResource.fetchSystemKeyForWorkspace(workspace);
 
   if (!key) {
     const group = await GroupResource.internalFetchWorkspaceSystemGroup(
-      workspace.id
+      workspace.id,
     );
     key = await KeyResource.makeNew(
       {
@@ -1137,7 +1129,7 @@ export async function getOrCreateSystemApiKey(
         role: "admin",
         name: DEFAULT_SYSTEM_KEY_NAME,
       },
-      group
+      group,
     );
   }
 
@@ -1165,7 +1157,7 @@ export async function prodAPICredentialsForOwner(
     useLocalInDev,
   }: {
     useLocalInDev: boolean;
-  } = { useLocalInDev: false }
+  } = { useLocalInDev: false },
 ): Promise<{
   apiKey: string;
   workspaceId: string;
@@ -1188,7 +1180,7 @@ export async function prodAPICredentialsForOwner(
         owner,
         error: systemAPIKeyRes.error,
       },
-      "Could not create system API key for workspace"
+      "Could not create system API key for workspace",
     );
     throw new Error(`Could not create system API key for workspace`);
   }
@@ -1201,7 +1193,7 @@ export async function prodAPICredentialsForOwner(
 
 export const getFeatureFlags = memoizer.sync({
   load: async (
-    workspace: LightWorkspaceType
+    workspace: LightWorkspaceType,
   ): Promise<WhitelistableFeature[]> => {
     if (ACTIVATE_ALL_FEATURES_DEV && isDevelopment()) {
       return [...WHITELISTABLE_FEATURES];
@@ -1219,7 +1211,7 @@ export const getFeatureFlags = memoizer.sync({
 });
 
 export async function isRestrictedFromAgentCreation(
-  owner: LightWorkspaceType
+  owner: LightWorkspaceType,
 ): Promise<boolean> {
   const featureFlags = await getFeatureFlags(owner);
 

--- a/front/lib/resources/group_space_resource.ts
+++ b/front/lib/resources/group_space_resource.ts
@@ -312,25 +312,6 @@ export class GroupSpaceMemberResource extends GroupSpaceBaseResource {
             workspaceId: this.workspaceId,
           },
         ];
-      case "public":
-        return [
-          {
-            groups: [
-              {
-                id: this.groupId,
-                permissions: ["read", "write"],
-              },
-            ],
-            roles: [
-              { role: "admin", permissions: ["admin", "read", "write"] },
-              { role: "builder", permissions: ["read", "write"] },
-              { role: "user", permissions: ["read"] },
-              // Everyone can read.
-              { role: "none", permissions: ["read"] },
-            ],
-            workspaceId: this.workspaceId,
-          },
-        ];
       case "global":
       case "conversations":
         return [

--- a/front/lib/resources/resource_with_space.ts
+++ b/front/lib/resources/resource_with_space.ts
@@ -41,7 +41,7 @@ export abstract class ResourceWithSpace<
   protected constructor(
     model: ModelStaticSoftDeletable<M>,
     blob: Attributes<M>,
-    public readonly space: SpaceResource
+    public readonly space: SpaceResource,
   ) {
     super(model, blob);
 
@@ -58,7 +58,7 @@ export abstract class ResourceWithSpace<
         model: ModelStaticSoftDeletable<M>,
         blob: Attributes<M>,
         space: SpaceResource,
-        includes?: IncludeType
+        includes?: IncludeType,
       ): T;
     } & { model: ModelStaticSoftDeletable<M> },
     auth: Authenticator,
@@ -71,7 +71,7 @@ export abstract class ResourceWithSpace<
       order,
       where,
     }: ResourceFindOptions<M> = {},
-    transaction?: Transaction
+    transaction?: Transaction,
   ): Promise<T[]> {
     const blobs = await this.model.findAll({
       attributes,
@@ -130,21 +130,21 @@ export abstract class ResourceWithSpace<
                     acc[key] = includedModel.get();
                   } else if (Array.isArray(includedModel)) {
                     acc[key] = includedModel.map((m) =>
-                      m.get()
+                      m.get(),
                     ) as IncludeType[keyof IncludeType];
                   }
                 }
               }
               return acc;
             },
-            {} as IncludeType
+            {} as IncludeType,
           );
 
           return new this(
             this.model,
             b.get(),
             SpaceResource.fromModel(space),
-            includedResults
+            includedResults,
           );
         })
         // Filter out resources that the user cannot fetch.
@@ -156,17 +156,17 @@ export abstract class ResourceWithSpace<
 
   protected abstract hardDelete(
     auth: Authenticator,
-    transaction?: Transaction
+    transaction?: Transaction,
   ): Promise<Result<number, Error>>;
 
   protected abstract softDelete(
     auth: Authenticator,
-    transaction?: Transaction
+    transaction?: Transaction,
   ): Promise<Result<number, Error>>;
 
   async delete(
     auth: Authenticator,
-    options: { hardDelete: boolean; transaction?: Transaction }
+    options: { hardDelete: boolean; transaction?: Transaction },
   ): Promise<Result<undefined | number, Error>> {
     const { hardDelete, transaction } = options;
 
@@ -199,16 +199,15 @@ export abstract class ResourceWithSpace<
     return this.space.canWrite(auth);
   }
 
-  // This method determines if the authenticated user can fetch data, based on workspace ownership
-  // or public space access. Changes to this logic can impact data security, so they must be
-  // reviewed and tested carefully to prevent unauthorized access.
+  // This method determines if the authenticated user can fetch data, based on workspace ownership.
+  // Changes to this logic can impact data security, so they must be reviewed and tested carefully
+  // to prevent unauthorized access.
   private canFetch(auth: Authenticator) {
     return (
       // Superusers can fetch any resource.
       auth.isDustSuperUser() ||
-      // Others, can only fetch resources from their workspace or public spaces.
-      this.workspaceId === auth.getNonNullableWorkspace().id ||
-      this.space.isPublic()
+      // Others, can only fetch resources from their workspace spaces.
+      this.workspaceId === auth.getNonNullableWorkspace().id
     );
   }
 }

--- a/front/lib/resources/resource_with_space.ts
+++ b/front/lib/resources/resource_with_space.ts
@@ -41,7 +41,7 @@ export abstract class ResourceWithSpace<
   protected constructor(
     model: ModelStaticSoftDeletable<M>,
     blob: Attributes<M>,
-    public readonly space: SpaceResource,
+    public readonly space: SpaceResource
   ) {
     super(model, blob);
 
@@ -58,7 +58,7 @@ export abstract class ResourceWithSpace<
         model: ModelStaticSoftDeletable<M>,
         blob: Attributes<M>,
         space: SpaceResource,
-        includes?: IncludeType,
+        includes?: IncludeType
       ): T;
     } & { model: ModelStaticSoftDeletable<M> },
     auth: Authenticator,
@@ -71,7 +71,7 @@ export abstract class ResourceWithSpace<
       order,
       where,
     }: ResourceFindOptions<M> = {},
-    transaction?: Transaction,
+    transaction?: Transaction
   ): Promise<T[]> {
     const blobs = await this.model.findAll({
       attributes,
@@ -130,21 +130,21 @@ export abstract class ResourceWithSpace<
                     acc[key] = includedModel.get();
                   } else if (Array.isArray(includedModel)) {
                     acc[key] = includedModel.map((m) =>
-                      m.get(),
+                      m.get()
                     ) as IncludeType[keyof IncludeType];
                   }
                 }
               }
               return acc;
             },
-            {} as IncludeType,
+            {} as IncludeType
           );
 
           return new this(
             this.model,
             b.get(),
             SpaceResource.fromModel(space),
-            includedResults,
+            includedResults
           );
         })
         // Filter out resources that the user cannot fetch.
@@ -156,17 +156,17 @@ export abstract class ResourceWithSpace<
 
   protected abstract hardDelete(
     auth: Authenticator,
-    transaction?: Transaction,
+    transaction?: Transaction
   ): Promise<Result<number, Error>>;
 
   protected abstract softDelete(
     auth: Authenticator,
-    transaction?: Transaction,
+    transaction?: Transaction
   ): Promise<Result<number, Error>>;
 
   async delete(
     auth: Authenticator,
-    options: { hardDelete: boolean; transaction?: Transaction },
+    options: { hardDelete: boolean; transaction?: Transaction }
   ): Promise<Result<undefined | number, Error>> {
     const { hardDelete, transaction } = options;
 

--- a/front/lib/resources/space_resource.test.ts
+++ b/front/lib/resources/space_resource.test.ts
@@ -1038,20 +1038,6 @@ describe("SpaceResource", () => {
       expect(spaces.some((s) => s.id === projectSpace.id)).toBe(false);
     });
 
-    it("should include public spaces", async () => {
-      const publicSpace = await SpaceResource.makeNew(
-        {
-          name: "Public Space",
-          kind: "public",
-          workspaceId: workspace.id,
-        },
-        { members: [] }
-      );
-
-      const spaces = await SpaceResource.listWorkspaceSpaces(adminAuth);
-      expect(spaces.some((s) => s.id === publicSpace.id)).toBe(true);
-    });
-
     it("should include deleted spaces when includeDeleted is true", async () => {
       const regularSpace = await SpaceFactory.regular(workspace);
       await regularSpace.delete(adminAuth, { hardDelete: false });
@@ -1077,14 +1063,6 @@ describe("SpaceResource", () => {
     it("should include all space types when all options are true", async () => {
       const regularSpace = await SpaceFactory.regular(workspace);
       const projectSpace = await SpaceFactory.project(workspace);
-      const publicSpace = await SpaceResource.makeNew(
-        {
-          name: "Public Space",
-          kind: "public",
-          workspaceId: workspace.id,
-        },
-        { members: [] }
-      );
 
       const spaces = await SpaceResource.listWorkspaceSpaces(adminAuth, {
         includeConversationsSpace: true,
@@ -1097,10 +1075,8 @@ describe("SpaceResource", () => {
       expect(spaceKinds).toContain("conversations");
       expect(spaceKinds).toContain("regular");
       expect(spaceKinds).toContain("project");
-      expect(spaceKinds).toContain("public");
       expect(spaces.some((s) => s.id === regularSpace.id)).toBe(true);
       expect(spaces.some((s) => s.id === projectSpace.id)).toBe(true);
-      expect(spaces.some((s) => s.id === publicSpace.id)).toBe(true);
     });
   });
 
@@ -1263,20 +1239,6 @@ describe("SpaceResource", () => {
       }
     });
 
-    it("should return public spaces for all workspace members", async () => {
-      const publicSpace = await SpaceResource.makeNew(
-        {
-          name: "Public Space",
-          kind: "public",
-          workspaceId: workspace.id,
-        },
-        { members: [] }
-      );
-
-      const spaces = await SpaceResource.listWorkspaceSpacesAsMember(userAuth);
-      expect(spaces.some((s) => s.id === publicSpace.id)).toBe(true);
-    });
-
     it("should return admin's spaces correctly", async () => {
       const spaces = await SpaceResource.listWorkspaceSpacesAsMember(adminAuth);
 
@@ -1375,23 +1337,6 @@ describe("SpaceResource", () => {
         expect(conversationsSpace.isMember(adminAuth)).toBe(false);
         expect(conversationsSpace.isMember(userAuth)).toBe(false);
         expect(conversationsSpace.isMember(nonMemberAuth)).toBe(false);
-      });
-    });
-
-    describe("public space", () => {
-      it("should return true for all workspace members", async () => {
-        const publicSpace = await SpaceResource.makeNew(
-          {
-            name: "Public Space",
-            kind: "public",
-            workspaceId: workspace.id,
-          },
-          { members: [] }
-        );
-
-        expect(publicSpace.isMember(adminAuth)).toBe(true);
-        expect(publicSpace.isMember(userAuth)).toBe(true);
-        expect(publicSpace.isMember(nonMemberAuth)).toBe(true);
       });
     });
 

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -251,7 +251,6 @@ export class SpaceResource extends BaseResource<SpaceModel> {
               "system",
               "global",
               "regular",
-              "public",
               ...(options?.includeConversationsSpace ? ["conversations"] : []),
               ...(options?.includeProjectSpaces ? ["project"] : []),
             ],
@@ -305,7 +304,6 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       "global",
       "regular",
       "project",
-      "public",
     ];
 
     let spaces: SpaceResource[] = [];
@@ -961,9 +959,6 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       case "conversations":
       case "system":
         return false;
-      case "public":
-        // I have a doubt on this one.
-        return true;
 
       default:
         assertNever(this.kind);

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -58,7 +58,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   constructor(
     model: ModelStaticSoftDeletable<SpaceModel>,
     blob: Attributes<SpaceModel>,
-    readonly groups: GroupResource[],
+    readonly groups: GroupResource[]
   ) {
     super(SpaceModel, blob);
   }
@@ -67,14 +67,14 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     return new SpaceResource(
       SpaceModel,
       space.get(),
-      space.groups.map((group) => new GroupResource(GroupModel, group.get())),
+      space.groups.map((group) => new GroupResource(GroupModel, group.get()))
     );
   }
 
   static async makeNew(
     blob: CreationAttributes<SpaceModel>,
     groups: { members: GroupResource[]; editors?: GroupResource[] },
-    transaction?: Transaction,
+    transaction?: Transaction
   ) {
     return withTransaction(async (t: Transaction) => {
       const space = await SpaceModel.create(blob, { transaction: t });
@@ -88,13 +88,13 @@ export class SpaceResource extends BaseResource<SpaceModel> {
             workspaceId: space.workspaceId,
             kind: "member",
           },
-          { transaction: t },
+          { transaction: t }
         );
       }
       if (editors.length > 0) {
         assert(
           blob.kind === "project",
-          "Only projects can have editor groups.",
+          "Only projects can have editor groups."
         );
         for (const editorGroup of editors) {
           await GroupSpaceModel.create(
@@ -104,7 +104,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
               workspaceId: space.workspaceId,
               kind: "project_editor",
             },
-            { transaction: t },
+            { transaction: t }
           );
         }
       }
@@ -125,7 +125,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       systemGroup: GroupResource;
       globalGroup: GroupResource;
     },
-    transaction?: Transaction,
+    transaction?: Transaction
   ) {
     assert(auth.isAdmin(), "Only admins can call `makeDefaultsForWorkspace`");
 
@@ -142,7 +142,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
           workspaceId: auth.getNonNullableWorkspace().id,
         },
         { members: [systemGroup] },
-        transaction,
+        transaction
       ));
 
     const globalSpace =
@@ -155,7 +155,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
           workspaceId: auth.getNonNullableWorkspace().id,
         },
         { members: [globalGroup] },
-        transaction,
+        transaction
       ));
 
     const conversationsSpace =
@@ -168,7 +168,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
           workspaceId: auth.getNonNullableWorkspace().id,
         },
         { members: [globalGroup] },
-        transaction,
+        transaction
       ));
 
     return {
@@ -207,7 +207,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       where,
       includeDeleted,
     }: ResourceFindOptions<SpaceModel> = {},
-    t?: Transaction,
+    t?: Transaction
   ) {
     const includeClauses: Includeable[] = [
       {
@@ -239,7 +239,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       includeProjectSpaces?: boolean;
       includeDeleted?: boolean;
     },
-    t?: Transaction,
+    t?: Transaction
   ): Promise<SpaceResource[]> {
     const spaces = await this.baseFetch(
       auth,
@@ -257,7 +257,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
           },
         },
       },
-      t,
+      t
     );
 
     return spaces;
@@ -272,7 +272,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
 
   static async listWorkspaceDefaultSpaces(
     auth: Authenticator,
-    options?: { includeConversationsSpace?: boolean },
+    options?: { includeConversationsSpace?: boolean }
   ) {
     return this.baseFetch(auth, {
       where: {
@@ -290,7 +290,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   static async listForGroups(
     auth: Authenticator,
     groups: (GroupResource | GroupType)[],
-    options?: { includeConversationsSpace?: boolean },
+    options?: { includeConversationsSpace?: boolean }
   ) {
     const groupSpaces = await GroupSpaceModel.findAll({
       where: {
@@ -334,7 +334,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   }
 
   static async fetchWorkspaceSystemSpace(
-    auth: Authenticator,
+    auth: Authenticator
   ): Promise<SpaceResource> {
     const [space] = await this.baseFetch(auth, { where: { kind: "system" } });
 
@@ -346,7 +346,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   }
 
   static async fetchWorkspaceGlobalSpace(
-    auth: Authenticator,
+    auth: Authenticator
   ): Promise<SpaceResource> {
     const [space] = await this.baseFetch(auth, { where: { kind: "global" } });
 
@@ -358,7 +358,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   }
 
   static async fetchWorkspaceConversationsSpace(
-    auth: Authenticator,
+    auth: Authenticator
   ): Promise<SpaceResource> {
     const [space] = await this.baseFetch(auth, {
       where: { kind: "conversations" },
@@ -374,7 +374,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   static async fetchById(
     auth: Authenticator,
     sId: string,
-    { includeDeleted }: { includeDeleted?: boolean } = {},
+    { includeDeleted }: { includeDeleted?: boolean } = {}
   ): Promise<SpaceResource | null> {
     const [space] = await this.fetchByIds(auth, [sId], { includeDeleted });
     return space ?? null;
@@ -383,7 +383,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   static async fetchByIds(
     auth: Authenticator,
     ids: string[],
-    { includeDeleted }: { includeDeleted?: boolean } = {},
+    { includeDeleted }: { includeDeleted?: boolean } = {}
   ): Promise<SpaceResource[]> {
     return this.baseFetch(auth, {
       where: {
@@ -396,7 +396,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   static async fetchByModelIds(
     auth: Authenticator,
     ids: ModelId[],
-    { includeDeleted }: { includeDeleted?: boolean } = {},
+    { includeDeleted }: { includeDeleted?: boolean } = {}
   ) {
     const spaces = await this.baseFetch(auth, {
       where: {
@@ -413,7 +413,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   static async isNameAvailable(
     auth: Authenticator,
     name: string,
-    t?: Transaction,
+    t?: Transaction
   ): Promise<boolean> {
     const owner = auth.getNonNullableWorkspace();
 
@@ -430,7 +430,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
 
   async delete(
     auth: Authenticator,
-    options: { hardDelete: boolean; transaction?: Transaction },
+    options: { hardDelete: boolean; transaction?: Transaction }
   ): Promise<Result<undefined, Error>> {
     const { hardDelete, transaction } = options;
 
@@ -465,7 +465,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       },
       {
         concurrency: 8,
-      },
+      }
     );
 
     await AgentProjectConfigurationModel.destroy({
@@ -490,7 +490,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
 
   async updateName(
     auth: Authenticator,
-    newName: string,
+    newName: string
   ): Promise<Result<undefined, Error>> {
     if (!auth.isAdmin()) {
       return new Err(new Error("Only admins can update space names."));
@@ -508,14 +508,14 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     if (this.isRegular()) {
       await regularGroup.updateName(
         auth,
-        `Group for ${this.isProject() ? "project" : "space"} ${newName}`,
+        `Group for ${this.isProject() ? "project" : "space"} ${newName}`
       );
     }
     const spaceEditorGroup = this.getSpaceManualEditorGroup();
     if (spaceEditorGroup && this.isRegular()) {
       await spaceEditorGroup.updateName(
         auth,
-        `Editors for ${this.isProject() ? "project" : "space"} ${newName}`,
+        `Editors for ${this.isProject() ? "project" : "space"} ${newName}`
       );
     }
 
@@ -536,7 +536,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
           managementMode: "group";
           editorGroupIds: string[];
         }
-    ),
+    )
   ): Promise<
     Result<
       undefined,
@@ -556,8 +556,8 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       return new Err(
         new DustError(
           "unauthorized",
-          "You do not have permission to update space permissions.",
-        ),
+          "You do not have permission to update space permissions."
+        )
       );
     }
 
@@ -565,8 +565,8 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       return new Err(
         new DustError(
           "unauthorized",
-          "Only projects and regular spaces can have members.",
-        ),
+          "Only projects and regular spaces can have members."
+        )
       );
     }
 
@@ -641,7 +641,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
 
         assert(
           memberGroupSpaces.length === 1,
-          "In manual management mode, there should be exactly one member group space.",
+          "In manual management mode, there should be exactly one member group space."
         );
 
         const setMembersRes = await memberGroupSpaces[0].setMembers(auth, {
@@ -668,7 +668,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
                 kind: "space_editors",
                 workspaceId: this.workspaceId,
               },
-              { transaction: t },
+              { transaction: t }
             );
 
             // Link the editor group to the space
@@ -678,20 +678,20 @@ export class SpaceResource extends BaseResource<SpaceModel> {
                 group: editorGroup,
                 space: this,
                 transaction: t,
-              },
+              }
             );
             editorGroupSpaces = [editorGroupSpace];
           }
           assert(
             editorGroupSpaces.length === 1,
-            "In manual management mode, there should be exactly one editor group space.",
+            "In manual management mode, there should be exactly one editor group space."
           );
 
           // Set members of the editor group using the GroupSpaceEditorResource
           const editorUsers = await UserResource.fetchByIds(editorIds);
           assert(
             editorUsers.length > 0,
-            "Projects must have at least one editor.",
+            "Projects must have at least one editor."
           );
           const setEditorsRes = await editorGroupSpaces[0].setMembers(auth, {
             users: editorUsers.map((u) => u.toJSON()),
@@ -708,7 +708,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
 
         // Remove existing external groups
         const existingExternalGroups = this.groups.filter(
-          (g) => g.kind === "provisioned",
+          (g) => g.kind === "provisioned"
         );
         for (const group of existingExternalGroups) {
           await this.removeGroup(auth, group, t);
@@ -717,7 +717,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
         // Add the new groups
         const selectedGroupsResult = await GroupResource.fetchByIds(
           auth,
-          groupIds,
+          groupIds
         );
         if (selectedGroupsResult.isErr()) {
           return selectedGroupsResult;
@@ -734,12 +734,12 @@ export class SpaceResource extends BaseResource<SpaceModel> {
         if (this.isProject()) {
           assert(
             editorGroupIds.length > 0,
-            "Projects must have at least one editor group.",
+            "Projects must have at least one editor group."
           );
           // Add the new editor groups
           const editorGroupsResult = await GroupResource.fetchByIds(
             auth,
-            editorGroupIds,
+            editorGroupIds
           );
           if (editorGroupsResult.isErr()) {
             return editorGroupsResult;
@@ -747,7 +747,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
           const selectedEditorGroups = editorGroupsResult.value;
           assert(
             selectedEditorGroups.length > 0,
-            "Projects must have at least one editor group.",
+            "Projects must have at least one editor group."
           );
           for (const selectedEditorGroup of selectedEditorGroups) {
             await GroupSpaceEditorResource.makeNew(auth, {
@@ -766,7 +766,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   private async removeGroup(
     auth: Authenticator,
     group: GroupResource,
-    transaction?: Transaction,
+    transaction?: Transaction
   ) {
     await GroupSpaceModel.destroy({
       where: {
@@ -784,7 +784,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       userIds,
     }: {
       userIds: string[];
-    },
+    }
   ): Promise<
     Result<
       UserResource[],
@@ -802,18 +802,18 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       return new Err(
         new DustError(
           "unauthorized",
-          "You do not have permission to add members to this space.",
-        ),
+          "You do not have permission to add members to this space."
+        )
       );
     }
 
     assert(
       this.isRegular() || this.isProject(),
-      "Only regular spaces and projects can have manual members.",
+      "Only regular spaces and projects can have manual members."
     );
     assert(
       this.managementMode === "manual",
-      "Can only add members in manual management mode.",
+      "Can only add members in manual management mode."
     );
 
     const users = await UserResource.fetchByIds(userIds);
@@ -829,7 +829,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
 
     assert(
       memberGroupSpaces.length === 1,
-      "In manual management mode, there should be exactly one member group space.",
+      "In manual management mode, there should be exactly one member group space."
     );
 
     const addMemberRes = await memberGroupSpaces[0].addMembers(auth, {
@@ -849,7 +849,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       userIds,
     }: {
       userIds: string[];
-    },
+    }
   ): Promise<
     Result<
       UserResource[],
@@ -866,8 +866,8 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       return new Err(
         new DustError(
           "unauthorized",
-          "You do not have permission to remove members from this space.",
-        ),
+          "You do not have permission to remove members from this space."
+        )
       );
     }
 
@@ -885,7 +885,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
 
     assert(
       memberGroupSpaces.length === 1,
-      "In manual management mode, there should be exactly one member group space.",
+      "In manual management mode, there should be exactly one member group space."
     );
 
     const removeMemberRes = await memberGroupSpaces[0].removeMembers(auth, {
@@ -901,25 +901,25 @@ export class SpaceResource extends BaseResource<SpaceModel> {
 
   private getSpaceManualMemberGroup(): GroupResource {
     const regularGroups = this.groups.filter(
-      (group) => group.kind === "regular",
+      (group) => group.kind === "regular"
     );
     assert(
       regularGroups.length === 1,
-      `Expected exactly one regular group for the space, but found ${regularGroups.length}.`,
+      `Expected exactly one regular group for the space, but found ${regularGroups.length}.`
     );
     return regularGroups[0];
   }
 
   private getSpaceManualEditorGroup(): GroupResource | null {
     const editorGroups = this.groups.filter(
-      (group) => group.kind === "space_editors",
+      (group) => group.kind === "space_editors"
     );
     if (editorGroups.length === 0) {
       return null;
     }
     assert(
       editorGroups.length === 1,
-      `Expected at most one space editors group for the space, but found ${editorGroups.length}.`,
+      `Expected at most one space editors group for the space, but found ${editorGroups.length}.`
     );
     return editorGroups[0];
   }
@@ -1177,7 +1177,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
    */
   private async suspendManualGroupMembers(
     auth: Authenticator,
-    transaction?: Transaction,
+    transaction?: Transaction
   ): Promise<void> {
     const spaceManualMemberGroup = this.getSpaceManualMemberGroup();
 
@@ -1192,7 +1192,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
           [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: new Date() } }],
         },
         transaction,
-      },
+      }
     );
 
     const spaceManualEditorGroup = this.getSpaceManualEditorGroup();
@@ -1208,7 +1208,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
             [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: new Date() } }],
           },
           transaction,
-        },
+        }
       );
     }
   }
@@ -1218,7 +1218,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
    */
   private async restoreManualGroupMembers(
     auth: Authenticator,
-    transaction?: Transaction,
+    transaction?: Transaction
   ): Promise<void> {
     const spaceManualMemberGroup = this.getSpaceManualMemberGroup();
     await GroupMembershipModel.update(
@@ -1232,7 +1232,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
           [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: new Date() } }],
         },
         transaction,
-      },
+      }
     );
 
     const spaceManualEditorGroup = this.getSpaceManualEditorGroup();
@@ -1248,7 +1248,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
             [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: new Date() } }],
           },
           transaction,
-        },
+        }
       );
     }
   }
@@ -1265,7 +1265,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       shouldIncludeAllMembers = false,
     }: {
       shouldIncludeAllMembers?: boolean;
-    } = {},
+    } = {}
   ): Promise<{
     groupsToProcess: GroupResource[];
     allGroupMemberships: GroupMembershipModel[];

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -58,7 +58,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   constructor(
     model: ModelStaticSoftDeletable<SpaceModel>,
     blob: Attributes<SpaceModel>,
-    readonly groups: GroupResource[]
+    readonly groups: GroupResource[],
   ) {
     super(SpaceModel, blob);
   }
@@ -67,14 +67,14 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     return new SpaceResource(
       SpaceModel,
       space.get(),
-      space.groups.map((group) => new GroupResource(GroupModel, group.get()))
+      space.groups.map((group) => new GroupResource(GroupModel, group.get())),
     );
   }
 
   static async makeNew(
     blob: CreationAttributes<SpaceModel>,
     groups: { members: GroupResource[]; editors?: GroupResource[] },
-    transaction?: Transaction
+    transaction?: Transaction,
   ) {
     return withTransaction(async (t: Transaction) => {
       const space = await SpaceModel.create(blob, { transaction: t });
@@ -88,13 +88,13 @@ export class SpaceResource extends BaseResource<SpaceModel> {
             workspaceId: space.workspaceId,
             kind: "member",
           },
-          { transaction: t }
+          { transaction: t },
         );
       }
       if (editors.length > 0) {
         assert(
           blob.kind === "project",
-          "Only projects can have editor groups."
+          "Only projects can have editor groups.",
         );
         for (const editorGroup of editors) {
           await GroupSpaceModel.create(
@@ -104,7 +104,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
               workspaceId: space.workspaceId,
               kind: "project_editor",
             },
-            { transaction: t }
+            { transaction: t },
           );
         }
       }
@@ -125,7 +125,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       systemGroup: GroupResource;
       globalGroup: GroupResource;
     },
-    transaction?: Transaction
+    transaction?: Transaction,
   ) {
     assert(auth.isAdmin(), "Only admins can call `makeDefaultsForWorkspace`");
 
@@ -142,7 +142,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
           workspaceId: auth.getNonNullableWorkspace().id,
         },
         { members: [systemGroup] },
-        transaction
+        transaction,
       ));
 
     const globalSpace =
@@ -155,7 +155,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
           workspaceId: auth.getNonNullableWorkspace().id,
         },
         { members: [globalGroup] },
-        transaction
+        transaction,
       ));
 
     const conversationsSpace =
@@ -168,7 +168,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
           workspaceId: auth.getNonNullableWorkspace().id,
         },
         { members: [globalGroup] },
-        transaction
+        transaction,
       ));
 
     return {
@@ -207,7 +207,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       where,
       includeDeleted,
     }: ResourceFindOptions<SpaceModel> = {},
-    t?: Transaction
+    t?: Transaction,
   ) {
     const includeClauses: Includeable[] = [
       {
@@ -239,7 +239,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       includeProjectSpaces?: boolean;
       includeDeleted?: boolean;
     },
-    t?: Transaction
+    t?: Transaction,
   ): Promise<SpaceResource[]> {
     const spaces = await this.baseFetch(
       auth,
@@ -258,7 +258,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
           },
         },
       },
-      t
+      t,
     );
 
     return spaces;
@@ -273,7 +273,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
 
   static async listWorkspaceDefaultSpaces(
     auth: Authenticator,
-    options?: { includeConversationsSpace?: boolean }
+    options?: { includeConversationsSpace?: boolean },
   ) {
     return this.baseFetch(auth, {
       where: {
@@ -291,7 +291,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   static async listForGroups(
     auth: Authenticator,
     groups: (GroupResource | GroupType)[],
-    options?: { includeConversationsSpace?: boolean }
+    options?: { includeConversationsSpace?: boolean },
   ) {
     const groupSpaces = await GroupSpaceModel.findAll({
       where: {
@@ -336,7 +336,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   }
 
   static async fetchWorkspaceSystemSpace(
-    auth: Authenticator
+    auth: Authenticator,
   ): Promise<SpaceResource> {
     const [space] = await this.baseFetch(auth, { where: { kind: "system" } });
 
@@ -348,7 +348,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   }
 
   static async fetchWorkspaceGlobalSpace(
-    auth: Authenticator
+    auth: Authenticator,
   ): Promise<SpaceResource> {
     const [space] = await this.baseFetch(auth, { where: { kind: "global" } });
 
@@ -360,7 +360,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   }
 
   static async fetchWorkspaceConversationsSpace(
-    auth: Authenticator
+    auth: Authenticator,
   ): Promise<SpaceResource> {
     const [space] = await this.baseFetch(auth, {
       where: { kind: "conversations" },
@@ -376,7 +376,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   static async fetchById(
     auth: Authenticator,
     sId: string,
-    { includeDeleted }: { includeDeleted?: boolean } = {}
+    { includeDeleted }: { includeDeleted?: boolean } = {},
   ): Promise<SpaceResource | null> {
     const [space] = await this.fetchByIds(auth, [sId], { includeDeleted });
     return space ?? null;
@@ -385,7 +385,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   static async fetchByIds(
     auth: Authenticator,
     ids: string[],
-    { includeDeleted }: { includeDeleted?: boolean } = {}
+    { includeDeleted }: { includeDeleted?: boolean } = {},
   ): Promise<SpaceResource[]> {
     return this.baseFetch(auth, {
       where: {
@@ -398,7 +398,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   static async fetchByModelIds(
     auth: Authenticator,
     ids: ModelId[],
-    { includeDeleted }: { includeDeleted?: boolean } = {}
+    { includeDeleted }: { includeDeleted?: boolean } = {},
   ) {
     const spaces = await this.baseFetch(auth, {
       where: {
@@ -415,7 +415,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   static async isNameAvailable(
     auth: Authenticator,
     name: string,
-    t?: Transaction
+    t?: Transaction,
   ): Promise<boolean> {
     const owner = auth.getNonNullableWorkspace();
 
@@ -432,7 +432,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
 
   async delete(
     auth: Authenticator,
-    options: { hardDelete: boolean; transaction?: Transaction }
+    options: { hardDelete: boolean; transaction?: Transaction },
   ): Promise<Result<undefined, Error>> {
     const { hardDelete, transaction } = options;
 
@@ -467,7 +467,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       },
       {
         concurrency: 8,
-      }
+      },
     );
 
     await AgentProjectConfigurationModel.destroy({
@@ -492,7 +492,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
 
   async updateName(
     auth: Authenticator,
-    newName: string
+    newName: string,
   ): Promise<Result<undefined, Error>> {
     if (!auth.isAdmin()) {
       return new Err(new Error("Only admins can update space names."));
@@ -507,17 +507,17 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     // For regular spaces that only have a single group, update
     // the group's name too (see https://github.com/dust-tt/tasks/issues/1738)
     const regularGroup = this.getSpaceManualMemberGroup();
-    if (this.isRegular() || this.isPublic()) {
+    if (this.isRegular()) {
       await regularGroup.updateName(
         auth,
-        `Group for ${this.isProject() ? "project" : "space"} ${newName}`
+        `Group for ${this.isProject() ? "project" : "space"} ${newName}`,
       );
     }
     const spaceEditorGroup = this.getSpaceManualEditorGroup();
-    if (spaceEditorGroup && (this.isRegular() || this.isPublic())) {
+    if (spaceEditorGroup && this.isRegular()) {
       await spaceEditorGroup.updateName(
         auth,
-        `Editors for ${this.isProject() ? "project" : "space"} ${newName}`
+        `Editors for ${this.isProject() ? "project" : "space"} ${newName}`,
       );
     }
 
@@ -538,7 +538,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
           managementMode: "group";
           editorGroupIds: string[];
         }
-    )
+    ),
   ): Promise<
     Result<
       undefined,
@@ -558,8 +558,8 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       return new Err(
         new DustError(
           "unauthorized",
-          "You do not have permission to update space permissions."
-        )
+          "You do not have permission to update space permissions.",
+        ),
       );
     }
 
@@ -567,8 +567,8 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       return new Err(
         new DustError(
           "unauthorized",
-          "Only projects and regular spaces can have members."
-        )
+          "Only projects and regular spaces can have members.",
+        ),
       );
     }
 
@@ -643,7 +643,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
 
         assert(
           memberGroupSpaces.length === 1,
-          "In manual management mode, there should be exactly one member group space."
+          "In manual management mode, there should be exactly one member group space.",
         );
 
         const setMembersRes = await memberGroupSpaces[0].setMembers(auth, {
@@ -670,7 +670,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
                 kind: "space_editors",
                 workspaceId: this.workspaceId,
               },
-              { transaction: t }
+              { transaction: t },
             );
 
             // Link the editor group to the space
@@ -680,20 +680,20 @@ export class SpaceResource extends BaseResource<SpaceModel> {
                 group: editorGroup,
                 space: this,
                 transaction: t,
-              }
+              },
             );
             editorGroupSpaces = [editorGroupSpace];
           }
           assert(
             editorGroupSpaces.length === 1,
-            "In manual management mode, there should be exactly one editor group space."
+            "In manual management mode, there should be exactly one editor group space.",
           );
 
           // Set members of the editor group using the GroupSpaceEditorResource
           const editorUsers = await UserResource.fetchByIds(editorIds);
           assert(
             editorUsers.length > 0,
-            "Projects must have at least one editor."
+            "Projects must have at least one editor.",
           );
           const setEditorsRes = await editorGroupSpaces[0].setMembers(auth, {
             users: editorUsers.map((u) => u.toJSON()),
@@ -710,7 +710,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
 
         // Remove existing external groups
         const existingExternalGroups = this.groups.filter(
-          (g) => g.kind === "provisioned"
+          (g) => g.kind === "provisioned",
         );
         for (const group of existingExternalGroups) {
           await this.removeGroup(auth, group, t);
@@ -719,7 +719,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
         // Add the new groups
         const selectedGroupsResult = await GroupResource.fetchByIds(
           auth,
-          groupIds
+          groupIds,
         );
         if (selectedGroupsResult.isErr()) {
           return selectedGroupsResult;
@@ -736,12 +736,12 @@ export class SpaceResource extends BaseResource<SpaceModel> {
         if (this.isProject()) {
           assert(
             editorGroupIds.length > 0,
-            "Projects must have at least one editor group."
+            "Projects must have at least one editor group.",
           );
           // Add the new editor groups
           const editorGroupsResult = await GroupResource.fetchByIds(
             auth,
-            editorGroupIds
+            editorGroupIds,
           );
           if (editorGroupsResult.isErr()) {
             return editorGroupsResult;
@@ -749,7 +749,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
           const selectedEditorGroups = editorGroupsResult.value;
           assert(
             selectedEditorGroups.length > 0,
-            "Projects must have at least one editor group."
+            "Projects must have at least one editor group.",
           );
           for (const selectedEditorGroup of selectedEditorGroups) {
             await GroupSpaceEditorResource.makeNew(auth, {
@@ -768,7 +768,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
   private async removeGroup(
     auth: Authenticator,
     group: GroupResource,
-    transaction?: Transaction
+    transaction?: Transaction,
   ) {
     await GroupSpaceModel.destroy({
       where: {
@@ -786,7 +786,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       userIds,
     }: {
       userIds: string[];
-    }
+    },
   ): Promise<
     Result<
       UserResource[],
@@ -804,18 +804,18 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       return new Err(
         new DustError(
           "unauthorized",
-          "You do not have permission to add members to this space."
-        )
+          "You do not have permission to add members to this space.",
+        ),
       );
     }
 
     assert(
       this.isRegular() || this.isProject(),
-      "Only regular spaces and projects can have manual members."
+      "Only regular spaces and projects can have manual members.",
     );
     assert(
       this.managementMode === "manual",
-      "Can only add members in manual management mode."
+      "Can only add members in manual management mode.",
     );
 
     const users = await UserResource.fetchByIds(userIds);
@@ -831,7 +831,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
 
     assert(
       memberGroupSpaces.length === 1,
-      "In manual management mode, there should be exactly one member group space."
+      "In manual management mode, there should be exactly one member group space.",
     );
 
     const addMemberRes = await memberGroupSpaces[0].addMembers(auth, {
@@ -851,7 +851,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       userIds,
     }: {
       userIds: string[];
-    }
+    },
   ): Promise<
     Result<
       UserResource[],
@@ -868,8 +868,8 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       return new Err(
         new DustError(
           "unauthorized",
-          "You do not have permission to remove members from this space."
-        )
+          "You do not have permission to remove members from this space.",
+        ),
       );
     }
 
@@ -887,7 +887,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
 
     assert(
       memberGroupSpaces.length === 1,
-      "In manual management mode, there should be exactly one member group space."
+      "In manual management mode, there should be exactly one member group space.",
     );
 
     const removeMemberRes = await memberGroupSpaces[0].removeMembers(auth, {
@@ -903,25 +903,25 @@ export class SpaceResource extends BaseResource<SpaceModel> {
 
   private getSpaceManualMemberGroup(): GroupResource {
     const regularGroups = this.groups.filter(
-      (group) => group.kind === "regular"
+      (group) => group.kind === "regular",
     );
     assert(
       regularGroups.length === 1,
-      `Expected exactly one regular group for the space, but found ${regularGroups.length}.`
+      `Expected exactly one regular group for the space, but found ${regularGroups.length}.`,
     );
     return regularGroups[0];
   }
 
   private getSpaceManualEditorGroup(): GroupResource | null {
     const editorGroups = this.groups.filter(
-      (group) => group.kind === "space_editors"
+      (group) => group.kind === "space_editors",
     );
     if (editorGroups.length === 0) {
       return null;
     }
     assert(
       editorGroups.length === 1,
-      `Expected at most one space editors group for the space, but found ${editorGroups.length}.`
+      `Expected at most one space editors group for the space, but found ${editorGroups.length}.`,
     );
     return editorGroups[0];
   }
@@ -984,19 +984,15 @@ export class SpaceResource extends BaseResource<SpaceModel> {
    * 1. System spaces:
    * - Restricted to workspace admins only
    *
-   * 2. Public spaces:
-   * - Read: Anyone
-   * - Write: Workspace admins and builders
-   *
-   * 3. Global spaces:
+   * 2. Global spaces:
    * - Read: All workspace members
    * - Write: Workspace admins and builders
    *
-   * 4. Open spaces:
+   * 3. Open spaces:
    * - Read: All workspace members
    * - Write: Admins and builders
    *
-   * 5. Restricted spaces:
+   * 4. Restricted spaces:
    * - Read/Write: Group members
    * - Admin: Workspace admins
    *
@@ -1009,26 +1005,6 @@ export class SpaceResource extends BaseResource<SpaceModel> {
         {
           workspaceId: this.workspaceId,
           roles: [{ role: "admin", permissions: ["admin", "write"] }],
-          groups: this.groups.map((group) => ({
-            id: group.id,
-            permissions: ["read", "write"],
-          })),
-        },
-      ];
-    }
-
-    // Public space.
-    if (this.isPublic()) {
-      return [
-        {
-          workspaceId: this.workspaceId,
-          roles: [
-            { role: "admin", permissions: ["admin", "read", "write"] },
-            { role: "builder", permissions: ["read", "write"] },
-            { role: "user", permissions: ["read"] },
-            // Everyone can read.
-            { role: "none", permissions: ["read"] },
-          ],
           groups: this.groups.map((group) => ({
             id: group.id,
             permissions: ["read", "write"],
@@ -1188,10 +1164,6 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     return this.groups.some((group) => group.isGlobal());
   }
 
-  isPublic() {
-    return this.kind === "public";
-  }
-
   isDeletable() {
     return (
       // Soft-deleted spaces can be deleted.
@@ -1210,7 +1182,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
    */
   private async suspendManualGroupMembers(
     auth: Authenticator,
-    transaction?: Transaction
+    transaction?: Transaction,
   ): Promise<void> {
     const spaceManualMemberGroup = this.getSpaceManualMemberGroup();
 
@@ -1225,7 +1197,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
           [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: new Date() } }],
         },
         transaction,
-      }
+      },
     );
 
     const spaceManualEditorGroup = this.getSpaceManualEditorGroup();
@@ -1241,7 +1213,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
             [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: new Date() } }],
           },
           transaction,
-        }
+        },
       );
     }
   }
@@ -1251,7 +1223,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
    */
   private async restoreManualGroupMembers(
     auth: Authenticator,
-    transaction?: Transaction
+    transaction?: Transaction,
   ): Promise<void> {
     const spaceManualMemberGroup = this.getSpaceManualMemberGroup();
     await GroupMembershipModel.update(
@@ -1265,7 +1237,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
           [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: new Date() } }],
         },
         transaction,
-      }
+      },
     );
 
     const spaceManualEditorGroup = this.getSpaceManualEditorGroup();
@@ -1281,7 +1253,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
             [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: new Date() } }],
           },
           transaction,
-        }
+        },
       );
     }
   }
@@ -1298,7 +1270,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       shouldIncludeAllMembers = false,
     }: {
       shouldIncludeAllMembers?: boolean;
-    } = {}
+    } = {},
   ): Promise<{
     groupsToProcess: GroupResource[];
     allGroupMemberships: GroupMembershipModel[];

--- a/front/lib/spaces.ts
+++ b/front/lib/spaces.ts
@@ -24,11 +24,7 @@ import type {
 import { GLOBAL_SPACE_NAME } from "@app/types";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 
-const SPACE_SECTION_GROUP_ORDER = [
-  "system",
-  "shared",
-  "restricted",
-] as const;
+const SPACE_SECTION_GROUP_ORDER = ["system", "shared", "restricted"] as const;
 
 export type SpaceSectionGroupType = (typeof SPACE_SECTION_GROUP_ORDER)[number];
 

--- a/front/lib/spaces.ts
+++ b/front/lib/spaces.ts
@@ -6,7 +6,6 @@ import {
   FolderIcon,
   GlobeAltIcon,
   LockIcon,
-  PlanetIcon,
   ServerIcon,
   SpaceClosedIcon,
   SpaceOpenIcon,
@@ -29,7 +28,6 @@ const SPACE_SECTION_GROUP_ORDER = [
   "system",
   "shared",
   "restricted",
-  "public",
 ] as const;
 
 export type SpaceSectionGroupType = (typeof SPACE_SECTION_GROUP_ORDER)[number];
@@ -39,10 +37,6 @@ export function getSpaceIcon(
 ): (props: React.SVGProps<SVGSVGElement>) => React.ReactElement {
   if (space.kind === "project") {
     return space.isRestricted ? SpaceClosedIcon : SpaceOpenIcon;
-  }
-
-  if (space.kind === "public") {
-    return PlanetIcon;
   }
 
   if (space.isRestricted) {
@@ -82,7 +76,6 @@ export const groupSpacesForDisplay = (spaces: SpaceType[]) => {
       }
 
       switch (space.kind) {
-        case "public":
         case "system":
           return space.kind;
 
@@ -108,7 +101,7 @@ export const isPrivateSpacesLimitReached = (
   plan: PlanType
 ) =>
   plan.limits.vaults.maxVaults !== -1 &&
-  spaces.filter((s) => s.kind === "regular" || s.kind === "public").length >=
+  spaces.filter((s) => s.kind === "regular").length >=
     plan.limits.vaults.maxVaults;
 
 export const CATEGORY_DETAILS: {

--- a/front/migrations/20241205_update_space_group_names.ts
+++ b/front/migrations/20241205_update_space_group_names.ts
@@ -13,9 +13,7 @@ makeScript({}, async ({ execute }) => {
   await runOnAllWorkspaces(async (w) => {
     const auth = await Authenticator.internalAdminForWorkspace(w.sId);
     const allSpaces = await SpaceResource.listWorkspaceSpaces(auth);
-    const regularSpaces = allSpaces.filter(
-      (s) => s.kind === "regular" || s.kind === "public"
-    );
+    const regularSpaces = allSpaces.filter((s) => s.kind === "regular");
     logger.info(
       `Found ${regularSpaces.length} regular spaces for workspace ${w.name}`
     );

--- a/front/migrations/db/migration_508.sql
+++ b/front/migrations/db/migration_508.sql
@@ -1,0 +1,5 @@
+-- Migration created on Feb. 05, 2026
+-- Migrate public spaces to regular spaces.
+-- Public spaces are being deprecated in favor of using regular spaces with appropriate
+-- group permissions. This migration converts all existing public spaces to regular spaces.
+UPDATE "public"."vaults" SET "kind" = 'regular' WHERE "kind" = 'public';

--- a/front/types/space.ts
+++ b/front/types/space.ts
@@ -6,7 +6,6 @@ export const UNIQUE_SPACE_KINDS = [
 
 export const SPACE_KINDS = [
   ...UNIQUE_SPACE_KINDS,
-  "public", // Anyone can access it.
   "regular", // Can be open or restricted based on the groups assigned to the space (if the global group is assigned, it's open, otherwise it's restricted).
   "project", // Can be open or restricted based on the groups assigned to the space (if the global group is assigned, it's open, otherwise it's restricted).
 ] as const;


### PR DESCRIPTION
## Description

Remove support for public spaces now that they are unused.

## Tests

Covered by type-checking, tests.
Local testing

## Risk

High touches to auth. Asking for 2 reviews from @fontanierh and @flvndvd as a consequence

## Deploy Plan

- run migration
- monitor prod (as migration is equivalent to code but easily revertable)
```
# in case needed
US: SELECT id FROM vaults WHERE kind='public'; => 93077
EU: SELECT * FROM vaults WHERE kind='public'; => 274877906953
```
- deploy `front`