### PR TITLE
Move agent memories to runtime context section for better prompt caching

### DIFF
--- a/front/lib/api/assistant/generation.test.ts
+++ b/front/lib/api/assistant/generation.test.ts
@@ -4,12 +4,15 @@ import {
   constructProjectContextSection,
   constructPromptMultiActions,
 } from "@app/lib/api/assistant/generation";
+import { buildMemoriesContext } from "@app/lib/api/assistant/global_agents/configurations/dust/dust";
+import { globalAgentInjectsMemory } from "@app/lib/api/assistant/global_agents/global_agents";
 import {
   normalizePrompt,
   systemPromptToText,
 } from "@app/lib/api/llm/types/options";
 import type { Authenticator } from "@app/lib/auth";
 import { getSupportedModelConfigs } from "@app/lib/llms/model_configurations";
+import { AgentMemoryResource } from "@app/lib/resources/agent_memory_resource";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
 import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
@@ -331,5 +334,147 @@ describe("constructPromptMultiActions - system prompt stability", () => {
     expect(instructions[0].content).toContain("# INSTRUCTIONS");
     expect(context.length).toBeGreaterThan(0);
     expect(context.every((s) => s.role === "context")).toBe(true);
+  });
+
+  it("should include memoriesContext in prompt output when provided", () => {
+    const memoriesContext =
+      "<existing_memories>\n- User prefers TypeScript (saved Jan 15, 2025).\n</existing_memories>";
+
+    const params = {
+      userMessage: userMessage1,
+      agentConfiguration: agentConfig1,
+      model: modelConfig,
+      hasAvailableActions: true,
+      agentsList: null,
+      enabledSkills: [],
+      equippedSkills: [],
+      memoriesContext,
+    };
+
+    const sections = constructPromptMultiActions(authenticator1, params);
+    const text = systemPromptToText(sections);
+
+    expect(text).toContain("<existing_memories>");
+    expect(text).toContain("User prefers TypeScript");
+  });
+
+  it("should produce a valid prompt when memoriesContext is omitted", () => {
+    const params = {
+      userMessage: userMessage1,
+      agentConfiguration: agentConfig1,
+      model: modelConfig,
+      hasAvailableActions: true,
+      agentsList: null,
+      enabledSkills: [],
+      equippedSkills: [],
+    };
+
+    const sections = constructPromptMultiActions(authenticator1, params);
+    const text = systemPromptToText(sections);
+
+    // Prompt works without memoriesContext (no crash, contains instructions).
+    expect(text).toContain("# INSTRUCTIONS");
+    expect(text).not.toContain("<existing_memories>");
+  });
+
+  it("should keep memory_guidelines in instructions but existing_memories in context for dust-like agents", () => {
+    const dustConfig = {
+      ...agentConfig1,
+      sId: GLOBAL_AGENTS_SID.DUST,
+      scope: "global" as const,
+      instructions: agentConfig1.instructions + "\n<memory_guidelines>\n",
+    };
+
+    const memoriesContext =
+      "<existing_memories>\n- Some memory (saved Jan 1, 2025).\n</existing_memories>";
+
+    const params = {
+      userMessage: userMessage1,
+      agentConfiguration: dustConfig,
+      model: modelConfig,
+      hasAvailableActions: true,
+      agentsList: null,
+      enabledSkills: [],
+      equippedSkills: [],
+      memoriesContext,
+    };
+
+    const sections = constructPromptMultiActions(authenticator1, params);
+    const [, context] = normalizePrompt(sections);
+
+    // Instructions section should contain memory_guidelines.
+    const instructionsSection = context.find((s) =>
+      s.content.includes("<memory_guidelines>")
+    );
+    expect(instructionsSection).toBeDefined();
+
+    // existing_memories should be in a separate context section, not in the instructions section.
+    expect(instructionsSection?.content).not.toContain("<existing_memories>");
+    const memoriesSection = context.find((s) =>
+      s.content.includes("<existing_memories>")
+    );
+    expect(memoriesSection).toBeDefined();
+    expect(memoriesSection?.content).toContain("Some memory");
+  });
+});
+
+describe("globalAgentInjectsMemory", () => {
+  it("should return true for dust-like agents", () => {
+    expect(globalAgentInjectsMemory(GLOBAL_AGENTS_SID.DUST)).toBe(true);
+    expect(globalAgentInjectsMemory(GLOBAL_AGENTS_SID.DUST_EDGE)).toBe(true);
+    expect(globalAgentInjectsMemory(GLOBAL_AGENTS_SID.DUST_QUICK)).toBe(true);
+    expect(globalAgentInjectsMemory(GLOBAL_AGENTS_SID.DUST_OAI)).toBe(true);
+    expect(globalAgentInjectsMemory(GLOBAL_AGENTS_SID.DUST_GOOG)).toBe(true);
+    expect(globalAgentInjectsMemory(GLOBAL_AGENTS_SID.DUST_NEXT)).toBe(true);
+    expect(globalAgentInjectsMemory(GLOBAL_AGENTS_SID.DUST_NEXT_HIGH)).toBe(
+      true
+    );
+  });
+
+  it("should return false for non-dust global agents", () => {
+    expect(globalAgentInjectsMemory(GLOBAL_AGENTS_SID.DEEP_DIVE)).toBe(false);
+    expect(globalAgentInjectsMemory(GLOBAL_AGENTS_SID.GPT4)).toBe(false);
+    expect(globalAgentInjectsMemory(GLOBAL_AGENTS_SID.HELPER)).toBe(false);
+    expect(globalAgentInjectsMemory(GLOBAL_AGENTS_SID.GEMINI_PRO)).toBe(false);
+  });
+
+  it("should return false for arbitrary non-global-agent strings", () => {
+    expect(globalAgentInjectsMemory("my-custom-agent")).toBe(false);
+    expect(globalAgentInjectsMemory("random-string")).toBe(false);
+    expect(globalAgentInjectsMemory("")).toBe(false);
+  });
+});
+
+describe("buildMemoriesContext", () => {
+  it("should output 'No existing memories' for an empty array", async () => {
+    const result = buildMemoriesContext([]);
+
+    expect(result).toContain("<existing_memories>");
+    expect(result).toContain("</existing_memories>");
+    expect(result).toContain("No existing memories");
+  });
+
+  it("should include each memory's content and a saved date marker", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+
+    const memory1 = await AgentMemoryResource.makeNew(authenticator, {
+      agentConfigurationId: "test-agent",
+      content: "User is a backend engineer",
+      userId: null,
+    });
+    const memory2 = await AgentMemoryResource.makeNew(authenticator, {
+      agentConfigurationId: "test-agent",
+      content: "Prefers dark mode",
+      userId: null,
+    });
+
+    const result = buildMemoriesContext([memory1, memory2]);
+
+    expect(result).toContain("<existing_memories>");
+    expect(result).toContain("</existing_memories>");
+    expect(result).toContain("User is a backend engineer");
+    expect(result).toContain("Prefers dark mode");
+    // Each memory should have a "saved" date marker from formatTimestampToFriendlyDate.
+    expect(result).toContain("(saved ");
   });
 });

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -69,7 +69,6 @@ import {
 import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";
-import { AgentMemoryResource } from "@app/lib/resources/agent_memory_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import type {
@@ -90,6 +89,69 @@ import { isJobType } from "@app/types/job_type";
 import { isDevelopment } from "@app/types/shared/env";
 import { isStringArray } from "@app/types/shared/utils/general";
 import { safeParseJSON } from "@app/types/shared/utils/json_utils";
+
+// Exhaustive map of flags for each global agent. This is used to control which agents inject
+// per-user dynamic content (like memories) into the prompt context. This approach is not ideal but
+// allows us to move dynamic content out of instructions and into context sections, improving prompt
+// cache hit rates. Will be properly refactored if we manage to improve cache hit rates.
+const GLOBAL_AGENT_FLAGS: Record<
+  GLOBAL_AGENTS_SID,
+  { injectsMemory: boolean }
+> = {
+  [GLOBAL_AGENTS_SID.DUST]: { injectsMemory: true },
+  [GLOBAL_AGENTS_SID.DUST_EDGE]: { injectsMemory: true },
+  [GLOBAL_AGENTS_SID.DUST_QUICK]: { injectsMemory: true },
+  [GLOBAL_AGENTS_SID.DUST_QUICK_MEDIUM]: { injectsMemory: true },
+  [GLOBAL_AGENTS_SID.DUST_OAI]: { injectsMemory: true },
+  [GLOBAL_AGENTS_SID.DUST_GOOG]: { injectsMemory: true },
+  [GLOBAL_AGENTS_SID.DUST_GOOG_MEDIUM]: { injectsMemory: true },
+  [GLOBAL_AGENTS_SID.DUST_NEXT]: { injectsMemory: true },
+  [GLOBAL_AGENTS_SID.DUST_NEXT_MEDIUM]: { injectsMemory: true },
+  [GLOBAL_AGENTS_SID.DUST_NEXT_HIGH]: { injectsMemory: true },
+  [GLOBAL_AGENTS_SID.HELPER]: { injectsMemory: false },
+  [GLOBAL_AGENTS_SID.DEEP_DIVE]: { injectsMemory: false },
+  [GLOBAL_AGENTS_SID.DUST_TASK]: { injectsMemory: false },
+  [GLOBAL_AGENTS_SID.DUST_BROWSER_SUMMARY]: { injectsMemory: false },
+  [GLOBAL_AGENTS_SID.DUST_PLANNING]: { injectsMemory: false },
+  [GLOBAL_AGENTS_SID.COPILOT]: { injectsMemory: false },
+  [GLOBAL_AGENTS_SID.SLACK]: { injectsMemory: false },
+  [GLOBAL_AGENTS_SID.GOOGLE_DRIVE]: { injectsMemory: false },
+  [GLOBAL_AGENTS_SID.NOTION]: { injectsMemory: false },
+  [GLOBAL_AGENTS_SID.GITHUB]: { injectsMemory: false },
+  [GLOBAL_AGENTS_SID.INTERCOM]: { injectsMemory: false },
+  [GLOBAL_AGENTS_SID.GPT35_TURBO]: { injectsMemory: false },
+  [GLOBAL_AGENTS_SID.GPT4]: { injectsMemory: false },
+  [GLOBAL_AGENTS_SID.GPT5]: { injectsMemory: false },
+  [GLOBAL_AGENTS_SID.GPT5_THINKING]: { injectsMemory: false },
+  [GLOBAL_AGENTS_SID.GPT5_NANO]: { injectsMemory: false },
+  [GLOBAL_AGENTS_SID.GPT5_MINI]: { injectsMemory: false },
+  [GLOBAL_AGENTS_SID.O1]: { injectsMemory: false },
+  [GLOBAL_AGENTS_SID.O1_MINI]: { injectsMemory: false },
+  [GLOBAL_AGENTS_SID.O1_HIGH_REASONING]: { injectsMemory: false },
+  [GLOBAL_AGENTS_SID.O3_MINI]: { injectsMemory: false },
+  [GLOBAL_AGENTS_SID.O3]: { injectsMemory: false },
+  [GLOBAL_AGENTS_SID.CLAUDE_4_5_HAIKU]: { injectsMemory: false },
+  [GLOBAL_AGENTS_SID.CLAUDE_4_5_SONNET]: { injectsMemory: false },
+  [GLOBAL_AGENTS_SID.CLAUDE_4_SONNET]: { injectsMemory: false },
+  [GLOBAL_AGENTS_SID.CLAUDE_3_OPUS]: { injectsMemory: false },
+  [GLOBAL_AGENTS_SID.CLAUDE_3_SONNET]: { injectsMemory: false },
+  [GLOBAL_AGENTS_SID.CLAUDE_3_HAIKU]: { injectsMemory: false },
+  [GLOBAL_AGENTS_SID.CLAUDE_3_7_SONNET]: { injectsMemory: false },
+  [GLOBAL_AGENTS_SID.MISTRAL_LARGE]: { injectsMemory: false },
+  [GLOBAL_AGENTS_SID.MISTRAL_MEDIUM]: { injectsMemory: false },
+  [GLOBAL_AGENTS_SID.MISTRAL_SMALL]: { injectsMemory: false },
+  [GLOBAL_AGENTS_SID.GEMINI_PRO]: { injectsMemory: false },
+  [GLOBAL_AGENTS_SID.DEEPSEEK_R1]: { injectsMemory: false },
+  [GLOBAL_AGENTS_SID.NOOP]: { injectsMemory: false },
+};
+
+export function globalAgentInjectsMemory(sId: string): boolean {
+  return isGlobalAgentId(sId) && GLOBAL_AGENT_FLAGS[sId].injectsMemory;
+}
+
+function isDustLikeAgent(sId: string): boolean {
+  return isGlobalAgentId(sId) && GLOBAL_AGENT_FLAGS[sId].injectsMemory;
+}
 
 export interface CopilotUserMetadata {
   jobType: JobType | null;
@@ -135,7 +197,6 @@ function getGlobalAgent({
   preFetchedDataSources,
   globalAgentSettings,
   mcpServerViews,
-  memories,
   availableToolsets,
   copilotMCPServerViews,
   copilotUserMetadata,
@@ -146,7 +207,6 @@ function getGlobalAgent({
   preFetchedDataSources: PrefetchedDataSourcesType | null;
   globalAgentSettings: GlobalAgentSettingsModel[];
   mcpServerViews: MCPServerViewsForGlobalAgentsMap;
-  memories: AgentMemoryResource[];
   availableToolsets: MCPServerViewResource[];
   copilotMCPServerViews: {
     context: MCPServerViewResource;
@@ -353,7 +413,6 @@ function getGlobalAgent({
         settings,
         preFetchedDataSources,
         mcpServerViews,
-        memories,
         availableToolsets,
         hasDeepDive,
       });
@@ -363,7 +422,6 @@ function getGlobalAgent({
         settings,
         preFetchedDataSources,
         mcpServerViews,
-        memories,
         availableToolsets,
         hasDeepDive,
       });
@@ -373,7 +431,6 @@ function getGlobalAgent({
         settings,
         preFetchedDataSources,
         mcpServerViews,
-        memories,
         availableToolsets,
         hasDeepDive,
       });
@@ -383,7 +440,6 @@ function getGlobalAgent({
         settings,
         preFetchedDataSources,
         mcpServerViews,
-        memories,
         availableToolsets,
         hasDeepDive,
       });
@@ -393,7 +449,6 @@ function getGlobalAgent({
         settings,
         preFetchedDataSources,
         mcpServerViews,
-        memories,
         availableToolsets,
         hasDeepDive,
       });
@@ -403,7 +458,6 @@ function getGlobalAgent({
         settings,
         preFetchedDataSources,
         mcpServerViews,
-        memories,
         availableToolsets,
         hasDeepDive,
       });
@@ -413,7 +467,6 @@ function getGlobalAgent({
         settings,
         preFetchedDataSources,
         mcpServerViews,
-        memories,
         availableToolsets,
         hasDeepDive,
       });
@@ -423,7 +476,6 @@ function getGlobalAgent({
         settings,
         preFetchedDataSources,
         mcpServerViews,
-        memories,
         availableToolsets,
         hasDeepDive,
       });
@@ -433,7 +485,6 @@ function getGlobalAgent({
         settings,
         preFetchedDataSources,
         mcpServerViews,
-        memories,
         availableToolsets,
         hasDeepDive,
       });
@@ -443,7 +494,6 @@ function getGlobalAgent({
         settings,
         preFetchedDataSources,
         mcpServerViews,
-        memories,
         availableToolsets,
         hasDeepDive,
       });
@@ -616,44 +666,12 @@ export async function getGlobalAgents(
     );
   }
 
-  let memories: AgentMemoryResource[] = [];
-  if (
-    variant === "full" &&
-    mcpServerViews.agent_memory !== null &&
-    auth.user() &&
-    (agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST) ||
-      agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST_EDGE) ||
-      agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST_QUICK) ||
-      agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST_OAI) ||
-      agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST_GOOG) ||
-      agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST_GOOG_MEDIUM) ||
-      agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST_QUICK_MEDIUM) ||
-      agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST_NEXT) ||
-      agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST_NEXT_MEDIUM) ||
-      agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST_NEXT_HIGH))
-  ) {
-    memories = await AgentMemoryResource.findByAgentConfigurationIdAndUser(
-      auth,
-      {
-        agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
-      }
-    );
-  }
-
+  const needsDustLikeData = agentsIdsToFetch.some(isDustLikeAgent);
   let availableToolsets: MCPServerViewResource[] = [];
   if (
     variant === "full" &&
     mcpServerViews.toolsets !== null &&
-    (agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST) ||
-      agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST_EDGE) ||
-      agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST_QUICK) ||
-      agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST_OAI) ||
-      agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST_GOOG) ||
-      agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST_GOOG_MEDIUM) ||
-      agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST_QUICK_MEDIUM) ||
-      agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST_NEXT) ||
-      agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST_NEXT_MEDIUM) ||
-      agentsIdsToFetch.includes(GLOBAL_AGENTS_SID.DUST_NEXT_HIGH))
+    needsDustLikeData
   ) {
     const globalSpace = await SpaceResource.fetchWorkspaceGlobalSpace(auth);
     availableToolsets = await MCPServerViewResource.listBySpace(
@@ -692,7 +710,6 @@ export async function getGlobalAgents(
       preFetchedDataSources,
       globalAgentSettings,
       mcpServerViews,
-      memories,
       availableToolsets,
       copilotMCPServerViews,
       copilotUserMetadata,

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -8,12 +8,15 @@ import { tryListMCPTools } from "@app/lib/actions/mcp_actions";
 import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
 import type { StepContext } from "@app/lib/actions/types";
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
+import { isServerSideMCPServerConfigurationWithName } from "@app/lib/actions/types/guards";
 import { computeStepContexts } from "@app/lib/actions/utils";
 import { createClientSideMCPServerConfigurations } from "@app/lib/api/actions/mcp_client_side";
 import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
 import { renderConversationForModel } from "@app/lib/api/assistant/conversation_rendering";
 import { categorizeConversationRenderErrorMessage } from "@app/lib/api/assistant/errors";
 import { constructPromptMultiActions } from "@app/lib/api/assistant/generation";
+import { buildMemoriesContext } from "@app/lib/api/assistant/global_agents/configurations/dust/dust";
+import { globalAgentInjectsMemory } from "@app/lib/api/assistant/global_agents/global_agents";
 import { getJITServers } from "@app/lib/api/assistant/jit_actions";
 import { listAttachments } from "@app/lib/api/assistant/jit_utils";
 import { isLegacyAgentConfiguration } from "@app/lib/api/assistant/legacy_agent";
@@ -37,6 +40,7 @@ import {
   getDelimitersConfiguration,
 } from "@app/lib/llms/agent_message_content_parser";
 import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
+import { AgentMemoryResource } from "@app/lib/resources/agent_memory_resource";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
@@ -259,6 +263,22 @@ export async function runModelActivity(
       })
     : null;
 
+  let memoriesContext: string | undefined;
+  const hasAgentMemoryAction = agentConfiguration.actions.some((action) =>
+    isServerSideMCPServerConfigurationWithName(action, "agent_memory")
+  );
+  if (
+    globalAgentInjectsMemory(agentConfiguration.sId) &&
+    hasAgentMemoryAction &&
+    auth.user()
+  ) {
+    const memories =
+      await AgentMemoryResource.findByAgentConfigurationIdAndUser(auth, {
+        agentConfigurationId: agentConfiguration.sId,
+      });
+    memoriesContext = buildMemoriesContext(memories);
+  }
+
   const prompt = constructPromptMultiActions(auth, {
     userMessage,
     agentConfiguration,
@@ -271,6 +291,7 @@ export async function runModelActivity(
     serverToolsAndInstructions: mcpActions,
     enabledSkills,
     equippedSkills,
+    memoriesContext,
   });
 
   const specifications: AgentActionSpecification[] = [];


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
In our effort to improve cache hit and reduce entropy on the `@dust` global agent. This PR moves per-user agent memories from `agentConfiguration.instructions` (baked in at config fetch time) into a separate `memoriesContext` parameter passed at runtime to `constructPromptMultiActions`, improving prompt cache hit rates by keeping instructions static. It refactors `GLOBAL_AGENT_FLAGS` map to centralize which global agents inject memory, replacing scattered inline lists. For now nothing changes on the cache side, we only shuffle things around to make system prompt stable.

This should bring us in a place where caching should improve at the workspace level as all remaining entropy is workspace-scoped.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->
Testing locally to confirm that memories are properly included. 

```
      {
        "role": "context",
        "content": "# GUIDELINES\n\n## CITING DOCUMENTS\nDocuments and web pages are automatically assigned a 3-character REFERENCE. When referring to a document or a web page, use the markdown directive :cite[REFERENCE] (eg :cite[xxx] or :cite[xxx,xxx] but not :cite[xxx][xxx]). After retrieving information from documents or web pages, include citations for all information you are using in your answer. Ensure citations are placed as close as possible to the related information.\n\n## MATH FORMULAS\nWhen generating LaTeX/Math formulas exclusively rely on the $$ escape sequence. Single dollar $ escape sequences are not supported and parentheses are not sufficient to denote mathematical formulas:\nBAD: \\( \\Delta \\)\nGOOD: $$ \\Delta $$.\n\n## RENDERING MARKDOWN CODE BLOCKS\nWhen rendering code blocks, always use quadruple backticks (````). To render nested code blocks, always use triple backticks (```) for the inner code blocks.\n## RENDERING MARKDOWN IMAGES\nWhen rendering markdown images, always use the file id of the image, which can be extracted from the corresponding `<attachment id=\"{FILE_ID}\" type... title...>` tag in the conversation history. Also, always use the file title which can similarly be extracted from the same `<attachment id... type... title=\"{TITLE}\">` tag in the conversation history.\nEvery image markdown should follow this pattern ![{TITLE}]({FILE_ID}).\n"
      },
      {
        "role": "context",
        "content": "<existing_memories>\n- User asked about Aubin Tchoi, a Software Engineer colleague at Dust (saved Feb 12, 2026).\n- Switched to CF for their app (as of Feb 2026) (saved Feb 12, 2026).\n</existing_memories>"
      }
```

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
Main risk lies in the fact that we re-organize the system instructions. Worst case, agent memory is not leveraged anymore. Safe to rollback.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
