### PR TITLE
[front] enh(dust-instructions): move toolsets to separate context block

### DIFF
--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -399,6 +399,7 @@ export function constructPromptMultiActions(
     enabledSkills,
     equippedSkills,
     memoriesContext,
+    toolsetsContext,
   }: {
     userMessage: UserMessageType;
     agentConfiguration: AgentConfigurationType;
@@ -412,6 +413,7 @@ export function constructPromptMultiActions(
     enabledSkills: (SkillResource & { extendedSkill: SkillResource | null })[];
     equippedSkills: SkillResource[];
     memoriesContext?: string;
+    toolsetsContext?: string;
   }
 ): SystemPromptSections {
   const owner = auth.workspace();
@@ -479,9 +481,11 @@ export function constructPromptMultiActions(
 
     const dynamicContext: SystemPromptContext[] = [
       { role: "context" as const, content: contextSection },
-      { role: "context" as const, content: projectContextSection },
-      { role: "context" as const, content: memoriesContext ?? "" },
-    ].filter((s) => s.content.trim() !== "");
+      { role: "context" as const, content: projectContextSection
+    },
+    { role: "context" as const, content: memoriesContext ?? "" },
+    { role: "context" as const, content: toolsetsContext ?? "" },
+  ].filter((s) => s.content.trim() !== "");
 
     return [
       [{ role: "instruction", content: fullInstructions }],

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -481,11 +481,10 @@ export function constructPromptMultiActions(
 
     const dynamicContext: SystemPromptContext[] = [
       { role: "context" as const, content: contextSection },
-      { role: "context" as const, content: projectContextSection
-    },
-    { role: "context" as const, content: memoriesContext ?? "" },
-    { role: "context" as const, content: toolsetsContext ?? "" },
-  ].filter((s) => s.content.trim() !== "");
+      { role: "context" as const, content: projectContextSection },
+      { role: "context" as const, content: memoriesContext ?? "" },
+      { role: "context" as const, content: toolsetsContext ?? "" },
+    ].filter((s) => s.content.trim() !== "");
 
     return [
       [{ role: "instruction", content: fullInstructions }],

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -1,7 +1,6 @@
 import { TOOL_NAME_SEPARATOR } from "@app/lib/actions/constants";
 import type { MCPServerConfigurationType } from "@app/lib/actions/mcp";
 import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
-import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import {
   AGENT_ROUTER_SERVER_NAME,
   SUGGEST_AGENTS_TOOL_NAME,
@@ -28,8 +27,11 @@ import {
   isEntreprisePlanPrefix,
 } from "@app/lib/plans/plan_codes";
 import type { AgentMemoryResource } from "@app/lib/resources/agent_memory_resource";
+import {
+  getMcpServerViewDescription,
+  getMcpServerViewDisplayName,
+} from "@app/lib/actions/mcp_helper";
 import type { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
-import { buildDiscoverToolsInstructions } from "@app/lib/resources/skill/global/discover_tools";
 import { formatTimestampToFriendlyDate } from "@app/lib/utils";
 import type {
   AgentConfigurationType,
@@ -67,7 +69,6 @@ interface DustLikeGlobalAgentArgs {
   settings: GlobalAgentSettingsModel | null;
   preFetchedDataSources: PrefetchedDataSourcesType | null;
   mcpServerViews: MCPServerViewsForGlobalAgentsMap;
-  availableToolsets: MCPServerViewResource[];
   hasDeepDive: boolean;
 }
 
@@ -178,10 +179,13 @@ The dataSourceId can typically be found by exploring the warehouse, each warehou
 A dataSourceId typically starts with the prefix "dts_".
 </data_warehouses_guidelines>`,
 
-  toolsets: (availableToolsets: MCPServerViewResource[]) => {
-    const instructions = buildDiscoverToolsInstructions(availableToolsets);
-    return `<toolsets_guidelines>${instructions}</toolsets_guidelines>`;
-  },
+  toolsets: `<toolsets_guidelines>
+The "toolsets" tools allow listing and enabling additional tools.
+
+When encountering any request that might benefit from specialized tools, review the available toolsets.
+Enable relevant toolsets using \`toolsets__enable\` with the toolsetId (shown in backticks) before attempting to fulfill the request.
+Never assume or reply that you cannot do something before checking if there's a relevant toolset available.
+</toolsets_guidelines>`,
 
   help: `<dust_platform_support_guidelines>
 Follow these guidelines when the user unambiguously asks support questions specifically about how to use Dust features, or needs help understanding Dust.
@@ -272,20 +276,47 @@ ${memoryList.trim()}
 </existing_memories>`;
 }
 
+export function buildToolsetsContext(
+  availableToolsets: MCPServerViewResource[]
+): string {
+  const toolsetsList = availableToolsets
+    .sort((a, b) => {
+      const aView = a.toJSON();
+      const bView = b.toJSON();
+      const nameCompare = getMcpServerViewDisplayName(aView).localeCompare(
+        getMcpServerViewDisplayName(bView)
+      );
+      if (nameCompare !== 0) {
+        return nameCompare;
+      }
+      return aView.sId.localeCompare(bView.sId);
+    })
+    .map((toolset) => {
+      const mcpServerView = toolset.toJSON();
+      const sId = mcpServerView.sId;
+      const displayName = getMcpServerViewDisplayName(mcpServerView);
+      const description = getMcpServerViewDescription(mcpServerView);
+      return `- **${displayName}** (toolsetId: \`${sId}\`): ${description}`;
+    })
+    .join("\n");
+
+  return `<available_toolsets>
+${toolsetsList.length > 0 ? toolsetsList : "No additional toolsets are currently available."}
+</available_toolsets>`;
+}
+
 function buildInstructions({
   hasDeepDive,
   hasFilesystemTools,
   hasDataWarehouses,
   hasAgentMemory,
   hasToolsets,
-  availableToolsets,
 }: {
   hasDeepDive: boolean;
   hasFilesystemTools: boolean;
   hasDataWarehouses: boolean;
   hasAgentMemory: boolean;
   hasToolsets: boolean;
-  availableToolsets: MCPServerViewResource[];
 }): string {
   const parts: string[] = [
     INSTRUCTION_SECTIONS.primary,
@@ -294,7 +325,7 @@ function buildInstructions({
       : INSTRUCTION_SECTIONS.simpleRequests,
     hasFilesystemTools && INSTRUCTION_SECTIONS.companyData,
     hasDataWarehouses && INSTRUCTION_SECTIONS.warehouses,
-    hasToolsets && INSTRUCTION_SECTIONS.toolsets(availableToolsets),
+    hasToolsets && INSTRUCTION_SECTIONS.toolsets,
     INSTRUCTION_SECTIONS.help,
     hasAgentMemory && INSTRUCTION_SECTIONS.memory,
   ].filter((part): part is string => typeof part === "string");
@@ -308,7 +339,6 @@ function _getDustLikeGlobalAgent(
     settings,
     preFetchedDataSources,
     mcpServerViews,
-    availableToolsets,
     hasDeepDive,
   }: DustLikeGlobalAgentArgs,
   {
@@ -373,15 +403,6 @@ function _getDustLikeGlobalAgent(
   const hasAgentMemory = agentMemoryMCPServerView !== null;
   const hasToolsets = toolsetsMCPServerView !== null;
 
-  // Filter available toolsets (similar to toolsets>list logic): tools with no requirements and not auto-hidden.
-  const filteredAvailableToolsets = availableToolsets.filter((toolset) => {
-    const mcpServerView = toolset.toJSON();
-    return (
-      getMCPServerRequirements(mcpServerView).noRequirement &&
-      mcpServerView.server.availability !== "auto_hidden_builder"
-    );
-  });
-
   const companyDataAction = getCompanyDataAction(
     preFetchedDataSources,
     mcpServerViews
@@ -398,7 +419,6 @@ function _getDustLikeGlobalAgent(
     hasDataWarehouses: dataWarehousesAction !== null,
     hasAgentMemory,
     hasToolsets,
-    availableToolsets: filteredAvailableToolsets,
   });
 
   const dustAgent = {

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -263,8 +263,7 @@ export function buildMemoriesContext(memories: AgentMemoryResource[]): string {
     ? memories.map(formatMemory).join("\n")
     : "No existing memories.";
 
-  return `
-<existing_memories>
+  return `<existing_memories>
 ${memoryList.trim()}
 </existing_memories>`;
 }

--- a/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/dust.ts
@@ -263,7 +263,8 @@ export function buildMemoriesContext(memories: AgentMemoryResource[]): string {
     ? memories.map(formatMemory).join("\n")
     : "No existing memories.";
 
-  return `<existing_memories>
+  return `
+<existing_memories>
 ${memoryList.trim()}
 </existing_memories>`;
 }

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -82,7 +82,6 @@ import type { Authenticator } from "@app/lib/auth";
 import { getFeatureFlags } from "@app/lib/auth";
 import { GlobalAgentSettingsModel } from "@app/lib/models/agent/agent";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
-import { SpaceResource } from "@app/lib/resources/space_resource";
 import type {
   AgentConfigurationType,
   AgentFetchVariant,
@@ -221,7 +220,6 @@ function getGlobalAgent({
   preFetchedDataSources,
   globalAgentSettings,
   mcpServerViews,
-  availableToolsets,
   copilotMCPServerViews,
   copilotUserMetadata,
   hasDeepDive,
@@ -231,7 +229,6 @@ function getGlobalAgent({
   preFetchedDataSources: PrefetchedDataSourcesType | null;
   globalAgentSettings: GlobalAgentSettingsModel[];
   mcpServerViews: MCPServerViewsForGlobalAgentsMap;
-  availableToolsets: MCPServerViewResource[];
   copilotMCPServerViews: {
     context: MCPServerViewResource;
   } | null;
@@ -437,7 +434,6 @@ function getGlobalAgent({
         settings,
         preFetchedDataSources,
         mcpServerViews,
-        availableToolsets,
         hasDeepDive,
       });
       break;
@@ -446,7 +442,6 @@ function getGlobalAgent({
         settings,
         preFetchedDataSources,
         mcpServerViews,
-        availableToolsets,
         hasDeepDive,
       });
       break;
@@ -563,7 +558,6 @@ function getGlobalAgent({
         settings,
         preFetchedDataSources,
         mcpServerViews,
-        availableToolsets,
         hasDeepDive,
       });
       break;
@@ -572,7 +566,6 @@ function getGlobalAgent({
         settings,
         preFetchedDataSources,
         mcpServerViews,
-        availableToolsets,
         hasDeepDive,
       });
       break;
@@ -581,7 +574,6 @@ function getGlobalAgent({
         settings,
         preFetchedDataSources,
         mcpServerViews,
-        availableToolsets,
         hasDeepDive,
       });
       break;
@@ -590,7 +582,6 @@ function getGlobalAgent({
         settings,
         preFetchedDataSources,
         mcpServerViews,
-        availableToolsets,
         hasDeepDive,
       });
       break;
@@ -599,7 +590,6 @@ function getGlobalAgent({
         settings,
         preFetchedDataSources,
         mcpServerViews,
-        availableToolsets,
         hasDeepDive,
       });
       break;
@@ -608,7 +598,6 @@ function getGlobalAgent({
         settings,
         preFetchedDataSources,
         mcpServerViews,
-        availableToolsets,
         hasDeepDive,
       });
       break;
@@ -617,7 +606,6 @@ function getGlobalAgent({
         settings,
         preFetchedDataSources,
         mcpServerViews,
-        availableToolsets,
         hasDeepDive,
       });
       break;
@@ -626,7 +614,6 @@ function getGlobalAgent({
         settings,
         preFetchedDataSources,
         mcpServerViews,
-        availableToolsets,
         hasDeepDive,
       });
       break;
@@ -810,20 +797,6 @@ export async function getGlobalAgents(
     );
   }
 
-  const needsDustLikeData = agentsIdsToFetch.some(isDustLikeAgent);
-  let availableToolsets: MCPServerViewResource[] = [];
-  if (
-    variant === "full" &&
-    mcpServerViews.toolsets !== null &&
-    needsDustLikeData
-  ) {
-    const globalSpace = await SpaceResource.fetchWorkspaceGlobalSpace(auth);
-    availableToolsets = await MCPServerViewResource.listBySpace(
-      auth,
-      globalSpace
-    );
-  }
-
   let copilotMCPServerViews: {
     context: MCPServerViewResource;
   } | null = null;
@@ -854,7 +827,6 @@ export async function getGlobalAgents(
       preFetchedDataSources,
       globalAgentSettings,
       mcpServerViews,
-      availableToolsets,
       copilotMCPServerViews,
       copilotUserMetadata,
       hasDeepDive: !isDeepDiveDisabled,

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -267,7 +267,11 @@ export function globalAgentInjectsToolsets(sId: string): boolean {
 }
 
 export function isDustLikeAgent(sId: string): boolean {
-  return isGlobalAgentId(sId) && GLOBAL_AGENT_FLAGS[sId].injectsMemory;
+  return (
+    isGlobalAgentId(sId) &&
+    GLOBAL_AGENT_FLAGS[sId].injectsMemory &&
+    GLOBAL_AGENT_FLAGS[sId].injectsToolsets
+  );
 }
 
 export interface CopilotUserMetadata {

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -107,69 +107,163 @@ import { safeParseJSON } from "@app/types/shared/utils/json_utils";
 // cache hit rates. Will be properly refactored if we manage to improve cache hit rates.
 const GLOBAL_AGENT_FLAGS: Record<
   GLOBAL_AGENTS_SID,
-  { injectsMemory: boolean }
+  { injectsMemory: boolean; injectsToolsets: boolean }
 > = {
-  [GLOBAL_AGENTS_SID.DUST]: { injectsMemory: true },
-  [GLOBAL_AGENTS_SID.DUST_EDGE]: { injectsMemory: true },
-  [GLOBAL_AGENTS_SID.DUST_QUICK]: { injectsMemory: true },
-  [GLOBAL_AGENTS_SID.DUST_QUICK_MEDIUM]: { injectsMemory: true },
-  [GLOBAL_AGENTS_SID.DUST_OAI]: { injectsMemory: true },
-  [GLOBAL_AGENTS_SID.DUST_GOOG]: { injectsMemory: true },
-  [GLOBAL_AGENTS_SID.DUST_GOOG_MEDIUM]: { injectsMemory: true },
-  [GLOBAL_AGENTS_SID.DUST_ANT]: { injectsMemory: true },
-  [GLOBAL_AGENTS_SID.DUST_ANT_MEDIUM]: { injectsMemory: true },
-  [GLOBAL_AGENTS_SID.DUST_ANT_HIGH]: { injectsMemory: true },
-  [GLOBAL_AGENTS_SID.DUST_KIMI]: { injectsMemory: true },
-  [GLOBAL_AGENTS_SID.DUST_KIMI_MEDIUM]: { injectsMemory: true },
-  [GLOBAL_AGENTS_SID.DUST_KIMI_HIGH]: { injectsMemory: true },
-  [GLOBAL_AGENTS_SID.DUST_GLM]: { injectsMemory: true },
-  [GLOBAL_AGENTS_SID.DUST_GLM_MEDIUM]: { injectsMemory: true },
-  [GLOBAL_AGENTS_SID.DUST_GLM_HIGH]: { injectsMemory: true },
-  [GLOBAL_AGENTS_SID.DUST_MINIMAX]: { injectsMemory: true },
-  [GLOBAL_AGENTS_SID.DUST_MINIMAX_MEDIUM]: { injectsMemory: true },
-  [GLOBAL_AGENTS_SID.DUST_MINIMAX_HIGH]: { injectsMemory: true },
-  [GLOBAL_AGENTS_SID.DUST_NEXT]: { injectsMemory: true },
-  [GLOBAL_AGENTS_SID.DUST_NEXT_MEDIUM]: { injectsMemory: true },
-  [GLOBAL_AGENTS_SID.DUST_NEXT_HIGH]: { injectsMemory: true },
-  [GLOBAL_AGENTS_SID.HELPER]: { injectsMemory: false },
-  [GLOBAL_AGENTS_SID.DEEP_DIVE]: { injectsMemory: false },
-  [GLOBAL_AGENTS_SID.DUST_TASK]: { injectsMemory: false },
-  [GLOBAL_AGENTS_SID.DUST_BROWSER_SUMMARY]: { injectsMemory: false },
-  [GLOBAL_AGENTS_SID.DUST_PLANNING]: { injectsMemory: false },
-  [GLOBAL_AGENTS_SID.COPILOT]: { injectsMemory: false },
-  [GLOBAL_AGENTS_SID.SLACK]: { injectsMemory: false },
-  [GLOBAL_AGENTS_SID.GOOGLE_DRIVE]: { injectsMemory: false },
-  [GLOBAL_AGENTS_SID.NOTION]: { injectsMemory: false },
-  [GLOBAL_AGENTS_SID.GITHUB]: { injectsMemory: false },
-  [GLOBAL_AGENTS_SID.INTERCOM]: { injectsMemory: false },
-  [GLOBAL_AGENTS_SID.GPT35_TURBO]: { injectsMemory: false },
-  [GLOBAL_AGENTS_SID.GPT4]: { injectsMemory: false },
-  [GLOBAL_AGENTS_SID.GPT5]: { injectsMemory: false },
-  [GLOBAL_AGENTS_SID.GPT5_THINKING]: { injectsMemory: false },
-  [GLOBAL_AGENTS_SID.GPT5_NANO]: { injectsMemory: false },
-  [GLOBAL_AGENTS_SID.GPT5_MINI]: { injectsMemory: false },
-  [GLOBAL_AGENTS_SID.O1]: { injectsMemory: false },
-  [GLOBAL_AGENTS_SID.O1_MINI]: { injectsMemory: false },
-  [GLOBAL_AGENTS_SID.O1_HIGH_REASONING]: { injectsMemory: false },
-  [GLOBAL_AGENTS_SID.O3_MINI]: { injectsMemory: false },
-  [GLOBAL_AGENTS_SID.O3]: { injectsMemory: false },
-  [GLOBAL_AGENTS_SID.CLAUDE_4_5_HAIKU]: { injectsMemory: false },
-  [GLOBAL_AGENTS_SID.CLAUDE_4_5_SONNET]: { injectsMemory: false },
-  [GLOBAL_AGENTS_SID.CLAUDE_4_SONNET]: { injectsMemory: false },
-  [GLOBAL_AGENTS_SID.CLAUDE_3_OPUS]: { injectsMemory: false },
-  [GLOBAL_AGENTS_SID.CLAUDE_3_SONNET]: { injectsMemory: false },
-  [GLOBAL_AGENTS_SID.CLAUDE_3_HAIKU]: { injectsMemory: false },
-  [GLOBAL_AGENTS_SID.CLAUDE_3_7_SONNET]: { injectsMemory: false },
-  [GLOBAL_AGENTS_SID.MISTRAL_LARGE]: { injectsMemory: false },
-  [GLOBAL_AGENTS_SID.MISTRAL_MEDIUM]: { injectsMemory: false },
-  [GLOBAL_AGENTS_SID.MISTRAL_SMALL]: { injectsMemory: false },
-  [GLOBAL_AGENTS_SID.GEMINI_PRO]: { injectsMemory: false },
-  [GLOBAL_AGENTS_SID.DEEPSEEK_R1]: { injectsMemory: false },
-  [GLOBAL_AGENTS_SID.NOOP]: { injectsMemory: false },
+  [GLOBAL_AGENTS_SID.DUST]: { injectsMemory: true, injectsToolsets: true },
+  [GLOBAL_AGENTS_SID.DUST_EDGE]: { injectsMemory: true, injectsToolsets: true },
+  [GLOBAL_AGENTS_SID.DUST_QUICK]: {
+    injectsMemory: true,
+    injectsToolsets: true,
+  },
+  [GLOBAL_AGENTS_SID.DUST_QUICK_MEDIUM]: {
+    injectsMemory: true,
+    injectsToolsets: true,
+  },
+  [GLOBAL_AGENTS_SID.DUST_OAI]: { injectsMemory: true, injectsToolsets: true },
+  [GLOBAL_AGENTS_SID.DUST_GOOG]: {
+    injectsMemory: true,
+    injectsToolsets: true,
+  },
+  [GLOBAL_AGENTS_SID.DUST_GOOG_MEDIUM]: {
+    injectsMemory: true,
+    injectsToolsets: true,
+  },
+  [GLOBAL_AGENTS_SID.DUST_ANT]: { injectsMemory: true, injectsToolsets: true },
+  [GLOBAL_AGENTS_SID.DUST_ANT_MEDIUM]: { injectsMemory: true, injectsToolsets: true },
+  [GLOBAL_AGENTS_SID.DUST_ANT_HIGH]: { injectsMemory: true, injectsToolsets: true },
+  [GLOBAL_AGENTS_SID.DUST_KIMI]: { injectsMemory: true, injectsToolsets: true },
+  [GLOBAL_AGENTS_SID.DUST_KIMI_MEDIUM]: { injectsMemory: true, injectsToolsets: true },
+  [GLOBAL_AGENTS_SID.DUST_KIMI_HIGH]: { injectsMemory: true, injectsToolsets: true },
+  [GLOBAL_AGENTS_SID.DUST_GLM]: { injectsMemory: true, injectsToolsets: true },
+  [GLOBAL_AGENTS_SID.DUST_GLM_MEDIUM]: { injectsMemory: true, injectsToolsets: true },
+  [GLOBAL_AGENTS_SID.DUST_GLM_HIGH]: { injectsMemory: true, injectsToolsets: true },
+  [GLOBAL_AGENTS_SID.DUST_MINIMAX]: { injectsMemory: true, injectsToolsets: true },
+  [GLOBAL_AGENTS_SID.DUST_MINIMAX_MEDIUM]: { injectsMemory: true, injectsToolsets: true },
+  [GLOBAL_AGENTS_SID.DUST_MINIMAX_HIGH]: { injectsMemory: true, injectsToolsets: true },
+  [GLOBAL_AGENTS_SID.DUST_NEXT]: {
+    injectsMemory: true,
+    injectsToolsets: true,
+  },
+  [GLOBAL_AGENTS_SID.DUST_NEXT_MEDIUM]: {
+    injectsMemory: true,
+    injectsToolsets: true,
+  },
+  [GLOBAL_AGENTS_SID.DUST_NEXT_HIGH]: {
+    injectsMemory: true,
+    injectsToolsets: true,
+  },
+  [GLOBAL_AGENTS_SID.HELPER]: { injectsMemory: false, injectsToolsets: false },
+  [GLOBAL_AGENTS_SID.DEEP_DIVE]: {
+    injectsMemory: false,
+    injectsToolsets: false,
+  },
+  [GLOBAL_AGENTS_SID.DUST_TASK]: {
+    injectsMemory: false,
+    injectsToolsets: false,
+  },
+  [GLOBAL_AGENTS_SID.DUST_BROWSER_SUMMARY]: {
+    injectsMemory: false,
+    injectsToolsets: false,
+  },
+  [GLOBAL_AGENTS_SID.DUST_PLANNING]: {
+    injectsMemory: false,
+    injectsToolsets: false,
+  },
+  [GLOBAL_AGENTS_SID.COPILOT]: { injectsMemory: false, injectsToolsets: false },
+  [GLOBAL_AGENTS_SID.SLACK]: { injectsMemory: false, injectsToolsets: false },
+  [GLOBAL_AGENTS_SID.GOOGLE_DRIVE]: {
+    injectsMemory: false,
+    injectsToolsets: false,
+  },
+  [GLOBAL_AGENTS_SID.NOTION]: { injectsMemory: false, injectsToolsets: false },
+  [GLOBAL_AGENTS_SID.GITHUB]: { injectsMemory: false, injectsToolsets: false },
+  [GLOBAL_AGENTS_SID.INTERCOM]: {
+    injectsMemory: false,
+    injectsToolsets: false,
+  },
+  [GLOBAL_AGENTS_SID.GPT35_TURBO]: {
+    injectsMemory: false,
+    injectsToolsets: false,
+  },
+  [GLOBAL_AGENTS_SID.GPT4]: { injectsMemory: false, injectsToolsets: false },
+  [GLOBAL_AGENTS_SID.GPT5]: { injectsMemory: false, injectsToolsets: false },
+  [GLOBAL_AGENTS_SID.GPT5_THINKING]: {
+    injectsMemory: false,
+    injectsToolsets: false,
+  },
+  [GLOBAL_AGENTS_SID.GPT5_NANO]: {
+    injectsMemory: false,
+    injectsToolsets: false,
+  },
+  [GLOBAL_AGENTS_SID.GPT5_MINI]: {
+    injectsMemory: false,
+    injectsToolsets: false,
+  },
+  [GLOBAL_AGENTS_SID.O1]: { injectsMemory: false, injectsToolsets: false },
+  [GLOBAL_AGENTS_SID.O1_MINI]: { injectsMemory: false, injectsToolsets: false },
+  [GLOBAL_AGENTS_SID.O1_HIGH_REASONING]: {
+    injectsMemory: false,
+    injectsToolsets: false,
+  },
+  [GLOBAL_AGENTS_SID.O3_MINI]: { injectsMemory: false, injectsToolsets: false },
+  [GLOBAL_AGENTS_SID.O3]: { injectsMemory: false, injectsToolsets: false },
+  [GLOBAL_AGENTS_SID.CLAUDE_4_5_HAIKU]: {
+    injectsMemory: false,
+    injectsToolsets: false,
+  },
+  [GLOBAL_AGENTS_SID.CLAUDE_4_5_SONNET]: {
+    injectsMemory: false,
+    injectsToolsets: false,
+  },
+  [GLOBAL_AGENTS_SID.CLAUDE_4_SONNET]: {
+    injectsMemory: false,
+    injectsToolsets: false,
+  },
+  [GLOBAL_AGENTS_SID.CLAUDE_3_OPUS]: {
+    injectsMemory: false,
+    injectsToolsets: false,
+  },
+  [GLOBAL_AGENTS_SID.CLAUDE_3_SONNET]: {
+    injectsMemory: false,
+    injectsToolsets: false,
+  },
+  [GLOBAL_AGENTS_SID.CLAUDE_3_HAIKU]: {
+    injectsMemory: false,
+    injectsToolsets: false,
+  },
+  [GLOBAL_AGENTS_SID.CLAUDE_3_7_SONNET]: {
+    injectsMemory: false,
+    injectsToolsets: false,
+  },
+  [GLOBAL_AGENTS_SID.MISTRAL_LARGE]: {
+    injectsMemory: false,
+    injectsToolsets: false,
+  },
+  [GLOBAL_AGENTS_SID.MISTRAL_MEDIUM]: {
+    injectsMemory: false,
+    injectsToolsets: false,
+  },
+  [GLOBAL_AGENTS_SID.MISTRAL_SMALL]: {
+    injectsMemory: false,
+    injectsToolsets: false,
+  },
+  [GLOBAL_AGENTS_SID.GEMINI_PRO]: {
+    injectsMemory: false,
+    injectsToolsets: false,
+  },
+  [GLOBAL_AGENTS_SID.DEEPSEEK_R1]: {
+    injectsMemory: false,
+    injectsToolsets: false,
+  },
+  [GLOBAL_AGENTS_SID.NOOP]: { injectsMemory: false, injectsToolsets: false },
 };
 
 export function globalAgentInjectsMemory(sId: string): boolean {
   return isGlobalAgentId(sId) && GLOBAL_AGENT_FLAGS[sId].injectsMemory;
+}
+
+export function globalAgentInjectsToolsets(sId: string): boolean {
+  return isGlobalAgentId(sId) && GLOBAL_AGENT_FLAGS[sId].injectsToolsets;
 }
 
 export function isDustLikeAgent(sId: string): boolean {

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -129,17 +129,44 @@ const GLOBAL_AGENT_FLAGS: Record<
     injectsToolsets: true,
   },
   [GLOBAL_AGENTS_SID.DUST_ANT]: { injectsMemory: true, injectsToolsets: true },
-  [GLOBAL_AGENTS_SID.DUST_ANT_MEDIUM]: { injectsMemory: true, injectsToolsets: true },
-  [GLOBAL_AGENTS_SID.DUST_ANT_HIGH]: { injectsMemory: true, injectsToolsets: true },
+  [GLOBAL_AGENTS_SID.DUST_ANT_MEDIUM]: {
+    injectsMemory: true,
+    injectsToolsets: true,
+  },
+  [GLOBAL_AGENTS_SID.DUST_ANT_HIGH]: {
+    injectsMemory: true,
+    injectsToolsets: true,
+  },
   [GLOBAL_AGENTS_SID.DUST_KIMI]: { injectsMemory: true, injectsToolsets: true },
-  [GLOBAL_AGENTS_SID.DUST_KIMI_MEDIUM]: { injectsMemory: true, injectsToolsets: true },
-  [GLOBAL_AGENTS_SID.DUST_KIMI_HIGH]: { injectsMemory: true, injectsToolsets: true },
+  [GLOBAL_AGENTS_SID.DUST_KIMI_MEDIUM]: {
+    injectsMemory: true,
+    injectsToolsets: true,
+  },
+  [GLOBAL_AGENTS_SID.DUST_KIMI_HIGH]: {
+    injectsMemory: true,
+    injectsToolsets: true,
+  },
   [GLOBAL_AGENTS_SID.DUST_GLM]: { injectsMemory: true, injectsToolsets: true },
-  [GLOBAL_AGENTS_SID.DUST_GLM_MEDIUM]: { injectsMemory: true, injectsToolsets: true },
-  [GLOBAL_AGENTS_SID.DUST_GLM_HIGH]: { injectsMemory: true, injectsToolsets: true },
-  [GLOBAL_AGENTS_SID.DUST_MINIMAX]: { injectsMemory: true, injectsToolsets: true },
-  [GLOBAL_AGENTS_SID.DUST_MINIMAX_MEDIUM]: { injectsMemory: true, injectsToolsets: true },
-  [GLOBAL_AGENTS_SID.DUST_MINIMAX_HIGH]: { injectsMemory: true, injectsToolsets: true },
+  [GLOBAL_AGENTS_SID.DUST_GLM_MEDIUM]: {
+    injectsMemory: true,
+    injectsToolsets: true,
+  },
+  [GLOBAL_AGENTS_SID.DUST_GLM_HIGH]: {
+    injectsMemory: true,
+    injectsToolsets: true,
+  },
+  [GLOBAL_AGENTS_SID.DUST_MINIMAX]: {
+    injectsMemory: true,
+    injectsToolsets: true,
+  },
+  [GLOBAL_AGENTS_SID.DUST_MINIMAX_MEDIUM]: {
+    injectsMemory: true,
+    injectsToolsets: true,
+  },
+  [GLOBAL_AGENTS_SID.DUST_MINIMAX_HIGH]: {
+    injectsMemory: true,
+    injectsToolsets: true,
+  },
   [GLOBAL_AGENTS_SID.DUST_NEXT]: {
     injectsMemory: true,
     injectsToolsets: true,

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -575,7 +575,6 @@ function getGlobalAgent({
         settings,
         preFetchedDataSources,
         mcpServerViews,
-        availableToolsets,
         hasDeepDive,
       });
       break;
@@ -584,7 +583,6 @@ function getGlobalAgent({
         settings,
         preFetchedDataSources,
         mcpServerViews,
-        availableToolsets,
         hasDeepDive,
       });
       break;
@@ -593,7 +591,6 @@ function getGlobalAgent({
         settings,
         preFetchedDataSources,
         mcpServerViews,
-        availableToolsets,
         hasDeepDive,
       });
       break;
@@ -602,7 +599,6 @@ function getGlobalAgent({
         settings,
         preFetchedDataSources,
         mcpServerViews,
-        availableToolsets,
         hasDeepDive,
       });
       break;
@@ -611,7 +607,6 @@ function getGlobalAgent({
         settings,
         preFetchedDataSources,
         mcpServerViews,
-        availableToolsets,
         hasDeepDive,
       });
       break;
@@ -620,7 +615,6 @@ function getGlobalAgent({
         settings,
         preFetchedDataSources,
         mcpServerViews,
-        availableToolsets,
         hasDeepDive,
       });
       break;
@@ -629,7 +623,6 @@ function getGlobalAgent({
         settings,
         preFetchedDataSources,
         mcpServerViews,
-        availableToolsets,
         hasDeepDive,
       });
       break;
@@ -638,7 +631,6 @@ function getGlobalAgent({
         settings,
         preFetchedDataSources,
         mcpServerViews,
-        availableToolsets,
         hasDeepDive,
       });
       break;
@@ -647,7 +639,6 @@ function getGlobalAgent({
         settings,
         preFetchedDataSources,
         mcpServerViews,
-        availableToolsets,
         hasDeepDive,
       });
       break;
@@ -656,7 +647,6 @@ function getGlobalAgent({
         settings,
         preFetchedDataSources,
         mcpServerViews,
-        availableToolsets,
         hasDeepDive,
       });
       break;
@@ -665,7 +655,6 @@ function getGlobalAgent({
         settings,
         preFetchedDataSources,
         mcpServerViews,
-        availableToolsets,
         hasDeepDive,
       });
       break;
@@ -674,7 +663,6 @@ function getGlobalAgent({
         settings,
         preFetchedDataSources,
         mcpServerViews,
-        availableToolsets,
         hasDeepDive,
       });
       break;

--- a/front/lib/resources/skill/global/discover_tools.ts
+++ b/front/lib/resources/skill/global/discover_tools.ts
@@ -37,13 +37,5 @@ export const discoverToolsSkill = {
 export function buildDiscoverToolsInstructions(
   availableToolsets: MCPServerViewResource[]
 ): string {
-  const toolsetsContextSection = buildToolsetsContext(availableToolsets);
-
-  return `The "toolsets" tools allow listing and enabling additional tools.
-
-${toolsetsContextSection}
-
-When encountering any request that might benefit from specialized tools, review the available toolsets above.
-Enable relevant toolsets using \`toolsets__enable\` with the toolsetId (shown in backticks) before attempting to fulfill the request.
-Never assume or reply that you cannot do something before checking if there's a relevant toolset available.`;
+  return buildToolsetsContext(availableToolsets);
 }

--- a/front/lib/resources/skill/global/discover_tools.ts
+++ b/front/lib/resources/skill/global/discover_tools.ts
@@ -1,8 +1,5 @@
-import {
-  getMcpServerViewDescription,
-  getMcpServerViewDisplayName,
-} from "@app/lib/actions/mcp_helper";
 import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
+import { buildToolsetsContext } from "@app/lib/api/assistant/global_agents/configurations/dust/dust";
 import type { Authenticator } from "@app/lib/auth";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import type { GlobalSkillDefinition } from "@app/lib/resources/skill/global/registry";
@@ -40,36 +37,11 @@ export const discoverToolsSkill = {
 export function buildDiscoverToolsInstructions(
   availableToolsets: MCPServerViewResource[]
 ): string {
-  const toolsetsList = availableToolsets
-    // Sort by display name, then by sId for deterministic ordering.
-    // This ensures consistent prompt generation for LLM cache optimization,
-    // especially when multiple toolsets share the same display name.
-    .sort((a, b) => {
-      const aView = a.toJSON();
-      const bView = b.toJSON();
-      const nameCompare = getMcpServerViewDisplayName(aView).localeCompare(
-        getMcpServerViewDisplayName(bView)
-      );
-      if (nameCompare !== 0) {
-        return nameCompare;
-      }
-      // Tie-breaker: sort by sId for stable ordering when names are equal.
-      return aView.sId.localeCompare(bView.sId);
-    })
-    .map((toolset) => {
-      const mcpServerView = toolset.toJSON();
-      const sId = mcpServerView.sId;
-      const displayName = getMcpServerViewDisplayName(mcpServerView);
-      const description = getMcpServerViewDescription(mcpServerView);
-      return `- **${displayName}** (toolsetId: \`${sId}\`): ${description}`;
-    })
-    .join("\n");
+  const toolsetsContextSection = buildToolsetsContext(availableToolsets);
 
   return `The "toolsets" tools allow listing and enabling additional tools.
 
-<available_toolsets>
-${toolsetsList.length > 0 ? toolsetsList : "No additional toolsets are currently available."}
-</available_toolsets>
+${toolsetsContextSection}
 
 When encountering any request that might benefit from specialized tools, review the available toolsets above.
 Enable relevant toolsets using \`toolsets__enable\` with the toolsetId (shown in backticks) before attempting to fulfill the request.

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -2,6 +2,7 @@ import { TOOL_NAME_SEPARATOR } from "@app/lib/actions/constants";
 import { buildToolSpecification } from "@app/lib/actions/mcp";
 import { tryListMCPTools } from "@app/lib/actions/mcp_actions";
 import type { InternalMCPServerNameType } from "@app/lib/actions/mcp_internal_actions/constants";
+import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import type { StepContext } from "@app/lib/actions/types";
 import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { isServerSideMCPServerConfigurationWithName } from "@app/lib/actions/types/guards";
@@ -10,7 +11,6 @@ import { createClientSideMCPServerConfigurations } from "@app/lib/api/actions/mc
 import { getAgentConfigurationsForView } from "@app/lib/api/assistant/configuration/views";
 import { renderConversationForModel } from "@app/lib/api/assistant/conversation_rendering";
 import { categorizeConversationRenderErrorMessage } from "@app/lib/api/assistant/errors";
-import { getMCPServerRequirements } from "@app/lib/actions/mcp_internal_actions/input_configuration";
 import { constructPromptMultiActions } from "@app/lib/api/assistant/generation";
 import {
   buildMemoriesContext,
@@ -46,8 +46,8 @@ import { getSupportedModelConfig } from "@app/lib/llms/model_configurations";
 import { AgentMemoryResource } from "@app/lib/resources/agent_memory_resource";
 import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
-import { SpaceResource } from "@app/lib/resources/space_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import logger from "@app/logger/logger";
 import tracer from "@app/logger/tracer";

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -303,10 +303,7 @@ export async function runModel(
   const hasToolsetsAction = agentConfiguration.actions.some((action) =>
     isServerSideMCPServerConfigurationWithName(action, "toolsets")
   );
-  if (
-    globalAgentInjectsToolsets(agentConfiguration.sId) &&
-    hasToolsetsAction
-  ) {
+  if (globalAgentInjectsToolsets(agentConfiguration.sId) && hasToolsetsAction) {
     const globalSpace = await SpaceResource.fetchWorkspaceGlobalSpace(auth);
     const allToolsets = await MCPServerViewResource.listBySpace(
       auth,

--- a/front/temporal/agent_loop/lib/run_model.ts
+++ b/front/temporal/agent_loop/lib/run_model.ts
@@ -16,7 +16,10 @@ import {
   buildMemoriesContext,
   buildToolsetsContext,
 } from "@app/lib/api/assistant/global_agents/configurations/dust/dust";
-import { globalAgentInjectsMemory } from "@app/lib/api/assistant/global_agents/global_agents";
+import {
+  globalAgentInjectsMemory,
+  globalAgentInjectsToolsets,
+} from "@app/lib/api/assistant/global_agents/global_agents";
 import { getJITServers } from "@app/lib/api/assistant/jit_actions";
 import { listAttachments } from "@app/lib/api/assistant/jit_utils";
 import { isLegacyAgentConfiguration } from "@app/lib/api/assistant/legacy_agent";
@@ -300,7 +303,10 @@ export async function runModel(
   const hasToolsetsAction = agentConfiguration.actions.some((action) =>
     isServerSideMCPServerConfigurationWithName(action, "toolsets")
   );
-  if (hasToolsetsAction) {
+  if (
+    globalAgentInjectsToolsets(agentConfiguration.sId) &&
+    hasToolsetsAction
+  ) {
     const globalSpace = await SpaceResource.fetchWorkspaceGlobalSpace(auth);
     const allToolsets = await MCPServerViewResource.listBySpace(
       auth,


### PR DESCRIPTION
## Description

- This PR moves the part of the prompt of the dust global agent relative to toolsets, with the list of available toolsets notably, to a context block.
- This changes the order of the instructions overall, but not major change in behavior expected.
- The goal is to categorize more efficiently the dynamic parts of the prompt to optimize our caching strategy.

## Tests

- Tested locally.

## Risk

- Medium.

## Deploy Plan

- Deploy front.
