### PR TITLE
[front] Handle navigation events

### DIFF
--- a/front/hooks/useNavigationLock.tsx
+++ b/front/hooks/useNavigationLock.tsx
@@ -1,8 +1,8 @@
-import { useContext, useEffect } from "react";
+import { useCallback, useContext, useEffect } from "react";
 import React from "react";
 
 import { ConfirmContext } from "@app/components/Confirm";
-import { useAppRouter } from "@app/lib/platform";
+import { useAppRouter, useNavigationBlocker } from "@app/lib/platform";
 
 export function useNavigationLock(
   isEnabled = true,
@@ -17,6 +17,18 @@ export function useNavigationLock(
   const confirm = useContext(ConfirmContext);
   const isNavigatingAway = React.useRef<boolean>(false);
 
+  // SPA (React Router): use useBlocker to intercept all navigation
+  // (browser back/forward, link clicks, programmatic navigate()).
+  const onBlock = useCallback(
+    () => confirm(warningData),
+    [confirm, warningData]
+  );
+
+  useNavigationBlocker(isEnabled, onBlock);
+
+  // Next.js: use routeChangeStart events to intercept navigation.
+  // This is a noop in the SPA since routeChangeStart is not emitted
+  // for browser-initiated navigation.
   useEffect(() => {
     const handleWindowClose = (e: BeforeUnloadEvent) => {
       if (!isEnabled) {

--- a/front/lib/platform/index.ts
+++ b/front/lib/platform/index.ts
@@ -15,6 +15,7 @@ export {
   LinkWrapper,
   Script,
   useAppRouter,
+  useNavigationBlocker,
   usePathParam,
   usePathParams,
   useRequiredPathParam,

--- a/front/lib/platform/next.tsx
+++ b/front/lib/platform/next.tsx
@@ -117,4 +117,16 @@ export function useSearchParam(name: string): string | null {
   return searchParams?.get(name) ?? null;
 }
 
+/**
+ * Navigation blocker - noop in Next.js.
+ * In Next.js, navigation blocking is handled via routeChangeStart events
+ * in useNavigationLock. This hook is only active in the SPA (React Router).
+ */
+export function useNavigationBlocker(
+  _shouldBlock: boolean,
+  _onBlock: () => Promise<boolean>
+) {
+  // Noop - Next.js uses routeChangeStart events for navigation blocking.
+}
+
 export type { AppRouter, HeadProps, ScriptProps };


### PR DESCRIPTION
fixes: https://github.com/dust-tt/tasks/issues/6323

## Description

- Fix useNavigationLock not showing the "unsaved changes" confirmation modal in the SPA (React Router) — e.g., when clicking browser back/forward from the agent builder with dirty form state
- Add useNavigationBlocker to the platform abstraction layer, backed by React Router's useBlocker in the SPA and a noop in Next.js

### Context

In Next.js, useNavigationLock intercepts navigation via routeChangeStart events emitted by the Next.js router before every route change. In the SPA, browser back/forward buttons trigger popstate events handled directly by React Router — they never go through our AppRouter.push()/back() methods, so routeChangeStart is never emitted and the confirmation modal never appears.

### Approach

Use React Router's useBlocker hook which intercepts all navigation (browser back/forward, link clicks, programmatic navigate()) at the router level. This is exposed as useNavigationBlocker in the platform abstraction:

- SPA (front-spa/src/lib/platform.tsx): Uses useBlocker to block navigation and calls back to show the Sparkle confirmation dialog
- Next.js (front/lib/platform/next.tsx): Noop — the existing routeChangeStart event mechanism handles it


## Tests

- SPA: Open agent builder, edit instructions, click browser Back → confirmation modal appears
- SPA: Click "Cancel" in modal → stays on page, modal closes (no re-opening)
- SPA: Click "OK" in modal → navigates away
- Next.js: Same flow still works as before (no regression)

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
