### PR TITLE
[front] Move Slack/Teams meta prompt to user message

### DIFF
--- a/front/lib/api/assistant/conversation_rendering/helpers.ts
+++ b/front/lib/api/assistant/conversation_rendering/helpers.ts
@@ -318,6 +318,10 @@ export function renderUserMessage(
       additionalInstructions +=
         "This message originated from Slack: make sure to retrieve the context from the attached thread content.";
     }
+    if (["slack", "teams"].includes(m.context.origin)) {
+      additionalInstructions +=
+        "If you need to ping or mention a user, tag them using @username.";
+    }
   }
 
   const systemContext = [];

--- a/front/lib/api/assistant/generation.test.ts
+++ b/front/lib/api/assistant/generation.test.ts
@@ -1,7 +1,6 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
 import {
-  constructGuidelinesSection,
   constructProjectContextSection,
   constructPromptMultiActions,
 } from "@app/lib/api/assistant/generation";
@@ -18,66 +17,6 @@ import type {
   UserMessageType,
   WorkspaceType,
 } from "@app/types";
-
-describe("constructGuidelinesSection", () => {
-  describe("MENTIONING USERS section with Slack/Teams origin handling", () => {
-    const baseAgentConfiguration: Pick<
-      AgentConfigurationType,
-      "actions" | "name"
-    > = {
-      actions: [],
-      name: "test-agent",
-    };
-
-    it("shouldn't include mention tools for web origin", () => {
-      const userMessage = {
-        context: {
-          origin: "web" as const,
-          timezone: "UTC",
-        },
-      } as UserMessageType;
-
-      const result = constructGuidelinesSection({
-        agentConfiguration: baseAgentConfiguration as AgentConfigurationType,
-        userMessage,
-      });
-
-      expect(result).toEqual(`# GUIDELINES
-
-## MATH FORMULAS
-When generating LaTeX/Math formulas exclusively rely on the $$ escape sequence. Single dollar $ escape sequences are not supported and parentheses are not sufficient to denote mathematical formulas:
-BAD: \\( \\Delta \\)
-GOOD: $$ \\Delta $$.
-
-## RENDERING MARKDOWN CODE BLOCKS
-When rendering code blocks, always use quadruple backticks (\`\`\`\`). To render nested code blocks, always use triple backticks (\`\`\`) for the inner code blocks.
-## RENDERING MARKDOWN IMAGES
-When rendering markdown images, always use the file id of the image, which can be extracted from the corresponding \`<attachment id="{FILE_ID}" type... title...>\` tag in the conversation history. Also, always use the file title which can similarly be extracted from the same \`<attachment id... type... title="{TITLE}">\` tag in the conversation history.
-Every image markdown should follow this pattern ![{TITLE}]({FILE_ID}).
-`);
-    });
-
-    it("should use simple @username for Slack origin", () => {
-      for (const origin of ["slack", "teams"] as const) {
-        const userMessage = {
-          context: {
-            origin: origin,
-            timezone: "UTC",
-          },
-        } as UserMessageType;
-
-        const result = constructGuidelinesSection({
-          agentConfiguration: baseAgentConfiguration as AgentConfigurationType,
-          userMessage,
-        });
-
-        expect(result).toContain(
-          `Use a simple @username to mention users in your messages in this conversation.`
-        );
-      }
-    });
-  });
-});
 
 describe("constructProjectContextSection", () => {
   it("should return null when conversation is undefined", () => {

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -281,10 +281,8 @@ function constructPastedContentSection(): string {
 
 export function constructGuidelinesSection({
   agentConfiguration,
-  userMessage,
 }: {
   agentConfiguration: AgentConfigurationType;
-  userMessage: UserMessageType;
 }): string {
   let guidelinesSection = "# GUIDELINES\n";
 
@@ -324,17 +322,6 @@ export function constructGuidelinesSection({
     'Also, always use the file title which can similarly be extracted from the same `<attachment id... type... title="{TITLE}">` tag in the conversation history.' +
     "\nEvery image markdown should follow this pattern ![{TITLE}]({FILE_ID}).\n";
 
-  const isSlackOrTeams =
-    userMessage.context.origin === "slack" ||
-    userMessage.context.origin === "teams";
-
-  if (isSlackOrTeams) {
-    guidelinesSection +=
-      `\n## MENTIONING USERS\n` +
-      "You have the ability to mention users in a message using the markdown directive." +
-      '\nUsers can also refer to mention as "ping".' +
-      "\nUse a simple @username to mention users in your messages in this conversation.";
-  }
   return guidelinesSection;
 }
 
@@ -443,7 +430,6 @@ export function constructPromptMultiActions(
     constructPastedContentSection(),
     constructGuidelinesSection({
       agentConfiguration,
-      userMessage,
     }),
     constructInstructionsSection({
       agentConfiguration,


### PR DESCRIPTION
## Description

- This PR moves the meta prompt part relative to Slack/Teams to user messages that actually come from Slack/Teams (allows continuing the conversation on the webapp).
- Goal is to make `constructPromptMultiActions` as context-free and static as possible.

## Tests

- Tested locally. Still triggers correct mentions in slack context.

## Risk

- Low.

## Deploy Plan

- Deploy front.
