### PR TITLE
[Conversations] Hide project butler conversations from project home list

### DIFF
--- a/front/components/assistant/conversation/space/conversations/SpaceConversationsTab.tsx
+++ b/front/components/assistant/conversation/space/conversations/SpaceConversationsTab.tsx
@@ -15,8 +15,8 @@ import { useFeatureFlags } from "@app/lib/swr/workspaces";
 import { getConversationRoute } from "@app/lib/utils/router";
 import type { GetSpaceResponseBody } from "@app/pages/api/w/[wId]/spaces/[spaceId]";
 import {
-  isUserMessageTypeWithContentFragments,
   type ConversationWithoutContentType,
+  isUserMessageTypeWithContentFragments,
   type LightConversationType,
 } from "@app/types/assistant/conversation";
 import type { RichMention } from "@app/types/assistant/mentions";


### PR DESCRIPTION
## Description
Follows https://github.com/dust-tt/dust/pull/21655.

Project butler conversations (origin `project_butler`) are system-generated and should not appear in the project home conversation list.

This PR filters those conversations out in `SpaceConversationsTab` before computing history, grouped list sections, and unread counts.

## Risks
Blast radius: project home conversation list rendering in space view
Risk: low

## Deploy Plan
- deploy front
