### PR TITLE
[front] enh: Move AppContentLayout to layout level

### DIFF
--- a/front-spa/src/app/App.tsx
+++ b/front-spa/src/app/App.tsx
@@ -4,6 +4,7 @@ import Custom404 from "@dust-tt/front/pages/404";
 import { safeLazy } from "@dust-tt/sparkle";
 import { AppReadyProvider } from "@spa/app/contexts/AppReadyContext";
 import { AdminLayout } from "@spa/app/layouts/AdminLayout";
+import { AppContentLayoutWrapper } from "@spa/app/layouts/AppContentLayoutWrapper";
 import { AuthenticatedPage } from "@spa/app/layouts/AuthenticatedPage";
 import { ConversationLayoutWrapper } from "@spa/app/layouts/ConversationLayoutWrapper";
 import { SpaceLayoutWrapper } from "@spa/app/layouts/SpaceLayoutWrapper";
@@ -306,107 +307,132 @@ const router = createBrowserRouter(
       path: "/w/:wId",
       element: <WorkspacePage />,
       children: [
-        // Index - redirect to conversation/new
+        // Routes WITH shared AppContentLayout (navigation, sidebar, title bar)
         {
-          index: true,
-          element: <RedirectWithSearchParams to="conversation/new" />,
-        },
-
-        // Profile
-        { path: "me", element: <ProfilePage /> },
-
-        // Conversation (wrapped with ConversationLayout)
-        {
-          path: "conversation",
-          element: <ConversationLayoutWrapper />,
+          element: <AppContentLayoutWrapper />,
           children: [
-            { path: ":cId", element: <ConversationPage /> },
-            { path: "space/:spaceId", element: <SpaceConversationsPage /> },
+            // Index - redirect to conversation/new
+            {
+              index: true,
+              element: <RedirectWithSearchParams to="conversation/new" />,
+            },
+
+            // Profile
+            { path: "me", element: <ProfilePage /> },
+
+            // Conversation (wrapped with ConversationLayout)
+            {
+              path: "conversation",
+              element: <ConversationLayoutWrapper />,
+              children: [
+                { path: ":cId", element: <ConversationPage /> },
+                {
+                  path: "space/:spaceId",
+                  element: <SpaceConversationsPage />,
+                },
+              ],
+            },
+
+            {
+              element: <AdminLayout />,
+              children: [
+                { path: "members", element: <MembersPage /> },
+                { path: "workspace", element: <WorkspaceSettingsPage /> },
+                { path: "analytics", element: <AnalyticsPage /> },
+                { path: "subscription", element: <SubscriptionPage /> },
+                {
+                  path: "subscription/manage",
+                  element: <ManageSubscriptionPage />,
+                },
+                {
+                  path: "subscription/payment_processing",
+                  element: <PaymentProcessingPage />,
+                },
+                { path: "developers/api-keys", element: <APIKeysPage /> },
+                {
+                  path: "developers/credits-usage",
+                  element: <CreditsUsagePage />,
+                },
+                { path: "developers/providers", element: <ProvidersPage /> },
+                { path: "developers/dev-secrets", element: <SecretsPage /> },
+              ],
+            },
+
+            // Labs
+            { path: "labs", element: <LabsPage /> },
+            { path: "labs/transcripts", element: <TranscriptsPage /> },
+            { path: "labs/mcp_actions", element: <MCPActionsDashboardPage /> },
+            {
+              path: "labs/mcp_actions/:agentId",
+              element: <AgentMCPActionsPage />,
+            },
+
+            // Spaces
+            {
+              path: "spaces/:spaceId",
+              element: <SpaceLayoutWrapper />,
+              children: [
+                { index: true, element: <SpacePage /> },
+                { path: "categories/actions", element: <SpaceActionsPage /> },
+                { path: "categories/apps", element: <SpaceAppsListPage /> },
+                {
+                  path: "categories/triggers",
+                  element: <SpaceTriggersPage />,
+                },
+                {
+                  path: "categories/:category",
+                  element: <SpaceCategoryPage />,
+                },
+                {
+                  path: "categories/:category/data_source_views/:dataSourceViewId",
+                  element: <DataSourceViewPage />,
+                },
+              ],
+            },
+
+            // Apps
+            { path: "spaces/:spaceId/apps/:aId", element: <AppViewPage /> },
+            {
+              path: "spaces/:spaceId/apps/:aId/settings",
+              element: <AppSettingsPage />,
+            },
+            {
+              path: "spaces/:spaceId/apps/:aId/specification",
+              element: <AppSpecificationPage />,
+            },
+            {
+              path: "spaces/:spaceId/apps/:aId/datasets",
+              element: <DatasetsPage />,
+            },
+            {
+              path: "spaces/:spaceId/apps/:aId/datasets/new",
+              element: <NewDatasetPage />,
+            },
+            {
+              path: "spaces/:spaceId/apps/:aId/datasets/:name",
+              element: <DatasetPage />,
+            },
+            { path: "spaces/:spaceId/apps/:aId/runs", element: <RunsPage /> },
+            {
+              path: "spaces/:spaceId/apps/:aId/runs/:runId",
+              element: <RunPage />,
+            },
+
+            // Builder (pages with sidebar layout)
+            { path: "builder/agents", element: <ManageAgentsPage /> },
+            { path: "builder/agents/create", element: <CreateAgentPage /> },
+            { path: "builder/skills", element: <ManageSkillsPage /> },
+
+            // Spaces redirect (inside layout to preserve sidebar)
+            { path: "spaces", element: <SpacesRedirectPage /> },
           ],
         },
 
-        {
-          element: <AdminLayout />,
-          children: [
-            { path: "members", element: <MembersPage /> },
-            { path: "workspace", element: <WorkspaceSettingsPage /> },
-            { path: "analytics", element: <AnalyticsPage /> },
-            { path: "subscription", element: <SubscriptionPage /> },
-            {
-              path: "subscription/manage",
-              element: <ManageSubscriptionPage />,
-            },
-            {
-              path: "subscription/payment_processing",
-              element: <PaymentProcessingPage />,
-            },
-            { path: "developers/api-keys", element: <APIKeysPage /> },
-            { path: "developers/credits-usage", element: <CreditsUsagePage /> },
-            { path: "developers/providers", element: <ProvidersPage /> },
-            { path: "developers/dev-secrets", element: <SecretsPage /> },
-          ],
-        },
+        // Routes WITHOUT AppContentLayout (no sidebar/navigation chrome)
 
-        // Labs
-        { path: "labs", element: <LabsPage /> },
-        { path: "labs/transcripts", element: <TranscriptsPage /> },
-        { path: "labs/mcp_actions", element: <MCPActionsDashboardPage /> },
-        {
-          path: "labs/mcp_actions/:agentId",
-          element: <AgentMCPActionsPage />,
-        },
-
-        // Spaces
-        { path: "spaces", element: <SpacesRedirectPage /> },
-        {
-          path: "spaces/:spaceId",
-          element: <SpaceLayoutWrapper />,
-          children: [
-            { index: true, element: <SpacePage /> },
-            { path: "categories/actions", element: <SpaceActionsPage /> },
-            { path: "categories/apps", element: <SpaceAppsListPage /> },
-            { path: "categories/triggers", element: <SpaceTriggersPage /> },
-            { path: "categories/:category", element: <SpaceCategoryPage /> },
-            {
-              path: "categories/:category/data_source_views/:dataSourceViewId",
-              element: <DataSourceViewPage />,
-            },
-          ],
-        },
-
-        // Apps
-        { path: "spaces/:spaceId/apps/:aId", element: <AppViewPage /> },
-        {
-          path: "spaces/:spaceId/apps/:aId/settings",
-          element: <AppSettingsPage />,
-        },
-        {
-          path: "spaces/:spaceId/apps/:aId/specification",
-          element: <AppSpecificationPage />,
-        },
-        {
-          path: "spaces/:spaceId/apps/:aId/datasets",
-          element: <DatasetsPage />,
-        },
-        {
-          path: "spaces/:spaceId/apps/:aId/datasets/new",
-          element: <NewDatasetPage />,
-        },
-        {
-          path: "spaces/:spaceId/apps/:aId/datasets/:name",
-          element: <DatasetPage />,
-        },
-        { path: "spaces/:spaceId/apps/:aId/runs", element: <RunsPage /> },
-        { path: "spaces/:spaceId/apps/:aId/runs/:runId", element: <RunPage /> },
-
-        // Builder/Agents
-        { path: "builder/agents", element: <ManageAgentsPage /> },
-        { path: "builder/agents/create", element: <CreateAgentPage /> },
+        // Builder (full-page editors without sidebar)
         { path: "builder/agents/new", element: <NewAgentPage /> },
         { path: "builder/agents/:aId", element: <EditAgentPage /> },
-
-        // Builder/Skills
-        { path: "builder/skills", element: <ManageSkillsPage /> },
         { path: "builder/skills/new", element: <CreateSkillPage /> },
         { path: "builder/skills/:sId", element: <EditSkillPage /> },
 

--- a/front-spa/src/app/layouts/AppContentLayoutWrapper.tsx
+++ b/front-spa/src/app/layouts/AppContentLayoutWrapper.tsx
@@ -1,0 +1,20 @@
+import { AppContentLayout } from "@dust-tt/front/components/sparkle/AppContentLayout";
+import { AppLayoutProvider } from "@dust-tt/front/components/sparkle/AppLayoutContext";
+import { Outlet } from "react-router-dom";
+
+/**
+ * Wrapper that provides the shared AppContentLayout (navigation sidebar, title bar, etc.)
+ * for SPA routes. Pages configure the layout via useAppLayoutConfig().
+ *
+ * Routes that don't need the layout chrome (onboarding, agent/skill builders)
+ * should be placed outside this wrapper.
+ */
+export function AppContentLayoutWrapper() {
+  return (
+    <AppLayoutProvider>
+      <AppContentLayout>
+        <Outlet />
+      </AppContentLayout>
+    </AppLayoutProvider>
+  );
+}

--- a/front/components/apps/DustAppPageLayout.tsx
+++ b/front/components/apps/DustAppPageLayout.tsx
@@ -2,17 +2,14 @@ import { Tabs, TabsList, TabsTrigger } from "@dust-tt/sparkle";
 import type { ReactNode } from "react";
 
 import { subNavigationApp } from "@app/components/navigation/config";
-import { AppContentLayout } from "@app/components/sparkle/AppContentLayout";
+import { useAppLayoutConfig } from "@app/components/sparkle/AppLayoutContext";
 import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
+import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { useAppRouter } from "@app/lib/platform";
 import { dustAppsListUrl } from "@app/lib/spaces";
 import type { AppType } from "@app/types/app";
-import type { SubscriptionType } from "@app/types/plan";
-import type { WorkspaceType } from "@app/types/user";
 
 interface DustAppPageLayoutProps {
-  owner: WorkspaceType;
-  subscription: SubscriptionType;
   app: AppType;
   currentTab: "specification" | "runs" | "settings" | "datasets";
   children: ReactNode;
@@ -21,53 +18,51 @@ interface DustAppPageLayoutProps {
 // TODO: We are not supposed to use z-index for radix components, check why
 // code input will go over without z-index.
 export function DustAppPageLayout({
-  owner,
-  subscription,
   app,
   currentTab,
   children,
 }: DustAppPageLayoutProps) {
+  const owner = useWorkspace();
   const router = useAppRouter();
 
-  return (
-    <AppContentLayout
-      contentWidth="centered"
-      contentClassName="pt-0"
-      subscription={subscription}
-      owner={owner}
-      hideSidebar
-      title={
+  useAppLayoutConfig(
+    () => ({
+      contentWidth: "centered",
+      contentClassName: "pt-0",
+      hideSidebar: true,
+      title: (
         <AppLayoutSimpleCloseTitle
           title={app.name}
           onClose={() => {
             void router.push(dustAppsListUrl(owner, app.space));
           }}
         />
-      }
-    >
-      <div className="flex w-full flex-col">
-        <Tabs
-          value={currentTab}
-          className="sticky top-0 z-10 bg-background pt-4 dark:bg-background-night"
-        >
-          <TabsList>
-            {subNavigationApp({ owner, app, current: currentTab }).map(
-              (item) => (
-                <TabsTrigger
-                  key={item.value}
-                  value={item.value}
-                  label={item.label}
-                  icon={item.icon}
-                  onClick={() => {
-                    void router.push(item.href);
-                  }}
-                />
-              )
-            )}
-          </TabsList>
-        </Tabs>
-        {children}
-      </div>
-    </AppContentLayout>
+      ),
+    }),
+    [owner, app, router]
+  );
+
+  return (
+    <div className="flex w-full flex-col">
+      <Tabs
+        value={currentTab}
+        className="sticky top-0 z-10 bg-background pt-4 dark:bg-background-night"
+      >
+        <TabsList>
+          {subNavigationApp({ owner, app, current: currentTab }).map((item) => (
+            <TabsTrigger
+              key={item.value}
+              value={item.value}
+              label={item.label}
+              icon={item.icon}
+              onClick={() => {
+                void router.push(item.href);
+              }}
+            />
+          ))}
+        </TabsList>
+      </Tabs>
+      {children}
+    </div>
   );
 }

--- a/front/components/apps/DustAppPageLayout.tsx
+++ b/front/components/apps/DustAppPageLayout.tsx
@@ -1,8 +1,14 @@
 import { Tabs, TabsList, TabsTrigger } from "@dust-tt/sparkle";
 import type { ReactNode } from "react";
+import { useMemo } from "react";
 
 import { subNavigationApp } from "@app/components/navigation/config";
-import { useAppLayoutConfig } from "@app/components/sparkle/AppLayoutContext";
+import {
+  useSetContentClassName,
+  useSetContentWidth,
+  useSetHideSidebar,
+  useSetTitle,
+} from "@app/components/sparkle/AppLayoutContext";
 import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { useAppRouter } from "@app/lib/platform";
@@ -25,22 +31,22 @@ export function DustAppPageLayout({
   const owner = useWorkspace();
   const router = useAppRouter();
 
-  useAppLayoutConfig(
-    () => ({
-      contentWidth: "centered",
-      contentClassName: "pt-0",
-      hideSidebar: true,
-      title: (
-        <AppLayoutSimpleCloseTitle
-          title={app.name}
-          onClose={() => {
-            void router.push(dustAppsListUrl(owner, app.space));
-          }}
-        />
-      ),
-    }),
+  const title = useMemo(
+    () => (
+      <AppLayoutSimpleCloseTitle
+        title={app.name}
+        onClose={() => {
+          void router.push(dustAppsListUrl(owner, app.space));
+        }}
+      />
+    ),
     [owner, app, router]
   );
+
+  useSetContentWidth("centered");
+  useSetContentClassName("pt-0");
+  useSetHideSidebar(true);
+  useSetTitle(title);
 
   return (
     <div className="flex w-full flex-col">

--- a/front/components/assistant/conversation/ConversationLayout.tsx
+++ b/front/components/assistant/conversation/ConversationLayout.tsx
@@ -17,7 +17,11 @@ import { MemberDetails } from "@app/components/assistant/details/MemberDetails";
 import { WelcomeTourGuide } from "@app/components/assistant/WelcomeTourGuide";
 import { useWelcomeTourGuide } from "@app/components/assistant/WelcomeTourGuideProvider";
 import { ErrorBoundary } from "@app/components/error_boundary/ErrorBoundary";
-import { useAppLayoutConfig } from "@app/components/sparkle/AppLayoutContext";
+import {
+  useSetHasTitle,
+  useSetNavChildren,
+  useSetPageTitle,
+} from "@app/components/sparkle/AppLayoutContext";
 import { useActiveConversationId } from "@app/hooks/useActiveConversationId";
 import { useURLSheet } from "@app/hooks/useURLSheet";
 import type { AuthContextValue } from "@app/lib/auth/AuthContext";
@@ -105,16 +109,18 @@ const ConversationLayoutContent = ({
     // Focus back on input bar
   };
 
-  useAppLayoutConfig(
-    () => ({
-      hasTitle: !!activeConversationId,
-      pageTitle: conversation?.title
-        ? `Dust - ${conversation.title}`
-        : "Dust - New Conversation",
-      navChildren: <AgentSidebarMenu owner={owner} />,
-    }),
-    [activeConversationId, conversation?.title, owner]
+  const pageTitle = conversation?.title
+    ? `Dust - ${conversation.title}`
+    : "Dust - New Conversation";
+
+  const navChildren = useMemo(
+    () => <AgentSidebarMenu owner={owner} />,
+    [owner]
   );
+
+  useSetHasTitle(!!activeConversationId);
+  useSetPageTitle(pageTitle);
+  useSetNavChildren(navChildren);
 
   return (
     <BlockedActionsProvider owner={owner} conversation={conversation}>

--- a/front/components/layouts/AdminLayout.tsx
+++ b/front/components/layouts/AdminLayout.tsx
@@ -2,8 +2,8 @@ import { cn } from "@dust-tt/sparkle";
 import type { ReactElement } from "react";
 
 import { subNavigationAdmin } from "@app/components/navigation/config";
-import { AppContentLayout } from "@app/components/sparkle/AppContentLayout";
-import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
+import { useAppLayoutConfig } from "@app/components/sparkle/AppLayoutContext";
+import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { useAppRouter } from "@app/lib/platform";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
 
@@ -13,34 +13,33 @@ interface AdminLayoutProps {
 
 export function AdminLayout({ children }: AdminLayoutProps) {
   const owner = useWorkspace();
-  const { subscription } = useAuth();
+
   const { featureFlags } = useFeatureFlags({
     workspaceId: owner.sId,
   });
 
   const router = useAppRouter();
 
-  const subNavigation = subNavigationAdmin({
-    owner,
-    currentRoute: router.pathname,
-    featureFlags,
-  });
+  useAppLayoutConfig(
+    () => ({
+      subNavigation: subNavigationAdmin({
+        owner,
+        currentRoute: router.pathname,
+        featureFlags,
+      }),
+    }),
+    [owner.sId, router.pathname, featureFlags]
+  );
 
   return (
-    <AppContentLayout
-      subNavigation={subNavigation}
-      subscription={subscription}
-      owner={owner}
+    <div
+      className={cn(
+        "flex h-full w-full flex-col items-center overflow-y-auto pt-4"
+      )}
     >
-      <div
-        className={cn(
-          "flex h-full w-full flex-col items-center overflow-y-auto pt-4"
-        )}
-      >
-        <div className="flex w-full max-w-4xl grow flex-col px-4 sm:px-8">
-          {children}
-        </div>
+      <div className="flex w-full max-w-4xl grow flex-col px-4 sm:px-8">
+        {children}
       </div>
-    </AppContentLayout>
+    </div>
   );
 }

--- a/front/components/layouts/AdminLayout.tsx
+++ b/front/components/layouts/AdminLayout.tsx
@@ -1,8 +1,9 @@
 import { cn } from "@dust-tt/sparkle";
 import type { ReactElement } from "react";
+import { useMemo } from "react";
 
 import { subNavigationAdmin } from "@app/components/navigation/config";
-import { useAppLayoutConfig } from "@app/components/sparkle/AppLayoutContext";
+import { useSetSubNavigation } from "@app/components/sparkle/AppLayoutContext";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { useAppRouter } from "@app/lib/platform";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
@@ -20,16 +21,17 @@ export function AdminLayout({ children }: AdminLayoutProps) {
 
   const router = useAppRouter();
 
-  useAppLayoutConfig(
-    () => ({
-      subNavigation: subNavigationAdmin({
+  const subNavigation = useMemo(
+    () =>
+      subNavigationAdmin({
         owner,
         currentRoute: router.pathname,
         featureFlags,
       }),
-    }),
-    [owner.sId, router.pathname, featureFlags]
+    [owner, router.pathname, featureFlags]
   );
+
+  useSetSubNavigation(subNavigation);
 
   return (
     <div

--- a/front/components/navigation/config.ts
+++ b/front/components/navigation/config.ts
@@ -174,8 +174,8 @@ export const getTopNavigationTabs = (
     icon: PlanetIcon,
     href: `/w/${owner.sId}/spaces`,
     isCurrent: (currentRoute: string) =>
-      currentRoute.startsWith("/w/[wId]/spaces/") ||
-      /^\/w\/[^/]+\/spaces\//.test(currentRoute),
+      currentRoute.startsWith("/w/[wId]/spaces") ||
+      /^\/w\/[^/]+\/spaces/.test(currentRoute),
     sizing: "hug",
     ref: spaceMenuButtonRef,
   });

--- a/front/components/pages/builder/agents/CreateAgentPage.tsx
+++ b/front/components/pages/builder/agents/CreateAgentPage.tsx
@@ -14,13 +14,11 @@ import { useMemo, useState } from "react";
 import { AgentTemplateGrid } from "@app/components/agent_builder/AgentTemplateGrid";
 import { AgentTemplateModal } from "@app/components/agent_builder/AgentTemplateModal";
 import { getUniqueTemplateTags } from "@app/components/agent_builder/utils";
-import {
-  AppContentLayout,
-  appLayoutBack,
-} from "@app/components/sparkle/AppContentLayout";
+import { appLayoutBack } from "@app/components/sparkle/AppContentLayout";
+import { useAppLayoutConfig } from "@app/components/sparkle/AppLayoutContext";
 import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { useYAMLUpload } from "@app/hooks/useYAMLUpload";
-import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
+import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { useAppRouter, useSearchParam } from "@app/lib/platform";
 import { useAssistantTemplates } from "@app/lib/swr/assistants";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
@@ -34,7 +32,6 @@ import {
 export function CreateAgentPage() {
   const router = useAppRouter();
   const owner = useWorkspace();
-  const { subscription } = useAuth();
   const templateTagsMapping = TEMPLATES_TAGS_CONFIG;
   const initialTemplateId = useSearchParam("templateId");
 
@@ -102,117 +99,116 @@ export function CreateAgentPage() {
     );
   };
 
-  return (
-    <AppContentLayout
-      contentWidth="centered"
-      subscription={subscription}
-      hideSidebar
-      owner={owner}
-      title={
+  useAppLayoutConfig(
+    () => ({
+      contentWidth: "centered",
+      hideSidebar: true,
+      title: (
         <AppLayoutSimpleCloseTitle
           title="Create an Agent"
           onClose={async () => {
             await appLayoutBack(owner, router);
           }}
         />
-      }
-    >
-      <div id="pageContent">
-        <Page variant="modal">
-          <div className="flex flex-col gap-6">
-            <div className="flex min-h-[20vh] flex-col justify-end gap-6">
-              <div className="flex flex-row items-center gap-2">
-                <Icon
-                  visual={PencilSquareIcon}
-                  size="lg"
-                  className="text-primary-400 dark:text-primary-500"
-                />
-                <Page.Header title="Start new" />
-              </div>
-              <div className="flex flex-row gap-3">
-                <Button
-                  icon={DocumentIcon}
-                  label="New Agent"
-                  data-gtm-label="assistantCreationButton"
-                  data-gtm-location="assistantCreationPage"
-                  size="md"
-                  variant="highlight"
-                  href={`/w/${owner.sId}/builder/agents/new`}
-                />
-                {hasFeature("agent_to_yaml") && (
-                  <Button
-                    icon={
-                      isUploadingYAML
-                        ? () => <Spinner size="xs" />
-                        : FolderOpenIcon
-                    }
-                    label={
-                      isUploadingYAML ? "Uploading..." : "Upload from YAML"
-                    }
-                    data-gtm-label="yamlUploadButton"
-                    data-gtm-location="assistantCreationPage"
-                    size="md"
-                    variant="outline"
-                    disabled={isUploadingYAML}
-                    onClick={triggerYAMLUpload}
-                  />
-                )}
-              </div>
-            </div>
+      ),
+    }),
+    [owner, router]
+  );
 
-            <Page.Separator />
-
+  return (
+    <div id="pageContent">
+      <Page variant="modal">
+        <div className="flex flex-col gap-6">
+          <div className="flex min-h-[20vh] flex-col justify-end gap-6">
             <div className="flex flex-row items-center gap-2">
               <Icon
-                visual={MagicIcon}
+                visual={PencilSquareIcon}
                 size="lg"
                 className="text-primary-400 dark:text-primary-500"
               />
-              <Page.Header title="Start from a template" />
+              <Page.Header title="Start new" />
             </div>
-
-            <div className="flex flex-col gap-6">
-              <SearchInput
-                placeholder="Search templates"
-                name="input"
-                value={searchTerm}
-                onChange={setSearchTerm}
+            <div className="flex flex-row gap-3">
+              <Button
+                icon={DocumentIcon}
+                label="New Agent"
+                data-gtm-label="assistantCreationButton"
+                data-gtm-location="assistantCreationPage"
+                size="md"
+                variant="highlight"
+                href={`/w/${owner.sId}/builder/agents/new`}
               />
-              <div className="flex flex-row flex-wrap gap-2">
-                {availableTags.map((tagName) => (
-                  <Button
-                    label={templateTagsMapping[tagName].label}
-                    variant={
-                      selectedTags.includes(tagName) ? "primary" : "outline"
-                    }
-                    key={tagName}
-                    size="xs"
-                    onClick={() => handleTagClick(tagName)}
-                  />
-                ))}
-              </div>
+              {hasFeature("agent_to_yaml") && (
+                <Button
+                  icon={
+                    isUploadingYAML
+                      ? () => <Spinner size="xs" />
+                      : FolderOpenIcon
+                  }
+                  label={isUploadingYAML ? "Uploading..." : "Upload from YAML"}
+                  data-gtm-label="yamlUploadButton"
+                  data-gtm-location="assistantCreationPage"
+                  size="md"
+                  variant="outline"
+                  disabled={isUploadingYAML}
+                  onClick={triggerYAMLUpload}
+                />
+              )}
             </div>
-            {filteredTemplates.length > 0 && (
-              <>
-                <Page.Separator />
-                <div className="flex flex-col pb-56">
-                  <AgentTemplateGrid
-                    templates={filteredTemplates}
-                    openTemplateModal={openTemplateModal}
-                    templateTagsMapping={templateTagsMapping}
-                    selectedTags={selectedTags}
-                  />
-                </div>
-              </>
-            )}
           </div>
-        </Page>
-        <AgentTemplateModal
-          owner={owner}
-          templateId={selectedTemplateId}
-          onClose={closeTemplateModal}
-        />
-      </div>
-    </AppContentLayout>
+
+          <Page.Separator />
+
+          <div className="flex flex-row items-center gap-2">
+            <Icon
+              visual={MagicIcon}
+              size="lg"
+              className="text-primary-400 dark:text-primary-500"
+            />
+            <Page.Header title="Start from a template" />
+          </div>
+
+          <div className="flex flex-col gap-6">
+            <SearchInput
+              placeholder="Search templates"
+              name="input"
+              value={searchTerm}
+              onChange={setSearchTerm}
+            />
+            <div className="flex flex-row flex-wrap gap-2">
+              {availableTags.map((tagName) => (
+                <Button
+                  label={templateTagsMapping[tagName].label}
+                  variant={
+                    selectedTags.includes(tagName) ? "primary" : "outline"
+                  }
+                  key={tagName}
+                  size="xs"
+                  onClick={() => handleTagClick(tagName)}
+                />
+              ))}
+            </div>
+          </div>
+          {filteredTemplates.length > 0 && (
+            <>
+              <Page.Separator />
+              <div className="flex flex-col pb-56">
+                <AgentTemplateGrid
+                  templates={filteredTemplates}
+                  openTemplateModal={openTemplateModal}
+                  templateTagsMapping={templateTagsMapping}
+                  selectedTags={selectedTags}
+                />
+              </div>
+            </>
+          )}
+        </div>
+      </Page>
+      <AgentTemplateModal
+        owner={owner}
+        templateId={selectedTemplateId}
+        onClose={closeTemplateModal}
+      />
+    </div>
   );
 }

--- a/front/components/pages/builder/agents/CreateAgentPage.tsx
+++ b/front/components/pages/builder/agents/CreateAgentPage.tsx
@@ -9,13 +9,18 @@ import {
   SearchInput,
   Spinner,
 } from "@dust-tt/sparkle";
+import type { ReactNode } from "react";
 import { useMemo, useState } from "react";
 
 import { AgentTemplateGrid } from "@app/components/agent_builder/AgentTemplateGrid";
 import { AgentTemplateModal } from "@app/components/agent_builder/AgentTemplateModal";
 import { getUniqueTemplateTags } from "@app/components/agent_builder/utils";
 import { appLayoutBack } from "@app/components/sparkle/AppContentLayout";
-import { useAppLayoutConfig } from "@app/components/sparkle/AppLayoutContext";
+import {
+  useSetContentWidth,
+  useSetHideSidebar,
+  useSetTitle,
+} from "@app/components/sparkle/AppLayoutContext";
 import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { useYAMLUpload } from "@app/hooks/useYAMLUpload";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
@@ -99,21 +104,21 @@ export function CreateAgentPage() {
     );
   };
 
-  useAppLayoutConfig(
-    () => ({
-      contentWidth: "centered",
-      hideSidebar: true,
-      title: (
-        <AppLayoutSimpleCloseTitle
-          title="Create an Agent"
-          onClose={async () => {
-            await appLayoutBack(owner, router);
-          }}
-        />
-      ),
-    }),
+  const title: ReactNode = useMemo(
+    () => (
+      <AppLayoutSimpleCloseTitle
+        title="Create an Agent"
+        onClose={async () => {
+          await appLayoutBack(owner, router);
+        }}
+      />
+    ),
     [owner, router]
   );
+
+  useSetContentWidth("centered");
+  useSetHideSidebar(true);
+  useSetTitle(title);
 
   return (
     <div id="pageContent">

--- a/front/components/pages/builder/agents/ManageAgentsPage.tsx
+++ b/front/components/pages/builder/agents/ManageAgentsPage.tsx
@@ -21,7 +21,10 @@ import { AgentDetails } from "@app/components/assistant/details/AgentDetails";
 import { AssistantsTable } from "@app/components/assistant/manager/AssistantsTable";
 import { TagsFilterMenu } from "@app/components/assistant/TagsFilterMenu";
 import { EmptyCallToAction } from "@app/components/EmptyCallToAction";
-import { useAppLayoutConfig } from "@app/components/sparkle/AppLayoutContext";
+import {
+  useSetContentWidth,
+  useSetNavChildren,
+} from "@app/components/sparkle/AppLayoutContext";
 import { useHashParam } from "@app/hooks/useHashParams";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
@@ -271,13 +274,13 @@ export function ManageAgentsPage() {
     };
   }, [isFeatureFlagsLoading, isRestrictedFromAgentCreation]);
 
-  useAppLayoutConfig(
-    () => ({
-      contentWidth: "wide",
-      navChildren: <AgentSidebarMenu owner={owner} />,
-    }),
+  const navChildren = useMemo(
+    () => <AgentSidebarMenu owner={owner} />,
     [owner]
   );
+
+  useSetContentWidth("wide");
+  useSetNavChildren(navChildren);
 
   return (
     <>

--- a/front/components/pages/builder/agents/ManageAgentsPage.tsx
+++ b/front/components/pages/builder/agents/ManageAgentsPage.tsx
@@ -21,7 +21,7 @@ import { AgentDetails } from "@app/components/assistant/details/AgentDetails";
 import { AssistantsTable } from "@app/components/assistant/manager/AssistantsTable";
 import { TagsFilterMenu } from "@app/components/assistant/TagsFilterMenu";
 import { EmptyCallToAction } from "@app/components/EmptyCallToAction";
-import { AppContentLayout } from "@app/components/sparkle/AppContentLayout";
+import { useAppLayoutConfig } from "@app/components/sparkle/AppLayoutContext";
 import { useHashParam } from "@app/hooks/useHashParams";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
@@ -82,7 +82,7 @@ function isValidTab(tab: string): tab is AssistantManagerTabsType {
 
 export function ManageAgentsPage() {
   const owner = useWorkspace();
-  const { subscription, user, isBuilder } = useAuth();
+  const { user, isBuilder } = useAuth();
   const [assistantSearch, setAssistantSearch] = useState("");
   const [showDisabledFreeWorkspacePopup, setShowDisabledFreeWorkspacePopup] =
     useState<string | null>(null);
@@ -271,13 +271,16 @@ export function ManageAgentsPage() {
     };
   }, [isFeatureFlagsLoading, isRestrictedFromAgentCreation]);
 
+  useAppLayoutConfig(
+    () => ({
+      contentWidth: "wide",
+      navChildren: <AgentSidebarMenu owner={owner} />,
+    }),
+    [owner]
+  );
+
   return (
-    <AppContentLayout
-      contentWidth="wide"
-      subscription={subscription}
-      owner={owner}
-      navChildren={<AgentSidebarMenu owner={owner} />}
-    >
+    <>
       {isFeatureFlagsLoading ? (
         <div className="flex h-full items-center justify-center">
           <Spinner size="lg" />
@@ -436,6 +439,6 @@ export function ManageAgentsPage() {
           </div>
         </>
       )}
-    </AppContentLayout>
+    </>
   );
 }

--- a/front/components/pages/builder/skills/ManageSkillsPage.tsx
+++ b/front/components/pages/builder/skills/ManageSkillsPage.tsx
@@ -16,7 +16,10 @@ import { AgentDetails } from "@app/components/assistant/details/AgentDetails";
 import { SkillDetailsSheet } from "@app/components/skills/SkillDetailsSheet";
 import { SkillsTable } from "@app/components/skills/SkillsTable";
 import { SuggestedSkillsSection } from "@app/components/skills/SuggestedSkillsSection";
-import { useAppLayoutConfig } from "@app/components/sparkle/AppLayoutContext";
+import {
+  useSetContentWidth,
+  useSetNavChildren,
+} from "@app/components/sparkle/AppLayoutContext";
 import { useHashParam } from "@app/hooks/useHashParams";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import { Head } from "@app/lib/platform";
@@ -193,13 +196,13 @@ export function ManageSkillsPage() {
     };
   }, []);
 
-  useAppLayoutConfig(
-    () => ({
-      contentWidth: "wide",
-      navChildren: <AgentSidebarMenu owner={owner} />,
-    }),
+  const navChildren = useMemo(
+    () => <AgentSidebarMenu owner={owner} />,
     [owner]
   );
+
+  useSetContentWidth("wide");
+  useSetNavChildren(navChildren);
 
   return (
     <>

--- a/front/components/pages/builder/skills/ManageSkillsPage.tsx
+++ b/front/components/pages/builder/skills/ManageSkillsPage.tsx
@@ -16,7 +16,7 @@ import { AgentDetails } from "@app/components/assistant/details/AgentDetails";
 import { SkillDetailsSheet } from "@app/components/skills/SkillDetailsSheet";
 import { SkillsTable } from "@app/components/skills/SkillsTable";
 import { SuggestedSkillsSection } from "@app/components/skills/SuggestedSkillsSection";
-import { AppContentLayout } from "@app/components/sparkle/AppContentLayout";
+import { useAppLayoutConfig } from "@app/components/sparkle/AppLayoutContext";
 import { useHashParam } from "@app/hooks/useHashParams";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import { Head } from "@app/lib/platform";
@@ -75,7 +75,7 @@ function sortSkillsByName(skills: SkillWithRelationsType[]) {
 
 export function ManageSkillsPage() {
   const owner = useWorkspace();
-  const { user, subscription } = useAuth();
+  const { user } = useAuth();
   const [selectedSkill, setSelectedSkill] =
     useState<SkillWithRelationsType | null>(null);
   const [agentId, setAgentId] = useState<string | null>(null);
@@ -193,13 +193,16 @@ export function ManageSkillsPage() {
     };
   }, []);
 
+  useAppLayoutConfig(
+    () => ({
+      contentWidth: "wide",
+      navChildren: <AgentSidebarMenu owner={owner} />,
+    }),
+    [owner]
+  );
+
   return (
-    <AppContentLayout
-      contentWidth="wide"
-      subscription={subscription}
-      owner={owner}
-      navChildren={<AgentSidebarMenu owner={owner} />}
-    >
+    <>
       <SkillDetailsSheet
         skill={selectedSkill}
         onClose={() => handleSkillSelect(null)}
@@ -281,6 +284,6 @@ export function ManageSkillsPage() {
           </div>
         </Page.Vertical>
       </div>
-    </AppContentLayout>
+    </>
   );
 }

--- a/front/components/pages/spaces/apps/AppSettingsPage.tsx
+++ b/front/components/pages/spaces/apps/AppSettingsPage.tsx
@@ -19,7 +19,7 @@ export function AppSettingsPage() {
   const spaceId = useRequiredPathParam("spaceId");
   const aId = useRequiredPathParam("aId");
   const owner = useWorkspace();
-  const { subscription, isBuilder } = useAuth();
+  const { isBuilder } = useAuth();
 
   const { spaceInfo: space, isSpaceInfoLoading } = useSpaceInfo({
     workspaceId: owner.sId,
@@ -159,12 +159,7 @@ export function AppSettingsPage() {
   }
 
   return (
-    <DustAppPageLayout
-      owner={owner}
-      subscription={subscription}
-      app={app}
-      currentTab="settings"
-    >
+    <DustAppPageLayout app={app} currentTab="settings">
       <div className="mt-8 flex flex-1">
         <div className="flex flex-col">
           <div className="flex flex-col gap-6">

--- a/front/components/pages/spaces/apps/AppSpecificationPage.tsx
+++ b/front/components/pages/spaces/apps/AppSpecificationPage.tsx
@@ -2,7 +2,11 @@ import { Spinner, Tabs, TabsList, TabsTrigger } from "@dust-tt/sparkle";
 import { useMemo } from "react";
 
 import { subNavigationApp } from "@app/components/navigation/config";
-import { useAppLayoutConfig } from "@app/components/sparkle/AppLayoutContext";
+import {
+  useSetContentWidth,
+  useSetHideSidebar,
+  useSetTitle,
+} from "@app/components/sparkle/AppLayoutContext";
 import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { useAppRouter, useRequiredPathParam } from "@app/lib/platform";
@@ -42,11 +46,9 @@ export function AppSpecificationPage() {
     }
   }, [app]);
 
-  useAppLayoutConfig(
-    () => ({
-      contentWidth: "centered",
-      hideSidebar: true,
-      title: app ? (
+  const title = useMemo(
+    () =>
+      app ? (
         <AppLayoutSimpleCloseTitle
           title={app.name}
           onClose={() => {
@@ -54,9 +56,12 @@ export function AppSpecificationPage() {
           }}
         />
       ) : undefined,
-    }),
     [owner, app, router]
   );
+
+  useSetContentWidth("centered");
+  useSetHideSidebar(true);
+  useSetTitle(title);
 
   return (
     <>

--- a/front/components/pages/spaces/apps/AppSpecificationPage.tsx
+++ b/front/components/pages/spaces/apps/AppSpecificationPage.tsx
@@ -2,9 +2,9 @@ import { Spinner, Tabs, TabsList, TabsTrigger } from "@dust-tt/sparkle";
 import { useMemo } from "react";
 
 import { subNavigationApp } from "@app/components/navigation/config";
-import { AppContentLayout } from "@app/components/sparkle/AppContentLayout";
+import { useAppLayoutConfig } from "@app/components/sparkle/AppLayoutContext";
 import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
-import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
+import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { useAppRouter, useRequiredPathParam } from "@app/lib/platform";
 import { dustAppsListUrl } from "@app/lib/spaces";
 import { dumpSpecification } from "@app/lib/specification";
@@ -17,7 +17,6 @@ export function AppSpecificationPage() {
   const spaceId = useRequiredPathParam("spaceId");
   const aId = useRequiredPathParam("aId");
   const owner = useWorkspace();
-  const { subscription } = useAuth();
 
   const { app, isAppLoading, isAppError } = useApp({
     workspaceId: owner.sId,
@@ -43,23 +42,24 @@ export function AppSpecificationPage() {
     }
   }, [app]);
 
+  useAppLayoutConfig(
+    () => ({
+      contentWidth: "centered",
+      hideSidebar: true,
+      title: app ? (
+        <AppLayoutSimpleCloseTitle
+          title={app.name}
+          onClose={() => {
+            void router.push(dustAppsListUrl(owner, app.space));
+          }}
+        />
+      ) : undefined,
+    }),
+    [owner, app, router]
+  );
+
   return (
-    <AppContentLayout
-      contentWidth="centered"
-      subscription={subscription}
-      owner={owner}
-      hideSidebar
-      title={
-        app ? (
-          <AppLayoutSimpleCloseTitle
-            title={app.name}
-            onClose={() => {
-              void router.push(dustAppsListUrl(owner, app.space));
-            }}
-          />
-        ) : undefined
-      }
-    >
+    <>
       {isAppError || (!isAppLoading && !app) ? (
         <Custom404 />
       ) : isAppLoading || !app ? (
@@ -95,6 +95,6 @@ export function AppSpecificationPage() {
           </div>
         </div>
       )}
-    </AppContentLayout>
+    </>
   );
 }

--- a/front/components/pages/spaces/apps/AppViewPage.tsx
+++ b/front/components/pages/spaces/apps/AppViewPage.tsx
@@ -101,7 +101,7 @@ export function AppViewPage() {
   const spaceId = useRequiredPathParam("spaceId");
   const aId = useRequiredPathParam("aId");
   const owner = useWorkspace();
-  const { subscription, isAdmin, isBuilder } = useAuth();
+  const { isAdmin, isBuilder } = useAuth();
   const readOnly = !isBuilder;
 
   const { app, isAppLoading, isAppError } = useApp({
@@ -361,12 +361,7 @@ export function AppViewPage() {
   }
 
   return (
-    <DustAppPageLayout
-      owner={owner}
-      subscription={subscription}
-      app={app}
-      currentTab="specification"
-    >
+    <DustAppPageLayout app={app} currentTab="specification">
       <div className="mt-8 flex flex-auto flex-col">
         <div className="mb-4 flex flex-row items-center space-x-2">
           <NewBlock

--- a/front/components/pages/spaces/apps/DatasetPage.tsx
+++ b/front/components/pages/spaces/apps/DatasetPage.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from "react";
 
 import DatasetView from "@app/components/app/DatasetView";
 import { subNavigationApp } from "@app/components/navigation/config";
-import { AppContentLayout } from "@app/components/sparkle/AppContentLayout";
+import { useAppLayoutConfig } from "@app/components/sparkle/AppLayoutContext";
 import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
@@ -23,7 +23,7 @@ export function DatasetPage() {
   const aId = useRequiredPathParam("aId");
   const name = useRequiredPathParam("name");
   const owner = useWorkspace();
-  const { subscription, isBuilder } = useAuth();
+  const { isBuilder } = useAuth();
   const readOnly = !isBuilder;
 
   const { app, isAppLoading } = useApp({
@@ -129,23 +129,24 @@ export function DatasetPage() {
 
   const isLoading = isAppLoading || isDatasetLoading;
 
+  useAppLayoutConfig(
+    () => ({
+      contentWidth: "centered",
+      hideSidebar: true,
+      title: app ? (
+        <AppLayoutSimpleCloseTitle
+          title={app.name}
+          onClose={() => {
+            void router.push(dustAppsListUrl(owner, app.space));
+          }}
+        />
+      ) : undefined,
+    }),
+    [owner, app, router]
+  );
+
   return (
-    <AppContentLayout
-      contentWidth="centered"
-      subscription={subscription}
-      owner={owner}
-      hideSidebar
-      title={
-        app ? (
-          <AppLayoutSimpleCloseTitle
-            title={app.name}
-            onClose={() => {
-              void router.push(dustAppsListUrl(owner, app.space));
-            }}
-          />
-        ) : undefined
-      }
-    >
+    <>
       {isDatasetError || (!isLoading && app && !dataset) ? (
         <Custom404 />
       ) : isLoading || !app || !dataset || !updatedDataset ? (
@@ -205,6 +206,6 @@ export function DatasetPage() {
           </div>
         </div>
       )}
-    </AppContentLayout>
+    </>
   );
 }

--- a/front/components/pages/spaces/apps/DatasetPage.tsx
+++ b/front/components/pages/spaces/apps/DatasetPage.tsx
@@ -1,11 +1,15 @@
 import "@uiw/react-textarea-code-editor/dist.css";
 
 import { Button, Spinner, Tabs, TabsList, TabsTrigger } from "@dust-tt/sparkle";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import DatasetView from "@app/components/app/DatasetView";
 import { subNavigationApp } from "@app/components/navigation/config";
-import { useAppLayoutConfig } from "@app/components/sparkle/AppLayoutContext";
+import {
+  useSetContentWidth,
+  useSetHideSidebar,
+  useSetTitle,
+} from "@app/components/sparkle/AppLayoutContext";
 import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
@@ -129,11 +133,9 @@ export function DatasetPage() {
 
   const isLoading = isAppLoading || isDatasetLoading;
 
-  useAppLayoutConfig(
-    () => ({
-      contentWidth: "centered",
-      hideSidebar: true,
-      title: app ? (
+  const title = useMemo(
+    () =>
+      app ? (
         <AppLayoutSimpleCloseTitle
           title={app.name}
           onClose={() => {
@@ -141,9 +143,12 @@ export function DatasetPage() {
           }}
         />
       ) : undefined,
-    }),
     [owner, app, router]
   );
+
+  useSetContentWidth("centered");
+  useSetHideSidebar(true);
+  useSetTitle(title);
 
   return (
     <>

--- a/front/components/pages/spaces/apps/DatasetsPage.tsx
+++ b/front/components/pages/spaces/apps/DatasetsPage.tsx
@@ -20,7 +20,7 @@ export function DatasetsPage() {
   const spaceId = useRequiredPathParam("spaceId");
   const aId = useRequiredPathParam("aId");
   const owner = useWorkspace();
-  const { subscription, isBuilder } = useAuth();
+  const { isBuilder } = useAuth();
 
   const { app, isAppLoading, isAppError } = useApp({
     workspaceId: owner.sId,
@@ -79,12 +79,7 @@ export function DatasetsPage() {
   }
 
   return (
-    <DustAppPageLayout
-      owner={owner}
-      subscription={subscription}
-      app={app}
-      currentTab="datasets"
-    >
+    <DustAppPageLayout app={app} currentTab="datasets">
       <div className="mt-8 flex flex-col">
         <div className="flex flex-1">
           <div className="mb-4 flex flex-auto flex-col gap-y-4">

--- a/front/components/pages/spaces/apps/NewDatasetPage.tsx
+++ b/front/components/pages/spaces/apps/NewDatasetPage.tsx
@@ -19,7 +19,7 @@ export function NewDatasetPage() {
   const spaceId = useRequiredPathParam("spaceId");
   const aId = useRequiredPathParam("aId");
   const owner = useWorkspace();
-  const { subscription, isBuilder } = useAuth();
+  const { isBuilder } = useAuth();
 
   const { app, isAppLoading, isAppError } = useApp({
     workspaceId: owner.sId,
@@ -120,12 +120,7 @@ export function NewDatasetPage() {
   }
 
   return (
-    <DustAppPageLayout
-      owner={owner}
-      subscription={subscription}
-      app={app}
-      currentTab="datasets"
-    >
+    <DustAppPageLayout app={app} currentTab="datasets">
       <div className="mt-8 flex flex-col">
         <div className="flex flex-1">
           <div className="space-y-6 divide-y divide-gray-200 dark:divide-gray-200-night">

--- a/front/components/pages/spaces/apps/RunPage.tsx
+++ b/front/components/pages/spaces/apps/RunPage.tsx
@@ -17,7 +17,7 @@ export function RunPage() {
   const aId = useRequiredPathParam("aId");
   const runId = useRequiredPathParam("runId");
   const owner = useWorkspace();
-  const { subscription, isAdmin, isBuilder } = useAuth();
+  const { isAdmin, isBuilder } = useAuth();
 
   const { app, isAppLoading, isAppError } = useApp({
     workspaceId: owner.sId,
@@ -98,12 +98,7 @@ export function RunPage() {
   }
 
   return (
-    <DustAppPageLayout
-      owner={owner}
-      subscription={subscription}
-      app={app}
-      currentTab="runs"
-    >
+    <DustAppPageLayout app={app} currentTab="runs">
       <div className="mt-8 flex flex-col">
         <div className="mb-4 flex flex-row items-center justify-between space-x-2 text-sm">
           <div className="flex flex-col items-start">

--- a/front/components/pages/spaces/apps/RunsPage.tsx
+++ b/front/components/pages/spaces/apps/RunsPage.tsx
@@ -34,7 +34,7 @@ export function RunsPage() {
   const aId = useRequiredPathParam("aId");
   const wIdTarget = useSearchParam("wIdTarget");
   const owner = useWorkspace();
-  const { subscription, isBuilder } = useAuth();
+  const { isBuilder } = useAuth();
 
   const readOnly = !isBuilder;
 
@@ -90,12 +90,7 @@ export function RunsPage() {
   }
 
   return (
-    <DustAppPageLayout
-      owner={owner}
-      subscription={subscription}
-      app={app}
-      currentTab="runs"
-    >
+    <DustAppPageLayout app={app} currentTab="runs">
       <div className="mt-8 flex">
         <nav className="flex" aria-label="Tabs">
           {tabs.map((tab, tabIdx) => (

--- a/front/components/pages/workspace/ProfilePage.tsx
+++ b/front/components/pages/workspace/ProfilePage.tsx
@@ -16,63 +16,63 @@ import { AccountSettings } from "@app/components/me/AccountSettings";
 import { PendingInvitationsTable } from "@app/components/me/PendingInvitationsTable";
 import { ProfileTriggersTab } from "@app/components/me/ProfileTriggersTab";
 import { UserToolsTable } from "@app/components/me/UserToolsTable";
-import { AppContentLayout } from "@app/components/sparkle/AppContentLayout";
-import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
+import { useAppLayoutConfig } from "@app/components/sparkle/AppLayoutContext";
+import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { usePendingInvitations } from "@app/lib/swr/user";
 
 export function ProfilePage() {
   const owner = useWorkspace();
-  const { subscription } = useAuth();
   const { pendingInvitations, isPendingInvitationsLoading } =
     usePendingInvitations({
       workspaceId: owner.sId,
     });
 
+  useAppLayoutConfig(
+    () => ({
+      contentWidth: "centered",
+      pageTitle: "Dust - Profile",
+      navChildren: <AgentSidebarMenu owner={owner} />,
+    }),
+    [owner]
+  );
+
   return (
-    <AppContentLayout
-      contentWidth="centered"
-      subscription={subscription}
-      owner={owner}
-      pageTitle="Dust - Profile"
-      navChildren={<AgentSidebarMenu owner={owner} />}
-    >
-      <Page>
-        <Page.Header title="Profile Settings" icon={UserIcon} />
-        <Page.Layout direction="vertical">
-          <Page.SectionHeader title="Account Settings" />
-          <AccountSettings owner={owner} />
+    <Page>
+      <Page.Header title="Profile Settings" icon={UserIcon} />
+      <Page.Layout direction="vertical">
+        <Page.SectionHeader title="Account Settings" />
+        <AccountSettings owner={owner} />
 
-          {isPendingInvitationsLoading ? (
-            <div className="flex justify-center py-4">
-              <Spinner />
-            </div>
-          ) : (
-            pendingInvitations.length > 0 && (
-              <>
-                <Separator />
-                <Page.SectionHeader title="Pending Invitations" />
-                <PendingInvitationsTable invitations={pendingInvitations} />
-              </>
-            )
-          )}
+        {isPendingInvitationsLoading ? (
+          <div className="flex justify-center py-4">
+            <Spinner />
+          </div>
+        ) : (
+          pendingInvitations.length > 0 && (
+            <>
+              <Separator />
+              <Page.SectionHeader title="Pending Invitations" />
+              <PendingInvitationsTable invitations={pendingInvitations} />
+            </>
+          )
+        )}
 
-          <Separator />
+        <Separator />
 
-          <Page.SectionHeader title="Tools & Triggers" />
-          <Tabs defaultValue="tools" className="w-full">
-            <TabsList>
-              <TabsTrigger value="tools" label="Tools" icon={BoltIcon} />
-              <TabsTrigger value="triggers" label="Triggers" icon={BellIcon} />
-            </TabsList>
-            <TabsContent value="tools" className="mt-4">
-              <UserToolsTable owner={owner} />
-            </TabsContent>
-            <TabsContent value="triggers" className="mt-4">
-              <ProfileTriggersTab owner={owner} />
-            </TabsContent>
-          </Tabs>
-        </Page.Layout>
-      </Page>
-    </AppContentLayout>
+        <Page.SectionHeader title="Tools & Triggers" />
+        <Tabs defaultValue="tools" className="w-full">
+          <TabsList>
+            <TabsTrigger value="tools" label="Tools" icon={BoltIcon} />
+            <TabsTrigger value="triggers" label="Triggers" icon={BellIcon} />
+          </TabsList>
+          <TabsContent value="tools" className="mt-4">
+            <UserToolsTable owner={owner} />
+          </TabsContent>
+          <TabsContent value="triggers" className="mt-4">
+            <ProfileTriggersTab owner={owner} />
+          </TabsContent>
+        </Tabs>
+      </Page.Layout>
+    </Page>
   );
 }

--- a/front/components/pages/workspace/ProfilePage.tsx
+++ b/front/components/pages/workspace/ProfilePage.tsx
@@ -10,13 +10,18 @@ import {
   TabsTrigger,
   UserIcon,
 } from "@dust-tt/sparkle";
+import { useMemo } from "react";
 
 import { AgentSidebarMenu } from "@app/components/assistant/conversation/SidebarMenu";
 import { AccountSettings } from "@app/components/me/AccountSettings";
 import { PendingInvitationsTable } from "@app/components/me/PendingInvitationsTable";
 import { ProfileTriggersTab } from "@app/components/me/ProfileTriggersTab";
 import { UserToolsTable } from "@app/components/me/UserToolsTable";
-import { useAppLayoutConfig } from "@app/components/sparkle/AppLayoutContext";
+import {
+  useSetContentWidth,
+  useSetNavChildren,
+  useSetPageTitle,
+} from "@app/components/sparkle/AppLayoutContext";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { usePendingInvitations } from "@app/lib/swr/user";
 
@@ -27,14 +32,14 @@ export function ProfilePage() {
       workspaceId: owner.sId,
     });
 
-  useAppLayoutConfig(
-    () => ({
-      contentWidth: "centered",
-      pageTitle: "Dust - Profile",
-      navChildren: <AgentSidebarMenu owner={owner} />,
-    }),
+  const navChildren = useMemo(
+    () => <AgentSidebarMenu owner={owner} />,
     [owner]
   );
+
+  useSetContentWidth("centered");
+  useSetPageTitle("Dust - Profile");
+  useSetNavChildren(navChildren);
 
   return (
     <Page>

--- a/front/components/pages/workspace/labs/LabsPage.tsx
+++ b/front/components/pages/workspace/labs/LabsPage.tsx
@@ -9,7 +9,7 @@ import {
 
 import { AgentSidebarMenu } from "@app/components/assistant/conversation/SidebarMenu";
 import { FeatureAccessButton } from "@app/components/labs/FeatureAccessButton";
-import { AppContentLayout } from "@app/components/sparkle/AppContentLayout";
+import { useAppLayoutConfig } from "@app/components/sparkle/AppLayoutContext";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import type { LabsFeatureItemType } from "@app/types/labs";
@@ -46,19 +46,22 @@ const getVisibleFeatures = (featureFlags: WhitelistableFeature[]) => {
 
 export function LabsPage() {
   const owner = useWorkspace();
-  const { subscription, isAdmin } = useAuth();
+  const { isAdmin } = useAuth();
   const { featureFlags } = useFeatureFlags({ workspaceId: owner.sId });
 
   const visibleFeatures = getVisibleFeatures(featureFlags);
 
+  useAppLayoutConfig(
+    () => ({
+      contentWidth: "centered",
+      pageTitle: "Dust - Exploratory features",
+      navChildren: <AgentSidebarMenu owner={owner} />,
+    }),
+    [owner]
+  );
+
   return (
-    <AppContentLayout
-      contentWidth="centered"
-      subscription={subscription}
-      owner={owner}
-      pageTitle="Dust - Exploratory features"
-      navChildren={<AgentSidebarMenu owner={owner} />}
-    >
+    <>
       <Page.Header
         title="Exploratory features"
         icon={TestTubeIcon}
@@ -92,6 +95,6 @@ export function LabsPage() {
           ))}
         </ContextItem.List>
       </Page.Layout>
-    </AppContentLayout>
+    </>
   );
 }

--- a/front/components/pages/workspace/labs/LabsPage.tsx
+++ b/front/components/pages/workspace/labs/LabsPage.tsx
@@ -6,10 +6,15 @@ import {
   Page,
   TestTubeIcon,
 } from "@dust-tt/sparkle";
+import { useMemo } from "react";
 
 import { AgentSidebarMenu } from "@app/components/assistant/conversation/SidebarMenu";
 import { FeatureAccessButton } from "@app/components/labs/FeatureAccessButton";
-import { useAppLayoutConfig } from "@app/components/sparkle/AppLayoutContext";
+import {
+  useSetContentWidth,
+  useSetNavChildren,
+  useSetPageTitle,
+} from "@app/components/sparkle/AppLayoutContext";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import type { LabsFeatureItemType } from "@app/types/labs";
@@ -51,14 +56,14 @@ export function LabsPage() {
 
   const visibleFeatures = getVisibleFeatures(featureFlags);
 
-  useAppLayoutConfig(
-    () => ({
-      contentWidth: "centered",
-      pageTitle: "Dust - Exploratory features",
-      navChildren: <AgentSidebarMenu owner={owner} />,
-    }),
+  const navChildren = useMemo(
+    () => <AgentSidebarMenu owner={owner} />,
     [owner]
   );
+
+  useSetContentWidth("centered");
+  useSetPageTitle("Dust - Exploratory features");
+  useSetNavChildren(navChildren);
 
   return (
     <>

--- a/front/components/pages/workspace/labs/TranscriptsPage.tsx
+++ b/front/components/pages/workspace/labs/TranscriptsPage.tsx
@@ -1,12 +1,16 @@
 import { BookOpenIcon, Breadcrumbs, Page, Spinner } from "@dust-tt/sparkle";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import { AgentSidebarMenu } from "@app/components/assistant/conversation/SidebarMenu";
 import { DeleteProviderDialog } from "@app/components/labs/transcripts/DeleteProviderDialog";
 import { ProcessingConfiguration } from "@app/components/labs/transcripts/ProcessingConfiguration";
 import { ProviderSelection } from "@app/components/labs/transcripts/ProviderSelection";
 import { StorageConfiguration } from "@app/components/labs/transcripts/StorageConfiguration";
-import { useAppLayoutConfig } from "@app/components/sparkle/AppLayoutContext";
+import {
+  useSetContentWidth,
+  useSetNavChildren,
+  useSetPageTitle,
+} from "@app/components/sparkle/AppLayoutContext";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
@@ -106,14 +110,14 @@ export function TranscriptsPage() {
     isFeatureFlagsLoading ||
     !featureFlags.includes("labs_transcripts");
 
-  useAppLayoutConfig(
-    () => ({
-      contentWidth: "centered",
-      pageTitle: "Dust - Transcripts processing",
-      navChildren: <AgentSidebarMenu owner={owner} />,
-    }),
+  const navChildren = useMemo(
+    () => <AgentSidebarMenu owner={owner} />,
     [owner]
   );
+
+  useSetContentWidth("centered");
+  useSetPageTitle("Dust - Transcripts processing");
+  useSetNavChildren(navChildren);
 
   return (
     <>

--- a/front/components/pages/workspace/labs/TranscriptsPage.tsx
+++ b/front/components/pages/workspace/labs/TranscriptsPage.tsx
@@ -6,9 +6,9 @@ import { DeleteProviderDialog } from "@app/components/labs/transcripts/DeletePro
 import { ProcessingConfiguration } from "@app/components/labs/transcripts/ProcessingConfiguration";
 import { ProviderSelection } from "@app/components/labs/transcripts/ProviderSelection";
 import { StorageConfiguration } from "@app/components/labs/transcripts/StorageConfiguration";
-import { AppContentLayout } from "@app/components/sparkle/AppContentLayout";
+import { useAppLayoutConfig } from "@app/components/sparkle/AppLayoutContext";
 import { useSendNotification } from "@app/hooks/useNotification";
-import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
+import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
 import { useAppRouter } from "@app/lib/platform";
 import { useAgentConfigurations } from "@app/lib/swr/assistants";
@@ -20,7 +20,6 @@ import { isProviderWithDefaultWorkspaceConfiguration } from "@app/types/oauth/li
 
 export function TranscriptsPage() {
   const owner = useWorkspace();
-  const { subscription } = useAuth();
   const router = useAppRouter();
 
   const { featureFlags, isFeatureFlagsLoading } = useFeatureFlags({
@@ -107,14 +106,17 @@ export function TranscriptsPage() {
     isFeatureFlagsLoading ||
     !featureFlags.includes("labs_transcripts");
 
+  useAppLayoutConfig(
+    () => ({
+      contentWidth: "centered",
+      pageTitle: "Dust - Transcripts processing",
+      navChildren: <AgentSidebarMenu owner={owner} />,
+    }),
+    [owner]
+  );
+
   return (
-    <AppContentLayout
-      contentWidth="centered"
-      subscription={subscription}
-      owner={owner}
-      pageTitle="Dust - Transcripts processing"
-      navChildren={<AgentSidebarMenu owner={owner} />}
-    >
+    <>
       {isLoading ? (
         <div className="flex h-full items-center justify-center">
           <Spinner />
@@ -179,6 +181,6 @@ export function TranscriptsPage() {
           </Page>
         </>
       )}
-    </AppContentLayout>
+    </>
   );
 }

--- a/front/components/pages/workspace/labs/mcp_actions/AgentMCPActionsPage.tsx
+++ b/front/components/pages/workspace/labs/mcp_actions/AgentMCPActionsPage.tsx
@@ -11,10 +11,14 @@ import {
   Pagination,
   Spinner,
 } from "@dust-tt/sparkle";
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 
 import { AgentSidebarMenu } from "@app/components/assistant/conversation/SidebarMenu";
-import { useAppLayoutConfig } from "@app/components/sparkle/AppLayoutContext";
+import {
+  useSetContentWidth,
+  useSetNavChildren,
+  useSetPageTitle,
+} from "@app/components/sparkle/AppLayoutContext";
 import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { useAppRouter, usePathParams } from "@app/lib/platform";
@@ -113,16 +117,18 @@ export function AgentMCPActionsPage() {
     isAgentConfigurationLoading ||
     !agent;
 
-  useAppLayoutConfig(
-    () => ({
-      contentWidth: "centered",
-      pageTitle: agent
-        ? `Dust - MCP Actions for ${agent.name}`
-        : "Dust - MCP Actions",
-      navChildren: <AgentSidebarMenu owner={owner} />,
-    }),
-    [owner, agent]
+  const pageTitle = agent
+    ? `Dust - MCP Actions for ${agent.name}`
+    : "Dust - MCP Actions";
+
+  const navChildren = useMemo(
+    () => <AgentSidebarMenu owner={owner} />,
+    [owner]
   );
+
+  useSetContentWidth("centered");
+  useSetPageTitle(pageTitle);
+  useSetNavChildren(navChildren);
 
   return (
     <>

--- a/front/components/pages/workspace/labs/mcp_actions/AgentMCPActionsPage.tsx
+++ b/front/components/pages/workspace/labs/mcp_actions/AgentMCPActionsPage.tsx
@@ -14,9 +14,9 @@ import {
 import { useCallback, useEffect } from "react";
 
 import { AgentSidebarMenu } from "@app/components/assistant/conversation/SidebarMenu";
-import { AppContentLayout } from "@app/components/sparkle/AppContentLayout";
+import { useAppLayoutConfig } from "@app/components/sparkle/AppLayoutContext";
 import type { ToolExecutionStatus } from "@app/lib/actions/statuses";
-import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
+import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { useAppRouter, usePathParams } from "@app/lib/platform";
 import { useAgentConfiguration } from "@app/lib/swr/assistants";
 import { useMCPActions } from "@app/lib/swr/mcp_actions";
@@ -26,7 +26,6 @@ import { isString } from "@app/types/shared/utils/general";
 
 export function AgentMCPActionsPage() {
   const owner = useWorkspace();
-  const { subscription } = useAuth();
   const router = useAppRouter();
   const { agentId } = usePathParams();
 
@@ -114,16 +113,19 @@ export function AgentMCPActionsPage() {
     isAgentConfigurationLoading ||
     !agent;
 
+  useAppLayoutConfig(
+    () => ({
+      contentWidth: "centered",
+      pageTitle: agent
+        ? `Dust - MCP Actions for ${agent.name}`
+        : "Dust - MCP Actions",
+      navChildren: <AgentSidebarMenu owner={owner} />,
+    }),
+    [owner, agent]
+  );
+
   return (
-    <AppContentLayout
-      contentWidth="centered"
-      subscription={subscription}
-      owner={owner}
-      pageTitle={
-        agent ? `Dust - MCP Actions for ${agent.name}` : "Dust - MCP Actions"
-      }
-      navChildren={<AgentSidebarMenu owner={owner} />}
-    >
+    <>
       {isPageLoading ? (
         <div className="flex h-full items-center justify-center">
           <Spinner />
@@ -284,6 +286,6 @@ export function AgentMCPActionsPage() {
           </Page>
         </>
       )}
-    </AppContentLayout>
+    </>
   );
 }

--- a/front/components/pages/workspace/labs/mcp_actions/MCPActionsDashboardPage.tsx
+++ b/front/components/pages/workspace/labs/mcp_actions/MCPActionsDashboardPage.tsx
@@ -11,10 +11,14 @@ import {
   RobotIcon,
   Spinner,
 } from "@dust-tt/sparkle";
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 
 import { AgentSidebarMenu } from "@app/components/assistant/conversation/SidebarMenu";
-import { useAppLayoutConfig } from "@app/components/sparkle/AppLayoutContext";
+import {
+  useSetContentWidth,
+  useSetNavChildren,
+  useSetPageTitle,
+} from "@app/components/sparkle/AppLayoutContext";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { useAppRouter } from "@app/lib/platform";
 import { useAgentConfigurations } from "@app/lib/swr/assistants";
@@ -67,14 +71,14 @@ export function MCPActionsDashboardPage() {
     isFeatureFlagsLoading ||
     !featureFlags.includes("labs_mcp_actions_dashboard");
 
-  useAppLayoutConfig(
-    () => ({
-      contentWidth: "centered",
-      pageTitle: "Dust - MCP Actions Dashboard",
-      navChildren: <AgentSidebarMenu owner={owner} />,
-    }),
+  const navChildren = useMemo(
+    () => <AgentSidebarMenu owner={owner} />,
     [owner]
   );
+
+  useSetContentWidth("centered");
+  useSetPageTitle("Dust - MCP Actions Dashboard");
+  useSetNavChildren(navChildren);
 
   return (
     <>

--- a/front/components/pages/workspace/labs/mcp_actions/MCPActionsDashboardPage.tsx
+++ b/front/components/pages/workspace/labs/mcp_actions/MCPActionsDashboardPage.tsx
@@ -14,15 +14,14 @@ import {
 import { useEffect } from "react";
 
 import { AgentSidebarMenu } from "@app/components/assistant/conversation/SidebarMenu";
-import { AppContentLayout } from "@app/components/sparkle/AppContentLayout";
-import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
+import { useAppLayoutConfig } from "@app/components/sparkle/AppLayoutContext";
+import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { useAppRouter } from "@app/lib/platform";
 import { useAgentConfigurations } from "@app/lib/swr/assistants";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
 
 export function MCPActionsDashboardPage() {
   const owner = useWorkspace();
-  const { subscription } = useAuth();
   const router = useAppRouter();
 
   const { featureFlags, isFeatureFlagsLoading } = useFeatureFlags({
@@ -68,14 +67,17 @@ export function MCPActionsDashboardPage() {
     isFeatureFlagsLoading ||
     !featureFlags.includes("labs_mcp_actions_dashboard");
 
+  useAppLayoutConfig(
+    () => ({
+      contentWidth: "centered",
+      pageTitle: "Dust - MCP Actions Dashboard",
+      navChildren: <AgentSidebarMenu owner={owner} />,
+    }),
+    [owner]
+  );
+
   return (
-    <AppContentLayout
-      contentWidth="centered"
-      subscription={subscription}
-      owner={owner}
-      pageTitle="Dust - MCP Actions Dashboard"
-      navChildren={<AgentSidebarMenu owner={owner} />}
-    >
+    <>
       {isLoading ? (
         <div className="flex h-full items-center justify-center">
           <Spinner />
@@ -158,6 +160,6 @@ export function MCPActionsDashboardPage() {
           </Page>
         </>
       )}
-    </AppContentLayout>
+    </>
   );
 }

--- a/front/components/spaces/SpaceLayout.tsx
+++ b/front/components/spaces/SpaceLayout.tsx
@@ -10,11 +10,14 @@ import {
   Page,
   Spinner,
 } from "@dust-tt/sparkle";
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 
 import { CreateOrEditSpaceModal } from "@app/components/spaces/CreateOrEditSpaceModal";
 import SpaceSideBarMenu from "@app/components/spaces/SpaceSideBarMenu";
-import { useAppLayoutConfig } from "@app/components/sparkle/AppLayoutContext";
+import {
+  useSetContentWidth,
+  useSetNavChildren,
+} from "@app/components/sparkle/AppLayoutContext";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import { isEntreprisePlanPrefix } from "@app/lib/plans/plan_codes";
 import { useAppRouter, usePathParams } from "@app/lib/platform";
@@ -68,19 +71,19 @@ export function SpaceLayout({ children }: SpaceLayoutProps) {
     []
   );
 
-  useAppLayoutConfig(
-    () => ({
-      contentWidth: "wide",
-      navChildren: (
-        <SpaceSideBarMenu
-          owner={owner}
-          isAdmin={isAdmin}
-          openSpaceCreationModal={openSpaceCreationModal}
-        />
-      ),
-    }),
+  const navChildren = useMemo(
+    () => (
+      <SpaceSideBarMenu
+        owner={owner}
+        isAdmin={isAdmin}
+        openSpaceCreationModal={openSpaceCreationModal}
+      />
+    ),
     [owner, isAdmin, openSpaceCreationModal]
   );
+
+  useSetContentWidth("wide");
+  useSetNavChildren(navChildren);
 
   return (
     <>

--- a/front/components/spaces/SpaceLayout.tsx
+++ b/front/components/spaces/SpaceLayout.tsx
@@ -14,7 +14,7 @@ import React, { useCallback, useState } from "react";
 
 import { CreateOrEditSpaceModal } from "@app/components/spaces/CreateOrEditSpaceModal";
 import SpaceSideBarMenu from "@app/components/spaces/SpaceSideBarMenu";
-import { AppContentLayout } from "@app/components/sparkle/AppContentLayout";
+import { useAppLayoutConfig } from "@app/components/sparkle/AppLayoutContext";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import { isEntreprisePlanPrefix } from "@app/lib/plans/plan_codes";
 import { useAppRouter, usePathParams } from "@app/lib/platform";
@@ -68,19 +68,22 @@ export function SpaceLayout({ children }: SpaceLayoutProps) {
     []
   );
 
-  return (
-    <AppContentLayout
-      contentWidth="wide"
-      subscription={subscription}
-      owner={owner}
-      navChildren={
+  useAppLayoutConfig(
+    () => ({
+      contentWidth: "wide",
+      navChildren: (
         <SpaceSideBarMenu
           owner={owner}
           isAdmin={isAdmin}
           openSpaceCreationModal={openSpaceCreationModal}
         />
-      }
-    >
+      ),
+    }),
+    [owner, isAdmin, openSpaceCreationModal]
+  );
+
+  return (
+    <>
       {isSpaceInfoLoading || !space ? (
         <div className="flex h-full items-center justify-center">
           <Spinner />
@@ -148,6 +151,6 @@ export function SpaceLayout({ children }: SpaceLayoutProps) {
           </DialogContent>
         </Dialog>
       )}
-    </AppContentLayout>
+    </>
   );
 }

--- a/front/components/sparkle/AppContentLayout.tsx
+++ b/front/components/sparkle/AppContentLayout.tsx
@@ -1,17 +1,17 @@
 import { cn } from "@dust-tt/sparkle";
 import React from "react";
 
-import type { SidebarNavigation } from "@app/components/navigation/config";
 import { useDesktopNavigation } from "@app/components/navigation/DesktopNavigationContext";
 import { Navigation } from "@app/components/navigation/Navigation";
 import { SubscriptionEndBanner } from "@app/components/navigation/TrialBanner";
+import { useAppLayout } from "@app/components/sparkle/AppLayoutContext";
 import { AppLayoutTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { NavigationLoadingOverlay } from "@app/components/sparkle/NavigationLoadingOverlay";
 import { useAppKeyboardShortcuts } from "@app/hooks/useAppKeyboardShortcuts";
+import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import type { AppRouter } from "@app/lib/platform";
 import { Head } from "@app/lib/platform";
 import { getConversationRoute } from "@app/lib/utils/router";
-import type { SubscriptionType } from "@app/types/plan";
 import type { WorkspaceType } from "@app/types/user";
 import { isAdmin } from "@app/types/user";
 
@@ -47,36 +47,24 @@ export const appLayoutBack = async (
   }
 };
 
-export interface AppContentLayoutProps {
+interface AppContentLayoutProps {
   children: React.ReactNode;
-  contentClassName?: string;
-  contentWidth?: "centered" | "wide";
-  hasTitle?: boolean;
-  hideSidebar?: boolean;
-  navChildren?: React.ReactNode;
-  owner: WorkspaceType;
-  pageTitle?: string;
-  subNavigation?: SidebarNavigation[] | null;
-  subscription: SubscriptionType;
-  title?: React.ReactNode;
 }
 
-// TODO(2025-04-11 yuka) We need to refactor AppLayout to avoid re-mounting on every page navigation.
-// Until then, AppLayout has been split into AppRootLayout and AppContentLayout.
-// When you need to use AppContentLayout, add `getLayout` function to your page and wrap the page with AppRootLayout.
-export function AppContentLayout({
-  children,
-  contentClassName,
-  contentWidth,
-  hasTitle = false,
-  hideSidebar = false,
-  navChildren,
-  owner,
-  pageTitle,
-  subNavigation,
-  subscription,
-  title,
-}: AppContentLayoutProps) {
+export function AppContentLayout({ children }: AppContentLayoutProps) {
+  const owner = useWorkspace();
+  const { subscription } = useAuth();
+  const {
+    contentClassName,
+    contentWidth,
+    hasTitle = false,
+    hideSidebar = false,
+    navChildren,
+    pageTitle,
+    subNavigation,
+    title,
+  } = useAppLayout();
+
   const hasTitleBar = !!title || hasTitle;
   useAppKeyboardShortcuts(owner);
   const { isNavigationBarOpen, setIsNavigationBarOpen } =

--- a/front/components/sparkle/AppLayoutContext.tsx
+++ b/front/components/sparkle/AppLayoutContext.tsx
@@ -1,0 +1,80 @@
+import type { DependencyList, ReactNode } from "react";
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useState,
+} from "react";
+
+import type { SidebarNavigation } from "@app/components/navigation/config";
+
+const useIsomorphicLayoutEffect =
+  typeof window !== "undefined" ? useLayoutEffect : useEffect;
+
+interface AppLayoutConfig {
+  contentClassName?: string;
+  contentWidth?: "centered" | "wide";
+  hasTitle?: boolean;
+  hideSidebar?: boolean;
+  navChildren?: ReactNode;
+  pageTitle?: string;
+  subNavigation?: SidebarNavigation[] | null;
+  title?: ReactNode;
+}
+
+const DEFAULT_CONFIG: AppLayoutConfig = {};
+
+interface AppLayoutContextValue {
+  config: AppLayoutConfig;
+  setConfig: (config: AppLayoutConfig) => void;
+}
+
+const AppLayoutContext = createContext<AppLayoutContextValue>({
+  config: DEFAULT_CONFIG,
+  setConfig: () => {},
+});
+
+interface AppLayoutProviderProps {
+  children: ReactNode;
+}
+
+export function AppLayoutProvider({ children }: AppLayoutProviderProps) {
+  const [config, setConfig] = useState<AppLayoutConfig>(DEFAULT_CONFIG);
+
+  const value = useMemo(() => ({ config, setConfig }), [config, setConfig]);
+
+  return (
+    <AppLayoutContext.Provider value={value}>
+      {children}
+    </AppLayoutContext.Provider>
+  );
+}
+
+/**
+ * Hook for pages/layouts to configure AppContentLayout.
+ * Uses useLayoutEffect so the config is set synchronously before paint,
+ * preventing flashes of stale layout during page transitions.
+ * Cleanup resets to DEFAULT_CONFIG so stale config doesn't persist
+ * when navigating to a page with different layout needs.
+ */
+export function useAppLayoutConfig(
+  configFn: () => AppLayoutConfig,
+  deps: DependencyList
+): void {
+  const { setConfig } = useContext(AppLayoutContext);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const config = useMemo(configFn, deps);
+  useIsomorphicLayoutEffect(() => {
+    setConfig(config);
+    return () => setConfig(DEFAULT_CONFIG);
+  }, [setConfig, config]);
+}
+
+/**
+ * Hook for AppContentLayout to read the current layout config.
+ */
+export function useAppLayout(): AppLayoutConfig {
+  return useContext(AppLayoutContext).config;
+}

--- a/front/components/sparkle/AppRootLayout.tsx
+++ b/front/components/sparkle/AppRootLayout.tsx
@@ -1,6 +1,7 @@
 import type { Novu } from "@novu/js";
 import React, { useEffect } from "react";
 
+import { InputBarProvider } from "@app/components/assistant/conversation/input_bar/InputBarContext";
 import { WelcomeTourGuideProvider } from "@app/components/assistant/WelcomeTourGuideProvider";
 import { DesktopNavigationProvider } from "@app/components/navigation/DesktopNavigationContext";
 import { QuickStartGuide } from "@app/components/QuickStartGuide";
@@ -14,9 +15,6 @@ import { ConversationsUpdatedEvent } from "@app/lib/notifications/events";
 import { Head, Script, useAppRouter } from "@app/lib/platform";
 import { getFaviconPath } from "@app/lib/utils";
 
-// TODO(2025-04-11 yuka) We need to refactor AppLayout to avoid re-mounting on every page navigation.
-// Until then, AppLayout has been split into AppRootLayout and AppContentLayout.
-// When you need to use AppContentLayout, add `getLayout` function to your page and wrap the page with AppRootLayout.
 export default function AppRootLayout({
   children,
 }: {
@@ -136,68 +134,70 @@ export default function AppRootLayout({
     <ThemeProvider>
       <WelcomeTourGuideProvider>
         <DesktopNavigationProvider>
-          <Head>
-            <link rel="icon" type="image/png" href={faviconPath} />
+          <InputBarProvider>
+            <Head>
+              <link rel="icon" type="image/png" href={faviconPath} />
 
-            <meta name="apple-mobile-web-app-title" content="Dust" />
-            <link rel="apple-touch-icon" href="/static/AppIcon.png" />
-            <link
-              rel="apple-touch-icon"
-              sizes="60x60"
-              href="/static/AppIcon_60.png"
-            />
-            <link
-              rel="apple-touch-icon"
-              sizes="76x76"
-              href="/static/AppIcon_76.png"
-            />
-            <link
-              rel="apple-touch-icon"
-              sizes="120x120"
-              href="/static/AppIcon_120.png"
-            />
-            <link
-              rel="apple-touch-icon"
-              sizes="152x152"
-              href="/static/AppIcon_152.png"
-            />
-            <link
-              rel="apple-touch-icon"
-              sizes="167x167"
-              href="/static/AppIcon_167.png"
-            />
-            <link
-              rel="apple-touch-icon"
-              sizes="180x180"
-              href="/static/AppIcon_180.png"
-            />
-            <link
-              rel="apple-touch-icon"
-              sizes="192x192"
-              href="/static/AppIcon_192.png"
-            />
-            <link
-              rel="apple-touch-icon"
-              sizes="228x228"
-              href="/static/AppIcon_228.png"
-            />
+              <meta name="apple-mobile-web-app-title" content="Dust" />
+              <link rel="apple-touch-icon" href="/static/AppIcon.png" />
+              <link
+                rel="apple-touch-icon"
+                sizes="60x60"
+                href="/static/AppIcon_60.png"
+              />
+              <link
+                rel="apple-touch-icon"
+                sizes="76x76"
+                href="/static/AppIcon_76.png"
+              />
+              <link
+                rel="apple-touch-icon"
+                sizes="120x120"
+                href="/static/AppIcon_120.png"
+              />
+              <link
+                rel="apple-touch-icon"
+                sizes="152x152"
+                href="/static/AppIcon_152.png"
+              />
+              <link
+                rel="apple-touch-icon"
+                sizes="167x167"
+                href="/static/AppIcon_167.png"
+              />
+              <link
+                rel="apple-touch-icon"
+                sizes="180x180"
+                href="/static/AppIcon_180.png"
+              />
+              <link
+                rel="apple-touch-icon"
+                sizes="192x192"
+                href="/static/AppIcon_192.png"
+              />
+              <link
+                rel="apple-touch-icon"
+                sizes="228x228"
+                href="/static/AppIcon_228.png"
+              />
 
-            <meta
-              name="viewport"
-              content="width=device-width, initial-scale=1, maximum-scale=1"
-            />
-          </Head>
-          {children}
-          <QuickStartGuide />
-          <Script id="google-tag-manager" strategy="afterInteractive">
-            {`
+              <meta
+                name="viewport"
+                content="width=device-width, initial-scale=1, maximum-scale=1"
+              />
+            </Head>
+            {children}
+            <QuickStartGuide />
+            <Script id="google-tag-manager" strategy="afterInteractive">
+              {`
               (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
               new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
               j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
               'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
               })(window,document,'script','dataLayer','${process.env.NEXT_PUBLIC_GTM_TRACKING_ID}');
           `}
-          </Script>
+            </Script>
+          </InputBarProvider>
         </DesktopNavigationProvider>
       </WelcomeTourGuideProvider>
     </ThemeProvider>

--- a/front/lib/auth/appGetLayout.tsx
+++ b/front/lib/auth/appGetLayout.tsx
@@ -1,0 +1,43 @@
+import type { ReactElement } from "react";
+
+import { ConversationLayout } from "@app/components/assistant/conversation/ConversationLayout";
+import { AdminLayout } from "@app/components/layouts/AdminLayout";
+import { SpaceLayout } from "@app/components/spaces/SpaceLayout";
+import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
+import { AppContentLayout } from "@app/components/sparkle/AppContentLayout";
+import { AppLayoutProvider } from "@app/components/sparkle/AppLayoutContext";
+import type { AuthContextValue } from "@app/lib/auth/AuthContext";
+
+export function appGetLayout(page: ReactElement, pageProps: AuthContextValue) {
+  return (
+    <AppAuthContextLayout authContext={pageProps}>
+      <AppLayoutProvider>
+        <AppContentLayout>{page}</AppContentLayout>
+      </AppLayoutProvider>
+    </AppAuthContextLayout>
+  );
+}
+
+export function conversationGetLayout(
+  page: ReactElement,
+  pageProps: AuthContextValue
+) {
+  return appGetLayout(
+    <ConversationLayout pageProps={pageProps}>{page}</ConversationLayout>,
+    pageProps
+  );
+}
+
+export function spaceGetLayout(
+  page: ReactElement,
+  pageProps: AuthContextValue
+) {
+  return appGetLayout(<SpaceLayout>{page}</SpaceLayout>, pageProps);
+}
+
+export function adminGetLayout(
+  page: ReactElement,
+  pageProps: AuthContextValue
+) {
+  return appGetLayout(<AdminLayout>{page}</AdminLayout>, pageProps);
+}

--- a/front/pages/w/[wId]/analytics/index.tsx
+++ b/front/pages/w/[wId]/analytics/index.tsx
@@ -1,25 +1,12 @@
-import type { ReactElement } from "react";
-
-import { AdminLayout } from "@app/components/layouts/AdminLayout";
 import { AnalyticsPage } from "@app/components/pages/workspace/AnalyticsPage";
-import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
+import { adminGetLayout } from "@app/lib/auth/appGetLayout";
 import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
 import { appGetServerSidePropsForAdmin } from "@app/lib/auth/appServerSideProps";
-import type { AuthContextValue } from "@app/lib/auth/AuthContext";
 
 export const getServerSideProps = appGetServerSidePropsForAdmin;
 
 const PageWithAuthLayout = AnalyticsPage as AppPageWithLayout;
 
-PageWithAuthLayout.getLayout = (
-  page: ReactElement,
-  pageProps: AuthContextValue
-) => {
-  return (
-    <AppAuthContextLayout authContext={pageProps}>
-      <AdminLayout>{page}</AdminLayout>
-    </AppAuthContextLayout>
-  );
-};
+PageWithAuthLayout.getLayout = adminGetLayout;
 
 export default PageWithAuthLayout;

--- a/front/pages/w/[wId]/builder/agents/create.tsx
+++ b/front/pages/w/[wId]/builder/agents/create.tsx
@@ -1,22 +1,12 @@
-import type { ReactElement } from "react";
-
 import { CreateAgentPage } from "@app/components/pages/builder/agents/CreateAgentPage";
-import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
+import { appGetLayout } from "@app/lib/auth/appGetLayout";
 import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
 import { appGetServerSideProps } from "@app/lib/auth/appServerSideProps";
-import type { AuthContextValue } from "@app/lib/auth/AuthContext";
 
 export const getServerSideProps = appGetServerSideProps;
 
 const PageWithAuthLayout = CreateAgentPage as AppPageWithLayout;
 
-PageWithAuthLayout.getLayout = (
-  page: ReactElement,
-  pageProps: AuthContextValue
-) => {
-  return (
-    <AppAuthContextLayout authContext={pageProps}>{page}</AppAuthContextLayout>
-  );
-};
+PageWithAuthLayout.getLayout = appGetLayout;
 
 export default PageWithAuthLayout;

--- a/front/pages/w/[wId]/builder/agents/index.tsx
+++ b/front/pages/w/[wId]/builder/agents/index.tsx
@@ -1,22 +1,12 @@
-import type { ReactElement } from "react";
-
 import { ManageAgentsPage } from "@app/components/pages/builder/agents/ManageAgentsPage";
-import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
+import { appGetLayout } from "@app/lib/auth/appGetLayout";
 import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
 import { appGetServerSideProps } from "@app/lib/auth/appServerSideProps";
-import type { AuthContextValue } from "@app/lib/auth/AuthContext";
 
 export const getServerSideProps = appGetServerSideProps;
 
 const PageWithAuthLayout = ManageAgentsPage as AppPageWithLayout;
 
-PageWithAuthLayout.getLayout = (
-  page: ReactElement,
-  pageProps: AuthContextValue
-) => {
-  return (
-    <AppAuthContextLayout authContext={pageProps}>{page}</AppAuthContextLayout>
-  );
-};
+PageWithAuthLayout.getLayout = appGetLayout;
 
 export default PageWithAuthLayout;

--- a/front/pages/w/[wId]/builder/skills/index.tsx
+++ b/front/pages/w/[wId]/builder/skills/index.tsx
@@ -1,22 +1,12 @@
-import type { ReactElement } from "react";
-
 import { ManageSkillsPage } from "@app/components/pages/builder/skills/ManageSkillsPage";
-import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
+import { appGetLayout } from "@app/lib/auth/appGetLayout";
 import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
 import { appGetServerSidePropsForBuilders } from "@app/lib/auth/appServerSideProps";
-import type { AuthContextValue } from "@app/lib/auth/AuthContext";
 
 export const getServerSideProps = appGetServerSidePropsForBuilders;
 
 const PageWithAuthLayout = ManageSkillsPage as AppPageWithLayout;
 
-PageWithAuthLayout.getLayout = (
-  page: ReactElement,
-  pageProps: AuthContextValue
-) => {
-  return (
-    <AppAuthContextLayout authContext={pageProps}>{page}</AppAuthContextLayout>
-  );
-};
+PageWithAuthLayout.getLayout = appGetLayout;
 
 export default PageWithAuthLayout;

--- a/front/pages/w/[wId]/conversation/[cId]/index.tsx
+++ b/front/pages/w/[wId]/conversation/[cId]/index.tsx
@@ -1,25 +1,12 @@
-import type { ReactElement } from "react";
-
-import { ConversationLayout } from "@app/components/assistant/conversation/ConversationLayout";
 import { ConversationPage } from "@app/components/pages/conversation/ConversationPage";
-import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
+import { conversationGetLayout } from "@app/lib/auth/appGetLayout";
 import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
 import { appGetServerSideProps } from "@app/lib/auth/appServerSideProps";
-import type { AuthContextValue } from "@app/lib/auth/AuthContext";
 
 export const getServerSideProps = appGetServerSideProps;
 
 const PageWithAuthLayout = ConversationPage as AppPageWithLayout;
 
-PageWithAuthLayout.getLayout = (
-  page: ReactElement,
-  pageProps: AuthContextValue
-) => {
-  return (
-    <AppAuthContextLayout authContext={pageProps}>
-      <ConversationLayout pageProps={pageProps}>{page}</ConversationLayout>
-    </AppAuthContextLayout>
-  );
-};
+PageWithAuthLayout.getLayout = conversationGetLayout;
 
 export default PageWithAuthLayout;

--- a/front/pages/w/[wId]/conversation/space/[spaceId]/index.tsx
+++ b/front/pages/w/[wId]/conversation/space/[spaceId]/index.tsx
@@ -1,25 +1,12 @@
-import type { ReactElement } from "react";
-
-import { ConversationLayout } from "@app/components/assistant/conversation/ConversationLayout";
 import { SpaceConversationsPage } from "@app/components/pages/conversation/SpaceConversationsPage";
-import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
+import { conversationGetLayout } from "@app/lib/auth/appGetLayout";
 import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
 import { appGetServerSideProps } from "@app/lib/auth/appServerSideProps";
-import type { AuthContextValue } from "@app/lib/auth/AuthContext";
 
 export const getServerSideProps = appGetServerSideProps;
 
 const PageWithAuthLayout = SpaceConversationsPage as AppPageWithLayout;
 
-PageWithAuthLayout.getLayout = (
-  page: ReactElement,
-  pageProps: AuthContextValue
-) => {
-  return (
-    <AppAuthContextLayout authContext={pageProps}>
-      <ConversationLayout pageProps={pageProps}>{page}</ConversationLayout>
-    </AppAuthContextLayout>
-  );
-};
+PageWithAuthLayout.getLayout = conversationGetLayout;
 
 export default PageWithAuthLayout;

--- a/front/pages/w/[wId]/developers/api-keys.tsx
+++ b/front/pages/w/[wId]/developers/api-keys.tsx
@@ -1,25 +1,12 @@
-import type { ReactElement } from "react";
-
-import { AdminLayout } from "@app/components/layouts/AdminLayout";
 import { APIKeysPage } from "@app/components/pages/workspace/developers/APIKeysPage";
-import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
+import { adminGetLayout } from "@app/lib/auth/appGetLayout";
 import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
 import { appGetServerSidePropsForAdmin } from "@app/lib/auth/appServerSideProps";
-import type { AuthContextValue } from "@app/lib/auth/AuthContext";
 
 export const getServerSideProps = appGetServerSidePropsForAdmin;
 
 const PageWithAuthLayout = APIKeysPage as AppPageWithLayout;
 
-PageWithAuthLayout.getLayout = (
-  page: ReactElement,
-  pageProps: AuthContextValue
-) => {
-  return (
-    <AppAuthContextLayout authContext={pageProps}>
-      <AdminLayout>{page}</AdminLayout>
-    </AppAuthContextLayout>
-  );
-};
+PageWithAuthLayout.getLayout = adminGetLayout;
 
 export default PageWithAuthLayout;

--- a/front/pages/w/[wId]/developers/credits-usage.tsx
+++ b/front/pages/w/[wId]/developers/credits-usage.tsx
@@ -1,25 +1,12 @@
-import type { ReactElement } from "react";
-
-import { AdminLayout } from "@app/components/layouts/AdminLayout";
 import { CreditsUsagePage } from "@app/components/pages/workspace/developers/CreditsUsagePage";
-import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
+import { adminGetLayout } from "@app/lib/auth/appGetLayout";
 import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
 import { appGetServerSidePropsForAdmin } from "@app/lib/auth/appServerSideProps";
-import type { AuthContextValue } from "@app/lib/auth/AuthContext";
 
 export const getServerSideProps = appGetServerSidePropsForAdmin;
 
 const PageWithAuthLayout = CreditsUsagePage as AppPageWithLayout;
 
-PageWithAuthLayout.getLayout = (
-  page: ReactElement,
-  pageProps: AuthContextValue
-) => {
-  return (
-    <AppAuthContextLayout authContext={pageProps}>
-      <AdminLayout>{page}</AdminLayout>
-    </AppAuthContextLayout>
-  );
-};
+PageWithAuthLayout.getLayout = adminGetLayout;
 
 export default PageWithAuthLayout;

--- a/front/pages/w/[wId]/developers/dev-secrets.tsx
+++ b/front/pages/w/[wId]/developers/dev-secrets.tsx
@@ -1,25 +1,12 @@
-import type { ReactElement } from "react";
-
-import { AdminLayout } from "@app/components/layouts/AdminLayout";
 import { SecretsPage } from "@app/components/pages/workspace/developers/SecretsPage";
-import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
+import { adminGetLayout } from "@app/lib/auth/appGetLayout";
 import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
 import { appGetServerSidePropsForBuilders } from "@app/lib/auth/appServerSideProps";
-import type { AuthContextValue } from "@app/lib/auth/AuthContext";
 
 export const getServerSideProps = appGetServerSidePropsForBuilders;
 
 const PageWithAuthLayout = SecretsPage as AppPageWithLayout;
 
-PageWithAuthLayout.getLayout = (
-  page: ReactElement,
-  pageProps: AuthContextValue
-) => {
-  return (
-    <AppAuthContextLayout authContext={pageProps}>
-      <AdminLayout>{page}</AdminLayout>
-    </AppAuthContextLayout>
-  );
-};
+PageWithAuthLayout.getLayout = adminGetLayout;
 
 export default PageWithAuthLayout;

--- a/front/pages/w/[wId]/developers/providers.tsx
+++ b/front/pages/w/[wId]/developers/providers.tsx
@@ -1,25 +1,12 @@
-import type { ReactElement } from "react";
-
-import { AdminLayout } from "@app/components/layouts/AdminLayout";
 import { ProvidersPage } from "@app/components/pages/workspace/developers/ProvidersPage";
-import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
+import { adminGetLayout } from "@app/lib/auth/appGetLayout";
 import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
 import { appGetServerSidePropsForAdmin } from "@app/lib/auth/appServerSideProps";
-import type { AuthContextValue } from "@app/lib/auth/AuthContext";
 
 export const getServerSideProps = appGetServerSidePropsForAdmin;
 
 const PageWithAuthLayout = ProvidersPage as AppPageWithLayout;
 
-PageWithAuthLayout.getLayout = (
-  page: ReactElement,
-  pageProps: AuthContextValue
-) => {
-  return (
-    <AppAuthContextLayout authContext={pageProps}>
-      <AdminLayout>{page}</AdminLayout>
-    </AppAuthContextLayout>
-  );
-};
+PageWithAuthLayout.getLayout = adminGetLayout;
 
 export default PageWithAuthLayout;

--- a/front/pages/w/[wId]/labs/index.tsx
+++ b/front/pages/w/[wId]/labs/index.tsx
@@ -1,22 +1,12 @@
-import type { ReactElement } from "react";
-
 import { LabsPage } from "@app/components/pages/workspace/labs/LabsPage";
-import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
+import { appGetLayout } from "@app/lib/auth/appGetLayout";
 import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
 import { appGetServerSideProps } from "@app/lib/auth/appServerSideProps";
-import type { AuthContextValue } from "@app/lib/auth/AuthContext";
 
 export const getServerSideProps = appGetServerSideProps;
 
 const PageWithAuthLayout = LabsPage as AppPageWithLayout;
 
-PageWithAuthLayout.getLayout = (
-  page: ReactElement,
-  pageProps: AuthContextValue
-) => {
-  return (
-    <AppAuthContextLayout authContext={pageProps}>{page}</AppAuthContextLayout>
-  );
-};
+PageWithAuthLayout.getLayout = appGetLayout;
 
 export default PageWithAuthLayout;

--- a/front/pages/w/[wId]/labs/mcp_actions/[agentId]/index.tsx
+++ b/front/pages/w/[wId]/labs/mcp_actions/[agentId]/index.tsx
@@ -1,22 +1,12 @@
-import type { ReactElement } from "react";
-
 import { AgentMCPActionsPage } from "@app/components/pages/workspace/labs/mcp_actions/AgentMCPActionsPage";
-import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
+import { appGetLayout } from "@app/lib/auth/appGetLayout";
 import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
 import { appGetServerSidePropsForAdmin } from "@app/lib/auth/appServerSideProps";
-import type { AuthContextValue } from "@app/lib/auth/AuthContext";
 
 export const getServerSideProps = appGetServerSidePropsForAdmin;
 
 const PageWithAuthLayout = AgentMCPActionsPage as AppPageWithLayout;
 
-PageWithAuthLayout.getLayout = (
-  page: ReactElement,
-  pageProps: AuthContextValue
-) => {
-  return (
-    <AppAuthContextLayout authContext={pageProps}>{page}</AppAuthContextLayout>
-  );
-};
+PageWithAuthLayout.getLayout = appGetLayout;
 
 export default PageWithAuthLayout;

--- a/front/pages/w/[wId]/labs/mcp_actions/index.tsx
+++ b/front/pages/w/[wId]/labs/mcp_actions/index.tsx
@@ -1,22 +1,12 @@
-import type { ReactElement } from "react";
-
 import { MCPActionsDashboardPage } from "@app/components/pages/workspace/labs/mcp_actions/MCPActionsDashboardPage";
-import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
+import { appGetLayout } from "@app/lib/auth/appGetLayout";
 import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
 import { appGetServerSidePropsForAdmin } from "@app/lib/auth/appServerSideProps";
-import type { AuthContextValue } from "@app/lib/auth/AuthContext";
 
 export const getServerSideProps = appGetServerSidePropsForAdmin;
 
 const PageWithAuthLayout = MCPActionsDashboardPage as AppPageWithLayout;
 
-PageWithAuthLayout.getLayout = (
-  page: ReactElement,
-  pageProps: AuthContextValue
-) => {
-  return (
-    <AppAuthContextLayout authContext={pageProps}>{page}</AppAuthContextLayout>
-  );
-};
+PageWithAuthLayout.getLayout = appGetLayout;
 
 export default PageWithAuthLayout;

--- a/front/pages/w/[wId]/labs/transcripts/index.tsx
+++ b/front/pages/w/[wId]/labs/transcripts/index.tsx
@@ -1,22 +1,12 @@
-import type { ReactElement } from "react";
-
 import { TranscriptsPage } from "@app/components/pages/workspace/labs/TranscriptsPage";
-import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
+import { appGetLayout } from "@app/lib/auth/appGetLayout";
 import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
 import { appGetServerSideProps } from "@app/lib/auth/appServerSideProps";
-import type { AuthContextValue } from "@app/lib/auth/AuthContext";
 
 export const getServerSideProps = appGetServerSideProps;
 
 const PageWithAuthLayout = TranscriptsPage as AppPageWithLayout;
 
-PageWithAuthLayout.getLayout = (
-  page: ReactElement,
-  pageProps: AuthContextValue
-) => {
-  return (
-    <AppAuthContextLayout authContext={pageProps}>{page}</AppAuthContextLayout>
-  );
-};
+PageWithAuthLayout.getLayout = appGetLayout;
 
 export default PageWithAuthLayout;

--- a/front/pages/w/[wId]/me/index.tsx
+++ b/front/pages/w/[wId]/me/index.tsx
@@ -1,22 +1,12 @@
-import type { ReactElement } from "react";
-
 import { ProfilePage } from "@app/components/pages/workspace/ProfilePage";
-import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
+import { appGetLayout } from "@app/lib/auth/appGetLayout";
 import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
 import { appGetServerSideProps } from "@app/lib/auth/appServerSideProps";
-import type { AuthContextValue } from "@app/lib/auth/AuthContext";
 
 export const getServerSideProps = appGetServerSideProps;
 
 const PageWithAuthLayout = ProfilePage as AppPageWithLayout;
 
-PageWithAuthLayout.getLayout = (
-  page: ReactElement,
-  pageProps: AuthContextValue
-) => {
-  return (
-    <AppAuthContextLayout authContext={pageProps}>{page}</AppAuthContextLayout>
-  );
-};
+PageWithAuthLayout.getLayout = appGetLayout;
 
 export default PageWithAuthLayout;

--- a/front/pages/w/[wId]/members/index.tsx
+++ b/front/pages/w/[wId]/members/index.tsx
@@ -1,25 +1,12 @@
-import type { ReactElement } from "react";
-
-import { AdminLayout } from "@app/components/layouts/AdminLayout";
 import { MembersPage } from "@app/components/pages/workspace/MembersPage";
-import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
+import { adminGetLayout } from "@app/lib/auth/appGetLayout";
 import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
 import { appGetServerSidePropsForAdmin } from "@app/lib/auth/appServerSideProps";
-import type { AuthContextValue } from "@app/lib/auth/AuthContext";
 
 export const getServerSideProps = appGetServerSidePropsForAdmin;
 
 const PageWithAuthLayout = MembersPage as AppPageWithLayout;
 
-PageWithAuthLayout.getLayout = (
-  page: ReactElement,
-  pageProps: AuthContextValue
-) => {
-  return (
-    <AppAuthContextLayout authContext={pageProps}>
-      <AdminLayout>{page}</AdminLayout>
-    </AppAuthContextLayout>
-  );
-};
+PageWithAuthLayout.getLayout = adminGetLayout;
 
 export default PageWithAuthLayout;

--- a/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets/[name]/index.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets/[name]/index.tsx
@@ -1,22 +1,12 @@
-import type { ReactElement } from "react";
-
 import { DatasetPage } from "@app/components/pages/spaces/apps/DatasetPage";
-import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
+import { appGetLayout } from "@app/lib/auth/appGetLayout";
 import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
 import { appGetServerSideProps } from "@app/lib/auth/appServerSideProps";
-import type { AuthContextValue } from "@app/lib/auth/AuthContext";
 
 export const getServerSideProps = appGetServerSideProps;
 
 const PageWithAuthLayout = DatasetPage as AppPageWithLayout;
 
-PageWithAuthLayout.getLayout = (
-  page: ReactElement,
-  pageProps: AuthContextValue
-) => {
-  return (
-    <AppAuthContextLayout authContext={pageProps}>{page}</AppAuthContextLayout>
-  );
-};
+PageWithAuthLayout.getLayout = appGetLayout;
 
 export default PageWithAuthLayout;

--- a/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets/index.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets/index.tsx
@@ -1,22 +1,12 @@
-import type { ReactElement } from "react";
-
 import { DatasetsPage } from "@app/components/pages/spaces/apps/DatasetsPage";
-import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
+import { appGetLayout } from "@app/lib/auth/appGetLayout";
 import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
 import { appGetServerSideProps } from "@app/lib/auth/appServerSideProps";
-import type { AuthContextValue } from "@app/lib/auth/AuthContext";
 
 export const getServerSideProps = appGetServerSideProps;
 
 const PageWithAuthLayout = DatasetsPage as AppPageWithLayout;
 
-PageWithAuthLayout.getLayout = (
-  page: ReactElement,
-  pageProps: AuthContextValue
-) => {
-  return (
-    <AppAuthContextLayout authContext={pageProps}>{page}</AppAuthContextLayout>
-  );
-};
+PageWithAuthLayout.getLayout = appGetLayout;
 
 export default PageWithAuthLayout;

--- a/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets/new.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets/new.tsx
@@ -1,22 +1,12 @@
-import type { ReactElement } from "react";
-
 import { NewDatasetPage } from "@app/components/pages/spaces/apps/NewDatasetPage";
-import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
+import { appGetLayout } from "@app/lib/auth/appGetLayout";
 import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
 import { appGetServerSideProps } from "@app/lib/auth/appServerSideProps";
-import type { AuthContextValue } from "@app/lib/auth/AuthContext";
 
 export const getServerSideProps = appGetServerSideProps;
 
 const PageWithAuthLayout = NewDatasetPage as AppPageWithLayout;
 
-PageWithAuthLayout.getLayout = (
-  page: ReactElement,
-  pageProps: AuthContextValue
-) => {
-  return (
-    <AppAuthContextLayout authContext={pageProps}>{page}</AppAuthContextLayout>
-  );
-};
+PageWithAuthLayout.getLayout = appGetLayout;
 
 export default PageWithAuthLayout;

--- a/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/index.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/index.tsx
@@ -1,22 +1,12 @@
-import type { ReactElement } from "react";
-
 import { AppViewPage } from "@app/components/pages/spaces/apps/AppViewPage";
-import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
+import { appGetLayout } from "@app/lib/auth/appGetLayout";
 import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
 import { appGetServerSideProps } from "@app/lib/auth/appServerSideProps";
-import type { AuthContextValue } from "@app/lib/auth/AuthContext";
 
 export const getServerSideProps = appGetServerSideProps;
 
 const PageWithAuthLayout = AppViewPage as AppPageWithLayout;
 
-PageWithAuthLayout.getLayout = (
-  page: ReactElement,
-  pageProps: AuthContextValue
-) => {
-  return (
-    <AppAuthContextLayout authContext={pageProps}>{page}</AppAuthContextLayout>
-  );
-};
+PageWithAuthLayout.getLayout = appGetLayout;
 
 export default PageWithAuthLayout;

--- a/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/index.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/index.tsx
@@ -1,22 +1,12 @@
-import type { ReactElement } from "react";
-
 import { RunPage } from "@app/components/pages/spaces/apps/RunPage";
-import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
+import { appGetLayout } from "@app/lib/auth/appGetLayout";
 import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
 import { appGetServerSideProps } from "@app/lib/auth/appServerSideProps";
-import type { AuthContextValue } from "@app/lib/auth/AuthContext";
 
 export const getServerSideProps = appGetServerSideProps;
 
 const PageWithAuthLayout = RunPage as AppPageWithLayout;
 
-PageWithAuthLayout.getLayout = (
-  page: ReactElement,
-  pageProps: AuthContextValue
-) => {
-  return (
-    <AppAuthContextLayout authContext={pageProps}>{page}</AppAuthContextLayout>
-  );
-};
+PageWithAuthLayout.getLayout = appGetLayout;
 
 export default PageWithAuthLayout;

--- a/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.tsx
@@ -1,22 +1,12 @@
-import type { ReactElement } from "react";
-
 import { RunsPage } from "@app/components/pages/spaces/apps/RunsPage";
-import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
+import { appGetLayout } from "@app/lib/auth/appGetLayout";
 import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
 import { appGetServerSideProps } from "@app/lib/auth/appServerSideProps";
-import type { AuthContextValue } from "@app/lib/auth/AuthContext";
 
 export const getServerSideProps = appGetServerSideProps;
 
 const PageWithAuthLayout = RunsPage as AppPageWithLayout;
 
-PageWithAuthLayout.getLayout = (
-  page: ReactElement,
-  pageProps: AuthContextValue
-) => {
-  return (
-    <AppAuthContextLayout authContext={pageProps}>{page}</AppAuthContextLayout>
-  );
-};
+PageWithAuthLayout.getLayout = appGetLayout;
 
 export default PageWithAuthLayout;

--- a/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/settings.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/settings.tsx
@@ -1,22 +1,12 @@
-import type { ReactElement } from "react";
-
 import { AppSettingsPage } from "@app/components/pages/spaces/apps/AppSettingsPage";
-import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
+import { appGetLayout } from "@app/lib/auth/appGetLayout";
 import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
 import { appGetServerSideProps } from "@app/lib/auth/appServerSideProps";
-import type { AuthContextValue } from "@app/lib/auth/AuthContext";
 
 export const getServerSideProps = appGetServerSideProps;
 
 const PageWithAuthLayout = AppSettingsPage as AppPageWithLayout;
 
-PageWithAuthLayout.getLayout = (
-  page: ReactElement,
-  pageProps: AuthContextValue
-) => {
-  return (
-    <AppAuthContextLayout authContext={pageProps}>{page}</AppAuthContextLayout>
-  );
-};
+PageWithAuthLayout.getLayout = appGetLayout;
 
 export default PageWithAuthLayout;

--- a/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/specification.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/specification.tsx
@@ -1,22 +1,12 @@
-import type { ReactElement } from "react";
-
 import { AppSpecificationPage } from "@app/components/pages/spaces/apps/AppSpecificationPage";
-import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
+import { appGetLayout } from "@app/lib/auth/appGetLayout";
 import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
 import { appGetServerSideProps } from "@app/lib/auth/appServerSideProps";
-import type { AuthContextValue } from "@app/lib/auth/AuthContext";
 
 export const getServerSideProps = appGetServerSideProps;
 
 const PageWithAuthLayout = AppSpecificationPage as AppPageWithLayout;
 
-PageWithAuthLayout.getLayout = (
-  page: ReactElement,
-  pageProps: AuthContextValue
-) => {
-  return (
-    <AppAuthContextLayout authContext={pageProps}>{page}</AppAuthContextLayout>
-  );
-};
+PageWithAuthLayout.getLayout = appGetLayout;
 
 export default PageWithAuthLayout;

--- a/front/pages/w/[wId]/spaces/[spaceId]/categories/[category]/data_source_views/[dataSourceViewId].tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/categories/[category]/data_source_views/[dataSourceViewId].tsx
@@ -1,25 +1,12 @@
-import type { ReactElement } from "react";
-
 import { DataSourceViewPage } from "@app/components/pages/spaces/DataSourceViewPage";
-import { SpaceLayout } from "@app/components/spaces/SpaceLayout";
-import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
+import { spaceGetLayout } from "@app/lib/auth/appGetLayout";
 import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
 import { appGetServerSideProps } from "@app/lib/auth/appServerSideProps";
-import type { AuthContextValue } from "@app/lib/auth/AuthContext";
 
 export const getServerSideProps = appGetServerSideProps;
 
 const PageWithAuthLayout = DataSourceViewPage as AppPageWithLayout;
 
-PageWithAuthLayout.getLayout = (
-  page: ReactElement,
-  pageProps: AuthContextValue
-) => {
-  return (
-    <AppAuthContextLayout authContext={pageProps}>
-      <SpaceLayout>{page}</SpaceLayout>
-    </AppAuthContextLayout>
-  );
-};
+PageWithAuthLayout.getLayout = spaceGetLayout;
 
 export default PageWithAuthLayout;

--- a/front/pages/w/[wId]/spaces/[spaceId]/categories/[category]/index.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/categories/[category]/index.tsx
@@ -1,25 +1,12 @@
-import type { ReactElement } from "react";
-
 import { SpaceCategoryPage } from "@app/components/pages/spaces/SpaceCategoryPage";
-import { SpaceLayout } from "@app/components/spaces/SpaceLayout";
-import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
+import { spaceGetLayout } from "@app/lib/auth/appGetLayout";
 import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
 import { appGetServerSideProps } from "@app/lib/auth/appServerSideProps";
-import type { AuthContextValue } from "@app/lib/auth/AuthContext";
 
 export const getServerSideProps = appGetServerSideProps;
 
 const PageWithAuthLayout = SpaceCategoryPage as AppPageWithLayout;
 
-PageWithAuthLayout.getLayout = (
-  page: ReactElement,
-  pageProps: AuthContextValue
-) => {
-  return (
-    <AppAuthContextLayout authContext={pageProps}>
-      <SpaceLayout>{page}</SpaceLayout>
-    </AppAuthContextLayout>
-  );
-};
+PageWithAuthLayout.getLayout = spaceGetLayout;
 
 export default PageWithAuthLayout;

--- a/front/pages/w/[wId]/spaces/[spaceId]/categories/actions/index.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/categories/actions/index.tsx
@@ -1,25 +1,12 @@
-import type { ReactElement } from "react";
-
 import { SpaceActionsPage } from "@app/components/pages/spaces/SpaceActionsPage";
-import { SpaceLayout } from "@app/components/spaces/SpaceLayout";
-import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
+import { spaceGetLayout } from "@app/lib/auth/appGetLayout";
 import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
 import { appGetServerSideProps } from "@app/lib/auth/appServerSideProps";
-import type { AuthContextValue } from "@app/lib/auth/AuthContext";
 
 export const getServerSideProps = appGetServerSideProps;
 
 const PageWithAuthLayout = SpaceActionsPage as AppPageWithLayout;
 
-PageWithAuthLayout.getLayout = (
-  page: ReactElement,
-  pageProps: AuthContextValue
-) => {
-  return (
-    <AppAuthContextLayout authContext={pageProps}>
-      <SpaceLayout>{page}</SpaceLayout>
-    </AppAuthContextLayout>
-  );
-};
+PageWithAuthLayout.getLayout = spaceGetLayout;
 
 export default PageWithAuthLayout;

--- a/front/pages/w/[wId]/spaces/[spaceId]/categories/apps/index.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/categories/apps/index.tsx
@@ -1,25 +1,12 @@
-import type { ReactElement } from "react";
-
 import { SpaceAppsListPage } from "@app/components/pages/spaces/SpaceAppsListPage";
-import { SpaceLayout } from "@app/components/spaces/SpaceLayout";
-import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
+import { spaceGetLayout } from "@app/lib/auth/appGetLayout";
 import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
 import { appGetServerSideProps } from "@app/lib/auth/appServerSideProps";
-import type { AuthContextValue } from "@app/lib/auth/AuthContext";
 
 export const getServerSideProps = appGetServerSideProps;
 
 const PageWithAuthLayout = SpaceAppsListPage as AppPageWithLayout;
 
-PageWithAuthLayout.getLayout = (
-  page: ReactElement,
-  pageProps: AuthContextValue
-) => {
-  return (
-    <AppAuthContextLayout authContext={pageProps}>
-      <SpaceLayout>{page}</SpaceLayout>
-    </AppAuthContextLayout>
-  );
-};
+PageWithAuthLayout.getLayout = spaceGetLayout;
 
 export default PageWithAuthLayout;

--- a/front/pages/w/[wId]/spaces/[spaceId]/categories/triggers/index.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/categories/triggers/index.tsx
@@ -1,25 +1,12 @@
-import type { ReactElement } from "react";
-
 import { SpaceTriggersPage } from "@app/components/pages/spaces/SpaceTriggersPage";
-import { SpaceLayout } from "@app/components/spaces/SpaceLayout";
-import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
+import { spaceGetLayout } from "@app/lib/auth/appGetLayout";
 import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
 import { appGetServerSideProps } from "@app/lib/auth/appServerSideProps";
-import type { AuthContextValue } from "@app/lib/auth/AuthContext";
 
 export const getServerSideProps = appGetServerSideProps;
 
 const PageWithAuthLayout = SpaceTriggersPage as AppPageWithLayout;
 
-PageWithAuthLayout.getLayout = (
-  page: ReactElement,
-  pageProps: AuthContextValue
-) => {
-  return (
-    <AppAuthContextLayout authContext={pageProps}>
-      <SpaceLayout>{page}</SpaceLayout>
-    </AppAuthContextLayout>
-  );
-};
+PageWithAuthLayout.getLayout = spaceGetLayout;
 
 export default PageWithAuthLayout;

--- a/front/pages/w/[wId]/spaces/[spaceId]/index.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/index.tsx
@@ -1,25 +1,12 @@
-import type { ReactElement } from "react";
-
 import { SpacePage } from "@app/components/pages/spaces/SpacePage";
-import { SpaceLayout } from "@app/components/spaces/SpaceLayout";
-import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
+import { spaceGetLayout } from "@app/lib/auth/appGetLayout";
 import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
 import { appGetServerSideProps } from "@app/lib/auth/appServerSideProps";
-import type { AuthContextValue } from "@app/lib/auth/AuthContext";
 
 export const getServerSideProps = appGetServerSideProps;
 
 const PageWithAuthLayout = SpacePage as AppPageWithLayout;
 
-PageWithAuthLayout.getLayout = (
-  page: ReactElement,
-  pageProps: AuthContextValue
-) => {
-  return (
-    <AppAuthContextLayout authContext={pageProps}>
-      <SpaceLayout>{page}</SpaceLayout>
-    </AppAuthContextLayout>
-  );
-};
+PageWithAuthLayout.getLayout = spaceGetLayout;
 
 export default PageWithAuthLayout;

--- a/front/pages/w/[wId]/spaces/index.tsx
+++ b/front/pages/w/[wId]/spaces/index.tsx
@@ -1,22 +1,12 @@
-import type { ReactElement } from "react";
-
 import { SpacesRedirectPage } from "@app/components/pages/spaces/SpacesRedirectPage";
-import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
+import { appGetLayout } from "@app/lib/auth/appGetLayout";
 import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
 import { appGetServerSideProps } from "@app/lib/auth/appServerSideProps";
-import type { AuthContextValue } from "@app/lib/auth/AuthContext";
 
 export const getServerSideProps = appGetServerSideProps;
 
 const PageWithAuthLayout = SpacesRedirectPage as AppPageWithLayout;
 
-PageWithAuthLayout.getLayout = (
-  page: ReactElement,
-  pageProps: AuthContextValue
-) => {
-  return (
-    <AppAuthContextLayout authContext={pageProps}>{page}</AppAuthContextLayout>
-  );
-};
+PageWithAuthLayout.getLayout = appGetLayout;
 
 export default PageWithAuthLayout;

--- a/front/pages/w/[wId]/subscription/index.tsx
+++ b/front/pages/w/[wId]/subscription/index.tsx
@@ -1,25 +1,12 @@
-import type { ReactElement } from "react";
-
-import { AdminLayout } from "@app/components/layouts/AdminLayout";
 import { SubscriptionPage } from "@app/components/pages/workspace/subscription/SubscriptionPage";
-import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
+import { adminGetLayout } from "@app/lib/auth/appGetLayout";
 import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
 import { appGetServerSidePropsForAdmin } from "@app/lib/auth/appServerSideProps";
-import type { AuthContextValue } from "@app/lib/auth/AuthContext";
 
 export const getServerSideProps = appGetServerSidePropsForAdmin;
 
 const PageWithAuthLayout = SubscriptionPage as AppPageWithLayout;
 
-PageWithAuthLayout.getLayout = (
-  page: ReactElement,
-  pageProps: AuthContextValue
-) => {
-  return (
-    <AppAuthContextLayout authContext={pageProps}>
-      <AdminLayout>{page}</AdminLayout>
-    </AppAuthContextLayout>
-  );
-};
+PageWithAuthLayout.getLayout = adminGetLayout;
 
 export default PageWithAuthLayout;

--- a/front/pages/w/[wId]/workspace/index.tsx
+++ b/front/pages/w/[wId]/workspace/index.tsx
@@ -1,25 +1,12 @@
-import type { ReactElement } from "react";
-
-import { AdminLayout } from "@app/components/layouts/AdminLayout";
 import { WorkspaceSettingsPage } from "@app/components/pages/workspace/WorkspaceSettingsPage";
-import { AppAuthContextLayout } from "@app/components/sparkle/AppAuthContextLayout";
+import { adminGetLayout } from "@app/lib/auth/appGetLayout";
 import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
 import { appGetServerSidePropsForAdmin } from "@app/lib/auth/appServerSideProps";
-import type { AuthContextValue } from "@app/lib/auth/AuthContext";
 
 export const getServerSideProps = appGetServerSidePropsForAdmin;
 
 const PageWithAuthLayout = WorkspaceSettingsPage as AppPageWithLayout;
 
-PageWithAuthLayout.getLayout = (
-  page: ReactElement,
-  pageProps: AuthContextValue
-) => {
-  return (
-    <AppAuthContextLayout authContext={pageProps}>
-      <AdminLayout>{page}</AdminLayout>
-    </AppAuthContextLayout>
-  );
-};
+PageWithAuthLayout.getLayout = adminGetLayout;
 
 export default PageWithAuthLayout;


### PR DESCRIPTION
## Description

Moves `AppContentLayout` (navigation sidebar) into a shared `getLayout` so it persists across page navigations, eliminating sidebar remounting/flickering.

### Architecture

**Before:** Each page/layout rendered its own `<AppContentLayout>` → unmounted and remounted on every navigation.

**After:** Single `AppContentLayout` instance in shared `getLayout` → pages configure it via `useAppLayoutConfig()` context hook.

### New files

- **`AppLayoutContext.tsx`** — Context + provider for layout configuration. `useAppLayoutConfig(configFn, deps)` for pages to set config, `useAppLayout()` for `AppContentLayout` to read it. Uses `useLayoutEffect` for synchronous updates with cleanup to prevent stale config.
- **`appGetLayout.tsx`** — Shared `getLayout` functions: `appGetLayout`, `conversationGetLayout`, `spaceGetLayout`, `adminGetLayout`. Each wraps the page with `InputBarProvider` → `AppLayoutProvider` → `AppContentLayout`.
- **`AppContentLayoutWrapper.tsx`** (SPA) — React Router equivalent of `appGetLayout`.

### Changes to existing files

- **`AppContentLayout`** — Removed all props except `children`. Now reads config from `useAppLayout()`, owner/subscription from auth context.
- **`ConversationLayout`, `SpaceLayout`, `AdminLayout`, `DustAppPageLayout`** — Removed `<AppContentLayout>` wrapper, added `useAppLayoutConfig()` call instead.
- **Page components** (~12) — Removed `<AppContentLayout>` wrapper, added `useAppLayoutConfig()`.
- **Page files** (~32) — Replaced inline `getLayout` with shared `appGetLayout`/`conversationGetLayout`/`spaceGetLayout`/`adminGetLayout`.
- **SPA `App.tsx`** — Routes restructured with `AppContentLayoutWrapper` as shared layout route.

## Tests

- Verified sidebar persists across all navigation transitions (chat → spaces → admin → labs → profile)
- Verified loading states render inside the layout
- Type check passes (`npx tsgo --noEmit`)
- Lint passes

## Risk

Medium — touches many files but the change is mechanical: remove `<AppContentLayout>` wrapper from each page, add `useAppLayoutConfig()` call, replace `getLayout` with shared function. The layout tree structure is preserved, just hoisted.

Rollback is safe — revert returns to per-page `AppContentLayout` rendering.

## Deploy Plan

Standard deploy. Stacked on #21415.