### PR TITLE
[front] - fix(SB): skill mutation

### DIFF
--- a/front/components/pages/builder/skills/CreateSkillPage.tsx
+++ b/front/components/pages/builder/skills/CreateSkillPage.tsx
@@ -11,12 +11,15 @@ export function CreateSkillPage() {
   const { user } = useAuth();
   const extendsParam = useSearchParam("extends");
 
-  const { skill: extendedSkillData, isSkillLoading: isExtendedSkillLoading } =
-    useSkill({
-      workspaceId: owner.sId,
-      skillId: extendsParam,
-      disabled: !extendsParam,
-    });
+  const {
+    skill: extendedSkillData,
+    isSkillLoading: isExtendedSkillLoading,
+    mutateSkill,
+  } = useSkill({
+    workspaceId: owner.sId,
+    skillId: extendsParam,
+    disabled: !extendsParam,
+  });
 
   if (extendsParam && isExtendedSkillLoading) {
     return (
@@ -35,7 +38,10 @@ export function CreateSkillPage() {
       <Head>
         <title>Dust - New Skill</title>
       </Head>
-      <SkillBuilder extendedSkill={extendedSkill ?? undefined} />
+      <SkillBuilder
+        extendedSkill={extendedSkill ?? undefined}
+        onSaved={mutateSkill}
+      />
     </SkillBuilderProvider>
   );
 }

--- a/front/components/pages/builder/skills/EditSkillPage.tsx
+++ b/front/components/pages/builder/skills/EditSkillPage.tsx
@@ -12,7 +12,7 @@ export function EditSkillPage() {
   const { user } = useAuth();
   const skillId = useRequiredPathParam("sId");
 
-  const { skill, isSkillLoading, isSkillError } = useSkill({
+  const { skill, isSkillLoading, isSkillError, mutateSkill } = useSkill({
     workspaceId: owner.sId,
     skillId,
     withRelations: true,
@@ -43,6 +43,7 @@ export function EditSkillPage() {
       <SkillBuilder
         skill={skill}
         extendedSkill={skill.relations?.extendedSkill ?? undefined}
+        onSaved={mutateSkill}
       />
     </SkillBuilderProvider>
   );

--- a/front/components/skill_builder/SkillBuilder.tsx
+++ b/front/components/skill_builder/SkillBuilder.tsx
@@ -39,11 +39,13 @@ import type { SkillType } from "@app/types/assistant/skill_configuration";
 interface SkillBuilderProps {
   skill?: SkillType;
   extendedSkill?: SkillType;
+  onSaved: () => void;
 }
 
 export default function SkillBuilder({
   skill,
   extendedSkill,
+  onSaved,
 }: SkillBuilderProps) {
   const { owner, user } = useSkillBuilderContext();
   const router = useAppRouter();
@@ -117,6 +119,8 @@ export default function SkillBuilder({
         : "Your skill has been successfully updated.",
       type: "success",
     });
+
+    onSaved();
 
     if (isCreatingNew && result.value.sId) {
       const newUrl = `/w/${owner.sId}/builder/skills/${result.value.sId}`;


### PR DESCRIPTION
## Description

This PR passes the `mutateSkill` method to the `<SkillBuilder>` component to enable skill data refetching

**References:**
- Fully fixes https://github.com/dust-tt/tasks/issues/6492

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front
