### PR TITLE
[Projects] Add project kickoff conversation feature (v0.1)

### DIFF
--- a/front/components/agent_builder/observability/constants.ts
+++ b/front/components/agent_builder/observability/constants.ts
@@ -167,4 +167,8 @@ export const USER_MESSAGE_ORIGIN_LABELS: Record<
     label: "Project Butler",
     color: "text-gray-400 dark:text-gray-400-night",
   },
+  project_kickoff: {
+    label: "Project Kickoff",
+    color: "text-info-muted dark:text-info-muted-night",
+  },
 };

--- a/front/components/assistant/conversation/space/conversations/ProjectKickoffButton.tsx
+++ b/front/components/assistant/conversation/space/conversations/ProjectKickoffButton.tsx
@@ -1,0 +1,42 @@
+import { Button, RocketIcon } from "@dust-tt/sparkle";
+
+import { useProjectKickoff } from "@app/hooks/useProjectKickoff";
+import { useAppRouter } from "@app/lib/platform";
+import { getConversationRoute } from "@app/lib/utils/router";
+import type { SpaceType, UserType, WorkspaceType } from "@app/types";
+
+interface ProjectKickoffButtonProps {
+  owner: WorkspaceType;
+  user: UserType;
+  space: SpaceType;
+}
+
+export function ProjectKickoffButton({
+  owner,
+  user,
+  space,
+}: ProjectKickoffButtonProps) {
+  const router = useAppRouter();
+  const { kickoffProject, isCreating } = useProjectKickoff({
+    owner,
+    user,
+    space,
+  });
+
+  const handleKickoff = async () => {
+    const conversation = await kickoffProject();
+    if (conversation) {
+      void router.push(getConversationRoute(owner.sId, conversation.sId));
+    }
+  };
+
+  return (
+    <Button
+      label="Kickoff project"
+      icon={RocketIcon}
+      variant="primary"
+      onClick={handleKickoff}
+      isLoading={isCreating}
+    />
+  );
+}

--- a/front/components/assistant/conversation/space/conversations/SpaceConversationsTab.tsx
+++ b/front/components/assistant/conversation/space/conversations/SpaceConversationsTab.tsx
@@ -12,6 +12,7 @@ import moment from "moment";
 import React, { useCallback, useMemo, useState } from "react";
 
 import { InputBar } from "@app/components/assistant/conversation/input_bar/InputBar";
+import { ProjectKickoffButton } from "@app/components/assistant/conversation/space/conversations/ProjectKickoffButton";
 import { SpaceConversationListItem } from "@app/components/assistant/conversation/space/conversations/SpaceConversationListItem";
 import { SpaceConversationsActions } from "@app/components/assistant/conversation/space/conversations/SpaceConversationsActions";
 import { SpaceJournalEntry } from "@app/components/assistant/conversation/space/conversations/SpaceJournalEntry";
@@ -193,10 +194,17 @@ export function SpaceConversationsTab({
 
           {/* Suggestions for empty rooms */}
           {!hasHistory && (
-            <SpaceConversationsActions
-              isEditor={isProjectEditor}
-              onOpenMembersPanel={onOpenMembersPanel}
-            />
+            <>
+              <ProjectKickoffButton
+                owner={owner}
+                user={user}
+                space={spaceInfo}
+              />
+              <SpaceConversationsActions
+                isEditor={isProjectEditor}
+                onOpenMembersPanel={onOpenMembersPanel}
+              />
+            </>
           )}
 
           {/* Space conversations section */}

--- a/front/components/assistant/conversation/types.ts
+++ b/front/components/assistant/conversation/types.ts
@@ -103,7 +103,8 @@ export const isHiddenMessage = (message: VirtuosoMessage): boolean => {
   return (
     (isUserMessage(message) &&
       (message.context.origin === "onboarding_conversation" ||
-        message.context.origin === "agent_copilot")) ||
+        message.context.origin === "agent_copilot" ||
+        message.context.origin === "project_kickoff")) ||
     isHandoverUserMessage(message)
   );
 };

