### PR TITLE
fix(mcp): move text to _meta in resources

### DIFF
--- a/front/lib/actions/mcp_internal_actions/utils/attachment_processing.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/attachment_processing.ts
@@ -118,7 +118,7 @@ export async function processAttachment({
       type: "resource" as const,
       resource: {
         blob: buffer.toString("base64"),
-        text: `Attachment: ${sanitizeFilename(filename)}`,
+        _meta: { text: `Attachment: ${sanitizeFilename(filename)}` },
         mimeType,
         uri: "",
       },

--- a/front/lib/api/actions/servers/ashby/tools/index.ts
+++ b/front/lib/api/actions/servers/ashby/tools/index.ts
@@ -182,7 +182,7 @@ const handlers: ToolHandlers<typeof ASHBY_TOOLS_METADATA> = {
           uri: `ashby-report-${reportId}.csv`,
           mimeType: "text/csv",
           blob: base64Content,
-          text: `Ashby report data (${dataRows.length} rows)`,
+          _meta: { text: `Ashby report data (${dataRows.length} rows)` },
         },
       },
     ]);

--- a/front/lib/api/actions/servers/file_generation/tools/index.ts
+++ b/front/lib/api/actions/servers/file_generation/tools/index.ts
@@ -279,7 +279,7 @@ ${file_content
               resource: {
                 name: file_name,
                 blob: base64,
-                text: "Your file was generated successfully.",
+                _meta: { text: "Your file was generated successfully." },
                 mimeType: getContentTypeFromOutputFormat(extension),
                 uri: fileNameWithoutExtension,
               },
@@ -299,14 +299,14 @@ ${file_content
     }
 
     // Basic case: we have a text-based format and we can generate the file directly.
+    // We return a base64 blob, it will be uploaded in MCPConfigurationServerRunner.run.
     return new Ok([
       {
         type: "resource" as const,
-        // We return a base64 blob, it will be uploaded in MCPConfigurationServerRunner.run.
         resource: {
           name: file_name,
           blob: Buffer.from(file_content).toString("base64"),
-          text: "Your file was generated successfully.",
+          _meta: { text: "Your file was generated successfully." },
           mimeType: getContentTypeFromOutputFormat(extension),
           uri: fileNameWithoutExtension,
         },

--- a/front/lib/api/actions/servers/sound_studio/tools/index.ts
+++ b/front/lib/api/actions/servers/sound_studio/tools/index.ts
@@ -35,7 +35,9 @@ const handlers: ToolHandlers<typeof SOUND_STUDIO_TOOLS_METADATA> = {
           resource: {
             name: fileName,
             blob: base64,
-            text: "Your sound effect was generated successfully.",
+            _meta: {
+              text: "Your sound effect was generated successfully.",
+            },
             mimeType: "audio/mpeg",
             uri: fileName,
           },

--- a/front/lib/api/actions/servers/speech_generator/tools/index.ts
+++ b/front/lib/api/actions/servers/speech_generator/tools/index.ts
@@ -43,7 +43,7 @@ const handlers: ToolHandlers<typeof SPEECH_GENERATOR_TOOLS_METADATA> = {
           resource: {
             name: fileName,
             blob: base64,
-            text: "Your audio file was generated successfully.",
+            _meta: { text: "Your audio file was generated successfully." },
             mimeType: "audio/mpeg",
             uri: fileName,
           },
@@ -89,7 +89,9 @@ const handlers: ToolHandlers<typeof SPEECH_GENERATOR_TOOLS_METADATA> = {
           resource: {
             name: fileName,
             blob: base64,
-            text: "Your dialogue audio file was generated successfully.",
+            _meta: {
+              text: "Your dialogue audio file was generated successfully.",
+            },
             mimeType: "audio/mpeg",
             uri: fileName,
           },


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

In MCP servers, resources can't have both text and blob. Otherwise, blob will be stripped. This way, we don't have anything when we generate a file for example.

This PR moves text to _meta, that we can use and is presented to the model downstream.

This PR handles all places in the code where blob and text where cohabiting in resources.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

Tested by hand

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

Should fix a problem, low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy front