### PR TITLE
Update pricing model names and refactor PlansTables

### DIFF
--- a/front/components/plans/PlansTables.tsx
+++ b/front/components/plans/PlansTables.tsx
@@ -94,6 +94,210 @@ const ENTERPRISE_PLAN_ITEMS: PriceTableItem[] = [
   },
 ];
 
+type SeatBasedPlan = "pro" | "business";
+
+type SeatBasedPlanItem = PriceTableItem & {
+  plans: SeatBasedPlan[];
+};
+
+function getSeatBasedPlanItems(
+  plan: SeatBasedPlan,
+  openFairUseModal: () => void
+): PriceTableItem[] {
+  const allItems: SeatBasedPlanItem[] = [
+    {
+      label: "From 1 user",
+      variant: "check",
+      display: ["landing", "subscribe"],
+      plans: ["pro", "business"],
+    },
+    {
+      label: "Multiple private spaces",
+      variant: "check",
+      display: ["landing"],
+      plans: ["business"],
+    },
+    {
+      label: "Flexible payment options (SEPA, Credit Card)",
+      variant: "check",
+      display: ["landing", "subscribe"],
+      plans: ["business"],
+    },
+    {
+      label: "US / EU data hosting",
+      variant: "check",
+      display: ["landing"],
+      plans: ["business"],
+    },
+    {
+      label: "Advanced models (GPT-5, Claude, Gemini, Mistral…)",
+      variant: "check",
+      display: ["landing", "subscribe"],
+      plans: ["pro", "business"],
+    },
+    {
+      label: "Custom agents which can execute actions",
+      variant: "check",
+      display: ["landing", "subscribe"],
+      plans: ["pro", "business"],
+    },
+    {
+      label: "Custom actions (Dust Apps)",
+      variant: "check",
+      display: ["landing", "subscribe"],
+      plans: ["pro"],
+    },
+    {
+      label: "Connections (GitHub, Google Drive, Notion, Slack, ...)",
+      variant: "check",
+      display: ["landing", "subscribe"],
+      plans: ["pro", "business"],
+    },
+    {
+      label: "Native integrations (Zendesk, Slack, Chrome Extension)",
+      variant: "check",
+      display: ["landing", "subscribe"],
+      plans: ["pro", "business"],
+    },
+    {
+      label: "Privacy and Data Security (SOC2, Zero Data Retention)",
+      variant: "check",
+      display: ["landing"],
+      plans: ["pro", "business"],
+    },
+    {
+      label: (
+        <>
+          Unlimited messages (
+          <Hoverable
+            className="cursor-pointer text-gray-400 underline hover:text-gray-500"
+            onClick={openFairUseModal}
+          >
+            Fair use limits apply*
+          </Hoverable>
+          )
+        </>
+      ),
+      variant: "check",
+      display: ["landing", "subscribe"],
+      plans: ["pro", "business"],
+    },
+    {
+      label: (
+        <>
+          Free credits for programmatic usage (API, GSheet, Zapier,...) (
+          <Hoverable
+            className="cursor-pointer text-gray-400 underline hover:text-gray-500"
+            href="https://dust-tt.notion.site/Programmatic-usage-at-Dust-2b728599d94181ceb124d8585f794e2e#2b728599d941808b8f8dfa8dbe7e466f"
+            target="_blank"
+          >
+            Learn more
+          </Hoverable>
+          )
+        </>
+      ),
+      variant: "check",
+      display: ["landing", "subscribe"],
+      plans: ["pro"],
+    },
+    {
+      label: "Fixed price on additional programmatic usage",
+      variant: "dash",
+      display: ["landing", "subscribe"],
+      plans: ["pro"],
+    },
+    {
+      label: "Up to 1GB/user of data sources",
+      variant: "dash",
+      display: ["landing", "subscribe"],
+      plans: ["pro", "business"],
+    },
+    {
+      label: "One private space",
+      variant: "dash",
+      display: ["landing"],
+      plans: ["pro"],
+    },
+  ];
+
+  return allItems.filter((item) => item.plans.includes(plan));
+}
+
+interface SeatBasedPriceTableProps {
+  plan: SeatBasedPlan;
+  title: string;
+  color: "emerald" | "blue";
+  price: string;
+  showButton: boolean;
+  display: PriceTableDisplay;
+  isProcessing?: boolean;
+  onClick?: () => void;
+  size: "sm" | "xs";
+}
+
+function SeatBasedPriceTable({
+  plan,
+  title,
+  color,
+  price,
+  showButton,
+  display,
+  isProcessing,
+  onClick,
+  size,
+}: SeatBasedPriceTableProps) {
+  const [isFairUseModalOpened, setIsFairUseModalOpened] = useState(false);
+  const biggerButtonSize = size === "xs" ? "sm" : "md";
+  const items = getSeatBasedPlanItems(plan, () =>
+    setIsFairUseModalOpened(true)
+  );
+
+  return (
+    <>
+      <FairUsageModal
+        isOpened={isFairUseModalOpened}
+        onClose={() => setIsFairUseModalOpened(false)}
+      />
+      <PriceTable
+        title={title}
+        price={price}
+        color={color}
+        priceLabel="/ month / user, excl. tax."
+        size={size}
+        magnified={false}
+      >
+        {onClick && showButton && (
+          <PriceTable.ActionContainer position="top">
+            <Button
+              variant="highlight"
+              size={biggerButtonSize}
+              label={
+                display === "landing" ? "Start now, 14 days free" : "Start now"
+              }
+              icon={RocketIcon}
+              disabled={isProcessing}
+              onClick={withTracking(
+                TRACKING_AREAS.PRICING,
+                "plan_pro_select",
+                onClick
+              )}
+            />
+          </PriceTable.ActionContainer>
+        )}
+        {items
+          .filter((item) => item.display.includes(display))
+          .map((item, index) => (
+            <PriceTable.Item
+              key={index}
+              label={item.label}
+              variant={item.variant}
+            />
+          ))}
+      </PriceTable>
+    </>
+  );
+}
+
 interface PriceTableProps {
   billingPeriod?: BillingPeriod;
   display: PriceTableDisplay;
@@ -113,8 +317,6 @@ export function ProPriceTable({
   plan,
   size,
 }: PriceTableProps) {
-  const [isFairUseModalOpened, setIsFairUseModalOpened] = useState(false);
-
   if (isWhitelistedBusinessPlan(owner)) {
     return (
       <BusinessPriceTable
@@ -127,142 +329,23 @@ export function ProPriceTable({
     );
   }
 
-  const PRO_PLAN_ITEMS: PriceTableItem[] = [
-    {
-      label: "From 1 user",
-      variant: "check",
-      display: ["landing", "subscribe"],
-    },
-    {
-      label: "Advanced models (GPT-4, Claude…)",
-      variant: "check",
-      display: ["landing", "subscribe"],
-    },
-    {
-      label: "Custom agents which can execute actions",
-      variant: "check",
-      display: ["landing", "subscribe"],
-    },
-    {
-      label: "Custom actions (Dust Apps)",
-      variant: "check",
-      display: ["landing", "subscribe"],
-    },
-    {
-      label: "Connections (GitHub, Google Drive, Notion, Slack, ...)",
-      variant: "check",
-      display: ["landing", "subscribe"],
-    },
-    {
-      label: "Native integrations (Zendesk, Slack, Chrome Extension)",
-      variant: "check",
-      display: ["landing", "subscribe"],
-    },
-    {
-      label: "Privacy and Data Security (SOC2, Zero Data Retention)",
-      variant: "check",
-      display: ["landing"],
-    },
-    {
-      label: (
-        <>
-          Unlimited messages (
-          <Hoverable
-            className="cursor-pointer text-gray-400 underline hover:text-gray-500"
-            onClick={() => setIsFairUseModalOpened(true)}
-          >
-            Fair use limits apply
-          </Hoverable>
-          )
-        </>
-      ),
-      variant: "check",
-      display: ["landing", "subscribe"],
-    },
-    {
-      label: (
-        <>
-          Free credits for programmatic usage (API, GSheet, Zapier,...) (
-          <Hoverable
-            className="cursor-pointer text-gray-400 underline hover:text-gray-500"
-            href="https://dust-tt.notion.site/Programmatic-usage-at-Dust-2b728599d94181ceb124d8585f794e2e#2b728599d941808b8f8dfa8dbe7e466f"
-            target="_blank"
-          >
-            Learn more
-          </Hoverable>
-          )
-        </>
-      ),
-      variant: "check",
-      display: ["landing", "subscribe"],
-    },
-    {
-      label: "Fixed price on additional programmatic usage",
-      variant: "dash",
-      display: ["landing", "subscribe"],
-    },
-    {
-      label: "Up to 1GB/user of data sources",
-      variant: "dash",
-      display: ["landing", "subscribe"],
-    },
-    {
-      label: "One private space",
-      variant: "dash",
-      display: ["landing"],
-    },
-  ];
-
-  const biggerButtonSize = size === "xs" ? "sm" : "md";
-
   const price =
     billingPeriod === "monthly"
       ? getPriceWithCurrency(PRO_PLAN_COST_MONTHLY)
       : getPriceWithCurrency(PRO_PLAN_COST_YEARLY);
 
   return (
-    <>
-      <FairUsageModal
-        isOpened={isFairUseModalOpened}
-        onClose={() => setIsFairUseModalOpened(false)}
-      />
-      <PriceTable
-        title="Pro"
-        price={price}
-        color="emerald"
-        priceLabel="/ month / user, excl. tax."
-        size={size}
-        magnified={false}
-      >
-        {onClick && (!plan || !isProOrBusinessPlanCode(plan)) && (
-          <PriceTable.ActionContainer position="top">
-            <Button
-              variant="highlight"
-              size={biggerButtonSize}
-              label={
-                display === "landing" ? "Start now, 14 days free" : "Start now"
-              }
-              icon={RocketIcon}
-              disabled={isProcessing}
-              onClick={withTracking(
-                TRACKING_AREAS.PRICING,
-                "plan_pro_select",
-                onClick
-              )}
-            />
-          </PriceTable.ActionContainer>
-        )}
-        {PRO_PLAN_ITEMS.filter((item) => item.display.includes(display)).map(
-          (item, index) => (
-            <PriceTable.Item
-              key={index}
-              label={item.label}
-              variant={item.variant}
-            />
-          )
-        )}
-      </PriceTable>
-    </>
+    <SeatBasedPriceTable
+      plan="pro"
+      title="Pro"
+      color="emerald"
+      price={price}
+      showButton={!plan || !isProOrBusinessPlanCode(plan)}
+      display={display}
+      isProcessing={isProcessing}
+      onClick={onClick}
+      size={size}
+    />
   );
 }
 
@@ -273,124 +356,18 @@ export function BusinessPriceTable({
   plan,
   size,
 }: PriceTableProps) {
-  const [isFairUseModalOpened, setIsFairUseModalOpened] = useState(false);
-
-  const PRO_PLAN_ITEMS: PriceTableItem[] = [
-    {
-      label: "From 1 user",
-      variant: "check",
-      display: ["landing", "subscribe"],
-    },
-    {
-      label: "Multiple private spaces",
-      variant: "check",
-      display: ["landing"],
-    },
-    {
-      label: "Flexible payment options (SEPA, Credit Card)",
-      variant: "check",
-      display: ["landing", "subscribe"],
-    },
-    {
-      label: "US / EU data hosting",
-      variant: "check",
-      display: ["landing"],
-    },
-    {
-      label: "Advanced models (GPT-4, Claude…)",
-      variant: "check",
-      display: ["landing", "subscribe"],
-    },
-    {
-      label: "Custom agents which can execute actions",
-      variant: "check",
-      display: ["landing", "subscribe"],
-    },
-    {
-      label: "Connections (GitHub, Google Drive, Notion, Slack, ...)",
-      variant: "check",
-      display: ["landing", "subscribe"],
-    },
-    {
-      label: "Native integrations (Zendesk, Slack, Chrome Extension)",
-      variant: "check",
-      display: ["landing", "subscribe"],
-    },
-    {
-      label: "Privacy and Data Security (SOC2, Zero Data Retention)",
-      variant: "check",
-      display: ["landing"],
-    },
-    {
-      label: (
-        <>
-          Unlimited messages (
-          <Hoverable
-            className="cursor-pointer text-gray-400 underline hover:text-gray-500"
-            onClick={() => setIsFairUseModalOpened(true)}
-          >
-            Fair use limits apply*
-          </Hoverable>
-          )
-        </>
-      ),
-      variant: "check",
-      display: ["landing", "subscribe"],
-    },
-    {
-      label: "Up to 1GB/user of data sources",
-      variant: "dash",
-      display: ["landing", "subscribe"],
-    },
-  ];
-
-  const biggerButtonSize = size === "xs" ? "sm" : "md";
-
-  const price = getPriceWithCurrency(BUSINESS_PLAN_COST_MONTHLY);
-
   return (
-    <>
-      <FairUsageModal
-        isOpened={isFairUseModalOpened}
-        onClose={() => setIsFairUseModalOpened(false)}
-      />
-      <PriceTable
-        title="Enterprise (Seat-based)"
-        price={price}
-        color="blue"
-        priceLabel="/ month / user, excl. tax."
-        size={size}
-        magnified={false}
-      >
-        {onClick && (!plan || !isProPlan(plan)) && (
-          <PriceTable.ActionContainer position="top">
-            <Button
-              variant="highlight"
-              size={biggerButtonSize}
-              label={
-                display === "landing" ? "Start now, 14 days free" : "Start now"
-              }
-              icon={RocketIcon}
-              disabled={isProcessing}
-              onClick={withTracking(
-                TRACKING_AREAS.PRICING,
-                "plan_pro_select",
-                onClick
-              )}
-            />
-          </PriceTable.ActionContainer>
-        )}
-        {PRO_PLAN_ITEMS.filter((item) => item.display.includes(display)).map(
-          (item, index) => (
-            <PriceTable.Item
-              key={index}
-              label={item.label}
-              variant={item.variant}
-            />
-          )
-        )}
-      </PriceTable>
-    </>
+    <SeatBasedPriceTable
+      plan="business"
+      title="Enterprise (Seat-based)"
+      color="blue"
+      price={getPriceWithCurrency(BUSINESS_PLAN_COST_MONTHLY)}
+      showButton={!plan || !isProPlan(plan)}
+      display={display}
+      isProcessing={isProcessing}
+      onClick={onClick}
+      size={size}
+    />
   );
 }
 


### PR DESCRIPTION
## Description

- Update the model name displayed on pricing pages from "GPT-4" to "GPT-5, Claude, Gemini, Mistral…" to reflect the latest supported models.
- Refactor PlansTables.tsx to eliminate duplication between ProPriceTable and BusinessPriceTable: extract a shared SeatBasedPriceTable component and a unified getSeatBasedPlanItems function where each item declares which plans it belongs to via a plans field.

## Tests

Locally. 

## Risk

Can be rolled back; 

## Deploy Plan

Deploy front. 