### PR TITLE
Fix React warning: Received  for a non-boolean attribute

### DIFF
--- a/front-spa/src/lib/ReactRouterLinkWrapper.tsx
+++ b/front-spa/src/lib/ReactRouterLinkWrapper.tsx
@@ -7,7 +7,10 @@ import url from "url";
 export const ReactRouterLinkWrapper = forwardRef<
   HTMLAnchorElement,
   SparkleLinkProps
->(function ReactRouterLinkWrapper({ href, children, ...props }, ref) {
+>(function ReactRouterLinkWrapper(
+  { href, children, shallow: _shallow, replace, prefetch: _prefetch, ...props },
+  ref
+) {
   // Convert UrlObject to string if needed
   const hrefString = typeof href !== "string" ? url.format(href) : href;
 
@@ -25,7 +28,7 @@ export const ReactRouterLinkWrapper = forwardRef<
   }
 
   return (
-    <Link ref={ref} to={hrefString} {...props}>
+    <Link ref={ref} to={hrefString} replace={replace} {...props}>
       {children}
     </Link>
   );


### PR DESCRIPTION
## Description

- Fix React warning `Received 'true' for a non-boolean attribute 'shallow'` on `/conversation/new`.
- `shallow` and `prefetch` are Next.js-specific `<Link>` props with no equivalent in React Router — they were leaking through `...props` onto native `<a>` and React Router `<Link>` elements where they have no effect.
- `replace` is valid for both Next.js and React Router `<Link>`, so it's now passed explicitly to `<Link>` while being excluded from the `<a>` fallback.
- The Next.js `NextLinkWrapper` used by `front/` is untouched — this change is SPA-only.

<img width="561" height="747" alt="Screenshot 2026-02-12 at 10 59 51" src="https://github.com/user-attachments/assets/11a2e33d-1e86-4daa-98bc-844a9e1dce4a" />


## Tests

Locally. 

## Risk

This change is SPA-only so contained to our workspace. 
Can be rolled back. 

## Deploy Plan

Deploy front-spa.