### PR TITLE
[Front] feat(copilot): add query param to search_agent_templates for semantic matching

### DIFF
--- a/front/components/agent_builder/CopilotPanelContext.tsx
+++ b/front/components/agent_builder/CopilotPanelContext.tsx
@@ -76,7 +76,7 @@ The copilotInstructions contain domain-specific rules for this agent type. IMMED
 Use \`suggest_*\` tools right away following the guidance in copilotInstructions.
 
 **If the user's response does NOT match any template from Step 2:**
-Call \`search_agent_templates\` with a \`query\` param describing the user's request to find semantically matching templates. If a match with copilotInstructions is found, use it as above.
+Call \`search_agent_templates\` with the user's message as the \`query\` param to find semantically matching templates. If a match with copilotInstructions is found, use it as above.
 
 **Fallback — no matching template or copilotInstructions is null/empty:**
 Proceed to Step 3.

--- a/front/components/agent_builder/CopilotPanelContext.tsx
+++ b/front/components/agent_builder/CopilotPanelContext.tsx
@@ -52,9 +52,6 @@ The response includes:
 - Instructions: The committed instructions text (without pending suggestions)
 - pendingSuggestions: Array of suggestions that have been made but not yet accepted/rejected by the user
 
-You MUST call \`get_agent_config\` to retrieve the current agent configuration and any pending suggestions.
-This tool must be called at session start to ensure you have the latest state.
-
 ## STEP 2: Discover templates & suggest use cases
 Call \`search_agent_templates\` with the user's job type from your instructions to discover relevant templates.
 
@@ -72,13 +69,16 @@ Provide 2-3 specific agent use case suggestions as bullet points. Use template u
 
 Pick one to start, or tell me what you're thinking."
 
-## STEP 2.5: When user picks a use case
+## STEP 2.5: When user responds
 
-**If the selected use case matches a template with non-null copilotInstructions:**
+**If the user's response matches a template with non-null copilotInstructions:**
 The copilotInstructions contain domain-specific rules for this agent type. IMMEDIATELY create suggestions based on copilotInstructions - do NOT wait for user response.
 Use \`suggest_*\` tools right away following the guidance in copilotInstructions.
 
-**If no matching template or copilotInstructions is null/empty:**
+**If the user's response does NOT match any template from Step 2:**
+Call \`search_agent_templates\` with a \`query\` param describing the user's request to find semantically matching templates. If a match with copilotInstructions is found, use it as above.
+
+**Fallback — no matching template or copilotInstructions is null/empty:**
 Proceed to Step 3.
 
 ${buildStep3({ includeInsights: false })}

--- a/front/lib/api/actions/servers/agent_copilot_context/agent_copilot_context.test.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/agent_copilot_context.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { USED_MODEL_CONFIGS } from "@app/components/providers/types";
+import { getSuggestedTemplatesForQuery } from "@app/lib/api/assistant/template_suggestion";
 import { Authenticator } from "@app/lib/auth";
 import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -17,6 +18,7 @@ import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { TemplateFactory } from "@app/tests/utils/TemplateFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
+import { Err, Ok } from "@app/types";
 
 import { TOOLS } from "./tools";
 
@@ -1548,10 +1550,6 @@ describe("agent_copilot_context tools", () => {
       const template1 = await TemplateFactory.published();
       await TemplateFactory.published();
 
-      const { getSuggestedTemplatesForQuery } = await import(
-        "@app/lib/api/assistant/template_suggestion"
-      );
-      const { Ok } = await import("@app/types");
       vi.mocked(getSuggestedTemplatesForQuery).mockResolvedValueOnce(
         new Ok([template1])
       );
@@ -1581,10 +1579,6 @@ describe("agent_copilot_context tools", () => {
 
       await TemplateFactory.published();
 
-      const { getSuggestedTemplatesForQuery } = await import(
-        "@app/lib/api/assistant/template_suggestion"
-      );
-      const { Err } = await import("@app/types");
       vi.mocked(getSuggestedTemplatesForQuery).mockResolvedValueOnce(
         new Err(new Error("LLM call failed"))
       );
@@ -1607,10 +1601,6 @@ describe("agent_copilot_context tools", () => {
       const template = await TemplateFactory.published();
       await template.updateAttributes({ tags: ["SALES"] });
 
-      const { getSuggestedTemplatesForQuery } = await import(
-        "@app/lib/api/assistant/template_suggestion"
-      );
-      const { Ok } = await import("@app/types");
       vi.mocked(getSuggestedTemplatesForQuery).mockResolvedValueOnce(
         new Ok([template])
       );

--- a/front/lib/api/actions/servers/agent_copilot_context/metadata.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/metadata.ts
@@ -338,14 +338,20 @@ export const AGENT_COPILOT_CONTEXT_TOOLS_METADATA = createToolsRecord({
   },
   search_agent_templates: {
     description:
-      "Search published agent templates by job type tags. Returns full template details including copilotInstructions. " +
-      "Call this when helping create a new agent to find relevant starting points.",
+      "Search published agent templates. Use jobType for tag-based filtering or query for semantic search. " +
+      "Returns full template details including copilotInstructions.",
     schema: {
       jobType: z
         .string()
         .optional()
         .describe(
           "User's job type to filter templates by relevant tags (e.g. 'sales', 'engineering', 'legal'). If omitted, returns all published templates."
+        ),
+      query: z
+        .string()
+        .optional()
+        .describe(
+          "Free-text query to semantically search templates. Use when the user describes a specific use case not covered by jobType tags."
         ),
     },
     stake: "never_ask",

--- a/front/lib/api/assistant/global_agents/configurations/dust/copilot.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/copilot.ts
@@ -261,7 +261,7 @@ Call these when first creating suggestions in a session. ALWAYS call these tools
 - \`get_available_tools\`: Returns available MCP servers/tools. If not obviously required, use the "Discover Tools" skill.
 - \`get_available_knowledge\`: Lists knowledge sources organized by spaces, with connected data sources, folders, and websites.
 - \`get_available_models\`: Model suggestions should be conservative - only suggest deviations from default when obvious.
-- \`search_agent_templates\`: Search published templates by job type. Returns full details including copilotInstructions for direct use when creating new agents.
+- \`search_agent_templates\`: Search published templates by job type or free-text query. Returns full details including copilotInstructions.
 </discovery_tools>
 
 <suggestion_tools>

--- a/front/lib/api/assistant/template_suggestion.test.ts
+++ b/front/lib/api/assistant/template_suggestion.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
 import { getSuggestedTemplatesForQuery } from "@app/lib/api/assistant/template_suggestion";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { TemplateFactory } from "@app/tests/utils/TemplateFactory";
@@ -8,6 +9,8 @@ import { TemplateFactory } from "@app/tests/utils/TemplateFactory";
 vi.mock("@app/lib/api/assistant/call_llm", () => ({
   runMultiActionsAgent: vi.fn(),
 }));
+
+const mockRunMultiActionsAgent = vi.mocked(runMultiActionsAgent);
 
 beforeEach(() => {
   vi.resetAllMocks();
@@ -21,10 +24,7 @@ describe("getSuggestedTemplatesForQuery", () => {
     const template2 = await TemplateFactory.published();
     const template3 = await TemplateFactory.published();
 
-    const { runMultiActionsAgent } = await import(
-      "@app/lib/api/assistant/call_llm"
-    );
-    vi.mocked(runMultiActionsAgent).mockResolvedValueOnce({
+    mockRunMultiActionsAgent.mockResolvedValueOnce({
       isOk: () => true,
       isErr: () => false,
       value: {
@@ -61,10 +61,7 @@ describe("getSuggestedTemplatesForQuery", () => {
 
     const template1 = await TemplateFactory.published();
 
-    const { runMultiActionsAgent } = await import(
-      "@app/lib/api/assistant/call_llm"
-    );
-    vi.mocked(runMultiActionsAgent).mockResolvedValueOnce({
+    mockRunMultiActionsAgent.mockResolvedValueOnce({
       isOk: () => true,
       isErr: () => false,
       value: {
@@ -100,10 +97,7 @@ describe("getSuggestedTemplatesForQuery", () => {
 
     const template1 = await TemplateFactory.published();
 
-    const { runMultiActionsAgent } = await import(
-      "@app/lib/api/assistant/call_llm"
-    );
-    vi.mocked(runMultiActionsAgent).mockResolvedValueOnce({
+    mockRunMultiActionsAgent.mockResolvedValueOnce({
       isOk: () => false,
       isErr: () => true,
       error: new Error("LLM call failed"),
@@ -125,10 +119,7 @@ describe("getSuggestedTemplatesForQuery", () => {
 
     const template1 = await TemplateFactory.published();
 
-    const { runMultiActionsAgent } = await import(
-      "@app/lib/api/assistant/call_llm"
-    );
-    vi.mocked(runMultiActionsAgent).mockResolvedValueOnce({
+    mockRunMultiActionsAgent.mockResolvedValueOnce({
       isOk: () => true,
       isErr: () => false,
       value: {
@@ -159,10 +150,7 @@ describe("getSuggestedTemplatesForQuery", () => {
     const template1 = await TemplateFactory.published();
     await template1.updateAttributes({ tags: ["SALES"] });
 
-    const { runMultiActionsAgent } = await import(
-      "@app/lib/api/assistant/call_llm"
-    );
-    vi.mocked(runMultiActionsAgent).mockResolvedValueOnce({
+    mockRunMultiActionsAgent.mockResolvedValueOnce({
       isOk: () => true,
       isErr: () => false,
       value: {
@@ -183,8 +171,8 @@ describe("getSuggestedTemplatesForQuery", () => {
       templates: [template1],
     });
 
-    expect(runMultiActionsAgent).toHaveBeenCalledOnce();
-    const [, , input] = vi.mocked(runMultiActionsAgent).mock.calls[0];
+    expect(mockRunMultiActionsAgent).toHaveBeenCalledOnce();
+    const [, , input] = mockRunMultiActionsAgent.mock.calls[0];
 
     // Query should be trimmed.
     expect(input.conversation.messages[0].content).toEqual([

--- a/front/lib/api/assistant/template_suggestion.test.ts
+++ b/front/lib/api/assistant/template_suggestion.test.ts
@@ -1,0 +1,198 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getSuggestedTemplatesForQuery } from "@app/lib/api/assistant/template_suggestion";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { TemplateFactory } from "@app/tests/utils/TemplateFactory";
+
+// Mock call_llm to control runMultiActionsAgent responses.
+vi.mock("@app/lib/api/assistant/call_llm", () => ({
+  runMultiActionsAgent: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe("getSuggestedTemplatesForQuery", () => {
+  it("returns matching templates from LLM response", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+
+    const template1 = await TemplateFactory.published();
+    const template2 = await TemplateFactory.published();
+    const template3 = await TemplateFactory.published();
+
+    const { runMultiActionsAgent } = await import(
+      "@app/lib/api/assistant/call_llm"
+    );
+    vi.mocked(runMultiActionsAgent).mockResolvedValueOnce({
+      isOk: () => true,
+      isErr: () => false,
+      value: {
+        actions: [
+          {
+            name: "suggest_templates",
+            arguments: {
+              suggested_templates: [
+                { id: template1.sId },
+                { id: template3.sId },
+              ],
+            },
+          },
+        ],
+        generation: "",
+      },
+    } as never);
+
+    const result = await getSuggestedTemplatesForQuery(authenticator, {
+      query: "help me draft sales emails",
+      templates: [template1, template2, template3],
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toHaveLength(2);
+      expect(result.value[0].sId).toBe(template1.sId);
+      expect(result.value[1].sId).toBe(template3.sId);
+    }
+  });
+
+  it("filters out unknown template IDs from LLM response", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+
+    const template1 = await TemplateFactory.published();
+
+    const { runMultiActionsAgent } = await import(
+      "@app/lib/api/assistant/call_llm"
+    );
+    vi.mocked(runMultiActionsAgent).mockResolvedValueOnce({
+      isOk: () => true,
+      isErr: () => false,
+      value: {
+        actions: [
+          {
+            name: "suggest_templates",
+            arguments: {
+              suggested_templates: [
+                { id: template1.sId },
+                { id: "non-existent-id" },
+              ],
+            },
+          },
+        ],
+        generation: "",
+      },
+    } as never);
+
+    const result = await getSuggestedTemplatesForQuery(authenticator, {
+      query: "data analysis agent",
+      templates: [template1],
+    });
+
+    expect(result.isOk()).toBe(true);
+    if (result.isOk()) {
+      expect(result.value).toHaveLength(1);
+      expect(result.value[0].sId).toBe(template1.sId);
+    }
+  });
+
+  it("returns error when LLM call fails", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+
+    const template1 = await TemplateFactory.published();
+
+    const { runMultiActionsAgent } = await import(
+      "@app/lib/api/assistant/call_llm"
+    );
+    vi.mocked(runMultiActionsAgent).mockResolvedValueOnce({
+      isOk: () => false,
+      isErr: () => true,
+      error: new Error("LLM call failed"),
+    } as never);
+
+    const result = await getSuggestedTemplatesForQuery(authenticator, {
+      query: "something",
+      templates: [template1],
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("Error suggesting templates");
+    }
+  });
+
+  it("returns error when LLM response has no suggested_templates", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+
+    const template1 = await TemplateFactory.published();
+
+    const { runMultiActionsAgent } = await import(
+      "@app/lib/api/assistant/call_llm"
+    );
+    vi.mocked(runMultiActionsAgent).mockResolvedValueOnce({
+      isOk: () => true,
+      isErr: () => false,
+      value: {
+        actions: [
+          {
+            name: "suggest_templates",
+            arguments: {},
+          },
+        ],
+        generation: "",
+      },
+    } as never);
+
+    const result = await getSuggestedTemplatesForQuery(authenticator, {
+      query: "something",
+      templates: [template1],
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isErr()) {
+      expect(result.error.message).toContain("No suggested_templates found");
+    }
+  });
+
+  it("passes query and formatted templates to LLM", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+
+    const template1 = await TemplateFactory.published();
+    await template1.updateAttributes({ tags: ["SALES"] });
+
+    const { runMultiActionsAgent } = await import(
+      "@app/lib/api/assistant/call_llm"
+    );
+    vi.mocked(runMultiActionsAgent).mockResolvedValueOnce({
+      isOk: () => true,
+      isErr: () => false,
+      value: {
+        actions: [
+          {
+            name: "suggest_templates",
+            arguments: {
+              suggested_templates: [{ id: template1.sId }],
+            },
+          },
+        ],
+        generation: "",
+      },
+    } as never);
+
+    await getSuggestedTemplatesForQuery(authenticator, {
+      query: "  sales emails  ",
+      templates: [template1],
+    });
+
+    expect(runMultiActionsAgent).toHaveBeenCalledOnce();
+    const [, , input] = vi.mocked(runMultiActionsAgent).mock.calls[0];
+
+    // Query should be trimmed.
+    expect(input.conversation.messages[0].content).toEqual([
+      { type: "text", text: "sales emails" },
+    ]);
+
+    // Prompt should contain formatted templates.
+    expect(input.prompt).toContain(template1.sId);
+    expect(input.prompt).toContain(template1.handle);
+  });
+});

--- a/front/lib/api/assistant/template_suggestion.ts
+++ b/front/lib/api/assistant/template_suggestion.ts
@@ -5,21 +5,19 @@ import type { TemplateResource } from "@app/lib/resources/template_resource";
 import type { Result } from "@app/types";
 import {
   Err,
-  GEMINI_2_5_FLASH_MODEL_CONFIG,
   getSmallWhitelistedModel,
-  isProviderWhitelisted,
   isString,
   Ok,
   removeNulls,
 } from "@app/types";
 
 const INSTRUCTIONS = `# Goal:
