### PR TITLE
Augment Notion API to support appending block id after specific block id

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
@@ -7,7 +7,6 @@
         "description": "Get detailed information about the current agent configuration, including name, description, instructions, model settings, and the IDs of all skills and tools currently used by the agent.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
-          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -139,7 +138,6 @@
         "description": "Get the list of available skills that can be added to agents. Returns skills accessible to the current user across all spaces they have access to.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
-          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -149,7 +147,6 @@
         "description": "Get the list of available tools (MCP servers) that can be added to agents. Returns tools accessible to the current user.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
-          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -721,7 +718,6 @@
         "description": "Retrieve all agent memories for the current user",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
-          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -743,7 +739,6 @@
         "description": "Returns a complete list of all published agents in the workspace. Each agent includes its name, description, and mention directive (e.g., `:mention[agent-name]{sId=xyz}`) to display a clickable link to the agent.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
-          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -807,46 +802,6 @@
         }
       },
       {
-        "name": "create_referral",
-        "description": "Create a referral for a candidate in Ashby. You must call get_referral_form first to know the available fields. The credited user is resolved automatically from the authenticated user. Field values must be provided as {title, value} pairs where title is the human-readable field title exactly as returned by get_referral_form.",
-        "inputSchema": {
-          "$schema": "http://json-schema.org/draft-07/schema#",
-          "additionalProperties": false,
-          "properties": {
-            "fieldSubmissions": {
-              "description": "Array of field values keyed by their human-readable title.",
-              "items": {
-                "additionalProperties": false,
-                "properties": {
-                  "title": {
-                    "description": "The human-readable field title (e.g. 'Candidate Name').",
-                    "type": "string"
-                  },
-                  "value": {
-                    "description": "The value for this field.",
-                    "type": [
-                      "string",
-                      "number",
-                      "boolean"
-                    ]
-                  }
-                },
-                "required": [
-                  "title",
-                  "value"
-                ],
-                "type": "object"
-              },
-              "type": "array"
-            }
-          },
-          "required": [
-            "fieldSubmissions"
-          ],
-          "type": "object"
-        }
-      },
-      {
         "name": "get_candidate_notes",
         "description": "Retrieve all notes for a candidate. This tool will search for the candidate by name or email and return all notes on their profile.",
         "inputSchema": {
@@ -881,16 +836,6 @@
               "type": "string"
             }
           },
-          "type": "object"
-        }
-      },
-      {
-        "name": "get_referral_form",
-        "description": "Retrieve the referral form definition from Ashby. Returns all form fields with their titles, types, and whether they are required. You must call this tool before creating a referral to know the available fields.",
-        "inputSchema": {
-          "$schema": "http://json-schema.org/draft-07/schema#",
-          "additionalProperties": false,
-          "properties": {},
           "type": "object"
         }
       },
@@ -934,10 +879,8 @@
     ],
     "toolsStakes": {
       "create_candidate_note": "high",
-      "create_referral": "high",
       "get_candidate_notes": "never_ask",
       "get_interview_feedback": "never_ask",
-      "get_referral_form": "never_ask",
       "get_report_data": "never_ask",
       "search_candidates": "never_ask"
     }
@@ -950,7 +893,6 @@
         "description": "Generate a random floating point number between 0 (inclusive) and 1 (exclusive).",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
-          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -1110,7 +1052,6 @@
         "description": "Get information about the currently authenticated Confluence user including account ID, display name, and email.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
-          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -1169,7 +1110,6 @@
         "description": "Get a list of Confluence spaces. Returns a list of spaces with their IDs, keys, names, types, and statuses.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
-          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -1304,7 +1244,6 @@
         "description": "List all files attached to the conversation.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
-          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -1815,7 +1754,6 @@
         "description": "List all SQL warehouses available in the Databricks workspace.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
-          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -2471,7 +2409,6 @@
         "description": "Lists available Freshservice ticket field ids for use in the get_ticket.fields parameter (read-time).",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
