### PR TITLE
 Fix knowledge node not rendering when alone on a line

### DIFF
--- a/front/components/editor/extensions/skill_builder/KnowledgeNode.tsx
+++ b/front/components/editor/extensions/skill_builder/KnowledgeNode.tsx
@@ -29,6 +29,10 @@ export const KNOWLEDGE_NODE_TYPE = "knowledgeNode";
 // This format is intentionally HTML-like for LLM readability.
 const KNOWLEDGE_MARKDOWN_TAG = "knowledge";
 
+const KNOWLEDGE_MARKDOWN_REGEX = new RegExp(
+  `^<${KNOWLEDGE_MARKDOWN_TAG}\\s+([^>]+)\\s*/>`
+);
+
 export const KnowledgeNode = Node.create<{}>({
   name: KNOWLEDGE_NODE_TYPE,
 
@@ -44,9 +48,7 @@ export const KnowledgeNode = Node.create<{}>({
       return src.indexOf(`<${KNOWLEDGE_MARKDOWN_TAG}`);
     },
     tokenize: (src) => {
-      const match = new RegExp(
-        `^<${KNOWLEDGE_MARKDOWN_TAG}\\s+([^>]+)\\s*/>`
-      ).exec(src);
+      const match = KNOWLEDGE_MARKDOWN_REGEX.exec(src);
       if (!match) {
         return undefined;
       }


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR:
- Fixes a bug where `<knowledge>` nodes in skill builder instructions were not displayed when they appeared alone
on their own line (e.g., separated by a blank line from other content)
- Root cause: marked.js (the markdown parser) treats `<knowledge ... />` as block-level HTML when it's on its own line, bypassing our inline `markdownTokenizer`. The tag then goes through TipTap's `parseHTML` pipeline which didn't recognize <knowledge> elements.
- Added a `parseHTML` fallback rule for `<knowledge>` tags with attribute extraction, so the block HTML path
produces the same selectedItems structure as the inline tokenizer path

Proper solution would be to use the markdown shortcode synthax but is would be a breaking change and is also less friendly for the LLM. See doc [here](https://tiptap.dev/docs/editor/markdown/api/utilities#createinlinemarkdownspec).

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
