### PR TITLE
Skill builder: only display the Slash extension menu if the editor has been focused

### DIFF
--- a/front/components/editor/extensions/skill_builder/SlashCommandExtension.tsx
+++ b/front/components/editor/extensions/skill_builder/SlashCommandExtension.tsx
@@ -43,6 +43,19 @@ export const SlashCommandExtension =
   Extension.create<SlashCommandExtensionOptions>({
     name: "slashCommand",
 
+    addStorage() {
+      return {
+        // Tracks whether the editor has been focused at least once by the user.
+        // This prevents the slash command dropdown from triggering when content
+        // ending with "/" is loaded programmatically via setContent on mount.
+        hasBeenFocused: false,
+      };
+    },
+
+    onFocus() {
+      this.storage.hasBeenFocused = true;
+    },
+
     addOptions() {
       return {
         suggestion: {
@@ -68,10 +81,13 @@ export const SlashCommandExtension =
     },
 
     addProseMirrorPlugins() {
+      const extensionStorage = this.storage;
+
       return [
         Suggestion({
           editor: this.editor,
           ...this.options.suggestion,
+          allow: () => extensionStorage.hasBeenFocused,
           command: ({ editor, range, props }) => {
             if (props.action === INSERT_KNOWLEDGE_NODE_ACTION) {
               editor


### PR DESCRIPTION
## Description

closes https://github.com/dust-tt/tasks/issues/6490

When opening the agent builder with the menu open it freezes the whole UI

## Tests

tested manually locally by saving an agent ending with `/` 

## Risk

low

## Deploy Plan

deploy front
