### PR TITLE
[front] Centralize UTM tracking to use sessionStorage via utmParams

### DIFF
--- a/front/components/app/PostHogTracker.tsx
+++ b/front/components/app/PostHogTracker.tsx
@@ -113,30 +113,12 @@ export function PostHogTracker({ children }: PostHogTrackerProps) {
           return null;
         }
 
-        // Extract marketing parameters from URL first, then fall back to sessionStorage.
+        // Read marketing parameters from sessionStorage (populated by useStripUtmParams).
         const storedParams = getStoredUTMParams();
-        if (event.properties.$current_url) {
-          try {
-            const url = new URL(event.properties.$current_url);
-            for (const param of MARKETING_PARAMS) {
-              const urlValue = url.searchParams.get(param);
-              const storedValue = storedParams[param];
-              if (urlValue) {
-                event.properties[param] = urlValue;
-              } else if (storedValue) {
-                event.properties[param] = storedValue;
-              }
-            }
-          } catch {
-            // Ignore URL parsing errors.
-          }
-        } else {
-          // No URL available, use sessionStorage values.
-          for (const param of MARKETING_PARAMS) {
-            const storedValue = storedParams[param];
-            if (storedValue) {
-              event.properties[param] = storedValue;
-            }
+        for (const param of MARKETING_PARAMS) {
+          const storedValue = storedParams[param];
+          if (storedValue) {
+            event.properties[param] = storedValue;
           }
         }
 

--- a/front/components/app/RootLayout.tsx
+++ b/front/components/app/RootLayout.tsx
@@ -5,6 +5,7 @@ import { SWRConfig } from "swr";
 import { ConfirmPopupArea } from "@app/components/Confirm";
 import { NavigationLoadingProvider } from "@app/components/sparkle/NavigationLoadingContext";
 import { SidebarProvider } from "@app/components/sparkle/SidebarContext";
+import { useStripUtmParams } from "@app/hooks/useStripUtmParams";
 import { LinkWrapper, useAppRouter } from "@app/lib/platform";
 import { isAPIErrorResponse } from "@app/types/error";
 
@@ -17,6 +18,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   const router = useAppRouter();
+  useStripUtmParams();
 
   return (
     <SparkleContext.Provider value={{ components: { link: LinkWrapper } }}>

--- a/front/components/home/LandingLayout.tsx
+++ b/front/components/home/LandingLayout.tsx
@@ -23,12 +23,13 @@ import {
 import { useGeolocation } from "@app/lib/swr/geo";
 import { TRACKING_AREAS, withTracking } from "@app/lib/tracking";
 import { classNames, getFaviconPath } from "@app/lib/utils";
-import { appendUTMParams, extractUTMParams } from "@app/lib/utils/utm";
+import { appendUTMParams } from "@app/lib/utils/utm";
 
 export interface LandingLayoutProps {
   shape: number;
   postLoginReturnToUrl?: string;
   gtmTrackingId?: string;
+  hideNavigation?: boolean;
 }
 
 export default function LandingLayout({
@@ -38,7 +39,11 @@ export default function LandingLayout({
   children: React.ReactNode;
   pageProps: LandingLayoutProps;
 }) {
-  const { postLoginReturnToUrl = "/api/login", gtmTrackingId } = pageProps;
+  const {
+    postLoginReturnToUrl = "/api/login",
+    gtmTrackingId,
+    hideNavigation,
+  } = pageProps;
 
   const [cookies, setCookie] = useCookies(
     [DUST_COOKIES_ACCEPTED, DUST_HAS_SESSION],
@@ -89,21 +94,6 @@ export default function LandingLayout({
     document.body.classList.remove("bg-background-night");
   }, []);
 
-  // Capture UTM parameters from URL and store as JSON blob in sessionStorage.
-  useEffect(() => {
-    try {
-      const params = Object.fromEntries(
-        new URLSearchParams(window.location.search)
-      );
-      const utmData = extractUTMParams(params);
-      if (Object.keys(utmData).length > 0) {
-        sessionStorage.setItem("utm_data", JSON.stringify(utmData));
-      }
-    } catch {
-      // Ignore errors (e.g. sessionStorage unavailable).
-    }
-  }, []);
-
   useEffect(() => {
     if (cookieValue !== undefined) {
       setShowCookieBanner(false);
@@ -128,57 +118,65 @@ export default function LandingLayout({
   return (
     <>
       <Header />
-      <ScrollingHeader>
-        <div className="flex h-full w-full items-center gap-4 px-6 xl:gap-10">
-          <div className="hidden h-[24px] w-[96px] xl:block">
+      {hideNavigation ? (
+        <div className="flex w-full justify-center pt-12 pb-2">
+          <div className="container flex items-center justify-center px-6">
             <PublicWebsiteLogo />
-          </div>
-          <MobileNavigation />
-          <div className="block xl:hidden">
-            <PublicWebsiteLogo />
-          </div>
-          <MainNavigation />
-          <div className="flex flex-grow justify-end gap-4">
-            {hasSession ? (
-              <OpenDustButton
-                variant="highlight"
-                size="sm"
-                trackingArea={TRACKING_AREAS.NAVIGATION}
-                trackingObject="go_to_app"
-              />
-            ) : (
-              <>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  label="Sign in"
-                  onClick={withTracking(
-                    TRACKING_AREAS.NAVIGATION,
-                    "sign_in",
-                    () => {
-                      // eslint-disable-next-line react-hooks/immutability
-                      window.location.href = appendUTMParams(
-                        `/api/workos/login?returnTo=${encodeURIComponent(postLoginReturnToUrl)}`
-                      );
-                    }
-                  )}
-                />
-                <UTMButton
-                  href="/home/contact"
-                  className="hidden xs:inline-flex"
-                  variant="highlight"
-                  size="sm"
-                  label="Contact sales"
-                  onClick={withTracking(
-                    TRACKING_AREAS.NAVIGATION,
-                    "contact_sales"
-                  )}
-                />
-              </>
-            )}
           </div>
         </div>
-      </ScrollingHeader>
+      ) : (
+        <ScrollingHeader>
+          <div className="flex h-full w-full items-center gap-4 px-6 xl:gap-10">
+            <div className="hidden h-[24px] w-[96px] xl:block">
+              <PublicWebsiteLogo />
+            </div>
+            <MobileNavigation />
+            <div className="block xl:hidden">
+              <PublicWebsiteLogo />
+            </div>
+            <MainNavigation />
+            <div className="flex flex-grow justify-end gap-4">
+              {hasSession ? (
+                <OpenDustButton
+                  variant="highlight"
+                  size="sm"
+                  trackingArea={TRACKING_AREAS.NAVIGATION}
+                  trackingObject="go_to_app"
+                />
+              ) : (
+                <>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    label="Sign in"
+                    onClick={withTracking(
+                      TRACKING_AREAS.NAVIGATION,
+                      "sign_in",
+                      () => {
+                        // eslint-disable-next-line react-hooks/immutability
+                        window.location.href = appendUTMParams(
+                          `/api/workos/login?returnTo=${encodeURIComponent(postLoginReturnToUrl)}`
+                        );
+                      }
+                    )}
+                  />
+                  <UTMButton
+                    href="/home/contact"
+                    className="hidden xs:inline-flex"
+                    variant="highlight"
+                    size="sm"
+                    label="Contact sales"
+                    onClick={withTracking(
+                      TRACKING_AREAS.NAVIGATION,
+                      "contact_sales"
+                    )}
+                  />
+                </>
+              )}
+            </div>
+          </div>
+        </ScrollingHeader>
+      )}
       <div className="fixed bottom-0 left-0 right-0 top-0 -z-50" />
       <div className="fixed inset-0 -z-30" />
       {/* <div className="fixed bottom-0 left-0 right-0 top-0 -z-40 overflow-hidden transition duration-1000">
@@ -188,7 +186,8 @@ export default function LandingLayout({
         <div
           className={classNames(
             "container flex w-full flex-col",
-            "gap-24 px-6 py-24 pb-12",
+            "gap-24 px-6 pb-12",
+            hideNavigation ? "pt-6" : "pt-24",
             "xl:gap-16",
             "2xl:gap-24"
           )}
@@ -216,7 +215,7 @@ export default function LandingLayout({
             `}
           </Script>
         )}
-        <FooterNavigation />
+        {!hideNavigation && <FooterNavigation />}
       </main>
     </>
   );

--- a/front/components/home/content/SqAgent/config/sqAgentConfig.tsx
+++ b/front/components/home/content/SqAgent/config/sqAgentConfig.tsx
@@ -74,7 +74,7 @@ export const sqAgentConfig: SqAgentConfig = {
         <br />
         <span className="text-foreground">for</span>
         <br />
-        <span className="bg-gradient-to-r from-blue-500 to-emerald-500 bg-clip-text text-transparent">
+        <span className="bg-gradient-to-r from-blue-500 to-emerald-500 bg-clip-text pr-1 text-transparent">
           AI Agents
         </span>
       </>

--- a/front/components/sparkle/AppRootLayout.tsx
+++ b/front/components/sparkle/AppRootLayout.tsx
@@ -196,7 +196,6 @@ export default function AppRootLayout({
               j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
               'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
               })(window,document,'script','dataLayer','${process.env.NEXT_PUBLIC_GTM_TRACKING_ID}');
-              (function(){var p=new URLSearchParams(window.location.search),k=['utm_source','utm_medium','utm_campaign','utm_term','utm_content','gclid','fbclid','msclkid','li_fat_id'],d={};k.forEach(function(n){var v=p.get(n);if(v)d[n]=v;});if(Object.keys(d).length>0)sessionStorage.setItem('utm_data',JSON.stringify(d));})();
           `}
           </Script>
         </DesktopNavigationProvider>

--- a/front/components/sparkle/OnboardingLayout.tsx
+++ b/front/components/sparkle/OnboardingLayout.tsx
@@ -88,7 +88,6 @@ export default function OnboardingLayout({
           j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
           })(window,document,'script','dataLayer','${process.env.NEXT_PUBLIC_GTM_TRACKING_ID}');
-          (function(){var p=new URLSearchParams(window.location.search),k=['utm_source','utm_medium','utm_campaign','utm_term','utm_content','gclid','fbclid','msclkid','li_fat_id'],d={};k.forEach(function(n){var v=p.get(n);if(v)d[n]=v;});if(Object.keys(d).length>0)sessionStorage.setItem('utm_data',JSON.stringify(d));})();
         `}
       </Script>
     </>

--- a/front/hooks/useStripUtmParams.ts
+++ b/front/hooks/useStripUtmParams.ts
@@ -1,0 +1,42 @@
+import { useEffect } from "react";
+
+import { useAppRouter } from "@app/lib/platform";
+import { extractUTMParams, MARKETING_PARAMS } from "@app/lib/utils/utm";
+
+/**
+ * Captures UTM parameters from the URL, stores them in sessionStorage,
+ * then strips them from the URL bar via a shallow router replace.
+ */
+export function useStripUtmParams() {
+  const router = useAppRouter();
+
+  useEffect(() => {
+    if (!router.isReady) {
+      return;
+    }
+
+    try {
+      const params = Object.fromEntries(
+        new URLSearchParams(window.location.search)
+      );
+      const utmData = extractUTMParams(params);
+      if (Object.keys(utmData).length > 0) {
+        sessionStorage.setItem("utm_data", JSON.stringify(utmData));
+
+        const url = new URL(window.location.href);
+        let hasMarketingParam = false;
+        for (const key of MARKETING_PARAMS) {
+          if (url.searchParams.has(key)) {
+            url.searchParams.delete(key);
+            hasMarketingParam = true;
+          }
+        }
+        if (hasMarketingParam) {
+          window.history.replaceState(window.history.state, "", url.toString());
+        }
+      }
+    } catch {
+      // Ignore errors (e.g. sessionStorage unavailable).
+    }
+  }, [router.isReady]);
+}

--- a/front/pages/landing/glean.tsx
+++ b/front/pages/landing/glean.tsx
@@ -7,18 +7,17 @@ import { DifferentiatorsSection } from "@app/components/home/content/Competitive
 import { EmailCTASection } from "@app/components/home/content/Competitive/EmailCTASection";
 import { StatsSection } from "@app/components/home/content/Competitive/StatsSection";
 import { TestimonialsGridSection } from "@app/components/home/content/Competitive/TestimonialsGridSection";
-import { H4 } from "@app/components/home/ContentComponents";
 import { FAQ } from "@app/components/home/FAQ";
 import type { LandingLayoutProps } from "@app/components/home/LandingLayout";
 import LandingLayout from "@app/components/home/LandingLayout";
 import { PageMetadata } from "@app/components/home/PageMetadata";
-import TrustedBy from "@app/components/home/TrustedBy";
 
 export async function getStaticProps() {
   return {
     props: {
       shape: 0,
       gtmTrackingId: process.env.NEXT_PUBLIC_GTM_TRACKING_ID ?? null,
+      hideNavigation: true,
     },
   };
 }
@@ -43,14 +42,6 @@ export default function GleanLandingPage() {
         trustBadges={gleanConfig.hero.trustBadges}
         trackingObject="glean_hero"
       />
-
-      {/* Trusted By */}
-      <div className="-mt-8">
-        <H4 className="mb-6 w-full text-center text-muted-foreground">
-          TRUSTED BY TEAMS WHO SWITCHED FROM GLEAN
-        </H4>
-        <TrustedBy showTitle={false} />
-      </div>
 
       {/* Testimonials */}
       <div className="mt-8">

--- a/front/pages/landing/skip.tsx
+++ b/front/pages/landing/skip.tsx
@@ -7,11 +7,9 @@ import { FeatureSection } from "@app/components/home/content/SqAgent/FeatureSect
 import { SqAgentHeroSection } from "@app/components/home/content/SqAgent/SqAgentHeroSection";
 import { SqCtaSection } from "@app/components/home/content/SqAgent/SqCtaSection";
 import { SqTestimonialsSection } from "@app/components/home/content/SqAgent/SqTestimonialsSection";
-import { H4 } from "@app/components/home/ContentComponents";
 import type { LandingLayoutProps } from "@app/components/home/LandingLayout";
 import LandingLayout from "@app/components/home/LandingLayout";
 import { PageMetadata } from "@app/components/home/PageMetadata";
-import TrustedBy from "@app/components/home/TrustedBy";
 
 const SECTION_VISUALS = [<CareerAdvantageVisual />, <AgentBuilderVisual />];
 
@@ -20,6 +18,7 @@ export async function getStaticProps() {
     props: {
       shape: 0,
       gtmTrackingId: process.env.NEXT_PUBLIC_GTM_TRACKING_ID ?? null,
+      hideNavigation: true,
     },
   };
 }
@@ -43,14 +42,6 @@ export default function SkipLandingPage() {
         videos={skipConfig.hero.videos}
         usersCount={skipConfig.hero.usersCount}
       />
-
-      {/* Trusted By Section */}
-      <div className="mt-8">
-        <H4 className="mb-6 w-full text-center text-muted-foreground">
-          {skipConfig.trustedByTitle}
-        </H4>
-        <TrustedBy showTitle={false} logoSet="landing" />
-      </div>
 
       {/* Feature Sections */}
       {skipConfig.sections.map((section, index) => (

--- a/front/pages/landing/sqagent.tsx
+++ b/front/pages/landing/sqagent.tsx
@@ -5,17 +5,16 @@ import { FeatureSection } from "@app/components/home/content/SqAgent/FeatureSect
 import { SqAgentHeroSection } from "@app/components/home/content/SqAgent/SqAgentHeroSection";
 import { SqCtaSection } from "@app/components/home/content/SqAgent/SqCtaSection";
 import { SqTestimonialsSection } from "@app/components/home/content/SqAgent/SqTestimonialsSection";
-import { H4 } from "@app/components/home/ContentComponents";
 import type { LandingLayoutProps } from "@app/components/home/LandingLayout";
 import LandingLayout from "@app/components/home/LandingLayout";
 import { PageMetadata } from "@app/components/home/PageMetadata";
-import TrustedBy from "@app/components/home/TrustedBy";
 
 export async function getStaticProps() {
   return {
     props: {
       shape: 0,
       gtmTrackingId: process.env.NEXT_PUBLIC_GTM_TRACKING_ID ?? null,
+      hideNavigation: true,
     },
   };
 }
@@ -39,14 +38,6 @@ export default function SqAgentLandingPage() {
         videos={sqAgentConfig.hero.videos}
         usersCount={sqAgentConfig.hero.usersCount}
       />
-
-      {/* Trusted By Section */}
-      <div className="mt-8">
-        <H4 className="mb-6 w-full text-center text-muted-foreground">
-          {sqAgentConfig.trustedByTitle}
-        </H4>
-        <TrustedBy showTitle={false} logoSet="landing" />
-      </div>
 
       {/* Feature Sections */}
       {sqAgentConfig.sections.map((section, index) => (


### PR DESCRIPTION
## Description
- Simplify PostHog before_send to read UTMs from sessionStorage only (URL read was dead code since params are stripped)
- Remove duplicate UTM capture inline scripts from AppRootLayout and OnboardingLayout
- Add useStripUtmParams hook to RootLayout
- Add hideNavigation option to LandingLayout for landing pages
- Remove trusted-by sections from landing pages (glean, skip, sqagent)
- Fix gradient text clipping in sqAgentConfig

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
