### PR TITLE
[front] - feat(agent): public endpoint YAML export

### DIFF
--- a/front/lib/api/assistant/configuration/yaml_export.ts
+++ b/front/lib/api/assistant/configuration/yaml_export.ts
@@ -1,0 +1,183 @@
+import {
+  convertActionsForFormData,
+  transformAgentConfigurationToFormData,
+} from "@app/components/agent_builder/transformAgentConfiguration";
+import {
+  buildInitialActions,
+  getAccessibleSourcesAndAppsForActions,
+} from "@app/lib/agent_builder/server_side_props_helpers";
+import { AgentYAMLConverter } from "@app/lib/agent_yaml_converter/converter";
+import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import config from "@app/lib/api/config";
+import type { Authenticator } from "@app/lib/auth";
+import { DataSourceResource } from "@app/lib/resources/data_source_resource";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import logger from "@app/logger/logger";
+import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
+import type { APIErrorWithStatusCode } from "@app/types/error";
+import type { Result } from "@app/types/shared/result";
+import { Err, Ok } from "@app/types/shared/result";
+import type { UserType } from "@app/types/user";
+
+const AGENT_NAME_SANITATION_REGEX = /[^a-zA-Z0-9-_]/g;
+
+export async function exportAgentConfigurationAsYAML(
+  auth: Authenticator,
+  agentId: string
+): Promise<
+  Result<{ yamlContent: string; filename: string }, APIErrorWithStatusCode>
+> {
+  const agentConfiguration = await getAgentConfiguration(auth, {
+    agentId,
+    variant: "full",
+  });
+
+  if (!agentConfiguration || (!agentConfiguration.canRead && !auth.isAdmin())) {
+    return new Err({
+      status_code: 404,
+      api_error: {
+        type: "agent_configuration_not_found",
+        message: "The agent configuration you requested was not found.",
+      },
+    });
+  }
+
+  if (
+    agentConfiguration.status !== "active" ||
+    agentConfiguration.scope === "global"
+  ) {
+    return new Err({
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Cannot export archived or global agents.",
+      },
+    });
+  }
+
+  const [{ dataSourceViews, mcpServerViews }, skills, editorsResult] =
+    await Promise.all([
+      getAccessibleSourcesAndAppsForActions(auth),
+      SkillResource.listByAgentConfiguration(auth, agentConfiguration),
+      GroupResource.findEditorGroupForAgent(auth, agentConfiguration),
+    ]);
+
+  const mcpServerViewsJSON = mcpServerViews.map((v) => v.toJSON());
+
+  const actions = await buildInitialActions({
+    dataSourceViews,
+    configuration: agentConfiguration,
+    mcpServerViews: mcpServerViewsJSON,
+  });
+
+  const editors: UserType[] = editorsResult.isOk()
+    ? (await editorsResult.value.getActiveMembers(auth)).map((m) => m.toJSON())
+    : [];
+
+  let slackProvider: "slack" | "slack_bot" | null = null;
+  let slackChannels: { slackChannelId: string; slackChannelName: string }[] =
+    [];
+
+  const [[slackDs], [slackBotDs]] = await Promise.all([
+    DataSourceResource.listByConnectorProvider(auth, "slack"),
+    DataSourceResource.listByConnectorProvider(auth, "slack_bot"),
+  ]);
+
+  const connectorsAPI = new ConnectorsAPI(
+    config.getConnectorsAPIConfig(),
+    logger
+  );
+
+  let slackConnectorId: string | null = null;
+  if (slackBotDs?.connectorId) {
+    const configRes = await connectorsAPI.getConnectorConfig(
+      slackBotDs.connectorId,
+      "botEnabled"
+    );
+    if (configRes.isOk() && configRes.value.configValue === "true") {
+      slackProvider = "slack_bot";
+      slackConnectorId = slackBotDs.connectorId;
+    }
+  }
+  if (!slackConnectorId && slackDs?.connectorId) {
+    slackProvider = "slack";
+    slackConnectorId = slackDs.connectorId;
+  }
+
+  if (slackConnectorId) {
+    const linkedRes = await connectorsAPI.getSlackChannelsLinkedWithAgent({
+      connectorId: slackConnectorId,
+    });
+    if (linkedRes.isOk()) {
+      slackChannels = linkedRes.value.slackChannels
+        .filter((ch) => ch.agentConfigurationId === agentConfiguration.sId)
+        .map((ch) => ({
+          slackChannelId: ch.slackChannelId,
+          slackChannelName: ch.slackChannelName,
+        }));
+    }
+  }
+
+  const baseFormData =
+    transformAgentConfigurationToFormData(agentConfiguration);
+  const formData = {
+    ...baseFormData,
+    actions: convertActionsForFormData(actions),
+    skills: skills.map((s) => {
+      const json = s.toJSON(auth);
+      return {
+        sId: json.sId,
+        name: json.name,
+        description: json.userFacingDescription,
+        icon: json.icon,
+      };
+    }),
+    agentSettings: {
+      ...baseFormData.agentSettings,
+      editors,
+      slackProvider,
+      slackChannels,
+    },
+  };
+
+  const yamlConfigResult = await AgentYAMLConverter.fromBuilderFormData(
+    auth,
+    formData
+  );
+
+  if (yamlConfigResult.isErr()) {
+    return new Err({
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: `Error converting agent configuration: ${yamlConfigResult.error.message}`,
+      },
+    });
+  }
+
+  const yamlStringResult = AgentYAMLConverter.toYAMLString(
+    yamlConfigResult.value
+  );
+
+  if (yamlStringResult.isErr()) {
+    return new Err({
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: `Error generating YAML string: ${yamlStringResult.error.message}`,
+      },
+    });
+  }
+
+  const sanitizedName = agentConfiguration.name.replace(
+    AGENT_NAME_SANITATION_REGEX,
+    "_"
+  );
+  const filename = `${sanitizedName}_agent.yaml`;
+
+  return new Ok({
+    yamlContent: yamlStringResult.value,
+    filename,
+  });
+}

