### PR TITLE
[front] Add "load more" button for poke webhook requests

### DIFF
--- a/front/components/poke/triggers/RecentWebhookRequests.tsx
+++ b/front/components/poke/triggers/RecentWebhookRequests.tsx
@@ -121,7 +121,7 @@ function PokeRecentWebhookRequestsContent({
 
   if (webhookRequests.length === 0) {
     return (
-      <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+      <p className="text-sm text-muted-foreground dark:text-muted-foreground-night pt-2">
         No webhook requests yet.
       </p>
     );

--- a/front/components/poke/triggers/RecentWebhookRequests.tsx
+++ b/front/components/poke/triggers/RecentWebhookRequests.tsx
@@ -1,4 +1,5 @@
 import {
+  Button,
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
@@ -16,6 +17,8 @@ import { WebhookRequestStatusBadge } from "@app/components/agent_builder/trigger
 import { usePokeWebhookRequests } from "@app/poke/swr/triggers";
 import type { TriggerType } from "@app/types/assistant/triggers";
 import type { LightWorkspaceType } from "@app/types/user";
+
+const PAGE_SIZE = 15;
 
 interface PokeRecentWebhookRequestsProps {
   owner: LightWorkspaceType;
@@ -61,7 +64,7 @@ export function PokeRecentWebhookRequests({
         )}
         <Collapsible defaultOpen={defaultOpen} onOpenChange={setIsOpen}>
           <CollapsibleTrigger>
-            <Label className="cursor-pointer">Recent requests (last 15)</Label>
+            <Label className="cursor-pointer">Recent requests</Label>
           </CollapsibleTrigger>
           <CollapsibleContent>
             <PokeRecentWebhookRequestsContent
@@ -82,17 +85,21 @@ interface PokeRecentWebhookRequestsContentProps {
   triggerId: string;
 }
 
+
 function PokeRecentWebhookRequestsContent({
   isOpen,
   owner,
   triggerId,
 }: PokeRecentWebhookRequestsContentProps) {
+  const [limit, setLimit] = useState(PAGE_SIZE);
   const { webhookRequests, isWebhookRequestsLoading, isWebhookRequestsError } =
     usePokeWebhookRequests({
       owner,
       triggerId,
+      limit,
       disabled: !isOpen,
     });
+  const hasMore = webhookRequests.length === limit;
 
   if (isWebhookRequestsLoading || !isOpen) {
     return (
@@ -167,6 +174,16 @@ function PokeRecentWebhookRequestsContent({
           </div>
         ))}
       </div>
+      {hasMore && (
+        <div className="flex justify-center pt-2">
+          <Button
+            variant="outline"
+            size="sm"
+            label="Load more"
+            onClick={() => setLimit((prev) => prev + PAGE_SIZE)}
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/front/components/poke/triggers/RecentWebhookRequests.tsx
+++ b/front/components/poke/triggers/RecentWebhookRequests.tsx
@@ -85,7 +85,6 @@ interface PokeRecentWebhookRequestsContentProps {
   triggerId: string;
 }
 
-
 function PokeRecentWebhookRequestsContent({
   isOpen,
   owner,

--- a/front/pages/api/poke/workspaces/[wId]/triggers/[tId]/webhook_requests.ts
+++ b/front/pages/api/poke/workspaces/[wId]/triggers/[tId]/webhook_requests.ts
@@ -77,8 +77,12 @@ async function handler(
     });
   }
 
+  const { limit: limitParam } = req.query;
+  const limit = isString(limitParam) ? parseInt(limitParam, 10) : undefined;
+
   const r = await fetchRecentWebhookRequestTriggersWithPayload(auth, {
     trigger: trigger.toJSON(),
+    ...(limit && !isNaN(limit) ? { limit } : {}),
   });
 
   return res.status(200).json({ requests: r });

--- a/front/poke/swr/triggers.ts
+++ b/front/poke/swr/triggers.ts
@@ -28,15 +28,22 @@ export function usePokeTriggers({
 export function usePokeWebhookRequests({
   owner,
   triggerId,
+  limit,
   disabled,
 }: {
   owner: LightWorkspaceType;
   triggerId: string;
+  limit?: number;
   disabled?: boolean;
 }) {
   const requestsFetcher: Fetcher<PokeGetWebhookRequestsResponseBody> = fetcher;
+  const params = new URLSearchParams();
+  if (limit !== undefined) {
+    params.set("limit", limit.toString());
+  }
+  const query = params.toString();
   const { data, error, mutate } = useSWRWithDefaults(
-    `/api/poke/workspaces/${owner.sId}/triggers/${triggerId}/webhook_requests`,
+    `/api/poke/workspaces/${owner.sId}/triggers/${triggerId}/webhook_requests${query ? `?${query}` : ""}`,
     requestsFetcher,
     { disabled }
   );


### PR DESCRIPTION
## Description

- This PR adds a button on the poke page for a trigger to load more requests from the history.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
