### PR TITLE
Fix multi-words angled brackets

### DIFF
--- a/front/components/editor/extensions/agent_builder/InstructionSuggestionExtension.test.ts
+++ b/front/components/editor/extensions/agent_builder/InstructionSuggestionExtension.test.ts
@@ -578,6 +578,37 @@ describe("InstructionSuggestionExtension", () => {
       expect(editor.getText().trim()).toContain("URL");
       expect(editor.getText().trim()).toContain("PLACEHOLDER");
     });
+
+    it("should strip brackets from multi-word angle-bracket patterns", () => {
+      const escaped = preprocessMarkdownForEditor(
+        '{"name": <string value>, "count": <number or null>}',
+        editor.state.schema
+      );
+      expect(escaped).not.toContain("<string");
+      expect(escaped).not.toContain("<number");
+      expect(escaped).toContain("string value");
+      expect(escaped).toContain("number or null");
+    });
+
+    it("should not throw when loading markdown with multi-word angle-bracket patterns", () => {
+      const markdown = [
+        "Parse the report and return JSON:",
+        '{"id": <numeric identifier>, "label": <short text>, "ratio": <decimal between 0 and 1>}',
+      ].join("\n");
+
+      const escaped = preprocessMarkdownForEditor(
+        markdown,
+        editor.state.schema
+      );
+      expect(() => {
+        editor.commands.setContent(escaped, { contentType: "markdown" });
+      }).not.toThrow();
+
+      const text = editor.getText().trim();
+      expect(text).toContain("numeric identifier");
+      expect(text).toContain("short text");
+      expect(text).toContain("decimal between 0 and 1");
+    });
   });
 
   describe("markdown preprocessing for instruction blocks", () => {

--- a/front/components/editor/lib/preprocessMarkdownForEditor.ts
+++ b/front/components/editor/lib/preprocessMarkdownForEditor.ts
@@ -43,19 +43,19 @@ export function preprocessMarkdownForEditor(
     new RegExp(`(<\\/${TAG_NAME_PATTERN}>)\\n(?!\\n)`, "g"),
     "$1\n\n"
   );
-  // 2. Escape unrecognized standalone tags (not part of matched pairs).
+  // 2. Escape all angle-bracket patterns that markdown-it would parse as HTML.
+  //    Matches any `<` followed by optional `/` and a tag name (which is how
+  //    markdown-it detects HTML), with optional trailing content (attributes,
+  //    spaces, commas, etc.) up to `>`. Preserves recognized schema tags and
+  //    matched instruction-block pairs.
   processed = processed.replace(
-    new RegExp(`<(\\/?${TAG_NAME_PATTERN})>`, "g"),
-    (match, tag) => {
-      const tagName = tag.replace(/^\//, "").toLowerCase();
-      if (recognized.has(tagName)) {
+    new RegExp(`<(\\/?)(${TAG_NAME_PATTERN})([^>]*)>`, "g"),
+    (match, slash, tagName, rest) => {
+      const normalized = tagName.toLowerCase();
+      if (recognized.has(normalized) || matchedPairs.has(normalized)) {
         return match;
       }
-      if (matchedPairs.has(tagName)) {
-        return match;
-      }
-
-      return tag;
+      return `${slash}${tagName}${rest}`;
     }
   );
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Follow up of https://github.com/dust-tt/dust/pull/21325.

This PR fixes `preprocessMarkdownForEditor` to escape multi-word angle-bracket patterns (e.g. `<string value>`, `<number or null>`) that would be parsed as HTML, causing `RangeError: Invalid content for node type paragraph`.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
