### PR TITLE
fix(projects): replace input with textarea for description field

### DIFF
--- a/front/components/assistant/conversation/space/about/SpaceAboutTab.tsx
+++ b/front/components/assistant/conversation/space/about/SpaceAboutTab.tsx
@@ -5,6 +5,7 @@ import {
   ScrollArea,
   SearchInput,
   SliderToggle,
+  TextArea,
   UserGroupIcon,
 } from "@dust-tt/sparkle";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -194,10 +195,10 @@ export function SpaceAboutTab({
         </div>
         <div className="flex w-full flex-col gap-2">
           <div className="heading-lg">Description</div>
-          <div className="flex w-full min-w-0 gap-2">
-            <Input
+          <div className="flex w-full min-w-0 flex-col gap-2">
+            <TextArea
               value={projectDescription}
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+              onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => {
                 setProjectDescription(e.target.value);
                 setIsEditingDescription(
                   e.target.value !== projectMetadata?.description
@@ -209,10 +210,12 @@ export function SpaceAboutTab({
                   : "Describe what this project is about..."
               }
               disabled={isProjectMetadataLoading}
-              containerClassName="flex-1"
+              minRows={3}
+              resize="vertical"
+              className="flex-1"
             />
             {isEditingDescription && (
-              <>
+              <div className="flex gap-2">
                 <Button
                   label="Save"
                   variant="highlight"
@@ -226,7 +229,7 @@ export function SpaceAboutTab({
                     setIsEditingDescription(false);
                   }}
                 />
-              </>
+              </div>
             )}
           </div>
         </div>


### PR DESCRIPTION
## Description

The project description field was using a single-line Input component, which truncated long text and made it difficult to view the full content.

Fixes: https://github.com/orgs/dust-tt/projects/3/views/12?pane=issue&itemId=154494947&issue=dust-tt%7Ctasks%7C6338

## Tests

<img width="976" height="216" alt="image" src="https://github.com/user-attachments/assets/6e068e51-ba24-4b6a-9ad5-fd7d2e651aaf" />
## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