--- a/front/pages/api/v1/w/[wId]/assistant/agent_configurations/[sId]/export/yaml.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/agent_configurations/[sId]/export/yaml.ts
@@ -1,0 +1,95 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import { exportAgentConfigurationAsYAML } from "@app/lib/api/assistant/configuration/yaml_export";
+import { withPublicAPIAuthentication } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import { isString } from "@app/types/shared/utils/general";
+
+/**
+ * @swagger
+ * /api/v1/w/{wId}/assistant/agent_configurations/{sId}/export/yaml:
+ *   get:
+ *     summary: Export agent configuration as YAML
+ *     description: Download the agent configuration identified by {sId} as a YAML file.
+ *     tags:
+ *       - Agents
+ *     parameters:
+ *       - in: path
+ *         name: wId
+ *         required: true
+ *         description: ID of the workspace
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: sId
+ *         required: true
+ *         description: ID of the agent configuration
+ *         schema:
+ *           type: string
+ *     security:
+ *       - BearerAuth: []
+ *     responses:
+ *       200:
+ *         description: The agent configuration as a downloadable YAML file
+ *         content:
+ *           text/yaml:
+ *             schema:
+ *               type: string
+ *         headers:
+ *           Content-Disposition:
+ *             description: Attachment with suggested filename
+ *             schema:
+ *               type: string
+ *       400:
+ *         description: Bad Request. Invalid or missing parameters.
+ *       401:
+ *         description: Unauthorized. Invalid or missing authentication token.
+ *       404:
+ *         description: Agent configuration not found.
+ *       405:
+ *         description: Method not supported. Only GET is expected.
+ *       500:
+ *         description: Internal Server Error.
+ */
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<string>>,
+  auth: Authenticator
+): Promise<void> {
+  if (req.method !== "GET") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "The method passed is not supported, GET is expected.",
+      },
+    });
+  }
+
+  const { sId } = req.query;
+  if (!isString(sId)) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: "Invalid path parameters.",
+      },
+    });
+  }
+
+  const result = await exportAgentConfigurationAsYAML(auth, sId);
+
+  if (result.isErr()) {
+    return apiError(req, res, result.error);
+  }
+
+  const { yamlContent, filename } = result.value;
+
+  res.setHeader("Content-Type", "text/yaml; charset=utf-8");
+  res.setHeader("Content-Disposition", `attachment; filename="${filename}"`);
+  return res.status(200).send(yamlContent);
+}
+
+export default withPublicAPIAuthentication(handler);

--- a/front/pages/api/v1/w/[wId]/assistant/agent_configurations/[sId]/export/yaml.ts
+++ b/front/pages/api/v1/w/[wId]/assistant/agent_configurations/[sId]/export/yaml.ts
@@ -1,3 +1,4 @@
+import type { GetAgentConfigurationYAMLExportResponseType } from "@dust-tt/client";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { exportAgentConfigurationAsYAML } from "@app/lib/api/assistant/configuration/yaml_export";
@@ -55,7 +56,9 @@ import { isString } from "@app/types/shared/utils/general";
  */
 async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<WithAPIErrorResponse<string>>,