-          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -2703,7 +2640,6 @@
         "description": "Lists SLA policies",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
-          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -3437,7 +3373,6 @@
         "description": "Get all inboxes/channels available in the workspace.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
-          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -3447,7 +3382,6 @@
         "description": "Get all available tags for categorizing conversations.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
-          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -3457,7 +3391,6 @@
         "description": "Get all teammates in the workspace for assignment and collaboration.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
-          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -6210,7 +6143,6 @@
         "description": "Gets the current authenticated user's HubSpot owner ID and profile information. Essential first step for getting your own activity data. Returns user_id (needed for get_user_activity), user details, and hub_id. Use this before calling get_user_activity with your own data.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
-          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -6313,7 +6245,6 @@
         "description": "Gets the current user's portal ID. To use before calling get_hubspot_link",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
-          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -6490,7 +6421,6 @@
         "description": "Lists all owners (users) in the HubSpot account with their IDs, names, and email addresses. Use this to find owner IDs for get_user_activity calls when you want to get activity for other users. For your own activity, use get_current_user_id instead.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
-          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -8191,7 +8121,6 @@
         "description": "Gets comprehensive connection information including user details, cloud ID, and site URL for the currently authenticated JIRA instance. This tool is used when the user is referring about themselves",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
-          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -8249,7 +8178,6 @@
         "description": "Retrieves all available issue link types that can be used when creating issue links.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
-          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -8259,7 +8187,6 @@
         "description": "Lists available Jira field keys/ids and names for use in the get_issue.fields parameter (read-time).",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
-          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -8509,7 +8436,6 @@
         "description": "Retrieves a list of JIRA projects.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
-          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -10022,7 +9948,6 @@
         "description": "List all Teams that the authenticated user has joined. Returns team details including name, description, and team ID.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
-          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -10134,7 +10059,6 @@
         "description": "This tool is a placeholder to catch missing actions.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
-          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -10546,7 +10470,6 @@
         "description": "Lists all accessible boards in Monday.com workspace. Returns up to 100 boards.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
-          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -11764,7 +11687,6 @@
         "description": "List all users in the Notion workspace.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
-          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -12859,7 +12781,6 @@
         "description": "Get the user's configured timezone from their Outlook mailbox settings. This should be called before creating, updating, or searching for events to ensure proper timezone handling.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
-          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -14717,7 +14638,6 @@
         "description": "List all schedules created for this agent.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
-          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -14868,7 +14788,6 @@
         "description": "Retrieve all topics for navigation and organization understanding.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
-          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -15545,7 +15464,6 @@
         "description": "List all databases accessible to the authenticated Snowflake user.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
-          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -15987,7 +15905,6 @@
         "description": "List all status pages accessible with the configured API key. Use this to discover available page IDs before using other tools.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
-          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -16083,7 +16000,6 @@
         "description": "List the available toolsets with their names and descriptions. This is like using 'ls' in Unix.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
-          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -16212,7 +16128,6 @@
         "description": "Get a list of active employees.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
-          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -16222,7 +16137,6 @@
         "description": "Get your own employee information from UKG Ready, including your employee ID, name, and username.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
-          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }

--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
@@ -7,6 +7,7 @@
         "description": "Get detailed information about the current agent configuration, including name, description, instructions, model settings, and the IDs of all skills and tools currently used by the agent.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
+          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -138,6 +139,7 @@
         "description": "Get the list of available skills that can be added to agents. Returns skills accessible to the current user across all spaces they have access to.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
+          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -147,6 +149,7 @@
         "description": "Get the list of available tools (MCP servers) that can be added to agents. Returns tools accessible to the current user.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
+          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -718,6 +721,7 @@
         "description": "Retrieve all agent memories for the current user",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
+          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -739,6 +743,7 @@
         "description": "Returns a complete list of all published agents in the workspace. Each agent includes its name, description, and mention directive (e.g., `:mention[agent-name]{sId=xyz}`) to display a clickable link to the agent.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
