### PR TITLE
Add agent builder editor view in Poke

### DIFF
--- a/front-spa/src/poke/PokeApp.tsx
+++ b/front-spa/src/poke/PokeApp.tsx
@@ -13,6 +13,7 @@ import { RegionProvider } from "@dust-tt/front/lib/auth/RegionContext";
 
 import { AppPage } from "@dust-tt/front/components/poke/pages/AppPage";
 import { AssistantDetailsPage } from "@dust-tt/front/components/poke/pages/AssistantDetailsPage";
+import { AssistantInstructionsPage } from "@dust-tt/front/components/poke/pages/AssistantInstructionsPage";
 import { ConnectorRedirectPage } from "@dust-tt/front/components/poke/pages/ConnectorRedirectPage";
 import { ConversationPage } from "@dust-tt/front/components/poke/pages/ConversationPage";
 import { DashboardPage } from "@dust-tt/front/components/poke/pages/DashboardPage";
@@ -76,6 +77,10 @@ const router = createBrowserRouter(
         { index: true, element: <WorkspacePage /> },
         { path: "memberships", element: <MembershipsPage /> },
         { path: "llm-traces/:runId", element: <LLMTracePage /> },
+        {
+          path: "assistants/:aId/instructions",
+          element: <AssistantInstructionsPage />,
+        },
         { path: "assistants/:aId", element: <AssistantDetailsPage /> },
         {
           path: "assistants/:aId/triggers/:triggerId",

--- a/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
+++ b/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
@@ -43,6 +43,59 @@ import type { LightAgentConfigurationType } from "@app/types";
 
 export const INSTRUCTIONS_MAXIMUM_CHARACTER_COUNT = 120_000;
 
+/**
+ * Base rendering extensions for the agent instructions editor.
+ * Used by the full editor and by read-only preview pages (e.g. poke).
+ */
+export function buildAgentInstructionsReadOnlyExtensions(): Extensions {
+  return [
+    Markdown,
+    InstructionsDocumentExtension,
+    StarterKit.configure({
+      document: false,
+      heading: false,
+      hardBreak: false,
+      paragraph: {
+        HTMLAttributes: { class: markdownStyles.paragraph() },
+      },
+      orderedList: {
+        HTMLAttributes: { class: markdownStyles.orderedList() },
+      },
+      listItem: {
+        HTMLAttributes: { class: markdownStyles.list() },
+      },
+      link: false,
+      bulletList: {
+        HTMLAttributes: { class: markdownStyles.unorderedList() },
+      },
+      blockquote: false,
+      horizontalRule: false,
+      strike: false,
+      code: {
+        HTMLAttributes: { class: markdownStyles.codeBlock() },
+      },
+      codeBlock: {
+        HTMLAttributes: { class: markdownStyles.codeBlock() },
+      },
+    }),
+    InstructionsRootExtension,
+    BlockIdExtension,
+    InstructionBlockExtension,
+    HeadingExtension.configure({
+      levels: [1, 2, 3, 4, 5, 6],
+      HTMLAttributes: { class: "mt-4 mb-3" },
+    }),
+    EmojiExtension,
+    LinkExtension.configure({
+      HTMLAttributes: {
+        class: "text-blue-600 hover:underline hover:text-blue-800",
+      },
+      autolink: false,
+      openOnClick: false,
+    }),
+  ];
+}
+
 export const BLUR_EVENT_NAME = "agent:instructions:blur";
 
 const editorVariants = cva(
@@ -105,54 +158,8 @@ export function AgentBuilderInstructionsEditor({
 
   const extensions = useMemo(() => {
     const extensions: Extensions = [
-      Markdown,
-      InstructionsDocumentExtension,
-      StarterKit.configure({
-        document: false, // Disabled, we use a custom document to enforce a single instructions root node.
-        heading: false, // Disabled, we use a custom one, see below.
-        hardBreak: false, // Disabled, we use custom EmptyLineParagraphExtension instead.
-        paragraph: {
-          HTMLAttributes: {
-            class: markdownStyles.paragraph(),
-          },
-        },
-        orderedList: {
-          HTMLAttributes: {
-            class: markdownStyles.orderedList(),
-          },
-        },
-        listItem: {
-          HTMLAttributes: {
-            class: markdownStyles.list(),
-          },
-        },
-        link: false, // we use custom LinkExtension instead
-        bulletList: {
-          HTMLAttributes: {
-            class: markdownStyles.unorderedList(),
-          },
-        },
-        blockquote: false,
-        horizontalRule: false,
-        strike: false,
-        undoRedo: {
-          depth: 100,
-        },
-        code: {
-          HTMLAttributes: {
-            class: markdownStyles.codeBlock(),
-          },
-        },
-        codeBlock: {
-          HTMLAttributes: {
-            class: markdownStyles.codeBlock(),
-          },
-        },
-      }),
-      InstructionsRootExtension,
+      ...buildAgentInstructionsReadOnlyExtensions(),
       KeyboardShortcutsExtension,
-      BlockIdExtension,
-      InstructionBlockExtension,
       AgentInstructionDiffExtension,
       InstructionSuggestionExtension,
       BlockInsertExtension.configure({
@@ -182,23 +189,6 @@ export function AgentBuilderInstructionsEditor({
       CharacterCount.configure({
         limit: INSTRUCTIONS_MAXIMUM_CHARACTER_COUNT,
       }),
-      HeadingExtension.configure({
-        levels: [1, 2, 3, 4, 5, 6],
-        HTMLAttributes: {
-          class: "mt-4 mb-3",
-        },
-      }),
-      EmojiExtension,
-      LinkExtension.configure({
-        HTMLAttributes: {
-          class: "text-blue-600 hover:underline hover:text-blue-800",
-        },
-        autolink: false,
-        openOnClick: false,
-      }),
-    ];
-
-    extensions.push(
       MentionExtension.configure({
         owner,
         HTMLAttributes: {
@@ -214,8 +204,8 @@ export function AgentBuilderInstructionsEditor({
             users: true,
           },
         }),
-      })
-    );
+      }),
+    ];
 
     return extensions;
   }, [owner, suggestionHandler]);

--- a/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
+++ b/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
@@ -52,30 +52,45 @@ export function buildAgentInstructionsReadOnlyExtensions(): Extensions {
     Markdown,
     InstructionsDocumentExtension,
     StarterKit.configure({
-      document: false,
-      heading: false,
-      hardBreak: false,
+      document: false, // Disabled, we use a custom document to enforce a single instructions root node.
+      heading: false, // Disabled, we use a custom one, see below.
+      hardBreak: false, // Disabled, we use custom EmptyLineParagraphExtension instead.
       paragraph: {
-        HTMLAttributes: { class: markdownStyles.paragraph() },
+        HTMLAttributes: {
+          class: markdownStyles.paragraph(),
+        },
       },
       orderedList: {
-        HTMLAttributes: { class: markdownStyles.orderedList() },
+        HTMLAttributes: {
+          class: markdownStyles.orderedList(),
+        },
       },
       listItem: {
-        HTMLAttributes: { class: markdownStyles.list() },
+        HTMLAttributes: {
+          class: markdownStyles.list(),
+        },
       },
-      link: false,
+      link: false, // we use custom LinkExtension instead
       bulletList: {
-        HTMLAttributes: { class: markdownStyles.unorderedList() },
+        HTMLAttributes: {
+          class: markdownStyles.unorderedList(),
+        },
       },
       blockquote: false,
       horizontalRule: false,
       strike: false,
+      undoRedo: {
+        depth: 100,
+      },
       code: {
-        HTMLAttributes: { class: markdownStyles.codeBlock() },
+        HTMLAttributes: {
+          class: markdownStyles.codeBlock(),
+        },
       },
       codeBlock: {
-        HTMLAttributes: { class: markdownStyles.codeBlock() },
+        HTMLAttributes: {
+          class: markdownStyles.codeBlock(),
+        },
       },
     }),
     InstructionsRootExtension,

--- a/front/components/poke/pages/AssistantDetailsPage.tsx
+++ b/front/components/poke/pages/AssistantDetailsPage.tsx
@@ -242,7 +242,19 @@ export function AssistantDetailsPage() {
                           )}
                         </div>
                         <div className="ml-4 text-sm text-muted-foreground dark:text-muted-foreground-night">
-                          <div className="font-bold">Instructions:</div>
+                          <div className="flex items-center gap-2">
+                            <span className="font-bold">Instructions:</span>
+                            <LinkWrapper
+                              href={`/poke/${owner.sId}/assistants/${a.sId}/instructions`}
+                            >
+                              <Button
+                                icon={ExternalLinkIcon}
+                                label="View in editor"
+                                variant="outline"
+                                size="xs"
+                              />
+                            </LinkWrapper>
+                          </div>
                           <TextArea
                             placeholder=""
                             value={a.instructions ?? ""}

--- a/front/components/poke/pages/AssistantInstructionsPage.tsx
+++ b/front/components/poke/pages/AssistantInstructionsPage.tsx
@@ -1,0 +1,104 @@
+import { Spinner } from "@dust-tt/sparkle";
+import { EditorContent, useEditor } from "@tiptap/react";
+import { useEffect, useMemo, useRef } from "react";
+
+import { buildAgentInstructionsReadOnlyExtensions } from "@app/components/agent_builder/instructions/AgentBuilderInstructionsEditor";
+import { escapeUnrecognizedHtmlTags } from "@app/components/editor/lib/escapeUnrecognizedHtmlTags";
+import { useWorkspace } from "@app/lib/auth/AuthContext";
+import { useRequiredPathParam } from "@app/lib/platform";
+import { usePokeAgentDetails } from "@app/poke/swr/agent_details";
+
+export function AssistantInstructionsPage() {
+  const owner = useWorkspace();
+  const aId = useRequiredPathParam("aId");
+
+  const {
+    data: agentDetails,
+    isLoading,
+    isError,
+  } = usePokeAgentDetails({
+    owner,
+    aId,
+    disabled: false,
+  });
+
+  const agentConfig = agentDetails?.agentConfigurations[0];
+  const instructions = agentConfig?.instructions ?? "";
+  const instructionsHtml = agentConfig?.instructionsHtml ?? null;
+
+  const extensions = useMemo(
+    () => buildAgentInstructionsReadOnlyExtensions(),
+    []
+  );
+
+  const initialContentSetRef = useRef(false);
+
+  const editor = useEditor(
+    {
+      extensions,
+      editable: false,
+      immediatelyRender: false,
+    },
+    [extensions]
+  );
+
+  useEffect(() => {
+    if (
+      !editor ||
+      editor.isDestroyed ||
+      initialContentSetRef.current ||
+      (!instructions && !instructionsHtml)
+    ) {
+      return;
+    }
+
+    initialContentSetRef.current = true;
+
+    requestAnimationFrame(() => {
+      if (editor && !editor.isDestroyed) {
+        // Prefer HTML content if available (preserves block IDs).
+        // Fall back to markdown for agents without stored HTML.
+        if (instructionsHtml) {
+          editor.commands.setContent(instructionsHtml, {
+            emitUpdate: false,
+          });
+        } else if (instructions) {
+          editor.commands.setContent(
+            escapeUnrecognizedHtmlTags(instructions, editor.schema),
+            {
+              emitUpdate: false,
+              contentType: "markdown",
+            }
+          );
+        }
+      }
+    });
+  }, [editor, instructions, instructionsHtml]);
+
+  if (isLoading) {
+    return (
+      <div className="flex h-64 items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (isError || !agentDetails) {
+    return (
+      <div className="flex h-64 items-center justify-center">
+        <p>Error loading agent details.</p>
+      </div>
+    );
+  }
+
+  const agentName = agentConfig?.name ?? "Unknown";
+
+  return (
+    <div>
+      <h3 className="mb-4 text-xl font-bold">Instructions for @{agentName}</h3>
+      <div className="overflow-auto rounded-xl border border-border p-2 dark:border-border-night">
+        <EditorContent editor={editor} className="leading-7" />
+      </div>
+    </div>
+  );
+}

--- a/front/components/poke/pages/AssistantInstructionsPage.tsx
+++ b/front/components/poke/pages/AssistantInstructionsPage.tsx
@@ -3,7 +3,7 @@ import { EditorContent, useEditor } from "@tiptap/react";
 import { useEffect, useMemo, useRef } from "react";
 
 import { buildAgentInstructionsReadOnlyExtensions } from "@app/components/agent_builder/instructions/AgentBuilderInstructionsEditor";
-import { escapeUnrecognizedHtmlTags } from "@app/components/editor/lib/escapeUnrecognizedHtmlTags";
+import { preprocessMarkdownForEditor } from "@app/components/editor/lib/preprocessMarkdownForEditor";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { useRequiredPathParam } from "@app/lib/platform";
 import { usePokeAgentDetails } from "@app/poke/swr/agent_details";
@@ -64,7 +64,7 @@ export function AssistantInstructionsPage() {
           });
         } else if (instructions) {
           editor.commands.setContent(
-            escapeUnrecognizedHtmlTags(instructions, editor.schema),
+            preprocessMarkdownForEditor(instructions, editor.schema),
             {
               emitUpdate: false,
               contentType: "markdown",


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR adds a new route in Poke so we can display the agent builder instructions in the actual editor used by our users. This is pretty helpful when needed to debug instructions rendering.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