--- a/front/hooks/useCreateConversationWithMessage.ts
+++ b/front/hooks/useCreateConversationWithMessage.ts
@@ -41,7 +41,7 @@ export function useCreateConversationWithMessage({
         clientSideMCPServerIds?: string[];
         selectedMCPServerViewIds?: string[];
         selectedSkillIds?: string[];
-        origin?: "web" | "agent_copilot";
+        origin?: "web" | "agent_copilot" | "project_kickoff";
       };
       visibility?: ConversationVisibility;
       title?: string;

--- a/front/hooks/useProjectKickoff.ts
+++ b/front/hooks/useProjectKickoff.ts
@@ -1,0 +1,72 @@
+import { useCallback, useState } from "react";
+
+import { useCreateConversationWithMessage } from "@app/hooks/useCreateConversationWithMessage";
+import { useSendNotification } from "@app/hooks/useNotification";
+import {
+  buildProjectKickoffPrompt,
+  PROJECT_KICKOFF_AGENT,
+} from "@app/lib/api/assistant/project_kickoff";
+import type { SpaceType, UserType, WorkspaceType } from "@app/types";
+
+export function useProjectKickoff({
+  owner,
+  user,
+  space,
+}: {
+  owner: WorkspaceType;
+  user: UserType | null;
+  space: SpaceType;
+}) {
+  const [isCreating, setIsCreating] = useState(false);
+  const sendNotification = useSendNotification();
+  const createConversationWithMessage = useCreateConversationWithMessage({
+    owner,
+    user,
+  });
+
+  const kickoffProject = useCallback(async () => {
+    if (!user || isCreating) {
+      return null;
+    }
+
+    setIsCreating(true);
+
+    const prompt = buildProjectKickoffPrompt({
+      projectName: space.name,
+      userName: user.username,
+    });
+
+    const result = await createConversationWithMessage({
+      messageData: {
+        input: prompt,
+        mentions: [{ configurationId: PROJECT_KICKOFF_AGENT }],
+        contentFragments: { uploaded: [], contentNodes: [] },
+        origin: "project_kickoff",
+      },
+      spaceId: space.sId,
+      visibility: "unlisted",
+      title: `Kickoff: ${space.name}`,
+    });
+
+    setIsCreating(false);
+
+    if (result.isErr()) {
+      sendNotification({
+        title: result.error.title,
+        description: result.error.message,
+        type: "error",
+      });
+      return null;
+    }
+
+    return result.value;
+  }, [
+    user,
+    isCreating,
+    space,
+    createConversationWithMessage,
+    sendNotification,
+  ]);
+
+  return { kickoffProject, isCreating };
+}

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -504,6 +504,7 @@ export function isUserMessageContextValid(
     case "triggered_programmatic":
     case "onboarding_conversation":
     case "agent_copilot":
+    case "project_kickoff":
     case "web":
       return false;
     default:

--- a/front/lib/api/assistant/project_kickoff.ts
+++ b/front/lib/api/assistant/project_kickoff.ts
@@ -15,18 +15,19 @@ You are helping a user kickstart a new project in Dust.
 Write a friendly greeting to help the user get started with their project "${projectName}".
 
 Your message should be:
-"Hey @${userName}; happy to help you kickstart ${projectName}. If you'd like, tell me a few words on the project (the goal, the context) and/or attach relevant files. I'll update the project's description, find related data in your company, use all of that to create an initial project document and get ${projectName} started."
+Hey @${userName}; happy to help you kickstart \`${projectName}\`.
 
-End with quick replies to guide the user:
-:quickReply[Tell you about the project]{message="Let me describe what this project is about..."} :quickReply[Attach files first]{message="I'll attach some relevant files"}
+If you'd like, tell me a few words on the project (the goal, the context) and/or attach relevant files. I'll update the project's description, find related data in your company, use all of that to create an initial project document and get ${projectName} started.
 
 ## SUBSEQUENT MESSAGES
 
 Once the user provides context:
 1. Acknowledge what they shared
-2. Search for related information in the company (use available tools)
-3. Suggest updating the project description based on what you learned
+2. If requested, search for related information in the company (use available tools)
+3. If relevant, suggest updating the project description based on what you learned
 4. Offer to create an initial project document summarizing the context
+
+Use quick replies for 3 and 4, e.g. :quickReply[Update project description]{message="Update the description."} :quickReply[Create project document]{message="Create an initial project document."}
 
 Always be helpful and action-oriented.
 </dust_system>`;

--- a/front/lib/api/assistant/project_kickoff.ts
+++ b/front/lib/api/assistant/project_kickoff.ts
@@ -1,0 +1,35 @@
+import { GLOBAL_AGENTS_SID } from "@app/types";
+
+export function buildProjectKickoffPrompt({
+  projectName,
+  userName,
+}: {
+  projectName: string;
+  userName: string;
+}): string {
+  return `<dust_system>
+You are helping a user kickstart a new project in Dust.
+
+## YOUR FIRST MESSAGE (respond now)
+
+Write a friendly greeting to help the user get started with their project "${projectName}".
+
+Your message should be:
+"Hey @${userName}; happy to help you kickstart ${projectName}. If you'd like, tell me a few words on the project (the goal, the context) and/or attach relevant files. I'll update the project's description, find related data in your company, use all of that to create an initial project document and get ${projectName} started."
+
+End with quick replies to guide the user:
+:quickReply[Tell you about the project]{message="Let me describe what this project is about..."} :quickReply[Attach files first]{message="I'll attach some relevant files"}
+
+## SUBSEQUENT MESSAGES
+
+Once the user provides context:
+1. Acknowledge what they shared
+2. Search for related information in the company (use available tools)
+3. Suggest updating the project description based on what you learned
+4. Offer to create an initial project document summarizing the context
+
+Always be helpful and action-oriented.
+</dust_system>`;
+}
+
+export const PROJECT_KICKOFF_AGENT = GLOBAL_AGENTS_SID.DUST;

--- a/front/lib/api/programmatic_usage/common.ts
+++ b/front/lib/api/programmatic_usage/common.ts
@@ -36,6 +36,7 @@ export const USAGE_ORIGINS_CLASSIFICATION: Record<
   onboarding_conversation: "user",
   agent_copilot: "user",
   project_butler: "user",
+  project_kickoff: "user",
 };
 
 export const USER_USAGE_ORIGINS = Object.keys(

--- a/front/lib/notifications/workflows/conversation-unread.ts
+++ b/front/lib/notifications/workflows/conversation-unread.ts
@@ -97,6 +97,7 @@ export const shouldSendNotificationForAgentAnswer = (
     case "triggered":
     case "zapier":
     case "zendesk":
+    case "project_kickoff":
     case undefined:
     case null:
       return false;

--- a/front/types/api/internal/assistant.ts
+++ b/front/types/api/internal/assistant.ts
@@ -13,6 +13,7 @@ const UserMentionSchema = t.type({ type: t.literal("user"), userId: t.string });
 const UserMessageOriginSchema = t.union([
   t.literal("web"),
   t.literal("agent_copilot"),
+  t.literal("project_kickoff"),
 ]);
 
 export const MessageBaseSchema = t.type({

--- a/front/types/assistant/conversation.ts
+++ b/front/types/assistant/conversation.ts
@@ -93,12 +93,14 @@ export type UserMessageOrigin =
   | "web"
   | "zapier"
   | "zendesk"
-  // TODO onboarding_conversation and agent_copilot aren't message origins. They have been used
-  // as a hack but should be removed and most likely handled as message metadata (to be created).
+  // TODO onboarding_conversation, agent_copilot, and project_kickoff aren't message origins. They
+  // have been used as a hack but should be removed and most likely handled as message metadata
+  // (to be created).
   | "onboarding_conversation"
   | "agent_copilot"
   // for internal use, for the butler in projects
-  | "project_butler";
+  | "project_butler"
+  | "project_kickoff";
 
 export type UserMessageContext = {
   username: string;

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -330,6 +330,7 @@ const UserMessageOriginSchema = z
     "onboarding_conversation",
     "agent_copilot",
     "project_butler",
+    "project_kickoff",
   ])
   .catch("api")
   .or(z.null())


### PR DESCRIPTION
## Description

Add a "Kickoff project" button to project views that initiates a conversation with the Dust agent. When clicked, the agent greets the user and offers to help gather context, find related company data, and create initial project documentation.

**Notes**: 
- The button is likely temporary, we could switch to having the kickoff auto-start at project creation;
- The behavior in-convo is an early draft, and will be iterated on.

<img width="1511" height="866" alt="image" src="https://github.com/user-attachments/assets/c3a59f7a-c4dc-418d-a4c6-11590b663733" />

<img width="2062" height="1250" alt="image" src="https://github.com/user-attachments/assets/895a2d6c-f5dd-4721-a36f-7150e648f8d8" />

Key changes:
- New `project_kickoff` origin type for user messages (hidden in UI like `onboarding_conversation`)
- `useProjectKickoff` hook handles conversation creation with pre-built prompt
- `ProjectKickoffButton` component renders only when the project has no conversations
- Uses the global Dust agent for now

## Risks

Blast radius: Project view for workspaces with "projects" feature flag
Risk: low

## Deploy Plan
- deploy front