### PR TITLE
[Projects] Mention user in project kickoff conversation

### DIFF
--- a/front/hooks/useProjectKickoff.ts
+++ b/front/hooks/useProjectKickoff.ts
@@ -34,7 +34,8 @@ export function useProjectKickoff({
 
     const prompt = buildProjectKickoffPrompt({
       projectName: space.name,
-      userName: user.username,
+      userFullName: user.fullName,
+      userSId: user.sId,
     });
 
     const result = await createConversationWithMessage({

--- a/front/lib/api/assistant/project_kickoff.test.ts
+++ b/front/lib/api/assistant/project_kickoff.test.ts
@@ -1,17 +1,28 @@
 import { describe, expect, it } from "vitest";
 
 import { buildProjectKickoffPrompt } from "@app/lib/api/assistant/project_kickoff";
+import { serializeMention } from "@app/lib/mentions/format";
 
 describe("buildProjectKickoffPrompt", () => {
+  const userFullName = "Test User";
+  const userSId = "user_123";
+  const userMention = serializeMention({
+    id: userSId,
+    type: "user",
+    label: userFullName,
+  });
+
   const prompt = buildProjectKickoffPrompt({
     projectName: "Test Kickstart",
-    userName: "test-user",
+    userFullName,
+    userSId,
   });
 
   it("should enforce the first message format and avoid fake search claims", () => {
     expect(prompt).toContain("Your first message MUST be exactly:");
+    expect(prompt).toContain(userMention);
     expect(prompt).toContain(
-      "Hey @test-user; happy to help you kickstart `Test Kickstart`."
+      `Hey ${userMention}; happy to help you kickstart \`Test Kickstart\`.`
     );
     expect(prompt).toContain(
       "Do not claim that you already searched anything in this first message."

--- a/front/lib/api/assistant/project_kickoff.test.ts
+++ b/front/lib/api/assistant/project_kickoff.test.ts
@@ -20,6 +20,7 @@ describe("buildProjectKickoffPrompt", () => {
 
   it("should enforce the first message format and avoid fake search claims", () => {
     expect(prompt).toContain("Your first message MUST be exactly:");
+    expect(prompt).toContain(":mention_user[");
     expect(prompt).toContain(userMention);
     expect(prompt).toContain(
       `Hey ${userMention}; happy to help you kickstart \`Test Kickstart\`.`

--- a/front/lib/api/assistant/project_kickoff.ts
+++ b/front/lib/api/assistant/project_kickoff.ts
@@ -1,19 +1,28 @@
+import { serializeMention } from "@app/lib/mentions/format";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
 
 export function buildProjectKickoffPrompt({
   projectName,
-  userName,
+  userFullName,
+  userSId,
 }: {
   projectName: string;
-  userName: string;
+  userFullName: string;
+  userSId: string;
 }): string {
+  const userMention = serializeMention({
+    id: userSId,
+    type: "user",
+    label: userFullName,
+  });
+
   return `<dust_system>
 You are helping a user kickstart a new project in Dust.
 
 ## YOUR FIRST MESSAGE (respond now)
 
 Your first message MUST be exactly:
-Hey @${userName}; happy to help you kickstart \`${projectName}\`.
+Hey ${userMention}; happy to help you kickstart \`${projectName}\`.
 
 If you'd like, tell me a few words on the project (the goal, the context) and/or attach relevant files. I can help update the project's description, find related data, and create an initial project document.
 


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/6501.
Follows https://github.com/dust-tt/dust/pull/21317.

Use a proper `:mention_user[...]` directive in the kickoff prompt so the first agent message mentions the initiating user.

<img width="1554" height="829" alt="image" src="https://github.com/user-attachments/assets/843bfb2d-028b-4b62-990b-d9cd91221f85" />

## Risks
Blast radius: project kickoff conversation initial agent message formatting/mentions
Risk: low

## Deploy Plan
- pmrr
- deploy front
