### PR TITLE
Various members panel improvements

### DIFF
--- a/front/components/assistant/conversation/space/ManageUsersPanel.tsx
+++ b/front/components/assistant/conversation/space/ManageUsersPanel.tsx
@@ -19,10 +19,7 @@ import { useSendNotification } from "@app/hooks/useNotification";
 import { useSearchMembers } from "@app/lib/swr/memberships";
 import { useUpdateSpace } from "@app/lib/swr/spaces";
 import type { SpaceType } from "@app/types/space";
-import type {
-  LightWorkspaceType,
-  SpaceUserType,
-} from "@app/types/user";
+import type { LightWorkspaceType, SpaceUserType } from "@app/types/user";
 
 interface ManageUsersPanelProps {
   isOpen: boolean;

--- a/front/components/pages/conversation/SpaceConversationsPage.tsx
+++ b/front/components/pages/conversation/SpaceConversationsPage.tsx
@@ -48,11 +48,12 @@ export function SpaceConversationsPage() {
   const spaceId = useActiveSpaceId();
   const sendNotification = useSendNotification();
 
-  const { spaceInfo, isSpaceInfoLoading, isSpaceInfoError } = useSpaceInfo({
-    workspaceId: owner.sId,
-    spaceId: spaceId,
-    includeAllMembers: true,
-  });
+  const { spaceInfo, isSpaceInfoLoading, isSpaceInfoError, mutateSpaceInfo } =
+    useSpaceInfo({
+      workspaceId: owner.sId,
+      spaceId: spaceId,
+      includeAllMembers: true,
+    });
 
   const { systemSpace, isSystemSpaceLoading } = useSystemSpace({
     workspaceId: owner.sId,
@@ -357,6 +358,7 @@ export function SpaceConversationsPage() {
         owner={owner}
         space={spaceInfo}
         currentProjectMembers={spaceInfo.members}
+        onSuccess={() => mutateSpaceInfo()}
       />
     </div>
   );


### PR DESCRIPTION
## Description

This PR fixes various bugs in the project "Manage Members" panel:
- "Save" button state (disabled or not) was only based on the members displayed (which depends on the search filter and the number of members loaded from the backend)
- The code of the `ManageUsersPanel` component is simplified: there's now `members` (the list of the workspace members to display) and `currentMembers`/`currentEditors` (that track the current state of members and editors)
- The call to `mutateSpaceInfo` is moved outside `ManageUsersPanel` because the list of members wasn't updated properly when saved

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Deploy front
