### PR TITLE
Replace instrumentation activities with Temporal sinks in agent loop

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
@@ -1,5 +1,4 @@
 import type { MCPServerConfigurationType } from "@app/lib/actions/mcp";
-import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import { USE_SUMMARY_SWITCH } from "@app/lib/actions/mcp_internal_actions/constants";
 import { WEB_SEARCH_BROWSE_ACTION_DESCRIPTION } from "@app/lib/api/actions/servers/web_search_browse/metadata";
 import {

--- a/front/temporal/agent_loop/activities/instrumentation.ts
+++ b/front/temporal/agent_loop/activities/instrumentation.ts
@@ -3,7 +3,7 @@ import logger from "@app/logger/logger";
 import { statsDClient } from "@app/logger/statsDClient";
 
 // StatsD metric names.
-const METRICS = {
+export const METRICS = {
   LOOP_COMPLETIONS: "agent_loop.completions",
   LOOP_DURATION: "agent_loop.duration_ms",
   LOOP_STARTS: "agent_loop.starts",

--- a/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
+++ b/front/temporal/agent_loop/activities/run_model_and_create_actions_wrapper.ts
@@ -8,7 +8,6 @@ import { AgentMCPActionModel } from "@app/lib/models/agent/actions/mcp";
 import { AgentStepContentModel } from "@app/lib/models/agent/agent_step_content";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import logger from "@app/logger/logger";
-import { logAgentLoopStepStart } from "@app/temporal/agent_loop/activities/instrumentation";
 import type { ActionBlob } from "@app/temporal/agent_loop/lib/create_tool_actions";
 import { createToolActionsActivity } from "@app/temporal/agent_loop/lib/create_tool_actions";
 import { handlePromptCommand } from "@app/temporal/agent_loop/lib/prompt_commands";
@@ -65,13 +64,6 @@ export async function runModelAndCreateActionsActivity({
   }
 
   const { auth, ...runAgentData } = runAgentDataRes.value;
-
-  // Log step start.
-  logAgentLoopStepStart({
-    agentMessageId: runAgentData.agentMessage.sId,
-    conversationId: runAgentData.conversation.sId,
-    step,
-  });
 
   // Tool test run: bypass LLM and directly execute tool commands.
   const featureFlags = await getFeatureFlags(auth.getNonNullableWorkspace());

--- a/front/temporal/agent_loop/config.ts
+++ b/front/temporal/agent_loop/config.ts
@@ -4,3 +4,6 @@ export const QUEUE_NAME = `agent-loop-queue-v${QUEUE_VERSION}`;
 
 // Max retry attempts for the runModelAndCreateActions activity.
 export const RUN_MODEL_MAX_RETRIES = 5;
+
+// Patch ID for migrating instrumentation activities to sinks.
+export const USE_INSTRUMENTATION_SINKS_PATCH = "use-instrumentation-sinks";

--- a/front/temporal/agent_loop/sinks.ts
+++ b/front/temporal/agent_loop/sinks.ts
@@ -1,0 +1,118 @@
+import type { InjectedSinks } from "@temporalio/worker";
+import type { Sinks } from "@temporalio/workflow";
+
+import logger from "@app/logger/logger";
+import { statsDClient } from "@app/logger/statsDClient";
+import { METRICS } from "@app/temporal/agent_loop/activities/instrumentation";
+
+/**
+ * Sink interface for agent loop instrumentation.
+ *
+ * Fire-and-forget sinks that don't record in workflow history, don't consume activity slots,
+ * and run on the same worker with callDuringReplay: false.
+ *
+ * All arguments must be primitives (structured clone constraint).
+ */
+export interface AgentLoopInstrumentationSinks extends Sinks {
+  metrics: {
+    logPhaseStart(
+      workspaceId: string,
+      agentMessageId: string,
+      conversationId: string,
+      startStep: number
+    ): void;
+
+    logStepCompletion(
+      agentMessageId: string,
+      conversationId: string,
+      step: number,
+      stepStartTime: number
+    ): void;
+
+    logPhaseCompletion(
+      workspaceId: string,
+      agentMessageId: string,
+      conversationId: string,
+      initialStartTime: number | undefined,
+      stepsCompleted: number,
+      syncStartTime: number
+    ): void;
+  };
+}
+
+export const instrumentationSinks: InjectedSinks<AgentLoopInstrumentationSinks> =
+  {
+    metrics: {
+      logPhaseStart: {
+        fn(
+          _info,
+          workspaceId: string,
+          agentMessageId: string,
+          conversationId: string,
+          startStep: number
+        ) {
+          logger.info(
+            { workspaceId, agentMessageId, conversationId, startStep },
+            "Agent loop phase execution started"
+          );
+          statsDClient.increment(METRICS.PHASE_STARTS, 1);
+        },
+      },
+      logStepCompletion: {
+        fn(
+          _info,
+          _agentMessageId: string,
+          _conversationId: string,
+          step: number,
+          stepStartTime: number
+        ) {
+          const stepDurationMs = Date.now() - stepStartTime;
+          const tags = [`step:${step}`];
+
+          statsDClient.increment(METRICS.STEP_STARTS, 1, tags);
+          statsDClient.increment(METRICS.STEP_COMPLETIONS, 1, tags);
+          statsDClient.distribution(
+            METRICS.STEP_DURATION,
+            stepDurationMs,
+            tags
+          );
+        },
+      },
+      logPhaseCompletion: {
+        fn(
+          _info,
+          workspaceId: string,
+          agentMessageId: string,
+          conversationId: string,
+          initialStartTime: number | undefined,
+          stepsCompleted: number,
+          syncStartTime: number
+        ) {
+          const now = Date.now();
+          const phaseDurationMs = now - syncStartTime;
+          const totalDurationMs = initialStartTime
+            ? now - initialStartTime
+            : phaseDurationMs;
+
+          logger.info(
+            {
+              workspaceId,
+              agentMessageId,
+              conversationId,
+              phaseDurationMs,
+              totalDurationMs,
+              stepsCompleted,
+            },
+            "Agent loop execution completed"
+          );
+
+          statsDClient.increment(METRICS.PHASE_COMPLETIONS, 1);
+          statsDClient.distribution(METRICS.PHASE_DURATION, phaseDurationMs);
+          statsDClient.histogram(METRICS.PHASE_STEPS, stepsCompleted);
+
+          statsDClient.increment(METRICS.LOOP_COMPLETIONS, 1);
+          statsDClient.distribution(METRICS.LOOP_DURATION, totalDurationMs);
+        },
+      },
+    },
+  };

--- a/front/temporal/agent_loop/worker.ts
+++ b/front/temporal/agent_loop/worker.ts
@@ -30,6 +30,7 @@ import { publishDeferredEventsActivity } from "@app/temporal/agent_loop/activiti
 import { runModelAndCreateActionsActivity } from "@app/temporal/agent_loop/activities/run_model_and_create_actions_wrapper";
 import { runToolActivity } from "@app/temporal/agent_loop/activities/run_tool";
 import { QUEUE_NAME } from "@app/temporal/agent_loop/config";
+import { instrumentationSinks } from "@app/temporal/agent_loop/sinks";
 import { getWorkflowConfig } from "@app/temporal/bundle_helper";
 import { isDevelopment } from "@app/types/shared/env";
 import { removeNulls } from "@app/types/shared/utils/general";
@@ -91,6 +92,7 @@ export async function runAgentLoopWorker() {
     sinks: {
       // @ts-expect-error InMemorySpanExporter type mismatch.
       exporter: makeWorkflowExporter(spanExporter, resource),
+      ...instrumentationSinks,
     },
     bundlerOptions: {
       // Update the webpack config to use aliases from our tsconfig.json. This let us import code


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
Over the past few days, we have iterated a lot around agent loop scaling. Looking at the full picture, we really want to optimize for activities to be valuable in the agent loop. We currently have 3 activities used only for instrumentation (`logAgentLoopPhaseStart`, `logAgentLoopStepCompletion`, `logAgentLoopPhaseCompletion`). This PR patches the existing agent loop workflow to use [sinks](https://docs.temporal.io/develop/typescript/observability) over activities:
- They don't consume activity slots (out of the 75 per pod)
- They don't record in workflow history
- They run on the same worker alongside the workflow code, so we should expect less scheduling latency

Uses `patched("use-instrumentation-sinks")` to preserve determinism for replaying workflows. Old activities are kept registered for replay compatibility.

Follow-up cleanup:
- ~1 h: Replace `patched()` with `deprecatePatch()`
- ~4 hours: Remove `deprecatePatch()`, old activity registrations, and dead code

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Blast radius is significative, it could break all the in-flight agent loops. Rollbacking is not that easy as it would break all the in-flight agent loop workflow that started on this code.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
