### PR TITLE
Check invitations in all regions

### DIFF
--- a/front/components/pages/onboarding/InviteChoosePage.tsx
+++ b/front/components/pages/onboarding/InviteChoosePage.tsx
@@ -18,11 +18,15 @@ export function InviteChoosePage() {
   const { pendingInvitations, isPendingInvitationsLoading } =
     usePendingInvitations();
 
-  const handleInvitationSelection = useCallback((token: string) => {
-    window.location.assign(
-      `${getApiBaseUrl()}/api/login?inviteToken=${encodeURIComponent(token)}`
-    );
-  }, []);
+  const handleInvitationSelection = useCallback(
+    (token: string, regionUrl?: string) => {
+      const baseUrl = regionUrl ?? getApiBaseUrl();
+      window.location.assign(
+        `${baseUrl}/api/login?inviteToken=${encodeURIComponent(token)}`
+      );
+    },
+    []
+  );
 
   if (isPendingInvitationsLoading) {
     return (
@@ -79,7 +83,10 @@ export function InviteChoosePage() {
                       variant="primary"
                       size="sm"
                       onClick={() =>
-                        handleInvitationSelection(invitation.token)
+                        handleInvitationSelection(
+                          invitation.token,
+                          invitation.regionUrl
+                        )
                       }
                     />
                   </div>

--- a/front/pages/api/lookup/[resource]/index.ts
+++ b/front/pages/api/lookup/[resource]/index.ts
@@ -5,12 +5,14 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import config from "@app/lib/api/config";
 import {
+  handleLookupInvitations,
   handleLookupWorkspace,
   hasEmailLocalRegionAffinity,
 } from "@app/lib/api/regions/lookup";
 import { getBearerToken } from "@app/lib/auth";
 import { apiError, withLogging } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
+import type { PendingInvitationOption } from "@app/types/membership_invitation";
 import { assertNever } from "@app/types/shared/utils/assert_never";
 
 export type WorkspaceLookupResponse = {
@@ -23,12 +25,19 @@ export type UserLookupResponse = {
   exists: boolean;
 };
 
+export type InvitationsLookupResponse = {
+  pendingInvitations: PendingInvitationOption[];
+};
+
 const ExternalUserCodec = t.type({
   email: t.string,
   email_verified: t.boolean,
 });
 
-type LookupResponseBody = UserLookupResponse | WorkspaceLookupResponse;
+type LookupResponseBody =
+  | UserLookupResponse
+  | WorkspaceLookupResponse
+  | InvitationsLookupResponse;
 
 const UserLookupSchema = t.type({
   user: ExternalUserCodec,
@@ -38,13 +47,25 @@ const WorkspaceLookupSchema = t.type({
   workspace: t.string,
 });
 
+const InvitationsLookupSchema = t.type({
+  email: t.string,
+});
+
 export type UserLookupRequestBodyType = t.TypeOf<typeof UserLookupSchema>;
 
 export type WorkspaceLookupRequestBodyType = t.TypeOf<
   typeof WorkspaceLookupSchema
 >;
 
-const ResourceType = t.union([t.literal("user"), t.literal("workspace")]);
+export type InvitationsLookupRequestBodyType = t.TypeOf<
+  typeof InvitationsLookupSchema
+>;
+
+const ResourceType = t.union([
+  t.literal("user"),
+  t.literal("workspace"),
+  t.literal("invitations"),
+]);
 
 async function handler(
   req: NextApiRequest,
@@ -99,7 +120,8 @@ async function handler(
       status_code: 400,
       api_error: {
         type: "invalid_request_error",
-        message: "Invalid resource type. Must be 'user' or 'workspace'",
+        message:
+          "Invalid resource type. Must be 'user', 'workspace', or 'invitations'",
       },
     });
   }
@@ -143,6 +165,25 @@ async function handler(
           });
         }
         response = await handleLookupWorkspace(bodyValidation.right);
+      }
+      break;
+
+    case "invitations":
+      {
+        const bodyValidation = InvitationsLookupSchema.decode(req.body);
+        if (isLeft(bodyValidation)) {
+          const pathError = reporter.formatValidationErrors(
+            bodyValidation.left
+          );
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message: `Invalid request body for invitations lookup: ${pathError}`,
+            },
+          });
+        }
+        response = await handleLookupInvitations(bodyValidation.right.email);
       }
       break;
 

--- a/front/types/membership_invitation.ts
+++ b/front/types/membership_invitation.ts
@@ -25,6 +25,7 @@ export interface PendingInvitationOption {
   initialRole: ActiveRoleType;
   createdAt: number;
   isExpired: boolean;
+  regionUrl?: string;
 }
 
 // Types for the invite form in Poke.


### PR DESCRIPTION
## Description

The `/api/invitations` endpoint only queries the local region's database for pending invitations. Users who have invitations on the other region (EU or US) don't see them on the InviteChoose page. This PR adds cross-region invitation fetching and merging.

**Key constraint**: Invitation tokens (JWTs) are signed with a region-specific secret and contain a region-local ModelId. They can only be validated in the region where they were created. So for cross-region invitations, the user is redirected to the other region's login endpoint.

### Changes

- **`PendingInvitationOption`**: Added optional `regionUrl` field to identify cross-region invitations.
- **Lookup endpoint** (`/api/lookup/invitations`): New `"invitations"` resource type so one region can query the other for pending invitations by email (Bearer-token authenticated, same pattern as `"user"` and `"workspace"` lookups).
- **`lookup.ts`**: Added `handleLookupInvitations` (serves the lookup endpoint) and `fetchInvitationsFromOtherRegion` (calls the other region's lookup endpoint, tags results with `regionUrl`).
- **`/api/invitations`**: After fetching local invitations, fetches cross-region invitations and merges them. Graceful degradation: if the cross-region call fails, logs the error and returns local invitations only.
- **`InviteChoosePage`**: `handleInvitationSelection` uses `regionUrl` when set to redirect to the other region's `/api/login`, otherwise uses `getApiBaseUrl()` (always absolute URL).

### Follow-up (not in scope)

`/api/login` (lines 128-139) also only checks local invitations when deciding whether to redirect to `/invite-choose`. If a user has 1 local + 1 cross-region invitation, they'd be auto-joined to the local one without seeing the choice page. This should be addressed separately.

## Tests

Manual verification: type-check (`npx tsgo --noEmit`), lint (`npm run lint`), and format (`biome format`) all pass.

## Risk

- **Low**: Cross-region fetch failure is handled gracefully (logged, local-only fallback).
- **Safe to rollback**: The new lookup endpoint is additive and won't break existing behavior if reverted.

## Deploy Plan

No special deployment order needed — the lookup endpoint is only called server-side between regions, and both regions need the code to fully work. Until both are deployed, cross-region invitations simply won't appear (graceful degradation).