### PR TITLE
[front] chore(FS-tools): remove duplication of metadata

### DIFF
--- a/front/lib/actions/mcp_internal_actions/types.ts
+++ b/front/lib/actions/mcp_internal_actions/types.ts
@@ -243,6 +243,40 @@ export function isDataSourceFilesystemListInputType(
   return DataSourceFilesystemListInputSchema.safeParse(input).success;
 }
 
+export const DataSourceFilesystemCatInputSchema = z.object({
+  dataSources:
+    ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE],
+  nodeId: z
+    .string()
+    .describe(
+      "The ID of the node to read. This is not the human-readable node title."
+    ),
+  offset: z
+    .number()
+    .optional()
+    .describe(
+      "The character position to start reading from (0-based). If not provided, starts from " +
+        "the beginning."
+    ),
+  limit: z
+    .number()
+    .optional()
+    .describe(
+      "The maximum number of characters to read. If not provided, reads all characters."
+    ),
+  grep: z
+    .string()
+    .optional()
+    .describe(
+      "A regular expression to filter lines. Applied after offset/limit slicing. Only lines " +
+        "matching this pattern will be returned."
+    ),
+});
+
+export type DataSourceFilesystemCatInputType = z.infer<
+  typeof DataSourceFilesystemCatInputSchema
+>;
+
 export const DataSourceFilesystemLocateTreeInputSchema = z.object({
   nodeId: z.string().describe("The ID of the node to locate in the tree."),
   dataSources:

--- a/front/lib/api/actions/servers/data_sources_file_system/index.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/index.ts
@@ -3,14 +3,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { shouldAutoGenerateTags } from "@app/lib/actions/mcp_internal_actions/tools/tags/utils";
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
-import {
-  FILESYSTEM_CAT_TOOL_NAME,
-  FILESYSTEM_FIND_TOOL_NAME,
-  FILESYSTEM_LIST_TOOL_NAME,
-  FILESYSTEM_LOCATE_IN_TREE_TOOL_NAME,
-  FILESYSTEM_SEARCH_TOOL_NAME,
-  FIND_TAGS_TOOL_NAME,
-} from "@app/lib/api/actions/servers/data_sources_file_system/metadata";
+import { FIND_TAGS_TOOL_NAME } from "@app/lib/api/actions/servers/data_sources_file_system/metadata";
 import { registerCatTool } from "@app/lib/api/actions/servers/data_sources_file_system/tools/cat";
 import { registerFindTool } from "@app/lib/api/actions/servers/data_sources_file_system/tools/find";
 import { registerListTool } from "@app/lib/api/actions/servers/data_sources_file_system/tools/list";
@@ -30,27 +23,11 @@ function createServer(
     : false;
 
   // Register all filesystem tools.
-  registerCatTool(auth, server, agentLoopContext, {
-    name: FILESYSTEM_CAT_TOOL_NAME,
-  });
-
-  registerListTool(auth, server, agentLoopContext, {
-    name: FILESYSTEM_LIST_TOOL_NAME,
-  });
-
-  registerSearchTool(auth, server, agentLoopContext, {
-    name: FILESYSTEM_SEARCH_TOOL_NAME,
-    areTagsDynamic,
-  });
-
-  registerFindTool(auth, server, agentLoopContext, {
-    name: FILESYSTEM_FIND_TOOL_NAME,
-    areTagsDynamic,
-  });
-
-  registerLocateTreeTool(auth, server, agentLoopContext, {
-    name: FILESYSTEM_LOCATE_IN_TREE_TOOL_NAME,
-  });
+  registerCatTool(auth, server, agentLoopContext);
+  registerListTool(auth, server, agentLoopContext);
+  registerSearchTool(auth, server, agentLoopContext, { areTagsDynamic });
+  registerFindTool(auth, server, agentLoopContext, { areTagsDynamic });
+  registerLocateTreeTool(auth, server, agentLoopContext);
 
   // If tags are dynamic, register the find tags tool to help agents discover tags.
   if (areTagsDynamic) {

--- a/front/lib/api/actions/servers/data_sources_file_system/metadata.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/metadata.ts
@@ -11,6 +11,7 @@ import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_de
 import {
   DataSourceFilesystemFindInputSchema,
   DataSourceFilesystemListInputSchema,
+  DataSourceFilesystemLocateTreeInputSchema,
   SearchWithNodesInputSchema,
   TagsInputSchema,
 } from "@app/lib/actions/mcp_internal_actions/types";
@@ -25,8 +26,8 @@ export const FILESYSTEM_LIST_TOOL_NAME = "list";
 export const DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA = createToolsRecord({
   [FILESYSTEM_CAT_TOOL_NAME]: {
     description:
-      "Read the contents of a node with offset/limit and optional grep filtering (named after the 'cat' unix tool). " +
-      "Use this when nodes are too large to read in full, or when you need to search for specific patterns within a node.",
+      "Read the contents of a document, referred to by its nodeId (named after the 'cat' unix tool). " +
+      "The nodeId can be obtained using the 'find', 'list' or 'search' tools.",
     schema: {
       dataSources:
         ConfigurableToolInputSchemas[
@@ -80,7 +81,8 @@ export const DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA = createToolsRecord({
   },
   [FILESYSTEM_SEARCH_TOOL_NAME]: {
     description:
-      "Search for content nodes semantically using a query string. Returns matching nodes with their content.",
+      "Perform a semantic search within the folders and files designated by `nodeIds`. All " +
+      "children of the designated nodes will be searched.",
     schema: SearchWithNodesInputSchema.shape,
     stake: "never_ask",
     displayLabels: {
@@ -90,8 +92,9 @@ export const DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA = createToolsRecord({
   },
   [FILESYSTEM_FIND_TOOL_NAME]: {
     description:
-      "Find nodes by title/name (like 'find' in Unix). Supports partial matching and can search " +
-      "within a specific subtree using rootNodeId. Returns matching nodes without their full content.",
+      "Find content based on their title starting from a specific node. Can be used to find specific " +
+      "nodes by searching for their titles. The query title can be omitted to list all nodes " +
+      "starting from a specific node. This is like using 'find' in Unix.",
     schema: DataSourceFilesystemFindInputSchema.shape,
     stake: "never_ask",
     displayLabels: {
@@ -101,17 +104,11 @@ export const DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA = createToolsRecord({
   },
   [FILESYSTEM_LOCATE_IN_TREE_TOOL_NAME]: {
     description:
-      "Locate a specific node in the folder hierarchy tree. Returns the path from root to the node, " +
-      "showing the hierarchy of parent folders. Useful to understand where a node is located in the structure.",
-    schema: {
-      nodeId: z
-        .string()
-        .describe("The ID of the node to locate in the tree hierarchy."),
-      dataSources:
-        ConfigurableToolInputSchemas[
-          INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE
-        ],
-    },
+      "Show the complete path from a node to the data source root, displaying the hierarchy of parent nodes. " +
+      "This is useful for understanding where a specific node is located within the data source structure. " +
+      "The path is returned as a list of nodes, with the first node being the data source root and " +
+      "the last node being the target node.",
+    schema: DataSourceFilesystemLocateTreeInputSchema.shape,
     stake: "never_ask",
     displayLabels: {
       running: "Locating content in hierarchy",

--- a/front/lib/api/actions/servers/data_sources_file_system/metadata.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/metadata.ts
@@ -9,6 +9,7 @@ import { DATA_SOURCE_FILESYSTEM_SERVER_INSTRUCTIONS } from "@app/lib/actions/mcp
 import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
+  DataSourceFilesystemCatInputSchema,
   DataSourceFilesystemFindInputSchema,
   DataSourceFilesystemListInputSchema,
   DataSourceFilesystemLocateTreeInputSchema,
@@ -28,37 +29,7 @@ export const DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA = createToolsRecord({
     description:
       "Read the contents of a document, referred to by its nodeId (named after the 'cat' unix tool). " +
       "The nodeId can be obtained using the 'find', 'list' or 'search' tools.",
-    schema: {
-      dataSources:
-        ConfigurableToolInputSchemas[
-          INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE
-        ],
-      nodeId: z
-        .string()
-        .describe(
-          "The ID of the node to read. This is not the human-readable node title."
-        ),
-      offset: z
-        .number()
-        .optional()
-        .describe(
-          "The character position to start reading from (0-based). If not provided, starts from " +
-            "the beginning."
-        ),
-      limit: z
-        .number()
-        .optional()
-        .describe(
-          "The maximum number of characters to read. If not provided, reads all characters."
-        ),
-      grep: z
-        .string()
-        .optional()
-        .describe(
-          "A regular expression to filter lines. Applied after offset/limit slicing. Only lines " +
-            "matching this pattern will be returned."
-        ),
-    },
+    schema: DataSourceFilesystemCatInputSchema.shape,
     stake: "never_ask",
     displayLabels: {
       running: "Reading file from data source",

--- a/front/lib/api/actions/servers/data_sources_file_system/metadata.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/metadata.ts
@@ -14,7 +14,6 @@ import {
   DataSourceFilesystemListInputSchema,
   DataSourceFilesystemLocateTreeInputSchema,
   SearchWithNodesInputSchema,
-  TagsInputSchema,
 } from "@app/lib/actions/mcp_internal_actions/types";
 
 export const FIND_TAGS_TOOL_NAME = "find_tags";
@@ -103,35 +102,6 @@ export const DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA = createToolsRecord({
     },
   },
 });
-
-// Tool metadata with tags support for search and find tools
-export const DATA_SOURCES_FILE_SYSTEM_TOOLS_WITH_TAGS_METADATA =
-  createToolsRecord({
-    [FILESYSTEM_CAT_TOOL_NAME]:
-      DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA[FILESYSTEM_CAT_TOOL_NAME],
-    [FILESYSTEM_LIST_TOOL_NAME]:
-      DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA[FILESYSTEM_LIST_TOOL_NAME],
-    [FILESYSTEM_SEARCH_TOOL_NAME]: {
-      ...DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA[FILESYSTEM_SEARCH_TOOL_NAME],
-      schema: {
-        ...SearchWithNodesInputSchema.shape,
-        ...TagsInputSchema.shape,
-      },
-    },
-    [FILESYSTEM_FIND_TOOL_NAME]: {
-      ...DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA[FILESYSTEM_FIND_TOOL_NAME],
-      schema: {
-        ...DataSourceFilesystemFindInputSchema.shape,
-        ...TagsInputSchema.shape,
-      },
-    },
-    [FILESYSTEM_LOCATE_IN_TREE_TOOL_NAME]:
-      DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA[
-        FILESYSTEM_LOCATE_IN_TREE_TOOL_NAME
-      ],
-    [FIND_TAGS_TOOL_NAME]:
-      DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA[FIND_TAGS_TOOL_NAME],
-  });
 
 export const DATA_SOURCES_FILE_SYSTEM_SERVER = {
   serverInfo: {

--- a/front/lib/api/actions/servers/data_sources_file_system/tools/cat.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/tools/cat.ts
@@ -9,6 +9,7 @@ import {
   getAgentDataSourceConfigurations,
   makeCoreSearchNodesFilters,
 } from "@app/lib/actions/mcp_internal_actions/tools/utils";
+import { DataSourceFilesystemCatInputSchema } from "@app/lib/actions/mcp_internal_actions/types";
 import { ensureAuthorizedDataSourceViews } from "@app/lib/actions/mcp_internal_actions/utils/data_source_views";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
@@ -27,13 +28,13 @@ export function registerCatTool(
   server: McpServer,
   agentLoopContext: AgentLoopContextType | undefined
 ) {
-  const metadata =
+  const { name, description } =
     DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA[FILESYSTEM_CAT_TOOL_NAME];
 
   server.tool(
-    metadata.name,
-    metadata.description,
-    metadata.schema,
+    name,
+    description,
+    DataSourceFilesystemCatInputSchema.shape,
     withToolLogging(
       auth,
       {

--- a/front/lib/api/actions/servers/data_sources_file_system/tools/cat.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/tools/cat.ts
@@ -1,10 +1,8 @@
 // eslint-disable-next-line dust/enforce-client-types-in-public-api
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { z } from "zod";
 
 import { MCPError } from "@app/lib/actions/mcp_errors";
-import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { renderNode } from "@app/lib/actions/mcp_internal_actions/rendering";
 import { checkConflictingTags } from "@app/lib/actions/mcp_internal_actions/tools/tags/utils";
 import {
@@ -14,60 +12,28 @@ import {
 import { ensureAuthorizedDataSourceViews } from "@app/lib/actions/mcp_internal_actions/utils/data_source_views";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
-import { FILESYSTEM_CAT_TOOL_NAME } from "@app/lib/api/actions/servers/data_sources_file_system/metadata";
+import {
+  DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA,
+  FILESYSTEM_CAT_TOOL_NAME,
+} from "@app/lib/api/actions/servers/data_sources_file_system/metadata";
 import { getRefs } from "@app/lib/api/assistant/citations";
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import { CoreAPI, Err, Ok } from "@app/types";
 
-const catToolInputSchema = {
-  dataSources:
-    ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE],
-  nodeId: z
-    .string()
-    .describe(
-      "The ID of the node to read. This is not the human-readable node title."
-    ),
-  offset: z
-    .number()
-    .optional()
-    .describe(
-      "The character position to start reading from (0-based). If not provided, starts from " +
-        "the beginning."
-    ),
-  limit: z
-    .number()
-    .optional()
-    .describe(
-      "The maximum number of characters to read. If not provided, reads all characters."
-    ),
-  grep: z
-    .string()
-    .optional()
-    .describe(
-      "A regular expression to filter lines. Applied after offset/limit slicing. Only lines " +
-        "matching this pattern will be returned."
-    ),
-};
-
 export function registerCatTool(
   auth: Authenticator,
   server: McpServer,
-  agentLoopContext: AgentLoopContextType | undefined,
-  { name, extraDescription }: { name: string; extraDescription?: string }
+  agentLoopContext: AgentLoopContextType | undefined
 ) {
-  const baseDescription =
-    "Read the contents of a document, referred to by its nodeId (named after the 'cat' unix tool). " +
-    "The nodeId can be obtained using the 'find', 'list' or 'search' tools.";
-  const toolDescription = extraDescription
-    ? baseDescription + "\n" + extraDescription
-    : baseDescription;
+  const metadata =
+    DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA[FILESYSTEM_CAT_TOOL_NAME];
 
   server.tool(
-    name,
-    toolDescription,
-    catToolInputSchema,
+    metadata.name,
+    metadata.description,
+    metadata.schema,
     withToolLogging(
       auth,
       {

--- a/front/lib/api/actions/servers/data_sources_file_system/tools/find.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/tools/find.ts
@@ -15,7 +15,7 @@ import type {
   TagsInputType,
 } from "@app/lib/actions/mcp_internal_actions/types";
 import {
-  SearchWithNodesInputSchema,
+  DataSourceFilesystemFindInputSchema,
   TagsInputSchema,
 } from "@app/lib/actions/mcp_internal_actions/types";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
@@ -45,10 +45,10 @@ export function registerFindTool(
     description,
     areTagsDynamic
       ? {
-          ...SearchWithNodesInputSchema.shape,
+          ...DataSourceFilesystemFindInputSchema.shape,
           ...TagsInputSchema.shape,
         }
-      : SearchWithNodesInputSchema.shape,
+      : DataSourceFilesystemFindInputSchema.shape,
     withToolLogging(
       auth,
       {

--- a/front/lib/api/actions/servers/data_sources_file_system/tools/find.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/tools/find.ts
@@ -14,11 +14,14 @@ import type {
   DataSourceFilesystemFindInputType,
   TagsInputType,
 } from "@app/lib/actions/mcp_internal_actions/types";
+import {
+  SearchWithNodesInputSchema,
+  TagsInputSchema,
+} from "@app/lib/actions/mcp_internal_actions/types";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import {
   DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA,
-  DATA_SOURCES_FILE_SYSTEM_TOOLS_WITH_TAGS_METADATA,
   FILESYSTEM_FIND_TOOL_NAME,
 } from "@app/lib/api/actions/servers/data_sources_file_system/metadata";
 import { extractDataSourceIdFromNodeId } from "@app/lib/api/actions/servers/data_sources_file_system/tools/utils";
@@ -34,16 +37,18 @@ export function registerFindTool(
   agentLoopContext: AgentLoopContextType | undefined,
   { areTagsDynamic }: { areTagsDynamic?: boolean }
 ) {
-  const metadata = areTagsDynamic
-    ? DATA_SOURCES_FILE_SYSTEM_TOOLS_WITH_TAGS_METADATA[
-        FILESYSTEM_FIND_TOOL_NAME
-      ]
-    : DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA[FILESYSTEM_FIND_TOOL_NAME];
+  const { name, description } =
+    DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA[FILESYSTEM_FIND_TOOL_NAME];
 
   server.tool(
-    metadata.name,
-    metadata.description,
-    metadata.schema,
+    name,
+    description,
+    areTagsDynamic
+      ? {
+          ...SearchWithNodesInputSchema.shape,
+          ...TagsInputSchema.shape,
+        }
+      : SearchWithNodesInputSchema.shape,
     withToolLogging(
       auth,
       {

--- a/front/lib/api/actions/servers/data_sources_file_system/tools/list.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/tools/list.ts
@@ -8,6 +8,7 @@ import {
   getAgentDataSourceConfigurations,
   makeCoreSearchNodesFilters,
 } from "@app/lib/actions/mcp_internal_actions/tools/utils";
+import { DataSourceFilesystemListInputSchema } from "@app/lib/actions/mcp_internal_actions/types";
 import { ensureAuthorizedDataSourceViews } from "@app/lib/actions/mcp_internal_actions/utils/data_source_views";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
@@ -23,6 +24,7 @@ import config from "@app/lib/api/config";
 import { ROOT_PARENT_ID } from "@app/lib/api/data_source_view";
 import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
+import metadata from "@app/pages/api/w/[wId]/files/[fileId]/metadata";
 import type {
   CoreAPIError,
   CoreAPISearchNodesResponse,
@@ -35,13 +37,13 @@ export function registerListTool(
   server: McpServer,
   agentLoopContext: AgentLoopContextType | undefined
 ) {
-  const metadata =
+  const { name, description } =
     DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA[FILESYSTEM_LIST_TOOL_NAME];
 
   server.tool(
-    metadata.name,
-    metadata.description,
-    metadata.schema,
+    name,
+    description,
+    DataSourceFilesystemListInputSchema.shape,
     withToolLogging(
       auth,
       {

--- a/front/lib/api/actions/servers/data_sources_file_system/tools/list.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/tools/list.ts
@@ -8,10 +8,13 @@ import {
   getAgentDataSourceConfigurations,
   makeCoreSearchNodesFilters,
 } from "@app/lib/actions/mcp_internal_actions/tools/utils";
-import { DataSourceFilesystemListInputSchema } from "@app/lib/actions/mcp_internal_actions/types";
 import { ensureAuthorizedDataSourceViews } from "@app/lib/actions/mcp_internal_actions/utils/data_source_views";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
+import {
+  DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA,
+  FILESYSTEM_LIST_TOOL_NAME,
+} from "@app/lib/api/actions/servers/data_sources_file_system/metadata";
 import {
   extractDataSourceIdFromNodeId,
   isDataSourceNodeId,
@@ -30,27 +33,19 @@ import { CoreAPI, Err, Ok } from "@app/types";
 export function registerListTool(
   auth: Authenticator,
   server: McpServer,
-  agentLoopContext: AgentLoopContextType | undefined,
-  { name, extraDescription }: { name: string; extraDescription?: string }
+  agentLoopContext: AgentLoopContextType | undefined
 ) {
-  const baseDescription =
-    "List the direct contents of a node, like 'ls' in Unix. Should only be used on nodes with children " +
-    "(hasChildren: true). A good fit is to explore the filesystem structure step " +
-    "by step. This tool can be called repeatedly by passing the 'nodeId' output from a step to " +
-    "the next step's nodeId. If a node output by this tool or the find tool has children " +
-    "(hasChildren: true), it means that this tool can be used again on it.";
-  const toolDescription = extraDescription
-    ? baseDescription + "\n" + extraDescription
-    : baseDescription;
+  const metadata =
+    DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA[FILESYSTEM_LIST_TOOL_NAME];
 
   server.tool(
-    name,
-    toolDescription,
-    DataSourceFilesystemListInputSchema.shape,
+    metadata.name,
+    metadata.description,
+    metadata.schema,
     withToolLogging(
       auth,
       {
-        toolNameForMonitoring: name,
+        toolNameForMonitoring: metadata.name,
         agentLoopContext,
         enableAlerting: true,
       },

--- a/front/lib/api/actions/servers/data_sources_file_system/tools/list.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/tools/list.ts
@@ -24,7 +24,6 @@ import config from "@app/lib/api/config";
 import { ROOT_PARENT_ID } from "@app/lib/api/data_source_view";
 import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
-import metadata from "@app/pages/api/w/[wId]/files/[fileId]/metadata";
 import type {
   CoreAPIError,
   CoreAPISearchNodesResponse,
@@ -47,7 +46,7 @@ export function registerListTool(
     withToolLogging(
       auth,
       {
-        toolNameForMonitoring: metadata.name,
+        toolNameForMonitoring: FILESYSTEM_LIST_TOOL_NAME,
         agentLoopContext,
         enableAlerting: true,
       },

--- a/front/lib/api/actions/servers/data_sources_file_system/tools/locate_tree.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/tools/locate_tree.ts
@@ -10,6 +10,7 @@ import {
   makeCoreSearchNodesFilters,
 } from "@app/lib/actions/mcp_internal_actions/tools/utils";
 import type { DataSourceFilesystemLocateTreeInputType } from "@app/lib/actions/mcp_internal_actions/types";
+import { DataSourceFilesystemLocateTreeInputSchema } from "@app/lib/actions/mcp_internal_actions/types";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import {
@@ -31,15 +32,15 @@ export function registerLocateTreeTool(
   server: McpServer,
   agentLoopContext: AgentLoopContextType | undefined
 ) {
-  const metadata =
+  const { name, description } =
     DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA[
       FILESYSTEM_LOCATE_IN_TREE_TOOL_NAME
     ];
 
   server.tool(
-    metadata.name,
-    metadata.description,
-    metadata.schema,
+    name,
+    description,
+    DataSourceFilesystemLocateTreeInputSchema.shape,
     withToolLogging(
       auth,
       {

--- a/front/lib/api/actions/servers/data_sources_file_system/tools/locate_tree.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/tools/locate_tree.ts
@@ -10,10 +10,12 @@ import {
   makeCoreSearchNodesFilters,
 } from "@app/lib/actions/mcp_internal_actions/tools/utils";
 import type { DataSourceFilesystemLocateTreeInputType } from "@app/lib/actions/mcp_internal_actions/types";
-import { DataSourceFilesystemLocateTreeInputSchema } from "@app/lib/actions/mcp_internal_actions/types";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
-import { FILESYSTEM_LOCATE_IN_TREE_TOOL_NAME } from "@app/lib/api/actions/servers/data_sources_file_system/metadata";
+import {
+  DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA,
+  FILESYSTEM_LOCATE_IN_TREE_TOOL_NAME,
+} from "@app/lib/api/actions/servers/data_sources_file_system/metadata";
 import {
   extractDataSourceIdFromNodeId,
   isDataSourceNodeId,
@@ -27,22 +29,17 @@ import { CoreAPI, DATA_SOURCE_NODE_ID, Err, Ok, removeNulls } from "@app/types";
 export function registerLocateTreeTool(
   auth: Authenticator,
   server: McpServer,
-  agentLoopContext: AgentLoopContextType | undefined,
-  { name, extraDescription }: { name: string; extraDescription?: string }
+  agentLoopContext: AgentLoopContextType | undefined
 ) {
-  const baseDescription =
-    "Show the complete path from a node to the data source root, displaying the hierarchy of parent nodes. " +
-    "This is useful for understanding where a specific node is located within the data source structure. " +
-    "The path is returned as a list of nodes, with the first node being the data source root and " +
-    "the last node being the target node.";
-  const toolDescription = extraDescription
-    ? baseDescription + "\n" + extraDescription
-    : baseDescription;
+  const metadata =
+    DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA[
+      FILESYSTEM_LOCATE_IN_TREE_TOOL_NAME
+    ];
 
   server.tool(
-    name,
-    toolDescription,
-    DataSourceFilesystemLocateTreeInputSchema.shape,
+    metadata.name,
+    metadata.description,
+    metadata.schema,
     withToolLogging(
       auth,
       {

--- a/front/lib/api/actions/servers/data_sources_file_system/tools/search.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/tools/search.ts
@@ -18,13 +18,13 @@ import type {
   SearchWithNodesInputType,
   TagsInputType,
 } from "@app/lib/actions/mcp_internal_actions/types";
-import {
-  SearchWithNodesInputSchema,
-  TagsInputSchema,
-} from "@app/lib/actions/mcp_internal_actions/types";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
-import { FILESYSTEM_SEARCH_TOOL_NAME } from "@app/lib/api/actions/servers/data_sources_file_system/metadata";
+import {
+  DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA,
+  DATA_SOURCES_FILE_SYSTEM_TOOLS_WITH_TAGS_METADATA,
+  FILESYSTEM_SEARCH_TOOL_NAME,
+} from "@app/lib/api/actions/servers/data_sources_file_system/metadata";
 import {
   extractDataSourceIdFromNodeId,
   isDataSourceNodeId,
@@ -51,53 +51,28 @@ export function registerSearchTool(
   auth: Authenticator,
   server: McpServer,
   agentLoopContext: AgentLoopContextType | undefined,
-  {
-    name,
-    extraDescription,
-    areTagsDynamic,
-  }: { name: string; extraDescription?: string; areTagsDynamic?: boolean }
+  { areTagsDynamic }: { areTagsDynamic?: boolean }
 ) {
-  const baseDescription =
-    "Perform a semantic search within the folders and files designated by `nodeIds`. All " +
-    "children of the designated nodes will be searched.";
-  const toolDescription = extraDescription
-    ? baseDescription + "\n" + extraDescription
-    : baseDescription;
+  const metadata = areTagsDynamic
+    ? DATA_SOURCES_FILE_SYSTEM_TOOLS_WITH_TAGS_METADATA[
+        FILESYSTEM_SEARCH_TOOL_NAME
+      ]
+    : DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA[FILESYSTEM_SEARCH_TOOL_NAME];
 
-  if (areTagsDynamic) {
-    server.tool(
-      name,
-      toolDescription,
+  server.tool(
+    metadata.name,
+    metadata.description,
+    metadata.schema,
+    withToolLogging(
+      auth,
       {
-        ...SearchWithNodesInputSchema.shape,
-        ...TagsInputSchema.shape,
+        toolNameForMonitoring: FILESYSTEM_SEARCH_TOOL_NAME,
+        agentLoopContext,
+        enableAlerting: true,
       },
-      withToolLogging(
-        auth,
-        {
-          toolNameForMonitoring: FILESYSTEM_SEARCH_TOOL_NAME,
-          agentLoopContext,
-          enableAlerting: true,
-        },
-        async (params) => searchCallback(auth, agentLoopContext, params)
-      )
-    );
-  } else {
-    server.tool(
-      name,
-      toolDescription,
-      SearchWithNodesInputSchema.shape,
-      withToolLogging(
-        auth,
-        {
-          toolNameForMonitoring: FILESYSTEM_SEARCH_TOOL_NAME,
-          agentLoopContext,
-          enableAlerting: true,
-        },
-        async (params) => searchCallback(auth, agentLoopContext, params)
-      )
-    );
-  }
+      async (params) => searchCallback(auth, agentLoopContext, params)
+    )
+  );
 }
 
 async function searchCallback(

--- a/front/lib/api/actions/servers/data_sources_file_system/tools/search.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/tools/search.ts
@@ -14,11 +14,13 @@ import {
   getCoreSearchArgs,
   makeCoreSearchNodesFilters,
 } from "@app/lib/actions/mcp_internal_actions/tools/utils";
+import type {
+  SearchWithNodesInputType,
+  TagsInputType,
+} from "@app/lib/actions/mcp_internal_actions/types";
 import {
   SearchWithNodesInputSchema,
-  SearchWithNodesInputType,
   TagsInputSchema,
-  TagsInputType,
 } from "@app/lib/actions/mcp_internal_actions/types";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";

--- a/front/lib/api/actions/servers/data_sources_file_system/tools/search.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/tools/search.ts
@@ -14,15 +14,16 @@ import {
   getCoreSearchArgs,
   makeCoreSearchNodesFilters,
 } from "@app/lib/actions/mcp_internal_actions/tools/utils";
-import type {
+import {
+  SearchWithNodesInputSchema,
   SearchWithNodesInputType,
+  TagsInputSchema,
   TagsInputType,
 } from "@app/lib/actions/mcp_internal_actions/types";
 import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import {
   DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA,
-  DATA_SOURCES_FILE_SYSTEM_TOOLS_WITH_TAGS_METADATA,
   FILESYSTEM_SEARCH_TOOL_NAME,
 } from "@app/lib/api/actions/servers/data_sources_file_system/metadata";
 import {
@@ -53,16 +54,18 @@ export function registerSearchTool(
   agentLoopContext: AgentLoopContextType | undefined,
   { areTagsDynamic }: { areTagsDynamic?: boolean }
 ) {
-  const metadata = areTagsDynamic
-    ? DATA_SOURCES_FILE_SYSTEM_TOOLS_WITH_TAGS_METADATA[
-        FILESYSTEM_SEARCH_TOOL_NAME
-      ]
-    : DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA[FILESYSTEM_SEARCH_TOOL_NAME];
+  const { name, description } =
+    DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA[FILESYSTEM_SEARCH_TOOL_NAME];
 
   server.tool(
-    metadata.name,
-    metadata.description,
-    metadata.schema,
+    name,
+    description,
+    areTagsDynamic
+      ? {
+          ...SearchWithNodesInputSchema.shape,
+          ...TagsInputSchema.shape,
+        }
+      : SearchWithNodesInputSchema.shape,
     withToolLogging(
       auth,
       {


### PR DESCRIPTION
## Description

- The metadata (description, schema, ...) of the data source filesystem tools has been duplicated during the move to the metadata pattern.
- This PR fixes that by consolidating around the metadata file.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
