### PR TITLE
fix: cell width when project already requested

### DIFF
--- a/front/components/agent_builder/capabilities/capabilities_sheet/SpaceSelectionPage.tsx
+++ b/front/components/agent_builder/capabilities/capabilities_sheet/SpaceSelectionPage.tsx
@@ -153,7 +153,7 @@ export function SpaceSelectionPageContent({
               <div className="flex flex-row items-center justify-between gap-3">
                 <div className="flex flex-row items-center gap-3 min-w-0">
                   <SpaceIcon className="h-5 w-5 min-h-5 min-w-5 text-muted-foreground dark:text-muted-foreground-night" />
-                  <div className="flex flex-col min-w-0">
+                  <div className="flex flex-col items-start min-w-0">
                     <span className="text-sm font-medium text-foreground dark:text-foreground-night truncate">
                       {row.original.name}
                     </span>
@@ -175,11 +175,13 @@ export function SpaceSelectionPageContent({
 
           if (row.original.isAlreadyRequested) {
             return (
-              <Tooltip
-                label="Used by other resources"
-                side="right"
-                trigger={cellContent}
-              />
+              <div className="[&>button]:w-full">
+                <Tooltip
+                  label="Used by other resources"
+                  side="right"
+                  trigger={cellContent}
+                />
+              </div>
             );
           }
 


### PR DESCRIPTION






## Description

This PR fixes a cell width issue in the Space Selection UI when a project has already been requested.

Before
<img width="673" height="469" alt="Capture d’écran 2026-02-12 à 11 41 18" src="https://github.com/user-attachments/assets/8b2d9f41-6cd6-4dd7-8eea-c5e6e24f2223" />

After
<img width="673" height="469" alt="Capture d’écran 2026-02-12 à 11 37 30" src="https://github.com/user-attachments/assets/017857f1-51ef-4107-8efd-6fc9cb416a4c" />

## Tests

Manually

## Risks

Low - UI-only change.

## Deploy Plan

Standard deployment.
