### PR TITLE
Prevent users from leaving a project if last editor

### DIFF
--- a/front/components/assistant/conversation/ProjectMenu.tsx
+++ b/front/components/assistant/conversation/ProjectMenu.tsx
@@ -178,10 +178,15 @@ export function ProjectMenu({
 
   // Determine permissions based on spaceInfo
   const isProject = space?.kind === "project" || spaceInfo?.kind === "project";
+  const isMember = spaceInfo?.isMember ?? false;
+  const projectEditors =
+    spaceInfo?.members?.filter((member) => member.isEditor) ?? [];
+  const isProjectEditor = projectEditors.some(
+    (member) => member.sId === user.sId
+  );
   const canLeave =
-    (spaceInfo?.isMember ?? false) &&
-    (spaceInfo?.members?.filter((member) => member.isEditor)?.length ?? 0) >
-      1 &&
+    ((isMember && !isProjectEditor) || // regular members can leave the project
+      (isProjectEditor && projectEditors.length > 1)) && // editors can leave if there's at least another editor
     isProject;
   const canRename = spaceInfo?.canWrite ?? false; // Only admins can rename
 

--- a/front/components/assistant/conversation/ProjectMenu.tsx
+++ b/front/components/assistant/conversation/ProjectMenu.tsx
@@ -178,7 +178,10 @@ export function ProjectMenu({
 
   // Determine permissions based on spaceInfo
   const isProject = space?.kind === "project" || spaceInfo?.kind === "project";
-  const canLeave = (spaceInfo?.isMember ?? false) && isProject;
+  const canLeave =
+    (spaceInfo?.isMember ?? false) &&
+    (spaceInfo?.members?.length ?? 0) > 1 &&
+    isProject;
   const canRename = spaceInfo?.canWrite ?? false; // Only admins can rename
 
   return (

--- a/front/components/assistant/conversation/ProjectMenu.tsx
+++ b/front/components/assistant/conversation/ProjectMenu.tsx
@@ -180,7 +180,7 @@ export function ProjectMenu({
   const isProject = space?.kind === "project" || spaceInfo?.kind === "project";
   const canLeave =
     (spaceInfo?.isMember ?? false) &&
-    (spaceInfo?.members?.length ?? 0) > 1 &&
+    (spaceInfo?.members?.filter((member) => member.isEditor)?.length ?? 0) > 1 &&
     isProject;
   const canRename = spaceInfo?.canWrite ?? false; // Only admins can rename
 

--- a/front/components/assistant/conversation/ProjectMenu.tsx
+++ b/front/components/assistant/conversation/ProjectMenu.tsx
@@ -180,7 +180,8 @@ export function ProjectMenu({
   const isProject = space?.kind === "project" || spaceInfo?.kind === "project";
   const canLeave =
     (spaceInfo?.isMember ?? false) &&
-    (spaceInfo?.members?.filter((member) => member.isEditor)?.length ?? 0) > 1 &&
+    (spaceInfo?.members?.filter((member) => member.isEditor)?.length ?? 0) >
+      1 &&
     isProject;
   const canRename = spaceInfo?.canWrite ?? false; // Only admins can rename
 

--- a/front/components/assistant/conversation/space/ProjectHeaderActions.tsx
+++ b/front/components/assistant/conversation/space/ProjectHeaderActions.tsx
@@ -59,7 +59,8 @@ export function ProjectHeaderActions({
     onSuccess: handleLeaveSuccess,
   });
 
-  const canLeaveProject = isMember && members.filter((member) => member.isEditor).length > 1;
+  const canLeaveProject =
+    isMember && members.filter((member) => member.isEditor).length > 1;
 
   return (
     <>

--- a/front/components/assistant/conversation/space/ProjectHeaderActions.tsx
+++ b/front/components/assistant/conversation/space/ProjectHeaderActions.tsx
@@ -59,7 +59,7 @@ export function ProjectHeaderActions({
     onSuccess: handleLeaveSuccess,
   });
 
-  const canLeaveProject = isMember && members.length > 1;
+  const canLeaveProject = isMember && members.filter((member) => member.isEditor).length > 1;
 
   return (
     <>
@@ -90,7 +90,7 @@ export function ProjectHeaderActions({
             <DropdownMenuContent>
               {!canLeaveProject ? (
                 <DropdownTooltipTrigger
-                  description="You are the last member of this project and cannot leave it."
+                  description="You are the last editor of this project and cannot leave it."
                   side="left"
                 >
                   <DropdownMenuItem

--- a/front/components/assistant/conversation/space/ProjectHeaderActions.tsx
+++ b/front/components/assistant/conversation/space/ProjectHeaderActions.tsx
@@ -5,6 +5,7 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
+  DropdownTooltipTrigger,
   MoreIcon,
   XMarkIcon,
 } from "@dust-tt/sparkle";
@@ -58,6 +59,8 @@ export function ProjectHeaderActions({
     onSuccess: handleLeaveSuccess,
   });
 
+  const canLeaveProject = isMember && members.length > 1;
+
   return (
     <>
       <div className="flex items-center gap-2">
@@ -85,11 +88,24 @@ export function ProjectHeaderActions({
               />
             </DropdownMenuTrigger>
             <DropdownMenuContent>
-              <DropdownMenuItem
-                label="Leave the project"
-                icon={XMarkIcon}
-                onClick={openLeaveDialog}
-              />
+              {!canLeaveProject ? (
+                <DropdownTooltipTrigger
+                  description="You are the last member of this project and cannot leave it."
+                  side="left"
+                >
+                  <DropdownMenuItem
+                    label="Leave the project"
+                    icon={XMarkIcon}
+                    disabled={true}
+                  />
+                </DropdownTooltipTrigger>
+              ) : (
+                <DropdownMenuItem
+                  label="Leave the project"
+                  icon={XMarkIcon}
+                  onClick={openLeaveDialog}
+                />
+              )}
             </DropdownMenuContent>
           </DropdownMenu>
         )}

--- a/front/components/assistant/conversation/space/ProjectHeaderActions.tsx
+++ b/front/components/assistant/conversation/space/ProjectHeaderActions.tsx
@@ -23,7 +23,6 @@ import type {
 
 interface ProjectHeaderActionsProps {
   isMember: boolean;
-  isEditor: boolean;
   isRestricted: boolean;
   members: SpaceUserType[];
   owner: LightWorkspaceType;
@@ -34,7 +33,6 @@ interface ProjectHeaderActionsProps {
 
 export function ProjectHeaderActions({
   isMember,
-  isEditor,
   isRestricted,
   members,
   owner,

--- a/front/components/assistant/conversation/space/ProjectHeaderActions.tsx
+++ b/front/components/assistant/conversation/space/ProjectHeaderActions.tsx
@@ -23,6 +23,7 @@ import type {
 
 interface ProjectHeaderActionsProps {
   isMember: boolean;
+  isEditor: boolean;
   isRestricted: boolean;
   members: SpaceUserType[];
   owner: LightWorkspaceType;
@@ -33,6 +34,7 @@ interface ProjectHeaderActionsProps {
 
 export function ProjectHeaderActions({
   isMember,
+  isEditor,
   isRestricted,
   members,
   owner,
@@ -59,9 +61,13 @@ export function ProjectHeaderActions({
     onSuccess: handleLeaveSuccess,
   });
 
+  const projectEditors = members.filter((member) => member.isEditor);
+  const isProjectEditor = projectEditors.some(
+    (member) => member.sId === user.sId
+  );
   const canLeaveProject =
-    isMember && members.filter((member) => member.isEditor).length > 1;
-
+    (isMember && !isProjectEditor) || // regular members can leave the project
+    (isProjectEditor && projectEditors.length > 1); // editors can leave if there's at least another editor
   return (
     <>
       <div className="flex items-center gap-2">

--- a/front/components/pages/conversation/SpaceConversationsPage.tsx
+++ b/front/components/pages/conversation/SpaceConversationsPage.tsx
@@ -310,6 +310,7 @@ export function SpaceConversationsPage() {
             (spaceInfo.isMember || !spaceInfo.isRestricted) && (
               <ProjectHeaderActions
                 isMember={spaceInfo.isMember}
+                isEditor={spaceInfo.isEditor}
                 isRestricted={spaceInfo.isRestricted}
                 members={spaceInfo.members}
                 owner={owner}

--- a/front/components/pages/conversation/SpaceConversationsPage.tsx
+++ b/front/components/pages/conversation/SpaceConversationsPage.tsx
@@ -310,7 +310,6 @@ export function SpaceConversationsPage() {
             (spaceInfo.isMember || !spaceInfo.isRestricted) && (
               <ProjectHeaderActions
                 isMember={spaceInfo.isMember}
-                isEditor={spaceInfo.isEditor}
                 isRestricted={spaceInfo.isRestricted}
                 members={spaceInfo.members}
                 owner={owner}

--- a/sparkle/src/components/Dropdown.tsx
+++ b/sparkle/src/components/Dropdown.tsx
@@ -834,7 +834,10 @@ const DropdownTooltipTrigger = React.forwardRef<
       <TooltipPrimitive.Provider delayDuration={300}>
         <TooltipPrimitive.Root onOpenChange={onVisibilityChange}>
           <TooltipPrimitive.Trigger asChild className={className} ref={ref}>
-            {children}
+            {/* Wrapper allows pointer events even when child is disabled, while maintaining proper positioning */}
+            <span className="s-block s-w-full">
+              {children}
+            </span>
           </TooltipPrimitive.Trigger>
           {mountPortal ? (
             <TooltipPrimitive.Portal container={container}>

--- a/sparkle/src/components/Dropdown.tsx
+++ b/sparkle/src/components/Dropdown.tsx
@@ -835,9 +835,7 @@ const DropdownTooltipTrigger = React.forwardRef<
         <TooltipPrimitive.Root onOpenChange={onVisibilityChange}>
           <TooltipPrimitive.Trigger asChild className={className} ref={ref}>
             {/* Wrapper allows pointer events even when child is disabled, while maintaining proper positioning */}
-            <span className="s-block s-w-full">
-              {children}
-            </span>
+            <span className="s-block s-w-full">{children}</span>
           </TooltipPrimitive.Trigger>
           {mountPortal ? (
             <TooltipPrimitive.Portal container={container}>

--- a/sparkle/src/stories/Dropdown.stories.tsx
+++ b/sparkle/src/stories/Dropdown.stories.tsx
@@ -997,7 +997,13 @@ export const WithTooltips: Story = {
               >
                 <DropdownMenuItem icon={AttachmentIcon} label="Add Knowledge" />
               </DropdownTooltipTrigger>
-              <DropdownMenuItem label="Save Draft" />
+              <DropdownTooltipTrigger
+                description="This feature is disabled because you need to configure settings first."
+                side="right"
+                sideOffset={8}
+              >
+                <DropdownMenuItem label="Save Draft" icon={CloudArrowDownIcon} disabled />
+              </DropdownTooltipTrigger>
             </DropdownMenuContent>
           </DropdownMenu>
 

--- a/sparkle/src/stories/Dropdown.stories.tsx
+++ b/sparkle/src/stories/Dropdown.stories.tsx
@@ -1002,7 +1002,11 @@ export const WithTooltips: Story = {
                 side="right"
                 sideOffset={8}
               >
-                <DropdownMenuItem label="Save Draft" icon={CloudArrowDownIcon} disabled />
+                <DropdownMenuItem
+                  label="Save Draft"
+                  icon={CloudArrowDownIcon}
+                  disabled
+                />
               </DropdownTooltipTrigger>
             </DropdownMenuContent>
           </DropdownMenu>


### PR DESCRIPTION
## Description

This PR prevents users from leaving a project when they are the last editor. It fixes an issue where users could leave a project even when they were the sole editor, which would result in an orphaned project.

The fix updates the leave button logic in both ProjectMenu and ProjectHeaderActions components to check the editor count before allowing the leave action.
<img width="430" height="154" alt="image" src="https://github.com/user-attachments/assets/7ebbe7ff-0dc6-40df-a279-03eff44be6cc" />


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Deploy front
