### PR TITLE
feat: move mentions to a skill

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
@@ -899,37 +899,6 @@
         }
       },
       {
-        "name": "get_mention_markdown",
-        "description": "Get the markdown directive to use to mention a user in a message.",
-        "inputSchema": {
-          "$schema": "http://json-schema.org/draft-07/schema#",
-          "additionalProperties": false,
-          "properties": {
-            "mention": {
-              "additionalProperties": false,
-              "description": "A mention to get the markdown directive for.",
-              "properties": {
-                "id": {
-                  "type": "string"
-                },
-                "label": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "id",
-                "label"
-              ],
-              "type": "object"
-            }
-          },
-          "required": [
-            "mention"
-          ],
-          "type": "object"
-        }
-      },
-      {
         "name": "math_operation",
         "description": "Perform mathematical operations.",
         "inputSchema": {
@@ -943,24 +912,6 @@
           },
           "required": [
             "expression"
-          ],
-          "type": "object"
-        }
-      },
-      {
-        "name": "search_available_users",
-        "description": "Search for users that are available to the conversation.",
-        "inputSchema": {
-          "$schema": "http://json-schema.org/draft-07/schema#",
-          "additionalProperties": false,
-          "properties": {
-            "searchTerm": {
-              "description": "A single search term to find users. Returns all the users that contain the search term in their name or description. Use an empty string to return all items.",
-              "type": "string"
-            }
-          },
-          "required": [
-            "searchTerm"
           ],
           "type": "object"
         }
@@ -990,9 +941,7 @@
       "generate_random_float": "never_ask",
       "generate_random_number": "never_ask",
       "get_current_time": "never_ask",
-      "get_mention_markdown": "never_ask",
       "math_operation": "never_ask",
-      "search_available_users": "never_ask",
       "wait": "never_ask"
     }
   },
@@ -16219,6 +16168,64 @@
       "get_pto_request_notes": "never_ask",
       "get_pto_requests": "never_ask",
       "get_schedules": "never_ask"
