### PR TITLE
[Dust Hive] Ensure MCP server views after first warm

### DIFF
--- a/x/henry/dust-hive/src/commands/warm.ts
+++ b/x/henry/dust-hive/src/commands/warm.ts
@@ -1,16 +1,19 @@
 import { setCacheSource } from "../lib/cache";
 import { withEnvironment } from "../lib/commands";
 import { startDocker } from "../lib/docker";
+import type { Environment } from "../lib/environment";
 import { isInitialized, markInitialized } from "../lib/environment";
 import { startForwarder } from "../lib/forward";
 import { FORWARDER_PORTS } from "../lib/forwarderConfig";
 import { createTemporalNamespaces, runAllDbInits, runSeedScript } from "../lib/init";
 import { logger } from "../lib/logger";
+import { getEnvFilePath, getWorktreeDir } from "../lib/paths";
 import { cleanupServicePorts, formatBlockedPorts } from "../lib/ports";
 import { isServiceRunning, readPid } from "../lib/process";
 import { startService, waitForServiceReady } from "../lib/registry";
 import { CommandError, Err, Ok } from "../lib/result";
 import type { ServiceName } from "../lib/services";
+import { buildShell } from "../lib/shell";
 import { isDockerRunning } from "../lib/state";
 
 interface WarmOptions {
@@ -26,6 +29,9 @@ const CRITICAL_ROUTES = [
   "/api/poke/auth-context", // Poke auth context API (no workspace)
   "/api/poke/workspaces/precompile/auth-context", // Poke auth context API (with workspace)
 ];
+
+const ENSURE_MCP_SERVER_VIEWS_COMMAND =
+  "npx tsx ./scripts/ensure_all_mcp_server_views_created.ts --execute";
 
 // Start pre-warming critical Next.js routes immediately (with retry)
 // Uses curl --retry to wait for server to be available, then triggers compilation
@@ -70,6 +76,41 @@ async function isTemporalRunning(): Promise<boolean> {
   });
   await proc.exited;
   return proc.exitCode === 0;
+}
+
+async function ensureAllMCPServerViewsCreated(env: Environment): Promise<void> {
+  const envShPath = getEnvFilePath(env.name);
+  const worktreePath = getWorktreeDir(env.name);
+
+  const command = buildShell({
+    sourceEnv: envShPath,
+    sourceNvm: true,
+    run: ENSURE_MCP_SERVER_VIEWS_COMMAND,
+  });
+
+  const proc = Bun.spawn(["bash", "-c", command], {
+    cwd: `${worktreePath}/front`,
+    env: process.env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const stdout = await new Response(proc.stdout).text();
+  const stderr = await new Response(proc.stderr).text();
+  await proc.exited;
+
+  if (proc.exitCode !== 0) {
+    logger.warn("Failed to ensure MCP server views are created. Continuing.");
+    if (stdout.trim()) {
+      logger.info(`MCP server views ensure stdout:\n${stdout.trim()}`);
+    }
+    if (stderr.trim()) {
+      logger.warn(`MCP server views ensure stderr:\n${stderr.trim()}`);
+    }
+    return;
+  }
+
+  logger.success("Ensured MCP server views are created for all workspaces");
 }
 
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: orchestration function with necessary complexity
@@ -240,6 +281,11 @@ export const warmCommand = withEnvironment("warm", async (env, options: WarmOpti
     waitForServiceReady(env, "oauth"),
   ]);
   logger.success("All services healthy");
+
+  if (needsInit) {
+    logger.step("Ensuring MCP server views are created for all workspaces...");
+    await ensureAllMCPServerViewsCreated(env);
+  }
 
   const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
   console.log();

--- a/x/henry/dust-hive/src/commands/warm.ts
+++ b/x/henry/dust-hive/src/commands/warm.ts
@@ -32,6 +32,7 @@ const CRITICAL_ROUTES = [
 
 const ENSURE_MCP_SERVER_VIEWS_COMMAND =
   "npx tsx ./scripts/ensure_all_mcp_server_views_created.ts --execute";
+const MCP_SERVER_VIEWS_ERROR_SUMMARY_PATTERN = /Migration completed with \d+ errors/;
 
 // Start pre-warming critical Next.js routes immediately (with retry)
 // Uses curl --retry to wait for server to be available, then triggers compilation
@@ -107,6 +108,13 @@ async function ensureAllMCPServerViewsCreated(env: Environment): Promise<void> {
     if (stderr.trim()) {
       logger.warn(`MCP server views ensure stderr:\n${stderr.trim()}`);
     }
+    return;
+  }
+
+  if (MCP_SERVER_VIEWS_ERROR_SUMMARY_PATTERN.test(stdout + stderr)) {
+    logger.warn(
+      "MCP server view ensure script completed with workspace errors. Check script logs for details."
+    );
     return;
   }
 


### PR DESCRIPTION
## Description
Fixes an issue where on a freshly warmed env, if talking to @dust and it decides to use tools, it fails.

On first `dust-hive warm`, run `front/scripts/ensure_all_mcp_server_views_created.ts --execute` after the env is healthy, for all workspaces.

Failures are logged as warnings and warm continues.

## Risks
Blast radius: `dust-hive warm` post-initialization flow in local dev environments.
Risk: low

## Deploy Plan
- pmrr
- none (local `dust-hive` tooling change)

## Test
- [x] `bun test` in `x/henry/dust-hive`