### PR TITLE
DustHiveCat: cli to better manage install/update + fix autofocus & kill issues

### DIFF
--- a/x/daph/dust-hive-cat/README.md
+++ b/x/daph/dust-hive-cat/README.md
@@ -19,74 +19,39 @@ A macOS app that displays a roaming cat on your screen. When Claude Code needs y
 - Status bar icon animates when notification is active
 - Lightweight (~15-20MB memory)
 
-## Quick Install (for coworkers)
-
-Download `DustHiveCat.app` from releases, move to Applications, double-click.
-
-## Build from Source
-
-### 1. Build the App
+## Install
 
 ```bash
 cd x/daph/dust-hive-cat
-./Scripts/bundle-app.sh
+./Scripts/cli.sh install
 ```
 
-The app will be at `.build/DustHiveCat.app`
+This builds the app, installs it to `/Applications/`, sets up the notify script, and adds the `dustcat` CLI to your PATH.
 
-### 2. Install & Run
-
-```bash
-# Copy to Applications (optional)
-cp -r .build/DustHiveCat.app /Applications/
-
-# Run it
-open .build/DustHiveCat.app
-```
-
-### 3. Configure Claude Code Hook
-
-1. Copy the notify script:
-
-```bash
-cp Scripts/dustcat-notify.sh ~/.claude/
-```
-
-2. Add to `~/.claude/settings.json`:
+Then add the following hooks to `~/.claude/settings.json`:
 
 ```json
 {
   "hooks": {
-    "Stop": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "~/.claude/dustcat-notify.sh"
-          }
-        ]
-      }
-    ],
-    "Notification": [
-      {
-        "matcher": "permission_prompt",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "~/.claude/dustcat-notify.sh"
-          }
-        ]
-      }
-    ]
+    "Stop": [{"hooks": [{"type": "command", "command": "~/.claude/dustcat-notify.sh"}]}],
+    "Notification": [{"matcher": "permission_prompt", "hooks": [{"type": "command", "command": "~/.claude/dustcat-notify.sh"}]}]
   }
 }
 ```
 
-The cat bounces when:
-- Claude finishes a response (Stop hook)
-- Claude needs your permission (Notification hook)
+The cat bounces when Claude finishes a response or needs your permission. Click it to switch to the exact tmux pane.
 
-Clicking it switches to the exact tmux pane.
+## CLI
+
+After install, the `dustcat` command is available:
+
+```
+dustcat install     # First-time setup
+dustcat update      # Rebuild from source, replace app, restart
+dustcat start       # Launch the app
+dustcat stop        # Quit the app
+dustcat uninstall   # Remove everything
+```
 
 ## URL Scheme
 
