### PR TITLE
[front] - chore(workspace): download buttons for tables

### DIFF
--- a/front/pages/api/w/[wId]/analytics/agents-export.ts
+++ b/front/pages/api/w/[wId]/analytics/agents-export.ts
@@ -1,0 +1,225 @@
+import type { estypes } from "@elastic/elasticsearch";
+import { stringify } from "csv-stringify/sync";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { QueryTypes } from "sequelize";
+import { z } from "zod";
+
+import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { bucketsToArray, searchAnalytics } from "@app/lib/api/elasticsearch";
+import type { Authenticator } from "@app/lib/auth";
+import { getFrontReplicaDbConnection } from "@app/lib/resources/storage";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+
+const QuerySchema = z.object({
+  days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
+});
+
+type TopAgentExportBucket = {
+  key: string;
+  doc_count: number;
+  unique_users?: estypes.AggregationsCardinalityAggregate;
+  unique_conversations?: estypes.AggregationsCardinalityAggregate;
+};
+
+type TopAgentsExportAggs = {
+  by_agent?: estypes.AggregationsMultiBucketAggregateBase<TopAgentExportBucket>;
+};
+
+interface AgentMetadataRow {
+  sId: string;
+  name: string;
+  description: string;
+  settings: string;
+  modelId: string;
+  providerId: string;
+  authorEmail: string | null;
+  lastEdit: string;
+}
+
+interface AgentExportRow {
+  name: string;
+  description: string;
+  settings: string;
+  modelId: string;
+  providerId: string;
+  authorEmails: string;
+  messages: number;
+  distinctUsersReached: number;
+  distinctConversations: number;
+  lastEdit: string;
+}
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<string>>,
+  auth: Authenticator
+) {
+  if (!auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "Only workspace admins can access workspace analytics.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      const { days } = req.query;
+      const q = QuerySchema.safeParse({ days });
+      if (!q.success) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid query parameters: ${q.error.message}`,
+          },
+        });
+      }
+
+      const owner = auth.getNonNullableWorkspace();
+
+      const baseQuery = buildAgentAnalyticsBaseQuery({
+        workspaceId: owner.sId,
+        days: q.data.days,
+      });
+
+      const esResult = await searchAnalytics<never, TopAgentsExportAggs>(
+        {
+          bool: {
+            filter: [baseQuery],
+          },
+        },
+        {
+          aggregations: {
+            by_agent: {
+              terms: { field: "agent_id", size: 10000 },
+              aggs: {
+                unique_users: { cardinality: { field: "user_id" } },
+                unique_conversations: {
+                  cardinality: { field: "conversation_id" },
+                },
+              },
+            },
+          },
+          size: 0,
+        }
+      );
+
+      if (esResult.isErr()) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: `Failed to retrieve agent analytics: ${esResult.error.message}`,
+          },
+        });
+      }
+
+      const buckets = bucketsToArray<TopAgentExportBucket>(
+        esResult.value.aggregations?.by_agent?.buckets
+      );
+
+      const esMetrics = new Map(
+        buckets.map((b) => [
+          String(b.key),
+          {
+            messages: b.doc_count,
+            distinctUsersReached: Math.round(b.unique_users?.value ?? 0),
+            distinctConversations: Math.round(
+              b.unique_conversations?.value ?? 0
+            ),
+          },
+        ])
+      );
+
+      const scopeFilter =
+        owner.role === "admin" ? "" : `AND ac."scope" != 'hidden'`;
+
+      const readReplica = getFrontReplicaDbConnection();
+      // eslint-disable-next-line dust/no-raw-sql -- Matches existing Activity Report query pattern.
+      const agents = await readReplica.query<AgentMetadataRow>(
+        `
+        SELECT ac."sId",
+               ac."name",
+               ac."description",
+               CASE
+                 WHEN ac."scope" = 'visible' THEN 'published'
+                 WHEN ac."scope" = 'hidden' THEN 'unpublished'
+                 ELSE 'unknown'
+               END AS "settings",
+               ac."modelId",
+               ac."providerId",
+               aut."email" AS "authorEmail",
+               COALESCE(
+                 CAST(ac."updatedAt" AS DATE),
+                 CAST(ac."createdAt" AS DATE)
+               ) AS "lastEdit"
+        FROM "agent_configurations" ac
+          LEFT JOIN "users" aut ON ac."authorId" = aut."id"
+        WHERE ac."workspaceId" = :wId
+          AND ac."status" = 'active'
+          ${scopeFilter}
+        `,
+        {
+          type: QueryTypes.SELECT,
+          replacements: { wId: owner.id },
+        }
+      );
+
+      const rows: AgentExportRow[] = agents.map((agent) => {
+        const metrics = esMetrics.get(agent.sId);
+        return {
+          name: agent.name,
+          description: agent.description,
+          settings: agent.settings,
+          modelId: agent.modelId,
+          providerId: agent.providerId,
+          authorEmails: agent.authorEmail ?? "",
+          messages: metrics?.messages ?? 0,
+          distinctUsersReached: metrics?.distinctUsersReached ?? 0,
+          distinctConversations: metrics?.distinctConversations ?? 0,
+          lastEdit: agent.lastEdit,
+        };
+      });
+
+      rows.sort((a, b) => b.messages - a.messages);
+
+      const headers: (keyof AgentExportRow)[] = [
+        "name",
+        "description",
+        "settings",
+        "modelId",
+        "providerId",
+        "authorEmails",
+        "messages",
+        "distinctUsersReached",
+        "distinctConversations",
+        "lastEdit",
+      ];
+      const csvData = rows.map((row) => headers.map((h) => row[h]));
+      const csv = stringify([headers, ...csvData], { header: false });
+
+      res.setHeader("Content-Type", "text/csv");
+      res.setHeader(
+        "Content-Disposition",
+        `attachment; filename="dust_agents_last_${q.data.days}_days.csv"`
+      );
+      return res.status(200).send(csv);
+    }
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/analytics/users-export.ts
+++ b/front/pages/api/w/[wId]/analytics/users-export.ts
@@ -1,0 +1,215 @@
+import type { estypes } from "@elastic/elasticsearch";
+import { stringify } from "csv-stringify/sync";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { Op } from "sequelize";
+import { z } from "zod";
+
+import { DEFAULT_PERIOD_DAYS } from "@app/components/agent_builder/observability/constants";
+import { buildAgentAnalyticsBaseQuery } from "@app/lib/api/assistant/observability/utils";
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import {
+  bucketsToArray,
+  formatUTCDateFromMillis,
+  searchAnalytics,
+} from "@app/lib/api/elasticsearch";
+import type { Authenticator } from "@app/lib/auth";
+import { MembershipModel } from "@app/lib/resources/storage/models/membership";
+import { UserModel } from "@app/lib/resources/storage/models/user";
+import { getUserGroupMemberships } from "@app/lib/workspace_usage";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types";
+
+const QuerySchema = z.object({
+  days: z.coerce.number().positive().optional().default(DEFAULT_PERIOD_DAYS),
+});
+
+type TopUserExportBucket = {
+  key: string;
+  doc_count: number;
+  last_message?: estypes.AggregationsMaxAggregate;
+  active_days?: estypes.AggregationsDateHistogramAggregate;
+};
+
+type TopUsersExportAggs = {
+  by_user?: estypes.AggregationsMultiBucketAggregateBase<TopUserExportBucket>;
+};
+
+interface UserExportRow {
+  userId: string;
+  userName: string;
+  userEmail: string;
+  messageCount: number;
+  lastMessageSent: string;
+  activeDaysCount: number;
+  groups: string;
+}
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<string>>,
+  auth: Authenticator
+) {
+  if (!auth.isAdmin()) {
+    return apiError(req, res, {
+      status_code: 403,
+      api_error: {
+        type: "workspace_auth_error",
+        message: "Only workspace admins can access workspace analytics.",
+      },
+    });
+  }
+
+  switch (req.method) {
+    case "GET": {
+      const { days } = req.query;
+      const q = QuerySchema.safeParse({ days });
+      if (!q.success) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: `Invalid query parameters: ${q.error.message}`,
+          },
+        });
+      }
+
+      const owner = auth.getNonNullableWorkspace();
+
+      const baseQuery = buildAgentAnalyticsBaseQuery({
+        workspaceId: owner.sId,
+        days: q.data.days,
+      });
+
+      const esResult = await searchAnalytics<never, TopUsersExportAggs>(
+        {
+          bool: {
+            filter: [baseQuery],
+          },
+        },
+        {
+          aggregations: {
+            by_user: {
+              terms: { field: "user_id", size: 10000 },
+              aggs: {
+                last_message: { max: { field: "timestamp" } },
+                active_days: {
+                  date_histogram: {
+                    field: "timestamp",
+                    calendar_interval: "day",
+                  },
+                },
+              },
+            },
+          },
+          size: 0,
+        }
+      );
+
+      if (esResult.isErr()) {
+        return apiError(req, res, {
+          status_code: 500,
+          api_error: {
+            type: "internal_server_error",
+            message: `Failed to retrieve user analytics: ${esResult.error.message}`,
+          },
+        });
+      }
+
+      const buckets = bucketsToArray<TopUserExportBucket>(
+        esResult.value.aggregations?.by_user?.buckets
+      );
+
+      const esMetrics = new Map(
+        buckets.map((b) => {
+          const lastMessageMs = b.last_message?.value;
+          const activeDaysBuckets = b.active_days?.buckets;
+          return [
+            String(b.key),
+            {
+              messageCount: b.doc_count,
+              lastMessageSent:
+                typeof lastMessageMs === "number"
+                  ? formatUTCDateFromMillis(lastMessageMs)
+                  : "",
+              activeDaysCount: Array.isArray(activeDaysBuckets)
+                ? activeDaysBuckets.filter((d) => d.doc_count > 0).length
+                : 0,
+            },
+          ] as const;
+        })
+      );
+
+      const now = new Date();
+      const startDate = new Date(now);
+      startDate.setDate(startDate.getDate() - q.data.days);
+
+      const memberships = await MembershipModel.findAll({
+        where: {
+          workspaceId: owner.id,
+          startAt: { [Op.lte]: now },
+          [Op.or]: [{ endAt: null }, { endAt: { [Op.gte]: startDate } }],
+        },
+        include: [
+          {
+            model: UserModel,
+            required: true,
+            attributes: ["id", "sId", "firstName", "lastName", "email"],
+          },
+        ],
+      });
+
+      const groupsMap = await getUserGroupMemberships(owner.id, startDate, now);
+
+      const rows: UserExportRow[] = memberships.map((membership) => {
+        const user = (membership as MembershipModel & { user: UserModel }).user;
+        const userSid = user.sId;
+        const metrics = esMetrics.get(userSid);
+        const userId = String(user.id);
+
+        return {
+          userId: userSid,
+          userName:
+            [user.firstName, user.lastName].filter(Boolean).join(" ") ||
+            user.email ||
+            "Unknown",
+          userEmail: user.email ?? "",
+          messageCount: metrics?.messageCount ?? 0,
+          lastMessageSent: metrics?.lastMessageSent ?? "",
+          activeDaysCount: metrics?.activeDaysCount ?? 0,
+          groups: groupsMap[userId] ?? "",
+        };
+      });
+
+      rows.sort((a, b) => b.messageCount - a.messageCount);
+
+      const headers: (keyof UserExportRow)[] = [
+        "userId",
+        "userName",
+        "userEmail",
+        "messageCount",
+        "lastMessageSent",
+        "activeDaysCount",
+        "groups",
+      ];
+      const csvData = rows.map((row) => headers.map((h) => row[h]));
+      const csv = stringify([headers, ...csvData], { header: false });
+
+      res.setHeader("Content-Type", "text/csv");
+      res.setHeader(
+        "Content-Disposition",
+        `attachment; filename="dust_users_last_${q.data.days}_days.csv"`
+      );
+      return res.status(200).send(csv);
+    }
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -4,6 +4,11 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
       "Advanced features for Notion workspace management shown to admins",
     stage: "on_demand",
   },
+  analytics_csv_export: {
+    description:
+      "CSV export buttons on analytics Top Agents and Top Users tables",
+    stage: "rolling_out",
+  },
   anthropic_vertex_fallback: {
     description: "Fallback to Vertex Anthropic for some Anthropic models",
     stage: "dust_only",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -660,6 +660,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "agent_builder_copilot"
   | "agent_management_tool"
   | "agent_to_yaml"
+  | "analytics_csv_export"
   | "custom_model_feature"
   | "anthropic_vertex_fallback"
   | "ashby_tool"


### PR DESCRIPTION
## Description

This PR adds CSV export functionality for the Top Agents and Top Users analytics tables in the workspace analytics page. The feature is gated behind the `analytics_csv_export` feature flag. When enabled, workspace admins can download CSV files containing analytics data for agents and users over a selected time period. The implementation includes two new API endpoints (`/api/w/[wId]/analytics/agents-export` and `/api/w/[wId]/analytics/users-export`) that aggregate data from Elasticsearch and Sequelize, formatting it as CSV files with relevant metrics (message counts, distinct users/conversations, active days, group memberships).

## Risk

Low risk. The feature is behind a feature flag (`analytics_csv_export`) so it can be rolled out gradually

## Tests

- [x] Locally
- [ ] Front edge

## Deploy Plan

Deploy front
