### PR TITLE
Fix SPA paywall-whitelisted pages blocked by WorkspacePage auth

### DIFF
--- a/front-spa/src/app/App.tsx
+++ b/front-spa/src/app/App.tsx
@@ -449,13 +449,6 @@ const router = createBrowserRouter(
         { path: "builder/skills/new", element: <CreateSkillPage /> },
         { path: "builder/skills/:sId", element: <EditSkillPage /> },
 
-        // Onboarding
-        { path: "welcome", element: <WelcomePage /> },
-        { path: "subscribe", element: <SubscribePage /> },
-        { path: "trial", element: <TrialPage /> },
-        { path: "trial-ended", element: <TrialEndedPage /> },
-        { path: "verify", element: <VerifyPage /> },
-
         // Legacy assistants -> agents redirects
         {
           path: "builder/assistants",
@@ -478,6 +471,33 @@ const router = createBrowserRouter(
         {
           path: "builder/assistants/:aId",
           element: <AssistantAgentRedirect />,
+        },
+
+        // Onboarding (paywall-whitelisted: accessible even when canUseProduct is false)
+        {
+          path: "welcome",
+          element: <WelcomePage />,
+          handle: { requireCanUseProduct: false },
+        },
+        {
+          path: "subscribe",
+          element: <SubscribePage />,
+          handle: { requireCanUseProduct: false },
+        },
+        {
+          path: "trial",
+          element: <TrialPage />,
+          handle: { requireCanUseProduct: false },
+        },
+        {
+          path: "trial-ended",
+          element: <TrialEndedPage />,
+          handle: { requireCanUseProduct: false },
+        },
+        {
+          path: "verify",
+          element: <VerifyPage />,
+          handle: { requireCanUseProduct: false },
         },
       ],
     },

--- a/front-spa/src/app/pages/IndexPage.tsx
+++ b/front-spa/src/app/pages/IndexPage.tsx
@@ -1,3 +1,4 @@
+import { getApiBaseUrl } from "@dust-tt/front/lib/egress/client";
 import { useAuthContext } from "@dust-tt/front/lib/swr/workspaces";
 import { AuthErrorPage } from "@spa/app/components/AuthErrorPage";
 import { useEffect } from "react";
@@ -5,17 +6,27 @@ import { useNavigate } from "react-router-dom";
 
 export function IndexPage() {
   const navigate = useNavigate();
-  const { authContext, authContextError } = useAuthContext();
+  const {
+    authContext,
+    authContextError,
+    isAuthContextLoading,
+    isAuthenticated,
+  } = useAuthContext();
 
   const defaultWorkspaceId = authContext?.defaultWorkspaceId;
-
   useEffect(() => {
-    if (defaultWorkspaceId) {
-      navigate(`/w/${defaultWorkspaceId}/conversation/new`, {
-        replace: true,
-      });
+    if (!isAuthContextLoading && isAuthenticated) {
+      if (defaultWorkspaceId) {
+        navigate(`/w/${defaultWorkspaceId}/conversation/new`, {
+          replace: true,
+        });
+      } else {
+        // No default workspace, redirect to /api/login which will create
+        // or find a workspace for the user
+        window.location.href = `${getApiBaseUrl()}/api/login`;
+      }
     }
-  }, [defaultWorkspaceId, navigate]);
+  }, [defaultWorkspaceId, navigate, isAuthContextLoading, isAuthenticated]);
 
   if (authContextError) {
     return <AuthErrorPage error={authContextError} />;

--- a/front/components/app/RootLayout.tsx
+++ b/front/components/app/RootLayout.tsx
@@ -2,10 +2,8 @@ import { ConfirmPopupArea } from "@app/components/Confirm";
 import { NavigationLoadingProvider } from "@app/components/sparkle/NavigationLoadingContext";
 import { SidebarProvider } from "@app/components/sparkle/SidebarContext";
 import { useStripUtmParams } from "@app/hooks/useStripUtmParams";
-import { LinkWrapper, useAppRouter } from "@app/lib/platform";
-import { isAPIErrorResponse } from "@app/types/error";
+import { LinkWrapper } from "@app/lib/platform";
 import { Notification, SparkleContext } from "@dust-tt/sparkle";
-import { SWRConfig } from "swr";
 
 /**
  * This layout is used in _app only
@@ -15,32 +13,17 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
-  const router = useAppRouter();
   useStripUtmParams();
 
   return (
     <SparkleContext.Provider value={{ components: { link: LinkWrapper } }}>
-      <SWRConfig
-        value={{
-          onError: async (error) => {
-            if (
-              isAPIErrorResponse(error) &&
-              error.error.type === "not_authenticated"
-            ) {
-              // Redirect to login page.
-              await router.push("/api/workos/login");
-            }
-          },
-        }}
-      >
-        <SidebarProvider>
-          <NavigationLoadingProvider>
-            <ConfirmPopupArea>
-              <Notification.Area>{children}</Notification.Area>
-            </ConfirmPopupArea>
-          </NavigationLoadingProvider>
-        </SidebarProvider>
-      </SWRConfig>
+      <SidebarProvider>
+        <NavigationLoadingProvider>
+          <ConfirmPopupArea>
+            <Notification.Area>{children}</Notification.Area>
+          </ConfirmPopupArea>
+        </NavigationLoadingProvider>
+      </SidebarProvider>
     </SparkleContext.Provider>
   );
 }

--- a/front/components/pages/onboarding/VerifyPage.tsx
+++ b/front/components/pages/onboarding/VerifyPage.tsx
@@ -10,7 +10,7 @@ import {
   RESEND_COOLDOWN_SECONDS,
 } from "@app/lib/plans/trial/phone";
 import { useAppRouter } from "@app/lib/platform";
-import { useVerifyData } from "@app/lib/swr/workspaces";
+import { useAuthContext, useVerifyData } from "@app/lib/swr/workspaces";
 import { Button, DustLogoSquare, Page, Spinner } from "@dust-tt/sparkle";
 import type React from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -21,6 +21,9 @@ type Step = "phone" | "code";
 export function VerifyPage() {
   const { workspace } = useAuth();
   const router = useAppRouter();
+  const { mutateAuthContext } = useAuthContext({
+    workspaceId: workspace.sId,
+  });
 
   const {
     verifyData,
@@ -162,6 +165,10 @@ export function VerifyPage() {
         setPhoneError(data.api_error?.message ?? "Failed to start trial");
         return;
       }
+
+      // Revalidate the auth context so the SPA picks up the new subscription
+      // (canUseProduct is now true) and doesn't redirect back to /trial.
+      await mutateAuthContext();
 
       void router.push(`/w/${workspace.sId}/conversation/new?welcome=true`);
     } catch {

--- a/front/lib/swr/poke.ts
+++ b/front/lib/swr/poke.ts
@@ -1,5 +1,4 @@
 import { useRegionContextSafe } from "@app/lib/auth/RegionContext";
-import { getApiBaseUrl } from "@app/lib/egress/client";
 import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import { isRegionRedirect } from "@app/lib/swr/workspaces";
 import type { GetPokeNoWorkspaceAuthContextResponseType } from "@app/pages/api/poke/auth-context";
@@ -13,7 +12,7 @@ import type { ConnectorPermission } from "@app/types/connectors/connectors_api";
 import type { DataSourceType } from "@app/types/data_source";
 import type { APIErrorResponse, RegionRedirectError } from "@app/types/error";
 import type { LightWorkspaceType } from "@app/types/user";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import type { Fetcher } from "swr";
 
 export function usePokeRegion() {
@@ -180,7 +179,6 @@ export function usePokeAuthContext(
   options: { workspaceId?: string; disabled?: boolean } = {}
 ) {
   const { workspaceId, disabled } = options;
-  const [isRedirecting, setIsRedirecting] = useState(false);
   const regionContext = useRegionContextSafe();
 
   const url = workspaceId
@@ -211,24 +209,10 @@ export function usePokeAuthContext(
     }
   }, [regionRedirect, mutate, regionContext]);
 
-  // Handle login redirect.
-  useEffect(() => {
-    if (error && !regionRedirect) {
-      if (error.error?.type === "not_authenticated") {
-        setIsRedirecting(true);
-        window.location.href = `${getApiBaseUrl()}/api/workos/login?returnTo=${encodeURIComponent(
-          window.location.pathname + window.location.search
-        )}`;
-      }
-      // For all other errors, let the consuming component handle the display.
-    }
-  }, [error, regionRedirect]);
-
   return {
     authContext: isRegionRedirectResponse ? undefined : data,
     isAuthenticated,
-    isAuthContextLoading:
-      isLoading || !!isRegionRedirectResponse || isRedirecting,
+    isAuthContextLoading: isLoading || !!isRegionRedirectResponse,
     authContextError: error,
   };
 }

--- a/front/lib/swr/swr.ts
+++ b/front/lib/swr/swr.ts
@@ -1,5 +1,5 @@
 import { BUILD_DATE, COMMIT_HASH } from "@app/lib/commit-hash";
-import { clientFetch } from "@app/lib/egress/client";
+import { clientFetch, getApiBaseUrl } from "@app/lib/egress/client";
 import { isAPIErrorResponse } from "@app/types/error";
 import { safeParseJSON } from "@app/types/shared/utils/json_utils";
 import type { PaginationState } from "@tanstack/react-table";
@@ -170,6 +170,15 @@ const resHandler = async (res: Response) => {
     const parseRes = safeParseJSON(errorText);
     if (parseRes.isOk()) {
       if (isAPIErrorResponse(parseRes.value)) {
+        if (parseRes.value.error.type === "not_authenticated") {
+          const returnTo =
+            window.location.pathname !== "/"
+              ? `?returnTo=${encodeURIComponent(window.location.pathname + window.location.search)}`
+              : "";
+          window.location.href = `${getApiBaseUrl()}/api/workos/login${returnTo}`;
+          // Return a never-resolving promise to prevent SWR from processing.
+          return new Promise(() => {});
+        }
         throw parseRes.value;
       }
     }

--- a/front/lib/swr/workspaces.ts
+++ b/front/lib/swr/workspaces.ts
@@ -4,7 +4,6 @@ import type {
   GroupByType,
 } from "@app/lib/api/analytics/programmatic_cost";
 import { useRegionContextSafe } from "@app/lib/auth/RegionContext";
-import { getApiBaseUrl } from "@app/lib/egress/client";
 import { emptyArray, fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { GetNoWorkspaceAuthContextResponseType } from "@app/pages/api/auth-context";
 import type { GetPendingInvitationsLookupResponseBody } from "@app/pages/api/invitations";
@@ -34,7 +33,7 @@ import type { GetWorkspaceLookupResponseBody } from "@app/pages/api/workspace-lo
 import type { APIErrorResponse, RegionRedirectError } from "@app/types/error";
 import type { WhitelistableFeature } from "@app/types/shared/feature_flags";
 import type { LightWorkspaceType } from "@app/types/user";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import type { Fetcher } from "swr";
 
 // Type guard to check if response is a region redirect
@@ -572,6 +571,7 @@ interface UseAuthContextResult<T> {
   isAuthenticated: boolean;
   isAuthContextLoading: boolean;
   authContextError: APIErrorResponse | Error | undefined;
+  mutateAuthContext: () => Promise<T | undefined>;
 }
 
 export function useAuthContext(options?: {
@@ -591,7 +591,6 @@ export function useAuthContext(
   options: { workspaceId?: string; disabled?: boolean } = {}
 ) {
   const { workspaceId, disabled } = options;
-  const [isRedirecting, setIsRedirecting] = useState(false);
   const regionContext = useRegionContextSafe();
 
   const url = workspaceId
@@ -624,25 +623,12 @@ export function useAuthContext(
     }
   }, [regionRedirect, mutate, regionContext]);
 
-  // Handle login redirect.
-  useEffect(() => {
-    if (error && !regionRedirect) {
-      if (error.error?.type === "not_authenticated") {
-        setIsRedirecting(true);
-        window.location.href = `${getApiBaseUrl()}/api/workos/login?returnTo=${encodeURIComponent(
-          window.location.pathname + window.location.search
-        )}`;
-      }
-      // For all other errors, let the consuming component handle the display.
-    }
-  }, [error, regionRedirect]);
-
   return {
     authContext: isRegionRedirectResponse ? undefined : data,
     isAuthenticated,
-    isAuthContextLoading:
-      isFetching || !!isRegionRedirectResponse || isRedirecting,
+    isAuthContextLoading: isFetching || !!isRegionRedirectResponse,
     authContextError: error,
+    mutateAuthContext: mutate,
   };
 }
 

--- a/front/pages/api/login.ts
+++ b/front/pages/api/login.ts
@@ -5,7 +5,6 @@ import {
   handleMembershipInvite,
   handleRegularSignupFlow,
 } from "@app/lib/api/signup";
-import { getApiBaseUrl } from "@app/lib/egress/client";
 import { AuthFlowError } from "@app/lib/iam/errors";
 import type { SessionWithUser } from "@app/lib/iam/provider";
 import { getUserFromSession } from "@app/lib/iam/session";
@@ -110,7 +109,7 @@ async function handler(
     if (flow === "unauthorized") {
       // Only happen if the workspace associated with workOSOrganizationId is not found.
       res.redirect(
-        `${getApiBaseUrl()}/api/workos/logout?returnTo=/login-error${encodeURIComponent(`?type=sso-login&reason=${flow}`)}`
+        `/api/workos/logout?returnTo=/login-error${encodeURIComponent(`?type=sso-login&reason=${flow}`)}`
       );
       return;
     }
@@ -133,7 +132,7 @@ async function handler(
 
     // More than one pending invitation, redirect to invite choose page - otherwise use the first one.
     if (pendingInvitations && pendingInvitations.length > 1) {
-      res.redirect("/invite-choose");
+      res.redirect(`${config.getAppUrl()}/invite-choose`);
       return;
     }
 
@@ -165,7 +164,7 @@ async function handler(
           "Error during login flow."
         );
         res.redirect(
-          `${getApiBaseUrl()}/api/workos/logout?returnTo=/login-error${encodeURIComponent(`?type=login&reason=${error.code}`)}`
+          `/api/workos/logout?returnTo=/login-error${encodeURIComponent(`?type=login&reason=${error.code}`)}`
         );
         return;
       }
@@ -180,14 +179,14 @@ async function handler(
         null
       );
       res.redirect(
-        `${getApiBaseUrl()}/api/workos/logout?returnTo=${encodeURIComponent(ssoLoginUrl)}`
+        `/api/workos/logout?returnTo=${encodeURIComponent(ssoLoginUrl)}`
       );
       return;
     }
 
     const { flow, workspace } = result.value;
     if (flow === "no-auto-join" || flow === "revoked") {
-      res.redirect(`/no-workspace?flow=${flow}`);
+      res.redirect(`${config.getAppUrl()}/no-workspace?flow=${flow}`);
       return;
     }
 
@@ -197,7 +196,7 @@ async function handler(
 
   const u = await getUserFromSession(session);
   if (!u || u.workspaces.length === 0) {
-    res.redirect("/no-workspace?flow=revoked");
+    res.redirect(`${config.getAppUrl()}/no-workspace?flow=revoked`);
     return;
   }
 

--- a/front/pages/api/workos/[action].ts
+++ b/front/pages/api/workos/[action].ts
@@ -84,7 +84,6 @@ async function handleLogin(req: NextApiRequest, res: NextApiResponse) {
     const sanitizedReturnTo = validatedReturnTo.valid
       ? validatedReturnTo.sanitizedPath
       : null;
-
     // Extract UTM params from query to preserve through OAuth flow
     const utmParams = extractUTMParams(req.query);
 
@@ -382,7 +381,7 @@ async function handleLogout(req: NextApiRequest, res: NextApiResponse) {
   const validatedReturnTo = validateRelativePath(returnTo);
   const sanitizedReturnTo = validatedReturnTo.valid
     ? validatedReturnTo.sanitizedPath
-    : "/";
+    : config.getClientFacingUrl();
 
   redirectTo(res, sanitizedReturnTo);
 }


### PR DESCRIPTION
## Summary

Fix SPA paywall-whitelisted pages (subscribe, trial, trial-ended, welcome, verify) being blocked by `WorkspacePage` auth, centralize `not_authenticated` handling, and fix various login/signup redirect issues for SPA compatibility.

## Changes

### SPA paywall enforcement
- **`auth-context.ts`**: Add `doesNotRequireCanUseProduct: true` so the endpoint no longer returns 403 on paywall. Conditionally return `isEligibleForTrial` (only when `canUseProduct` is false) to avoid extra DB queries on the happy path.
- **`App.tsx`**: Add `handle: { paywallWhitelisted: true }` to onboarding route definitions (subscribe, trial, trial-ended, welcome, verify).
- **`WorkspacePage.tsx`**: Use `useMatches()` to check route handles for paywall whitelist. When `canUseProduct` is false and route is not whitelisted, redirect to `/trial` (if eligible) or `/subscribe`.

### Centralized auth redirect
- **`swr.ts`**: Handle `not_authenticated` in the global SWR fetcher (`resHandler`) by redirecting to login and returning a never-resolving promise — keeping SWR hooks in loading state during redirect. Same pattern as existing `X-Reload-Required` handling.
- **`RootLayout.tsx`**: Remove the `SWRConfig` `onError` handler (now handled by fetcher).
- **`workspaces.ts`** / **`poke.ts`**: Remove duplicate `not_authenticated` `useEffect` handlers and `isRedirecting` state.

### Auth context revalidation
- **`workspaces.ts`**: Expose `mutateAuthContext` from `useAuthContext` hook.
- **`VerifyPage.tsx`**: Call `mutateAuthContext()` after trial activation to prevent redirect loop back to `/trial`.

### Login/signup redirect fixes
- **`login.ts`**: Remove `getApiBaseUrl()` calls — returns nothing server-side and makes no sense since we are already on an API server route. Use relative paths for logout redirects, and `config.getAppUrl()` for SPA-compatible redirects to `/invite-choose` and `/no-workspace`.
- **`[action].ts`**: Use `config.getClientFacingUrl()` as default logout redirect.
- **`IndexPage.tsx`**: Handle missing `defaultWorkspaceId` by redirecting to `/api/login`.

## Tests

Manual testing of the full flow: login → paywall redirect → trial/subscribe → verify → conversation.

## Risk

Medium — changes auth-context endpoint behavior and centralizes auth redirect handling across SWR hooks. Mitigated by:
- `doesNotRequireCanUseProduct` only affects the auth-context endpoint, paywall enforcement moves to client-side
- `not_authenticated` fetcher handling uses the same never-resolving promise pattern already proven by `X-Reload-Required`
- `isEligibleForTrial` is only computed when `canUseProduct` is false (no perf impact on happy path)