### PR TITLE
Allow workOS activity to remove members from provisioned groups

### DIFF
--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -1276,7 +1276,7 @@ export class GroupResource extends BaseResource<GroupModel> {
         this.kind === "agent_editors" ||
         this.kind === "skill_editors" ||
         (allowProvisionnedGroups && this.kind === "provisioned"),
-      `You can't remove members to ${this.kind} groups.`
+      `You can't remove members from ${this.kind} groups.`
     );
     const owner = auth.getNonNullableWorkspace();
     if (users.length === 0) {

--- a/front/temporal/workos_events_queue/activities.ts
+++ b/front/temporal/workos_events_queue/activities.ts
@@ -690,6 +690,7 @@ async function handleUserRemovedFromGroup(
   }
   const res = await group.dangerouslyRemoveMember(auth, {
     user: user.toJSON(),
+    allowProvisionnedGroups: true,
   });
   if (res.isErr() && res.error.code !== "user_not_member") {
     throw new Error(res.error.message);
@@ -838,6 +839,7 @@ async function handleDeleteWorkOSUser(
     }
     const removeResult = await group.dangerouslyRemoveMember(auth, {
       user: user.toJSON(),
+      allowProvisionnedGroups: true,
     });
     if (removeResult.isErr()) {
       logger.warn(


### PR DESCRIPTION
## Description

This PR enables WorkOS activities to handle provisioned groups in two scenarios:
- When a user is removed from a group in WorkOS
- When a provisioned group is deleted in WorkOS

By default, provisioned group memberships can't be edited. However, these activities need to be allowed as exceptions."

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Deploy front
