### PR TITLE
feat: add delay triggering project new conversation

### DIFF
--- a/front/lib/notifications/triggers/project-new-conversation.ts
+++ b/front/lib/notifications/triggers/project-new-conversation.ts
@@ -21,6 +21,8 @@ export type ProjectNewConversationPayloadType = z.infer<
   typeof projectNewConversationPayloadSchema
 >;
 
+const NOTIFICATION_DELAY_MS = 15000; // 15 seconds
+
 /**
  * Trigger notifications for users added to a project.
  */
@@ -43,6 +45,10 @@ const triggerProjectNewConversationNotifications = async (
   if (!userThatCreatedConversation) {
     return new Ok(undefined);
   }
+
+  // Wait before triggering the notification. This is useful to ensure that
+  // the conversation has a title and its participants are fully created.
+  await new Promise((resolve) => setTimeout(resolve, NOTIFICATION_DELAY_MS));
 
   // Fetch all members of the project
   const space = await SpaceResource.fetchById(auth, conversation.spaceId);

--- a/front/lib/notifications/triggers/project-new-conversation.ts
+++ b/front/lib/notifications/triggers/project-new-conversation.ts
@@ -21,7 +21,7 @@ export type ProjectNewConversationPayloadType = z.infer<
   typeof projectNewConversationPayloadSchema
 >;
 
-const NOTIFICATION_DELAY_MS = 15000; // 15 seconds
+const NOTIFICATION_DELAY_MS = 15_000; // 15 seconds
 
 /**
  * Trigger notifications for users added to a project.

--- a/front/lib/notifications/workflows/project-new-conversation.ts
+++ b/front/lib/notifications/workflows/project-new-conversation.ts
@@ -234,8 +234,8 @@ export const projectNewConversationWorkflow = workflow(
           };
         }
         return {
-          subject: details.projectName,
-          body: `${details.userThatCreatedConversationFullName} created a new conversation in "${details.projectName}".`,
+          subject: `New conversation in ${details.projectName}`,
+          body: `${details.userThatCreatedConversationFullName} created "${details.conversationTitle}"`,
           primaryAction: {
             label: "View",
             redirect: {


### PR DESCRIPTION






## Description

This PR adds a 15-second delay before triggering project new conversation notifications to ensure the conversation has a title and its participants are fully created.
<img width="382" height="168" alt="Capture d’écran 2026-02-09 à 11 24 46" src="https://github.com/user-attachments/assets/7af0963d-388d-4638-a562-08520d534d5a" />


## Tests

Manually

## Risks

Low risk. 
## Deploy Plan

Standard deployment.
