### PR TITLE
[poke] - feat(plugin): data source retrieval treemap

### DIFF
--- a/front/components/charts/DatasourceRetrievalTreemapContent.tsx
+++ b/front/components/charts/DatasourceRetrievalTreemapContent.tsx
@@ -1,0 +1,226 @@
+import { cn } from "@dust-tt/sparkle";
+
+import {
+  buildColorClass,
+  INDEXED_COLORS,
+} from "@app/components/agent_builder/observability/constants";
+import type { ConnectorProvider } from "@app/types";
+
+const LABEL_COLOR_VARIANT = 900;
+const VALUE_COLOR_VARIANT = 700;
+
+const MIN_TILE_HEIGHT_FOR_VALUE = 24;
+const MIN_TILE_HEIGHT_FOR_NAME_AND_VALUE = 42;
+const GROUP_OUTLINE_INSET = 2;
+const GROUP_OUTLINE_STROKE_WIDTH = 2;
+const LEAF_STROKE_WIDTH = 1;
+const LEAF_BORDER_RADIUS = 4;
+const GROUP_LABEL_HEIGHT = 18;
+const MIN_GROUP_WIDTH_FOR_LABEL = 40;
+const MIN_GROUP_HEIGHT_FOR_LABEL = 24;
+
+export interface DatasourceRetrievalTreemapNode {
+  name: string;
+  size: number;
+  color: string;
+  baseColor: string;
+  mcpServerConfigIds?: string[];
+  mcpServerDisplayName?: string;
+  mcpServerName?: string;
+  dataSourceId?: string;
+  connectorProvider?: ConnectorProvider;
+  parentId?: string | null;
+  documentId?: string;
+  sourceUrl?: string | null;
+  children?: DatasourceRetrievalTreemapNode[];
+  [key: string]: unknown;
+}
+
+interface DatasourceRetrievalTreemapContentProps {
+  x?: number;
+  y?: number;
+  width?: number;
+  height?: number;
+  name?: string;
+  value?: number;
+  depth?: number;
+  index?: number;
+  color?: string;
+  baseColor?: string;
+  mcpServerConfigIds?: string[];
+  mcpServerDisplayName?: string;
+  mcpServerName?: string;
+  dataSourceId?: string;
+  connectorProvider?: ConnectorProvider;
+  parentId?: string | null;
+  documentId?: string;
+  sourceUrl?: string | null;
+  children?: DatasourceRetrievalTreemapNode[] | null;
+  root?: {
+    depth?: number;
+    name?: string;
+    x?: number;
+    y?: number;
+    width?: number;
+    height?: number;
+    children?: unknown[] | null;
+    value?: number;
+  };
+  onNodeClick?: (node: DatasourceRetrievalTreemapNode) => void;
+}
+
+export function DatasourceRetrievalTreemapContent({
+  x = 0,
+  y = 0,
+  width = 0,
+  height = 0,
+  name = "",
+  value = 0,
+  depth = 0,
+  index,
+  color = INDEXED_COLORS[0],
+  baseColor = "orange",
+  mcpServerConfigIds,
+  mcpServerDisplayName,
+  mcpServerName,
+  dataSourceId,
+  connectorProvider,
+  parentId,
+  documentId,
+  sourceUrl,
+  children,
+  root,
+  onNodeClick,
+}: DatasourceRetrievalTreemapContentProps) {
+  if (depth === 0) {
+    return null;
+  }
+
+  if ((children?.length ?? 0) > 0) {
+    return null;
+  }
+
+  const shouldShowValue = height >= MIN_TILE_HEIGHT_FOR_VALUE;
+  const shouldShowName = height >= MIN_TILE_HEIGHT_FOR_NAME_AND_VALUE;
+  const isClickable = !!onNodeClick;
+  const leafClassName = isClickable ? `${color} cursor-pointer` : color;
+
+  const rootX = root?.x ?? 0;
+  const rootY = root?.y ?? 0;
+  const rootWidth = root?.width ?? 0;
+  const rootHeight = root?.height ?? 0;
+  const rootChildrenCount = root?.children?.length ?? 0;
+
+  const shouldShowGroupOutline =
+    root?.depth === 1 &&
+    typeof index === "number" &&
+    index === rootChildrenCount - 1;
+
+  const groupName = root?.name ?? "";
+  const groupValue = typeof root?.value === "number" ? root.value : null;
+  const groupLabel =
+    groupValue !== null ? `${groupName} — ${groupValue}` : groupName;
+  const shouldShowGroupLabel =
+    shouldShowGroupOutline &&
+    groupName.length > 0 &&
+    rootWidth >= MIN_GROUP_WIDTH_FOR_LABEL &&
+    rootHeight >= MIN_GROUP_HEIGHT_FOR_LABEL;
+
+  const nameTextClassName = documentId ? "text-[10px]" : "text-xs";
+
+  return (
+    <g>
+      <rect
+        x={x}
+        y={y}
+        width={width}
+        height={height}
+        rx={LEAF_BORDER_RADIUS}
+        fill="currentColor"
+        className={leafClassName}
+        stroke="white"
+        strokeWidth={LEAF_STROKE_WIDTH}
+        onClick={
+          onNodeClick
+            ? (e) => {
+                e.stopPropagation();
+                onNodeClick({
+                  name,
+                  size: value,
+                  color,
+                  baseColor,
+                  mcpServerConfigIds,
+                  mcpServerDisplayName,
+                  mcpServerName,
+                  dataSourceId,
+                  connectorProvider,
+                  parentId,
+                  documentId,
+                  sourceUrl,
+                });
+              }
+            : undefined
+        }
+      />
+      {shouldShowValue && (
+        <foreignObject
+          x={x}
+          y={y}
+          width={width}
+          height={height}
+          pointerEvents="none"
+        >
+          <div className="flex h-full w-full flex-col items-center justify-center gap-0.5 overflow-hidden p-1 text-center">
+            {shouldShowName && (
+              <div
+                className={cn(
+                  "w-full min-w-0 overflow-hidden text-ellipsis whitespace-nowrap font-medium",
+                  nameTextClassName,
+                  buildColorClass(baseColor, LABEL_COLOR_VARIANT)
+                )}
+              >
+                {name}
+              </div>
+            )}
+            <div
+              className={cn(
+                "text-xs",
+                buildColorClass(baseColor, VALUE_COLOR_VARIANT)
+              )}
+            >
+              {value}
+            </div>
+          </div>
+        </foreignObject>
+      )}
+      {shouldShowGroupOutline && (
+        <rect
+          x={rootX + GROUP_OUTLINE_INSET}
+          y={rootY + GROUP_OUTLINE_INSET}
+          width={Math.max(0, rootWidth - GROUP_OUTLINE_INSET * 2)}
+          height={Math.max(0, rootHeight - GROUP_OUTLINE_INSET * 2)}
+          rx={2}
+          fill="none"
+          stroke="white"
+          strokeWidth={GROUP_OUTLINE_STROKE_WIDTH}
+          pointerEvents="none"
+        />
+      )}
+      {shouldShowGroupLabel && (
+        <foreignObject
+          x={rootX}
+          y={rootY}
+          width={Math.max(0, rootWidth)}
+          height={GROUP_LABEL_HEIGHT}
+          pointerEvents="none"
+        >
+          <div className="flex h-full w-full items-center justify-center overflow-hidden">
+            <div className="w-full min-w-0 overflow-hidden text-ellipsis whitespace-nowrap rounded bg-white/70 px-1 py-0.5 text-center text-[11px] font-medium text-foreground dark:bg-black/30 dark:text-foreground-night">
+              {groupLabel}
+            </div>
+          </div>
+        </foreignObject>
+      )}
+    </g>
+  );
+}

