### PR TITLE
Reload if app is outdated

### DIFF
--- a/front-spa/src/app/App.tsx
+++ b/front-spa/src/app/App.tsx
@@ -31,17 +31,24 @@ function PageLoader() {
   );
 }
 
-// Helper to wrap lazy components with Suspense
+// Helper to wrap lazy components with Suspense.
+// On chunk load failure (typically after a deploy replaces old assets),
+// automatically reload to get fresh assets.
 function withSuspense(
   importFn: () => Promise<Record<string, unknown>>,
   exportName?: string
 ) {
   const LazyComponent = lazy(() =>
-    importFn().then((module) => ({
-      default: (exportName
-        ? module[exportName]
-        : module.default) as React.ComponentType,
-    }))
+    importFn()
+      .catch(() => {
+        window.location.reload();
+        return new Promise<Record<string, unknown>>(() => {});
+      })
+      .then((module) => ({
+        default: (exportName
+          ? module[exportName]
+          : module.default) as React.ComponentType,
+      }))
   );
   return function SuspenseWrapper() {
     return (


### PR DESCRIPTION
## Description

Fixes random "Failed to fetch dynamically imported module" .

This is a common issue with SPAs deployed behind CDNs. When deploying, we remove old chunks, which are not available anymore for previous versions of the app.

1. User loads the app : browser caches index.html which references chunk-abc123.js
2. You deploy a new version : Cloudflare Pages now serves chunk-def456.js, the old chunk-abc123.js no longer exists
3. User navigates to a new route (triggering a lazy import()) : browser requests chunk-abc123.js : 404 : "Failed to fetch dynamically imported module"

Fix auto-reload the whole app when a chunk fail to load.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy spa