### PR TITLE
[front] - fix(spaces): tools search

### DIFF
--- a/front/components/actions/mcp/AdminActionsList.tsx
+++ b/front/components/actions/mcp/AdminActionsList.tsx
@@ -219,8 +219,20 @@ export const AdminActionsList = ({
         cell: (info: CellContext<RowData, string>) => (
           <NameCell row={info.row.original} />
         ),
-        filterFn: (row, id, filterValue) =>
-          filterMCPServer(row.original.mcpServer, filterValue),
+        filterFn: (row, _, filterValue) => {
+          const { mcpServer, mcpServerView } = row.original;
+          const filterLower = filterValue.toLowerCase();
+
+          // Check base server properties (name, description, tools).
+          if (filterMCPServer(mcpServer, filterValue)) {
+            return true;
+          }
+          // Check display name (may differ from server name due to custom view name or formatting).
+          const displayName = mcpServerView
+            ? getMcpServerViewDisplayName(mcpServerView)
+            : getMcpServerDisplayName(mcpServer);
+          return displayName.toLowerCase().includes(filterLower);
+        },
         sortingFn: (rowA, rowB) => {
           return mcpServersSortingFn(
             {


### PR DESCRIPTION
## Description

Fixes MCP server filtering in the Tools administration list to include display name matching. 

Previously, the filter only checked server name, description, and tool names, but users can edit display names via MCP server views, which were being ignored during filtering

## Risk

Low

## Tests

Locallly

## Deploy Plan

Deploy front