### PR TITLE
Extract dustapp layout

### DIFF
--- a/front-spa/src/app/App.tsx
+++ b/front-spa/src/app/App.tsx
@@ -7,6 +7,7 @@ import { AdminRouterLayout } from "@spa/app/layouts/AdminRouterLayout";
 import { AppContentRouterLayout } from "@spa/app/layouts/AppContentRouterLayout";
 import { AuthenticatedPage } from "@spa/app/layouts/AuthenticatedPage";
 import { ConversationRouterLayout } from "@spa/app/layouts/ConversationRouterLayout";
+import { DustAppRouterLayout } from "@spa/app/layouts/DustAppRouterLayout";
 import { SpaceRouterLayout } from "@spa/app/layouts/SpaceRouterLayout";
 import { UnauthenticatedPage } from "@spa/app/layouts/UnauthenticatedPage";
 import { WorkspacePage } from "@spa/app/layouts/WorkspacePage";
@@ -391,31 +392,19 @@ const router = createBrowserRouter(
             },
 
             // Apps
-            { path: "spaces/:spaceId/apps/:aId", element: <AppViewPage /> },
             {
-              path: "spaces/:spaceId/apps/:aId/settings",
-              element: <AppSettingsPage />,
-            },
-            {
-              path: "spaces/:spaceId/apps/:aId/specification",
-              element: <AppSpecificationPage />,
-            },
-            {
-              path: "spaces/:spaceId/apps/:aId/datasets",
-              element: <DatasetsPage />,
-            },
-            {
-              path: "spaces/:spaceId/apps/:aId/datasets/new",
-              element: <NewDatasetPage />,
-            },
-            {
-              path: "spaces/:spaceId/apps/:aId/datasets/:name",
-              element: <DatasetPage />,
-            },
-            { path: "spaces/:spaceId/apps/:aId/runs", element: <RunsPage /> },
-            {
-              path: "spaces/:spaceId/apps/:aId/runs/:runId",
-              element: <RunPage />,
+              path: "spaces/:spaceId/apps/:aId",
+              element: <DustAppRouterLayout />,
+              children: [
+                { index: true, element: <AppViewPage /> },
+                { path: "settings", element: <AppSettingsPage /> },
+                { path: "specification", element: <AppSpecificationPage /> },
+                { path: "datasets", element: <DatasetsPage /> },
+                { path: "datasets/new", element: <NewDatasetPage /> },
+                { path: "datasets/:name", element: <DatasetPage /> },
+                { path: "runs", element: <RunsPage /> },
+                { path: "runs/:runId", element: <RunPage /> },
+              ],
             },
 
             // Builder (pages with sidebar layout)

--- a/front-spa/src/app/layouts/DustAppRouterLayout.tsx
+++ b/front-spa/src/app/layouts/DustAppRouterLayout.tsx
@@ -1,0 +1,10 @@
+import { DustAppPageLayout } from "@dust-tt/front/components/apps/DustAppPageLayout";
+import { Outlet } from "react-router-dom";
+
+export function DustAppRouterLayout() {
+  return (
+    <DustAppPageLayout>
+      <Outlet />
+    </DustAppPageLayout>
+  );
+}

