### PR TITLE
Add ability to read formatting of google docs and apply batch edits

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
@@ -4637,8 +4637,26 @@
     "name": "google_drive",
     "tools": [
       {
+        "name": "get_document_structure",
+        "description": "Get the full structure of a Google Docs document including text, tables, formatting, and indices. Use this instead of get_file_content when working with tables or when you need element indices for updates.",
+        "inputSchema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "additionalProperties": false,
+          "properties": {
+            "documentId": {
+              "description": "The ID of the Google Docs document to retrieve.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "documentId"
+          ],
+          "type": "object"
+        }
+      },
+      {
         "name": "get_file_content",
-        "description": "Get the content of a Google Drive file with offset-based pagination. Supported mimeTypes: application/vnd.google-apps.document, application/vnd.google-apps.presentation, application/vnd.google-apps.spreadsheet, text/plain, text/markdown, text/csv.",
+        "description": "Get the content of a Google Drive file as plain text with offset-based pagination. Supported mimeTypes: application/vnd.google-apps.document, application/vnd.google-apps.presentation, application/vnd.google-apps.spreadsheet, text/plain, text/markdown, text/csv. If you need to preserve table structure or get element indices, use get_document_structure instead.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
           "additionalProperties": false,
@@ -4815,6 +4833,7 @@
       "create_presentation": "low",
       "create_reply": "low",
       "create_spreadsheet": "low",
+      "get_document_structure": "never_ask",
       "get_file_content": "never_ask",
       "get_spreadsheet": "never_ask",
       "get_worksheet": "never_ask",

--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
@@ -4638,7 +4638,7 @@
     "tools": [
       {
         "name": "get_document_structure",
-        "description": "Get the full structure of a Google Docs document including text, tables, formatting, and indices. Use this instead of get_file_content when working with tables or when you need element indices for updates.",
+        "description": "Get the full structure of a Google Docs document including text, tables, formatting, and indices. Use this instead of get_file_content when working with tables or when you need element indices for updates. Supports pagination for large documents.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
           "additionalProperties": false,
@@ -4646,6 +4646,16 @@
             "documentId": {
               "description": "The ID of the Google Docs document to retrieve.",
               "type": "string"
+            },
+            "limit": {
+              "default": 100,
+              "description": "Maximum number of elements to return. Defaults to 100. Set to 0 for no limit.",
+              "type": "number"
+            },
+            "offset": {
+              "default": 0,
+              "description": "Element index to start from (for pagination). Defaults to 0.",
+              "type": "number"
             }
           },
           "required": [

--- a/front/lib/api/actions/servers/google_drive/format_document.ts
+++ b/front/lib/api/actions/servers/google_drive/format_document.ts
@@ -1,0 +1,84 @@
+import type { docs_v1 } from "googleapis";
+
+/**
+ * Formats a Google Docs document structure into readable markdown.
+ * Extracts key information like text content, tables, and indices while
+ * limiting verbosity for better LLM consumption.
+ */
+export function formatDocumentStructure(doc: docs_v1.Schema$Document): string {
+  const lines: string[] = [];
+
+  lines.push(`# Document: ${doc.title ?? "Untitled"}`);
+  lines.push(`Document ID: ${doc.documentId}`);
+  lines.push("");
+
+  // Body content
+  if (doc.body?.content) {
+    lines.push("## Document Structure");
+    lines.push("");
+
+    doc.body.content.forEach((element) => {
+      const start = element.startIndex;
+      const end = element.endIndex;
+
+      if (element.paragraph) {
+        const para = element.paragraph;
+        lines.push(`### Paragraph [${start}-${end}]`);
+
+        if (para.elements) {
+          para.elements.forEach((elem) => {
+            if (elem.textRun?.content) {
+              const text = elem.textRun.content.replace(/\n/g, "\\n");
+              lines.push(
+                `- Text (${elem.startIndex}-${elem.endIndex}): "${text}"`
+              );
+            }
+          });
+        }
+        lines.push("");
+      } else if (element.table) {
+        const table = element.table;
+        lines.push(`### Table [${start}-${end}]`);
+        lines.push(`- Rows: ${table.rows}`);
+        lines.push(`- Columns: ${table.columns}`);
+
+        if (table.tableRows) {
+          table.tableRows.forEach((row, rowIdx) => {
+            lines.push(`  - Row ${rowIdx}:`);
+            row.tableCells?.forEach((cell, colIdx) => {
+              const cellStart = cell.startIndex;
+              const cellEnd = cell.endIndex;
+              lines.push(
+                `    - Cell[${rowIdx},${colIdx}] (${cellStart}-${cellEnd})`
+              );
+
+              // Extract cell text content
+              const cellTexts: string[] = [];
+              cell.content?.forEach((cellElement) => {
+                cellElement.paragraph?.elements?.forEach((elem) => {
+                  if (elem.textRun?.content && elem.textRun.content.trim()) {
+                    cellTexts.push(elem.textRun.content.trim());
+                  }
+                });
+              });
+              if (cellTexts.length > 0) {
+                lines.push(`      Content: "${cellTexts.join(" ")}"`);
+              }
+            });
+          });
+        }
+        lines.push("");
+      } else if (element.sectionBreak) {
+        lines.push(`### Section Break [${start}-${end}]`);
+        lines.push("");
+      }
+    });
+  }
+
+  lines.push("---");
+  lines.push(
+    "*Note: Indices shown are character positions in the document for use with update_document batch requests.*"
+  );
+
+  return lines.join("\n");
+}

--- a/front/lib/api/actions/servers/google_drive/format_document.ts
+++ b/front/lib/api/actions/servers/google_drive/format_document.ts
@@ -69,8 +69,7 @@ export function formatDocumentStructure(
             row.tableCells?.forEach((cell, colIdx) => {
               const cellStart = cell.startIndex;
               const cellEnd = cell.endIndex;
-              const insertIndex =
-                cellStart !== undefined ? cellStart + 1 : undefined;
+              const insertIndex = cellStart != null ? cellStart + 1 : undefined;
               lines.push(
                 `    - Cell[${rowIdx},${colIdx}]: boundaries (${cellStart}-${cellEnd}), insert at index ${insertIndex}`
               );

--- a/front/lib/api/actions/servers/google_drive/google_docs_request_types.ts
+++ b/front/lib/api/actions/servers/google_drive/google_docs_request_types.ts
@@ -1,0 +1,341 @@
+import { z } from "zod";
+
+/**
+ * Complete Zod schemas for all Google Docs API batch update request types.
+ *
+ * This matches the googleapis Schema$Request structure where all request types
+ * are optional properties on a single object (discriminated union pattern).
+ *
+ * Reference: https://developers.google.com/workspace/docs/api/reference/rest/v1/documents/request
+ */
+
+// ============================================================================
+// Common Types
+// ============================================================================
+
+const LocationSchema = z.object({
+  index: z.number().int(),
+  segmentId: z.string().optional(),
+  tabId: z.string().optional(),
+});
+
+const RangeSchema = z.object({
+  startIndex: z.number().int().optional(),
+  endIndex: z.number().int().optional(),
+  segmentId: z.string().optional(),
+  tabId: z.string().optional(),
+});
+
+const DimensionSchema = z.object({
+  magnitude: z.number(),
+  unit: z.enum(["PT"]),
+});
+
+const RgbColorSchema = z.object({
+  red: z.number().min(0).max(1).optional(),
+  green: z.number().min(0).max(1).optional(),
+  blue: z.number().min(0).max(1).optional(),
+});
+
+const ColorSchema = z.object({
+  rgbColor: RgbColorSchema.optional(),
+});
+
+const OptionalColorSchema = z.object({
+  color: ColorSchema.optional(),
+});
+
+const TableCellLocationSchema = z.object({
+  tableStartLocation: LocationSchema,
+  rowIndex: z.number().int(),
+  columnIndex: z.number().int(),
+  tabId: z.string().optional(),
+});
+
+// ============================================================================
+// Individual Request Type Schemas
+// ============================================================================
+
+const CreateFooterSchema = z.object({
+  type: z.enum(["DEFAULT", "FIRST_PAGE_ONLY", "EVEN_PAGE_ONLY"]).optional(),
+  sectionBreakLocation: LocationSchema.optional(),
+  tabId: z.string().optional(),
+});
+
+const CreateFootnoteSchema = z.object({
+  location: LocationSchema,
+  footnoteContent: z.array(z.record(z.unknown())).optional(),
+});
+
+const CreateHeaderSchema = z.object({
+  type: z.enum(["DEFAULT", "FIRST_PAGE_ONLY", "EVEN_PAGE_ONLY"]).optional(),
+  sectionBreakLocation: LocationSchema.optional(),
+  tabId: z.string().optional(),
+});
+
+const CreateNamedRangeSchema = z.object({
+  name: z.string(),
+  range: RangeSchema,
+});
+
+const CreateParagraphBulletsSchema = z.object({
+  range: RangeSchema,
+  bulletPreset: z
+    .enum([
+      "BULLET_DISC_CIRCLE_SQUARE",
+      "BULLET_DIAMONDX_ARROW3D_SQUARE",
+      "BULLET_CHECKBOX",
+      "BULLET_ARROW_DIAMOND_DISC",
+      "BULLET_STAR_CIRCLE_SQUARE",
+      "BULLET_ARROW3D_CIRCLE_SQUARE",
+      "BULLET_LEFTTRIANGLE_DIAMOND_DISC",
+      "BULLET_DIAMONDX_HOLLOWDIAMOND_SQUARE",
+      "BULLET_DIAMOND_CIRCLE_SQUARE",
+      "NUMBERED_DECIMAL_ALPHA_ROMAN",
+      "NUMBERED_DECIMAL_ALPHA_ROMAN_PARENS",
+      "NUMBERED_DECIMAL_NESTED",
+      "NUMBERED_UPPERALPHA_ALPHA_ROMAN",
+      "NUMBERED_UPPERROMAN_UPPERALPHA_DECIMAL",
+      "NUMBERED_ZERODECIMAL_ALPHA_ROMAN",
+    ])
+    .optional(),
+});
+
+const DeleteContentRangeSchema = z.object({
+  range: RangeSchema,
+});
+
+const DeleteFooterSchema = z.object({
+  footerId: z.string(),
+  tabId: z.string().optional(),
+});
+
+const DeleteHeaderSchema = z.object({
+  headerId: z.string(),
+  tabId: z.string().optional(),
+});
+
+const DeleteNamedRangeSchema = z.object({
+  name: z.string().optional(),
+  namedRangeId: z.string().optional(),
+  tabId: z.string().optional(),
+});
+
+const DeleteParagraphBulletsSchema = z.object({
+  range: RangeSchema,
+});
+
+const DeletePositionedObjectSchema = z.object({
+  objectId: z.string(),
+  tabId: z.string().optional(),
+});
+
+const DeleteTableColumnSchema = z.object({
+  tableCellLocation: TableCellLocationSchema,
+});
+
+const DeleteTableRowSchema = z.object({
+  tableCellLocation: TableCellLocationSchema,
+});
+
+const InsertInlineImageSchema = z.object({
+  location: LocationSchema,
+  uri: z.string(),
+  objectSize: z
+    .object({
+      width: DimensionSchema.optional(),
+      height: DimensionSchema.optional(),
+    })
+    .optional(),
+});
+
+const InsertPageBreakSchema = z.object({
+  location: LocationSchema,
+});
+
+const InsertSectionBreakSchema = z.object({
+  location: LocationSchema,
+  sectionType: z
+    .enum(["SECTION_TYPE_UNSPECIFIED", "CONTINUOUS", "NEXT_PAGE"])
+    .optional(),
+});
+
+const InsertTableSchema = z.object({
+  rows: z.number().int().positive(),
+  columns: z.number().int().positive(),
+  location: LocationSchema,
+});
+
+const InsertTableColumnSchema = z.object({
+  tableCellLocation: TableCellLocationSchema,
+  insertRight: z.boolean().optional(),
+});
+
+const InsertTableRowSchema = z.object({
+  tableCellLocation: TableCellLocationSchema,
+  insertBelow: z.boolean().optional(),
+});
+
+const InsertTextSchema = z.object({
+  text: z.string(),
+  location: LocationSchema,
+});
+
+const MergeTableCellsSchema = z.object({
+  tableRange: z.object({
+    tableCellLocation: TableCellLocationSchema,
+    rowSpan: z.number().int().positive(),
+    columnSpan: z.number().int().positive(),
+  }),
+});
+
+const PinTableHeaderRowsSchema = z.object({
+  tableStartLocation: LocationSchema,
+  pinnedHeaderRowsCount: z.number().int(),
+  tabId: z.string().optional(),
+});
+
+const ReplaceAllTextSchema = z.object({
+  containsText: z.object({
+    text: z.string(),
+    matchCase: z.boolean().optional(),
+  }),
+  replaceText: z.string(),
+  tabsCriteria: z.record(z.unknown()).optional(),
+});
+
+const ReplaceImageSchema = z.object({
+  imageObjectId: z.string(),
+  uri: z.string(),
+  imageReplaceMethod: z.enum(["CENTER_CROP"]).optional(),
+  tabId: z.string().optional(),
+});
+
+const ReplaceNamedRangeContentSchema = z.object({
+  namedRangeId: z.string().optional(),
+  namedRangeName: z.string().optional(),
+  text: z.string(),
+  tabId: z.string().optional(),
+});
+
+const UnmergeTableCellsSchema = z.object({
+  tableRange: z.object({
+    tableCellLocation: TableCellLocationSchema,
+    rowSpan: z.number().int().positive(),
+    columnSpan: z.number().int().positive(),
+  }),
+});
+
+const UpdateDocumentStyleSchema = z.object({
+  documentStyle: z.record(z.unknown()),
+  fields: z.string(),
+  tabId: z.string().optional(),
+});
+
+const UpdateParagraphStyleSchema = z.object({
+  range: RangeSchema,
+  paragraphStyle: z.record(z.unknown()),
+  fields: z.string(),
+});
+
+const UpdateSectionStyleSchema = z.object({
+  range: RangeSchema,
+  sectionStyle: z.record(z.unknown()),
+  fields: z.string(),
+});
+
+const UpdateTableCellStyleSchema = z.object({
+  tableRange: z.object({
+    tableCellLocation: TableCellLocationSchema,
+    rowSpan: z.number().int().positive().optional(),
+    columnSpan: z.number().int().positive().optional(),
+  }),
+  tableCellStyle: z.record(z.unknown()),
+  fields: z.string(),
+});
+
+const UpdateTableColumnPropertiesSchema = z.object({
+  tableStartLocation: LocationSchema,
+  columnIndices: z.array(z.number().int()),
+  tableColumnProperties: z.record(z.unknown()),
+  fields: z.string(),
+  tabId: z.string().optional(),
+});
+
+const UpdateTableRowStyleSchema = z.object({
+  tableStartLocation: LocationSchema,
+  rowIndices: z.array(z.number().int()),
+  tableRowStyle: z.record(z.unknown()),
+  fields: z.string(),
+  tabId: z.string().optional(),
+});
+
+const UpdateTextStyleSchema = z.object({
+  range: RangeSchema,
+  textStyle: z.object({
+    bold: z.boolean().optional(),
+    italic: z.boolean().optional(),
+    underline: z.boolean().optional(),
+    strikethrough: z.boolean().optional(),
+    smallCaps: z.boolean().optional(),
+    fontSize: DimensionSchema.optional(),
+    foregroundColor: OptionalColorSchema.optional(),
+    backgroundColor: OptionalColorSchema.optional(),
+    weightedFontFamily: z.record(z.unknown()).optional(),
+    baselineOffset: z
+      .enum(["BASELINE_OFFSET_UNSPECIFIED", "NONE", "SUPERSCRIPT", "SUBSCRIPT"])
+      .optional(),
+    link: z.record(z.unknown()).optional(),
+  }),
+  fields: z.string(),
+});
+
+// ============================================================================
+// Combined Request Schema (matches googleapis Schema$Request structure)
+// ============================================================================
+
+/**
+ * Schema for a single Google Docs API request.
+ * Matches the googleapis Schema$Request interface where all request types
+ * are optional properties (discriminated union - only one should be set).
+ */
+export const GoogleDocsRequestSchema = z.object({
+  createFooter: CreateFooterSchema.optional(),
+  createFootnote: CreateFootnoteSchema.optional(),
+  createHeader: CreateHeaderSchema.optional(),
+  createNamedRange: CreateNamedRangeSchema.optional(),
+  createParagraphBullets: CreateParagraphBulletsSchema.optional(),
+  deleteContentRange: DeleteContentRangeSchema.optional(),
+  deleteFooter: DeleteFooterSchema.optional(),
+  deleteHeader: DeleteHeaderSchema.optional(),
+  deleteNamedRange: DeleteNamedRangeSchema.optional(),
+  deleteParagraphBullets: DeleteParagraphBulletsSchema.optional(),
+  deletePositionedObject: DeletePositionedObjectSchema.optional(),
+  deleteTableColumn: DeleteTableColumnSchema.optional(),
+  deleteTableRow: DeleteTableRowSchema.optional(),
+  insertInlineImage: InsertInlineImageSchema.optional(),
+  insertPageBreak: InsertPageBreakSchema.optional(),
+  insertSectionBreak: InsertSectionBreakSchema.optional(),
+  insertTable: InsertTableSchema.optional(),
+  insertTableColumn: InsertTableColumnSchema.optional(),
+  insertTableRow: InsertTableRowSchema.optional(),
+  insertText: InsertTextSchema.optional(),
+  mergeTableCells: MergeTableCellsSchema.optional(),
+  pinTableHeaderRows: PinTableHeaderRowsSchema.optional(),
+  replaceAllText: ReplaceAllTextSchema.optional(),
+  replaceImage: ReplaceImageSchema.optional(),
+  replaceNamedRangeContent: ReplaceNamedRangeContentSchema.optional(),
+  unmergeTableCells: UnmergeTableCellsSchema.optional(),
+  updateDocumentStyle: UpdateDocumentStyleSchema.optional(),
+  updateParagraphStyle: UpdateParagraphStyleSchema.optional(),
+  updateSectionStyle: UpdateSectionStyleSchema.optional(),
+  updateTableCellStyle: UpdateTableCellStyleSchema.optional(),
+  updateTableColumnProperties: UpdateTableColumnPropertiesSchema.optional(),
+  updateTableRowStyle: UpdateTableRowStyleSchema.optional(),
+  updateTextStyle: UpdateTextStyleSchema.optional(),
+});
+
+/**
+ * Array of Google Docs requests for use in metadata.ts.
+ */
+export const GoogleDocsRequestsArraySchema = z.array(GoogleDocsRequestSchema);

--- a/front/lib/api/actions/servers/google_drive/google_docs_request_types.ts
+++ b/front/lib/api/actions/servers/google_drive/google_docs_request_types.ts
@@ -140,7 +140,7 @@ const DeleteTableRowSchema = z.object({
 
 const InsertInlineImageSchema = z.object({
   location: LocationSchema,
-  uri: z.string(),
+  uri: z.string().url(),
   objectSize: z
     .object({
       width: DimensionSchema.optional(),
@@ -206,7 +206,7 @@ const ReplaceAllTextSchema = z.object({
 
 const ReplaceImageSchema = z.object({
   imageObjectId: z.string(),
-  uri: z.string(),
+  uri: z.string().url(),
   imageReplaceMethod: z.enum(["CENTER_CROP"]).optional(),
   tabId: z.string().optional(),
 });

--- a/front/lib/api/actions/servers/google_drive/metadata.ts
+++ b/front/lib/api/actions/servers/google_drive/metadata.ts
@@ -19,6 +19,9 @@ export const MAX_FILE_SIZE = 64 * 1024 * 1024; // 64 MB max original file size
 
 export const GOOGLE_DRIVE_TOOL_NAME = "google_drive" as const;
 
+// Tool name constants for cross-referencing in descriptions
+const GET_DOCUMENT_STRUCTURE_TOOL = "get_document_structure" as const;
+
 export const GOOGLE_DRIVE_TOOLS_METADATA = createToolsRecord({
   list_drives: {
     description: "List all shared drives accessible by the user.",
@@ -105,7 +108,7 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
     },
   },
   get_file_content: {
-    description: `Get the content of a Google Drive file as plain text with offset-based pagination. Supported mimeTypes: ${SUPPORTED_MIMETYPES.join(", ")}. If you need to preserve table structure or get element indices, use get_document_structure instead.`,
+    description: `Get the content of a Google Drive file as plain text with offset-based pagination. Supported mimeTypes: ${SUPPORTED_MIMETYPES.join(", ")}. If you need to preserve table structure or get element indices, use ${GET_DOCUMENT_STRUCTURE_TOOL} instead.`,
     schema: {
       fileId: z
         .string()
@@ -129,7 +132,7 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
       done: "Get Google Drive file content",
     },
   },
-  get_document_structure: {
+  [GET_DOCUMENT_STRUCTURE_TOOL]: {
     description:
       "Get the full structure of a Google Docs document including text, tables, formatting, and indices. " +
       "Use this instead of get_file_content when working with tables or when you need element indices for updates.",

--- a/front/lib/api/actions/servers/google_drive/metadata.ts
+++ b/front/lib/api/actions/servers/google_drive/metadata.ts
@@ -135,11 +135,26 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
   [GET_DOCUMENT_STRUCTURE_TOOL]: {
     description:
       "Get the full structure of a Google Docs document including text, tables, formatting, and indices. " +
-      "Use this instead of get_file_content when working with tables or when you need element indices for updates.",
+      "Use this instead of get_file_content when working with tables or when you need element indices for updates. " +
+      "Supports pagination for large documents.",
     schema: {
       documentId: z
         .string()
         .describe("The ID of the Google Docs document to retrieve."),
+      offset: z
+        .number()
+        .optional()
+        .default(0)
+        .describe(
+          "Element index to start from (for pagination). Defaults to 0."
+        ),
+      limit: z
+        .number()
+        .optional()
+        .default(100)
+        .describe(
+          "Maximum number of elements to return. Defaults to 100. Set to 0 for no limit."
+        ),
     },
     stake: "never_ask",
     displayLabels: {
@@ -275,8 +290,10 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
   update_document: {
     description:
       "Update an existing Google Docs document by inserting/deleting text, working with tables, and applying formatting. " +
-      "IMPORTANT: To insert text into table cells, first read the document with get_document_structure to determine cell indices, " +
-      "or calculate indices based on table structure (table start +1, each row +1, each cell +2).",
+      "IMPORTANT: When creating a new table, use a two-step process: (1) Create the table with insertTable at a valid index (e.g., index 1 for empty documents), " +
+      "(2) Call get_document_structure to get the actual cell indices, then (3) Use update_document again to insert text into specific cells. " +
+      "For existing tables, use get_document_structure to find cell indices before inserting content. " +
+      "NOTE: Cell indices in get_document_structure show boundaries (startIndex-endIndex). To insert text in a cell, use startIndex + 1 (e.g., for Cell (4-6), insert at index 5).",
     schema: {
       documentId: z.string().describe("The ID of the document to update."),
       requests: z

--- a/front/lib/api/actions/servers/google_drive/metadata.ts
+++ b/front/lib/api/actions/servers/google_drive/metadata.ts
@@ -105,7 +105,7 @@ Each key sorts ascending by default, but can be reversed with desc modified. Exa
     },
   },
   get_file_content: {
-    description: `Get the content of a Google Drive file with offset-based pagination. Supported mimeTypes: ${SUPPORTED_MIMETYPES.join(", ")}. NOTE: For Google Docs with tables, use get_document_structure instead to preserve table content.`,
+    description: `Get the content of a Google Drive file as plain text with offset-based pagination. Supported mimeTypes: ${SUPPORTED_MIMETYPES.join(", ")}. If you need to preserve table structure or get element indices, use get_document_structure instead.`,
     schema: {
       fileId: z
         .string()

--- a/front/lib/api/actions/servers/google_drive/tools/index.ts
+++ b/front/lib/api/actions/servers/google_drive/tools/index.ts
@@ -368,7 +368,7 @@ const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
       ]);
     } catch (err) {
       return handleFileAccessError(err, fileId, extra);
-     }
+    }
   },
   get_document_structure: async (
     { documentId, offset = 0, limit = 100 },

--- a/front/lib/api/actions/servers/google_drive/tools/index.ts
+++ b/front/lib/api/actions/servers/google_drive/tools/index.ts
@@ -604,10 +604,13 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
     }
 
     try {
-      const res = await docs.documents.batchUpdate({
-        documentId,
-        requestBody: { requests },
-      });
+      const res = await docs.documents.batchUpdate(
+        {
+          documentId,
+          requestBody: { requests },
+        },
+        {}
+      );
 
       return new Ok([
         {

--- a/front/lib/api/actions/servers/google_drive/tools/index.ts
+++ b/front/lib/api/actions/servers/google_drive/tools/index.ts
@@ -9,6 +9,7 @@ import {
   makeFileAuthorizationError,
   makePersonalAuthenticationError,
 } from "@app/lib/actions/mcp_internal_actions/utils";
+import { formatDocumentStructure } from "@app/lib/api/actions/servers/google_drive/format_document";
 import {
   getDocsClient,
   getDriveClient,
@@ -381,9 +382,10 @@ const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
         documentId,
       });
 
-      return new Ok([
-        { type: "text" as const, text: JSON.stringify(res.data, null, 2) },
-      ]);
+      // Format as markdown for better readability
+      const markdown = formatDocumentStructure(res.data);
+
+      return new Ok([{ type: "text" as const, text: markdown }]);
     } catch (err) {
       return handleFileAccessError(err, documentId, extra, {
         name: documentId,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Current implementation of `update_document` only allows for inserting or removing text but Google API allows for more through batch edit including adding/updating tables, formatting etc
This PR adds that functionality and adds a new tool `get_document_structure` for google docs since our current read tool only grabs plain text content, we need structure to see existing tables and update them
## Tests
Tested manually:
<img width="484" height="753" alt="Screenshot 2026-02-05 at 4 53 06 PM" src="https://github.com/user-attachments/assets/9eb28d38-10b9-48b3-8110-26c5b8ebed23" />
<img width="683" height="487" alt="Screenshot 2026-02-05 at 4 52 40 PM" src="https://github.com/user-attachments/assets/a754e930-b490-4450-97ba-50fa93a13e23" />

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low, still behind FF
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [ ] deploy front

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
