### PR TITLE
Allow dd headers in cors

### DIFF
--- a/front/config/cors.ts
+++ b/front/config/cors.ts
@@ -46,6 +46,13 @@ export const ALLOWED_HEADERS = [
   "x-dust-extension-version",
   "x-hackerone-research",
   "x-request-origin",
+  // Datadog RUM tracing headers (injected automatically by the browser SDK).
+  "traceparent",
+  "tracestate",
+  "x-datadog-origin",
+  "x-datadog-parent-id",
+  "x-datadog-sampling-priority",
+  "x-datadog-trace-id",
 ] as const;
 type AllowedHeaderType = (typeof ALLOWED_HEADERS)[number];
 


### PR DESCRIPTION
## Description

Fix CORS error on SPA reload by allowing Datadog RUM tracing headers

Summary

- Add Datadog RUM tracing headers (traceparent, tracestate, x-datadog-*) to the CORS allowed headers list
- Fixes 403 CORS errors when the SPA (app.dust.tt) makes cross-origin API calls to dust.tt

Context

The SPA on app.dust.tt makes cross-origin fetch requests to dust.tt. Datadog RUM SDK automatically injects tracing headers (traceparent, tracestate, x-datadog-origin, x-datadog-parent-id, x-datadog-sampling-priority, x-datadog-trace-id) into these requests.

When Chrome sends the CORS preflight (OPTIONS), the Access-Control-Request-Headers includes these Datadog headers. The middleware checks them against ALLOWED_HEADERS, rejects them as unauthorized, and returns a 403 without CORS headers — which the browser surfaces as a CORS error on the subsequent GET.

This explains why the issue was intermittent: it only occurred after Datadog RUM had initialized (typically on page reload, not on the initial navigation from dust.tt).


## Tests

- Reload app.dust.tt in Chrome — verify no CORS error on auth-context
- Verify Datadog RUM tracing still works (traces should flow through)

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

deploy front
