### PR TITLE
Fix markdown escape logic

### DIFF
--- a/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
+++ b/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
@@ -297,7 +297,7 @@ export function AgentBuilderInstructionsEditor({
         });
       } else if (field.value) {
         editor.commands.setContent(
-          preprocessMarkdownForEditor(field.value, editor.schema),
+          preprocessMarkdownForEditor(field.value),
           {
             emitUpdate: false,
             contentType: "markdown",
@@ -374,7 +374,7 @@ export function AgentBuilderInstructionsEditor({
             });
           } else {
             editor.commands.setContent(
-              preprocessMarkdownForEditor(field.value, editor.schema),
+              preprocessMarkdownForEditor(field.value),
               {
                 emitUpdate: false,
                 contentType: "markdown",

--- a/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
+++ b/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
@@ -296,13 +296,10 @@ export function AgentBuilderInstructionsEditor({
           emitUpdate: false,
         });
       } else if (field.value) {
-        editor.commands.setContent(
-          preprocessMarkdownForEditor(field.value),
-          {
-            emitUpdate: false,
-            contentType: "markdown",
-          }
-        );
+        editor.commands.setContent(preprocessMarkdownForEditor(field.value), {
+          emitUpdate: false,
+          contentType: "markdown",
+        });
       }
 
       // Then focus after content is set

--- a/front/components/editor/extensions/agent_builder/InstructionSuggestionExtension.test.ts
+++ b/front/components/editor/extensions/agent_builder/InstructionSuggestionExtension.test.ts
@@ -607,6 +607,36 @@ describe("InstructionSuggestionExtension", () => {
       );
     });
 
+    it("should preserve nested same-tag blocks", () => {
+      const markdown = [
+        "<rules>",
+        "Outer content",
+        "<rules>",
+        "Inner content",
+        "</rules>",
+        "</rules>",
+      ].join("\n");
+
+      const escaped = preprocessMarkdownForEditor(markdown);
+
+      // All four tags preserved (no zero-width space in rules tags)
+      expect(escaped).not.toContain("\u200Brules");
+      expect(escaped).not.toContain("\u200B/rules");
+      expect(escaped).toContain("<rules>");
+      expect(escaped).toContain("</rules>");
+    });
+
+    it("should escape orphan closing tag when count is already zero", () => {
+      const markdown = ["<rules>", "Content", "</rules>", "</rules>"].join(
+        "\n"
+      );
+
+      const escaped = preprocessMarkdownForEditor(markdown);
+
+      // First pair preserved; extra </rules> has no matching opening (count 0)
+      expect(escaped).toContain("<\u200B/rules>");
+    });
+
     it("should escape block-level tags with attributes", () => {
       const markdown = ['<rules id="test">', "Some content", "</rules>"].join(
         "\n"

--- a/front/components/editor/extensions/agent_builder/InstructionSuggestionExtension.test.ts
+++ b/front/components/editor/extensions/agent_builder/InstructionSuggestionExtension.test.ts
@@ -535,10 +535,7 @@ describe("InstructionSuggestionExtension", () => {
 
   describe("markdown parsing resilience", () => {
     it("should handle angle-bracketed non-HTML tokens like <URL>", () => {
-      const escaped = preprocessMarkdownForEditor(
-        "Test <URL>",
-        editor.state.schema
-      );
+      const escaped = preprocessMarkdownForEditor("Test <URL>");
       expect(() => {
         editor.commands.setContent(escaped, { contentType: "markdown" });
       }).not.toThrow();
@@ -547,26 +544,19 @@ describe("InstructionSuggestionExtension", () => {
     });
 
     it("should escape inline unmatched HTML tags with zero-width space", () => {
-      const escaped = preprocessMarkdownForEditor(
-        "Test <p> and <code>",
-        editor.state.schema
-      );
+      const escaped = preprocessMarkdownForEditor("Test <p> and <code>");
       // <p> and <code> are recognized but inline (not at start of line)
       expect(escaped).toBe("Test <\u200Bp> and <\u200Bcode>");
     });
 
     it("should escape inline unrecognized tags with zero-width space", () => {
-      const escaped = preprocessMarkdownForEditor(
-        "Test <URL>",
-        editor.state.schema
-      );
+      const escaped = preprocessMarkdownForEditor("Test <URL>");
       expect(escaped).toBe("Test <\u200BURL>");
     });
 
     it("should handle multiple inline unrecognized tags", () => {
       const escaped = preprocessMarkdownForEditor(
-        "Use <URL> and <PLACEHOLDER> here",
-        editor.state.schema
+        "Use <URL> and <PLACEHOLDER> here"
       );
       expect(() => {
         editor.commands.setContent(escaped, { contentType: "markdown" });
@@ -577,8 +567,7 @@ describe("InstructionSuggestionExtension", () => {
 
     it("should escape tags whose first word matches TAG_NAME_PATTERN even with spaces", () => {
       const escaped = preprocessMarkdownForEditor(
-        "Example: <Prompt Good Practices>\nSome content here",
-        editor.state.schema
+        "Example: <Prompt Good Practices>\nSome content here"
       );
       // "Prompt" matches TAG_NAME_PATTERN, " Good Practices" is rest — inline so escaped
       expect(escaped).toBe(
@@ -588,8 +577,7 @@ describe("InstructionSuggestionExtension", () => {
 
     it("should escape inline instruction block examples with zero-width space", () => {
       const escaped = preprocessMarkdownForEditor(
-        "Example: <do>Provide a concise summary</do> <don't>Include opinions</don't>",
-        editor.state.schema
+        "Example: <do>Provide a concise summary</do> <don't>Include opinions</don't>"
       );
       // These are inline (preceded by text), so they get zero-width space
       expect(escaped).toBe(
@@ -608,10 +596,7 @@ describe("InstructionSuggestionExtension", () => {
         "But Example: <do>this</do> is inline",
       ].join("\n");
 
-      const escaped = preprocessMarkdownForEditor(
-        markdown,
-        editor.state.schema
-      );
+      const escaped = preprocessMarkdownForEditor(markdown);
 
       // Block-level <rules> preserved, inline <do> gets zero-width space
       expect(escaped).toContain("<rules>");
@@ -627,10 +612,7 @@ describe("InstructionSuggestionExtension", () => {
         "\n"
       );
 
-      const escaped = preprocessMarkdownForEditor(
-        markdown,
-        editor.state.schema
-      );
+      const escaped = preprocessMarkdownForEditor(markdown);
 
       expect(escaped).toContain('<\u200Brules id="test">');
       expect(escaped).toContain("<\u200B/rules>");
@@ -638,8 +620,7 @@ describe("InstructionSuggestionExtension", () => {
 
     it("should escape inline HTML formatting examples", () => {
       const escaped = preprocessMarkdownForEditor(
-        "- Use <strong>bold</strong> for emphasis\n- Use <ul><li> for lists",
-        editor.state.schema
+        "- Use <strong>bold</strong> for emphasis\n- Use <ul><li> for lists"
       );
       expect(escaped).toBe(
         "- Use <\u200Bstrong>bold<\u200B/strong> for emphasis\n- Use <\u200Bul><\u200Bli> for lists"
@@ -648,20 +629,23 @@ describe("InstructionSuggestionExtension", () => {
 
     it("should escape inline self-closing tags", () => {
       const escaped = preprocessMarkdownForEditor(
-        'Line 1<br>Line 2\n\nImage: <img src="test.jpg" />',
-        editor.state.schema
+        'Line 1<br>Line 2\n\nImage: <img src="test.jpg" />'
       );
       expect(escaped).toBe(
         'Line 1<\u200Bbr>Line 2\n\nImage: <\u200Bimg src="test.jpg" />'
       );
     });
 
+    it("should escape unmatched tags regardless of position (matching only)", () => {
+      const markdown = "Paragraph\n\n<br>\nMore text";
+      const escaped = preprocessMarkdownForEditor(markdown);
+      // <br> has no </br> pair — escaped regardless of position
+      expect(escaped).toContain("\u200Bbr");
+    });
+
     it("should preserve block-level recognized tags", () => {
       const markdown = "\n<p>\nSome paragraph\n</p>";
-      const escaped = preprocessMarkdownForEditor(
-        markdown,
-        editor.state.schema
-      );
+      const escaped = preprocessMarkdownForEditor(markdown);
 
       // Step 1 adds blank line before <p> (single \n → \n\n)
       expect(escaped).toContain("\n\n<p>");
@@ -674,8 +658,7 @@ describe("InstructionSuggestionExtension", () => {
     it("should parse instruction block preceded by single newline", () => {
       editor.commands.setContent(
         preprocessMarkdownForEditor(
-          "You are an expert\n<CRITICAL_INFORMATION>\nTEST\n</CRITICAL_INFORMATION>",
-          editor.state.schema
+          "You are an expert\n<CRITICAL_INFORMATION>TEST</CRITICAL_INFORMATION>"
         ),
         { contentType: "markdown" }
       );
@@ -689,8 +672,7 @@ describe("InstructionSuggestionExtension", () => {
     it("should preserve text before instruction block", () => {
       editor.commands.setContent(
         preprocessMarkdownForEditor(
-          "You are an expert\n<rules>\nDo this\n</rules>",
-          editor.state.schema
+          "You are an expert\n<rules>\nDo this\n</rules>"
         ),
         { contentType: "markdown" }
       );
@@ -709,8 +691,7 @@ describe("InstructionSuggestionExtension", () => {
     it("should handle tag names with underscores", () => {
       editor.commands.setContent(
         preprocessMarkdownForEditor(
-          "Hello\n<MY_CUSTOM_TAG>\ncontent\n</MY_CUSTOM_TAG>",
-          editor.state.schema
+          "Hello\n<MY_CUSTOM_TAG>\ncontent\n</MY_CUSTOM_TAG>"
         ),
         { contentType: "markdown" }
       );
@@ -724,10 +705,7 @@ describe("InstructionSuggestionExtension", () => {
 
     it("should not double-add newlines when already present", () => {
       editor.commands.setContent(
-        preprocessMarkdownForEditor(
-          "Hello\n\n<rules>\ncontent\n</rules>",
-          editor.state.schema
-        ),
+        preprocessMarkdownForEditor("Hello\n\n<rules>\ncontent\n</rules>"),
         { contentType: "markdown" }
       );
 
@@ -739,7 +717,7 @@ describe("InstructionSuggestionExtension", () => {
 
     it("should escape standalone unrecognized tags", () => {
       editor.commands.setContent(
-        preprocessMarkdownForEditor("Use <URL> for links", editor.state.schema),
+        preprocessMarkdownForEditor("Use <URL> for links"),
         { contentType: "markdown" }
       );
 
@@ -754,10 +732,9 @@ describe("InstructionSuggestionExtension", () => {
     it("should round-trip instruction blocks through markdown", () => {
       const input =
         "You are an expert\n<CRITICAL_INFORMATION>\n@\n</CRITICAL_INFORMATION>";
-      editor.commands.setContent(
-        preprocessMarkdownForEditor(input, editor.state.schema),
-        { contentType: "markdown" }
-      );
+      editor.commands.setContent(preprocessMarkdownForEditor(input), {
+        contentType: "markdown",
+      });
 
       const markdown = editor.getMarkdown();
       expect(markdown).toContain("<critical_information>");

--- a/front/components/editor/lib/preprocessMarkdownForEditor.ts
+++ b/front/components/editor/lib/preprocessMarkdownForEditor.ts
@@ -1,27 +1,12 @@
-import type { Schema, TagParseRule } from "@tiptap/pm/model";
-import { DOMParser as PMDOMParser } from "@tiptap/pm/model";
-
 import { TAG_NAME_PATTERN } from "@app/components/editor/extensions/agent_builder/instructionBlockUtils";
 
 /**
- * Workaround for tiptap/markdown #7256: strip angle brackets from <WORD> tokens
- * that the schema doesn't recognize as HTML, preventing block-in-inline schema
- * violations. Recognized tags (e.g. <p>, <code>) are left untouched.
+ * Workaround for tiptap/markdown #7256: escape angle brackets from <WORD> tokens
+ * that markdown-it would parse as HTML, except for matched instruction-block pairs.
  *
  * TODO: Remove when tiptap merges https://github.com/ueberdosis/tiptap/pull/7260
  */
-export function preprocessMarkdownForEditor(
-  markdown: string,
-  schema: Schema
-): string {
-  const recognized = new Set(
-    PMDOMParser.fromSchema(schema)
-      .rules.filter((r): r is TagParseRule => "tag" in r)
-      .map((r) => r.tag.match(/^([a-z_][a-z0-9._:-]*)/i)?.[1]?.toLowerCase())
-      .filter(Boolean)
-  );
-
-  // Build set of matched tag pairs
+export function preprocessMarkdownForEditor(markdown: string): string {
   const matchedPairs = new Set<string>();
   const pairRegex = new RegExp(
     `<(${TAG_NAME_PATTERN})>[\\s\\S]*?<\\/\\1>`,
@@ -44,21 +29,30 @@ export function preprocessMarkdownForEditor(
     "$1\n\n"
   );
   // 2. Escape all angle-bracket patterns that markdown-it would parse as HTML.
-  //    Preserves matched instruction-block pairs if they're recognized AND at start of line.
+  //    Preserves only matched pairs where the opening tag is at start of line.
+  const openPreservedTags = new Set<string>();
   processed = processed.replace(
     new RegExp(`<(\\/?)(${TAG_NAME_PATTERN})([^>]*)>`, "g"),
     (match, slash, tagName, rest, offset) => {
       const normalized = tagName.toLowerCase();
+      const isClosing = slash === "/";
 
+      if (isClosing) {
+        if (openPreservedTags.has(normalized)) {
+          openPreservedTags.delete(normalized);
+          return match;
+        }
+        return `<\u200B${slash}${tagName}${rest}>`;
+      }
+
+      // Opening: preserve only if in matched pair and at start of line
       const beforeMatch = processed.substring(0, offset);
       const lastNewlineIndex = beforeMatch.lastIndexOf("\n");
       const textOnSameLine = beforeMatch.substring(lastNewlineIndex + 1);
       const isAtStartOfLine = /^\s*$/.test(textOnSameLine);
 
-      if (
-        (recognized.has(normalized) || matchedPairs.has(normalized)) &&
-        isAtStartOfLine
-      ) {
+      if (matchedPairs.has(normalized) && isAtStartOfLine) {
+        openPreservedTags.add(normalized);
         return match;
       }
       return `<\u200B${slash}${tagName}${rest}>`;

--- a/front/components/poke/pages/AssistantInstructionsPage.tsx
+++ b/front/components/poke/pages/AssistantInstructionsPage.tsx
@@ -64,7 +64,7 @@ export function AssistantInstructionsPage() {
           });
         } else if (instructions) {
           editor.commands.setContent(
-            preprocessMarkdownForEditor(instructions, editor.schema),
+            preprocessMarkdownForEditor(instructions),
             {
               emitUpdate: false,
               contentType: "markdown",


### PR DESCRIPTION
## Description

* Instruction blocks should only be escaped if they are by a newline
* Adding \u200B (zero width space) to escape so that the tags are not rendered as html, but visual elements are retained for the user 

## Tests

* Validated with examples in https://github.com/dust-tt/tasks/issues/6466

## Risk

* Attempting to fix existing issue

## Deploy Plan

* Deploy front