### PR TITLE
[Front] feat(copilot): add clickable use case suggestions via quickReply directives

### DIFF
--- a/front/components/agent_builder/CopilotPanelContext.tsx
+++ b/front/components/agent_builder/CopilotPanelContext.tsx
@@ -60,18 +60,19 @@ Based on:
 - User's job function and preferred platforms (from your instructions)
 - Matching templates (search_agent_templates result)
 
-Provide 2-3 specific agent use case suggestions as bullet points. Use template userFacingDescription to inspire your suggestions. Example:
+Provide 2-3 specific agent use case suggestions. PRIORITIZE templates returned by \`search_agent_templates\` — if templates are available, prioritize them even if job type is not specified (use its userFacingDescription to inspire the suggestion). Templates have copilotInstructions that make the builder experience much better.
+IMPORTANT: Use case suggestions MUST use the \`:quickReply\` directive format so users can click to select. Do NOT use bullet points. Do NOT put any text after the last \`:quickReply\` directive — the buttons are self-explanatory.
+Example:
 "I can help you build agents for your work in [role/team]. A few ideas:
 
-• **Meeting prep agent** - pulls prospect info from CRM before calls
-• **Follow-up drafter** - generates personalized emails based on call notes
-• **Competitive intel** - monitors competitor news and surfaces updates
-
-Pick one to start, or tell me what you're thinking."
+:quickReply[Meeting prep agent - pulls prospect info from CRM]{message="I want to build a meeting prep agent that pulls prospect info from CRM before calls"}
+:quickReply[Follow-up drafter - generates personalized emails]{message="I want to build a follow-up drafter that generates personalized emails based on call notes"}
+:quickReply[Competitive intel - monitors competitor news]{message="I want to build a competitive intel agent that monitors competitor news and surfaces updates"}"
 
 ## STEP 2.5: When user responds
 
 **If the user's response matches a template with non-null copilotInstructions:**
+You already have all template data from \`search_agent_templates\` in STEP 2. Do NOT call \`get_agent_template\`.
 The copilotInstructions contain domain-specific rules for this agent type. IMMEDIATELY create suggestions based on copilotInstructions - do NOT wait for user response.
 Use \`suggest_*\` tools right away following the guidance in copilotInstructions.
 

--- a/front/components/agent_builder/CopilotPanelContext.tsx
+++ b/front/components/agent_builder/CopilotPanelContext.tsx
@@ -63,7 +63,7 @@ Based on:
 Provide 2-3 specific agent use case suggestions. PRIORITIZE templates returned by \`search_agent_templates\` — if templates are available, prioritize them even if job type is not specified (use its userFacingDescription to inspire the suggestion). Templates have copilotInstructions that make the builder experience much better.
 IMPORTANT: Use case suggestions MUST use the \`:quickReply\` directive format so users can click to select. Do NOT use bullet points. Do NOT put any text after the last \`:quickReply\` directive — the buttons are self-explanatory.
 Example:
-"I can help you build agents for your work in [role/team]. A few ideas:
+"I can help you build agents for your work in [role/team]. Here are a few ideas, or tell me if you have another idea in mind:
 
 :quickReply[Meeting prep agent - pulls prospect info from CRM]{message="I want to build a meeting prep agent that pulls prospect info from CRM before calls"}
 :quickReply[Follow-up drafter - generates personalized emails]{message="I want to build a follow-up drafter that generates personalized emails based on call notes"}


### PR DESCRIPTION
## Description

Make copilot use case suggestions clickable buttons instead of bullet points.

### Problem/Context

Users had to copy-paste use case suggestions to indicate their choice, creating unnecessary friction ([dust-tt/tasks#6252](https://github.com/dust-tt/tasks/issues/6252)).

### Solution

Updated the copilot system prompt to:
- Replace bullet-point suggestions with `:quickReply` directives so users can click to select
- Prioritize `search_agent_templates` results even when job type is unspecified
- Prevent redundant `get_agent_template` calls (data already available from step 2)
- Remove trailing filler text after buttons

### Related Work

- Fixes: [dust-tt/tasks#6252](https://github.com/dust-tt/tasks/issues/6252)
- Builds on: #21401 (`search_agent_templates` tool)

## Tests

![Screen Recording 2026-02-11 at 17 06 48](https://github.com/user-attachments/assets/77ba3d56-89a0-460f-92da-9a47e66ce5a9)

- Follow-up PR: hide incomplete directive text during streaming (`:quickReply[...` flashes as raw text before fully parsed)
