### PR TITLE
Change extensions aliases in tsconfig

### DIFF
--- a/extension/platforms/chrome/background.ts
+++ b/extension/platforms/chrome/background.ts
@@ -7,13 +7,13 @@ import type {
   GetActiveTabBackgroundMessage,
   GetActiveTabBackgroundResponse,
   InputBarStatusMessage,
-} from "@app/platforms/chrome/messages";
-import type { PendingUpdate } from "@app/platforms/chrome/services/core_platform";
-import { ChromeCorePlatformService } from "@app/platforms/chrome/services/core_platform";
-import { DUST_US_URL } from "@app/shared/lib/config";
-import { extractPage } from "@app/shared/lib/extraction";
-import { generatePKCE } from "@app/shared/lib/utils";
-import type { OAuthAuthorizeResponse } from "@app/shared/services/auth";
+} from "@extension/platforms/chrome/messages";
+import type { PendingUpdate } from "@extension/platforms/chrome/services/core_platform";
+import { ChromeCorePlatformService } from "@extension/platforms/chrome/services/core_platform";
+import { DUST_US_URL } from "@extension/shared/lib/config";
+import { extractPage } from "@extension/shared/lib/extraction";
+import { generatePKCE } from "@extension/shared/lib/utils";
+import type { OAuthAuthorizeResponse } from "@extension/shared/services/auth";
 import { jwtDecode } from "jwt-decode";
 
 const log = console.error;

--- a/extension/platforms/chrome/components/ChromeCaptureActions.tsx
+++ b/extension/platforms/chrome/components/ChromeCaptureActions.tsx
@@ -1,6 +1,6 @@
-import { useCurrentUrlAndDomain } from "@app/platforms/chrome/hooks/useCurrentDomain";
-import type { CaptureActionsProps } from "@app/shared/services/platform";
 import { Button, CameraIcon, DocumentPlusIcon } from "@dust-tt/sparkle";
