### PR TITLE
fix(sandbox): bump vulnerable python dependency minimums

### DIFF
--- a/sandbox/requirements.txt
+++ b/sandbox/requirements.txt
@@ -10,22 +10,22 @@ seaborn>=0.13.0
 plotly>=5.18.0
 
 # Machine Learning
-scikit-learn>=1.4.0
+scikit-learn>=1.5.0
 
 # Document Processing
-pypdf>=4.0.0
+pypdf>=6.6.2
 pdfplumber>=0.10.0
 reportlab>=4.1.0
 openpyxl>=3.1.0
 xlrd>=2.0.0
 python-pptx>=0.6.23
 python-docx>=1.1.0
-Pillow>=10.2.0
+Pillow>=10.3.0
 
 # HTTP & APIs
-requests>=2.31.0
+requests>=2.32.4
 httpx>=0.26.0
-aiohttp>=3.9.0
+aiohttp>=3.13.3
 
 # Utilities
 python-dotenv>=1.0.0


### PR DESCRIPTION
## Description

Raise vulnerable minimum versions in `sandbox/requirements.txt` so newly built sandbox images install patched package ranges.

Updated minimums:
- `aiohttp` to `>=3.13.3` (includes fixes beyond the 3.9.x advisory window)
- `requests` to `>=2.32.4`
- `pypdf` to `>=6.6.2`
- `scikit-learn` to `>=1.5.0`
- `Pillow` to `>=10.3.0`

## Tests

- `python3 -m venv /tmp/sandbox-ship-check && /tmp/sandbox-ship-check/bin/pip install --dry-run -r sandbox/requirements.txt`
- Queried OSV for each raised minimum to verify no known advisories at those floor versions.

## Risk

Low to moderate.
- Change is limited to sandbox Python dependency floor constraints.
- Runtime behavior changes are possible where APIs evolved across major versions (notably `pypdf`), but these are minimum constraints and compatible newer versions were already allowed.
- Safe rollback: revert this commit to restore previous minimums.

## Deploy Plan

1. Merge this PR.
2. Rebuild the sandbox Docker image from this commit in Northflank.
3. Smoke test representative sandbox scripts that use HTTP clients and document parsing libraries.
4. Monitor build/runtime logs for import or API regressions.