### PR TITLE
[front] enh(triggers): allow filtering by status in poke view

### DIFF
--- a/front/components/agent_builder/triggers/WebhookRequestStatusBadge.tsx
+++ b/front/components/agent_builder/triggers/WebhookRequestStatusBadge.tsx
@@ -1,4 +1,4 @@
-import type { WebhookRequestTriggerStatus } from "@app/lib/models/agent/triggers/webhook_request_trigger";
+import type { WebhookRequestTriggerStatus } from "@app/types/assistant/triggers";
 import { Chip } from "@dust-tt/sparkle";
 import type { ComponentProps } from "react";
 

--- a/front/components/poke/triggers/RecentWebhookRequests.tsx
+++ b/front/components/poke/triggers/RecentWebhookRequests.tsx
@@ -143,7 +143,7 @@ function PokeRecentWebhookRequestsContent({
       {webhookRequests.length === 0 ? (
         <p className="text-sm text-muted-foreground dark:text-muted-foreground-night pt-2">
           {statusFilter
-            ? `No "${STATUS_FILTER_LABELS[statusFilter]}" requests.`
+            ? `No ${STATUS_FILTER_LABELS[statusFilter].toLowerCase()} requests.`
             : "No webhook requests yet."}
         </p>
       ) : (

--- a/front/components/poke/triggers/RecentWebhookRequests.tsx
+++ b/front/components/poke/triggers/RecentWebhookRequests.tsx
@@ -103,7 +103,7 @@ function PokeRecentWebhookRequestsContent({
 
   if (isWebhookRequestsError) {
     return (
-      <ContentMessageInline variant="warning">
+      <ContentMessageInline variant="warning" className="pt-2">
         Unable to load recent webhook requests.
       </ContentMessageInline>
     );

--- a/front/components/poke/triggers/RecentWebhookRequests.tsx
+++ b/front/components/poke/triggers/RecentWebhookRequests.tsx
@@ -1,9 +1,9 @@
 import { WebhookRequestStatusBadge } from "@app/components/agent_builder/triggers/WebhookRequestStatusBadge";
+import { usePokeWebhookRequests } from "@app/poke/swr/triggers";
 import {
   WEBHOOK_REQUEST_TRIGGER_STATUSES,
   type WebhookRequestTriggerStatus,
 } from "@app/types/assistant/triggers";
-import { usePokeWebhookRequests } from "@app/poke/swr/triggers";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
   Button,
@@ -92,7 +92,7 @@ function PokeRecentWebhookRequestsContent({
 
   if (isWebhookRequestsLoading || !isOpen) {
     return (
-      <div className="flex items-center gap-2">
+      <div className="flex items-center gap-2 pt-2">
         <Spinner size="sm" />
         <span className="text-sm text-muted-foreground dark:text-muted-foreground-night">
           Loading recent requests...

--- a/front/components/poke/triggers/RecentWebhookRequests.tsx
+++ b/front/components/poke/triggers/RecentWebhookRequests.tsx
@@ -29,8 +29,8 @@ interface PokeRecentWebhookRequestsProps {
 }
 
 const STATUS_FILTER_LABELS: Record<WebhookRequestTriggerStatus, string> = {
-  workflow_start_succeeded: "Succeeded",
-  workflow_start_failed: "Failed",
+  workflow_start_succeeded: "Matched (succeeded)",
+  workflow_start_failed: "Matched (failed)",
   not_matched: "Not Matched",
   rate_limited: "Rate Limited",
 };

--- a/front/components/poke/triggers/RecentWebhookRequests.tsx
+++ b/front/components/poke/triggers/RecentWebhookRequests.tsx
@@ -29,8 +29,8 @@ interface PokeRecentWebhookRequestsProps {
 }
 
 const STATUS_FILTER_LABELS: Record<WebhookRequestTriggerStatus, string> = {
-  workflow_start_succeeded: "Matched (succeeded)",
-  workflow_start_failed: "Matched (failed)",
+  workflow_start_succeeded: "Matched",
+  workflow_start_failed: "Failed",
   not_matched: "Not Matched",
   rate_limited: "Rate Limited",
 };

--- a/front/components/poke/triggers/RecentWebhookRequests.tsx
+++ b/front/components/poke/triggers/RecentWebhookRequests.tsx
@@ -1,8 +1,11 @@
 import { WebhookRequestStatusBadge } from "@app/components/agent_builder/triggers/WebhookRequestStatusBadge";
+import type { WebhookRequestTriggerStatus } from "@app/lib/models/agent/triggers/webhook_request_trigger";
+import { WEBHOOK_REQUEST_TRIGGER_STATUSES } from "@app/lib/models/agent/triggers/webhook_request_trigger";
 import { usePokeWebhookRequests } from "@app/poke/swr/triggers";
 import type { LightWorkspaceType } from "@app/types/user";
 import {
   Button,
+  Chip,
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
@@ -22,6 +25,13 @@ interface PokeRecentWebhookRequestsProps {
   owner: LightWorkspaceType;
   triggerId: string;
 }
+
+const STATUS_FILTER_LABELS: Record<WebhookRequestTriggerStatus, string> = {
+  workflow_start_succeeded: "Succeeded",
+  workflow_start_failed: "Failed",
+  not_matched: "Not Matched",
+  rate_limited: "Rate Limited",
+};
 
 export function PokeRecentWebhookRequests({
   owner,
@@ -65,11 +75,15 @@ function PokeRecentWebhookRequestsContent({
   triggerId,
 }: PokeRecentWebhookRequestsContentProps) {
   const [limit, setLimit] = useState(PAGE_SIZE);
+  const [statusFilter, setStatusFilter] = useState<
+    WebhookRequestTriggerStatus | undefined
+  >(undefined);
   const { webhookRequests, isWebhookRequestsLoading, isWebhookRequestsError } =
     usePokeWebhookRequests({
       owner,
       triggerId,
       limit,
+      status: statusFilter,
       disabled: !isOpen,
     });
   const hasMore = webhookRequests.length === limit;
@@ -93,69 +107,99 @@ function PokeRecentWebhookRequestsContent({
     );
   }
 
-  if (webhookRequests.length === 0) {
-    return (
-      <p className="text-sm text-muted-foreground dark:text-muted-foreground-night pt-2">
-        No webhook requests yet.
-      </p>
-    );
-  }
-
   const wasRateLimited = webhookRequests.some(
     (request) => request.status === "rate_limited"
   );
 
   return (
     <div className="space-y-2">
-      {wasRateLimited && (
-        <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-          Some requests were rate limited.
-        </div>
-      )}
-      <div className="flex flex-col px-4">
-        {webhookRequests.map((request, idx) => (
-          <div key={request.id}>
-            <Collapsible defaultOpen={false}>
-              <CollapsibleTrigger>
-                <div className="my-2 flex w-full items-center justify-between gap-4">
-                  {moment(new Date(request.timestamp)).calendar(undefined, {
-                    sameDay: "[Today at] LTS",
-                    lastDay: "[Yesterday at] LTS",
-                    lastWeek: "[Last] dddd [at] LTS",
-                  })}
-                  <WebhookRequestStatusBadge status={request.status} />
-                </div>
-              </CollapsibleTrigger>
-              <CollapsibleContent>
-                {request.payload ? (
-                  <div className="rounded">
-                    <pre className="max-h-64 overflow-auto text-xs">
-                      <Markdown
-                        forcedTextSize="xs"
-                        content={`\`\`\`json\n${JSON.stringify(request.payload.body, null, 2)}\n\`\`\``}
-                      />
-                    </pre>
-                  </div>
-                ) : (
-                  <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
-                    No payload available.
-                  </p>
-                )}
-              </CollapsibleContent>
-            </Collapsible>
-            {idx < webhookRequests.length - 1 && <Separator />}
-          </div>
+      <div className="flex flex-wrap items-center gap-2 pt-2">
+        <Chip
+          color={statusFilter === undefined ? "primary" : "white"}
+          size="xs"
+          label="All"
+          className="cursor-pointer select-none"
+          onClick={() => {
+            setStatusFilter(undefined);
+            setLimit(PAGE_SIZE);
+          }}
+        />
+        {WEBHOOK_REQUEST_TRIGGER_STATUSES.map((s) => (
+          <Chip
+            key={s}
+            color={statusFilter === s ? "primary" : "white"}
+            size="xs"
+            label={STATUS_FILTER_LABELS[s]}
+            className="cursor-pointer select-none"
+            onClick={() => {
+              setStatusFilter(s);
+              setLimit(PAGE_SIZE);
+            }}
+          />
         ))}
       </div>
-      {hasMore && (
-        <div className="flex justify-center pt-2">
-          <Button
-            variant="outline"
-            size="sm"
-            label="Load more"
-            onClick={() => setLimit((prev) => prev + PAGE_SIZE)}
-          />
-        </div>
+      {webhookRequests.length === 0 ? (
+        <p className="text-sm text-muted-foreground dark:text-muted-foreground-night pt-2">
+          {statusFilter
+            ? `No "${STATUS_FILTER_LABELS[statusFilter]}" requests.`
+            : "No webhook requests yet."}
+        </p>
+      ) : (
+        <>
+          {wasRateLimited && !statusFilter && (
+            <div className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+              Some requests were rate limited.
+            </div>
+          )}
+          <div className="flex flex-col px-4">
+            {webhookRequests.map((request, idx) => (
+              <div key={request.id}>
+                <Collapsible defaultOpen={false}>
+                  <CollapsibleTrigger>
+                    <div className="my-2 flex w-full items-center justify-between gap-4">
+                      {moment(new Date(request.timestamp)).calendar(
+                        undefined,
+                        {
+                          sameDay: "[Today at] LTS",
+                          lastDay: "[Yesterday at] LTS",
+                          lastWeek: "[Last] dddd [at] LTS",
+                        }
+                      )}
+                      <WebhookRequestStatusBadge status={request.status} />
+                    </div>
+                  </CollapsibleTrigger>
+                  <CollapsibleContent>
+                    {request.payload ? (
+                      <div className="rounded">
+                        <pre className="max-h-64 overflow-auto text-xs">
+                          <Markdown
+                            forcedTextSize="xs"
+                            content={`\`\`\`json\n${JSON.stringify(request.payload.body, null, 2)}\n\`\`\``}
+                          />
+                        </pre>
+                      </div>
+                    ) : (
+                      <p className="text-sm text-muted-foreground dark:text-muted-foreground-night">
+                        No payload available.
+                      </p>
+                    )}
+                  </CollapsibleContent>
+                </Collapsible>
+                {idx < webhookRequests.length - 1 && <Separator />}
+              </div>
+            ))}
+          </div>
+          {hasMore && (
+            <div className="flex justify-center pt-2">
+              <Button
+                variant="outline"
+                size="sm"
+                label="Load more"
+                onClick={() => setLimit((prev) => prev + PAGE_SIZE)}
+              />
+            </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/front/components/poke/triggers/RecentWebhookRequests.tsx
+++ b/front/components/poke/triggers/RecentWebhookRequests.tsx
@@ -157,14 +157,11 @@ function PokeRecentWebhookRequestsContent({
                 <Collapsible defaultOpen={false}>
                   <CollapsibleTrigger>
                     <div className="my-2 flex w-full items-center justify-between gap-4">
-                      {moment(new Date(request.timestamp)).calendar(
-                        undefined,
-                        {
-                          sameDay: "[Today at] LTS",
-                          lastDay: "[Yesterday at] LTS",
-                          lastWeek: "[Last] dddd [at] LTS",
-                        }
-                      )}
+                      {moment(new Date(request.timestamp)).calendar(undefined, {
+                        sameDay: "[Today at] LTS",
+                        lastDay: "[Yesterday at] LTS",
+                        lastWeek: "[Last] dddd [at] LTS",
+                      })}
                       <WebhookRequestStatusBadge status={request.status} />
                     </div>
                   </CollapsibleTrigger>

--- a/front/components/poke/triggers/RecentWebhookRequests.tsx
+++ b/front/components/poke/triggers/RecentWebhookRequests.tsx
@@ -1,6 +1,8 @@
 import { WebhookRequestStatusBadge } from "@app/components/agent_builder/triggers/WebhookRequestStatusBadge";
-import type { WebhookRequestTriggerStatus } from "@app/lib/models/agent/triggers/webhook_request_trigger";
-import { WEBHOOK_REQUEST_TRIGGER_STATUSES } from "@app/lib/models/agent/triggers/webhook_request_trigger";
+import {
+  WEBHOOK_REQUEST_TRIGGER_STATUSES,
+  type WebhookRequestTriggerStatus,
+} from "@app/types/assistant/triggers";
 import { usePokeWebhookRequests } from "@app/poke/swr/triggers";
 import type { LightWorkspaceType } from "@app/types/user";
 import {

--- a/front/lib/models/agent/triggers/webhook_request_trigger.ts
+++ b/front/lib/models/agent/triggers/webhook_request_trigger.ts
@@ -1,21 +1,11 @@
 import { frontSequelize } from "@app/lib/resources/storage";
 import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
+import type { WebhookRequestTriggerStatus } from "@app/types/assistant/triggers";
 import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
 import { DataTypes } from "sequelize";
 
 import { TriggerModel } from "./triggers";
 import { WebhookRequestModel } from "./webhook_request";
-
-// Single source of truth for webhook request trigger statuses
-export const WEBHOOK_REQUEST_TRIGGER_STATUSES = [
-  "workflow_start_succeeded",
-  "workflow_start_failed",
-  "not_matched",
-  "rate_limited",
-] as const;
-
-export type WebhookRequestTriggerStatus =
-  (typeof WEBHOOK_REQUEST_TRIGGER_STATUSES)[number];
 
 /**
  * WebhookRequestTrigger model maps webhook requests to triggers.

--- a/front/lib/resources/webhook_request_resource.ts
+++ b/front/lib/resources/webhook_request_resource.ts
@@ -1,7 +1,6 @@
 import type { Authenticator } from "@app/lib/auth";
 import type { WebhookRequestStatus } from "@app/lib/models/agent/triggers/webhook_request";
 import { WebhookRequestModel } from "@app/lib/models/agent/triggers/webhook_request";
-import type { WebhookRequestTriggerStatus } from "@app/lib/models/agent/triggers/webhook_request_trigger";
 import { WebhookRequestTriggerModel } from "@app/lib/models/agent/triggers/webhook_request_trigger";
 import { BaseResource } from "@app/lib/resources/base_resource";
 import { frontSequelize } from "@app/lib/resources/storage";
@@ -9,7 +8,10 @@ import type { ReadonlyAttributesType } from "@app/lib/resources/storage/types";
 import type { ResourceFindOptions } from "@app/lib/resources/types";
 import { concurrentExecutor } from "@app/lib/utils/async_utils";
 import logger from "@app/logger/logger";
-import type { TriggerType } from "@app/types/assistant/triggers";
+import type {
+  TriggerType,
+  WebhookRequestTriggerStatus,
+} from "@app/types/assistant/triggers";
 import type { ModelId } from "@app/types/shared/model_id";
 import type { Result } from "@app/types/shared/result";
 import { Err, Ok } from "@app/types/shared/result";

--- a/front/lib/resources/webhook_request_resource.ts
+++ b/front/lib/resources/webhook_request_resource.ts
@@ -182,9 +182,11 @@ export class WebhookRequestResource extends BaseResource<WebhookRequestModel> {
     {
       triggerId,
       limit,
+      status,
     }: {
       triggerId: ModelId;
       limit?: number;
+      status?: WebhookRequestTriggerStatus;
     }
   ) {
     const workspace = auth.getNonNullableWorkspace();
@@ -193,6 +195,7 @@ export class WebhookRequestResource extends BaseResource<WebhookRequestModel> {
       where: {
         workspaceId: workspace.id,
         triggerId,
+        ...(status ? { status } : {}),
       },
       include: [
         {

--- a/front/lib/triggers/webhook.ts
+++ b/front/lib/triggers/webhook.ts
@@ -813,9 +813,11 @@ export async function fetchRecentWebhookRequestTriggersWithPayload(
   {
     trigger,
     limit = 15,
+    status,
   }: {
     trigger: TriggerType;
     limit?: number;
+    status?: WebhookRequestTriggerStatus;
   }
 ): Promise<
   {
@@ -834,6 +836,7 @@ export async function fetchRecentWebhookRequestTriggersWithPayload(
     {
       triggerId: trigger.id,
       limit,
+      status,
     }
   );
 

--- a/front/lib/triggers/webhook.ts
+++ b/front/lib/triggers/webhook.ts
@@ -4,7 +4,6 @@ import { Authenticator } from "@app/lib/auth";
 import type { DustError } from "@app/lib/error";
 import { getWebhookRequestsBucket } from "@app/lib/file_storage";
 import { matchPayload, parseMatcherExpression } from "@app/lib/matcher";
-import type { WebhookRequestTriggerStatus } from "@app/lib/models/agent/triggers/webhook_request_trigger";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { UserResource } from "@app/lib/resources/user_resource";
 import { WebhookRequestResource } from "@app/lib/resources/webhook_request_resource";
@@ -24,6 +23,7 @@ import { launchAgentTriggerWorkflow } from "@app/temporal/triggers/common/client
 import type { ContentFragmentInputWithFileIdType } from "@app/types/api/internal/assistant";
 import type {
   TriggerType,
+  WebhookRequestTriggerStatus,
   WebhookTriggerType,
 } from "@app/types/assistant/triggers";
 import { isWebhookTrigger } from "@app/types/assistant/triggers";

--- a/front/pages/api/poke/workspaces/[wId]/triggers/[tId]/webhook_requests.ts
+++ b/front/pages/api/poke/workspaces/[wId]/triggers/[tId]/webhook_requests.ts
@@ -1,11 +1,11 @@
 import { withSessionAuthenticationForPoke } from "@app/lib/api/auth_wrappers";
 import { Authenticator } from "@app/lib/auth";
 import type { SessionWithUser } from "@app/lib/iam/provider";
-import type { WebhookRequestTriggerStatus } from "@app/lib/models/agent/triggers/webhook_request_trigger";
-import { WEBHOOK_REQUEST_TRIGGER_STATUSES } from "@app/lib/models/agent/triggers/webhook_request_trigger";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { fetchRecentWebhookRequestTriggersWithPayload } from "@app/lib/triggers/webhook";
 import { apiError } from "@app/logger/withlogging";
+import type { WebhookRequestTriggerStatus } from "@app/types/assistant/triggers";
+import { WEBHOOK_REQUEST_TRIGGER_STATUSES } from "@app/types/assistant/triggers";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";

--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/triggers/[tId]/webhook_requests.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/triggers/[tId]/webhook_requests.ts
@@ -1,10 +1,10 @@
 import { withSessionAuthenticationForWorkspace } from "@app/lib/api/auth_wrappers";
 import type { Authenticator } from "@app/lib/auth";
-import type { WebhookRequestTriggerStatus } from "@app/lib/models/agent/triggers/webhook_request_trigger";
 import { TriggerResource } from "@app/lib/resources/trigger_resource";
 import { fetchRecentWebhookRequestTriggersWithPayload } from "@app/lib/triggers/webhook";
 import logger from "@app/logger/logger";
 import { apiError, withLogging } from "@app/logger/withlogging";
+import type { WebhookRequestTriggerStatus } from "@app/types/assistant/triggers";
 import type { WithAPIErrorResponse } from "@app/types/error";
 import { isString } from "@app/types/shared/utils/general";
 import type { NextApiRequest, NextApiResponse } from "next";

--- a/front/poke/swr/triggers.ts
+++ b/front/poke/swr/triggers.ts
@@ -28,17 +28,22 @@ export function usePokeWebhookRequests({
   owner,
   triggerId,
   limit,
+  status,
   disabled,
 }: {
   owner: LightWorkspaceType;
   triggerId: string;
   limit?: number;
+  status?: string;
   disabled?: boolean;
 }) {
   const requestsFetcher: Fetcher<PokeGetWebhookRequestsResponseBody> = fetcher;
   const params = new URLSearchParams();
   if (limit !== undefined) {
     params.set("limit", limit.toString());
+  }
+  if (status) {
+    params.set("status", status);
   }
   const query = params.toString();
   const { data, error, mutate } = useSWRWithDefaults(

--- a/front/poke/swr/triggers.ts
+++ b/front/poke/swr/triggers.ts
@@ -2,6 +2,7 @@ import { fetcher, useSWRWithDefaults } from "@app/lib/swr/swr";
 import type { PokeListTriggers } from "@app/pages/api/poke/workspaces/[wId]/triggers";
 import type { PokeGetWebhookRequestsResponseBody } from "@app/pages/api/poke/workspaces/[wId]/triggers/[tId]/webhook_requests";
 import type { PokeConditionalFetchProps } from "@app/poke/swr/types";
+import type { WebhookRequestTriggerStatus } from "@app/types/assistant/triggers";
 import type { LightWorkspaceType } from "@app/types/user";
 import type { Fetcher } from "swr";
 
@@ -34,7 +35,7 @@ export function usePokeWebhookRequests({
   owner: LightWorkspaceType;
   triggerId: string;
   limit?: number;
-  status?: string;
+  status?: WebhookRequestTriggerStatus;
   disabled?: boolean;
 }) {
   const requestsFetcher: Fetcher<PokeGetWebhookRequestsResponseBody> = fetcher;


### PR DESCRIPTION
## Description

- Trying to debug an issue where I get unexpected triggers but cannot find them amongst a large number of correctly unmatched triggers.
- This PR allows filtering by status in the backend and uses it in the poke page.
- TBD if we want to do the same in the Agent Builder view.
- Already an index to speed up the query.

## Tests

- Tested locally.

## Risk

- Low.

## Deploy Plan

- Deploy front.
