### PR TITLE
feat: automatically select slack user for notifications

### DIFF
--- a/front/components/me/NotificationPreferences.tsx
+++ b/front/components/me/NotificationPreferences.tsx
@@ -85,7 +85,7 @@ export const NotificationPreferences = forwardRef<
   const {
     isSlackSetup,
     isSlackSetupLoading,
-    mutateIsSlackSetup,
+    isConfiguringSlack,
     setupSlackNotifications,
   } = useSetupSlackNotifications(owner.sId, {
     disabled: !hasSlackNotificationsFeature,
@@ -194,7 +194,7 @@ export const NotificationPreferences = forwardRef<
 
   // Load workflow-specific preferences from Novu
   useEffect(() => {
-    if (!novuClient || isSlackSetupLoading) {
+    if (!novuClient) {
       return;
     }
     setIsLoadingPreferences(true);
@@ -223,7 +223,7 @@ export const NotificationPreferences = forwardRef<
 
       setIsLoadingPreferences(false);
     });
-  }, [novuClient, isSlackSetupLoading]);
+  }, [novuClient]);
 
   // Expose methods to parent component
   useImperativeHandle(
@@ -476,7 +476,6 @@ export const NotificationPreferences = forwardRef<
   ) => {
     if (channel === "chat" && enabled && !isSlackSetup) {
       await setupSlackNotifications();
-      void mutateIsSlackSetup(() => ({ isConfigured: true }));
     }
     setConversationPreferences((prev) => {
       if (!prev) {
@@ -516,7 +515,7 @@ export const NotificationPreferences = forwardRef<
     });
   };
 
-  if (isLoadingPreferences) {
+  if (isLoadingPreferences || isSlackSetupLoading || isConfiguringSlack) {
     return <Spinner />;
   }
 

--- a/front/lib/notifications/index.ts
+++ b/front/lib/notifications/index.ts
@@ -93,3 +93,10 @@ export const getUserNotificationDelay = async ({
     ? metadataValue
     : DEFAULT_NOTIFICATION_DELAY;
 };
+
+export const getSlackConnectionIdentifier = (
+  userSId: string,
+  workspaceSId: string
+): string => {
+  return `slack_${userSId}_${workspaceSId}`;
+};

--- a/front/lib/swr/user.ts
+++ b/front/lib/swr/user.ts
@@ -284,30 +284,29 @@ export function useSetupSlackNotifications(
       setIsConfiguringSlack(false);
     };
 
+    const pollIntervalMs = 500;
     const interval = setInterval(async () => {
       if (openedWindow && openedWindow.closed) {
         clearInterval(interval);
         await completeSetup();
         completed = true;
       }
-    }, 500);
+    }, pollIntervalMs);
 
     // Cleanup after 5 minutes (safety timeout)
-    setTimeout(
-      () => {
-        clearInterval(interval);
-        if (!completed) {
-          sendNotification({
-            type: "error",
-            title: "Setup Timeout",
-            description: "Authentication window timed out.",
-          });
-          setIsConfiguringSlack(false);
-          completed = true;
-        }
-      },
-      5 * 60 * 1000
-    );
+    const setupTimeoutMs = 5 * 60 * 1000;
+    setTimeout(() => {
+      clearInterval(interval);
+      if (!completed) {
+        sendNotification({
+          type: "error",
+          title: "Setup Timeout",
+          description: "Authentication window timed out.",
+        });
+        setIsConfiguringSlack(false);
+        completed = true;
+      }
+    }, setupTimeoutMs);
   }, [workspaceId, sendNotification, mutateIsSlackSetup]);
 
   return {


### PR DESCRIPTION






## Description

This PR automates the Slack user selection process for notifications by automatically configuring the novu channel endpoint.

- Notifications will be received as private messages from the Dust Slack app.


https://github.com/user-attachments/assets/d049c429-0d76-488f-8153-428486474bb7



<img width="864" height="793" alt="Capture d’écran 2026-02-16 à 11 58 38" src="https://github.com/user-attachments/assets/0eccdf54-a4db-4cd2-9323-35a9fa5ecbb8" />


## Tests

Manually

## Risks
Low. Feature is hidden behind feature flag.

## Deploy Plan

Standard deployment. 