### PR TITLE
[Dust Apps] Surface app deletion errors

### DIFF
--- a/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/index.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/index.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+
+import { AgentMCPServerConfigurationModel } from "@app/lib/models/agent/actions/mcp";
+import { MCPServerViewModel } from "@app/lib/models/agent/actions/mcp_server_view";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
+import { AppResource } from "@app/lib/resources/app_resource";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+
+import handler from "./index";
+
+describe("DELETE /api/w/[wId]/spaces/[spaceId]/apps/[aId]", () => {
+  it("returns 409 when the app is used by an active agent", async () => {
+    const { req, res, workspace, user, globalSpace, authenticator } =
+      await createPrivateApiMockRequest({
+        method: "DELETE",
+        role: "admin",
+      });
+
+    const app = await AppResource.makeNew(
+      {
+        description: "Test app",
+        dustAPIProjectId: "dust-api-project-id",
+        name: "Test App",
+        savedConfig: "{}",
+        savedSpecification: "[]",
+        sId: generateRandomModelSId(),
+        visibility: "private",
+        workspaceId: workspace.id,
+      },
+      globalSpace
+    );
+
+    const agent = await AgentConfigurationModel.create({
+      sId: generateRandomModelSId(),
+      version: 0,
+      status: "active",
+      scope: "visible",
+      name: "Agent using app",
+      description: "Agent description",
+      instructions: null,
+      instructionsHtml: null,
+      providerId: "openai",
+      modelId: "gpt-4-turbo",
+      temperature: 0.7,
+      reasoningEffort: null,
+      pictureUrl: "https://dust.tt/static/systemavatar/test_avatar_1.png",
+      workspaceId: workspace.id,
+      authorId: user.id,
+      templateId: null,
+      requestedSpaceIds: [],
+      maxStepsPerRun: 8,
+    });
+
+    const mcpServerView = await MCPServerViewModel.create({
+      workspaceId: workspace.id,
+      vaultId: globalSpace.id,
+      editedAt: new Date(),
+      editedByUserId: user.id,
+      serverType: "internal",
+      internalMCPServerId: generateRandomModelSId(),
+      remoteMCPServerId: null,
+      name: null,
+      description: null,
+      oAuthUseCase: null,
+    });
+
+    await AgentMCPServerConfigurationModel.create({
+      sId: generateRandomModelSId(),
+      agentConfigurationId: agent.id,
+      workspaceId: workspace.id,
+      mcpServerViewId: mcpServerView.id,
+      internalMCPServerId: "internal_mcp_server_id",
+      additionalConfiguration: {},
+      timeFrame: null,
+      jsonSchema: null,
+      name: null,
+      singleToolDescriptionOverride: null,
+      appId: app.sId,
+      secretName: null,
+    });
+
+    req.query = {
+      ...req.query,
+      wId: workspace.sId,
+      spaceId: globalSpace.sId,
+      aId: app.sId,
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(409);
+    const data = res._getJSONData();
+    expect(data).toHaveProperty("error");
+    expect(data.error.type).toBe("invalid_request_error");
+    expect(data.error.message).toContain("Cannot delete app in use by");
+    expect(data.error.message).toContain(agent.name);
+
+    const stillThere = await AppResource.fetchById(authenticator, app.sId);
+    expect(stillThere).not.toBeNull();
+  });
+
+  it("returns 204 and deletes the app when it is unused", async () => {
+    const { req, res, workspace, globalSpace, authenticator } =
+      await createPrivateApiMockRequest({
+        method: "DELETE",
+        role: "admin",
+      });
+
+    const app = await AppResource.makeNew(
+      {
+        description: "Test app",
+        dustAPIProjectId: "dust-api-project-id",
+        name: "Test App",
+        savedConfig: "{}",
+        savedSpecification: "[]",
+        sId: generateRandomModelSId(),
+        visibility: "private",
+        workspaceId: workspace.id,
+      },
+      globalSpace
+    );
+
+    req.query = {
+      ...req.query,
+      wId: workspace.sId,
+      spaceId: globalSpace.sId,
+      aId: app.sId,
+    };
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(204);
+    const deleted = await AppResource.fetchById(authenticator, app.sId);
+    expect(deleted).toBeNull();
+  });
+});

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/index.test.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/index.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { autoInternalMCPServerNameToSId } from "@app/lib/actions/mcp_helper";
 import { AgentMCPServerConfigurationModel } from "@app/lib/models/agent/actions/mcp";
 import { MCPServerViewModel } from "@app/lib/models/agent/actions/mcp_server_view";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
@@ -52,13 +53,18 @@ describe("DELETE /api/w/[wId]/spaces/[spaceId]/apps/[aId]", () => {
       maxStepsPerRun: 8,
     });
 
+    const internalMCPServerId = autoInternalMCPServerNameToSId({
+      name: "search",
+      workspaceId: workspace.id,
+    });
+
     const mcpServerView = await MCPServerViewModel.create({
       workspaceId: workspace.id,
       vaultId: globalSpace.id,
       editedAt: new Date(),
       editedByUserId: user.id,
       serverType: "internal",
-      internalMCPServerId: generateRandomModelSId(),
+      internalMCPServerId,
       remoteMCPServerId: null,
       name: null,
       description: null,
@@ -70,7 +76,7 @@ describe("DELETE /api/w/[wId]/spaces/[spaceId]/apps/[aId]", () => {
       agentConfigurationId: agent.id,
       workspaceId: workspace.id,
       mcpServerViewId: mcpServerView.id,
-      internalMCPServerId: "internal_mcp_server_id",
+      internalMCPServerId,
       additionalConfiguration: {},
       timeFrame: null,
       jsonSchema: null,

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/index.ts
@@ -117,7 +117,16 @@ async function handler(
         });
       }
 
-      await softDeleteApp(auth, app);
+      const deleteRes = await softDeleteApp(auth, app);
+      if (deleteRes.isErr()) {
+        return apiError(req, res, {
+          status_code: 409,
+          api_error: {
+            type: "invalid_request_error",
+            message: deleteRes.error.message,
+          },
+        });
+      }
 
       res.status(204).end();
       return;

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/index.ts
@@ -137,7 +137,7 @@ async function handler(
         api_error: {
           type: "method_not_supported_error",
           message:
-            "The method passed is not supported, POST or DELETE is expected.",
+            "The method passed is not supported, GET, POST or DELETE is expected.",
         },
       });
   }


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/6469.

Context: https://dust4ai.slack.com/archives/C07EEJQT0RX/p1770742649419009?thread_ts=1770742445.596099&cid=C07EEJQT0RX

The app DELETE route was ignoring `softDeleteApp` failures (e.g. app referenced by active agents) and returning 204, so the UI redirected even though the app remained.
This now returns a 409 with the error message, and adds API tests for the blocked + success paths.

## Risks
Blast radius: deleting apps from a space
Risk: low

## Deploy Plan
- pmrr
- deploy front

## Test
- [x] `NODE_ENV=test npm -w front test -- pages/api/w/\[wId]/spaces/\[spaceId]/apps/\[aId]/index.test.ts`
