### PR TITLE
[PPUL] Remove legacy Redis-based programmatic usage tracking

### DIFF
--- a/front/lib/api/programmatic_usage/tracking.test.ts
+++ b/front/lib/api/programmatic_usage/tracking.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import {
   compareCreditsForConsumption,
   computeCreditAlertThresholdKey,
-  decreaseProgrammaticCreditsV2,
+  decreaseProgrammaticCredits,
 } from "@app/lib/api/programmatic_usage/tracking";
 import { Authenticator } from "@app/lib/auth";
 import { CreditResource } from "@app/lib/resources/credit_resource";
@@ -142,7 +142,7 @@ describe("compareCreditsForConsumption", () => {
   });
 });
 
-describe("decreaseProgrammaticCreditsV2", () => {
+describe("decreaseProgrammaticCredits", () => {
   const ONE_YEAR = 365 * 24 * 60 * 60 * 1000;
   const ONE_MONTH = 30 * 24 * 60 * 60 * 1000;
   const TWO_MONTHS = 60 * 24 * 60 * 60 * 1000;
@@ -210,7 +210,7 @@ describe("decreaseProgrammaticCreditsV2", () => {
         new Date(Date.now() + ONE_YEAR)
       );
 
-      await decreaseProgrammaticCreditsV2(
+      await decreaseProgrammaticCredits(
         auth,
         {
           amountMicroUsd: 3_000_000,
@@ -230,7 +230,7 @@ describe("decreaseProgrammaticCreditsV2", () => {
         new Date(Date.now() + ONE_YEAR)
       );
 
-      await decreaseProgrammaticCreditsV2(
+      await decreaseProgrammaticCredits(
         auth,
         {
           amountMicroUsd: 10_000_000,
@@ -244,7 +244,7 @@ describe("decreaseProgrammaticCreditsV2", () => {
     });
 
     it("should not throw when no credits are available", async () => {
-      await decreaseProgrammaticCreditsV2(
+      await decreaseProgrammaticCredits(
         auth,
         {
           amountMicroUsd: 10_000_000,
@@ -262,7 +262,7 @@ describe("decreaseProgrammaticCreditsV2", () => {
         new Date(Date.now() + ONE_YEAR)
       );
 
-      await decreaseProgrammaticCreditsV2(
+      await decreaseProgrammaticCredits(
         auth,
         {
           amountMicroUsd: 0,
@@ -289,7 +289,7 @@ describe("decreaseProgrammaticCreditsV2", () => {
         new Date(Date.now() + ONE_YEAR)
       );
 
-      await decreaseProgrammaticCreditsV2(
+      await decreaseProgrammaticCredits(
         auth,
         {
           amountMicroUsd: 3_000_000,
@@ -317,7 +317,7 @@ describe("decreaseProgrammaticCreditsV2", () => {
         new Date(Date.now() + ONE_YEAR)
       );
 
-      await decreaseProgrammaticCreditsV2(
+      await decreaseProgrammaticCredits(
         auth,
         {
           amountMicroUsd: 3_000_000,
@@ -354,7 +354,7 @@ describe("decreaseProgrammaticCreditsV2", () => {
       // 1. freeCredit (200)
       // 2. committedCredit (200)
       // 3. paygCredit (100)
-      await decreaseProgrammaticCreditsV2(
+      await decreaseProgrammaticCredits(
         auth,
         {
           amountMicroUsd: 5_000_000,
@@ -386,7 +386,7 @@ describe("decreaseProgrammaticCreditsV2", () => {
         new Date(Date.now() + TWO_MONTHS)
       );
 
-      await decreaseProgrammaticCreditsV2(
+      await decreaseProgrammaticCredits(
         auth,
         {
           amountMicroUsd: 3_000_000,
@@ -414,7 +414,7 @@ describe("decreaseProgrammaticCreditsV2", () => {
         new Date(Date.now() + TWO_MONTHS)
       );
 
-      await decreaseProgrammaticCreditsV2(
+      await decreaseProgrammaticCredits(
         auth,
         {
           amountMicroUsd: 5_000_000,
@@ -445,7 +445,7 @@ describe("decreaseProgrammaticCreditsV2", () => {
         new Date(Date.now() + 6 * ONE_MONTH)
       );
 
-      await decreaseProgrammaticCreditsV2(
+      await decreaseProgrammaticCredits(
         auth,
         {
           amountMicroUsd: 3_000_000,
@@ -495,7 +495,7 @@ describe("decreaseProgrammaticCreditsV2", () => {
       // 2. freeLater (100)
       // 3. committedEarlier (100)
       // 4. paygEarlier (50)
-      await decreaseProgrammaticCreditsV2(
+      await decreaseProgrammaticCredits(
         auth,
         {
           amountMicroUsd: 3_500_000,

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -25,7 +25,6 @@ import type {
   LightWorkspaceType,
   MembershipOriginType,
   MembershipRoleType,
-  PublicAPILimitsType,
   Result,
   RoleType,
   SubscriptionType,
@@ -404,7 +403,6 @@ export async function deleteWorkspace(
 
 export interface WorkspaceMetadata {
   maintenance?: "relocation" | "relocation-done";
-  publicApiLimits?: PublicAPILimitsType;
   allowContentCreationFileSharing?: boolean;
   allowVoiceTranscription?: boolean;
   autoCreateSpaceForProvisionedGroups?: boolean;
@@ -441,13 +439,6 @@ export function isWorkspaceRelocationOngoing(
 
 export function isWorkspaceRelocationDone(owner: LightWorkspaceType): boolean {
   return owner.metadata?.maintenance === "relocation-done";
-}
-
-export function getWorkspacePublicAPILimits(
-  owner: LightWorkspaceType
-): PublicAPILimitsType | null {
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-  return owner.metadata?.publicApiLimits || null;
 }
 
 export async function updateExtensionConfiguration(

--- a/front/migrations/20251126_backfill_programmatic_usage_configurations.ts
+++ b/front/migrations/20251126_backfill_programmatic_usage_configurations.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck - Legacy migration kept for reference, uses removed getWorkspacePublicAPILimits
 import { getWorkspacePublicAPILimits } from "@app/lib/api/workspace";
 import { Authenticator } from "@app/lib/auth";
 import { isEntreprisePlanPrefix } from "@app/lib/plans/plan_codes";

--- a/front/migrations/20251202_fix_programmatic_credits_cents_conversion.ts
+++ b/front/migrations/20251202_fix_programmatic_credits_cents_conversion.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck - Legacy migration kept for reference, uses removed getWorkspacePublicAPILimits
 import { getWorkspacePublicAPILimits } from "@app/lib/api/workspace";
 import { runOnRedis } from "@app/lib/api/redis";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";

--- a/front/types/user.ts
+++ b/front/types/user.ts
@@ -40,21 +40,6 @@ export function isActiveRoleType(role: string): role is ActiveRoleType {
   return ACTIVE_ROLES.includes(role as ActiveRoleType);
 }
 
-type PublicAPILimitsEnabled = {
-  enabled: true;
-  markup: number;
-  monthlyLimit: number; // in USD
-  billingDay: number; // Best-effort, represents the day of the month when the billing period starts.
-};
-
-type PublicAPILimitsDisabled = {
-  enabled: false;
-};
-
-export type PublicAPILimitsType =
-  | PublicAPILimitsEnabled
-  | PublicAPILimitsDisabled;
-
 export type LightWorkspaceType = {
   id: ModelId;
   sId: string;
@@ -64,7 +49,6 @@ export type LightWorkspaceType = {
   whiteListedProviders: ModelProviderIdType[] | null;
   defaultEmbeddingProvider: EmbeddingProviderIdType | null;
   metadata: {
-    publicApiLimits?: PublicAPILimitsType;
     [key: string]: string | number | boolean | object | undefined;
   } | null;
   workOSOrganizationId?: string | null;


### PR DESCRIPTION
## Description

Fixes https://github.com/dust-tt/tasks/issues/5298
Removes the legacy Redis-based programmatic usage tracking system that was superseded by the new credits-based system (V2).

Changes:
- Remove `decreaseProgrammaticCredits` and `initializeCredits` functions (legacy Redis tracking)
- Remove `getWorkspacePublicAPILimits` helper and `PublicAPILimitsType` type
- Remove `publicApiLimits` from `WorkspaceMetadata` and `LightWorkspaceType.metadata`
- Rename `decreaseProgrammaticCreditsV2` to `decreaseProgrammaticCredits`
- Add `@ts-nocheck` to legacy migration files that reference the removed code

Note: The `publicApiLimits` field remains in existing workspace metadata in the database but is no longer used. A migration to clean this up was deemed unnecessary as the data is inert.

## Risks

Blast radius: Programmatic usage tracking for API calls
Risk: low (removing unused code, new system already in place)

## Deploy Plan
- pmrr
- deploy front