### PR TITLE
Context limit reached Chip: implement on extension to avoid crash

### DIFF
--- a/front/components/assistant/conversation/AgentMessage.tsx
+++ b/front/components/assistant/conversation/AgentMessage.tsx
@@ -113,23 +113,29 @@ function PrunedContextChip() {
     <Tooltip
       label={
         <div className="flex flex-col gap-2 py-2">
-          <div className="font-semibold">Context window limit reached</div>
-          <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-            Some tool results were removed to keep this conversation within its
-            size limit. For more accurate results, try narrowing your query or
-            starting a new conversation.&nbsp;
-            <a
-              href={UNDERTAND_LLMS_CONTEXT_WINDOW_URL}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="underline hover:text-foreground dark:hover:text-foreground-night"
-            >
-              Learn more
-            </a>
+          <div className="font-semibold">
+            This conversation reached its size limit
+          </div>
+          <div className="flex flex-col gap-2 text-justify text-sm text-muted-foreground dark:text-muted-foreground-night">
+            <p>
+              The agent can only process so much information at once. We removed
+              some <strong>data from earlier steps</strong> to make room. For
+              better accuracy, start a fresh conversation.
+            </p>
+            <p>
+              <a
+                href={UNDERTAND_LLMS_CONTEXT_WINDOW_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline hover:text-foreground dark:hover:text-foreground-night"
+              >
+                Learn more
+              </a>
+            </p>
           </div>
         </div>
       }
-      className="max-w-md"
+      className="max-w-sm"
       trigger={
         <Chip
           label="Context limit reached"


### PR DESCRIPTION
## Description

Eng runner card: https://github.com/dust-tt/tasks/issues/6539

- Handle the agent_context_pruned streaming event in the Chrome extension's AgentMessage component, fixing a runtime crash caused by the event hitting assertNever in the reducer
- Add a "Context limit reached" chip (with tooltip) to the extension, matching the front app's behavior via the infoChip prop
- Improve the PrunedContextChip tooltip copy and layout in both the extension and the front app (justified text, clearer wording, paragraph  spacing)

Before: 
<kbd>
<img width="588" height="354" alt="Screenshot 2026-02-13 at 14 21 26" src="https://github.com/user-attachments/assets/a5793f82-e163-4fc5-8baf-97bbff6850b9" />
</kbd>
After: 
<kbd>
<img width="506" height="307" alt="Screenshot 2026-02-13 at 15 31 36" src="https://github.com/user-attachments/assets/f8b88ce2-137b-40a4-9dbf-d18a91a8709f" />
</kbd>



## Tests

Tested locally by editing in `temporal/agent_loop/lib/run_model.ts` to trigger the event. 

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

Deploy front. 
Make a new version of the extension and ship.