### PR TITLE
fix: breadcrumb size in header

### DIFF
--- a/front/components/assistant/conversation/ConversationTitle.tsx
+++ b/front/components/assistant/conversation/ConversationTitle.tsx
@@ -80,6 +80,7 @@ export function ConversationTitle({ owner }: { owner: WorkspaceType }) {
         <Breadcrumbs
           items={breadcrumbItems}
           className="dd-privacy-mask"
+          truncateLengthMiddle={35}
           truncateLengthEnd={120}
         />
         <EditConversationTitleDialog

--- a/sparkle/src/components/Breadcrumbs.tsx
+++ b/sparkle/src/components/Breadcrumbs.tsx
@@ -15,7 +15,7 @@ import { cva } from "class-variance-authority";
 import type { ComponentType } from "react";
 import React from "react";
 
-const LABEL_TRUNCATE_LENGTH_MIDDLE = 15;
+const DEFAULT_LABEL_TRUNCATE_LENGTH_MIDDLE = 15;
 const DEFAULT_LABEL_TRUNCATE_LENGTH_END = 30;
 const ELLIPSIS_STRING = "...";
 
@@ -88,6 +88,7 @@ interface BreadcrumbItemProps {
   itemsHidden?: BreadcrumbItem[];
   size?: "xs" | "sm";
   hasLighterFont?: boolean;
+  truncateLengthMiddle?: number;
   truncateLengthEnd?: number;
 }
 
@@ -97,6 +98,7 @@ function BreadcrumbItem({
   itemsHidden,
   size = "sm",
   hasLighterFont = true,
+  truncateLengthMiddle = DEFAULT_LABEL_TRUNCATE_LENGTH_MIDDLE,
   truncateLengthEnd = DEFAULT_LABEL_TRUNCATE_LENGTH_END,
 }: BreadcrumbItemProps) {
   if (item.label === ELLIPSIS_STRING) {
@@ -136,7 +138,7 @@ function BreadcrumbItem({
 
   const truncatedLabel = truncateTextToLength(
     item.label,
-    isLast ? truncateLengthEnd : LABEL_TRUNCATE_LENGTH_MIDDLE
+    isLast ? truncateLengthEnd : truncateLengthMiddle
   );
 
   const isLabelTruncated = truncatedLabel !== item.label;
@@ -192,6 +194,7 @@ interface BreadcrumbProps {
   className?: string;
   size?: "xs" | "sm";
   hasLighterFont?: boolean;
+  truncateLengthMiddle?: number;
   truncateLengthEnd?: number;
 }
 
@@ -205,6 +208,7 @@ export function Breadcrumbs({
   className,
   size = "sm",
   hasLighterFont = true,
+  truncateLengthMiddle,
   truncateLengthEnd,
 }: BreadcrumbProps) {
   const { itemsShown, itemsHidden } = items.reduce(
@@ -236,6 +240,7 @@ export function Breadcrumbs({
               itemsHidden={itemsHidden}
               size={size}
               hasLighterFont={hasLighterFont}
+              truncateLengthMiddle={truncateLengthMiddle}
               truncateLengthEnd={truncateLengthEnd}
             />
             {index === itemsShown.length - 1 ? null : (


### PR DESCRIPTION
## Description

Fixes: https://github.com/orgs/dust-tt/projects/3/views/12?pane=issue&itemId=156579618&issue=dust-tt%7Ctasks%7C6512

### Now
<img width="824" height="327" alt="image" src="https://github.com/user-attachments/assets/202c176c-12d1-4b48-9f5d-2e3b6ad15495" />

### Before

<img width="715" height="358" alt="image" src="https://github.com/user-attachments/assets/b3adda2e-d382-4ccd-be7a-09faab64ccdb" />

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
