### PR TITLE
Ability to search by stripe sub id on poké

### DIFF
--- a/front/pages/api/poke/workspaces/index.ts
+++ b/front/pages/api/poke/workspaces/index.ts
@@ -166,6 +166,19 @@ async function handler(
       }
 
       if (searchTerm) {
+        // Search by Stripe subscription ID (exact match).
+        let isSearchByStripeSubscription = false;
+        if (searchTerm.startsWith("sub_")) {
+          const subscription =
+            await SubscriptionResource.fetchByStripeId(searchTerm);
+          if (subscription) {
+            isSearchByStripeSubscription = true;
+            conditions.push({
+              id: subscription.workspaceId,
+            });
+          }
+        }
+
         let isSearchByEmail = false;
         if (isEmailValid(searchTerm)) {
           // We can have 2 users with the same email if a Google user and a Github user have the same email.
@@ -197,7 +210,11 @@ async function handler(
           }
         }
 
-        if (!isSearchByEmail && !isSearchByDomain) {
+        if (
+          !isSearchByEmail &&
+          !isSearchByDomain &&
+          !isSearchByStripeSubscription
+        ) {
           conditions.push({
             [Op.or]: [
               {


### PR DESCRIPTION
## Description

- Add ability to search by Stripe subscription ID (sub_*) in Poke
- Works in both the homepage search bar and command palette (Cmd+K)
- Auto-detects Stripe IDs by the sub_ prefix and performs exact match lookup
- Returns the associated workspace when a matching subscription is found


## Tests

Locally. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 