### PR TITLE
Gong: filter out private conversation as they should not be exposed

### DIFF
--- a/connectors/src/connectors/gong/lib/gong_api.ts
+++ b/connectors/src/connectors/gong/lib/gong_api.ts
@@ -120,6 +120,7 @@ const GongTranscriptMetadataWithoutTrackersCodec = t.intersection([
         title: t.string,
         media: t.union([t.literal("Video"), t.literal("Audio")]),
         language: t.string, // The language codes (as defined by ISO-639-2B): eng, fre, spa, ger, and ita.
+        isPrivate: t.union([t.boolean, t.undefined]), // Whether the call is marked as private in Gong.
       }),
       CatchAllCodec,
     ]),

--- a/connectors/src/connectors/gong/temporal/activities.ts
+++ b/connectors/src/connectors/gong/temporal/activities.ts
@@ -213,6 +213,15 @@ export async function gongSyncTranscriptsActivity({
         return;
       }
 
+      // Always filter out private transcripts.
+      if (transcriptMetadata.metaData.isPrivate === true) {
+        logger.info(
+          { ...loggerArgs, callId: transcript.callId },
+          "[Gong] Skipping private transcript."
+        );
+        return;
+      }
+
       const { parties = [] } = transcriptMetadata;
 
       const participants = await getGongUsers(connector, {


### PR DESCRIPTION
## Description

According to the doc of the endpoint we call there is a "isPrivate" field we should use to filter out private conversation
https://gong.app.gong.io/settings/api/documentation#post-/v2/calls/extensive



## Tests

not tested

## Risk

can hide more conversations than expected 

## Deploy Plan

deploy front
