### PR TITLE
feat: add digest step for project new conversation

### DIFF
--- a/front/lib/notifications/email-templates/project-new-conversation.tsx
+++ b/front/lib/notifications/email-templates/project-new-conversation.tsx
@@ -36,7 +36,7 @@ const ProjectNewConversationEmailTemplate = ({
       <p>Hi {name},</p>
       <p>
         {conversations.length === 1
-          ? "A new conversation has been created in one of your projects:"
+          ? `A new conversation has been created in ${conversations[0].projectName}:`
           : `${conversations.length} new conversations have been created in your projects:`}
       </p>
       <ul>
@@ -51,8 +51,7 @@ const ProjectNewConversationEmailTemplate = ({
               )}
               target="_blank"
             >
-              {conversation.createdByFullName} created "{conversation.title}" in
-              "{conversation.projectName}"
+              {conversation.createdByFullName} created "{conversation.title}"
             </a>
           </li>
         ))}

--- a/front/lib/notifications/email-templates/project-new-conversation.tsx
+++ b/front/lib/notifications/email-templates/project-new-conversation.tsx
@@ -1,0 +1,66 @@
+import { render } from "@react-email/render";
+import * as React from "react";
+import { z } from "zod";
+
+import config from "@app/lib/api/config";
+import { EmailLayout } from "@app/lib/notifications/email-templates/_layout";
+import { getConversationRoute } from "@app/lib/utils/router";
+
+export const ProjectNewConversationEmailTemplatePropsSchema = z.object({
+  name: z.string(),
+  workspace: z.object({
+    id: z.string(),
+    name: z.string(),
+  }),
+  conversations: z.array(
+    z.object({
+      id: z.string(),
+      title: z.string(),
+      projectName: z.string(),
+      createdByFullName: z.string(),
+    })
+  ),
+});
+
+type ProjectNewConversationEmailTemplateProps = z.infer<
+  typeof ProjectNewConversationEmailTemplatePropsSchema
+>;
+
+const ProjectNewConversationEmailTemplate = ({
+  name,
+  workspace,
+  conversations,
+}: ProjectNewConversationEmailTemplateProps) => {
+  return (
+    <EmailLayout workspace={workspace}>
+      <p>Hi {name},</p>
+      <p>
+        {conversations.length === 1
+          ? "A new conversation has been created in one of your projects:"
+          : `${conversations.length} new conversations have been created in your projects:`}
+      </p>
+      <ul>
+        {conversations.map((conversation) => (
+          <li key={conversation.id}>
+            <a
+              href={getConversationRoute(
+                workspace.id,
+                conversation.id,
+                undefined,
+                config.getAppUrl()
+              )}
+              target="_blank"
+            >
+              {conversation.createdByFullName} created "{conversation.title}" in
+              "{conversation.projectName}"
+            </a>
+          </li>
+        ))}
+      </ul>
+    </EmailLayout>
+  );
+};
+
+export function renderEmail(args: ProjectNewConversationEmailTemplateProps) {
+  return render(<ProjectNewConversationEmailTemplate {...args} />);
+}

--- a/front/lib/notifications/workflows/project-new-conversation.ts
+++ b/front/lib/notifications/workflows/project-new-conversation.ts
@@ -271,7 +271,7 @@ export const projectNewConversationWorkflow = workflow(
           subscriberId: subscriber.subscriberId,
           workspaceId: payload.workspaceId,
           channel: "email",
-          workflowTriggerId: WORKFLOW_TRIGGER_IDS.PROJECT_NEW_CONVERSATION,
+          workflowTriggerId: PROJECT_NEW_CONVERSATION_TRIGGER_ID,
         });
         return { delay: userNotificationDelay };
       },

--- a/front/lib/notifications/workflows/project-new-conversation.ts
+++ b/front/lib/notifications/workflows/project-new-conversation.ts
@@ -1,27 +1,35 @@
 import { workflow } from "@novu/framework";
