### PR TITLE
[front] - fix(agents): mutate edited agent

### DIFF
--- a/front/components/agent_builder/AgentBuilder.tsx
+++ b/front/components/agent_builder/AgentBuilder.tsx
@@ -97,6 +97,7 @@ interface AgentBuilderProps {
   // TODO(copilot 2026-02-10): hack to allow copilot to access draft templates, remove once done iterating on copilot template instructions.
   copilotTemplateId?: string | null;
   conversationId?: string;
+  onSaved?: () => void;
 }
 
 export default function AgentBuilder({
@@ -104,6 +105,7 @@ export default function AgentBuilder({
   duplicateAgentId,
   copilotTemplateId,
   conversationId,
+  onSaved,
 }: AgentBuilderProps) {
   const { owner, user, assistantTemplate } = useAgentBuilderContext();
   const { supportedDataSourceViews } = useDataSourceViewsContext();
@@ -423,6 +425,7 @@ export default function AgentBuilder({
 
       // Mutate triggers and actions to refresh from backend
       await Promise.all([mutateTriggers(), mutateActions()]);
+      onSaved?.();
 
       if (isCreatingNew && createdAgent.sId) {
         const newUrl = `/w/${owner.sId}/builder/agents/${createdAgent.sId}?showCreatedDialog=1`;

--- a/front/components/pages/builder/agents/EditAgentPage.tsx
+++ b/front/components/pages/builder/agents/EditAgentPage.tsx
@@ -16,6 +16,7 @@ export function EditAgentPage() {
     agentConfiguration,
     isAgentConfigurationLoading,
     isAgentConfigurationError,
+    mutateAgentConfiguration,
   } = useAgentConfiguration({
     workspaceId: owner.sId,
     agentConfigurationId: agentId,
@@ -52,7 +53,10 @@ export function EditAgentPage() {
       isAdmin={isAdmin}
       assistantTemplate={null}
     >
-      <AgentBuilder agentConfiguration={agentConfiguration} />
+      <AgentBuilder
+        agentConfiguration={agentConfiguration}
+        onSaved={mutateAgentConfiguration}
+      />
     </AgentBuilderProvider>
   );
 }


### PR DESCRIPTION

## Description

This PR integrates `onSaved` callback in the `EditAgentPage` component to trigger a re-fetch of the agent configuration data after saving changes

## Tests

Locally

## Risk

Low

## Deploy Plan

Deploy front
