### PR TITLE
[Poke] Add region flag in worspace page

### DIFF
--- a/front/components/poke/pages/WorkspacePage.tsx
+++ b/front/components/poke/pages/WorkspacePage.tsx
@@ -1,5 +1,6 @@
 import {
   Button,
+  Chip,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -40,6 +41,8 @@ import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { clientFetch } from "@app/lib/egress/client";
 import { useAppRouter } from "@app/lib/platform";
+import { getRegionChipColor, getRegionDisplay } from "@app/lib/poke/regions";
+import { usePokeRegion } from "@app/lib/swr/poke";
 import { usePokeDataRetention } from "@app/poke/swr/data_retention";
 import { usePokeWorkspaceInfo } from "@app/poke/swr/workspace_info";
 import type { WorkspaceSegmentationType } from "@app/types";
@@ -48,6 +51,7 @@ import { isString } from "@app/types";
 export function WorkspacePage() {
   const owner = useWorkspace();
   useSetPokePageTitle(owner.name ?? "Workspace");
+  const { regionData } = usePokeRegion();
 
   const router = useAppRouter();
 
@@ -146,7 +150,14 @@ export function WorkspacePage() {
       )}
       <div className="flex justify-between gap-3">
         <div className="flex-grow">
-          <span className="text-2xl font-bold">{owner.name}</span>
+          <div className="flex items-center gap-2">
+            <span className="text-2xl font-bold">{owner.name}</span>
+            {regionData && (
+              <Chip size="xs" color={getRegionChipColor(regionData.region)}>
+                {getRegionDisplay(regionData.region)}
+              </Chip>
+            )}
+          </div>
           <div className="flex gap-4 pt-2">
             <Button
               href={`/poke/${owner.sId}/memberships`}


### PR DESCRIPTION
## Description

This PR adds the region flag (EU or US) next to the workspace name in Poke, since this information is not in the url anymore.
<img width="1071" height="381" alt="image" src="https://github.com/user-attachments/assets/d75f36b8-36e3-4d5f-aa33-821c63aab87c" />

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Deploy front
