### PR TITLE
[front] Add dedicated inbox page

### DIFF
--- a/front/components/assistant/conversation/SidebarMenu.tsx
+++ b/front/components/assistant/conversation/SidebarMenu.tsx
@@ -7,7 +7,6 @@ import {
   ChatBubbleBottomCenterTextIcon,
   ChatBubbleLeftRightIcon,
   Checkbox,
-  CheckDoubleIcon,
   DocumentIcon,
   DropdownMenu,
   DropdownMenuContent,
@@ -19,6 +18,7 @@ import {
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
+  InboxIcon,
   Label,
   ListCheckIcon,
   MagicIcon,
@@ -66,7 +66,6 @@ import {
 import { SidebarContext } from "@app/components/sparkle/SidebarContext";
 import { useDeleteConversation } from "@app/hooks/useDeleteConversation";
 import { useHideTriggeredConversations } from "@app/hooks/useHideTriggeredConversations";
-import { useMarkAllConversationsAsRead } from "@app/hooks/useMarkAllConversationsAsRead";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useProjectsSectionCollapsed } from "@app/hooks/useProjectsSectionCollapsed";
 import { useYAMLUpload } from "@app/hooks/useYAMLUpload";
@@ -84,6 +83,7 @@ import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 import {
   getAgentBuilderRoute,
   getConversationRoute,
+  getInboxRoute,
   getSkillBuilderRoute,
 } from "@app/lib/utils/router";
 import type { ConversationWithoutContentType, WorkspaceType } from "@app/types";
@@ -401,6 +401,11 @@ export function AgentSidebarMenu({ owner }: AgentSidebarMenuProps) {
     titleFilter,
   ]);
 
+  const spaceUnreadCount = useMemo(
+    () => summary.reduce((acc, s) => acc + s.unreadConversations.length, 0),
+    [summary]
+  );
+
   const conversationsList = useMemo(() => {
     return (
       <NavigationListWithInbox
@@ -418,6 +423,8 @@ export function AgentSidebarMenu({ owner }: AgentSidebarMenuProps) {
         handleNewClick={handleNewClick}
         toggleMultiSelect={toggleMultiSelect}
         setShowDeleteDialog={setShowDeleteDialog}
+        spaceUnreadCount={spaceUnreadCount}
+        hasInbox={hasSpaceConversations}
       />
     );
   }, [
@@ -435,6 +442,8 @@ export function AgentSidebarMenu({ owner }: AgentSidebarMenuProps) {
     handleNewClick,
     toggleMultiSelect,
     setShowDeleteDialog,
+    spaceUnreadCount,
+    hasSpaceConversations,
   ]);
 
   return (
@@ -646,19 +655,6 @@ export function AgentSidebarMenu({ owner }: AgentSidebarMenuProps) {
   );
 }
 
-interface InboxConversationListProps {
-  inboxConversations: ConversationWithoutContentType[];
-  dateLabel: string;
-  isMultiSelect: boolean;
-  isMarkingAllAsRead: boolean;
-  onMarkAllAsRead: (conversations: ConversationWithoutContentType[]) => void;
-  selectedConversations: ConversationWithoutContentType[];
-  toggleConversationSelection: (c: ConversationWithoutContentType) => void;
-  router: AppRouter;
-  owner: WorkspaceType;
-  titleFilter: string;
-}
-
 interface ConversationListContainerProps {
   children: React.ReactNode;
 }
@@ -667,56 +663,6 @@ const ConversationListContainer = ({
   children,
 }: ConversationListContainerProps) => {
   return <div className="sm:flex sm:flex-col sm:gap-0.5">{children}</div>;
-};
-
-const InboxConversationList = ({
-  inboxConversations,
-  dateLabel,
-  isMultiSelect,
-  isMarkingAllAsRead,
-  titleFilter,
-  onMarkAllAsRead,
-  ...props
-}: InboxConversationListProps) => {
-  if (inboxConversations.length === 0) {
-    return null;
-  }
-
-  const shouldShowMarkAllAsReadButton =
-    inboxConversations.length > 0 &&
-    titleFilter.length === 0 &&
-    !isMultiSelect &&
-    onMarkAllAsRead;
-
-  return (
-    <NavigationListCollapsibleSection
-      label={dateLabel}
-      className="border-b border-t border-border bg-background/50 px-2 pb-2 dark:border-border-night dark:bg-background-night/50"
-      defaultOpen
-      actionOnHover={false}
-      action={
-        shouldShowMarkAllAsReadButton ? (
-          <Button
-            size="xmini"
-            variant="ghost"
-            icon={CheckDoubleIcon}
-            tooltip="Mark all as read"
-            onClick={() => onMarkAllAsRead(inboxConversations)}
-            isLoading={isMarkingAllAsRead}
-          />
-        ) : null
-      }
-    >
-      {inboxConversations.map((conversation) => (
-        <ConversationListItem
-          key={conversation.sId}
-          conversation={conversation}
-          isMultiSelect={isMultiSelect}
-          {...props}
-        />
-      ))}
-    </NavigationListCollapsibleSection>
-  );
 };
 
 const ConversationList = ({
@@ -866,6 +812,8 @@ interface NavigationListWithInboxProps {
   handleNewClick: () => void;
   toggleMultiSelect: () => void;
   setShowDeleteDialog: (value: "all" | "selection" | null) => void;
+  spaceUnreadCount: number;
+  hasInbox: boolean;
 }
 
 const NavigationListWithInbox = forwardRef<
@@ -887,6 +835,8 @@ const NavigationListWithInbox = forwardRef<
       handleNewClick,
       toggleMultiSelect,
       setShowDeleteDialog,
+      spaceUnreadCount,
+      hasInbox,
     },
     ref
   ) => {
@@ -902,16 +852,14 @@ const NavigationListWithInbox = forwardRef<
       );
     }, [conversations, titleFilter]);
 
-    const { markAllAsRead, isMarkingAllAsRead } = useMarkAllConversationsAsRead(
-      {
-        owner,
-      }
-    );
+    const totalUnreadCount = inboxConversations.length + spaceUnreadCount;
 
-    // TODO: Remove filtering by titleFilter when we release the inbox.
-    const conversationsByDate = readConversations?.length
+    // When hasInbox is false, show all conversations (including unread) inline.
+    const visibleConversations = hasInbox ? readConversations : conversations;
+
+    const conversationsByDate = visibleConversations?.length
       ? getGroupConversationsByDate({
-          conversations: readConversations.slice(
+          conversations: visibleConversations.slice(
             0,
             (conversationsPage + 1) * CONVERSATIONS_PER_PAGE
           ),
@@ -945,19 +893,16 @@ const NavigationListWithInbox = forwardRef<
 
     return (
       <div className="dd-privacy-mask h-full w-full overflow-y-auto">
-        {inboxConversations.length > 0 && (
-          <InboxConversationList
-            inboxConversations={inboxConversations}
-            dateLabel={`Inbox (${inboxConversations.length})`}
-            isMultiSelect={isMultiSelect}
-            isMarkingAllAsRead={isMarkingAllAsRead}
-            titleFilter={titleFilter}
-            onMarkAllAsRead={markAllAsRead}
-            selectedConversations={selectedConversations}
-            toggleConversationSelection={toggleConversationSelection}
-            router={router}
-            owner={owner}
-          />
+        {hasInbox && (
+          <NavigationList className="px-2">
+            <NavigationListItem
+              icon={InboxIcon}
+              label="Inbox"
+              count={totalUnreadCount}
+              href={getInboxRoute(owner.sId)}
+              selected={router.pathname === "/w/[wId]/conversation/inbox"}
+            />
+          </NavigationList>
         )}
         {projectsSection}
         <NavigationList className="px-2">

--- a/front/components/pages/conversation/InboxPage.tsx
+++ b/front/components/pages/conversation/InboxPage.tsx
@@ -1,0 +1,306 @@
+import {
+  Button,
+  CheckIcon,
+  ConversationListItem,
+  InboxIcon,
+  ListGroup,
+  ListItemSection,
+  Spinner,
+} from "@dust-tt/sparkle";
+import moment from "moment";
+import { useEffect, useMemo } from "react";
+
+import { SpaceConversationListItem } from "@app/components/assistant/conversation/space/conversations/SpaceConversationListItem";
+import { useMarkAllConversationsAsRead } from "@app/hooks/useMarkAllConversationsAsRead";
+import { useWorkspace } from "@app/lib/auth/AuthContext";
+import { useAppRouter } from "@app/lib/platform";
+import {
+  useConversations,
+  useSpaceConversations,
+  useSpaceConversationsSummary,
+} from "@app/lib/swr/conversations";
+import { useFeatureFlags } from "@app/lib/swr/workspaces";
+import { getConversationRoute } from "@app/lib/utils/router";
+import { formatTimestring } from "@app/lib/utils/timestamps";
+import type {
+  ConversationWithoutContentType,
+  LightConversationType,
+  SpaceType,
+  WorkspaceType,
+} from "@app/types";
+
+function getConversationTitle(
+  conversation: ConversationWithoutContentType
+): string {
+  return (
+    conversation.title ??
+    (moment(conversation.created).isSame(moment(), "day")
+      ? "New Conversation"
+      : `Conversation from ${new Date(conversation.created).toLocaleDateString()}`)
+  );
+}
+
+interface InboxSectionProps {
+  label: string;
+  conversations: ConversationWithoutContentType[];
+  owner: WorkspaceType;
+  children: React.ReactNode;
+}
+
+function InboxSection({
+  label,
+  conversations,
+  owner,
+  children,
+}: InboxSectionProps) {
+  const { markAllAsRead, isMarkingAllAsRead } = useMarkAllConversationsAsRead({
+    owner,
+  });
+
+  if (conversations.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-col">
+      <ListItemSection
+        size="sm"
+        action={
+          <Button
+            size="xs"
+            variant="ghost-secondary"
+            icon={CheckIcon}
+            label="Mark as read"
+            onClick={() => markAllAsRead(conversations)}
+            isLoading={isMarkingAllAsRead}
+          />
+        }
+      >
+        {label}
+      </ListItemSection>
+      <ListGroup>{children}</ListGroup>
+    </div>
+  );
+}
+
+/**
+ * Renders a ConversationListItem from lean conversation data
+ * (ConversationWithoutContentType), used when rich data is unavailable.
+ */
+interface LeanConversationItemProps {
+  conversation: ConversationWithoutContentType;
+  owner: WorkspaceType;
+}
+
+function LeanConversationItem({
+  conversation,
+  owner,
+}: LeanConversationItemProps) {
+  const router = useAppRouter();
+
+  return (
+    <ConversationListItem
+      conversation={{
+        id: conversation.sId,
+        title: getConversationTitle(conversation),
+        updatedAt: new Date(conversation.updated),
+      }}
+      time={formatTimestring(conversation.updated)}
+      onClick={async () => {
+        await router.push(
+          getConversationRoute(owner.sId, conversation.sId),
+          undefined,
+          { shallow: true }
+        );
+      }}
+    />
+  );
+}
+
+interface PersonalInboxSectionProps {
+  conversations: ConversationWithoutContentType[];
+  owner: WorkspaceType;
+}
+
+function PersonalInboxSection({
+  conversations,
+  owner,
+}: PersonalInboxSectionProps) {
+  return (
+    <InboxSection
+      label={`My conversations (${conversations.length})`}
+      conversations={conversations}
+      owner={owner}
+    >
+      {conversations.map((conversation) => (
+        <LeanConversationItem
+          key={conversation.sId}
+          conversation={conversation}
+          owner={owner}
+        />
+      ))}
+    </InboxSection>
+  );
+}
+
+interface SpaceInboxSectionProps {
+  space: SpaceType;
+  unreadConversations: ConversationWithoutContentType[];
+  owner: WorkspaceType;
+}
+
+function SpaceInboxSection({
+  space,
+  unreadConversations,
+  owner,
+}: SpaceInboxSectionProps) {
+  // Fetch rich conversation data for this space.
+  const { conversations: spaceConversations } = useSpaceConversations({
+    workspaceId: owner.sId,
+    spaceId: space.sId,
+  });
+
+  // Map from sId to LightConversationType for rich rendering.
+  const richConversationMap = useMemo(() => {
+    const map = new Map<string, LightConversationType>();
+    for (const c of spaceConversations) {
+      map.set(c.sId, c);
+    }
+    return map;
+  }, [spaceConversations]);
+
+  const sortedUnread = useMemo(
+    () => [...unreadConversations].sort((a, b) => b.updated - a.updated),
+    [unreadConversations]
+  );
+
+  return (
+    <InboxSection
+      label={`${space.name} (${sortedUnread.length})`}
+      conversations={sortedUnread}
+      owner={owner}
+    >
+      {sortedUnread.map((conversation) => {
+        const richConversation = richConversationMap.get(conversation.sId);
+        if (richConversation) {
+          return (
+            <SpaceConversationListItem
+              key={conversation.sId}
+              conversation={richConversation}
+              owner={owner}
+            />
+          );
+        }
+        return (
+          <LeanConversationItem
+            key={conversation.sId}
+            conversation={conversation}
+            owner={owner}
+          />
+        );
+      })}
+    </InboxSection>
+  );
+}
+
+export function InboxPage() {
+  const owner = useWorkspace();
+  const router = useAppRouter();
+  const { hasFeature, isFeatureFlagsLoading } = useFeatureFlags({
+    workspaceId: owner.sId,
+  });
+
+  const hasSpaceConversations = hasFeature("projects");
+
+  useEffect(() => {
+    if (!isFeatureFlagsLoading && !hasSpaceConversations) {
+      void router.replace(getConversationRoute(owner.sId, "new"));
+    }
+  }, [isFeatureFlagsLoading, hasSpaceConversations, router, owner.sId]);
+
+  const { conversations, isConversationsLoading } = useConversations({
+    workspaceId: owner.sId,
+  });
+
+  const { summary, isLoading: isSummaryLoading } = useSpaceConversationsSummary(
+    {
+      workspaceId: owner.sId,
+      options: { disabled: !hasSpaceConversations },
+    }
+  );
+
+  // Personal unread conversations (not in a space).
+  const personalUnreadConversations = useMemo(
+    () =>
+      conversations
+        .filter((c) => (c.unread || c.actionRequired) && !c.spaceId)
+        .toSorted((a, b) => b.updated - a.updated),
+    [conversations]
+  );
+
+  // Space sections with unread conversations.
+  const spaceSections = useMemo(
+    () => summary.filter((s) => s.unreadConversations.length > 0),
+    [summary]
+  );
+
+  // Redirect when projects flag is off.
+  if (!isFeatureFlagsLoading && !hasSpaceConversations) {
+    return (
+      <div className="flex h-full w-full items-center justify-center px-6">
+        <Spinner />
+      </div>
+    );
+  }
+
+  const isLoading = isConversationsLoading || isSummaryLoading;
+  const hasNoUnread =
+    personalUnreadConversations.length === 0 && spaceSections.length === 0;
+
+  if (isLoading) {
+    return (
+      <div className="flex h-full w-full items-center justify-center px-6">
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (hasNoUnread) {
+    return (
+      <div className="flex h-full w-full flex-col items-center justify-center gap-2 px-6 text-foreground dark:text-foreground-night">
+        <InboxIcon className="h-8 w-8" />
+        <h2 className="text-2xl">Inbox</h2>
+        <p className="text-center text-lg text-muted-foreground dark:text-muted-foreground-night">
+          You&apos;re all caught up!
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full w-full flex-col px-6">
+      <div className="flex h-full min-h-0 flex-1 flex-col overflow-y-auto">
+        <div className="mx-auto flex w-full max-w-4xl flex-col py-8">
+          <h2 className="mb-4 text-2xl font-bold text-foreground dark:text-foreground-night">
+            Inbox
+          </h2>
+          <div className="flex flex-col">
+            <PersonalInboxSection
+              conversations={personalUnreadConversations}
+              owner={owner}
+            />
+
+            {spaceSections.map(({ space, unreadConversations }) => (
+              <SpaceInboxSection
+                key={space.sId}
+                space={space}
+                unreadConversations={unreadConversations}
+                owner={owner}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/front/lib/utils/router.ts
+++ b/front/lib/utils/router.ts
@@ -84,6 +84,10 @@ export const getConversationRoute = (
   return baseUrl ? `${baseUrl}${route}` : route;
 };
 
+export const getInboxRoute = (workspaceId: string) => {
+  return `/w/${workspaceId}/conversation/inbox`;
+};
+
 export const getSpaceRoute = (workspaceId: string, spaceId: string) => {
   return `/w/${workspaceId}/spaces/${spaceId}`;
 };

--- a/front/pages/w/[wId]/conversation/inbox/index.tsx
+++ b/front/pages/w/[wId]/conversation/inbox/index.tsx
@@ -1,0 +1,25 @@
+import type { ReactElement } from "react";
+
+import { ConversationLayout } from "@app/components/assistant/conversation/ConversationLayout";
+import { InboxPage } from "@app/components/pages/conversation/InboxPage";
+import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
+import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
+import { appGetServerSideProps } from "@app/lib/auth/appServerSideProps";
+import type { AuthContextValue } from "@app/lib/auth/AuthContext";
+
+export const getServerSideProps = appGetServerSideProps;
+
+const PageWithAuthLayout = InboxPage as AppPageWithLayout;
+
+PageWithAuthLayout.getLayout = (
+  page: ReactElement,
+  pageProps: AuthContextValue
+) => {
+  return (
+    <AppAuthContextLayout authContext={pageProps}>
+      <ConversationLayout pageProps={pageProps}>{page}</ConversationLayout>
+    </AppAuthContextLayout>
+  );
+};
+
+export default PageWithAuthLayout;


### PR DESCRIPTION
## Description

Replace inline inbox conversation list in the sidebar with a single "Inbox" navigation item that links to a dedicated inbox page.

- Add `/w/{wId}/conversation/inbox` page route with `InboxPage` component
- Sidebar shows "Inbox" with unread count badge instead of inline conversation list
- Inbox page groups unread conversations into "My conversations" (personal) and per-project sections
- Space sections use rich conversation cards (avatars, descriptions, reply sections via `SpaceConversationListItem`)
- Each section has a "Mark as read" button (each section owns its own mark-as-read behavior)
- Empty state: "You're all caught up!" when no unread conversations
- Centered layout with `max-w-4xl` matching the Sparkle playground design

## Missing elements (follow-up)

- Add conversation description for personal conversations (requires richer data than `ConversationWithoutContentType`)
- Gate behind `projects` feature flag

## Tests

- [x] Navigate to `/w/{wId}/conversation/inbox` and verify sections render with unread conversations
- [x] Click "Mark as read" on a section and verify it disappears after refresh
- [ ] Open an unread conversation and verify auto-mark-as-read (existing 2s delay)
- [ ] Verify empty state when no unread conversations
- [ ] Verify sidebar "Inbox" badge count matches total unread

## Risk
low

## Deploy plan
front