### PR TITLE
[CI] Use Redis service in core workflow

### DIFF
--- a/.github/workflows/build-and-test-core.yml
+++ b/.github/workflows/build-and-test-core.yml
@@ -44,6 +44,16 @@ jobs:
     runs-on: ubuntu-latest
     needs: check-changes
     if: needs.check-changes.outputs.core-changed == 'true'
+    services:
+      redis:
+        image: redis:7.2.5
+        ports:
+          - 5434:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -54,13 +64,6 @@ jobs:
           profile: minimal
           toolchain: stable
           components: cargo, rustfmt, rust-std, rustc
-
-      - name: Install Redis
-        uses: chenjuneking/redis-setup-action@v1
-        with:
-          version: "7.2.5"
-          hostPort: 5434
-          containerPort: 6379
 
       - name: Install Postgres
         uses: dust-tt/postgresql-action@91c1ba371e7f9529945c312bb2883e9e0630063b


### PR DESCRIPTION
## Description
Replace the Redis setup GitHub Action with a `services: redis` container in the core CI workflow.

This avoids failures from running `docker` inside an action container with an outdated Docker client.

## Risks
Blast radius: CI (core workflow Redis setup)
Risk: low

## Deploy Plan
- no deploy (CI only)