### PR TITLE
Strip all spaces except the project one when updating project conversation requirements.

### DIFF
--- a/front/lib/api/assistant/conversation/mentions.test.ts
+++ b/front/lib/api/assistant/conversation/mentions.test.ts
@@ -13,6 +13,7 @@ import {
   createAgentMessages,
   createUserMentions,
   createUserMessage,
+  updateConversationRequirements,
   validateUserMention,
 } from "@app/lib/api/assistant/conversation/mentions";
 import { Authenticator } from "@app/lib/auth";
@@ -44,6 +45,7 @@ import { UserFactory } from "@app/tests/utils/UserFactory";
 import type {
   AgenticMessageData,
   AgentMention,
+  ContentFragmentInputWithContentNode,
   ConversationType,
   ConversationWithoutContentType,
   LightAgentConfigurationType,
@@ -3788,6 +3790,643 @@ describe("validateUserMention", () => {
         },
       });
       expect(mention?.status).toBe("approved");
+    });
+  });
+});
+
+describe("updateConversationRequirements", () => {
+  let workspace: WorkspaceType;
+  let auth: Authenticator;
+  let projectSpace: Awaited<ReturnType<typeof SpaceFactory.project>>;
+  let anotherProjectSpace: Awaited<ReturnType<typeof SpaceFactory.project>>;
+
+  beforeEach(async () => {
+    const setup = await createResourceTest({});
+    workspace = setup.workspace;
+    auth = setup.authenticator;
+
+    // Create project spaces
+    projectSpace = await SpaceFactory.project(workspace);
+    anotherProjectSpace = await SpaceFactory.project(workspace);
+
+    // Add user to project spaces
+    const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
+      workspace.sId
+    );
+    const user = auth.getNonNullableUser();
+    const userJson = user.toJSON();
+
+    const projectSpaceGroup = projectSpace.groups.find(
+      (g) => g.kind === "regular"
+    );
+    const anotherProjectSpaceGroup = anotherProjectSpace.groups.find(
+      (g) => g.kind === "regular"
+    );
+
+    if (projectSpaceGroup) {
+      const addRes = await projectSpaceGroup.addMember(internalAdminAuth, {
+        user: userJson,
+      });
+      if (addRes.isErr()) {
+        throw new Error(
+          `Failed to add user to project space group: ${addRes.error.message}`
+        );
+      }
+    }
+
+    if (anotherProjectSpaceGroup) {
+      const addRes = await anotherProjectSpaceGroup.addMember(
+        internalAdminAuth,
+        {
+          user: userJson,
+        }
+      );
+      if (addRes.isErr()) {
+        throw new Error(
+          `Failed to add user to another project space group: ${addRes.error.message}`
+        );
+      }
+    }
+
+    await auth.refresh();
+  });
+
+  describe("project conversations", () => {
+    it("should set requestedSpaceIds to only the project space", async () => {
+      // Create a project conversation
+      const conversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: "test-agent",
+        messagesCreatedAt: [],
+        spaceId: projectSpace.id,
+      });
+
+      // Create agents with different space requirements
+      const agent1 = await AgentConfigurationFactory.createTestAgent(auth, {
+        name: "Agent 1",
+      });
+      const agent2 = await AgentConfigurationFactory.createTestAgent(auth, {
+        name: "Agent 2",
+      });
+
+      // Update agents to have space requirements
+      const { AgentConfigurationModel } = await import(
+        "@app/lib/models/agent/agent"
+      );
+      await AgentConfigurationModel.update(
+        { requestedSpaceIds: [anotherProjectSpace.id] },
+        {
+          where: {
+            sId: agent1.sId,
+            workspaceId: workspace.id,
+          },
+          hooks: false,
+          silent: true,
+        }
+      );
+
+      // Fetch conversation to get the full type
+      const fetchedConversationResult = await getConversation(
+        auth,
+        conversation.sId
+      );
+      if (fetchedConversationResult.isErr()) {
+        throw new Error("Failed to fetch conversation");
+      }
+      const projectConversation = fetchedConversationResult.value;
+
+      // Call updateConversationRequirements with agents that have different space requirements
+      await updateConversationRequirements(auth, {
+        agents: [agent1, agent2],
+        conversation: projectConversation,
+      });
+
+      // Verify the conversation requirements are set to only the project space
+      const updatedConversationResult = await getConversation(
+        auth,
+        conversation.sId
+      );
+      if (updatedConversationResult.isErr()) {
+        throw new Error("Failed to fetch updated conversation");
+      }
+      const updatedConversation = updatedConversationResult.value;
+
+      expect(updatedConversation.requestedSpaceIds).toHaveLength(1);
+      expect(updatedConversation.requestedSpaceIds[0]).toBe(projectSpace.sId);
+    });
+
+    it("should not update if requirements are already correct", async () => {
+      // Create a project conversation
+      const conversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: "test-agent",
+        messagesCreatedAt: [],
+        spaceId: projectSpace.id,
+      });
+
+      // Manually set the requirements to the project space
+      await ConversationResource.updateRequirements(auth, conversation.sId, [
+        projectSpace.id,
+      ]);
+
+      // Fetch conversation
+      const fetchedConversationResult = await getConversation(
+        auth,
+        conversation.sId
+      );
+      if (fetchedConversationResult.isErr()) {
+        throw new Error("Failed to fetch conversation");
+      }
+      const projectConversation = fetchedConversationResult.value;
+
+      // Verify initial state
+      expect(projectConversation.requestedSpaceIds).toHaveLength(1);
+      expect(projectConversation.requestedSpaceIds[0]).toBe(projectSpace.sId);
+
+      // Call updateConversationRequirements - should not update
+      await updateConversationRequirements(auth, {
+        agents: [],
+        conversation: projectConversation,
+      });
+
+      // Verify requirements are unchanged
+      const updatedConversationResult = await getConversation(
+        auth,
+        conversation.sId
+      );
+      if (updatedConversationResult.isErr()) {
+        throw new Error("Failed to fetch updated conversation");
+      }
+      const updatedConversation = updatedConversationResult.value;
+
+      expect(updatedConversation.requestedSpaceIds).toHaveLength(1);
+      expect(updatedConversation.requestedSpaceIds[0]).toBe(projectSpace.sId);
+    });
+  });
+
+  describe("regular conversations", () => {
+    it("should add space requirements from agents", async () => {
+      // Create a regular conversation (no spaceId)
+      const conversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: "test-agent",
+        messagesCreatedAt: [],
+        visibility: "unlisted",
+      });
+
+      // Create agents with space requirements
+      const agent1 = await AgentConfigurationFactory.createTestAgent(auth, {
+        name: "Agent 1",
+      });
+      const agent2 = await AgentConfigurationFactory.createTestAgent(auth, {
+        name: "Agent 2",
+      });
+
+      // Update agents to have space requirements
+      const { AgentConfigurationModel } = await import(
+        "@app/lib/models/agent/agent"
+      );
+      await AgentConfigurationModel.update(
+        { requestedSpaceIds: [projectSpace.id] },
+        {
+          where: {
+            sId: agent1.sId,
+            workspaceId: workspace.id,
+          },
+          hooks: false,
+          silent: true,
+        }
+      );
+      await AgentConfigurationModel.update(
+        { requestedSpaceIds: [anotherProjectSpace.id] },
+        {
+          where: {
+            sId: agent2.sId,
+            workspaceId: workspace.id,
+          },
+          hooks: false,
+          silent: true,
+        }
+      );
+
+      // Fetch agents with updated requirements
+      const { getAgentConfigurations } = await import(
+        "@app/lib/api/assistant/configuration/agent"
+      );
+      const agents = await getAgentConfigurations(auth, {
+        agentIds: [agent1.sId, agent2.sId],
+        variant: "light",
+      });
+
+      // Fetch conversation
+      const fetchedConversationResult = await getConversation(
+        auth,
+        conversation.sId
+      );
+      if (fetchedConversationResult.isErr()) {
+        throw new Error("Failed to fetch conversation");
+      }
+      const regularConversation = fetchedConversationResult.value;
+
+      // Call updateConversationRequirements
+      await updateConversationRequirements(auth, {
+        agents,
+        conversation: regularConversation,
+      });
+
+      // Verify the conversation requirements include both spaces
+      const updatedConversationResult = await getConversation(
+        auth,
+        conversation.sId
+      );
+      if (updatedConversationResult.isErr()) {
+        throw new Error("Failed to fetch updated conversation");
+      }
+      const updatedConversation = updatedConversationResult.value;
+
+      expect(updatedConversation.requestedSpaceIds.length).toBeGreaterThan(0);
+      expect(updatedConversation.requestedSpaceIds).toContain(projectSpace.sId);
+      expect(updatedConversation.requestedSpaceIds).toContain(
+        anotherProjectSpace.sId
+      );
+    });
+
+    it("should add space requirements from content fragments", async () => {
+      const { DataSourceViewFactory } = await import(
+        "@app/tests/utils/DataSourceViewFactory"
+      );
+
+      // Create a regular conversation
+      const conversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: "test-agent",
+        messagesCreatedAt: [],
+        visibility: "unlisted",
+      });
+
+      // Create a data source view in a project space
+      const dsView = await DataSourceViewFactory.folder(
+        workspace,
+        projectSpace,
+        auth.user() ?? null
+      );
+
+      // Create content fragment input
+      const contentFragment: ContentFragmentInputWithContentNode = {
+        title: "Test Fragment",
+        nodeId: "test-node-id",
+        nodeDataSourceViewId: dsView.sId,
+      };
+
+      // Fetch conversation
+      const fetchedConversationResult = await getConversation(
+        auth,
+        conversation.sId
+      );
+      if (fetchedConversationResult.isErr()) {
+        throw new Error("Failed to fetch conversation");
+      }
+      const regularConversation = fetchedConversationResult.value;
+
+      // Call updateConversationRequirements with content fragment
+      await updateConversationRequirements(auth, {
+        contentFragment,
+        conversation: regularConversation,
+      });
+
+      // Verify the conversation requirements include the space from the content fragment
+      const updatedConversationResult = await getConversation(
+        auth,
+        conversation.sId
+      );
+      if (updatedConversationResult.isErr()) {
+        throw new Error("Failed to fetch updated conversation");
+      }
+      const updatedConversation = updatedConversationResult.value;
+
+      expect(updatedConversation.requestedSpaceIds).toContain(projectSpace.sId);
+    });
+
+    it("should add space requirements from both agents and content fragments", async () => {
+      const { DataSourceViewFactory } = await import(
+        "@app/tests/utils/DataSourceViewFactory"
+      );
+
+      // Create a regular conversation
+      const conversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: "test-agent",
+        messagesCreatedAt: [],
+        visibility: "unlisted",
+      });
+
+      // Create an agent with space requirements
+      const agent = await AgentConfigurationFactory.createTestAgent(auth, {
+        name: "Agent 1",
+      });
+
+      const { AgentConfigurationModel } = await import(
+        "@app/lib/models/agent/agent"
+      );
+      await AgentConfigurationModel.update(
+        { requestedSpaceIds: [projectSpace.id] },
+        {
+          where: {
+            sId: agent.sId,
+            workspaceId: workspace.id,
+          },
+          hooks: false,
+          silent: true,
+        }
+      );
+
+      // Create a data source view in another project space
+      const dsView = await DataSourceViewFactory.folder(
+        workspace,
+        anotherProjectSpace,
+        auth.user() ?? null
+      );
+
+      const contentFragment: ContentFragmentInputWithContentNode = {
+        title: "Test Fragment",
+        nodeId: "test-node-id",
+        nodeDataSourceViewId: dsView.sId,
+      };
+
+      // Fetch agents and conversation
+      const { getAgentConfigurations } = await import(
+        "@app/lib/api/assistant/configuration/agent"
+      );
+      const agents = await getAgentConfigurations(auth, {
+        agentIds: [agent.sId],
+        variant: "light",
+      });
+
+      const fetchedConversationResult = await getConversation(
+        auth,
+        conversation.sId
+      );
+      if (fetchedConversationResult.isErr()) {
+        throw new Error("Failed to fetch conversation");
+      }
+      const regularConversation = fetchedConversationResult.value;
+
+      // Call updateConversationRequirements with both
+      await updateConversationRequirements(auth, {
+        agents,
+        contentFragment,
+        conversation: regularConversation,
+      });
+
+      // Verify the conversation requirements include both spaces
+      const updatedConversationResult = await getConversation(
+        auth,
+        conversation.sId
+      );
+      if (updatedConversationResult.isErr()) {
+        throw new Error("Failed to fetch updated conversation");
+      }
+      const updatedConversation = updatedConversationResult.value;
+
+      expect(updatedConversation.requestedSpaceIds).toContain(projectSpace.sId);
+      expect(updatedConversation.requestedSpaceIds).toContain(
+        anotherProjectSpace.sId
+      );
+    });
+
+    it("should not duplicate existing space requirements", async () => {
+      // Create a regular conversation
+      const conversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: "test-agent",
+        messagesCreatedAt: [],
+        visibility: "unlisted",
+      });
+
+      // Manually set initial requirements
+      await ConversationResource.updateRequirements(auth, conversation.sId, [
+        projectSpace.id,
+      ]);
+
+      // Create an agent with the same space requirement
+      const agent = await AgentConfigurationFactory.createTestAgent(auth, {
+        name: "Agent 1",
+      });
+
+      const { AgentConfigurationModel } = await import(
+        "@app/lib/models/agent/agent"
+      );
+      await AgentConfigurationModel.update(
+        { requestedSpaceIds: [projectSpace.id] },
+        {
+          where: {
+            sId: agent.sId,
+            workspaceId: workspace.id,
+          },
+          hooks: false,
+          silent: true,
+        }
+      );
+
+      // Fetch agent and conversation
+      const { getAgentConfigurations } = await import(
+        "@app/lib/api/assistant/configuration/agent"
+      );
+      const agents = await getAgentConfigurations(auth, {
+        agentIds: [agent.sId],
+        variant: "light",
+      });
+
+      const fetchedConversationResult = await getConversation(
+        auth,
+        conversation.sId
+      );
+      if (fetchedConversationResult.isErr()) {
+        throw new Error("Failed to fetch conversation");
+      }
+      const regularConversation = fetchedConversationResult.value;
+
+      // Call updateConversationRequirements
+      await updateConversationRequirements(auth, {
+        agents,
+        conversation: regularConversation,
+      });
+
+      // Verify requirements are not duplicated
+      const updatedConversationResult = await getConversation(
+        auth,
+        conversation.sId
+      );
+      if (updatedConversationResult.isErr()) {
+        throw new Error("Failed to fetch updated conversation");
+      }
+      const updatedConversation = updatedConversationResult.value;
+
+      const projectSpaceIdCount = updatedConversation.requestedSpaceIds.filter(
+        (id) => id === projectSpace.sId
+      ).length;
+      expect(projectSpaceIdCount).toBe(1);
+    });
+
+    it("should handle agents with no space requirements", async () => {
+      // Create a regular conversation
+      const conversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: "test-agent",
+        messagesCreatedAt: [],
+        visibility: "unlisted",
+      });
+
+      // Create an agent with no space requirements (empty array)
+      const agent = await AgentConfigurationFactory.createTestAgent(auth, {
+        name: "Agent 1",
+      });
+
+      // Fetch agent and conversation
+      const { getAgentConfigurations } = await import(
+        "@app/lib/api/assistant/configuration/agent"
+      );
+      const agents = await getAgentConfigurations(auth, {
+        agentIds: [agent.sId],
+        variant: "light",
+      });
+
+      const fetchedConversationResult = await getConversation(
+        auth,
+        conversation.sId
+      );
+      if (fetchedConversationResult.isErr()) {
+        throw new Error("Failed to fetch conversation");
+      }
+      const regularConversation = fetchedConversationResult.value;
+
+      // Call updateConversationRequirements
+      await updateConversationRequirements(auth, {
+        agents,
+        conversation: regularConversation,
+      });
+
+      // Verify requirements are unchanged (no new requirements added)
+      const updatedConversationResult = await getConversation(
+        auth,
+        conversation.sId
+      );
+      if (updatedConversationResult.isErr()) {
+        throw new Error("Failed to fetch updated conversation");
+      }
+      const updatedConversation = updatedConversationResult.value;
+
+      // Should have no new requirements added
+      expect(updatedConversation.requestedSpaceIds.length).toBe(
+        regularConversation.requestedSpaceIds.length
+      );
+    });
+
+    it("should handle empty agents and content fragments", async () => {
+      // Create a regular conversation
+      const conversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: "test-agent",
+        messagesCreatedAt: [],
+        visibility: "unlisted",
+      });
+
+      // Fetch conversation
+      const fetchedConversationResult = await getConversation(
+        auth,
+        conversation.sId
+      );
+      if (fetchedConversationResult.isErr()) {
+        throw new Error("Failed to fetch conversation");
+      }
+      const regularConversation = fetchedConversationResult.value;
+
+      const initialRequirements = regularConversation.requestedSpaceIds.length;
+
+      // Call updateConversationRequirements with empty inputs
+      await updateConversationRequirements(auth, {
+        agents: [],
+        conversation: regularConversation,
+      });
+
+      // Verify requirements are unchanged
+      const updatedConversationResult = await getConversation(
+        auth,
+        conversation.sId
+      );
+      if (updatedConversationResult.isErr()) {
+        throw new Error("Failed to fetch updated conversation");
+      }
+      const updatedConversation = updatedConversationResult.value;
+
+      expect(updatedConversation.requestedSpaceIds.length).toBe(
+        initialRequirements
+      );
+    });
+
+    it("should preserve existing requirements when adding new ones", async () => {
+      // Create a regular conversation
+      const conversation = await ConversationFactory.create(auth, {
+        agentConfigurationId: "test-agent",
+        messagesCreatedAt: [],
+        visibility: "unlisted",
+      });
+
+      // Manually set initial requirements
+      await ConversationResource.updateRequirements(auth, conversation.sId, [
+        projectSpace.id,
+      ]);
+
+      // Create an agent with a different space requirement
+      const agent = await AgentConfigurationFactory.createTestAgent(auth, {
+        name: "Agent 1",
+      });
+
+      const { AgentConfigurationModel } = await import(
+        "@app/lib/models/agent/agent"
+      );
+      await AgentConfigurationModel.update(
+        { requestedSpaceIds: [anotherProjectSpace.id] },
+        {
+          where: {
+            sId: agent.sId,
+            workspaceId: workspace.id,
+          },
+          hooks: false,
+          silent: true,
+        }
+      );
+
+      // Fetch agent and conversation
+      const { getAgentConfigurations } = await import(
+        "@app/lib/api/assistant/configuration/agent"
+      );
+      const agents = await getAgentConfigurations(auth, {
+        agentIds: [agent.sId],
+        variant: "light",
+      });
+
+      const fetchedConversationResult = await getConversation(
+        auth,
+        conversation.sId
+      );
+      if (fetchedConversationResult.isErr()) {
+        throw new Error("Failed to fetch conversation");
+      }
+      const regularConversation = fetchedConversationResult.value;
+
+      // Call updateConversationRequirements
+      await updateConversationRequirements(auth, {
+        agents,
+        conversation: regularConversation,
+      });
+
+      // Verify both old and new requirements are present
+      const updatedConversationResult = await getConversation(
+        auth,
+        conversation.sId
+      );
+      if (updatedConversationResult.isErr()) {
+        throw new Error("Failed to fetch updated conversation");
+      }
+      const updatedConversation = updatedConversationResult.value;
+
+      expect(updatedConversation.requestedSpaceIds).toContain(projectSpace.sId);
+      expect(updatedConversation.requestedSpaceIds).toContain(
+        anotherProjectSpace.sId
+      );
     });
   });
 });

