### PR TITLE
feat(agents): show personal triggers in agent details

### DIFF
--- a/front/components/assistant/details/AgentDetails.tsx
+++ b/front/components/assistant/details/AgentDetails.tsx
@@ -107,7 +107,7 @@ export function AgentDetails({
   const [showRestoreModal, setShowRestoreModal] = useState(false);
   const showEditorsTabs = agentId != null && !isGlobalAgent;
   const showTriggersTabs =
-    agentId != null && agentId === GLOBAL_AGENTS_SID.DUST;
+    agentId != null && (!isGlobalAgent || agentId === GLOBAL_AGENTS_SID.DUST);
   const showAgentMemory = !!agentConfiguration?.actions.find((arg) =>
     isServerSideMCPServerConfigurationWithName(arg, AGENT_MEMORY_SERVER_NAME)
   );
@@ -286,6 +286,7 @@ export function AgentDetails({
                       <TabsContent value="triggers">
                         <AgentTriggersTab
                           agentConfiguration={agentConfiguration}
+                          isGlobalAgent={isGlobalAgent}
                           owner={owner}
                         />
                       </TabsContent>

--- a/front/components/assistant/details/tabs/AgentTriggersTab.tsx
+++ b/front/components/assistant/details/tabs/AgentTriggersTab.tsx
@@ -9,6 +9,7 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
+  PencilSquareIcon,
   TrashIcon,
 } from "@dust-tt/sparkle";
 import { Button } from "@dust-tt/sparkle";
@@ -21,17 +22,20 @@ import {
   useAgentTriggers,
   useDeleteTrigger,
 } from "@app/lib/swr/agent_triggers";
+import { getAgentBuilderRoute } from "@app/lib/utils/router";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type { TriggerType } from "@app/types/assistant/triggers";
 import type { WorkspaceType } from "@app/types/user";
 
 interface AgentTriggersTabProps {
   agentConfiguration: LightAgentConfigurationType;
+  isGlobalAgent: boolean;
   owner: WorkspaceType;
 }
 
 export function AgentTriggersTab({
   agentConfiguration,
+  isGlobalAgent,
   owner,
 }: AgentTriggersTabProps) {
   const { triggers, isTriggersLoading } = useAgentTriggers({
@@ -113,14 +117,27 @@ export function AgentTriggersTab({
                     <div className="font-semibold">{trigger.name}</div>
                   </div>
                   <div className="self-end">
-                    <Button
-                      label="Delete"
-                      disabled={!trigger.isEditor}
-                      icon={TrashIcon}
-                      variant="outline"
-                      size="sm"
-                      onClick={() => setTriggerToDelete(trigger)}
-                    />
+                    {isGlobalAgent ? (
+                      <Button
+                        label="Delete"
+                        disabled={!trigger.isEditor}
+                        icon={TrashIcon}
+                        variant="outline"
+                        size="sm"
+                        onClick={() => setTriggerToDelete(trigger)}
+                      />
+                    ) : (
+                      <Button
+                        label="Edit"
+                        icon={PencilSquareIcon}
+                        variant="outline"
+                        size="sm"
+                        href={getAgentBuilderRoute(
+                          owner.sId,
+                          agentConfiguration.sId
+                        )}
+                      />
+                    )}
                   </div>
                 </div>
                 {trigger.kind === "schedule" && (

--- a/front/components/assistant/details/tabs/AgentTriggersTab.tsx
+++ b/front/components/assistant/details/tabs/AgentTriggersTab.tsx
@@ -1,6 +1,7 @@
 import {
   Avatar,
   BellIcon,
+  Chip,
   ClockIcon,
   Dialog,
   DialogContainer,
@@ -26,6 +27,7 @@ import { getAgentBuilderRoute } from "@app/lib/utils/router";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type { TriggerType } from "@app/types/assistant/triggers";
 import type { WorkspaceType } from "@app/types/user";
+import { isAdmin } from "@app/types/user";
 
 interface AgentTriggersTabProps {
   agentConfiguration: LightAgentConfigurationType;
@@ -78,6 +80,9 @@ export function AgentTriggersTab({
     }
   };
 
+  const canEditAgent =
+    !isGlobalAgent && (agentConfiguration.canEdit || isAdmin(owner));
+
   // TODO(adrien): for now, we only show the user's triggers.
   // We might reconsider it, and display a "My triggers" section,
   // and a "How others automate this" section in the future.
@@ -115,18 +120,14 @@ export function AgentTriggersTab({
                       }
                     />
                     <div className="font-semibold">{trigger.name}</div>
+                    {trigger.status !== "enabled" && (
+                      <Chip size="xs" color="primary">
+                        Disabled
+                      </Chip>
+                    )}
                   </div>
                   <div className="self-end">
-                    {isGlobalAgent ? (
-                      <Button
-                        label="Delete"
-                        disabled={!trigger.isEditor}
-                        icon={TrashIcon}
-                        variant="outline"
-                        size="sm"
-                        onClick={() => setTriggerToDelete(trigger)}
-                      />
-                    ) : (
+                    {canEditAgent ? (
                       <Button
                         label="Edit"
                         icon={PencilSquareIcon}
@@ -136,6 +137,15 @@ export function AgentTriggersTab({
                           owner.sId,
                           agentConfiguration.sId
                         )}
+                      />
+                    ) : (
+                      <Button
+                        label="Delete"
+                        disabled={!trigger.isEditor}
+                        icon={TrashIcon}
+                        variant="outline"
+                        size="sm"
+                        onClick={() => setTriggerToDelete(trigger)}
                       />
                     )}
                   </div>


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

This PR brings the triggers tab of the agent details to every custom agent (+dust). 
No reason to show it for dust and no other agent.

This only shows the user's triggers.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front