### PR TITLE
copilot: MCP to Inspect existing agent

### DIFF
--- a/front/lib/api/actions/servers/agent_copilot_context/metadata.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/metadata.ts
@@ -134,6 +134,18 @@ export const AGENT_COPILOT_CONTEXT_TOOLS_METADATA = createToolsRecord({
       done: "List available agents",
     },
   },
+  inspect_available_agent: {
+    description:
+      "Get detailed information about a specific agent by its ID. Returns the agent's name, description, prompt/instructions, list of tool IDs, and list of skill IDs.",
+    schema: {
+      agentId: z.string().describe("The agent ID (sId) to inspect"),
+    },
+    stake: "never_ask",
+    displayLabels: {
+      running: "Inspecting agent",
+      done: "Inspect agent",
+    },
+  },
   get_agent_feedback: {
     description: "Get user feedback for the agent.",
     schema: {

--- a/front/tests/utils/AgentMCPServerConfigurationFactory.ts
+++ b/front/tests/utils/AgentMCPServerConfigurationFactory.ts
@@ -1,27 +1,37 @@
 import { autoInternalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
 import type { Authenticator } from "@app/lib/auth";
 import { AgentMCPServerConfigurationModel } from "@app/lib/models/agent/actions/mcp";
+import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import type { SpaceResource } from "@app/lib/resources/space_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { MCPServerViewFactory } from "@app/tests/utils/MCPServerViewFactory";
+import type { AgentConfigurationType } from "@app/types/assistant/agent";
 
 export class AgentMCPServerConfigurationFactory {
   static async create(
     auth: Authenticator,
-    space: SpaceResource
+    space: SpaceResource,
+    options?: {
+      agent?: AgentConfigurationType;
+      mcpServerView?: MCPServerViewResource;
+    }
   ): Promise<AgentMCPServerConfigurationModel> {
     const owner = auth.getNonNullableWorkspace();
 
-    const agent = await AgentConfigurationFactory.createTestAgent(auth);
-    const mcpServerView = await MCPServerViewFactory.create(
-      owner,
-      autoInternalMCPServerNameToSId({
-        name: "search",
-        workspaceId: owner.id,
-      }),
-      space
-    );
+    const agent =
+      options?.agent ?? (await AgentConfigurationFactory.createTestAgent(auth));
+
+    const mcpServerView =
+      options?.mcpServerView ??
+      (await MCPServerViewFactory.create(
+        owner,
+        autoInternalMCPServerNameToSId({
+          name: "search",
+          workspaceId: owner.id,
+        }),
+        space
+      ));
 
     return AgentMCPServerConfigurationModel.create({
       sId: generateRandomModelSId(),


### PR DESCRIPTION
## Description

Add a MCP tool so the copilot can inspect other agent, which is useful for shrink wrap use case.
Tools and skills are returned as IDs but the agent can explore the tools/skills already with another MCP tool

## Tests

Add unit test, including listing tools and skills.

## Risk

low

## Deploy Plan

deploy front
