### PR TITLE
New CTA

### DIFF
--- a/front/components/home/ContactForm.tsx
+++ b/front/components/home/ContactForm.tsx
@@ -241,6 +241,21 @@ export function ContactForm({
   // Once geo data loads, hide it for non-GDPR and set consent to true.
   const [showMarketingConsent, setShowMarketingConsent] = useState(true);
 
+  // With getStaticProps, router.query is empty on first render.
+  // Set prefilled values once they become available.
+  useEffect(() => {
+    const { dirtyFields } = form.formState;
+    if (prefillEmail && !dirtyFields.email) {
+      form.setValue("email", prefillEmail);
+    }
+    if (prefillHeadcount && !dirtyFields.company_headcount_form) {
+      form.setValue("company_headcount_form", prefillHeadcount);
+    }
+    if (prefillRegion && !dirtyFields.headquarters_region) {
+      form.setValue("headquarters_region", prefillRegion);
+    }
+  }, [prefillEmail, prefillHeadcount, prefillRegion, form]);
+
   useEffect(() => {
     if (!isGeoDataLoading && geoData) {
       if (!geoData.isGDPR) {

--- a/front/components/home/content/Competitive/CompetitiveHeroSection.tsx
+++ b/front/components/home/content/Competitive/CompetitiveHeroSection.tsx
@@ -1,27 +1,8 @@
-import {
-  ArrowRightIcon,
-  Button,
-  CheckIcon,
-  Icon,
-  LockIcon,
-  Spinner,
-  TimeIcon,
-} from "@dust-tt/sparkle";
+import { CheckIcon, Icon, LockIcon, TimeIcon } from "@dust-tt/sparkle";
 import type { ReactNode } from "react";
-import { useEffect, useState } from "react";
-import { useCookies } from "react-cookie";
 
-import { DUST_HAS_SESSION, hasSessionIndicator } from "@app/lib/cookies";
-import { clientFetch } from "@app/lib/egress/client";
-import {
-  trackEvent,
-  TRACKING_ACTIONS,
-  TRACKING_AREAS,
-  withTracking,
-} from "@app/lib/tracking";
-import { appendUTMParams } from "@app/lib/utils/utm";
-import logger from "@app/logger/logger";
-import { normalizeError } from "@app/types";
+import { LandingEmailSignup } from "@app/components/home/content/Landing/LandingEmailSignup";
+import { TRACKING_AREAS } from "@app/lib/tracking";
 
 interface CompetitiveHeroSectionProps {
   chip: string;
@@ -44,61 +25,6 @@ export function CompetitiveHeroSection({
   trustBadges,
   trackingObject = "glean_hero",
 }: CompetitiveHeroSectionProps) {
-  const [email, setEmail] = useState("");
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  const [cookies] = useCookies([DUST_HAS_SESSION], { doNotParse: true });
-  const [hasSession, setHasSession] = useState(false);
-
-  useEffect(() => {
-    setHasSession(hasSessionIndicator(cookies[DUST_HAS_SESSION]));
-  }, [cookies]);
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setError(null);
-
-    if (!email || !email.includes("@")) {
-      setError("Please enter a valid email");
-      return;
-    }
-
-    trackEvent({
-      area: TRACKING_AREAS.COMPETITIVE,
-      object: `${trackingObject}_email`,
-      action: TRACKING_ACTIONS.SUBMIT,
-    });
-
-    setIsLoading(true);
-
-    try {
-      const response = await clientFetch("/api/enrichment/company", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ email }),
-      });
-
-      const data = await response.json();
-
-      if (!data.success && data.error) {
-        setError(data.error);
-        return;
-      }
-
-      if (data.redirectUrl) {
-        window.location.href = appendUTMParams(data.redirectUrl);
-      }
-    } catch (err) {
-      logger.error({ error: normalizeError(err) }, "Enrichment error");
-      window.location.href = appendUTMParams(
-        `/api/workos/login?screenHint=sign-up&loginHint=${encodeURIComponent(email)}`
-      );
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
   return (
     <section className="w-full">
       <div
@@ -154,49 +80,11 @@ export function CompetitiveHeroSection({
 
           {/* Email CTA */}
           <div className="mt-2 w-full max-w-lg">
-            {hasSession ? (
-              <div className="flex flex-col items-center gap-3">
-                <Button
-                  variant="highlight"
-                  size="md"
-                  label="Open Dust"
-                  icon={ArrowRightIcon}
-                  onClick={withTracking(
-                    TRACKING_AREAS.COMPETITIVE,
-                    `${trackingObject}_open_dust`,
-                    () => {
-                      window.location.href = "/api/login";
-                    }
-                  )}
-                />
-                <p className="text-sm text-muted-foreground">
-                  Welcome back! Continue where you left off.
-                </p>
-              </div>
-            ) : (
-              <form onSubmit={handleSubmit}>
-                <div className="flex w-full items-center gap-2 rounded-xl border border-gray-200 bg-white p-1.5 shadow-md">
-                  <input
-                    type="email"
-                    value={email}
-                    onChange={(e) => setEmail(e.target.value)}
-                    placeholder="Enter your work email"
-                    className="flex-1 border-none bg-transparent px-3 py-2 text-base text-gray-700 placeholder-gray-400 outline-none focus:ring-0"
-                    disabled={isLoading}
-                  />
-                  <button
-                    type="submit"
-                    disabled={isLoading}
-                    className="flex items-center gap-2 rounded-lg bg-blue-500 px-5 py-2.5 font-semibold text-white shadow-sm transition-all hover:bg-blue-600 hover:shadow-md disabled:opacity-70"
-                  >
-                    {isLoading && <Spinner size="xs" />}
-                    {ctaButtonText}
-                    <ArrowRightIcon className="h-4 w-4" />
-                  </button>
-                </div>
-                {error && <p className="mt-2 text-sm text-red-500">{error}</p>}
-              </form>
-            )}
+            <LandingEmailSignup
+              ctaButtonText={ctaButtonText}
+              trackingLocation={trackingObject}
+              trackingArea={TRACKING_AREAS.COMPETITIVE}
+            />
           </div>
 
           {/* Trust badges */}

--- a/front/components/home/content/Competitive/EmailCTASection.tsx
+++ b/front/components/home/content/Competitive/EmailCTASection.tsx
@@ -1,24 +1,7 @@
-import {
-  ArrowRightIcon,
-  Button,
-  CheckIcon,
-  Icon,
-  Spinner,
-} from "@dust-tt/sparkle";
-import { useEffect, useState } from "react";
-import { useCookies } from "react-cookie";
+import { CheckIcon, Icon } from "@dust-tt/sparkle";
 
-import { DUST_HAS_SESSION, hasSessionIndicator } from "@app/lib/cookies";
-import { clientFetch } from "@app/lib/egress/client";
-import {
-  trackEvent,
-  TRACKING_ACTIONS,
-  TRACKING_AREAS,
-  withTracking,
-} from "@app/lib/tracking";
-import { appendUTMParams } from "@app/lib/utils/utm";
-import logger from "@app/logger/logger";
-import { normalizeError } from "@app/types";
+import { LandingEmailSignup } from "@app/components/home/content/Landing/LandingEmailSignup";
+import { TRACKING_AREAS } from "@app/lib/tracking";
 
 interface EmailCTASectionProps {
   title: string;
@@ -35,61 +18,6 @@ export function EmailCTASection({
   trustBadges,
   trackingObject = "glean_cta_bottom",
 }: EmailCTASectionProps) {
-  const [email, setEmail] = useState("");
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  const [cookies] = useCookies([DUST_HAS_SESSION], { doNotParse: true });
-  const [hasSession, setHasSession] = useState(false);
-
-  useEffect(() => {
-    setHasSession(hasSessionIndicator(cookies[DUST_HAS_SESSION]));
-  }, [cookies]);
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setError(null);
-
-    if (!email || !email.includes("@")) {
-      setError("Please enter a valid email");
-      return;
-    }
-
-    trackEvent({
-      area: TRACKING_AREAS.COMPETITIVE,
-      object: `${trackingObject}_email`,
-      action: TRACKING_ACTIONS.SUBMIT,
-    });
-
-    setIsLoading(true);
-
-    try {
-      const response = await clientFetch("/api/enrichment/company", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ email }),
-      });
-
-      const data = await response.json();
-
-      if (!data.success && data.error) {
-        setError(data.error);
-        return;
-      }
-
-      if (data.redirectUrl) {
-        window.location.href = appendUTMParams(data.redirectUrl);
-      }
-    } catch (err) {
-      logger.error({ error: normalizeError(err) }, "Enrichment error");
-      window.location.href = appendUTMParams(
-        `/api/workos/login?screenHint=sign-up&loginHint=${encodeURIComponent(email)}`
-      );
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
   return (
     <section className="w-full">
       <div
@@ -104,51 +32,13 @@ export function EmailCTASection({
           </h2>
           <p className="mb-8 text-lg text-blue-100">{subtitle}</p>
 
-          <div className="mx-auto max-w-lg">
-            {hasSession ? (
-              <div className="flex flex-col items-center gap-3">
-                <Button
-                  variant="highlight"
-                  size="md"
-                  label="Open Dust"
-                  icon={ArrowRightIcon}
-                  onClick={withTracking(
-                    TRACKING_AREAS.COMPETITIVE,
-                    `${trackingObject}_open_dust`,
-                    () => {
-                      window.location.href = "/api/login";
-                    }
-                  )}
-                />
-                <p className="text-sm text-blue-200">
-                  Welcome back! Continue where you left off.
-                </p>
-              </div>
-            ) : (
-              <form onSubmit={handleSubmit}>
-                <div className="flex w-full flex-col items-center gap-3 sm:flex-row">
-                  <input
-                    type="email"
-                    value={email}
-                    onChange={(e) => setEmail(e.target.value)}
-                    placeholder="Enter your work email"
-                    className="w-full flex-1 rounded-xl border-2 border-white/20 bg-white px-4 py-3.5 text-base text-gray-700 placeholder-gray-400 shadow-lg outline-none focus:border-white/40 focus:ring-0"
-                    disabled={isLoading}
-                  />
-                  <button
-                    type="submit"
-                    disabled={isLoading}
-                    className="flex w-full items-center justify-center gap-2 rounded-xl bg-emerald-500 px-6 py-3.5 font-semibold text-white shadow-lg transition-all hover:bg-emerald-600 hover:shadow-xl disabled:opacity-70 sm:w-auto"
-                  >
-                    {isLoading && <Spinner size="xs" />}
-                    {buttonText}
-                    <Icon visual={ArrowRightIcon} size="sm" />
-                  </button>
-                </div>
-                {error && <p className="mt-2 text-sm text-red-200">{error}</p>}
-              </form>
-            )}
-          </div>
+          <LandingEmailSignup
+            variant="dark"
+            ctaButtonText={buttonText}
+            trackingLocation={trackingObject}
+            trackingArea={TRACKING_AREAS.COMPETITIVE}
+            className="mx-auto max-w-lg"
+          />
 
           {/* Trust badges */}
           <div className="mt-6 flex flex-wrap items-center justify-center gap-4 text-sm text-blue-100">

--- a/front/components/home/content/Landing/EnterpriseChoiceModal.tsx
+++ b/front/components/home/content/Landing/EnterpriseChoiceModal.tsx
@@ -9,6 +9,7 @@ import {
   RocketIcon,
   UserGroupIcon,
 } from "@dust-tt/sparkle";
+import { useEffect, useRef } from "react";
 
 import {
   trackEvent,
@@ -58,11 +59,30 @@ export function EnterpriseChoiceModal({
     ? `${companyName} might benefit from our Enterprise plan`
     : "Your team might benefit from our Enterprise plan";
 
+  // Track modal open.
+  const prevOpenRef = useRef(false);
+  useEffect(() => {
+    if (isOpen && !prevOpenRef.current) {
+      trackEvent({
+        area: TRACKING_AREAS.HOME,
+        object: `${trackingLocation}_enterprise_modal`,
+        action: TRACKING_ACTIONS.OPEN,
+        extra: { companyName: companyName ?? "unknown" },
+      });
+    }
+    prevOpenRef.current = isOpen;
+  }, [isOpen, trackingLocation, companyName]);
+
   return (
     <Dialog
       open={isOpen}
       onOpenChange={(open) => {
         if (!open) {
+          trackEvent({
+            area: TRACKING_AREAS.HOME,
+            object: `${trackingLocation}_enterprise_modal`,
+            action: TRACKING_ACTIONS.CLOSE,
+          });
           onClose();
         }
       }}

--- a/front/components/home/content/Landing/EnterpriseChoiceModal.tsx
+++ b/front/components/home/content/Landing/EnterpriseChoiceModal.tsx
@@ -1,0 +1,112 @@
+import {
+  Dialog,
+  DialogContainer,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  Icon,
+  RocketIcon,
+  UserGroupIcon,
+} from "@dust-tt/sparkle";
+
+import {
+  trackEvent,
+  TRACKING_ACTIONS,
+  TRACKING_AREAS,
+} from "@app/lib/tracking";
+import { appendUTMParams } from "@app/lib/utils/utm";
+
+export interface EnterpriseChoiceModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  companyName?: string;
+  contactUrl: string;
+  signupUrl: string;
+  trackingLocation: string;
+}
+
+export function EnterpriseChoiceModal({
+  isOpen,
+  onClose,
+  companyName,
+  contactUrl,
+  signupUrl,
+  trackingLocation,
+}: EnterpriseChoiceModalProps) {
+  const handleFreeTrial = () => {
+    trackEvent({
+      area: TRACKING_AREAS.HOME,
+      object: `${trackingLocation}_enterprise_choice`,
+      action: TRACKING_ACTIONS.CLICK,
+      extra: { choice: "free_trial" },
+    });
+    window.location.href = appendUTMParams(signupUrl);
+  };
+
+  const handleScheduleDemo = () => {
+    trackEvent({
+      area: TRACKING_AREAS.HOME,
+      object: `${trackingLocation}_enterprise_choice`,
+      action: TRACKING_ACTIONS.CLICK,
+      extra: { choice: "schedule_demo" },
+    });
+    window.location.href = appendUTMParams(contactUrl);
+  };
+
+  const title = companyName
+    ? `${companyName} might benefit from our Enterprise plan`
+    : "Your team might benefit from our Enterprise plan";
+
+  return (
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) {
+          onClose();
+        }
+      }}
+    >
+      <DialogContent size="md">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>
+            How would you like to get started?
+          </DialogDescription>
+        </DialogHeader>
+        <DialogContainer>
+          <div className="flex flex-col gap-3 sm:flex-row">
+            <button
+              onClick={handleFreeTrial}
+              className="group flex flex-1 flex-col items-center rounded-2xl border border-gray-200 px-5 py-6 text-center transition-all hover:border-blue-300 hover:bg-blue-50 hover:shadow-md"
+            >
+              <div className="mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-blue-100 transition-colors group-hover:bg-blue-200">
+                <Icon visual={RocketIcon} className="text-blue-600" />
+              </div>
+              <span className="text-base font-semibold text-gray-900">
+                Start a free trial
+              </span>
+              <span className="mt-1 text-sm text-gray-500">
+                Get started right away with our Pro plan
+              </span>
+            </button>
+            <button
+              onClick={handleScheduleDemo}
+              className="group flex flex-1 flex-col items-center rounded-2xl border border-gray-200 px-5 py-6 text-center transition-all hover:border-emerald-300 hover:bg-emerald-50 hover:shadow-md"
+            >
+              <div className="mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-emerald-100 transition-colors group-hover:bg-emerald-200">
+                <Icon visual={UserGroupIcon} className="text-emerald-600" />
+              </div>
+              <span className="text-base font-semibold text-gray-900">
+                Schedule a demo
+              </span>
+              <span className="mt-1 text-sm text-gray-500">
+                See how Enterprise features can help your team
+              </span>
+            </button>
+          </div>
+        </DialogContainer>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/front/components/home/content/Landing/LandingEmailSignup.tsx
+++ b/front/components/home/content/Landing/LandingEmailSignup.tsx
@@ -1,4 +1,5 @@
 import { ArrowRightIcon, Button, cn, Icon, Spinner } from "@dust-tt/sparkle";
+import { useRouter } from "next/router";
 import type { ReactNode } from "react";
 import { useEffect, useState } from "react";
 import { useCookies } from "react-cookie";
@@ -30,6 +31,7 @@ export function LandingEmailSignup({
   className = "",
   children,
 }: LandingEmailSignupProps) {
+  const router = useRouter();
   const {
     email,
     setEmail,
@@ -49,6 +51,14 @@ export function LandingEmailSignup({
     setHasSession(hasSessionIndicator(cookies[DUST_HAS_SESSION]));
   }, [cookies]);
 
+  const handleOpenDust = withTracking(
+    trackingArea,
+    `${trackingLocation}_open_dust`,
+    () => {
+      void router.push("/api/login");
+    }
+  );
+
   if (hasSession) {
     return (
       <div className={cn("flex flex-col items-center gap-3", className)}>
@@ -57,13 +67,7 @@ export function LandingEmailSignup({
           size="md"
           label="Open Dust"
           icon={ArrowRightIcon}
-          onClick={withTracking(
-            trackingArea,
-            `${trackingLocation}_open_dust`,
-            () => {
-              window.location.href = "/api/login";
-            }
-          )}
+          onClick={handleOpenDust}
         />
         <p
           className={cn(

--- a/front/components/home/content/Landing/LandingEmailSignup.tsx
+++ b/front/components/home/content/Landing/LandingEmailSignup.tsx
@@ -1,35 +1,46 @@
-import { ArrowRightIcon, Button, cn, Spinner } from "@dust-tt/sparkle";
+import { ArrowRightIcon, Button, cn, Icon, Spinner } from "@dust-tt/sparkle";
+import type { ReactNode } from "react";
 import { useEffect, useState } from "react";
 import { useCookies } from "react-cookie";
 
+import { EnterpriseChoiceModal } from "@app/components/home/content/Landing/EnterpriseChoiceModal";
+import { useEnrichmentSubmit } from "@app/components/home/content/Landing/useEnrichmentSubmit";
 import { DUST_HAS_SESSION, hasSessionIndicator } from "@app/lib/cookies";
-import { clientFetch } from "@app/lib/egress/client";
-import {
-  trackEvent,
-  TRACKING_ACTIONS,
-  TRACKING_AREAS,
-  withTracking,
-} from "@app/lib/tracking";
-import { appendUTMParams } from "@app/lib/utils/utm";
-import logger from "@app/logger/logger";
-import { normalizeError } from "@app/types";
+import type { TrackingArea } from "@app/lib/tracking";
+import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 
 interface LandingEmailSignupProps {
   ctaButtonText: string;
-  welcomeBackText?: string;
   trackingLocation: string;
+  trackingArea?: TrackingArea;
+  placeholder?: string;
+  welcomeBackText?: string;
+  variant?: "default" | "dark";
   className?: string;
+  children?: ReactNode;
 }
 
 export function LandingEmailSignup({
   ctaButtonText,
   welcomeBackText = "Welcome back! Continue where you left off.",
   trackingLocation,
+  trackingArea = TRACKING_AREAS.HOME,
+  placeholder = "Enter your work email",
+  variant = "default",
   className = "",
+  children,
 }: LandingEmailSignupProps) {
-  const [email, setEmail] = useState("");
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const {
+    email,
+    setEmail,
+    isLoading,
+    error,
+    handleSubmit,
+    enterpriseModalProps,
+  } = useEnrichmentSubmit({
+    trackingArea,
+    trackingObject: trackingLocation,
+  });
 
   const [cookies] = useCookies([DUST_HAS_SESSION], { doNotParse: true });
   const [hasSession, setHasSession] = useState(false);
@@ -37,50 +48,6 @@ export function LandingEmailSignup({
   useEffect(() => {
     setHasSession(hasSessionIndicator(cookies[DUST_HAS_SESSION]));
   }, [cookies]);
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setError(null);
-
-    if (!email || !email.includes("@")) {
-      setError("Please enter a valid email");
-      return;
-    }
-
-    trackEvent({
-      area: TRACKING_AREAS.HOME,
-      object: `${trackingLocation}_email`,
-      action: TRACKING_ACTIONS.SUBMIT,
-    });
-
-    setIsLoading(true);
-
-    try {
-      const response = await clientFetch("/api/enrichment/company", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ email }),
-      });
-
-      const data = await response.json();
-
-      if (!data.success && data.error) {
-        setError(data.error);
-        return;
-      }
-
-      if (data.redirectUrl) {
-        window.location.href = appendUTMParams(data.redirectUrl);
-      }
-    } catch (err) {
-      logger.error({ error: normalizeError(err) }, "Enrichment error");
-      window.location.href = appendUTMParams(
-        `/api/workos/login?screenHint=sign-up&loginHint=${encodeURIComponent(email)}`
-      );
-    } finally {
-      setIsLoading(false);
-    }
-  };
 
   if (hasSession) {
     return (
@@ -91,40 +58,84 @@ export function LandingEmailSignup({
           label="Open Dust"
           icon={ArrowRightIcon}
           onClick={withTracking(
-            TRACKING_AREAS.HOME,
+            trackingArea,
             `${trackingLocation}_open_dust`,
             () => {
               window.location.href = "/api/login";
             }
           )}
         />
-        <p className="text-sm text-muted-foreground">{welcomeBackText}</p>
+        <p
+          className={cn(
+            "text-sm",
+            variant === "dark" ? "text-blue-200" : "text-muted-foreground"
+          )}
+        >
+          {welcomeBackText}
+        </p>
       </div>
     );
   }
 
+  const isDark = variant === "dark";
+
   return (
-    <form onSubmit={handleSubmit} className={className}>
-      <div className="flex w-full items-center gap-2 rounded-xl border border-gray-200 bg-white p-1.5 shadow-md">
-        <input
-          type="email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-          placeholder="Enter your work email"
-          className="flex-1 border-none bg-transparent px-3 py-2 text-base text-gray-700 placeholder-gray-400 outline-none focus:ring-0"
-          disabled={isLoading}
-        />
-        <button
-          type="submit"
-          disabled={isLoading}
-          className="flex items-center gap-2 rounded-lg bg-blue-500 px-5 py-2.5 font-semibold text-white shadow-sm transition-all hover:bg-blue-600 hover:shadow-md disabled:opacity-70"
-        >
-          {isLoading && <Spinner size="xs" />}
-          {ctaButtonText}
-          <ArrowRightIcon className="h-4 w-4" />
-        </button>
-      </div>
-      {error && <p className="mt-2 text-sm text-red-500">{error}</p>}
-    </form>
+    <>
+      <form onSubmit={handleSubmit} className={className}>
+        {isDark ? (
+          <div className="flex w-full flex-col items-center gap-3 sm:flex-row">
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder={placeholder}
+              className="w-full flex-1 rounded-xl border-2 border-white/20 bg-white px-4 py-3.5 text-base text-gray-700 placeholder-gray-400 shadow-lg outline-none focus:border-white/40 focus:ring-0"
+              disabled={isLoading}
+            />
+            <button
+              type="submit"
+              disabled={isLoading}
+              className="flex w-full items-center justify-center gap-2 rounded-xl bg-emerald-500 px-6 py-3.5 font-semibold text-white shadow-lg transition-all hover:bg-emerald-600 hover:shadow-xl disabled:opacity-70 sm:w-auto"
+            >
+              {isLoading && <Spinner size="xs" />}
+              {ctaButtonText}
+              <Icon visual={ArrowRightIcon} size="sm" />
+            </button>
+          </div>
+        ) : (
+          <div className="flex w-full items-center gap-2 rounded-xl border border-gray-200 bg-white p-1.5 shadow-md">
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder={placeholder}
+              className="flex-1 border-none bg-transparent px-3 py-2 text-base text-gray-700 placeholder-gray-400 outline-none focus:ring-0"
+              disabled={isLoading}
+            />
+            <button
+              type="submit"
+              disabled={isLoading}
+              className="flex items-center gap-2 rounded-lg bg-blue-500 px-5 py-2.5 font-semibold text-white shadow-sm transition-all hover:bg-blue-600 hover:shadow-md disabled:opacity-70"
+            >
+              {isLoading && <Spinner size="xs" />}
+              {ctaButtonText}
+              <ArrowRightIcon className="h-4 w-4" />
+            </button>
+          </div>
+        )}
+        {error && (
+          <p
+            className={cn(
+              "mt-2 text-sm",
+              isDark ? "text-red-200" : "text-red-500"
+            )}
+          >
+            {error}
+          </p>
+        )}
+        {children}
+      </form>
+      <EnterpriseChoiceModal {...enterpriseModalProps} />
+    </>
   );
 }

--- a/front/components/home/content/Landing/useEnrichmentSubmit.ts
+++ b/front/components/home/content/Landing/useEnrichmentSubmit.ts
@@ -1,11 +1,8 @@
 import { useState } from "react";
 
 import { clientFetch } from "@app/lib/egress/client";
-import {
-  trackEvent,
-  TRACKING_ACTIONS,
-  type TrackingArea,
-} from "@app/lib/tracking";
+import type { TrackingArea } from "@app/lib/tracking";
+import { trackEvent, TRACKING_ACTIONS } from "@app/lib/tracking";
 import { appendUTMParams } from "@app/lib/utils/utm";
 import logger from "@app/logger/logger";
 import { normalizeError } from "@app/types";

--- a/front/components/home/content/Landing/useEnrichmentSubmit.ts
+++ b/front/components/home/content/Landing/useEnrichmentSubmit.ts
@@ -1,0 +1,115 @@
+import { useState } from "react";
+
+import { clientFetch } from "@app/lib/egress/client";
+import {
+  trackEvent,
+  TRACKING_ACTIONS,
+  type TrackingArea,
+} from "@app/lib/tracking";
+import { appendUTMParams } from "@app/lib/utils/utm";
+import logger from "@app/logger/logger";
+import { normalizeError } from "@app/types";
+
+import type { EnterpriseChoiceModalProps } from "./EnterpriseChoiceModal";
+
+interface UseEnrichmentSubmitOptions {
+  trackingArea: TrackingArea;
+  trackingObject: string;
+}
+
+export function useEnrichmentSubmit({
+  trackingArea,
+  trackingObject,
+}: UseEnrichmentSubmitOptions) {
+  const [email, setEmail] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [enterpriseData, setEnterpriseData] = useState<{
+    contactUrl: string;
+    signupUrl: string;
+    companyName?: string;
+  } | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    if (!email || !email.includes("@")) {
+      setError("Please enter a valid email");
+      return;
+    }
+
+    trackEvent({
+      area: trackingArea,
+      object: `${trackingObject}_email`,
+      action: TRACKING_ACTIONS.SUBMIT,
+    });
+
+    setIsLoading(true);
+
+    // TODO: Remove this dev shortcut before committing.
+    if (process.env.NODE_ENV === "development") {
+      const encodedEmail = encodeURIComponent(email);
+      setEnterpriseData({
+        contactUrl: `/home/contact?email=${encodedEmail}`,
+        signupUrl: `/api/workos/login?screenHint=sign-up&loginHint=${encodedEmail}`,
+        companyName: "Qonto",
+      });
+      setIsLoading(false);
+      return;
+    }
+
+    try {
+      const response = await clientFetch("/api/enrichment/company", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email }),
+      });
+
+      const data = await response.json();
+
+      if (!data.success && data.error) {
+        setError(data.error);
+        return;
+      }
+
+      if (data.redirectUrl) {
+        if (data.redirectUrl.includes("/home/contact")) {
+          const encodedEmail = encodeURIComponent(email);
+          setEnterpriseData({
+            contactUrl: data.redirectUrl,
+            signupUrl: `/api/workos/login?screenHint=sign-up&loginHint=${encodedEmail}`,
+            companyName: data.companyName,
+          });
+        } else {
+          window.location.href = appendUTMParams(data.redirectUrl);
+        }
+      }
+    } catch (err) {
+      logger.error({ error: normalizeError(err) }, "Enrichment error");
+      window.location.href = appendUTMParams(
+        `/api/workos/login?screenHint=sign-up&loginHint=${encodeURIComponent(email)}`
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const enterpriseModalProps: EnterpriseChoiceModalProps = {
+    isOpen: enterpriseData !== null,
+    onClose: () => setEnterpriseData(null),
+    companyName: enterpriseData?.companyName,
+    contactUrl: enterpriseData?.contactUrl ?? "",
+    signupUrl: enterpriseData?.signupUrl ?? "",
+    trackingLocation: trackingObject,
+  };
+
+  return {
+    email,
+    setEmail,
+    isLoading,
+    error,
+    handleSubmit,
+    enterpriseModalProps,
+  };
+}

--- a/front/components/home/content/Landing/useEnrichmentSubmit.ts
+++ b/front/components/home/content/Landing/useEnrichmentSubmit.ts
@@ -47,18 +47,6 @@ export function useEnrichmentSubmit({
 
     setIsLoading(true);
 
-    // TODO: Remove this dev shortcut before committing.
-    if (process.env.NODE_ENV === "development") {
-      const encodedEmail = encodeURIComponent(email);
-      setEnterpriseData({
-        contactUrl: `/home/contact?email=${encodedEmail}`,
-        signupUrl: `/api/workos/login?screenHint=sign-up&loginHint=${encodedEmail}`,
-        companyName: "Qonto",
-      });
-      setIsLoading(false);
-      return;
-    }
-
     try {
       const response = await clientFetch("/api/enrichment/company", {
         method: "POST",

--- a/front/components/home/content/Product/IntroSection.tsx
+++ b/front/components/home/content/Product/IntroSection.tsx
@@ -38,7 +38,7 @@ const HeroContent = () => {
           trackingLocation="hero"
         >
           <p className="mt-3 text-sm text-muted-foreground">
-            14-day free trial. Cancel anytime.
+            14-day free trial. No credit card required. Cancel anytime.
           </p>
         </LandingEmailSignup>
       </div>

--- a/front/components/home/content/Product/IntroSection.tsx
+++ b/front/components/home/content/Product/IntroSection.tsx
@@ -1,8 +1,7 @@
-import { ArrowRightIcon, PlayIcon, Spinner } from "@dust-tt/sparkle";
+import { PlayIcon } from "@dust-tt/sparkle";
 import Image from "next/image";
-import { useEffect, useState } from "react";
-import { useCookies } from "react-cookie";
 
+import { LandingEmailSignup } from "@app/components/home/content/Landing/LandingEmailSignup";
 import { ScrollProgressSection } from "@app/components/home/content/Product/ScrollProgressSection";
 import { ValuePropSection } from "@app/components/home/content/Product/ValuePropSection";
 import {
@@ -14,74 +13,9 @@ import { FunctionsSection } from "@app/components/home/FunctionsSection";
 import TrustedBy from "@app/components/home/TrustedBy";
 import { BorderBeam } from "@app/components/magicui/border-beam";
 import UTMButton from "@app/components/UTMButton";
-import { DUST_HAS_SESSION, hasSessionIndicator } from "@app/lib/cookies";
-import { clientFetch } from "@app/lib/egress/client";
-import {
-  trackEvent,
-  TRACKING_ACTIONS,
-  TRACKING_AREAS,
-  withTracking,
-} from "@app/lib/tracking";
-import { appendUTMParams } from "@app/lib/utils/utm";
-import logger from "@app/logger/logger";
+import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 
 const HeroContent = () => {
-  const [email, setEmail] = useState("");
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  // Check session cookie only on client to avoid hydration mismatch.
-  const [cookies] = useCookies([DUST_HAS_SESSION], { doNotParse: true });
-  const [hasSession, setHasSession] = useState(false);
-  useEffect(() => {
-    setHasSession(hasSessionIndicator(cookies[DUST_HAS_SESSION]));
-  }, [cookies]);
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setError(null);
-
-    if (!email || !email.includes("@")) {
-      setError("Please enter a valid email");
-      return;
-    }
-
-    trackEvent({
-      area: TRACKING_AREAS.HOME,
-      object: "hero_email",
-      action: TRACKING_ACTIONS.SUBMIT,
-    });
-
-    setIsLoading(true);
-
-    try {
-      const response = await clientFetch("/api/enrichment/company", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ email }),
-      });
-
-      const data = await response.json();
-
-      if (!data.success && data.error) {
-        setError(data.error);
-        return;
-      }
-
-      if (data.redirectUrl) {
-        window.location.href = appendUTMParams(data.redirectUrl);
-      }
-    } catch (err) {
-      logger.error({ error: err }, "Enrichment error");
-      // Fallback to signup on error
-      window.location.href = appendUTMParams(
-        `/api/workos/login?screenHint=sign-up&loginHint=${encodeURIComponent(email)}`
-      );
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
   return (
     <div className="mx-auto flex max-w-4xl flex-col items-center gap-6 px-4 text-center sm:gap-2 sm:px-6">
       <H1 className="text-center text-5xl font-medium text-foreground md:text-6xl lg:text-7xl">
@@ -97,53 +31,16 @@ const HeroContent = () => {
         <br />
         knowledge and tools.
       </P>
-      {/* Email input or Open Dust button */}
       <div className="mt-12 w-full max-w-xl">
-        {hasSession ? (
-          <div className="flex flex-col items-center gap-3">
-            <button
-              onClick={withTracking(
-                TRACKING_AREAS.HOME,
-                "hero_open_dust",
-                () => {
-                  window.location.href = "/api/login";
-                }
-              )}
-              className="flex items-center gap-2 rounded-2xl bg-blue-500 px-8 py-4 text-lg font-semibold text-white shadow-sm transition-colors hover:bg-blue-600"
-            >
-              <ArrowRightIcon className="h-5 w-5" />
-              Open Dust
-            </button>
-            <p className="text-sm text-muted-foreground">
-              Welcome back! Continue where you left off.
-            </p>
-          </div>
-        ) : (
-          <form onSubmit={handleSubmit}>
-            <div className="flex w-full items-center gap-2 rounded-2xl border border-gray-100 bg-white px-1.5 py-1.5 shadow-sm">
-              <input
-                type="email"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                placeholder="What's your work email?"
-                className="flex-1 border-none bg-transparent pl-2 text-base text-gray-700 placeholder-gray-400 outline-none focus:ring-0"
-                disabled={isLoading}
-              />
-              <button
-                type="submit"
-                disabled={isLoading}
-                className="flex items-center gap-2 rounded-xl bg-blue-500 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-blue-600 disabled:opacity-70"
-              >
-                {isLoading && <Spinner size="xs" />}
-                Get started
-              </button>
-            </div>
-            {error && <p className="mt-2 text-sm text-red-500">{error}</p>}
-            <p className="mt-3 text-sm text-muted-foreground">
-              14-day free trial. Cancel anytime.
-            </p>
-          </form>
-        )}
+        <LandingEmailSignup
+          ctaButtonText="Get started"
+          placeholder="What's your work email?"
+          trackingLocation="hero"
+        >
+          <p className="mt-3 text-sm text-muted-foreground">
+            14-day free trial. Cancel anytime.
+          </p>
+        </LandingEmailSignup>
       </div>
     </div>
   );

--- a/front/components/home/content/Skip/config/skipConfig.tsx
+++ b/front/components/home/content/Skip/config/skipConfig.tsx
@@ -71,7 +71,7 @@ export const skipConfig: SkipConfig = {
     headline: "Welcome, Skip listeners 👋",
     subheadline:
       "You just heard about Dust on Nikhyl's show. Here's how ambitious tech professionals are using AI agents to level up their impact—and their careers.",
-    ctaButtonText: "Get started with Dust",
+    ctaButtonText: "Get started",
     testimonials: [
       {
         quote:
@@ -185,7 +185,7 @@ export const skipConfig: SkipConfig = {
   cta: {
     title: "See how Dust can accelerate your impact",
     subtitle: "Model-agnostic • Enterprise-ready • Deploy in minutes",
-    ctaText: "Get started with Dust",
+    ctaText: "Get started",
     ctaLink: "/api/workos/login?screenHint=sign-up",
   },
 };


### PR DESCRIPTION








## Description
Changes the user flow for enterprise signups—instead of redirecting directly to the contact form, they now see a modal offering two paths.
Consolidates duplicated email signup logic across competitive and product landing pages into a shared `LandingEmailSignup` component and introduces an enterprise choice modal. (-200 lines of duplicate code by extracting the email enrichment flow into a reusable `useEnrichmentSubmit` hook)
Implements an `EnterpriseChoiceModal` that lets large companies choose between starting a free trial or scheduling a demo when the enrichment API detects they qualify for Enterprise. 
Also adds logic to the `ContactForm` to prefill email, headcount, and region from query parameters (fixes issue where `router.query` is empty on first render with `getStaticProps`).

<img width="998" height="712" alt="Screenshot 2026-02-09 at 11 45 25" src="https://github.com/user-attachments/assets/db1f2e3e-b010-4de9-a008-96b5629a7a68" />

