### PR TITLE
fix(conversation): redirect to project after deleting project conversation

### DIFF
--- a/front/components/assistant/conversation/ConversationMenu.tsx
+++ b/front/components/assistant/conversation/ConversationMenu.tsx
@@ -32,8 +32,13 @@ import {
   useJoinConversation,
 } from "@app/lib/swr/conversations";
 import { useUser } from "@app/lib/swr/user";
-import { getConversationRoute, setQueryParam } from "@app/lib/utils/router";
+import {
+  getConversationRoute,
+  getProjectRoute,
+  setQueryParam,
+} from "@app/lib/utils/router";
 import type { ConversationWithoutContentType, WorkspaceType } from "@app/types";
+import { isProjectConversation } from "@app/types";
 
 /**
  * Hook for handling right-click context menu with timing protection
@@ -177,10 +182,13 @@ export function ConversationMenu({
   const leaveOrDelete = useCallback(
     async (forceDelete: boolean = false) => {
       const res = await doDelete(conversation, forceDelete);
-      // eslint-disable-next-line no-unused-expressions
-      isConversationDisplayed &&
-        res &&
-        void router.push(getConversationRoute(owner.sId));
+      if (isConversationDisplayed && res) {
+        const redirectRoute =
+          conversation && isProjectConversation(conversation)
+            ? getProjectRoute(owner.sId, conversation.spaceId)
+            : getConversationRoute(owner.sId);
+        void router.push(redirectRoute);
+      }
     },
     [conversation, doDelete, owner.sId, router, isConversationDisplayed]
   );


### PR DESCRIPTION
## Description

[task](https://github.com/dust-tt/tasks/issues/6345)  

Fix the redirect behavior after deleting a conversation that belongs to a project.

- Redirect to project page when deleting a project conversation
- Keep existing behavior (redirect to conversation list) for non-project conversations

## Tests
- [x] Delete a conversation from within a project → should redirect to project page
- [x] Delete a regular conversation → should redirect to conversation list

## Risk
low

## Deploy plan
front