### PR TITLE
oauth metadata for Microsoft connector

### DIFF
--- a/front/components/data_source/ConnectorPermissionsModal.tsx
+++ b/front/components/data_source/ConnectorPermissionsModal.tsx
@@ -62,6 +62,7 @@ import { clientFetch } from "@app/lib/egress/client";
 import {
   useConnectorConfig,
   useConnectorPermissions,
+  useOAuthMetadata,
 } from "@app/lib/swr/connectors";
 import { useSlackIsLegacy } from "@app/lib/swr/oauth";
 import { useSpaceDataSourceViews, useSystemSpace } from "@app/lib/swr/spaces";
@@ -273,6 +274,33 @@ function UpdateConnectionOAuthModal({
   const { connectorProvider, editedByUser } = dataSource;
 
   const isSlack = connectorProvider === "slack";
+  const isMicrosoft = connectorProvider === "microsoft";
+
+  // Fetch existing OAuth metadata when modal is open
+  const { metadata, isMetadataLoading } = useOAuthMetadata({
+    dataSource,
+    owner,
+    disabled: !isOpen || !dataSource.connectorId || !isMicrosoft,
+  });
+
+  // Populate extraConfig from metadata on first load only
+  // This preserves user's unsaved changes when closing/reopening the modal
+  useEffect(() => {
+    if (isOpen && !isMetadataLoading && isMicrosoft) {
+      if (metadata) {
+        // Convert metadata to string Record
+        const stringMetadata: Record<string, string> = {};
+        for (const [key, value] of Object.entries(metadata)) {
+          if (typeof value === "string") {
+            stringMetadata[key] = value;
+          }
+        }
+        setExtraConfig(stringMetadata);
+      } else {
+        setExtraConfig({});
+      }
+    }
+  }, [isOpen, metadata, isMetadataLoading, isMicrosoft, dataSource.sId]);
 
   const { configValue: slackCredentialId } = useConnectorConfig({
     configKey: "privateIntegrationCredentialId",
@@ -436,7 +464,8 @@ function UpdateConnectionOAuthModal({
           </div>
         )}
         {connectorUIConfiguration.oauthExtraConfigComponent &&
-          showSlackOauthExtraComponent && (
+          ((isMicrosoft && !isMetadataLoading) ||
+            showSlackOauthExtraComponent) && (
             <connectorUIConfiguration.oauthExtraConfigComponent
               extraConfig={extraConfig}
               setExtraConfig={setExtraConfig}

--- a/front/components/data_source/MicrosoftOAuthExtraConfig.tsx
+++ b/front/components/data_source/MicrosoftOAuthExtraConfig.tsx
@@ -109,6 +109,7 @@ export function MicrosoftOAuthExtraConfig({
           />
           <Input
             label="Service Account secret"
+            placeholder="Save this secret - you'll need to re-enter it each time you configure this connector"
             disabled={!useServicePrincipal}
             name="client_secret"
             type="password"

--- a/front/components/data_source/MicrosoftOAuthExtraConfig.tsx
+++ b/front/components/data_source/MicrosoftOAuthExtraConfig.tsx
@@ -1,5 +1,5 @@
 import { classNames, Input, SliderToggle, TextArea } from "@dust-tt/sparkle";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import type { ConnectorOauthExtraConfigProps } from "@app/lib/connector_providers_ui";
 
@@ -8,13 +8,30 @@ export function MicrosoftOAuthExtraConfig({
   setExtraConfig,
   setIsExtraConfigValid,
 }: ConnectorOauthExtraConfigProps) {
-  const initialServicePrincipal = !!extraConfig.client_id;
+  // Store the initial extraConfig values when they're first loaded
+  const initialExtraConfigRef = useRef<Record<string, string>>({});
+  const prevUseServicePrincipalRef = useRef<boolean>(!!extraConfig.client_id);
 
   const [useServicePrincipal, setUseServicePrincipal] = useState(
-    initialServicePrincipal
+    !!extraConfig.client_id
   );
 
   const selectedSitesValue = extraConfig.selected_sites || "";
+
+  // Store initial values when extraConfig is first populated with data
+  useEffect(() => {
+    if (
+      extraConfig.client_id &&
+      Object.keys(initialExtraConfigRef.current).length === 0
+    ) {
+      initialExtraConfigRef.current = { ...extraConfig };
+    }
+  }, [extraConfig]);
+
+  // Update useServicePrincipal when extraConfig changes (e.g., when loading existing config)
+  useEffect(() => {
+    setUseServicePrincipal(!!extraConfig.client_id);
+  }, [extraConfig.client_id]);
 
   useEffect(() => {
     setIsExtraConfigValid(
@@ -25,17 +42,29 @@ export function MicrosoftOAuthExtraConfig({
     );
   }, [useServicePrincipal, extraConfig, setIsExtraConfigValid]);
 
+  // Handle toggling service principal on/off
   useEffect(() => {
-    if (!useServicePrincipal) {
-      setExtraConfig((prev: Record<string, string>) => {
-        const updated = { ...prev };
-        delete updated.tenant_id;
-        delete updated.client_id;
-        delete updated.client_secret;
-        delete updated.selected_sites;
-        return updated;
-      });
+    const wasToggled =
+      prevUseServicePrincipalRef.current !== useServicePrincipal;
+
+    if (wasToggled) {
+      if (!useServicePrincipal) {
+        // Toggled to false - clear the fields
+        setExtraConfig((prev: Record<string, string>) => {
+          const updated = { ...prev };
+          delete updated.tenant_id;
+          delete updated.client_id;
+          delete updated.client_secret;
+          delete updated.selected_sites;
+          return updated;
+        });
+      } else if (Object.keys(initialExtraConfigRef.current).length > 0) {
+        // Toggled to true - restore initial values if they exist
+        setExtraConfig(initialExtraConfigRef.current);
+      }
     }
+
+    prevUseServicePrincipalRef.current = useServicePrincipal;
   }, [useServicePrincipal, setExtraConfig]);
 
   return (
@@ -47,82 +76,85 @@ export function MicrosoftOAuthExtraConfig({
           onClick={() => setUseServicePrincipal(!useServicePrincipal)}
         />
       </div>
-      <div
-        className={classNames(
-          "flex flex-col gap-2",
-          !useServicePrincipal ? "opacity-50" : ""
-        )}
-      >
-        <Input
-          label="Tenant ID"
-          disabled={!useServicePrincipal}
-          name="tenant_id"
-          value={extraConfig.tenant_id ?? ""}
-          onChange={(e) => {
-            setExtraConfig((prev: Record<string, string>) => ({
-              ...prev,
-              tenant_id: e.target.value,
-            }));
-          }}
-        />
-        <Input
-          label="Client ID"
-          disabled={!useServicePrincipal}
-          name="client_id"
-          value={extraConfig.client_id ?? ""}
-          onChange={(e) => {
-            setExtraConfig((prev: Record<string, string>) => ({
-              ...prev,
-              client_id: e.target.value,
-            }));
-          }}
-        />
-        <Input
-          label="Service Account secret"
-          disabled={!useServicePrincipal}
-          name="client_secret"
-          value={extraConfig.client_secret ?? ""}
-          onChange={(e) => {
-            setExtraConfig((prev: Record<string, string>) => ({
-              ...prev,
-              client_secret: e.target.value,
-            }));
-          }}
-        />
-        <div className="flex flex-col gap-1">
-          <div className="text-sm font-medium text-slate-700">
-            Selected SharePoint sites Dust will have access to (one per line).
-          </div>
-          <TextArea
-            placeholder={
-              "contoso.sharepoint.com,1234abcd-...\ncontoso.sharepoint.com,5678efgh-..."
-            }
+      {useServicePrincipal && (
+        <div
+          className={classNames(
+            "flex flex-col gap-2",
+            !useServicePrincipal ? "opacity-50" : ""
+          )}
+        >
+          <Input
+            label="Tenant ID"
             disabled={!useServicePrincipal}
-            name="selected_sites"
-            value={selectedSitesValue}
+            name="tenant_id"
+            value={extraConfig.tenant_id ?? ""}
             onChange={(e) => {
-              if (e.target.value.trim().length === 0) {
-                setExtraConfig((prev: Record<string, string>) => {
-                  const updated = { ...prev };
-                  delete updated.selected_sites;
-                  return updated;
-                });
-              } else {
-                setExtraConfig((prev: Record<string, string>) => ({
-                  ...prev,
-                  selected_sites: e.target.value,
-                }));
-              }
+              setExtraConfig((prev: Record<string, string>) => ({
+                ...prev,
+                tenant_id: e.target.value,
+              }));
             }}
-            minRows={4}
           />
-          <div className="text-xs text-slate-500">
-            Provide the SharePoint site identifiers assigned to the service
-            principal. Enter one identifier per line. This is not required if
-            your Service Principal has access to all sites.
+          <Input
+            label="Client ID"
+            disabled={!useServicePrincipal}
+            name="client_id"
+            value={extraConfig.client_id ?? ""}
+            onChange={(e) => {
+              setExtraConfig((prev: Record<string, string>) => ({
+                ...prev,
+                client_id: e.target.value,
+              }));
+            }}
+          />
+          <Input
+            label="Service Account secret"
+            disabled={!useServicePrincipal}
+            name="client_secret"
+            type="password"
+            value={extraConfig.client_secret ?? ""}
+            onChange={(e) => {
+              setExtraConfig((prev: Record<string, string>) => ({
+                ...prev,
+                client_secret: e.target.value,
+              }));
+            }}
+          />
+          <div className="flex flex-col gap-1">
+            <div className="text-sm font-medium text-slate-700">
+              Selected SharePoint sites Dust will have access to (one per line).
+            </div>
+            <TextArea
+              placeholder={
+                "contoso.sharepoint.com,1234abcd-...\ncontoso.sharepoint.com,5678efgh-..."
+              }
+              disabled={!useServicePrincipal}
+              name="selected_sites"
+              value={selectedSitesValue}
+              onChange={(e) => {
+                if (e.target.value.trim().length === 0) {
+                  setExtraConfig((prev: Record<string, string>) => {
+                    const updated = { ...prev };
+                    delete updated.selected_sites;
+                    return updated;
+                  });
+                } else {
+                  setExtraConfig((prev: Record<string, string>) => ({
+                    ...prev,
+                    selected_sites: e.target.value,
+                  }));
+                }
+              }}
+              minRows={4}
+            />
+            <div className="text-xs text-slate-500">
+              Provide the SharePoint site identifiers assigned to the service
+              principal. Enter one identifier per line. This is not required if
+              your Service Principal has access to all sites.
+            </div>
           </div>
         </div>
-      </div>
+      )}
     </>
   );
 }

--- a/front/lib/swr/connectors.ts
+++ b/front/lib/swr/connectors.ts
@@ -112,6 +112,32 @@ export function useConnectorConfig({
   };
 }
 
+export function useOAuthMetadata({
+  dataSource,
+  disabled,
+  owner,
+}: {
+  dataSource: DataSourceType | null;
+  disabled?: boolean;
+  owner: LightWorkspaceType;
+}) {
+  const metadataFetcher: Fetcher<{ metadata: Record<string, unknown> }> =
+    fetcher;
+
+  const url = `/api/w/${owner.sId}/data_sources/${dataSource?.sId}/managed/oauth-metadata`;
+
+  const { data, error } = useSWRWithDefaults(url, metadataFetcher, {
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+    disabled: disabled || !dataSource,
+  });
+
+  return {
+    metadata: data ? data.metadata : null,
+    isMetadataLoading: !error && !data,
+    isMetadataError: error,
+  };
+}
+
 export function useToggleChatBot({
   dataSource,
   owner,

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/managed/oauth-metadata.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/managed/oauth-metadata.ts
@@ -131,6 +131,9 @@ async function handler(
       const { connection } = metadataRes.value;
       const metadata = connection.metadata || {};
 
+      delete metadata.client_secret;
+      delete metadata.refresh_token;
+
       res.status(200).json({ metadata });
       return;
 

--- a/front/pages/api/w/[wId]/data_sources/[dsId]/managed/oauth-metadata.ts
+++ b/front/pages/api/w/[wId]/data_sources/[dsId]/managed/oauth-metadata.ts
@@ -1,0 +1,148 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import config from "@app/lib/api/config";
+import type { Authenticator } from "@app/lib/auth";
+import { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import logger from "@app/logger/logger";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+import { ConnectorsAPI, OAuthAPI } from "@app/types";
+
+export type GetOAuthMetadataResponseBody = {
+  metadata: Record<string, unknown>;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<GetOAuthMetadataResponseBody | void>
+  >,
+  auth: Authenticator
+): Promise<void> {
+  const { dsId } = req.query;
+  if (typeof dsId !== "string") {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid path parameters.",
+      },
+    });
+  }
+
+  // fetchById enforces through auth the authorization (workspace here mainly).
+  const dataSource = await DataSourceResource.fetchById(auth, dsId);
+  if (!dataSource) {
+    return apiError(req, res, {
+      status_code: 404,
+      api_error: {
+        type: "data_source_not_found",
+        message: "The data source you requested was not found.",
+      },
+    });
+  }
+
+  if (!dataSource.connectorId) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "data_source_not_managed",
+        message: "The data source you requested is not managed.",
+      },
+    });
+  }
+
+  if (!dataSource.canAdministrate(auth)) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "data_source_auth_error",
+        message: "Only workspace admins can access data source OAuth metadata.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET":
+      // Fetch connector details from connectors service
+      const connectorsAPI = new ConnectorsAPI(
+        config.getConnectorsAPIConfig(),
+        logger
+      );
+
+      const connectorRes = await connectorsAPI.getConnector(
+        dataSource.connectorId.toString()
+      );
+
+      if (connectorRes.isErr()) {
+        logger.error(
+          {
+            connectorId: dataSource.connectorId,
+            error: connectorRes.error,
+          },
+          "Failed to fetch connector details"
+        );
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "Failed to fetch connector details.",
+          },
+        });
+      }
+
+      const connectionId = connectorRes.value.connectionId;
+
+      if (!connectionId) {
+        return apiError(req, res, {
+          status_code: 404,
+          api_error: {
+            type: "connector_oauth_connection_not_found",
+            message: "No OAuth connection found for this connector.",
+          },
+        });
+      }
+
+      // Fetch OAuth connection metadata
+      const oauthAPI = new OAuthAPI(config.getOAuthAPIConfig(), logger);
+      const metadataRes = await oauthAPI.getConnectionMetadata({
+        connectionId,
+      });
+
+      if (metadataRes.isErr()) {
+        logger.error(
+          {
+            connectionId,
+            error: metadataRes.error,
+          },
+          "Failed to fetch OAuth connection metadata"
+        );
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: "Failed to fetch OAuth connection metadata.",
+          },
+        });
+      }
+
+      // Extract relevant metadata fields, excluding sensitive system fields
+      const { connection } = metadataRes.value;
+      const metadata = connection.metadata || {};
+
+      res.status(200).json({ metadata });
+      return;
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/types/error.ts
+++ b/front/types/error.ts
@@ -55,6 +55,7 @@ const API_ERROR_TYPES = [
   "connector_not_found_error",
   "connector_update_error",
   "connector_update_unauthorized",
+  "connector_oauth_connection_not_found",
   "connector_oauth_target_mismatch",
   "connector_oauth_user_missing_rights",
   "connector_provider_not_supported",


### PR DESCRIPTION
## Description

Fixes the issue where admins couldn't edit Microsoft Service Principal connections. 
Adds a new API endpoint to fetch OAuth metadata from the connection and populates the service principal form fields (tenant_id, client_id, client_secret, selected_sites) when the "Edit permissions" modal opens. 
The form maintains state correctly when toggling the service principal option on/off, and the client_secret field is now properly displayed as a password input.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low. Normally, no sensitive data is sent by the new endpoint.

## Deploy Plan

Deploy
