### PR TITLE
Add MCP token endpoint auth method support

### DIFF
--- a/core/src/oauth/providers/mcp.rs
+++ b/core/src/oauth/providers/mcp.rs
@@ -12,7 +12,6 @@ use crate::{
 };
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
-use base64::Engine;
 use serde::Deserialize;
 use tracing::{error, info};
 

--- a/core/src/oauth/providers/mcp.rs
+++ b/core/src/oauth/providers/mcp.rs
@@ -11,8 +11,8 @@ use crate::{
     utils,
 };
 use anyhow::{anyhow, Result};
-use base64::Engine;
 use async_trait::async_trait;
+use base64::Engine;
 use serde::Deserialize;
 use tracing::{error, info};
 
@@ -144,8 +144,11 @@ impl Provider for MCPConnectionProvider {
         if use_basic_auth {
             let auth_header = Self::build_basic_auth_header(
                 &client_id,
-                client_secret.as_ref().expect("client_secret missing"),
+                client_secret
+                    .as_ref()
+                    .ok_or_else(|| anyhow!("client_secret required for basic auth"))?,
             );
+
             req = req.header("Authorization", auth_header);
         }
 
@@ -239,7 +242,9 @@ impl Provider for MCPConnectionProvider {
         if use_basic_auth {
             let auth_header = Self::build_basic_auth_header(
                 &client_id,
-                client_secret.as_ref().expect("client_secret missing"),
+                client_secret
+                    .as_ref()
+                    .ok_or_else(|| anyhow!("client_secret required for basic auth"))?,
             );
             req = req.header("Authorization", auth_header);
         }

--- a/front/components/actions/mcp/MCPServerOAuthConnexion.tsx
+++ b/front/components/actions/mcp/MCPServerOAuthConnexion.tsx
@@ -39,6 +39,19 @@ export const OAUTH_USE_CASE_TO_DESCRIPTION: Record<MCPOAuthUseCase, string> = {
     "Each member logs in with their own credentials when they use the tool.",
 };
 
+const TOKEN_ENDPOINT_AUTH_METHOD_KEY = "token_endpoint_auth_method" as const;
+
+const TOKEN_ENDPOINT_AUTH_METHOD_OPTIONS = [
+  {
+    value: "client_secret_post",
+    label: "Request body (recommended)",
+  },
+  {
+    value: "client_secret_basic",
+    label: "Basic auth header",
+  },
+] as const;
+
 // Error key used for credential validation errors.
 // Parent components can check formState.errors[AUTH_CREDENTIALS_ERROR_KEY].
 export const AUTH_CREDENTIALS_ERROR_KEY = "authCredentials" as const;
@@ -219,6 +232,10 @@ export function MCPServerOAuthConnexion({
       {inputs && (
         <div className="w-full space-y-4 pt-4">
           {Object.entries(inputs).map(([key, inputData]) => {
+            if (key === TOKEN_ENDPOINT_AUTH_METHOD_KEY) {
+              return null;
+            }
+
             if (inputData.value || !isSupportedOAuthCredential(key)) {
               return null; // Skip pre-filled or unsupported credentials.
             }
@@ -244,6 +261,49 @@ export function MCPServerOAuthConnexion({
               </div>
             );
           })}
+          {inputs[TOKEN_ENDPOINT_AUTH_METHOD_KEY] && (
+            <div className="w-full space-y-2">
+              <Label className="text-sm font-semibold text-foreground dark:text-foreground-night">
+                {inputs[TOKEN_ENDPOINT_AUTH_METHOD_KEY]?.label}
+              </Label>
+              <div className="grid w-full grid-cols-2 gap-2">
+                {TOKEN_ENDPOINT_AUTH_METHOD_OPTIONS.map((option) => {
+                  const selected =
+                    (authCredentials?.[TOKEN_ENDPOINT_AUTH_METHOD_KEY] ||
+                      TOKEN_ENDPOINT_AUTH_METHOD_OPTIONS[0].value) ===
+                    option.value;
+
+                  return (
+                    <Card
+                      key={option.value}
+                      variant={selected ? "secondary" : "primary"}
+                      selected={selected}
+                      className={cn(
+                        "cursor-pointer",
+                        "px-3 py-2",
+                        "text-xs"
+                      )}
+                      onClick={() =>
+                        handleCredentialChange(
+                          TOKEN_ENDPOINT_AUTH_METHOD_KEY,
+                          option.value
+                        )
+                      }
+                    >
+                      <div className="font-medium text-foreground dark:text-foreground-night">
+                        {option.label}
+                      </div>
+                    </Card>
+                  );
+                })}
+              </div>
+              {inputs[TOKEN_ENDPOINT_AUTH_METHOD_KEY]?.helpMessage && (
+                <div className="text-xs text-muted-foreground dark:text-muted-foreground-night">
+                  {inputs[TOKEN_ENDPOINT_AUTH_METHOD_KEY]?.helpMessage}
+                </div>
+              )}
+            </div>
+          )}
         </div>
       )}
 

--- a/front/components/actions/mcp/MCPServerOAuthConnexion.tsx
+++ b/front/components/actions/mcp/MCPServerOAuthConnexion.tsx
@@ -1,6 +1,12 @@
 import {
+  Button,
   Card,
   cn,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
   Hoverable,
   Icon,
   Input,
@@ -266,32 +272,46 @@ export function MCPServerOAuthConnexion({
               <Label className="text-sm font-semibold text-foreground dark:text-foreground-night">
                 {inputs[TOKEN_ENDPOINT_AUTH_METHOD_KEY]?.label}
               </Label>
-              <div className="grid w-full grid-cols-2 gap-2">
-                {TOKEN_ENDPOINT_AUTH_METHOD_OPTIONS.map((option) => {
-                  const selected =
-                    (authCredentials?.[TOKEN_ENDPOINT_AUTH_METHOD_KEY] ??
-                      TOKEN_ENDPOINT_AUTH_METHOD_OPTIONS[0].value) ===
-                    option.value;
-
-                  return (
-                    <Card
-                      key={option.value}
-                      variant={selected ? "secondary" : "primary"}
-                      selected={selected}
-                      className={cn("cursor-pointer", "px-3 py-2", "text-xs")}
-                      onClick={() =>
-                        handleCredentialChange(
-                          TOKEN_ENDPOINT_AUTH_METHOD_KEY,
-                          option.value
-                        )
+              <div>
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      variant="outline"
+                      isSelect
+                      label={
+                        TOKEN_ENDPOINT_AUTH_METHOD_OPTIONS.find(
+                          (option) =>
+                            option.value ===
+                            (authCredentials?.[
+                              TOKEN_ENDPOINT_AUTH_METHOD_KEY
+                            ] ?? TOKEN_ENDPOINT_AUTH_METHOD_OPTIONS[0].value)
+                        )?.label ?? TOKEN_ENDPOINT_AUTH_METHOD_OPTIONS[0].label
+                      }
+                    />
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent>
+                    <DropdownMenuRadioGroup
+                      value={
+                        authCredentials?.[TOKEN_ENDPOINT_AUTH_METHOD_KEY] ??
+                        TOKEN_ENDPOINT_AUTH_METHOD_OPTIONS[0].value
                       }
                     >
-                      <div className="font-medium text-foreground dark:text-foreground-night">
-                        {option.label}
-                      </div>
-                    </Card>
-                  );
-                })}
+                      {TOKEN_ENDPOINT_AUTH_METHOD_OPTIONS.map((option) => (
+                        <DropdownMenuRadioItem
+                          key={option.value}
+                          value={option.value}
+                          label={option.label}
+                          onClick={() =>
+                            handleCredentialChange(
+                              TOKEN_ENDPOINT_AUTH_METHOD_KEY,
+                              option.value
+                            )
+                          }
+                        />
+                      ))}
+                    </DropdownMenuRadioGroup>
+                  </DropdownMenuContent>
+                </DropdownMenu>
               </div>
               {inputs[TOKEN_ENDPOINT_AUTH_METHOD_KEY]?.helpMessage && (
                 <div className="text-xs text-muted-foreground dark:text-muted-foreground-night">

--- a/front/components/actions/mcp/MCPServerOAuthConnexion.tsx
+++ b/front/components/actions/mcp/MCPServerOAuthConnexion.tsx
@@ -269,7 +269,7 @@ export function MCPServerOAuthConnexion({
               <div className="grid w-full grid-cols-2 gap-2">
                 {TOKEN_ENDPOINT_AUTH_METHOD_OPTIONS.map((option) => {
                   const selected =
-                    (authCredentials?.[TOKEN_ENDPOINT_AUTH_METHOD_KEY] ||
+                    (authCredentials?.[TOKEN_ENDPOINT_AUTH_METHOD_KEY] ??
                       TOKEN_ENDPOINT_AUTH_METHOD_OPTIONS[0].value) ===
                     option.value;
 
@@ -278,11 +278,7 @@ export function MCPServerOAuthConnexion({
                       key={option.value}
                       variant={selected ? "secondary" : "primary"}
                       selected={selected}
-                      className={cn(
-                        "cursor-pointer",
-                        "px-3 py-2",
-                        "text-xs"
-                      )}
+                      className={cn("cursor-pointer", "px-3 py-2", "text-xs")}
                       onClick={() =>
                         handleCredentialChange(
                           TOKEN_ENDPOINT_AUTH_METHOD_KEY,

--- a/front/lib/api/oauth/providers/mcp.ts
+++ b/front/lib/api/oauth/providers/mcp.ts
@@ -37,11 +37,13 @@ const MCPOAuthConnectionMetadataSchema = BaseMCPMetadataSchema.extend({
   client_secret: z.string().optional(),
   scope: z.string().optional(),
   resource: z.string().optional(),
+  token_endpoint_auth_method: z.string().optional(),
 });
 
 const MCPMetadataSchema = BaseMCPMetadataSchema.extend({
   code_challenge: z.string(),
   code_verifier: z.string(),
+  token_endpoint_auth_method: z.string().optional(),
 });
 
 export type MCPOAuthConnectionMetadataType = z.infer<
@@ -241,6 +243,8 @@ export class MCPOAuthProvider implements BaseOAuthStrategyProvider {
           authorization_endpoint: connection.metadata.authorization_endpoint,
           scope: connection.metadata.scope,
           resource: connection.metadata.resource,
+          token_endpoint_auth_method:
+            connection.metadata.token_endpoint_auth_method,
           code_verifier,
           code_challenge,
           ...restConfig,

--- a/front/lib/resources/remote_mcp_servers_resource.ts
+++ b/front/lib/resources/remote_mcp_servers_resource.ts
@@ -446,9 +446,21 @@ export class RemoteMCPServerResource extends BaseResource<RemoteMCPServerModel> 
       fetchFn,
     });
 
+    const supportedTokenAuthMethods =
+      metadata.token_endpoint_auth_methods_supported;
+
+    const tokenEndpointAuthMethod = supportedTokenAuthMethods?.includes(
+      "client_secret_post"
+    )
+      ? "client_secret_post"
+      : supportedTokenAuthMethods?.includes("client_secret_basic")
+        ? "client_secret_basic"
+        : undefined;
+
     const connectionMetadata: MCPOAuthConnectionMetadataType = {
       authorization_endpoint: metadata.authorization_endpoint,
       token_endpoint: metadata.token_endpoint,
+      token_endpoint_auth_method: tokenEndpointAuthMethod,
       client_id: fullInformation.client_id,
       resource: resource
         ? url.format(resource, { fragment: false })

--- a/front/types/oauth/lib.ts
+++ b/front/types/oauth/lib.ts
@@ -377,7 +377,7 @@ export function getProviderRequiredOAuthCredentialInputs({
             validator: isValidScope,
           },
           token_endpoint_auth_method: {
-            label: "Token Endpoint Authentication",
+            label: "Token Endpoint Authentication Method",
             value: "client_secret_post",
             helpMessage:
               "How to send the client ID/secret when exchanging tokens.",

--- a/front/types/oauth/lib.ts
+++ b/front/types/oauth/lib.ts
@@ -99,6 +99,7 @@ const SUPPORTED_OAUTH_CREDENTIALS = [
   "scope",
   "resource",
   "token_endpoint",
+  "token_endpoint_auth_method",
   "authorization_endpoint",
   "freshservice_domain",
   "freshworks_org_url",
@@ -375,6 +376,13 @@ export function getProviderRequiredOAuthCredentialInputs({
             helpMessage: "The scope(s) to request (space separated list).",
             validator: isValidScope,
           },
+          token_endpoint_auth_method: {
+            label: "Token Endpoint Authentication",
+            value: "client_secret_post",
+            helpMessage:
+              "How to send the client ID/secret when exchanging tokens.",
+            validator: isValidTokenEndpointAuthMethod,
+          },
         };
         return result;
       }
@@ -490,6 +498,13 @@ export function isValidOptionalClientSecret(s: unknown): s is string {
 
 export function isValidUrl(s: unknown): s is string {
   return typeof s === "string" && validateUrl(s).valid;
+}
+
+export function isValidTokenEndpointAuthMethod(s: unknown): s is string {
+  return (
+    typeof s === "string" &&
+    (s === "client_secret_post" || s === "client_secret_basic")
+  );
 }
 
 export function isValidSnowflakeAccount(s: unknown): s is string {


### PR DESCRIPTION
## Description

Add basic auth support for MCP server based on https://github.com/dust-tt/dust/pull/21221 from a customer.

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front, oauth