### PR TITLE
Deprecate agent loop patch

### DIFF
--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -158,7 +158,7 @@ export async function agentLoopWorkflow({
         typeof agentLoopConversationTitleWorkflow
       > | null = null;
 
-      // TODO(2026-03-11): Remove deprecatePatch() and old activity registrations.
+      // TODO(2026-02-12): Remove deprecatePatch() and old activity registrations.
       deprecatePatch(USE_INSTRUMENTATION_SINKS_PATCH);
       metrics.logPhaseStart(
         authType.workspaceId,

--- a/front/temporal/agent_loop/workflows.ts
+++ b/front/temporal/agent_loop/workflows.ts
@@ -5,7 +5,7 @@ import type {
 } from "@temporalio/workflow";
 import {
   CancellationScope,
-  patched,
+  deprecatePatch,
   proxyActivities,
   proxySinks,
   setHandler,
@@ -21,7 +21,6 @@ import {
 import type { AuthenticatorType } from "@app/lib/auth";
 import type * as ensureTitleActivities from "@app/temporal/agent_loop/activities/ensure_conversation_title";
 import type * as finalizeActivities from "@app/temporal/agent_loop/activities/finalize";
-import type * as instrumentationActivities from "@app/temporal/agent_loop/activities/instrumentation";
 import type * as publishDeferredEventsActivities from "@app/temporal/agent_loop/activities/publish_deferred_events";
 import type * as runModelAndCreateWrapperActivities from "@app/temporal/agent_loop/activities/run_model_and_create_actions_wrapper";
 import type * as runToolActivities from "@app/temporal/agent_loop/activities/run_tool";
@@ -95,14 +94,6 @@ const { publishDeferredEventsActivity } = proxyActivities<
   startToCloseTimeout: "2 minutes",
 });
 
-const {
-  logAgentLoopPhaseStartActivity,
-  logAgentLoopPhaseCompletionActivity,
-  logAgentLoopStepCompletionActivity,
-} = proxyActivities<typeof instrumentationActivities>({
-  startToCloseTimeout: "30 seconds",
-});
-
 const { metrics } = proxySinks<AgentLoopInstrumentationSinks>();
 
 const { ensureConversationTitleActivity } = proxyActivities<
@@ -167,27 +158,14 @@ export async function agentLoopWorkflow({
         typeof agentLoopConversationTitleWorkflow
       > | null = null;
 
-      // Patch lifecycle for instrumentation sinks:
-      // 1. Now: patched() routes new workflows to sinks, replaying workflows use old activities.
-      // 2. TODO: Replace patched() withdeprecatePatch().
-      // 3. TODO: Remove deprecatePatch() and old activity calls.
-      if (patched(USE_INSTRUMENTATION_SINKS_PATCH)) {
-        metrics.logPhaseStart(
-          authType.workspaceId,
-          agentMessageId,
-          conversationId,
-          startStep
-        );
-      } else {
-        await logAgentLoopPhaseStartActivity({
-          authType,
-          eventData: {
-            agentMessageId,
-            conversationId,
-            startStep,
-          },
-        });
-      }
+      // TODO(2026-03-11): Remove deprecatePatch() and old activity registrations.
+      deprecatePatch(USE_INSTRUMENTATION_SINKS_PATCH);
+      metrics.logPhaseStart(
+        authType.workspaceId,
+        agentMessageId,
+        conversationId,
+        startStep
+      );
 
       for (let i = startStep; i < MAX_STEPS_USE_PER_RUN_LIMIT + 1; i++) {
         currentStep = i;
@@ -210,21 +188,12 @@ export async function agentLoopWorkflow({
           runIds.push(runId);
         }
 
-        if (patched(USE_INSTRUMENTATION_SINKS_PATCH)) {
-          metrics.logStepCompletion(
-            agentMessageId,
-            conversationId,
-            currentStep,
-            stepStartTime
-          );
-        } else {
-          await logAgentLoopStepCompletionActivity({
-            agentMessageId,
-            conversationId,
-            step: currentStep,
-            stepStartTime,
-          });
-        }
+        metrics.logStepCompletion(
+          agentMessageId,
+          conversationId,
+          currentStep,
+          stepStartTime
+        );
 
         // After the first step completes, launch title generation in the background.
         // We wait until the first step so the agent has at least one response in the database,
@@ -257,27 +226,14 @@ export async function agentLoopWorkflow({
 
       const stepsCompleted = currentStep - startStep;
 
-      if (patched(USE_INSTRUMENTATION_SINKS_PATCH)) {
-        metrics.logPhaseCompletion(
-          authType.workspaceId,
-          agentMessageId,
-          conversationId,
-          initialStartTime,
-          stepsCompleted,
-          syncStartTime
-        );
-      } else {
-        await logAgentLoopPhaseCompletionActivity({
-          authType,
-          eventData: {
-            agentMessageId,
-            conversationId,
-            initialStartTime,
-            stepsCompleted,
-            syncStartTime,
-          },
-        });
-      }
+      metrics.logPhaseCompletion(
+        authType.workspaceId,
+        agentMessageId,
+        conversationId,
+        initialStartTime,
+        stepsCompleted,
+        syncStartTime
+      );
 
       await CancellationScope.nonCancellable(async () => {
         await finalizeSuccessfulAgentLoopActivity(authType, agentLoopArgs);


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR is a follow up of https://github.com/dust-tt/dust/pull/21498.

It deprecates the patch introduced to use sinks over activities for the instrumentation. All in-flight agent loops are running the new code already.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
