### PR TITLE
Fix conversation drafts

### DIFF
--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -553,9 +553,17 @@ const InputBarContainer = ({
     const draft = getDraft();
     // Only restore draft if editor is empty to avoid overwriting existing content or sticky mentions.
     if (draft && editorService.isEmpty()) {
-      editorService.setContent(draft.text);
+      // Schedule content restoration to avoid flushing during render lifecycle.
+      queueMicrotask(() => editorService.setContent(draft.text));
     }
-  }, [conversation, editor, editorService, getDraft]);
+  }, [
+    conversation,
+    editor,
+    editor?.isInitialized,
+    editor?.isEditable,
+    editorService,
+    getDraft,
+  ]);
 
   useHandleMentions(
     editorService,

--- a/front/components/assistant/conversation/input_bar/useConversationDrafts.ts
+++ b/front/components/assistant/conversation/input_bar/useConversationDrafts.ts
@@ -83,19 +83,20 @@ export function useConversationDrafts({
   }, []);
 
   // Create a ref to hold the debounced save function
-  const debouncedSaveRef = useRef<
-    ReturnType<
-      typeof debounce<
-        (params: {
-          workspaceId: string;
-          userId: string;
-          draftKey: string;
-          text: string;
-          timestamp: number;
-        }) => void
+  const debouncedSaveRef =
+    useRef<
+      ReturnType<
+        typeof debounce<
+          (params: {
+            workspaceId: string;
+            userId: string;
+            draftKey: string;
+            text: string;
+            timestamp: number;
+          }) => void
+        >
       >
-    >
-  >();
+    >();
 
   // Update the debounced function when dependencies change
   useEffect(() => {
@@ -175,7 +176,13 @@ export function useConversationDrafts({
     debouncedSaveRef.current?.cancel();
 
     saveDraftsToStorage(drafts);
-  }, [getDraftsFromStorage, workspaceId, userId, draftKey, saveDraftsToStorage]);
+  }, [
+    getDraftsFromStorage,
+    workspaceId,
+    userId,
+    draftKey,
+    saveDraftsToStorage,
+  ]);
 
   const clearAllDraftsFromUser = useCallback(() => {
     const drafts = getDraftsFromStorage();

--- a/front/components/assistant/conversation/input_bar/useConversationDrafts.ts
+++ b/front/components/assistant/conversation/input_bar/useConversationDrafts.ts
@@ -1,5 +1,5 @@
 import debounce from "lodash/debounce";
-import { useCallback, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 
 import logger from "@app/logger/logger";
 
@@ -82,9 +82,28 @@ export function useConversationDrafts({
     }
   }, []);
 
-  // Debounced save function.
-  const debouncedSave = useRef(
-    debounce(
+  // Create a ref to hold the debounced save function
+  const debouncedSaveRef = useRef<
+    ReturnType<
+      typeof debounce<
+        (params: {
+          workspaceId: string;
+          userId: string;
+          draftKey: string;
+          text: string;
+          timestamp: number;
+        }) => void
+      >
+    >
+  >();
+
+  // Update the debounced function when dependencies change
+  useEffect(() => {
+    // Cancel any pending debounced calls from the old function
+    debouncedSaveRef.current?.cancel();
+
+    // Create new debounced function with current closures
+    debouncedSaveRef.current = debounce(
       ({
         workspaceId,
         userId,
@@ -110,8 +129,8 @@ export function useConversationDrafts({
         saveDraftsToStorage(drafts);
       },
       500
-    )
-  ).current;
+    );
+  }, [getDraftsFromStorage, saveDraftsToStorage]);
 
   // Save draft for current conversation (debounced).
   const saveDraft = useCallback(
@@ -120,7 +139,7 @@ export function useConversationDrafts({
         return;
       }
 
-      debouncedSave({
+      debouncedSaveRef.current?.({
         workspaceId,
         userId,
         draftKey,
@@ -128,7 +147,7 @@ export function useConversationDrafts({
         timestamp: Date.now(),
       });
     },
-    [debouncedSave, workspaceId, userId, shouldUseDraft, draftKey]
+    [workspaceId, userId, shouldUseDraft, draftKey]
   );
 
   // Get draft for current conversation.
@@ -153,17 +172,10 @@ export function useConversationDrafts({
     delete drafts[getKeyId(workspaceId, userId, draftKey)];
 
     // Also, cancel any pending debounced save.
-    debouncedSave.cancel();
+    debouncedSaveRef.current?.cancel();
 
     saveDraftsToStorage(drafts);
-  }, [
-    getDraftsFromStorage,
-    workspaceId,
-    userId,
-    draftKey,
-    saveDraftsToStorage,
-    debouncedSave,
-  ]);
+  }, [getDraftsFromStorage, workspaceId, userId, draftKey, saveDraftsToStorage]);
 
   const clearAllDraftsFromUser = useCallback(() => {
     const drafts = getDraftsFromStorage();


### PR DESCRIPTION
## Description

**Problem**: The draft auto-save feature for the conversation input bar was broken and no longer persisting user input to localStorage.

The `useConversationDrafts` hook had a stale closure issue. The debounced save function was created once using `useRef` and captured the initial versions of `getDraftsFromStorage()` and `saveDraftsToStorage()`. When these functions were recreated (due to dependency changes), the debounced function continued using the stale versions, causing drafts to fail to save.

This PR restructures the hook to store the debounced function itself in a ref and recreate it in a useEffect whenever `getDraftsFromStorage` or `saveDraftsToStorage` change. This ensures the debounced function always has fresh closures over the current function versions.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Deploy front
