### PR TITLE
Refactor search to use registerTool().

### DIFF
--- a/front/lib/actions/mcp_internal_actions/wrappers.ts
+++ b/front/lib/actions/mcp_internal_actions/wrappers.ts
@@ -46,7 +46,7 @@ export function registerTool(
  *
  * The tool name is used as a tag in the DD metric, it's 1 tool name <=> 1 monitor.
  */
-export function withToolLogging<T>(
+function withToolLogging<T>(
   auth: Authenticator,
   {
     toolNameForMonitoring,

--- a/front/lib/api/actions/servers/data_sources_file_system/tools/index.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/tools/index.ts
@@ -35,7 +35,7 @@ const handlersWithTags: ToolHandlers<
     if (!auth) {
       return new Err(new MCPError("Authentication required"));
     }
-    return executeFindTags(auth, query, dataSources);
+    return executeFindTags(query, dataSources, auth);
   },
 };
 

--- a/front/lib/api/actions/servers/extract_data/tools/index.ts
+++ b/front/lib/api/actions/servers/extract_data/tools/index.ts
@@ -163,7 +163,7 @@ export function createExtractDataTools(
       return extractFunction(params);
     },
     find_tags: async ({ query, dataSources }, _extra) => {
-      return executeFindTags(auth, query, dataSources);
+      return executeFindTags(query, dataSources, auth);
     },
   };
   return buildTools(EXTRACT_DATA_WITH_TAGS_TOOLS_METADATA, handlers);

--- a/front/lib/api/actions/servers/include_data/tools/index.ts
+++ b/front/lib/api/actions/servers/include_data/tools/index.ts
@@ -220,7 +220,7 @@ export function createIncludeDataTools(
       return includeFunction(params);
     },
     find_tags: async ({ query, dataSources }, _extra) => {
-      return executeFindTags(auth, query, dataSources);
+      return executeFindTags(query, dataSources, auth);
     },
   };
   return buildTools(INCLUDE_DATA_WITH_TAGS_TOOLS_METADATA, handlers);

--- a/front/lib/api/actions/servers/search/index.ts
+++ b/front/lib/api/actions/servers/search/index.ts
@@ -1,22 +1,17 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 import { shouldAutoGenerateTags } from "@app/lib/actions/mcp_internal_actions/tools/tags/utils";
-import {
-  SearchInputSchema,
-  TagsInputSchema,
-} from "@app/lib/actions/mcp_internal_actions/types";
 import { makeInternalMCPServer } from "@app/lib/actions/mcp_internal_actions/utils";
-import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
+import { registerTool } from "@app/lib/actions/mcp_internal_actions/wrappers";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
 import {
   SEARCH_SERVER,
   SEARCH_SERVER_NAME,
-  SEARCH_TOOL_DESCRIPTION,
-  SEARCH_TOOL_NAME,
 } from "@app/lib/api/actions/servers/search/metadata";
