### PR TITLE
[Front] Clarify user-message navigation tooltips

### DIFF
--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -298,14 +298,14 @@ export const AgentInputBar = ({
                   onClick={scrollToPreviousUserMessage}
                   disabled={!canScrollUp}
                   size="xs"
-                  tooltip="Previous message"
+                  tooltip="Previous user message"
                 />
                 <IconButton
                   icon={ArrowDownIcon}
                   onClick={scrollToNextUserMessage}
                   disabled={!canScrollDown}
                   size="xs"
-                  tooltip="Next message"
+                  tooltip="Next user message"
                 />
               </>
             )}


### PR DESCRIPTION
## Description
Context: [slack thread](https://dust4ai.slack.com/archives/C09T7N4S6GG/p1770891967936119)

Clarifies the conversation navigation tooltips to “previous/next user message”, matching the current behavior.

## Risks
Blast radius: Conversation message navigation tooltip copy
Risk: low

## Deploy Plan
- deploy front