### PR TITLE
Make Google Calendar `list_events` less verbose

### DIFF
--- a/front/lib/api/actions/servers/google_calendar/helpers.ts
+++ b/front/lib/api/actions/servers/google_calendar/helpers.ts
@@ -224,8 +224,12 @@ export function enrichEventWithDayOfWeek(
   return enrichedEvent;
 }
 
-export function formatEventAsText(event: EnrichedGoogleCalendarEvent): string {
+export function formatEventAsText(
+  event: EnrichedGoogleCalendarEvent,
+  include?: Set<string>
+): string {
   const lines: string[] = [];
+  const includeAll = !include;
 
   if (event.summary) {
     lines.push(`Title: ${event.summary}`);
@@ -281,11 +285,15 @@ export function formatEventAsText(event: EnrichedGoogleCalendarEvent): string {
     lines.push(`Location: ${event.location}`);
   }
 
-  if (event.description) {
+  if ((includeAll || include?.has("description")) && event.description) {
     lines.push(`Description: ${event.description}`);
   }
 
-  if (event.attendees && event.attendees.length > 0) {
+  if (
+    (includeAll || include?.has("attendees")) &&
+    event.attendees &&
+    event.attendees.length > 0
+  ) {
     const attendeeList = event.attendees
       .map((a) => {
         const name = a.displayName ?? a.email ?? "Unknown";
@@ -313,7 +321,8 @@ export function formatEventAsText(event: EnrichedGoogleCalendarEvent): string {
 
 export function formatEventsListAsText(
   events: EnrichedGoogleCalendarEvent[],
-  summary?: string
+  summary?: string,
+  include?: Set<string>
 ): string {
   if (events.length === 0) {
     return summary ? `${summary}\n\nNo events found.` : "No events found.";
@@ -329,7 +338,7 @@ export function formatEventsListAsText(
     if (index > 0) {
       lines.push("\n---\n");
     }
-    lines.push(formatEventAsText(event));
+    lines.push(formatEventAsText(event, include));
   });
 
   return lines.join("\n");

--- a/front/lib/api/actions/servers/google_calendar/metadata.ts
+++ b/front/lib/api/actions/servers/google_calendar/metadata.ts
@@ -49,6 +49,12 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = createToolsRecord({
         .optional()
         .describe("Maximum number of events to return (max 2500)."),
       pageToken: z.string().optional().describe("Page token for pagination."),
+      include: z
+        .array(z.enum(["description", "attendees"]))
+        .optional()
+        .describe(
+          "Optional fields to include in the output. Omitted by default to keep output concise. Use get_event for full details."
+        ),
     },
     stake: "never_ask",
     displayLabels: {

--- a/front/lib/api/actions/servers/google_calendar/metadata.ts
+++ b/front/lib/api/actions/servers/google_calendar/metadata.ts
@@ -78,7 +78,11 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = createToolsRecord({
     },
   },
   create_event: {
-    description: "Create a new event in a Google Calendar.",
+    description:
+      "Create a new event in a Google Calendar. By default when creating a meeting, " +
+      "(1) set the calling user as the organizer and an attendee (2) check availability for " +
+      "attendees using the check_availability tool (3) use `get_user_timezones` to check attendee " +
+      "timezones for better scheduling",
     schema: {
       calendarId: z
         .string()
@@ -260,8 +264,7 @@ export const GOOGLE_CALENDAR_SERVER = {
     },
     icon: "GcalLogo",
     documentationUrl: "https://docs.dust.tt/docs/google-calendar",
-    instructions:
-      "By default when creating a meeting, (1) set the calling user as the organizer and an attendee (2) check availability for attendees using the check_availability tool (3) use get_user_timezones to check attendee timezones for better scheduling.",
+    instructions: null,
   },
   tools: Object.values(GOOGLE_CALENDAR_TOOLS_METADATA).map((t) => ({
     name: t.name,

--- a/front/lib/api/actions/servers/google_calendar/metadata.ts
+++ b/front/lib/api/actions/servers/google_calendar/metadata.ts
@@ -7,6 +7,8 @@ import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_de
 
 export const GOOGLE_CALENDAR_TOOL_NAME = "google_calendar" as const;
 
+const GET_USER_TIMEZONE_TOOL_NAME = "get_user_timezones";
+
 export const GOOGLE_CALENDAR_TOOLS_METADATA = createToolsRecord({
   list_calendars: {
     description:
@@ -81,8 +83,8 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = createToolsRecord({
     description:
       "Create a new event in a Google Calendar. By default when creating a meeting, " +
       "(1) set the calling user as the organizer and an attendee (2) check availability for " +
-      "attendees using the check_availability tool (3) use `get_user_timezones` to check attendee " +
-      "timezones for better scheduling",
+      `attendees using the check_availability tool (3) use ${GET_USER_TIMEZONE_TOOL_NAME} to ` +
+      "check attendee timezones for better scheduling",
     schema: {
       calendarId: z
         .string()
@@ -234,7 +236,7 @@ export const GOOGLE_CALENDAR_TOOLS_METADATA = createToolsRecord({
       done: "Check Google Calendar availability",
     },
   },
-  get_user_timezones: {
+  [GET_USER_TIMEZONE_TOOL_NAME]: {
     description:
       "Get timezone information for multiple users by attempting to access their calendars. Only works for calendars shared with you.",
     schema: {

--- a/front/lib/api/actions/servers/google_calendar/tools/index.ts
+++ b/front/lib/api/actions/servers/google_calendar/tools/index.ts
@@ -48,7 +48,15 @@ const handlers: ToolHandlers<typeof GOOGLE_CALENDAR_TOOLS_METADATA> = {
   },
 
   list_events: async (
-    { calendarId = "primary", q, timeMin, timeMax, maxResults, pageToken },
+    {
+      calendarId = "primary",
+      q,
+      timeMin,
+      timeMax,
+      maxResults,
+      pageToken,
+      include,
+    },
     extra
   ) => {
     const calendar = await getCalendarClient(extra.authInfo);
@@ -78,7 +86,12 @@ const handlers: ToolHandlers<typeof GOOGLE_CALENDAR_TOOLS_METADATA> = {
 
       const eventCount = enrichedEvents.length;
       const summaryText = `Found ${eventCount} event${eventCount !== 1 ? "s" : ""}${res.data.nextPageToken ? " (more available)" : ""}`;
-      const formattedText = formatEventsListAsText(enrichedEvents, summaryText);
+      const includeSet = new Set(include ?? []);
+      const formattedText = formatEventsListAsText(
+        enrichedEvents,
+        summaryText,
+        includeSet
+      );
 
       return new Ok([{ type: "text" as const, text: formattedText }]);
     } catch (err) {


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR aims at making the `list_events` tool on Google Calendar less verbose. Today, it prevents listing many events as it quickly go outside of the context window. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
Worst case it breaks some existing workflow, but model can always include those fields. Safe to rollback.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
