### PR TITLE
[front] Remove agent builder local space selection sheet

### DIFF
--- a/front/components/agent_builder/capabilities/capabilities_sheet/hooks.ts
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/hooks.ts
@@ -1,8 +1,6 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
-import { useWatch } from "react-hook-form";
+import { useCallback, useMemo, useState } from "react";
 
 import type {
-  AgentBuilderFormData,
   AgentBuilderSkillsType,
   MCPFormData,
 } from "@app/components/agent_builder/AgentBuilderFormContext";
@@ -23,47 +21,14 @@ import { useMCPServerViewsContext } from "@app/components/shared/tools_picker/MC
 import type { BuilderAction } from "@app/components/shared/tools_picker/types";
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
-import { doesSkillTriggerSelectSpaces } from "@app/lib/skill";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
 
-function isGlobalSkillWithSpaceSelection(skill: SkillType): boolean {
-  return doesSkillTriggerSelectSpaces(skill.sId);
-}
-
-export const useSkillSpaceSelection = () => {
-  const agentBuilderFormAdditionalSpaces = useWatch<
-    AgentBuilderFormData,
-    "additionalSpaces"
-  >({
-    name: "additionalSpaces",
-  });
-
-  const [localSelectedSpaces, setLocalSelectedSpaces] = useState<string[]>([]);
-
-  const resetLocalState = useCallback(() => {
-    setLocalSelectedSpaces(agentBuilderFormAdditionalSpaces);
-  }, [agentBuilderFormAdditionalSpaces]);
-
-  useEffect(() => {
-    // When agent builder form spaces change, make sure local state is updated
-    resetLocalState();
-  }, [agentBuilderFormAdditionalSpaces, resetLocalState]);
-
-  return {
-    localSelectedSpaces,
-    setLocalSelectedSpaces,
-    resetLocalState,
-  };
-};
-
 type UseSkillSelectionProps = {
-  onStateChange: (state: SheetState) => void;
   alreadyAddedSkillIds: Set<string>;
   searchQuery: string;
 };
 
 export const useSkillSelection = ({
-  onStateChange,
   alreadyAddedSkillIds,
   searchQuery,
 }: UseSkillSelectionProps) => {
@@ -113,14 +78,6 @@ export const useSkillSelection = ({
         return;
       }
 
-      if (isGlobalSkillWithSpaceSelection(skill)) {
-        onStateChange({
-          state: "space-selection",
-          capability: skill,
-        });
-        return;
-      }
-
       setLocalSelectedSkills((prev) => [
         ...prev,
         {
@@ -131,24 +88,7 @@ export const useSkillSelection = ({
         },
       ]);
     },
-    [selectedSkillIds, onStateChange, setLocalSelectedSkills]
-  );
-
-  const handleSpaceSelectionSave = useCallback(
-    (skill: SkillType) => {
-      // Add the skill
-      setLocalSelectedSkills((prev) => [
-        ...prev,
-        {
-          sId: skill.sId,
-          name: skill.name,
-          description: skill.userFacingDescription,
-          icon: skill.icon,
-        },
-      ]);
-      onStateChange({ state: "selection" });
-    },
-    [onStateChange, setLocalSelectedSkills]
+    [selectedSkillIds, setLocalSelectedSkills]
   );
 
   return {
@@ -158,7 +98,6 @@ export const useSkillSelection = ({
     filteredSkills,
     isSkillsLoading,
     selectedSkillIds,
-    handleSpaceSelectionSave,
     resetLocalState,
   };
 };

--- a/front/components/agent_builder/capabilities/capabilities_sheet/types.ts
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/types.ts
@@ -13,11 +13,9 @@ export type CapabilitiesSheetContentProps = {
   onClose: () => void;
   onCapabilitiesSave: (data: {
     skills: AgentBuilderSkillsType[];
-    additionalSpaces: string[];
     tools: SelectedTool[];
   }) => void;
   onToolEditSave: (updatedAction: BuilderAction) => void;
-  alreadyRequestedSpaceIds: Set<string>;
   alreadyAddedSkillIds: Set<string>;
   selectedActions: BuilderAction[];
   getAgentInstructions: () => string;

--- a/front/components/agent_builder/capabilities/capabilities_sheet/utils.tsx
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/utils.tsx
@@ -10,11 +10,9 @@ import { CapabilitiesFooter } from "@app/components/agent_builder/capabilities/c
 import { CapabilitiesSelectionPageContent } from "@app/components/agent_builder/capabilities/capabilities_sheet/CapabilitiesSelectionPage";
 import {
   useSkillSelection,
-  useSkillSpaceSelection,
   useToolSelection,
 } from "@app/components/agent_builder/capabilities/capabilities_sheet/hooks";
 import { SkillInfoPage } from "@app/components/agent_builder/capabilities/capabilities_sheet/SkillInfoPage";
-import { SpaceSelectionPageContent } from "@app/components/agent_builder/capabilities/capabilities_sheet/SpaceSelectionPage";
 import type { CapabilitiesSheetContentProps } from "@app/components/agent_builder/capabilities/capabilities_sheet/types";
 import { MCPServerConfigurationPage } from "@app/components/agent_builder/capabilities/mcp/MCPServerConfigurationPage";
 import { MCPServerInfoPage } from "@app/components/agent_builder/capabilities/mcp/MCPServerInfoPage";
@@ -41,7 +39,6 @@ export function useCapabilitiesPageAndFooter({
   onClose,
   onCapabilitiesSave,
   onToolEditSave,
-  alreadyRequestedSpaceIds,
   alreadyAddedSkillIds,
   selectedActions,
   getAgentInstructions,
@@ -53,9 +50,7 @@ export function useCapabilitiesPageAndFooter({
   const { owner, user } = useAgentBuilderContext();
   const [searchQuery, setSearchQuery] = useState("");
 
-  const skillSpaceSelection = useSkillSpaceSelection();
   const skillSelection = useSkillSelection({
-    onStateChange,
     alreadyAddedSkillIds,
     searchQuery,
   });
@@ -66,21 +61,18 @@ export function useCapabilitiesPageAndFooter({
   });
 
   const resetSheetState = useCallback(() => {
-    skillSpaceSelection.resetLocalState();
     skillSelection.resetLocalState();
     toolSelection.resetLocalState();
-  }, [skillSpaceSelection, skillSelection, toolSelection]);
+  }, [skillSelection, toolSelection]);
 
   const handleCapabilitiesSelectionSave = useCallback(() => {
     onCapabilitiesSave({
       skills: skillSelection.localSelectedSkills,
-      additionalSpaces: skillSpaceSelection.localSelectedSpaces,
       tools: toolSelection.localSelectedTools,
     });
     resetSheetState();
     onClose();
   }, [
-    skillSpaceSelection,
     skillSelection,
     toolSelection,
     onCapabilitiesSave,
@@ -273,37 +265,6 @@ export function useCapabilitiesPageAndFooter({
               },
         };
       }
-
-    case "space-selection":
-      return {
-        page: {
-          title: `Select spaces`,
-          description:
-            "Automatically grant access to all knowledge sources discovery from your selected spaces",
-          id: sheetState.state,
-          content: (
-            <SpaceSelectionPageContent
-              alreadyRequestedSpaceIds={alreadyRequestedSpaceIds}
-              selectedSpaces={skillSpaceSelection.localSelectedSpaces}
-              setSelectedSpaces={skillSpaceSelection.setLocalSelectedSpaces}
-            />
-          ),
-        },
-        leftButton: {
-          label: "Cancel",
-          variant: "outline",
-          onClick: () => {
-            skillSpaceSelection.resetLocalState();
-            onStateChange({ state: "selection" });
-          },
-        },
-        rightButton: {
-          label: "Save",
-          variant: "primary",
-          onClick: () =>
-            skillSelection.handleSpaceSelectionSave(sheetState.capability),
-        },
-      };
 
     case "configuration":
       // index === null means new configuration, index !== null means edit

--- a/front/components/agent_builder/skills/AgentBuilderCapabilitiesBlock.tsx
+++ b/front/components/agent_builder/skills/AgentBuilderCapabilitiesBlock.tsx
@@ -144,14 +144,13 @@ export function AgentBuilderCapabilitiesBlock() {
   const { skills: allSkills, isSkillsLoading } = useSkillsContext();
   const { spaces } = useSpacesContext();
 
-  const { alreadyAddedSkillIds } =
-    useSkillsAndActionsState(
-      skillFields,
-      actionFields,
-      mcpServerViews,
-      allSkills,
-      spaces
-    );
+  const { alreadyAddedSkillIds } = useSkillsAndActionsState(
+    skillFields,
+    actionFields,
+    mcpServerViews,
+    allSkills,
+    spaces
+  );
 
   const [sheetState, setSheetState] = useState<SheetState>({ state: "closed" });
 

--- a/front/components/agent_builder/skills/AgentBuilderCapabilitiesBlock.tsx
+++ b/front/components/agent_builder/skills/AgentBuilderCapabilitiesBlock.tsx
@@ -11,7 +11,7 @@ import {
   XMarkIcon,
 } from "@dust-tt/sparkle";
 import React, { useCallback, useState } from "react";
-import { useController, useFieldArray, useFormContext } from "react-hook-form";
+import { useFieldArray, useFormContext } from "react-hook-form";
 
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import type {
@@ -136,13 +136,6 @@ export function AgentBuilderCapabilitiesBlock() {
   } = useFieldArray<AgentBuilderFormData, "actions">({
     name: "actions",
   });
-  const { field: additionalSpacesField } = useController<
-    AgentBuilderFormData,
-    "additionalSpaces"
-  >({
-    name: "additionalSpaces",
-  });
-
   const {
     mcpServerViewsWithKnowledge,
     mcpServerViewsWithoutKnowledge,
@@ -151,7 +144,7 @@ export function AgentBuilderCapabilitiesBlock() {
   const { skills: allSkills, isSkillsLoading } = useSkillsContext();
   const { spaces } = useSpacesContext();
 
-  const { alreadyAddedSkillIds, alreadyRequestedSpaceIds } =
+  const { alreadyAddedSkillIds } =
     useSkillsAndActionsState(
       skillFields,
       actionFields,
@@ -227,11 +220,9 @@ export function AgentBuilderCapabilitiesBlock() {
   const handleCapabilitiesSave = useCallback(
     ({
       skills,
-      additionalSpaces,
       tools,
     }: {
       skills: AgentBuilderSkillsType[];
-      additionalSpaces: string[];
       tools: SelectedTool[];
     }) => {
       // Validate any configured tools before adding
@@ -257,10 +248,9 @@ export function AgentBuilderCapabilitiesBlock() {
       );
 
       appendSkills(skills);
-      additionalSpacesField.onChange(additionalSpaces);
       appendActions(validatedActions);
     },
-    [appendSkills, additionalSpacesField, appendActions, sendNotification]
+    [appendSkills, appendActions, sendNotification]
   );
 
   const handleClickKnowledge = () => {
@@ -378,7 +368,6 @@ export function AgentBuilderCapabilitiesBlock() {
         onCapabilitiesSave={handleCapabilitiesSave}
         onToolEditSave={handleToolEditSave}
         onStateChange={setSheetState}
-        alreadyRequestedSpaceIds={alreadyRequestedSpaceIds}
         alreadyAddedSkillIds={alreadyAddedSkillIds}
         selectedActions={actionFields}
         getAgentInstructions={() => getValues("instructions")}

--- a/front/components/agent_builder/skills/skillsAndActionsState.ts
+++ b/front/components/agent_builder/skills/skillsAndActionsState.ts
@@ -11,7 +11,6 @@ export function computeSkillsAndActionsState({
   skillFields,
   actionFields,
   mcpServerViews,
-  allSkills,
   spaces,
 }: {
   skillFields: AgentBuilderSkillsType[];
@@ -21,26 +20,10 @@ export function computeSkillsAndActionsState({
   spaces: SpaceType[];
 }): {
   alreadyAddedSkillIds: Set<string>;
-  alreadyRequestedSpaceIds: Set<string>;
   nonGlobalSpacesUsedInActions: SpaceType[];
 } {
   const alreadyAddedSkillIds = new Set(skillFields.map((s) => s.sId));
   const spaceIdToActions = getSpaceIdToActionsMap(actionFields, mcpServerViews);
-
-  const alreadyRequestedSpaceIds = new Set<string>();
-  for (const spaceId of Object.keys(spaceIdToActions)) {
-    if (spaceIdToActions[spaceId]?.length > 0) {
-      alreadyRequestedSpaceIds.add(spaceId);
-    }
-  }
-
-  for (const skill of allSkills) {
-    if (alreadyAddedSkillIds.has(skill.sId) && skill.canWrite) {
-      for (const spaceId of skill.requestedSpaceIds) {
-        alreadyRequestedSpaceIds.add(spaceId);
-      }
-    }
-  }
 
   const nonGlobalSpaces = spaces.filter((s) => s.kind !== "global");
   const nonGlobalSpacesUsedInActions = nonGlobalSpaces.filter(
@@ -49,7 +32,6 @@ export function computeSkillsAndActionsState({
 
   return {
     alreadyAddedSkillIds,
-    alreadyRequestedSpaceIds,
     nonGlobalSpacesUsedInActions,
   };
 }

--- a/front/components/agent_builder/skills/types.ts
+++ b/front/components/agent_builder/skills/types.ts
@@ -1,15 +1,11 @@
 import type { MCPServerViewTypeWithLabel } from "@app/components/shared/tools_picker/MCPServerViewsContext";
 import type { BuilderAction } from "@app/components/shared/tools_picker/types";
 import type { TemplateActionPreset } from "@app/types";
-import type {
-  SkillType,
-  SkillWithRelationsType,
-} from "@app/types/assistant/skill_configuration";
+import type { SkillWithRelationsType } from "@app/types/assistant/skill_configuration";
 
 type SheetStateType =
   | "closed"
   | "selection"
-  | "space-selection"
   | "info"
   | "knowledge"
   | "configuration";
@@ -41,13 +37,6 @@ export type InfoState<
 };
 
 /**
- * Capabilities sheet: space selection page for skills.
- */
-export type SpaceSelectionState = SheetStateBase<"space-selection"> & {
-  capability: SkillType;
-};
-
-/**
  * Capabilities sheet: tool configuration/edit page.
  */
 export type ConfigurationState = EditableSheetStateBase<"configuration"> & {
@@ -67,7 +56,6 @@ export type CapabilitiesSheetState =
   | SelectionState
   | InfoState<"skill", SkillWithRelationsType>
   | InfoState<"tool", BuilderAction>
-  | SpaceSelectionState
   | ConfigurationState;
 
 /**

--- a/front/lib/skill.ts
+++ b/front/lib/skill.ts
@@ -68,15 +68,6 @@ export function getSkillIcon(
     });
 }
 
-const IDS_OF_SKILLS_TRIGGERING_SELECT_SPACES_OPTIONS: string[] = [
-  // We don't trigger this flow for now.
-  // TODO(skills 2025-12-24): confirm whether we need this flow of space selection or not,
-  //  if we do, then add the skill IDs here, otherwise remove it from Agent Builder.
-];
-
-export function doesSkillTriggerSelectSpaces(sId: string): boolean {
-  return IDS_OF_SKILLS_TRIGGERING_SELECT_SPACES_OPTIONS.includes(sId);
-}
 export function hasRelations(
   skill: SkillType & { relations?: SkillRelations }
 ): skill is SkillWithRelationsType {


### PR DESCRIPTION
## Description

- We had a flow that could be triggered upon clicking on selected global skills to select spaces.
- This flow was not used, we opted out of it because of the potential confusion with a configuration specific to the skill.
- This PR removes the corresponding code.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
