### PR TITLE
Handle whole-block replacement when suggestion changes node type

### DIFF
--- a/front/components/agent_builder/copilot/CopilotSuggestionsContext.tsx
+++ b/front/components/agent_builder/copilot/CopilotSuggestionsContext.tsx
@@ -278,21 +278,19 @@ export const CopilotSuggestionsProvider = ({
         continue;
       }
 
-      // TODO(2026-02-05 COPILOT): Apply suggestion to editor.
-      // const { oldString, newString } = suggestion.suggestion;
+      const applied = editor.commands.applySuggestion({
+        id: suggestion.sId,
+        content: suggestion.suggestion.content,
+        targetBlockId: suggestion.suggestion.targetBlockId,
+      });
 
-      // const applied = editor.commands.applySuggestion({
-      //   id: suggestion.sId,
-      //   find: oldString,
-      //   replacement: newString,
-      // });
-
-      // if (applied) {
-      //   appliedSuggestionsRef.current.add(suggestion.sId);
-      // } else {
-      //   // Text no longer matches - mark as outdated.
-      //   outdatedSuggestions.push(suggestion);
-      // }
+      if (applied) {
+        appliedSuggestionsRef.current.add(suggestion.sId);
+      } else {
+        // TODO: Improve.
+        // Text no longer matches, mark as outdated.
+        // outdatedSuggestions.push(suggestion);
+      }
     }
 
     if (outdatedSuggestions.length > 0) {

--- a/front/components/agent_builder/copilot/CopilotSuggestionsContext.tsx
+++ b/front/components/agent_builder/copilot/CopilotSuggestionsContext.tsx
@@ -287,9 +287,8 @@ export const CopilotSuggestionsProvider = ({
       if (applied) {
         appliedSuggestionsRef.current.add(suggestion.sId);
       } else {
-        // TODO: Improve.
-        // Text no longer matches, mark as outdated.
-        // outdatedSuggestions.push(suggestion);
+        // If block not found, mark suggestion as outdated.
+        outdatedSuggestions.push(suggestion);
       }
     }
 

--- a/front/components/editor/extensions/agent_builder/BlockIdExtension.tsx
+++ b/front/components/editor/extensions/agent_builder/BlockIdExtension.tsx
@@ -10,6 +10,8 @@ function generateShortId(): string {
   return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
 }
 
+export const BLOCK_ID_ATTRIBUTE = "block-id";
+
 /**
  * Block ID extension that adds unique IDs to block-level nodes
  * (paragraphs, headings, and instruction blocks).
@@ -21,6 +23,6 @@ function generateShortId(): string {
  */
 export const BlockIdExtension = UniqueID.configure({
   types: ["paragraph", "heading", "instructionBlock"],
-  attributeName: "block-id",
+  attributeName: BLOCK_ID_ATTRIBUTE,
   generateID: generateShortId,
 });

--- a/front/components/editor/extensions/agent_builder/InstructionSuggestionExtension.test.ts
+++ b/front/components/editor/extensions/agent_builder/InstructionSuggestionExtension.test.ts
@@ -2,464 +2,300 @@ import type { Editor } from "@tiptap/core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
-  getCommittedTextContent,
+  BLOCK_ID_ATTRIBUTE,
+  BlockIdExtension,
+} from "@app/components/editor/extensions/agent_builder/BlockIdExtension";
+import {
+  getActiveSuggestionIds,
+  getActiveSuggestions,
   InstructionSuggestionExtension,
 } from "@app/components/editor/extensions/agent_builder/InstructionSuggestionExtension";
 import { EditorFactory } from "@app/components/editor/extensions/tests/utils";
+
+function getBlockIds(editor: Editor): string[] {
+  const ids: string[] = [];
+
+  editor.state.doc.descendants((node) => {
+    const id = node.attrs[BLOCK_ID_ATTRIBUTE];
+    if (id) {
+      ids.push(id);
+    }
+  });
+
+  return ids;
+}
 
 describe("InstructionSuggestionExtension", () => {
   let editor: Editor;
 
   beforeEach(() => {
-    editor = EditorFactory([InstructionSuggestionExtension]);
+    editor = EditorFactory([InstructionSuggestionExtension, BlockIdExtension]);
   });
 
   afterEach(() => {
     editor.destroy();
   });
 
-  describe("applySuggestion", () => {
-    it("should apply suggestion with deletion and addition marks", () => {
+  describe("applySuggestion (block-based)", () => {
+    it("should apply suggestion and track it in plugin state", () => {
       editor.commands.setContent("Hello world", { contentType: "markdown" });
+
+      const [targetBlockId] = getBlockIds(editor);
 
       const result = editor.commands.applySuggestion({
         id: "test-suggestion-1",
-        find: "world",
-        replacement: "there",
+        targetBlockId,
+        content: "<p>Hello there</p>",
       });
 
       expect(result).toBe(true);
 
+      // With pure decoration approach, document is unchanged.
       const json = editor.getJSON();
       const paragraph = json.content?.[0];
       expect(paragraph?.type).toBe("paragraph");
 
-      // Should have: "Hello " + "world" (deletion) + "there" (addition)
-      const content = paragraph?.content;
-      expect(content).toHaveLength(3);
+      const content = paragraph?.content as
+        | Array<{ text?: string }>
+        | undefined;
+      expect(content?.length).toBe(1);
+      expect(content?.[0]?.text).toBe("Hello world");
 
-      // Plain text "Hello "
-      expect(content?.[0]).toEqual({ type: "text", text: "Hello " });
-
-      // Deletion mark on "world"
-      expect(content?.[1]).toEqual({
-        type: "text",
-        text: "world",
-        marks: [
-          {
-            type: "suggestionDeletion",
-            attrs: { suggestionId: "test-suggestion-1" },
-          },
-        ],
-      });
-
-      // Addition mark on "there"
-      expect(content?.[2]).toEqual({
-        type: "text",
-        text: "there",
-        marks: [
-          {
-            type: "suggestionAddition",
-            attrs: { suggestionId: "test-suggestion-1" },
-          },
-        ],
-      });
+      // Suggestion should be tracked in plugin state.
+      expect(getActiveSuggestionIds(editor.state)).toContain(
+        "test-suggestion-1"
+      );
     });
 
-    it("should handle suggestion that replaces entire content", () => {
-      editor.commands.setContent("old content", { contentType: "markdown" });
+    it("should return false if block ID not found", () => {
+      editor.commands.setContent("Hello world", { contentType: "markdown" });
 
       const result = editor.commands.applySuggestion({
         id: "test-suggestion-2",
-        find: "old content",
-        replacement: "new content",
-      });
-
-      expect(result).toBe(true);
-
-      const json = editor.getJSON();
-      const content = json.content?.[0]?.content;
-
-      // Should have deletion + addition only (no plain text)
-      expect(content).toHaveLength(2);
-
-      expect(content?.[0]).toMatchObject({
-        text: "old content",
-        marks: [{ type: "suggestionDeletion" }],
-      });
-
-      expect(content?.[1]).toMatchObject({
-        text: "new content",
-        marks: [{ type: "suggestionAddition" }],
-      });
-    });
-
-    it("should handle insertion (empty find)", () => {
-      editor.commands.setContent("Hello", { contentType: "markdown" });
-
-      const result = editor.commands.applySuggestion({
-        id: "test-suggestion-3",
-        find: "",
-        replacement: " world",
-      });
-
-      expect(result).toBe(true);
-
-      const json = editor.getJSON();
-      const content = json.content?.[0]?.content;
-
-      // Should have addition mark for new text
-      const additionNode = content?.find(
-        (node: { marks?: Array<{ type: string }> }) =>
-          node.marks?.some((m) => m.type === "suggestionAddition")
-      );
-      expect(additionNode).toMatchObject({ text: " world" });
-    });
-
-    it("should handle deletion (empty replacement)", () => {
-      editor.commands.setContent("Hello world", { contentType: "markdown" });
-
-      const result = editor.commands.applySuggestion({
-        id: "test-suggestion-4",
-        find: " world",
-        replacement: "",
-      });
-
-      expect(result).toBe(true);
-
-      const json = editor.getJSON();
-      const content = json.content?.[0]?.content;
-
-      // Should have "Hello" plain + " world" with deletion mark (no addition)
-      expect(
-        content?.some((node: { marks?: Array<{ type: string }> }) =>
-          node.marks?.some((m) => m.type === "suggestionDeletion")
-        )
-      ).toBe(true);
-
-      expect(
-        content?.some((node: { marks?: Array<{ type: string }> }) =>
-          node.marks?.some((m) => m.type === "suggestionAddition")
-        )
-      ).toBe(false);
-    });
-
-    it("should return false if find text not found", () => {
-      editor.commands.setContent("Hello world", { contentType: "markdown" });
-
-      const result = editor.commands.applySuggestion({
-        id: "test-suggestion-5",
-        find: "not found",
-        replacement: "replacement",
+        targetBlockId: "nonexistent",
+        content: "<p>New content</p>",
       });
 
       expect(result).toBe(false);
     });
 
-    it("should track suggestion ID in storage", () => {
+    it("should track suggestion in plugin state", () => {
       editor.commands.setContent("Hello world", { contentType: "markdown" });
+      const [targetBlockId] = getBlockIds(editor);
 
       editor.commands.applySuggestion({
-        id: "test-suggestion-6",
-        find: "world",
-        replacement: "there",
+        id: "test-suggestion-3",
+        targetBlockId,
+        content: "<p>Hello there</p>",
       });
 
-      expect(
-        editor.storage.instructionSuggestion.activeSuggestionIds
-      ).toContain("test-suggestion-6");
+      expect(getActiveSuggestionIds(editor.state)).toContain(
+        "test-suggestion-3"
+      );
+      expect(getActiveSuggestions(editor.state).has("test-suggestion-3")).toBe(
+        true
+      );
     });
 
-    it("should handle multiple suggestions", () => {
-      editor.commands.setContent("Hello world, goodbye world", {
-        contentType: "markdown",
+    it("should handle complete content replacement", () => {
+      editor.commands.setContent("old content", { contentType: "markdown" });
+      const [targetBlockId] = getBlockIds(editor);
+
+      const result = editor.commands.applySuggestion({
+        id: "test-suggestion-4",
+        targetBlockId,
+        content: "<p>new content</p>",
       });
 
-      editor.commands.applySuggestion({
-        id: "suggestion-a",
-        find: "Hello",
-        replacement: "Hi",
+      expect(result).toBe(true);
+
+      // Document unchanged with pure decoration approach.
+      const text = editor.getText();
+      expect(text).toBe("old content");
+
+      // Suggestion tracked.
+      expect(getActiveSuggestionIds(editor.state)).toContain(
+        "test-suggestion-4"
+      );
+    });
+
+    it("should store HTML content as-is for later parsing", () => {
+      editor.commands.setContent("Simple text", { contentType: "markdown" });
+      const [targetBlockId] = getBlockIds(editor);
+
+      const result = editor.commands.applySuggestion({
+        id: "test-html-storage",
+        targetBlockId,
+        content: "<h2>Heading text</h2>",
       });
 
-      editor.commands.applySuggestion({
-        id: "suggestion-b",
-        find: "goodbye",
-        replacement: "farewell",
-      });
+      expect(result).toBe(true);
 
-      expect(
-        editor.storage.instructionSuggestion.activeSuggestionIds
-      ).toContain("suggestion-a");
-      expect(
-        editor.storage.instructionSuggestion.activeSuggestionIds
-      ).toContain("suggestion-b");
+      // HTML is stored as-is, parsed during decoration building.
+      const suggestion = getActiveSuggestions(editor.state).get(
+        "test-html-storage"
+      );
+      expect(suggestion).toBeDefined();
+      expect(suggestion?.operations[0].newContent).toBe(
+        "<h2>Heading text</h2>"
+      );
     });
   });
 
   describe("acceptSuggestion", () => {
-    it("should remove deletion marks and keep addition text", () => {
+    it("should replace content with new content on accept", () => {
       editor.commands.setContent("Hello world", { contentType: "markdown" });
+      const [targetBlockId] = getBlockIds(editor);
 
       editor.commands.applySuggestion({
         id: "test-accept-1",
-        find: "world",
-        replacement: "there",
+        targetBlockId,
+        content: "<p>Hello there</p>",
       });
 
       const result = editor.commands.acceptSuggestion("test-accept-1");
       expect(result).toBe(true);
 
-      // After accepting: "Hello there" (deletion removed, addition kept without mark)
+      // After accept, document should have new content.
       const text = editor.getText();
       expect(text).toBe("Hello there");
-
-      // No suggestion marks should remain
-      const json = editor.getJSON();
-      const content = json.content?.[0]?.content;
-      const hasMarks = content?.some(
-        (node: { marks?: Array<{ type: string }> }) =>
-          node.marks?.some(
-            (m) =>
-              m.type === "suggestionAddition" || m.type === "suggestionDeletion"
-          )
-      );
-      expect(hasMarks).toBe(false);
     });
 
-    it("should remove suggestion ID from storage after accepting", () => {
+    it("should remove suggestion from plugin state after accepting", () => {
       editor.commands.setContent("Hello world", { contentType: "markdown" });
+      const [targetBlockId] = getBlockIds(editor);
 
       editor.commands.applySuggestion({
         id: "test-accept-2",
-        find: "world",
-        replacement: "there",
+        targetBlockId,
+        content: "<p>Hello there</p>",
       });
 
-      expect(
-        editor.storage.instructionSuggestion.activeSuggestionIds
-      ).toContain("test-accept-2");
+      expect(getActiveSuggestionIds(editor.state)).toContain("test-accept-2");
 
       editor.commands.acceptSuggestion("test-accept-2");
 
-      expect(
-        editor.storage.instructionSuggestion.activeSuggestionIds
-      ).not.toContain("test-accept-2");
-    });
-
-    it("should only affect the specified suggestion", () => {
-      editor.commands.setContent("Hello world, goodbye world", {
-        contentType: "markdown",
-      });
-
-      editor.commands.applySuggestion({
-        id: "suggestion-x",
-        find: "Hello",
-        replacement: "Hi",
-      });
-
-      editor.commands.applySuggestion({
-        id: "suggestion-y",
-        find: "goodbye",
-        replacement: "farewell",
-      });
-
-      // Accept only suggestion-x
-      editor.commands.acceptSuggestion("suggestion-x");
-
-      // suggestion-x should be removed from storage
-      expect(
-        editor.storage.instructionSuggestion.activeSuggestionIds
-      ).not.toContain("suggestion-x");
-
-      // suggestion-y should still be active
-      expect(
-        editor.storage.instructionSuggestion.activeSuggestionIds
-      ).toContain("suggestion-y");
+      expect(getActiveSuggestionIds(editor.state)).not.toContain(
+        "test-accept-2"
+      );
+      expect(getActiveSuggestions(editor.state).has("test-accept-2")).toBe(
+        false
+      );
     });
   });
 
   describe("rejectSuggestion", () => {
-    it("should remove addition marks and keep deletion text", () => {
+    it("should keep original content on reject", () => {
       editor.commands.setContent("Hello world", { contentType: "markdown" });
+      const [targetBlockId] = getBlockIds(editor);
 
       editor.commands.applySuggestion({
         id: "test-reject-1",
-        find: "world",
-        replacement: "there",
+        targetBlockId,
+        content: "<p>Hello there</p>",
       });
 
       const result = editor.commands.rejectSuggestion("test-reject-1");
       expect(result).toBe(true);
 
-      // After rejecting: "Hello world" (original text restored, addition removed)
+      // After reject, document should still have original content.
       const text = editor.getText();
       expect(text).toBe("Hello world");
-
-      // No suggestion marks should remain
-      const json = editor.getJSON();
-      const content = json.content?.[0]?.content;
-      const hasMarks = content?.some(
-        (node: { marks?: Array<{ type: string }> }) =>
-          node.marks?.some(
-            (m) =>
-              m.type === "suggestionAddition" || m.type === "suggestionDeletion"
-          )
-      );
-      expect(hasMarks).toBe(false);
     });
 
-    it("should remove suggestion ID from storage after rejecting", () => {
+    it("should remove suggestion from plugin state after rejecting", () => {
       editor.commands.setContent("Hello world", { contentType: "markdown" });
+      const [targetBlockId] = getBlockIds(editor);
 
       editor.commands.applySuggestion({
         id: "test-reject-2",
-        find: "world",
-        replacement: "there",
+        targetBlockId,
+        content: "<p>Hello there</p>",
       });
 
-      expect(
-        editor.storage.instructionSuggestion.activeSuggestionIds
-      ).toContain("test-reject-2");
+      expect(getActiveSuggestionIds(editor.state)).toContain("test-reject-2");
 
       editor.commands.rejectSuggestion("test-reject-2");
 
-      expect(
-        editor.storage.instructionSuggestion.activeSuggestionIds
-      ).not.toContain("test-reject-2");
+      expect(getActiveSuggestionIds(editor.state)).not.toContain(
+        "test-reject-2"
+      );
     });
   });
 
   describe("acceptAllSuggestions", () => {
-    it("should accept a single suggestion", () => {
-      editor.commands.setContent("Hello world", {
-        contentType: "markdown",
-      });
+    it("should accept all suggestions", () => {
+      editor.commands.setContent("Hello world", { contentType: "markdown" });
+      const [targetBlockId] = getBlockIds(editor);
 
       editor.commands.applySuggestion({
         id: "all-1",
-        find: "Hello",
-        replacement: "Hi",
+        targetBlockId,
+        content: "<p>Hi there</p>",
       });
 
       editor.commands.acceptAllSuggestions();
 
       const text = editor.getText();
       expect(text).toContain("Hi");
-      expect(text).not.toContain("Hello");
+      expect(text).toContain("there");
 
-      // Storage should be empty
-      expect(
-        editor.storage.instructionSuggestion.activeSuggestionIds
-      ).toHaveLength(0);
+      expect(getActiveSuggestionIds(editor.state)).toHaveLength(0);
     });
 
-    it("should clear all suggestion IDs from storage", () => {
-      editor.commands.setContent("Hello world", {
+    it("should correctly map positions when accepting multiple suggestions", () => {
+      // Create two paragraphs.
+      editor.commands.setContent("First paragraph\n\nSecond paragraph", {
         contentType: "markdown",
       });
 
+      const [blockId1, blockId2] = getBlockIds(editor);
+
+      // Apply suggestions to both blocks.
       editor.commands.applySuggestion({
-        id: "all-2",
-        find: "world",
-        replacement: "there",
+        id: "multi-1",
+        targetBlockId: blockId1,
+        content: "<p>Short</p>",
       });
 
-      expect(
-        editor.storage.instructionSuggestion.activeSuggestionIds
-      ).toHaveLength(1);
+      editor.commands.applySuggestion({
+        id: "multi-2",
+        targetBlockId: blockId2,
+        content: "<p>New second</p>",
+      });
 
-      editor.commands.acceptAllSuggestions();
+      // Accept first suggestion (this changes document positions).
+      editor.commands.acceptSuggestion("multi-1");
 
-      expect(
-        editor.storage.instructionSuggestion.activeSuggestionIds
-      ).toHaveLength(0);
+      // Second suggestion should still work after position shift.
+      editor.commands.acceptSuggestion("multi-2");
+
+      const text = editor.getText();
+      expect(text).toContain("Short");
+      expect(text).toContain("New second");
+      expect(text).not.toContain("First paragraph");
+      expect(text).not.toContain("Second paragraph");
     });
   });
 
   describe("rejectAllSuggestions", () => {
-    it("should reject a single suggestion and restore original text", () => {
-      editor.commands.setContent("Hello world", {
-        contentType: "markdown",
-      });
+    it("should reject all suggestions and keep original text", () => {
+      editor.commands.setContent("Hello world", { contentType: "markdown" });
+      const [targetBlockId] = getBlockIds(editor);
 
       editor.commands.applySuggestion({
         id: "reject-all-1",
-        find: "Hello",
-        replacement: "Hi",
+        targetBlockId,
+        content: "<p>Hi there</p>",
       });
 
       editor.commands.rejectAllSuggestions();
 
-      // Original text should be restored
       const text = editor.getText();
       expect(text).toContain("Hello");
-      expect(text).not.toContain("Hi");
+      expect(text).toContain("world");
 
-      // Storage should be empty
-      expect(
-        editor.storage.instructionSuggestion.activeSuggestionIds
-      ).toHaveLength(0);
-    });
-
-    it("should clear all suggestion IDs from storage", () => {
-      editor.commands.setContent("Hello world", {
-        contentType: "markdown",
-      });
-
-      editor.commands.applySuggestion({
-        id: "reject-all-2",
-        find: "world",
-        replacement: "there",
-      });
-
-      expect(
-        editor.storage.instructionSuggestion.activeSuggestionIds
-      ).toHaveLength(1);
-
-      editor.commands.rejectAllSuggestions();
-
-      expect(
-        editor.storage.instructionSuggestion.activeSuggestionIds
-      ).toHaveLength(0);
-    });
-  });
-
-  describe("getCommittedTextContent", () => {
-    it("should return text without addition marks", () => {
-      editor.commands.setContent("Hello world", { contentType: "markdown" });
-
-      editor.commands.applySuggestion({
-        id: "committed-1",
-        find: "world",
-        replacement: "there",
-      });
-
-      // getCommittedTextContent should return original text (without additions)
-      const committed = getCommittedTextContent(editor);
-      expect(committed).toContain("Hello");
-      expect(committed).toContain("world");
-      expect(committed).not.toContain("there");
-    });
-
-    it("should return empty string for editor with only additions", () => {
-      editor.commands.setContent("", { contentType: "markdown" });
-
-      editor.commands.applySuggestion({
-        id: "committed-2",
-        find: "",
-        replacement: "new content",
-      });
-
-      const committed = getCommittedTextContent(editor);
-      // Should not contain the addition
-      expect(committed).not.toContain("new content");
-    });
-
-    it("should return full text when no suggestions applied", () => {
-      editor.commands.setContent("Hello world", { contentType: "markdown" });
-
-      const committed = getCommittedTextContent(editor);
-      expect(committed).toContain("Hello world");
+      expect(getActiveSuggestionIds(editor.state)).toHaveLength(0);
     });
   });
 });

--- a/front/components/editor/extensions/agent_builder/InstructionSuggestionExtension.test.ts
+++ b/front/components/editor/extensions/agent_builder/InstructionSuggestionExtension.test.ts
@@ -11,6 +11,7 @@ import {
   getActiveSuggestionIds,
   getActiveSuggestions,
   InstructionSuggestionExtension,
+  SUGGESTION_ID_ATTRIBUTE,
 } from "@app/components/editor/extensions/agent_builder/InstructionSuggestionExtension";
 import { EditorFactory } from "@app/components/editor/extensions/tests/utils";
 
@@ -19,7 +20,7 @@ function getDeletions(editor: Editor) {
     editor.view.dom.querySelectorAll(".suggestion-deletion")
   ).map((el) => ({
     text: el.textContent,
-    suggestionId: el.getAttribute("data-suggestion-id"),
+    suggestionId: el.getAttribute(SUGGESTION_ID_ATTRIBUTE),
   }));
 }
 
@@ -28,7 +29,7 @@ function getAdditions(editor: Editor) {
     editor.view.dom.querySelectorAll(".suggestion-addition")
   ).map((el) => ({
     text: el.textContent,
-    suggestionId: el.getAttribute("data-suggestion-id"),
+    suggestionId: el.getAttribute(SUGGESTION_ID_ATTRIBUTE),
   }));
 }
 

--- a/front/components/editor/extensions/agent_builder/InstructionSuggestionExtension.test.ts
+++ b/front/components/editor/extensions/agent_builder/InstructionSuggestionExtension.test.ts
@@ -538,17 +538,13 @@ describe("InstructionSuggestionExtension", () => {
 
     it("should detect suffix replacement", () => {
       const changes = diff("Hello world", "Hello there");
-      expect(changes).toEqual([
-        { fromA: 6, toA: 11, fromB: 6, toB: 11 },
-      ]);
+      expect(changes).toEqual([{ fromA: 6, toA: 11, fromB: 6, toB: 11 }]);
     });
 
     it("should detect prefix replacement", () => {
       // "Hello world" → "Hi world": common prefix "H", common suffix " world".
       const changes = diff("Hello world", "Hi world");
-      expect(changes).toEqual([
-        { fromA: 1, toA: 5, fromB: 1, toB: 2 },
-      ]);
+      expect(changes).toEqual([{ fromA: 1, toA: 5, fromB: 1, toB: 2 }]);
     });
 
     it("should detect two disjoint changes", () => {
@@ -562,9 +558,7 @@ describe("InstructionSuggestionExtension", () => {
 
     it("should detect full replacement", () => {
       const changes = diff("old", "new");
-      expect(changes).toEqual([
-        { fromA: 0, toA: 3, fromB: 0, toB: 3 },
-      ]);
+      expect(changes).toEqual([{ fromA: 0, toA: 3, fromB: 0, toB: 3 }]);
     });
 
     it("should return empty array for identical content", () => {
@@ -574,16 +568,12 @@ describe("InstructionSuggestionExtension", () => {
 
     it("should detect pure insertion", () => {
       const changes = diff("ab", "aXb");
-      expect(changes).toEqual([
-        { fromA: 1, toA: 1, fromB: 1, toB: 2 },
-      ]);
+      expect(changes).toEqual([{ fromA: 1, toA: 1, fromB: 1, toB: 2 }]);
     });
 
     it("should detect pure deletion", () => {
       const changes = diff("aXb", "ab");
-      expect(changes).toEqual([
-        { fromA: 1, toA: 2, fromB: 1, toB: 1 },
-      ]);
+      expect(changes).toEqual([{ fromA: 1, toA: 2, fromB: 1, toB: 1 }]);
     });
   });
 });

--- a/front/components/editor/extensions/agent_builder/InstructionSuggestionExtension.ts
+++ b/front/components/editor/extensions/agent_builder/InstructionSuggestionExtension.ts
@@ -28,7 +28,7 @@ interface PluginState {
 }
 
 // Change range from diffing old vs new content.
-interface BlockChange {
+export interface BlockChange {
   fromA: number; // Range in old content.
   toA: number;
   fromB: number; // Range in new content.
@@ -47,7 +47,7 @@ const CLASSES = {
     "suggestion-addition rounded px-0.5 bg-blue-50 dark:bg-blue-900/20 text-gray-400",
 };
 
-function diffBlockContent(
+export function diffBlockContent(
   oldNode: PMNode,
   newNode: PMNode,
   schema: Schema

--- a/front/components/editor/extensions/agent_builder/InstructionSuggestionExtension.ts
+++ b/front/components/editor/extensions/agent_builder/InstructionSuggestionExtension.ts
@@ -67,6 +67,8 @@ export function diffBlockContent(
     null
   );
 
+  // Convert from doc positions (content starts at 1, after the block's opening token) back to
+  // block-content-relative coordinates (starting at 0).
   return changeSet.changes.map((change) => ({
     fromA: change.fromA - 1,
     toA: change.toA - 1,

--- a/front/components/editor/extensions/agent_builder/InstructionSuggestionExtension.ts
+++ b/front/components/editor/extensions/agent_builder/InstructionSuggestionExtension.ts
@@ -37,6 +37,8 @@ export interface BlockChange {
 
 const pluginKey = new PluginKey<PluginState>("suggestionPlugin");
 
+export const SUGGESTION_ID_ATTRIBUTE = "data-suggestion-id";
+
 const CLASSES = {
   remove:
     "suggestion-deletion rounded px-0.5 line-through bg-red-100 dark:bg-red-900/50 text-red-800 dark:text-red-200",
@@ -162,7 +164,7 @@ function buildDecorations(
               contentStart + change.toA,
               {
                 class: isHighlighted ? CLASSES.remove : CLASSES.removeDimmed,
-                "data-suggestion-id": suggestionId,
+                [SUGGESTION_ID_ATTRIBUTE]: suggestionId,
               }
             )
           );
@@ -179,7 +181,7 @@ function buildDecorations(
                 span.className = isHighlighted
                   ? CLASSES.add
                   : CLASSES.addDimmed;
-                span.setAttribute("data-suggestion-id", suggestionId);
+                span.setAttribute(SUGGESTION_ID_ATTRIBUTE, suggestionId);
                 span.contentEditable = "false";
 
                 const serializer = DOMSerializer.fromSchema(schema);

--- a/front/package.json
+++ b/front/package.json
@@ -181,6 +181,7 @@
     "postcss": "^8.5.6",
     "posthog-js": "^1.266.1",
     "posthog-node": "^5.8.5",
+    "prosemirror-changeset": "^2.3.1",
     "react": "^18.3.1",
     "react-beforeunload": "^2.5.3",
     "react-cookie": "^7.2.2",

--- a/front/tests/utils/AgentSuggestionFactory.ts
+++ b/front/tests/utils/AgentSuggestionFactory.ts
@@ -28,7 +28,7 @@ export class AgentSuggestionFactory {
       {
         kind: "instructions",
         suggestion: overrides.suggestion ?? {
-          content: "You are a helpful assistant.",
+          content: "<p>You are a helpful assistant.</p>",
           targetBlockId: "12334",
           type: "replace",
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -514,6 +514,7 @@
         "postcss": "^8.5.6",
         "posthog-js": "^1.266.1",
         "posthog-node": "^5.8.5",
+        "prosemirror-changeset": "^2.3.1",
         "react": "^18.3.1",
         "react-beforeunload": "^2.5.3",
         "react-cookie": "^7.2.2",


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Follow up of https://github.com/dust-tt/dust/pull/21205.

This PR adds support to show a proper visual diff when the suggestion replaces the whole node.

How it works:
- When a suggestion changes a block's node type (e.g. paragraph to heading), use whole-block decorations instead of inline diffs so the new node renders with proper styling
- `acceptSuggestion` replace the entire block node (not just inner content) when types differ, preserving the block ID

## Demo

![WholeBlockReplacement](https://github.com/user-attachments/assets/89728074-3748-4a70-ab6d-dc0e4fd5baa8)

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
