### PR TITLE
fix(sdk): break reconnection loop on empty stream closures

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61604,7 +61604,7 @@
     },
     "sdks/js": {
       "name": "@dust-tt/client",
-      "version": "1.2.5",
+      "version": "1.2.6",
       "license": "ISC",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/sdks/js/package.json
+++ b/sdks/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dust-tt/client",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "Client for Dust API",
   "repository": {
     "type": "git",

--- a/sdks/js/src/index.ts
+++ b/sdks/js/src/index.ts
@@ -1115,6 +1115,7 @@ export class DustAPI {
         }
 
         let pendingEvents: AgentEvent[] = [];
+        let receivedEventsInThisConnection = false;
 
         const parser = createParser((event) => {
           if (event.type === "event") {
@@ -1157,6 +1158,7 @@ export class DustAPI {
 
               for (const event of pendingEvents) {
                 yield event;
+                receivedEventsInThisConnection = true;
 
                 if (terminalEventTypes.includes(event.type)) {
                   receivedTerminalEvent = true;
@@ -1188,13 +1190,16 @@ export class DustAPI {
 
         // Stream ended - check if we need to reconnect
         if (!receivedTerminalEvent && autoReconnect) {
-          // Only increment reconnect attempts for actual errors, not clean closures (pagination).
-          if (streamEndedWithError) {
+          if (streamEndedWithError || !receivedEventsInThisConnection) {
+            // Increment on errors AND empty clean closures (stale/finished stream).
             reconnectAttempts += 1;
+          } else {
+            // Successful connection with events: reset counter (like EventSource onopen).
+            reconnectAttempts = 0;
+          }
 
-            if (reconnectAttempts >= maxReconnectAttempts) {
-              throw new Error("Exceeded maximum reconnection attempts");
-            }
+          if (reconnectAttempts >= maxReconnectAttempts) {
+            throw new Error("Exceeded maximum reconnection attempts");
           }
 
           await new Promise((resolve) => setTimeout(resolve, reconnectDelay));


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

  - Track whether events were received per connection in `streamAgentMessageEvents`
  - Increment `reconnectAttempts` on empty clean closures (stale/finished stream) — previously only errors incremented, causing an infinite loop
  - Reset `reconnectAttempts` on clean closures that delivered events (mirrors EventSource `onopen` behavior)

Should fix https://github.com/dust-tt/dust/issues/15131 🤞 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Deploy SDK version, merge CLI PR, deploy CLI.