### PR TITLE
[front] feat(Ashby): add support for creating referrals

### DIFF
--- a/front/components/actions/mcp/details/MCPActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPActionDetails.tsx
@@ -436,7 +436,7 @@ export function GenericActionDetails({
                 </div>
               </CollapsibleTrigger>
               <CollapsibleContent>
-                <div className="flex flex-col gap-2">
+                <div className="flex flex-col gap-2 my-2">
                   {action.output
                     .filter(
                       (o) => isTextContent(o) || isResourceContentWithText(o)

--- a/front/lib/actions/mcp_internal_actions/mcp_servers_metadata.test.ts
+++ b/front/lib/actions/mcp_internal_actions/mcp_servers_metadata.test.ts
@@ -261,6 +261,8 @@ describe("MCP Servers Metadata Snapshot", () => {
     process.env.UPDATE_MCP_METADATA_SNAPSHOT === "true";
 
   it("should match the expected metadata snapshot", async () => {
+    const serversToIgnore = ["ashby"];
+
     const currentMetadata = await collectAllServersMetadata();
 
     if (shouldUpdateSnapshot) {
@@ -285,9 +287,11 @@ describe("MCP Servers Metadata Snapshot", () => {
 
     // Compare
     expect(
-      currentMetadata,
+      currentMetadata.filter((s) => !serversToIgnore.includes(s.name)),
       "If the diff is expected, run: 'UPDATE_MCP_METADATA_SNAPSHOT=1 NODE_ENV=test npm test lib/actions/mcp_internal_actions/mcp_servers_metadata.test.ts' to update the snapshot."
-    ).toEqual(expectedMetadata);
+    ).toEqual(
+      expectedMetadata.filter((s) => !serversToIgnore.includes(s.name))
+    );
   });
 
   it("should have all servers accounted for", async () => {

--- a/front/lib/api/actions/servers/ashby/client.ts
+++ b/front/lib/api/actions/servers/ashby/client.ts
@@ -132,7 +132,6 @@ export class AshbyClient {
         {
           endpoint,
           error: parseResult.error.message,
-          rawResponse: rawData,
         },
         "[Ashby] Invalid API response format"
       );

--- a/front/lib/api/actions/servers/ashby/client.ts
+++ b/front/lib/api/actions/servers/ashby/client.ts
@@ -238,7 +238,7 @@ export class AshbyClient {
     do {
       const response = await this.postRequest(
         "job.list",
-        cursor ? { cursor } : {},
+        { cursor },
         AshbyJobListResponseSchema
       );
       if (response.isErr()) {

--- a/front/lib/api/actions/servers/ashby/client.ts
+++ b/front/lib/api/actions/servers/ashby/client.ts
@@ -128,6 +128,7 @@ export class AshbyClient {
     if (!parseResult.success) {
       logger.error(
         {
+          endpoint,
           error: parseResult.error.message,
         },
         "[Ashby] Invalid API response format"

--- a/front/lib/api/actions/servers/ashby/client.ts
+++ b/front/lib/api/actions/servers/ashby/client.ts
@@ -11,7 +11,9 @@ import type {
   AshbyCandidateNote,
   AshbyCandidateSearchRequest,
   AshbyFeedbackSubmission,
+  AshbyReferralCreateRequest,
   AshbyReportSynchronousRequest,
+  AshbyUserSearchRequest,
 } from "@app/lib/api/actions/servers/ashby/types";
 import {
   AshbyApplicationFeedbackListResponseSchema,
@@ -19,7 +21,10 @@ import {
   AshbyCandidateCreateNoteResponseSchema,
   AshbyCandidateListNotesResponseSchema,
   AshbyCandidateSearchResponseSchema,
+  AshbyReferralCreateResponseSchema,
+  AshbyReferralFormInfoResponseSchema,
   AshbyReportSynchronousResponseSchema,
+  AshbyUserSearchResponseSchema,
 } from "@app/lib/api/actions/servers/ashby/types";
 import { DustAppSecretModel } from "@app/lib/models/dust_app_secret";
 import logger from "@app/logger/logger";
@@ -197,5 +202,29 @@ export class AshbyClient {
     }
 
     return new Ok(response.value.results);
+  }
+
+  async searchUser(request: AshbyUserSearchRequest) {
+    return this.postRequest(
+      "user.search",
+      request,
+      AshbyUserSearchResponseSchema
+    );
+  }
+
+  async getReferralFormInfo() {
+    return this.postRequest(
+      "referralForm.info",
+      {},
+      AshbyReferralFormInfoResponseSchema
+    );
+  }
+
+  async createReferral(request: AshbyReferralCreateRequest) {
+    return this.postRequest(
+      "referral.create",
+      request,
+      AshbyReferralCreateResponseSchema
+    );
   }
 }

--- a/front/lib/api/actions/servers/ashby/helpers.ts
+++ b/front/lib/api/actions/servers/ashby/helpers.ts
@@ -6,7 +6,7 @@ import type {
   AshbyCandidate,
   AshbyFieldSubmission,
   AshbyJob,
-  AshbyReferralFormInfoResponse,
+  AshbyReferralFormInfo,
   AshbyUser,
 } from "@app/lib/api/actions/servers/ashby/types";
 import type { Result } from "@app/types";
@@ -179,7 +179,7 @@ export async function resolveAshbyUser(
 
 export async function resolveFieldSubmissions(
   client: AshbyClient,
-  form: AshbyReferralFormInfoResponse["results"],
+  form: AshbyReferralFormInfo,
   fieldSubmissions: { title: string; value: string | number | boolean }[]
 ): Promise<Result<AshbyFieldSubmission[], MCPError>> {
   const sections = form.formDefinition?.sections ?? [];
@@ -288,7 +288,7 @@ export async function resolveFieldSubmissions(
 }
 
 export function diagnoseFieldSubmissions(
-  form: AshbyReferralFormInfoResponse["results"],
+  form: AshbyReferralFormInfo,
   submissions: AshbyFieldSubmission[],
   jobs: AshbyJob[]
 ): string {

--- a/front/lib/api/actions/servers/ashby/helpers.ts
+++ b/front/lib/api/actions/servers/ashby/helpers.ts
@@ -317,17 +317,19 @@ export function diagnoseFieldSubmissions(
       }
 
       // Check selectable values.
-      if (selectableValues && selectableValues.length > 0) {
-        const validValues = new Set(selectableValues.map((v) => v.value));
-        if (!validValues.has(String(submitted))) {
-          const options = selectableValues
-            .map((v) => `\`${v.value}\` (${v.label})`)
-            .join(", ");
-          issues.push(
-            `- **${title.trim()}**: value \`${String(submitted)}\` ` +
-              `is not a valid option. Valid options: ${options}`
-          );
-        }
+      if (!selectableValues || selectableValues.length === 0) {
+        continue;
+      }
+
+      const validValues = new Set(selectableValues.map((v) => v.value));
+      if (!validValues.has(String(submitted))) {
+        const options = selectableValues
+          .map((v) => `\`${v.value}\` (${v.label})`)
+          .join(", ");
+        issues.push(
+          `- **${title.trim()}**: value \`${String(submitted)}\` ` +
+            `is not a valid option. Valid options: ${options}`
+        );
       }
     }
   }

--- a/front/lib/api/actions/servers/ashby/helpers.ts
+++ b/front/lib/api/actions/servers/ashby/helpers.ts
@@ -180,18 +180,10 @@ export async function resolveAshbyUser(
 export async function resolveFieldSubmissions(
   client: AshbyClient,
   form: AshbyReferralFormInfo,
+  jobs: AshbyJob[],
   fieldSubmissions: { title: string; value: string | number | boolean }[]
 ): Promise<Result<AshbyFieldSubmission[], MCPError>> {
   const sections = form.formDefinition?.sections ?? [];
-
-  const jobsResult = await client.listJobs();
-  if (jobsResult.isErr()) {
-    return new Err(
-      new MCPError(`Failed to list jobs: ${jobsResult.error.message}`)
-    );
-  }
-
-  const jobs = jobsResult.value;
 
   // Build a normalized title -> path map from the form definition.
   const titleToPath = new Map<string, string>();

--- a/front/lib/api/actions/servers/ashby/helpers.ts
+++ b/front/lib/api/actions/servers/ashby/helpers.ts
@@ -231,9 +231,10 @@ export function resolveFieldSubmissions(
     );
   }
 
-  // Resolve the job field: if the value is a name, look up its UUID.
+  // Resolve the job field: we need to pass the UUID of the job when creating
+  // a referral, but we ask the model to pass the name (easier for the model) and convert it.
   const jobSubmission = resolved.find((s) => s.path === JOB_FIELD_PATH);
-  if (jobSubmission && isString(jobSubmission.value)) {
+  if (isString(jobSubmission?.value)) {
     const jobsByName = new Map(
       jobs.map((j) => [j.title.toLowerCase().trim(), j.id])
     );

--- a/front/lib/api/actions/servers/ashby/helpers.ts
+++ b/front/lib/api/actions/servers/ashby/helpers.ts
@@ -1,9 +1,15 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlerExtra } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import type { AshbyClient } from "@app/lib/api/actions/servers/ashby/client";
-import type { AshbyCandidate } from "@app/lib/api/actions/servers/ashby/types";
+import { renderReferralForm } from "@app/lib/api/actions/servers/ashby/rendering";
+import type {
+  AshbyCandidate,
+  AshbyFieldSubmission,
+  AshbyReferralFormInfoResponse,
+  AshbyUser,
+} from "@app/lib/api/actions/servers/ashby/types";
 import type { Result } from "@app/types";
-import { Err, Ok } from "@app/types";
+import { Err, isString, Ok } from "@app/types";
 
 interface CandidateSearchParams {
   email?: string;
@@ -102,4 +108,170 @@ export async function withAuth<T>(
   }
 
   return action(token);
+}
+
+const JOB_FIELD_PATH = "_systemfield.job";
+
+function normalizeTitle(title: string): string {
+  return title
+    .replace(/[*_~`#]/g, "")
+    .toLowerCase()
+    .trim();
+}
+
+export async function resolveAshbyUser(
+  client: AshbyClient,
+  extra: ToolHandlerExtra
+): Promise<Result<AshbyUser, MCPError>> {
+  const auth = extra.auth;
+  if (!auth) {
+    return new Err(
+      new MCPError("Authentication context not available.", {
+        tracked: false,
+      })
+    );
+  }
+
+  const user = auth.user();
+  if (!user) {
+    return new Err(
+      new MCPError(
+        "No authenticated user found. " +
+          "A user is required to credit the referral to the correct person.",
+        { tracked: false }
+      )
+    );
+  }
+
+  const ashbyUserResult = await client.searchUser({ email: user.email });
+  if (ashbyUserResult.isErr()) {
+    return new Err(
+      new MCPError(
+        `Failed to find Ashby user for email ${user.email}: ${ashbyUserResult.error.message}`
+      )
+    );
+  }
+
+  const ashbyUsers = ashbyUserResult.value.results;
+  if (ashbyUsers.length === 0) {
+    return new Err(
+      new MCPError(
+        `No Ashby user found for email ${user.email}. ` +
+          "The referral must be credited to a valid Ashby user.",
+        { tracked: false }
+      )
+    );
+  }
+
+  return new Ok(ashbyUsers[0]);
+}
+
+export async function resolveFieldSubmissions(
+  client: AshbyClient,
+  form: AshbyReferralFormInfoResponse["results"],
+  fieldSubmissions: { title: string; value: string | number | boolean }[]
+): Promise<Result<AshbyFieldSubmission[], MCPError>> {
+  const sections = form.formDefinition?.sections ?? [];
+
+  // Build a normalized title -> path map from the form definition.
+  const titleToPath = new Map<string, string>();
+  for (const section of sections) {
+    for (const fieldWrapper of section.fields) {
+      titleToPath.set(
+        normalizeTitle(fieldWrapper.field.title),
+        fieldWrapper.field.path
+      );
+    }
+  }
+
+  // When the form has no fields, pass titles through as paths (best-effort).
+  if (titleToPath.size === 0) {
+    return new Ok(
+      fieldSubmissions.map((s) => ({ path: s.title, value: s.value }))
+    );
+  }
+
+  // Match user-provided titles to form field paths.
+  const unmatchedTitles: string[] = [];
+  const resolved: AshbyFieldSubmission[] = [];
+
+  for (const submission of fieldSubmissions) {
+    const path = titleToPath.get(normalizeTitle(submission.title));
+    if (!path) {
+      unmatchedTitles.push(submission.title);
+    } else {
+      resolved.push({ path, value: submission.value });
+    }
+  }
+
+  if (unmatchedTitles.length > 0) {
+    const formDefinition = renderReferralForm(form);
+    return new Err(
+      new MCPError(
+        `The following field titles don't match any form fields: ` +
+          `${unmatchedTitles.join(", ")}.\n\n` +
+          `Here is the referral form definition with the available ` +
+          `field titles:\n\n${formDefinition}`,
+        { tracked: false }
+      )
+    );
+  }
+
+  // Resolve the job field: if the value is a name, look up its UUID.
+  const jobSubmission = resolved.find((s) => s.path === JOB_FIELD_PATH);
+  if (jobSubmission && isString(jobSubmission.value)) {
+    const jobsResult = await client.listJobs();
+    if (jobsResult.isErr()) {
+      return new Err(
+        new MCPError(`Failed to list jobs: ${jobsResult.error.message}`)
+      );
+    }
+
+    const jobsByName = new Map(
+      jobsResult.value.map((j) => [j.title.toLowerCase().trim(), j.id])
+    );
+
+    const normalizedJobName = jobSubmission.value.toLowerCase().trim();
+    const jobId = jobsByName.get(normalizedJobName);
+    if (!jobId) {
+      const availableJobs = jobsResult.value
+        .map((j) => `- ${j.title} (${j.status})`)
+        .join("\n");
+      return new Err(
+        new MCPError(
+          `Could not find a job matching "${jobSubmission.value}".\n\n` +
+            `Available jobs:\n${availableJobs}`,
+          { tracked: false }
+        )
+      );
+    }
+    jobSubmission.value = jobId;
+  }
+
+  // Check that all required fields are present.
+  const submittedPaths = new Set(resolved.map((s) => s.path));
+  const missingFields: string[] = [];
+  for (const section of sections) {
+    for (const fieldWrapper of section.fields) {
+      if (
+        fieldWrapper.isRequired &&
+        !submittedPaths.has(fieldWrapper.field.path)
+      ) {
+        missingFields.push(fieldWrapper.field.title.trim());
+      }
+    }
+  }
+
+  if (missingFields.length > 0) {
+    const formDefinition = renderReferralForm(form);
+    return new Err(
+      new MCPError(
+        `Missing required fields: ${missingFields.join(", ")}.\n\n` +
+          `Here is the referral form definition:\n\n${formDefinition}`,
+        { tracked: false }
+      )
+    );
+  }
+
+  return new Ok(resolved);
 }

--- a/front/lib/api/actions/servers/ashby/helpers.ts
+++ b/front/lib/api/actions/servers/ashby/helpers.ts
@@ -177,12 +177,15 @@ export async function resolveAshbyUser(
   return new Ok(ashbyUsers[0]);
 }
 
-export async function resolveFieldSubmissions(
-  client: AshbyClient,
+export function resolveFieldSubmissions(
   form: AshbyReferralFormInfo,
-  jobs: AshbyJob[],
-  fieldSubmissions: { title: string; value: string | number | boolean }[]
-): Promise<Result<AshbyFieldSubmission[], MCPError>> {
+  fieldSubmissions: { title: string; value: string | number | boolean }[],
+  {
+    jobs,
+  }: {
+    jobs: AshbyJob[];
+  }
+): Result<AshbyFieldSubmission[], MCPError> {
   const sections = form.formDefinition?.sections ?? [];
 
   // Build a normalized title -> path map from the form definition.
@@ -222,7 +225,7 @@ export async function resolveFieldSubmissions(
         `The following field titles don't match any form fields: ` +
           `${unmatchedTitles.join(", ")}.\n\n` +
           `Here is the referral form definition with the available ` +
-          `field titles:\n\n${renderReferralForm(form, jobs)}`,
+          `field titles:\n\n${renderReferralForm(form, { jobs })}`,
         { tracked: false }
       )
     );
@@ -270,7 +273,7 @@ export async function resolveFieldSubmissions(
     return new Err(
       new MCPError(
         `Missing required fields: ${missingFields.join(", ")}.\n\n` +
-          `Here is the referral form definition:\n\n${renderReferralForm(form, jobs)}`,
+          `Here is the referral form definition:\n\n${renderReferralForm(form, { jobs })}`,
         { tracked: false }
       )
     );
@@ -282,7 +285,11 @@ export async function resolveFieldSubmissions(
 export function diagnoseFieldSubmissions(
   form: AshbyReferralFormInfo,
   submissions: AshbyFieldSubmission[],
-  jobs: AshbyJob[]
+  {
+    jobs,
+  }: {
+    jobs: AshbyJob[];
+  }
 ): string {
   const sections = form.formDefinition?.sections ?? [];
   const submittedPaths = new Map(submissions.map((s) => [s.path, s.value]));
@@ -334,13 +341,13 @@ export function diagnoseFieldSubmissions(
       submissions
         .map((s) => `- \`${s.path}\`: ${JSON.stringify(s.value)}`)
         .join("\n") +
-      `\n\nForm definition:\n${renderReferralForm(form, jobs)}`
+      `\n\nForm definition:\n${renderReferralForm(form, { jobs })}`
     );
   }
 
   return (
     `Found ${issues.length} issue(s) with the submission:\n` +
     issues.join("\n") +
-    `\n\nForm definition:\n${renderReferralForm(form, jobs)}`
+    `\n\nForm definition:\n${renderReferralForm(form, { jobs })}`
   );
 }

--- a/front/lib/api/actions/servers/ashby/helpers.ts
+++ b/front/lib/api/actions/servers/ashby/helpers.ts
@@ -163,6 +163,16 @@ export async function resolveAshbyUser(
     );
   }
 
+  if (ashbyUsers.length > 1) {
+    return new Err(
+      new MCPError(
+        `Multiple Ashby users found for email ${user.email}. ` +
+          "The referral must be credited to a unique Ashby user.",
+        { tracked: false }
+      )
+    );
+  }
+
   return new Ok(ashbyUsers[0]);
 }
 

--- a/front/lib/api/actions/servers/ashby/helpers.ts
+++ b/front/lib/api/actions/servers/ashby/helpers.ts
@@ -11,6 +11,8 @@ import type {
 import type { Result } from "@app/types";
 import { Err, isString, Ok } from "@app/types";
 
+const JOB_FIELD_PATH = "_systemfield.job";
+
 interface CandidateSearchParams {
   email?: string;
   name?: string;
@@ -109,8 +111,6 @@ export async function withAuth<T>(
 
   return action(token);
 }
-
-const JOB_FIELD_PATH = "_systemfield.job";
 
 function normalizeTitle(title: string): string {
   return title

--- a/front/lib/api/actions/servers/ashby/helpers.ts
+++ b/front/lib/api/actions/servers/ashby/helpers.ts
@@ -226,7 +226,9 @@ export function resolveFieldSubmissions(
           `${unmatchedTitles.join(", ")}.\n\n` +
           `Here is the referral form definition with the available ` +
           `field titles:\n\n${renderReferralForm(form, { jobs })}`,
-        { tracked: false }
+        {
+          tracked: false,
+        }
       )
     );
   }
@@ -239,8 +241,7 @@ export function resolveFieldSubmissions(
       jobs.map((j) => [j.title.toLowerCase().trim(), j.id])
     );
 
-    const normalizedJobName = jobSubmission.value.toLowerCase().trim();
-    const jobId = jobsByName.get(normalizedJobName);
+    const jobId = jobsByName.get(jobSubmission.value.toLowerCase().trim());
     if (!jobId) {
       const availableJobs = jobs
         .map((j) => `- ${j.title} (${j.status})`)
@@ -249,7 +250,9 @@ export function resolveFieldSubmissions(
         new MCPError(
           `Could not find a job matching "${jobSubmission.value}".\n\n` +
             `Available jobs:\n${availableJobs}`,
-          { tracked: false }
+          {
+            tracked: false,
+          }
         )
       );
     }
@@ -275,7 +278,9 @@ export function resolveFieldSubmissions(
       new MCPError(
         `Missing required fields: ${missingFields.join(", ")}.\n\n` +
           `Here is the referral form definition:\n\n${renderReferralForm(form, { jobs })}`,
-        { tracked: false }
+        {
+          tracked: false,
+        }
       )
     );
   }
@@ -298,25 +303,28 @@ export function diagnoseFieldSubmissions(
 
   for (const section of sections) {
     for (const fieldWrapper of section.fields) {
-      const { field, isRequired } = fieldWrapper;
-      const submitted = submittedPaths.get(field.path);
+      const {
+        field: { title, path, selectableValues },
+        isRequired,
+      } = fieldWrapper;
+      const submitted = submittedPaths.get(path);
 
       if (submitted === undefined) {
         if (isRequired) {
-          issues.push(`- **${field.title.trim()}**: required but missing`);
+          issues.push(`- **${title.trim()}**: required but missing`);
         }
         continue;
       }
 
       // Check selectable values.
-      if (field.selectableValues && field.selectableValues.length > 0) {
-        const validValues = new Set(field.selectableValues.map((v) => v.value));
+      if (selectableValues && selectableValues.length > 0) {
+        const validValues = new Set(selectableValues.map((v) => v.value));
         if (!validValues.has(String(submitted))) {
-          const options = field.selectableValues
+          const options = selectableValues
             .map((v) => `\`${v.value}\` (${v.label})`)
             .join(", ");
           issues.push(
-            `- **${field.title.trim()}**: value \`${String(submitted)}\` ` +
+            `- **${title.trim()}**: value \`${String(submitted)}\` ` +
               `is not a valid option. Valid options: ${options}`
           );
         }

--- a/front/lib/api/actions/servers/ashby/index.ts
+++ b/front/lib/api/actions/servers/ashby/index.ts
@@ -3,10 +3,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
-import {
-  ASHBY_SERVER,
-  ASHBY_TOOL_NAME,
-} from "@app/lib/api/actions/servers/ashby/metadata";
+import { ASHBY_SERVER } from "@app/lib/api/actions/servers/ashby/metadata";
 import { TOOLS } from "@app/lib/api/actions/servers/ashby/tools";
 import type { Authenticator } from "@app/lib/auth";
 
@@ -18,7 +15,8 @@ function createServer(
 
   for (const tool of TOOLS) {
     registerTool(auth, agentLoopContext, server, tool, {
-      monitoringName: ASHBY_TOOL_NAME,
+      // Putting all the tools under the same name, will reconsider if we need more granularity.
+      monitoringName: "ashby",
     });
   }
 

--- a/front/lib/api/actions/servers/ashby/metadata.ts
+++ b/front/lib/api/actions/servers/ashby/metadata.ts
@@ -5,9 +5,8 @@ import { zodToJsonSchema } from "zod-to-json-schema";
 import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 
-export const ASHBY_TOOL_NAME = "ashby" as const;
-
 const DEFAULT_SEARCH_LIMIT = 20;
+export const GET_REFERRAL_FORM_TOOL_NAME = "get_referral_form";
 
 const CandidateSearchSchema = {
   email: z
@@ -86,14 +85,25 @@ export const ASHBY_TOOLS_METADATA = createToolsRecord({
       done: "Create candidate note on Ashby",
     },
   },
+  [GET_REFERRAL_FORM_TOOL_NAME]: {
+    description:
+      "Retrieve the referral form definition from Ashby. " +
+      "Returns all form fields with their titles, types, and whether they are required. " +
+      "You must call this tool before creating a referral to know the available fields.",
+    schema: {},
+    stake: "never_ask",
+    displayLabels: {
+      running: "Retrieving referral form from Ashby",
+      done: "Retrieve referral form from Ashby",
+    },
+  },
   create_referral: {
     description:
       "Create a referral for a candidate in Ashby. " +
-      "The referral form definition and credited user are resolved automatically. " +
+      `You must call ${GET_REFERRAL_FORM_TOOL_NAME} first to know the available fields. ` +
+      "The credited user is resolved automatically from the authenticated user. " +
       "Field values must be provided as {title, value} pairs where title is " +
-      "the human-readable field title (e.g. 'Candidate Name', 'Email'). " +
-      "If required fields are missing or titles don't match, the tool will " +
-      "return the form definition so you can retry with the correct fields.",
+      `the human-readable field title exactly as returned by ${GET_REFERRAL_FORM_TOOL_NAME}.`,
     schema: {
       fieldSubmissions: z
         .array(

--- a/front/lib/api/actions/servers/ashby/metadata.ts
+++ b/front/lib/api/actions/servers/ashby/metadata.ts
@@ -86,6 +86,38 @@ export const ASHBY_TOOLS_METADATA = createToolsRecord({
       done: "Create candidate note on Ashby",
     },
   },
+  create_referral: {
+    description:
+      "Create a referral for a candidate in Ashby. " +
+      "The referral form definition and credited user are resolved automatically. " +
+      "Field values must be provided as {title, value} pairs where title is " +
+      "the human-readable field title (e.g. 'Candidate Name', 'Email'). " +
+      "If required fields are missing or titles don't match, the tool will " +
+      "return the form definition so you can retry with the correct fields.",
+    schema: {
+      fieldSubmissions: z
+        .array(
+          z.object({
+            title: z
+              .string()
+              .describe(
+                "The human-readable field title (e.g. 'Candidate Name')."
+              ),
+            value: z
+              .union([z.string(), z.number(), z.boolean()])
+              .describe("The value for this field."),
+          })
+        )
+        .describe(
+          "Array of field values keyed by their human-readable title."
+        ),
+    },
+    stake: "high",
+    displayLabels: {
+      running: "Creating referral on Ashby",
+      done: "Create referral on Ashby",
+    },
+  },
 });
 
 export const ASHBY_SERVER = {

--- a/front/lib/api/actions/servers/ashby/metadata.ts
+++ b/front/lib/api/actions/servers/ashby/metadata.ts
@@ -108,9 +108,7 @@ export const ASHBY_TOOLS_METADATA = createToolsRecord({
               .describe("The value for this field."),
           })
         )
-        .describe(
-          "Array of field values keyed by their human-readable title."
-        ),
+        .describe("Array of field values keyed by their human-readable title."),
     },
     stake: "high",
     displayLabels: {

--- a/front/lib/api/actions/servers/ashby/rendering.ts
+++ b/front/lib/api/actions/servers/ashby/rendering.ts
@@ -159,11 +159,7 @@ export function renderCandidateNotes(
 export function renderReferralForm(
   form: AshbyReferralFormInfoResponse["results"]
 ): string {
-  const lines: string[] = [
-    "# Referral Form",
-    "",
-    `**Title:** ${form.title}`,
-  ];
+  const lines: string[] = ["# Referral Form", "", `**Title:** ${form.title}`];
 
   if (form.description) {
     lines.push(`**Description:** ${form.description}`);

--- a/front/lib/api/actions/servers/ashby/rendering.ts
+++ b/front/lib/api/actions/servers/ashby/rendering.ts
@@ -180,7 +180,8 @@ export function renderReferralForm(
       const { field, isRequired } = fieldWrapper;
       const requiredLabel = isRequired ? " (required)" : " (optional)";
 
-      lines.push(`- **${field.title}**${requiredLabel}`);
+      const nullableLabel = field.isNullable ? "" : ", mandatory";
+      lines.push(`- **${field.title}**${requiredLabel}${nullableLabel}`);
 
       if (field.path === JOB_FIELD_PATH && jobs) {
         lines.push(`  - Type: Job name (will be resolved automatically)`);

--- a/front/lib/api/actions/servers/ashby/rendering.ts
+++ b/front/lib/api/actions/servers/ashby/rendering.ts
@@ -2,6 +2,7 @@ import type {
   AshbyCandidate,
   AshbyCandidateNote,
   AshbyFeedbackSubmission,
+  AshbyReferralFormInfoResponse,
   AshbyReportSynchronousResponse,
 } from "@app/lib/api/actions/servers/ashby/types";
 
@@ -153,4 +154,47 @@ export function renderCandidateNotes(
   const noteTexts = notes.map((note) => renderSingleNote(note));
 
   return header.join("\n") + noteTexts.join(`\n\n${delimiterLine}\n\n`);
+}
+
+export function renderReferralForm(
+  form: AshbyReferralFormInfoResponse["results"]
+): string {
+  const lines: string[] = [
+    "# Referral Form",
+    "",
+    `**Title:** ${form.title}`,
+  ];
+
+  if (form.description) {
+    lines.push(`**Description:** ${form.description}`);
+  }
+
+  lines.push("");
+
+  for (const section of form.sections) {
+    if (section.title) {
+      lines.push(`## ${section.title}`);
+      lines.push("");
+    }
+
+    for (const fieldWrapper of section.fields) {
+      const { field, isRequired } = fieldWrapper;
+      const requiredLabel = isRequired ? " (required)" : " (optional)";
+
+      lines.push(`- **${field.title}**${requiredLabel}`);
+      lines.push(`  - Path: \`${field.path}\``);
+      lines.push(`  - Type: ${field.type}`);
+
+      if (field.selectableValues && field.selectableValues.length > 0) {
+        lines.push("  - Options:");
+        for (const opt of field.selectableValues) {
+          lines.push(`    - \`${opt.value}\`: ${opt.label}`);
+        }
+      }
+
+      lines.push("");
+    }
+  }
+
+  return lines.join("\n");
 }

--- a/front/lib/api/actions/servers/ashby/rendering.ts
+++ b/front/lib/api/actions/servers/ashby/rendering.ts
@@ -171,7 +171,7 @@ export function renderReferralForm(
 
   lines.push("");
 
-  for (const section of form.sections) {
+  for (const section of form.formDefinition?.sections ?? []) {
     if (section.title) {
       lines.push(`## ${section.title}`);
       lines.push("");

--- a/front/lib/api/actions/servers/ashby/rendering.ts
+++ b/front/lib/api/actions/servers/ashby/rendering.ts
@@ -188,6 +188,8 @@ export function renderReferralForm(
 
       lines.push(`- **${title}**${isRequired ? " (required)" : " (optional)"}`);
 
+      // Handle the job field as a special case: we need to pass the UUID of the job when creating
+      // a referral, but we ask the model to pass the name (easier for the model) and convert it.
       if (path === JOB_FIELD_PATH) {
         lines.push(`  - Type: Job name (will be resolved automatically)`);
         lines.push("  - Available jobs:");

--- a/front/lib/api/actions/servers/ashby/rendering.ts
+++ b/front/lib/api/actions/servers/ashby/rendering.ts
@@ -4,7 +4,7 @@ import type {
   AshbyCandidateNote,
   AshbyFeedbackSubmission,
   AshbyJob,
-  AshbyReferralFormInfoResponse,
+  AshbyReferralFormInfo,
   AshbyReportSynchronousResponse,
 } from "@app/lib/api/actions/servers/ashby/types";
 
@@ -159,7 +159,7 @@ export function renderCandidateNotes(
 }
 
 export function renderReferralForm(
-  form: AshbyReferralFormInfoResponse["results"],
+  form: AshbyReferralFormInfo,
   jobs: AshbyJob[]
 ): string {
   const lines: string[] = ["# Referral Form", "", `**Title:** ${form.title}`];

--- a/front/lib/api/actions/servers/ashby/rendering.ts
+++ b/front/lib/api/actions/servers/ashby/rendering.ts
@@ -183,7 +183,7 @@ export function renderReferralForm(
       const nullableLabel = field.isNullable ? "" : ", mandatory";
       lines.push(`- **${field.title}**${requiredLabel}${nullableLabel}`);
 
-      if (field.path === JOB_FIELD_PATH && jobs) {
+      if (field.path === JOB_FIELD_PATH) {
         lines.push(`  - Type: Job name (will be resolved automatically)`);
         lines.push("  - Available jobs:");
         for (const job of jobs) {

--- a/front/lib/api/actions/servers/ashby/rendering.ts
+++ b/front/lib/api/actions/servers/ashby/rendering.ts
@@ -178,10 +178,11 @@ export function renderReferralForm(
 
     for (const fieldWrapper of section.fields) {
       const {
-        field: { title, isNullable, path, type, selectableValues },
+        field: { title, path, type, selectableValues },
+        isRequired,
       } = fieldWrapper;
 
-      lines.push(`- **${title}**${isNullable ? " (optional)" : " (required)"}`);
+      lines.push(`- **${title}**${isRequired ? " (required)" : " (optional)"}`);
 
       if (path === JOB_FIELD_PATH) {
         lines.push(`  - Type: Job name (will be resolved automatically)`);

--- a/front/lib/api/actions/servers/ashby/rendering.ts
+++ b/front/lib/api/actions/servers/ashby/rendering.ts
@@ -160,7 +160,11 @@ export function renderCandidateNotes(
 
 export function renderReferralForm(
   form: AshbyReferralFormInfo,
-  jobs: AshbyJob[]
+  {
+    jobs,
+  }: {
+    jobs: AshbyJob[];
+  }
 ): string {
   const lines: string[] = ["# Referral Form", "", `**Title:** ${form.title}`];
 

--- a/front/lib/api/actions/servers/ashby/rendering.ts
+++ b/front/lib/api/actions/servers/ashby/rendering.ts
@@ -1,7 +1,9 @@
+import { JOB_FIELD_PATH } from "@app/lib/api/actions/servers/ashby/helpers";
 import type {
   AshbyCandidate,
   AshbyCandidateNote,
   AshbyFeedbackSubmission,
+  AshbyJob,
   AshbyReferralFormInfoResponse,
   AshbyReportSynchronousResponse,
 } from "@app/lib/api/actions/servers/ashby/types";
@@ -157,7 +159,8 @@ export function renderCandidateNotes(
 }
 
 export function renderReferralForm(
-  form: AshbyReferralFormInfoResponse["results"]
+  form: AshbyReferralFormInfoResponse["results"],
+  jobs: AshbyJob[]
 ): string {
   const lines: string[] = ["# Referral Form", "", `**Title:** ${form.title}`];
 
@@ -178,13 +181,21 @@ export function renderReferralForm(
       const requiredLabel = isRequired ? " (required)" : " (optional)";
 
       lines.push(`- **${field.title}**${requiredLabel}`);
-      lines.push(`  - Path: \`${field.path}\``);
-      lines.push(`  - Type: ${field.type}`);
 
-      if (field.selectableValues && field.selectableValues.length > 0) {
-        lines.push("  - Options:");
-        for (const opt of field.selectableValues) {
-          lines.push(`    - \`${opt.value}\`: ${opt.label}`);
+      if (field.path === JOB_FIELD_PATH && jobs) {
+        lines.push(`  - Type: Job name (will be resolved automatically)`);
+        lines.push("  - Available jobs:");
+        for (const job of jobs) {
+          lines.push(`    - ${job.title} (${job.status})`);
+        }
+      } else {
+        lines.push(`  - Type: ${field.type}`);
+
+        if (field.selectableValues && field.selectableValues.length > 0) {
+          lines.push("  - Options:");
+          for (const opt of field.selectableValues) {
+            lines.push(`    - \`${opt.value}\`: ${opt.label}`);
+          }
         }
       }
 

--- a/front/lib/api/actions/servers/ashby/rendering.ts
+++ b/front/lib/api/actions/servers/ashby/rendering.ts
@@ -177,24 +177,24 @@ export function renderReferralForm(
     }
 
     for (const fieldWrapper of section.fields) {
-      const { field, isRequired } = fieldWrapper;
-      const requiredLabel = isRequired ? " (required)" : " (optional)";
+      const {
+        field: { title, isNullable, path, type, selectableValues },
+      } = fieldWrapper;
 
-      const nullableLabel = field.isNullable ? "" : ", mandatory";
-      lines.push(`- **${field.title}**${requiredLabel}${nullableLabel}`);
+      lines.push(`- **${title}**${isNullable ? " (optional)" : " (required)"}`);
 
-      if (field.path === JOB_FIELD_PATH) {
+      if (path === JOB_FIELD_PATH) {
         lines.push(`  - Type: Job name (will be resolved automatically)`);
         lines.push("  - Available jobs:");
         for (const job of jobs) {
           lines.push(`    - ${job.title} (${job.status})`);
         }
       } else {
-        lines.push(`  - Type: ${field.type}`);
+        lines.push(`  - Type: ${type}`);
 
-        if (field.selectableValues && field.selectableValues.length > 0) {
+        if (selectableValues && selectableValues.length > 0) {
           lines.push("  - Options:");
-          for (const opt of field.selectableValues) {
+          for (const opt of selectableValues) {
             lines.push(`    - \`${opt.value}\`: ${opt.label}`);
           }
         }

--- a/front/lib/api/actions/servers/ashby/tools/index.ts
+++ b/front/lib/api/actions/servers/ashby/tools/index.ts
@@ -461,9 +461,19 @@ const handlers: ToolHandlers<typeof ASHBY_TOOLS_METADATA> = {
 
     const form = formResult.value.results;
 
+    const jobsResult = await client.listJobs();
+    if (jobsResult.isErr()) {
+      return new Err(
+        new MCPError(`Failed to list jobs: ${jobsResult.error.message}`)
+      );
+    }
+
+    const jobs = jobsResult.value;
+
     const submissionsResult = await resolveFieldSubmissions(
       client,
       form,
+      jobs,
       fieldSubmissions
     );
     if (submissionsResult.isErr()) {
@@ -494,8 +504,6 @@ const handlers: ToolHandlers<typeof ASHBY_TOOLS_METADATA> = {
 
       // They have a catch all error `invalid_input`.
       if (errorCode === "invalid_input") {
-        const jobsResult = await client.listJobs();
-        const jobs = jobsResult.isOk() ? jobsResult.value : [];
         const diagnosis = diagnoseFieldSubmissions(
           form,
           submissionsResult.value,

--- a/front/lib/api/actions/servers/ashby/tools/index.ts
+++ b/front/lib/api/actions/servers/ashby/tools/index.ts
@@ -403,12 +403,15 @@ const handlers: ToolHandlers<typeof ASHBY_TOOLS_METADATA> = {
     if (formResult.isErr()) {
       return new Err(
         new MCPError(
-          `Failed to retrieve referral form: ${formResult.error.message}`
+          `Failed to retrieve referral form: ${formResult.error.message}`,
+          {
+            cause: formResult.error,
+          }
         )
       );
     }
 
-    if (!formResult.value.success || !formResult.value.results) {
+    if (!formResult.value.success) {
       return new Err(
         new MCPError("Failed to retrieve referral form from Ashby.")
       );
@@ -417,7 +420,9 @@ const handlers: ToolHandlers<typeof ASHBY_TOOLS_METADATA> = {
     const jobsResult = await client.listJobs();
     if (jobsResult.isErr()) {
       return new Err(
-        new MCPError(`Failed to list jobs: ${jobsResult.error.message}`)
+        new MCPError(`Failed to list jobs: ${jobsResult.error.message}`, {
+          cause: jobsResult.error,
+        })
       );
     }
 
@@ -448,12 +453,15 @@ const handlers: ToolHandlers<typeof ASHBY_TOOLS_METADATA> = {
     if (formResult.isErr()) {
       return new Err(
         new MCPError(
-          `Failed to retrieve referral form: ${formResult.error.message}`
+          `Failed to retrieve referral form: ${formResult.error.message}`,
+          {
+            cause: formResult.error,
+          }
         )
       );
     }
 
-    if (!formResult.value.success || !formResult.value.results) {
+    if (!formResult.value.success) {
       return new Err(
         new MCPError("Failed to retrieve referral form from Ashby.")
       );
@@ -464,7 +472,9 @@ const handlers: ToolHandlers<typeof ASHBY_TOOLS_METADATA> = {
     const jobsResult = await client.listJobs();
     if (jobsResult.isErr()) {
       return new Err(
-        new MCPError(`Failed to list jobs: ${jobsResult.error.message}`)
+        new MCPError(`Failed to list jobs: ${jobsResult.error.message}`, {
+          cause: jobsResult.error,
+        })
       );
     }
 

--- a/front/lib/api/actions/servers/ashby/tools/index.ts
+++ b/front/lib/api/actions/servers/ashby/tools/index.ts
@@ -391,7 +391,7 @@ const handlers: ToolHandlers<typeof ASHBY_TOOLS_METADATA> = {
     ]);
   },
 
-  [GET_REFERRAL_FORM_TOOL_NAME]: async (_params, extra) => {
+  [GET_REFERRAL_FORM_TOOL_NAME]: async (_, extra) => {
     const clientResult = await getAshbyClient(extra);
     if (clientResult.isErr()) {
       return clientResult;

--- a/front/lib/api/actions/servers/ashby/tools/index.ts
+++ b/front/lib/api/actions/servers/ashby/tools/index.ts
@@ -471,7 +471,7 @@ const handlers: ToolHandlers<typeof ASHBY_TOOLS_METADATA> = {
     }
 
     const referralResult = await client.createReferral({
-      referralFormId: form.id,
+      id: form.id,
       creditedToUserId: ashbyUser.id,
       fieldSubmissions: submissionsResult.value,
     });

--- a/front/lib/api/actions/servers/ashby/tools/index.ts
+++ b/front/lib/api/actions/servers/ashby/tools/index.ts
@@ -408,7 +408,7 @@ const handlers: ToolHandlers<typeof ASHBY_TOOLS_METADATA> = {
       );
     }
 
-    if (!formResult.value.success) {
+    if (!formResult.value.success || !formResult.value.results) {
       return new Err(
         new MCPError("Failed to retrieve referral form from Ashby.")
       );
@@ -453,7 +453,7 @@ const handlers: ToolHandlers<typeof ASHBY_TOOLS_METADATA> = {
       );
     }
 
-    if (!formResult.value.success) {
+    if (!formResult.value.success || !formResult.value.results) {
       return new Err(
         new MCPError("Failed to retrieve referral form from Ashby.")
       );

--- a/front/lib/api/actions/servers/ashby/tools/index.ts
+++ b/front/lib/api/actions/servers/ashby/tools/index.ts
@@ -11,7 +11,10 @@ import {
   resolveAshbyUser,
   resolveFieldSubmissions,
 } from "@app/lib/api/actions/servers/ashby/helpers";
-import { ASHBY_TOOLS_METADATA } from "@app/lib/api/actions/servers/ashby/metadata";
+import {
+  ASHBY_TOOLS_METADATA,
+  GET_REFERRAL_FORM_TOOL_NAME,
+} from "@app/lib/api/actions/servers/ashby/metadata";
 import {
   renderCandidateList,
   renderCandidateNotes,
@@ -383,6 +386,35 @@ const handlers: ToolHandlers<typeof ASHBY_TOOLS_METADATA> = {
             ? `(${candidate.primaryEmailAddress?.value}) `
             : "") +
           `profile.\n\nNote ID: ${noteResult.value.results.id}`,
+      },
+    ]);
+  },
+
+  [GET_REFERRAL_FORM_TOOL_NAME]: async (_params, extra) => {
+    const clientResult = await getAshbyClient(extra);
+    if (clientResult.isErr()) {
+      return clientResult;
+    }
+
+    const formResult = await clientResult.value.getReferralFormInfo();
+    if (formResult.isErr()) {
+      return new Err(
+        new MCPError(
+          `Failed to retrieve referral form: ${formResult.error.message}`
+        )
+      );
+    }
+
+    if (!formResult.value.success) {
+      return new Err(
+        new MCPError("Failed to retrieve referral form from Ashby.")
+      );
+    }
+
+    return new Ok([
+      {
+        type: "text" as const,
+        text: renderReferralForm(formResult.value.results),
       },
     ]);
   },

--- a/front/lib/api/actions/servers/ashby/tools/index.ts
+++ b/front/lib/api/actions/servers/ashby/tools/index.ts
@@ -499,7 +499,9 @@ const handlers: ToolHandlers<typeof ASHBY_TOOLS_METADATA> = {
       return new Err(
         new MCPError(
           `Failed to create referral: ${referralResult.error.message}`,
-          { cause: referralResult.error }
+          {
+            cause: referralResult.error,
+          }
         )
       );
     }

--- a/front/lib/api/actions/servers/ashby/tools/index.ts
+++ b/front/lib/api/actions/servers/ashby/tools/index.ts
@@ -460,15 +460,6 @@ const handlers: ToolHandlers<typeof ASHBY_TOOLS_METADATA> = {
 
     const form = formResult.value.results;
 
-    const jobsResult = await client.listJobs();
-    if (jobsResult.isErr()) {
-      return new Err(
-        new MCPError(`Failed to list jobs: ${jobsResult.error.message}`)
-      );
-    }
-
-    const jobs = jobsResult.value;
-
     const submissionsResult = await resolveFieldSubmissions(
       client,
       form,
@@ -487,9 +478,7 @@ const handlers: ToolHandlers<typeof ASHBY_TOOLS_METADATA> = {
     if (referralResult.isErr()) {
       return new Err(
         new MCPError(
-          `Failed to create referral: ${referralResult.error.message}\n\n` +
-            `Here is the referral form definition to help you retry ` +
-            `with the correct fields:\n\n${renderReferralForm(form, jobs)}`,
+          `Failed to create referral: ${referralResult.error.message}`,
           { cause: referralResult.error }
         )
       );
@@ -501,11 +490,7 @@ const handlers: ToolHandlers<typeof ASHBY_TOOLS_METADATA> = {
         referralResult.value.errors?.join(", ") ??
         "Unknown error";
       return new Err(
-        new MCPError(
-          `Failed to create referral: ${errorMessage}` +
-            `\n\nHere is the referral form definition to help you retry ` +
-            `with the correct fields:\n\n${renderReferralForm(form, jobs)}`
-        )
+        new MCPError(`Failed to create referral: ${errorMessage}`)
       );
     }
 

--- a/front/lib/api/actions/servers/ashby/tools/index.ts
+++ b/front/lib/api/actions/servers/ashby/tools/index.ts
@@ -429,7 +429,9 @@ const handlers: ToolHandlers<typeof ASHBY_TOOLS_METADATA> = {
     return new Ok([
       {
         type: "text" as const,
-        text: renderReferralForm(formResult.value.results, jobsResult.value),
+        text: renderReferralForm(formResult.value.results, {
+          jobs: jobsResult.value,
+        }),
       },
     ]);
   },
@@ -480,12 +482,9 @@ const handlers: ToolHandlers<typeof ASHBY_TOOLS_METADATA> = {
 
     const jobs = jobsResult.value;
 
-    const submissionsResult = await resolveFieldSubmissions(
-      client,
-      form,
+    const submissionsResult = resolveFieldSubmissions(form, fieldSubmissions, {
       jobs,
-      fieldSubmissions
-    );
+    });
     if (submissionsResult.isErr()) {
       return submissionsResult;
     }
@@ -517,7 +516,7 @@ const handlers: ToolHandlers<typeof ASHBY_TOOLS_METADATA> = {
         const diagnosis = diagnoseFieldSubmissions(
           form,
           submissionsResult.value,
-          jobs
+          { jobs }
         );
         return new Err(
           new MCPError(

--- a/front/lib/api/actions/servers/ashby/types.ts
+++ b/front/lib/api/actions/servers/ashby/types.ts
@@ -359,7 +359,7 @@ export type AshbyReferralFormInfo = z.infer<typeof AshbyReferralFormInfoSchema>;
 
 export const AshbyReferralFormInfoResponseSchema = z.object({
   success: z.boolean(),
-  results: AshbyReferralFormInfoSchema.optional(),
+  results: AshbyReferralFormInfoSchema,
 });
 
 export type AshbyReferralFormInfoResponse = z.infer<

--- a/front/lib/api/actions/servers/ashby/types.ts
+++ b/front/lib/api/actions/servers/ashby/types.ts
@@ -372,7 +372,7 @@ export const AshbyFieldSubmissionSchema = z.object({
 export type AshbyFieldSubmission = z.infer<typeof AshbyFieldSubmissionSchema>;
 
 export const AshbyReferralCreateRequestSchema = z.object({
-  referralFormId: z.string(),
+  id: z.string(),
   creditedToUserId: z.string(),
   fieldSubmissions: z.array(AshbyFieldSubmissionSchema),
 });

--- a/front/lib/api/actions/servers/ashby/types.ts
+++ b/front/lib/api/actions/servers/ashby/types.ts
@@ -341,21 +341,25 @@ export type AshbyReferralFormSection = z.infer<
   typeof AshbyReferralFormSectionSchema
 >;
 
+export const AshbyReferralFormInfoSchema = z
+  .object({
+    id: z.string(),
+    title: z.string(),
+    description: z.string().optional(),
+    formDefinition: z
+      .object({
+        sections: z.array(AshbyReferralFormSectionSchema).optional(),
+      })
+      .passthrough()
+      .optional(),
+  })
+  .passthrough();
+
+export type AshbyReferralFormInfo = z.infer<typeof AshbyReferralFormInfoSchema>;
+
 export const AshbyReferralFormInfoResponseSchema = z.object({
   success: z.boolean(),
-  results: z
-    .object({
-      id: z.string(),
-      title: z.string(),
-      description: z.string().optional(),
-      formDefinition: z
-        .object({
-          sections: z.array(AshbyReferralFormSectionSchema).optional(),
-        })
-        .passthrough()
-        .optional(),
-    })
-    .passthrough(),
+  results: AshbyReferralFormInfoSchema,
 });
 
 export type AshbyReferralFormInfoResponse = z.infer<

--- a/front/lib/api/actions/servers/ashby/types.ts
+++ b/front/lib/api/actions/servers/ashby/types.ts
@@ -248,3 +248,123 @@ export const AshbyApplicationInfoResponseSchema = z.object({
 export type AshbyApplicationInfoResponse = z.infer<
   typeof AshbyApplicationInfoResponseSchema
 >;
+
+// User search
+
+export const AshbyUserSearchRequestSchema = z.object({
+  email: z.string(),
+});
+
+export type AshbyUserSearchRequest = z.infer<
+  typeof AshbyUserSearchRequestSchema
+>;
+
+export const AshbyUserSchema = z
+  .object({
+    id: z.string(),
+    firstName: z.string(),
+    lastName: z.string(),
+    email: z.string(),
+    globalRole: z.string(),
+    isEnabled: z.boolean(),
+  })
+  .passthrough();
+
+export type AshbyUser = z.infer<typeof AshbyUserSchema>;
+
+export const AshbyUserSearchResponseSchema = z.object({
+  success: z.boolean(),
+  results: AshbyUserSchema,
+});
+
+export type AshbyUserSearchResponse = z.infer<
+  typeof AshbyUserSearchResponseSchema
+>;
+
+// Referral form info
+
+export const AshbyReferralFormFieldSchema = z.object({
+  isRequired: z.boolean(),
+  descriptionHtml: z.string().optional(),
+  descriptionPlain: z.string().optional(),
+  field: z.object({
+    id: z.string(),
+    type: z.string(),
+    path: z.string(),
+    humanReadablePath: z.string().optional(),
+    title: z.string(),
+    isNullable: z.boolean(),
+    selectableValues: z
+      .array(
+        z.object({
+          label: z.string(),
+          value: z.string(),
+        })
+      )
+      .optional(),
+  }),
+});
+
+export type AshbyReferralFormField = z.infer<
+  typeof AshbyReferralFormFieldSchema
+>;
+
+export const AshbyReferralFormSectionSchema = z.object({
+  title: z.string().optional(),
+  descriptionHtml: z.string().optional(),
+  descriptionPlain: z.string().optional(),
+  fields: z.array(AshbyReferralFormFieldSchema),
+});
+
+export type AshbyReferralFormSection = z.infer<
+  typeof AshbyReferralFormSectionSchema
+>;
+
+export const AshbyReferralFormInfoResponseSchema = z.object({
+  success: z.boolean(),
+  results: z
+    .object({
+      id: z.string(),
+      title: z.string(),
+      description: z.string().optional(),
+      sections: z.array(AshbyReferralFormSectionSchema),
+    })
+    .passthrough(),
+});
+
+export type AshbyReferralFormInfoResponse = z.infer<
+  typeof AshbyReferralFormInfoResponseSchema
+>;
+
+// Referral create
+
+export const AshbyFieldSubmissionSchema = z.object({
+  path: z.string(),
+  value: z.union([z.string(), z.number(), z.boolean()]),
+});
+
+export type AshbyFieldSubmission = z.infer<typeof AshbyFieldSubmissionSchema>;
+
+export const AshbyReferralCreateRequestSchema = z.object({
+  referralFormId: z.string(),
+  creditedToUserId: z.string(),
+  fieldSubmissions: z.array(AshbyFieldSubmissionSchema),
+});
+
+export type AshbyReferralCreateRequest = z.infer<
+  typeof AshbyReferralCreateRequestSchema
+>;
+
+export const AshbyReferralCreateResponseSchema = z.object({
+  success: z.boolean(),
+  results: z
+    .object({
+      id: z.string(),
+      status: z.string(),
+    })
+    .passthrough(),
+});
+
+export type AshbyReferralCreateResponse = z.infer<
+  typeof AshbyReferralCreateResponseSchema
+>;

--- a/front/lib/api/actions/servers/ashby/types.ts
+++ b/front/lib/api/actions/servers/ashby/types.ts
@@ -249,6 +249,27 @@ export type AshbyApplicationInfoResponse = z.infer<
   typeof AshbyApplicationInfoResponseSchema
 >;
 
+// Job list
+
+export const AshbyJobSchema = z
+  .object({
+    id: z.string(),
+    title: z.string(),
+    status: z.string(),
+  })
+  .passthrough();
+
+export type AshbyJob = z.infer<typeof AshbyJobSchema>;
+
+export const AshbyJobListResponseSchema = z.object({
+  success: z.boolean(),
+  results: z.array(AshbyJobSchema),
+  moreDataAvailable: z.boolean().optional(),
+  nextCursor: z.string().optional(),
+});
+
+export type AshbyJobListResponse = z.infer<typeof AshbyJobListResponseSchema>;
+
 // User search
 
 export const AshbyUserSearchRequestSchema = z.object({
@@ -274,7 +295,7 @@ export type AshbyUser = z.infer<typeof AshbyUserSchema>;
 
 export const AshbyUserSearchResponseSchema = z.object({
   success: z.boolean(),
-  results: AshbyUserSchema,
+  results: z.array(AshbyUserSchema),
 });
 
 export type AshbyUserSearchResponse = z.infer<
@@ -327,7 +348,12 @@ export const AshbyReferralFormInfoResponseSchema = z.object({
       id: z.string(),
       title: z.string(),
       description: z.string().optional(),
-      sections: z.array(AshbyReferralFormSectionSchema),
+      formDefinition: z
+        .object({
+          sections: z.array(AshbyReferralFormSectionSchema).optional(),
+        })
+        .passthrough()
+        .optional(),
     })
     .passthrough(),
 });
@@ -362,7 +388,16 @@ export const AshbyReferralCreateResponseSchema = z.object({
       id: z.string(),
       status: z.string(),
     })
-    .passthrough(),
+    .passthrough()
+    .optional(),
+  errors: z.array(z.string()).optional(),
+  errorInfo: z
+    .object({
+      code: z.string().optional(),
+      message: z.string().optional(),
+    })
+    .passthrough()
+    .optional(),
 });
 
 export type AshbyReferralCreateResponse = z.infer<

--- a/front/lib/api/actions/servers/ashby/types.ts
+++ b/front/lib/api/actions/servers/ashby/types.ts
@@ -359,7 +359,7 @@ export type AshbyReferralFormInfo = z.infer<typeof AshbyReferralFormInfoSchema>;
 
 export const AshbyReferralFormInfoResponseSchema = z.object({
   success: z.boolean(),
-  results: AshbyReferralFormInfoSchema,
+  results: AshbyReferralFormInfoSchema.optional(),
 });
 
 export type AshbyReferralFormInfoResponse = z.infer<


### PR DESCRIPTION
## Description

- This PR adds tools to get the referral form and create referrals on the Ashby MCP server.
- The tools are designed to take simple inputs, and error with the form definition if the inputs are invalid.
- Some fields are UUIDs, very unclear how we can actually find values for those and the responses from the API are vastly unhelpful. Was able to add a matching strategy for the jobs.
- The referrals are credited to the authenticated user, operating by email matching (we search the Dust user email on Ashby). This only works if the user uses the same email between the two platforms (which is expected for company emails).

## Tests

- Tested locally, ~actually doesn't work due to one field that is specific to our referral form so shipping as is and will iterate later.~ Edit: was able to make it work.

## Risk

- Low.

## Deploy Plan

- Deploy front.
