### PR TITLE
Gdrive cli: allow to export structure of only one folder

### DIFF
--- a/connectors/src/connectors/google_drive/lib/cli.ts
+++ b/connectors/src/connectors/google_drive/lib/cli.ts
@@ -365,12 +365,14 @@ export const google_drive = async ({
       const authCredentials = await getAuthObject(connector.connectionId);
       const drive = await getDriveClient(authCredentials);
 
-      // Get all folders configured to sync
-      const foldersToSync = await GoogleDriveFoldersModel.findAll({
-        where: {
-          connectorId: connector.id,
-        },
-      });
+      // Determine root folder IDs to export
+      const rootFolderIds: string[] = args.rootFolderId
+        ? [args.rootFolderId]
+        : (
+            await GoogleDriveFoldersModel.findAll({
+              where: { connectorId: connector.id },
+            })
+          ).map((f) => f.folderId);
 
       interface FolderNode {
         id: string;
@@ -494,8 +496,8 @@ export const google_drive = async ({
       };
 
       // Build tree for each root folder
-      for (const folder of foldersToSync) {
-        const rootNode = await buildFolderTree(folder.folderId);
+      for (const folderId of rootFolderIds) {
+        const rootNode = await buildFolderTree(folderId);
         folderStructure.push(rootNode);
       }
 


### PR DESCRIPTION
## Description

This allow to explore a smaller path to avoid computing everything 

## Tests

no

## Risk

low

## Deploy Plan

deploy connector
