### PR TITLE
[Dust CLI] Add --projectName and --projectId flags for conversation creation

### DIFF
--- a/cli/src/index.tsx
+++ b/cli/src/index.tsx
@@ -88,6 +88,14 @@ const cli = meow({
       description:
         "Resume a conversation by ID, or pass no value to pick from recent",
     },
+    projectName: {
+      type: "string",
+      description: "Create conversation in a project by name",
+    },
+    projectId: {
+      type: "string",
+      description: "Create conversation in a project by space ID",
+    },
   },
 });
 

--- a/cli/src/ui/App.tsx
+++ b/cli/src/ui/App.tsx
@@ -72,6 +72,12 @@ interface AppProps {
       type: "string";
       shortFlag: "r";
     };
+    projectName: {
+      type: "string";
+    };
+    projectId: {
+      type: "string";
+    };
   }>;
 }
 
@@ -123,6 +129,8 @@ const App: FC<AppProps> = ({ cli }) => {
             conversationId={flags.conversationId}
             messageId={flags.messageId}
             details={flags.details}
+            projectName={flags.projectName}
+            projectId={flags.projectId}
           />
         );
       }
@@ -133,6 +141,8 @@ const App: FC<AppProps> = ({ cli }) => {
           agentSearch={flags.agent}
           conversationId={effectiveConversationId}
           autoAcceptEditsFlag={flags.auto}
+          projectName={flags.projectName}
+          projectId={flags.projectId}
         />
       );
     case "skill:init":

--- a/cli/src/ui/Help.tsx
+++ b/cli/src/ui/Help.tsx
@@ -124,6 +124,18 @@ const Help: FC = () => {
           with --api-key)
         </Text>
       </Box>
+      <Box marginLeft={2}>
+        <Text>
+          <Text bold>--projectName</Text> Create conversation in a project by
+          name
+        </Text>
+      </Box>
+      <Box marginLeft={2}>
+        <Text>
+          <Text bold>--projectId</Text> Create conversation in a project by
+          space ID
+        </Text>
+      </Box>
       <Box marginTop={1}>
         <Text>Environment Variables:</Text>
       </Box>

