### PR TITLE
Flav/add missing sql indexes

### DIFF
--- a/front/lib/resources/storage/models/group_memberships.ts
+++ b/front/lib/resources/storage/models/group_memberships.ts
@@ -54,6 +54,12 @@ GroupMembershipModel.init(
         fields: ["workspaceId", "groupId", "status", "startAt"],
         concurrently: true,
       },
+      // Optimized index for listUserGroupModelIdsInWorkspace: equality on userId, workspaceId, status
+      // then range scan on startAt.
+      {
+        fields: ["userId", "workspaceId", "status", "startAt"],
+        concurrently: true,
+      },
     ],
   }
 );

--- a/front/migrations/db/migration_509.sql
+++ b/front/migrations/db/migration_509.sql
@@ -1,0 +1,2 @@
+-- Migration created on Feb 13, 2026
+CREATE INDEX CONCURRENTLY "group_memberships_user_id_workspace_id_status_start_at" ON "group_memberships" ("userId", "workspaceId", "status", "startAt");


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR adds a composite index `(userId, workspaceId, status, startAt)` on `group_memberships` table to optimize the listUserGroupModelIdsInWorkspace query used in `fromSession`. The existing index (workspaceId, groupId, status, startAt) doesn't include `userId`, forcing Postgres to scan all memberships in a workspace to find a single user's groups. Causing severe slowdowns on large workspaces.

```
SELECT id FROM groups WHERE workspaceId = ? AND kind IN ( ? ) AND id IN ( SELECT groupId FROM group_memberships WHERE userId = ? AND workspaceId = ? AND startAt <= ? AND ( endAt IS ? OR endAt > ? ) AND status = ? )
```

<img width="810" height="307" alt="image" src="https://github.com/user-attachments/assets/af703a21-a5a3-43ae-97d9-d94e50274faa" />


## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

- [x] Apply the SQL migration
- [x] Deploy front
