### PR TITLE
Revert "always retrieve the latest data in agent builder"

### DIFF
--- a/front/components/pages/builder/agents/EditAgentPage.tsx
+++ b/front/components/pages/builder/agents/EditAgentPage.tsx
@@ -16,7 +16,6 @@ export function EditAgentPage() {
     agentConfiguration,
     isAgentConfigurationLoading,
     isAgentConfigurationError,
-    isAgentConfigurationValidating,
   } = useAgentConfiguration({
     workspaceId: owner.sId,
     agentConfigurationId: agentId,
@@ -35,11 +34,7 @@ export function EditAgentPage() {
     );
   }
 
-  if (
-    isAgentConfigurationLoading ||
-    isAgentConfigurationValidating ||
-    !agentConfiguration
-  ) {
+  if (isAgentConfigurationLoading || !agentConfiguration) {
     return (
       <div className="flex h-screen items-center justify-center">
         <Spinner size="lg" />


### PR DESCRIPTION
Reverts dust-tt/dust#21244

Using `isAgentConfigurationValidating` causes the entire editor to unmount/remount on every SWR background revalidation (window focus, interval, etc.). When we already have agentConfiguration data, there's no reason to show a spinner during revalidation.