--- a/front-spa/src/lib/platform.tsx
+++ b/front-spa/src/lib/platform.tsx
@@ -273,20 +273,25 @@ export function useAppRouter(): AppRouter {
   // In SPA mode, router is always ready (no SSR hydration needed)
   const isReady = true;
 
-  return {
-    push,
-    replace,
-    back,
-    reload,
-    pathname,
-    asPath: pathname + search + hash,
-    query,
-    isReady,
-    events: routerEvents,
-    // beforePopState is a noop in SPA mode (not supported in React Router)
-    // TODO: Check usage in AppContentLayout and remove it.
-    beforePopState: () => {},
-  };
+  const beforePopState = useCallback(() => {}, []);
+
+  return useMemo(
+    () => ({
+      push,
+      replace,
+      back,
+      reload,
+      pathname,
+      asPath: pathname + search + hash,
+      query,
+      isReady,
+      events: routerEvents,
+      // beforePopState is a noop in SPA mode (not supported in React Router)
+      // TODO: Check usage in AppContentLayout and remove it.
+      beforePopState,
+    }),
+    [push, replace, back, reload, pathname, search, hash, query, beforePopState]
+  );
 }
 
 /**

--- a/front/components/pages/spaces/apps/AppSettingsPage.tsx
+++ b/front/components/pages/spaces/apps/AppSettingsPage.tsx
@@ -1,7 +1,6 @@
 import { Button, Input, Label, Spinner } from "@dust-tt/sparkle";
 import { useContext, useEffect, useState } from "react";
 
-import { DustAppPageLayout } from "@app/components/apps/DustAppPageLayout";
 import { ConfirmContext } from "@app/components/Confirm";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
@@ -159,51 +158,49 @@ export function AppSettingsPage() {
   }
 
   return (
-    <DustAppPageLayout app={app} currentTab="settings">
-      <div className="mt-8 flex flex-1">
-        <div className="flex flex-col">
-          <div className="flex flex-col gap-6">
-            <div className="flex w-64 flex-col gap-2">
-              <Label>App Name</Label>
-              <Input
-                type="text"
-                name="name"
-                id="appName"
-                value={appName}
-                onChange={(e) => setAppName(e.target.value)}
-                message="Use only a-z, 0-9, - or _. Must be unique."
-                messageStatus={appNameError ? "error" : "default"}
-              />
-            </div>
-
-            <div className="flex flex-col gap-2">
-              <Label>Description</Label>
-              <Input
-                type="text"
-                name="description"
-                id="appDescription"
-                value={appDescription}
-                onChange={(e) => setAppDescription(e.target.value)}
-                message="Description needed to use in Agent Builder - helps agents understand when to use your app."
-                messageStatus="default"
-              />
-            </div>
-          </div>
-          <div className="flex justify-between py-6">
-            <Button
-              disabled={disable || isUpdating || isDeleting}
-              onClick={handleUpdate}
-              label={isUpdating ? "Updating..." : "Update"}
+    <div className="mt-8 flex flex-1">
+      <div className="flex flex-col">
+        <div className="flex flex-col gap-6">
+          <div className="flex w-64 flex-col gap-2">
+            <Label>App Name</Label>
+            <Input
+              type="text"
+              name="name"
+              id="appName"
+              value={appName}
+              onChange={(e) => setAppName(e.target.value)}
+              message="Use only a-z, 0-9, - or _. Must be unique."
+              messageStatus={appNameError ? "error" : "default"}
             />
-            <Button
-              variant="warning"
-              onClick={handleDelete}
-              disabled={isDeleting || isUpdating}
-              label={isDeleting ? "Deleting..." : "Delete"}
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <Label>Description</Label>
+            <Input
+              type="text"
+              name="description"
+              id="appDescription"
+              value={appDescription}
+              onChange={(e) => setAppDescription(e.target.value)}
+              message="Description needed to use in Agent Builder - helps agents understand when to use your app."
+              messageStatus="default"
             />
           </div>
         </div>
+        <div className="flex justify-between py-6">
+          <Button
+            disabled={disable || isUpdating || isDeleting}
+            onClick={handleUpdate}
+            label={isUpdating ? "Updating..." : "Update"}
+          />
+          <Button
+            variant="warning"
+            onClick={handleDelete}
+            disabled={isDeleting || isUpdating}
+            label={isDeleting ? "Deleting..." : "Delete"}
+          />
+        </div>
       </div>
-    </DustAppPageLayout>
+    </div>
   );
 }

--- a/front/components/pages/spaces/apps/AppSpecificationPage.tsx
+++ b/front/components/pages/spaces/apps/AppSpecificationPage.tsx
@@ -1,23 +1,14 @@
-import { Spinner, Tabs, TabsList, TabsTrigger } from "@dust-tt/sparkle";
+import { Spinner } from "@dust-tt/sparkle";
 import { useMemo } from "react";
 
-import { subNavigationApp } from "@app/components/navigation/config";
-import {
-  useSetContentWidth,
-  useSetHideSidebar,
-  useSetTitle,
-} from "@app/components/sparkle/AppLayoutContext";
-import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { useWorkspace } from "@app/lib/auth/AuthContext";
-import { useAppRouter, useRequiredPathParam } from "@app/lib/platform";
-import { dustAppsListUrl } from "@app/lib/spaces";
+import { useRequiredPathParam } from "@app/lib/platform";
 import { dumpSpecification } from "@app/lib/specification";
 import { useApp } from "@app/lib/swr/apps";
 import Custom404 from "@app/pages/404";
 import type { SpecificationType } from "@app/types/app";
 
 export function AppSpecificationPage() {
-  const router = useAppRouter();
   const spaceId = useRequiredPathParam("spaceId");
   const aId = useRequiredPathParam("aId");
   const owner = useWorkspace();
@@ -46,60 +37,24 @@ export function AppSpecificationPage() {
     }
   }, [app]);
 
-  const title = useMemo(
-    () =>
-      app ? (
-        <AppLayoutSimpleCloseTitle
-          title={app.name}
-          onClose={() => {
-            void router.push(dustAppsListUrl(owner, app.space));
-          }}
-        />
-      ) : undefined,
-    [owner, app, router]
-  );
+  if (isAppError || (!isAppLoading && !app)) {
+    return <Custom404 />;
+  }
 
-  useSetContentWidth("centered");
-  useSetHideSidebar(true);
-  useSetTitle(title);
+  if (isAppLoading || !app) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
 
   return (
-    <>
-      {isAppError || (!isAppLoading && !app) ? (
-        <Custom404 />
-      ) : isAppLoading || !app ? (
-        <div className="flex h-full items-center justify-center">
-          <Spinner />
-        </div>
-      ) : (
-        <div className="flex w-full flex-col">
-          <Tabs value="specification" className="mt-2">
-            <TabsList>
-              {subNavigationApp({ owner, app, current: "specification" }).map(
-                (tab) => (
-                  <TabsTrigger
-                    key={tab.value}
-                    value={tab.value}
-                    label={tab.label}
-                    icon={tab.icon}
-                    onClick={() => {
-                      if (tab.href) {
-                        void router.push(tab.href);
-                      }
-                    }}
-                  />
-                )
-              )}
-            </TabsList>
-          </Tabs>
-          <div className="mt-8 flex flex-col gap-4">
-            <h3>Current specifications:</h3>
-            <div className="whitespace-pre font-mono text-sm text-gray-700">
-              {specification}
-            </div>
-          </div>
-        </div>
-      )}
-    </>
+    <div className="mt-8 flex flex-col gap-4">
+      <h3>Current specifications:</h3>
+      <div className="whitespace-pre font-mono text-sm text-gray-700">
+        {specification}
+      </div>
+    </div>
   );
 }

--- a/front/components/pages/spaces/apps/AppViewPage.tsx
+++ b/front/components/pages/spaces/apps/AppViewPage.tsx
@@ -12,7 +12,6 @@ import { useSWRConfig } from "swr";
 import NewBlock from "@app/components/app/NewBlock";
 import SpecRunView from "@app/components/app/SpecRunView";
 import { ViewAppAPIModal } from "@app/components/app/ViewAppAPIModal";
-import { DustAppPageLayout } from "@app/components/apps/DustAppPageLayout";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import { extractConfig } from "@app/lib/config";
 import { clientFetch } from "@app/lib/egress/client";
@@ -361,7 +360,7 @@ export function AppViewPage() {
   }
 
   return (
-    <DustAppPageLayout app={app} currentTab="specification">
+    <>
       <div className="mt-8 flex flex-auto flex-col">
         <div className="mb-4 flex flex-row items-center space-x-2">
           <NewBlock
@@ -530,6 +529,6 @@ export function AppViewPage() {
         ) : null}
       </div>
       <div ref={bottomRef} className="mt-4"></div>
-    </DustAppPageLayout>
+    </>
   );
 }

--- a/front/components/pages/spaces/apps/DatasetPage.tsx
+++ b/front/components/pages/spaces/apps/DatasetPage.tsx
@@ -1,21 +1,13 @@
 import "@uiw/react-textarea-code-editor/dist.css";
 
-import { Button, Spinner, Tabs, TabsList, TabsTrigger } from "@dust-tt/sparkle";
-import { useEffect, useMemo, useState } from "react";
+import { Button, Spinner } from "@dust-tt/sparkle";
+import { useEffect, useState } from "react";
 
 import DatasetView from "@app/components/app/DatasetView";
-import { subNavigationApp } from "@app/components/navigation/config";
-import {
-  useSetContentWidth,
-  useSetHideSidebar,
-  useSetTitle,
-} from "@app/components/sparkle/AppLayoutContext";
-import { AppLayoutSimpleCloseTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
 import { useRegisterUnloadHandlers } from "@app/lib/front";
 import { useAppRouter, useRequiredPathParam } from "@app/lib/platform";
-import { dustAppsListUrl } from "@app/lib/spaces";
 import { useApp } from "@app/lib/swr/apps";
 import { useDataset } from "@app/lib/swr/datasets";
 import Custom404 from "@app/pages/404";
@@ -133,84 +125,48 @@ export function DatasetPage() {
 
   const isLoading = isAppLoading || isDatasetLoading;
 
-  const title = useMemo(
-    () =>
-      app ? (
-        <AppLayoutSimpleCloseTitle
-          title={app.name}
-          onClose={() => {
-            void router.push(dustAppsListUrl(owner, app.space));
-          }}
-        />
-      ) : undefined,
-    [owner, app, router]
-  );
+  if (isDatasetError || (!isLoading && app && !dataset)) {
+    return <Custom404 />;
+  }
 
-  useSetContentWidth("centered");
-  useSetHideSidebar(true);
-  useSetTitle(title);
+  if (isLoading || !app || !dataset || !updatedDataset) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
 
   return (
-    <>
-      {isDatasetError || (!isLoading && app && !dataset) ? (
-        <Custom404 />
-      ) : isLoading || !app || !dataset || !updatedDataset ? (
-        <div className="flex h-full items-center justify-center">
-          <Spinner />
-        </div>
-      ) : (
-        <div className="flex w-full flex-col">
-          <Tabs value="datasets" className="mt-2">
-            <TabsList>
-              {subNavigationApp({ owner, app, current: "datasets" }).map(
-                (tab) => (
-                  <TabsTrigger
-                    key={tab.value}
-                    value={tab.value}
-                    label={tab.label}
-                    icon={tab.icon}
-                    onClick={() => {
-                      if (tab.href) {
-                        void router.push(tab.href);
-                      }
-                    }}
-                  />
-                )
-              )}
-            </TabsList>
-          </Tabs>
-          <div className="mt-8 flex flex-col">
-            <div className="flex flex-1">
-              <div className="mb-8 w-full">
-                <div className="space-y-6 divide-y divide-gray-200 dark:divide-gray-200-night">
-                  <DatasetView
-                    readOnly={readOnly}
-                    datasets={[] as DatasetType[]}
-                    dataset={updatedDataset}
-                    schema={dataset.schema ?? null}
-                    onUpdate={onUpdate}
-                    nameDisabled={true}
-                    viewType="full"
-                  />
+    <div className="mt-8 flex flex-col">
+      <div className="flex flex-1">
+        <div className="mb-8 w-full">
+          <div className="space-y-6 divide-y divide-gray-200 dark:divide-gray-200-night">
+            <DatasetView
+              readOnly={readOnly}
+              datasets={[] as DatasetType[]}
+              dataset={updatedDataset}
+              schema={dataset.schema ?? null}
+              onUpdate={onUpdate}
+              nameDisabled={true}
+              viewType="full"
+            />
 
-                  {readOnly ? null : (
-                    <div className="flex flex-row pt-6">
-                      <div className="flex-initial">
-                        <Button
-                          disabled={disable || loading}
-                          onClick={() => handleSubmit()}
-                          label="Update"
-                          variant="primary"
-                        />
-                      </div>
-                    </div>
-                  )}
+            {readOnly ? null : (
+              <div className="flex flex-row pt-6">
+                <div className="flex-initial">
+                  <Button
+                    disabled={disable || loading}
+                    onClick={() => handleSubmit()}
+                    label="Update"
+                    variant="primary"
+                  />
                 </div>
               </div>
-            </div>
+            )}
           </div>
         </div>
-      )}
-    </>
+      </div>
+    </div>
   );
 }

--- a/front/components/pages/spaces/apps/DatasetsPage.tsx
+++ b/front/components/pages/spaces/apps/DatasetsPage.tsx
@@ -1,7 +1,6 @@
 import { Button, Chip, PlusIcon, Spinner, TrashIcon } from "@dust-tt/sparkle";
 import { useContext } from "react";
 
-import { DustAppPageLayout } from "@app/components/apps/DustAppPageLayout";
 import { ConfirmContext } from "@app/components/Confirm";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
@@ -79,81 +78,79 @@ export function DatasetsPage() {
   }
 
   return (
-    <DustAppPageLayout app={app} currentTab="datasets">
-      <div className="mt-8 flex flex-col">
-        <div className="flex flex-1">
-          <div className="mb-4 flex flex-auto flex-col gap-y-4">
-            <div className="flex flex-row items-center justify-between">
-              <Button
-                disabled={readOnly}
-                variant="primary"
-                label="New Dataset"
-                icon={PlusIcon}
-                onClick={() => {
-                  void router.push(
-                    `/w/${owner.sId}/spaces/${app.space.sId}/apps/${app.sId}/datasets/new`
-                  );
-                }}
-              />
-            </div>
-            <div className="mt-2">
-              <ul role="list" className="flex-1 space-y-4">
-                {datasets.map((d) => {
-                  return (
-                    <LinkWrapper
-                      key={d.name}
-                      href={`/w/${owner.sId}/spaces/${app.space.sId}/apps/${app.sId}/datasets/${d.name}`}
-                      className="block"
-                    >
-                      <div className="group rounded border border-gray-300 px-4 py-4 dark:border-gray-300-night">
-                        <div className="flex items-center justify-between">
-                          <p className="heading-base truncate text-highlight-500">
-                            {d.name}
-                          </p>
-                          {readOnly ? null : (
-                            <div className="ml-2 flex flex-shrink-0">
-                              <TrashIcon
-                                className="hidden h-4 w-4 text-gray-400 hover:text-warning group-hover:block dark:text-gray-400-night"
-                                onClick={async (e) => {
-                                  e.preventDefault();
-                                  await handleDelete(d.name);
-                                }}
-                              />
-                            </div>
-                          )}
-                        </div>
-                        <div className="mt-2 sm:flex sm:justify-between">
-                          <div className="sm:flex">
-                            <p
-                              className={classNames(
-                                d.description
-                                  ? "text-gray-700 dark:text-gray-700-night"
-                                  : "text-gray-300 dark:text-gray-300-night",
-                                "text-s flex items-center"
-                              )}
-                            >
-                              {/* eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing */}
-                              {d.description ? d.description : "No description"}
-                            </p>
+    <div className="mt-8 flex flex-col">
+      <div className="flex flex-1">
+        <div className="mb-4 flex flex-auto flex-col gap-y-4">
+          <div className="flex flex-row items-center justify-between">
+            <Button
+              disabled={readOnly}
+              variant="primary"
+              label="New Dataset"
+              icon={PlusIcon}
+              onClick={() => {
+                void router.push(
+                  `/w/${owner.sId}/spaces/${app.space.sId}/apps/${app.sId}/datasets/new`
+                );
+              }}
+            />
+          </div>
+          <div className="mt-2">
+            <ul role="list" className="flex-1 space-y-4">
+              {datasets.map((d) => {
+                return (
+                  <LinkWrapper
+                    key={d.name}
+                    href={`/w/${owner.sId}/spaces/${app.space.sId}/apps/${app.sId}/datasets/${d.name}`}
+                    className="block"
+                  >
+                    <div className="group rounded border border-gray-300 px-4 py-4 dark:border-gray-300-night">
+                      <div className="flex items-center justify-between">
+                        <p className="heading-base truncate text-highlight-500">
+                          {d.name}
+                        </p>
+                        {readOnly ? null : (
+                          <div className="ml-2 flex flex-shrink-0">
+                            <TrashIcon
+                              className="hidden h-4 w-4 text-gray-400 hover:text-warning group-hover:block dark:text-gray-400-night"
+                              onClick={async (e) => {
+                                e.preventDefault();
+                                await handleDelete(d.name);
+                              }}
+                            />
                           </div>
+                        )}
+                      </div>
+                      <div className="mt-2 sm:flex sm:justify-between">
+                        <div className="sm:flex">
+                          <p
+                            className={classNames(
+                              d.description
+                                ? "text-gray-700 dark:text-gray-700-night"
+                                : "text-gray-300 dark:text-gray-300-night",
+                              "text-s flex items-center"
+                            )}
+                          >
+                            {/* eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing */}
+                            {d.description ? d.description : "No description"}
+                          </p>
                         </div>
                       </div>
-                    </LinkWrapper>
-                  );
-                })}
-              </ul>
-              <div className="mt-2 px-2">
-                <div className="py-2 text-sm text-gray-400 dark:text-gray-400-night">
-                  Datasets are used as input data to apps (
-                  <Chip label="input" /> block) or few-shot examples to prompt
-                  models (
-                  <Chip label="data" /> block).
-                </div>
+                    </div>
+                  </LinkWrapper>
+                );
+              })}
+            </ul>
+            <div className="mt-2 px-2">
+              <div className="py-2 text-sm text-gray-400 dark:text-gray-400-night">
+                Datasets are used as input data to apps (
+                <Chip label="input" /> block) or few-shot examples to prompt
+                models (
+                <Chip label="data" /> block).
               </div>
             </div>
           </div>
         </div>
       </div>
