### PR TITLE
Suspend group memberships when fully archiving an agent, re-active on restore.

### DIFF
--- a/front/components/assistant/details/AgentDetails.tsx
+++ b/front/components/assistant/details/AgentDetails.tsx
@@ -105,9 +105,14 @@ export function AgentDetails({
   );
 
   const [showRestoreModal, setShowRestoreModal] = useState(false);
-  const showEditorsTabs = agentId != null && !isGlobalAgent;
+  const showEditorsTabs =
+    agentId != null &&
+    !isGlobalAgent &&
+    agentConfiguration?.status === "active";
   const showTriggersTabs =
-    agentId != null && (!isGlobalAgent || agentId === GLOBAL_AGENTS_SID.DUST);
+    agentId != null &&
+    (!isGlobalAgent || agentId === GLOBAL_AGENTS_SID.DUST) &&
+    agentConfiguration?.status === "active";
   const showAgentMemory = !!agentConfiguration?.actions.find((arg) =>
     isServerSideMCPServerConfigurationWithName(arg, AGENT_MEMORY_SERVER_NAME)
   );

--- a/front/lib/api/assistant/configuration/agent.test.ts
+++ b/front/lib/api/assistant/configuration/agent.test.ts
@@ -1,11 +1,15 @@
 import {
+  archiveAgentConfiguration,
   createAgentConfiguration,
   createPendingAgentConfiguration,
   getAgentConfiguration,
+  restoreAgentConfiguration,
 } from "@app/lib/api/assistant/configuration/agent";
 import { Authenticator } from "@app/lib/auth";
 import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { AgentSuggestionResource } from "@app/lib/resources/agent_suggestion_resource";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { AgentSuggestionFactory } from "@app/tests/utils/AgentSuggestionFactory";
@@ -242,6 +246,82 @@ describe("createAgentConfiguration with pending agent", () => {
           result.value.sId
         );
       expect(suggestionsAfter).toHaveLength(1);
+    }
+  });
+});
+
+describe("archiveAgentConfiguration and restoreAgentConfiguration", () => {
+  it("suspends editor group memberships when archiving and restores them when restoring", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+
+    const agent =
+      await AgentConfigurationFactory.createTestAgent(authenticator);
+    const editorGroupRes = await GroupResource.findEditorGroupForAgent(
+      authenticator,
+      agent
+    );
+    expect(editorGroupRes.isOk()).toBe(true);
+    const editorGroup = editorGroupRes.isOk() ? editorGroupRes.value : null;
+    expect(editorGroup).not.toBeNull();
+
+    const membershipsBeforeArchive = await GroupMembershipModel.findAll({
+      where: {
+        groupId: editorGroup!.id,
+        workspaceId: workspace.id,
+      },
+    });
+    expect(membershipsBeforeArchive.length).toBeGreaterThan(0);
+    expect(membershipsBeforeArchive.every((m) => m.status === "active")).toBe(
+      true
+    );
+
+    const archived = await archiveAgentConfiguration(authenticator, agent.sId);
+    expect(archived).toBe(true);
+
+    const membershipsAfterArchive = await GroupMembershipModel.findAll({
+      where: {
+        groupId: editorGroup!.id,
+        workspaceId: workspace.id,
+      },
+    });
+    expect(membershipsAfterArchive.every((m) => m.status === "suspended")).toBe(
+      true
+    );
+
+    const restoreResult = await restoreAgentConfiguration(
+      authenticator,
+      agent.sId
+    );
+    expect(restoreResult.isOk()).toBe(true);
+    expect(restoreResult.isOk() && restoreResult.value.restored).toBe(true);
+
+    const membershipsAfterRestore = await GroupMembershipModel.findAll({
+      where: {
+        groupId: editorGroup!.id,
+        workspaceId: workspace.id,
+      },
+    });
+    expect(membershipsAfterRestore.every((m) => m.status === "active")).toBe(
+      true
+    );
+  });
+
+  it("restore returns error when agent is not archived", async () => {
+    const { authenticator } = await createResourceTest({ role: "admin" });
+    const agent =
+      await AgentConfigurationFactory.createTestAgent(authenticator);
+
+    const restoreResult = await restoreAgentConfiguration(
+      authenticator,
+      agent.sId
+    );
+    expect(restoreResult.isErr()).toBe(true);
+    if (restoreResult.isErr()) {
+      expect(restoreResult.error.message).toBe(
+        "Agent configuration is not archived"
+      );
     }
   });
 });

--- a/front/migrations/20260215_suspend_agent_editor_memberships_no_active_agent.ts
+++ b/front/migrations/20260215_suspend_agent_editor_memberships_no_active_agent.ts
@@ -1,0 +1,70 @@
+import { QueryTypes } from "sequelize";
+
+import { frontSequelize } from "@app/lib/resources/storage";
+import { makeScript } from "@app/scripts/helpers";
+
+const SUSPEND_AGENT_EDITOR_MEMBERSHIPS_SQL = `
+UPDATE group_memberships gm
+SET status = 'suspended'
+WHERE gm."groupId" IN (
+    SELECT g.id
+    FROM groups g
+    INNER JOIN group_agents ga ON (g.id = ga."groupId")
+    WHERE g.kind = 'agent_editors'
+    -- Only groups that have no active agents
+    AND NOT EXISTS (
+        SELECT 1
+        FROM group_agents ga2
+        INNER JOIN agent_configurations ac ON (ga2."agentConfigurationId" = ac.id)
+        WHERE ga2."groupId" = g.id
+        AND ac.status = 'active'
+    )
+)
+-- Safety: only update if not already suspended
+AND gm.status != 'suspended';
+`;
+
+makeScript({}, async ({ execute }, logger) => {
+  logger.info(
+    "Suspending group_memberships for agent_editors groups with no active agents"
+  );
+
+  if (execute) {
+    const [_, rowCount] = await frontSequelize.query(
+      SUSPEND_AGENT_EDITOR_MEMBERSHIPS_SQL,
+      {
+        type: QueryTypes.UPDATE,
+      }
+    );
+    logger.info(
+      { updatedCount: rowCount },
+      "Updated group_memberships to suspended"
+    );
+  } else {
+    const [countResult] = await frontSequelize.query<{ count: string }>(
+      `
+      SELECT COUNT(*) as count
+      FROM group_memberships gm
+      WHERE gm."groupId" IN (
+          SELECT g.id
+          FROM groups g
+          INNER JOIN group_agents ga ON (g.id = ga."groupId")
+          WHERE g.kind = 'agent_editors'
+          AND NOT EXISTS (
+              SELECT 1
+              FROM group_agents ga2
+              INNER JOIN agent_configurations ac ON (ga2."agentConfigurationId" = ac.id)
+              WHERE ga2."groupId" = g.id
+              AND ac.status = 'active'
+          )
+      )
+      AND gm.status != 'suspended';
+      `,
+      { type: QueryTypes.SELECT }
+    );
+    logger.info(
+      { wouldUpdateCount: countResult.count },
+      "Dry run: would suspend this many group_memberships (use --execute to apply)"
+    );
+  }
+});


### PR DESCRIPTION
## Description

Suspend editors group memberships when we fully archive an agent, re-active when we restore so they are not part of the "auth" of an user.
+ backfill script (checked in prod: 55k memberships to update)

## Tests

Locally + added

## Risk

Low

## Deploy Plan

Deploy front