### PR TITLE
[Front] chore(agents): auto-cleanup stale pending agent configurations

### DIFF
--- a/front/temporal/hard_delete/activities.test.ts
+++ b/front/temporal/hard_delete/activities.test.ts
@@ -1,0 +1,218 @@
+import { createPendingAgentConfiguration } from "@app/lib/api/assistant/configuration/agent";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
+import { GroupAgentModel } from "@app/lib/models/agent/group_agent";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import { purgeExpiredPendingAgentsActivity } from "@app/temporal/hard_delete/activities";
+import { PENDING_AGENTS_RETENTION_HOURS } from "@app/temporal/hard_delete/utils";
+import { AgentConfigurationFactory } from "@app/tests/utils/AgentConfigurationFactory";
+import { createResourceTest } from "@app/tests/utils/generic_resource_tests";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@temporalio/activity", () => ({
+  Context: {
+    current: vi.fn(() => ({
+      heartbeat: vi.fn(),
+      info: { attempt: 1 },
+      cancellationSignal: { aborted: false },
+    })),
+  },
+}));
+
+const PAST_THRESHOLD_MS = (PENDING_AGENTS_RETENTION_HOURS + 1) * 3600 * 1000;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+async function getEditorGroupId(
+  agentConfigurationId: number,
+  workspaceId: number
+): Promise<number> {
+  const groupAgent = await GroupAgentModel.findOne({
+    where: { agentConfigurationId, workspaceId },
+  });
+  expect(groupAgent).not.toBeNull();
+  return groupAgent!.groupId;
+}
+
+describe("purgeExpiredPendingAgentsActivity", () => {
+  it("deletes pending agents older than threshold with their editor groups", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+
+    const { sId } = await createPendingAgentConfiguration(authenticator);
+    const agent = await AgentConfigurationModel.findOne({
+      where: { sId, workspaceId: workspace.id },
+    });
+    const editorGroupId = await getEditorGroupId(agent!.id, workspace.id);
+
+    // Advance time past the retention threshold.
+    vi.advanceTimersByTime(PAST_THRESHOLD_MS);
+
+    await purgeExpiredPendingAgentsActivity();
+
+    // Agent should be deleted.
+    const agentAfter = await AgentConfigurationModel.findOne({
+      where: { sId, workspaceId: workspace.id },
+    });
+    expect(agentAfter).toBeNull();
+
+    // Editor group should be deleted too.
+    const groupsAfter = await GroupResource.fetchByModelIds(authenticator, [
+      editorGroupId,
+    ]);
+    expect(groupsAfter).toHaveLength(0);
+  });
+
+  it("does not delete pending agents younger than threshold", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+
+    const { sId } = await createPendingAgentConfiguration(authenticator);
+    const agent = await AgentConfigurationModel.findOne({
+      where: { sId, workspaceId: workspace.id },
+    });
+    const editorGroupId = await getEditorGroupId(agent!.id, workspace.id);
+
+    await purgeExpiredPendingAgentsActivity();
+
+    // Agent should survive.
+    const agentAfter = await AgentConfigurationModel.findOne({
+      where: { sId, workspaceId: workspace.id },
+    });
+    expect(agentAfter).not.toBeNull();
+    expect(agentAfter!.status).toBe("pending");
+
+    // Editor group should survive too.
+    const groupsAfter = await GroupResource.fetchByModelIds(authenticator, [
+      editorGroupId,
+    ]);
+    expect(groupsAfter).toHaveLength(1);
+  });
+
+  it("deletes all expired agents across multiple batches", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+
+    const sIds: string[] = [];
+    for (let i = 0; i < 3; i++) {
+      const { sId } = await createPendingAgentConfiguration(authenticator);
+      sIds.push(sId);
+    }
+
+    // Advance time past the retention threshold.
+    vi.advanceTimersByTime(PAST_THRESHOLD_MS);
+
+    // Use batchSize=1 to force multiple pagination loops.
+    await purgeExpiredPendingAgentsActivity(1);
+
+    const remaining = await AgentConfigurationModel.findAll({
+      where: { sId: sIds, workspaceId: workspace.id },
+    });
+    expect(remaining).toHaveLength(0);
+  });
+
+  it("does not delete active agents or their groups", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+
+    const agentConfig = await AgentConfigurationFactory.createTestAgent(
+      authenticator,
+      { name: "Active Agent" }
+    );
+    const editorGroupId = await getEditorGroupId(agentConfig.id, workspace.id);
+
+    // Advance time past the retention threshold.
+    vi.advanceTimersByTime(PAST_THRESHOLD_MS);
+
+    await purgeExpiredPendingAgentsActivity();
+
+    // Active agent should survive.
+    const agents = await AgentConfigurationModel.findAll({
+      where: { name: "Active Agent", workspaceId: workspace.id },
+    });
+    expect(agents).toHaveLength(1);
+    expect(agents[0].status).toBe("active");
+
+    // Its editor group should survive too.
+    const groupsAfter = await GroupResource.fetchByModelIds(authenticator, [
+      editorGroupId,
+    ]);
+    expect(groupsAfter).toHaveLength(1);
+  });
+
+  it("only deletes expired pending agents, leaves fresh pending and active intact", async () => {
+    const { authenticator, workspace } = await createResourceTest({
+      role: "admin",
+    });
+
+    // Create a pending agent that will expire.
+    const { sId: expiredSId } =
+      await createPendingAgentConfiguration(authenticator);
+    const expiredAgent = await AgentConfigurationModel.findOne({
+      where: { sId: expiredSId, workspaceId: workspace.id },
+    });
+    const expiredGroupId = await getEditorGroupId(
+      expiredAgent!.id,
+      workspace.id
+    );
+
+    // Advance time past the threshold.
+    vi.advanceTimersByTime(PAST_THRESHOLD_MS);
+
+    // Create a fresh pending agent (after time advance, so it's young).
+    const { sId: freshSId } =
+      await createPendingAgentConfiguration(authenticator);
+    const freshAgent = await AgentConfigurationModel.findOne({
+      where: { sId: freshSId, workspaceId: workspace.id },
+    });
+    const freshGroupId = await getEditorGroupId(freshAgent!.id, workspace.id);
+
+    // Create an active agent.
+    const activeAgent = await AgentConfigurationFactory.createTestAgent(
+      authenticator,
+      { name: "Survivor" }
+    );
+    const activeGroupId = await getEditorGroupId(activeAgent.id, workspace.id);
+
+    await purgeExpiredPendingAgentsActivity();
+
+    // Expired pending agent + group: deleted.
+    expect(
+      await AgentConfigurationModel.findOne({
+        where: { sId: expiredSId, workspaceId: workspace.id },
+      })
+    ).toBeNull();
+    expect(
+      await GroupResource.fetchByModelIds(authenticator, [expiredGroupId])
+    ).toHaveLength(0);
+
+    // Fresh pending agent + group: survived.
+    const freshAfter = await AgentConfigurationModel.findOne({
+      where: { sId: freshSId, workspaceId: workspace.id },
+    });
+    expect(freshAfter).not.toBeNull();
+    expect(freshAfter!.status).toBe("pending");
+    expect(
+      await GroupResource.fetchByModelIds(authenticator, [freshGroupId])
+    ).toHaveLength(1);
+
+    // Active agent + group: survived.
+    expect(
+      await AgentConfigurationModel.findAll({
+        where: { name: "Survivor", workspaceId: workspace.id },
+      })
+    ).toHaveLength(1);
+    expect(
+      await GroupResource.fetchByModelIds(authenticator, [activeGroupId])
+    ).toHaveLength(1);
+  });
+});