-    </DustAppPageLayout>
+    </div>
   );
 }

--- a/front/components/pages/spaces/apps/NewDatasetPage.tsx
+++ b/front/components/pages/spaces/apps/NewDatasetPage.tsx
@@ -4,7 +4,6 @@ import { Button, Spinner } from "@dust-tt/sparkle";
 import { useEffect, useState } from "react";
 
 import DatasetView from "@app/components/app/DatasetView";
-import { DustAppPageLayout } from "@app/components/apps/DustAppPageLayout";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
 import { useRegisterUnloadHandlers } from "@app/lib/front";
@@ -120,31 +119,29 @@ export function NewDatasetPage() {
   }
 
   return (
-    <DustAppPageLayout app={app} currentTab="datasets">
-      <div className="mt-8 flex flex-col">
-        <div className="flex flex-1">
-          <div className="space-y-6 divide-y divide-gray-200 dark:divide-gray-200-night">
-            <DatasetView
-              readOnly={false}
-              datasets={datasets}
-              dataset={dataset}
-              schema={schema}
-              onUpdate={onUpdate}
-              nameDisabled={false}
-              viewType="full"
-            />
+    <div className="mt-8 flex flex-col">
+      <div className="flex flex-1">
+        <div className="space-y-6 divide-y divide-gray-200 dark:divide-gray-200-night">
+          <DatasetView
+            readOnly={false}
+            datasets={datasets}
+            dataset={dataset}
+            schema={schema}
+            onUpdate={onUpdate}
+            nameDisabled={false}
+            viewType="full"
+          />
 
-            <div className="flex py-6">
-              <Button
-                label="Create"
-                variant="primary"
-                disabled={disable || loading}
-                onClick={() => handleSubmit()}
-              />
-            </div>
+          <div className="flex py-6">
+            <Button
+              label="Create"
+              variant="primary"
+              disabled={disable || loading}
+              onClick={() => handleSubmit()}
+            />
           </div>
         </div>
       </div>
-    </DustAppPageLayout>
+    </div>
   );
 }

