### PR TITLE
[front] Report conditional JIT tools in `getOutputFromLLMStream`

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
@@ -1,5 +1,4 @@
 import type { MCPServerConfigurationType } from "@app/lib/actions/mcp";
-import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import { USE_SUMMARY_SWITCH } from "@app/lib/actions/mcp_internal_actions/constants";
 import { WEB_SEARCH_BROWSE_ACTION_DESCRIPTION } from "@app/lib/api/actions/servers/web_search_browse/metadata";
 import {

--- a/front/lib/api/assistant/jit_actions.test.ts
+++ b/front/lib/api/assistant/jit_actions.test.ts
@@ -67,7 +67,7 @@ describe("getJITServers", () => {
 
   describe("basic MCP servers", () => {
     it("should return common_utilities MCP server when no attachments", async () => {
-      const jitServers = await getJITServers(auth, {
+      const { servers: jitServers } = await getJITServers(auth, {
         agentConfiguration: agentConfig,
         conversation,
         attachments: [],
@@ -106,7 +106,7 @@ describe("getJITServers", () => {
         },
       ];
 
-      const jitServers = await getJITServers(auth, {
+      const { servers: jitServers } = await getJITServers(auth, {
         agentConfiguration: agentConfig,
         conversation,
         attachments,
@@ -137,7 +137,7 @@ describe("getJITServers", () => {
         agentConfigurationId: agentConfig.id,
       });
 
-      const jitServers = await getJITServers(auth, {
+      const { servers: jitServers } = await getJITServers(auth, {
         agentConfiguration: agentConfig,
         conversation,
         attachments: [],
@@ -157,7 +157,7 @@ describe("getJITServers", () => {
     it("should not include skill_management server when agent has no skills", async () => {
       await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
 
-      const jitServers = await getJITServers(auth, {
+      const { servers: jitServers } = await getJITServers(auth, {
         agentConfiguration: agentConfig,
         conversation,
         attachments: [],
@@ -192,7 +192,7 @@ describe("getJITServers", () => {
 
       expect(projectDatasourceView).toBeDefined();
 
-      const jitServers = await getJITServers(auth, {
+      const { servers: jitServers } = await getJITServers(auth, {
         agentConfiguration: agentConfig,
         conversation: conversationWithSpace,
         attachments: [],
@@ -218,7 +218,7 @@ describe("getJITServers", () => {
     });
 
     it("should not include project search server when feature flag is disabled", async () => {
-      const jitServers = await getJITServers(auth, {
+      const { servers: jitServers } = await getJITServers(auth, {
         agentConfiguration: agentConfig,
         conversation,
         attachments: [],
@@ -236,7 +236,7 @@ describe("getJITServers", () => {
       await FeatureFlagFactory.basic("projects", workspace);
       await MCPServerViewResource.ensureAllAutoToolsAreCreated(auth);
 
-      const jitServers = await getJITServers(auth, {
+      const { servers: jitServers } = await getJITServers(auth, {
         agentConfiguration: agentConfig,
         conversation: {
           ...conversation,
@@ -258,7 +258,7 @@ describe("getJITServers", () => {
     });
 
     it("should not include project_manager server when feature flag is disabled", async () => {
-      const jitServers = await getJITServers(auth, {
+      const { servers: jitServers } = await getJITServers(auth, {
         agentConfiguration: agentConfig,
         conversation: {
           ...conversation,
@@ -278,7 +278,7 @@ describe("getJITServers", () => {
       // Enable projects feature flag.
       await FeatureFlagFactory.basic("projects", workspace);
 
-      const jitServers = await getJITServers(auth, {
+      const { servers: jitServers } = await getJITServers(auth, {
         agentConfiguration: agentConfig,
         conversation,
         attachments: [],
@@ -303,7 +303,7 @@ describe("getJITServers", () => {
         workspace.id
       );
 
-      const jitServers = await getJITServers(auth, {
+      const { servers: jitServers } = await getJITServers(auth, {
         agentConfiguration: agentConfig,
         conversation,
         attachments: [],
@@ -321,7 +321,7 @@ describe("getJITServers", () => {
     });
 
     it("should not include schedules_management server for non-onboarding conversations", async () => {
-      const jitServers = await getJITServers(auth, {
+      const { servers: jitServers } = await getJITServers(auth, {
         agentConfiguration: agentConfig,
         conversation,
         attachments: [],
@@ -360,7 +360,7 @@ describe("getJITServers", () => {
         },
       ];
 
-      const jitServers = await getJITServers(auth, {
+      const { servers: jitServers } = await getJITServers(auth, {
         agentConfiguration: agentConfig,
         conversation,
         attachments,
@@ -411,7 +411,7 @@ describe("getJITServers", () => {
         },
       ];
 
-      const jitServers = await getJITServers(auth, {
+      const { servers: jitServers } = await getJITServers(auth, {
         agentConfiguration: agentConfig,
         conversation,
         attachments,
@@ -458,7 +458,7 @@ describe("getJITServers", () => {
         },
       ];
 
-      const jitServers = await getJITServers(auth, {
+      const { servers: jitServers } = await getJITServers(auth, {
         agentConfiguration: agentConfig,
         conversation,
         attachments,
@@ -496,7 +496,7 @@ describe("getJITServers", () => {
         },
       ];
 
-      const jitServers = await getJITServers(auth, {
+      const { servers: jitServers } = await getJITServers(auth, {
         agentConfiguration: agentConfig,
         conversation,
         attachments,
@@ -536,7 +536,7 @@ describe("getJITServers", () => {
         },
       ];
 
-      const jitServers = await getJITServers(auth, {
+      const { servers: jitServers } = await getJITServers(auth, {
         agentConfiguration: agentConfig,
         conversation,
         attachments,
@@ -557,7 +557,7 @@ describe("getJITServers", () => {
 
   describe("server structure", () => {
     it("should return servers with correct structure", async () => {
-      const jitServers = await getJITServers(auth, {
+      const { servers: jitServers } = await getJITServers(auth, {
         agentConfiguration: agentConfig,
         conversation,
         attachments: [],
@@ -613,7 +613,7 @@ describe("getJITServers", () => {
         },
       ];
 
-      const jitServers = await getJITServers(auth, {
+      const { servers: jitServers } = await getJITServers(auth, {
         agentConfiguration: agentConfig,
         conversation,
         attachments,

--- a/front/lib/api/assistant/jit_actions.ts
+++ b/front/lib/api/assistant/jit_actions.ts
@@ -103,6 +103,10 @@ async function getConditionalJITServers(
 
   // Add tools to manipulate conversation files, if any.
 
+  if (attachments.length === 0) {
+    return removeNulls(servers);
+  }
+
   const conversationFilesServer = await getConversationFilesServer(
     auth,
 

--- a/front/lib/api/assistant/jit_actions.ts
+++ b/front/lib/api/assistant/jit_actions.ts
@@ -19,7 +19,7 @@ import type { ConversationWithoutContentType } from "@app/types/assistant/conver
 import { removeNulls } from "@app/types/shared/utils/general";
 
 /**
- * Servers whose tool specifications are always added.
+ * Servers whose tool specifications are mostly always added or never added.
  */
 async function getUnconditionalJITServers(
   auth: Authenticator,
@@ -68,9 +68,7 @@ async function getUnconditionalJITServers(
 }
 
 /**
- * Servers whose presence depends on the conversation state (attached MCP
- * servers, project membership, attachments, etc.). They change the tool
- * specifications across conversations and bust the LLM cache.
+ * Servers whose presence depends heavily on the conversation state and may change mid-conversation.
  */
 async function getConditionalJITServers(
   auth: Authenticator,

--- a/front/lib/api/assistant/jit_actions.ts
+++ b/front/lib/api/assistant/jit_actions.ts
@@ -16,6 +16,7 @@ import { getSkillManagementServer } from "@app/lib/api/assistant/jit/skills";
 import type { Authenticator } from "@app/lib/auth";
 import type { AgentConfigurationType } from "@app/types/assistant/agent";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import { removeNulls } from "@app/types/shared/utils/general";
 
 /**
  * Servers whose tool specifications are always added.
@@ -30,9 +31,8 @@ async function getUnconditionalJITServers(
     conversation: ConversationWithoutContentType;
   }
 ): Promise<ServerSideMCPServerConfigurationType[]> {
-  const servers: ServerSideMCPServerConfigurationType[] = [];
+  const servers: (ServerSideMCPServerConfigurationType | null)[] = [];
 
-  // Get common utilities server.
   const commonUtilitiesServer = await getCommonUtilitiesServer(
     auth,
     agentConfiguration,

--- a/front/lib/api/assistant/jit_actions.ts
+++ b/front/lib/api/assistant/jit_actions.ts
@@ -147,16 +147,14 @@ export async function getJITServers(
   servers: ServerSideMCPServerConfigurationType[];
   hasConditionalJITTools: boolean;
 }> {
-  const baseServers = await getUnconditionalJITServers(auth, {
-    agentConfiguration,
-    conversation,
-  });
-
-  const conditionalServers = await getConditionalJITServers(auth, {
-    agentConfiguration,
-    conversation,
-    attachments,
-  });
+  const [baseServers, conditionalServers] = await Promise.all([
+    getUnconditionalJITServers(auth, { agentConfiguration, conversation }),
+    getConditionalJITServers(auth, {
+      agentConfiguration,
+      conversation,
+      attachments,
+    }),
+  ]);
 
   return {
     servers: [...baseServers, ...conditionalServers],

--- a/front/lib/api/llm/clients/anthropic/index.ts
+++ b/front/lib/api/llm/clients/anthropic/index.ts
@@ -37,10 +37,10 @@ import { dustManagedCredentials } from "@app/types/api/credentials";
  * Both currently use the default 5min cache TTL. Once we remove entropy from
  * instructions, we can use extended-cache-ttl (1h) for better cache savings.
  */
-function buildSystemBlocks([instructions, context]: [
-  SystemPromptInstruction[],
-  SystemPromptContext[],
-]) {
+function buildSystemBlocks(
+  [instructions, context]: [SystemPromptInstruction[], SystemPromptContext[]],
+  _: { hasJITTools: boolean }
+) {
   const instructionsText = instructions.map((s) => s.content).join("\n");
   const contextText = context.map((s) => s.content).join("\n");
 
@@ -86,6 +86,7 @@ export class AnthropicLLM extends LLM {
 
   async *internalStream({
     conversation,
+    hasJITTools,
     prompt,
     specifications,
     forceToolCall,
@@ -114,7 +115,9 @@ export class AnthropicLLM extends LLM {
         ...(this.modelConfig.customBetas ?? []),
       ];
 
-      const system = buildSystemBlocks(normalizePrompt(prompt));
+      const system = buildSystemBlocks(normalizePrompt(prompt), {
+        hasJITTools,
+      });
 
       const events = this.client.beta.messages.stream({
         model: this.modelId,

--- a/front/lib/api/llm/clients/anthropic/index.ts
+++ b/front/lib/api/llm/clients/anthropic/index.ts
@@ -39,7 +39,7 @@ import { dustManagedCredentials } from "@app/types/api/credentials";
  */
 function buildSystemBlocks(
   [instructions, context]: [SystemPromptInstruction[], SystemPromptContext[]],
-  _: { hasJITTools: boolean }
+  _: { hasConditionalJITTools?: boolean }
 ) {
   const instructionsText = instructions.map((s) => s.content).join("\n");
   const contextText = context.map((s) => s.content).join("\n");
@@ -86,7 +86,7 @@ export class AnthropicLLM extends LLM {
 
   async *internalStream({
     conversation,
-    hasJITTools,
+    hasConditionalJITTools,
     prompt,
     specifications,
     forceToolCall,
@@ -116,7 +116,7 @@ export class AnthropicLLM extends LLM {
       ];
 
       const system = buildSystemBlocks(normalizePrompt(prompt), {
-        hasJITTools,
+        hasConditionalJITTools,
       });
 
       const events = this.client.beta.messages.stream({

--- a/front/lib/api/llm/types/options.ts
+++ b/front/lib/api/llm/types/options.ts
@@ -94,7 +94,7 @@ export type ForceToolCall = string;
 
 export interface LLMStreamParameters {
   conversation: ModelConversationTypeMultiActions;
-  hasJITTools: boolean;
+  hasConditionalJITTools?: boolean;
   prompt: SystemPromptInput;
   specifications: AgentActionSpecification[];
   /**

--- a/front/lib/api/llm/types/options.ts
+++ b/front/lib/api/llm/types/options.ts
@@ -94,6 +94,7 @@ export type ForceToolCall = string;
 
 export interface LLMStreamParameters {
   conversation: ModelConversationTypeMultiActions;
+  hasJITTools: boolean;
   prompt: SystemPromptInput;
   specifications: AgentActionSpecification[];
   /**

--- a/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
+++ b/front/pages/api/poke/workspaces/[wId]/conversations/[cId]/render.ts
@@ -159,7 +159,7 @@ async function handler(
 
       // Build tools list and prompt similar to the agent loop.
       const attachments = listAttachments(conversation);
-      const jitServers = await getJITServers(auth, {
+      const { servers: jitServers } = await getJITServers(auth, {
         agentConfiguration,
         conversation,
         attachments,

--- a/front/temporal/agent_loop/lib/get_output_from_llm.ts
+++ b/front/temporal/agent_loop/lib/get_output_from_llm.ts
@@ -128,7 +128,7 @@ export async function getOutputFromLLMStream(
   {
     modelConversationRes,
     conversation,
-    hasJITTools,
+    hasConditionalJITTools,
     specifications,
     flushParserTokens,
     contentParser,
@@ -146,7 +146,7 @@ export async function getOutputFromLLMStream(
   let timeToFirstEvent: number | undefined = undefined;
   const events = llm.stream({
     conversation: modelConversationRes.value.modelConversation,
-    hasJITTools,
+    hasConditionalJITTools,
     prompt,
     specifications,
   });

--- a/front/temporal/agent_loop/lib/get_output_from_llm.ts
+++ b/front/temporal/agent_loop/lib/get_output_from_llm.ts
@@ -128,6 +128,7 @@ export async function getOutputFromLLMStream(
   {
     modelConversationRes,
     conversation,
+    hasJITTools,
     specifications,
     flushParserTokens,
     contentParser,
@@ -145,6 +146,7 @@ export async function getOutputFromLLMStream(
   let timeToFirstEvent: number | undefined = undefined;
   const events = llm.stream({
     conversation: modelConversationRes.value.modelConversation,
+    hasJITTools,
     prompt,
     specifications,
   });

--- a/front/temporal/agent_loop/lib/prompt_commands.ts
+++ b/front/temporal/agent_loop/lib/prompt_commands.ts
@@ -161,7 +161,7 @@ async function listAvailableTools(
     });
 
   const attachments = listAttachments(conversation);
-  const jitServers = await getJITServers(auth, {
+  const { servers: jitServers } = await getJITServers(auth, {
     agentConfiguration,
     conversation,
     attachments,

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -172,11 +172,14 @@ export async function runModelActivity(
   }
 
   const attachments = listAttachments(conversation);
-  const jitServers = await getJITServers(auth, {
-    agentConfiguration,
-    conversation,
-    attachments,
-  });
+  const { servers: jitServers, hasConditionalJITTools } = await getJITServers(
+    auth,
+    {
+      agentConfiguration,
+      conversation,
+      attachments,
+    }
+  );
   // Get client-side MCP server configurations from the user message context.
   const clientSideMCPActionConfigurations =
     await createClientSideMCPServerConfigurations(
@@ -450,7 +453,7 @@ export async function runModelActivity(
   const getOutputFromActionResponse = await getOutputFromLLMStream(auth, {
     modelConversationRes,
     conversation,
-    hasJITTools: false,
+    hasConditionalJITTools,
     userMessage,
     specifications,
     flushParserTokens,

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -450,6 +450,7 @@ export async function runModelActivity(
   const getOutputFromActionResponse = await getOutputFromLLMStream(auth, {
     modelConversationRes,
     conversation,
+    hasJITTools: false,
     userMessage,
     specifications,
     flushParserTokens,

--- a/front/temporal/agent_loop/lib/types.ts
+++ b/front/temporal/agent_loop/lib/types.ts
@@ -40,7 +40,7 @@ export type GetOutputRequestParams = {
     tokensUsed: number;
   }>;
   conversation: ConversationType;
-  hasJITTools: boolean;
+  hasConditionalJITTools: boolean;
   userMessage: UserMessageType;
   specifications: AgentActionSpecification[];
   flushParserTokens: () => Promise<void>;

--- a/front/temporal/agent_loop/lib/types.ts
+++ b/front/temporal/agent_loop/lib/types.ts
@@ -40,6 +40,7 @@ export type GetOutputRequestParams = {
     tokensUsed: number;
   }>;
   conversation: ConversationType;
+  hasJITTools: boolean;
   userMessage: UserMessageType;
   specifications: AgentActionSpecification[];
   flushParserTokens: () => Promise<void>;


### PR DESCRIPTION
## Description

- This PR adds a `hasConditionalJITTools` condition generated when retrieving the JIT servers and exposes it `getOutputFromLLMStream`.
- Goal is to use this condition to control caching mechanism.
- Changes in the specifications bust the cache, so our caching strategy may vary depending on the presence of conditional JIT servers.
- No change in the caching strategy in this PR, no runtime change expected.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
