### PR TITLE
Extend Private API Authentication

### DIFF
--- a/front/lib/api/auth_wrappers.ts
+++ b/front/lib/api/auth_wrappers.ts
@@ -1,4 +1,3 @@
-import { config as multiRegionsConfig } from "@app/lib/api/regions/config";
 import { getUserWithWorkspaces } from "@app/lib/api/user";
 import { getUserFromWorkOSToken, verifyWorkOSToken } from "@app/lib/api/workos";
 import {
@@ -135,7 +134,7 @@ export function withSessionAuthenticationForWorkspace<T>(
     req: NextApiRequest,
     res: NextApiResponse<WithAPIErrorResponse<T>>,
     auth: Authenticator,
-    session: SessionWithUser
+    session: SessionWithUser | null
   ) => Promise<void> | void,
   opts: {
     isStreaming?: boolean;
@@ -214,17 +213,8 @@ export function withSessionAuthenticationForWorkspace<T>(
       const owner = auth.workspace();
       const plan = auth.plan();
 
-      // When using bearer token, we don't have a session object, so we pass a minimal session
-      const minimalSession = session || {
-        type: "workos" as const,
-        sessionId: "",
-        user: {} as any,
-        region: multiRegionsConfig.getCurrentRegion(),
-        isSSO: false,
-        authenticationMethod: "bearer_token",
-      };
       if (opts.allowMissingWorkspace && (!owner || !plan)) {
-        return handler(req, res, auth, minimalSession);
+        return handler(req, res, auth, session);
       }
 
       if (!owner || !plan) {
@@ -277,7 +267,7 @@ export function withSessionAuthenticationForWorkspace<T>(
         });
       }
 
-      return handler(req, res, auth, minimalSession);
+      return handler(req, res, auth, session);
     },
     opts.isStreaming
   );

--- a/front/lib/api/auth_wrappers.ts
+++ b/front/lib/api/auth_wrappers.ts
@@ -214,16 +214,16 @@ export function withSessionAuthenticationForWorkspace<T>(
       const owner = auth.workspace();
       const plan = auth.plan();
 
+      // When using bearer token, we don't have a session object, so we pass a minimal session
+      const minimalSession = session || {
+        type: "workos" as const,
+        sessionId: "",
+        user: {} as any,
+        region: multiRegionsConfig.getCurrentRegion(),
+        isSSO: false,
+        authenticationMethod: "bearer_token",
+      };
       if (opts.allowMissingWorkspace && (!owner || !plan)) {
-        // When using bearer token, we don't have a session object, so we pass a minimal session
-        const minimalSession = session || {
-          type: "workos" as const,
-          sessionId: "",
-          user: {} as any,
-          region: multiRegionsConfig.getCurrentRegion(),
-          isSSO: false,
-          authenticationMethod: "bearer_token",
-        };
         return handler(req, res, auth, minimalSession);
       }
 
@@ -276,16 +276,6 @@ export function withSessionAuthenticationForWorkspace<T>(
           },
         });
       }
-
-      // When using bearer token, we don't have a session object, so we pass a minimal session
-      const minimalSession = session || {
-        type: "workos" as const,
-        sessionId: "",
-        user: {} as any,
-        region: multiRegionsConfig.getCurrentRegion(),
-        isSSO: false,
-        authenticationMethod: "bearer_token",
-      };
 
       return handler(req, res, auth, minimalSession);
     },