--- a/cli/src/ui/commands/NonInteractiveChat.tsx
+++ b/cli/src/ui/commands/NonInteractiveChat.tsx
@@ -31,27 +31,24 @@ const NonInteractiveChat: FC<NonInteractiveChatProps> = ({
 }) => {
   const [error, setError] = useState<string | null>(null);
 
-  // Validate flags usage
+  // Handle all non-interactive operations with fail-fast validation
   useEffect(() => {
-    try {
-      validateNonInteractiveFlags(
+    async function handleNonInteractive() {
+      // Validate flags first - fail fast before any side effects
+      const validationError = validateNonInteractiveFlags(
         message,
         agentSearch,
         conversationId,
         messageId,
         details,
         projectName,
-        projectId,
-        setError
+        projectId
       );
-    } catch (err) {
-      setError(normalizeError(err).message);
-    }
-  }, [message, agentSearch, conversationId, messageId, details, projectName, projectId]);
+      if (validationError) {
+        setError(validationError);
+        return;
+      }
 
-  // Handle all non-interactive operations
-  useEffect(() => {
-    async function handleNonInteractive() {
       try {
         // Handle messageId mode - fetch agent message from conversation
         if (messageId && conversationId) {
@@ -155,7 +152,15 @@ const NonInteractiveChat: FC<NonInteractiveChatProps> = ({
     }
 
     void handleNonInteractive();
-  }, [message, agentSearch, conversationId, messageId, details, projectName, projectId]);
+  }, [
+    message,
+    agentSearch,
+    conversationId,
+    messageId,
+    details,
+    projectName,
+    projectId,
+  ]);
 
   if (error) {
     return (

--- a/cli/src/ui/commands/NonInteractiveChat.tsx
+++ b/cli/src/ui/commands/NonInteractiveChat.tsx
@@ -16,6 +16,8 @@ interface NonInteractiveChatProps {
   conversationId?: string;
   messageId?: string;
   details?: boolean;
+  projectName?: string;
+  projectId?: string;
 }
 
 const NonInteractiveChat: FC<NonInteractiveChatProps> = ({
@@ -24,6 +26,8 @@ const NonInteractiveChat: FC<NonInteractiveChatProps> = ({
   conversationId,
   messageId,
   details,
+  projectName,
+  projectId,
 }) => {
   const [error, setError] = useState<string | null>(null);
 
@@ -36,12 +40,14 @@ const NonInteractiveChat: FC<NonInteractiveChatProps> = ({
         conversationId,
         messageId,
         details,
+        projectName,
+        projectId,
         setError
       );
     } catch (err) {
       setError(normalizeError(err).message);
     }
-  }, [message, agentSearch, conversationId, messageId, details]);
+  }, [message, agentSearch, conversationId, messageId, details, projectName, projectId]);
 
   // Handle all non-interactive operations
   useEffect(() => {
@@ -139,6 +145,8 @@ const NonInteractiveChat: FC<NonInteractiveChatProps> = ({
           me,
           conversationId,
           details,
+          projectName,
+          projectId,
           setError
         );
       } catch (error) {
@@ -147,7 +155,7 @@ const NonInteractiveChat: FC<NonInteractiveChatProps> = ({
     }
 
     void handleNonInteractive();
-  }, [message, agentSearch, conversationId, messageId, details]);
+  }, [message, agentSearch, conversationId, messageId, details, projectName, projectId]);
 
   if (error) {
     return (

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -100,6 +100,10 @@ export const MAX_CONVERSATION_DEPTH = 4;
  *                 type: boolean
  *                 description: Whether to wait for the agent to generate the initial message. If true the query will wait for the agent's answer. If false (default), the API will return a conversation ID directly and you will need to use streaming events to get the messages.
  *                 example: true
+ *               spaceId:
+ *                 type: string
+ *                 description: The sId of the space (project) in which to create the conversation (optional). If not provided, the conversation is created in the user's personal space.
+ *                 example: space_abc123
  *     responses:
  *       200:
  *         description: Conversation created successfully.

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -102,7 +102,7 @@ export const MAX_CONVERSATION_DEPTH = 4;
  *                 example: true
  *               spaceId:
  *                 type: string
- *                 description: The sId of the space (project) in which to create the conversation (optional). If not provided, the conversation is created in the user's personal space.
+ *                 description: The sId of the space (project) in which to create the conversation (optional). If not provided, the conversation is created outside projects
  *                 example: space_abc123
  *     responses:
  *       200:
@@ -306,7 +306,7 @@ async function handler(
       let resolvedSpaceModelId: number | null = null;
       if (spaceId) {
         const space = await SpaceResource.fetchById(auth, spaceId);
-        if (!space || !space.canReadOrAdministrate(auth)) {
+        if (!space || !space.isMember(auth)) {
           return apiError(req, res, {
             status_code: 404,
             api_error: {

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -884,6 +884,7 @@ export class DustAPI {
     contentFragments,
     blocking = false,
     skipToolsValidation = false,
+    spaceId,
     params,
     signal,
   }: PublicPostConversationsRequestBody & {
@@ -905,6 +906,7 @@ export class DustAPI {
         contentFragments,
         blocking,
         skipToolsValidation,
+        spaceId,
       },
       signal,
     });

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -2142,6 +2142,7 @@ export const PublicPostConversationsRequestBodySchema = z.intersection(
       .optional()
       .default("unlisted"),
     depth: z.number().optional(),
+    spaceId: z.string().optional(),
     message: z.union([
       z.intersection(
         z.object({


### PR DESCRIPTION
## Description

Add `--projectName` and `--projectId` flags to the Dust CLI to allow creating conversations in a specific project/space.

**Changes:**
- SDK: Add `spaceId` parameter to conversation creation schema and method
- API (v1): Support `spaceId` in POST /conversations endpoint with proper permission check (consistent with internal API)
- CLI: Add flags with mutual exclusivity validation and space resolution

## Risks

Blast radius: CLI conversation creation, v1 API conversation creation
Risk: low

## Deploy Plan

- deploy front