### PR TITLE
incremental logs for zendesk activities

### DIFF
--- a/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
+++ b/connectors/src/connectors/zendesk/temporal/incremental_activities.ts
@@ -122,6 +122,11 @@ export async function syncZendeskArticleUpdateBatchActivity({
       startTime,
     });
 
+  logger.info(
+    { ...loggerArgs, articlesSynced: articles.length, hasMore },
+    `[Zendesk] Incremental sync: processing ${articles.length} updated articles.`
+  );
+
   await concurrentExecutor(
     articles,
     async (article) => {
@@ -256,6 +261,11 @@ export async function syncZendeskTicketUpdateBatchActivity({
 
   const { tickets, hasMore, nextLink } = await zendeskClient.listTickets(
     url ? { url } : { brandSubdomain, startTime }
+  );
+
+  logger.info(
+    { ...loggerArgs, ticketsSynced: tickets.length, hasMore },
+    `[Zendesk] Incremental sync: processing ${tickets.length} updated tickets.`
   );
 
   const commentsPerTicket: Record<number, ZendeskTicketComment[]> = {};


### PR DESCRIPTION
## Description

https://github.com/dust-tt/tasks/issues/6577

Related to https://github.com/dust-tt/tasks/issues/6577

So we can investigate when a user has a peak of request on their Zendesk connector.

Logs already exist for fullSync

## Tests

no

## Risk

low

## Deploy Plan

deploy connector
