### PR TITLE
feat: add project availability warning in agent builder

### DIFF
--- a/front/components/agent_builder/AgentBuilderSpacesBlock.tsx
+++ b/front/components/agent_builder/AgentBuilderSpacesBlock.tsx
@@ -213,21 +213,24 @@ export function AgentBuilderSpacesBlock() {
               {nonGlobalSpacesWithRestrictions.map((v) => v.name).join(", ")}
             </strong>
             .
-          </ContentMessage>
-        </div>
-      )}
-      {isProjectsEnabled && displayProjectWarning && (
-        <div className="mb-4 w-full">
-          <ContentMessage variant="golden" size="lg">
-            {privateProjectWithoutWarning ? (
-              <>
-                Based on your selection of knowledge and capabilities, this
-                agent will only be available in the following project:{" "}
-                <strong>{privateProjectWithoutWarning.name}</strong>
-              </>
-            ) : (
-              "Based on your selection of knowledge and capabilities, this agent will be unavailable in project conversations."
-            )}
+            {isProjectsEnabled &&
+              displayProjectWarning &&
+              (privateProjectWithoutWarning ? (
+                <>
+                  <br />
+                  <br />
+                  Based on your selection of knowledge and capabilities, this
+                  agent will only be available in the following project:{" "}
+                  <strong>{privateProjectWithoutWarning.name}</strong>
+                </>
+              ) : (
+                <>
+                  <br />
+                  <br />
+                  Based on your selection of knowledge and capabilities, this
+                  agent will be unavailable in project conversations.
+                </>
+              ))}
           </ContentMessage>
         </div>
       )}

--- a/front/components/agent_builder/AgentBuilderSpacesBlock.tsx
+++ b/front/components/agent_builder/AgentBuilderSpacesBlock.tsx
@@ -92,6 +92,31 @@ export function AgentBuilderSpacesBlock() {
     return nonGlobalSpaces.filter((s) => allRequestedSpaceIds.has(s.sId));
   }, [spaces, actionsAndSkillsRequestedSpaceIds, additionalSpaces]);
 
+  const { displayProjectWarning, privateProjectWithoutWarning } =
+    useMemo(() => {
+      const allRequestedSpaceIds = new Set([
+        ...actionsAndSkillsRequestedSpaceIds,
+        ...additionalSpaces,
+      ]);
+
+      const selectedPrivateSpaces = spaces.filter(
+        (s) =>
+          s.kind !== "global" &&
+          allRequestedSpaceIds.has(s.sId) &&
+          s.isRestricted
+      );
+
+      const displayProjectWarning = selectedPrivateSpaces.length > 0;
+
+      const privateProjectWithoutWarning =
+        selectedPrivateSpaces.length === 1 &&
+        selectedPrivateSpaces[0].kind === "project"
+          ? selectedPrivateSpaces[0]
+          : null;
+
+      return { displayProjectWarning, privateProjectWithoutWarning };
+    }, [spaces, actionsAndSkillsRequestedSpaceIds, additionalSpaces]);
+
   const handleRemoveSpace = async (space: SpaceType) => {
     // Compute items to remove for the dialog
     const actionsToRemove = spaceIdToActions[space.sId] || [];
@@ -188,6 +213,21 @@ export function AgentBuilderSpacesBlock() {
               {nonGlobalSpacesWithRestrictions.map((v) => v.name).join(", ")}
             </strong>
             .
+          </ContentMessage>
+        </div>
+      )}
+      {isProjectsEnabled && displayProjectWarning && (
+        <div className="mb-4 w-full">
+          <ContentMessage variant="golden" size="lg">
+            {privateProjectWithoutWarning ? (
+              <>
+                Based on your selection of knowledge and capabilities, this
+                agent will only be available in the following project:{" "}
+                <strong>{privateProjectWithoutWarning.name}</strong>
+              </>
+            ) : (
+              "Based on your selection of knowledge and capabilities, this agent will be unavailable in project conversations."
+            )}
           </ContentMessage>
         </div>
       )}


### PR DESCRIPTION



## Description

This PR adds a warning that is displayed when the agent configuration will make the agent not available in projects
<img width="1082" height="630" alt="Capture d’écran 2026-02-11 à 15 04 30" src="https://github.com/user-attachments/assets/24b8a82c-2ffd-47e4-9a61-4ca10a5fe345" />
<img width="1082" height="630" alt="Capture d’écran 2026-02-11 à 15 04 42" src="https://github.com/user-attachments/assets/0aef4c1c-6cee-4f88-b59e-6b1bcfc169e6" />


## Tests

Manually

## Risks

Low risk - this is a UI-only change.

## Deploy Plan

No special deployment steps required - can be deployed normally.
