### PR TITLE
feat: send slack notifications

### DIFF
--- a/front/lib/notifications/index.ts
+++ b/front/lib/notifications/index.ts
@@ -118,7 +118,7 @@ const isSlackNotificationsFeatureEnabled = async (
   return featureFlags.includes("conversations_slack_notifications");
 };
 
-const isSlackChannelConfigured = async (
+const isNovuSlackChannelConfigured = async (
   subscriberId: string
 ): Promise<boolean> => {
   const novu = await getNovuClient();
@@ -210,7 +210,7 @@ const getSlackToken = async (
   return new Ok(tokenResult.value.access_token);
 };
 
-const configureSlackChannelForUser = async (
+const configureNovuSlackChannelForUser = async (
   subscriberId: string | undefined,
   workspaceId: string
 ): Promise<{
@@ -301,12 +301,12 @@ export const ensureSlackNotificationsReady = async (
     return { isReady: false };
   }
 
-  const isChannelConfigured = await isSlackChannelConfigured(subscriberId);
+  const isChannelConfigured = await isNovuSlackChannelConfigured(subscriberId);
 
   // If the slack channel is not configured, we attempt to configure it automatically.
   // This will fail if the Dust Slack Bot is not configured for the workspace.
   if (!isChannelConfigured) {
-    const { success } = await configureSlackChannelForUser(
+    const { success } = await configureNovuSlackChannelForUser(
       subscriberId,
       workspaceId
     );

--- a/front/lib/notifications/workflows/conversation-unread.ts
+++ b/front/lib/notifications/workflows/conversation-unread.ts
@@ -3,6 +3,7 @@ import type { AgentActionSpecification } from "@app/lib/actions/types/agent";
 import { runMultiActionsAgent } from "@app/lib/api/assistant/call_llm";
 import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
 import { renderConversationForModel } from "@app/lib/api/assistant/conversation_rendering";
+import config from "@app/lib/api/config";
 import { Authenticator } from "@app/lib/auth";
 import {
   getAgentsDataRetention,
@@ -11,6 +12,7 @@ import {
 import { DustError } from "@app/lib/error";
 import type { NotificationAllowedTags } from "@app/lib/notifications";
 import {
+  ensureSlackNotificationsReady,
   getNovuClient,
   getUserNotificationDelay,
 } from "@app/lib/notifications";
@@ -114,6 +116,7 @@ const ConversationDetailsSchema = z.object({
   hasUnreadMentions: z.boolean(),
   hasConversationRetentionPolicy: z.boolean(),
   hasAgentRetentionPolicies: z.boolean(),
+  newMessageContent: z.string().nullable(),
 });
 
 type ConversationDetailsType = z.infer<typeof ConversationDetailsSchema>;
@@ -160,6 +163,7 @@ const getConversationDetails = async ({
         hasUnreadMentions: false,
         hasConversationRetentionPolicy: false,
         hasAgentRetentionPolicies: false,
+        newMessageContent: null,
       });
     }
     auth = await Authenticator.fromUserIdAndWorkspaceId(
@@ -207,6 +211,10 @@ const getConversationDetails = async ({
   let authorIsAgent: boolean;
   let avatarUrl: string | undefined;
   let mentionedUserIds: string[] = [];
+  const messageContent =
+    message.type === "agent_message" || message.type === "user_message"
+      ? message.content
+      : "";
 
   if (isContentFragmentType(message)) {
     // Content fragments don't have author info.
@@ -268,6 +276,7 @@ const getConversationDetails = async ({
     hasUnreadMentions,
     hasConversationRetentionPolicy,
     hasAgentRetentionPolicies,
+    newMessageContent: messageContent,
   });
 };
 
@@ -531,6 +540,28 @@ const generateUnreadMessagesSummary = async ({
   );
 };
 
+const getMessagePreview = (
+  details: ConversationDetailsType
+): string | undefined => {
+  if (details.hasConversationRetentionPolicy) {
+    return "> Preview not available due to data retention policy on conversations in this workspace.";
+  }
+  if (details.hasAgentRetentionPolicies) {
+    return "> Preview not available due to data retention policy on agents in this conversation.";
+  }
+  if (details.newMessageContent) {
+    const stripped = stripMarkdown(details.newMessageContent);
+    const trimmed = stripped.trim();
+    const truncated =
+      trimmed.substring(0, 300) + (trimmed.length > 300 ? "..." : "");
+    // Replace newlines with "> \n" to maintain blockquote formatting on each line
+    return truncated
+      .split("\n")
+      .map((line) => `> ${line}`)
+      .join("\n");
+  }
+};
+
 export const conversationUnreadWorkflow = workflow(
   CONVERSATION_UNREAD_TRIGGER_ID,
   async ({ step, payload, subscriber }) => {
@@ -613,6 +644,55 @@ export const conversationUnreadWorkflow = workflow(
       {
         outputSchema: UserNotificationDelaySchema,
         skip: async () => !details,
+      }
+    );
+
+    await step.chat(
+      "slack-notification",
+      async () => {
+        // details is guaranteed non-null here because skip prevents execution otherwise.
+        const d = details!;
+        const conversationUrl = getConversationRoute(
+          payload.workspaceId,
+          payload.conversationId,
+          undefined,
+          config.getAppUrl()
+        );
+
+        // Create message preview
+        const messagePreview = getMessagePreview(d);
+
+        const baseMessage = d.authorIsAgent
+          ? `${d.author} replied in "${d.subject}"`
+          : `New message from ${d.author} in "${d.subject}"`;
+
+        const message = messagePreview
+          ? `${baseMessage}\n${messagePreview}\n<${conversationUrl}|View conversation>`
+          : `${baseMessage}\n<${conversationUrl}|View conversation>`;
+
+        return {
+          body: message,
+        };
+      },
+      {
+        skip: async () => {
+          if (!details) {
+            return true;
+          }
+          const { isReady } = await ensureSlackNotificationsReady(
+            subscriber.subscriberId,
+            payload.workspaceId
+          );
+          if (!isReady) {
+            return true;
+          }
+          return shouldSkipConversation({
+            subscriberId: subscriber.subscriberId,
+            payload,
+            triggerShouldSkip: false,
+            hasUnreadMessages: details.hasUnreadMessages,
+          });
+        },
       }
     );
 

--- a/front/lib/notifications/workflows/project-added-as-member.ts
+++ b/front/lib/notifications/workflows/project-added-as-member.ts
@@ -1,7 +1,11 @@
+import config from "@app/lib/api/config";
 import { Authenticator } from "@app/lib/auth";
 import type { DustError } from "@app/lib/error";
 import type { NotificationAllowedTags } from "@app/lib/notifications";
-import { getNovuClient } from "@app/lib/notifications";
+import {
+  ensureSlackNotificationsReady,
+  getNovuClient,
+} from "@app/lib/notifications";
 import { renderEmail } from "@app/lib/notifications/email-templates/default";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
@@ -131,6 +135,35 @@ export const projectAddedAsMemberWorkflow = workflow(
       },
       {
         skip: async () => shouldSkipProject({ payload }),
+      }
+    );
+
+    await step.chat(
+      "slack-notification",
+      async () => {
+        const projectUrl =
+          config.getAppUrl() +
+          getProjectRoute(payload.workspaceId, payload.projectId);
+
+        const baseMessage = `${details.userThatAddedYouFullname} added you to project "${details.projectName}"`;
+
+        const message = `${baseMessage}\n<${projectUrl}|View project>`;
+
+        return {
+          body: message,
+        };
+      },
+      {
+        skip: async () => {
+          const { isReady } = await ensureSlackNotificationsReady(
+            subscriber.subscriberId,
+            payload.workspaceId
+          );
+          if (!isReady) {
+            return true;
+          }
+          return shouldSkipProject({ payload });
+        },
       }
     );
 

--- a/front/lib/notifications/workflows/project-added-as-member.ts
+++ b/front/lib/notifications/workflows/project-added-as-member.ts
@@ -155,6 +155,10 @@ export const projectAddedAsMemberWorkflow = workflow(
       },
       {
         skip: async () => {
+          const shouldSkip = await shouldSkipProject({ payload });
+          if (shouldSkip) {
+            return true;
+          }
           const { isReady } = await ensureSlackNotificationsReady(
             subscriber.subscriberId,
             payload.workspaceId
@@ -162,7 +166,7 @@ export const projectAddedAsMemberWorkflow = workflow(
           if (!isReady) {
             return true;
           }
-          return shouldSkipProject({ payload });
+          return false;
         },
       }
     );

--- a/front/lib/notifications/workflows/project-new-conversation.ts
+++ b/front/lib/notifications/workflows/project-new-conversation.ts
@@ -345,6 +345,13 @@ export const projectNewConversationWorkflow = workflow(
           if (!details) {
             return true;
           }
+          const shouldSkip = await shouldSkipConversation({
+            subscriberId: subscriber.subscriberId,
+            payload,
+          });
+          if (shouldSkip) {
+            return true;
+          }
           const { isReady } = await ensureSlackNotificationsReady(
             subscriber.subscriberId,
             payload.workspaceId
@@ -352,10 +359,7 @@ export const projectNewConversationWorkflow = workflow(
           if (!isReady) {
             return true;
           }
-          return shouldSkipConversation({
-            subscriberId: subscriber.subscriberId,
-            payload,
-          });
+          return false;
         },
       }
     );

--- a/front/lib/notifications/workflows/project-new-conversation.ts
+++ b/front/lib/notifications/workflows/project-new-conversation.ts
@@ -1,7 +1,16 @@
+import { getConversation } from "@app/lib/api/assistant/conversation/fetch";
+import config from "@app/lib/api/config";
 import { Authenticator } from "@app/lib/auth";
+import {
+  getAgentsDataRetention,
+  getConversationsDataRetention,
+} from "@app/lib/data_retention";
 import { DustError } from "@app/lib/error";
 import type { NotificationAllowedTags } from "@app/lib/notifications";
-import { getUserNotificationDelay } from "@app/lib/notifications";
+import {
+  ensureSlackNotificationsReady,
+  getUserNotificationDelay,
+} from "@app/lib/notifications";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
@@ -18,10 +27,10 @@ import {
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { assertNever } from "@app/types/shared/utils/assert_never";
+import { stripMarkdown } from "@app/types/shared/utils/string_utils";
 import { workflow } from "@novu/framework";
 import uniqBy from "lodash/uniqBy";
 import z from "zod";
-
 import { renderEmail } from "../email-templates/project-new-conversation";
 import type { ProjectNewConversationPayloadType } from "../triggers/project-new-conversation";
 import { projectNewConversationPayloadSchema } from "../triggers/project-new-conversation";
@@ -30,6 +39,9 @@ const ConversationDetailsSchema = z.object({
   projectName: z.string(),
   userThatCreatedConversationFullName: z.string(),
   conversationTitle: z.string(),
+  hasConversationRetentionPolicy: z.boolean(),
+  hasAgentRetentionPolicies: z.boolean(),
+  firstMessageContent: z.string().nullable(),
 });
 
 const ConversationDetailsResultSchema = z.discriminatedUnion("success", [
@@ -70,6 +82,9 @@ const getConversationDetails = async ({
       projectName: "A project",
       userThatCreatedConversationFullName: "Someone",
       conversationTitle: "New conversation",
+      hasAgentRetentionPolicies: false,
+      hasConversationRetentionPolicy: false,
+      firstMessageContent: null,
     });
   }
 
@@ -78,18 +93,15 @@ const getConversationDetails = async ({
     payload.workspaceId
   );
 
-  const conversationResource = await ConversationResource.fetchById(
-    auth,
-    payload.conversationId
-  );
+  const conversationRes = await getConversation(auth, payload.conversationId);
 
-  const conversation = conversationResource?.toJSON();
-
-  if (!conversation) {
+  if (conversationRes.isErr()) {
     return new Err(
       new DustError("conversation_not_found", "Conversation not found")
     );
   }
+
+  const conversation = conversationRes.value;
 
   if (!isProjectConversation(conversation)) {
     return new Err(
@@ -119,10 +131,30 @@ const getConversationDetails = async ({
     );
   }
 
+  const conversationsRetention = await getConversationsDataRetention(auth);
+  const hasConversationRetentionPolicy = conversationsRetention !== null;
+
+  const agentsRetention = await getAgentsDataRetention(auth);
+  const hasAgentRetentionPolicies = conversation.content.flat().some((msg) => {
+    if (msg.type !== "agent_message") {
+      return false;
+    }
+
+    return msg.configuration.sId in agentsRetention;
+  });
+
+  const firstMessageContent =
+    conversation.content[0]?.[0].type === "user_message"
+      ? conversation.content[0][0].content
+      : null;
+
   return new Ok({
     projectName: project.name,
     userThatCreatedConversationFullName: userThatCreatedConversation.fullName(),
     conversationTitle: conversation.title ?? "New conversation",
+    hasConversationRetentionPolicy,
+    hasAgentRetentionPolicies,
+    firstMessageContent,
   });
 };
 
@@ -194,6 +226,26 @@ const shouldSkipConversation = async ({
   return false;
 };
 
+const getMessagePreview = (details: ProjectDetailsType): string | undefined => {
+  if (details.hasConversationRetentionPolicy) {
+    return "> Preview not available due to data retention policy on conversations in this workspace.";
+  }
+  if (details.hasAgentRetentionPolicies) {
+    return "> Preview not available due to data retention policy on agents in this conversation.";
+  }
+  if (details.firstMessageContent) {
+    const stripped = stripMarkdown(details.firstMessageContent);
+    const trimmed = stripped.trim();
+    const truncated =
+      trimmed.substring(0, 300) + (trimmed.length > 300 ? "..." : "");
+    // Replace newlines with "> \n" to maintain blockquote formatting on each line
+    return truncated
+      .split("\n")
+      .map((line) => `> ${line}`)
+      .join("\n");
+  }
+};
+
 export const projectNewConversationWorkflow = workflow(
   PROJECT_NEW_CONVERSATION_TRIGGER_ID,
   async ({ step, payload, subscriber }) => {
@@ -254,6 +306,50 @@ export const projectNewConversationWorkflow = workflow(
       {
         skip: async () => {
           if (!details) {
+            return true;
+          }
+          return shouldSkipConversation({
+            subscriberId: subscriber.subscriberId,
+            payload,
+          });
+        },
+      }
+    );
+
+    await step.chat(
+      "slack-notification",
+      async () => {
+        // details is guaranteed non-null here because skip prevents execution otherwise.
+        const d = details!;
+        const conversationUrl = getConversationRoute(
+          payload.workspaceId,
+          payload.conversationId,
+          undefined,
+          config.getAppUrl()
+        );
+
+        // Create message preview
+        const messagePreview = getMessagePreview(d);
+
+        const baseMessage = `There is a new conversation in "${d.projectName}": ${d.userThatCreatedConversationFullName} started "${d.conversationTitle}"`;
+
+        const message = messagePreview
+          ? `${baseMessage}\n${messagePreview}\n<${conversationUrl}|View conversation>`
+          : `${baseMessage}\n<${conversationUrl}|View conversation>`;
+        return {
+          body: message,
+        };
+      },
+      {
+        skip: async () => {
+          if (!details) {
+            return true;
+          }
+          const { isReady } = await ensureSlackNotificationsReady(
+            subscriber.subscriberId,
+            payload.workspaceId
+          );
+          if (!isReady) {
             return true;
           }
           return shouldSkipConversation({


### PR DESCRIPTION


## Description

This PR implements Slack notifications for unread conversations and project notifications.

- Adds `ensureSlackNotificationsReady` function to automatically configure Slack channel connections for users when needed
- Reuse Slack access token from Slack Bot connection.
- Automatically looks up user Slack IDs by email and creates Novu channel connections/endpoints

<img width="869" height="395" alt="Capture d’écran 2026-02-17 à 10 57 07" src="https://github.com/user-attachments/assets/6dbc3c26-72d3-4c90-9e32-5e1343b7cd1e" />

## Tests

Manually

## Risks

Low. Feature is hidden behind feature flag. If Slack Bot is not configured or feature flag is not active, notifications are silently skipped.

## Deploy Plan

Standard deployment