### PR TITLE
[poke] - feat(plugin): workspace level data source treemap

### DIFF
--- a/front/components/poke/plugins/RunPluginDialog.tsx
+++ b/front/components/poke/plugins/RunPluginDialog.tsx
@@ -14,6 +14,7 @@ import { AlertCircle } from "lucide-react";
 import { useCallback, useState } from "react";
 
 import { DatasourceRetrievalTreemapPluginChart } from "@app/components/poke/plugins/components/DatasourceRetrievalTreemapPluginChart";
+import { WorkspaceDatasourceRetrievalTreemapPluginChart } from "@app/components/poke/plugins/components/WorkspaceDatasourceRetrievalTreemapPluginChart";
 import { PluginForm } from "@app/components/poke/plugins/PluginForm";
 import {
   PokeAlert,
@@ -27,6 +28,32 @@ import {
   useRunPokePlugin,
 } from "@app/poke/swr/plugins";
 import type { PluginResourceTarget } from "@app/types";
+import { assertNever } from "@app/types/shared/utils/assert_never";
+
+function renderPluginComponent(
+  result: Extract<PluginResponse, { display: "component" }>
+): React.ReactNode {
+  const { component } = result;
+  switch (component) {
+    case "datasourceRetrievalTreemap":
+      return (
+        <DatasourceRetrievalTreemapPluginChart
+          workspaceId={result.props.workspaceId}
+          agentConfigurationId={result.props.agentConfigurationId}
+          period={result.props.period}
+        />
+      );
+    case "workspaceDatasourceRetrievalTreemap":
+      return (
+        <WorkspaceDatasourceRetrievalTreemapPluginChart
+          workspaceId={result.props.workspaceId}
+          period={result.props.period}
+        />
+      );
+    default:
+      assertNever(component);
+  }
+}
 
 type ExecutePluginDialogProps = {
   onClose: () => void;
@@ -161,17 +188,9 @@ export function RunPluginDialog({
                   </div>
                 </div>
               )}
-              {result &&
-                result.display === "component" &&
-                result.component === "datasourceRetrievalTreemap" && (
-                  <div className="mb-4 mt-4">
-                    <DatasourceRetrievalTreemapPluginChart
-                      workspaceId={result.props.workspaceId}
-                      agentConfigurationId={result.props.agentConfigurationId}
-                      period={result.props.period}
-                    />
-                  </div>
-                )}
+              {result && result.display === "component" && (
+                <div className="mb-4 mt-4">{renderPluginComponent(result)}</div>
+              )}
               {isLoadingAsyncArgs ? (
                 <Spinner />
               ) : (

--- a/front/components/poke/plugins/components/WorkspaceDatasourceRetrievalTreemapPluginChart.tsx
+++ b/front/components/poke/plugins/components/WorkspaceDatasourceRetrievalTreemapPluginChart.tsx
@@ -1,0 +1,104 @@
+import { useCallback, useMemo } from "react";
+import { Tooltip, Treemap } from "recharts";
+
+import {
+  CHART_HEIGHT,
+  DEFAULT_PERIOD_DAYS,
+  INDEXED_COLORS,
+} from "@app/components/agent_builder/observability/constants";
+import { ChartContainer } from "@app/components/charts/ChartContainer";
+import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
+import type { DatasourceRetrievalTreemapNode } from "@app/components/charts/DatasourceRetrievalTreemapContent";
+import { DatasourceRetrievalTreemapContent } from "@app/components/charts/DatasourceRetrievalTreemapContent";
+import { usePokeWorkspaceDatasourceRetrieval } from "@app/poke/swr/workspace_info";
+
+interface WorkspaceDatasourceRetrievalTreemapPluginChartProps {
+  workspaceId: string;
+  period?: number;
+}
+
+export function WorkspaceDatasourceRetrievalTreemapPluginChart({
+  workspaceId,
+  period = DEFAULT_PERIOD_DAYS,
+}: WorkspaceDatasourceRetrievalTreemapPluginChartProps) {
+  const {
+    datasourceRetrieval,
+    totalRetrievals,
+    isDatasourceRetrievalLoading,
+    isDatasourceRetrievalError,
+  } = usePokeWorkspaceDatasourceRetrieval({
+    workspaceId,
+    days: period,
+  });
+
+  const treemapData = useMemo(() => {
+    if (!datasourceRetrieval.length) {
+      return null;
+    }
+
+    return datasourceRetrieval.map(
+      (ds, index): DatasourceRetrievalTreemapNode => ({
+        name: ds.displayName,
+        dataSourceId: ds.dataSourceId,
+        size: ds.count,
+        color: INDEXED_COLORS[index % INDEXED_COLORS.length],
+        baseColor: "sky",
+        connectorProvider: ds.connectorProvider,
+      })
+    );
+  }, [datasourceRetrieval]);
+
+  const renderTooltip = useCallback(
+    (props: { payload?: { payload?: DatasourceRetrievalTreemapNode }[] }) => {
+      const data = props.payload?.[0]?.payload;
+      if (!data) {
+        return null;
+      }
+
+      const size = data.size ?? 0;
+      const percent =
+        totalRetrievals > 0 ? Math.round((size / totalRetrievals) * 100) : 0;
+
+      return (
+        <ChartTooltipCard
+          title={data.name}
+          rows={[{ label: "Retrievals", value: size, percent }]}
+        />
+      );
+    },
+    [totalRetrievals]
+  );
+
+  return (
+    <ChartContainer
+      title="Workspace datasource retrieval"
+      description={`Number of documents retrieved across all agents (last ${period} days).`}
+      isLoading={isDatasourceRetrievalLoading}
+      errorMessage={
+        isDatasourceRetrievalError
+          ? "Failed to load workspace datasource retrieval data."
+          : undefined
+      }
+      emptyMessage={
+        !treemapData || treemapData.length === 0
+          ? "No retrieval data for this period."
+          : undefined
+      }
+      height={CHART_HEIGHT}
+    >
+      <Treemap
+        data={treemapData ?? []}
+        dataKey="size"
+        aspectRatio={4 / 3}
+        isAnimationActive={false}
+        content={<DatasourceRetrievalTreemapContent />}
+      >
+        <Tooltip
+          cursor={false}
+          content={renderTooltip}
+          wrapperStyle={{ outline: "none" }}
+        />
+      </Treemap>
+    </ChartContainer>
+  );
+}

--- a/front/lib/api/poke/plugins/workspaces/index.ts
+++ b/front/lib/api/poke/plugins/workspaces/index.ts
@@ -30,4 +30,5 @@ export * from "./toggle_feature_flag";
 export * from "./upgrade_downgrade";
 export * from "./upgrade_to_business_plan";
 export * from "./user_identity_merge";
+export * from "./workspace_datasource_retrieval_treemap";
 export * from "./workspace_retention";

--- a/front/lib/api/poke/plugins/workspaces/workspace_datasource_retrieval_treemap.ts
+++ b/front/lib/api/poke/plugins/workspaces/workspace_datasource_retrieval_treemap.ts
@@ -1,0 +1,27 @@
+import { createPlugin } from "@app/lib/api/poke/types";
+import { Err, Ok } from "@app/types";
+
+export const workspaceDatasourceRetrievalTreemapPlugin = createPlugin({
+  manifest: {
+    id: "workspace-datasource-retrieval-treemap",
+    name: "Workspace Datasource Retrieval Treemap",
+    description:
+      "View which datasources are retrieved across all agents in this workspace",
+    resourceTypes: ["workspaces"],
+    args: {},
+  },
+  execute: async (auth, workspace) => {
+    if (!workspace) {
+      return new Err(new Error("Workspace not found"));
+    }
+
+    return new Ok({
+      display: "component",
+      component: "workspaceDatasourceRetrievalTreemap",
+      props: {
+        workspaceId: workspace.sId,
+        period: 30,
+      },
+    });
+  },
+});

--- a/front/lib/api/poke/types.ts
+++ b/front/lib/api/poke/types.ts
@@ -62,12 +62,6 @@ export type InferPluginArgsAtExecution<T extends PluginArgs> = {
   [K in keyof T]: InferArgType<T[K]["type"]>;
 };
 
-interface DatasourceRetrievalTreemapProps {
-  workspaceId: string;
-  agentConfigurationId: string;
-  period?: number;
-}
-
 type PluginTextResponse = {
   display: "text";
   value: string;
@@ -89,21 +83,24 @@ type PluginTextWithLinkResponse = {
   link: string;
   linkText: string;
 };
-interface WorkspaceDatasourceRetrievalTreemapProps {
-  workspaceId: string;
-  period?: number;
-}
 
 type PluginComponentResponse =
   | {
       display: "component";
       component: "datasourceRetrievalTreemap";
-      props: DatasourceRetrievalTreemapProps;
+      props: {
+        workspaceId: string;
+        agentConfigurationId: string;
+        period?: number;
+      };
     }
   | {
       display: "component";
       component: "workspaceDatasourceRetrievalTreemap";
-      props: WorkspaceDatasourceRetrievalTreemapProps;
+      props: {
+        workspaceId: string;
+        period?: number;
+      };
     };
 
 export type PluginResponse =

--- a/front/lib/api/poke/types.ts
+++ b/front/lib/api/poke/types.ts
@@ -89,6 +89,22 @@ type PluginTextWithLinkResponse = {
   link: string;
   linkText: string;
 };
+interface WorkspaceDatasourceRetrievalTreemapProps {
+  workspaceId: string;
+  period?: number;
+}
+
+type PluginComponentResponse =
+  | {
+      display: "component";
+      component: "datasourceRetrievalTreemap";
+      props: DatasourceRetrievalTreemapProps;
+    }
+  | {
+      display: "component";
+      component: "workspaceDatasourceRetrievalTreemap";
+      props: WorkspaceDatasourceRetrievalTreemapProps;
+    };
 
 export type PluginResponse =
   | PluginTextResponse

--- a/front/lib/api/poke/types.ts
+++ b/front/lib/api/poke/types.ts
@@ -90,12 +90,6 @@ type PluginTextWithLinkResponse = {
   linkText: string;
 };
 
-type PluginComponentResponse = {
-  display: "component";
-  component: "datasourceRetrievalTreemap";
-  props: DatasourceRetrievalTreemapProps;
-};
-
 export type PluginResponse =
   | PluginTextResponse
   | PluginJSONResponse

--- a/front/pages/api/poke/workspaces/[wId]/observability/datasource-retrieval.ts
+++ b/front/pages/api/poke/workspaces/[wId]/observability/datasource-retrieval.ts
@@ -1,0 +1,102 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
+
+import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import type { WorkspaceDatasourceRetrievalData } from "@app/lib/api/assistant/observability/datasource_retrieval";
+import { fetchWorkspaceDatasourceRetrievalMetrics } from "@app/lib/api/assistant/observability/datasource_retrieval";
+import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
+import { Authenticator } from "@app/lib/auth";
+import type { SessionWithUser } from "@app/lib/iam/provider";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+import { isString } from "@app/types";
+
+const QuerySchema = z.object({
+  days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
+});
+
+export type PokeGetWorkspaceDatasourceRetrievalResponse = {
+  datasources: WorkspaceDatasourceRetrievalData[];
+  total: number;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<PokeGetWorkspaceDatasourceRetrievalResponse>
+  >,
+  session: SessionWithUser
+): Promise<void> {
+  const { wId } = req.query;
+  if (!isString(wId)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid workspace ID.",
+      },
+    });
+  }
+
+  const auth = await Authenticator.fromSuperUserSession(session, wId);
+  const owner = auth.workspace();
+
+  if (!owner || !auth.isDustSuperUser()) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "workspace_not_found",
+        message: "Workspace not found.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      const q = QuerySchema.safeParse(req.query);
+      if (!q.success) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid query parameters: ${fromError(q.error).toString()}`,
+          },
+        });
+      }
+
+      const days = q.data.days;
+
+      const datasourceRetrievalResult =
+        await fetchWorkspaceDatasourceRetrievalMetrics(auth, { days });
+
+      if (datasourceRetrievalResult.isErr()) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: `Failed to retrieve workspace datasource retrieval metrics: ${fromError(datasourceRetrievalResult.error).toString()}`,
+          },
+        });
+      }
+
+      const datasources = datasourceRetrievalResult.value;
+      const total = datasources.reduce((sum, ds) => sum + ds.count, 0);
+
+      return res.status(200).json({
+        datasources,
+        total,
+      });
+    }
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForPoke(handler);

--- a/front/poke/swr/workspace_info.ts
+++ b/front/poke/swr/workspace_info.ts
@@ -1,6 +1,8 @@
 import type { Fetcher } from "swr";
 
-import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import type { PokeGetWorkspaceDatasourceRetrievalResponse } from "@app/pages/api/poke/workspaces/[wId]/observability/datasource-retrieval";
 import type { PokeGetWorkspaceInfo } from "@app/pages/api/poke/workspaces/[wId]/workspace-info";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
 
@@ -20,5 +22,35 @@ export function usePokeWorkspaceInfo({
     isLoading: !error && !data && !disabled,
     isError: error,
     mutate,
+  };
+}
+
+interface UsePokeWorkspaceDatasourceRetrievalProps {
+  workspaceId: string;
+  days?: number;
+  disabled?: boolean;
+}
+
+export function usePokeWorkspaceDatasourceRetrieval({
+  workspaceId,
+  days = DEFAULT_PERIOD_DAYS,
+  disabled,
+}: UsePokeWorkspaceDatasourceRetrievalProps) {
+  const fetcherFn: Fetcher<PokeGetWorkspaceDatasourceRetrievalResponse> =
+    fetcher;
+  const params = new URLSearchParams({ days: days.toString() });
+  const key = `/api/poke/workspaces/${workspaceId}/observability/datasource-retrieval?${params.toString()}`;
+
+  const { data, error, isValidating } = useSWRWithDefaults(
+    disabled ? null : key,
+    fetcherFn
+  );
+
+  return {
+    datasourceRetrieval: data?.datasources ?? emptyArray(),
+    totalRetrievals: data?.total ?? 0,
+    isDatasourceRetrievalLoading: !error && !data && !disabled,
+    isDatasourceRetrievalError: error,
+    isDatasourceRetrievalValidating: isValidating,
   };
 }


### PR DESCRIPTION
## Description

Extends the poke datasource retrieval treemap plugin to support workspace-level analytics. The PR adds a new API endpoint that aggregates datasource retrieval metrics across all agents in a workspace, creates a workspace-level treemap component, and refactors the plugin rendering logic to support multiple component types.

## Risk

Low - poke only

## Tests

- [x] Locally

## Deploy Plan

Deploy front