### PR TITLE
[front] perf: Cache workspace fetchById

### DIFF
--- a/front/lib/api/signup.ts
+++ b/front/lib/api/signup.ts
@@ -28,12 +28,13 @@ export async function createAndLogMembership({
   origin,
 }: {
   user: UserResource;
-  workspace: WorkspaceModel | LightWorkspaceType;
+  workspace: WorkspaceResource | WorkspaceModel | LightWorkspaceType;
   role: ActiveRoleType;
   origin: MembershipOriginType;
 }) {
   const w =
-    workspace instanceof WorkspaceModel
+    workspace instanceof WorkspaceModel ||
+    workspace instanceof WorkspaceResource
       ? renderLightWorkspaceType({ workspace })
       : workspace;
   const m = await MembershipResource.createMembership({

--- a/front/lib/iam/workspaces.ts
+++ b/front/lib/iam/workspaces.ts
@@ -6,7 +6,6 @@ import { isFreePlan, isUpgraded } from "@app/lib/plans/plan_codes";
 import { GroupResource } from "@app/lib/resources/group_resource";
 import { MCPServerViewResource } from "@app/lib/resources/mcp_server_view_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
-import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
 import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
@@ -73,7 +72,7 @@ export async function createWorkspaceInternal({
     };
   }
 
-  const workspace = await WorkspaceModel.create({
+  const workspace = await WorkspaceResource.makeNew({
     sId: generateRandomModelSId(),
     name,
     metadata,

--- a/front/lib/resources/workspace_resource.ts
+++ b/front/lib/resources/workspace_resource.ts
@@ -6,12 +6,15 @@ import {
 import type { Authenticator } from "@app/lib/auth";
 import type { ResourceLogJSON } from "@app/lib/resources/base_resource";
 import { BaseResource } from "@app/lib/resources/base_resource";
+import type { ModelProviderIdType } from "@app/lib/resources/storage/models/workspace";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import { WorkspaceHasDomainModel } from "@app/lib/resources/storage/models/workspace_has_domain";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ModelStaticWorkspaceAware } from "@app/lib/resources/storage/wrappers/workspace_models";
+import { cacheWithRedis, invalidateCacheWithRedis } from "@app/lib/utils/cache";
 import { renderLightWorkspaceType } from "@app/lib/workspace";
 import logger from "@app/logger/logger";
+import type { EmbeddingProviderIdType } from "@app/types/assistant/models/types";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
@@ -25,6 +28,26 @@ import type {
   Transaction,
 } from "sequelize";
 import { Op } from "sequelize";
+
+const WORKSPACE_CACHE_TTL_MS = 30 * 60 * 1000; // 30 minutes
+
+// We use this to avoid accidentaly inflating the cache footprint
+// Add new attributes with caution
+type CachedWorkspaceData = {
+  id: ModelId;
+  sId: string;
+  name: string;
+  description: string | null;
+  segmentation: WorkspaceSegmentationType | null;
+  ssoEnforced: boolean;
+  workOSOrganizationId: string | null;
+  whiteListedProviders: ModelProviderIdType[] | null;
+  defaultEmbeddingProvider: EmbeddingProviderIdType | null;
+  metadata: Record<string, string | number | boolean | object> | null;
+  conversationsRetentionDays: number | null;
+  createdAt: number;
+  updatedAt: number;
+};
 
 // Attributes are marked as read-only to reflect the stateless nature of our Resource.
 // This design will be moved up to BaseResource once we transition away from Sequelize.
@@ -48,6 +71,74 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
     this.blob = blob;
   }
 
+  private static readonly workspaceCacheKeyResolver = (wId: string) =>
+    `workspace:sid:${wId}`;
+
+  private static async _fetchByIdUncached(
+    wId: string
+  ): Promise<CachedWorkspaceData | null> {
+    const workspace = await WorkspaceModel.findOne({
+      where: { sId: wId },
+    });
+    if (!workspace) {
+      return null;
+    }
+    return {
+      id: workspace.id,
+      sId: workspace.sId,
+      name: workspace.name,
+      description: workspace.description,
+      segmentation: workspace.segmentation,
+      ssoEnforced: workspace.ssoEnforced ?? false,
+      workOSOrganizationId: workspace.workOSOrganizationId,
+      whiteListedProviders: workspace.whiteListedProviders,
+      defaultEmbeddingProvider: workspace.defaultEmbeddingProvider,
+      metadata: workspace.metadata,
+      conversationsRetentionDays: workspace.conversationsRetentionDays,
+      createdAt: workspace.createdAt.getTime(),
+      updatedAt: workspace.updatedAt.getTime(),
+    };
+  }
+
+  private static fetchByIdCached = cacheWithRedis(
+    WorkspaceResource._fetchByIdUncached,
+    WorkspaceResource.workspaceCacheKeyResolver,
+    { ttlMs: WORKSPACE_CACHE_TTL_MS }
+  );
+
+  private static invalidateWorkspaceCache = invalidateCacheWithRedis(
+    WorkspaceResource._fetchByIdUncached,
+    WorkspaceResource.workspaceCacheKeyResolver
+  );
+
+  private static fromCachedData(data: CachedWorkspaceData): WorkspaceResource {
+    const blob: Attributes<WorkspaceModel> = {
+      id: data.id,
+      sId: data.sId,
+      name: data.name,
+      description: data.description,
+      segmentation: data.segmentation,
+      ssoEnforced: data.ssoEnforced,
+      workOSOrganizationId: data.workOSOrganizationId,
+      whiteListedProviders: data.whiteListedProviders,
+      defaultEmbeddingProvider: data.defaultEmbeddingProvider,
+      metadata: data.metadata,
+      conversationsRetentionDays: data.conversationsRetentionDays,
+      createdAt: new Date(data.createdAt),
+      updatedAt: new Date(data.updatedAt),
+    };
+    return new WorkspaceResource(WorkspaceModel, blob);
+  }
+
+  protected override async update(
+    blob: Partial<Attributes<WorkspaceModel>>,
+    transaction?: Transaction
+  ): Promise<[affectedCount: number]> {
+    const result = await super.update(blob, transaction);
+    await WorkspaceResource.invalidateWorkspaceCache(this.sId);
+    return result;
+  }
+
   static async makeNew(
     blob: CreationAttributes<WorkspaceModel>
   ): Promise<WorkspaceResource> {
@@ -56,13 +147,23 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
     return new this(this.model, workspace.get());
   }
 
-  static async fetchById(wId: string): Promise<WorkspaceResource | null> {
-    const workspace = await this.model.findOne({
-      where: {
-        sId: wId,
-      },
-    });
-    return workspace ? new this(this.model, workspace.get()) : null;
+  static async fetchById(
+    wId: string,
+    transaction?: Transaction
+  ): Promise<WorkspaceResource | null> {
+    if (transaction) {
+      const workspace = await this.model.findOne({
+        where: { sId: wId },
+        transaction,
+      });
+      return workspace ? new this(this.model, workspace.get()) : null;
+    }
+
+    const cached = await this.fetchByIdCached(wId);
+    if (!cached) {
+      return null;
+    }
+    return this.fromCachedData(cached);
   }
 
   static async fetchByName(name: string): Promise<WorkspaceResource | null> {
@@ -426,19 +527,16 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
   static async disableSSOEnforcement(
     id: ModelId
   ): Promise<Result<void, Error>> {
-    const [affectedCount] = await WorkspaceModel.update(
-      { ssoEnforced: false },
-      {
-        where: {
-          id,
-          ssoEnforced: true,
-        },
-      }
-    );
+    const workspace = await this.model.findOne({
+      where: { id, ssoEnforced: true },
+    });
 
-    if (affectedCount === 0) {
+    if (!workspace) {
       return new Err(new Error("SSO enforcement is already disabled."));
     }
+
+    const workspaceResource = new this(this.model, workspace.get());
+    await workspaceResource.update({ ssoEnforced: false });
 
     return new Ok(undefined);
   }
@@ -460,6 +558,7 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
         where: { id: this.blob.id },
         transaction,
       });
+      await WorkspaceResource.invalidateWorkspaceCache(this.sId);
       return new Ok(deletedCount);
     } catch (error) {
       return new Err(normalizeError(error));
@@ -472,18 +571,20 @@ export class WorkspaceResource extends BaseResource<WorkspaceModel> {
     };
   }
 
-  // Perform an update operation and check workspace existence.
   static async updateByModelIdAndCheckExistence(
     id: ModelId,
     updateValues: Partial<Attributes<WorkspaceModel>>
   ): Promise<Result<void, Error>> {
-    const [affectedCount] = await WorkspaceModel.update(updateValues, {
+    const workspace = await this.model.findOne({
       where: { id },
     });
 
-    if (affectedCount === 0) {
+    if (!workspace) {
       return new Err(new Error("Workspace not found."));
     }
+
+    const workspaceResource = new this(this.model, workspace.get());
+    await workspaceResource.update(updateValues);
 
     return new Ok(undefined);
   }

--- a/front/poke/temporal/activities.ts
+++ b/front/poke/temporal/activities.ts
@@ -60,7 +60,6 @@ import {
   UserToolApprovalModel,
 } from "@app/lib/resources/storage/models/user";
 import { UserProjectDigestModel } from "@app/lib/resources/storage/models/user_project_digest";
-import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import { WorkspaceHasDomainModel } from "@app/lib/resources/storage/models/workspace_has_domain";
 import { TagResource } from "@app/lib/resources/tags_resource";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
@@ -727,11 +726,11 @@ export async function deleteWorkspaceActivity({
   await AgentDataRetentionModel.destroy({
     where: { workspaceId: workspace.id },
   });
-  await WorkspaceModel.destroy({
-    where: {
-      id: workspace.id,
-    },
-  });
+
+  const workspaceResource = await WorkspaceResource.fetchById(workspace.sId);
+  if (workspaceResource) {
+    await workspaceResource.delete(auth, {});
+  }
 }
 
 export async function deleteTranscriptsActivity({


### PR DESCRIPTION
## Description

This is part of a global effort to reduce Dust's api latency, this stack focusing on fromSession (20M req / day)

- Cache workspace resource's fetchById
- Invalidate cache key where it makes sense (reviewer: please keep me honest 🙏 )
- cacheKey:     `workspace:sid:${wId}`;


## Tests

Tested manually

## Risk

Low: 1 key per worskpace added in redis + not a lot of data ~ not worried. More worried about forgetting to invalidate keys
Blast Radius: Small (or big if we blast redis)

## Deploy Plan

- [ ] Deploy front