### PR TITLE
Disable user mentions in copilot

### DIFF
--- a/front/components/assistant/conversation/AgentInputBar.tsx
+++ b/front/components/assistant/conversation/AgentInputBar.tsx
@@ -362,6 +362,7 @@ export const AgentInputBar = ({
         conversation={context.conversation}
         draftKey={context.draftKey}
         disableAutoFocus={isMobile}
+        disableUserMentions={!!context.agentBuilderContext}
         actions={context.agentBuilderContext?.actionsToShow}
         isSubmitting={context.agentBuilderContext?.isSubmitting === true}
       />

--- a/front/components/assistant/conversation/input_bar/InputBar.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBar.tsx
@@ -52,6 +52,7 @@ interface InputBarProps {
   stickyMentions?: RichMention[];
   actions?: InputBarContainerProps["actions"];
   disableAutoFocus: boolean;
+  disableUserMentions?: boolean;
   isFloating?: boolean;
   isFloatingWithoutMargin?: boolean;
   isSubmitting?: boolean;
@@ -69,6 +70,7 @@ export const InputBar = React.memo(function InputBar({
   stickyMentions,
   actions = DEFAULT_INPUT_BAR_ACTIONS,
   disableAutoFocus = false,
+  disableUserMentions,
   isFloating = true,
   isSubmitting = false,
   disable = false,
@@ -365,6 +367,7 @@ export const InputBar = React.memo(function InputBar({
           <InputBarContainer
             actions={actions}
             disableAutoFocus={disableAutoFocus}
+            disableUserMentions={disableUserMentions}
             allAgents={activeAgents}
             owner={owner}
             conversation={conversation}

--- a/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
+++ b/front/components/assistant/conversation/input_bar/InputBarContainer.tsx
@@ -79,6 +79,7 @@ export interface InputBarContainerProps {
   space?: SpaceType;
   disableAutoFocus: boolean;
   disableInput: boolean;
+  disableUserMentions?: boolean;
   fileUploaderService: FileUploaderService;
   getDraft: () => { text: string } | null;
   isSubmitting: boolean;
@@ -108,6 +109,7 @@ const InputBarContainer = ({
   stickyMentions,
   actions,
   disableAutoFocus,
+  disableUserMentions,
   isSubmitting,
   disableInput,
   fileUploaderService,
@@ -293,6 +295,7 @@ const InputBarContainer = ({
   const { editor, editorService } = useCustomEditor({
     onEnterKeyDown,
     disableAutoFocus,
+    disableUserMentions,
     onUrlDetected: handleUrlDetected,
     owner,
     conversationId: conversation?.sId,

--- a/front/components/editor/input_bar/useCustomEditor.tsx
+++ b/front/components/editor/input_bar/useCustomEditor.tsx
@@ -169,6 +169,7 @@ export interface CustomEditorProps {
     setLoading: (loading: boolean) => void
   ) => void;
   disableAutoFocus: boolean;
+  disableUserMentions?: boolean;
   onUrlDetected?: (candidate: UrlCandidate | NodeCandidate | null) => void;
   owner: WorkspaceType;
   conversationId?: string | null;
@@ -187,12 +188,14 @@ export const buildEditorExtensions = ({
   owner,
   conversationId,
   spaceId,
+  disableUserMentions,
   onInlineText,
   onUrlDetected,
 }: {
   owner: WorkspaceType;
   conversationId?: string | null;
   spaceId?: string;
+  disableUserMentions?: boolean;
   onInlineText?: (fileId: string, textContent: string) => void;
   onUrlDetected?: (candidate: UrlCandidate | NodeCandidate | null) => void;
 }) => {
@@ -264,7 +267,7 @@ export const buildEditorExtensions = ({
         spaceId,
         select: {
           agents: true,
-          users: true,
+          users: !disableUserMentions,
         },
       }),
     }),
@@ -293,6 +296,7 @@ export const buildEditorExtensions = ({
 const useCustomEditor = ({
   onEnterKeyDown,
   disableAutoFocus,
+  disableUserMentions,
   onUrlDetected,
   owner,
   conversationId,
@@ -308,6 +312,7 @@ const useCustomEditor = ({
         owner,
         conversationId,
         spaceId,
+        disableUserMentions,
         onInlineText,
         onUrlDetected,
       }),


### PR DESCRIPTION
## Description

Currently users can be mentioned in the copilot conversation, which triggers an invite prompt to join the conversation. We don't want this, so disable user mentions functionality in Copilot. 

The fix is to flow a new `disableUserMentions` flag, which we set to false in the copilot case.

Fixes https://github.com/dust-tt/tasks/issues/6537

## Tests

Manual

## Risk

Low

## Deploy Plan

Front