### PR TITLE
feat(agents): allow searching archived in manage

### DIFF
--- a/front/components/assistant/manager/AssistantsTable.tsx
+++ b/front/components/assistant/manager/AssistantsTable.tsx
@@ -31,7 +31,6 @@ import {
 import { getAgentBuilderRoute } from "@app/lib/utils/router";
 import type {
   AgentConfigurationScope,
-  AgentConfigurationStatus,
   AgentUsageType,
   LightAgentConfigurationType,
   WorkspaceType,
@@ -50,7 +49,6 @@ type RowData = {
   feedbacks: { up: number; down: number } | undefined;
   lastUpdate: string | null;
   scope: AgentConfigurationScope;
-  status: AgentConfigurationStatus;
   onClick?: () => void;
   menuItems?: MenuItem[];
   agentTags: TagType[];
@@ -146,17 +144,13 @@ const getTableColumns = ({
         <DataTable.CellContent
           disabled={isDisabled(info.row.original.canArchive, isBatchEdit)}
         >
-          {info.row.original.status === "archived" ? (
-            <Chip size="xs" label="Archived" color="warning" />
-          ) : (
-            info.getValue() !== "hidden" && (
-              <Chip
-                size="xs"
-                label={SCOPE_INFO[info.getValue()].shortLabel}
-                color={SCOPE_INFO[info.getValue()].color}
-                icon={SCOPE_INFO[info.getValue()].icon}
-              />
-            )
+          {info.getValue() !== "hidden" && (
+            <Chip
+              size="xs"
+              label={SCOPE_INFO[info.getValue()].shortLabel}
+              color={SCOPE_INFO[info.getValue()].color}
+              icon={SCOPE_INFO[info.getValue()].icon}
+            />
           )}
         </DataTable.CellContent>
       ),
@@ -385,7 +379,6 @@ export function AssistantsTable({
           feedbacks: agentConfiguration.feedbacks,
           editors: agentConfiguration.editors ?? [],
           scope: agentConfiguration.scope,
-          status: agentConfiguration.status,
           agentTags: agentConfiguration.tags,
           agentTagsAsString:
             agentConfiguration.tags.length > 0

--- a/front/components/assistant/manager/AssistantsTable.tsx
+++ b/front/components/assistant/manager/AssistantsTable.tsx
@@ -31,6 +31,7 @@ import {
 import { getAgentBuilderRoute } from "@app/lib/utils/router";
 import type {
   AgentConfigurationScope,
+  AgentConfigurationStatus,
   AgentUsageType,
   LightAgentConfigurationType,
   WorkspaceType,
@@ -49,6 +50,7 @@ type RowData = {
   feedbacks: { up: number; down: number } | undefined;
   lastUpdate: string | null;
   scope: AgentConfigurationScope;
+  status: AgentConfigurationStatus;
   onClick?: () => void;
   menuItems?: MenuItem[];
   agentTags: TagType[];
@@ -144,13 +146,17 @@ const getTableColumns = ({
         <DataTable.CellContent
           disabled={isDisabled(info.row.original.canArchive, isBatchEdit)}
         >
-          {info.getValue() !== "hidden" && (
-            <Chip
-              size="xs"
-              label={SCOPE_INFO[info.getValue()].shortLabel}
-              color={SCOPE_INFO[info.getValue()].color}
-              icon={SCOPE_INFO[info.getValue()].icon}
-            />
+          {info.row.original.status === "archived" ? (
+            <Chip size="xs" label="Archived" color="warning" />
+          ) : (
+            info.getValue() !== "hidden" && (
+              <Chip
+                size="xs"
+                label={SCOPE_INFO[info.getValue()].shortLabel}
+                color={SCOPE_INFO[info.getValue()].color}
+                icon={SCOPE_INFO[info.getValue()].icon}
+              />
+            )
           )}
         </DataTable.CellContent>
       ),
@@ -379,6 +385,7 @@ export function AssistantsTable({
           feedbacks: agentConfiguration.feedbacks,
           editors: agentConfiguration.editors ?? [],
           scope: agentConfiguration.scope,
+          status: agentConfiguration.status,
           agentTags: agentConfiguration.tags,
           agentTagsAsString:
             agentConfiguration.tags.length > 0

--- a/front/components/pages/builder/agents/ManageAgentsPage.tsx
+++ b/front/components/pages/builder/agents/ManageAgentsPage.tsx
@@ -61,9 +61,15 @@ export const AGENT_MANAGER_TABS = [
   },
   {
     id: "search",
-    label: "Searching across all agents",
+    label: "Active",
     icon: MagnifyingGlassIcon,
-    description: "Searching across all agents",
+    description: "Active agents matching your search",
+  },
+  {
+    id: "search_archived",
+    label: "Archived",
+    icon: MagnifyingGlassIcon,
+    description: "Archived agents matching your search",
   },
 ] as const;
 
@@ -96,13 +102,17 @@ export function ManageAgentsPage() {
     isFeatureFlagsLoading || isRestrictedFromAgentCreation;
   const isSearchActive = assistantSearch.trim() !== "";
 
+  const [selectedSearchTab, setSelectedSearchTab] = useState<
+    "search" | "search_archived"
+  >("search");
+
   const activeTab = useMemo(() => {
     if (isSearchActive) {
-      return "search";
+      return selectedSearchTab;
     }
 
     return selectedTab && isValidTab(selectedTab) ? selectedTab : "all_custom";
-  }, [isSearchActive, selectedTab]);
+  }, [isSearchActive, selectedTab, selectedSearchTab]);
 
   // only fetch the agents that are relevant to the current scope, except when
   // user searches: search across all agents
@@ -152,7 +162,19 @@ export function ManageAgentsPage() {
       archived: archivedAgentConfigurations.sort((a, b) =>
         a.name.toLowerCase().localeCompare(b.name.toLowerCase())
       ),
-      search: [...agentConfigurations, ...archivedAgentConfigurations]
+      search: agentConfigurations
+        .filter((a) =>
+          // Filters on search query
+          subFilter(assistantSearch.toLowerCase(), getAgentSearchString(a))
+        )
+        .sort((a, b) => {
+          return compareForFuzzySort(
+            assistantSearch.toLowerCase(),
+            getAgentSearchString(a),
+            getAgentSearchString(b)
+          );
+        }),
+      search_archived: archivedAgentConfigurations
         .filter((a) =>
           // Filters on search query
           subFilter(assistantSearch.toLowerCase(), getAgentSearchString(a))
@@ -216,16 +238,21 @@ export function ManageAgentsPage() {
     await mutateAgentConfigurations();
   };
 
-  // if search is active, only show the search tab, otherwise show all tabs with agents except the search tab
+  // if search is active, show search tabs, otherwise show all tabs except search tabs
   const visibleTabs = useMemo(() => {
     const searchTab = AGENT_MANAGER_TABS.find((tab) => tab.id === "search");
-    if (!searchTab) {
-      throw new Error("Unexpected: Search tab not found");
+    const searchArchivedTab = AGENT_MANAGER_TABS.find(
+      (tab) => tab.id === "search_archived"
+    );
+    if (!searchTab || !searchArchivedTab) {
+      throw new Error("Unexpected: Search tabs not found");
     }
 
     return isSearchActive
-      ? [searchTab]
-      : AGENT_MANAGER_TABS.filter((tab) => tab.id !== "search");
+      ? [searchTab, searchArchivedTab]
+      : AGENT_MANAGER_TABS.filter(
+          (tab) => tab.id !== "search" && tab.id !== "search_archived"
+        );
   }, [isSearchActive]);
 
   const searchBarRef = useRef<HTMLInputElement>(null);
@@ -361,12 +388,25 @@ export function ManageAgentsPage() {
                       key={tab.id}
                       value={tab.id}
                       label={tab.label}
-                      onClick={() => !assistantSearch && setSelectedTab(tab.id)}
+                      onClick={() => {
+                        if (isSearchActive) {
+                          if (
+                            tab.id === "search" ||
+                            tab.id === "search_archived"
+                          ) {
+                            setSelectedSearchTab(tab.id);
+                          }
+                        } else {
+                          setSelectedTab(tab.id);
+                        }
+                      }}
                       tooltip={
                         AGENT_MANAGER_TABS.find((t) => t.id === tab.id)
                           ?.description
                       }
-                      isCounter={tab.id !== "archived"}
+                      isCounter={
+                        tab.id !== "archived" && tab.id !== "search_archived"
+                      }
                       counterValue={`${agentsByTab[tab.id].length}`}
                     />
                   ))}

--- a/front/components/pages/builder/agents/ManageAgentsPage.tsx
+++ b/front/components/pages/builder/agents/ManageAgentsPage.tsx
@@ -128,7 +128,9 @@ export function ManageAgentsPage() {
     workspaceId: owner.sId,
     agentsGetView: "archived",
     includes: ["usage", "feedbacks", "editors"],
-    disabled: shouldDisableAgentFetching || selectedTab !== "archived",
+    disabled:
+      shouldDisableAgentFetching ||
+      (selectedTab !== "archived" && !isSearchActive),
   });
 
   const agentsByTab = useMemo(() => {
@@ -150,12 +152,10 @@ export function ManageAgentsPage() {
       archived: archivedAgentConfigurations.sort((a, b) =>
         a.name.toLowerCase().localeCompare(b.name.toLowerCase())
       ),
-      search: agentConfigurations
-        .filter(
-          (a) =>
-            a.status === "active" &&
-            // Filters on search query
-            subFilter(assistantSearch.toLowerCase(), getAgentSearchString(a))
+      search: [...agentConfigurations, ...archivedAgentConfigurations]
+        .filter((a) =>
+          // Filters on search query
+          subFilter(assistantSearch.toLowerCase(), getAgentSearchString(a))
         )
         .sort((a, b) => {
           return compareForFuzzySort(
@@ -294,7 +294,7 @@ export function ManageAgentsPage() {
               name="search"
               placeholder="Search (Name, Editors)"
               value={assistantSearch}
-              onChange={(s) => {
+              onChange={(s: string) => {
                 setAssistantSearch(s);
               }}
             />

--- a/front/components/pages/builder/agents/ManageAgentsPage.tsx
+++ b/front/components/pages/builder/agents/ManageAgentsPage.tsx
@@ -154,6 +154,18 @@ export function ManageAgentsPage() {
       })
       .sort((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()));
 
+    const searchLower = assistantSearch.toLowerCase();
+    const filterAndSortBySearch = (agents: LightAgentConfigurationType[]) =>
+      agents
+        .filter((a) => subFilter(searchLower, getAgentSearchString(a)))
+        .sort((a, b) =>
+          compareForFuzzySort(
+            searchLower,
+            getAgentSearchString(a),
+            getAgentSearchString(b)
+          )
+        );
+
     return {
       // do not show the "all" tab while still loading all agents
       all_custom: allAgents.filter((a) => a.scope !== "global"),
@@ -162,30 +174,8 @@ export function ManageAgentsPage() {
       archived: archivedAgentConfigurations.sort((a, b) =>
         a.name.toLowerCase().localeCompare(b.name.toLowerCase())
       ),
-      search: agentConfigurations
-        .filter((a) =>
-          // Filters on search query
-          subFilter(assistantSearch.toLowerCase(), getAgentSearchString(a))
-        )
-        .sort((a, b) => {
-          return compareForFuzzySort(
-            assistantSearch.toLowerCase(),
-            getAgentSearchString(a),
-            getAgentSearchString(b)
-          );
-        }),
-      search_archived: archivedAgentConfigurations
-        .filter((a) =>
-          // Filters on search query
-          subFilter(assistantSearch.toLowerCase(), getAgentSearchString(a))
-        )
-        .sort((a, b) => {
-          return compareForFuzzySort(
-            assistantSearch.toLowerCase(),
-            getAgentSearchString(a),
-            getAgentSearchString(b)
-          );
-        }),
+      search: filterAndSortBySearch(agentConfigurations),
+      search_archived: filterAndSortBySearch(archivedAgentConfigurations),
     };
   }, [
     agentConfigurations,

--- a/front/lib/api/assistant/configuration/views.ts
+++ b/front/lib/api/assistant/configuration/views.ts
@@ -194,6 +194,7 @@ async function fetchWorkspaceAgentConfigurationsWithoutActions(
 
         return AgentConfigurationModel.findAll({
           where: {
+            workspaceId: owner.id,
             id: {
               [Op.in]: filteredIds,
             },


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

This PR allows searching through archived agents. see https://dust4ai.slack.com/archives/C066R3PMUAU/p1770314669839789
Adds a red pill "archived" in access column when searching.

e.g :
<img width="1624" height="1061" alt="Capture d’écran 2026-02-06 à 09 03 50" src="https://github.com/user-attachments/assets/f15b929b-bd30-4dc0-ab3f-91a42747d267" />

Also fixes a workspace iso in the agent fetch

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front