### PR TITLE
feat: move logo to the botton of emails

### DIFF
--- a/front/lib/notifications/email-templates/_layout.tsx
+++ b/front/lib/notifications/email-templates/_layout.tsx
@@ -22,7 +22,15 @@ export const EmailLayout = ({
           padding: "20px",
         }}
       >
-        <div style={{ width: "100%", textAlign: "left", marginBottom: "30px" }}>
+        <div
+          style={{
+            maxWidth: "600px",
+            backgroundColor: "#ffffff",
+          }}
+        >
+          {children}
+        </div>
+        <div style={{ width: "100%", textAlign: "left", marginTop: "20px" }}>
           <a
             href={process.env.NEXT_PUBLIC_DUST_CLIENT_FACING_URL}
             target="_new"
@@ -35,14 +43,6 @@ export const EmailLayout = ({
               src="https://dust.tt/static/landing/logos/dust/Dust_Logo.png"
             />
           </a>
-        </div>
-        <div
-          style={{
-            maxWidth: "600px",
-            backgroundColor: "#ffffff",
-          }}
-        >
-          {children}
         </div>
         <div
           style={{

--- a/front/lib/notifications/workflows/project-new-conversation.ts
+++ b/front/lib/notifications/workflows/project-new-conversation.ts
@@ -157,9 +157,9 @@ const shouldSkipConversation = async ({
       conversationResource.id
     );
 
-  const isRead = !!lastReadAt && lastReadAt > conversationResource.updatedAt;
+  const hasBeenOpened = !!lastReadAt;
 
-  if (isRead) {
+  if (hasBeenOpened) {
     return true;
   }
 


### PR DESCRIPTION





## Description

Fixes https://github.com/dust-tt/tasks/issues/6432
This PR moves the Dust logo from the top to the bottom of notification emails.

Moreover the skip condition for the project new conversation notification has been changed so that the notification is skipped if the conversation has already been opened once.

<img width="655" height="408" alt="Capture d’écran 2026-02-12 à 13 48 02" src="https://github.com/user-attachments/assets/4c36bc09-1f2d-479d-ba20-37f8105fb9a1" />

## Tests

Manually

## Risks

Low risk. 

## Deploy Plan

Standard deployment. 