### PR TITLE
[front] enh(skills): disable skills that require data sources if no ds found

### DIFF
--- a/front/lib/api/assistant/skill_actions.ts
+++ b/front/lib/api/assistant/skill_actions.ts
@@ -68,13 +68,11 @@ export async function getSkillServers(
           requiresDataSourceConfiguration,
         } = getMCPServerRequirements(view.toJSON());
 
-        let applicableViews: DataSourceViewResource[];
+        let applicableViews: DataSourceViewResource[] = [];
         if (requiresDataWarehouseConfiguration) {
           applicableViews = remoteDbViews;
         } else if (requiresDataSourceConfiguration) {
           applicableViews = nonRemoteDbViews;
-        } else {
-          applicableViews = [];
         }
 
         if (

--- a/front/lib/api/assistant/skill_actions.ts
+++ b/front/lib/api/assistant/skill_actions.ts
@@ -75,6 +75,7 @@ export async function getSkillServers(
           applicableViews = nonRemoteDbViews;
         }
 
+        // We don't expose the tools if they require data sources but none are available.
         if (
           (requiresDataWarehouseConfiguration ||
             requiresDataSourceConfiguration) &&

--- a/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
@@ -163,16 +163,19 @@ async function handler(
         attachments,
       });
 
-      const { enabledSkills, equippedSkills } =
+      const { enabledSkills: allEnabledSkills, equippedSkills } =
         await SkillResource.listForAgentLoop(auth, {
           agentConfiguration,
           conversation,
         });
 
-      const skillServers = await getSkillServers(auth, {
-        agentConfiguration,
-        skills: enabledSkills,
-      });
+      const { servers: skillServers, enabledSkills } = await getSkillServers(
+        auth,
+        {
+          agentConfiguration,
+          skills: allEnabledSkills,
+        }
+      );
 
       const clientSideMCPActionConfigurations =
         await createClientSideMCPServerConfigurations(

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -183,13 +183,10 @@ export async function runModelActivity(
   const { enabledSkills: allEnabledSkills, equippedSkills } =
     await SkillResource.listForAgentLoop(auth, runAgentData);
 
-  const { servers: skillServers, enabledSkills } = await getSkillServers(
-    auth,
-    {
-      agentConfiguration,
-      skills: allEnabledSkills,
-    }
-  );
+  const { servers: skillServers, enabledSkills } = await getSkillServers(auth, {
+    agentConfiguration,
+    skills: allEnabledSkills,
+  });
 
   // Add file system server if skills have attached knowledge.
   const dataSourceConfigurations = await getSkillDataSourceConfigurations(

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -180,13 +180,16 @@ export async function runModelActivity(
       userMessage.context.clientSideMCPServerIds
     );
 
-  const { enabledSkills, equippedSkills } =
+  const { enabledSkills: allEnabledSkills, equippedSkills } =
     await SkillResource.listForAgentLoop(auth, runAgentData);
 
-  const skillServers = await getSkillServers(auth, {
-    agentConfiguration,
-    skills: enabledSkills,
-  });
+  const { servers: skillServers, enabledSkills } = await getSkillServers(
+    auth,
+    {
+      agentConfiguration,
+      skills: allEnabledSkills,
+    }
+  );
 
   // Add file system server if skills have attached knowledge.
   const dataSourceConfigurations = await getSkillDataSourceConfigurations(


### PR DESCRIPTION
## Description

- This PR improves the situation in some rare cases where no data source is available on any of the requested spaces of the agent by disabling the skill in this case. The issue comes from the fact that the dsfs and dw tools error if no data source is passed and don't have much purpose then.
- Next step is to add a warning in Agent Builder.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
