### PR TITLE
Stop fetching metadata, load picker with fileId instead of search term

### DIFF
--- a/front/components/assistant/conversation/GoogleDriveFileAuthorizationRequired.tsx
+++ b/front/components/assistant/conversation/GoogleDriveFileAuthorizationRequired.tsx
@@ -104,7 +104,7 @@ export function GoogleDriveFileAuthorizationRequired({
     developerKey: pickerCredentials?.developerKey ?? "",
     accessToken: pickerCredentials?.accessToken ?? null,
     appId: pickerCredentials?.appId ?? "",
-    searchQuery: fileAuthorizationInfo.fileName,
+    fileId: fileAuthorizationInfo.fileId,
     onFilesSelected: handleFilesSelected,
     onCancel: handlePickerCancel,
   });
@@ -139,15 +139,9 @@ export function GoogleDriveFileAuthorizationRequired({
         <>
           <div className="font-sm whitespace-normal break-words text-foreground dark:text-foreground-night">
             {isAuthorized ? (
-              `${fileAuthorizationInfo.fileName} is now accessible. Continuing...`
+              ` your file is now accessible. Continuing...`
             ) : (
-              <>
-                To access{" "}
-                <span className="font-semibold">
-                  {fileAuthorizationInfo.fileName}
-                </span>
-                , please authorize it once.
-              </>
+              <>To access your file, please authorize it once.</>
             )}
           </div>
           {!isAuthorized && (

--- a/front/hooks/useGooglePicker.ts
+++ b/front/hooks/useGooglePicker.ts
@@ -185,7 +185,7 @@ export function useGooglePicker({
         view.setMimeTypes(mimeTypes.join(","));
       }
 
-      // pre-fill with file but allow user to search outside the initial one selected
+      // Pre-select the file that needs authorization
       view.setFileIds(fileId);
 
       // Build the picker

--- a/front/hooks/useGooglePicker.ts
+++ b/front/hooks/useGooglePicker.ts
@@ -16,6 +16,7 @@ interface PickerBuilder {
 interface DocsView {
   setMimeTypes(mimeTypes: string): DocsView;
   setQuery(query: string): DocsView;
+  setFileIds(ids: string): DocsView;
 }
 
 interface Picker {
@@ -64,7 +65,7 @@ export interface UseGooglePickerProps {
   developerKey: string;
   accessToken: string | null;
   appId: string; // The Cloud project number (from clientId before .apps.googleusercontent.com)
-  searchQuery?: string;
+  fileId: string;
   mimeTypes?: string[];
   onFilesSelected: (files: GooglePickerFile[]) => void;
   onCancel?: () => void;
@@ -81,7 +82,7 @@ export function useGooglePicker({
   developerKey,
   accessToken,
   appId,
-  searchQuery,
+  fileId,
   mimeTypes,
   onFilesSelected,
   onCancel,
@@ -184,10 +185,8 @@ export function useGooglePicker({
         view.setMimeTypes(mimeTypes.join(","));
       }
 
-      // Set search query to help user find the file
-      if (searchQuery) {
-        view.setQuery(searchQuery);
-      }
+      // pre-fill with file but allow user to search outside the initial one selected
+      view.setFileIds(fileId);
 
       // Build the picker
       // setAppId is required for drive.file scope to grant access to selected files
@@ -211,8 +210,8 @@ export function useGooglePicker({
     accessToken,
     appId,
     developerKey,
+    fileId,
     mimeTypes,
-    searchQuery,
     handlePickerCallback,
   ]);
 

--- a/front/lib/api/actions/servers/google_drive/tools/index.ts
+++ b/front/lib/api/actions/servers/google_drive/tools/index.ts
@@ -509,28 +509,8 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
         },
       ]);
     } catch (err) {
-      // Only fetch metadata for better error messages if the comment creation fails
       if (isFileNotAuthorizedError(err)) {
-        let fileName = fileId;
-        let mimeType = "unknown";
-
-        // Try to get file metadata for a better error message (non-blocking failure)
-        try {
-          const fileMetadata = await drive.files.get({
-            fileId,
-            supportsAllDrives: true,
-            fields: "id, name, mimeType",
-          });
-          fileName = fileMetadata.data.name ?? fileId;
-          mimeType = fileMetadata.data.mimeType ?? "unknown";
-        } catch {
-          // If metadata fetch also fails, just use fileId as the name
-        }
-
-        return handleFileAccessError(err, fileId, extra, {
-          name: fileName,
-          mimeType,
-        });
+        return handleFileAccessError(err, fileId, extra);
       }
 
       return handlePermissionError(err);
@@ -569,28 +549,8 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
         },
       ]);
     } catch (err) {
-      // Only fetch metadata for better error messages if the reply creation fails
       if (isFileNotAuthorizedError(err)) {
-        let fileName = fileId;
-        let mimeType = "unknown";
-
-        // Try to get file metadata for a better error message (non-blocking failure)
-        try {
-          const fileMetadata = await drive.files.get({
-            fileId,
-            supportsAllDrives: true,
-            fields: "id, name, mimeType",
-          });
-          fileName = fileMetadata.data.name ?? fileId;
-          mimeType = fileMetadata.data.mimeType ?? "unknown";
-        } catch {
-          // If metadata fetch also fails, just use fileId as the name
-        }
-
-        return handleFileAccessError(err, fileId, extra, {
-          name: fileName,
-          mimeType,
-        });
+        return handleFileAccessError(err, fileId, extra);
       }
 
       return handlePermissionError(err);


### PR DESCRIPTION
## Description
Instead of fetching extra file metadata, we can use `setFileId` to populate the modal with the exact file we are referencing. Downside is we don't have the title for specific error messages but I think that's worth it to avoid the extra fetch

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Tested manually, file picker now populates with the exact file in reference
<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan
- [ ] deploy front

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->