### PR TITLE
fix: improve knowledge space page load speed

### DIFF
--- a/front/lib/resources/storage/models/files.ts
+++ b/front/lib/resources/storage/models/files.ts
@@ -8,8 +8,13 @@ import type {
   FileUseCase,
   FileUseCaseMetadata,
 } from "@app/types/files";
-import type { CreationOptional, ForeignKey, NonAttribute } from "sequelize";
-import { DataTypes } from "sequelize";
+import {
+  type CreationOptional,
+  DataTypes,
+  type ForeignKey,
+  literal,
+  type NonAttribute,
+} from "sequelize";
 
 export class FileModel extends WorkspaceAwareModel<FileModel> {
   declare createdAt: CreationOptional<Date>;
@@ -82,6 +87,15 @@ FileModel.init(
     indexes: [
       { fields: ["workspaceId", "id"] },
       { fields: ["workspaceId", "userId"] },
+      {
+        fields: [
+          "workspaceId",
+          "useCase",
+          "status",
+          // index on the JSONB field, not the best but it works
+          literal("(\"useCaseMetadata\" #>> '{spaceId}')"),
+        ],
+      },
     ],
   }
 );

--- a/front/migrations/db/migration_513.sql
+++ b/front/migrations/db/migration_513.sql
@@ -1,0 +1,3 @@
+-- Migration created on Feb 16, 2026
+CREATE INDEX "files_workspace_id_use_case_status_"
+    ON "files" ("workspaceId", "useCase", "status", ("useCaseMetadata" #>> '{spaceId}'));


### PR DESCRIPTION
## Description

The knowledge page calls this [sql query](https://github.com/dust-tt/dust/blob/08cffdf017fbd7730e070171c9482d24b2dbd7a4/front/lib/resources/file_resource.ts#L248), and it's [not optimized](https://console.cloud.google.com/sql/instances/cell-00000-front-db/insights;database=front;duration=P7D;trace=94608793204a8d136581773a614bdd86;span=dcd3bdba8b329f2c;query_hash=10991007470333723851;sort_by=TOTAL_EXEC_TIME/executed?project=or1g1n-186209).

This PR adds an index to make it fast

## Tests

<!-- Explain how you tested your changes, did you do it manually, did you add / update some existing tests ? See [here](https://www.notion.so/dust-tt/Guide-Testing-18428599d94180e09250ff256d6ac46e) -->

## Risk

<!-- Discuss potential risks and how they will be mitigated. Consider the impact and whether the changes are safe to rollback. -->

## Deploy Plan

<!-- Outline the deployment steps. Specify the order of operations and any considerations that should be made before, during, and after deployment/ -->
