### PR TITLE
copilot: MCP to get conversation content

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
@@ -155,6 +155,32 @@
         }
       },
       {
+        "name": "inspect_conversation",
+        "description": "Inspect a conversation to get its shape and summary. Returns the conversation title, a timeline of messages with user messages (content and mentions) and agent messages (actions taken, handoffs, status), useful for understanding what happened in a conversation.",
+        "inputSchema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "additionalProperties": false,
+          "properties": {
+            "conversationId": {
+              "description": "The conversation to inspect",
+              "type": "string"
+            },
+            "fromMessageIndex": {
+              "description": "Start timeline from this message index (0-based)",
+              "type": "integer"
+            },
+            "toMessageIndex": {
+              "description": "End timeline at this message index (0-based, exclusive)",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "conversationId"
+          ],
+          "type": "object"
+        }
+      },
+      {
         "name": "list_suggestions",
         "description": "List existing suggestions for the agent's configuration changes.",
         "inputSchema": {
@@ -507,6 +533,7 @@
       "get_available_models": "never_ask",
       "get_available_skills": "never_ask",
       "get_available_tools": "never_ask",
+      "inspect_conversation": "never_ask",
       "list_suggestions": "never_ask",
       "suggest_model": "never_ask",
       "suggest_prompt_edits": "never_ask",

--- a/front/lib/api/actions/servers/agent_copilot_context/agent_copilot_context.test.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/agent_copilot_context.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { USED_MODEL_CONFIGS } from "@app/components/providers/types";
-import type { Authenticator } from "@app/lib/auth";
+import { Authenticator } from "@app/lib/auth";
 import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
@@ -1552,8 +1552,9 @@ describe("agent_copilot_context tools", () => {
     });
 
     it("prevents cross-workspace unauthorized conversation access", async () => {
-      const { authenticator: auth1, workspace: workspace1 } =
-        await createResourceTest({ role: "admin" });
+      const { authenticator: auth1 } = await createResourceTest({
+        role: "admin",
+      });
 
       // Create a second workspace with a different user.
       const { authenticator: auth2 } = await createResourceTest({

--- a/front/lib/api/actions/servers/agent_copilot_context/metadata.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/metadata.ts
@@ -349,6 +349,30 @@ export const AGENT_COPILOT_CONTEXT_TOOLS_METADATA = createToolsRecord({
       done: "Fetch template",
     },
   },
+  inspect_conversation: {
+    description:
+      "Inspect a conversation to get its shape and summary. Returns the conversation title, " +
+      "a timeline of messages with user messages (content and mentions) and agent messages " +
+      "(actions taken, handoffs, status), useful for understanding what happened in a conversation.",
+    schema: {
+      conversationId: z.string().describe("The conversation to inspect"),
+      fromMessageIndex: z
+        .number()
+        .int()
+        .optional()
+        .describe("Start timeline from this message index (0-based)"),
+      toMessageIndex: z
+        .number()
+        .int()
+        .optional()
+        .describe("End timeline at this message index (0-based, exclusive)"),
+    },
+    stake: "never_ask",
+    displayLabels: {
+      running: "Inspecting conversation",
+      done: "Inspect conversation",
+    },
+  },
 });
 
 export const AGENT_COPILOT_CONTEXT_SERVER = {


### PR DESCRIPTION
## Description

Get the conversation and return the revelant elements, truncating the biggest ones if needed
Return as markdown

## Tests

<img width="2276" height="1510" alt="image" src="https://github.com/user-attachments/assets/d3fc7a23-6d48-4a3d-9796-cf853c453a7a" />

manual test + unit test

## Risk

low, conversation are accessed with the user's auth

## Deploy Plan

deploy front
