### PR TITLE
copilot: Mcp inspect single message

### DIFF
--- a/front/components/actions/mcp/details/MCPActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPActionDetails.tsx
@@ -1,5 +1,3 @@
-
-
 import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
 import {
   makeQueryTextForDataSourceSearch,
@@ -100,10 +98,10 @@ import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
+  ContentBlockWrapper,
   ContentMessage,
   cn,
   GlobeAltIcon,
-  ContentBlockWrapper,
   MagnifyingGlassIcon,
   Markdown,
 } from "@dust-tt/sparkle";

--- a/front/components/actions/mcp/details/MCPActionDetails.tsx
+++ b/front/components/actions/mcp/details/MCPActionDetails.tsx
@@ -1,3 +1,5 @@
+
+
 import { ActionDetailsWrapper } from "@app/components/actions/ActionDetailsWrapper";
 import {
   makeQueryTextForDataSourceSearch,
@@ -101,6 +103,7 @@ import {
   ContentMessage,
   cn,
   GlobeAltIcon,
+  ContentBlockWrapper,
   MagnifyingGlassIcon,
   Markdown,
 } from "@dust-tt/sparkle";
@@ -515,8 +518,10 @@ const RenderToolItemMarkdown = ({
   }
 
   return (
-    <ContentMessage variant="primary" size="lg">
-      <Markdown content={text} />
-    </ContentMessage>
+    <ContentBlockWrapper content={text}>
+      <ContentMessage variant="primary" size="lg">
+        <Markdown content={text} />
+      </ContentMessage>
+    </ContentBlockWrapper>
   );
 };

--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -16,6 +16,7 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "get_available_tools": "never_ask",
     "inspect_available_agent": "never_ask",
     "inspect_conversation": "never_ask",
+    "inspect_message": "never_ask",
     "list_suggestions": "never_ask",
     "search_agent_templates": "never_ask",
     "suggest_model": "never_ask",

--- a/front/lib/api/actions/servers/agent_copilot_context/agent_copilot_context.test.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/agent_copilot_context.test.ts
@@ -1,6 +1,6 @@
 import { USED_MODEL_CONFIGS } from "@app/components/providers/types";
-import { getSuggestedTemplatesForQuery } from "@app/lib/api/assistant/template_suggestion";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
+import { getSuggestedTemplatesForQuery } from "@app/lib/api/assistant/template_suggestion";
 import { Authenticator } from "@app/lib/auth";
 import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";

--- a/front/lib/api/actions/servers/agent_copilot_context/agent_copilot_context.test.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/agent_copilot_context.test.ts
@@ -1,5 +1,6 @@
 import { USED_MODEL_CONFIGS } from "@app/components/providers/types";
 import { getSuggestedTemplatesForQuery } from "@app/lib/api/assistant/template_suggestion";
+import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { Authenticator } from "@app/lib/auth";
 import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -1844,7 +1845,7 @@ describe("agent_copilot_context tools", () => {
           // Should not indicate truncation.
           expect(text).not.toContain("_(conversation truncated)_");
           // 2 user messages + 2 agent messages = 4 "## Message" headers.
-          const messageHeaders = text.match(/^## Message \d+$/gm) ?? [];
+          const messageHeaders = text.match(/^## Message \d+: \S+$/gm) ?? [];
           expect(messageHeaders).toHaveLength(4);
           // First message should be from user.
           expect(text).toContain("from user");
@@ -2006,11 +2007,185 @@ describe("agent_copilot_context tools", () => {
         if (content.type === "text") {
           const text = content.text;
           // Should have 2 messages (index 1 and 2).
-          const messageHeaders = text.match(/^## Message \d+$/gm) ?? [];
+          const messageHeaders = text.match(/^## Message \d+: \S+$/gm) ?? [];
           expect(messageHeaders).toHaveLength(2);
           // Should indicate truncation.
           expect(text).toContain("_(conversation truncated)_");
         }
+      }
+    });
+  });
+
+  describe("inspect_message", () => {
+    it("returns user message details", async () => {
+      const { authenticator, workspace } = await createResourceTest({
+        role: "admin",
+      });
+
+      const agentConfiguration =
+        await AgentConfigurationFactory.createTestAgent(authenticator);
+
+      const conversation = await ConversationFactory.create(authenticator, {
+        agentConfigurationId: agentConfiguration.sId,
+        messagesCreatedAt: [],
+      });
+
+      // Create a user message with a known sId.
+      const userMsgRow = await ConversationFactory.createUserMessageWithRank({
+        auth: authenticator,
+        workspace,
+        conversationId: conversation.id,
+        rank: 0,
+        content: "Hello world",
+      });
+
+      const tool = getToolByName("inspect_message");
+      const result = await tool.handler(
+        { conversationId: conversation.sId, messageId: userMsgRow.sId },
+        createTestExtra(authenticator)
+      );
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        const content = result.value[0];
+        expect(content.type).toBe("text");
+        if (content.type === "text") {
+          const text = content.text;
+          expect(text).toContain(`# User message ${userMsgRow.sId}`);
+          expect(text).toContain("from");
+          expect(text).toContain("## Content");
+          expect(text).toContain("Hello world");
+        }
+      }
+    });
+
+    it("returns agent message details", async () => {
+      const { authenticator } = await createResourceTest({
+        role: "admin",
+      });
+
+      const agentConfiguration =
+        await AgentConfigurationFactory.createTestAgent(authenticator);
+
+      // Create a conversation with one message pair (user + agent).
+      const conversation = await ConversationFactory.create(authenticator, {
+        agentConfigurationId: agentConfiguration.sId,
+        messagesCreatedAt: [new Date()],
+      });
+
+      // Fetch the conversation to find the agent message sId.
+      const conversationRes = await getConversation(
+        authenticator,
+        conversation.sId
+      );
+      expect(conversationRes.isOk()).toBe(true);
+      if (!conversationRes.isOk()) {
+        return;
+      }
+      const fullConversation = conversationRes.value;
+      const agentMessageSId = fullConversation.content
+        .flat()
+        .find((m) => m.type === "agent_message")?.sId;
+      expect(agentMessageSId).toBeDefined();
+
+      const tool = getToolByName("inspect_message");
+      const result = await tool.handler(
+        { conversationId: conversation.sId, messageId: agentMessageSId! },
+        createTestExtra(authenticator)
+      );
+
+      expect(result.isOk()).toBe(true);
+      if (result.isOk()) {
+        const content = result.value[0];
+        expect(content.type).toBe("text");
+        if (content.type === "text") {
+          const text = content.text;
+          expect(text).toContain("# Agent message");
+          expect(text).toContain(agentConfiguration.sId);
+          expect(text).toContain("## Content");
+        }
+      }
+    });
+
+    it("returns error for non-existent message", async () => {
+      const { authenticator } = await createResourceTest({ role: "admin" });
+
+      const agentConfiguration =
+        await AgentConfigurationFactory.createTestAgent(authenticator);
+
+      const conversation = await ConversationFactory.create(authenticator, {
+        agentConfigurationId: agentConfiguration.sId,
+        messagesCreatedAt: [new Date()],
+      });
+
+      const tool = getToolByName("inspect_message");
+      const result = await tool.handler(
+        {
+          conversationId: conversation.sId,
+          messageId: "non-existent-message-id",
+        },
+        createTestExtra(authenticator)
+      );
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.message).toContain("Message not found");
+        expect(result.error.message).toContain("non-existent-message-id");
+      }
+    });
+
+    it("returns error for non-existent conversation", async () => {
+      const { authenticator } = await createResourceTest({ role: "admin" });
+
+      const tool = getToolByName("inspect_message");
+      const result = await tool.handler(
+        {
+          conversationId: "non-existent-conversation-id",
+          messageId: "some-message-id",
+        },
+        createTestExtra(authenticator)
+      );
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.message).toContain("not found or not accessible");
+      }
+    });
+
+    it("prevents cross-workspace unauthorized message access", async () => {
+      const { authenticator: auth1, workspace: workspace1 } =
+        await createResourceTest({
+          role: "admin",
+        });
+
+      const { authenticator: auth2 } = await createResourceTest({
+        role: "admin",
+      });
+
+      const agentConfiguration =
+        await AgentConfigurationFactory.createTestAgent(auth1);
+      const conversation = await ConversationFactory.create(auth1, {
+        agentConfigurationId: agentConfiguration.sId,
+        messagesCreatedAt: [],
+      });
+
+      const userMsgRow = await ConversationFactory.createUserMessageWithRank({
+        auth: auth1,
+        workspace: workspace1,
+        conversationId: conversation.id,
+        rank: 0,
+        content: "Secret message",
+      });
+
+      const tool = getToolByName("inspect_message");
+      const result = await tool.handler(
+        { conversationId: conversation.sId, messageId: userMsgRow.sId },
+        createTestExtra(auth2)
+      );
+
+      expect(result.isErr()).toBe(true);
+      if (result.isErr()) {
+        expect(result.error.message).toContain("not found or not accessible");
       }
     });
   });

