### PR TITLE
[spa] preload geist fonts

### DIFF
--- a/front-spa/index.html
+++ b/front-spa/index.html
@@ -6,6 +6,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="robots" content="noindex" />
     <title>Dust</title>
+    <link rel="preload" href="/static/fonts/Geist-Regular.woff2" as="font" type="font/woff2" crossorigin />
+    <link rel="preload" href="/static/fonts/Geist-SemiBold.woff2" as="font" type="font/woff2" crossorigin />
     <script>
       // Shim for Node.js Buffer API used by some dependencies
       globalThis.Buffer = globalThis.Buffer || {

--- a/sparkle/src/components/Input.tsx
+++ b/sparkle/src/components/Input.tsx
@@ -70,7 +70,7 @@ const inputStyleClasses = cva(
     "s-bg-muted-background dark:s-bg-muted-background-night",
     "s-border focus-visible:s-ring",
     "file:s-border-0 file:s-bg-transparent file:s-text-sm file:s-font-medium file:s-text-foreground",
-    "placeholder:s-text-muted-foreground placeholder:s-italic dark:placeholder:s-text-muted-foreground-night"
+    "placeholder:s-text-muted-foreground dark:placeholder:s-text-muted-foreground-night"
   ),
   {
     variants: {


### PR DESCRIPTION
## Description
This PR is to preload geist fonts in SPA. I was running lighthouse and we have a network dependency tree, if I understand it correctly we can avoid if we preload these fonts? Also I removed Italic from placeholder, the italic placeholder feels outdated (I checked everywhere but nobody is using italic in placeholder) and we can remove one default resource in the conversation page. 

<img width="1392" height="748" alt="CleanShot 2026-02-09 at 14 08 04@2x" src="https://github.com/user-attachments/assets/7e3bd734-abea-42cb-ab4b-2bf4b10bcaae" />


<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
