### PR TITLE
[Front] feat(copilot): expose presetInstructions in get_agent_template tool

### DIFF
--- a/front/components/agent_builder/CopilotPanelContext.tsx
+++ b/front/components/agent_builder/CopilotPanelContext.tsx
@@ -126,7 +126,12 @@ Create all suggestions in this turn. Brief message (2-3 sentences) explaining wh
 **If neither presetInstructions nor copilotInstructions exist:**
 Proceed exactly as a new agent - suggest 2-3 use cases based on user's job function and preferred platforms, then wait for user response.
 
-${buildStep3({ includeInsights: false })}
+## Follow-up turns
+Use \`suggest_*\` tools to create actionable suggestions. Brief explanation (3-4 sentences max). Always include their output verbatim in your response - it renders as interactive cards.
+
+Warning: do not suggest instructions if there is no existing tools or skills to do an action.
+For instance if the user wants to create a agent to answer on JIRA issues but there is no tool to interact with JIRA then it won't be possible.
+In that case, instead of doing prompt suggestions ask the user for clarifications.
 </dust_system>`;
 }
 

--- a/front/lib/api/actions/servers/agent_copilot_context/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/tools/index.ts
@@ -1460,6 +1460,7 @@ const handlers: ToolHandlers<typeof AGENT_COPILOT_CONTEXT_TOOLS_METADATA> = {
             userFacingDescription: template.userFacingDescription,
             agentFacingDescription: template.agentFacingDescription,
             copilotInstructions: template.copilotInstructions,
+            presetInstructions: template.presetInstructions,
           },
           null,
           2


### PR DESCRIPTION
## Description

- Add `presetInstructions` to `get_agent_template` tool response so copilot can access template preset instructions
- Rework copilot template init message to call all discovery tools (skills, tools, knowledge, models) in parallel upfront 
- Handle `presetInstructions` properly: skip instruction suggestions if already injected in form (published templates), suggest as full rewrite if not yet present (draft templates)

## Tests

Local

## Risk



## Deploy Plan

