### PR TITLE
[Agent Loop] Halve max actions per step at each depth level

### DIFF
--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -194,6 +194,14 @@ export function isTemplateAgentConfiguration(
 
 export const MAX_STEPS_USE_PER_RUN_LIMIT = 64;
 export const MAX_ACTIONS_PER_STEP = 16;
+const MIN_ACTIONS_PER_STEP = 2;
+
+// Returns the max actions per step for a given conversation depth.
+// Halves at each depth level: 16 → 8 → 4 → 2, capping total concurrent
+// agent loop activities at 512 for a single user message.
+export function getMaxActionsPerStep(depth: number): number {
+  return Math.max(MIN_ACTIONS_PER_STEP, MAX_ACTIONS_PER_STEP >> depth);
+}
 
 /**
  * Agent events


### PR DESCRIPTION
## Description

Refs https://github.com/dust-tt/tasks/issues/6420

Also related to this [thread](https://dust4ai.slack.com/archives/C05B529FHV1/p1770834673228379)

Follows https://github.com/dust-tt/dust/pull/21481

Reduces `MAX_ACTIONS_PER_STEP` based on conversation depth: 16 → 8 → 4 → 2. This caps total concurrent agent loop activities at 512 for a single user message (16 × 8 × 4 × 2 with `MAX_CONVERSATION_DEPTH = 4`), containing the cascading fan-out that caused the Feb 6 message explosion.

This is a first containment. TBD if we want to be smarter by:
- prompting model to explain max actions (which wasn't done afaict until now, we silently slice);
- adapt actions depending on concurrency level (e.g. if depth 0 spawns only 1 sub agent, the subagent still gets 16 steps). Could be done smart by passing on the concurrency along with the depth, and doing something like min(remaining / concurrency, 16) to be tweaked

## Risks

Blast radius: agent loop action concurrency at depth > 0
Risk: low

## Deploy Plan

- deploy front