### PR TITLE
fix: select projects as datasource

### DIFF
--- a/front/lib/agent_builder/server_side_props_helpers.ts
+++ b/front/lib/agent_builder/server_side_props_helpers.ts
@@ -36,7 +36,9 @@ export const getAccessibleSourcesAndAppsForActions = async (
 ) => {
   return tracer.trace("getAccessibleSourcesAndAppsForActions", async () => {
     const accessibleSpaces = (
-      await SpaceResource.listWorkspaceSpaces(auth)
+      await SpaceResource.listWorkspaceSpaces(auth, {
+        includeProjectSpaces: true,
+      })
     ).filter((space) => !space.isSystem() && space.canRead(auth));
 
     const [dsViews, allMCPServerViews] = await Promise.all([


### PR DESCRIPTION
## Description

This PR fixes the selection of projects as datasources in the agent builder by including project spaces in the workspace spaces list.
Previously loading an agent with a project selected as a datasource would raise an error.

- Updated `listWorkspaceSpaces` call in `getAccessibleSourcesAndAppsForActions` to include `includeProjectSpaces: true` parameter

## Tests

Manually

## Risks

Low risk. The change only adds project spaces to the list of accessible spaces, which should not break existing functionality.

## Deploy Plan

Standard deployment.
