### PR TITLE
Fix: streaming of subagent in public api with backward compatible layer.

### DIFF
--- a/front/lib/api/actions/servers/interactive_content/helpers.ts
+++ b/front/lib/api/actions/servers/interactive_content/helpers.ts
@@ -1,6 +1,4 @@
-// eslint-disable-next-line dust/enforce-client-types-in-public-api
-import type { MCPProgressNotificationType } from "@dust-tt/client";
-
+import type { MCPProgressNotificationType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import type { FileResource } from "@app/lib/resources/file_resource";
 
 /**

--- a/front/lib/api/actions/servers/interactive_content/tools/index.ts
+++ b/front/lib/api/actions/servers/interactive_content/tools/index.ts
@@ -1,9 +1,8 @@
 // eslint-disable-next-line dust/enforce-client-types-in-public-api
-import type { MCPProgressNotificationType } from "@dust-tt/client";
-// eslint-disable-next-line dust/enforce-client-types-in-public-api
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 
 import { MCPError } from "@app/lib/actions/mcp_errors";
+import type { MCPProgressNotificationType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import type {
   ToolDefinition,
   ToolHandlers,

--- a/front/lib/api/actions/servers/slideshow/tools/index.ts
+++ b/front/lib/api/actions/servers/slideshow/tools/index.ts
@@ -1,9 +1,8 @@
 // eslint-disable-next-line dust/enforce-client-types-in-public-api
-import type { MCPProgressNotificationType } from "@dust-tt/client";
-// eslint-disable-next-line dust/enforce-client-types-in-public-api
 import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 
 import { MCPError } from "@app/lib/actions/mcp_errors";
+import type { MCPProgressNotificationType } from "@app/lib/actions/mcp_internal_actions/output_schemas";
 import type {
   ToolDefinition,
   ToolHandlers,

--- a/sdks/js/src/output_schemas.ts
+++ b/sdks/js/src/output_schemas.ts
@@ -535,6 +535,13 @@ export const ProgressNotificationContentSchema = z.object({
   progress: z.number(),
   total: z.number(),
   progressToken: z.union([z.string(), z.number()]),
+  // This one is deprecated, use _meta.data instead
+  data: z
+    .object({
+      label: z.string(),
+      output: ProgressNotificationOutputSchema,
+    })
+    .optional(),
   // Custom data.
   _meta: z.object({
     data: z.object({

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -1262,6 +1262,13 @@ const NotificationContentSchema = z.union([
 const ToolNotificationProgressSchema = z.object({
   progress: z.number(),
   total: z.number(),
+  // This one is deprecated, use _meta.data instead
+  data: z
+    .object({
+      label: z.string(),
+      output: NotificationContentSchema.optional(),
+    })
+    .optional(),
   _meta: z.object({
     data: z.object({
       label: z.string(),


### PR DESCRIPTION
## Description

My [last PR](https://github.com/dust-tt/dust/pull/21385) broke streaming of sub agent as I moved the content to `_meta`.
Fixed by adding them back where they are expected until we release a new extension.

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy front