### PR TITLE
escape XML tags coming from markdown instructions

### DIFF
--- a/front/components/editor/extensions/agent_builder/InstructionSuggestionExtension.test.ts
+++ b/front/components/editor/extensions/agent_builder/InstructionSuggestionExtension.test.ts
@@ -558,8 +558,16 @@ describe("InstructionSuggestionExtension", () => {
         "Test <URL>",
         editor.state.schema
       );
-      expect(escaped).toBe("Test URL");
+      expect(escaped).toBe("Test <span>&lt;URL&gt;</span>");
     });
+
+    // it("should strip brackets from unrecognized comments", () => {
+    //   const escaped = escapeUnrecognizedHtmlTags(
+    //     "abcd<!-- hello -->efgh",
+    //     editor.state.schema
+    //   );
+    //   expect(escaped).toBe("abcd<span>&lt;!-- hello --&gt;</span>efgh");
+    // });
 
     it("should handle multiple unrecognized tags", () => {
       const escaped = escapeUnrecognizedHtmlTags(

--- a/front/components/editor/lib/escapeUnrecognizedHtmlTags.ts
+++ b/front/components/editor/lib/escapeUnrecognizedHtmlTags.ts
@@ -1,10 +1,21 @@
 import type { Schema, TagParseRule } from "@tiptap/pm/model";
 import { DOMParser as PMDOMParser } from "@tiptap/pm/model";
 
+import { TAG_NAME_PATTERN } from "@app/components/editor/extensions/agent_builder/instructionBlockUtils";
+
 /**
- * Workaround for tiptap/markdown #7256: strip angle brackets from <WORD> tokens
- * that the schema doesn't recognize as HTML, preventing block-in-inline schema
- * violations. Recognized tags (e.g. <p>, <code>) are left untouched.
+ * Workaround for tiptap/markdown #7256: handles unrecognized HTML-like tags to prevent
+ * block-in-inline schema violations.
+ *
+ * Behavior:
+ * - Recognized HTML tags (e.g. <p>, <code>) are left untouched
+ * - Instruction blocks with matching tags (e.g. <abc>xyz</abc>) are preserved as instruction blocks
+ * - Orphan tags without matching pairs (e.g. <foo>) are wrapped in HTML spans with entities
+ *
+ * Examples:
+ * - "<abc>content</abc>" → "<abc>content</abc>" (preserved as instruction block)
+ * - "test <foo>" → "test <span>&lt;foo&gt;</span>" (markdown) → "<p>test <span>&lt;foo&gt;</span></p>" (HTML) → "test <foo>" (rendered)
+ * - "<p>text</p>" → "<p>text</p>" (recognized HTML, left untouched)
  *
  * TODO: Remove when tiptap merges https://github.com/ueberdosis/tiptap/pull/7260
  */
@@ -19,12 +30,47 @@ export function escapeUnrecognizedHtmlTags(
       .filter(Boolean)
   );
 
-  return markdown.replace(/<([A-Za-z][A-Za-z0-9]*)>/g, (match, tag) => {
-    if (recognized.has(tag.toLowerCase())) {
-      return match;
-    }
+  // Create a global regex for matching instruction blocks (without ^ anchor)
+  // Matches: <tagName>content</tagName> where tagName follows TAG_NAME_PATTERN
+  const instructionBlockRegex = new RegExp(
+    `<(${TAG_NAME_PATTERN})>([\\s\\S]*?)</\\1>`,
+    "gi"
+  );
 
-    // Strip the angle brackets, return the text content of the tag.
-    return tag;
+  // First, protect instruction blocks by temporarily replacing them with placeholders
+  const instructionBlocks: string[] = [];
+  let markdownWithPlaceholders = markdown.replace(
+    instructionBlockRegex,
+    (match) => {
+      const placeholder = `__INSTRUCTION_BLOCK_${instructionBlocks.length}__`;
+      instructionBlocks.push(match);
+      return placeholder;
+    }
+  );
+
+  // Now escape orphan unrecognized HTML-like tags (but not instruction blocks)
+  markdownWithPlaceholders = markdownWithPlaceholders.replace(
+    /<\/?([A-Za-z][A-Za-z0-9]*)>/g,
+    (match, tag) => {
+      if (recognized.has(tag.toLowerCase())) {
+        return match;
+      }
+
+      // Use inline HTML span with HTML entities to preserve the tag display
+      // This allows markdown parser to pass through the HTML, which will render as plain text
+      // <foo> becomes <span>&lt;foo&gt;</span> which displays as <foo>
+      return `<span>${match.replace(/</g, "&lt;").replace(/>/g, "&gt;")}</span>`;
+    }
+  );
+
+  // Restore instruction blocks
+  instructionBlocks.forEach((block, index) => {
+    const placeholder = `__INSTRUCTION_BLOCK_${index}__`;
+    markdownWithPlaceholders = markdownWithPlaceholders.replace(
+      placeholder,
+      block
+    );
   });
+
+  return markdownWithPlaceholders;
 }


### PR DESCRIPTION
## Description

Tactical attempt at fixing issue that is preventing customers from editing their agents. It's still broken if instructions have HTML comments, and we'll tackle that next.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Front