### PR TITLE
[Dust Hive] Queue user search indexation workflows after SQL seed

### DIFF
--- a/front/scripts/queue_user_search_indexation.ts
+++ b/front/scripts/queue_user_search_indexation.ts
@@ -1,0 +1,43 @@
+import { makeScript } from "@app/scripts/helpers";
+import { launchIndexUserSearchWorkflow } from "@app/temporal/es_indexation/client";
+
+makeScript(
+  {
+    userSids: {
+      type: "array",
+      demandOption: true,
+      description: "User sIds to queue for user search indexation",
+    },
+  },
+  async ({ userSids, execute }, logger) => {
+    const uniqueUserSids = [...new Set(userSids)];
+
+    if (!execute) {
+      logger.info(
+        {
+          userCount: uniqueUserSids.length,
+        },
+        "Would queue user search indexation workflows"
+      );
+      return;
+    }
+
+    for (const userSid of uniqueUserSids) {
+      if (typeof userSid !== "string" || userSid.length === 0) {
+        throw new Error("All --userSids values must be non-empty strings");
+      }
+
+      const workflowResult = await launchIndexUserSearchWorkflow({ userId: userSid });
+      if (workflowResult.isErr()) {
+        throw workflowResult.error;
+      }
+
+      logger.info(
+        {
+          userSid,
+        },
+        "Queued user search indexation workflow"
+      );
+    }
+  }
+);

--- a/front/scripts/seed/queue_user_search_indexation.ts
+++ b/front/scripts/seed/queue_user_search_indexation.ts
@@ -27,7 +27,9 @@ makeScript(
         throw new Error("All --userSids values must be non-empty strings");
       }
 
-      const workflowResult = await launchIndexUserSearchWorkflow({ userId: userSid });
+      const workflowResult = await launchIndexUserSearchWorkflow({
+        userId: userSid,
+      });
       if (workflowResult.isErr()) {
         throw workflowResult.error;
       }

--- a/x/henry/dust-hive/src/lib/seed.ts
+++ b/x/henry/dust-hive/src/lib/seed.ts
@@ -110,7 +110,7 @@ async function queueUserSearchIndexationWorkflows({
   const command = buildShell({
     sourceEnv: envShPath,
     sourceNvm: true,
-    run: `npx tsx ./scripts/queue_user_search_indexation.ts --execute ${userSidArgs}`,
+    run: `npx tsx ./scripts/seed/queue_user_search_indexation.ts --execute ${userSidArgs}`,
   });
 
   const proc = Bun.spawn(["bash", "-c", command], {


### PR DESCRIPTION
## Description
The SQL-based dust-hive seed path bypasses app-layer resource hooks, so seeded users were not being added to the `user_search` index.

In all places in UX where users are listed (e.g. workspace admin, e.g. when mentioning) seeded users do not appear.

This change, right after successful SQL seed, queries active seeded users in the seeded workspace and queues `launchIndexUserSearchWorkflow` for each of them.

If workflow queueing fails, warm/seed logs a warning and continues.

## Risks
Blast radius: dust-hive first warm SQL seed flow and user search availability for seeded users in local environments.
Risk: low

## Deploy Plan
- pmrr
- no deploy required (local dust-hive tooling change only)

## Tests
- [x] `cd x/henry/dust-hive && bun run test`