+  res: NextApiResponse<
+    WithAPIErrorResponse<GetAgentConfigurationYAMLExportResponseType>
+  >,
   auth: Authenticator
 ): Promise<void> {
   if (req.method !== "GET") {
@@ -89,7 +92,7 @@ async function handler(
 
   res.setHeader("Content-Type", "text/yaml; charset=utf-8");
   res.setHeader("Content-Disposition", `attachment; filename="${filename}"`);
-  return res.status(200).send(yamlContent);
+  res.status(200).end(yamlContent);
 }
 
 export default withPublicAPIAuthentication(handler);

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/export/yaml.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/export/yaml.ts
@@ -1,34 +1,16 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 
-import {
-  convertActionsForFormData,
-  transformAgentConfigurationToFormData,
-} from "@app/components/agent_builder/transformAgentConfiguration";
-import {
-  buildInitialActions,
-  getAccessibleSourcesAndAppsForActions,
-} from "@app/lib/agent_builder/server_side_props_helpers";
-import { AgentYAMLConverter } from "@app/lib/agent_yaml_converter/converter";
-import { getAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import { exportAgentConfigurationAsYAML } from "@app/lib/api/assistant/configuration/yaml_export";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
-import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
-import { DataSourceResource } from "@app/lib/resources/data_source_resource";
-import { GroupResource } from "@app/lib/resources/group_resource";
-import { SkillResource } from "@app/lib/resources/skill/skill_resource";
-import logger from "@app/logger/logger";
 import { apiError } from "@app/logger/withlogging";
-import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
-import type { UserType } from "@app/types/user";
 
 export type GetAgentConfigurationYAMLExportResponseBody = {
   yamlContent: string;
   filename: string;
 };
-
-const AGENT_NAME_SANITATION_REGEX = /[^a-zA-Z0-9-_]/g;
 
 async function handler(
   req: NextApiRequest,
@@ -58,164 +40,13 @@ async function handler(
     });
   }
 
-  const agentConfiguration = await getAgentConfiguration(auth, {
-    agentId: aId,
-    variant: "full",
-  });
+  const result = await exportAgentConfigurationAsYAML(auth, aId);
 
-  if (!agentConfiguration || (!agentConfiguration.canRead && !auth.isAdmin())) {
-    return apiError(req, res, {
-      status_code: 404,
-      api_error: {
-        type: "agent_configuration_not_found",
-        message: "The agent configuration you requested was not found.",
-      },
-    });
+  if (result.isErr()) {
+    return apiError(req, res, result.error);
   }
 
-  if (
-    agentConfiguration.status !== "active" ||
-    agentConfiguration.scope === "global"
-  ) {
-    return apiError(req, res, {
-      status_code: 400,
-      api_error: {
-        type: "invalid_request_error",
-        message: "Cannot export archived or global agents.",
-      },
-    });
-  }
-
-  const [{ dataSourceViews, mcpServerViews }, skills, editorsResult] =
-    await Promise.all([
-      getAccessibleSourcesAndAppsForActions(auth),
-      SkillResource.listByAgentConfiguration(auth, agentConfiguration),
-      GroupResource.findEditorGroupForAgent(auth, agentConfiguration),
-    ]);
-
-  const mcpServerViewsJSON = mcpServerViews.map((v) => v.toJSON());
-
-  const actions = await buildInitialActions({
-    dataSourceViews,
-    configuration: agentConfiguration,
-    mcpServerViews: mcpServerViewsJSON,
-  });
-
-  // Fetch editors from the editor group.
-  let editors: UserType[] = [];
-  if (editorsResult.isOk()) {
-    const editorGroup = editorsResult.value;
-    const members = await editorGroup.getActiveMembers(auth);
-    editors = members.map((m) => m.toJSON());
-  }
-
-  // Fetch linked Slack channels for this agent.
-  let slackProvider: "slack" | "slack_bot" | null = null;
-  let slackChannels: { slackChannelId: string; slackChannelName: string }[] =
-    [];
-
-  const [[slackDs], [slackBotDs]] = await Promise.all([
-    DataSourceResource.listByConnectorProvider(auth, "slack"),
-    DataSourceResource.listByConnectorProvider(auth, "slack_bot"),
-  ]);
-
-  const connectorsAPI = new ConnectorsAPI(
-    config.getConnectorsAPIConfig(),
-    logger
-  );
-
-  // Determine which Slack connector is active.
-  let slackConnectorId: string | null = null;
-  if (slackBotDs?.connectorId) {
-    const configRes = await connectorsAPI.getConnectorConfig(
-      slackBotDs.connectorId,
-      "botEnabled"
-    );
-    if (configRes.isOk() && configRes.value.configValue === "true") {
-      slackProvider = "slack_bot";
-      slackConnectorId = slackBotDs.connectorId.toString();
-    }
-  }
-  if (!slackConnectorId && slackDs?.connectorId) {
-    slackProvider = "slack";
-    slackConnectorId = slackDs.connectorId.toString();
-  }
-
-  if (slackConnectorId) {
-    const linkedRes = await connectorsAPI.getSlackChannelsLinkedWithAgent({
-      connectorId: slackConnectorId,
-    });
-    if (linkedRes.isOk()) {
-      slackChannels = linkedRes.value.slackChannels
-        .filter((ch) => ch.agentConfigurationId === agentConfiguration.sId)
-        .map((ch) => ({
-          slackChannelId: ch.slackChannelId,
-          slackChannelName: ch.slackChannelName,
-        }));
-    }
-  }
-
-  const baseFormData =
-    transformAgentConfigurationToFormData(agentConfiguration);
-  const formData = {
-    ...baseFormData,
-    actions: convertActionsForFormData(actions),
-    skills: skills.map((s) => {
-      const json = s.toJSON(auth);
-      return {
-        sId: json.sId,
-        name: json.name,
-        description: json.userFacingDescription,
-        icon: json.icon,
-      };
-    }),
-    agentSettings: {
-      ...baseFormData.agentSettings,
-      editors,
-      slackProvider,
-      slackChannels,
-    },
-  };
-
-  const yamlConfigResult = await AgentYAMLConverter.fromBuilderFormData(
-    auth,
-    formData
-  );
-
-  if (yamlConfigResult.isErr()) {
-    return apiError(req, res, {
-      status_code: 500,
-      api_error: {
-        type: "internal_server_error",
-        message: `Error converting agent configuration: ${yamlConfigResult.error.message}`,
-      },
-    });
-  }
-
-  const yamlStringResult = AgentYAMLConverter.toYAMLString(
-    yamlConfigResult.value
-  );
-
-  if (yamlStringResult.isErr()) {
-    return apiError(req, res, {
-      status_code: 500,
-      api_error: {
-        type: "internal_server_error",
-        message: `Error generating YAML string: ${yamlStringResult.error.message}`,
-      },
-    });
-  }
-
-  const sanitizedName = agentConfiguration.name.replace(
-    AGENT_NAME_SANITATION_REGEX,
-    "_"
-  );
-  const filename = `${sanitizedName}_agent.yaml`;
-
-  return res.status(200).json({
-    yamlContent: yamlStringResult.value,
-    filename,
-  });
+  return res.status(200).json(result.value);
 }
 
 export default withSessionAuthenticationForWorkspace(handler);

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -1906,6 +1906,15 @@ export type PatchAgentConfigurationRequestType = z.infer<
   typeof PatchAgentConfigurationRequestSchema
 >;
 
+export const GetAgentConfigurationYAMLExportResponseSchema = z.object({
+  yamlContent: z.string(),
+  filename: z.string(),
+});
+
+export type GetAgentConfigurationYAMLExportResponseType = z.infer<
+  typeof GetAgentConfigurationYAMLExportResponseSchema
+>;
+
 export const GetAgentConfigurationsResponseSchema = z.object({
   agentConfigurations: LightAgentConfigurationSchema.array(),
 });

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -1906,10 +1906,7 @@ export type PatchAgentConfigurationRequestType = z.infer<
   typeof PatchAgentConfigurationRequestSchema
 >;
 
-export const GetAgentConfigurationYAMLExportResponseSchema = z.object({
-  yamlContent: z.string(),
-  filename: z.string(),
-});
+export const GetAgentConfigurationYAMLExportResponseSchema = z.string();
 
 export type GetAgentConfigurationYAMLExportResponseType = z.infer<
   typeof GetAgentConfigurationYAMLExportResponseSchema


### PR DESCRIPTION
## Description

This PR adds a public API endpoint for exporting agent configurations as YAML. The change extracts the YAML export logic into a reusable service (`yaml_export.ts`) that is now shared between the existing session-authenticated private endpoint and the new public API endpoint at `/api/v1/w/[wId]/assistant/agent_configurations/[sId]/export/yaml`. The new endpoint uses `withPublicAPIAuthentication` for bearer token authentication and returns the YAML file with appropriate headers for download.

## Risk

The refactoring consolidates duplicated code by moving logic into a centralized service, which could impact existing YAML export functionality. However, the private endpoint's behavior should remain unchanged as it now delegates to the same service logic.

## Tests

- [x] Locally

## Deploy 

Deploy front
