### PR TITLE
[front] fix missing error message for tool stakes test

### DIFF
--- a/front/lib/actions/mcp_internal_actions/mcp_servers_metadata.test.ts
+++ b/front/lib/actions/mcp_internal_actions/mcp_servers_metadata.test.ts
@@ -260,11 +260,18 @@ describe("MCP Servers Metadata Snapshot", () => {
       allStakes[serverName] = sortToolsStakes(stakes) ?? {};
     }
 
-    expect(
-      allStakes,
-      "Tool stakes changed. Review the diff and press `u` in watch mode or run " +
-        "`NODE_ENV=test npm test -- --update lib/actions/mcp_internal_actions/" +
-        "mcp_servers_metadata.test.ts` to update the snapshot."
-    ).toMatchSnapshot();
+    try {
+      expect(allStakes).toMatchSnapshot();
+    } catch (error) {
+      const hint =
+        "\n\nTool stakes changed. Review the diff above and run:\n" +
+        "  NODE_ENV=test npm test -- --update lib/actions/mcp_internal_actions/mcp_servers_metadata.test.ts\n" +
+        "to update the snapshot.";
+
+      if (error instanceof Error) {
+        error.message += hint;
+      }
+      throw error;
+    }
   });
 });

--- a/front/lib/actions/mcp_internal_actions/mcp_servers_metadata.test.ts
+++ b/front/lib/actions/mcp_internal_actions/mcp_servers_metadata.test.ts
@@ -265,7 +265,8 @@ describe("MCP Servers Metadata Snapshot", () => {
     } catch (error) {
       const hint =
         "\n\nTool stakes changed. Review the diff above and run:\n" +
-        "  NODE_ENV=test npm test -- --update lib/actions/mcp_internal_actions/mcp_servers_metadata.test.ts\n" +
+        "  NODE_ENV=test npm test -- --update lib/actions/" +
+        "mcp_internal_actions/mcp_servers_metadata.test.ts\n" +
         "to update the snapshot.";
 
       if (error instanceof Error) {

--- a/front/lib/api/actions/servers/ashby/metadata.ts
+++ b/front/lib/api/actions/servers/ashby/metadata.ts
@@ -27,7 +27,7 @@ export const ASHBY_TOOLS_METADATA = createToolsRecord({
       "Search for candidates by name and/or email. " +
       `Returns up to ${DEFAULT_SEARCH_LIMIT} matching candidates by default.`,
     schema: CandidateSearchSchema,
-    stake: "never_ask",
+    stake: "low",
     displayLabels: {
       running: "Searching candidates on Ashby",
       done: "Search candidates on Ashby",

--- a/front/lib/api/actions/servers/ashby/metadata.ts
+++ b/front/lib/api/actions/servers/ashby/metadata.ts
@@ -27,7 +27,7 @@ export const ASHBY_TOOLS_METADATA = createToolsRecord({
       "Search for candidates by name and/or email. " +
       `Returns up to ${DEFAULT_SEARCH_LIMIT} matching candidates by default.`,
     schema: CandidateSearchSchema,
-    stake: "low",
+    stake: "never_ask",
     displayLabels: {
       running: "Searching candidates on Ashby",
       done: "Search candidates on Ashby",


### PR DESCRIPTION
## Description

- In the test that checks for changes in the tool stakes the error message with the command to run does not appear ([example](https://github.com/dust-tt/dust/actions/runs/21998904051/job/63566583413)).
- This PR fixes that ([example](https://github.com/dust-tt/dust/runs/63568845129)).

## Tests

## Risk

## Deploy Plan

- No deploy.
