### PR TITLE
[front] enh: List/Search private conversations with paginate

### DIFF
--- a/front/components/assistant/conversation/BlockedActionsProvider.tsx
+++ b/front/components/assistant/conversation/BlockedActionsProvider.tsx
@@ -1,7 +1,6 @@
 import { useConversations } from "@app/hooks/conversations";
 import type { BlockedToolExecution } from "@app/lib/actions/mcp";
 import { useBlockedActions } from "@app/lib/swr/blocked_actions";
-import type { GetConversationsResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { ReactNode } from "react";
@@ -229,16 +228,12 @@ export function BlockedActionsProvider({
       // We only show the conversation in unread inbox if actionRequired is true (and this happens only when you come back to a conversation
       // since we don't update this value on frontend side), so we don't have to update the cache if it's not in the unread inbox.
       void mutateConversations(
-        (currentData: GetConversationsResponseBody | undefined) =>
-          currentData
-            ? {
-                conversations: currentData.conversations.map((c) =>
-                  c.sId === conversationId && c.actionRequired
-                    ? { ...c, actionRequired: false }
-                    : c
-                ),
-              }
-            : undefined,
+        (currentData: ConversationWithoutContentType[] | undefined) =>
+          currentData?.map((c) =>
+            c.sId === conversationId && c.actionRequired
+              ? { ...c, actionRequired: false }
+              : c
+          ),
         { revalidate: false }
       );
     },

--- a/front/components/assistant/conversation/ConversationContainer.tsx
+++ b/front/components/assistant/conversation/ConversationContainer.tsx
@@ -14,7 +14,7 @@ import type { DustError } from "@app/lib/error";
 import { useAppRouter } from "@app/lib/platform";
 import { classNames } from "@app/lib/utils";
 import { getConversationRoute } from "@app/lib/utils/router";
-import type { GetConversationsResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { RichMention } from "@app/types/assistant/mentions";
 import {
   toMentionType,
@@ -114,13 +114,11 @@ export function ConversationContainerVirtuoso({
         );
 
         await mutateConversations(
-          (currentData: GetConversationsResponseBody | undefined) => ({
+          (currentData: ConversationWithoutContentType[] | undefined) => [
             // Immediately update the list of conversations in the sidebar by adding the new conversation.
-            conversations: [
-              ...(currentData?.conversations ?? []),
-              conversationRes.value,
-            ],
-          }),
+            ...(currentData ?? []),
+            conversationRes.value,
+          ],
           { revalidate: false }
         );
 

--- a/front/components/assistant/conversation/ConversationViewer.tsx
+++ b/front/components/assistant/conversation/ConversationViewer.tsx
@@ -33,7 +33,6 @@ import type { DustError } from "@app/lib/error";
 import { AgentMessageCompletedEvent } from "@app/lib/notifications/events";
 import { useSpaceInfo } from "@app/lib/swr/spaces";
 import { classNames } from "@app/lib/utils";
-import type { GetConversationsResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations";
 import type {
   AgentGenerationCancelledEvent,
   AgentMessageDoneEvent,
@@ -41,6 +40,7 @@ import type {
 import type {
   AgentMessageNewEvent,
   ConversationTitleEvent,
+  ConversationWithoutContentType,
   LightMessageType,
   UserMessageNewEvent,
 } from "@app/types/assistant/conversation";
@@ -370,16 +370,12 @@ export const ConversationViewer = ({
                 );
 
                 void mutateConversations(
-                  (currentData: GetConversationsResponseBody | undefined) =>
-                    currentData
-                      ? {
-                          conversations: currentData.conversations.map((c) =>
-                            c.sId === conversationId
-                              ? { ...c, hasError: false, unread: false }
-                              : c
-                          ),
-                        }
-                      : undefined,
+                  (currentData: ConversationWithoutContentType[] | undefined) =>
+                    currentData?.map((c) =>
+                      c.sId === conversationId
+                        ? { ...c, hasError: false, unread: false }
+                        : c
+                    ),
                   { revalidate: false }
                 );
               }
@@ -440,16 +436,10 @@ export const ConversationViewer = ({
 
             // to refresh the list of convos in the sidebar (title)
             void mutateConversations(
-              (currentData: GetConversationsResponseBody | undefined) =>
-                currentData
-                  ? {
-                      conversations: currentData.conversations.map((c) =>
-                        c.sId === conversationId
-                          ? { ...c, title: event.title }
-                          : c
-                      ),
-                    }
-                  : undefined,
+              (currentData: ConversationWithoutContentType[] | undefined) =>
+                currentData?.map((c) =>
+                  c.sId === conversationId ? { ...c, title: event.title } : c
+                ),
               { revalidate: false }
             );
 
@@ -461,16 +451,12 @@ export const ConversationViewer = ({
 
             // Update the conversation hasError state in the local cache without making a network request.
             void mutateConversations(
-              (currentData: GetConversationsResponseBody | undefined) =>
-                currentData
-                  ? {
-                      conversations: currentData.conversations.map((c) =>
-                        c.sId === event.conversationId
-                          ? { ...c, hasError: event.status === "error" }
-                          : c
-                      ),
-                    }
-                  : undefined,
+              (currentData: ConversationWithoutContentType[] | undefined) =>
+                currentData?.map((c) =>
+                  c.sId === event.conversationId
+                    ? { ...c, hasError: event.status === "error" }
+                    : c
+                ),
               { revalidate: false }
             );
 
@@ -625,16 +611,12 @@ export const ConversationViewer = ({
       );
 
       void mutateConversations(
-        (currentData: GetConversationsResponseBody | undefined) =>
-          currentData
-            ? {
-                conversations: currentData.conversations.map((c) =>
-                  c.sId === conversationId
-                    ? { ...c, updated: new Date().getTime() }
-                    : c
-                ),
-              }
-            : undefined,
+        (currentData: ConversationWithoutContentType[] | undefined) =>
+          currentData?.map((c) =>
+            c.sId === conversationId
+              ? { ...c, updated: new Date().getTime() }
+              : c
+          ),
         { revalidate: false }
       );
 

--- a/front/hooks/conversations/index.ts
+++ b/front/hooks/conversations/index.ts
@@ -24,6 +24,8 @@ export {
   useConversationTools,
 } from "./useConversationTools";
 export { usePostOnboardingFollowUp } from "./usePostOnboardingFollowUp";
+export { useSearchPrivateConversations } from "./useSearchPrivateConversations";
+export { useSearchProjectConversations } from "./useSearchProjectConversations";
 export {
   useSpaceConversations,
   useSpaceConversationsSummary,

--- a/front/hooks/conversations/useConversationMarkAsRead.ts
+++ b/front/hooks/conversations/useConversationMarkAsRead.ts
@@ -1,6 +1,5 @@
 import { clientFetch } from "@app/lib/egress/client";
 import logger from "@app/logger/logger";
-import type { GetConversationsResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations";
 import type { PatchConversationsRequestBody } from "@app/pages/api/w/[wId]/assistant/conversations/[cId]";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import { isProjectConversation } from "@app/types/assistant/conversation";
@@ -53,14 +52,10 @@ export function useConversationMarkAsRead({
         }
         if (options?.mutateList) {
           void mutateConversations(
-            (prevState: GetConversationsResponseBody | undefined) =>
-              prevState
-                ? {
-                    conversations: prevState.conversations.map((c) =>
-                      c.sId === conversationId ? { ...c, unread: false } : c
-                    ),
-                  }
-                : undefined,
+            (prevState: ConversationWithoutContentType[] | undefined) =>
+              prevState?.map((c) =>
+                c.sId === conversationId ? { ...c, unread: false } : c
+              ),
             { revalidate: false }
           );
         }

--- a/front/hooks/conversations/useConversations.ts
+++ b/front/hooks/conversations/useConversations.ts
@@ -1,26 +1,123 @@
-import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
+import {
+  emptyArray,
+  fetcher,
+  useSWRInfiniteWithDefaults,
+} from "@app/lib/swr/swr";
 import type { GetConversationsResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import { useCallback, useMemo } from "react";
 import type { Fetcher } from "swr";
+import type { SWRInfiniteMutatorOptions } from "swr/infinite";
+
+const DEFAULT_LIMIT = 100;
+
+type ConversationsUpdater = (
+  prevData: ConversationWithoutContentType[] | undefined
+) => ConversationWithoutContentType[] | undefined;
+
+type MutateOptions = {
+  revalidate?: boolean;
+};
 
 export function useConversations({
   workspaceId,
-  options,
+  limit = DEFAULT_LIMIT,
 }: {
   workspaceId: string;
-  options?: { disabled: boolean };
+  limit?: number;
 }) {
-  const conversationFetcher: Fetcher<GetConversationsResponseBody> = fetcher;
+  const conversationsFetcher: Fetcher<GetConversationsResponseBody> = fetcher;
 
-  const { data, error, mutate } = useSWRWithDefaults(
-    `/api/w/${workspaceId}/assistant/conversations`,
-    conversationFetcher,
-    options
+  const { data, error, mutate, size, setSize, isValidating } =
+    useSWRInfiniteWithDefaults(
+      (
+        pageIndex: number,
+        previousPageData: GetConversationsResponseBody | null
+      ) => {
+        if (previousPageData && !previousPageData.hasMore) {
+          return null;
+        }
+
+        const baseUrl = `/api/w/${workspaceId}/assistant/conversations?limit=${limit}`;
+
+        if (previousPageData === null) {
+          return baseUrl;
+        }
+
+        return `${baseUrl}&lastValue=${previousPageData.lastValue}`;
+      },
+      conversationsFetcher,
+      {
+        revalidateAll: false,
+        revalidateFirstPage: false,
+        revalidateOnFocus: false,
+        revalidateOnReconnect: false,
+      }
+    );
+
+  const conversations = useMemo(() => {
+    if (!data) {
+      return emptyArray<ConversationWithoutContentType>();
+    }
+    return data.flatMap((page) => page.conversations);
+  }, [data]);
+
+  const hasMore = data ? (data[data.length - 1]?.hasMore ?? false) : false;
+
+  const loadMore = useCallback(() => {
+    if (hasMore && !isValidating) {
+      void setSize(size + 1);
+    }
+  }, [hasMore, isValidating, setSize, size]);
+
+  const mutateConversations = useCallback(
+    (updater?: ConversationsUpdater, options?: MutateOptions) => {
+      if (!updater) {
+        return mutate();
+      }
+
+      const swrOptions: SWRInfiniteMutatorOptions<
+        GetConversationsResponseBody[]
+      > = {
+        revalidate: options?.revalidate ?? true,
+      };
+
+      return mutate((prevPages) => {
+        if (!prevPages) {
+          return prevPages;
+        }
+
+        const allConversations = prevPages.flatMap(
+          (page) => page.conversations
+        );
+        const updatedConversations = updater(allConversations);
+
+        if (!updatedConversations) {
+          return prevPages;
+        }
+
+        let remaining = [...updatedConversations];
+        return prevPages.map((page) => {
+          const pageSize = page.conversations.length;
+          const pageConversations = remaining.slice(0, pageSize);
+          remaining = remaining.slice(pageSize);
+          return {
+            ...page,
+            conversations: pageConversations,
+          };
+        });
+      }, swrOptions);
+    },
+    [mutate]
   );
 
   return {
-    conversations: data?.conversations ?? emptyArray(),
+    conversations,
     isConversationsLoading: !error && !data,
     isConversationsError: error,
-    mutateConversations: mutate,
+    mutateConversations,
+    hasMore,
+    loadMore,
+    isLoadingMore: isValidating && size > 1,
   };
 }

--- a/front/hooks/conversations/useSearchPrivateConversations.ts
+++ b/front/hooks/conversations/useSearchPrivateConversations.ts
@@ -1,0 +1,95 @@
+import {
+  emptyArray,
+  fetcher,
+  useSWRInfiniteWithDefaults,
+} from "@app/lib/swr/swr";
+import type { SearchConversationsResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations/search";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { Fetcher } from "swr";
+
+type PrivateConversationSearchResult =
+  SearchConversationsResponseBody["conversations"][number];
+
+interface UseSearchPrivateConversationsParams {
+  workspaceId: string;
+  enabled?: boolean;
+  query?: string;
+  limit?: number;
+}
+
+export function useSearchPrivateConversations({
+  workspaceId,
+  enabled = true,
+  query = "",
+  limit = 20,
+}: UseSearchPrivateConversationsParams) {
+  const [debouncedQuery, setDebouncedQuery] = useState(query);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedQuery(query), 300);
+    return () => clearTimeout(timer);
+  }, [query]);
+
+  const isDebouncing = query !== debouncedQuery;
+
+  const shouldFetch = useMemo(() => {
+    return !!(enabled && workspaceId && debouncedQuery.trim().length > 0);
+  }, [enabled, workspaceId, debouncedQuery]);
+
+  const searchFetcher: Fetcher<SearchConversationsResponseBody> = fetcher;
+
+  const { data, error, size, setSize, isValidating } =
+    useSWRInfiniteWithDefaults(
+      (
+        pageIndex: number,
+        previousPageData: SearchConversationsResponseBody | null
+      ) => {
+        if (!shouldFetch) {
+          return null;
+        }
+
+        if (previousPageData && !previousPageData.hasMore) {
+          return null;
+        }
+
+        if (previousPageData === null) {
+          return `/api/w/${workspaceId}/assistant/conversations/search?query=${encodeURIComponent(debouncedQuery)}&limit=${limit}`;
+        }
+
+        return `/api/w/${workspaceId}/assistant/conversations/search?query=${encodeURIComponent(debouncedQuery)}&limit=${limit}&lastValue=${previousPageData.lastValue}`;
+      },
+      searchFetcher,
+      {
+        revalidateAll: false,
+        revalidateOnFocus: false,
+        revalidateOnReconnect: false,
+      }
+    );
+
+  const conversations = useMemo(() => {
+    if (!data) {
+      return emptyArray<PrivateConversationSearchResult>();
+    }
+    return data.flatMap((page) => page.conversations);
+  }, [data]);
+
+  const hasMore = data ? (data[data.length - 1]?.hasMore ?? false) : false;
+
+  const loadMore = useCallback(() => {
+    if (hasMore && !isValidating) {
+      void setSize(size + 1);
+    }
+  }, [hasMore, isValidating, setSize, size]);
+
+  return {
+    conversations: conversations as ConversationWithoutContentType[],
+    isSearching:
+      (!error && !data && shouldFetch) || isDebouncing || isValidating,
+    isLoadingMore: isValidating && size > 1,
+    hasMore,
+    loadMore,
+    isSearchError: error,
+    searchQuery: debouncedQuery,
+  };
+}

--- a/front/hooks/useDeleteConversation.ts
+++ b/front/hooks/useDeleteConversation.ts
@@ -2,7 +2,6 @@ import { useConversations } from "@app/hooks/conversations";
 import { useSendNotification } from "@app/hooks/useNotification";
 import { clientFetch } from "@app/lib/egress/client";
 import { getErrorFromResponse } from "@app/lib/swr/swr";
-import type { GetConversationsResponseBody } from "@app/pages/api/w/[wId]/assistant/conversations";
 import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
 import type { LightWorkspaceType } from "@app/types/user";
 import { useCallback } from "react";
@@ -39,14 +38,8 @@ export function useDeleteConversation(owner: LightWorkspaceType) {
       }
 
       void mutateConversations(
-        (prevState: GetConversationsResponseBody | undefined) =>
-          prevState
-            ? {
-                conversations: prevState.conversations.filter(
-                  (c) => c.sId !== conversation.sId
-                ),
-              }
-            : undefined
+        (prevState: ConversationWithoutContentType[] | undefined) =>
+          prevState?.filter((c) => c.sId !== conversation.sId)
       );
 
       return true;

--- a/front/lib/api/pagination.ts
+++ b/front/lib/api/pagination.ts
@@ -35,14 +35,17 @@ function getOrderColumnCodec(supportedOrderColumns: string[]): t.Mixed {
   ]);
 }
 
-const LimitCodec = createRangeCodec(0, 2000);
+const DEFAULT_MAX_LIMIT = 2000;
 
-const PaginationParamsCodec = (supportedOrderColumns: string[]) =>
+const PaginationParamsCodec = (
+  supportedOrderColumns: string[],
+  maxLimit: number
+) =>
   t.type({
     orderColumn: getOrderColumnCodec(supportedOrderColumns),
     orderDirection: t.union([t.literal("asc"), t.literal("desc")]),
     lastValue: t.union([t.string, t.undefined]),
-    limit: LimitCodec,
+    limit: createRangeCodec(0, maxLimit),
   });
 
 interface PaginationOptions {
@@ -50,6 +53,7 @@ interface PaginationOptions {
   defaultOrderColumn: string;
   defaultOrderDirection: "asc" | "desc";
   supportedOrderColumn: string[];
+  maxLimit?: number;
 }
 
 export function getPaginationParams(
@@ -67,7 +71,8 @@ export function getPaginationParams(
   };
 
   const queryValidation = PaginationParamsCodec(
-    defaults.supportedOrderColumn
+    defaults.supportedOrderColumn,
+    defaults.maxLimit ?? DEFAULT_MAX_LIMIT
   ).decode(rawParams);
 
   // Validate and decode the raw parameters.
@@ -97,7 +102,7 @@ export type SortingParams = t.TypeOf<typeof SortingParamsCodec>;
 // Cursor pagination.
 
 const CursorPaginationParamsCodec = t.type({
-  limit: LimitCodec,
+  limit: createRangeCodec(0, DEFAULT_MAX_LIMIT),
   cursor: t.union([t.string, t.null]),
 });
 

--- a/front/pages/api/w/[wId]/assistant/conversations/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/index.ts
@@ -7,6 +7,7 @@ import {
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { apiErrorForConversation } from "@app/lib/api/assistant/conversation/helper";
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { getPaginationParams } from "@app/lib/api/pagination";
 import type { Authenticator } from "@app/lib/auth";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
@@ -29,6 +30,8 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 export type GetConversationsResponseBody = {
   conversations: ConversationWithoutContentType[];
+  hasMore: boolean;
+  lastValue: string | null;
 };
 export type PostConversationsResponseBody = {
   conversation: ConversationType;
@@ -49,12 +52,39 @@ async function handler(
 
   switch (req.method) {
     case "GET":
-      const conversations =
-        await ConversationResource.listPrivateConversationsForUser(auth);
+      const paginationRes = getPaginationParams(req, {
+        defaultLimit: 100,
+        defaultOrderColumn: "updatedAt",
+        defaultOrderDirection: "desc",
+        supportedOrderColumn: ["updatedAt"],
+      });
+
+      if (paginationRes.isErr()) {
+        return apiError(req, res, {
+          status_code: 400,
+          api_error: {
+            type: "invalid_request_error",
+            message: paginationRes.error.reason,
+          },
+        });
+      }
+
+      const pagination = paginationRes.value;
+
+      const result =
+        await ConversationResource.listPrivateConversationsForUserPaginated(
+          auth,
+          {
+            limit: pagination.limit,
+            lastValue: pagination.lastValue,
+            orderDirection: pagination.orderDirection,
+          }
+        );
+
       res.status(200).json({
-        conversations: conversations
-          .filter((c) => !c.spaceId)
-          .map((c) => c.toJSON()),
+        conversations: result.conversations.map((c) => c.toJSON()),
+        hasMore: result.hasMore,
+        lastValue: result.lastValue,
       });
       return;
 

--- a/front/pages/api/w/[wId]/assistant/conversations/search.test.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/search.test.ts
@@ -16,180 +16,36 @@ vi.mock("@app/lib/api/config", () => ({
   },
 }));
 
-vi.mock("@app/lib/lock", () => ({
-  executeWithLock: vi.fn(async (_lockName, fn) => {
-    return fn();
-  }),
-}));
-
-import { createDataSourceAndConnectorForProject } from "@app/lib/api/projects";
-import { Authenticator, getOrCreateSystemApiKey } from "@app/lib/auth";
+import {
+  ConversationModel,
+  ConversationParticipantModel,
+} from "@app/lib/models/agent/conversation";
 import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
-import type { GroupFactory } from "@app/tests/utils/GroupFactory";
 import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
-import { KeyFactory } from "@app/tests/utils/KeyFactory";
-import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
 import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
-import { DEFAULT_EMBEDDING_PROVIDER_ID } from "@app/types/assistant/models/embedding";
-import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
-import { CoreAPI, EMBEDDING_CONFIGS } from "@app/types/core/core_api";
-import type { CoreAPIDocument } from "@app/types/core/data_source";
-import { DEFAULT_QDRANT_CLUSTER } from "@app/types/core/data_source";
-import { Err, Ok } from "@app/types/shared/result";
 
 import handler from "./search";
 
-async function setupDataSourceMocks(
-  workspace: { sId: string },
-  globalGroup: Awaited<ReturnType<typeof GroupFactory.defaults>>["globalGroup"]
+async function createConversationWithTitle(
+  authenticator: Parameters<typeof ConversationFactory.create>[0],
+  options: Parameters<typeof ConversationFactory.create>[1],
+  title: string,
+  userId: number
 ) {
-  const mockProjectId = Math.floor(Math.random() * 1000000);
-  const mockDataSourceId = "test-data-source-id-" + Math.random();
-  const mockConnectorId = "test-connector-id-" + Math.random();
-  const mockWorkflowId = "test-workflow-id-" + Math.random();
+  const conversation = await ConversationFactory.create(authenticator, options);
+  await ConversationModel.update({ title }, { where: { id: conversation.id } });
 
-  const mockSystemKey = await KeyFactory.system(globalGroup);
-  vi.spyOn(
-    { getOrCreateSystemApiKey },
-    "getOrCreateSystemApiKey"
-  ).mockResolvedValue(new Ok(mockSystemKey));
+  const workspaceId = authenticator.getNonNullableWorkspace().id;
+  await ConversationParticipantModel.create({
+    conversationId: conversation.id,
+    userId,
+    workspaceId,
+    action: "posted",
+    unread: false,
+    actionRequired: false,
+  });
 
-  vi.spyOn(CoreAPI.prototype, "createProject").mockResolvedValue(
-    new Ok({
-      project: {
-        project_id: mockProjectId,
-      },
-    })
-  );
-
-  vi.spyOn(CoreAPI.prototype, "createDataSource").mockResolvedValue(
-    new Ok({
-      data_source: {
-        created: Date.now(),
-        data_source_id: mockDataSourceId,
-        data_source_internal_id: `internal-${mockDataSourceId}`,
-        name: "test-datasource",
-        config: {
-          embedder_config: {
-            embedder: {
-              provider_id: DEFAULT_EMBEDDING_PROVIDER_ID,
-              model_id:
-                EMBEDDING_CONFIGS[DEFAULT_EMBEDDING_PROVIDER_ID].model_id,
-              splitter_id:
-                EMBEDDING_CONFIGS[DEFAULT_EMBEDDING_PROVIDER_ID].splitter_id,
-              max_chunk_size:
-                EMBEDDING_CONFIGS[DEFAULT_EMBEDDING_PROVIDER_ID].max_chunk_size,
-            },
-          },
-          qdrant_config: {
-            cluster: DEFAULT_QDRANT_CLUSTER,
-            shadow_write_cluster: null,
-          },
-        },
-      },
-    })
-  );
-
-  vi.spyOn(CoreAPI.prototype, "getDataSource").mockResolvedValue(
-    new Ok({
-      data_source: {
-        data_source_id: mockDataSourceId,
-        data_source_internal_id: `internal-${mockDataSourceId}`,
-        name: "test-datasource",
-        project_id: mockProjectId.toString(),
-        created: Date.now(),
-        updated: Date.now(),
-        config: {
-          embedder_config: {
-            embedder: {
-              max_chunk_size: 512,
-              model_id: "text-embedding-ada-002",
-              provider_id: "openai",
-              splitter_id: "base_v0",
-            },
-          },
-          qdrant_config: {
-            cluster: DEFAULT_QDRANT_CLUSTER,
-            shadow_write_cluster: null,
-          },
-        },
-      },
-    })
-  );
-
-  vi.spyOn(CoreAPI.prototype, "upsertDataSourceFolder").mockResolvedValue(
-    new Ok({
-      folder: {
-        data_source_id: mockDataSourceId,
-        folder_id: "context",
-        parent_id: null,
-        parents: ["context"],
-        title: "Context",
-        timestamp: Date.now(),
-      },
-    })
-  );
-
-  vi.spyOn(ConnectorsAPI.prototype, "createConnector").mockResolvedValue(
-    new Ok({
-      id: mockConnectorId,
-      type: "dust_project",
-      workspaceId: workspace.sId,
-      dataSourceId: "test-data-source-id",
-      connectionId: "test-space-id",
-      useProxy: false,
-      configuration: null,
-      updatedAt: Date.now(),
-    })
-  );
-
-  vi.spyOn(ConnectorsAPI.prototype, "getConnector").mockResolvedValue(
-    new Ok({
-      id: mockConnectorId,
-      type: "dust_project",
-      workspaceId: workspace.sId,
-      dataSourceId: "test-data-source-id",
-      connectionId: "test-space-id",
-      useProxy: false,
-      configuration: null,
-      updatedAt: Date.now(),
-    })
-  );
-
-  vi.spyOn(ConnectorsAPI.prototype, "syncConnector").mockResolvedValue(
-    new Ok({
-      workflowId: mockWorkflowId,
-    })
-  );
-
-  return {
-    mockProjectId,
-    mockDataSourceId,
-    mockConnectorId,
-    mockWorkflowId,
-  };
-}
-
-function createMockDocument(
-  dataSourceId: string,
-  conversationId: string,
-  score: number
-): CoreAPIDocument {
-  return {
-    data_source_id: dataSourceId,
-    created: Date.now(),
-    document_id: `doc-${Math.random()}`,
-    parents: [],
-    parent_id: null,
-    timestamp: Date.now(),
-    tags: [`conversation:${conversationId}`],
-    hash: `hash-${Math.random()}`,
-    text_size: 100,
-    chunk_count: 1,
-    chunks: [{ text: "test content", hash: "chunk-hash", offset: 0, score }],
-    title: "Test Document",
-    mime_type: null,
-  };
+  return { ...conversation, title };
 }
 
 describe("GET /api/w/[wId]/assistant/conversations/search", () => {
@@ -264,54 +120,43 @@ describe("GET /api/w/[wId]/assistant/conversations/search", () => {
   });
 
   describe("Empty Results", () => {
-    it("returns empty array when no project spaces exist", async () => {
+    it("returns empty array when no conversations exist", async () => {
       const { req, res, workspace } = await createPrivateApiMockRequest({
         method: "GET",
         role: "admin",
       });
 
       req.query.wId = workspace.sId;
-      req.query.query = "test query";
+      req.query.query = "nonexistent";
 
       await handler(req, res);
 
       expect(res._getStatusCode()).toBe(200);
       const data = res._getJSONData();
       expect(data.conversations).toHaveLength(0);
+      expect(data.hasMore).toBe(false);
+      expect(data.lastValue).toBeNull();
     });
 
-    it("returns empty array when no conversations found", async () => {
-      const { req, res, workspace, user, authenticator, globalGroup } =
+    it("returns empty array when query does not match any title", async () => {
+      const { req, res, workspace, authenticator, user } =
         await createPrivateApiMockRequest({
           method: "GET",
           role: "admin",
         });
 
-      const projectSpace = await SpaceFactory.project(workspace);
-
-      const adminAuth = await Authenticator.internalAdminForWorkspace(
-        workspace.sId
+      await createConversationWithTitle(
+        authenticator,
+        {
+          agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+          messagesCreatedAt: [new Date()],
+        },
+        "My Important Meeting",
+        user.id
       );
-      const addMembersRes = await projectSpace.addMembers(adminAuth, {
-        userIds: [user.sId],
-      });
-      if (!addMembersRes.isOk()) {
-        throw new Error("Failed to add user to space");
-      }
-
-      await authenticator.refresh();
 
       req.query.wId = workspace.sId;
-      req.query.query = "test query";
-
-      await setupDataSourceMocks(workspace, globalGroup);
-      await createDataSourceAndConnectorForProject(authenticator, projectSpace);
-
-      vi.spyOn(CoreAPI.prototype, "bulkSearchDataSources").mockResolvedValue(
-        new Ok({
-          documents: [],
-        })
-      );
+      req.query.query = "zzz nonexistent zzz";
 
       await handler(req, res);
 
@@ -322,235 +167,45 @@ describe("GET /api/w/[wId]/assistant/conversations/search", () => {
   });
 
   describe("Success Cases", () => {
-    it("returns conversations ordered by relevance", async () => {
-      const { req, res, workspace, user, authenticator, globalGroup } =
+    it("returns conversations matching the query in title", async () => {
+      const { req, res, workspace, authenticator, user } =
         await createPrivateApiMockRequest({
           method: "GET",
           role: "admin",
         });
 
-      const projectSpace = await SpaceFactory.project(workspace);
-
-      const adminAuth = await Authenticator.internalAdminForWorkspace(
-        workspace.sId
-      );
-      const addMembersRes = await projectSpace.addMembers(adminAuth, {
-        userIds: [user.sId],
-      });
-      if (!addMembersRes.isOk()) {
-        throw new Error("Failed to add user to space");
-      }
-
-      await authenticator.refresh();
-
-      req.query.wId = workspace.sId;
-      req.query.query = "test query";
-
-      const { mockDataSourceId } = await setupDataSourceMocks(
-        workspace,
-        globalGroup
-      );
-      await createDataSourceAndConnectorForProject(authenticator, projectSpace);
-
-      const conv1 = await ConversationFactory.create(authenticator, {
-        agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
-        messagesCreatedAt: [new Date()],
-        spaceId: projectSpace.id,
-      });
-      const conv2 = await ConversationFactory.create(authenticator, {
-        agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
-        messagesCreatedAt: [new Date()],
-        spaceId: projectSpace.id,
-      });
-      const conv3 = await ConversationFactory.create(authenticator, {
-        agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
-        messagesCreatedAt: [new Date()],
-        spaceId: projectSpace.id,
-      });
-
-      vi.spyOn(CoreAPI.prototype, "bulkSearchDataSources").mockResolvedValue(
-        new Ok({
-          documents: [
-            createMockDocument(mockDataSourceId, conv2.sId, 0.5),
-            createMockDocument(mockDataSourceId, conv3.sId, 0.9),
-            createMockDocument(mockDataSourceId, conv1.sId, 0.7),
-          ],
-        })
-      );
-
-      await handler(req, res);
-
-      expect(res._getStatusCode()).toBe(200);
-      const data = res._getJSONData();
-      expect(data.conversations).toHaveLength(3);
-      expect(data.conversations[0].sId).toBe(conv3.sId);
-      expect(data.conversations[1].sId).toBe(conv1.sId);
-      expect(data.conversations[2].sId).toBe(conv2.sId);
-    });
-
-    it("handles documents with multiple chunks and uses max score", async () => {
-      const { req, res, workspace, user, authenticator, globalGroup } =
-        await createPrivateApiMockRequest({
-          method: "GET",
-          role: "admin",
-        });
-
-      const projectSpace = await SpaceFactory.project(workspace);
-
-      const adminAuth = await Authenticator.internalAdminForWorkspace(
-        workspace.sId
-      );
-      const addMembersRes = await projectSpace.addMembers(adminAuth, {
-        userIds: [user.sId],
-      });
-      if (!addMembersRes.isOk()) {
-        throw new Error("Failed to add user to space");
-      }
-
-      await authenticator.refresh();
-
-      req.query.wId = workspace.sId;
-      req.query.query = "test query";
-
-      const { mockDataSourceId } = await setupDataSourceMocks(
-        workspace,
-        globalGroup
-      );
-      await createDataSourceAndConnectorForProject(authenticator, projectSpace);
-
-      const conv1 = await ConversationFactory.create(authenticator, {
-        agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
-        messagesCreatedAt: [new Date()],
-        spaceId: projectSpace.id,
-      });
-      const conv2 = await ConversationFactory.create(authenticator, {
-        agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
-        messagesCreatedAt: [new Date()],
-        spaceId: projectSpace.id,
-      });
-
-      const mockDocuments: CoreAPIDocument[] = [
-        {
-          data_source_id: mockDataSourceId,
-          created: Date.now(),
-          document_id: "doc-1",
-          parents: [],
-          parent_id: null,
-          timestamp: Date.now(),
-          tags: [`conversation:${conv1.sId}`],
-          hash: "hash1",
-          text_size: 100,
-          chunk_count: 2,
-          chunks: [
-            { text: "test", hash: "chunk-hash-1", offset: 0, score: 0.5 },
-            { text: "test", hash: "chunk-hash-2", offset: 10, score: 0.6 },
-          ],
-          title: "Doc 1",
-          mime_type: null,
-        },
-        {
-          data_source_id: mockDataSourceId,
-          created: Date.now(),
-          document_id: "doc-2",
-          parents: [],
-          parent_id: null,
-          timestamp: Date.now(),
-          tags: [`conversation:${conv2.sId}`],
-          hash: "hash2",
-          text_size: 100,
-          chunk_count: 2,
-          chunks: [
-            { text: "test", hash: "chunk-hash-3", offset: 0, score: 0.3 },
-            { text: "test", hash: "chunk-hash-4", offset: 10, score: 0.9 },
-          ],
-          title: "Doc 2",
-          mime_type: null,
-        },
-      ];
-
-      vi.spyOn(CoreAPI.prototype, "bulkSearchDataSources").mockResolvedValue(
-        new Ok({
-          documents: mockDocuments,
-        })
-      );
-
-      await handler(req, res);
-
-      expect(res._getStatusCode()).toBe(200);
-      const data = res._getJSONData();
-      expect(data.conversations).toHaveLength(2);
-      expect(data.conversations[0].sId).toBe(conv2.sId);
-      expect(data.conversations[1].sId).toBe(conv1.sId);
-    });
-
-    it("searches across multiple project spaces", async () => {
-      const { req, res, workspace, user, authenticator, globalGroup } =
-        await createPrivateApiMockRequest({
-          method: "GET",
-          role: "admin",
-        });
-
-      const projectSpace1 = await SpaceFactory.project(workspace);
-      const projectSpace2 = await SpaceFactory.project(workspace);
-
-      const adminAuth = await Authenticator.internalAdminForWorkspace(
-        workspace.sId
-      );
-      let addMembersRes = await projectSpace1.addMembers(adminAuth, {
-        userIds: [user.sId],
-      });
-      if (!addMembersRes.isOk()) {
-        throw new Error("Failed to add user to space 1");
-      }
-      addMembersRes = await projectSpace2.addMembers(adminAuth, {
-        userIds: [user.sId],
-      });
-      if (!addMembersRes.isOk()) {
-        throw new Error("Failed to add user to space 2");
-      }
-
-      await authenticator.refresh();
-
-      req.query.wId = workspace.sId;
-      req.query.query = "test query";
-
-      const { mockDataSourceId: dsId1 } = await setupDataSourceMocks(
-        workspace,
-        globalGroup
-      );
-      await createDataSourceAndConnectorForProject(
+      const conv1 = await createConversationWithTitle(
         authenticator,
-        projectSpace1
+        {
+          agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+          messagesCreatedAt: [new Date()],
+        },
+        "Discussion about testing",
+        user.id
       );
 
-      const { mockDataSourceId: dsId2 } = await setupDataSourceMocks(
-        workspace,
-        globalGroup
-      );
-      await createDataSourceAndConnectorForProject(
+      await createConversationWithTitle(
         authenticator,
-        projectSpace2
+        {
+          agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+          messagesCreatedAt: [new Date()],
+        },
+        "Random conversation",
+        user.id
       );
 
-      const conv1 = await ConversationFactory.create(authenticator, {
-        agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
-        messagesCreatedAt: [new Date()],
-        spaceId: projectSpace1.id,
-      });
-      const conv2 = await ConversationFactory.create(authenticator, {
-        agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
-        messagesCreatedAt: [new Date()],
-        spaceId: projectSpace2.id,
-      });
-
-      vi.spyOn(CoreAPI.prototype, "bulkSearchDataSources").mockResolvedValue(
-        new Ok({
-          documents: [
-            createMockDocument(dsId1, conv1.sId, 0.9),
-            createMockDocument(dsId2, conv2.sId, 0.8),
-          ],
-        })
+      const conv3 = await createConversationWithTitle(
+        authenticator,
+        {
+          agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+          messagesCreatedAt: [new Date()],
+        },
+        "Testing best practices",
+        user.id
       );
+
+      req.query.wId = workspace.sId;
+      req.query.query = "testing";
 
       await handler(req, res);
 
@@ -558,265 +213,128 @@ describe("GET /api/w/[wId]/assistant/conversations/search", () => {
       const data = res._getJSONData();
       expect(data.conversations).toHaveLength(2);
 
-      const spaceNames = data.conversations.map(
-        (c: { spaceName: string }) => c.spaceName
+      const sIds = data.conversations.map((c: { sId: string }) => c.sId);
+      expect(sIds).toContain(conv1.sId);
+      expect(sIds).toContain(conv3.sId);
+    });
+
+    it("performs case-insensitive search", async () => {
+      const { req, res, workspace, authenticator, user } =
+        await createPrivateApiMockRequest({
+          method: "GET",
+          role: "admin",
+        });
+
+      const conv = await createConversationWithTitle(
+        authenticator,
+        {
+          agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+          messagesCreatedAt: [new Date()],
+        },
+        "UPPERCASE Title Here",
+        user.id
       );
-      expect(spaceNames).toContain(projectSpace1.name);
-      expect(spaceNames).toContain(projectSpace2.name);
+
+      req.query.wId = workspace.sId;
+      req.query.query = "uppercase";
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+      const data = res._getJSONData();
+      expect(data.conversations).toHaveLength(1);
+      expect(data.conversations[0].sId).toBe(conv.sId);
+    });
+
+    it("returns spaceName as null for all conversations", async () => {
+      const { req, res, workspace, authenticator, user } =
+        await createPrivateApiMockRequest({
+          method: "GET",
+          role: "admin",
+        });
+
+      await createConversationWithTitle(
+        authenticator,
+        {
+          agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+          messagesCreatedAt: [new Date()],
+        },
+        "Test conversation",
+        user.id
+      );
+
+      req.query.wId = workspace.sId;
+      req.query.query = "Test";
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+      const data = res._getJSONData();
+      expect(data.conversations).toHaveLength(1);
+      expect(data.conversations[0].spaceName).toBeNull();
     });
   });
 
-  describe("Error Handling", () => {
-    it("returns 500 when CoreAPI.bulkSearchDataSources fails", async () => {
-      const { req, res, workspace, user, authenticator, globalGroup } =
+  describe("Pagination", () => {
+    it("respects limit parameter", async () => {
+      const { req, res, workspace, authenticator, user } =
         await createPrivateApiMockRequest({
           method: "GET",
           role: "admin",
         });
 
-      const projectSpace = await SpaceFactory.project(workspace);
-
-      const adminAuth = await Authenticator.internalAdminForWorkspace(
-        workspace.sId
-      );
-      const addMembersRes = await projectSpace.addMembers(adminAuth, {
-        userIds: [user.sId],
-      });
-      if (!addMembersRes.isOk()) {
-        throw new Error("Failed to add user to space");
+      for (let i = 0; i < 5; i++) {
+        await createConversationWithTitle(
+          authenticator,
+          {
+            agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+            messagesCreatedAt: [new Date()],
+          },
+          `Test conversation ${i}`,
+          user.id
+        );
       }
 
-      await authenticator.refresh();
-
       req.query.wId = workspace.sId;
-      req.query.query = "test query";
-
-      await setupDataSourceMocks(workspace, globalGroup);
-      await createDataSourceAndConnectorForProject(authenticator, projectSpace);
-
-      vi.spyOn(CoreAPI.prototype, "bulkSearchDataSources").mockResolvedValue(
-        new Err({
-          code: "internal_server_error",
-          message: "Search failed",
-        })
-      );
-
-      await handler(req, res);
-
-      expect(res._getStatusCode()).toBe(500);
-      expect(res._getJSONData().error.type).toBe("internal_server_error");
-    });
-
-    it("filters out conversations that cannot be fetched", async () => {
-      const { req, res, workspace, user, authenticator, globalGroup } =
-        await createPrivateApiMockRequest({
-          method: "GET",
-          role: "admin",
-        });
-
-      const projectSpace = await SpaceFactory.project(workspace);
-
-      const adminAuth = await Authenticator.internalAdminForWorkspace(
-        workspace.sId
-      );
-      const addMembersRes = await projectSpace.addMembers(adminAuth, {
-        userIds: [user.sId],
-      });
-      if (!addMembersRes.isOk()) {
-        throw new Error("Failed to add user to space");
-      }
-
-      await authenticator.refresh();
-
-      req.query.wId = workspace.sId;
-      req.query.query = "test query";
-
-      const { mockDataSourceId } = await setupDataSourceMocks(
-        workspace,
-        globalGroup
-      );
-      await createDataSourceAndConnectorForProject(authenticator, projectSpace);
-
-      const conv1 = await ConversationFactory.create(authenticator, {
-        agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
-        messagesCreatedAt: [new Date()],
-        spaceId: projectSpace.id,
-      });
-
-      const mockDocuments: CoreAPIDocument[] = [
-        createMockDocument(mockDataSourceId, conv1.sId, 0.7),
-        {
-          data_source_id: mockDataSourceId,
-          created: Date.now(),
-          document_id: "doc-2",
-          parents: [],
-          parent_id: null,
-          timestamp: Date.now(),
-          tags: ["conversation:non-existent-id"],
-          hash: "hash2",
-          text_size: 100,
-          chunk_count: 1,
-          chunks: [{ text: "test", hash: "chunk-hash", offset: 0, score: 0.8 }],
-          title: "Doc 2",
-          mime_type: null,
-        },
-      ];
-
-      vi.spyOn(CoreAPI.prototype, "bulkSearchDataSources").mockResolvedValue(
-        new Ok({
-          documents: mockDocuments,
-        })
-      );
+      req.query.query = "Test";
+      req.query.limit = "2";
 
       await handler(req, res);
 
       expect(res._getStatusCode()).toBe(200);
       const data = res._getJSONData();
-      expect(data.conversations).toHaveLength(1);
-      expect(data.conversations[0].sId).toBe(conv1.sId);
+      expect(data.conversations).toHaveLength(2);
+      expect(data.hasMore).toBe(true);
+      expect(data.lastValue).not.toBeNull();
     });
 
-    it("excludes conversations from spaces user cannot read", async () => {
-      const { req, res, workspace, user, authenticator, globalGroup } =
+    it("returns hasMore=false when all results fit in limit", async () => {
+      const { req, res, workspace, authenticator, user } =
         await createPrivateApiMockRequest({
           method: "GET",
-          role: "user",
+          role: "admin",
         });
 
-      const permittedSpace = await SpaceFactory.project(workspace);
-      const unpermittedSpace = await SpaceFactory.project(workspace);
-
-      const adminAuth = await Authenticator.internalAdminForWorkspace(
-        workspace.sId
-      );
-      const addMembersRes = await permittedSpace.addMembers(adminAuth, {
-        userIds: [user.sId],
-      });
-      if (!addMembersRes.isOk()) {
-        throw new Error("Failed to add user to permitted space");
-      }
-
-      await authenticator.refresh();
-
-      req.query.wId = workspace.sId;
-      req.query.query = "test query";
-
-      const { mockDataSourceId: permittedDsId } = await setupDataSourceMocks(
-        workspace,
-        globalGroup
-      );
-      await createDataSourceAndConnectorForProject(
+      await createConversationWithTitle(
         authenticator,
-        permittedSpace
+        {
+          agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+          messagesCreatedAt: [new Date()],
+        },
+        "Single test conversation",
+        user.id
       );
-
-      const conv1 = await ConversationFactory.create(authenticator, {
-        agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
-        messagesCreatedAt: [new Date()],
-        spaceId: permittedSpace.id,
-      });
-
-      const unpermittedAdminAuth =
-        await Authenticator.internalAdminForWorkspace(workspace.sId);
-      const { mockDataSourceId: unpermittedDsId } = await setupDataSourceMocks(
-        workspace,
-        globalGroup
-      );
-      await createDataSourceAndConnectorForProject(
-        unpermittedAdminAuth,
-        unpermittedSpace
-      );
-
-      const conv2 = await ConversationFactory.create(unpermittedAdminAuth, {
-        agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
-        messagesCreatedAt: [new Date()],
-        spaceId: unpermittedSpace.id,
-      });
-
-      vi.spyOn(CoreAPI.prototype, "bulkSearchDataSources").mockResolvedValue(
-        new Ok({
-          documents: [
-            createMockDocument(permittedDsId, conv1.sId, 0.9),
-            createMockDocument(unpermittedDsId, conv2.sId, 0.8),
-          ],
-        })
-      );
-
-      await handler(req, res);
-
-      expect(res._getStatusCode()).toBe(200);
-      const data = res._getJSONData();
-      expect(data.conversations).toHaveLength(1);
-      expect(data.conversations[0].sId).toBe(conv1.sId);
-      expect(data.conversations[0].spaceName).toBe(permittedSpace.name);
-    });
-
-    it("excludes conversations from projects admin can read but is not a member of", async () => {
-      const { req, res, workspace, user, authenticator, globalGroup } =
-        await createPrivateApiMockRequest({
-          method: "GET",
-          role: "admin",
-        });
-
-      const memberSpace = await SpaceFactory.project(workspace);
-      const nonMemberSpace = await SpaceFactory.project(workspace);
-
-      const adminAuth = await Authenticator.internalAdminForWorkspace(
-        workspace.sId
-      );
-
-      const addMembersRes = await memberSpace.addMembers(adminAuth, {
-        userIds: [user.sId],
-      });
-      if (!addMembersRes.isOk()) {
-        throw new Error("Failed to add admin to member space");
-      }
-
-      await authenticator.refresh();
 
       req.query.wId = workspace.sId;
-      req.query.query = "test query";
-
-      const { mockDataSourceId: memberDsId } = await setupDataSourceMocks(
-        workspace,
-        globalGroup
-      );
-      await createDataSourceAndConnectorForProject(authenticator, memberSpace);
-
-      const conv1 = await ConversationFactory.create(authenticator, {
-        agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
-        messagesCreatedAt: [new Date()],
-        spaceId: memberSpace.id,
-      });
-
-      const { mockDataSourceId: nonMemberDsId } = await setupDataSourceMocks(
-        workspace,
-        globalGroup
-      );
-      await createDataSourceAndConnectorForProject(adminAuth, nonMemberSpace);
-
-      const conv2 = await ConversationFactory.create(adminAuth, {
-        agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
-        messagesCreatedAt: [new Date()],
-        spaceId: nonMemberSpace.id,
-      });
-
-      vi.spyOn(CoreAPI.prototype, "bulkSearchDataSources").mockResolvedValue(
-        new Ok({
-          documents: [
-            createMockDocument(memberDsId, conv1.sId, 0.9),
-            createMockDocument(nonMemberDsId, conv2.sId, 0.8),
-          ],
-        })
-      );
+      req.query.query = "test";
+      req.query.limit = "10";
 
       await handler(req, res);
 
       expect(res._getStatusCode()).toBe(200);
       const data = res._getJSONData();
       expect(data.conversations).toHaveLength(1);
-      expect(data.conversations[0].sId).toBe(conv1.sId);
-      expect(data.conversations[0].spaceName).toBe(memberSpace.name);
+      expect(data.hasMore).toBe(false);
     });
   });
 });

--- a/front/pages/api/w/[wId]/assistant/conversations/semantic_search.test.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/semantic_search.test.ts
@@ -1,0 +1,822 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@app/lib/api/config", () => ({
+  default: {
+    getCoreAPIConfig: () => ({
+      url: "http://localhost:3001",
+      apiKey: "test-api-key",
+    }),
+    getConnectorsAPIConfig: () => ({
+      url: "http://localhost:3002",
+      secret: "test-secret",
+      webhookSecret: "test-webhook-secret",
+    }),
+    getClientFacingUrl: () => "http://localhost:3000",
+    getAppUrl: () => "http://localhost:3000",
+  },
+}));
+
+vi.mock("@app/lib/lock", () => ({
+  executeWithLock: vi.fn(async (_lockName, fn) => {
+    return fn();
+  }),
+}));
+
+import { createDataSourceAndConnectorForProject } from "@app/lib/api/projects";
+import { Authenticator, getOrCreateSystemApiKey } from "@app/lib/auth";
+import { ConversationFactory } from "@app/tests/utils/ConversationFactory";
+import type { GroupFactory } from "@app/tests/utils/GroupFactory";
+import { createPrivateApiMockRequest } from "@app/tests/utils/generic_private_api_tests";
+import { KeyFactory } from "@app/tests/utils/KeyFactory";
+import { SpaceFactory } from "@app/tests/utils/SpaceFactory";
+import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
+import { DEFAULT_EMBEDDING_PROVIDER_ID } from "@app/types/assistant/models/embedding";
+import { ConnectorsAPI } from "@app/types/connectors/connectors_api";
+import { CoreAPI, EMBEDDING_CONFIGS } from "@app/types/core/core_api";
+import type { CoreAPIDocument } from "@app/types/core/data_source";
+import { DEFAULT_QDRANT_CLUSTER } from "@app/types/core/data_source";
+import { Err, Ok } from "@app/types/shared/result";
+
+import handler from "./semantic_search";
+
+async function setupDataSourceMocks(
+  workspace: { sId: string },
+  globalGroup: Awaited<ReturnType<typeof GroupFactory.defaults>>["globalGroup"]
+) {
+  const mockProjectId = Math.floor(Math.random() * 1000000);
+  const mockDataSourceId = "test-data-source-id-" + Math.random();
+  const mockConnectorId = "test-connector-id-" + Math.random();
+  const mockWorkflowId = "test-workflow-id-" + Math.random();
+
+  const mockSystemKey = await KeyFactory.system(globalGroup);
+  vi.spyOn(
+    { getOrCreateSystemApiKey },
+    "getOrCreateSystemApiKey"
+  ).mockResolvedValue(new Ok(mockSystemKey));
+
+  vi.spyOn(CoreAPI.prototype, "createProject").mockResolvedValue(
+    new Ok({
+      project: {
+        project_id: mockProjectId,
+      },
+    })
+  );
+
+  vi.spyOn(CoreAPI.prototype, "createDataSource").mockResolvedValue(
+    new Ok({
+      data_source: {
+        created: Date.now(),
+        data_source_id: mockDataSourceId,
+        data_source_internal_id: `internal-${mockDataSourceId}`,
+        name: "test-datasource",
+        config: {
+          embedder_config: {
+            embedder: {
+              provider_id: DEFAULT_EMBEDDING_PROVIDER_ID,
+              model_id:
+                EMBEDDING_CONFIGS[DEFAULT_EMBEDDING_PROVIDER_ID].model_id,
+              splitter_id:
+                EMBEDDING_CONFIGS[DEFAULT_EMBEDDING_PROVIDER_ID].splitter_id,
+              max_chunk_size:
+                EMBEDDING_CONFIGS[DEFAULT_EMBEDDING_PROVIDER_ID].max_chunk_size,
+            },
+          },
+          qdrant_config: {
+            cluster: DEFAULT_QDRANT_CLUSTER,
+            shadow_write_cluster: null,
+          },
+        },
+      },
+    })
+  );
+
+  vi.spyOn(CoreAPI.prototype, "getDataSource").mockResolvedValue(
+    new Ok({
+      data_source: {
+        data_source_id: mockDataSourceId,
+        data_source_internal_id: `internal-${mockDataSourceId}`,
+        name: "test-datasource",
+        project_id: mockProjectId.toString(),
+        created: Date.now(),
+        updated: Date.now(),
+        config: {
+          embedder_config: {
+            embedder: {
+              max_chunk_size: 512,
+              model_id: "text-embedding-ada-002",
+              provider_id: "openai",
+              splitter_id: "base_v0",
+            },
+          },
+          qdrant_config: {
+            cluster: DEFAULT_QDRANT_CLUSTER,
+            shadow_write_cluster: null,
+          },
+        },
+      },
+    })
+  );
+
+  vi.spyOn(CoreAPI.prototype, "upsertDataSourceFolder").mockResolvedValue(
+    new Ok({
+      folder: {
+        data_source_id: mockDataSourceId,
+        folder_id: "context",
+        parent_id: null,
+        parents: ["context"],
+        title: "Context",
+        timestamp: Date.now(),
+      },
+    })
+  );
+
+  vi.spyOn(ConnectorsAPI.prototype, "createConnector").mockResolvedValue(
+    new Ok({
+      id: mockConnectorId,
+      type: "dust_project",
+      workspaceId: workspace.sId,
+      dataSourceId: "test-data-source-id",
+      connectionId: "test-space-id",
+      useProxy: false,
+      configuration: null,
+      updatedAt: Date.now(),
+    })
+  );
+
+  vi.spyOn(ConnectorsAPI.prototype, "getConnector").mockResolvedValue(
+    new Ok({
+      id: mockConnectorId,
+      type: "dust_project",
+      workspaceId: workspace.sId,
+      dataSourceId: "test-data-source-id",
+      connectionId: "test-space-id",
+      useProxy: false,
+      configuration: null,
+      updatedAt: Date.now(),
+    })
+  );
+
+  vi.spyOn(ConnectorsAPI.prototype, "syncConnector").mockResolvedValue(
+    new Ok({
+      workflowId: mockWorkflowId,
+    })
+  );
+
+  return {
+    mockProjectId,
+    mockDataSourceId,
+    mockConnectorId,
+    mockWorkflowId,
+  };
+}
+
+function createMockDocument(
+  dataSourceId: string,
+  conversationId: string,
+  score: number
+): CoreAPIDocument {
+  return {
+    data_source_id: dataSourceId,
+    created: Date.now(),
+    document_id: `doc-${Math.random()}`,
+    parents: [],
+    parent_id: null,
+    timestamp: Date.now(),
+    tags: [`conversation:${conversationId}`],
+    hash: `hash-${Math.random()}`,
+    text_size: 100,
+    chunk_count: 1,
+    chunks: [{ text: "test content", hash: "chunk-hash", offset: 0, score }],
+    title: "Test Document",
+    mime_type: null,
+  };
+}
+
+describe("GET /api/w/[wId]/assistant/conversations/semantic_search", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("Parameter Validation", () => {
+    it("returns 400 when query parameter is missing", async () => {
+      const { req, res, workspace } = await createPrivateApiMockRequest({
+        method: "GET",
+        role: "admin",
+      });
+
+      req.query.wId = workspace.sId;
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(400);
+      expect(res._getJSONData().error.type).toBe("invalid_request_error");
+    });
+
+    it("returns 400 when query parameter is empty", async () => {
+      const { req, res, workspace } = await createPrivateApiMockRequest({
+        method: "GET",
+        role: "admin",
+      });
+
+      req.query.wId = workspace.sId;
+      req.query.query = "";
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(400);
+      expect(res._getJSONData().error.type).toBe("invalid_request_error");
+    });
+
+    it("returns 400 when limit exceeds max (100)", async () => {
+      const { req, res, workspace } = await createPrivateApiMockRequest({
+        method: "GET",
+        role: "admin",
+      });
+
+      req.query.wId = workspace.sId;
+      req.query.query = "test";
+      req.query.limit = "101";
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(400);
+      expect(res._getJSONData().error.type).toBe("invalid_request_error");
+    });
+
+    it("returns 405 for non-GET methods", async () => {
+      for (const method of ["POST", "PUT", "DELETE", "PATCH"] as const) {
+        const { req, res, workspace } = await createPrivateApiMockRequest({
+          method,
+          role: "admin",
+        });
+
+        req.query.wId = workspace.sId;
+        req.query.query = "test";
+
+        await handler(req, res);
+
+        expect(res._getStatusCode()).toBe(405);
+        expect(res._getJSONData().error.type).toBe(
+          "method_not_supported_error"
+        );
+      }
+    });
+  });
+
+  describe("Empty Results", () => {
+    it("returns empty array when no project spaces exist", async () => {
+      const { req, res, workspace } = await createPrivateApiMockRequest({
+        method: "GET",
+        role: "admin",
+      });
+
+      req.query.wId = workspace.sId;
+      req.query.query = "test query";
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+      const data = res._getJSONData();
+      expect(data.conversations).toHaveLength(0);
+    });
+
+    it("returns empty array when no conversations found", async () => {
+      const { req, res, workspace, user, authenticator, globalGroup } =
+        await createPrivateApiMockRequest({
+          method: "GET",
+          role: "admin",
+        });
+
+      const projectSpace = await SpaceFactory.project(workspace);
+
+      const adminAuth = await Authenticator.internalAdminForWorkspace(
+        workspace.sId
+      );
+      const addMembersRes = await projectSpace.addMembers(adminAuth, {
+        userIds: [user.sId],
+      });
+      if (!addMembersRes.isOk()) {
+        throw new Error("Failed to add user to space");
+      }
+
+      await authenticator.refresh();
+
+      req.query.wId = workspace.sId;
+      req.query.query = "test query";
+
+      await setupDataSourceMocks(workspace, globalGroup);
+      await createDataSourceAndConnectorForProject(authenticator, projectSpace);
+
+      vi.spyOn(CoreAPI.prototype, "bulkSearchDataSources").mockResolvedValue(
+        new Ok({
+          documents: [],
+        })
+      );
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+      const data = res._getJSONData();
+      expect(data.conversations).toHaveLength(0);
+    });
+  });
+
+  describe("Success Cases", () => {
+    it("returns conversations ordered by relevance", async () => {
+      const { req, res, workspace, user, authenticator, globalGroup } =
+        await createPrivateApiMockRequest({
+          method: "GET",
+          role: "admin",
+        });
+
+      const projectSpace = await SpaceFactory.project(workspace);
+
+      const adminAuth = await Authenticator.internalAdminForWorkspace(
+        workspace.sId
+      );
+      const addMembersRes = await projectSpace.addMembers(adminAuth, {
+        userIds: [user.sId],
+      });
+      if (!addMembersRes.isOk()) {
+        throw new Error("Failed to add user to space");
+      }
+
+      await authenticator.refresh();
+
+      req.query.wId = workspace.sId;
+      req.query.query = "test query";
+
+      const { mockDataSourceId } = await setupDataSourceMocks(
+        workspace,
+        globalGroup
+      );
+      await createDataSourceAndConnectorForProject(authenticator, projectSpace);
+
+      const conv1 = await ConversationFactory.create(authenticator, {
+        agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+        messagesCreatedAt: [new Date()],
+        spaceId: projectSpace.id,
+      });
+      const conv2 = await ConversationFactory.create(authenticator, {
+        agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+        messagesCreatedAt: [new Date()],
+        spaceId: projectSpace.id,
+      });
+      const conv3 = await ConversationFactory.create(authenticator, {
+        agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+        messagesCreatedAt: [new Date()],
+        spaceId: projectSpace.id,
+      });
+
+      vi.spyOn(CoreAPI.prototype, "bulkSearchDataSources").mockResolvedValue(
+        new Ok({
+          documents: [
+            createMockDocument(mockDataSourceId, conv2.sId, 0.5),
+            createMockDocument(mockDataSourceId, conv3.sId, 0.9),
+            createMockDocument(mockDataSourceId, conv1.sId, 0.7),
+          ],
+        })
+      );
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+      const data = res._getJSONData();
+      expect(data.conversations).toHaveLength(3);
+      expect(data.conversations[0].sId).toBe(conv3.sId);
+      expect(data.conversations[1].sId).toBe(conv1.sId);
+      expect(data.conversations[2].sId).toBe(conv2.sId);
+    });
+
+    it("handles documents with multiple chunks and uses max score", async () => {
+      const { req, res, workspace, user, authenticator, globalGroup } =
+        await createPrivateApiMockRequest({
+          method: "GET",
+          role: "admin",
+        });
+
+      const projectSpace = await SpaceFactory.project(workspace);
+
+      const adminAuth = await Authenticator.internalAdminForWorkspace(
+        workspace.sId
+      );
+      const addMembersRes = await projectSpace.addMembers(adminAuth, {
+        userIds: [user.sId],
+      });
+      if (!addMembersRes.isOk()) {
+        throw new Error("Failed to add user to space");
+      }
+
+      await authenticator.refresh();
+
+      req.query.wId = workspace.sId;
+      req.query.query = "test query";
+
+      const { mockDataSourceId } = await setupDataSourceMocks(
+        workspace,
+        globalGroup
+      );
+      await createDataSourceAndConnectorForProject(authenticator, projectSpace);
+
+      const conv1 = await ConversationFactory.create(authenticator, {
+        agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+        messagesCreatedAt: [new Date()],
+        spaceId: projectSpace.id,
+      });
+      const conv2 = await ConversationFactory.create(authenticator, {
+        agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+        messagesCreatedAt: [new Date()],
+        spaceId: projectSpace.id,
+      });
+
+      const mockDocuments: CoreAPIDocument[] = [
+        {
+          data_source_id: mockDataSourceId,
+          created: Date.now(),
+          document_id: "doc-1",
+          parents: [],
+          parent_id: null,
+          timestamp: Date.now(),
+          tags: [`conversation:${conv1.sId}`],
+          hash: "hash1",
+          text_size: 100,
+          chunk_count: 2,
+          chunks: [
+            { text: "test", hash: "chunk-hash-1", offset: 0, score: 0.5 },
+            { text: "test", hash: "chunk-hash-2", offset: 10, score: 0.6 },
+          ],
+          title: "Doc 1",
+          mime_type: null,
+        },
+        {
+          data_source_id: mockDataSourceId,
+          created: Date.now(),
+          document_id: "doc-2",
+          parents: [],
+          parent_id: null,
+          timestamp: Date.now(),
+          tags: [`conversation:${conv2.sId}`],
+          hash: "hash2",
+          text_size: 100,
+          chunk_count: 2,
+          chunks: [
+            { text: "test", hash: "chunk-hash-3", offset: 0, score: 0.3 },
+            { text: "test", hash: "chunk-hash-4", offset: 10, score: 0.9 },
+          ],
+          title: "Doc 2",
+          mime_type: null,
+        },
+      ];
+
+      vi.spyOn(CoreAPI.prototype, "bulkSearchDataSources").mockResolvedValue(
+        new Ok({
+          documents: mockDocuments,
+        })
+      );
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+      const data = res._getJSONData();
+      expect(data.conversations).toHaveLength(2);
+      expect(data.conversations[0].sId).toBe(conv2.sId);
+      expect(data.conversations[1].sId).toBe(conv1.sId);
+    });
+
+    it("searches across multiple project spaces", async () => {
+      const { req, res, workspace, user, authenticator, globalGroup } =
+        await createPrivateApiMockRequest({
+          method: "GET",
+          role: "admin",
+        });
+
+      const projectSpace1 = await SpaceFactory.project(workspace);
+      const projectSpace2 = await SpaceFactory.project(workspace);
+
+      const adminAuth = await Authenticator.internalAdminForWorkspace(
+        workspace.sId
+      );
+      let addMembersRes = await projectSpace1.addMembers(adminAuth, {
+        userIds: [user.sId],
+      });
+      if (!addMembersRes.isOk()) {
+        throw new Error("Failed to add user to space 1");
+      }
+      addMembersRes = await projectSpace2.addMembers(adminAuth, {
+        userIds: [user.sId],
+      });
+      if (!addMembersRes.isOk()) {
+        throw new Error("Failed to add user to space 2");
+      }
+
+      await authenticator.refresh();
+
+      req.query.wId = workspace.sId;
+      req.query.query = "test query";
+
+      const { mockDataSourceId: dsId1 } = await setupDataSourceMocks(
+        workspace,
+        globalGroup
+      );
+      await createDataSourceAndConnectorForProject(
+        authenticator,
+        projectSpace1
+      );
+
+      const { mockDataSourceId: dsId2 } = await setupDataSourceMocks(
+        workspace,
+        globalGroup
+      );
+      await createDataSourceAndConnectorForProject(
+        authenticator,
+        projectSpace2
+      );
+
+      const conv1 = await ConversationFactory.create(authenticator, {
+        agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+        messagesCreatedAt: [new Date()],
+        spaceId: projectSpace1.id,
+      });
+      const conv2 = await ConversationFactory.create(authenticator, {
+        agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+        messagesCreatedAt: [new Date()],
+        spaceId: projectSpace2.id,
+      });
+
+      vi.spyOn(CoreAPI.prototype, "bulkSearchDataSources").mockResolvedValue(
+        new Ok({
+          documents: [
+            createMockDocument(dsId1, conv1.sId, 0.9),
+            createMockDocument(dsId2, conv2.sId, 0.8),
+          ],
+        })
+      );
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+      const data = res._getJSONData();
+      expect(data.conversations).toHaveLength(2);
+
+      const spaceNames = data.conversations.map(
+        (c: { spaceName: string }) => c.spaceName
+      );
+      expect(spaceNames).toContain(projectSpace1.name);
+      expect(spaceNames).toContain(projectSpace2.name);
+    });
+  });
+
+  describe("Error Handling", () => {
+    it("returns 500 when CoreAPI.bulkSearchDataSources fails", async () => {
+      const { req, res, workspace, user, authenticator, globalGroup } =
+        await createPrivateApiMockRequest({
+          method: "GET",
+          role: "admin",
+        });
+
+      const projectSpace = await SpaceFactory.project(workspace);
+
+      const adminAuth = await Authenticator.internalAdminForWorkspace(
+        workspace.sId
+      );
+      const addMembersRes = await projectSpace.addMembers(adminAuth, {
+        userIds: [user.sId],
+      });
+      if (!addMembersRes.isOk()) {
+        throw new Error("Failed to add user to space");
+      }
+
+      await authenticator.refresh();
+
+      req.query.wId = workspace.sId;
+      req.query.query = "test query";
+
+      await setupDataSourceMocks(workspace, globalGroup);
+      await createDataSourceAndConnectorForProject(authenticator, projectSpace);
+
+      vi.spyOn(CoreAPI.prototype, "bulkSearchDataSources").mockResolvedValue(
+        new Err({
+          code: "internal_server_error",
+          message: "Search failed",
+        })
+      );
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(500);
+      expect(res._getJSONData().error.type).toBe("internal_server_error");
+    });
+
+    it("filters out conversations that cannot be fetched", async () => {
+      const { req, res, workspace, user, authenticator, globalGroup } =
+        await createPrivateApiMockRequest({
+          method: "GET",
+          role: "admin",
+        });
+
+      const projectSpace = await SpaceFactory.project(workspace);
+
+      const adminAuth = await Authenticator.internalAdminForWorkspace(
+        workspace.sId
+      );
+      const addMembersRes = await projectSpace.addMembers(adminAuth, {
+        userIds: [user.sId],
+      });
+      if (!addMembersRes.isOk()) {
+        throw new Error("Failed to add user to space");
+      }
+
+      await authenticator.refresh();
+
+      req.query.wId = workspace.sId;
+      req.query.query = "test query";
+
+      const { mockDataSourceId } = await setupDataSourceMocks(
+        workspace,
+        globalGroup
+      );
+      await createDataSourceAndConnectorForProject(authenticator, projectSpace);
+
+      const conv1 = await ConversationFactory.create(authenticator, {
+        agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+        messagesCreatedAt: [new Date()],
+        spaceId: projectSpace.id,
+      });
+
+      const mockDocuments: CoreAPIDocument[] = [
+        createMockDocument(mockDataSourceId, conv1.sId, 0.7),
+        {
+          data_source_id: mockDataSourceId,
+          created: Date.now(),
+          document_id: "doc-2",
+          parents: [],
+          parent_id: null,
+          timestamp: Date.now(),
+          tags: ["conversation:non-existent-id"],
+          hash: "hash2",
+          text_size: 100,
+          chunk_count: 1,
+          chunks: [{ text: "test", hash: "chunk-hash", offset: 0, score: 0.8 }],
+          title: "Doc 2",
+          mime_type: null,
+        },
+      ];
+
+      vi.spyOn(CoreAPI.prototype, "bulkSearchDataSources").mockResolvedValue(
+        new Ok({
+          documents: mockDocuments,
+        })
+      );
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+      const data = res._getJSONData();
+      expect(data.conversations).toHaveLength(1);
+      expect(data.conversations[0].sId).toBe(conv1.sId);
+    });
+
+    it("excludes conversations from spaces user cannot read", async () => {
+      const { req, res, workspace, user, authenticator, globalGroup } =
+        await createPrivateApiMockRequest({
+          method: "GET",
+          role: "user",
+        });
+
+      const permittedSpace = await SpaceFactory.project(workspace);
+      const unpermittedSpace = await SpaceFactory.project(workspace);
+
+      const adminAuth = await Authenticator.internalAdminForWorkspace(
+        workspace.sId
+      );
+      const addMembersRes = await permittedSpace.addMembers(adminAuth, {
+        userIds: [user.sId],
+      });
+      if (!addMembersRes.isOk()) {
+        throw new Error("Failed to add user to permitted space");
+      }
+
+      await authenticator.refresh();
+
+      req.query.wId = workspace.sId;
+      req.query.query = "test query";
+
+      const { mockDataSourceId: permittedDsId } = await setupDataSourceMocks(
+        workspace,
+        globalGroup
+      );
+      await createDataSourceAndConnectorForProject(
+        authenticator,
+        permittedSpace
+      );
+
+      const conv1 = await ConversationFactory.create(authenticator, {
+        agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+        messagesCreatedAt: [new Date()],
+        spaceId: permittedSpace.id,
+      });
+
+      const unpermittedAdminAuth =
+        await Authenticator.internalAdminForWorkspace(workspace.sId);
+      const { mockDataSourceId: unpermittedDsId } = await setupDataSourceMocks(
+        workspace,
+        globalGroup
+      );
+      await createDataSourceAndConnectorForProject(
+        unpermittedAdminAuth,
+        unpermittedSpace
+      );
+
+      const conv2 = await ConversationFactory.create(unpermittedAdminAuth, {
+        agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+        messagesCreatedAt: [new Date()],
+        spaceId: unpermittedSpace.id,
+      });
+
+      vi.spyOn(CoreAPI.prototype, "bulkSearchDataSources").mockResolvedValue(
+        new Ok({
+          documents: [
+            createMockDocument(permittedDsId, conv1.sId, 0.9),
+            createMockDocument(unpermittedDsId, conv2.sId, 0.8),
+          ],
+        })
+      );
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+      const data = res._getJSONData();
+      expect(data.conversations).toHaveLength(1);
+      expect(data.conversations[0].sId).toBe(conv1.sId);
+      expect(data.conversations[0].spaceName).toBe(permittedSpace.name);
+    });
+
+    it("excludes conversations from projects admin can read but is not a member of", async () => {
+      const { req, res, workspace, user, authenticator, globalGroup } =
+        await createPrivateApiMockRequest({
+          method: "GET",
+          role: "admin",
+        });
+
+      const memberSpace = await SpaceFactory.project(workspace);
+      const nonMemberSpace = await SpaceFactory.project(workspace);
+
+      const adminAuth = await Authenticator.internalAdminForWorkspace(
+        workspace.sId
+      );
+
+      const addMembersRes = await memberSpace.addMembers(adminAuth, {
+        userIds: [user.sId],
+      });
+      if (!addMembersRes.isOk()) {
+        throw new Error("Failed to add admin to member space");
+      }
+
+      await authenticator.refresh();
+
+      req.query.wId = workspace.sId;
+      req.query.query = "test query";
+
+      const { mockDataSourceId: memberDsId } = await setupDataSourceMocks(
+        workspace,
+        globalGroup
+      );
+      await createDataSourceAndConnectorForProject(authenticator, memberSpace);
+
+      const conv1 = await ConversationFactory.create(authenticator, {
+        agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+        messagesCreatedAt: [new Date()],
+        spaceId: memberSpace.id,
+      });
+
+      const { mockDataSourceId: nonMemberDsId } = await setupDataSourceMocks(
+        workspace,
+        globalGroup
+      );
+      await createDataSourceAndConnectorForProject(adminAuth, nonMemberSpace);
+
+      const conv2 = await ConversationFactory.create(adminAuth, {
+        agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+        messagesCreatedAt: [new Date()],
+        spaceId: nonMemberSpace.id,
+      });
+
+      vi.spyOn(CoreAPI.prototype, "bulkSearchDataSources").mockResolvedValue(
+        new Ok({
+          documents: [
+            createMockDocument(memberDsId, conv1.sId, 0.9),
+            createMockDocument(nonMemberDsId, conv2.sId, 0.8),
+          ],
+        })
+      );
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(200);
+      const data = res._getJSONData();
+      expect(data.conversations).toHaveLength(1);
+      expect(data.conversations[0].sId).toBe(conv1.sId);
+      expect(data.conversations[0].spaceName).toBe(memberSpace.name);
+    });
+  });
+});

--- a/front/pages/api/w/[wId]/assistant/conversations/semantic_search.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/semantic_search.ts
@@ -1,0 +1,106 @@
+import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
+import { searchProjectConversations } from "@app/lib/api/projects";
+import type { Authenticator } from "@app/lib/auth";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { apiError } from "@app/logger/withlogging";
+import type { ConversationWithoutContentType } from "@app/types/assistant/conversation";
+import type { WithAPIErrorResponse } from "@app/types/error";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+import { fromError } from "zod-validation-error";
+
+const SEMANTIC_SEARCH_SCORE_CUTOFF = 0.25;
+
+export type SemanticSearchConversationsResponseBody = {
+  conversations: Array<ConversationWithoutContentType & { spaceName: string }>;
+};
+
+const SearchQuerySchema = z.object({
+  query: z.string().min(1, "Query is required"),
+  limit: z.coerce.number().int().min(1).max(100).optional().default(10),
+});
+
+async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<
+    WithAPIErrorResponse<SemanticSearchConversationsResponseBody>
+  >,
+  auth: Authenticator
+): Promise<void> {
+  if (req.method !== "GET") {
+    return apiError(req, res, {
+      status_code: 405,
+      api_error: {
+        type: "method_not_supported_error",
+        message: "The method passed is not supported, GET is expected.",
+      },
+    });
+  }
+
+  const queryValidation = SearchQuerySchema.safeParse(req.query);
+  if (!queryValidation.success) {
+    return apiError(req, res, {
+      status_code: 400,
+      api_error: {
+        type: "invalid_request_error",
+        message: `Invalid query parameters: ${fromError(queryValidation.error).toString()}`,
+      },
+    });
+  }
+
+  const { query, limit } = queryValidation.data;
+
+  const projectSpaces = (await SpaceResource.listProjectSpaces(auth)).filter(
+    (space) => space.isMember(auth)
+  );
+
+  if (projectSpaces.length === 0) {
+    return res.status(200).json({ conversations: [] });
+  }
+
+  const searchRes = await searchProjectConversations(auth, {
+    query,
+    spaceIds: projectSpaces.map((s) => s.sId),
+    topK: limit,
+  });
+
+  if (searchRes.isErr()) {
+    return apiError(req, res, {
+      status_code: 500,
+      api_error: {
+        type: "internal_server_error",
+        message: "Failed to search conversations.",
+      },
+    });
+  }
+
+  const filteredResults = searchRes.value.filter(
+    (r) => r.score >= SEMANTIC_SEARCH_SCORE_CUTOFF
+  );
+
+  const spaceIdToName = new Map(projectSpaces.map((s) => [s.sId, s.name]));
+
+  const conversations = await ConversationResource.fetchByIds(
+    auth,
+    filteredResults.map((r) => r.conversationId)
+  );
+  const conversationMap = new Map(conversations.map((c) => [c.sId, c]));
+
+  const results = filteredResults
+    .map((r) => {
+      const conv = conversationMap.get(r.conversationId);
+      if (!conv) {
+        return null;
+      }
+      return {
+        ...conv.toJSON(),
+        spaceName: spaceIdToName.get(r.spaceId) ?? "Unknown",
+      };
+    })
+    .filter((c) => c !== null);
+
+  return res.status(200).json({ conversations: results });
+}
+
+export default withSessionAuthenticationForWorkspace(handler);

--- a/front/pages/api/w/[wId]/spaces/search_projects.ts
+++ b/front/pages/api/w/[wId]/spaces/search_projects.ts
@@ -36,6 +36,7 @@ async function handler(
     defaultOrderColumn: "name",
     defaultOrderDirection: "asc",
     supportedOrderColumn: ["name"],
+    maxLimit: 100,
   });
 
   if (paginationRes.isErr()) {

--- a/front/scripts/dev/seed_conversations.ts
+++ b/front/scripts/dev/seed_conversations.ts
@@ -1,0 +1,472 @@
+import { Authenticator } from "@app/lib/auth";
+import {
+  AgentMessageModel,
+  MessageModel,
+  UserMessageModel,
+} from "@app/lib/models/agent/conversation";
+import { AgentStepContentResource } from "@app/lib/resources/agent_step_content_resource";
+import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import { MembershipResource } from "@app/lib/resources/membership_resource";
+import { SpaceResource } from "@app/lib/resources/space_resource";
+import { generateRandomModelSId } from "@app/lib/resources/string_ids";
+import { UserResource } from "@app/lib/resources/user_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { concurrentExecutor } from "@app/lib/utils/async_utils";
+import { renderLightWorkspaceType } from "@app/lib/workspace";
+import type { Logger } from "@app/logger/logger";
+import { makeScript } from "@app/scripts/helpers";
+import { GLOBAL_AGENTS_SID } from "@app/types/assistant/assistant";
+import {
+  PROJECT_EDITOR_GROUP_PREFIX,
+  PROJECT_GROUP_PREFIX,
+} from "@app/types/groups";
+import { faker } from "@faker-js/faker";
+
+interface SeedConfig {
+  workspaceId: string;
+  conversationCount: number;
+  projectCount: number;
+  privateRatio: number;
+  messagesPerConversation: number;
+}
+
+interface ConversationToCreate {
+  index: number;
+  space: SpaceResource | null;
+  title: string;
+  messages: Array<{
+    userContent: string;
+    agentContent: string;
+  }>;
+}
+
+function generateConversationTitle(): string {
+  const templates = [
+    `Help with ${faker.company.buzzPhrase()}`,
+    `Question about ${faker.commerce.productName()}`,
+    `Understanding ${faker.hacker.noun()}`,
+    `How to ${faker.hacker.verb()} ${faker.hacker.noun()}`,
+    `${faker.company.buzzVerb()} ${faker.company.buzzNoun()}`,
+    `Review of ${faker.commerce.productName()}`,
+    `Explain ${faker.science.chemicalElement().name}`,
+    `${faker.word.adjective()} ${faker.word.noun()} guide`,
+  ];
+  return templates[Math.floor(Math.random() * templates.length)];
+}
+
+function generateUserMessage(): string {
+  const templates = [
+    `Can you help me understand ${faker.company.buzzPhrase()}?`,
+    `I'm trying to ${faker.hacker.verb()} the ${faker.hacker.noun()}. Any suggestions?`,
+    `What's the best approach to ${faker.company.buzzVerb()} ${faker.company.buzzNoun()}?`,
+    `Could you explain how ${faker.commerce.productName()} works?`,
+    `I need help with ${faker.hacker.adjective()} ${faker.hacker.noun()} implementation.`,
+    `Is there a way to ${faker.hacker.verb()} without ${faker.hacker.ingverb()}?`,
+    `What are the benefits of ${faker.company.buzzPhrase()}?`,
+    `How do I get started with ${faker.company.buzzNoun()}?`,
+  ];
+  return templates[Math.floor(Math.random() * templates.length)];
+}
+
+function generateAgentResponse(): string {
+  const paragraphs = faker.lorem.paragraphs({ min: 1, max: 3 });
+  const bullets = Array.from({ length: faker.number.int({ min: 2, max: 4 }) })
+    .map(() => `- ${faker.lorem.sentence()}`)
+    .join("\n");
+  return `${paragraphs}\n\nHere are some key points:\n${bullets}`;
+}
+
+async function createProject(
+  auth: Authenticator,
+  workspace: { id: number },
+  creatorId: number,
+  projectName: string
+): Promise<SpaceResource> {
+  const existingSpaces = await SpaceResource.listProjectSpaces(auth);
+  const existingSpace = existingSpaces.find((s) => s.name === projectName);
+  if (existingSpace) {
+    return existingSpace;
+  }
+
+  const memberGroupName = `${PROJECT_GROUP_PREFIX} ${projectName}`;
+  let memberGroup = await GroupResource.fetchByName(auth, memberGroupName);
+  if (!memberGroup) {
+    memberGroup = await GroupResource.makeNew({
+      name: memberGroupName,
+      workspaceId: workspace.id,
+      kind: "regular",
+    });
+  }
+
+  const editorGroupName = `${PROJECT_EDITOR_GROUP_PREFIX} ${projectName}`;
+  let editorGroup = await GroupResource.fetchByName(auth, editorGroupName);
+  if (!editorGroup) {
+    editorGroup = await GroupResource.makeNew(
+      {
+        name: editorGroupName,
+        workspaceId: workspace.id,
+        kind: "space_editors",
+      },
+      {
+        memberIds: [creatorId],
+      }
+    );
+  }
+
+  return SpaceResource.makeNew(
+    {
+      name: projectName,
+      kind: "project",
+      workspaceId: workspace.id,
+    },
+    { members: [memberGroup], editors: [editorGroup] }
+  );
+}
+
+async function createConversation(
+  auth: Authenticator,
+  user: UserResource,
+  workspace: { id: number },
+  conv: ConversationToCreate,
+  logger: Logger
+): Promise<void> {
+  const conversation = await ConversationResource.makeNew(
+    auth,
+    {
+      sId: generateRandomModelSId(),
+      title: conv.title,
+      visibility: "unlisted",
+      depth: 0,
+      requestedSpaceIds: conv.space ? [conv.space.id] : [],
+      spaceId: conv.space?.id ?? null,
+    },
+    conv.space
+  );
+
+  await ConversationResource.upsertParticipation(auth, {
+    conversation: conversation.toJSON(),
+    action: "posted",
+    user: user.toJSON(),
+    lastReadAt: new Date(),
+  });
+
+  for (let i = 0; i < conv.messages.length; i++) {
+    const exchange = conv.messages[i];
+
+    const userMessageRow = await UserMessageModel.create({
+      userId: user.id,
+      workspaceId: workspace.id,
+      content: exchange.userContent,
+      userContextUsername: user.username ?? "dev-user",
+      userContextTimezone: "UTC",
+      userContextFullName: user.fullName() ?? "Dev User",
+      userContextEmail: user.email ?? "dev@dust.tt",
+      userContextProfilePictureUrl: null,
+      userContextOrigin: "web",
+      clientSideMCPServerIds: [],
+    });
+
+    const userMsgRow = await MessageModel.create({
+      sId: generateRandomModelSId(),
+      rank: i * 2,
+      conversationId: conversation.id,
+      parentId: null,
+      userMessageId: userMessageRow.id,
+      workspaceId: workspace.id,
+    });
+
+    const agentMessageRow = await AgentMessageModel.create({
+      status: "succeeded",
+      agentConfigurationId: GLOBAL_AGENTS_SID.DUST,
+      agentConfigurationVersion: 0,
+      workspaceId: workspace.id,
+      skipToolsValidation: false,
+    });
+
+    await AgentStepContentResource.createNewVersion({
+      agentMessageId: agentMessageRow.id,
+      workspaceId: workspace.id,
+      step: 0,
+      index: 0,
+      type: "text_content",
+      value: {
+        type: "text_content",
+        value: exchange.agentContent,
+      },
+    });
+
+    await MessageModel.create({
+      sId: generateRandomModelSId(),
+      rank: i * 2 + 1,
+      conversationId: conversation.id,
+      parentId: userMsgRow.id,
+      agentMessageId: agentMessageRow.id,
+      workspaceId: workspace.id,
+    });
+  }
+
+  logger.info(
+    { conversationSId: conversation.sId, index: conv.index },
+    "Conversation created"
+  );
+}
+
+async function fetchWorkspaceAndUser(workspaceId: string): Promise<{
+  workspace: WorkspaceResource;
+  user: UserResource;
+  auth: Authenticator;
+}> {
+  const workspace = await WorkspaceResource.fetchById(workspaceId);
+  if (!workspace) {
+    throw new Error(`Workspace ${workspaceId} not found.`);
+  }
+
+  const { memberships } = await MembershipResource.getActiveMemberships({
+    workspace: renderLightWorkspaceType({ workspace }),
+    roles: ["admin"],
+  });
+  if (memberships.length === 0) {
+    throw new Error(`No admin user found in workspace ${workspaceId}.`);
+  }
+
+  const membershipUser = memberships[0].user;
+  if (!membershipUser) {
+    throw new Error("Membership has no associated user.");
+  }
+
+  const user = await UserResource.fetchById(membershipUser.sId);
+  if (!user) {
+    throw new Error("User not found.");
+  }
+
+  const auth = await Authenticator.fromUserIdAndWorkspaceId(
+    user.sId,
+    workspaceId
+  );
+
+  return { workspace, user, auth };
+}
+
+function calculateDistribution(config: SeedConfig): {
+  privateCount: number;
+  projectConvCount: number;
+  convsPerProject: number;
+} {
+  const privateCount = Math.floor(
+    config.conversationCount * config.privateRatio
+  );
+  const projectConvCount = config.conversationCount - privateCount;
+  const convsPerProject =
+    config.projectCount > 0
+      ? Math.ceil(projectConvCount / config.projectCount)
+      : 0;
+
+  return { privateCount, projectConvCount, convsPerProject };
+}
+
+async function createProjects(
+  auth: Authenticator,
+  workspace: WorkspaceResource,
+  user: UserResource,
+  projectCount: number,
+  logger: Logger
+): Promise<SpaceResource[]> {
+  const projects: SpaceResource[] = [];
+  logger.info({ count: projectCount }, "Creating projects");
+
+  for (let i = 0; i < projectCount; i++) {
+    const projectName = `Project ${faker.company.buzzNoun()} ${i + 1}`;
+    const project = await createProject(
+      auth,
+      { id: workspace.id },
+      user.id,
+      projectName
+    );
+    projects.push(project);
+    logger.info(
+      { projectSId: project.sId, name: projectName },
+      "Project created"
+    );
+  }
+
+  return projects;
+}
+
+function generateMessages(
+  count: number
+): Array<{ userContent: string; agentContent: string }> {
+  return Array.from({ length: count }).map(() => ({
+    userContent: generateUserMessage(),
+    agentContent: generateAgentResponse(),
+  }));
+}
+
+function buildConversationSpecs(
+  projects: SpaceResource[],
+  distribution: {
+    privateCount: number;
+    projectConvCount: number;
+    convsPerProject: number;
+  },
+  conversationCount: number,
+  messagesPerConversation: number
+): ConversationToCreate[] {
+  const specs: ConversationToCreate[] = [];
+
+  for (let i = 0; i < distribution.privateCount; i++) {
+    specs.push({
+      index: i,
+      space: null,
+      title: generateConversationTitle(),
+      messages: generateMessages(messagesPerConversation),
+    });
+  }
+
+  let projectConvIndex = distribution.privateCount;
+  for (const project of projects) {
+    for (let c = 0; c < distribution.convsPerProject; c++) {
+      if (projectConvIndex >= conversationCount) {
+        break;
+      }
+      specs.push({
+        index: projectConvIndex,
+        space: project,
+        title: generateConversationTitle(),
+        messages: generateMessages(messagesPerConversation),
+      });
+      projectConvIndex++;
+    }
+  }
+
+  return specs;
+}
+
+async function seedConversations(
+  config: SeedConfig,
+  logger: Logger,
+  execute: boolean
+): Promise<void> {
+  if (process.env.NODE_ENV !== "development") {
+    throw new Error("This script can only be run in development.");
+  }
+
+  logger.info(config, "Starting seed conversations script");
+
+  const { workspace, user, auth } = await fetchWorkspaceAndUser(
+    config.workspaceId
+  );
+  const distribution = calculateDistribution(config);
+
+  logger.info(
+    {
+      privateCount: distribution.privateCount,
+      projectConvCount: distribution.projectConvCount,
+      projectCount: config.projectCount,
+      convsPerProject: distribution.convsPerProject,
+    },
+    "Distribution calculated"
+  );
+
+  if (!execute) {
+    logger.info("Dry run mode - no changes will be made");
+    logger.info(
+      {
+        wouldCreateProjects: config.projectCount,
+        wouldCreatePrivateConversations: distribution.privateCount,
+        wouldCreateProjectConversations: distribution.projectConvCount,
+      },
+      "Would create"
+    );
+    return;
+  }
+
+  const projects = await createProjects(
+    auth,
+    workspace,
+    user,
+    config.projectCount,
+    logger
+  );
+
+  const conversationsToCreate = buildConversationSpecs(
+    projects,
+    distribution,
+    config.conversationCount,
+    config.messagesPerConversation
+  );
+
+  logger.info(
+    { count: conversationsToCreate.length },
+    "Creating conversations"
+  );
+
+  await concurrentExecutor(
+    conversationsToCreate,
+    async (conv) => {
+      await createConversation(auth, user, { id: workspace.id }, conv, logger);
+    },
+    { concurrency: 10 }
+  );
+
+  logger.info(
+    {
+      projectsCreated: projects.length,
+      conversationsCreated: conversationsToCreate.length,
+    },
+    "Seed completed"
+  );
+}
+
+makeScript(
+  {
+    workspaceId: {
+      type: "string",
+      description: "Workspace sId to seed conversations in",
+      demandOption: true,
+    },
+    conversationCount: {
+      type: "number",
+      description: "Total number of conversations to create",
+      default: 200,
+    },
+    projectCount: {
+      type: "number",
+      description: "Number of projects to create",
+      default: 100,
+    },
+    privateRatio: {
+      type: "number",
+      description: "Ratio of private conversations (0-1)",
+      default: 0.5,
+    },
+    messagesPerConversation: {
+      type: "number",
+      description: "Number of message exchanges per conversation",
+      default: 3,
+    },
+  },
+  async (
+    {
+      workspaceId,
+      conversationCount,
+      projectCount,
+      privateRatio,
+      messagesPerConversation,
+      execute,
+    },
+    logger
+  ) => {
+    await seedConversations(
+      {
+        workspaceId,
+        conversationCount,
+        projectCount,
+        privateRatio,
+        messagesPerConversation,
+      },
+      logger,
+      execute
+    );
+  }
+);


### PR DESCRIPTION
## Description

- [ ] Paginate conversations list
- [ ] Add exact matching search for conversations (needed since conversations list is now paginated)
- [ ] Move conversations/search to conversations/semantic_search
- [ ] Add script to seed conv / project data

## Tests

- Tested manally
- Unit tests

## Risk

Low
Blast radius: Conversation listing / searching

## Deploy Plan

- [x] Deploy on front-edge
- [ ] Deploy on front