--- a/front/temporal/hard_delete/activities.ts
+++ b/front/temporal/hard_delete/activities.ts
@@ -1,17 +1,23 @@
 // biome-ignore-all lint/plugin/noRawSql: hard delete activities require raw SQL for cascade deletions
+import { Authenticator } from "@app/lib/auth";
+import { AgentConfigurationModel } from "@app/lib/models/agent/agent";
 import { getCorePrimaryDbConnection } from "@app/lib/production_checks/utils";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import { WorkspaceResource } from "@app/lib/resources/workspace_resource";
+import { withTransaction } from "@app/lib/utils/sql_utils";
 import logger from "@app/logger/logger";
 import type {
   RunExecutionRow,
   RunsJoinsRow,
 } from "@app/temporal/hard_delete/types";
 import {
+  getPendingAgentsDeletionCutoffDate,
   getRunExecutionsDeletionCutoffDate,
   isSequelizeForeignKeyConstraintError,
 } from "@app/temporal/hard_delete/utils";
 import { Context } from "@temporalio/activity";
 import type { Sequelize } from "sequelize";
-import { QueryTypes } from "sequelize";
+import { Op, QueryTypes } from "sequelize";
 
 const BATCH_SIZE = 100;
 
@@ -121,4 +127,63 @@ async function deleteRunExecutionBatch(
       runIds,
     },
   });
