### PR TITLE
[front] Replace session cookie check with auth-context API for landing pages

### DIFF
--- a/front/components/home/LandingLayout.tsx
+++ b/front/components/home/LandingLayout.tsx
@@ -11,7 +11,7 @@ import { FooterNavigation } from "@app/components/home/menu/FooterNavigation";
 import { MainNavigation } from "@app/components/home/menu/MainNavigation";
 import { MobileNavigation } from "@app/components/home/menu/MobileNavigation";
 import ScrollingHeader from "@app/components/home/ScrollingHeader";
-import { WorkspaceSelector } from "@app/components/home/WorkspaceSelector";
+import { OpenDustButton } from "@app/components/home/OpenDustButton";
 import UTMButton from "@app/components/UTMButton";
 import {
   DUST_COOKIES_ACCEPTED,
@@ -140,10 +140,9 @@ export default function LandingLayout({
           <MainNavigation />
           <div className="flex flex-grow justify-end gap-4">
             {hasSession ? (
-              <WorkspaceSelector
+              <OpenDustButton
                 variant="highlight"
                 size="sm"
-                postLoginReturnToUrl={postLoginReturnToUrl}
                 trackingArea={TRACKING_AREAS.NAVIGATION}
                 trackingObject="go_to_app"
               />

--- a/front/components/home/LandingLayout.tsx
+++ b/front/components/home/LandingLayout.tsx
@@ -1,4 +1,4 @@
-import { ArrowRightIcon, Button, DustLogo } from "@dust-tt/sparkle";
+import { Button, DustLogo } from "@dust-tt/sparkle";
 import { cva } from "class-variance-authority";
 import Head from "next/head";
 import Link from "next/link";
@@ -11,6 +11,7 @@ import { FooterNavigation } from "@app/components/home/menu/FooterNavigation";
 import { MainNavigation } from "@app/components/home/menu/MainNavigation";
 import { MobileNavigation } from "@app/components/home/menu/MobileNavigation";
 import ScrollingHeader from "@app/components/home/ScrollingHeader";
+import { WorkspaceSelector } from "@app/components/home/WorkspaceSelector";
 import UTMButton from "@app/components/UTMButton";
 import {
   DUST_COOKIES_ACCEPTED,
@@ -139,21 +140,12 @@ export default function LandingLayout({
           <MainNavigation />
           <div className="flex flex-grow justify-end gap-4">
             {hasSession ? (
-              <Button
+              <WorkspaceSelector
                 variant="highlight"
                 size="sm"
-                label="Open Dust"
-                icon={ArrowRightIcon}
-                onClick={withTracking(
-                  TRACKING_AREAS.NAVIGATION,
-                  "go_to_app",
-                  () => {
-                    // eslint-disable-next-line react-hooks/immutability
-                    window.location.href = appendUTMParams(
-                      `/api/workos/login?returnTo=${encodeURIComponent(postLoginReturnToUrl)}`
-                    );
-                  }
-                )}
+                postLoginReturnToUrl={postLoginReturnToUrl}
+                trackingArea={TRACKING_AREAS.NAVIGATION}
+                trackingObject="go_to_app"
               />
             ) : (
               <>

--- a/front/components/home/LandingLayout.tsx
+++ b/front/components/home/LandingLayout.tsx
@@ -10,8 +10,8 @@ import { A } from "@app/components/home/ContentComponents";
 import { FooterNavigation } from "@app/components/home/menu/FooterNavigation";
 import { MainNavigation } from "@app/components/home/menu/MainNavigation";
 import { MobileNavigation } from "@app/components/home/menu/MobileNavigation";
-import ScrollingHeader from "@app/components/home/ScrollingHeader";
 import { OpenDustButton } from "@app/components/home/OpenDustButton";
+import ScrollingHeader from "@app/components/home/ScrollingHeader";
 import UTMButton from "@app/components/UTMButton";
 import {
   DUST_COOKIES_ACCEPTED,

--- a/front/components/home/OpenDustButton.tsx
+++ b/front/components/home/OpenDustButton.tsx
@@ -1,4 +1,4 @@
-import { ArrowRightIcon, Button, Spinner } from "@dust-tt/sparkle";
+import { ArrowRightIcon, Button } from "@dust-tt/sparkle";
 import { useEffect, useState } from "react";
 import { useCookies } from "react-cookie";
 
@@ -12,6 +12,7 @@ interface OpenDustButtonProps {
   size?: "sm" | "md";
   trackingArea?: string;
   trackingObject?: string;
+  showWelcome?: boolean;
 }
 
 export function OpenDustButton({
@@ -19,6 +20,7 @@ export function OpenDustButton({
   size = "sm",
   trackingArea = TRACKING_AREAS.NAVIGATION,
   trackingObject = "open_dust",
+  showWelcome = false,
 }: OpenDustButtonProps) {
   const [cookies] = useCookies([DUST_HAS_SESSION], { doNotParse: true });
   const [hasSession, setHasSession] = useState(false);
@@ -27,7 +29,7 @@ export function OpenDustButton({
     setHasSession(hasSessionIndicator(cookies[DUST_HAS_SESSION]));
   }, [cookies]);
 
-  const { isLoading, isAuthenticated } = useLandingAuthContext({
+  const { user, isLoading, isAuthenticated } = useLandingAuthContext({
     hasSessionCookie: hasSession,
   });
 
@@ -51,7 +53,7 @@ export function OpenDustButton({
     return null;
   }
 
-  return (
+  const button = (
     <Button
       variant={variant}
       size={size}
@@ -63,64 +65,16 @@ export function OpenDustButton({
       })}
     />
   );
-}
 
-interface HeroOpenDustButtonProps {
-  trackingArea?: string;
-  trackingObject?: string;
-}
-
-export function HeroOpenDustButton({
-  trackingArea = TRACKING_AREAS.HOME,
-  trackingObject = "hero_open_dust",
-}: HeroOpenDustButtonProps) {
-  const [cookies] = useCookies([DUST_HAS_SESSION], { doNotParse: true });
-  const [hasSession, setHasSession] = useState(false);
-
-  useEffect(() => {
-    setHasSession(hasSessionIndicator(cookies[DUST_HAS_SESSION]));
-  }, [cookies]);
-
-  const { user, isLoading, isAuthenticated } = useLandingAuthContext({
-    hasSessionCookie: hasSession,
-  });
-
-  if (!hasSession) {
-    return null;
+  if (!showWelcome) {
+    return button;
   }
 
-  if (isLoading) {
-    return (
-      <div className="flex flex-col items-center gap-3">
-        <button
-          disabled
-          className="flex items-center gap-2 rounded-2xl bg-blue-500 px-8 py-4 text-lg font-semibold text-white opacity-70 shadow-sm"
-        >
-          <Spinner size="xs" />
-          Open Dust
-        </button>
-      </div>
-    );
-  }
-
-  if (!isAuthenticated || !user) {
-    return null;
-  }
-
-  const firstName = user.firstName || "there";
+  const firstName = user?.firstName ?? "there";
 
   return (
     <div className="flex flex-col items-center gap-3">
-      <button
-        onClick={withTracking(trackingArea, trackingObject, () => {
-          // eslint-disable-next-line react-hooks/immutability
-          window.location.href = appendUTMParams("/api/login");
-        })}
-        className="flex items-center gap-2 rounded-2xl bg-blue-500 px-8 py-4 text-lg font-semibold text-white shadow-sm transition-colors hover:bg-blue-600"
-      >
-        <ArrowRightIcon className="h-5 w-5" />
-        Open Dust
-      </button>
+      {button}
       <p className="text-sm text-muted-foreground">
         Welcome back, {firstName}! Continue where you left off.
       </p>

--- a/front/components/home/OpenDustButton.tsx
+++ b/front/components/home/OpenDustButton.tsx
@@ -27,8 +27,9 @@ export function OpenDustButton({
     setHasSession(hasSessionIndicator(cookies[DUST_HAS_SESSION]));
   }, [cookies]);
 
-  const { defaultWorkspaceUrl, isLoading, isAuthenticated } =
-    useLandingAuthContext({ hasSessionCookie: hasSession });
+  const { isLoading, isAuthenticated } = useLandingAuthContext({
+    hasSessionCookie: hasSession,
+  });
 
   if (!hasSession) {
     return null;
@@ -46,7 +47,7 @@ export function OpenDustButton({
     );
   }
 
-  if (!isAuthenticated || !defaultWorkspaceUrl) {
+  if (!isAuthenticated) {
     return null;
   }
 
@@ -58,7 +59,7 @@ export function OpenDustButton({
       icon={ArrowRightIcon}
       onClick={withTracking(trackingArea, trackingObject, () => {
         // eslint-disable-next-line react-hooks/immutability
-        window.location.href = appendUTMParams(defaultWorkspaceUrl);
+        window.location.href = appendUTMParams("/api/login");
       })}
     />
   );
@@ -80,8 +81,9 @@ export function HeroOpenDustButton({
     setHasSession(hasSessionIndicator(cookies[DUST_HAS_SESSION]));
   }, [cookies]);
 
-  const { user, defaultWorkspaceUrl, isLoading, isAuthenticated } =
-    useLandingAuthContext({ hasSessionCookie: hasSession });
+  const { user, isLoading, isAuthenticated } = useLandingAuthContext({
+    hasSessionCookie: hasSession,
+  });
 
   if (!hasSession) {
     return null;
@@ -101,7 +103,7 @@ export function HeroOpenDustButton({
     );
   }
 
-  if (!isAuthenticated || !defaultWorkspaceUrl || !user) {
+  if (!isAuthenticated || !user) {
     return null;
   }
 
@@ -112,7 +114,7 @@ export function HeroOpenDustButton({
       <button
         onClick={withTracking(trackingArea, trackingObject, () => {
           // eslint-disable-next-line react-hooks/immutability
-          window.location.href = appendUTMParams(defaultWorkspaceUrl);
+          window.location.href = appendUTMParams("/api/login");
         })}
         className="flex items-center gap-2 rounded-2xl bg-blue-500 px-8 py-4 text-lg font-semibold text-white shadow-sm transition-colors hover:bg-blue-600"
       >

--- a/front/components/home/WorkspaceSelector.tsx
+++ b/front/components/home/WorkspaceSelector.tsx
@@ -1,0 +1,165 @@
+import { ArrowRightIcon, Button, Spinner } from "@dust-tt/sparkle";
+import { useEffect, useState } from "react";
+import { useCookies } from "react-cookie";
+
+import { DUST_HAS_SESSION, hasSessionIndicator } from "@app/lib/cookies";
+import { useLandingPageAuthContext } from "@app/lib/swr/website";
+import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
+import { appendUTMParams } from "@app/lib/utils/utm";
+
+interface WorkspaceSelectorProps {
+  variant?: "highlight" | "outline";
+  size?: "sm" | "md";
+  postLoginReturnToUrl?: string;
+  trackingArea?: string;
+  trackingObject?: string;
+  showWelcomeMessage?: boolean;
+  welcomeMessageClassName?: string;
+}
+
+export function WorkspaceSelector({
+  variant = "highlight",
+  size = "sm",
+  postLoginReturnToUrl = "/api/login",
+  trackingArea = TRACKING_AREAS.NAVIGATION,
+  trackingObject = "open_dust",
+  showWelcomeMessage = false,
+  welcomeMessageClassName = "text-xs text-muted-foreground",
+}: WorkspaceSelectorProps) {
+  // Check session cookie only on client to avoid hydration mismatch.
+  const [cookies] = useCookies([DUST_HAS_SESSION], { doNotParse: true });
+  const [hasSession, setHasSession] = useState(false);
+  useEffect(() => {
+    setHasSession(hasSessionIndicator(cookies[DUST_HAS_SESSION]));
+  }, [cookies]);
+
+  const { user, workspaces, isLoading, isAuthenticated } =
+    useLandingPageAuthContext({
+      hasSessionCookie: hasSession,
+    });
+
+  // If no session cookie, don't show anything (the parent component handles the sign-in flow)
+  if (!hasSession) {
+    return null;
+  }
+
+  // Loading state while fetching auth context
+  if (isLoading) {
+    return (
+      <Button
+        variant={variant}
+        size={size}
+        label="Open Dust"
+        disabled
+        isLoading
+      />
+    );
+  }
+
+  // Not authenticated - this shouldn't happen if hasSession is true, but handle gracefully
+  if (!isAuthenticated || !user) {
+    return null;
+  }
+
+  const firstName = user.firstName || "there";
+
+  // Redirect to first workspace or fallback to login
+  const redirectUrl = workspaces[0]?.url ?? postLoginReturnToUrl;
+
+  const button = (
+    <Button
+      variant={variant}
+      size={size}
+      label="Open Dust"
+      icon={ArrowRightIcon}
+      onClick={withTracking(trackingArea, trackingObject, () => {
+        // eslint-disable-next-line react-hooks/immutability
+        window.location.href = appendUTMParams(redirectUrl);
+      })}
+    />
+  );
+
+  if (!showWelcomeMessage) {
+    return button;
+  }
+
+  return (
+    <div className="flex flex-col items-center gap-1">
+      {button}
+      <span className={welcomeMessageClassName}>
+        Welcome back, {firstName}!
+      </span>
+    </div>
+  );
+}
+
+/**
+ * Hero version of the workspace selector with custom styling for landing pages.
+ */
+interface HeroWorkspaceSelectorProps {
+  trackingArea?: string;
+  trackingObject?: string;
+}
+
+export function HeroWorkspaceSelector({
+  trackingArea = TRACKING_AREAS.HOME,
+  trackingObject = "hero_open_dust",
+}: HeroWorkspaceSelectorProps) {
+  // Check session cookie only on client to avoid hydration mismatch.
+  const [cookies] = useCookies([DUST_HAS_SESSION], { doNotParse: true });
+  const [hasSession, setHasSession] = useState(false);
+  useEffect(() => {
+    setHasSession(hasSessionIndicator(cookies[DUST_HAS_SESSION]));
+  }, [cookies]);
+
+  const { user, workspaces, isLoading, isAuthenticated } =
+    useLandingPageAuthContext({
+      hasSessionCookie: hasSession,
+    });
+
+  // If no session cookie, don't show anything
+  if (!hasSession) {
+    return null;
+  }
+
+  // Loading state
+  if (isLoading) {
+    return (
+      <div className="flex flex-col items-center gap-3">
+        <button
+          disabled
+          className="flex items-center gap-2 rounded-2xl bg-blue-500 px-8 py-4 text-lg font-semibold text-white opacity-70 shadow-sm"
+        >
+          <Spinner size="xs" />
+          Open Dust
+        </button>
+      </div>
+    );
+  }
+
+  // Not authenticated
+  if (!isAuthenticated || !user) {
+    return null;
+  }
+
+  const firstName = user.firstName || "there";
+  const redirectUrl = workspaces[0]?.url ?? "/api/login";
+
+  return (
+    <div className="flex flex-col items-center gap-3">
+      <button
+        onClick={withTracking(trackingArea, trackingObject, () => {
+          // eslint-disable-next-line react-hooks/immutability
+          window.location.href = appendUTMParams(redirectUrl);
+        })}
+        className="flex items-center gap-2 rounded-2xl bg-blue-500 px-8 py-4 text-lg font-semibold text-white shadow-sm transition-colors hover:bg-blue-600"
+      >
+        <ArrowRightIcon className="h-5 w-5" />
+        Open Dust
+      </button>
+      <p className="text-sm text-muted-foreground">
+        Welcome back, {firstName}! Continue where you left off.
+      </p>
+    </div>
+  );
+}

--- a/front/components/home/content/Competitive/CompetitiveHeroSection.tsx
+++ b/front/components/home/content/Competitive/CompetitiveHeroSection.tsx
@@ -1,38 +1,12 @@
-import {
-  ArrowRightIcon,
-  CheckIcon,
-  Icon,
-  LockIcon,
-  Spinner,
-  TimeIcon,
-} from "@dust-tt/sparkle";
+import { CheckIcon, Icon, LockIcon, TimeIcon } from "@dust-tt/sparkle";
 import type { ReactNode } from "react";
+import { useEffect, useState } from "react";
+import { useCookies } from "react-cookie";
 
+import { LandingEmailSignup } from "@app/components/home/content/Landing/LandingEmailSignup";
 import { OpenDustButton } from "@app/components/home/OpenDustButton";
 import { DUST_HAS_SESSION, hasSessionIndicator } from "@app/lib/cookies";
-import { clientFetch } from "@app/lib/egress/client";
-import {
-  trackEvent,
-  TRACKING_ACTIONS,
-  TRACKING_AREAS,
-} from "@app/lib/tracking";
-import { appendUTMParams } from "@app/lib/utils/utm";
-import logger from "@app/logger/logger";
-import { normalizeError } from "@app/types";
-
-function getTrustBadgeIcon(index: number): {
-  icon: typeof CheckIcon;
-  colorClass: string;
-} {
-  switch (index) {
-    case 0:
-      return { icon: CheckIcon, colorClass: "text-emerald-500" };
-    case 1:
-      return { icon: TimeIcon, colorClass: "text-blue-500" };
-    default:
-      return { icon: LockIcon, colorClass: "text-amber-500" };
-  }
-}
+import { TRACKING_AREAS } from "@app/lib/tracking";
 
 interface CompetitiveHeroSectionProps {
   chip: string;
@@ -55,6 +29,13 @@ export function CompetitiveHeroSection({
   trustBadges,
   trackingObject = "glean_hero",
 }: CompetitiveHeroSectionProps) {
+  const [cookies] = useCookies([DUST_HAS_SESSION], { doNotParse: true });
+  const [hasSession, setHasSession] = useState(false);
+
+  useEffect(() => {
+    setHasSession(hasSessionIndicator(cookies[DUST_HAS_SESSION]));
+  }, [cookies]);
+
   return (
     <section className="w-full">
       <div
@@ -116,47 +97,34 @@ export function CompetitiveHeroSection({
                 size="md"
                 trackingArea={TRACKING_AREAS.COMPETITIVE}
                 trackingObject={`${trackingObject}_open_dust`}
+                showWelcome
               />
             ) : (
-              <form onSubmit={handleSubmit}>
-                <div className="flex w-full items-center gap-2 rounded-xl border border-gray-200 bg-white p-1.5 shadow-md">
-                  <input
-                    type="email"
-                    value={email}
-                    onChange={(e) => setEmail(e.target.value)}
-                    placeholder="Enter your work email"
-                    className="flex-1 border-none bg-transparent px-3 py-2 text-base text-gray-700 placeholder-gray-400 outline-none focus:ring-0"
-                    disabled={isLoading}
-                  />
-                  <button
-                    type="submit"
-                    disabled={isLoading}
-                    className="flex items-center gap-2 rounded-lg bg-blue-500 px-5 py-2.5 font-semibold text-white shadow-sm transition-all hover:bg-blue-600 hover:shadow-md disabled:opacity-70"
-                  >
-                    {isLoading && <Spinner size="xs" />}
-                    {ctaButtonText}
-                    <ArrowRightIcon className="h-4 w-4" />
-                  </button>
-                </div>
-                {error && <p className="mt-2 text-sm text-red-500">{error}</p>}
-              </form>
+              <LandingEmailSignup
+                ctaButtonText={ctaButtonText}
+                trackingLocation={trackingObject}
+                trackingArea={TRACKING_AREAS.COMPETITIVE}
+              />
             )}
           </div>
 
           {/* Trust badges */}
           <div className="flex flex-wrap items-center justify-center gap-6 text-sm text-muted-foreground">
-            {trustBadges.map((badge, index) => {
-              const iconConfig = getTrustBadgeIcon(index);
-              return (
-                <div key={index} className="flex items-center gap-2">
+            {trustBadges.map((badge, index) => (
+              <div key={index} className="flex items-center gap-2">
+                {index === 0 ? (
                   <Icon
-                    visual={iconConfig.icon}
-                    className={`h-4 w-4 ${iconConfig.colorClass}`}
+                    visual={CheckIcon}
+                    className="h-4 w-4 text-emerald-500"
                   />
-                  <span>{badge}</span>
-                </div>
-              );
-            })}
+                ) : index === 1 ? (
+                  <Icon visual={TimeIcon} className="h-4 w-4 text-blue-500" />
+                ) : (
+                  <Icon visual={LockIcon} className="h-4 w-4 text-amber-500" />
+                )}
+                <span>{badge}</span>
+              </div>
+            ))}
           </div>
         </div>
       </div>

--- a/front/components/home/content/Competitive/CompetitiveHeroSection.tsx
+++ b/front/components/home/content/Competitive/CompetitiveHeroSection.tsx
@@ -8,7 +8,7 @@ import {
 } from "@dust-tt/sparkle";
 import type { ReactNode } from "react";
 
-import { WorkspaceSelector } from "@app/components/home/WorkspaceSelector";
+import { OpenDustButton } from "@app/components/home/OpenDustButton";
 import { DUST_HAS_SESSION, hasSessionIndicator } from "@app/lib/cookies";
 import { clientFetch } from "@app/lib/egress/client";
 import {
@@ -111,12 +111,11 @@ export function CompetitiveHeroSection({
           {/* Email CTA */}
           <div className="mt-2 w-full max-w-lg">
             {hasSession ? (
-              <WorkspaceSelector
+              <OpenDustButton
                 variant="highlight"
                 size="md"
                 trackingArea={TRACKING_AREAS.COMPETITIVE}
                 trackingObject={`${trackingObject}_open_dust`}
-                showWelcomeMessage
               />
             ) : (
               <form onSubmit={handleSubmit}>

--- a/front/components/home/content/Competitive/EmailCTASection.tsx
+++ b/front/components/home/content/Competitive/EmailCTASection.tsx
@@ -1,7 +1,18 @@
-import { CheckIcon, Icon } from "@dust-tt/sparkle";
+import { ArrowRightIcon, CheckIcon, Icon, Spinner } from "@dust-tt/sparkle";
+import { useEffect, useState } from "react";
+import { useCookies } from "react-cookie";
 
-import { LandingEmailSignup } from "@app/components/home/content/Landing/LandingEmailSignup";
-import { TRACKING_AREAS } from "@app/lib/tracking";
+import { WorkspaceSelector } from "@app/components/home/WorkspaceSelector";
+import { DUST_HAS_SESSION, hasSessionIndicator } from "@app/lib/cookies";
+import { clientFetch } from "@app/lib/egress/client";
+import {
+  trackEvent,
+  TRACKING_ACTIONS,
+  TRACKING_AREAS,
+} from "@app/lib/tracking";
+import { appendUTMParams } from "@app/lib/utils/utm";
+import logger from "@app/logger/logger";
+import { normalizeError } from "@app/types";
 
 interface EmailCTASectionProps {
   title: string;
@@ -32,13 +43,41 @@ export function EmailCTASection({
           </h2>
           <p className="mb-8 text-lg text-blue-100">{subtitle}</p>
 
-          <LandingEmailSignup
-            variant="dark"
-            ctaButtonText={buttonText}
-            trackingLocation={trackingObject}
-            trackingArea={TRACKING_AREAS.COMPETITIVE}
-            className="mx-auto max-w-lg"
-          />
+          <div className="mx-auto max-w-lg">
+            {hasSession ? (
+              <WorkspaceSelector
+                variant="highlight"
+                size="md"
+                trackingArea={TRACKING_AREAS.COMPETITIVE}
+                trackingObject={`${trackingObject}_open_dust`}
+                showWelcomeMessage
+                welcomeMessageClassName="text-sm text-blue-200"
+              />
+            ) : (
+              <form onSubmit={handleSubmit}>
+                <div className="flex w-full flex-col items-center gap-3 sm:flex-row">
+                  <input
+                    type="email"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    placeholder="Enter your work email"
+                    className="w-full flex-1 rounded-xl border-2 border-white/20 bg-white px-4 py-3.5 text-base text-gray-700 placeholder-gray-400 shadow-lg outline-none focus:border-white/40 focus:ring-0"
+                    disabled={isLoading}
+                  />
+                  <button
+                    type="submit"
+                    disabled={isLoading}
+                    className="flex w-full items-center justify-center gap-2 rounded-xl bg-emerald-500 px-6 py-3.5 font-semibold text-white shadow-lg transition-all hover:bg-emerald-600 hover:shadow-xl disabled:opacity-70 sm:w-auto"
+                  >
+                    {isLoading && <Spinner size="xs" />}
+                    {buttonText}
+                    <Icon visual={ArrowRightIcon} size="sm" />
+                  </button>
+                </div>
+                {error && <p className="mt-2 text-sm text-red-200">{error}</p>}
+              </form>
+            )}
+          </div>
 
           {/* Trust badges */}
           <div className="mt-6 flex flex-wrap items-center justify-center gap-4 text-sm text-blue-100">

--- a/front/components/home/content/Competitive/EmailCTASection.tsx
+++ b/front/components/home/content/Competitive/EmailCTASection.tsx
@@ -1,18 +1,11 @@
-import { ArrowRightIcon, CheckIcon, Icon, Spinner } from "@dust-tt/sparkle";
+import { CheckIcon, Icon } from "@dust-tt/sparkle";
 import { useEffect, useState } from "react";
 import { useCookies } from "react-cookie";
 
+import { LandingEmailSignup } from "@app/components/home/content/Landing/LandingEmailSignup";
 import { OpenDustButton } from "@app/components/home/OpenDustButton";
 import { DUST_HAS_SESSION, hasSessionIndicator } from "@app/lib/cookies";
-import { clientFetch } from "@app/lib/egress/client";
-import {
-  trackEvent,
-  TRACKING_ACTIONS,
-  TRACKING_AREAS,
-} from "@app/lib/tracking";
-import { appendUTMParams } from "@app/lib/utils/utm";
-import logger from "@app/logger/logger";
-import { normalizeError } from "@app/types";
+import { TRACKING_AREAS } from "@app/lib/tracking";
 
 interface EmailCTASectionProps {
   title: string;
@@ -29,6 +22,13 @@ export function EmailCTASection({
   trustBadges,
   trackingObject = "glean_cta_bottom",
 }: EmailCTASectionProps) {
+  const [cookies] = useCookies([DUST_HAS_SESSION], { doNotParse: true });
+  const [hasSession, setHasSession] = useState(false);
+
+  useEffect(() => {
+    setHasSession(hasSessionIndicator(cookies[DUST_HAS_SESSION]));
+  }, [cookies]);
+
   return (
     <section className="w-full">
       <div
@@ -50,30 +50,15 @@ export function EmailCTASection({
                 size="md"
                 trackingArea={TRACKING_AREAS.COMPETITIVE}
                 trackingObject={`${trackingObject}_open_dust`}
+                showWelcome
               />
             ) : (
-              <form onSubmit={handleSubmit}>
-                <div className="flex w-full flex-col items-center gap-3 sm:flex-row">
-                  <input
-                    type="email"
-                    value={email}
-                    onChange={(e) => setEmail(e.target.value)}
-                    placeholder="Enter your work email"
-                    className="w-full flex-1 rounded-xl border-2 border-white/20 bg-white px-4 py-3.5 text-base text-gray-700 placeholder-gray-400 shadow-lg outline-none focus:border-white/40 focus:ring-0"
-                    disabled={isLoading}
-                  />
-                  <button
-                    type="submit"
-                    disabled={isLoading}
-                    className="flex w-full items-center justify-center gap-2 rounded-xl bg-emerald-500 px-6 py-3.5 font-semibold text-white shadow-lg transition-all hover:bg-emerald-600 hover:shadow-xl disabled:opacity-70 sm:w-auto"
-                  >
-                    {isLoading && <Spinner size="xs" />}
-                    {buttonText}
-                    <Icon visual={ArrowRightIcon} size="sm" />
-                  </button>
-                </div>
-                {error && <p className="mt-2 text-sm text-red-200">{error}</p>}
-              </form>
+              <LandingEmailSignup
+                variant="dark"
+                ctaButtonText={buttonText}
+                trackingLocation={trackingObject}
+                trackingArea={TRACKING_AREAS.COMPETITIVE}
+              />
             )}
           </div>
 

--- a/front/components/home/content/Competitive/EmailCTASection.tsx
+++ b/front/components/home/content/Competitive/EmailCTASection.tsx
@@ -2,7 +2,7 @@ import { ArrowRightIcon, CheckIcon, Icon, Spinner } from "@dust-tt/sparkle";
 import { useEffect, useState } from "react";
 import { useCookies } from "react-cookie";
 
-import { WorkspaceSelector } from "@app/components/home/WorkspaceSelector";
+import { OpenDustButton } from "@app/components/home/OpenDustButton";
 import { DUST_HAS_SESSION, hasSessionIndicator } from "@app/lib/cookies";
 import { clientFetch } from "@app/lib/egress/client";
 import {
@@ -45,13 +45,11 @@ export function EmailCTASection({
 
           <div className="mx-auto max-w-lg">
             {hasSession ? (
-              <WorkspaceSelector
+              <OpenDustButton
                 variant="highlight"
                 size="md"
                 trackingArea={TRACKING_AREAS.COMPETITIVE}
                 trackingObject={`${trackingObject}_open_dust`}
-                showWelcomeMessage
-                welcomeMessageClassName="text-sm text-blue-200"
               />
             ) : (
               <form onSubmit={handleSubmit}>

--- a/front/components/home/content/Product/IntroSection.tsx
+++ b/front/components/home/content/Product/IntroSection.tsx
@@ -11,7 +11,7 @@ import {
 } from "@app/components/home/ContentComponents";
 import { FunctionsSection } from "@app/components/home/FunctionsSection";
 import TrustedBy from "@app/components/home/TrustedBy";
-import { HeroWorkspaceSelector } from "@app/components/home/WorkspaceSelector";
+import { HeroOpenDustButton } from "@app/components/home/OpenDustButton";
 import { BorderBeam } from "@app/components/magicui/border-beam";
 import UTMButton from "@app/components/UTMButton";
 import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
@@ -34,7 +34,7 @@ const HeroContent = () => {
       </P>
       <div className="mt-12 w-full max-w-xl">
         {hasSession ? (
-          <HeroWorkspaceSelector
+          <HeroOpenDustButton
             trackingArea={TRACKING_AREAS.HOME}
             trackingObject="hero_open_dust"
           />

--- a/front/components/home/content/Product/IntroSection.tsx
+++ b/front/components/home/content/Product/IntroSection.tsx
@@ -10,8 +10,8 @@ import {
   TeamFeatureSection,
 } from "@app/components/home/ContentComponents";
 import { FunctionsSection } from "@app/components/home/FunctionsSection";
-import TrustedBy from "@app/components/home/TrustedBy";
 import { HeroOpenDustButton } from "@app/components/home/OpenDustButton";
+import TrustedBy from "@app/components/home/TrustedBy";
 import { BorderBeam } from "@app/components/magicui/border-beam";
 import UTMButton from "@app/components/UTMButton";
 import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";

--- a/front/components/home/content/Product/IntroSection.tsx
+++ b/front/components/home/content/Product/IntroSection.tsx
@@ -1,5 +1,7 @@
-import { PlayIcon, Spinner } from "@dust-tt/sparkle";
+import { PlayIcon } from "@dust-tt/sparkle";
 import Image from "next/image";
+import { useEffect, useState } from "react";
+import { useCookies } from "react-cookie";
 
 import { LandingEmailSignup } from "@app/components/home/content/Landing/LandingEmailSignup";
 import { ScrollProgressSection } from "@app/components/home/content/Product/ScrollProgressSection";
@@ -10,13 +12,21 @@ import {
   TeamFeatureSection,
 } from "@app/components/home/ContentComponents";
 import { FunctionsSection } from "@app/components/home/FunctionsSection";
-import { HeroOpenDustButton } from "@app/components/home/OpenDustButton";
+import { OpenDustButton } from "@app/components/home/OpenDustButton";
 import TrustedBy from "@app/components/home/TrustedBy";
 import { BorderBeam } from "@app/components/magicui/border-beam";
 import UTMButton from "@app/components/UTMButton";
+import { DUST_HAS_SESSION, hasSessionIndicator } from "@app/lib/cookies";
 import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 
 const HeroContent = () => {
+  const [cookies] = useCookies([DUST_HAS_SESSION], { doNotParse: true });
+  const [hasSession, setHasSession] = useState(false);
+
+  useEffect(() => {
+    setHasSession(hasSessionIndicator(cookies[DUST_HAS_SESSION]));
+  }, [cookies]);
+
   return (
     <div className="mx-auto flex max-w-4xl flex-col items-center gap-6 px-4 text-center sm:gap-2 sm:px-6">
       <H1 className="text-center text-5xl font-medium text-foreground md:text-6xl lg:text-7xl">
@@ -34,35 +44,23 @@ const HeroContent = () => {
       </P>
       <div className="mt-12 w-full max-w-xl">
         {hasSession ? (
-          <HeroOpenDustButton
+          <OpenDustButton
+            size="md"
             trackingArea={TRACKING_AREAS.HOME}
             trackingObject="hero_open_dust"
+            showWelcome
           />
         ) : (
-          <form onSubmit={handleSubmit}>
-            <div className="flex w-full items-center gap-2 rounded-2xl border border-gray-100 bg-white px-1.5 py-1.5 shadow-sm">
-              <input
-                type="email"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                placeholder="What's your work email?"
-                className="flex-1 border-none bg-transparent pl-2 text-base text-gray-700 placeholder-gray-400 outline-none focus:ring-0"
-                disabled={isLoading}
-              />
-              <button
-                type="submit"
-                disabled={isLoading}
-                className="flex items-center gap-2 rounded-xl bg-blue-500 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-blue-600 disabled:opacity-70"
-              >
-                {isLoading && <Spinner size="xs" />}
-                Get started
-              </button>
-            </div>
-            {error && <p className="mt-2 text-sm text-red-500">{error}</p>}
+          <LandingEmailSignup
+            ctaButtonText="Get started"
+            trackingLocation="hero"
+            trackingArea={TRACKING_AREAS.HOME}
+            placeholder="What's your work email?"
+          >
             <p className="mt-3 text-sm text-muted-foreground">
               14-day free trial. Cancel anytime.
             </p>
-          </form>
+          </LandingEmailSignup>
         )}
       </div>
     </div>

--- a/front/components/home/content/Product/IntroSection.tsx
+++ b/front/components/home/content/Product/IntroSection.tsx
@@ -1,4 +1,4 @@
-import { PlayIcon } from "@dust-tt/sparkle";
+import { PlayIcon, Spinner } from "@dust-tt/sparkle";
 import Image from "next/image";
 
 import { LandingEmailSignup } from "@app/components/home/content/Landing/LandingEmailSignup";
@@ -11,6 +11,7 @@ import {
 } from "@app/components/home/ContentComponents";
 import { FunctionsSection } from "@app/components/home/FunctionsSection";
 import TrustedBy from "@app/components/home/TrustedBy";
+import { HeroWorkspaceSelector } from "@app/components/home/WorkspaceSelector";
 import { BorderBeam } from "@app/components/magicui/border-beam";
 import UTMButton from "@app/components/UTMButton";
 import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
@@ -32,15 +33,37 @@ const HeroContent = () => {
         knowledge and tools.
       </P>
       <div className="mt-12 w-full max-w-xl">
-        <LandingEmailSignup
-          ctaButtonText="Get started"
-          placeholder="What's your work email?"
-          trackingLocation="hero"
-        >
-          <p className="mt-3 text-sm text-muted-foreground">
-            14-day free trial. No credit card required. Cancel anytime.
-          </p>
-        </LandingEmailSignup>
+        {hasSession ? (
+          <HeroWorkspaceSelector
+            trackingArea={TRACKING_AREAS.HOME}
+            trackingObject="hero_open_dust"
+          />
+        ) : (
+          <form onSubmit={handleSubmit}>
+            <div className="flex w-full items-center gap-2 rounded-2xl border border-gray-100 bg-white px-1.5 py-1.5 shadow-sm">
+              <input
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="What's your work email?"
+                className="flex-1 border-none bg-transparent pl-2 text-base text-gray-700 placeholder-gray-400 outline-none focus:ring-0"
+                disabled={isLoading}
+              />
+              <button
+                type="submit"
+                disabled={isLoading}
+                className="flex items-center gap-2 rounded-xl bg-blue-500 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-blue-600 disabled:opacity-70"
+              >
+                {isLoading && <Spinner size="xs" />}
+                Get started
+              </button>
+            </div>
+            {error && <p className="mt-2 text-sm text-red-500">{error}</p>}
+            <p className="mt-3 text-sm text-muted-foreground">
+              14-day free trial. Cancel anytime.
+            </p>
+          </form>
+        )}
       </div>
     </div>
   );

--- a/front/lib/swr/website.ts
+++ b/front/lib/swr/website.ts
@@ -1,0 +1,104 @@
+import type { Fetcher } from "swr";
+
+import type { RegionType } from "@app/lib/api/regions/config";
+import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { GetNoWorkspaceAuthContextResponseType } from "@app/pages/api/auth-context";
+
+export interface WorkspaceWithRegion {
+  sId: string;
+  name: string;
+  region: RegionType | null;
+  url: string;
+}
+
+/**
+ * Get the base URL for a given region.
+ * Falls back to current origin for unknown regions or development.
+ */
+function getRegionBaseUrl(region: RegionType | null): string {
+  if (typeof window === "undefined") {
+    return "";
+  }
+
+  // In development or for unknown regions, use current origin
+  const isDevelopment =
+    window.location.hostname === "localhost" ||
+    window.location.hostname === "127.0.0.1";
+
+  if (isDevelopment || !region) {
+    return window.location.origin;
+  }
+
+  // Production region URLs
+  switch (region) {
+    case "europe-west1":
+      return "https://eu.dust.tt";
+    case "us-central1":
+      return "https://dust.tt";
+    default:
+      return window.location.origin;
+  }
+}
+
+/**
+ * Hook to fetch auth context for the landing page.
+ *
+ * Unlike useAuthContext from workspaces.ts, this hook:
+ * - Does NOT redirect to login if unauthenticated
+ * - Is designed for public pages that may show different UI for logged-in users
+ * - Only fetches when hasSessionCookie is true to avoid unnecessary API calls
+ */
+export function useLandingPageAuthContext({
+  hasSessionCookie,
+}: {
+  hasSessionCookie: boolean;
+}) {
+  const authContextFetcher: Fetcher<GetNoWorkspaceAuthContextResponseType> =
+    fetcher;
+
+  const { data, error } = useSWRWithDefaults(
+    "/api/auth-context",
+    authContextFetcher,
+    {
+      disabled: !hasSessionCookie,
+      // Don't retry on auth errors - user is simply not logged in
+      shouldRetryOnError: false,
+    }
+  );
+
+  const isLoading = hasSessionCookie && !error && !data;
+  const isAuthenticated = !!data?.user;
+
+  // Build workspaces with region info from organizations
+  const workspacesWithRegion: WorkspaceWithRegion[] = [];
+  if (data?.user) {
+    const orgByExternalId = new Map<string, { region: RegionType | null }>();
+    for (const org of data.user.organizations ?? []) {
+      if (org.externalId) {
+        const region = (org.metadata?.region as RegionType) ?? null;
+        orgByExternalId.set(org.externalId, { region });
+      }
+    }
+
+    for (const workspace of data.user.workspaces) {
+      const orgInfo = orgByExternalId.get(workspace.sId);
+      const region = orgInfo?.region ?? null;
+      const baseUrl = getRegionBaseUrl(region);
+      workspacesWithRegion.push({
+        sId: workspace.sId,
+        name: workspace.name,
+        region,
+        url: `${baseUrl}/w/${workspace.sId}`,
+      });
+    }
+  }
+
+  return {
+    user: data?.user ?? null,
+    defaultWorkspaceId: data?.defaultWorkspaceId ?? null,
+    workspaces: workspacesWithRegion,
+    isAuthenticated,
+    isLoading,
+    isError: !!error,
+  };
+}

--- a/front/lib/swr/website.ts
+++ b/front/lib/swr/website.ts
@@ -4,23 +4,11 @@ import type { RegionType } from "@app/lib/api/regions/config";
 import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetNoWorkspaceAuthContextResponseType } from "@app/pages/api/auth-context";
 
-export interface WorkspaceWithRegion {
-  sId: string;
-  name: string;
-  region: RegionType | null;
-  url: string;
-}
-
-/**
- * Get the base URL for a given region.
- * Falls back to current origin for unknown regions or development.
- */
 function getRegionBaseUrl(region: RegionType | null): string {
   if (typeof window === "undefined") {
     return "";
   }
 
-  // In development or for unknown regions, use current origin
   const isDevelopment =
     window.location.hostname === "localhost" ||
     window.location.hostname === "127.0.0.1";
@@ -29,7 +17,6 @@ function getRegionBaseUrl(region: RegionType | null): string {
     return window.location.origin;
   }
 
-  // Production region URLs
   switch (region) {
     case "europe-west1":
       return "https://eu.dust.tt";
@@ -40,15 +27,7 @@ function getRegionBaseUrl(region: RegionType | null): string {
   }
 }
 
-/**
- * Hook to fetch auth context for the landing page.
- *
- * Unlike useAuthContext from workspaces.ts, this hook:
- * - Does NOT redirect to login if unauthenticated
- * - Is designed for public pages that may show different UI for logged-in users
- * - Only fetches when hasSessionCookie is true to avoid unnecessary API calls
- */
-export function useLandingPageAuthContext({
+export function useLandingAuthContext({
   hasSessionCookie,
 }: {
   hasSessionCookie: boolean;
@@ -61,44 +40,27 @@ export function useLandingPageAuthContext({
     authContextFetcher,
     {
       disabled: !hasSessionCookie,
-      // Don't retry on auth errors - user is simply not logged in
       shouldRetryOnError: false,
     }
   );
 
   const isLoading = hasSessionCookie && !error && !data;
-  const isAuthenticated = !!data?.user;
+  const user = data?.user ?? null;
 
-  // Build workspaces with region info from organizations
-  const workspacesWithRegion: WorkspaceWithRegion[] = [];
-  if (data?.user) {
-    const orgByExternalId = new Map<string, { region: RegionType | null }>();
-    for (const org of data.user.organizations ?? []) {
-      if (org.externalId) {
-        const region = (org.metadata?.region as RegionType) ?? null;
-        orgByExternalId.set(org.externalId, { region });
-      }
-    }
-
-    for (const workspace of data.user.workspaces) {
-      const orgInfo = orgByExternalId.get(workspace.sId);
-      const region = orgInfo?.region ?? null;
-      const baseUrl = getRegionBaseUrl(region);
-      workspacesWithRegion.push({
-        sId: workspace.sId,
-        name: workspace.name,
-        region,
-        url: `${baseUrl}/w/${workspace.sId}`,
-      });
-    }
+  // Get the default workspace URL with correct region
+  let defaultWorkspaceUrl: string | null = null;
+  if (user && user.workspaces.length > 0) {
+    const workspace = user.workspaces[0];
+    const org = user.organizations?.find((o) => o.externalId === workspace.sId);
+    const region = (org?.metadata?.region as RegionType) ?? null;
+    const baseUrl = getRegionBaseUrl(region);
+    defaultWorkspaceUrl = `${baseUrl}/w/${workspace.sId}`;
   }
 
   return {
-    user: data?.user ?? null,
-    defaultWorkspaceId: data?.defaultWorkspaceId ?? null,
-    workspaces: workspacesWithRegion,
-    isAuthenticated,
+    user,
+    defaultWorkspaceUrl,
     isLoading,
-    isError: !!error,
+    isAuthenticated: !!user,
   };
 }

--- a/front/lib/swr/website.ts
+++ b/front/lib/swr/website.ts
@@ -1,31 +1,7 @@
 import type { Fetcher } from "swr";
 
-import type { RegionType } from "@app/lib/api/regions/config";
 import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetNoWorkspaceAuthContextResponseType } from "@app/pages/api/auth-context";
-
-function getRegionBaseUrl(region: RegionType | null): string {
-  if (typeof window === "undefined") {
-    return "";
-  }
-
-  const isDevelopment =
-    window.location.hostname === "localhost" ||
-    window.location.hostname === "127.0.0.1";
-
-  if (isDevelopment || !region) {
-    return window.location.origin;
-  }
-
-  switch (region) {
-    case "europe-west1":
-      return "https://eu.dust.tt";
-    case "us-central1":
-      return "https://dust.tt";
-    default:
-      return window.location.origin;
-  }
-}
 
 export function useLandingAuthContext({
   hasSessionCookie,
@@ -44,23 +20,9 @@ export function useLandingAuthContext({
     }
   );
 
-  const isLoading = hasSessionCookie && !error && !data;
-  const user = data?.user ?? null;
-
-  // Get the default workspace URL with correct region
-  let defaultWorkspaceUrl: string | null = null;
-  if (user && user.workspaces.length > 0) {
-    const workspace = user.workspaces[0];
-    const org = user.organizations?.find((o) => o.externalId === workspace.sId);
-    const region = (org?.metadata?.region as RegionType) ?? null;
-    const baseUrl = getRegionBaseUrl(region);
-    defaultWorkspaceUrl = `${baseUrl}/w/${workspace.sId}`;
-  }
-
   return {
-    user,
-    defaultWorkspaceUrl,
-    isLoading,
-    isAuthenticated: !!user,
+    user: data?.user ?? null,
+    isLoading: hasSessionCookie && !error && !data,
+    isAuthenticated: !!data?.user,
   };
 }


### PR DESCRIPTION

## Description
- Add new SWR hook `useLandingPageAuthContext` that fetches /api/auth-context
- Add WorkspaceSelector component for authenticated user landing experience
- Display personalized "Welcome back, {firstName}!" message
- Redirect to correct region URL (eu.dust.tt or dust.tt) based on workspace
- Refactor nested ternary in CompetitiveHeroSection to use switch statement
