### PR TITLE
copilot: add info button to get the conversation id

### DIFF
--- a/front/components/agent_builder/CopilotPanelContext.tsx
+++ b/front/components/agent_builder/CopilotPanelContext.tsx
@@ -127,6 +127,18 @@ interface CopilotPanelProviderProps {
   isNewAgent: boolean;
 }
 
+const updateCopilotConversationIdQueryParam = (
+  conversationId: string | null
+) => {
+  const url = new URL(window.location.href);
+  if (conversationId) {
+    url.searchParams.set("copilotConversationId", conversationId);
+  } else {
+    url.searchParams.delete("copilotConversationId");
+  }
+  window.history.replaceState({}, "", url.toString());
+};
+
 export const CopilotPanelProvider = ({
   children,
   targetAgentConfigurationId,
@@ -182,6 +194,7 @@ export const CopilotPanelProvider = ({
 
     if (result.isOk()) {
       setConversation(result.value);
+      updateCopilotConversationIdQueryParam(result.value.sId);
     } else {
       setCreationFailed(true);
       sendNotification({
@@ -205,6 +218,7 @@ export const CopilotPanelProvider = ({
     hasStartedRef.current = false;
     setConversation(null);
     setCreationFailed(false);
+    updateCopilotConversationIdQueryParam(null);
   }, []);
 
   const value: CopilotPanelContextType = useMemo(


### PR DESCRIPTION
## Description

closes https://github.com/dust-tt/tasks/issues/6362

Add the conversation SID in the UTL as query param so we can retrieve it to debug

```
http://localhost:3000/w/DevWkSpace/builder/agents/new?copilotConversationId=CLS06AEwPs
```

It also changes if we restart the conversation

## Tests

manual tests

## Risk
low

## Deploy Plan

deploy front
