### PR TITLE
[front] fix: file download/view URLs missing API base URL in SPA

### DIFF
--- a/front/lib/swr/files.ts
+++ b/front/lib/swr/files.ts
@@ -2,7 +2,7 @@ import type { Fetcher, SWRConfiguration } from "swr";
 
 import { useSendNotification } from "@app/hooks/useNotification";
 import { usePeriodicRefresh } from "@app/hooks/usePeriodicRefresh";
-import { clientFetch } from "@app/lib/egress/client";
+import { clientFetch, getApiBaseUrl } from "@app/lib/egress/client";
 import { useDataSourceViewContentNodes } from "@app/lib/swr/data_source_views";
 import {
   fetcher,
@@ -21,20 +21,22 @@ import type { LightWorkspaceType } from "@app/types/user";
 export const getFileProcessedUrl = (
   owner: LightWorkspaceType,
   fileId: string | null | undefined
-) => `/api/w/${owner.sId}/files/${fileId}?action=view&version=processed`;
+) =>
+  `${getApiBaseUrl()}/api/w/${owner.sId}/files/${fileId}?action=view&version=processed`;
 
 export const getProcessedFileDownloadUrl = (
   owner: LightWorkspaceType,
   fileId: string
-) => `/api/w/${owner.sId}/files/${fileId}?action=download&version=processed`;
+) =>
+  `${getApiBaseUrl()}/api/w/${owner.sId}/files/${fileId}?action=download&version=processed`;
 
 export const getFileDownloadUrl = (owner: LightWorkspaceType, fileId: string) =>
-  `/api/w/${owner.sId}/files/${fileId}?action=download`;
+  `${getApiBaseUrl()}/api/w/${owner.sId}/files/${fileId}?action=download`;
 
 export const getFileViewUrl = (
   owner: LightWorkspaceType,
   fileId: string | null | undefined
-) => `/api/w/${owner.sId}/files/${fileId}?action=view`;
+) => `${getApiBaseUrl()}/api/w/${owner.sId}/files/${fileId}?action=view`;
 
 export function useFileProcessedContent({
   owner,


### PR DESCRIPTION
## Description

fixes: https://github.com/dust-tt/tasks/issues/6438

Fix file download redirecting to `app.dust.tt/api/...` instead of `dust.tt/api/...` in the SPA.

The four URL helper functions in `lib/swr/files.ts` (`getFileProcessedUrl`, `getProcessedFileDownloadUrl`, `getFileDownloadUrl`, `getFileViewUrl`) returned relative URLs (`/api/w/...`). When used with `window.open()` in the SPA context, these resolved against the current origin (`app.dust.tt`) instead of the API origin (`dust.tt`).

The fix prepends `getApiBaseUrl()` which returns `https://dust.tt` in the SPA and `""` in Next.js, so there's no behavior change for the Next.js app.

Affected call sites:
- `AttachmentViewer.tsx` — "Download file" button
- `FilePreviewSheet.tsx` — Download and "Open in browser" buttons
- `AttachmentCitation.tsx` — image `src` and `downloadUrl` props
- `AttachmentViewer.tsx` — `<audio src=...>` tag (latent bug)

## Tests

Manual — verify file download works from the SPA on `app.dust.tt`.

## Risk

Low. `getApiBaseUrl()` returns empty string in the Next.js context, so the URLs remain relative there (identical to current behavior). In the SPA, URLs become absolute and correctly target `dust.tt`.

## Deploy Plan

Standard deploy, no special steps needed.
