### PR TITLE
[front] chore(FS-tools): move `cat` tool input schema to type file

### DIFF
--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.expected.json
@@ -1462,7 +1462,7 @@
               "type": "array"
             },
             "nodeId": {
-              "description": "The ID of the node to locate in the tree hierarchy.",
+              "description": "The ID of the node to locate in the tree.",
               "type": "string"
             }
           },

--- a/front/lib/actions/mcp_internal_actions/types.ts
+++ b/front/lib/actions/mcp_internal_actions/types.ts
@@ -190,6 +190,46 @@ export function isDataSourceFilesystemFindInputType(
   return DataSourceFilesystemFindInputSchema.safeParse(input).success;
 }
 
+export const DataSourceFilesystemCatInputSchema = z.object({
+  dataSources:
+    ConfigurableToolInputSchemas[INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE],
+  nodeId: z
+    .string()
+    .describe(
+      "The ID of the node to read. This is not the human-readable node title."
+    ),
+  offset: z
+    .number()
+    .optional()
+    .describe(
+      "The character position to start reading from (0-based). If not provided, starts from " +
+        "the beginning."
+    ),
+  limit: z
+    .number()
+    .optional()
+    .describe(
+      "The maximum number of characters to read. If not provided, reads all characters."
+    ),
+  grep: z
+    .string()
+    .optional()
+    .describe(
+      "A regular expression to filter lines. Applied after offset/limit slicing. Only lines " +
+        "matching this pattern will be returned."
+    ),
+});
+
+export type DataSourceFilesystemCatInputType = z.infer<
+  typeof DataSourceFilesystemCatInputSchema
+>;
+
+export function isDataSourceFilesystemCatInputType(
+  input: Record<string, unknown>
+): input is DataSourceFilesystemCatInputType {
+  return DataSourceFilesystemCatInputSchema.safeParse(input).success;
+}
+
 export const DataSourceFilesystemListInputSchema = z.object({
   nodeId: z
     .string()

--- a/front/lib/api/actions/servers/data_sources_file_system/metadata.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/metadata.ts
@@ -81,15 +81,7 @@ export const DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA = createToolsRecord({
       "Show the complete path from a node to the data source root, displaying the hierarchy of parent nodes. " +
       "This is useful for understanding where a specific node is located within the data source structure. " +
       "The path is returned as a list of nodes, with the first node being the data source root and the last node being the target node.",
-    schema: {
-      nodeId: z
-        .string()
-        .describe("The ID of the node to locate in the tree hierarchy."),
-      dataSources:
-        ConfigurableToolInputSchemas[
-          INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE
-        ],
-    },
+    schema: DataSourceFilesystemLocateTreeInputSchema.shape,
     stake: "never_ask",
     displayLabels: {
       running: "Locating content in hierarchy",

--- a/front/lib/api/actions/servers/data_sources_file_system/metadata.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/metadata.ts
@@ -1,16 +1,16 @@
 // eslint-disable-next-line dust/enforce-client-types-in-public-api
-import { INTERNAL_MIME_TYPES } from "@dust-tt/client";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
-import { ConfigurableToolInputSchemas } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import { DATA_SOURCE_FILESYSTEM_SERVER_INSTRUCTIONS } from "@app/lib/actions/mcp_internal_actions/instructions";
 import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import {
+  DataSourceFilesystemCatInputSchema,
   DataSourceFilesystemFindInputSchema,
   DataSourceFilesystemListInputSchema,
+  DataSourceFilesystemLocateTreeInputSchema,
   SearchWithNodesInputSchema,
   TagsInputSchema,
 } from "@app/lib/actions/mcp_internal_actions/types";
@@ -30,37 +30,7 @@ export const DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA = createToolsRecord({
   [FILESYSTEM_CAT_TOOL_NAME]: {
     description:
       "Read the contents of a document, referred to by its nodeId (named after the 'cat' unix tool). The nodeId can be obtained using the 'find', 'list' or 'search' tools.",
-    schema: {
-      dataSources:
-        ConfigurableToolInputSchemas[
-          INTERNAL_MIME_TYPES.TOOL_INPUT.DATA_SOURCE
-        ],
-      nodeId: z
-        .string()
-        .describe(
-          "The ID of the node to read. This is not the human-readable node title."
-        ),
-      offset: z
-        .number()
-        .optional()
-        .describe(
-          "The character position to start reading from (0-based). If not provided, starts from " +
-            "the beginning."
-        ),
-      limit: z
-        .number()
-        .optional()
-        .describe(
-          "The maximum number of characters to read. If not provided, reads all characters."
-        ),
-      grep: z
-        .string()
-        .optional()
-        .describe(
-          "A regular expression to filter lines. Applied after offset/limit slicing. Only lines " +
-            "matching this pattern will be returned."
-        ),
-    },
+    schema: DataSourceFilesystemCatInputSchema.shape,
     stake: "never_ask",
     displayLabels: {
       running: "Reading file from data source",

--- a/front/lib/api/actions/servers/data_sources_file_system/metadata.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/metadata.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line dust/enforce-client-types-in-public-api
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";


### PR DESCRIPTION
## Description

- This PR does 2 things: move the input schema of the `cat` tool to the same file as the other data source filesystem tools and re-use the existing schema for the `locate_in_tree` tool.
- Not necessary per se but nice to have all the schemas at one place (we didn't do it initially because we don't need the schema for `cat` in the `MCPActionDetails`, the component only relies on the output).

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
