### PR TITLE
[front] Remove `{USER_FULL_NAME}` replacement in instructions

### DIFF
--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -341,12 +341,10 @@ export function constructGuidelinesSection({
 function constructInstructionsSection({
   agentConfiguration,
   fallbackPrompt,
-  userMessage,
   agentsList,
 }: {
   agentConfiguration: AgentConfigurationType;
   fallbackPrompt?: string;
-  userMessage: UserMessageType;
   agentsList: LightAgentConfigurationType[] | null;
 }): string {
   let instructions = "# INSTRUCTIONS\n\n";
@@ -356,13 +354,6 @@ function constructInstructionsSection({
   } else if (fallbackPrompt) {
     instructions += `${fallbackPrompt}\n`;
   }
-
-  // Replacement if instructions include "{USER_FULL_NAME}".
-  instructions = instructions.replaceAll(
-    "{USER_FULL_NAME}",
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-    userMessage.context.fullName || "Unknown user"
-  );
 
   // Replacement if instructions includes "{ASSISTANTS_LIST}"
   if (instructions.includes("{ASSISTANTS_LIST}") && agentsList) {
@@ -448,7 +439,6 @@ export function constructPromptMultiActions(
     constructInstructionsSection({
       agentConfiguration,
       fallbackPrompt,
-      userMessage,
       agentsList,
     }),
   ];


### PR DESCRIPTION
## Description

- We have a mechanism that replaces the exact string `{USER_FULL_NAME}` if found within agent instructions.
- This feature is not used anymore: no active agent using it in either region.
- This PR removes it; it's a feature that is not discoverable and that adds entropy to the system prompt generation.
- Next steps are to remove all dependency on the user message, https://github.com/dust-tt/dust/pull/21405 removes it from the guidelines section and the context section will only rely on the user context for the timezone.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
