### PR TITLE
Add MCP token endpoint auth method support

### DIFF
--- a/front/components/actions/mcp/MCPServerOAuthConnexion.tsx
+++ b/front/components/actions/mcp/MCPServerOAuthConnexion.tsx
@@ -39,6 +39,19 @@ export const OAUTH_USE_CASE_TO_DESCRIPTION: Record<MCPOAuthUseCase, string> = {
     "Each member logs in with their own credentials when they use the tool.",
 };
 
+const TOKEN_ENDPOINT_AUTH_METHOD_KEY = "token_endpoint_auth_method" as const;
+
+const TOKEN_ENDPOINT_AUTH_METHOD_OPTIONS = [
+  {
+    value: "client_secret_post",
+    label: "Request body (recommended)",
+  },
+  {
+    value: "client_secret_basic",
+    label: "Basic auth header",
+  },
+] as const;
+
 // Error key used for credential validation errors.
 // Parent components can check formState.errors[AUTH_CREDENTIALS_ERROR_KEY].
 export const AUTH_CREDENTIALS_ERROR_KEY = "authCredentials" as const;
@@ -219,6 +232,10 @@ export function MCPServerOAuthConnexion({
       {inputs && (
         <div className="w-full space-y-4 pt-4">
           {Object.entries(inputs).map(([key, inputData]) => {
+            if (key === TOKEN_ENDPOINT_AUTH_METHOD_KEY) {
+              return null;
+            }
+
             if (inputData.value || !isSupportedOAuthCredential(key)) {
               return null; // Skip pre-filled or unsupported credentials.
             }
@@ -244,6 +261,49 @@ export function MCPServerOAuthConnexion({
               </div>
             );
           })}
+          {inputs[TOKEN_ENDPOINT_AUTH_METHOD_KEY] && (
+            <div className="w-full space-y-2">
+              <Label className="text-sm font-semibold text-foreground dark:text-foreground-night">
+                {inputs[TOKEN_ENDPOINT_AUTH_METHOD_KEY]?.label}
+              </Label>
+              <div className="grid w-full grid-cols-2 gap-2">
+                {TOKEN_ENDPOINT_AUTH_METHOD_OPTIONS.map((option) => {
+                  const selected =
+                    (authCredentials?.[TOKEN_ENDPOINT_AUTH_METHOD_KEY] ||
+                      TOKEN_ENDPOINT_AUTH_METHOD_OPTIONS[0].value) ===
+                    option.value;
+
+                  return (
+                    <Card
+                      key={option.value}
+                      variant={selected ? "secondary" : "primary"}
+                      selected={selected}
+                      className={cn(
+                        "cursor-pointer",
+                        "px-3 py-2",
+                        "text-xs"
+                      )}
+                      onClick={() =>
+                        handleCredentialChange(
+                          TOKEN_ENDPOINT_AUTH_METHOD_KEY,
+                          option.value
+                        )
+                      }
+                    >
+                      <div className="font-medium text-foreground dark:text-foreground-night">
+                        {option.label}
+                      </div>
+                    </Card>
+                  );
+                })}
+              </div>
+              {inputs[TOKEN_ENDPOINT_AUTH_METHOD_KEY]?.helpMessage && (
+                <div className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+                  {inputs[TOKEN_ENDPOINT_AUTH_METHOD_KEY]?.helpMessage}
+                </div>
+              )}
+            </div>
+          )}
         </div>
       )}
 

--- a/front/lib/actions/mcp_oauth_provider.ts
+++ b/front/lib/actions/mcp_oauth_provider.ts
@@ -88,6 +88,20 @@ export class MCPOAuthProvider implements OAuthClientProvider {
       );
     }
 
+    const supportedTokenAuthMethods = (
+      this.metadata as OAuthMetadata & {
+        token_endpoint_auth_methods_supported?: string[];
+      }
+    ).token_endpoint_auth_methods_supported;
+
+    const tokenEndpointAuthMethod = supportedTokenAuthMethods?.includes(
+      "client_secret_basic"
+    )
+      ? "client_secret_basic"
+      : supportedTokenAuthMethods?.includes("client_secret_post")
+      ? "client_secret_post"
+      : undefined;
+
     // Raise an error to let the client know that the server requires an OAuth connection.
     // We pass the metadata to the client to allow them to handle the oauth flow.
     throw new MCPOAuthRequiredError({
@@ -97,6 +111,7 @@ export class MCPOAuthProvider implements OAuthClientProvider {
       token_endpoint: this.metadata.token_endpoint,
       authorization_endpoint: this.metadata.authorization_endpoint,
       resource: this.resource,
+      token_endpoint_auth_method: tokenEndpointAuthMethod,
     });
   }
 

--- a/front/lib/api/oauth/providers/mcp.ts
+++ b/front/lib/api/oauth/providers/mcp.ts
@@ -37,11 +37,13 @@ const MCPOAuthConnectionMetadataSchema = BaseMCPMetadataSchema.extend({
   client_secret: z.string().optional(),
   scope: z.string().optional(),
   resource: z.string().optional(),
+  token_endpoint_auth_method: z.string().optional(),
 });
 
 const MCPMetadataSchema = BaseMCPMetadataSchema.extend({
   code_challenge: z.string(),
   code_verifier: z.string(),
+  token_endpoint_auth_method: z.string().optional(),
 });
 
 export type MCPOAuthConnectionMetadataType = z.infer<
@@ -241,6 +243,8 @@ export class MCPOAuthProvider implements BaseOAuthStrategyProvider {
           authorization_endpoint: connection.metadata.authorization_endpoint,
           scope: connection.metadata.scope,
           resource: connection.metadata.resource,
+          token_endpoint_auth_method:
+            connection.metadata.token_endpoint_auth_method,
           code_verifier,
           code_challenge,
           ...restConfig,

--- a/front/types/oauth/lib.ts
+++ b/front/types/oauth/lib.ts
@@ -99,6 +99,7 @@ const SUPPORTED_OAUTH_CREDENTIALS = [
   "scope",
   "resource",
   "token_endpoint",
+  "token_endpoint_auth_method",
   "authorization_endpoint",
   "freshservice_domain",
   "freshworks_org_url",
@@ -375,6 +376,13 @@ export function getProviderRequiredOAuthCredentialInputs({
             helpMessage: "The scope(s) to request (space separated list).",
             validator: isValidScope,
           },
+          token_endpoint_auth_method: {
+            label: "Token Endpoint Authentication",
+            value: "client_secret_post",
+            helpMessage:
+              "How to send the client ID/secret when exchanging tokens.",
+            validator: isValidTokenEndpointAuthMethod,
+          },
         };
         return result;
       }
@@ -490,6 +498,13 @@ export function isValidOptionalClientSecret(s: unknown): s is string {
 
 export function isValidUrl(s: unknown): s is string {
   return typeof s === "string" && validateUrl(s).valid;
+}
+
+export function isValidTokenEndpointAuthMethod(s: unknown): s is string {
+  return (
+    typeof s === "string" &&
+    (s === "client_secret_post" || s === "client_secret_basic")
+  );
 }
 
 export function isValidSnowflakeAccount(s: unknown): s is string {


### PR DESCRIPTION
## Description
I’m an independent contributor from one of Dust’s clients (Novutech). We ran into a NetSuite MCP OAuth issue: NetSuite requires `client_id:client_secret` to be sent via `Authorization: Basic …` at the token endpoint. Dust’s MCP OAuth flow currently sends credentials only in the body, so refresh fails.

This change adds minimal, backward‑compatible support for MCP servers that require Basic auth at the token endpoint:

- **MCP OAuth metadata** now supports an optional `token_endpoint_auth_method` field (`client_secret_basic` or `client_secret_post`).
- **OAuth discovery** captures `token_endpoint_auth_methods_supported` and stores a preferred method (Basic if available, else POST).
- **Static MCP OAuth UI** adds a compact two‑option selector (request body vs Basic header) placed under OAuth scopes, defaulting to request body.
- **OAuth service** uses Basic auth in `finalize` and `refresh` when `token_endpoint_auth_method=client_secret_basic`, otherwise it keeps current body‑based behavior.

This fixes NetSuite while preserving existing MCP integrations.

## Test
Not run (no local test environment).

## Risks
- Low: behavior is unchanged unless the new metadata field is set.
- Potential risk if a server misreports `token_endpoint_auth_methods_supported`; in that case the manual override in Static OAuth can be used.

## Deploy Plan
- Normal deploy.
- If any MCP server regresses, remove `token_endpoint_auth_method` from its metadata to revert to existing behavior.