### PR TITLE
[front] Snowflake keypair activation UI + settings refactor

### DIFF
--- a/front/components/actions/mcp/MCPServerSettings.tsx
+++ b/front/components/actions/mcp/MCPServerSettings.tsx
@@ -1,4 +1,5 @@
 import { ConnectMCPServerDialog } from "@app/components/actions/mcp/create/ConnectMCPServerDialog";
+import { ConnectSnowflakeMCPKeypairDialog } from "@app/components/actions/mcp/create/ConnectSnowflakeMCPKeypairDialog";
 import {
   OAUTH_USE_CASE_TO_DESCRIPTION,
   OAUTH_USE_CASE_TO_LABEL,
@@ -23,6 +24,7 @@ export function MCPServerSettings({
   owner,
 }: MCPServerSettingsProps) {
   const authorization = mcpServerView.server.authorization;
+  const isSnowflake = authorization?.provider === "snowflake";
 
   const { connections, isConnectionsLoading } = useMCPServerConnections({
     owner,
@@ -45,6 +47,7 @@ export function MCPServerSettings({
   });
 
   const [isConnectDialogOpen, setIsConnectDialogOpen] = useState(false);
+  const [isKeypairDialogOpen, setIsKeypairDialogOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [selectedUseCase, setSelectedUseCase] =
     useState<MCPOAuthUseCase | null>(null);
@@ -65,13 +68,24 @@ export function MCPServerSettings({
 
   return (
     <>
-      <ConnectMCPServerDialog
-        owner={owner}
-        mcpServerView={mcpServerView}
-        setIsLoading={setIsLoading}
-        isOpen={isConnectDialogOpen}
-        setIsOpen={setIsConnectDialogOpen}
-      />
+      {!isSnowflake && (
+        <ConnectMCPServerDialog
+          owner={owner}
+          mcpServerView={mcpServerView}
+          setIsLoading={setIsLoading}
+          isOpen={isConnectDialogOpen}
+          setIsOpen={setIsConnectDialogOpen}
+        />
+      )}
+      {isSnowflake && (
+        <ConnectSnowflakeMCPKeypairDialog
+          owner={owner}
+          mcpServerView={mcpServerView}
+          setIsLoading={setIsLoading}
+          isOpen={isKeypairDialogOpen}
+          setIsOpen={setIsKeypairDialogOpen}
+        />
+      )}
       <div className="space-y-2">
         <div className="heading-base">Authentication</div>
         <div className="flex space-x-2">
@@ -95,6 +109,15 @@ export function MCPServerSettings({
               variant="outline"
               onClick={handleDeleteConnection}
             />
+          ) : isSnowflake ? (
+            <Button
+              label="Activate (Key-pair)"
+              icon={LoginIcon}
+              variant="primary"
+              onClick={() => setIsKeypairDialogOpen(true)}
+              disabled={isLoading}
+              isLoading={isLoading}
+            />
           ) : (
             <Button
               label="Activate"
@@ -111,6 +134,12 @@ export function MCPServerSettings({
       {connection && (
         <div className="space-y-2">
           <div className="heading-base">Credentials</div>
+          {isSnowflake && (
+            <div className="w-full text-muted-foreground dark:text-muted-foreground-night">
+              <span className="font-semibold">Auth type</span>:{" "}
+              {connection.authType === "keypair" ? "Key-pair" : "OAuth"}
+            </div>
+          )}
           <div className="w-full text-muted-foreground dark:text-muted-foreground-night">
             {useCase === "platform_actions" && (
               <>

--- a/front/components/actions/mcp/MCPServerSettings.tsx
+++ b/front/components/actions/mcp/MCPServerSettings.tsx
@@ -111,7 +111,7 @@ export function MCPServerSettings({
             />
           ) : isSnowflake ? (
             <Button
-              label="Activate (Key-pair)"
+              label="Activate (Static credentials)"
               icon={LoginIcon}
               variant="primary"
               onClick={() => setIsKeypairDialogOpen(true)}
@@ -137,7 +137,9 @@ export function MCPServerSettings({
           {isSnowflake && (
             <div className="w-full text-muted-foreground dark:text-muted-foreground-night">
               <span className="font-semibold">Auth type</span>:{" "}
-              {connection.authType === "keypair" ? "Key-pair" : "OAuth"}
+              {connection.authType === "keypair"
+                ? "Static credentials"
+                : "OAuth"}
             </div>
           )}
           <div className="w-full text-muted-foreground dark:text-muted-foreground-night">

--- a/front/components/actions/mcp/MCPServerSettings.tsx
+++ b/front/components/actions/mcp/MCPServerSettings.tsx
@@ -1,9 +1,14 @@
-import { ConnectMCPServerDialog } from "@app/components/actions/mcp/create/ConnectMCPServerDialog";
-import { ConnectSnowflakeMCPKeypairDialog } from "@app/components/actions/mcp/create/ConnectSnowflakeMCPKeypairDialog";
+import { Button, Chip, XMarkIcon } from "@dust-tt/sparkle";
+import { useMemo, useState } from "react";
+
 import {
   OAUTH_USE_CASE_TO_DESCRIPTION,
   OAUTH_USE_CASE_TO_LABEL,
 } from "@app/components/actions/mcp/MCPServerOAuthConnexion";
+import {
+  MCPServerSettingsActivationControl,
+  MCPServerSettingsCredentialDetails,
+} from "@app/components/actions/mcp/MCPServerSettingsProviderControls";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import {
   useDeleteMCPServerConnection,
@@ -11,8 +16,6 @@ import {
 } from "@app/lib/swr/mcp_servers";
 import type { MCPOAuthUseCase } from "@app/types/oauth/lib";
 import type { LightWorkspaceType } from "@app/types/user";
-import { Button, Chip, LoginIcon, XMarkIcon } from "@dust-tt/sparkle";
-import { useMemo, useState } from "react";
 
 interface MCPServerSettingsProps {
   mcpServerView: MCPServerViewType;
@@ -24,7 +27,7 @@ export function MCPServerSettings({
   owner,
 }: MCPServerSettingsProps) {
   const authorization = mcpServerView.server.authorization;
-  const isSnowflake = authorization?.provider === "snowflake";
+  const provider = authorization?.provider;
 
   const { connections, isConnectionsLoading } = useMCPServerConnections({
     owner,
@@ -46,8 +49,6 @@ export function MCPServerSettings({
     owner,
   });
 
-  const [isConnectDialogOpen, setIsConnectDialogOpen] = useState(false);
-  const [isKeypairDialogOpen, setIsKeypairDialogOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [selectedUseCase, setSelectedUseCase] =
     useState<MCPOAuthUseCase | null>(null);
@@ -68,24 +69,6 @@ export function MCPServerSettings({
 
   return (
     <>
-      {!isSnowflake && (
-        <ConnectMCPServerDialog
-          owner={owner}
-          mcpServerView={mcpServerView}
-          setIsLoading={setIsLoading}
-          isOpen={isConnectDialogOpen}
-          setIsOpen={setIsConnectDialogOpen}
-        />
-      )}
-      {isSnowflake && (
-        <ConnectSnowflakeMCPKeypairDialog
-          owner={owner}
-          mcpServerView={mcpServerView}
-          setIsLoading={setIsLoading}
-          isOpen={isKeypairDialogOpen}
-          setIsOpen={setIsKeypairDialogOpen}
-        />
-      )}
       <div className="space-y-2">
         <div className="heading-base">Authentication</div>
         <div className="flex space-x-2">
@@ -109,23 +92,13 @@ export function MCPServerSettings({
               variant="outline"
               onClick={handleDeleteConnection}
             />
-          ) : isSnowflake ? (
-            <Button
-              label="Activate (Static credentials)"
-              icon={LoginIcon}
-              variant="primary"
-              onClick={() => setIsKeypairDialogOpen(true)}
-              disabled={isLoading}
-              isLoading={isLoading}
-            />
           ) : (
-            <Button
-              label="Activate"
-              icon={LoginIcon}
-              variant="primary"
-              onClick={() => setIsConnectDialogOpen(true)}
-              disabled={isLoading}
+            <MCPServerSettingsActivationControl
+              owner={owner}
+              mcpServerView={mcpServerView}
+              provider={provider}
               isLoading={isLoading}
+              setIsLoading={setIsLoading}
             />
           )}
         </div>
@@ -134,14 +107,10 @@ export function MCPServerSettings({
       {connection && (
         <div className="space-y-2">
           <div className="heading-base">Credentials</div>
-          {isSnowflake && (
-            <div className="w-full text-muted-foreground dark:text-muted-foreground-night">
-              <span className="font-semibold">Auth type</span>:{" "}
-              {connection.authType === "keypair"
-                ? "Static credentials"
-                : "OAuth"}
-            </div>
-          )}
+          <MCPServerSettingsCredentialDetails
+            provider={provider}
+            connection={connection}
+          />
           <div className="w-full text-muted-foreground dark:text-muted-foreground-night">
             {useCase === "platform_actions" && (
               <>

--- a/front/components/actions/mcp/MCPServerSettingsProviderControls.tsx
+++ b/front/components/actions/mcp/MCPServerSettingsProviderControls.tsx
@@ -34,7 +34,7 @@ export function MCPServerSettingsActivationControl({
     provider === "snowflake"
       ? {
           dialog: ConnectSnowflakeMCPKeypairDialog,
-          buttonLabel: "Activate (Key-pair)",
+          buttonLabel: "Activate (Static credentials)",
         }
       : {
           dialog: ConnectMCPServerDialog,
@@ -69,7 +69,7 @@ export function MCPServerSettingsCredentialDetails({
   return (
     <div className="w-full text-muted-foreground dark:text-muted-foreground-night">
       <span className="font-semibold">Auth type</span>:{" "}
-      {connection.authType === "keypair" ? "Key-pair" : "OAuth"}
+      {connection.authType === "keypair" ? "Static credentials" : "OAuth"}
     </div>
   );
 }

--- a/front/components/actions/mcp/MCPServerSettingsProviderControls.tsx
+++ b/front/components/actions/mcp/MCPServerSettingsProviderControls.tsx
@@ -1,11 +1,11 @@
-import { Button, LoginIcon } from "@dust-tt/sparkle";
-import { useState } from "react";
-
 import { ConnectMCPServerDialog } from "@app/components/actions/mcp/create/ConnectMCPServerDialog";
 import { ConnectSnowflakeMCPKeypairDialog } from "@app/components/actions/mcp/create/ConnectSnowflakeMCPKeypairDialog";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import type { MCPServerConnectionType } from "@app/lib/resources/mcp_server_connection_resource";
-import type { LightWorkspaceType, OAuthProvider } from "@app/types";
+import type { OAuthProvider } from "@app/types/oauth/lib";
+import type { LightWorkspaceType } from "@app/types/user";
+import { Button, LoginIcon } from "@dust-tt/sparkle";
+import { useState } from "react";
 
 interface ActivationControlProps {
   owner: LightWorkspaceType;
@@ -15,14 +15,6 @@ interface ActivationControlProps {
   setIsLoading: (isLoading: boolean) => void;
 }
 
-interface WorkspaceActivationDialogProps {
-  owner: LightWorkspaceType;
-  mcpServerView: MCPServerViewType;
-  setIsLoading: (isLoading: boolean) => void;
-  isOpen: boolean;
-  setIsOpen: (isOpen: boolean) => void;
-}
-
 export function MCPServerSettingsActivationControl({
   owner,
   mcpServerView,
@@ -30,26 +22,33 @@ export function MCPServerSettingsActivationControl({
   isLoading,
   setIsLoading,
 }: ActivationControlProps) {
-  const config =
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+
+  const DialogComponent =
     provider === "snowflake"
-      ? {
-          dialog: ConnectSnowflakeMCPKeypairDialog,
-          buttonLabel: "Activate (Static credentials)",
-        }
-      : {
-          dialog: ConnectMCPServerDialog,
-          buttonLabel: "Activate",
-        };
+      ? ConnectSnowflakeMCPKeypairDialog
+      : ConnectMCPServerDialog;
+  const buttonLabel =
+    provider === "snowflake" ? "Activate (Static credentials)" : "Activate";
 
   return (
-    <WorkspaceActivationControl
-      owner={owner}
-      mcpServerView={mcpServerView}
-      DialogComponent={config.dialog}
-      buttonLabel={config.buttonLabel}
-      isLoading={isLoading}
-      setIsLoading={setIsLoading}
-    />
+    <>
+      <DialogComponent
+        owner={owner}
+        mcpServerView={mcpServerView}
+        setIsLoading={setIsLoading}
+        isOpen={isDialogOpen}
+        setIsOpen={setIsDialogOpen}
+      />
+      <Button
+        label={buttonLabel}
+        icon={LoginIcon}
+        variant="primary"
+        onClick={() => setIsDialogOpen(true)}
+        disabled={isLoading}
+        isLoading={isLoading}
+      />
+    </>
   );
 }
 
@@ -71,45 +70,5 @@ export function MCPServerSettingsCredentialDetails({
       <span className="font-semibold">Auth type</span>:{" "}
       {connection.authType === "keypair" ? "Static credentials" : "OAuth"}
     </div>
-  );
-}
-
-interface WorkspaceActivationControlProps {
-  owner: LightWorkspaceType;
-  mcpServerView: MCPServerViewType;
-  DialogComponent: (props: WorkspaceActivationDialogProps) => JSX.Element;
-  buttonLabel: string;
-  isLoading: boolean;
-  setIsLoading: (isLoading: boolean) => void;
-}
-
-function WorkspaceActivationControl({
-  owner,
-  mcpServerView,
-  DialogComponent,
-  buttonLabel,
-  isLoading,
-  setIsLoading,
-}: WorkspaceActivationControlProps) {
-  const [isDialogOpen, setIsDialogOpen] = useState(false);
-
-  return (
-    <>
-      <DialogComponent
-        owner={owner}
-        mcpServerView={mcpServerView}
-        setIsLoading={setIsLoading}
-        isOpen={isDialogOpen}
-        setIsOpen={setIsDialogOpen}
-      />
-      <Button
-        label={buttonLabel}
-        icon={LoginIcon}
-        variant="primary"
-        onClick={() => setIsDialogOpen(true)}
-        disabled={isLoading}
-        isLoading={isLoading}
-      />
-    </>
   );
 }

--- a/front/components/actions/mcp/MCPServerSettingsProviderControls.tsx
+++ b/front/components/actions/mcp/MCPServerSettingsProviderControls.tsx
@@ -1,0 +1,130 @@
+import { Button, LoginIcon } from "@dust-tt/sparkle";
+import { useState } from "react";
+
+import { ConnectMCPServerDialog } from "@app/components/actions/mcp/create/ConnectMCPServerDialog";
+import { ConnectSnowflakeMCPKeypairDialog } from "@app/components/actions/mcp/create/ConnectSnowflakeMCPKeypairDialog";
+import type { MCPServerViewType } from "@app/lib/api/mcp";
+import type { MCPServerConnectionType } from "@app/lib/resources/mcp_server_connection_resource";
+import type { LightWorkspaceType, OAuthProvider } from "@app/types";
+
+interface ActivationControlProps {
+  owner: LightWorkspaceType;
+  mcpServerView: MCPServerViewType;
+  provider: OAuthProvider | undefined;
+  isLoading: boolean;
+  setIsLoading: (isLoading: boolean) => void;
+}
+
+export function MCPServerSettingsActivationControl({
+  owner,
+  mcpServerView,
+  provider,
+  isLoading,
+  setIsLoading,
+}: ActivationControlProps) {
+  if (provider === "snowflake") {
+    return (
+      <SnowflakeWorkspaceActivationControl
+        owner={owner}
+        mcpServerView={mcpServerView}
+        isLoading={isLoading}
+        setIsLoading={setIsLoading}
+      />
+    );
+  }
+
+  return (
+    <DefaultWorkspaceActivationControl
+      owner={owner}
+      mcpServerView={mcpServerView}
+      isLoading={isLoading}
+      setIsLoading={setIsLoading}
+    />
+  );
+}
+
+interface CredentialDetailsProps {
+  provider: OAuthProvider | undefined;
+  connection: MCPServerConnectionType;
+}
+
+export function MCPServerSettingsCredentialDetails({
+  provider,
+  connection,
+}: CredentialDetailsProps) {
+  if (provider !== "snowflake") {
+    return null;
+  }
+
+  return (
+    <div className="w-full text-muted-foreground dark:text-muted-foreground-night">
+      <span className="font-semibold">Auth type</span>:{" "}
+      {connection.authType === "keypair" ? "Key-pair" : "OAuth"}
+    </div>
+  );
+}
+
+interface WorkspaceActivationControlProps {
+  owner: LightWorkspaceType;
+  mcpServerView: MCPServerViewType;
+  isLoading: boolean;
+  setIsLoading: (isLoading: boolean) => void;
+}
+
+function DefaultWorkspaceActivationControl({
+  owner,
+  mcpServerView,
+  isLoading,
+  setIsLoading,
+}: WorkspaceActivationControlProps) {
+  const [isConnectDialogOpen, setIsConnectDialogOpen] = useState(false);
+
+  return (
+    <>
+      <ConnectMCPServerDialog
+        owner={owner}
+        mcpServerView={mcpServerView}
+        setIsLoading={setIsLoading}
+        isOpen={isConnectDialogOpen}
+        setIsOpen={setIsConnectDialogOpen}
+      />
+      <Button
+        label="Activate"
+        icon={LoginIcon}
+        variant="primary"
+        onClick={() => setIsConnectDialogOpen(true)}
+        disabled={isLoading}
+        isLoading={isLoading}
+      />
+    </>
+  );
+}
+
+function SnowflakeWorkspaceActivationControl({
+  owner,
+  mcpServerView,
+  isLoading,
+  setIsLoading,
+}: WorkspaceActivationControlProps) {
+  const [isKeypairDialogOpen, setIsKeypairDialogOpen] = useState(false);
+
+  return (
+    <>
+      <ConnectSnowflakeMCPKeypairDialog
+        owner={owner}
+        mcpServerView={mcpServerView}
+        setIsLoading={setIsLoading}
+        isOpen={isKeypairDialogOpen}
+        setIsOpen={setIsKeypairDialogOpen}
+      />
+      <Button
+        label="Activate (Key-pair)"
+        icon={LoginIcon}
+        variant="primary"
+        onClick={() => setIsKeypairDialogOpen(true)}
+        disabled={isLoading}
+        isLoading={isLoading}
+      />
+    </>
+  );
+}

--- a/front/components/actions/mcp/MCPServerSettingsProviderControls.tsx
+++ b/front/components/actions/mcp/MCPServerSettingsProviderControls.tsx
@@ -15,6 +15,14 @@ interface ActivationControlProps {
   setIsLoading: (isLoading: boolean) => void;
 }
 
+interface WorkspaceActivationDialogProps {
+  owner: LightWorkspaceType;
+  mcpServerView: MCPServerViewType;
+  setIsLoading: (isLoading: boolean) => void;
+  isOpen: boolean;
+  setIsOpen: (isOpen: boolean) => void;
+}
+
 export function MCPServerSettingsActivationControl({
   owner,
   mcpServerView,
@@ -22,21 +30,23 @@ export function MCPServerSettingsActivationControl({
   isLoading,
   setIsLoading,
 }: ActivationControlProps) {
-  if (provider === "snowflake") {
-    return (
-      <SnowflakeWorkspaceActivationControl
-        owner={owner}
-        mcpServerView={mcpServerView}
-        isLoading={isLoading}
-        setIsLoading={setIsLoading}
-      />
-    );
-  }
+  const config =
+    provider === "snowflake"
+      ? {
+          dialog: ConnectSnowflakeMCPKeypairDialog,
+          buttonLabel: "Activate (Key-pair)",
+        }
+      : {
+          dialog: ConnectMCPServerDialog,
+          buttonLabel: "Activate",
+        };
 
   return (
-    <DefaultWorkspaceActivationControl
+    <WorkspaceActivationControl
       owner={owner}
       mcpServerView={mcpServerView}
+      DialogComponent={config.dialog}
+      buttonLabel={config.buttonLabel}
       isLoading={isLoading}
       setIsLoading={setIsLoading}
     />
@@ -67,61 +77,36 @@ export function MCPServerSettingsCredentialDetails({
 interface WorkspaceActivationControlProps {
   owner: LightWorkspaceType;
   mcpServerView: MCPServerViewType;
+  DialogComponent: (props: WorkspaceActivationDialogProps) => JSX.Element;
+  buttonLabel: string;
   isLoading: boolean;
   setIsLoading: (isLoading: boolean) => void;
 }
 
-function DefaultWorkspaceActivationControl({
+function WorkspaceActivationControl({
   owner,
   mcpServerView,
+  DialogComponent,
+  buttonLabel,
   isLoading,
   setIsLoading,
 }: WorkspaceActivationControlProps) {
-  const [isConnectDialogOpen, setIsConnectDialogOpen] = useState(false);
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
 
   return (
     <>
-      <ConnectMCPServerDialog
+      <DialogComponent
         owner={owner}
         mcpServerView={mcpServerView}
         setIsLoading={setIsLoading}
-        isOpen={isConnectDialogOpen}
-        setIsOpen={setIsConnectDialogOpen}
+        isOpen={isDialogOpen}
+        setIsOpen={setIsDialogOpen}
       />
       <Button
-        label="Activate"
+        label={buttonLabel}
         icon={LoginIcon}
         variant="primary"
-        onClick={() => setIsConnectDialogOpen(true)}
-        disabled={isLoading}
-        isLoading={isLoading}
-      />
-    </>
-  );
-}
-
-function SnowflakeWorkspaceActivationControl({
-  owner,
-  mcpServerView,
-  isLoading,
-  setIsLoading,
-}: WorkspaceActivationControlProps) {
-  const [isKeypairDialogOpen, setIsKeypairDialogOpen] = useState(false);
-
-  return (
-    <>
-      <ConnectSnowflakeMCPKeypairDialog
-        owner={owner}
-        mcpServerView={mcpServerView}
-        setIsLoading={setIsLoading}
-        isOpen={isKeypairDialogOpen}
-        setIsOpen={setIsKeypairDialogOpen}
-      />
-      <Button
-        label="Activate (Key-pair)"
-        icon={LoginIcon}
-        variant="primary"
-        onClick={() => setIsKeypairDialogOpen(true)}
+        onClick={() => setIsDialogOpen(true)}
         disabled={isLoading}
         isLoading={isLoading}
       />

--- a/front/components/actions/mcp/create/ConnectSnowflakeMCPKeypairDialog.tsx
+++ b/front/components/actions/mcp/create/ConnectSnowflakeMCPKeypairDialog.tsx
@@ -1,0 +1,235 @@
+import {
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  TextArea,
+} from "@dust-tt/sparkle";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+
+import { FormProvider } from "@app/components/sparkle/FormProvider";
+import { useSendNotification } from "@app/hooks/useNotification";
+import { getMcpServerDisplayName } from "@app/lib/actions/mcp_helper";
+import type { MCPServerViewType } from "@app/lib/api/mcp";
+import { clientFetch } from "@app/lib/egress/client";
+import {
+  useCreateMCPServerConnection,
+  useUpdateMCPServerView,
+} from "@app/lib/swr/mcp_servers";
+import type { PostCredentialsResponseBody } from "@app/pages/api/w/[wId]/credentials";
+import type { WithAPIErrorResponse, WorkspaceType } from "@app/types";
+import { isAPIErrorResponse } from "@app/types/error";
+
+const snowflakeMCPKeypairFormSchema = z.object({
+  account: z.string().min(1, "Account is required."),
+  username: z.string().min(1, "Username is required."),
+  role: z.string().min(1, "Role is required."),
+  warehouse: z.string().min(1, "Warehouse is required."),
+  privateKey: z.string().min(1, "Private key is required."),
+  privateKeyPassphrase: z.string().optional(),
+});
+
+type SnowflakeMCPKeypairFormValues = z.infer<
+  typeof snowflakeMCPKeypairFormSchema
+>;
+
+interface ConnectSnowflakeMCPKeypairDialogProps {
+  owner: WorkspaceType;
+  mcpServerView: MCPServerViewType;
+  setIsLoading: (isCreating: boolean) => void;
+  isOpen: boolean;
+  setIsOpen: (isOpen: boolean) => void;
+}
+
+export function ConnectSnowflakeMCPKeypairDialog({
+  owner,
+  mcpServerView,
+  setIsLoading: setExternalIsLoading,
+  isOpen = false,
+  setIsOpen,
+}: ConnectSnowflakeMCPKeypairDialogProps) {
+  const sendNotification = useSendNotification();
+  const [isLoading, setIsLoading] = useState(false);
+
+  const form = useForm<SnowflakeMCPKeypairFormValues>({
+    resolver: zodResolver(snowflakeMCPKeypairFormSchema),
+    defaultValues: {
+      account: "",
+      username: "",
+      role: "",
+      warehouse: "",
+      privateKey: "",
+      privateKeyPassphrase: undefined,
+    },
+    mode: "onChange",
+  });
+
+  const { createMCPServerConnection } = useCreateMCPServerConnection({
+    owner,
+    connectionType: "workspace",
+  });
+  const { updateServerView } = useUpdateMCPServerView(owner, mcpServerView);
+
+  const resetState = () => {
+    setExternalIsLoading(false);
+    form.reset();
+    setIsLoading(false);
+  };
+
+  const handleSave = async (values: SnowflakeMCPKeypairFormValues) => {
+    setIsLoading(true);
+
+    const response = await clientFetch(`/api/w/${owner.sId}/credentials`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        provider: "snowflake",
+        credentials: {
+          auth_type: "keypair",
+          username: values.username,
+          account: values.account,
+          role: values.role,
+          warehouse: values.warehouse,
+          private_key: values.privateKey,
+          private_key_passphrase: values.privateKeyPassphrase,
+        },
+      }),
+    });
+
+    const result: WithAPIErrorResponse<PostCredentialsResponseBody> =
+      await response.json();
+
+    if (!response.ok || isAPIErrorResponse(result)) {
+      sendNotification({
+        type: "error",
+        title: "Failed to save Snowflake credentials",
+        description: isAPIErrorResponse(result)
+          ? result.error.message
+          : "An error occurred.",
+      });
+      setIsLoading(false);
+      return;
+    }
+
+    const credentialId = result.credentials.id;
+
+    setExternalIsLoading(true);
+    const connectionCreationRes = await createMCPServerConnection({
+      credentialId,
+      mcpServerId: mcpServerView.server.sId,
+      mcpServerDisplayName: getMcpServerDisplayName(mcpServerView.server),
+      provider: "snowflake",
+    });
+    if (!connectionCreationRes) {
+      setExternalIsLoading(false);
+      setIsLoading(false);
+      return;
+    }
+
+    const updateServerViewRes = await updateServerView({
+      oAuthUseCase: "platform_actions",
+    });
+    if (!updateServerViewRes) {
+      setExternalIsLoading(false);
+      setIsLoading(false);
+      return;
+    }
+
+    setIsLoading(false);
+    setIsOpen(false);
+    resetState();
+  };
+
+  const canSubmit = form.formState.isValid;
+
+  return (
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        setIsOpen(open);
+        if (!open) {
+          resetState();
+        }
+      }}
+    >
+      <DialogContent size="lg">
+        <DialogHeader>
+          <DialogTitle>Connect Snowflake (Key-pair)</DialogTitle>
+        </DialogHeader>
+        <DialogContainer>
+          <FormProvider form={form}>
+            <div className="space-y-5 text-foreground dark:text-foreground-night">
+              <Input
+                {...form.register("account")}
+                label="Account"
+                placeholder="abc123.us-east-1"
+                isError={!!form.formState.errors.account}
+                message={form.formState.errors.account?.message}
+              />
+              <div className="grid grid-cols-2 gap-3">
+                <Input
+                  {...form.register("username")}
+                  label="Username"
+                  isError={!!form.formState.errors.username}
+                  message={form.formState.errors.username?.message}
+                />
+                <Input
+                  {...form.register("role")}
+                  label="Role"
+                  isError={!!form.formState.errors.role}
+                  message={form.formState.errors.role?.message}
+                />
+              </div>
+              <Input
+                {...form.register("warehouse")}
+                label="Warehouse"
+                isError={!!form.formState.errors.warehouse}
+                message={form.formState.errors.warehouse?.message}
+              />
+              <div className="space-y-2">
+                <label className="text-sm font-medium">
+                  Private key (PEM format)
+                </label>
+                <TextArea
+                  {...form.register("privateKey")}
+                  placeholder="-----BEGIN PRIVATE KEY-----"
+                  rows={8}
+                />
+                {form.formState.errors.privateKey?.message && (
+                  <p className="text-sm text-red-600 dark:text-red-400">
+                    {form.formState.errors.privateKey.message}
+                  </p>
+                )}
+              </div>
+              <Input
+                {...form.register("privateKeyPassphrase")}
+                label="Private key passphrase (optional)"
+                type="password"
+              />
+            </div>
+          </FormProvider>
+        </DialogContainer>
+        <DialogFooter
+          leftButtonProps={{
+            label: "Cancel",
+            variant: "outline",
+            onClick: () => setIsOpen(false),
+          }}
+          rightButtonProps={{
+            label: "Connect",
+            variant: "primary",
+            onClick: form.handleSubmit(handleSave),
+            disabled: !canSubmit,
+            isLoading,
+          }}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/front/components/actions/mcp/create/ConnectSnowflakeMCPKeypairDialog.tsx
+++ b/front/components/actions/mcp/create/ConnectSnowflakeMCPKeypairDialog.tsx
@@ -160,7 +160,7 @@ export function ConnectSnowflakeMCPKeypairDialog({
     >
       <DialogContent size="lg">
         <DialogHeader>
-          <DialogTitle>Connect Snowflake (Key-pair)</DialogTitle>
+          <DialogTitle>Connect Snowflake (Static credentials)</DialogTitle>
         </DialogHeader>
         <DialogContainer>
           <FormProvider form={form}>

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -681,8 +681,8 @@ export function useCreateMCPServerConnection({
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          ...(connectionId ? { connectionId } : {}),
-          ...(credentialId ? { credentialId } : {}),
+          connectionId,
+          credentialId,
           mcpServerId,
           provider,
         }),

--- a/front/lib/swr/mcp_servers.ts
+++ b/front/lib/swr/mcp_servers.ts
@@ -655,15 +655,24 @@ export function useCreateMCPServerConnection({
   const sendNotification = useSendNotification();
   const createMCPServerConnection = async ({
     connectionId,
+    credentialId,
     mcpServerId,
     mcpServerDisplayName,
     provider,
   }: {
-    connectionId: string;
+    connectionId?: string;
+    credentialId?: string;
     mcpServerId: string;
     mcpServerDisplayName: string;
     provider: OAuthProvider;
   }): Promise<PostConnectionResponseBody | null> => {
+    if (!connectionId && !credentialId) {
+      throw new Error("Missing connectionId or credentialId.");
+    }
+    if (connectionId && credentialId) {
+      throw new Error("Only one of connectionId or credentialId must be set.");
+    }
+
     const response = await clientFetch(
       `/api/w/${owner.sId}/mcp/connections/${connectionType}`,
       {
@@ -672,7 +681,8 @@ export function useCreateMCPServerConnection({
           "Content-Type": "application/json",
         },
         body: JSON.stringify({
-          connectionId,
+          ...(connectionId ? { connectionId } : {}),
+          ...(credentialId ? { credentialId } : {}),
           mcpServerId,
           provider,
         }),


### PR DESCRIPTION
## Description

Enable Snowflake workspace activation with static credentials in MCP settings, while simplifying provider-specific UI wiring.

- Add `ConnectSnowflakeMCPKeypairDialog` to capture and store Snowflake key-pair credentials.
- Add credential-backed MCP connection creation support (`credentialId`) in `front/lib/swr/mcp_servers.ts`.
- Update `MCPServerSettings` to surface Snowflake workspace static-credentials activation and auth-type display.
- Extract provider-specific controls into `MCPServerSettingsProviderControls` and deduplicate workspace activation control rendering.
- Keep behavior unchanged for non-Snowflake providers.

## Tests

Extensive local tests

## Risk

Medium.

- UI/auth wiring changes for workspace activation flow.
- No DB schema/data migration in this PR.

## Deploy Plan

- Deploy `front` as usual.
