### PR TITLE
[front] perf: Cache groups for fromSession

### DIFF
--- a/front/lib/api/actions/servers/agent_copilot_context/agent_copilot_context.test.ts
+++ b/front/lib/api/actions/servers/agent_copilot_context/agent_copilot_context.test.ts
@@ -1556,7 +1556,8 @@ describe("agent_copilot_context tools", () => {
       const { getAgentConfigurationIdFromContext } = await import(
         "@app/lib/api/actions/servers/agent_copilot_helpers"
       );
-      vi.mocked(getAgentConfigurationIdFromContext).mockReturnValueOnce(null);
+      // Reset and set return value to ensure isolation from other tests.
+      vi.mocked(getAgentConfigurationIdFromContext).mockReturnValue(null);
 
       const tool = getToolByName("list_suggestions");
       const result = await tool.handler({}, createTestExtra(authenticator));
@@ -1570,7 +1571,8 @@ describe("agent_copilot_context tools", () => {
       const { getAgentConfigurationIdFromContext } = await import(
         "@app/lib/api/actions/servers/agent_copilot_helpers"
       );
-      vi.mocked(getAgentConfigurationIdFromContext).mockReturnValueOnce(
+      // Reset and set return value to ensure isolation from other tests.
+      vi.mocked(getAgentConfigurationIdFromContext).mockReturnValue(
         "test-agent-id"
       );
 
@@ -1596,7 +1598,8 @@ describe("agent_copilot_context tools", () => {
       const { getAgentConfigurationIdFromContext } = await import(
         "@app/lib/api/actions/servers/agent_copilot_helpers"
       );
-      vi.mocked(getAgentConfigurationIdFromContext).mockReturnValueOnce(
+      // Reset and set return value to ensure isolation from other tests.
+      vi.mocked(getAgentConfigurationIdFromContext).mockReturnValue(
         "test-agent-id"
       );
 

--- a/front/lib/api/assistant/configuration/agent.ts
+++ b/front/lib/api/assistant/configuration/agent.ts
@@ -1218,19 +1218,7 @@ export async function archiveAgentConfiguration(
       agentConfig
     );
     if (editorGroupRes.isOk()) {
-      const editorGroup = editorGroupRes.value;
-      await GroupMembershipModel.update(
-        { status: "suspended" },
-        {
-          where: {
-            groupId: editorGroup.id,
-            workspaceId: owner.id,
-            status: "active",
-            startAt: { [Op.lte]: new Date() },
-            [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: new Date() } }],
-          },
-        }
-      );
+      await editorGroupRes.value.suspendMembers(auth);
     }
   }
 
@@ -1276,19 +1264,7 @@ export async function restoreAgentConfiguration(
       id: latestConfig.id,
     } as LightAgentConfigurationType);
     if (editorGroupRes.isOk()) {
-      const editorGroup = editorGroupRes.value;
-      await GroupMembershipModel.update(
-        { status: "active" },
-        {
-          where: {
-            groupId: editorGroup.id,
-            workspaceId: owner.id,
-            status: "suspended",
-            startAt: { [Op.lte]: new Date() },
-            [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: new Date() } }],
-          },
-        }
-      );
+      await editorGroupRes.value.restoreMembers(auth);
     }
 
     const triggers = await TriggerResource.listByAgentConfigurationId(

--- a/front/lib/api/assistant/template_suggestion.test.ts
+++ b/front/lib/api/assistant/template_suggestion.test.ts
@@ -11,8 +11,9 @@ vi.mock("@app/lib/api/assistant/call_llm", () => ({
 
 const mockRunMultiActionsAgent = vi.mocked(runMultiActionsAgent);
 
+// Use clearAllMocks (not resetAllMocks) to preserve global mock implementations from vite.setup.ts.
 beforeEach(() => {
-  vi.resetAllMocks();
+  vi.clearAllMocks();
 });
 
 describe("getSuggestedTemplatesForQuery", () => {

--- a/front/lib/api/workspace.ts
+++ b/front/lib/api/workspace.ts
@@ -191,7 +191,7 @@ export async function searchMembers(
   options: {
     searchTerm?: string;
     searchEmails?: string[];
-    groupKind?: Omit<GroupKind, "system">;
+    groupKind?: Exclude<GroupKind, "system">;
     buildersOnly?: boolean;
   },
   paginationParams: SearchMembersPaginationParams

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -198,17 +198,16 @@ export class Authenticator {
         user,
         workspace: lightWorkspace,
       }),
-      GroupResource.listUserGroupModelIdsInWorkspace({
+      GroupResource.dangerouslyListUserGroupsForAuth({
         user,
         workspace: lightWorkspace,
-        dangerouslySkipMembershipCheck: true,
       }),
       SubscriptionResource.fetchActiveByWorkspaceModelId(lightWorkspace.id),
     ]);
 
     return {
       role,
-      groupModelIds: role === "none" ? [] : groupModelIds,
+      groupModelIds: Authenticator.isMember(role) ? groupModelIds : [],
       subscription,
     };
   }
@@ -256,16 +255,22 @@ export class Authenticator {
     });
   }
 
+  /**
+   * Checks if a role indicates workspace membership (role is not "none").
+   */
+  static isMember(role: RoleType): boolean {
+    return role !== "none";
+  }
+
   async refresh({ transaction }: { transaction?: Transaction } = {}) {
     if (this._user && this._workspace) {
-      this._groupModelIds =
-        await GroupResource.listUserGroupModelIdsInWorkspace({
-          user: this._user,
-          workspace: renderLightWorkspaceType({ workspace: this._workspace }),
-          transaction,
-        });
-    } else {
-      return;
+      this._groupModelIds = Authenticator.isMember(this._role)
+        ? await GroupResource.dangerouslyListUserGroupsForAuth({
+            user: this._user,
+            workspace: renderLightWorkspaceType({ workspace: this._workspace }),
+            transaction,
+          })
+        : [];
     }
   }
 
@@ -679,11 +684,10 @@ export class Authenticator {
       return null;
     }
 
-    const groupModelIds = await GroupResource.listUserGroupModelIdsInWorkspace({
+    // Membership already verified above (activeMembership found).
+    const groupModelIds = await GroupResource.dangerouslyListUserGroupsForAuth({
       user,
-      workspace: renderLightWorkspaceType({ workspace: owner }),
-      // Membership already verified above (activeMembership found).
-      dangerouslySkipMembershipCheck: true,
+      workspace: owner,
     });
 
     return new Authenticator({

--- a/front/lib/iam/users.ts
+++ b/front/lib/iam/users.ts
@@ -8,11 +8,11 @@ import {
 import { UserMessageModel } from "@app/lib/models/agent/conversation";
 import { DustAppSecretModel } from "@app/lib/models/dust_app_secret";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
+import { GroupResource } from "@app/lib/resources/group_resource";
 import { MembershipResource } from "@app/lib/resources/membership_resource";
 import { AgentMemoryModel } from "@app/lib/resources/storage/models/agent_memories";
 import { ContentFragmentModel } from "@app/lib/resources/storage/models/content_fragment";
 import { FileModel } from "@app/lib/resources/storage/models/files";
-import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
 import { KeyModel } from "@app/lib/resources/storage/models/keys";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import { UserResource } from "@app/lib/resources/user_resource";
@@ -328,23 +328,11 @@ export async function mergeUserIdentities({
   // Migrate authorship of agent memories from the secondary user to the primary user.
   await AgentMemoryModel.update(userIdValues, userIdOptions);
 
-  // Delete all group memberships for the secondary user that are already member.
-  const groups = await GroupMembershipModel.findAll({
-    where: {
-      userId: primaryUser.id,
-      workspaceId: workspaceId,
-    },
-    attributes: ["groupId"],
+  // Migrate group memberships from secondary user to primary user
+  await GroupResource.migrateUserMemberships(auth, {
+    primaryUser,
+    secondaryUser,
   });
-  await GroupMembershipModel.destroy({
-    where: {
-      userId: secondaryUser.id,
-      groupId: groups.map((p) => p.groupId),
-      workspaceId: workspaceId,
-    },
-  });
-  // Replace all group memberships for the secondary user with the primary user.
-  await GroupMembershipModel.update(userIdValues, userIdOptions);
 
   // Delete all agent-user relations for the secondary user that already have a relation.
   const agentConfigurations = await AgentUserRelationModel.findAll({

--- a/front/lib/resources/group_resource.test.ts
+++ b/front/lib/resources/group_resource.test.ts
@@ -65,100 +65,496 @@ vi.mock("@app/lib/utils/cache", () => ({
     ),
 }));
 
-import { Authenticator } from "@app/lib/auth";
-import { GroupResource } from "@app/lib/resources/group_resource";
-import { GroupModel } from "@app/lib/resources/storage/models/groups";
+import type { Authenticator } from "@app/lib/auth";
+import type { GroupResource } from "@app/lib/resources/group_resource";
+import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
 import type { UserResource } from "@app/lib/resources/user_resource";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
 import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
 import { UserFactory } from "@app/tests/utils/UserFactory";
-import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
-import type { WorkspaceType } from "@app/types/user";
+import type { LightWorkspaceType } from "@app/types/user";
+
+function getCacheKeyForUser(userId: number, workspaceId: number): string {
+  // The function name is empty because an anonymous arrow function is passed to cacheWithRedis
+  return `cacheWithRedis--groups:user:${userId}:workspace:${workspaceId}`;
+}
 
 describe("GroupResource", () => {
-  describe("listUserGroupModelIdsInWorkspace", () => {
-    let workspace: WorkspaceType;
-    let member: UserResource;
+  let workspace: LightWorkspaceType;
+  let user: UserResource;
+  let authenticator: Authenticator;
+  let globalGroup: GroupResource;
 
-    beforeEach(async () => {
-      workspace = await WorkspaceFactory.basic();
-      member = await UserFactory.basic();
-      await MembershipFactory.associate(workspace, member, { role: "user" });
-    });
+  beforeEach(async () => {
+    const testSetup = await createResourceTest({ role: "admin" });
+    workspace = testSetup.workspace;
+    user = testSetup.user;
+    authenticator = testSetup.authenticator;
+    globalGroup = testSetup.globalGroup;
+    // Clear cache after setup since Authenticator creation may populate it
+    inMemoryCache.clear();
+  });
 
+  describe("dangerouslyListUserGroupsForAuth", () => {
     it("returns global group and explicit groups for a workspace member", async () => {
+      const { GroupResource } = await import(
+        "@app/lib/resources/group_resource"
+      );
+
       const regularGroup = await GroupResource.makeNew({
         name: "Test Group",
         workspaceId: workspace.id,
         kind: "regular",
       });
-      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
-      await regularGroup.dangerouslyAddMembers(auth, {
-        users: [member.toJSON()],
+      await regularGroup.dangerouslyAddMembers(authenticator, {
+        users: [user.toJSON()],
       });
 
-      const groupIds = await GroupResource.listUserGroupModelIdsInWorkspace({
-        user: member,
+      const groupIds = await GroupResource.dangerouslyListUserGroupsForAuth({
+        user,
         workspace,
       });
 
       expect(groupIds.length).toBe(2);
-
-      const globalGroup = await GroupModel.findOne({
-        where: { workspaceId: workspace.id, kind: "global" },
-      });
-      expect(globalGroup).not.toBeNull();
-      expect(groupIds).toContain(globalGroup!.id);
+      expect(groupIds).toContain(globalGroup.id);
       expect(groupIds).toContain(regularGroup.id);
     });
 
-    it("returns empty array for non-member", async () => {
+    it("returns global group for non-member (no membership check)", async () => {
+      const { GroupResource } = await import(
+        "@app/lib/resources/group_resource"
+      );
       const nonMember = await UserFactory.basic();
 
-      const groupIds = await GroupResource.listUserGroupModelIdsInWorkspace({
+      const groupIds = await GroupResource.dangerouslyListUserGroupsForAuth({
         user: nonMember,
         workspace,
       });
 
-      expect(groupIds).toEqual([]);
+      expect(groupIds.length).toBe(1);
+      expect(groupIds).toContain(globalGroup.id);
     });
 
-    it("returns groups for non-member when dangerouslySkipMembershipCheck is true", async () => {
-      const nonMember = await UserFactory.basic();
+    it("throws when global group is missing", async () => {
+      const { GroupResource } = await import(
+        "@app/lib/resources/group_resource"
+      );
+      const { GroupModel } = await import(
+        "@app/lib/resources/storage/models/groups"
+      );
 
-      const groupIds = await GroupResource.listUserGroupModelIdsInWorkspace({
-        user: nonMember,
-        workspace,
-        dangerouslySkipMembershipCheck: true,
-      });
-
-      // Should still return the global group even though the user is not a member.
-      expect(groupIds.length).toBeGreaterThanOrEqual(1);
-      const globalGroup = await GroupModel.findOne({
-        where: { workspaceId: workspace.id, kind: "global" },
-      });
-      expect(groupIds).toContain(globalGroup!.id);
-    });
-
-    it("throws when global group is missing regardless of skip flag", async () => {
-      // Delete the global group to simulate a data integrity issue.
       await GroupModel.destroy({
         where: { workspaceId: workspace.id, kind: "global" },
       });
 
       await expect(
-        GroupResource.listUserGroupModelIdsInWorkspace({
-          user: member,
+        GroupResource.dangerouslyListUserGroupsForAuth({
+          user,
           workspace,
         })
       ).rejects.toThrow("Global group not found.");
+    });
+  });
 
-      await expect(
-        GroupResource.listUserGroupModelIdsInWorkspace({
-          user: member,
-          workspace,
-          dangerouslySkipMembershipCheck: true,
-        })
-      ).rejects.toThrow("Global group not found.");
+  describe("dangerouslyListUserGroupsForAuth caching", () => {
+    it("returns groups for authenticated user", async () => {
+      const { GroupResource } = await import(
+        "@app/lib/resources/group_resource"
+      );
+
+      const regularGroup = await GroupResource.makeNew({
+        name: "Auth Test Group",
+        workspaceId: workspace.id,
+        kind: "regular",
+      });
+      await regularGroup.dangerouslyAddMembers(authenticator, {
+        users: [user.toJSON()],
+      });
+
+      const groupIds = await GroupResource.dangerouslyListUserGroupsForAuth({
+        user,
+        workspace,
+      });
+
+      expect(groupIds.length).toBe(2);
+      expect(groupIds).toContain(globalGroup.id);
+      expect(groupIds).toContain(regularGroup.id);
+    });
+
+    it("populates cache on first call", async () => {
+      const { GroupResource } = await import(
+        "@app/lib/resources/group_resource"
+      );
+      const cacheKey = getCacheKeyForUser(user.id, workspace.id);
+
+      expect(inMemoryCache.has(cacheKey)).toBe(false);
+
+      await GroupResource.dangerouslyListUserGroupsForAuth({ user, workspace });
+
+      expect(inMemoryCache.has(cacheKey)).toBe(true);
+    });
+
+    it("serves from cache on second call", async () => {
+      const { GroupResource } = await import(
+        "@app/lib/resources/group_resource"
+      );
+      const cacheKey = getCacheKeyForUser(user.id, workspace.id);
+
+      const groupIds1 = await GroupResource.dangerouslyListUserGroupsForAuth({
+        user,
+        workspace,
+      });
+      expect(inMemoryCache.has(cacheKey)).toBe(true);
+
+      const groupIds2 = await GroupResource.dangerouslyListUserGroupsForAuth({
+        user,
+        workspace,
+      });
+      expect(inMemoryCache.has(cacheKey)).toBe(true);
+
+      expect(groupIds1).toEqual(groupIds2);
+    });
+  });
+
+  describe("suspendMembers", () => {
+    it("suspends active members and returns affected user IDs", async () => {
+      const { GroupResource } = await import(
+        "@app/lib/resources/group_resource"
+      );
+
+      const regularGroup = await GroupResource.makeNew({
+        name: "Suspend Test Group",
+        workspaceId: workspace.id,
+        kind: "regular",
+      });
+      await regularGroup.dangerouslyAddMembers(authenticator, {
+        users: [user.toJSON()],
+      });
+
+      const membership = await GroupMembershipModel.findOne({
+        where: {
+          groupId: regularGroup.id,
+          userId: user.id,
+          workspaceId: workspace.id,
+        },
+      });
+      expect(membership?.status).toBe("active");
+
+      const affectedUserIds = await regularGroup.suspendMembers(authenticator);
+
+      expect(affectedUserIds).toContain(user.id);
+
+      const updatedMembership = await GroupMembershipModel.findOne({
+        where: {
+          groupId: regularGroup.id,
+          userId: user.id,
+          workspaceId: workspace.id,
+        },
+      });
+      expect(updatedMembership?.status).toBe("suspended");
+    });
+
+    it("invalidates cache for all affected users", async () => {
+      const { GroupResource } = await import(
+        "@app/lib/resources/group_resource"
+      );
+
+      const regularGroup = await GroupResource.makeNew({
+        name: "Cache Invalidation Test",
+        workspaceId: workspace.id,
+        kind: "regular",
+      });
+      await regularGroup.dangerouslyAddMembers(authenticator, {
+        users: [user.toJSON()],
+      });
+
+      await GroupResource.dangerouslyListUserGroupsForAuth({ user, workspace });
+      const cacheKey = getCacheKeyForUser(user.id, workspace.id);
+      expect(inMemoryCache.has(cacheKey)).toBe(true);
+
+      await regularGroup.suspendMembers(authenticator);
+
+      expect(inMemoryCache.has(cacheKey)).toBe(false);
+    });
+  });
+
+  describe("restoreMembers", () => {
+    it("restores suspended members and returns affected user IDs", async () => {
+      const { GroupResource } = await import(
+        "@app/lib/resources/group_resource"
+      );
+
+      const regularGroup = await GroupResource.makeNew({
+        name: "Restore Test Group",
+        workspaceId: workspace.id,
+        kind: "regular",
+      });
+      await regularGroup.dangerouslyAddMembers(authenticator, {
+        users: [user.toJSON()],
+      });
+
+      await regularGroup.suspendMembers(authenticator);
+      const suspendedMembership = await GroupMembershipModel.findOne({
+        where: {
+          groupId: regularGroup.id,
+          userId: user.id,
+          workspaceId: workspace.id,
+        },
+      });
+      expect(suspendedMembership?.status).toBe("suspended");
+
+      const affectedUserIds = await regularGroup.restoreMembers(authenticator);
+
+      expect(affectedUserIds).toContain(user.id);
+
+      const restoredMembership = await GroupMembershipModel.findOne({
+        where: {
+          groupId: regularGroup.id,
+          userId: user.id,
+          workspaceId: workspace.id,
+        },
+      });
+      expect(restoredMembership?.status).toBe("active");
+    });
+
+    it("invalidates cache for all affected users", async () => {
+      const { GroupResource } = await import(
+        "@app/lib/resources/group_resource"
+      );
+
+      const regularGroup = await GroupResource.makeNew({
+        name: "Restore Cache Test",
+        workspaceId: workspace.id,
+        kind: "regular",
+      });
+      await regularGroup.dangerouslyAddMembers(authenticator, {
+        users: [user.toJSON()],
+      });
+
+      await regularGroup.suspendMembers(authenticator);
+
+      await GroupResource.dangerouslyListUserGroupsForAuth({ user, workspace });
+      const cacheKey = getCacheKeyForUser(user.id, workspace.id);
+      expect(inMemoryCache.has(cacheKey)).toBe(true);
+
+      await regularGroup.restoreMembers(authenticator);
+
+      expect(inMemoryCache.has(cacheKey)).toBe(false);
+    });
+  });
+
+  describe("migrateUserMemberships", () => {
+    it("migrates memberships from secondary to primary user", async () => {
+      const { GroupResource } = await import(
+        "@app/lib/resources/group_resource"
+      );
+
+      const secondaryUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, secondaryUser, {
+        role: "user",
+      });
+
+      const regularGroup = await GroupResource.makeNew({
+        name: "Migration Test Group",
+        workspaceId: workspace.id,
+        kind: "regular",
+      });
+      await regularGroup.dangerouslyAddMembers(authenticator, {
+        users: [secondaryUser.toJSON()],
+      });
+
+      const membershipBefore = await GroupMembershipModel.findOne({
+        where: {
+          groupId: regularGroup.id,
+          userId: secondaryUser.id,
+          workspaceId: workspace.id,
+        },
+      });
+      expect(membershipBefore).not.toBeNull();
+
+      await GroupResource.migrateUserMemberships(authenticator, {
+        primaryUser: user,
+        secondaryUser: secondaryUser,
+      });
+
+      const membershipAfter = await GroupMembershipModel.findOne({
+        where: {
+          groupId: regularGroup.id,
+          userId: user.id,
+          workspaceId: workspace.id,
+        },
+      });
+      expect(membershipAfter).not.toBeNull();
+
+      const secondaryMembershipAfter = await GroupMembershipModel.findOne({
+        where: {
+          groupId: regularGroup.id,
+          userId: secondaryUser.id,
+          workspaceId: workspace.id,
+        },
+      });
+      expect(secondaryMembershipAfter).toBeNull();
+    });
+
+    it("handles duplicate memberships by removing from secondary user first", async () => {
+      const { GroupResource } = await import(
+        "@app/lib/resources/group_resource"
+      );
+
+      const secondaryUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, secondaryUser, {
+        role: "user",
+      });
+
+      const regularGroup = await GroupResource.makeNew({
+        name: "Duplicate Migration Test",
+        workspaceId: workspace.id,
+        kind: "regular",
+      });
+
+      await regularGroup.dangerouslyAddMembers(authenticator, {
+        users: [user.toJSON()],
+      });
+      await regularGroup.dangerouslyAddMembers(authenticator, {
+        users: [secondaryUser.toJSON()],
+      });
+
+      await GroupResource.migrateUserMemberships(authenticator, {
+        primaryUser: user,
+        secondaryUser: secondaryUser,
+      });
+
+      const primaryMembership = await GroupMembershipModel.findOne({
+        where: {
+          groupId: regularGroup.id,
+          userId: user.id,
+          workspaceId: workspace.id,
+        },
+      });
+      expect(primaryMembership).not.toBeNull();
+
+      const secondaryMembership = await GroupMembershipModel.findOne({
+        where: {
+          groupId: regularGroup.id,
+          userId: secondaryUser.id,
+          workspaceId: workspace.id,
+        },
+      });
+      expect(secondaryMembership).toBeNull();
+    });
+
+    it("invalidates cache for both users", async () => {
+      const { GroupResource } = await import(
+        "@app/lib/resources/group_resource"
+      );
+
+      const secondaryUser = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, secondaryUser, {
+        role: "user",
+      });
+
+      const regularGroup = await GroupResource.makeNew({
+        name: "Cache Migration Test",
+        workspaceId: workspace.id,
+        kind: "regular",
+      });
+      await regularGroup.dangerouslyAddMembers(authenticator, {
+        users: [secondaryUser.toJSON()],
+      });
+
+      // Populate cache for both users
+      await GroupResource.dangerouslyListUserGroupsForAuth({ user, workspace });
+      await GroupResource.dangerouslyListUserGroupsForAuth({
+        user: secondaryUser,
+        workspace,
+      });
+
+      const primaryCacheKey = getCacheKeyForUser(user.id, workspace.id);
+      const secondaryCacheKey = getCacheKeyForUser(
+        secondaryUser.id,
+        workspace.id
+      );
+      expect(inMemoryCache.has(primaryCacheKey)).toBe(true);
+      expect(inMemoryCache.has(secondaryCacheKey)).toBe(true);
+
+      await GroupResource.migrateUserMemberships(authenticator, {
+        primaryUser: user,
+        secondaryUser: secondaryUser,
+      });
+
+      expect(inMemoryCache.has(primaryCacheKey)).toBe(false);
+      expect(inMemoryCache.has(secondaryCacheKey)).toBe(false);
+    });
+  });
+
+  describe("cache invalidation on membership changes", () => {
+    it("dangerouslyAddMembers invalidates cache for added users", async () => {
+      const { GroupResource } = await import(
+        "@app/lib/resources/group_resource"
+      );
+
+      await GroupResource.dangerouslyListUserGroupsForAuth({ user, workspace });
+      const cacheKey = getCacheKeyForUser(user.id, workspace.id);
+      expect(inMemoryCache.has(cacheKey)).toBe(true);
+
+      const regularGroup = await GroupResource.makeNew({
+        name: "Add Member Cache Test",
+        workspaceId: workspace.id,
+        kind: "regular",
+      });
+      await regularGroup.dangerouslyAddMembers(authenticator, {
+        users: [user.toJSON()],
+      });
+
+      expect(inMemoryCache.has(cacheKey)).toBe(false);
+    });
+
+    it("dangerouslyRemoveMembers invalidates cache for removed users", async () => {
+      const { GroupResource } = await import(
+        "@app/lib/resources/group_resource"
+      );
+
+      const regularGroup = await GroupResource.makeNew({
+        name: "Remove Member Cache Test",
+        workspaceId: workspace.id,
+        kind: "regular",
+      });
+      await regularGroup.dangerouslyAddMembers(authenticator, {
+        users: [user.toJSON()],
+      });
+
+      await GroupResource.dangerouslyListUserGroupsForAuth({ user, workspace });
+      const cacheKey = getCacheKeyForUser(user.id, workspace.id);
+      expect(inMemoryCache.has(cacheKey)).toBe(true);
+
+      await regularGroup.dangerouslyRemoveMembers(authenticator, {
+        users: [user.toJSON()],
+      });
+
+      expect(inMemoryCache.has(cacheKey)).toBe(false);
+    });
+
+    it("delete invalidates cache for all members when group is deleted", async () => {
+      const { GroupResource } = await import(
+        "@app/lib/resources/group_resource"
+      );
+
+      const regularGroup = await GroupResource.makeNew({
+        name: "Delete Group Cache Test",
+        workspaceId: workspace.id,
+        kind: "regular",
+      });
+      await regularGroup.dangerouslyAddMembers(authenticator, {
+        users: [user.toJSON()],
+      });
+
+      await GroupResource.dangerouslyListUserGroupsForAuth({ user, workspace });
+      const cacheKey = getCacheKeyForUser(user.id, workspace.id);
+      expect(inMemoryCache.has(cacheKey)).toBe(true);
+
+      await regularGroup.delete(authenticator);
+
+      expect(inMemoryCache.has(cacheKey)).toBe(false);
     });
   });
 });

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -1,4 +1,3 @@
-import { getRedisCacheClient } from "@app/lib/api/redis";
 import type { Authenticator } from "@app/lib/auth";
 import { DustError } from "@app/lib/error";
 import type { AgentConfigurationModel } from "@app/lib/models/agent/agent";
@@ -15,7 +14,11 @@ import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import { getResourceIdFromSId, makeSId } from "@app/lib/resources/string_ids";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import { UserResource } from "@app/lib/resources/user_resource";
-import { cacheWithRedis } from "@app/lib/utils/cache";
+import {
+  batchInvalidateCacheWithRedis,
+  cacheWithRedis,
+  invalidateCacheWithRedis,
+} from "@app/lib/utils/cache";
 import logger from "@app/logger/logger";
 import type {
   AgentConfigurationType,
@@ -45,7 +48,7 @@ import { Op, QueryTypes } from "sequelize";
 
 export const ADMIN_GROUP_NAME = "dust-admins";
 export const BUILDER_GROUP_NAME = "dust-builders";
-const GROUP_IDS_CACHE_TTL_MS = 1000 * 60 * 5; // 5 minutes
+const GROUP_IDS_CACHE_TTL_MS = 30 * 60 * 1000; // 30 minutes
 
 /**
  * ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
@@ -77,194 +80,106 @@ export class GroupResource extends BaseResource<GroupModel> {
   }
 
   // Default group kinds for auth (excludes system groups).
-  private static readonly defaultAuthGroupKinds: GroupKind[] =
-    GROUP_KINDS.filter((k) => k !== "system");
+  private static readonly defaultAuthGroupKinds: Exclude<
+    GroupKind,
+    "system"
+  >[] = GROUP_KINDS.filter(
+    (k): k is Exclude<GroupKind, "system"> => k !== "system"
+  );
 
   private static readonly groupIdsCacheKeyResolver = ({
     user,
     workspace,
   }: {
-    user: UserResource;
-    workspace: LightWorkspaceType;
+    user: { id: ModelId };
+    workspace: { id: ModelId };
   }) => `groups:user:${user.id}:workspace:${workspace.id}`;
 
-  private static async listUserGroupsForAuthUncached({
+  private static async dangerouslyListUserGroupsForAuthUncached({
     user,
     workspace,
+    transaction,
   }: {
     user: UserResource;
     workspace: LightWorkspaceType;
+    transaction?: Transaction;
   }): Promise<ModelId[]> {
     return GroupResource.listUserGroupModelIdsInWorkspace({
       user,
       workspace,
       groupKinds: GroupResource.defaultAuthGroupKinds,
+      transaction,
       dangerouslySkipMembershipCheck: true,
     });
   }
 
-  private static listUserGroupsForAuthCached = cacheWithRedis(
+  private static dangerouslyListUserGroupsForAuthCached = cacheWithRedis(
     ({
       user,
       workspace,
     }: {
       user: UserResource;
       workspace: LightWorkspaceType;
-    }) => GroupResource.listUserGroupsForAuthUncached({ user, workspace }),
+    }) =>
+      GroupResource.dangerouslyListUserGroupsForAuthUncached({
+        user,
+        workspace,
+      }),
     GroupResource.groupIdsCacheKeyResolver,
     { ttlMs: GROUP_IDS_CACHE_TTL_MS, cacheNullValues: false }
   );
 
-  static async invalidateGroupIdsCacheForUser(
-    userId: ModelId,
-    workspaceId: ModelId
-  ): Promise<void> {
-    const redisCli = await getRedisCacheClient({ origin: "cache_with_redis" });
-    const key = `cacheWithRedis--groups:user:${userId}:workspace:${workspaceId}`;
-    await redisCli.del(key);
-  }
+  static invalidateGroupIdsCacheForUser = invalidateCacheWithRedis(
+    (_params: { user: { id: ModelId }; workspace: { id: ModelId } }) =>
+      Promise.resolve([]),
+    GroupResource.groupIdsCacheKeyResolver
+  );
 
-  static async batchInvalidateGroupIdsCacheForUsers(
-    userWorkspacePairs: Array<{ userId: ModelId; workspaceId: ModelId }>
-  ): Promise<void> {
-    if (userWorkspacePairs.length === 0) {
-      return;
-    }
-    const redisCli = await getRedisCacheClient({ origin: "cache_with_redis" });
-    const keys = userWorkspacePairs.map(
-      ({ userId, workspaceId }) =>
-        `cacheWithRedis--groups:user:${userId}:workspace:${workspaceId}`
-    );
-    await redisCli.del(keys);
-  }
+  static batchInvalidateGroupIdsCacheForUsers = batchInvalidateCacheWithRedis(
+    (_params: { user: { id: ModelId }; workspace: { id: ModelId } }) =>
+      Promise.resolve([]),
+    GroupResource.groupIdsCacheKeyResolver
+  );
 
-  static async listUserGroupsForAuth({
+  /**
+   * WARNING: This method skips workspace membership checks. It is intended for use in
+   * authentication/authorization contexts where the user's group membership
+   * needs to be determined before permissions can be evaluated.
+   */
+  static async dangerouslyListUserGroupsForAuth({
     user,
     workspace,
+    transaction,
   }: {
     user: UserResource;
     workspace: LightWorkspaceType;
+    transaction?: Transaction;
   }): Promise<ModelId[]> {
-    return this.listUserGroupsForAuthCached({ user, workspace });
-  }
-
-  /**
-   * Suspends all active members of the specified groups.
-   * Returns array of affected user ModelIds.
-   */
-  static async suspendMembersForGroups(
-    groupIds: ModelId[],
-    workspaceId: ModelId,
-    { transaction }: { transaction?: Transaction } = {}
-  ): Promise<ModelId[]> {
-    if (groupIds.length === 0) {
-      return [];
-    }
-
-    const affectedMemberships = await GroupMembershipModel.findAll({
-      where: {
-        groupId: { [Op.in]: groupIds },
-        workspaceId,
-        status: "active",
-        startAt: { [Op.lte]: new Date() },
-        [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: new Date() } }],
-      },
-      attributes: ["userId"],
-      transaction,
-    });
-    const affectedUserIds = [
-      ...new Set(affectedMemberships.map((m) => m.userId)),
-    ];
-
-    await GroupMembershipModel.update(
-      { status: "suspended" },
-      {
-        where: {
-          groupId: { [Op.in]: groupIds },
-          workspaceId,
-          status: "active",
-          startAt: { [Op.lte]: new Date() },
-          [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: new Date() } }],
-        },
+    if (transaction) {
+      return this.dangerouslyListUserGroupsForAuthUncached({
+        user,
+        workspace,
         transaction,
-      }
-    );
-
-    // Always invalidate - safe even if transaction rolls back (just causes cache miss)
-    if (affectedUserIds.length > 0) {
-      await GroupResource.batchInvalidateGroupIdsCacheForUsers(
-        affectedUserIds.map((userId) => ({ userId, workspaceId }))
-      );
+      });
     }
-
-    return affectedUserIds;
-  }
-
-  /**
-   * Restores all suspended members of the specified groups.
-   * Returns array of affected user ModelIds.
-   */
-  static async restoreMembersForGroups(
-    groupIds: ModelId[],
-    workspaceId: ModelId,
-    { transaction }: { transaction?: Transaction } = {}
-  ): Promise<ModelId[]> {
-    if (groupIds.length === 0) {
-      return [];
-    }
-
-    const affectedMemberships = await GroupMembershipModel.findAll({
-      where: {
-        groupId: { [Op.in]: groupIds },
-        workspaceId,
-        status: "suspended",
-        startAt: { [Op.lte]: new Date() },
-        [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: new Date() } }],
-      },
-      attributes: ["userId"],
-      transaction,
-    });
-    const affectedUserIds = [
-      ...new Set(affectedMemberships.map((m) => m.userId)),
-    ];
-
-    await GroupMembershipModel.update(
-      { status: "active" },
-      {
-        where: {
-          groupId: { [Op.in]: groupIds },
-          workspaceId,
-          status: "suspended",
-          startAt: { [Op.lte]: new Date() },
-          [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: new Date() } }],
-        },
-        transaction,
-      }
-    );
-
-    // Always invalidate
-    if (affectedUserIds.length > 0) {
-      await GroupResource.batchInvalidateGroupIdsCacheForUsers(
-        affectedUserIds.map((userId) => ({ userId, workspaceId }))
-      );
-    }
-
-    return affectedUserIds;
+    return this.dangerouslyListUserGroupsForAuthCached({ user, workspace });
   }
 
   /**
    * Migrates all group memberships from one user to another within a workspace.
    * Handles duplicate memberships by destroying them first.
    */
-  static async migrateUserMemberships({
-    primaryUser,
-    secondaryUser,
-    workspace,
-  }: {
-    primaryUser: UserResource;
-    secondaryUser: UserResource;
-    workspace: LightWorkspaceType;
-  }): Promise<void> {
+  static async migrateUserMemberships(
+    auth: Authenticator,
+    {
+      primaryUser,
+      secondaryUser,
+    }: {
+      primaryUser: UserResource;
+      secondaryUser: UserResource;
+    }
+  ): Promise<void> {
+    const workspace = auth.getNonNullableWorkspace();
     const primaryMemberships = await GroupMembershipModel.findAll({
       where: { userId: primaryUser.id, workspaceId: workspace.id },
       attributes: ["groupId"],
@@ -288,8 +203,8 @@ export class GroupResource extends BaseResource<GroupModel> {
 
     // Always invalidate
     await GroupResource.batchInvalidateGroupIdsCacheForUsers([
-      { userId: primaryUser.id, workspaceId: workspace.id },
-      { userId: secondaryUser.id, workspaceId: workspace.id },
+      [{ user: { id: primaryUser.id }, workspace: { id: workspace.id } }],
+      [{ user: { id: secondaryUser.id }, workspace: { id: workspace.id } }],
     ]);
   }
 
@@ -1036,22 +951,18 @@ export class GroupResource extends BaseResource<GroupModel> {
     return groups.filter((group) => group.canRead(auth));
   }
 
-  static async listUserGroupModelIdsInWorkspace({
+  private static async listUserGroupModelIdsInWorkspace({
     user,
     workspace,
     groupKinds = GROUP_KINDS.filter((k) => k !== "system"),
-    dangerouslySkipMembershipCheck = false,
     transaction,
+    dangerouslySkipMembershipCheck = false,
   }: {
     user: UserResource;
     workspace: LightWorkspaceType;
-    groupKinds?: Omit<GroupKind, "system">[];
-    // When true, skips the membership check. Only use this from
-    // Authenticator.fetchRoleGroupsAndSubscription (which handles
-    // the role === "none" safety reset) or when membership has been
-    // independently verified (e.g. fromKey).
-    dangerouslySkipMembershipCheck?: boolean;
+    groupKinds?: Exclude<GroupKind, "system">[];
     transaction?: Transaction;
+    dangerouslySkipMembershipCheck?: boolean;
   }): Promise<ModelId[]> {
     if (!dangerouslySkipMembershipCheck) {
       const workspaceMembership =
@@ -1067,9 +978,10 @@ export class GroupResource extends BaseResource<GroupModel> {
 
     const includeGlobal = groupKinds.includes("global");
 
-    // Single query to fetch both the global group (implicit membership for all workspace members)
+    // Single combined query to fetch both the global group (implicit membership for all workspace members)
     // and groups the user explicitly belongs to via group_memberships.
-    // biome-ignore lint/plugin/noRawSql: We are using a raw query to optimize memory usage as people may have a lot of groups.
+    // eslint-disable-next-line dust/no-raw-sql -- Raw query to optimize memory usage as people may have a lot of groups.
+    // biome-ignore lint/plugin: Raw query to optimize memory usage as people may have a lot of groups.
     const groups = await frontSequelize.query<{ id: ModelId; kind: string }>(
       `
       SELECT id, kind FROM groups
@@ -1095,8 +1007,8 @@ export class GroupResource extends BaseResource<GroupModel> {
           now: new Date(),
         },
         type: QueryTypes.SELECT,
-        transaction,
         raw: true,
+        transaction,
       }
     );
 
@@ -1117,7 +1029,7 @@ export class GroupResource extends BaseResource<GroupModel> {
   }: {
     user: UserResource;
     workspace: LightWorkspaceType;
-    groupKinds?: Omit<GroupKind, "system">[];
+    groupKinds?: Exclude<GroupKind, "system">[];
     transaction?: Transaction;
   }): Promise<GroupResource[]> {
     const groupIds = await this.listUserGroupModelIdsInWorkspace({
@@ -1424,7 +1336,7 @@ export class GroupResource extends BaseResource<GroupModel> {
 
     // Always invalidate cache - safe even if transaction rolls back (just causes cache miss)
     await GroupResource.batchInvalidateGroupIdsCacheForUsers(
-      users.map((u) => ({ userId: u.id, workspaceId: owner.id }))
+      users.map((u) => [{ user: { id: u.id }, workspace: { id: owner.id } }])
     );
 
     return new Ok(undefined);
@@ -1579,7 +1491,7 @@ export class GroupResource extends BaseResource<GroupModel> {
 
     // Always invalidate cache - safe even if transaction rolls back (just causes cache miss)
     await GroupResource.batchInvalidateGroupIdsCacheForUsers(
-      users.map((u) => ({ userId: u.id, workspaceId: owner.id }))
+      users.map((u) => [{ user: { id: u.id }, workspace: { id: owner.id } }])
     );
 
     return new Ok(undefined);
@@ -1666,6 +1578,12 @@ export class GroupResource extends BaseResource<GroupModel> {
       );
     }
 
+    // Always invalidate cache - safe even if transaction rolls back (just causes cache miss)
+    await GroupResource.invalidateGroupIdsCacheForUser({
+      user: { id: user.id },
+      workspace: { id: workspace.id },
+    });
+
     return new Ok(undefined);
   }
 
@@ -1733,6 +1651,12 @@ export class GroupResource extends BaseResource<GroupModel> {
       { transaction }
     );
 
+    // Always invalidate cache - safe even if transaction rolls back (just causes cache miss)
+    await GroupResource.invalidateGroupIdsCacheForUser({
+      user: { id: user.id },
+      workspace: { id: workspace.id },
+    });
+
     return new Ok(undefined);
   }
 
@@ -1794,6 +1718,106 @@ export class GroupResource extends BaseResource<GroupModel> {
     }
 
     return new Ok(undefined);
+  }
+
+  /**
+   * Suspends all active members of this group.
+   * Returns array of affected user ModelIds.
+   */
+  async suspendMembers(
+    auth: Authenticator,
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<ModelId[]> {
+    const workspaceId = auth.getNonNullableWorkspace().id;
+
+    const affectedMemberships = await GroupMembershipModel.findAll({
+      where: {
+        groupId: this.id,
+        workspaceId,
+        status: "active",
+        startAt: { [Op.lte]: new Date() },
+        [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: new Date() } }],
+      },
+      attributes: ["userId"],
+      transaction,
+    });
+    const affectedUserIds = [
+      ...new Set(affectedMemberships.map((m) => m.userId)),
+    ];
+
+    await GroupMembershipModel.update(
+      { status: "suspended" },
+      {
+        where: {
+          groupId: this.id,
+          workspaceId,
+          status: "active",
+          startAt: { [Op.lte]: new Date() },
+          [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: new Date() } }],
+        },
+        transaction,
+      }
+    );
+
+    if (affectedUserIds.length > 0) {
+      await GroupResource.batchInvalidateGroupIdsCacheForUsers(
+        affectedUserIds.map((userId) => [
+          { user: { id: userId }, workspace: { id: workspaceId } },
+        ])
+      );
+    }
+
+    return affectedUserIds;
+  }
+
+  /**
+   * Restores all suspended members of this group.
+   * Returns array of affected user ModelIds.
+   */
+  async restoreMembers(
+    auth: Authenticator,
+    { transaction }: { transaction?: Transaction } = {}
+  ): Promise<ModelId[]> {
+    const workspaceId = auth.getNonNullableWorkspace().id;
+
+    const affectedMemberships = await GroupMembershipModel.findAll({
+      where: {
+        groupId: this.id,
+        workspaceId,
+        status: "suspended",
+        startAt: { [Op.lte]: new Date() },
+        [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: new Date() } }],
+      },
+      attributes: ["userId"],
+      transaction,
+    });
+    const affectedUserIds = [
+      ...new Set(affectedMemberships.map((m) => m.userId)),
+    ];
+
+    await GroupMembershipModel.update(
+      { status: "active" },
+      {
+        where: {
+          groupId: this.id,
+          workspaceId,
+          status: "suspended",
+          startAt: { [Op.lte]: new Date() },
+          [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: new Date() } }],
+        },
+        transaction,
+      }
+    );
+
+    if (affectedUserIds.length > 0) {
+      await GroupResource.batchInvalidateGroupIdsCacheForUsers(
+        affectedUserIds.map((userId) => [
+          { user: { id: userId }, workspace: { id: workspaceId } },
+        ])
+      );
+    }
+
+    return affectedUserIds;
   }
 
   // Updates
@@ -1875,7 +1899,9 @@ export class GroupResource extends BaseResource<GroupModel> {
       // Always invalidate cache for all former members - safe even if transaction rolls back (just causes cache miss)
       if (memberUserIds.length > 0) {
         await GroupResource.batchInvalidateGroupIdsCacheForUsers(
-          memberUserIds.map((userId) => ({ userId, workspaceId: owner.id }))
+          memberUserIds.map((userId) => [
+            { user: { id: userId }, workspace: { id: owner.id } },
+          ])
         );
       }
 

--- a/front/lib/resources/membership_resource.ts
+++ b/front/lib/resources/membership_resource.ts
@@ -864,6 +864,10 @@ export class MembershipResource extends BaseResource<MembershipModel> {
       workspaceModelId: workspace.id,
     });
 
+    // We do not invalidate GroupMembership here
+    // because WorkspaceMembership is tested before GroupMembership
+    // in  lib/auth
+
     return new Ok({
       role: membership.role,
       startAt: membership.startAt,

--- a/front/lib/resources/skill/skill_resource.ts
+++ b/front/lib/resources/skill/skill_resource.ts
@@ -29,7 +29,6 @@ import type { GlobalSkillDefinition } from "@app/lib/resources/skill/global/regi
 import { GlobalSkillsRegistry } from "@app/lib/resources/skill/global/registry";
 import type { SkillConfigurationFindOptions } from "@app/lib/resources/skill/types";
 import { SpaceResource } from "@app/lib/resources/space_resource";
-import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
 import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import {
   getResourceIdFromSId,
@@ -1484,7 +1483,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
     const workspace = auth.getNonNullableWorkspace();
 
-    return withTransaction(async (transaction) => {
+    const affectedCount = await withTransaction(async (transaction) => {
       // Rename any existing archived skill with the same name to avoid unique constraint violation.
       const existingArchivedSkill = await this.model.findOne({
         where: {
@@ -1508,30 +1507,17 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
       // We preserve AgentSkillModel and ConversationSkillModel relationships
       // so they can be restored when the skill is unarchived.
-      const [affectedCount] = await this.update(
-        { status: "archived" },
-        transaction
-      );
+      const [count] = await this.update({ status: "archived" }, transaction);
 
       // Suspend all editor group memberships for this skill.
-      if (affectedCount > 0 && this.editorGroup) {
-        await GroupMembershipModel.update(
-          { status: "suspended" },
-          {
-            where: {
-              groupId: this.editorGroup.id,
-              workspaceId: this.workspaceId,
-              status: "active",
-              startAt: { [Op.lte]: new Date() },
-              [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: new Date() } }],
-            },
-            transaction,
-          }
-        );
+      if (count > 0 && this.editorGroup) {
+        await this.editorGroup.suspendMembers(auth, { transaction });
       }
 
-      return { affectedCount };
+      return count;
     });
+
+    return { affectedCount };
   }
 
   async restore(auth: Authenticator): Promise<{ affectedCount: number }> {
@@ -1541,18 +1527,7 @@ export class SkillResource extends BaseResource<SkillConfigurationModel> {
 
     // Restore all editor group memberships (set suspended → active).
     if (affectedCount > 0 && this.editorGroup) {
-      await GroupMembershipModel.update(
-        { status: "active" },
-        {
-          where: {
-            groupId: this.editorGroup.id,
-            workspaceId: this.workspaceId,
-            status: "suspended",
-            startAt: { [Op.lte]: new Date() },
-            [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: new Date() } }],
-          },
-        }
-      );
+      await this.editorGroup.restoreMembers(auth);
     }
 
     return { affectedCount };

--- a/front/lib/resources/space_resource.ts
+++ b/front/lib/resources/space_resource.ts
@@ -1277,37 +1277,14 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     auth: Authenticator,
     transaction?: Transaction
   ): Promise<void> {
-    const spaceManualMemberGroup = this.getSpaceManualMemberGroup();
+    const groups = [this.getSpaceManualMemberGroup()];
+    const editorGroup = this.getSpaceManualEditorGroup();
+    if (editorGroup) {
+      groups.push(editorGroup);
+    }
 
-    await GroupMembershipModel.update(
-      { status: "suspended" },
-      {
-        where: {
-          groupId: spaceManualMemberGroup.id,
-          workspaceId: this.workspaceId,
-          status: "active",
-          startAt: { [Op.lte]: new Date() },
-          [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: new Date() } }],
-        },
-        transaction,
-      }
-    );
-
-    const spaceManualEditorGroup = this.getSpaceManualEditorGroup();
-    if (spaceManualEditorGroup) {
-      await GroupMembershipModel.update(
-        { status: "suspended" },
-        {
-          where: {
-            groupId: spaceManualEditorGroup.id,
-            workspaceId: this.workspaceId,
-            status: "active",
-            startAt: { [Op.lte]: new Date() },
-            [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: new Date() } }],
-          },
-          transaction,
-        }
-      );
+    for (const group of groups) {
+      await group.suspendMembers(auth, { transaction });
     }
   }
 
@@ -1318,36 +1295,14 @@ export class SpaceResource extends BaseResource<SpaceModel> {
     auth: Authenticator,
     transaction?: Transaction
   ): Promise<void> {
-    const spaceManualMemberGroup = this.getSpaceManualMemberGroup();
-    await GroupMembershipModel.update(
-      { status: "active" },
-      {
-        where: {
-          groupId: spaceManualMemberGroup.id,
-          workspaceId: this.workspaceId,
-          status: "suspended",
-          startAt: { [Op.lte]: new Date() },
-          [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: new Date() } }],
-        },
-        transaction,
-      }
-    );
+    const groups = [this.getSpaceManualMemberGroup()];
+    const editorGroup = this.getSpaceManualEditorGroup();
+    if (editorGroup) {
+      groups.push(editorGroup);
+    }
 
-    const spaceManualEditorGroup = this.getSpaceManualEditorGroup();
-    if (spaceManualEditorGroup) {
-      await GroupMembershipModel.update(
-        { status: "active" },
-        {
-          where: {
-            groupId: spaceManualEditorGroup.id,
-            workspaceId: this.workspaceId,
-            status: "suspended",
-            startAt: { [Op.lte]: new Date() },
-            [Op.or]: [{ endAt: null }, { endAt: { [Op.gt]: new Date() } }],
-          },
-          transaction,
-        }
-      );
+    for (const group of groups) {
+      await group.restoreMembers(auth, { transaction });
     }
   }
 

--- a/front/lib/swr/memberships.ts
+++ b/front/lib/swr/memberships.ts
@@ -103,7 +103,7 @@ export function useSearchMembers({
   searchTerm: string;
   pageIndex: number;
   pageSize: number;
-  groupKind?: Omit<GroupKind, "system">;
+  groupKind?: Exclude<GroupKind, "system">;
   buildersOnly?: boolean;
   disabled?: boolean;
 }) {


### PR DESCRIPTION
## Description

- Encapsulate group memberships updates inside group resource
- cache user's group ids memberships
- cacheKey: `groups:user:${userId}:workspace:${workspaceId}`
- Invalidate the cache where it makes sense

## Tests

- Unit tests + test on front-edge

## Risk

Low
Blast radius: Cache invalidation issues + potentially breaking lib/auth 

## Deploy Plan

- [ ] Deploy front