@@ -100,6 +65,12 @@ Note: The target uses URL encoding (`:` → `%3A`, `.` → `%2E`).
 ## Project Structure
 
 ```
+Scripts/
+├── cli.sh                 # dustcat CLI (install/update/start/stop/uninstall)
+├── bundle-app.sh          # Build .app bundle from Swift source
+├── dustcat-notify.sh      # Notify script installed to ~/.claude/
+└── codex-notify.sh        # Notify script for OpenAI Codex
+
 DustHiveCat/
 ├── App/
 │   ├── DustHiveCatApp.swift       # App entry point

--- a/x/daph/dust-hive-cat/Scripts/cli.sh
+++ b/x/daph/dust-hive-cat/Scripts/cli.sh
@@ -1,0 +1,206 @@
+#!/bin/bash
+# dustcat CLI — manage DustHiveCat
+# Usage: dustcat <command>
+
+set -e
+
+# Resolve project directory (works whether called via symlink or directly)
+SOURCE="${BASH_SOURCE[0]}"
+while [ -L "$SOURCE" ]; do
+    DIR="$(cd "$(dirname "$SOURCE")" && pwd)"
+    SOURCE="$(readlink "$SOURCE")"
+    [[ "$SOURCE" != /* ]] && SOURCE="$DIR/$SOURCE"
+done
+SCRIPT_DIR="$(cd "$(dirname "$SOURCE")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+APP_NAME="DustHiveCat"
+APP_BUNDLE="$PROJECT_DIR/.build/$APP_NAME.app"
+INSTALL_DIR="/Applications"
+NOTIFY_DEST="$HOME/.claude/dustcat-notify.sh"
+SETTINGS_FILE="$HOME/.claude/settings.json"
+
+# ─── Helpers ───
+
+build() {
+    echo "  Building $APP_NAME..."
+    "$SCRIPT_DIR/bundle-app.sh" > /dev/null 2>&1
+}
+
+quit_app() {
+    if pgrep -x "$APP_NAME" > /dev/null 2>&1; then
+        echo "  Stopping running instance..."
+        pkill -x "$APP_NAME" 2>/dev/null || true
+        sleep 1
+    fi
+}
+
+install_app() {
+    echo "  Installing app to $INSTALL_DIR/"
+    rm -rf "$INSTALL_DIR/$APP_NAME.app"
+    cp -r "$APP_BUNDLE" "$INSTALL_DIR/"
+}
+
+install_notify_script() {
+    echo "  Installing notify script to $NOTIFY_DEST"
+    mkdir -p "$(dirname "$NOTIFY_DEST")"
+    cp "$SCRIPT_DIR/dustcat-notify.sh" "$NOTIFY_DEST"
+    chmod +x "$NOTIFY_DEST"
+}
+
+print_hook_config() {
+    if grep -q "dustcat-notify" "$SETTINGS_FILE" 2>/dev/null; then
+        echo "  Claude Code hooks already configured."
+    else
+        echo ""
+        echo "  Add the following hooks to $SETTINGS_FILE:"
+        echo ""
+        echo '    "hooks": {'
+        echo '      "Stop": [{"hooks": [{"type": "command", "command": "~/.claude/dustcat-notify.sh"}]}],'
+        echo '      "Notification": [{"matcher": "permission_prompt", "hooks": [{"type": "command", "command": "~/.claude/dustcat-notify.sh"}]}]'
+        echo '    }'
+    fi
+}
+
+install_cli() {
+    local dest="$HOME/.local/bin/dustcat"
+    mkdir -p "$HOME/.local/bin"
+    ln -sf "$SCRIPT_DIR/cli.sh" "$dest"
+    echo "  Symlinked CLI to $dest"
+
+    if ! echo "$PATH" | tr ':' '\n' | grep -qx "$HOME/.local/bin"; then
+        echo ""
+        echo "  Add to your shell profile:"
+        echo '    export PATH="$HOME/.local/bin:$PATH"'
+    fi
+}
+
+launch_app() {
+    echo "  Launching $APP_NAME..."
+    open "$INSTALL_DIR/$APP_NAME.app"
+}
+
+is_installed() {
+    [ -d "$INSTALL_DIR/$APP_NAME.app" ]
+}
+
+# ─── Commands ───
+
+cmd_install() {
+    echo "Installing DustHiveCat..."
+    echo ""
+    if ! is_installed; then
+        build
+        install_app
+    else
+        echo "  App already installed, skipping build."
+    fi
+    if [ ! -f "$NOTIFY_DEST" ]; then
+        install_notify_script
+    else
+        echo "  Notify script already installed, skipping."
+    fi
+    if [ ! -L "$HOME/.local/bin/dustcat" ]; then
+        install_cli
+    else
+        echo "  CLI already linked, skipping."
+    fi
+    print_hook_config
+    if ! pgrep -x "$APP_NAME" > /dev/null 2>&1; then
+        echo ""
+        launch_app
+    fi
+    echo ""
+    echo "Done! Run 'dustcat update' anytime to get the latest version."
+}
+
+cmd_update() {
+    if ! is_installed; then
+        echo "DustHiveCat is not installed. Run 'dustcat install' first."
+        exit 1
+    fi
+
+    echo "Updating DustHiveCat..."
+    echo ""
+    build
+    quit_app
+    install_app
+    install_notify_script
+    echo ""
+    launch_app
+    echo ""
+    echo "Done!"
+}
+
+cmd_start() {
+    if ! is_installed; then
+        echo "DustHiveCat is not installed. Run 'dustcat install' first."
+        exit 1
+    fi
+    if pgrep -x "$APP_NAME" > /dev/null 2>&1; then
+        echo "DustHiveCat is already running."
+        exit 0
+    fi
+    launch_app
+    echo "Done!"
+}
+
+cmd_stop() {
+    if ! pgrep -x "$APP_NAME" > /dev/null 2>&1; then
+        echo "DustHiveCat is not running."
+        exit 0
+    fi
+    quit_app
+    echo "Done!"
+}
+
+cmd_uninstall() {
+    echo "Uninstalling DustHiveCat..."
+    echo ""
+    quit_app
+    if [ -d "$INSTALL_DIR/$APP_NAME.app" ]; then
+        echo "  Removing $INSTALL_DIR/$APP_NAME.app"
+        rm -rf "$INSTALL_DIR/$APP_NAME.app"
+    fi
+    if [ -f "$NOTIFY_DEST" ]; then
+        echo "  Removing $NOTIFY_DEST"
+        rm -f "$NOTIFY_DEST"
+    fi
+    if [ -L "$HOME/.local/bin/dustcat" ]; then
+        echo "  Removing ~/.local/bin/dustcat"
+        rm -f "$HOME/.local/bin/dustcat"
+    fi
+    echo ""
+    echo "Done! You may also want to remove the dustcat hooks from $SETTINGS_FILE."
+}
+
+cmd_help() {
+    echo "dustcat — manage DustHiveCat"
+    echo ""
+    echo "Usage: dustcat <command>"
+    echo ""
+    echo "Commands:"
+    echo "  install     First-time setup: build, install app + notify script, add CLI to PATH"
+    echo "  update      Rebuild from source, replace app, restart"
+    echo "  start       Launch DustHiveCat"
+    echo "  stop        Quit DustHiveCat"
+    echo "  uninstall   Remove app, notify script, and CLI"
+    echo "  help        Show this help"
+}
+
+# ─── Main ───
+
+case "${1:-help}" in
+    install)   cmd_install ;;
+    update)    cmd_update ;;
+    start)     cmd_start ;;
+    stop)      cmd_stop ;;
+    uninstall) cmd_uninstall ;;
+    help)      cmd_help ;;
+    *)
+        echo "Unknown command: $1"
+        echo ""
+        cmd_help
+        exit 1
+        ;;
+esac

--- a/x/daph/dust-hive-cat/Scripts/codex-notify.sh
+++ b/x/daph/dust-hive-cat/Scripts/codex-notify.sh
@@ -40,4 +40,7 @@ else
 fi
 
 TARGET_ENCODED=$(echo "$TARGET" | sed 's/:/%3A/g; s/\./%2E/g')
-open "dustcat://notify?target=${TARGET_ENCODED}&title=Codex+ready"
+# Only notify if DustHiveCat is already running (don't relaunch after quit)
+if pgrep -x DustHiveCat > /dev/null 2>&1; then
+    open -g "dustcat://notify?target=${TARGET_ENCODED}&title=Codex+ready"
+fi

--- a/x/daph/dust-hive-cat/Scripts/dustcat-notify.sh
+++ b/x/daph/dust-hive-cat/Scripts/dustcat-notify.sh
@@ -1,8 +1,56 @@
 #!/bin/bash
-if [ -n "$TMUX" ]; then
-  TARGET=$(tmux display-message -p '#S:#I.#P')
+# DustHiveCat notify script for Claude Code hooks.
+# Finds the tmux pane by walking up the process tree, checks if the user
+# is already focused, and skips the notification if so.
+
+# Find tmux pane by walking up process tree and matching pane PID
+find_tmux_pane() {
+    local pid=$$
+
+    # Get all tmux pane PIDs into an associative array (pane_pid -> pane_id)
+    declare -A pane_map
+    while read -r pane_id pane_pid; do
+        pane_map["$pane_pid"]="$pane_id"
+    done < <(tmux list-panes -a -F '#{session_name}:#{window_index}.#{pane_index} #{pane_pid}' 2>/dev/null)
+
+    # Walk up process tree, checking if any ancestor IS a tmux pane's shell
+    while [ "$pid" != "1" ] && [ -n "$pid" ]; do
+        if [ -n "${pane_map[$pid]}" ]; then
+            echo "${pane_map[$pid]}"
+            return 0
+        fi
+        pid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
+    done
+    return 1
+}
+
+# Check if tmux server is running
+if tmux list-sessions &>/dev/null; then
+    TARGET=$(find_tmux_pane)
+    if [ -n "$TARGET" ]; then
+        # Check if this pane's window is the active one in its session
+        ACTIVE_WINDOW=$(tmux display-message -t "${TARGET}" -p '#{window_active}' 2>/dev/null)
+        ACTIVE_PANE=$(tmux display-message -t "${TARGET}" -p '#{pane_active}' 2>/dev/null)
+
+        # Check if Alacritty is the frontmost app
+        FRONTMOST=$(osascript -e 'tell application "System Events" to get name of first process whose frontmost is true' 2>/dev/null)
+        FRONTMOST_LOWER=$(echo "$FRONTMOST" | tr '[:upper:]' '[:lower:]')
+
+        # If pane is active AND Alacritty is focused, user is already looking — skip
+        if [ "$ACTIVE_WINDOW" = "1" ] && [ "$ACTIVE_PANE" = "1" ] && [ "$FRONTMOST_LOWER" = "alacritty" ]; then
+            exit 0
+        fi
+    else
+        TARGET="default"
+    fi
 else
-  TARGET='default'
+    TARGET="default"
 fi
+
+# URL encode the target (basic)
 TARGET_ENCODED=$(echo "$TARGET" | sed 's/:/%3A/g; s/\./%2E/g')
-open "dustcat://notify?target=${TARGET_ENCODED}"
+
+# Only notify if DustHiveCat is already running (don't relaunch after quit)
+if pgrep -x DustHiveCat > /dev/null 2>&1; then
+    open -g "dustcat://notify?target=${TARGET_ENCODED}&title=Claude+ready"
+fi


### PR DESCRIPTION
## Summary

- **Bug fixes:**
  - App no longer relaunches after Quit (notify scripts check if app is running first)
  - Notifications no longer steal focus (`open -g`)
  - Cat auto-dismisses when you manually switch to the target tmux pane

- **`dustcat` CLI** (`Scripts/cli.sh`, symlinked to `~/.local/bin/dustcat`):
  - `dustcat install` — first-time setup, idempotent
  - `dustcat update` — rebuild from source, replace app, restart
  - `dustcat start` / `stop` / `uninstall`

- **Notify script** (`Scripts/dustcat-notify.sh`) — upgraded from simple version that relied on `$TMUX` env var (doesn't work when called from Claude Code hooks) to one that walks up the process tree to find the right tmux pane. Also skips the notification if you're already focused on that pane.

- README updated