### PR TITLE
[Front] feat(copilot): open copilot tab when navigating from template gallery

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -108,6 +108,7 @@ export default function AgentBuilder({
   const { owner, user, assistantTemplate } = useAgentBuilderContext();
   const { supportedDataSourceViews } = useDataSourceViewsContext();
   const { mcpServerViews } = useMCPServerViewsContext();
+  const { hasFeature } = useFeatureFlags({ workspaceId: owner.sId });
 
   const router = useAppRouter();
   const sendNotification = useSendNotification(true);
@@ -227,14 +228,26 @@ export default function AgentBuilder({
     }
 
     if (assistantTemplate) {
-      return transformTemplateToFormData(assistantTemplate, user, owner);
+      return transformTemplateToFormData(
+        assistantTemplate,
+        user,
+        owner,
+        hasFeature
+      );
     }
 
     return getDefaultAgentFormData({
       owner,
       user,
     });
-  }, [agentConfiguration, duplicateAgentId, assistantTemplate, user, owner]);
+  }, [
+    agentConfiguration,
+    duplicateAgentId,
+    assistantTemplate,
+    user,
+    owner,
+    hasFeature,
+  ]);
 
   const form = useForm<AgentBuilderFormData>({
     resolver: zodResolver(agentBuilderFormSchema),

--- a/front/components/agent_builder/AgentBuilderRightPanel.tsx
+++ b/front/components/agent_builder/AgentBuilderRightPanel.tsx
@@ -225,6 +225,10 @@ export function AgentBuilderRightPanel({
   const hasTemplate = !!assistantTemplate;
   const hasCopilot = hasFeature("agent_builder_copilot");
 
+  // Default tab priority:
+  // - Template tab: when building from a template (copilot OFF)
+  // - Copilot tab: from template gallery (hasTemplate) or shrink-wrap (conversationId)
+  // - Preview tab: fallback
   function getDefaultTab(): AgentBuilderRightPanelTabType {
     if (hasTemplate && !hasCopilot) {
       return "template";

--- a/front/components/agent_builder/AgentBuilderRightPanel.tsx
+++ b/front/components/agent_builder/AgentBuilderRightPanel.tsx
@@ -224,11 +224,19 @@ export function AgentBuilderRightPanel({
 
   const hasTemplate = !!assistantTemplate;
   const hasCopilot = hasFeature("agent_builder_copilot");
-  const inferFromConversation = conversationId && hasCopilot && !hasTemplate;
 
-  const [selectedTab, setSelectedTab] = useState<AgentBuilderRightPanelTabType>(
-    hasTemplate ? "template" : inferFromConversation ? "copilot" : "preview"
-  );
+  function getDefaultTab(): AgentBuilderRightPanelTabType {
+    if (hasTemplate && !hasCopilot) {
+      return "template";
+    }
+    if (hasCopilot && (!!conversationId || hasTemplate)) {
+      return "copilot";
+    }
+    return "preview";
+  }
+
+  const [selectedTab, setSelectedTab] =
+    useState<AgentBuilderRightPanelTabType>(getDefaultTab);
 
   const handleTogglePanel = () => {
     setIsPreviewPanelOpen((prev) => !prev);

--- a/front/components/pages/builder/agents/NewAgentPage.tsx
+++ b/front/components/pages/builder/agents/NewAgentPage.tsx
@@ -25,7 +25,7 @@ function isBuilderFlow(value: string): value is BuilderFlow {
 export function NewAgentPage() {
   const owner = useWorkspace();
   const { user, isAdmin, isBuilder } = useAuth();
-  const { hasFeature } = useFeatureFlags({
+  const { featureFlags, isFeatureFlagsLoading, hasFeature } = useFeatureFlags({
     workspaceId: owner.sId,
   });
 
@@ -39,9 +39,6 @@ export function NewAgentPage() {
   const copilotTemplateId = useSearchParam("copilotTemplateId");
   const conversationId = useSearchParam("conversationId");
 
-  const { featureFlags, isFeatureFlagsLoading } = useFeatureFlags({
-    workspaceId: owner.sId,
-  });
   const isRestrictedFromAgentCreation =
     featureFlags.includes("disallow_agent_creation_to_users") && !isBuilder;
 


### PR DESCRIPTION
## Description

When `agent_builder_copilot` FF is enabled, clicking "Use this template" from the template gallery now opens the builder with the copilot tab active instead of the template tab, and skips preset instructions so the copilot can guide the user from scratch.


See [Slack thread](https://dust4ai.slack.com/archives/C0A6TBTU7JS/p1770739584221809?thread_ts=1770296026.414079&cid=C0A6TBTU7JS).


Template tab remains visible for reference even when copilot is active.

## Tests

![Screen Recording 2026-02-11 at 16 57 38](https://github.com/user-attachments/assets/e3c5ea85-eadf-45d3-9fd7-d9bbda26091f)


