### PR TITLE
Disable emoticons to avoid the :null: bug

### DIFF
--- a/front/components/editor/extensions/EmojiExtension.tsx
+++ b/front/components/editor/extensions/EmojiExtension.tsx
@@ -59,8 +59,14 @@ export const EmojiExtension = Emoji.extend({
     await loadEmojiData();
   },
 }).configure({
-  // Enable emoticon conversion (e.g., <3 → ❤️, :) → 😊)
-  enableEmoticons: true,
+  // Disable emoticon conversion to prevent :null: bug
+  // When enableEmoticons is true with an empty emojis array, TipTap creates
+  // an input rule with regex (?:^|\s)() $ which matches any double space,
+  // creating emoji nodes with name: null that render as :null:
+  // TODO: To enable emoticons, we need to either:
+  // 1. Load emoji data synchronously before extension creation, or
+  // 2. Implement a mechanism to update input rules after async data loads
+  enableEmoticons: false,
 
   // HTML attributes for styling
   HTMLAttributes: {
@@ -70,7 +76,7 @@ export const EmojiExtension = Emoji.extend({
   // Configure suggestion plugin for :emoji: syntax
   suggestion: createEmojiSuggestion(),
 
-  // Start with empty emojis - emoticon conversion won't work until data loads
+  // Start with empty emojis array - this is populated asynchronously in onCreate()
   // The emoji picker/search uses EmojiDropdown which loads data independently
   emojis,
 });


### PR DESCRIPTION
## Description

Closes https://github.com/dust-tt/tasks/issues/6437

Root cause:
 - The emoji extension was configured with enableEmoticons: true and an empty emojis array
 - TipTap created an emoticon input rule with regex (?:^|\s)() $ (empty capture group)
 - This regex matched any double space, creating emoji nodes with name: null
 - These rendered as :null: text
 - Emoticons are never rendered as emoji (try typing `:)` or `<3`in prod)
 
Solution:
 - Set enableEmoticons: false to prevent the buggy input rule from being created
 - Added clear comments explaining why and how to enable emoticons properly in the future

@ElPicador can I let you investigate how to re-enable the emoticons, if we actually want it ?

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

manual test

## Risk

low

## Deploy Plan

deploy front
