### PR TITLE
fix: check feature flag to display project notification preferences

### DIFF
--- a/front/components/me/NotificationPreferences.tsx
+++ b/front/components/me/NotificationPreferences.tsx
@@ -464,10 +464,6 @@ export const NotificationPreferences = forwardRef<
     projectNewConversationPreferences?.channels.email &&
     projectNewConversationPreferences?.enabled;
 
-  // Check if any email notification is enabled
-  const isAnyEmailEnabled =
-    isConversationEmailEnabled === true || isProjectEmailEnabled === true;
-
   return (
     <div className="flex flex-col gap-4">
       {/* Conversation notifications */}
@@ -565,8 +561,36 @@ export const NotificationPreferences = forwardRef<
         </div>
       </div>
 
+      {/* Unread conversation email frequency setting */}
+      {isConversationEmailEnabled && (
+        <div className="flex flex-wrap items-center gap-1.5 pt-2">
+          <Label className="text-foreground dark:text-foreground-night">
+            Email me at most
+          </Label>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="outline"
+                size="sm"
+                isSelect
+                label={NOTIFICATION_PREFERENCES_DELAY_LABELS[emailDelay]}
+              />
+            </DropdownMenuTrigger>
+            <DropdownMenuContent>
+              {NOTIFICATION_DELAY_OPTIONS.map((delay) => (
+                <DropdownMenuItem
+                  key={delay}
+                  label={NOTIFICATION_PREFERENCES_DELAY_LABELS[delay]}
+                  onClick={() => setEmailDelay(delay)}
+                />
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      )}
+
       {/* Project notifications */}
-      {projectPreferences && (
+      {projectPreferences && isProjectsFeatureEnabled && (
         <>
           <div className="flex flex-wrap items-center gap-1.5 pt-2">
             <Label className="text-foreground dark:text-foreground-night">
@@ -621,33 +645,6 @@ export const NotificationPreferences = forwardRef<
         </>
       )}
 
-      {/* Global email frequency setting */}
-      {isAnyEmailEnabled && (
-        <div className="flex flex-wrap items-center gap-1.5 pt-2">
-          <Label className="text-foreground dark:text-foreground-night">
-            Email me at most
-          </Label>
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant="outline"
-                size="sm"
-                isSelect
-                label={NOTIFICATION_PREFERENCES_DELAY_LABELS[emailDelay]}
-              />
-            </DropdownMenuTrigger>
-            <DropdownMenuContent>
-              {NOTIFICATION_DELAY_OPTIONS.map((delay) => (
-                <DropdownMenuItem
-                  key={delay}
-                  label={NOTIFICATION_PREFERENCES_DELAY_LABELS[delay]}
-                  onClick={() => setEmailDelay(delay)}
-                />
-              ))}
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </div>
-      )}
       {/* Project new conversations notifications */}
       {!!projectNewConversationPreferences && isProjectsFeatureEnabled && (
         <>


### PR DESCRIPTION




## Description

This PR fixes the display of project notification preferences by properly checking the feature flag.
The block to set the mail frequency is moved above the projects settings, because the project notifications do not follow those preferences.
<img width="1125" height="716" alt="Capture d’écran 2026-02-05 à 13 51 27" src="https://github.com/user-attachments/assets/c5206749-3add-421b-804b-e9b4e230b694" />


## Tests

Manually

## Risks

Low. 

## Deploy Plan

Standard deployment.