+}
+
+export async function purgeExpiredPendingAgentsActivity(
+  batchSize: number = BATCH_SIZE
+) {
+  const cutoffDate = getPendingAgentsDeletionCutoffDate();
+
+  logger.info(
+    {},
+    `About to purge pending agents created before ${cutoffDate.toISOString()}.`
+  );
+
+  const workspaces = await WorkspaceResource.listAll();
+
+  let totalDeleted = 0;
+
+  for (const workspace of workspaces) {
+    const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+
+    let hasMore = true;
+    do {
+      const batch = await AgentConfigurationModel.findAll({
+        where: {
+          status: "pending",
+          createdAt: { [Op.lt]: cutoffDate },
+          workspaceId: workspace.id,
+        },
+        limit: batchSize,
+        order: [["createdAt", "ASC"]],
+      });
+
+      hasMore = batch.length === batchSize;
+
+      for (const agent of batch) {
+        await withTransaction(async (t) => {
+          const group = await GroupResource.fetchByAgentConfiguration({
+            auth,
+            agentConfiguration: agent,
+            isDeletionFlow: true,
+          });
+
+          if (group) {
+            await group.delete(auth, { transaction: t });
+          }
+
+          await agent.destroy({ transaction: t });
+        });
+
+        totalDeleted++;
+      }
+
+      Context.current().heartbeat();
+    } while (hasMore);
+  }
+
+  logger.info(
+    { totalDeleted },
+    "Done purging expired pending agent configurations."
+  );
 }

--- a/front/temporal/hard_delete/client.ts
+++ b/front/temporal/hard_delete/client.ts
@@ -1,7 +1,7 @@
 import { getTemporalClientForFrontNamespace } from "@app/lib/temporal";
 import logger from "@app/logger/logger";
-import { getPurgeRunExecutionsScheduleId } from "@app/temporal/hard_delete/utils";
-import { purgeRunExecutionsCronWorkflow } from "@app/temporal/hard_delete/workflows";
+import { getHardDeleteScheduleId } from "@app/temporal/hard_delete/utils";
+import { hardDeleteCronWorkflow } from "@app/temporal/hard_delete/workflows";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";
 import { normalizeError } from "@app/types/shared/utils/error_utils";
