### PR TITLE
[front] Rename add knowledge slash command label

### DIFF
--- a/front/components/editor/extensions/skill_builder/SlashCommandExtension.tsx
+++ b/front/components/editor/extensions/skill_builder/SlashCommandExtension.tsx
@@ -21,7 +21,7 @@ const SLASH_COMMANDS: SlashCommand[] = [
     id: "add-knowledge",
     action: INSERT_KNOWLEDGE_NODE_ACTION,
     icon: AttachmentIcon,
-    label: "Add knowledge",
+    label: "Attach knowledge",
     tooltip: {
       description: "Use company knowledge for context.",
       media: (


### PR DESCRIPTION
## Description

- Part of https://github.com/dust-tt/tasks/issues/6425.
- This PR renames the label for "Add knowledge" on the dropdown menu in Skill Builder.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
