### PR TITLE
[front] fix: Do not list all mcp in McpDetails

### DIFF
--- a/front/pages/api/w/[wId]/mcp/[serverId]/index.ts
+++ b/front/pages/api/w/[wId]/mcp/[serverId]/index.ts
@@ -8,11 +8,12 @@ import {
   requiresBearerTokenConfiguration,
 } from "@app/lib/actions/mcp_helper";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import type { MCPServerType } from "@app/lib/api/mcp";
+import type { MCPServerType, MCPServerTypeWithViews } from "@app/lib/api/mcp";
 import { withWorkspaceConnectionRequirement } from "@app/lib/api/mcp_oauth_prerequisites";
 import type { Authenticator } from "@app/lib/auth";
 import { InternalMCPServerInMemoryResource } from "@app/lib/resources/internal_mcp_server_in_memory_resource";
 import { MCPServerConnectionResource } from "@app/lib/resources/mcp_server_connection_resource";
+import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { RemoteMCPServerResource } from "@app/lib/resources/remote_mcp_servers_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { apiError } from "@app/logger/withlogging";
@@ -45,7 +46,7 @@ const PatchMCPServerBodySchema = z
 export type PatchMCPServerBody = z.infer<typeof PatchMCPServerBodySchema>;
 
 export type GetMCPServerResponseBody = {
-  server: MCPServerType;
+  server: MCPServerTypeWithViews;
 };
 
 export type PatchMCPServerResponseBody = {
@@ -116,11 +117,16 @@ async function handler(
 
           const json = server.toJSON();
 
+          const views = (
+            await MCPServerViewResource.listByMCPServer(auth, json.sId)
+          ).map((v) => v.toJSON());
+
           // Enrich authorization so the client can block the OAuth popup when the
           // workspace-level connection is missing.
           return res.status(200).json({
             server: {
               ...json,
+              views,
               authorization: withWorkspaceConnectionRequirement(
                 json.authorization,
                 {
@@ -153,11 +159,16 @@ async function handler(
 
           const json = server.toJSON();
 
+          const views = (
+            await MCPServerViewResource.listByMCPServer(auth, json.sId)
+          ).map((v) => v.toJSON());
+
           // Enrich authorization so the client can block the OAuth popup when the
           // workspace-level connection is missing.
           return res.status(200).json({
             server: {
               ...json,
+              views,
               authorization: withWorkspaceConnectionRequirement(
                 json.authorization,
                 {


### PR DESCRIPTION
## Description

- use useMCPServer to load the mcp in details panel instead of all mcp servers
- adjusted the endpoint to pass the views needed for sharing settings

## Tests

Tested manually

## Risk

Low: We now have to list all the mcp server views for the mcp ims_xx or ems_xx we're querying. Could add some load. 
I checked the different places where it's used and it's seldom used, but so was MCPServerDetails supposed to be in the first place.

In any case we still load 1 instead of n+1 compared to what we did, hence the low.

## Deploy Plan

- [ ] Deploy front