### PR TITLE
Handle hash changes in router

### DIFF
--- a/front-spa/src/app/App.tsx
+++ b/front-spa/src/app/App.tsx
@@ -14,10 +14,10 @@ import RootLayout from "@dust-tt/front/components/app/RootLayout";
 import { RegionProvider } from "@dust-tt/front/lib/auth/RegionContext";
 import { AdminLayout } from "@spa/app/layouts/AdminLayout";
 
-// Redirect component that preserves query params
+// Redirect component that preserves query params and hash
 function RedirectWithSearchParams({ to }: { to: string }) {
   const location = useLocation();
-  return <Navigate to={`${to}${location.search}`} replace />;
+  return <Navigate to={`${to}${location.search}${location.hash}`} replace />;
 }
 
 // Loading fallback component

--- a/front-spa/src/lib/platform.tsx
+++ b/front-spa/src/lib/platform.tsx
@@ -9,6 +9,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import {
@@ -139,16 +140,53 @@ export function useAppRouter(): AppRouter {
     }
   }, [location]);
 
-  // Emit routeChangeComplete when location changes (for NavigationLoadingContext)
-  const locationKey = location?.key;
+  // Emit router events when location changes
+  // Track previous location to detect hash-only changes and skip initial mount
+  const previousLocationRef = useRef<{
+    pathname: string;
+    search: string;
+    hash: string;
+  } | null>(null);
+
+  // Track location for route change events
   useEffect(() => {
-    if (locationKey) {
-      // Emit after a microtask to ensure new components have mounted
-      queueMicrotask(() => {
-        routerEvents.emit("routeChangeComplete", location?.pathname);
-      });
+    if (location) {
+      const currentLocation = {
+        pathname: location.pathname,
+        search: location.search,
+        hash: window.location.hash,
+      };
+
+      const previousLocation = previousLocationRef.current;
+
+      // Skip initial mount - don't emit event on first render
+      if (previousLocation !== null) {
+        // Only emit if pathname or search changed (not hash - that's handled by hashchange listener)
+        if (
+          previousLocation.pathname !== currentLocation.pathname ||
+          previousLocation.search !== currentLocation.search
+        ) {
+          const fullUrl = `${currentLocation.pathname}${currentLocation.search}${currentLocation.hash}`;
+          queueMicrotask(() => {
+            routerEvents.emit("routeChangeComplete", fullUrl);
+          });
+        }
+      }
+
+      previousLocationRef.current = currentLocation;
     }
-  }, [locationKey, location?.pathname]);
+  }, [location]);
+
+  // Listen for hash changes (React Router doesn't track these)
+  useEffect(() => {
+    const handleHashChange = () => {
+      const fullUrl = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+      routerEvents.emit("hashChangeComplete", fullUrl);
+    };
+
+    window.addEventListener("hashchange", handleHashChange);
+    return () => window.removeEventListener("hashchange", handleHashChange);
+  }, []);
 
   const push = useCallback(
     async (
@@ -217,6 +255,8 @@ export function useAppRouter(): AppRouter {
 
   const pathname = location?.pathname ?? window.location.pathname;
   const search = location?.search ?? window.location.search;
+  // React Router doesn't track hash - always use window.location.hash
+  const hash = window.location.hash;
 
   // In SPA mode, router is always ready (no SSR hydration needed)
   const isReady = true;
@@ -227,7 +267,7 @@ export function useAppRouter(): AppRouter {
     back,
     reload,
     pathname,
-    asPath: pathname + search,
+    asPath: pathname + search + hash,
     query,
     isReady,
     events: routerEvents,

--- a/front-spa/src/poke/PokeApp.tsx
+++ b/front-spa/src/poke/PokeApp.tsx
@@ -44,7 +44,7 @@ function PokeRedirect() {
   const params = useParams();
   const location = useLocation();
   const rest = params["*"] || "";
-  return <Navigate to={`/${rest}${location.search}`} replace />;
+  return <Navigate to={`/${rest}${location.search}${location.hash}`} replace />;
 }
 
 const router = createBrowserRouter(


### PR DESCRIPTION
## Description

fixes: https://github.com/dust-tt/tasks/issues/6367

Fix hash-based URL navigation in the SPA (React Router 7). Hash parameters were being immediately removed when navigating, breaking tab navigation and other hash-dependent features.

- React Router 7 does not track hash changes in its location.hash (always empty)
- Added native hashchange event listener to properly emit hashChangeComplete events
- Fixed asPath to include hash from window.location.hash
- Fixed redirect components to preserve hash during navigation


## Tests

- Navigate to /w/{workspace}/conversation/new
- Click on "All agents" tab - hash should persist in URL (#?selectedTab=all)
- Refresh page with hash in URL - tab selection should be preserved
- Test other hash-based navigation (e.g., space tabs)

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
