### PR TITLE
fix(ui): unify separator line color and alignment across panels

### DIFF
--- a/front/components/navigation/NavigationSidebar.tsx
+++ b/front/components/navigation/NavigationSidebar.tsx
@@ -111,30 +111,32 @@ export const NavigationSidebar = React.forwardRef<
         )}
         {navs.length > 1 && (
           <Tabs value={currentTab?.id ?? "conversations"}>
-            <TabsList className="px-2">
-              {navs.map((tab) => (
-                <div key={tab.id} ref={tab.ref ?? undefined}>
-                  <TabsTrigger
-                    key={tab.id}
-                    value={tab.id}
-                    label={tab.hideLabel ? undefined : tab.label}
-                    tooltip={tab.hideLabel ? tab.label : undefined}
-                    icon={tab.icon}
-                    href={tab.href}
-                    onClick={() => handleTabClick(tab.href)}
-                  />
-                </div>
-              ))}
-              {isMobile && (
-                <div className="flex flex-grow justify-end">
-                  <TabsTrigger
-                    value="close-icon"
-                    icon={XMarkIcon}
-                    onClick={() => setSidebarOpen(false)}
-                  />
-                </div>
-              )}
-            </TabsList>
+            <div className="border-b border-separator px-2 dark:border-separator-night">
+              <TabsList border={false}>
+                {navs.map((tab) => (
+                  <div key={tab.id} ref={tab.ref ?? undefined}>
+                    <TabsTrigger
+                      key={tab.id}
+                      value={tab.id}
+                      label={tab.hideLabel ? undefined : tab.label}
+                      tooltip={tab.hideLabel ? tab.label : undefined}
+                      icon={tab.icon}
+                      href={tab.href}
+                      onClick={() => handleTabClick(tab.href)}
+                    />
+                  </div>
+                ))}
+                {isMobile && (
+                  <div className="flex flex-grow justify-end">
+                    <TabsTrigger
+                      value="close-icon"
+                      icon={XMarkIcon}
+                      onClick={() => setSidebarOpen(false)}
+                    />
+                  </div>
+                )}
+              </TabsList>
+            </div>
             {navs.map((tab) => (
               <TabsContent key={tab.id} value={tab.id}>
                 <NavigationList className="px-3">

--- a/front/components/pages/conversation/SpaceConversationsPage.tsx
+++ b/front/components/pages/conversation/SpaceConversationsPage.tsx
@@ -281,7 +281,7 @@ export function SpaceConversationsPage() {
         onValueChange={(value) => handleTabChange(value as SpaceTab)}
         className="flex min-h-0 flex-1 flex-col pt-3"
       >
-        <div className="flex items-start justify-between border-b border-separator px-6">
+        <div className="flex items-start justify-between border-b border-separator px-6 dark:border-separator-night">
           <TabsList border={false}>
             <TabsTrigger
               value="conversations"

--- a/front/components/sparkle/AppLayoutTitle.tsx
+++ b/front/components/sparkle/AppLayoutTitle.tsx
@@ -10,9 +10,9 @@ export function AppLayoutTitle({ children, className }: AppLayoutTitleProps) {
   return (
     <div
       className={cn(
-        "flex h-14 w-full shrink-0 flex-col border-b border-border px-4 pl-14 lg:pl-4",
+        "flex h-[58px] w-full shrink-0 flex-col border-b border-separator px-4 pl-14 lg:pl-4",
         "bg-background dark:bg-background-night",
-        "dark:border-border-night",
+        "dark:border-separator-night",
         // When no children, only show on mobile for hamburger menu alignment.
         !children && "block lg:hidden",
         className


### PR DESCRIPTION
## Description

[task](https://github.com/dust-tt/tasks/issues/6341)


Fixes separator line inconsistencies in the project and conversation views:

- **Color issue**: Left sidebar's separator appeared WHITE in dark mode instead of proper gray
- **Alignment issue**: Left and right panel separators were vertically misaligned

## Changes
- `NavigationSidebar.tsx`: Wrap TabsList in a div with `border-separator` classes and disable TabsList's built-in border
- `SpaceConversationsPage.tsx`: Add dark mode class to existing border
- `AppLayoutTitle.tsx`: Change from `border-border` to `border-separator` classes and adjust height to 58px for alignment

## Tests
- [x] Project view: Both separators have consistent color in light/dark mode
- [x] Project view: Both separators are pixel-perfect aligned (verified 0px difference)
- [x] Conversation view: Title bar separator matches sidebar separator alignment

## Risk
low

## Deploy plan
front