### PR TITLE
feat(sandbox-benchmarks): add e2b sandbox benchmark

### DIFF
--- a/x/henry/sandbox-benchmarks/e2b/bench_sandbox.ts
+++ b/x/henry/sandbox-benchmarks/e2b/bench_sandbox.ts
@@ -1,0 +1,526 @@
+/**
+ * Benchmark E2B Sandbox cold start latency.
+ *
+ * Pattern (same as Northflank/Cloudflare/Blaxel benchmark):
+ *   create sandbox -> retry exec until online -> delete sandbox
+ *
+ * Run from repo root (requires front deps for tsx):
+ *   npm --prefix x/henry/sandbox-benchmarks/e2b install
+ *   cd front && E2B_API_KEY=xxx \
+ *     npx tsx ../x/henry/sandbox-benchmarks/e2b/bench_sandbox.ts [plan] [-n <runs>] [--no-delete-between-runs]
+ */
+
+const HARD_TIMEOUT_MS = 60_000; // fail if not online
+const EXEC_RETRY_DELAY_MS = 500;
+const EXEC_ATTEMPT_TIMEOUT_MS = 5_000;
+
+const BENCHMARK_TAG = "sandbox-cold-start";
+const PROVIDER_TAG = "e2b";
+
+interface StepTiming {
+  step: string;
+  durationMs: number;
+  error?: string;
+}
+
+interface BenchmarkRunResult {
+  timings: StepTiming[];
+  success: boolean;
+  execAttempts: number;
+}
+
+interface CommandResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  error?: string;
+}
+
+interface SandboxInfo {
+  sandboxId: string;
+  metadata?: Record<string, string>;
+}
+
+interface SandboxPaginator {
+  hasNext: boolean;
+  nextItems(): Promise<SandboxInfo[]>;
+}
+
+interface SandboxInstance {
+  sandboxId: string;
+  commands: {
+    run(
+      cmd: string,
+      opts?: { timeoutMs?: number; requestTimeoutMs?: number },
+    ): Promise<CommandResult>;
+  };
+  kill(opts?: { requestTimeoutMs?: number }): Promise<void>;
+}
+
+interface SandboxApi {
+  create(
+    template: string,
+    opts?: {
+      apiKey?: string;
+      metadata?: Record<string, string>;
+      timeoutMs?: number;
+      requestTimeoutMs?: number;
+    },
+  ): Promise<SandboxInstance>;
+  list(opts?: {
+    apiKey?: string;
+    query?: { metadata?: Record<string, string> };
+    limit?: number;
+    nextToken?: string;
+    requestTimeoutMs?: number;
+  }): SandboxPaginator;
+  kill(
+    sandboxId: string,
+    opts?: { apiKey?: string; requestTimeoutMs?: number },
+  ): Promise<boolean>;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function printUsage(): void {
+  console.log(`Usage:
+  bench_sandbox.ts [plan] [-n <runs>] [--no-delete-between-runs]
+
+Args:
+  plan                      E2B template (default: base)
+
+Options:
+  -n, --runs <runs>         Number of runs (default: 1)
+  --no-delete-between-runs  Don't delete sandboxes between runs; only cleanup at start/end
+  -h, --help                Show this help
+`);
+}
+
+function parsePositiveInt(argName: string, value: string): number {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`${argName} must be a positive integer, got "${value}"`);
+  }
+  return parsed;
+}
+
+function parseArgs(argv: string[]): {
+  plan: string;
+  runs: number;
+  help: boolean;
+  deleteBetweenRuns: boolean;
+} {
+  let plan: string | undefined;
+  let runs = 1;
+  let help = false;
+  let deleteBetweenRuns = true;
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+
+    if (arg === "-h" || arg === "--help") {
+      help = true;
+      continue;
+    }
+
+    if (arg === "-n" || arg === "--runs") {
+      const value = argv[i + 1];
+      if (!value) {
+        throw new Error(`${arg} requires a value`);
+      }
+      runs = parsePositiveInt(arg, value);
+      i++;
+      continue;
+    }
+
+    if (arg.startsWith("--runs=")) {
+      runs = parsePositiveInt("--runs", arg.slice("--runs=".length));
+      continue;
+    }
+
+    if (arg === "--no-delete-between-runs") {
+      deleteBetweenRuns = false;
+      continue;
+    }
+
+    if (arg.startsWith("-")) {
+      throw new Error(`Unknown option: ${arg}`);
+    }
+
+    if (!plan) {
+      plan = arg;
+      continue;
+    }
+
+    throw new Error(`Unexpected argument: ${arg}`);
+  }
+
+  return { plan: plan ?? "base", runs, help, deleteBetweenRuns };
+}
+
+function mean(values: number[]): number {
+  if (values.length === 0) {
+    return 0;
+  }
+  return values.reduce((sum, v) => sum + v, 0) / values.length;
+}
+
+function stddev(values: number[]): number {
+  if (values.length <= 1) {
+    return 0;
+  }
+  const m = mean(values);
+  const variance = mean(values.map((v) => (v - m) ** 2));
+  return Math.sqrt(variance);
+}
+
+function getEnv(name: string): string | undefined {
+  const value = process.env[name];
+  if (!value) {
+    return undefined;
+  }
+  return value;
+}
+
+function getRequiredEnv(name: string): string {
+  const value = getEnv(name);
+  if (!value) {
+    throw new Error(`${name} env var is required`);
+  }
+  return value;
+}
+
+function sanitizePlan(plan: string): string {
+  const normalized = plan
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+  if (!normalized) {
+    return "base";
+  }
+  return normalized.slice(0, 20);
+}
+
+async function loadSandboxApi(): Promise<SandboxApi> {
+  try {
+    const mod = (await import("e2b")) as { Sandbox: SandboxApi };
+    if (!mod.Sandbox) {
+      throw new Error("module 'e2b' did not export Sandbox");
+    }
+    return mod.Sandbox;
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `Failed to load package "e2b" (${reason}). ` +
+        `Install it locally: npm --prefix x/henry/sandbox-benchmarks/e2b install`,
+    );
+  }
+}
+
+async function listBenchSandboxes(
+  Sandbox: SandboxApi,
+  apiKey: string,
+): Promise<SandboxInfo[]> {
+  const list: SandboxInfo[] = [];
+  const paginator = Sandbox.list({
+    apiKey,
+    limit: 100,
+    query: {
+      metadata: {
+        benchmark: BENCHMARK_TAG,
+        provider: PROVIDER_TAG,
+      },
+    },
+  });
+
+  while (paginator.hasNext) {
+    const page = await paginator.nextItems();
+    list.push(...page);
+  }
+
+  return list;
+}
+
+async function cleanupCluster(Sandbox: SandboxApi, apiKey: string) {
+  console.log("Cleaning up existing resources...");
+
+  const sandboxes = await listBenchSandboxes(Sandbox, apiKey);
+  for (const sandbox of sandboxes) {
+    console.log(`  Deleting sandbox: ${sandbox.sandboxId}`);
+    await Sandbox.kill(sandbox.sandboxId, {
+      apiKey,
+      requestTimeoutMs: 15_000,
+    }).catch(() => {});
+  }
+
+  console.log("Cleanup done.\n");
+}
+
+async function tryExec(
+  sandbox: SandboxInstance,
+  timeoutMs: number,
+): Promise<{
+  ok: boolean;
+  stdout: string;
+  stderr: string;
+  error?: string;
+}> {
+  let timer: NodeJS.Timeout | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error("exec timeout")), timeoutMs);
+  });
+
+  try {
+    const result = (await Promise.race([
+      sandbox.commands.run("echo i_am_online", {
+        timeoutMs,
+        requestTimeoutMs: timeoutMs,
+      }),
+      timeoutPromise,
+    ])) as CommandResult;
+
+    if (result.exitCode === 0 && result.stdout.includes("i_am_online")) {
+      return { ok: true, stdout: result.stdout, stderr: result.stderr };
+    }
+
+    return {
+      ok: false,
+      stdout: result.stdout,
+      stderr: result.stderr,
+      error: result.error ?? `exit=${result.exitCode}`,
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      stdout: "",
+      stderr: "",
+      error: err instanceof Error ? err.message : String(err),
+    };
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+}
+
+async function runBenchmark(
+  Sandbox: SandboxApi,
+  apiKey: string,
+  plan: string,
+  options: { deleteSandboxAtEnd: boolean },
+): Promise<BenchmarkRunResult> {
+  const planShort = sanitizePlan(plan);
+  const ts = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
+  const benchTag = `bench-${planShort}-${ts}`;
+  const timings: StepTiming[] = [];
+  let sandbox: SandboxInstance | null = null;
+
+  function recordStep(step: string, startMs: number, error?: string): StepTiming {
+    const timing = { step, durationMs: Date.now() - startMs, error };
+    timings.push(timing);
+    const status = error ? `FAILED: ${error}` : `${timing.durationMs}ms`;
+    console.log(`  ${step.padEnd(22)} ${status}`);
+    return timing;
+  }
+
+  async function cleanup() {
+    if (!sandbox) {
+      return;
+    }
+    await sandbox.kill({ requestTimeoutMs: 15_000 }).catch(() => {});
+  }
+
+  let t0 = Date.now();
+  try {
+    sandbox = await Sandbox.create(plan, {
+      apiKey,
+      timeoutMs: 300_000,
+      requestTimeoutMs: 30_000,
+      metadata: {
+        benchmark: BENCHMARK_TAG,
+        provider: PROVIDER_TAG,
+        plan,
+        run_id: benchTag,
+      },
+    });
+    recordStep("Create service", t0);
+  } catch (err) {
+    recordStep("Create service", t0, err instanceof Error ? err.message : String(err));
+    if (options.deleteSandboxAtEnd) {
+      await cleanup();
+    }
+    return { timings, success: false, execAttempts: 0 };
+  }
+
+  t0 = Date.now();
+  const hardDeadline = Date.now() + HARD_TIMEOUT_MS;
+  let execOk = false;
+  let lastExecError = "";
+  let attempts = 0;
+
+  while (Date.now() < hardDeadline) {
+    attempts++;
+    const result = await tryExec(sandbox, EXEC_ATTEMPT_TIMEOUT_MS);
+
+    if (result.ok && result.stdout.includes("i_am_online")) {
+      execOk = true;
+      break;
+    }
+
+    lastExecError = result.error ?? "no output";
+
+    if (Date.now() < hardDeadline) {
+      await sleep(EXEC_RETRY_DELAY_MS);
+    }
+  }
+
+  if (!execOk) {
+    recordStep(
+      "Exec readiness",
+      t0,
+      `${attempts} attempts in ${HARD_TIMEOUT_MS}ms — last: ${lastExecError}`,
+    );
+    if (options.deleteSandboxAtEnd) {
+      await cleanup();
+    }
+    return { timings, success: false, execAttempts: attempts };
+  }
+
+  recordStep("Exec readiness", t0);
+  console.log(`    (${attempts} exec attempt(s))`);
+
+  if (options.deleteSandboxAtEnd) {
+    t0 = Date.now();
+    await cleanup();
+    recordStep("Delete service", t0);
+  }
+
+  return { timings, success: true, execAttempts: attempts };
+}
+
+async function main() {
+  const { plan, runs, help, deleteBetweenRuns } = parseArgs(process.argv.slice(2));
+  if (help) {
+    printUsage();
+    return;
+  }
+
+  const apiKey = getRequiredEnv("E2B_API_KEY");
+  const Sandbox = await loadSandboxApi();
+
+  console.log(`Plan: ${plan}`);
+  console.log(`Runs: ${runs}`);
+  console.log(`Delete between runs: ${deleteBetweenRuns ? "yes" : "no"}`);
+  console.log(
+    `Readiness: retry exec until success (hard timeout: ${HARD_TIMEOUT_MS}ms)` +
+      ` (attempt timeout: ${EXEC_ATTEMPT_TIMEOUT_MS}ms, retry: ${EXEC_RETRY_DELAY_MS}ms)`,
+  );
+  console.log(
+    `Pattern: create(1 sandbox, no volume) -> exec${deleteBetweenRuns ? " -> delete" : ""}\n`,
+  );
+
+  await cleanupCluster(Sandbox, apiKey);
+
+  const results: BenchmarkRunResult[] = [];
+  try {
+    for (let i = 0; i < runs; i++) {
+      const runLabel = runs === 1 ? "" : ` (${i + 1}/${runs})`;
+      console.log(`--- Benchmark${runLabel}: ${plan} ---`);
+
+      const result = await runBenchmark(Sandbox, apiKey, plan, {
+        deleteSandboxAtEnd: deleteBetweenRuns,
+      });
+      results.push(result);
+
+      console.log();
+      if (result.success) {
+        const totalMs = result.timings.reduce((sum, t) => sum + t.durationMs, 0);
+        console.log(`TOTAL: ${totalMs}ms`);
+      } else {
+        console.log("RESULT: FAILED");
+        const failedStep = result.timings.find((t) => t.error);
+        if (failedStep) {
+          console.log(`  Failed at: ${failedStep.step}`);
+          console.log(`  Error: ${failedStep.error}`);
+        }
+      }
+
+      if (runs !== 1) {
+        console.log();
+      }
+    }
+
+    if (runs <= 1) {
+      return;
+    }
+
+    const successfulResults = results.filter((r) => r.success);
+    const failedRuns = results.length - successfulResults.length;
+
+    console.log("=== Summary ===");
+    console.log(
+      `Runs: ${results.length} (success: ${successfulResults.length}, failed: ${failedRuns})`,
+    );
+
+    if (successfulResults.length === 0) {
+      return;
+    }
+
+    const totalMsByRun = successfulResults.map((r) =>
+      r.timings.reduce((sum, t) => sum + t.durationMs, 0),
+    );
+    const execAttemptsByRun = successfulResults.map((r) => r.execAttempts);
+
+    console.log(
+      `TOTAL (ms): avg=${mean(totalMsByRun).toFixed(1)} ` +
+        `std=${stddev(totalMsByRun).toFixed(1)} ` +
+        `min=${Math.min(...totalMsByRun)} ` +
+        `max=${Math.max(...totalMsByRun)}`,
+    );
+    console.log(
+      `EXEC attempts: avg=${mean(execAttemptsByRun).toFixed(2)} ` +
+        `std=${stddev(execAttemptsByRun).toFixed(2)} ` +
+        `min=${Math.min(...execAttemptsByRun)} ` +
+        `max=${Math.max(...execAttemptsByRun)}`,
+    );
+
+    const stepNames = Array.from(
+      new Set(successfulResults.flatMap((r) => r.timings.map((t) => t.step))),
+    );
+
+    for (const stepName of stepNames) {
+      const stepDurationsMs = successfulResults
+        .map((r) => r.timings.find((t) => t.step === stepName))
+        .filter((t): t is StepTiming => t !== undefined && !t.error)
+        .map((t) => t.durationMs);
+
+      if (stepDurationsMs.length === 0) {
+        continue;
+      }
+
+      console.log(
+        `${stepName.padEnd(22)} ` +
+          `avg=${mean(stepDurationsMs).toFixed(1)}ms ` +
+          `std=${stddev(stepDurationsMs).toFixed(1)}ms ` +
+          `min=${Math.min(...stepDurationsMs)}ms ` +
+          `max=${Math.max(...stepDurationsMs)}ms ` +
+          `(n=${stepDurationsMs.length})`,
+      );
+    }
+  } finally {
+    if (!deleteBetweenRuns) {
+      console.log("\nCleaning up bench sandboxes...");
+      await cleanupCluster(Sandbox, apiKey);
+    }
+  }
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error("Fatal:", err);
+    process.exit(1);
+  });