+    }
+  },
+  {
+    "name": "user_mentions",
+    "tools": [
+      {
+        "name": "get_mention_markdown",
+        "description": "Get the markdown directive to use to mention a user in a message.",
+        "inputSchema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "additionalProperties": false,
+          "properties": {
+            "mention": {
+              "additionalProperties": false,
+              "description": "A mention to get the markdown directive for.",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "label": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "id",
+                "label"
+              ],
+              "type": "object"
+            }
+          },
+          "required": [
+            "mention"
+          ],
+          "type": "object"
+        }
+      },
+      {
+        "name": "search_available_users",
+        "description": "Search for users that are available to the conversation.",
+        "inputSchema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "additionalProperties": false,
+          "properties": {
+            "searchTerm": {
+              "description": "A single search term to find users. Returns all the users that contain the search term in their name or description. Use an empty string to return all items.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "searchTerm"
+          ],
+          "type": "object"
+        }
+      }
+    ],
+    "toolsStakes": {
+      "get_mention_markdown": "never_ask",
+      "search_available_users": "never_ask"
     }
   },
   {

--- a/front/lib/actions/mcp_internal_actions/constants.test.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.test.ts
@@ -64,6 +64,7 @@ describe("INTERNAL_MCP_SERVERS", () => {
       { name: "agent_copilot_agent_state", id: 1023 },
       { name: "sandbox", id: 1024 },
       { name: "project_conversation", id: 1025 },
+      { name: "user_mentions", id: 1026 },
     ];
     expect(
       autoInternalTools,

--- a/front/lib/actions/mcp_internal_actions/constants.ts
+++ b/front/lib/actions/mcp_internal_actions/constants.ts
@@ -69,6 +69,7 @@ import { SPEECH_GENERATOR_SERVER } from "@app/lib/api/actions/servers/speech_gen
 import { STATUSPAGE_SERVER } from "@app/lib/api/actions/servers/statuspage/metadata";
 import { TOOLSETS_SERVER } from "@app/lib/api/actions/servers/toolsets/metadata";
 import { UKG_READY_SERVER } from "@app/lib/api/actions/servers/ukg_ready/metadata";
+import { USER_MENTIONS_SERVER } from "@app/lib/api/actions/servers/user_mentions/metadata";
 import { VAL_TOWN_SERVER } from "@app/lib/api/actions/servers/val_town/metadata";
 import { VANTA_SERVER } from "@app/lib/api/actions/servers/vanta/metadata";
 import {
@@ -181,6 +182,7 @@ export const AVAILABLE_INTERNAL_MCP_SERVER_NAMES = [
   "statuspage",
   "toolsets",
   "ukg_ready",
+  "user_mentions",
   "val_town",
   "vanta",
   "front",
@@ -1051,6 +1053,17 @@ export const INTERNAL_MCP_SERVERS = {
     tools_retry_policies: undefined,
     timeoutMs: undefined,
     metadata: PROJECT_CONVERSATION_SERVER,
+  },
+  user_mentions: {
+    id: 1026,
+    availability: "auto_hidden_builder",
+    allowMultipleInstances: false,
+    isPreview: false,
+    isRestricted: undefined,
+    tools_arguments_requiring_approval: undefined,
+    tools_retry_policies: undefined,
+    timeoutMs: undefined,
+    metadata: USER_MENTIONS_SERVER,
   },
   // Using satisfies here instead of: type to avoid TypeScript widening the type and breaking the type inference for AutoInternalMCPServerNameType.
 } satisfies {

--- a/front/lib/actions/mcp_internal_actions/servers/index.ts
+++ b/front/lib/actions/mcp_internal_actions/servers/index.ts
@@ -67,6 +67,7 @@ import { default as speechGenerator } from "@app/lib/api/actions/servers/speech_
 import { default as statuspageServer } from "@app/lib/api/actions/servers/statuspage";
 import { default as toolsetsServer } from "@app/lib/api/actions/servers/toolsets";
 import { default as ukgReadyServer } from "@app/lib/api/actions/servers/ukg_ready";
+import { default as userMentionsServer } from "@app/lib/api/actions/servers/user_mentions";
 import { default as valtownServer } from "@app/lib/api/actions/servers/val_town";
 import { default as vantaServer } from "@app/lib/api/actions/servers/vanta";
 import { default as webSearchBrowseServer } from "@app/lib/api/actions/servers/web_search_browse";
@@ -237,6 +238,8 @@ export async function getInternalMCPServer(
       return projectConversationServer(auth, agentLoopContext);
     case "ukg_ready":
       return ukgReadyServer(auth, agentLoopContext);
+    case "user_mentions":
+      return userMentionsServer(auth, agentLoopContext);
     case "statuspage":
       return statuspageServer(auth, agentLoopContext);
     case "sandbox":

--- a/front/lib/api/actions/servers/common_utilities/metadata.ts
+++ b/front/lib/api/actions/servers/common_utilities/metadata.ts
@@ -6,8 +6,6 @@ import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_
 import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 
 export const COMMON_UTILITIES_SERVER_NAME = "common_utilities" as const;
-export const SEARCH_AVAILABLE_USERS_TOOL_NAME = "search_available_users";
-export const GET_MENTION_MARKDOWN_TOOL_NAME = "get_mention_markdown";
 
 const RANDOM_INTEGER_DEFAULT_MAX = 1_000_000;
 const MAX_WAIT_DURATION_MS = 3 * 60 * 1_000;
@@ -89,38 +87,6 @@ export const COMMON_UTILITIES_TOOLS_METADATA = createToolsRecord({
     displayLabels: {
       running: "Calculating",
       done: "Calculate",
-    },
-  },
-  [SEARCH_AVAILABLE_USERS_TOOL_NAME]: {
-    description: "Search for users that are available to the conversation.",
-    schema: {
-      searchTerm: z
-        .string()
-        .describe(
-          "A single search term to find users. Returns all the users that contain the search term in their name or description. Use an empty string to return all items."
-        ),
-    },
-    stake: "never_ask",
-    displayLabels: {
-      running: "Searching users",
-      done: "Search users",
-    },
-  },
-  [GET_MENTION_MARKDOWN_TOOL_NAME]: {
-    description:
-      "Get the markdown directive to use to mention a user in a message.",
-    schema: {
-      mention: z
-        .object({
-          id: z.string(),
-          label: z.string(),
-        })
-        .describe("A mention to get the markdown directive for."),
-    },
-    stake: "never_ask",
-    displayLabels: {
-      running: "Getting mention markdown",
-      done: "Get mention markdown",
     },
   },
 });

--- a/front/lib/api/actions/servers/common_utilities/tools/index.ts
+++ b/front/lib/api/actions/servers/common_utilities/tools/index.ts
@@ -1,20 +1,10 @@
-// eslint-disable-next-line dust/enforce-client-types-in-public-api
-import { DustAPI } from "@dust-tt/client";
 import { compile } from "mathjs";
 
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
-import {
-  GET_MENTION_MARKDOWN_TOOL_NAME,
-  SEARCH_AVAILABLE_USERS_TOOL_NAME,
-} from "@app/lib/api/actions/servers/common_utilities/metadata";
 import { COMMON_UTILITIES_TOOLS_METADATA } from "@app/lib/api/actions/servers/common_utilities/metadata";
-import config from "@app/lib/api/config";
-import { prodAPICredentialsForOwner } from "@app/lib/auth";
-import { serializeMention } from "@app/lib/mentions/format";
-import logger from "@app/logger/logger";
-import { Err, getHeaderFromUserEmail, normalizeError, Ok } from "@app/types";
+import { Err, normalizeError, Ok } from "@app/types";
 
 const RANDOM_INTEGER_DEFAULT_MAX = 1_000_000;
 
@@ -102,68 +92,6 @@ const handlers: ToolHandlers<typeof COMMON_UTILITIES_TOOLS_METADATA> = {
         })
       );
     }
-  },
-
-  [SEARCH_AVAILABLE_USERS_TOOL_NAME]: async ({ searchTerm }, extra) => {
-    const auth = extra.auth;
-    if (!auth) {
-      return new Err(new MCPError("Authentication required"));
-    }
-
-    const user = auth.user();
-    const prodCredentials = await prodAPICredentialsForOwner(
-      auth.getNonNullableWorkspace()
-    );
-    const api = new DustAPI(
-      config.getDustAPIConfig(),
-      {
-        ...prodCredentials,
-        extraHeaders: {
-          // We use a system API key to override the user here (not groups and role) so that the
-          // sub-agent can access the same spaces as the user but also as the sub-agent may rely
-          // on personal actions that have to be operated in the name of the user initiating the
-          // interaction.
-          ...getHeaderFromUserEmail(user?.email),
-        },
-      },
-      logger
-    );
-
-    const r = await api.getMentionsSuggestions({
-      query: searchTerm,
-      select: ["users"],
-      conversationId: extra.agentLoopContext?.runContext?.conversation?.sId,
-    });
-
-    if (r.isErr()) {
-      return new Err(
-        new MCPError(`Error getting mentions suggestions: ${r.error.message}`, {
-          cause: r.error,
-        })
-      );
-    }
-
-    const suggestions = r.value;
-
-    return new Ok([
-      {
-        type: "text",
-        text: JSON.stringify(suggestions),
-      },
-    ]);
-  },
-
-  [GET_MENTION_MARKDOWN_TOOL_NAME]: async ({ mention }, _extra) => {
-    return new Ok([
-      {
-        type: "text",
-        text: serializeMention({
-          id: mention.id,
-          label: mention.label,
-          type: "user",
-        }),
-      },
-    ]);
   },
 };
 

