### PR TITLE
[dust-hive] Fix local dev env vars and workspace switcher fallback

### DIFF
--- a/front/components/UserMenu.tsx
+++ b/front/components/UserMenu.tsx
@@ -43,7 +43,12 @@ import type {
   UserTypeWithWorkspaces,
   WorkspaceType,
 } from "@app/types";
-import { isOnlyAdmin, isOnlyBuilder, isOnlyUser } from "@app/types";
+import {
+  isDevelopment,
+  isOnlyAdmin,
+  isOnlyBuilder,
+  isOnlyUser,
+} from "@app/types";
 
 interface UserMenuProps {
   user: UserTypeWithWorkspaces;
@@ -113,9 +118,16 @@ export function UserMenu({ user, owner, subscription }: UserMenuProps) {
     [owner, sendNotification, featureFlags, router]
   );
 
-  // Check if user has multiple workspaces
+  // Check if user has multiple workspaces (from WorkOS orgs, or in dev
+  // mode from local DB workspaces as fallback).
   const hasMultipleWorkspaces = useMemo(() => {
-    return user.organizations && user.organizations.length > 1;
+    const hasMultipleOrgs =
+      !!user.organizations && user.organizations.length > 1;
+    const hasMultipleLocalWorkspaces =
+      isDevelopment() &&
+      !user.organizations?.length &&
+      user.workspaces.length > 1;
+    return hasMultipleOrgs || hasMultipleLocalWorkspaces;
   }, [user]);
 
   return (

--- a/front/components/pages/onboarding/SubscribePage.tsx
+++ b/front/components/pages/onboarding/SubscribePage.tsx
@@ -18,6 +18,7 @@ import {
 } from "@app/lib/swr/workspaces";
 import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 import type { BillingPeriod } from "@app/types";
+import { isDevelopment } from "@app/types";
 
 export function SubscribePage() {
   const { workspace, isAdmin } = useAuth();
@@ -106,9 +107,13 @@ export function SubscribePage() {
         rightActions={
           <>
             <div className="flex flex-row items-center">
-              {user?.organizations && user.organizations.length > 1 && (
-                <WorkspacePicker user={user} workspace={workspace} />
-              )}
+              {user &&
+                (!!(user.organizations && user.organizations.length > 1) ||
+                  (isDevelopment() &&
+                    !user.organizations?.length &&
+                    user.workspaces.length > 1)) && (
+                  <WorkspacePicker user={user} workspace={workspace} />
+                )}
               <div>
                 {user && (
                   <UserMenu user={user} owner={workspace} subscription={null} />

--- a/front/components/pages/onboarding/SubscribePage.tsx
+++ b/front/components/pages/onboarding/SubscribePage.tsx
@@ -99,6 +99,15 @@ export function SubscribePage() {
     subscriptions.length === 0 ||
     (subscriptions.length === 1 && isOldFreePlan(subscriptions[0].plan.code)); // FREE_TEST_PLAN did not pay, they should be asked to start instead of resume
 
+  // Show workspace picker if user has multiple WorkOS orgs, or in dev
+  // mode fall back to local DB workspaces (no orgs in seeded envs).
+  const shouldShowPicker =
+    !!(user?.organizations && user.organizations.length > 1) ||
+    (isDevelopment() &&
+      !user?.organizations?.length &&
+      !!user &&
+      user.workspaces.length > 1);
+
   return (
     <>
       <BarHeader
@@ -107,13 +116,9 @@ export function SubscribePage() {
         rightActions={
           <>
             <div className="flex flex-row items-center">
-              {user &&
-                (!!(user.organizations && user.organizations.length > 1) ||
-                  (isDevelopment() &&
-                    !user.organizations?.length &&
-                    user.workspaces.length > 1)) && (
-                  <WorkspacePicker user={user} workspace={workspace} />
-                )}
+              {user && shouldShowPicker && (
+                <WorkspacePicker user={user} workspace={workspace} />
+              )}
               <div>
                 {user && (
                   <UserMenu user={user} owner={workspace} subscription={null} />

--- a/front/pages/no-workspace.tsx
+++ b/front/pages/no-workspace.tsx
@@ -91,6 +91,15 @@ export default function NoWorkspace({
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const { user } = useUser();
 
+  // Show workspace picker if user has multiple WorkOS orgs, or in dev
+  // mode fall back to local DB workspaces (no orgs in seeded envs).
+  const shouldShowPicker =
+    !!(user?.organizations && user.organizations.length > 1) ||
+    (isDevelopment() &&
+      !user?.organizations?.length &&
+      !!user &&
+      user.workspaces.length > 1);
+
   return (
     <Page variant="normal">
       <BarHeader
@@ -98,13 +107,9 @@ export default function NoWorkspace({
         className="ml-10 lg:ml-0"
         rightActions={
           <div className="flex flex-row items-center">
-            {user &&
-              (!!(user.organizations && user.organizations.length > 1) ||
-                (isDevelopment() &&
-                  !user.organizations?.length &&
-                  user.workspaces.length > 1)) && (
-                <WorkspacePicker user={user} workspace={workspace} />
-              )}
+            {user && shouldShowPicker && (
+              <WorkspacePicker user={user} workspace={workspace} />
+            )}
             <div>
               {user && (
                 <UserMenu user={user} owner={workspace} subscription={null} />

--- a/front/pages/no-workspace.tsx
+++ b/front/pages/no-workspace.tsx
@@ -13,6 +13,7 @@ import { useUser } from "@app/lib/swr/user";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
 import type { WorkspaceType } from "@app/types";
+import { isDevelopment } from "@app/types";
 
 export const getServerSideProps = withDefaultUserAuthPaywallWhitelisted<{
   workspace: WorkspaceType;
@@ -97,9 +98,13 @@ export default function NoWorkspace({
         className="ml-10 lg:ml-0"
         rightActions={
           <div className="flex flex-row items-center">
-            {user?.organizations && user.organizations.length > 1 && (
-              <WorkspacePicker user={user} workspace={workspace} />
-            )}
+            {user &&
+              (!!(user.organizations && user.organizations.length > 1) ||
+                (isDevelopment() &&
+                  !user.organizations?.length &&
+                  user.workspaces.length > 1)) && (
+                <WorkspacePicker user={user} workspace={workspace} />
+              )}
             <div>
               {user && (
                 <UserMenu user={user} owner={workspace} subscription={null} />

--- a/x/henry/dust-hive/src/lib/envgen.ts
+++ b/x/henry/dust-hive/src/lib/envgen.ts
@@ -68,8 +68,6 @@ export TEXT_EXTRACTION_URL=http://localhost:${ports.apacheTika}
 export DUST_US_URL=http://localhost:${ports.front}
 export DUST_EU_URL=http://localhost:${ports.front}
 export DEFAULT_DUST_API_DOMAIN=http://localhost:${ports.front}
-export WORKOS_DOMAIN=api.workos.com
-export WORKOS_CLAIM_NAMESPACE="https://dust.tt/"
 `;
 }
 

--- a/x/henry/dust-hive/src/lib/envgen.ts
+++ b/x/henry/dust-hive/src/lib/envgen.ts
@@ -63,6 +63,13 @@ export QDRANT_CLUSTER_0_URL=http://127.0.0.1:${ports.qdrantGrpc}
 export QDRANT_USE_SHARDING=false
 export ELASTICSEARCH_URL=http://localhost:${ports.elasticsearch}
 export TEXT_EXTRACTION_URL=http://localhost:${ports.apacheTika}
+
+# === Region & auth overrides (used by front cross-region and Dust CLI) ===
+export DUST_US_URL=http://localhost:${ports.front}
+export DUST_EU_URL=http://localhost:${ports.front}
+export DEFAULT_DUST_API_DOMAIN=http://localhost:${ports.front}
+export WORKOS_DOMAIN=api.workos.com
+export WORKOS_CLAIM_NAMESPACE="https://dust.tt/"
 `;
 }
 


### PR DESCRIPTION
## Description

Fixes two issues when using dust-hive local dev environments:

1. **CLI and front cross-region called production**: `config.env` sets `DUST_US_URL=https://dust.tt`, which was never overridden by `env.sh`. This caused the Dust CLI to authenticate against production and `front/lib/api/regions/config.ts` to route cross-region lookups to production. Fixed by adding `DUST_US_URL`, `DUST_EU_URL`, `DEFAULT_DUST_API_DOMAIN`, `WORKOS_DOMAIN`, and `WORKOS_CLAIM_NAMESPACE` overrides to the generated `env.sh`.

2. **Workspace switcher showed WorkOS orgs instead of local workspaces**: The `WorkspacePicker` only rendered `user.organizations` (from WorkOS production API). Since seeded workspaces have no `workOSOrganizationId`, they never appeared. Added a dev-only fallback (`isDevelopment()` gated) to show `user.workspaces` from the local DB when no WorkOS organizations exist.

## Risks

Blast radius: dust-hive env generation + workspace picker in dev mode only
Risk: none

## Deploy Plan

- No deployment needed (dust-hive is a local tool, front changes are gated behind `isDevelopment()`)