### PR TITLE
feat: skip slack notification when not configured

### DIFF
--- a/front/lib/notifications/workflows/conversation-unread.ts
+++ b/front/lib/notifications/workflows/conversation-unread.ts
@@ -12,6 +12,7 @@ import {
 import { DustError } from "@app/lib/error";
 import type { NotificationAllowedTags } from "@app/lib/notifications";
 import {
+  areSlackNotificationsEnabledAndConfigured,
   getNovuClient,
   getUserNotificationDelay,
 } from "@app/lib/notifications";
@@ -676,6 +677,14 @@ export const conversationUnreadWorkflow = workflow(
       {
         skip: async () => {
           if (!details) {
+            return true;
+          }
+          const isSlackEnabledAndConfigured =
+            await areSlackNotificationsEnabledAndConfigured(
+              subscriber.subscriberId,
+              payload.workspaceId
+            );
+          if (!isSlackEnabledAndConfigured) {
             return true;
           }
           return shouldSkipConversation({

--- a/front/lib/notifications/workflows/project-added-as-member.ts
+++ b/front/lib/notifications/workflows/project-added-as-member.ts
@@ -2,7 +2,10 @@ import config from "@app/lib/api/config";
 import { Authenticator } from "@app/lib/auth";
 import type { DustError } from "@app/lib/error";
 import type { NotificationAllowedTags } from "@app/lib/notifications";
-import { getNovuClient } from "@app/lib/notifications";
+import {
+  areSlackNotificationsEnabledAndConfigured,
+  getNovuClient,
+} from "@app/lib/notifications";
 import { renderEmail } from "@app/lib/notifications/email-templates/default";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
@@ -151,7 +154,17 @@ export const projectAddedAsMemberWorkflow = workflow(
         };
       },
       {
-        skip: async () => shouldSkipProject({ payload }),
+        skip: async () => {
+          const isSlackEnabledAndConfigured =
+            await areSlackNotificationsEnabledAndConfigured(
+              subscriber.subscriberId,
+              payload.workspaceId
+            );
+          if (!isSlackEnabledAndConfigured) {
+            return true;
+          }
+          return shouldSkipProject({ payload });
+        },
       }
     );
 

--- a/front/lib/notifications/workflows/project-new-conversation.ts
+++ b/front/lib/notifications/workflows/project-new-conversation.ts
@@ -7,7 +7,10 @@ import {
 } from "@app/lib/data_retention";
 import { DustError } from "@app/lib/error";
 import type { NotificationAllowedTags } from "@app/lib/notifications";
-import { getUserNotificationDelay } from "@app/lib/notifications";
+import {
+  areSlackNotificationsEnabledAndConfigured,
+  getUserNotificationDelay,
+} from "@app/lib/notifications";
 import { ConversationResource } from "@app/lib/resources/conversation_resource";
 import { SpaceResource } from "@app/lib/resources/space_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
@@ -340,6 +343,14 @@ export const projectNewConversationWorkflow = workflow(
       {
         skip: async () => {
           if (!details) {
+            return true;
+          }
+          const isSlackEnabledAndConfigured =
+            await areSlackNotificationsEnabledAndConfigured(
+              subscriber.subscriberId,
+              payload.workspaceId
+            );
+          if (!isSlackEnabledAndConfigured) {
             return true;
           }
           return shouldSkipConversation({

--- a/front/pages/api/w/[wId]/me/slack-notifications.ts
+++ b/front/pages/api/w/[wId]/me/slack-notifications.ts
@@ -4,6 +4,7 @@ import type { Authenticator } from "@app/lib/auth";
 import {
   getNovuClient,
   getSlackConnectionIdentifier,
+  isSlackChannelConfigured,
 } from "@app/lib/notifications";
 import { DataSourceResource } from "@app/lib/resources/data_source_resource";
 import logger from "@app/logger/logger";
@@ -51,37 +52,10 @@ async function handler(
 
   switch (req.method) {
     case "GET": {
-      const novu = await getNovuClient();
-
-      const connectionIdentifier = getSlackConnectionIdentifier(
-        userResource.sId
-      );
-
-      const slackChannelConnections = await novu.channelConnections.list({
-        subscriberId: userResource.sId,
-        integrationIdentifier: "slack",
-        channel: "chat",
-      });
-
-      const slackChannelConnection = slackChannelConnections.result.data.find(
-        (connection) => connection.identifier === connectionIdentifier
-      );
-
-      if (!slackChannelConnection) {
-        return res.status(200).json({
-          isConfigured: false,
-        });
-      }
-
-      const slackChannelEndpoints = await novu.channelEndpoints.list({
-        subscriberId: userResource.sId,
-        integrationIdentifier: "slack",
-        connectionIdentifier,
-        channel: "chat",
-      });
+      const isConfigured = await isSlackChannelConfigured(userResource.sId);
 
       return res.status(200).json({
-        isConfigured: slackChannelEndpoints.result.data.length > 0,
+        isConfigured,
       });
     }
     case "POST": {


### PR DESCRIPTION
## Description

This PR introduces a check to skip Slack notifications when they are not properly configured.
This is useful to avoid having errors in novu due to slack not being configured for the subscriber.

## Tests

Manually

## Risks

Low risk. This feature is behind feature flag.

## Deploy Plan

Standard deployment.
