### PR TITLE
[front] enh(Ashby): accept larger sets of URLs in Ashby report retrieval

### DIFF
--- a/front/lib/api/actions/servers/ashby/tools/index.ts
+++ b/front/lib/api/actions/servers/ashby/tools/index.ts
@@ -106,11 +106,11 @@ const handlers: ToolHandlers<typeof ASHBY_TOOLS_METADATA> = {
     const client = clientResult.value;
 
     // Parse the report ID from the URL
-    // Expected format: https://app.ashbyhq.com/reports/.../[reportId]
-    if (!reportUrl.startsWith("https://app.ashbyhq.com/reports/")) {
+    // Expected format: https://app.ashbyhq.com/.../[reportId]
+    if (!reportUrl.startsWith("https://app.ashbyhq.com/")) {
       return new Err(
         new MCPError(
-          "Invalid Ashby report URL. Expected format: https://app.ashbyhq.com/reports/.../[reportId]"
+          "Invalid Ashby report URL. Expected format: https://app.ashbyhq.com/.../[reportId]"
         )
       );
     }
@@ -119,7 +119,7 @@ const handlers: ToolHandlers<typeof ASHBY_TOOLS_METADATA> = {
     if (!reportId) {
       return new Err(
         new MCPError(
-          "Invalid Ashby report URL. Expected format: https://app.ashbyhq.com/reports/.../[reportId]"
+          "Invalid Ashby report URL. Expected format: https://app.ashbyhq.com/.../[reportId]"
         )
       );
     }

--- a/front/lib/api/actions/servers/ashby/tools/index.ts
+++ b/front/lib/api/actions/servers/ashby/tools/index.ts
@@ -1,4 +1,5 @@
 import sanitizeHtml from "sanitize-html";
+import { validate as validateUuid } from "uuid";
 
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
@@ -116,7 +117,7 @@ const handlers: ToolHandlers<typeof ASHBY_TOOLS_METADATA> = {
     }
 
     const reportId = reportUrl.split("/").pop();
-    if (!reportId) {
+    if (!reportId || !validateUuid(reportId)) {
       return new Err(
         new MCPError(
           "Invalid Ashby report URL. Expected format: https://app.ashbyhq.com/.../[reportId]"

--- a/front/lib/api/actions/servers/ashby/tools/index.ts
+++ b/front/lib/api/actions/servers/ashby/tools/index.ts
@@ -116,7 +116,7 @@ const handlers: ToolHandlers<typeof ASHBY_TOOLS_METADATA> = {
       );
     }
 
-    const reportId = reportUrl.split("/").pop();
+    const reportId = new URL(reportUrl).pathname.split("/").pop();
     if (!reportId || !validateUuid(reportId)) {
       return new Err(
         new MCPError(


### PR DESCRIPTION
## Description

- The Ashby MCP server contains a tool to retrieve a report given its URL.
- For now the URL format was constrained to `https://app.ashbyhq.com/reports/.../[reportId]`.
- There are actually cases where the report URL has a different format (context [here](https://dust4ai.slack.com/archives/C08G3DGJV32/p1770839696421789?thread_ts=1770327736.864029&cid=C08G3DGJV32)).
- This PR remove `/reports` from the URL matching + add some UUID validation.
- Also improves the handling of query params/hash params.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
