### PR TITLE
Remove duplicate notif on project creation

### DIFF
--- a/front/components/assistant/conversation/CreateProjectModal.tsx
+++ b/front/components/assistant/conversation/CreateProjectModal.tsx
@@ -11,7 +11,6 @@ import {
 } from "@dust-tt/sparkle";
 import { useCallback, useEffect, useState } from "react";
 
-import { useSendNotification } from "@app/hooks/useNotification";
 import { useAppRouter } from "@app/lib/platform";
 import { useSpaceConversationsSummary } from "@app/lib/swr/conversations";
 import { useCreateSpace } from "@app/lib/swr/spaces";
@@ -35,8 +34,6 @@ export function CreateProjectModal({
 
   const doCreate = useCreateSpace({ owner });
   const router = useAppRouter();
-
-  const sendNotification = useSendNotification();
 
   const { mutate: mutateSpaceSummary } = useSpaceConversationsSummary({
     workspaceId: owner.sId,
@@ -65,23 +62,24 @@ export function CreateProjectModal({
     }
 
     setIsSaving(true);
-    const createdSpace = await doCreate({
-      name: trimmedName,
-      isRestricted: !isPublic,
-      managementMode: "manual",
-      memberIds: [],
-      spaceKind: "project",
-    });
+    const createdSpace = await doCreate(
+      {
+        name: trimmedName,
+        isRestricted: !isPublic,
+        managementMode: "manual",
+        memberIds: [],
+        spaceKind: "project",
+      },
+      {
+        title: "Project created",
+        description: `Project "${trimmedName}" has been created.`,
+      }
+    );
 
     setIsSaving(false);
 
     if (createdSpace) {
       void mutateSpaceSummary();
-      sendNotification({
-        type: "success",
-        title: "Project created",
-        description: `Project "${trimmedName}" has been created.`,
-      });
       handleClose();
       void router.push(getProjectRoute(owner.sId, createdSpace.sId));
     }
@@ -90,7 +88,6 @@ export function CreateProjectModal({
     isPublic,
     doCreate,
     handleClose,
-    sendNotification,
     mutateSpaceSummary,
     router,
     owner.sId,

--- a/front/components/spaces/CreateOrEditSpaceModal.tsx
+++ b/front/components/spaces/CreateOrEditSpaceModal.tsx
@@ -16,7 +16,6 @@ import { ConfirmContext } from "@app/components/Confirm";
 import { ConfirmDeleteSpaceDialog } from "@app/components/spaces/ConfirmDeleteSpaceDialog";
 import { RestrictedAccessBody } from "@app/components/spaces/RestrictedAccessBody";
 import { RestrictedAccessHeader } from "@app/components/spaces/RestrictedAccessHeader";
-import { useSendNotification } from "@app/hooks/useNotification";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import { useAppRouter } from "@app/lib/platform";
 import { useGroups } from "@app/lib/swr/groups";
@@ -81,7 +80,6 @@ export function CreateOrEditSpaceModal({
   const doDelete = useDeleteSpace({ owner, force: true });
 
   const router = useAppRouter();
-  const sendNotification = useSendNotification();
 
   const { spaceInfo, mutateSpaceInfo } = useSpaceInfo({
     workspaceId: owner.sId,
@@ -237,13 +235,8 @@ export function CreateOrEditSpaceModal({
       }
 
       setIsSaving(false);
-      if (createdSpace) {
-        sendNotification({
-          type: "success",
-          title: "Successfully created space",
-          description: "Space was successfully created.",
-        });
-        onCreated?.(createdSpace);
+      if (createdSpace && onCreated) {
+        onCreated(createdSpace);
       }
     }
 
@@ -256,7 +249,6 @@ export function CreateOrEditSpaceModal({
     isRestricted,
     mutateSpaceInfo,
     onCreated,
-    sendNotification,
     space,
     spaceInfo,
     selectedMembers,

--- a/front/components/spaces/CreateOrEditSpaceModal.tsx
+++ b/front/components/spaces/CreateOrEditSpaceModal.tsx
@@ -16,6 +16,7 @@ import { ConfirmContext } from "@app/components/Confirm";
 import { ConfirmDeleteSpaceDialog } from "@app/components/spaces/ConfirmDeleteSpaceDialog";
 import { RestrictedAccessBody } from "@app/components/spaces/RestrictedAccessBody";
 import { RestrictedAccessHeader } from "@app/components/spaces/RestrictedAccessHeader";
+import { useSendNotification } from "@app/hooks/useNotification";
 import { useAuth } from "@app/lib/auth/AuthContext";
 import { useAppRouter } from "@app/lib/platform";
 import { useGroups } from "@app/lib/swr/groups";
@@ -80,6 +81,7 @@ export function CreateOrEditSpaceModal({
   const doDelete = useDeleteSpace({ owner, force: true });
 
   const router = useAppRouter();
+  const sendNotification = useSendNotification();
 
   const { spaceInfo, mutateSpaceInfo } = useSpaceInfo({
     workspaceId: owner.sId,
@@ -235,8 +237,13 @@ export function CreateOrEditSpaceModal({
       }
 
       setIsSaving(false);
-      if (createdSpace && onCreated) {
-        onCreated(createdSpace);
+      if (createdSpace) {
+        sendNotification({
+          type: "success",
+          title: "Successfully created space",
+          description: "Space was successfully created.",
+        });
+        onCreated?.(createdSpace);
       }
     }
 
@@ -249,6 +256,7 @@ export function CreateOrEditSpaceModal({
     isRestricted,
     mutateSpaceInfo,
     onCreated,
+    sendNotification,
     space,
     spaceInfo,
     selectedMembers,

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -543,7 +543,8 @@ export function useCreateSpace({ owner }: { owner: LightWorkspaceType }) {
       sendNotification({
         type: "success",
         title: notification?.title ?? "Successfully created space",
-        description: notification?.description ?? "Space was successfully created.",
+        description:
+          notification?.description ?? "Space was successfully created.",
       });
 
       const response: PostSpacesResponseBody = await res.json();

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -458,7 +458,10 @@ export function useCreateSpace({ owner }: { owner: LightWorkspaceType }) {
     disabled: true, // Needed just to mutate.
   });
 
-  const doCreate = async (params: PostSpaceRequestBodyType) => {
+  const doCreate = async (
+    params: PostSpaceRequestBodyType,
+    notification?: { title: string; description: string }
+  ) => {
     const { name, managementMode, isRestricted, spaceKind } = params;
 
     if (!name) {
@@ -536,6 +539,12 @@ export function useCreateSpace({ owner }: { owner: LightWorkspaceType }) {
     } else {
       void mutateSpaces();
       void mutateSpacesAsAdmin();
+
+      sendNotification({
+        type: "success",
+        title: notification?.title ?? "Successfully created space",
+        description: notification?.description ?? "Space was successfully created.",
+      });
 
       const response: PostSpacesResponseBody = await res.json();
       return response.space;

--- a/front/lib/swr/spaces.ts
+++ b/front/lib/swr/spaces.ts
@@ -537,12 +537,6 @@ export function useCreateSpace({ owner }: { owner: LightWorkspaceType }) {
       void mutateSpaces();
       void mutateSpacesAsAdmin();
 
-      sendNotification({
-        type: "success",
-        title: "Successfully created space",
-        description: "Space was successfully created.",
-      });
-
       const response: PostSpacesResponseBody = await res.json();
       return response.space;
     }


### PR DESCRIPTION
## Description

Fixes the duplicate notification issue when creating a project (issue #6554). Previously, when creating a project, users would see both "Successfully created space" and "Project created" notifications. This happened because `useCreateSpace` was sending a generic notification, and `CreateProjectModal` was sending its own specific notification. 

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

Deploy front
