### PR TITLE
[Projects] Fix kickoff prompt flow for project kickoff conversations

### DIFF
--- a/front/lib/api/assistant/project_kickoff.test.ts
+++ b/front/lib/api/assistant/project_kickoff.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import { buildProjectKickoffPrompt } from "@app/lib/api/assistant/project_kickoff";
+
+describe("buildProjectKickoffPrompt", () => {
+  const prompt = buildProjectKickoffPrompt({
+    projectName: "Test Kickstart",
+    userName: "test-user",
+  });
+
+  it("should enforce the first message format and avoid fake search claims", () => {
+    expect(prompt).toContain("Your first message MUST be exactly:");
+    expect(prompt).toContain(
+      "Hey @test-user; happy to help you kickstart `Test Kickstart`."
+    );
+    expect(prompt).toContain(
+      "Do not claim that you already searched anything in this first message."
+    );
+  });
+
+  it("should guide direct project context writes without skill detours", () => {
+    expect(prompt).toContain(
+      "use `project_manager.add_file` directly with `content`"
+    );
+    expect(prompt).toContain(
+      "Do NOT enable skills/tools just to create files when `project_manager.add_file` can do it directly"
+    );
+  });
+
+  it("should require accurate search reporting", () => {
+    expect(prompt).toContain(
+      'Never claim "I searched" or "I didn\'t find" unless you actually ran search tools in this conversation'
+    );
+  });
+
+  it("should enforce quick replies at the end of the message", () => {
+    expect(prompt).toContain("Quick reply formatting rules:");
+    expect(prompt).toContain(
+      "- Quick replies MUST be the last lines of the message"
+    );
+    expect(prompt).toContain(
+      ':quickReply[Update project description]{message="Update the description."}'
+    );
+    expect(prompt).toContain(
+      ':quickReply[Create project document]{message="Create an initial project document."}'
+    );
+  });
+});

--- a/front/lib/api/assistant/project_kickoff.ts
+++ b/front/lib/api/assistant/project_kickoff.ts
@@ -12,22 +12,31 @@ You are helping a user kickstart a new project in Dust.
 
 ## YOUR FIRST MESSAGE (respond now)
 
-Write a friendly greeting to help the user get started with their project "${projectName}".
-
-Your message should be:
+Your first message MUST be exactly:
 Hey @${userName}; happy to help you kickstart \`${projectName}\`.
 
-If you'd like, tell me a few words on the project (the goal, the context) and/or attach relevant files. I'll update the project's description, find related data in your company, use all of that to create an initial project document and get ${projectName} started.
+If you'd like, tell me a few words on the project (the goal, the context) and/or attach relevant files. I can help update the project's description, find related data, and create an initial project document.
+
+Do not claim that you already searched anything in this first message.
 
 ## SUBSEQUENT MESSAGES
 
 Once the user provides context:
 1. Acknowledge what they shared
-2. If requested, search for related information in the company (use available tools)
-3. If relevant, suggest updating the project description based on what you learned
-4. Offer to create an initial project document summarizing the context
+2. If context suggests it is useful, search for related information in the company (use available tools)
+3. Never claim "I searched" or "I didn't find" unless you actually ran search tools in this conversation
+4. If relevant, suggest updating the project description based on what you learned
+5. If asked to create project documentation or save context for future conversations, use \`project_manager.add_file\` directly with \`content\` (plain text or markdown)
+6. Do NOT enable skills/tools just to create files when \`project_manager.add_file\` can do it directly
 
-Use quick replies for 3 and 4, e.g. :quickReply[Update project description]{message="Update the description."} :quickReply[Create project document]{message="Create an initial project document."}
+Quick reply formatting rules:
+- Quick replies MUST be the last lines of the message
+- Never put regular text after the final quick reply
+- Never put regular prose on the same line as a quick reply
+
+Use quick replies for 4 and 5, for example:
+:quickReply[Update project description]{message="Update the description."}
+:quickReply[Create project document]{message="Create an initial project document."}
 
 Always be helpful and action-oriented.
 </dust_system>`;


### PR DESCRIPTION
## Description
Fixes regression in https://github.com/dust-tt/dust/pull/21197.
Context: [slack thread](https://dust4ai.slack.com/archives/C09T7N4S6GG/p1770634129388989).

Tightens the kickoff system prompt so the first message stays deterministic, quick replies are rendered at the end of messages, and the agent prefers direct project context writes via `project_manager.add_file` instead of enabling extra skills/tools.
<img width="1419" height="1123" alt="image" src="https://github.com/user-attachments/assets/68396bfb-88ec-4fb8-aa2f-15885224b4e1" />

Adds a focused unit test for kickoff prompt directives.

## Risks
Blast radius: Project kickoff conversation behavior in project spaces.
Risk: low

## Deploy Plan
- deploy front
