### PR TITLE
[front] Allow Go deep to inherit agent data sources

### DIFF
--- a/front/lib/resources/skill/global/go_deep.ts
+++ b/front/lib/resources/skill/global/go_deep.ts
@@ -35,4 +35,5 @@ export const goDeepSkill = {
   version: 2,
   icon: "ActionAtomIcon",
   isRestricted: isDeepDiveDisabledByAdmin,
+  inheritAgentConfigurationDataSources: true,
 } as const satisfies GlobalSkillDefinition;


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/6374.
- Context in [thread](https://dust4ai.slack.com/archives/C05F84CFP0E/p1770292761096239).
- This PR fixes an issue where the tools added via Go deep (dsfs, dw) do not have access to the agent's data sources.
- Rationale is that the skill now allows the main agent to do stuff instead of offloading to a sub agent, so it needs access to the data sources.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
