### PR TITLE
[Front] chore(copilot): remove legacy description compat from template pull endpoint

### DIFF
--- a/front/pages/api/poke/templates/pull.ts
+++ b/front/pages/api/poke/templates/pull.ts
@@ -81,22 +81,8 @@ async function handler(
           continue;
         }
 
-        // TODO(copilot 2026-02-09): remove legacy description compat once all regions are deployed
-        const rawTemplate: FetchAgentTemplateResponse & {
-          description?: string;
-        } = await templateResponse.json();
-
-        const template: FetchAgentTemplateResponse = {
-          ...rawTemplate,
-          userFacingDescription:
-            rawTemplate.userFacingDescription ??
-            rawTemplate.description ??
-            null,
-          agentFacingDescription:
-            rawTemplate.agentFacingDescription ??
-            rawTemplate.description ??
-            null,
-        };
+        const template: FetchAgentTemplateResponse =
+          await templateResponse.json();
 
         await TemplateResource.upsertByHandle(template);
 


### PR DESCRIPTION
## Description

Remove legacy `description` field fallback from the poke template pull endpoint. All regions are now deployed with `userFacingDescription`/`agentFacingDescription`, so the compat layer is no longer needed.