### PR TITLE
[LLM-ROUTER] Add accept header when calling openai

### DIFF
--- a/front/lib/api/llm/clients/openai/index.ts
+++ b/front/lib/api/llm/clients/openai/index.ts
@@ -50,6 +50,7 @@ export class OpenAIResponsesLLM extends LLM {
       baseURL: OPENAI_BASE_URL ?? "https://api.openai.com/v1",
       defaultHeaders: {
         "Content-Type": "application/json; charset=utf-8",
+        Accept: "application/json; charset=utf-8",
       },
     });
   }


### PR DESCRIPTION
## Description

To avoid gpt5 unicode characters corruption

## Tests

local

## Risk

low

## Deploy Plan

front