### PR TITLE
suspend / re-active group memberships on skills archive / restore

### DIFF
--- a/front/lib/resources/skill/skill_resource.test.ts
+++ b/front/lib/resources/skill/skill_resource.test.ts
@@ -5,6 +5,7 @@ import type { DataSourceViewResource } from "@app/lib/resources/data_source_view
 import { GroupResource } from "@app/lib/resources/group_resource";
 import type { SkillAttachedKnowledge } from "@app/lib/resources/skill/skill_resource";
 import { SkillResource } from "@app/lib/resources/skill/skill_resource";
+import { GroupMembershipModel } from "@app/lib/resources/storage/models/group_memberships";
 import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
 import { DataSourceViewFactory } from "@app/tests/utils/DataSourceViewFactory";
 import { GroupSpaceFactory } from "@app/tests/utils/GroupSpaceFactory";
@@ -637,6 +638,57 @@ describe("SkillResource", () => {
       // sharedSpace kept because skill2 still requires it.
       expect(spaceIds).toContain(sharedSpace.id);
       expect(spaceIds).toContain(skill1OnlySpace.id);
+    });
+  });
+
+  describe("archive and restore", () => {
+    it("suspends editor group memberships when archiving and restores them when restoring", async () => {
+      const skill = await SkillFactory.create(testContext.authenticator, {
+        name: "Skill To Archive",
+      });
+      expect(skill.editorGroup).not.toBeNull();
+      const editorGroup = skill.editorGroup!;
+
+      const membershipsBeforeArchive = await GroupMembershipModel.findAll({
+        where: {
+          groupId: editorGroup.id,
+          workspaceId: testContext.workspace.id,
+        },
+      });
+      expect(membershipsBeforeArchive.length).toBeGreaterThan(0);
+      expect(membershipsBeforeArchive.every((m) => m.status === "active")).toBe(
+        true
+      );
+
+      const { affectedCount: archiveCount } = await skill.archive(
+        testContext.authenticator
+      );
+      expect(archiveCount).toBe(1);
+
+      const membershipsAfterArchive = await GroupMembershipModel.findAll({
+        where: {
+          groupId: editorGroup.id,
+          workspaceId: testContext.workspace.id,
+        },
+      });
+      expect(
+        membershipsAfterArchive.every((m) => m.status === "suspended")
+      ).toBe(true);
+
+      const { affectedCount: restoreCount } = await skill.restore(
+        testContext.authenticator
+      );
+      expect(restoreCount).toBe(1);
+
+      const membershipsAfterRestore = await GroupMembershipModel.findAll({
+        where: {
+          groupId: editorGroup.id,
+          workspaceId: testContext.workspace.id,
+        },
+      });
+      expect(membershipsAfterRestore.every((m) => m.status === "active")).toBe(
+        true
+      );
     });
   });
 

--- a/front/migrations/20260215_suspend_skill_editor_memberships_no_active_skill.ts
+++ b/front/migrations/20260215_suspend_skill_editor_memberships_no_active_skill.ts
@@ -1,0 +1,70 @@
+import { QueryTypes } from "sequelize";
+
+import { frontSequelize } from "@app/lib/resources/storage";
+import { makeScript } from "@app/scripts/helpers";
+
+const SUSPEND_SKILL_EDITOR_MEMBERSHIPS_SQL = `
+UPDATE group_memberships gm
+SET status = 'suspended'
+WHERE gm."groupId" IN (
+    SELECT g.id
+    FROM groups g
+    INNER JOIN group_skills gs ON (g.id = gs."groupId")
+    WHERE g.kind = 'skill_editors'
+    -- Only groups that have no active skills
+    AND NOT EXISTS (
+        SELECT 1
+        FROM group_skills gs2
+        INNER JOIN skill_configurations sc ON (gs2."skillConfigurationId" = sc.id)
+        WHERE gs2."groupId" = g.id
+        AND sc.status = 'active'
+    )
+)
+-- Safety: only update if not already suspended
+AND gm.status != 'suspended';
+`;
+
+makeScript({}, async ({ execute }, logger) => {
+  logger.info(
+    "Suspending group_memberships for skill_editors groups with no active skills"
+  );
+
+  if (execute) {
+    const [_, rowCount] = await frontSequelize.query(
+      SUSPEND_SKILL_EDITOR_MEMBERSHIPS_SQL,
+      {
+        type: QueryTypes.UPDATE,
+      }
+    );
+    logger.info(
+      { updatedCount: rowCount },
+      "Updated group_memberships to suspended"
+    );
+  } else {
+    const [countResult] = await frontSequelize.query<{ count: string }>(
+      `
+      SELECT COUNT(*) as count
+      FROM group_memberships gm
+      WHERE gm."groupId" IN (
+          SELECT g.id
+          FROM groups g
+          INNER JOIN group_skills gs ON (g.id = gs."groupId")
+          WHERE g.kind = 'skill_editors'
+          AND NOT EXISTS (
+              SELECT 1
+              FROM group_skills gs2
+              INNER JOIN skill_configurations sc ON (gs2."skillConfigurationId" = sc.id)
+              WHERE gs2."groupId" = g.id
+              AND sc.status = 'active'
+          )
+      )
+      AND gm.status != 'suspended';
+      `,
+      { type: QueryTypes.SELECT }
+    );
+    logger.info(
+      { wouldUpdateCount: countResult.count },
+      "Dry run: would suspend this many group_memberships (use --execute to apply)"
+    );
+  }
+});


### PR DESCRIPTION
## Description

Suspend editors group memberships when we fully archive a skill, re-active when we restore so they are not part of the "auth" of an user.

• backfill script (checked in prod: 94 memberships to update)

## Tests

Local + added

## Risk

Low

## Deploy Plan

Deploy front