--- a/front/components/pages/spaces/apps/RunPage.tsx
+++ b/front/components/pages/spaces/apps/RunPage.tsx
@@ -3,7 +3,6 @@ import { useContext, useState } from "react";
 
 import CopyRun from "@app/components/app/CopyRun";
 import SpecRunView from "@app/components/app/SpecRunView";
-import { DustAppPageLayout } from "@app/components/apps/DustAppPageLayout";
 import { ConfirmContext } from "@app/components/Confirm";
 import { cleanSpecificationFromCore } from "@app/lib/api/run";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
@@ -98,7 +97,7 @@ export function RunPage() {
   }
 
   return (
-    <DustAppPageLayout app={app} currentTab="runs">
+    <>
       <div className="mt-8 flex flex-col">
         <div className="mb-4 flex flex-row items-center justify-between space-x-2 text-sm">
           <div className="flex flex-col items-start">
@@ -181,6 +180,6 @@ export function RunPage() {
         />
       </div>
       <div className="mt-4"></div>
-    </DustAppPageLayout>
+    </>
   );
 }

--- a/front/components/pages/spaces/apps/RunsPage.tsx
+++ b/front/components/pages/spaces/apps/RunsPage.tsx
@@ -1,7 +1,6 @@
 import { Button, cn, Spinner } from "@dust-tt/sparkle";
 import { useEffect, useState } from "react";
 