--- a/x/henry/sandbox-benchmarks/e2b/package-lock.json
+++ b/x/henry/sandbox-benchmarks/e2b/package-lock.json
@@ -1,0 +1,398 @@
+{
+  "name": "@dust-tt/sandbox-benchmark-e2b",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@dust-tt/sandbox-benchmark-e2b",
+      "dependencies": {
+        "e2b": "2.12.1"
+      }
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.11.0.tgz",
+      "integrity": "sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
+    "node_modules/@connectrpc/connect": {
+      "version": "2.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.0.0-rc.3.tgz",
+      "integrity": "sha512-ARBt64yEyKbanyRETTjcjJuHr2YXorzQo0etyS5+P6oSeW8xEuzajA9g+zDnMcj1hlX2dQE93foIWQGfpru7gQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.2.0"
+      }
+    },
+    "node_modules/@connectrpc/connect-web": {
+      "version": "2.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect-web/-/connect-web-2.0.0-rc.3.tgz",
+      "integrity": "sha512-w88P8Lsn5CCsA7MFRl2e6oLY4J/5toiNtJns/YJrlyQaWOy3RO8pDgkz+iIkG98RPMhj2thuBvsd3Cn4DKKCkw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.2.0",
+        "@connectrpc/connect": "2.0.0-rc.3"
+      }
+    },
+    "node_modules/@isaacs/balanced-match": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
+      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@isaacs/brace-expansion": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.1.tgz",
+      "integrity": "sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@isaacs/balanced-match": "^4.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
+      "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/compare-versions": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
+      "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==",
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/dockerfile-ast": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/dockerfile-ast/-/dockerfile-ast-0.7.1.tgz",
+      "integrity": "sha512-oX/A4I0EhSkGqrFv0YuvPkBUSYp1XiY8O8zAKc8Djglx8ocz+JfOr8gP0ryRMC2myqvDLagmnZaU9ot1vG2ijw==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-languageserver-textdocument": "^1.0.8",
+        "vscode-languageserver-types": "^3.17.3"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/e2b": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/e2b/-/e2b-2.12.1.tgz",
+      "integrity": "sha512-qKYwS0VSZqvtWAT4OrCtOwRhhMlcd359zyFRGAZZ1wpYHHjr9zR872UCoDb/d5jFVUsREcUgktURc47XxfznPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@bufbuild/protobuf": "^2.6.2",
+        "@connectrpc/connect": "2.0.0-rc.3",
+        "@connectrpc/connect-web": "2.0.0-rc.3",
+        "chalk": "^5.3.0",
+        "compare-versions": "^6.1.0",
+        "dockerfile-ast": "^0.7.1",
+        "glob": "^11.1.0",
+        "openapi-fetch": "^0.14.1",
+        "platform": "^1.3.6",
+        "tar": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jackspeak": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
+      "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^9.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.2.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz",
+      "integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.2.tgz",
+      "integrity": "sha512-fu656aJ0n2kcXwsnwnv9g24tkU5uSmOlTjd6WyyaKm2Z+h1qmY6bAjrcaIxF/BslFqbZ8UBtbJi7KgQOZD2PTw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/brace-expansion": "^5.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/openapi-fetch": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/openapi-fetch/-/openapi-fetch-0.14.1.tgz",
+      "integrity": "sha512-l7RarRHxlEZYjMLd/PR0slfMVse2/vvIAGm75/F7J6MlQ8/b9uUQmUF2kCPrQhJqMXSxmYWObVgeYXbFYzZR+A==",
+      "license": "MIT",
+      "dependencies": {
+        "openapi-typescript-helpers": "^0.0.15"
+      }
+    },
+    "node_modules/openapi-typescript-helpers": {
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/openapi-typescript-helpers/-/openapi-typescript-helpers-0.0.15.tgz",
+      "integrity": "sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw==",
+      "license": "MIT"
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
+      "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
+      "license": "MIT"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/tar": {
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.7.tgz",
+      "integrity": "sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "license": "MIT"
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/x/henry/sandbox-benchmarks/e2b/package.json
+++ b/x/henry/sandbox-benchmarks/e2b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@dust-tt/sandbox-benchmark-e2b",
+  "private": true,
+  "dependencies": {
+    "e2b": "2.12.1"
+  }
+}


### PR DESCRIPTION
## Description

Add a new E2B sandbox benchmark under `x/henry/sandbox-benchmarks/e2b` with the same flow as the existing benchmarks:
- create sandbox
- retry exec until ready
- delete sandbox (with optional `--no-delete-between-runs`)

Also add a local `package.json` + lockfile in that benchmark directory so the `e2b` dependency is isolated there and does not modify `front/package.json`.

## Tests

- `npm --prefix x/henry/sandbox-benchmarks/e2b install`
- `cd front && E2B_API_KEY=... npx tsx ../x/henry/sandbox-benchmarks/e2b/bench_sandbox.ts -n 1`
- `cd front && E2B_API_KEY=... npx tsx ../x/henry/sandbox-benchmarks/e2b/bench_sandbox.ts -n 32`

## Risk

Low. Changes are isolated to `x/henry/sandbox-benchmarks/e2b` and only affect local benchmarking scripts. No runtime product paths are touched.

## Deploy Plan

No deploy steps required. This is benchmark tooling only.