### PR TITLE
Add retry button on cancelled messages

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -838,6 +838,7 @@ export function AgentMessage({
               owner={owner}
               conversationId={conversationId}
               retryHandler={retryHandler}
+              isRetryHandlerProcessing={isRetryHandlerProcessing}
               isLastMessage={isLastMessage}
               agentMessage={agentMessage}
               references={references}
@@ -877,6 +878,7 @@ function AgentMessageContent({
   activeReferences,
   setActiveReferences,
   retryHandler,
+  isRetryHandlerProcessing,
   onQuickReplySend,
   additionalMarkdownComponents: propsAdditionalMarkdownComponents,
   additionalMarkdownPlugins,
@@ -890,6 +892,7 @@ function AgentMessageContent({
     messageId: string;
     blockedOnly?: boolean;
   }) => Promise<void>;
+  isRetryHandlerProcessing: boolean;
   agentMessage: MessageTemporaryState;
   references: { [key: string]: MCPReferenceCitation };
   streaming: boolean;
@@ -1198,8 +1201,10 @@ function AgentMessageContent({
                       messageId: agentMessage.sId,
                     });
                   },
+                  disabled: isRetryHandlerProcessing,
                 },
               ]}
+              align="end"
             />
           </div>
         </div>

--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -1174,8 +1174,34 @@ function AgentMessageContent({
         </div>
       )}
       {agentMessage.status === "cancelled" && (
-        <div className="text-faint dark:text-faint-night">
-          Message generation was interrupted
+        <div className="flex flex-col gap-2">
+          <div className="text-faint dark:text-faint-night">
+            Message generation was interrupted
+          </div>
+          <div>
+            <ButtonGroupDropdown
+              trigger={
+                <Button
+                  variant="outline"
+                  size="xs"
+                  icon={MoreIcon}
+                  className="text-muted-foreground"
+                />
+              }
+              items={[
+                {
+                  label: "Retry",
+                  icon: ArrowPathIcon,
+                  onSelect: () => {
+                    void retryHandler({
+                      conversationId,
+                      messageId: agentMessage.sId,
+                    });
+                  },
+                },
+              ]}
+            />
+          </div>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Description

Closes https://github.com/dust-tt/tasks/issues/6526

Add a retry button for canceled message, inside a ... menu similar to normal messages for look consistency

<img width="1888" height="1050" alt="image" src="https://github.com/user-attachments/assets/b5a6bdfd-fb84-42ec-9371-856371be3a84" />


https://github.com/user-attachments/assets/3de8b1f5-e419-4d11-b1a9-1d88da98d920



## Tests

locally tested

## Risk

low

## Deploy Plan

deploy front
