### PR TITLE
fix: update copilot context tool to use split template description fields

### DIFF
--- a/front/lib/api/actions/servers/agent_copilot_context/agent_copilot_context.test.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/agent_copilot_context.test.ts
@@ -1444,7 +1444,12 @@ describe("agent_copilot_context tools", () => {
           const parsed = JSON.parse(content.text);
           expect(parsed.sId).toBe(template.sId);
           expect(parsed.handle).toBe(template.handle);
-          expect(parsed.description).toBe(template.description);
+          expect(parsed.userFacingDescription).toBe(
+            template.userFacingDescription
+          );
+          expect(parsed.agentFacingDescription).toBe(
+            template.agentFacingDescription
+          );
           expect(parsed.copilotInstructions).toBe(
             "Test copilot instructions for this template"
           );

--- a/front/lib/api/actions/servers/agent_copilot_context/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/tools/index.ts
@@ -1457,7 +1457,8 @@ const handlers: ToolHandlers<typeof AGENT_COPILOT_CONTEXT_TOOLS_METADATA> = {
           {
             sId: template.sId,
             handle: template.handle,
-            description: template.description,
+            userFacingDescription: template.userFacingDescription,
+            agentFacingDescription: template.agentFacingDescription,
             copilotInstructions: template.copilotInstructions,
           },
           null,


### PR DESCRIPTION
## Description

#21301 split `templates.description` into `userFacingDescription` + `agentFacingDescription` but missed updating the `get_agent_template` copilot context tool and its test. This fixes the build.

## Tests

Type-check passes (`npx tsgo --noEmit`).

## Risk

Low — straightforward field rename, no behavior change.

## Deploy Plan

Standard deploy, no special steps needed.