### PR TITLE
[Front] fix(copilot): prevent LLM from fabricating suggestion directives

### DIFF
--- a/front/components/agent_builder/CopilotPanelContext.tsx
+++ b/front/components/agent_builder/CopilotPanelContext.tsx
@@ -32,7 +32,7 @@ Create suggestions in your first response. Do not wait for the user to respond. 
 
 Tool usage: ${toolRules}
 
-Use \`suggest_*\` tools to create actionable suggestions. Brief explanation (3-4 sentences max). Always include their output verbatim in your response - it renders as interactive cards.
+Use \`suggest_*\` tools to create actionable suggestions. Brief explanation (3-4 sentences max). Each tool returns a markdown directive — include it verbatim in your response. NEVER write suggestion directives yourself; only use the exact output from completed tool calls.
 
 Balance context gathering and minimizing the number of tool calls - the first copilot message should be fast but helpful in driving builder actions.`;
 }

--- a/front/lib/api/assistant/global_agents/configurations/dust/copilot.ts
+++ b/front/lib/api/assistant/global_agents/configurations/dust/copilot.ts
@@ -398,6 +398,7 @@ When creating suggestions:
 4. On each new agent message, suggestions for the current agent are refreshed to reflect the latest data.
 
 5. NEVER output the \`:agent_suggestion[]{sId=... kind=...}\` directive for suggestions that are approved or rejected.
+6. NEVER fabricate suggestion directives yourself. Only include directives returned verbatim from completed \`suggest_*\` tool calls. Do NOT create placeholder or temporary directives with made-up sIds.
 
 </suggestion_creation_guidelines>`,
 


### PR DESCRIPTION
## Description

Prevent copilot from outputting placeholder suggestion directives with made-up sIds before `suggest_*` tool calls complete.

### Problem/Context

The copilot LLM was fabricating `:agent_suggestion[]{sId=temp_query_tables kind=tools}` directives in its response text before the actual `suggest_*` tools returned results, causing broken suggestion cards in the first copilot message.

Fixes: https://github.com/dust-tt/tasks/issues/6532

### Solution

- Added rule 6 to `suggestionCreation` instructions: explicitly forbid fabricating directives with made-up sIds
- Clarified `buildStep3` init message: replaced ambiguous "always include their output verbatim" with explicit "NEVER write suggestion directives yourself; only use the exact output from completed tool calls"

## Tests

- [ ] Manual testing: create a new agent from template, verify copilot no longer outputs placeholder directives

## Risk

**Scope:** Prompt-only change, no code logic affected.