+import { useCurrentUrlAndDomain } from "@extension/platforms/chrome/hooks/useCurrentDomain";
+import type { CaptureActionsProps } from "@extension/shared/services/platform";
 
 export function ChromeCaptureActions({
   fileUploaderService,

--- a/extension/platforms/chrome/main.tsx
+++ b/extension/platforms/chrome/main.tsx
@@ -7,14 +7,6 @@ import "../../ui/css/components.css";
 // Local custom styles
 import "../../ui/css/custom.css";
 
-import { PortProvider } from "@app/platforms/chrome/context/PortContext";
-import { ChromePlatformService } from "@app/platforms/chrome/services/platform";
-import {
-  PlatformProvider,
-  usePlatform,
-} from "@app/shared/context/PlatformContext";
-import { AuthProvider } from "@app/ui/components/auth/AuthProvider";
-import { routes } from "@app/ui/pages/routes";
 import { datadogLogs } from "@datadog/browser-logs";
 import {
   Button,
@@ -23,6 +15,14 @@ import {
   Notification,
   Page,
 } from "@dust-tt/sparkle";
+import { PortProvider } from "@extension/platforms/chrome/context/PortContext";
+import { ChromePlatformService } from "@extension/platforms/chrome/services/platform";
+import {
+  PlatformProvider,
+  usePlatform,
+} from "@extension/shared/context/PlatformContext";
+import { AuthProvider } from "@extension/ui/components/auth/AuthProvider";
+import { routes } from "@extension/ui/pages/routes";
 import { compare } from "compare-versions";
 import React from "react";
 import ReactDOM from "react-dom/client";

--- a/extension/platforms/chrome/messages.ts
+++ b/extension/platforms/chrome/messages.ts
@@ -1,8 +1,8 @@
 import type {
   AuthService,
   OAuthAuthorizeResponse,
-} from "@app/shared/services/auth";
-import type { CaptureOptions } from "@app/shared/services/capture";
+} from "@extension/shared/services/auth";
+import type { CaptureOptions } from "@extension/shared/services/capture";
 
 export type AuthBackgroundResponseError = {
   success: false;

--- a/extension/platforms/chrome/page.ts
+++ b/extension/platforms/chrome/page.ts
@@ -25,7 +25,7 @@
  * THE SOFTWARE.
  */
 
-import type { CaptureFullPageMessage } from "@app/platforms/chrome/messages";
+import type { CaptureFullPageMessage } from "@extension/platforms/chrome/messages";
 
 declare global {
   interface Window {

--- a/extension/platforms/chrome/services/auth.ts
+++ b/extension/platforms/chrome/services/auth.ts
@@ -1,19 +1,19 @@
+import { datadogLogs } from "@datadog/browser-logs";
+import type { Result } from "@dust-tt/client";
+import { Err, Ok } from "@dust-tt/client";
 import {
   sendAuthMessage,
   sendRefreshTokenMessage,
   sentLogoutMessage,
-} from "@app/platforms/chrome/messages";
-import type { StoredTokens, StoredUser } from "@app/shared/services/auth";
+} from "@extension/platforms/chrome/messages";
+import type { StoredTokens, StoredUser } from "@extension/shared/services/auth";
 import {
   AuthError,
   AuthService,
   getConnectionDetails,
   getDustDomain,
-} from "@app/shared/services/auth";
-import type { StorageService } from "@app/shared/services/storage";
-import { datadogLogs } from "@datadog/browser-logs";
-import type { Result } from "@dust-tt/client";
-import { Err, Ok } from "@dust-tt/client";
+} from "@extension/shared/services/auth";
+import type { StorageService } from "@extension/shared/services/storage";
 import { jwtDecode } from "jwt-decode";
 
 const log = console.error;

--- a/extension/platforms/chrome/services/browser_messaging.ts
+++ b/extension/platforms/chrome/services/browser_messaging.ts
@@ -1,5 +1,5 @@
-import type { AttachSelectionMessage } from "@app/platforms/chrome/messages";
-import type { BrowserMessagingService } from "@app/shared/services/platform";
+import type { AttachSelectionMessage } from "@extension/platforms/chrome/messages";
+import type { BrowserMessagingService } from "@extension/shared/services/platform";
 
 export class ChromeBrowserMessagingService implements BrowserMessagingService {
   addMessageListener(

--- a/extension/platforms/chrome/services/capture.ts
+++ b/extension/platforms/chrome/services/capture.ts
@@ -1,12 +1,12 @@
-import { sendGetActiveTabMessage } from "@app/platforms/chrome/messages";
+import type { Result } from "@dust-tt/client";
+import { Err, Ok } from "@dust-tt/client";
+import { sendGetActiveTabMessage } from "@extension/platforms/chrome/messages";
 import type {
   CaptureOperationId,
   CaptureOptions,
   CaptureService,
   TabContent,
-} from "@app/shared/services/capture";
-import type { Result } from "@dust-tt/client";
-import { Err, Ok } from "@dust-tt/client";
+} from "@extension/shared/services/capture";
 
 const getIncludeCurrentTab = async (params: CaptureOptions) => {
   const backgroundRes = await sendGetActiveTabMessage(params);

--- a/extension/platforms/chrome/services/core_platform.ts
+++ b/extension/platforms/chrome/services/core_platform.ts
@@ -1,8 +1,8 @@
-import { ChromeAuthService } from "@app/platforms/chrome/services/auth";
-import { ChromeBrowserMessagingService } from "@app/platforms/chrome/services/browser_messaging";
-import { ChromeCaptureService } from "@app/platforms/chrome/services/capture";
-import { ChromeStorageService } from "@app/platforms/chrome/services/storage";
-import { CorePlatformService } from "@app/shared/services/platform";
+import { ChromeAuthService } from "@extension/platforms/chrome/services/auth";
+import { ChromeBrowserMessagingService } from "@extension/platforms/chrome/services/browser_messaging";
+import { ChromeCaptureService } from "@extension/platforms/chrome/services/capture";
+import { ChromeStorageService } from "@extension/platforms/chrome/services/storage";
+import { CorePlatformService } from "@extension/shared/services/platform";
 
 export interface PendingUpdate {
   detectedAt: number;

--- a/extension/platforms/chrome/services/platform.ts
+++ b/extension/platforms/chrome/services/platform.ts
@@ -1,5 +1,5 @@
-import { ChromeCaptureActions } from "@app/platforms/chrome/components/ChromeCaptureActions";
-import { ChromeCorePlatformService } from "@app/platforms/chrome/services/core_platform";
+import { ChromeCaptureActions } from "@extension/platforms/chrome/components/ChromeCaptureActions";
+import { ChromeCorePlatformService } from "@extension/platforms/chrome/services/core_platform";
 
 // This class extends the ChromeCorePlatformService to include UI-specific functionality.
 // It provides methods that return React components, such as getCaptureActionsComponent,

--- a/extension/platforms/chrome/services/storage.ts
+++ b/extension/platforms/chrome/services/storage.ts
@@ -1,4 +1,4 @@
-import type { StorageService } from "@app/shared/services/storage";
+import type { StorageService } from "@extension/shared/services/storage";
 
 export class ChromeStorageService implements StorageService {
   private storage = chrome.storage.local;

--- a/extension/platforms/chrome/webpack.config.ts
+++ b/extension/platforms/chrome/webpack.config.ts
@@ -92,7 +92,8 @@ export const getConfig = async ({
     resolve: {
       extensions: [".js", ".json", ".mjs", ".jsx", ".ts", ".tsx"],
       alias: {
-        "@app": path.resolve(__dirname, "../../"),
+        "@extension": path.resolve(__dirname, "../../"),
+        "@app": path.resolve(__dirname, "../../../front"),
         redis: false,
       },
       fallback: {

--- a/extension/platforms/front/context/FrontPlatformProvider.tsx
+++ b/extension/platforms/front/context/FrontPlatformProvider.tsx
@@ -1,7 +1,7 @@
-import { useFrontContext } from "@app/platforms/front/context/FrontProvider";
-import { FrontPlatformService } from "@app/platforms/front/services/platform";
-import { PlatformProvider } from "@app/shared/context/PlatformContext";
 import { Spinner } from "@dust-tt/sparkle";
+import { useFrontContext } from "@extension/platforms/front/context/FrontProvider";
+import { FrontPlatformService } from "@extension/platforms/front/services/platform";
+import { PlatformProvider } from "@extension/shared/context/PlatformContext";
 import { useEffect, useMemo } from "react";
 
 const updateTheme = (isDark: boolean) => {

--- a/extension/platforms/front/main.tsx
+++ b/extension/platforms/front/main.tsx
@@ -7,11 +7,11 @@ import "../../ui/css/components.css";
 // Local custom styles
 import "../../ui/css/custom.css";
 
-import { FrontPlatformProvider } from "@app/platforms/front/context/FrontPlatformProvider";
-import { FrontContextProvider } from "@app/platforms/front/context/FrontProvider";
-import { AuthProvider } from "@app/ui/components/auth/AuthProvider";
-import { routes } from "@app/ui/pages/routes";
 import { Notification } from "@dust-tt/sparkle";
+import { FrontPlatformProvider } from "@extension/platforms/front/context/FrontPlatformProvider";
+import { FrontContextProvider } from "@extension/platforms/front/context/FrontProvider";
+import { AuthProvider } from "@extension/ui/components/auth/AuthProvider";
+import { routes } from "@extension/ui/pages/routes";
 import { useEffect, useState } from "react";
 import ReactDOM from "react-dom/client";
 import { createMemoryRouter, RouterProvider } from "react-router-dom";

--- a/extension/platforms/front/services/auth.ts
+++ b/extension/platforms/front/services/auth.ts
@@ -1,15 +1,15 @@
-import { DUST_US_URL, FRONT_EXTENSION_URL } from "@app/shared/lib/config";
-import { generatePKCE } from "@app/shared/lib/utils";
-import type { StoredTokens } from "@app/shared/services/auth";
+import type { Result } from "@dust-tt/client";
+import { Err, Ok } from "@dust-tt/client";
+import { DUST_US_URL, FRONT_EXTENSION_URL } from "@extension/shared/lib/config";
+import { generatePKCE } from "@extension/shared/lib/utils";
+import type { StoredTokens } from "@extension/shared/services/auth";
 import {
   AuthError,
   AuthService,
   getConnectionDetails,
   getDustDomain,
-} from "@app/shared/services/auth";
-import type { StorageService } from "@app/shared/services/storage";
-import type { Result } from "@dust-tt/client";
-import { Err, Ok } from "@dust-tt/client";
+} from "@extension/shared/services/auth";
+import type { StorageService } from "@extension/shared/services/storage";
 import { jwtDecode } from "jwt-decode";
 
 const POPUP_CONFIG = {

--- a/extension/platforms/front/services/mcp.ts
+++ b/extension/platforms/front/services/mcp.ts
@@ -1,7 +1,7 @@
-import { registerAllTools } from "@app/platforms/front/tools";
-import { McpService } from "@app/shared/services/mcp";
 import type { DustAPI } from "@dust-tt/client";
 import { DustMcpServerTransport } from "@dust-tt/client";
+import { registerAllTools } from "@extension/platforms/front/tools";
+import { McpService } from "@extension/shared/services/mcp";
 import type { WebViewContext } from "@frontapp/plugin-sdk/dist/webViewSdkTypes";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 

--- a/extension/platforms/front/services/platform.ts
+++ b/extension/platforms/front/services/platform.ts
@@ -1,8 +1,8 @@
-import { FrontAuthService } from "@app/platforms/front/services/auth";
-import { FrontMcpService } from "@app/platforms/front/services/mcp";
-import { FrontStorageService } from "@app/platforms/front/services/storage";
-import type { CaptureActionsProps } from "@app/shared/services/platform";
-import { PlatformService } from "@app/shared/services/platform";
+import { FrontAuthService } from "@extension/platforms/front/services/auth";
+import { FrontMcpService } from "@extension/platforms/front/services/mcp";
+import { FrontStorageService } from "@extension/platforms/front/services/storage";
+import type { CaptureActionsProps } from "@extension/shared/services/platform";
+import { PlatformService } from "@extension/shared/services/platform";
 import type { WebViewContext } from "@frontapp/plugin-sdk/dist/webViewSdkTypes";
 import type { ComponentType } from "react";
 

--- a/extension/platforms/front/services/storage.ts
+++ b/extension/platforms/front/services/storage.ts
@@ -1,4 +1,4 @@
-import type { StorageService } from "@app/shared/services/storage";
+import type { StorageService } from "@extension/shared/services/storage";
 
 type StorageListener = (changes: Record<string, any>) => void;
 

--- a/extension/platforms/front/tools/emailDraftTool.ts
+++ b/extension/platforms/front/tools/emailDraftTool.ts
@@ -1,4 +1,4 @@
-import { normalizeError } from "@app/shared/lib/utils";
+import { normalizeError } from "@extension/shared/lib/utils";
 import type { WebViewContext } from "@frontapp/plugin-sdk/dist/webViewSdkTypes";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";

--- a/extension/platforms/front/tools/getCurrentConversationTool.ts
+++ b/extension/platforms/front/tools/getCurrentConversationTool.ts
@@ -1,5 +1,5 @@
-import { getCurrentConversationTimeline } from "@app/platforms/front/tools/utils";
-import { normalizeError } from "@app/shared/lib/utils";
+import { getCurrentConversationTimeline } from "@extension/platforms/front/tools/utils";
+import { normalizeError } from "@extension/shared/lib/utils";
 import type { WebViewContext } from "@frontapp/plugin-sdk/dist/webViewSdkTypes";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 

--- a/extension/platforms/front/tools/index.ts
+++ b/extension/platforms/front/tools/index.ts
@@ -1,7 +1,7 @@
-import { registerEmailDraftTool } from "@app/platforms/front/tools/emailDraftTool";
-import { registerGetCurrentConversationTool } from "@app/platforms/front/tools/getCurrentConversationTool";
-import { registerNewConversationDraftTool } from "@app/platforms/front/tools/newConversationDraftTool";
-import { registerUpdateDraftTool } from "@app/platforms/front/tools/updateDraftTool";
+import { registerEmailDraftTool } from "@extension/platforms/front/tools/emailDraftTool";
+import { registerGetCurrentConversationTool } from "@extension/platforms/front/tools/getCurrentConversationTool";
+import { registerNewConversationDraftTool } from "@extension/platforms/front/tools/newConversationDraftTool";
+import { registerUpdateDraftTool } from "@extension/platforms/front/tools/updateDraftTool";
 import type { WebViewContext } from "@frontapp/plugin-sdk/dist/webViewSdkTypes";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 

--- a/extension/platforms/front/tools/newConversationDraftTool.ts
+++ b/extension/platforms/front/tools/newConversationDraftTool.ts
@@ -1,4 +1,4 @@
-import { normalizeError } from "@app/shared/lib/utils";
+import { normalizeError } from "@extension/shared/lib/utils";
 import type { WebViewContext } from "@frontapp/plugin-sdk/dist/webViewSdkTypes";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";

--- a/extension/platforms/front/tools/updateDraftTool.ts
+++ b/extension/platforms/front/tools/updateDraftTool.ts
@@ -1,4 +1,4 @@
-import { normalizeError } from "@app/shared/lib/utils";
+import { normalizeError } from "@extension/shared/lib/utils";
 import type { ApplicationDraftUpdate } from "@frontapp/plugin-sdk";
 import type { WebViewContext } from "@frontapp/plugin-sdk/dist/webViewSdkTypes";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";

--- a/extension/platforms/front/webpack.config.ts
+++ b/extension/platforms/front/webpack.config.ts
@@ -1,4 +1,4 @@
-import type { Environment } from "@app/config/env";
+import type { Environment } from "@extension/config/env";
 import Dotenv from "dotenv-webpack";
 import HtmlWebpackPlugin from "html-webpack-plugin";
 import path from "path";
@@ -64,7 +64,8 @@ export const getConfig = ({ env }: { env: Environment }) => {
     resolve: {
       extensions: [".tsx", ".ts", ".js"],
       alias: {
-        "@app": path.resolve(__dirname, "../../"),
+        "@extension": path.resolve(__dirname, "../../"),
+        "@app": path.resolve(__dirname, "../../../front"),
       },
       fallback: {
         http: require.resolve("stream-http"),

--- a/extension/run/build.ts
+++ b/extension/run/build.ts
@@ -1,5 +1,5 @@
-import type { PlatformType } from "@app/shared/services/platform";
-import { isValidPlatform } from "@app/shared/services/platform";
+import type { PlatformType } from "@extension/shared/services/platform";
+import { isValidPlatform } from "@extension/shared/services/platform";
 import webpack from "webpack";
 
 import { getConfig as getChromeConfig } from "../platforms/chrome/webpack.config";

--- a/extension/run/watch.ts
+++ b/extension/run/watch.ts
@@ -1,5 +1,5 @@
-import type { PlatformType } from "@app/shared/services/platform";
-import { isValidPlatform } from "@app/shared/services/platform";
+import type { PlatformType } from "@extension/shared/services/platform";
+import { isValidPlatform } from "@extension/shared/services/platform";
 import webpack from "webpack";
 import WebpackDevServer from "webpack-dev-server";
 

--- a/extension/shared/context/PlatformContext.tsx
+++ b/extension/shared/context/PlatformContext.tsx
@@ -1,4 +1,4 @@
-import type { PlatformService } from "@app/shared/services/platform";
+import type { PlatformService } from "@extension/shared/services/platform";
 import type React from "react";
 import type { ReactNode } from "react";
 import { createContext, useContext } from "react";

--- a/extension/shared/hooks/useMcpServer.ts
+++ b/extension/shared/hooks/useMcpServer.ts
@@ -1,6 +1,6 @@
-import { usePlatform } from "@app/shared/context/PlatformContext";
-import { useDustAPI } from "@app/shared/lib/dust_api";
-import { normalizeError } from "@app/shared/lib/utils";
+import { usePlatform } from "@extension/shared/context/PlatformContext";
+import { useDustAPI } from "@extension/shared/lib/dust_api";
+import { normalizeError } from "@extension/shared/lib/utils";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 /**

--- a/extension/shared/lib/content_nodes.ts
+++ b/extension/shared/lib/content_nodes.ts
@@ -1,4 +1,3 @@
-import { CONNECTOR_CONFIGURATIONS } from "@app/shared/lib/connector_providers";
 import type {
   ContentNodeType,
   DataSourceType,
@@ -14,6 +13,7 @@ import {
   LockIcon,
   Square3Stack3DIcon,
 } from "@dust-tt/sparkle";
+import { CONNECTOR_CONFIGURATIONS } from "@extension/shared/lib/connector_providers";
 
 import { assertNeverAndIgnore } from "./assertNeverAndIgnore";
 

--- a/extension/shared/lib/conversation.ts
+++ b/extension/shared/lib/conversation.ts
@@ -1,5 +1,3 @@
-import type { ContentFragmentsType } from "@app/shared/lib/types";
-import type { PlatformService } from "@app/shared/services/platform";
 import type {
   AgentMentionType,
   AgentMessageNewEvent,
@@ -16,6 +14,8 @@ import type {
   UserType,
 } from "@dust-tt/client";
 import { Err, Ok } from "@dust-tt/client";
+import type { ContentFragmentsType } from "@extension/shared/lib/types";
+import type { PlatformService } from "@extension/shared/services/platform";
 
 type SubmitMessageError = {
   type:

--- a/extension/shared/lib/dust_api.ts
+++ b/extension/shared/lib/dust_api.ts
@@ -1,6 +1,6 @@
-import { usePlatform } from "@app/shared/context/PlatformContext";
-import { useAuth } from "@app/ui/components/auth/AuthProvider";
 import { DustAPI } from "@dust-tt/client";
+import { usePlatform } from "@extension/shared/context/PlatformContext";
+import { useAuth } from "@extension/ui/components/auth/AuthProvider";
 import { useMemo } from "react";
 
 export const useDustAPI = () => {

--- a/extension/shared/lib/swr.ts
+++ b/extension/shared/lib/swr.ts
@@ -1,4 +1,4 @@
-import { useAuthErrorCheck } from "@app/ui/hooks/useAuthErrorCheck";
+import { useAuthErrorCheck } from "@extension/ui/hooks/useAuthErrorCheck";
 import { useCallback } from "react";
 import type { Fetcher, Key, SWRConfiguration } from "swr";
 import useSWR, { useSWRConfig } from "swr";

--- a/extension/shared/lib/tool_inputs.ts
+++ b/extension/shared/lib/tool_inputs.ts
@@ -1,5 +1,5 @@
-import type { TimeFrame } from "@app/shared/lib/time_frame";
-import { parseTimeFrame } from "@app/shared/lib/time_frame";
+import type { TimeFrame } from "@extension/shared/lib/time_frame";
+import { parseTimeFrame } from "@extension/shared/lib/time_frame";
 import { z } from "zod";
 
 export const SearchInputSchema = z

--- a/extension/shared/lib/utils.ts
+++ b/extension/shared/lib/utils.ts
@@ -2,11 +2,11 @@
  * Utils to generate PKCE code verifier and challenge.
  */
 
-import { GLOBAL_AGENTS_SID } from "@app/shared/lib/global_agents";
 import type {
   DataSourceViewContentNodeType,
   LightAgentConfigurationType,
 } from "@dust-tt/client";
+import { GLOBAL_AGENTS_SID } from "@extension/shared/lib/global_agents";
 
 const base64URLEncode = (buffer: ArrayBuffer): string => {
   return btoa(String.fromCharCode(...new Uint8Array(buffer)))

--- a/extension/shared/services/auth.ts
+++ b/extension/shared/services/auth.ts
@@ -1,10 +1,3 @@
-import {
-  DEFAULT_DUST_API_DOMAIN,
-  DUST_EU_URL,
-  DUST_US_URL,
-  WORKOS_CLAIM_NAMESPACE,
-} from "@app/shared/lib/config";
-import type { StorageService } from "@app/shared/services/storage";
 import type {
   ExtensionWorkspaceType,
   Result,
@@ -12,6 +5,13 @@ import type {
   WorkspaceType,
 } from "@dust-tt/client";
 import { Err, Ok } from "@dust-tt/client";
+import {
+  DEFAULT_DUST_API_DOMAIN,
+  DUST_EU_URL,
+  DUST_US_URL,
+  WORKOS_CLAIM_NAMESPACE,
+} from "@extension/shared/lib/config";
+import type { StorageService } from "@extension/shared/services/storage";
 
 export type Organization = {
   id: string;

--- a/extension/shared/services/platform.ts
+++ b/extension/shared/services/platform.ts
@@ -1,14 +1,14 @@
-import type { UploadedContentFragmentTypeWithKind } from "@app/shared/lib/types";
-import type { AuthService, StoredUser } from "@app/shared/services/auth";
-import type { CaptureService } from "@app/shared/services/capture";
-import { createMockCaptureService } from "@app/shared/services/capture";
-import type { McpService } from "@app/shared/services/mcp";
-import type { StorageService } from "@app/shared/services/storage";
-import type { FileUploaderService } from "@app/ui/hooks/useFileUploaderService";
 import type {
   ContentFragmentType,
   ExtensionWorkspaceType,
 } from "@dust-tt/client";
+import type { UploadedContentFragmentTypeWithKind } from "@extension/shared/lib/types";
+import type { AuthService, StoredUser } from "@extension/shared/services/auth";
+import type { CaptureService } from "@extension/shared/services/capture";
+import { createMockCaptureService } from "@extension/shared/services/capture";
+import type { McpService } from "@extension/shared/services/mcp";
+import type { StorageService } from "@extension/shared/services/storage";
+import type { FileUploaderService } from "@extension/ui/hooks/useFileUploaderService";
 import type { ComponentType } from "react";
 
 const PLATFORM_TYPES = ["chrome", "front"] as const;

--- a/extension/tsconfig.json
+++ b/extension/tsconfig.json
@@ -21,7 +21,8 @@
     "noImplicitAny": true,
     "types": ["chrome", "react", "react-dom"],
     "paths": {
-      "@app/*": ["./*"]
+      "@extension/*": ["./*"],
+      "@app/*": ["../front/*"]
     }
   },
   "include": ["./shared/**/*", "./platforms/**/*", "./ui/**/*", "./run/**/*"],

--- a/extension/ui/components/DropzoneContainer.tsx
+++ b/extension/ui/components/DropzoneContainer.tsx
@@ -1,4 +1,3 @@
-import { useFileDrop } from "@app/ui/components/conversation/FileUploaderContext";
 import {
   isSupportedFileContentType,
   isSupportedImageContentType,
@@ -7,6 +6,7 @@ import {
   supportedOtherFileFormats,
 } from "@dust-tt/client";
 import { DropzoneOverlay, useSendNotification } from "@dust-tt/sparkle";
+import { useFileDrop } from "@extension/ui/components/conversation/FileUploaderContext";
 import { useEffect } from "react";
 import { useDropzone } from "react-dropzone";
 

--- a/extension/ui/components/actions/mcp/details/MCPActionDetails.tsx
+++ b/extension/ui/components/actions/mcp/details/MCPActionDetails.tsx
@@ -1,40 +1,3 @@
-import {
-  isDataSourceFilesystemFindInputType,
-  isDataSourceFilesystemListInputType,
-  isIncludeInputType,
-  isSearchInputType,
-  isWebsearchInputType,
-  makeQueryTextForDataSourceSearch,
-  makeQueryTextForFind,
-  makeQueryTextForInclude,
-  makeQueryTextForList,
-} from "@app/shared/lib/tool_inputs";
-import { asDisplayName } from "@app/shared/lib/utils";
-import { ActionDetailsWrapper } from "@app/ui/components/actions/ActionDetailsWrapper";
-import { MCPAgentManagementActionDetails } from "@app/ui/components/actions/mcp/details/MCPAgentManagementActionDetails";
-import {
-  MCPAgentMemoryEditActionDetails,
-  MCPAgentMemoryEraseActionDetails,
-  MCPAgentMemoryRecordActionDetails,
-  MCPAgentMemoryRetrieveActionDetails,
-} from "@app/ui/components/actions/mcp/details/MCPAgentMemoryActionDetails";
-import { MCPBrowseActionDetails } from "@app/ui/components/actions/mcp/details/MCPBrowseActionDetails";
-import { MCPConversationCatFileDetails } from "@app/ui/components/actions/mcp/details/MCPConversationFilesActionDetails";
-import {
-  DataSourceNodeContentDetails,
-  FilesystemPathDetails,
-} from "@app/ui/components/actions/mcp/details/MCPDataSourcesFileSystemActionDetails";
-import { MCPDataWarehousesBrowseDetails } from "@app/ui/components/actions/mcp/details/MCPDataWarehousesBrowseDetails";
-import { MCPDeepDiveActionDetails } from "@app/ui/components/actions/mcp/details/MCPDeepDiveActionDetails";
-import { MCPExtractActionDetails } from "@app/ui/components/actions/mcp/details/MCPExtractActionDetails";
-import { MCPGetDatabaseSchemaActionDetails } from "@app/ui/components/actions/mcp/details/MCPGetDatabaseSchemaActionDetails";
-import { MCPListToolsActionDetails } from "@app/ui/components/actions/mcp/details/MCPListToolsActionDetails";
-import { MCPReasoningActionDetails } from "@app/ui/components/actions/mcp/details/MCPReasoningActionDetails";
-import { MCPRunAgentActionDetails } from "@app/ui/components/actions/mcp/details/MCPRunAgentActionDetails";
-import { MCPSkillEnableActionDetails } from "@app/ui/components/actions/mcp/details/MCPSkillEnableActionDetails";
-import { MCPTablesQueryActionDetails } from "@app/ui/components/actions/mcp/details/MCPTablesQueryActionDetails";
-import { SearchResultDetails } from "@app/ui/components/actions/mcp/details/MCPToolOutputDetails";
-import { MCPToolsetsEnableActionDetails } from "@app/ui/components/actions/mcp/details/MCPToolsetsEnableActionDetails";
 import type {
   AgentActionPublicType,
   LightWorkspaceType,
@@ -47,6 +10,43 @@ import {
   GlobeAltIcon,
   MagnifyingGlassIcon,
 } from "@dust-tt/sparkle";
+import {
+  isDataSourceFilesystemFindInputType,
+  isDataSourceFilesystemListInputType,
+  isIncludeInputType,
+  isSearchInputType,
+  isWebsearchInputType,
+  makeQueryTextForDataSourceSearch,
+  makeQueryTextForFind,
+  makeQueryTextForInclude,
+  makeQueryTextForList,
+} from "@extension/shared/lib/tool_inputs";
+import { asDisplayName } from "@extension/shared/lib/utils";
+import { ActionDetailsWrapper } from "@extension/ui/components/actions/ActionDetailsWrapper";
+import { MCPAgentManagementActionDetails } from "@extension/ui/components/actions/mcp/details/MCPAgentManagementActionDetails";
+import {
+  MCPAgentMemoryEditActionDetails,
+  MCPAgentMemoryEraseActionDetails,
+  MCPAgentMemoryRecordActionDetails,
+  MCPAgentMemoryRetrieveActionDetails,
+} from "@extension/ui/components/actions/mcp/details/MCPAgentMemoryActionDetails";
+import { MCPBrowseActionDetails } from "@extension/ui/components/actions/mcp/details/MCPBrowseActionDetails";
+import { MCPConversationCatFileDetails } from "@extension/ui/components/actions/mcp/details/MCPConversationFilesActionDetails";
+import {
+  DataSourceNodeContentDetails,
+  FilesystemPathDetails,
+} from "@extension/ui/components/actions/mcp/details/MCPDataSourcesFileSystemActionDetails";
+import { MCPDataWarehousesBrowseDetails } from "@extension/ui/components/actions/mcp/details/MCPDataWarehousesBrowseDetails";
+import { MCPDeepDiveActionDetails } from "@extension/ui/components/actions/mcp/details/MCPDeepDiveActionDetails";
+import { MCPExtractActionDetails } from "@extension/ui/components/actions/mcp/details/MCPExtractActionDetails";
+import { MCPGetDatabaseSchemaActionDetails } from "@extension/ui/components/actions/mcp/details/MCPGetDatabaseSchemaActionDetails";
+import { MCPListToolsActionDetails } from "@extension/ui/components/actions/mcp/details/MCPListToolsActionDetails";
+import { MCPReasoningActionDetails } from "@extension/ui/components/actions/mcp/details/MCPReasoningActionDetails";
+import { MCPRunAgentActionDetails } from "@extension/ui/components/actions/mcp/details/MCPRunAgentActionDetails";
+import { MCPSkillEnableActionDetails } from "@extension/ui/components/actions/mcp/details/MCPSkillEnableActionDetails";
+import { MCPTablesQueryActionDetails } from "@extension/ui/components/actions/mcp/details/MCPTablesQueryActionDetails";
+import { SearchResultDetails } from "@extension/ui/components/actions/mcp/details/MCPToolOutputDetails";
+import { MCPToolsetsEnableActionDetails } from "@extension/ui/components/actions/mcp/details/MCPToolsetsEnableActionDetails";
 
 export interface MCPActionDetailsProps {
   action: AgentActionPublicType;

--- a/extension/ui/components/actions/mcp/details/MCPAgentManagementActionDetails.tsx
+++ b/extension/ui/components/actions/mcp/details/MCPAgentManagementActionDetails.tsx
@@ -1,6 +1,6 @@
-import { ActionDetailsWrapper } from "@app/ui/components/actions/ActionDetailsWrapper";
-import type { MCPActionDetailsProps } from "@app/ui/components/actions/mcp/details/MCPActionDetails";
 import { ActionRobotIcon } from "@dust-tt/sparkle";
+import { ActionDetailsWrapper } from "@extension/ui/components/actions/ActionDetailsWrapper";
+import type { MCPActionDetailsProps } from "@extension/ui/components/actions/mcp/details/MCPActionDetails";
 
 export function MCPAgentManagementActionDetails({
   viewType,

--- a/extension/ui/components/actions/mcp/details/MCPAgentMemoryActionDetails.tsx
+++ b/extension/ui/components/actions/mcp/details/MCPAgentMemoryActionDetails.tsx
@@ -1,6 +1,6 @@
-import { ActionDetailsWrapper } from "@app/ui/components/actions/ActionDetailsWrapper";
-import type { MCPActionDetailsProps } from "@app/ui/components/actions/mcp/details/MCPActionDetails";
 import { ActionLightbulbIcon } from "@dust-tt/sparkle";
+import { ActionDetailsWrapper } from "@extension/ui/components/actions/ActionDetailsWrapper";
+import type { MCPActionDetailsProps } from "@extension/ui/components/actions/mcp/details/MCPActionDetails";
 
 export function MCPAgentMemoryRetrieveActionDetails({
   viewType,

--- a/extension/ui/components/actions/mcp/details/MCPBrowseActionDetails.tsx
+++ b/extension/ui/components/actions/mcp/details/MCPBrowseActionDetails.tsx
@@ -1,6 +1,6 @@
-import { ActionDetailsWrapper } from "@app/ui/components/actions/ActionDetailsWrapper";
-import type { MCPActionDetailsProps } from "@app/ui/components/actions/mcp/details/MCPActionDetails";
 import { GlobeAltIcon } from "@dust-tt/sparkle";
+import { ActionDetailsWrapper } from "@extension/ui/components/actions/ActionDetailsWrapper";
+import type { MCPActionDetailsProps } from "@extension/ui/components/actions/mcp/details/MCPActionDetails";
 
 export function MCPBrowseActionDetails({
   action,

--- a/extension/ui/components/actions/mcp/details/MCPConversationFilesActionDetails.tsx
+++ b/extension/ui/components/actions/mcp/details/MCPConversationFilesActionDetails.tsx
@@ -1,6 +1,6 @@
-import { ActionDetailsWrapper } from "@app/ui/components/actions/ActionDetailsWrapper";
-import type { MCPActionDetailsProps } from "@app/ui/components/actions/mcp/details/MCPActionDetails";
 import { DocumentIcon } from "@dust-tt/sparkle";
+import { ActionDetailsWrapper } from "@extension/ui/components/actions/ActionDetailsWrapper";
+import type { MCPActionDetailsProps } from "@extension/ui/components/actions/mcp/details/MCPActionDetails";
 
 export function MCPConversationCatFileDetails({
   viewType,

--- a/extension/ui/components/actions/mcp/details/MCPDataSourcesFileSystemActionDetails.tsx
+++ b/extension/ui/components/actions/mcp/details/MCPDataSourcesFileSystemActionDetails.tsx
@@ -1,6 +1,6 @@
-import { ActionDetailsWrapper } from "@app/ui/components/actions/ActionDetailsWrapper";
-import type { MCPActionDetailsProps } from "@app/ui/components/actions/mcp/details/MCPActionDetails";
 import { ActionPinDistanceIcon, DocumentIcon } from "@dust-tt/sparkle";
+import { ActionDetailsWrapper } from "@extension/ui/components/actions/ActionDetailsWrapper";
+import type { MCPActionDetailsProps } from "@extension/ui/components/actions/mcp/details/MCPActionDetails";
 
 export function DataSourceNodeContentDetails({
   viewType,

--- a/extension/ui/components/actions/mcp/details/MCPDataWarehousesBrowseDetails.tsx
+++ b/extension/ui/components/actions/mcp/details/MCPDataWarehousesBrowseDetails.tsx
@@ -1,6 +1,6 @@
-import { ActionDetailsWrapper } from "@app/ui/components/actions/ActionDetailsWrapper";
-import type { MCPActionDetailsProps } from "@app/ui/components/actions/mcp/details/MCPActionDetails";
 import { TableIcon } from "@dust-tt/sparkle";
+import { ActionDetailsWrapper } from "@extension/ui/components/actions/ActionDetailsWrapper";
+import type { MCPActionDetailsProps } from "@extension/ui/components/actions/mcp/details/MCPActionDetails";
 
 export function MCPDataWarehousesBrowseDetails({
   viewType,

--- a/extension/ui/components/actions/mcp/details/MCPDeepDiveActionDetails.tsx
+++ b/extension/ui/components/actions/mcp/details/MCPDeepDiveActionDetails.tsx
@@ -1,6 +1,6 @@
-import { ActionDetailsWrapper } from "@app/ui/components/actions/ActionDetailsWrapper";
-import type { MCPActionDetailsProps } from "@app/ui/components/actions/mcp/details/MCPActionDetails";
 import { RobotIcon } from "@dust-tt/sparkle";
+import { ActionDetailsWrapper } from "@extension/ui/components/actions/ActionDetailsWrapper";
+import type { MCPActionDetailsProps } from "@extension/ui/components/actions/mcp/details/MCPActionDetails";
 
 export function MCPDeepDiveActionDetails({ viewType }: MCPActionDetailsProps) {
   return (

--- a/extension/ui/components/actions/mcp/details/MCPExtractActionDetails.tsx
+++ b/extension/ui/components/actions/mcp/details/MCPExtractActionDetails.tsx
@@ -1,6 +1,3 @@
-import { isTimeFrame } from "@app/shared/lib/time_frame";
-import { ActionDetailsWrapper } from "@app/ui/components/actions/ActionDetailsWrapper";
-import type { MCPActionDetailsProps } from "@app/ui/components/actions/mcp/details/MCPActionDetails";
 import type { AgentActionPublicType } from "@dust-tt/client";
 import { isExtractQueryResourceType } from "@dust-tt/client";
 import {
@@ -10,6 +7,9 @@ import {
   CollapsibleTrigger,
   ScanIcon,
 } from "@dust-tt/sparkle";
+import { isTimeFrame } from "@extension/shared/lib/time_frame";
+import { ActionDetailsWrapper } from "@extension/ui/components/actions/ActionDetailsWrapper";
+import type { MCPActionDetailsProps } from "@extension/ui/components/actions/mcp/details/MCPActionDetails";
 import type { JSONSchema7 as JSONSchema } from "json-schema";
 
 interface MCPExtractActionQueryProps {

--- a/extension/ui/components/actions/mcp/details/MCPGetDatabaseSchemaActionDetails.tsx
+++ b/extension/ui/components/actions/mcp/details/MCPGetDatabaseSchemaActionDetails.tsx
@@ -1,6 +1,6 @@
-import { ActionDetailsWrapper } from "@app/ui/components/actions/ActionDetailsWrapper";
-import type { MCPActionDetailsProps } from "@app/ui/components/actions/mcp/details/MCPActionDetails";
 import { TableIcon } from "@dust-tt/sparkle";
+import { ActionDetailsWrapper } from "@extension/ui/components/actions/ActionDetailsWrapper";
+import type { MCPActionDetailsProps } from "@extension/ui/components/actions/mcp/details/MCPActionDetails";
 
 export function MCPGetDatabaseSchemaActionDetails({
   viewType,

--- a/extension/ui/components/actions/mcp/details/MCPListToolsActionDetails.tsx
+++ b/extension/ui/components/actions/mcp/details/MCPListToolsActionDetails.tsx
@@ -1,6 +1,6 @@
-import { ActionDetailsWrapper } from "@app/ui/components/actions/ActionDetailsWrapper";
-import type { MCPActionDetailsProps } from "@app/ui/components/actions/mcp/details/MCPActionDetails";
 import { BoltIcon } from "@dust-tt/sparkle";
+import { ActionDetailsWrapper } from "@extension/ui/components/actions/ActionDetailsWrapper";
+import type { MCPActionDetailsProps } from "@extension/ui/components/actions/mcp/details/MCPActionDetails";
 
 export function MCPListToolsActionDetails({ viewType }: MCPActionDetailsProps) {
   return (

--- a/extension/ui/components/actions/mcp/details/MCPReasoningActionDetails.tsx
+++ b/extension/ui/components/actions/mcp/details/MCPReasoningActionDetails.tsx
@@ -1,11 +1,11 @@
-import { ActionDetailsWrapper } from "@app/ui/components/actions/ActionDetailsWrapper";
-import type { MCPActionDetailsProps } from "@app/ui/components/actions/mcp/details/MCPActionDetails";
+import { isReasoningSuccessOutput, isThinkingOutput } from "@dust-tt/client";
+import { ChatBubbleThoughtIcon } from "@dust-tt/sparkle";
+import { ActionDetailsWrapper } from "@extension/ui/components/actions/ActionDetailsWrapper";
+import type { MCPActionDetailsProps } from "@extension/ui/components/actions/mcp/details/MCPActionDetails";
 import {
   ReasoningSuccessBlock,
   ThinkingBlock,
-} from "@app/ui/components/actions/mcp/details/MCPToolOutputDetails";
-import { isReasoningSuccessOutput, isThinkingOutput } from "@dust-tt/client";
-import { ChatBubbleThoughtIcon } from "@dust-tt/sparkle";
+} from "@extension/ui/components/actions/mcp/details/MCPToolOutputDetails";
 
 export function MCPReasoningActionDetails({
   action,

--- a/extension/ui/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
+++ b/extension/ui/components/actions/mcp/details/MCPRunAgentActionDetails.tsx
@@ -1,6 +1,6 @@
-import { ActionDetailsWrapper } from "@app/ui/components/actions/ActionDetailsWrapper";
-import type { MCPActionDetailsProps } from "@app/ui/components/actions/mcp/details/MCPActionDetails";
 import { RobotIcon } from "@dust-tt/sparkle";
+import { ActionDetailsWrapper } from "@extension/ui/components/actions/ActionDetailsWrapper";
+import type { MCPActionDetailsProps } from "@extension/ui/components/actions/mcp/details/MCPActionDetails";
 
 export function MCPRunAgentActionDetails({
   action: { toolName },

--- a/extension/ui/components/actions/mcp/details/MCPSkillEnableActionDetails.tsx
+++ b/extension/ui/components/actions/mcp/details/MCPSkillEnableActionDetails.tsx
@@ -1,7 +1,7 @@
-import { isSkillEnableInputType } from "@app/shared/lib/tool_inputs";
-import { ActionDetailsWrapper } from "@app/ui/components/actions/ActionDetailsWrapper";
-import type { MCPActionDetailsProps } from "@app/ui/components/actions/mcp/details/MCPActionDetails";
 import { PuzzleIcon } from "@dust-tt/sparkle";
+import { isSkillEnableInputType } from "@extension/shared/lib/tool_inputs";
+import { ActionDetailsWrapper } from "@extension/ui/components/actions/ActionDetailsWrapper";
+import type { MCPActionDetailsProps } from "@extension/ui/components/actions/mcp/details/MCPActionDetails";
 
 export function MCPSkillEnableActionDetails({
   action: { params },

--- a/extension/ui/components/actions/mcp/details/MCPTablesQueryActionDetails.tsx
+++ b/extension/ui/components/actions/mcp/details/MCPTablesQueryActionDetails.tsx
@@ -1,7 +1,7 @@
-import { ActionDetailsWrapper } from "@app/ui/components/actions/ActionDetailsWrapper";
-import type { MCPActionDetailsProps } from "@app/ui/components/actions/mcp/details/MCPActionDetails";
 import { isThinkingOutput } from "@dust-tt/client";
 import { TableIcon } from "@dust-tt/sparkle";
+import { ActionDetailsWrapper } from "@extension/ui/components/actions/ActionDetailsWrapper";
+import type { MCPActionDetailsProps } from "@extension/ui/components/actions/mcp/details/MCPActionDetails";
 
 export function MCPTablesQueryActionDetails({
   action,

--- a/extension/ui/components/actions/mcp/details/MCPToolOutputDetails.tsx
+++ b/extension/ui/components/actions/mcp/details/MCPToolOutputDetails.tsx
@@ -1,4 +1,3 @@
-import { ActionDetailsWrapper } from "@app/ui/components/actions/ActionDetailsWrapper";
 import type {
   ReasoningSuccessOutputType,
   ThinkingOutputType,
@@ -8,6 +7,7 @@ import {
   InformationCircleIcon,
   Markdown,
 } from "@dust-tt/sparkle";
+import { ActionDetailsWrapper } from "@extension/ui/components/actions/ActionDetailsWrapper";
 
 interface ThinkingBlockProps {
   resource: ThinkingOutputType;

--- a/extension/ui/components/actions/mcp/details/MCPToolsetsEnableActionDetails.tsx
+++ b/extension/ui/components/actions/mcp/details/MCPToolsetsEnableActionDetails.tsx
@@ -1,6 +1,6 @@
-import { ActionDetailsWrapper } from "@app/ui/components/actions/ActionDetailsWrapper";
-import type { MCPActionDetailsProps } from "@app/ui/components/actions/mcp/details/MCPActionDetails";
 import { BoltIcon } from "@dust-tt/sparkle";
+import { ActionDetailsWrapper } from "@extension/ui/components/actions/ActionDetailsWrapper";
+import type { MCPActionDetailsProps } from "@extension/ui/components/actions/mcp/details/MCPActionDetails";
 
 export function MCPToolsetsEnableActionDetails({
   viewType,

--- a/extension/ui/components/agents/AgentFavorites.tsx
+++ b/extension/ui/components/agents/AgentFavorites.tsx
@@ -1,7 +1,7 @@
-import type { StoredUser } from "@app/shared/services/auth";
-import { usePublicAgentConfigurations } from "@app/ui/components/agents/usePublicAgentConfigurations";
-import { InputBarContext } from "@app/ui/components/input_bar/InputBarContext";
 import { AssistantCard, Button, CardGrid, Page } from "@dust-tt/sparkle";
+import type { StoredUser } from "@extension/shared/services/auth";
+import { usePublicAgentConfigurations } from "@extension/ui/components/agents/usePublicAgentConfigurations";
+import { InputBarContext } from "@extension/ui/components/input_bar/InputBarContext";
 import { useCallback, useContext } from "react";
 
 interface AgentFavoritesProps {

--- a/extension/ui/components/agents/AgentPicker.tsx
+++ b/extension/ui/components/agents/AgentPicker.tsx
@@ -1,4 +1,3 @@
-import { filterAndSortAgents } from "@app/shared/lib/utils";
 import type {
   LightAgentConfigurationType,
   LightWorkspaceType,
@@ -15,6 +14,7 @@ import {
   RobotIcon,
   ScrollArea,
 } from "@dust-tt/sparkle";
+import { filterAndSortAgents } from "@extension/shared/lib/utils";
 import { useEffect, useState } from "react";
 
 export function AgentPicker({

--- a/extension/ui/components/agents/state/messageReducer.ts
+++ b/extension/ui/components/agents/state/messageReducer.ts
@@ -1,4 +1,3 @@
-import { assertNeverAndIgnore } from "@app/shared/lib/assertNeverAndIgnore";
 import type {
   AgentActionPublicType,
   AgentActionSpecificEvent,
@@ -12,6 +11,7 @@ import type {
   ToolNotificationEvent,
   ToolNotificationProgress,
 } from "@dust-tt/client";
+import { assertNeverAndIgnore } from "@extension/shared/lib/assertNeverAndIgnore";
 
 export type AgentStateClassification =
   | "thinking"

--- a/extension/ui/components/agents/usePublicAgentConfigurations.ts
+++ b/extension/ui/components/agents/usePublicAgentConfigurations.ts
@@ -1,6 +1,6 @@
-import { useDustAPI } from "@app/shared/lib/dust_api";
-import { useSWRWithDefaults } from "@app/shared/lib/swr";
 import type { AgentConfigurationViewType } from "@dust-tt/client";
+import { useDustAPI } from "@extension/shared/lib/dust_api";
+import { useSWRWithDefaults } from "@extension/shared/lib/swr";
 import { useMemo } from "react";
 
 export function usePublicAgentConfigurations(

--- a/extension/ui/components/auth/AuthProvider.tsx
+++ b/extension/ui/components/auth/AuthProvider.tsx
@@ -1,6 +1,6 @@
-import type { AuthError, StoredUser } from "@app/shared/services/auth";
-import { useAuthHook } from "@app/ui/components/auth/useAuth";
 import type { ExtensionWorkspaceType, WorkspaceType } from "@dust-tt/client";
+import type { AuthError, StoredUser } from "@extension/shared/services/auth";
+import { useAuthHook } from "@extension/ui/components/auth/useAuth";
 import type { ReactNode } from "react";
 import { createContext, useContext } from "react";
 

--- a/extension/ui/components/auth/ProtectedRoute.tsx
+++ b/extension/ui/components/auth/ProtectedRoute.tsx
@@ -1,9 +1,9 @@
-import type { RouteChangeMesssage } from "@app/platforms/chrome/messages";
-import { usePlatform } from "@app/shared/context/PlatformContext";
-import type { StoredUser } from "@app/shared/services/auth";
-import { useAuth } from "@app/ui/components/auth/AuthProvider";
 import type { ExtensionWorkspaceType } from "@dust-tt/client";
 import { classNames, Spinner } from "@dust-tt/sparkle";
+import type { RouteChangeMesssage } from "@extension/platforms/chrome/messages";
+import { usePlatform } from "@extension/shared/context/PlatformContext";
+import type { StoredUser } from "@extension/shared/services/auth";
+import { useAuth } from "@extension/ui/components/auth/AuthProvider";
 import type { ReactNode } from "react";
 import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";

--- a/extension/ui/components/auth/useAuth.ts
+++ b/extension/ui/components/auth/useAuth.ts
@@ -1,11 +1,11 @@
-import { usePlatform } from "@app/shared/context/PlatformContext";
-import type { StoredTokens, StoredUser } from "@app/shared/services/auth";
+import type { WorkspaceType } from "@dust-tt/client";
+import { usePlatform } from "@extension/shared/context/PlatformContext";
+import type { StoredTokens, StoredUser } from "@extension/shared/services/auth";
 import {
   AuthError,
   isValidEnterpriseConnection,
   makeEnterpriseConnectionName,
-} from "@app/shared/services/auth";
-import type { WorkspaceType } from "@dust-tt/client";
+} from "@extension/shared/services/auth";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 const PROACTIVE_REFRESH_WINDOW_MS = 1000 * 60; // 1 minute

--- a/extension/ui/components/conversation/ActionValidationProvider.tsx
+++ b/extension/ui/components/conversation/ActionValidationProvider.tsx
@@ -1,5 +1,3 @@
-import { useDustAPI } from "@app/shared/lib/dust_api";
-import { asDisplayName } from "@app/shared/lib/utils";
 import type {
   BlockedActionExecutionType,
   MCPToolStakeLevelPublicType,
@@ -18,6 +16,8 @@ import {
   MultiPageDialog,
   MultiPageDialogContent,
 } from "@dust-tt/sparkle";
+import { useDustAPI } from "@extension/shared/lib/dust_api";
+import { asDisplayName } from "@extension/shared/lib/utils";
 import { createContext, useCallback, useMemo, useState } from "react";
 
 type ActionValidationContextType = {

--- a/extension/ui/components/conversation/AgentMessage.tsx
+++ b/extension/ui/components/conversation/AgentMessage.tsx
@@ -1,39 +1,3 @@
-import { usePlatform } from "@app/shared/context/PlatformContext";
-import { assertNeverAndIgnore } from "@app/shared/lib/assertNeverAndIgnore";
-import { retryMessage } from "@app/shared/lib/conversation";
-import { formatTimestring } from "@app/shared/lib/utils";
-import type { StoredUser } from "@app/shared/services/auth";
-import type {
-  AgentMessageStateEvent,
-  MessageTemporaryState,
-} from "@app/ui/components/agents/state/messageReducer";
-import { messageReducer } from "@app/ui/components/agents/state/messageReducer";
-import { ActionValidationContext } from "@app/ui/components/conversation/ActionValidationProvider";
-import { AgentMessageActions } from "@app/ui/components/conversation/AgentMessageActions";
-import type { FeedbackSelectorBaseProps } from "@app/ui/components/conversation/FeedbackSelector";
-import { FeedbackSelector } from "@app/ui/components/conversation/FeedbackSelector";
-import { GenerationContext } from "@app/ui/components/conversation/GenerationContextProvider";
-import { MCPServerAuthRequired } from "@app/ui/components/conversation/MCPServerAuthRequired";
-import {
-  AgentMentionBlock,
-  agentMentionDirective,
-} from "@app/ui/components/markdown/AgentMentionBlock";
-import {
-  CitationsContext,
-  CiteBlock,
-  getCiteDirective,
-} from "@app/ui/components/markdown/CiteBlock";
-import {
-  getImgPlugin,
-  imgDirective,
-} from "@app/ui/components/markdown/ImageBlock";
-import type { MarkdownCitation } from "@app/ui/components/markdown/MarkdownCitation";
-import {
-  getUserMentionPlugin,
-  userMentionDirective,
-} from "@app/ui/components/markdown/UserMentionBlock";
-import { useSubmitFunction } from "@app/ui/components/utils/useSubmitFunction";
-import { useEventSource } from "@app/ui/hooks/useEventSource";
 import type {
   AgentMessagePublicType,
   LightAgentConfigurationType,
@@ -72,6 +36,42 @@ import {
   useCopyToClipboard,
   useSendNotification,
 } from "@dust-tt/sparkle";
+import { usePlatform } from "@extension/shared/context/PlatformContext";
+import { assertNeverAndIgnore } from "@extension/shared/lib/assertNeverAndIgnore";
+import { retryMessage } from "@extension/shared/lib/conversation";
+import { formatTimestring } from "@extension/shared/lib/utils";
+import type { StoredUser } from "@extension/shared/services/auth";
+import type {
+  AgentMessageStateEvent,
+  MessageTemporaryState,
+} from "@extension/ui/components/agents/state/messageReducer";
+import { messageReducer } from "@extension/ui/components/agents/state/messageReducer";
+import { ActionValidationContext } from "@extension/ui/components/conversation/ActionValidationProvider";
+import { AgentMessageActions } from "@extension/ui/components/conversation/AgentMessageActions";
+import type { FeedbackSelectorBaseProps } from "@extension/ui/components/conversation/FeedbackSelector";
+import { FeedbackSelector } from "@extension/ui/components/conversation/FeedbackSelector";
+import { GenerationContext } from "@extension/ui/components/conversation/GenerationContextProvider";
+import { MCPServerAuthRequired } from "@extension/ui/components/conversation/MCPServerAuthRequired";
+import {
+  AgentMentionBlock,
+  agentMentionDirective,
+} from "@extension/ui/components/markdown/AgentMentionBlock";
+import {
+  CitationsContext,
+  CiteBlock,
+  getCiteDirective,
+} from "@extension/ui/components/markdown/CiteBlock";
+import {
+  getImgPlugin,
+  imgDirective,
+} from "@extension/ui/components/markdown/ImageBlock";
+import type { MarkdownCitation } from "@extension/ui/components/markdown/MarkdownCitation";
+import {
+  getUserMentionPlugin,
+  userMentionDirective,
+} from "@extension/ui/components/markdown/UserMentionBlock";
+import { useSubmitFunction } from "@extension/ui/components/utils/useSubmitFunction";
+import { useEventSource } from "@extension/ui/hooks/useEventSource";
 import { marked } from "marked";
 import {
   useCallback,

--- a/extension/ui/components/conversation/AgentMessageActions.tsx
+++ b/extension/ui/components/conversation/AgentMessageActions.tsx
@@ -1,6 +1,3 @@
-import { MCPActionDetails } from "@app/ui/components/actions/mcp/details/MCPActionDetails";
-import type { ActionProgressState } from "@app/ui/components/agents/state/messageReducer";
-import type { AgentStateClassification } from "@app/ui/components/conversation/AgentMessage";
 import type {
   AgentMessagePublicType,
   LightWorkspaceType,
@@ -13,6 +10,9 @@ import {
   Markdown,
   Spinner,
 } from "@dust-tt/sparkle";
+import { MCPActionDetails } from "@extension/ui/components/actions/mcp/details/MCPActionDetails";
+import type { ActionProgressState } from "@extension/ui/components/agents/state/messageReducer";
+import type { AgentStateClassification } from "@extension/ui/components/conversation/AgentMessage";
 
 interface AgentMessageActionsProps {
   agentMessage: AgentMessagePublicType;

--- a/extension/ui/components/conversation/AgentSuggestion.tsx
+++ b/extension/ui/components/conversation/AgentSuggestion.tsx
@@ -1,8 +1,3 @@
-import { useDustAPI } from "@app/shared/lib/dust_api";
-import { GLOBAL_AGENTS_SID } from "@app/shared/lib/global_agents";
-import { AgentPicker } from "@app/ui/components/agents/AgentPicker";
-import { usePublicAgentConfigurations } from "@app/ui/components/agents/usePublicAgentConfigurations";
-import { useSubmitFunction } from "@app/ui/components/utils/useSubmitFunction";
 import type {
   LightAgentConfigurationType,
   LightWorkspaceType,
@@ -16,6 +11,11 @@ import {
   Spinner,
   useSendNotification,
 } from "@dust-tt/sparkle";
+import { useDustAPI } from "@extension/shared/lib/dust_api";
+import { GLOBAL_AGENTS_SID } from "@extension/shared/lib/global_agents";
+import { AgentPicker } from "@extension/ui/components/agents/AgentPicker";
+import { usePublicAgentConfigurations } from "@extension/ui/components/agents/usePublicAgentConfigurations";
+import { useSubmitFunction } from "@extension/ui/components/utils/useSubmitFunction";
 import { useEffect, useMemo, useRef, useState } from "react";
 
 interface AgentSuggestionProps {

--- a/extension/ui/components/conversation/AttachFragment.tsx
+++ b/extension/ui/components/conversation/AttachFragment.tsx
@@ -1,7 +1,7 @@
-import { usePlatform } from "@app/shared/context/PlatformContext";
-import { InputBarContext } from "@app/ui/components/input_bar/InputBarContext";
-import type { FileUploaderService } from "@app/ui/hooks/useFileUploaderService";
 import type { ExtensionWorkspaceType } from "@dust-tt/client";
+import { usePlatform } from "@extension/shared/context/PlatformContext";
+import { InputBarContext } from "@extension/ui/components/input_bar/InputBarContext";
+import type { FileUploaderService } from "@extension/ui/hooks/useFileUploaderService";
 import { useContext, useEffect } from "react";
 
 interface AttachFragmentProps {

--- a/extension/ui/components/conversation/AttachmentCitation.tsx
+++ b/extension/ui/components/conversation/AttachmentCitation.tsx
@@ -1,9 +1,3 @@
-import { getConnectorProviderLogoWithFallback } from "@app/shared/lib/connector_providers";
-import {
-  getIcon,
-  isCustomResourceIconType,
-  isInternalAllowedIcon,
-} from "@app/shared/lib/resources_icons";
 import type { ContentFragmentType } from "@dust-tt/client";
 import {
   Citation,
@@ -21,6 +15,12 @@ import {
   TableIcon,
   Tooltip,
 } from "@dust-tt/sparkle";
+import { getConnectorProviderLogoWithFallback } from "@extension/shared/lib/connector_providers";
+import {
+  getIcon,
+  isCustomResourceIconType,
+  isInternalAllowedIcon,
+} from "@extension/shared/lib/resources_icons";
 import type React from "react";
 
 export type FileAttachment = {

--- a/extension/ui/components/conversation/ConversationContainer.tsx
+++ b/extension/ui/components/conversation/ConversationContainer.tsx
@@ -1,29 +1,29 @@
-import { usePlatform } from "@app/shared/context/PlatformContext";
-import { useMcpServer } from "@app/shared/hooks/useMcpServer";
-import {
-  createPlaceholderUserMessage,
-  postConversation,
-  postMessage,
-  updateConversationWithOptimisticData,
-} from "@app/shared/lib/conversation";
-import { useDustAPI } from "@app/shared/lib/dust_api";
-import { getRandomGreetingForName } from "@app/shared/lib/greetings";
-import type { ContentFragmentsType } from "@app/shared/lib/types";
-import type { StoredUser } from "@app/shared/services/auth";
-import { AgentFavorites } from "@app/ui/components/agents/AgentFavorites";
-import { ConversationViewer } from "@app/ui/components/conversation/ConversationViewer";
-import { GenerationContextProvider } from "@app/ui/components/conversation/GenerationContextProvider";
-import { ReachedLimitPopup } from "@app/ui/components/conversation/ReachedLimitPopup";
-import { usePublicConversation } from "@app/ui/components/conversation/usePublicConversation";
-import { AssistantInputBar } from "@app/ui/components/input_bar/InputBar";
-import { InputBarContext } from "@app/ui/components/input_bar/InputBarContext";
-import { useSubmitFunction } from "@app/ui/components/utils/useSubmitFunction";
 import type {
   AgentMentionType,
   ContentFragmentType,
   ExtensionWorkspaceType,
 } from "@dust-tt/client";
 import { cn, Page, useSendNotification } from "@dust-tt/sparkle";
+import { usePlatform } from "@extension/shared/context/PlatformContext";
+import { useMcpServer } from "@extension/shared/hooks/useMcpServer";
+import {
+  createPlaceholderUserMessage,
+  postConversation,
+  postMessage,
+  updateConversationWithOptimisticData,
+} from "@extension/shared/lib/conversation";
+import { useDustAPI } from "@extension/shared/lib/dust_api";
+import { getRandomGreetingForName } from "@extension/shared/lib/greetings";
+import type { ContentFragmentsType } from "@extension/shared/lib/types";
+import type { StoredUser } from "@extension/shared/services/auth";
+import { AgentFavorites } from "@extension/ui/components/agents/AgentFavorites";
+import { ConversationViewer } from "@extension/ui/components/conversation/ConversationViewer";
+import { GenerationContextProvider } from "@extension/ui/components/conversation/GenerationContextProvider";
+import { ReachedLimitPopup } from "@extension/ui/components/conversation/ReachedLimitPopup";
+import { usePublicConversation } from "@extension/ui/components/conversation/usePublicConversation";
+import { AssistantInputBar } from "@extension/ui/components/input_bar/InputBar";
+import { InputBarContext } from "@extension/ui/components/input_bar/InputBarContext";
+import { useSubmitFunction } from "@extension/ui/components/utils/useSubmitFunction";
 import { useCallback, useContext, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 

--- a/extension/ui/components/conversation/ConversationViewer.tsx
+++ b/extension/ui/components/conversation/ConversationViewer.tsx
@@ -1,12 +1,3 @@
-import type { MessageWithContentFragmentsType } from "@app/shared/lib/conversation";
-import { getUpdatedMessagesFromEvent } from "@app/shared/lib/conversation";
-import { classNames } from "@app/shared/lib/utils";
-import type { StoredUser } from "@app/shared/services/auth";
-import MessageGroup from "@app/ui/components/conversation/MessageGroup";
-import { useConversationFeedbacks } from "@app/ui/components/conversation/useConversationFeedbacks";
-import { useConversationMarkAsRead } from "@app/ui/components/conversation/useConversationMarkAsRead";
-import { usePublicConversation } from "@app/ui/components/conversation/usePublicConversation";
-import { useEventSource } from "@app/ui/hooks/useEventSource";
 import { datadogLogs } from "@datadog/browser-logs";
 import type {
   AgentGenerationCancelledEvent,
@@ -21,6 +12,15 @@ import type {
   UserMessageType,
 } from "@dust-tt/client";
 import { isAgentMention, isAgentMessage } from "@dust-tt/client";
+import type { MessageWithContentFragmentsType } from "@extension/shared/lib/conversation";
+import { getUpdatedMessagesFromEvent } from "@extension/shared/lib/conversation";
+import { classNames } from "@extension/shared/lib/utils";
+import type { StoredUser } from "@extension/shared/services/auth";
+import MessageGroup from "@extension/ui/components/conversation/MessageGroup";
+import { useConversationFeedbacks } from "@extension/ui/components/conversation/useConversationFeedbacks";
+import { useConversationMarkAsRead } from "@extension/ui/components/conversation/useConversationMarkAsRead";
+import { usePublicConversation } from "@extension/ui/components/conversation/usePublicConversation";
+import { useEventSource } from "@extension/ui/hooks/useEventSource";
 import debounce from "lodash/debounce";
 import groupBy from "lodash/groupBy";
 import { useCallback, useEffect, useMemo, useRef } from "react";

--- a/extension/ui/components/conversation/ConversationsListButton.tsx
+++ b/extension/ui/components/conversation/ConversationsListButton.tsx
@@ -1,5 +1,3 @@
-import { removeDiacritics, subFilter } from "@app/shared/lib/utils";
-import { useConversations } from "@app/ui/components/conversation/useConversations";
 import type { ConversationWithoutContentPublicType } from "@dust-tt/client";
 import {
   Button,
@@ -16,6 +14,8 @@ import {
   ScrollArea,
   Spinner,
 } from "@dust-tt/sparkle";
+import { removeDiacritics, subFilter } from "@extension/shared/lib/utils";
+import { useConversations } from "@extension/ui/components/conversation/useConversations";
 import moment from "moment";
 import React, { useState } from "react";
 import type { NavigateFunction } from "react-router-dom";

--- a/extension/ui/components/conversation/MCPServerAuthRequired.tsx
+++ b/extension/ui/components/conversation/MCPServerAuthRequired.tsx
@@ -1,4 +1,3 @@
-import { asDisplayName } from "@app/shared/lib/utils";
 import {
   Button,
   CloudArrowLeftRightIcon,
@@ -18,6 +17,7 @@ import {
   SalesforceLogo,
   SlackLogo,
 } from "@dust-tt/sparkle";
+import { asDisplayName } from "@extension/shared/lib/utils";
 import type { ComponentType } from "react";
 
 const PROVIDER_ICONS: Record<string, ComponentType<{ className?: string }>> = {

--- a/extension/ui/components/conversation/MessageGroup.tsx
+++ b/extension/ui/components/conversation/MessageGroup.tsx
@@ -1,13 +1,13 @@
-import type { MessageWithContentFragmentsType } from "@app/shared/lib/conversation";
-import type { AgentMessageFeedbackType } from "@app/shared/lib/feedbacks";
-import type { StoredUser } from "@app/shared/services/auth";
-import MessageItem from "@app/ui/components/conversation/MessageItem";
 import type {
   AgentMessagePublicType,
   ConversationMessageReactionsType,
   LightWorkspaceType,
   UserMessageType,
 } from "@dust-tt/client";
+import type { MessageWithContentFragmentsType } from "@extension/shared/lib/conversation";
+import type { AgentMessageFeedbackType } from "@extension/shared/lib/feedbacks";
+import type { StoredUser } from "@extension/shared/services/auth";
+import MessageItem from "@extension/ui/components/conversation/MessageItem";
 import { useEffect, useRef } from "react";
 
 interface MessageGroupProps {

--- a/extension/ui/components/conversation/MessageItem.tsx
+++ b/extension/ui/components/conversation/MessageItem.tsx
@@ -1,21 +1,21 @@
-import type { MessageWithContentFragmentsType } from "@app/shared/lib/conversation";
-import { useDustAPI } from "@app/shared/lib/dust_api";
-import type { AgentMessageFeedbackType } from "@app/shared/lib/feedbacks";
-import type { StoredUser } from "@app/shared/services/auth";
-import { AgentMessage } from "@app/ui/components/conversation/AgentMessage";
-import {
-  AttachmentCitation,
-  contentFragmentToAttachmentCitation,
-} from "@app/ui/components/conversation/AttachmentCitation";
-import type { FeedbackSelectorBaseProps } from "@app/ui/components/conversation/FeedbackSelector";
-import { UserMessage } from "@app/ui/components/conversation/UserMessage";
-import { useSubmitFunction } from "@app/ui/components/utils/useSubmitFunction";
 import type {
   AgentMessagePublicType,
   ConversationMessageReactionsType,
   LightWorkspaceType,
   UserMessageType,
 } from "@dust-tt/client";
+import type { MessageWithContentFragmentsType } from "@extension/shared/lib/conversation";
+import { useDustAPI } from "@extension/shared/lib/dust_api";
+import type { AgentMessageFeedbackType } from "@extension/shared/lib/feedbacks";
+import type { StoredUser } from "@extension/shared/services/auth";
+import { AgentMessage } from "@extension/ui/components/conversation/AgentMessage";
+import {
+  AttachmentCitation,
+  contentFragmentToAttachmentCitation,
+} from "@extension/ui/components/conversation/AttachmentCitation";
+import type { FeedbackSelectorBaseProps } from "@extension/ui/components/conversation/FeedbackSelector";
+import { UserMessage } from "@extension/ui/components/conversation/UserMessage";
+import { useSubmitFunction } from "@extension/ui/components/utils/useSubmitFunction";
 import React from "react";
 import { useSWRConfig } from "swr";
 

--- a/extension/ui/components/conversation/UserMessage.tsx
+++ b/extension/ui/components/conversation/UserMessage.tsx
@@ -1,23 +1,23 @@
-import { formatTimestring } from "@app/shared/lib/utils";
-import { AgentSuggestion } from "@app/ui/components/conversation/AgentSuggestion";
+import type { LightWorkspaceType, UserMessageType } from "@dust-tt/client";
+import { ConversationMessage, Markdown } from "@dust-tt/sparkle";
+import { formatTimestring } from "@extension/shared/lib/utils";
+import { AgentSuggestion } from "@extension/ui/components/conversation/AgentSuggestion";
 import {
   AgentMentionBlock,
   agentMentionDirective,
-} from "@app/ui/components/markdown/AgentMentionBlock";
+} from "@extension/ui/components/markdown/AgentMentionBlock";
 import {
   CiteBlock,
   getCiteDirective,
-} from "@app/ui/components/markdown/CiteBlock";
+} from "@extension/ui/components/markdown/CiteBlock";
 import {
   ContentNodeMentionBlock,
   contentNodeMentionDirective,
-} from "@app/ui/components/markdown/ContentNodeMentionBlock";
+} from "@extension/ui/components/markdown/ContentNodeMentionBlock";
 import {
   getUserMentionPlugin,
   userMentionDirective,
-} from "@app/ui/components/markdown/UserMentionBlock";
-import type { LightWorkspaceType, UserMessageType } from "@dust-tt/client";
-import { ConversationMessage, Markdown } from "@dust-tt/sparkle";
+} from "@extension/ui/components/markdown/UserMentionBlock";
 import type React from "react";
 import { useMemo } from "react";
 import type { Components } from "react-markdown";

--- a/extension/ui/components/conversation/useConversationFeedbacks.ts
+++ b/extension/ui/components/conversation/useConversationFeedbacks.ts
@@ -1,6 +1,6 @@
-import { useDustAPI } from "@app/shared/lib/dust_api";
-import type { AgentMessageFeedbackType } from "@app/shared/lib/feedbacks";
-import { useSWRWithDefaults } from "@app/shared/lib/swr";
+import { useDustAPI } from "@extension/shared/lib/dust_api";
+import type { AgentMessageFeedbackType } from "@extension/shared/lib/feedbacks";
+import { useSWRWithDefaults } from "@extension/shared/lib/swr";
 import { useMemo } from "react";
 
 type FeedbacksKey =

--- a/extension/ui/components/conversation/useConversationMarkAsRead.ts
+++ b/extension/ui/components/conversation/useConversationMarkAsRead.ts
@@ -1,7 +1,7 @@
-import { useDustAPI } from "@app/shared/lib/dust_api";
-import { useConversations } from "@app/ui/components/conversation/useConversations";
 import { datadogLogs } from "@datadog/browser-logs";
 import type { ConversationPublicType } from "@dust-tt/client";
+import { useDustAPI } from "@extension/shared/lib/dust_api";
+import { useConversations } from "@extension/ui/components/conversation/useConversations";
 import { useCallback, useEffect } from "react";
 
 const DELAY_BEFORE_MARKING_AS_READ = 2000;

--- a/extension/ui/components/conversation/useConversations.ts
+++ b/extension/ui/components/conversation/useConversations.ts
@@ -1,6 +1,6 @@
-import { useDustAPI } from "@app/shared/lib/dust_api";
-import { useSWRWithDefaults } from "@app/shared/lib/swr";
 import type { ConversationWithoutContentPublicType } from "@dust-tt/client";
+import { useDustAPI } from "@extension/shared/lib/dust_api";
+import { useSWRWithDefaults } from "@extension/shared/lib/swr";
 import { useMemo } from "react";
 
 type ConversationsKey = ["getConversations", string];

--- a/extension/ui/components/conversation/usePublicConversation.ts
+++ b/extension/ui/components/conversation/usePublicConversation.ts
@@ -1,6 +1,6 @@
-import { useDustAPI } from "@app/shared/lib/dust_api";
-import { useSWRWithDefaults } from "@app/shared/lib/swr";
 import type { ConversationPublicType } from "@dust-tt/client";
+import { useDustAPI } from "@extension/shared/lib/dust_api";
+import { useSWRWithDefaults } from "@extension/shared/lib/swr";
 import type { KeyedMutator } from "swr";
 
 type ConversationKey =

--- a/extension/ui/components/input_bar/InputBar.tsx
+++ b/extension/ui/components/input_bar/InputBar.tsx
@@ -1,22 +1,3 @@
-import type { AttachSelectionMessage } from "@app/platforms/chrome/messages";
-import { usePlatform } from "@app/shared/context/PlatformContext";
-import { useDustAPI } from "@app/shared/lib/dust_api";
-import { getSpaceIcon } from "@app/shared/lib/spaces";
-import type { ContentFragmentsType } from "@app/shared/lib/types";
-import {
-  classNames,
-  compareAgentsForSort,
-  isEqualNode,
-} from "@app/shared/lib/utils";
-import { usePublicAgentConfigurations } from "@app/ui/components/agents/usePublicAgentConfigurations";
-import { useFileDrop } from "@app/ui/components/conversation/FileUploaderContext";
-import { GenerationContext } from "@app/ui/components/conversation/GenerationContextProvider";
-import { InputBarAttachments } from "@app/ui/components/input_bar/InputBarAttachment";
-import type { InputBarContainerProps } from "@app/ui/components/input_bar/InputBarContainer";
-import { InputBarContainer } from "@app/ui/components/input_bar/InputBarContainer";
-import { InputBarContext } from "@app/ui/components/input_bar/InputBarContext";
-import { useFileUploaderService } from "@app/ui/hooks/useFileUploaderService";
-import { useSpaces } from "@app/ui/hooks/useSpaces";
 import type {
   AgentMentionType,
   ConversationPublicType,
@@ -25,6 +6,25 @@ import type {
   LightAgentConfigurationType,
 } from "@dust-tt/client";
 import { Button, Page, Spinner, StopIcon } from "@dust-tt/sparkle";
+import type { AttachSelectionMessage } from "@extension/platforms/chrome/messages";
+import { usePlatform } from "@extension/shared/context/PlatformContext";
+import { useDustAPI } from "@extension/shared/lib/dust_api";
+import { getSpaceIcon } from "@extension/shared/lib/spaces";
+import type { ContentFragmentsType } from "@extension/shared/lib/types";
+import {
+  classNames,
+  compareAgentsForSort,
+  isEqualNode,
+} from "@extension/shared/lib/utils";
+import { usePublicAgentConfigurations } from "@extension/ui/components/agents/usePublicAgentConfigurations";
+import { useFileDrop } from "@extension/ui/components/conversation/FileUploaderContext";
+import { GenerationContext } from "@extension/ui/components/conversation/GenerationContextProvider";
+import { InputBarAttachments } from "@extension/ui/components/input_bar/InputBarAttachment";
+import type { InputBarContainerProps } from "@extension/ui/components/input_bar/InputBarContainer";
+import { InputBarContainer } from "@extension/ui/components/input_bar/InputBarContainer";
+import { InputBarContext } from "@extension/ui/components/input_bar/InputBarContext";
+import { useFileUploaderService } from "@extension/ui/hooks/useFileUploaderService";
+import { useSpaces } from "@extension/ui/hooks/useSpaces";
 import {
   useCallback,
   useContext,

--- a/extension/ui/components/input_bar/InputBarAttachment.tsx
+++ b/extension/ui/components/input_bar/InputBarAttachment.tsx
@@ -1,21 +1,21 @@
-import { getConnectorProviderLogoWithFallback } from "@app/shared/lib/connector_providers";
+import type { DataSourceViewContentNodeType } from "@dust-tt/client";
+import { isFolder, isWebsite } from "@dust-tt/client";
+import { CitationGrid, DoubleIcon, Icon } from "@dust-tt/sparkle";
+import { getConnectorProviderLogoWithFallback } from "@extension/shared/lib/connector_providers";
 import {
   getLocationForDataSourceViewContentNode,
   getVisualForDataSourceViewContentNode,
-} from "@app/shared/lib/content_nodes";
+} from "@extension/shared/lib/content_nodes";
 import type {
   Attachment,
   FileAttachment,
   NodeAttachment,
-} from "@app/ui/components/conversation/AttachmentCitation";
+} from "@extension/ui/components/conversation/AttachmentCitation";
 import {
   AttachmentCitation,
   attachmentToAttachmentCitation,
-} from "@app/ui/components/conversation/AttachmentCitation";
-import type { FileUploaderService } from "@app/ui/hooks/useFileUploaderService";
-import type { DataSourceViewContentNodeType } from "@dust-tt/client";
-import { isFolder, isWebsite } from "@dust-tt/client";
-import { CitationGrid, DoubleIcon, Icon } from "@dust-tt/sparkle";
+} from "@extension/ui/components/conversation/AttachmentCitation";
+import type { FileUploaderService } from "@extension/ui/hooks/useFileUploaderService";
 import { useMemo } from "react";
 
 interface FileAttachmentsProps {

--- a/extension/ui/components/input_bar/InputBarAttachmentPicker.tsx
+++ b/extension/ui/components/input_bar/InputBarAttachmentPicker.tsx
@@ -1,20 +1,3 @@
-import { getConnectorProviderLogoWithFallback } from "@app/shared/lib/connector_providers";
-import {
-  getDisplayNameForDataSource,
-  getLocationForDataSourceViewContentNode,
-  getVisualForContentNodeType,
-  getVisualForDataSourceViewContentNode,
-} from "@app/shared/lib/content_nodes";
-import { getIcon } from "@app/shared/lib/resources_icons";
-import { useDebounce } from "@app/ui/hooks/useDebounce";
-import type { FileUploaderService } from "@app/ui/hooks/useFileUploaderService";
-import { useSpaces } from "@app/ui/hooks/useSpaces";
-import { useToolFileUpload } from "@app/ui/hooks/useToolFileUpload";
-import type {
-  DataSourceViewContentNode,
-  ToolSearchResult,
-} from "@app/ui/hooks/useUnifiedSearch";
-import { useUnifiedSearch } from "@app/ui/hooks/useUnifiedSearch";
 import type { DataSourceType, LightWorkspaceType } from "@dust-tt/client";
 import { isFolder, isWebsite } from "@dust-tt/client";
 import type { DropdownMenuFilterOption } from "@dust-tt/sparkle";
@@ -36,6 +19,23 @@ import {
   ScrollBar,
   Spinner,
 } from "@dust-tt/sparkle";
+import { getConnectorProviderLogoWithFallback } from "@extension/shared/lib/connector_providers";
+import {
+  getDisplayNameForDataSource,
+  getLocationForDataSourceViewContentNode,
+  getVisualForContentNodeType,
+  getVisualForDataSourceViewContentNode,
+} from "@extension/shared/lib/content_nodes";
+import { getIcon } from "@extension/shared/lib/resources_icons";
+import { useDebounce } from "@extension/ui/hooks/useDebounce";
+import type { FileUploaderService } from "@extension/ui/hooks/useFileUploaderService";
+import { useSpaces } from "@extension/ui/hooks/useSpaces";
+import { useToolFileUpload } from "@extension/ui/hooks/useToolFileUpload";
+import type {
+  DataSourceViewContentNode,
+  ToolSearchResult,
+} from "@extension/ui/hooks/useUnifiedSearch";
+import { useUnifiedSearch } from "@extension/ui/hooks/useUnifiedSearch";
 import { useEffect, useMemo, useRef, useState } from "react";
 export const MIN_SEARCH_QUERY_SIZE = 2;
 const PAGE_SIZE = 25;

--- a/extension/ui/components/input_bar/InputBarContainer.tsx
+++ b/extension/ui/components/input_bar/InputBarContainer.tsx
@@ -1,22 +1,3 @@
-import { usePlatform } from "@app/shared/context/PlatformContext";
-import type { NodeCandidate, UrlCandidate } from "@app/shared/lib/connectors";
-import { isNodeCandidate } from "@app/shared/lib/connectors";
-import { getSpaceAccessPriority } from "@app/shared/lib/spaces";
-import { classNames } from "@app/shared/lib/utils";
-import { AgentPicker } from "@app/ui/components/agents/AgentPicker";
-import { AttachFragment } from "@app/ui/components/conversation/AttachFragment";
-import { MentionDropdown } from "@app/ui/components/input_bar/editor/MentionDropdown";
-import type { CustomEditorProps } from "@app/ui/components/input_bar/editor/useCustomEditor";
-import useCustomEditor from "@app/ui/components/input_bar/editor/useCustomEditor";
-import useHandleMentions from "@app/ui/components/input_bar/editor/useHandleMentions";
-import { useMentionDropdown } from "@app/ui/components/input_bar/editor/useMentionDropdown";
-import { usePublicAssistantSuggestions } from "@app/ui/components/input_bar/editor/usePublicAssistantSuggestions";
-import useUrlHandler from "@app/ui/components/input_bar/editor/useUrlHandler";
-import { InputBarAttachmentsPicker } from "@app/ui/components/input_bar/InputBarAttachmentPicker";
-import { InputBarContext } from "@app/ui/components/input_bar/InputBarContext";
-import type { FileUploaderService } from "@app/ui/hooks/useFileUploaderService";
-import { useSpaces } from "@app/ui/hooks/useSpaces";
-import { useSpacesSearch } from "@app/ui/hooks/useSpacesSearch";
 import type {
   AgentMentionType,
   DataSourceViewContentNodeType,
@@ -33,6 +14,28 @@ import {
   FlexSplitButton,
   useSendNotification,
 } from "@dust-tt/sparkle";
+import { usePlatform } from "@extension/shared/context/PlatformContext";
+import type {
+  NodeCandidate,
+  UrlCandidate,
+} from "@extension/shared/lib/connectors";
+import { isNodeCandidate } from "@extension/shared/lib/connectors";
+import { getSpaceAccessPriority } from "@extension/shared/lib/spaces";
+import { classNames } from "@extension/shared/lib/utils";
+import { AgentPicker } from "@extension/ui/components/agents/AgentPicker";
+import { AttachFragment } from "@extension/ui/components/conversation/AttachFragment";
+import { MentionDropdown } from "@extension/ui/components/input_bar/editor/MentionDropdown";
+import type { CustomEditorProps } from "@extension/ui/components/input_bar/editor/useCustomEditor";
+import useCustomEditor from "@extension/ui/components/input_bar/editor/useCustomEditor";
+import useHandleMentions from "@extension/ui/components/input_bar/editor/useHandleMentions";
+import { useMentionDropdown } from "@extension/ui/components/input_bar/editor/useMentionDropdown";
+import { usePublicAssistantSuggestions } from "@extension/ui/components/input_bar/editor/usePublicAssistantSuggestions";
+import useUrlHandler from "@extension/ui/components/input_bar/editor/useUrlHandler";
+import { InputBarAttachmentsPicker } from "@extension/ui/components/input_bar/InputBarAttachmentPicker";
+import { InputBarContext } from "@extension/ui/components/input_bar/InputBarContext";
+import type { FileUploaderService } from "@extension/ui/hooks/useFileUploaderService";
+import { useSpaces } from "@extension/ui/hooks/useSpaces";
+import { useSpacesSearch } from "@extension/ui/hooks/useSpacesSearch";
 import type { Editor } from "@tiptap/react";
 import { EditorContent } from "@tiptap/react";
 import {

--- a/extension/ui/components/input_bar/editor/MentionDropdown.tsx
+++ b/extension/ui/components/input_bar/editor/MentionDropdown.tsx
@@ -1,4 +1,3 @@
-import type { EditorSuggestion } from "@app/ui/components/input_bar/editor/suggestion";
 import {
   Avatar,
   cn,
@@ -7,6 +6,7 @@ import {
   DropdownMenuTrigger,
   Spinner,
 } from "@dust-tt/sparkle";
+import type { EditorSuggestion } from "@extension/ui/components/input_bar/editor/suggestion";
 import type React from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 

--- a/extension/ui/components/input_bar/editor/extensions/MentionStorageExtension.ts
+++ b/extension/ui/components/input_bar/editor/extensions/MentionStorageExtension.ts
@@ -1,4 +1,4 @@
-import type { EditorSuggestions } from "@app/ui/components/input_bar/editor/suggestion";
+import type { EditorSuggestions } from "@extension/ui/components/input_bar/editor/suggestion";
 import { Extension } from "@tiptap/react";
 
 declare module "@tiptap/core" {

--- a/extension/ui/components/input_bar/editor/extensions/MentionWithPasteExtension.tsx
+++ b/extension/ui/components/input_bar/editor/extensions/MentionWithPasteExtension.tsx
@@ -1,4 +1,4 @@
-import type { EditorSuggestions } from "@app/ui/components/input_bar/editor/suggestion";
+import type { EditorSuggestions } from "@extension/ui/components/input_bar/editor/suggestion";
 import Mention from "@tiptap/extension-mention";
 import type { PasteRuleMatch } from "@tiptap/react";
 import { nodePasteRule } from "@tiptap/react";

--- a/extension/ui/components/input_bar/editor/extensions/URLDetectionExtension.tsx
+++ b/extension/ui/components/input_bar/editor/extensions/URLDetectionExtension.tsx
@@ -1,8 +1,11 @@
-import type { NodeCandidate, UrlCandidate } from "@app/shared/lib/connectors";
+import type {
+  NodeCandidate,
+  UrlCandidate,
+} from "@extension/shared/lib/connectors";
 import {
   isUrlCandidate,
   nodeCandidateFromUrl,
-} from "@app/shared/lib/connectors";
+} from "@extension/shared/lib/connectors";
 import { Extension } from "@tiptap/core";
 import { Plugin, PluginKey } from "@tiptap/pm/state";
 

--- a/extension/ui/components/input_bar/editor/suggestion.ts
+++ b/extension/ui/components/input_bar/editor/suggestion.ts
@@ -1,9 +1,9 @@
-import { GLOBAL_AGENTS_SID } from "@app/shared/lib/global_agents";
+import { GLOBAL_AGENTS_SID } from "@extension/shared/lib/global_agents";
 import {
   compareAgentsForSort,
   compareForFuzzySort,
   subFilter,
-} from "@app/shared/lib/utils";
+} from "@extension/shared/lib/utils";
 
 export interface EditorSuggestion {
   id: string;

--- a/extension/ui/components/input_bar/editor/useCustomEditor.tsx
+++ b/extension/ui/components/input_bar/editor/useCustomEditor.tsx
@@ -1,13 +1,16 @@
-import type { NodeCandidate, UrlCandidate } from "@app/shared/lib/connectors";
-import { DataSourceLinkExtension } from "@app/ui/components/input_bar/editor/extensions/DataSourceLinkExtension";
-import { MarkdownStyleExtension } from "@app/ui/components/input_bar/editor/extensions/MarkdownStyleExtension";
-import { MentionStorageExtension } from "@app/ui/components/input_bar/editor/extensions/MentionStorageExtension";
-import { MentionWithPasteExtension } from "@app/ui/components/input_bar/editor/extensions/MentionWithPasteExtension";
-import { URLDetectionExtension } from "@app/ui/components/input_bar/editor/extensions/URLDetectionExtension";
-import { URLStorageExtension } from "@app/ui/components/input_bar/editor/extensions/URLStorageExtension";
-import { createMarkdownSerializer } from "@app/ui/components/input_bar/editor/markdownSerializer";
-import type { EditorSuggestions } from "@app/ui/components/input_bar/editor/suggestion";
-import type { SuggestionProps } from "@app/ui/components/input_bar/editor/useMentionDropdown";
+import type {
+  NodeCandidate,
+  UrlCandidate,
+} from "@extension/shared/lib/connectors";
+import { DataSourceLinkExtension } from "@extension/ui/components/input_bar/editor/extensions/DataSourceLinkExtension";
+import { MarkdownStyleExtension } from "@extension/ui/components/input_bar/editor/extensions/MarkdownStyleExtension";
+import { MentionStorageExtension } from "@extension/ui/components/input_bar/editor/extensions/MentionStorageExtension";
+import { MentionWithPasteExtension } from "@extension/ui/components/input_bar/editor/extensions/MentionWithPasteExtension";
+import { URLDetectionExtension } from "@extension/ui/components/input_bar/editor/extensions/URLDetectionExtension";
+import { URLStorageExtension } from "@extension/ui/components/input_bar/editor/extensions/URLStorageExtension";
+import { createMarkdownSerializer } from "@extension/ui/components/input_bar/editor/markdownSerializer";
+import type { EditorSuggestions } from "@extension/ui/components/input_bar/editor/suggestion";
+import type { SuggestionProps } from "@extension/ui/components/input_bar/editor/useMentionDropdown";
 import Paragraph from "@tiptap/extension-paragraph";
 import { Placeholder } from "@tiptap/extensions";
 import { PluginKey } from "@tiptap/pm/state";

--- a/extension/ui/components/input_bar/editor/useHandleMentions.tsx
+++ b/extension/ui/components/input_bar/editor/useHandleMentions.tsx
@@ -1,11 +1,11 @@
 import type {
-  EditorMention,
-  EditorService,
-} from "@app/ui/components/input_bar/editor/useCustomEditor";
-import type {
   AgentMentionType,
   LightAgentConfigurationType,
 } from "@dust-tt/client";
+import type {
+  EditorMention,
+  EditorService,
+} from "@extension/ui/components/input_bar/editor/useCustomEditor";
 import { useEffect, useRef } from "react";
 
 const useHandleMentions = (

--- a/extension/ui/components/input_bar/editor/useMentionDropdown.tsx
+++ b/extension/ui/components/input_bar/editor/useMentionDropdown.tsx
@@ -1,8 +1,8 @@
 import type {
   EditorSuggestion,
   EditorSuggestions,
-} from "@app/ui/components/input_bar/editor/suggestion";
-import { filterSuggestions } from "@app/ui/components/input_bar/editor/suggestion";
+} from "@extension/ui/components/input_bar/editor/suggestion";
+import { filterSuggestions } from "@extension/ui/components/input_bar/editor/suggestion";
 import type { Editor } from "@tiptap/react";
 import type { SuggestionKeyDownProps } from "@tiptap/suggestion";
 import { useCallback, useEffect, useRef, useState } from "react";

--- a/extension/ui/components/input_bar/editor/usePublicAssistantSuggestions.ts
+++ b/extension/ui/components/input_bar/editor/usePublicAssistantSuggestions.ts
@@ -1,6 +1,6 @@
-import { compareAgentsForSort } from "@app/shared/lib/utils";
-import { usePublicAgentConfigurations } from "@app/ui/components/agents/usePublicAgentConfigurations";
 import type { LightAgentConfigurationType } from "@dust-tt/client";
+import { compareAgentsForSort } from "@extension/shared/lib/utils";
+import { usePublicAgentConfigurations } from "@extension/ui/components/agents/usePublicAgentConfigurations";
 import { useMemo } from "react";
 
 function makeEditorSuggestions(

--- a/extension/ui/components/input_bar/editor/useUrlHandler.ts
+++ b/extension/ui/components/input_bar/editor/useUrlHandler.ts
@@ -1,6 +1,9 @@
-import type { NodeCandidate, UrlCandidate } from "@app/shared/lib/connectors";
-import { isUrlCandidate } from "@app/shared/lib/connectors";
 import type { DataSourceViewContentNodeType } from "@dust-tt/client";
+import type {
+  NodeCandidate,
+  UrlCandidate,
+} from "@extension/shared/lib/connectors";
+import { isUrlCandidate } from "@extension/shared/lib/connectors";
 import type { Editor } from "@tiptap/core";
 import { useCallback, useEffect } from "react";
 

--- a/extension/ui/components/markdown/AgentMentionBlock.tsx
+++ b/extension/ui/components/markdown/AgentMentionBlock.tsx
@@ -1,5 +1,5 @@
-import { InputBarContext } from "@app/ui/components/input_bar/InputBarContext";
 import { classNames } from "@dust-tt/sparkle";
+import { InputBarContext } from "@extension/ui/components/input_bar/InputBarContext";
 import { useContext } from "react";
 import { visit } from "unist-util-visit";
 

--- a/extension/ui/components/markdown/CiteBlock.tsx
+++ b/extension/ui/components/markdown/CiteBlock.tsx
@@ -1,5 +1,5 @@
-import type { MarkdownCitation } from "@app/ui/components/markdown/MarkdownCitation";
 import { classNames } from "@dust-tt/sparkle";
+import type { MarkdownCitation } from "@extension/ui/components/markdown/MarkdownCitation";
 import React, { useEffect } from "react";
 import type { ReactMarkdownProps } from "react-markdown/lib/complex-types";
 import { visit } from "unist-util-visit";

--- a/extension/ui/components/markdown/ImageBlock.tsx
+++ b/extension/ui/components/markdown/ImageBlock.tsx
@@ -1,5 +1,5 @@
-import { useDustAPI } from "@app/shared/lib/dust_api";
 import { InteractiveImageGrid } from "@dust-tt/sparkle";
+import { useDustAPI } from "@extension/shared/lib/dust_api";
 import { useEffect, useState } from "react";
 import { visit } from "unist-util-visit";
 

--- a/extension/ui/components/navigation/UserDropdownMenu.tsx
+++ b/extension/ui/components/navigation/UserDropdownMenu.tsx
@@ -1,6 +1,3 @@
-import type { StoredUser } from "@app/shared/services/auth";
-import { useAuth } from "@app/ui/components/auth/AuthProvider";
-import { useTheme } from "@app/ui/hooks/useTheme";
 import {
   Avatar,
   DropdownMenu,
@@ -16,6 +13,9 @@ import {
   LightModeIcon,
   LogoutIcon,
 } from "@dust-tt/sparkle";
+import type { StoredUser } from "@extension/shared/services/auth";
+import { useAuth } from "@extension/ui/components/auth/AuthProvider";
+import { useTheme } from "@extension/ui/hooks/useTheme";
 
 interface UserDropdownMenuProps {
   handleLogout: () => void;

--- a/extension/ui/hooks/useAuthErrorCheck.ts
+++ b/extension/ui/hooks/useAuthErrorCheck.ts
@@ -1,5 +1,5 @@
-import { usePlatform } from "@app/shared/context/PlatformContext";
-import { useAuth } from "@app/ui/components/auth/AuthProvider";
+import { usePlatform } from "@extension/shared/context/PlatformContext";
+import { useAuth } from "@extension/ui/components/auth/AuthProvider";
 import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 

--- a/extension/ui/hooks/useEventSource.ts
+++ b/extension/ui/hooks/useEventSource.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 const RECONNECT_DELAY = 5000; // 5 seconds.
 
-import { usePlatform } from "@app/shared/context/PlatformContext";
+import { usePlatform } from "@extension/shared/context/PlatformContext";
 import { EventSourcePolyfill } from "event-source-polyfill";
 
 /**

--- a/extension/ui/hooks/useFileUploaderService.ts
+++ b/extension/ui/hooks/useFileUploaderService.ts
@@ -1,9 +1,3 @@
-import { useDustAPI } from "@app/shared/lib/dust_api";
-import type { UploadedFileKind } from "@app/shared/lib/types";
-import type {
-  CaptureOptions,
-  CaptureService,
-} from "@app/shared/services/capture";
 import type {
   ConversationPublicType,
   Result,
@@ -16,6 +10,12 @@ import {
   Ok,
 } from "@dust-tt/client";
 import { useSendNotification } from "@dust-tt/sparkle";
+import { useDustAPI } from "@extension/shared/lib/dust_api";
+import type { UploadedFileKind } from "@extension/shared/lib/types";
+import type {
+  CaptureOptions,
+  CaptureService,
+} from "@extension/shared/services/capture";
 import { useState } from "react";
 
 interface FileBlob {

--- a/extension/ui/hooks/useSpaces.ts
+++ b/extension/ui/hooks/useSpaces.ts
@@ -1,6 +1,6 @@
-import { useDustAPI } from "@app/shared/lib/dust_api";
-import { useSWRWithDefaults } from "@app/shared/lib/swr";
 import type { SpaceType } from "@dust-tt/client";
+import { useDustAPI } from "@extension/shared/lib/dust_api";
+import { useSWRWithDefaults } from "@extension/shared/lib/swr";
 import { useMemo } from "react";
 
 type SpacesKey = ["getSpaces", string];

--- a/extension/ui/hooks/useSpacesSearch.ts
+++ b/extension/ui/hooks/useSpacesSearch.ts
@@ -1,10 +1,10 @@
-import { useDustAPI } from "@app/shared/lib/dust_api";
-import { useSWRWithDefaults } from "@app/shared/lib/swr";
 import type {
   ContentNodesViewType,
   DataSourceContentNodeType,
   SearchRequestBodyType,
 } from "@dust-tt/client";
+import { useDustAPI } from "@extension/shared/lib/dust_api";
+import { useSWRWithDefaults } from "@extension/shared/lib/swr";
 import { useMemo } from "react";
 
 type SearchKey = ["searchNodes", string, SearchRequestBodyType];

--- a/extension/ui/hooks/useTheme.ts
+++ b/extension/ui/hooks/useTheme.ts
@@ -1,6 +1,6 @@
-import { usePlatform } from "@app/shared/context/PlatformContext";
-import type { Theme } from "@app/shared/services/platform";
-import { DEFAULT_THEME } from "@app/shared/services/platform";
+import { usePlatform } from "@extension/shared/context/PlatformContext";
+import type { Theme } from "@extension/shared/services/platform";
+import { DEFAULT_THEME } from "@extension/shared/services/platform";
 import { useEffect, useState } from "react";
 
 export const useTheme = () => {

--- a/extension/ui/hooks/useToolFileUpload.ts
+++ b/extension/ui/hooks/useToolFileUpload.ts
@@ -1,8 +1,8 @@
-import { useDustAPI } from "@app/shared/lib/dust_api";
-import type { FileUploaderService } from "@app/ui/hooks/useFileUploaderService";
-import type { ToolSearchResult } from "@app/ui/hooks/useUnifiedSearch";
 import type { SupportedFileContentType } from "@dust-tt/client";
 import { useSendNotification } from "@dust-tt/sparkle";
+import { useDustAPI } from "@extension/shared/lib/dust_api";
+import type { FileUploaderService } from "@extension/ui/hooks/useFileUploaderService";
+import type { ToolSearchResult } from "@extension/ui/hooks/useUnifiedSearch";
 import { useCallback, useState } from "react";
 
 export function useToolFileUpload({

--- a/extension/ui/hooks/useUnifiedSearch.ts
+++ b/extension/ui/hooks/useUnifiedSearch.ts
@@ -1,16 +1,16 @@
-import { useDustAPI } from "@app/shared/lib/dust_api";
-import type {
-  CustomResourceIconType,
-  InternalAllowedIconType,
-} from "@app/shared/lib/resources_icons";
-import { getSpaceAccessPriority } from "@app/shared/lib/spaces";
-import { useSpaces } from "@app/ui/hooks/useSpaces";
 import type {
   ContentNodesViewType,
   ContentNodeType,
   DataSourceContentNodeType,
   DataSourceViewContentNodeType,
 } from "@dust-tt/client";
+import { useDustAPI } from "@extension/shared/lib/dust_api";
+import type {
+  CustomResourceIconType,
+  InternalAllowedIconType,
+} from "@extension/shared/lib/resources_icons";
+import { getSpaceAccessPriority } from "@extension/shared/lib/spaces";
+import { useSpaces } from "@extension/ui/hooks/useSpaces";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 export interface ToolSearchResult {

--- a/extension/ui/pages/LoginPage.tsx
+++ b/extension/ui/pages/LoginPage.tsx
@@ -1,4 +1,3 @@
-import { useAuth } from "@app/ui/components/auth/AuthProvider";
 import {
   Button,
   ChevronDownIcon,
@@ -12,6 +11,7 @@ import {
   Page,
   Spinner,
 } from "@dust-tt/sparkle";
+import { useAuth } from "@extension/ui/components/auth/AuthProvider";
 import { useEffect } from "react";
 import { Link, useNavigate } from "react-router-dom";
 

--- a/extension/ui/pages/MainPage.tsx
+++ b/extension/ui/pages/MainPage.tsx
@@ -1,18 +1,18 @@
-import type { ProtectedRouteChildrenProps } from "@app/ui/components/auth/ProtectedRoute";
-import { ActionValidationProvider } from "@app/ui/components/conversation/ActionValidationProvider";
-import { ConversationContainer } from "@app/ui/components/conversation/ConversationContainer";
-import { ConversationsListButton } from "@app/ui/components/conversation/ConversationsListButton";
-import { FileDropProvider } from "@app/ui/components/conversation/FileUploaderContext";
-import { usePublicConversation } from "@app/ui/components/conversation/usePublicConversation";
-import { DropzoneContainer } from "@app/ui/components/DropzoneContainer";
-import { InputBarProvider } from "@app/ui/components/input_bar/InputBarContext";
-import { UserDropdownMenu } from "@app/ui/components/navigation/UserDropdownMenu";
 import {
   BarHeader,
   Button,
   ChevronLeftIcon,
   ExternalLinkIcon,
 } from "@dust-tt/sparkle";
+import type { ProtectedRouteChildrenProps } from "@extension/ui/components/auth/ProtectedRoute";
+import { ActionValidationProvider } from "@extension/ui/components/conversation/ActionValidationProvider";
+import { ConversationContainer } from "@extension/ui/components/conversation/ConversationContainer";
+import { ConversationsListButton } from "@extension/ui/components/conversation/ConversationsListButton";
+import { FileDropProvider } from "@extension/ui/components/conversation/FileUploaderContext";
+import { usePublicConversation } from "@extension/ui/components/conversation/usePublicConversation";
+import { DropzoneContainer } from "@extension/ui/components/DropzoneContainer";
+import { InputBarProvider } from "@extension/ui/components/input_bar/InputBarContext";
+import { UserDropdownMenu } from "@extension/ui/components/navigation/UserDropdownMenu";
 import { useMemo } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 

--- a/extension/ui/pages/RunPage.tsx
+++ b/extension/ui/pages/RunPage.tsx
@@ -1,8 +1,8 @@
-import { usePlatform } from "@app/shared/context/PlatformContext";
-import { postConversation } from "@app/shared/lib/conversation";
-import { useDustAPI } from "@app/shared/lib/dust_api";
-import { useFileUploaderService } from "@app/ui/hooks/useFileUploaderService";
 import { Spinner } from "@dust-tt/sparkle";
+import { usePlatform } from "@extension/shared/context/PlatformContext";
+import { postConversation } from "@extension/shared/lib/conversation";
+import { useDustAPI } from "@extension/shared/lib/dust_api";
+import { useFileUploaderService } from "@extension/ui/hooks/useFileUploaderService";
 import { useEffect } from "react";
 import { useLocation, useNavigate } from "react-router";
 

--- a/extension/ui/pages/SubscribePage.tsx
+++ b/extension/ui/pages/SubscribePage.tsx
@@ -1,5 +1,3 @@
-import type { ProtectedRouteChildrenProps } from "@app/ui/components/auth/ProtectedRoute";
-import { UserDropdownMenu } from "@app/ui/components/navigation/UserDropdownMenu";
 import {
   BarHeader,
   Button,
@@ -8,6 +6,8 @@ import {
   Page,
   RocketIcon,
 } from "@dust-tt/sparkle";
+import type { ProtectedRouteChildrenProps } from "@extension/ui/components/auth/ProtectedRoute";
+import { UserDropdownMenu } from "@extension/ui/components/navigation/UserDropdownMenu";
 import { Link } from "react-router-dom";
 
 export const SubscribePage = ({

--- a/extension/ui/pages/routes.tsx
+++ b/extension/ui/pages/routes.tsx
@@ -1,8 +1,8 @@
-import { ProtectedRoute } from "@app/ui/components/auth/ProtectedRoute";
-import { LoginPage } from "@app/ui/pages/LoginPage";
-import { MainPage } from "@app/ui/pages/MainPage";
-import { RunPage } from "@app/ui/pages/RunPage";
-import { SubscribePage } from "@app/ui/pages/SubscribePage";
+import { ProtectedRoute } from "@extension/ui/components/auth/ProtectedRoute";
+import { LoginPage } from "@extension/ui/pages/LoginPage";
+import { MainPage } from "@extension/ui/pages/MainPage";
+import { RunPage } from "@extension/ui/pages/RunPage";
+import { SubscribePage } from "@extension/ui/pages/SubscribePage";
 
 export const routes = [
   {


### PR DESCRIPTION
## Description

Changes the extension's TypeScript alias from `@app` to `@extension` to prevent collisions with the main front codebase. The `@app` alias now correctly points to `../front` instead of the extension's root directory.

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

Low

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
