### PR TITLE
feat(copilot): add template scenario to copilot init message

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -505,6 +505,7 @@ export default function AgentBuilder({
             isCreatedDialogOpen={isCreatedDialogOpen}
             setIsCreatedDialogOpen={setIsCreatedDialogOpen}
             isNewAgent={!!duplicateAgentId || !agentConfiguration}
+            templateId={assistantTemplate?.sId ?? null}
           />
         </CopilotSuggestionsProvider>
       </FormProvider>
@@ -535,6 +536,7 @@ interface AgentBuilderContentProps {
   isCreatedDialogOpen: boolean;
   setIsCreatedDialogOpen: (open: boolean) => void;
   isNewAgent: boolean;
+  templateId: string | null;
 }
 
 function AgentBuilderContent({
@@ -550,6 +552,7 @@ function AgentBuilderContent({
   isCreatedDialogOpen,
   setIsCreatedDialogOpen,
   isNewAgent,
+  templateId,
 }: AgentBuilderContentProps) {
   const { owner } = useAgentBuilderContext();
   const { hasFeature } = useFeatureFlags({ workspaceId: owner.sId });
@@ -648,6 +651,7 @@ function AgentBuilderContent({
               clientSideMCPServerId ? [clientSideMCPServerId] : []
             }
             isNewAgent={isNewAgent}
+            templateId={templateId}
           >
             <ConversationSidePanelProvider>
               <AgentBuilderRightPanel

--- a/front/components/agent_builder/CopilotPanelContext.tsx
+++ b/front/components/agent_builder/CopilotPanelContext.tsx
@@ -15,6 +15,26 @@ import { useUser } from "@app/lib/swr/user";
 import type { ConversationType } from "@app/types";
 import { GLOBAL_AGENTS_SID } from "@app/types";
 
+function buildStep3({ includeInsights }: { includeInsights: boolean }): string {
+  const insightsLine = includeInsights
+    ? `- \`get_agent_insights\`: Only if you need additional information to improve the agent.\n`
+    : "";
+
+  return `## STEP 3: After user responds, create suggestions
+Tool usage rules when creating suggestions:
+- \`get_available_skills\`: Call FIRST. Bias towards skills.
+- \`get_available_tools\`: Only if clearly needed. If the desired agent is not specialized but meant to be multi-purpose, suggest "Discover Tools" skill instead.
+${insightsLine}- \`get_available_models\`: Only if user explicitly asks OR obvious need.
+
+Use \`suggest_*\` tools to create actionable suggestions. Brief explanation (3-4 sentences max). Always include their output verbatim in your response - it renders as interactive cards
+
+Warning: do not suggest instructions if there is no existing tools or skills to do an action.
+For instance if the user wants to create a agent to answer on JIRA issues but there is no tool to interact with JIRA then it won't be possible.
+In that case, instead of doing prompt suggestions ask the user for clarifications.
+
+Balance context gathering with latency - the first copilot message should be fast but helpful in driving builder actions.`;
+}
+
 function buildNewAgentInitMessage(): string {
   return `<dust_system>
 NEW agent - no suggestions/feedback/insights.
@@ -40,24 +60,12 @@ Provide 2-3 specific agent use case suggestions as bullet points. Example:
 "I can help you build agents for your work in [role/team]. A few ideas:
 
 • **Meeting prep agent** - pulls prospect info from CRM before calls
-• **Follow-up drafter** - generates personalized emails based on call notes  
+• **Follow-up drafter** - generates personalized emails based on call notes
 • **Competitive intel** - monitors competitor news and surfaces updates
 
 Pick one to start, or tell me what you're thinking."
 
-## STEP 3: After user responds, create suggestions
-Tool usage rules when creating suggestions:
-- \`get_available_skills\`: Call FIRST. Bias towards skills.
-- \`get_available_tools\`: Only if clearly needed. If the desired agent is not specialized but meant to be multi-purpose, suggest "Discover Tools" skill instead.
-- \`get_available_models\`: Only if user explicitly asks OR obvious need.
-
-Use \`suggest_*\` tools to create actionable suggestions. Brief explanation (3-4 sentences max). Always include their output verbatim in your response - it renders as interactive cards
-
-Warning: do not suggest instructions if there is no existing tools or skills to do an action.
-For instance if the user wants to create a agent to answer on JIRA issues but there is no tool to interact with JIRA then it won't be possible.
-In that case, instead of doing prompt suggestions ask the user for clarifications.
-
-Balance context gathering with latency - the first copilot message should be fast but helpful in driving builder actions.
+${buildStep3({ includeInsights: false })}
 </dust_system>`;
 }
 
@@ -79,20 +87,31 @@ Based on gathered data, provide a brief summary:
 - If pending suggestions exist from \`get_agent_config\`, output their directives to render them as cards:
   CRITICAL: For each suggestion, output: \`:agent_suggestion[]{sId=<sId> kind=<kind>}\`
 
-## STEP 3: After user responds, create suggestions
-Tool usage rules when creating suggestions:
-- \`get_available_skills\`: Call FIRST. Bias towards skills.
-- \`get_available_tools\`: Only if clearly needed. If the desired agent is not specialized but meant to be multi-purpose, suggest "Discover Tools" skill instead.
-- \`get_agent_insights\`: Only if you need additional information to improve the agent.
-- \`get_available_models\`: Only if user explicitly asks OR obvious need.
+${buildStep3({ includeInsights: true })}
+</dust_system>`;
+}
 
-Use \`suggest_*\` tools to create actionable suggestions. Brief explanation (3-4 sentences max). Always include their output verbatim in your response - it renders as interactive cards
+function buildTemplateAgentInitMessage(templateId: string): string {
+  return `<dust_system>
+NEW agent from TEMPLATE.
 
-Warning: do not suggest instructions if there is no existing tools or skills to do an action.
-For instance if the user wants to create a agent to answer on JIRA issues but there is no tool to interact with JIRA then it won't be possible.
-In that case, instead of doing prompt suggestions ask the user for clarifications.
+## STEP 1: Gather context
+You MUST call these tools simultaneously in the same tool call round:
+1. \`get_agent_config\` - to retrieve the current agent configuration and any pending suggestions
+2. \`get_agent_template\` with templateId="${templateId}" - to retrieve template-specific copilot instructions
 
-Balance context gathering with latency - the first copilot message should be fast but helpful in driving builder actions.
+CRITICAL: All tools must be called together in parallel, not sequentially.
+
+## STEP 2: Check copilotInstructions and act accordingly
+
+**If copilotInstructions has content:**
+The instructions contain domain-specific rules for this agent type. IMMEDIATELY create suggestions based on those instructions - do NOT wait for user response.
+Use \`suggest_*\` tools right away following the guidance in copilotInstructions.
+
+**If copilotInstructions is null or empty:**
+Proceed exactly as a new agent - suggest 2-3 use cases based on user's job function and preferred platforms, then wait for user response.
+
+${buildStep3({ includeInsights: false })}
 </dust_system>`;
 }
 
@@ -125,6 +144,7 @@ interface CopilotPanelProviderProps {
   targetAgentConfigurationVersion: number;
   clientSideMCPServerIds: string[];
   isNewAgent: boolean;
+  templateId: string | null;
 }
 
 const updateCopilotConversationIdQueryParam = (
@@ -145,6 +165,7 @@ export const CopilotPanelProvider = ({
   targetAgentConfigurationVersion,
   clientSideMCPServerIds,
   isNewAgent,
+  templateId,
 }: CopilotPanelProviderProps) => {
   const { owner } = useAgentBuilderContext();
   const { user } = useUser();
@@ -170,9 +191,11 @@ export const CopilotPanelProvider = ({
 
     setIsCreatingConversation(true);
 
-    const firstMessagePrompt = isNewAgent
-      ? buildNewAgentInitMessage()
-      : buildExistingAgentInitMessage();
+    const firstMessagePrompt = templateId
+      ? buildTemplateAgentInitMessage(templateId)
+      : isNewAgent
+        ? buildNewAgentInitMessage()
+        : buildExistingAgentInitMessage();
 
     const result = await createConversationWithMessage({
       messageData: {
@@ -212,6 +235,7 @@ export const CopilotPanelProvider = ({
     sendNotification,
     targetAgentConfigurationId,
     targetAgentConfigurationVersion,
+    templateId,
   ]);
 
   const resetConversation = useCallback(() => {

--- a/front/components/agent_builder/CopilotPanelContext.tsx
+++ b/front/components/agent_builder/CopilotPanelContext.tsx
@@ -16,15 +16,19 @@ import type { ConversationType } from "@app/types";
 import { GLOBAL_AGENTS_SID } from "@app/types";
 
 function buildStep3({ includeInsights }: { includeInsights: boolean }): string {
-  const insightsLine = includeInsights
-    ? `- \`get_agent_insights\`: Only if you need additional information to improve the agent.\n`
-    : "";
+  const toolRules = [
+    `- \`get_available_skills\`: Call FIRST. Bias towards skills.`,
+    `- \`get_available_tools\`: Only if clearly needed. If the desired agent is not specialized but meant to be multi-purpose, suggest "Discover Tools" skill instead.`,
+    includeInsights &&
+      `- \`get_agent_insights\`: Only if you need additional information to improve the agent.`,
+    `- \`get_available_models\`: Only if user explicitly asks OR obvious need.`,
+  ]
+    .filter(Boolean)
+    .join("\n");
 
   return `## STEP 3: After user responds, create suggestions
 Tool usage rules when creating suggestions:
-- \`get_available_skills\`: Call FIRST. Bias towards skills.
-- \`get_available_tools\`: Only if clearly needed. If the desired agent is not specialized but meant to be multi-purpose, suggest "Discover Tools" skill instead.
-${insightsLine}- \`get_available_models\`: Only if user explicitly asks OR obvious need.
+${toolRules}
 
 Use \`suggest_*\` tools to create actionable suggestions. Brief explanation (3-4 sentences max). Always include their output verbatim in your response - it renders as interactive cards
 

--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
@@ -62,6 +62,24 @@
         }
       },
       {
+        "name": "get_agent_template",
+        "description": "Fetch template-specific guidance for the current agent. Use this tool when the agent was created from a template to retrieve specialized copilotInstructions that define how you should assist with this agent type. These instructions may contain domain-specific rules, preferred approaches, or constraints you should follow.",
+        "inputSchema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "additionalProperties": false,
+          "properties": {
+            "templateId": {
+              "description": "The sId of the template to retrieve",
+              "type": "string"
+            }
+          },
+          "required": [
+            "templateId"
+          ],
+          "type": "object"
+        }
+      },
+      {
         "name": "get_available_agents",
         "description": "Get the list of available agents that can be used as sub-agents. Returns active agents accessible to the current user, excluding global agents.",
         "inputSchema": {
@@ -483,6 +501,7 @@
     "toolsStakes": {
       "get_agent_feedback": "never_ask",
       "get_agent_insights": "never_ask",
+      "get_agent_template": "never_ask",
       "get_available_agents": "never_ask",
       "get_available_knowledge": "never_ask",
       "get_available_models": "never_ask",

--- a/front/lib/api/actions/servers/agent_copilot_context/metadata.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/metadata.ts
@@ -335,6 +335,20 @@ export const AGENT_COPILOT_CONTEXT_TOOLS_METADATA = createToolsRecord({
       done: "Update suggestion state",
     },
   },
+  get_agent_template: {
+    description:
+      "Fetch template-specific guidance for the current agent. " +
+      "Use this tool when the agent was created from a template to retrieve specialized copilotInstructions that define how you should assist with this agent type. " +
+      "These instructions may contain domain-specific rules, preferred approaches, or constraints you should follow.",
+    schema: {
+      templateId: z.string().describe("The sId of the template to retrieve"),
+    },
+    stake: "never_ask",
+    displayLabels: {
+      running: "Fetching template",
+      done: "Fetch template",
+    },
+  },
 });
 
 export const AGENT_COPILOT_CONTEXT_SERVER = {

--- a/front/lib/api/actions/servers/agent_copilot_context/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/tools/index.ts
@@ -24,6 +24,7 @@ import { DataSourceViewResource } from "@app/lib/resources/data_source_view_reso
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
+import { TemplateResource } from "@app/lib/resources/template_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import type {
   DataSourceViewCategory,
@@ -1252,6 +1253,39 @@ const handlers: ToolHandlers<typeof AGENT_COPILOT_CONTEXT_TOOLS_METADATA> = {
       {
         type: "text" as const,
         text: JSON.stringify({ results }, null, 2),
+      },
+    ]);
+  },
+
+  get_agent_template: async ({ templateId }, extra) => {
+    const auth = extra.auth;
+    if (!auth) {
+      return new Err(new MCPError("Authentication required"));
+    }
+
+    const template = await TemplateResource.fetchByExternalId(templateId);
+
+    if (!template) {
+      return new Err(
+        new MCPError(`Template not found: ${templateId}`, {
+          tracked: false,
+        })
+      );
+    }
+
+    return new Ok([
+      {
+        type: "text" as const,
+        text: JSON.stringify(
+          {
+            sId: template.sId,
+            handle: template.handle,
+            description: template.description,
+            copilotInstructions: template.copilotInstructions,
+          },
+          null,
+          2
+        ),
       },
     ]);
   },


### PR DESCRIPTION
Linked to: https://github.com/dust-tt/tasks/issues/6093

## Description

When user creates agent from template, copilot now:
1. Detects template context via `templateId`
2. Calls `get_agent_template` to fetch `copilotInstructions`
3. Uses those instructions to guide suggestions immediately

Changes:
- Add `get_agent_template` tool to agent_copilot_context MCP server
- Pass `templateId` from `AgentBuilder` → `CopilotPanelProvider`
- Add `buildTemplateAgentInitMessage()` that instructs copilot to call both `get_agent_config` and `get_agent_template` in parallel
- Extract `buildStep3()` helper to dedupe STEP 3 across init messages

## Tests

Local + MCP tests

## Risk


## Deploy Plan