### PR TITLE
Hide instructions placeholder on suggestions existence + tweak instructions 

### DIFF
--- a/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
+++ b/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
@@ -23,7 +23,10 @@ import { BlockInsertExtension } from "@app/components/editor/extensions/agent_bu
 import { InstructionBlockExtension } from "@app/components/editor/extensions/agent_builder/InstructionBlockExtension";
 import { InstructionsDocumentExtension } from "@app/components/editor/extensions/agent_builder/InstructionsDocumentExtension";
 import { InstructionsRootExtension } from "@app/components/editor/extensions/agent_builder/InstructionsRootExtension";
-import { InstructionSuggestionExtension } from "@app/components/editor/extensions/agent_builder/InstructionSuggestionExtension";
+import {
+  getActiveSuggestions,
+  InstructionSuggestionExtension,
+} from "@app/components/editor/extensions/agent_builder/InstructionSuggestionExtension";
 import { EmojiExtension } from "@app/components/editor/extensions/EmojiExtension";
 import { HeadingExtension } from "@app/components/editor/extensions/HeadingExtension";
 import { KeyboardShortcutsExtension } from "@app/components/editor/extensions/input_bar/KeyboardShortcutsExtension";
@@ -157,12 +160,14 @@ export function AgentBuilderInstructionsEditor({
       }),
       Placeholder.configure({
         placeholder: ({ editor }) => {
-          // Don't show placeholder inside instruction blocks
-          const { state } = editor;
-          const { selection } = state;
-          const $pos = selection.$anchor;
+          // Hide placeholder when suggestions are being displayed.
+          if (getActiveSuggestions(editor.state).size > 0) {
+            return "";
+          }
 
-          // Check if we're inside an instruction block
+          // Don't show placeholder inside instruction blocks.
+          const { selection } = editor.state;
+          const $pos = selection.$anchor;
           for (let depth = $pos.depth; depth > 0; depth--) {
             if ($pos.node(depth).type.name === "instructionBlock") {
               return "";

--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
@@ -280,7 +280,7 @@
       },
       {
         "name": "suggest_prompt_edits",
-        "description": "Create suggestions to modify the agent's instructions/prompt using block-based targeting. The instructions HTML contains blocks with data-block-id attributes (e.g., 'a3f1b20e'). Each suggestion targets a specific block by its ID and provides the full replacement HTML for that block. Word-level diffs will be computed and displayed inline. IMPORTANT: Include the tool output verbatim in your response - it renders as interactive card(s).",
+        "description": "Create suggestions to modify the agent's instructions/prompt using block-based targeting. The instructions HTML contains blocks with data-block-id attributes (e.g., 'a3f1b20e'). Each suggestion targets a specific block by its ID and provides the full replacement HTML for that block. Each block ID must appear at most once. For full rewrites, use targetBlockId 'instructions-root'. Word-level diffs will be computed and displayed inline. IMPORTANT: Include the tool output verbatim in your response - it renders as interactive card(s).",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
           "additionalProperties": false,

--- a/front/lib/api/actions/servers/agent_copilot_context/metadata.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/metadata.ts
@@ -178,6 +178,7 @@ export const AGENT_COPILOT_CONTEXT_TOOLS_METADATA = createToolsRecord({
       "Create suggestions to modify the agent's instructions/prompt using block-based targeting. " +
       "The instructions HTML contains blocks with data-block-id attributes (e.g., 'a3f1b20e'). " +
       "Each suggestion targets a specific block by its ID and provides the full replacement HTML for that block. " +
+      "Each block ID must appear at most once. For full rewrites, use targetBlockId 'instructions-root'. " +
       "Word-level diffs will be computed and displayed inline. " +
       "IMPORTANT: Include the tool output verbatim in your response - it renders as interactive card(s).",
     schema: {

--- a/front/lib/api/actions/servers/agent_copilot_context/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/tools/index.ts
@@ -647,6 +647,19 @@ const handlers: ToolHandlers<typeof AGENT_COPILOT_CONTEXT_TOOLS_METADATA> = {
       );
     }
 
+    // Reject batches where multiple suggestions target the same block.
+    const targetBlockIds = params.suggestions.map((s) => s.targetBlockId);
+    const uniqueTargetBlockIds = new Set(targetBlockIds);
+    if (uniqueTargetBlockIds.size !== targetBlockIds.length) {
+      return new Err(
+        new MCPError(
+          "Multiple suggestions target the same block ID. Use a single suggestion per block." +
+            "For full rewrites, target 'instructions-root' instead.",
+          { tracked: false }
+        )
+      );
+    }
+
     // Check pending suggestion limit before proceeding.
     const pendingInstructions =
       await AgentSuggestionResource.listByAgentConfigurationId(

--- a/front/lib/api/assistant/global_agents/configurations/dust/copilot.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/copilot.ts
@@ -158,9 +158,11 @@ When you receive the agent instructions via \`get_agent_config\`, they will be i
 <block_editing_principles>
 1. Think in blocks, not documents — identify which block(s) your change affects before suggesting.
 2. One block per suggestion — users accept/reject each independently.
-3. Copy block IDs exactly — they are random identifiers, never construct them yourself.
-4. Always include the HTML tag — content must include the wrapping tag (e.g., \`<p>...</p>\`).
-5. Diffs are computed automatically — just provide the full new content.
+3. One suggestion per block — never send multiple suggestions targeting the same block ID.
+4. Copy block IDs exactly — they are random identifiers, never construct them yourself.
+5. Always include the HTML tag — content must include the wrapping tag (e.g., \`<p>...</p>\`).
+6. Diffs are computed automatically — just provide the full new content.
+7. For full rewrites, target the root — use \`targetBlockId: "instructions-root"\` with content wrapped in \`<div data-type="instructions-root">...</div>\` to replace all instructions at once.
 </block_editing_principles>
 
 <block_examples>
@@ -187,6 +189,11 @@ EXAMPLE 3: User says "make that a heading"
 \`\`\`
 \`\`\`json
 { "targetBlockId": "a1b2c3d4", "type": "replace", "content": "<h2>Output Guidelines</h2>" }
+\`\`\`
+
+EXAMPLE 4: User says "write instructions from scratch" (full rewrite targeting root)
+\`\`\`json
+{ "targetBlockId": "instructions-root", "type": "replace", "content": "<div data-type=\\"instructions-root\\"><h2>Role</h2><p>You are a helpful assistant.</p><h2>Output</h2><p>Always respond in JSON.</p></div>" }
 \`\`\`
 </block_examples>
 

--- a/front/lib/api/assistant/global_agents/configurations/dust/copilot.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/copilot.ts
@@ -145,7 +145,7 @@ When newlines hurt:
 </agent_instructions_best_practices>`,
 
   blockAwareEditing: `<block_aware_editing>
-Agent instructions are organized into "blocks" — logical containers that group related instructions.
+Agent instructions are organized into "blocks", logical containers that group related instructions.
 Each block has a unique \`data-block-id\` attribute, an 8-character random identifier (e.g., "7f3a2b1c").
 These IDs are persisted and stable across editing sessions.
 
@@ -156,13 +156,13 @@ When you receive the agent instructions via \`get_agent_config\`, they will be i
 \`\`\`
 
 <block_editing_principles>
-1. Think in blocks, not documents — identify which block(s) your change affects before suggesting.
-2. One block per suggestion — users accept/reject each independently.
-3. One suggestion per block — never send multiple suggestions targeting the same block ID.
-4. Copy block IDs exactly — they are random identifiers, never construct them yourself.
-5. Always include the HTML tag — content must include the wrapping tag (e.g., \`<p>...</p>\`).
-6. Diffs are computed automatically — just provide the full new content.
-7. For full rewrites, target the root — use \`targetBlockId: "instructions-root"\` with content wrapped in \`<div data-type="instructions-root">...</div>\` to replace all instructions at once.
+1. Think in blocks, not documents. Identify which block(s) your change affects before suggesting.
+2. One block per suggestion. Users accept/reject each independently.
+3. One suggestion per block. Never send multiple suggestions targeting the same block ID.
+4. Copy block IDs exactly. They are random identifiers, never construct them yourself.
+5. Always include the HTML tag. Content must include the wrapping tag (e.g., \`<p>...</p>\`).
+6. Diffs are computed automatically. Just provide the full new content.
+7. For full rewrites, target the root. Use \`targetBlockId: "instructions-root"\` with content wrapped in \`<div data-type="instructions-root">...</div>\` to replace all instructions at once.
 </block_editing_principles>
 
 <block_examples>


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR fixes https://github.com/dust-tt/tasks/issues/6415, to hide the placeholder when there is at least one suggestion. It also updates the copilot instructions to explain how to proceed with full rewrite + refuse all tool call that target many times the same block id.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
