### PR TITLE
[RUNNER] Add utf8 header in openai client

### DIFF
--- a/front/lib/api/llm/clients/openai/index.ts
+++ b/front/lib/api/llm/clients/openai/index.ts
@@ -48,6 +48,9 @@ export class OpenAIResponsesLLM extends LLM {
     this.client = new OpenAI({
       apiKey: OPENAI_API_KEY,
       baseURL: OPENAI_BASE_URL ?? "https://api.openai.com/v1",
+      defaultHeaders: {
+        "Content-Type": "application/json; charset=utf-8",
+      },
     });
   }
 


### PR DESCRIPTION
## Description

We get tool arguments validation errors because of corrupted unicode characters likely sent by openai api.
Could not repro locally, trying with this header to see how it goes

## Tests

Checked that gpt models still worked with that param

## Risk

low

## Deploy Plan

front