--- a/front/lib/api/actions/servers/agent_copilot_context/metadata.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/metadata.ts
@@ -409,6 +409,21 @@ export const AGENT_COPILOT_CONTEXT_TOOLS_METADATA = createToolsRecord({
       done: "Inspect conversation",
     },
   },
+  inspect_message: {
+    description:
+      "Inspect a specific message in a conversation. Returns detailed information about " +
+      "a user message (content, mentions, context, content fragments) or an agent message " +
+      "(actions with inputs/outputs, status, errors, chain of thought, handoffs).",
+    schema: {
+      conversationId: z.string().describe("The conversation ID"),
+      messageId: z.string().describe("The ID of the message to inspect"),
+    },
+    stake: "never_ask",
+    displayLabels: {
+      running: "Inspecting message",
+      done: "Inspect message",
+    },
+  },
 });
 
 export const AGENT_COPILOT_CONTEXT_SERVER = {

--- a/front/lib/api/actions/servers/agent_copilot_context/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/tools/index.ts
@@ -50,7 +50,7 @@ import type { JobType } from "@app/types/job_type";
 import { isJobType } from "@app/types/job_type";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
-import { removeNulls } from "@app/types/shared/utils/general";
+import { isString, removeNulls } from "@app/types/shared/utils/general";
 import type { SpaceType } from "@app/types/space";
 import type {
   AgentSuggestionState,
@@ -1321,7 +1321,7 @@ const handlers: ToolHandlers<typeof AGENT_COPILOT_CONTEXT_TOOLS_METADATA> = {
           let actionLine = `- ${action.functionCallName} (${actionStatus})`;
           if (action.internalMCPServerName === "run_agent") {
             const childConvId = action.params.conversationId;
-            if (typeof childConvId === "string") {
+            if (isString(childConvId)) {
               actionLine += ` → child conversation: ${childConvId}`;
             }
           }
@@ -1507,7 +1507,7 @@ const handlers: ToolHandlers<typeof AGENT_COPILOT_CONTEXT_TOOLS_METADATA> = {
         }
         if (action.internalMCPServerName === "run_agent") {
           const childConvId = action.params.conversationId;
-          if (typeof childConvId === "string") {
+          if (isString(childConvId)) {
             lines.push(`child conversation: ${childConvId}`);
           }
         }

--- a/front/lib/api/actions/servers/agent_copilot_context/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/tools/index.ts
@@ -44,6 +44,8 @@ import { CUSTOM_MODEL_CONFIGS } from "@app/types/assistant/models/custom_models.
 import { isModelProviderId } from "@app/types/assistant/models/providers";
 import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 import type { TemplateTagCodeType } from "@app/types/assistant/templates";
+import type { ContentFragmentType } from "@app/types/content_fragment";
+import { isContentFragmentType } from "@app/types/content_fragment";
 import type { JobType } from "@app/types/job_type";
 import { isJobType } from "@app/types/job_type";
 import { Err, Ok } from "@app/types/shared/result";
@@ -1280,9 +1282,9 @@ const handlers: ToolHandlers<typeof AGENT_COPILOT_CONTEXT_TOOLS_METADATA> = {
         const { content, contentTruncated } = truncateContent(msg.content);
         currentTotalChars += content ? content.length : 0;
 
-        lines.push(`## Message ${index}`);
+        lines.push(`## Message ${index}: ${msg.sId}`);
         lines.push(`at ${msg.created}`);
-        lines.push(`from user ${msg.sId}`);
+        lines.push(`from user ${msg.context.username}`);
         const mentions = msg.mentions.filter(isAgentMention);
         if (mentions.length > 0) {
           lines.push(
@@ -1303,7 +1305,7 @@ const handlers: ToolHandlers<typeof AGENT_COPILOT_CONTEXT_TOOLS_METADATA> = {
 
       const status = agentMsg.status === "succeeded" ? "succeeded" : "failed";
 
-      lines.push(`## Message ${index}`);
+      lines.push(`## Message ${index}: ${agentMsg.sId}`);
       lines.push(`at ${agentMsg.created}`);
       lines.push(
         `from agent ${agentMsg.configuration.sId} (${agentMsg.configuration.name}) - ${status}`
@@ -1341,6 +1343,217 @@ const handlers: ToolHandlers<typeof AGENT_COPILOT_CONTEXT_TOOLS_METADATA> = {
       lines.push(content ?? "_empty_");
       lines.push("");
     }
+
+    return new Ok([
+      {
+        type: "text" as const,
+        text: lines.join("\n"),
+      },
+    ]);
+  },
+
+  inspect_message: async ({ conversationId, messageId }, extra) => {
+    const auth = extra.auth;
+    if (!auth) {
+      return new Err(new MCPError("Authentication required"));
+    }
+
+    const conversationRes = await getConversation(auth, conversationId);
+    if (conversationRes.isErr()) {
+      return new Err(
+        new MCPError(
+          `Conversation not found or not accessible: ${conversationId}`,
+          { tracked: false }
+        )
+      );
+    }
+
+    const conversation = conversationRes.value;
+
+    // Flatten to last version of each message, find the target by sId.
+    let foundMessage: UserMessageType | AgentMessageType | null = null;
+    let foundIndex = -1;
+    const flatMessages: (
+      | UserMessageType
+      | AgentMessageType
+      | ContentFragmentType
+    )[] = [];
+
+    for (const messageVersions of conversation.content) {
+      if (messageVersions.length === 0) {
+        continue;
+      }
+      const lastVersion = messageVersions[messageVersions.length - 1];
+      flatMessages.push(lastVersion);
+    }
+
+    for (let i = 0; i < flatMessages.length; i++) {
+      const msg = flatMessages[i];
+      if (
+        (isUserMessageType(msg) || isAgentMessageType(msg)) &&
+        msg.sId === messageId
+      ) {
+        foundMessage = msg;
+        foundIndex = i;
+        break;
+      }
+    }
+
+    // Collect content fragments that precede the found user message.
+    const contentFragments: {
+      sId: string;
+      title: string;
+      contentType: string;
+    }[] = [];
+
+    if (foundMessage && isUserMessageType(foundMessage)) {
+      for (let j = foundIndex - 1; j >= 0; j--) {
+        const prev = flatMessages[j];
+        if (isContentFragmentType(prev)) {
+          contentFragments.unshift({
+            sId: prev.sId,
+            title: prev.title,
+            contentType: prev.contentType,
+          });
+        } else {
+          break;
+        }
+      }
+    }
+
+    if (!foundMessage) {
+      return new Err(
+        new MCPError(
+          `Message not found: ${messageId} in conversation ${conversationId}`,
+          { tracked: false }
+        )
+      );
+    }
+
+    const lines: string[] = [];
+
+    if (isUserMessageType(foundMessage)) {
+      lines.push(`# User message ${foundMessage.sId}`);
+      lines.push(`at ${foundMessage.created}`);
+      lines.push(
+        `from ${foundMessage.context.username} (${foundMessage.context.email})`
+      );
+      if (foundMessage.context.origin) {
+        lines.push(`origin: ${foundMessage.context.origin}`);
+      }
+      const mentions = foundMessage.mentions.filter(isAgentMention);
+      if (mentions.length > 0) {
+        lines.push(
+          `mentions: ${mentions.map((m) => m.configurationId).join(", ")}`
+        );
+      }
+      lines.push("");
+
+      if (contentFragments.length > 0) {
+        lines.push("## Content fragments");
+        for (const cf of contentFragments) {
+          lines.push(`- ${cf.title} (${cf.contentType}) [${cf.sId}]`);
+        }
+        lines.push("");
+      }
+
+      lines.push("## Content");
+      lines.push(foundMessage.content ?? "_empty_");
+      lines.push("");
+
+      return new Ok([
+        {
+          type: "text" as const,
+          text: lines.join("\n"),
+        },
+      ]);
+    }
+
+    // Agent message.
+    const agentMsg = foundMessage;
+    const status = agentMsg.status === "succeeded" ? "succeeded" : "failed";
+
+    lines.push(
+      `# Agent message ${agentMsg.sId} from ${agentMsg.configuration.sId} (${agentMsg.configuration.name}) - ${status}`
+    );
+    lines.push(`at ${agentMsg.created}`);
+    if (agentMsg.parentMessageId) {
+      lines.push(`parent message: ${agentMsg.parentMessageId}`);
+    }
+    if (agentMsg.parentAgentMessageId) {
+      lines.push(`parent agent message: ${agentMsg.parentAgentMessageId}`);
+    }
+    lines.push("");
+
+    if (agentMsg.error) {
+      lines.push(
+        `**Error** [${agentMsg.error.code}]: ${agentMsg.error.message}`
+      );
+      lines.push("");
+    }
+
+    // Actions.
+    if (agentMsg.actions.length > 0) {
+      lines.push("## Actions");
+      for (const action of agentMsg.actions) {
+        const actionStatus =
+          action.status === "succeeded" ? "success" : "error";
+        lines.push(
+          `### ${action.functionCallName} (${actionStatus}) [${action.sId}]`
+        );
+        lines.push(`at ${action.createdAt}`);
+        if (action.executionDurationMs !== null) {
+          lines.push(`duration: ${action.executionDurationMs}ms`);
+        }
+        if (action.internalMCPServerName === "run_agent") {
+          const childConvId = action.params.conversationId;
+          if (typeof childConvId === "string") {
+            lines.push(`child conversation: ${childConvId}`);
+          }
+        }
+        lines.push("");
+        lines.push("**Input:**");
+        lines.push("```json");
+        lines.push(JSON.stringify(action.params, null, 2));
+        lines.push("```");
+        lines.push("");
+        lines.push("**Output:**");
+        lines.push("```json");
+        lines.push(JSON.stringify(action.output, null, 2));
+        lines.push("```");
+        lines.push("");
+      }
+    }
+
+    // Find agents that this message handed off to.
+    const handoffTargets: { agentSId: string; agentName: string }[] = [];
+    for (const msg of flatMessages) {
+      if (
+        isAgentMessageType(msg) &&
+        msg.parentAgentMessageId === agentMsg.sId
+      ) {
+        handoffTargets.push({
+          agentSId: msg.configuration.sId,
+          agentName: msg.configuration.name,
+        });
+      }
+    }
+    if (handoffTargets.length > 0) {
+      lines.push(
+        `Handed off to: ${handoffTargets.map((h) => `${h.agentSId} (${h.agentName})`).join(", ")}`
+      );
+      lines.push("");
+    }
+
+    if (agentMsg.chainOfThought) {
+      lines.push("## Chain of thought");
+      lines.push(agentMsg.chainOfThought);
+      lines.push("");
+    }
+
+    lines.push("## Content");
+    lines.push(agentMsg.content ?? "_empty_");
+    lines.push("");
 
     return new Ok([
       {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "clean": "find . -name 'node_modules' -type d -prune -exec rm -rf '{}' +",
     "install:all": "npm install",
     "knip": "knip",
-    "format": "biome format --write .",
+    "format": "biome check --write .",
     "format:check": "biome check .",
     "format:lefthook": "biome format --write",
     "lint": "biome lint .",


### PR DESCRIPTION
## Description

 - MCP to inspect message
 - return format as markdown
 - wrap the markdown display of tool result to get a copy button (so we can copy as markdown and not just text)

## Tests
Unit tests and manual tests 

<img width="1964" height="822" alt="image" src="https://github.com/user-attachments/assets/b5e62d3b-7f28-4b7b-ba6b-fa43550ec244" />

<img width="2274" height="1446" alt="image" src="https://github.com/user-attachments/assets/a8c41765-b0cd-4596-8c17-94621912821e" />

## Risk

low

## Deploy Plan

deploy front