### PR TITLE
Add logic to mark instructions as outdated

### DIFF
--- a/front/components/editor/extensions/agent_builder/InstructionSuggestionExtension.test.ts
+++ b/front/components/editor/extensions/agent_builder/InstructionSuggestionExtension.test.ts
@@ -8,10 +8,7 @@ import {
 } from "@app/components/editor/extensions/agent_builder/BlockIdExtension";
 import { InstructionBlockExtension } from "@app/components/editor/extensions/agent_builder/InstructionBlockExtension";
 import { InstructionsDocumentExtension } from "@app/components/editor/extensions/agent_builder/InstructionsDocumentExtension";
-import {
-  INSTRUCTIONS_ROOT_ID,
-  InstructionsRootExtension,
-} from "@app/components/editor/extensions/agent_builder/InstructionsRootExtension";
+import { InstructionsRootExtension } from "@app/components/editor/extensions/agent_builder/InstructionsRootExtension";
 import type { BlockChange } from "@app/components/editor/extensions/agent_builder/InstructionSuggestionExtension";
 import {
   diffBlockContent,
@@ -22,6 +19,7 @@ import {
 } from "@app/components/editor/extensions/agent_builder/InstructionSuggestionExtension";
 import { EditorFactory } from "@app/components/editor/extensions/tests/utils";
 import { preprocessMarkdownForEditor } from "@app/components/editor/lib/preprocessMarkdownForEditor";
+import { INSTRUCTIONS_ROOT_TARGET_BLOCK_ID } from "@app/types/suggestions/agent_suggestion";
 
 function getDeletions(editor: Editor) {
   return Array.from(
@@ -826,7 +824,7 @@ describe("Root-targeting suggestions", () => {
       }
     });
 
-    expect(ids).toContain(INSTRUCTIONS_ROOT_ID);
+    expect(ids).toContain(INSTRUCTIONS_ROOT_TARGET_BLOCK_ID);
   });
 
   it("should apply a suggestion targeting the root node", () => {
@@ -836,7 +834,7 @@ describe("Root-targeting suggestions", () => {
 
     const result = editor.commands.applySuggestion({
       id: "root-1",
-      targetBlockId: INSTRUCTIONS_ROOT_ID,
+      targetBlockId: INSTRUCTIONS_ROOT_TARGET_BLOCK_ID,
       content: `<div data-type="instructions-root"><p>Replaced content</p></div>`,
     });
 
@@ -851,7 +849,7 @@ describe("Root-targeting suggestions", () => {
 
     editor.commands.applySuggestion({
       id: "root-diff",
-      targetBlockId: INSTRUCTIONS_ROOT_ID,
+      targetBlockId: INSTRUCTIONS_ROOT_TARGET_BLOCK_ID,
       content: `<div data-type="instructions-root"><p>New text</p></div>`,
     });
 
@@ -869,7 +867,7 @@ describe("Root-targeting suggestions", () => {
 
     editor.commands.applySuggestion({
       id: "root-accept",
-      targetBlockId: INSTRUCTIONS_ROOT_ID,
+      targetBlockId: INSTRUCTIONS_ROOT_TARGET_BLOCK_ID,
       content: `<div data-type="instructions-root"><p>After</p></div>`,
     });
 
@@ -885,7 +883,7 @@ describe("Root-targeting suggestions", () => {
 
     editor.commands.applySuggestion({
       id: "root-reject",
-      targetBlockId: INSTRUCTIONS_ROOT_ID,
+      targetBlockId: INSTRUCTIONS_ROOT_TARGET_BLOCK_ID,
       content: `<div data-type="instructions-root"><p>Nope</p></div>`,
     });
 
@@ -947,7 +945,9 @@ describe("Root-targeting suggestions", () => {
 
       // Find the paragraph's block-id (not the instructionsRoot).
       const ids = getBlockIds(editor);
-      const paragraphBlockId = ids.find((id) => id !== INSTRUCTIONS_ROOT_ID);
+      const paragraphBlockId = ids.find(
+        (id) => id !== INSTRUCTIONS_ROOT_TARGET_BLOCK_ID
+      );
       expect(paragraphBlockId).toBeDefined();
 
       // In the root-constrained schema, parsing "<p>Hello there</p>" produces
@@ -979,7 +979,9 @@ describe("Root-targeting suggestions", () => {
       editor.commands.setContent("Hello world", { contentType: "markdown" });
 
       const ids = getBlockIds(editor);
-      const paragraphBlockId = ids.find((id) => id !== INSTRUCTIONS_ROOT_ID);
+      const paragraphBlockId = ids.find(
+        (id) => id !== INSTRUCTIONS_ROOT_TARGET_BLOCK_ID
+      );
       expect(paragraphBlockId).toBeDefined();
 
       editor.commands.applySuggestion({
@@ -1005,7 +1007,7 @@ describe("Root-targeting suggestions", () => {
       // instructionsRoot inside the parsed result.
       editor.commands.applySuggestion({
         id: "child-bullet-deco",
-        targetBlockId: INSTRUCTIONS_ROOT_ID,
+        targetBlockId: INSTRUCTIONS_ROOT_TARGET_BLOCK_ID,
         content: `<div data-type="instructions-root"><ul><li><p>Changed item</p></li><li><p>Item two</p></li></ul></div>`,
       });
 

--- a/front/components/editor/extensions/agent_builder/InstructionsRootExtension.test.ts
+++ b/front/components/editor/extensions/agent_builder/InstructionsRootExtension.test.ts
@@ -2,11 +2,9 @@ import type { Editor } from "@tiptap/core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { InstructionsDocumentExtension } from "@app/components/editor/extensions/agent_builder/InstructionsDocumentExtension";
-import {
-  INSTRUCTIONS_ROOT_DATA_TYPE,
-  InstructionsRootExtension,
-} from "@app/components/editor/extensions/agent_builder/InstructionsRootExtension";
+import { InstructionsRootExtension } from "@app/components/editor/extensions/agent_builder/InstructionsRootExtension";
 import { EditorFactory } from "@app/components/editor/extensions/tests/utils";
+import { INSTRUCTIONS_ROOT_TARGET_BLOCK_ID } from "@app/types/suggestions/agent_suggestion";
 
 describe("InstructionsRootExtension serialization", () => {
   let editor: Editor;
@@ -35,7 +33,7 @@ describe("InstructionsRootExtension serialization", () => {
 
     const html = editor.getHTML();
 
-    expect(html).toContain(`data-type="${INSTRUCTIONS_ROOT_DATA_TYPE}"`);
+    expect(html).toContain(`data-type="${INSTRUCTIONS_ROOT_TARGET_BLOCK_ID}"`);
     expect(html).toContain("<p>Hello world</p>");
   });
 

--- a/front/components/editor/extensions/agent_builder/InstructionsRootExtension.tsx
+++ b/front/components/editor/extensions/agent_builder/InstructionsRootExtension.tsx
@@ -1,10 +1,10 @@
 import { Node } from "@tiptap/core";
 
+import { INSTRUCTIONS_ROOT_TARGET_BLOCK_ID } from "@app/types/suggestions/agent_suggestion";
+
 import { BLOCK_ID_ATTRIBUTE } from "./BlockIdExtension";
 
 export const INSTRUCTIONS_ROOT_NODE_NAME = "instructionsRoot";
-export const INSTRUCTIONS_ROOT_DATA_TYPE = "instructions-root";
-export const INSTRUCTIONS_ROOT_ID = INSTRUCTIONS_ROOT_DATA_TYPE;
 
 // Wrapper node that sits between doc and the block-level content.
 // Carries a stable block-id so the copilot can target it to replace
@@ -17,26 +17,26 @@ export const InstructionsRootExtension = Node.create({
   addAttributes() {
     return {
       [BLOCK_ID_ATTRIBUTE]: {
-        default: INSTRUCTIONS_ROOT_ID,
+        default: INSTRUCTIONS_ROOT_TARGET_BLOCK_ID,
         parseHTML: (element) =>
           element.getAttribute(`data-${BLOCK_ID_ATTRIBUTE}`) ??
-          INSTRUCTIONS_ROOT_ID,
+          INSTRUCTIONS_ROOT_TARGET_BLOCK_ID,
         renderHTML: (attributes) => ({
           [`data-${BLOCK_ID_ATTRIBUTE}`]:
-            attributes[BLOCK_ID_ATTRIBUTE] ?? INSTRUCTIONS_ROOT_ID,
+            attributes[BLOCK_ID_ATTRIBUTE] ?? INSTRUCTIONS_ROOT_TARGET_BLOCK_ID,
         }),
       },
     };
   },
 
   parseHTML() {
-    return [{ tag: `div[data-type='${INSTRUCTIONS_ROOT_DATA_TYPE}']` }];
+    return [{ tag: `div[data-type='${INSTRUCTIONS_ROOT_TARGET_BLOCK_ID}']` }];
   },
 
   renderHTML({ HTMLAttributes }) {
     return [
       "div",
-      { "data-type": INSTRUCTIONS_ROOT_DATA_TYPE, ...HTMLAttributes },
+      { "data-type": INSTRUCTIONS_ROOT_TARGET_BLOCK_ID, ...HTMLAttributes },
       0,
     ];
   },

--- a/front/components/markdown/suggestion/CopilotSuggestionCard.tsx
+++ b/front/components/markdown/suggestion/CopilotSuggestionCard.tsx
@@ -462,17 +462,17 @@ export function SuggestionCardSkeleton({ kind }: SuggestionCardSkeletonProps) {
   );
 }
 
-export function SuggestionCardError() {
+export function SuggestionCardNotFound() {
   return (
     <div className="mb-2 inline-block w-full max-w-md align-top">
       <ContentMessage
-        title="Failed to load suggestion"
+        title="Suggestion not found"
         icon={ExclamationCircleIcon}
         variant="warning"
         size="sm"
       >
         <span className="text-sm">
-          The suggestion could not be loaded. Please try refreshing the page.
+          This suggestion is outdated or has been deleted.
         </span>
       </ContentMessage>
     </div>

--- a/front/components/markdown/suggestion/CopilotSuggestionDirective.tsx
+++ b/front/components/markdown/suggestion/CopilotSuggestionDirective.tsx
@@ -11,7 +11,7 @@ import { visit } from "unist-util-visit";
 import { useCopilotSuggestions } from "@app/components/agent_builder/copilot/CopilotSuggestionsContext";
 import {
   CopilotSuggestionCard,
-  SuggestionCardError,
+  SuggestionCardNotFound,
   SuggestionCardSkeleton,
 } from "@app/components/markdown/suggestion/CopilotSuggestionCard";
 import type { AgentSuggestionKind } from "@app/types/suggestions/agent_suggestion";
@@ -91,7 +91,7 @@ export function getCopilotSuggestionPlugin() {
       if (isSuggestionsValidating || !hasAttemptedRefetch(sId)) {
         return <SuggestionCardSkeleton kind={kind} />;
       }
-      return <SuggestionCardError />;
+      return <SuggestionCardNotFound />;
     }
 
     return <CopilotSuggestionCard agentSuggestion={suggestion} />;

--- a/front/lib/api/actions/servers/agent_copilot_context/metadata.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/metadata.ts
@@ -9,6 +9,7 @@ import { REASONING_EFFORTS } from "@app/types/assistant/models/reasoning";
 import {
   AGENT_SUGGESTION_KINDS,
   AGENT_SUGGESTION_STATES,
+  INSTRUCTIONS_ROOT_TARGET_BLOCK_ID,
 } from "@app/types/suggestions/agent_suggestion";
 
 export const AGENT_COPILOT_CONTEXT_TOOL_NAME = "agent_copilot_context" as const;
@@ -178,7 +179,7 @@ export const AGENT_COPILOT_CONTEXT_TOOLS_METADATA = createToolsRecord({
       "Create suggestions to modify the agent's instructions/prompt using block-based targeting. " +
       "The instructions HTML contains blocks with data-block-id attributes (e.g., 'a3f1b20e'). " +
       "Each suggestion targets a specific block by its ID and provides the full replacement HTML for that block. " +
-      "Each block ID must appear at most once. For full rewrites, use targetBlockId 'instructions-root'. " +
+      `Each block ID must appear at most once. For full rewrites, use targetBlockId '${INSTRUCTIONS_ROOT_TARGET_BLOCK_ID}'. ` +
       "Word-level diffs will be computed and displayed inline. " +
       "IMPORTANT: Include the tool output verbatim in your response - it renders as interactive card(s).",
     schema: {

--- a/front/lib/api/actions/servers/agent_copilot_context/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/tools/index.ts
@@ -52,6 +52,7 @@ import type {
   ToolsSuggestionType,
 } from "@app/types/suggestions/agent_suggestion";
 import {
+  INSTRUCTIONS_ROOT_TARGET_BLOCK_ID,
   isSkillsSuggestion,
   isSubAgentSuggestion,
   isToolsSuggestion,
@@ -662,7 +663,7 @@ const handlers: ToolHandlers<typeof AGENT_COPILOT_CONTEXT_TOOLS_METADATA> = {
       return new Err(
         new MCPError(
           "Multiple suggestions target the same block ID. Use a single suggestion per block." +
-            "For full rewrites, target 'instructions-root' instead.",
+            `For full rewrites, target '${INSTRUCTIONS_ROOT_TARGET_BLOCK_ID}' instead.`,
           { tracked: false }
         )
       );
@@ -736,7 +737,7 @@ const handlers: ToolHandlers<typeof AGENT_COPILOT_CONTEXT_TOOLS_METADATA> = {
 
     await pruneConflictingInstructionSuggestions(
       auth,
-      agentConfiguration.sId,
+      agentConfiguration,
       createdSuggestions
     );
 

--- a/front/lib/api/assistant/agent_suggestion_pruning.test.ts
+++ b/front/lib/api/assistant/agent_suggestion_pruning.test.ts
@@ -351,372 +351,447 @@ describe("pruneSuggestionsForAgent", () => {
     });
   });
 
-  // TODO(2026-02-05 COPILOT): Add tests for instructions suggestions once implemented.
   describe("instructions suggestions", () => {
-    // it.skip("should mark suggestion as outdated when oldString is not in current instructions", async () => {
-    //   const suggestion = await AgentSuggestionFactory.createInstructions(
-    //     authenticator,
-    //     agentConfiguration,
-    //     {
-    //       suggestion: {
-    //         oldString: "This text does not exist",
-    //         newString: "New text",
-    //       },
-    //     }
-    //   );
-    //   const fullAgent = await getFullAgentConfiguration(
-    //     authenticator,
-    //     agentConfiguration.sId
-    //   );
-    //   await pruneSuggestionsForAgent(authenticator, fullAgent);
-    //   const fetched = await AgentSuggestionResource.fetchById(
-    //     authenticator,
-    //     suggestion.sId
-    //   );
-    //   expect(fetched?.state).toBe("outdated");
-    // });
-    // it.skip("should not mark suggestion as outdated when oldString exists in instructions", async () => {
-    //   // The agent has "Test Instructions" as its instructions.
-    //   const suggestion = await AgentSuggestionFactory.createInstructions(
-    //     authenticator,
-    //     agentConfiguration,
-    //     {
-    //       suggestion: {
-    //         oldString: "Test Instructions",
-    //         newString: "Updated Instructions",
-    //       },
-    //     }
-    //   );
-    //   const fullAgent = await getFullAgentConfiguration(
-    //     authenticator,
-    //     agentConfiguration.sId
-    //   );
-    //   await pruneSuggestionsForAgent(authenticator, fullAgent);
-    //   const fetched = await AgentSuggestionResource.fetchById(
-    //     authenticator,
-    //     suggestion.sId
-    //   );
-    //   expect(fetched?.state).toBe("pending");
-    // });
-    // it.skip("should handle multiple non-overlapping suggestions correctly", async () => {
-    //   // Create an agent with longer instructions.
-    //   const agentWithLongInstructions =
-    //     await AgentConfigurationFactory.updateTestAgent(
-    //       authenticator,
-    //       agentConfiguration.sId,
-    //       {
-    //         instructions: "Part A content. Part B content.",
-    //       }
-    //     );
-    //   // Create two non-overlapping suggestions (most recent first in list).
-    //   const suggestion1 = await AgentSuggestionFactory.createInstructions(
-    //     authenticator,
-    //     agentWithLongInstructions,
-    //     {
-    //       suggestion: {
-    //         oldString: "Part A content",
-    //         newString: "Modified Part A",
-    //       },
-    //     }
-    //   );
-    //   const suggestion2 = await AgentSuggestionFactory.createInstructions(
-    //     authenticator,
-    //     agentWithLongInstructions,
-    //     {
-    //       suggestion: {
-    //         oldString: "Part B content",
-    //         newString: "Modified Part B",
-    //       },
-    //     }
-    //   );
-    //   const fullAgent = await getFullAgentConfiguration(
-    //     authenticator,
-    //     agentWithLongInstructions.sId
-    //   );
-    //   await pruneSuggestionsForAgent(authenticator, fullAgent);
-    //   const fetched1 = await AgentSuggestionResource.fetchById(
-    //     authenticator,
-    //     suggestion1.sId
-    //   );
-    //   const fetched2 = await AgentSuggestionResource.fetchById(
-    //     authenticator,
-    //     suggestion2.sId
-    //   );
-    //   // Both should still be pending as they don't overlap.
-    //   expect(fetched1?.state).toBe("pending");
-    //   expect(fetched2?.state).toBe("pending");
-    // });
-    // it.skip("should mark overlapping suggestion as outdated", async () => {
-    //   // Create an agent with specific instructions.
-    //   const agentWithInstructions =
-    //     await AgentConfigurationFactory.updateTestAgent(
-    //       authenticator,
-    //       agentConfiguration.sId,
-    //       {
-    //         instructions: "Hello World",
-    //       }
-    //     );
-    //   // First suggestion (created earlier, processed later) targets "World".
-    //   const suggestion1 = await AgentSuggestionFactory.createInstructions(
-    //     authenticator,
-    //     agentWithInstructions,
-    //     {
-    //       suggestion: {
-    //         oldString: "World",
-    //         newString: "Universe",
-    //       },
-    //     }
-    //   );
-    //   // Wait a bit to ensure different timestamps.
-    //   await new Promise((resolve) => setTimeout(resolve, 10));
-    //   // Second suggestion (created later, processed first) targets "Hello World" - overlaps with first.
-    //   const suggestion2 = await AgentSuggestionFactory.createInstructions(
-    //     authenticator,
-    //     agentWithInstructions,
-    //     {
-    //       suggestion: {
-    //         oldString: "Hello World",
-    //         newString: "Greetings Universe",
-    //       },
-    //     }
-    //   );
-    //   const fullAgent = await getFullAgentConfiguration(
-    //     authenticator,
-    //     agentWithInstructions.sId
-    //   );
-    //   await pruneSuggestionsForAgent(authenticator, fullAgent);
-    //   const fetched1 = await AgentSuggestionResource.fetchById(
-    //     authenticator,
-    //     suggestion1.sId
-    //   );
-    //   const fetched2 = await AgentSuggestionResource.fetchById(
-    //     authenticator,
-    //     suggestion2.sId
-    //   );
-    //   // Suggestion2 (most recent) is processed first and applies.
-    //   expect(fetched2?.state).toBe("pending");
-    //   // Suggestion1 (older) cannot apply because the text is now changed.
-    //   expect(fetched1?.state).toBe("outdated");
-    // });
-    // it.skip("should shift regions correctly when earlier suggestion changes text length", async () => {
-    //   // Create an agent with specific instructions.
-    //   const agentWithInstructions =
-    //     await AgentConfigurationFactory.updateTestAgent(
-    //       authenticator,
-    //       agentConfiguration.sId,
-    //       {
-    //         instructions: "ABC DEF GHI",
-    //       }
-    //     );
-    //   // Older suggestion targets "GHI" at the end.
-    //   const suggestion1 = await AgentSuggestionFactory.createInstructions(
-    //     authenticator,
-    //     agentWithInstructions,
-    //     {
-    //       suggestion: {
-    //         oldString: "GHI",
-    //         newString: "JKL",
-    //       },
-    //     }
-    //   );
-    //   await new Promise((resolve) => setTimeout(resolve, 10));
-    //   // Newer suggestion targets "ABC" at the beginning.
-    //   // This should still apply, and the region for "GHI" should shift.
-    //   const suggestion2 = await AgentSuggestionFactory.createInstructions(
-    //     authenticator,
-    //     agentWithInstructions,
-    //     {
-    //       suggestion: {
-    //         oldString: "ABC",
-    //         newString: "ABCXYZ", // Longer replacement
-    //       },
-    //     }
-    //   );
-    //   const fullAgent = await getFullAgentConfiguration(
-    //     authenticator,
-    //     agentWithInstructions.sId
-    //   );
-    //   await pruneSuggestionsForAgent(authenticator, fullAgent);
-    //   const fetched1 = await AgentSuggestionResource.fetchById(
-    //     authenticator,
-    //     suggestion1.sId
-    //   );
-    //   const fetched2 = await AgentSuggestionResource.fetchById(
-    //     authenticator,
-    //     suggestion2.sId
-    //   );
-    //   // Both should still be pending - they edit different parts.
-    //   expect(fetched1?.state).toBe("pending");
-    //   expect(fetched2?.state).toBe("pending");
-    // });
-    // it.skip("should mark suggestion as outdated when expectedOccurrences does not match", async () => {
-    //   // Create an agent with repeated text.
-    //   const agentWithRepeatedText =
-    //     await AgentConfigurationFactory.updateTestAgent(
-    //       authenticator,
-    //       agentConfiguration.sId,
-    //       {
-    //         instructions: "test test test",
-    //       }
-    //     );
-    //   // Suggestion expects 2 occurrences but there are 3.
-    //   const suggestion = await AgentSuggestionFactory.createInstructions(
-    //     authenticator,
-    //     agentWithRepeatedText,
-    //     {
-    //       suggestion: {
-    //         oldString: "test",
-    //         newString: "TEST",
-    //         expectedOccurrences: 2,
-    //       },
-    //     }
-    //   );
-    //   const fullAgent = await getFullAgentConfiguration(
-    //     authenticator,
-    //     agentWithRepeatedText.sId
-    //   );
-    //   await pruneSuggestionsForAgent(authenticator, fullAgent);
-    //   const fetched = await AgentSuggestionResource.fetchById(
-    //     authenticator,
-    //     suggestion.sId
-    //   );
-    //   expect(fetched?.state).toBe("outdated");
-    // });
-    // it.skip("should handle multiple occurrences correctly when count matches", async () => {
-    //   // Create an agent with repeated text.
-    //   const agentWithRepeatedText =
-    //     await AgentConfigurationFactory.updateTestAgent(
-    //       authenticator,
-    //       agentConfiguration.sId,
-    //       {
-    //         instructions: "foo bar foo baz foo",
-    //       }
-    //     );
-    //   // Suggestion expects 3 occurrences and there are exactly 3.
-    //   const suggestion = await AgentSuggestionFactory.createInstructions(
-    //     authenticator,
-    //     agentWithRepeatedText,
-    //     {
-    //       suggestion: {
-    //         oldString: "foo",
-    //         newString: "FOO",
-    //         expectedOccurrences: 3,
-    //       },
-    //     }
-    //   );
-    //   const fullAgent = await getFullAgentConfiguration(
-    //     authenticator,
-    //     agentWithRepeatedText.sId
-    //   );
-    //   await pruneSuggestionsForAgent(authenticator, fullAgent);
-    //   const fetched = await AgentSuggestionResource.fetchById(
-    //     authenticator,
-    //     suggestion.sId
-    //   );
-    //   // Should still be pending since it can be applied (all 3 occurrences exist).
-    //   expect(fetched?.state).toBe("pending");
-    // });
-    // it.skip("should handle multiple occurrences with another suggestion overlapping one", async () => {
-    //   // Create an agent with repeated text.
-    //   const agentWithRepeatedText =
-    //     await AgentConfigurationFactory.updateTestAgent(
-    //       authenticator,
-    //       agentConfiguration.sId,
-    //       {
-    //         instructions: "AAA BBB AAA",
-    //       }
-    //     );
-    //   // Older suggestion targets the middle part "BBB".
-    //   const suggestion1 = await AgentSuggestionFactory.createInstructions(
-    //     authenticator,
-    //     agentWithRepeatedText,
-    //     {
-    //       suggestion: {
-    //         oldString: "BBB",
-    //         newString: "CCC",
-    //       },
-    //     }
-    //   );
-    //   await new Promise((resolve) => setTimeout(resolve, 10));
-    //   // Newer suggestion targets "AAA" (2 occurrences).
-    //   const suggestion2 = await AgentSuggestionFactory.createInstructions(
-    //     authenticator,
-    //     agentWithRepeatedText,
-    //     {
-    //       suggestion: {
-    //         oldString: "AAA",
-    //         newString: "XXX",
-    //         expectedOccurrences: 2,
-    //       },
-    //     }
-    //   );
-    //   const fullAgent = await getFullAgentConfiguration(
-    //     authenticator,
-    //     agentWithRepeatedText.sId
-    //   );
-    //   await pruneSuggestionsForAgent(authenticator, fullAgent);
-    //   const fetched1 = await AgentSuggestionResource.fetchById(
-    //     authenticator,
-    //     suggestion1.sId
-    //   );
-    //   const fetched2 = await AgentSuggestionResource.fetchById(
-    //     authenticator,
-    //     suggestion2.sId
-    //   );
-    //   // Both should be pending - AAA regions don't overlap with BBB region.
-    //   expect(fetched1?.state).toBe("pending");
-    //   expect(fetched2?.state).toBe("pending");
-    // });
-    // it.skip("should not mark suggestions as outdated when source regions overlap but changes don't", async () => {
-    //   // Create an agent with specific instructions.
-    //   const agentWithInstructions =
-    //     await AgentConfigurationFactory.updateTestAgent(
-    //       authenticator,
-    //       agentConfiguration.sId,
-    //       {
-    //         instructions: "ABCDE",
-    //       }
-    //     );
-    //   // Older suggestion targets "ABC" and changes B to X.
-    //   const suggestion1 = await AgentSuggestionFactory.createInstructions(
-    //     authenticator,
-    //     agentWithInstructions,
-    //     {
-    //       suggestion: {
-    //         oldString: "ABC",
-    //         newString: "AXXXXXC",
-    //       },
-    //     }
-    //   );
-    //   await new Promise((resolve) => setTimeout(resolve, 10));
-    //   // Newer suggestion targets "CDE" and changes D to Y.
-    //   // The source regions overlap at "C", but "C" is unchanged in both suggestions.
-    //   const suggestion2 = await AgentSuggestionFactory.createInstructions(
-    //     authenticator,
-    //     agentWithInstructions,
-    //     {
-    //       suggestion: {
-    //         oldString: "CDE",
-    //         newString: "CYYYYYE",
-    //       },
-    //     }
-    //   );
-    //   const fullAgent = await getFullAgentConfiguration(
-    //     authenticator,
-    //     agentWithInstructions.sId
-    //   );
-    //   await pruneSuggestionsForAgent(authenticator, fullAgent);
-    //   const fetched1 = await AgentSuggestionResource.fetchById(
-    //     authenticator,
-    //     suggestion1.sId
-    //   );
-    //   const fetched2 = await AgentSuggestionResource.fetchById(
-    //     authenticator,
-    //     suggestion2.sId
-    //   );
-    //   // Both should remain pending since the actual changes don't overlap.
-    //   expect(fetched1?.state).toBe("pending");
-    //   expect(fetched2?.state).toBe("pending");
-    // });
+    it("should mark suggestion as outdated when target block ID does not exist", async () => {
+      const agentWithInstructions =
+        await AgentConfigurationFactory.updateTestAgent(
+          authenticator,
+          agentConfiguration.sId,
+          {
+            instructionsHtml:
+              '<p data-block-id="abc12345">You are a helpful assistant.</p>',
+          }
+        );
+
+      // Create a suggestion targeting a different block ID
+      const suggestion = await AgentSuggestionFactory.createInstructions(
+        authenticator,
+        agentWithInstructions,
+        {
+          suggestion: {
+            targetBlockId: "xyz99999",
+            content: "<p>New instructions</p>",
+            type: "replace",
+          },
+        }
+      );
+
+      const fullAgent = await getFullAgentConfiguration(
+        authenticator,
+        agentWithInstructions.sId
+      );
+
+      await pruneSuggestionsForAgent(authenticator, fullAgent);
+
+      const fetched = await AgentSuggestionResource.fetchById(
+        authenticator,
+        suggestion.sId
+      );
+      expect(fetched?.state).toBe("outdated");
+    });
+
+    it("should not mark suggestion as outdated when target block ID exists", async () => {
+      const agentWithInstructions =
+        await AgentConfigurationFactory.updateTestAgent(
+          authenticator,
+          agentConfiguration.sId,
+          {
+            instructionsHtml:
+              '<p data-block-id="abc12345">You are a helpful assistant.</p>',
+          }
+        );
+
+      // Create a suggestion targeting the existing block ID
+      const suggestion = await AgentSuggestionFactory.createInstructions(
+        authenticator,
+        agentWithInstructions,
+        {
+          suggestion: {
+            targetBlockId: "abc12345",
+            content: "<p>You are an expert assistant.</p>",
+            type: "replace",
+          },
+        }
+      );
+
+      const fullAgent = await getFullAgentConfiguration(
+        authenticator,
+        agentWithInstructions.sId
+      );
+
+      await pruneSuggestionsForAgent(authenticator, fullAgent);
+
+      const fetched = await AgentSuggestionResource.fetchById(
+        authenticator,
+        suggestion.sId
+      );
+      expect(fetched?.state).toBe("pending");
+    });
+
+    it("should not mark suggestion as outdated for instructions-root target", async () => {
+      const agentWithInstructions =
+        await AgentConfigurationFactory.updateTestAgent(
+          authenticator,
+          agentConfiguration.sId,
+          {
+            instructionsHtml:
+              '<p data-block-id="abc12345">You are a helpful assistant.</p>',
+          }
+        );
+
+      const suggestion = await AgentSuggestionFactory.createInstructions(
+        authenticator,
+        agentWithInstructions,
+        {
+          suggestion: {
+            targetBlockId: "instructions-root",
+            content: "<p>Completely new instructions</p>",
+            type: "replace",
+          },
+        }
+      );
+
+      const fullAgent = await getFullAgentConfiguration(
+        authenticator,
+        agentWithInstructions.sId
+      );
+
+      await pruneSuggestionsForAgent(authenticator, fullAgent);
+
+      const fetched = await AgentSuggestionResource.fetchById(
+        authenticator,
+        suggestion.sId
+      );
+      expect(fetched?.state).toBe("pending");
+    });
+
+    it("should mark all suggestions as outdated when instructions are null", async () => {
+      const agentWithoutInstructions =
+        await AgentConfigurationFactory.updateTestAgent(
+          authenticator,
+          agentConfiguration.sId,
+          {
+            instructionsHtml: null,
+          }
+        );
+
+      const suggestion = await AgentSuggestionFactory.createInstructions(
+        authenticator,
+        agentWithoutInstructions,
+        {
+          suggestion: {
+            targetBlockId: "abc12345",
+            content: "<p>New instructions</p>",
+            type: "replace",
+          },
+        }
+      );
+
+      const fullAgent = await getFullAgentConfiguration(
+        authenticator,
+        agentWithoutInstructions.sId
+      );
+
+      await pruneSuggestionsForAgent(authenticator, fullAgent);
+
+      const fetched = await AgentSuggestionResource.fetchById(
+        authenticator,
+        suggestion.sId
+      );
+      expect(fetched?.state).toBe("outdated");
+    });
+
+    it("should handle multiple block IDs correctly", async () => {
+      const agentWithMultipleBlocks =
+        await AgentConfigurationFactory.updateTestAgent(
+          authenticator,
+          agentConfiguration.sId,
+          {
+            instructionsHtml:
+              '<p data-block-id="block001">First paragraph.</p><p data-block-id="block002">Second paragraph.</p><h2 data-block-id="block003">Heading</h2>',
+          }
+        );
+
+      const suggestion1 = await AgentSuggestionFactory.createInstructions(
+        authenticator,
+        agentWithMultipleBlocks,
+        {
+          suggestion: {
+            targetBlockId: "block002",
+            content: "<p>Updated second paragraph.</p>",
+            type: "replace",
+          },
+        }
+      );
+
+      const suggestion2 = await AgentSuggestionFactory.createInstructions(
+        authenticator,
+        agentWithMultipleBlocks,
+        {
+          suggestion: {
+            targetBlockId: "block999",
+            content: "<p>New content.</p>",
+            type: "replace",
+          },
+        }
+      );
+
+      const fullAgent = await getFullAgentConfiguration(
+        authenticator,
+        agentWithMultipleBlocks.sId
+      );
+
+      await pruneSuggestionsForAgent(authenticator, fullAgent);
+
+      const fetched1 = await AgentSuggestionResource.fetchById(
+        authenticator,
+        suggestion1.sId
+      );
+      const fetched2 = await AgentSuggestionResource.fetchById(
+        authenticator,
+        suggestion2.sId
+      );
+
+      expect(fetched1?.state).toBe("pending");
+      expect(fetched2?.state).toBe("outdated");
+    });
+
+    it("should not mark suggestions as outdated based on conflicts (handled at creation time)", async () => {
+      // Note: Conflict resolution (root vs blocks, duplicate blocks) now happens
+      // at suggestion creation time via pruneConflictingInstructionSuggestions().
+      // pruneSuggestionsForAgent only checks for missing block IDs.
+
+      // Create an agent with some blocks
+      const agentWithBlocks = await AgentConfigurationFactory.updateTestAgent(
+        authenticator,
+        agentConfiguration.sId,
+        {
+          instructionsHtml:
+            '<p data-block-id="block001">First.</p><p data-block-id="block002">Second.</p>',
+        }
+      );
+
+      // Create a block-specific suggestion first
+      const blockSuggestion = await AgentSuggestionFactory.createInstructions(
+        authenticator,
+        agentWithBlocks,
+        {
+          suggestion: {
+            targetBlockId: "block001",
+            content: "<p>Updated first.</p>",
+            type: "replace",
+          },
+        }
+      );
+
+      // Create an instructions-root suggestion - conflict detection doesn't happen here
+      const rootSuggestion = await AgentSuggestionFactory.createInstructions(
+        authenticator,
+        agentWithBlocks,
+        {
+          suggestion: {
+            targetBlockId: "instructions-root",
+            content:
+              '<div data-type="instructions-root"><p>Completely new instructions.</p></div>',
+            type: "replace",
+          },
+        }
+      );
+
+      const fullAgent = await getFullAgentConfiguration(
+        authenticator,
+        agentWithBlocks.sId
+      );
+
+      await pruneSuggestionsForAgent(authenticator, fullAgent);
+
+      const fetchedBlock = await AgentSuggestionResource.fetchById(
+        authenticator,
+        blockSuggestion.sId
+      );
+      const fetchedRoot = await AgentSuggestionResource.fetchById(
+        authenticator,
+        rootSuggestion.sId
+      );
+
+      expect(fetchedBlock?.state).toBe("pending");
+      expect(fetchedRoot?.state).toBe("pending");
+    });
+  });
+
+  describe("pruneConflictingInstructionSuggestions (hierarchy-aware)", () => {
+    it("should mark child block suggestions as outdated when parent block suggestion is created", async () => {
+      // Create nested structure: parent instructionBlock with child paragraphs
+      const agentWithNested = await AgentConfigurationFactory.updateTestAgent(
+        authenticator,
+        agentConfiguration.sId,
+        {
+          instructionsHtml:
+            '<div data-instruction-type="context" data-block-id="parent">' +
+            '<p data-block-id="child1">First child.</p>' +
+            '<p data-block-id="child2">Second child.</p>' +
+            "</div>",
+        }
+      );
+
+      // Create suggestions for the child blocks first
+      const childSuggestion1 = await AgentSuggestionFactory.createInstructions(
+        authenticator,
+        agentWithNested,
+        {
+          suggestion: {
+            targetBlockId: "child1",
+            content: "<p>Modified first child.</p>",
+            type: "replace",
+          },
+        }
+      );
+
+      const childSuggestion2 = await AgentSuggestionFactory.createInstructions(
+        authenticator,
+        agentWithNested,
+        {
+          suggestion: {
+            targetBlockId: "child2",
+            content: "<p>Modified second child.</p>",
+            type: "replace",
+          },
+        }
+      );
+
+      // Both child suggestions should be pending initially
+      expect(childSuggestion1.state).toBe("pending");
+      expect(childSuggestion2.state).toBe("pending");
+
+      // Now create a suggestion for the parent block
+      const parentSuggestion = await AgentSuggestionFactory.createInstructions(
+        authenticator,
+        agentWithNested,
+        {
+          suggestion: {
+            targetBlockId: "parent",
+            content:
+              '<div data-instruction-type="context">' +
+              "<p>Completely new parent content.</p>" +
+              "</div>",
+            type: "replace",
+          },
+        }
+      );
+
+      // Manually trigger conflict pruning (in production, suggest_prompt_edits does this)
+      const { pruneConflictingInstructionSuggestions } = await import(
+        "@app/lib/api/assistant/agent_suggestion_pruning"
+      );
+      await pruneConflictingInstructionSuggestions(
+        authenticator,
+        agentWithNested.sId,
+        [{ sId: parentSuggestion.sId, targetBlockId: "parent" }]
+      );
+
+      // Refetch the child suggestions
+      const fetchedChild1 = await AgentSuggestionResource.fetchById(
+        authenticator,
+        childSuggestion1.sId
+      );
+      const fetchedChild2 = await AgentSuggestionResource.fetchById(
+        authenticator,
+        childSuggestion2.sId
+      );
+
+      // Child suggestions should be outdated (parent will replace them)
+      expect(fetchedChild1?.state).toBe("outdated");
+      expect(fetchedChild2?.state).toBe("outdated");
+
+      // Parent suggestion should remain pending
+      expect(parentSuggestion.state).toBe("pending");
+    });
+
+    it("should mark all block suggestions as outdated when instructions-root suggestion is created", async () => {
+      // Create agent with blocks
+      const agentWithBlocks = await AgentConfigurationFactory.updateTestAgent(
+        authenticator,
+        agentConfiguration.sId,
+        {
+          instructionsHtml:
+            '<p data-block-id="block1">First.</p><p data-block-id="block2">Second.</p>',
+        }
+      );
+
+      // Create suggestions for individual blocks
+      const blockSuggestion1 = await AgentSuggestionFactory.createInstructions(
+        authenticator,
+        agentWithBlocks,
+        {
+          suggestion: {
+            targetBlockId: "block1",
+            content: "<p>Modified first.</p>",
+            type: "replace",
+          },
+        }
+      );
+
+      const blockSuggestion2 = await AgentSuggestionFactory.createInstructions(
+        authenticator,
+        agentWithBlocks,
+        {
+          suggestion: {
+            targetBlockId: "block2",
+            content: "<p>Modified second.</p>",
+            type: "replace",
+          },
+        }
+      );
+
+      // Both should be pending initially
+      expect(blockSuggestion1.state).toBe("pending");
+      expect(blockSuggestion2.state).toBe("pending");
+
+      // Create instructions-root suggestion (full rewrite)
+      const rootSuggestion = await AgentSuggestionFactory.createInstructions(
+        authenticator,
+        agentWithBlocks,
+        {
+          suggestion: {
+            targetBlockId: "instructions-root",
+            content:
+              '<div data-type="instructions-root"><p>Brand new instructions.</p></div>',
+            type: "replace",
+          },
+        }
+      );
+
+      // Manually trigger conflict pruning (in production, suggest_prompt_edits does this)
+      const { pruneConflictingInstructionSuggestions } = await import(
+        "@app/lib/api/assistant/agent_suggestion_pruning"
+      );
+      await pruneConflictingInstructionSuggestions(
+        authenticator,
+        agentWithBlocks.sId,
+        [
+          {
+            sId: rootSuggestion.sId,
+            targetBlockId: "instructions-root",
+          },
+        ]
+      );
+
+      // Refetch block suggestions
+      const fetchedBlock1 = await AgentSuggestionResource.fetchById(
+        authenticator,
+        blockSuggestion1.sId
+      );
+      const fetchedBlock2 = await AgentSuggestionResource.fetchById(
+        authenticator,
+        blockSuggestion2.sId
+      );
+
+      // All block suggestions should be outdated (root replaces everything)
+      expect(fetchedBlock1?.state).toBe("outdated");
+      expect(fetchedBlock2?.state).toBe("outdated");
+
+      // Root suggestion should remain pending
+      expect(rootSuggestion.state).toBe("pending");
+    });
   });
 });

--- a/front/lib/api/assistant/agent_suggestion_pruning.test.ts
+++ b/front/lib/api/assistant/agent_suggestion_pruning.test.ts
@@ -12,6 +12,7 @@ import type {
   AgentConfigurationType,
   LightAgentConfigurationType,
 } from "@app/types";
+import { INSTRUCTIONS_ROOT_TARGET_BLOCK_ID } from "@app/types/suggestions/agent_suggestion";
 
 async function getFullAgentConfiguration(
   auth: Authenticator,
@@ -444,7 +445,7 @@ describe("pruneSuggestionsForAgent", () => {
         agentWithInstructions,
         {
           suggestion: {
-            targetBlockId: "instructions-root",
+            targetBlockId: INSTRUCTIONS_ROOT_TARGET_BLOCK_ID,
             content: "<p>Completely new instructions</p>",
             type: "replace",
           },
@@ -590,9 +591,8 @@ describe("pruneSuggestionsForAgent", () => {
         agentWithBlocks,
         {
           suggestion: {
-            targetBlockId: "instructions-root",
-            content:
-              '<div data-type="instructions-root"><p>Completely new instructions.</p></div>',
+            targetBlockId: INSTRUCTIONS_ROOT_TARGET_BLOCK_ID,
+            content: `<div data-type="${INSTRUCTIONS_ROOT_TARGET_BLOCK_ID}"><p>Completely new instructions.</p></div>`,
             type: "replace",
           },
         }
@@ -685,7 +685,7 @@ describe("pruneSuggestionsForAgent", () => {
       );
       await pruneConflictingInstructionSuggestions(
         authenticator,
-        agentWithNested.sId,
+        agentWithNested,
         [{ sId: parentSuggestion.sId, targetBlockId: "parent" }]
       );
 
@@ -753,9 +753,8 @@ describe("pruneSuggestionsForAgent", () => {
         agentWithBlocks,
         {
           suggestion: {
-            targetBlockId: "instructions-root",
-            content:
-              '<div data-type="instructions-root"><p>Brand new instructions.</p></div>',
+            targetBlockId: INSTRUCTIONS_ROOT_TARGET_BLOCK_ID,
+            content: `<div data-type="${INSTRUCTIONS_ROOT_TARGET_BLOCK_ID}"><p>Brand new instructions.</p></div>`,
             type: "replace",
           },
         }
@@ -767,11 +766,11 @@ describe("pruneSuggestionsForAgent", () => {
       );
       await pruneConflictingInstructionSuggestions(
         authenticator,
-        agentWithBlocks.sId,
+        agentWithBlocks,
         [
           {
             sId: rootSuggestion.sId,
-            targetBlockId: "instructions-root",
+            targetBlockId: INSTRUCTIONS_ROOT_TARGET_BLOCK_ID,
           },
         ]
       );

--- a/front/lib/api/assistant/agent_suggestion_pruning.ts
+++ b/front/lib/api/assistant/agent_suggestion_pruning.ts
@@ -1,4 +1,7 @@
+import { JSDOM } from "jsdom";
+
 import type { MCPServerConfigurationType } from "@app/lib/actions/mcp";
+import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
@@ -119,7 +122,8 @@ export async function pruneSuggestions(
     return;
   }
 
-  const { tools, sub_agent, skills, model } = splitByKind(pendingSuggestions);
+  const { tools, sub_agent, skills, model, instructions } =
+    splitByKind(pendingSuggestions);
 
   const outdatedByKind = await Promise.all([
     getOutdatedToolsSuggestions(tools, agentConfiguration.actions),
@@ -130,11 +134,10 @@ export async function pruneSuggestions(
       agentConfiguration.model.modelId,
       agentConfiguration.model.reasoningEffort ?? null
     ),
-    // TODO(2026-02-05 COPILOT) Implement proper pruning for instructions suggestions based on block id and block inheritance.
-    // getOutdatedInstructionsSuggestions(
-    //   instructions,
-    //   agentConfiguration.instructions
-    // ),
+    getOutdatedInstructionsSuggestions(
+      instructions,
+      agentConfiguration.instructionsHtml
+    ),
   ]);
 
   const allOutdated = outdatedByKind.flat();
@@ -264,12 +267,167 @@ function getOutdatedModelSuggestions(
   return outdatedSuggestions;
 }
 
+function extractBlockIds(instructionsHtml: string): Set<string> {
+  const blockIds = new Set<string>();
+  const blockIdRegex = /data-block-id="([^"]+)"/g;
+  let match;
+
+  while ((match = blockIdRegex.exec(instructionsHtml)) !== null) {
+    blockIds.add(match[1]);
+  }
+
+  return blockIds;
+}
+
+function getOutdatedInstructionsSuggestions(
+  suggestions: InstructionsSuggestionResource[],
+  currentInstructions: string | null
+): InstructionsSuggestionResource[] {
+  if (suggestions.length === 0) {
+    return [];
+  }
+
+  if (!currentInstructions) {
+    return suggestions;
+  }
+
+  const currentBlockIds = extractBlockIds(currentInstructions);
+  const outdatedSuggestions: InstructionsSuggestionResource[] = [];
+
+  for (const suggestion of suggestions) {
+    const { targetBlockId } = suggestion.suggestion;
+
+    if (targetBlockId === "instructions-root") {
+      continue;
+    }
+
+    if (!currentBlockIds.has(targetBlockId)) {
+      outdatedSuggestions.push(suggestion);
+    }
+  }
+
+  return outdatedSuggestions;
+}
+
+function getDescendantBlockIds(
+  instructionsHtml: string,
+  targetBlockId: string
+): Set<string> {
+  const descendants = new Set<string>();
+
+  const dom = new JSDOM(instructionsHtml);
+  const doc = dom.window.document;
+
+  const targetElement = doc.querySelector(`[data-block-id="${targetBlockId}"]`);
+  if (!targetElement) {
+    return descendants;
+  }
+
+  const descendantElements = targetElement.querySelectorAll("[data-block-id]");
+  descendantElements.forEach((element) => {
+    const descendantId = element.getAttribute("data-block-id");
+    if (descendantId && descendantId !== targetBlockId) {
+      descendants.add(descendantId);
+    }
+  });
+
+  return descendants;
+}
+
 /**
- * Prunes pending suggestions for an agent configuration.
- * Fetches pending suggestions and marks outdated ones.
+ * Marks existing instruction suggestions as outdated when new suggestions conflict.
  *
- * This should be called after saving an agent configuration.
+ * Conflict rules:
+ * - Same block ID: New suggestion replaces old one
+ * - Parent-child hierarchy: Parent change invalidates child suggestions
+ * - instructions-root: Full rewrite invalidates all block suggestions
  */
+export async function pruneConflictingInstructionSuggestions(
+  auth: Authenticator,
+  agentConfigurationSId: string,
+  newSuggestions: Array<{ sId: string; targetBlockId: string }>
+): Promise<void> {
+  if (newSuggestions.length === 0) {
+    return;
+  }
+
+  const agent = await getAgentConfiguration(auth, {
+    agentId: agentConfigurationSId,
+    variant: "light",
+  });
+
+  if (!agent || !agent.instructionsHtml) {
+    return;
+  }
+
+  const allPending = await AgentSuggestionResource.listByAgentConfigurationId(
+    auth,
+    agentConfigurationSId,
+    { states: ["pending"], kind: "instructions" }
+  );
+
+  const newSuggestionSIds = new Set(newSuggestions.map((s) => s.sId));
+  const existingPending = allPending.filter(
+    (s) => !newSuggestionSIds.has(s.sId)
+  ) as InstructionsSuggestionResource[];
+
+  if (existingPending.length === 0) {
+    return;
+  }
+
+  // Build conflict detection sets: which blocks are being changed, and which are their descendants
+  const newTargetBlockIds = new Set<string>();
+  const allDescendantBlockIds = new Set<string>();
+
+  for (const newSugg of newSuggestions) {
+    const { targetBlockId } = newSugg;
+    newTargetBlockIds.add(targetBlockId);
+
+    // instructions-root is a full rewrite: mark everything outdated
+    if (targetBlockId === "instructions-root") {
+      if (existingPending.length > 0) {
+        await AgentSuggestionResource.bulkUpdateState(
+          auth,
+          existingPending,
+          "outdated"
+        );
+      }
+      return;
+    }
+
+    // Collect all descendants of this block (child blocks that would be replaced)
+    const descendants = getDescendantBlockIds(
+      agent.instructionsHtml,
+      targetBlockId
+    );
+    descendants.forEach((id) => allDescendantBlockIds.add(id));
+  }
+
+  const toMarkOutdated: InstructionsSuggestionResource[] = [];
+  for (const existingSugg of existingPending) {
+    const existingTargetId = existingSugg.suggestion.targetBlockId;
+
+    // Conflict 1: Same block (duplicate suggestion for same target)
+    if (newTargetBlockIds.has(existingTargetId)) {
+      toMarkOutdated.push(existingSugg);
+      continue;
+    }
+
+    // Conflict 2: Child block (existing targets a descendant that will be replaced)
+    if (allDescendantBlockIds.has(existingTargetId)) {
+      toMarkOutdated.push(existingSugg);
+    }
+  }
+
+  if (toMarkOutdated.length > 0) {
+    await AgentSuggestionResource.bulkUpdateState(
+      auth,
+      toMarkOutdated,
+      "outdated"
+    );
+  }
+}
+
 export async function pruneSuggestionsForAgent(
   auth: Authenticator,
   agentConfiguration: AgentConfigurationType
@@ -281,6 +439,5 @@ export async function pruneSuggestionsForAgent(
       { states: ["pending"] }
     );
 
-  // TODO(2026-02-05 COPILOT) Implement proper pruning based on block id and block inheritance.
   await pruneSuggestions(auth, agentConfiguration, pendingSuggestions);
 }

--- a/front/lib/api/assistant/agent_suggestion_pruning.ts
+++ b/front/lib/api/assistant/agent_suggestion_pruning.ts
@@ -366,9 +366,9 @@ export async function pruneConflictingInstructionSuggestions(
     { states: ["pending"], kind: "instructions" }
   );
 
-  const newSuggestionSIds = new Set(newSuggestions.map((s) => s.sId));
+  const newSuggestionIds = new Set(newSuggestions.map((s) => s.sId));
   const existingPending = allPending.filter(
-    (s) => !newSuggestionSIds.has(s.sId)
+    (s) => !newSuggestionIds.has(s.sId)
   ) as InstructionsSuggestionResource[];
 
   if (existingPending.length === 0) {

--- a/front/lib/api/assistant/global_agents/configurations/dust/copilot.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/copilot.ts
@@ -125,6 +125,18 @@ Example:
 The goal is flexible agents that handle real-world variation, not brittle agents that only match training examples.
 </generalization_over_examples>
 
+<llm_centric_suggestions>
+Focus suggestions on actionable information that changes what the agent does.
+
+Filter out:
+- Information only relevant for humans, not the LLM
+- User motivations and aspirations
+- Generic qualities without specific behavior changes
+- Information the LLM already knows or can infer
+
+Ask yourself: "Does this tell the agent WHAT TO DO differently, or just context about why?"
+</llm_centric_suggestions>
+
 <contradictory_information>
 Always assess the instructions and suggestions for contradictory information.
 This includes contradictory information in different instruction sections.
@@ -257,19 +269,29 @@ When creating suggestions:
 
 1. Each call to a suggestion tool (\`suggest_prompt_edits\`, \`suggest_tools\`, \`suggest_skills\`, \`suggest_model\`) will:
    - Save the suggestion in the database with state \`pending\`
-   - Deterministically mark overlapping suggestions as \`outdated\`
+   - Automatically mark conflicting suggestions as \`outdated\` (see conflict rules below)
    - Emit a notification to render the suggestion chip in the conversation
    - Return a markdown directive that renders the suggestion inline
 
 2. The custom markdown component will:
    - Render the suggestion chip in the conversation viewer
    - For instruction suggestions, render an inline diff
-   - Expose a CTA to apply the suggestion directly from the conversation
+   - Expose a call to action to apply the suggestion directly from the conversation
+   - Outdated suggestions are shown grayed out with a clock icon
 
 3. Users can accept/reject displayed suggestions, triggering an API call to update the state.
-   - Edge case: concurrent state changes follow "last write wins"
 
 4. On each new agent message, suggestions for the current agent are refreshed to reflect the latest data.
+
+<suggestion_conflict_rules>
+When you create a new instruction suggestion, the system automatically marks existing suggestions as outdated based on hierarchy:
+
+- **Same block**: If you suggest changes to block "abc123" and there's already a pending suggestion for "abc123", the old one becomes outdated
+- **Parent-child**: If you suggest changes to a parent block that contains child blocks, any suggestions targeting those children become outdated (because the parent replacement would overwrite them)
+- **Full rewrite**: If you target \`instructions-root\` (full rewrite), ALL other instruction suggestions become outdated
+
+This happens automatically - you don't need to manually mark suggestions as outdated.
+</suggestion_conflict_rules>
 
 </suggestion_creation_guidelines>`,
 

--- a/front/lib/api/assistant/global_agents/configurations/dust/copilot.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/copilot.ts
@@ -10,8 +10,8 @@ import {
   GLOBAL_AGENTS_SID,
   MAX_STEPS_USE_PER_RUN_LIMIT,
 } from "@app/types";
-import { INSTRUCTIONS_ROOT_TARGET_BLOCK_ID } from "@app/types/suggestions/agent_suggestion";
 import { JOB_TYPE_LABELS } from "@app/types/job_type";
+import { INSTRUCTIONS_ROOT_TARGET_BLOCK_ID } from "@app/types/suggestions/agent_suggestion";
 
 interface CopilotMCPServerViews {
   context: MCPServerViewResource;

--- a/front/lib/swr/agent_suggestions.ts
+++ b/front/lib/swr/agent_suggestions.ts
@@ -21,12 +21,14 @@ export function useAgentSuggestions({
   disabled,
   kind,
   state,
+  limit,
   workspaceId,
 }: {
   agentConfigurationId: string | null;
   disabled?: boolean;
   kind?: GetSuggestionsQuery["kind"];
   state?: GetSuggestionsQuery["states"];
+  limit?: number;
   workspaceId: string;
 }) {
   const suggestionsFetcher: Fetcher<GetSuggestionsResponseBody> = fetcher;
@@ -37,6 +39,9 @@ export function useAgentSuggestions({
   }
   if (kind) {
     urlParams.append("kind", kind);
+  }
+  if (limit !== undefined) {
+    urlParams.append("limit", limit.toString());
   }
 
   const queryString = urlParams.toString();

--- a/front/tests/utils/AgentConfigurationFactory.ts
+++ b/front/tests/utils/AgentConfigurationFactory.ts
@@ -69,6 +69,7 @@ export class AgentConfigurationFactory {
       name: string;
       description: string;
       instructions: string;
+      instructionsHtml: string | null;
     }> = {}
   ): Promise<AgentConfigurationType> {
     const user = auth.user();
@@ -78,7 +79,7 @@ export class AgentConfigurationFactory {
       name: overrides.name ?? "Test Agent",
       description: overrides.description ?? "Test Agent Description",
       instructions: overrides.instructions ?? "Updated Test Instructions",
-      instructionsHtml: null,
+      instructionsHtml: overrides.instructionsHtml ?? null,
       pictureUrl: "https://dust.tt/static/systemavatar/test_avatar_1.png",
       status: "active",
       scope: "visible",

--- a/front/types/suggestions/agent_suggestion.ts
+++ b/front/types/suggestions/agent_suggestion.ts
@@ -29,6 +29,8 @@ export const AGENT_SUGGESTION_SOURCES = ["reinforcement", "copilot"] as const;
 
 export type AgentSuggestionSource = (typeof AGENT_SUGGESTION_SOURCES)[number];
 
+export const INSTRUCTIONS_ROOT_TARGET_BLOCK_ID = "instructions-root";
+
 const ToolsSuggestionSchema = z.object({
   action: z.enum(["add", "remove"]),
   toolId: z.string(),


### PR DESCRIPTION
## Description

* Marking suggestion outdated on agent save if the block no longer exists
* During agent creation workflow, marking suggestion outdated if (1) it overwrites a block of an existing suggestion (2) it overwrites a parent of an existing suggestion
* Minor instruction updates so copilot is aware of this behavior
* Fixing bug in that we don't actually query for outdated suggestions in CopilotSuggestionsContext

## Tests

Validated manually
1. Created suggestions
2. Overwrote suggestion set and that the original suggestion is marked outdated

Extensive unit testing

## Risk

* Low

## Deploy Plan

* Deploy front