### PR TITLE
[front] perf: Cache subscriptions for fromSession

### DIFF
--- a/front/lib/api/signup.ts
+++ b/front/lib/api/signup.ts
@@ -279,8 +279,8 @@ export async function handleRegularSignupFlow(
     }
 
     const workspaceSubscription =
-      await SubscriptionResource.fetchActiveByWorkspace(
-        renderLightWorkspaceType({ workspace: existingWorkspace })
+      await SubscriptionResource.fetchActiveByWorkspaceModelId(
+        existingWorkspace.id
       );
 
     if (!workspaceSubscription) {

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -203,7 +203,7 @@ export class Authenticator {
         workspace: lightWorkspace,
         dangerouslySkipMembershipCheck: true,
       }),
-      SubscriptionResource.fetchActiveByWorkspace(lightWorkspace),
+      SubscriptionResource.fetchActiveByWorkspaceModelId(lightWorkspace.id),
     ]);
 
     return {
@@ -297,9 +297,7 @@ export class Authenticator {
               workspaceId: workspace.id,
             })
           : [],
-        SubscriptionResource.fetchActiveByWorkspace(
-          renderLightWorkspaceType({ workspace })
-        ),
+        SubscriptionResource.fetchActiveByWorkspaceModelId(workspace.id),
       ]);
     }
 
@@ -450,22 +448,30 @@ export class Authenticator {
         [requestedGroups, keySubscription, workspaceSubscription] =
           await Promise.all([
             GroupResource.listGroupsWithSystemKey(key, requestedGroupIds),
-            SubscriptionResource.fetchActiveByWorkspace(lightKeyWorkspace),
+            SubscriptionResource.fetchActiveByWorkspaceModelId(
+              lightKeyWorkspace.id
+            ),
             // We need to fetch the subscription separately as requested groups
             // might not include the global group which is used to fetch the
             // subscription in fetchRoleGroupsAndSubscription.
             isKeyWorkspace
               ? null
-              : SubscriptionResource.fetchActiveByWorkspace(lightWorkspace),
+              : SubscriptionResource.fetchActiveByWorkspaceModelId(
+                  lightWorkspace.id
+                ),
           ]);
       } else {
         [keyGroups, keySubscription, workspaceSubscription] = await Promise.all(
           [
             GroupResource.listWorkspaceGroupsFromKey(key),
-            SubscriptionResource.fetchActiveByWorkspace(lightKeyWorkspace),
+            SubscriptionResource.fetchActiveByWorkspaceModelId(
+              lightKeyWorkspace.id
+            ),
             isKeyWorkspace
               ? null
-              : SubscriptionResource.fetchActiveByWorkspace(lightWorkspace),
+              : SubscriptionResource.fetchActiveByWorkspaceModelId(
+                  lightWorkspace.id
+                ),
           ]
         );
       }
