### PR TITLE
[Programmatic Usage] Fix daily cap schema breaking enterprise upgrade

### DIFF
--- a/front/lib/api/poke/plugins/workspaces/manage_programmatic_usage_configuration.ts
+++ b/front/lib/api/poke/plugins/workspaces/manage_programmatic_usage_configuration.ts
@@ -56,7 +56,7 @@ export const ProgrammaticUsageConfigurationSchema = z
         `PAYG cap cannot exceed $${MAX_PAYG_CAP_DOLLARS.toLocaleString()}`
       )
       .optional(),
-    dailyCapEnabled: z.boolean(),
+    customDailyCapEnabled: z.boolean().default(false),
     dailyCapDollars: z
       .number()
       .min(
@@ -103,7 +103,7 @@ export const ProgrammaticUsageConfigurationSchema = z
   .refine(
     (data) => {
       if (
-        data.dailyCapEnabled &&
+        data.customDailyCapEnabled &&
         (!data.dailyCapDollars || data.dailyCapDollars < MIN_DAILY_CAP_DOLLARS)
       ) {
         return false;
@@ -186,7 +186,7 @@ export const manageProgrammaticUsageConfigurationPlugin = createPlugin({
         async: true,
         dependsOn: { field: "paygEnabled", value: true },
       },
-      dailyCapEnabled: {
+      customDailyCapEnabled: {
         type: "boolean",
         variant: "toggle",
         label: "Custom Daily Cap",
@@ -199,7 +199,7 @@ export const manageProgrammaticUsageConfigurationPlugin = createPlugin({
         label: "Daily Cap (USD)",
         description: `Maximum daily programmatic spending ($${MIN_DAILY_CAP_DOLLARS}-$${MAX_DAILY_CAP_DOLLARS.toLocaleString()}).`,
         async: true,
-        dependsOn: { field: "dailyCapEnabled", value: true },
+        dependsOn: { field: "customDailyCapEnabled", value: true },
       },
     },
   },
@@ -228,8 +228,8 @@ export const manageProgrammaticUsageConfigurationPlugin = createPlugin({
         defaultDiscountPercent: 0,
         paygEnabled: false,
         paygCapDollars: 0,
-        dailyCapEnabled: false,
-        dailyCapEnabledDescription: dailyCapDescription,
+        customDailyCapEnabled: false,
+        customDailyCapEnabledDescription: dailyCapDescription,
         dailyCapDollars: defaultDailyCapDollars,
       });
     }
@@ -253,8 +253,8 @@ export const manageProgrammaticUsageConfigurationPlugin = createPlugin({
       defaultDiscountPercent: config.defaultDiscountPercent,
       paygEnabled: config.paygCapMicroUsd !== null,
       paygCapDollars,
-      dailyCapEnabled: config.dailyCapMicroUsd !== null,
-      dailyCapEnabledDescription: dailyCapDescription,
+      customDailyCapEnabled: config.dailyCapMicroUsd !== null,
+      customDailyCapEnabledDescription: dailyCapDescription,
       dailyCapDollars,
     });
   },
@@ -278,7 +278,7 @@ export const manageProgrammaticUsageConfigurationPlugin = createPlugin({
       defaultDiscountPercent,
       paygEnabled,
       paygCapDollars,
-      dailyCapEnabled,
+      customDailyCapEnabled,
       dailyCapDollars,
     } = parseResult.data;
 
@@ -309,7 +309,7 @@ export const manageProgrammaticUsageConfigurationPlugin = createPlugin({
 
     // When daily cap override is disabled, use default algorithm
     const dailyCapMicroUsd =
-      dailyCapEnabled && dailyCapDollars
+      customDailyCapEnabled && dailyCapDollars
         ? Math.round(dailyCapDollars * 1_000_000)
         : null;
 
@@ -375,7 +375,7 @@ export const manageProgrammaticUsageConfigurationPlugin = createPlugin({
       ? `PAYG enabled with $${paygCapDollars} cap`
       : "PAYG disabled";
 
-    const dailyCapStatus = dailyCapEnabled
+    const dailyCapStatus = customDailyCapEnabled
       ? `Daily cap: $${dailyCapDollars}`
       : "Daily cap: default";
 


### PR DESCRIPTION
## Description

Context: [Slack thread](https://dust4ai.slack.com/archives/C06QC8ZRL0N/p1770652574537499)

Fixes regression introduced by the combination of https://github.com/dust-tt/dust/pull/20939 and https://github.com/dust-tt/dust/pull/20014.

PR #20939 added `dailyCapEnabled` as a required boolean to `ProgrammaticUsageConfigurationSchema`. PR #20014 made the enterprise upgrade endpoint validate against that same schema. Since the enterprise upgrade form doesn't include the daily cap field, validation always fails, making enterprise upgrades via Poke broken.

**Changes:**
- Rename `dailyCapEnabled` to `customDailyCapEnabled` for clarity (a default daily cap always exists, this toggle is for *custom* overrides)
- Add `.default(false)` so the schema doesn't require the field -- enterprise upgrade works again, custom daily cap can be configured later via the manage plugin

## Risks

Blast radius: Poke enterprise upgrade and programmatic usage configuration plugin
Risk: low

## Deploy Plan
- pmrr
- deploy front
