### PR TITLE
Fix conversation suggestion cards; Minor bugs

### DIFF
--- a/front/components/agent_builder/AgentBuilderRightPanel.tsx
+++ b/front/components/agent_builder/AgentBuilderRightPanel.tsx
@@ -64,7 +64,7 @@ function PanelHeader({
                 {hasCopilot && (
                   <TabsTrigger
                     value="copilot"
-                    label="Copilot"
+                    label="Copilot (Beta)"
                     icon={RobotIcon}
                     onClick={() => onTabChange("copilot")}
                   />

--- a/front/components/agent_builder/copilot/CopilotSuggestionsContext.tsx
+++ b/front/components/agent_builder/copilot/CopilotSuggestionsContext.tsx
@@ -514,10 +514,20 @@ export const CopilotSuggestionsProvider = ({
       editor
         .chain()
         .focus()
-        // Position + 1 to trigger the suggestion bubble menu
-        .setTextSelection(position + 1)
+        .setHighlightedSuggestion(suggestionId)
+        .setTextSelection(position)
         .scrollIntoView()
         .run();
+
+      // After focusing, trigger a click on the suggestion element to open the bubble menu
+      requestAnimationFrame(() => {
+        const suggestionElement = editor.view.dom.querySelector(
+          `[data-suggestion-id="${suggestionId}"]`
+        );
+        if (suggestionElement instanceof HTMLElement) {
+          suggestionElement.click();
+        }
+      });
     }
   }, []);
 

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -488,7 +488,7 @@ export function AgentMessage({
   const { hasFeature } = useFeatureFlags({
     workspaceId: owner.sId,
   });
-  const hasCopilotFeatureFlag = hasFeature("agent_builder_copilot");
+  const hasShrinkWrapFeatureFlag = hasFeature("agent_builder_shrink_wrap");
 
   const handleDeleteAgentMessage = useCallback(async () => {
     if (isDeleted || !canDeleteAgentMessage || isDeleting) {
@@ -606,7 +606,7 @@ export function AgentMessage({
       });
     }
 
-    if (hasCopilotFeatureFlag && isLastMessage && isBuilder(owner)) {
+    if (hasShrinkWrapFeatureFlag && isLastMessage && isBuilder(owner)) {
       dropdownItems.push({
         label: "Turn into agent",
         icon: RobotIcon,

--- a/front/components/assistant/conversation/types.ts
+++ b/front/components/assistant/conversation/types.ts
@@ -103,8 +103,8 @@ export const isHiddenMessage = (message: VirtuosoMessage): boolean => {
   return (
     (isUserMessage(message) &&
       (message.context.origin === "onboarding_conversation" ||
-        message.context.origin === "agent_copilot" ||
-        message.context.origin === "project_kickoff")) ||
+        message.context.origin === "project_kickoff" ||
+        isCopilotBootstrapMessage(message))) ||
     isHandoverUserMessage(message)
   );
 };
@@ -142,3 +142,9 @@ export const makeInitialMessageStreamState = (
 
 export const hasHumansInteracting = (messages: VirtuosoMessage[]) =>
   uniq(messages.filter(isUserMessage).map((m) => m.user?.sId)).length >= 2;
+
+export const isCopilotBootstrapMessage = (
+  message: UserMessageTypeWithContentFragments
+): boolean => {
+  return message.context.origin === "agent_copilot" && message.rank === 0;
+};

--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -29,6 +29,10 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Enable Copilot in Agent Builder",
     stage: "dust_only",
   },
+  agent_builder_shrink_wrap: {
+    description: "Enable 'Turn into agent' button on agent messages",
+    stage: "dust_only",
+  },
   ashby_tool: {
     description: "Ashby tool for ATS integration",
     stage: "on_demand",

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -658,6 +658,7 @@ export type RetrievalDocumentPublicType = z.infer<
 const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "advanced_notion_management"
   | "agent_builder_copilot"
+  | "agent_builder_shrink_wrap"
   | "agent_management_tool"
   | "agent_to_yaml"
   | "custom_model_feature"

--- a/sparkle/src/components/DiffBlock.tsx
+++ b/sparkle/src/components/DiffBlock.tsx
@@ -119,17 +119,17 @@ export function DiffBlock({
           <div ref={contentRef} className="s-space-y-4 s-font-mono s-text-sm">
             {changes.map((change, index) => (
               <div key={index} className="s-space-y-0.5">
-                {change.old && (
-                  <div className="s-whitespace-pre-wrap">
-                    <span className={diffLineVariants({ type: "remove" })}>
-                      {change.old}
-                    </span>
-                  </div>
-                )}
                 {change.new && (
                   <div className="s-whitespace-pre-wrap">
                     <span className={diffLineVariants({ type: "add" })}>
                       {change.new}
+                    </span>
+                  </div>
+                )}
+                {change.old && (
+                  <div className="s-whitespace-pre-wrap">
+                    <span className={diffLineVariants({ type: "remove" })}>
+                      {change.old}
                     </span>
                   </div>
                 )}

--- a/sparkle/src/components/DiffBlock.tsx
+++ b/sparkle/src/components/DiffBlock.tsx
@@ -119,17 +119,17 @@ export function DiffBlock({
           <div ref={contentRef} className="s-space-y-4 s-font-mono s-text-sm">
             {changes.map((change, index) => (
               <div key={index} className="s-space-y-0.5">
-                {change.new && (
-                  <div className="s-whitespace-pre-wrap">
-                    <span className={diffLineVariants({ type: "add" })}>
-                      {change.new}
-                    </span>
-                  </div>
-                )}
                 {change.old && (
                   <div className="s-whitespace-pre-wrap">
                     <span className={diffLineVariants({ type: "remove" })}>
                       {change.old}
+                    </span>
+                  </div>
+                )}
+                {change.new && (
+                  <div className="s-whitespace-pre-wrap">
+                    <span className={diffLineVariants({ type: "add" })}>
+                      {change.new}
                     </span>
                   </div>
                 )}


### PR DESCRIPTION
## Description

* Fixing instruction suggestion conversation card
* Marking copilot tab with beta tag
* Fixing suggestion highlighting from conversation
* Putting shrink wrap behind a different FF
* Fixing bug where copilot messages were always hidden (Note: I'm aware it might not be extensible to rely on this isCopilotBootstrapMessage function, but I wanted to avoid doing additional magic like we did for agent_handoff, so thought this was the cleanest approach)
* The card just shows the old diff string and the new diff string. I did not do any word-specific diff logic as I was concerned it would be more difficult to visualize in that view. 

## Tests
<img width="1572" height="716" alt="Screenshot 2026-02-10 at 5 55 33 PM" src="https://github.com/user-attachments/assets/7a5fa564-9e5d-48a7-b043-5a0d4f5802ef" />

## Risk

* Low

## Deploy Plan

* Deploy front