### PR TITLE
Add production check for stale ended_backend_only subscriptions

### DIFF
--- a/front/lib/production_checks/checks/check_ended_backend_only_subscriptions.ts
+++ b/front/lib/production_checks/checks/check_ended_backend_only_subscriptions.ts
@@ -1,0 +1,55 @@
+import { QueryTypes } from "sequelize";
+
+import { getFrontReplicaDbConnection } from "@app/lib/production_checks/utils";
+import type { ActionLink, CheckFunction } from "@app/types/production_checks";
+
+interface StaleEndedBackendOnlySubscription {
+  sId: string;
+  workspaceId: string;
+  workspaceName: string;
+  updatedAt: string;
+}
+
+export const checkEndedBackendOnlySubscriptions: CheckFunction = async (
+  _checkName,
+  _logger,
+  reportSuccess,
+  reportFailure
+) => {
+  const frontDb = getFrontReplicaDbConnection();
+
+  const staleSubscriptions: StaleEndedBackendOnlySubscription[] =
+    // eslint-disable-next-line dust/no-raw-sql -- Production check using read replica
+    await frontDb.query(
+      `
+      SELECT
+        s."sId" as "sId",
+        w."sId" as "workspaceId",
+        w."name" as "workspaceName",
+        s."updatedAt" as "updatedAt"
+      FROM subscriptions s
+      JOIN workspaces w ON s."workspaceId" = w.id
+      WHERE s."status" = 'ended_backend_only'
+        AND s."updatedAt" < NOW() - INTERVAL '1 hour'
+      ORDER BY s."updatedAt" ASC
+      `,
+      {
+        type: QueryTypes.SELECT,
+      }
+    );
+
+  if (staleSubscriptions.length > 0) {
+    const actionLinks: ActionLink[] = staleSubscriptions.map((s) => ({
+      label: `${s.workspaceName} (sub: ${s.sId})`,
+      url: `/poke/${s.workspaceId}`,
+    }));
+
+    const message =
+      `${staleSubscriptions.length} subscription(s) stuck in "ended_backend_only" status for more than 1 hour. ` +
+      `Stripe webhook may have failed to process.`;
+
+    reportFailure({ staleSubscriptions, actionLinks }, message);
+  } else {
+    reportSuccess();
+  }
+};

--- a/front/temporal/production_checks/activities.ts
+++ b/front/temporal/production_checks/activities.ts
@@ -5,6 +5,7 @@ import { checkActiveWorkflows } from "@app/lib/production_checks/checks/check_ac
 import { checkActiveWorkflowsForFront } from "@app/lib/production_checks/checks/check_active_workflows_for_front";
 import { checkConnectorsLastSyncSuccess } from "@app/lib/production_checks/checks/check_connectors_last_sync_success";
 import { checkDataSourcesConsistency } from "@app/lib/production_checks/checks/check_data_sources_consistency";
+import { checkEndedBackendOnlySubscriptions } from "@app/lib/production_checks/checks/check_ended_backend_only_subscriptions";
 import { checkExcessCredits } from "@app/lib/production_checks/checks/check_excess_credits";
 import { checkExtraneousWorkflows } from "@app/lib/production_checks/checks/check_extraneous_workflows_for_paused_connectors";
 import { checkNotionActiveWorkflows } from "@app/lib/production_checks/checks/check_notion_active_workflows";
@@ -69,6 +70,11 @@ export const REGISTERED_CHECKS: Check[] = [
   {
     name: "check_excess_credits",
     check: checkExcessCredits,
+    everyHour: 24,
+  },
+  {
+    name: "check_ended_backend_only_subscriptions",
+    check: checkEndedBackendOnlySubscriptions,
     everyHour: 24,
   },
 ];


### PR DESCRIPTION
## Description

Add a daily production check that detects subscriptions stuck in ended_backend_only status for more than 1 hour, which indicates a Stripe webhook may have failed to process. Reports failing subscriptions with poke links to the affected workspaces.

## Tests

 - Tested locally by inserting a fake subscription with ended_backend_only status and updatedAt > 1 hour ago, confirmed the check reports failure.
- Verified the check reports success when no stale subscriptions exist.

<kbd>
<img width="637" height="614" alt="Screenshot 2026-02-13 at 11 09 07" src="https://github.com/user-attachments/assets/ec4224e7-16bc-4718-a3ae-a1c20f77444b" />
</kbd>

💅🏻 super convenient for testing 🤩 


## Risk

Can be rolled back. 

## Deploy Plan

Merge and deploy front. 