### PR TITLE
[Extension] Implement a content script-based side panel

### DIFF
--- a/extension/platforms/chrome/background.ts
+++ b/extension/platforms/chrome/background.ts
@@ -77,11 +77,14 @@ chrome.runtime.onUpdateAvailable.addListener(async (details) => {
 /**
  * Listener to set up context menus when the extension is installed.
  */
+// Ensure Chrome never intercepts action clicks for the side panel — we handle
+// them ourselves in chrome.action.onClicked so the content script sidebar works.
+if (isSidePanelSupported()) {
+  void chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: false });
+}
+
 chrome.runtime.onInstalled.addListener(() => {
   void platform.storage.set("extensionReady", false);
-  if (isSidePanelSupported()) {
-    void chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true });
-  }
   chrome.contextMenus.create({
     id: "add_tab_content",
     title: "Add tab content to conversation",
@@ -131,17 +134,15 @@ const ensureContentScriptLoaded = async (tabId: number): Promise<boolean> => {
  * automatically, so we only need this handler for the content script fallback.
  */
 chrome.action.onClicked.addListener(async (tab) => {
-  if (isSidePanelSupported()) {
-    // Side panel is opened automatically via openPanelOnActionClick.
-    return;
-  }
-
+  // In Chrome with openPanelOnActionClick active, this listener never fires
+  // (Chrome handles the click natively). For all other cases — Arc, Firefox,
+  // and Chrome before onInstalled has run — we fall through to the content
+  // script sidebar.
   if (!tab.id || !canInjectContentScript(tab.url)) {
     console.log("Cannot inject content script in this tab:", tab.url);
     return;
   }
 
-  // Ensure content script is loaded
   const loaded = await ensureContentScriptLoaded(tab.id);
   if (!loaded) {
     console.error("Failed to load content script");
@@ -295,7 +296,7 @@ chrome.contextMenus.onClicked.addListener(async (event, tab) => {
       const loaded = await ensureContentScriptLoaded(tab.id);
       if (loaded) {
         try {
-          await chrome.tabs.sendMessage(tab.id, { action: "toggleSidebar" });
+          await chrome.tabs.sendMessage(tab.id, { action: "openSidebar" });
         } catch (error) {
           console.error("Failed to open sidebar:", error);
         }
@@ -522,7 +523,7 @@ chrome.runtime.onMessageExternal.addListener((request) => {
           log("[onMessageExternal] Failed to load content script");
           return;
         }
-        await chrome.tabs.sendMessage(tab.id, { action: "toggleSidebar" });
+        await chrome.tabs.sendMessage(tab.id, { action: "openSidebar" });
       }
     };
 

--- a/extension/platforms/chrome/background.ts
+++ b/extension/platforms/chrome/background.ts
@@ -50,14 +50,111 @@ const isSidePanelSupported = (): boolean => {
   return typeof chrome.sidePanel !== "undefined";
 };
 
+// In-memory cache (valid for this service worker's lifetime). Persisted to
+// storage so detection survives service worker restarts.
+let nativeSidePanelCache: boolean | null = null;
+
+// Tracks whether we are currently inside the first-time native side panel
+// probe. While true the persistent onConnect handler must not update
+// nativeSidePanelCache, because the probe may be seeing a phantom connection
+// from Arc and will set the correct value itself after the probe resolves.
+let isProbing = false;
+
+// Keeps a reference to the active native side panel port so we can send a
+// close request when the user clicks the toolbar button again. Null when the
+// panel is closed (or after a service-worker restart).
+let activeSidePanelPort: chrome.runtime.Port | null = null;
+
 /**
- * Returns true only when the native side panel is both supported and actually
- * functional. Arc is Chromium-based so it exposes chrome.sidePanel, but it
- * does not implement the native side panel UI — we fall back to the content
- * script sidebar there.
+ * Opens the native side panel if supported and actually functional.
+ *
+ * On first call, opens the panel and waits up to 800 ms to see whether the
+ * side panel UI connects back via the "sidepanel-connection" port. Arc exposes
+ * the chrome.sidePanel API but resolves open() without ever showing a UI, so
+ * this probe reliably distinguishes Chrome (connects) from Arc (times out).
+ *
+ * The result is cached in memory for the lifetime of this service worker
+ * instance. The probe runs once per SW start.
+ *
+ * Returns true if the native side panel was opened, false to fall back to the
+ * content script sidebar.
  */
-const useNativeSidePanel = (): boolean => {
-  return isSidePanelSupported() && !navigator.userAgent.includes("Arc/");
+const tryOpenNativeSidePanel = async (windowId: number): Promise<boolean> => {
+  if (!isSidePanelSupported()) {
+    return false;
+  }
+
+  // Use in-memory cache when available (valid for this service worker's
+  // lifetime). The probe runs once per SW start; the cost (~800 ms worst-case)
+  // is acceptable on the first toolbar click after each SW restart.
+  if (nativeSidePanelCache !== null) {
+    if (nativeSidePanelCache) {
+      void chrome.sidePanel.open({ windowId });
+    }
+    return nativeSidePanelCache;
+  }
+
+  // First-time detection: open the panel and verify the connection persists.
+  //
+  // Some browsers (e.g. Arc) expose chrome.sidePanel but load the panel
+  // invisibly, causing a sidepanel-connection port to fire and then immediately
+  // disconnect. A real side panel (Chrome) stays connected for as long as the
+  // panel is open. We use a two-phase check:
+  //   1. Wait up to 800 ms for a sidepanel-connection port.
+  //   2. If one arrives, wait 300 ms to see if it stays connected.
+  // Only if both conditions are met do we consider the native panel functional.
+  //
+  // isProbing prevents the persistent onConnect handler from treating the
+  // phantom Arc connection as a real native side panel.
+  isProbing = true;
+  void chrome.sidePanel.open({ windowId });
+  const { connected, port: probePort } = await new Promise<{
+    connected: boolean;
+    port: chrome.runtime.Port | null;
+  }>((resolve) => {
+    const timeoutTimer = setTimeout(() => {
+      chrome.runtime.onConnect.removeListener(portListener);
+      resolve({ connected: false, port: null });
+    }, 800);
+
+    const portListener = (port: chrome.runtime.Port) => {
+      if (port.name === "sidepanel-connection") {
+        clearTimeout(timeoutTimer);
+        chrome.runtime.onConnect.removeListener(portListener);
+
+        // Panel connected — check that it stays connected (real UI) vs
+        // disconnects immediately (invisible/phantom panel in Arc).
+        const persistTimer = setTimeout(() => {
+          port.onDisconnect.removeListener(onEarlyDisconnect);
+          resolve({ connected: true, port });
+        }, 300);
+
+        const onEarlyDisconnect = () => {
+          clearTimeout(persistTimer);
+          resolve({ connected: false, port: null });
+        };
+        port.onDisconnect.addListener(onEarlyDisconnect);
+      }
+    };
+
+    chrome.runtime.onConnect.addListener(portListener);
+  });
+  isProbing = false;
+
+  // For Chrome (connected = true), track the open port so the action handler
+  // can toggle the panel closed later.
+  if (connected && probePort) {
+    activeSidePanelPort = probePort;
+    void platform.storage.set("extensionReady", true);
+    probePort.onDisconnect.addListener(async () => {
+      activeSidePanelPort = null;
+      await platform.storage.set("extensionReady", false);
+      state.lastHandler = undefined;
+    });
+  }
+
+  nativeSidePanelCache = connected;
+  return connected;
 };
 
 /**
@@ -87,18 +184,17 @@ chrome.runtime.onUpdateAvailable.addListener(async (details) => {
 /**
  * Listener to set up context menus when the extension is installed.
  */
-// In Chrome (native side panel), let the browser handle action icon clicks
-// automatically. In Arc and other browsers without a working side panel UI,
-// keep openPanelOnActionClick false so chrome.action.onClicked always fires
-// and we can toggle the content script sidebar instead.
+// Always keep openPanelOnActionClick false so chrome.action.onClicked fires
+// in every browser. We open the side panel (or content script sidebar) manually
+// inside that handler, using a try-catch to detect browsers like Arc that expose
+// the chrome.sidePanel API but don't implement the native side panel UI.
 if (isSidePanelSupported()) {
-  void chrome.sidePanel.setPanelBehavior({
-    openPanelOnActionClick: useNativeSidePanel(),
-  });
+  void chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: false });
 }
 
 chrome.runtime.onInstalled.addListener(() => {
   void platform.storage.set("extensionReady", false);
+  nativeSidePanelCache = null;
   chrome.contextMenus.create({
     id: "add_tab_content",
     title: "Add tab content to conversation",
@@ -144,14 +240,25 @@ const ensureContentScriptLoaded = async (tabId: number): Promise<boolean> => {
 
 /**
  * Listener to toggle the sidebar when the user clicks on the extension icon.
- * When the Side Panel API is supported, openPanelOnActionClick handles this
- * automatically, so we only need this handler for the content script fallback.
  */
 chrome.action.onClicked.addListener(async (tab) => {
-  // In Chrome with openPanelOnActionClick active, this listener never fires
-  // (Chrome handles the click natively). For all other cases — Arc, Firefox,
-  // and Chrome before onInstalled has run — we fall through to the content
-  // script sidebar.
+  // Fast path for Chrome (native side panel already confirmed): toggle it.
+  // If the panel is open, ask it to close itself; otherwise open it.
+  if (nativeSidePanelCache === true) {
+    if (activeSidePanelPort) {
+      activeSidePanelPort.postMessage({ type: "CLOSE_SIDE_PANEL" });
+    } else {
+      void chrome.sidePanel.open({ windowId: tab.windowId });
+    }
+    return;
+  }
+
+  // For the first click (or after a service-worker restart where the probe
+  // hasn't run yet), go through the full detection flow.
+  if (await tryOpenNativeSidePanel(tab.windowId)) {
+    return;
+  }
+
   if (!tab.id || !canInjectContentScript(tab.url)) {
     console.log("Cannot inject content script in this tab:", tab.url);
     return;
@@ -232,11 +339,27 @@ chrome.tabs.onActivated.addListener(async (activeInfo) => {
 
 chrome.runtime.onConnect.addListener(async (port) => {
   if (port.name === "sidepanel-connection") {
+    // Skip connections that arrive during the first-time probe — those are
+    // handled (and may be phantom Arc connections) by the probe's own listener.
+    if (isProbing) {
+      return;
+    }
     console.log("Sidepanel is there");
+    nativeSidePanelCache = true;
+    activeSidePanelPort = port;
     void platform.storage.set("extensionReady", true);
     port.onDisconnect.addListener(async () => {
       // This fires when sidepanel closes
       console.log("Sidepanel was closed");
+      activeSidePanelPort = null;
+      await platform.storage.set("extensionReady", false);
+      state.lastHandler = undefined;
+    });
+  } else if (port.name === "content-script-connection") {
+    // Content-script sidebar (Arc and similar browsers). Only manage
+    // extensionReady — do NOT touch nativeSidePanelCache.
+    void platform.storage.set("extensionReady", true);
+    port.onDisconnect.addListener(async () => {
       await platform.storage.set("extensionReady", false);
       state.lastHandler = undefined;
     });
@@ -303,8 +426,8 @@ chrome.contextMenus.onClicked.addListener(async (event, tab) => {
   if (!isExtensionReady && tab) {
     // Store the handler for later use when the extension is ready.
     state.lastHandler = handler;
-    if (useNativeSidePanel()) {
-      void chrome.sidePanel.open({ windowId: tab.windowId });
+    if (await tryOpenNativeSidePanel(tab.windowId)) {
+      // Native side panel opened — it will fire INPUT_BAR_STATUS when ready.
     } else if (tab.id && canInjectContentScript(tab.url)) {
       // Open the sidebar via content script
       const loaded = await ensureContentScriptLoaded(tab.id);
@@ -525,20 +648,19 @@ chrome.runtime.onMessageExternal.addListener((request) => {
     }
 
     const openSidebar = async () => {
-      if (useNativeSidePanel()) {
-        await chrome.sidePanel.open({ windowId: tab.windowId });
-      } else {
-        if (!tab.id || !canInjectContentScript(tab.url)) {
-          log("[onMessageExternal] Cannot inject content script in this tab");
-          return;
-        }
-        const loaded = await ensureContentScriptLoaded(tab.id);
-        if (!loaded) {
-          log("[onMessageExternal] Failed to load content script");
-          return;
-        }
-        await chrome.tabs.sendMessage(tab.id, { action: "openSidebar" });
+      if (await tryOpenNativeSidePanel(tab.windowId)) {
+        return;
       }
+      if (!tab.id || !canInjectContentScript(tab.url)) {
+        log("[onMessageExternal] Cannot inject content script in this tab");
+        return;
+      }
+      const loaded = await ensureContentScriptLoaded(tab.id);
+      if (!loaded) {
+        log("[onMessageExternal] Failed to load content script");
+        return;
+      }
+      await chrome.tabs.sendMessage(tab.id, { action: "openSidebar" });
     };
 
     try {

--- a/extension/platforms/chrome/background.ts
+++ b/extension/platforms/chrome/background.ts
@@ -34,6 +34,42 @@ const state: {
 };
 
 /**
+ * Helper function to check if we can inject content script into a URL
+ */
+const canInjectContentScript = (url: string | undefined): boolean => {
+  if (!url) {
+    return false;
+  }
+
+  // Block chrome:// URLs
+  if (url.startsWith("chrome://")) {
+    return false;
+  }
+
+  // Block chrome-extension:// URLs
+  if (url.startsWith("chrome-extension://")) {
+    return false;
+  }
+
+  // Block edge:// URLs
+  if (url.startsWith("edge://")) {
+    return false;
+  }
+
+  // Block about: URLs
+  if (url.startsWith("about:")) {
+    return false;
+  }
+
+  // Block other browser-specific URLs
+  if (url.startsWith("brave://") || url.startsWith("opera://")) {
+    return false;
+  }
+
+  return true;
+};
+
+/**
  * Listener for force update mechanism.
  */
 chrome.runtime.onUpdateAvailable.addListener(async (details) => {
@@ -46,11 +82,10 @@ chrome.runtime.onUpdateAvailable.addListener(async (details) => {
 });
 
 /**
- * Listener to open/close the side panel when the user clicks on the extension icon.
+ * Listener to set up context menus when the extension is installed.
  */
 chrome.runtime.onInstalled.addListener(() => {
   void platform.storage.set("extensionReady", false);
-  void chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true });
   chrome.contextMenus.create({
     id: "add_tab_content",
     title: "Add tab content to conversation",
@@ -67,6 +102,54 @@ chrome.runtime.onInstalled.addListener(() => {
     title: "Add selection to conversation",
     contexts: ["selection"],
   });
+});
+
+/**
+ * Inject content script programmatically if not already loaded
+ */
+const ensureContentScriptLoaded = async (tabId: number): Promise<boolean> => {
+  try {
+    // Try to send a ping message to check if content script is loaded
+    await chrome.tabs.sendMessage(tabId, { action: "ping" });
+    return true;
+  } catch (_error) {
+    // Content script not loaded, inject it now
+    try {
+      await chrome.scripting.executeScript({
+        target: { tabId },
+        files: ["content-script.js"],
+      });
+      // Wait a bit for the script to initialize
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      return true;
+    } catch (injectError) {
+      console.error("Failed to inject content script:", injectError);
+      return false;
+    }
+  }
+};
+
+/**
+ * Listener to toggle the sidebar when the user clicks on the extension icon.
+ */
+chrome.action.onClicked.addListener(async (tab) => {
+  if (!tab.id || !canInjectContentScript(tab.url)) {
+    console.log("Cannot inject content script in this tab:", tab.url);
+    return;
+  }
+
+  // Ensure content script is loaded
+  const loaded = await ensureContentScriptLoaded(tab.id);
+  if (!loaded) {
+    console.error("Failed to load content script");
+    return;
+  }
+
+  try {
+    await chrome.tabs.sendMessage(tab.id, { action: "toggleSidebar" });
+  } catch (error) {
+    console.error("Failed to toggle sidebar:", error);
+  }
 });
 
 /**
@@ -198,12 +281,18 @@ chrome.contextMenus.onClicked.addListener(async (event, tab) => {
   const isExtensionReady =
     await platform.storage.get<boolean>("extensionReady");
 
-  if (!isExtensionReady && tab) {
+  if (!isExtensionReady && tab?.id && canInjectContentScript(tab.url)) {
     // Store the handler for later use when the extension is ready.
     state.lastHandler = handler;
-    void chrome.sidePanel.open({
-      windowId: tab.windowId,
-    });
+    // Open the sidebar via content script
+    const loaded = await ensureContentScriptLoaded(tab.id);
+    if (loaded) {
+      try {
+        await chrome.tabs.sendMessage(tab.id, { action: "toggleSidebar" });
+      } catch (error) {
+        console.error("Failed to open sidebar:", error);
+      }
+    }
   } else {
     void handler();
   }
@@ -405,75 +494,84 @@ chrome.runtime.onMessageExternal.addListener((request) => {
     return true;
   }
 
-  chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-    if (tabs[0]) {
-      void chrome.sidePanel
-        .open({
-          windowId: tabs[0].windowId,
-        })
-        .then(() => {
-          chrome.storage.local.get(
-            ["extensionReady", "selectedWorkspace"],
-            ({ extensionReady, selectedWorkspace }) => {
-              if (request.workspaceId != selectedWorkspace) {
-                log("[onMessageExternal] User selected another workspace.");
+  chrome.tabs.query({ active: true, currentWindow: true }, async (tabs) => {
+    const tab = tabs[0];
+    if (!tab?.id || !canInjectContentScript(tab.url)) {
+      log("[onMessageExternal] Cannot inject content script in this tab");
+      return;
+    }
+
+    // Ensure content script is loaded
+    const loaded = await ensureContentScriptLoaded(tab.id);
+    if (!loaded) {
+      log("[onMessageExternal] Failed to load content script");
+      return;
+    }
+
+    try {
+      // Open the sidebar via content script
+      await chrome.tabs.sendMessage(tab.id, { action: "toggleSidebar" });
+
+      chrome.storage.local.get(
+        ["extensionReady", "selectedWorkspace"],
+        ({ extensionReady, selectedWorkspace }) => {
+          if (request.workspaceId != user?.selectedWorkspace) {
+            log("[onMessageExternal] User selected another workspace.");
+            return;
+          }
+
+          const sendMessage = () => {
+            const params = JSON.stringify({
+              conversationId: request.conversationId,
+            });
+            void chrome.runtime.sendMessage({
+              type: "EXT_ROUTE_CHANGE",
+              pathname: "/run",
+              search: `?${params}`,
+            });
+          };
+
+          if (!extensionReady) {
+            let retries = 0;
+            const MAX_RETRIES = 15;
+            const RETRY_INTERVAL = 500; // Check every 500ms 15 times = 7.5s total.
+
+            const checkReady = () => {
+              if (retries >= MAX_RETRIES) {
+                log(
+                  "[onMessageExternal] Max retries reached waiting for extension ready."
+                );
                 return;
               }
 
-              const sendMessage = () => {
-                const params = JSON.stringify({
-                  conversationId: request.conversationId,
-                });
-                void chrome.runtime.sendMessage({
-                  type: "EXT_ROUTE_CHANGE",
-                  pathname: "/run",
-                  search: `?${params}`,
-                });
-              };
-
-              if (!extensionReady) {
-                let retries = 0;
-                const MAX_RETRIES = 15;
-                const RETRY_INTERVAL = 500; // Check every 500ms 15 times = 7.5s total.
-
-                const checkReady = () => {
-                  if (retries >= MAX_RETRIES) {
+              chrome.storage.local.get(
+                ["extensionReady"],
+                ({ extensionReady }) => {
+                  if (chrome.runtime.lastError) {
                     log(
-                      "[onMessageExternal] Max retries reached waiting for extension ready."
+                      "[onMessageExternal] Error checking extension ready:",
+                      chrome.runtime.lastError
                     );
                     return;
                   }
 
-                  chrome.storage.local.get(
-                    ["extensionReady"],
-                    ({ extensionReady }) => {
-                      if (chrome.runtime.lastError) {
-                        log(
-                          "[onMessageExternal] Error checking extension ready:",
-                          chrome.runtime.lastError
-                        );
-                        return;
-                      }
-
-                      if (extensionReady) {
-                        sendMessage();
-                      } else {
-                        retries++;
-                        setTimeout(checkReady, RETRY_INTERVAL);
-                      }
-                    }
-                  );
-                };
-                checkReady();
-              } else {
-                sendMessage();
-              }
-            }
-          );
-        })
-        .catch((err) => {
-          log("[onMessageExternal] Error opening side panel:", err);
-        });
+                  if (extensionReady) {
+                    sendMessage();
+                  } else {
+                    retries++;
+                    setTimeout(checkReady, RETRY_INTERVAL);
+                  }
+                }
+              );
+            };
+            checkReady();
+          } else {
+            sendMessage();
+          }
+        }
+      );
+    } catch (err) {
+      log("[onMessageExternal] Error opening sidebar:", err);
     }
   });
 

--- a/extension/platforms/chrome/background.ts
+++ b/extension/platforms/chrome/background.ts
@@ -44,6 +44,13 @@ const state: {
 };
 
 /**
+ * Helper function to check if the browser supports the Side Panel API.
+ */
+const isSidePanelSupported = (): boolean => {
+  return typeof chrome.sidePanel !== "undefined";
+};
+
+/**
  * Helper function to check if we can inject content script into a URL
  */
 const canInjectContentScript = (url: string | undefined): boolean => {
@@ -72,6 +79,9 @@ chrome.runtime.onUpdateAvailable.addListener(async (details) => {
  */
 chrome.runtime.onInstalled.addListener(() => {
   void platform.storage.set("extensionReady", false);
+  if (isSidePanelSupported()) {
+    void chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true });
+  }
   chrome.contextMenus.create({
     id: "add_tab_content",
     title: "Add tab content to conversation",
@@ -117,8 +127,15 @@ const ensureContentScriptLoaded = async (tabId: number): Promise<boolean> => {
 
 /**
  * Listener to toggle the sidebar when the user clicks on the extension icon.
+ * When the Side Panel API is supported, openPanelOnActionClick handles this
+ * automatically, so we only need this handler for the content script fallback.
  */
 chrome.action.onClicked.addListener(async (tab) => {
+  if (isSidePanelSupported()) {
+    // Side panel is opened automatically via openPanelOnActionClick.
+    return;
+  }
+
   if (!tab.id || !canInjectContentScript(tab.url)) {
     console.log("Cannot inject content script in this tab:", tab.url);
     return;
@@ -268,16 +285,20 @@ chrome.contextMenus.onClicked.addListener(async (event, tab) => {
   const isExtensionReady =
     await platform.storage.get<boolean>("extensionReady");
 
-  if (!isExtensionReady && tab?.id && canInjectContentScript(tab.url)) {
+  if (!isExtensionReady && tab) {
     // Store the handler for later use when the extension is ready.
     state.lastHandler = handler;
-    // Open the sidebar via content script
-    const loaded = await ensureContentScriptLoaded(tab.id);
-    if (loaded) {
-      try {
-        await chrome.tabs.sendMessage(tab.id, { action: "toggleSidebar" });
-      } catch (error) {
-        console.error("Failed to open sidebar:", error);
+    if (isSidePanelSupported()) {
+      void chrome.sidePanel.open({ windowId: tab.windowId });
+    } else if (tab.id && canInjectContentScript(tab.url)) {
+      // Open the sidebar via content script
+      const loaded = await ensureContentScriptLoaded(tab.id);
+      if (loaded) {
+        try {
+          await chrome.tabs.sendMessage(tab.id, { action: "toggleSidebar" });
+        } catch (error) {
+          console.error("Failed to open sidebar:", error);
+        }
       }
     }
   } else {
@@ -483,26 +504,35 @@ chrome.runtime.onMessageExternal.addListener((request) => {
 
   chrome.tabs.query({ active: true, currentWindow: true }, async (tabs) => {
     const tab = tabs[0];
-    if (!tab?.id || !canInjectContentScript(tab.url)) {
-      log("[onMessageExternal] Cannot inject content script in this tab");
+    if (!tab) {
+      log("[onMessageExternal] No active tab found");
       return;
     }
 
-    // Ensure content script is loaded
-    const loaded = await ensureContentScriptLoaded(tab.id);
-    if (!loaded) {
-      log("[onMessageExternal] Failed to load content script");
-      return;
-    }
+    const openSidebar = async () => {
+      if (isSidePanelSupported()) {
+        await chrome.sidePanel.open({ windowId: tab.windowId });
+      } else {
+        if (!tab.id || !canInjectContentScript(tab.url)) {
+          log("[onMessageExternal] Cannot inject content script in this tab");
+          return;
+        }
+        const loaded = await ensureContentScriptLoaded(tab.id);
+        if (!loaded) {
+          log("[onMessageExternal] Failed to load content script");
+          return;
+        }
+        await chrome.tabs.sendMessage(tab.id, { action: "toggleSidebar" });
+      }
+    };
 
     try {
-      // Open the sidebar via content script
-      await chrome.tabs.sendMessage(tab.id, { action: "toggleSidebar" });
+      await openSidebar();
 
       chrome.storage.local.get(
         ["extensionReady", "selectedWorkspace"],
         ({ extensionReady, selectedWorkspace }) => {
-          if (request.workspaceId != user?.selectedWorkspace) {
+          if (request.workspaceId != selectedWorkspace) {
             log("[onMessageExternal] User selected another workspace.");
             return;
           }

--- a/extension/platforms/chrome/background.ts
+++ b/extension/platforms/chrome/background.ts
@@ -18,6 +18,16 @@ import { jwtDecode } from "jwt-decode";
 const log = console.error;
 const DEFAULT_TOKEN_EXPIRY_IN_SECONDS = 5 * 60; // 5 minutes.
 
+// URL prefixes that are restricted for content script injection
+const RESTRICTED_URL_PREFIXES = [
+  "chrome://",
+  "chrome-extension://",
+  "edge://",
+  "about:",
+  "brave://",
+  "opera://",
+] as const;
+
 // Initialize the platform service.
 const platform = new ChromeCorePlatformService();
 
@@ -41,32 +51,8 @@ const canInjectContentScript = (url: string | undefined): boolean => {
     return false;
   }
 
-  // Block chrome:// URLs
-  if (url.startsWith("chrome://")) {
-    return false;
-  }
-
-  // Block chrome-extension:// URLs
-  if (url.startsWith("chrome-extension://")) {
-    return false;
-  }
-
-  // Block edge:// URLs
-  if (url.startsWith("edge://")) {
-    return false;
-  }
-
-  // Block about: URLs
-  if (url.startsWith("about:")) {
-    return false;
-  }
-
-  // Block other browser-specific URLs
-  if (url.startsWith("brave://") || url.startsWith("opera://")) {
-    return false;
-  }
-
-  return true;
+  // Block restricted URLs (browser-specific and extension URLs)
+  return !RESTRICTED_URL_PREFIXES.some((prefix) => url.startsWith(prefix));
 };
 
 /**
@@ -158,7 +144,8 @@ chrome.action.onClicked.addListener(async (tab) => {
 const shouldDisableContextMenuForDomain = async (
   url: string
 ): Promise<boolean> => {
-  if (url.startsWith("chrome://")) {
+  // Disable context menu for restricted URLs
+  if (RESTRICTED_URL_PREFIXES.some((prefix) => url.startsWith(prefix))) {
     return true;
   }
 

--- a/extension/platforms/chrome/background.ts
+++ b/extension/platforms/chrome/background.ts
@@ -51,6 +51,16 @@ const isSidePanelSupported = (): boolean => {
 };
 
 /**
+ * Returns true only when the native side panel is both supported and actually
+ * functional. Arc is Chromium-based so it exposes chrome.sidePanel, but it
+ * does not implement the native side panel UI — we fall back to the content
+ * script sidebar there.
+ */
+const useNativeSidePanel = (): boolean => {
+  return isSidePanelSupported() && !navigator.userAgent.includes("Arc/");
+};
+
+/**
  * Helper function to check if we can inject content script into a URL
  */
 const canInjectContentScript = (url: string | undefined): boolean => {
@@ -77,10 +87,14 @@ chrome.runtime.onUpdateAvailable.addListener(async (details) => {
 /**
  * Listener to set up context menus when the extension is installed.
  */
-// Ensure Chrome never intercepts action clicks for the side panel — we handle
-// them ourselves in chrome.action.onClicked so the content script sidebar works.
+// In Chrome (native side panel), let the browser handle action icon clicks
+// automatically. In Arc and other browsers without a working side panel UI,
+// keep openPanelOnActionClick false so chrome.action.onClicked always fires
+// and we can toggle the content script sidebar instead.
 if (isSidePanelSupported()) {
-  void chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: false });
+  void chrome.sidePanel.setPanelBehavior({
+    openPanelOnActionClick: useNativeSidePanel(),
+  });
 }
 
 chrome.runtime.onInstalled.addListener(() => {
@@ -289,7 +303,7 @@ chrome.contextMenus.onClicked.addListener(async (event, tab) => {
   if (!isExtensionReady && tab) {
     // Store the handler for later use when the extension is ready.
     state.lastHandler = handler;
-    if (isSidePanelSupported()) {
+    if (useNativeSidePanel()) {
       void chrome.sidePanel.open({ windowId: tab.windowId });
     } else if (tab.id && canInjectContentScript(tab.url)) {
       // Open the sidebar via content script
@@ -511,7 +525,7 @@ chrome.runtime.onMessageExternal.addListener((request) => {
     }
 
     const openSidebar = async () => {
-      if (isSidePanelSupported()) {
+      if (useNativeSidePanel()) {
         await chrome.sidePanel.open({ windowId: tab.windowId });
       } else {
         if (!tab.id || !canInjectContentScript(tab.url)) {

--- a/extension/platforms/chrome/background.ts
+++ b/extension/platforms/chrome/background.ts
@@ -158,9 +158,9 @@ const tryOpenNativeSidePanel = async (windowId: number): Promise<boolean> => {
 };
 
 /**
- * Helper function to check if we can inject content script into a URL
+ * Helper function to check if we can inject content script into a URL or open the side panel
  */
-const canInjectContentScript = (url: string | undefined): boolean => {
+const canOpenExtension = (url: string | undefined): boolean => {
   if (!url) {
     return false;
   }
@@ -245,6 +245,10 @@ chrome.action.onClicked.addListener(async (tab) => {
   // Fast path for Chrome (native side panel already confirmed): toggle it.
   // If the panel is open, ask it to close itself; otherwise open it.
   if (nativeSidePanelCache === true) {
+    if (!tab.id || !canOpenExtension(tab.url)) {
+      console.log("Cannot open extension on this tab:", tab.url);
+      return;
+    }
     if (activeSidePanelPort) {
       activeSidePanelPort.postMessage({ type: "CLOSE_SIDE_PANEL" });
     } else {
@@ -253,14 +257,13 @@ chrome.action.onClicked.addListener(async (tab) => {
     return;
   }
 
-  // For the first click (or after a service-worker restart where the probe
-  // hasn't run yet), go through the full detection flow.
+  // For the first click, go through the full detection flow.
   if (await tryOpenNativeSidePanel(tab.windowId)) {
     return;
   }
 
-  if (!tab.id || !canInjectContentScript(tab.url)) {
-    console.log("Cannot inject content script in this tab:", tab.url);
+  if (!tab.id || !canOpenExtension(tab.url)) {
+    console.log("Cannot open extension on this tab:", tab.url);
     return;
   }
 
@@ -428,7 +431,7 @@ chrome.contextMenus.onClicked.addListener(async (event, tab) => {
     state.lastHandler = handler;
     if (await tryOpenNativeSidePanel(tab.windowId)) {
       // Native side panel opened — it will fire INPUT_BAR_STATUS when ready.
-    } else if (tab.id && canInjectContentScript(tab.url)) {
+    } else if (tab.id && canOpenExtension(tab.url)) {
       // Open the sidebar via content script
       const loaded = await ensureContentScriptLoaded(tab.id);
       if (loaded) {
@@ -651,7 +654,7 @@ chrome.runtime.onMessageExternal.addListener((request) => {
       if (await tryOpenNativeSidePanel(tab.windowId)) {
         return;
       }
-      if (!tab.id || !canInjectContentScript(tab.url)) {
+      if (!tab.id || !canOpenExtension(tab.url)) {
         log("[onMessageExternal] Cannot inject content script in this tab");
         return;
       }

--- a/extension/platforms/chrome/content-script.ts
+++ b/extension/platforms/chrome/content-script.ts
@@ -1,0 +1,281 @@
+// Content script that injects a sidebar with iframe containing the Dust extension
+
+const DEFAULT_SIDEBAR_WIDTH = 450;
+const MIN_SIDEBAR_WIDTH = 300;
+const MAX_SIDEBAR_WIDTH = 1200;
+const SIDEBAR_ID = "dust-extension-sidebar";
+const IFRAME_ID = "dust-extension-iframe";
+const RESIZE_HANDLE_ID = "dust-extension-resize-handle";
+const STORAGE_KEY_VISIBLE = "dustSidebarVisible";
+const STORAGE_KEY_WIDTH = "dustSidebarWidth";
+
+// Track sidebar state
+let sidebarVisible = false;
+let sidebarWidth = DEFAULT_SIDEBAR_WIDTH;
+let sidebarElement: HTMLDivElement | null = null;
+let iframeElement: HTMLIFrameElement | null = null;
+let resizeHandle: HTMLDivElement | null = null;
+let isResizing = false;
+
+/**
+ * Update sidebar width
+ */
+function updateSidebarWidth(width: number): void {
+  const clampedWidth = Math.max(
+    MIN_SIDEBAR_WIDTH,
+    Math.min(MAX_SIDEBAR_WIDTH, width)
+  );
+  sidebarWidth = clampedWidth;
+
+  if (sidebarElement) {
+    sidebarElement.style.width = `${clampedWidth}px`;
+  }
+
+  if (sidebarVisible) {
+    document.body.style.marginRight = `${clampedWidth}px`;
+  }
+
+  // Save width to storage
+  chrome.storage.local
+    .set({ [STORAGE_KEY_WIDTH]: clampedWidth })
+    .catch(console.error);
+}
+
+/**
+ * Handle resize start
+ */
+function handleResizeStart(e: MouseEvent): void {
+  e.preventDefault();
+  isResizing = true;
+  document.body.style.cursor = "ew-resize";
+  document.body.style.userSelect = "none";
+
+  // Disable pointer events on iframe to capture mouseup
+  if (iframeElement) {
+    iframeElement.style.pointerEvents = "none";
+  }
+}
+
+/**
+ * Handle resize move
+ */
+function handleResizeMove(e: MouseEvent): void {
+  if (!isResizing) {
+    return;
+  }
+
+  const newWidth = window.innerWidth - e.clientX;
+  updateSidebarWidth(newWidth);
+}
+
+/**
+ * Handle resize end
+ */
+function handleResizeEnd(): void {
+  if (isResizing) {
+    isResizing = false;
+    document.body.style.cursor = "";
+    document.body.style.userSelect = "";
+
+    // Re-enable pointer events on iframe
+    if (iframeElement) {
+      iframeElement.style.pointerEvents = "auto";
+    }
+  }
+}
+
+/**
+ * Create and inject the sidebar into the page
+ */
+function createSidebar(): void {
+  // Check if sidebar already exists
+  if (sidebarElement) {
+    return;
+  }
+
+  // Create sidebar container
+  sidebarElement = document.createElement("div");
+  sidebarElement.id = SIDEBAR_ID;
+  sidebarElement.style.cssText = `
+    position: fixed;
+    top: 0;
+    right: 0;
+    width: ${sidebarWidth}px;
+    height: 100vh;
+    z-index: 2147483647;
+    background: white;
+    box-shadow: -2px 0 8px rgba(0, 0, 0, 0.1);
+    border-left: 1px solid #e5e7eb;
+    display: none;
+  `;
+
+  // Create resize handle
+  resizeHandle = document.createElement("div");
+  resizeHandle.id = RESIZE_HANDLE_ID;
+  resizeHandle.style.cssText = `
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 4px;
+    height: 100%;
+    cursor: ew-resize;
+    z-index: 2147483648;
+    background: transparent;
+    transition: background 0.2s;
+  `;
+
+  // Add hover effect
+  resizeHandle.addEventListener("mouseenter", () => {
+    if (resizeHandle) {
+      resizeHandle.style.background = "rgba(59, 130, 246, 0.3)";
+    }
+  });
+
+  resizeHandle.addEventListener("mouseleave", () => {
+    if (resizeHandle && !isResizing) {
+      resizeHandle.style.background = "transparent";
+    }
+  });
+
+  // Add resize listeners
+  resizeHandle.addEventListener("mousedown", handleResizeStart);
+
+  // Create iframe
+  iframeElement = document.createElement("iframe");
+  iframeElement.id = IFRAME_ID;
+  iframeElement.src = chrome.runtime.getURL("main.html");
+  iframeElement.style.cssText = `
+    width: 100%;
+    height: 100%;
+    border: none;
+    margin: 0;
+    padding: 0;
+  `;
+
+  sidebarElement.appendChild(resizeHandle);
+  sidebarElement.appendChild(iframeElement);
+  document.body.appendChild(sidebarElement);
+
+  // Add global mouse listeners for resizing
+  document.addEventListener("mousemove", handleResizeMove);
+  document.addEventListener("mouseup", handleResizeEnd);
+}
+
+/**
+ * Show the sidebar
+ */
+function showSidebar(): void {
+  if (!sidebarElement) {
+    createSidebar();
+  }
+
+  if (sidebarElement) {
+    sidebarElement.style.display = "block";
+    document.body.style.marginRight = `${sidebarWidth}px`;
+    sidebarVisible = true;
+
+    // Save state
+    chrome.storage.local
+      .set({ [STORAGE_KEY_VISIBLE]: true })
+      .catch(console.error);
+  }
+}
+
+/**
+ * Hide the sidebar
+ */
+function hideSidebar(): void {
+  if (sidebarElement) {
+    sidebarElement.style.display = "none";
+    document.body.style.marginRight = "0";
+    sidebarVisible = false;
+
+    // Save state
+    chrome.storage.local
+      .set({ [STORAGE_KEY_VISIBLE]: false })
+      .catch(console.error);
+  }
+}
+
+/**
+ * Toggle sidebar visibility
+ */
+function toggleSidebar(): void {
+  if (sidebarVisible) {
+    hideSidebar();
+  } else {
+    showSidebar();
+  }
+}
+
+/**
+ * Remove the sidebar from the page
+ */
+function removeSidebar(): void {
+  if (sidebarElement) {
+    sidebarElement.remove();
+    sidebarElement = null;
+    iframeElement = null;
+    resizeHandle = null;
+    document.body.style.marginRight = "0";
+    sidebarVisible = false;
+  }
+
+  // Clean up event listeners
+  document.removeEventListener("mousemove", handleResizeMove);
+  document.removeEventListener("mouseup", handleResizeEnd);
+}
+
+/**
+ * Initialize the content script
+ */
+async function init(): Promise<void> {
+  try {
+    // Restore previous state
+    const result = await chrome.storage.local.get([
+      STORAGE_KEY_VISIBLE,
+      STORAGE_KEY_WIDTH,
+    ]);
+
+    // Restore saved width
+    if (result[STORAGE_KEY_WIDTH]) {
+      sidebarWidth = result[STORAGE_KEY_WIDTH];
+    }
+
+    // Restore visibility
+    const wasVisible = result[STORAGE_KEY_VISIBLE] === true;
+    if (wasVisible) {
+      showSidebar();
+    }
+  } catch (error) {
+    console.error("[Dust Content Script] Error initializing:", error);
+  }
+}
+
+// Listen for messages from background script
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.action === "ping") {
+    sendResponse({ success: true });
+    return true;
+  }
+
+  if (message.action === "toggleSidebar") {
+    toggleSidebar();
+    sendResponse({ success: true, visible: sidebarVisible });
+    return true;
+  }
+
+  return false;
+});
+
+// Handle page unload
+window.addEventListener("beforeunload", () => {
+  removeSidebar();
+});
+
+// Initialize when DOM is ready
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", init);
+} else {
+  void init();
+}

--- a/extension/platforms/chrome/content-script.ts
+++ b/extension/platforms/chrome/content-script.ts
@@ -13,6 +13,12 @@ const SIDEBAR_MARGIN = 8;
 const STORAGE_KEY_VISIBLE = "dustSidebarVisible";
 const STORAGE_KEY_WIDTH = "dustSidebarWidth";
 
+// Slide animation: sidebar translates off-screen to the right when hidden.
+const TRANSITION_DURATION = 300; // ms
+const SIDEBAR_TRANSITION = `transform ${TRANSITION_DURATION}ms cubic-bezier(0.4, 0, 0.2, 1)`;
+// Must exceed SIDEBAR_MARGIN so the rounded edge is fully out of view.
+const SIDEBAR_SLIDE_OUT = `translateX(calc(100% + ${SIDEBAR_MARGIN * 2}px))`;
+
 // Track sidebar state
 let sidebarVisible = false;
 let sidebarWidth = DEFAULT_SIDEBAR_WIDTH;
@@ -22,6 +28,8 @@ let iframeElement: HTMLIFrameElement | null = null;
 let resizeHandle: HTMLDivElement | null = null;
 let closeButton: HTMLButtonElement | null = null;
 let isResizing = false;
+// Deferred cleanup when hiding: resets backdrop + body margin after slide-out.
+let hideTimeoutId: ReturnType<typeof setTimeout> | undefined;
 
 /**
  * Update sidebar width
@@ -118,8 +126,11 @@ function createSidebar(): void {
     border: 1px solid #e5e7eb;
     border-radius: 12px;
     overflow: hidden;
-    display: none;
+    display: flex;
     flex-direction: column;
+    transform: ${SIDEBAR_SLIDE_OUT};
+    transition: ${SIDEBAR_TRANSITION};
+    pointer-events: none;
   `;
 
   // Create resize handle
@@ -203,7 +214,9 @@ function createSidebar(): void {
   // Create iframe
   iframeElement = document.createElement("iframe");
   iframeElement.id = IFRAME_ID;
-  iframeElement.src = chrome.runtime.getURL("main.html");
+  // Mark the URL so PortProvider knows it is embedded in a content-script
+  // sidebar (Arc, etc.) rather than running as a native side panel.
+  iframeElement.src = chrome.runtime.getURL("main.html") + "?embedded=1";
   iframeElement.style.cssText = `
     flex: 1;
     width: 100%;
@@ -246,11 +259,21 @@ function showSidebar(): void {
   }
 
   if (sidebarElement) {
-    sidebarElement.style.display = "flex";
+    // Cancel any deferred cleanup from a previous hide.
+    if (hideTimeoutId !== undefined) {
+      clearTimeout(hideTimeoutId);
+      hideTimeoutId = undefined;
+    }
+
     if (backdropElement) {
       backdropElement.style.display = "block";
     }
     document.body.style.marginRight = `${sidebarWidth + SIDEBAR_MARGIN * 2}px`;
+    sidebarElement.style.pointerEvents = "all";
+    // Force a reflow so the off-screen transform is committed before we
+    // change it, ensuring the CSS transition fires.
+    void sidebarElement.offsetWidth;
+    sidebarElement.style.transform = "translateX(0)";
     sidebarVisible = true;
 
     // Save state
@@ -265,12 +288,19 @@ function showSidebar(): void {
  */
 function hideSidebar(): void {
   if (sidebarElement) {
-    sidebarElement.style.display = "none";
-    if (backdropElement) {
-      backdropElement.style.display = "none";
-    }
-    document.body.style.marginRight = "0";
+    sidebarElement.style.transform = SIDEBAR_SLIDE_OUT;
+    sidebarElement.style.pointerEvents = "none";
     sidebarVisible = false;
+
+    // Defer the layout cleanup until after the slide-out animation so the
+    // page content doesn't snap back before the panel has fully left.
+    hideTimeoutId = setTimeout(() => {
+      hideTimeoutId = undefined;
+      if (backdropElement) {
+        backdropElement.style.display = "none";
+      }
+      document.body.style.marginRight = "0";
+    }, TRANSITION_DURATION);
 
     // Save state
     chrome.storage.local
@@ -294,6 +324,11 @@ function toggleSidebar(): void {
  * Remove the sidebar from the page
  */
 function removeSidebar(): void {
+  if (hideTimeoutId !== undefined) {
+    clearTimeout(hideTimeoutId);
+    hideTimeoutId = undefined;
+  }
+
   if (sidebarElement) {
     sidebarElement.remove();
     sidebarElement = null;

--- a/extension/platforms/chrome/content-script.ts
+++ b/extension/platforms/chrome/content-script.ts
@@ -6,6 +6,10 @@ const MAX_SIDEBAR_WIDTH = 1200;
 const SIDEBAR_ID = "dust-extension-sidebar";
 const IFRAME_ID = "dust-extension-iframe";
 const RESIZE_HANDLE_ID = "dust-extension-resize-handle";
+const HEADER_ID = "dust-extension-header";
+const CLOSE_BUTTON_ID = "dust-extension-close-button";
+const HEADER_HEIGHT = 40;
+const SIDEBAR_MARGIN = 8;
 const STORAGE_KEY_VISIBLE = "dustSidebarVisible";
 const STORAGE_KEY_WIDTH = "dustSidebarWidth";
 
@@ -13,8 +17,10 @@ const STORAGE_KEY_WIDTH = "dustSidebarWidth";
 let sidebarVisible = false;
 let sidebarWidth = DEFAULT_SIDEBAR_WIDTH;
 let sidebarElement: HTMLDivElement | null = null;
+let backdropElement: HTMLDivElement | null = null;
 let iframeElement: HTMLIFrameElement | null = null;
 let resizeHandle: HTMLDivElement | null = null;
+let closeButton: HTMLButtonElement | null = null;
 let isResizing = false;
 
 /**
@@ -31,8 +37,12 @@ function updateSidebarWidth(width: number): void {
     sidebarElement.style.width = `${clampedWidth}px`;
   }
 
+  if (backdropElement) {
+    backdropElement.style.width = `${clampedWidth + SIDEBAR_MARGIN * 2}px`;
+  }
+
   if (sidebarVisible) {
-    document.body.style.marginRight = `${clampedWidth}px`;
+    document.body.style.marginRight = `${clampedWidth + SIDEBAR_MARGIN * 2}px`;
   }
 
   // Save width to storage
@@ -98,15 +108,18 @@ function createSidebar(): void {
   sidebarElement.id = SIDEBAR_ID;
   sidebarElement.style.cssText = `
     position: fixed;
-    top: 0;
-    right: 0;
+    top: ${SIDEBAR_MARGIN}px;
+    right: ${SIDEBAR_MARGIN}px;
     width: ${sidebarWidth}px;
-    height: 100vh;
+    height: calc(100vh - ${SIDEBAR_MARGIN * 2}px);
     z-index: 2147483647;
     background: white;
-    box-shadow: -2px 0 8px rgba(0, 0, 0, 0.1);
-    border-left: 1px solid #e5e7eb;
+    box-shadow: 0 4px 24px rgba(0, 0, 0, 0.15);
+    border: 1px solid #e5e7eb;
+    border-radius: 12px;
+    overflow: hidden;
     display: none;
+    flex-direction: column;
   `;
 
   // Create resize handle
@@ -140,20 +153,83 @@ function createSidebar(): void {
   // Add resize listeners
   resizeHandle.addEventListener("mousedown", handleResizeStart);
 
+  // Create header with close button
+  const header = document.createElement("div");
+  header.id = HEADER_ID;
+  header.style.cssText = `
+    flex-shrink: 0;
+    height: ${HEADER_HEIGHT}px;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    padding: 0 8px;
+    border-bottom: 1px solid #e5e7eb;
+  `;
+
+  closeButton = document.createElement("button");
+  closeButton.id = CLOSE_BUTTON_ID;
+  closeButton.textContent = "✕";
+  closeButton.style.cssText = `
+    width: 24px;
+    height: 24px;
+    border: none;
+    border-radius: 4px;
+    background: rgba(0, 0, 0, 0.06);
+    color: #6b7280;
+    font-size: 12px;
+    line-height: 1;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    transition: background 0.15s, color 0.15s;
+  `;
+  closeButton.addEventListener("mouseenter", () => {
+    if (closeButton) {
+      closeButton.style.background = "rgba(0, 0, 0, 0.12)";
+      closeButton.style.color = "#111827";
+    }
+  });
+  closeButton.addEventListener("mouseleave", () => {
+    if (closeButton) {
+      closeButton.style.background = "rgba(0, 0, 0, 0.06)";
+      closeButton.style.color = "#6b7280";
+    }
+  });
+  closeButton.addEventListener("click", hideSidebar);
+  header.appendChild(closeButton);
+
   // Create iframe
   iframeElement = document.createElement("iframe");
   iframeElement.id = IFRAME_ID;
   iframeElement.src = chrome.runtime.getURL("main.html");
   iframeElement.style.cssText = `
+    flex: 1;
     width: 100%;
-    height: 100%;
     border: none;
     margin: 0;
     padding: 0;
+    min-height: 0;
+  `;
+
+  // Create white backdrop covering the full reserved strip
+  backdropElement = document.createElement("div");
+  backdropElement.style.cssText = `
+    position: fixed;
+    top: 0;
+    right: 0;
+    width: ${sidebarWidth + SIDEBAR_MARGIN * 2}px;
+    height: 100vh;
+    z-index: 2147483646;
+    background: white;
+    display: none;
   `;
 
   sidebarElement.appendChild(resizeHandle);
+  sidebarElement.appendChild(header);
   sidebarElement.appendChild(iframeElement);
+  document.body.appendChild(backdropElement);
   document.body.appendChild(sidebarElement);
 
   // Add global mouse listeners for resizing
@@ -170,8 +246,11 @@ function showSidebar(): void {
   }
 
   if (sidebarElement) {
-    sidebarElement.style.display = "block";
-    document.body.style.marginRight = `${sidebarWidth}px`;
+    sidebarElement.style.display = "flex";
+    if (backdropElement) {
+      backdropElement.style.display = "block";
+    }
+    document.body.style.marginRight = `${sidebarWidth + SIDEBAR_MARGIN * 2}px`;
     sidebarVisible = true;
 
     // Save state
@@ -187,6 +266,9 @@ function showSidebar(): void {
 function hideSidebar(): void {
   if (sidebarElement) {
     sidebarElement.style.display = "none";
+    if (backdropElement) {
+      backdropElement.style.display = "none";
+    }
     document.body.style.marginRight = "0";
     sidebarVisible = false;
 
@@ -217,6 +299,9 @@ function removeSidebar(): void {
     sidebarElement = null;
     iframeElement = null;
     resizeHandle = null;
+    closeButton = null;
+    backdropElement?.remove();
+    backdropElement = null;
     document.body.style.marginRight = "0";
     sidebarVisible = false;
   }
@@ -242,11 +327,7 @@ async function init(): Promise<void> {
       sidebarWidth = result[STORAGE_KEY_WIDTH];
     }
 
-    // Restore visibility
-    const wasVisible = result[STORAGE_KEY_VISIBLE] === true;
-    if (wasVisible) {
-      showSidebar();
-    }
+    showSidebar();
   } catch (error) {
     console.error("[Dust Content Script] Error initializing:", error);
   }
@@ -256,6 +337,12 @@ async function init(): Promise<void> {
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.action === "ping") {
     sendResponse({ success: true });
+    return true;
+  }
+
+  if (message.action === "openSidebar") {
+    showSidebar();
+    sendResponse({ success: true, visible: sidebarVisible });
     return true;
   }
 

--- a/extension/platforms/chrome/content-script.ts
+++ b/extension/platforms/chrome/content-script.ts
@@ -317,17 +317,12 @@ function removeSidebar(): void {
 async function init(): Promise<void> {
   try {
     // Restore previous state
-    const result = await chrome.storage.local.get([
-      STORAGE_KEY_VISIBLE,
-      STORAGE_KEY_WIDTH,
-    ]);
+    const result = await chrome.storage.local.get([STORAGE_KEY_WIDTH]);
 
     // Restore saved width
     if (result[STORAGE_KEY_WIDTH]) {
       sidebarWidth = result[STORAGE_KEY_WIDTH];
     }
-
-    showSidebar();
   } catch (error) {
     console.error("[Dust Content Script] Error initializing:", error);
   }

--- a/extension/platforms/chrome/content-script.ts
+++ b/extension/platforms/chrome/content-script.ts
@@ -31,9 +31,6 @@ let isResizing = false;
 // Deferred cleanup when hiding: resets backdrop + body margin after slide-out.
 let hideTimeoutId: ReturnType<typeof setTimeout> | undefined;
 
-/**
- * Update sidebar width
- */
 function updateSidebarWidth(width: number): void {
   const clampedWidth = Math.max(
     MIN_SIDEBAR_WIDTH,
@@ -59,9 +56,6 @@ function updateSidebarWidth(width: number): void {
     .catch(console.error);
 }
 
-/**
- * Handle resize start
- */
 function handleResizeStart(e: MouseEvent): void {
   e.preventDefault();
   isResizing = true;
@@ -74,9 +68,6 @@ function handleResizeStart(e: MouseEvent): void {
   }
 }
 
-/**
- * Handle resize move
- */
 function handleResizeMove(e: MouseEvent): void {
   if (!isResizing) {
     return;
@@ -86,9 +77,6 @@ function handleResizeMove(e: MouseEvent): void {
   updateSidebarWidth(newWidth);
 }
 
-/**
- * Handle resize end
- */
 function handleResizeEnd(): void {
   if (isResizing) {
     isResizing = false;
@@ -102,9 +90,6 @@ function handleResizeEnd(): void {
   }
 }
 
-/**
- * Create and inject the sidebar into the page
- */
 function createSidebar(): void {
   // Check if sidebar already exists
   if (sidebarElement) {
@@ -250,9 +235,6 @@ function createSidebar(): void {
   document.addEventListener("mouseup", handleResizeEnd);
 }
 
-/**
- * Show the sidebar
- */
 function showSidebar(): void {
   if (!sidebarElement) {
     createSidebar();
@@ -283,9 +265,6 @@ function showSidebar(): void {
   }
 }
 
-/**
- * Hide the sidebar
- */
 function hideSidebar(): void {
   if (sidebarElement) {
     sidebarElement.style.transform = SIDEBAR_SLIDE_OUT;
@@ -309,9 +288,6 @@ function hideSidebar(): void {
   }
 }
 
-/**
- * Toggle sidebar visibility
- */
 function toggleSidebar(): void {
   if (sidebarVisible) {
     hideSidebar();
@@ -320,9 +296,8 @@ function toggleSidebar(): void {
   }
 }
 
-/**
- * Remove the sidebar from the page
- */
+// Unlike hideSidebar (animated slide-out), this immediately destroys the DOM
+// elements and removes global event listeners. Used on page unload.
 function removeSidebar(): void {
   if (hideTimeoutId !== undefined) {
     clearTimeout(hideTimeoutId);
@@ -346,9 +321,6 @@ function removeSidebar(): void {
   document.removeEventListener("mouseup", handleResizeEnd);
 }
 
-/**
- * Initialize the content script
- */
 async function init(): Promise<void> {
   try {
     // Restore previous state

--- a/extension/platforms/chrome/context/PortContext.tsx
+++ b/extension/platforms/chrome/context/PortContext.tsx
@@ -9,8 +9,11 @@ export const PortProvider = ({ children }: { children: React.ReactNode }) => {
     // Use a different port name when embedded in a content-script iframe (e.g.
     // Arc) vs. running as a native side panel (e.g. Chrome). The content
     // script sets ?embedded=1 on the iframe src so we can tell the two apart
-    // reliably — window.self !== window.top is not sufficient because Chrome
-    // also embeds the native side panel in a frame internally.
+    // reliably (window.self !== window.top is not sufficient because Chrome
+    // also embeds the native side panel in a frame internally).
+    // This is necessary to avoid conflicts between the two contexts since they
+    // both use the same background script and could otherwise accidentally
+    // receive each other's messages.
     const isEmbedded =
       new URLSearchParams(window.location.search).get("embedded") === "1";
     const portName = isEmbedded

--- a/extension/platforms/chrome/context/PortContext.tsx
+++ b/extension/platforms/chrome/context/PortContext.tsx
@@ -6,8 +6,29 @@ export const PortProvider = ({ children }: { children: React.ReactNode }) => {
   const [port, setPort] = useState<chrome.runtime.Port | null>(null);
 
   useEffect(() => {
-    console.log("Connecting to sidepanel");
-    const port = chrome.runtime.connect({ name: "sidepanel-connection" });
+    // Use a different port name when embedded in a content-script iframe (e.g.
+    // Arc) vs. running as a native side panel (e.g. Chrome). The content
+    // script sets ?embedded=1 on the iframe src so we can tell the two apart
+    // reliably — window.self !== window.top is not sufficient because Chrome
+    // also embeds the native side panel in a frame internally.
+    const isEmbedded =
+      new URLSearchParams(window.location.search).get("embedded") === "1";
+    const portName = isEmbedded
+      ? "content-script-connection"
+      : "sidepanel-connection";
+
+    console.log(`Connecting to ${portName}`);
+    const port = chrome.runtime.connect({ name: portName });
+
+    // When running as a native side panel, listen for a close request from
+    // the background (triggered when the user clicks the toolbar button again).
+    if (!isEmbedded) {
+      port.onMessage.addListener((message) => {
+        if (message.type === "CLOSE_SIDE_PANEL") {
+          window.close();
+        }
+      });
+    }
 
     setPort(port);
 

--- a/extension/platforms/chrome/manifests/manifest.base.json
+++ b/extension/platforms/chrome/manifests/manifest.base.json
@@ -23,11 +23,20 @@
       }
     }
   },
-  "side_panel": {
-    "default_path": "main.html"
-  },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content-script.js"],
+      "run_at": "document_end"
+    }
+  ],
+  "web_accessible_resources": [
+    {
+      "resources": ["main.html", "main.js", "*.chunk.js", "images/*"],
+      "matches": ["<all_urls>"]
+    }
+  ],
   "permissions": [
-    "sidePanel",
     "identity",
     "storage",
     "tabs",

--- a/extension/platforms/chrome/manifests/manifest.base.json
+++ b/extension/platforms/chrome/manifests/manifest.base.json
@@ -23,6 +23,9 @@
       }
     }
   },
+  "side_panel": {
+    "default_path": "main.html"
+  },
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
@@ -37,6 +40,7 @@
     }
   ],
   "permissions": [
+    "sidePanel",
     "identity",
     "storage",
     "tabs",

--- a/extension/platforms/chrome/webpack.config.ts
+++ b/extension/platforms/chrome/webpack.config.ts
@@ -83,6 +83,7 @@ export const getConfig = async ({
       main: resolvePath("./main.tsx"),
       background: resolvePath("./background.ts"),
       page: resolvePath("./page.ts"),
+      "content-script": resolvePath("./content-script.ts"),
     },
     output: {
       path: buildDirPath,


### PR DESCRIPTION
## Description

This PR adds Arc browser support to the Chrome extension by implementing a hybrid approach: browsers with working Side Panel API support (like Chrome) continue using the native side panel, while browsers without it (like Arc) fall back to a content script-based implementation. 

The content script injects a custom sidebar directly into the page DOM using an iframe containing the existing `main.html` React app, maintaining visual consistency across browsers. 

## Tests

Manually tested on Arc browser and standard Chrome.

## Risk

Low. The extension preserves existing functionality on Chrome while extending compatibility to Arc and other browsers. The React app remains unchanged—it works identically in both the native side panel and the injected iframe.

## Deploy Plan

Deploy and publish new extension version (at the end of the initiative only).
