### PR TITLE
[front] Switch `dust-next` to Opus 4.6

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -46,7 +46,6 @@ import {
   MAX_STEPS_USE_PER_RUN_LIMIT,
 } from "@app/types";
 import { DUST_AVATAR_URL } from "@app/types/assistant/avatar";
-import { CUSTOM_MODEL_CONFIGS } from "@app/types/assistant/models/custom_models.generated";
 
 interface DustLikeGlobalAgentArgs {
   settings: GlobalAgentSettingsModel | null;

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -27,9 +27,10 @@ import type { AgentMemoryResource } from "@app/lib/resources/agent_memory_resour
 import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { buildDiscoverToolsInstructions } from "@app/lib/resources/skill/global/discover_tools";
 import { timeAgoFrom } from "@app/lib/utils";
-import type {
+import {
   AgentConfigurationType,
   AgentModelConfigurationType,
+  CLAUDE_OPUS_4_6_DEFAULT_MODEL_CONFIG,
   ModelConfigurationType,
   ReasoningEffort,
 } from "@app/types";
@@ -554,13 +555,10 @@ export function _getDustNextGlobalAgent(
   auth: Authenticator,
   args: DustLikeGlobalAgentArgs
 ): AgentConfigurationType | null {
-  const customModel = CUSTOM_MODEL_CONFIGS[0];
-
   return _getDustLikeGlobalAgent(auth, args, {
     agentId: GLOBAL_AGENTS_SID.DUST_NEXT,
     name: "dust-next",
-    preferredModelConfiguration:
-      customModel ?? CLAUDE_4_5_OPUS_DEFAULT_MODEL_CONFIG,
+    preferredModelConfiguration: CLAUDE_OPUS_4_6_DEFAULT_MODEL_CONFIG,
     preferredReasoningEffort: "light",
   });
 }

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -27,14 +27,14 @@ import type { AgentMemoryResource } from "@app/lib/resources/agent_memory_resour
 import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { buildDiscoverToolsInstructions } from "@app/lib/resources/skill/global/discover_tools";
 import { timeAgoFrom } from "@app/lib/utils";
-import {
+import type {
   AgentConfigurationType,
   AgentModelConfigurationType,
-  CLAUDE_OPUS_4_6_DEFAULT_MODEL_CONFIG,
   ModelConfigurationType,
   ReasoningEffort,
 } from "@app/types";
 import {
+  CLAUDE_OPUS_4_6_DEFAULT_MODEL_CONFIG,
   CLAUDE_4_5_OPUS_DEFAULT_MODEL_CONFIG,
   CLAUDE_4_5_SONNET_DEFAULT_MODEL_CONFIG,
   GEMINI_3_FLASH_MODEL_CONFIG,

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -34,9 +34,9 @@ import type {
   ReasoningEffort,
 } from "@app/types";
 import {
-  CLAUDE_OPUS_4_6_DEFAULT_MODEL_CONFIG,
   CLAUDE_4_5_OPUS_DEFAULT_MODEL_CONFIG,
   CLAUDE_4_5_SONNET_DEFAULT_MODEL_CONFIG,
+  CLAUDE_OPUS_4_6_DEFAULT_MODEL_CONFIG,
   GEMINI_3_FLASH_MODEL_CONFIG,
   getLargeWhitelistedModel,
   getSmallWhitelistedModel,


### PR DESCRIPTION
## Description

- This PR updates the dust-next global agent to use Opus 4.6.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
