### PR TITLE
Do not return connected datasources from search

### DIFF
--- a/front/components/data_source_view/DataSourceViewSelector.tsx
+++ b/front/components/data_source_view/DataSourceViewSelector.tsx
@@ -408,13 +408,17 @@ export function DataSourceViewsSelector({
       }));
     });
 
+    if (useCase === "transcriptsProcessing") {
+      return processedResults.filter((node) => !node.dataSource.connectorId);
+    }
+
     // Filter results based on URL match if we have a URL candidate
     return nodeOrUrlCandidate && !isNodeCandidate(nodeOrUrlCandidate)
       ? processedResults.filter(
           (node) => node.sourceUrl === nodeOrUrlCandidate.url
         )
       : processedResults;
-  }, [rawSearchResultNodes, filteredDSVs, nodeOrUrlCandidate]);
+  }, [rawSearchResultNodes, filteredDSVs, nodeOrUrlCandidate, useCase]);
 
   useEffect(() => {
     if (searchResult) {

--- a/front/lib/connectors.ts
+++ b/front/lib/connectors.ts
@@ -372,8 +372,7 @@ export function nodeCandidateFromUrl(
       }
     }
     return null;
-  } catch (error) {
-    console.error("Error parsing URL:", error);
+  } catch {
     return null;
   }
 }

--- a/front/migrations/20260209_disable_transcripts_on_connected_datasources.ts
+++ b/front/migrations/20260209_disable_transcripts_on_connected_datasources.ts
@@ -1,0 +1,90 @@
+import { Op } from "sequelize";
+
+import { LabsTranscriptsConfigurationResource } from "@app/lib/resources/labs_transcripts_resource";
+import { DataSourceModel } from "@app/lib/resources/storage/models/data_source";
+import { DataSourceViewModel } from "@app/lib/resources/storage/models/data_source_view";
+import { LabsTranscriptsConfigurationModel } from "@app/lib/resources/storage/models/labs_transcripts";
+import type { Logger } from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+import {
+  launchRetrieveTranscriptsWorkflow,
+  stopRetrieveTranscriptsWorkflow,
+} from "@app/temporal/labs/transcripts/client";
+
+async function disableTranscriptsOnConnectedDataSources({
+  execute,
+  logger,
+}: {
+  execute: boolean;
+  logger: Logger;
+}) {
+  // Find all transcript configurations pointing to a connected data source
+  // (i.e., data_sources where connectorId is not null).
+  const configurations = await LabsTranscriptsConfigurationModel.findAll({
+    where: {
+      dataSourceViewId: { [Op.ne]: null },
+    },
+    include: [
+      {
+        model: DataSourceViewModel,
+        as: "dataSourceView",
+        required: true,
+        include: [
+          {
+            model: DataSourceModel,
+            as: "dataSourceForView",
+            required: true,
+            where: {
+              connectorId: { [Op.ne]: null },
+            },
+          },
+        ],
+      },
+    ],
+  });
+
+  logger.info(
+    { count: configurations.length },
+    "Found transcript configurations pointing to connected data sources"
+  );
+
+  for (const config of configurations) {
+    const resource = new LabsTranscriptsConfigurationResource(
+      LabsTranscriptsConfigurationModel,
+      config.get()
+    );
+
+    logger.info(
+      {
+        configId: config.id,
+        workspaceId: config.workspaceId,
+        provider: config.provider,
+        status: config.status,
+        dataSourceViewId: config.dataSourceViewId,
+      },
+      "Disabling transcript configuration on connected data source"
+    );
+
+    if (!execute) {
+      continue;
+    }
+
+    // Mirror the PATCH endpoint behavior: stop workflow, clear dataSourceViewId,
+    // then restart if the config is still active.
+    await stopRetrieveTranscriptsWorkflow(resource, false);
+    await resource.setDataSourceView(null);
+
+    if (resource.isActive()) {
+      await launchRetrieveTranscriptsWorkflow(resource);
+    }
+
+    logger.info(
+      { configId: config.id, workspaceId: config.workspaceId },
+      "Cleared dataSourceViewId for transcript configuration"
+    );
+  }
+}
+
+makeScript({}, async ({ execute }, logger) => {
+  await disableTranscriptsOnConnectedDataSources({ execute, logger });
+});


### PR DESCRIPTION
## Description

https://github.com/dust-tt/tasks/issues/5809

For transcripts useCase, we don't return connected datasources - only folders.

Also remove error logging, throwing everythime we don't search for a url

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
