### PR TITLE
Hoist layouts

### DIFF
--- a/front/components/assistant/conversation/ConversationLayout.tsx
+++ b/front/components/assistant/conversation/ConversationLayout.tsx
@@ -115,19 +115,19 @@ const ConversationLayoutContent = ({
   };
 
   return (
-    <BlockedActionsProvider owner={owner} conversation={conversation}>
-      <InputBarProvider>
-        <AppContentLayout
-          hasTitle={!!activeConversationId}
-          subscription={subscription}
-          owner={owner}
-          pageTitle={
-            conversation?.title
-              ? `Dust - ${conversation?.title}`
-              : `Dust - New Conversation`
-          }
-          navChildren={<AgentSidebarMenu owner={owner} />}
-        >
+    <InputBarProvider>
+      <AppContentLayout
+        hasTitle={!!activeConversationId}
+        subscription={subscription}
+        owner={owner}
+        pageTitle={
+          conversation?.title
+            ? `Dust - ${conversation?.title}`
+            : `Dust - New Conversation`
+        }
+        navChildren={<AgentSidebarMenu owner={owner} />}
+      >
+        <BlockedActionsProvider owner={owner} conversation={conversation}>
           <AgentDetails
             owner={owner}
             user={user}
@@ -162,9 +162,9 @@ const ConversationLayoutContent = ({
               onTourGuideEnd={onTourGuideEnd}
             />
           )}
-        </AppContentLayout>
-      </InputBarProvider>
-    </BlockedActionsProvider>
+        </BlockedActionsProvider>
+      </AppContentLayout>
+    </InputBarProvider>
   );
 };
 

--- a/front/components/pages/builder/agents/ManageAgentsPage.tsx
+++ b/front/components/pages/builder/agents/ManageAgentsPage.tsx
@@ -271,18 +271,6 @@ export function ManageAgentsPage() {
     };
   }, [isFeatureFlagsLoading, isRestrictedFromAgentCreation]);
 
