### PR TITLE
refactor(projects): remove urls field from project metadata model

### DIFF
--- a/connectors/src/connectors/dust_project/lib/format_metadata.test.ts
+++ b/connectors/src/connectors/dust_project/lib/format_metadata.test.ts
@@ -15,10 +15,6 @@ describe("formatProjectMetadata", () => {
       updatedAt: 0,
       spaceId: "space-123",
       description: "This is a test project",
-      urls: [
-        { name: "What", url: "https://example.com" },
-        { name: "Is this", url: "https://docs.example.com" },
-      ],
       members: ["alice@example.com", "bob@example.com"],
     };
 
@@ -27,11 +23,6 @@ describe("formatProjectMetadata", () => {
     expect(result).toEqual(`# Description
 
 This is a test project
-
-# URLs
-
-- [What](https://example.com)
-- [Is this](https://docs.example.com)
 
 # Members
 
@@ -47,7 +38,6 @@ This is a test project
       updatedAt: 0,
       spaceId: "space-123",
       description: "Only a description here",
-      urls: [],
       members: [],
     };
 
@@ -59,25 +49,6 @@ Only a description here
 `);
   });
 
-  it("should handle metadata with only URLs", () => {
-    const metadata: ProjectMetadataType = {
-      createdAt: 0,
-      sId: "",
-      updatedAt: 0,
-      spaceId: "space-123",
-      description: null,
-      urls: [{ name: "what", url: "https://example.com" }],
-      members: [],
-    };
-
-    const result = formatProjectMetadata(metadata);
-
-    expect(result).toEqual(`# URLs
-
-- [what](https://example.com)
-`);
-  });
-
   it("should handle metadata with only members", () => {
     const metadata: ProjectMetadataType = {
       createdAt: 0,
@@ -85,7 +56,6 @@ Only a description here
       updatedAt: 0,
       spaceId: "space-123",
       description: null,
-      urls: [],
       members: ["alice@example.com"],
     };
 

--- a/connectors/src/connectors/dust_project/lib/format_metadata.ts
+++ b/connectors/src/connectors/dust_project/lib/format_metadata.ts
@@ -12,15 +12,6 @@ export function formatProjectMetadata(metadata: ProjectMetadataType): string {
     sections.push(metadata.description);
     sections.push("");
   }
-  // URLs section
-  if (metadata.urls && metadata.urls.length > 0) {
-    sections.push("# URLs");
-    sections.push("");
-    for (const urlItem of metadata.urls) {
-      sections.push(`- [${urlItem.name}](${urlItem.url})`);
-    }
-    sections.push("");
-  }
 
   // Members section
   if (metadata.members && metadata.members.length > 0) {

--- a/front/components/assistant/conversation/space/about/SpaceAboutTab.tsx
+++ b/front/components/assistant/conversation/space/about/SpaceAboutTab.tsx
@@ -66,17 +66,13 @@ export function SpaceAboutTab({
 
   const form = useForm<PatchProjectMetadataBodyType>({
     resolver: zodResolver(PatchProjectMetadataBodySchema),
-    defaultValues: {
-      urls: [],
-    },
+    defaultValues: {},
   });
 
   // Sync form with loaded metadata
   useEffect(() => {
     if (projectMetadata) {
-      form.reset({
-        urls: projectMetadata.urls ?? [],
-      });
+      form.reset({});
       setProjectDescription(projectMetadata.description ?? "");
     }
   }, [projectMetadata, form]);

--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
@@ -13775,47 +13775,6 @@
         }
       },
       {
-        "name": "add_url",
-        "description": "Add a new URL to the project. URLs are named links (e.g., documentation, repository, design files).",
-        "inputSchema": {
-          "$schema": "http://json-schema.org/draft-07/schema#",
-          "additionalProperties": false,
-          "properties": {
-            "dustProject": {
-              "additionalProperties": false,
-              "properties": {
-                "mimeType": {
-                  "const": "application/vnd.dust.tool-input.dust-project",
-                  "type": "string"
-                },
-                "uri": {
-                  "pattern": "^project:\\/\\/dust\\/w\\/(\\w+)\\/projects\\/(\\w+)$",
-                  "type": "string"
-                }
-              },
-              "required": [
-                "uri",
-                "mimeType"
-              ],
-              "type": "object"
-            },
-            "name": {
-              "description": "Name/label for the URL (e.g., 'Documentation')",
-              "type": "string"
-            },
-            "url": {
-              "description": "The URL to add",
-              "type": "string"
-            }
-          },
-          "required": [
-            "name",
-            "url"
-          ],
-          "type": "object"
-        }
-      },
-      {
         "name": "edit_description",
         "description": "Edit the project description. This updates the project's description text.",
         "inputSchema": {
@@ -13852,52 +13811,8 @@
         }
       },
       {
-        "name": "edit_url",
-        "description": "Edit an existing URL in the project. You can change the name and/or the URL itself. Identify the URL to edit by its current name.",
-        "inputSchema": {
-          "$schema": "http://json-schema.org/draft-07/schema#",
-          "additionalProperties": false,
-          "properties": {
-            "currentName": {
-              "description": "Current name/label of the URL to edit",
-              "type": "string"
-            },
-            "dustProject": {
-              "additionalProperties": false,
-              "properties": {
-                "mimeType": {
-                  "const": "application/vnd.dust.tool-input.dust-project",
-                  "type": "string"
-                },
-                "uri": {
-                  "pattern": "^project:\\/\\/dust\\/w\\/(\\w+)\\/projects\\/(\\w+)$",
-                  "type": "string"
-                }
-              },
-              "required": [
-                "uri",
-                "mimeType"
-              ],
-              "type": "object"
-            },
-            "newName": {
-              "description": "New name/label for the URL (leave empty to keep current)",
-              "type": "string"
-            },
-            "newUrl": {
-              "description": "New URL value (leave empty to keep current)",
-              "type": "string"
-            }
-          },
-          "required": [
-            "currentName"
-          ],
-          "type": "object"
-        }
-      },
-      {
         "name": "get_information",
-        "description": "Get comprehensive information about the project context, including project URL, description, URLs, file count, and file list.",
+        "description": "Get comprehensive information about the project context, including project URL, description, file count, and file list.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
           "additionalProperties": false,
@@ -14039,9 +13954,7 @@
     ],
     "toolsStakes": {
       "add_file": "high",
-      "add_url": "low",
       "edit_description": "low",
-      "edit_url": "low",
       "get_information": "never_ask",
       "list_files": "never_ask",
       "search_unread": "never_ask",

--- a/front/lib/api/actions/servers/project_manager/metadata.ts
+++ b/front/lib/api/actions/servers/project_manager/metadata.ts
@@ -108,53 +108,9 @@ export const PROJECT_MANAGER_TOOLS_METADATA = createToolsRecord({
       done: "Edit project description",
     },
   },
-  add_url: {
-    description:
-      "Add a new URL to the project. URLs are named links (e.g., documentation, repository, design files).",
-    schema: {
-      name: z
-        .string()
-        .describe("Name/label for the URL (e.g., 'Documentation')"),
-      url: z.string().describe("The URL to add"),
-      dustProject:
-        ConfigurableToolInputSchemas[
-          INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_PROJECT
-        ].optional(),
-    },
-    stake: "low",
-    displayLabels: {
-      running: "Adding project URL",
-      done: "Add project URL",
-    },
-  },
-  edit_url: {
-    description:
-      "Edit an existing URL in the project. You can change the name and/or the URL itself. " +
-      "Identify the URL to edit by its current name.",
-    schema: {
-      currentName: z.string().describe("Current name/label of the URL to edit"),
-      newName: z
-        .string()
-        .optional()
-        .describe("New name/label for the URL (leave empty to keep current)"),
-      newUrl: z
-        .string()
-        .optional()
-        .describe("New URL value (leave empty to keep current)"),
-      dustProject:
-        ConfigurableToolInputSchemas[
-          INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_PROJECT
-        ].optional(),
-    },
-    stake: "low",
-    displayLabels: {
-      running: "Editing project URL",
-      done: "Edit project URL",
-    },
-  },
   get_information: {
     description:
-      "Get comprehensive information about the project context, including project URL, description, URLs, file count, and file list.",
+      "Get comprehensive information about the project context, including project URL, description, file count, and file list.",
     schema: {
       dustProject:
         ConfigurableToolInputSchemas[
@@ -200,7 +156,7 @@ export const PROJECT_MANAGER_TOOLS_METADATA = createToolsRecord({
 });
 
 const PROJECT_MANAGER_INSTRUCTIONS =
-  "Project files, URLs, and metadata are shared across all conversations in this project. " +
+  "Project files and metadata are shared across all conversations in this project. " +
   "Only text-based files are supported for adding/updating. " +
   "You can add/update files by providing text content directly, or by copying from existing files (like those you've generated). " +
   "Requires write permissions on the project space.";
@@ -210,7 +166,7 @@ export const PROJECT_MANAGER_SERVER = {
     name: "project_manager",
     version: "1.0.0",
     description:
-      "Manage project files, URLs, and metadata. Add, update, list files, and organize project resources.",
+      "Manage project files and metadata. Add, update, list files, and organize project resources.",
     icon: "ActionDocumentTextIcon",
     authorization: null,
     documentationUrl: null,

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -572,7 +572,7 @@ export async function createSpaceAndGroup(
       await ProjectMetadataResource.makeNew(
         auth,
         space,
-        { description: null, urls: [] },
+        { description: null },
         t
       );
     }

--- a/front/lib/resources/project_metadata_resource.test.ts
+++ b/front/lib/resources/project_metadata_resource.test.ts
@@ -32,7 +32,6 @@ describe("ProjectMetadataResource", () => {
     it("returns metadata when it exists", async () => {
       await ProjectMetadataResource.makeNew(auth, projectSpace, {
         description: "Test",
-        urls: [{ name: "Website", url: "https://example.com" }],
       });
 
       const metadata = await ProjectMetadataResource.fetchBySpace(
@@ -51,13 +50,10 @@ describe("ProjectMetadataResource", () => {
         projectSpace,
         {
           description: "Full metadata",
-          urls: [{ name: "GitHub", url: "https://github.com" }],
         }
       );
 
       expect(metadata.description).toBe("Full metadata");
-      expect(metadata.urls[0].name).toBe("GitHub");
-      expect(metadata.urls[0].url).toBe("https://github.com");
       expect(metadata.sId).toMatch(/^pmd_/);
     });
   });
@@ -69,13 +65,11 @@ describe("ProjectMetadataResource", () => {
         projectSpace,
         {
           description: "Initial",
-          urls: [],
         }
       );
 
       await metadata.updateMetadata({
         description: "Updated",
-        urls: [{ name: "Website", url: "https://updated.com" }],
       });
 
       const updated = await ProjectMetadataResource.fetchBySpace(
@@ -83,7 +77,6 @@ describe("ProjectMetadataResource", () => {
         projectSpace
       );
       expect(updated!.description).toBe("Updated");
-      expect(updated!.urls[0].url).toBe("https://updated.com");
     });
   });
 
@@ -94,7 +87,6 @@ describe("ProjectMetadataResource", () => {
         projectSpace,
         {
           description: "To delete",
-          urls: [],
         }
       );
 
@@ -115,7 +107,6 @@ describe("ProjectMetadataResource", () => {
         projectSpace,
         {
           description: "JSON test",
-          urls: [{ name: "Website", url: "https://test.com" }],
         }
       );
 

--- a/front/lib/resources/project_metadata_resource.ts
+++ b/front/lib/resources/project_metadata_resource.ts
@@ -102,7 +102,6 @@ export class ProjectMetadataResource extends BaseResource<ProjectMetadataModel> 
   async updateMetadata(
     blob: Partial<{
       description: string | null;
-      urls: Array<{ name: string; url: string }>;
     }>,
     transaction?: Transaction
   ): Promise<Result<void, Error>> {
@@ -131,7 +130,6 @@ export class ProjectMetadataResource extends BaseResource<ProjectMetadataModel> 
       updatedAt: this.updatedAt.getTime(),
       spaceId: this.spaceSId,
       description: this.description,
-      urls: this.urls,
     };
   }
 }

--- a/front/lib/resources/storage/models/project_metadata.ts
+++ b/front/lib/resources/storage/models/project_metadata.ts
@@ -13,7 +13,6 @@ export class ProjectMetadataModel extends WorkspaceAwareModel<ProjectMetadataMod
   declare spaceId: ForeignKey<SpaceModel["id"]>;
 
   declare description: string | null;
-  declare urls: Array<{ name: string; url: string }>;
 }
 
 ProjectMetadataModel.init(
@@ -31,11 +30,6 @@ ProjectMetadataModel.init(
     description: {
       type: DataTypes.TEXT,
       allowNull: true,
-    },
-    urls: {
-      type: DataTypes.ARRAY(DataTypes.JSONB),
-      allowNull: false,
-      defaultValue: [],
     },
   },
   {

--- a/front/migrations/20260114_backfill_project_metadata.ts
+++ b/front/migrations/20260114_backfill_project_metadata.ts
@@ -86,7 +86,6 @@ async function backfillProjectMetadata(
           workspaceId: workspace.id,
           spaceId: space.id,
           description: null,
-          urls: [],
         });
       }
     },

--- a/front/migrations/db/migration_503.sql
+++ b/front/migrations/db/migration_503.sql
@@ -1,0 +1,4 @@
+-- Migration: Remove urls column from project_metadata table
+-- 2026-02-05
+
+ALTER TABLE "project_metadata" DROP COLUMN IF EXISTS "urls";

--- a/front/pages/api/v1/w/[wId]/spaces/[spaceId]/project_metadata.test.ts
+++ b/front/pages/api/v1/w/[wId]/spaces/[spaceId]/project_metadata.test.ts
@@ -180,7 +180,6 @@ describe("GET /api/v1/w/[wId]/spaces/[spaceId]/project_metadata", () => {
     // Create project metadata
     await ProjectMetadataResource.makeNew(adminAuth, space, {
       description: "Test project description",
-      urls: [{ name: "Website", url: "https://example.com" }],
     });
 
     req.query.spaceId = space.sId;
@@ -195,7 +194,6 @@ describe("GET /api/v1/w/[wId]/spaces/[spaceId]/project_metadata", () => {
       sId: expect.anything(),
       spaceId: space.sId,
       updatedAt: expect.anything(),
-      urls: [{ name: "Website", url: "https://example.com" }],
       members: [],
     });
   });
@@ -231,10 +229,6 @@ describe("GET /api/v1/w/[wId]/spaces/[spaceId]/project_metadata", () => {
     // Create project metadata
     await ProjectMetadataResource.makeNew(adminAuth, space, {
       description: "Test project with members",
-      urls: [
-        { name: "Website", url: "https://example.com" },
-        { name: "GitHub", url: "https://github.com/test/repo" },
-      ],
     });
 
     req.query.spaceId = space.sId;
@@ -249,10 +243,6 @@ describe("GET /api/v1/w/[wId]/spaces/[spaceId]/project_metadata", () => {
       sId: expect.anything(),
       spaceId: space.sId,
       updatedAt: expect.anything(),
-      urls: [
-        { name: "Website", url: "https://example.com" },
-        { name: "GitHub", url: "https://github.com/test/repo" },
-      ],
       members: expect.arrayContaining([
         expect.stringContaining(member1.sId),
         expect.stringContaining(member2.sId),

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_metadata.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_metadata.test.ts
@@ -17,7 +17,6 @@ describe("GET /api/w/[wId]/spaces/[spaceId]/project_metadata", () => {
 
     await ProjectMetadataResource.makeNew(authenticator, projectSpace, {
       description: "Test description",
-      urls: [{ name: "GitHub", url: "https://github.com/test" }],
     });
 
     await handler(req, res);
@@ -54,7 +53,6 @@ describe("PATCH /api/w/[wId]/spaces/[spaceId]/project_metadata", () => {
     req.query.spaceId = projectSpace.sId;
     req.body = {
       description: "New description",
-      urls: [{ name: "API", url: "https://api.example.com" }],
     };
 
     await handler(req, res);
@@ -62,9 +60,6 @@ describe("PATCH /api/w/[wId]/spaces/[spaceId]/project_metadata", () => {
     expect(res._getStatusCode()).toBe(200);
     expect(res._getJSONData().projectMetadata.description).toBe(
       "New description"
-    );
-    expect(res._getJSONData().projectMetadata.urls[0].url).toBe(
-      "https://api.example.com"
     );
   });
 
@@ -88,21 +83,6 @@ describe("PATCH /api/w/[wId]/spaces/[spaceId]/project_metadata", () => {
     await handler(req, res);
 
     expect(res._getStatusCode()).toBe(403);
-  });
-
-  it("rejects invalid body", async () => {
-    const { req, res, workspace } = await createPrivateApiMockRequest({
-      method: "PATCH",
-      role: "admin",
-    });
-
-    const projectSpace = await SpaceFactory.project(workspace);
-    req.query.spaceId = projectSpace.sId;
-    req.body = { urls: "not-an-array" };
-
-    await handler(req, res);
-
-    expect(res._getStatusCode()).toBe(400);
   });
 });
 

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/project_metadata.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/project_metadata.ts
@@ -79,7 +79,6 @@ async function handler(
         // Create new metadata
         metadata = await ProjectMetadataResource.makeNew(auth, space, {
           description: body.description ?? null,
-          urls: body.urls ?? [],
         });
       } else {
         // Update existing metadata

--- a/front/scripts/ensure_project_datasource_and_connector_created.ts
+++ b/front/scripts/ensure_project_datasource_and_connector_created.ts
@@ -133,7 +133,6 @@ async function processProjectSpace(
       // Create new metadata
       metadata ??= await ProjectMetadataResource.makeNew(auth, space, {
         description: null,
-        urls: [],
       });
     } else {
       if (hadConnectorBefore) {

--- a/front/types/api/internal/spaces.ts
+++ b/front/types/api/internal/spaces.ts
@@ -40,20 +40,6 @@ export type GetPostNotionSyncResponseBody = t.TypeOf<
 
 export const PatchProjectMetadataBodySchema = z.object({
   description: z.string().optional(),
-  urls: z
-    .array(
-      z.object({
-        name: z
-          .string()
-          .nonempty("URL name is required")
-          .max(255, "URL name should be less than 255 characters"),
-        url: z
-          .string()
-          .url("Please enter a valid URL")
-          .nonempty("URL is required"),
-      })
-    )
-    .optional(),
 });
 
 export type PatchProjectMetadataBodyType = z.infer<

--- a/front/types/project_metadata.ts
+++ b/front/types/project_metadata.ts
@@ -4,5 +4,4 @@ export interface ProjectMetadataType {
   updatedAt: number;
   spaceId: string;
   description: string | null;
-  urls: Array<{ name: string; url: string }>;
 }

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -2428,7 +2428,6 @@ export const ProjectMetadataSchema = z.object({
   updatedAt: z.number(),
   spaceId: z.string(),
   description: z.string().nullable(),
-  urls: z.array(z.object({ name: z.string(), url: z.string() })),
   members: z.array(z.string()),
 });
 export type ProjectMetadataType = z.infer<typeof ProjectMetadataSchema>;


### PR DESCRIPTION
## Description

Remove the urls array field from the ProjectMetadataModel and all related code:
- Remove urls field from database model and TypeScript types
- Remove add_url and edit_url MCP tools from project_manager server
- Update all API endpoints, business logic, and UI components
- Update all test files to remove URL references
- Add database migration to drop urls column

Fixes: https://github.com/orgs/dust-tt/projects/3/views/12?pane=issue&itemId=154497440&issue=dust-tt%7Ctasks%7C6342

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