--- a/front/lib/api/assistant/conversation/mentions.test.ts
+++ b/front/lib/api/assistant/conversation/mentions.test.ts
@@ -1346,7 +1346,7 @@ describe("createAgentMessages", () => {
       expect(mentionInDb?.status).toBe("approved");
     });
 
-    it("should reject agent mentions when agent uses open (non-global) spaces other than conversation's space", async () => {
+    it("should allow agent mentions when agent uses open spaces other than conversation's space", async () => {
       // Create a space for the conversation
       const conversationSpace = await SpaceFactory.regular(workspace);
       const user = auth.getNonNullableUser();
@@ -1472,17 +1472,18 @@ describe("createAgentMessages", () => {
         }
       );
 
-      // Should NOT create agent message because open (non-global) spaces are rejected
-      expect(agentMessages).toHaveLength(0);
+      // Should create agent message successfully because open spaces are now allowed
+      expect(agentMessages).toHaveLength(1);
+      expect(agentMessages[0].configuration.sId).toBe(agentConfig.sId);
 
-      // Verify richMentions shows the restriction
+      // Verify richMentions are returned correctly
       expect(richMentions).toHaveLength(1);
       if (isRichAgentMention(richMentions[0])) {
         expect(richMentions[0].id).toBe(agentConfig.sId);
-        expect(richMentions[0].status).toBe("agent_restricted_by_space_usage");
+        expect(richMentions[0].status).toBe("approved");
       }
 
-      // Verify mention was created with restricted status
+      // Verify mention was created with approved status
       const mentionInDb = await MentionModel.findOne({
         where: {
           workspaceId: workspace.id,
@@ -1491,7 +1492,7 @@ describe("createAgentMessages", () => {
         },
       });
       expect(mentionInDb).not.toBeNull();
-      expect(mentionInDb?.status).toBe("agent_restricted_by_space_usage");
+      expect(mentionInDb?.status).toBe("approved");
     });
   });
 });