--- a/front/lib/api/auth_wrappers.ts
+++ b/front/lib/api/auth_wrappers.ts
@@ -121,6 +121,10 @@ export function withSessionAuthenticationForPoke<T>(
  * This function is a wrapper for API routes that require session authentication for a workspace.
  * It must be used on all routes that require workspace authentication (prefix: /w/[wId]/).
  *
+ * This function now supports both cookie-based sessions and bearer token authentication.
+ * If a session cookie is present, it will be used. Otherwise, it will attempt to authenticate
+ * using a bearer token from the Authorization header.
+ *
  * @param handler
  * @param opts
  * @returns
@@ -138,11 +142,10 @@ export function withSessionAuthenticationForWorkspace<T>(
     allowMissingWorkspace?: boolean;
   } = {}
 ) {
-  return withSessionAuthentication(
+  return withLogging(
     async (
       req: NextApiRequestWithContext,
-      res: NextApiResponse<WithAPIErrorResponse<T>>,
-      session: SessionWithUser
+      res: NextApiResponse<WithAPIErrorResponse<T>>
     ) => {
       const { wId } = req.query;
       if (typeof wId !== "string" || !wId) {
@@ -155,13 +158,72 @@ export function withSessionAuthenticationForWorkspace<T>(
         });
       }
 
-      const auth = await Authenticator.fromSession(session, wId);
+      // Try to get session from cookies first
+      const session = await getSession(req, res);
+      let auth: Authenticator;
+
+      if (session) {
+        // Use session-based authentication
+        auth = await Authenticator.fromSession(session, wId);
+      } else {
+        // Try bearer token authentication as fallback
+        const bearerTokenRes = await getBearerToken(req);
+        if (bearerTokenRes.isErr()) {
+          return apiError(req, res, {
+            status_code: 401,
+            api_error: {
+              type: "not_authenticated",
+              message:
+                "The user does not have an active session or is not authenticated.",
+            },
+          });
+        }
+
+        const token = bearerTokenRes.value;
+        if (!isOAuthToken(token)) {
+          return apiError(req, res, {
+            status_code: 401,
+            api_error: {
+              type: "not_authenticated",
+              message:
+                "The request does not have valid authentication credentials.",
+            },
+          });
+        }
+
+        try {
+          const authRes = await handleWorkOSAuth(req, res, token, wId);
+          if (authRes.isErr()) {
+            return apiError(req, res, authRes.error);
+          }
+          auth = authRes.value;
+        } catch (error) {
+          logger.error({ error }, "Failed to verify token");
+          return apiError(req, res, {
+            status_code: 401,
+            api_error: {
+              type: "invalid_oauth_token_error",
+              message:
+                "The request does not have valid authentication credentials.",
+            },
+          });
+        }
+      }
 
       const owner = auth.workspace();
       const plan = auth.plan();
 
       if (opts.allowMissingWorkspace && (!owner || !plan)) {
-        return handler(req, res, auth, session);
+        // When using bearer token, we don't have a session object, so we pass a minimal session
+        const minimalSession = session || {
+          type: "workos" as const,
+          sessionId: "",
+          user: {} as any,
+          region: owner?.region || "us",
+          isSSO: false,
+          authenticationMethod: "bearer_token",
+        };
+        return handler(req, res, auth, minimalSession);
       }
 
       if (!owner || !plan) {
@@ -214,7 +276,17 @@ export function withSessionAuthenticationForWorkspace<T>(
         });
       }
 
-      return handler(req, res, auth, session);
+      // When using bearer token, we don't have a session object, so we pass a minimal session
+      const minimalSession = session || {
+        type: "workos" as const,
+        sessionId: "",
+        user: {} as any,
+        region: owner.region,
+        isSSO: false,
+        authenticationMethod: "bearer_token",
+      };
+
+      return handler(req, res, auth, minimalSession);
     },
     opts
   );

--- a/front/lib/api/auth_wrappers.ts
+++ b/front/lib/api/auth_wrappers.ts
@@ -1,3 +1,4 @@
+import { config as multiRegionsConfig } from "@app/lib/api/regions/config";
 import { getUserWithWorkspaces } from "@app/lib/api/user";
 import { getUserFromWorkOSToken, verifyWorkOSToken } from "@app/lib/api/workos";
 import {
@@ -219,7 +220,7 @@ export function withSessionAuthenticationForWorkspace<T>(
           type: "workos" as const,
           sessionId: "",
           user: {} as any,
-          region: owner?.region || "us",
+          region: multiRegionsConfig.getCurrentRegion(),
           isSSO: false,
           authenticationMethod: "bearer_token",
         };
@@ -281,14 +282,14 @@ export function withSessionAuthenticationForWorkspace<T>(
         type: "workos" as const,
         sessionId: "",
         user: {} as any,
-        region: owner.region,
+        region: multiRegionsConfig.getCurrentRegion(),
         isSSO: false,
         authenticationMethod: "bearer_token",
       };
 
       return handler(req, res, auth, minimalSession);
     },
