### PR TITLE
Fix remote server errors

### DIFF
--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -393,19 +393,14 @@ export async function connectToMCPServer(
                   )
                 );
               } else if (connectionType === "workspace") {
-                // For workspace connection, only show "admin needs to setup" if connection was never created.
-                // If it's an access token error (expired/revoked token), pass through to trigger re-auth.
-                if (c.error.message === "connection_not_found") {
-                  return new Err(
-                    new MCPServerRequiresAdminAuthenticationError(
-                      params.mcpServerId,
-                      remoteMCPServer.authorization.provider,
-                      scope
-                    )
-                  );
-                }
-                // For other errors (like mcp_access_token_error), pass through to trigger re-auth
-                return c;
+                // For platform actions, we return an error to display a message to the user saying that the server requires the admin to setup the connection.
+                return new Err(
+                  new MCPServerRequiresAdminAuthenticationError(
+                    params.mcpServerId,
+                    remoteMCPServer.authorization.provider,
+                    scope
+                  )
+                );
               } else {
                 assertNever(connectionType);
               }

--- a/front/lib/actions/mcp_metadata.ts
+++ b/front/lib/actions/mcp_metadata.ts
@@ -365,14 +365,17 @@ export async function connectToMCPServer(
 
               if (connectionType === "personal") {
                 // Check if admin connection exists for the server.
-                const adminConnection = await getConnectionForMCPServer(auth, {
-                  mcpServerId: params.mcpServerId,
-                  connectionType: "workspace",
-                });
+                // We only check if the connection resource exists (not if the token is valid)
+                // because for personal_actions we just need to know if admin setup is done.
+                const adminConnectionRes =
+                  await MCPServerConnectionResource.findByMCPServer(auth, {
+                    mcpServerId: params.mcpServerId,
+                    connectionType: "workspace",
+                  });
                 // If no admin connection exists, return an error to display a message to the user saying that the server requires the admin to setup the connection.
                 if (
-                  adminConnection.isErr() &&
-                  adminConnection.error.message === "connection_not_found"
+                  adminConnectionRes.isErr() &&
+                  adminConnectionRes.error.message === "connection_not_found"
                 ) {
                   return new Err(
                     new MCPServerRequiresAdminAuthenticationError(
@@ -390,14 +393,19 @@ export async function connectToMCPServer(
                   )
                 );
               } else if (connectionType === "workspace") {
-                // For platform actions, we return an error to display a message to the user saying that the server requires the admin to setup the connection.
-                return new Err(
-                  new MCPServerRequiresAdminAuthenticationError(
-                    params.mcpServerId,
-                    remoteMCPServer.authorization.provider,
-                    scope
-                  )
-                );
+                // For workspace connection, only show "admin needs to setup" if connection was never created.
+                // If it's an access token error (expired/revoked token), pass through to trigger re-auth.
+                if (c.error.message === "connection_not_found") {
+                  return new Err(
+                    new MCPServerRequiresAdminAuthenticationError(
+                      params.mcpServerId,
+                      remoteMCPServer.authorization.provider,
+                      scope
+                    )
+                  );
+                }
+                // For other errors (like mcp_access_token_error), pass through to trigger re-auth
+                return c;
               } else {
                 assertNever(connectionType);
               }


### PR DESCRIPTION
## Description

Fixes the error handling for remote MCP server connections to properly distinguish between missing connections and invalid/expired tokens. 

When attempting to connect to a remote MCP server, for personal connections: checks only if the admin connection resource exists (not if the token is valid), because personal actions just need to know if admin setup was done.

This prevents showing misleading "admin setup required" errors when the actual issue is an expired token that should prompt re-authentication.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Deploy front
