### PR TITLE
[front] - refacto(insights): conversations as datasources

### DIFF
--- a/front/components/agent_builder/observability/charts/DatasourceRetrievalTreemapChart.tsx
+++ b/front/components/agent_builder/observability/charts/DatasourceRetrievalTreemapChart.tsx
@@ -20,6 +20,7 @@ import { ChartContainer } from "@app/components/charts/ChartContainer";
 import { ChartTooltipCard } from "@app/components/charts/ChartTooltip";
 import type { DatasourceRetrievalTreemapNode } from "@app/components/charts/DatasourceRetrievalTreemapContent";
 import { DatasourceRetrievalTreemapContent } from "@app/components/charts/DatasourceRetrievalTreemapContent";
+import { CONVERSATION_FILES_AGGREGATE_KEY } from "@app/lib/api/assistant/observability/datasource_retrieval";
 import {
   useAgentDatasourceRetrieval,
   useAgentDatasourceRetrievalDocuments,
@@ -180,10 +181,12 @@ export function DatasourceRetrievalTreemapChart({
       const hasConfigIds =
         node.mcpServerConfigIds && node.mcpServerConfigIds.length > 0;
       // Need either config IDs or server name (for servers like data_sources_file_system).
+      // Skip aggregated conversation files — no document drill-down available.
       if (
         (!hasConfigIds && !node.mcpServerName) ||
         !node.mcpServerDisplayName ||
-        !node.dataSourceId
+        !node.dataSourceId ||
+        node.dataSourceId === CONVERSATION_FILES_AGGREGATE_KEY
       ) {
         return;
       }

--- a/front/lib/api/assistant/observability/datasource_retrieval.ts
+++ b/front/lib/api/assistant/observability/datasource_retrieval.ts
@@ -17,6 +17,7 @@ import { Err, Ok } from "@app/types/shared/result";
 
 export const CONVERSATION_FILES_AGGREGATE_KEY = "__conversation_files__";
 const CONVERSATION_FILES_DISPLAY_NAME = "Conversation Files";
+const CONVERSATION_FILES_SERVER_DISPLAY_NAME = "Search Conversations";
 
 export type DatasourceRetrievalData = {
   mcpServerConfigIds: string[];
@@ -326,6 +327,14 @@ export async function fetchDatasourceRetrievalMetrics(
 
       group.count += configBucket.doc_count;
       addDatasourcesToGroup(group, datasourceBuckets);
+    }
+  }
+
+  // Rename the legend for groups containing aggregated conversation files so the
+  // treemap shows "Search Conversations" instead of the raw MCP server name.
+  for (const group of groupedByCompositeKey.values()) {
+    if (group.datasources.has(CONVERSATION_FILES_AGGREGATE_KEY)) {
+      group.mcpServerDisplayName = CONVERSATION_FILES_SERVER_DISPLAY_NAME;
     }
   }
 

--- a/front/lib/api/assistant/observability/datasource_retrieval.ts
+++ b/front/lib/api/assistant/observability/datasource_retrieval.ts
@@ -38,6 +38,56 @@ type DatasourceAggregation = {
   connectorProvider?: ConnectorProvider;
 };
 
+function resolveDatasourceDisplayName(
+  dataSourceId: string,
+  dataSource: DataSourceResource | undefined,
+  isConversationDs: boolean
+): string {
+  if (isConversationDs) {
+    return CONVERSATION_FILES_DISPLAY_NAME;
+  }
+  if (dataSource) {
+    return getDisplayNameForDataSource(dataSource.toJSON());
+  }
+  return dataSourceId;
+}
+
+function aggregateDatasourceBuckets({
+  target,
+  buckets,
+  conversationDataSourceIds,
+  dataSourceBySId,
+}: {
+  target: Map<string, DatasourceAggregation>;
+  buckets: DatasourceBucket[];
+  conversationDataSourceIds: Set<string>;
+  dataSourceBySId: Map<string, DataSourceResource>;
+}): void {
+  for (const bucket of buckets) {
+    const isConversationDs = conversationDataSourceIds.has(bucket.key);
+    const key = isConversationDs
+      ? CONVERSATION_FILES_AGGREGATE_KEY
+      : bucket.key;
+
+    const existing = target.get(key);
+    if (existing) {
+      existing.count += bucket.doc_count;
+    } else {
+      const dataSource = dataSourceBySId.get(bucket.key);
+      target.set(key, {
+        dataSourceId: key,
+        displayName: resolveDatasourceDisplayName(
+          bucket.key,
+          dataSource,
+          isConversationDs
+        ),
+        count: bucket.doc_count,
+        connectorProvider: dataSource?.connectorProvider ?? undefined,
+      });
+    }
+  }
+}
+
 type ToolAggregation = {
   mcpServerConfigIds: Set<string>;
   mcpServerDisplayName: string;
@@ -221,30 +271,12 @@ export async function fetchDatasourceRetrievalMetrics(
     group: ToolAggregation,
     datasourceBuckets: DatasourceBucket[]
   ) {
-    for (const dsBucket of datasourceBuckets) {
-      const isConversationDs = conversationDataSourceIds.has(dsBucket.key);
-      const key = isConversationDs
-        ? CONVERSATION_FILES_AGGREGATE_KEY
-        : dsBucket.key;
-
-      const existing = group.datasources.get(key);
-      if (existing) {
-        existing.count += dsBucket.doc_count;
-      } else {
-        const dataSource = dataSourceBySId.get(dsBucket.key);
-        const displayName = isConversationDs
-          ? CONVERSATION_FILES_DISPLAY_NAME
-          : dataSource
-            ? getDisplayNameForDataSource(dataSource.toJSON())
-            : dsBucket.key;
-        group.datasources.set(key, {
-          dataSourceId: key,
-          displayName,
-          count: dsBucket.doc_count,
-          connectorProvider: dataSource?.connectorProvider ?? undefined,
-        });
-      }
-    }
+    aggregateDatasourceBuckets({
+      target: group.datasources,
+      buckets: datasourceBuckets,
+      conversationDataSourceIds,
+      dataSourceBySId,
+    });
   }
 
   for (const configBucket of mcpServerConfigBuckets) {
@@ -382,34 +414,18 @@ export async function fetchWorkspaceDatasourceRetrievalMetrics(
     dataSources.filter((ds) => ds.conversationId !== null).map((ds) => ds.sId)
   );
 
-  const resultMap = new Map<string, WorkspaceDatasourceRetrievalData>();
+  const resultMap = new Map<string, DatasourceAggregation>();
 
-  for (const bucket of datasourceBuckets) {
-    const isConversationDs = conversationDataSourceIds.has(bucket.key);
-    const key = isConversationDs
-      ? CONVERSATION_FILES_AGGREGATE_KEY
-      : bucket.key;
+  aggregateDatasourceBuckets({
+    target: resultMap,
+    buckets: datasourceBuckets,
+    conversationDataSourceIds,
+    dataSourceBySId,
+  });
 
-    const existing = resultMap.get(key);
-    if (existing) {
-      existing.count += bucket.doc_count;
-    } else {
-      const dataSource = dataSourceBySId.get(bucket.key);
-      const displayName = isConversationDs
-        ? CONVERSATION_FILES_DISPLAY_NAME
-        : dataSource
-          ? getDisplayNameForDataSource(dataSource.toJSON())
-          : bucket.key;
-      resultMap.set(key, {
-        dataSourceId: key,
-        displayName,
-        count: bucket.doc_count,
-        connectorProvider: dataSource?.connectorProvider ?? undefined,
-      });
-    }
-  }
-
-  const data = Array.from(resultMap.values());
+  const data: WorkspaceDatasourceRetrievalData[] = Array.from(
+    resultMap.values()
+  );
 
   return new Ok(data);
 }


### PR DESCRIPTION
## Description
Aggregates conversation file data sources in the observability metrics treemap by grouping them under a singledisplay name "Conversation Files", and renames the corresponding MCP server display to "Search Conversations" for better clarity in the UI.

## Risk

Low

## Tests
Manual testing of the treemap chart display.

## Deploy Plan

Deploy front