### PR TITLE
[front] fix: replace bare @app/types imports

### DIFF
--- a/front/lib/api/actions/servers/agent_copilot_context/agent_copilot_context.test.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/agent_copilot_context.test.ts
@@ -19,7 +19,7 @@ import { SkillFactory } from "@app/tests/utils/SkillFactory";
 import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { TemplateFactory } from "@app/tests/utils/TemplateFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
-import { Err, Ok } from "@app/types";
+import { Err, Ok } from "@app/types/shared/result";
 
 import { TOOLS } from "./tools";
 

--- a/front/lib/api/assistant/template_suggestion.ts
+++ b/front/lib/api/assistant/template_suggestion.ts
@@ -2,14 +2,10 @@ import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
 import type { Authenticator } from "@app/lib/auth";
 import type { TemplateResource } from "@app/lib/resources/template_resource";
-import type { Result } from "@app/types";
-import {
-  Err,
-  getSmallWhitelistedModel,
-  isString,
-  Ok,
-  removeNulls,
-} from "@app/types";
+import { getSmallWhitelistedModel } from "@app/types/assistant/assistant";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import { isString, removeNulls } from "@app/types/shared/utils/general";
 
 const INSTRUCTIONS = `# Goal:
 Find the most relevant agent templates based on the user's query.


### PR DESCRIPTION
## Description

Fix build errors caused by bare `@app/types` imports in `template_suggestion.ts` and `agent_copilot_context.test.ts` introduced by #21438
## Tests

`npx tsgo --noEmit` passes. Knip shows no new issues.

## Risk

None — import path changes only, no logic change.

## Deploy Plan

Standard deploy.