### PR TITLE
[spa] Fix oauth message

### DIFF
--- a/front/components/pages/oauth/OAuthFinalizePage.tsx
+++ b/front/components/pages/oauth/OAuthFinalizePage.tsx
@@ -56,10 +56,19 @@ export function OAuthFinalizePage() {
             provider: validProvider,
           };
 
+      // Get opener origin from connection metadata (passed through OAuth flow)
+      const openerOrigin = res.isOk()
+        ? res.value.metadata.opener_origin
+        : undefined;
+
       // Method 1: window.opener (preferred, direct communication)
+      // Use opener origin from metadata, fall back to window.location.origin if not available
       if (window.opener && !window.opener.closed) {
         try {
-          window.opener.postMessage(messageData, window.location.origin);
+          window.opener.postMessage(
+            messageData,
+            openerOrigin ?? window.location.origin
+          );
         } catch (e) {
           logger.error(
             { err: e },

--- a/front/lib/api/oauth.ts
+++ b/front/lib/api/oauth.ts
@@ -98,7 +98,8 @@ export async function createConnectionAndGetSetupUrl(
   auth: Authenticator,
   provider: OAuthProvider,
   useCase: OAuthUseCase,
-  extraConfig: ExtraConfigType
+  extraConfig: ExtraConfigType,
+  openerOrigin?: string
 ): Promise<Result<string, OAuthError>> {
   const api = new OAuthAPI(config.getOAuthAPIConfig(), logger);
 
@@ -191,6 +192,8 @@ export async function createConnectionAndGetSetupUrl(
     workspace_id: auth.getNonNullableWorkspace().sId,
     user_id: auth.getNonNullableUser().sId,
     ...extraConfig,
+    // Store opener origin for postMessage after OAuth finalize (cross-origin popup communication)
+    ...(openerOrigin && { opener_origin: openerOrigin }),
   };
 
   const cRes = await api.createConnection({

--- a/front/pages/api/w/[wId]/oauth/[provider]/setup.ts
+++ b/front/pages/api/w/[wId]/oauth/[provider]/setup.ts
@@ -35,7 +35,7 @@ async function handler(
     });
   }
 
-  const { provider, useCase, extraConfig } = req.query;
+  const { provider, useCase, extraConfig, openerOrigin } = req.query;
 
   if (!isOAuthProvider(provider)) {
     return apiError(req, res, {
@@ -86,7 +86,8 @@ async function handler(
     auth,
     provider,
     useCase,
-    parsedExtraConfig
+    parsedExtraConfig,
+    isString(openerOrigin) ? openerOrigin : undefined
   );
 
   if (!urlRes.isOk()) {


### PR DESCRIPTION
## Description

Summary

- Fix cross-origin postMessage in OAuth finalize flow by passing opener origin through the OAuth flow metadata

Problem

When initiating OAuth from the front-SPA (running on port 3011 in dev), the flow opens a popup that goes through the NextJS server (port 3000). After OAuth completes, the OAuthFinalizePage component sends a message back to the opener using postMessage.

Two issues prevented this from working:

1. Sender side (OAuthFinalizePage.tsx): Used window.location.origin as the target origin (port 3000), but the opener is on port 3011 and couldn't receive messages targeted at a different origin.
2. Receiver side (setup.ts): Checked event.origin !== window.location.origin, rejecting messages from port 3000 since the receiver's origin is port 3011.

Solution

Pass the opener's origin through the OAuth flow via connection metadata.
- The target origin is explicitly specified based on the actual opener
- The receiver validates messages come from the expected OAuth server origin
- Falls back to "window.location.origin" only if opener origin is unavailable (backward compatibility)

## Tests

- Initiate an OAuth connection flow (e.g., GitHub, Google)
- Verify the popup successfully communicates back to the opener after OAuth completes
- Verify the connection is created and displayed in the UI

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
