### PR TITLE
fix: fix main

### DIFF
--- a/.github/workflows/build-and-lint-front.yml
+++ b/.github/workflows/build-and-lint-front.yml
@@ -22,6 +22,16 @@ jobs:
         shardIndex: [1, 2, 3]
         shardTotal: [3]
     runs-on: ubuntu-latest
+    services:
+      redis:
+        image: redis:7.2.5
+        ports:
+          - 5434:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@v3
       - name: Setup Node Dependencies
@@ -29,12 +39,6 @@ jobs:
         with:
           build-sdks: "true"
           build-sparkle: "true"
-      - name: Install Redis
-        uses: chenjuneking/redis-setup-action@v1
-        with:
-          version: "7.2.5"
-          hostPort: 5434
-          containerPort: 6379
       - name: Install Postgres
         uses: dust-tt/postgresql-action@91c1ba371e7f9529945c312bb2883e9e0630063b
         with:

--- a/biome.json
+++ b/biome.json
@@ -25,7 +25,8 @@
       "!!extension/packages",
       "!!**/package-lock.json",
       "!!**/__snapshots__",
-      "lefthook.yml"
+      "lefthook.yml",
+      ".github/*.yml"
     ]
   },
   "formatter": {


### PR DESCRIPTION
## Description

What changed                                                                                                                                                                                                   
                                  
  File: .github/workflows/build-and-lint-front.yml                                                                                                                                                               
                                                                                                                                                                                                                 
  Before: Used chenjuneking/redis-setup-action@v1 — a third-party action that internally runs docker run to start Redis. This broke when GitHub upgraded ubuntu-latest runners to Docker API v1.44+, since the
  action's Docker client is pinned to v1.40.

  After: Uses a native GitHub Actions service container (services.redis). This is the standard, supported way to run sidecar services in GitHub Actions. It:
  - Starts Redis 7.2.5 before any steps run
  - Maps port 5434 → 6379 (same as before)
  - Includes health checks so the job waits until Redis is actually ready
  - Doesn't depend on any third-party action or Docker client version
  
## Tests

CI

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