-Find the most relevant agent templates based on the user's description of what they want their agent to do.
+Find the most relevant agent templates based on the user's query.
 Return up to 5 most relevant templates, ordered by match confidence.
 
 # Guidelines:
-- Match based on semantic similarity between the user's request and each template's description and tags.
-- Prefer templates whose description closely matches the user's stated use case.
+- Match based on semantic similarity between the query and each template's description and tags.
+- Prefer templates whose description closely matches the intent of the query.
 
 Here is the list of available templates:
 `;
@@ -66,17 +64,13 @@ export async function getSuggestedTemplatesForQuery(
 ): Promise<Result<TemplateResource[], Error>> {
   const owner = auth.getNonNullableWorkspace();
 
-  let model = getSmallWhitelistedModel(owner);
+  const model = getSmallWhitelistedModel(owner);
   if (!model) {
     return new Err(
       new Error(
         "Error suggesting templates: failed to find a whitelisted model."
       )
     );
-  }
-
-  if (isProviderWhitelisted(owner, "google_ai_studio")) {
-    model = GEMINI_2_5_FLASH_MODEL_CONFIG;
   }
 
   const formattedTemplates = JSON.stringify(

--- a/front/lib/api/assistant/template_suggestion.ts
+++ b/front/lib/api/assistant/template_suggestion.ts
@@ -1,0 +1,146 @@
+import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
+import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
+import type { Authenticator } from "@app/lib/auth";
+import type { TemplateResource } from "@app/lib/resources/template_resource";
+import type { Result } from "@app/types";
+import {
+  Err,
+  GEMINI_2_5_FLASH_MODEL_CONFIG,
+  getSmallWhitelistedModel,
+  isProviderWhitelisted,
+  Ok,
+  removeNulls,
+} from "@app/types";
+
+const INSTRUCTIONS = `# Goal:
+Find the most relevant agent templates based on the user's description of what they want their agent to do.
+Return up to 5 most relevant templates, ordered by match confidence.
+
+# Guidelines:
+- Match based on semantic similarity between the user's request and each template's description and tags.
+- Prefer templates whose description closely matches the user's stated use case.
+
+Here is the list of available templates:
+`;
+
+const FUNCTION_NAME = "suggest_templates";
+
+const SUGGEST_TEMPLATES_FUNCTION_SPECIFICATIONS: AgentActionSpecification[] = [
+  {
+    name: FUNCTION_NAME,
+    description:
+      "Get the most relevant template ids matching the user's request.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        suggested_templates: {
+          type: "array",
+          description: "Array of template ids.",
+          items: {
+            type: "object",
+            properties: {
+              id: {
+                type: "string",
+                description: "The unique sId of the template.",
+              },
+            },
+            required: ["id"],
+          },
+        },
+      },
+      required: ["suggested_templates"],
+    },
+  },
+];
+
+export async function getSuggestedTemplatesForQuery(
+  auth: Authenticator,
+  {
+    query,
+    templates,
+  }: {
+    query: string;
+    templates: TemplateResource[];
+  }
+): Promise<Result<TemplateResource[], Error>> {
+  const owner = auth.getNonNullableWorkspace();
+
+  let model = getSmallWhitelistedModel(owner);
+  if (!model) {
+    return new Err(
+      new Error(
+        "Error suggesting templates: failed to find a whitelisted model."
+      )
+    );
+  }
+
+  if (isProviderWhitelisted(owner, "google_ai_studio")) {
+    model = GEMINI_2_5_FLASH_MODEL_CONFIG;
+  }
+
+  const formattedTemplates = JSON.stringify(
+    templates.map((t) => ({
+      id: t.sId,
+      handle: t.handle,
+      description: t.agentFacingDescription,
+      tags: t.tags,
+    }))
+  );
+
+  const res = await runMultiActionsAgent(
+    auth,
+    {
+      providerId: model.providerId,
+      modelId: model.modelId,
+      functionCall: FUNCTION_NAME,
+      temperature: 0.7,
+      useCache: true,
+    },
+    {
+      conversation: {
+        messages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: query.trim() }],
+            name: "",
+          },
+        ],
+      },
+      prompt: `${INSTRUCTIONS}${formattedTemplates}`,
+      specifications: SUGGEST_TEMPLATES_FUNCTION_SPECIFICATIONS,
+      forceToolCall: FUNCTION_NAME,
+    },
+    {
+      context: {
+        operationType: "copilot_template_suggestion",
+        userId: auth.user()?.sId,
+        workspaceId: owner.sId,
+      },
+    }
+  );
+
+  if (res.isErr()) {
+    return new Err(
+      new Error(`Error suggesting templates: ${res.error.message}`)
+    );
+  }
+
+  const suggestedTemplates =
+    res.value.actions?.[0]?.arguments?.suggested_templates;
+
+  if (!suggestedTemplates || !Array.isArray(suggestedTemplates)) {
+    return new Err(
+      new Error(
+        "No suggested_templates found in LLM response or invalid format"
+      )
+    );
+  }
+
+  const suggestions = removeNulls(
+    suggestedTemplates.map((t: { id: string }) =>
+      templates.find((t2) => t2.sId === t.id)
+    )
+  );
+
+  return new Ok(suggestions);
+}

--- a/front/lib/api/assistant/template_suggestion.ts
+++ b/front/lib/api/assistant/template_suggestion.ts
@@ -8,6 +8,7 @@ import {
   GEMINI_2_5_FLASH_MODEL_CONFIG,
   getSmallWhitelistedModel,
   isProviderWhitelisted,
+  isString,
   Ok,
   removeNulls,
 } from "@app/types";
@@ -136,10 +137,12 @@ export async function getSuggestedTemplatesForQuery(
     );
   }
 
+  const suggestedIds = suggestedTemplates
+    .map((entry) => entry?.id)
+    .filter(isString);
+
   const suggestions = removeNulls(
-    suggestedTemplates.map((t: { id: string }) =>
-      templates.find((t2) => t2.sId === t.id)
-    )
+    suggestedIds.map((id) => templates.find((t) => t.sId === id))
   );
 
   return new Ok(suggestions);

--- a/front/lib/api/llm/traces/types.ts
+++ b/front/lib/api/llm/traces/types.ts
@@ -21,6 +21,7 @@ interface LLMTraceContextBase {
     | "agent_suggestion"
     | "conversation_title_suggestion"
     | "conversation_unread_summary"
+    | "copilot_template_suggestion"
     | "process_data_sources"
     | "process_schema_generator"
     | "skill_builder_description_suggestion"


### PR DESCRIPTION
## Description

Add a `query` param to `search_agent_templates` so the copilot can semantically search templates when tag-based filtering doesn't cover the user's use case.

- [Task](https://github.com/dust-tt/tasks/issues/6093)
- [Slack thread](https://dust4ai.slack.com/archives/C0A6TBTU7JS/p1770654790043359)

### Solution

- New `getSuggestedTemplatesForQuery` in `template_suggestion.ts` — mirrors `agent_suggestion.ts` pattern: formats templates as JSON, calls `runMultiActionsAgent` with forced tool call, hydrates results
- `query` takes precedence over `jobType` when both provided
- Copilot Step 2.5 updated: falls back to `query`-based search when user response doesn't match any tag-filtered template

## Tests

- Unit tests for `getSuggestedTemplatesForQuery` (5 tests): matching, unknown ID filtering, LLM errors, missing response, prompt construction
- Handler tests for `search_agent_templates` (3 tests): query success, error handling, query precedence over jobType
![Screen Recording 2026-02-11 at 14 19 12](https://github.com/user-attachments/assets/cdf3030a-5d46-4d12-94bd-88e6a5ae66bb)

