### PR TITLE
[AGENT-BUILDER] Set GPT 5.2 as latest flgship

### DIFF
--- a/front/components/agent_builder/instructions/utils.ts
+++ b/front/components/agent_builder/instructions/utils.ts
@@ -1,7 +1,7 @@
 import { CLAUDE_4_5_SONNET_20250929_MODEL_ID } from "@app/types/assistant/models/anthropic";
 import { GEMINI_2_5_PRO_MODEL_ID } from "@app/types/assistant/models/google_ai_studio";
 import { MISTRAL_LARGE_MODEL_ID } from "@app/types/assistant/models/mistral";
-import { GPT_5_MODEL_ID } from "@app/types/assistant/models/openai";
+import { GPT_5_2_MODEL_ID } from "@app/types/assistant/models/openai";
 import type {
   ModelConfigurationType,
   ModelIdType,
@@ -9,7 +9,7 @@ import type {
 } from "@app/types/assistant/models/types";
 
 export const BEST_PERFORMING_MODELS_ID: ModelIdType[] = [
-  GPT_5_MODEL_ID,
+  GPT_5_2_MODEL_ID,
   CLAUDE_4_5_SONNET_20250929_MODEL_ID,
   MISTRAL_LARGE_MODEL_ID,
   GEMINI_2_5_PRO_MODEL_ID,

--- a/front/types/assistant/models/openai.ts
+++ b/front/types/assistant/models/openai.ts
@@ -203,9 +203,9 @@ export const GPT_5_MODEL_CONFIG: ModelConfigurationType = {
   recommendedExhaustiveTopK: 64, // 32_768
   largeModel: true,
   description: "OpenAI's GPT 5 model (400k context).",
-  shortDescription: "OpenAI's latest model.",
+  shortDescription: "OpenAI's flagship model.",
   isLegacy: false,
-  isLatest: true,
+  isLatest: false,
   generationTokensCount: 128_000,
   supportsVision: true,
   // gpt-5 does not support "none" but "minimal"
@@ -299,7 +299,7 @@ export const GPT_5_NANO_MODEL_CONFIG: ModelConfigurationType = {
   recommendedExhaustiveTopK: 64, // 32_768
   largeModel: true,
   description: "OpenAI's fastest, and most cost-efficient version of GPT-5",
-  shortDescription: "OpenAI's latest model.",
+  shortDescription: "OpenAI's fastest model.",
   isLegacy: false,
   isLatest: true,
   generationTokensCount: 128_000,


### PR DESCRIPTION
## Description

Update openai model descrition and set 5.2 as latest flagship to encourage using it
There are some problems with gpt 5 tool call arguments

## Tests

local

## Risk

low

## Deploy Plan

front
