### PR TITLE
Real-time check if project name exists

### DIFF
--- a/front/components/assistant/conversation/CreateProjectModal.tsx
+++ b/front/components/assistant/conversation/CreateProjectModal.tsx
@@ -1,5 +1,5 @@
+import { useSpaceConversationsSummary } from "@app/hooks/conversations";
 import { useAppRouter } from "@app/lib/platform";
-import { useSpaceConversationsSummary } from "@app/lib/swr/conversations";
 import { useCheckProjectName } from "@app/lib/swr/projects";
 import { useCreateSpace } from "@app/lib/swr/spaces";
 import { getProjectRoute } from "@app/lib/utils/router";

--- a/front/components/assistant/conversation/CreateProjectModal.tsx
+++ b/front/components/assistant/conversation/CreateProjectModal.tsx
@@ -1,3 +1,9 @@
+import { useAppRouter } from "@app/lib/platform";
+import { useSpaceConversationsSummary } from "@app/lib/swr/conversations";
+import { useCheckProjectName } from "@app/lib/swr/projects";
+import { useCreateSpace } from "@app/lib/swr/spaces";
+import { getProjectRoute } from "@app/lib/utils/router";
+import type { LightWorkspaceType } from "@app/types/user";
 import {
   Button,
   Dialog,
@@ -10,13 +16,6 @@ import {
   SliderToggle,
 } from "@dust-tt/sparkle";
 import { useCallback, useEffect, useState } from "react";
-
-import { useAppRouter } from "@app/lib/platform";
-import { useSpaceConversationsSummary } from "@app/lib/swr/conversations";
-import { useCheckProjectName } from "@app/lib/swr/projects";
-import { useCreateSpace } from "@app/lib/swr/spaces";
-import { getProjectRoute } from "@app/lib/utils/router";
-import type { LightWorkspaceType } from "@app/types/user";
 
 interface CreateProjectModalProps {
   isOpen: boolean;

--- a/front/components/assistant/conversation/CreateProjectModal.tsx
+++ b/front/components/assistant/conversation/CreateProjectModal.tsx
@@ -1,8 +1,3 @@
-import { useSpaceConversationsSummary } from "@app/hooks/conversations";
-import { useAppRouter } from "@app/lib/platform";
-import { useCreateSpace } from "@app/lib/swr/spaces";
-import { getProjectRoute } from "@app/lib/utils/router";
-import type { LightWorkspaceType } from "@app/types/user";
 import {
   Button,
   Dialog,
@@ -15,6 +10,13 @@ import {
   SliderToggle,
 } from "@dust-tt/sparkle";
 import { useCallback, useEffect, useState } from "react";
+
+import { useAppRouter } from "@app/lib/platform";
+import { useSpaceConversationsSummary } from "@app/lib/swr/conversations";
+import { useCheckProjectName } from "@app/lib/swr/projects";
+import { useCreateSpace } from "@app/lib/swr/spaces";
+import { getProjectRoute } from "@app/lib/utils/router";
+import type { LightWorkspaceType } from "@app/types/user";
 
 interface CreateProjectModalProps {
   isOpen: boolean;
@@ -39,24 +41,35 @@ export function CreateProjectModal({
     options: { disabled: true },
   });
 
+  const {
+    isNameAvailable,
+    isChecking,
+    existingSpaceLink,
+    setValue: setNameToCheck,
+  } = useCheckProjectName({
+    owner,
+  });
+
   useEffect(() => {
     if (isOpen) {
       setProjectName("");
       setIsSaving(false);
+      setNameToCheck("");
     }
-  }, [isOpen]);
+  }, [isOpen, setNameToCheck]);
 
   const handleClose = useCallback(() => {
     onClose();
     setTimeout(() => {
       setProjectName("");
       setIsSaving(false);
+      setNameToCheck("");
     }, 500);
-  }, [onClose]);
+  }, [onClose, setNameToCheck]);
 
   const onSave = useCallback(async () => {
     const trimmedName = projectName.trim();
-    if (!trimmedName) {
+    if (!trimmedName || !isNameAvailable) {
       return;
     }
 
@@ -84,6 +97,7 @@ export function CreateProjectModal({
     }
   }, [
     projectName,
+    isNameAvailable,
     isPublic,
     doCreate,
     handleClose,
@@ -94,12 +108,15 @@ export function CreateProjectModal({
 
   const handleKeyPress = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
-      if (e.key === "Enter" && projectName.trim()) {
+      if (e.key === "Enter" && projectName.trim() && isNameAvailable) {
         void onSave();
       }
     },
-    [onSave, projectName]
+    [onSave, projectName, isNameAvailable]
   );
+
+  const nameNotAvailable =
+    projectName.trim() && !isChecking && !isNameAvailable;
 
   return (
     <Dialog open={isOpen} onOpenChange={handleClose}>
@@ -109,17 +126,36 @@ export function CreateProjectModal({
         </DialogHeader>
         <DialogContainer>
           <div className="flex w-full flex-col gap-y-4">
-            <Input
-              label="Project name"
-              placeholder="Enter project name"
-              value={projectName}
-              name="projectName"
-              onChange={(e) => {
-                setProjectName(e.target.value);
-              }}
-              onKeyDown={handleKeyPress}
-              autoFocus
-            />
+            <div className="flex flex-col">
+              <Input
+                label="Project name"
+                placeholder="Enter project name"
+                value={projectName}
+                name="projectName"
+                onChange={(e) => {
+                  const newValue = e.target.value;
+                  setProjectName(newValue);
+                  setNameToCheck(newValue);
+                }}
+                onKeyDown={handleKeyPress}
+                autoFocus
+              />
+              {nameNotAvailable && (
+                <div className="mt-1 text-xs text-warning-500 dark:text-warning-500">
+                  A project with this name already exists.{" "}
+                  {existingSpaceLink && (
+                    <a
+                      href={existingSpaceLink}
+                      className="underline hover:text-warning-600 dark:hover:text-warning-600"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      View existing project
+                    </a>
+                  )}
+                </div>
+              )}
+            </div>
             <div className="flex items-start justify-between gap-4">
               <div className="flex flex-col">
                 <div className="text-sm font-semibold text-foreground dark:text-foreground-night">
@@ -142,7 +178,9 @@ export function CreateProjectModal({
           <Button
             label={isSaving ? "Creating..." : "Create"}
             onClick={onSave}
-            disabled={!projectName.trim() || isSaving}
+            disabled={
+              !projectName.trim() || isSaving || isChecking || !isNameAvailable
+            }
           />
         </DialogFooter>
       </DialogContent>

--- a/front/components/assistant/conversation/space/about/MembersTable.tsx
+++ b/front/components/assistant/conversation/space/about/MembersTable.tsx
@@ -1,6 +1,6 @@
 import { ConfirmContext } from "@app/components/Confirm";
 import { useSendNotification } from "@app/hooks/useNotification";
-import { useSpaceInfo, useUpdateSpace } from "@app/lib/swr/spaces";
+import { useUpdateSpace } from "@app/lib/swr/spaces";
 import type { SpaceType } from "@app/types/space";
 import type { LightWorkspaceType, SpaceUserType } from "@app/types/user";
 import type { MenuItem } from "@dust-tt/sparkle";
@@ -21,6 +21,7 @@ interface MembersTableProps {
   selectedMembers: SpaceUserType[];
   searchSelectedMembers: string;
   isEditor?: boolean;
+  mutateSpaceInfo: () => Promise<void>;
 }
 
 type MemberRowData = {
@@ -52,14 +53,11 @@ export function MembersTable({
   selectedMembers,
   searchSelectedMembers,
   isEditor,
+  mutateSpaceInfo,
 }: MembersTableProps) {
   const sendNotifications = useSendNotification();
 
   const doUpdate = useUpdateSpace({ owner });
-  const { mutateSpaceInfo } = useSpaceInfo({
-    workspaceId: owner.sId,
-    spaceId: space.sId,
-  });
   const confirm = useContext(ConfirmContext);
 
   const removeMember = useCallback(

--- a/front/components/assistant/conversation/space/about/SpaceAboutTab.tsx
+++ b/front/components/assistant/conversation/space/about/SpaceAboutTab.tsx
@@ -170,6 +170,7 @@ export function SpaceAboutTab({
           <div className="flex w-full min-w-0 gap-2">
             <Input
               value={projectName}
+              disabled={!isProjectEditor}
               onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                 setProjectName(e.target.value);
                 setIsEditingName(e.target.value.trim() !== space.name.trim());
@@ -208,7 +209,7 @@ export function SpaceAboutTab({
                   ? "Loading..."
                   : "Describe what this project is about..."
               }
-              disabled={isProjectMetadataLoading}
+              disabled={isProjectMetadataLoading || !isProjectEditor}
               minRows={3}
               resize="vertical"
               className="flex-1"

--- a/front/components/assistant/conversation/space/about/SpaceAboutTab.tsx
+++ b/front/components/assistant/conversation/space/about/SpaceAboutTab.tsx
@@ -68,6 +68,11 @@ export function SpaceAboutTab({
     defaultValues: {},
   });
 
+  // Sync projectName with space.name when it changes
+  useEffect(() => {
+    setProjectName(space.name);
+  }, [space.name]);
+
   // Sync form with loaded metadata
   useEffect(() => {
     if (projectMetadata) {
@@ -77,7 +82,7 @@ export function SpaceAboutTab({
   }, [projectMetadata, form]);
 
   const doUpdate = useUpdateSpace({ owner });
-  const { mutateSpaceInfo } = useSpaceInfo({
+  const { mutateSpaceInfoRegardlessOfQueryParams } = useSpaceInfo({
     workspaceId: owner.sId,
     spaceId: space.sId,
   });
@@ -109,7 +114,7 @@ export function SpaceAboutTab({
     });
 
     if (updated) {
-      await mutateSpaceInfo();
+      await mutateSpaceInfoRegardlessOfQueryParams();
       // Optimistically update the space name in the sidebar without refetching
       void mutateSpaceSummary();
       setIsEditingName(false);
@@ -157,7 +162,7 @@ export function SpaceAboutTab({
     });
 
     if (updated) {
-      await mutateSpaceInfo();
+      await mutateSpaceInfoRegardlessOfQueryParams();
     }
   };
 

--- a/front/components/assistant/conversation/space/about/SpaceAboutTab.tsx
+++ b/front/components/assistant/conversation/space/about/SpaceAboutTab.tsx
@@ -280,6 +280,7 @@ export function SpaceAboutTab({
                 selectedMembers={projectMembers}
                 searchSelectedMembers={searchSelectedMembers}
                 isEditor={isProjectEditor}
+                mutateSpaceInfo={() => mutateSpaceInfoRegardlessOfQueryParams()}
               />
             </ScrollArea>
           </>

--- a/front/components/assistant/conversation/space/about/SpaceAboutTab.tsx
+++ b/front/components/assistant/conversation/space/about/SpaceAboutTab.tsx
@@ -86,9 +86,13 @@ export function SpaceAboutTab({
   });
 
   const onSaveName = async () => {
+    const newProjectName = projectName.trim();
+    if (!newProjectName || newProjectName === space.name.trim()) {
+      return;
+    }
     const confirmed = await confirm({
       title: "Update project name?",
-      message: `The project name will be changed to "${projectName}".`,
+      message: `The project name will be changed to "${newProjectName}".`,
       validateVariant: "warning",
     });
 
@@ -101,7 +105,7 @@ export function SpaceAboutTab({
       memberIds: projectMembers.filter((m) => !m.isEditor).map((m) => m.sId),
       editorIds: projectMembers.filter((m) => m.isEditor).map((m) => m.sId),
       managementMode: "manual",
-      name: projectName,
+      name: newProjectName,
     });
 
     if (updated) {
@@ -168,7 +172,7 @@ export function SpaceAboutTab({
               value={projectName}
               onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                 setProjectName(e.target.value);
-                setIsEditingName(e.target.value !== space.name);
+                setIsEditingName(e.target.value.trim() !== space.name.trim());
               }}
               placeholder="Enter project name"
               containerClassName="flex-1"

--- a/front/components/assistant/conversation/space/about/SpaceAboutTab.tsx
+++ b/front/components/assistant/conversation/space/about/SpaceAboutTab.tsx
@@ -68,11 +68,6 @@ export function SpaceAboutTab({
     defaultValues: {},
   });
 
-  // Sync projectName with space.name when it changes
-  useEffect(() => {
-    setProjectName(space.name);
-  }, [space.name]);
-
   // Sync form with loaded metadata
   useEffect(() => {
     if (projectMetadata) {

--- a/front/lib/api/spaces.ts
+++ b/front/lib/api/spaces.ts
@@ -420,7 +420,10 @@ export async function createSpaceAndGroup(
       );
     }
 
-    const { name, isRestricted, spaceKind, managementMode } = params;
+    const { name: rawName, isRestricted, spaceKind, managementMode } = params;
+    // Trim the name to prevent issues with leading/trailing whitespace
+    const name = rawName.trim();
+
     if (spaceKind === "regular" && !isRestricted) {
       assert(
         managementMode === "manual",

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -471,21 +471,21 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     return spaces ?? [];
   }
 
+  static async fetchByName(
+    auth: Authenticator,
+    name: string,
+    t?: Transaction
+  ): Promise<SpaceResource | null> {
+    const [space] = await this.baseFetch(auth, { where: { name } }, t);
+    return space ?? null;
+  }
+
   static async isNameAvailable(
     auth: Authenticator,
     name: string,
     t?: Transaction
   ): Promise<boolean> {
-    const owner = auth.getNonNullableWorkspace();
-
-    const space = await this.model.findOne({
-      where: {
-        name,
-        workspaceId: owner.id,
-      },
-      transaction: t,
-    });
-
+    const space = await this.fetchByName(auth, name, t);
     return !space;
   }
 

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -476,7 +476,12 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     name: string,
     t?: Transaction
   ): Promise<SpaceResource | null> {
-    const [space] = await this.baseFetch(auth, { where: { name } }, t);
+    const trimmedName = name.trim();
+    const [space] = await this.baseFetch(
+      auth,
+      { where: { name: { [Op.iLike]: trimmedName } } },
+      t
+    );
     return space ?? null;
   }
 
@@ -557,26 +562,30 @@ export class SpaceResource extends BaseResource<SpaceModel> {
       return new Err(new Error("Only admins can update space names."));
     }
 
-    const nameAvailable = await SpaceResource.isNameAvailable(auth, newName);
+    const trimmedName = newName.trim();
+    const nameAvailable = await SpaceResource.isNameAvailable(
+      auth,
+      trimmedName
+    );
     if (!nameAvailable) {
       return new Err(new Error("This space name is already used."));
     }
 
-    await this.update({ name: newName });
+    await this.update({ name: trimmedName });
     // For regular spaces that only have a single group, update
     // the group's name too (see https://github.com/dust-tt/tasks/issues/1738)
     const regularGroup = this.getSpaceManualMemberGroup();
     if (this.isRegular()) {
       await regularGroup.updateName(
         auth,
-        `Group for ${this.isProject() ? "project" : "space"} ${newName}`
+        `Group for ${this.isProject() ? "project" : "space"} ${trimmedName}`
       );
     }
     const spaceEditorGroup = this.getSpaceManualEditorGroup();
     if (spaceEditorGroup && this.isRegular()) {
       await spaceEditorGroup.updateName(
         auth,
-        `Editors for ${this.isProject() ? "project" : "space"} ${newName}`
+        `Editors for ${this.isProject() ? "project" : "space"} ${trimmedName}`
       );
     }
 

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -563,11 +563,8 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     }
 
     const trimmedName = newName.trim();
-    const nameAvailable = await SpaceResource.isNameAvailable(
-      auth,
-      trimmedName
-    );
-    if (!nameAvailable) {
+    const existingSpace = await SpaceResource.fetchByName(auth, trimmedName);
+    if (existingSpace && existingSpace.id !== this.id) {
       return new Err(new Error("This space name is already used."));
     }
 

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -558,7 +558,7 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     auth: Authenticator,
     newName: string
   ): Promise<Result<undefined, Error>> {
-    if (!auth.isAdmin()) {
+    if (!this.canAdministrate(auth)) {
       return new Err(new Error("Only admins can update space names."));
     }
 

--- a/front/lib/swr/projects.ts
+++ b/front/lib/swr/projects.ts
@@ -1,5 +1,3 @@
-import { useMemo } from "react";
-
 import { useDebounce } from "@app/hooks/useDebounce";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
@@ -17,6 +15,7 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 import type { LightWorkspaceType } from "@app/types/user";
+import { useMemo } from "react";
 import type { Fetcher } from "swr";
 
 export type { FileWithCreatorType };

--- a/front/lib/swr/projects.ts
+++ b/front/lib/swr/projects.ts
@@ -1,3 +1,6 @@
+import { useMemo } from "react";
+
+import { useDebounce } from "@app/hooks/useDebounce";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
 import {
@@ -9,6 +12,7 @@ import type {
   FileWithCreatorType,
   GetProjectFilesResponseBody,
 } from "@app/pages/api/w/[wId]/spaces/[spaceId]/project_files";
+import type { CheckNameResponseBody } from "@app/pages/api/w/[wId]/spaces/check-name";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -122,5 +126,41 @@ export function useRenameProjectFile({ owner }: { owner: LightWorkspaceType }) {
       });
       return new Err(new Error(errorMessage));
     }
+  };
+}
+
+export function useCheckProjectName({
+  owner,
+  initialName = "",
+}: {
+  owner: LightWorkspaceType;
+  initialName?: string;
+}) {
+  const {
+    debouncedValue: debouncedName,
+    isDebouncing,
+    setValue,
+  } = useDebounce(initialName, {
+    delay: 300,
+    minLength: 1,
+  });
+
+  const shouldFetch = useMemo(() => {
+    return debouncedName.trim().length > 0;
+  }, [debouncedName]);
+
+  const checkKey = shouldFetch
+    ? `/api/w/${owner.sId}/spaces/check-name?name=${encodeURIComponent(debouncedName)}`
+    : null;
+
+  const checkFetcher: Fetcher<CheckNameResponseBody> = fetcher;
+
+  const { data, isLoading } = useSWRWithDefaults(checkKey, checkFetcher);
+
+  return {
+    isNameAvailable: data?.available ?? true,
+    existingSpaceLink: data?.existingSpaceLink,
+    isChecking: isLoading || isDebouncing,
+    setValue,
   };
 }

--- a/front/pages/api/w/[wId]/spaces/check-name.ts
+++ b/front/pages/api/w/[wId]/spaces/check-name.ts
@@ -1,0 +1,77 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import z from "zod";
+
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import type { Authenticator } from "@app/lib/auth";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { WithAPIErrorResponse } from "@app/types/error";
+
+const CheckNameQuerySchema = z.object({
+  name: z.string().min(1),
+});
+
+export type CheckNameResponseBody = {
+  available: boolean;
+  existingSpaceLink?: string;
+};
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<WithAPIErrorResponse<CheckNameResponseBody>>,
+  auth: Authenticator
+): Promise<void> {
+  switch (req.method) {
+    case "GET": {
+      const queryValidation = CheckNameQuerySchema.safeParse(req.query);
+      if (!queryValidation.success) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: "The query parameter `name` is required.",
+          },
+        });
+      }
+
+      const { name } = queryValidation.data;
+      const owner = auth.getNonNullableWorkspace();
+
+      // Find the space with this name
+      const existingSpace = await SpaceResource.fetchByName(auth, name);
+
+      if (!existingSpace) {
+        return res.status(200).json({ available: true });
+      }
+
+      // Don't provide the link if the user doesn't have access to the space
+      if (!existingSpace.canRead(auth)) {
+        return res.status(200).json({ available: false });
+      }
+
+      // Space exists and user can access it, provide the link
+      let existingSpaceLink: string;
+      if (existingSpace.isProject()) {
+        existingSpaceLink = `/w/${owner.sId}/conversation/space/${existingSpace.sId}`;
+      } else {
+        existingSpaceLink = `/w/${owner.sId}/spaces/${existingSpace.sId}`;
+      }
+
+      return res.status(200).json({
+        available: false,
+        existingSpaceLink,
+      });
+    }
+
+    default:
+      return apiError(req, res, {
+        status_code: 405,
+        api_error: {
+          type: "method_not_supported_error",
+          message: "The method passed is not supported, GET is expected.",
+        },
+      });
+  }
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/spaces/check-name.ts
+++ b/front/pages/api/w/[wId]/spaces/check-name.ts
@@ -37,7 +37,7 @@ async function handler(
       const { name } = queryValidation.data;
       const owner = auth.getNonNullableWorkspace();
 
-      // Find the space with this name
+      // Find the space with this name (case-insensitive)
       const existingSpace = await SpaceResource.fetchByName(auth, name);
 
       if (!existingSpace) {

--- a/front/pages/api/w/[wId]/spaces/check-name.ts
+++ b/front/pages/api/w/[wId]/spaces/check-name.ts
@@ -1,11 +1,10 @@
-import type { NextApiRequest, NextApiResponse } from "next";
-import z from "zod";
-
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
+import type { NextApiRequest, NextApiResponse } from "next";
+import z from "zod";
 
 const CheckNameQuerySchema = z.object({
   name: z.string().min(1),


### PR DESCRIPTION
## Description

Adds real-time validation for project name availability in the CreateProjectModal. When users type a project name, the modal now performs a debounced check (300ms) to verify if the name already exists, displaying a warning message with a link to the existing project if accessible. 
<img width="456" height="286" alt="image" src="https://github.com/user-attachments/assets/943b6a1e-e0d9-40da-a788-f10cee4abeaa" />


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Deploy front
