### PR TITLE
[front] Add Office viewer to CSP frame-src

### DIFF
--- a/front/next.config.js
+++ b/front/next.config.js
@@ -18,7 +18,7 @@ const CONTENT_SECURITY_POLICIES = [
   `style-src-elem 'self' 'unsafe-inline' *.fontawesome.com *.googleapis.com *.gstatic.com;`,
   `img-src 'self' data: blob: webkit-fake-url: https:;`,
   `connect-src 'self' blob: dust.tt *.dust.tt https://dust.tt https://*.dust.tt browser-intake-datadoghq.eu *.google-analytics.com *.googlesyndication.com *.googleadservices.com cdn.jsdelivr.net *.hsforms.com *.hscollectedforms.net *.hubspot.com *.hubapi.com *.hsappstatic.net *.cr-relay.com *.usercentrics.eu *.ads.linkedin.com px.ads.linkedin.com google.com *.google.com *.workos.com translate-pa.googleapis.com forms.default.com nucleus.default.com *.default.com *.novu.co wss://*.novu.co *.vector.co;`,
-  `frame-src 'self' *.wistia.net eu.viz.dust.tt viz.dust.tt *.hsforms.net *.googletagmanager.com *.doubleclick.net *.default.com *.hsforms.com *.youtube.com *.youtube-nocookie.com *.google.com docs.google.com drive.google.com${isDev ? " http://localhost:3007" : ""};`,
+  `frame-src 'self' *.wistia.net eu.viz.dust.tt viz.dust.tt *.hsforms.net *.googletagmanager.com *.doubleclick.net *.default.com *.hsforms.com *.youtube.com *.youtube-nocookie.com *.google.com docs.google.com drive.google.com view.officeapps.live.com${isDev ? " http://localhost:3007" : ""};`,
   `font-src 'self' data: dust.tt *.dust.tt https://dust.tt https://*.dust.tt *.gstatic.com *.wistia.net fonts.cdnfonts.com migaku-public-data.migaku.com;`,
   `media-src 'self' data:;`,
   `object-src 'none';`,


### PR DESCRIPTION
## Description

Add `view.officeapps.live.com` to the Content-Security-Policy `frame-src` directive.

- The `FilePreviewSheet` component embeds Microsoft's Office Online viewer in an iframe to preview Word/Excel/PowerPoint files
- The CSP `frame-src` directive was missing this domain, causing the iframe to be blocked in production

## Tests
- [x] Upload an Office file (docx/xlsx/pptx) to a Space and verify the preview loads

## Risk
low

## Deploy plan
front