### PR TITLE
fix: editors can add mentioned users to private projects

### DIFF
--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -956,12 +956,6 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     }
   }
 
-  // TODO(projects): update this method to check groups whose group_vaults relationship is
-  // space_editor (not space_viewer or space_member) when the PR adding the relationship is live.
-  isEditor(auth: Authenticator): boolean {
-    return this.isMember(auth);
-  }
-
   /**
    * Computes resource permissions based on space type and group configuration.
    *


### PR DESCRIPTION





## Description

Fixes https://github.com/dust-tt/tasks/issues/6518

This PR fixes the user mention flow in private project conversations by allowing project editors to add mentioned users.

- Do not check if the user can access the conversation for project conversations
- Add tests

## Tests

Tests added for mention status.

## Risks

Low risk. This changes the mentions behavior only for project conversations, not other conversations.

## Deploy Plan

Standard deployment, no special steps required.
