### PR TITLE
fix: limit webbrowser tool to 16 URLs per call

### DIFF
--- a/front/lib/api/actions/servers/web_search_browse/metadata.ts
+++ b/front/lib/api/actions/servers/web_search_browse/metadata.ts
@@ -5,6 +5,7 @@ import { zodToJsonSchema } from "zod-to-json-schema";
 import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 
+export const MAX_BROWSE_URLS = 16;
 export const WEB_SEARCH_BROWSE_SERVER_NAME = "web_search_&_browse" as const;
 export const WEB_SEARCH_BROWSE_ACTION_DESCRIPTION =
   "Agent can search (Google) and retrieve information from specific websites.";
@@ -33,7 +34,11 @@ export const WEB_SEARCH_BROWSE_TOOLS_METADATA = createToolsRecord({
     description:
       "A tool to browse websites, you can provide a list of urls to browse all at once.",
     schema: {
-      urls: z.string().array().describe("List of urls to browse"),
+      urls: z
+        .string()
+        .array()
+        .max(MAX_BROWSE_URLS)
+        .describe("List of urls to browse"),
       format: z
         .enum(["markdown", "html"])
         .optional()


### PR DESCRIPTION
## Summary
- Adds a `maxItems: 16` constraint on the `urls` array input of the `webbrowser` tool schema
- The limit is surfaced in the JSON schema sent to the model (`maxItems: 16`) and validated at runtime by Zod

## Context
Part of the containment measures for dust-tt/tasks#6420: during the Feb 6 message explosion, agents were passing unbounded URL lists to the browse tool, amplifying the cascade. This caps each browse call to 16 URLs.

## Test plan
- [ ] Verify the tool schema exposes `maxItems: 16` to the model
- [ ] Verify that passing >16 URLs returns a validation error