### PR TITLE
Add agent attribution to google drive comment tools

### DIFF
--- a/front/lib/api/actions/servers/google_drive/tools/index.ts
+++ b/front/lib/api/actions/servers/google_drive/tools/index.ts
@@ -101,6 +101,18 @@ function handlePermissionError(err: unknown): ToolHandlerResult {
   return new Err(new MCPError(error.message || "Operation failed"));
 }
 
+/**
+ * Adds agent attribution to content (comments, replies, etc.).
+ * Returns the original content with attribution appended if agent context is available.
+ */
+function addAgentAttribution(content: string, extra: ToolHandlerExtra): string {
+  if (extra.agentLoopContext?.runContext?.agentConfiguration) {
+    const agentConfig = extra.agentLoopContext.runContext.agentConfiguration;
+    return `${content}\n\nSent via ${agentConfig.name} Agent on Dust`;
+  }
+  return content;
+}
+
 const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
   list_drives: async ({ pageToken }, { authInfo }) => {
     const drive = await getDriveClient(authInfo);
@@ -577,11 +589,13 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
       return new Err(new MCPError("Failed to authenticate with Google Drive"));
     }
 
+    const finalContent = addAgentAttribution(content, extra);
+
     try {
       const res = await drive.comments.create({
         fileId,
         fields: "id,content,createdTime,author",
-        requestBody: { content },
+        requestBody: { content: finalContent },
       });
       return new Ok([
         {
@@ -614,12 +628,14 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
       return new Err(new MCPError("Failed to authenticate with Google Drive"));
     }
 
+    const finalContent = addAgentAttribution(content, extra);
+
     try {
       const res = await drive.replies.create({
         fileId,
         commentId,
         requestBody: {
-          content,
+          content: finalContent,
         },
         fields: "id,content,author,createdTime",
       });


### PR DESCRIPTION
## Description
Pauline requested we follow the slack pattern and add agent attribution to gdrive comments
Closes https://github.com/dust-tt/tasks/issues/6429
<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests
tested manually:
<img width="298" height="198" alt="Screenshot 2026-02-10 at 12 31 48 PM" src="https://github.com/user-attachments/assets/a4c4738f-4658-4d62-b377-a688876369dd" />

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk
low
<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [ ] deploy front

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
