### PR TITLE
[CLI] Prefer exact agent match in non-interactive -a lookup

### DIFF
--- a/cli/src/ui/commands/NonInteractiveChat.tsx
+++ b/cli/src/ui/commands/NonInteractiveChat.tsx
@@ -109,16 +109,28 @@ const NonInteractiveChat: FC<NonInteractiveChatProps> = ({
           return;
         }
 
+        let selectedAgent = matchingAgents[0];
         if (matchingAgents.length > 1) {
-          setError(
-            `Multiple agents found: Multiple agents match "${agentSearch}": ${matchingAgents
-              .map((a) => a.name)
-              .join(", ")}`
+          const exactMatches = matchingAgents.filter(
+            (agent) => agent.name.toLowerCase() === searchLower
           );
-          return;
-        }
 
-        const selectedAgent = matchingAgents[0];
+          if (exactMatches.length === 1) {
+            selectedAgent = exactMatches[0];
+            console.warn(
+              `Multiple agents matched "${agentSearch}". Using exact match "${selectedAgent.name}" among: ${matchingAgents
+                .map((agent) => agent.name)
+                .join(", ")}`
+            );
+          } else {
+            setError(
+              `Multiple agents found: Multiple agents match "${agentSearch}": ${matchingAgents
+                .map((a) => a.name)
+                .join(", ")}`
+            );
+            return;
+          }
+        }
 
         // Call the standalone function
         await sendNonInteractiveMessage(


### PR DESCRIPTION
## Description
When `dust chat -a <name> -m ...` returns multiple prefix matches, the CLI now selects a unique case-insensitive exact match when available.

For example, `-a issuebot` now selects `issueBot` even if `issuebot-gemini` also matches, and emits a warning to stderr describing the disambiguation.

If no unique exact match exists, behavior is unchanged and the command still fails as ambiguous.

## Risks
Blast radius: non-interactive CLI chat agent lookup (`-a` with `-m`) when multiple prefix matches exist.
Risk: low

## Deploy Plan
- include in next CLI release (no service deploy, no migration).
