### PR TITLE
[Conversations] Exclude test conversations from project home list API

### DIFF
--- a/front/pages/api/w/[wId]/assistant/conversations/spaces/[spaceId]/index.ts
+++ b/front/pages/api/w/[wId]/assistant/conversations/spaces/[spaceId]/index.ts
@@ -74,6 +74,9 @@ async function handler(
         lastValue,
       } = await ConversationResource.listConversationsInSpacePaginated(auth, {
         spaceId,
+        options: {
+          excludeTest: true,
+        },
         pagination: {
           limit: pagination.limit,
           lastValue: pagination.lastValue,


### PR DESCRIPTION
## Description
Supersedes https://github.com/dust-tt/dust/pull/21693 with the simpler fix discussed in [Slack](https://dust4ai.slack.com/archives/C09GELMTTRT/p1771242239327339).

In `front/pages/api/w/[wId]/assistant/conversations/spaces/[spaceId]/index.ts`, we keep the existing list logic and only add `options: { excludeTest: true }` when calling `ConversationResource.listConversationsInSpacePaginated(...)`.

Why this works: butler conversations are `visibility = "test"`, so they are filtered at query time and never reach the project home list.

## Risks
Blast radius: project home conversations list endpoint for spaces.
Risk: low

## Deploy Plan
- deploy front
