### PR TITLE
Don't invalidate user

### DIFF
--- a/front/lib/swr/user.ts
+++ b/front/lib/swr/user.ts
@@ -23,11 +23,12 @@ export function useUser(
   }
 ) {
   const userFetcher: Fetcher<GetUserResponseBody> = fetcher;
-  const { data, error, mutate } = useSWRWithDefaults(
-    "/api/user",
-    userFetcher,
-    swrOptions
-  );
+  const { data, error, mutate } = useSWRWithDefaults("/api/user", userFetcher, {
+    revalidateOnFocus: false,
+    revalidateOnReconnect: false,
+    revalidateIfStale: false,
+    ...swrOptions,
+  });
 
   return {
     user: data ? data.user : null,


### PR DESCRIPTION
## Description

Disable automatic revalidation for the `/api/user` SWR hook to avoid unnecessary refetches. The user data rarely changes during a session, so `revalidateOnFocus`, `revalidateOnReconnect`, and `revalidateIfStale` are set to `false` by default (can still be overridden via `swrOptions`).

This fixes issues where user data invalidation caused unwanted re-renders and stale dependency errors (e.g., Vite "Outdated Optimize Dep").

## Tests

Manual — verified the user hook no longer refetches on tab focus/reconnect.

## Risk

Low. Only changes default SWR caching behavior for the user hook. Callers can still override via `swrOptions`.

## Deploy Plan

Standard deploy, no migration needed.