### PR TITLE
[front] - fix(AB): filter feedback by date

### DIFF
--- a/front/components/agent_builder/FeedbacksSection.tsx
+++ b/front/components/agent_builder/FeedbacksSection.tsx
@@ -54,12 +54,14 @@ interface FeedbacksSectionProps {
   owner: LightWorkspaceType;
   agentConfigurationId: string;
   version?: number;
+  days?: number;
 }
 
 export const FeedbacksSection = ({
   owner,
   agentConfigurationId,
   version,
+  days,
 }: FeedbacksSectionProps) => {
   const [feedbackFilter, setFeedbackFilter] =
     useState<FeedbackFilter>("unseen");
@@ -78,6 +80,7 @@ export const FeedbacksSection = ({
     limit: FEEDBACKS_PAGE_SIZE,
     filter: feedbackFilter,
     version,
+    days,
   });
 
   // Intersection observer to detect when the user has scrolled to the bottom of the list.

--- a/front/components/observability/AgentFeedback.tsx
+++ b/front/components/observability/AgentFeedback.tsx
@@ -88,6 +88,7 @@ export function AgentFeedback({
 
       {allowReactions && (
         <FeedbacksSection
+          key={`${versionFilter?.version ?? "all"}-${mode === "timeRange" ? period : "none"}`}
           owner={owner}
           agentConfigurationId={agentConfigurationId}
           version={versionFilter ? Number(versionFilter.version) : undefined}

--- a/front/components/observability/AgentFeedback.tsx
+++ b/front/components/observability/AgentFeedback.tsx
@@ -91,6 +91,7 @@ export function AgentFeedback({
           owner={owner}
           agentConfigurationId={agentConfigurationId}
           version={versionFilter ? Number(versionFilter.version) : undefined}
+          days={mode === "timeRange" ? period : undefined}
         />
       )}
     </div>

--- a/front/lib/api/assistant/feedback.ts
+++ b/front/lib/api/assistant/feedback.ts
@@ -185,6 +185,7 @@ export async function getAgentFeedbacks({
   paginationParams,
   filter = "active",
   version,
+  days,
 }: {
   auth: Authenticator;
   withMetadata: boolean;
@@ -192,6 +193,7 @@ export async function getAgentFeedbacks({
   paginationParams: PaginationParams;
   filter?: "active" | "all";
   version?: number;
+  days?: number;
 }): Promise<
   Result<
     (AgentMessageFeedbackType | AgentMessageFeedbackWithMetadataType)[],
@@ -217,6 +219,7 @@ export async function getAgentFeedbacks({
         paginationParams,
         filter,
         version,
+        days,
       }
     );
 

--- a/front/lib/resources/agent_message_feedback_resource.ts
+++ b/front/lib/resources/agent_message_feedback_resource.ts
@@ -194,12 +194,14 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
     paginationParams,
     filter = "active",
     version,
+    days,
   }: {
     workspace: WorkspaceType;
     agentConfiguration: LightAgentConfigurationType;
     paginationParams: PaginationParams;
     filter?: "active" | "all";
     version?: number;
+    days?: number;
   }) {
     const where: WhereOptions<AgentMessageFeedbackModel> = {
       // Safety check: global models share ids across workspaces and some have had feedbacks.
@@ -209,6 +211,12 @@ export class AgentMessageFeedbackResource extends BaseResource<AgentMessageFeedb
 
     if (version !== undefined) {
       where.agentConfigurationVersion = version;
+    }
+
+    if (days !== undefined) {
+      const cutoffDate = new Date();
+      cutoffDate.setDate(cutoffDate.getDate() - days);
+      where.createdAt = { [Op.gte]: cutoffDate };
     }
 
     if (filter === "active") {

--- a/front/lib/swr/assistants.ts
+++ b/front/lib/swr/assistants.ts
@@ -300,6 +300,7 @@ interface AgentConfigurationFeedbacksByDescVersionProps {
   limit: number;
   filter?: "unseen" | "all";
   version?: number;
+  days?: number;
 }
 
 export function useAgentConfigurationFeedbacksByDescVersion({
@@ -308,6 +309,7 @@ export function useAgentConfigurationFeedbacksByDescVersion({
   limit,
   filter = "unseen",
   version,
+  days,
 }: AgentConfigurationFeedbacksByDescVersionProps) {
   const agentConfigurationFeedbacksFetcher: Fetcher<{
     feedbacks: (
@@ -343,6 +345,10 @@ export function useAgentConfigurationFeedbacksByDescVersion({
 
         if (version !== undefined) {
           urlParams.set("version", version.toString());
+        }
+
+        if (days !== undefined) {
+          urlParams.set("days", days.toString());
         }
 
         if (previousPageData !== null) {

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/feedbacks.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/feedbacks.ts
@@ -8,8 +8,8 @@ import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrapper
 import { getPaginationParams } from "@app/lib/api/pagination";
 import type { Authenticator } from "@app/lib/auth";
 import { apiError } from "@app/logger/withlogging";
-import { isString } from "@app/types";
 import type { WithAPIErrorResponse } from "@app/types/error";
+import { isString } from "@app/types/shared/utils/general";
 
 async function handler(
   req: NextApiRequest,

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/feedbacks.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/feedbacks.ts
@@ -70,11 +70,16 @@ async function handler(
           paginationRes.error
         );
       }
-      const { filter: filterParam, version: versionParam } = req.query;
+      const {
+        filter: filterParam,
+        version: versionParam,
+        days: daysParam,
+      } = req.query;
       const filter = filterParam === "all" ? "all" : "active";
       const version = isString(versionParam)
         ? parseInt(versionParam, 10)
         : undefined;
+      const days = isString(daysParam) ? parseInt(daysParam, 10) : undefined;
       const feedbacksRes = await getAgentFeedbacks({
         auth,
         agentConfigurationId: aId,
@@ -82,6 +87,7 @@ async function handler(
         paginationParams: paginationRes.value,
         filter,
         version: Number.isNaN(version) ? undefined : version,
+        days: Number.isNaN(days) ? undefined : days,
       });
 
       if (feedbacksRes.isErr()) {


### PR DESCRIPTION
## Description

Adds time range filtering to the agent feedback section when the observability is in "timeRange" mode. The feedback list now respects the selected period (e.g., 7, 14, 30 days) and only displays feedback created within that timeframe. A React key prop is added to `FeedbacksSection` to force a remount when the filter changes, ensuring the component refreshes properly with the new filtered data.

## Risk

Low

## Tests

- [x] Locally

## Deploy Plan

Deploy front