### PR TITLE
[front] - fix(AB): add version filtering to feedback

### DIFF
--- a/front/components/agent_builder/FeedbacksSection.tsx
+++ b/front/components/agent_builder/FeedbacksSection.tsx
@@ -53,11 +53,13 @@ type FeedbackFilter = "unseen" | "all";
 interface FeedbacksSectionProps {
   owner: LightWorkspaceType;
   agentConfigurationId: string;
+  version?: number;
 }
 
 export const FeedbacksSection = ({
   owner,
   agentConfigurationId,
+  version,
 }: FeedbacksSectionProps) => {
   const [feedbackFilter, setFeedbackFilter] =
     useState<FeedbackFilter>("unseen");
@@ -72,9 +74,10 @@ export const FeedbacksSection = ({
     mutateAgentConfigurationFeedbacks,
   } = useAgentConfigurationFeedbacksByDescVersion({
     workspaceId: owner.sId,
-    agentConfigurationId: agentConfigurationId,
+    agentConfigurationId,
     limit: FEEDBACKS_PAGE_SIZE,
     filter: feedbackFilter,
+    version,
   });
 
   // Intersection observer to detect when the user has scrolled to the bottom of the list.
@@ -100,7 +103,7 @@ export const FeedbacksSection = ({
   const { agentConfigurationHistory, isAgentConfigurationHistoryLoading } =
     useAgentConfigurationHistory({
       workspaceId: owner.sId,
-      agentConfigurationId: agentConfigurationId,
+      agentConfigurationId,
       disabled: !agentConfigurationId,
     });
 

--- a/front/components/observability/AgentFeedback.tsx
+++ b/front/components/observability/AgentFeedback.tsx
@@ -38,14 +38,15 @@ export function AgentFeedback({
   allowReactions,
 }: AgentFeedbackProps) {
   const { period, mode, selectedVersion } = useObservabilityContext();
+
+  const versionFilter =
+    allowReactions && mode === "version" ? selectedVersion : null;
+
   const { agentAnalytics } = useAgentAnalytics({
     workspaceId: owner.sId,
     agentConfigurationId,
     period,
-    version:
-      allowReactions && mode === "version"
-        ? selectedVersion?.version
-        : undefined,
+    version: versionFilter?.version,
   });
 
   return (
@@ -89,6 +90,7 @@ export function AgentFeedback({
         <FeedbacksSection
           owner={owner}
           agentConfigurationId={agentConfigurationId}
+          version={versionFilter ? Number(versionFilter.version) : undefined}
         />
       )}
     </div>

--- a/front/lib/api/assistant/feedback.ts
+++ b/front/lib/api/assistant/feedback.ts
@@ -184,12 +184,14 @@ export async function getAgentFeedbacks({
   withMetadata,
   paginationParams,
   filter = "active",
+  version,
 }: {
   auth: Authenticator;
   withMetadata: boolean;
   agentConfigurationId: string;
   paginationParams: PaginationParams;
   filter?: "active" | "all";
+  version?: number;
 }): Promise<
   Result<
     (AgentMessageFeedbackType | AgentMessageFeedbackWithMetadataType)[],
@@ -214,6 +216,7 @@ export async function getAgentFeedbacks({
         agentConfiguration,
         paginationParams,
         filter,
+        version,
       }
     );
 

--- a/front/lib/resources/agent_message_feedback_resource.ts
+++ b/front/lib/resources/agent_message_feedback_resource.ts
@@ -193,17 +193,23 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
     agentConfiguration,
     paginationParams,
     filter = "active",
+    version,
   }: {
     workspace: WorkspaceType;
     agentConfiguration: LightAgentConfigurationType;
     paginationParams: PaginationParams;
     filter?: "active" | "all";
+    version?: number;
   }) {
     const where: WhereOptions<AgentMessageFeedbackModel> = {
       // Safety check: global models share ids across workspaces and some have had feedbacks.
       workspaceId: workspace.id,
       agentConfigurationId: agentConfiguration.sId,
     };
+
+    if (version !== undefined) {
+      where.agentConfigurationVersion = version;
+    }
 
     if (filter === "active") {
       where.dismissed = false;

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -299,6 +299,7 @@ interface AgentConfigurationFeedbacksByDescVersionProps {
   agentConfigurationId: string | null;
   limit: number;
   filter?: "unseen" | "all";
+  version?: number;
 }
 
 export function useAgentConfigurationFeedbacksByDescVersion({
@@ -306,6 +307,7 @@ export function useAgentConfigurationFeedbacksByDescVersion({
   agentConfigurationId,
   limit,
   filter = "unseen",
+  version,
 }: AgentConfigurationFeedbacksByDescVersionProps) {
   const agentConfigurationFeedbacksFetcher: Fetcher<{
     feedbacks: (
@@ -338,6 +340,10 @@ export function useAgentConfigurationFeedbacksByDescVersion({
           withMetadata: "true",
           filter,
         });
+
+        if (version !== undefined) {
+          urlParams.set("version", version.toString());
+        }
 
         if (previousPageData !== null) {
           const lastIdValue =

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/feedbacks.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/feedbacks.ts
@@ -8,8 +8,8 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import { getPaginationParams } from "@app/lib/api/pagination";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
-import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types";
+import type { WithAPIErrorResponse } from "@app/types/error";
 
 async function handler(
   req: NextApiRequest,


### PR DESCRIPTION
## Description

Adds version filtering to the agent feedback section in the agent builder's observability tab. When the observability context is in "version" mode and reactions are allowed, the feedback display now filters to show only feedback for the selected version. This addresses the issue where all feedback was displayed regardless of version selection.

**References:**
- Fixes https://github.com/dust-tt/tasks/issues/6450

## Risk

Low

## Tests

Locally

## Deploy Plan

Deploy front