### PR TITLE
Reload on chunk load failure

### DIFF
--- a/front-spa/src/app/App.tsx
+++ b/front-spa/src/app/App.tsx
@@ -1,6 +1,7 @@
 import RootLayout from "@dust-tt/front/components/app/RootLayout";
 import { RegionProvider } from "@dust-tt/front/lib/auth/RegionContext";
 import Custom404 from "@dust-tt/front/pages/404";
+import { safeLazy } from "@dust-tt/sparkle";
 import { AppReadyProvider } from "@spa/app/contexts/AppReadyContext";
 import { AdminLayout } from "@spa/app/layouts/AdminLayout";
 import { ConversationLayoutWrapper } from "@spa/app/layouts/ConversationLayoutWrapper";
@@ -8,7 +9,7 @@ import { SpaceLayoutWrapper } from "@spa/app/layouts/SpaceLayoutWrapper";
 import { UnauthenticatedPage } from "@spa/app/layouts/UnauthenticatedPage";
 import { WorkspacePage } from "@spa/app/layouts/WorkspacePage";
 import { IndexPage } from "@spa/app/pages/IndexPage";
-import { lazy, Suspense } from "react";
+import { Suspense } from "react";
 import {
   createBrowserRouter,
   Navigate,
@@ -32,23 +33,14 @@ function PageLoader() {
 }
 
 // Helper to wrap lazy components with Suspense.
-// On chunk load failure (typically after a deploy replaces old assets),
-// automatically reload to get fresh assets.
 function withSuspense(
   importFn: () => Promise<Record<string, unknown>>,
-  exportName?: string
+  exportName: string
 ) {
-  const LazyComponent = lazy(() =>
-    importFn()
-      .catch(() => {
-        window.location.reload();
-        return new Promise<Record<string, unknown>>(() => {});
-      })
-      .then((module) => ({
-        default: (exportName
-          ? module[exportName]
-          : module.default) as React.ComponentType,
-      }))
+  const LazyComponent = safeLazy(() =>
+    importFn().then((module) => ({
+      default: module[exportName] as React.ComponentType,
+    }))
   );
   return function SuspenseWrapper() {
     return (

--- a/front/components/SuspensedCodeEditor.tsx
+++ b/front/components/SuspensedCodeEditor.tsx
@@ -1,5 +1,6 @@
+import { safeLazy } from "@dust-tt/sparkle";
 import type { TextareaCodeEditorProps } from "@uiw/react-textarea-code-editor";
-import React, { lazy, Suspense } from "react";
+import React, { Suspense } from "react";
 
 function CodeEditorFallback() {
   return (
@@ -7,7 +8,7 @@ function CodeEditorFallback() {
   );
 }
 
-const CodeEditor = lazy(() =>
+const CodeEditor = safeLazy(() =>
   import("@uiw/react-textarea-code-editor").then((mod) => ({
     default: mod.default,
   }))

--- a/front/components/observability/AgentFeedback.tsx
+++ b/front/components/observability/AgentFeedback.tsx
@@ -1,9 +1,10 @@
 import {
   HandThumbDownIcon,
   HandThumbUpIcon,
+  safeLazy,
   ValueCard,
 } from "@dust-tt/sparkle";
-import { lazy, Suspense } from "react";
+import { Suspense } from "react";
 
 import { FeedbacksSection } from "@app/components/agent_builder/FeedbacksSection";
 import { useObservabilityContext } from "@app/components/agent_builder/observability/ObservabilityContext";
@@ -11,7 +12,7 @@ import { TabContentChildSectionLayout } from "@app/components/agent_builder/obse
 import { useAgentAnalytics } from "@app/lib/swr/assistants";
 import type { LightWorkspaceType } from "@app/types";
 
-const FeedbackDistributionChart = lazy(() =>
+const FeedbackDistributionChart = safeLazy(() =>
   import(
     "@app/components/agent_builder/observability/charts/FeedbackDistributionChart"
   ).then((mod) => ({

--- a/front/components/observability/AgentObservability.tsx
+++ b/front/components/observability/AgentObservability.tsx
@@ -3,10 +3,11 @@ import {
   CardGrid,
   ContentMessage,
   LoadingBlock,
+  safeLazy,
   Spinner,
   ValueCard,
 } from "@dust-tt/sparkle";
-import { lazy, Suspense } from "react";
+import { Suspense } from "react";
 
 import { useObservabilityContext } from "@app/components/agent_builder/observability/ObservabilityContext";
 import { TabContentChildSectionLayout } from "@app/components/agent_builder/observability/TabContentChildSectionLayout";
@@ -18,42 +19,42 @@ import type { LightWorkspaceType } from "@app/types";
 
 // Dynamic imports for chart components to exclude recharts from server bundle
 
-const DatasourceRetrievalTreemapChart = lazy(() =>
+const DatasourceRetrievalTreemapChart = safeLazy(() =>
   import(
     "@app/components/agent_builder/observability/charts/DatasourceRetrievalTreemapChart"
   ).then((mod) => ({
     default: mod.DatasourceRetrievalTreemapChart,
   }))
 );
-const LatencyChart = lazy(() =>
+const LatencyChart = safeLazy(() =>
   import(
     "@app/components/agent_builder/observability/charts/LatencyChart"
   ).then((mod) => ({
     default: mod.LatencyChart,
   }))
 );
-const SourceChart = lazy(() =>
+const SourceChart = safeLazy(() =>
   import("@app/components/agent_builder/observability/charts/SourceChart").then(
     (mod) => ({
       default: mod.SourceChart,
     })
   )
 );
-const ToolUsageChart = lazy(() =>
+const ToolUsageChart = safeLazy(() =>
   import(
     "@app/components/agent_builder/observability/charts/ToolUsageChart"
   ).then((mod) => ({
     default: mod.ToolUsageChart,
   }))
 );
-const ToolExecutionTimeChart = lazy(() =>
+const ToolExecutionTimeChart = safeLazy(() =>
   import(
     "@app/components/agent_builder/observability/charts/ToolExecutionTimeChart"
   ).then((mod) => ({
     default: mod.ToolExecutionTimeChart,
   }))
 );
-const UsageMetricsChart = lazy(() =>
+const UsageMetricsChart = safeLazy(() =>
   import(
     "@app/components/agent_builder/observability/charts/UsageMetricsChart"
   ).then((mod) => ({

--- a/front/components/pages/workspace/developers/CreditsUsagePage.tsx
+++ b/front/components/pages/workspace/developers/CreditsUsagePage.tsx
@@ -6,8 +6,9 @@ import {
   ExclamationCircleIcon,
   Hoverable,
   Page,
+  safeLazy,
 } from "@dust-tt/sparkle";
-import { lazy, Suspense, useMemo, useState } from "react";
+import { Suspense, useMemo, useState } from "react";
 
 import { BuyCreditDialog } from "@app/components/workspace/BuyCreditDialog";
 import { CreditHistorySheet } from "@app/components/workspace/CreditHistorySheet";
@@ -21,7 +22,7 @@ import { useCreditPurchaseInfo, useCredits } from "@app/lib/swr/credits";
 import type { SubscriptionType } from "@app/types";
 import type { CreditDisplayData, CreditType } from "@app/types/credits";
 
-const ProgrammaticCostChart = lazy(() =>
+const ProgrammaticCostChart = safeLazy(() =>
   import("@app/components/workspace/ProgrammaticCostChart").then((mod) => ({
     default: mod.ProgrammaticCostChart,
   }))

--- a/front/components/poke/credits/table.tsx
+++ b/front/components/poke/credits/table.tsx
@@ -1,11 +1,11 @@
-import { Tooltip } from "@dust-tt/sparkle";
-import { lazy, Suspense } from "react";
+import { safeLazy, Tooltip } from "@dust-tt/sparkle";
+import { Suspense } from "react";
 import type Stripe from "stripe";
 
 import { makeColumnsForCredits } from "@app/components/poke/credits/columns";
 import { PokeDataTableConditionalFetch } from "@app/components/poke/PokeConditionalDataTables";
 
-const PokeProgrammaticCostChart = lazy(() =>
+const PokeProgrammaticCostChart = safeLazy(() =>
   import("@app/components/poke/credits/PokeProgrammaticCostChart").then(
     (mod) => ({
       default: mod.PokeProgrammaticCostChart,

--- a/sparkle/src/components/markdown/CodeBlock.tsx
+++ b/sparkle/src/components/markdown/CodeBlock.tsx
@@ -1,9 +1,10 @@
 import { customColors } from "@sparkle/lib/colors";
+import { safeLazy } from "@sparkle/lib/safeLazy";
 import { cva } from "class-variance-authority";
 import React, { Suspense } from "react";
 import { violet } from "tailwindcss/colors";
 
-const SyntaxHighlighter = React.lazy(
+const SyntaxHighlighter = safeLazy(
   () => import("react-syntax-highlighter/dist/esm/default-highlight")
 );
 

--- a/sparkle/src/lib/index.ts
+++ b/sparkle/src/lib/index.ts
@@ -1,2 +1,3 @@
 export * as avatarUtils from "./avatar/utils";
+export * from "./safeLazy";
 export * from "./utils";

--- a/sparkle/src/lib/safeLazy.ts
+++ b/sparkle/src/lib/safeLazy.ts
@@ -1,0 +1,25 @@
+import { type ComponentType, lazy } from "react";
+
+/**
+ * Wrapper around React.lazy that handles chunk load failures
+ * (e.g. after a deploy replaces old assets) by reloading the page.
+ *
+ * Only reloads in the SPA (Vite) context where old chunks are gone after deploy.
+ * In Next.js, chunk failures are re-thrown so Next.js can handle them natively.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function safeLazy<T extends ComponentType<any>>(
+  factory: () => Promise<{ default: T }>
+) {
+  return lazy(() =>
+    factory().catch((error) => {
+      // In Next.js (detected via __NEXT_DATA__), let the framework handle errors.
+      if (typeof window !== "undefined" && "__NEXT_DATA__" in window) {
+        throw error;
+      }
+      // In SPA (Vite), reload to fetch fresh assets.
+      window.location.reload();
+      return new Promise<never>(() => {});
+    })
+  );
+}


### PR DESCRIPTION
## Description

Introduces a `safeLazy` utility in Sparkle that wraps `React.lazy` to handle chunk load failures (e.g. after a deploy replaces old hashed assets). In the SPA (Vite) context, it automatically reloads the page to fetch fresh assets. In Next.js, it re-throws so the framework handles errors natively.

All existing `React.lazy` calls across `front`, `front-spa`, and `sparkle` are replaced with `safeLazy`, and the ad-hoc reload logic previously in `front-spa/App.tsx` is removed in favor of the shared utility.

## Tests

Manual — verified lazy-loaded components still load correctly in both SPA and Next.js contexts.

## Risk

Low. `safeLazy` is a thin wrapper around `React.lazy` that only changes behavior on chunk load failure (a scenario that currently results in a broken page anyway). Next.js behavior is unchanged since errors are re-thrown.

## Deploy Plan

No special deploy steps. Standard deploy — Sparkle is bundled into both front and front-spa.