--- a/front/lib/api/actions/servers/user_mentions/index.ts
+++ b/front/lib/api/actions/servers/user_mentions/index.ts
@@ -1,0 +1,25 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
+import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
+import { USER_MENTIONS_SERVER_NAME } from "@app/lib/api/actions/servers/user_mentions/metadata";
+import { TOOLS } from "@app/lib/api/actions/servers/user_mentions/tools";
+import type { Authenticator } from "@app/lib/auth";
+
+function createServer(
+  auth: Authenticator,
+  agentLoopContext?: AgentLoopContextType
+): McpServer {
+  const server = makeInternalMCPServer(USER_MENTIONS_SERVER_NAME);
+
+  for (const tool of TOOLS) {
+    registerTool(auth, agentLoopContext, server, tool, {
+      monitoringName: USER_MENTIONS_SERVER_NAME,
+    });
+  }
+
+  return server;
+}
+
+export default createServer;

--- a/front/lib/api/actions/servers/user_mentions/metadata.ts
+++ b/front/lib/api/actions/servers/user_mentions/metadata.ts
@@ -1,0 +1,66 @@
+import type { JSONSchema7 as JSONSchema } from "json-schema";
+import { z } from "zod";
+import { zodToJsonSchema } from "zod-to-json-schema";
+
+import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+
+export const USER_MENTIONS_SERVER_NAME = "user_mentions" as const;
+export const SEARCH_AVAILABLE_USERS_TOOL_NAME = "search_available_users";
+export const GET_MENTION_MARKDOWN_TOOL_NAME = "get_mention_markdown";
+
+export const USER_MENTIONS_TOOLS_METADATA = createToolsRecord({
+  [SEARCH_AVAILABLE_USERS_TOOL_NAME]: {
+    description: "Search for users that are available to the conversation.",
+    schema: {
+      searchTerm: z
+        .string()
+        .describe(
+          "A single search term to find users. Returns all the users that contain the search term in their name or description. Use an empty string to return all items."
+        ),
+    },
+    stake: "never_ask",
+    displayLabels: {
+      running: "Searching users",
+      done: "Search users",
+    },
+  },
+  [GET_MENTION_MARKDOWN_TOOL_NAME]: {
+    description:
+      "Get the markdown directive to use to mention a user in a message.",
+    schema: {
+      mention: z
+        .object({
+          id: z.string(),
+          label: z.string(),
+        })
+        .describe("A mention to get the markdown directive for."),
+    },
+    stake: "never_ask",
+    displayLabels: {
+      running: "Getting mention markdown",
+      done: "Get mention markdown",
+    },
+  },
+});
+
+export const USER_MENTIONS_SERVER = {
+  serverInfo: {
+    name: USER_MENTIONS_SERVER_NAME,
+    version: "1.0.0",
+    description: "Tools for mentioning users in conversations.",
+    icon: "ActionMegaphoneIcon",
+    authorization: null,
+    documentationUrl: null,
+    instructions: null,
+  },
+  tools: Object.values(USER_MENTIONS_TOOLS_METADATA).map((t) => ({
+    name: t.name,
+    description: t.description,
+    inputSchema: zodToJsonSchema(z.object(t.schema)) as JSONSchema,
+    displayLabels: t.displayLabels,
+  })),
+  tools_stakes: Object.fromEntries(
+    Object.values(USER_MENTIONS_TOOLS_METADATA).map((t) => [t.name, t.stake])
+  ),
+} as const satisfies ServerMetadata;

