### PR TITLE
Add frames pages to app

### DIFF
--- a/front-spa/package.json
+++ b/front-spa/package.json
@@ -6,7 +6,7 @@
     "dev:poke": "VITE_APP_NAME=poke VITE_DUST_CLIENT_FACING_URL=$DUST_CLIENT_FACING_URL vite",
     "dev:app": "VITE_APP_NAME=app VITE_DUST_CLIENT_FACING_URL=$DUST_CLIENT_FACING_URL vite",
     "build:poke": "VITE_APP_NAME=poke vite build && cp public-poke/_redirects dist/poke/_redirects",
-    "build:app": "VITE_APP_NAME=app vite build",
+    "build:app": "VITE_APP_NAME=app vite build && cp public-app/_redirects dist/app/_redirects",
     "build": "npm run build:poke && npm run build:app",
     "preview:poke": "VITE_APP_NAME=poke vite preview",
     "preview:app": "VITE_APP_NAME=app vite preview",

--- a/front-spa/public-app/_redirects
+++ b/front-spa/public-app/_redirects
@@ -1,0 +1,5 @@
+# /share routes - must be before the catch-all
+/share/*  /share/index.html  200
+
+# SPA fallback for main app
+/*  /index.html  200

--- a/front-spa/share.html
+++ b/front-spa/share.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="robots"
+      content="noindex, nofollow, noarchive, nosnippet, noimageindex"
+    />
+    <meta
+      name="googlebot"
+      content="noindex, nofollow, noarchive, nosnippet, noimageindex"
+    />
+    <meta
+      name="bingbot"
+      content="noindex, nofollow, noarchive, nosnippet, noimageindex"
+    />
+    <title>Dust - Shared Content</title>
+    <script>
+      // Shim for Node.js Buffer API used by some dependencies
+      globalThis.Buffer = globalThis.Buffer || {
+        isBuffer: function () {
+          return false;
+        },
+        from: function (x) {
+          return new Uint8Array(
+            typeof x === "string"
+              ? Array.from(x).map(function (c) {
+                  return c.charCodeAt(0);
+                })
+              : x
+          );
+        },
+        alloc: function (n) {
+          return new Uint8Array(n);
+        },
+      };
+    </script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/share/main.tsx"></script>
+  </body>
+</html>

--- a/front-spa/src/lib/platform.tsx
+++ b/front-spa/src/lib/platform.tsx
@@ -254,7 +254,7 @@ export function Head({ children }: HeadProps) {
 
       if (child.type === "title") {
         const previousTitle = document.title;
-        document.title = String(props.children ?? "");
+        document.title = Children.toArray(props.children).join("") ?? "";
         cleanupFns.push(() => {
           document.title = previousTitle;
         });

--- a/front-spa/src/share/ShareApp.tsx
+++ b/front-spa/src/share/ShareApp.tsx
@@ -1,0 +1,36 @@
+import { Notification, SparkleContext } from "@dust-tt/sparkle";
+import { createBrowserRouter, RouterProvider } from "react-router-dom";
+import { SWRConfig } from "swr";
+
+import { SharedFilePage } from "@dust-tt/front/components/pages/share/SharedFilePage";
+import { SharedFramePage } from "@dust-tt/front/components/pages/share/SharedFramePage";
+import { RegionProvider } from "@dust-tt/front/lib/auth/RegionContext";
+import { LinkWrapper } from "@dust-tt/front/lib/platform";
+
+const router = createBrowserRouter(
+  [
+    // Frame: /share/frame/:token
+    {
+      path: "/share/frame/:token",
+      element: <SharedFramePage />,
+    },
+    // File: /share/file/:token (redirects to frame)
+    {
+      path: "/share/file/:token",
+      element: <SharedFilePage />,
+    },
+  ],
+  {
+    basename: import.meta.env.VITE_BASE_PATH ?? "",
+  }
+);
+
+export default function ShareApp() {
+  return (
+    <RegionProvider>
+      <SWRConfig>
+        <RouterProvider router={router} />
+      </SWRConfig>
+    </RegionProvider>
+  );
+}

--- a/front-spa/src/share/main.tsx
+++ b/front-spa/src/share/main.tsx
@@ -1,0 +1,16 @@
+// Tailwind base globals
+import "@dust-tt/front/styles/global.css";
+// Use sparkle styles, override local globals
+import "@dust-tt/sparkle/dist/sparkle.css";
+// Local index.css for any app-specific overrides
+import "@spa/index.css";
+
+import ShareApp from "@spa/share/ShareApp";
+import React from "react";
+import ReactDOM from "react-dom/client";
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <ShareApp />
+  </React.StrictMode>
+);

--- a/front-spa/vite.config.ts
+++ b/front-spa/vite.config.ts
@@ -3,6 +3,33 @@ import path from "path";
 import type { Plugin } from "vite";
 import { defineConfig, loadEnv } from "vite";
 
+const apps = {
+  app: {
+    assets: [["share.html", "share/index.html"]],
+    inputs: {
+      main: path.resolve(__dirname, "index.html"),
+      share: path.resolve(__dirname, "share.html"),
+    },
+    serveMapping: (url: string | undefined) => {
+      if (url?.startsWith("/share/")) {
+        return "/share.html";
+      }
+      return "/index.html";
+    },
+    port: 3011,
+  },
+  poke: {
+    assets: [["poke.html", "index.html"]],
+    inputs: {
+      main: path.resolve(__dirname, "poke.html"),
+    },
+    serveMapping: () => {
+      return "/poke.html";
+    },
+    port: 3010,
+  },
+};
+
 // Virtual module plugin to stub out server-side only modules
 function stubModulesPlugin(): Plugin {
   const stubs: Record<string, string> = {
@@ -80,25 +107,33 @@ function reactScanPlugin(enabled: boolean): Plugin {
   };
 }
 
-// Plugin to rename output HTML to index.html for SPA deployment
-function renameHtmlPlugin(sourceHtml: string): Plugin {
+// Plugin to organize multi-entry HTML output into subdirectories
+function organizeMultiEntryOutputPlugin(
+  appDefinition: typeof apps.poke | typeof apps.app
+): Plugin {
+  const { assets } = appDefinition;
+
   return {
-    name: "rename-html",
+    name: "organize-multi-entry-output",
     enforce: "post",
     generateBundle(_, bundle) {
-      if (sourceHtml === "index.html") return;
-      const htmlAsset = bundle[sourceHtml];
-      if (htmlAsset) {
-        htmlAsset.fileName = "index.html";
-        delete bundle[sourceHtml];
-        bundle["index.html"] = htmlAsset;
-      }
+      // Move poke.html to index.html
+      assets.forEach(([source, target]) => {
+        const asset = bundle[source];
+        if (asset) {
+          asset.fileName = target;
+          delete bundle[source];
+          bundle[target] = asset;
+        }
+      });
     },
   };
 }
 
 // Plugin to serve the correct HTML file in dev mode (SPA fallback)
-function serveHtmlPlugin(htmlFile: string): Plugin {
+function serveHtmlPlugin(
+  appDefinition: typeof apps.poke | typeof apps.app
+): Plugin {
   return {
     name: "serve-html",
     configureServer(server) {
@@ -112,8 +147,9 @@ function serveHtmlPlugin(htmlFile: string): Plugin {
         ) {
           return next();
         }
-        // Rewrite all other requests to the HTML file (SPA fallback)
-        req.url = `/${htmlFile}`;
+
+        req.url = appDefinition.serveMapping(req.url);
+
         next();
       });
     },
@@ -130,7 +166,7 @@ export default defineConfig(({ mode }) => {
 
   // Determine which app to build: "poke" or "app" (default: "app")
   const appName = env.VITE_APP_NAME ?? "app";
-  const isPokeApp = appName === "poke";
+  const appDefinition = apps[appName];
 
   // Map NEXT_PUBLIC_* env vars to process.env.NEXT_PUBLIC_* for compatibility
   const envVarDefines: Record<string, string> = {};
@@ -147,9 +183,6 @@ export default defineConfig(({ mode }) => {
   // Base path for the app (set via VITE_BASE_PATH env var from build script)
   const basePath = env.VITE_BASE_PATH ?? "/";
 
-  // HTML entry file based on app
-  const htmlEntry = isPokeApp ? "poke.html" : "index.html";
-
   const enableReactScan =
     mode === "development" && env.VITE_REACT_SCAN === "true";
 
@@ -159,8 +192,8 @@ export default defineConfig(({ mode }) => {
     publicDir: path.resolve(__dirname, "../front/public"),
     plugins: [
       stubModulesPlugin(),
-      serveHtmlPlugin(htmlEntry),
-      renameHtmlPlugin(htmlEntry),
+      serveHtmlPlugin(appDefinition),
+      organizeMultiEntryOutputPlugin(appDefinition),
       reactScanPlugin(enableReactScan),
       react(),
     ],
@@ -170,12 +203,8 @@ export default defineConfig(({ mode }) => {
       "process.env": {},
     },
     server: {
-      port: isPokeApp ? 3010 : 3011,
+      port: appDefinition.port,
       // No proxy - client calls API directly using VITE_DUST_CLIENT_FACING_URL
-      warmup: {
-        // Pre-transform files on server startup to speed up first page load
-        clientFiles: ["./src/**/*.tsx", "./src/**/*.ts"],
-      },
       fs: {
         // Allow serving files from the front directory (for shared code)
         allow: [
@@ -228,7 +257,7 @@ export default defineConfig(({ mode }) => {
       outDir: path.resolve(__dirname, `dist/${appName}`),
       sourcemap: true,
       rollupOptions: {
-        input: path.resolve(__dirname, htmlEntry),
+        input: appDefinition.inputs,
       },
     },
   };

--- a/viz/next.config.mjs
+++ b/viz/next.config.mjs
@@ -2,7 +2,7 @@
 const isDev = process.env.NODE_ENV === "development";
 
 const CONTENT_SECURITY_POLICIES = `connect-src 'self'; media-src 'self'; frame-ancestors 'self' ${
-  isDev ? "http://localhost:3000" : "https://dust.tt https://eu.dust.tt https://front-edge.dust.tt https://eu.front-edge.dust.tt"
+  isDev ? "http://localhost:3000 http://localhost:3011" : "https://dust.tt https://app.dust.tt https://eu.dust.tt https://front-edge.dust.tt https://eu.front-edge.dust.tt"
 };`;
 
 const nextConfig = {


### PR DESCRIPTION
## Description

Same as https://github.com/dust-tt/dust/pull/21105 - this is building an independant bundle, served for /share urls, instead of loading the whole app. This include the frame/viz pages. 
Also updated the csp rule


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
