### PR TITLE
Handle multi-region in join endpoint

### DIFF
--- a/front-spa/src/app/App.tsx
+++ b/front-spa/src/app/App.tsx
@@ -15,7 +15,6 @@ import {
 
 import RootLayout from "@dust-tt/front/components/app/RootLayout";
 import { RegionProvider } from "@dust-tt/front/lib/auth/RegionContext";
-
 import Custom404 from "@dust-tt/front/pages/404";
 
 // Redirect component that preserves query params and hash
@@ -296,13 +295,6 @@ const router = createBrowserRouter(
   [
     { path: "/", element: <IndexPage /> },
     {
-      element: <UnauthenticatedPage />,
-      children: [
-        { path: "/w/:wId/join", element: <JoinPage /> },
-        { path: "/login-error", element: <LoginErrorPage /> },
-      ],
-    },
-    {
       path: "/w/:wId",
       element: <WorkspacePage />,
       children: [
@@ -420,7 +412,11 @@ const router = createBrowserRouter(
     },
     {
       element: <UnauthenticatedPage />,
-      children: [{ path: "*", element: <Custom404 /> }],
+      children: [
+        { path: "/w/:wId/join", element: <JoinPage /> },
+        { path: "/login-error", element: <LoginErrorPage /> },
+        { path: "*", element: <Custom404 /> },
+      ],
     },
   ],
   {


### PR DESCRIPTION
## Description

Summary

- Handle multi-region in /w/[wId]/join endpoint: When a workspace isn't found locally, the backend now checks if it exists in another region and returns a workspace_in_different_region redirect error, same as auth-context.ts. The useJoinData SWR hook detects this redirect, switches the SPA's API base URL via RegionContext, and re-fetches — so unauthenticated users hitting /w/[wId]/join for a workspace in EU (or any other region) get seamlessly routed.

## Tests

- Navigate to /w/[wId]/join for a workspace in a different region — should resolve region and show join page
- Navigate to /w/[wId]/join for a workspace in the local region — should work as before
- Navigate to /w/[wId]/join for a non-existent workspace — should show 404

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
