### PR TITLE
Add sparkle editor with top bar component

### DIFF
--- a/sparkle/src/components/ContainerWithTopBar.tsx
+++ b/sparkle/src/components/ContainerWithTopBar.tsx
@@ -1,7 +1,7 @@
 import { cn } from "@sparkle/lib/utils";
 import React, { type ReactNode } from "react";
 
-export interface EditorWithTopBarProps {
+export interface ContainerWithTopBarProps {
   children: ReactNode;
   topBar: ReactNode;
   error?: boolean;
@@ -9,30 +9,30 @@ export interface EditorWithTopBarProps {
 }
 
 /**
- * Container for rich text editors with a sticky top toolbar.
- * Provides a bordered container with focus states and a sticky header bar.
+ * Bordered container with a sticky top bar and focus states.
+ * Use for editors, forms, or any content that needs a toolbar header.
  *
  * @example
  * ```tsx
- * <EditorWithTopBar
- *   topBar={<MyToolbar editor={editor} />}
+ * <ContainerWithTopBar
+ *   topBar={<MyToolbar />}
  *   error={hasError}
  * >
  *   <EditorContent editor={editor} />
- * </EditorWithTopBar>
+ * </ContainerWithTopBar>
  * ```
  */
-export function EditorWithTopBar({
+export function ContainerWithTopBar({
   children,
   topBar,
   error = false,
   className,
-}: EditorWithTopBarProps) {
+}: ContainerWithTopBarProps) {
   return (
     <div
       className={cn(
         "s-flex s-w-full s-flex-col",
-        "s-rounded-xl s-border s-bg-muted-background s-transition-all s-duration-200",
+        "s-rounded-xl s-border s-bg-muted-background dark:s-bg-muted-background-night s-transition-all s-duration-200",
         "s-border-border dark:s-border-border-night",
         "focus-within:s-border-border-focus dark:focus-within:s-border-border-focus-night",
         "focus-within:s-outline-none focus-within:s-ring-2",

--- a/sparkle/src/components/EditorWithTopBar.tsx
+++ b/sparkle/src/components/EditorWithTopBar.tsx
@@ -38,8 +38,7 @@ export function EditorWithTopBar({
         "focus-within:s-outline-none focus-within:s-ring-2",
         "focus-within:s-ring-highlight/20 dark:focus-within:s-ring-highlight/50",
         "s-min-h-40",
-        error &&
-          "s-border-warning-500 dark:s-border-warning-500-night",
+        error && "s-border-warning-500 dark:s-border-warning-500-night",
         className
       )}
     >

--- a/sparkle/src/components/EditorWithTopBar.tsx
+++ b/sparkle/src/components/EditorWithTopBar.tsx
@@ -1,0 +1,58 @@
+import { cn } from "@sparkle/lib/utils";
+import React, { type ReactNode } from "react";
+
+export interface EditorWithTopBarProps {
+  children: ReactNode;
+  topBar: ReactNode;
+  error?: boolean;
+  className?: string;
+}
+
+/**
+ * Container for rich text editors with a sticky top toolbar.
+ * Provides a bordered container with focus states and a sticky header bar.
+ *
+ * @example
+ * ```tsx
+ * <EditorWithTopBar
+ *   topBar={<MyToolbar editor={editor} />}
+ *   error={hasError}
+ * >
+ *   <EditorContent editor={editor} />
+ * </EditorWithTopBar>
+ * ```
+ */
+export function EditorWithTopBar({
+  children,
+  topBar,
+  error = false,
+  className,
+}: EditorWithTopBarProps) {
+  return (
+    <div
+      className={cn(
+        "s-flex s-w-full s-flex-col",
+        "s-rounded-xl s-border s-bg-muted-background s-transition-all s-duration-200",
+        "s-border-border dark:s-border-border-night",
+        "focus-within:s-border-border-focus dark:focus-within:s-border-border-focus-night",
+        "focus-within:s-outline-none focus-within:s-ring-2",
+        "focus-within:s-ring-highlight/20 dark:focus-within:s-ring-highlight/50",
+        "s-min-h-40",
+        error &&
+          "s-border-warning-500 dark:s-border-warning-500-night",
+        className
+      )}
+    >
+      <div
+        className={cn(
+          "s-sticky s-top-0 s-z-10 s-flex s-items-center s-rounded-t-xl",
+          "s-border-b s-border-border dark:s-border-border-night",
+          "s-bg-muted-background/80 s-backdrop-blur-sm dark:s-bg-muted-background-night/80"
+        )}
+      >
+        {topBar}
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -112,6 +112,10 @@ export {
   DropdownTooltipTrigger,
 } from "./Dropdown";
 export { default as DropzoneOverlay } from "./DropzoneOverlay";
+export {
+  EditorWithTopBar,
+  type EditorWithTopBarProps,
+} from "./EditorWithTopBar";
 export type { EmojiMartData } from "./EmojiPicker";
 export { DataEmojiMart, EmojiPicker } from "./EmojiPicker";
 export { EmptyCTA, EmptyCTAButton } from "./EmptyCTA";

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -41,6 +41,10 @@ export {
 export { default as ConfettiBackground } from "./ConfettiBackground";
 export { Container } from "./Container";
 export {
+  ContainerWithTopBar,
+  type ContainerWithTopBarProps,
+} from "./ContainerWithTopBar";
+export {
   ContentMessage,
   ContentMessageAction,
   ContentMessageInline,
@@ -112,10 +116,6 @@ export {
   DropdownTooltipTrigger,
 } from "./Dropdown";
 export { default as DropzoneOverlay } from "./DropzoneOverlay";
-export {
-  ContainerWithTopBar,
-  type ContainerWithTopBarProps,
-} from "./ContainerWithTopBar";
 export type { EmojiMartData } from "./EmojiPicker";
 export { DataEmojiMart, EmojiPicker } from "./EmojiPicker";
 export { EmptyCTA, EmptyCTAButton } from "./EmptyCTA";

--- a/sparkle/src/components/index.ts
+++ b/sparkle/src/components/index.ts
@@ -113,9 +113,9 @@ export {
 } from "./Dropdown";
 export { default as DropzoneOverlay } from "./DropzoneOverlay";
 export {
-  EditorWithTopBar,
-  type EditorWithTopBarProps,
-} from "./EditorWithTopBar";
+  ContainerWithTopBar,
+  type ContainerWithTopBarProps,
+} from "./ContainerWithTopBar";
 export type { EmojiMartData } from "./EmojiPicker";
 export { DataEmojiMart, EmojiPicker } from "./EmojiPicker";
 export { EmptyCTA, EmptyCTAButton } from "./EmptyCTA";

--- a/sparkle/src/stories/ContainerWithTopBar.stories.tsx
+++ b/sparkle/src/stories/ContainerWithTopBar.stories.tsx
@@ -1,0 +1,64 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import React from "react";
+
+import {
+  BoldIcon,
+  Button,
+  ContainerWithTopBar,
+  ItalicIcon,
+  LinkIcon,
+} from "../index_with_tw_base";
+
+const meta = {
+  title: "Primitives/ContainerWithTopBar",
+  component: ContainerWithTopBar,
+} satisfies Meta<typeof ContainerWithTopBar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const MockToolbar = () => (
+  <div className="s-flex s-items-center s-gap-1 s-px-3 s-py-2">
+    <Button
+      icon={BoldIcon}
+      size="icon"
+      variant="ghost-secondary"
+      tooltip="Bold"
+    />
+    <Button
+      icon={ItalicIcon}
+      size="icon"
+      variant="ghost-secondary"
+      tooltip="Italic"
+    />
+    <Button
+      icon={LinkIcon}
+      size="icon"
+      variant="ghost-secondary"
+      tooltip="Link"
+    />
+  </div>
+);
+
+export const Default: Story = {
+  args: {
+    topBar: <MockToolbar />,
+    children: (
+      <div className="s-p-4 s-text-sm s-text-muted-foreground">
+        Focus inside the container to see the focus ring.
+      </div>
+    ),
+  },
+};
+
+export const WithError: Story = {
+  args: {
+    topBar: <MockToolbar />,
+    error: true,
+    children: (
+      <div className="s-p-4 s-text-sm s-text-muted-foreground">
+        Error state: border turns warning color.
+      </div>
+    ),
+  },
+};


### PR DESCRIPTION
## Description

* Adding sparkle component for having an editor with a top bar
* Meta: I was actually unclear if the standard was to put the type of semi-unique components in front or sparkle, we seemed to be inconsistent, but I biased towards sparkle

## Tests

<img width="732" height="115" alt="Screenshot 2026-02-12 at 4 48 09 PM" src="https://github.com/user-attachments/assets/09d01a7a-8b73-4d5f-a2d4-63cec7157ec8" />


## Risk

* Low

## Deploy Plan

* Deploy sparkle