### PR TITLE
[Web Browse] Limit URLs per browse call to 16

### DIFF
--- a/front/lib/api/actions/servers/web_search_browse/metadata.ts
+++ b/front/lib/api/actions/servers/web_search_browse/metadata.ts
@@ -32,13 +32,13 @@ export const WEB_SEARCH_BROWSE_TOOLS_METADATA = createToolsRecord({
   },
   webbrowser: {
     description:
-      "A tool to browse websites, you can provide a list of urls to browse all at once.",
+      `A tool to browse websites, you can provide a list of up to ${MAX_BROWSE_URLS} urls to browse all at once.`,
     schema: {
       urls: z
         .string()
         .array()
         .max(MAX_BROWSE_URLS)
-        .describe("List of urls to browse"),
+        .describe(`List of urls to browse (max: ${MAX_BROWSE_URLS})`),
       format: z
         .enum(["markdown", "html"])
         .optional()

--- a/front/lib/api/actions/servers/web_search_browse/metadata.ts
+++ b/front/lib/api/actions/servers/web_search_browse/metadata.ts
@@ -5,6 +5,7 @@ import { zodToJsonSchema } from "zod-to-json-schema";
 import type { ServerMetadata } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { createToolsRecord } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 
+export const MAX_BROWSE_URLS = 16;
 export const WEB_SEARCH_BROWSE_SERVER_NAME = "web_search_&_browse" as const;
 export const WEB_SEARCH_BROWSE_ACTION_DESCRIPTION =
   "Agent can search (Google) and retrieve information from specific websites.";
@@ -33,7 +34,11 @@ export const WEB_SEARCH_BROWSE_TOOLS_METADATA = createToolsRecord({
     description:
       "A tool to browse websites, you can provide a list of urls to browse all at once.",
     schema: {
-      urls: z.string().array().describe("List of urls to browse"),
+      urls: z
+        .string()
+        .array()
+        .max(MAX_BROWSE_URLS)
+        .describe("List of urls to browse"),
       format: z
         .enum(["markdown", "html"])
         .optional()

--- a/front/lib/api/actions/servers/web_search_browse/metadata.ts
+++ b/front/lib/api/actions/servers/web_search_browse/metadata.ts
@@ -31,8 +31,7 @@ export const WEB_SEARCH_BROWSE_TOOLS_METADATA = createToolsRecord({
     },
   },
   webbrowser: {
-    description:
-      `A tool to browse websites, you can provide a list of up to ${MAX_BROWSE_URLS} urls to browse all at once.`,
+    description: `A tool to browse websites, you can provide a list of up to ${MAX_BROWSE_URLS} urls to browse all at once.`,
     schema: {
       urls: z
         .string()


### PR DESCRIPTION
## Description

Refs https://github.com/dust-tt/tasks/issues/6420

Having no limit on the number of pages an agent can browse in 1 task is not desirable, since we could  have an agent spawn 16 tasks browsing e.g. 128 pages each leading to 4k agent messages created in a single step. 

Adds a `maxItems: 16` constraint on the `urls` array input of the `webbrowser` tool. The constraint surfaces in the JSON schema (`maxItems: 16`) so the model respects the limit.

During the Feb 6 message explosion, the users had indeed created a browsing agent that spawned many subagents themselves browsing lots of pages.

## Risks

Blast radius: webbrowser tool input validation
Risk: low

## Deploy Plan

- deploy front
