### PR TITLE
[Front] fix(copilot): prevent hash param changes from triggering unsaved changes dialog

### DIFF
--- a/front/hooks/useHashParams.ts
+++ b/front/hooks/useHashParams.ts
@@ -106,14 +106,7 @@ export const useHashParam = (
         const newUrl = `${pathname}${search}${hash ? `#${hash}` : ""}`;
 
         if (innerValue.options.history === "replace") {
-          void router
-            .replace(newUrl, undefined, { shallow: true })
-            .catch((e) => {
-              // workaround for https://github.com/vercel/next.js/issues/37362
-              if (!e.cancelled) {
-                throw e;
-              }
-            });
+          window.history.replaceState(window.history.state, "", newUrl);
         } else {
           void router.push(newUrl);
         }


### PR DESCRIPTION
## Description

Opening the copilot tool breakdown side panel ("Completed in N seconds") incorrectly triggers the "You have unsaved changes" dialog in Agent Builder.

### Problem

`useHashParam` used `router.replace()` for hash param URL updates, going through the full Next.js/React Router routing stack and triggering both navigation blocking mechanisms in `useNavigationLock` (`routeChangeStart` + `useBlocker`).

See: https://github.com/dust-tt/tasks/issues/6491

### Solution

Replace `router.replace()` with `window.history.replaceState()` for the `replace` history mode (default, used by all call sites except pagination). `router.push()` is kept for the `push` history mode (pagination only) to preserve correct back/forward behavior.

## Tests

Tested both on SPA and Next.js :

![Screen Recording 2026-02-12 at 16 05 42](https://github.com/user-attachments/assets/d8c39c80-ce4b-4eac-93bf-8c07b2f34176)

## Risk

**Scope:** Only affects `replace` history mode in `useHashParam` — copilot side panel, frame fullscreen, space view type toggle, skills/agents/browser tab switching.

**Rollback safety:** Safe to revert.