### PR TITLE
Reverse feature-flag

### DIFF
--- a/front/lib/auth/appServerSideProps.ts
+++ b/front/lib/auth/appServerSideProps.ts
@@ -30,7 +30,7 @@ const redirectToDustSpa = async (
   const workspace = auth.getNonNullableWorkspace();
   const featureFlags = await getFeatureFlags(workspace);
 
-  if (!isEdge && featureFlags.includes("dust_spa")) {
+  if (!isEdge && !featureFlags.includes("dust_no_spa")) {
     const appUrl = config.getAppUrl(true) || DEFAULT_APP_URL;
 
     const destination = context.resolvedUrl;


### PR DESCRIPTION
## Description

Inverts the SPA redirect logic: all requests are now redirected to the SPA by default, unless the `dust_no_spa` feature flag is enabled for the workspace.

- Replaces the `dust_spa` opt-in flag with a `dust_no_spa` opt-out flag
- Updates the condition in `redirectToDustSpa` to redirect unless `dust_no_spa` is present
- Updates SDK types accordingly

## Tests

Manual review — the change is a simple condition inversion.

## Risk

**Medium** — This changes the default behavior from "no SPA" to "SPA for everyone". Workspaces that need to opt out must have the `dust_no_spa` flag set before deploy. Safe to rollback by reverting.

## Deploy Plan

When ready to switch all workspaces : 
1. Ensure `dust_no_spa` flag is set for any workspaces that should not be redirected to the SPA
2. Update NEXT_PUBLIC_DUST_APP_URL secret 
3. Deploy front + spa
