### PR TITLE
[front] Instrument LLM prompt caching

### DIFF
--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -319,20 +319,18 @@ export abstract class LLM {
 
         // We only use caching for conversations, excluding other operation types to prevent noise.
         if (this.context.operationType === "agent_conversation") {
-          if (tokenUsage.cachedTokens && tokenUsage.cachedTokens > 0) {
-            statsDClient.increment(
-              "llm_cache_hit.count",
-              1,
+          const { cacheCreationTokens, cachedTokens } = tokenUsage;
+          if (cachedTokens) {
+            statsDClient.distribution(
+              "llm_cache.tokens_read",
+              cachedTokens,
               cacheHitMetricTags
             );
           }
-          if (
-            tokenUsage.cacheCreationTokens &&
-            tokenUsage.cacheCreationTokens > 0
-          ) {
-            statsDClient.increment(
-              "llm_cache_write.count",
-              1,
+          if (cacheCreationTokens) {
+            statsDClient.distribution(
+              "llm_cache.tokens_written",
+              cacheCreationTokens,
               cacheHitMetricTags
             );
           }

--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -319,11 +319,16 @@ export abstract class LLM {
 
         // We only use caching for conversations, excluding other operation types to prevent noise.
         if (this.context.operationType === "agent_conversation") {
-          const { cacheCreationTokens, cachedTokens } = tokenUsage;
+          const { cacheCreationTokens, cachedTokens, inputTokens } = tokenUsage;
           if (cachedTokens) {
             statsDClient.distribution(
               "llm_cache.tokens_read",
               cachedTokens,
+              cacheHitMetricTags
+            );
+            statsDClient.distribution(
+              "llm_cache.token_hit_ratio",
+              cachedTokens / inputTokens,
               cacheHitMetricTags
             );
           }

--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -312,6 +312,16 @@ export abstract class LLM {
             reasoning_tokens: tokenUsage.reasoningTokens ?? 0,
           },
         });
+
+        if (tokenUsage.cachedTokens && tokenUsage.cachedTokens > 0) {
+          statsDClient.increment("llm_cache_hit.count", 1, metricTags);
+        }
+        if (
+          tokenUsage.cacheCreationTokens &&
+          tokenUsage.cacheCreationTokens > 0
+        ) {
+          statsDClient.increment("llm_cache_write.count", 1, metricTags);
+        }
       }
 
       if (buffer.error) {

--- a/front/lib/api/llm/llm.ts
+++ b/front/lib/api/llm/llm.ts
@@ -317,18 +317,25 @@ export abstract class LLM {
           },
         });
 
-        if (tokenUsage.cachedTokens && tokenUsage.cachedTokens > 0) {
-          statsDClient.increment("llm_cache_hit.count", 1, cacheHitMetricTags);
-        }
-        if (
-          tokenUsage.cacheCreationTokens &&
-          tokenUsage.cacheCreationTokens > 0
-        ) {
-          statsDClient.increment(
-            "llm_cache_write.count",
-            1,
-            cacheHitMetricTags
-          );
+        // We only use caching for conversations, excluding other operation types to prevent noise.
+        if (this.context.operationType === "agent_conversation") {
+          if (tokenUsage.cachedTokens && tokenUsage.cachedTokens > 0) {
+            statsDClient.increment(
+              "llm_cache_hit.count",
+              1,
+              cacheHitMetricTags
+            );
+          }
+          if (
+            tokenUsage.cacheCreationTokens &&
+            tokenUsage.cacheCreationTokens > 0
+          ) {
+            statsDClient.increment(
+              "llm_cache_write.count",
+              1,
+              cacheHitMetricTags
+            );
+          }
         }
       }
 

--- a/front/lib/api/llm/traces/buffer.ts
+++ b/front/lib/api/llm/traces/buffer.ts
@@ -15,6 +15,7 @@ import type { SystemPromptInput } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
 import { getLLMTracesBucket } from "@app/lib/file_storage";
 import logger from "@app/logger/logger";
+import { statsDClient } from "@app/logger/statsDClient";
 import type { ModelConversationTypeMultiActions } from "@app/types/assistant/generation";
 import type {
   ModelIdType,
@@ -56,6 +57,7 @@ export class LLMTraceBuffer {
   private outputByteSize = 0;
   private truncated = false;
   private readonly MAX_OUTPUT_SIZE = 64 * 1024; // 64KB for output only.
+  private readonly CACHE_METRIC_AGENT_IDS = ["dust", "deep-dive"];
 
   private content = "";
   private finishReason: LLMTraceOutput["finishReason"] = "unknown";
@@ -160,6 +162,7 @@ export class LLMTraceBuffer {
 
       case "token_usage":
         this.tokenUsage = event.content;
+        this.reportCacheMetrics(event.content);
         break;
 
       // TODO(2025-10-31 DIRECT_LLM): Looks like success event is never sent.
@@ -172,6 +175,39 @@ export class LLMTraceBuffer {
         this.endingError = event;
         this.finishReason = "error";
         break;
+    }
+  }
+
+  private reportCacheMetrics(tokenUsage: TokenUsage): void {
+    const { agentConfigurationId, operationType } = this.context;
+    if (
+      operationType !== "agent_conversation" ||
+      !agentConfigurationId ||
+      !this.CACHE_METRIC_AGENT_IDS.includes(agentConfigurationId)
+    ) {
+      return;
+    }
+
+    const tags = [
+      `model_id:${this.input?.modelId ?? "unknown"}`,
+      `agent_configuration_id:${agentConfigurationId}`,
+    ];
+
+    const { cacheCreationTokens, cachedTokens, inputTokens } = tokenUsage;
+    if (cachedTokens) {
+      statsDClient.distribution("llm_cache.tokens_read", cachedTokens, tags);
+      statsDClient.distribution(
+        "llm_cache.token_hit_ratio",
+        cachedTokens / inputTokens,
+        tags
+      );
+    }
+    if (cacheCreationTokens) {
+      statsDClient.distribution(
+        "llm_cache.tokens_written",
+        cacheCreationTokens,
+        tags
+      );
     }
   }
 


### PR DESCRIPTION
## Description

- This PR adds three metrics: `llm_cache.tokens_read` and `llm_cache.tokens_written` and `llm_cache.token_hit_ratio`, both have the following tags: `model_id`, and `agent_id`.
  - for `llm_cache.tokens_read` we want to see if we have bumps in the distribution around the number of tokens in the system prompts of dust and deep dive
  - `llm_cache.token_hit_ratio` will help determine the proportion of times we are mostly hitting the cache
- Goal is to use these metrics to optimize our caching strategy, notably in terms of duration (5min or 1h).
- Requires a cross-workspace caching to be leveraged (the metrics are not scoped by workspace).
- To be precise the logging is done in line https://github.com/dust-tt/dust/blob/86d57d1291165e2f164dbd92abd00da68b0d9a07/front/lib/api/llm/llm.ts#L232

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
