### PR TITLE
Move stable prompt sections into cacheable instructions block for dust agents

### DIFF
--- a/front/lib/api/assistant/generation.test.ts
+++ b/front/lib/api/assistant/generation.test.ts
@@ -399,16 +399,14 @@ describe("constructPromptMultiActions - system prompt stability", () => {
     };
 
     const sections = constructPromptMultiActions(authenticator1, params);
-    const [, context] = normalizePrompt(sections);
+    const [instructions, context] = normalizePrompt(sections);
 
-    // Instructions section should contain memory_guidelines.
-    const instructionsSection = context.find((s) =>
-      s.content.includes("<memory_guidelines>")
-    );
-    expect(instructionsSection).toBeDefined();
+    // Dust-like agents use the tuple form: memory_guidelines are in instructions.
+    expect(instructions).toHaveLength(1);
+    expect(instructions[0].content).toContain("<memory_guidelines>");
+    expect(instructions[0].content).not.toContain("<existing_memories>");
 
-    // existing_memories should be in a separate context section, not in the instructions section.
-    expect(instructionsSection?.content).not.toContain("<existing_memories>");
+    // existing_memories should be in a separate context section.
     const memoriesSection = context.find((s) =>
       s.content.includes("<existing_memories>")
     );

--- a/front/lib/api/assistant/generation.ts
+++ b/front/lib/api/assistant/generation.ts
@@ -18,6 +18,7 @@ import {
 import { CONVERSATION_CAT_FILE_ACTION_NAME } from "@app/lib/api/actions/servers/conversation_files/metadata";
 import { PROJECT_MANAGER_SERVER_NAME } from "@app/lib/api/actions/servers/project_manager/metadata";
 import { citationMetaPrompt } from "@app/lib/api/assistant/citations";
+import { isDustLikeAgent } from "@app/lib/api/assistant/global_agents/global_agents";
 import type {
   SystemPromptContext,
   SystemPromptSections,
@@ -419,8 +420,10 @@ export function constructPromptMultiActions(
   // Global agents with fully static instructions (no per-user data baked in) use the tuple form
   // [instructions, context] which enables extended prompt caching. Per-user dynamic content like
   // memories is passed as a separate context section so it doesn't pollute instruction caching.
+  // Only enabled for `deep-dive` and `dust(-x)` agents.
   const hasStaticInstructions =
-    agentConfiguration.sId === GLOBAL_AGENTS_SID.DEEP_DIVE;
+    agentConfiguration.sId === GLOBAL_AGENTS_SID.DEEP_DIVE ||
+    isDustLikeAgent(agentConfiguration.sId);
 
   const instructionsContent = constructInstructionsSection({
     agentConfiguration,
@@ -428,59 +431,76 @@ export function constructPromptMultiActions(
     agentsList,
   });
 
-  const contextSections: SystemPromptContext[] = [
-    {
-      role: "context" as const,
-      content: constructContextSection({
-        agentConfiguration,
-        errorContext,
-        model,
-        owner,
-        userMessage,
-      }),
-    },
-    {
-      role: "context" as const,
-      content: constructProjectContextSection(conversation) ?? "",
-    },
-    {
-      role: "context" as const,
-      content: constructToolsSection({
-        hasAvailableActions,
-        model,
-        agentConfiguration,
-        serverToolsAndInstructions,
-      }),
-    },
-    {
-      role: "context" as const,
-      content: constructSkillsSection({
-        enabledSkills,
-        equippedSkills,
-      }),
-    },
-    { role: "context" as const, content: constructAttachmentsSection() },
-    { role: "context" as const, content: constructPastedContentSection() },
-    {
-      role: "context" as const,
-      content: constructGuidelinesSection({
-        agentConfiguration,
-      }),
-    },
-    { role: "context" as const, content: memoriesContext ?? "" },
-  ].filter((s) => s.content.trim() !== "");
+  const contextSection = constructContextSection({
+    agentConfiguration,
+    errorContext,
+    model,
+    owner,
+    userMessage,
+  });
+  const projectContextSection =
+    constructProjectContextSection(conversation) ?? "";
+  const toolsSection = constructToolsSection({
+    hasAvailableActions,
+    model,
+    agentConfiguration,
+    serverToolsAndInstructions,
+  });
+  const skillsSection = constructSkillsSection({
+    enabledSkills,
+    equippedSkills,
+  });
+  const attachmentsSection = constructAttachmentsSection();
+  const pastedContentSection = constructPastedContentSection();
+  const guidelinesSection = constructGuidelinesSection({ agentConfiguration });
 
   if (hasStaticInstructions) {
-    // Tuple form: instructions first, then context. Enables extended caching.
+    // Tuple form [instructions, context] for prompt caching.
+    //
+    // The instructions block is cached across calls. It contains content that is
+    // stable for a given agent configuration: agent instructions, tools
+    // (directives + server listing), skills, format docs, and guidelines.
+    // Tools and skills can vary when JIT servers or mid-conversation skill
+    // activation occur, but this is uncommon enough that the cache hit rate
+    // is still favorable.
+    //
+    // The context block contains per-call dynamic content: date, conversation
+    // project, and user memories.
+    const fullInstructions = [
+      instructionsContent,
+      toolsSection,
+      skillsSection,
+      attachmentsSection,
+      pastedContentSection,
+      guidelinesSection,
+    ]
+      .filter((s) => s.trim() !== "")
+      .join("\n");
+
+    const dynamicContext: SystemPromptContext[] = [
+      { role: "context" as const, content: contextSection },
+      { role: "context" as const, content: projectContextSection },
+      { role: "context" as const, content: memoriesContext ?? "" },
+    ].filter((s) => s.content.trim() !== "");
+
     return [
-      [{ role: "instruction", content: instructionsContent }],
-      contextSections,
+      [{ role: "instruction", content: fullInstructions }],
+      dynamicContext,
     ];
   }
 
-  // Flat context-only form: instructions go into context alongside everything else.
-  return [
-    { role: "context", content: instructionsContent },
-    ...contextSections,
-  ];
+  // Flat context-only form: everything goes into context. Original section order.
+  const allSections: SystemPromptContext[] = [
+    { role: "context" as const, content: instructionsContent },
+    { role: "context" as const, content: contextSection },
+    { role: "context" as const, content: projectContextSection },
+    { role: "context" as const, content: toolsSection },
+    { role: "context" as const, content: skillsSection },
+    { role: "context" as const, content: attachmentsSection },
+    { role: "context" as const, content: pastedContentSection },
+    { role: "context" as const, content: guidelinesSection },
+    { role: "context" as const, content: memoriesContext ?? "" },
+  ].filter((s) => s.content.trim() !== "");
+
+  return allSections;
 }

--- a/front/lib/api/assistant/global_agents/global_agents.ts
+++ b/front/lib/api/assistant/global_agents/global_agents.ts
@@ -149,7 +149,7 @@ export function globalAgentInjectsMemory(sId: string): boolean {
   return isGlobalAgentId(sId) && GLOBAL_AGENT_FLAGS[sId].injectsMemory;
 }
 
-function isDustLikeAgent(sId: string): boolean {
+export function isDustLikeAgent(sId: string): boolean {
   return isGlobalAgentId(sId) && GLOBAL_AGENT_FLAGS[sId].injectsMemory;
 }
 


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->
This PR aims at improving the cache hit for `@dust` and `@deep-dive` global agent.

It focuses around re-structuring `constructPromptMultiActions` into a cached instructions block and a dynamic context block for `dust(-like)` and `deep-dive` agents (tuple form). Instructions block contains stable content: agent instructions, tools, skills, attachments/pasted content format docs, and guidelines (all at least workspace-based).

All other agents are not being changed.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->
We are shuffling around the order of instructions a bit. Safe to rollback.

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
