### PR TITLE
[RUNNER] Create dedicated feature flag for opus 4.6

### DIFF
--- a/front/types/assistant/models/anthropic.ts
+++ b/front/types/assistant/models/anthropic.ts
@@ -209,7 +209,7 @@ export const CLAUDE_4_5_OPUS_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
 export const CLAUDE_OPUS_4_6_DEFAULT_MODEL_CONFIG: ModelConfigurationType = {
   providerId: "anthropic",
   modelId: CLAUDE_OPUS_4_6_MODEL_ID,
-  displayName: "Claude Opus 4.6 (Dust only)",
+  displayName: "Claude Opus 4.6",
   contextSize: 200_000,
   recommendedTopK: 16,
   recommendedExhaustiveTopK: 64,


### PR DESCRIPTION
## Description

Put opus 4.6 behind its own feature flag.

## Tests

local

## Risk

Low risk of workspaces that had opus 4.5 enabled and created agents with 4.6.

## Deploy Plan

front
