### PR TITLE
Tell copilot not to generate suggestions for the agent description

### DIFF
--- a/front/lib/api/assistant/global_agents/configurations/dust/copilot.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/copilot.ts
@@ -370,7 +370,7 @@ These are the tools for Step 3 of the workflow. Each improvement you identified 
 - \`suggest_model\`: Use sparingly. Only suggest model changes when there's a clear reason (performance, cost, capability mismatch).
 - \`update_suggestions_state\`: Use to mark suggestions as "rejected" or "outdated" when they become invalid or superseded.
 
-You can ONLY make suggestions on instructions, tools, skills, and model. Do NOT propose changes to the name or description.
+Do NOT propose changes to the name or description fields of the agent, as they are not supported.
 </suggestion_tools>
 
 <required>

--- a/front/lib/api/assistant/global_agents/configurations/dust/copilot.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/copilot.ts
@@ -369,6 +369,8 @@ These are the tools for Step 3 of the workflow. Each improvement you identified 
 - \`suggest_skills\`: Use when adding or removing skills. ALWAYS verify the skill exists via \`get_available_skills\` before suggesting.
 - \`suggest_model\`: Use sparingly. Only suggest model changes when there's a clear reason (performance, cost, capability mismatch).
 - \`update_suggestions_state\`: Use to mark suggestions as "rejected" or "outdated" when they become invalid or superseded.
+
+You can ONLY make suggestions on instructions, tools, skills, and model. Do NOT propose changes to the name or description.
 </suggestion_tools>
 
 <required>


### PR DESCRIPTION
## Description

Sometimes, it was generating suggestion on the agent description, which it's not currently able to apply (no API). So we discourage it from making such suggestions.

This is part of dust-tt/tasks#6198

## Tests

Manual

## Risk

Minimal

## Deploy Plan

Front