+import uniqBy from "lodash/uniqBy";
 import z from "zod";
 
-import config from "@app/lib/api/config";
 import { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import type { NotificationAllowedTags } from "@app/lib/notifications";
+import { getUserNotificationDelay } from "@app/lib/notifications";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { getConversationRoute } from "@app/lib/utils/router";
 import type { Result } from "@app/types";
 import { Err, isProjectConversation, Ok } from "@app/types";
-import { PROJECT_NEW_CONVERSATION_TRIGGER_ID } from "@app/types/notification_preferences";
+import {
+  DEFAULT_NOTIFICATION_DELAY,
+  NOTIFICATION_DELAY_OPTIONS,
+  NOTIFICATION_PREFERENCES_DELAYS,
+  PROJECT_NEW_CONVERSATION_TRIGGER_ID,
+} from "@app/types/notification_preferences";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 
-import { renderEmail } from "../email-templates/default";
+import { renderEmail } from "../email-templates/project-new-conversation";
 import type { ProjectNewConversationPayloadType } from "../triggers/project-new-conversation";
 import { projectNewConversationPayloadSchema } from "../triggers/project-new-conversation";
 
 const ConversationDetailsSchema = z.object({
   projectName: z.string(),
   userThatCreatedConversationFullName: z.string(),
+  conversationTitle: z.string(),
 });
 
 const ConversationDetailsResultSchema = z.discriminatedUnion("success", [
@@ -34,9 +42,13 @@ const ConversationDetailsResultSchema = z.discriminatedUnion("success", [
   }),
 ]);
 
+const UserNotificationDelaySchema = z.object({
+  delay: z.enum(NOTIFICATION_DELAY_OPTIONS),
+});
+
 type ProjectDetailsType = z.infer<typeof ConversationDetailsSchema>;
 
-const getProjectDetails = async ({
+const getConversationDetails = async ({
   subscriberId,
   payload,
 }: {
@@ -57,6 +69,7 @@ const getProjectDetails = async ({
     return new Ok({
       projectName: "A project",
       userThatCreatedConversationFullName: "Someone",
+      conversationTitle: "New conversation",
     });
   }
 
@@ -109,6 +122,7 @@ const getProjectDetails = async ({
   return new Ok({
     projectName: project.name,
     userThatCreatedConversationFullName: userThatCreatedConversation.fullName(),
+    conversationTitle: conversation.title ?? "New conversation",
   });
 };
 
@@ -136,14 +150,26 @@ const shouldSkipConversation = async ({
     return true;
   }
 
+  const { lastReadAt } =
+    await ConversationResource.getActionRequiredAndLastReadAtForUser(
+      auth,
+      conversationResource.id
+    );
+
+  const isRead = !!lastReadAt && lastReadAt > conversationResource.updatedAt;
+
+  if (isRead) {
+    return true;
+  }
+
   const conversationParticipants =
     await conversationResource.listParticipants(auth);
 
-  const isConversatinParticipant = conversationParticipants.some(
+  const isConversationParticipant = conversationParticipants.some(
     (participant) => participant.sId === subscriberId
   );
 
-  if (isConversatinParticipant) {
+  if (isConversationParticipant) {
     return true;
   }
 
@@ -174,7 +200,7 @@ export const projectNewConversationWorkflow = workflow(
     const detailsResult = await step.custom(
       "get-project-details",
       async () => {
-        const details = await getProjectDetails({
+        const details = await getConversationDetails({
           subscriberId: subscriber.subscriberId,
           payload,
         });
@@ -238,42 +264,19 @@ export const projectNewConversationWorkflow = workflow(
       }
     );
 
-    await step.email(
-      "send-email",
+    const userNotificationDelayStep = await step.custom(
+      "get-user-notification-delay",
       async () => {
-        const workspace = await WorkspaceResource.fetchById(
-          payload.workspaceId
-        );
-        // Details is guaranteed non-null because the step is skipped otherwise
-        if (!details) {
-          return {
-            subject: "",
-            body: "",
-          };
-        }
-        const body = await renderEmail({
-          name: subscriber.firstName ?? "You",
-          workspace: {
-            id: payload.workspaceId,
-            name: workspace?.name ?? "A workspace",
-          },
-          content: `${details.userThatCreatedConversationFullName} created a new conversation in "${details.projectName}".`,
-          action: {
-            label: "View conversation",
-            url: getConversationRoute(
-              payload.workspaceId,
-              payload.conversationId,
-              undefined,
-              config.getAppUrl()
-            ),
-          },
+        const userNotificationDelay = await getUserNotificationDelay({
+          subscriberId: subscriber.subscriberId,
+          workspaceId: payload.workspaceId,
+          channel: "email",
+          workflowTriggerId: WORKFLOW_TRIGGER_IDS.PROJECT_NEW_CONVERSATION,
         });
-        return {
-          subject: `[Dust] New conversation in '${details.projectName}'`,
-          body,
-        };
+        return { delay: userNotificationDelay };
       },
       {
+        outputSchema: UserNotificationDelaySchema,
         skip: async () => {
           if (!details) {
             return true;
@@ -282,6 +285,124 @@ export const projectNewConversationWorkflow = workflow(
             subscriberId: subscriber.subscriberId,
             payload,
           });
+        },
+      }
+    );
+
+    const { events } = await step.digest(
+      "digest",
+      async () => {
+        const digestKey = `workspace-${payload.workspaceId}-project-new-conversation`;
+        const userPreferences =
+          userNotificationDelayStep.delay ?? DEFAULT_NOTIFICATION_DELAY;
+        return {
+          ...NOTIFICATION_PREFERENCES_DELAYS[userPreferences],
+          digestKey,
+        };
+      },
+      {
+        skip: async () => {
+          if (!details) {
+            return true;
+          }
+          // NOTE: We only check `details` here because `subscriber.subscriberId` is null
+          // when the digest step's skip condition is evaluated (Novu framework bug).
+          // All subscriber-based filtering (shouldSkipConversation) is handled in the
+          // email step below, where subscriber context is properly available.
+          return false;
+        },
+      }
+    );
+
+    await step.email(
+      "send-email",
+      async () => {
+        const workspace = await WorkspaceResource.fetchById(
+          payload.workspaceId
+        );
+
+        const conversations: Parameters<
+          typeof renderEmail
+        >[0]["conversations"] = [];
+
+        const uniqEventsPerConversation = uniqBy(
+          events,
+          (event) => event.payload.conversationId
+        );
+
+        await concurrentExecutor(
+          uniqEventsPerConversation,
+          async (event) => {
+            const eventPayload =
+              event.payload as ProjectNewConversationPayloadType;
+            const conversationDetailsResult = await getConversationDetails({
+              subscriberId: subscriber.subscriberId,
+              payload: eventPayload,
+            });
+            if (conversationDetailsResult.isErr()) {
+              switch (conversationDetailsResult.error.code) {
+                case "conversation_not_found":
+                case "invalid_conversation":
+                case "space_not_found":
+                case "user_not_found":
+                  return;
+                default:
+                  assertNever(conversationDetailsResult.error.code);
+              }
+            }
+            const conversationDetails = conversationDetailsResult.value;
+            conversations.push({
+              id: eventPayload.conversationId,
+              title: conversationDetails.conversationTitle,
+              projectName: conversationDetails.projectName,
+              createdByFullName:
+                conversationDetails.userThatCreatedConversationFullName,
+            });
+          },
+          {
+            concurrency: 8,
+          }
+        );
+
+        const body = await renderEmail({
+          name: subscriber.firstName ?? "You",
+          workspace: {
+            id: payload.workspaceId,
+            name: workspace?.name ?? "A workspace",
+          },
+          conversations,
+        });
+        const uniqueProjectNames = uniqBy(
+          conversations,
+          (conversation) => conversation.projectName
+        ).map((conversation) => conversation.projectName);
+        const subject =
+          uniqueProjectNames.length > 1
+            ? `[Dust] New conversations in your projects`
+            : `[Dust] New conversation(s) in '${uniqueProjectNames[0]}'`;
+        return {
+          subject,
+          body,
+        };
+      },
+      {
+        skip: async () => {
+          if (!details) {
+            return true;
+          }
+          const shouldSkip = await concurrentExecutor(
+            events,
+            async (event) => {
+              return shouldSkipConversation({
+                subscriberId: subscriber.subscriberId,
+                payload: event.payload as ProjectNewConversationPayloadType,
+              });
+            },
+            { concurrency: 8 }
+          );
+
+          // Do not skip if at least one conversation is not skipped.
+          return shouldSkip.every(Boolean);
         },
       }
     );

--- a/front/types/notification_preferences.ts
+++ b/front/types/notification_preferences.ts
@@ -1,5 +1,7 @@
 import type { ChannelPreference } from "@novu/react";
 
+import { isDevelopment } from "./shared/env";
+
 /**
  * Available delay options for email digest notifications.
  */
@@ -13,6 +15,34 @@ export const NOTIFICATION_DELAY_OPTIONS = [
 
 export type NotificationPreferencesDelay =
   (typeof NOTIFICATION_DELAY_OPTIONS)[number];
+
+type NotificationDelayAmountConfig = {
+  amount: number;
+  unit: "minutes" | "hours" | "days";
+};
+
+type NotificationDelayCronConfig = { cron: string };
+
+type NotificationDelayConfig =
+  | NotificationDelayAmountConfig
+  | NotificationDelayCronConfig;
+
+/**
+ * Maps delay option keys to their time configurations.
+ */
+export const NOTIFICATION_PREFERENCES_DELAYS: Record<
+  NotificationPreferencesDelay,
+  NotificationDelayConfig
+> = {
+  "5_minutes": { amount: 5, unit: "minutes" },
+  "15_minutes": { amount: 15, unit: "minutes" },
+  "30_minutes": { amount: 30, unit: "minutes" },
+  "1_hour": { amount: 1, unit: "hours" },
+  daily: { cron: "0 6 * * *" }, // Every day at 6am
+};
+
+export const DEFAULT_NOTIFICATION_DELAY: NotificationPreferencesDelay =
+  isDevelopment() ? "5_minutes" : "1_hour";
 
 export const isNotificationPreferencesDelay = (
   value: unknown

--- a/front/types/notification_preferences.ts
+++ b/front/types/notification_preferences.ts
@@ -100,7 +100,7 @@ export const PROJECT_ADDED_AS_MEMBER_TRIGGER_ID =
 export const PROJECT_NEW_CONVERSATION_TRIGGER_ID =
   "project-new-conversation" as const;
 
-type WorkflowTriggerId =
+export type WorkflowTriggerId =
   | typeof CONVERSATION_UNREAD_TRIGGER_ID
   | typeof CONVERSATION_ADDED_AS_PARTICIPANT_TRIGGER_ID
   | typeof PROJECT_ADDED_AS_MEMBER_TRIGGER_ID


### PR DESCRIPTION





## Description

This PR adds a digest step to the project new conversation notification workflow

- Extracted `getUserNotificationDelay` to a shared location in `front/lib/notifications/index.ts` for reuse across workflows
- Added digest step to `project-new-conversation` workflow
- Created new email template `project-new-conversation.tsx` that displays multiple conversations in a single digest email
<img width="835" height="409" alt="Capture d’écran 2026-02-09 à 11 44 18" src="https://github.com/user-attachments/assets/fb156b57-8349-4bec-b11d-953e8bbe790d" />


## Tests

Manually

## Risk
Low

## Deploy Plan

Standard deployment. 