### PR TITLE
Skill builder: fix the slash behaviour to search knowledge

### DIFF
--- a/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
+++ b/front/components/skill_builder/SkillBuilderInstructionsEditor.tsx
@@ -205,12 +205,19 @@ export function SkillBuilderInstructionsEditor({
     });
   }, [editor, displayError]);
 
+  // Sync external changes to the editor content
   useEffect(() => {
     if (!editor || instructionsField.value === undefined) {
       return;
     }
 
-    if (editor.isFocused) {
+    // Skip if the editor or any of its node views (e.g. knowledge search input)
+    // currently have focus — the editor itself is the source of this change.
+    if (
+      editor.isFocused ||
+      // KnowledgeSearchComponent is a sibling of the editor view in the DOM
+      editor.view.dom.parentElement?.contains(document.activeElement)
+    ) {
       return;
     }
     const currentContent = editor.getMarkdown();


### PR DESCRIPTION
## Description

Issue: the knowledge box automatically disappears from the skill builder when added from the slash command

https://github.com/user-attachments/assets/4a66da8f-524e-4a4c-a249-dee3809ea203

Fix

https://github.com/user-attachments/assets/8c197ed2-369c-4e25-9b0b-60d47d3d0d4a


## Tests

manual test locally

## Risk

low

## Deploy Plan

deploy front
