### PR TITLE
[connectors] enh(Gong): throw `ExternalOAuthTokenError` on selected 401 responses

### DIFF
--- a/connectors/src/connectors/gong/lib/gong_api.ts
+++ b/connectors/src/connectors/gong/lib/gong_api.ts
@@ -205,7 +205,7 @@ export class GongClient {
       if (
         response.status === 401 &&
         response.statusText.includes(
-          "Validate credentials failed. Please check your credentials and try again.",
+          "Validate credentials failed. Please check your credentials and try again."
         )
       ) {
         throw new ExternalOAuthTokenError();

--- a/connectors/src/connectors/gong/lib/gong_api.ts
+++ b/connectors/src/connectors/gong/lib/gong_api.ts
@@ -202,6 +202,14 @@ export class GongClient {
       if (response.status === 403 && response.statusText === "Forbidden") {
         throw new ExternalOAuthTokenError();
       }
+      if (
+        response.status === 401 &&
+        response.statusText.includes(
+          "Validate credentials failed. Please check your credentials and try again.",
+        )
+      ) {
+        throw new ExternalOAuthTokenError();
+      }
 
       // Handle rate limiting
       // https://gong.app.gong.io/settings/api/documentation#overview


### PR DESCRIPTION
## Description

- This PR improves the handling of 401 responses from Gong's API to pause and error the connector.
- Sample logs [here](https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40attempt%3A%3E19%20%40dd.service%3Aconnectors-worker%20%40activityType%3AgongSyncTranscriptsActivity&additional_filters=%5B%5D&clustering_pattern_field_path=%40error.errors&cols=%40workflowId%2C%40error.type&event=AwAAAZxDGxrlLqowMAAAABhBWnhER3lqZkFBQ3hyeVVxVDR3RkZ3QXUAAAAkMDE5YzQzMWYtYWE5OS00ZDQ1LTlhNzUtM2MxZjYyODM4ZGEyAAACXw&fromUser=true&messageDisplay=inline&refresh_mode=sliding&saved-view-id=186044&storage=hot&stream_sort=desc&viz=pattern&from_ts=1770650089373&to_ts=1770653689373&live=true).

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy connectors.
