### PR TITLE
[front] - chore(workspace): D/W/MAU analytics

### DIFF
--- a/front/components/agent_builder/observability/constants.ts
+++ b/front/components/agent_builder/observability/constants.ts
@@ -18,6 +18,18 @@ export const USAGE_METRICS_LEGEND = [
   { key: "activeUsers", label: "Active users" },
 ] as const;
 
+export const ACTIVE_USERS_PALETTE = {
+  dau: "text-blue-500 dark:text-blue-500-night",
+  wau: "text-violet-500 dark:text-violet-500-night",
+  mau: "text-golden-500 dark:text-golden-500-night",
+} as const;
+
+export const ACTIVE_USERS_LEGEND = [
+  { key: "dau", label: "DAU" },
+  { key: "wau", label: "WAU" },
+  { key: "mau", label: "MAU" },
+] as const;
+
 export const LATENCY_PALETTE = {
   average: "text-blue-500 dark:text-blue-500-night",
   median: "text-violet-500 dark:text-violet-500-night",

--- a/front/components/poke/pages/WorkspacePage.tsx
+++ b/front/components/poke/pages/WorkspacePage.tsx
@@ -20,6 +20,7 @@ import { FeatureFlagsDataTable } from "@app/components/poke/features/table";
 import { GroupDataTable } from "@app/components/poke/groups/table";
 import { MCPServerViewsDataTable } from "@app/components/poke/mcp_server_views/table";
 import { WorkspaceDatasourceRetrievalTreemapPluginChart } from "@app/components/poke/plugins/components/WorkspaceDatasourceRetrievalTreemapPluginChart";
+import { WorkspaceUsageChart } from "@app/components/workspace/analytics/WorkspaceUsageChart";
 import { PluginList } from "@app/components/poke/plugins/PluginList";
 import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
 import {
@@ -292,10 +293,13 @@ export function WorkspacePage() {
               />
             </TabsContent>
             <TabsContent value="analytics">
-              <WorkspaceDatasourceRetrievalTreemapPluginChart
-                workspaceId={owner.sId}
-                period={30}
-              />
+              <div className="flex flex-col gap-6">
+                <WorkspaceUsageChart workspaceId={owner.sId} period={30} />
+                <WorkspaceDatasourceRetrievalTreemapPluginChart
+                  workspaceId={owner.sId}
+                  period={30}
+                />
+              </div>
             </TabsContent>
           </Tabs>
         </div>

--- a/front/components/poke/pages/WorkspacePage.tsx
+++ b/front/components/poke/pages/WorkspacePage.tsx
@@ -20,7 +20,6 @@ import { FeatureFlagsDataTable } from "@app/components/poke/features/table";
 import { GroupDataTable } from "@app/components/poke/groups/table";
 import { MCPServerViewsDataTable } from "@app/components/poke/mcp_server_views/table";
 import { WorkspaceDatasourceRetrievalTreemapPluginChart } from "@app/components/poke/plugins/components/WorkspaceDatasourceRetrievalTreemapPluginChart";
-import { WorkspaceUsageChart } from "@app/components/workspace/analytics/WorkspaceUsageChart";
 import { PluginList } from "@app/components/poke/plugins/PluginList";
 import { useSetPokePageTitle } from "@app/components/poke/PokeLayout";
 import {
@@ -36,6 +35,7 @@ import {
 } from "@app/components/poke/subscriptions/table";
 import { TriggerDataTable } from "@app/components/poke/triggers/table";
 import { WorkspaceInfoTable } from "@app/components/poke/workspace/table";
+import { WorkspaceUsageChart } from "@app/components/workspace/analytics/WorkspaceUsageChart";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { clientFetch } from "@app/lib/egress/client";

--- a/front/components/workspace/analytics/WorkspaceUsageChart.tsx
+++ b/front/components/workspace/analytics/WorkspaceUsageChart.tsx
@@ -178,7 +178,7 @@ function UsageMetricsTooltip({
         colorClassName: ACTIVE_USERS_PALETTE.wau,
       },
       {
-        label: "MAU (30-day)",
+        label: "MAU (28-day)",
         value: row.mau.toLocaleString(),
         colorClassName: ACTIVE_USERS_PALETTE.mau,
       },

--- a/front/components/workspace/analytics/WorkspaceUsageChart.tsx
+++ b/front/components/workspace/analytics/WorkspaceUsageChart.tsx
@@ -53,17 +53,17 @@ function getLegendItemsForMode(displayMode: UsageDisplayMode): LegendItem[] {
       return [
         {
           key: "dau",
-          label: "DAU",
+          label: "Daily",
           colorClassName: ACTIVE_USERS_PALETTE.dau,
         },
         {
           key: "wau",
-          label: "WAU",
+          label: "Weekly",
           colorClassName: ACTIVE_USERS_PALETTE.wau,
         },
         {
           key: "mau",
-          label: "MAU",
+          label: "Monthly",
           colorClassName: ACTIVE_USERS_PALETTE.mau,
         },
       ];

--- a/front/lib/api/assistant/observability/active_users_metrics.ts
+++ b/front/lib/api/assistant/observability/active_users_metrics.ts
@@ -33,7 +33,7 @@ interface ActiveUsersAggs {
 }
 
 const WAU_WINDOW_DAYS = 7;
-const MAU_WINDOW_DAYS = 30;
+const MAU_WINDOW_DAYS = 28;
 const MAX_USERS_PER_DAY = 10000;
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 

--- a/front/lib/api/assistant/observability/active_users_metrics.ts
+++ b/front/lib/api/assistant/observability/active_users_metrics.ts
@@ -1,0 +1,167 @@
+import type { estypes } from "@elastic/elasticsearch";
+
+import {
+  bucketsToArray,
+  formatUTCDateFromMillis,
+  searchAnalytics,
+} from "@app/lib/api/elasticsearch";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+
+export interface ActiveUsersMetricsPoint {
+  timestamp: number;
+  date: string;
+  dau: number;
+  wau: number;
+  mau: number;
+}
+
+interface UserBucket {
+  key: string;
+  doc_count: number;
+}
+
+interface DayBucket {
+  key: number;
+  key_as_string: string;
+  doc_count: number;
+  users?: estypes.AggregationsMultiBucketAggregateBase<UserBucket>;
+}
+
+interface ActiveUsersAggs {
+  by_day?: estypes.AggregationsMultiBucketAggregateBase<DayBucket>;
+}
+
+const WAU_WINDOW_DAYS = 7;
+const MAU_WINDOW_DAYS = 30;
+const MAX_USERS_PER_DAY = 10000;
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * Computes the count of unique users over a rolling window ending at the given timestamp.
+ */
+function computeRollingActiveUsers(
+  usersByDay: Map<number, Set<string>>,
+  endTimestamp: number,
+  windowDays: number
+): number {
+  const startMs = endTimestamp - (windowDays - 1) * MS_PER_DAY;
+  const uniqueUsers = new Set<string>();
+
+  for (const [ts, users] of usersByDay) {
+    if (ts >= startMs && ts <= endTimestamp) {
+      for (const user of users) {
+        uniqueUsers.add(user);
+      }
+    }
+  }
+
+  return uniqueUsers.size;
+}
+
+/**
+ * Fetches DAU/WAU/MAU metrics for the given time range.
+ *
+ * Strategy:
+ * 1. Fetch user IDs per day using a single ES query with terms aggregation
+ * 2. Compute rolling WAU (7-day) and MAU (30-day) windows on the server
+ *
+ * This approach is efficient (single ES query) and accurate for typical workspace sizes.
+ */
+export async function fetchActiveUsersMetrics(
+  workspaceId: string,
+  days: number
+): Promise<Result<ActiveUsersMetricsPoint[], Error>> {
+  // Extend the query range to include extra days for rolling window calculations
+  // We need MAU_WINDOW_DAYS - 1 extra days before the start to calculate MAU for day 1
+  const extendedDays = days + MAU_WINDOW_DAYS - 1;
+
+  const query: estypes.QueryDslQueryContainer = {
+    bool: {
+      filter: [
+        { term: { workspace_id: workspaceId } },
+        { range: { timestamp: { gte: `now-${extendedDays}d/d` } } },
+        { exists: { field: "user_id" } }, // Exclude programmatic usage
+      ],
+    },
+  };
+
+  const result = await searchAnalytics<never, ActiveUsersAggs>(query, {
+    aggregations: {
+      by_day: {
+        date_histogram: {
+          field: "timestamp",
+          calendar_interval: "day",
+          time_zone: "UTC",
+        },
+        aggs: {
+          users: {
+            terms: {
+              field: "user_id",
+              size: MAX_USERS_PER_DAY,
+            },
+          },
+        },
+      },
+    },
+    size: 0,
+  });
+
+  if (result.isErr()) {
+    return new Err(new Error(result.error.message));
+  }
+
+  const dayBuckets = bucketsToArray<DayBucket>(
+    result.value.aggregations?.by_day?.buckets
+  );
+
+  // Build a map of timestamp -> Set of user IDs
+  const usersByDay = new Map<number, Set<string>>();
+  const sortedTimestamps: number[] = [];
+
+  for (const bucket of dayBuckets) {
+    const users = bucketsToArray<UserBucket>(bucket.users?.buckets);
+    const userSet = new Set(users.map((u) => u.key));
+    usersByDay.set(bucket.key, userSet);
+    sortedTimestamps.push(bucket.key);
+  }
+
+  sortedTimestamps.sort((a, b) => a - b);
+
+  // Determine the cutoff timestamp - we only return points for the requested range
+  const now = Date.now();
+  const startOfToday = new Date(now).setUTCHours(0, 0, 0, 0);
+  const cutoffTimestamp = startOfToday - (days - 1) * MS_PER_DAY;
+
+  // Calculate rolling windows for each day in the requested range
+  const points: ActiveUsersMetricsPoint[] = [];
+
+  for (const timestamp of sortedTimestamps) {
+    // Only include days within the requested range
+    if (timestamp < cutoffTimestamp) {
+      continue;
+    }
+
+    const dau = usersByDay.get(timestamp)?.size ?? 0;
+    const wau = computeRollingActiveUsers(
+      usersByDay,
+      timestamp,
+      WAU_WINDOW_DAYS
+    );
+    const mau = computeRollingActiveUsers(
+      usersByDay,
+      timestamp,
+      MAU_WINDOW_DAYS
+    );
+
+    points.push({
+      timestamp,
+      date: formatUTCDateFromMillis(timestamp),
+      dau,
+      wau,
+      mau,
+    });
+  }
+
+  return new Ok(points);
+}

--- a/front/lib/swr/workspaces.ts
+++ b/front/lib/swr/workspaces.ts
@@ -11,6 +11,7 @@ import { getApiBaseUrl } from "@app/lib/egress/client";
 import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetNoWorkspaceAuthContextResponseType } from "@app/pages/api/auth-context";
 import type { GetWorkspaceResponseBody } from "@app/pages/api/w/[wId]";
+import type { GetWorkspaceActiveUsersResponse } from "@app/pages/api/w/[wId]/analytics/active-users";
 import type { GetWorkspaceAnalyticsOverviewResponse } from "@app/pages/api/w/[wId]/analytics/overview";
 import type { GetWorkspaceContextOriginResponse } from "@app/pages/api/w/[wId]/analytics/source";
 import type { GetWorkspaceToolUsageResponse } from "@app/pages/api/w/[wId]/analytics/tool-usage";
@@ -140,6 +141,31 @@ export function useWorkspaceUsageMetrics({
     isUsageMetricsLoading: !error && !data && !disabled,
     isUsageMetricsError: error,
     isUsageMetricsValidating: isValidating,
+  };
+}
+
+export function useWorkspaceActiveUsersMetrics({
+  workspaceId,
+  days = DEFAULT_PERIOD_DAYS,
+  disabled,
+}: {
+  workspaceId: string;
+  days?: number;
+  disabled?: boolean;
+}) {
+  const fetcherFn: Fetcher<GetWorkspaceActiveUsersResponse> = fetcher;
+  const key = `/api/w/${workspaceId}/analytics/active-users?days=${days}`;
+
+  const { data, error, isValidating } = useSWRWithDefaults(
+    disabled ? null : key,
+    fetcherFn
+  );
+
+  return {
+    activeUsersMetrics: data?.points ?? emptyArray(),
+    isActiveUsersMetricsLoading: !error && !data && !disabled,
+    isActiveUsersMetricsError: error,
+    isActiveUsersMetricsValidating: isValidating,
   };
 }
 

--- a/front/pages/api/w/[wId]/analytics/active-users.ts
+++ b/front/pages/api/w/[wId]/analytics/active-users.ts
@@ -1,0 +1,79 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+
+import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import type { ActiveUsersMetricsPoint } from "@app/lib/api/assistant/observability/active_users_metrics";
+import { fetchActiveUsersMetrics } from "@app/lib/api/assistant/observability/active_users_metrics";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+
+const QuerySchema = z.object({
+  days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
+});
+
+export type GetWorkspaceActiveUsersResponse = {
+  points: ActiveUsersMetricsPoint[];
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<GetWorkspaceActiveUsersResponse>>,
+  auth: Authenticator
+) {
+  if (!auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "Only workspace admins can access workspace analytics.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      const { days: queryDays } = req.query;
+      const q = QuerySchema.safeParse({ days: queryDays });
+      if (!q.success) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid query parameters: ${q.error.message}`,
+          },
+        });
+      }
+
+      const { days } = q.data;
+      const owner = auth.getNonNullableWorkspace();
+
+      const result = await fetchActiveUsersMetrics(owner.sId, days);
+
+      if (result.isErr()) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: `Failed to retrieve active users metrics: ${result.error.message}`,
+          },
+        });
+      }
+
+      return res.status(200).json({
+        points: result.value,
+      });
+    }
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);


### PR DESCRIPTION
## Description

Adds Daily/Weekly/Monthly Active Users (DAU/WAU/MAU) metrics to workspace analytics. The `WorkspaceUsageChart` component now supports a "Users" display mode alongside the existing "Activity" mode, showing three distinct lines for active user breakdown over time.

A new backend API endpoint `/api/w/[wId]/analytics/active-users` leverages Elasticsearch aggregations to efficiently compute rolling active user windows. DAU tracks unique users per day, WAU uses a 7-day rolling window, and MAU uses a 28-day rolling window. The implementation pre-fetches extra days to accurately compute rolling windows for all requested dates.

The chart is integrated into the poke workspace analytics tab alongside the existing datasource retrieval treemap.

## Risk

Low. This adds a new analytics endpoint and chart display mode without modifying existing functionality.

## Tests

- [x] Locally
- [ ] Front-edge

## Deploy Plan

Deploy front