### PR TITLE
Show MCP call durations in Poke

### DIFF
--- a/front/components/poke/pages/ConversationPage.tsx
+++ b/front/components/poke/pages/ConversationPage.tsx
@@ -215,6 +215,12 @@ const AgentMessageView = ({
                 )}
                 {a.created && <>{new Date(a.created).toLocaleTimeString()}: </>}
                 step {a.step}: <b className="px-1">{a.functionCallName}()</b>
+                {"executionDurationMs" in a &&
+                  typeof a.executionDurationMs === "number" && (
+                    <span className="ml-1 text-xs">
+                      ({(a.executionDurationMs / 1000).toFixed(1)}s)
+                    </span>
+                  )}
                 {a.runId && (
                   <>
                     log:{" "}


### PR DESCRIPTION
## Description

Simple addition to show the duration for each call, e.g.

<img width="347" height="79" alt="Screenshot 2026-02-15 at 19 57 38" src="https://github.com/user-attachments/assets/9112361d-c429-4f2d-bab1-fdbe64f3dfee" />


## Tests

Manual

## Risk

Minimal, Poke only

## Deploy Plan

Front