### PR TITLE
Frames: fix issue for hiding footer in generated PDF for entreprise users

### DIFF
--- a/front/pages/api/w/[wId]/files/[fileId]/export/pdf.ts
+++ b/front/pages/api/w/[wId]/files/[fileId]/export/pdf.ts
@@ -162,10 +162,10 @@ async function handler(
 
   // Only show footer for non-Enterprise plans and non-FriendsAndFamily plans.
   const plan = auth.plan();
-  const showFooter =
-    !plan ||
-    !isEntreprisePlanPrefix(plan.code) ||
-    !isFriendsAndFamilyPlan(plan.code);
+  const shouldHideFooter =
+    plan &&
+    (isEntreprisePlanPrefix(plan.code) || isFriendsAndFamilyPlan(plan.code));
+  const showFooter = !shouldHideFooter;
 
   const renderer = new DocumentRenderer(documentRendererUrl, logger);
 


### PR DESCRIPTION
## Description

closes https://github.com/dust-tt/tasks/issues/6547 and closes https://github.com/dust-tt/dust/issues/21565

the logic was bad so the footer always display

## Tests

no

## Risk

low

## Deploy Plan

deploy front
