### PR TITLE
fix: correctly update lastReadAt when upserting participation

### DIFF
--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -1110,15 +1110,6 @@ export class ConversationResource extends BaseResource<ConversationModel> {
           },
           { transaction: t }
         );
-      } else {
-        await UserConversationReadsModel.destroy({
-          where: {
-            conversationId: conversation.id,
-            userId: user.id,
-            workspaceId: auth.getNonNullableWorkspace().id,
-          },
-          transaction: t,
-        });
       }
     }, transaction);
 

--- a/front/lib/resources/conversation_resource.ts
+++ b/front/lib/resources/conversation_resource.ts
@@ -1097,18 +1097,28 @@ export class ConversationResource extends BaseResource<ConversationModel> {
           },
           { transaction: t }
         );
-        if (lastReadAt) {
-          await UserConversationReadsModel.upsert(
-            {
-              conversationId: conversation.id,
-              userId: user.id,
-              workspaceId: auth.getNonNullableWorkspace().id,
-              lastReadAt,
-            },
-            { transaction: t }
-          );
-        }
         status = "added";
+      }
+
+      if (lastReadAt) {
+        await UserConversationReadsModel.upsert(
+          {
+            conversationId: conversation.id,
+            userId: user.id,
+            workspaceId: auth.getNonNullableWorkspace().id,
+            lastReadAt,
+          },
+          { transaction: t }
+        );
+      } else {
+        await UserConversationReadsModel.destroy({
+          where: {
+            conversationId: conversation.id,
+            userId: user.id,
+            workspaceId: auth.getNonNullableWorkspace().id,
+          },
+          transaction: t,
+        });
       }
     }, transaction);
 


### PR DESCRIPTION
## Description

This PR fixes the `lastReadAt` update logic when upserting conversation participation to ensure it is correctly updated for both new and existing participations.

- Previously, the `lastReadAt` field was only updated when a new participation was created, not when updating an existing one
- Moved the `UserConversationReadsModel.upsert` logic outside of the new participation creation block so it always executes
- Added an `else` clause to destroy the read record when `lastReadAt` is null

## Tests

Manually

## Risks

## Deploy Plan

Standard deployment - no special considerations required.
