### PR TITLE
Increase URL size of MCP to 2048

### DIFF
--- a/front/lib/models/agent/actions/remote_mcp_server.ts
+++ b/front/lib/models/agent/actions/remote_mcp_server.ts
@@ -43,7 +43,7 @@ RemoteMCPServerModel.init(
       defaultValue: DataTypes.NOW,
     },
     url: {
-      type: DataTypes.STRING,
+      type: DataTypes.STRING(2048),
       allowNull: false,
     },
     icon: {
@@ -56,7 +56,7 @@ RemoteMCPServerModel.init(
       defaultValue: DEFAULT_MCP_ACTION_VERSION,
     },
     cachedName: {
-      type: DataTypes.STRING,
+      type: DataTypes.STRING(2048),
       allowNull: false,
     },
     cachedDescription: {

--- a/front/migrations/db/migration_512.sql
+++ b/front/migrations/db/migration_512.sql
@@ -1,0 +1,6 @@
+-- Migration created on Feb 16, 2026
+ALTER TABLE "remote_mcp_servers"
+  ALTER COLUMN "url" TYPE VARCHAR(2048);
+
+ALTER TABLE "remote_mcp_servers"
+  ALTER COLUMN "cachedName" TYPE VARCHAR(2048);

--- a/front/pages/api/w/[wId]/mcp/index.ts
+++ b/front/pages/api/w/[wId]/mcp/index.ts
@@ -149,6 +149,17 @@ async function handler(
           });
         }
 
+        if (url.length > 2048) {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message:
+                "MCP server URL exceeds maximum length (2048 characters).",
+            },
+          });
+        }
+
         // Default to the shared secret if it exists.
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         let bearerToken = sharedSecret || null;
@@ -209,6 +220,16 @@ async function handler(
 
         // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         const name = defaultConfig?.name || metadata.name;
+        if (name.length > 2048) {
+          return apiError(req, res, {
+            status_code: 400,
+            api_error: {
+              type: "invalid_request_error",
+              message:
+                "MCP server name exceeds maximum length (2048 characters).",
+            },
+          });
+        }
 
         const newRemoteMCPServer = await RemoteMCPServerResource.makeNew(auth, {
           workspaceId: auth.getNonNullableWorkspace().id,


### PR DESCRIPTION
## Description

May be the solution to https://github.com/dust-tt/tasks/issues/6556
Increase the allowed size of MCP URL to 2048 character because 255 may be too chort if there are various params in the URL

## Tests

no

## Risk

low

## Deploy Plan

block front
merge
migrate
deploy 
unlock front
