### PR TITLE
feat: add copilotTemplateId query param to agent builder

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -92,11 +92,14 @@ function processAdditionalConfigurationFromStorage(
 interface AgentBuilderProps {
   agentConfiguration?: LightAgentConfigurationType;
   duplicateAgentId?: string | null;
+  // TODO(copilot 2026-02-10): hack to allow copilot to access draft templates, remove once done iterating on copilot template instructions.
+  copilotTemplateId?: string | null;
 }
 
 export default function AgentBuilder({
   agentConfiguration,
   duplicateAgentId,
+  copilotTemplateId,
 }: AgentBuilderProps) {
   const { owner, user, assistantTemplate } = useAgentBuilderContext();
   const { supportedDataSourceViews } = useDataSourceViewsContext();
@@ -505,7 +508,7 @@ export default function AgentBuilder({
             isCreatedDialogOpen={isCreatedDialogOpen}
             setIsCreatedDialogOpen={setIsCreatedDialogOpen}
             isNewAgent={!!duplicateAgentId || !agentConfiguration}
-            templateId={assistantTemplate?.sId ?? null}
+            templateId={assistantTemplate?.sId ?? copilotTemplateId ?? null}
           />
         </CopilotSuggestionsProvider>
       </FormProvider>

--- a/front/components/pages/builder/agents/NewAgentPage.tsx
+++ b/front/components/pages/builder/agents/NewAgentPage.tsx
@@ -32,6 +32,8 @@ export function NewAgentPage() {
 
   const duplicateAgentId = useSearchParam("duplicate");
   const templateId = useSearchParam("templateId");
+  // TODO(copilot 2026-02-10): hack to allow copilot to access draft templates, remove once done iterating on copilot template instructions.
+  const copilotTemplateId = useSearchParam("copilotTemplateId");
 
   const { featureFlags, isFeatureFlagsLoading } = useFeatureFlags({
     workspaceId: owner.sId,
@@ -122,6 +124,7 @@ export function NewAgentPage() {
       <AgentBuilder
         agentConfiguration={duplicateConfiguration ?? undefined}
         duplicateAgentId={duplicateAgentId}
+        copilotTemplateId={copilotTemplateId}
       />
     </AgentBuilderProvider>
   );


### PR DESCRIPTION
## Description

Add a `copilotTemplateId` query param to the new agent page, allowing copilot to pass a draft template ID directly to `AgentBuilder`. This bypasses the standard `assistantTemplate` context loading, which is needed while iterating on copilot template instructions.

Temporary hack — will be removed once copilot template instructions are finalized.

## Tests

Manual testing with copilotTemplateId query param.

## Risk

Low — additive change, no impact on existing template flow. Falls through to `null` if param not provided.

## Deploy Plan

Standard deploy, no migration needed.