+          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -802,6 +807,46 @@
         }
       },
       {
+        "name": "create_referral",
+        "description": "Create a referral for a candidate in Ashby. You must call get_referral_form first to know the available fields. The credited user is resolved automatically from the authenticated user. Field values must be provided as {title, value} pairs where title is the human-readable field title exactly as returned by get_referral_form.",
+        "inputSchema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "additionalProperties": false,
+          "properties": {
+            "fieldSubmissions": {
+              "description": "Array of field values keyed by their human-readable title.",
+              "items": {
+                "additionalProperties": false,
+                "properties": {
+                  "title": {
+                    "description": "The human-readable field title (e.g. 'Candidate Name').",
+                    "type": "string"
+                  },
+                  "value": {
+                    "description": "The value for this field.",
+                    "type": [
+                      "string",
+                      "number",
+                      "boolean"
+                    ]
+                  }
+                },
+                "required": [
+                  "title",
+                  "value"
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "fieldSubmissions"
+          ],
+          "type": "object"
+        }
+      },
+      {
         "name": "get_candidate_notes",
         "description": "Retrieve all notes for a candidate. This tool will search for the candidate by name or email and return all notes on their profile.",
         "inputSchema": {
@@ -836,6 +881,16 @@
               "type": "string"
             }
           },
+          "type": "object"
+        }
+      },
+      {
+        "name": "get_referral_form",
+        "description": "Retrieve the referral form definition from Ashby. Returns all form fields with their titles, types, and whether they are required. You must call this tool before creating a referral to know the available fields.",
+        "inputSchema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "additionalProperties": false,
+          "properties": {},
           "type": "object"
         }
       },
@@ -879,8 +934,10 @@
     ],
     "toolsStakes": {
       "create_candidate_note": "high",
+      "create_referral": "high",
       "get_candidate_notes": "never_ask",
       "get_interview_feedback": "never_ask",
+      "get_referral_form": "never_ask",
       "get_report_data": "never_ask",
       "search_candidates": "never_ask"
     }
@@ -893,6 +950,7 @@
         "description": "Generate a random floating point number between 0 (inclusive) and 1 (exclusive).",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
+          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -1052,6 +1110,7 @@
         "description": "Get information about the currently authenticated Confluence user including account ID, display name, and email.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
+          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -1110,6 +1169,7 @@
         "description": "Get a list of Confluence spaces. Returns a list of spaces with their IDs, keys, names, types, and statuses.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
+          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -1244,6 +1304,7 @@
         "description": "List all files attached to the conversation.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
+          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -1754,6 +1815,7 @@
         "description": "List all SQL warehouses available in the Databricks workspace.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
+          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -2409,6 +2471,7 @@
         "description": "Lists available Freshservice ticket field ids for use in the get_ticket.fields parameter (read-time).",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
+          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -2640,6 +2703,7 @@
         "description": "Lists SLA policies",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
+          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -3373,6 +3437,7 @@
         "description": "Get all inboxes/channels available in the workspace.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
+          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -3382,6 +3447,7 @@
         "description": "Get all available tags for categorizing conversations.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
+          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -3391,6 +3457,7 @@
         "description": "Get all teammates in the workspace for assignment and collaboration.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
+          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -6143,6 +6210,7 @@
         "description": "Gets the current authenticated user's HubSpot owner ID and profile information. Essential first step for getting your own activity data. Returns user_id (needed for get_user_activity), user details, and hub_id. Use this before calling get_user_activity with your own data.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
+          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -6245,6 +6313,7 @@
         "description": "Gets the current user's portal ID. To use before calling get_hubspot_link",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
+          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -6421,6 +6490,7 @@
         "description": "Lists all owners (users) in the HubSpot account with their IDs, names, and email addresses. Use this to find owner IDs for get_user_activity calls when you want to get activity for other users. For your own activity, use get_current_user_id instead.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
