### PR TITLE
Lower max concurrency activity for agent loop from 100 to 75

### DIFF
--- a/front/temporal/agent_loop/worker.ts
+++ b/front/temporal/agent_loop/worker.ts
@@ -68,6 +68,7 @@ export async function runAgentLoopWorker() {
     // This also bounds the time until an activity may receive a cancellation signal.
     // See https://docs.temporal.io/encyclopedia/detecting-activity-failures#throttling
     maxHeartbeatThrottleInterval: "20 seconds",
+    maxConcurrentActivityTaskExecutions: 75,
     interceptors: {
       workflowModules: removeNulls([
         !isDevelopment() || process.env.USE_TEMPORAL_BUNDLES === "true"


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See incident [thread](https://dust4ai.slack.com/archives/C05B529FHV1/p1770740384748679).

During the incident, we reach 100 activities running in concurrency, this led a few times on OOM events on our pods. This PR lowers the number of concurrent activities that can be processed to 75. The infra has been updated to use HPA to scale as needed so it should bridge the gap (previously max 1k activities -> new infra 1.5k activities). 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
