### PR TITLE
[Rate Limit] Add per-actor 100/min guardrail for assistant messages

### DIFF
--- a/front/lib/api/assistant/conversation.test.ts
+++ b/front/lib/api/assistant/conversation.test.ts
@@ -439,7 +439,7 @@ describe("retryAgentMessage", () => {
     expect(result.isOk()).toBe(true);
     expect(rateLimiterSpy).toHaveBeenCalledWith(
       expect.objectContaining({
-        key: `workspace:${workspace.id}:user:${userId}:post_user_message`,
+        key: `workspace:${workspace.sId}:user:${userId}:post_user_message`,
       })
     );
 
@@ -470,7 +470,7 @@ describe("retryAgentMessage", () => {
 
     expect(rateLimiterSpy).toHaveBeenCalledWith(
       expect.objectContaining({
-        key: `workspace:${workspace.id}:api_key:${systemKey.id}:post_user_message`,
+        key: `workspace:${workspace.sId}:api_key:${systemKey.id}:post_user_message`,
       })
     );
 
@@ -494,7 +494,7 @@ describe("retryAgentMessage", () => {
     expect(result.isOk()).toBe(true);
     expect(rateLimiterSpy).toHaveBeenCalledWith(
       expect.objectContaining({
-        key: `workspace:${workspace.id}:user:${userId}:post_user_message`,
+        key: `workspace:${workspace.sId}:user:${userId}:post_user_message`,
       })
     );
 

--- a/front/lib/api/assistant/conversation.ts
+++ b/front/lib/api/assistant/conversation.ts
@@ -1822,14 +1822,14 @@ function getMessageRateLimitActor(auth: Authenticator):
       id: number;
     }
   | null {
-  const apiKey = auth.key();
-  if (apiKey) {
-    return { type: "api_key", id: apiKey.id };
-  }
-
   const user = auth.user();
   if (user) {
     return { type: "user", id: user.id };
+  }
+
+  const apiKey = auth.key();
+  if (apiKey) {
+    return { type: "api_key", id: apiKey.id };
   }
 
   return null;

--- a/front/lib/api/assistant/rate_limits.ts
+++ b/front/lib/api/assistant/rate_limits.ts
@@ -8,10 +8,35 @@ import {
 } from "@app/lib/utils/rate_limiter";
 import type { LightWorkspaceType, MaxMessagesTimeframeType } from "@app/types";
 
+export const MESSAGE_RATE_LIMIT_PER_ACTOR_PER_MINUTE = 100;
+export const MESSAGE_RATE_LIMIT_WINDOW_SECONDS = 60;
+
+type MessageRateLimitActor =
+  | {
+      type: "api_key";
+      id: number;
+    }
+  | {
+      type: "user";
+      id: number;
+    };
+
 export const makeMessageRateLimitKeyForWorkspace = (
   owner: LightWorkspaceType
 ) => {
   return `postUserMessage:${owner.sId}`;
+};
+
+export const makeMessageRateLimitKeyForWorkspaceActor = (
+  owner: LightWorkspaceType,
+  actor: MessageRateLimitActor
+) => {
+  switch (actor.type) {
+    case "api_key":
+      return `workspace:${owner.id}:api_key:${actor.id}:post_user_message`;
+    case "user":
+      return `workspace:${owner.id}:user:${actor.id}:post_user_message`;
+  }
 };
 
 export const makeAgentMentionsRateLimitKeyForWorkspace = (

--- a/front/lib/api/assistant/rate_limits.ts
+++ b/front/lib/api/assistant/rate_limits.ts
@@ -33,9 +33,9 @@ export const makeMessageRateLimitKeyForWorkspaceActor = (
 ) => {
   switch (actor.type) {
     case "api_key":
-      return `workspace:${owner.id}:api_key:${actor.id}:post_user_message`;
+      return `workspace:${owner.sId}:api_key:${actor.id}:post_user_message`;
     case "user":
-      return `workspace:${owner.id}:user:${actor.id}:post_user_message`;
+      return `workspace:${owner.sId}:user:${actor.id}:post_user_message`;
   }
 };
 


### PR DESCRIPTION
## Description
Partly fixes https://github.com/dust-tt/tasks/issues/6420

dust_demo has > 50 members, allowing Dora to send more than 500 messages / minutes which was too much

- Adds an actor-scoped assistant message rate limiter (100 messages per 60 seconds) keyed by workspace + user id or workspace + API key id
- Purposefully high, as it's an infrastructure protection not a business one;
- Enforces this limiter before the programmatic-usage branch in `isMessagesLimitReached`, api key usage is counted
- Keeps existing workspace (`10 * activeSeats` per minute, not counting sub-agents + summarizers) and plan mention limits in place; good to have both a per-actor limit and a workspace-global limit.

## Risks
Blast radius: Assistant message posting/retry rate-limit checks in front (user auth, API key auth, and sub-agent cascades).
Risk: standard

## Deploy Plan
- deploy front
