### PR TITLE
[spa] Improve auth-context error reporting

### DIFF
--- a/front-spa/src/app/components/AuthErrorPage.tsx
+++ b/front-spa/src/app/components/AuthErrorPage.tsx
@@ -1,0 +1,72 @@
+import { Button, ExclamationCircleIcon, Icon } from "@dust-tt/sparkle";
+
+import Custom404 from "@dust-tt/front/pages/404";
+import type { APIErrorResponse } from "@dust-tt/front/types/error";
+import { isAPIErrorResponse } from "@dust-tt/front/types/error";
+
+interface AuthErrorPageProps {
+  error: APIErrorResponse | Error;
+}
+
+export function AuthErrorPage({ error }: AuthErrorPageProps) {
+  if (isAPIErrorResponse(error)) {
+    if (error.error.type === "workspace_not_found") {
+      return <Custom404 />;
+    }
+
+    return (
+      <div className="flex h-dvh items-center justify-center">
+        <div className="flex flex-col gap-3 text-center">
+          <div className="flex flex-col items-center">
+            <Icon
+              visual={ExclamationCircleIcon}
+              size="lg"
+              className="text-warning-400"
+            />
+            <p className="heading-xl text-foreground dark:text-foreground-night">
+              Something went wrong
+            </p>
+            <p className="copy-sm text-muted-foreground dark:text-muted-foreground-night">
+              {error.error.message}
+            </p>
+          </div>
+          <div>
+            <Button
+              variant="outline"
+              label="Try again"
+              onClick={() => window.location.reload()}
+            />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-dvh items-center justify-center">
+      <div className="flex flex-col gap-3 text-center">
+        <div className="flex flex-col items-center">
+          <Icon
+            visual={ExclamationCircleIcon}
+            size="lg"
+            className="text-warning-400"
+          />
+          <p className="heading-xl text-foreground dark:text-foreground-night">
+            Connection error
+          </p>
+          <p className="copy-sm text-muted-foreground dark:text-muted-foreground-night">
+            We couldn't reach the server. Please check your connection and try
+            again.
+          </p>
+        </div>
+        <div>
+          <Button
+            variant="outline"
+            label="Try again"
+            onClick={() => window.location.reload()}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/front-spa/src/app/layouts/WorkspacePage.tsx
+++ b/front-spa/src/app/layouts/WorkspacePage.tsx
@@ -1,3 +1,4 @@
+import { AuthErrorPage } from "@spa/app/components/AuthErrorPage";
 import { useAppReadyContext } from "@spa/app/contexts/AppReadyContext";
 import { useRequiredPathParam } from "@spa/lib/platform";
 import { type ReactNode, useEffect } from "react";
@@ -13,26 +14,22 @@ interface WorkspacePageProps {
 export function WorkspacePage({ children }: WorkspacePageProps) {
   const wId = useRequiredPathParam("wId");
 
-  const { authContext, isAuthenticated, isAuthContextError } = useAuthContext({
+  const { authContext, isAuthenticated, authContextError } = useAuthContext({
     workspaceId: wId,
   });
 
   const signalAppReady = useAppReadyContext();
 
-  // Signal that the app is ready when auth is loaded
+  // Signal that the app is ready when auth is loaded or on error
   // This will dismiss the loading screen
   useEffect(() => {
-    if (isAuthenticated && authContext) {
+    if ((isAuthenticated && authContext) || authContextError) {
       signalAppReady();
     }
-  }, [isAuthenticated, authContext, signalAppReady]);
+  }, [isAuthenticated, authContext, authContextError, signalAppReady]);
 
-  if (isAuthContextError) {
-    return (
-      <div className="flex h-screen w-full items-center justify-center">
-        <p>{isAuthContextError.message}</p>
-      </div>
-    );
+  if (authContextError) {
+    return <AuthErrorPage error={authContextError} />;
   }
 
   // Return null while loading - the loading screen handles the loading state

--- a/front-spa/src/app/pages/IndexPage.tsx
+++ b/front-spa/src/app/pages/IndexPage.tsx
@@ -1,3 +1,4 @@
+import { AuthErrorPage } from "@spa/app/components/AuthErrorPage";
 import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 
@@ -5,7 +6,7 @@ import { useAuthContext } from "@dust-tt/front/lib/swr/workspaces";
 
 export function IndexPage() {
   const navigate = useNavigate();
-  const { authContext } = useAuthContext();
+  const { authContext, authContextError } = useAuthContext();
 
   const defaultWorkspaceId = authContext?.defaultWorkspaceId;
 
@@ -16,6 +17,10 @@ export function IndexPage() {
       });
     }
   }, [defaultWorkspaceId, navigate]);
+
+  if (authContextError) {
+    return <AuthErrorPage error={authContextError} />;
+  }
 
   // The static loading screen in index.html handles the initial loading state
   return null;

--- a/front-spa/src/poke/layouts/PokePage.tsx
+++ b/front-spa/src/poke/layouts/PokePage.tsx
@@ -1,4 +1,5 @@
 import { Spinner } from "@dust-tt/sparkle";
+import { AuthErrorPage } from "@spa/app/components/AuthErrorPage";
 import { useAppReadyContext } from "@spa/app/contexts/AppReadyContext";
 import { type ReactNode, useEffect } from "react";
 import { Outlet } from "react-router-dom";
@@ -11,15 +12,20 @@ interface PokeLayoutProps {
 }
 
 export function PokePage({ children }: PokeLayoutProps) {
-  const { authContext, isAuthenticated } = usePokeAuthContext();
+  const { authContext, isAuthenticated, authContextError } =
+    usePokeAuthContext();
 
   const signalAppReady = useAppReadyContext();
 
   useEffect(() => {
-    if (isAuthenticated && authContext) {
+    if ((isAuthenticated && authContext) || authContextError) {
       signalAppReady();
     }
-  }, [isAuthenticated, authContext, signalAppReady]);
+  }, [isAuthenticated, authContext, authContextError, signalAppReady]);
+
+  if (authContextError) {
+    return <AuthErrorPage error={authContextError} />;
+  }
 
   if (!isAuthenticated || !authContext) {
     return (

--- a/front-spa/src/poke/layouts/PokeWorkspacePage.tsx
+++ b/front-spa/src/poke/layouts/PokeWorkspacePage.tsx
@@ -1,4 +1,5 @@
 import { Spinner } from "@dust-tt/sparkle";
+import { AuthErrorPage } from "@spa/app/components/AuthErrorPage";
 import { useAppReadyContext } from "@spa/app/contexts/AppReadyContext";
 import { useRequiredPathParam } from "@spa/lib/platform";
 import { type ReactNode, useEffect } from "react";
@@ -14,17 +15,23 @@ interface PokeLayoutProps {
 export function PokeWorkspacePage({ children }: PokeLayoutProps) {
   const wId = useRequiredPathParam("wId");
 
-  const { authContext, isAuthenticated } = usePokeAuthContext({
-    workspaceId: wId,
-  });
+  const { authContext, isAuthenticated, authContextError } = usePokeAuthContext(
+    {
+      workspaceId: wId,
+    }
+  );
 
   const signalAppReady = useAppReadyContext();
 
   useEffect(() => {
-    if (isAuthenticated && authContext) {
+    if ((isAuthenticated && authContext) || authContextError) {
       signalAppReady();
     }
-  }, [isAuthenticated, authContext, signalAppReady]);
+  }, [isAuthenticated, authContext, authContextError, signalAppReady]);
+
+  if (authContextError) {
+    return <AuthErrorPage error={authContextError} />;
+  }
 
   if (!isAuthenticated || !authContext) {
     return (

--- a/front/lib/swr/poke.ts
+++ b/front/lib/swr/poke.ts
@@ -18,6 +18,7 @@ import type {
   LightWorkspaceType,
   RegionRedirectError,
 } from "@app/types";
+import type { APIErrorResponse } from "@app/types/error";
 
 export function usePokeRegion() {
   const regionFetcher: Fetcher<GetRegionResponseType> = fetcher;
@@ -165,7 +166,7 @@ interface UsePokeAuthContextResult<T> {
   authContext: T | undefined;
   isAuthenticated: boolean;
   isAuthContextLoading: boolean;
-  isAuthContextError: boolean;
+  authContextError: APIErrorResponse | Error | undefined;
 }
 
 export function usePokeAuthContext(options?: {
@@ -217,15 +218,13 @@ export function usePokeAuthContext(
   // Handle login redirect.
   useEffect(() => {
     if (error && !regionRedirect) {
-      setIsRedirecting(true);
       if (error.error?.type === "not_authenticated") {
+        setIsRedirecting(true);
         window.location.href = `${getApiBaseUrl()}/api/workos/login?returnTo=${encodeURIComponent(
           window.location.pathname + window.location.search
         )}`;
-      } else {
-        //TODO: Handle other error types with nicer messages.
-        window.location.href = `/404`;
       }
+      // For all other errors, let the consuming component handle the display.
     }
   }, [error, regionRedirect]);
 
@@ -234,6 +233,6 @@ export function usePokeAuthContext(
     isAuthenticated,
     isAuthContextLoading:
       isLoading || !!isRegionRedirectResponse || isRedirecting,
-    isAuthContextError: !!error,
+    authContextError: error,
   };
 }

--- a/front/lib/swr/workspaces.ts
+++ b/front/lib/swr/workspaces.ts
@@ -37,6 +37,7 @@ import type {
   RegionRedirectError,
   WhitelistableFeature,
 } from "@app/types";
+import type { APIErrorResponse } from "@app/types/error";
 
 // Type guard to check if response is a region redirect
 export function isRegionRedirect(data: unknown): data is RegionRedirectError {
@@ -572,7 +573,7 @@ interface UseAuthContextResult<T> {
   authContext: T | undefined;
   isAuthenticated: boolean;
   isAuthContextLoading: boolean;
-  isAuthContextError: Error | undefined;
+  authContextError: APIErrorResponse | Error | undefined;
 }
 
 export function useAuthContext(options?: {
@@ -628,15 +629,13 @@ export function useAuthContext(
   // Handle login redirect.
   useEffect(() => {
     if (error && !regionRedirect) {
-      setIsRedirecting(true);
       if (error.error?.type === "not_authenticated") {
+        setIsRedirecting(true);
         window.location.href = `${getApiBaseUrl()}/api/workos/login?returnTo=${encodeURIComponent(
           window.location.pathname + window.location.search
         )}`;
-      } else {
-        //TODO: Handle other error types with nicer messages.
-        window.location.href = `/404`;
       }
+      // For all other errors, let the consuming component handle the display.
     }
   }, [error, regionRedirect]);
 
@@ -645,7 +644,7 @@ export function useAuthContext(
     isAuthenticated,
     isAuthContextLoading:
       isFetching || !!isRegionRedirectResponse || isRedirecting,
-    isAuthContextError: error,
+    authContextError: error,
   };
 }
 


### PR DESCRIPTION
## Description

- Stop redirecting to /404 on auth-context errors — only redirect for not_authenticated (→ login)
- Show contextual error pages inline via a new AuthErrorPage component:
  - workspace_not_found → renders the 404 page inline
  - Other API errors → "Something went wrong" with the server error message
  - Network/CORS errors → "Connection error" with retry button
- Dismiss the loading screen on error so users aren't stuck on a spinner
- Apply consistently across app SPA (IndexPage, WorkspacePage) and poke SPA (PokePage, PokeWorkspacePage)
- Rename isAuthContextError → authContextError (it's not a boolean) and type it as APIErrorResponse | Error | undefined

Context

Previously, any non-not_authenticated error from useAuthContext triggered a redirect to /404. This was wrong for network/CORS errors (the user would lose their URL context) and for other API errors that deserved their own messaging.

## Test plan

- Verify not_authenticated still redirects to login
- Navigate to /w/invalid-workspace-id — should show 404 page inline
- Simulate network error (e.g. offline mode) — should show "Connection error" with retry button
- Verify poke SPA has the same behavior