-import { DustAppPageLayout } from "@app/components/apps/DustAppPageLayout";
 import { useAuth, useWorkspace } from "@app/lib/auth/AuthContext";
 import {
   LinkWrapper,
@@ -90,7 +89,7 @@ export function RunsPage() {
   }
 
   return (
-    <DustAppPageLayout app={app} currentTab="runs">
+    <>
       <div className="mt-8 flex">
         <nav className="flex" aria-label="Tabs">
           {tabs.map((tab, tabIdx) => (
@@ -226,6 +225,6 @@ export function RunsPage() {
           ) : null}
         </ul>
       </div>
-    </DustAppPageLayout>
+    </>
   );
 }

--- a/front/lib/auth/appGetLayout.tsx
+++ b/front/lib/auth/appGetLayout.tsx
@@ -1,5 +1,6 @@
 import type { ReactElement } from "react";
 
+import { DustAppPageLayout } from "@app/components/apps/DustAppPageLayout";
 import { ConversationLayout } from "@app/components/assistant/conversation/ConversationLayout";
 import { AdminLayout } from "@app/components/layouts/AdminLayout";
 import { SpaceLayout } from "@app/components/spaces/SpaceLayout";
@@ -40,4 +41,11 @@ export function adminGetLayout(
   pageProps: AuthContextValue
 ) {
   return appGetLayout(<AdminLayout>{page}</AdminLayout>, pageProps);
+}
+
+export function dustAppGetLayout(
+  page: ReactElement,
+  pageProps: AuthContextValue
+) {
+  return appGetLayout(<DustAppPageLayout>{page}</DustAppPageLayout>, pageProps);
 }

--- a/front/lib/platform/next.tsx
+++ b/front/lib/platform/next.tsx
@@ -10,24 +10,28 @@ import {
 } from "next/navigation";
 import { useRouter as useNextRouter } from "next/router";
 import NextScript from "next/script";
+import { useMemo } from "react";
 
 import { NextLinkWrapper } from "./NextLinkWrapper";
 import type { AppRouter, HeadProps, ImageProps, ScriptProps } from "./types";
 
 export function useAppRouter(): AppRouter {
   const router = useNextRouter();
-  return {
-    push: router.push,
-    replace: router.replace,
-    back: router.back,
-    reload: router.reload,
-    pathname: router.pathname,
-    asPath: router.asPath,
-    query: router.query as Record<string, string | string[] | undefined>,
-    isReady: router.isReady,
-    events: router.events,
-    beforePopState: router.beforePopState,
-  };
+  return useMemo(
+    () => ({
+      push: router.push,
+      replace: router.replace,
+      back: router.back,
+      reload: router.reload,
+      pathname: router.pathname,
+      asPath: router.asPath,
+      query: router.query as Record<string, string | string[] | undefined>,
+      isReady: router.isReady,
+      events: router.events,
+      beforePopState: router.beforePopState,
+    }),
+    [router]
+  );
 }
 
 export const LinkWrapper = NextLinkWrapper;

--- a/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets/[name]/index.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets/[name]/index.tsx
@@ -1,5 +1,5 @@
 import { DatasetPage } from "@app/components/pages/spaces/apps/DatasetPage";
-import { appGetLayout } from "@app/lib/auth/appGetLayout";
+import { dustAppGetLayout } from "@app/lib/auth/appGetLayout";
 import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
 import { appGetServerSideProps } from "@app/lib/auth/appServerSideProps";
 
@@ -7,6 +7,6 @@ export const getServerSideProps = appGetServerSideProps;
 
 const PageWithAuthLayout = DatasetPage as AppPageWithLayout;
 
-PageWithAuthLayout.getLayout = appGetLayout;
+PageWithAuthLayout.getLayout = dustAppGetLayout;
 
 export default PageWithAuthLayout;

--- a/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets/index.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets/index.tsx
@@ -1,5 +1,5 @@
 import { DatasetsPage } from "@app/components/pages/spaces/apps/DatasetsPage";
-import { appGetLayout } from "@app/lib/auth/appGetLayout";
+import { dustAppGetLayout } from "@app/lib/auth/appGetLayout";
 import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
 import { appGetServerSideProps } from "@app/lib/auth/appServerSideProps";
 
@@ -7,6 +7,6 @@ export const getServerSideProps = appGetServerSideProps;
 
 const PageWithAuthLayout = DatasetsPage as AppPageWithLayout;
 
-PageWithAuthLayout.getLayout = appGetLayout;
+PageWithAuthLayout.getLayout = dustAppGetLayout;
 
 export default PageWithAuthLayout;

--- a/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets/new.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/datasets/new.tsx
@@ -1,5 +1,5 @@
 import { NewDatasetPage } from "@app/components/pages/spaces/apps/NewDatasetPage";
-import { appGetLayout } from "@app/lib/auth/appGetLayout";
+import { dustAppGetLayout } from "@app/lib/auth/appGetLayout";
 import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
 import { appGetServerSideProps } from "@app/lib/auth/appServerSideProps";
 
@@ -7,6 +7,6 @@ export const getServerSideProps = appGetServerSideProps;
 
 const PageWithAuthLayout = NewDatasetPage as AppPageWithLayout;
 
-PageWithAuthLayout.getLayout = appGetLayout;
+PageWithAuthLayout.getLayout = dustAppGetLayout;
 
 export default PageWithAuthLayout;

--- a/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/index.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/index.tsx
@@ -1,5 +1,5 @@
 import { AppViewPage } from "@app/components/pages/spaces/apps/AppViewPage";
-import { appGetLayout } from "@app/lib/auth/appGetLayout";
+import { dustAppGetLayout } from "@app/lib/auth/appGetLayout";
 import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
 import { appGetServerSideProps } from "@app/lib/auth/appServerSideProps";
 
@@ -7,6 +7,6 @@ export const getServerSideProps = appGetServerSideProps;
 
 const PageWithAuthLayout = AppViewPage as AppPageWithLayout;
 
-PageWithAuthLayout.getLayout = appGetLayout;
+PageWithAuthLayout.getLayout = dustAppGetLayout;
 
 export default PageWithAuthLayout;

--- a/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/index.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/[runId]/index.tsx
@@ -1,5 +1,5 @@
 import { RunPage } from "@app/components/pages/spaces/apps/RunPage";
-import { appGetLayout } from "@app/lib/auth/appGetLayout";
+import { dustAppGetLayout } from "@app/lib/auth/appGetLayout";
 import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
 import { appGetServerSideProps } from "@app/lib/auth/appServerSideProps";
 
@@ -7,6 +7,6 @@ export const getServerSideProps = appGetServerSideProps;
 
 const PageWithAuthLayout = RunPage as AppPageWithLayout;
 
-PageWithAuthLayout.getLayout = appGetLayout;
+PageWithAuthLayout.getLayout = dustAppGetLayout;
 
 export default PageWithAuthLayout;

--- a/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.tsx
@@ -1,5 +1,5 @@
 import { RunsPage } from "@app/components/pages/spaces/apps/RunsPage";
-import { appGetLayout } from "@app/lib/auth/appGetLayout";
+import { dustAppGetLayout } from "@app/lib/auth/appGetLayout";
 import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
 import { appGetServerSideProps } from "@app/lib/auth/appServerSideProps";
 
@@ -7,6 +7,6 @@ export const getServerSideProps = appGetServerSideProps;
 
 const PageWithAuthLayout = RunsPage as AppPageWithLayout;
 
-PageWithAuthLayout.getLayout = appGetLayout;
+PageWithAuthLayout.getLayout = dustAppGetLayout;
 
 export default PageWithAuthLayout;

--- a/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/settings.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/settings.tsx
@@ -1,5 +1,5 @@
 import { AppSettingsPage } from "@app/components/pages/spaces/apps/AppSettingsPage";
-import { appGetLayout } from "@app/lib/auth/appGetLayout";
+import { dustAppGetLayout } from "@app/lib/auth/appGetLayout";
 import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
 import { appGetServerSideProps } from "@app/lib/auth/appServerSideProps";
 
@@ -7,6 +7,6 @@ export const getServerSideProps = appGetServerSideProps;
 
 const PageWithAuthLayout = AppSettingsPage as AppPageWithLayout;
 
-PageWithAuthLayout.getLayout = appGetLayout;
+PageWithAuthLayout.getLayout = dustAppGetLayout;
 
 export default PageWithAuthLayout;

--- a/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/specification.tsx
+++ b/front/pages/w/[wId]/spaces/[spaceId]/apps/[aId]/specification.tsx
@@ -1,5 +1,5 @@
 import { AppSpecificationPage } from "@app/components/pages/spaces/apps/AppSpecificationPage";
-import { appGetLayout } from "@app/lib/auth/appGetLayout";
+import { dustAppGetLayout } from "@app/lib/auth/appGetLayout";
 import type { AppPageWithLayout } from "@app/lib/auth/appServerSideProps";
 import { appGetServerSideProps } from "@app/lib/auth/appServerSideProps";
 
@@ -7,6 +7,6 @@ export const getServerSideProps = appGetServerSideProps;
 
 const PageWithAuthLayout = AppSpecificationPage as AppPageWithLayout;
 
-PageWithAuthLayout.getLayout = appGetLayout;
+PageWithAuthLayout.getLayout = dustAppGetLayout;
 
 export default PageWithAuthLayout;


### PR DESCRIPTION
## Description

Hoists `DustAppPageLayout` into a shared layout so that the tab bar persists when navigating between app sub-pages (specification, datasets, runs, settings) — eliminating the flicker caused by the layout unmounting/remounting on each navigation.

### What changed

- **`DustAppPageLayout` is now self-contained**: it fetches the app via `useApp()` and derives the current tab from the route path, instead of receiving `app`/`currentTab` as props.
- **Next.js**: added `dustAppGetLayout()` in `appGetLayout.tsx` (same pattern as `spaceGetLayout`, `adminGetLayout`). All 8 app page files now use it.
- **SPA**: added `DustAppRouterLayout` and nested all app routes under it in `App.tsx`.
- **Simplified 8 page components**: removed `<DustAppPageLayout>` wrappers from 6 pages, removed manual tabs + `useAppLayoutConfig` from `AppSpecificationPage` and `DatasetPage`.

## Tests

- `npx tsgo --noEmit` passes
- ESLint on changed files passes
- Manual: navigate between app tabs — tabs persist without flicker

## Risk

Low. This is a layout restructuring with no business logic changes. The tab rendering and `useAppLayoutConfig` logic moved from individual pages into the shared layout — same behavior, just hoisted.

## Deploy Plan

Standard deploy — no migrations, no feature flags, no dependencies.