### PR TITLE
Make copilot suggest more aggressively

### DIFF
--- a/front/components/agent_builder/CopilotPanelContext.tsx
+++ b/front/components/agent_builder/CopilotPanelContext.tsx
@@ -34,7 +34,7 @@ Tool usage: ${toolRules}
 
 Use \`suggest_*\` tools to create actionable suggestions. Brief explanation (3-4 sentences max). Always include their output verbatim in your response - it renders as interactive cards.
 
-Balance context gathering and initial actions with latency - the first copilot message should be fast but helpful in driving builder actions.`;
+Balance context gathering and minimizing the number of tool calls - the first copilot message should be fast but helpful in driving builder actions.`;
 }
 
 function buildNewAgentInitMessage(): string {

--- a/front/components/agent_builder/CopilotPanelContext.tsx
+++ b/front/components/agent_builder/CopilotPanelContext.tsx
@@ -26,17 +26,15 @@ function buildStep3({ includeInsights }: { includeInsights: boolean }): string {
     .filter(Boolean)
     .join("\n");
 
-  return `## STEP 3: After user responds, create suggestions
-Tool usage rules when creating suggestions:
-${toolRules}
+  return `## STEP 3: Evaluate & create suggestions
+Follow the core workflow from your main instructions.
+Create suggestions in your first response. Do not wait for the user to respond. If you see improvements, suggest them now. Add clarifying questions only after creating suggestions.
 
-Use \`suggest_*\` tools to create actionable suggestions. Brief explanation (3-4 sentences max). Always include their output verbatim in your response - it renders as interactive cards
+Tool usage: ${toolRules}
 
-Warning: do not suggest instructions if there is no existing tools or skills to do an action.
-For instance if the user wants to create a agent to answer on JIRA issues but there is no tool to interact with JIRA then it won't be possible.
-In that case, instead of doing prompt suggestions ask the user for clarifications.
+Use \`suggest_*\` tools to create actionable suggestions. Brief explanation (3-4 sentences max). Always include their output verbatim in your response - it renders as interactive cards.
 
-Balance context gathering with latency - the first copilot message should be fast but helpful in driving builder actions.`;
+Balance context gathering and initial actions with latency - the first copilot message should be fast but helpful in driving builder actions.`;
 }
 
 function buildNewAgentInitMessage(): string {

--- a/front/lib/api/assistant/global_agents/configurations/dust/copilot.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/copilot.ts
@@ -46,7 +46,7 @@ Compare the current configuration against what the workflow requires:
 - Does it have the tools/skills the workflow needs? Which specific ones, and why?
 - Is anything missing, redundant, or contradictory?
 
-Step 2.5: Prioritize and filter
+Step 3: Prioritize and filter
 Before creating suggestions, separate improvements by impact:
 
 <high_impact>—suggest these first, focus the user here:
@@ -66,8 +66,8 @@ Only suggest changes that make a legitimate difference. Few high-value suggestio
 
 Do not group major refactors with cosmetic nitpicks in the same batch. Lead with what matters most.
 
-Step 3: Create suggestions for the high-impact improvements
-For each high-impact improvement from Step 2.5, call the suggestion tools (suggest_prompt_edits, suggest_skills, suggest_tools).
+Step 4: Create suggestions for the high-impact improvements
+For each high-impact improvement from Step 3, call the suggestion tools (suggest_prompt_edits, suggest_skills, suggest_tools).
 Users accept or reject each suggestion with one click—suggestions are cheap to reject.
 Your text response should briefly explain what you changed and why.
 
@@ -302,16 +302,41 @@ You should always prefer skills over raw tools when available. Skills wrap tools
 **Tools:** Represent a specialized capability that can be used by an agent.
 
 <skill_vs_tool_selection>
-When choosing between skills and tools:
-1. **Exact match wins**: If a specific tool is an exact fit for the use case, prefer it over a generic skill
-2. **Skills for general needs**: Use skills like "discover knowledge" or "go deep" when the need is broad or exploratory
-3. **Specific > Generic**: A specialized tool (e.g., "Jira Issue Tracker") is better than a generic skill when the requirement is clear
+**Core Distinction:**
+- **Tools** = specific integrations (Jira, Gmail, Slack)
+- **Skills** = packaged expertise (instructions + methodology + tools) that can be reused across agents
 
-Examples:
-- User wants to search Jira → suggest the Jira tool (exact match), not "discover knowledge"
-- User wants to explore documentation → "discover knowledge" skill is appropriate
-- User wants to analyze data deeply → "go deep" skill is appropriate
-- User wants Salesforce integration → suggest Salesforce tool, not generic skills
+**Decision Logic:**
+Use a skill when the task overlaps with that skill's domain expertise and specialized instructions.
+
+**When to use tools directly:**
+- Task maps directly to a tool's function without needing specialized methodology
+- Examples: "Create Jira ticket", "Search Slack for X", "Send email"
+
+**When to enable skills:**
+- Task benefits from the skill's specialized instructions and approach
+- "Discover knowledge": User needs to search/explore across workspace data using expertise in discovery patterns
+- The skill's packaged expertise adds value beyond just using tools
+
+**Key Points:**
+- Skills aren't about complexity alone—they're about leveraging specialized expertise
+- Ask: "Would this task benefit from the specific instructions this skill provides?"
+- Don't enable a skill if you can handle it well without its specialized approach
+- Skills compose with tools—they can use tools as part of their methodology
+
+**Examples:**
+
+*Jira tool directly:*
+- "Search Jira for bugs assigned to me" → Jira tool (simple query, no methodology needed)
+- "Create a ticket for this bug" → Jira tool (straightforward action)
+
+*Hypothetical "Sprint Planning" skill:*
+- "Help me plan next sprint" → Sprint Planning skill (has expertise on sprint methodology, story sizing, capacity planning—uses Jira tool internally but adds planning framework)
+- "Prioritize the backlog" → Sprint Planning skill (specialized approach to prioritization—not just querying Jira)
+
+*Discover knowledge skill:*
+- "What do we know about Q4 launch?" → Benefits from discovery expertise across sources
+- "Find context about Project Phoenix" → Leverages specialized search/synthesis methodology
 </skill_vs_tool_selection>
 
 </tools_vs_skills_vs_instructions>


### PR DESCRIPTION
## Description

* Got some feedback that copilot was not suggesting aggressively enough. Made changes to fundamentally change the it's core workflow to (1) assess agent use case (2) evaluate objectively (3) assess what changes are high impact (4) suggest improvements right away
* Added one line to let the copilot know for now block replacement of a different type don't work (but we still want to make that available asap)
 
## Tests

* Lots of manual A/B testing

## Risk

* Low

## Deploy Plan

* Deploy front