### PR TITLE
[Sparkle] fix(markdown): hide incomplete text directives during streaming

### DIFF
--- a/front/components/agent_builder/CopilotPanelContext.tsx
+++ b/front/components/agent_builder/CopilotPanelContext.tsx
@@ -60,18 +60,19 @@ Based on:
 - User's job function and preferred platforms (from your instructions)
 - Matching templates (search_agent_templates result)
 
-Provide 2-3 specific agent use case suggestions as bullet points. Use template userFacingDescription to inspire your suggestions. Example:
+Provide 2-3 specific agent use case suggestions. PRIORITIZE templates returned by \`search_agent_templates\` — if templates are available, prioritize them even if job type is not specified (use its userFacingDescription to inspire the suggestion). Templates have copilotInstructions that make the builder experience much better.
+IMPORTANT: Use case suggestions MUST use the \`:quickReply\` directive format so users can click to select. Do NOT use bullet points. Do NOT put any text after the last \`:quickReply\` directive — the buttons are self-explanatory.
+Example:
 "I can help you build agents for your work in [role/team]. A few ideas:
 
-• **Meeting prep agent** - pulls prospect info from CRM before calls
-• **Follow-up drafter** - generates personalized emails based on call notes
-• **Competitive intel** - monitors competitor news and surfaces updates
-
-Pick one to start, or tell me what you're thinking."
+:quickReply[Meeting prep agent - pulls prospect info from CRM]{message="I want to build a meeting prep agent that pulls prospect info from CRM before calls"}
+:quickReply[Follow-up drafter - generates personalized emails]{message="I want to build a follow-up drafter that generates personalized emails based on call notes"}
+:quickReply[Competitive intel - monitors competitor news]{message="I want to build a competitive intel agent that monitors competitor news and surfaces updates"}"
 
 ## STEP 2.5: When user responds
 
 **If the user's response matches a template with non-null copilotInstructions:**
+You already have all template data from \`search_agent_templates\` in STEP 2. Do NOT call \`get_agent_template\`.
 The copilotInstructions contain domain-specific rules for this agent type. IMMEDIATELY create suggestions based on copilotInstructions - do NOT wait for user response.
 Use \`suggest_*\` tools right away following the guidance in copilotInstructions.
 

--- a/front/components/agent_builder/CopilotPanelContext.tsx
+++ b/front/components/agent_builder/CopilotPanelContext.tsx
@@ -63,7 +63,7 @@ Based on:
 Provide 2-3 specific agent use case suggestions. PRIORITIZE templates returned by \`search_agent_templates\` — if templates are available, prioritize them even if job type is not specified (use its userFacingDescription to inspire the suggestion). Templates have copilotInstructions that make the builder experience much better.
 IMPORTANT: Use case suggestions MUST use the \`:quickReply\` directive format so users can click to select. Do NOT use bullet points. Do NOT put any text after the last \`:quickReply\` directive — the buttons are self-explanatory.
 Example:
-"I can help you build agents for your work in [role/team]. A few ideas:
+"I can help you build agents for your work in [role/team]. Here are a few ideas, or tell me if you have another idea in mind:
 
 :quickReply[Meeting prep agent - pulls prospect info from CRM]{message="I want to build a meeting prep agent that pulls prospect info from CRM before calls"}
 :quickReply[Follow-up drafter - generates personalized emails]{message="I want to build a follow-up drafter that generates personalized emails based on call notes"}

--- a/sparkle/src/components/markdown/utils.ts
+++ b/sparkle/src/components/markdown/utils.ts
@@ -29,6 +29,13 @@ export function sanitizeContent(str: string): string {
     str += "`";
   }
 
+  // (2) Hide incomplete text directives during streaming.
+  // Incomplete = trailing :directive[... without ] or :directive[...]{... without }
+  // Uses $ (end of string, no m flag) so only the last streamed tokens are affected.
+  str = str
+    .replace(/:[\w]+\[[^\]]*$/, "")
+    .replace(/:[\w]+\[[^\]]*\]\{[^}]*$/, "");
+
   return str;
 }
 


### PR DESCRIPTION
## Description

During streaming, partial `:quickReply[Meeting prep...` text flashes as raw text before the complete directive is parsed into a button. This affects all text directives (`quickReply`, `agent_suggestion`, `toolSetup`, etc.).

Root cause: `remarkDirective` only recognizes complete directive syntax — partial text is treated as plain text.

### Solution

Extended `sanitizeContent` (which already handles unclosed backticks) to also strip trailing incomplete text directives:

```ts
// Hide incomplete :directive[... without ] or :directive[...]{... without }
str = str
  .replace(/:[\w]+\[[^\]]*$/, "")
  .replace(/:[\w]+\[[^\]]*\]\{[^}]*$/, "");
```

**Why this is safe:**
- Complete directives (`:name[label]{attr}`) won't match — they have closing `]` and `}`
- `$` anchors to end of string only (no `m` flag) — only trailing incomplete content is affected
- Same pattern as existing backtick sanitization, already memoized

### Related Work

- Follow-up to #21470 (clickable use case suggestions via `quickReply`)

## Tests

Copilot tab:
![Screen Recording 2026-02-11 at 18 08 34](https://github.com/user-attachments/assets/9d4549d0-d6a1-4f51-b207-5a07e09b1605)
Onboarding convo:
![Screen Recording 2026-02-11 at 18 09 35](https://github.com/user-attachments/assets/57c51f00-21eb-4392-a099-59225bb74a38)
