### PR TITLE
[front] - fix(SB): instructions deletions

### DIFF
--- a/front/components/skill_builder/SkillBuilder.tsx
+++ b/front/components/skill_builder/SkillBuilder.tsx
@@ -96,7 +96,7 @@ export default function SkillBuilder({
     const result = await submitSkillBuilderForm({
       formData: data,
       owner,
-      skillId: !isCreatingNew ? skill?.sId : undefined,
+      skillId: skill?.sId,
       currentEditors: editors,
     });
 


### PR DESCRIPTION
## Description

The skill builder's "guidelines" field wasn't persisting on save because useController's `field.onChange` is an unstable reference that changes every render, causing the debounced form update to be silently cancelled. This PR fixes it by replacing `field.onChange` with `setValue` from `useFormContext` (a stable reference) and passing `{ shouldDirty: true } `so the form correctly tracks changes.

**References:**

- Partially or fully fixes https://github.com/dust-tt/tasks/issues/6492

## Tests

Locally

## Risk

Medium - might break other things

## Deploy Plan

Deploy front
