### PR TITLE
Region-scoped incident banners via StatusPage components

### DIFF
--- a/front/lib/api/status/index.ts
+++ b/front/lib/api/status/index.ts
@@ -1,12 +1,8 @@
 import config from "@app/lib/api/config";
-import {
-  config as regionConfig,
-  type RegionType,
-} from "@app/lib/api/regions/config";
-import {
-  getUnresolvedIncidents,
-  type StatusPageIncidentType,
-} from "@app/lib/api/status/status_page";
+import type { RegionType } from "@app/lib/api/regions/config";
+import { config as regionConfig } from "@app/lib/api/regions/config";
+import type { StatusPageIncidentType } from "@app/lib/api/status/status_page";
+import { getUnresolvedIncidents } from "@app/lib/api/status/status_page";
 import { cacheWithRedis } from "@app/lib/utils/cache";
 import { isDevelopment } from "@app/types/shared/env";
 

--- a/front/lib/api/status/index.ts
+++ b/front/lib/api/status/index.ts
@@ -1,5 +1,12 @@
 import config from "@app/lib/api/config";
-import { getUnresolvedIncidents } from "@app/lib/api/status/status_page";
+import {
+  config as regionConfig,
+  type RegionType,
+} from "@app/lib/api/regions/config";
+import {
+  getUnresolvedIncidents,
+  type StatusPageIncidentType,
+} from "@app/lib/api/status/status_page";
 import { cacheWithRedis } from "@app/lib/utils/cache";
 import { isDevelopment } from "@app/types/shared/env";
 
@@ -14,18 +21,40 @@ export interface AppStatus {
   providersStatus: AppStatusComponent | null;
 }
 
+/**
+ * Determines if a StatusPage incident is relevant to a given region.
+ * - Incidents with no components are global and shown in all regions.
+ * - Incidents with components are shown only if a matching region component is
+ *   present.
+ */
+function isIncidentRelevantToRegion(
+  incident: Pick<StatusPageIncidentType, "components">,
+  region: RegionType
+): boolean {
+  if (incident.components.length === 0) {
+    return true;
+  }
+
+  return incident.components.some((c) => c.name === region);
+}
+
 async function getProvidersStatus(): Promise<AppStatusComponent | null> {
   if (isDevelopment()) {
     return null;
   }
 
+  const currentRegion = regionConfig.getCurrentRegion();
   const providersIncidents = await getUnresolvedIncidents({
     apiToken: config.getStatusPageApiToken(),
     pageId: config.getStatusPageProvidersPageId(),
   });
 
-  if (providersIncidents.length > 0) {
-    const [incident] = providersIncidents;
+  const relevantIncidents = providersIncidents.filter((incident) =>
+    isIncidentRelevantToRegion(incident, currentRegion)
+  );
+
+  if (relevantIncidents.length > 0) {
+    const [incident] = relevantIncidents;
     const { name, incident_updates: incidentUpdates } = incident;
     const [latestUpdate] = incidentUpdates;
     return {
@@ -43,13 +72,18 @@ async function getDustStatus(): Promise<AppStatusComponent | null> {
     return null;
   }
 
+  const currentRegion = regionConfig.getCurrentRegion();
   const dustIncidents = await getUnresolvedIncidents({
     apiToken: config.getStatusPageApiToken(),
     pageId: config.getStatusPageDustPageId(),
   });
 
-  if (dustIncidents.length > 0) {
-    const [incident] = dustIncidents;
+  const relevantIncidents = dustIncidents.filter((incident) =>
+    isIncidentRelevantToRegion(incident, currentRegion)
+  );
+
+  if (relevantIncidents.length > 0) {
+    const [incident] = relevantIncidents;
     const { name, incident_updates: incidentUpdates } = incident;
     const [latestUpdate] = incidentUpdates;
     return {
@@ -65,7 +99,7 @@ async function getDustStatus(): Promise<AppStatusComponent | null> {
 export const getProviderStatusMemoized = cacheWithRedis(
   getProvidersStatus,
   () => {
-    return "provider-status";
+    return `provider-status-${regionConfig.getCurrentRegion()}`;
   },
   // Caches data for 2 minutes to limit frequent API calls.
   // Status page rate limit is pretty aggressive.
@@ -77,7 +111,7 @@ export const getProviderStatusMemoized = cacheWithRedis(
 export const getDustStatusMemoized = cacheWithRedis(
   getDustStatus,
   () => {
-    return "dust-status";
+    return `dust-status-${regionConfig.getCurrentRegion()}`;
   },
   // Caches data for 2 minutes to limit frequent API calls.
   // Status page rate limit is pretty aggressive.

--- a/front/lib/api/status/status_page.ts
+++ b/front/lib/api/status/status_page.ts
@@ -4,6 +4,10 @@ import * as reporter from "io-ts-reporters";
 
 import logger from "@app/logger/logger";
 
+const StatusPageComponentCodec = t.type({
+  name: t.string,
+});
+
 const StatusPageUnresolvedIncident = t.type({
   name: t.string,
   incident_updates: t.array(
@@ -12,11 +16,16 @@ const StatusPageUnresolvedIncident = t.type({
     })
   ),
   shortlink: t.string,
+  components: t.array(StatusPageComponentCodec),
 });
 
 const StatusPageResponseSchema = t.array(StatusPageUnresolvedIncident);
 
-type StatusPageReponseType = t.TypeOf<typeof StatusPageResponseSchema>;
+export type StatusPageIncidentType = t.TypeOf<
+  typeof StatusPageUnresolvedIncident
+>;
+
+type StatusPageReponseType = StatusPageIncidentType[];
 
 export async function getUnresolvedIncidents({
   apiToken,


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR adds region-scoped incident banners. To achieve this we rely on StatusPage components (`europe-west1`, `us-central1`).

The region logic is as following:
- Incidents with no components remain global and are shown in all regions
- Incidents attached to a specific region component are only shown in that region

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
Low risk, worst case region-scoped does not work. Safe to rollback.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
- [ ] Update runbook
