### PR TITLE
Fix SPA 401 on file uploads by sending credentials for absolute API URLs

### DIFF
--- a/front/lib/egress/client.ts
+++ b/front/lib/egress/client.ts
@@ -27,14 +27,16 @@ export function clientFetch(
 ): Promise<Response> {
   const baseUrl = getApiBaseUrl();
 
-  // Only prepend base URL for relative paths (starting with /).
-  if (
-    baseUrl.length > 0 &&
-    typeof input === "string" &&
-    input.startsWith("/")
-  ) {
-    input = `${baseUrl}${input}`;
-    init = { ...init, credentials: "include" };
+  if (baseUrl.length > 0 && typeof input === "string") {
+    if (input.startsWith("/")) {
+      input = `${baseUrl}${input}`;
+    }
+
+    // Include credentials for all requests targeting the API (needed for
+    // cross-origin requests from the SPA on app.dust.tt to the API on dust.tt).
+    if (input.startsWith(baseUrl)) {
+      init = { ...init, credentials: "include" };
+    }
   }
 
   // eslint-disable-next-line no-restricted-globals


### PR DESCRIPTION
## Description

When uploading files from the SPA (`app.dust.tt`), the request to upload file content was failing with a 401 "not_authenticated" error. This only affected the SPA, not the Next.js frontend.

### Root cause

The file upload flow has two steps:
1. `POST /api/w/{wId}/files` to create the file record
2. `POST` to the returned `file.uploadUrl` to upload the content

Step 1 uses a relative URL (`/api/w/...`), which `clientFetch` correctly prepends with the API base URL and adds `credentials: "include"`.

Step 2 uses `file.uploadUrl` — an **absolute** URL returned by the server (e.g. `https://dust.tt/api/w/.../files/...`). The old `clientFetch` only added `credentials: "include"` for relative URLs (starting with `/`). Since the SPA is on `app.dust.tt` (different origin than `dust.tt`), the browser's default `credentials: "same-origin"` policy skipped sending the `workos_session` cookie, causing the 401.

The same absolute URL issue affected the image preview after upload: `sourceUrl` was set to `fileUploaded.downloadUrl` (absolute), which violated CSP `img-src 'self'` when the page origin didn't match.

### Fix

- **`clientFetch` (client.ts)**: Also set `credentials: "include"` for absolute URLs that start with the API base URL. This is a safety net for any code passing absolute API URLs. No-op in Next.js where `getApiBaseUrl()` returns `""`.
- **`useFileUploaderService.ts`**: Stop using the server-provided absolute `file.uploadUrl` and `fileUploaded.downloadUrl`. Instead, construct URLs client-side using `getApiBaseUrl()`:
  - In Next.js: returns `""` → relative URL → resolves to same-origin
  - In SPA: returns `"https://dust.tt"` → absolute URL → credentials added

The server is correct to return absolute URLs (needed by the public API and extensions), but the frontend client must construct its own URLs because only it knows its rendering context.

Existing conversations are not affected — their `sourceUrl` comes from the server via content fragments, not from this upload path.


## Tests

- [ ] Upload a file (image) in a conversation from the SPA — no 401
- [ ] Verify the image preview displays correctly in the SPA input bar
- [ ] Upload a file from the Next.js frontend — still works, no CSP errors
- [ ] Verify image preview displays correctly in Next.js
- [ ] Click to zoom/download an uploaded image — works in both frontends

## Risk

Break upload. 
Can be rolled back. 

## Deploy Plan

Deploy front. 