### PR TITLE
Fix agent execution duration

### DIFF
--- a/front/components/assistant/conversation/AgentMessageCompletionStatus.tsx
+++ b/front/components/assistant/conversation/AgentMessageCompletionStatus.tsx
@@ -31,14 +31,14 @@ export const AgentMessageCompletionStatus = ({
   let timeString: null | string = null;
 
   // If we have a completed timestamp, we can show the duration.
-  if (agentMessage.completedTs !== null) {
+  if (agentMessage.completionDurationMs !== null) {
     let statusText = "Completed in";
     if (agentMessage.status === "failed") {
       statusText = "Errored after";
     } else if (agentMessage.status === "cancelled") {
       statusText = "Cancelled after";
     }
-    const completedInMs = agentMessage.completedTs - agentMessage.created;
+    const completedInMs = agentMessage.completionDurationMs;
     timeString = formatDurationString(completedInMs);
     displayText = statusText;
   }

--- a/front/components/assistant/conversation/AgentMessageCompletionStatus.tsx
+++ b/front/components/assistant/conversation/AgentMessageCompletionStatus.tsx
@@ -31,14 +31,14 @@ export const AgentMessageCompletionStatus = ({
   let timeString: null | string = null;
 
   // If we have a completed timestamp, we can show the duration.
-  if (agentMessage.completionDurationMs !== null) {
+  if (agentMessage.completedTs !== null) {
     let statusText = "Completed in";
     if (agentMessage.status === "failed") {
       statusText = "Errored after";
     } else if (agentMessage.status === "cancelled") {
       statusText = "Cancelled after";
     }
-    const completedInMs = agentMessage.completionDurationMs;
+    const completedInMs = agentMessage.completedTs - agentMessage.created;
     timeString = formatDurationString(completedInMs);
     displayText = statusText;
   }

--- a/front/components/assistant/conversation/actions/AgentActionsPanelSummary.tsx
+++ b/front/components/assistant/conversation/actions/AgentActionsPanelSummary.tsx
@@ -16,14 +16,13 @@ export function AgentActionSummary({
 }) {
   // Do not display summary if we did not store the completion time.
   // All new agent messages should have a completion time as of now.
-  if (!agentMessageToRender.completedTs) {
+  if (!agentMessageToRender.completionDurationMs) {
     return null;
   }
 
   const nbActions = agentMessageToRender.actions.length;
   const showSeparator = nbActions > 0;
-  const completedInMs =
-    agentMessageToRender.completedTs - agentMessageToRender.created;
+  const completedInMs = agentMessageToRender.completionDurationMs;
 
   let statusText = "Completed in";
   if (agentMessageToRender.status === "failed") {


### PR DESCRIPTION
## Description

This PR fixes a bug where the agent execution duration shown in the conversation UI doesn't reflect actual agent processing time. 
e.g. A deep-dive agent that ran for 32min34sec displayed "2m23sec" in the conversation.

This PR harmonizes the way this duration is calculated between the panel and the agent message, using `completedTs - created` instead of `completionDurationMs` (which doesn't seem to reflect the actual processing time).

<img width="435" height="146" alt="image" src="https://github.com/user-attachments/assets/92b0eb37-9eea-4eed-92ae-9af9483b5a1f" /> <br />
--
<img width="893" height="58" alt="image" src="https://github.com/user-attachments/assets/f55b8d7c-138b-4b8d-9270-892cf15ade4a" />


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Deploy front
