### PR TITLE
feat(cli): inline selector for /attach and /switch

### DIFF
--- a/cli/src/ui/components/Conversation.tsx
+++ b/cli/src/ui/components/Conversation.tsx
@@ -17,6 +17,8 @@ import { clearTerminal } from "../../utils/terminal.js";
 import type { Command } from "../commands/types.js";
 import { CommandSelector } from "./CommandSelector.js";
 import type { UploadedFile } from "./FileUpload.js";
+import type { InlineSelectorItem } from "./InlineSelector.js";
+import { InlineSelector } from "./InlineSelector.js";
 import { InputBox } from "./InputBox.js";
 
 export type ConversationItem = { key: string } & (
@@ -73,6 +75,13 @@ interface ConversationProps {
   commandCursorPosition: number;
   commands?: Command[];
   autoAcceptEdits: boolean;
+  inlineSelector?: {
+    items: InlineSelectorItem[];
+    query: string;
+    selectedIndex: number;
+    prompt?: string;
+    header?: React.ReactNode;
+  } | null;
 }
 
 const _Conversation: FC<ConversationProps> = ({
@@ -89,6 +98,7 @@ const _Conversation: FC<ConversationProps> = ({
   commandCursorPosition,
   commands = [],
   autoAcceptEdits,
+  inlineSelector,
 }: ConversationProps) => {
   return (
     <Box flexDirection="column" height="100%">
@@ -129,7 +139,16 @@ const _Conversation: FC<ConversationProps> = ({
           onSelect={() => {}}
         />
       )}
-      {!showCommandSelector && (
+      {!showCommandSelector && inlineSelector && (
+        <InlineSelector
+          items={inlineSelector.items}
+          query={inlineSelector.query}
+          selectedIndex={inlineSelector.selectedIndex}
+          prompt={inlineSelector.prompt}
+          header={inlineSelector.header}
+        />
+      )}
+      {!showCommandSelector && !inlineSelector && (
         <Box marginTop={0} paddingLeft={1}>
           <Text dimColor>
             ↵ to send · \↵ for new line · ESC to clear

--- a/cli/src/ui/components/InlineSelector.tsx
+++ b/cli/src/ui/components/InlineSelector.tsx
@@ -1,0 +1,74 @@
+import { Box, Text } from "ink";
+import React from "react";
+
+export interface InlineSelectorItem {
+  id: string;
+  label: string;
+  description?: string;
+}
+
+interface InlineSelectorProps {
+  items: InlineSelectorItem[];
+  query: string;
+  selectedIndex: number;
+  maxVisible?: number;
+  prompt?: string;
+  header?: React.ReactNode;
+}
+
+export function InlineSelector({
+  items,
+  query,
+  selectedIndex,
+  maxVisible = 10,
+  prompt,
+  header,
+}: InlineSelectorProps) {
+  const filtered = items.filter((item) =>
+    item.label.toLowerCase().includes(query.toLowerCase())
+  );
+
+  const visible = filtered.slice(0, maxVisible);
+  const remaining = filtered.length - visible.length;
+
+  return (
+    <Box flexDirection="column">
+      {header && <Box paddingX={1}>{header}</Box>}
+      {prompt && (
+        <Box paddingX={1}>
+          <Text dimColor>{prompt}</Text>
+        </Box>
+      )}
+      {visible.length === 0 ? (
+        <Box paddingX={1}>
+          <Text dimColor>No matches</Text>
+        </Box>
+      ) : (
+        <Box paddingX={1} flexDirection="column">
+          {visible.map((item, index) => {
+            const isSelected = index === selectedIndex;
+            return (
+              <Box key={item.id} flexDirection="row">
+                <Text color={isSelected ? "blue" : undefined} bold={isSelected}>
+                  {isSelected ? "> " : "  "}
+                  {item.label}
+                </Text>
+                {item.description && (
+                  <Text dimColor>
+                    {"  "}
+                    {item.description}
+                  </Text>
+                )}
+              </Box>
+            );
+          })}
+          {remaining > 0 && (
+            <Box>
+              <Text dimColor> ({remaining} more)</Text>
+            </Box>
+          )}
+        </Box>
+      )}
+    </Box>
+  );
+}


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

This PR changes the UI for /attach and /switch to use an inline selector. Same UI as what we did when we do a / command.

This also allows to hit "ESC" to return to input, which was not possible when it was a standalone page separated from this.

Agent picker ⏬ 
<img width="1255" height="456" alt="Capture d’écran 2026-02-10 à 11 22 11" src="https://github.com/user-attachments/assets/941fc360-005f-436e-b581-38ace949d2c6" />

File picker ⏬ 
<img width="1255" height="456" alt="Capture d’écran 2026-02-10 à 11 22 16" src="https://github.com/user-attachments/assets/511aa6a9-3020-44d5-b830-17ebb04e9691" />

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy CLI