### PR TITLE
[Front] Stabilize restricted project space access test

### DIFF
--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -1844,24 +1844,11 @@ describe("Space Handling", () => {
         await MembershipFactory.associate(workspace, memberUser, {
           role: "user",
         });
-        const projectMemberGroup = await GroupResource.makeNew(
-          {
-            name: "Group for project Restricted Project Space",
-            workspaceId: workspace.id,
-            kind: "regular",
-          },
-          { memberIds: [memberUser.id] }
-        );
-
-        const projectSpace = await SpaceResource.makeNew(
-          {
-            name: "Restricted Project Space",
-            kind: "project",
-            workspaceId: workspace.id,
-            managementMode: "manual",
-          },
-          { members: [projectMemberGroup] }
-        );
+        const projectSpace = await SpaceFactory.project(workspace);
+        const addMemberRes = await projectSpace.addMembers(internalAdminAuth, {
+          userIds: [memberUser.sId],
+        });
+        assert(addMemberRes.isOk(), "Failed to add member to project space.");
 
         const memberAuth = await Authenticator.fromUserIdAndWorkspaceId(
           memberUser.sId,

--- a/front/lib/resources/conversation_resource.test.ts
+++ b/front/lib/resources/conversation_resource.test.ts
@@ -9,7 +9,6 @@ import {
 } from "vitest";
 
 import { destroyConversation } from "@app/lib/api/assistant/conversation/destroy";
-import { createSpaceAndGroup } from "@app/lib/api/spaces";
 import { Authenticator } from "@app/lib/auth";
 import {
   ConversationModel,
@@ -50,6 +49,8 @@ vi.mock(import("../../lib/api/redis"), async (importOriginal) => {
     ),
   };
 });
+
+const RESTRICTED_PROJECT_SPACE_ACCESS_TEST_TIMEOUT_MS = 30_000;
 
 const setupTestAgents = async (
   workspace: LightWorkspaceType,
@@ -1829,99 +1830,78 @@ describe("Space Handling", () => {
   });
 
   describe("restricted project space access", () => {
-    it("should not allow a user not in a restricted project space to fetch a conversation in that space", async () => {
-      // Create a workspace
-      const workspace = await WorkspaceFactory.basic();
+    it(
+      "should not allow a user not in a restricted project space to fetch a conversation in that space",
+      async () => {
+        const workspace = await WorkspaceFactory.basic();
 
-      // Set up default spaces (global, system, conversations) for the workspace first
-      const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
-        workspace.sId
-      );
-      await SpaceFactory.defaults(internalAdminAuth);
+        const internalAdminAuth = await Authenticator.internalAdminForWorkspace(
+          workspace.sId
+        );
+        await SpaceFactory.defaults(internalAdminAuth);
 
-      // Create an admin user to create the project space
-      const adminUser = await UserFactory.basic();
-      await MembershipFactory.associate(workspace, adminUser, {
-        role: "admin",
-      });
-      const adminAuth = await Authenticator.fromUserIdAndWorkspaceId(
-        adminUser.sId,
-        workspace.sId
-      );
+        const memberUser = await UserFactory.basic();
+        await MembershipFactory.associate(workspace, memberUser, {
+          role: "user",
+        });
+        const projectMemberGroup = await GroupResource.makeNew(
+          {
+            name: "Group for project Restricted Project Space",
+            workspaceId: workspace.id,
+            kind: "regular",
+          },
+          { memberIds: [memberUser.id] }
+        );
 
-      // Create a user who will be a member of the project space
-      const memberUser = await UserFactory.basic();
-      await MembershipFactory.associate(workspace, memberUser, {
-        role: "user",
-      });
-      const memberAuth = await Authenticator.fromUserIdAndWorkspaceId(
-        memberUser.sId,
-        workspace.sId
-      );
+        const projectSpace = await SpaceResource.makeNew(
+          {
+            name: "Restricted Project Space",
+            kind: "project",
+            workspaceId: workspace.id,
+            managementMode: "manual",
+          },
+          { members: [projectMemberGroup] }
+        );
 
-      // Create a restricted project space using admin auth
-      const projectSpaceResult = await createSpaceAndGroup(adminAuth, {
-        name: "Restricted Project Space",
-        isRestricted: true,
-        spaceKind: "project",
-        managementMode: "manual",
-        memberIds: [],
-      });
+        const memberAuth = await Authenticator.fromUserIdAndWorkspaceId(
+          memberUser.sId,
+          workspace.sId
+        );
 
-      expect(projectSpaceResult.isOk()).toBe(true);
-      if (!projectSpaceResult.isOk()) {
-        throw new Error("Failed to create restricted project space");
-      }
-      const projectSpace = projectSpaceResult.value;
+        // Create a conversation with the project space id using the member user
+        const conversation = await ConversationResource.makeNew(
+          memberAuth,
+          {
+            title: "Test conversation in restricted project",
+            sId: generateRandomModelSId(),
+            spaceId: projectSpace.id,
+            requestedSpaceIds: [],
+          },
+          projectSpace
+        );
 
-      // Add the member user to the project space
-      const addMemberResult = await projectSpace.addMembers(adminAuth, {
-        userIds: [memberUser.sId],
-      });
-      expect(addMemberResult.isOk()).toBe(true);
+        // Create another user in the same workspace who is NOT part of the project space
+        const nonMemberUser = await UserFactory.basic();
+        await MembershipFactory.associate(workspace, nonMemberUser, {
+          role: "user",
+        });
+        const nonMemberAuth = await Authenticator.fromUserIdAndWorkspaceId(
+          nonMemberUser.sId,
+          workspace.sId
+        );
 
-      // Reload the authenticator to get updated group memberships
-      await memberAuth.refresh();
+        // Try to fetch the conversation with the non-member user's authenticator
+        // This should fail (return null) because the user is not part of the restricted project space
+        const fetchedConversation = await ConversationResource.fetchById(
+          nonMemberAuth,
+          conversation.sId
+        );
 
-      // Reload the space to get updated group memberships
-      const reloadedProjectSpace = await SpaceResource.fetchById(
-        memberAuth,
-        projectSpace.sId
-      );
-      expect(reloadedProjectSpace).not.toBeNull();
-
-      // Create a conversation with the project space id using the member user
-      const conversation = await ConversationResource.makeNew(
-        memberAuth,
-        {
-          title: "Test conversation in restricted project",
-          sId: generateRandomModelSId(),
-          spaceId: reloadedProjectSpace!.id,
-          requestedSpaceIds: [],
-        },
-        reloadedProjectSpace!
-      );
-
-      // Create another user in the same workspace who is NOT part of the project space
-      const nonMemberUser = await UserFactory.basic();
-      await MembershipFactory.associate(workspace, nonMemberUser, {
-        role: "user",
-      });
-      const nonMemberAuth = await Authenticator.fromUserIdAndWorkspaceId(
-        nonMemberUser.sId,
-        workspace.sId
-      );
-
-      // Try to fetch the conversation with the non-member user's authenticator
-      // This should fail (return null) because the user is not part of the restricted project space
-      const fetchedConversation = await ConversationResource.fetchById(
-        nonMemberAuth,
-        conversation.sId
-      );
-
-      // The conversation should not be accessible to the non-member user
-      expect(fetchedConversation).toBeNull();
-    });
+        // The conversation should not be accessible to the non-member user
+        expect(fetchedConversation).toBeNull();
+      },
+      RESTRICTED_PROJECT_SPACE_ACCESS_TEST_TIMEOUT_MS
+    );
   });
 
   describe("canAccess", () => {


### PR DESCRIPTION
## Description
Stabilize the `restricted project space access` test by avoiding the `createSpaceAndGroup` helper for project spaces (it triggers `createDataSourceAndConnectorForProject`, which can make Core/Connectors API calls and add variable latency in CI).

Changes:
- Use `SpaceFactory.project` for project space setup.
- Add the user to the project space and build the member `Authenticator` after membership is applied (no membership refresh / space reload needed).
- Add an explicit 30s per-test timeout.

The assertion is unchanged: a non-member cannot `ConversationResource.fetchById` for a conversation in a restricted project space.

## Risks
Blast radius: Front unit tests only
Risk: low

## Deploy Plan
- no deploy (tests only)
