### PR TITLE
feat: copilot knowledge suggestions — backend

### DIFF
--- a/front/components/agent_builder/CopilotPanelContext.tsx
+++ b/front/components/agent_builder/CopilotPanelContext.tsx
@@ -19,6 +19,7 @@ function buildStep3({ includeInsights }: { includeInsights: boolean }): string {
   const toolRules = [
     `- \`get_available_skills\`: Call FIRST. Bias towards skills.`,
     `- \`get_available_tools\`: Only if clearly needed. If the desired agent is not specialized but meant to be multi-purpose, suggest "Discover Tools" skill instead.`,
+    `- \`search_knowledge\`: When use case involves specific data needs (documents, records, databases).`,
     includeInsights &&
       `- \`get_agent_insights\`: Only if you need additional information to improve the agent.`,
     `- \`get_available_models\`: Only if user explicitly asks OR obvious need.`,

--- a/front/components/agent_builder/copilot/CopilotSuggestionsContext.tsx
+++ b/front/components/agent_builder/copilot/CopilotSuggestionsContext.tsx
@@ -218,6 +218,10 @@ export const CopilotSuggestionsProvider = ({
         case "instructions":
           return { ...suggestion, relations: null };
 
+        case "knowledge":
+          // Handled in frontend PR.
+          return null;
+
         default:
           assertNever(suggestion);
       }

--- a/front/components/markdown/suggestion/CopilotSuggestionCard.tsx
+++ b/front/components/markdown/suggestion/CopilotSuggestionCard.tsx
@@ -459,6 +459,9 @@ export function CopilotSuggestionCard({
       return <SkillSuggestionCard agentSuggestion={agentSuggestion} />;
     case "model":
       return <ModelSuggestionCard agentSuggestion={agentSuggestion} />;
+    case "knowledge":
+      // Handled in frontend PR.
+      return null;
     default:
       assertNever(agentSuggestion);
   }

--- a/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
+++ b/front/lib/actions/mcp_internal_actions/__snapshots__/mcp_servers_metadata.test.ts.snap
@@ -19,6 +19,8 @@ exports[`MCP Servers Metadata Snapshot > should have stable tool stakes across a
     "inspect_message": "never_ask",
     "list_suggestions": "never_ask",
     "search_agent_templates": "never_ask",
+    "search_knowledge": "never_ask",
+    "suggest_knowledge": "never_ask",
     "suggest_model": "never_ask",
     "suggest_prompt_edits": "never_ask",
     "suggest_skills": "never_ask",

--- a/front/lib/api/assistant/global_agents/configurations/dust/copilot.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/copilot.ts
@@ -124,7 +124,7 @@ When you identify improvements, CREATE the suggestion cards. Don't describe them
 Create a suggestion when you have value to add. You DO NOT need to obtain every piece of information before suggesting. You SHOULD NOT ask for user approval before suggesting.
 
 You SHOULD be proactive in gathering all business requirements from the user. Do not assume the user has provided all the information they need or know the best way to achieve their goals.
- 
+
 There are rare cases where it is valid to ask clarifying questions without suggesting:
 - Truly ambiguous (e.g., "make it better" with no context)
 - Missing critical context that would make any suggestion a random guess
@@ -359,6 +359,7 @@ Call these when first creating suggestions in a session. ALWAYS call these tools
 - \`get_available_knowledge\`: Lists knowledge sources organized by spaces, with connected data sources, folders, and websites.
 - \`get_available_models\`: Model suggestions should be conservative - only suggest deviations from default when obvious.
 - \`search_agent_templates\`: Search published templates by job type or free-text query. Returns full details including copilotInstructions.
+- \`search_knowledge\`: When the agent's use case mentions specific data needs (e.g., "closed opportunities", "customer tickets", "product documentation"). It performs semantic search across all workspace data sources and returns matching sources with hit counts.
 </discovery_tools>
 
 <suggestion_tools>
@@ -367,6 +368,7 @@ These are the tools for Step 3 of the workflow. Each improvement you identified 
 - \`suggest_prompt_edits\`: Use for any instruction/prompt changes. Prioritize small batches of multiple edits in one call, instead of a big individual edit.
 - \`suggest_tools\`: Use when adding or removing tools from the agent configuration. ALWAYS verify tools exist via \`get_available_tools\` before suggesting.
 - \`suggest_skills\`: Use when adding or removing skills. ALWAYS verify the skill exists via \`get_available_skills\` before suggesting.
+- \`suggest_knowledge\`: Use to suggest adding or removing knowledge sources. Always call \`search_knowledge\` first to identify relevant sources, then pass the matching \`dataSourceViewId\`. Max 3 pending suggestions.
 - \`suggest_model\`: Use sparingly. Only suggest model changes when there's a clear reason (performance, cost, capability mismatch).
 - \`update_suggestions_state\`: Use to mark suggestions as "rejected" or "outdated" when they become invalid or superseded.
 
@@ -381,7 +383,7 @@ Do NOT propose changes to the name or description fields of the agent, as they a
   suggestionCreation: `<suggestion_creation_guidelines>
 When creating suggestions:
 
-1. Each call to a suggestion tool (\`suggest_prompt_edits\`, \`suggest_tools\`, \`suggest_skills\`, \`suggest_model\`) will:
+1. Each call to a suggestion tool (\`suggest_prompt_edits\`, \`suggest_tools\`, \`suggest_skills\`, \`suggest_knowledge\`, \`suggest_model\`) will:
    - Save the suggestion in the database with state \`pending\`
    - Automatically mark conflicting suggestions as \`outdated\` (see conflict rules below)
    - Emit a notification to render the suggestion chip in the conversation

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/search_conversations.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/search_conversations.ts
@@ -12,7 +12,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 import { fromError } from "zod-validation-error";
 
-const SEMANTIC_SEARCH_SCORE_CUTOFF = 0.10;
+const SEMANTIC_SEARCH_SCORE_CUTOFF = 0.1;
 
 export type SearchConversationsResponseBody = {
   conversations: ConversationWithoutContentType[];

--- a/front/types/suggestions/agent_suggestion.ts
+++ b/front/types/suggestions/agent_suggestion.ts
@@ -3,6 +3,7 @@ import { MODEL_IDS } from "@app/types/assistant/models/models";
 import { REASONING_EFFORTS } from "@app/types/assistant/models/reasoning";
 import type { ModelConfigurationType } from "@app/types/assistant/models/types";
 import type { SkillType } from "@app/types/assistant/skill_configuration";
+import type { DataSourceViewType } from "@app/types/data_source_view";
 import { z } from "zod";
 
 export const AGENT_SUGGESTION_KINDS = [
@@ -11,6 +12,7 @@ export const AGENT_SUGGESTION_KINDS = [
   "sub_agent",
   "skills",
   "model",
+  "knowledge",
 ] as const;
 
 export type AgentSuggestionKind = (typeof AGENT_SUGGESTION_KINDS)[number];
@@ -63,6 +65,12 @@ const ModelSuggestionSchema = z.object({
   reasoningEffort: z.enum(REASONING_EFFORTS).optional(),
 });
 
+const KnowledgeSuggestionSchema = z.object({
+  action: z.enum(["add", "remove"]),
+  dataSourceViewId: z.string(),
+  description: z.string().optional(),
+});
+
 export type ToolsSuggestionType = z.infer<typeof ToolsSuggestionSchema>;
 export type SubAgentSuggestionType = z.infer<typeof SubAgentSuggestionSchema>;
 export type SkillsSuggestionType = z.infer<typeof SkillsSuggestionSchema>;
@@ -70,6 +78,7 @@ export type InstructionsSuggestionSchemaType = z.infer<
   typeof InstructionsSuggestionSchema
 >;
 export type ModelSuggestionType = z.infer<typeof ModelSuggestionSchema>;
+export type KnowledgeSuggestionType = z.infer<typeof KnowledgeSuggestionSchema>;
 
 export function isToolsSuggestion(data: unknown): data is ToolsSuggestionType {
   return ToolsSuggestionSchema.safeParse(data).success;
@@ -91,8 +100,15 @@ export function isModelSuggestion(data: unknown): data is ModelSuggestionType {
   return ModelSuggestionSchema.safeParse(data).success;
 }
 
+export function isKnowledgeSuggestion(
+  data: unknown
+): data is KnowledgeSuggestionType {
+  return KnowledgeSuggestionSchema.safeParse(data).success;
+}
+
 export type SuggestionPayload =
   | InstructionsSuggestionSchemaType
+  | KnowledgeSuggestionType
   | ModelSuggestionType
   | SkillsSuggestionType
   | SubAgentSuggestionType
@@ -110,6 +126,10 @@ export const AgentSuggestionDataSchema = z.discriminatedUnion("kind", [
     suggestion: InstructionsSuggestionSchema,
   }),
   z.object({ kind: z.literal("model"), suggestion: ModelSuggestionSchema }),
+  z.object({
+    kind: z.literal("knowledge"),
+    suggestion: KnowledgeSuggestionSchema,
+  }),
 ]);
 
 export type AgentSuggestionData = z.infer<typeof AgentSuggestionDataSchema>;
@@ -156,6 +176,10 @@ export interface ModelSuggestionRelations {
   model: ModelConfigurationType;
 }
 
+export interface KnowledgeSuggestionRelations {
+  dataSourceView: DataSourceViewType;
+}
+
 export type AgentSuggestionWithRelationsType =
   | (Extract<AgentSuggestionType, { kind: "tools" }> & {
       relations: ToolSuggestionRelations;
@@ -168,6 +192,9 @@ export type AgentSuggestionWithRelationsType =
     })
   | (Extract<AgentSuggestionType, { kind: "model" }> & {
       relations: ModelSuggestionRelations;
+    })
+  | (Extract<AgentSuggestionType, { kind: "knowledge" }> & {
+      relations: KnowledgeSuggestionRelations;
     })
   | (AgentInstructionsSuggestionType & {
       relations: null;


### PR DESCRIPTION
## Description

Add the ability for the copilot to suggest knowledge sources via two new MCP tools and a new suggestion kind.

### Problem/Context

The copilot can suggest instructions, tools, skills, sub-agents, and model changes — but NOT knowledge sources. Users building agents must manually configure data sources.

### Solution

- New `"knowledge"` suggestion kind in `agent_suggestion.ts` (schema, type guard, relations)
- `search_knowledge` tool: semantic search across all workspace data sources via `CoreAPI.bulkSearchDataSources()`, aggregated by data source view (topK capped at 10)
- `suggest_knowledge` tool: creates knowledge suggestion cards with optional `description` field (used as the action description when accepted)
- Updated copilot system prompt (`copilot.ts` + `CopilotPanelContext.tsx`) to guide tool usage

### Design Decisions

**Why custom `search_knowledge` instead of reusing `discover_knowledge` skill?**
- Copilot's `requestedSpaceIds` is `[]` — skill inheritance wouldn't access all workspace data
- Existing search returns full document chunks — we need lightweight aggregation by data source

## Tests

- [ ] Manual: covered by PR 3/3 (seed data)

## Risk

Behind `agent_builder_copilot` feature flag. Backend-only, no user-facing changes in this PR.