### PR TITLE
[front] enh(frames): allow searching templates from agent data sources

### DIFF
--- a/front/lib/api/actions/servers/interactive_content/template_utils.ts
+++ b/front/lib/api/actions/servers/interactive_content/template_utils.ts
@@ -52,12 +52,10 @@ export async function fetchTemplateContent(
   });
 
   // Get merged data source configurations from skills.
-  const skillDataSourceConfigurations = await getSkillDataSourceConfigurations(
-    auth,
-    {
+  const { documentDataSourceConfigurations: skillDataSourceConfigurations } =
+    await getSkillDataSourceConfigurations(auth, {
       skills: enabledSkills,
-    }
-  );
+    });
 
   // Also collect data source configurations from the agent's actions.
   const actionDataSourceConfigurations: DataSourceConfiguration[] =

--- a/front/lib/api/actions/servers/interactive_content/template_utils.ts
+++ b/front/lib/api/actions/servers/interactive_content/template_utils.ts
@@ -52,10 +52,12 @@ export async function fetchTemplateContent(
   });
 
   // Get merged data source configurations from skills.
-  const { documentDataSourceConfigurations: skillDataSourceConfigurations } =
-    await getSkillDataSourceConfigurations(auth, {
+  const skillDataSourceConfigurations = await getSkillDataSourceConfigurations(
+    auth,
+    {
       skills: enabledSkills,
-    });
+    }
+  );
 
   // Also collect data source configurations from the agent's actions.
   const actionDataSourceConfigurations: DataSourceConfiguration[] =

--- a/front/lib/api/actions/servers/interactive_content/template_utils.ts
+++ b/front/lib/api/actions/servers/interactive_content/template_utils.ts
@@ -65,19 +65,10 @@ export async function fetchTemplateContent(
       .filter(isServerSideMCPServerConfiguration)
       .flatMap((action) => action.dataSources ?? []);
 
-  // Merge both sources, deduplicating by dataSourceViewId.
-  const dataSourceConfigsByViewId = new Map<string, DataSourceConfiguration>();
-  for (const config of [
+  const dataSourceConfigurations = [
     ...skillDataSourceConfigurations,
     ...actionDataSourceConfigurations,
-  ]) {
-    if (!dataSourceConfigsByViewId.has(config.dataSourceViewId)) {
-      dataSourceConfigsByViewId.set(config.dataSourceViewId, config);
-    }
-  }
-  const dataSourceConfigurations = Array.from(
-    dataSourceConfigsByViewId.values()
-  );
+  ];
 
   if (dataSourceConfigurations.length === 0) {
     return new Err(

--- a/front/lib/api/actions/servers/interactive_content/template_utils.ts
+++ b/front/lib/api/actions/servers/interactive_content/template_utils.ts
@@ -1,6 +1,11 @@
 import { MCPError } from "@app/lib/actions/mcp_errors";
-import { makeCoreSearchNodesFilters } from "@app/lib/actions/mcp_internal_actions/tools/utils";
+import {
+  makeCoreSearchNodesFilters,
+  type ResolvedDataSourceConfiguration,
+} from "@app/lib/actions/mcp_internal_actions/tools/utils";
 import type { AgentLoopRunContextType } from "@app/lib/actions/types";
+import { isServerSideMCPServerConfiguration } from "@app/lib/actions/types/guards";
+import type { DataSourceConfiguration } from "@app/lib/api/assistant/configuration/types";
 import { getSkillDataSourceConfigurations } from "@app/lib/api/assistant/skill_actions";
 import config from "@app/lib/api/config";
 import type { Authenticator } from "@app/lib/auth";
@@ -15,7 +20,7 @@ import { Err, Ok } from "@app/types/shared/result";
 const MAX_TEMPLATE_SIZE_BYTES = 1 * 1024 * 1024; // 1MB
 
 /**
- * Fetches template content from a knowledge node using the agent's skills configuration.
+ * Fetches template content from a knowledge node using the agent's skills and action data sources.
  */
 export async function fetchTemplateContent(
   auth: Authenticator,
@@ -47,23 +52,43 @@ export async function fetchTemplateContent(
   });
 
   // Get merged data source configurations from skills.
-  const { documentDataSourceConfigurations: dataSourceConfigurations } =
+  const { documentDataSourceConfigurations: skillDataSourceConfigurations } =
     await getSkillDataSourceConfigurations(auth, {
       skills: enabledSkills,
     });
 
+  // Also collect data source configurations from the agent's actions.
+  const actionDataSourceConfigurations: DataSourceConfiguration[] =
+    agentConfiguration.actions
+      .filter(isServerSideMCPServerConfiguration)
+      .flatMap((action) => action.dataSources ?? []);
+
+  // Merge both sources, deduplicating by dataSourceViewId.
+  const dataSourceConfigsByViewId = new Map<string, DataSourceConfiguration>();
+  for (const config of [
+    ...skillDataSourceConfigurations,
+    ...actionDataSourceConfigurations,
+  ]) {
+    if (!dataSourceConfigsByViewId.has(config.dataSourceViewId)) {
+      dataSourceConfigsByViewId.set(config.dataSourceViewId, config);
+    }
+  }
+  const dataSourceConfigurations = Array.from(
+    dataSourceConfigsByViewId.values()
+  );
+
   if (dataSourceConfigurations.length === 0) {
     return new Err(
       new MCPError(
-        "No data sources found in skills configuration. " +
-          "Template nodes can only be used when the agent has skills with attached knowledge.",
+        "No data sources found in agent configuration. " +
+          "Template nodes can only be used when the agent has data sources attached.",
         { tracked: false }
       )
     );
   }
 
   // Resolve DataSourceConfiguration[] to ResolvedDataSourceConfiguration[].
-  const agentDataSourceConfigurations = [];
+  const agentDataSourceConfigurations: ResolvedDataSourceConfiguration[] = [];
   const dataSourceViews = await DataSourceViewResource.fetchByIds(
     auth,
     dataSourceConfigurations.map((c) => c.dataSourceViewId)
@@ -115,7 +140,7 @@ export async function fetchTemplateContent(
         `Could not find template node: ${templateNodeId}. ${
           searchResult.isErr()
             ? `Error: ${searchResult.error.message}`
-            : "The node may not exist or may not be accessible through your skills configuration."
+            : "The node may not exist or may not be accessible through the agent's configuration."
         }`,
         { tracked: false }
       )


### PR DESCRIPTION
## Description

- This PR allows agents to use Frame templates from the data sources configured on the agent.
- Up to now only skill data sources are allowed.
- Allows agents to find a template via an `ls` and use it to create a Frame.
- Allows doing stuff like:
<img width="996" height="474" alt="Screenshot 2026-02-16 at 6 12 43 PM" src="https://github.com/user-attachments/assets/657574c5-3f2b-4775-a691-0803f27e2765" />

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
