### PR TITLE
SPA: fix ts errors in App.tsx

### DIFF
--- a/front-spa/TROUBLESHOOTING.md
+++ b/front-spa/TROUBLESHOOTING.md
@@ -1,0 +1,19 @@
+# front-spa Troubleshooting
+
+## "Failed to fetch dynamically imported module" / 504 Outdated Optimize Dep
+
+**Symptoms:**
+- Browser console shows `Failed to fetch dynamically imported module: http://localhost:.../<SomePage>.tsx`
+- Network tab shows `504 (Outdated Optimize Dep)` on a `.js` file under `node_modules/.vite/deps/`
+- React Router displays "Unexpected Application Error!"
+
+**Cause:**
+Vite's dependency optimizer cache has gone stale (after a restart, dependency change, or git operation). The browser still has cached JS chunks referencing old dependency hashes, and Vite returns 504 for those.
+
+**Fix:**
+1. Restart the SPA Vite dev server (not the Next.js `front` service):
+   - With dust-hive: `dust-hive restart <env-name> front-spa-app`
+   - Without dust-hive: kill and re-run the Vite dev server process for front-spa
+2. Hard refresh the browser: **Cmd+Shift+R**
+
+**Note:** This is a dev-only issue. Production builds use static assets with stable hashes.

--- a/front-spa/src/app/App.tsx
+++ b/front-spa/src/app/App.tsx
@@ -32,21 +32,21 @@ function PageLoader() {
 }
 
 // Helper to wrap lazy components with Suspense
-function withSuspense<T extends React.ComponentType<object>>(
-  importFn: () => Promise<{ default: T } | { [key: string]: T }>,
+function withSuspense(
+  importFn: () => Promise<Record<string, unknown>>,
   exportName?: string
 ) {
   const LazyComponent = lazy(() =>
     importFn().then((module) => ({
-      default: exportName
-        ? (module as { [key: string]: T })[exportName]
-        : (module as { default: T }).default,
+      default: (exportName
+        ? module[exportName]
+        : module.default) as React.ComponentType,
     }))
   );
-  return function SuspenseWrapper(props: React.ComponentProps<T>) {
+  return function SuspenseWrapper() {
     return (
       <Suspense fallback={<PageLoader />}>
-        <LazyComponent {...props} />
+        <LazyComponent />
       </Suspense>
     );
   };
@@ -397,7 +397,7 @@ const router = createBrowserRouter(
     { path: "*", element: <Custom404 /> },
   ],
   {
-    basename: import.meta.env.VITE_BASE_PATH ?? "",
+    basename: import.meta.env?.VITE_BASE_PATH ?? "",
   }
 );
 

--- a/front/global.d.ts
+++ b/front/global.d.ts
@@ -52,6 +52,7 @@ declare global {
   }
   interface ImportMeta {
     env?: {
+      VITE_BASE_PATH?: string;
       VITE_DUST_CLIENT_FACING_URL?: string;
       VITE_DUST_REGION_STORAGE_KEY?: string;
     };

--- a/front/scripts/seed/basics/assets/agent.json
+++ b/front/scripts/seed/basics/assets/agent.json
@@ -1,6 +1,12 @@
-{
+[{
   "name": "HaikuPoet",
   "description": "A creative agent that writes haikus based on your message topic",
   "instructions": "You are a creative haiku poet. When the user sends you a message, identify the main topic or theme and respond with a beautiful haiku (5-7-5 syllable pattern) that captures the essence of that topic. Always explain briefly what inspired your haiku.",
   "pictureUrl": "https://dust.tt/static/systemavatar/claude_avatar_full.png"
-}
+},
+ {
+    "name": "Soupinou",
+    "description": "Very cute yet not super helpful assistant. Mostly sounds like a cat.",
+    "instructions": "You are a very cute black cat.",
+    "pictureUrl": "https://dust.tt/static/systemavatar/helper_avatar_full.png"
+  } ]

--- a/front/scripts/seed/basics/seed.test.ts
+++ b/front/scripts/seed/basics/seed.test.ts
@@ -9,9 +9,9 @@ import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import type { UserResource } from "@app/lib/resources/user_resource";
 import logger from "@app/logger/logger";
 import type { Assets } from "@app/scripts/seed/basics/seed";
-import type { CreatedAgent, SeedContext } from "@app/scripts/seed/factories";
+import type { SeedContext } from "@app/scripts/seed/factories";
 import {
-  seedAgent,
+  seedAgents,
   seedConversations,
   seedSkill,
 } from "@app/scripts/seed/factories";
@@ -63,21 +63,17 @@ describe("basics seed script integration test", () => {
     // Run the seed flow (same order as seed.ts)
     const createdSkill = await seedSkill(ctx, assets.skill);
     const skillsToLink = createdSkill ? [createdSkill] : [];
-    const customAgent = await seedAgent(ctx, assets.agent, {
+    const createdAgents = await seedAgents(ctx, assets.agent, {
       skills: skillsToLink,
     });
 
-    // Build agents map for conversations
-    const agents = new Map<string, CreatedAgent>();
-    if (customAgent) {
-      agents.set(assets.agent.name, customAgent);
-    }
-    agents.set("Dust", { sId: GLOBAL_AGENTS_SID.DUST, name: "Dust" });
+    // Add Dust global agent for conversations
+    createdAgents.set("Dust", { sId: GLOBAL_AGENTS_SID.DUST, name: "Dust" });
 
     await seedConversations(ctx, assets.conversations, {
-      agents,
+      agents: createdAgents,
       placeholders: {
-        __CUSTOM_AGENT_SID__: customAgent?.sId ?? "",
+        __CUSTOM_AGENT_SID__: createdAgents.values().next().value?.sId ?? "",
       },
     });
 
@@ -89,8 +85,8 @@ describe("basics seed script integration test", () => {
     expect(foundSkill).toBeDefined();
     expect(foundSkill?.name).toBe(assets.skill.name);
 
-    // Verify agent was created
-    expect(customAgent).toBeDefined();
+    // Verify agents were created
+    expect(createdAgents.size).toBeGreaterThan(1);
 
     // Verify all conversations were created
     const allConversations = assets.conversations;


### PR DESCRIPTION
## Description

- Simplify withSuspense generic signature — the previous { [key: string]: T } index signature required all module exports to be components, which broke for modules that also export non-component values (e.g. AGENT_MANAGER_TABS, APIKeysProps)
- Add optional chaining on import.meta.env access to fix "possibly undefined" TS error
- Add VITE_BASE_PATH to the ImportMeta env type declaration

## Tests

- Verify lazy-loaded pages still render correctly in the SPA (conversation, builder/agents, spaces)
- Verify VITE_BASE_PATH routing still works when set

## Risk

Break SPA. 

## Deploy Plan

Merge. 