### PR TITLE
Polish Capabilities tool input bar

### DIFF
--- a/front/components/actions/mcp/MCPServerDetails.tsx
+++ b/front/components/actions/mcp/MCPServerDetails.tsx
@@ -29,6 +29,7 @@ interface MCPServerDetailsProps {
   onClose: () => void;
   mcpServerView: MCPServerViewType | null;
   isOpen: boolean;
+  readOnly?: boolean;
 }
 
 export function MCPServerDetails({
@@ -36,6 +37,7 @@ export function MCPServerDetails({
   mcpServerView,
   isOpen,
   onClose,
+  readOnly = false,
 }: MCPServerDetailsProps) {
   const { spaces } = useSpacesAsAdmin({
     workspaceId: owner.sId,
@@ -343,6 +345,7 @@ export function MCPServerDetails({
         onSave={onSave}
         onCancel={onCancel}
         spaces={spaces}
+        readOnly={readOnly}
       />
     </FormProvider>
   );

--- a/front/components/actions/mcp/MCPServerDetailsInfo.tsx
+++ b/front/components/actions/mcp/MCPServerDetailsInfo.tsx
@@ -12,15 +12,18 @@ import {
 } from "@app/lib/actions/mcp_helper";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
 import type { LightWorkspaceType } from "@app/types";
+import { asDisplayName } from "@app/types";
 
 type MCPServerDetailsInfoProps = {
   mcpServerView: MCPServerViewType | null;
   owner: LightWorkspaceType;
+  readOnly?: boolean;
 };
 
 export function MCPServerDetailsInfo({
   mcpServerView,
   owner,
+  readOnly = false,
 }: MCPServerDetailsInfoProps) {
   const editedAt = useMemo(() => {
     const d = new Date(0);
@@ -30,6 +33,32 @@ export function MCPServerDetailsInfo({
 
   if (!mcpServerView) {
     return null;
+  }
+
+  if (readOnly) {
+    const tools = mcpServerView.server.tools ?? [];
+    return (
+      <div className="flex flex-col gap-2">
+        <div className="heading-lg">Available Tools ({tools.length})</div>
+        {tools.map((tool, index) => (
+          <div key={index} className="flex flex-col gap-1 py-1">
+            <div className="heading-base text-foreground dark:text-foreground-night">
+              {asDisplayName(tool.name)}
+            </div>
+            {tool.description && (
+              <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+                {tool.description}
+              </p>
+            )}
+          </div>
+        ))}
+        {tools.length === 0 && (
+          <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+            No tools available.
+          </p>
+        )}
+      </div>
+    );
   }
 
   const requiresBearerToken = requiresBearerTokenConfiguration(

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -388,6 +388,7 @@ export const InputBar = React.memo(function InputBar({
             attachedNodes={attachedNodes}
             saveDraft={saveDraft}
             getDraft={getDraft}
+            user={user}
           />
         </div>
       </div>

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -52,6 +52,7 @@ import type {
   RichAgentMention,
   RichMention,
   SpaceType,
+  UserType,
   WorkspaceType,
 } from "@app/types";
 import {
@@ -98,6 +99,7 @@ export interface InputBarContainerProps {
   selectedMCPServerViews: MCPServerViewType[];
   selectedSkills: SkillType[];
   stickyMentions?: RichMention[];
+  user: UserType | null;
 }
 
 const InputBarContainer = ({
@@ -124,6 +126,7 @@ const InputBarContainer = ({
   onSkillDeselect,
   selectedSkills,
   saveDraft,
+  user,
 }: InputBarContainerProps) => {
   const isMobile = useIsMobile();
   const [nodeOrUrlCandidate, setNodeOrUrlCandidate] = useState<
@@ -759,6 +762,7 @@ const InputBarContainer = ({
                   {actions.includes("capabilities") && (
                     <CapabilitiesPicker
                       owner={owner}
+                      user={user}
                       selectedMCPServerViews={selectedMCPServerViews}
                       onSelect={onMCPServerViewSelect}
                       selectedSkills={selectedSkills}


### PR DESCRIPTION
## Description

- Improved CapabilitiesPicker dropdown design: removed inline descriptions (now shown as tooltips on hover), narrowed the dropdown width, reduced item padding for a more compact list.
- Added detail sheet access: hover reveals a 3-dot button that opens SkillDetailsSheet for skills and a read-only MCPServerDetails for tools.
- Added readOnly mode to MCPServerDetails: hides tabs, footer (Save/Cancel), delete button, and admin forms — shows only the server header and a clean list of tools with
names and descriptions.


### Before

<kbd>
<img width="854" height="574" alt="Screenshot 2026-02-11 at 10 20 18" src="https://github.com/user-attachments/assets/0056d51a-7360-45cb-9acc-b614d85970f3" />
</kbd>

### After 

<kbd>
<img width="854" height="617" alt="Screenshot 2026-02-11 at 10 16 29" src="https://github.com/user-attachments/assets/798e51bf-ff09-49fe-8543-d899b075460a" />
</kbd>

This follows design from @pinotalexandre [here](https://dust4ai.slack.com/archives/C066R3PMUAU/p1770651225179049?thread_ts=1770125657.074659&cid=C066R3PMUAU)!

If I click on the 3dots buttons it will open a side modal. For skills we already had one, for tools I simply made a "readonly" version of the one we display in the agent builder. It looks like this: 

<kbd>
<img width="629" height="779" alt="Screenshot 2026-02-11 at 10 18 47" src="https://github.com/user-attachments/assets/4af9abd5-02a0-4119-bf4d-7fdb7a4b0e59" />
</kbd>

## Tests

Locally. 

## Risk

Break this list, break tool modal on builder? 
Can be rolled back. 

## Deploy Plan

Deploy front. 