### PR TITLE
Make sure the description/avatar are generated when accepting suggestion

### DIFF
--- a/front/components/agent_builder/copilot/CopilotSuggestionsContext.tsx
+++ b/front/components/agent_builder/copilot/CopilotSuggestionsContext.tsx
@@ -11,7 +11,10 @@ import React, {
 } from "react";
 
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
-import { BLUR_EVENT_NAME } from "@app/components/agent_builder/instructions/AgentBuilderInstructionsEditor";
+import {
+  BLUR_EVENT_NAME,
+  INSTRUCTIONS_DEBOUNCE_MS,
+} from "@app/components/agent_builder/instructions/AgentBuilderInstructionsEditor";
 import { getSuggestionPosition } from "@app/components/editor/extensions/agent_builder/InstructionSuggestionExtension";
 import { stripHtmlAttributes } from "@app/components/editor/input_bar/cleanupPastedHTML";
 import { useSkillsContext } from "@app/components/shared/skills/SkillsContext";
@@ -270,7 +273,7 @@ export const CopilotSuggestionsProvider = ({
   // Dispatch the blur event after a delay so the editor's debounced form sync
   // (250ms) completes first, ensuring the instructions field is up-to-date
   // when the description/avatar auto-generation reads it.
-  const BLUR_DISPATCH_DELAY_MS = 300;
+  const BLUR_DISPATCH_DELAY_MS = INSTRUCTIONS_DEBOUNCE_MS + 50;
   const dispatchDelayedBlur = useCallback(() => {
     setTimeout(() => {
       window.dispatchEvent(new CustomEvent(BLUR_EVENT_NAME));

--- a/front/components/agent_builder/copilot/CopilotSuggestionsContext.tsx
+++ b/front/components/agent_builder/copilot/CopilotSuggestionsContext.tsx
@@ -11,6 +11,7 @@ import React, {
 } from "react";
 
 import { useAgentBuilderContext } from "@app/components/agent_builder/AgentBuilderContext";
+import { BLUR_EVENT_NAME } from "@app/components/agent_builder/instructions/AgentBuilderInstructionsEditor";
 import { getSuggestionPosition } from "@app/components/editor/extensions/agent_builder/InstructionSuggestionExtension";
 import { stripHtmlAttributes } from "@app/components/editor/input_bar/cleanupPastedHTML";
 import { useSkillsContext } from "@app/components/shared/skills/SkillsContext";
@@ -266,6 +267,16 @@ export const CopilotSuggestionsProvider = ({
     checkEditorReady();
   }, []);
 
+  // Dispatch the blur event after a delay so the editor's debounced form sync
+  // (250ms) completes first, ensuring the instructions field is up-to-date
+  // when the description/avatar auto-generation reads it.
+  const BLUR_DISPATCH_DELAY_MS = 300;
+  const dispatchDelayedBlur = useCallback(() => {
+    setTimeout(() => {
+      window.dispatchEvent(new CustomEvent(BLUR_EVENT_NAME));
+    }, BLUR_DISPATCH_DELAY_MS);
+  }, []);
+
   // Apply pending instruction suggestions to the editor when they arrive from backend.
   useEffect(() => {
     const editor = editorRef.current;
@@ -384,11 +395,12 @@ export const CopilotSuggestionsProvider = ({
       if (suggestion.kind === "instructions") {
         editor.commands.acceptSuggestion(sId);
         appliedSuggestionsRef.current.delete(sId);
+        dispatchDelayedBlur();
       }
 
       return true;
     },
-    [patchSuggestions, getSuggestion]
+    [patchSuggestions, getSuggestion, dispatchDelayedBlur]
   );
 
   const rejectSuggestion = useCallback(
@@ -461,8 +473,10 @@ export const CopilotSuggestionsProvider = ({
         appliedSuggestionsRef.current.delete(sId);
       }
 
+      dispatchDelayedBlur();
+
       return true;
-    }, [patchSuggestions, getPendingSuggestions]);
+    }, [patchSuggestions, getPendingSuggestions, dispatchDelayedBlur]);
 
   const rejectAllInstructionSuggestions =
     useCallback(async (): Promise<boolean> => {

--- a/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
+++ b/front/components/agent_builder/instructions/AgentBuilderInstructionsEditor.tsx
@@ -112,6 +112,7 @@ export function buildAgentInstructionsReadOnlyExtensions(): Extensions {
 }
 
 export const BLUR_EVENT_NAME = "agent:instructions:blur";
+export const INSTRUCTIONS_DEBOUNCE_MS = 250;
 
 const editorVariants = cva(
   [
@@ -234,7 +235,7 @@ export function AgentBuilderInstructionsEditor({
           // Strip style/class/id attributes to store clean HTML structure.
           instructionsHtmlField.onChange(stripHtmlAttributes(editor.getHTML()));
         }
-      }, 250),
+      }, INSTRUCTIONS_DEBOUNCE_MS),
     [field, instructionsHtmlField, isInstructionDiffMode]
   );
 


### PR DESCRIPTION
## Description

The description/avatar fields are auto-generated when there is a Blur event on the instruction, which doesn't happen automatically when clicking accept button.

The fix uses a simple 300ms delay (just above the editor's 250ms debounce) before dispatching the blur event, giving the debounced form sync time to flush so the instructions field is populated when the description/avatar auto-generation reads it.

This is part of https://github.com/dust-tt/tasks/issues/6198

## Tests

Manual

## Risk

Low

## Deploy Plan

Front