### PR TITLE
[Dust CLI] Bump to 0.3.5

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/dust-cli",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "A command-line interface for interacting with Dust.",
   "type": "module",
   "main": "dist/index.js",
@@ -22,7 +22,7 @@
   "author": "Dust",
   "license": "MIT",
   "dependencies": {
-    "@dust-tt/client": "^1.1.22",
+    "@dust-tt/client": "^1.2.5",
     "@modelcontextprotocol/sdk": "^1.9.0",
     "chalk": "^5.4.1",
     "clipboardy": "^4.0.0",

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/dust-cli",
-  "version": "0.3.5",
+  "version": "0.4.0",
   "description": "A command-line interface for interacting with Dust.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Description

Bump CLI version to 0.3.5 and update `@dust-tt/client` dependency to `^1.2.5`.

## Risks

Blast radius: CLI users
Risk: none

## Deploy Plan

- publish CLI to npm