### PR TITLE
[Front] fix(suggestions): allow admins to access suggestions endpoint

### DIFF
--- a/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/suggestions.ts
+++ b/front/pages/api/w/[wId]/assistant/agent_configurations/[aId]/suggestions.ts
@@ -88,7 +88,8 @@ async function handler(
       },
     });
   }
-  if (!agent.canEdit) {
+
+  if (!agent.canEdit && !auth.isAdmin()) {
     return apiError(req, res, {
       status_code: 403,
       api_error: {

--- a/front/pages/api/w/[wId]/spaces/[spaceId]/search_conversations.ts
+++ b/front/pages/api/w/[wId]/spaces/[spaceId]/search_conversations.ts
@@ -12,7 +12,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 import { fromError } from "zod-validation-error";
 
-const SEMANTIC_SEARCH_SCORE_CUTOFF = 0.10;
+const SEMANTIC_SEARCH_SCORE_CUTOFF = 0.1;
 
 export type SearchConversationsResponseBody = {
   conversations: ConversationWithoutContentType[];


### PR DESCRIPTION
## Description

Fix the `canEdit` permission check on the suggestions endpoint to also allow workspace admins.



