### PR TITLE
Fix TipTap Range Error on Invalid Angle Bracketed Tags

### DIFF
--- a/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
+++ b/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
@@ -30,6 +30,7 @@ import {
   cleanupPastedHTML,
   stripHtmlAttributes,
 } from "@app/components/editor/input_bar/cleanupPastedHTML";
+import { escapeUnrecognizedHtmlTags } from "@app/components/editor/lib/escapeUnrecognizedHtmlTags";
 import { LinkExtension } from "@app/components/editor/input_bar/LinkExtension";
 import { createMentionSuggestion } from "@app/components/editor/input_bar/mentionSuggestion";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
@@ -280,10 +281,13 @@ export function AgentBuilderInstructionsEditor({
           emitUpdate: false,
         });
       } else if (field.value) {
-        editor.commands.setContent(field.value, {
-          emitUpdate: false,
-          contentType: "markdown",
-        });
+        editor.commands.setContent(
+          escapeUnrecognizedHtmlTags(field.value, editor.schema),
+          {
+            emitUpdate: false,
+            contentType: "markdown",
+          }
+        );
       }
 
       // Then focus after content is set
@@ -354,10 +358,13 @@ export function AgentBuilderInstructionsEditor({
               emitUpdate: false,
             });
           } else {
-            editor.commands.setContent(field.value, {
-              emitUpdate: false,
-              contentType: "markdown",
-            });
+            editor.commands.setContent(
+              escapeUnrecognizedHtmlTags(field.value, editor.schema),
+              {
+                emitUpdate: false,
+                contentType: "markdown",
+              }
+            );
           }
         }
       });

--- a/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
+++ b/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
@@ -30,9 +30,9 @@ import {
   cleanupPastedHTML,
   stripHtmlAttributes,
 } from "@app/components/editor/input_bar/cleanupPastedHTML";
-import { escapeUnrecognizedHtmlTags } from "@app/components/editor/lib/escapeUnrecognizedHtmlTags";
 import { LinkExtension } from "@app/components/editor/input_bar/LinkExtension";
 import { createMentionSuggestion } from "@app/components/editor/input_bar/mentionSuggestion";
+import { escapeUnrecognizedHtmlTags } from "@app/components/editor/lib/escapeUnrecognizedHtmlTags";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import type { LightAgentConfigurationType } from "@app/types";
 

--- a/front/components/editor/extensions/agent_builder/InstructionSuggestionExtension.test.ts
+++ b/front/components/editor/extensions/agent_builder/InstructionSuggestionExtension.test.ts
@@ -13,8 +13,8 @@ import {
   InstructionSuggestionExtension,
   SUGGESTION_ID_ATTRIBUTE,
 } from "@app/components/editor/extensions/agent_builder/InstructionSuggestionExtension";
-import { escapeUnrecognizedHtmlTags } from "@app/components/editor/lib/escapeUnrecognizedHtmlTags";
 import { EditorFactory } from "@app/components/editor/extensions/tests/utils";
+import { escapeUnrecognizedHtmlTags } from "@app/components/editor/lib/escapeUnrecognizedHtmlTags";
 
 function getDeletions(editor: Editor) {
   return Array.from(
@@ -542,11 +542,17 @@ describe("InstructionSuggestionExtension", () => {
         "Test <p> and <code>",
         editor.state.schema
       );
-      // Tags recognized by the schema should not be escaped.
+      // Tags recognized by the schema should be left untouched.
       expect(escaped).toContain("<p>");
       expect(escaped).toContain("<code>");
-      expect(escaped).not.toContain("&lt;p&gt;");
-      expect(escaped).not.toContain("&lt;code&gt;");
+    });
+
+    it("should strip brackets from unrecognized tags", () => {
+      const escaped = escapeUnrecognizedHtmlTags(
+        "Test <URL>",
+        editor.state.schema
+      );
+      expect(escaped).toBe("Test URL");
     });
 
     it("should handle multiple unrecognized tags", () => {

--- a/front/components/editor/lib/escapeUnrecognizedHtmlTags.ts
+++ b/front/components/editor/lib/escapeUnrecognizedHtmlTags.ts
@@ -2,8 +2,9 @@ import type { Schema, TagParseRule } from "@tiptap/pm/model";
 import { DOMParser as PMDOMParser } from "@tiptap/pm/model";
 
 /**
- * Workaround for tiptap/markdown #7256: escape <WORD> tokens that the schema
- * doesn't recognize as HTML, preventing block-in-inline schema violations.
+ * Workaround for tiptap/markdown #7256: strip angle brackets from <WORD> tokens
+ * that the schema doesn't recognize as HTML, preventing block-in-inline schema
+ * violations. Recognized tags (e.g. <p>, <code>) are left untouched.
  *
  * TODO: Remove when tiptap merges https://github.com/ueberdosis/tiptap/pull/7260
  */
@@ -22,8 +23,8 @@ export function escapeUnrecognizedHtmlTags(
     if (recognized.has(tag.toLowerCase())) {
       return match;
     }
-    // Use HTML entities so `marked` treats them as literal text, not as an
-    // HTML tag (which would cause the block-in-inline schema violation).
-    return `&lt;${tag}&gt;`;
+
+    // Strip the angle brackets, return the text content of the tag.
+    return tag;
   });
 }

--- a/front/components/editor/lib/escapeUnrecognizedHtmlTags.ts
+++ b/front/components/editor/lib/escapeUnrecognizedHtmlTags.ts
@@ -1,0 +1,29 @@
+import type { Schema, TagParseRule } from "@tiptap/pm/model";
+import { DOMParser as PMDOMParser } from "@tiptap/pm/model";
+
+/**
+ * Workaround for tiptap/markdown #7256: escape <WORD> tokens that the schema
+ * doesn't recognize as HTML, preventing block-in-inline schema violations.
+ *
+ * TODO: Remove when tiptap merges https://github.com/ueberdosis/tiptap/pull/7260
+ */
+export function escapeUnrecognizedHtmlTags(
+  markdown: string,
+  schema: Schema
+): string {
+  const recognized = new Set(
+    PMDOMParser.fromSchema(schema)
+      .rules.filter((r): r is TagParseRule => "tag" in r)
+      .map((r) => r.tag.match(/^([a-z][a-z0-9]*)/i)?.[1]?.toLowerCase())
+      .filter(Boolean)
+  );
+
+  return markdown.replace(/<([A-Za-z][A-Za-z0-9]*)>/g, (match, tag) => {
+    if (recognized.has(tag.toLowerCase())) {
+      return match;
+    }
+    // Use HTML entities so `marked` treats them as literal text, not as an
+    // HTML tag (which would cause the block-in-inline schema violation).
+    return `&lt;${tag}&gt;`;
+  });
+}


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
It resolves https://github.com/dust-tt/tasks/issues/6413.

This PR:
- fixes `RangeError: Invalid content for node type paragraph` crash when markdown contains angle-bracketed tokens
like `<URL>` that marked lexes as inline HTML
- adds `escapeUnrecognizedHtmlTags` helper that derives recognized tags from the editor's `ProseMirror` schema and
escapes unrecognized ones with HTML entities before passing to the markdown parser

### Context

There is a known tiptap bug https://github.com/ueberdosis/tiptap/issues/7256. The lib `@tiptap/markdown`'s `parseHTMLToken` calls `generateJSON` on unrecognized tags which produces block nodes that violate the inline schema. Upstream fix `https://github.com/ueberdosis/tiptap/pull/7260` not yet merged. This workaround can be removed once it is.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