-    opts
+    opts.isStreaming
   );
 }
 

--- a/front/pages/api/w/[wId]/auth-context.ts
+++ b/front/pages/api/w/[wId]/auth-context.ts
@@ -1,7 +1,6 @@
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import { getWorkspaceRegionRedirect } from "@app/lib/api/regions/lookup";
 import type { Authenticator } from "@app/lib/auth";
-import type { SessionWithUser } from "@app/lib/iam/provider";
 import { isWorkspaceEligibleForTrial } from "@app/lib/plans/trial";
 import { apiError } from "@app/logger/withlogging";
 import type { WithAPIErrorResponse } from "@app/types/error";
@@ -24,8 +23,7 @@ async function handler(
   res: NextApiResponse<
     WithAPIErrorResponse<GetWorkspaceAuthContextResponseType>
   >,
-  auth: Authenticator,
-  _session: SessionWithUser | null
+  auth: Authenticator
 ): Promise<void> {
   if (req.method !== "GET") {
     return apiError(req, res, {

--- a/front/pages/api/w/[wId]/auth-context.ts
+++ b/front/pages/api/w/[wId]/auth-context.ts
@@ -25,7 +25,7 @@ async function handler(
     WithAPIErrorResponse<GetWorkspaceAuthContextResponseType>
   >,
   auth: Authenticator,
-  _session: SessionWithUser
+  _session: SessionWithUser | null
 ): Promise<void> {
   if (req.method !== "GET") {
     return apiError(req, res, {

--- a/front/pages/api/w/[wId]/oauth/[provider]/setup.ts
+++ b/front/pages/api/w/[wId]/oauth/[provider]/setup.ts
@@ -23,7 +23,7 @@ async function handler(
   req: NextApiRequest,
   res: NextApiResponse<WithAPIErrorResponse<GetOAuthSetupResponseBody>>,
   auth: Authenticator,
-  _session: SessionWithUser
+  _session: SessionWithUser | null
 ): Promise<void> {
   if (req.method !== "GET") {
     return apiError(req, res, {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/apps/[aId]/runs/index.ts
@@ -33,7 +33,7 @@ async function handler(
   >,
   auth: Authenticator,
   { space }: { space: SpaceResource },
-  session: SessionWithUser
+  session: SessionWithUser | null
 ) {
   const { aId } = req.query;
   if (typeof aId !== "string") {
@@ -178,7 +178,7 @@ async function handler(
       return;
 
     case "GET":
-      if (req.query.wIdTarget) {
+      if (req.query.wIdTarget && session) {
         // If we have a `wIdTarget` query parameter, we are fetching runs that were created with an
         // API key coming from another workspace. So we override the `owner` variable. This is only
         // available to dust super users.


### PR DESCRIPTION
## Description

Extends `withSessionAuthenticationForWorkspace` to support both cookie-based session authentication (existing) and OAuth bearer token authentication (new) for accessing private API routes. This enables the Chrome extension to authenticate with bearer tokens while the front continues using session cookies. 

When no session cookie is present, the wrapper attempts WorkOS bearer token authentication and creates a minimal session object to maintain API compatibility.

## Tests

Local app manually tested.

## Risk

Low. The change adds a fallback authentication method without modifying existing cookie-based session authentication flows. Routes that previously required session cookies now also accept bearer tokens.

## Deploy Plan

Deploy front
