### PR TITLE
Add copy file tool to google drive write

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
@@ -4834,7 +4834,7 @@
     ],
     "toolsStakes": {
       "append_to_spreadsheet": "medium",
-      "clone_file": "low",
+      "copy_file": "low",
       "create_comment": "low",
       "create_document": "low",
       "create_presentation": "low",

--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
@@ -4834,6 +4834,7 @@
     ],
     "toolsStakes": {
       "append_to_spreadsheet": "medium",
+      "clone_file": "low",
       "create_comment": "low",
       "create_document": "low",
       "create_presentation": "low",

--- a/front/lib/api/actions/servers/google_drive/metadata.ts
+++ b/front/lib/api/actions/servers/google_drive/metadata.ts
@@ -296,29 +296,29 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
       done: "Create Google presentation",
     },
   },
-  clone_file: {
+  copy_file: {
     description:
-      "Clone (copy) an existing Google Drive file (Doc, Sheet, or Presentation). " +
+      "Copy an existing Google Drive file (Doc, Sheet, or Presentation). " +
       "Creates a duplicate of the file with a new name in the same folder or a different location.",
     schema: {
-      fileId: z.string().describe("The ID of the file to clone."),
+      fileId: z.string().describe("The ID of the file to copy."),
       name: z
         .string()
         .optional()
         .describe(
-          "The name for the cloned file. If not provided, defaults to 'Copy of [original name]'."
+          "The name for the copied file. If not provided, defaults to 'Copy of [original name]'."
         ),
       parentId: z
         .string()
         .optional()
         .describe(
-          "The ID of the folder to place the clone in. If not provided, the clone will be placed in the same folder as the original."
+          "The ID of the folder to place the copy in. If not provided, the copy will be placed in the same folder as the original."
         ),
     },
     stake: "low",
     displayLabels: {
-      running: "Cloning Google Drive file",
-      done: "Clone Google Drive file",
+      running: "Copying Google Drive file",
+      done: "Copy Google Drive file",
     },
   },
   create_comment: {

--- a/front/lib/api/actions/servers/google_drive/metadata.ts
+++ b/front/lib/api/actions/servers/google_drive/metadata.ts
@@ -296,6 +296,31 @@ export const GOOGLE_DRIVE_WRITE_TOOLS_METADATA = createToolsRecord({
       done: "Create Google presentation",
     },
   },
+  clone_file: {
+    description:
+      "Clone (copy) an existing Google Drive file (Doc, Sheet, or Presentation). " +
+      "Creates a duplicate of the file with a new name in the same folder or a different location.",
+    schema: {
+      fileId: z.string().describe("The ID of the file to clone."),
+      name: z
+        .string()
+        .optional()
+        .describe(
+          "The name for the cloned file. If not provided, defaults to 'Copy of [original name]'."
+        ),
+      parentId: z
+        .string()
+        .optional()
+        .describe(
+          "The ID of the folder to place the clone in. If not provided, the clone will be placed in the same folder as the original."
+        ),
+    },
+    stake: "low",
+    displayLabels: {
+      running: "Cloning Google Drive file",
+      done: "Clone Google Drive file",
+    },
+  },
   create_comment: {
     description:
       "Add a comment to a Google Drive file (Doc, Sheet, or Presentation).",

--- a/front/lib/api/actions/servers/google_drive/tools/index.ts
+++ b/front/lib/api/actions/servers/google_drive/tools/index.ts
@@ -517,57 +517,58 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
       return new Err(new MCPError("Failed to authenticate with Google Drive"));
     }
 
-    try {
-      const requestBody: { name?: string; parents?: string[] } = {};
-      if (name) {
-        requestBody.name = name;
-      }
-      if (parentId) {
-        requestBody.parents = [parentId];
-      }
+    const requestBody: { name?: string; parents?: string[] } = {};
+    if (name) {
+      requestBody.name = name;
+    }
+    if (parentId) {
+      requestBody.parents = [parentId];
+    }
 
-      const res = await drive.files.copy({
+    let res;
+    try {
+      res = await drive.files.copy({
         fileId,
         requestBody,
         supportsAllDrives: true,
         fields: "id,name,mimeType,webViewLink",
       });
-
-      // Construct appropriate URL based on file type
-      let url = res.data.webViewLink;
-      if (res.data.mimeType === "application/vnd.google-apps.document") {
-        url = `https://docs.google.com/document/d/${res.data.id}/edit`;
-      } else if (
-        res.data.mimeType === "application/vnd.google-apps.spreadsheet"
-      ) {
-        url = `https://docs.google.com/spreadsheets/d/${res.data.id}/edit`;
-      } else if (
-        res.data.mimeType === "application/vnd.google-apps.presentation"
-      ) {
-        url = `https://docs.google.com/presentation/d/${res.data.id}/edit`;
-      }
-
-      return new Ok([
-        {
-          type: "text" as const,
-          text: JSON.stringify(
-            {
-              fileId: res.data.id,
-              name: res.data.name,
-              mimeType: res.data.mimeType,
-              url,
-            },
-            null,
-            2
-          ),
-        },
-      ]);
     } catch (err) {
       if (isFileNotAuthorizedError(err)) {
         return handleFileAccessError(err, fileId, extra);
       }
       return handlePermissionError(err);
     }
+
+    // Construct appropriate URL based on file type
+    let url = res.data.webViewLink;
+    if (res.data.mimeType === "application/vnd.google-apps.document") {
+      url = `https://docs.google.com/document/d/${res.data.id}/edit`;
+    } else if (
+      res.data.mimeType === "application/vnd.google-apps.spreadsheet"
+    ) {
+      url = `https://docs.google.com/spreadsheets/d/${res.data.id}/edit`;
+    } else if (
+      res.data.mimeType === "application/vnd.google-apps.presentation"
+    ) {
+      url = `https://docs.google.com/presentation/d/${res.data.id}/edit`;
+    }
+
+    return new Ok([
+      {
+        type: "text" as const,
+        text: JSON.stringify(
+          {
+            fileId: res.data.id,
+            name: res.data.name,
+            mimeType: res.data.mimeType,
+            url,
+          },
+          null,
+          2
+        ),
+      },
+    ]);
   },
 
   create_comment: async ({ fileId, content }, extra) => {

--- a/front/lib/api/actions/servers/google_drive/tools/index.ts
+++ b/front/lib/api/actions/servers/google_drive/tools/index.ts
@@ -511,6 +511,76 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
     }
   },
 
+  clone_file: async ({ fileId, name, parentId }, extra) => {
+    const drive = await getDriveClient(extra.authInfo);
+    if (!drive) {
+      return new Err(new MCPError("Failed to authenticate with Google Drive"));
+    }
+
+    try {
+      // First get the original file metadata to construct a proper response
+      const originalFile = await drive.files.get({
+        fileId,
+        fields: "id,name,mimeType",
+        supportsAllDrives: true,
+      });
+
+      // Prepare the request body for copying
+      const requestBody: { name?: string; parents?: string[] } = {};
+      if (name) {
+        requestBody.name = name;
+      }
+      if (parentId) {
+        requestBody.parents = [parentId];
+      }
+
+      // Copy the file
+      const res = await drive.files.copy({
+        fileId,
+        requestBody,
+        supportsAllDrives: true,
+        fields: "id,name,mimeType,webViewLink",
+      });
+
+      // Construct appropriate URL based on file type
+      let url = res.data.webViewLink;
+      if (res.data.mimeType === "application/vnd.google-apps.document") {
+        url = `https://docs.google.com/document/d/${res.data.id}/edit`;
+      } else if (
+        res.data.mimeType === "application/vnd.google-apps.spreadsheet"
+      ) {
+        url = `https://docs.google.com/spreadsheets/d/${res.data.id}/edit`;
+      } else if (
+        res.data.mimeType === "application/vnd.google-apps.presentation"
+      ) {
+        url = `https://docs.google.com/presentation/d/${res.data.id}/edit`;
+      }
+
+      return new Ok([
+        {
+          type: "text" as const,
+          text: JSON.stringify(
+            {
+              fileId: res.data.id,
+              name: res.data.name,
+              mimeType: res.data.mimeType,
+              originalFileId: originalFile.data.id,
+              originalFileName: originalFile.data.name,
+              url,
+            },
+            null,
+            2
+          ),
+        },
+      ]);
+    } catch (err) {
+      if (isFileNotAuthorizedError(err)) {
+        return handleFileAccessError(err, fileId, extra);
+      }
+      return handlePermissionError(err);
+    }
+  },
+
   create_comment: async ({ fileId, content }, extra) => {
     const drive = await getDriveClient(extra.authInfo);
     if (!drive) {

--- a/front/lib/api/actions/servers/google_drive/tools/index.ts
+++ b/front/lib/api/actions/servers/google_drive/tools/index.ts
@@ -511,21 +511,13 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
     }
   },
 
-  clone_file: async ({ fileId, name, parentId }, extra) => {
+  copy_file: async ({ fileId, name, parentId }, extra) => {
     const drive = await getDriveClient(extra.authInfo);
     if (!drive) {
       return new Err(new MCPError("Failed to authenticate with Google Drive"));
     }
 
     try {
-      // First get the original file metadata to construct a proper response
-      const originalFile = await drive.files.get({
-        fileId,
-        fields: "id,name,mimeType",
-        supportsAllDrives: true,
-      });
-
-      // Prepare the request body for copying
       const requestBody: { name?: string; parents?: string[] } = {};
       if (name) {
         requestBody.name = name;
@@ -534,7 +526,6 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
         requestBody.parents = [parentId];
       }
 
-      // Copy the file
       const res = await drive.files.copy({
         fileId,
         requestBody,
@@ -564,8 +555,6 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
               fileId: res.data.id,
               name: res.data.name,
               mimeType: res.data.mimeType,
-              originalFileId: originalFile.data.id,
-              originalFileName: originalFile.data.name,
               url,
             },
             null,


### PR DESCRIPTION
closes [#6428](https://github.com/dust-tt/tasks/issues/6428)

## Description
Adding a tool for copying files in google drive
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
Tested manually:
<img width="725" height="348" alt="Screenshot 2026-02-09 at 2 16 39 PM" src="https://github.com/user-attachments/assets/2c331035-855a-48dc-a326-f9ce329d67ec" />

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
Low
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [ ] deploy front

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
