### PR TITLE
[front] chore: Bump up Sequelize pool to 80

### DIFF
--- a/front/lib/resources/storage/index.ts
+++ b/front/lib/resources/storage/index.ts
@@ -90,7 +90,7 @@ function getPoolMaxForService(): number {
   const service = config.getServiceName();
 
   // DO NOT BLINDLY INCREASE THIS NUMBER (see comment below).
-  return service && WEB_SERVING_SERVICES.has(service) ? 40 : 25;
+  return service && WEB_SERVING_SERVICES.has(service) ? 80 : 25;
 }
 
 export const frontSequelize = new SequelizeWithComments(


### PR DESCRIPTION
## Description

https://dust4ai.slack.com/archives/C05B529FHV1/p1771073860637529?thread_ts=1771065421.360329&cid=C05B529FHV1

Increasing the connection pool because even at 40, random agent_mcp_action_output_items queries can cause pool exhaustion.
We are well under 100 max pool size, and well under 5k max clients. ✅ 

## Tests

N/A

## Risk

Low
Blast Radius: Whole application

## Deploy Plan

- [ ] Deploy front