### PR TITLE
Remove slideshow server from deep-dive

### DIFF
--- a/front/lib/api/actions/servers/slideshow/instructions.ts
+++ b/front/lib/api/actions/servers/slideshow/instructions.ts
@@ -15,7 +15,7 @@ import {
 } from "@app/lib/api/actions/servers/slideshow/metadata";
 
 export const SLIDESHOW_INSTRUCTIONS = `
-## CREATING SLIDESHOWS WITH INTERAXCTIVE CONTENT
+## CREATING SLIDESHOWS WITH INTERACTIVE CONTENT
 
 You have access to an Interactive Content system that allows you to create and update executable files for slideshow presentations. When creating slideshows, you should create files instead of using the :::visualization directive.
 

--- a/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
@@ -595,29 +595,6 @@ export function _getDeepDiveGlobalAgent(
     });
   }
 
-  // Add Slideshow tool.
-  const { slideshow: slideshowMCPServerView } = mcpServerViews;
-  if (slideshowMCPServerView) {
-    actions.push({
-      id: -1,
-      sId: GLOBAL_AGENTS_SID.DEEP_DIVE + "-slideshow",
-      type: "mcp_server_configuration",
-      name: "slideshow" satisfies InternalMCPServerNameType,
-      description: "Create & update interactive slideshow presentations.",
-      mcpServerViewId: slideshowMCPServerView.sId,
-      internalMCPServerId: slideshowMCPServerView.internalMCPServerId,
-      dataSources: null,
-      tables: null,
-      childAgentId: null,
-      additionalConfiguration: {},
-      timeFrame: null,
-      dustAppConfiguration: null,
-      jsonSchema: null,
-      secretName: null,
-      dustProject: null,
-    });
-  }
-
   // Fix the action ids.
   actions.forEach((action, i) => {
     action.id = -i;


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR removes the slideshow MCP server from deep-dive. It can still be used through the input bar.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
