### PR TITLE
[front] Migrate deep dive agent from interactive content tools to frames skill

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
@@ -631,6 +631,7 @@ export function _getDeepDiveGlobalAgent(
     ...deepAgent,
     status,
     actions,
+    skills: ["frames"],
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
   };
 }
@@ -750,7 +751,6 @@ export function _getDustTaskGlobalAgent(
     status: "active",
     actions,
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
-    skills: ["frames"],
   };
 }
 

--- a/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
@@ -529,31 +529,6 @@ export function _getDeepDiveGlobalAgent(
     actions.push(dataWarehousesAction);
   }
 
-  // Add Interactive Content tool.
-  const { interactive_content: interactiveContentMCPServerView } =
-    mcpServerViews;
-
-  if (interactiveContentMCPServerView) {
-    actions.push({
-      id: -1,
-      sId: GLOBAL_AGENTS_SID.DEEP_DIVE + "-interactive-content",
-      type: "mcp_server_configuration",
-      name: "interactive_content" satisfies InternalMCPServerNameType,
-      description: "Create & update Interactive Content files.",
-      mcpServerViewId: interactiveContentMCPServerView.sId,
-      internalMCPServerId: interactiveContentMCPServerView.internalMCPServerId,
-      dataSources: null,
-      tables: null,
-      childAgentId: null,
-      additionalConfiguration: {},
-      timeFrame: null,
-      dustAppConfiguration: null,
-      jsonSchema: null,
-      secretName: null,
-      dustProject: null,
-    });
-  }
-
   // Add run_agent to call dust-task
   if (runAgentMCPServerView) {
     actions.push({

--- a/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
@@ -750,6 +750,7 @@ export function _getDustTaskGlobalAgent(
     status: "active",
     actions,
     maxStepsPerRun: MAX_STEPS_USE_PER_RUN_LIMIT,
+    skills: ["frames"],
   };
 }
 

--- a/front/lib/api/assistant/global_agents/tools.ts
+++ b/front/lib/api/assistant/global_agents/tools.ts
@@ -21,18 +21,17 @@ export type PrefetchedDataSourcesType = {
   workspaceId: string;
 };
 
-export const MCP_SERVERS_FOR_GLOBAL_AGENTS: readonly AutoInternalMCPServerNameType[] =
-  [
-    "agent_router",
-    "web_search_&_browse",
-    "search",
-    "data_sources_file_system",
-    "run_agent",
-    "toolsets",
-    "data_warehouses",
-    "slideshow",
-    "agent_memory",
-  ] as const;
+export const MCP_SERVERS_FOR_GLOBAL_AGENTS = [
+  "agent_router",
+  "web_search_&_browse",
+  "search",
+  "data_sources_file_system",
+  "run_agent",
+  "toolsets",
+  "data_warehouses",
+  "slideshow",
+  "agent_memory",
+] as const satisfies AutoInternalMCPServerNameType[];
 
 export type MCPServerViewsForGlobalAgentsMap = Record<
   (typeof MCP_SERVERS_FOR_GLOBAL_AGENTS)[number],


### PR DESCRIPTION
## Description

- This PR migrates the deep dive global agent to use the Frames skill instead of having the tools.

## Tests

- Tested locally.

## Risk

- Medium.

## Deploy Plan

- Deploy front.
