### PR TITLE
[front] enh: catch and reformulate `"No data source views available"` error preemptively

### DIFF
--- a/front/lib/actions/mcp_internal_actions/tools/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/utils.ts
@@ -1,4 +1,5 @@
 import { renderDataSourceConfiguration } from "@app/lib/actions/configuration/helpers";
+import { MCPError } from "@app/lib/actions/mcp_errors";
 import type {
   DataSourcesToolConfigurationType,
   TablesConfigurationToolType,
@@ -31,6 +32,11 @@ import type {
 } from "@app/types";
 import { Err, Ok, removeNulls } from "@app/types";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+
+export const NO_DATA_SOURCE_AVAILABLE_ERROR =
+  "No data source is available in the current scope. There is no data to " +
+  "search or browse. Retrying is only useful if the data configuration has " +
+  "changed on the user's side.";
 
 // Type to represent data source configuration with resolved data source model
 export type ResolvedDataSourceConfiguration = DataSourceConfiguration & {
@@ -312,7 +318,7 @@ export async function getDataSourceConfiguration(
 export async function getAgentDataSourceConfigurations(
   auth: Authenticator,
   dataSources: DataSourcesToolConfigurationType
-): Promise<Result<ResolvedDataSourceConfiguration[], Error>> {
+): Promise<Result<ResolvedDataSourceConfiguration[], MCPError>> {
   const configResults = await concurrentExecutor(
     dataSources,
     async (dataSourceConfiguration) => {
@@ -433,12 +439,20 @@ export async function getAgentDataSourceConfigurations(
   );
 
   if (configResults.some((res) => res.isErr())) {
-    return new Err(new Error("Failed to fetch data source configurations."));
+    return new Err(new MCPError("Failed to fetch data source configurations."));
   }
 
-  return new Ok(
-    removeNulls(configResults.map((res) => (res.isOk() ? res.value : null)))
+  const configs = removeNulls(
+    configResults.map((res) => (res.isOk() ? res.value : null))
   );
+
+  if (configs.length === 0) {
+    return new Err(
+      new MCPError(NO_DATA_SOURCE_AVAILABLE_ERROR, { tracked: false })
+    );
+  }
+
+  return new Ok(configs);
 }
 
 export async function getCoreSearchArgs(

--- a/front/lib/actions/mcp_internal_actions/tools/utils.ts
+++ b/front/lib/actions/mcp_internal_actions/tools/utils.ts
@@ -33,7 +33,7 @@ import type {
 import { Err, Ok, removeNulls } from "@app/types";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 
-export const NO_DATA_SOURCE_AVAILABLE_ERROR =
+const NO_DATA_SOURCE_AVAILABLE_ERROR =
   "No data source is available in the current scope. There is no data to " +
   "search or browse. Retrying is only useful if the data configuration has " +
   "changed on the user's side.";

--- a/front/lib/api/actions/servers/data_sources_file_system/tools/cat.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/tools/cat.ts
@@ -15,7 +15,6 @@ import { ensureAuthorizedDataSourceViews } from "@app/lib/actions/mcp_internal_a
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { FILESYSTEM_CAT_TOOL_NAME } from "@app/lib/api/actions/servers/data_sources_file_system/metadata";
-import { NO_DATA_SOURCE_AVAILABLE_ERROR } from "@app/lib/api/actions/servers/data_sources_file_system/tools/utils";
 import { getRefs } from "@app/lib/api/assistant/citations";
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
@@ -90,15 +89,9 @@ export function registerCatTool(
         );
 
         if (fetchResult.isErr()) {
-          return new Err(new MCPError(fetchResult.error.message));
+          return new Err(fetchResult.error);
         }
         const agentDataSourceConfigurations = fetchResult.value;
-
-        if (agentDataSourceConfigurations.length === 0) {
-          return new Err(
-            new MCPError(NO_DATA_SOURCE_AVAILABLE_ERROR, { tracked: false })
-          );
-        }
 
         const authRes = await ensureAuthorizedDataSourceViews(
           auth,

--- a/front/lib/api/actions/servers/data_sources_file_system/tools/cat.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/tools/cat.ts
@@ -15,6 +15,7 @@ import { ensureAuthorizedDataSourceViews } from "@app/lib/actions/mcp_internal_a
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { FILESYSTEM_CAT_TOOL_NAME } from "@app/lib/api/actions/servers/data_sources_file_system/metadata";
+import { NO_DATA_SOURCE_AVAILABLE_ERROR } from "@app/lib/api/actions/servers/data_sources_file_system/tools/utils";
 import { getRefs } from "@app/lib/api/assistant/citations";
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
@@ -92,6 +93,12 @@ export function registerCatTool(
           return new Err(new MCPError(fetchResult.error.message));
         }
         const agentDataSourceConfigurations = fetchResult.value;
+
+        if (agentDataSourceConfigurations.length === 0) {
+          return new Err(
+            new MCPError(NO_DATA_SOURCE_AVAILABLE_ERROR, { tracked: false })
+          );
+        }
 
         const authRes = await ensureAuthorizedDataSourceViews(
           auth,

--- a/front/lib/api/actions/servers/data_sources_file_system/tools/find.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/tools/find.ts
@@ -21,10 +21,7 @@ import {
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import { FILESYSTEM_FIND_TOOL_NAME } from "@app/lib/api/actions/servers/data_sources_file_system/metadata";
-import {
-  extractDataSourceIdFromNodeId,
-  NO_DATA_SOURCE_AVAILABLE_ERROR,
-} from "@app/lib/api/actions/servers/data_sources_file_system/tools/utils";
+import { extractDataSourceIdFromNodeId } from "@app/lib/api/actions/servers/data_sources_file_system/tools/utils";
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
@@ -112,15 +109,9 @@ async function findCallback(
   const fetchResult = await getAgentDataSourceConfigurations(auth, dataSources);
 
   if (fetchResult.isErr()) {
-    return new Err(new MCPError(fetchResult.error.message));
+    return fetchResult;
   }
   const agentDataSourceConfigurations = fetchResult.value;
-
-  if (agentDataSourceConfigurations.length === 0) {
-    return new Err(
-      new MCPError(NO_DATA_SOURCE_AVAILABLE_ERROR, { tracked: false })
-    );
-  }
 
   const conflictingTags = checkConflictingTags(
     agentDataSourceConfigurations.map(({ filter }) => filter.tags),

--- a/front/lib/api/actions/servers/data_sources_file_system/tools/find.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/tools/find.ts
@@ -149,11 +149,6 @@ async function findCallback(
     viewFilter = viewFilter.filter(
       (view) => view.data_source_id === dataSourceNodeId
     );
-    if (viewFilter.length === 0) {
-      return new Err(
-        new MCPError(NO_DATA_SOURCE_AVAILABLE_ERROR, { tracked: false })
-      );
-    }
   } else if (rootNodeId) {
     // Checking that we do have access to the root node.
     const rootNodeSearchResult = await coreAPI.searchNodes({

--- a/front/lib/api/actions/servers/data_sources_file_system/tools/list.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/tools/list.ts
@@ -15,6 +15,7 @@ import type { AgentLoopContextType } from "@app/lib/actions/types";
 import {
   extractDataSourceIdFromNodeId,
   isDataSourceNodeId,
+  NO_DATA_SOURCE_AVAILABLE_ERROR,
 } from "@app/lib/api/actions/servers/data_sources_file_system/tools/utils";
 import config from "@app/lib/api/config";
 import { ROOT_PARENT_ID } from "@app/lib/api/data_source_view";
@@ -81,6 +82,12 @@ export function registerListTool(
           return new Err(new MCPError(fetchResult.error.message));
         }
         const agentDataSourceConfigurations = fetchResult.value;
+
+        if (agentDataSourceConfigurations.length === 0) {
+          return new Err(
+            new MCPError(NO_DATA_SOURCE_AVAILABLE_ERROR, { tracked: false })
+          );
+        }
 
         const authRes = await ensureAuthorizedDataSourceViews(
           auth,

--- a/front/lib/api/actions/servers/data_sources_file_system/tools/list.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/tools/list.ts
@@ -15,7 +15,6 @@ import type { AgentLoopContextType } from "@app/lib/actions/types";
 import {
   extractDataSourceIdFromNodeId,
   isDataSourceNodeId,
-  NO_DATA_SOURCE_AVAILABLE_ERROR,
 } from "@app/lib/api/actions/servers/data_sources_file_system/tools/utils";
 import config from "@app/lib/api/config";
 import { ROOT_PARENT_ID } from "@app/lib/api/data_source_view";
@@ -79,15 +78,10 @@ export function registerListTool(
         );
 
         if (fetchResult.isErr()) {
-          return new Err(new MCPError(fetchResult.error.message));
+          return fetchResult;
         }
-        const agentDataSourceConfigurations = fetchResult.value;
 
-        if (agentDataSourceConfigurations.length === 0) {
-          return new Err(
-            new MCPError(NO_DATA_SOURCE_AVAILABLE_ERROR, { tracked: false })
-          );
-        }
+        const agentDataSourceConfigurations = fetchResult.value;
 
         const authRes = await ensureAuthorizedDataSourceViews(
           auth,

--- a/front/lib/api/actions/servers/data_sources_file_system/tools/locate_tree.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/tools/locate_tree.ts
@@ -17,6 +17,7 @@ import { FILESYSTEM_LOCATE_IN_TREE_TOOL_NAME } from "@app/lib/api/actions/server
 import {
   extractDataSourceIdFromNodeId,
   isDataSourceNodeId,
+  NO_DATA_SOURCE_AVAILABLE_ERROR,
 } from "@app/lib/api/actions/servers/data_sources_file_system/tools/utils";
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
@@ -64,6 +65,12 @@ export function registerLocateTreeTool(
           return new Err(new MCPError(fetchResult.error.message));
         }
         const agentDataSourceConfigurations = fetchResult.value;
+
+        if (agentDataSourceConfigurations.length === 0) {
+          return new Err(
+            new MCPError(NO_DATA_SOURCE_AVAILABLE_ERROR, { tracked: false })
+          );
+        }
 
         const conflictingTags = checkConflictingTags(
           agentDataSourceConfigurations.map(({ filter }) => filter.tags),

--- a/front/lib/api/actions/servers/data_sources_file_system/tools/locate_tree.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/tools/locate_tree.ts
@@ -17,7 +17,6 @@ import { FILESYSTEM_LOCATE_IN_TREE_TOOL_NAME } from "@app/lib/api/actions/server
 import {
   extractDataSourceIdFromNodeId,
   isDataSourceNodeId,
-  NO_DATA_SOURCE_AVAILABLE_ERROR,
 } from "@app/lib/api/actions/servers/data_sources_file_system/tools/utils";
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
@@ -62,15 +61,9 @@ export function registerLocateTreeTool(
         );
 
         if (fetchResult.isErr()) {
-          return new Err(new MCPError(fetchResult.error.message));
+          return fetchResult;
         }
         const agentDataSourceConfigurations = fetchResult.value;
-
-        if (agentDataSourceConfigurations.length === 0) {
-          return new Err(
-            new MCPError(NO_DATA_SOURCE_AVAILABLE_ERROR, { tracked: false })
-          );
-        }
 
         const conflictingTags = checkConflictingTags(
           agentDataSourceConfigurations.map(({ filter }) => filter.tags),

--- a/front/lib/api/actions/servers/data_sources_file_system/tools/search.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/tools/search.ts
@@ -28,6 +28,7 @@ import { FILESYSTEM_SEARCH_TOOL_NAME } from "@app/lib/api/actions/servers/data_s
 import {
   extractDataSourceIdFromNodeId,
   isDataSourceNodeId,
+  NO_DATA_SOURCE_AVAILABLE_ERROR,
 } from "@app/lib/api/actions/servers/data_sources_file_system/tools/utils";
 import { getRefs } from "@app/lib/api/assistant/citations";
 import config from "@app/lib/api/config";
@@ -199,12 +200,9 @@ async function searchCallback(
 
   if (coreSearchArgs.length === 0) {
     return new Err(
-      new MCPError(
-        "Search action must have at least one data source configured.",
-        {
-          tracked: false,
-        }
-      )
+      new MCPError(NO_DATA_SOURCE_AVAILABLE_ERROR, {
+        tracked: false,
+      })
     );
   }
 

--- a/front/lib/api/actions/servers/data_sources_file_system/tools/search.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/tools/search.ts
@@ -13,7 +13,6 @@ import {
   getAgentDataSourceConfigurations,
   getCoreSearchArgs,
   makeCoreSearchNodesFilters,
-  NO_DATA_SOURCE_AVAILABLE_ERROR,
 } from "@app/lib/actions/mcp_internal_actions/tools/utils";
 import type {
   SearchWithNodesInputType,
@@ -198,9 +197,12 @@ async function searchCallback(
 
   if (coreSearchArgs.length === 0) {
     return new Err(
-      new MCPError(NO_DATA_SOURCE_AVAILABLE_ERROR, {
-        tracked: false,
-      })
+      new MCPError(
+        "Search action must have at least one data source configured.",
+        {
+          tracked: false,
+        }
+      )
     );
   }
 

--- a/front/lib/api/actions/servers/data_sources_file_system/tools/search.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/tools/search.ts
@@ -13,6 +13,7 @@ import {
   getAgentDataSourceConfigurations,
   getCoreSearchArgs,
   makeCoreSearchNodesFilters,
+  NO_DATA_SOURCE_AVAILABLE_ERROR,
 } from "@app/lib/actions/mcp_internal_actions/tools/utils";
 import type {
   SearchWithNodesInputType,
@@ -28,7 +29,6 @@ import { FILESYSTEM_SEARCH_TOOL_NAME } from "@app/lib/api/actions/servers/data_s
 import {
   extractDataSourceIdFromNodeId,
   isDataSourceNodeId,
-  NO_DATA_SOURCE_AVAILABLE_ERROR,
 } from "@app/lib/api/actions/servers/data_sources_file_system/tools/utils";
 import { getRefs } from "@app/lib/api/assistant/citations";
 import config from "@app/lib/api/config";
@@ -130,9 +130,7 @@ async function searchCallback(
     await getAgentDataSourceConfigurations(auth, dataSources);
 
   if (agentDataSourceConfigurationsResult.isErr()) {
-    return new Err(
-      new MCPError(agentDataSourceConfigurationsResult.error.message)
-    );
+    return agentDataSourceConfigurationsResult;
   }
   const agentDataSourceConfigurations =
     agentDataSourceConfigurationsResult.value;

--- a/front/lib/api/actions/servers/data_sources_file_system/tools/utils.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/tools/utils.ts
@@ -2,8 +2,7 @@ import { DATA_SOURCE_NODE_ID } from "@app/types";
 
 export const NO_DATA_SOURCE_AVAILABLE_ERROR =
   "No data source is available in the current scope. There is no data to " +
-  "search or browse. Retrying will not do anything, no data sources are " +
-  "accessible for this action.";
+  "search or browse. Retrying will not do anything.";
 
 /**
  * Check if a node ID represents a data source node.

--- a/front/lib/api/actions/servers/data_sources_file_system/tools/utils.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/tools/utils.ts
@@ -1,9 +1,5 @@
 import { DATA_SOURCE_NODE_ID } from "@app/types";
 
-export const NO_DATA_SOURCE_AVAILABLE_ERROR =
-  "No data source is available in the current scope. There is no data to " +
-  "search or browse. Retrying will not do anything.";
-
 /**
  * Check if a node ID represents a data source node.
  * Data source node IDs have the format: "datasource_node_id-{data_source_id}"

--- a/front/lib/api/actions/servers/data_sources_file_system/tools/utils.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/tools/utils.ts
@@ -1,5 +1,10 @@
 import { DATA_SOURCE_NODE_ID } from "@app/types";
 
+export const NO_DATA_SOURCE_AVAILABLE_ERROR =
+  "No data source is available in the current scope. There is no data to " +
+  "search or browse. Retrying will not do anything, no data sources are " +
+  "accessible for this action.";
+
 /**
  * Check if a node ID represents a data source node.
  * Data source node IDs have the format: "datasource_node_id-{data_source_id}"

--- a/front/lib/api/actions/servers/data_warehouses/tools/index.ts
+++ b/front/lib/api/actions/servers/data_warehouses/tools/index.ts
@@ -47,7 +47,7 @@ const handlers: ToolHandlers<typeof DATA_WAREHOUSES_TOOLS_METADATA> = {
       );
 
     if (dataSourceConfigurationsResult.isErr()) {
-      return new Err(dataSourceConfigurationsResult.error);
+      return dataSourceConfigurationsResult;
     }
 
     const agentDataSourceConfigurations = dataSourceConfigurationsResult.value;
@@ -113,7 +113,7 @@ const handlers: ToolHandlers<typeof DATA_WAREHOUSES_TOOLS_METADATA> = {
       );
 
     if (dataSourceConfigurationsResult.isErr()) {
-      return new Err(dataSourceConfigurationsResult.error);
+      return dataSourceConfigurationsResult;
     }
 
     const agentDataSourceConfigurations = dataSourceConfigurationsResult.value;
@@ -172,7 +172,7 @@ const handlers: ToolHandlers<typeof DATA_WAREHOUSES_TOOLS_METADATA> = {
       );
 
     if (dataSourceConfigurationsResult.isErr()) {
-      return new Err(dataSourceConfigurationsResult.error);
+      return dataSourceConfigurationsResult;
     }
 
     const agentDataSourceConfigurations = dataSourceConfigurationsResult.value;
@@ -255,7 +255,7 @@ const handlers: ToolHandlers<typeof DATA_WAREHOUSES_TOOLS_METADATA> = {
       );
 
     if (dataSourceConfigurationsResult.isErr()) {
-      return new Err(dataSourceConfigurationsResult.error);
+      return dataSourceConfigurationsResult;
     }
 
     const agentDataSourceConfigurations = dataSourceConfigurationsResult.value;

--- a/front/lib/api/actions/servers/data_warehouses/tools/index.ts
+++ b/front/lib/api/actions/servers/data_warehouses/tools/index.ts
@@ -47,9 +47,7 @@ const handlers: ToolHandlers<typeof DATA_WAREHOUSES_TOOLS_METADATA> = {
       );
 
     if (dataSourceConfigurationsResult.isErr()) {
-      return new Err(
-        new MCPError(dataSourceConfigurationsResult.error.message)
-      );
+      return new Err(dataSourceConfigurationsResult.error);
     }
 
     const agentDataSourceConfigurations = dataSourceConfigurationsResult.value;
@@ -115,9 +113,7 @@ const handlers: ToolHandlers<typeof DATA_WAREHOUSES_TOOLS_METADATA> = {
       );
 
     if (dataSourceConfigurationsResult.isErr()) {
-      return new Err(
-        new MCPError(dataSourceConfigurationsResult.error.message)
-      );
+      return new Err(dataSourceConfigurationsResult.error);
     }
 
     const agentDataSourceConfigurations = dataSourceConfigurationsResult.value;
@@ -176,9 +172,7 @@ const handlers: ToolHandlers<typeof DATA_WAREHOUSES_TOOLS_METADATA> = {
       );
 
     if (dataSourceConfigurationsResult.isErr()) {
-      return new Err(
-        new MCPError(dataSourceConfigurationsResult.error.message)
-      );
+      return new Err(dataSourceConfigurationsResult.error);
     }
 
     const agentDataSourceConfigurations = dataSourceConfigurationsResult.value;
@@ -261,9 +255,7 @@ const handlers: ToolHandlers<typeof DATA_WAREHOUSES_TOOLS_METADATA> = {
       );
 
     if (dataSourceConfigurationsResult.isErr()) {
-      return new Err(
-        new MCPError(dataSourceConfigurationsResult.error.message)
-      );
+      return new Err(dataSourceConfigurationsResult.error);
     }
 
     const agentDataSourceConfigurations = dataSourceConfigurationsResult.value;


### PR DESCRIPTION
## Description

- This PR improves the error message exposed to the model when running a search/cat/list/find when no data source is available. We have observed cases where the model get confused and retries in with slightly different inputs.
- We catch these pre-emptively rather than reactively, which would require string-matching on core's various errors (`Failed to search content: ...`, `Failed to list node contents: ...`).

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
