### PR TITLE
[front] chore(mcp): make `auth` mandatory in tool callbacks

### DIFF
--- a/front/lib/actions/mcp_actions.test.ts
+++ b/front/lib/actions/mcp_actions.test.ts
@@ -17,6 +17,7 @@ import {
 } from "@app/lib/actions/mcp_actions";
 import { internalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
 import { autoInternalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
+import type { DataSourcesToolConfigurationType } from "@app/lib/actions/mcp_internal_actions/input_schemas";
 import type { MCPConnectionParams } from "@app/lib/actions/mcp_metadata";
 import { connectToMCPServer } from "@app/lib/actions/mcp_metadata";
 import type { AgentLoopRunContextType } from "@app/lib/actions/types";
@@ -137,14 +138,12 @@ vi.mock("@app/lib/api/actions/servers/search/tools", async () => {
   const handlersWithTags = {
     ...handlers,
     [FIND_TAGS_TOOL_NAME]: (
-      params: { query: string; dataSources: unknown[] },
-      extra: { auth?: Authenticator }
-    ) =>
-      executeFindTags(
-        params.query,
-        params.dataSources as Parameters<typeof executeFindTags>[1],
-        extra.auth
-      ),
+      params: {
+        query: string;
+        dataSources: DataSourcesToolConfigurationType;
+      },
+      { auth }: { auth: Authenticator }
+    ) => executeFindTags(auth, params.query, params.dataSources),
   };
 
   return {

--- a/front/lib/actions/mcp_internal_actions/tool_definition.ts
+++ b/front/lib/actions/mcp_internal_actions/tool_definition.ts
@@ -22,8 +22,8 @@ export type ToolHandlerExtra = RequestHandlerExtra<
   ServerRequest,
   ServerNotification
 > & {
+  auth: Authenticator;
   agentLoopContext?: AgentLoopContextType;
-  auth?: Authenticator;
 };
 
 export type ToolHandlerResult = Result<CallToolResult["content"], MCPError>;

--- a/front/lib/api/actions/servers/agent_copilot_agent_state/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_copilot_agent_state/tools/index.ts
@@ -12,15 +12,9 @@ import { Err, Ok } from "@app/types/shared/result";
 
 const handlers: ToolHandlers<typeof AGENT_COPILOT_AGENT_STATE_TOOLS_METADATA> =
   {
-    get_agent_info: async (_, extra) => {
-      const auth = extra.auth;
-      if (!auth) {
-        return new Err(new MCPError("Authentication required"));
-      }
-
-      const agentConfigurationId = getAgentConfigurationIdFromContext(
-        extra.agentLoopContext
-      );
+    get_agent_info: async (_, { auth, agentLoopContext }) => {
+      const agentConfigurationId =
+        getAgentConfigurationIdFromContext(agentLoopContext);
 
       if (!agentConfigurationId) {
         return new Err(
@@ -31,9 +25,8 @@ const handlers: ToolHandlers<typeof AGENT_COPILOT_AGENT_STATE_TOOLS_METADATA> =
         );
       }
 
-      const agentVersion = getAgentConfigurationVersionFromContext(
-        extra.agentLoopContext
-      );
+      const agentVersion =
+        getAgentConfigurationVersionFromContext(agentLoopContext);
 
       // Fetch the agent configuration with full details to get the actions.
       const agentConfiguration = await getAgentConfiguration(auth, {

--- a/front/lib/api/actions/servers/agent_copilot_context/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/tools/index.ts
@@ -267,12 +267,7 @@ async function listAvailableSkills(
 }
 
 const handlers: ToolHandlers<typeof AGENT_COPILOT_CONTEXT_TOOLS_METADATA> = {
-  get_available_knowledge: async ({ spaceId, category }, extra) => {
-    const auth = extra.auth;
-    if (!auth) {
-      return new Err(new MCPError("Authentication required"));
-    }
-
+  get_available_knowledge: async ({ spaceId, category }, { auth }) => {
     // Get all spaces the user is a member of.
     let spaces = await SpaceResource.listWorkspaceSpacesAsMember(auth);
 
@@ -371,12 +366,7 @@ const handlers: ToolHandlers<typeof AGENT_COPILOT_CONTEXT_TOOLS_METADATA> = {
     ]);
   },
 
-  get_available_models: async ({ providerId }, extra) => {
-    const auth = extra.auth;
-    if (!auth) {
-      return new Err(new MCPError("Authentication required"));
-    }
-
+  get_available_models: async ({ providerId }, { auth }) => {
     let models = await getAvailableModelsForWorkspace(auth);
 
     if (providerId) {
@@ -415,12 +405,7 @@ const handlers: ToolHandlers<typeof AGENT_COPILOT_CONTEXT_TOOLS_METADATA> = {
     ]);
   },
 
-  get_available_skills: async (_, extra) => {
-    const auth = extra.auth;
-    if (!auth) {
-      return new Err(new MCPError("Authentication required"));
-    }
-
+  get_available_skills: async (_, { auth }) => {
     const skillList = await listAvailableSkills(auth);
 
     return new Ok([
@@ -438,12 +423,7 @@ const handlers: ToolHandlers<typeof AGENT_COPILOT_CONTEXT_TOOLS_METADATA> = {
     ]);
   },
 
-  get_available_tools: async (_, extra) => {
-    const auth = extra.auth;
-    if (!auth) {
-      return new Err(new MCPError("Authentication required"));
-    }
-
+  get_available_tools: async (_, { auth }) => {
     const toolList = await listAvailableTools(auth);
 
     return new Ok([
@@ -461,12 +441,7 @@ const handlers: ToolHandlers<typeof AGENT_COPILOT_CONTEXT_TOOLS_METADATA> = {
     ]);
   },
 
-  get_available_agents: async ({ limit }, extra) => {
-    const auth = extra.auth;
-    if (!auth) {
-      return new Err(new MCPError("Authentication required"));
-    }
-
+  get_available_agents: async ({ limit }, { auth }) => {
     const agents = await getAgentConfigurationsForView({
       auth,
       agentsGetView: "list",
@@ -496,12 +471,7 @@ const handlers: ToolHandlers<typeof AGENT_COPILOT_CONTEXT_TOOLS_METADATA> = {
     ]);
   },
 
-  inspect_available_agent: async ({ agentId }, extra) => {
-    const auth = extra.auth;
-    if (!auth) {
-      return new Err(new MCPError("Authentication required"));
-    }
-
+  inspect_available_agent: async ({ agentId }, { auth }) => {
     const agentConfiguration = await getAgentConfiguration(auth, {
       agentId,
       variant: "full",
@@ -545,15 +515,9 @@ const handlers: ToolHandlers<typeof AGENT_COPILOT_CONTEXT_TOOLS_METADATA> = {
     ]);
   },
 
-  get_agent_feedback: async ({ limit, filter }, extra) => {
-    const auth = extra.auth;
-    if (!auth) {
-      return new Err(new MCPError("Authentication required"));
-    }
-
-    const agentConfigurationId = getAgentConfigurationIdFromContext(
-      extra.agentLoopContext
-    );
+  get_agent_feedback: async ({ limit, filter }, { auth, agentLoopContext }) => {
+    const agentConfigurationId =
+      getAgentConfigurationIdFromContext(agentLoopContext);
 
     if (!agentConfigurationId) {
       return new Err(
@@ -624,15 +588,9 @@ const handlers: ToolHandlers<typeof AGENT_COPILOT_CONTEXT_TOOLS_METADATA> = {
     ]);
   },
 
-  get_agent_insights: async ({ days }, extra) => {
-    const auth = extra.auth;
-    if (!auth) {
-      return new Err(new MCPError("Authentication required"));
-    }
-
-    const agentConfigurationId = getAgentConfigurationIdFromContext(
-      extra.agentLoopContext
-    );
+  get_agent_insights: async ({ days }, { auth, agentLoopContext }) => {
+    const agentConfigurationId =
+      getAgentConfigurationIdFromContext(agentLoopContext);
 
     if (!agentConfigurationId) {
       return new Err(
@@ -706,15 +664,9 @@ const handlers: ToolHandlers<typeof AGENT_COPILOT_CONTEXT_TOOLS_METADATA> = {
   },
 
   // Suggestion handlers
-  suggest_prompt_edits: async (params, extra) => {
-    const auth = extra.auth;
-    if (!auth) {
-      return new Err(new MCPError("Authentication required"));
-    }
-
-    const agentConfigurationId = getAgentConfigurationIdFromContext(
-      extra.agentLoopContext
-    );
+  suggest_prompt_edits: async (params, { auth, agentLoopContext }) => {
+    const agentConfigurationId =
+      getAgentConfigurationIdFromContext(agentLoopContext);
 
     if (!agentConfigurationId) {
       return new Err(
@@ -818,15 +770,9 @@ const handlers: ToolHandlers<typeof AGENT_COPILOT_CONTEXT_TOOLS_METADATA> = {
     ]);
   },
 
-  suggest_tools: async (params, extra) => {
-    const auth = extra.auth;
-    if (!auth) {
-      return new Err(new MCPError("Authentication required"));
-    }
-
-    const agentConfigurationId = getAgentConfigurationIdFromContext(
-      extra.agentLoopContext
-    );
+  suggest_tools: async (params, { auth, agentLoopContext }) => {
+    const agentConfigurationId =
+      getAgentConfigurationIdFromContext(agentLoopContext);
 
     if (!agentConfigurationId) {
       return new Err(
@@ -921,15 +867,9 @@ const handlers: ToolHandlers<typeof AGENT_COPILOT_CONTEXT_TOOLS_METADATA> = {
     }
   },
 
-  suggest_sub_agent: async (params, extra) => {
-    const auth = extra.auth;
-    if (!auth) {
-      return new Err(new MCPError("Authentication required"));
-    }
-
-    const agentConfigurationId = getAgentConfigurationIdFromContext(
-      extra.agentLoopContext
-    );
+  suggest_sub_agent: async (params, { auth, agentLoopContext }) => {
+    const agentConfigurationId =
+      getAgentConfigurationIdFromContext(agentLoopContext);
 
     if (!agentConfigurationId) {
       return new Err(
@@ -1049,15 +989,9 @@ const handlers: ToolHandlers<typeof AGENT_COPILOT_CONTEXT_TOOLS_METADATA> = {
     }
   },
 
-  suggest_skills: async (params, extra) => {
-    const auth = extra.auth;
-    if (!auth) {
-      return new Err(new MCPError("Authentication required"));
-    }
-
-    const agentConfigurationId = getAgentConfigurationIdFromContext(
-      extra.agentLoopContext
-    );
+  suggest_skills: async (params, { auth, agentLoopContext }) => {
+    const agentConfigurationId =
+      getAgentConfigurationIdFromContext(agentLoopContext);
 
     if (!agentConfigurationId) {
       return new Err(
@@ -1150,12 +1084,7 @@ const handlers: ToolHandlers<typeof AGENT_COPILOT_CONTEXT_TOOLS_METADATA> = {
     }
   },
 
-  suggest_model: async (params, extra) => {
-    const auth = extra.auth;
-    if (!auth) {
-      return new Err(new MCPError("Authentication required"));
-    }
-
+  suggest_model: async (params, { auth, agentLoopContext }) => {
     const availableModels = await getAvailableModelsForWorkspace(auth);
     const availableModelIds = availableModels.map((m) => m.modelId);
 
@@ -1169,9 +1098,8 @@ const handlers: ToolHandlers<typeof AGENT_COPILOT_CONTEXT_TOOLS_METADATA> = {
       );
     }
 
-    const agentConfigurationId = getAgentConfigurationIdFromContext(
-      extra.agentLoopContext
-    );
+    const agentConfigurationId =
+      getAgentConfigurationIdFromContext(agentLoopContext);
 
     if (!agentConfigurationId) {
       return new Err(
@@ -1225,15 +1153,9 @@ const handlers: ToolHandlers<typeof AGENT_COPILOT_CONTEXT_TOOLS_METADATA> = {
     }
   },
 
-  list_suggestions: async (params, extra) => {
-    const auth = extra.auth;
-    if (!auth) {
-      return new Err(new MCPError("Authentication required"));
-    }
-
-    const agentConfigurationId = getAgentConfigurationIdFromContext(
-      extra.agentLoopContext
-    );
+  list_suggestions: async (params, { auth, agentLoopContext }) => {
+    const agentConfigurationId =
+      getAgentConfigurationIdFromContext(agentLoopContext);
 
     if (!agentConfigurationId) {
       return new Err(
@@ -1275,13 +1197,8 @@ const handlers: ToolHandlers<typeof AGENT_COPILOT_CONTEXT_TOOLS_METADATA> = {
 
   inspect_conversation: async (
     { conversationId, fromMessageIndex, toMessageIndex },
-    extra
+    { auth }
   ) => {
-    const auth = extra.auth;
-    if (!auth) {
-      return new Err(new MCPError("Authentication required"));
-    }
-
     const conversationRes = await getConversation(auth, conversationId);
     if (conversationRes.isErr()) {
       return new Err(
@@ -1433,12 +1350,7 @@ const handlers: ToolHandlers<typeof AGENT_COPILOT_CONTEXT_TOOLS_METADATA> = {
     ]);
   },
 
-  update_suggestions_state: async (params, extra) => {
-    const auth = extra.auth;
-    if (!auth) {
-      return new Err(new MCPError("Authentication required"));
-    }
-
+  update_suggestions_state: async (params, { auth }) => {
     const { suggestions: suggestionUpdates } = params;
 
     const suggestionIds = suggestionUpdates.map((s) => s.suggestionId);
@@ -1503,12 +1415,7 @@ const handlers: ToolHandlers<typeof AGENT_COPILOT_CONTEXT_TOOLS_METADATA> = {
     ]);
   },
 
-  search_agent_templates: async ({ jobType, query }, extra) => {
-    const auth = extra.auth;
-    if (!auth) {
-      return new Err(new MCPError("Authentication required"));
-    }
-
+  search_agent_templates: async ({ jobType, query }, { auth }) => {
     const allTemplates = await TemplateResource.listAll({
       visibility: "published",
     });
@@ -1558,12 +1465,7 @@ const handlers: ToolHandlers<typeof AGENT_COPILOT_CONTEXT_TOOLS_METADATA> = {
     ]);
   },
 
-  get_agent_template: async ({ templateId }, extra) => {
-    const auth = extra.auth;
-    if (!auth) {
-      return new Err(new MCPError("Authentication required"));
-    }
-
+  get_agent_template: async ({ templateId }, _extra) => {
     const template = await TemplateResource.fetchByExternalId(templateId);
 
     if (!template) {

--- a/front/lib/api/actions/servers/agent_management/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_management/tools/index.ts
@@ -28,13 +28,8 @@ const handlers: ToolHandlers<typeof AGENT_MANAGEMENT_TOOLS_METADATA> = {
       sub_agent_instructions,
       sub_agent_emoji,
     },
-    extra
+    { auth }
   ) => {
-    const auth = extra.auth;
-    if (!auth) {
-      return new Err(new MCPError("Authentication required"));
-    }
-
     const owner = auth.workspace();
     if (!owner) {
       return new Err(new MCPError("Workspace not found"));

--- a/front/lib/api/actions/servers/agent_memory/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_memory/tools/index.ts
@@ -37,12 +37,7 @@ const renderMemory = (
 };
 
 const handlers: ToolHandlers<typeof AGENT_MEMORY_TOOLS_METADATA> = {
-  [AGENT_MEMORY_RETRIEVE_TOOL_NAME]: async (_, extra) => {
-    const auth = extra.auth;
-    if (!auth) {
-      return new Err(new MCPError("Authentication required"));
-    }
-
+  [AGENT_MEMORY_RETRIEVE_TOOL_NAME]: async (_, { auth, agentLoopContext }) => {
     const user = auth.user();
     if (!user) {
       return new Err(
@@ -53,10 +48,10 @@ const handlers: ToolHandlers<typeof AGENT_MEMORY_TOOLS_METADATA> = {
     }
 
     assert(
-      extra.agentLoopContext?.runContext,
+      agentLoopContext?.runContext,
       "agentLoopContext is required to run the memory retrieve tool"
     );
-    const { agentConfiguration } = extra.agentLoopContext.runContext;
+    const { agentConfiguration } = agentLoopContext.runContext;
 
     const memory = await AgentMemoryResource.retrieveMemory(auth, {
       agentConfiguration,
@@ -65,12 +60,10 @@ const handlers: ToolHandlers<typeof AGENT_MEMORY_TOOLS_METADATA> = {
     return renderMemory(memory);
   },
 
-  [AGENT_MEMORY_RECORD_TOOL_NAME]: async ({ entries }, extra) => {
-    const auth = extra.auth;
-    if (!auth) {
-      return new Err(new MCPError("Authentication required"));
-    }
-
+  [AGENT_MEMORY_RECORD_TOOL_NAME]: async (
+    { entries },
+    { auth, agentLoopContext }
+  ) => {
     const user = auth.user();
     if (!user) {
       return new Err(
@@ -81,10 +74,10 @@ const handlers: ToolHandlers<typeof AGENT_MEMORY_TOOLS_METADATA> = {
     }
 
     assert(
-      extra.agentLoopContext?.runContext,
+      agentLoopContext?.runContext,
       "agentLoopContext is required to run the memory record_entries tool"
     );
-    const { agentConfiguration } = extra.agentLoopContext.runContext;
+    const { agentConfiguration } = agentLoopContext.runContext;
 
     const result = await AgentMemoryResource.recordEntries(auth, {
       agentConfiguration,
@@ -99,12 +92,10 @@ const handlers: ToolHandlers<typeof AGENT_MEMORY_TOOLS_METADATA> = {
     return renderMemory(result.value);
   },
 
-  [AGENT_MEMORY_ERASE_TOOL_NAME]: async ({ indexes }, extra) => {
-    const auth = extra.auth;
-    if (!auth) {
-      return new Err(new MCPError("Authentication required"));
-    }
-
+  [AGENT_MEMORY_ERASE_TOOL_NAME]: async (
+    { indexes },
+    { auth, agentLoopContext }
+  ) => {
     const user = auth.user();
     if (!user) {
       return new Err(
@@ -115,10 +106,10 @@ const handlers: ToolHandlers<typeof AGENT_MEMORY_TOOLS_METADATA> = {
     }
 
     assert(
-      extra.agentLoopContext?.runContext,
+      agentLoopContext?.runContext,
       "agentLoopContext is required to run the memory erase_entries tool"
     );
-    const { agentConfiguration } = extra.agentLoopContext.runContext;
+    const { agentConfiguration } = agentLoopContext.runContext;
 
     const memory = await AgentMemoryResource.eraseEntries(auth, {
       agentConfiguration,
@@ -128,12 +119,10 @@ const handlers: ToolHandlers<typeof AGENT_MEMORY_TOOLS_METADATA> = {
     return renderMemory(memory);
   },
 
-  [AGENT_MEMORY_EDIT_TOOL_NAME]: async ({ edits }, extra) => {
-    const auth = extra.auth;
-    if (!auth) {
-      return new Err(new MCPError("Authentication required"));
-    }
-
+  [AGENT_MEMORY_EDIT_TOOL_NAME]: async (
+    { edits },
+    { auth, agentLoopContext }
+  ) => {
     const user = auth.user();
     if (!user) {
       return new Err(
@@ -144,10 +133,10 @@ const handlers: ToolHandlers<typeof AGENT_MEMORY_TOOLS_METADATA> = {
     }
 
     assert(
-      extra.agentLoopContext?.runContext,
+      agentLoopContext?.runContext,
       "agentLoopContext is required to run the memory edit_entries tool"
     );
-    const { agentConfiguration } = extra.agentLoopContext.runContext;
+    const { agentConfiguration } = agentLoopContext.runContext;
 
     const result = await AgentMemoryResource.editEntries(auth, {
       agentConfiguration,
@@ -162,12 +151,10 @@ const handlers: ToolHandlers<typeof AGENT_MEMORY_TOOLS_METADATA> = {
     return renderMemory(result.value);
   },
 
-  [AGENT_MEMORY_COMPACT_TOOL_NAME]: async ({ edits }, extra) => {
-    const auth = extra.auth;
-    if (!auth) {
-      return new Err(new MCPError("Authentication required"));
-    }
-
+  [AGENT_MEMORY_COMPACT_TOOL_NAME]: async (
+    { edits },
+    { auth, agentLoopContext }
+  ) => {
     const user = auth.user();
     if (!user) {
       return new Err(
@@ -178,10 +165,10 @@ const handlers: ToolHandlers<typeof AGENT_MEMORY_TOOLS_METADATA> = {
     }
 
     assert(
-      extra.agentLoopContext?.runContext,
+      agentLoopContext?.runContext,
       "agentLoopContext is required to run the memory compact_memory tool"
     );
-    const { agentConfiguration } = extra.agentLoopContext.runContext;
+    const { agentConfiguration } = agentLoopContext.runContext;
 
     const result = await AgentMemoryResource.editEntries(auth, {
       agentConfiguration,

--- a/front/lib/api/actions/servers/agent_router/tools/index.ts
+++ b/front/lib/api/actions/servers/agent_router/tools/index.ts
@@ -17,12 +17,7 @@ import { Err, Ok } from "@app/types/shared/result";
 const MAX_INSTRUCTIONS_LENGTH = 1000;
 
 const handlers: ToolHandlers<typeof AGENT_ROUTER_TOOLS_METADATA> = {
-  list_all_published_agents: async (_, extra) => {
-    const auth = extra.auth;
-    if (!auth) {
-      return new Err(new MCPError("Authentication required"));
-    }
-
+  list_all_published_agents: async (_, { auth }) => {
     const owner = auth.getNonNullableWorkspace();
     const requestedGroupIds = auth.groupIds();
 
@@ -67,12 +62,7 @@ const handlers: ToolHandlers<typeof AGENT_ROUTER_TOOLS_METADATA> = {
     ]);
   },
 
-  suggest_agents_for_content: async ({ userMessage }, extra) => {
-    const auth = extra.auth;
-    if (!auth) {
-      return new Err(new MCPError("Authentication required"));
-    }
-
+  suggest_agents_for_content: async ({ userMessage }, { auth }) => {
     const owner = auth.getNonNullableWorkspace();
     const requestedGroupIds = auth.groupIds();
 

--- a/front/lib/api/actions/servers/ashby/client.ts
+++ b/front/lib/api/actions/servers/ashby/client.ts
@@ -36,19 +36,11 @@ import { decrypt } from "@app/types/shared/utils/hashing";
 
 const ASHBY_API_BASE_URL = "https://api.ashbyhq.com";
 
-export async function getAshbyClient(
-  extra: ToolHandlerExtra
-): Promise<Result<AshbyClient, MCPError>> {
-  const auth = extra.auth;
-  const toolConfig = extra.agentLoopContext?.runContext?.toolConfiguration;
-
-  if (!auth) {
-    return new Err(
-      new MCPError("Authentication context not available.", {
-        tracked: false,
-      })
-    );
-  }
+export async function getAshbyClient({
+  auth,
+  agentLoopContext,
+}: ToolHandlerExtra): Promise<Result<AshbyClient, MCPError>> {
+  const toolConfig = agentLoopContext?.runContext?.toolConfiguration;
 
   if (
     !toolConfig ||

--- a/front/lib/api/actions/servers/ashby/helpers.ts
+++ b/front/lib/api/actions/servers/ashby/helpers.ts
@@ -103,10 +103,10 @@ export async function findUniqueCandidate(
 }
 
 export async function withAuth<T>(
-  extra: ToolHandlerExtra,
+  { authInfo }: ToolHandlerExtra,
   action: (token: string) => Promise<Result<T, MCPError>>
 ): Promise<Result<T, MCPError>> {
-  const token = extra.authInfo?.token;
+  const token = authInfo?.token;
   if (!token) {
     return new Err(new MCPError("No access token provided"));
   }
@@ -123,17 +123,8 @@ function normalizeTitle(title: string): string {
 
 export async function resolveAshbyUser(
   client: AshbyClient,
-  extra: ToolHandlerExtra
+  { auth }: ToolHandlerExtra
 ): Promise<Result<AshbyUser, MCPError>> {
-  const auth = extra.auth;
-  if (!auth) {
-    return new Err(
-      new MCPError("Authentication context not available.", {
-        tracked: false,
-      })
-    );
-  }
-
   const user = auth.user();
   if (!user) {
     return new Err(

--- a/front/lib/api/actions/servers/conversation_files/tools/index.ts
+++ b/front/lib/api/actions/servers/conversation_files/tools/index.ts
@@ -32,12 +32,12 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
 const MAX_FILE_SIZE_FOR_GREP = 20 * 1024 * 1024; // 20MB.
 
 const handlers: ToolHandlers<typeof CONVERSATION_FILES_TOOLS_METADATA> = {
-  [CONVERSATION_LIST_FILES_ACTION_NAME]: async (_, extra) => {
-    if (!extra.agentLoopContext?.runContext) {
+  [CONVERSATION_LIST_FILES_ACTION_NAME]: async (_, { agentLoopContext }) => {
+    if (!agentLoopContext?.runContext) {
       return new Err(new MCPError("No conversation context available"));
     }
 
-    const conversation = extra.agentLoopContext.runContext.conversation;
+    const conversation = agentLoopContext.runContext.conversation;
     const attachments = listAttachments(conversation);
 
     if (attachments.length === 0) {
@@ -67,20 +67,15 @@ const handlers: ToolHandlers<typeof CONVERSATION_FILES_TOOLS_METADATA> = {
 
   [CONVERSATION_CAT_FILE_ACTION_NAME]: async (
     { fileId, offset, limit, grep },
-    extra
+    { auth, agentLoopContext }
   ) => {
-    if (!extra.agentLoopContext?.runContext) {
+    if (!agentLoopContext?.runContext) {
       return new Err(new MCPError("No conversation context available"));
     }
 
-    const auth = extra.auth;
-    if (!auth) {
-      return new Err(new MCPError("Authentication required"));
-    }
-
-    const conversation = extra.agentLoopContext.runContext.conversation;
+    const conversation = agentLoopContext.runContext.conversation;
     const model = getSupportedModelConfig(
-      extra.agentLoopContext.runContext.agentConfiguration.model
+      agentLoopContext.runContext.agentConfiguration.model
     );
     if (!model) {
       return new Err(new MCPError("Model configuration not found"));

--- a/front/lib/api/actions/servers/data_sources_file_system/tools/cat.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/tools/cat.ts
@@ -35,11 +35,8 @@ export async function cat(
   {
     auth,
     agentLoopContext,
-  }: { auth?: Authenticator; agentLoopContext?: AgentLoopContextType }
+  }: { auth: Authenticator; agentLoopContext?: AgentLoopContextType }
 ) {
-  if (!auth) {
-    return new Err(new MCPError("Authentication required"));
-  }
   if (!agentLoopContext?.runContext) {
     return new Err(new MCPError("No conversation context available"));
   }

--- a/front/lib/api/actions/servers/data_sources_file_system/tools/find.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/tools/find.ts
@@ -32,12 +32,8 @@ export async function find(
     tagsIn,
     tagsNot,
   }: DataSourceFilesystemFindInputType & TagsInputType,
-  { auth }: { auth?: Authenticator }
+  { auth }: { auth: Authenticator }
 ): Promise<Result<CallToolResult["content"], MCPError>> {
-  if (!auth) {
-    return new Err(new MCPError("Authentication required"));
-  }
-
   const invalidMimeTypes = mimeTypes?.filter((m) => !isDustMimeType(m));
   if (invalidMimeTypes && invalidMimeTypes.length > 0) {
     return new Err(

--- a/front/lib/api/actions/servers/data_sources_file_system/tools/index.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/tools/index.ts
@@ -1,4 +1,3 @@
-import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA } from "@app/lib/api/actions/servers/data_sources_file_system/metadata";
@@ -17,7 +16,6 @@ import { list } from "@app/lib/api/actions/servers/data_sources_file_system/tool
 import { locateTree } from "@app/lib/api/actions/servers/data_sources_file_system/tools/locate_tree";
 import { search } from "@app/lib/api/actions/servers/data_sources_file_system/tools/search";
 import { executeFindTags } from "@app/lib/api/actions/tools/find_tags";
-import { Err } from "@app/types/shared/result";
 
 const handlers: ToolHandlers<typeof DATA_SOURCES_FILE_SYSTEM_TOOLS_METADATA> = {
   [FILESYSTEM_CAT_TOOL_NAME]: cat,
@@ -32,10 +30,7 @@ const handlersWithTags: ToolHandlers<
 > = {
   ...handlers,
   [FIND_TAGS_TOOL_NAME]: async ({ query, dataSources }, { auth }) => {
-    if (!auth) {
-      return new Err(new MCPError("Authentication required"));
-    }
-    return executeFindTags(query, dataSources, auth);
+    return executeFindTags(auth, query, dataSources);
   },
 };
 

--- a/front/lib/api/actions/servers/data_sources_file_system/tools/list.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/tools/list.ts
@@ -41,12 +41,8 @@ export async function list(
     sortBy?: "title" | "timestamp";
     nextPageCursor?: string;
   },
-  { auth }: { auth?: Authenticator }
+  { auth }: { auth: Authenticator }
 ) {
-  if (!auth) {
-    return new Err(new MCPError("Authentication required"));
-  }
-
   const invalidMimeTypes = mimeTypes?.filter((m) => !isDustMimeType(m));
   if (invalidMimeTypes && invalidMimeTypes.length > 0) {
     return new Err(

--- a/front/lib/api/actions/servers/data_sources_file_system/tools/locate_tree.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/tools/locate_tree.ts
@@ -27,12 +27,8 @@ import { removeNulls } from "@app/types/shared/utils/general";
 
 export const locateTree = async (
   { nodeId, dataSources }: DataSourceFilesystemLocateTreeInputType,
-  { auth }: { auth?: Authenticator }
+  { auth }: { auth: Authenticator }
 ) => {
-  if (!auth) {
-    return new Err(new MCPError("Authentication required"));
-  }
-
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
   const fetchResult = await getAgentDataSourceConfigurations(auth, dataSources);
 

--- a/front/lib/api/actions/servers/data_sources_file_system/tools/search.ts
+++ b/front/lib/api/actions/servers/data_sources_file_system/tools/search.ts
@@ -51,15 +51,11 @@ export async function search(
   {
     auth,
     agentLoopContext,
-  }: { auth?: Authenticator; agentLoopContext?: AgentLoopContextType }
+  }: { auth: Authenticator; agentLoopContext?: AgentLoopContextType }
 ): Promise<Result<CallToolResult["content"], MCPError>> {
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
   const credentials = dustManagedCredentials();
   const timeFrame = parseTimeFrame(relativeTimeFrame);
-
-  if (!auth) {
-    return new Err(new MCPError("Authentication required"));
-  }
 
   if (!agentLoopContext?.runContext) {
     throw new Error(

--- a/front/lib/api/actions/servers/data_warehouses/tools/index.ts
+++ b/front/lib/api/actions/servers/data_warehouses/tools/index.ts
@@ -29,12 +29,7 @@ const DEFAULT_LIMIT = 50;
 const MAX_LIMIT = 100;
 
 const handlers: ToolHandlers<typeof DATA_WAREHOUSES_TOOLS_METADATA> = {
-  list: async ({ nodeId, limit, nextPageCursor, dataSources }, extra) => {
-    const { auth } = extra;
-    if (!auth) {
-      return new Err(new MCPError("Authentication required"));
-    }
-
+  list: async ({ nodeId, limit, nextPageCursor, dataSources }, { auth }) => {
     // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     const effectiveLimit = Math.min(limit || DEFAULT_LIMIT, MAX_LIMIT);
 
@@ -94,13 +89,8 @@ const handlers: ToolHandlers<typeof DATA_WAREHOUSES_TOOLS_METADATA> = {
 
   find: async (
     { query, rootNodeId, limit, nextPageCursor, dataSources },
-    extra
+    { auth }
   ) => {
-    const { auth } = extra;
-    if (!auth) {
-      return new Err(new MCPError("Authentication required"));
-    }
-
     // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     const effectiveLimit = Math.min(limit || DEFAULT_LIMIT, MAX_LIMIT);
 
@@ -157,12 +147,7 @@ const handlers: ToolHandlers<typeof DATA_WAREHOUSES_TOOLS_METADATA> = {
     ]);
   },
 
-  describe_tables: async ({ dataSources, tableIds }, extra) => {
-    const { auth } = extra;
-    if (!auth) {
-      return new Err(new MCPError("Authentication required"));
-    }
-
+  describe_tables: async ({ dataSources, tableIds }, { auth }) => {
     const dataSourceConfigurationsResult =
       await getAgentDataSourceConfigurations(
         auth,
@@ -232,12 +217,10 @@ const handlers: ToolHandlers<typeof DATA_WAREHOUSES_TOOLS_METADATA> = {
     ]);
   },
 
-  query: async ({ dataSources, tableIds, query, fileName }, extra) => {
-    const { auth, agentLoopContext } = extra;
-    if (!auth) {
-      return new Err(new MCPError("Authentication required"));
-    }
-
+  query: async (
+    { dataSources, tableIds, query, fileName },
+    { auth, agentLoopContext }
+  ) => {
     if (!agentLoopContext?.runContext) {
       return new Err(
         new MCPError("Missing agentLoopContext for file generation")

--- a/front/lib/api/actions/servers/databricks/tools/index.ts
+++ b/front/lib/api/actions/servers/databricks/tools/index.ts
@@ -9,9 +9,9 @@ import { DATABRICKS_TOOLS_METADATA } from "@app/lib/api/actions/servers/databric
 import { Ok } from "@app/types/shared/result";
 
 const handlers: ToolHandlers<typeof DATABRICKS_TOOLS_METADATA> = {
-  list_warehouses: async (_params, extra) => {
+  list_warehouses: async (_params, { authInfo }) => {
     return withAuth({
-      authInfo: extra.authInfo,
+      authInfo,
       action: async (accessToken, workspaceUrl) => {
         const result = await listWarehouses(accessToken, workspaceUrl);
 

--- a/front/lib/api/actions/servers/extract_data/tools/index.ts
+++ b/front/lib/api/actions/servers/extract_data/tools/index.ts
@@ -163,7 +163,7 @@ export function createExtractDataTools(
       return extractFunction(params);
     },
     find_tags: async ({ query, dataSources }, _extra) => {
-      return executeFindTags(query, dataSources, auth);
+      return executeFindTags(auth, query, dataSources);
     },
   };
   return buildTools(EXTRACT_DATA_WITH_TAGS_TOOLS_METADATA, handlers);

--- a/front/lib/api/actions/servers/file_generation/tools/index.ts
+++ b/front/lib/api/actions/servers/file_generation/tools/index.ts
@@ -57,15 +57,10 @@ const handlers: ToolHandlers<typeof FILE_GENERATION_TOOLS_METADATA> = {
 
   convert_file_format: async (
     { file_name, file_id_or_url, source_format, output_format },
-    extra
+    { auth }
   ) => {
     if (!process.env.CONVERTAPI_API_KEY) {
       return new Err(new MCPError("Missing environment variable."));
-    }
-
-    const auth = extra.auth;
-    if (!auth) {
-      return new Err(new MCPError("Authentication required"));
     }
 
     const contentType = getContentTypeFromOutputFormat(output_format);
@@ -136,17 +131,13 @@ const handlers: ToolHandlers<typeof FILE_GENERATION_TOOLS_METADATA> = {
     }
   },
 
-  generate_file: async (
-    { file_name, file_content, source_format = "text" },
-    extra
-  ) => {
+  generate_file: async ({
+    file_name,
+    file_content,
+    source_format = "text",
+  }) => {
     if (!process.env.CONVERTAPI_API_KEY) {
       return new Err(new MCPError("Missing environment variable."));
-    }
-
-    const auth = extra.auth;
-    if (!auth) {
-      return new Err(new MCPError("Authentication required"));
     }
 
     const fileNameWithoutExtension = basename(file_name);

--- a/front/lib/api/actions/servers/front/helpers.ts
+++ b/front/lib/api/actions/servers/front/helpers.ts
@@ -153,13 +153,11 @@ export async function getFrontAPIToken(
   return apiToken;
 }
 
-export async function getFrontAPITokenFromExtra(
-  extra: ToolHandlerExtra
-): Promise<string> {
-  if (!extra.auth) {
-    throw new MCPError("No authenticator provided");
-  }
-  return getFrontAPIToken(extra.auth, extra.agentLoopContext);
+export async function getFrontAPITokenFromExtra({
+  auth,
+  agentLoopContext,
+}: ToolHandlerExtra): Promise<string> {
+  return getFrontAPIToken(auth, agentLoopContext);
 }
 
 interface FrontConversation {

--- a/front/lib/api/actions/servers/google_calendar/tools/index.ts
+++ b/front/lib/api/actions/servers/google_calendar/tools/index.ts
@@ -23,8 +23,8 @@ import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
 const handlers: ToolHandlers<typeof GOOGLE_CALENDAR_TOOLS_METADATA> = {
-  list_calendars: async ({ pageToken, maxResults }, extra) => {
-    const accessToken = extra.authInfo?.token;
+  list_calendars: async ({ pageToken, maxResults }, { authInfo }) => {
+    const accessToken = authInfo?.token;
     assert(accessToken, "No access token provided");
 
     const oauth2Client = new google.auth.OAuth2();
@@ -49,9 +49,9 @@ const handlers: ToolHandlers<typeof GOOGLE_CALENDAR_TOOLS_METADATA> = {
 
   list_events: async (
     { calendarId = "primary", q, timeMin, timeMax, maxResults, pageToken },
-    extra
+    { authInfo, agentLoopContext }
   ) => {
-    const calendar = await getCalendarClient(extra.authInfo);
+    const calendar = await getCalendarClient(authInfo);
     assert(
       calendar,
       "Calendar client could not be created - it should never happen"
@@ -68,7 +68,7 @@ const handlers: ToolHandlers<typeof GOOGLE_CALENDAR_TOOLS_METADATA> = {
         singleEvents: true,
       });
 
-      const userTimezone = getUserTimezone(extra.agentLoopContext);
+      const userTimezone = getUserTimezone(agentLoopContext);
 
       const enrichedEvents = res.data.items
         ? res.data.items
@@ -90,8 +90,11 @@ const handlers: ToolHandlers<typeof GOOGLE_CALENDAR_TOOLS_METADATA> = {
     }
   },
 
-  get_event: async ({ calendarId = "primary", eventId }, extra) => {
-    const calendar = await getCalendarClient(extra.authInfo);
+  get_event: async (
+    { calendarId = "primary", eventId },
+    { authInfo, agentLoopContext }
+  ) => {
+    const calendar = await getCalendarClient(authInfo);
     assert(
       calendar,
       "Calendar client could not be created - it should never happen"
@@ -103,7 +106,7 @@ const handlers: ToolHandlers<typeof GOOGLE_CALENDAR_TOOLS_METADATA> = {
         eventId,
       });
 
-      const userTimezone = getUserTimezone(extra.agentLoopContext);
+      const userTimezone = getUserTimezone(agentLoopContext);
       const enrichedEvent = isGoogleCalendarEvent(res.data)
         ? enrichEventWithDayOfWeek(res.data, userTimezone)
         : null;
@@ -134,9 +137,9 @@ const handlers: ToolHandlers<typeof GOOGLE_CALENDAR_TOOLS_METADATA> = {
       colorId,
       createConference = true,
     },
-    extra
+    { authInfo, agentLoopContext }
   ) => {
-    const calendar = await getCalendarClient(extra.authInfo);
+    const calendar = await getCalendarClient(authInfo);
     assert(
       calendar,
       "Calendar client could not be created - it should never happen"
@@ -191,7 +194,7 @@ const handlers: ToolHandlers<typeof GOOGLE_CALENDAR_TOOLS_METADATA> = {
         conferenceDataVersion: 1,
       });
 
-      const userTimezone = getUserTimezone(extra.agentLoopContext);
+      const userTimezone = getUserTimezone(agentLoopContext);
       const enrichedEvent = isGoogleCalendarEvent(res.data)
         ? enrichEventWithDayOfWeek(res.data, userTimezone)
         : null;
@@ -228,9 +231,9 @@ const handlers: ToolHandlers<typeof GOOGLE_CALENDAR_TOOLS_METADATA> = {
       colorId,
       createConference,
     },
-    extra
+    { authInfo, agentLoopContext }
   ) => {
-    const calendar = await getCalendarClient(extra.authInfo);
+    const calendar = await getCalendarClient(authInfo);
     assert(
       calendar,
       "Calendar client could not be created - it should never happen"
@@ -295,7 +298,7 @@ const handlers: ToolHandlers<typeof GOOGLE_CALENDAR_TOOLS_METADATA> = {
         conferenceDataVersion: 1,
       });
 
-      const userTimezone = getUserTimezone(extra.agentLoopContext);
+      const userTimezone = getUserTimezone(agentLoopContext);
       const enrichedEvent = isGoogleCalendarEvent(res.data)
         ? enrichEventWithDayOfWeek(res.data, userTimezone)
         : null;
@@ -319,8 +322,8 @@ const handlers: ToolHandlers<typeof GOOGLE_CALENDAR_TOOLS_METADATA> = {
     }
   },
 
-  delete_event: async ({ calendarId = "primary", eventId }, extra) => {
-    const calendar = await getCalendarClient(extra.authInfo);
+  delete_event: async ({ calendarId = "primary", eventId }, { authInfo }) => {
+    const calendar = await getCalendarClient(authInfo);
     assert(
       calendar,
       "Calendar client could not be created - it should never happen"
@@ -343,9 +346,9 @@ const handlers: ToolHandlers<typeof GOOGLE_CALENDAR_TOOLS_METADATA> = {
 
   check_availability: async (
     { participants, startTimeRange, endTimeRange, excludeWeekends = false },
-    extra
+    { authInfo }
   ) => {
-    const calendar = await getCalendarClient(extra.authInfo);
+    const calendar = await getCalendarClient(authInfo);
     assert(
       calendar,
       "Calendar client could not be created - it should never happen"
@@ -451,8 +454,8 @@ const handlers: ToolHandlers<typeof GOOGLE_CALENDAR_TOOLS_METADATA> = {
     }
   },
 
-  get_user_timezones: async ({ emails }, extra) => {
-    const calendar = await getCalendarClient(extra.authInfo);
+  get_user_timezones: async ({ emails }, { authInfo }) => {
+    const calendar = await getCalendarClient(authInfo);
     assert(
       calendar,
       "Calendar client could not be created - it should never happen"

--- a/front/lib/api/actions/servers/google_drive/tools/index.ts
+++ b/front/lib/api/actions/servers/google_drive/tools/index.ts
@@ -48,7 +48,10 @@ function normalizeCode(code: string | number | undefined): string | undefined {
 export async function handleFileAccessError(
   err: unknown,
   fileId: string,
-  extra: ToolHandlerExtra,
+  {
+    authInfo,
+    agentLoopContext,
+  }: Pick<ToolHandlerExtra, "authInfo" | "agentLoopContext">,
   fileMeta?: { name?: string; mimeType?: string }
 ): Promise<ToolHandlerResult> {
   if (err instanceof Common.GaxiosError) {
@@ -63,7 +66,7 @@ export async function handleFileAccessError(
         message.includes("write access"))
     ) {
       const connectionId =
-        extra.agentLoopContext?.runContext?.toolConfiguration.toolServerId ??
+        agentLoopContext?.runContext?.toolConfiguration.toolServerId ??
         "google_drive";
 
       return new Ok(
@@ -88,7 +91,7 @@ export async function handleFileAccessError(
 
     // Handle 404 errors - try to fetch metadata for better error message
     if (status === "404") {
-      const drive = await getDriveClient(extra.authInfo);
+      const drive = await getDriveClient(authInfo);
       if (drive) {
         try {
           const fileMetadata = await drive.files.get({
@@ -165,9 +168,12 @@ function handleDriveAccessError(err: unknown): ToolHandlerResult {
  * Adds agent attribution to content (comments, replies, etc.).
  * Returns the original content with attribution appended if agent context is available.
  */
-function addAgentAttribution(content: string, extra: ToolHandlerExtra): string {
-  if (extra.agentLoopContext?.runContext?.agentConfiguration) {
-    const agentConfig = extra.agentLoopContext.runContext.agentConfiguration;
+function addAgentAttribution(
+  content: string,
+  { agentLoopContext }: Pick<ToolHandlerExtra, "agentLoopContext">
+): string {
+  if (agentLoopContext?.runContext?.agentConfiguration) {
+    const agentConfig = agentLoopContext.runContext.agentConfiguration;
     return `${content}\n\nSent via ${agentConfig.name} Agent on Dust`;
   }
   return content;
@@ -257,9 +263,9 @@ const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
 
   get_file_content: async (
     { fileId, offset = 0, limit = MAX_CONTENT_SIZE },
-    extra
+    { authInfo }
   ) => {
-    const drive = await getDriveClient(extra.authInfo);
+    const drive = await getDriveClient(authInfo);
     if (!drive) {
       return new Err(new MCPError("Failed to authenticate with Google Drive"));
     }
@@ -371,8 +377,8 @@ const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
     }
   },
 
-  get_spreadsheet: async ({ spreadsheetId }, extra) => {
-    const sheets = await getSheetsClient(extra.authInfo);
+  get_spreadsheet: async ({ spreadsheetId }, { authInfo }) => {
+    const sheets = await getSheetsClient(authInfo);
     if (!sheets) {
       return new Err(new MCPError("Failed to authenticate with Google Sheets"));
     }
@@ -397,9 +403,9 @@ const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
       majorDimension = "ROWS",
       valueRenderOption = "FORMATTED_VALUE",
     },
-    extra
+    { authInfo }
   ) => {
-    const sheets = await getSheetsClient(extra.authInfo);
+    const sheets = await getSheetsClient(authInfo);
     if (!sheets) {
       return new Err(new MCPError("Failed to authenticate with Google Sheets"));
     }
@@ -421,9 +427,9 @@ const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
   },
   list_comments: async (
     { fileId, pageSize = 100, pageToken, includeDeleted = false },
-    extra
+    { authInfo }
   ) => {
-    const drive = await getDriveClient(extra.authInfo);
+    const drive = await getDriveClient(authInfo);
     if (!drive) {
       return new Err(new MCPError("Failed to authenticate with Google Drive"));
     }
@@ -450,9 +456,9 @@ const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
   },
   get_document_structure: async (
     { documentId, offset = 0, limit = 100 },
-    extra
+    { authInfo }
   ) => {
-    const docs = await getDocsClient(extra.authInfo);
+    const docs = await getDocsClient(authInfo);
     if (!docs) {
       return new Err(new MCPError("Failed to authenticate with Google Docs"));
     }
@@ -472,9 +478,9 @@ const handlers: ToolHandlers<typeof GOOGLE_DRIVE_TOOLS_METADATA> = {
   },
   get_presentation_structure: async (
     { presentationId, offset = 0, limit = 10 },
-    extra
+    { authInfo }
   ) => {
-    const slides = await getSlidesClient(extra.authInfo);
+    const slides = await getSlidesClient(authInfo);
     if (!slides) {
       return new Err(new MCPError("Failed to authenticate with Google Slides"));
     }
@@ -577,8 +583,8 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
     }
   },
 
-  copy_file: async ({ fileId, name, parentId }, extra) => {
-    const drive = await getDriveClient(extra.authInfo);
+  copy_file: async ({ fileId, name, parentId }, { authInfo }) => {
+    const drive = await getDriveClient(authInfo);
     if (!drive) {
       return new Err(new MCPError("Failed to authenticate with Google Drive"));
     }
@@ -634,13 +640,16 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
     ]);
   },
 
-  create_comment: async ({ fileId, content }, extra) => {
-    const drive = await getDriveClient(extra.authInfo);
+  create_comment: async (
+    { fileId, content },
+    { authInfo, agentLoopContext }
+  ) => {
+    const drive = await getDriveClient(authInfo);
     if (!drive) {
       return new Err(new MCPError("Failed to authenticate with Google Drive"));
     }
 
-    const finalContent = addAgentAttribution(content, extra);
+    const finalContent = addAgentAttribution(content, { agentLoopContext });
 
     try {
       const res = await drive.comments.create({
@@ -665,17 +674,20 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
         },
       ]);
     } catch (err) {
-      return handleFileAccessError(err, fileId, extra);
+      return handleFileAccessError(err, fileId, { authInfo, agentLoopContext });
     }
   },
 
-  create_reply: async ({ fileId, commentId, content }, extra) => {
-    const drive = await getDriveClient(extra.authInfo);
+  create_reply: async (
+    { fileId, commentId, content },
+    { authInfo, agentLoopContext }
+  ) => {
+    const drive = await getDriveClient(authInfo);
     if (!drive) {
       return new Err(new MCPError("Failed to authenticate with Google Drive"));
     }
 
-    const finalContent = addAgentAttribution(content, extra);
+    const finalContent = addAgentAttribution(content, { agentLoopContext });
 
     try {
       const res = await drive.replies.create({
@@ -703,12 +715,15 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
         },
       ]);
     } catch (err) {
-      return handleFileAccessError(err, fileId, extra);
+      return handleFileAccessError(err, fileId, { authInfo, agentLoopContext });
     }
   },
 
-  update_document: async ({ documentId, requests }, extra) => {
-    const docs = await getDocsClient(extra.authInfo);
+  update_document: async (
+    { documentId, requests },
+    { authInfo, agentLoopContext }
+  ) => {
+    const docs = await getDocsClient(authInfo);
     if (!docs) {
       return new Err(new MCPError("Failed to authenticate with Google Docs"));
     }
@@ -737,10 +752,15 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
         },
       ]);
     } catch (err) {
-      return handleFileAccessError(err, documentId, extra, {
-        name: documentId,
-        mimeType: "application/vnd.google-apps.document",
-      });
+      return handleFileAccessError(
+        err,
+        documentId,
+        { authInfo, agentLoopContext },
+        {
+          name: documentId,
+          mimeType: "application/vnd.google-apps.document",
+        }
+      );
     }
   },
 
@@ -753,9 +773,9 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
       valueInputOption = "USER_ENTERED",
       insertDataOption = "INSERT_ROWS",
     },
-    extra
+    { authInfo, agentLoopContext }
   ) => {
-    const sheets = await getSheetsClient(extra.authInfo);
+    const sheets = await getSheetsClient(authInfo);
     if (!sheets) {
       return new Err(new MCPError("Failed to authenticate with Google Sheets"));
     }
@@ -776,15 +796,23 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
         { type: "text" as const, text: JSON.stringify(res.data, null, 2) },
       ]);
     } catch (err) {
-      return handleFileAccessError(err, spreadsheetId, extra, {
-        name: spreadsheetId,
-        mimeType: "application/vnd.google-apps.spreadsheet",
-      });
+      return handleFileAccessError(
+        err,
+        spreadsheetId,
+        { authInfo, agentLoopContext },
+        {
+          name: spreadsheetId,
+          mimeType: "application/vnd.google-apps.spreadsheet",
+        }
+      );
     }
   },
 
-  update_spreadsheet: async ({ spreadsheetId, requests }, extra) => {
-    const sheets = await getSheetsClient(extra.authInfo);
+  update_spreadsheet: async (
+    { spreadsheetId, requests },
+    { authInfo, agentLoopContext }
+  ) => {
+    const sheets = await getSheetsClient(authInfo);
     if (!sheets) {
       return new Err(new MCPError("Failed to authenticate with Google Sheets"));
     }
@@ -813,15 +841,23 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
         },
       ]);
     } catch (err) {
-      return handleFileAccessError(err, spreadsheetId, extra, {
-        name: spreadsheetId,
-        mimeType: "application/vnd.google-apps.spreadsheet",
-      });
+      return handleFileAccessError(
+        err,
+        spreadsheetId,
+        { authInfo, agentLoopContext },
+        {
+          name: spreadsheetId,
+          mimeType: "application/vnd.google-apps.spreadsheet",
+        }
+      );
     }
   },
 
-  update_presentation: async ({ presentationId, requests }, extra) => {
-    const slides = await getSlidesClient(extra.authInfo);
+  update_presentation: async (
+    { presentationId, requests },
+    { authInfo, agentLoopContext }
+  ) => {
+    const slides = await getSlidesClient(authInfo);
     if (!slides) {
       return new Err(new MCPError("Failed to authenticate with Google Slides"));
     }
@@ -847,10 +883,15 @@ const writeHandlers: ToolHandlers<typeof GOOGLE_DRIVE_WRITE_TOOLS_METADATA> = {
         },
       ]);
     } catch (err) {
-      return handleFileAccessError(err, presentationId, extra, {
-        name: presentationId,
-        mimeType: "application/vnd.google-apps.presentation",
-      });
+      return handleFileAccessError(
+        err,
+        presentationId,
+        { authInfo, agentLoopContext },
+        {
+          name: presentationId,
+          mimeType: "application/vnd.google-apps.presentation",
+        }
+      );
     }
   },
 };

--- a/front/lib/api/actions/servers/google_sheets/helpers.ts
+++ b/front/lib/api/actions/servers/google_sheets/helpers.ts
@@ -24,14 +24,14 @@ export const ERROR_MESSAGES = {
  * Provides access to both Drive and Sheets clients.
  */
 export async function withAuth(
-  extra: ToolHandlerExtra,
+  { authInfo }: ToolHandlerExtra,
   action: (clients: {
     drive: drive_v3.Drive;
     sheets: sheets_v4.Sheets;
     accessToken: string;
   }) => Promise<ToolHandlerResult>
 ): Promise<ToolHandlerResult> {
-  const accessToken = extra.authInfo?.token;
+  const accessToken = authInfo?.token;
   if (!accessToken) {
     return new Err(new MCPError(ERROR_MESSAGES.NO_ACCESS_TOKEN));
   }
@@ -50,10 +50,10 @@ export async function withAuth(
  * Wrapper specifically for operations that only need the Sheets client.
  */
 export async function withSheetsAuth(
-  extra: ToolHandlerExtra,
+  { authInfo }: ToolHandlerExtra,
   action: (sheets: sheets_v4.Sheets) => Promise<ToolHandlerResult>
 ): Promise<ToolHandlerResult> {
-  const accessToken = extra.authInfo?.token;
+  const accessToken = authInfo?.token;
   if (!accessToken) {
     return new Err(new MCPError(ERROR_MESSAGES.SHEETS_AUTH_FAILED));
   }
@@ -71,10 +71,10 @@ export async function withSheetsAuth(
  * Wrapper specifically for operations that only need the Drive client.
  */
 export async function withDriveAuth(
-  extra: ToolHandlerExtra,
+  { authInfo }: ToolHandlerExtra,
   action: (drive: drive_v3.Drive) => Promise<ToolHandlerResult>
 ): Promise<ToolHandlerResult> {
-  const accessToken = extra.authInfo?.token;
+  const accessToken = authInfo?.token;
   if (!accessToken) {
     return new Err(new MCPError(ERROR_MESSAGES.DRIVE_AUTH_FAILED));
   }

--- a/front/lib/api/actions/servers/http_client/tools/index.ts
+++ b/front/lib/api/actions/servers/http_client/tools/index.ts
@@ -109,13 +109,8 @@ async function handleSendRequest(
     body?: string;
     timeout_ms?: number;
   },
-  extra: ToolHandlerExtra
+  { auth, agentLoopContext }: ToolHandlerExtra
 ) {
-  const { auth, agentLoopContext } = extra;
-  if (!auth) {
-    return new Err(new MCPError("Authentication required"));
-  }
-
   const timeoutMs = timeout_ms ?? DEFAULT_TIMEOUT_MS;
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), timeoutMs);

--- a/front/lib/api/actions/servers/hubspot/helpers.ts
+++ b/front/lib/api/actions/servers/hubspot/helpers.ts
@@ -64,10 +64,10 @@ export const convertObjectTypeToId = (objectTypeId: string): string => {
  * Wrapper to handle authentication and error logging for HubSpot operations.
  */
 export const withAuth = async (
-  extra: ToolHandlerExtra,
+  { authInfo }: ToolHandlerExtra,
   action: (accessToken: string) => Promise<ToolHandlerResult>
 ): Promise<ToolHandlerResult> => {
-  const accessToken = extra.authInfo?.token;
+  const accessToken = authInfo?.token;
   if (!accessToken) {
     return new Err(new MCPError(ERROR_MESSAGES.NO_ACCESS_TOKEN));
   }

--- a/front/lib/api/actions/servers/hubspot/tools/index.ts
+++ b/front/lib/api/actions/servers/hubspot/tools/index.ts
@@ -333,8 +333,8 @@ const handlers: ToolHandlers<typeof HUBSPOT_TOOLS_METADATA> = {
     });
   },
 
-  export_crm_objects_csv: async (input, extra) => {
-    const token = extra.authInfo?.token;
+  export_crm_objects_csv: async (input, { authInfo }) => {
+    const token = authInfo?.token;
     if (!token) {
       return new Err(new MCPError("Missing HubSpot access token"));
     }

--- a/front/lib/api/actions/servers/include_data/tools/index.ts
+++ b/front/lib/api/actions/servers/include_data/tools/index.ts
@@ -218,7 +218,7 @@ export function createIncludeDataTools(
       return includeFunction(params);
     },
     find_tags: async ({ query, dataSources }, _extra) => {
-      return executeFindTags(query, dataSources, auth);
+      return executeFindTags(auth, query, dataSources);
     },
   };
   return buildTools(INCLUDE_DATA_WITH_TAGS_TOOLS_METADATA, handlers);

--- a/front/lib/api/actions/servers/jira/tools/index.ts
+++ b/front/lib/api/actions/servers/jira/tools/index.ts
@@ -38,7 +38,7 @@ import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
 const handlers: ToolHandlers<typeof JIRA_TOOLS_METADATA> = {
-  get_issue_read_fields: async (_params, extra) => {
+  get_issue_read_fields: async (_params, { authInfo }) => {
     return withAuth({
       action: async (baseUrl, accessToken) => {
         const result = await listFieldSummaries(baseUrl, accessToken);
@@ -55,11 +55,11 @@ const handlers: ToolHandlers<typeof JIRA_TOOLS_METADATA> = {
           },
         ]);
       },
-      authInfo: extra.authInfo,
+      authInfo,
     });
   },
 
-  get_issue: async ({ issueKey, fields }, extra) => {
+  get_issue: async ({ issueKey, fields }, { authInfo }) => {
     return withAuth({
       action: async (baseUrl, accessToken) => {
         const issue = await getIssue({
@@ -98,11 +98,11 @@ const handlers: ToolHandlers<typeof JIRA_TOOLS_METADATA> = {
           },
         ]);
       },
-      authInfo: extra.authInfo,
+      authInfo,
     });
   },
 
-  get_projects: async (_params, extra) => {
+  get_projects: async (_params, { authInfo }) => {
     return withAuth({
       action: async (baseUrl, accessToken) => {
         const result = await getProjects(baseUrl, accessToken);
@@ -119,11 +119,11 @@ const handlers: ToolHandlers<typeof JIRA_TOOLS_METADATA> = {
           { type: "text" as const, text: JSON.stringify(result, null, 2) },
         ]);
       },
-      authInfo: extra.authInfo,
+      authInfo,
     });
   },
 
-  get_project: async ({ projectKey }, extra) => {
+  get_project: async ({ projectKey }, { authInfo }) => {
     return withAuth({
       action: async (baseUrl, accessToken) => {
         const result = await getProject(baseUrl, accessToken, projectKey);
@@ -147,11 +147,11 @@ const handlers: ToolHandlers<typeof JIRA_TOOLS_METADATA> = {
           },
         ]);
       },
-      authInfo: extra.authInfo,
+      authInfo,
     });
   },
 
-  get_project_versions: async ({ projectKey }, extra) => {
+  get_project_versions: async ({ projectKey }, { authInfo }) => {
     return withAuth({
       action: async (baseUrl, accessToken) => {
         const result = await getProjectVersions(
@@ -175,11 +175,11 @@ const handlers: ToolHandlers<typeof JIRA_TOOLS_METADATA> = {
           },
         ]);
       },
-      authInfo: extra.authInfo,
+      authInfo,
     });
   },
 
-  get_transitions: async ({ issueKey }, extra) => {
+  get_transitions: async ({ issueKey }, { authInfo }) => {
     return withAuth({
       action: async (baseUrl, accessToken) => {
         const result = await getTransitions(baseUrl, accessToken, issueKey);
@@ -196,11 +196,11 @@ const handlers: ToolHandlers<typeof JIRA_TOOLS_METADATA> = {
           { type: "text" as const, text: JSON.stringify(result, null, 2) },
         ]);
       },
-      authInfo: extra.authInfo,
+      authInfo,
     });
   },
 
-  get_issues: async ({ filters, sortBy, nextPageToken }, extra) => {
+  get_issues: async ({ filters, sortBy, nextPageToken }, { authInfo }) => {
     return withAuth({
       action: async (baseUrl, accessToken) => {
         const result = await searchIssues(baseUrl, accessToken, filters, {
@@ -237,13 +237,13 @@ const handlers: ToolHandlers<typeof JIRA_TOOLS_METADATA> = {
           },
         ]);
       },
-      authInfo: extra.authInfo,
+      authInfo,
     });
   },
 
   get_issues_using_jql: async (
     { jql, maxResults, fields, nextPageToken },
-    extra
+    { authInfo }
   ) => {
     return withAuth({
       action: async (baseUrl, accessToken) => {
@@ -287,11 +287,11 @@ const handlers: ToolHandlers<typeof JIRA_TOOLS_METADATA> = {
           },
         ]);
       },
-      authInfo: extra.authInfo,
+      authInfo,
     });
   },
 
-  get_issue_types: async ({ projectKey }, extra) => {
+  get_issue_types: async ({ projectKey }, { authInfo }) => {
     return withAuth({
       action: async (baseUrl, accessToken) => {
         try {
@@ -319,11 +319,14 @@ const handlers: ToolHandlers<typeof JIRA_TOOLS_METADATA> = {
           );
         }
       },
-      authInfo: extra.authInfo,
+      authInfo,
     });
   },
 
-  get_issue_create_fields: async ({ projectKey, issueTypeId }, extra) => {
+  get_issue_create_fields: async (
+    { projectKey, issueTypeId },
+    { authInfo }
+  ) => {
     return withAuth({
       action: async (baseUrl, accessToken) => {
         try {
@@ -356,12 +359,12 @@ const handlers: ToolHandlers<typeof JIRA_TOOLS_METADATA> = {
           );
         }
       },
-      authInfo: extra.authInfo,
+      authInfo,
     });
   },
 
-  get_connection_info: async (_params, extra) => {
-    const accessToken = extra.authInfo?.token;
+  get_connection_info: async (_params, { authInfo }) => {
+    const accessToken = authInfo?.token;
     if (!accessToken) {
       return new Err(new MCPError("No access token found"));
     }
@@ -387,7 +390,7 @@ const handlers: ToolHandlers<typeof JIRA_TOOLS_METADATA> = {
     ]);
   },
 
-  get_issue_link_types: async (_params, extra) => {
+  get_issue_link_types: async (_params, { authInfo }) => {
     return withAuth({
       action: async (baseUrl, accessToken) => {
         const result = await getIssueLinkTypes(baseUrl, accessToken);
@@ -407,13 +410,13 @@ const handlers: ToolHandlers<typeof JIRA_TOOLS_METADATA> = {
           },
         ]);
       },
-      authInfo: extra.authInfo,
+      authInfo,
     });
   },
 
   get_users: async (
     { emailAddress, name, maxResults = SEARCH_USERS_MAX_RESULTS, startAt },
-    extra
+    { authInfo }
   ) => {
     return withAuth({
       action: async (baseUrl, accessToken) => {
@@ -484,11 +487,11 @@ const handlers: ToolHandlers<typeof JIRA_TOOLS_METADATA> = {
           },
         ]);
       },
-      authInfo: extra.authInfo,
+      authInfo,
     });
   },
 
-  get_attachments: async ({ issueKey }, extra) => {
+  get_attachments: async ({ issueKey }, { authInfo }) => {
     return withAuth({
       action: async (baseUrl, accessToken) => {
         const attachmentsResult = await getIssueAttachments({
@@ -536,11 +539,11 @@ const handlers: ToolHandlers<typeof JIRA_TOOLS_METADATA> = {
           },
         ]);
       },
-      authInfo: extra.authInfo,
+      authInfo,
     });
   },
 
-  read_attachment: async ({ issueKey, attachmentId }, extra) => {
+  read_attachment: async ({ issueKey, attachmentId }, { authInfo }) => {
     return withAuth({
       action: async (baseUrl, accessToken) => {
         try {
@@ -601,14 +604,14 @@ const handlers: ToolHandlers<typeof JIRA_TOOLS_METADATA> = {
           );
         }
       },
-      authInfo: extra.authInfo,
+      authInfo,
     });
   },
 
   // Write operations
   create_comment: async (
     { issueKey, comment, visibilityType, visibilityValue },
-    extra
+    { authInfo }
   ) => {
     return withAuth({
       action: async (baseUrl, accessToken) => {
@@ -656,11 +659,11 @@ const handlers: ToolHandlers<typeof JIRA_TOOLS_METADATA> = {
           },
         ]);
       },
-      authInfo: extra.authInfo,
+      authInfo,
     });
   },
 
-  transition_issue: async ({ issueKey, transitionId }, extra) => {
+  transition_issue: async ({ issueKey, transitionId }, { authInfo }) => {
     return withAuth({
       action: async (baseUrl, accessToken) => {
         const result = await transitionIssue(
@@ -712,11 +715,11 @@ const handlers: ToolHandlers<typeof JIRA_TOOLS_METADATA> = {
           },
         ]);
       },
-      authInfo: extra.authInfo,
+      authInfo,
     });
   },
 
-  create_issue: async ({ issueData }, extra) => {
+  create_issue: async ({ issueData }, { authInfo }) => {
     return withAuth({
       action: async (baseUrl, accessToken) => {
         const result = await createIssue(baseUrl, accessToken, issueData);
@@ -738,11 +741,11 @@ const handlers: ToolHandlers<typeof JIRA_TOOLS_METADATA> = {
           },
         ]);
       },
-      authInfo: extra.authInfo,
+      authInfo,
     });
   },
 
-  update_issue: async ({ issueKey, updateData }, extra) => {
+  update_issue: async ({ issueKey, updateData }, { authInfo }) => {
     return withAuth({
       action: async (baseUrl, accessToken) => {
         const result = await updateIssue(
@@ -781,11 +784,11 @@ const handlers: ToolHandlers<typeof JIRA_TOOLS_METADATA> = {
           },
         ]);
       },
-      authInfo: extra.authInfo,
+      authInfo,
     });
   },
 
-  create_issue_link: async ({ linkData }, extra) => {
+  create_issue_link: async ({ linkData }, { authInfo }) => {
     return withAuth({
       action: async (baseUrl, accessToken) => {
         const result = await createIssueLink(baseUrl, accessToken, linkData);
@@ -811,11 +814,11 @@ const handlers: ToolHandlers<typeof JIRA_TOOLS_METADATA> = {
           },
         ]);
       },
-      authInfo: extra.authInfo,
+      authInfo,
     });
   },
 
-  delete_issue_link: async ({ linkId }, extra) => {
+  delete_issue_link: async ({ linkId }, { authInfo }) => {
     return withAuth({
       action: async (baseUrl, accessToken) => {
         const result = await deleteIssueLink(baseUrl, accessToken, linkId);
@@ -835,11 +838,14 @@ const handlers: ToolHandlers<typeof JIRA_TOOLS_METADATA> = {
           },
         ]);
       },
-      authInfo: extra.authInfo,
+      authInfo,
     });
   },
 
-  upload_attachment: async ({ issueKey, attachment }, extra) => {
+  upload_attachment: async (
+    { issueKey, attachment },
+    { auth, authInfo, agentLoopContext }
+  ) => {
     return withAuth({
       action: async (baseUrl, accessToken) => {
         let fileToUpload: {
@@ -849,18 +855,18 @@ const handlers: ToolHandlers<typeof JIRA_TOOLS_METADATA> = {
         };
 
         if (attachment.type === "conversation_file") {
-          if (!extra.auth || !extra.agentLoopContext) {
+          if (!agentLoopContext) {
             return new Err(
               new MCPError(
-                "Authentication and conversation context required for conversation file attachments"
+                "Conversation context required for conversation file attachments"
               )
             );
           }
 
           const fileResult = await getFileFromConversationAttachment(
-            extra.auth,
+            auth,
             attachment.fileId,
-            extra.agentLoopContext
+            agentLoopContext
           );
 
           if (fileResult.isErr()) {
@@ -944,7 +950,7 @@ const handlers: ToolHandlers<typeof JIRA_TOOLS_METADATA> = {
           },
         ]);
       },
-      authInfo: extra.authInfo,
+      authInfo,
     });
   },
 };

--- a/front/lib/api/actions/servers/microsoft_drive/tools/index.ts
+++ b/front/lib/api/actions/servers/microsoft_drive/tools/index.ts
@@ -21,8 +21,11 @@ import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
 const handlers: ToolHandlers<typeof MICROSOFT_DRIVE_TOOLS_METADATA> = {
-  search_in_files: async ({ query, dataSource, maximumResults }, extra) => {
-    const client = await getGraphClient(extra.authInfo);
+  search_in_files: async (
+    { query, dataSource, maximumResults },
+    { authInfo }
+  ) => {
+    const client = await getGraphClient(authInfo);
     if (!client) {
       return new Err(
         new MCPError("Failed to authenticate with Microsoft Graph")
@@ -56,8 +59,8 @@ const handlers: ToolHandlers<typeof MICROSOFT_DRIVE_TOOLS_METADATA> = {
     }
   },
 
-  search_drive_items: async ({ query }, extra) => {
-    const client = await getGraphClient(extra.authInfo);
+  search_drive_items: async ({ query }, { authInfo }) => {
+    const client = await getGraphClient(authInfo);
     if (!client) {
       return new Err(
         new MCPError("Failed to authenticate with Microsoft Graph")
@@ -87,9 +90,9 @@ const handlers: ToolHandlers<typeof MICROSOFT_DRIVE_TOOLS_METADATA> = {
 
   update_word_document: async (
     { itemId, driveId, siteId, documentXml },
-    extra
+    { authInfo }
   ) => {
-    const client = await getGraphClient(extra.authInfo);
+    const client = await getGraphClient(authInfo);
     if (!client) {
       return new Err(
         new MCPError("Failed to authenticate with Microsoft Graph")
@@ -176,9 +179,9 @@ const handlers: ToolHandlers<typeof MICROSOFT_DRIVE_TOOLS_METADATA> = {
 
   get_file_content: async (
     { itemId, driveId, siteId, offset, limit, getAsXml },
-    extra
+    { authInfo }
   ) => {
-    const client = await getGraphClient(extra.authInfo);
+    const client = await getGraphClient(authInfo);
     if (!client) {
       return new Err(
         new MCPError("Failed to authenticate with Microsoft Graph")
@@ -251,21 +254,16 @@ const handlers: ToolHandlers<typeof MICROSOFT_DRIVE_TOOLS_METADATA> = {
 
   upload_file: async (
     { fileId, driveId, siteId, folderPath, fileName },
-    extra
+    { auth, authInfo, agentLoopContext }
   ) => {
-    const client = await getGraphClient(extra.authInfo);
+    const client = await getGraphClient(authInfo);
     if (!client) {
       return new Err(
         new MCPError("Failed to authenticate with Microsoft Graph")
       );
     }
 
-    const auth = extra.auth;
-    if (!auth) {
-      return new Err(new MCPError("Authentication required"));
-    }
-
-    if (!extra.agentLoopContext) {
+    if (!agentLoopContext) {
       return new Err(
         new MCPError("No conversation context available for file access")
       );
@@ -276,7 +274,7 @@ const handlers: ToolHandlers<typeof MICROSOFT_DRIVE_TOOLS_METADATA> = {
       const fileResult = await getFileFromConversationAttachment(
         auth,
         fileId,
-        extra.agentLoopContext
+        agentLoopContext
       );
 
       if (fileResult.isErr()) {
@@ -403,12 +401,15 @@ const handlers: ToolHandlers<typeof MICROSOFT_DRIVE_TOOLS_METADATA> = {
     }
   },
 
-  copy_file: async ({ itemId, driveId, siteId, parentItemId, name }, extra) => {
+  copy_file: async (
+    { itemId, driveId, siteId, parentItemId, name },
+    { authInfo }
+  ) => {
     if (!driveId && !siteId) {
       return new Err(new MCPError("Either driveId or siteId must be provided"));
     }
 
-    const client = await getGraphClient(extra.authInfo);
+    const client = await getGraphClient(authInfo);
     if (!client) {
       return new Err(
         new MCPError("Failed to authenticate with Microsoft Graph")

--- a/front/lib/api/actions/servers/microsoft_excel/tools/index.ts
+++ b/front/lib/api/actions/servers/microsoft_excel/tools/index.ts
@@ -12,8 +12,8 @@ import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
 
 const handlers: ToolHandlers<typeof MICROSOFT_EXCEL_TOOLS_METADATA> = {
-  list_excel_files: async ({ query }, extra) => {
-    const client = await getGraphClient(extra.authInfo);
+  list_excel_files: async ({ query }, { authInfo }) => {
+    const client = await getGraphClient(authInfo);
     if (!client) {
       return new Err(
         new MCPError("Failed to authenticate with Microsoft Graph")
@@ -46,8 +46,8 @@ const handlers: ToolHandlers<typeof MICROSOFT_EXCEL_TOOLS_METADATA> = {
     }
   },
 
-  get_worksheets: async ({ itemId, driveId, siteId }, extra) => {
-    const client = await getGraphClient(extra.authInfo);
+  get_worksheets: async ({ itemId, driveId, siteId }, { authInfo }) => {
+    const client = await getGraphClient(authInfo);
     if (!client) {
       return new Err(
         new MCPError("Failed to authenticate with Microsoft Graph")
@@ -60,7 +60,7 @@ const handlers: ToolHandlers<typeof MICROSOFT_EXCEL_TOOLS_METADATA> = {
       const response = await makeExcelRequest(
         client,
         itemId,
-        extra.authInfo?.clientId ?? "",
+        authInfo?.clientId ?? "",
         `${endpoint}/workbook/worksheets`,
         "get"
       );
@@ -77,9 +77,9 @@ const handlers: ToolHandlers<typeof MICROSOFT_EXCEL_TOOLS_METADATA> = {
 
   read_worksheet: async (
     { itemId, driveId, siteId, worksheetName, range },
-    extra
+    { authInfo }
   ) => {
-    const client = await getGraphClient(extra.authInfo);
+    const client = await getGraphClient(authInfo);
     if (!client) {
       return new Err(
         new MCPError("Failed to authenticate with Microsoft Graph")
@@ -101,7 +101,7 @@ const handlers: ToolHandlers<typeof MICROSOFT_EXCEL_TOOLS_METADATA> = {
       const response = await makeExcelRequest(
         client,
         itemId,
-        extra.authInfo?.clientId ?? "",
+        authInfo?.clientId ?? "",
         apiPath,
         "get"
       );
@@ -120,9 +120,9 @@ const handlers: ToolHandlers<typeof MICROSOFT_EXCEL_TOOLS_METADATA> = {
 
   write_worksheet: async (
     { itemId, driveId, siteId, worksheetName, range, data },
-    extra
+    { authInfo }
   ) => {
-    const client = await getGraphClient(extra.authInfo);
+    const client = await getGraphClient(authInfo);
     if (!client) {
       return new Err(
         new MCPError("Failed to authenticate with Microsoft Graph")
@@ -205,7 +205,7 @@ const handlers: ToolHandlers<typeof MICROSOFT_EXCEL_TOOLS_METADATA> = {
       const response = await makeExcelRequest(
         client,
         itemId,
-        extra.authInfo?.clientId ?? "",
+        authInfo?.clientId ?? "",
         apiPath,
         "patch",
         { values: data }
@@ -225,9 +225,9 @@ const handlers: ToolHandlers<typeof MICROSOFT_EXCEL_TOOLS_METADATA> = {
 
   create_worksheet: async (
     { itemId, driveId, siteId, worksheetName },
-    extra
+    { authInfo }
   ) => {
-    const client = await getGraphClient(extra.authInfo);
+    const client = await getGraphClient(authInfo);
     if (!client) {
       return new Err(
         new MCPError("Failed to authenticate with Microsoft Graph")
@@ -242,7 +242,7 @@ const handlers: ToolHandlers<typeof MICROSOFT_EXCEL_TOOLS_METADATA> = {
       const response = await makeExcelRequest(
         client,
         itemId,
-        extra.authInfo?.clientId ?? "",
+        authInfo?.clientId ?? "",
         apiPath,
         "post",
         { name: worksheetName }
@@ -262,9 +262,9 @@ const handlers: ToolHandlers<typeof MICROSOFT_EXCEL_TOOLS_METADATA> = {
 
   clear_range: async (
     { itemId, driveId, siteId, worksheetName, range, applyTo },
-    extra
+    { authInfo }
   ) => {
-    const client = await getGraphClient(extra.authInfo);
+    const client = await getGraphClient(authInfo);
     if (!client) {
       return new Err(
         new MCPError("Failed to authenticate with Microsoft Graph")
@@ -281,7 +281,7 @@ const handlers: ToolHandlers<typeof MICROSOFT_EXCEL_TOOLS_METADATA> = {
       await makeExcelRequest(
         client,
         itemId,
-        extra.authInfo?.clientId ?? "",
+        authInfo?.clientId ?? "",
         apiPath,
         "post",
         {

--- a/front/lib/api/actions/servers/microsoft_teams/tools/index.ts
+++ b/front/lib/api/actions/servers/microsoft_teams/tools/index.ts
@@ -24,8 +24,8 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
 const MAX_NUMBER_OF_MESSAGES = 200;
 
 const handlers: ToolHandlers<typeof MICROSOFT_TEAMS_TOOLS_METADATA> = {
-  search_messages_content: async ({ query }, extra) => {
-    const client = await getGraphClient(extra.authInfo);
+  search_messages_content: async ({ query }, { authInfo }) => {
+    const client = await getGraphClient(authInfo);
     if (!client) {
       return new Err(
         new MCPError("Failed to authenticate with Microsoft Graph")
@@ -64,8 +64,8 @@ const handlers: ToolHandlers<typeof MICROSOFT_TEAMS_TOOLS_METADATA> = {
     }
   },
 
-  list_teams: async (_params, extra) => {
-    const client = await getGraphClient(extra.authInfo);
+  list_teams: async (_params, { authInfo }) => {
+    const client = await getGraphClient(authInfo);
     if (!client) {
       return new Err(
         new MCPError("Failed to authenticate with Microsoft Graph")
@@ -88,8 +88,8 @@ const handlers: ToolHandlers<typeof MICROSOFT_TEAMS_TOOLS_METADATA> = {
     }
   },
 
-  list_users: async ({ nameFilter, limit }, extra) => {
-    const client = await getGraphClient(extra.authInfo);
+  list_users: async ({ nameFilter, limit }, { authInfo }) => {
+    const client = await getGraphClient(authInfo);
     if (!client) {
       return new Err(
         new MCPError("Failed to authenticate with Microsoft Graph")
@@ -127,8 +127,8 @@ const handlers: ToolHandlers<typeof MICROSOFT_TEAMS_TOOLS_METADATA> = {
     }
   },
 
-  list_channels: async ({ teamId, nameFilter }, extra) => {
-    const client = await getGraphClient(extra.authInfo);
+  list_channels: async ({ teamId, nameFilter }, { authInfo }) => {
+    const client = await getGraphClient(authInfo);
     if (!client) {
       return new Err(
         new MCPError("Failed to authenticate with Microsoft Graph")
@@ -162,8 +162,8 @@ const handlers: ToolHandlers<typeof MICROSOFT_TEAMS_TOOLS_METADATA> = {
     }
   },
 
-  list_chats: async ({ limit, chatType, nameFilter }, extra) => {
-    const client = await getGraphClient(extra.authInfo);
+  list_chats: async ({ limit, chatType, nameFilter }, { authInfo }) => {
+    const client = await getGraphClient(authInfo);
     if (!client) {
       return new Err(
         new MCPError("Failed to authenticate with Microsoft Graph")
@@ -208,8 +208,11 @@ const handlers: ToolHandlers<typeof MICROSOFT_TEAMS_TOOLS_METADATA> = {
     }
   },
 
-  list_messages: async ({ teamId, channelId, fromDate, toDate }, extra) => {
-    const client = await getGraphClient(extra.authInfo);
+  list_messages: async (
+    { teamId, channelId, fromDate, toDate },
+    { authInfo }
+  ) => {
+    const client = await getGraphClient(authInfo);
     if (!client) {
       return new Err(
         new MCPError("Failed to authenticate with Microsoft Graph")
@@ -284,18 +287,13 @@ const handlers: ToolHandlers<typeof MICROSOFT_TEAMS_TOOLS_METADATA> = {
       userIds,
       parentMessageId,
     },
-    extra
+    { auth, authInfo, agentLoopContext }
   ) => {
-    const client = await getGraphClient(extra.authInfo);
+    const client = await getGraphClient(authInfo);
     if (!client) {
       return new Err(
         new MCPError("Failed to authenticate with Microsoft Graph")
       );
-    }
-
-    const auth = extra.auth;
-    if (!auth) {
-      return new Err(new MCPError("Authentication required"));
     }
 
     try {
@@ -424,15 +422,14 @@ const handlers: ToolHandlers<typeof MICROSOFT_TEAMS_TOOLS_METADATA> = {
 
       // Add footer with link to Dust conversation if agent context is available
       let finalContent = messageContent;
-      if (extra.agentLoopContext?.runContext?.agentConfiguration) {
+      if (agentLoopContext?.runContext?.agentConfiguration) {
         const agentUrl = getConversationRoute(
           auth.getNonNullableWorkspace().sId,
           "new",
-          `agentDetails=${extra.agentLoopContext.runContext.agentConfiguration.sId}`,
+          `agentDetails=${agentLoopContext.runContext.agentConfiguration.sId}`,
           config.getAppUrl()
         );
-        const agentName =
-          extra.agentLoopContext.runContext.agentConfiguration.name;
+        const agentName = agentLoopContext.runContext.agentConfiguration.name;
         const footerMessage = `<em>Sent via <a href="${agentUrl}">${agentName} Agent</a> on Dust</em>`;
         finalContent = `${messageContent}<br/><br/>${footerMessage}`;
       }

--- a/front/lib/api/actions/servers/query_tables_v2/tools/index.ts
+++ b/front/lib/api/actions/servers/query_tables_v2/tools/index.ts
@@ -27,12 +27,7 @@ import { CoreAPI } from "@app/types/core/core_api";
 import { Err, Ok } from "@app/types/shared/result";
 
 const handlers: ToolHandlers<typeof QUERY_TABLES_V2_TOOLS_METADATA> = {
-  [GET_DATABASE_SCHEMA_TOOL_NAME]: async ({ tables }, extra) => {
-    const auth = extra.auth;
-    if (!auth) {
-      return new Err(new MCPError("Authentication required"));
-    }
-
+  [GET_DATABASE_SCHEMA_TOOL_NAME]: async ({ tables }, { auth }) => {
     // Fetch table configurations
     const tableConfigurationsRes = await fetchTableDataSourceConfigurations(
       auth,
@@ -140,19 +135,14 @@ const handlers: ToolHandlers<typeof QUERY_TABLES_V2_TOOLS_METADATA> = {
 
   [EXECUTE_DATABASE_QUERY_TOOL_NAME]: async (
     { tables, query, fileName },
-    extra
+    { auth, agentLoopContext }
   ) => {
-    const auth = extra.auth;
-    if (!auth) {
-      return new Err(new MCPError("Authentication required"));
-    }
-
     // TODO(mcp): @fontanierh: we should not have a strict dependency on the agentLoopRunContext.
-    if (!extra.agentLoopContext?.runContext) {
+    if (!agentLoopContext?.runContext) {
       throw new Error("Unreachable: missing agentLoopContext.");
     }
 
-    const agentLoopRunContext = extra.agentLoopContext.runContext;
+    const agentLoopRunContext = agentLoopContext.runContext;
 
     // Fetch table configurations
     const tableConfigurationsRes = await fetchTableDataSourceConfigurations(

--- a/front/lib/api/actions/servers/run_agent/index.ts
+++ b/front/lib/api/actions/servers/run_agent/index.ts
@@ -98,7 +98,7 @@ const runAgent = async (
     toolName,
     childAgentBlob,
   }: {
-    auth?: Authenticator;
+    auth: Authenticator;
     agentLoopContext?: AgentLoopContextType;
     sendNotification?: (
       notification: MCPProgressNotificationType
@@ -109,7 +109,6 @@ const runAgent = async (
     childAgentBlob: ChildAgentBlob;
   }
 ): Promise<ToolHandlerResult> => {
-  assert(auth, "auth is required to run the run_agent tool");
   assert(
     agentLoopContext?.runContext,
     "agentLoopContext is required to run the run_agent tool"

--- a/front/lib/api/actions/servers/salesforce/helpers.ts
+++ b/front/lib/api/actions/servers/salesforce/helpers.ts
@@ -13,11 +13,11 @@ import { normalizeError } from "@app/types/shared/utils/error_utils";
 export const SF_API_VERSION = "57.0";
 
 export async function withAuth(
-  extra: ToolHandlerExtra,
+  { authInfo }: ToolHandlerExtra,
   action: (conn: Connection) => Promise<ToolHandlerResult>
 ): Promise<ToolHandlerResult> {
-  const accessToken = extra.authInfo?.token;
-  const instanceUrl = extra.authInfo?.extra?.instance_url;
+  const accessToken = authInfo?.token;
+  const instanceUrl = authInfo?.extra?.instance_url;
 
   if (typeof instanceUrl !== "string") {
     return new Err(new MCPError("Missing or invalid instance_url in authInfo"));

--- a/front/lib/api/actions/servers/search/tools/index.ts
+++ b/front/lib/api/actions/servers/search/tools/index.ts
@@ -36,31 +36,28 @@ import {
   timeFrameFromNow,
 } from "@app/types/shared/utils/time_frame";
 
-export async function searchFunction({
-  query,
-  relativeTimeFrame,
-  dataSources,
-  tagsIn,
-  tagsNot,
-  auth,
-  agentLoopContext,
-}: {
-  query: string;
-  relativeTimeFrame: string;
-  dataSources: DataSourcesToolConfigurationType;
-  tagsIn?: string[];
-  tagsNot?: string[];
-  auth?: Authenticator;
-  agentLoopContext?: AgentLoopContextType;
-}): Promise<Result<CallToolResult["content"], MCPError>> {
+export async function searchFunction(
+  auth: Authenticator,
+  {
+    query,
+    relativeTimeFrame,
+    dataSources,
+    tagsIn,
+    tagsNot,
+    agentLoopContext,
+  }: {
+    query: string;
+    relativeTimeFrame: string;
+    dataSources: DataSourcesToolConfigurationType;
+    tagsIn?: string[];
+    tagsNot?: string[];
+    agentLoopContext?: AgentLoopContextType;
+  }
+): Promise<Result<CallToolResult["content"], MCPError>> {
   const coreAPI = new CoreAPI(config.getCoreAPIConfig(), logger);
 
   const credentials = dustManagedCredentials();
   const timeFrame = parseTimeFrame(relativeTimeFrame);
-
-  if (!auth) {
-    return new Err(new MCPError("Authentication required"));
-  }
 
   if (!agentLoopContext?.runContext) {
     throw new Error(
@@ -213,18 +210,17 @@ export async function searchFunction({
 }
 
 const handlers: ToolHandlers<typeof SEARCH_TOOLS_METADATA> = {
-  [SEARCH_TOOL_NAME]: (params, extra) =>
-    searchFunction({
+  [SEARCH_TOOL_NAME]: (params, { auth, agentLoopContext }) =>
+    searchFunction(auth, {
       ...params,
-      auth: extra.auth,
-      agentLoopContext: extra.agentLoopContext,
+      agentLoopContext,
     }),
 };
 
 const handlersWithTags: ToolHandlers<typeof SEARCH_TOOL_METADATA_WITH_TAGS> = {
   ...handlers,
   [FIND_TAGS_TOOL_NAME]: async ({ query, dataSources }, { auth }) => {
-    return executeFindTags(query, dataSources, auth);
+    return executeFindTags(auth, query, dataSources);
   },
 };
 

--- a/front/lib/api/actions/servers/skill_management/tools/index.ts
+++ b/front/lib/api/actions/servers/skill_management/tools/index.ts
@@ -7,18 +7,15 @@ import { SkillResource } from "@app/lib/resources/skill/skill_resource";
 import { Err, Ok } from "@app/types/shared/result";
 
 const handlers: ToolHandlers<typeof SKILL_MANAGEMENT_TOOLS_METADATA> = {
-  [ENABLE_SKILL_TOOL_NAME]: async ({ skillName }, extra) => {
-    const auth = extra.auth;
-    if (!auth) {
-      return new Err(new MCPError("Authentication required"));
-    }
-
-    if (!extra.agentLoopContext?.runContext) {
+  [ENABLE_SKILL_TOOL_NAME]: async (
+    { skillName },
+    { auth, agentLoopContext }
+  ) => {
+    if (!agentLoopContext?.runContext) {
       return new Err(new MCPError("No conversation context available"));
     }
 
-    const { conversation, agentConfiguration } =
-      extra.agentLoopContext.runContext;
+    const { conversation, agentConfiguration } = agentLoopContext.runContext;
 
     const skill = await SkillResource.fetchActiveByName(auth, skillName);
     if (!skill) {

--- a/front/lib/api/actions/servers/snowflake/tools/index.ts
+++ b/front/lib/api/actions/servers/snowflake/tools/index.ts
@@ -79,8 +79,8 @@ async function getClientFromAuthInfo(
 }
 
 const handlers: ToolHandlers<typeof SNOWFLAKE_TOOLS_METADATA> = {
-  list_databases: async (_params, extra) => {
-    const clientRes = await getClientFromAuthInfo(extra.authInfo);
+  list_databases: async (_params, { authInfo }) => {
+    const clientRes = await getClientFromAuthInfo(authInfo);
     if (clientRes.isErr()) {
       return clientRes;
     }
@@ -103,8 +103,8 @@ const handlers: ToolHandlers<typeof SNOWFLAKE_TOOLS_METADATA> = {
     ]);
   },
 
-  list_schemas: async ({ database }, extra) => {
-    const clientRes = await getClientFromAuthInfo(extra.authInfo);
+  list_schemas: async ({ database }, { authInfo }) => {
+    const clientRes = await getClientFromAuthInfo(authInfo);
     if (clientRes.isErr()) {
       return clientRes;
     }
@@ -127,8 +127,8 @@ const handlers: ToolHandlers<typeof SNOWFLAKE_TOOLS_METADATA> = {
     ]);
   },
 
-  list_tables: async ({ database, schema }, extra) => {
-    const clientRes = await getClientFromAuthInfo(extra.authInfo);
+  list_tables: async ({ database, schema }, { authInfo }) => {
+    const clientRes = await getClientFromAuthInfo(authInfo);
     if (clientRes.isErr()) {
       return clientRes;
     }
@@ -151,8 +151,8 @@ const handlers: ToolHandlers<typeof SNOWFLAKE_TOOLS_METADATA> = {
     ]);
   },
 
-  describe_table: async ({ database, schema, table }, extra) => {
-    const clientRes = await getClientFromAuthInfo(extra.authInfo);
+  describe_table: async ({ database, schema, table }, { authInfo }) => {
+    const clientRes = await getClientFromAuthInfo(authInfo);
     if (clientRes.isErr()) {
       return clientRes;
     }
@@ -184,8 +184,11 @@ const handlers: ToolHandlers<typeof SNOWFLAKE_TOOLS_METADATA> = {
     ]);
   },
 
-  query: async ({ sql, database, schema, warehouse, max_rows }, extra) => {
-    const clientRes = await getClientFromAuthInfo(extra.authInfo);
+  query: async (
+    { sql, database, schema, warehouse, max_rows },
+    { authInfo }
+  ) => {
+    const clientRes = await getClientFromAuthInfo(authInfo);
     if (clientRes.isErr()) {
       return clientRes;
     }

--- a/front/lib/api/actions/servers/toolsets/tools/index.ts
+++ b/front/lib/api/actions/servers/toolsets/tools/index.ts
@@ -20,10 +20,6 @@ import { Err, Ok } from "@app/types/shared/result";
 
 const handlers: ToolHandlers<typeof TOOLSETS_TOOLS_METADATA> = {
   list: async (_, { auth, agentLoopContext }) => {
-    if (!auth) {
-      return new Err(new MCPError("Authentication required"));
-    }
-
     const mcpServerViewIdsFromAgentConfiguration =
       agentLoopContext?.runContext?.agentConfiguration.actions
         .filter(isServerSideMCPServerConfiguration)
@@ -80,10 +76,6 @@ const handlers: ToolHandlers<typeof TOOLSETS_TOOLS_METADATA> = {
   },
 
   enable: async ({ toolsetId }, { auth, agentLoopContext }) => {
-    if (!auth) {
-      return new Err(new MCPError("Authentication required"));
-    }
-
     const conversationId = agentLoopContext?.runContext?.conversation.sId;
     if (!conversationId) {
       return new Err(

--- a/front/lib/api/actions/servers/ukg_ready/helpers.ts
+++ b/front/lib/api/actions/servers/ukg_ready/helpers.ts
@@ -38,10 +38,10 @@ interface UkgReadyAuthContext {
 
 // withAuth pattern - extracts token and provides consistent error handling
 export async function withAuth(
-  extra: ToolHandlerExtra,
+  { authInfo }: ToolHandlerExtra,
   action: (ctx: UkgReadyAuthContext) => Promise<ToolHandlerResult>
 ): Promise<ToolHandlerResult> {
-  const accessToken = extra.authInfo?.token;
+  const accessToken = authInfo?.token;
   if (!accessToken) {
     return new Err(
       new MCPError(
@@ -50,7 +50,7 @@ export async function withAuth(
     );
   }
 
-  const instanceUrl = extra.authInfo?.extra?.instance_url;
+  const instanceUrl = authInfo?.extra?.instance_url;
   if (!instanceUrl || typeof instanceUrl !== "string") {
     return new Err(
       new MCPError(
@@ -59,7 +59,7 @@ export async function withAuth(
     );
   }
 
-  const companyId = extra.authInfo?.extra?.ukg_ready_company_id;
+  const companyId = authInfo?.extra?.ukg_ready_company_id;
   if (!companyId || typeof companyId !== "string") {
     return new Err(
       new MCPError(

--- a/front/lib/api/actions/servers/user_mentions/tools/index.ts
+++ b/front/lib/api/actions/servers/user_mentions/tools/index.ts
@@ -17,12 +17,10 @@ import { Err, Ok } from "@app/types/shared/result";
 import { getHeaderFromUserEmail } from "@app/types/user";
 
 const handlers: ToolHandlers<typeof USER_MENTIONS_TOOLS_METADATA> = {
-  [SEARCH_AVAILABLE_USERS_TOOL_NAME]: async ({ searchTerm }, extra) => {
-    const auth = extra.auth;
-    if (!auth) {
-      return new Err(new MCPError("Authentication required"));
-    }
-
+  [SEARCH_AVAILABLE_USERS_TOOL_NAME]: async (
+    { searchTerm },
+    { auth, agentLoopContext }
+  ) => {
     const user = auth.user();
     const prodCredentials = await prodAPICredentialsForOwner(
       auth.getNonNullableWorkspace()
@@ -45,7 +43,7 @@ const handlers: ToolHandlers<typeof USER_MENTIONS_TOOLS_METADATA> = {
     const r = await api.getMentionsSuggestions({
       query: searchTerm,
       select: ["users"],
-      conversationId: extra.agentLoopContext?.runContext?.conversation?.sId,
+      conversationId: agentLoopContext?.runContext?.conversation?.sId,
     });
 
     if (r.isErr()) {

--- a/front/lib/api/actions/servers/web_search_browse/tools/index.ts
+++ b/front/lib/api/actions/servers/web_search_browse/tools/index.ts
@@ -106,10 +106,6 @@ async function handleWebbrowser(
   if (!agentLoopContext?.runContext) {
     return new Err(new MCPError("No conversation context available"));
   }
-  if (!auth) {
-    return new Err(new MCPError("Authentication required"));
-  }
-
   const { toolConfiguration } = agentLoopContext.runContext;
   const useSummarization =
     isLightServerSideMCPToolConfiguration(toolConfiguration) &&

--- a/front/lib/api/actions/tools/find_tags/index.ts
+++ b/front/lib/api/actions/tools/find_tags/index.ts
@@ -16,14 +16,10 @@ import { removeNulls } from "@app/types/shared/utils/general";
 const DEFAULT_SEARCH_LABELS_UPPER_LIMIT = 2000;
 
 export async function executeFindTags(
+  auth: Authenticator,
   query: string,
-  dataSources: DataSourcesToolConfigurationType,
-  auth?: Authenticator
+  dataSources: DataSourcesToolConfigurationType
 ): Promise<Result<TextContent[], MCPError>> {
-  if (!auth) {
-    return new Err(new MCPError("Authentication required"));
-  }
-
   const coreSearchArgsResults = await concurrentExecutor(
     dataSources,
     async (dataSourceConfiguration) =>

--- a/front/runbooks/NEW_MCP_SERVER.md
+++ b/front/runbooks/NEW_MCP_SERVER.md
@@ -405,10 +405,10 @@ import { Err } from "@app/types/shared/result";
 
 // withAuth pattern - extracts token and provides consistent error handling
 export async function withAuth<T>(
-  extra: ToolHandlerExtra,
+  { authInfo }: ToolHandlerExtra,
   action: (token: string) => Promise<ToolHandlerResult>
 ): Promise<ToolHandlerResult> {
-  const token = extra.authInfo?.token;
+  const token = authInfo?.token;
   if (!token) {
     return new Err(new MCPError("No access token provided"));
   }


### PR DESCRIPTION
## Description

- This PR changes the type of `ToolHandlerExtra` (extra params passed to MCP tool callbacks) to make the Authenticator mandatory.
- Allows cleaning up the tool implementations.

## Tests

- Tested locally.

## Risk

- Low, very well covered by typing.

## Deploy Plan

- Deploy front.
