### PR TITLE
Add redirects for /assistants

### DIFF
--- a/front-spa/src/app/App.tsx
+++ b/front-spa/src/app/App.tsx
@@ -18,12 +18,25 @@ import {
   Navigate,
   RouterProvider,
   useLocation,
+  useParams,
 } from "react-router-dom";
 
 // Redirect component that preserves query params and hash
 function RedirectWithSearchParams({ to }: { to: string }) {
   const location = useLocation();
   return <Navigate to={`${to}${location.search}${location.hash}`} replace />;
+}
+
+// Redirect component for /builder/assistants/:aId -> /builder/agents/:aId
+function AssistantAgentRedirect() {
+  const { aId } = useParams();
+  const location = useLocation();
+  return (
+    <Navigate
+      to={`../builder/agents/${aId}${location.search}${location.hash}`}
+      replace
+    />
+  );
 }
 
 // Loading fallback component
@@ -431,6 +444,30 @@ const router = createBrowserRouter(
         { path: "trial", element: <TrialPage /> },
         { path: "trial-ended", element: <TrialEndedPage /> },
         { path: "verify", element: <VerifyPage /> },
+
+        // Legacy assistants -> agents redirects
+        {
+          path: "builder/assistants",
+          element: <RedirectWithSearchParams to="../builder/agents" />,
+        },
+        {
+          path: "builder/assistants/create",
+          element: <RedirectWithSearchParams to="../builder/agents/create" />,
+        },
+        {
+          path: "builder/assistants/new",
+          element: <RedirectWithSearchParams to="../builder/agents/new" />,
+        },
+        {
+          path: "builder/assistants/dust",
+          element: (
+            <RedirectWithSearchParams to="../builder/agents#?selectedTab=global" />
+          ),
+        },
+        {
+          path: "builder/assistants/:aId",
+          element: <AssistantAgentRedirect />,
+        },
       ],
     },
     {


### PR DESCRIPTION
## Summary

Add permanent redirects from `/builder/assistants/*` to `/builder/agents/*` in the SPA, mirroring the existing Next.js SSR redirects.

## Changes

- **`App.tsx`**: Add redirect routes for legacy assistants URLs:
  - `/builder/assistants` → `/builder/agents`
  - `/builder/assistants/create` → `/builder/agents/create`
  - `/builder/assistants/new` → `/builder/agents/new`
  - `/builder/assistants/dust` → `/builder/agents#selectedTab=global`
  - `/builder/assistants/:aId` → `/builder/agents/:aId`
- All redirects preserve query params and hash via the existing `RedirectWithSearchParams` helper and a new `AssistantAgentRedirect` component for the parameterized route.

## Test plan

- [ ] `/w/{wId}/builder/assistants` redirects to `/w/{wId}/builder/agents`
- [ ] `/w/{wId}/builder/assistants/new?foo=bar` redirects to `/w/{wId}/builder/agents/new?foo=bar`
- [ ] `/w/{wId}/builder/assistants/some-id` redirects to `/w/{wId}/builder/agents/some-id`
- [ ] `/w/{wId}/builder/assistants/dust` redirects to `/w/{wId}/builder/agents#selectedTab=global`