### PR TITLE
Project: polish tabs

### DIFF
--- a/front/components/assistant/conversation/space/SpaceAlphaTab.tsx
+++ b/front/components/assistant/conversation/space/SpaceAlphaTab.tsx
@@ -1,0 +1,27 @@
+import { LinkWrapper } from "@dust-tt/sparkle";
+
+export const SpaceAlphaTab = () => {
+  return (
+    <div className="flex h-full min-h-0 w-full flex-1 flex-col overflow-y-auto px-6">
+      <div className="mx-auto flex w-full max-w-4xl flex-col gap-6 py-8">
+        <p>
+          This feature is currently in alpha, and only available in the Dust
+          workspace ("projects" feature flag). The goal is to get feedback from
+          internal usage and quickly iterate.
+        </p>
+        <p>
+          Share your feedback in the{" "}
+          <LinkWrapper
+            href="https://dust4ai.slack.com/archives/C09T7N4S6GG"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-500 hover:text-blue-600"
+          >
+            initiative slack channel
+          </LinkWrapper>
+          .{" "}
+        </p>
+      </div>
+    </div>
+  );
+};

--- a/front/components/assistant/conversation/space/SpaceKnowledgeTab.tsx
+++ b/front/components/assistant/conversation/space/SpaceKnowledgeTab.tsx
@@ -13,6 +13,7 @@ import {
   TrashIcon,
 } from "@dust-tt/sparkle";
 import type { CellContext, ColumnDef } from "@tanstack/react-table";
+import moment from "moment";
 import React, { useContext, useMemo, useRef, useState } from "react";
 
 import { RenameFileDialog } from "@app/components/assistant/conversation/space/RenameFileDialog";
