### PR TITLE
[sparkle] - fix: prop forwarding

### DIFF
--- a/sparkle/src/context.tsx
+++ b/sparkle/src/context.tsx
@@ -42,15 +42,27 @@ export type SparkleContextType = {
 export const aLink: SparkleContextLinkType = React.forwardRef<
   HTMLAnchorElement,
   SparkleLinkProps
->(({ href, children, ...props }, ref) => {
-  const hrefAsString = typeof href !== "string" ? url.format(href) : href;
+>(
+  (
+    {
+      href,
+      children,
+      replace: _replace,
+      shallow: _shallow,
+      prefetch: _prefetch,
+      ...rest
+    },
+    ref
+  ) => {
+    const hrefAsString = typeof href !== "string" ? url.format(href) : href;
 
-  return (
-    <a ref={ref} href={hrefAsString} {...props}>
-      {children}
-    </a>
-  );
-});
+    return (
+      <a ref={ref} href={hrefAsString} {...rest}>
+        {children}
+      </a>
+    );
+  }
+);
 
 export const noHrefLink: SparkleContextLinkType = React.forwardRef<
   HTMLAnchorElement,


### PR DESCRIPTION
## Description

This PR fixes a console error due to a wrongly forward ref:

<details>

<summary>Error log</summary>

```
  installHook.js:1 Warning: Received `true` for a non-boolean attribute `shallow`.

  If you want to write it to the DOM, pass a string instead: shallow="true" or shallow={value.toString()}. Error Component Stack
      at a (<anonymous>)
      at context.tsx:45:6
      at LinkWrapper.tsx:22:7
      at div (<anonymous>)
      at NavigationList.tsx:94:7
      at SidebarMenu.tsx:778:5
      at div (<anonymous>)
      at div (<anonymous>)
      at NavigationList.tsx:381:7
      at InboxConversationList (SidebarMenu.tsx:674:3)
      at div (<anonymous>)
      at SidebarMenu.tsx:908:7
      at div (<anonymous>)
      at div (<anonymous>)
      at div (<anonymous>)
      at AgentSidebarMenu (SidebarMenu.tsx:111:36)
      at div (<anonymous>)
      at div (<anonymous>)
      at NavigationSidebar2 (NavigationSidebar.tsx:49:5)
      at div (<anonymous>)
      at div (<anonymous>)
      at div (<anonymous>)
      at Navigation (Navigation.tsx:38:3)
      at div (<anonymous>)
      at AppContentLayout (AppContentLayout.tsx:68:3)
      at ManageSkillsPage (ManageSkillsPage.tsx:77:17)
      at Suspense (<anonymous>)
      at SuspenseWrapper (<anonymous>)
      at RenderedRoute (react-router-dom.js?v=2aa889a7:6301:26)
      at Outlet (react-router-dom.js?v=2aa889a7:7082:26)
      at DesktopNavigationProvider (DesktopNavigationContext.tsx:25:3)
      at WelcomeTourGuideProvider (WelcomeTourGuideProvider.tsx:13:3)
      at ThemeProvider (ThemeContext.tsx:94:33)
      at AppRootLayout (AppRootLayout.tsx:21:3)
      at AppAuthContextLayout (AppAuthContextLayout.tsx:12:3)
      at WorkspacePage (WorkspacePage.tsx:13:33)
      at RenderedRoute (react-router-dom.js?v=2aa889a7:6301:26)
      at RenderErrorBoundary (react-router-dom.js?v=2aa889a7:6211:5)
      at DataRoutes (react-router-dom.js?v=2aa889a7:6999:3)
      at Router (react-router-dom.js?v=2aa889a7:7091:13)
      at RouterProvider (react-router-dom.js?v=2aa889a7:6765:11)
      at RouterProvider2 (<anonymous>)
      at Area (Notification.tsx:96:12)
      at ConfirmPopupArea (Confirm.tsx:25:36)
      at NavigationLoadingProvider (NavigationLoadingContext.tsx:24:3)
      at SidebarProvider (SidebarContext.tsx:18:3)
      at SWRConfig (chunk-NW3FA2SP.js?v=2aa889a7:455:11)
      at RootLayout (RootLayout.tsx:16:3)
      at RegionProvider (RegionContext.tsx:43:34)
      at AppReadyProvider (AppReadyContext.tsx:18:36)
      at App (<anonymous>)
```

</details>

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front