### PR TITLE
refactor: list conversations for user

### DIFF
--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -830,7 +830,7 @@ describe("baseFetchWithAuthorization with space-based permissions", () => {
   });
 });
 
-describe("listConversationsForUser", () => {
+describe("listPrivateConversationsForUser", () => {
   let adminAuth: Authenticator;
   let userAuth: Authenticator;
   let workspace: LightWorkspaceType;
@@ -885,7 +885,7 @@ describe("listConversationsForUser", () => {
 
   it("should return only conversations user participates in", async () => {
     const userConversations =
-      await ConversationResource.listConversationsForUser(userAuth);
+      await ConversationResource.listPrivateConversationsForUser(userAuth);
 
     expect(userConversations).toHaveLength(1);
     expect(userConversations[0].sId).toBe(conversationIds[0]);
@@ -910,7 +910,7 @@ describe("listConversationsForUser", () => {
     assert(participation, "Participation not found");
 
     const userConversations =
-      await ConversationResource.listConversationsForUser(userAuth);
+      await ConversationResource.listPrivateConversationsForUser(userAuth);
 
     expect(userConversations).toHaveLength(1);
     const conversationData = userConversations[0].toJSON();
@@ -942,7 +942,7 @@ describe("listConversationsForUser", () => {
     });
 
     const userConversations =
-      await ConversationResource.listConversationsForUser(userAuth);
+      await ConversationResource.listPrivateConversationsForUser(userAuth);
 
     expect(userConversations).toHaveLength(2);
     // Most recent participation should be first.
@@ -971,7 +971,7 @@ describe("listConversationsForUser", () => {
     );
 
     const conversations =
-      await ConversationResource.listConversationsForUser(orphanAuth);
+      await ConversationResource.listPrivateConversationsForUser(orphanAuth);
 
     expect(conversations).toHaveLength(0);
   });
@@ -993,7 +993,7 @@ describe("listConversationsForUser", () => {
 
     // By default, should only see unlisted conversations (not test conversations)
     const userConversations =
-      await ConversationResource.listConversationsForUser(userAuth);
+      await ConversationResource.listPrivateConversationsForUser(userAuth);
     const conversationIds = userConversations.map((c) => c.sId);
     expect(conversationIds).toContain(conversationIds[0]); // original conversation
     expect(conversationIds).not.toContain(testConvo.sId); // test conversation should be filtered out
@@ -1002,380 +1002,254 @@ describe("listConversationsForUser", () => {
     await destroyConversation(adminAuth, { conversationId: testConvo.sId });
   });
 
-  describe("onlyUnread filter", () => {
-    it("should return only unread conversations when onlyUnread is true", async () => {
-      const { UserConversationReadsModel } = await import(
-        "@app/lib/models/agent/conversation"
+  it("should return only private conversations", async () => {
+    // Create a space
+    const space = await SpaceFactory.regular(workspace);
+
+    // Add user to the space
+    const addMembersRes = await space.addMembers(adminAuth, {
+      userIds: [userAuth.getNonNullableUser().sId],
+    });
+    assert(addMembersRes.isOk(), "Failed to add user to space");
+
+    await userAuth.refresh();
+
+    // Create a new conversation and add user as participant
+    const spaceConvo = await ConversationFactory.create(userAuth, {
+      agentConfigurationId: agents[0].sId,
+      messagesCreatedAt: [dateFromDaysAgo(1)],
+      spaceId: space.id,
+    });
+
+    await ConversationResource.upsertParticipation(userAuth, {
+      conversation: spaceConvo,
+      action: "posted",
+      user: userAuth.getNonNullableUser().toJSON(),
+    });
+
+    // Test with kind: "private"
+    const privateConversations =
+      await ConversationResource.listPrivateConversationsForUser(userAuth);
+
+    const privateIds = privateConversations.map((c) => c.sId);
+    expect(privateIds).toContain(conversationIds[0]); // original private conversation
+    expect(privateIds).not.toContain(spaceConvo.sId); // space conversation should be filtered out
+
+    // Clean up
+    await destroyConversation(adminAuth, { conversationId: spaceConvo.sId });
+  });
+});
+
+describe("listSpaceUnreadConversationsForUser", () => {
+  let adminAuth: Authenticator;
+  let userAuth: Authenticator;
+  let workspace: LightWorkspaceType;
+  let agents: LightAgentConfigurationType[];
+  let conversationIds: string[];
+  let spaceModelIds: number[];
+
+  beforeEach(async () => {
+    const {
+      authenticator,
+      user,
+      workspace: w,
+    } = await createResourceTest({
+      role: "admin",
+    });
+
+    workspace = w;
+    const adminUser = user;
+    const regularUser = await UserFactory.basic();
+    await MembershipFactory.associate(workspace, regularUser, {
+      role: "user",
+    });
+
+    adminAuth = authenticator;
+    userAuth = await Authenticator.fromUserIdAndWorkspaceId(
+      regularUser.sId,
+      workspace.sId
+    );
+
+    agents = await setupTestAgents(workspace, adminUser);
+    const space = await SpaceFactory.project(workspace);
+
+    // Create a new conversation and add user as participant
+    const conversation = await ConversationFactory.create(adminAuth, {
+      agentConfigurationId: agents[0].sId,
+      messagesCreatedAt: [dateFromDaysAgo(5)],
+      spaceId: space.id,
+    });
+
+    conversationIds = [conversation.sId];
+    spaceModelIds = [space.id];
+
+    // Add regular user as participant
+    await ConversationResource.upsertParticipation(userAuth, {
+      conversation,
+      action: "posted",
+      user: userAuth.getNonNullableUser().toJSON(),
+    });
+  });
+
+  afterEach(async () => {
+    for (const sId of conversationIds) {
+      await destroyConversation(adminAuth, { conversationId: sId });
+    }
+  });
+
+  it("should return only conversations user participates in", async () => {
+    const nonParticipantConversation = await ConversationFactory.create(
+      adminAuth,
+      {
+        agentConfigurationId: agents[0].sId,
+        messagesCreatedAt: [dateFromDaysAgo(5)],
+        spaceId: spaceModelIds[0],
+      }
+    );
+
+    const userConversations =
+      await ConversationResource.listSpaceUnreadConversationsForUser(
+        userAuth,
+        spaceModelIds
       );
 
-      // Create two more conversations
-      const unreadConvo = await ConversationFactory.create(adminAuth, {
-        agentConfigurationId: agents[0].sId,
-        messagesCreatedAt: [dateFromDaysAgo(2)],
-      });
+    expect(userConversations).toHaveLength(1);
+    expect(userConversations[0].sId).toBe(conversationIds[0]);
+    expect(userConversations[0]).toBeInstanceOf(ConversationResource);
+    expect(userConversations).not.toContain(nonParticipantConversation.sId);
+  });
 
-      const readConvo = await ConversationFactory.create(adminAuth, {
-        agentConfigurationId: agents[0].sId,
-        messagesCreatedAt: [dateFromDaysAgo(1)],
-      });
-
-      // Add user as participant to both
-      await ConversationResource.upsertParticipation(userAuth, {
-        conversation: unreadConvo,
-        action: "posted",
-        user: userAuth.getNonNullableUser().toJSON(),
-      });
-
-      await ConversationResource.upsertParticipation(userAuth, {
-        conversation: readConvo,
-        action: "posted",
-        user: userAuth.getNonNullableUser().toJSON(),
-      });
-
-      // Mark the original conversation as read
-      await UserConversationReadsModel.upsert({
+  it("should return conversations with populated participation data", async () => {
+    // First, get the raw participation data from the database to compare
+    const { ConversationParticipantModel } = await import(
+      "@app/lib/models/agent/conversation"
+    );
+    const participation = await ConversationParticipantModel.findOne({
+      where: {
         conversationId: (await ConversationResource.fetchById(
           adminAuth,
           conversationIds[0]
         ))!.id,
-        workspaceId: userAuth.getNonNullableWorkspace().id,
         userId: userAuth.getNonNullableUser().id,
-        lastReadAt: new Date(),
-      });
-
-      // Mark unreadConvo as unread
-      await UserConversationReadsModel.upsert({
-        conversationId: (await ConversationResource.fetchById(
-          adminAuth,
-          unreadConvo.sId
-        ))!.id,
         workspaceId: userAuth.getNonNullableWorkspace().id,
-        userId: userAuth.getNonNullableUser().id,
-        lastReadAt: dateFromDaysAgo(10),
-      });
-
-      // Mark readConvo as read
-      await UserConversationReadsModel.upsert({
-        conversationId: (await ConversationResource.fetchById(
-          adminAuth,
-          readConvo.sId
-        ))!.id,
-        workspaceId: userAuth.getNonNullableWorkspace().id,
-        userId: userAuth.getNonNullableUser().id,
-        lastReadAt: new Date(),
-      });
-
-      // Test with onlyUnread: true
-      const unreadConversations =
-        await ConversationResource.listConversationsForUser(userAuth, {
-          onlyUnread: true,
-          kind: "private",
-        });
-
-      const unreadIds = unreadConversations.map((c) => c.sId);
-      expect(unreadIds).toContain(unreadConvo.sId);
-      expect(unreadIds).not.toContain(conversationIds[0]);
-      expect(unreadIds).not.toContain(readConvo.sId);
-
-      // Test with onlyUnread: false (default)
-      const allConversations =
-        await ConversationResource.listConversationsForUser(userAuth, {
-          onlyUnread: false,
-          kind: "private",
-        });
-
-      const allIds = allConversations.map((c) => c.sId);
-      expect(allIds.length).toBeGreaterThanOrEqual(3);
-      expect(allIds).toContain(unreadConvo.sId);
-      expect(allIds).toContain(readConvo.sId);
-
-      // Clean up
-      await destroyConversation(adminAuth, { conversationId: unreadConvo.sId });
-      await destroyConversation(adminAuth, { conversationId: readConvo.sId });
+      },
     });
+    assert(participation, "Participation not found");
 
-    it("should return empty array when onlyUnread is true but user has no unread conversations", async () => {
-      // Mark all conversations as read
-      const { UserConversationReadsModel } = await import(
-        "@app/lib/models/agent/conversation"
+    const userConversations =
+      await ConversationResource.listSpaceUnreadConversationsForUser(
+        userAuth,
+        spaceModelIds
       );
 
-      const conversation = await ConversationResource.fetchById(
-        adminAuth,
-        conversationIds[0]
-      );
-      assert(conversation, "Conversation not found");
+    expect(userConversations).toHaveLength(1);
+    const conversationData = userConversations[0].toJSON();
 
-      await UserConversationReadsModel.upsert({
-        conversationId: conversation.id,
-        workspaceId: userAuth.getNonNullableWorkspace().id,
-        userId: userAuth.getNonNullableUser().id,
-        lastReadAt: new Date(),
-      });
+    // Verify participation data is used in toJSON.
+    expect(conversationData.unread).toBe(false);
+    expect(conversationData.actionRequired).toBe(participation.actionRequired);
 
-      const unreadConversations =
-        await ConversationResource.listConversationsForUser(userAuth, {
-          onlyUnread: true,
-          kind: "private",
-        });
-
-      expect(unreadConversations).toHaveLength(0);
-    });
+    // Verify other fields are present.
+    expect(conversationData.id).toBeDefined();
+    expect(conversationData.sId).toBeDefined();
+    expect(conversationData.title).toBeDefined();
+    expect(conversationData.created).toBeDefined();
+    expect(conversationData.updated).toBeDefined();
+    expect(Array.isArray(conversationData.requestedSpaceIds)).toBe(true);
   });
 
-  describe("kind filter", () => {
-    it("should return only private conversations when kind is private", async () => {
-      // Create a space
-      const space = await SpaceFactory.regular(workspace);
-
-      // Add user to the space
-      const addMembersRes = await space.addMembers(adminAuth, {
-        userIds: [userAuth.getNonNullableUser().sId],
-      });
-      assert(addMembersRes.isOk(), "Failed to add user to space");
-
-      await userAuth.refresh();
-
-      // Create a new conversation and add user as participant
-      const spaceConvo = await ConversationFactory.create(userAuth, {
-        agentConfigurationId: agents[0].sId,
-        messagesCreatedAt: [dateFromDaysAgo(1)],
-        spaceId: space.id,
-      });
-
-      await ConversationResource.upsertParticipation(userAuth, {
-        conversation: spaceConvo,
-        action: "posted",
-        user: userAuth.getNonNullableUser().toJSON(),
-      });
-
-      // Test with kind: "private"
-      const privateConversations =
-        await ConversationResource.listConversationsForUser(userAuth, {
-          onlyUnread: false,
-          kind: "private",
-        });
-
-      const privateIds = privateConversations.map((c) => c.sId);
-      expect(privateIds).toContain(conversationIds[0]); // original private conversation
-      expect(privateIds).not.toContain(spaceConvo.sId); // space conversation should be filtered out
-
-      // Clean up
-      await destroyConversation(adminAuth, { conversationId: spaceConvo.sId });
+  it("should return conversations sorted by participation updated time", async () => {
+    // Create a new conversation with more recent participation
+    const recentConvo = await ConversationFactory.create(adminAuth, {
+      agentConfigurationId: agents[0].sId,
+      messagesCreatedAt: [new Date()],
+      spaceId: spaceModelIds[0],
     });
 
-    it("should return only space conversations when kind is space", async () => {
-      // Create a space
-      const space = await SpaceFactory.regular(workspace);
-
-      // Add user to the space
-      const addMembersRes = await space.addMembers(adminAuth, {
-        userIds: [userAuth.getNonNullableUser().sId],
-      });
-      assert(addMembersRes.isOk(), "Failed to add user to space");
-
-      await userAuth.refresh();
-
-      // Create a new conversation and add user as participant
-      const spaceConvo = await ConversationFactory.create(userAuth, {
-        agentConfigurationId: agents[0].sId,
-        messagesCreatedAt: [dateFromDaysAgo(1)],
-        spaceId: space.id,
-      });
-
-      await ConversationResource.upsertParticipation(userAuth, {
-        conversation: spaceConvo,
-        action: "posted",
-        user: userAuth.getNonNullableUser().toJSON(),
-      });
-
-      // Test with kind: "space"
-      const spaceConversations =
-        await ConversationResource.listConversationsForUser(userAuth, {
-          onlyUnread: false,
-          kind: "space",
-        });
-
-      const spaceIds = spaceConversations.map((c) => c.sId);
-      expect(spaceIds).toContain(spaceConvo.sId); // space conversation should be included
-      expect(spaceIds).not.toContain(conversationIds[0]); // private conversation should be filtered out
-
-      // Clean up
-      await destroyConversation(adminAuth, { conversationId: spaceConvo.sId });
+    await ConversationResource.upsertParticipation(userAuth, {
+      conversation: recentConvo,
+      action: "posted",
+      user: userAuth.getNonNullableUser().toJSON(),
+      lastReadAt: null, // Ensure it's marked as unread
     });
 
-    it("should default to private conversations when kind is not specified", async () => {
-      // Create a space
-      const space = await SpaceFactory.regular(workspace);
+    const userConversations =
+      await ConversationResource.listSpaceUnreadConversationsForUser(
+        userAuth,
+        spaceModelIds
+      );
+    expect(userConversations).toHaveLength(2);
+    // Most recent participation should be first.
+    expect(userConversations[0].sId).toBe(recentConvo.sId);
+    expect(userConversations[1].sId).toBe(conversationIds[0]);
 
-      // Add user to the space
-      const addMembersRes = await space.addMembers(adminAuth, {
-        userIds: [userAuth.getNonNullableUser().sId],
-      });
-      assert(addMembersRes.isOk(), "Failed to add user to space");
+    const serializedConvs = userConversations.map((c) => c.toJSON());
 
-      await userAuth.refresh();
+    // Verify sorting by updated time.
+    expect(serializedConvs[0].updated).toBeGreaterThan(
+      serializedConvs[1].updated!
+    );
 
-      // Create a new conversation and add user as participant
-      const spaceConvo = await ConversationFactory.create(userAuth, {
-        agentConfigurationId: agents[0].sId,
-        messagesCreatedAt: [dateFromDaysAgo(1)],
-        spaceId: space.id,
-      });
-
-      await ConversationResource.upsertParticipation(userAuth, {
-        conversation: spaceConvo,
-        action: "posted",
-        user: userAuth.getNonNullableUser().toJSON(),
-      });
-
-      // Test with default parameters (should default to kind: "private")
-      const defaultConversations =
-        await ConversationResource.listConversationsForUser(userAuth);
-
-      const defaultIds = defaultConversations.map((c) => c.sId);
-      expect(defaultIds).toContain(conversationIds[0]); // original private conversation
-      expect(defaultIds).not.toContain(spaceConvo.sId); // space conversation should be filtered out
-
-      // Clean up
-      await destroyConversation(adminAuth, { conversationId: spaceConvo.sId });
-    });
+    await destroyConversation(adminAuth, { conversationId: recentConvo.sId });
   });
 
-  describe("combined filters", () => {
-    it("should filter by both onlyUnread and kind when both are specified", async () => {
-      const { UserConversationReadsModel } = await import(
-        "@app/lib/models/agent/conversation"
+  it("should not return test conversations by default", async () => {
+    // Create a test conversation by updating visibility
+    const testConvo = await ConversationFactory.create(adminAuth, {
+      agentConfigurationId: agents[0].sId,
+      messagesCreatedAt: [dateFromDaysAgo(3)],
+      visibility: "test",
+      spaceId: spaceModelIds[0],
+    });
+
+    // Add user as participant to the test conversation
+    await ConversationResource.upsertParticipation(userAuth, {
+      conversation: testConvo,
+      action: "posted",
+      user: userAuth.getNonNullableUser().toJSON(),
+      lastReadAt: null, // Ensure it's marked as unread
+    });
+
+    // By default, should only see unlisted conversations (not test conversations)
+    const userConversations =
+      await ConversationResource.listSpaceUnreadConversationsForUser(
+        userAuth,
+        spaceModelIds
+      );
+    const conversationIds = userConversations.map((c) => c.sId);
+    expect(conversationIds).toContain(conversationIds[0]); // original conversation
+    expect(conversationIds).not.toContain(testConvo.sId); // test conversation should be filtered out
+
+    // Clean up
+    await destroyConversation(adminAuth, { conversationId: testConvo.sId });
+  });
+
+  it("should return only space conversations", async () => {
+    // Create a new private conversation and add user as participant
+    const privateConvo = await ConversationFactory.create(userAuth, {
+      agentConfigurationId: agents[0].sId,
+      messagesCreatedAt: [dateFromDaysAgo(1)],
+    });
+
+    await ConversationResource.upsertParticipation(userAuth, {
+      conversation: privateConvo,
+      action: "posted",
+      user: userAuth.getNonNullableUser().toJSON(),
+      lastReadAt: null, // Ensure it's marked as unread
+    });
+
+    const spaceConversations =
+      await ConversationResource.listSpaceUnreadConversationsForUser(
+        userAuth,
+        spaceModelIds
       );
 
-      // Create a space
-      const space = await SpaceFactory.regular(workspace);
+    const spaceIds = spaceConversations.map((c) => c.sId);
+    expect(spaceIds).toContain(conversationIds[0]); // space conversation should be included
+    expect(spaceIds).not.toContain(privateConvo.sId); // private conversation should be filtered out
 
-      // Add user to the space
-      const addMembersRes = await space.addMembers(adminAuth, {
-        userIds: [userAuth.getNonNullableUser().sId],
-      });
-      assert(addMembersRes.isOk(), "Failed to add user to space");
-
-      await userAuth.refresh();
-
-      // Create unread space conversation
-      const unreadSpaceConvo = await ConversationFactory.create(userAuth, {
-        agentConfigurationId: agents[0].sId,
-        messagesCreatedAt: [dateFromDaysAgo(1)],
-        spaceId: space.id,
-      });
-
-      await ConversationResource.upsertParticipation(userAuth, {
-        conversation: unreadSpaceConvo,
-        action: "posted",
-        user: userAuth.getNonNullableUser().toJSON(),
-      });
-
-      // Create read space conversation
-      const readSpaceConvo = await ConversationFactory.create(userAuth, {
-        agentConfigurationId: agents[0].sId,
-        messagesCreatedAt: [dateFromDaysAgo(1)],
-        spaceId: space.id,
-      });
-
-      await ConversationResource.upsertParticipation(userAuth, {
-        conversation: readSpaceConvo,
-        action: "posted",
-        user: userAuth.getNonNullableUser().toJSON(),
-      });
-
-      // Create unread private conversation
-      const unreadPrivateConvo = await ConversationFactory.create(userAuth, {
-        agentConfigurationId: agents[0].sId,
-        messagesCreatedAt: [dateFromDaysAgo(1)],
-      });
-
-      // Add user as participant to all
-      await ConversationResource.upsertParticipation(userAuth, {
-        conversation: unreadSpaceConvo,
-        action: "posted",
-        user: userAuth.getNonNullableUser().toJSON(),
-      });
-
-      await ConversationResource.upsertParticipation(userAuth, {
-        conversation: readSpaceConvo,
-        action: "posted",
-        user: userAuth.getNonNullableUser().toJSON(),
-      });
-
-      await ConversationResource.upsertParticipation(userAuth, {
-        conversation: unreadPrivateConvo,
-        action: "posted",
-        user: userAuth.getNonNullableUser().toJSON(),
-      });
-
-      // Mark unreadSpaceConvo as unread
-      await UserConversationReadsModel.upsert({
-        conversationId: unreadSpaceConvo.id,
-        workspaceId: userAuth.getNonNullableWorkspace().id,
-        userId: userAuth.getNonNullableUser().id,
-        lastReadAt: dateFromDaysAgo(2),
-      });
-
-      // Mark readSpaceConvo as read
-      await UserConversationReadsModel.upsert({
-        conversationId: (await ConversationResource.fetchById(
-          userAuth,
-          readSpaceConvo.sId
-        ))!.id,
-        workspaceId: userAuth.getNonNullableWorkspace().id,
-        userId: userAuth.getNonNullableUser().id,
-        lastReadAt: new Date(),
-      });
-
-      // Mark unreadPrivateConvo as unread
-      await UserConversationReadsModel.destroy({
-        where: {
-          conversationId: (await ConversationResource.fetchById(
-            adminAuth,
-            unreadPrivateConvo.sId
-          ))!.id,
-          workspaceId: userAuth.getNonNullableWorkspace().id,
-          userId: userAuth.getNonNullableUser().id,
-        },
-      });
-
-      // Test with onlyUnread: true and kind: "space" - should only return unread space conversations
-      const unreadSpaceConversations =
-        await ConversationResource.listConversationsForUser(userAuth, {
-          onlyUnread: true,
-          kind: "space",
-        });
-
-      const unreadSpaceIds = unreadSpaceConversations.map((c) => c.sId);
-      expect(unreadSpaceIds).toContain(unreadSpaceConvo.sId);
-      expect(unreadSpaceIds).not.toContain(readSpaceConvo.sId);
-      expect(unreadSpaceIds).not.toContain(unreadPrivateConvo.sId);
-
-      // Test with onlyUnread: true and kind: "private" - should only return unread private conversations
-      const unreadPrivateConversations =
-        await ConversationResource.listConversationsForUser(userAuth, {
-          onlyUnread: true,
-          kind: "private",
-        });
-
-      const unreadPrivateIds = unreadPrivateConversations.map((c) => c.sId);
-      expect(unreadPrivateIds).toContain(unreadPrivateConvo.sId);
-      expect(unreadPrivateIds).not.toContain(unreadSpaceConvo.sId);
-      expect(unreadPrivateIds).not.toContain(readSpaceConvo.sId);
-
-      // Clean up
-      await destroyConversation(adminAuth, {
-        conversationId: unreadSpaceConvo.sId,
-      });
-      await destroyConversation(adminAuth, {
-        conversationId: readSpaceConvo.sId,
-      });
-      await destroyConversation(adminAuth, {
-        conversationId: unreadPrivateConvo.sId,
-      });
-    });
+    // Clean up
+    await destroyConversation(adminAuth, { conversationId: privateConvo.sId });
   });
 });
 

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -1046,6 +1046,7 @@ describe("listSpaceUnreadConversationsForUser", () => {
   let workspace: LightWorkspaceType;
   let agents: LightAgentConfigurationType[];
   let conversationIds: string[];
+  let conversationModelIds: number[];
   let spaceModelIds: number[];
 
   beforeEach(async () => {
@@ -1081,6 +1082,7 @@ describe("listSpaceUnreadConversationsForUser", () => {
     });
 
     conversationIds = [conversation.sId];
+    conversationModelIds = [conversation.id];
     spaceModelIds = [space.id];
 
     // Add regular user as participant
@@ -1088,6 +1090,7 @@ describe("listSpaceUnreadConversationsForUser", () => {
       conversation,
       action: "posted",
       user: userAuth.getNonNullableUser().toJSON(),
+      lastReadAt: dateFromDaysAgo(10), // Mark as read
     });
   });
 
@@ -1126,10 +1129,7 @@ describe("listSpaceUnreadConversationsForUser", () => {
     );
     const participation = await ConversationParticipantModel.findOne({
       where: {
-        conversationId: (await ConversationResource.fetchById(
-          adminAuth,
-          conversationIds[0]
-        ))!.id,
+        conversationId: conversationModelIds[0],
         userId: userAuth.getNonNullableUser().id,
         workspaceId: userAuth.getNonNullableWorkspace().id,
       },
@@ -1170,7 +1170,7 @@ describe("listSpaceUnreadConversationsForUser", () => {
       conversation: recentConvo,
       action: "posted",
       user: userAuth.getNonNullableUser().toJSON(),
-      lastReadAt: null, // Ensure it's marked as unread
+      lastReadAt: dateFromDaysAgo(20), // Ensure it's marked as unread
     });
 
     const userConversations =
@@ -1207,7 +1207,7 @@ describe("listSpaceUnreadConversationsForUser", () => {
       conversation: testConvo,
       action: "posted",
       user: userAuth.getNonNullableUser().toJSON(),
-      lastReadAt: null, // Ensure it's marked as unread
+      lastReadAt: dateFromDaysAgo(20), // Ensure it's marked as unread
     });
 
     // By default, should only see unlisted conversations (not test conversations)

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -735,6 +735,8 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       }
     });
 
+    // These conversations are used to display the unread count in the sidebar.
+    // We do not count conversations the user does not participate in.
     const unreadConversations = conversations.filter((c) => {
       const participation = c.userParticipation;
       if (!participation) {

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -656,18 +656,8 @@ export class ConversationResource extends BaseResource<ConversationModel> {
     return new Ok(undefined);
   }
 
-  static async listConversationsForUser(
-    auth: Authenticator,
-    {
-      onlyUnread,
-      kind,
-    }: {
-      onlyUnread: boolean;
-      kind: "private" | "space";
-    } = {
-      onlyUnread: false,
-      kind: "private",
-    }
+  static async listPrivateConversationsForUser(
+    auth: Authenticator
   ): Promise<ConversationResource[]> {
     // First get all participations for the user to get conversation IDs and metadata.
     const participationMap = await this.fetchParticipationMapForUser(auth);
@@ -677,40 +667,14 @@ export class ConversationResource extends BaseResource<ConversationModel> {
       return [];
     }
 
-    const whereClause: WhereOptions<ConversationModel> = {
-      id: { [Op.in]: conversationIds },
-    };
-
-    if (kind === "space") {
-      whereClause.spaceId = { [Op.not]: null };
-    } else if (kind === "private") {
-      whereClause.spaceId = { [Op.is]: null };
-    }
-
     const conversations = await this.baseFetchWithAuthorization(
       auth,
       {},
       {
         where: {
-          ...whereClause,
+          id: { [Op.in]: conversationIds },
+          spaceId: { [Op.is]: null },
           visibility: { [Op.eq]: "unlisted" },
-          ...(onlyUnread
-            ? {
-                [Op.or]: Array.from(participationMap.entries()).map(
-                  ([id, participation]) => {
-                    if (participation.lastReadAt === null) {
-                      return { id };
-                    }
-                    return {
-                      [Op.and]: [
-                        { id },
-                        { updatedAt: { [Op.gt]: participation.lastReadAt } },
-                      ],
-                    };
-                  }
-                ),
-              }
-            : {}),
         },
       }
     );
@@ -725,6 +689,68 @@ export class ConversationResource extends BaseResource<ConversationModel> {
 
     // Sort by participation updated time descending.
     return conversations.sort(
+      (a, b) =>
+        (b.userParticipation?.updated ?? 0) -
+        (a.userParticipation?.updated ?? 0)
+    );
+  }
+
+  static async listSpaceUnreadConversationsForUser(
+    auth: Authenticator,
+    spaceIds: number[]
+  ): Promise<ConversationResource[]> {
+    if (spaceIds.length === 0) {
+      return [];
+    }
+    const conversations = await this.baseFetchWithAuthorization(
+      auth,
+      {},
+      {
+        where: {
+          spaceId: { [Op.in]: spaceIds },
+          visibility: { [Op.eq]: "unlisted" },
+        },
+      }
+    );
+
+    if (conversations.length === 0) {
+      return [];
+    }
+
+    const participationMap = await this.fetchParticipationMapForUser(
+      auth,
+      conversations.map((c) => c.id)
+    );
+    const conversationIds = Array.from(participationMap.keys());
+
+    if (conversationIds.length === 0) {
+      return [];
+    }
+
+    // Attach participation data to resources.
+    conversations.forEach((c) => {
+      const participation = participationMap.get(c.id);
+      if (participation) {
+        c.userParticipation = participation;
+      }
+    });
+
+    const unreadConversations = conversations.filter((c) => {
+      const participation = c.userParticipation;
+      if (!participation) {
+        return false;
+      }
+      if (participation.lastReadAt === null) {
+        return true;
+      }
+      if (c.updatedAt > participation.lastReadAt) {
+        return true;
+      }
+      return false;
+    });
+
+    // Sort by participation updated time descending.
+    return unreadConversations.sort(
       (a, b) =>
         (b.userParticipation?.updated ?? 0) -
         (a.userParticipation?.updated ?? 0)

--- a/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/conversations/index.ts
@@ -516,7 +516,7 @@ async function handler(
         });
       }
       const conversations =
-        await ConversationResource.listConversationsForUser(auth);
+        await ConversationResource.listPrivateConversationsForUser(auth);
       res.status(200).json({
         conversations: conversations.map((c) =>
           addBackwardCompatibleConversationWithoutContentFields(

--- a/front/pages/api/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/index.ts
@@ -51,7 +51,7 @@ async function handler(
   switch (req.method) {
     case "GET":
       const conversations =
-        await ConversationResource.listConversationsForUser(auth);
+        await ConversationResource.listPrivateConversationsForUser(auth);
       res.status(200).json({
         conversations: conversations
           .filter((c) => !c.spaceId)

--- a/front/pages/api/w/[wId]/assistant/conversations/spaces/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/spaces/index.ts
@@ -27,10 +27,10 @@ async function handler(
 
       // Fetch all unread conversations for the user in one query
       const unreadConversations =
-        await ConversationResource.listConversationsForUser(auth, {
-          onlyUnread: true,
-          kind: "space",
-        });
+        await ConversationResource.listSpaceUnreadConversationsForUser(
+          auth,
+          spaces.map((s) => s.id)
+        );
 
       // Group conversations by space
       const spaceIdToSpaceMap = new Map(spaces.map((s) => [s.id, s]));


### PR DESCRIPTION






## Description

This PR refactors the conversation listing logic by splitting the previous method into two specialized methods with clearer responsibilities.

- Renames `listConversationsForUser` to `listPrivateConversationsForUser` and removes filtering parameters (`onlyUnread` and `kind`)
- Introduces a new method `listSpaceUnreadConversationsForUser` specifically for fetching unread conversations in spaces
- When fetching space unread conversations
    - conversations from the space are fetched before the participation map to avoid fetching the participation map for all conversations (private + space)
    - the participation map is fetched only for the space conversations
    - space conversations are filtered to keep only the unread ones
   
## Tests

All existing tests have been updated . The test suite now includes:
- Tests for `listPrivateConversationsForUser` 
- Tests for `listSpaceUnreadConversationsForUser` 

## Risks

Low risk. 
## Deploy Plan

Standard deployment.