### PR TITLE
feat: add slack notification feature flag

### DIFF
--- a/front/types/shared/feature_flags.ts
+++ b/front/types/shared/feature_flags.ts
@@ -244,6 +244,10 @@ export const WHITELISTABLE_FEATURES_CONFIG = {
     description: "Enable /run command to directly call tools without LLM",
     stage: "dust_only",
   },
+  conversations_slack_notifications: {
+    description: "Enable slack notifications",
+    stage: "dust_only",
+  },
 } as const satisfies Record<string, FeatureFlag>;
 
 export type FeatureFlagStage = "dust_only" | "rolling_out" | "on_demand";

--- a/sdks/js/src/types.ts
+++ b/sdks/js/src/types.ts
@@ -714,6 +714,7 @@ const WhitelistableFeaturesSchema = FlexibleEnumSchema<
   | "run_tools_from_prompt"
   | "usage_data_api"
   | "xai_feature"
+  | "conversations_slack_notifications"
 >();
 
 export type WhitelistableFeature = z.infer<typeof WhitelistableFeaturesSchema>;


### PR DESCRIPTION





## Description

This PR adds a new feature flag for Slack notifications.

## Tests

Manually

## Risks

Low risk. This only introduces the feature flag definition.

## Deploy Plan

Standard deployment. 
