### PR TITLE
feat: use precomputed citations in light view

### DIFF
--- a/front/admin/db.ts
+++ b/front/admin/db.ts
@@ -59,6 +59,7 @@ import {
 import { GroupSkillModel } from "@app/lib/models/skill/group_skill";
 import { TagModel } from "@app/lib/models/tags";
 import { AgentMemoryModel } from "@app/lib/resources/storage/models/agent_memories";
+import { AgentMessageCitationsModel } from "@app/lib/resources/storage/models/agent_message_citations";
 import {
   AppModel,
   CloneModel,
@@ -177,6 +178,7 @@ export function loadAllModels() {
     AgentStepContentModel,
     AgentMCPActionModel,
     AgentMCPActionOutputItemModel,
+    AgentMessageCitationsModel,
     AgentChildAgentConfigurationModel,
     FeatureFlagModel,
     KillSwitchModel,

--- a/front/lib/api/assistant/citations.ts
+++ b/front/lib/api/assistant/citations.ts
@@ -4,6 +4,7 @@ import {
   isSearchResultResourceType,
   isWebsearchResultResourceType,
 } from "@app/lib/actions/mcp_internal_actions/output_schemas";
+import type { PrecomputedCitationsData } from "@app/lib/resources/agent_message_citations_resource";
 import { rand } from "@app/lib/utils/seeded_random";
 import type { AgentMCPActionWithOutputType } from "@app/types/actions";
 import type {
@@ -172,6 +173,51 @@ export function getLightAgentMessageFromAgentMessage(
         contentType: f.contentType,
         ...(f.hidden ? { hidden: true } : {}),
       })),
+    richMentions: agentMessage.richMentions,
+    completionDurationMs: agentMessage.completionDurationMs,
+    reactions: agentMessage.reactions,
+    prunedContext: agentMessage.prunedContext,
+  };
+}
+
+/**
+ * Build a LightAgentMessageType directly from precomputed citation data,
+ * bypassing the need for action output items (TOAST reads).
+ * Used by the light view read path when precomputed data is available.
+ */
+export function buildLightAgentMessageFromPrecomputed(
+  agentMessage: Omit<AgentMessageType, "actions" | "contents"> & {
+    actions: {
+      executionDurationMs: number | null;
+      createdAt: number;
+      updatedAt: number;
+    }[];
+  },
+  precomputed: PrecomputedCitationsData
+): LightAgentMessageType {
+  return {
+    type: "agent_message",
+    sId: agentMessage.sId,
+    created: agentMessage.created,
+    completedTs: agentMessage.completedTs,
+    version: agentMessage.version,
+    rank: agentMessage.rank,
+    parentMessageId: agentMessage.parentMessageId,
+    parentAgentMessageId: agentMessage.parentAgentMessageId,
+    visibility: agentMessage.visibility,
+    content: agentMessage.content,
+    chainOfThought: agentMessage.chainOfThought,
+    error: agentMessage.error,
+    status: agentMessage.status,
+    configuration: {
+      sId: agentMessage.configuration.sId,
+      name: agentMessage.configuration.name,
+      pictureUrl: agentMessage.configuration.pictureUrl,
+      status: agentMessage.configuration.status,
+      canRead: agentMessage.configuration.canRead,
+    },
+    citations: precomputed.citations,
+    generatedFiles: precomputed.generatedFiles,
     richMentions: agentMessage.richMentions,
     completionDurationMs: agentMessage.completionDurationMs,
     reactions: agentMessage.reactions,

--- a/front/lib/resources/agent_message_citations_resource.ts
+++ b/front/lib/resources/agent_message_citations_resource.ts
@@ -1,0 +1,92 @@
+import type { Authenticator } from "@app/lib/auth";
+import type { PrecomputedGeneratedFile } from "@app/lib/resources/storage/models/agent_message_citations";
+import { AgentMessageCitationsModel } from "@app/lib/resources/storage/models/agent_message_citations";
+import type { CitationType } from "@app/types/assistant/conversation";
+import type { ModelId } from "@app/types/shared/model_id";
+import type { Result } from "@app/types/shared/result";
+import { Ok } from "@app/types/shared/result";
+import { Op } from "sequelize";
+
+export type PrecomputedCitationsData = {
+  citations: Record<string, CitationType>;
+  generatedFiles: PrecomputedGeneratedFile[];
+};
+
+// TODO(message-resource): This resource should be part of a more general AgentMessageResource.
+// This is just a wrapper around two static methods for upserting and fetching precomputed citation data for agent messages.
+// Ideally, we'd message.upsertPrecomputedCitationsData(...) and message.fetchPrecomputedCitationsData(...) instead of having a
+// separate resource class. When AgentMessageResource comes to life, this class should be refactored to be a part of that.
+export class AgentMessageCitationsResource {
+  /**
+   * Upsert precomputed citations for an agent message.
+   * Merges new citations and generated files with any existing data
+   * (supports incremental writes from multiple action successes).
+   * Returns Result to allow callers to handle errors gracefully.
+   */
+  static async upsertPrecomputedData(
+    auth: Authenticator,
+    {
+      agentMessageId,
+      citations,
+      generatedFiles,
+    }: {
+      agentMessageId: ModelId;
+      citations: Record<string, CitationType>;
+      generatedFiles: PrecomputedGeneratedFile[];
+    }
+  ): Promise<Result<void, Error>> {
+    const workspaceId = auth.getNonNullableWorkspace().id;
+
+    const existing = await AgentMessageCitationsModel.findOne({
+      where: { workspaceId, agentMessageId },
+    });
+
+    if (existing) {
+      await existing.update({
+        citations: { ...existing.citations, ...citations },
+        generatedFiles: [...existing.generatedFiles, ...generatedFiles],
+      });
+    } else {
+      await AgentMessageCitationsModel.create({
+        workspaceId,
+        agentMessageId,
+        citations,
+        generatedFiles,
+      });
+    }
+
+    return new Ok(undefined);
+  }
+
+  /**
+   * Batch-fetch precomputed citation data for a list of agent message IDs.
+   * Returns a Map keyed by agentMessageId for O(1) lookup.
+   */
+  static async fetchByAgentMessageIds(
+    auth: Authenticator,
+    agentMessageIds: ModelId[]
+  ): Promise<Map<ModelId, PrecomputedCitationsData>> {
+    if (agentMessageIds.length === 0) {
+      return new Map();
+    }
+
+    const workspaceId = auth.getNonNullableWorkspace().id;
+
+    const rows = await AgentMessageCitationsModel.findAll({
+      where: {
+        workspaceId,
+        agentMessageId: { [Op.in]: agentMessageIds },
+      },
+    });
+
+    const result = new Map<ModelId, PrecomputedCitationsData>();
+    for (const row of rows) {
+      result.set(row.agentMessageId, {
+        citations: row.citations,
+        generatedFiles: row.generatedFiles,
+      });
+    }
+
+    return result;
+  }
+}

--- a/front/lib/resources/storage/models/agent_message_citations.ts
+++ b/front/lib/resources/storage/models/agent_message_citations.ts
@@ -1,0 +1,73 @@
+import { AgentMessageModel } from "@app/lib/models/agent/conversation";
+import { frontSequelize } from "@app/lib/resources/storage";
+import { WorkspaceAwareModel } from "@app/lib/resources/storage/wrappers/workspace_models";
+import type { CitationType } from "@app/types/assistant/conversation";
+import type { AllSupportedFileContentType } from "@app/types/files";
+import type { CreationOptional, ForeignKey } from "sequelize";
+import { DataTypes } from "sequelize";
+
+export type PrecomputedGeneratedFile = {
+  fileId: string;
+  title: string;
+  contentType: AllSupportedFileContentType;
+  hidden?: boolean;
+};
+
+export class AgentMessageCitationsModel extends WorkspaceAwareModel<AgentMessageCitationsModel> {
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  declare agentMessageId: ForeignKey<AgentMessageModel["id"]>;
+  declare citations: Record<string, CitationType>;
+  declare generatedFiles: PrecomputedGeneratedFile[];
+}
+
+AgentMessageCitationsModel.init(
+  {
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    citations: {
+      type: DataTypes.JSONB,
+      allowNull: false,
+      defaultValue: {},
+    },
+    generatedFiles: {
+      type: DataTypes.JSONB,
+      allowNull: false,
+      defaultValue: [],
+    },
+  },
+  {
+    modelName: "agent_message_citations",
+    sequelize: frontSequelize,
+    indexes: [
+      {
+        unique: true,
+        fields: ["workspaceId", "agentMessageId"],
+        name: "agent_message_citations_workspace_agent_msg",
+        concurrently: true,
+      },
+      {
+        fields: ["agentMessageId"],
+        concurrently: true,
+      },
+    ],
+  }
+);
+
+AgentMessageModel.hasOne(AgentMessageCitationsModel, {
+  foreignKey: { name: "agentMessageId", allowNull: false },
+  onDelete: "CASCADE",
+});
+
+AgentMessageCitationsModel.belongsTo(AgentMessageModel, {
+  foreignKey: { name: "agentMessageId", allowNull: false },
+});

--- a/front/migrations/db/migration_510.sql
+++ b/front/migrations/db/migration_510.sql
@@ -1,0 +1,16 @@
+-- Migration created on févr. 16, 2026
+CREATE TABLE IF NOT EXISTS "agent_message_citations" (
+    "createdAt" timestamp with time zone NOT NULL,
+    "updatedAt" timestamp with time zone NOT NULL,
+    "citations" jsonb NOT NULL DEFAULT '{}',
+    "generatedFiles" jsonb NOT NULL DEFAULT '[]',
+    "workspaceId" bigint NOT NULL REFERENCES "workspaces" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    "id" bigserial,
+    "agentMessageId" bigint NOT NULL REFERENCES "agent_messages" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX CONCURRENTLY "agent_message_citations_workspace_agent_msg" ON "agent_message_citations" ("workspaceId", "agentMessageId");
+
+CREATE INDEX CONCURRENTLY "agent_message_citations_agent_message_id" ON "agent_message_citations" ("agentMessageId");
+


### PR DESCRIPTION
## Description

<!-- Briefly describe the changes you've made and link any relevant issues (e.g., "Fixes #123"). -->
<!-- If the PR includes UI changes, please attach a screenshot or GIF to illustrate the modifications. -->

  - For non-full views (paginated messages list), batch-fetch precomputed citations and skip `enrichActionsWithOutputItems()` for messages that have
  precomputed data
  - Messages without precomputed data (created before PR 2) fall back to existing behavior
  - Full view (side panel) is unchanged — always enriches with full output

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->

Depends on #21725
Merge the other one first, then this one.