### PR TITLE
Handle web summary via a direct LLM call instead of doing a full sub conversation.

### DIFF
--- a/front/lib/actions/mcp_internal_actions/utils/web_summarization.ts
+++ b/front/lib/actions/mcp_internal_actions/utils/web_summarization.ts
@@ -1,12 +1,15 @@
 import { DustAPI } from "@dust-tt/client";
 
 import type { AgentLoopRunContextType } from "@app/lib/actions/types";
+import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
+import { getFastModelConfig } from "@app/lib/api/assistant/global_agents/configurations/dust/deep-dive";
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
 import { prodAPICredentialsForOwner } from "@app/lib/auth";
 import logger from "@app/logger/logger";
 import type { UserMessageOrigin } from "@app/types/assistant/conversation";
 import { isUserMessageType } from "@app/types/assistant/conversation";
+import type { ModelConversationTypeMultiActions } from "@app/types/assistant/generation";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { getHeaderFromUserEmail } from "@app/types/user";
@@ -111,4 +114,84 @@ export async function summarizeWithAgent({
     return new Err(new Error("Summary agent returned empty content"));
   }
   return new Ok(finalContent);
+}
+
+/**
+ * Alternative version of summarizeWithAgent that uses a direct LLM call via runMultiActionsAgent.
+ * This avoids creating a conversation and streaming through the Dust API, instead making a direct
+ * LLM call for faster summarization.
+ */
+export async function summarizeWithLLM({
+  auth,
+  content,
+  agentLoopRunContext,
+}: {
+  auth: Authenticator;
+  content: string;
+  agentLoopRunContext?: AgentLoopRunContextType;
+}): Promise<Result<string, Error>> {
+  const owner = auth.getNonNullableWorkspace();
+  const toSummarize = content.slice(0, MAX_CHARACTERS_TO_SUMMARIZE);
+
+  const model = getFastModelConfig(owner);
+  if (!model) {
+    return new Err(
+      new Error("Failed to find a whitelisted model to generate summary")
+    );
+  }
+
+  const conversation: ModelConversationTypeMultiActions = {
+    messages: [
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: `Summarize the following web page content.\n\n${toSummarize}`,
+          },
+        ],
+        name: "",
+      },
+    ],
+  };
+
+  const prompt =
+    "Summarize the provided web page content concisely. Focus on the main points and key information.";
+
+  const res = await runMultiActionsAgent(
+    auth,
+    {
+      providerId: model.modelConfiguration.providerId,
+      modelId: model.modelConfiguration.modelId,
+      functionCall: null, // No function call needed, just text generation
+      temperature: 0.3,
+      useCache: false,
+    },
+    {
+      conversation,
+      prompt,
+      specifications: [], // No tools needed for simple summarization
+    },
+    {
+      context: {
+        operationType: "web_content_summarization",
+        userId: auth.user()?.sId,
+        workspaceId: owner.sId,
+        ...(agentLoopRunContext && {
+          conversationId: agentLoopRunContext.conversation.sId,
+        }),
+      },
+    }
+  );
+
+  if (res.isErr()) {
+    return new Err(res.error);
+  }
+
+  const summary = res.value.generation?.trim();
+  if (!summary) {
+    return new Err(new Error("LLM returned empty summary"));
+  }
+
+  return new Ok(summary);
 }

--- a/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/deep-dive.ts
@@ -400,7 +400,7 @@ function getModelConfig(
   };
 }
 
-function getFastModelConfig(owner: WorkspaceType): {
+export function getFastModelConfig(owner: WorkspaceType): {
   modelConfiguration: ModelConfigurationType;
   reasoningEffort: AgentReasoningEffort;
 } | null {

--- a/front/lib/api/llm/traces/types.ts
+++ b/front/lib/api/llm/traces/types.ts
@@ -31,6 +31,7 @@ interface LLMTraceContextBase {
     | "trigger_cron_timezone_generator"
     | "trigger_webhook_filter_generator"
     | "voice_agent_finder"
+    | "web_content_summarization"
     | "workspace_tags_suggestion";
 
   workspaceId?: string;


### PR DESCRIPTION
## Description

Web summarization account for 15% of our total conversations since it was added and incure a lot of unecessary infra work.
Created an alternative method with a direct LLM call as well as skipping it altogether if the content is short enough.
Added a log for observability and comparison.

## Tests

Local

## Risk

Low

## Deploy Plan

Deploy front