### PR TITLE
Refactor Agent Instructions Suggestions for a Block Approach

### DIFF
--- a/front/components/agent_builder/copilot/CopilotSuggestionsContext.tsx
+++ b/front/components/agent_builder/copilot/CopilotSuggestionsContext.tsx
@@ -280,20 +280,21 @@ export const CopilotSuggestionsProvider = ({
         continue;
       }
 
-      const { oldString, newString } = suggestion.suggestion;
+      // TODO(2026-02-05 COPILOT): Apply suggestion to editor.
+      // const { oldString, newString } = suggestion.suggestion;
 
-      const applied = editor.commands.applySuggestion({
-        id: suggestion.sId,
-        find: oldString,
-        replacement: newString,
-      });
+      // const applied = editor.commands.applySuggestion({
+      //   id: suggestion.sId,
+      //   find: oldString,
+      //   replacement: newString,
+      // });
 
-      if (applied) {
-        appliedSuggestionsRef.current.add(suggestion.sId);
-      } else {
-        // Text no longer matches - mark as outdated.
-        outdatedSuggestions.push(suggestion);
-      }
+      // if (applied) {
+      //   appliedSuggestionsRef.current.add(suggestion.sId);
+      // } else {
+      //   // Text no longer matches - mark as outdated.
+      //   outdatedSuggestions.push(suggestion);
+      // }
     }
 
     if (outdatedSuggestions.length > 0) {

--- a/front/components/agent_builder/copilot/tools/getAgentConfig.ts
+++ b/front/components/agent_builder/copilot/tools/getAgentConfig.ts
@@ -22,14 +22,16 @@ export function registerGetAgentConfigTool(
 
   mcpServer.tool(
     "get_agent_config",
-    `Get the current (unsaved) agent configuration from the agent builder form. Use this to understand what the user is currently configuring for their agent.
+    `Get the current (unsaved) agent configuration from the agent builder form.
+Use this to understand what the user is currently configuring for their agent.
 
 The response includes:
 - Agent settings (name, description, scope, model, tools, skills)
 - Instructions: The committed instructions text (without pending suggestions)
 - pendingSuggestions: Array of suggestions that have been made but not yet accepted/rejected by the user
 
-When there are pending suggestions, the "instructions" field shows the original text, and you can see what changes are pending in the "pendingSuggestions" array.`,
+When there are pending suggestions, the "instructions" field shows the original text,
+and you can see what changes are pending in the "pendingSuggestions" array.`,
     {},
     () => {
       const formData = getFormValues();

--- a/front/components/agent_builder/copilot/tools/getAgentConfig.ts
+++ b/front/components/agent_builder/copilot/tools/getAgentConfig.ts
@@ -74,8 +74,7 @@ When there are pending suggestions, the "instructions" field shows the original 
               ? {
                   sId: suggestion.sId,
                   kind: suggestion.kind,
-                  oldString: suggestion.suggestion.oldString,
-                  newString: suggestion.suggestion.newString,
+                  ...suggestion.suggestion,
                 }
               : {
                   sId: suggestion.sId,

--- a/front/components/markdown/suggestion/CopilotSuggestionCard.tsx
+++ b/front/components/markdown/suggestion/CopilotSuggestionCard.tsx
@@ -88,7 +88,8 @@ function InstructionsSuggestionCard({
 }: {
   agentSuggestion: AgentInstructionsSuggestionType;
 }) {
-  const { oldString, newString } = agentSuggestion.suggestion;
+  const { content, targetBlockId } = agentSuggestion.suggestion;
+  // TODO(2026-02-05 COPILOT): focusOnSuggestion uses text position over proper position.
   const { focusOnSuggestion } = useCopilotSuggestions();
 
   const cardState = mapSuggestionStateToCardState(agentSuggestion.state);
@@ -96,9 +97,13 @@ function InstructionsSuggestionCard({
     focusOnSuggestion(agentSuggestion.sId)
   );
 
+  // TODO(2026-02-05 COPILOT): Find a better way to display the diff.
   return (
     <DiffBlock
-      changes={[{ old: oldString, new: newString }]}
+      changes={[{
+        old: `[Block ${targetBlockId}]`,
+        new: content,
+      }]}
       actions={actions}
       className={cardState !== "active" ? "opacity-70" : undefined}
     />

--- a/front/components/markdown/suggestion/CopilotSuggestionCard.tsx
+++ b/front/components/markdown/suggestion/CopilotSuggestionCard.tsx
@@ -100,10 +100,12 @@ function InstructionsSuggestionCard({
   // TODO(2026-02-05 COPILOT): Find a better way to display the diff.
   return (
     <DiffBlock
-      changes={[{
-        old: `[Block ${targetBlockId}]`,
-        new: content,
-      }]}
+      changes={[
+        {
+          old: `[Block ${targetBlockId}]`,
+          new: content,
+        },
+      ]}
       actions={actions}
       className={cardState !== "active" ? "opacity-70" : undefined}
     />

--- a/front/components/markdown/suggestion/CopilotSuggestionCard.tsx
+++ b/front/components/markdown/suggestion/CopilotSuggestionCard.tsx
@@ -13,6 +13,7 @@ import {
   LoadingBlock,
   XMarkIcon,
 } from "@dust-tt/sparkle";
+import DOMPurify from "dompurify";
 import React, { useCallback, useMemo } from "react";
 import { useController, useFormContext } from "react-hook-form";
 
@@ -97,13 +98,16 @@ function InstructionsSuggestionCard({
     focusOnSuggestion(agentSuggestion.sId)
   );
 
+  // Sanitize HTML content to prevent XSS attacks.
+  const sanitizedContent = DOMPurify.sanitize(content);
+
   // TODO(2026-02-05 COPILOT): Find a better way to display the diff.
   return (
     <DiffBlock
       changes={[
         {
           old: `[Block ${targetBlockId}]`,
-          new: content,
+          new: sanitizedContent,
         },
       ]}
       actions={actions}

--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
@@ -279,13 +279,13 @@
       },
       {
         "name": "suggest_prompt_edits",
-        "description": "Create suggestions to modify the agent's instructions/prompt. CRITICAL: Make SMALL, SCOPED edits - each oldString should be 1-3 lines max, targeting specific phrases or sentences. NEVER replace entire instruction blocks. Example: To improve clarity, create 3 separate suggestions: one to change 'respond with' → 'reply using', another to add a bullet point, another to rephrase a sentence. IMPORTANT: Include the tool output verbatim in your response - it renders as interactive card(s).",
+        "description": "Create suggestions to modify the agent's instructions/prompt using block-based targeting. The instructions HTML contains blocks with data-block-id attributes (e.g., 'a3f1b20e'). Each suggestion targets a specific block by its ID and provides the full replacement HTML for that block. Word-level diffs will be computed and displayed inline. IMPORTANT: Include the tool output verbatim in your response - it renders as interactive card(s).",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
           "additionalProperties": false,
           "properties": {
             "suggestions": {
-              "description": "Array of small, scoped instruction modifications. Each should target 1-3 lines max. Each suggestion can have its own analysis.",
+              "description": "Array of block modifications. Each targets a block by its data-block-id and provides new content. Each suggestion can have its own analysis.",
               "items": {
                 "additionalProperties": false,
                 "properties": {
@@ -293,22 +293,26 @@
                     "description": "Analysis or reasoning for this specific suggestion",
                     "type": "string"
                   },
-                  "expectedOccurrences": {
-                    "description": "Number of occurrences to replace.",
-                    "type": "number"
-                  },
-                  "newString": {
-                    "description": "The exact replacement text",
+                  "content": {
+                    "description": "The full HTML content for this block, including the tag (e.g., '<p>New text</p>' or '<h2>Section Title</h2>')",
                     "type": "string"
                   },
-                  "oldString": {
-                    "description": "The exact text to find (including surrounding context)",
+                  "targetBlockId": {
+                    "description": "The data-block-id of the block to modify (e.g., '7f3a2b1c')",
+                    "type": "string"
+                  },
+                  "type": {
+                    "description": "The type of modification to perform on the target block",
+                    "enum": [
+                      "replace"
+                    ],
                     "type": "string"
                   }
                 },
                 "required": [
-                  "oldString",
-                  "newString"
+                  "content",
+                  "targetBlockId",
+                  "type"
                 ],
                 "type": "object"
               },

--- a/front/lib/api/actions/servers/agent_copilot_context/agent_copilot_context.test.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/agent_copilot_context.test.ts
@@ -586,7 +586,13 @@ describe("agent_copilot_context tools", () => {
       const tool = getToolByName("suggest_prompt_edits");
       const result = await tool.handler(
         {
-          suggestions: [{ oldString: "old text", newString: "new text" }],
+          suggestions: [
+            {
+              content: "<p>new text</p>",
+              targetBlockId: "block123",
+              type: "replace",
+            },
+          ],
         },
         createTestExtra(authenticator)
       );
@@ -611,7 +617,13 @@ describe("agent_copilot_context tools", () => {
       const tool = getToolByName("suggest_prompt_edits");
       const result = await tool.handler(
         {
-          suggestions: [{ oldString: "old text", newString: "new text" }],
+          suggestions: [
+            {
+              content: "<p>new text</p>",
+              targetBlockId: "block123",
+              type: "replace",
+            },
+          ],
         },
         createTestExtra(authenticator)
       );
@@ -642,8 +654,9 @@ describe("agent_copilot_context tools", () => {
           agentConfiguration,
           {
             suggestion: {
-              oldString: `old text ${i}`,
-              newString: `new text ${i}`,
+              content: `<p>new text ${i}</p>`,
+              targetBlockId: `block${i}`,
+              type: "replace",
             },
             state: "pending",
           }
@@ -660,7 +673,13 @@ describe("agent_copilot_context tools", () => {
       const tool = getToolByName("suggest_prompt_edits");
       const result = await tool.handler(
         {
-          suggestions: [{ oldString: "one more", newString: "exceeds limit" }],
+          suggestions: [
+            {
+              content: "<p>exceeds limit</p>",
+              targetBlockId: "blockExtra",
+              type: "replace",
+            },
+          ],
         },
         createTestExtra(authenticator)
       );

--- a/front/lib/api/actions/servers/agent_copilot_context/metadata.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/metadata.ts
@@ -19,18 +19,21 @@ const KNOWLEDGE_CATEGORIES = ["managed", "folder", "website"] as const;
 // Suggestion tool schemas
 
 const InstructionsSuggestionSchema = z.object({
-  oldString: z
-    .string()
-    .describe("The exact text to find (including surrounding context)"),
-  newString: z.string().describe("The exact replacement text"),
-  expectedOccurrences: z
-    .number()
-    .optional()
-    .describe("Number of occurrences to replace."),
   analysis: z
     .string()
     .optional()
     .describe("Analysis or reasoning for this specific suggestion"),
+  content: z
+    .string()
+    .describe(
+      "The full HTML content for this block, including the tag (e.g., '<p>New text</p>' or '<h2>Section Title</h2>')"
+    ),
+  targetBlockId: z
+    .string()
+    .describe("The data-block-id of the block to modify (e.g., '7f3a2b1c')"),
+  type: z
+    .enum(["replace"])
+    .describe("The type of modification to perform on the target block"),
 });
 
 const ToolsSuggestionSchema = z.object({
@@ -172,16 +175,16 @@ export const AGENT_COPILOT_CONTEXT_TOOLS_METADATA = createToolsRecord({
   // Suggestion tools
   suggest_prompt_edits: {
     description:
-      "Create suggestions to modify the agent's instructions/prompt. " +
-      "CRITICAL: Make SMALL, SCOPED edits - each oldString should be 1-3 lines max, targeting specific phrases or sentences. " +
-      "NEVER replace entire instruction blocks. " +
-      "Example: To improve clarity, create 3 separate suggestions: one to change 'respond with' → 'reply using', another to add a bullet point, another to rephrase a sentence. " +
+      "Create suggestions to modify the agent's instructions/prompt using block-based targeting. " +
+      "The instructions HTML contains blocks with data-block-id attributes (e.g., 'a3f1b20e'). " +
+      "Each suggestion targets a specific block by its ID and provides the full replacement HTML for that block. " +
+      "Word-level diffs will be computed and displayed inline. " +
       "IMPORTANT: Include the tool output verbatim in your response - it renders as interactive card(s).",
     schema: {
       suggestions: z
         .array(InstructionsSuggestionSchema)
         .describe(
-          "Array of small, scoped instruction modifications. Each should target 1-3 lines max. Each suggestion can have its own analysis."
+          "Array of block modifications. Each targets a block by its data-block-id and provides new content. Each suggestion can have its own analysis."
         ),
     },
     stake: "never_ask",

--- a/front/lib/api/assistant/agent_suggestion_pruning.test.ts
+++ b/front/lib/api/assistant/agent_suggestion_pruning.test.ts
@@ -353,426 +353,370 @@ describe("pruneSuggestionsForAgent", () => {
 
   // TODO(2026-02-05 COPILOT): Add tests for instructions suggestions once implemented.
   describe("instructions suggestions", () => {
-    it.skip("should mark suggestion as outdated when oldString is not in current instructions", async () => {
-      const suggestion = await AgentSuggestionFactory.createInstructions(
-        authenticator,
-        agentConfiguration,
-        {
-          suggestion: {
-            oldString: "This text does not exist",
-            newString: "New text",
-          },
-        }
-      );
-
-      const fullAgent = await getFullAgentConfiguration(
-        authenticator,
-        agentConfiguration.sId
-      );
-
-      await pruneSuggestionsForAgent(authenticator, fullAgent);
-
-      const fetched = await AgentSuggestionResource.fetchById(
-        authenticator,
-        suggestion.sId
-      );
-      expect(fetched?.state).toBe("outdated");
-    });
-
-    it.skip("should not mark suggestion as outdated when oldString exists in instructions", async () => {
-      // The agent has "Test Instructions" as its instructions.
-      const suggestion = await AgentSuggestionFactory.createInstructions(
-        authenticator,
-        agentConfiguration,
-        {
-          suggestion: {
-            oldString: "Test Instructions",
-            newString: "Updated Instructions",
-          },
-        }
-      );
-
-      const fullAgent = await getFullAgentConfiguration(
-        authenticator,
-        agentConfiguration.sId
-      );
-
-      await pruneSuggestionsForAgent(authenticator, fullAgent);
-
-      const fetched = await AgentSuggestionResource.fetchById(
-        authenticator,
-        suggestion.sId
-      );
-      expect(fetched?.state).toBe("pending");
-    });
-
-    it.skip("should handle multiple non-overlapping suggestions correctly", async () => {
-      // Create an agent with longer instructions.
-      const agentWithLongInstructions =
-        await AgentConfigurationFactory.updateTestAgent(
-          authenticator,
-          agentConfiguration.sId,
-          {
-            instructions: "Part A content. Part B content.",
-          }
-        );
-
-      // Create two non-overlapping suggestions (most recent first in list).
-      const suggestion1 = await AgentSuggestionFactory.createInstructions(
-        authenticator,
-        agentWithLongInstructions,
-        {
-          suggestion: {
-            oldString: "Part A content",
-            newString: "Modified Part A",
-          },
-        }
-      );
-
-      const suggestion2 = await AgentSuggestionFactory.createInstructions(
-        authenticator,
-        agentWithLongInstructions,
-        {
-          suggestion: {
-            oldString: "Part B content",
-            newString: "Modified Part B",
-          },
-        }
-      );
-
-      const fullAgent = await getFullAgentConfiguration(
-        authenticator,
-        agentWithLongInstructions.sId
-      );
-
-      await pruneSuggestionsForAgent(authenticator, fullAgent);
-
-      const fetched1 = await AgentSuggestionResource.fetchById(
-        authenticator,
-        suggestion1.sId
-      );
-      const fetched2 = await AgentSuggestionResource.fetchById(
-        authenticator,
-        suggestion2.sId
-      );
-
-      // Both should still be pending as they don't overlap.
-      expect(fetched1?.state).toBe("pending");
-      expect(fetched2?.state).toBe("pending");
-    });
-
-    it.skip("should mark overlapping suggestion as outdated", async () => {
-      // Create an agent with specific instructions.
-      const agentWithInstructions =
-        await AgentConfigurationFactory.updateTestAgent(
-          authenticator,
-          agentConfiguration.sId,
-          {
-            instructions: "Hello World",
-          }
-        );
-
-      // First suggestion (created earlier, processed later) targets "World".
-      const suggestion1 = await AgentSuggestionFactory.createInstructions(
-        authenticator,
-        agentWithInstructions,
-        {
-          suggestion: {
-            oldString: "World",
-            newString: "Universe",
-          },
-        }
-      );
-
-      // Wait a bit to ensure different timestamps.
-      await new Promise((resolve) => setTimeout(resolve, 10));
-
-      // Second suggestion (created later, processed first) targets "Hello World" - overlaps with first.
-      const suggestion2 = await AgentSuggestionFactory.createInstructions(
-        authenticator,
-        agentWithInstructions,
-        {
-          suggestion: {
-            oldString: "Hello World",
-            newString: "Greetings Universe",
-          },
-        }
-      );
-
-      const fullAgent = await getFullAgentConfiguration(
-        authenticator,
-        agentWithInstructions.sId
-      );
-
-      await pruneSuggestionsForAgent(authenticator, fullAgent);
-
-      const fetched1 = await AgentSuggestionResource.fetchById(
-        authenticator,
-        suggestion1.sId
-      );
-      const fetched2 = await AgentSuggestionResource.fetchById(
-        authenticator,
-        suggestion2.sId
-      );
-
-      // Suggestion2 (most recent) is processed first and applies.
-      expect(fetched2?.state).toBe("pending");
-      // Suggestion1 (older) cannot apply because the text is now changed.
-      expect(fetched1?.state).toBe("outdated");
-    });
-
-    it.skip("should shift regions correctly when earlier suggestion changes text length", async () => {
-      // Create an agent with specific instructions.
-      const agentWithInstructions =
-        await AgentConfigurationFactory.updateTestAgent(
-          authenticator,
-          agentConfiguration.sId,
-          {
-            instructions: "ABC DEF GHI",
-          }
-        );
-
-      // Older suggestion targets "GHI" at the end.
-      const suggestion1 = await AgentSuggestionFactory.createInstructions(
-        authenticator,
-        agentWithInstructions,
-        {
-          suggestion: {
-            oldString: "GHI",
-            newString: "JKL",
-          },
-        }
-      );
-
-      await new Promise((resolve) => setTimeout(resolve, 10));
-
-      // Newer suggestion targets "ABC" at the beginning.
-      // This should still apply, and the region for "GHI" should shift.
-      const suggestion2 = await AgentSuggestionFactory.createInstructions(
-        authenticator,
-        agentWithInstructions,
-        {
-          suggestion: {
-            oldString: "ABC",
-            newString: "ABCXYZ", // Longer replacement
-          },
-        }
-      );
-
-      const fullAgent = await getFullAgentConfiguration(
-        authenticator,
-        agentWithInstructions.sId
-      );
-
-      await pruneSuggestionsForAgent(authenticator, fullAgent);
-
-      const fetched1 = await AgentSuggestionResource.fetchById(
-        authenticator,
-        suggestion1.sId
-      );
-      const fetched2 = await AgentSuggestionResource.fetchById(
-        authenticator,
-        suggestion2.sId
-      );
-
-      // Both should still be pending - they edit different parts.
-      expect(fetched1?.state).toBe("pending");
-      expect(fetched2?.state).toBe("pending");
-    });
-
-    it.skip("should mark suggestion as outdated when expectedOccurrences does not match", async () => {
-      // Create an agent with repeated text.
-      const agentWithRepeatedText =
-        await AgentConfigurationFactory.updateTestAgent(
-          authenticator,
-          agentConfiguration.sId,
-          {
-            instructions: "test test test",
-          }
-        );
-
-      // Suggestion expects 2 occurrences but there are 3.
-      const suggestion = await AgentSuggestionFactory.createInstructions(
-        authenticator,
-        agentWithRepeatedText,
-        {
-          suggestion: {
-            oldString: "test",
-            newString: "TEST",
-            expectedOccurrences: 2,
-          },
-        }
-      );
-
-      const fullAgent = await getFullAgentConfiguration(
-        authenticator,
-        agentWithRepeatedText.sId
-      );
-
-      await pruneSuggestionsForAgent(authenticator, fullAgent);
-
-      const fetched = await AgentSuggestionResource.fetchById(
-        authenticator,
-        suggestion.sId
-      );
-      expect(fetched?.state).toBe("outdated");
-    });
-
-    it.skip("should handle multiple occurrences correctly when count matches", async () => {
-      // Create an agent with repeated text.
-      const agentWithRepeatedText =
-        await AgentConfigurationFactory.updateTestAgent(
-          authenticator,
-          agentConfiguration.sId,
-          {
-            instructions: "foo bar foo baz foo",
-          }
-        );
-
-      // Suggestion expects 3 occurrences and there are exactly 3.
-      const suggestion = await AgentSuggestionFactory.createInstructions(
-        authenticator,
-        agentWithRepeatedText,
-        {
-          suggestion: {
-            oldString: "foo",
-            newString: "FOO",
-            expectedOccurrences: 3,
-          },
-        }
-      );
-
-      const fullAgent = await getFullAgentConfiguration(
-        authenticator,
-        agentWithRepeatedText.sId
-      );
-
-      await pruneSuggestionsForAgent(authenticator, fullAgent);
-
-      const fetched = await AgentSuggestionResource.fetchById(
-        authenticator,
-        suggestion.sId
-      );
-      // Should still be pending since it can be applied (all 3 occurrences exist).
-      expect(fetched?.state).toBe("pending");
-    });
-
-    it.skip("should handle multiple occurrences with another suggestion overlapping one", async () => {
-      // Create an agent with repeated text.
-      const agentWithRepeatedText =
-        await AgentConfigurationFactory.updateTestAgent(
-          authenticator,
-          agentConfiguration.sId,
-          {
-            instructions: "AAA BBB AAA",
-          }
-        );
-
-      // Older suggestion targets the middle part "BBB".
-      const suggestion1 = await AgentSuggestionFactory.createInstructions(
-        authenticator,
-        agentWithRepeatedText,
-        {
-          suggestion: {
-            oldString: "BBB",
-            newString: "CCC",
-          },
-        }
-      );
-
-      await new Promise((resolve) => setTimeout(resolve, 10));
-
-      // Newer suggestion targets "AAA" (2 occurrences).
-      const suggestion2 = await AgentSuggestionFactory.createInstructions(
-        authenticator,
-        agentWithRepeatedText,
-        {
-          suggestion: {
-            oldString: "AAA",
-            newString: "XXX",
-            expectedOccurrences: 2,
-          },
-        }
-      );
-
-      const fullAgent = await getFullAgentConfiguration(
-        authenticator,
-        agentWithRepeatedText.sId
-      );
-
-      await pruneSuggestionsForAgent(authenticator, fullAgent);
-
-      const fetched1 = await AgentSuggestionResource.fetchById(
-        authenticator,
-        suggestion1.sId
-      );
-      const fetched2 = await AgentSuggestionResource.fetchById(
-        authenticator,
-        suggestion2.sId
-      );
-
-      // Both should be pending - AAA regions don't overlap with BBB region.
-      expect(fetched1?.state).toBe("pending");
-      expect(fetched2?.state).toBe("pending");
-    });
-
-    it.skip("should not mark suggestions as outdated when source regions overlap but changes don't", async () => {
-      // Create an agent with specific instructions.
-      const agentWithInstructions =
-        await AgentConfigurationFactory.updateTestAgent(
-          authenticator,
-          agentConfiguration.sId,
-          {
-            instructions: "ABCDE",
-          }
-        );
-
-      // Older suggestion targets "ABC" and changes B to X.
-      const suggestion1 = await AgentSuggestionFactory.createInstructions(
-        authenticator,
-        agentWithInstructions,
-        {
-          suggestion: {
-            oldString: "ABC",
-            newString: "AXXXXXC",
-          },
-        }
-      );
-
-      await new Promise((resolve) => setTimeout(resolve, 10));
-
-      // Newer suggestion targets "CDE" and changes D to Y.
-      // The source regions overlap at "C", but "C" is unchanged in both suggestions.
-      const suggestion2 = await AgentSuggestionFactory.createInstructions(
-        authenticator,
-        agentWithInstructions,
-        {
-          suggestion: {
-            oldString: "CDE",
-            newString: "CYYYYYE",
-          },
-        }
-      );
-
-      const fullAgent = await getFullAgentConfiguration(
-        authenticator,
-        agentWithInstructions.sId
-      );
-
-      await pruneSuggestionsForAgent(authenticator, fullAgent);
-
-      const fetched1 = await AgentSuggestionResource.fetchById(
-        authenticator,
-        suggestion1.sId
-      );
-      const fetched2 = await AgentSuggestionResource.fetchById(
-        authenticator,
-        suggestion2.sId
-      );
-
-      // Both should remain pending since the actual changes don't overlap.
-      expect(fetched1?.state).toBe("pending");
-      expect(fetched2?.state).toBe("pending");
-    });
+    // it.skip("should mark suggestion as outdated when oldString is not in current instructions", async () => {
+    //   const suggestion = await AgentSuggestionFactory.createInstructions(
+    //     authenticator,
+    //     agentConfiguration,
+    //     {
+    //       suggestion: {
+    //         oldString: "This text does not exist",
+    //         newString: "New text",
+    //       },
+    //     }
+    //   );
+    //   const fullAgent = await getFullAgentConfiguration(
+    //     authenticator,
+    //     agentConfiguration.sId
+    //   );
+    //   await pruneSuggestionsForAgent(authenticator, fullAgent);
+    //   const fetched = await AgentSuggestionResource.fetchById(
+    //     authenticator,
+    //     suggestion.sId
+    //   );
+    //   expect(fetched?.state).toBe("outdated");
+    // });
+    // it.skip("should not mark suggestion as outdated when oldString exists in instructions", async () => {
+    //   // The agent has "Test Instructions" as its instructions.
+    //   const suggestion = await AgentSuggestionFactory.createInstructions(
+    //     authenticator,
+    //     agentConfiguration,
+    //     {
+    //       suggestion: {
+    //         oldString: "Test Instructions",
+    //         newString: "Updated Instructions",
+    //       },
+    //     }
+    //   );
+    //   const fullAgent = await getFullAgentConfiguration(
+    //     authenticator,
+    //     agentConfiguration.sId
+    //   );
+    //   await pruneSuggestionsForAgent(authenticator, fullAgent);
+    //   const fetched = await AgentSuggestionResource.fetchById(
+    //     authenticator,
+    //     suggestion.sId
+    //   );
+    //   expect(fetched?.state).toBe("pending");
+    // });
+    // it.skip("should handle multiple non-overlapping suggestions correctly", async () => {
+    //   // Create an agent with longer instructions.
+    //   const agentWithLongInstructions =
+    //     await AgentConfigurationFactory.updateTestAgent(
+    //       authenticator,
+    //       agentConfiguration.sId,
+    //       {
+    //         instructions: "Part A content. Part B content.",
+    //       }
+    //     );
+    //   // Create two non-overlapping suggestions (most recent first in list).
+    //   const suggestion1 = await AgentSuggestionFactory.createInstructions(
+    //     authenticator,
+    //     agentWithLongInstructions,
+    //     {
+    //       suggestion: {
+    //         oldString: "Part A content",
+    //         newString: "Modified Part A",
+    //       },
+    //     }
+    //   );
+    //   const suggestion2 = await AgentSuggestionFactory.createInstructions(
+    //     authenticator,
+    //     agentWithLongInstructions,
+    //     {
+    //       suggestion: {
+    //         oldString: "Part B content",
+    //         newString: "Modified Part B",
+    //       },
+    //     }
+    //   );
+    //   const fullAgent = await getFullAgentConfiguration(
+    //     authenticator,
+    //     agentWithLongInstructions.sId
+    //   );
+    //   await pruneSuggestionsForAgent(authenticator, fullAgent);
+    //   const fetched1 = await AgentSuggestionResource.fetchById(
+    //     authenticator,
+    //     suggestion1.sId
+    //   );
+    //   const fetched2 = await AgentSuggestionResource.fetchById(
+    //     authenticator,
+    //     suggestion2.sId
+    //   );
+    //   // Both should still be pending as they don't overlap.
+    //   expect(fetched1?.state).toBe("pending");
+    //   expect(fetched2?.state).toBe("pending");
+    // });
+    // it.skip("should mark overlapping suggestion as outdated", async () => {
+    //   // Create an agent with specific instructions.
+    //   const agentWithInstructions =
+    //     await AgentConfigurationFactory.updateTestAgent(
+    //       authenticator,
+    //       agentConfiguration.sId,
+    //       {
+    //         instructions: "Hello World",
+    //       }
+    //     );
+    //   // First suggestion (created earlier, processed later) targets "World".
+    //   const suggestion1 = await AgentSuggestionFactory.createInstructions(
+    //     authenticator,
+    //     agentWithInstructions,
+    //     {
+    //       suggestion: {
+    //         oldString: "World",
+    //         newString: "Universe",
+    //       },
+    //     }
+    //   );
+    //   // Wait a bit to ensure different timestamps.
+    //   await new Promise((resolve) => setTimeout(resolve, 10));
+    //   // Second suggestion (created later, processed first) targets "Hello World" - overlaps with first.
+    //   const suggestion2 = await AgentSuggestionFactory.createInstructions(
+    //     authenticator,
+    //     agentWithInstructions,
+    //     {
+    //       suggestion: {
+    //         oldString: "Hello World",
+    //         newString: "Greetings Universe",
+    //       },
+    //     }
+    //   );
+    //   const fullAgent = await getFullAgentConfiguration(
+    //     authenticator,
+    //     agentWithInstructions.sId
+    //   );
+    //   await pruneSuggestionsForAgent(authenticator, fullAgent);
+    //   const fetched1 = await AgentSuggestionResource.fetchById(
+    //     authenticator,
+    //     suggestion1.sId
+    //   );
+    //   const fetched2 = await AgentSuggestionResource.fetchById(
+    //     authenticator,
+    //     suggestion2.sId
+    //   );
+    //   // Suggestion2 (most recent) is processed first and applies.
+    //   expect(fetched2?.state).toBe("pending");
+    //   // Suggestion1 (older) cannot apply because the text is now changed.
+    //   expect(fetched1?.state).toBe("outdated");
+    // });
+    // it.skip("should shift regions correctly when earlier suggestion changes text length", async () => {
+    //   // Create an agent with specific instructions.
+    //   const agentWithInstructions =
+    //     await AgentConfigurationFactory.updateTestAgent(
+    //       authenticator,
+    //       agentConfiguration.sId,
+    //       {
+    //         instructions: "ABC DEF GHI",
+    //       }
+    //     );
+    //   // Older suggestion targets "GHI" at the end.
+    //   const suggestion1 = await AgentSuggestionFactory.createInstructions(
+    //     authenticator,
+    //     agentWithInstructions,
+    //     {
+    //       suggestion: {
+    //         oldString: "GHI",
+    //         newString: "JKL",
+    //       },
+    //     }
+    //   );
+    //   await new Promise((resolve) => setTimeout(resolve, 10));
+    //   // Newer suggestion targets "ABC" at the beginning.
+    //   // This should still apply, and the region for "GHI" should shift.
+    //   const suggestion2 = await AgentSuggestionFactory.createInstructions(
+    //     authenticator,
+    //     agentWithInstructions,
+    //     {
+    //       suggestion: {
+    //         oldString: "ABC",
+    //         newString: "ABCXYZ", // Longer replacement
+    //       },
+    //     }
+    //   );
+    //   const fullAgent = await getFullAgentConfiguration(
+    //     authenticator,
+    //     agentWithInstructions.sId
+    //   );
+    //   await pruneSuggestionsForAgent(authenticator, fullAgent);
+    //   const fetched1 = await AgentSuggestionResource.fetchById(
+    //     authenticator,
+    //     suggestion1.sId
+    //   );
+    //   const fetched2 = await AgentSuggestionResource.fetchById(
+    //     authenticator,
+    //     suggestion2.sId
+    //   );
+    //   // Both should still be pending - they edit different parts.
+    //   expect(fetched1?.state).toBe("pending");
+    //   expect(fetched2?.state).toBe("pending");
+    // });
+    // it.skip("should mark suggestion as outdated when expectedOccurrences does not match", async () => {
+    //   // Create an agent with repeated text.
+    //   const agentWithRepeatedText =
+    //     await AgentConfigurationFactory.updateTestAgent(
+    //       authenticator,
+    //       agentConfiguration.sId,
+    //       {
+    //         instructions: "test test test",
+    //       }
+    //     );
+    //   // Suggestion expects 2 occurrences but there are 3.
+    //   const suggestion = await AgentSuggestionFactory.createInstructions(
+    //     authenticator,
+    //     agentWithRepeatedText,
+    //     {
+    //       suggestion: {
+    //         oldString: "test",
+    //         newString: "TEST",
+    //         expectedOccurrences: 2,
+    //       },
+    //     }
+    //   );
+    //   const fullAgent = await getFullAgentConfiguration(
+    //     authenticator,
+    //     agentWithRepeatedText.sId
+    //   );
+    //   await pruneSuggestionsForAgent(authenticator, fullAgent);
+    //   const fetched = await AgentSuggestionResource.fetchById(
+    //     authenticator,
+    //     suggestion.sId
+    //   );
+    //   expect(fetched?.state).toBe("outdated");
+    // });
+    // it.skip("should handle multiple occurrences correctly when count matches", async () => {
+    //   // Create an agent with repeated text.
+    //   const agentWithRepeatedText =
+    //     await AgentConfigurationFactory.updateTestAgent(
+    //       authenticator,
+    //       agentConfiguration.sId,
+    //       {
+    //         instructions: "foo bar foo baz foo",
+    //       }
+    //     );
+    //   // Suggestion expects 3 occurrences and there are exactly 3.
+    //   const suggestion = await AgentSuggestionFactory.createInstructions(
+    //     authenticator,
+    //     agentWithRepeatedText,
+    //     {
+    //       suggestion: {
+    //         oldString: "foo",
+    //         newString: "FOO",
+    //         expectedOccurrences: 3,
+    //       },
+    //     }
+    //   );
+    //   const fullAgent = await getFullAgentConfiguration(
+    //     authenticator,
+    //     agentWithRepeatedText.sId
+    //   );
+    //   await pruneSuggestionsForAgent(authenticator, fullAgent);
+    //   const fetched = await AgentSuggestionResource.fetchById(
+    //     authenticator,
+    //     suggestion.sId
+    //   );
+    //   // Should still be pending since it can be applied (all 3 occurrences exist).
+    //   expect(fetched?.state).toBe("pending");
+    // });
+    // it.skip("should handle multiple occurrences with another suggestion overlapping one", async () => {
+    //   // Create an agent with repeated text.
+    //   const agentWithRepeatedText =
+    //     await AgentConfigurationFactory.updateTestAgent(
+    //       authenticator,
+    //       agentConfiguration.sId,
+    //       {
+    //         instructions: "AAA BBB AAA",
+    //       }
+    //     );
+    //   // Older suggestion targets the middle part "BBB".
+    //   const suggestion1 = await AgentSuggestionFactory.createInstructions(
+    //     authenticator,
+    //     agentWithRepeatedText,
+    //     {
+    //       suggestion: {
+    //         oldString: "BBB",
+    //         newString: "CCC",
+    //       },
+    //     }
+    //   );
+    //   await new Promise((resolve) => setTimeout(resolve, 10));
+    //   // Newer suggestion targets "AAA" (2 occurrences).
+    //   const suggestion2 = await AgentSuggestionFactory.createInstructions(
+    //     authenticator,
+    //     agentWithRepeatedText,
+    //     {
+    //       suggestion: {
+    //         oldString: "AAA",
+    //         newString: "XXX",
+    //         expectedOccurrences: 2,
+    //       },
+    //     }
+    //   );
+    //   const fullAgent = await getFullAgentConfiguration(
+    //     authenticator,
+    //     agentWithRepeatedText.sId
+    //   );
+    //   await pruneSuggestionsForAgent(authenticator, fullAgent);
+    //   const fetched1 = await AgentSuggestionResource.fetchById(
+    //     authenticator,
+    //     suggestion1.sId
+    //   );
+    //   const fetched2 = await AgentSuggestionResource.fetchById(
+    //     authenticator,
+    //     suggestion2.sId
+    //   );
+    //   // Both should be pending - AAA regions don't overlap with BBB region.
+    //   expect(fetched1?.state).toBe("pending");
+    //   expect(fetched2?.state).toBe("pending");
+    // });
+    // it.skip("should not mark suggestions as outdated when source regions overlap but changes don't", async () => {
+    //   // Create an agent with specific instructions.
+    //   const agentWithInstructions =
+    //     await AgentConfigurationFactory.updateTestAgent(
+    //       authenticator,
+    //       agentConfiguration.sId,
+    //       {
+    //         instructions: "ABCDE",
+    //       }
+    //     );
+    //   // Older suggestion targets "ABC" and changes B to X.
+    //   const suggestion1 = await AgentSuggestionFactory.createInstructions(
+    //     authenticator,
+    //     agentWithInstructions,
+    //     {
+    //       suggestion: {
+    //         oldString: "ABC",
+    //         newString: "AXXXXXC",
+    //       },
+    //     }
+    //   );
+    //   await new Promise((resolve) => setTimeout(resolve, 10));
+    //   // Newer suggestion targets "CDE" and changes D to Y.
+    //   // The source regions overlap at "C", but "C" is unchanged in both suggestions.
+    //   const suggestion2 = await AgentSuggestionFactory.createInstructions(
+    //     authenticator,
+    //     agentWithInstructions,
+    //     {
+    //       suggestion: {
+    //         oldString: "CDE",
+    //         newString: "CYYYYYE",
+    //       },
+    //     }
+    //   );
+    //   const fullAgent = await getFullAgentConfiguration(
+    //     authenticator,
+    //     agentWithInstructions.sId
+    //   );
+    //   await pruneSuggestionsForAgent(authenticator, fullAgent);
+    //   const fetched1 = await AgentSuggestionResource.fetchById(
+    //     authenticator,
+    //     suggestion1.sId
+    //   );
+    //   const fetched2 = await AgentSuggestionResource.fetchById(
+    //     authenticator,
+    //     suggestion2.sId
+    //   );
+    //   // Both should remain pending since the actual changes don't overlap.
+    //   expect(fetched1?.state).toBe("pending");
+    //   expect(fetched2?.state).toBe("pending");
+    // });
   });
 });

--- a/front/lib/api/assistant/agent_suggestion_pruning.test.ts
+++ b/front/lib/api/assistant/agent_suggestion_pruning.test.ts
@@ -351,8 +351,9 @@ describe("pruneSuggestionsForAgent", () => {
     });
   });
 
+  // TODO(2026-02-05 COPILOT): Add tests for instructions suggestions once implemented.
   describe("instructions suggestions", () => {
-    it("should mark suggestion as outdated when oldString is not in current instructions", async () => {
+    it.skip("should mark suggestion as outdated when oldString is not in current instructions", async () => {
       const suggestion = await AgentSuggestionFactory.createInstructions(
         authenticator,
         agentConfiguration,
@@ -378,7 +379,7 @@ describe("pruneSuggestionsForAgent", () => {
       expect(fetched?.state).toBe("outdated");
     });
 
-    it("should not mark suggestion as outdated when oldString exists in instructions", async () => {
+    it.skip("should not mark suggestion as outdated when oldString exists in instructions", async () => {
       // The agent has "Test Instructions" as its instructions.
       const suggestion = await AgentSuggestionFactory.createInstructions(
         authenticator,
@@ -405,7 +406,7 @@ describe("pruneSuggestionsForAgent", () => {
       expect(fetched?.state).toBe("pending");
     });
 
-    it("should handle multiple non-overlapping suggestions correctly", async () => {
+    it.skip("should handle multiple non-overlapping suggestions correctly", async () => {
       // Create an agent with longer instructions.
       const agentWithLongInstructions =
         await AgentConfigurationFactory.updateTestAgent(
@@ -460,7 +461,7 @@ describe("pruneSuggestionsForAgent", () => {
       expect(fetched2?.state).toBe("pending");
     });
 
-    it("should mark overlapping suggestion as outdated", async () => {
+    it.skip("should mark overlapping suggestion as outdated", async () => {
       // Create an agent with specific instructions.
       const agentWithInstructions =
         await AgentConfigurationFactory.updateTestAgent(
@@ -520,7 +521,7 @@ describe("pruneSuggestionsForAgent", () => {
       expect(fetched1?.state).toBe("outdated");
     });
 
-    it("should shift regions correctly when earlier suggestion changes text length", async () => {
+    it.skip("should shift regions correctly when earlier suggestion changes text length", async () => {
       // Create an agent with specific instructions.
       const agentWithInstructions =
         await AgentConfigurationFactory.updateTestAgent(
@@ -579,7 +580,7 @@ describe("pruneSuggestionsForAgent", () => {
       expect(fetched2?.state).toBe("pending");
     });
 
-    it("should mark suggestion as outdated when expectedOccurrences does not match", async () => {
+    it.skip("should mark suggestion as outdated when expectedOccurrences does not match", async () => {
       // Create an agent with repeated text.
       const agentWithRepeatedText =
         await AgentConfigurationFactory.updateTestAgent(
@@ -617,7 +618,7 @@ describe("pruneSuggestionsForAgent", () => {
       expect(fetched?.state).toBe("outdated");
     });
 
-    it("should handle multiple occurrences correctly when count matches", async () => {
+    it.skip("should handle multiple occurrences correctly when count matches", async () => {
       // Create an agent with repeated text.
       const agentWithRepeatedText =
         await AgentConfigurationFactory.updateTestAgent(
@@ -656,7 +657,7 @@ describe("pruneSuggestionsForAgent", () => {
       expect(fetched?.state).toBe("pending");
     });
 
-    it("should handle multiple occurrences with another suggestion overlapping one", async () => {
+    it.skip("should handle multiple occurrences with another suggestion overlapping one", async () => {
       // Create an agent with repeated text.
       const agentWithRepeatedText =
         await AgentConfigurationFactory.updateTestAgent(
@@ -715,7 +716,7 @@ describe("pruneSuggestionsForAgent", () => {
       expect(fetched2?.state).toBe("pending");
     });
 
-    it("should not mark suggestions as outdated when source regions overlap but changes don't", async () => {
+    it.skip("should not mark suggestions as outdated when source regions overlap but changes don't", async () => {
       // Create an agent with specific instructions.
       const agentWithInstructions =
         await AgentConfigurationFactory.updateTestAgent(

--- a/front/lib/api/assistant/agent_suggestion_pruning.ts
+++ b/front/lib/api/assistant/agent_suggestion_pruning.ts
@@ -274,7 +274,7 @@ export async function pruneSuggestionsForAgent(
   auth: Authenticator,
   agentConfiguration: AgentConfigurationType
 ): Promise<void> {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+   
   const pendingSuggestions =
     await AgentSuggestionResource.listByAgentConfigurationId(
       auth,
@@ -283,4 +283,5 @@ export async function pruneSuggestionsForAgent(
     );
 
   // TODO(2026-02-05 COPILOT) Implement proper pruning based on block id and block inheritance.
+  await pruneSuggestions(auth, agentConfiguration, pendingSuggestions);
 }

--- a/front/lib/api/assistant/agent_suggestion_pruning.ts
+++ b/front/lib/api/assistant/agent_suggestion_pruning.ts
@@ -5,7 +5,7 @@ import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import logger from "@app/logger/logger";
 import type { AgentConfigurationType } from "@app/types";
 import type {
-  InstructionsSuggestionType,
+  InstructionsSuggestionSchemaType,
   ModelSuggestionType,
   SkillsSuggestionType,
   SubAgentSuggestionType,
@@ -35,17 +35,17 @@ type ModelSuggestionResource = AgentSuggestionResource & {
 
 type InstructionsSuggestionResource = AgentSuggestionResource & {
   kind: "instructions";
-  suggestion: InstructionsSuggestionType;
+  suggestion: InstructionsSuggestionSchemaType;
 };
 
 // Maps each kind to its corresponding resource type.
-type SuggestionResourceByKind = {
-  tools: ToolsSuggestionResource;
-  sub_agent: SubAgentSuggestionResource;
-  skills: SkillsSuggestionResource;
-  model: ModelSuggestionResource;
+interface SuggestionResourceByKind {
   instructions: InstructionsSuggestionResource;
-};
+  model: ModelSuggestionResource;
+  skills: SkillsSuggestionResource;
+  sub_agent: SubAgentSuggestionResource;
+  tools: ToolsSuggestionResource;
+}
 
 type SuggestionsByKind = {
   [K in keyof SuggestionResourceByKind]: SuggestionResourceByKind[K][];
@@ -119,8 +119,7 @@ export async function pruneSuggestions(
     return;
   }
 
-  const { tools, sub_agent, skills, model, instructions } =
-    splitByKind(pendingSuggestions);
+  const { tools, sub_agent, skills, model } = splitByKind(pendingSuggestions);
 
   const outdatedByKind = await Promise.all([
     getOutdatedToolsSuggestions(tools, agentConfiguration.actions),
@@ -131,10 +130,11 @@ export async function pruneSuggestions(
       agentConfiguration.model.modelId,
       agentConfiguration.model.reasoningEffort ?? null
     ),
-    getOutdatedInstructionsSuggestions(
-      instructions,
-      agentConfiguration.instructions
-    ),
+    // TODO(2026-02-05 COPILOT) Implement proper pruning for instructions suggestions based on block id and block inheritance.
+    // getOutdatedInstructionsSuggestions(
+    //   instructions,
+    //   agentConfiguration.instructions
+    // ),
   ]);
 
   const allOutdated = outdatedByKind.flat();
@@ -264,224 +264,6 @@ function getOutdatedModelSuggestions(
   return outdatedSuggestions;
 }
 
-function getOutdatedInstructionsSuggestions(
-  suggestions: InstructionsSuggestionResource[],
-  currentInstructions: string | null
-): InstructionsSuggestionResource[] {
-  if (suggestions.length === 0) {
-    return [];
-  }
-
-  const outdatedSuggestions: InstructionsSuggestionResource[] = [];
-
-  // Suggestions are already sorted by createdAt DESC (most recent first).
-  // We process them in order, tracking applied regions in the edited prompt.
-  let editedInstructions = currentInstructions ?? "";
-  const appliedRegions: Array<{ start: number; end: number }> = [];
-
-  for (const suggestion of suggestions) {
-    const result = canApplyInstructionSuggestion(
-      suggestion.suggestion,
-      currentInstructions,
-      editedInstructions,
-      appliedRegions
-    );
-
-    if (!result.canApply) {
-      outdatedSuggestions.push(suggestion);
-    } else {
-      // Apply the suggestion to the edited instructions and track the regions.
-      const { newEditedInstructions, newRegions, regionShift } = result;
-      editedInstructions = newEditedInstructions;
-
-      // Shift existing regions that come after the first new region by the total shift.
-      if (newRegions.length > 0 && regionShift !== 0) {
-        const firstNewRegionStart = newRegions[0].start;
-        for (const region of appliedRegions) {
-          if (region.start >= firstNewRegionStart) {
-            region.start += regionShift;
-            region.end += regionShift;
-          }
-        }
-      }
-
-      appliedRegions.push(...newRegions);
-    }
-  }
-
-  return outdatedSuggestions;
-}
-
-/**
- * Checks if an instruction suggestion can be applied.
- * Returns whether it can be applied, and if so, the updated edited instructions
- * and the regions that were modified.
- *
- * When expectedOccurrences > 1, all occurrences must be replaceable without
- * overlapping each other or any previously applied regions.
- */
-function canApplyInstructionSuggestion(
-  suggestion: InstructionsSuggestionType,
-  currentInstructions: string | null,
-  editedInstructions: string,
-  appliedRegions: Array<{ start: number; end: number }>
-):
-  | { canApply: false }
-  | {
-      canApply: true;
-      newEditedInstructions: string;
-      newRegions: Array<{ start: number; end: number }>;
-      regionShift: number;
-    } {
-  const { oldString, newString, expectedOccurrences } = suggestion;
-
-  // Check 1: oldString must exist in current instructions.
-  if (
-    currentInstructions === null ||
-    !currentInstructions.includes(oldString)
-  ) {
-    return { canApply: false };
-  }
-
-  const positions = findAllOccurrences(editedInstructions, oldString);
-
-  // Verify occurrence count.
-  if (expectedOccurrences !== undefined) {
-    if (positions.length !== expectedOccurrences) {
-      return { canApply: false };
-    }
-  } else {
-    if (positions.length !== 1) {
-      return { canApply: false };
-    }
-  }
-
-  // Compute the range of characters that actually change in this suggestion.
-  // This allows suggestions with overlapping source regions but non-overlapping
-  // changes to both remain valid.
-  const changedRange = computeChangedRange(oldString, newString);
-
-  const newRegions: Array<{ start: number; end: number }> = positions.map(
-    (pos) => ({
-      start: pos + changedRange.start,
-      end: pos + changedRange.end,
-    })
-  );
-
-  // No new changed region should overlap with any applied changed region.
-  for (const newRegion of newRegions) {
-    for (const appliedRegion of appliedRegions) {
-      if (
-        regionsOverlap(
-          newRegion.start,
-          newRegion.end,
-          appliedRegion.start,
-          appliedRegion.end
-        )
-      ) {
-        return { canApply: false };
-      }
-    }
-  }
-
-  // Apply all replacements from last to first (to preserve positions).
-  let result = editedInstructions;
-  const sortedPositions = [...positions].sort((a, b) => b - a); // Descending order
-  for (const pos of sortedPositions) {
-    result =
-      result.substring(0, pos) +
-      newString +
-      result.substring(pos + oldString.length);
-  }
-
-  // Calculate final regions after replacement (tracking only the changed portion).
-  const singleShift = newString.length - oldString.length;
-  const totalShift = singleShift * positions.length;
-
-  const finalRegions: Array<{ start: number; end: number }> = [];
-  let accumulatedShift = 0;
-
-  for (const pos of positions) {
-    finalRegions.push({
-      start: pos + changedRange.start + accumulatedShift,
-      end: pos + changedRange.end + accumulatedShift,
-    });
-    accumulatedShift += singleShift;
-  }
-
-  return {
-    canApply: true,
-    newEditedInstructions: result,
-    newRegions: finalRegions,
-    regionShift: totalShift,
-  };
-}
-
-/** Returns all positions of substr in str (non-overlapping). */
-function findAllOccurrences(str: string, substr: string): number[] {
-  const positions: number[] = [];
-  let pos = 0;
-  while ((pos = str.indexOf(substr, pos)) !== -1) {
-    positions.push(pos);
-    pos += substr.length; // Move past this occurrence (non-overlapping)
-  }
-  return positions;
-}
-
-function regionsOverlap(
-  start1: number,
-  end1: number,
-  start2: number,
-  end2: number
-): boolean {
-  // Regions overlap if one starts before the other ends and vice versa.
-  return start1 < end2 && start2 < end1;
-}
-
-/**
- * Computes the range of characters that actually change between oldString and newString.
- * Returns a {start, end} range relative to the oldString positions,
- * where start is inclusive and end is exclusive.
- *
- * For example:
- * - "ABC" -> "AXC" returns {start: 1, end: 2} (only B changes to X)
- * - "ABC" -> "AXXC" returns {start: 1, end: 2} (B is replaced, insertion happens there)
- * - "ABCD" -> "AXYD" returns {start: 1, end: 3} (BC changes to XY)
- *
- * TODO(copilot): We may store this in DB to avoid recomputing it each time.
- */
-function computeChangedRange(
-  oldString: string,
-  newString: string
-): { start: number; end: number } {
-  // Find common prefix length.
-  let prefixLen = 0;
-  while (
-    prefixLen < oldString.length &&
-    prefixLen < newString.length &&
-    oldString[prefixLen] === newString[prefixLen]
-  ) {
-    prefixLen++;
-  }
-
-  // Find common suffix length (but don't overlap with prefix).
-  let suffixLen = 0;
-  while (
-    suffixLen < oldString.length - prefixLen &&
-    suffixLen < newString.length - prefixLen &&
-    oldString[oldString.length - 1 - suffixLen] ===
-      newString[newString.length - 1 - suffixLen]
-  ) {
-    suffixLen++;
-  }
-
-  // The changed region in oldString is from prefixLen to (oldString.length - suffixLen).
-  const changedStart = prefixLen;
-  const changedEnd = oldString.length - suffixLen;
-
-  return { start: changedStart, end: Math.max(changedStart, changedEnd) };
-}
-
 /**
  * Prunes pending suggestions for an agent configuration.
  * Fetches pending suggestions and marks outdated ones.
@@ -492,6 +274,7 @@ export async function pruneSuggestionsForAgent(
   auth: Authenticator,
   agentConfiguration: AgentConfigurationType
 ): Promise<void> {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const pendingSuggestions =
     await AgentSuggestionResource.listByAgentConfigurationId(
       auth,
@@ -499,5 +282,5 @@ export async function pruneSuggestionsForAgent(
       { states: ["pending"] }
     );
 
-  await pruneSuggestions(auth, agentConfiguration, pendingSuggestions);
+  // TODO(2026-02-05 COPILOT) Implement proper pruning based on block id and block inheritance.
 }

--- a/front/lib/api/assistant/agent_suggestion_pruning.ts
+++ b/front/lib/api/assistant/agent_suggestion_pruning.ts
@@ -274,7 +274,6 @@ export async function pruneSuggestionsForAgent(
   auth: Authenticator,
   agentConfiguration: AgentConfigurationType
 ): Promise<void> {
-   
   const pendingSuggestions =
     await AgentSuggestionResource.listByAgentConfigurationId(
       auth,

--- a/front/lib/api/assistant/configuration/agent.test.ts
+++ b/front/lib/api/assistant/configuration/agent.test.ts
@@ -197,7 +197,13 @@ describe("createAgentConfiguration with pending agent", () => {
     await AgentSuggestionFactory.createInstructions(
       authenticator,
       pendingAgent!,
-      { suggestion: { oldString: "old", newString: "new" } }
+      {
+        suggestion: {
+          content: "<p>new</p>",
+          targetBlockId: "1234",
+          type: "replace",
+        },
+      }
     );
 
     const result = await createAgentConfiguration(authenticator, {

--- a/front/lib/api/assistant/global_agents/configurations/dust/copilot.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/copilot.ts
@@ -144,7 +144,7 @@ When newlines hurt:
 
 </agent_instructions_best_practices>`,
 
-blockAwareEditing: `<block_aware_editing>
+  blockAwareEditing: `<block_aware_editing>
 Agent instructions are organized into "blocks" — logical containers that group related instructions.
 Each block has a unique \`data-block-id\` attribute, an 8-character random identifier (e.g., "7f3a2b1c").
 These IDs are persisted and stable across editing sessions.

--- a/front/lib/resources/agent_suggestion_resource.test.ts
+++ b/front/lib/resources/agent_suggestion_resource.test.ts
@@ -30,9 +30,9 @@ describe("AgentSuggestionResource", () => {
         agentConfiguration,
         {
           suggestion: {
-            oldString: "Be helpful",
-            newString: "Be extremely helpful and detailed",
-            expectedOccurrences: 1,
+            content: "<p>Be extremely helpful and detailed</p>",
+            targetBlockId: "abc12345",
+            type: "replace",
           },
           analysis: "Making the agent more helpful",
         }
@@ -57,9 +57,9 @@ describe("AgentSuggestionResource", () => {
       const json = fetched!.toJSON();
       expect(json.kind).toBe("instructions");
       expect(json.suggestion).toEqual({
-        oldString: "Be helpful",
-        newString: "Be extremely helpful and detailed",
-        expectedOccurrences: 1,
+        content: "<p>Be extremely helpful and detailed</p>",
+        targetBlockId: "abc12345",
+        type: "replace",
       });
     });
   });
@@ -235,7 +235,11 @@ describe("AgentSuggestionResource", () => {
         authenticator,
         agentConfiguration,
         {
-          suggestion: { oldString: "old", newString: "new" },
+          suggestion: {
+            content: "<p>new content</p>",
+            targetBlockId: "block123",
+            type: "replace",
+          },
         }
       );
 
@@ -258,12 +262,24 @@ describe("AgentSuggestionResource", () => {
       const suggestion1 = await AgentSuggestionFactory.createInstructions(
         authenticator,
         agentConfiguration,
-        { suggestion: { oldString: "old1", newString: "new1" } }
+        {
+          suggestion: {
+            content: "<p>new1</p>",
+            targetBlockId: "block1",
+            type: "replace",
+          },
+        }
       );
       const suggestion2 = await AgentSuggestionFactory.createInstructions(
         authenticator,
         agentConfiguration,
-        { suggestion: { oldString: "old2", newString: "new2" } }
+        {
+          suggestion: {
+            content: "<p>new2</p>",
+            targetBlockId: "block2",
+            type: "replace",
+          },
+        }
       );
 
       await AgentSuggestionResource.bulkUpdateState(
@@ -289,7 +305,11 @@ describe("AgentSuggestionResource", () => {
         authenticator,
         agentConfiguration,
         {
-          suggestion: { oldString: "old", newString: "new" },
+          suggestion: {
+            content: "<p>new</p>",
+            targetBlockId: "block123",
+            type: "replace",
+          },
         }
       );
 
@@ -369,7 +389,11 @@ describe("AgentSuggestionResource", () => {
           agentConfiguration,
           {
             kind: "instructions",
-            suggestion: { oldString: "old", newString: "new" },
+            suggestion: {
+              content: "<p>new</p>",
+              targetBlockId: "block123",
+              type: "replace",
+            },
             analysis: null,
             state: "pending",
             source: "copilot",
@@ -410,8 +434,9 @@ describe("AgentSuggestionResource", () => {
           agentConfiguration,
           {
             suggestion: {
-              oldString: "old",
-              newString: "new",
+              content: "<p>new content</p>",
+              targetBlockId: "block123",
+              type: "replace",
             },
           }
         );
@@ -421,12 +446,14 @@ describe("AgentSuggestionResource", () => {
       // Type narrowing based on kind
       switch (json.kind) {
         case "instructions":
-          expect(json.suggestion.oldString).toBe("old");
-          expect(json.suggestion.newString).toBe("new");
+          expect(json.suggestion.content).toBe("<p>new content</p>");
+          expect(json.suggestion.targetBlockId).toBe("block123");
+          expect(json.suggestion.type).toBe("replace");
           break;
         case "tools":
         case "skills":
         case "model":
+        case "sub_agent":
           throw new Error("Unexpected kind");
       }
     });
@@ -438,7 +465,13 @@ describe("AgentSuggestionResource", () => {
       await AgentSuggestionFactory.createInstructions(
         authenticator,
         agentConfiguration,
-        { suggestion: { oldString: "a", newString: "b" } }
+        {
+          suggestion: {
+            content: "<p>b</p>",
+            targetBlockId: "block1",
+            type: "replace",
+          },
+        }
       );
       await AgentSuggestionFactory.createTools(
         authenticator,
@@ -462,7 +495,14 @@ describe("AgentSuggestionResource", () => {
       const pending = await AgentSuggestionFactory.createInstructions(
         authenticator,
         agentConfiguration,
-        { suggestion: { oldString: "a", newString: "b" }, state: "pending" }
+        {
+          suggestion: {
+            content: "<p>b</p>",
+            targetBlockId: "block1",
+            type: "replace",
+          },
+          state: "pending",
+        }
       );
       await AgentSuggestionFactory.createTools(
         authenticator,
@@ -509,7 +549,13 @@ describe("AgentSuggestionResource", () => {
       await AgentSuggestionFactory.createInstructions(
         authenticator,
         agentConfiguration,
-        { suggestion: { oldString: "a", newString: "b" } }
+        {
+          suggestion: {
+            content: "<p>b</p>",
+            targetBlockId: "block1",
+            type: "replace",
+          },
+        }
       );
       await AgentSuggestionFactory.createTools(
         authenticator,
@@ -545,12 +591,24 @@ describe("AgentSuggestionResource", () => {
       const instructions1 = await AgentSuggestionFactory.createInstructions(
         authenticator,
         agentConfiguration,
-        { suggestion: { oldString: "a", newString: "b" } }
+        {
+          suggestion: {
+            content: "<p>b</p>",
+            targetBlockId: "block1",
+            type: "replace",
+          },
+        }
       );
       await AgentSuggestionFactory.createInstructions(
         authenticator,
         agentConfiguration,
-        { suggestion: { oldString: "c", newString: "d" } }
+        {
+          suggestion: {
+            content: "<p>d</p>",
+            targetBlockId: "block2",
+            type: "replace",
+          },
+        }
       );
       await AgentSuggestionFactory.createTools(
         authenticator,
@@ -591,7 +649,13 @@ describe("AgentSuggestionResource", () => {
         const suggestion = await AgentSuggestionFactory.createInstructions(
           authenticator,
           agentConfiguration,
-          { suggestion: { oldString: `old-${i}`, newString: `new-${i}` } }
+          {
+            suggestion: {
+              content: `<p>new-${i}</p>`,
+              targetBlockId: `block${i}`,
+              type: "replace",
+            },
+          }
         );
         createdSuggestions.push(suggestion);
       }
@@ -613,7 +677,13 @@ describe("AgentSuggestionResource", () => {
       await AgentSuggestionFactory.createInstructions(
         authenticator,
         agentConfiguration,
-        { suggestion: { oldString: "a", newString: "b" } }
+        {
+          suggestion: {
+            content: "<p>b</p>",
+            targetBlockId: "block1",
+            type: "replace",
+          },
+        }
       );
 
       // Create a different user who is not an editor of the agent.
@@ -638,7 +708,13 @@ describe("AgentSuggestionResource", () => {
       const suggestion1 = await AgentSuggestionFactory.createInstructions(
         authenticator,
         agentConfiguration,
-        { suggestion: { oldString: "v0-old", newString: "v0-new" } }
+        {
+          suggestion: {
+            content: "<p>v0-new</p>",
+            targetBlockId: "block-v0",
+            type: "replace",
+          },
+        }
       );
 
       // Update the agent to create a new version (version 1).
@@ -685,7 +761,11 @@ describe("AgentSuggestionResource", () => {
         authenticator,
         agentConfiguration,
         {
-          suggestion: { oldString: "old1", newString: "new1" },
+          suggestion: {
+            content: "<p>new1</p>",
+            targetBlockId: "block1",
+            type: "replace",
+          },
         }
       );
 
@@ -730,7 +810,11 @@ describe("AgentSuggestionResource", () => {
         authenticator,
         agentConfiguration,
         {
-          suggestion: { oldString: "old", newString: "new" },
+          suggestion: {
+            content: "<p>new</p>",
+            targetBlockId: "block1",
+            type: "replace",
+          },
         }
       );
 
@@ -765,7 +849,11 @@ describe("AgentSuggestionResource", () => {
         authenticator,
         agentConfiguration,
         {
-          suggestion: { oldString: "old1", newString: "new1" },
+          suggestion: {
+            content: "<p>new1</p>",
+            targetBlockId: "block1",
+            type: "replace",
+          },
         }
       );
 
@@ -780,7 +868,11 @@ describe("AgentSuggestionResource", () => {
         authenticator2,
         agentConfiguration2,
         {
-          suggestion: { oldString: "old2", newString: "new2" },
+          suggestion: {
+            content: "<p>new2</p>",
+            targetBlockId: "block2",
+            type: "replace",
+          },
         }
       );
 

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/suggestions.test.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/suggestions.test.ts
@@ -275,7 +275,7 @@ describe("PATCH /api/w/[wId]/assistant/agent_configurations/[aId]/suggestions", 
       kind: "instructions",
       analysis: "Test analysis",
       source: "copilot",
-      suggestion: { oldString: "old text", newString: "new text" },
+      suggestion: { content: "<p>new text</p>", targetBlockId: "block123", type: "replace" },
     });
     expect(responseData.suggestions[0].createdAt).toBeDefined();
     expect(responseData.suggestions[0].updatedAt).toBeDefined();

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/suggestions.test.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/suggestions.test.ts
@@ -275,7 +275,11 @@ describe("PATCH /api/w/[wId]/assistant/agent_configurations/[aId]/suggestions", 
       kind: "instructions",
       analysis: "Test analysis",
       source: "copilot",
-      suggestion: { content: "<p>new text</p>", targetBlockId: "block123", type: "replace" },
+      suggestion: {
+        content: "<p>new text</p>",
+        targetBlockId: "block123",
+        type: "replace",
+      },
     });
     expect(responseData.suggestions[0].createdAt).toBeDefined();
     expect(responseData.suggestions[0].updatedAt).toBeDefined();

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/suggestions.test.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/suggestions.test.ts
@@ -247,7 +247,11 @@ describe("PATCH /api/w/[wId]/assistant/agent_configurations/[aId]/suggestions", 
       authenticator,
       agent,
       {
-        suggestion: { oldString: "old text", newString: "new text" },
+        suggestion: {
+          content: "<p>new text</p>",
+          targetBlockId: "block123",
+          type: "replace",
+        },
         analysis: "Test analysis",
         state: "pending",
         source: "copilot",

--- a/front/scripts/seed/copilot/assets/suggestions.json
+++ b/front/scripts/seed/copilot/assets/suggestions.json
@@ -20,8 +20,9 @@
     "agentName": "MeteoWithSuggestions",
     "kind": "instructions",
     "suggestion": {
-      "oldString": "Always remind users to check official weather services for critical decisions.",
-      "newString": "Always remind users to check official weather services for critical decisions. Include temperature in both Celsius and Fahrenheit when providing forecasts."
+      "content": "<p>Always remind users to check official weather services for critical decisions. Include temperature in both Celsius and Fahrenheit when providing forecasts.</p>",
+      "targetBlockId": "block001",
+      "type": "replace"
     },
     "analysis": "Adding dual temperature units would make the agent more useful for international users."
   },
@@ -29,8 +30,9 @@
     "agentName": "MeteoWithSuggestions",
     "kind": "instructions",
     "suggestion": {
-      "oldString": "Be friendly and informative.",
-      "newString": "Be friendly and informative. When discussing weather conditions, also mention any relevant safety tips (e.g., UV protection on sunny days, staying hydrated during heat waves)."
+      "content": "<p>Be friendly and informative. When discussing weather conditions, also mention any relevant safety tips (e.g., UV protection on sunny days, staying hydrated during heat waves).</p>",
+      "targetBlockId": "block002",
+      "type": "replace"
     },
     "analysis": "Adding safety tips would make the agent more helpful and proactive about user wellbeing."
   },

--- a/front/tests/utils/AgentSuggestionFactory.ts
+++ b/front/tests/utils/AgentSuggestionFactory.ts
@@ -4,7 +4,7 @@ import type { LightAgentConfigurationType } from "@app/types";
 import type {
   AgentSuggestionSource,
   AgentSuggestionState,
-  InstructionsSuggestionType,
+  InstructionsSuggestionSchemaType,
   ModelSuggestionType,
   SkillsSuggestionType,
   SubAgentSuggestionType,
@@ -16,7 +16,7 @@ export class AgentSuggestionFactory {
     auth: Authenticator,
     agentConfiguration: LightAgentConfigurationType,
     overrides: Partial<{
-      suggestion: InstructionsSuggestionType;
+      suggestion: InstructionsSuggestionSchemaType;
       analysis: string | null;
       state: AgentSuggestionState;
       source: AgentSuggestionSource;
@@ -28,9 +28,9 @@ export class AgentSuggestionFactory {
       {
         kind: "instructions",
         suggestion: overrides.suggestion ?? {
-          oldString: "You are a helpful assistant.",
-          newString: "You are an expert assistant specialized in coding.",
-          expectedOccurrences: 1,
+          content: "You are a helpful assistant.",
+          targetBlockId: "12334",
+          type: "replace",
         },
         analysis:
           overrides.analysis ?? "Improved instructions for better coding help",

--- a/front/types/suggestions/agent_suggestion.ts
+++ b/front/types/suggestions/agent_suggestion.ts
@@ -46,14 +46,15 @@ const SkillsSuggestionSchema = z.object({
 });
 
 const InstructionsSuggestionSchema = z.object({
-  oldString: z
+  content: z
     .string()
-    .describe("The exact text to find (including surrounding context)"),
-  newString: z.string().describe("The exact replacement text"),
-  expectedOccurrences: z
-    .number()
-    .optional()
-    .describe("Number of occurrences to replace."),
+    .describe("The full HTML content for this block, including the tag"),
+  targetBlockId: z
+    .string()
+    .describe("The data-block-id of the block to modify"),
+  type: z
+    .enum(["replace"])
+    .describe("The type of modification to perform on the target block"),
 });
 
 const ModelSuggestionSchema = z.object({
@@ -64,7 +65,7 @@ const ModelSuggestionSchema = z.object({
 export type ToolsSuggestionType = z.infer<typeof ToolsSuggestionSchema>;
 export type SubAgentSuggestionType = z.infer<typeof SubAgentSuggestionSchema>;
 export type SkillsSuggestionType = z.infer<typeof SkillsSuggestionSchema>;
-export type InstructionsSuggestionType = z.infer<
+export type InstructionsSuggestionSchemaType = z.infer<
   typeof InstructionsSuggestionSchema
 >;
 export type ModelSuggestionType = z.infer<typeof ModelSuggestionSchema>;
@@ -85,22 +86,16 @@ export function isSkillsSuggestion(
   return SkillsSuggestionSchema.safeParse(data).success;
 }
 
-export function isInstructionsSuggestion(
-  data: unknown
-): data is InstructionsSuggestionType {
-  return InstructionsSuggestionSchema.safeParse(data).success;
-}
-
 export function isModelSuggestion(data: unknown): data is ModelSuggestionType {
   return ModelSuggestionSchema.safeParse(data).success;
 }
 
 export type SuggestionPayload =
-  | ToolsSuggestionType
-  | SubAgentSuggestionType
+  | InstructionsSuggestionSchemaType
+  | ModelSuggestionType
   | SkillsSuggestionType
-  | InstructionsSuggestionType
-  | ModelSuggestionType;
+  | SubAgentSuggestionType
+  | ToolsSuggestionType;
 
 export const AgentSuggestionDataSchema = z.discriminatedUnion("kind", [
   z.object({ kind: z.literal("tools"), suggestion: ToolsSuggestionSchema }),


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See full context [here](https://github.com/dust-tt/dust/pull/21126).

This PR builds on top of #21191 and refactors the copilot suggestion system to use a block-based approach.

**Background:** The previous `oldString`/`newString` approach for instruction suggestions proved deeply complex with visual issues. The new block-based approach encourages the model to replace entire blocks instead of smaller strings.

This PR changes many pieces:
- New suggestion format: Instructions suggestions now use `{ content, targetBlockId, type }` instead of `{ oldString, newString, expectedOccurrences }`
- Suggestion types: Currently supports `type: "replace"`, with potential for future types (deletion, add, etc.)
- Commented out pruning logic: Will be reworked to use block IDs in a follow-up (code will be greatly simplified)

### Migration Strategy

Taking a radical approach: all existing suggestions will be dropped before shipping to avoid supporting both code paths.

### Next Steps

This PR bundles the agent loop and server-side tool changes. Client-side updates are coming in a follow-up PR.

> [!IMPORTANT]  
> Once this PR lands, copilot will be temporarily broken. The feature flag will be disabled until the follow-up PRs ship.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [x] Disable copilot FF
- [x] Drop previous instructions suggestions