-  if (isFeatureFlagsLoading) {
-    return (
-      <div className="flex h-screen items-center justify-center">
-        <Spinner size="lg" />
-      </div>
-    );
-  }
-
-  if (isRestrictedFromAgentCreation) {
-    return <Custom404 />;
-  }
-
   return (
     <AppContentLayout
       contentWidth="wide"
@@ -290,151 +278,164 @@ export function ManageAgentsPage() {
       owner={owner}
       navChildren={<AgentSidebarMenu owner={owner} />}
     >
-      <AgentDetails
-        owner={owner}
-        user={user}
-        agentId={detailedAgentId}
-        onClose={() => setDetailedAgentId(null)}
-      />
-      <div className="flex w-full flex-col gap-8 pb-4 pt-2 lg:pt-8">
-        <Page.Header title="Manage Agents" icon={ContactsRobotIcon} />
-        <Page.Vertical gap="md" align="stretch">
-          <div className="flex flex-row gap-2">
-            <SearchInput
-              ref={searchBarRef}
-              className="flex-grow"
-              name="search"
-              placeholder="Search (Name, Editors)"
-              value={assistantSearch}
-              onChange={(s: string) => {
-                setAssistantSearch(s);
-              }}
-            />
-            {!isBatchEdit && (
-              <div className="flex gap-2">
-                {isAdmin(owner) && (
-                  <Button
-                    variant="outline"
-                    icon={ListSelectIcon}
-                    label="Batch edit"
-                    onClick={() => {
-                      setIsBatchEdit(true);
-                    }}
-                  />
-                )}
-
-                <TagsFilterMenu
-                  tags={uniqueTags}
-                  selectedTags={selectedTags}
-                  setSelectedTags={setSelectedTags}
-                  owner={owner}
+      {isFeatureFlagsLoading ? (
+        <div className="flex h-full items-center justify-center">
+          <Spinner size="lg" />
+        </div>
+      ) : isRestrictedFromAgentCreation ? (
+        <Custom404 />
+      ) : (
+        <>
+          <AgentDetails
+            owner={owner}
+            user={user}
+            agentId={detailedAgentId}
+            onClose={() => setDetailedAgentId(null)}
+          />
+          <div className="flex w-full flex-col gap-8 pb-4 pt-2 lg:pt-8">
+            <Page.Header title="Manage Agents" icon={ContactsRobotIcon} />
+            <Page.Vertical gap="md" align="stretch">
+              <div className="flex flex-row gap-2">
+                <SearchInput
+                  ref={searchBarRef}
+                  className="flex-grow"
+                  name="search"
+                  placeholder="Search (Name, Editors)"
+                  value={assistantSearch}
+                  onChange={(s: string) => {
+                    setAssistantSearch(s);
+                  }}
                 />
-                {!isRestrictedFromAgentCreation && (
-                  <CreateDropdown
-                    owner={owner}
-                    dataGtmLocation="assistantsWorkspace"
-                  />
+                {!isBatchEdit && (
+                  <div className="flex gap-2">
+                    {isAdmin(owner) && (
+                      <Button
+                        variant="outline"
+                        icon={ListSelectIcon}
+                        label="Batch edit"
+                        onClick={() => {
+                          setIsBatchEdit(true);
+                        }}
+                      />
+                    )}
+
+                    <TagsFilterMenu
+                      tags={uniqueTags}
+                      selectedTags={selectedTags}
+                      setSelectedTags={setSelectedTags}
+                      owner={owner}
+                    />
+                    {!isRestrictedFromAgentCreation && (
+                      <CreateDropdown
+                        owner={owner}
+                        dataGtmLocation="assistantsWorkspace"
+                      />
+                    )}
+                  </div>
                 )}
               </div>
-            )}
-          </div>
-          {selectedTags.length > 0 && (
-            <div className="flex flex-row gap-2">
-              {selectedTags.map((tag) => (
-                <Chip
-                  key={tag.sId}
-                  label={tag.name}
-                  size="xs"
-                  color="golden"
-                  onRemove={() =>
-                    setSelectedTags(selectedTags.filter((t) => t !== tag))
-                  }
-                />
-              ))}
-            </div>
-          )}
-          <div className="flex flex-col pt-3">
-            {isBatchEdit ? (
-              <AgentEditBar
-                onClose={() => {
-                  setIsBatchEdit(false);
-                  setSelection([]);
-                }}
-                owner={owner}
-                selectedAgents={selectedAgents}
-                tags={uniqueTags}
-                mutateAgentConfigurations={mutateAgentConfigurations}
-              />
-            ) : (
-              <Tabs value={activeTab}>
-                <TabsList>
-                  {visibleTabs.map((tab) => (
-                    <TabsTrigger
-                      key={tab.id}
-                      value={tab.id}
-                      label={tab.label}
-                      onClick={() => {
-                        if (isSearchActive) {
-                          if (
-                            tab.id === "search" ||
-                            tab.id === "search_archived"
-                          ) {
-                            setSelectedSearchTab(tab.id);
-                          }
-                        } else {
-                          setSelectedTab(tab.id);
-                        }
-                      }}
-                      tooltip={
-                        AGENT_MANAGER_TABS.find((t) => t.id === tab.id)
-                          ?.description
+              {selectedTags.length > 0 && (
+                <div className="flex flex-row gap-2">
+                  {selectedTags.map((tag) => (
+                    <Chip
+                      key={tag.sId}
+                      label={tag.name}
+                      size="xs"
+                      color="golden"
+                      onRemove={() =>
+                        setSelectedTags(selectedTags.filter((t) => t !== tag))
                       }
-                      isCounter={
-                        tab.id !== "archived" && tab.id !== "search_archived"
-                      }
-                      counterValue={`${agentsByTab[tab.id].length}`}
                     />
                   ))}
-                </TabsList>
-              </Tabs>
-            )}
-            {isAgentConfigurationsLoading ||
-            isArchivedAgentConfigurationsLoading ? (
-              <div className="mt-8 flex justify-center">
-                <Spinner size="lg" />
-              </div>
-            ) : activeTab && agentsByTab[activeTab] ? (
-              <AssistantsTable
-                isBatchEdit={isBatchEdit}
-                selection={selection}
-                setSelection={setSelection}
-                owner={owner}
-                agents={agentsByTab[activeTab]}
-                setDetailedAgentId={setDetailedAgentId}
-                handleToggleAgentStatus={handleToggleAgentStatus}
-                showDisabledFreeWorkspacePopup={showDisabledFreeWorkspacePopup}
-                setShowDisabledFreeWorkspacePopup={
-                  setShowDisabledFreeWorkspacePopup
-                }
-                mutateAgentConfigurations={mutateAgentConfigurations}
-              />
-            ) : (
-              !assistantSearch &&
-              !isRestrictedFromAgentCreation && (
-                <div className="pt-2">
-                  <EmptyCallToAction
-                    href={`/w/${owner.sId}/builder/agents/create`}
-                    label="Create an agent"
-                    icon={PlusIcon}
-                    data-gtm-label="assistantCreationButton"
-                    data-gtm-location="assistantsWorkspace"
-                  />
                 </div>
-              )
-            )}
+              )}
+              <div className="flex flex-col pt-3">
+                {isBatchEdit ? (
+                  <AgentEditBar
+                    onClose={() => {
+                      setIsBatchEdit(false);
+                      setSelection([]);
+                    }}
+                    owner={owner}
+                    selectedAgents={selectedAgents}
+                    tags={uniqueTags}
+                    mutateAgentConfigurations={mutateAgentConfigurations}
+                  />
+                ) : (
+                  <Tabs value={activeTab}>
+                    <TabsList>
+                      {visibleTabs.map((tab) => (
+                        <TabsTrigger
+                          key={tab.id}
+                          value={tab.id}
+                          label={tab.label}
+                          onClick={() => {
+                            if (isSearchActive) {
+                              if (
+                                tab.id === "search" ||
+                                tab.id === "search_archived"
+                              ) {
+                                setSelectedSearchTab(tab.id);
+                              }
+                            } else {
+                              setSelectedTab(tab.id);
+                            }
+                          }}
+                          tooltip={
+                            AGENT_MANAGER_TABS.find((t) => t.id === tab.id)
+                              ?.description
+                          }
+                          isCounter={
+                            tab.id !== "archived" &&
+                            tab.id !== "search_archived"
+                          }
+                          counterValue={`${agentsByTab[tab.id].length}`}
+                        />
+                      ))}
+                    </TabsList>
+                  </Tabs>
+                )}
+                {isAgentConfigurationsLoading ||
+                isArchivedAgentConfigurationsLoading ? (
+                  <div className="mt-8 flex justify-center">
+                    <Spinner size="lg" />
+                  </div>
+                ) : activeTab && agentsByTab[activeTab] ? (
+                  <AssistantsTable
+                    isBatchEdit={isBatchEdit}
+                    selection={selection}
+                    setSelection={setSelection}
+                    owner={owner}
+                    agents={agentsByTab[activeTab]}
+                    setDetailedAgentId={setDetailedAgentId}
+                    handleToggleAgentStatus={handleToggleAgentStatus}
+                    showDisabledFreeWorkspacePopup={
+                      showDisabledFreeWorkspacePopup
+                    }
+                    setShowDisabledFreeWorkspacePopup={
+                      setShowDisabledFreeWorkspacePopup
+                    }
+                    mutateAgentConfigurations={mutateAgentConfigurations}
+                  />
+                ) : (
+                  !assistantSearch &&
+                  !isRestrictedFromAgentCreation && (
+                    <div className="pt-2">
+                      <EmptyCallToAction
+                        href={`/w/${owner.sId}/builder/agents/create`}
+                        label="Create an agent"
+                        icon={PlusIcon}
+                        data-gtm-label="assistantCreationButton"
+                        data-gtm-location="assistantsWorkspace"
+                      />
+                    </div>
+                  )
+                )}
+              </div>
+            </Page.Vertical>
           </div>
-        </Page.Vertical>
-      </div>
+        </>
+      )}
     </AppContentLayout>
   );
 }

--- a/front/components/pages/builder/skills/ManageSkillsPage.tsx
+++ b/front/components/pages/builder/skills/ManageSkillsPage.tsx
@@ -194,96 +194,93 @@ export function ManageSkillsPage() {
   }, []);
 
   return (
-    <>
+    <AppContentLayout
+      contentWidth="wide"
+      subscription={subscription}
+      owner={owner}
+      navChildren={<AgentSidebarMenu owner={owner} />}
+    >
       <SkillDetailsSheet
         skill={selectedSkill}
         onClose={() => handleSkillSelect(null)}
         user={user}
         owner={owner}
       />
-
       <AgentDetails
         owner={owner}
         user={user}
         agentId={agentId}
         onClose={() => setAgentId(null)}
       />
-      <AppContentLayout
-        contentWidth="wide"
-        subscription={subscription}
-        owner={owner}
-        navChildren={<AgentSidebarMenu owner={owner} />}
-      >
-        <Head>
-          <title>Dust - Manage Skills</title>
-        </Head>
-        <div className="flex w-full flex-col gap-8 pb-4 pt-2 lg:pt-8">
-          <Page.Header
-            title="Manage Skills"
-            icon={SKILL_ICON}
-            description="Reusable packages of instructions and tools that agents can share."
-          />
-          <Page.Vertical gap="md" align="stretch">
-            <div className="flex flex-row gap-2">
-              <SearchInput
-                ref={searchBarRef}
-                className="flex-grow"
-                name="search"
-                placeholder="Search (Name, Editors)"
-                value={skillSearch}
-                onChange={(s) => {
-                  setSkillSearch(s);
-                }}
-              />
-              <Button
-                label="Create skill"
-                href={getSkillBuilderRoute(owner.sId, "new")}
-                icon={PlusIcon}
-                tooltip="Create a new skill"
-              />
-            </div>
-            <div className="flex flex-col pt-3">
-              <Tabs value={activeTab}>
-                <TabsList>
-                  {visibleTabs.map((tab) => (
-                    <TabsTrigger
-                      key={tab.id}
-                      value={tab.id}
-                      label={tab.label}
-                      onClick={() => !skillSearch && setSelectedTab(tab.id)}
-                      tooltip={tab.description}
-                      isCounter={tab.id !== "archived"}
-                      counterValue={`${skillsByTab[tab.id].length}`}
-                    />
-                  ))}
-                </TabsList>
-              </Tabs>
-              {isLoading ? (
-                <div className="mt-8 flex justify-center">
-                  <Spinner size="lg" />
-                </div>
-              ) : (
-                <>
-                  {activeTab === "active" && suggestedSkills.length > 0 && (
-                    <SuggestedSkillsSection
-                      skills={sortSkillsByName(suggestedSkills)}
-                      onSkillClick={handleSkillSelect}
-                      owner={owner}
-                      user={user}
-                    />
-                  )}
-                  <SkillsTable
-                    owner={owner}
-                    skills={skillsByTab[activeTab]}
-                    onSkillClick={handleSkillSelect}
-                    onAgentClick={setAgentId}
+      <Head>
+        <title>Dust - Manage Skills</title>
+      </Head>
+      <div className="flex w-full flex-col gap-8 pb-4 pt-2 lg:pt-8">
+        <Page.Header
+          title="Manage Skills"
+          icon={SKILL_ICON}
+          description="Reusable packages of instructions and tools that agents can share."
+        />
+        <Page.Vertical gap="md" align="stretch">
+          <div className="flex flex-row gap-2">
+            <SearchInput
+              ref={searchBarRef}
+              className="flex-grow"
+              name="search"
+              placeholder="Search (Name, Editors)"
+              value={skillSearch}
+              onChange={(s) => {
+                setSkillSearch(s);
+              }}
+            />
+            <Button
+              label="Create skill"
+              href={getSkillBuilderRoute(owner.sId, "new")}
+              icon={PlusIcon}
+              tooltip="Create a new skill"
+            />
+          </div>
+          <div className="flex flex-col pt-3">
+            <Tabs value={activeTab}>
+              <TabsList>
+                {visibleTabs.map((tab) => (
+                  <TabsTrigger
+                    key={tab.id}
+                    value={tab.id}
+                    label={tab.label}
+                    onClick={() => !skillSearch && setSelectedTab(tab.id)}
+                    tooltip={tab.description}
+                    isCounter={tab.id !== "archived"}
+                    counterValue={`${skillsByTab[tab.id].length}`}
                   />
-                </>
-              )}
-            </div>
-          </Page.Vertical>
-        </div>
-      </AppContentLayout>
-    </>
+                ))}
+              </TabsList>
+            </Tabs>
+            {isLoading ? (
+              <div className="mt-8 flex justify-center">
+                <Spinner size="lg" />
+              </div>
+            ) : (
+              <>
+                {activeTab === "active" && suggestedSkills.length > 0 && (
+                  <SuggestedSkillsSection
+                    skills={sortSkillsByName(suggestedSkills)}
+                    onSkillClick={handleSkillSelect}
+                    owner={owner}
+                    user={user}
+                  />
+                )}
+                <SkillsTable
+                  owner={owner}
+                  skills={skillsByTab[activeTab]}
+                  onSkillClick={handleSkillSelect}
+                  onAgentClick={setAgentId}
+                />
+              </>
+            )}
+          </div>
+        </Page.Vertical>
+      </div>
+    </AppContentLayout>
   );
 }

--- a/front/components/pages/spaces/apps/AppSpecificationPage.tsx
+++ b/front/components/pages/spaces/apps/AppSpecificationPage.tsx
@@ -43,19 +43,6 @@ export function AppSpecificationPage() {
     }
   }, [app]);
 
-  // Show 404 on error or if app not found after loading completes
-  if (isAppError || (!isAppLoading && !app)) {
-    return <Custom404 />;
-  }
-
-  if (isAppLoading || !app) {
-    return (
-      <div className="flex h-screen items-center justify-center">
-        <Spinner />
-      </div>
-    );
-  }
-
   return (
     <AppContentLayout
       contentWidth="centered"
@@ -63,41 +50,51 @@ export function AppSpecificationPage() {
       owner={owner}
       hideSidebar
       title={
-        <AppLayoutSimpleCloseTitle
-          title={app.name}
-          onClose={() => {
-            void router.push(dustAppsListUrl(owner, app.space));
-          }}
-        />
+        app ? (
+          <AppLayoutSimpleCloseTitle
+            title={app.name}
+            onClose={() => {
+              void router.push(dustAppsListUrl(owner, app.space));
+            }}
+          />
+        ) : undefined
       }
     >
-      <div className="flex w-full flex-col">
-        <Tabs value="specification" className="mt-2">
-          <TabsList>
-            {subNavigationApp({ owner, app, current: "specification" }).map(
-              (tab) => (
-                <TabsTrigger
-                  key={tab.value}
-                  value={tab.value}
-                  label={tab.label}
-                  icon={tab.icon}
-                  onClick={() => {
-                    if (tab.href) {
-                      void router.push(tab.href);
-                    }
-                  }}
-                />
-              )
-            )}
-          </TabsList>
-        </Tabs>
-        <div className="mt-8 flex flex-col gap-4">
-          <h3>Current specifications:</h3>
-          <div className="whitespace-pre font-mono text-sm text-gray-700">
-            {specification}
+      {isAppError || (!isAppLoading && !app) ? (
+        <Custom404 />
+      ) : isAppLoading || !app ? (
+        <div className="flex h-full items-center justify-center">
+          <Spinner />
+        </div>
+      ) : (
+        <div className="flex w-full flex-col">
+          <Tabs value="specification" className="mt-2">
+            <TabsList>
+              {subNavigationApp({ owner, app, current: "specification" }).map(
+                (tab) => (
+                  <TabsTrigger
+                    key={tab.value}
+                    value={tab.value}
+                    label={tab.label}
+                    icon={tab.icon}
+                    onClick={() => {
+                      if (tab.href) {
+                        void router.push(tab.href);
+                      }
+                    }}
+                  />
+                )
+              )}
+            </TabsList>
+          </Tabs>
+          <div className="mt-8 flex flex-col gap-4">
+            <h3>Current specifications:</h3>
+            <div className="whitespace-pre font-mono text-sm text-gray-700">
+              {specification}
+            </div>
           </div>
         </div>
-      </div>
+      )}
     </AppContentLayout>
   );
 }

--- a/front/components/pages/spaces/apps/DatasetPage.tsx
+++ b/front/components/pages/spaces/apps/DatasetPage.tsx
@@ -129,19 +129,6 @@ export function DatasetPage() {
 
   const isLoading = isAppLoading || isDatasetLoading;
 
-  // Show 404 on error or if dataset not found after loading completes
-  if (isDatasetError || (!isLoading && app && !dataset)) {
-    return <Custom404 />;
-  }
-
-  if (isLoading || !app || !dataset || !updatedDataset) {
-    return (
-      <div className="flex h-screen items-center justify-center">
-        <Spinner />
-      </div>
-    );
-  }
-
   return (
     <AppContentLayout
       contentWidth="centered"
@@ -149,65 +136,75 @@ export function DatasetPage() {
       owner={owner}
       hideSidebar
       title={
-        <AppLayoutSimpleCloseTitle
-          title={app.name}
-          onClose={() => {
-            void router.push(dustAppsListUrl(owner, app.space));
-          }}
-        />
+        app ? (
+          <AppLayoutSimpleCloseTitle
+            title={app.name}
+            onClose={() => {
+              void router.push(dustAppsListUrl(owner, app.space));
+            }}
+          />
+        ) : undefined
       }
     >
-      <div className="flex w-full flex-col">
-        <Tabs value="datasets" className="mt-2">
-          <TabsList>
-            {subNavigationApp({ owner, app, current: "datasets" }).map(
-              (tab) => (
-                <TabsTrigger
-                  key={tab.value}
-                  value={tab.value}
-                  label={tab.label}
-                  icon={tab.icon}
-                  onClick={() => {
-                    if (tab.href) {
-                      void router.push(tab.href);
-                    }
-                  }}
-                />
-              )
-            )}
-          </TabsList>
-        </Tabs>
-        <div className="mt-8 flex flex-col">
-          <div className="flex flex-1">
-            <div className="mb-8 w-full">
-              <div className="space-y-6 divide-y divide-gray-200 dark:divide-gray-200-night">
-                <DatasetView
-                  readOnly={readOnly}
-                  datasets={[] as DatasetType[]}
-                  dataset={updatedDataset}
-                  schema={dataset.schema ?? null}
-                  onUpdate={onUpdate}
-                  nameDisabled={true}
-                  viewType="full"
-                />
+      {isDatasetError || (!isLoading && app && !dataset) ? (
+        <Custom404 />
+      ) : isLoading || !app || !dataset || !updatedDataset ? (
+        <div className="flex h-full items-center justify-center">
+          <Spinner />
+        </div>
+      ) : (
+        <div className="flex w-full flex-col">
+          <Tabs value="datasets" className="mt-2">
+            <TabsList>
+              {subNavigationApp({ owner, app, current: "datasets" }).map(
+                (tab) => (
+                  <TabsTrigger
+                    key={tab.value}
+                    value={tab.value}
+                    label={tab.label}
+                    icon={tab.icon}
+                    onClick={() => {
+                      if (tab.href) {
+                        void router.push(tab.href);
+                      }
+                    }}
+                  />
+                )
+              )}
+            </TabsList>
+          </Tabs>
+          <div className="mt-8 flex flex-col">
+            <div className="flex flex-1">
+              <div className="mb-8 w-full">
+                <div className="space-y-6 divide-y divide-gray-200 dark:divide-gray-200-night">
+                  <DatasetView
+                    readOnly={readOnly}
+                    datasets={[] as DatasetType[]}
+                    dataset={updatedDataset}
+                    schema={dataset.schema ?? null}
+                    onUpdate={onUpdate}
+                    nameDisabled={true}
+                    viewType="full"
+                  />
 
-                {readOnly ? null : (
-                  <div className="flex flex-row pt-6">
-                    <div className="flex-initial">
-                      <Button
-                        disabled={disable || loading}
-                        onClick={() => handleSubmit()}
-                        label="Update"
-                        variant="primary"
-                      />
+                  {readOnly ? null : (
+                    <div className="flex flex-row pt-6">
+                      <div className="flex-initial">
+                        <Button
+                          disabled={disable || loading}
+                          onClick={() => handleSubmit()}
+                          label="Update"
+                          variant="primary"
+                        />
+                      </div>
                     </div>
-                  </div>
-                )}
+                  )}
+                </div>
               </div>
             </div>
           </div>
         </div>
-      </div>
+      )}
     </AppContentLayout>
   );
 }

--- a/front/components/pages/workspace/labs/TranscriptsPage.tsx
+++ b/front/components/pages/workspace/labs/TranscriptsPage.tsx
@@ -90,25 +90,6 @@ export function TranscriptsPage() {
     return response;
   };
 
-  if (
-    isTranscriptsConfigurationLoading ||
-    isFeatureFlagsLoading ||
-    !featureFlags.includes("labs_transcripts")
-  ) {
-    return (
-      <div
-        style={{
-          display: "flex",
-          justifyContent: "center",
-          alignItems: "center",
-          height: "100vh",
-        }}
-      >
-        <Spinner />
-      </div>
-    );
-  }
-
   const agents = agentConfigurations.filter((a) => a.status === "active");
   const items = [
     {
@@ -121,6 +102,11 @@ export function TranscriptsPage() {
     },
   ];
 
+  const isLoading =
+    isTranscriptsConfigurationLoading ||
+    isFeatureFlagsLoading ||
+    !featureFlags.includes("labs_transcripts");
+
   return (
     <AppContentLayout
       contentWidth="centered"
@@ -129,58 +115,70 @@ export function TranscriptsPage() {
       pageTitle="Dust - Transcripts processing"
       navChildren={<AgentSidebarMenu owner={owner} />}
     >
-      <Breadcrumbs items={items} />
-      <DeleteProviderDialog
-        isOpen={isDeleteProviderDialogOpened}
-        onClose={() => setIsDeleteProviderDialogOpened(false)}
-        onConfirm={async () => {
-          await handleDisconnectProvider(
-            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-            transcriptsConfiguration?.sId || null
-          );
-        }}
-      />
-      <Page>
-        <Page.Header
-          title="Meeting transcripts processing"
-          icon={BookOpenIcon}
-          description="Receive meeting minutes processed by email automatically and store them in a Dust Folder."
-        />
-        <Page.Layout direction="vertical">
-          <ProviderSelection
-            transcriptsConfiguration={transcriptsConfiguration}
-            mutateTranscriptsConfiguration={mutateTranscriptsConfiguration}
-            setIsDeleteProviderDialogOpened={setIsDeleteProviderDialogOpened}
-            owner={owner}
+      {isLoading ? (
+        <div className="flex h-full items-center justify-center">
+          <Spinner />
+        </div>
+      ) : (
+        <>
+          <Breadcrumbs items={items} />
+          <DeleteProviderDialog
+            isOpen={isDeleteProviderDialogOpened}
+            onClose={() => setIsDeleteProviderDialogOpened(false)}
+            onConfirm={async () => {
+              await handleDisconnectProvider(
+                // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+                transcriptsConfiguration?.sId || null
+              );
+            }}
           />
-
-          {transcriptsConfiguration && (
-            <>
-              {(!isProviderWithDefaultWorkspaceConfiguration(
-                transcriptsConfiguration.provider
-              ) ||
-                transcriptsConfiguration.isDefaultWorkspaceConfiguration) && (
-                <StorageConfiguration
-                  owner={owner}
-                  transcriptsConfiguration={transcriptsConfiguration}
-                  mutateTranscriptsConfiguration={
-                    mutateTranscriptsConfiguration
-                  }
-                  dataSourcesViews={dataSourceViews}
-                  spaces={spaces}
-                  isSpacesLoading={isSpacesLoading}
-                />
-              )}
-              <ProcessingConfiguration
-                owner={owner}
-                agents={agents}
+          <Page>
+            <Page.Header
+              title="Meeting transcripts processing"
+              icon={BookOpenIcon}
+              description="Receive meeting minutes processed by email automatically and store them in a Dust Folder."
+            />
+            <Page.Layout direction="vertical">
+              <ProviderSelection
                 transcriptsConfiguration={transcriptsConfiguration}
                 mutateTranscriptsConfiguration={mutateTranscriptsConfiguration}
+                setIsDeleteProviderDialogOpened={
+                  setIsDeleteProviderDialogOpened
+                }
+                owner={owner}
               />
-            </>
-          )}
-        </Page.Layout>
-      </Page>
+
+              {transcriptsConfiguration && (
+                <>
+                  {(!isProviderWithDefaultWorkspaceConfiguration(
+                    transcriptsConfiguration.provider
+                  ) ||
+                    transcriptsConfiguration.isDefaultWorkspaceConfiguration) && (
+                    <StorageConfiguration
+                      owner={owner}
+                      transcriptsConfiguration={transcriptsConfiguration}
+                      mutateTranscriptsConfiguration={
+                        mutateTranscriptsConfiguration
+                      }
+                      dataSourcesViews={dataSourceViews}
+                      spaces={spaces}
+                      isSpacesLoading={isSpacesLoading}
+                    />
+                  )}
+                  <ProcessingConfiguration
+                    owner={owner}
+                    agents={agents}
+                    transcriptsConfiguration={transcriptsConfiguration}
+                    mutateTranscriptsConfiguration={
+                      mutateTranscriptsConfiguration
+                    }
+                  />
+                </>
+              )}
+            </Page.Layout>
+          </Page>
+        </>
+      )}
     </AppContentLayout>
   );
 }

--- a/front/components/pages/workspace/labs/mcp_actions/AgentMCPActionsPage.tsx
+++ b/front/components/pages/workspace/labs/mcp_actions/AgentMCPActionsPage.tsx
@@ -71,38 +71,10 @@ export function AgentMCPActionsPage() {
     }
   }, [agent, isAgentConfigurationLoading, agentId, owner.sId, router]);
 
-  if (
-    isFeatureFlagsLoading ||
-    !featureFlags.includes("labs_mcp_actions_dashboard") ||
-    isAgentConfigurationLoading ||
-    !agent
-  ) {
-    return (
-      <div className="flex h-screen items-center justify-center">
-        <Spinner />
-      </div>
-    );
-  }
-
   const pagination = {
     pageIndex: currentPage,
     pageSize: 25,
   };
-
-  const items = [
-    {
-      label: "Exploratory features",
-      href: `/w/${owner.sId}/labs`,
-    },
-    {
-      label: "MCP Actions Dashboard",
-      href: `/w/${owner.sId}/labs/mcp_actions`,
-    },
-    {
-      label: agent.name,
-      href: `/w/${owner.sId}/labs/mcp_actions/${agent.sId}`,
-    },
-  ];
 
   const formatParams = (params: Record<string, unknown>): string => {
     try {
@@ -136,149 +108,182 @@ export function AgentMCPActionsPage() {
     }
   };
 
+  const isPageLoading =
+    isFeatureFlagsLoading ||
+    !featureFlags.includes("labs_mcp_actions_dashboard") ||
+    isAgentConfigurationLoading ||
+    !agent;
+
   return (
     <AppContentLayout
       contentWidth="centered"
       subscription={subscription}
       owner={owner}
-      pageTitle={`Dust - MCP Actions for ${agent.name}`}
+      pageTitle={
+        agent ? `Dust - MCP Actions for ${agent.name}` : "Dust - MCP Actions"
+      }
       navChildren={<AgentSidebarMenu owner={owner} />}
     >
-      <div className="mb-4">
-        <Breadcrumbs items={items} />
-      </div>
-
-      <Page>
-        <Page.Header
-          title={`MCP Actions for ${agent.name}`}
-          icon={ActionCodeBoxIcon}
-          description={`View all MCP actions executed by the ${agent.name} agent.`}
-        />
-
-        {/* Agent info section */}
-        <div className="mb-6 border-b border-gray-200 pb-4">
-          <div className="flex items-center gap-3">
-            <Avatar size="md" name={agent.name} visual={agent.pictureUrl} />
-            <div className="flex flex-col">
-              <h3 className="text-lg font-medium text-foreground dark:text-foreground-night">
-                {agent.name}
-              </h3>
-              <div className="flex items-center gap-2">
-                <Chip
-                  color={agent.scope === "global" ? "primary" : "green"}
-                  size="xs"
-                >
-                  {agent.scope === "global" ? "Default Agent" : "Custom Agent"}
-                </Chip>
-                <Chip
-                  color={agent.status === "active" ? "success" : "warning"}
-                  size="xs"
-                >
-                  {agent.status}
-                </Chip>
-              </div>
-              {agent.description && (
-                <p className="mt-1 text-sm text-muted-foreground dark:text-muted-foreground-night">
-                  {agent.description}
-                </p>
-              )}
-            </div>
-          </div>
+      {isPageLoading ? (
+        <div className="flex h-full items-center justify-center">
+          <Spinner />
         </div>
+      ) : (
+        <>
+          <div className="mb-4">
+            <Breadcrumbs
+              items={[
+                {
+                  label: "Exploratory features",
+                  href: `/w/${owner.sId}/labs`,
+                },
+                {
+                  label: "MCP Actions Dashboard",
+                  href: `/w/${owner.sId}/labs/mcp_actions`,
+                },
+                {
+                  label: agent.name,
+                  href: `/w/${owner.sId}/labs/mcp_actions/${agent.sId}`,
+                },
+              ]}
+            />
+          </div>
 
-        <Page.Layout direction="vertical">
-          {isLoading && actions.length === 0 ? (
-            <div className="flex justify-center py-8">
-              <Spinner />
-            </div>
-          ) : (
-            <>
-              <ContextItem.List>
-                <ContextItem.SectionHeader
-                  title="Action History"
-                  description={`${totalCount} MCP action${totalCount !== 1 ? "s" : ""} executed by this agent`}
-                />
+          <Page>
+            <Page.Header
+              title={`MCP Actions for ${agent.name}`}
+              icon={ActionCodeBoxIcon}
+              description={`View all MCP actions executed by the ${agent.name} agent.`}
+            />
 
-                {actions.length > 0 ? (
-                  <>
-                    {actions.map((action) => (
-                      <ContextItem
-                        key={action.sId}
-                        title={action.functionCallName || "Unknown Action"}
-                        visual={<Icon visual={ActionCodeBoxIcon} />}
-                        action={
-                          <div className="flex items-center gap-2">
-                            <Chip
-                              color={
-                                action.status === "errored"
-                                  ? "warning"
-                                  : getExecutionStateColor(action.status)
-                              }
-                              size="xs"
-                            >
-                              {action.status === "errored"
-                                ? "Error"
-                                : action.status.replace("_", " ")}
-                            </Chip>
-                            {action.conversationId && (
-                              <Button
-                                size="xs"
-                                variant="outline"
-                                icon={ExternalLinkIcon}
-                                onClick={() =>
-                                  handleConversationLink(
-                                    action.conversationId,
-                                    action.messageId
-                                  )
-                                }
-                                label="View Conversation"
-                              />
-                            )}
-                          </div>
-                        }
-                      >
-                        <div className="space-y-2">
-                          <ContextItem.Description
-                            description={`Executed on ${new Date(action.createdAt).toLocaleString()}`}
-                          />
-                          {Object.keys(action.params).length > 0 && (
-                            <div className="rounded-md border border-gray-200 bg-gray-50 p-3 dark:border-gray-700 dark:bg-gray-800">
-                              <h4 className="mb-2 text-sm font-medium text-foreground dark:text-foreground-night">
-                                Input Parameters:
-                              </h4>
-                              <pre className="max-h-32 overflow-auto whitespace-pre-wrap text-xs text-muted-foreground dark:text-muted-foreground-night">
-                                {formatParams(action.params)}
-                              </pre>
-                            </div>
-                          )}
-                        </div>
-                      </ContextItem>
-                    ))}
-                  </>
-                ) : (
-                  <ContextItem
-                    title="No Actions Found"
-                    visual={<Icon visual={ActionCodeBoxIcon} />}
-                  >
-                    <ContextItem.Description description="No MCP actions have been executed by this agent yet." />
-                  </ContextItem>
-                )}
-              </ContextItem.List>
-
-              {totalCount > pagination.pageSize && (
-                <div className="mt-4">
-                  <Pagination
-                    rowCount={totalCount}
-                    pagination={pagination}
-                    setPagination={setPagination}
-                    size="sm"
-                  />
+            {/* Agent info section */}
+            <div className="mb-6 border-b border-gray-200 pb-4">
+              <div className="flex items-center gap-3">
+                <Avatar size="md" name={agent.name} visual={agent.pictureUrl} />
+                <div className="flex flex-col">
+                  <h3 className="text-lg font-medium text-foreground dark:text-foreground-night">
+                    {agent.name}
+                  </h3>
+                  <div className="flex items-center gap-2">
+                    <Chip
+                      color={agent.scope === "global" ? "primary" : "green"}
+                      size="xs"
+                    >
+                      {agent.scope === "global"
+                        ? "Default Agent"
+                        : "Custom Agent"}
+                    </Chip>
+                    <Chip
+                      color={agent.status === "active" ? "success" : "warning"}
+                      size="xs"
+                    >
+                      {agent.status}
+                    </Chip>
+                  </div>
+                  {agent.description && (
+                    <p className="mt-1 text-sm text-muted-foreground dark:text-muted-foreground-night">
+                      {agent.description}
+                    </p>
+                  )}
                 </div>
+              </div>
+            </div>
+
+            <Page.Layout direction="vertical">
+              {isLoading && actions.length === 0 ? (
+                <div className="flex justify-center py-8">
+                  <Spinner />
+                </div>
+              ) : (
+                <>
+                  <ContextItem.List>
+                    <ContextItem.SectionHeader
+                      title="Action History"
+                      description={`${totalCount} MCP action${totalCount !== 1 ? "s" : ""} executed by this agent`}
+                    />
+
+                    {actions.length > 0 ? (
+                      <>
+                        {actions.map((action) => (
+                          <ContextItem
+                            key={action.sId}
+                            title={action.functionCallName || "Unknown Action"}
+                            visual={<Icon visual={ActionCodeBoxIcon} />}
+                            action={
+                              <div className="flex items-center gap-2">
+                                <Chip
+                                  color={
+                                    action.status === "errored"
+                                      ? "warning"
+                                      : getExecutionStateColor(action.status)
+                                  }
+                                  size="xs"
+                                >
+                                  {action.status === "errored"
+                                    ? "Error"
+                                    : action.status.replace("_", " ")}
+                                </Chip>
+                                {action.conversationId && (
+                                  <Button
+                                    size="xs"
+                                    variant="outline"
+                                    icon={ExternalLinkIcon}
+                                    onClick={() =>
+                                      handleConversationLink(
+                                        action.conversationId,
+                                        action.messageId
+                                      )
+                                    }
+                                    label="View Conversation"
+                                  />
+                                )}
+                              </div>
+                            }
+                          >
+                            <div className="space-y-2">
+                              <ContextItem.Description
+                                description={`Executed on ${new Date(action.createdAt).toLocaleString()}`}
+                              />
+                              {Object.keys(action.params).length > 0 && (
+                                <div className="rounded-md border border-gray-200 bg-gray-50 p-3 dark:border-gray-700 dark:bg-gray-800">
+                                  <h4 className="mb-2 text-sm font-medium text-foreground dark:text-foreground-night">
+                                    Input Parameters:
+                                  </h4>
+                                  <pre className="max-h-32 overflow-auto whitespace-pre-wrap text-xs text-muted-foreground dark:text-muted-foreground-night">
+                                    {formatParams(action.params)}
+                                  </pre>
+                                </div>
+                              )}
+                            </div>
+                          </ContextItem>
+                        ))}
+                      </>
+                    ) : (
+                      <ContextItem
+                        title="No Actions Found"
+                        visual={<Icon visual={ActionCodeBoxIcon} />}
+                      >
+                        <ContextItem.Description description="No MCP actions have been executed by this agent yet." />
+                      </ContextItem>
+                    )}
+                  </ContextItem.List>
+
+                  {totalCount > pagination.pageSize && (
+                    <div className="mt-4">
+                      <Pagination
+                        rowCount={totalCount}
+                        pagination={pagination}
+                        setPagination={setPagination}
+                        size="sm"
+                      />
+                    </div>
+                  )}
+                </>
               )}
-            </>
-          )}
-        </Page.Layout>
-      </Page>
+            </Page.Layout>
+          </Page>
+        </>
+      )}
     </AppContentLayout>
   );
 }

--- a/front/components/pages/workspace/labs/mcp_actions/MCPActionsDashboardPage.tsx
+++ b/front/components/pages/workspace/labs/mcp_actions/MCPActionsDashboardPage.tsx
@@ -46,17 +46,6 @@ export function MCPActionsDashboardPage() {
     }
   }, [featureFlags, isFeatureFlagsLoading, owner.sId, router]);
 
-  if (
-    isFeatureFlagsLoading ||
-    !featureFlags.includes("labs_mcp_actions_dashboard")
-  ) {
-    return (
-      <div className="flex h-screen items-center justify-center">
-        <Spinner />
-      </div>
-    );
-  }
-
   const items = [
     {
       label: "Exploratory features",
@@ -75,6 +64,10 @@ export function MCPActionsDashboardPage() {
   const activeAgents =
     agentConfigurations?.filter((agent) => agent.status === "active") || [];
 
+  const isLoading =
+    isFeatureFlagsLoading ||
+    !featureFlags.includes("labs_mcp_actions_dashboard");
+
   return (
     <AppContentLayout
       contentWidth="centered"
@@ -83,78 +76,88 @@ export function MCPActionsDashboardPage() {
       pageTitle="Dust - MCP Actions Dashboard"
       navChildren={<AgentSidebarMenu owner={owner} />}
     >
-      <div className="mb-4">
-        <Breadcrumbs items={items} />
-      </div>
+      {isLoading ? (
+        <div className="flex h-full items-center justify-center">
+          <Spinner />
+        </div>
+      ) : (
+        <>
+          <div className="mb-4">
+            <Breadcrumbs items={items} />
+          </div>
 
-      <Page>
-        <Page.Header
-          title="MCP Actions Dashboard"
-          icon={ActionCodeBoxIcon}
-          description="Monitor and track MCP (Model Context Protocol) actions executed by your agents."
-        />
+          <Page>
+            <Page.Header
+              title="MCP Actions Dashboard"
+              icon={ActionCodeBoxIcon}
+              description="Monitor and track MCP (Model Context Protocol) actions executed by your agents."
+            />
 
-        <Page.Layout direction="vertical">
-          {isAgentConfigurationsLoading ? (
-            <div className="flex justify-center py-8">
-              <Spinner />
-            </div>
-          ) : (
-            <ContextItem.List>
-              <ContextItem.SectionHeader
-                title="Active Agents"
-                description={`${activeAgents.length} agent${activeAgents.length !== 1 ? "s" : ""} available for MCP action monitoring.`}
-              />
-
-              {activeAgents.length > 0 ? (
-                activeAgents.map((agent) => (
-                  <ContextItem
-                    key={agent.sId}
-                    title={agent.name}
-                    visual={
-                      <Avatar
-                        size="sm"
-                        name={agent.name}
-                        visual={agent.pictureUrl}
-                      />
-                    }
-                    action={
-                      <div className="flex items-center gap-2">
-                        <Chip
-                          color={agent.scope === "global" ? "primary" : "green"}
-                          size="xs"
-                        >
-                          {agent.scope === "global" ? "Default" : "Custom"}
-                        </Chip>
-                        <Button
-                          size="sm"
-                          variant="outline"
-                          icon={ExternalLinkIcon}
-                          onClick={() => handleAgentSelect(agent.sId)}
-                          label="View Actions"
-                        />
-                      </div>
-                    }
-                  >
-                    <ContextItem.Description
-                      description={
-                        agent.description || "No description available"
-                      }
-                    />
-                  </ContextItem>
-                ))
+            <Page.Layout direction="vertical">
+              {isAgentConfigurationsLoading ? (
+                <div className="flex justify-center py-8">
+                  <Spinner />
+                </div>
               ) : (
-                <ContextItem
-                  title="No Active Agents Found"
-                  visual={<Icon visual={RobotIcon} />}
-                >
-                  <ContextItem.Description description="No active agents found in this workspace. Agents must be active to execute MCP actions." />
-                </ContextItem>
+                <ContextItem.List>
+                  <ContextItem.SectionHeader
+                    title="Active Agents"
+                    description={`${activeAgents.length} agent${activeAgents.length !== 1 ? "s" : ""} available for MCP action monitoring.`}
+                  />
+
+                  {activeAgents.length > 0 ? (
+                    activeAgents.map((agent) => (
+                      <ContextItem
+                        key={agent.sId}
+                        title={agent.name}
+                        visual={
+                          <Avatar
+                            size="sm"
+                            name={agent.name}
+                            visual={agent.pictureUrl}
+                          />
+                        }
+                        action={
+                          <div className="flex items-center gap-2">
+                            <Chip
+                              color={
+                                agent.scope === "global" ? "primary" : "green"
+                              }
+                              size="xs"
+                            >
+                              {agent.scope === "global" ? "Default" : "Custom"}
+                            </Chip>
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              icon={ExternalLinkIcon}
+                              onClick={() => handleAgentSelect(agent.sId)}
+                              label="View Actions"
+                            />
+                          </div>
+                        }
+                      >
+                        <ContextItem.Description
+                          description={
+                            agent.description || "No description available"
+                          }
+                        />
+                      </ContextItem>
+                    ))
+                  ) : (
+                    <ContextItem
+                      title="No Active Agents Found"
+                      visual={<Icon visual={RobotIcon} />}
+                    >
+                      <ContextItem.Description description="No active agents found in this workspace. Agents must be active to execute MCP actions." />
+                    </ContextItem>
+                  )}
+                </ContextItem.List>
               )}
-            </ContextItem.List>
-          )}
-        </Page.Layout>
-      </Page>
+            </Page.Layout>
+          </Page>
+        </>
+      )}
     </AppContentLayout>
   );
 }

--- a/front/components/spaces/SpaceLayout.tsx
+++ b/front/components/spaces/SpaceLayout.tsx
@@ -82,7 +82,7 @@ export function SpaceLayout({ children }: SpaceLayoutProps) {
       }
     >
       {isSpaceInfoLoading || !space ? (
-        <div className="flex h-screen items-center justify-center">
+        <div className="flex h-full items-center justify-center">
           <Spinner />
         </div>
       ) : (


### PR DESCRIPTION
## Description

Hoists `AppContentLayout` above loading/error early-returns in page components, so the navigation sidebar always renders even while page content is loading.

Previously, several pages would early-return a bare `<Spinner>` before reaching their `<AppContentLayout>` wrapper, causing the sidebar to disappear during loading states. Now the loading/error states render inside the layout.

### Changes

- **ManageAgentsPage, ManageSkillsPage, AppSpecificationPage, DatasetPage, TranscriptsPage, AgentMCPActionsPage, MCPActionsDashboardPage** — Moved loading/error early-returns inside `AppContentLayout` so the sidebar persists during loading
- **ConversationLayout** — Reordered providers: `InputBarProvider` now wraps `AppContentLayout` which wraps `BlockedActionsProvider` (prepares for later hoisting `InputBarProvider` above `AppContentLayout`)
- **SpaceLayout** — Changed spinner from `h-screen` to `h-full` (correct sizing inside layout)

## Tests

- Verified sidebar stays visible while pages load
- Verified loading spinners display correctly inside the layout
- Verified error states (404) display correctly inside the layout
- Type check passes

## Risk

Low — moves existing rendering logic inside `AppContentLayout` without changing behavior. The sidebar now stays mounted during loading states, which is the intended improvement.

## Deploy Plan

Standard deploy. Stacked on #21414.