### PR TITLE
fix: reset tab to conversations when navigating between projects [#6502]

### DIFF
--- a/front/components/pages/conversation/SpaceConversationsPage.tsx
+++ b/front/components/pages/conversation/SpaceConversationsPage.tsx
@@ -9,7 +9,7 @@ import {
   TabsTrigger,
   TestTubeIcon,
 } from "@dust-tt/sparkle";
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useRef, useState } from "react";
 
 import { SpaceAboutTab } from "@app/components/assistant/conversation/space/about/SpaceAboutTab";
 import { SpaceConversationsTab } from "@app/components/assistant/conversation/space/conversations/SpaceConversationsTab";
@@ -126,6 +126,20 @@ export function SpaceConversationsPage() {
     return () => window.removeEventListener("hashchange", updateTabFromHash);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []); // Only run on mount and cleanup on unmount
+
+  // Reset tab to conversations when navigating to a different project.
+  const prevSpaceIdRef = useRef(spaceId);
+  React.useEffect(() => {
+    if (prevSpaceIdRef.current !== spaceId) {
+      prevSpaceIdRef.current = spaceId;
+      setCurrentTab("conversations");
+      window.history.replaceState(
+        null,
+        "",
+        `${window.location.pathname}${window.location.search}#conversations`
+      );
+    }
+  }, [spaceId]);
 
   const handleTabChange = useCallback((tab: SpaceTab) => {
     // Use replaceState to avoid adding to browser history for each tab switch


### PR DESCRIPTION
## Description

When creating a new project while on the knowledge tab of another project, the new project opened on the knowledge tab instead of conversations. The `SpaceConversationsPage` component uses URL hash to track the active tab, but since the component doesn't remount during client-side navigation between projects (same Next.js page), the tab state remained stale.

Adds a `useEffect` that detects `spaceId` changes and resets the tab to "conversations".

Fixes dust-tt/tasks#6502

## Tests

Manually tested: create a new project from another project's knowledge tab → new project opens on conversations tab. Direct navigation with `#knowledge` hash still works on page load.