### PR TITLE
DustHiveCat: auto-dismiss notification when user focuses target pane

### DIFF
--- a/x/daph/dust-hive-cat/README.md
+++ b/x/daph/dust-hive-cat/README.md
@@ -7,8 +7,10 @@ A macOS app that displays a roaming cat on your screen. When Claude Code needs y
 - Roaming cat that walks and sleeps around your screen (like a real cat!)
 - Integrates with Claude Code hooks via `dustcat://` URL scheme
 - Click the cat when it's bouncing to switch to the correct tmux pane
+- Auto-dismisses when you manually switch to the target tmux pane
 - Click status bar icon to do the same (left-click = cat action, right-click = menu)
 - Double-tap Option key (⌥⌥) as a global hotkey to jump to the tmux session
+- Never steals focus from your current app
 - Drag and drop the cat anywhere on screen or to another monitor (sets new "home" position)
 - Cat roams within a configurable radius of its home position
 - Preferences window (via menu bar) to customize:

--- a/x/daph/dust-hive-cat/Scripts/dustcat-notify.sh
+++ b/x/daph/dust-hive-cat/Scripts/dustcat-notify.sh
@@ -52,5 +52,5 @@ TARGET_ENCODED=$(echo "$TARGET" | sed 's/:/%3A/g; s/\./%2E/g')
 
 # Only notify if DustHiveCat is already running (don't relaunch after quit)
 if pgrep -x DustHiveCat > /dev/null 2>&1; then
-    open -g "dustcat://notify?target=${TARGET_ENCODED}&title=Claude+ready"
+    open -g "dustcat://notify?target=${TARGET_ENCODED}"
 fi


### PR DESCRIPTION
- **Auto-dismiss**: when the cat is notifying, it now polls every 2s to check if you've manually switched to the target tmux pane (Alacritty focused + pane active). If so,
the notification dismisses itself — no need to click the cat.
- **Notify script**: removed hardcoded `&title=Claude+ready` from the URL to keep the script generic
- **README**: added auto-dismiss and no-focus-stealing to features list
