### PR TITLE
Fix MCP transport base url

### DIFF
--- a/front/lib/client/BrowserMCPTransport.ts
+++ b/front/lib/client/BrowserMCPTransport.ts
@@ -1,7 +1,7 @@
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
 
-import { clientFetch } from "@app/lib/egress/client";
+import { clientFetch, getApiBaseUrl } from "@app/lib/egress/client";
 
 const HEARTBEAT_INTERVAL_MS = 15 * 60 * 1000; // 15 minutes.
 const RECONNECT_DELAY_MS = 5 * 1000; // 5 seconds.
@@ -177,17 +177,17 @@ export class BrowserMCPTransport implements Transport {
     }
 
     // Build URL with query parameters.
-    const url = new URL(
-      `/api/w/${this.workspaceId}/mcp/requests`,
-      window.location.origin
-    );
+    const base = getApiBaseUrl() || window.location.origin;
+    const url = new URL(`/api/w/${this.workspaceId}/mcp/requests`, base);
     url.searchParams.set("serverId", this.serverId);
     if (this.lastEventId) {
       url.searchParams.set("lastEventId", this.lastEventId);
     }
 
     // Create native EventSource (uses session cookies automatically).
-    this.eventSource = new EventSource(url.toString());
+    this.eventSource = new EventSource(url.toString(), {
+      withCredentials: true,
+    });
 
     this.eventSource.onmessage = (event) => {
       try {


### PR DESCRIPTION
## Description

* Via dust-hive, UI can be served from SPA dev server and front a different port. This breaks this base url since window.location.origin can differ from the correct api base url

## Tests

* Local validation

## Risk

* Low

## Deploy Plan

* Deploy front