--- a/front/components/poke/plugins/RunPluginDialog.tsx
+++ b/front/components/poke/plugins/RunPluginDialog.tsx
@@ -13,6 +13,7 @@ import {
 import { AlertCircle } from "lucide-react";
 import { useCallback, useState } from "react";
 
+import { DatasourceRetrievalTreemapPluginChart } from "@app/components/poke/plugins/components/DatasourceRetrievalTreemapPluginChart";
 import { PluginForm } from "@app/components/poke/plugins/PluginForm";
 import {
   PokeAlert,
@@ -160,6 +161,17 @@ export function RunPluginDialog({
                   </div>
                 </div>
               )}
+              {result &&
+                result.display === "component" &&
+                result.component === "datasourceRetrievalTreemap" && (
+                  <div className="mb-4 mt-4">
+                    <DatasourceRetrievalTreemapPluginChart
+                      workspaceId={result.props.workspaceId}
+                      agentConfigurationId={result.props.agentConfigurationId}
+                      period={result.props.period}
+                    />
+                  </div>
+                )}
               {isLoadingAsyncArgs ? (
                 <Spinner />
               ) : (

--- a/front/components/poke/plugins/components/DatasourceRetrievalTreemapPluginChart.tsx
+++ b/front/components/poke/plugins/components/DatasourceRetrievalTreemapPluginChart.tsx
@@ -1,0 +1,139 @@
+import { useCallback, useMemo } from "react";
+import { Tooltip, Treemap } from "recharts";
+
+import {
+  CHART_HEIGHT,
+  DEFAULT_PERIOD_DAYS,
+} from "@app/components/agent_builder/observability/constants";
+import {
+  getIndexedBaseColor,
+  getIndexedColor,
+} from "@app/components/agent_builder/observability/utils";
+import { ChartContainer } from "@app/components/charts/ChartContainer";
+import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
+import type { DatasourceRetrievalTreemapNode } from "@app/components/charts/DatasourceRetrievalTreemapContent";
+import { DatasourceRetrievalTreemapContent } from "@app/components/charts/DatasourceRetrievalTreemapContent";
+import { usePokeAgentDatasourceRetrieval } from "@app/poke/swr/agent_details";
+
+interface DatasourceRetrievalTreemapPluginChartProps {
+  workspaceId: string;
+  agentConfigurationId: string;
+  period?: number;
+}
+
+export function DatasourceRetrievalTreemapPluginChart({
+  workspaceId,
+  agentConfigurationId,
+  period = DEFAULT_PERIOD_DAYS,
+}: DatasourceRetrievalTreemapPluginChartProps) {
+  const {
+    datasourceRetrieval,
+    totalRetrievals,
+    isDatasourceRetrievalLoading,
+    isDatasourceRetrievalError,
+  } = usePokeAgentDatasourceRetrieval({
+    workspaceId,
+    agentConfigurationId,
+    days: period,
+  });
+
+  const { treemapData, legendItems } = useMemo(() => {
+    if (!datasourceRetrieval.length) {
+      return { treemapData: null, legendItems: [] };
+    }
+
+    const toolKeys = datasourceRetrieval.map((mcp) => mcp.mcpServerDisplayName);
+    const flattenedData: DatasourceRetrievalTreemapNode[] = [];
+    const legend: Array<{
+      key: string;
+      label: string;
+      colorClassName: string;
+    }> = [];
+    const seenServers = new Set<string>();
+
+    for (const mcp of datasourceRetrieval) {
+      const serverColor = getIndexedColor(mcp.mcpServerDisplayName, toolKeys);
+      const serverBaseColor = getIndexedBaseColor(
+        mcp.mcpServerDisplayName,
+        toolKeys
+      );
+
+      if (!seenServers.has(mcp.mcpServerDisplayName)) {
+        legend.push({
+          key: mcp.mcpServerDisplayName,
+          label: mcp.mcpServerDisplayName,
+          colorClassName: serverColor,
+        });
+        seenServers.add(mcp.mcpServerDisplayName);
+      }
+
+      for (const datasource of mcp.datasources) {
+        flattenedData.push({
+          name: datasource.displayName,
+          dataSourceId: datasource.dataSourceId,
+          size: datasource.count,
+          color: serverColor,
+          baseColor: serverBaseColor,
+          mcpServerDisplayName: mcp.mcpServerDisplayName,
+        });
+      }
+    }
+
+    return { treemapData: flattenedData, legendItems: legend };
+  }, [datasourceRetrieval]);
+
+  const renderTooltip = useCallback(
+    (props: { payload?: { payload?: DatasourceRetrievalTreemapNode }[] }) => {
+      const data = props.payload?.[0]?.payload;
+      if (!data) {
+        return null;
+      }
+
+      const size = data.size ?? 0;
+      const percent =
+        totalRetrievals > 0 ? Math.round((size / totalRetrievals) * 100) : 0;
+
+      return (
+        <ChartTooltipCard
+          title={data.name}
+          rows={[{ label: "Retrievals", value: size, percent }]}
+        />
+      );
+    },
+    [totalRetrievals]
+  );
+
+  return (
+    <ChartContainer
+      title="Documents retrieved by data sources"
+      description={`Number of documents retrieved per searches, grouped by datasource (last ${period} days).`}
+      isLoading={isDatasourceRetrievalLoading}
+      errorMessage={
+        isDatasourceRetrievalError
+          ? "Failed to load datasource retrieval data."
+          : undefined
+      }
+      emptyMessage={
+        !treemapData || treemapData.length === 0
+          ? "No retrieval data for this period."
+          : undefined
+      }
+      height={CHART_HEIGHT}
+      legendItems={legendItems}
+    >
+      <Treemap
+        data={treemapData ?? []}
+        dataKey="size"
+        aspectRatio={4 / 3}
+        isAnimationActive={false}
+        content={<DatasourceRetrievalTreemapContent />}
+      >
+        <Tooltip
+          cursor={false}
+          content={renderTooltip}
+          wrapperStyle={{ outline: "none" }}
+        />
+      </Treemap>
+    </ChartContainer>
+  );
+}

--- a/front/lib/api/poke/plugins/agents/datasource_retrieval_treemap.ts
+++ b/front/lib/api/poke/plugins/agents/datasource_retrieval_treemap.ts
@@ -1,0 +1,30 @@
+import { createPlugin } from "@app/lib/api/poke/types";
+import { Err, Ok } from "@app/types";
+
+export const datasourceRetrievalTreemapPlugin = createPlugin({
+  manifest: {
+    id: "datasource-retrieval-treemap",
+    name: "Datasource Retrieval Treemap",
+    description: "View which datasources this agent retrieves documents from",
+    resourceTypes: ["agents"],
+    args: {},
+  },
+  execute: async (auth, resource) => {
+    if (!resource) {
+      return new Err(new Error("Agent configuration not found"));
+    }
+
+    const workspace = auth.getNonNullableWorkspace();
+
+    return new Ok({
+      display: "component",
+      component: "datasourceRetrievalTreemap",
+      props: {
+        workspaceId: workspace.sId,
+        agentConfigurationId: resource.sId,
+        period: 30,
+      },
+    });
+  },
+  isApplicableTo: (_auth, resource) => resource?.status === "active",
+});

--- a/front/lib/api/poke/plugins/agents/index.ts
+++ b/front/lib/api/poke/plugins/agents/index.ts
@@ -1,2 +1,3 @@
 export * from "./agent_editors";
 export * from "./agent_retention";
+export * from "./datasource_retrieval_treemap";

--- a/front/lib/api/poke/types.ts
+++ b/front/lib/api/poke/types.ts
@@ -68,6 +68,28 @@ interface DatasourceRetrievalTreemapProps {
   period?: number;
 }
 
+type PluginTextResponse = {
+  display: "text";
+  value: string;
+};
+
+type PluginJSONResponse = {
+  display: "json";
+  value: Record<string, unknown>;
+};
+
+type PluginMarkdownResponse = {
+  display: "markdown";
+  value: string;
+};
+
+type PluginTextWithLinkResponse = {
+  display: "textWithLink";
+  value: string;
+  link: string;
+  linkText: string;
+};
+
 type PluginComponentResponse = {
   display: "component";
   component: "datasourceRetrievalTreemap";
@@ -75,10 +97,10 @@ type PluginComponentResponse = {
 };
 
 export type PluginResponse =
-  | { display: "text"; value: string }
-  | { display: "json"; value: Record<string, unknown> }
-  | { display: "markdown"; value: string }
-  | { display: "textWithLink"; value: string; link: string; linkText: string }
+  | PluginTextResponse
+  | PluginJSONResponse
+  | PluginMarkdownResponse
+  | PluginTextWithLinkResponse
   | PluginComponentResponse;
 
 // Base plugin interface.

--- a/front/lib/api/poke/types.ts
+++ b/front/lib/api/poke/types.ts
@@ -62,11 +62,24 @@ export type InferPluginArgsAtExecution<T extends PluginArgs> = {
   [K in keyof T]: InferArgType<T[K]["type"]>;
 };
 
+interface DatasourceRetrievalTreemapProps {
+  workspaceId: string;
+  agentConfigurationId: string;
+  period?: number;
+}
+
+type PluginComponentResponse = {
+  display: "component";
+  component: "datasourceRetrievalTreemap";
+  props: DatasourceRetrievalTreemapProps;
+};
+
 export type PluginResponse =
   | { display: "text"; value: string }
   | { display: "json"; value: Record<string, unknown> }
   | { display: "markdown"; value: string }
-  | { display: "textWithLink"; value: string; link: string; linkText: string };
+  | { display: "textWithLink"; value: string; link: string; linkText: string }
+  | PluginComponentResponse;
 
 // Base plugin interface.
 interface BasePlugin<

--- a/front/lib/resources/plugin_run_resource.ts
+++ b/front/lib/resources/plugin_run_resource.ts
@@ -57,6 +57,9 @@ function trimPluginRunResultOrError(result: PluginResponse | string) {
   let stringResult: string;
   if (typeof result === "string") {
     stringResult = JSON.stringify(result);
+  } else if (result.display === "component") {
+    // For component responses, stringify the whole object since there's no value property.
+    stringResult = JSON.stringify(result);
   } else {
     stringResult = JSON.stringify(result.value);
   }

--- a/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/observability/datasource-retrieval.ts
+++ b/front/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/observability/datasource-retrieval.ts
@@ -1,0 +1,123 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
+
+import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import type { DatasourceRetrievalData } from "@app/lib/api/assistant/observability/datasource_retrieval";
+import { fetchDatasourceRetrievalMetrics } from "@app/lib/api/assistant/observability/datasource_retrieval";
+import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+import { isString } from "@app/types";
+
+const QuerySchema = z.object({
+  days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
+});
+
+export type PokeGetDatasourceRetrievalResponse = {
+  datasources: DatasourceRetrievalData[];
+  total: number;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<PokeGetDatasourceRetrievalResponse>
+  >,
+  session: SessionWithUser
+): Promise<void> {
+  const { wId, aId } = req.query;
+  if (!isString(wId) || !isString(aId)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid workspace or agent ID.",
+      },
+    });
+  }
+
+  const auth = await Authenticator.fromSuperUserSession(session, wId);
+  const owner = auth.workspace();
+
+  if (!owner || !auth.isDustSuperUser()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_not_found",
+        message: "Workspace not found.",
+      },
+    });
+  }
+
+  const assistant = await getAgentConfiguration(auth, {
+    agentId: aId,
+    variant: "light",
+  });
+
+  if (!assistant) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "agent_configuration_not_found",
+        message: "The agent you're trying to access was not found.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      const q = QuerySchema.safeParse(req.query);
+      if (!q.success) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid query parameters: ${fromError(q.error).toString()}`,
+          },
+        });
+      }
+
+      const days = q.data.days;
+
+      const datasourceRetrievalResult = await fetchDatasourceRetrievalMetrics(
+        auth,
+        {
+          agentId: assistant.sId,
+          days,
+        }
+      );
+
+      if (datasourceRetrievalResult.isErr()) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: `Failed to retrieve datasource retrieval metrics: ${fromError(datasourceRetrievalResult.error).toString()}`,
+          },
+        });
+      }
+
+      const datasources = datasourceRetrievalResult.value;
+      const total = datasources.reduce((sum, ds) => sum + ds.count, 0);
+
+      return res.status(200).json({
+        datasources,
+        total,
+      });
+    }
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForPoke(handler);

--- a/front/poke/swr/agent_details.ts
+++ b/front/poke/swr/agent_details.ts
@@ -1,7 +1,9 @@
 import type { Fetcher } from "swr";
 
-import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeGetAgentDetails } from "@app/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/details";
+import type { PokeGetDatasourceRetrievalResponse } from "@app/pages/api/poke/workspaces/[wId]/agent_configurations/[aId]/observability/datasource-retrieval";
 import type { LightWorkspaceType } from "@app/types";
 
 interface UsePokeAgentDetailsProps {
@@ -27,5 +29,36 @@ export function usePokeAgentDetails({
     isLoading: !error && !data && !disabled,
     isError: error,
     mutate,
+  };
+}
+
+interface UsePokeAgentDatasourceRetrievalProps {
+  workspaceId: string;
+  agentConfigurationId: string;
+  days?: number;
+  disabled?: boolean;
+}
+
+export function usePokeAgentDatasourceRetrieval({
+  workspaceId,
+  agentConfigurationId,
+  days = DEFAULT_PERIOD_DAYS,
+  disabled,
+}: UsePokeAgentDatasourceRetrievalProps) {
+  const fetcherFn: Fetcher<PokeGetDatasourceRetrievalResponse> = fetcher;
+  const params = new URLSearchParams({ days: days.toString() });
+  const key = `/api/poke/workspaces/${workspaceId}/agent_configurations/${agentConfigurationId}/observability/datasource-retrieval?${params.toString()}`;
+
+  const { data, error, isValidating } = useSWRWithDefaults(
+    disabled ? null : key,
+    fetcherFn
+  );
+
+  return {
+    datasourceRetrieval: data?.datasources ?? emptyArray(),
+    totalRetrievals: data?.total ?? 0,
+    isDatasourceRetrievalLoading: !error && !data && !disabled,
+    isDatasourceRetrievalError: error,
+    isDatasourceRetrievalValidating: isValidating,
   };
 }


### PR DESCRIPTION
## Description

Adds a datasource retrieval treemap plugin to poke for visualizing which datasources an agent retrieves from. The PR extracts the existing `TreemapContent` component from the agent builder observability feature into a reusable component, creates a new poke API endpoint to fetch datasource retrieval metrics, and implements a poke plugin that renders the treemap visualization.

## Risk

Low -  This is a new poke-only feature

## Tests

- [x] Locally

## Deploy Plan

Deploy front