### PR TITLE
[COPILOT] Turn into agent redirects to AB with copilot tab open

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -94,12 +94,14 @@ interface AgentBuilderProps {
   duplicateAgentId?: string | null;
   // TODO(copilot 2026-02-10): hack to allow copilot to access draft templates, remove once done iterating on copilot template instructions.
   copilotTemplateId?: string | null;
+  conversationId?: string;
 }
 
 export default function AgentBuilder({
   agentConfiguration,
   duplicateAgentId,
   copilotTemplateId,
+  conversationId,
 }: AgentBuilderProps) {
   const { owner, user, assistantTemplate } = useAgentBuilderContext();
   const { supportedDataSourceViews } = useDataSourceViewsContext();
@@ -510,6 +512,7 @@ export default function AgentBuilder({
             setIsCreatedDialogOpen={setIsCreatedDialogOpen}
             isNewAgent={!!duplicateAgentId || !agentConfiguration}
             templateId={assistantTemplate?.sId ?? copilotTemplateId ?? null}
+            conversationId={conversationId}
           />
         </CopilotSuggestionsProvider>
       </FormProvider>
@@ -541,6 +544,7 @@ interface AgentBuilderContentProps {
   setIsCreatedDialogOpen: (open: boolean) => void;
   isNewAgent: boolean;
   templateId: string | null;
+  conversationId?: string;
 }
 
 function AgentBuilderContent({
@@ -557,6 +561,7 @@ function AgentBuilderContent({
   setIsCreatedDialogOpen,
   isNewAgent,
   templateId,
+  conversationId,
 }: AgentBuilderContentProps) {
   const { owner } = useAgentBuilderContext();
   const { hasFeature } = useFeatureFlags({ workspaceId: owner.sId });
@@ -656,10 +661,12 @@ function AgentBuilderContent({
             }
             isNewAgent={isNewAgent}
             templateId={templateId}
+            conversationId={conversationId}
           >
             <ConversationSidePanelProvider>
               <AgentBuilderRightPanel
                 agentConfigurationSId={agentConfiguration?.sId}
+                conversationId={conversationId}
               />
             </ConversationSidePanelProvider>
           </CopilotPanelProvider>

--- a/front/components/agent_builder/AgentBuilderRightPanel.tsx
+++ b/front/components/agent_builder/AgentBuilderRightPanel.tsx
@@ -12,7 +12,7 @@ import {
   TabsTrigger,
   TestTubeIcon,
 } from "@dust-tt/sparkle";
-import React, { useState } from "react";
+import { useState } from "react";
 
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import { AgentBuilderCopilot } from "@app/components/agent_builder/AgentBuilderCopilot";
@@ -240,10 +240,12 @@ function ExpandedContent({
 
 interface AgentBuilderRightPanelProps {
   agentConfigurationSId?: string;
+  conversationId?: string;
 }
 
 export function AgentBuilderRightPanel({
   agentConfigurationSId,
+  conversationId,
 }: AgentBuilderRightPanelProps) {
   const { isPreviewPanelOpen, setIsPreviewPanelOpen } =
     usePreviewPanelContext();
@@ -252,9 +254,10 @@ export function AgentBuilderRightPanel({
 
   const hasTemplate = !!assistantTemplate;
   const hasCopilot = hasFeature("agent_builder_copilot");
+  const inferFromConversation = conversationId && hasCopilot && !hasTemplate;
 
   const [selectedTab, setSelectedTab] = useState<AgentBuilderRightPanelTabType>(
-    hasTemplate ? "template" : "preview"
+    hasTemplate ? "template" : inferFromConversation ? "copilot" : "preview",
   );
 
   const handleTogglePanel = () => {

--- a/front/components/agent_builder/AgentBuilderRightPanel.tsx
+++ b/front/components/agent_builder/AgentBuilderRightPanel.tsx
@@ -257,7 +257,7 @@ export function AgentBuilderRightPanel({
   const inferFromConversation = conversationId && hasCopilot && !hasTemplate;
 
   const [selectedTab, setSelectedTab] = useState<AgentBuilderRightPanelTabType>(
-    hasTemplate ? "template" : inferFromConversation ? "copilot" : "preview",
+    hasTemplate ? "template" : inferFromConversation ? "copilot" : "preview"
   );
 
   const handleTogglePanel = () => {

--- a/front/components/agent_builder/CopilotPanelContext.tsx
+++ b/front/components/agent_builder/CopilotPanelContext.tsx
@@ -149,6 +149,7 @@ interface CopilotPanelProviderProps {
   clientSideMCPServerIds: string[];
   isNewAgent: boolean;
   templateId: string | null;
+  conversationId?: string;
 }
 
 export const CopilotPanelProvider = ({

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -479,10 +479,10 @@ export function AgentMessage({
   const canDeleteAgentMessage =
     !isDeleted && agentMessage.status !== "created" && isTriggeredByCurrentUser;
 
-  const { featureFlags } = useFeatureFlags({
+  const { hasFeature } = useFeatureFlags({
     workspaceId: owner.sId,
   });
-  const hasCopilotFeatureFlag = featureFlags.includes("agent_builder_copilot");
+  const hasCopilotFeatureFlag = hasFeature("agent_builder_copilot");
 
   const handleDeleteAgentMessage = useCallback(async () => {
     if (isDeleted || !canDeleteAgentMessage || isDeleting) {

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -75,12 +75,16 @@ import config from "@app/lib/api/config";
 import { getApiBaseUrl } from "@app/lib/egress/client";
 import type { DustError } from "@app/lib/error";
 import { FILE_ID_PATTERN } from "@app/lib/files";
+import { useAppRouter } from "@app/lib/platform";
 import {
   useCancelMessage,
   usePostOnboardingFollowUp,
 } from "@app/lib/swr/conversations";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
-import { getConversationRoute } from "@app/lib/utils/router";
+import {
+  getAgentBuilderRoute,
+  getConversationRoute,
+} from "@app/lib/utils/router";
 import { formatTimestring } from "@app/lib/utils/timestamps";
 import type {
   ContentFragmentsType,
@@ -165,6 +169,7 @@ export function AgentMessage({
   additionalMarkdownPlugins,
 }: AgentMessageProps) {
   const sId = agentMessage.sId;
+  const router = useAppRouter();
 
   const [isRetryHandlerProcessing, setIsRetryHandlerProcessing] =
     React.useState<boolean>(false);
@@ -604,7 +609,14 @@ export function AgentMessage({
       dropdownItems.push({
         label: "Turn into agent",
         icon: RobotIcon,
-        onSelect: () => {},
+        onSelect: () => {
+          const route = getAgentBuilderRoute(
+            owner.sId,
+            "new",
+            `conversationId=${conversationId}`
+          );
+          void router.push(route);
+        },
       });
     }
 

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -101,6 +101,7 @@ import {
   isSupportedImageContentType,
 } from "@app/types";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import { isBuilder } from "@app/types/user";
 
 const UNDERTAND_LLMS_CONTEXT_WINDOW_URL =
   "https://docs.dust.tt/docs/understanding-llms-context-windows";
@@ -605,7 +606,7 @@ export function AgentMessage({
       });
     }
 
-    if (hasCopilotFeatureFlag && isLastMessage) {
+    if (hasCopilotFeatureFlag && isLastMessage && isBuilder(owner)) {
       dropdownItems.push({
         label: "Turn into agent",
         icon: RobotIcon,

--- a/front/components/pages/builder/agents/NewAgentPage.tsx
+++ b/front/components/pages/builder/agents/NewAgentPage.tsx
@@ -25,6 +25,9 @@ export function NewAgentPage() {
   const router = useAppRouter();
   const owner = useWorkspace();
   const { user, isAdmin, isBuilder } = useAuth();
+  const { hasFeature } = useFeatureFlags({
+    workspaceId: owner.sId,
+  });
 
   const flowParam = useSearchParam("flow");
   const flow: BuilderFlow =
@@ -52,7 +55,8 @@ export function NewAgentPage() {
     disabled: !duplicateAgentId,
   });
 
-  const shouldPassConversationId = agentConfiguration?.version === 0;
+  const shouldPassConversationId =
+    hasFeature("agent_builder_copilot") && agentConfiguration === null;
 
   const {
     assistantTemplate,

--- a/front/components/pages/builder/agents/NewAgentPage.tsx
+++ b/front/components/pages/builder/agents/NewAgentPage.tsx
@@ -34,6 +34,7 @@ export function NewAgentPage() {
   const templateId = useSearchParam("templateId");
   // TODO(copilot 2026-02-10): hack to allow copilot to access draft templates, remove once done iterating on copilot template instructions.
   const copilotTemplateId = useSearchParam("copilotTemplateId");
+  const conversationId = useSearchParam("conversationId");
 
   const { featureFlags, isFeatureFlagsLoading } = useFeatureFlags({
     workspaceId: owner.sId,
@@ -50,6 +51,8 @@ export function NewAgentPage() {
     agentConfigurationId: duplicateAgentId,
     disabled: !duplicateAgentId,
   });
+
+  const shouldPassConversationId = agentConfiguration?.version === 0;
 
   const {
     assistantTemplate,
@@ -125,6 +128,9 @@ export function NewAgentPage() {
         agentConfiguration={duplicateConfiguration ?? undefined}
         duplicateAgentId={duplicateAgentId}
         copilotTemplateId={copilotTemplateId}
+        conversationId={
+          shouldPassConversationId ? (conversationId ?? undefined) : undefined
+        }
       />
     </AgentBuilderProvider>
   );


### PR DESCRIPTION
## Description

When turning conversation into agent, user is redirected to the agent builder.
if the agent has no configuration yet, then the agent builder copilot tab is open 

Next, the init message of the copilot will be updated to call the inspect conversation tool and suggest agent instructions


https://github.com/user-attachments/assets/d0831ff0-51b9-4c8b-b87c-1ebb1a057249



## Tests

local

## Risk

no - behind ff

## Deploy Plan

front
