### PR TITLE
Replaced spinner

### DIFF
--- a/front-spa/index.html
+++ b/front-spa/index.html
@@ -79,10 +79,7 @@
 
     <style>
       #loading {
-        --loading-logo-size: 40px;
         --loading-sidebar-width: 320px;
-        --loading-gap: 10px;
-        --loading-text-size: 11px;
         position: fixed;
         top: 0;
         left: 0;
@@ -105,54 +102,41 @@
       }
       #loading-main {
         flex: 1;
-        position: relative;
+        display: flex;
+        align-items: center;
+        justify-content: center;
         background-color: rgb(255, 255, 255);
       }
-      #loading-content {
-        position: absolute;
-        top: 50%;
-        left: 50%;
-        transform: translate(
-          calc(var(--loading-logo-size) / -2),
-          calc((var(--loading-logo-size) + var(--loading-gap) + var(--loading-text-size)) / -2)
-        );
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        gap: var(--loading-gap);
-      }
-      #loading-logo {
-        width: var(--loading-logo-size);
-        height: var(--loading-logo-size);
-      }
-
-
-      #loading-text {
-        line-height: 1;
-        font-family: system-ui, -apple-system, sans-serif;
-        font-size: var(--loading-text-size);
-        color: #64748b;
-        opacity: 0;
+      #loading-spinner path {
+        fill: #0F172A;
         animation:
-          loading-fade-in 300ms ease-out 2s forwards,
-          loading-pulsing 3s ease-in-out 2.3s infinite;
+          xs-svg-shape 2.24s ease-in-out infinite,
+          xs-svg-opacity 2.24s ease-in-out infinite,
+          xs-svg-bounce 2.24s ease-in-out infinite;
       }
-      @keyframes loading-pulsing {
-        0%,
-        100% {
-          opacity: 1;
-        }
-        50% {
-          opacity: 0.5;
-        }
+      .dark #loading-spinner path {
+        fill: #FFFFFF;
       }
