### PR TITLE
feat: copilot knowledge suggestions — frontend

### DIFF
--- a/front/components/markdown/suggestion/CopilotSuggestionCard.tsx
+++ b/front/components/markdown/suggestion/CopilotSuggestionCard.tsx
@@ -215,18 +215,24 @@ function ToolSuggestionCard({ agentSuggestion }: ToolSuggestionCardProps) {
 
   const displayName = getMcpServerViewDisplayName(tool);
 
+  const labels = isAddition
+    ? {
+        title: `Add ${displayName} tool`,
+        applyLabel: "Add",
+        acceptedTitle: `${displayName} tool added`,
+      }
+    : {
+        title: `Remove ${displayName} tool`,
+        applyLabel: "Remove",
+        acceptedTitle: `${displayName} tool removed`,
+      };
+
   return (
     <ActionCardBlock
-      title={
-        isAddition ? `Add ${displayName} tool` : `Remove ${displayName} tool`
-      }
+      {...labels}
       visual={<Avatar icon={getIcon(tool.server.icon)} size="sm" />}
       description={analysis ?? undefined}
       state={cardState}
-      applyLabel={isAddition ? "Add" : "Remove"}
-      acceptedTitle={
-        isAddition ? `${displayName} tool added` : `${displayName} tool removed`
-      }
       rejectedTitle={`${displayName} tool rejected`}
       actionsPosition="header"
       onClickAccept={handleAccept}
@@ -306,16 +312,24 @@ function SubAgentSuggestionCard({
     ? `Run ${childAgentName}`
     : "Run sub-agent";
 
+  const labels = isAddition
+    ? {
+        title: `Add ${displayName}`,
+        applyLabel: "Add",
+        acceptedTitle: `${displayName} added`,
+      }
+    : {
+        title: `Remove ${displayName}`,
+        applyLabel: "Remove",
+        acceptedTitle: `${displayName} removed`,
+      };
+
   return (
     <ActionCardBlock
-      title={isAddition ? `Add ${displayName}` : `Remove ${displayName}`}
+      {...labels}
       visual={<Avatar icon={getIcon(tool.server.icon)} size="sm" />}
       description={analysis ?? undefined}
       state={cardState}
-      applyLabel={isAddition ? "Add" : "Remove"}
-      acceptedTitle={
-        isAddition ? `${displayName} added` : `${displayName} removed`
-      }
       rejectedTitle={`${displayName} dismissed`}
       actionsPosition="header"
       onClickAccept={handleAccept}
@@ -366,18 +380,24 @@ function SkillSuggestionCard({ agentSuggestion }: SkillSuggestionCardProps) {
     void rejectSuggestion(sId);
   }, [rejectSuggestion, sId]);
 
+  const labels = isAddition
+    ? {
+        title: `Add ${skill.name} skill`,
+        applyLabel: "Add",
+        acceptedTitle: `${skill.name} skill added`,
+      }
+    : {
+        title: `Remove ${skill.name} skill`,
+        applyLabel: "Remove",
+        acceptedTitle: `${skill.name} skill removed`,
+      };
+
   return (
     <ActionCardBlock
-      title={
-        isAddition ? `Add ${skill.name} skill` : `Remove ${skill.name} skill`
-      }
+      {...labels}
       visual={<Icon visual={getSkillAvatarIcon(skill.icon)} />}
       description={analysis ?? undefined}
       state={cardState}
-      applyLabel={isAddition ? "Add" : "Remove"}
-      acceptedTitle={
-        isAddition ? `${skill.name} skill added` : `${skill.name} skill removed`
-      }
       rejectedTitle={`${skill.name} skill suggestion rejected`}
       actionsPosition="header"
       onClickAccept={handleAccept}
@@ -519,22 +539,24 @@ function KnowledgeSuggestionCard({
       ].getLogoComponent()
     : FolderIcon;
 
+  const labels = isAddition
+    ? {
+        title: `Add ${displayName} as knowledge source`,
+        applyLabel: "Add",
+        acceptedTitle: `${displayName} knowledge added`,
+      }
+    : {
+        title: `Remove ${displayName} knowledge source`,
+        applyLabel: "Remove",
+        acceptedTitle: `${displayName} knowledge removed`,
+      };
+
   return (
     <ActionCardBlock
-      title={
-        isAddition
-          ? `Add ${displayName} as knowledge source`
-          : `Remove ${displayName} knowledge source`
-      }
+      {...labels}
       visual={<Avatar icon={icon} size="sm" />}
       description={analysis ?? undefined}
       state={cardState}
-      applyLabel={isAddition ? "Add" : "Remove"}
-      acceptedTitle={
-        isAddition
-          ? `${displayName} knowledge added`
-          : `${displayName} knowledge removed`
-      }
       rejectedTitle={`${displayName} knowledge rejected`}
       actionsPosition="header"
       onClickAccept={handleAccept}

--- a/front/components/markdown/suggestion/CopilotSuggestionCard.tsx
+++ b/front/components/markdown/suggestion/CopilotSuggestionCard.tsx
@@ -1,6 +1,9 @@
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
 import type { AgentBuilderFormData } from "@app/components/agent_builder/AgentBuilderFormContext";
-import { nameToStorageFormat } from "@app/components/agent_builder/capabilities/mcp/utils/actionNameUtils";
+import {
+  generateUniqueActionName,
+  nameToStorageFormat,
+} from "@app/components/agent_builder/capabilities/mcp/utils/actionNameUtils";
 import { useCopilotSuggestions } from "@app/components/agent_builder/copilot/CopilotSuggestionsContext";
 import { buildAgentInstructionsReadOnlyExtensions } from "@app/components/agent_builder/instructions/AgentBuilderInstructionsEditor";
 import { getDefaultMCPAction } from "@app/components/agent_builder/types";
@@ -8,14 +11,21 @@ import { InstructionSuggestionExtension } from "@app/components/editor/extension
 import { getIcon } from "@app/components/resources/resources_icons";
 import { getMcpServerViewDisplayName } from "@app/lib/actions/mcp_helper";
 import type { MCPServerViewType } from "@app/lib/api/mcp";
+import { CONNECTOR_UI_CONFIGURATIONS } from "@app/lib/connector_providers_ui";
+import { getDisplayNameForDataSource } from "@app/lib/data_sources";
 import { getSkillAvatarIcon } from "@app/lib/skill";
 import { useAgentConfigurations } from "@app/lib/swr/assistants";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 import type {
   AgentInstructionsSuggestionType,
+  AgentKnowledgeSuggestionWithRelationsType,
+  AgentModelSuggestionWithRelationsType,
+  AgentSkillsSuggestionWithRelationsType,
+  AgentSubAgentSuggestionWithRelationsType,
   AgentSuggestionKind,
   AgentSuggestionState,
   AgentSuggestionWithRelationsType,
+  AgentToolsSuggestionWithRelationsType,
 } from "@app/types/suggestions/agent_suggestion";
 import type { ActionCardState } from "@dust-tt/sparkle";
 import {
@@ -25,13 +35,13 @@ import {
   ContentMessage,
   ExclamationCircleIcon,
   EyeIcon,
+  FolderIcon,
   Icon,
   LoadingBlock,
   PencilSquareIcon,
 } from "@dust-tt/sparkle";
 import { EditorContent, useEditor } from "@tiptap/react";
-// biome-ignore lint/correctness/noUnusedImports: ignored using `--suppress`
-import React, { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { useController, useFormContext } from "react-hook-form";
 
 function mapSuggestionStateToCardState(
@@ -51,15 +61,13 @@ function mapSuggestionStateToCardState(
   }
 }
 
-interface SuggestionCardProps {
-  agentSuggestion: AgentSuggestionWithRelationsType;
+interface InstructionsSuggestionCardProps {
+  agentSuggestion: AgentInstructionsSuggestionType;
 }
 
 function InstructionsSuggestionCard({
   agentSuggestion,
-}: {
-  agentSuggestion: AgentInstructionsSuggestionType;
-}) {
+}: InstructionsSuggestionCardProps) {
   const { content, targetBlockId } = agentSuggestion.suggestion;
   const { analysis, state, sId } = agentSuggestion;
   const { focusOnSuggestion, getCommittedInstructionsHtml } =
@@ -167,11 +175,11 @@ function getNewSubAgentAction(
   return newAction;
 }
 
-function ToolSuggestionCard({
-  agentSuggestion,
-}: {
-  agentSuggestion: Extract<AgentSuggestionWithRelationsType, { kind: "tools" }>;
-}) {
+interface ToolSuggestionCardProps {
+  agentSuggestion: AgentToolsSuggestionWithRelationsType;
+}
+
+function ToolSuggestionCard({ agentSuggestion }: ToolSuggestionCardProps) {
   const { suggestion, relations, state, sId, analysis } = agentSuggestion;
   const cardState = mapSuggestionStateToCardState(state);
   const { acceptSuggestion, rejectSuggestion } = useCopilotSuggestions();
@@ -216,11 +224,10 @@ function ToolSuggestionCard({
       description={analysis ?? undefined}
       state={cardState}
       applyLabel={isAddition ? "Add" : "Remove"}
-      rejectLabel="Dismiss"
       acceptedTitle={
         isAddition ? `${displayName} tool added` : `${displayName} tool removed`
       }
-      rejectedTitle={`${displayName} tool dismissed`}
+      rejectedTitle={`${displayName} tool rejected`}
       actionsPosition="header"
       onClickAccept={handleAccept}
       onClickReject={handleReject}
@@ -228,14 +235,13 @@ function ToolSuggestionCard({
   );
 }
 
+interface SubAgentSuggestionCardProps {
+  agentSuggestion: AgentSubAgentSuggestionWithRelationsType;
+}
+
 function SubAgentSuggestionCard({
   agentSuggestion,
-}: {
-  agentSuggestion: Extract<
-    AgentSuggestionWithRelationsType,
-    { kind: "sub_agent" }
-  >;
-}) {
+}: SubAgentSuggestionCardProps) {
   const { suggestion, relations, state, sId, analysis } = agentSuggestion;
   const cardState = mapSuggestionStateToCardState(state);
   const { acceptSuggestion, rejectSuggestion } = useCopilotSuggestions();
@@ -318,14 +324,11 @@ function SubAgentSuggestionCard({
   );
 }
 
-function SkillSuggestionCard({
-  agentSuggestion,
-}: {
-  agentSuggestion: Extract<
-    AgentSuggestionWithRelationsType,
-    { kind: "skills" }
-  >;
-}) {
+interface SkillSuggestionCardProps {
+  agentSuggestion: AgentSkillsSuggestionWithRelationsType;
+}
+
+function SkillSuggestionCard({ agentSuggestion }: SkillSuggestionCardProps) {
   const { suggestion, relations, state, sId, analysis } = agentSuggestion;
   const cardState = mapSuggestionStateToCardState(state);
   const { acceptSuggestion, rejectSuggestion } = useCopilotSuggestions();
@@ -383,12 +386,11 @@ function SkillSuggestionCard({
   );
 }
 
-// Model suggestion
-function ModelSuggestionCard({
-  agentSuggestion,
-}: {
-  agentSuggestion: Extract<AgentSuggestionWithRelationsType, { kind: "model" }>;
-}) {
+interface ModelSuggestionCardProps {
+  agentSuggestion: AgentModelSuggestionWithRelationsType;
+}
+
+function ModelSuggestionCard({ agentSuggestion }: ModelSuggestionCardProps) {
   const { relations, suggestion, state, sId, analysis } = agentSuggestion;
   const cardState = mapSuggestionStateToCardState(state);
   const modelName =
@@ -445,6 +447,106 @@ function ModelSuggestionCard({
   );
 }
 
+interface KnowledgeSuggestionCardProps {
+  agentSuggestion: AgentKnowledgeSuggestionWithRelationsType;
+}
+
+function KnowledgeSuggestionCard({
+  agentSuggestion,
+}: KnowledgeSuggestionCardProps) {
+  const { suggestion, relations, state, sId, analysis } = agentSuggestion;
+  const cardState = mapSuggestionStateToCardState(state);
+  const { acceptSuggestion, rejectSuggestion } = useCopilotSuggestions();
+  const { setValue, getValues } = useFormContext<AgentBuilderFormData>();
+
+  const isAddition = suggestion.action === "add";
+  const dataSourceView = relations.dataSourceView;
+  const displayName = getDisplayNameForDataSource(dataSourceView.dataSource);
+
+  const handleAccept = useCallback(async () => {
+    const success = await acceptSuggestion(sId);
+    if (!success) {
+      return;
+    }
+
+    const currentActions = getValues("actions");
+    if (isAddition) {
+      const newAction = getDefaultMCPAction(relations.searchServerView);
+      newAction.name = generateUniqueActionName({
+        baseName: nameToStorageFormat(`search ${displayName}`),
+        existingActions: currentActions,
+      });
+      newAction.description = suggestion.description ?? `Search ${displayName}`;
+      newAction.configuration.dataSourceConfigurations = {
+        [dataSourceView.sId]: {
+          dataSourceView: dataSourceView,
+          selectedResources: [],
+          excludedResources: [],
+          isSelectAll: true,
+          tagsFilter: null,
+        },
+      };
+
+      setValue("actions", [...currentActions, newAction], {
+        shouldDirty: true,
+      });
+    } else {
+      const filteredActions = currentActions.filter((action) => {
+        const dsConfigs = action.configuration.dataSourceConfigurations;
+        return !dsConfigs || !(dataSourceView.sId in dsConfigs);
+      });
+      setValue("actions", filteredActions, { shouldDirty: true });
+    }
+  }, [
+    acceptSuggestion,
+    sId,
+    isAddition,
+    relations.searchServerView,
+    getValues,
+    setValue,
+    dataSourceView,
+    displayName,
+    suggestion.description,
+  ]);
+
+  const handleReject = useCallback(() => {
+    void rejectSuggestion(sId);
+  }, [rejectSuggestion, sId]);
+
+  const icon = dataSourceView.dataSource.connectorProvider
+    ? CONNECTOR_UI_CONFIGURATIONS[
+        dataSourceView.dataSource.connectorProvider
+      ].getLogoComponent()
+    : FolderIcon;
+
+  return (
+    <ActionCardBlock
+      title={
+        isAddition
+          ? `Add ${displayName} as knowledge source`
+          : `Remove ${displayName} knowledge source`
+      }
+      visual={<Avatar icon={icon} size="sm" />}
+      description={analysis ?? undefined}
+      state={cardState}
+      applyLabel={isAddition ? "Add" : "Remove"}
+      acceptedTitle={
+        isAddition
+          ? `${displayName} knowledge added`
+          : `${displayName} knowledge removed`
+      }
+      rejectedTitle={`${displayName} knowledge rejected`}
+      actionsPosition="header"
+      onClickAccept={handleAccept}
+      onClickReject={handleReject}
+    />
+  );
+}
+
+interface SuggestionCardProps {
+  agentSuggestion: AgentSuggestionWithRelationsType;
+}
+
 export function CopilotSuggestionCard({
   agentSuggestion,
 }: SuggestionCardProps) {
@@ -460,8 +562,7 @@ export function CopilotSuggestionCard({
     case "model":
       return <ModelSuggestionCard agentSuggestion={agentSuggestion} />;
     case "knowledge":
-      // Handled in frontend PR.
-      return null;
+      return <KnowledgeSuggestionCard agentSuggestion={agentSuggestion} />;
     default:
       assertNever(agentSuggestion);
   }
@@ -476,7 +577,6 @@ export function SuggestionCardSkeleton({ kind }: SuggestionCardSkeletonProps) {
     return <LoadingBlock className="h-24 w-full" />;
   }
 
-  // For tools/skills/model, match ActionCardBlock structure
   return (
     <ActionCardBlock
       state="accepted"

--- a/front/types/suggestions/agent_suggestion.ts
+++ b/front/types/suggestions/agent_suggestion.ts
@@ -160,6 +160,31 @@ export type AgentInstructionsSuggestionType = Extract<
   { kind: "instructions" }
 >;
 
+export type AgentToolsSuggestionType = Extract<
+  AgentSuggestionType,
+  { kind: "tools" }
+>;
+
+export type AgentSubAgentSuggestionType = Extract<
+  AgentSuggestionType,
+  { kind: "sub_agent" }
+>;
+
+export type AgentSkillsSuggestionType = Extract<
+  AgentSuggestionType,
+  { kind: "skills" }
+>;
+
+export type AgentModelSuggestionType = Extract<
+  AgentSuggestionType,
+  { kind: "model" }
+>;
+
+export type AgentKnowledgeSuggestionType = Extract<
+  AgentSuggestionType,
+  { kind: "knowledge" }
+>;
+
 export interface ToolSuggestionRelations {
   tool: MCPServerViewType;
 }
@@ -178,24 +203,30 @@ export interface ModelSuggestionRelations {
 
 export interface KnowledgeSuggestionRelations {
   dataSourceView: DataSourceViewType;
+  searchServerView: MCPServerViewType;
 }
 
+export type AgentToolsSuggestionWithRelationsType = AgentToolsSuggestionType & {
+  relations: ToolSuggestionRelations;
+};
+
+export type AgentSubAgentSuggestionWithRelationsType =
+  AgentSubAgentSuggestionType & { relations: SubAgentSuggestionRelations };
+
+export type AgentSkillsSuggestionWithRelationsType =
+  AgentSkillsSuggestionType & { relations: SkillSuggestionRelations };
+
+export type AgentModelSuggestionWithRelationsType = AgentModelSuggestionType & {
+  relations: ModelSuggestionRelations;
+};
+
+export type AgentKnowledgeSuggestionWithRelationsType =
+  AgentKnowledgeSuggestionType & { relations: KnowledgeSuggestionRelations };
+
 export type AgentSuggestionWithRelationsType =
-  | (Extract<AgentSuggestionType, { kind: "tools" }> & {
-      relations: ToolSuggestionRelations;
-    })
-  | (Extract<AgentSuggestionType, { kind: "sub_agent" }> & {
-      relations: SubAgentSuggestionRelations;
-    })
-  | (Extract<AgentSuggestionType, { kind: "skills" }> & {
-      relations: SkillSuggestionRelations;
-    })
-  | (Extract<AgentSuggestionType, { kind: "model" }> & {
-      relations: ModelSuggestionRelations;
-    })
-  | (Extract<AgentSuggestionType, { kind: "knowledge" }> & {
-      relations: KnowledgeSuggestionRelations;
-    })
-  | (AgentInstructionsSuggestionType & {
-      relations: null;
-    });
+  | AgentToolsSuggestionWithRelationsType
+  | AgentSubAgentSuggestionWithRelationsType
+  | AgentSkillsSuggestionWithRelationsType
+  | AgentModelSuggestionWithRelationsType
+  | AgentKnowledgeSuggestionWithRelationsType
+  | (AgentInstructionsSuggestionType & { relations: null });


### PR DESCRIPTION
## Description

Frontend integration for copilot knowledge suggestions (stacked on #21538).

### Solution

- `KnowledgeSuggestionCard`: renders accept/reject cards for knowledge suggestions
  - Accept: creates a "search" action with `isSelectAll: true` using `relations.searchServerView`
  - Uses `generateUniqueActionName` to avoid name conflicts
  - Uses `suggestion.description` for action description (fallback: `Search ${displayName}`)
  - Shows connector logo via `CONNECTOR_UI_CONFIGURATIONS` with `FolderIcon` fallback
- `CopilotSuggestionsContext`: resolves knowledge suggestion relations
  - Uses `useDataSourceViewsContext` (existing provider) instead of direct `useDataSourceViews`
  - Resolves `searchServerView` in relations — card doesn't render until available
- `agent_suggestion.ts`: extracted named types for all suggestion-with-relations variants

## Tests
![Screen Recording 2026-02-17 at 11 14 06](https://github.com/user-attachments/assets/853775da-3fd6-4b37-9140-26eabc36e9de)


## Risk

Behind `agent_builder_copilot` feature flag.