@@ -13,19 +13,19 @@ import {
 import { QUEUE_NAME } from "./config";
 
 /**
- * This function starts a schedule to purge expired run executions.
+ * This function starts the hard delete schedule.
  */
-export async function launchPurgeRunExecutionsSchedule(): Promise<
+export async function launchHardDeleteSchedule(): Promise<
   Result<undefined, Error>
 > {
   const client = await getTemporalClientForFrontNamespace();
-  const scheduleId = getPurgeRunExecutionsScheduleId();
+  const scheduleId = getHardDeleteScheduleId();
 
   try {
     await client.schedule.create({
       action: {
         type: "startWorkflow",
-        workflowType: purgeRunExecutionsCronWorkflow,
+        workflowType: hardDeleteCronWorkflow,
         args: [],
         taskQueue: QUEUE_NAME,
       },
@@ -39,7 +39,7 @@ export async function launchPurgeRunExecutionsSchedule(): Promise<
     });
   } catch (err) {
     if (!(err instanceof ScheduleAlreadyRunning)) {
-      logger.error({}, "Failed to start purge run executions.");
+      logger.error({}, "Failed to start hard delete schedule.");
 
       return new Err(normalizeError(err));
     }

--- a/front/temporal/hard_delete/utils.ts
+++ b/front/temporal/hard_delete/utils.ts
@@ -27,7 +27,7 @@ export function getRunExecutionsDeletionCutoffDate(): number {
  * Purge pending agents logic.
  */
 
-export const PENDING_AGENTS_RETENTION_HOURS = 24;
+export const PENDING_AGENTS_RETENTION_HOURS = 72;
 
 export function getPendingAgentsDeletionCutoffDate(): Date {
   const cutoffDate = new Date();

--- a/front/temporal/hard_delete/utils.ts
+++ b/front/temporal/hard_delete/utils.ts
@@ -22,3 +22,16 @@ export function getRunExecutionsDeletionCutoffDate(): number {
 
   return cutoffDate.getTime();
 }
+
+/**
+ * Purge pending agents logic.
+ */
+
+export const PENDING_AGENTS_RETENTION_HOURS = 24;
+
+export function getPendingAgentsDeletionCutoffDate(): Date {
+  const cutoffDate = new Date();
+  cutoffDate.setHours(cutoffDate.getHours() - PENDING_AGENTS_RETENTION_HOURS);
+
+  return cutoffDate;
+}

--- a/front/temporal/hard_delete/utils.ts
+++ b/front/temporal/hard_delete/utils.ts
@@ -8,7 +8,7 @@ export function isSequelizeForeignKeyConstraintError(err: unknown) {
  * Purge run executions logic.
  */
 
-export function getPurgeRunExecutionsScheduleId() {
+export function getHardDeleteScheduleId() {
   return "purge-run-executions-schedule";
 }
 

--- a/front/temporal/hard_delete/worker.ts
+++ b/front/temporal/hard_delete/worker.ts
@@ -6,7 +6,7 @@ import { ActivityInboundLogInterceptor } from "@app/lib/temporal_monitoring";
 import logger from "@app/logger/logger";
 import { getWorkflowConfig } from "@app/temporal/bundle_helper";
 import * as activities from "@app/temporal/hard_delete/activities";
-import { launchPurgeRunExecutionsSchedule } from "@app/temporal/hard_delete/client";
+import { launchHardDeleteSchedule } from "@app/temporal/hard_delete/client";
 import type { Context } from "@temporalio/activity";
 import { Worker } from "@temporalio/worker";
 
@@ -35,7 +35,7 @@ export async function runHardDeleteWorker() {
   });
 
   // Start the schedule.
-  await launchPurgeRunExecutionsSchedule();
+  await launchHardDeleteSchedule();
 
   await worker.run();
 }

--- a/front/temporal/hard_delete/workflows.ts
+++ b/front/temporal/hard_delete/workflows.ts
@@ -7,7 +7,7 @@ const { purgeExpiredRunExecutionsActivity, purgeExpiredPendingAgentsActivity } =
     startToCloseTimeout: "60 minutes",
   });
 
-export async function purgeRunExecutionsCronWorkflow(): Promise<void> {
+export async function hardDeleteCronWorkflow(): Promise<void> {
   await purgeExpiredRunExecutionsActivity();
   await purgeExpiredPendingAgentsActivity();
 }

--- a/front/temporal/hard_delete/workflows.ts
+++ b/front/temporal/hard_delete/workflows.ts
@@ -2,12 +2,12 @@ import type * as activities from "@app/temporal/hard_delete/activities";
 import { proxyActivities } from "@temporalio/workflow";
 
 // TODO(2024-06-13 flav) Lower `startToCloseTimeout` to 10 minutes.
-const { purgeExpiredRunExecutionsActivity } = proxyActivities<
-  typeof activities
->({
-  startToCloseTimeout: "60 minutes",
-});
+const { purgeExpiredRunExecutionsActivity, purgeExpiredPendingAgentsActivity } =
+  proxyActivities<typeof activities>({
+    startToCloseTimeout: "60 minutes",
+  });
 
 export async function purgeRunExecutionsCronWorkflow(): Promise<void> {
   await purgeExpiredRunExecutionsActivity();
+  await purgeExpiredPendingAgentsActivity();
 }


### PR DESCRIPTION
## Description

Pending agent configurations are created when the agent builder opens but accumulate forever if the user never saves. This adds a cleanup activity to the existing `hard_delete` temporal cron that deletes pending agents older than 3 days along with their `agent_editors` groups.

### Solution

- Added `purgeExpiredPendingAgentsActivity` to the hard_delete workflow
- Iterates all workspaces, queries `AgentConfigurationModel` for stale pending agents (>3 days)
- Batch-deletes editor groups (memberships, group_agents, groups) and agents in a single transaction per batch — avoids N+1 queries
- Renamed workflow/schedule functions to reflect the broader `hard_delete` scope (schedule ID string unchanged)

### Related Work

- Closes: https://github.com/dust-tt/tasks/issues/6059

## Tests

- **Unit tests** (`activities.test.ts`): 5 test cases covering:
  - Expired pending agent + editor group deleted
  - Young pending agent + group preserved
  - Active agent + group preserved
  - Pagination across multiple batches (batchSize=1)
  - Mixed scenario: only expired pending deleted, fresh pending + active intact with their groups