### PR TITLE
[front] Iterate on mentions global skill

### DIFF
--- a/front/lib/resources/skill/global/mention_users.ts
+++ b/front/lib/resources/skill/global/mention_users.ts
@@ -5,20 +5,22 @@ export const mentionUsersSkill = {
   name: "Mention Users",
   userFacingDescription:
     "Allow agents to mention and notify workspace users in conversations.",
-  agentFacingDescription: `Search for workspace users and mention them in responses to notify them. Use these tools when:
-- The user asks you to notify, alert, or mention someone
-- You need to include someone in the conversation`,
+  agentFacingDescription:
+    "Use this skill when you need to search for workspace users and " +
+    "mention them in responses to notify them. Some useful situations are:\n" +
+    "- The user asks you to notify, alert, or mention someone\n" +
+    "- You need to include someone in the conversation",
   instructions: `The "user_mentions" tools allow you to search for users in the workspace and mention them in your responses.
 
 Important notes:
-- Always search for users first using search_available_users before mentioning them
-- Use get_mention_markdown to get the correct markdown format for mentions
-- Only mention users when it's relevant and appropriate
-- Do not over-mention users - only when explicitly requested or clearly necessary
+- Before mentioning a user, search for users first using search_available_users tool
+- Use the get_mention_markdown tool if you need to get the correct Markdown format for mentions
+- Only mention users when it is relevant and appropriate
+- Do not over-mention users, only when explicitly requested or clearly necessary
 
 When to mention users (useful situations):
 - User explicitly asks to notify someone: "let John know about this", "tag Sarah", "notify the team lead"
-- Delegating tasks or requesting approval: "this needs Jane's review", "assign this to Mike"
+- Delegating tasks or requesting approval: "request a review from Jane", "assign this to Mike"
 - Bringing expertise into discussion: "we should get the security team's input on this"
 - Following up on action items: "as discussed with Alex, here's the update"
 - Notifying stakeholders about critical updates or blockers
@@ -29,16 +31,14 @@ When NOT to mention users:
 - Discussing someone in passing without needing their input: "John worked on this last week"
 - Routine automated reports or scheduled updates
 - When the user mentions someone conversationally without intent to notify: "similar to what Sarah did"
+- Ask a question about a user: "What is John's role?"
 `,
   mcpServers: [{ name: "user_mentions" }],
-  version: 1,
+  version: 2,
   icon: "ActionMegaphoneIcon",
-  isAutoEnabled: true,
   isDisabledForAgentLoop: ({ userMessage }) => {
-    return (
-      userMessage.context.origin === "slack" ||
-      userMessage.context.origin === "slack_workflow" ||
-      userMessage.context.origin === "teams"
+    return ["slack", "slack_workflow", "teams"].includes(
+      userMessage.context.origin
     );
   },
 } as const satisfies GlobalSkillDefinition;


### PR DESCRIPTION
## Description

- This PR aims at improving the instructions and agent facing description of the mentions global skill.
- Goal is to avoid incorrect triggers and spiky behaviors.
- Looking into [this conversation](https://app.dust.tt/w/0ec9852c2f/conversation/otrJEHxuMQ#?spid=rU02dIFUtd&spt=actions), one of the potential spiky behavior has been located as a missing context in the part about searching for users which, isolated, incentivizes the model to run a tool without correlating it to the intent behind it.
- Reformulates the agent facing description in a more passive and descriptive tone and adds an example.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
