### PR TITLE
[front] Clarify template mode instructions to avoid unnecessary content fetch

### DIFF
--- a/front/lib/api/actions/servers/interactive_content/instructions.ts
+++ b/front/lib/api/actions/servers/interactive_content/instructions.ts
@@ -65,6 +65,8 @@ ${CREATE_INTERACTIVE_CONTENT_FILE_TOOL_NAME}({
   description: "Sales dashboard"
 })
 \`\`\`
+When using template mode, you don't need to read the template content first.
+Just pass the knowledge ID to the tool and the content will be fetched server-side.
 Common pattern: Create from template, then use \`${EDIT_INTERACTIVE_CONTENT_FILE_TOOL_NAME}\` to customize.
 This approach works well when adapting existing templates (preserves structure/style, no token cost for base content).
 Typical use cases: Suitable template exists, adapting existing code, saving tokens on large files.


### PR DESCRIPTION
## Description

- We are observing cases where agent fetch content ahead of time, realizing later that the content is not needed for template mode, example [here](https://poke.dust.tt/0ec9852c2f/conversation/Uef4KcvbVe#?spid=fil_vomozqgO10kern%401771017957281&spt=interactive_content).
- This PR tweaks the instructions in this direction.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
