### PR TITLE
Inline 404 errors

### DIFF
--- a/front/components/pages/builder/agents/EditAgentPage.tsx
+++ b/front/components/pages/builder/agents/EditAgentPage.tsx
@@ -3,11 +3,11 @@ import { Spinner } from "@dust-tt/sparkle";
 import AgentBuilder from "@app/components/agent_builder/AgentBuilder";
 import { AgentBuilderProvider } from "@app/components/agent_builder/AgentBuilderContext";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
-import { useAppRouter, useRequiredPathParam } from "@app/lib/platform";
+import { useRequiredPathParam } from "@app/lib/platform";
 import { useAgentConfiguration } from "@app/lib/swr/assistants";
+import Custom404 from "@app/pages/404";
 
 export function EditAgentPage() {
-  const router = useAppRouter();
   const owner = useWorkspace();
   const { user, isAdmin } = useAuth();
   const agentId = useRequiredPathParam("aId");
@@ -26,12 +26,7 @@ export function EditAgentPage() {
     (!isAgentConfigurationLoading && !agentConfiguration) ||
     (agentConfiguration && !agentConfiguration.canEdit && !isAdmin)
   ) {
-    void router.replace("/404");
-    return (
-      <div className="flex h-screen items-center justify-center">
-        <Spinner size="lg" />
-      </div>
-    );
+    return <Custom404 />;
   }
 
   if (isAgentConfigurationLoading || !agentConfiguration) {

--- a/front/components/pages/builder/agents/ManageAgentsPage.tsx
+++ b/front/components/pages/builder/agents/ManageAgentsPage.tsx
@@ -25,7 +25,6 @@ import { AppWideModeLayout } from "@app/components/sparkle/AppWideModeLayout";
 import { useHashParam } from "@app/hooks/useHashParams";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
-import { useAppRouter } from "@app/lib/platform";
 import { useAgentConfigurations } from "@app/lib/swr/assistants";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import {
@@ -33,6 +32,7 @@ import {
   getAgentSearchString,
   subFilter,
 } from "@app/lib/utils";
+import Custom404 from "@app/pages/404";
 import type { LightAgentConfigurationType } from "@app/types";
 import { isAdmin } from "@app/types";
 import type { TagType } from "@app/types/tag";
@@ -81,7 +81,6 @@ function isValidTab(tab: string): tab is AssistantManagerTabsType {
 }
 
 export function ManageAgentsPage() {
-  const router = useAppRouter();
   const owner = useWorkspace();
   const { subscription, user, isBuilder } = useAuth();
   const [assistantSearch, setAssistantSearch] = useState("");
@@ -281,12 +280,7 @@ export function ManageAgentsPage() {
   }
 
   if (isRestrictedFromAgentCreation) {
-    void router.replace("/404");
-    return (
-      <div className="flex h-screen items-center justify-center">
-        <Spinner size="lg" />
-      </div>
-    );
+    return <Custom404 />;
   }
 
   return (

--- a/front/components/pages/builder/agents/NewAgentPage.tsx
+++ b/front/components/pages/builder/agents/NewAgentPage.tsx
@@ -6,12 +6,13 @@ import type { BuilderFlow } from "@app/components/agent_builder/types";
 import { BUILDER_FLOWS } from "@app/components/agent_builder/types";
 import { throwIfInvalidAgentConfiguration } from "@app/lib/actions/types/guards";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
-import { useAppRouter, useSearchParam } from "@app/lib/platform";
+import { useSearchParam } from "@app/lib/platform";
 import {
   useAgentConfiguration,
   useAssistantTemplate,
 } from "@app/lib/swr/assistants";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
+import Custom404 from "@app/pages/404";
 import type {
   AgentConfigurationScope,
   AgentConfigurationType,
@@ -22,7 +23,6 @@ function isBuilderFlow(value: string): value is BuilderFlow {
 }
 
 export function NewAgentPage() {
-  const router = useAppRouter();
   const owner = useWorkspace();
   const { user, isAdmin, isBuilder } = useAuth();
   const { hasFeature } = useFeatureFlags({
@@ -85,12 +85,7 @@ export function NewAgentPage() {
   }
 
   if (isRestrictedFromAgentCreation) {
-    void router.replace("/404");
-    return (
-      <div className="flex h-screen items-center justify-center">
-        <Spinner size="lg" />
-      </div>
-    );
+    return <Custom404 />;
   }
 
   if (
@@ -101,12 +96,7 @@ export function NewAgentPage() {
       (isAssistantTemplateError ||
         (!isAssistantTemplateLoading && !assistantTemplate)))
   ) {
-    void router.replace("/404");
-    return (
-      <div className="flex h-screen items-center justify-center">
-        <Spinner size="lg" />
-      </div>
-    );
+    return <Custom404 />;
   }
 
   if (isDuplicateLoading || (templateId && isAssistantTemplateLoading)) {

--- a/front/components/pages/builder/skills/EditSkillPage.tsx
+++ b/front/components/pages/builder/skills/EditSkillPage.tsx
@@ -3,11 +3,11 @@ import { Spinner } from "@dust-tt/sparkle";
 import SkillBuilder from "@app/components/skill_builder/SkillBuilder";
 import { SkillBuilderProvider } from "@app/components/skill_builder/SkillBuilderContext";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
-import { Head, useAppRouter, useRequiredPathParam } from "@app/lib/platform";
+import { Head, useRequiredPathParam } from "@app/lib/platform";
 import { useSkill } from "@app/lib/swr/skill_configurations";
+import Custom404 from "@app/pages/404";
 
 export function EditSkillPage() {
-  const router = useAppRouter();
   const owner = useWorkspace();
   const { user } = useAuth();
   const skillId = useRequiredPathParam("sId");
@@ -24,10 +24,10 @@ export function EditSkillPage() {
     (skill && (!skill.canWrite || skill.status === "archived"));
 
   if (isNotFound) {
-    void router.replace("/404");
+    return <Custom404 />;
   }
 
-  if (isNotFound || isSkillLoading || !skill) {
+  if (isSkillLoading || !skill) {
     return (
       <div className="flex h-screen items-center justify-center">
         <Spinner size="xl" />

--- a/front/components/pages/onboarding/JoinPage.tsx
+++ b/front/components/pages/onboarding/JoinPage.tsx
@@ -9,12 +9,9 @@ import {
 import { useEffect } from "react";
 
 import OnboardingLayout from "@app/components/sparkle/OnboardingLayout";
-import {
-  useAppRouter,
-  useRequiredPathParam,
-  useSearchParam,
-} from "@app/lib/platform";
+import { useRequiredPathParam, useSearchParam } from "@app/lib/platform";
 import { useJoinData } from "@app/lib/swr/workspaces";
+import Custom404 from "@app/pages/404";
 
 function isRedirectResponse(data: unknown): data is { redirectUrl: string } {
   return (
@@ -26,7 +23,6 @@ function isRedirectResponse(data: unknown): data is { redirectUrl: string } {
 }
 
 export function JoinPage() {
-  const router = useAppRouter();
   const wId = useRequiredPathParam("wId");
   const token = useSearchParam("t");
   const conversationId = useSearchParam("cId");
@@ -49,12 +45,10 @@ export function JoinPage() {
     }
   }, [redirectUrl]);
 
-  // Redirect to 404 for unknown workspaces or missing auto-join domains.
-  useEffect(() => {
-    if (!isJoinDataLoading && !redirectUrl && !joinData) {
-      void router.replace("/404");
-    }
-  }, [isJoinDataLoading, redirectUrl, joinData, router]);
+  // Show 404 for unknown workspaces or missing auto-join domains.
+  if (!isJoinDataLoading && !redirectUrl && !joinData) {
+    return <Custom404 />;
+  }
 
   if (!joinData) {
     return (

--- a/front/components/pages/onboarding/NoWorkspacePage.tsx
+++ b/front/components/pages/onboarding/NoWorkspacePage.tsx
@@ -5,7 +5,6 @@ import {
   Page,
   Spinner,
 } from "@dust-tt/sparkle";
-
 import { useEffect } from "react";
 
 import { UserMenu } from "@app/components/UserMenu";

--- a/front/components/pages/spaces/apps/AppSettingsPage.tsx
+++ b/front/components/pages/spaces/apps/AppSettingsPage.tsx
@@ -10,6 +10,7 @@ import { dustAppsListUrl } from "@app/lib/spaces";
 import { useApp } from "@app/lib/swr/apps";
 import { useSpaceInfo } from "@app/lib/swr/spaces";
 import { MODELS_STRING_MAX_LENGTH } from "@app/lib/utils";
+import Custom404 from "@app/pages/404";
 import type { APIError } from "@app/types";
 import { APP_NAME_REGEXP } from "@app/types";
 
@@ -146,12 +147,7 @@ export function AppSettingsPage() {
 
   // Show 404 on error or if app not found after loading completes
   if (isAppError || (!isLoading && !app)) {
-    void router.replace("/404");
-    return (
-      <div className="flex h-screen items-center justify-center">
-        <Spinner />
-      </div>
-    );
+    return <Custom404 />;
   }
 
   if (isLoading || !app || !space) {

--- a/front/components/pages/spaces/apps/AppSpecificationPage.tsx
+++ b/front/components/pages/spaces/apps/AppSpecificationPage.tsx
@@ -9,6 +9,7 @@ import { useAppRouter, useRequiredPathParam } from "@app/lib/platform";
 import { dustAppsListUrl } from "@app/lib/spaces";
 import { dumpSpecification } from "@app/lib/specification";
 import { useApp } from "@app/lib/swr/apps";
+import Custom404 from "@app/pages/404";
 import type { SpecificationType } from "@app/types";
 
 export function AppSpecificationPage() {
@@ -44,12 +45,7 @@ export function AppSpecificationPage() {
 
   // Show 404 on error or if app not found after loading completes
   if (isAppError || (!isAppLoading && !app)) {
-    void router.replace("/404");
-    return (
-      <div className="flex h-screen items-center justify-center">
-        <Spinner />
-      </div>
-    );
+    return <Custom404 />;
   }
 
   if (isAppLoading || !app) {

--- a/front/components/pages/spaces/apps/AppViewPage.tsx
+++ b/front/components/pages/spaces/apps/AppViewPage.tsx
@@ -24,6 +24,7 @@ import {
   moveBlockUp,
 } from "@app/lib/specification";
 import { useApp, useCancelRun, useSavedRunStatus } from "@app/lib/swr/apps";
+import Custom404 from "@app/pages/404";
 import type {
   APIErrorResponse,
   BlockRunConfig,
@@ -348,12 +349,7 @@ export function AppViewPage() {
 
   // Show 404 on error or if app not found after loading completes
   if (isAppError || (!isAppLoading && !app)) {
-    void router.replace("/404");
-    return (
-      <div className="flex h-screen items-center justify-center">
-        <Spinner />
-      </div>
-    );
+    return <Custom404 />;
   }
 
   if (isAppLoading || !app) {

--- a/front/components/pages/spaces/apps/DatasetPage.tsx
+++ b/front/components/pages/spaces/apps/DatasetPage.tsx
@@ -14,6 +14,7 @@ import { useAppRouter, useRequiredPathParam } from "@app/lib/platform";
 import { dustAppsListUrl } from "@app/lib/spaces";
 import { useApp } from "@app/lib/swr/apps";
 import { useDataset } from "@app/lib/swr/datasets";
+import Custom404 from "@app/pages/404";
 import type { DatasetSchema, DatasetType } from "@app/types";
 
 export function DatasetPage() {
@@ -130,12 +131,7 @@ export function DatasetPage() {
 
   // Show 404 on error or if dataset not found after loading completes
   if (isDatasetError || (!isLoading && app && !dataset)) {
-    void router.replace("/404");
-    return (
-      <div className="flex h-screen items-center justify-center">
-        <Spinner />
-      </div>
-    );
+    return <Custom404 />;
   }
 
   if (isLoading || !app || !dataset || !updatedDataset) {

--- a/front/components/pages/spaces/apps/DatasetsPage.tsx
+++ b/front/components/pages/spaces/apps/DatasetsPage.tsx
@@ -13,6 +13,7 @@ import {
 import { useApp } from "@app/lib/swr/apps";
 import { useDatasets } from "@app/lib/swr/datasets";
 import { classNames } from "@app/lib/utils";
+import Custom404 from "@app/pages/404";
 
 export function DatasetsPage() {
   const router = useAppRouter();
@@ -66,12 +67,7 @@ export function DatasetsPage() {
 
   // Show 404 on error or if app not found after loading completes
   if (isAppError || (!isLoading && !app)) {
-    void router.replace("/404");
-    return (
-      <div className="flex h-screen items-center justify-center">
-        <Spinner />
-      </div>
-    );
+    return <Custom404 />;
   }
 
   if (isLoading || !app) {

--- a/front/components/pages/spaces/apps/NewDatasetPage.tsx
+++ b/front/components/pages/spaces/apps/NewDatasetPage.tsx
@@ -11,6 +11,7 @@ import { useRegisterUnloadHandlers } from "@app/lib/front";
 import { useAppRouter, useRequiredPathParam } from "@app/lib/platform";
 import { useApp } from "@app/lib/swr/apps";
 import { useDatasets } from "@app/lib/swr/datasets";
+import Custom404 from "@app/pages/404";
 import type { DatasetSchema, DatasetType } from "@app/types";
 
 export function NewDatasetPage() {
@@ -107,12 +108,7 @@ export function NewDatasetPage() {
 
   // Show 404 on error or if app not found after loading completes
   if (isAppError || (!isLoading && !app)) {
-    void router.replace("/404");
-    return (
-      <div className="flex h-screen items-center justify-center">
-        <Spinner />
-      </div>
-    );
+    return <Custom404 />;
   }
 
   if (isLoading || !app) {

--- a/front/components/pages/spaces/apps/RunPage.tsx
+++ b/front/components/pages/spaces/apps/RunPage.tsx
@@ -8,11 +8,11 @@ import { ConfirmContext } from "@app/components/Confirm";
 import { cleanSpecificationFromCore } from "@app/lib/api/run";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
-import { useAppRouter, useRequiredPathParam } from "@app/lib/platform";
+import { useRequiredPathParam } from "@app/lib/platform";
 import { useApp, useRunWithSpec } from "@app/lib/swr/apps";
+import Custom404 from "@app/pages/404";
 
 export function RunPage() {
-  const router = useAppRouter();
   const spaceId = useRequiredPathParam("spaceId");
   const aId = useRequiredPathParam("aId");
   const runId = useRequiredPathParam("runId");
@@ -86,12 +86,7 @@ export function RunPage() {
 
   // Show 404 on error or if app/run not found after loading completes
   if (isAppError || isRunError || (!pageIsLoading && (!app || !run))) {
-    void router.replace("/404");
-    return (
-      <div className="flex h-screen items-center justify-center">
-        <Spinner />
-      </div>
-    );
+    return <Custom404 />;
   }
 
   if (pageIsLoading || !app || !run || !spec) {

--- a/front/components/pages/spaces/apps/RunsPage.tsx
+++ b/front/components/pages/spaces/apps/RunsPage.tsx
@@ -5,12 +5,12 @@ import { DustAppPageLayout } from "@app/components/apps/DustAppPageLayout";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import {
   LinkWrapper,
-  useAppRouter,
   useRequiredPathParam,
   useSearchParam,
 } from "@app/lib/platform";
 import { useApp, useRuns } from "@app/lib/swr/apps";
 import { classNames, timeAgoFrom } from "@app/lib/utils";
+import Custom404 from "@app/pages/404";
 import type { RunRunType, RunStatus } from "@app/types";
 
 const TABS = [
@@ -30,7 +30,6 @@ const inputCount = (status: RunStatus) => {
 };
 
 export function RunsPage() {
-  const router = useAppRouter();
   const spaceId = useRequiredPathParam("spaceId");
   const aId = useRequiredPathParam("aId");
   const wIdTarget = useSearchParam("wIdTarget");
@@ -79,12 +78,7 @@ export function RunsPage() {
 
   // Show 404 on error or if app not found after loading completes
   if (isAppError || (!isAppLoading && !app)) {
-    void router.replace("/404");
-    return (
-      <div className="flex h-screen items-center justify-center">
-        <Spinner />
-      </div>
-    );
+    return <Custom404 />;
   }
 
   if (isAppLoading || !app) {

--- a/front/lib/swr/workspaces.ts
+++ b/front/lib/swr/workspaces.ts
@@ -22,7 +22,6 @@ import type { GetWorkspaceUsageMetricsResponse } from "@app/pages/api/w/[wId]/an
 import type { GetWorkspaceAuthContextResponseType } from "@app/pages/api/w/[wId]/auth-context";
 import type { GetWorkspaceFeatureFlagsResponseType } from "@app/pages/api/w/[wId]/feature-flags";
 import type { GetJoinResponseBody } from "@app/pages/api/w/[wId]/join";
-import type { GetWorkspaceLookupResponseBody } from "@app/pages/api/workspace-lookup";
 import type { GetSeatAvailabilityResponseBody } from "@app/pages/api/w/[wId]/seats/availability";
 import type { GetWorkspaceSeatsCountResponseBody } from "@app/pages/api/w/[wId]/seats/count";
 import type { GetSubscriptionsResponseBody } from "@app/pages/api/w/[wId]/subscriptions";
@@ -33,6 +32,7 @@ import type { GetWorkspaceVerifiedDomainsResponseBody } from "@app/pages/api/w/[
 import type { GetVerifyResponseBody } from "@app/pages/api/w/[wId]/verify";
 import type { GetWelcomeResponseBody } from "@app/pages/api/w/[wId]/welcome";
 import type { GetWorkspaceAnalyticsResponse } from "@app/pages/api/w/[wId]/workspace-analytics";
+import type { GetWorkspaceLookupResponseBody } from "@app/pages/api/workspace-lookup";
 import type {
   LightWorkspaceType,
   RegionRedirectError,


### PR DESCRIPTION
## Description

Summary

- Replace all router.replace("/404") calls with inline <Custom404 /> rendering across 13 page components
- Previously, not-found states triggered a client-side navigation to /404, which caused a flash of spinner before the 404 page appeared. Now the 404 page renders immediately in place.
- Removed unused useAppRouter imports from 7 files where the router was only used for the 404 redirect (EditAgentPage, ManageAgentsPage, NewAgentPage, EditSkillPage, JoinPage, RunPage, RunsPage)

## Tests

- Navigate to a non-existent agent edit page (/w/[wId]/builder/agents/fake-id) — should show 404 immediately without spinner flash
- Navigate to a non-existent app page (/w/[wId]/spaces/[spaceId]/apps/fake-id) — should show 404
- Navigate to /w/[wId]/join for a non-existent workspace — should show 404
- Navigate to valid pages (agent edit, app view, datasets, runs) — should still load normally

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
