### PR TITLE
[front[ Update eslint rule on no instructions at MCP server level

### DIFF
--- a/eslint-plugin-dust/rules/no-mcp-server-instructions.js
+++ b/eslint-plugin-dust/rules/no-mcp-server-instructions.js
@@ -1,5 +1,12 @@
 "use strict";
 
+const ERROR_MESSAGE =
+  "MCP server instructions need to be avoided. " +
+  "Tools should be self-explanatory and straightforward to use: avoid coupling " +
+  '(e.g., "always use tool A before B", should be bundled in tool B itself). ' +
+  "Proper design eliminates the need for server-level instructions, preventing " +
+  "context bloat and instruction clashes.";
+
 function isNullLiteral(node) {
   return node.type === "Literal" && node.value === null;
 }
@@ -19,8 +26,8 @@ function isInternalMcpServersDeclarator(node) {
   );
 }
 
-function findInstructionsProperty(serverInfoNode) {
-  return serverInfoNode.value.properties.find(
+function findInstructionsProperty(objectNode) {
+  return objectNode.properties.find(
     (prop) =>
       prop.type === "Property" &&
       prop.key.type === "Identifier" &&
@@ -36,18 +43,42 @@ function isServerInfoProperty(node) {
   );
 }
 
+function isSatisfiesServerMetadata(node) {
+  const init = node.init;
+  return (
+    init?.type === "TSSatisfiesExpression" &&
+    init.typeAnnotation?.type === "TSTypeReference" &&
+    init.typeAnnotation.typeName?.type === "Identifier" &&
+    init.typeAnnotation.typeName.name === "ServerMetadata"
+  );
+}
+
+function findServerInfoInObject(objectNode) {
+  return objectNode.properties.find(
+    (prop) =>
+      prop.type === "Property" &&
+      prop.key.type === "Identifier" &&
+      prop.key.name === "serverInfo" &&
+      prop.value.type === "ObjectExpression"
+  );
+}
+
 module.exports = {
   meta: {
     type: "suggestion",
     docs: {
-      description: "Disallow non-null instructions in INTERNAL_MCP_SERVERS",
+      description:
+        "Disallow non-null instructions in MCP server metadata definitions",
     },
     schema: [],
   },
 
   create: function (context) {
     const filename = context.filename || context.getFilename();
-    if (!filename.endsWith("constants.ts")) {
+    const isConstants = filename.endsWith("constants.ts");
+    const isMetadata = filename.endsWith("metadata.ts");
+
+    if (!isConstants && !isMetadata) {
       return {};
     }
 
@@ -55,13 +86,45 @@ module.exports = {
 
     return {
       VariableDeclarator(node) {
-        if (isInternalMcpServersDeclarator(node)) {
+        // In constants.ts: track when we're inside INTERNAL_MCP_SERVERS.
+        // This is the pre-metadata migration path.
+        if (isConstants && isInternalMcpServersDeclarator(node)) {
           inInternalMcpServers = true;
+        }
+
+        // In metadata.ts: check variables with `satisfies ServerMetadata`.
+        if (isMetadata && isSatisfiesServerMetadata(node)) {
+          // `{ ... } as const satisfies ServerMetadata` is parsed as:
+          //   TSSatisfiesExpression > TSAsExpression > ObjectExpression.
+          // `{ ... } satisfies ServerMetadata` is parsed as:
+          //   TSSatisfiesExpression > ObjectExpression.
+          let objectExpr = node.init.expression;
+          if (objectExpr?.type === "TSAsExpression") {
+            objectExpr = objectExpr.expression;
+          }
+          if (objectExpr?.type !== "ObjectExpression") {
+            return;
+          }
+          const serverInfoProp = findServerInfoInObject(objectExpr);
+          if (!serverInfoProp) {
+            return;
+          }
+          const instructionsProp = findInstructionsProperty(
+            serverInfoProp.value
+          );
+          if (!instructionsProp || isNullLiteral(instructionsProp.value)) {
+            return;
+          }
+          context.report({
+            node: instructionsProp,
+            message: ERROR_MESSAGE,
+          });
         }
       },
 
       "VariableDeclarator:exit"(node) {
         if (
+          isConstants &&
           node.id.type === "Identifier" &&
           node.id.name === "INTERNAL_MCP_SERVERS"
         ) {
@@ -70,23 +133,18 @@ module.exports = {
       },
 
       Property(node) {
-        if (!inInternalMcpServers || !isServerInfoProperty(node)) {
+        if (!isConstants || !inInternalMcpServers || !isServerInfoProperty(node)) {
           return;
         }
 
-        const instructionsProp = findInstructionsProperty(node);
+        const instructionsProp = findInstructionsProperty(node.value);
         if (!instructionsProp || isNullLiteral(instructionsProp.value)) {
           return;
         }
 
         context.report({
           node: instructionsProp,
-          message:
-            "Instructions in INTERNAL_MCP_SERVERS need to be avoided. " +
-            "Tools should be self-explanatory and straightforward to use: avoid coupling " +
-            '(e.g., "always use tool A before B", should be bundled in tool B itself). ' +
-            "Proper design eliminates the need for server-level instructions, preventing " +
-            "context bloat and instruction clashes.",
+          message: ERROR_MESSAGE,
         });
       },
     };

--- a/eslint-plugin-dust/rules/no-mcp-server-instructions.js
+++ b/eslint-plugin-dust/rules/no-mcp-server-instructions.js
@@ -133,7 +133,11 @@ module.exports = {
       },
 
       Property(node) {
-        if (!isConstants || !inInternalMcpServers || !isServerInfoProperty(node)) {
+        if (
+          !isConstants ||
+          !inInternalMcpServers ||
+          !isServerInfoProperty(node)
+        ) {
           return;
         }
 

--- a/front/lib/api/actions/servers/data_sources_file_system/metadata.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/metadata.ts
@@ -15,9 +15,6 @@ import {
   TagsInputSchema,
 } from "@app/lib/actions/mcp_internal_actions/types";
 
-export const DATA_SOURCES_FILE_SYSTEM_SERVER_NAME =
-  "data_sources_file_system" as const;
-
 export const FIND_TAGS_TOOL_NAME = "find_tags";
 export const FILESYSTEM_SEARCH_TOOL_NAME = "semantic_search";
 export const FILESYSTEM_CAT_TOOL_NAME = "cat";
@@ -176,6 +173,9 @@ export const DATA_SOURCES_FILE_SYSTEM_SERVER = {
     authorization: null,
     icon: "ActionDocumentTextIcon",
     documentationUrl: null,
+    // TODO(2026-02-09 aubin): clean this up once global agents are moved to
+    //  using the Discover Knowledge skill.
+    // eslint-disable-next-line dust/no-mcp-server-instructions
     instructions: DATA_SOURCE_FILESYSTEM_SERVER_INSTRUCTIONS,
   },
   tools: Object.values(DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA).map((t) => ({

--- a/front/lib/api/actions/servers/freshservice/metadata.ts
+++ b/front/lib/api/actions/servers/freshservice/metadata.ts
@@ -692,6 +692,9 @@ export const FRESHSERVICE_SERVER = {
     },
     icon: "FreshserviceLogo",
     documentationUrl: "https://docs.dust.tt/docs/freshservice",
+    // Predates the introduction of the rule, would require extensive work to
+    // improve, already widely adopted.
+    // eslint-disable-next-line dust/no-mcp-server-instructions
     instructions: FRESHSERVICE_SERVER_INSTRUCTIONS,
   },
   tools: Object.values(FRESHSERVICE_TOOLS_METADATA).map((t) => ({

--- a/front/lib/api/actions/servers/http_client/metadata.ts
+++ b/front/lib/api/actions/servers/http_client/metadata.ts
@@ -111,6 +111,9 @@ export const HTTP_CLIENT_SERVER = {
     authorization: null,
     icon: "ActionGlobeAltIcon" as const,
     documentationUrl: null,
+    // Predates the introduction of the rule, would require extensive work to
+    // improve, already widely adopted.
+    // eslint-disable-next-line dust/no-mcp-server-instructions
     instructions: HTTP_CLIENT_INSTRUCTIONS,
     developerSecretSelection: "optional" as const,
     developerSecretSelectionDescription:

--- a/front/lib/api/actions/servers/image_generation/metadata.ts
+++ b/front/lib/api/actions/servers/image_generation/metadata.ts
@@ -96,6 +96,9 @@ export const IMAGE_GENERATION_SERVER = {
     authorization: null,
     icon: "ActionImageIcon",
     documentationUrl: null,
+    // Predates the introduction of the rule, would require extensive work to
+    // improve, already widely adopted.
+    // eslint-disable-next-line dust/no-mcp-server-instructions
     instructions: IMAGE_GENERATION_SERVER_INSTRUCTIONS,
   },
   tools: Object.values(IMAGE_GENERATION_TOOLS_METADATA).map((t) => ({

--- a/front/lib/api/actions/servers/jira/metadata.ts
+++ b/front/lib/api/actions/servers/jira/metadata.ts
@@ -399,6 +399,9 @@ export const JIRA_SERVER = {
     },
     icon: "JiraLogo",
     documentationUrl: "https://docs.dust.tt/docs/jira",
+    // Predates the introduction of the rule, would require extensive work to
+    // improve, already widely adopted.
+    // eslint-disable-next-line dust/no-mcp-server-instructions
     instructions: JIRA_SERVER_INSTRUCTIONS,
   },
   tools: Object.values(JIRA_TOOLS_METADATA).map((t) => ({

--- a/front/lib/api/actions/servers/productboard/metadata.ts
+++ b/front/lib/api/actions/servers/productboard/metadata.ts
@@ -526,6 +526,9 @@ export const PRODUCTBOARD_SERVER = {
     },
     icon: "ProductboardLogo",
     documentationUrl: "https://docs.dust.tt/docs/productboard",
+    // Predates the introduction of the rule, would require extensive work to
+    // improve, as it's already widely adopted.
+    // eslint-disable-next-line dust/no-mcp-server-instructions
     instructions: PRODUCTBOARD_SERVER_INSTRUCTIONS,
   },
   tools: Object.values(PRODUCTBOARD_TOOLS_METADATA).map((t) => ({

--- a/front/lib/api/actions/servers/project_conversation/metadata.ts
+++ b/front/lib/api/actions/servers/project_conversation/metadata.ts
@@ -49,6 +49,9 @@ export const PROJECT_CONVERSATION_SERVER = {
     icon: "ActionMegaphoneIcon",
     authorization: null,
     documentationUrl: null,
+    // These instructions do not belong on the server, they should either be bundled on the
+    // instructions since always added programmatically or bundled in a skill.
+    // eslint-disable-next-line dust/no-mcp-server-instructions
     instructions: PROJECT_CONVERSATION_INSTRUCTIONS,
   },
   tools: Object.values(PROJECT_CONVERSATION_TOOLS_METADATA).map((t) => ({

--- a/front/lib/api/actions/servers/project_manager/metadata.ts
+++ b/front/lib/api/actions/servers/project_manager/metadata.ts
@@ -170,6 +170,9 @@ export const PROJECT_MANAGER_SERVER = {
     icon: "ActionDocumentTextIcon",
     authorization: null,
     documentationUrl: null,
+    // These instructions do not belong on the server, they should either be bundled on the
+    // instructions since always added programmatically or bundled in a skill.
+    // eslint-disable-next-line dust/no-mcp-server-instructions
     instructions: PROJECT_MANAGER_INSTRUCTIONS,
   },
   tools: Object.values(PROJECT_MANAGER_TOOLS_METADATA).map((t) => ({

--- a/front/lib/api/actions/servers/salesforce/metadata.ts
+++ b/front/lib/api/actions/servers/salesforce/metadata.ts
@@ -115,6 +115,9 @@ export const SALESFORCE_SERVER = {
     },
     icon: "SalesforceLogo",
     documentationUrl: "https://docs.dust.tt/docs/salesforce",
+    // Predates the introduction of the rule, would require extensive work to
+    // improve, already widely adopted.
+    // eslint-disable-next-line dust/no-mcp-server-instructions
     instructions: SALESFORCE_SERVER_INSTRUCTIONS,
   },
   tools: Object.values(SALESFORCE_TOOLS_METADATA).map((t) => ({


### PR DESCRIPTION
## Description

- This PR updates the rule that prohibits adding instructions at the MCP server level to also follow the new metadata pattern (previously only checked instructions defined in the big `constant.ts` file).
- Rationale of adding a rule is to discourage creating new ones, we have very little appetite for improving the existing ones to not rely on additional instructions as they are already used by customers and yield satisfactory results.

## Tests

- Checked locally.

## Risk

- Low.

## Deploy Plan

- No deploy.
