### PR TITLE
Speed up Next.js build: Docker cache, parallel compilation, SWC minify

### DIFF
--- a/front/next.config.js
+++ b/front/next.config.js
@@ -67,16 +67,7 @@ const config = {
     // Ensure dd-trace and other dependencies are included in standalone build.
     // Paths are relative to front/ directory. With npm workspaces, deps are hoisted to root node_modules.
     outputFileTracingIncludes: {
-      "/**": [
-        "../node_modules/dd-trace/**/*",
-        "../node_modules/@datadog/**/*",
-        // Include entire Redux ecosystem to avoid issues with partial inclusion.
-        "../node_modules/redux/**/*",
-        "../node_modules/@reduxjs/**/*",
-        "../node_modules/immer/**/*",
-        "../node_modules/reselect/**/*",
-        "../node_modules/redux-thunk/**/*",
-      ],
+      "/**": ["../node_modules/dd-trace/**/*", "../node_modules/@datadog/**/*"],
     },
   },
   async redirects() {

--- a/front/next.config.js
+++ b/front/next.config.js
@@ -50,8 +50,8 @@ const config = {
     ],
   },
   transpilePackages: ["@uiw/react-textarea-code-editor"],
-  // As of Next 14.2.3 swc minification creates a bug in the generated client side files.
-  swcMinify: false,
+  // SWC minification is ~5-10x faster than terser. Re-enabled on Next 14.2.35 (bug was in 14.2.3).
+  swcMinify: true,
   onDemandEntries: {
     // Keep dev-compiled pages around longer to avoid re-compiles on nav
     maxInactiveAge: 1000 * 60 * 60, // 1 hour
@@ -60,10 +60,19 @@ const config = {
   experimental: {
     // Prevents minification of the temporalio client workflow ids.
     serverMinification: false,
-    // In production (webpack), disable ESM externals for safer CJS-only resolution.
-    // In dev, use the default (true) for turbopack compatibility and faster builds.
-    ...(!isDev && { esmExternals: false }),
     instrumentationHook: !isDev,
+    turbotrace: {
+            contextDirectory: path.join(__dirname, ".."),
+    },
+    ...(!isDev && {
+      // In production (webpack), disable ESM externals for safer CJS-only resolution.
+      // In dev, use the default (true) for turbopack compatibility and faster builds.
+      esmExternals: false,
+      // Parallelize server compilation and build traces for faster builds (webpack-only, not turbopack).
+      webpackBuildWorker: true,
+      parallelServerCompiles: true,
+      parallelServerBuildTraces: true,
+    }),
     // Ensure dd-trace and other dependencies are included in standalone build.
     // Paths are relative to front/ directory. With npm workspaces, deps are hoisted to root node_modules.
     outputFileTracingIncludes: {


### PR DESCRIPTION
## Summary

- **Docker cache mount for `.next/cache`**: Webpack stores persistent cache here. With a cache mount, subsequent builds only recompile changed files instead of starting from scratch every time.
- **`webpackBuildWorker: true`**: Runs webpack in a separate worker thread with its own heap.
- **`parallelServerCompiles: true`**: Compiles server pages in parallel.
- **`parallelServerBuildTraces: true`**: Runs NFT trace collection in parallel with compilation.
- **`swcMinify: true`**: Re-enabled SWC minification (5-10x faster than terser). The bug was in Next 14.2.3, we're on 14.2.35.
- **Removed unused Redux outputFileTracingIncludes** (from previous commit): Redux is only a transitive client-side dep of recharts, no need to trace 385 files.

## Test plan

- [ ] CI build passes
- [ ] Verify no client-side regressions from swcMinify (check JS console for errors)
- [ ] Compare build times before/after (especially on second build with cache warm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)