### PR TITLE
[front] - fix(AB): export/import YAML

### DIFF
--- a/front/lib/agent_yaml_converter/schemas.ts
+++ b/front/lib/agent_yaml_converter/schemas.ts
@@ -53,39 +53,41 @@ export const agentYAMLDataSourceConfigurationSchema = z.object({
   tags_filter: agentYAMLTagsFilterSchema.nullable(),
 });
 
-export const baseAgentYAMLActionSchema = z.object({
+export const agentYAMLTableConfigurationSchema = z.object({
+  view_id: z.string().min(1, "View ID is required"),
+  table_id: z.string().min(1, "Table ID is required"),
+});
+
+export const agentYAMLDustAppConfigurationSchema = z.object({
+  type: z.literal("dust_app_run_configuration"),
+  app_workspace_id: z.string(),
+  app_id: z.string(),
+});
+
+export const agentYAMLProjectConfigurationSchema = z.object({
+  workspace_id: z.string(),
+  project_id: z.string(),
+});
+
+export const agentYAMLMCPActionSchema = z.object({
   name: z.string().min(1, "Action name is required"),
   description: z.string().min(1, "Action description is required"),
-});
-
-/**
- * Base Data Source Action Configuration
- * Common configuration for actions that work with data sources
- */
-export const baseDataSourceActionConfigurationSchema = z.object({
-  data_sources: z.record(z.string(), agentYAMLDataSourceConfigurationSchema),
-});
-
-export const timeFrameActionConfigurationSchema =
-  baseDataSourceActionConfigurationSchema.extend({
-    time_frame: agentYAMLTimeFrameSchema,
-  });
-
-/**
- * YAML Action Schemas
- */
-export const agentYAMLDataVisualizationActionSchema = baseAgentYAMLActionSchema;
-
-export const agentYAMLMCPActionSchema = baseAgentYAMLActionSchema.extend({
   type: z.literal("MCP"),
   configuration: z.object({
     mcp_server_name: z.string(),
     data_sources: z
       .record(z.string(), agentYAMLDataSourceConfigurationSchema)
       .optional(),
+    tables: z.array(agentYAMLTableConfigurationSchema).nullable().optional(),
+    child_agent_id: z.string().nullable().optional(),
     time_frame: agentYAMLTimeFrameSchema.optional(),
     json_schema: z.object({}).nullable().optional(),
     additional_configuration: additionalConfigurationSchema.optional(),
+    dust_app_configuration: agentYAMLDustAppConfigurationSchema
+      .nullable()
+      .optional(),
+    secret_name: z.string().nullable().optional(),
+    dust_project: agentYAMLProjectConfigurationSchema.nullable().optional(),
   }),
 });
 
@@ -103,10 +105,11 @@ export const agentYAMLSlackIntegrationSchema = z.object({
   ),
 });
 
-/**
- * Complete YAML Configuration Schema
- * The main schema that validates the entire YAML structure
- */
+export const agentYAMLSkillSchema = z.object({
+  sId: z.string().min(1, "Skill ID is required"),
+  name: z.string().min(1, "Skill name is required"),
+});
+
 export const agentYAMLConfigSchema = z.object({
   agent: agentYAMLBasicInfoSchema,
   instructions: z.string().min(1, "Instructions are required"),
@@ -114,6 +117,7 @@ export const agentYAMLConfigSchema = z.object({
   tags: z.array(agentYAMLTagSchema),
   editors: z.array(agentYAMLEditorSchema),
   toolset: z.array(agentYAMLActionSchema),
+  skills: z.array(agentYAMLSkillSchema).optional(),
   slack_integration: agentYAMLSlackIntegrationSchema.optional(),
 });
 
@@ -122,8 +126,11 @@ export type AgentYAMLEditor = z.infer<typeof agentYAMLEditorSchema>;
 export type AgentYAMLDataSourceConfiguration = z.infer<
   typeof agentYAMLDataSourceConfigurationSchema
 >;
-
+export type AgentYAMLTableConfiguration = z.infer<
+  typeof agentYAMLTableConfigurationSchema
+>;
 export type AgentYAMLAction = z.infer<typeof agentYAMLActionSchema>;
+export type AgentYAMLSkill = z.infer<typeof agentYAMLSkillSchema>;
 export type AgentYAMLSlackIntegration = z.infer<
   typeof agentYAMLSlackIntegrationSchema
 >;

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/new/yaml.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/new/yaml.ts
@@ -42,7 +42,6 @@ async function handler(
     });
   }
 
-  // Check kill switches
   const killSwitches = await KillSwitchResource.listEnabledKillSwitches();
   if (killSwitches?.includes("save_agent_configurations")) {
     return apiError(req, res, {
@@ -107,8 +106,7 @@ async function handler(
     name: yamlConfig.agent.handle,
     description: yamlConfig.agent.description,
     instructions: yamlConfig.instructions,
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-    pictureUrl: yamlConfig.agent.avatar_url || "",
+    pictureUrl: yamlConfig.agent.avatar_url ?? "",
     status: "active" as const,
     scope: yamlConfig.agent.scope,
     model: {
@@ -116,9 +114,7 @@ async function handler(
       providerId: yamlConfig.generation_settings.provider_id,
       temperature: yamlConfig.generation_settings.temperature,
       reasoningEffort: yamlConfig.generation_settings.reasoning_effort,
-      responseFormat:
-        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-        yamlConfig.generation_settings.response_format || undefined,
+      responseFormat: yamlConfig.generation_settings.response_format,
     },
     maxStepsPerRun: yamlConfig.agent.max_steps_per_run,
     actions: mcpConfigurations,
@@ -131,7 +127,9 @@ async function handler(
     editors: yamlConfig.editors.map((editor) => ({
       sId: editor.user_id,
     })),
-    skills: [],
+    skills: (yamlConfig.skills ?? []).map((skill) => ({
+      sId: skill.sId,
+    })),
     additionalRequestedSpaceIds: [],
   };
 


### PR DESCRIPTION
## Description

This PR extends the agent YAML export/import functionality to support skills, table configurations, child agents, Dust app configurations, and project configurations. Previously, the YAML converter only handled basic MCP actions with data sources and time frames. Now it exports and imports the full agent configuration state, including skills associated with the agent and all advanced MCP action parameters such as table configurations, child agent IDs, Dust app integrations, and project settings. The YAML export endpoint also fetches editors from the editor group and linked Slack channels to include in the YAML.

## Risk

Medium - behind FF

## Tests

- [x] Locally
- [x] Front-edge

## Deploy Plan

Deploy front