@@ -44,12 +45,8 @@ type ProjectFileWithActions = FileWithCreatorType & {
 };
 
 function formatDate(timestamp: number): string {
-  const date = new Date(timestamp);
-  return date.toLocaleDateString("en-US", {
-    month: "short",
-    day: "numeric",
-    year: "numeric",
-  });
+  const date = moment(timestamp).fromNow();
+  return date;
 }
 
 export function SpaceKnowledgeTab({ owner, space }: SpaceKnowledgeTabProps) {
@@ -286,7 +283,7 @@ export function SpaceKnowledgeTab({ owner, space }: SpaceKnowledgeTabProps) {
       />
 
       <div className="flex h-full min-h-0 w-full flex-1 flex-col overflow-y-auto px-6">
-        <div className="mx-auto flex w-full flex-col gap-4 py-8">
+        <div className="mx-auto flex w-full max-w-4xl flex-col gap-4 py-8">
           <div className="flex gap-2">
             <h3 className="heading-2xl flex-1 items-center">Knowledge</h3>
             {hasFiles && (
@@ -296,6 +293,7 @@ export function SpaceKnowledgeTab({ owner, space }: SpaceKnowledgeTabProps) {
                 label={uploadButtonLabel}
                 onClick={handleUploadClick}
                 disabled={isUploading}
+                isLoading={isUploading}
               />
             )}
           </div>
@@ -309,6 +307,7 @@ export function SpaceKnowledgeTab({ owner, space }: SpaceKnowledgeTabProps) {
                   label={uploadButtonLabel}
                   onClick={handleUploadClick}
                   disabled={isUploading}
+                  isLoading={isUploading}
                 />
               }
             />

--- a/front/components/assistant/conversation/space/conversations/SpaceConversationListItem.tsx
+++ b/front/components/assistant/conversation/space/conversations/SpaceConversationListItem.tsx
@@ -6,7 +6,6 @@ import { useMemo } from "react";
 
 import { useAppRouter } from "@app/lib/platform";
 import { getConversationRoute } from "@app/lib/utils/router";
-import { formatTimestring } from "@app/lib/utils/timestamps";
 import type { LightConversationType, WorkspaceType } from "@app/types";
 import { isUserMessageTypeWithContentFragments } from "@app/types";
 import { stripMarkdown } from "@app/types";
@@ -77,7 +76,7 @@ export function SpaceConversationListItem({
       ? "New Conversation"
       : `Conversation from ${new Date(conversation.created).toLocaleDateString()}`);
 
-  const time = formatTimestring(conversation.updated);
+  const time = moment(conversation.updated).fromNow();
 
   const replyCount = conversation.content.length - 1;
 

--- a/front/components/assistant/conversation/space/conversations/SpaceConversationsTab.tsx
+++ b/front/components/assistant/conversation/space/conversations/SpaceConversationsTab.tsx
@@ -1,8 +1,6 @@
 import {
   Button,
   cn,
-  ContentMessage,
-  LinkWrapper,
   ListGroup,
   ListItemSection,
   SearchInputWithPopover,
@@ -144,29 +142,6 @@ export function SpaceConversationsTab({
           )}
         >
           <div className="flex w-full flex-col gap-3">
-            <div>
-              <ContentMessage
-                title="Experimental feature"
-                variant="info"
-                size="lg"
-              >
-                <p>
-                  This feature is currently in alpha, and only available in the
-                  Dust workspace ("projects" feature flag). The goal is to get
-                  feedback from internal usage and quickly iterate. Share your
-                  feedback in the{" "}
-                  <LinkWrapper
-                    href="https://dust4ai.slack.com/archives/C09T7N4S6GG"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-blue-500 hover:text-blue-600"
-                  >
-                    initiative slack channel
-                  </LinkWrapper>
-                  .
-                </p>
-              </ContentMessage>
-            </div>
             <h2 className="heading-2xl text-foreground dark:text-foreground-night">
               {spaceInfo.name}
             </h2>

--- a/front/components/pages/conversation/SpaceConversationsPage.tsx
+++ b/front/components/pages/conversation/SpaceConversationsPage.tsx
@@ -7,6 +7,7 @@ import {
   TabsContent,
   TabsList,
   TabsTrigger,
+  TestTubeIcon,
 } from "@dust-tt/sparkle";
 import React, { useCallback, useState } from "react";
 
@@ -14,6 +15,7 @@ import { SpaceAboutTab } from "@app/components/assistant/conversation/space/abou
 import { SpaceConversationsTab } from "@app/components/assistant/conversation/space/conversations/SpaceConversationsTab";
 import { ManageUsersPanel } from "@app/components/assistant/conversation/space/ManageUsersPanel";
 import { ProjectHeaderActions } from "@app/components/assistant/conversation/space/ProjectHeaderActions";
+import { SpaceAlphaTab } from "@app/components/assistant/conversation/space/SpaceAlphaTab";
 import { SpaceKnowledgeTab } from "@app/components/assistant/conversation/space/SpaceKnowledgeTab";
 import { useActiveSpaceId } from "@app/hooks/useActiveSpaceId";
 import { useCreateConversationWithMessage } from "@app/hooks/useCreateConversationWithMessage";
@@ -298,6 +300,12 @@ export function SpaceConversationsPage() {
               label="Settings"
               icon={Cog6ToothIcon}
             />
+            <TabsTrigger
+              value="alpha"
+              label="Alpha"
+              icon={TestTubeIcon}
+              variant="warning-secondary"
+            />
           </TabsList>
 
           {spaceInfo.kind === "project" &&
@@ -340,6 +348,10 @@ export function SpaceConversationsPage() {
             space={spaceInfo}
             onOpenMembersPanel={() => setIsInvitePanelOpen(true)}
           />
+        </TabsContent>
+
+        <TabsContent value="alpha">
+          <SpaceAlphaTab key={spaceId} />
         </TabsContent>
       </Tabs>
       <ManageUsersPanel


### PR DESCRIPTION
## Description

- move ugly experimental warning in dedicated tab.
- keep knowledge width similar to other tabs.
- use relative time for conversations & knowledge.
- show loading animation when uploading file.

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy front