### PR TITLE
[Front] feat(copilot): template page with card grid and direct builder navigation

### DIFF
--- a/front/components/agent_builder/AgentTemplateGrid.tsx
+++ b/front/components/agent_builder/AgentTemplateGrid.tsx
@@ -1,16 +1,23 @@
+import {
+  AssistantCard,
+  CardGrid,
+  ContextItem,
+  LargeAssistantCard,
+} from "@dust-tt/sparkle";
 import { getUniqueTemplateTags } from "@app/components/agent_builder/utils";
 import type { AssistantTemplateListType } from "@app/pages/api/templates";
 import type {
   TemplateTagCodeType,
   TemplateTagsType,
 } from "@app/types/assistant/templates";
-import { ContextItem, LargeAssistantCard } from "@dust-tt/sparkle";
 
 interface AgentTemplateGridProps {
   templates: AssistantTemplateListType[];
   openTemplateModal: (templateId: string) => void;
   templateTagsMapping: TemplateTagsType;
   selectedTags: TemplateTagCodeType[];
+  useCopilotLayout?: boolean;
+  onTemplateClick?: (templateId: string) => void;
 }
 
 export function AgentTemplateGrid({
@@ -18,6 +25,8 @@ export function AgentTemplateGrid({
   openTemplateModal,
   templateTagsMapping,
   selectedTags,
+  useCopilotLayout,
+  onTemplateClick,
 }: AgentTemplateGridProps) {
   if (!templates.length) {
     return null;
@@ -44,17 +53,32 @@ export function AgentTemplateGrid({
                 title={templateTagsMapping[tagName].label}
                 hasBorder={false}
               />
-              <div className="grid grid-cols-2 gap-2">
-                {templatesForTag.map((template) => (
-                  <LargeAssistantCard
-                    key={template.sId}
-                    title={template.handle}
-                    pictureUrl={template.pictureUrl}
-                    description={template.userFacingDescription ?? ""}
-                    onClick={() => openTemplateModal(template.sId)}
-                  />
-                ))}
-              </div>
+              {useCopilotLayout ? (
+                <CardGrid>
+                  {templatesForTag.map((template) => (
+                    <AssistantCard
+                      key={template.sId}
+                      title={template.handle}
+                      pictureUrl={template.pictureUrl}
+                      description={template.userFacingDescription ?? ""}
+                      onClick={() => onTemplateClick?.(template.sId)}
+                      variant="secondary"
+                    />
+                  ))}
+                </CardGrid>
+              ) : (
+                <div className="grid grid-cols-2 gap-2">
+                  {templatesForTag.map((template) => (
+                    <LargeAssistantCard
+                      key={template.sId}
+                      title={template.handle}
+                      pictureUrl={template.pictureUrl}
+                      description={template.userFacingDescription ?? ""}
+                      onClick={() => openTemplateModal(template.sId)}
+                    />
+                  ))}
+                </div>
+              )}
             </div>
           );
         })

--- a/front/components/agent_builder/AgentTemplateGrid.tsx
+++ b/front/components/agent_builder/AgentTemplateGrid.tsx
@@ -1,15 +1,15 @@
-import {
-  AssistantCard,
-  CardGrid,
-  ContextItem,
-  LargeAssistantCard,
-} from "@dust-tt/sparkle";
 import { getUniqueTemplateTags } from "@app/components/agent_builder/utils";
 import type { AssistantTemplateListType } from "@app/pages/api/templates";
 import type {
   TemplateTagCodeType,
   TemplateTagsType,
 } from "@app/types/assistant/templates";
+import {
+  AssistantCard,
+  CardGrid,
+  ContextItem,
+  LargeAssistantCard,
+} from "@dust-tt/sparkle";
 
 interface AgentTemplateGridProps {
   templates: AssistantTemplateListType[];

--- a/front/components/agent_builder/AgentTemplateGrid.tsx
+++ b/front/components/agent_builder/AgentTemplateGrid.tsx
@@ -16,7 +16,7 @@ interface AgentTemplateGridProps {
   openTemplateModal: (templateId: string) => void;
   templateTagsMapping: TemplateTagsType;
   selectedTags: TemplateTagCodeType[];
-  useCopilotLayout?: boolean;
+  hasCopilot?: boolean;
   onTemplateClick?: (templateId: string) => void;
 }
 
@@ -25,7 +25,7 @@ export function AgentTemplateGrid({
   openTemplateModal,
   templateTagsMapping,
   selectedTags,
-  useCopilotLayout,
+  hasCopilot,
   onTemplateClick,
 }: AgentTemplateGridProps) {
   if (!templates.length) {
@@ -53,7 +53,7 @@ export function AgentTemplateGrid({
                 title={templateTagsMapping[tagName].label}
                 hasBorder={false}
               />
-              {useCopilotLayout ? (
+              {hasCopilot ? (
                 <CardGrid>
                   {templatesForTag.map((template) => (
                     <AssistantCard

--- a/front/components/agent_builder/AgentTemplateGrid.tsx
+++ b/front/components/agent_builder/AgentTemplateGrid.tsx
@@ -16,8 +16,8 @@ interface AgentTemplateGridProps {
   openTemplateModal: (templateId: string) => void;
   templateTagsMapping: TemplateTagsType;
   selectedTags: TemplateTagCodeType[];
-  hasCopilot?: boolean;
-  onTemplateClick?: (templateId: string) => void;
+  hasCopilot: boolean;
+  onTemplateClick: (templateId: string) => void;
 }
 
 export function AgentTemplateGrid({
@@ -61,7 +61,7 @@ export function AgentTemplateGrid({
                       title={template.handle}
                       pictureUrl={template.pictureUrl}
                       description={template.userFacingDescription ?? ""}
-                      onClick={() => onTemplateClick?.(template.sId)}
+                      onClick={() => onTemplateClick(template.sId)}
                       variant="secondary"
                     />
                   ))}

--- a/front/components/pages/builder/agents/CreateAgentPage.tsx
+++ b/front/components/pages/builder/agents/CreateAgentPage.tsx
@@ -13,6 +13,7 @@ import { useWorkspace } from "@app/lib/auth/AuthContext";
 import { useAppRouter, useSearchParam } from "@app/lib/platform";
 import { useAssistantTemplates } from "@app/lib/swr/assistants";
 import { useFeatureFlags } from "@app/lib/swr/workspaces";
+import { getAgentBuilderRoute } from "@app/lib/utils/router";
 import { removeParamFromRouter } from "@app/lib/utils/router_util";
 import type { TemplateTagCodeType } from "@app/types/assistant/templates";
 import {
@@ -119,19 +120,18 @@ export function CreateAgentPage() {
   useSetHideSidebar(true);
   useSetTitle(title);
 
-  const isCopilot = hasFeature("agent_builder_copilot");
+  const hasCopilot = hasFeature("agent_builder_copilot");
 
   return (
     <div id="pageContent">
       <Page variant="modal">
         <div className="flex flex-col gap-6">
-          {isCopilot && (
+          {hasCopilot ? (
             <Page.Header
               title="Start with a template"
               description="Explore different ways to use Dust. Find a setup that works for you and make it your own."
             />
-          )}
-          {!isCopilot && (
+          ) : (
             <>
               <div className="flex min-h-[20vh] flex-col justify-end gap-6">
                 <div className="flex flex-row items-center gap-2">
@@ -216,10 +216,10 @@ export function CreateAgentPage() {
                   openTemplateModal={openTemplateModal}
                   templateTagsMapping={templateTagsMapping}
                   selectedTags={selectedTags}
-                  useCopilotLayout={isCopilot}
+                  hasCopilot={hasCopilot}
                   onTemplateClick={(id) =>
                     router.push(
-                      `/w/${owner.sId}/builder/agents/new?templateId=${id}`
+                      getAgentBuilderRoute(owner.sId, "new", `templateId=${id}`)
                     )
                   }
                 />
@@ -228,7 +228,7 @@ export function CreateAgentPage() {
           )}
         </div>
       </Page>
-      {!isCopilot && (
+      {!hasCopilot && (
         <AgentTemplateModal
           owner={owner}
           templateId={selectedTemplateId}

--- a/front/components/pages/builder/agents/CreateAgentPage.tsx
+++ b/front/components/pages/builder/agents/CreateAgentPage.tsx
@@ -119,58 +119,72 @@ export function CreateAgentPage() {
   useSetHideSidebar(true);
   useSetTitle(title);
 
+  const isCopilot = hasFeature("agent_builder_copilot");
+
   return (
     <div id="pageContent">
       <Page variant="modal">
         <div className="flex flex-col gap-6">
-          <div className="flex min-h-[20vh] flex-col justify-end gap-6">
-            <div className="flex flex-row items-center gap-2">
-              <Icon
-                visual={PencilSquareIcon}
-                size="lg"
-                className="text-primary-400 dark:text-primary-500"
-              />
-              <Page.Header title="Start new" />
-            </div>
-            <div className="flex flex-row gap-3">
-              <Button
-                icon={DocumentIcon}
-                label="New Agent"
-                data-gtm-label="assistantCreationButton"
-                data-gtm-location="assistantCreationPage"
-                size="md"
-                variant="highlight"
-                href={`/w/${owner.sId}/builder/agents/new`}
-              />
-              {hasFeature("agent_to_yaml") && (
-                <Button
-                  icon={
-                    isUploadingYAML
-                      ? () => <Spinner size="xs" />
-                      : FolderOpenIcon
-                  }
-                  label={isUploadingYAML ? "Uploading..." : "Upload from YAML"}
-                  data-gtm-label="yamlUploadButton"
-                  data-gtm-location="assistantCreationPage"
-                  size="md"
-                  variant="outline"
-                  disabled={isUploadingYAML}
-                  onClick={triggerYAMLUpload}
-                />
-              )}
-            </div>
-          </div>
-
-          <Page.Separator />
-
-          <div className="flex flex-row items-center gap-2">
-            <Icon
-              visual={MagicIcon}
-              size="lg"
-              className="text-primary-400 dark:text-primary-500"
+          {isCopilot && (
+            <Page.Header
+              title="Start with a template"
+              description="Explore different ways to use Dust. Find a setup that works for you and make it your own."
             />
-            <Page.Header title="Start from a template" />
-          </div>
+          )}
+          {!isCopilot && (
+            <>
+              <div className="flex min-h-[20vh] flex-col justify-end gap-6">
+                <div className="flex flex-row items-center gap-2">
+                  <Icon
+                    visual={PencilSquareIcon}
+                    size="lg"
+                    className="text-primary-400 dark:text-primary-500"
+                  />
+                  <Page.Header title="Start new" />
+                </div>
+                <div className="flex flex-row gap-3">
+                  <Button
+                    icon={DocumentIcon}
+                    label="New Agent"
+                    data-gtm-label="assistantCreationButton"
+                    data-gtm-location="assistantCreationPage"
+                    size="md"
+                    variant="highlight"
+                    href={`/w/${owner.sId}/builder/agents/new`}
+                  />
+                  {hasFeature("agent_to_yaml") && (
+                    <Button
+                      icon={
+                        isUploadingYAML
+                          ? () => <Spinner size="xs" />
+                          : FolderOpenIcon
+                      }
+                      label={
+                        isUploadingYAML ? "Uploading..." : "Upload from YAML"
+                      }
+                      data-gtm-label="yamlUploadButton"
+                      data-gtm-location="assistantCreationPage"
+                      size="md"
+                      variant="outline"
+                      disabled={isUploadingYAML}
+                      onClick={triggerYAMLUpload}
+                    />
+                  )}
+                </div>
+              </div>
+
+              <Page.Separator />
+
+              <div className="flex flex-row items-center gap-2">
+                <Icon
+                  visual={MagicIcon}
+                  size="lg"
+                  className="text-primary-400 dark:text-primary-500"
+                />
+                <Page.Header title="Start from a template" />
+              </div>
+            </>
+          )}
 
           <div className="flex flex-col gap-6">
             <SearchInput
@@ -202,17 +216,25 @@ export function CreateAgentPage() {
                   openTemplateModal={openTemplateModal}
                   templateTagsMapping={templateTagsMapping}
                   selectedTags={selectedTags}
+                  useCopilotLayout={isCopilot}
+                  onTemplateClick={(id) =>
+                    router.push(
+                      `/w/${owner.sId}/builder/agents/new?templateId=${id}`
+                    )
+                  }
                 />
               </div>
             </>
           )}
         </div>
       </Page>
-      <AgentTemplateModal
-        owner={owner}
-        templateId={selectedTemplateId}
-        onClose={closeTemplateModal}
-      />
+      {!isCopilot && (
+        <AgentTemplateModal
+          owner={owner}
+          templateId={selectedTemplateId}
+          onClose={closeTemplateModal}
+        />
+      )}
     </div>
   );
 }

--- a/front/scripts/seed/copilot/assets/templates.json
+++ b/front/scripts/seed/copilot/assets/templates.json
@@ -10,6 +10,56 @@
     "copilotInstructions": "Configure this agent to review code and provide feedback.\n\nModel: Use Claude Sonnet for balanced speed and quality, or Opus for complex architectural reviews.\n\nTools to add:\n- Web navigation: Allow fetching PR links from GitHub/GitLab\n- Include @mention: Let users tag specific team members for context\n\nSkills to consider:\n- Create a \"formatting standards\" skill with your team's code style rules\n- Add a \"security checklist\" skill for common vulnerability patterns\n\nInstructions should define:\n- Your team's coding standards and conventions\n- Severity levels for different issue types\n- Tone guidelines (constructive, educational)"
   },
   {
+    "handle": "bugTriageAssistant",
+    "userFacingDescription": "Helps triage bug reports by analyzing stack traces, checking recent deployments, and suggesting likely root causes based on your codebase and past incidents.",
+    "agentFacingDescription": "A bug triage agent that analyzes error logs and stack traces, correlates with recent deployments, and suggests root causes based on codebase context and incident history.",
+    "emoji": "bug/1f41b",
+    "backgroundColor": "bg-red-300",
+    "visibility": "published",
+    "tags": ["ENGINEERING"],
+    "copilotInstructions": "Configure this agent for bug triage.\n\nModel: Use Claude Sonnet for analytical reasoning.\n\nTools to add:\n- Web navigation: Fetch issue links from GitHub/Jira\n- Search data sources: Access codebase documentation and past incident reports\n\nInstructions should define:\n- How to classify bug severity (P0-P3)\n- Required information for a bug report\n- Escalation criteria for critical issues"
+  },
+  {
+    "handle": "testWriter",
+    "userFacingDescription": "Generates unit and integration tests for your code, following your team's testing conventions, frameworks, and coverage requirements.",
+    "agentFacingDescription": "A test generation agent that writes unit and integration tests matching the team's testing framework, conventions, and coverage standards.",
+    "emoji": "test_tube/1f9ea",
+    "backgroundColor": "bg-teal-300",
+    "visibility": "published",
+    "tags": ["ENGINEERING"],
+    "copilotInstructions": "Configure this agent for test generation.\n\nModel: Use Claude Sonnet for code generation quality.\n\nTools to add:\n- Search data sources: Access codebase and existing test files\n- Web navigation: Reference testing library documentation\n\nInstructions should define:\n- Testing framework (Jest, Pytest, etc.)\n- Coverage targets and what to prioritize\n- Test naming conventions and file structure"
+  },
+  {
+    "handle": "cicdTroubleshooter",
+    "userFacingDescription": "Diagnoses CI/CD pipeline failures by analyzing build logs, identifying flaky tests, and suggesting fixes based on your pipeline configuration.",
+    "agentFacingDescription": "A CI/CD troubleshooting agent that parses build logs, identifies failure patterns and flaky tests, and recommends fixes based on pipeline config and history.",
+    "emoji": "gear/2699-fe0f",
+    "backgroundColor": "bg-slate-300",
+    "visibility": "published",
+    "tags": ["ENGINEERING"],
+    "copilotInstructions": "Configure this agent for CI/CD troubleshooting.\n\nModel: Use Claude Sonnet for log analysis.\n\nTools to add:\n- Web navigation: Access CI/CD dashboards (GitHub Actions, CircleCI)\n- Search data sources: Access pipeline configs and past failure patterns\n\nInstructions should define:\n- CI/CD platform and pipeline structure\n- Common failure categories and their fixes\n- Retry vs. escalation policies"
+  },
+  {
+    "handle": "securityScanner",
+    "userFacingDescription": "Reviews code and dependencies for security vulnerabilities, checks against OWASP guidelines, and suggests remediation steps for identified issues.",
+    "agentFacingDescription": "A security review agent that scans code and dependencies for vulnerabilities, checks OWASP compliance, and provides prioritized remediation guidance.",
+    "emoji": "shield/1f6e1-fe0f",
+    "backgroundColor": "bg-amber-300",
+    "visibility": "published",
+    "tags": ["ENGINEERING"],
+    "copilotInstructions": "Configure this agent for security review.\n\nModel: Use Claude Opus for thorough analysis.\n\nTools to add:\n- Search data sources: Access security policies and dependency lists\n- Web navigation: Check CVE databases and security advisories\n\nInstructions should define:\n- Security standards to enforce (OWASP Top 10, etc.)\n- Severity classification for vulnerabilities\n- Remediation SLAs by severity level"
+  },
+  {
+    "handle": "deploymentAssistant",
+    "userFacingDescription": "Guides you through deployment checklists, monitors rollout health, and provides rollback instructions when issues are detected.",
+    "agentFacingDescription": "A deployment assistant that manages pre-deploy checklists, monitors rollout metrics, and coordinates rollback procedures when anomalies are detected.",
+    "emoji": "rocket/1f680",
+    "backgroundColor": "bg-indigo-300",
+    "visibility": "published",
+    "tags": ["ENGINEERING"],
+    "copilotInstructions": "Configure this agent for deployment management.\n\nModel: Use Claude Sonnet for speed during deployments.\n\nTools to add:\n- Web navigation: Access deployment dashboards and monitoring\n- Search data sources: Access runbooks and deployment procedures\n\nInstructions should define:\n- Pre-deployment checklist items\n- Health metrics to monitor post-deploy\n- Rollback criteria and procedures"
+  },
+  {
     "handle": "salesCallPrep",
     "userFacingDescription": "Prepares you for sales calls by pulling prospect info from your CRM, summarizing recent interactions, and suggesting talking points based on deal stage and history.",
     "agentFacingDescription": "A sales call preparation agent that gathers prospect data from CRM, summarizes past interactions, and generates talking points tailored to the deal stage.",
@@ -33,7 +83,7 @@
     "handle": "marketingCopywriter",
     "userFacingDescription": "Generates marketing copy for emails, social media posts, landing pages, and ad campaigns, following your brand voice and style guidelines.",
     "agentFacingDescription": "A marketing copywriting agent that produces on-brand content for emails, social media, landing pages, and ads based on brand guidelines and campaign briefs.",
-    "emoji": "pencil2/270f",
+    "emoji": "pencil2/270f-fe0f",
     "backgroundColor": "bg-pink-300",
     "visibility": "published",
     "tags": ["MARKETING", "CONTENT"],

--- a/sparkle/src/components/AssistantCard.tsx
+++ b/sparkle/src/components/AssistantCard.tsx
@@ -7,12 +7,14 @@ import {
   type IconOnlyButtonProps,
 } from "@sparkle/components/";
 import type { CardVariantType } from "@sparkle/components/Card";
+import { TruncatedText } from "@sparkle/components/TruncatedText";
 import { MoreIcon } from "@sparkle/icons/app/";
 import { cn } from "@sparkle/lib/utils";
 import React from "react";
 
 interface BaseAssistantCardProps {
   description: string;
+  descriptionLineClamp?: number;
   title: string;
   pictureUrl: string;
   subtitle?: string;
@@ -47,6 +49,7 @@ export const AssistantCard = React.forwardRef<
       onContextMenu,
       title,
       description,
+      descriptionLineClamp = 2,
       pictureUrl,
       subtitle,
       action,
@@ -83,14 +86,15 @@ export const AssistantCard = React.forwardRef<
           </div>
         </div>
         {description && (
-          <p
+          <TruncatedText
+            lineClamp={descriptionLineClamp}
             className={cn(
-              "s-line-clamp-2 s-overflow-hidden s-text-ellipsis s-pb-1 s-text-sm",
+              "s-overflow-hidden s-text-ellipsis s-pb-1 s-text-sm",
               "s-text-muted-foreground dark:s-text-muted-foreground-night"
             )}
           >
             {description}
-          </p>
+          </TruncatedText>
         )}
       </Card>
     );


### PR DESCRIPTION
## Description

Replaces the template creation page layout when `agent_builder_copilot` flag is enabled: uses `AssistantCard` instead of `LargeAssistantCard`, and navigates directly to the builder on click (no intermediate modal).

### Misc

- **AssistantCard (sparkle)**: replace description `<p>` with `TruncatedText` (tooltip on overflow), add `descriptionLineClamp` prop (default 2)
- **Seed**: add 5 engineering templates, fix `marketingCopywriter` emoji unified code

### Related Work

- Closes: https://github.com/dust-tt/tasks/issues/6530

## Tests
![Screen Recording 2026-02-13 at 17 04 54](https://github.com/user-attachments/assets/b7f34643-ef44-441d-95d4-de196d8d0e20)

## Risk

Behind `agent_builder_copilot` feature flag -> UI stays the same without it