### PR TITLE
[MCP Snowflake] add metadata audit

### DIFF
--- a/front/lib/api/actions/servers/snowflake/client.ts
+++ b/front/lib/api/actions/servers/snowflake/client.ts
@@ -90,7 +90,7 @@ export class SnowflakeClient {
     account: string,
     auth: SnowflakeClientAuth,
     warehouse: string,
-    queryTagMetadata?: SnowflakeQueryTagMetadata,
+    queryTagMetadata?: SnowflakeQueryTagMetadata
   ) {
     this.account = account.trim();
     this.warehouse = warehouse.trim();
@@ -117,15 +117,15 @@ export class SnowflakeClient {
         // Use proxy if defined to have all requests coming from the same IP.
         proxyHost: EnvironmentConfig.getOptionalEnvVariable("PROXY_HOST"),
         proxyPort: parseOptionalInt(
-          EnvironmentConfig.getOptionalEnvVariable("PROXY_PORT"),
+          EnvironmentConfig.getOptionalEnvVariable("PROXY_PORT")
         ),
         proxyUser: EnvironmentConfig.getOptionalEnvVariable("PROXY_USER_NAME"),
         proxyPassword: EnvironmentConfig.getOptionalEnvVariable(
-          "PROXY_USER_PASSWORD",
+          "PROXY_USER_PASSWORD"
         ),
       };
 
-      // Set query tag for agent-level tracking in Snowflake
+      // Set query tag for agent-level tracking in Snowflake.
       if (this.queryTagMetadata) {
         connectionOptions.queryTag = JSON.stringify(this.queryTagMetadata);
       }
@@ -162,8 +162,8 @@ export class SnowflakeClient {
               }
               reject(
                 new Error(
-                  "Connection attempt timed out while contacting Snowflake. This often indicates an invalid account or region hostname.",
-                ),
+                  "Connection attempt timed out while contacting Snowflake. This often indicates an invalid account or region hostname."
+                )
               );
             });
           } catch (e) {
@@ -189,7 +189,7 @@ export class SnowflakeClient {
       try {
         await this.runSql(
           connection,
-          `USE WAREHOUSE "${escapeSnowflakeIdentifier(this.warehouse)}"`,
+          `USE WAREHOUSE "${escapeSnowflakeIdentifier(this.warehouse)}"`
         );
       } catch (error) {
         // Clean up connection on USE WAREHOUSE failure
@@ -201,7 +201,7 @@ export class SnowflakeClient {
       try {
         await this.runSql(
           connection,
-          `ALTER SESSION SET STATEMENT_TIMEOUT_IN_SECONDS = ${QUERY_TIMEOUT_SECONDS}`,
+          `ALTER SESSION SET STATEMENT_TIMEOUT_IN_SECONDS = ${QUERY_TIMEOUT_SECONDS}`
         );
       } catch (error) {
         await this.closeConnection(connection);
@@ -251,7 +251,7 @@ export class SnowflakeClient {
    */
   private async executeQuery(
     conn: Connection,
-    sql: string,
+    sql: string
   ): Promise<Result<SnowflakeQueryResult, Error>> {
     try {
       type SnowflakeRows = Record<string, unknown>[];
@@ -265,7 +265,7 @@ export class SnowflakeClient {
           complete: (
             err: SnowflakeError | undefined,
             stmt: RowStatement,
-            rows: SnowflakeRows | undefined,
+            rows: SnowflakeRows | undefined
           ) => {
             if (err) {
               reject(err);
@@ -299,7 +299,7 @@ export class SnowflakeClient {
    * Execute a statement with connection management.
    */
   private async executeStatement(
-    sql: string,
+    sql: string
   ): Promise<Result<SnowflakeQueryResult, Error>> {
     const connRes = await this.connect();
     if (connRes.isErr()) {
@@ -328,7 +328,7 @@ export class SnowflakeClient {
 
   async listSchemas(database: string): Promise<Result<string[], Error>> {
     const result = await this.executeStatement(
-      `SHOW SCHEMAS IN DATABASE "${escapeSnowflakeIdentifier(database)}"`,
+      `SHOW SCHEMAS IN DATABASE "${escapeSnowflakeIdentifier(database)}"`
     );
     if (result.isErr()) {
       return result;
@@ -342,10 +342,10 @@ export class SnowflakeClient {
 
   async listTables(
     database: string,
-    schema: string,
+    schema: string
   ): Promise<Result<Array<{ name: string; kind: string }>, Error>> {
     const result = await this.executeStatement(
-      `SHOW TABLES IN SCHEMA "${escapeSnowflakeIdentifier(database)}"."${escapeSnowflakeIdentifier(schema)}"`,
+      `SHOW TABLES IN SCHEMA "${escapeSnowflakeIdentifier(database)}"."${escapeSnowflakeIdentifier(schema)}"`
     );
     if (result.isErr()) {
       return result;
@@ -366,7 +366,7 @@ export class SnowflakeClient {
 
     // Also get views (failure is non-fatal - some schemas may not have view permissions)
     const viewsResult = await this.executeStatement(
-      `SHOW VIEWS IN SCHEMA "${escapeSnowflakeIdentifier(database)}"."${escapeSnowflakeIdentifier(schema)}"`,
+      `SHOW VIEWS IN SCHEMA "${escapeSnowflakeIdentifier(database)}"."${escapeSnowflakeIdentifier(schema)}"`
     );
     if (viewsResult.isOk()) {
       const views = viewsResult.value.rows
@@ -387,10 +387,10 @@ export class SnowflakeClient {
   async describeTable(
     database: string,
     schema: string,
-    table: string,
+    table: string
   ): Promise<Result<SnowflakeColumn[], Error>> {
     const result = await this.executeStatement(
-      `DESCRIBE TABLE "${escapeSnowflakeIdentifier(database)}"."${escapeSnowflakeIdentifier(schema)}"."${escapeSnowflakeIdentifier(table)}"`,
+      `DESCRIBE TABLE "${escapeSnowflakeIdentifier(database)}"."${escapeSnowflakeIdentifier(schema)}"."${escapeSnowflakeIdentifier(table)}"`
     );
     if (result.isErr()) {
       return result;
@@ -416,7 +416,7 @@ export class SnowflakeClient {
    */
   private async validateReadOnlyWithExplain(
     conn: Connection,
-    sql: string,
+    sql: string
   ): Promise<Result<void, Error>> {
     // Use EXPLAIN USING TABULAR to get the query plan as structured data.
     const explainSql = `EXPLAIN USING TABULAR ${sql}`;
@@ -426,7 +426,7 @@ export class SnowflakeClient {
     if (result.isErr()) {
       // If EXPLAIN fails, the query is likely invalid anyway
       return new Err(
-        new Error(`Failed to validate query: ${result.error.message}`),
+        new Error(`Failed to validate query: ${result.error.message}`)
       );
     }
 
@@ -452,8 +452,8 @@ export class SnowflakeClient {
       if (operation && blockedOperations.has(operation.toUpperCase())) {
         return new Err(
           new Error(
-            `Write operation detected: ${operation}. Only SELECT queries are permitted.`,
-          ),
+            `Write operation detected: ${operation}. Only SELECT queries are permitted.`
+          )
         );
       }
     }
@@ -466,7 +466,7 @@ export class SnowflakeClient {
     database?: string,
     schema?: string,
     warehouse?: string,
-    maxRows: number = 1000,
+    maxRows: number = 1000
   ): Promise<Result<SnowflakeQueryResult, Error>> {
     // Strip trailing semicolons before wrapping. Multi-statement injection is
     // already prevented by the SDK (MULTI_STATEMENT_COUNT defaults to 1) and by
@@ -484,7 +484,7 @@ export class SnowflakeClient {
       if (database) {
         const useDbResult = await this.executeQuery(
           conn,
-          `USE DATABASE "${escapeSnowflakeIdentifier(database)}"`,
+          `USE DATABASE "${escapeSnowflakeIdentifier(database)}"`
         );
         if (useDbResult.isErr()) {
           return useDbResult;
@@ -493,7 +493,7 @@ export class SnowflakeClient {
       if (schema) {
         const useSchemaResult = await this.executeQuery(
           conn,
-          `USE SCHEMA "${escapeSnowflakeIdentifier(schema)}"`,
+          `USE SCHEMA "${escapeSnowflakeIdentifier(schema)}"`
         );
         if (useSchemaResult.isErr()) {
           return useSchemaResult;
@@ -502,7 +502,7 @@ export class SnowflakeClient {
       if (warehouse) {
         const useWhResult = await this.executeQuery(
           conn,
-          `USE WAREHOUSE "${escapeSnowflakeIdentifier(warehouse)}"`,
+          `USE WAREHOUSE "${escapeSnowflakeIdentifier(warehouse)}"`
         );
         if (useWhResult.isErr()) {
           return useWhResult;
@@ -513,7 +513,7 @@ export class SnowflakeClient {
       // This checks what the query actually does, not what it looks like.
       const validationResult = await this.validateReadOnlyWithExplain(
         conn,
-        sanitizedSql,
+        sanitizedSql
       );
 
       if (validationResult.isErr()) {

--- a/front/lib/api/actions/servers/snowflake/client.ts
+++ b/front/lib/api/actions/servers/snowflake/client.ts
@@ -44,14 +44,6 @@ type SnowflakeClientAuth =
       privateKeyPassphrase?: string;
     };
 
-export interface SnowflakeQueryTagMetadata {
-  workspace_id: string;
-  agent_id: string;
-  agent_name: string;
-  conversation_id: string;
-  user_id: string | null;
-}
-
 /**
  * Parse an optional string to an integer, returning undefined if not set or invalid.
  */
@@ -84,18 +76,18 @@ export class SnowflakeClient {
   private account: string;
   private warehouse: string;
   private auth: SnowflakeClientAuth;
-  private queryTagMetadata?: SnowflakeQueryTagMetadata;
+  private queryTag?: string;
 
   constructor(
     account: string,
     auth: SnowflakeClientAuth,
     warehouse: string,
-    queryTagMetadata?: SnowflakeQueryTagMetadata
+    queryTag?: string
   ) {
     this.account = account.trim();
     this.warehouse = warehouse.trim();
     this.auth = auth;
-    this.queryTagMetadata = queryTagMetadata;
+    this.queryTag = queryTag;
   }
 
   /**
@@ -126,8 +118,8 @@ export class SnowflakeClient {
       };
 
       // Set query tag for agent-level tracking in Snowflake.
-      if (this.queryTagMetadata) {
-        connectionOptions.queryTag = JSON.stringify(this.queryTagMetadata);
+      if (this.queryTag) {
+        connectionOptions.queryTag = this.queryTag;
       }
 
       if (this.auth.type === "oauth") {

--- a/front/lib/api/actions/servers/snowflake/client.ts
+++ b/front/lib/api/actions/servers/snowflake/client.ts
@@ -44,6 +44,14 @@ type SnowflakeClientAuth =
       privateKeyPassphrase?: string;
     };
 
+export interface SnowflakeQueryTagMetadata {
+  workspace_id: string;
+  agent_id: string;
+  agent_name: string;
+  conversation_id: string;
+  user_id: string | null;
+}
+
 /**
  * Parse an optional string to an integer, returning undefined if not set or invalid.
  */
@@ -76,11 +84,18 @@ export class SnowflakeClient {
   private account: string;
   private warehouse: string;
   private auth: SnowflakeClientAuth;
+  private queryTagMetadata?: SnowflakeQueryTagMetadata;
 
-  constructor(account: string, auth: SnowflakeClientAuth, warehouse: string) {
+  constructor(
+    account: string,
+    auth: SnowflakeClientAuth,
+    warehouse: string,
+    queryTagMetadata?: SnowflakeQueryTagMetadata,
+  ) {
     this.account = account.trim();
     this.warehouse = warehouse.trim();
     this.auth = auth;
+    this.queryTagMetadata = queryTagMetadata;
   }
 
   /**
@@ -102,13 +117,18 @@ export class SnowflakeClient {
         // Use proxy if defined to have all requests coming from the same IP.
         proxyHost: EnvironmentConfig.getOptionalEnvVariable("PROXY_HOST"),
         proxyPort: parseOptionalInt(
-          EnvironmentConfig.getOptionalEnvVariable("PROXY_PORT")
+          EnvironmentConfig.getOptionalEnvVariable("PROXY_PORT"),
         ),
         proxyUser: EnvironmentConfig.getOptionalEnvVariable("PROXY_USER_NAME"),
         proxyPassword: EnvironmentConfig.getOptionalEnvVariable(
-          "PROXY_USER_PASSWORD"
+          "PROXY_USER_PASSWORD",
         ),
       };
+
+      // Set query tag for agent-level tracking in Snowflake
+      if (this.queryTagMetadata) {
+        connectionOptions.queryTag = JSON.stringify(this.queryTagMetadata);
+      }
 
       if (this.auth.type === "oauth") {
         connectionOptions.authenticator = "OAUTH";
@@ -142,8 +162,8 @@ export class SnowflakeClient {
               }
               reject(
                 new Error(
-                  "Connection attempt timed out while contacting Snowflake. This often indicates an invalid account or region hostname."
-                )
+                  "Connection attempt timed out while contacting Snowflake. This often indicates an invalid account or region hostname.",
+                ),
               );
             });
           } catch (e) {
@@ -169,7 +189,7 @@ export class SnowflakeClient {
       try {
         await this.runSql(
           connection,
-          `USE WAREHOUSE "${escapeSnowflakeIdentifier(this.warehouse)}"`
+          `USE WAREHOUSE "${escapeSnowflakeIdentifier(this.warehouse)}"`,
         );
       } catch (error) {
         // Clean up connection on USE WAREHOUSE failure
@@ -181,7 +201,7 @@ export class SnowflakeClient {
       try {
         await this.runSql(
           connection,
-          `ALTER SESSION SET STATEMENT_TIMEOUT_IN_SECONDS = ${QUERY_TIMEOUT_SECONDS}`
+          `ALTER SESSION SET STATEMENT_TIMEOUT_IN_SECONDS = ${QUERY_TIMEOUT_SECONDS}`,
         );
       } catch (error) {
         await this.closeConnection(connection);
@@ -231,7 +251,7 @@ export class SnowflakeClient {
    */
   private async executeQuery(
     conn: Connection,
-    sql: string
+    sql: string,
   ): Promise<Result<SnowflakeQueryResult, Error>> {
     try {
       type SnowflakeRows = Record<string, unknown>[];
@@ -245,7 +265,7 @@ export class SnowflakeClient {
           complete: (
             err: SnowflakeError | undefined,
             stmt: RowStatement,
-            rows: SnowflakeRows | undefined
+            rows: SnowflakeRows | undefined,
           ) => {
             if (err) {
               reject(err);
@@ -279,7 +299,7 @@ export class SnowflakeClient {
    * Execute a statement with connection management.
    */
   private async executeStatement(
-    sql: string
+    sql: string,
   ): Promise<Result<SnowflakeQueryResult, Error>> {
     const connRes = await this.connect();
     if (connRes.isErr()) {
@@ -308,7 +328,7 @@ export class SnowflakeClient {
 
   async listSchemas(database: string): Promise<Result<string[], Error>> {
     const result = await this.executeStatement(
-      `SHOW SCHEMAS IN DATABASE "${escapeSnowflakeIdentifier(database)}"`
+      `SHOW SCHEMAS IN DATABASE "${escapeSnowflakeIdentifier(database)}"`,
     );
     if (result.isErr()) {
       return result;
@@ -322,10 +342,10 @@ export class SnowflakeClient {
 
   async listTables(
     database: string,
-    schema: string
+    schema: string,
   ): Promise<Result<Array<{ name: string; kind: string }>, Error>> {
     const result = await this.executeStatement(
-      `SHOW TABLES IN SCHEMA "${escapeSnowflakeIdentifier(database)}"."${escapeSnowflakeIdentifier(schema)}"`
+      `SHOW TABLES IN SCHEMA "${escapeSnowflakeIdentifier(database)}"."${escapeSnowflakeIdentifier(schema)}"`,
     );
     if (result.isErr()) {
       return result;
@@ -346,7 +366,7 @@ export class SnowflakeClient {
 
     // Also get views (failure is non-fatal - some schemas may not have view permissions)
     const viewsResult = await this.executeStatement(
-      `SHOW VIEWS IN SCHEMA "${escapeSnowflakeIdentifier(database)}"."${escapeSnowflakeIdentifier(schema)}"`
+      `SHOW VIEWS IN SCHEMA "${escapeSnowflakeIdentifier(database)}"."${escapeSnowflakeIdentifier(schema)}"`,
     );
     if (viewsResult.isOk()) {
       const views = viewsResult.value.rows
@@ -367,10 +387,10 @@ export class SnowflakeClient {
   async describeTable(
     database: string,
     schema: string,
-    table: string
+    table: string,
   ): Promise<Result<SnowflakeColumn[], Error>> {
     const result = await this.executeStatement(
-      `DESCRIBE TABLE "${escapeSnowflakeIdentifier(database)}"."${escapeSnowflakeIdentifier(schema)}"."${escapeSnowflakeIdentifier(table)}"`
+      `DESCRIBE TABLE "${escapeSnowflakeIdentifier(database)}"."${escapeSnowflakeIdentifier(schema)}"."${escapeSnowflakeIdentifier(table)}"`,
     );
     if (result.isErr()) {
       return result;
@@ -396,7 +416,7 @@ export class SnowflakeClient {
    */
   private async validateReadOnlyWithExplain(
     conn: Connection,
-    sql: string
+    sql: string,
   ): Promise<Result<void, Error>> {
     // Use EXPLAIN USING TABULAR to get the query plan as structured data.
     const explainSql = `EXPLAIN USING TABULAR ${sql}`;
@@ -406,7 +426,7 @@ export class SnowflakeClient {
     if (result.isErr()) {
       // If EXPLAIN fails, the query is likely invalid anyway
       return new Err(
-        new Error(`Failed to validate query: ${result.error.message}`)
+        new Error(`Failed to validate query: ${result.error.message}`),
       );
     }
 
@@ -432,8 +452,8 @@ export class SnowflakeClient {
       if (operation && blockedOperations.has(operation.toUpperCase())) {
         return new Err(
           new Error(
-            `Write operation detected: ${operation}. Only SELECT queries are permitted.`
-          )
+            `Write operation detected: ${operation}. Only SELECT queries are permitted.`,
+          ),
         );
       }
     }
@@ -446,7 +466,7 @@ export class SnowflakeClient {
     database?: string,
     schema?: string,
     warehouse?: string,
-    maxRows: number = 1000
+    maxRows: number = 1000,
   ): Promise<Result<SnowflakeQueryResult, Error>> {
     // Strip trailing semicolons before wrapping. Multi-statement injection is
     // already prevented by the SDK (MULTI_STATEMENT_COUNT defaults to 1) and by
@@ -464,7 +484,7 @@ export class SnowflakeClient {
       if (database) {
         const useDbResult = await this.executeQuery(
           conn,
-          `USE DATABASE "${escapeSnowflakeIdentifier(database)}"`
+          `USE DATABASE "${escapeSnowflakeIdentifier(database)}"`,
         );
         if (useDbResult.isErr()) {
           return useDbResult;
@@ -473,7 +493,7 @@ export class SnowflakeClient {
       if (schema) {
         const useSchemaResult = await this.executeQuery(
           conn,
-          `USE SCHEMA "${escapeSnowflakeIdentifier(schema)}"`
+          `USE SCHEMA "${escapeSnowflakeIdentifier(schema)}"`,
         );
         if (useSchemaResult.isErr()) {
           return useSchemaResult;
@@ -482,7 +502,7 @@ export class SnowflakeClient {
       if (warehouse) {
         const useWhResult = await this.executeQuery(
           conn,
-          `USE WAREHOUSE "${escapeSnowflakeIdentifier(warehouse)}"`
+          `USE WAREHOUSE "${escapeSnowflakeIdentifier(warehouse)}"`,
         );
         if (useWhResult.isErr()) {
           return useWhResult;
@@ -493,7 +513,7 @@ export class SnowflakeClient {
       // This checks what the query actually does, not what it looks like.
       const validationResult = await this.validateReadOnlyWithExplain(
         conn,
-        sanitizedSql
+        sanitizedSql,
       );
 
       if (validationResult.isErr()) {

--- a/front/lib/api/actions/servers/snowflake/tools/index.ts
+++ b/front/lib/api/actions/servers/snowflake/tools/index.ts
@@ -20,20 +20,20 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
 const CONNECTION_ERROR = new MCPError(
-  "Snowflake connection not configured. Please connect your Snowflake account.",
+  "Snowflake connection not configured. Please connect your Snowflake account."
 );
 
 function buildQueryTagMetadata(
   agentLoopContext?: AgentLoopContextType,
-  auth?: Authenticator,
+  auth?: Authenticator
 ): SnowflakeQueryTagMetadata | undefined {
-  if (!agentLoopContext?.runContext) {
+  if (!agentLoopContext?.runContext || !auth) {
     return undefined;
   }
 
   const { agentConfiguration, conversation } = agentLoopContext.runContext;
-  const workspace = auth?.getNonNullableWorkspace();
-  const user = auth?.user();
+  const workspace = auth.getNonNullableWorkspace();
+  const user = auth.user();
 
   return {
     workspace_id: workspace.sId,
@@ -53,7 +53,7 @@ async function getClientFromAuthInfo(
     | null
     | undefined,
   agentLoopContext?: AgentLoopContextType,
-  auth?: Authenticator,
+  auth?: Authenticator
 ): Promise<Result<SnowflakeClient, MCPError>> {
   const queryTagMetadata = buildQueryTagMetadata(agentLoopContext, auth);
 
@@ -67,8 +67,8 @@ async function getClientFromAuthInfo(
         account,
         { type: "oauth", token },
         warehouse,
-        queryTagMetadata,
-      ),
+        queryTagMetadata
+      )
     );
   }
 
@@ -87,7 +87,7 @@ async function getClientFromAuthInfo(
   }
 
   const contentValidation = SnowflakeKeyPairCredentialsSchema.decode(
-    credentialRes.value.credential.content,
+    credentialRes.value.credential.content
   );
   if (isLeft(contentValidation)) {
     const pathError = reporter.formatValidationErrors(contentValidation.left);
@@ -107,8 +107,8 @@ async function getClientFromAuthInfo(
         privateKeyPassphrase: credentials.private_key_passphrase,
       },
       credentials.warehouse,
-      queryTagMetadata,
-    ),
+      queryTagMetadata
+    )
   );
 }
 
@@ -117,7 +117,7 @@ const handlers: ToolHandlers<typeof SNOWFLAKE_TOOLS_METADATA> = {
     const clientRes = await getClientFromAuthInfo(
       authInfo,
       agentLoopContext,
-      auth,
+      auth
     );
     if (clientRes.isErr()) {
       return clientRes;
@@ -145,7 +145,7 @@ const handlers: ToolHandlers<typeof SNOWFLAKE_TOOLS_METADATA> = {
     const clientRes = await getClientFromAuthInfo(
       authInfo,
       agentLoopContext,
-      auth,
+      auth
     );
     if (clientRes.isErr()) {
       return clientRes;
@@ -171,12 +171,12 @@ const handlers: ToolHandlers<typeof SNOWFLAKE_TOOLS_METADATA> = {
 
   list_tables: async (
     { database, schema },
-    { authInfo, agentLoopContext, auth },
+    { authInfo, agentLoopContext, auth }
   ) => {
     const clientRes = await getClientFromAuthInfo(
       authInfo,
       agentLoopContext,
-      auth,
+      auth
     );
     if (clientRes.isErr()) {
       return clientRes;
@@ -202,12 +202,12 @@ const handlers: ToolHandlers<typeof SNOWFLAKE_TOOLS_METADATA> = {
 
   describe_table: async (
     { database, schema, table },
-    { authInfo, agentLoopContext, auth },
+    { authInfo, agentLoopContext, auth }
   ) => {
     const clientRes = await getClientFromAuthInfo(
       authInfo,
       agentLoopContext,
-      auth,
+      auth
     );
     if (clientRes.isErr()) {
       return clientRes;
@@ -234,7 +234,7 @@ const handlers: ToolHandlers<typeof SNOWFLAKE_TOOLS_METADATA> = {
             columns,
           },
           null,
-          2,
+          2
         ),
       },
     ]);
@@ -242,12 +242,12 @@ const handlers: ToolHandlers<typeof SNOWFLAKE_TOOLS_METADATA> = {
 
   query: async (
     { sql, database, schema, warehouse, max_rows },
-    { authInfo, agentLoopContext, auth },
+    { authInfo, agentLoopContext, auth }
   ) => {
     const clientRes = await getClientFromAuthInfo(
       authInfo,
       agentLoopContext,
-      auth,
+      auth
     );
     if (clientRes.isErr()) {
       return clientRes;
@@ -258,7 +258,7 @@ const handlers: ToolHandlers<typeof SNOWFLAKE_TOOLS_METADATA> = {
       database,
       schema,
       warehouse,
-      max_rows ?? MAX_QUERY_ROWS,
+      max_rows ?? MAX_QUERY_ROWS
     );
     if (result.isErr()) {
       return new Err(new MCPError(result.error.message));
@@ -284,7 +284,7 @@ const handlers: ToolHandlers<typeof SNOWFLAKE_TOOLS_METADATA> = {
             data: rows,
           },
           null,
-          2,
+          2
         ),
       },
     ]);

--- a/front/lib/api/actions/servers/snowflake/tools/index.ts
+++ b/front/lib/api/actions/servers/snowflake/tools/index.ts
@@ -4,12 +4,15 @@ import * as reporter from "io-ts-reporters";
 import { MCPError } from "@app/lib/actions/mcp_errors";
 import type { ToolHandlers } from "@app/lib/actions/mcp_internal_actions/tool_definition";
 import { buildTools } from "@app/lib/actions/mcp_internal_actions/tool_definition";
+import type { AgentLoopContextType } from "@app/lib/actions/types";
+import type { SnowflakeQueryTagMetadata } from "@app/lib/api/actions/servers/snowflake/client";
 import { SnowflakeClient } from "@app/lib/api/actions/servers/snowflake/client";
 import {
   MAX_QUERY_ROWS,
   SNOWFLAKE_TOOLS_METADATA,
 } from "@app/lib/api/actions/servers/snowflake/metadata";
 import apiConfig from "@app/lib/api/config";
+import type { Authenticator } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import { SnowflakeKeyPairCredentialsSchema } from "@app/types/oauth/lib";
 import { OAuthAPI } from "@app/types/oauth/oauth_api";
@@ -17,8 +20,29 @@ import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 
 const CONNECTION_ERROR = new MCPError(
-  "Snowflake connection not configured. Please connect your Snowflake account."
+  "Snowflake connection not configured. Please connect your Snowflake account.",
 );
+
+function buildQueryTagMetadata(
+  agentLoopContext?: AgentLoopContextType,
+  auth?: Authenticator,
+): SnowflakeQueryTagMetadata | undefined {
+  if (!agentLoopContext?.runContext) {
+    return undefined;
+  }
+
+  const { agentConfiguration, conversation } = agentLoopContext.runContext;
+  const workspace = auth?.getNonNullableWorkspace();
+  const user = auth?.user();
+
+  return {
+    workspace_id: workspace.sId,
+    agent_id: agentConfiguration.sId,
+    agent_name: agentConfiguration.name,
+    conversation_id: conversation.sId,
+    user_id: user?.sId ?? null,
+  };
+}
 
 async function getClientFromAuthInfo(
   authInfo:
@@ -27,15 +51,24 @@ async function getClientFromAuthInfo(
         token?: string;
       }
     | null
-    | undefined
+    | undefined,
+  agentLoopContext?: AgentLoopContextType,
+  auth?: Authenticator,
 ): Promise<Result<SnowflakeClient, MCPError>> {
+  const queryTagMetadata = buildQueryTagMetadata(agentLoopContext, auth);
+
   const account = authInfo?.extra?.snowflake_account;
   const warehouse = authInfo?.extra?.snowflake_warehouse;
   const token = authInfo?.token;
 
   if (typeof account === "string" && typeof warehouse === "string" && token) {
     return new Ok(
-      new SnowflakeClient(account, { type: "oauth", token }, warehouse)
+      new SnowflakeClient(
+        account,
+        { type: "oauth", token },
+        warehouse,
+        queryTagMetadata,
+      ),
     );
   }
 
@@ -54,7 +87,7 @@ async function getClientFromAuthInfo(
   }
 
   const contentValidation = SnowflakeKeyPairCredentialsSchema.decode(
-    credentialRes.value.credential.content
+    credentialRes.value.credential.content,
   );
   if (isLeft(contentValidation)) {
     const pathError = reporter.formatValidationErrors(contentValidation.left);
@@ -73,14 +106,19 @@ async function getClientFromAuthInfo(
         privateKey: credentials.private_key,
         privateKeyPassphrase: credentials.private_key_passphrase,
       },
-      credentials.warehouse
-    )
+      credentials.warehouse,
+      queryTagMetadata,
+    ),
   );
 }
 
 const handlers: ToolHandlers<typeof SNOWFLAKE_TOOLS_METADATA> = {
-  list_databases: async (_params, { authInfo }) => {
-    const clientRes = await getClientFromAuthInfo(authInfo);
+  list_databases: async (_params, { authInfo, agentLoopContext, auth }) => {
+    const clientRes = await getClientFromAuthInfo(
+      authInfo,
+      agentLoopContext,
+      auth,
+    );
     if (clientRes.isErr()) {
       return clientRes;
     }
@@ -103,8 +141,12 @@ const handlers: ToolHandlers<typeof SNOWFLAKE_TOOLS_METADATA> = {
     ]);
   },
 
-  list_schemas: async ({ database }, { authInfo }) => {
-    const clientRes = await getClientFromAuthInfo(authInfo);
+  list_schemas: async ({ database }, { authInfo, agentLoopContext, auth }) => {
+    const clientRes = await getClientFromAuthInfo(
+      authInfo,
+      agentLoopContext,
+      auth,
+    );
     if (clientRes.isErr()) {
       return clientRes;
     }
@@ -127,8 +169,15 @@ const handlers: ToolHandlers<typeof SNOWFLAKE_TOOLS_METADATA> = {
     ]);
   },
 
-  list_tables: async ({ database, schema }, { authInfo }) => {
-    const clientRes = await getClientFromAuthInfo(authInfo);
+  list_tables: async (
+    { database, schema },
+    { authInfo, agentLoopContext, auth },
+  ) => {
+    const clientRes = await getClientFromAuthInfo(
+      authInfo,
+      agentLoopContext,
+      auth,
+    );
     if (clientRes.isErr()) {
       return clientRes;
     }
@@ -151,8 +200,15 @@ const handlers: ToolHandlers<typeof SNOWFLAKE_TOOLS_METADATA> = {
     ]);
   },
 
-  describe_table: async ({ database, schema, table }, { authInfo }) => {
-    const clientRes = await getClientFromAuthInfo(authInfo);
+  describe_table: async (
+    { database, schema, table },
+    { authInfo, agentLoopContext, auth },
+  ) => {
+    const clientRes = await getClientFromAuthInfo(
+      authInfo,
+      agentLoopContext,
+      auth,
+    );
     if (clientRes.isErr()) {
       return clientRes;
     }
@@ -178,7 +234,7 @@ const handlers: ToolHandlers<typeof SNOWFLAKE_TOOLS_METADATA> = {
             columns,
           },
           null,
-          2
+          2,
         ),
       },
     ]);
@@ -186,9 +242,13 @@ const handlers: ToolHandlers<typeof SNOWFLAKE_TOOLS_METADATA> = {
 
   query: async (
     { sql, database, schema, warehouse, max_rows },
-    { authInfo }
+    { authInfo, agentLoopContext, auth },
   ) => {
-    const clientRes = await getClientFromAuthInfo(authInfo);
+    const clientRes = await getClientFromAuthInfo(
+      authInfo,
+      agentLoopContext,
+      auth,
+    );
     if (clientRes.isErr()) {
       return clientRes;
     }
@@ -198,7 +258,7 @@ const handlers: ToolHandlers<typeof SNOWFLAKE_TOOLS_METADATA> = {
       database,
       schema,
       warehouse,
-      max_rows ?? MAX_QUERY_ROWS
+      max_rows ?? MAX_QUERY_ROWS,
     );
     if (result.isErr()) {
       return new Err(new MCPError(result.error.message));
@@ -224,7 +284,7 @@ const handlers: ToolHandlers<typeof SNOWFLAKE_TOOLS_METADATA> = {
             data: rows,
           },
           null,
-          2
+          2,
         ),
       },
     ]);


### PR DESCRIPTION
## Description

Adds query tag metadata to Snowflake MCP queries for agent-level usage tracking and audit purposes. When executing Snowflake queries through MCP, the client now includes metadata (workspace ID, agent ID, agent name, conversation ID, and user ID) in the `QUERY_TAG` session parameter. This enables customers to build usage reports and dashboards in Snowflake showing which agents are executing queries.

## Risk

None - query tags are passive metadata that don't affect query execution or results.

## Tests

Manually tested with Snowflake MCP connection.

## Deploy 

Run front
