### PR TITLE
[connector] throw external oauth token error for gong 

### DIFF
--- a/connectors/src/lib/oauth.ts
+++ b/connectors/src/lib/oauth.ts
@@ -40,7 +40,7 @@ export async function getOAuthConnectionAccessTokenWithThrow({
       // Happens with confluence
       (tokRes.error.code === "provider_access_token_refresh_error" &&
         tokRes.error.message.includes("Token was globally revoked")) ||
-      // Happens with microsoft
+      // Happens with microsoft & gong
       (tokRes.error.code === "provider_access_token_refresh_error" &&
         (tokRes.error.message.includes("invalid_grant") ||
           tokRes.error.message.includes("invalid_client"))) ||


### PR DESCRIPTION
## Description
We have another [stuck connector error](https://app.datadoghq.eu/logs?query=host%3Aconnectors-worker-gong-deployment-c86bd474b-zf2qr%20service%3Aconnectors-worker%20container_id%3A4704e700192b1035111f1bb4b7f959f42cf4aa2c7f06d4d797dbcda9553e7b0f%20filename%3A0.log&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&context_event=AZxOv9RSAAA1zL2bWEP0TQBJ&fromUser=false&messageDisplay=inline&overlay=events&overlayQuery=%28%28%22Activity%20failed%22%20OR%20%22Unhandled%20activity%20error%22%29%20%40attempt%3A%3E19%20%40dd.service%3Aconnectors-worker%20region%3Aus-central1%20%40level%3Aerror%20%40workflowId%3A%2A%29%20%40workflowId%3AgoogleDrive-IncrementalSync-26087&panelFrom=1770833410047&panelStorageType=hot&panelTo=1770847810047&panelType=logs&refresh_mode=sliding&screenId=eza-jyh-pwy&storage=hot&stream_sort=time%2Cdesc&to_event=AwAAAZxOwUpeXAGTpAAAABhBWnhPd1ZyeEFBRHFNZmVOT3ZrT09BQk0AAAAkZjE5YzRlYzEtOWFjMy00OTE5LWIxN2UtMDg5YzdhY2Y4NjAyAABZJw&viz=&from_ts=1770847415813&to_ts=1770847816287&live=false) for Gong, and from what I understood we want to throw an ExternalOAuthTokenError, which can be handled if we use  `getOAuthConnectionAccessTokenWithThrow`? 👶

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
