### PR TITLE
Expose instructions as HTML in client-side MCP

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -567,7 +567,7 @@ function AgentBuilderContent({
     const pendingInstructionSuggestions = suggestionsContext
       .getPendingSuggestions()
       .filter((s) => s.kind === "instructions");
-    const committedInstructions = suggestionsContext.getCommittedInstructions();
+    const committedInstructions = suggestionsContext.getCommittedInstructionsHtml();
 
     // Avoid allowing to save if there are no committed instructions.
     if (!committedInstructions.trim()) {

--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -567,7 +567,8 @@ function AgentBuilderContent({
     const pendingInstructionSuggestions = suggestionsContext
       .getPendingSuggestions()
       .filter((s) => s.kind === "instructions");
-    const committedInstructions = suggestionsContext.getCommittedInstructionsHtml();
+    const committedInstructions =
+      suggestionsContext.getCommittedInstructionsHtml();
 
     // Avoid allowing to save if there are no committed instructions.
     if (!committedInstructions.trim()) {

--- a/front/components/agent_builder/copilot/CopilotSuggestionsContext.tsx
+++ b/front/components/agent_builder/copilot/CopilotSuggestionsContext.tsx
@@ -11,10 +11,8 @@ import React, {
 } from "react";
 
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
-import {
-  getCommittedTextContent,
-  getSuggestionPosition,
-} from "@app/components/editor/extensions/agent_builder/InstructionSuggestionExtension";
+import { getSuggestionPosition } from "@app/components/editor/extensions/agent_builder/InstructionSuggestionExtension";
+import { stripHtmlAttributes } from "@app/components/editor/input_bar/cleanupPastedHTML";
 import { useSkillsContext } from "@app/components/shared/skills/SkillsContext";
 import { useMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
 import { getModelConfigByModelId } from "@app/lib/llms/model_configurations";
@@ -44,7 +42,7 @@ export interface CopilotSuggestionsContextType {
 
   // Editor registration for applying instruction suggestions.
   registerEditor: (editor: Editor) => void;
-  getCommittedInstructions: () => string;
+  getCommittedInstructionsHtml: () => string;
 
   // Actions on suggestions. Returns true on success, false on failure.
   acceptSuggestion: (sId: string) => Promise<boolean>;
@@ -457,12 +455,14 @@ export const CopilotSuggestionsProvider = ({
       return true;
     }, [patchSuggestions, getPendingSuggestions]);
 
-  const getCommittedInstructions = useCallback(() => {
+  const getCommittedInstructionsHtml = useCallback(() => {
     const editor = editorRef.current;
     if (!editor) {
       return "";
     }
-    return getCommittedTextContent(editor);
+
+    // Get HTML and strip styling attributes while preserving data-block-id.
+    return stripHtmlAttributes(editor.getHTML());
   }, []);
 
   const focusOnSuggestion = useCallback((suggestionId: string) => {
@@ -484,34 +484,34 @@ export const CopilotSuggestionsProvider = ({
 
   const value: CopilotSuggestionsContextType = useMemo(
     () => ({
-      getSuggestionWithRelations,
+      acceptAllInstructionSuggestions,
+      acceptSuggestion,
+      focusOnSuggestion,
+      getCommittedInstructionsHtml,
       getPendingSuggestions,
-      triggerRefetch,
+      getSuggestionWithRelations,
+      hasAttemptedRefetch,
       isSuggestionsLoading,
       isSuggestionsValidating,
-      hasAttemptedRefetch,
       registerEditor,
-      getCommittedInstructions,
-      acceptSuggestion,
-      rejectSuggestion,
-      acceptAllInstructionSuggestions,
       rejectAllInstructionSuggestions,
-      focusOnSuggestion,
+      rejectSuggestion,
+      triggerRefetch,
     }),
     [
-      getSuggestionWithRelations,
+      acceptAllInstructionSuggestions,
+      acceptSuggestion,
+      focusOnSuggestion,
+      getCommittedInstructionsHtml,
       getPendingSuggestions,
-      triggerRefetch,
+      getSuggestionWithRelations,
+      hasAttemptedRefetch,
       isSuggestionsLoading,
       isSuggestionsValidating,
-      hasAttemptedRefetch,
       registerEditor,
-      getCommittedInstructions,
-      acceptSuggestion,
-      rejectSuggestion,
-      acceptAllInstructionSuggestions,
       rejectAllInstructionSuggestions,
-      focusOnSuggestion,
+      rejectSuggestion,
+      triggerRefetch,
     ]
   );
 

--- a/front/components/agent_builder/copilot/tools/getAgentConfig.ts
+++ b/front/components/agent_builder/copilot/tools/getAgentConfig.ts
@@ -6,7 +6,7 @@ import type { AgentSuggestionType } from "@app/types/suggestions/agent_suggestio
 export interface GetAgentConfigCallbacks {
   getFormValues: () => AgentBuilderFormData;
   getPendingSuggestions?: () => AgentSuggestionType[];
-  getCommittedInstructions?: () => string;
+  getCommittedInstructionsHtml?: () => string;
 }
 
 /**
@@ -17,7 +17,7 @@ export function registerGetAgentConfigTool(
   mcpServer: McpServer,
   callbacks: GetAgentConfigCallbacks
 ): void {
-  const { getFormValues, getPendingSuggestions, getCommittedInstructions } =
+  const { getFormValues, getPendingSuggestions, getCommittedInstructionsHtml } =
     callbacks;
 
   mcpServer.tool(
@@ -27,26 +27,22 @@ Use this to understand what the user is currently configuring for their agent.
 
 The response includes:
 - Agent settings (name, description, scope, model, tools, skills)
-- Instructions: The committed instructions text (without pending suggestions)
-- pendingSuggestions: Array of suggestions that have been made but not yet accepted/rejected by the user
-
-When there are pending suggestions, the "instructions" field shows the original text,
-and you can see what changes are pending in the "pendingSuggestions" array.`,
+- instructionsHtml: HTML version of instructions with data-block-id attributes on each block.
+  Use these block IDs when making instruction suggestions to target specific blocks.
+- pendingSuggestions: Array of suggestions that have been made but not yet accepted/rejected by the user`,
     {},
     () => {
       const formData = getFormValues();
 
-      // Use committed instructions if available (excludes suggestion marks).
-      // Otherwise fall back to form instructions.
-      const instructions =
-        getCommittedInstructions?.() ?? formData.instructions;
+      // HTML instructions with block IDs for targeting specific blocks.
+      const instructionsHtml = getCommittedInstructionsHtml?.() ?? "";
 
       const pendingSuggestions = getPendingSuggestions?.() ?? [];
 
       const config = {
         name: formData.agentSettings.name,
         description: formData.agentSettings.description,
-        instructions,
+        instructionsHtml,
         scope: formData.agentSettings.scope,
         model: {
           modelId: formData.generationSettings.modelSettings.modelId,

--- a/front/components/agent_builder/copilot/useMCPServer.ts
+++ b/front/components/agent_builder/copilot/useMCPServer.ts
@@ -86,8 +86,9 @@ export function useCopilotMCPServer({
           getPendingSuggestions: suggestionsContextRef.current
             ? () => suggestionsContextRef.current!.getPendingSuggestions()
             : undefined,
-          getCommittedInstructions: suggestionsContextRef.current
-            ? () => suggestionsContextRef.current!.getCommittedInstructions()
+          getCommittedInstructionsHtml: suggestionsContextRef.current
+            ? () =>
+                suggestionsContextRef.current!.getCommittedInstructionsHtml()
             : undefined,
         });
 

--- a/front/lib/api/assistant/global_agents/configurations/dust/copilot.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/copilot.ts
@@ -216,7 +216,7 @@ You should always prefer skills over raw tools when available. Skills wrap tools
 Use tools strategically to construct high-quality suggestions. Here is when each tool should be called:
 
 <read_state_tools>
-- \`get_agent_config\`: Returns live builder form state (name, description, instructions, scope, model, tools, skills) plus pending suggestions
+- \`get_agent_config\`: Returns live builder form state (name, description, instructionsHtml, scope, model, tools, skills) plus pending suggestions
 - \`get_agent_feedback\`: Call for existing agents to retrieve user feedback.
 - \`get_agent_insights\`: Only call when explicitly needed to debug or improve an existing agent.
 - \`list_suggestions\`: Retrieve existing suggestions. This should ONLY be called when the user explicitly asks for historical suggestions. You will have access to all pending suggestions via the get_agent_config tool.


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See full context [here](https://github.com/dust-tt/dust/pull/21126).

This PR builds on top https://github.com/dust-tt/dust/pull/21196. It updates the client-side MCP server used to retrieve the current agent state so it exposes the instructions as HTML (with style stripped).

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
