### PR TITLE
[connectors] enh(Gong): handle revoked access tokens

### DIFF
--- a/connectors/src/connectors/gong/lib/gong_api.ts
+++ b/connectors/src/connectors/gong/lib/gong_api.ts
@@ -203,9 +203,12 @@ export class GongClient {
       }
       if (
         response.status === 401 &&
-        response.statusText.includes(
+        (response.statusText.includes(
           "Validate credentials failed. Please check your credentials and try again."
-        )
+        ) ||
+          response.statusText.includes(
+            "Your access token has been revoked. Please generate a new access token."
+          ))
       ) {
         throw new ExternalOAuthTokenError();
       }


### PR DESCRIPTION
## Description

- [Logs](https://app.datadoghq.eu/logs?query=%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40attempt%3A%3E19%20%40dd.service%3Aconnectors-worker&additional_filters=%5B%5D&clustering_pattern_field_path=message&cols=%40workflowId%2C%40error.type&event=AwAAAZxInjKG-R9LmAAAABhBWnhJbmpxTEFBQVdBNVphSWtZWnJ3QUUAAAAkMDE5YzQ4OWUtM2RkYS00MzE1LThiNDktMDZlZWNkZDljMjk2AABFEw&fromUser=true&messageDisplay=inline&refresh_mode=sliding&saved-view-id=186044&storage=hot&stream_sort=desc&viz=stream&from_ts=1770741334077&to_ts=1770744934077&live=true).
- Handle 401 responses with revoked access tokens by pausing and erroring the connector.

## Tests

## Risk

- N/A.

## Deploy Plan

- Deploy connectors.
