### PR TITLE
[connectors] Add `memo` and `searchAttributes` to gong sync workflows

### DIFF
--- a/connectors/src/connectors/gong/index.ts
+++ b/connectors/src/connectors/gong/index.ts
@@ -122,6 +122,12 @@ export class GongConnectorManager extends BaseConnectorManager<null> {
           },
         ],
         taskQueue: QUEUE_NAME,
+        searchAttributes: {
+          connectorId: [connector.id],
+        },
+        memo: {
+          connectorId: connector.id,
+        },
       },
       scheduleId: makeGongSyncScheduleId(connector),
       policies: SCHEDULE_POLICIES,

--- a/connectors/src/connectors/gong/index.ts
+++ b/connectors/src/connectors/gong/index.ts
@@ -28,6 +28,7 @@ import {
   scheduleExists,
   unpauseAndTriggerSchedule,
 } from "@connectors/lib/temporal_schedules";
+import { connectorIdSearchAttribute } from "@connectors/lib/temporal";
 import mainLogger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { ContentNode, DataSourceConfig } from "@connectors/types";
@@ -122,9 +123,12 @@ export class GongConnectorManager extends BaseConnectorManager<null> {
           },
         ],
         taskQueue: QUEUE_NAME,
-        searchAttributes: {
-          connectorId: [connector.id],
-        },
+        typedSearchAttributes: [
+          {
+            key: connectorIdSearchAttribute,
+            value: connector.id,
+          },
+        ],
         memo: {
           connectorId: connector.id,
         },

--- a/connectors/src/connectors/gong/index.ts
+++ b/connectors/src/connectors/gong/index.ts
@@ -21,6 +21,7 @@ import {
 } from "@connectors/connectors/interface";
 import { dataSourceConfigFromConnector } from "@connectors/lib/api/data_source_config";
 import { upsertDataSourceFolder } from "@connectors/lib/data_sources";
+import { connectorIdSearchAttribute } from "@connectors/lib/temporal";
 import {
   createSchedule,
   deleteSchedule,
@@ -28,7 +29,6 @@ import {
   scheduleExists,
   unpauseAndTriggerSchedule,
 } from "@connectors/lib/temporal_schedules";
-import { connectorIdSearchAttribute } from "@connectors/lib/temporal";
 import mainLogger from "@connectors/logger/logger";
 import { ConnectorResource } from "@connectors/resources/connector_resource";
 import type { ContentNode, DataSourceConfig } from "@connectors/types";

--- a/connectors/src/lib/temporal.ts
+++ b/connectors/src/lib/temporal.ts
@@ -8,7 +8,7 @@ import { NativeConnection } from "@temporalio/worker";
 import fs from "fs-extra";
 
 // Define the connectorId search attribute key for typed access.
-const connectorIdSearchAttribute = defineSearchAttributeKey<"INT">(
+export const connectorIdSearchAttribute = defineSearchAttributeKey<"INT">(
   "connectorId",
   "INT"
 );


### PR DESCRIPTION
## Description

- Context [here](https://dust4ai.slack.com/archives/C050SM8NSPK/p1770906241305129).
- The gong sync workflows we create have no memo nor `searchAttributes` (example [here](https://cloud.temporal.io/namespaces/eu-dust-prod.gmnlm/workflows?query=%60WorkflowId%60%3D%22274877908537%22)).
- The schedules do not add them when creating the workflows, this PR fixes that.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy connectors.
- Restart schedules to have them create workflows with correct metadata.