--- a/front/lib/api/actions/servers/user_mentions/tools/index.ts
+++ b/front/lib/api/actions/servers/user_mentions/tools/index.ts
@@ -1,0 +1,82 @@
+// eslint-disable-next-line dust/enforce-client-types-in-public-api
+import { DustAPI } from "@dust-tt/client";
+
+import { MCPError } from "@app/lib/actions/mcp_errors";
+import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import {
+  GET_MENTION_MARKDOWN_TOOL_NAME,
+  SEARCH_AVAILABLE_USERS_TOOL_NAME,
+  USER_MENTIONS_TOOLS_METADATA,
+} from "@app/lib/api/actions/servers/user_mentions/metadata";
+import config from "@app/lib/api/config";
+import { prodAPICredentialsForOwner } from "@app/lib/auth";
+import { serializeMention } from "@app/lib/mentions/format";
+import logger from "@app/logger/logger";
+import { Err, getHeaderFromUserEmail, Ok } from "@app/types";
+
+const handlers: ToolHandlers<typeof USER_MENTIONS_TOOLS_METADATA> = {
+  [SEARCH_AVAILABLE_USERS_TOOL_NAME]: async ({ searchTerm }, extra) => {
+    const auth = extra.auth;
+    if (!auth) {
+      return new Err(new MCPError("Authentication required"));
+    }
+
+    const user = auth.user();
+    const prodCredentials = await prodAPICredentialsForOwner(
+      auth.getNonNullableWorkspace()
+    );
+    const api = new DustAPI(
+      config.getDustAPIConfig(),
+      {
+        ...prodCredentials,
+        extraHeaders: {
+          // We use a system API key to override the user here (not groups and role) so that the
+          // sub-agent can access the same spaces as the user but also as the sub-agent may rely
+          // on personal actions that have to be operated in the name of the user initiating the
+          // interaction.
+          ...getHeaderFromUserEmail(user?.email),
+        },
+      },
+      logger
+    );
+
+    const r = await api.getMentionsSuggestions({
+      query: searchTerm,
+      select: ["users"],
+      conversationId: extra.agentLoopContext?.runContext?.conversation?.sId,
+    });
+
+    if (r.isErr()) {
+      return new Err(
+        new MCPError(`Error getting mentions suggestions: ${r.error.message}`, {
+          cause: r.error,
+        })
+      );
+    }
+
+    const suggestions = r.value;
+
+    return new Ok([
+      {
+        type: "text",
+        text: JSON.stringify(suggestions),
+      },
+    ]);
+  },
+
+  [GET_MENTION_MARKDOWN_TOOL_NAME]: async ({ mention }, _extra) => {
+    return new Ok([
+      {
+        type: "text",
+        text: serializeMention({
+          id: mention.id,
+          label: mention.label,
+          type: "user",
+        }),
+      },
+    ]);
+  },
+};
+
+export const TOOLS = buildTools(USER_MENTIONS_TOOLS_METADATA, handlers);

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -15,10 +15,6 @@ import {
   areDataSourcesConfigured,
   isServerSideMCPServerConfigurationWithName,
 } from "@app/lib/actions/types/guards";
