### PR TITLE
[Gmail MCP] enabled gmail workspace account

### DIFF
--- a/front/lib/api/actions/servers/gmail/metadata.ts
+++ b/front/lib/api/actions/servers/gmail/metadata.ts
@@ -204,7 +204,7 @@ export const GMAIL_SERVER = {
     description: "Access messages and email drafts.",
     authorization: {
       provider: "google_drive",
-      supported_use_cases: ["personal_actions"],
+      supported_use_cases: ["personal_actions", "platform_actions"],
       scope:
         "https://www.googleapis.com/auth/gmail.readonly https://www.googleapis.com/auth/gmail.compose",
     },


### PR DESCRIPTION
## Description
Adds `platform_actions` to Gmail server's supported use cases, allowing workspace-level Gmail connections for assistants. Previously, Gmail only supported `personal_actions` (individual user OAuth). This aligns Gmail with Google Calendar, which already supports both use cases.
Use cases: service account or group (support, help, news letter, hr etc)

## Risk
Low. The change is additive and mirrors the existing Google Calendar implementation. The OAuth provider logic already handles both use cases - we're just declaring that Gmail now supports platform actions in the server metadata.

## Tests
Manual testing with workspace-level Gmail connection for platform actions.

## Deploy Plan
Run front