### PR TITLE
Add copilot origin to new messages

### DIFF
--- a/front/lib/api/actions/servers/helpers.ts
+++ b/front/lib/api/actions/servers/helpers.ts
@@ -22,6 +22,10 @@ function extractCopilotMetadata(
   return null;
 }
 
+export function isCopilotConversation(metadata: ConversationMetadata): boolean {
+  return extractCopilotMetadata(metadata) !== null;
+}
+
 /**
  * Extracts the copilot metadata from the agent loop context.
  *


### PR DESCRIPTION
## Description

* Copilot conversations would trigger an email notification if agent replied (which we do not want) because the subsequent conversation messages did not have the proper origin
* Preferring server side derivation so we can use the conversation metadata as a single source of truth and we don't need to expose the enum via api

## Tests

* Local copilot validation

## Risk

* No intended consequences

## Deploy Plan

* Deploy front