### PR TITLE
[Projects] Kickoff convo: Skip initial message in list preview

### DIFF
--- a/front/components/assistant/conversation/space/conversations/SpaceConversationListItem.tsx
+++ b/front/components/assistant/conversation/space/conversations/SpaceConversationListItem.tsx
@@ -24,13 +24,6 @@ export function SpaceConversationListItem({
   owner,
 }: SpaceConversationListItemProps) {
   const router = useAppRouter();
-  const firstVisibleMessage = conversation.content.find((message) => {
-    if (!isUserMessageTypeWithContentFragments(message)) {
-      return true;
-    }
-    return !isHiddenMessage(message);
-  });
-
   const firstUserMessage = conversation.content.find(
     isUserMessageTypeWithContentFragments
   );
@@ -89,6 +82,21 @@ export function SpaceConversationListItem({
 
   const replyCount = conversation.content.length - 1;
 
+  let firstMessageForDescription: LightConversationType["content"][number] =
+    firstUserMessage;
+  if (isHiddenMessage(firstUserMessage)) {
+    const firstNonHiddenMessage = conversation.content.find((message) => {
+      if (!isUserMessageTypeWithContentFragments(message)) {
+        return true;
+      }
+      return !isHiddenMessage(message);
+    });
+
+    if (firstNonHiddenMessage) {
+      firstMessageForDescription = firstNonHiddenMessage;
+    }
+  }
+
   return (
     <>
       <ConversationListItem
@@ -96,7 +104,7 @@ export function SpaceConversationListItem({
         conversation={{
           id: conversation.sId,
           title: conversationLabel,
-          description: stripMarkdown(firstVisibleMessage?.content ?? ""),
+          description: stripMarkdown(firstMessageForDescription.content ?? ""),
           updatedAt: new Date(conversation.updated),
         }}
         creator={{

--- a/front/components/assistant/conversation/space/conversations/SpaceConversationListItem.tsx
+++ b/front/components/assistant/conversation/space/conversations/SpaceConversationListItem.tsx
@@ -83,7 +83,7 @@ export function SpaceConversationListItem({
     undefined;
 
   let conversationLabel: string;
-  if (conversation.title) {
+  if (conversation.title !== null) {
     conversationLabel = conversation.title;
   } else {
     if (moment(conversation.created).isSame(moment(), "day")) {


### PR DESCRIPTION
## Description
Project kickoff conversations start with a hidden bootstrap user message (origin `project_kickoff`). The conversation list preview previously always used the first user message, so it could surface that hidden kickoff text.

<img width="1332" height="180" alt="image" src="https://github.com/user-attachments/assets/6fdd4f2c-209b-4152-a4e8-2ebb3aee337d" />


This PR keeps the existing behavior by default (use first user message), and adds one exception: when that first user message is hidden, we instead use the first non-hidden message (user or agent) for the preview description.

## Risks
Blast radius: project space conversation list preview description text
Risk: low

## Deploy Plan
- deploy front
