### PR TITLE
fix N+1 query in GET /mcp endpoint

### DIFF
--- a/front/pages/api/w/[wId]/mcp/index.ts
+++ b/front/pages/api/w/[wId]/mcp/index.ts
@@ -16,7 +16,11 @@ import { fetchRemoteServerMetaDataByURL } from "@app/lib/actions/mcp_metadata";
 import type { AuthorizationInfo } from "@app/lib/actions/mcp_metadata_extraction";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import apiConfig from "@app/lib/api/config";
-import type { MCPServerType, MCPServerTypeWithViews } from "@app/lib/api/mcp";
+import type {
+  MCPServerType,
+  MCPServerTypeWithViews,
+  MCPServerViewType,
+} from "@app/lib/api/mcp";
 import type { Authenticator } from "@app/lib/auth";
 import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
 import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
@@ -24,7 +28,6 @@ import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resour
 import { RemoteMCPServerToolMetadataResource } from "@app/lib/resources/remote_mcp_server_tool_metadata_resource";
 import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
-import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
@@ -94,25 +97,30 @@ async function handler(
       const internalMCPs =
         await InternalMCPServerInMemoryResource.listByWorkspace(auth);
 
-      const servers = [...remoteMCPs, ...internalMCPs].sort((a, b) =>
-        a.toJSON().name.localeCompare(b.toJSON().name)
+      const servers = [...remoteMCPs, ...internalMCPs]
+        .map((r) => r.toJSON())
+        .sort((a, b) => a.name.localeCompare(b.name));
+
+      // Batch-fetch all views in a single query instead of N+1.
+      const allViews = await MCPServerViewResource.listByMCPServers(
+        auth,
+        servers.map((s) => s.sId)
       );
+
+      const viewsByServerId = new Map<string, MCPServerViewType[]>();
+      for (const view of allViews) {
+        const serverId = view.mcpServerId;
+        const existing = viewsByServerId.get(serverId) ?? [];
+        existing.push(view.toJSON());
+        viewsByServerId.set(serverId, existing);
+      }
 
       return res.status(200).json({
         success: true,
-        servers: await concurrentExecutor(
-          servers,
-          async (r) => {
-            const server = r.toJSON();
-            const views = (
-              await MCPServerViewResource.listByMCPServer(auth, server.sId)
-            ).map((v) => v.toJSON());
-            return { ...server, views };
-          },
-          {
-            concurrency: 10,
-          }
-        ),
+        servers: servers.map((server) => ({
+          ...server,
+          views: viewsByServerId.get(server.sId) ?? [],
+        })),
       });
     }
     case "POST": {


### PR DESCRIPTION
## Description

- Replace N+1 listByMCPServer calls (one per server inside concurrentExecutor) with a single listByMCPServers batch query using WHERE IN, then group views in a local Map for O(1) lookup per server.
- Serialize servers with toJSON() once upfront instead of repeatedly in the sort comparator, sId extraction, and final mapping.
- Remove the now-unused concurrentExecutor import.

## Tests

Existing test still passes + test app locally. 

## Risk

Can be rolled back. 

## Deploy Plan

Deploy front. 