### PR TITLE
feat(cli): add conversation resume command

### DIFF
--- a/cli/src/index.tsx
+++ b/cli/src/index.tsx
@@ -82,6 +82,12 @@ const cli = meow({
       type: "string",
       description: "Workspace ID for headless authentication",
     },
+    resume: {
+      type: "string",
+      shortFlag: "r",
+      description:
+        "Resume a conversation by ID, or pass no value to pick from recent",
+    },
   },
 });
 

--- a/cli/src/ui/App.tsx
+++ b/cli/src/ui/App.tsx
@@ -7,6 +7,7 @@ import AgentsMCP from "./commands/AgentsMCP.js";
 import Auth from "./commands/Auth.js";
 import Cache from "./commands/Cache.js";
 import Chat from "./commands/Chat.js";
+import Conversations from "./commands/Conversations.js";
 import Logout from "./commands/Logout.js";
 import NonInteractiveChat from "./commands/NonInteractiveChat.js";
 import Status from "./commands/Status.js";
@@ -67,6 +68,10 @@ interface AppProps {
     workspaceId: {
       type: "string";
     };
+    resume: {
+      type: "string";
+      shortFlag: "r";
+    };
   }>;
 }
 
@@ -93,6 +98,10 @@ const App: FC<AppProps> = ({ cli }) => {
 
   const command = input[0] || "chat";
 
+  // Handle --resume flag: treat as chat with conversationId
+  const resumeId = flags.resume;
+  const effectiveConversationId = resumeId || flags.conversationId;
+
   switch (command) {
     case "login":
       return (
@@ -104,6 +113,8 @@ const App: FC<AppProps> = ({ cli }) => {
       return <Logout />;
     case "agents-mcp":
       return <AgentsMCP port={flags.port} sId={flags.sId} />;
+    case "conversations":
+      return <Conversations />;
     case "chat":
       // Check if this is a non-interactive chat operation
       if (flags.message || flags.messageId) {
@@ -122,7 +133,7 @@ const App: FC<AppProps> = ({ cli }) => {
         <Chat
           sId={flags.sId?.[0]}
           agentSearch={flags.agent}
-          conversationId={flags.conversationId}
+          conversationId={effectiveConversationId}
           autoAcceptEditsFlag={flags.auto}
         />
       );

--- a/cli/src/ui/commands/Conversations.tsx
+++ b/cli/src/ui/commands/Conversations.tsx
@@ -1,0 +1,104 @@
+import type { ConversationWithoutContentPublicType } from "@dust-tt/client";
+import { Box, Text } from "ink";
+import Spinner from "ink-spinner";
+import type { FC } from "react";
+import React, { useEffect, useState } from "react";
+
+import { getDustClient } from "../../utils/dustClient.js";
+
+const Conversations: FC = () => {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [conversations, setConversations] = useState<
+    ConversationWithoutContentPublicType[]
+  >([]);
+
+  useEffect(() => {
+    void (async () => {
+      const dustClientRes = await getDustClient();
+      if (dustClientRes.isErr()) {
+        setError(dustClientRes.error.message);
+        setLoading(false);
+        return;
+      }
+      const dustClient = dustClientRes.value;
+      if (!dustClient) {
+        setError("Authentication required. Run `dust login` first.");
+        setLoading(false);
+        return;
+      }
+
+      const convRes = await dustClient.getConversations();
+      if (convRes.isErr()) {
+        setError(`Failed to fetch conversations: ${convRes.error.message}`);
+        setLoading(false);
+        return;
+      }
+
+      const convs = convRes.value
+        .filter((c) => c.visibility !== "deleted")
+        .slice(0, 20);
+
+      setConversations(convs);
+      setLoading(false);
+    })();
+  }, []);
+
+  if (loading) {
+    return (
+      <Box>
+        <Text color="green">
+          <Spinner type="dots" /> Loading conversations...
+        </Text>
+      </Box>
+    );
+  }
+
+  if (error) {
+    return (
+      <Box flexDirection="column">
+        <Box borderStyle="round" borderColor="red" padding={1}>
+          <Text color="red">{error}</Text>
+        </Box>
+      </Box>
+    );
+  }
+
+  if (conversations.length === 0) {
+    return (
+      <Box>
+        <Text dimColor>No conversations found.</Text>
+      </Box>
+    );
+  }
+
+  return (
+    <Box flexDirection="column">
+      <Text bold>Recent Conversations</Text>
+      <Box height={1} />
+      {conversations.map((conv) => {
+        const date = new Date(conv.created).toLocaleDateString("en-US", {
+          month: "short",
+          day: "numeric",
+          year: "numeric",
+        });
+        const title = conv.title || "Untitled";
+        return (
+          <Box key={conv.sId} flexDirection="row">
+            <Box width={14}>
+              <Text dimColor>{date}</Text>
+            </Box>
+            <Box width={14}>
+              <Text color="cyan">{conv.sId}</Text>
+            </Box>
+            <Text>{title}</Text>
+          </Box>
+        );
+      })}
+      <Box height={1} />
+      <Text dimColor>Resume with: dust --resume &lt;conversationId&gt;</Text>
+    </Box>
+  );
+};
+
+export default Conversations;

--- a/cli/src/ui/commands/types.ts
+++ b/cli/src/ui/commands/types.ts
@@ -3,6 +3,9 @@ export interface CommandContext {
   attachFile?: () => void;
   clearFiles?: () => void;
   toggleAutoEdits?: () => void;
+  startNewConversation?: () => void;
+  showHelp?: () => void;
+  resumeConversation?: () => void;
 }
 
 export interface Command {
@@ -13,10 +16,12 @@ export interface Command {
 
 export const createCommands = (context: CommandContext): Command[] => [
   {
-    name: "exit",
-    description: "Exit the chat",
+    name: "help",
+    description: "Show commands and keyboard shortcuts",
     execute: () => {
-      process.exit(0);
+      if (context.showHelp) {
+        context.showHelp();
+      }
     },
   },
   {
@@ -25,6 +30,24 @@ export const createCommands = (context: CommandContext): Command[] => [
     execute: () => {
       if (context.triggerAgentSwitch) {
         context.triggerAgentSwitch();
+      }
+    },
+  },
+  {
+    name: "new",
+    description: "Start a new conversation",
+    execute: () => {
+      if (context.startNewConversation) {
+        context.startNewConversation();
+      }
+    },
+  },
+  {
+    name: "resume",
+    description: "Resume a recent conversation",
+    execute: () => {
+      if (context.resumeConversation) {
+        context.resumeConversation();
       }
     },
   },
@@ -53,6 +76,13 @@ export const createCommands = (context: CommandContext): Command[] => [
       if (context.toggleAutoEdits) {
         context.toggleAutoEdits();
       }
+    },
+  },
+  {
+    name: "exit",
+    description: "Exit the chat",
+    execute: () => {
+      process.exit(0);
     },
   },
 ];


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

This PR adds a way to create a new conversastion without leaving the CLI, and resuming a previous Dust converstaion.

<img width="1255" height="456" alt="Capture d’écran 2026-02-10 à 14 22 36" src="https://github.com/user-attachments/assets/4c91089a-e10e-4cfd-aac6-eb1feddafaab" />

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy CLI