### PR TITLE
[Skills] Document --projectName, --projectId and --details in dust-call-agent skill

### DIFF
--- a/.claude/skills/dust-call-agent/SKILL.md
+++ b/.claude/skills/dust-call-agent/SKILL.md
@@ -5,16 +5,16 @@ description: Call a Dust agent to get information (read a slack thread, a notion
 
 Access Dust agents that have context on all the company, e.g. recent projects, engineering, sales, marketing, etc., via the Dust CLI non-interactively, e.g.:
 `$ dust chat -a issueBot -m "create an issue for this: ..."`
-`$ dust chat -a deep-dive -m "Research all info we have on kubernetes probe failures in recent weeks.`
+`$ dust chat -a deep-dive -m "Research all info we have on kubernetes probe failures in recent weeks."`
 
 A conversation with an agent can be continued after the first message using the argument `-c CONVERSATION_STRING_ID`. The conversation id will be returned in the JSON result from the initial call.
 `$ dust chat -a issueBot -c 'TdWyn4aDt1' -m "also add a subsequent issue about this: ..."`
 
-Use `--projectName` or `--projectId` to create the conversation inside a specific project (space):
+Use `--projectName` or `--projectId` to create the conversation inside a specific project (space). These cannot be used with `-c` (only for new conversations):
 `$ dust chat -a prea --projectName "Engineering" -m "summarize recent incidents"`
 `$ dust chat -a prea --projectId "abc123" -m "summarize recent incidents"`
 
-Use `-d` / `--details` to get detailed message information in the output (e.g. full chain of thought, actions performed by the agent):
+Use `-d` / `--details` to get detailed message information in the output (raw event stream, tool actions, and full agent message payload):
 `$ dust chat -a prea -d -m "what's the status of project X?"`
 
 If the tool errors because login is needed, ask the user to perform it manually.

--- a/.claude/skills/dust-call-agent/SKILL.md
+++ b/.claude/skills/dust-call-agent/SKILL.md
@@ -10,4 +10,11 @@ Access Dust agents that have context on all the company, e.g. recent projects, e
 A conversation with an agent can be continued after the first message using the argument `-c CONVERSATION_STRING_ID`. The conversation id will be returned in the JSON result from the initial call.
 `$ dust chat -a issueBot -c 'TdWyn4aDt1' -m "also add a subsequent issue about this: ..."`
 
+Use `--projectName` or `--projectId` to create the conversation inside a specific project (space):
+`$ dust chat -a prea --projectName "Engineering" -m "summarize recent incidents"`
+`$ dust chat -a prea --projectId "abc123" -m "summarize recent incidents"`
+
+Use `-d` / `--details` to get detailed message information in the output (e.g. full chain of thought, actions performed by the agent):
+`$ dust chat -a prea -d -m "what's the status of project X?"`
+
 If the tool errors because login is needed, ask the user to perform it manually.


### PR DESCRIPTION
## Description

Add documentation for the `--projectName`, `--projectId`, and `-d`/`--details` CLI flags to the `dust-call-agent` skill, so coding agents know how to use them when calling Dust agents.

## Risks

Blast radius: skill documentation only, no code changes
Risk: none

## Deploy Plan
-  pmrr
- No deploy needed (skill file only)