### PR TITLE
[Front] Increase Vitest CI test timeout

### DIFF
--- a/front/package.json
+++ b/front/package.json
@@ -29,7 +29,7 @@
     "tsgo": "tsgo",
     "test": "FRONT_DATABASE_URI=$TEST_FRONT_DATABASE_URI REDIS_URI=$TEST_REDIS_URI REDIS_CACHE_URI=$TEST_REDIS_URI vitest --run",
     "test:watch": "FRONT_DATABASE_URI=$TEST_FRONT_DATABASE_URI REDIS_URI=$TEST_REDIS_URI REDIS_CACHE_URI=$TEST_REDIS_URI vitest --watch",
-    "test:ci": "vitest --reporter=junit --watch=false --test-timeout=10000",
+    "test:ci": "vitest --reporter=junit --watch=false --test-timeout=30000",
     "coverage": "vitest --coverage",
     "initdb": "./admin/init_db.sh",
     "create-db-migration": "./create_db_migration_file.sh",


### PR DESCRIPTION
## Description
Increase the Vitest per-test timeout in CI from 10s to 30s to reduce flakes on slower GitHub runners.

CI is slower/noisier than local, and a 10s per-test timeout is tight for integration-y front tests (DB/Redis). This reduces false-red runs without removing the timeout (still bounded).

## Risks
Blast radius: Front test suite execution time/behavior in CI
Risk: low

## Deploy Plan
- no deploy (tests/CI only)