-      @keyframes loading-fade-in {
-        from {
-          opacity: 0;
-        }
-        to {
-          opacity: 1;
-        }
+      @keyframes xs-svg-shape {
+        0%        { d: path("M 202 21 C 300.9 21 381 101.1 381 200 C 381 298.9 300.9 379 202 379 C 103.1 379 23 298.9 23 200 C 23 101.1 103.1 21 202 21 Z"); }
+        23%       { d: path("M 200 19.8 C 225.6 64.1 251.2 108.4 276.7 152.7 C 302.3 197 327.9 241.3 353.5 285.6 C 251.2 285.6 148.8 285.6 46.5 285.6 C 97.7 197 148.8 108.4 200 19.8 Z"); }
+        33%       { d: path("M 200 19.8 C 225.6 64.1 251.2 108.4 276.7 152.7 C 302.3 197 327.9 241.3 353.5 285.6 C 251.2 285.6 148.8 285.6 46.5 285.6 C 97.7 197 148.8 108.4 200 19.8 Z"); }
+        61%       { d: path("M 327 70 C 327 154 327 238 327 322 C 243 322 159 322 75 322 C 75 238 75 154 75 70 C 159 70 243 70 327 70 Z"); }
+        72%       { d: path("M 327 70 C 327 154 327 238 327 322 C 243 322 159 322 75 322 C 75 238 75 154 75 70 C 159 70 243 70 327 70 Z"); }
+        93%, 100% { d: path("M 202 21 C 300.9 21 381 101.1 381 200 C 381 298.9 300.9 379 202 379 C 103.1 379 23 298.9 23 200 C 23 101.1 103.1 21 202 21 Z"); }
+      }
+      @keyframes xs-svg-opacity {
+        0%        { opacity: 0.7; }
+        23%       { opacity: 1; }
+        33%       { opacity: 1; }
+        61%       { opacity: 0.8; }
+        72%       { opacity: 0.8; }
+        93%, 100% { opacity: 0.7; }
+      }
+      @keyframes xs-svg-bounce {
+        0%, 9%    { transform: translateY(0); }
+        23%, 41%  { transform: translateY(42px); }
+        52%, 100% { transform: translateY(0); }
       }
       .dark #loading-sidebar {
         background-color: #1c222d;
@@ -172,17 +156,9 @@
     <div id="loading">
       <div id="loading-sidebar"></div>
       <div id="loading-main">
-        <div id="loading-content">
-          <svg id="loading-logo" xmlns="http://www.w3.org/2000/svg" width="40" height="40" fill="none"
-            viewBox="0 0 48 48">
-            <path fill="#64748B" fill-rule="evenodd"
-              d="M12 24c6.627 0 12-5.373 12-12 0 6.627 5.373 12 12 12s12-5.373 12-12S42.627 0 36 0 24 5.373 24 12c0-6.627-5.373-12-12-12S0 5.373 0 12s5.373 12 12 12Zm24 12H24v12h12V36ZM12 48a6 6 0 0 0 0-12H0v12h12Z"
-              clip-rule="evenodd" />
-            <path fill="#334155" fill-rule="evenodd" d="M12 0H0v24h12a6 6 0 0 0 0 12h36V24H12V0Zm12 0h24v12H24V0Z"
-              clip-rule="evenodd" />
-          </svg>
-          <span id="loading-text">Loading...</span>
-        </div>
+        <svg id="loading-spinner" width="20" height="20" viewBox="0 0 400 400" xmlns="http://www.w3.org/2000/svg">
+          <path d="M 202 21 C 300.9 21 381 101.1 381 200 C 381 298.9 300.9 379 202 379 C 103.1 379 23 298.9 23 200 C 23 101.1 103.1 21 202 21 Z" />
+        </svg>
       </div>
     </div>
     <script type="module" src="/src/app/main.tsx"></script>

--- a/front-spa/src/app/App.tsx
+++ b/front-spa/src/app/App.tsx
@@ -1,7 +1,7 @@
 import RootLayout from "@dust-tt/front/components/app/RootLayout";
 import { RegionProvider } from "@dust-tt/front/lib/auth/RegionContext";
 import Custom404 from "@dust-tt/front/pages/404";
-import { safeLazy } from "@dust-tt/sparkle";
+import { Spinner, safeLazy } from "@dust-tt/sparkle";
 import { AppReadyProvider } from "@spa/app/contexts/AppReadyContext";
 import { AdminRouterLayout } from "@spa/app/layouts/AdminRouterLayout";
 import { AppContentRouterLayout } from "@spa/app/layouts/AppContentRouterLayout";
@@ -29,8 +29,8 @@ function RedirectWithSearchParams({ to }: { to: string }) {
 // Loading fallback component
 function PageLoader() {
   return (
-    <div className="flex h-full w-full items-center justify-center">
-      <div className="h-8 w-8 animate-spin rounded-full border-4 border-gray-300 border-t-blue-600" />
+    <div className="absolute inset-0 flex items-center justify-center z-10">
+      <Spinner size="sm" />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- **`PageLoader` (React)**: Use absolute positioning so the Suspense loading spinner is always centered in the content area, regardless of which layout wraps it (SpaceLayout, AdminLayout, ConversationLayout, etc.). Uses the Sparkle `Spinner` component.
- **`index.html` loading screen**: Replace the static Dust logo + "Loading..." text with the animated Dust spinner (circle → triangle → square morph). Uses pure CSS `@keyframes` animating the SVG `d` path attribute — zero external dependencies (no lottie-web), renders instantly.
- Dark mode support for both loaders.

## Test plan

- [ ] Verify the initial HTML loading spinner renders correctly in both light and dark mode
- [ ] Verify the React `PageLoader` (Suspense fallback) is centered consistently across SpaceLayout, AdminLayout, ConversationLayout
- [ ] Check the SVG path animation matches the Sparkle Spinner visually