### PR TITLE
feat: project label bold when unread converations

### DIFF
--- a/front/components/assistant/conversation/sidebar/ProjectsList.tsx
+++ b/front/components/assistant/conversation/sidebar/ProjectsList.tsx
@@ -29,11 +29,13 @@ const ProjectListItem = memo(
   ({
     space,
     unreadCount,
+    hasUnread,
     owner,
     moveConversationToProject,
   }: {
     space: SpaceType;
     unreadCount: number;
+    hasUnread: boolean;
     owner: WorkspaceType;
     moveConversationToProject: (
       conversation: ConversationWithoutContentType,
@@ -114,6 +116,7 @@ const ProjectListItem = memo(
         icon={getSpaceIcon(space)}
         selected={isSpaceSelected && !isDragOver}
         label={space.name}
+        bold={hasUnread}
         count={unreadCount > 0 ? unreadCount : undefined}
         onClick={async () => {
           // Side bar is the floating sidebar that appears when the screen is small.
@@ -178,15 +181,21 @@ export function ProjectsList({
 
   return (
     <>
-      {filteredSummary.map(({ space, unreadConversations }) => (
-        <ProjectListItem
-          key={space.sId}
-          space={space}
-          unreadCount={unreadConversations.length}
-          owner={owner}
-          moveConversationToProject={moveConversationToProject}
-        />
-      ))}
+      {filteredSummary.map(
+        ({ space, unreadConversations, nonParticipantUnreadConversations }) => (
+          <ProjectListItem
+            key={space.sId}
+            space={space}
+            unreadCount={unreadConversations.length}
+            hasUnread={
+              unreadConversations.length > 0 ||
+              nonParticipantUnreadConversations.length > 0
+            }
+            owner={owner}
+            moveConversationToProject={moveConversationToProject}
+          />
+        )
+      )}
     </>
   );
 }

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -1121,7 +1121,7 @@ describe("listSpaceUnreadConversationsForUser", () => {
         spaceModelIds
       );
 
-    expect(userConversations).toHaveLength(1);
+    expect(userConversations.unreadConversations).toHaveLength(1);
     expect(userConversations.unreadConversations[0].sId).toBe(
       conversationIds[0]
     );
@@ -1149,7 +1149,7 @@ describe("listSpaceUnreadConversationsForUser", () => {
         spaceModelIds
       );
 
-    expect(userConversations).toHaveLength(1);
+    expect(userConversations.nonParticipantUnreadConversations).toHaveLength(1);
     expect(userConversations.nonParticipantUnreadConversations[0].sId).toBe(
       nonParticipantConversation.sId
     );
@@ -1181,7 +1181,7 @@ describe("listSpaceUnreadConversationsForUser", () => {
         spaceModelIds
       );
 
-    expect(userConversations).toHaveLength(1);
+    expect(userConversations.unreadConversations).toHaveLength(1);
     const conversationData = userConversations.unreadConversations[0].toJSON();
 
     // Verify participation data is used in toJSON.

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -1105,7 +1105,7 @@ describe("listSpaceUnreadConversationsForUser", () => {
     }
   });
 
-  it("should return only conversations user participates in", async () => {
+  it("should return only conversations user participates in as unreadConversations", async () => {
     const nonParticipantConversation = await ConversationFactory.create(
       adminAuth,
       {
@@ -1122,14 +1122,46 @@ describe("listSpaceUnreadConversationsForUser", () => {
       );
 
     expect(userConversations).toHaveLength(1);
-    expect(userConversations[0].sId).toBe(conversationIds[0]);
-    expect(userConversations[0]).toBeInstanceOf(ConversationResource);
-    expect(userConversations.map((c) => c.sId)).not.toContain(
-      nonParticipantConversation.sId
+    expect(userConversations.unreadConversations[0].sId).toBe(
+      conversationIds[0]
     );
+    expect(userConversations.unreadConversations[0]).toBeInstanceOf(
+      ConversationResource
+    );
+    expect(
+      userConversations.unreadConversations.map((c) => c.sId)
+    ).not.toContain(nonParticipantConversation.sId);
   });
 
-  it("should return conversations with populated participation data", async () => {
+  it("should return only conversations user does not participates in as nonParticipantUnreadConversations", async () => {
+    const nonParticipantConversation = await ConversationFactory.create(
+      adminAuth,
+      {
+        agentConfigurationId: agents[0].sId,
+        messagesCreatedAt: [dateFromDaysAgo(5)],
+        spaceId: spaceModelIds[0],
+      }
+    );
+
+    const userConversations =
+      await ConversationResource.listSpaceUnreadConversationsForUser(
+        userAuth,
+        spaceModelIds
+      );
+
+    expect(userConversations).toHaveLength(1);
+    expect(userConversations.nonParticipantUnreadConversations[0].sId).toBe(
+      nonParticipantConversation.sId
+    );
+    expect(
+      userConversations.nonParticipantUnreadConversations[0]
+    ).toBeInstanceOf(ConversationResource);
+    expect(
+      userConversations.nonParticipantUnreadConversations.map((c) => c.sId)
+    ).not.toContain(conversationIds[0]);
+  });
+
+  it("should return conversations with populated participation data for unreadConversations", async () => {
     // First, get the raw participation data from the database to compare
     const { ConversationParticipantModel } = await import(
       "@app/lib/models/agent/conversation"
@@ -1150,7 +1182,7 @@ describe("listSpaceUnreadConversationsForUser", () => {
       );
 
     expect(userConversations).toHaveLength(1);
-    const conversationData = userConversations[0].toJSON();
+    const conversationData = userConversations.unreadConversations[0].toJSON();
 
     // Verify participation data is used in toJSON.
     expect(conversationData.unread).toBe(true);
@@ -1163,41 +1195,6 @@ describe("listSpaceUnreadConversationsForUser", () => {
     expect(conversationData.created).toBeDefined();
     expect(conversationData.updated).toBeDefined();
     expect(Array.isArray(conversationData.requestedSpaceIds)).toBe(true);
-  });
-
-  it("should return conversations sorted by participation updated time", async () => {
-    // Create a new conversation with more recent participation
-    const recentConvo = await ConversationFactory.create(adminAuth, {
-      agentConfigurationId: agents[0].sId,
-      messagesCreatedAt: [new Date()],
-      spaceId: spaceModelIds[0],
-    });
-
-    await ConversationResource.upsertParticipation(userAuth, {
-      conversation: recentConvo,
-      action: "posted",
-      user: userAuth.getNonNullableUser().toJSON(),
-      lastReadAt: dateFromDaysAgo(20), // Ensure it's marked as unread
-    });
-
-    const userConversations =
-      await ConversationResource.listSpaceUnreadConversationsForUser(
-        userAuth,
-        spaceModelIds
-      );
-    expect(userConversations).toHaveLength(2);
-    // Most recent participation should be first.
-    expect(userConversations[0].sId).toBe(recentConvo.sId);
-    expect(userConversations[1].sId).toBe(conversationIds[0]);
-
-    const serializedConvs = userConversations.map((c) => c.toJSON());
-
-    // Verify sorting by updated time.
-    expect(serializedConvs[0].updated).toBeGreaterThan(
-      serializedConvs[1].updated!
-    );
-
-    await destroyConversation(adminAuth, { conversationId: recentConvo.sId });
   });
 
   it("should not return test conversations by default", async () => {
@@ -1223,7 +1220,10 @@ describe("listSpaceUnreadConversationsForUser", () => {
         userAuth,
         spaceModelIds
       );
-    const userConversationIds = userConversations.map((c) => c.sId);
+    const userConversationIds = [
+      ...userConversations.unreadConversations,
+      ...userConversations.nonParticipantUnreadConversations,
+    ].map((c) => c.sId);
     expect(userConversationIds).toContain(conversationIds[0]); // original conversation
     expect(userConversationIds).not.toContain(testConvo.sId); // test conversation should be filtered out
 
@@ -1251,7 +1251,10 @@ describe("listSpaceUnreadConversationsForUser", () => {
         spaceModelIds
       );
 
-    const spaceConversationIds = spaceConversations.map((c) => c.sId);
+    const spaceConversationIds = [
+      ...spaceConversations.unreadConversations,
+      ...spaceConversations.nonParticipantUnreadConversations,
+    ].map((c) => c.sId);
     expect(spaceConversationIds).toContain(conversationIds[0]); // space conversation should be included
     expect(spaceConversationIds).not.toContain(privateConvo.sId); // private conversation should be filtered out
 

--- a/front/lib/swr/conversations.ts
+++ b/front/lib/swr/conversations.ts
@@ -901,18 +901,14 @@ export function useConversationMarkAsRead({
                 if (spaceSummary.space.sId === conversation?.spaceId) {
                   return {
                     ...spaceSummary,
-                    unreadConversations: spaceSummary.unreadConversations.map(
-                      (convSummary) => {
-                        if (convSummary.sId === conversationId) {
-                          return {
-                            ...convSummary,
-                            unread: false,
-                            lastRead: Date.now(),
-                          };
-                        }
-                        return convSummary;
-                      }
-                    ),
+                    unreadConversations:
+                      spaceSummary.unreadConversations.filter(
+                        ({ sId }) => sId !== conversationId
+                      ) ?? [],
+                    nonParticipantUnreadConversations:
+                      spaceSummary.nonParticipantUnreadConversations.filter(
+                        ({ sId }) => sId !== conversationId
+                      ) ?? [],
                   };
                 }
                 return spaceSummary;

--- a/sparkle/src/components/NavigationList.tsx
+++ b/sparkle/src/components/NavigationList.tsx
@@ -82,6 +82,7 @@ interface NavigationListItemProps
   moreMenu?: React.ReactNode;
   status?: NavigationListItemStatus;
   count?: number;
+  bold?: boolean;
 }
 
 const NavigationListItem = React.forwardRef<
@@ -103,6 +104,7 @@ const NavigationListItem = React.forwardRef<
       moreMenu,
       status = "idle",
       count,
+      bold,
       ...props
     },
     ref
@@ -167,7 +169,12 @@ const NavigationListItem = React.forwardRef<
             {icon && <Icon visual={icon} size="xs" className="s-m-0.5" />}
             {avatar}
             {label && (
-              <span className="s-grow s-overflow-hidden s-text-ellipsis s-whitespace-nowrap group-focus-within/menu-item:s-pr-8 group-hover/menu-item:s-pr-8 group-data-[selected=true]/menu-item:s-pr-8">
+              <span
+                className={cn(
+                  "s-grow s-overflow-hidden s-text-ellipsis s-whitespace-nowrap group-focus-within/menu-item:s-pr-8 group-hover/menu-item:s-pr-8 group-data-[selected=true]/menu-item:s-pr-8",
+                  bold && "s-font-bold"
+                )}
+              >
                 {label}
               </span>
             )}


### PR DESCRIPTION





## Description

This PR makes project labels in the sidebar appear bold when they contain unread conversations.

- Split unread conversations into two categories: `unreadConversations` (conversations the user participates in) and `nonParticipantUnreadConversations` (conversations the user doesn't participate in but hasn't read)

<img width="315" height="392" alt="Capture d’écran 2026-02-12 à 11 50 48" src="https://github.com/user-attachments/assets/55577fe9-103b-4428-9d20-9d979abce72b" />

## Tests

Manually tested. 
## Risks

Low risk. 

## Deploy Plan

Standard deployment. No special steps required.