-import {
-  GET_MENTION_MARKDOWN_TOOL_NAME,
-  SEARCH_AVAILABLE_USERS_TOOL_NAME,
-} from "@app/lib/api/actions/servers/common_utilities/metadata";
 import { CONVERSATION_CAT_FILE_ACTION_NAME } from "@app/lib/api/actions/servers/conversation_files/metadata";
 import { citationMetaPrompt } from "@app/lib/api/assistant/citations";
 import type { Authenticator } from "@app/lib/auth";
@@ -332,39 +328,11 @@ export function constructGuidelinesSection({
     userMessage.context.origin === "slack" ||
     userMessage.context.origin === "teams";
 
-  if (!isSlackOrTeams) {
-    guidelinesSection +=
-      `\n## MENTIONING USERS\n` +
-      'You can notify users in this conversation by mentioning them (also called "pinging").\n' +
-      "\n" +
-      "User mentions require a specific markdown format. " +
-      "You MUST use the tools below - attempting to guess or construct the format manually will fail silently and the user will NOT be notified.\n" +
-      "\n### Required 2-step process:\n" +
-      `1. Call \`${SEARCH_AVAILABLE_USERS_TOOL_NAME}\` with a search term (or empty string "" to list all users)\n` +
-      `   - Returns JSON array: [{"id": "user_123", "label": "John Doe", "type": "user", ...}]\n` +
-      `   - Extract the "id" and "label" fields from the user you want to mention\n` +
-      `2. Call \`${GET_MENTION_MARKDOWN_TOOL_NAME}\` with the exact id and label from step 1\n` +
-      `   - Pass: { mention: { id: "user_123", label: "John Doe" } }\n` +
-      `   - Returns the correct mention string to include in your response\n` +
-      "\n### Format distinction (for reference only - never construct manually):\n" +
-      "- Agent mentions: `:mention[Name]{sId=agent_id}` (no suffix)\n" +
-      "- User mentions: `:mention_user[Name]{sId=user_id}` (note the `_user` suffix)\n" +
-      "- The `_user` suffix is critical - wrong format = no notification sent\n" +
-      "\n### Common mistakes to avoid:\n" +
-      "WRONG: `:mention[John Doe]{sId=user_123}` (missing _user suffix)\n" +
-      "WRONG: `@John Doe` (only works in Slack/Teams, not web)\n" +
-      "WRONG: Constructing the format yourself without tools\n" +
-      `CORRECT: Always use ${SEARCH_AVAILABLE_USERS_TOOL_NAME} + ${GET_MENTION_MARKDOWN_TOOL_NAME}\n` +
-      "\n### When to mention users:\n" +
-      "- In multi-user conversations, prefix your response with a mention to address specific users directly\n" +
-      "- Only use mentions when you want to ping/notify the user (they receive a notification)\n" +
-      "- To simply refer to someone without notifying them, use their name as plain text";
-  } else {
+  if (isSlackOrTeams) {
     guidelinesSection +=
       `\n## MENTIONING USERS\n` +
       "You have the ability to mention users in a message using the markdown directive." +
       '\nUsers can also refer to mention as "ping".' +
-      `\nDo not use the \`${SEARCH_AVAILABLE_USERS_TOOL_NAME}\` or the \`${GET_MENTION_MARKDOWN_TOOL_NAME}\` tools to mention users.\n` +
       "\nUse a simple @username to mention users in your messages in this conversation.";
   }
   return guidelinesSection;

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -498,7 +498,7 @@ function _getDustLikeGlobalAgent(
     ...dustAgent,
     status: "active",
     actions,
-    skills: ["frames", "go-deep"],
+    skills: ["frames", "go-deep", "mention_users"],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
   };
 }

--- a/front/lib/resources/skill/global/mention_users.ts
+++ b/front/lib/resources/skill/global/mention_users.ts
@@ -1,0 +1,44 @@
+import type { GlobalSkillDefinition } from "@app/lib/resources/skill/global/registry";
+
+export const mentionUsersSkill = {
+  sId: "mention_users",
+  name: "Mention Users",
+  userFacingDescription:
+    "Allow agents to mention and notify workspace users in conversations.",
+  agentFacingDescription: `Search for workspace users and mention them in responses to notify them. Use these tools when:
+- The user asks you to notify, alert, or mention someone
+- You need to include someone in the conversation`,
+  instructions: `The "user_mentions" tools allow you to search for users in the workspace and mention them in your responses.
+
+Important notes:
+- Always search for users first using search_available_users before mentioning them
+- Use get_mention_markdown to get the correct markdown format for mentions
+- Only mention users when it's relevant and appropriate
+- Do not over-mention users - only when explicitly requested or clearly necessary
+
+When to mention users (useful situations):
+- User explicitly asks to notify someone: "let John know about this", "tag Sarah", "notify the team lead"
+- Delegating tasks or requesting approval: "this needs Jane's review", "assign this to Mike"
+- Bringing expertise into discussion: "we should get the security team's input on this"
+- Following up on action items: "as discussed with Alex, here's the update"
+- Notifying stakeholders about critical updates or blockers
+
+When NOT to mention users:
+- Answering general questions that don't require immediate attention from anyone
+- Providing information summaries or status updates that are purely informational
+- Discussing someone in passing without needing their input: "John worked on this last week"
+- Routine automated reports or scheduled updates
+- When the user mentions someone conversationally without intent to notify: "similar to what Sarah did"
+`,
+  mcpServers: [{ name: "user_mentions" }],
+  version: 1,
+  icon: "ActionMegaphoneIcon",
+  isAutoEnabled: true,
+  isDisabledForAgentLoop: ({ userMessage }) => {
+    return (
+      userMessage.context.origin === "slack" ||
+      userMessage.context.origin === "slack_workflow" ||
+      userMessage.context.origin === "teams"
+    );
+  },
+} as const satisfies GlobalSkillDefinition;

--- a/front/lib/resources/skill/global/registry.ts
+++ b/front/lib/resources/skill/global/registry.ts
@@ -4,6 +4,7 @@ import { discoverKnowledgeSkill } from "@app/lib/resources/skill/global/discover
 import { discoverToolsSkill } from "@app/lib/resources/skill/global/discover_tools";
 import { framesSkill } from "@app/lib/resources/skill/global/frames";
 import { goDeepSkill } from "@app/lib/resources/skill/global/go_deep";
+import { mentionUsersSkill } from "@app/lib/resources/skill/global/mention_users";
 import type { AllSkillConfigurationFindOptions } from "@app/lib/resources/skill/types";
 import type { ResourceSId } from "@app/lib/resources/string_ids";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -83,6 +84,7 @@ const GLOBAL_SKILLS_ARRAY = ensureUniqueSIds([
   discoverToolsSkill,
   framesSkill,
   goDeepSkill,
+  mentionUsersSkill,
 ] as const);
 
 // Build lookup map for direct access by sId.


### PR DESCRIPTION
## Description

Now that we can enable skills on the fly, we can move "mentioning users" to a skill. This PR does:
* move mentions in a skill
* move the tools for mentioning on a specific tool
* enable the skill in Dust


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
