### PR TITLE
Replace useUser with useAuth

### DIFF
--- a/front/components/agent_builder/AgentBuilderCopilot.tsx
+++ b/front/components/agent_builder/AgentBuilderCopilot.tsx
@@ -15,8 +15,8 @@ import {
   copilotSuggestionDirective,
   getCopilotSuggestionPlugin,
 } from "@app/components/markdown/suggestion/CopilotSuggestionDirective";
+import { useAuth } from "@app/lib/auth/AuthContext";
 import { isFreeTrialPhonePlan } from "@app/lib/plans/plan_codes";
-import { useUser } from "@app/lib/swr/user";
 import { useWorkspaceActiveSubscription } from "@app/lib/swr/workspaces";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { ConversationSidePanelType } from "@app/types/conversation_side_panel";
@@ -128,7 +128,7 @@ function CopilotContent({
 
 export function AgentBuilderCopilot() {
   const { owner, isAdmin } = useAgentBuilderContext();
-  const { user } = useUser();
+  const { user } = useAuth();
   const { activeSubscription } = useWorkspaceActiveSubscription({ owner });
   const isTrialPlan =
     activeSubscription && isFreeTrialPhonePlan(activeSubscription.plan.code);

--- a/front/components/agent_builder/AgentBuilderPreview.tsx
+++ b/front/components/agent_builder/AgentBuilderPreview.tsx
@@ -16,9 +16,9 @@ import { ConversationViewer } from "@app/components/assistant/conversation/Conve
 import { GenerationContextProvider } from "@app/components/assistant/conversation/GenerationContextProvider";
 import { InputBar } from "@app/components/assistant/conversation/input_bar/InputBar";
 import { useMCPServerViewsContext } from "@app/components/shared/tools_picker/MCPServerViewsContext";
+import { useAuth } from "@app/lib/auth/AuthContext";
 import type { DustError } from "@app/lib/error";
 import { isFreeTrialPhonePlan } from "@app/lib/plans/plan_codes";
-import { useUser } from "@app/lib/swr/user";
 import { useWorkspaceActiveSubscription } from "@app/lib/swr/workspaces";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
@@ -156,7 +156,7 @@ function PreviewContent({
 
 export function AgentBuilderPreview() {
   const { owner, isAdmin } = useAgentBuilderContext();
-  const { user } = useUser();
+  const { user } = useAuth();
   const { activeSubscription } = useWorkspaceActiveSubscription({ owner });
   const isTrialPlan =
     activeSubscription && isFreeTrialPhonePlan(activeSubscription.plan.code);

--- a/front/components/agent_builder/CopilotPanelContext.tsx
+++ b/front/components/agent_builder/CopilotPanelContext.tsx
@@ -11,7 +11,7 @@ import React, {
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import { useCreateConversationWithMessage } from "@app/hooks/useCreateConversationWithMessage";
 import { useSendNotification } from "@app/hooks/useNotification";
-import { useUser } from "@app/lib/swr/user";
+import { useAuth } from "@app/lib/auth/AuthContext";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 import type { ConversationType } from "@app/types/assistant/conversation";
 
@@ -197,7 +197,7 @@ export const CopilotPanelProvider = ({
   conversationId,
 }: CopilotPanelProviderProps) => {
   const { owner } = useAgentBuilderContext();
-  const { user } = useUser();
+  const { user } = useAuth();
   const sendNotification = useSendNotification();
 
   const [conversation, setConversation] = useState<ConversationType | null>(

--- a/front/components/agent_builder/hooks/useAgentPreview.ts
+++ b/front/components/agent_builder/hooks/useAgentPreview.ts
@@ -7,8 +7,8 @@ import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBu
 import { submitAgentBuilderForm } from "@app/components/agent_builder/submitAgentBuilderForm";
 import { useCreateConversationWithMessage } from "@app/hooks/useCreateConversationWithMessage";
 import { useSendNotification } from "@app/hooks/useNotification";
+import { useAuth } from "@app/lib/auth/AuthContext";
 import type { DustError } from "@app/lib/error";
-import { useUser } from "@app/lib/swr/user";
 import type { LightAgentConfigurationType } from "@app/types/assistant/agent";
 import type { ConversationType } from "@app/types/assistant/conversation";
 import type { RichMention } from "@app/types/assistant/mentions";
@@ -109,7 +109,7 @@ export function useDraftConversation({
   getDraftAgent: () => Promise<LightAgentConfigurationType | null>;
 }) {
   const { owner } = useAgentBuilderContext();
-  const { user } = useUser();
+  const { user } = useAuth();
   const sendNotification = useSendNotification();
   const [conversation, setConversation] = useState<
     ConversationType | undefined

--- a/front/components/agent_builder/triggers/TriggerCard.tsx
+++ b/front/components/agent_builder/triggers/TriggerCard.tsx
@@ -11,7 +11,7 @@ import { useMemo } from "react";
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import type { AgentBuilderTriggerType } from "@app/components/agent_builder/AgentBuilderFormContext";
 import { getIcon } from "@app/components/resources/resources_icons";
-import { useUser } from "@app/lib/swr/user";
+import { useAuth } from "@app/lib/auth/AuthContext";
 import { normalizeWebhookIcon } from "@app/lib/webhookSource";
 import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
 import { WEBHOOK_PRESETS } from "@app/types/triggers/webhooks";
@@ -64,7 +64,7 @@ export const TriggerCard = ({
   onEdit,
 }: TriggerCardProps) => {
   const { isAdmin } = useAgentBuilderContext();
-  const { user } = useUser();
+  const { user } = useAuth();
   const isEditor = trigger.editor === user?.id;
   const description = useMemo(() => {
     if (trigger.kind === "schedule") {

--- a/front/components/agent_builder/triggers/TriggerViewsSheet.tsx
+++ b/front/components/agent_builder/triggers/TriggerViewsSheet.tsx
@@ -24,7 +24,7 @@ import {
 import { WebhookEditionSheetContent } from "@app/components/agent_builder/triggers/webhook/WebhookEditionSheet";
 import { getAvatarFromIcon } from "@app/components/resources/resources_icons";
 import { FormProvider } from "@app/components/sparkle/FormProvider";
-import { useUser } from "@app/lib/swr/user";
+import { useAuth } from "@app/lib/auth/AuthContext";
 import { normalizeWebhookIcon } from "@app/lib/webhookSource";
 import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
 import type { LightWorkspaceType } from "@app/types/user";
@@ -60,7 +60,7 @@ export function TriggerViewsSheet({
   onAppendTriggerToCreate,
   onAppendTriggerToUpdate,
 }: TriggerViewsSheetProps) {
-  const { user } = useUser();
+  const { user } = useAuth();
 
   const [currentPageId, setCurrentPageId] = useState<string>(
     TRIGGERS_SHEET_PAGE_IDS.SELECTION

--- a/front/components/agent_builder/triggers/schedule/scheduleEditionFormSchema.ts
+++ b/front/components/agent_builder/triggers/schedule/scheduleEditionFormSchema.ts
@@ -5,7 +5,7 @@ import type {
   AgentBuilderTriggerType,
 } from "@app/components/agent_builder/AgentBuilderFormContext";
 import { triggerStatusSchema } from "@app/components/agent_builder/AgentBuilderFormContext";
-import type { UserTypeWithWorkspaces } from "@app/types/user";
+import type { UserType } from "@app/types/user";
 
 export const ScheduleFormSchema = z.object({
   name: z
@@ -50,7 +50,7 @@ export function formValuesToScheduleTriggerData({
 }: {
   schedule: ScheduleFormValues;
   editTrigger: AgentBuilderTriggerType | null;
-  user: UserTypeWithWorkspaces;
+  user: UserType;
 }): AgentBuilderScheduleTriggerType {
   return {
     sId: editTrigger?.kind === "schedule" ? editTrigger.sId : undefined,

--- a/front/components/agent_builder/triggers/webhook/webhookEditionFormSchema.ts
+++ b/front/components/agent_builder/triggers/webhook/webhookEditionFormSchema.ts
@@ -8,7 +8,7 @@ import { triggerStatusSchema } from "@app/components/agent_builder/AgentBuilderF
 import { DEFAULT_SINGLE_TRIGGER_EXECUTION_PER_DAY_LIMIT } from "@app/types/assistant/triggers";
 import { asDisplayName } from "@app/types/shared/utils/string_utils";
 import type { WebhookSourceViewType } from "@app/types/triggers/webhooks";
-import type { UserTypeWithWorkspaces } from "@app/types/user";
+import type { UserType } from "@app/types/user";
 
 export const WebhookFormSchema = z.object({
   name: z
@@ -66,7 +66,7 @@ export function formValuesToWebhookTriggerData({
 }: {
   webhook: WebhookFormValues;
   editTrigger: AgentBuilderTriggerType | null;
-  user: UserTypeWithWorkspaces;
+  user: UserType;
   webhookSourceView: WebhookSourceViewType | null;
 }): AgentBuilderWebhookTriggerType {
   return {

--- a/front/components/assistant/UserMessageMarkdown.integration.test.tsx
+++ b/front/components/assistant/UserMessageMarkdown.integration.test.tsx
@@ -4,6 +4,13 @@ import { describe, expect, it, vi } from "vitest";
 
 import { UserMessageMarkdown } from "./UserMessageMarkdown";
 
+// Mock useAuth to provide a fake user for mention components.
+vi.mock("@app/lib/auth/AuthContext", () => ({
+  useAuth: () => ({
+    user: { sId: "user_1", fullName: "Test User" },
+  }),
+}));
+
 // Mock router utilities and hooks for mention directives
 const pushMock = vi.fn();
 vi.mock("next/router", () => ({

--- a/front/components/assistant/conversation/ConversationMenu.tsx
+++ b/front/components/assistant/conversation/ConversationMenu.tsx
@@ -27,6 +27,7 @@ import { useDeleteConversation } from "@app/hooks/useDeleteConversation";
 import { useMoveConversationToProject } from "@app/hooks/useMoveConversationToProject";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useURLSheet } from "@app/hooks/useURLSheet";
+import { useAuth } from "@app/lib/auth/AuthContext";
 import { useAppRouter } from "@app/lib/platform";
 import { getSpaceIcon } from "@app/lib/spaces";
 import {
@@ -35,7 +36,6 @@ import {
   useJoinConversation,
 } from "@app/lib/swr/conversations";
 import { useSpaces } from "@app/lib/swr/spaces";
-import { useUser } from "@app/lib/swr/user";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import {
   getConversationRoute,
@@ -133,10 +133,11 @@ export function ConversationMenu({
   onOpenChange: (open: boolean) => void;
   triggerPosition?: { x: number; y: number };
 }) {
-  const { user } = useUser();
+  const { user } = useAuth();
   const { hasFeature } = useFeatureFlags({
     workspaceId: owner.sId,
   });
+
   const router = useAppRouter();
   const sendNotification = useSendNotification();
 

--- a/front/components/assistant/conversation/ConversationTitle.tsx
+++ b/front/components/assistant/conversation/ConversationTitle.tsx
@@ -9,10 +9,10 @@ import {
 } from "@app/components/assistant/conversation/ConversationMenu";
 import { AppLayoutTitle } from "@app/components/sparkle/AppLayoutTitle";
 import { useActiveConversationId } from "@app/hooks/useActiveConversationId";
+import { useAuth } from "@app/lib/auth/AuthContext";
 import { useAppRouter } from "@app/lib/platform";
 import { useConversation } from "@app/lib/swr/conversations";
 import { useSpaceInfo } from "@app/lib/swr/spaces";
-import { useUser } from "@app/lib/swr/user";
 import { getProjectRoute } from "@app/lib/utils/router";
 import type { WorkspaceType } from "@app/types/user";
 
@@ -20,7 +20,7 @@ import { EditConversationTitleDialog } from "./EditConversationTitleDialog";
 
 export function ConversationTitle({ owner }: { owner: WorkspaceType }) {
   const activeConversationId = useActiveConversationId();
-  const { user } = useUser();
+  const { user } = useAuth();
   const { conversation } = useConversation({
     conversationId: activeConversationId,
     workspaceId: owner.sId,

--- a/front/components/assistant/conversation/GoogleDriveFileAuthorizationRequired.tsx
+++ b/front/components/assistant/conversation/GoogleDriveFileAuthorizationRequired.tsx
@@ -9,8 +9,8 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import type { GooglePickerFile } from "@app/hooks/useGooglePicker";
 import { useGooglePicker } from "@app/hooks/useGooglePicker";
 import type { FileAuthorizationInfo } from "@app/lib/actions/mcp";
+import { useAuth } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
-import { useUser } from "@app/lib/swr/user";
 import type { PickerTokenResponseType } from "@app/pages/api/w/[wId]/google_drive/picker_token";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
 
@@ -29,7 +29,7 @@ export function GoogleDriveFileAuthorizationRequired({
   mcpServerId,
   retryHandler,
 }: GoogleDriveFileAuthorizationRequiredProps) {
-  const { user } = useUser();
+  const { user } = useAuth();
   const [isAuthorized, setIsAuthorized] = useState(false);
   const [isOpeningPicker, setIsOpeningPicker] = useState(false);
   const [pickerCredentials, setPickerCredentials] = useState<{

--- a/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.tsx
+++ b/front/components/assistant/conversation/MCPServerPersonalAuthenticationRequired.tsx
@@ -13,12 +13,12 @@ import {
 import { getIcon } from "@app/components/resources/resources_icons";
 import { getMcpServerDisplayName } from "@app/lib/actions/mcp_helper";
 import type { MCPServerType } from "@app/lib/api/mcp";
+import { useAuth } from "@app/lib/auth/AuthContext";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import {
   useCreatePersonalConnection,
   useMCPServer,
 } from "@app/lib/swr/mcp_servers";
-import { useUser } from "@app/lib/swr/user";
 import type { OAuthProvider } from "@app/types/oauth/lib";
 import { getOverridablePersonalAuthInputs } from "@app/types/oauth/lib";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
@@ -40,7 +40,7 @@ export function MCPServerPersonalAuthenticationRequired({
   retryHandler,
   scope,
 }: MCPServerPersonalAuthenticationRequiredProps) {
-  const { user } = useUser();
+  const { user } = useAuth();
   const { server: mcpServer } = useMCPServer({
     owner,
     serverId: mcpServerId,

--- a/front/components/assistant/conversation/MCPToolValidationRequired.tsx
+++ b/front/components/assistant/conversation/MCPToolValidationRequired.tsx
@@ -16,7 +16,7 @@ import { getIcon } from "@app/components/resources/resources_icons";
 import { useValidateAction } from "@app/hooks/useValidateAction";
 import type { MCPValidationOutputType } from "@app/lib/actions/constants";
 import type { BlockedToolExecution } from "@app/lib/actions/mcp";
-import { useUser } from "@app/lib/swr/user";
+import { useAuth } from "@app/lib/auth/AuthContext";
 import { asDisplayName } from "@app/types/shared/utils/string_utils";
 import type { LightWorkspaceType, UserType } from "@app/types/user";
 
@@ -69,7 +69,7 @@ export function MCPToolValidationRequired({
   conversationId,
   messageId,
 }: MCPToolValidationRequiredProps) {
-  const { user } = useUser();
+  const { user } = useAuth();
   const [neverAskAgain, setNeverAskAgain] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 

--- a/front/components/assistant/conversation/MentionInvalid.tsx
+++ b/front/components/assistant/conversation/MentionInvalid.tsx
@@ -8,8 +8,8 @@ import {
 import { useMemo, useState } from "react";
 
 import type { VirtuosoMessage } from "@app/components/assistant/conversation/types";
+import { useAuth } from "@app/lib/auth/AuthContext";
 import { useDismissMention } from "@app/lib/swr/mentions";
-import { useUser } from "@app/lib/swr/user";
 import type {
   ConversationWithoutContentType,
   RichMentionWithStatus,
@@ -39,7 +39,7 @@ export function MentionInvalid({
   conversation,
   message,
 }: MentionInvalidProps) {
-  const { user } = useUser();
+  const { user } = useAuth();
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const { dismissMention } = useDismissMention({

--- a/front/components/assistant/conversation/MentionValidationRequired.tsx
+++ b/front/components/assistant/conversation/MentionValidationRequired.tsx
@@ -8,8 +8,8 @@ import { useMemo, useState } from "react";
 
 import type { VirtuosoMessage } from "@app/components/assistant/conversation/types";
 import { isMessageTemporayState } from "@app/components/assistant/conversation/types";
+import { useAuth } from "@app/lib/auth/AuthContext";
 import { useMentionValidation } from "@app/lib/swr/mentions";
-import { useUser } from "@app/lib/swr/user";
 import type {
   ConversationWithoutContentType,
   RichMentionWithStatus,
@@ -36,7 +36,7 @@ export function MentionValidationRequired({
   conversation,
   message,
 }: MentionValidationRequiredProps) {
-  const { user } = useUser();
+  const { user } = useAuth();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const isProjectMembership = mention.status === "pending_project_membership";
 

--- a/front/components/assistant/conversation/MessageReactions.tsx
+++ b/front/components/assistant/conversation/MessageReactions.tsx
@@ -1,6 +1,6 @@
 import { Button, Tooltip } from "@dust-tt/sparkle";
 
-import { useUser } from "@app/lib/swr/user";
+import { useAuth } from "@app/lib/auth/AuthContext";
 import type { MessageReactionType } from "@app/types/assistant/conversation";
 
 import { ReactionPill } from "./ReactionPill";
@@ -16,7 +16,7 @@ export function MessageReactions({
   reactions,
   onReactionClick,
 }: MessageReactionsProps) {
-  const { user } = useUser();
+  const { user } = useAuth();
 
   if (reactions.length === 0) {
     return null;

--- a/front/components/assistant/conversation/ProjectMenu.tsx
+++ b/front/components/assistant/conversation/ProjectMenu.tsx
@@ -22,9 +22,9 @@ import { LeaveProjectDialog } from "@app/components/assistant/conversation/Leave
 import { useLeaveProjectDialog } from "@app/hooks/useLeaveProjectDialog";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useURLSheet } from "@app/hooks/useURLSheet";
+import { useAuth } from "@app/lib/auth/AuthContext";
 import { useAppRouter } from "@app/lib/platform";
 import { useSpaceInfo } from "@app/lib/swr/spaces";
-import { useUser } from "@app/lib/swr/user";
 import {
   getConversationRoute,
   getProjectRoute,
@@ -120,7 +120,7 @@ export function ProjectMenu({
   onOpenChange: (open: boolean) => void;
   triggerPosition?: { x: number; y: number };
 }) {
-  const { user } = useUser();
+  const { user } = useAuth();
   const router = useAppRouter();
   const sendNotification = useSendNotification();
 

--- a/front/components/assistant/details/AgentDetailsButtonBar.tsx
+++ b/front/components/assistant/details/AgentDetailsButtonBar.tsx
@@ -19,10 +19,10 @@ import { useState } from "react";
 
 import { DeleteAgentDialog } from "@app/components/assistant/DeleteAgentDialog";
 import { useSendNotification } from "@app/hooks/useNotification";
+import { useAuth } from "@app/lib/auth/AuthContext";
 import { clientFetch } from "@app/lib/egress/client";
 import { useAppRouter } from "@app/lib/platform";
 import { useUpdateUserFavorite } from "@app/lib/swr/assistants";
-import { useUser } from "@app/lib/swr/user";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import {
   getAgentBuilderRoute,
@@ -45,7 +45,7 @@ export function AgentDetailsButtonBar({
   isAgentConfigurationValidating,
   owner,
 }: AgentDetailsButtonBarProps) {
-  const { user } = useUser();
+  const { user } = useAuth();
 
   const { featureFlags } = useFeatureFlags({
     workspaceId: owner.sId,

--- a/front/components/data_source/ConnectorPermissionsModal.tsx
+++ b/front/components/data_source/ConnectorPermissionsModal.tsx
@@ -48,6 +48,7 @@ import { AdvancedNotionManagement } from "@app/components/spaces/AdvancedNotionM
 import { ConnectorDataUpdatedModal } from "@app/components/spaces/ConnectorDataUpdatedModal";
 import { useTheme } from "@app/components/sparkle/ThemeContext";
 import { useSendNotification } from "@app/hooks/useNotification";
+import { useAuth } from "@app/lib/auth/AuthContext";
 import { CONNECTOR_CONFIGURATIONS } from "@app/lib/connector_providers";
 import {
   CONNECTOR_UI_CONFIGURATIONS,
@@ -65,7 +66,6 @@ import {
 } from "@app/lib/swr/connectors";
 import { useSlackIsLegacy } from "@app/lib/swr/oauth";
 import { useSpaceDataSourceViews, useSystemSpace } from "@app/lib/swr/spaces";
-import { useUser } from "@app/lib/swr/user";
 import {
   useFeatureFlags,
   useWorkspaceActiveSubscription,
@@ -269,7 +269,7 @@ function UpdateConnectionOAuthModal({
   const [isExtraConfigValid, setIsExtraConfigValid] = useState(true);
   const { hasFeature } = useFeatureFlags({ workspaceId: owner.sId });
 
-  const { user } = useUser();
+  const { user } = useAuth();
 
   const { connectorProvider, editedByUser } = dataSource;
 
@@ -513,7 +513,7 @@ function DataSourceDeletionModal({
   const { isDark } = useTheme();
   const [isLoading, setIsLoading] = useState(false);
   const sendNotification = useSendNotification();
-  const { user } = useUser();
+  const { user } = useAuth();
   const { systemSpace } = useSystemSpace({
     workspaceId: owner.sId,
   });
@@ -766,7 +766,7 @@ export function ConnectorPermissionsModal({
 
   const [saving, setSaving] = useState(false);
   const sendNotification = useSendNotification();
-  const { user } = useUser();
+  const { user } = useAuth();
 
   function closeModal(save: boolean) {
     setModalToShow(null);

--- a/front/components/mentions/MentionDisplay.test.tsx
+++ b/front/components/mentions/MentionDisplay.test.tsx
@@ -7,6 +7,13 @@ import type { LightWorkspaceType } from "@app/types/user";
 
 import { MentionDisplay } from "./MentionDisplay";
 
+// Mock useAuth to provide a fake user for mention highlighting.
+vi.mock("@app/lib/auth/AuthContext", () => ({
+  useAuth: () => ({
+    user: { sId: "user_1", fullName: "Test User" },
+  }),
+}));
+
 // Mock Sparkle primitives used by MentionDisplay to simplify tooltip behavior.
 vi.mock("@dust-tt/sparkle", () => {
   const Provider: React.FC<{ children: React.ReactNode }> = ({ children }) => (

--- a/front/components/mentions/MentionDisplay.tsx
+++ b/front/components/mentions/MentionDisplay.tsx
@@ -16,7 +16,7 @@ import {
 import React from "react";
 
 import { MentionDropdown } from "@app/components/mentions/MentionDropdown";
-import { useUser } from "@app/lib/swr/user";
+import { useAuth } from "@app/lib/auth/AuthContext";
 import type { RichMention } from "@app/types/assistant/mentions";
 import type { WorkspaceType } from "@app/types/user";
 
@@ -63,7 +63,7 @@ export function MentionDisplay({
   owner,
   showTooltip = true,
 }: MentionDisplayProps) {
-  const { user } = useUser();
+  const { user } = useAuth();
   const isCurrentUserMentioned = mention.id === user?.sId;
   // If interactive and owner is provided, wrap with dropdown.
   if (interactive && owner) {

--- a/front/components/spaces/CreateOrEditSpaceModal.tsx
+++ b/front/components/spaces/CreateOrEditSpaceModal.tsx
@@ -16,6 +16,7 @@ import { ConfirmContext } from "@app/components/Confirm";
 import { ConfirmDeleteSpaceDialog } from "@app/components/spaces/ConfirmDeleteSpaceDialog";
 import { RestrictedAccessBody } from "@app/components/spaces/RestrictedAccessBody";
 import { RestrictedAccessHeader } from "@app/components/spaces/RestrictedAccessHeader";
+import { useAuth } from "@app/lib/auth/AuthContext";
 import { useAppRouter } from "@app/lib/platform";
 import { useGroups } from "@app/lib/swr/groups";
 import {
@@ -24,7 +25,6 @@ import {
   useSpaceInfo,
   useUpdateSpace,
 } from "@app/lib/swr/spaces";
-import { useUser } from "@app/lib/swr/user";
 import type { SpaceCategoryInfo } from "@app/pages/api/w/[wId]/spaces/[spaceId]";
 import type { GroupType } from "@app/types/groups";
 import type { PlanType } from "@app/types/plan";
@@ -67,7 +67,7 @@ export function CreateOrEditSpaceModal({
   const [isDirty, setIsDirty] = useState(false);
 
   const planAllowsSCIM = plan.limits.users.isSCIMAllowed;
-  const { user } = useUser();
+  const { user } = useAuth();
 
   useEffect(() => {
     if (!planAllowsSCIM) {

--- a/front/components/sparkle/AppRootLayout.tsx
+++ b/front/components/sparkle/AppRootLayout.tsx
@@ -9,9 +9,9 @@ import { useBrowserNotification } from "@app/hooks/useBrowserNotification";
 import { useDatadogLogs } from "@app/hooks/useDatadogLogs";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { useNovuClient } from "@app/hooks/useNovuClient";
+import { useAuth } from "@app/lib/auth/AuthContext";
 import { ConversationsUpdatedEvent } from "@app/lib/notifications/events";
 import { Head, Script, useAppRouter } from "@app/lib/platform";
-import { useUser } from "@app/lib/swr/user";
 import { getFaviconPath } from "@app/lib/utils";
 
 // TODO(2025-04-11 yuka) We need to refactor AppLayout to avoid re-mounting on every page navigation.
@@ -23,7 +23,7 @@ export default function AppRootLayout({
   children: React.ReactNode;
 }) {
   const { push } = useAppRouter();
-  const { user } = useUser();
+  const { user } = useAuth();
   const { novuClient } = useNovuClient();
   useDatadogLogs();
   const faviconPath = getFaviconPath();

--- a/front/hooks/useDatadogLogs.ts
+++ b/front/hooks/useDatadogLogs.ts
@@ -1,11 +1,11 @@
 import { datadogLogs } from "@datadog/browser-logs";
 import { useEffect } from "react";
 
+import { useAuth } from "@app/lib/auth/AuthContext";
 import { useAppRouter } from "@app/lib/platform";
-import { useUser } from "@app/lib/swr/user";
 
 export function useDatadogLogs() {
-  const { user } = useUser();
+  const { user } = useAuth();
   const userId = user?.sId;
 
   const router = useAppRouter();

--- a/front/hooks/useReaction.ts
+++ b/front/hooks/useReaction.ts
@@ -3,9 +3,9 @@ import {
   isMessageTemporayState,
   isUserMessage,
 } from "@app/components/assistant/conversation/types";
+import { useAuth } from "@app/lib/auth/AuthContext";
 import { useSubmitFunction } from "@app/lib/client/utils";
 import { clientFetch } from "@app/lib/egress/client";
-import { useUser } from "@app/lib/swr/user";
 
 export function useReaction({
   owner,
@@ -16,7 +16,7 @@ export function useReaction({
   conversationId?: string | null;
   message: VirtuosoMessage;
 }) {
-  const { user } = useUser();
+  const { user } = useAuth();
 
   const { submit: onReactionToggle } = useSubmitFunction(
     async ({ emoji }: { emoji: string }) => {


### PR DESCRIPTION
## Description

Replace `useUser()` (SWR-based hook fetching `/api/user`) with `useAuth()` (stable React context hook) wherever possible across the front codebase.

`useAuth()` provides a non-null `UserType` from context, avoiding unnecessary SWR network requests when only basic user properties (`sId`, `fullName`, `email`, `username`, `image`, `id`) are needed.

**22 files updated** across hooks, agent builder, conversation components, and other UI components.

**2 helper type signatures narrowed** (`scheduleEditionFormSchema.ts`, `webhookEditionFormSchema.ts`) from `UserTypeWithWorkspaces` to `UserType` since they only use `user.id` and `user.fullName`.

**9 files intentionally left unchanged** because they depend on `UserTypeWithWorkspaces`-specific fields (`subscriberHash`, `workspaces`, `organizations`, `origin`), SWR loading/mutation states, or run outside the AuthProvider context (onboarding/public pages).

## Tests

- `npx tsgo --noEmit` passes cleanly
- `npm run lint` passes (0 errors)
- `biome format` passes

## Risk

Low. Each replacement is a direct swap from SWR-fetched user to context-provided user. The `UserType` fields used at each call site were verified to be available on `useAuth().user`. No behavioral change — same data, different source.

## Deploy Plan

Standard deploy, no migration needed.