### PR TITLE
[COPILOT] Turn into agent call to action

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -482,6 +482,7 @@ export function AgentMessage({
   const { featureFlags } = useFeatureFlags({
     workspaceId: owner.sId,
   });
+  const hasCopilotFeatureFlag = featureFlags.includes("agent_builder_copilot");
 
   const handleDeleteAgentMessage = useCallback(async () => {
     if (isDeleted || !canDeleteAgentMessage || isDeleting) {
@@ -599,7 +600,7 @@ export function AgentMessage({
       });
     }
 
-    if (featureFlags.includes("agent_builder_copilot") && isLastMessage) {
+    if (hasCopilotFeatureFlag && isLastMessage) {
       dropdownItems.push({
         label: "Turn into agent",
         icon: RobotIcon,

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -15,6 +15,7 @@ import {
   InteractiveImageGrid,
   LinkIcon,
   MoreIcon,
+  RobotIcon,
   StopIcon,
   Tooltip,
   TrashIcon,
@@ -78,6 +79,7 @@ import {
   useCancelMessage,
   usePostOnboardingFollowUp,
 } from "@app/lib/swr/conversations";
+import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import { getConversationRoute } from "@app/lib/utils/router";
 import { formatTimestring } from "@app/lib/utils/timestamps";
 import type {
@@ -477,6 +479,10 @@ export function AgentMessage({
   const canDeleteAgentMessage =
     !isDeleted && agentMessage.status !== "created" && isTriggeredByCurrentUser;
 
+  const { featureFlags } = useFeatureFlags({
+    workspaceId: owner.sId,
+  });
+
   const handleDeleteAgentMessage = useCallback(async () => {
     if (isDeleted || !canDeleteAgentMessage || isDeleting) {
       return;
@@ -590,6 +596,14 @@ export function AgentMessage({
           });
         },
         disabled: isRetryHandlerProcessing || shouldStream,
+      });
+    }
+
+    if (featureFlags.includes("agent_builder_copilot") && isLastMessage) {
+      dropdownItems.push({
+        label: "Turn into agent",
+        icon: RobotIcon,
+        onSelect: () => {},
       });
     }
 


### PR DESCRIPTION
## Description

Adds button in UI to enable user to turn a conversation into an agent
UI only, nothing happens on click
In the last agent message of the conversation: might be placed in the input bar later 

<img width="944" height="709" alt="image" src="https://github.com/user-attachments/assets/a8dbecad-98ad-4034-ab07-82c2370944f7" />


## Tests

local

## Risk

No - feature flagged

## Deploy Plan

front
