### PR TITLE
Reduce auth DB pool pressure by deduplicating queries

### DIFF
--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -201,7 +201,7 @@ export class Authenticator {
       GroupResource.listUserGroupModelIdsInWorkspace({
         user,
         workspace: lightWorkspace,
-        dangerousSkipMembershipCheck: true,
+        dangerouslySkipMembershipCheck: true,
       }),
       SubscriptionResource.fetchActiveByWorkspace(lightWorkspace),
     ]);
@@ -681,7 +681,7 @@ export class Authenticator {
       user,
       workspace: renderLightWorkspaceType({ workspace: owner }),
       // Membership already verified above (activeMembership found).
-      dangerousSkipMembershipCheck: true,
+      dangerouslySkipMembershipCheck: true,
     });
 
     return new Authenticator({

--- a/front/lib/auth.ts
+++ b/front/lib/auth.ts
@@ -175,6 +175,45 @@ export class Authenticator {
   }
 
   /**
+   * Fetches role, group memberships, and subscription for a user in a workspace.
+   * Runs all three queries in parallel. If the user is not a member (role is
+   * "none"), groups are reset to [] to prevent non-members from getting access
+   * via the global group.
+   */
+  private static async fetchRoleGroupsAndSubscription({
+    user,
+    workspace,
+  }: {
+    user: UserResource;
+    workspace: WorkspaceResource;
+  }): Promise<{
+    role: RoleType;
+    groupModelIds: ModelId[];
+    subscription: SubscriptionResource | null;
+  }> {
+    const lightWorkspace = renderLightWorkspaceType({ workspace });
+
+    const [role, groupModelIds, subscription] = await Promise.all([
+      MembershipResource.getActiveRoleForUserInWorkspace({
+        user,
+        workspace: lightWorkspace,
+      }),
+      GroupResource.listUserGroupModelIdsInWorkspace({
+        user,
+        workspace: lightWorkspace,
+        dangerousSkipMembershipCheck: true,
+      }),
+      SubscriptionResource.fetchActiveByWorkspace(lightWorkspace),
+    ]);
+
+    return {
+      role,
+      groupModelIds: role === "none" ? [] : groupModelIds,
+      subscription,
+    };
+  }
+
+  /**
    * Get an Authenticator for the target workspace associated with the authentified user from the
    * workos session.
    *
@@ -197,19 +236,13 @@ export class Authenticator {
       let subscription: SubscriptionResource | null = null;
 
       if (user && workspace) {
-        [role, groupModelIds, subscription] = await Promise.all([
-          MembershipResource.getActiveRoleForUserInWorkspace({
-            user,
-            workspace: renderLightWorkspaceType({ workspace }),
-          }),
-          GroupResource.listUserGroupModelIdsInWorkspace({
-            user,
-            workspace: renderLightWorkspaceType({ workspace }),
-          }),
-          SubscriptionResource.fetchActiveByWorkspace(
-            renderLightWorkspaceType({ workspace })
-          ),
-        ]);
+        const authData = await this.fetchRoleGroupsAndSubscription({
+          user,
+          workspace,
+        });
+        role = authData.role;
+        groupModelIds = authData.groupModelIds;
+        subscription = authData.subscription;
       }
 
       return new Authenticator({
@@ -301,19 +334,13 @@ export class Authenticator {
     let subscription: SubscriptionResource | null = null;
 
     if (user && workspace) {
-      [role, groupModelIds, subscription] = await Promise.all([
-        MembershipResource.getActiveRoleForUserInWorkspace({
-          user,
-          workspace: renderLightWorkspaceType({ workspace }),
-        }),
-        GroupResource.listUserGroupModelIdsInWorkspace({
-          user,
-          workspace: renderLightWorkspaceType({ workspace }),
-        }),
-        SubscriptionResource.fetchActiveByWorkspace(
-          renderLightWorkspaceType({ workspace })
-        ),
-      ]);
+      const authData = await this.fetchRoleGroupsAndSubscription({
+        user,
+        workspace,
+      });
+      role = authData.role;
+      groupModelIds = authData.groupModelIds;
+      subscription = authData.subscription;
     }
 
     return new Authenticator({
@@ -338,42 +365,31 @@ export class Authenticator {
       { code: "user_not_found" | "workspace_not_found" | "sso_enforced" }
     >
   > {
-    const user = await UserResource.fetchByWorkOSUserId(token.sub);
+    const [user, workspace] = await Promise.all([
+      UserResource.fetchByWorkOSUserId(token.sub),
+      WorkspaceResource.fetchById(wId),
+    ]);
+
     if (!user) {
       return new Err({ code: "user_not_found" });
     }
-
-    const workspace = await WorkspaceResource.fetchById(wId);
     if (!workspace) {
       return new Err({ code: "workspace_not_found" });
     }
 
-    let role = "none" as RoleType;
-    let groupModelIds: ModelId[] = [];
-    let subscription: SubscriptionResource | null = null;
-
-    [role, groupModelIds, subscription] = await Promise.all([
-      MembershipResource.getActiveRoleForUserInWorkspace({
-        user: user,
-        workspace: renderLightWorkspaceType({ workspace }),
-      }),
-      GroupResource.listUserGroupModelIdsInWorkspace({
-        user,
-        workspace: renderLightWorkspaceType({ workspace }),
-      }),
-      SubscriptionResource.fetchActiveByWorkspace(
-        renderLightWorkspaceType({ workspace })
-      ),
-    ]);
+    const authData = await this.fetchRoleGroupsAndSubscription({
+      user,
+      workspace,
+    });
 
     return new Ok(
       new Authenticator({
         authMethod: "oauth",
         workspace,
-        groupModelIds,
+        groupModelIds: authData.groupModelIds,
         user,
-        role,
-        subscription,
+        role: authData.role,
+        subscription: authData.subscription,
       })
     );
   }
@@ -400,12 +416,8 @@ export class Authenticator {
     keyAuth: Authenticator;
   }> {
     const [workspace, keyWorkspace] = await Promise.all([
-      (async () => {
-        return WorkspaceResource.fetchById(wId);
-      })(),
-      (async () => {
-        return WorkspaceResource.fetchByModelId(key.workspaceId);
-      })(),
+      WorkspaceResource.fetchById(wId),
+      WorkspaceResource.fetchByModelId(key.workspaceId),
     ]);
 
     if (!keyWorkspace) {
@@ -424,35 +436,44 @@ export class Authenticator {
       }
     }
 
-    const getSubscriptionForWorkspace = (workspace: WorkspaceResource) =>
-      SubscriptionResource.fetchActiveByWorkspace(
-        renderLightWorkspaceType({ workspace })
-      );
-
     let keyGroups: GroupResource[] = [];
     let requestedGroups: GroupResource[] = [];
     let workspaceSubscription: SubscriptionResource | null = null;
     let keySubscription: SubscriptionResource | null = null;
 
     if (workspace) {
+      const lightWorkspace = renderLightWorkspaceType({ workspace });
+      const lightKeyWorkspace = renderLightWorkspaceType({
+        workspace: keyWorkspace,
+      });
       if (requestedGroupIds && key.isSystem) {
         [requestedGroups, keySubscription, workspaceSubscription] =
           await Promise.all([
-            // Key related attributes.
             GroupResource.listGroupsWithSystemKey(key, requestedGroupIds),
-            getSubscriptionForWorkspace(keyWorkspace),
-            // Workspace related attributes.
-            getSubscriptionForWorkspace(workspace),
+            SubscriptionResource.fetchActiveByWorkspace(lightKeyWorkspace),
+            // We need to fetch the subscription separately as requested groups
+            // might not include the global group which is used to fetch the
+            // subscription in fetchRoleGroupsAndSubscription.
+            isKeyWorkspace
+              ? null
+              : SubscriptionResource.fetchActiveByWorkspace(lightWorkspace),
           ]);
       } else {
         [keyGroups, keySubscription, workspaceSubscription] = await Promise.all(
           [
             GroupResource.listWorkspaceGroupsFromKey(key),
-            getSubscriptionForWorkspace(keyWorkspace),
-            // Workspace related attributes.
-            getSubscriptionForWorkspace(workspace),
+            SubscriptionResource.fetchActiveByWorkspace(lightKeyWorkspace),
+            isKeyWorkspace
+              ? null
+              : SubscriptionResource.fetchActiveByWorkspace(lightWorkspace),
           ]
         );
+      }
+
+      // When the key workspace is the target workspace, both subscriptions
+      // are identical - reuse the one we already fetched.
+      if (isKeyWorkspace) {
+        workspaceSubscription = keySubscription;
       }
     }
     const allGroups = requestedGroupIds ? requestedGroups : keyGroups;
@@ -659,6 +680,8 @@ export class Authenticator {
     const groupModelIds = await GroupResource.listUserGroupModelIdsInWorkspace({
       user,
       workspace: renderLightWorkspaceType({ workspace: owner }),
+      // Membership already verified above (activeMembership found).
+      dangerousSkipMembershipCheck: true,
     });
 
     return new Authenticator({

--- a/front/lib/resources/group_resource.test.ts
+++ b/front/lib/resources/group_resource.test.ts
@@ -1,0 +1,98 @@
+import { Authenticator } from "@app/lib/auth";
+import { GroupResource } from "@app/lib/resources/group_resource";
+import { GroupModel } from "@app/lib/resources/storage/models/groups";
+import type { UserResource } from "@app/lib/resources/user_resource";
+import { MembershipFactory } from "@app/tests/utils/MembershipFactory";
+import { UserFactory } from "@app/tests/utils/UserFactory";
+import { WorkspaceFactory } from "@app/tests/utils/WorkspaceFactory";
+import type { WorkspaceType } from "@app/types/user";
+import { beforeEach, describe, expect, it } from "vitest";
+
+describe("GroupResource", () => {
+  describe("listUserGroupModelIdsInWorkspace", () => {
+    let workspace: WorkspaceType;
+    let member: UserResource;
+
+    beforeEach(async () => {
+      workspace = await WorkspaceFactory.basic();
+      member = await UserFactory.basic();
+      await MembershipFactory.associate(workspace, member, { role: "user" });
+    });
+
+    it("returns global group and explicit groups for a workspace member", async () => {
+      const regularGroup = await GroupResource.makeNew({
+        name: "Test Group",
+        workspaceId: workspace.id,
+        kind: "regular",
+      });
+      const auth = await Authenticator.internalAdminForWorkspace(workspace.sId);
+      await regularGroup.dangerouslyAddMembers(auth, {
+        users: [member.toJSON()],
+      });
+
+      const groupIds = await GroupResource.listUserGroupModelIdsInWorkspace({
+        user: member,
+        workspace,
+      });
+
+      expect(groupIds.length).toBe(2);
+
+      const globalGroup = await GroupModel.findOne({
+        where: { workspaceId: workspace.id, kind: "global" },
+      });
+      expect(globalGroup).not.toBeNull();
+      expect(groupIds).toContain(globalGroup!.id);
+      expect(groupIds).toContain(regularGroup.id);
+    });
+
+    it("returns empty array for non-member", async () => {
+      const nonMember = await UserFactory.basic();
+
+      const groupIds = await GroupResource.listUserGroupModelIdsInWorkspace({
+        user: nonMember,
+        workspace,
+      });
+
+      expect(groupIds).toEqual([]);
+    });
+
+    it("returns groups for non-member when dangerouslySkipMembershipCheck is true", async () => {
+      const nonMember = await UserFactory.basic();
+
+      const groupIds = await GroupResource.listUserGroupModelIdsInWorkspace({
+        user: nonMember,
+        workspace,
+        dangerouslySkipMembershipCheck: true,
+      });
+
+      // Should still return the global group even though the user is not a member.
+      expect(groupIds.length).toBeGreaterThanOrEqual(1);
+      const globalGroup = await GroupModel.findOne({
+        where: { workspaceId: workspace.id, kind: "global" },
+      });
+      expect(groupIds).toContain(globalGroup!.id);
+    });
+
+    it("throws when global group is missing regardless of skip flag", async () => {
+      // Delete the global group to simulate a data integrity issue.
+      await GroupModel.destroy({
+        where: { workspaceId: workspace.id, kind: "global" },
+      });
+
+      await expect(
+        GroupResource.listUserGroupModelIdsInWorkspace({
+          user: member,
+          workspace,
+        })
+      ).rejects.toThrow("Global group not found.");
+
+      await expect(
+        GroupResource.listUserGroupModelIdsInWorkspace({
+          user: member,
+          workspace,
+          dangerouslySkipMembershipCheck: true,
+        })
+      ).rejects.toThrow("Global group not found.");
+    });
+  });
+});

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -820,62 +820,57 @@ export class GroupResource extends BaseResource<GroupModel> {
     user,
     workspace,
     groupKinds = GROUP_KINDS.filter((k) => k !== "system"),
+    dangerousSkipMembershipCheck = false,
     transaction,
   }: {
     user: UserResource;
     workspace: LightWorkspaceType;
     groupKinds?: Omit<GroupKind, "system">[];
+    // When true, skips the membership check. Only use this from
+    // Authenticator.fetchRoleGroupsAndSubscription (which handles
+    // the role === "none" safety reset) or when membership has been
+    // independently verified (e.g. fromKey).
+    dangerousSkipMembershipCheck?: boolean;
     transaction?: Transaction;
   }): Promise<ModelId[]> {
-    // First we need to check if the user is a member of the workspace.
-    const workspaceMembership =
-      await MembershipResource.getActiveMembershipOfUserInWorkspace({
-        user,
-        workspace,
-        transaction,
-      });
-    if (!workspaceMembership) {
-      return [];
-    }
-
-    // If yes, we can fetch the groups the user is a member of.
-    // First the global group which has no db entries and is always present.
-    let globalGroup: GroupModel | null = null;
-
-    if (groupKinds.includes("global")) {
-      globalGroup = await this.model.findOne({
-        attributes: ["id"],
-        where: {
-          workspaceId: workspace.id,
-          kind: "global",
-        },
-        transaction,
-      });
-
-      if (!globalGroup) {
-        throw new Error("Global group not found.");
+    if (!dangerousSkipMembershipCheck) {
+      const workspaceMembership =
+        await MembershipResource.getActiveMembershipOfUserInWorkspace({
+          user,
+          workspace,
+          transaction,
+        });
+      if (!workspaceMembership) {
+        return [];
       }
     }
 
-    // eslint-disable-next-line dust/no-raw-sql -- We are using a raw query to optimize memory usage as people may have a lot of groups.
-    const userGroupModelIds = await frontSequelize.query<{ id: ModelId }>(
+    const includeGlobal = groupKinds.includes("global");
+
+    // Single query to fetch both the global group (implicit membership for all workspace members)
+    // and groups the user explicitly belongs to via group_memberships.
+    // eslint-disable-next-line dust/no-raw-sql -- Raw query to optimize memory usage as people may have a lot of groups.
+    const groups = await frontSequelize.query<{ id: ModelId; kind: string }>(
       `
-      SELECT id FROM groups
+      SELECT id, kind FROM groups
       WHERE "workspaceId" = :workspaceId
-      AND kind IN (:kind)
-      AND id IN (
-        SELECT "groupId" FROM group_memberships
-        WHERE "userId" = :userId
-        AND "workspaceId" = :workspaceId
-        AND "startAt" <= :now
-        AND ("endAt" IS NULL OR "endAt" > :now)
-        AND status = 'active'
+      AND kind IN (:groupKinds)
+      AND (
+        kind = 'global'
+        OR id IN (
+          SELECT "groupId" FROM group_memberships
+          WHERE "userId" = :userId
+          AND "workspaceId" = :workspaceId
+          AND "startAt" <= :now
+          AND ("endAt" IS NULL OR "endAt" > :now)
+          AND status = 'active'
+        )
       )
     `,
       {
         replacements: {
           workspaceId: workspace.id,
-          kind: groupKinds.filter((k) => k !== "global") as GroupKind[],
+          groupKinds,
           userId: user.id,
           now: new Date(),
         },
@@ -885,10 +880,16 @@ export class GroupResource extends BaseResource<GroupModel> {
       }
     );
 
-    const groups = [
-      ...(globalGroup ? [globalGroup] : []),
-      ...userGroupModelIds,
-    ];
+    // Only validate global group presence when membership was verified by this
+    // method. When skipped, the caller handles the non-member case (e.g.
+    // fetchRoleGroupsAndSubscription discards groups when role is "none").
+    if (
+      !dangerousSkipMembershipCheck &&
+      includeGlobal &&
+      !groups.some((g) => g.kind === "global")
+    ) {
+      throw new Error("Global group not found.");
+    }
 
     return groups.map((group) => group.id);
   }

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -880,14 +880,7 @@ export class GroupResource extends BaseResource<GroupModel> {
       }
     );
 
-    // Only validate global group presence when membership was verified by this
-    // method. When skipped, the caller handles the non-member case (e.g.
-    // fetchRoleGroupsAndSubscription discards groups when role is "none").
-    if (
-      !dangerouslySkipMembershipCheck &&
-      includeGlobal &&
-      !groups.some((g) => g.kind === "global")
-    ) {
+    if (includeGlobal && !groups.some((g) => g.kind === "global")) {
       throw new Error("Global group not found.");
     }
 

--- a/front/lib/resources/group_resource.ts
+++ b/front/lib/resources/group_resource.ts
@@ -820,7 +820,7 @@ export class GroupResource extends BaseResource<GroupModel> {
     user,
     workspace,
     groupKinds = GROUP_KINDS.filter((k) => k !== "system"),
-    dangerousSkipMembershipCheck = false,
+    dangerouslySkipMembershipCheck = false,
     transaction,
   }: {
     user: UserResource;
@@ -830,10 +830,10 @@ export class GroupResource extends BaseResource<GroupModel> {
     // Authenticator.fetchRoleGroupsAndSubscription (which handles
     // the role === "none" safety reset) or when membership has been
     // independently verified (e.g. fromKey).
-    dangerousSkipMembershipCheck?: boolean;
+    dangerouslySkipMembershipCheck?: boolean;
     transaction?: Transaction;
   }): Promise<ModelId[]> {
-    if (!dangerousSkipMembershipCheck) {
+    if (!dangerouslySkipMembershipCheck) {
       const workspaceMembership =
         await MembershipResource.getActiveMembershipOfUserInWorkspace({
           user,
@@ -884,7 +884,7 @@ export class GroupResource extends BaseResource<GroupModel> {
     // method. When skipped, the caller handles the non-member case (e.g.
     // fetchRoleGroupsAndSubscription discards groups when role is "none").
     if (
-      !dangerousSkipMembershipCheck &&
+      !dangerouslySkipMembershipCheck &&
       includeGlobal &&
       !groups.some((g) => g.kind === "global")
     ) {

--- a/front/tests/utils/WorkspaceFactory.ts
+++ b/front/tests/utils/WorkspaceFactory.ts
@@ -1,6 +1,7 @@
 import { PlanModel } from "@app/lib/models/plan";
 import { PRO_PLAN_SEAT_29_CODE } from "@app/lib/plans/plan_codes";
 import { renderPlanFromModel } from "@app/lib/plans/renderers";
+import { GroupResource } from "@app/lib/resources/group_resource";
 import { WorkspaceModel } from "@app/lib/resources/storage/models/workspace";
 import { generateRandomModelSId } from "@app/lib/resources/string_ids";
 import { SubscriptionResource } from "@app/lib/resources/subscription_resource";
@@ -41,10 +42,16 @@ export class WorkspaceFactory {
       renderPlanFromModel({ plan: newPlan })
     );
 
-    return {
+    const workspaceType: WorkspaceType = {
       ...renderLightWorkspaceType({ workspace }),
       ssoEnforced: workspace.ssoEnforced,
       workOSOrganizationId: workspace.workOSOrganizationId,
     };
+
+    // Create default groups (global, system) so tests don't need to call
+    // GroupFactory.defaults() manually. Idempotent if already created.
+    await GroupResource.makeDefaultsForWorkspace(workspaceType);
+
+    return workspaceType;
   }
 }


### PR DESCRIPTION
## Description
### `GroupResource.listUserGroupModelIdsInWorkspace`

- **`dangerouslySkipMembershipCheck` parameter**: When true, skips the redundant membership query. The method was querying `memberships` to verify the user belongs to the workspace, but callers like `fromSession` already check this via `getActiveRoleForUserInWorkspace` in the same `Promise.all`. The global group validation throw is also skipped when the flag is set. The caller is responsible for handling non-members (see `fetchRoleGroupsAndSubscription` below).

- **Merge two queries into one**: Replaced a `findOne` for the global group + a separate raw SQL for user group memberships with a single query using `kind = 'global' OR id IN (SELECT ... FROM group_memberships ...)`.

### `Authenticator.fetchRoleGroupsAndSubscription` (new private helper)

Encapsulates the role + groups + subscription parallel fetch that was copy-pasted across 3 factory methods. Runs all three queries in `Promise.all` and resets `groupModelIds` to `[]` when `role === "none"` to prevent non-members from getting access via the global group. This is the single place where `dangerouslySkipMembershipCheck: true` and the safety reset live — no caller can forget it.

### `Authenticator` factory methods

- **`fromSession`**, **`fromUserIdAndWorkspaceId`**, **`fromWorkOSToken`**: Replaced duplicated `Promise.all` blocks with a single call to `fetchRoleGroupsAndSubscription`.
- **`fromWorkOSToken`**: Parallelized user + workspace fetches that were sequential.
- **`fromKey`**: Uses `dangerouslySkipMembershipCheck: true` directly (membership already verified via `activeMembership`). Removed unnecessary async wrappers. Deduplicated subscription fetch when key workspace is the target workspace while keeping full parallelism when they differ.

## Impact on `fromSession`

| | Before | After |
|---|---|---|
| Pool acquisitions | 7 | 5 |
| Peak concurrent connections | 5 | 3 |
| 15 req × peak (worst case) | 75 needed / 25 available | 45 needed / 25 available |

The "15 req × peak" row is a worst-case estimate assuming 15 concurrent requests per pod (from Flavien's analysis) all hitting stage 2 simultaneously. It shows total pool demand vs the pool max of 25. Before, demand was 3x supply; after, ~1.8x. Still above the limit but significantly less starvation pressure.

Same number of sequential stages, same wall-clock time, no behavioral change.

## Tests

No behavioral change, existing tests pass.

## Risk

Blast radius is bad since this touches auth. 

Why I think dangerouslySkipMembershipCheck is okay: The flag is only used from two places:
- 1. fetchRoleGroupsAndSubscription (private helper) -- runs getActiveRoleForUserInWorkspace in parallel, which already answers "is this user a member?". If not, role comes back as "none" and the helper resets groupModelIds to []. A non-member can never receive group permissions. The safety invariant is preserved, just enforced one layer up instead of being checked twice.
- 2. fromKey -- membership is not relevant since API keys authenticate via the key itself, not via user membership.
The dangerous prefix + JSDoc comment on the parameter make the contract explicit: any future caller must handle the non-member case themselves.

PR is safe to rollback (revert to previous auth code with no data migration needed).

## Deploy Plan

Deploy front. 