### PR TITLE
Don't always check last editor

### DIFF
--- a/front/lib/resources/group_space_editor_resource.ts
+++ b/front/lib/resources/group_space_editor_resource.ts
@@ -151,10 +151,11 @@ export class GroupSpaceEditorResource extends GroupSpaceBaseResource {
 
   async canRemoveMember(
     auth: Authenticator,
-    _userId: string
+    _userId: string,
+    skipCheckLastMember?: boolean
   ): Promise<boolean> {
     const editorsCount = await this.group.getMemberCount(auth);
-    if (editorsCount <= 1) {
+    if (!skipCheckLastMember && editorsCount <= 1) {
       return false;
     }
     const requestedPermissions = await this.requestedPermissions();

--- a/front/lib/resources/group_space_member_resource.ts
+++ b/front/lib/resources/group_space_member_resource.ts
@@ -146,7 +146,11 @@ export class GroupSpaceMemberResource extends GroupSpaceBaseResource {
     return auth.canWrite(requestedPermissions);
   }
 
-  async canRemoveMember(auth: Authenticator, userId: string): Promise<boolean> {
+  async canRemoveMember(
+    auth: Authenticator,
+    userId: string,
+    _skipCheckLastMember?: boolean
+  ): Promise<boolean> {
     if (this.space.isProject()) {
       const currentUser = auth.getNonNullableUser();
       if (userId === currentUser.sId) {

--- a/front/lib/resources/group_space_resource.ts
+++ b/front/lib/resources/group_space_resource.ts
@@ -36,7 +36,9 @@ export abstract class GroupSpaceBaseResource extends BaseResource<GroupSpaceMode
   abstract canAddMember(auth: Authenticator, userId: string): Promise<boolean>;
   abstract canRemoveMember(
     auth: Authenticator,
-    userId: string
+    userId: string,
+    /** If true, removing the last member of the group is allowed (useful when we add and remove member at the same time) */
+    skipCheckLastMember?: boolean
   ): Promise<boolean>;
 
   /**
@@ -172,7 +174,8 @@ export abstract class GroupSpaceBaseResource extends BaseResource<GroupSpaceMode
     );
     const canRemoveResults = await concurrentExecutor(
       membersToRemove,
-      async (user) => this.canRemoveMember(auth, user.sId),
+      async (user) =>
+        this.canRemoveMember(auth, user.sId, !!membersToAdd.length),
       { concurrency: 8 }
     );
     if (

--- a/front/lib/resources/group_space_viewer_resource.ts
+++ b/front/lib/resources/group_space_viewer_resource.ts
@@ -134,7 +134,8 @@ export class GroupSpaceViewerResource extends GroupSpaceBaseResource {
 
   async canRemoveMember(
     _auth: Authenticator,
-    _userId: string
+    _userId: string,
+    _skipCheckLastMember?: boolean
   ): Promise<boolean> {
     // No one can remove members from the viewer group except through system processes
     return false;


### PR DESCRIPTION
## Description

When updating project editors by adding and removing editors in a single operation, the system was incorrectly preventing the removal of the last editor even when new editors were being added simultaneously. This PR introduces a `skipCheckLastMember` parameter to `canRemoveMember` methods that bypasses the "last editor" check when editors are being added and removed concurrently.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Deploy front
