### PR TITLE
[front] - chore(agent): add spaces to YAML

### DIFF
--- a/front/lib/agent_yaml_converter/converter.ts
+++ b/front/lib/agent_yaml_converter/converter.ts
@@ -11,6 +11,7 @@ import type {
   AgentYAMLEditor,
   AgentYAMLSkill,
   AgentYAMLSlackIntegration,
+  AgentYAMLSpace,
   AgentYAMLTableConfiguration,
   AgentYAMLTag,
 } from "@app/lib/agent_yaml_converter/schemas";
@@ -27,7 +28,8 @@ import * as yaml from "js-yaml";
 export class AgentYAMLConverter {
   static async fromBuilderFormData(
     auth: Authenticator,
-    formData: AgentBuilderFormData
+    formData: AgentBuilderFormData,
+    spaces: AgentYAMLSpace[]
   ): Promise<Result<AgentYAMLConfig, Error>> {
     try {
       const actionsResult = await this.convertActions(auth, formData.actions);
@@ -57,6 +59,7 @@ export class AgentYAMLConverter {
         tags: this.convertTags(formData.agentSettings.tags),
         editors: this.convertEditors(formData.agentSettings.editors),
         toolset: actionsResult.value,
+        spaces,
         skills: skills.length > 0 ? skills : undefined,
         slack_integration: this.convertSlackIntegration(formData.agentSettings),
       };

--- a/front/lib/agent_yaml_converter/schemas.ts
+++ b/front/lib/agent_yaml_converter/schemas.ts
@@ -109,6 +109,11 @@ export const agentYAMLSkillSchema = z.object({
   name: z.string().min(1, "Skill name is required"),
 });
 
+export const agentYAMLSpaceSchema = z.object({
+  space_id: z.string().min(1, "Space ID is required"),
+  name: z.string().min(1, "Space name is required"),
+});
+
 export const agentYAMLConfigSchema = z.object({
   agent: agentYAMLBasicInfoSchema,
   instructions: z.string().min(1, "Instructions are required"),
@@ -116,6 +121,7 @@ export const agentYAMLConfigSchema = z.object({
   tags: z.array(agentYAMLTagSchema),
   editors: z.array(agentYAMLEditorSchema),
   toolset: z.array(agentYAMLActionSchema),
+  spaces: z.array(agentYAMLSpaceSchema),
   skills: z.array(agentYAMLSkillSchema).optional(),
   slack_integration: agentYAMLSlackIntegrationSchema.optional(),
 });
@@ -130,6 +136,7 @@ export type AgentYAMLTableConfiguration = z.infer<
 >;
 export type AgentYAMLAction = z.infer<typeof agentYAMLActionSchema>;
 export type AgentYAMLSkill = z.infer<typeof agentYAMLSkillSchema>;
+export type AgentYAMLSpace = z.infer<typeof agentYAMLSpaceSchema>;
 export type AgentYAMLSlackIntegration = z.infer<
   typeof agentYAMLSlackIntegrationSchema
 >;

--- a/front/lib/agent_yaml_converter/schemas.ts
+++ b/front/lib/agent_yaml_converter/schemas.ts
@@ -121,7 +121,7 @@ export const agentYAMLConfigSchema = z.object({
   tags: z.array(agentYAMLTagSchema),
   editors: z.array(agentYAMLEditorSchema),
   toolset: z.array(agentYAMLActionSchema),
-  spaces: z.array(agentYAMLSpaceSchema),
+  spaces: z.array(agentYAMLSpaceSchema).optional(),
   skills: z.array(agentYAMLSkillSchema).optional(),
   slack_integration: agentYAMLSlackIntegrationSchema.optional(),
 });


### PR DESCRIPTION
## Description

This PR adds space configuration to the agent YAML export functionality. The agent's `requestedSpaceIds` are now fetched and included in the YAML output as a `spaces` field containing space IDs and names.

## Risk

Low. This is an additive change to the YAML export functionality. 

## Tests

Locally

## Deploy Plan

Deploy front