--- a/front/lib/api/assistant/conversation/mentions.ts
+++ b/front/lib/api/assistant/conversation/mentions.ts
@@ -316,7 +316,7 @@ export async function canAgentBeUsedInProjectConversation(
   if (!isProjectConversation(conversation)) {
     throw new Error("Unexpected: conversation is not a project conversation");
   }
-  // In case of Project's conversation, we need to check if the agent configuration is using only the project spaces or public spaces, otherwise we reject the mention and do not create the agent message.
+  // In case of Project's conversation, we need to check if the agent configuration is using only the project spaces or open spaces, otherwise we reject the mention and do not create the agent message.
   // Check to skip heavy work if the agent configuration is only using the project space.
   if (
     configuration.requestedSpaceIds.some(
@@ -330,7 +330,7 @@ export async function canAgentBeUsedInProjectConversation(
         (spaceId) => spaceId !== conversation.spaceId
       )
     );
-    if (spaces.some((space) => !space.isGlobal())) {
+    if (spaces.some((space) => !space.isOpen())) {
       return false;
     }
   }


### PR DESCRIPTION
## Description

Enforce that a project conversation is always available to all viewers / members of a space by striping space requirements except the project's space itself.

Will be useful to:
- move a conversation to a project (upcoming)
- use agents with open spaces that might become restricted later (upcoming)

As a reminder, right now in a project:
- you can only use agents that do use the global space or the project's space
- you can only attach to the convo content nodes from the global space

## Tests

Added

## Risk

Low at the moment (projects are behind FF) but this is a significant changes on how conversations's requestedSpaceIds work.

## Deploy Plan

Deploy front