+          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -8121,6 +8191,7 @@
         "description": "Gets comprehensive connection information including user details, cloud ID, and site URL for the currently authenticated JIRA instance. This tool is used when the user is referring about themselves",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
+          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -8178,6 +8249,7 @@
         "description": "Retrieves all available issue link types that can be used when creating issue links.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
+          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -8187,6 +8259,7 @@
         "description": "Lists available Jira field keys/ids and names for use in the get_issue.fields parameter (read-time).",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
+          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -8436,6 +8509,7 @@
         "description": "Retrieves a list of JIRA projects.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
+          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -9948,6 +10022,7 @@
         "description": "List all Teams that the authenticated user has joined. Returns team details including name, description, and team ID.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
+          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -10059,6 +10134,7 @@
         "description": "This tool is a placeholder to catch missing actions.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
+          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -10470,6 +10546,7 @@
         "description": "Lists all accessible boards in Monday.com workspace. Returns up to 100 boards.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
+          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -10876,6 +10953,10 @@
           "$schema": "http://json-schema.org/draft-07/schema#",
           "additionalProperties": false,
           "properties": {
+            "after": {
+              "description": "The ID of the existing block to insert after.",
+              "type": "string"
+            },
             "blockId": {
               "description": "The ID of the parent block or page.",
               "type": "string"
@@ -11683,6 +11764,7 @@
         "description": "List all users in the Notion workspace.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
+          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -12777,6 +12859,7 @@
         "description": "Get the user's configured timezone from their Outlook mailbox settings. This should be called before creating, updating, or searching for events to ensure proper timezone handling.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
+          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -14634,6 +14717,7 @@
         "description": "List all schedules created for this agent.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
+          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -14784,6 +14868,7 @@
         "description": "Retrieve all topics for navigation and organization understanding.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
+          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -15460,6 +15545,7 @@
         "description": "List all databases accessible to the authenticated Snowflake user.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
+          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -15901,6 +15987,7 @@
         "description": "List all status pages accessible with the configured API key. Use this to discover available page IDs before using other tools.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
+          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -15996,6 +16083,7 @@
         "description": "List the available toolsets with their names and descriptions. This is like using 'ls' in Unix.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
+          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -16124,6 +16212,7 @@
         "description": "Get a list of active employees.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
+          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }
@@ -16133,6 +16222,7 @@
         "description": "Get your own employee information from UKG Ready, including your employee ID, name, and username.",
         "inputSchema": {
           "$schema": "http://json-schema.org/draft-07/schema#",
+          "additionalProperties": false,
           "properties": {},
           "type": "object"
         }

--- a/front/lib/api/actions/servers/notion/metadata.ts
+++ b/front/lib/api/actions/servers/notion/metadata.ts
@@ -395,6 +395,10 @@ export const NOTION_TOOLS_METADATA = createToolsRecord({
     description:
       "Add a single content block to a Notion page. For multiple blocks, call this action multiple times. Only supports adding to Notion pages. Blocks that can contain children include: page, toggle, to-do, bulleted list, numbered list, callout, and quote.",
     schema: {
+      after: z
+        .string()
+        .optional()
+        .describe("The ID of the existing block to insert after."),
       blockId: z.string().describe("The ID of the parent block or page."),
       children: z
         .array(NotionBlockSchema)

--- a/front/lib/api/actions/servers/notion/tools/index.ts
+++ b/front/lib/api/actions/servers/notion/tools/index.ts
@@ -324,10 +324,11 @@ export function createNotionTools(
       );
     },
 
-    add_page_content: async ({ blockId, children }, { authInfo }) => {
+    add_page_content: async ({ after, blockId, children }, { authInfo }) => {
       return withNotionClient(
         (notion) =>
           notion.blocks.children.append({
+            after,
             block_id: blockId,
             children,
           }),


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR augments the existing Notion MCP server so the model can actually specific an after id when appending a block. This comes to be very helpful when needing to add a new block right after an existing one.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