@@ -563,9 +569,7 @@ export class Authenticator {
 
     [globalGroup, subscription] = await Promise.all([
       GroupResource.internalFetchWorkspaceGlobalGroup(workspace.id),
-      SubscriptionResource.fetchActiveByWorkspace(
-        renderLightWorkspaceType({ workspace })
-      ),
+      SubscriptionResource.fetchActiveByWorkspaceModelId(workspace.id),
     ]);
 
     return new Authenticator({
@@ -602,9 +606,7 @@ export class Authenticator {
           return globalGroup ? [globalGroup] : [];
         }
       })(),
-      SubscriptionResource.fetchActiveByWorkspace(
-        renderLightWorkspaceType({ workspace })
-      ),
+      SubscriptionResource.fetchActiveByWorkspaceModelId(workspace.id),
     ]);
 
     return new Authenticator({
@@ -1000,7 +1002,9 @@ export class Authenticator {
 
     const subscription =
       authType.subscriptionId && lightWorkspace
-        ? await SubscriptionResource.fetchActiveByWorkspace(lightWorkspace)
+        ? await SubscriptionResource.fetchActiveByWorkspaceModelId(
+            lightWorkspace.id
+          )
         : null;
 
     // Skip mismatch check for no-plan subscriptions: they have ephemeral random sIds

--- a/front/lib/production_checks/checks/check_notion_active_workflows.ts
+++ b/front/lib/production_checks/checks/check_notion_active_workflows.ts
@@ -174,7 +174,7 @@ export const checkNotionActiveWorkflows: CheckFunction = async (
   const workspaces = workspaceResources.map((w) =>
     renderLightWorkspaceType({ workspace: w })
   );
-  const subscriptionByWorkspaceSId =
+  const subscriptionsByWorkspaceId =
     await SubscriptionResource.fetchActiveByWorkspaces(workspaces);
 
   const client = await getTemporalClientForConnectorsNamespace();
@@ -201,7 +201,7 @@ export const checkNotionActiveWorkflows: CheckFunction = async (
     }
 
     const subscription =
-      subscriptionByWorkspaceSId[notionConnector.workspaceId];
+      subscriptionsByWorkspaceId[notionConnector.workspaceId];
     if (!subscription || !isUpgraded(subscription.getPlan())) {
       continue;
     }

--- a/front/lib/production_checks/checks/check_paused_connectors.ts
+++ b/front/lib/production_checks/checks/check_paused_connectors.ts
@@ -36,7 +36,7 @@ export const checkPausedConnectors: CheckFunction = async (
     .map((w) => renderLightWorkspaceType({ workspace: w }))
     .filter((w) => !w.metadata?.maintenance); // Exclude workspaces in maintenance mode (relocation or relocation done).
 
-  const subscriptionByWorkspaceSId =
+  const subscriptionsByWorkspaceId =
     await SubscriptionResource.fetchActiveByWorkspaces(workspaces);
 
   // If the connector is paused and the workspace has a valid subscription, add it to the report.
@@ -46,7 +46,7 @@ export const checkPausedConnectors: CheckFunction = async (
       "Connector is paused. Checking if workspace has a valid subscription."
     );
 
-    const subscription = subscriptionByWorkspaceSId[connector.workspaceId];
+    const subscription = subscriptionsByWorkspaceId[connector.workspaceId];
 
     if (subscription && isUpgraded(subscription.getPlan())) {
       connectorsToReport.push(connector);

--- a/front/lib/tracking/customerio/server.ts
+++ b/front/lib/tracking/customerio/server.ts
@@ -218,7 +218,7 @@ export class CustomerioServerSideTracking {
     }
 
     const subscription =
-      await SubscriptionResource.fetchActiveByWorkspace(workspace);
+      await SubscriptionResource.fetchActiveByWorkspaceModelId(workspace.id);
 
     if (!subscription) {
       throw new Error("Unreachable: Workspace subscription not found");

--- a/front/lib/tracking/server.ts
+++ b/front/lib/tracking/server.ts
@@ -29,8 +29,10 @@ export class ServerSideTracking {
 
   static async trackGetUser({ user }: { user: UserTypeWithWorkspaces }) {
     try {
-      const subscriptionByWorkspaceId =
-        await SubscriptionResource.fetchActiveByWorkspaces(user.workspaces);
+      const subscriptionByWorkspaceModelId =
+        await SubscriptionResource.fetchActiveByWorkspacesModelId(
+          user.workspaces.map((w) => w.id)
+        );
 
       const seatsByWorkspaceId = _.keyBy(
         await Promise.all(
@@ -52,20 +54,20 @@ export class ServerSideTracking {
       const workspacesToTrackOnCustomerIo = user.workspaces
         .map((ws) => {
           const subscriptionStartInt =
-            subscriptionByWorkspaceId[ws.sId].startDate;
+            subscriptionByWorkspaceModelId[ws.id].startDate;
           const subscriptionStartAt = subscriptionStartInt
             ? new Date(subscriptionStartInt)
             : null;
 
           const requestCancelAtInt =
-            subscriptionByWorkspaceId[ws.sId].requestCancelAt;
+            subscriptionByWorkspaceModelId[ws.id].requestCancelAt;
           const requestCancelAt = requestCancelAtInt
             ? new Date(requestCancelAtInt)
             : null;
 
           return {
             ...ws,
-            planCode: subscriptionByWorkspaceId[ws.sId].getPlan().code,
+            planCode: subscriptionByWorkspaceModelId[ws.id].getPlan().code,
             seats: seatsByWorkspaceId[ws.sId].seats,
             subscriptionStartAt,
             requestCancelAt,

--- a/front/migrations/20240513_backfill_customerio_delete_free_test.ts
+++ b/front/migrations/20240513_backfill_customerio_delete_free_test.ts
@@ -40,11 +40,9 @@ const backfillCustomerIo = async (execute: boolean) => {
       (ws) => ws.id.toString()
     );
 
-    const subscriptionByWorkspaceSid =
-      await SubscriptionResource.fetchActiveByWorkspaces(
-        Object.values(workspaceById).map((w) =>
-          renderLightWorkspaceType({ workspace: w })
-        )
+    const subscriptionByWorkspaceModelId =
+      await SubscriptionResource.fetchActiveByWorkspacesModelId(
+        Object.values(workspaceById).map((w) => w.id)
       );
 
     const promises: Promise<unknown>[] = [];
@@ -54,7 +52,7 @@ const backfillCustomerIo = async (execute: boolean) => {
         memberships.map((m) => workspaceById[m.workspaceId.toString()]) ?? [];
       const subscriptions =
         removeNulls(
-          workspaces.map((ws) => subscriptionByWorkspaceSid[ws.sId])
+          workspaces.map((ws) => subscriptionByWorkspaceModelId[ws.id])
         ) ?? [];
 
       if (
@@ -88,7 +86,7 @@ const backfillCustomerIo = async (execute: boolean) => {
       }
 
       const workspacesWithoutRealSubscriptions = workspaces.filter((ws) => {
-        const subscription = subscriptionByWorkspaceSid[ws.sId];
+        const subscription = subscriptionByWorkspaceModelId[ws.id];
         return (
           !subscription || subscription.getPlan().code === FREE_TEST_PLAN_CODE
         );

--- a/front/migrations/20250602_migrate_organizations.ts
+++ b/front/migrations/20250602_migrate_organizations.ts
@@ -32,7 +32,7 @@ async function shouldCreateWorkOSOrganization(
   }
 
   const activeSubscription =
-    await SubscriptionResource.fetchActiveByWorkspace(workspace);
+    await SubscriptionResource.fetchActiveByWorkspaceModelId(workspace.id);
   if (activeSubscription && !activeSubscription.isLegacyFreeNoPlan()) {
     return { shouldCreate: true, domain: undefined };
   }

--- a/front/migrations/20251126_backfill_programmatic_usage_configurations.ts
+++ b/front/migrations/20251126_backfill_programmatic_usage_configurations.ts
@@ -36,8 +36,9 @@ async function backfillWorkspace(
   const workspaceLogger = logger.child({ workspaceId: workspace.sId });
 
   // Get active subscription and check if it's enterprise.
-  const subscription =
-    await SubscriptionResource.fetchActiveByWorkspace(workspace);
+  const subscription = await SubscriptionResource.fetchActiveByWorkspaceModelId(
+    workspace.id
+  );
 
   if (!subscription || !subscription.stripeSubscriptionId) {
     workspaceLogger.info("Skipping: no active subscription found");

--- a/front/migrations/20251128_backfill_free_credits.ts
+++ b/front/migrations/20251128_backfill_free_credits.ts
@@ -55,8 +55,9 @@ async function addCreditToWorkspace(
   execute: boolean
 ): Promise<"added" | "skipped"> {
   // Check workspace has an active subscription
-  const subscription =
-    await SubscriptionResource.fetchActiveByWorkspace(workspace);
+  const subscription = await SubscriptionResource.fetchActiveByWorkspaceModelId(
+    workspace.id
+  );
   if (!subscription) {
     logger.info(
       { workspaceSId: workspace.sId, workspaceId: workspace.id },

--- a/front/pages/api/stripe/webhook.ts
+++ b/front/pages/api/stripe/webhook.ts
@@ -223,8 +223,8 @@ async function handler(
 
             await withTransaction(async (t) => {
               const activeSubscription =
-                await SubscriptionResource.fetchActiveByWorkspace(
-                  renderLightWorkspaceType({ workspace }),
+                await SubscriptionResource.fetchActiveByWorkspaceModelId(
+                  workspace.id,
                   t
                 );
 

--- a/front/scripts/backfill_credits.ts
+++ b/front/scripts/backfill_credits.ts
@@ -129,8 +129,9 @@ async function reconcileWorkspaceCredits(
   const workspace = auth.getNonNullableWorkspace();
   const lightWorkspace = renderLightWorkspaceType({ workspace });
 
-  const subscription =
-    await SubscriptionResource.fetchActiveByWorkspace(lightWorkspace);
+  const subscription = await SubscriptionResource.fetchActiveByWorkspaceModelId(
+    lightWorkspace.id
+  );
 
   const stripeSubscription = subscription?.stripeSubscriptionId
     ? await getStripeSubscription(subscription.stripeSubscriptionId)

--- a/front/temporal/scrub_workspace/activities.ts
+++ b/front/temporal/scrub_workspace/activities.ts
@@ -324,9 +324,9 @@ async function cleanupCustomerio(auth: Authenticator) {
   );
 
   // Finally, fetch all the subscriptions for the workspaces.
-  const subscriptionsByWorkspaceSid =
-    await SubscriptionResource.fetchActiveByWorkspaces(
-      Object.values(workspaceById)
+  const subscriptionsByWorkspaceModelId =
+    await SubscriptionResource.fetchActiveByWorkspacesModelId(
+      Object.values(workspaceById).map((w) => w.id)
     );
 
   // Process the workspace users in chunks of 4.
@@ -346,7 +346,7 @@ async function cleanupCustomerio(auth: Authenticator) {
         );
         if (
           workspacesOfUser.some((w) => {
-            const subscription = subscriptionsByWorkspaceSid[w.sId];
+            const subscription = subscriptionsByWorkspaceModelId[w.id];
             return (
               subscription &&
               ![FREE_TEST_PLAN_CODE, FREE_NO_PLAN_CODE].includes(


### PR DESCRIPTION
## Description

- switch fetchActiveByWorkspaces from taking a worskpace as argument to workspaceModelId
- cache fetchActiveByWorkspaces ( `subscription:active:workspaceId:${workspaceId}`)
- invalidate this cache key where it makes sense

## Tests

- Unit tests
- [x] Front-edge

## Risk

Low
Blast radius: Wide -> lib/auth + cache invalidation issues

## Deploy Plan

- [ ] Deploy front