### PR TITLE
The skip LP

### DIFF
--- a/front/components/home/content/Landing/LandingCtaSection.tsx
+++ b/front/components/home/content/Landing/LandingCtaSection.tsx
@@ -1,0 +1,51 @@
+import { Button } from "@dust-tt/sparkle";
+
+import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
+import { appendUTMParams } from "@app/lib/utils/utm";
+
+interface LandingCtaSectionProps {
+  title: string;
+  subtitle: string;
+  ctaText: string;
+  ctaLink: string;
+  trackingLocation: string;
+}
+
+export function LandingCtaSection({
+  title,
+  subtitle,
+  ctaText,
+  ctaLink,
+  trackingLocation,
+}: LandingCtaSectionProps) {
+  return (
+    <section className="w-full">
+      <div
+        className="relative left-1/2 right-1/2 -ml-[50vw] -mr-[50vw] w-screen py-16 md:py-20"
+        style={{
+          background: "linear-gradient(135deg, #3B82F6 0%, #1D4ED8 100%)",
+        }}
+      >
+        <div className="mx-auto max-w-3xl px-4 text-center">
+          <h2 className="mb-4 text-3xl font-bold text-white md:text-4xl">
+            {title}
+          </h2>
+          <p className="mb-8 text-lg text-blue-100">{subtitle}</p>
+          <Button
+            variant="highlight"
+            size="md"
+            label={ctaText}
+            onClick={withTracking(
+              TRACKING_AREAS.HOME,
+              `${trackingLocation}_bottom_cta`,
+              () => {
+                // eslint-disable-next-line react-hooks/immutability
+                window.location.href = appendUTMParams(ctaLink);
+              }
+            )}
+          />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/front/components/home/content/Landing/LandingEmailSignup.tsx
+++ b/front/components/home/content/Landing/LandingEmailSignup.tsx
@@ -1,0 +1,130 @@
+import { ArrowRightIcon, Button, cn, Spinner } from "@dust-tt/sparkle";
+import { useEffect, useState } from "react";
+import { useCookies } from "react-cookie";
+
+import { DUST_HAS_SESSION, hasSessionIndicator } from "@app/lib/cookies";
+import { clientFetch } from "@app/lib/egress/client";
+import {
+  trackEvent,
+  TRACKING_ACTIONS,
+  TRACKING_AREAS,
+  withTracking,
+} from "@app/lib/tracking";
+import { appendUTMParams } from "@app/lib/utils/utm";
+import logger from "@app/logger/logger";
+import { normalizeError } from "@app/types";
+
+interface LandingEmailSignupProps {
+  ctaButtonText: string;
+  welcomeBackText?: string;
+  trackingLocation: string;
+  className?: string;
+}
+
+export function LandingEmailSignup({
+  ctaButtonText,
+  welcomeBackText = "Welcome back! Continue where you left off.",
+  trackingLocation,
+  className = "",
+}: LandingEmailSignupProps) {
+  const [email, setEmail] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [cookies] = useCookies([DUST_HAS_SESSION], { doNotParse: true });
+  const [hasSession, setHasSession] = useState(false);
+
+  useEffect(() => {
+    setHasSession(hasSessionIndicator(cookies[DUST_HAS_SESSION]));
+  }, [cookies]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    if (!email || !email.includes("@")) {
+      setError("Please enter a valid email");
+      return;
+    }
+
+    trackEvent({
+      area: TRACKING_AREAS.HOME,
+      object: `${trackingLocation}_email`,
+      action: TRACKING_ACTIONS.SUBMIT,
+    });
+
+    setIsLoading(true);
+
+    try {
+      const response = await clientFetch("/api/enrichment/company", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email }),
+      });
+
+      const data = await response.json();
+
+      if (!data.success && data.error) {
+        setError(data.error);
+        return;
+      }
+
+      if (data.redirectUrl) {
+        window.location.href = appendUTMParams(data.redirectUrl);
+      }
+    } catch (err) {
+      logger.error({ error: normalizeError(err) }, "Enrichment error");
+      window.location.href = appendUTMParams(
+        `/api/workos/login?screenHint=sign-up&loginHint=${encodeURIComponent(email)}`
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  if (hasSession) {
+    return (
+      <div className={cn("flex flex-col items-center gap-3", className)}>
+        <Button
+          variant="highlight"
+          size="md"
+          label="Open Dust"
+          icon={ArrowRightIcon}
+          onClick={withTracking(
+            TRACKING_AREAS.HOME,
+            `${trackingLocation}_open_dust`,
+            () => {
+              window.location.href = "/api/login";
+            }
+          )}
+        />
+        <p className="text-sm text-muted-foreground">{welcomeBackText}</p>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className={className}>
+      <div className="flex w-full items-center gap-2 rounded-xl border border-gray-200 bg-white p-1.5 shadow-md">
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="Enter your work email"
+          className="flex-1 border-none bg-transparent px-3 py-2 text-base text-gray-700 placeholder-gray-400 outline-none focus:ring-0"
+          disabled={isLoading}
+        />
+        <button
+          type="submit"
+          disabled={isLoading}
+          className="flex items-center gap-2 rounded-lg bg-blue-500 px-5 py-2.5 font-semibold text-white shadow-sm transition-all hover:bg-blue-600 hover:shadow-md disabled:opacity-70"
+        >
+          {isLoading && <Spinner size="xs" />}
+          {ctaButtonText}
+          <ArrowRightIcon className="h-4 w-4" />
+        </button>
+      </div>
+      {error && <p className="mt-2 text-sm text-red-500">{error}</p>}
+    </form>
+  );
+}

--- a/front/components/home/content/Landing/LandingHeroSection.tsx
+++ b/front/components/home/content/Landing/LandingHeroSection.tsx
@@ -1,0 +1,115 @@
+import { cn } from "@dust-tt/sparkle";
+import type { ReactNode } from "react";
+
+import { LandingEmailSignup } from "@app/components/home/content/Landing/LandingEmailSignup";
+import { P } from "@app/components/home/ContentComponents";
+
+interface LandingHeroSectionProps {
+  headline: ReactNode;
+  subheadline: string;
+  ctaButtonText: string;
+  welcomeBackText?: string;
+  trackingLocation: string;
+  chip?: string;
+  layout?: "centered" | "split";
+  rightContent?: ReactNode;
+  bottomContent?: ReactNode;
+}
+
+export function LandingHeroSection({
+  headline,
+  subheadline,
+  ctaButtonText,
+  welcomeBackText,
+  trackingLocation,
+  chip,
+  layout = "centered",
+  rightContent,
+  bottomContent,
+}: LandingHeroSectionProps) {
+  const isCentered = layout === "centered";
+
+  return (
+    <section className="w-full">
+      <div
+        className="relative left-1/2 right-1/2 -ml-[50vw] -mr-[50vw] w-screen py-16 md:py-24"
+        style={{
+          background:
+            "linear-gradient(180deg, #FFF 0%, #F0F9FF 40%, #F0F9FF 60%, #FFF 100%)",
+        }}
+      >
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+          <div
+            className={
+              isCentered
+                ? "mx-auto max-w-3xl text-center"
+                : "flex flex-col gap-12 lg:flex-row lg:items-center lg:gap-16"
+            }
+          >
+            {/* Left/Main content */}
+            <div
+              className={isCentered ? "" : "flex flex-col items-start lg:w-1/2"}
+            >
+              {/* Chip */}
+              {chip && (
+                <div
+                  className={cn(
+                    "mb-6 inline-flex items-center gap-2 rounded-full bg-blue-100 px-4 py-1.5 text-sm font-medium text-blue-700",
+                    isCentered && "mx-auto"
+                  )}
+                >
+                  <span className="flex h-2 w-2 rounded-full bg-blue-500" />
+                  {chip}
+                </div>
+              )}
+
+              {/* Headline */}
+              <h1
+                className={cn(
+                  "mb-6 text-4xl font-bold md:text-5xl lg:text-6xl",
+                  !isCentered && "text-left"
+                )}
+              >
+                {headline}
+              </h1>
+
+              {/* Subheadline */}
+              <P
+                size="md"
+                className={cn(
+                  "mb-10 text-muted-foreground",
+                  isCentered && "mx-auto max-w-2xl"
+                )}
+              >
+                {subheadline}
+              </P>
+
+              {/* Email CTA */}
+              <div className={cn("w-full max-w-md", isCentered && "mx-auto")}>
+                <LandingEmailSignup
+                  ctaButtonText={ctaButtonText}
+                  welcomeBackText={welcomeBackText}
+                  trackingLocation={trackingLocation}
+                />
+              </div>
+
+              {/* Bottom content (testimonials, etc.) */}
+              {bottomContent && isCentered && (
+                <div className="mt-10 w-full">{bottomContent}</div>
+              )}
+
+              {bottomContent && !isCentered && (
+                <div className="mt-10 w-full">{bottomContent}</div>
+              )}
+            </div>
+
+            {/* Right content (video, image, etc.) */}
+            {rightContent && !isCentered && (
+              <div className="flex-1">{rightContent}</div>
+            )}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/front/components/home/content/Landing/index.ts
+++ b/front/components/home/content/Landing/index.ts
@@ -1,0 +1,3 @@
+export { LandingCtaSection } from "./LandingCtaSection";
+export { LandingEmailSignup } from "./LandingEmailSignup";
+export { LandingHeroSection } from "./LandingHeroSection";

--- a/front/components/home/content/Skip/AgentBuilderVisual.tsx
+++ b/front/components/home/content/Skip/AgentBuilderVisual.tsx
@@ -1,0 +1,95 @@
+import { cn } from "@dust-tt/sparkle";
+
+const AGENTS = [
+  {
+    name: "Support Agent",
+    description: "Resolves tickets from help docs",
+    emoji: "🎧",
+    tools: ["Zendesk", "Notion"],
+    accentColor: "bg-blue-500",
+    bgColor: "bg-blue-50",
+  },
+  {
+    name: "Ops Agent",
+    description: "Updates CRM & tracks deals",
+    emoji: "⚙️",
+    tools: ["Salesforce", "Slack"],
+    accentColor: "bg-emerald-500",
+    bgColor: "bg-emerald-50",
+  },
+  {
+    name: "Research Agent",
+    description: "Synthesizes customer feedback",
+    emoji: "🔍",
+    tools: ["Slack", "Drive", "Notion"],
+    accentColor: "bg-purple-500",
+    bgColor: "bg-purple-50",
+  },
+];
+
+export function AgentBuilderVisual() {
+  return (
+    <div className="relative w-full overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-lg">
+      {/* Header bar */}
+      <div className="flex items-center justify-between border-b border-gray-100 bg-gray-50 px-4 py-2.5">
+        <div className="flex items-center gap-2">
+          <div className="flex gap-1.5">
+            <div className="h-2.5 w-2.5 rounded-full bg-gray-300" />
+            <div className="h-2.5 w-2.5 rounded-full bg-gray-300" />
+            <div className="h-2.5 w-2.5 rounded-full bg-gray-300" />
+          </div>
+          <span className="ml-2 text-xs font-medium text-gray-500">
+            My Agents
+          </span>
+        </div>
+        <div className="rounded-md bg-blue-500 px-2.5 py-1 text-xs font-medium text-white">
+          + New Agent
+        </div>
+      </div>
+
+      <div className="space-y-3 p-4">
+        {AGENTS.map((agent) => (
+          <div
+            key={agent.name}
+            className="flex items-center gap-3 rounded-xl border border-gray-100 p-3 transition-colors"
+          >
+            {/* Icon */}
+            <div
+              className={cn(
+                "flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-lg text-lg",
+                agent.bgColor
+              )}
+            >
+              {agent.emoji}
+            </div>
+
+            {/* Info */}
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2">
+                <span className="text-sm font-semibold text-gray-900">
+                  {agent.name}
+                </span>
+                <span className="flex items-center gap-1 rounded-full bg-emerald-50 px-1.5 py-0.5 text-[10px] font-medium text-emerald-600">
+                  <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" />
+                  Active
+                </span>
+              </div>
+              <p className="text-xs text-gray-500">{agent.description}</p>
+              {/* Tool badges */}
+              <div className="mt-1 flex gap-1">
+                {agent.tools.map((tool) => (
+                  <span
+                    key={tool}
+                    className="rounded bg-gray-100 px-1.5 py-0.5 text-[10px] font-medium text-gray-500"
+                  >
+                    {tool}
+                  </span>
+                ))}
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/front/components/home/content/Skip/CareerAdvantageVisual.tsx
+++ b/front/components/home/content/Skip/CareerAdvantageVisual.tsx
@@ -1,0 +1,97 @@
+import { CheckIcon, cn, Icon } from "@dust-tt/sparkle";
+
+const TOOL_PILLS = [
+  { name: "Slack", color: "bg-purple-100 text-purple-700" },
+  { name: "Notion", color: "bg-gray-100 text-gray-700" },
+  { name: "Drive", color: "bg-blue-100 text-blue-700" },
+  { name: "Salesforce", color: "bg-sky-100 text-sky-700" },
+  { name: "GitHub", color: "bg-gray-100 text-gray-700" },
+];
+
+const COMPLETED_TASKS = [
+  {
+    label: "PRD drafted from 12 Slack threads",
+    timeAgo: "2m ago",
+    accent: "bg-emerald-500",
+  },
+  {
+    label: "Board meeting prep synthesized",
+    timeAgo: "8m ago",
+    accent: "bg-emerald-500",
+  },
+  {
+    label: "Q3 competitive analysis complete",
+    timeAgo: "14m ago",
+    accent: "bg-emerald-500",
+  },
+];
+
+export function CareerAdvantageVisual() {
+  return (
+    <div className="relative w-full overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-lg">
+      {/* Header bar */}
+      <div className="flex items-center gap-2 border-b border-gray-100 bg-gray-50 px-4 py-2.5">
+        <div className="flex gap-1.5">
+          <div className="h-2.5 w-2.5 rounded-full bg-gray-300" />
+          <div className="h-2.5 w-2.5 rounded-full bg-gray-300" />
+          <div className="h-2.5 w-2.5 rounded-full bg-gray-300" />
+        </div>
+        <div className="ml-2 h-5 flex-1 rounded bg-gray-100" />
+      </div>
+
+      <div className="p-5">
+        {/* Connected tools */}
+        <div className="mb-4">
+          <p className="mb-2 text-xs font-medium uppercase tracking-wider text-gray-400">
+            Connected sources
+          </p>
+          <div className="flex flex-wrap gap-1.5">
+            {TOOL_PILLS.map((tool) => (
+              <span
+                key={tool.name}
+                className={cn(
+                  "rounded-full px-2.5 py-0.5 text-xs font-medium",
+                  tool.color
+                )}
+              >
+                {tool.name}
+              </span>
+            ))}
+          </div>
+        </div>
+
+        {/* Divider with flow indicator */}
+        <div className="mb-4 flex items-center gap-2">
+          <div className="h-px flex-1 bg-gray-100" />
+          <span className="text-xs text-gray-300">&#x25BC;</span>
+          <div className="h-px flex-1 bg-gray-100" />
+        </div>
+
+        {/* Completed tasks */}
+        <div className="space-y-2">
+          {COMPLETED_TASKS.map((task) => (
+            <div
+              key={task.label}
+              className="flex items-center gap-3 rounded-lg border border-gray-100 bg-gray-50/50 px-3 py-2.5"
+            >
+              <span className="flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full bg-emerald-100">
+                <Icon visual={CheckIcon} className="h-3 w-3 text-emerald-600" />
+              </span>
+              <span className="flex-1 text-sm text-gray-700">{task.label}</span>
+              <span className="flex-shrink-0 text-xs text-gray-400">
+                {task.timeAgo}
+              </span>
+            </div>
+          ))}
+        </div>
+
+        {/* Bottom stat */}
+        <div className="mt-4 flex justify-center">
+          <span className="rounded-full bg-emerald-50 px-3 py-1 text-xs font-medium text-emerald-700">
+            4.2 hours saved today
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/front/components/home/content/Skip/config/skipConfig.tsx
+++ b/front/components/home/content/Skip/config/skipConfig.tsx
@@ -1,0 +1,191 @@
+import type { ReactNode } from "react";
+
+interface VideoConfig {
+  id: string;
+  title: string;
+  embedUrl: string;
+}
+
+interface TestimonialConfig {
+  quote: string;
+  name: string;
+  title: string;
+  logo: string;
+}
+
+interface HeroConfig {
+  chip: string;
+  headline: ReactNode;
+  subheadline: string;
+  ctaButtonText: string;
+  testimonials: TestimonialConfig[];
+  videos: VideoConfig[];
+  usersCount: string;
+}
+
+interface FeatureSectionConfig {
+  title: string;
+  titleHighlight: string;
+  description: string;
+  features: string[];
+  image: {
+    src: string;
+    alt: string;
+  };
+  imagePosition: "left" | "right";
+  backgroundColor?: string;
+}
+
+interface BottomTestimonial {
+  quote: string;
+  name: string;
+  title: string;
+  avatar?: string;
+  logo: string;
+}
+
+interface BottomTestimonialsConfig {
+  title: string;
+  subtitle: string;
+  testimonials: BottomTestimonial[];
+}
+
+interface CtaConfig {
+  title: string;
+  subtitle: string;
+  ctaText: string;
+  ctaLink: string;
+}
+
+export interface SkipConfig {
+  hero: HeroConfig;
+  trustedByTitle: string;
+  sections: FeatureSectionConfig[];
+  bottomTestimonials: BottomTestimonialsConfig;
+  cta: CtaConfig;
+}
+
+export const skipConfig: SkipConfig = {
+  hero: {
+    chip: "",
+    headline: "Welcome, Skip listeners 👋",
+    subheadline:
+      "You just heard about Dust on Nikhyl's show. Here's how ambitious tech professionals are using AI agents to level up their impact—and their careers.",
+    ctaButtonText: "Get started with Dust",
+    testimonials: [
+      {
+        quote:
+          "We've reduced our response time by 73% and our team loves using it daily.",
+        name: "Daniel Banet",
+        title: "Head of AI Solutions",
+        logo: "/static/landing/logos/gray/vanta.svg",
+      },
+      {
+        quote:
+          "Dust is the most impactful software we've adopted since building Clay. It delivers immediate value while continuously getting smarter.",
+        name: "Everett Berry",
+        title: "GTM Eng Lead, Clay",
+        logo: "/static/landing/logos/gray/clay.svg",
+      },
+      {
+        quote:
+          "Allows us to create qualitative deliverables, not only search/answer questions.",
+        name: "Ryan Wang",
+        title: "CEO, Assembled",
+        logo: "/static/landing/logos/gray/assembled.svg",
+      },
+    ],
+    videos: [
+      {
+        id: "dust-in-action",
+        title: "Dust in Action",
+        embedUrl: "https://www.youtube.com/embed/UNrGsKCtAV0",
+      },
+      {
+        id: "clay-dust-gtm",
+        title: "Clay x Dust - GTM AI",
+        embedUrl: "https://www.youtube.com/embed/kZ-Zyjjd7ns",
+      },
+      {
+        id: "multiple-agents",
+        title: "Multiple Agents",
+        embedUrl: "https://www.youtube.com/embed/38vCIR2yHoA",
+      },
+    ],
+    usersCount: "2,000+ teams already using Dust",
+  },
+
+  trustedByTitle: "TRUSTED BY AMBITIOUS TEAMS AT:",
+
+  sections: [
+    {
+      title: "The career advantage",
+      titleHighlight: "hiding in plain sight",
+      description:
+        "The best PMs, operators, and leaders don't get promoted for working harder. They get promoted for delivering more impact with less effort. While your peers are buried in Slack threads, hunting for data, and updating spreadsheets, you could be:",
+      features: [
+        "Shipping faster: Draft PRDs, prep for meetings, and synthesize research in minutes instead of hours",
+        "Making better decisions: Get instant answers from your company's collective knowledge across every tool",
+        "Getting credit for what matters: Automate the busywork so you can focus on the strategic thinking that gets you promoted",
+      ],
+      image: {
+        src: "/static/landing/sqagent/feature-1.png",
+        alt: "AI agents working across multiple tools",
+      },
+      imagePosition: "right",
+    },
+    {
+      title: "Build custom AI agents",
+      titleHighlight: "in minutes",
+      description:
+        "No coding required. They connect to all your tools (Slack, Notion, Drive, Salesforce, GitHub), understand your company's knowledge, and take action across your entire workflow.",
+      features: [
+        "A support agent that resolves tickets using your help docs and past conversations",
+        "An ops agent that updates your CRM, tracks deals, and flags risks automatically",
+        "A research agent that synthesizes customer feedback across every channel",
+        "They work across teams—so the whole company gets smarter, not just you",
+      ],
+      image: {
+        src: "/static/landing/sqagent/feature-2.png",
+        alt: "No-code agent builder interface",
+      },
+      imagePosition: "left",
+      backgroundColor: "bg-muted",
+    },
+  ],
+
+  bottomTestimonials: {
+    title: "Loved by ambitious teams",
+    subtitle: "See why leading companies trust Dust to power their operations.",
+    testimonials: [
+      {
+        quote:
+          '"We\'ve reduced our response time by 73% and our team loves using it daily."',
+        name: "Daniel Banet",
+        title: "Head of AI Solutions, Vanta",
+        logo: "/static/landing/logos/gray/vanta.svg",
+      },
+      {
+        quote:
+          '"Allows us to create qualitative deliverables, not only search/answer questions"',
+        name: "Ryan Wang",
+        title: "CEO, Assembled",
+        logo: "/static/landing/logos/gray/assembled.svg",
+      },
+      {
+        quote:
+          '"I have Dust agents for vendor research, interviewing, and even to check changes in our knowledge base, endless possibilities with the platform."',
+        name: "Everett Berry",
+        title: "GTM Eng Lead, Clay",
+        logo: "/static/landing/logos/gray/clay.svg",
+      },
+    ],
+  },
+
+  cta: {
+    title: "See how Dust can accelerate your impact",
+    subtitle: "Model-agnostic • Enterprise-ready • Deploy in minutes",
+    ctaText: "Get started with Dust",
+    ctaLink: "/api/workos/login?screenHint=sign-up",
+  },
+};

--- a/front/components/home/content/SqAgent/FeatureSection.tsx
+++ b/front/components/home/content/SqAgent/FeatureSection.tsx
@@ -1,4 +1,5 @@
 import { CheckIcon, cn, Icon } from "@dust-tt/sparkle";
+import type { ReactNode } from "react";
 
 import { H2, P } from "@app/components/home/ContentComponents";
 
@@ -21,6 +22,7 @@ interface FeatureSectionProps {
   imagePosition: "left" | "right";
   backgroundColor?: string;
   colorIndex?: number;
+  visualComponent?: ReactNode;
 }
 
 export function FeatureSection({
@@ -32,6 +34,7 @@ export function FeatureSection({
   imagePosition,
   backgroundColor,
   colorIndex = 0,
+  visualComponent,
 }: FeatureSectionProps) {
   const colors = BULLET_COLORS[colorIndex % BULLET_COLORS.length];
 
@@ -66,15 +69,17 @@ export function FeatureSection({
 
   const imageSection = (
     <div className="flex items-center justify-center lg:w-1/2">
-      <div className="relative aspect-video w-full overflow-hidden rounded-2xl bg-gradient-to-br from-slate-100 to-slate-200 shadow-lg">
-        {/* Placeholder for actual image - can be replaced with actual screenshots */}
-        <div className="absolute inset-0 flex items-center justify-center">
-          <div className="flex flex-col items-center gap-4 text-center">
-            <div className="h-16 w-16 rounded-2xl bg-gradient-to-br from-blue-500 to-emerald-500" />
-            <span className="text-sm text-muted-foreground">{image.alt}</span>
+      {visualComponent ?? (
+        <div className="relative aspect-video w-full overflow-hidden rounded-2xl bg-gradient-to-br from-slate-100 to-slate-200 shadow-lg">
+          {/* Placeholder for actual image - can be replaced with actual screenshots */}
+          <div className="absolute inset-0 flex items-center justify-center">
+            <div className="flex flex-col items-center gap-4 text-center">
+              <div className="h-16 w-16 rounded-2xl bg-gradient-to-br from-blue-500 to-emerald-500" />
+              <span className="text-sm text-muted-foreground">{image.alt}</span>
+            </div>
           </div>
         </div>
-      </div>
+      )}
     </div>
   );
 

--- a/front/components/home/content/SqAgent/SqAgentHeroSection.tsx
+++ b/front/components/home/content/SqAgent/SqAgentHeroSection.tsx
@@ -1,29 +1,15 @@
 import {
-  ArrowRightIcon,
-  Button,
   ChevronLeftIcon,
   ChevronRightIcon,
   cn,
-  Spinner,
   UserGroupIcon,
 } from "@dust-tt/sparkle";
 import Image from "next/image";
 import type { ReactNode } from "react";
 import { useCallback, useEffect, useState } from "react";
-import { useCookies } from "react-cookie";
 
+import { LandingEmailSignup } from "@app/components/home/content/Landing/LandingEmailSignup";
 import { P } from "@app/components/home/ContentComponents";
-import { DUST_HAS_SESSION, hasSessionIndicator } from "@app/lib/cookies";
-import { clientFetch } from "@app/lib/egress/client";
-import {
-  trackEvent,
-  TRACKING_ACTIONS,
-  TRACKING_AREAS,
-  withTracking,
-} from "@app/lib/tracking";
-import { appendUTMParams } from "@app/lib/utils/utm";
-import logger from "@app/logger/logger";
-import { normalizeError } from "@app/types";
 
 interface VideoConfig {
   id: string;
@@ -61,60 +47,6 @@ export function SqAgentHeroSection({
 }: SqAgentHeroSectionProps) {
   const [activeVideo, setActiveVideo] = useState(0);
   const [activeTestimonial, setActiveTestimonial] = useState(0);
-  const [email, setEmail] = useState("");
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  const [cookies] = useCookies([DUST_HAS_SESSION], { doNotParse: true });
-  const [hasSession, setHasSession] = useState(false);
-
-  useEffect(() => {
-    setHasSession(hasSessionIndicator(cookies[DUST_HAS_SESSION]));
-  }, [cookies]);
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setError(null);
-
-    if (!email || !email.includes("@")) {
-      setError("Please enter a valid email");
-      return;
-    }
-
-    trackEvent({
-      area: TRACKING_AREAS.HOME,
-      object: "sqagent_hero_email",
-      action: TRACKING_ACTIONS.SUBMIT,
-    });
-
-    setIsLoading(true);
-
-    try {
-      const response = await clientFetch("/api/enrichment/company", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ email }),
-      });
-
-      const data = await response.json();
-
-      if (!data.success && data.error) {
-        setError(data.error);
-        return;
-      }
-
-      if (data.redirectUrl) {
-        window.location.href = appendUTMParams(data.redirectUrl);
-      }
-    } catch (err) {
-      logger.error({ error: normalizeError(err) }, "Enrichment error");
-      window.location.href = appendUTMParams(
-        `/api/workos/login?screenHint=sign-up&loginHint=${encodeURIComponent(email)}`
-      );
-    } finally {
-      setIsLoading(false);
-    }
-  };
 
   const rotateTestimonial = useCallback(() => {
     setActiveTestimonial((prev) => (prev + 1) % testimonials.length);
@@ -162,53 +94,11 @@ export function SqAgentHeroSection({
               </P>
 
               {/* Email CTA */}
-              <div className="w-full max-w-md">
-                {hasSession ? (
-                  <div className="flex flex-col items-start gap-3">
-                    <Button
-                      variant="highlight"
-                      size="md"
-                      label="Open Dust"
-                      icon={ArrowRightIcon}
-                      onClick={withTracking(
-                        TRACKING_AREAS.HOME,
-                        "sqagent_hero_open_dust",
-                        () => {
-                          window.location.href = "/api/login";
-                        }
-                      )}
-                    />
-                    <p className="text-sm text-muted-foreground">
-                      Welcome back! Continue where you left off.
-                    </p>
-                  </div>
-                ) : (
-                  <form onSubmit={handleSubmit}>
-                    <div className="flex w-full items-center gap-2 rounded-xl border border-gray-200 bg-white p-1.5 shadow-md">
-                      <input
-                        type="email"
-                        value={email}
-                        onChange={(e) => setEmail(e.target.value)}
-                        placeholder="Enter your work email"
-                        className="flex-1 border-none bg-transparent px-3 py-2 text-base text-gray-700 placeholder-gray-400 outline-none focus:ring-0"
-                        disabled={isLoading}
-                      />
-                      <button
-                        type="submit"
-                        disabled={isLoading}
-                        className="flex items-center gap-2 rounded-lg bg-blue-500 px-5 py-2.5 font-semibold text-white shadow-sm transition-all hover:bg-blue-600 hover:shadow-md disabled:opacity-70"
-                      >
-                        {isLoading && <Spinner size="xs" />}
-                        {ctaButtonText}
-                        <ArrowRightIcon className="h-4 w-4" />
-                      </button>
-                    </div>
-                    {error && (
-                      <p className="mt-2 text-sm text-red-500">{error}</p>
-                    )}
-                  </form>
-                )}
-              </div>
+              <LandingEmailSignup
+                ctaButtonText={ctaButtonText}
+                trackingLocation="sqagent_hero"
+                className="w-full max-w-md"
+              />
 
               {/* Rotating Testimonial */}
               <div className="mt-10 w-full">

--- a/front/next.config.js
+++ b/front/next.config.js
@@ -388,6 +388,13 @@ const config = {
         destination: "/",
         permanent: true,
       },
+      // Podcast landing pages
+      {
+        source: "/skip",
+        destination:
+          "/landing/skip?utm_source=podcast&utm_campaign=skip&utm_event=listener",
+        permanent: false,
+      },
     ];
   },
   poweredByHeader: false,

--- a/front/pages/landing/skip.tsx
+++ b/front/pages/landing/skip.tsx
@@ -1,0 +1,93 @@
+import type { ReactElement } from "react";
+
+import { AgentBuilderVisual } from "@app/components/home/content/Skip/AgentBuilderVisual";
+import { CareerAdvantageVisual } from "@app/components/home/content/Skip/CareerAdvantageVisual";
+import { skipConfig } from "@app/components/home/content/Skip/config/skipConfig";
+import { FeatureSection } from "@app/components/home/content/SqAgent/FeatureSection";
+import { SqAgentHeroSection } from "@app/components/home/content/SqAgent/SqAgentHeroSection";
+import { SqCtaSection } from "@app/components/home/content/SqAgent/SqCtaSection";
+import { SqTestimonialsSection } from "@app/components/home/content/SqAgent/SqTestimonialsSection";
+import { H4 } from "@app/components/home/ContentComponents";
+import type { LandingLayoutProps } from "@app/components/home/LandingLayout";
+import LandingLayout from "@app/components/home/LandingLayout";
+import { PageMetadata } from "@app/components/home/PageMetadata";
+import TrustedBy from "@app/components/home/TrustedBy";
+
+const SECTION_VISUALS = [<CareerAdvantageVisual />, <AgentBuilderVisual />];
+
+export async function getStaticProps() {
+  return {
+    props: {
+      shape: 0,
+    },
+  };
+}
+
+export default function SkipLandingPage() {
+  return (
+    <>
+      <PageMetadata
+        title="Welcome Skip Listeners | Dust"
+        description="Build AI agents in minutes, not months. Dust lets you create custom AI teammates that work across all your tools—no code required."
+        pathname="/landing/skip"
+      />
+
+      {/* Hero Section */}
+      <SqAgentHeroSection
+        chip={skipConfig.hero.chip}
+        headline={skipConfig.hero.headline}
+        subheadline={skipConfig.hero.subheadline}
+        ctaButtonText={skipConfig.hero.ctaButtonText}
+        testimonials={skipConfig.hero.testimonials}
+        videos={skipConfig.hero.videos}
+        usersCount={skipConfig.hero.usersCount}
+      />
+
+      {/* Trusted By Section */}
+      <div className="mt-8">
+        <H4 className="mb-6 w-full text-center text-muted-foreground">
+          {skipConfig.trustedByTitle}
+        </H4>
+        <TrustedBy showTitle={false} logoSet="landing" />
+      </div>
+
+      {/* Feature Sections */}
+      {skipConfig.sections.map((section, index) => (
+        <FeatureSection
+          key={index}
+          title={section.title}
+          titleHighlight={section.titleHighlight}
+          description={section.description}
+          features={section.features}
+          image={section.image}
+          imagePosition={section.imagePosition}
+          backgroundColor={section.backgroundColor}
+          colorIndex={index}
+          visualComponent={SECTION_VISUALS[index]}
+        />
+      ))}
+
+      {/* Testimonials Section */}
+      <SqTestimonialsSection
+        title={skipConfig.bottomTestimonials.title}
+        subtitle={skipConfig.bottomTestimonials.subtitle}
+        testimonials={skipConfig.bottomTestimonials.testimonials}
+      />
+
+      {/* CTA Section */}
+      <SqCtaSection
+        title={skipConfig.cta.title}
+        subtitle={skipConfig.cta.subtitle}
+        ctaText={skipConfig.cta.ctaText}
+        ctaLink={skipConfig.cta.ctaLink}
+      />
+    </>
+  );
+}
+
+SkipLandingPage.getLayout = (
+  page: ReactElement,
+  pageProps: LandingLayoutProps
+) => {
+  return <LandingLayout pageProps={pageProps}>{page}</LandingLayout>;
+};


### PR DESCRIPTION











## Description

Add Skip podcast landing page at `/landing/skip` with custom visuals and refactor SqAgent email signup. The page targets podcast listeners from Nikhyl's "Skip" show with a career-focused message about AI agents.

This PR extracts shared landing page components (LandingEmailSignup, LandingHeroSection, LandingCtaSection) and deduplicates ~50 lines from SqAgentHeroSection by reusing LandingEmailSignup. It also adds two custom visual components (CareerAdvantageVisual and AgentBuilderVisual) that replace generic placeholders with mock UI representations, and enhances FeatureSection to accept custom React components via `visualComponent` prop.

A `/skip` redirect is added with UTM parameters to track podcast traffic.

## Risk

Low. New landing page with minimal impact on existing code. The refactoring of SqAgentHeroSection removes duplicated code but maintains identical functionality.

## Tests

Verify landing pages render correctly at `/landing/skip` and `/landing/sqagent`, and check that email signup CTAs still work. Test the `/skip` redirect with proper UTM params.

## Deploy Plan

Deploy front only.
