### PR TITLE
Bump Sequelize Connection Pool from 25 to 40

### DIFF
--- a/front/lib/api/config.ts
+++ b/front/lib/api/config.ts
@@ -400,6 +400,10 @@ const config = {
   getTemporalAgentNamespace: () => {
     return EnvironmentConfig.getOptionalEnvVariable("TEMPORAL_AGENT_NAMESPACE");
   },
+  // Deployment component name. Set via DD_SERVICE in helm values per deployment.
+  getServiceName: (): string | undefined => {
+    return EnvironmentConfig.getOptionalEnvVariable("DD_SERVICE");
+  },
   // Northflank sandbox.
   getNorthflankApiToken: () => {
     return EnvironmentConfig.getOptionalEnvVariable("NORTHFLANK_API_TOKEN");

--- a/front/lib/resources/storage/index.ts
+++ b/front/lib/resources/storage/index.ts
@@ -1,11 +1,10 @@
-import assert from "assert";
-import type { Sequelize } from "sequelize";
-
 import config from "@app/lib/api/config";
 import { SequelizeWithComments } from "@app/lib/api/database";
 import { dbConfig } from "@app/lib/resources/storage/config";
 import { getStatsDClient } from "@app/lib/utils/statsd";
 import { isDevelopment } from "@app/types/shared/env";
+import assert from "assert";
+import type { Sequelize } from "sequelize";
 
 // Directly require 'pg' here to make sure we are using the same version of the
 // package as the one used by pg package.


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
See full context in [this thread](https://dust4ai.slack.com/archives/C050SM8NSPK/p1771015465883399).

This PR bumps the connection acquisition for front facing deployments (API mainly) from 25 to 40. More context in the thread above but this should ease the current contention we see.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
