### PR TITLE
Fix 404 never ending loader

### DIFF
--- a/front-spa/src/app/App.tsx
+++ b/front-spa/src/app/App.tsx
@@ -411,7 +411,10 @@ const router = createBrowserRouter(
         { path: "verify", element: <VerifyPage /> },
       ],
     },
-    { path: "*", element: <Custom404 /> },
+    {
+      element: <UnauthenticatedPage />,
+      children: [{ path: "*", element: <Custom404 /> }],
+    },
   ],
   {
     basename: import.meta.env?.VITE_BASE_PATH ?? "",


### PR DESCRIPTION
## Description

Wrap the 404 catch-all route with UnauthenticatedPage so that signalAppReady() is called and the HTML loading screen is dismissed. Without this, navigating to an unknown URL in the SPA shows an infinite loader instead of the 404 page.


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
