### PR TITLE
Allow copilot to be mentioned explicitly

### DIFF
--- a/front/lib/api/assistant/conversation/mention_suggestions.ts
+++ b/front/lib/api/assistant/conversation/mention_suggestions.ts
@@ -234,6 +234,8 @@ export const suggestionsOfMentions = async (
       variant: "light",
     });
 
+    const activeAgentIds = new Set(agentConfigurations.map((a) => a.sId));
+
     const activeAgents: RichAgentMentionInConversation[] = agentConfigurations
       .filter((a) => a.status === "active")
       .map((a) => ({
@@ -242,6 +244,13 @@ export const suggestionsOfMentions = async (
         lastActivityAt:
           participantAgents.find((pa) => pa.id === a.sId)?.lastActivityAt ?? 0,
       }));
+
+    // Include participant agents not already in the fetched configurations
+    // (e.g. the copilot agent which is excluded from global agent listings).
+    const missingParticipants = participantAgents.filter(
+      (pa) => !activeAgentIds.has(pa.id)
+    );
+    activeAgents.push(...missingParticipants);
 
     const filteredAgents = filterAndSortEditorSuggestionAgents(
       normalizedQuery,


### PR DESCRIPTION
## Description

This makes sure that you are able to mention `@copilot` in the context of a copilot conversation.

Fixes https://github.com/dust-tt/tasks/issues/6361

## Tests

Manual

## Risk

Low. Although it's in the general non-copilot code path, it should be a no-op in most cases.

## Deploy Plan

Front.