### PR TITLE
Fixed missing param for cross-origin

### DIFF
--- a/front/components/pages/oauth/OAuthSetupRedirectPage.tsx
+++ b/front/components/pages/oauth/OAuthSetupRedirectPage.tsx
@@ -11,6 +11,7 @@ export function OAuthSetupRedirectPage() {
   const providerParam = usePathParam("provider");
   const useCaseParam = useSearchParam("useCase");
   const extraConfigParam = useSearchParam("extraConfig");
+  const openerOriginParam = useSearchParam("openerOrigin");
 
   const router = useAppRouter();
 
@@ -39,6 +40,7 @@ export function OAuthSetupRedirectPage() {
     provider: provider ?? "github",
     useCase: useCase ?? "connection",
     extraConfig,
+    openerOrigin: openerOriginParam ?? undefined,
     disabled: !wId || !provider || !useCase,
   });
 

--- a/front/lib/swr/oauth.ts
+++ b/front/lib/swr/oauth.ts
@@ -90,12 +90,14 @@ export function useOAuthSetup({
   provider,
   useCase,
   extraConfig,
+  openerOrigin,
   disabled,
 }: {
   workspaceId: string;
   provider: OAuthProvider;
   useCase: OAuthUseCase;
   extraConfig?: OAuthCredentials;
+  openerOrigin?: string;
   disabled?: boolean;
 }) {
   const oauthSetupFetcher: Fetcher<GetOAuthSetupResponseBody> = fetcher;
@@ -103,6 +105,9 @@ export function useOAuthSetup({
   let url = `/api/w/${workspaceId}/oauth/${provider}/setup?useCase=${useCase}`;
   if (extraConfig) {
     url += `&extraConfig=${encodeURIComponent(JSON.stringify(extraConfig))}`;
+  }
+  if (openerOrigin) {
+    url += `&openerOrigin=${encodeURIComponent(openerOrigin)}`;
   }
 
   const { data, error, isLoading } = useSWRWithDefaults(


### PR DESCRIPTION
## Description

Pass the "openerOrigin" param from setup page to oauth/setup endpoint, to handle cross origin messages ( nextjs -> spa )

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
