### PR TITLE
[front] Add ability to attach data warehouse to skills

### DIFF
--- a/front/lib/api/actions/servers/interactive_content/template_utils.ts
+++ b/front/lib/api/actions/servers/interactive_content/template_utils.ts
@@ -47,12 +47,10 @@ export async function fetchTemplateContent(
   });
 
   // Get merged data source configurations from skills.
-  const dataSourceConfigurations = await getSkillDataSourceConfigurations(
-    auth,
-    {
+  const { documentDataSourceConfigurations: dataSourceConfigurations } =
+    await getSkillDataSourceConfigurations(auth, {
       skills: enabledSkills,
-    }
-  );
+    });
 
   if (dataSourceConfigurations.length === 0) {
     return new Err(

--- a/front/temporal/agent_loop/lib/prompt_commands.ts
+++ b/front/temporal/agent_loop/lib/prompt_commands.ts
@@ -8,6 +8,7 @@ import { getJITServers } from "@app/lib/api/assistant/jit_actions";
 import { listAttachments } from "@app/lib/api/assistant/jit_utils";
 import { getCompletionDuration } from "@app/lib/api/assistant/messages";
 import {
+  createSkillKnowledgeDataWarehouseServer,
   createSkillKnowledgeFileSystemServer,
   getSkillDataSourceConfigurations,
   getSkillServers,
@@ -182,16 +183,22 @@ async function listAvailableTools(
     skills: enabledSkills,
   });
 
-  const dataSourceConfigurations = await getSkillDataSourceConfigurations(
-    auth,
-    { skills: enabledSkills }
-  );
+  const { documentDataSourceConfigurations, warehouseDataSourceConfigurations } =
+    await getSkillDataSourceConfigurations(auth, { skills: enabledSkills });
 
-  const fileSystemServer = await createSkillKnowledgeFileSystemServer(auth, {
-    dataSourceConfigurations,
-  });
+  const [fileSystemServer, dataWarehouseServer] = await Promise.all([
+    createSkillKnowledgeFileSystemServer(auth, {
+      dataSourceConfigurations: documentDataSourceConfigurations,
+    }),
+    createSkillKnowledgeDataWarehouseServer(auth, {
+      dataSourceConfigurations: warehouseDataSourceConfigurations,
+    }),
+  ]);
   if (fileSystemServer) {
     skillServers.push(fileSystemServer);
+  }
+  if (dataWarehouseServer) {
+    skillServers.push(dataWarehouseServer);
   }
 
   const { serverToolsAndInstructions: mcpActions } = await tryListMCPTools(

--- a/front/temporal/agent_loop/lib/prompt_commands.ts
+++ b/front/temporal/agent_loop/lib/prompt_commands.ts
@@ -183,8 +183,10 @@ async function listAvailableTools(
     skills: enabledSkills,
   });
 
-  const { documentDataSourceConfigurations, warehouseDataSourceConfigurations } =
-    await getSkillDataSourceConfigurations(auth, { skills: enabledSkills });
+  const {
+    documentDataSourceConfigurations,
+    warehouseDataSourceConfigurations,
+  } = await getSkillDataSourceConfigurations(auth, { skills: enabledSkills });
 
   const [fileSystemServer, dataWarehouseServer] = await Promise.all([
     createSkillKnowledgeFileSystemServer(auth, {

--- a/front/temporal/agent_loop/lib/prompt_commands.ts
+++ b/front/temporal/agent_loop/lib/prompt_commands.ts
@@ -188,14 +188,15 @@ async function listAvailableTools(
     warehouseDataSourceConfigurations,
   } = await getSkillDataSourceConfigurations(auth, { skills: enabledSkills });
 
-  const [fileSystemServer, dataWarehouseServer] = await Promise.all([
-    createSkillKnowledgeFileSystemServer(auth, {
-      dataSourceConfigurations: documentDataSourceConfigurations,
-    }),
-    createSkillKnowledgeDataWarehouseServer(auth, {
+  const fileSystemServer = await createSkillKnowledgeFileSystemServer(auth, {
+    dataSourceConfigurations: documentDataSourceConfigurations,
+  });
+  const dataWarehouseServer = await createSkillKnowledgeDataWarehouseServer(
+    auth,
+    {
       dataSourceConfigurations: warehouseDataSourceConfigurations,
-    }),
-  ]);
+    }
+  );
   if (fileSystemServer) {
     skillServers.push(fileSystemServer);
   }

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -208,10 +208,12 @@ export async function runModel(
     });
 
   // Add file system / data warehouse servers if skills have attached knowledge.
-  const { documentDataSourceConfigurations, warehouseDataSourceConfigurations } =
-    await getSkillDataSourceConfigurations(auth, {
-      skills: enabledSkills,
-    });
+  const {
+    documentDataSourceConfigurations,
+    warehouseDataSourceConfigurations,
+  } = await getSkillDataSourceConfigurations(auth, {
+    skills: enabledSkills,
+  });
 
   const [fileSystemServer, dataWarehouseServer] = await Promise.all([
     createSkillKnowledgeFileSystemServer(auth, {

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -207,28 +207,28 @@ export async function runModel(
       skills: enabledSkills,
     });
 
-  // Add file system / data warehouse servers if skills have attached knowledge.
-  const {
-    documentDataSourceConfigurations,
-    warehouseDataSourceConfigurations,
-  } = await getSkillDataSourceConfigurations(auth, {
-    skills: enabledSkills,
-  });
+    // Add file system / data warehouse servers if skills have attached knowledge.
+    const {
+      documentDataSourceConfigurations,
+      warehouseDataSourceConfigurations,
+    } = await getSkillDataSourceConfigurations(auth, {
+      skills: enabledSkills,
+    });
 
-  const [fileSystemServer, dataWarehouseServer] = await Promise.all([
-    createSkillKnowledgeFileSystemServer(auth, {
-      dataSourceConfigurations: documentDataSourceConfigurations,
-    }),
-    createSkillKnowledgeDataWarehouseServer(auth, {
-      dataSourceConfigurations: warehouseDataSourceConfigurations,
-    }),
-  ]);
-  if (fileSystemServer) {
-    skillServers.push(fileSystemServer);
-  }
-  if (dataWarehouseServer) {
-    skillServers.push(dataWarehouseServer);
-  }
+    const [fileSystemServer, dataWarehouseServer] = await Promise.all([
+      createSkillKnowledgeFileSystemServer(auth, {
+        dataSourceConfigurations: documentDataSourceConfigurations,
+      }),
+      createSkillKnowledgeDataWarehouseServer(auth, {
+        dataSourceConfigurations: warehouseDataSourceConfigurations,
+      }),
+    ]);
+    if (fileSystemServer) {
+      skillServers.push(fileSystemServer);
+    }
+    if (dataWarehouseServer) {
+      skillServers.push(dataWarehouseServer);
+    }
 
     const {
       serverToolsAndInstructions: mcpActions,

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -215,14 +215,15 @@ export async function runModel(
       skills: enabledSkills,
     });
 
-    const [fileSystemServer, dataWarehouseServer] = await Promise.all([
-      createSkillKnowledgeFileSystemServer(auth, {
-        dataSourceConfigurations: documentDataSourceConfigurations,
-      }),
-      createSkillKnowledgeDataWarehouseServer(auth, {
+    const fileSystemServer = await createSkillKnowledgeFileSystemServer(auth, {
+      dataSourceConfigurations: documentDataSourceConfigurations,
+    });
+    const dataWarehouseServer = await createSkillKnowledgeDataWarehouseServer(
+      auth,
+      {
         dataSourceConfigurations: warehouseDataSourceConfigurations,
-      }),
-    ]);
+      }
+    );
     if (fileSystemServer) {
       skillServers.push(fileSystemServer);
     }


### PR DESCRIPTION
## Description

- This PR adds the ability to attach data warehouses to skills.
- Allows attaching content from data warehouses, which leads to adding a data warehouse instead of a data source filesystem if the attached content is a remote database.
- Will monitor how well that works if the skill has both dsfs and dw, no specific prompting so low risk.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
