### PR TITLE
[front] enh(`SlashCommandDropdown`): add event listener on CMD +/-

### DIFF
--- a/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
+++ b/front/components/editor/extensions/skill_builder/SlashCommandDropdown.tsx
@@ -106,6 +106,15 @@ export const SlashCommandDropdown = forwardRef<
 
   useEffect(() => {
     updateTriggerPosition();
+
+    const viewport = window.visualViewport;
+    if (viewport) {
+      // Event triggered when hitting CMD +/-.
+      viewport.addEventListener("resize", updateTriggerPosition);
+      return () => {
+        viewport.removeEventListener("resize", updateTriggerPosition);
+      };
+    }
   }, [updateTriggerPosition]);
 
   return (


### PR DESCRIPTION
## Description

- Closes https://github.com/dust-tt/tasks/issues/6425.
- This PR adds an event listener that updates the position of the slash command dropdown when zooming in and out.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
