### PR TITLE
Merge skills & tools into single alphabetical list in input bar CapabilitiesPicker

### DIFF
--- a/front/components/assistant/CapabilitiesPicker.tsx
+++ b/front/components/assistant/CapabilitiesPicker.tsx
@@ -18,7 +18,6 @@ import {
   getMcpServerViewDescription,
   getMcpServerViewDisplayName,
   mcpServersSortingFn,
-  mcpServerViewSortingFn,
 } from "@app/lib/actions/mcp_helper";
 import { getAvatar } from "@app/lib/actions/mcp_icons";
 import type { DefaultRemoteMCPServerConfig } from "@app/lib/actions/mcp_internal_actions/remote_servers";
@@ -116,7 +115,6 @@ interface CapabilitiesPickerProps {
   onSelect: (serverView: MCPServerViewType) => void;
   selectedSkills: SkillType[];
   onSkillSelect: (skill: SkillType) => void;
-  onSkillDeselect: (skill: SkillType) => void;
   isLoading?: boolean;
   disabled?: boolean;
   buttonSize?: "xs" | "sm" | "md";
@@ -205,8 +203,7 @@ export function CapabilitiesPicker({
               .toLowerCase()
               .includes(searchText.toLowerCase()))
       )
-      .filter((v) => !selectedMCPServerViewIds.includes(v.sId))
-      .sort(mcpServerViewSortingFn);
+      .filter((v) => !selectedMCPServerViewIds.includes(v.sId));
   }, [serverViews, searchText, selectedMCPServerViewIds]);
 
   const { availableMCPServers, isAvailableMCPServersLoading } =

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -753,7 +753,6 @@ const InputBarContainer = ({
                       owner={owner}
                       selectedMCPServerViews={selectedMCPServerViews}
                       onSelect={onMCPServerViewSelect}
-                      onDeselect={onMCPServerViewDeselect}
                       selectedSkills={selectedSkills}
                       onSkillSelect={onSkillSelect}
                       onSkillDeselect={onSkillDeselect}

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -755,7 +755,6 @@ const InputBarContainer = ({
                       onSelect={onMCPServerViewSelect}
                       selectedSkills={selectedSkills}
                       onSkillSelect={onSkillSelect}
-                      onSkillDeselect={onSkillDeselect}
                       disabled={disableTextInput}
                       buttonSize={buttonSize}
                     />


### PR DESCRIPTION
## Description

 - Remove filter tabs (All/Skills/Tools) from the input bar's capabilities dropdown
  - Merge skills and tools into a single alphabetically sorted list
  - Simplify Enter key handler to select the first merged item (skill or tool)
  - Simplify Enter key handler to select the first visible item (skill or tool). The previous handler operated on `filteredServerViews` which included both selected and unselected server views — pressing Enter could deselect a server that wasn't even visible in the dropdown. The new handler uses `mergedItems` (unselected only), so Enter always acts on what the user actually sees. Removed the now-unused `onDeselect` prop accordingly.

Next step is to find a design that will work better than the long descriptions. 
We discussed it with @pinotalexandre, he is okay to ship this first and will provide designs for this part. 🙏🏻 

## Tests

Locally. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 