### PR TITLE
Fix file not authorized routing flow for sheets/slides

### DIFF
--- a/front/lib/api/actions/servers/google_drive/tools/index.test.ts
+++ b/front/lib/api/actions/servers/google_drive/tools/index.test.ts
@@ -44,9 +44,7 @@ describe("isFileNotAuthorizedError", () => {
 
   it("should return true for Sheets/Slides API permission errors", () => {
     expect(
-      isFileNotAuthorizedError(
-        new Error("The caller does not have permission")
-      )
+      isFileNotAuthorizedError(new Error("The caller does not have permission"))
     ).toBe(true);
     expect(
       isFileNotAuthorizedError(

--- a/front/lib/api/actions/servers/google_drive/tools/index.test.ts
+++ b/front/lib/api/actions/servers/google_drive/tools/index.test.ts
@@ -42,6 +42,19 @@ describe("isFileNotAuthorizedError", () => {
     ).toBe(true);
   });
 
+  it("should return true for Sheets/Slides API permission errors", () => {
+    expect(
+      isFileNotAuthorizedError(
+        new Error("The caller does not have permission")
+      )
+    ).toBe(true);
+    expect(
+      isFileNotAuthorizedError(
+        new Error("Error: The caller does not have permission [403]")
+      )
+    ).toBe(true);
+  });
+
   it("should return false for other errors", () => {
     expect(isFileNotAuthorizedError(new Error("Permission denied"))).toBe(
       false

--- a/front/lib/api/actions/servers/google_drive/tools/index.ts
+++ b/front/lib/api/actions/servers/google_drive/tools/index.ts
@@ -30,6 +30,10 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
  * Checks if an error indicates the file is not authorized.
  * Google returns 404 when user doesn't have access to a file via drive.file scope,
  * or a permission error when the user hasn't granted write access.
+ *
+ * Different Google APIs return different error messages:
+ * - Docs/Drive API: "The user has not granted the app {appId} write access to the file"
+ * - Sheets/Slides API: "The caller does not have permission"
  */
 export function isFileNotAuthorizedError(err: unknown): boolean {
   const error = normalizeError(err);
@@ -38,7 +42,8 @@ export function isFileNotAuthorizedError(err: unknown): boolean {
     message.includes("404") ||
     message.includes("not found") ||
     message.includes("has not granted") ||
-    message.includes("write access")
+    message.includes("write access") ||
+    message.includes("caller does not have permission")
   );
 }
 


### PR DESCRIPTION
## Description
For most tools (adding comments, updating docs) if we need to open the file picker google sends us a 404 file not authorized error. For some reason on the sheets and slides api they send a different error - a 403 with "caller does not have permission" which we were incorrectly routing to the oauth flow instead of the file picker flow.
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Verified that 403 oauth errors are still properly routed to the google oauth flow
File picker now correctly triggered when the error is at the file permission level instead of tool permission level
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low, still behind FF
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [ ] deploy front
<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
