### PR TITLE
Make /list prompt command support partial matches and use action buttons

### DIFF
--- a/front/temporal/agent_loop/lib/prompt_commands.ts
+++ b/front/temporal/agent_loop/lib/prompt_commands.ts
@@ -381,7 +381,7 @@ async function handleToolListCommand(
     const content =
       (matchedTool.description ? `${matchedTool.description}\n\n` : "") +
       "```\n" +
-      `${matchedTool.name}(${JSON.stringify(templateArgs, null, 2)})` +
+      `/run ${matchedTool.name}(${JSON.stringify(templateArgs, null, 2)})` +
       "\n```";
     return publishSuccessAndFinish(auth, runAgentData, step, content);
   }

--- a/front/temporal/agent_loop/lib/prompt_commands.ts
+++ b/front/temporal/agent_loop/lib/prompt_commands.ts
@@ -331,6 +331,16 @@ export async function handlePromptCommand(
 }
 
 /**
+ * Format a list of tools as quickReply buttons, each linking to `/list <tool_name>`.
+ */
+function formatToolListWithButtons(tools: MCPToolConfigurationType[]): string {
+  const buttons = tools
+    .map((t) => `:quickReply[${t.name}]{message="/list ${t.name}"}`)
+    .join("\n");
+  return "Click a button to get details on a specific tool:\n\n" + buttons;
+}
+
+/**
  * Handle the /list command: list available tools and publish as success message.
  * If a filter is provided (e.g. `/list search_term`), find tools whose name
  * contains that term. If exactly one matches, show its schema. If multiple
@@ -356,14 +366,12 @@ async function handleToolListCommand(
     }
 
     if (matchingTools.length > 1) {
-      const buttons = matchingTools
-        .map(
-          (t) => `:quickReply[${t.name}]{message="/list ${t.name}"}`
-        )
-        .join("\n");
-      const content =
-        "Click a button to get details on a specific tool:\n\n" + buttons;
-      return publishSuccessAndFinish(auth, runAgentData, step, content);
+      return publishSuccessAndFinish(
+        auth,
+        runAgentData,
+        step,
+        formatToolListWithButtons(matchingTools)
+      );
     }
 
     // Exactly one match — show its schema.
@@ -391,9 +399,12 @@ async function handleToolListCommand(
     return publishSuccessAndFinish(auth, runAgentData, step, content);
   }
 
-  const toolNames = availableTools.map((t) => t.name);
-  const content = "```\n" + toolNames.join("\n") + "\n```";
-  return publishSuccessAndFinish(auth, runAgentData, step, content);
+  return publishSuccessAndFinish(
+    auth,
+    runAgentData,
+    step,
+    formatToolListWithButtons(availableTools)
+  );
 }
 
 /**

--- a/front/temporal/agent_loop/lib/prompt_commands.ts
+++ b/front/temporal/agent_loop/lib/prompt_commands.ts
@@ -356,8 +356,13 @@ async function handleToolListCommand(
     }
 
     if (matchingTools.length > 1) {
+      const buttons = matchingTools
+        .map(
+          (t) => `:quickReply[${t.name}]{message="/list ${t.name}"}`
+        )
+        .join("\n");
       const content =
-        "```\n" + matchingTools.map((t) => t.name).join("\n") + "\n```";
+        "Click a button to get details on a specific tool:\n\n" + buttons;
       return publishSuccessAndFinish(auth, runAgentData, step, content);
     }
 

--- a/front/temporal/agent_loop/lib/prompt_commands.ts
+++ b/front/temporal/agent_loop/lib/prompt_commands.ts
@@ -26,9 +26,8 @@ import type { AgentLoopExecutionData } from "@app/types/assistant/agent_run";
 import type { AgentMessageType } from "@app/types/assistant/conversation";
 import type { ModelId } from "@app/types/shared/model_id";
 
-// Matches the command (/run or /list) as the second word in the message.
-// The first word is the agent mention text (e.g. "Dust").
-const COMMAND_REGEX = /^\S+\s+\/(run|list)\b/;
+// Matches the command (/run or /list), optionally preceded by an agent mention.
+const COMMAND_REGEX = /^(?:\S+\s+)?\/(run|list)\b/;
 
 // Matches the start of a tool call: tool_name followed by optional whitespace and '('.
 const TOOL_CALL_START_REGEX = /(\w+)\s*\(/g;


### PR DESCRIPTION
## Description

  - Before: /list tool_name required an exact match on the tool name.
  - After: /list search_term does a case-insensitive substring match:
    - 0 matches: shows an error with all available tool names
    - 1 match: shows that tool's schema (same as before)
    - Multiple matches: lists the matching tool names (filtered list)

Also, display `/run` before command details to show the more complete command.

Also, use action buttons to make it easier to get tool details.

## Tests

Manual

## Risk

Minimal, under Dust only flag

## Deploy Plan

Front