-import { searchFunction } from "@app/lib/api/actions/servers/search/tools";
-import { registerFindTagsTool } from "@app/lib/api/actions/tools/find_tags";
-import { FIND_TAGS_TOOL_NAME } from "@app/lib/api/actions/tools/find_tags/metadata";
+import {
+  TOOLS_WITH_TAGS,
+  TOOLS_WITHOUT_TAGS,
+} from "@app/lib/api/actions/servers/search/tools";
 import type { Authenticator } from "@app/lib/auth";
 
 function createServer(
@@ -29,43 +24,9 @@ function createServer(
     ? shouldAutoGenerateTags(agentLoopContext)
     : false;
 
-  if (!areTagsDynamic) {
-    server.tool(
-      SEARCH_TOOL_NAME,
-      SEARCH_TOOL_DESCRIPTION,
-      SearchInputSchema.shape,
-      withToolLogging(
-        auth,
-        {
-          toolNameForMonitoring: SEARCH_TOOL_NAME,
-          agentLoopContext,
-          enableAlerting: true,
-        },
-        async (args) => searchFunction({ ...args, auth, agentLoopContext })
-      )
-    );
-  } else {
-    server.tool(
-      SEARCH_TOOL_NAME,
-      SEARCH_TOOL_DESCRIPTION,
-      {
-        ...SearchInputSchema.shape,
-        ...TagsInputSchema.shape,
-      },
-      withToolLogging(
-        auth,
-        {
-          toolNameForMonitoring: SEARCH_TOOL_NAME,
-          agentLoopContext,
-          enableAlerting: true,
-        },
-        async (args) => searchFunction({ ...args, auth, agentLoopContext })
-      )
-    );
-
-    registerFindTagsTool(auth, server, agentLoopContext, {
-      name: FIND_TAGS_TOOL_NAME,
-      extraDescription: `This tool is meant to be used before the ${SEARCH_TOOL_NAME} tool.`,
+  for (const tool of areTagsDynamic ? TOOLS_WITH_TAGS : TOOLS_WITHOUT_TAGS) {
+    registerTool(auth, agentLoopContext, server, tool, {
+      monitoringName: SEARCH_SERVER_NAME,
     });
   }
 

--- a/front/lib/api/actions/servers/search/metadata.ts
+++ b/front/lib/api/actions/servers/search/metadata.ts
@@ -1,10 +1,14 @@
+// eslint-disable-next-line dust/enforce-client-types-in-public-api
+import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
+import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { SearchInputSchema } from "@app/lib/actions/mcp_internal_actions/types";
+import { FIND_TAGS_TOOL_NAME } from "@app/lib/api/actions/servers/data_sources_file_system/metadata";
 
 // Define constants locally to avoid circular dependency with constants.ts
 export const SEARCH_SERVER_NAME = "search";
@@ -24,6 +28,35 @@ export const SEARCH_TOOLS_METADATA = createToolsRecord({
       running: "Searching data sources",
       done: "Search data sources",
     },
+  },
+});
+
+export const SEARCH_TOOL_METADATA_WITH_TAGS = createToolsRecord({
+  ...SEARCH_TOOLS_METADATA,
+  [FIND_TAGS_TOOL_NAME]: {
+    description:
+      "Discover available tags/labels that can be used to filter content. Returns tags " +
+      "with their usage counts. Only available when dynamic tags are enabled.",
+    schema: {
+      query: z
+        .string()
+        .describe(
+          "The text to search for in existing labels (also called tags) using edge ngram " +
+            "matching (case-insensitive). Matches labels that start with any word in the " +
+            "search text. The returned labels can be used in tagsIn/tagsNot parameters to " +
+            "restrict or exclude content based on the user request and conversation context."
+        ),
+      dataSources:
+        ConfigurableToolInputSchemas[
+          INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE
+        ],
+    },
+    stake: "never_ask",
+    displayLabels: {
+      running: "Finding tags",
+      done: "Find tags",
+    },
+    enableAlerting: true,
   },
 });
 

--- a/front/lib/api/actions/servers/search/tools/index.ts
+++ b/front/lib/api/actions/servers/search/tools/index.ts
@@ -6,10 +6,19 @@ import assert from "assert";
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { DataSourcesToolConfigurationType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type { SearchResultResourceType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
+import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { checkConflictingTags } from "@app/lib/actions/mcp_internal_actions/tools/tags/utils";
 import { getCoreSearchArgs } from "@app/lib/actions/mcp_internal_actions/tools/utils";
 import { ensureAuthorizedDataSourceViews } from "@app/lib/actions/mcp_internal_actions/utils/data_source_views";
 import type { AgentLoopContextType } from "@app/lib/actions/types";
+import {
+  SEARCH_TOOL_METADATA_WITH_TAGS,
+  SEARCH_TOOLS_METADATA,
+} from "@app/lib/api/actions/servers/search/metadata";
+import { SEARCH_TOOL_NAME } from "@app/lib/api/actions/servers/search/metadata";
+import { executeFindTags } from "@app/lib/api/actions/tools/find_tags";
+import { FIND_TAGS_TOOL_NAME } from "@app/lib/api/actions/tools/find_tags/metadata";
 import { getRefs } from "@app/lib/api/assistant/citations";
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
@@ -42,13 +51,17 @@ export async function searchFunction({
   dataSources: DataSourcesToolConfigurationType;
   tagsIn?: string[];
   tagsNot?: string[];
-  auth: Authenticator;
+  auth?: Authenticator;
   agentLoopContext?: AgentLoopContextType;
 }): Promise<Result<CallToolResult["content"], MCPError>> {
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
 
   const credentials = dustManagedCredentials();
   const timeFrame = parseTimeFrame(relativeTimeFrame);
+
+  if (!auth) {
+    return new Err(new MCPError("Authentication required"));
+  }
 
   if (!agentLoopContext?.runContext) {
     throw new Error(
@@ -199,3 +212,26 @@ export async function searchFunction({
     }))
   );
 }
+
+const handlers: ToolHandlers<typeof SEARCH_TOOLS_METADATA> = {
+  [SEARCH_TOOL_NAME]: (params, extra) =>
+    searchFunction({
+      ...params,
+      auth: extra.auth,
+      agentLoopContext: extra.agentLoopContext,
+    }),
+};
+
+const handlersWithTags: ToolHandlers<typeof SEARCH_TOOL_METADATA_WITH_TAGS> = {
+  ...handlers,
+  [FIND_TAGS_TOOL_NAME]: async ({ query, dataSources }, { auth }) => {
+    return executeFindTags(query, dataSources, auth);
+  },
+};
+
+export const TOOLS_WITHOUT_TAGS = buildTools(SEARCH_TOOLS_METADATA, handlers);
+
+export const TOOLS_WITH_TAGS = buildTools(
+  SEARCH_TOOL_METADATA_WITH_TAGS,
+  handlersWithTags
+);

--- a/front/lib/api/actions/tools/find_tags/index.ts
+++ b/front/lib/api/actions/tools/find_tags/index.ts
@@ -1,17 +1,9 @@
-import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { TextContent } from "@modelcontextprotocol/sdk/types.js";
 import trim from "lodash/trim";
 
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { DataSourcesToolConfigurationType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { getCoreSearchArgs } from "@app/lib/actions/mcp_internal_actions/tools/utils";
-import { withToolLogging } from "@app/lib/actions/mcp_internal_actions/wrappers";
-import type { AgentLoopContextType } from "@app/lib/actions/types";
-import {
-  FIND_TAGS_BASE_DESCRIPTION,
-  FIND_TAGS_TOOL_NAME,
-  findTagsSchema,
-} from "@app/lib/api/actions/tools/find_tags/metadata";
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
@@ -22,10 +14,14 @@ import { CoreAPI, Err, Ok, removeNulls } from "@app/types";
 const DEFAULT_SEARCH_LABELS_UPPER_LIMIT = 2000;
 
 export async function executeFindTags(
-  auth: Authenticator,
   query: string,
-  dataSources: DataSourcesToolConfigurationType
+  dataSources: DataSourcesToolConfigurationType,
+  auth?: Authenticator
 ): Promise<Result<TextContent[], MCPError>> {
+  if (!auth) {
+    return new Err(new MCPError("Authentication required"));
+  }
+
   const coreSearchArgsResults = await concurrentExecutor(
     dataSources,
     async (dataSourceConfiguration) =>
@@ -111,38 +107,4 @@ export async function executeFindTags(
         ).join("\n"),
     },
   ]);
-}
-
-export function registerFindTagsTool(
-  auth: Authenticator,
-  server: McpServer,
-  agentLoopContext: AgentLoopContextType | undefined,
-  { name, extraDescription }: { name: string; extraDescription?: string }
-) {
-  const toolDescription = extraDescription
-    ? FIND_TAGS_BASE_DESCRIPTION + "\n" + extraDescription
-    : FIND_TAGS_BASE_DESCRIPTION;
-
-  server.tool(
-    name,
-    toolDescription,
-    findTagsSchema,
-    withToolLogging(
-      auth,
-      {
-        toolNameForMonitoring: FIND_TAGS_TOOL_NAME,
-        agentLoopContext,
-        enableAlerting: true,
-      },
-      async ({
-        query,
-        dataSources,
-      }: {
-        query: string;
-        dataSources: DataSourcesToolConfigurationType[number][];
-      }) => {
-        return executeFindTags(auth, query, dataSources);
-      }
-    )
-  );
 }


### PR DESCRIPTION
## Description

Uses registerTool() instead of server.tool()

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy front