### PR TITLE
[front] enh: Use breacrumb for project conversations

### DIFF
--- a/front/components/assistant/conversation/ConversationTitle.tsx
+++ b/front/components/assistant/conversation/ConversationTitle.tsx
@@ -1,4 +1,5 @@
-import { ArrowLeftIcon, Button, IconButton, MoreIcon } from "@dust-tt/sparkle";
+import type { BreadcrumbItem } from "@dust-tt/sparkle";
+import { ArrowLeftIcon, Breadcrumbs, Button, MoreIcon } from "@dust-tt/sparkle";
 import { useState } from "react";
 
 import { ConversationFilesPopover } from "@app/components/assistant/conversation/ConversationFilesPopover";
@@ -45,51 +46,49 @@ export function ConversationTitle({ owner }: { owner: WorkspaceType }) {
     return null;
   }
 
+  const spaceId = conversation?.spaceId;
+  const isProjectConversation = !!spaceId;
+  const isLoading = isProjectConversation && !spaceInfo;
+
+  const breadcrumbItems: BreadcrumbItem[] = [];
+
+  if (spaceId && spaceInfo) {
+    breadcrumbItems.push({
+      icon: ArrowLeftIcon,
+      label: spaceInfo.name,
+      onClick: () => {
+        void router.push(getProjectRoute(owner.sId, spaceId), undefined, {
+          shallow: true,
+        });
+      },
+    });
+  }
+
+  if (!isLoading) {
+    breadcrumbItems.push({
+      label: currentTitle || "New Conversation",
+      onClick: () => setShowRenameDialog(true),
+    });
+  }
+
   return (
     <AppLayoutTitle>
       <div
-        className="grid h-full min-w-0 max-w-full grid-cols-[auto,1fr,auto] items-center gap-3"
+        className="grid h-full min-w-0 max-w-full grid-cols-[1fr,auto] items-center gap-3"
         onContextMenu={handleRightClick}
       >
-        <div className="flex min-w-0">
-          {conversation?.spaceId && (
-            <IconButton
-              size="xmini"
-              variant="outline"
-              icon={ArrowLeftIcon}
-              aria-label={`Back to ${spaceInfo?.name}`}
-              onClick={() => {
-                void router.push(
-                  getProjectRoute(owner.sId, conversation.spaceId!),
-                  undefined,
-                  {
-                    shallow: true,
-                  }
-                );
-              }}
-            />
-          )}
-        </div>
-        <div className="flex min-w-0 flex-row items-center gap-1 text-primary dark:text-primary-night">
-          {!!spaceInfo && (
-            <div className="dd-privacy-mask min-w-0 overflow-hidden truncate text-base font-normal text-muted-foreground">
-              {spaceInfo.name} -
-            </div>
-          )}
-          <div
-            className="dd-privacy-mask min-w-0 cursor-pointer overflow-hidden truncate text-base font-normal text-muted-foreground hover:underline"
-            onClick={() => setShowRenameDialog(true)}
-          >
-            {currentTitle}
-          </div>
-          <EditConversationTitleDialog
-            isOpen={showRenameDialog}
-            onClose={() => setShowRenameDialog(false)}
-            owner={owner}
-            conversationId={activeConversationId}
-            currentTitle={currentTitle}
-          />
-        </div>
+        <Breadcrumbs
+          items={breadcrumbItems}
+          className="dd-privacy-mask"
+          truncateLengthEnd={120}
+        />
+        <EditConversationTitleDialog
+          isOpen={showRenameDialog}
+          onClose={() => setShowRenameDialog(false)}
+          owner={owner}
+          conversationId={activeConversationId}
+          currentTitle={currentTitle}
+        />
         <div className="flex items-center gap-2">
           <ConversationFilesPopover
             conversationId={activeConversationId}

--- a/sparkle/src/components/Breadcrumbs.tsx
+++ b/sparkle/src/components/Breadcrumbs.tsx
@@ -15,7 +15,7 @@ import { ChevronRightIcon } from "@sparkle/icons/app";
 import { cn } from "@sparkle/lib";
 
 const LABEL_TRUNCATE_LENGTH_MIDDLE = 15;
-const LABEL_TRUNCATE_LENGTH_END = 30;
+const DEFAULT_LABEL_TRUNCATE_LENGTH_END = 30;
 const ELLIPSIS_STRING = "...";
 
 const breadcrumbTextVariants = cva("", {
@@ -87,6 +87,7 @@ interface BreadcrumbItemProps {
   itemsHidden?: BreadcrumbItem[];
   size?: "xs" | "sm";
   hasLighterFont?: boolean;
+  truncateLengthEnd?: number;
 }
 
 function BreadcrumbItem({
@@ -95,6 +96,7 @@ function BreadcrumbItem({
   itemsHidden,
   size = "sm",
   hasLighterFont = true,
+  truncateLengthEnd = DEFAULT_LABEL_TRUNCATE_LENGTH_END,
 }: BreadcrumbItemProps) {
   if (item.label === ELLIPSIS_STRING) {
     return (
@@ -133,7 +135,7 @@ function BreadcrumbItem({
 
   const truncatedLabel = truncateTextToLength(
     item.label,
-    isLast ? LABEL_TRUNCATE_LENGTH_END : LABEL_TRUNCATE_LENGTH_MIDDLE
+    isLast ? truncateLengthEnd : LABEL_TRUNCATE_LENGTH_MIDDLE
   );
 
   const isLabelTruncated = truncatedLabel !== item.label;
@@ -189,6 +191,7 @@ interface BreadcrumbProps {
   className?: string;
   size?: "xs" | "sm";
   hasLighterFont?: boolean;
+  truncateLengthEnd?: number;
 }
 
 interface BreadcrumbsAccumulator {
@@ -201,6 +204,7 @@ export function Breadcrumbs({
   className,
   size = "sm",
   hasLighterFont = true,
+  truncateLengthEnd,
 }: BreadcrumbProps) {
   const { itemsShown, itemsHidden } = items.reduce(
     (acc: BreadcrumbsAccumulator, item, index) => {
@@ -231,6 +235,7 @@ export function Breadcrumbs({
               itemsHidden={itemsHidden}
               size={size}
               hasLighterFont={hasLighterFont}
+              truncateLengthEnd={truncateLengthEnd}
             />
             {index === itemsShown.length - 1 ? null : (
               <Icon


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/5692

Add breadcrumb to conversation nested in projects

Also update breadcrumb component to make word-len cutoff parameterized

<img width="402" height="98" alt="image" src="https://github.com/user-attachments/assets/6bf8539a-ddb8-40c7-94d0-148c6ae408c9" />

(hovering the project title)

## Tests

- Tested manually

## Risk

Low

## Deploy Plan

- [ ] Deploy front