### PR TITLE
[Deep Research] Add GPT-5 mini branch for fast models; reorder in flash -> g5-mini -> haiku 

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
@@ -412,15 +412,15 @@ function getFastModelConfig(owner: WorkspaceType): {
       reasoningEffort: GPT_5_MINI_MODEL_CONFIG.minimumReasoningEffort,
     };
   }
-  if (isProviderWhitelisted(owner, "anthropic")) {
-    return {
-      modelConfiguration: CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG,
-      reasoningEffort: "none",
-    };
-  }
   if (isProviderWhitelisted(owner, "google_ai_studio")) {
     return {
       modelConfiguration: GEMINI_2_5_FLASH_MODEL_CONFIG,
+      reasoningEffort: "none",
+    };
+  }
+  if (isProviderWhitelisted(owner, "anthropic")) {
+    return {
+      modelConfiguration: CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG,
       reasoningEffort: "none",
     };
   }

--- a/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
@@ -39,6 +39,7 @@ import {
 import { GEMINI_2_5_FLASH_MODEL_CONFIG } from "@app/types/assistant/models/google_ai_studio";
 import {
   GPT_5_2_MODEL_CONFIG,
+  GPT_5_MINI_MODEL_CONFIG,
   GPT_5_MODEL_CONFIG,
 } from "@app/types/assistant/models/openai";
 import { isProviderWhitelisted } from "@app/types/assistant/models/providers";
@@ -405,6 +406,12 @@ function getFastModelConfig(owner: WorkspaceType): {
   modelConfiguration: ModelConfigurationType;
   reasoningEffort: AgentReasoningEffort;
 } | null {
+  if (isProviderWhitelisted(owner, "openai")) {
+    return {
+      modelConfiguration: GPT_5_MINI_MODEL_CONFIG,
+      reasoningEffort: GPT_5_MINI_MODEL_CONFIG.minimumReasoningEffort,
+    };
+  }
   if (isProviderWhitelisted(owner, "anthropic")) {
     return {
       modelConfiguration: CLAUDE_4_5_HAIKU_DEFAULT_MODEL_CONFIG,

--- a/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
@@ -406,16 +406,16 @@ function getFastModelConfig(owner: WorkspaceType): {
   modelConfiguration: ModelConfigurationType;
   reasoningEffort: AgentReasoningEffort;
 } | null {
-  if (isProviderWhitelisted(owner, "openai")) {
-    return {
-      modelConfiguration: GPT_5_MINI_MODEL_CONFIG,
-      reasoningEffort: GPT_5_MINI_MODEL_CONFIG.minimumReasoningEffort,
-    };
-  }
   if (isProviderWhitelisted(owner, "google_ai_studio")) {
     return {
       modelConfiguration: GEMINI_2_5_FLASH_MODEL_CONFIG,
       reasoningEffort: "none",
+    };
+  }
+  if (isProviderWhitelisted(owner, "openai")) {
+    return {
+      modelConfiguration: GPT_5_MINI_MODEL_CONFIG,
+      reasoningEffort: GPT_5_MINI_MODEL_CONFIG.minimumReasoningEffort,
     };
   }
   if (isProviderWhitelisted(owner, "anthropic")) {

--- a/front/lib/api/assistant/global_agents/utils.ts
+++ b/front/lib/api/assistant/global_agents/utils.ts
@@ -1,9 +1,9 @@
-import { GPT_4_1_MODEL_CONFIG } from "@app/types/assistant/models/openai";
+import { GPT_5_NANO_MODEL_CONFIG } from "@app/types/assistant/models/openai";
 
 // Used when returning an agent with status 'disabled_by_admin'
 export const dummyModelConfiguration = {
-  providerId: GPT_4_1_MODEL_CONFIG.providerId,
-  modelId: GPT_4_1_MODEL_CONFIG.modelId,
+  providerId: GPT_5_NANO_MODEL_CONFIG.providerId,
+  modelId: GPT_5_NANO_MODEL_CONFIG.modelId,
   temperature: 0,
-  reasoningEffort: GPT_4_1_MODEL_CONFIG.defaultReasoningEffort,
+  reasoningEffort: GPT_5_NANO_MODEL_CONFIG.minimumReasoningEffort,
 };


### PR DESCRIPTION
## Description

gpt5-mini is 4 times cheaper than haiku, and faster from my experience. For basic page summaries, model skill is not really an issue so using the cheaper / faster that's not dumb seems a good thing to do (so flash would come first)

Independently of the order, updating fast model fn with an openai branch seems adapted (vs fallbacking on getModel which isn't light).

Also, updates `dummyModelConfiguration` to use `GPT_5_NANO_MODEL_CONFIG` instead of expensive & slow GPT 4.1

## Risks
Blast radius: Global agent model selection for disabled-agent placeholders and `dust-browser-summary` model selection.
Risk: low

## Deploy Plan
- deploy front
