### PR TITLE
feat: agent builder space block ui for projects

### DIFF
--- a/front/components/agent_builder/capabilities/capabilities_sheet/SpaceSelectionPage.tsx
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/SpaceSelectionPage.tsx
@@ -1,14 +1,16 @@
-import { Checkbox, DataTable, Tooltip } from "@dust-tt/sparkle";
+import { Checkbox, cn, DataTable, Tooltip } from "@dust-tt/sparkle";
 import type { ColumnDef } from "@tanstack/react-table";
 import React, { useCallback, useMemo } from "react";
 
 import { useSpacesContext } from "@app/components/agent_builder/SpacesContext";
 import { getSpaceIcon, getSpaceName } from "@app/lib/spaces";
+import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import type { SpaceType } from "@app/types/space";
 
 type SpaceRowData = {
   sId: string;
   name: string;
+  description?: string;
   space: SpaceType;
   isSelected: boolean;
   isAlreadyRequested: boolean;
@@ -20,18 +22,41 @@ interface SpaceSelectionPageProps {
   alreadyRequestedSpaceIds: Set<string>;
   selectedSpaces: string[];
   setSelectedSpaces: React.Dispatch<React.SetStateAction<string[]>>;
+  searchQuery?: string;
 }
 
 export function SpaceSelectionPageContent({
   alreadyRequestedSpaceIds,
   selectedSpaces,
   setSelectedSpaces,
+  searchQuery = "",
 }: SpaceSelectionPageProps) {
-  const { spaces } = useSpacesContext();
+  const { spaces, owner } = useSpacesContext();
+
+  const { hasFeature } = useFeatureFlags({
+    workspaceId: owner.sId,
+  });
+
+  const isProjectsEnabled = hasFeature("projects");
 
   const selectableSpaces = useMemo(() => {
-    return spaces.filter((s) => s.kind !== "global");
-  }, [spaces]);
+    return spaces
+      .filter(
+        (s) =>
+          s.kind !== "global" &&
+          s.name.toLowerCase().includes(searchQuery.toLowerCase())
+      )
+      .sort((a, b) => {
+        // Public spaces first, then alphabetically
+        if (a.isRestricted && !b.isRestricted) {
+          return 1;
+        }
+        if (!a.isRestricted && b.isRestricted) {
+          return -1;
+        }
+        return getSpaceName(a).localeCompare(getSpaceName(b));
+      });
+  }, [spaces, searchQuery]);
 
   const selectedSpaceIds = useMemo(
     () => new Set(selectedSpaces),
@@ -50,18 +75,42 @@ export function SpaceSelectionPageContent({
     [setSelectedSpaces]
   );
 
-  const tableData: SpaceRowData[] = useMemo(() => {
-    return selectableSpaces.map((space) => {
-      const isAlreadyRequested = alreadyRequestedSpaceIds.has(space.sId);
-      return {
-        sId: space.sId,
-        name: getSpaceName(space),
-        space,
-        isSelected: selectedSpaceIds.has(space.sId) || isAlreadyRequested,
-        isAlreadyRequested,
-        onToggle: () => handleSpaceToggle(space),
-      };
-    });
+  const spacesTableData: SpaceRowData[] = useMemo(() => {
+    return selectableSpaces
+      .filter((space) => space.kind !== "project")
+      .map((space) => {
+        const isAlreadyRequested = alreadyRequestedSpaceIds.has(space.sId);
+        return {
+          sId: space.sId,
+          name: getSpaceName(space),
+          space,
+          isSelected: selectedSpaceIds.has(space.sId) || isAlreadyRequested,
+          isAlreadyRequested,
+          onToggle: () => handleSpaceToggle(space),
+        };
+      });
+  }, [
+    selectableSpaces,
+    alreadyRequestedSpaceIds,
+    selectedSpaceIds,
+    handleSpaceToggle,
+  ]);
+
+  const projectsTableData: SpaceRowData[] = useMemo(() => {
+    return selectableSpaces
+      .filter((s) => s.kind === "project")
+      .map((space) => {
+        const isAlreadyRequested = alreadyRequestedSpaceIds.has(space.sId);
+        return {
+          sId: space.sId,
+          name: getSpaceName(space),
+          description: space.description,
+          space,
+          isSelected: selectedSpaceIds.has(space.sId) || isAlreadyRequested,
+          isAlreadyRequested,
+          onToggle: () => handleSpaceToggle(space),
+        };
+      });
   }, [
     selectableSpaces,
     alreadyRequestedSpaceIds,
@@ -73,8 +122,6 @@ export function SpaceSelectionPageContent({
     () => [
       {
         id: "name",
-        accessorKey: "name",
-        header: "Name",
         cell: ({ row }) => {
           const SpaceIcon = getSpaceIcon(row.original.space);
           const cellContent = (
@@ -84,23 +131,33 @@ export function SpaceSelectionPageContent({
                   ? undefined
                   : row.original.onToggle
               }
+              grow
+              className={cn(
+                "p-3 hover:bg-muted-background dark:hover:bg-muted-background-night active:bg-primary-100 dark:active:bg-primary-100-night",
+                row.original.isAlreadyRequested
+                  ? "cursor-not-allowed opacity-60"
+                  : "cursor-pointer"
+              )}
             >
-              <div
-                className={`flex items-center gap-3 ${
-                  row.original.isAlreadyRequested
-                    ? "cursor-not-allowed opacity-60"
-                    : "cursor-pointer"
-                }`}
-              >
+              <div className="flex flex-row items-center justify-between gap-3">
+                <div className="flex flex-row items-center gap-3 min-w-0">
+                  <SpaceIcon className="h-5 w-5 min-h-5 min-w-5 text-muted-foreground dark:text-muted-foreground-night" />
+                  <div className="flex flex-col min-w-0">
+                    <span className="text-sm font-medium text-foreground dark:text-foreground-night truncate">
+                      {row.original.name}
+                    </span>
+                    <span className="text-xs text-muted-foreground dark:text-muted-foreground-night truncate">
+                      {row.original.description}
+                    </span>
+                  </div>
+                </div>
                 <Checkbox
                   checked={row.original.isSelected}
                   disabled={row.original.isAlreadyRequested}
                   onCheckedChange={row.original.onToggle}
                   onClick={(e: React.MouseEvent) => e.stopPropagation()}
-                  size="xs"
+                  size="sm"
                 />
-                <SpaceIcon className="h-4 w-4 text-muted-foreground dark:text-muted-foreground-night" />
-                <span>{row.original.name}</span>
               </div>
             </DataTable.CellContent>
           );
@@ -128,14 +185,33 @@ export function SpaceSelectionPageContent({
   return (
     <div className="flex flex-col gap-4">
       {selectableSpaces.length > 0 ? (
-        <DataTable
-          data={tableData}
-          columns={columns}
-          sorting={[{ id: "name", desc: false }]}
-        />
+        <div className="flex flex-col">
+          <div className="heading-sm bg-muted-background p-2 dark:bg-muted-background-night/50 text-foreground dark:text-foreground-night">
+            Spaces
+          </div>
+          <DataTable
+            data={spacesTableData}
+            columns={columns}
+            className="[&_thead]:hidden [&_td]:pl-0"
+          />
+          {isProjectsEnabled && (
+            <>
+              <div className="heading-sm bg-muted-background p-2 dark:bg-muted-background-night/50 text-foreground dark:text-foreground-night">
+                Projects
+              </div>
+              <DataTable
+                data={projectsTableData}
+                columns={columns}
+                className="[&_thead]:hidden [&_td]:pl-0"
+              />
+            </>
+          )}
+        </div>
       ) : (
         <div className="py-4 text-center text-sm text-muted-foreground dark:text-muted-foreground-night">
-          No spaces available
+          {searchQuery.length > 0
+            ? "No results found for your search"
+            : "No spaces and projects available"}
         </div>
       )}
     </div>

--- a/front/components/shared/RemoveSpaceDialog.tsx
+++ b/front/components/shared/RemoveSpaceDialog.tsx
@@ -102,12 +102,12 @@ export function useRemoveSpaceConfirm({
     const hasKnowledge = knowledgeInInstructions.length > 0;
 
     return confirm({
-      title: `Remove ${getSpaceName(space)} space`,
+      title: `Remove ${getSpaceName(space)} ${space.kind === "project" ? "project" : "space"}`,
       message: (
         <div className="space-y-3">
           <p className="text-sm">
             {hasKnowledge
-              ? `The following elements from this space are used in the ${entityName}:`
+              ? `The following elements from this ${space.kind === "project" ? "project" : "space"} are used in the ${entityName}:`
               : `This will remove the following elements from the ${entityName}:`}
           </p>
           <span className="flex flex-wrap items-center gap-1">
@@ -127,8 +127,8 @@ export function useRemoveSpaceConfirm({
           </span>
           {hasKnowledge && (
             <p className="dark:text-warning-night text-sm">
-              To remove this space, first update your instructions to remove the
-              knowledge references.
+              To remove this {space.kind === "project" ? "project" : "space"},
+              first update your instructions to remove the knowledge references.
             </p>
           )}
         </div>


### PR DESCRIPTION






## Description

This PR updates the agent builder spaces block UI to differentiate between projects and spaces.


<img width="1477" height="844" alt="Capture d’écran 2026-02-11 à 10 38 45" src="https://github.com/user-attachments/assets/07465f16-2b4c-4a30-a0fa-827177c7a73d" />
<img width="1477" height="844" alt="Capture d’écran 2026-02-11 à 10 39 41" src="https://github.com/user-attachments/assets/c3bf1253-41f7-41c5-8f5e-449426c47489" />
<img width="1477" height="844" alt="Capture d’écran 2026-02-11 à 10 43 57" src="https://github.com/user-attachments/assets/4f8f4438-aa7f-42c9-8789-7cbcbeafe151" />

## Tests

Manually

## Risks

Low - Changes are primarily UI-focused.

## Deploy Plan

Standard deployment - no special considerations needed.
