### PR TITLE
feat: display correct projects in agent builder

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -650,6 +650,7 @@ function AgentBuilderContent({
             // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
             agentConfigurationId={agentConfiguration?.sId || null}
             isTriggersLoading={isTriggersLoading}
+            initialRequestedSpaceIds={agentConfiguration?.requestedSpaceIds}
           />
         }
         rightPanel={

--- a/front/components/agent_builder/AgentBuilderLeftPanel.tsx
+++ b/front/components/agent_builder/AgentBuilderLeftPanel.tsx
@@ -21,6 +21,7 @@ interface AgentBuilderLeftPanelProps {
   agentConfigurationId: string | null;
   saveButtonProps?: ButtonProps;
   isTriggersLoading?: boolean;
+  initialRequestedSpaceIds?: string[];
 }
 
 export function AgentBuilderLeftPanel({
@@ -29,6 +30,7 @@ export function AgentBuilderLeftPanel({
   agentConfigurationId,
   saveButtonProps,
   isTriggersLoading,
+  initialRequestedSpaceIds,
 }: AgentBuilderLeftPanelProps) {
   const { owner } = useAgentBuilderContext();
 
@@ -55,8 +57,12 @@ export function AgentBuilderLeftPanel({
           <AgentBuilderInstructionsBlock
             agentConfigurationId={agentConfigurationId}
           />
-          <AgentBuilderSpacesBlock />
-          <AgentBuilderCapabilitiesBlock />
+          <AgentBuilderSpacesBlock
+            initialRequestedSpaceIds={initialRequestedSpaceIds}
+          />
+          <AgentBuilderCapabilitiesBlock
+            initialRequestedSpaceIds={initialRequestedSpaceIds}
+          />
           <AgentBuilderTriggersBlock
             owner={owner}
             isTriggersLoading={isTriggersLoading}

--- a/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
+++ b/front/components/agent_builder/capabilities/knowledge/KnowledgeConfigurationSheet.tsx
@@ -73,6 +73,7 @@ interface KnowledgeConfigurationSheetProps {
   mcpServerViews: MCPServerViewType[];
   getAgentInstructions: () => string;
   presetActionData?: TemplateActionPreset;
+  initialRequestedSpaceIds?: string[];
 }
 
 export function KnowledgeConfigurationSheet({
@@ -146,6 +147,7 @@ function KnowledgeConfigurationSheetForm({
   onSave,
   onCancel,
   setIsDirty,
+  initialRequestedSpaceIds,
 }: KnowledgeConfigurationSheetFormProps) {
   const { supportedDataSourceViews } = useDataSourceViewsContext();
 
@@ -230,6 +232,7 @@ function KnowledgeConfigurationSheetForm({
             onCancel={onCancel}
             getAgentInstructions={getAgentInstructions}
             isEditing={isEditing}
+            initialRequestedSpaceIds={initialRequestedSpaceIds}
           />
         </KnowledgePageProvider>
       </DataSourceBuilderProvider>
@@ -242,6 +245,7 @@ interface KnowledgeConfigurationSheetContentProps {
   onCancel: () => Promise<void>;
   getAgentInstructions: () => string;
   isEditing: boolean;
+  initialRequestedSpaceIds?: string[];
 }
 
 function KnowledgeConfigurationSheetContent({
@@ -249,6 +253,7 @@ function KnowledgeConfigurationSheetContent({
   onCancel,
   getAgentInstructions,
   isEditing,
+  initialRequestedSpaceIds,
 }: KnowledgeConfigurationSheetContentProps) {
   const { currentPageId, setSheetPageId } = useKnowledgePageContext();
   const { setValue, getValues, setFocus } =
@@ -365,7 +370,12 @@ function KnowledgeConfigurationSheetContent({
         : "Choose the data sources to include in your knowledge base",
       icon: undefined,
       noScroll: true,
-      content: <DataSourceBuilderSelector viewType="all" />,
+      content: (
+        <DataSourceBuilderSelector
+          viewType="all"
+          initialRequestedSpaceIds={initialRequestedSpaceIds}
+        />
+      ),
       footerContent: <KnowledgeFooter />,
     },
     {

--- a/front/components/agent_builder/skills/AgentBuilderCapabilitiesBlock.tsx
+++ b/front/components/agent_builder/skills/AgentBuilderCapabilitiesBlock.tsx
@@ -116,7 +116,13 @@ function ActionButtons({
   );
 }
 
-export function AgentBuilderCapabilitiesBlock() {
+interface AgentBuilderCapabilitiesBlockProps {
+  initialRequestedSpaceIds?: string[];
+}
+
+export function AgentBuilderCapabilitiesBlock({
+  initialRequestedSpaceIds,
+}: AgentBuilderCapabilitiesBlockProps) {
   const sendNotification = useSendNotification();
   const { owner } = useAgentBuilderContext();
 
@@ -355,6 +361,7 @@ export function AgentBuilderCapabilitiesBlock() {
         presetActionData={
           sheetState.state === "knowledge" ? sheetState.presetData : undefined
         }
+        initialRequestedSpaceIds={initialRequestedSpaceIds}
       />
       <CapabilitiesSheet
         isOpen={isCapabilitiesSheetOpen(sheetState)}

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -40,6 +40,7 @@ import type {
   PatchProjectMetadataResponseBody,
 } from "@app/pages/api/w/[wId]/spaces/[spaceId]/project_metadata";
 import type { GetUserProjectDigestsResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/user_project_digests";
+<<<<<<< HEAD
 import type { PatchProjectMetadataBodyType } from "@app/types/api/internal/spaces";
 import type { DataSourceViewCategoryWithoutApps } from "@app/types/api/public/spaces";
 import type { ContentNodesViewType } from "@app/types/connectors/content_nodes";
@@ -50,6 +51,21 @@ import type { ProjectMetadataType } from "@app/types/project_metadata";
 import { isString } from "@app/types/shared/utils/general";
 import type { SpaceKind, SpaceType } from "@app/types/space";
 import type { LightWorkspaceType } from "@app/types/user";
+=======
+import type { SpacesLookupResponseBody } from "@app/pages/api/w/[wId]/spaces/projects-lookup";
+import type {
+  ContentNodesViewType,
+  DataSourceViewCategoryWithoutApps,
+  DataSourceViewType,
+  LightWorkspaceType,
+  PatchProjectMetadataBodyType,
+  ProjectMetadataType,
+  SearchWarningCode,
+  SpaceKind,
+  SpaceType,
+} from "@app/types";
+import { isString, MIN_SEARCH_QUERY_SIZE } from "@app/types";
+>>>>>>> 66118820c5 (feat: display correct projects in agent builder)
 
 export function useSpaces({
   workspaceId,
@@ -81,6 +97,45 @@ export function useSpaces({
     spaces,
     isSpacesLoading: !error && !data && !disabled,
     isSpacesError: error,
+    mutate,
+  };
+}
+
+export function useSpaceProjectsLookup({
+  workspaceId,
+  spaceIds,
+  disabled,
+}: {
+  workspaceId: string;
+  spaceIds: string[];
+  disabled?: boolean;
+}) {
+  const spacesLookupFetcher: Fetcher<SpacesLookupResponseBody> = fetcher;
+
+  const query =
+    spaceIds.length > 0
+      ? `/api/w/${workspaceId}/spaces/projects-lookup?${spaceIds
+          .map((id) => `ids=${encodeURIComponent(id)}`)
+          .join("&")}`
+      : null;
+
+  const { data, error, mutate } = useSWRWithDefaults(
+    query,
+    spacesLookupFetcher,
+    { disabled: disabled ?? spaceIds.length === 0 }
+  );
+
+  const spaces = useMemo(() => {
+    if (!data?.spaces) {
+      return emptyArray<SpaceType>();
+    }
+    return data.spaces;
+  }, [data?.spaces]);
+
+  return {
+    spaces,
+    isSpacesLookupLoading: !error && !data && !!query && !disabled,
+    isSpacesLookupError: !!error,
     mutate,
   };
 }

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -40,7 +40,7 @@ import type {
   PatchProjectMetadataResponseBody,
 } from "@app/pages/api/w/[wId]/spaces/[spaceId]/project_metadata";
 import type { GetUserProjectDigestsResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]/user_project_digests";
-<<<<<<< HEAD
+import type { SpacesLookupResponseBody } from "@app/pages/api/w/[wId]/spaces/projects-lookup";
 import type { PatchProjectMetadataBodyType } from "@app/types/api/internal/spaces";
 import type { DataSourceViewCategoryWithoutApps } from "@app/types/api/public/spaces";
 import type { ContentNodesViewType } from "@app/types/connectors/content_nodes";
@@ -51,21 +51,6 @@ import type { ProjectMetadataType } from "@app/types/project_metadata";
 import { isString } from "@app/types/shared/utils/general";
 import type { SpaceKind, SpaceType } from "@app/types/space";
 import type { LightWorkspaceType } from "@app/types/user";
-=======
-import type { SpacesLookupResponseBody } from "@app/pages/api/w/[wId]/spaces/projects-lookup";
-import type {
-  ContentNodesViewType,
-  DataSourceViewCategoryWithoutApps,
-  DataSourceViewType,
-  LightWorkspaceType,
-  PatchProjectMetadataBodyType,
-  ProjectMetadataType,
-  SearchWarningCode,
-  SpaceKind,
-  SpaceType,
-} from "@app/types";
-import { isString, MIN_SEARCH_QUERY_SIZE } from "@app/types";
->>>>>>> 66118820c5 (feat: display correct projects in agent builder)
 
 export function useSpaces({
   workspaceId,

--- a/front/pages/api/w/[wId]/spaces/projects-lookup.ts
+++ b/front/pages/api/w/[wId]/spaces/projects-lookup.ts
@@ -1,0 +1,85 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import z from "zod";
+
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { apiError } from "@app/logger/withlogging";
+import type { SpaceType, WithAPIErrorResponse } from "@app/types";
+
+const SpacesLookupQuerySchema = z.object({
+  ids: z.union([z.string(), z.array(z.string())]),
+});
+
+export type SpacesLookupResponseBody = {
+  spaces: SpaceType[];
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<SpacesLookupResponseBody>>,
+  auth: Authenticator
+): Promise<void> {
+  switch (req.method) {
+    case "GET": {
+      const queryValidation = SpacesLookupQuerySchema.safeParse(req.query);
+      if (!queryValidation.success) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "The query parameter `ids` is required.",
+          },
+        });
+      }
+
+      const rawIds = queryValidation.data.ids;
+      const ids = Array.isArray(rawIds) ? rawIds : [rawIds];
+
+      if (ids.length === 0) {
+        return res.status(200).json({ spaces: [] });
+      }
+
+      const uniqueIds = Array.from(new Set(ids));
+      const spaces = await SpaceResource.fetchByIds(auth, uniqueIds);
+      const openProjects = spaces.filter(
+        (space) => space.isProject() && space.isOpen()
+      );
+
+      // Fetch project metadata for projects to include description
+      const projectsWithDescriptions = await concurrentExecutor(
+        openProjects,
+        async (space) => {
+          const spaceJson = space.toJSON();
+
+          const projectMetadata = await ProjectMetadataResource.fetchBySpace(
+            auth,
+            space
+          );
+          if (projectMetadata) {
+            spaceJson.description = projectMetadata.description ?? undefined;
+          }
+          return spaceJson;
+        },
+        { concurrency: 8 }
+      );
+
+      return res.status(200).json({
+        spaces: projectsWithDescriptions,
+      });
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/spaces/projects-lookup.ts
+++ b/front/pages/api/w/[wId]/spaces/projects-lookup.ts
@@ -7,7 +7,8 @@ import { ProjectMetadataResource } from "@app/lib/resources/project_metadata_res
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import { apiError } from "@app/logger/withlogging";
-import type { SpaceType, WithAPIErrorResponse } from "@app/types";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import type { SpaceType } from "@app/types/space";
 
 const SpacesLookupQuerySchema = z.object({
   ids: z.union([z.string(), z.array(z.string())]),
@@ -45,7 +46,7 @@ async function handler(
       const uniqueIds = Array.from(new Set(ids));
       const spaces = await SpaceResource.fetchByIds(auth, uniqueIds);
       const openProjects = spaces.filter(
-        (space) => space.isProject() && space.isOpen()
+        (space) => space.isProject() && space.canRead(auth)
       );
 
       // Fetch project metadata for projects to include description


### PR DESCRIPTION
## Description

This PR fixes a visibility issue in the agent builder where public projects linked to an agent were not displayed for users who are not members of those projects.

When an agent is configured to use data from a public project, users who edit that agent need to see which projects are being used, even if they are not members of those projects. Previously, only projects the user was a member of would appear in the agent builder UI, hiding some of the agent's actual data sources.

Note that is the agent is linked to a private project that the user does not have access to, the user will not be able to access the agent builder.

Note that an alternative would have been to display all open project, regardless of the user being a member. This option has been discarded to avoid displaying too many projects.

## Tests

Manually

## Risk

Low risk. The changes only affect the agent builder UI and ensure proper visibility of public projects. The new endpoint respects project visibility rules (only returns open projects).

## Deploy Plan

Standard deployment. No special considerations needed.
