### PR TITLE
feat: update warning ui

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -11,7 +11,7 @@ import {
   ConversationMessageContainer,
   ConversationMessageContent,
   ConversationMessageTitle,
-  ExclamationCircleIcon,
+  InformationCircleIcon,
   InteractiveImageGrid,
   LinkIcon,
   MoreIcon,
@@ -99,13 +99,23 @@ import { assertNever } from "@app/types/shared/utils/assert_never";
 function PrunedContextChip() {
   return (
     <Tooltip
-      label="Some tool results were too large and removed to keep this conversation within its context size limit. The answer may be less accurate or miss details."
+      label={
+        <div className="flex flex-col gap-2">
+          <div className="font-semibold">Context window limit reached</div>
+          <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+            Some tool results were removed to keep this conversation within its
+            size limit. For more accurate results, try narrowing your query or
+            starting a new conversation.
+          </div>
+        </div>
+      }
+      className="max-w-md"
       trigger={
         <Chip
-          label="Answer may be inaccurate"
+          label="Context limit reached"
           size="xs"
-          color="golden"
-          icon={ExclamationCircleIcon}
+          color="white"
+          icon={InformationCircleIcon}
         />
       }
     />

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -100,7 +100,7 @@ function PrunedContextChip() {
   return (
     <Tooltip
       label={
-        <div className="flex flex-col gap-2">
+        <div className="flex flex-col gap-2 py-2">
           <div className="font-semibold">Context window limit reached</div>
           <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
             Some tool results were removed to keep this conversation within its


### PR DESCRIPTION
## Description

Updates the warning message when conversation history exceeds the context window and last tool results are pruned to keep the conversation within limits because warning was reflecting poorly on Dust

from (with hover / tooltip):
<img width="813" height="270" alt="image" src="https://github.com/user-attachments/assets/ef087811-c9b7-4865-94d5-a003b00b4c5b" />
 to:
 
<img width="822" height="279" alt="image" src="https://github.com/user-attachments/assets/e23eda42-d96b-4bda-b179-f92a26421582" />


## Tests

local

## Risk

no

## Deploy Plan

front
