### PR TITLE
feat: improve prompt to hint the model to look into the project first

### DIFF
--- a/front/lib/api/actions/servers/project_manager/metadata.ts
+++ b/front/lib/api/actions/servers/project_manager/metadata.ts
@@ -92,11 +92,13 @@ export const PROJECT_MANAGER_TOOLS_METADATA = createToolsRecord({
   },
   edit_description: {
     description:
-      "Edit the project description. This updates the project's description text.",
+      "Edit the project description. Only plain text is accepted (no markdown, HTML, or formatting). Descriptions should be brief and concise.",
     schema: {
       description: z
         .string()
-        .describe("New project description (free-form text)."),
+        .describe(
+          "New project description. Must be plain text only (no markdown, HTML, or other formatting). Keep it brief and concise: 1-2 short sentences max."
+        ),
       dustProject:
         ConfigurableToolInputSchemas[
           INTERNAL_MIME_TYPES.TOOL_INPUT.DUST_PROJECT

--- a/front/lib/api/assistant/generation.test.ts
+++ b/front/lib/api/assistant/generation.test.ts
@@ -88,6 +88,13 @@ This conversation is associated with a project. The project provides:
 - Locate specific content across multiple files
 - Answer questions based on project knowledge
 
+## Tool Usage Priority
+
+When answering questions that require searching for information, follow this priority order:
+1. **First**, use \`search_project_context\` to search within the project's files. Project context is the most relevant source of information for this conversation.
+2. **Second**, use \`project_manager\` to gather more context on the project.
+2. **Then**, if the project context is insufficient, use \`company_data_*\` tools and \`search\` to search across the broader company data sources.
+
 ## Project Files vs Conversation Attachments
 - **Project files**: Persistent, shared across all conversations in the project, managed via project_manager
 - **Conversation attachments**: Scoped to this conversation only, temporary context for the current discussion

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -3,12 +3,14 @@ import moment from "moment-timezone";
 import {
   DEFAULT_CONVERSATION_QUERY_TABLES_ACTION_NAME,
   DEFAULT_CONVERSATION_SEARCH_ACTION_NAME,
+  DEFAULT_PROJECT_SEARCH_ACTION_NAME,
   ENABLE_SKILL_TOOL_NAME,
   TOOL_NAME_SEPARATOR,
 } from "@app/lib/actions/constants";
 import type { ServerToolsAndInstructions } from "@app/lib/actions/mcp_actions";
 import {
   INTERNAL_SERVERS_WITH_WEBSEARCH,
+  SEARCH_SERVER_NAME,
   SKILL_MANAGEMENT_SERVER_NAME,
 } from "@app/lib/actions/mcp_internal_actions/constants";
 import {
@@ -16,6 +18,7 @@ import {
   isServerSideMCPServerConfigurationWithName,
 } from "@app/lib/actions/types/guards";
 import { CONVERSATION_CAT_FILE_ACTION_NAME } from "@app/lib/api/actions/servers/conversation_files/metadata";
+import { PROJECT_MANAGER_SERVER_NAME } from "@app/lib/api/actions/servers/project_manager/metadata";
 import { citationMetaPrompt } from "@app/lib/api/assistant/citations";
 import type {
   SystemPromptContext,
@@ -83,7 +86,6 @@ export function constructProjectContextSection(
   if (!conversation?.spaceId) {
     return null;
   }
-
   return `# PROJECT CONTEXT
 
 This conversation is associated with a project. The project provides:
@@ -95,10 +97,17 @@ This conversation is associated with a project. The project provides:
 ## Using Project Tools
 
 **project_manager**: Use these tools to manage persistent project files, metadata, and conversations
-**search_project_context**: Use this tool to semantically search across all project files when you need to:
+**${DEFAULT_PROJECT_SEARCH_ACTION_NAME}**: Use this tool to semantically search across all project files when you need to:
 - Find relevant information within the project
 - Locate specific content across multiple files
 - Answer questions based on project knowledge
+
+## Tool Usage Priority
+
+When answering questions that require searching for information, follow this priority order:
+1. **First**, use \`${DEFAULT_PROJECT_SEARCH_ACTION_NAME}\` to search within the project's files. Project context is the most relevant source of information for this conversation.
+2. **Second**, use \`${PROJECT_MANAGER_SERVER_NAME}\` to gather more context on the project.
+2. **Then**, if the project context is insufficient, use \`company_data_*\` tools and \`${SEARCH_SERVER_NAME}\` to search across the broader company data sources.
 
 ## Project Files vs Conversation Attachments
 - **Project files**: Persistent, shared across all conversations in the project, managed via project_manager


### PR DESCRIPTION
## Description

This PR does 2 things:
* improve prompt so models are hinted to use project MCP tools in priority
* improve tool on description to hint for non formatted text, and brief

Closes: 
* https://github.com/orgs/dust-tt/projects/3/views/12?pane=issue&itemId=156555059&issue=dust-tt%7Ctasks%7C6506
* https://github.com/orgs/dust-tt/projects/3/views/12?pane=issue&itemId=156551033&issue=dust-tt%7Ctasks%7C6504
## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
