### PR TITLE
[Agent Loop] Cap global nested run_agent invocations per message

### DIFF
--- a/front/lib/api/actions/servers/run_agent/index.ts
+++ b/front/lib/api/actions/servers/run_agent/index.ts
@@ -300,9 +300,7 @@ const runAgent = async (
       maxCount: MAX_RUN_AGENT_INVOCATIONS_PER_ROOT_MESSAGE,
     });
 
-    if (
-      runAgentInvocationCount >= MAX_RUN_AGENT_INVOCATIONS_PER_ROOT_MESSAGE
-    ) {
+    if (runAgentInvocationCount >= MAX_RUN_AGENT_INVOCATIONS_PER_ROOT_MESSAGE) {
       statsDClient.increment(RUN_AGENT_CAP_HIT_METRIC, 1, [
         `workspace:${workspace.sId}`,
       ]);

--- a/front/types/assistant/agent.ts
+++ b/front/types/assistant/agent.ts
@@ -194,6 +194,7 @@ export function isTemplateAgentConfiguration(
 
 export const MAX_STEPS_USE_PER_RUN_LIMIT = 64;
 export const MAX_ACTIONS_PER_STEP = 16;
+export const MAX_RUN_AGENT_INVOCATIONS_PER_ROOT_MESSAGE = 128;
 const MIN_ACTIONS_PER_STEP = 2;
 
 // Returns the max actions per step for a given conversation depth.


### PR DESCRIPTION
## Description
Fixes https://github.com/dust-tt/tasks/issues/6573.
Part of https://github.com/dust-tt/tasks/issues/6520.
Context: [slack thread](https://dust4ai.slack.com/archives/C05B529FHV1/p1770834673228379)

- Adds `MAX_RUN_AGENT_INVOCATIONS_PER_ROOT_MESSAGE = 128`.
- Enforces the cap in the `run_agent` server by resolving the root agent message and recursively counting nested `run_agent` invocations.
- When cap is reached, skips extra invocations with a non-error tool exit; logs and emits `use_tools_run_agent_cap_hit.count`.
- Keeps resume idempotent by skipping cap enforcement on `run_agent` resume state.

## Risks
Blast radius: `run_agent` tool execution path for nested agent-as-tool fan-out.
Risk: standard

## Deploy Plan
- deploy front
